### PR TITLE
fix(codegen): bridge JSON Schema constraints across TS->Zod hop

### DIFF
--- a/.changeset/zod-codegen-numeric-string-constraints.md
+++ b/.changeset/zod-codegen-numeric-string-constraints.md
@@ -1,0 +1,15 @@
+---
+'@adcp/sdk': minor
+---
+
+fix(codegen): bridge JSON Schema validation constraints across the lossy TS → Zod hop
+
+Generated Zod schemas now enforce the `minimum`, `maximum`, `minLength`, `maxLength`, `pattern`, and `format` keywords from the upstream JSON Schemas. Before this change, those keywords were silently lost during the `JSON Schema → TypeScript (json-schema-to-typescript) → Zod (ts-to-zod)` codegen because TypeScript can't carry a numeric range or a regex on a `number` / `string` field. The emitted Zod for `MediaBuy.revision` was `z.number().optional()` instead of `z.number().min(1).optional()`, so typed validators accepted constraint-violating values that Ajv (which loads the raw JSON Schema) correctly rejected.
+
+The codegen now pre-processes each schema before it reaches `json-schema-to-typescript`, encoding each property's constraints into the JSDoc-bound `description` field as `@minimum` / `@maximum` / `@minLength` / `@maxLength` / `@pattern` / `@format` tags. `ts-to-zod` natively reads those JSDoc tags, so the constraints round-trip into `.min()` / `.max()` / `.regex()` / `.iso.datetime()` / `.email()` / etc. on the emitted Zod schemas. About 900 new validator chains land across `schemas.generated.ts` covering currency codes, ISO country codes, ISBN/IBAN/BIC patterns, RFC-conformant URLs, ISO-8601 timestamps, and numeric ranges (`revision >= 1`, `priority >= 1`, all monetary `total_budget`/`rate` >= 0, etc.).
+
+Behavioral impact for adopters: typed SDK validators (`MediaBuySchema.parse(...)`, etc.) now reject inputs they previously silently accepted. This matches what real Ajv-driven server-side validation already did — the SDK no longer hands a typed buyer payload the wire would refuse. Adopters who relied on the looser typed validators to construct fixtures or intermediate stages will need to populate the constraint-valid values.
+
+`exclusiveMinimum` / `exclusiveMaximum` are not injected (ts-to-zod has no exclusive variant); they continue to be enforced at runtime by Ajv against the unstripped schema. Pattern values containing newlines or unsupported `format` keywords (e.g. `iri-reference`) are likewise skipped — same Ajv fallback.
+
+Fixes #1745.

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ schemas/cache/
 compliance/cache/
 .adcp-sync-*/
 
+# Test harness scratch dirs (test/jsdoc-constraints-codegen.test.js)
+.tmp-jsdoc-constraints-*/
+
 # Environment variables
 .env
 .env.local

--- a/scripts/generate-types.ts
+++ b/scripts/generate-types.ts
@@ -3,7 +3,7 @@
 import { writeFileSync, mkdirSync, readFileSync, existsSync, readdirSync, statSync } from 'fs';
 import { compile } from 'json-schema-to-typescript';
 import path from 'path';
-import { removeArrayLengthConstraints } from './schema-utils';
+import { injectJsdocConstraints, removeArrayLengthConstraints } from './schema-utils';
 
 // Write file only if content differs (excluding timestamp)
 function writeFileIfChanged(filePath: string, newContent: string): boolean {
@@ -913,7 +913,7 @@ async function generateToolTypes(tools: ToolDefinition[]) {
       if (url.startsWith('/schemas/')) {
         const schema = loadCachedSchema(url);
         if (schema) {
-          return Promise.resolve(enforceStrictSchema(removeArrayLengthConstraints(schema)));
+          return Promise.resolve(enforceStrictSchema(removeArrayLengthConstraints(injectJsdocConstraints(schema))));
         }
       }
       return Promise.reject(new Error(`Cannot resolve $ref: ${url}`));
@@ -930,7 +930,9 @@ async function generateToolTypes(tools: ToolDefinition[]) {
       if (tool.paramsSchema) {
         const paramTypeName = `${tool.methodName.charAt(0).toUpperCase() + tool.methodName.slice(1)}Request`;
         // Process schema: remove additionalProperties and minItems constraints
-        const strictParamsSchema = enforceStrictSchema(removeArrayLengthConstraints(tool.paramsSchema));
+        const strictParamsSchema = enforceStrictSchema(
+          removeArrayLengthConstraints(injectJsdocConstraints(tool.paramsSchema))
+        );
         const paramTypes = await compile(strictParamsSchema, paramTypeName, {
           bannerComment: '',
           style: { semi: true, singleQuote: true },
@@ -953,7 +955,9 @@ async function generateToolTypes(tools: ToolDefinition[]) {
       if (tool.responseSchema) {
         const responseTypeName = `${tool.methodName.charAt(0).toUpperCase() + tool.methodName.slice(1)}Response`;
         // Process schema: remove additionalProperties and minItems constraints
-        const strictResponseSchema = enforceStrictSchema(removeArrayLengthConstraints(tool.responseSchema));
+        const strictResponseSchema = enforceStrictSchema(
+          removeArrayLengthConstraints(injectJsdocConstraints(tool.responseSchema))
+        );
         const responseTypes = await compile(strictResponseSchema, responseTypeName, {
           bannerComment: '',
           style: { semi: true, singleQuote: true },
@@ -1934,7 +1938,7 @@ async function compileGapSchemas(generatedTypes: Set<string>, refResolver: any):
         schema = makeFieldsOptional(schema, BACKWARD_COMPAT_OPTIONAL_FIELDS[pascalName]);
       }
 
-      const strictSchema = enforceStrictSchema(removeArrayLengthConstraints(schema));
+      const strictSchema = enforceStrictSchema(removeArrayLengthConstraints(injectJsdocConstraints(schema)));
       const types = await compile(strictSchema, typeName, {
         bannerComment: '',
         style: { semi: true, singleQuote: true },
@@ -1990,7 +1994,7 @@ async function generateTypes() {
       if (url.startsWith('/schemas/')) {
         const schema = loadCachedSchema(url);
         if (schema) {
-          return Promise.resolve(enforceStrictSchema(removeArrayLengthConstraints(schema)));
+          return Promise.resolve(enforceStrictSchema(removeArrayLengthConstraints(injectJsdocConstraints(schema))));
         }
       }
       return Promise.reject(new Error(`Cannot resolve $ref: ${url}`));
@@ -2008,7 +2012,7 @@ async function generateTypes() {
       if (schema) {
         console.log(`🔧 Generating TypeScript types for ${schemaName}...`);
         // Process schema: remove additionalProperties and minItems constraints
-        const strictSchema = enforceStrictSchema(removeArrayLengthConstraints(schema));
+        const strictSchema = enforceStrictSchema(removeArrayLengthConstraints(injectJsdocConstraints(schema)));
         const types = await compile(strictSchema, schemaName, {
           bannerComment: '',
           style: {
@@ -2060,7 +2064,7 @@ async function generateTypes() {
       if (schema) {
         console.log(`🔧 Generating TypeScript types for ${schemaName}...`);
         // Process schema: remove additionalProperties and minItems constraints
-        const strictSchema = enforceStrictSchema(removeArrayLengthConstraints(schema));
+        const strictSchema = enforceStrictSchema(removeArrayLengthConstraints(injectJsdocConstraints(schema)));
         const types = await compile(strictSchema, schemaName, {
           bannerComment: '',
           style: {

--- a/scripts/schema-utils.ts
+++ b/scripts/schema-utils.ts
@@ -126,9 +126,32 @@ export function injectJsdocConstraints(schema: any): any {
     if (typeof out.minLength === 'number') addTag('minLength', out.minLength);
     if (typeof out.maxLength === 'number') addTag('maxLength', out.maxLength);
     if (typeof out.pattern === 'string' && !/[\n\r]/.test(out.pattern)) {
-      // Escape `/` so ts-to-zod's `/PATTERN/` wrapper stays a valid literal.
-      const escaped = out.pattern.replace(/\//g, '\\/');
-      addTag('pattern', escaped);
+      // ts-to-zod wraps the JSDoc `@pattern` value as `/PATTERN/`, so we
+      // need to escape any unescaped `/` to keep the regex literal valid.
+      // The input is already in JS-regex source form (e.g. `\d`, `\.`),
+      // so we must NOT double-escape `\` — `\d` would become `\\d`, which
+      // means "literal backslash then d" instead of the digit class.
+      //
+      // Walk the string once, treating `\X` as a single regex token that
+      // passes through verbatim. Bare `/` becomes `\/`. A trailing unpaired
+      // `\` would consume the closing delimiter of `/PATTERN/`, so the
+      // pattern is skipped entirely (Ajv still enforces it at runtime
+      // against the unstripped schema).
+      const pattern = out.pattern;
+      const trailingBackslashes = pattern.match(/\\*$/)?.[0].length ?? 0;
+      if (trailingBackslashes % 2 === 0) {
+        let escaped = '';
+        for (let i = 0; i < pattern.length; i++) {
+          const ch = pattern[i];
+          if (ch === '\\' && i + 1 < pattern.length) {
+            escaped += ch + pattern[i + 1];
+            i++;
+            continue;
+          }
+          escaped += ch === '/' ? '\\/' : ch;
+        }
+        addTag('pattern', escaped);
+      }
     }
     if (typeof out.format === 'string' && TS_TO_ZOD_SUPPORTED_FORMATS.has(out.format)) {
       addTag('format', out.format);

--- a/scripts/schema-utils.ts
+++ b/scripts/schema-utils.ts
@@ -3,6 +3,146 @@
  */
 
 /**
+ * Set of JSDoc `@format` tag values that ts-to-zod can translate into Zod
+ * validators. Anything else is dropped (Ajv still enforces the JSON Schema
+ * `format` against the unstripped schema at runtime).
+ *
+ * Source: ts-to-zod's `builtInJSDocFormatsTypes` in `core/jsDocTags.ts`. Keep
+ * in sync if upgrading ts-to-zod.
+ */
+const TS_TO_ZOD_SUPPORTED_FORMATS = new Set([
+  'date-time',
+  'date',
+  'time',
+  'duration',
+  'email',
+  'ip',
+  'ipv4',
+  'ipv6',
+  'url',
+  'uuid',
+  'emoji',
+  'base64',
+  'base64url',
+  'nanoid',
+  'cuid',
+  'cuid2',
+  'ulid',
+  'cidrv4',
+  'cidrv6',
+  'iso-date',
+  'iso-time',
+  'iso-datetime',
+  'iso-duration',
+  'int',
+  'float32',
+  'float64',
+  'int32',
+  'uint32',
+  'int64',
+  'uint64',
+]);
+
+/**
+ * Inject JSON Schema validation constraints as JSDoc tags into each
+ * subschema's `description`, so json-schema-to-typescript emits them as
+ * JSDoc and ts-to-zod picks them up.
+ *
+ * Pipeline context: the codegen goes JSON Schema → TypeScript (jsts) → Zod
+ * (ts-to-zod). The TS hop is lossy — `revision: number` can't carry
+ * `minimum: 1`. ts-to-zod natively reads six JSDoc constraint tags
+ * (`@minimum`, `@maximum`, `@minLength`, `@maxLength`, `@pattern`,
+ * `@format`), so we encode the constraints into the JSDoc-bound description
+ * field before jsts runs. The emitted JSDoc round-trips into Zod chains
+ * (`z.number().min(1)`, etc).
+ *
+ * Skipped (Ajv still enforces these against the unstripped schema at runtime):
+ *  - `exclusiveMinimum` / `exclusiveMaximum` — ts-to-zod has no exclusive variant.
+ *  - `pattern` containing `\n` or `\r` — would break JSDoc parsing.
+ *  - `format` values outside ts-to-zod's supported set.
+ *
+ * Forward slashes inside a `pattern` are escaped (`/` → `\/`) so the regex
+ * literal jsDocTags wraps it in (`/PATTERN/`) stays valid.
+ *
+ * Fixes adcp-client#1745.
+ */
+export function injectJsdocConstraints(schema: any): any {
+  return walk(schema);
+
+  function walk(node: any): any {
+    if (!node || typeof node !== 'object') return node;
+    if (Array.isArray(node)) return node.map(walk);
+
+    const out: any = { ...node };
+
+    // Recurse into structural keywords before annotating, so nested
+    // subschemas get their own injections. The set mirrors enforceStrictSchema.
+    if (out.properties && typeof out.properties === 'object') {
+      out.properties = Object.fromEntries(Object.entries(out.properties).map(([k, v]) => [k, walk(v)]));
+    }
+    if (out.patternProperties && typeof out.patternProperties === 'object') {
+      out.patternProperties = Object.fromEntries(Object.entries(out.patternProperties).map(([k, v]) => [k, walk(v)]));
+    }
+    if (out.additionalProperties && typeof out.additionalProperties === 'object') {
+      out.additionalProperties = walk(out.additionalProperties);
+    }
+    if (out.items) {
+      out.items = Array.isArray(out.items) ? out.items.map(walk) : walk(out.items);
+    }
+    for (const key of ['oneOf', 'anyOf', 'allOf']) {
+      if (Array.isArray(out[key])) {
+        out[key] = out[key].map(walk);
+      }
+    }
+    for (const key of ['not', 'if', 'then', 'else', 'contains', 'propertyNames']) {
+      if (out[key] && typeof out[key] === 'object') {
+        out[key] = walk(out[key]);
+      }
+    }
+    for (const key of ['definitions', '$defs']) {
+      if (out[key] && typeof out[key] === 'object' && !Array.isArray(out[key])) {
+        out[key] = Object.fromEntries(Object.entries(out[key]).map(([k, v]) => [k, walk(v)]));
+      }
+    }
+
+    // Now annotate this node's own description with any constraint tags it
+    // carries. Tags are appended idempotently — if the description already
+    // contains `@minimum N`, we don't re-add it (lets the function run
+    // multiple times safely; ref resolution may visit the same schema twice).
+    const tags: string[] = [];
+    const existingDescription = typeof out.description === 'string' ? out.description : '';
+
+    const addTag = (tag: string, value: string | number) => {
+      const line = `@${tag} ${value}`;
+      // Allow-list-style idempotency: only suppress if the *exact* tag with
+      // the same value is already present. Different values mean a real
+      // conflict — let jsts emit both so a human reviewing the diff sees it.
+      if (existingDescription.split('\n').some(l => l.trim() === line)) return;
+      tags.push(line);
+    };
+
+    if (typeof out.minimum === 'number') addTag('minimum', out.minimum);
+    if (typeof out.maximum === 'number') addTag('maximum', out.maximum);
+    if (typeof out.minLength === 'number') addTag('minLength', out.minLength);
+    if (typeof out.maxLength === 'number') addTag('maxLength', out.maxLength);
+    if (typeof out.pattern === 'string' && !/[\n\r]/.test(out.pattern)) {
+      // Escape `/` so ts-to-zod's `/PATTERN/` wrapper stays a valid literal.
+      const escaped = out.pattern.replace(/\//g, '\\/');
+      addTag('pattern', escaped);
+    }
+    if (typeof out.format === 'string' && TS_TO_ZOD_SUPPORTED_FORMATS.has(out.format)) {
+      addTag('format', out.format);
+    }
+
+    if (tags.length > 0) {
+      out.description = existingDescription ? `${existingDescription}\n${tags.join('\n')}` : tags.join('\n');
+    }
+
+    return out;
+  }
+}
+
+/**
  * Recursively remove minItems constraints from arrays to allow empty arrays.
  *
  * DESIGN DECISION: The AdCP JSON Schema specifies minItems: 1 for fields like

--- a/src/lib/types/core.generated.ts
+++ b/src/lib/types/core.generated.ts
@@ -1,5 +1,5 @@
 // Generated AdCP core types from official schemas v3.0.11
-// Generated at: 2026-05-11T09:20:21.634Z
+// Generated at: 2026-05-16T10:00:09.042Z
 
 // MEDIA-BUY SCHEMA
 /**
@@ -153,10 +153,12 @@ export type FrequencyCap = {
   suppress?: Duration;
   /**
    * Deprecated — use suppress instead. Cooldown period in minutes between consecutive exposures to the same entity (e.g. 60 for a 1-hour cooldown).
+   * @minimum 0
    */
   suppress_minutes?: number;
   /**
    * Maximum number of impressions per entity per window. For duration windows, implementations typically use a rolling window; 'campaign' applies a fixed cap across the full flight.
+   * @minimum 1
    */
   max_impressions?: number;
   /**
@@ -267,6 +269,7 @@ export type OptimizationGoal =
           };
       /**
        * Relative priority among all optimization goals on this package. 1 = highest priority (primary goal); higher numbers are lower priority (secondary signals). When omitted, sellers may use array position as priority.
+       * @minimum 1
        */
       priority?: number;
     }
@@ -278,6 +281,7 @@ export type OptimizationGoal =
       event_sources: {
         /**
          * Event source to include (must be configured on this account via sync_event_sources)
+         * @minLength 1
          */
         event_source_id: string;
         event_type: EventType;
@@ -330,6 +334,7 @@ export type OptimizationGoal =
       };
       /**
        * Relative priority among all optimization goals on this package. 1 = highest priority (primary goal); higher numbers are lower priority (secondary signals). When omitted, sellers may use array position as priority.
+       * @minimum 1
        */
       priority?: number;
     };
@@ -349,6 +354,7 @@ export interface MediaBuy {
   rejection_reason?: string;
   /**
    * ISO 8601 timestamp when the seller confirmed this media buy. A successful create_media_buy response constitutes order confirmation.
+   * @format date-time
    */
   confirmed_at?: string;
   /**
@@ -357,16 +363,19 @@ export interface MediaBuy {
   cancellation?: {
     /**
      * ISO 8601 timestamp when this media buy was canceled.
+     * @format date-time
      */
     canceled_at: string;
     canceled_by: CanceledBy;
     /**
      * Reason provided when the media buy was canceled.
+     * @maxLength 500
      */
     reason?: string;
   };
   /**
    * Total budget amount
+   * @minimum 0
    */
   total_budget: number;
   /**
@@ -376,18 +385,22 @@ export interface MediaBuy {
   invoice_recipient?: BusinessEntity;
   /**
    * ISO 8601 timestamp for creative upload deadline
+   * @format date-time
    */
   creative_deadline?: string;
   /**
    * Monotonically increasing revision number. Incremented on every state change or update. Callers MAY include this in update_media_buy requests for optimistic concurrency — sellers MUST reject with CONFLICT if the provided revision does not match the current value.
+   * @minimum 1
    */
   revision?: number;
   /**
    * Creation timestamp
+   * @format date-time
    */
   created_at?: string;
   /**
    * Last update timestamp
+   * @format date-time
    */
   updated_at?: string;
   ext?: ExtensionObject;
@@ -416,6 +429,7 @@ export interface Account {
   brand?: BrandReference;
   /**
    * Domain of the entity operating this account. When the brand operates directly, this is the brand's domain.
+   * @pattern ^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$
    */
   operator?: string;
   billing?: BillingParty;
@@ -429,7 +443,13 @@ export interface Account {
    * Maximum outstanding balance allowed
    */
   credit_limit?: {
+    /**
+     * @minimum 0
+     */
     amount: number;
+    /**
+     * @pattern ^[A-Z]{3}$
+     */
     currency: string;
   };
   /**
@@ -446,6 +466,7 @@ export interface Account {
     message: string;
     /**
      * When this setup link expires.
+     * @format date-time
      */
     expires_at?: string;
   };
@@ -456,6 +477,7 @@ export interface Account {
   governance_agents?: {
     /**
      * Governance agent endpoint URL. Must use HTTPS.
+     * @pattern ^https:\/\/
      */
     url: string;
     /**
@@ -470,14 +492,21 @@ export interface Account {
     protocol: CloudStorageProtocol;
     /**
      * Bucket or container name
+     * @minLength 3
+     * @maxLength 63
+     * @pattern ^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$
      */
     bucket: string;
     /**
      * Path prefix within the bucket. Seller appends date-based partitioning beneath this prefix.
+     * @maxLength 512
+     * @pattern ^[a-zA-Z0-9\/_.-]+$
      */
     prefix?: string;
     /**
      * Cloud region for the bucket
+     * @maxLength 64
+     * @pattern ^[a-z0-9-]+$
      */
     region?: string;
     /**
@@ -490,10 +519,12 @@ export interface Account {
     compression?: 'gzip' | 'none';
     /**
      * How long reporting files are retained in the bucket before deletion. Buyers must read files within this window. Minimum recommended: 14 days.
+     * @minimum 1
      */
     file_retention_days: number;
     /**
      * URL to documentation for configuring buyer read access to this bucket (IAM role, service account, etc.). Operator-facing documentation — buyer agents MUST NOT auto-fetch this URL; surface it to a human operator. If an implementation fetches it (for preview), apply webhook URL SSRF validation and do not pass the fetched content into an LLM context without indirect-prompt-injection guarding. See docs/media-buy/media-buys/optimization-reporting#security-considerations-for-offline-delivery.
+     * @pattern ^https:\/\/
      */
     setup_instructions?: string;
   };
@@ -509,6 +540,7 @@ export interface Account {
 export interface BrandReference {
   /**
    * Domain where /.well-known/brand.json is hosted, or the brand's operating domain
+   * @pattern ^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$
    */
   domain: string;
   brand_id?: BrandID;
@@ -529,18 +561,22 @@ export interface BrandReference {
 export interface BusinessEntity {
   /**
    * Registered legal name of the business entity
+   * @maxLength 200
    */
   legal_name: string;
   /**
    * VAT identification number (e.g., DE123456789 for Germany, FR12345678901 for France). Required for B2B invoicing in the EU. Must be normalized: no spaces, dots, or dashes.
+   * @pattern ^[A-Z]{2}[A-Z0-9]{2,13}$
    */
   vat_id?: string;
   /**
    * Tax identification number for jurisdictions that do not use VAT (e.g., US EIN)
+   * @maxLength 30
    */
   tax_id?: string;
   /**
    * Company registration number (e.g., HRB 12345 for German Handelsregister)
+   * @maxLength 50
    */
   registration_number?: string;
   /**
@@ -549,16 +585,25 @@ export interface BusinessEntity {
   address?: {
     /**
      * Street address including building number
+     * @maxLength 200
      */
     street: string;
+    /**
+     * @maxLength 100
+     */
     city: string;
+    /**
+     * @maxLength 20
+     */
     postal_code: string;
     /**
      * State, province, or region
+     * @maxLength 100
      */
     region?: string;
     /**
      * ISO 3166-1 alpha-2 country code
+     * @pattern ^[A-Z]{2}$
      */
     country: string;
   };
@@ -572,9 +617,17 @@ export interface BusinessEntity {
     role: 'billing' | 'legal' | 'creative' | 'general';
     /**
      * Full name of the contact
+     * @maxLength 200
      */
     name?: string;
+    /**
+     * @maxLength 254
+     * @format email
+     */
     email?: string;
+    /**
+     * @maxLength 30
+     */
     phone?: string;
   }[];
   /**
@@ -583,22 +636,27 @@ export interface BusinessEntity {
   bank?: {
     /**
      * Name on the bank account
+     * @maxLength 200
      */
     account_holder: string;
     /**
      * International Bank Account Number (SEPA markets)
+     * @pattern ^[A-Z]{2}[0-9]{2}[A-Z0-9]{4,30}$
      */
     iban?: string;
     /**
      * Bank Identifier Code / SWIFT code (SEPA markets)
+     * @pattern ^[A-Z]{4}[A-Z]{2}[A-Z0-9]{2}([A-Z0-9]{3})?$
      */
     bic?: string;
     /**
      * Bank routing number for non-SEPA markets (e.g., US ABA routing number, Canadian transit/institution number)
+     * @maxLength 30
      */
     routing_number?: string;
     /**
      * Bank account number for non-SEPA markets
+     * @maxLength 30
      */
     account_number?: string;
   };
@@ -622,6 +680,7 @@ export interface Package {
   product_id?: string;
   /**
    * Budget allocation for this package in the currency specified by the pricing option
+   * @minimum 0
    */
   budget?: number;
   pacing?: Pacing;
@@ -631,11 +690,13 @@ export interface Package {
   pricing_option_id?: string;
   /**
    * Bid price for auction-based pricing. This is the exact bid/price to honor unless the selected pricing option has max_bid=true, in which case bid_price is the buyer's maximum willingness to pay (ceiling).
+   * @minimum 0
    */
   bid_price?: number;
   price_breakdown?: PriceBreakdown;
   /**
    * Impression goal for this package
+   * @minimum 0
    */
   impressions?: number;
   /**
@@ -666,10 +727,12 @@ export interface Package {
   optimization_goals?: OptimizationGoal[];
   /**
    * Flight start date/time for this package in ISO 8601 format. When omitted, the package inherits the media buy's start_time. Sellers SHOULD always include the resolved value in responses, even when inherited.
+   * @format date-time
    */
   start_time?: string;
   /**
    * Flight end date/time for this package in ISO 8601 format. When omitted, the package inherits the media buy's end_time. Sellers SHOULD always include the resolved value in responses, even when inherited.
+   * @format date-time
    */
   end_time?: string;
   /**
@@ -686,24 +749,29 @@ export interface Package {
   cancellation?: {
     /**
      * ISO 8601 timestamp when this package was canceled.
+     * @format date-time
      */
     canceled_at: string;
     canceled_by: CanceledBy;
     /**
      * Reason the package was canceled.
+     * @maxLength 500
      */
     reason?: string;
     /**
      * ISO 8601 timestamp when the seller acknowledged the cancellation. Confirms inventory has been released and billing stopped. Absent until the seller processes the cancellation.
+     * @format date-time
      */
     acknowledged_at?: string;
   };
   /**
    * Agency estimate or authorization number for this package. Echoed from the buyer's request. When present on the package, takes precedence over the media buy-level estimate number.
+   * @maxLength 100
    */
   agency_estimate_number?: string;
   /**
    * ISO 8601 timestamp for creative upload or change deadline for this package. After this deadline, creative changes are rejected. When absent, the media buy's creative_deadline applies.
+   * @format date-time
    */
   creative_deadline?: string;
   context?: ContextObject;
@@ -833,18 +901,22 @@ export interface FormatReferenceStructuredObject {
   agent_url: string;
   /**
    * Format identifier within the agent's namespace (e.g., 'display_static', 'video_hosted', 'audio_standard'). When used alone, references a template format. When combined with dimension/duration fields, creates a parameterized format ID for a specific variant.
+   * @pattern ^[a-zA-Z0-9_-]+$
    */
   id: string;
   /**
    * Width in pixels for visual formats. When specified, height must also be specified. Both fields together create a parameterized format ID for dimension-specific variants.
+   * @minimum 1
    */
   width?: number;
   /**
    * Height in pixels for visual formats. When specified, width must also be specified. Both fields together create a parameterized format ID for dimension-specific variants.
+   * @minimum 1
    */
   height?: number;
   /**
    * Duration in milliseconds for time-based formats (video, audio). When specified, creates a parameterized format ID. Omit to reference a template format without parameters.
+   * @minimum 1
    */
   duration_ms?: number;
 }
@@ -940,6 +1012,8 @@ export interface TargetingOverlay {
   age_restriction?: {
     /**
      * Minimum age required
+     * @minimum 13
+     * @maximum 99
      */
     min: number;
     /**
@@ -996,11 +1070,13 @@ export interface TargetingOverlay {
   keyword_targets?: {
     /**
      * The keyword to target
+     * @minLength 1
      */
     keyword: string;
     match_type: MatchType;
     /**
      * Per-keyword bid price, denominated in the same currency as the package's pricing option. Overrides the package-level bid_price for this keyword. Inherits the max_bid interpretation from the pricing option: when max_bid is true, this is the keyword's bid ceiling; when false, this is the exact bid. If omitted, the package bid_price applies.
+     * @minimum 0
      */
     bid_price?: number;
   }[];
@@ -1010,6 +1086,7 @@ export interface TargetingOverlay {
   negative_keywords?: {
     /**
      * The keyword to exclude
+     * @minLength 1
      */
     keyword: string;
     match_type: MatchType;
@@ -1025,10 +1102,14 @@ export interface DaypartTarget {
   days: DayOfWeek[];
   /**
    * Start hour (inclusive), 0-23 in 24-hour format. 0 = midnight, 6 = 6:00am, 18 = 6:00pm.
+   * @minimum 0
+   * @maximum 23
    */
   start_hour: number;
   /**
    * End hour (exclusive), 1-24 in 24-hour format. 10 = 10:00am, 24 = midnight. Must be greater than start_hour.
+   * @minimum 1
+   * @maximum 24
    */
   end_hour: number;
   /**
@@ -1042,6 +1123,7 @@ export interface DaypartTarget {
 export interface Duration {
   /**
    * Number of time units. Must be 1 when unit is 'campaign'.
+   * @minimum 1
    */
   interval: number;
   /**
@@ -1059,6 +1141,7 @@ export interface PropertyListReference {
   agent_url: string;
   /**
    * Identifier for the property list within the agent
+   * @minLength 1
    */
   list_id: string;
   /**
@@ -1076,6 +1159,7 @@ export interface CollectionListReference {
   agent_url: string;
   /**
    * Identifier for the collection list within the agent
+   * @minLength 1
    */
   list_id: string;
   /**
@@ -1094,6 +1178,7 @@ export interface MeasurementTerms {
     vendor: BrandReference;
     /**
      * Maximum acceptable variance between the billing vendor's count and the other party's count before resolution is triggered (e.g., 10 means a 10% divergence triggers review).
+     * @minimum 0
      */
     max_variance_percent?: number;
     /**
@@ -1118,6 +1203,8 @@ export interface PerformanceStandard {
   metric: PerformanceStandardMetric;
   /**
    * Rate threshold as a decimal (e.g., 0.70 for 70%). Whether this is a floor or ceiling depends on the metric: for viewability, completion_rate, brand_safety, attention_score the actual rate must be >= threshold; for ivt the actual rate must be <= threshold.
+   * @minimum 0
+   * @maximum 1
    */
   threshold: number;
   standard?: ViewabilityStandard;
@@ -1133,6 +1220,8 @@ export interface CreativeAssignment {
   creative_id: string;
   /**
    * Relative delivery weight for this creative (0–100). When multiple creatives are assigned to the same package, weights determine impression distribution proportionally — a creative with weight 2 gets twice the delivery of weight 1. When omitted, the creative receives equal rotation with other unweighted creatives. A weight of 0 means the creative is assigned but paused (receives no delivery).
+   * @minimum 0
+   * @maximum 100
    */
   weight?: number;
   /**
@@ -1229,6 +1318,7 @@ export type VASTAsset = {
   vpaid_enabled?: boolean;
   /**
    * Expected video duration in milliseconds (if known)
+   * @minimum 0
    */
   duration_ms?: number;
   /**
@@ -1410,6 +1500,7 @@ export type DAASTAsset = {
   daast_version?: DAASTVersion;
   /**
    * Expected audio duration in milliseconds (if known)
+   * @minimum 0
    */
   duration_ms?: number;
   /**
@@ -1554,6 +1645,8 @@ export interface CreativeAsset {
   status?: CreativeStatus;
   /**
    * Optional delivery weight for creative rotation when uploading via create_media_buy or update_media_buy (0-100). If omitted, platform determines rotation. Only used during upload to media buy - not stored in creative library.
+   * @minimum 0
+   * @maximum 100
    */
   weight?: number;
   /**
@@ -1580,10 +1673,12 @@ export interface ImageAsset {
   url: string;
   /**
    * Width in pixels
+   * @minimum 1
    */
   width: number;
   /**
    * Height in pixels
+   * @minimum 1
    */
   height: number;
   /**
@@ -1637,10 +1732,12 @@ export interface Provenance {
   };
   /**
    * When this provenance claim was made (ISO 8601). Distinct from created_time, which records when the content itself was produced. A provenance claim may be attached well after content creation, for example when retroactively declaring AI involvement for regulatory compliance.
+   * @format date-time
    */
   declared_at?: string;
   /**
    * When this content was created or generated (ISO 8601)
+   * @format date-time
    */
   created_time?: string;
   /**
@@ -1687,6 +1784,7 @@ export interface Provenance {
         persistence?: DisclosurePersistence;
         /**
          * Minimum display duration in milliseconds for initial persistence. Recommended when persistence is initial — without it, the duration is at the publisher's discretion. At serve time the publisher reads this from provenance since the brief is not available.
+         * @minimum 1
          */
         min_duration_ms?: number;
         /**
@@ -1707,6 +1805,7 @@ export interface Provenance {
     verified_by: string;
     /**
      * When the verification was performed (ISO 8601)
+     * @format date-time
      */
     verified_time?: string;
     /**
@@ -1715,6 +1814,8 @@ export interface Provenance {
     result: 'authentic' | 'ai_generated' | 'ai_modified' | 'inconclusive';
     /**
      * Confidence score of the verification result (0.0 to 1.0)
+     * @minimum 0
+     * @maximum 1
      */
     confidence?: number;
     /**
@@ -1738,18 +1839,22 @@ export interface VideoAsset {
   url: string;
   /**
    * Width in pixels
+   * @minimum 1
    */
   width: number;
   /**
    * Height in pixels
+   * @minimum 1
    */
   height: number;
   /**
    * Video duration in milliseconds
+   * @minimum 1
    */
   duration_ms?: number;
   /**
    * File size in bytes
+   * @minimum 1
    */
   file_size_bytes?: number;
   /**
@@ -1762,6 +1867,7 @@ export interface VideoAsset {
   video_codec?: string;
   /**
    * Video stream bitrate in kilobits per second
+   * @minimum 1
    */
   video_bitrate_kbps?: number;
   /**
@@ -1811,6 +1917,7 @@ export interface VideoAsset {
   audio_bit_depth?: 16 | 24 | 32;
   /**
    * Audio bitrate in kilobits per second
+   * @minimum 1
    */
   audio_bitrate_kbps?: number;
   /**
@@ -1849,10 +1956,12 @@ export interface AudioAsset {
   url: string;
   /**
    * Audio duration in milliseconds
+   * @minimum 0
    */
   duration_ms?: number;
   /**
    * File size in bytes
+   * @minimum 1
    */
   file_size_bytes?: number;
   /**
@@ -1874,6 +1983,7 @@ export interface AudioAsset {
   bit_depth?: 16 | 24 | 32;
   /**
    * Bitrate in kilobits per second
+   * @minimum 1
    */
   bitrate_kbps?: number;
   /**
@@ -2017,6 +2127,8 @@ export interface WebhookAsset {
   method?: HTTPMethod;
   /**
    * Maximum time to wait for response in milliseconds
+   * @minimum 10
+   * @maximum 5000
    */
   timeout_ms?: number;
   /**
@@ -2156,6 +2268,7 @@ export interface CreativeBrief {
       regulation?: string;
       /**
        * Minimum display duration in milliseconds. For video/audio disclosures, how long the disclosure must be visible or audible. For static formats, how long the disclosure must remain on screen before any auto-advance.
+       * @minimum 1
        */
       min_duration_ms?: number;
       /**
@@ -2194,6 +2307,7 @@ export interface IndustryIdentifier {
   type: CreativeIdentifierType;
   /**
    * The identifier value (e.g., 'ABCD1234000H' for Ad-ID)
+   * @maxLength 64
    */
   value: string;
 }
@@ -2204,6 +2318,7 @@ export type PublisherPropertySelector =
   | {
       /**
        * Domain where publisher's adagents.json is hosted (e.g., 'cnn.com')
+       * @pattern ^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$
        */
       publisher_domain: string;
       /**
@@ -2214,6 +2329,7 @@ export type PublisherPropertySelector =
   | {
       /**
        * Domain where publisher's adagents.json is hosted (e.g., 'cnn.com')
+       * @pattern ^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$
        */
       publisher_domain: string;
       /**
@@ -2228,6 +2344,7 @@ export type PublisherPropertySelector =
   | {
       /**
        * Domain where publisher's adagents.json is hosted (e.g., 'cnn.com')
+       * @pattern ^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$
        */
       publisher_domain: string;
       /**
@@ -2241,10 +2358,12 @@ export type PublisherPropertySelector =
     };
 /**
  * Identifier for a publisher property. Must be lowercase alphanumeric with underscores only.
+ * @pattern ^[a-z0-9_]+$
  */
 export type PropertyID = string;
 /**
  * Tag for categorizing publisher properties. Must be lowercase alphanumeric with underscores only.
+ * @pattern ^[a-z0-9_]+$
  */
 export type PropertyTag = string;
 /**
@@ -2308,14 +2427,17 @@ export type ForecastRange = {
 } & {
   /**
    * Conservative (low-end) forecast value
+   * @minimum 0
    */
   low?: number;
   /**
    * Expected (most likely) forecast value
+   * @minimum 0
    */
   mid?: number;
   /**
    * Optimistic (high-end) forecast value
+   * @minimum 0
    */
   high?: number;
 };
@@ -2380,6 +2502,7 @@ export type DataProviderSignalSelector =
   | {
       /**
        * Domain where data provider's adagents.json is hosted (e.g., 'polk.com')
+       * @pattern ^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$
        */
       data_provider_domain: string;
       /**
@@ -2390,6 +2513,7 @@ export type DataProviderSignalSelector =
   | {
       /**
        * Domain where data provider's adagents.json is hosted (e.g., 'polk.com')
+       * @pattern ^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$
        */
       data_provider_domain: string;
       /**
@@ -2404,6 +2528,7 @@ export type DataProviderSignalSelector =
   | {
       /**
        * Domain where data provider's adagents.json is hosted (e.g., 'polk.com')
+       * @pattern ^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$
        */
       data_provider_domain: string;
       /**
@@ -2619,6 +2744,7 @@ export interface Product {
   };
   /**
    * Maximum number of optimization_goals this product accepts on a package. When absent, no limit is declared. Most social platforms accept only 1 goal — buyers sending arrays longer than this value should expect the seller to use only the highest-priority (lowest priority number) goal.
+   * @minimum 1
    */
   max_optimization_goals?: number;
   measurement_readiness?: MeasurementReadiness;
@@ -2653,10 +2779,12 @@ export interface Product {
     matched_ids?: string[];
     /**
      * Number of catalog items that matched this product's inventory.
+     * @minimum 0
      */
     matched_count?: number;
     /**
      * Total catalog items evaluated from the buyer's catalog.
+     * @minimum 0
      */
     submitted_count: number;
   };
@@ -2666,6 +2794,7 @@ export interface Product {
   brief_relevance?: string;
   /**
    * Expiration timestamp. After this time, the product may no longer be available for purchase and create_media_buy may reject packages referencing it.
+   * @format date-time
    */
   expires_at?: string;
   /**
@@ -2756,14 +2885,17 @@ export interface Product {
   material_submission?: {
     /**
      * HTTPS URL for uploading or submitting physical creative materials
+     * @pattern ^https:\/\/
      */
     url?: string;
     /**
      * Email address for creative material submission
+     * @format email
      */
     email?: string;
     /**
      * Human-readable instructions for material submission (file naming conventions, shipping address, etc.)
+     * @maxLength 2000
      */
     instructions?: string;
     ext?: ExtensionObject;
@@ -2809,14 +2941,17 @@ export interface CPMPricingOption {
   pricing_model: 'cpm';
   /**
    * ISO 4217 currency code
+   * @pattern ^[A-Z]{3}$
    */
   currency: string;
   /**
    * Fixed price per unit. If present, this is fixed pricing. If absent, auction-based.
+   * @minimum 0
    */
   fixed_price?: number;
   /**
    * Minimum acceptable bid for auction pricing (mutually exclusive with fixed_price). Bids below this value will be rejected.
+   * @minimum 0
    */
   floor_price?: number;
   /**
@@ -2826,6 +2961,7 @@ export interface CPMPricingOption {
   price_guidance?: PriceGuidance;
   /**
    * Minimum spend requirement per package using this pricing option, in the specified currency
+   * @minimum 0
    */
   min_spend_per_package?: number;
   price_breakdown?: PriceBreakdown;
@@ -2840,18 +2976,22 @@ export interface CPMPricingOption {
 export interface PriceGuidance {
   /**
    * 25th percentile of recent winning bids
+   * @minimum 0
    */
   p25?: number;
   /**
    * Median of recent winning bids
+   * @minimum 0
    */
   p50?: number;
   /**
    * 75th percentile of recent winning bids
+   * @minimum 0
    */
   p75?: number;
   /**
    * 90th percentile of recent winning bids
+   * @minimum 0
    */
   p90?: number;
 }
@@ -2869,14 +3009,17 @@ export interface VCPMPricingOption {
   pricing_model: 'vcpm';
   /**
    * ISO 4217 currency code
+   * @pattern ^[A-Z]{3}$
    */
   currency: string;
   /**
    * Fixed price per unit. If present, this is fixed pricing. If absent, auction-based.
+   * @minimum 0
    */
   fixed_price?: number;
   /**
    * Minimum acceptable bid for auction pricing (mutually exclusive with fixed_price). Bids below this value will be rejected.
+   * @minimum 0
    */
   floor_price?: number;
   /**
@@ -2886,6 +3029,7 @@ export interface VCPMPricingOption {
   price_guidance?: PriceGuidance;
   /**
    * Minimum spend requirement per package using this pricing option, in the specified currency
+   * @minimum 0
    */
   min_spend_per_package?: number;
   price_breakdown?: PriceBreakdown;
@@ -2908,14 +3052,17 @@ export interface CPCPricingOption {
   pricing_model: 'cpc';
   /**
    * ISO 4217 currency code
+   * @pattern ^[A-Z]{3}$
    */
   currency: string;
   /**
    * Fixed price per click. If present, this is fixed pricing. If absent, auction-based.
+   * @minimum 0
    */
   fixed_price?: number;
   /**
    * Minimum acceptable bid for auction pricing (mutually exclusive with fixed_price). Bids below this value will be rejected.
+   * @minimum 0
    */
   floor_price?: number;
   /**
@@ -2925,6 +3072,7 @@ export interface CPCPricingOption {
   price_guidance?: PriceGuidance;
   /**
    * Minimum spend requirement per package using this pricing option, in the specified currency
+   * @minimum 0
    */
   min_spend_per_package?: number;
   price_breakdown?: PriceBreakdown;
@@ -2947,14 +3095,17 @@ export interface CPCVPricingOption {
   pricing_model: 'cpcv';
   /**
    * ISO 4217 currency code
+   * @pattern ^[A-Z]{3}$
    */
   currency: string;
   /**
    * Fixed price per completed view. If present, this is fixed pricing. If absent, auction-based.
+   * @minimum 0
    */
   fixed_price?: number;
   /**
    * Minimum acceptable bid for auction pricing (mutually exclusive with fixed_price). Bids below this value will be rejected.
+   * @minimum 0
    */
   floor_price?: number;
   /**
@@ -2964,6 +3115,7 @@ export interface CPCVPricingOption {
   price_guidance?: PriceGuidance;
   /**
    * Minimum spend requirement per package using this pricing option, in the specified currency
+   * @minimum 0
    */
   min_spend_per_package?: number;
   price_breakdown?: PriceBreakdown;
@@ -2986,14 +3138,17 @@ export interface CPVPricingOption {
   pricing_model: 'cpv';
   /**
    * ISO 4217 currency code
+   * @pattern ^[A-Z]{3}$
    */
   currency: string;
   /**
    * Fixed price per view. If present, this is fixed pricing. If absent, auction-based.
+   * @minimum 0
    */
   fixed_price?: number;
   /**
    * Minimum acceptable bid for auction pricing (mutually exclusive with fixed_price). Bids below this value will be rejected.
+   * @minimum 0
    */
   floor_price?: number;
   /**
@@ -3010,12 +3165,14 @@ export interface CPVPricingOption {
       | {
           /**
            * Seconds of viewing required
+           * @minimum 1
            */
           duration_seconds: number;
         };
   };
   /**
    * Minimum spend requirement per package using this pricing option, in the specified currency
+   * @minimum 0
    */
   min_spend_per_package?: number;
   price_breakdown?: PriceBreakdown;
@@ -3038,14 +3195,17 @@ export interface CPPPricingOption {
   pricing_model: 'cpp';
   /**
    * ISO 4217 currency code
+   * @pattern ^[A-Z]{3}$
    */
   currency: string;
   /**
    * Fixed price per rating point. If present, this is fixed pricing. If absent, auction-based.
+   * @minimum 0
    */
   fixed_price?: number;
   /**
    * Minimum acceptable bid for auction pricing (mutually exclusive with fixed_price). Bids below this value will be rejected.
+   * @minimum 0
    */
   floor_price?: number;
   price_guidance?: PriceGuidance;
@@ -3060,11 +3220,13 @@ export interface CPPPricingOption {
     demographic: string;
     /**
      * Minimum GRPs/TRPs required
+     * @minimum 0
      */
     min_points?: number;
   };
   /**
    * Minimum spend requirement per package using this pricing option, in the specified currency
+   * @minimum 0
    */
   min_spend_per_package?: number;
   price_breakdown?: PriceBreakdown;
@@ -3099,6 +3261,7 @@ export interface CPAPricingOption {
   event_source_id?: string;
   /**
    * ISO 4217 currency code
+   * @pattern ^[A-Z]{3}$
    */
   currency: string;
   /**
@@ -3107,6 +3270,7 @@ export interface CPAPricingOption {
   fixed_price: number;
   /**
    * Minimum spend requirement per package using this pricing option, in the specified currency
+   * @minimum 0
    */
   min_spend_per_package?: number;
   price_breakdown?: PriceBreakdown;
@@ -3129,20 +3293,24 @@ export interface FlatRatePricingOption {
   pricing_model: 'flat_rate';
   /**
    * ISO 4217 currency code
+   * @pattern ^[A-Z]{3}$
    */
   currency: string;
   /**
    * Flat rate cost. If present, this is fixed pricing. If absent, auction-based.
+   * @minimum 0
    */
   fixed_price?: number;
   /**
    * Minimum acceptable bid for auction pricing (mutually exclusive with fixed_price). Bids below this value will be rejected.
+   * @minimum 0
    */
   floor_price?: number;
   price_guidance?: PriceGuidance;
   parameters?: DoohParameters;
   /**
    * Minimum spend requirement per package using this pricing option, in the specified currency
+   * @minimum 0
    */
   min_spend_per_package?: number;
   price_breakdown?: PriceBreakdown;
@@ -3161,14 +3329,18 @@ export interface DoohParameters {
   type: 'dooh';
   /**
    * Guaranteed share of voice as a percentage (0-100)
+   * @minimum 0
+   * @maximum 100
    */
   sov_percentage?: number;
   /**
    * Duration of the ad loop rotation in seconds
+   * @minimum 1
    */
   loop_duration_seconds?: number;
   /**
    * Minimum number of plays per hour guaranteed
+   * @minimum 1
    */
   min_plays_per_hour?: number;
   /**
@@ -3177,6 +3349,7 @@ export interface DoohParameters {
   venue_package?: string;
   /**
    * Duration of the DOOH slot in hours (e.g., 24 for a full-day takeover)
+   * @minimum 0
    */
   duration_hours?: number;
   /**
@@ -3185,6 +3358,7 @@ export interface DoohParameters {
   daypart?: string;
   /**
    * Estimated audience impressions for this slot (informational, not a delivery guarantee)
+   * @minimum 0
    */
   estimated_impressions?: number;
 }
@@ -3202,14 +3376,17 @@ export interface TimeBasedPricingOption {
   pricing_model: 'time';
   /**
    * ISO 4217 currency code
+   * @pattern ^[A-Z]{3}$
    */
   currency: string;
   /**
    * Cost per time unit. If present, this is fixed pricing. If absent, auction-based.
+   * @minimum 0
    */
   fixed_price?: number;
   /**
    * Minimum acceptable bid per time unit for auction pricing (mutually exclusive with fixed_price). Bids below this value will be rejected.
+   * @minimum 0
    */
   floor_price?: number;
   price_guidance?: PriceGuidance;
@@ -3223,15 +3400,18 @@ export interface TimeBasedPricingOption {
     time_unit: 'hour' | 'day' | 'week' | 'month';
     /**
      * Minimum booking duration in time_units
+     * @minimum 1
      */
     min_duration?: number;
     /**
      * Maximum booking duration in time_units. Must be >= min_duration when both are present.
+     * @minimum 1
      */
     max_duration?: number;
   };
   /**
    * Minimum spend requirement per package using this pricing option, in the specified currency
+   * @minimum 0
    */
   min_spend_per_package?: number;
   price_breakdown?: PriceBreakdown;
@@ -3261,15 +3441,19 @@ export interface DeliveryForecast {
   demographic?: string;
   /**
    * Third-party measurement provider whose data was used to produce this forecast. Distinct from demographic_system, which specifies demographic notation — measurement_source identifies whose data produced the forecast numbers. Should be present when measured_impressions is used. Lowercase slug format.
+   * @maxLength 64
+   * @pattern ^[a-z0-9_]+$
    */
   measurement_source?: string;
   reach_unit?: ReachUnit;
   /**
    * When this forecast was computed
+   * @format date-time
    */
   generated_at?: string;
   /**
    * When this forecast expires. After this time, the forecast should be refreshed. Forecast expiry does not affect proposal executability.
+   * @format date-time
    */
   valid_until?: string;
   ext?: ExtensionObject;
@@ -3280,10 +3464,12 @@ export interface DeliveryForecast {
 export interface ForecastPoint {
   /**
    * Human-readable name for this forecast point. Required when forecast_range_unit is 'package' so buyer agents can identify and reference individual packages. Optional for other forecast types.
+   * @maxLength 128
    */
   label?: string;
   /**
    * Budget amount for this forecast point. Required for spend curves; omit for availability forecasts where the metrics represent total available inventory. For allocation-level forecasts, this is the absolute budget for that allocation (not the percentage). For proposal-level forecasts, this is the total proposal budget. When omitted, use metrics.spend to express the estimated cost of the available inventory.
+   * @minimum 0
    */
   budget?: number;
   /**
@@ -3345,10 +3531,13 @@ export interface CancellationPolicy {
     type: 'percent_remaining' | 'full_commitment' | 'fixed_fee' | 'none';
     /**
      * Fee rate as a decimal proportion of remaining committed spend. Required when type is 'percent_remaining' (e.g., 0.5 means 50% of remaining spend).
+     * @minimum 0
+     * @maximum 1
      */
     rate?: number;
     /**
      * Fixed fee amount in the buy's currency. Required when type is 'fixed_fee'.
+     * @minimum 0
      */
     amount?: number;
   };
@@ -3363,6 +3552,7 @@ export interface ReportingCapabilities {
   available_reporting_frequencies: ReportingFrequency[];
   /**
    * Expected delay in minutes before reporting data becomes available (e.g., 240 for 4-hour delay)
+   * @minimum 0
    */
   expected_delay_minutes: number;
   /**
@@ -3442,18 +3632,22 @@ export interface GeographicBreakdownSupport {
 export interface MeasurementWindow {
   /**
    * Identifier for this maturation stage. Standard broadcast values: 'live' (real-time viewers only), 'c3' (live + 3 days time-shifted), 'c7' (live + 7 days time-shifted). Standard values for other channels include 'tentative' (provisional data available quickly), 'final' (post-processing certified data), 'post_ivt' (digital after invalid-traffic filtering), 'post_sivt' (digital after sophisticated-IVT filtering), 'downloads_7d' / 'downloads_30d' (podcast download maturation). Sellers may define custom IDs.
+   * @maxLength 50
    */
   window_id: string;
   /**
    * Human-readable description of what this window measures
+   * @maxLength 500
    */
   description?: string;
   /**
    * Number of days of accumulation included in this window before processing begins. For broadcast, this is DVR accumulation (0 = live only, 3 = live + 3 days DVR, 7 = live + 7 days DVR). For channels without an accumulation period (DOOH tentative→final, digital IVT filtering), this is 0 — maturation is entirely vendor processing time captured in expected_availability_days.
+   * @minimum 0
    */
   duration_days: number;
   /**
    * Expected number of days after delivery before this window's data is available from the measurement vendor. Captures accumulation time plus vendor processing time. Examples: broadcast C7 from VideoAmp ~22 days (7-day accumulation + ~15-day processing); DOOH tentative plays same-day; DOOH final (post-IVT/fraud-check) ~1 day; digital post-SIVT ~2–3 days.
+   * @minimum 0
    */
   expected_availability_days?: number;
   /**
@@ -3517,6 +3711,7 @@ export interface DiagnosticIssue {
 export interface CollectionSelector {
   /**
    * Domain where the adagents.json declaring these collections is hosted (e.g., 'mrbeast.com'). The collections array in that file contains the authoritative collection definitions.
+   * @pattern ^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$
    */
   publisher_domain: string;
   /**
@@ -3550,11 +3745,13 @@ export interface Installment {
   installment_number?: string;
   /**
    * When the installment airs or publishes (ISO 8601)
+   * @format date-time
    */
   scheduled_at?: string;
   status?: InstallmentStatus;
   /**
    * Expected duration of the installment in seconds
+   * @minimum 0
    */
   duration_seconds?: number;
   /**
@@ -3563,6 +3760,7 @@ export interface Installment {
   flexible_end?: boolean;
   /**
    * When this installment data expires and should be re-queried. Agents should re-query before committing budget to products with tentative installments.
+   * @format date-time
    */
   valid_until?: string;
   content_rating?: ContentRating;
@@ -3610,10 +3808,12 @@ export interface Special {
   category?: SpecialCategory;
   /**
    * When the event starts (ISO 8601)
+   * @format date-time
    */
   starts?: string;
   /**
    * When the event ends (ISO 8601). Omit for single-day events.
+   * @format date-time
    */
   ends?: string;
 }
@@ -3637,14 +3837,17 @@ export interface Talent {
 export interface AdInventoryConfiguration {
   /**
    * Number of planned ad breaks in the installment
+   * @minimum 0
    */
   expected_breaks: number;
   /**
    * Total seconds of ad time across all breaks
+   * @minimum 0
    */
   total_ad_seconds?: number;
   /**
    * Maximum duration in seconds for a single ad within a break. Buyers need this to know whether their creative fits.
+   * @minimum 1
    */
   max_ad_duration_seconds?: number;
   /**
@@ -3662,10 +3865,12 @@ export interface AdInventoryConfiguration {
 export interface InstallmentDeadlines {
   /**
    * Last date/time to book a placement in this installment (ISO 8601). After this point, the seller will not accept new bookings.
+   * @format date-time
    */
   booking_deadline?: string;
   /**
    * Last date/time to cancel without penalty (ISO 8601). Cancellations after this point may incur fees per the seller's terms.
+   * @format date-time
    */
   cancellation_deadline?: string;
   /**
@@ -3683,6 +3888,7 @@ export interface MaterialDeadline {
   stage: string;
   /**
    * When materials for this stage are due (ISO 8601)
+   * @format date-time
    */
   due_at: string;
   /**
@@ -3917,6 +4123,8 @@ export type AudienceSelector =
       type: 'description';
       /**
        * Natural language description of the audience (e.g., 'likely EV buyers', 'high net worth individuals', 'vulnerable communities')
+       * @minLength 1
+       * @maxLength 2000
        */
       description: string;
       /**
@@ -3935,10 +4143,12 @@ export type SignalID =
       source: 'catalog';
       /**
        * Domain of the data provider that owns this signal (e.g., 'polk.com', 'experian.com'). The signal definition is published at this domain's /.well-known/adagents.json
+       * @pattern ^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$
        */
       data_provider_domain: string;
       /**
        * Signal identifier within the data provider's catalog (e.g., 'likely_tesla_buyers', 'income_100k_plus')
+       * @pattern ^[a-zA-Z0-9_-]+$
        */
       id: string;
     }
@@ -3953,6 +4163,7 @@ export type SignalID =
       agent_url: string;
       /**
        * Signal identifier within the agent's signal set (e.g., 'custom_auto_intenders')
+       * @pattern ^[a-zA-Z0-9_-]+$
        */
       id: string;
     };
@@ -4009,7 +4220,13 @@ export type PreviewRender =
        * Dimensions for this rendered piece
        */
       dimensions?: {
+        /**
+         * @minimum 0
+         */
         width: number;
+        /**
+         * @minimum 0
+         */
         height: number;
       };
       /**
@@ -4055,7 +4272,13 @@ export type PreviewRender =
        * Dimensions for this rendered piece
        */
       dimensions?: {
+        /**
+         * @minimum 0
+         */
         width: number;
+        /**
+         * @minimum 0
+         */
         height: number;
       };
       /**
@@ -4105,7 +4328,13 @@ export type PreviewRender =
        * Dimensions for this rendered piece
        */
       dimensions?: {
+        /**
+         * @minimum 0
+         */
         width: number;
+        /**
+         * @minimum 0
+         */
         height: number;
       };
       /**
@@ -4157,6 +4386,9 @@ export type CatalogItemStatus = 'approved' | 'pending' | 'rejected' | 'warning';
 export interface MCPWebhookPayload {
   /**
    * Sender-generated key stable across retries of the same webhook event. Publishers MUST generate a cryptographically random value (UUID v4 recommended) per distinct event and reuse the same key on every retry of that event. Receivers MUST dedupe by this key, scoped to the authenticated sender identity (HMAC secret or Bearer credential) — keys from different publishers are independent. This is the canonical dedup field — the (task_id, status, timestamp) tuple is insufficient when a single transition is retried with unchanged timestamp or when two transitions share a timestamp.
+   * @minLength 16
+   * @maxLength 255
+   * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   idempotency_key: string;
   /**
@@ -4172,6 +4404,7 @@ export interface MCPWebhookPayload {
   status: TaskStatus;
   /**
    * ISO 8601 timestamp when this webhook was generated.
+   * @format date-time
    */
   timestamp: string;
   /**
@@ -4294,14 +4527,17 @@ export interface GetProductsResponse {
 export interface Proposal {
   /**
    * Unique identifier for this proposal. Used to execute it via create_media_buy.
+   * @maxLength 255
    */
   proposal_id: string;
   /**
    * Human-readable name for this media plan proposal
+   * @maxLength 500
    */
   name: string;
   /**
    * Explanation of the proposal strategy and what it achieves
+   * @maxLength 2000
    */
   description?: string;
   /**
@@ -4311,6 +4547,7 @@ export interface Proposal {
   proposal_status?: ProposalStatus;
   /**
    * When this proposal expires and can no longer be executed. For draft proposals, indicates when indicative pricing becomes stale. For committed proposals, indicates when the inventory hold lapses — the buyer must call create_media_buy before this time.
+   * @format date-time
    */
   expires_at?: string;
   insertion_order?: InsertionOrder;
@@ -4320,14 +4557,17 @@ export interface Proposal {
   total_budget_guidance?: {
     /**
      * Minimum recommended budget
+     * @minimum 0
      */
     min?: number;
     /**
      * Recommended budget for optimal performance
+     * @minimum 0
      */
     recommended?: number;
     /**
      * Maximum budget before diminishing returns
+     * @minimum 0
      */
     max?: number;
     /**
@@ -4337,6 +4577,7 @@ export interface Proposal {
   };
   /**
    * Explanation of how this proposal aligns with the campaign brief
+   * @maxLength 2000
    */
   brief_alignment?: string;
   forecast?: DeliveryForecast;
@@ -4352,6 +4593,8 @@ export interface ProductAllocation {
   product_id: string;
   /**
    * Percentage of total budget allocated to this product (0-100)
+   * @minimum 0
+   * @maximum 100
    */
   allocation_percentage: number;
   /**
@@ -4364,6 +4607,7 @@ export interface ProductAllocation {
   rationale?: string;
   /**
    * Optional ordering hint for multi-line-item plans (1-based)
+   * @minimum 1
    */
   sequence?: number;
   /**
@@ -4372,10 +4616,12 @@ export interface ProductAllocation {
   tags?: string[];
   /**
    * Recommended flight start date/time for this allocation in ISO 8601 format. Allows publishers to propose per-flight scheduling within a proposal. When omitted, the allocation applies to the full campaign date range.
+   * @format date-time
    */
   start_time?: string;
   /**
    * Recommended flight end date/time for this allocation in ISO 8601 format. Allows publishers to propose per-flight scheduling within a proposal. When omitted, the allocation applies to the full campaign date range.
+   * @format date-time
    */
   end_time?: string;
   /**
@@ -4391,6 +4637,7 @@ export interface ProductAllocation {
 export interface InsertionOrder {
   /**
    * Unique identifier for this insertion order. Referenced by io_acceptance on create_media_buy.
+   * @maxLength 255
    */
   io_id: string;
   /**
@@ -4399,28 +4646,37 @@ export interface InsertionOrder {
   terms?: {
     /**
      * Advertiser name or identifier
+     * @maxLength 500
      */
     advertiser?: string;
     /**
      * Publisher name or identifier
+     * @maxLength 500
      */
     publisher?: string;
     /**
      * Total committed budget
      */
     total_budget?: {
+      /**
+       * @minimum 0
+       */
       amount: number;
       /**
        * ISO 4217 currency code
+       * @minLength 3
+       * @maxLength 3
        */
       currency: string;
     };
     /**
      * Campaign start date
+     * @format date-time
      */
     flight_start?: string;
     /**
      * Campaign end date
+     * @format date-time
      */
     flight_end?: string;
     /**
@@ -4447,6 +4703,8 @@ export interface InsertionOrder {
 export interface Error {
   /**
    * Error code for programmatic handling. Standard codes are defined in error-code.json and enable autonomous agent recovery. Sellers MAY use codes not in the standard vocabulary for platform-specific errors; agents MUST handle unknown codes gracefully by falling back to the recovery classification.
+   * @minLength 1
+   * @maxLength 64
    */
   code: string;
   /**
@@ -4463,6 +4721,8 @@ export interface Error {
   suggestion?: string;
   /**
    * Seconds to wait before retrying the operation. Sellers MUST return values between 1 and 3600. Clients MUST clamp values outside this range.
+   * @minimum 1
+   * @maximum 3600
    */
   retry_after?: number;
   /**
@@ -4509,6 +4769,7 @@ export interface PaginationResponse {
   cursor?: string;
   /**
    * Total number of items matching the query across all pages. Optional because not all backends can efficiently compute this.
+   * @minimum 0
    */
   total_count?: number;
 }
@@ -4518,6 +4779,8 @@ export interface PaginationResponse {
 export interface GetProductsAsyncWorking {
   /**
    * Progress percentage of the search operation
+   * @minimum 0
+   * @maximum 100
    */
   percentage?: number;
   /**
@@ -4560,6 +4823,7 @@ export interface GetProductsAsyncInputRequired {
 export interface GetProductsAsyncSubmitted {
   /**
    * Estimated completion time for the search
+   * @format date-time
    */
   estimated_completion?: string;
   context?: ContextObject;
@@ -4578,14 +4842,17 @@ export interface CreateMediaBuySuccess {
   status?: MediaBuyStatus;
   /**
    * ISO 8601 timestamp when this media buy was confirmed by the seller. A successful create_media_buy response constitutes order confirmation.
+   * @format date-time
    */
   confirmed_at?: string;
   /**
    * ISO 8601 timestamp for creative upload deadline
+   * @format date-time
    */
   creative_deadline?: string;
   /**
    * Initial revision number for this media buy. Use in subsequent update_media_buy requests for optimistic concurrency.
+   * @minimum 1
    */
   revision?: number;
   /**
@@ -4627,10 +4894,12 @@ export interface PlannedDelivery {
   channels?: MediaChannel[];
   /**
    * Actual flight start the seller will use.
+   * @format date-time
    */
   start_time?: string;
   /**
    * Actual flight end the seller will use.
+   * @format date-time
    */
   end_time?: string;
   frequency_cap?: FrequencyCap;
@@ -4644,10 +4913,12 @@ export interface PlannedDelivery {
   audience_targeting?: AudienceSelector[];
   /**
    * Total budget the seller will deliver against.
+   * @minimum 0
    */
   total_budget?: number;
   /**
    * ISO 4217 currency code for the budget.
+   * @pattern ^[A-Z]{3}$
    */
   currency?: string;
   /**
@@ -4681,6 +4952,7 @@ export interface CreateMediaBuySubmitted {
   task_id: string;
   /**
    * Optional human-readable explanation of why the task is submitted — e.g., 'Awaiting IO signature from sales team; typical turnaround 2–4 hours.' Plain text only. Buyers MUST treat this as untrusted seller input: escape before rendering to HTML UIs, and sanitize or isolate before passing to an LLM prompt context — a hostile seller may inject prompt-injection payloads aimed at the buyer's agent.
+   * @maxLength 2000
    */
   message?: string;
   /**
@@ -4696,6 +4968,8 @@ export interface CreateMediaBuySubmitted {
 export interface CreateMediaBuyAsyncWorking {
   /**
    * Completion percentage (0-100)
+   * @minimum 0
+   * @maximum 100
    */
   percentage?: number;
   /**
@@ -4704,10 +4978,12 @@ export interface CreateMediaBuyAsyncWorking {
   current_step?: string;
   /**
    * Total number of steps in the operation
+   * @minimum 1
    */
   total_steps?: number;
   /**
    * Current step number
+   * @minimum 1
    */
   step_number?: number;
   context?: ContextObject;
@@ -4746,10 +5022,12 @@ export interface UpdateMediaBuySuccess {
   status?: MediaBuyStatus;
   /**
    * Revision number after this update. Use this value in subsequent update_media_buy requests for optimistic concurrency.
+   * @minimum 1
    */
   revision?: number;
   /**
    * ISO 8601 timestamp when changes take effect (null if pending approval)
+   * @format date-time
    */
   implementation_date?: string | null;
   invoice_recipient?: BusinessEntity;
@@ -4785,6 +5063,8 @@ export interface UpdateMediaBuyError {
 export interface UpdateMediaBuyAsyncWorking {
   /**
    * Completion percentage (0-100)
+   * @minimum 0
+   * @maximum 100
    */
   percentage?: number;
   /**
@@ -4793,10 +5073,12 @@ export interface UpdateMediaBuyAsyncWorking {
   current_step?: string;
   /**
    * Total number of steps in the operation
+   * @minimum 1
    */
   total_steps?: number;
   /**
    * Current step number
+   * @minimum 1
    */
   step_number?: number;
   context?: ContextObject;
@@ -4831,6 +5113,7 @@ export interface BuildCreativeSuccess {
   sandbox?: boolean;
   /**
    * ISO 8601 timestamp when generated asset URLs in the manifest expire. Set to the earliest expiration across all generated assets. Re-build the creative after this time to get fresh URLs.
+   * @format date-time
    */
   expires_at?: string;
   /**
@@ -4875,6 +5158,7 @@ export interface BuildCreativeSuccess {
     interactive_url?: string;
     /**
      * ISO 8601 timestamp when preview URLs expire. May differ from the manifest's expires_at.
+     * @format date-time
      */
     expires_at: string;
   };
@@ -4885,10 +5169,12 @@ export interface BuildCreativeSuccess {
   pricing_option_id?: string;
   /**
    * Cost incurred for this build, denominated in currency. May be 0 for CPM-priced creatives where cost accrues at serve time rather than build time.
+   * @minimum 0
    */
   vendor_cost?: number;
   /**
    * ISO 4217 currency code for vendor_cost.
+   * @pattern ^[A-Z]{3}$
    */
   currency?: string;
   consumption?: CreativeConsumption;
@@ -4942,10 +5228,12 @@ export interface RightsConstraint {
   };
   /**
    * Start of the rights validity period
+   * @format date-time
    */
   valid_from?: string;
   /**
    * End of the rights validity period. Creative should not be served after this time.
+   * @format date-time
    */
   valid_until?: string;
   /**
@@ -4962,6 +5250,7 @@ export interface RightsConstraint {
   excluded_countries?: string[];
   /**
    * Maximum total impressions allowed for the full validity period (valid_from to valid_until). This is the absolute cap across all creatives using this rights grant, not a per-creative or per-period limit.
+   * @minimum 1
    */
   impression_cap?: number;
   right_type?: RightType;
@@ -4981,18 +5270,22 @@ export interface RightsConstraint {
 export interface CreativeConsumption {
   /**
    * LLM or generation tokens consumed during creative generation.
+   * @minimum 0
    */
   tokens?: number;
   /**
    * Number of images produced during generation.
+   * @minimum 0
    */
   images_generated?: number;
   /**
    * Number of render passes performed (video, animation).
+   * @minimum 0
    */
   renders?: number;
   /**
    * Processing time billed, in seconds. For compute-time pricing models.
+   * @minimum 0
    */
   duration_seconds?: number;
 }
@@ -5010,6 +5303,7 @@ export interface BuildCreativeMultiSuccess {
   sandbox?: boolean;
   /**
    * ISO 8601 timestamp when the earliest generated asset URL expires across all manifests. Re-build after this time to get fresh URLs.
+   * @format date-time
    */
   expires_at?: string;
   /**
@@ -5055,6 +5349,7 @@ export interface BuildCreativeMultiSuccess {
     interactive_url?: string;
     /**
      * ISO 8601 timestamp when preview URLs expire. May differ from the manifest's expires_at.
+     * @format date-time
      */
     expires_at: string;
   };
@@ -5065,10 +5360,12 @@ export interface BuildCreativeMultiSuccess {
   pricing_option_id?: string;
   /**
    * Total cost incurred for this multi-format build, denominated in currency. May be 0 for CPM-priced creatives where cost accrues at serve time.
+   * @minimum 0
    */
   vendor_cost?: number;
   /**
    * ISO 4217 currency code for vendor_cost.
+   * @pattern ^[A-Z]{3}$
    */
   currency?: string;
   consumption?: CreativeConsumption;
@@ -5092,6 +5389,8 @@ export interface BuildCreativeError {
 export interface BuildCreativeAsyncWorking {
   /**
    * Completion percentage (0-100)
+   * @minimum 0
+   * @maximum 100
    */
   percentage?: number;
   /**
@@ -5100,10 +5399,12 @@ export interface BuildCreativeAsyncWorking {
   current_step?: string;
   /**
    * Total number of steps in the operation
+   * @minimum 1
    */
   total_steps?: number;
   /**
    * Current step number
+   * @minimum 1
    */
   step_number?: number;
   context?: ContextObject;
@@ -5172,6 +5473,7 @@ export interface SyncCreativesSuccess {
     preview_url?: string;
     /**
      * ISO 8601 timestamp when preview link expires (only present when preview_url exists)
+     * @format date-time
      */
     expires_at?: string;
     /**
@@ -5223,6 +5525,7 @@ export interface SyncCreativesSubmitted {
   task_id: string;
   /**
    * Optional human-readable explanation of why the task is submitted — e.g., 'Batch ingestion queued; typical turnaround 15-30 minutes.' Plain text only. Buyers MUST treat this as untrusted seller input: escape before rendering to HTML UIs, and sanitize or isolate before passing to an LLM prompt context — a hostile seller may inject prompt-injection payloads aimed at the buyer's agent.
+   * @maxLength 2000
    */
   message?: string;
   /**
@@ -5238,6 +5541,8 @@ export interface SyncCreativesSubmitted {
 export interface SyncCreativesAsyncWorking {
   /**
    * Completion percentage (0-100)
+   * @minimum 0
+   * @maximum 100
    */
   percentage?: number;
   /**
@@ -5246,18 +5551,22 @@ export interface SyncCreativesAsyncWorking {
   current_step?: string;
   /**
    * Total number of steps in the operation
+   * @minimum 1
    */
   total_steps?: number;
   /**
    * Current step number
+   * @minimum 1
    */
   step_number?: number;
   /**
    * Number of creatives processed so far
+   * @minimum 0
    */
   creatives_processed?: number;
   /**
    * Total number of creatives to process
+   * @minimum 0
    */
   creatives_total?: number;
   context?: ContextObject;
@@ -5304,18 +5613,22 @@ export interface SyncCatalogsSuccess {
     platform_id?: string;
     /**
      * Total number of items in the catalog after sync. Required when action is 'created', 'updated', or 'unchanged'. Omitted on 'failed' and 'deleted'.
+     * @minimum 0
      */
     item_count?: number;
     /**
      * Number of items approved by the platform. Populated when the platform performs item-level review.
+     * @minimum 0
      */
     items_approved?: number;
     /**
      * Number of items pending platform review. Common for product catalogs where items must pass content policy checks.
+     * @minimum 0
      */
     items_pending?: number;
     /**
      * Number of items rejected by the platform. Check item_issues for rejection reasons.
+     * @minimum 0
      */
     items_rejected?: number;
     /**
@@ -5334,10 +5647,12 @@ export interface SyncCatalogsSuccess {
     }[];
     /**
      * ISO 8601 timestamp of when the most recent sync was accepted by the platform
+     * @format date-time
      */
     last_synced_at?: string;
     /**
      * ISO 8601 timestamp of when the platform will next fetch the feed URL. Only present for URL-based catalogs with update_frequency.
+     * @format date-time
      */
     next_fetch_at?: string;
     /**
@@ -5377,6 +5692,8 @@ export interface SyncCatalogsError {
 export interface SyncCatalogsAsyncWorking {
   /**
    * Completion percentage (0-100)
+   * @minimum 0
+   * @maximum 100
    */
   percentage?: number;
   /**
@@ -5385,26 +5702,32 @@ export interface SyncCatalogsAsyncWorking {
   current_step?: string;
   /**
    * Total number of steps in the operation
+   * @minimum 1
    */
   total_steps?: number;
   /**
    * Current step number
+   * @minimum 1
    */
   step_number?: number;
   /**
    * Number of catalogs processed so far
+   * @minimum 0
    */
   catalogs_processed?: number;
   /**
    * Total number of catalogs to process
+   * @minimum 0
    */
   catalogs_total?: number;
   /**
    * Total number of catalog items processed across all catalogs
+   * @minimum 0
    */
   items_processed?: number;
   /**
    * Total number of catalog items to process across all catalogs
+   * @minimum 0
    */
   items_total?: number;
   context?: ContextObject;
@@ -5574,6 +5897,7 @@ export interface A2UIUserAction {
   };
   /**
    * When the action occurred
+   * @format date-time
    */
   timestamp?: string;
 }
@@ -5591,6 +5915,8 @@ export type AuthenticationScheme = 'Bearer' | 'HMAC-SHA256';
 export interface AcquireRightsRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -5624,14 +5950,17 @@ export interface AcquireRightsRequest {
     format_ids?: FormatReferenceStructuredObject[];
     /**
      * Estimated total impressions for the campaign. Required when the request carries an intent-phase governance_context token AND the selected pricing_option has model: 'cpm' — the brand agent projects commitment as (pricing_option.price / 1000) × estimated_impressions evaluated in pricing_option.currency. Brand agents MUST reject with INVALID_REQUEST (field: campaign.estimated_impressions) when CPM-priced rights are requested under a governance_context and this field is omitted or zero; implementer-chosen defaults are non-conformant. See the acquire_rights task reference for the full validation contract including currency-mismatch handling.
+     * @minimum 0
      */
     estimated_impressions?: number;
     /**
      * Campaign start date (ISO 8601)
+     * @format date
      */
     start_date?: string;
     /**
      * Campaign end date (ISO 8601). Brand agents MUST reject with INVALID_REQUEST (field: campaign.end_date) when end_date is in the past at the time of the request — acquiring rights for an elapsed window produces a zero-duration grant and is almost always a buyer-side bug.
+     * @format date
      */
     end_date?: string;
   };
@@ -5639,6 +5968,9 @@ export interface AcquireRightsRequest {
   push_notification_config?: PushNotificationConfig;
   /**
    * Client-generated key for safe retries. Resubmitting with the same key returns the original response rather than creating a duplicate acquisition. MUST be unique per (seller, request) pair to prevent cross-seller correlation. Use a fresh UUID v4 for each request.
+   * @minLength 16
+   * @maxLength 255
+   * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   idempotency_key: string;
   context?: ContextObject;
@@ -5654,6 +5986,7 @@ export interface PushNotificationConfig {
   url: string;
   /**
    * Optional client-provided token for webhook validation. Echoed back in webhook payload to validate request authenticity.
+   * @minLength 16
    */
   token?: string;
   /**
@@ -5666,6 +5999,7 @@ export interface PushNotificationConfig {
     schemes: AuthenticationScheme[];
     /**
      * Credentials for the legacy scheme. For Bearer: token sent in Authorization header. For HMAC-SHA256: shared secret used to generate signature. Minimum 32 characters. Exchanged out-of-band during onboarding.
+     * @minLength 32
      */
     credentials: string;
   };
@@ -5731,13 +6065,31 @@ export interface AcquireRightsAcquired {
  */
 export interface RightsTerms {
   pricing_option_id: string;
+  /**
+   * @minimum 0
+   */
   amount: number;
+  /**
+   * @pattern ^[A-Z]{3}$
+   */
   currency: string;
   period?: RightsBillingPeriod;
   uses: RightUse[];
+  /**
+   * @minimum 1
+   */
   impression_cap?: number;
+  /**
+   * @minimum 0
+   */
   overage_cpm?: number;
+  /**
+   * @format date
+   */
   start_date?: string;
+  /**
+   * @format date
+   */
   end_date?: string;
   /**
    * Exclusivity terms if applicable
@@ -5765,6 +6117,7 @@ export interface GenerationCredential {
   uses: RightUse[];
   /**
    * When this credential expires. Key lifetime is determined by the provider.
+   * @format date-time
    */
   expires_at?: string;
   /**
@@ -5822,6 +6175,8 @@ export interface AcquireRightsError {
 export interface CreativeApprovalRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -5847,6 +6202,9 @@ export interface CreativeApprovalRequest {
   metadata?: {};
   /**
    * Client-generated key for safe retries. Resubmitting with the same key returns the original response. MUST be unique per (seller, request) pair to prevent cross-seller correlation. Use a fresh UUID v4 for each request.
+   * @minLength 16
+   * @maxLength 255
+   * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   idempotency_key: string;
   context?: ContextObject;
@@ -5874,6 +6232,9 @@ export interface CreativeApproved {
    */
   creative_id?: string;
   creative_url?: string;
+  /**
+   * @format date-time
+   */
   approved_at?: string;
   /**
    * Conditions on the approval (e.g., 'approved for NL market only')
@@ -5939,6 +6300,8 @@ export interface CreativeApprovalError {
 export interface GetBrandIdentityRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -6093,10 +6456,13 @@ export interface GetBrandIdentitySuccess {
           files?: {
             /**
              * HTTPS URL to the font file
+             * @pattern ^https:\/\/
              */
             url: string;
             /**
              * CSS numeric font-weight
+             * @minimum 100
+             * @maximum 900
              */
             weight?: number;
             /**
@@ -6130,10 +6496,13 @@ export interface GetBrandIdentitySuccess {
           files?: {
             /**
              * HTTPS URL to the font file
+             * @pattern ^https:\/\/
              */
             url: string;
             /**
              * CSS numeric font-weight
+             * @minimum 100
+             * @maximum 900
              */
             weight?: number;
             /**
@@ -6165,10 +6534,13 @@ export interface GetBrandIdentitySuccess {
               files?: {
                 /**
                  * HTTPS URL to the font file
+                 * @pattern ^https:\/\/
                  */
                 url: string;
                 /**
                  * CSS numeric font-weight
+                 * @minimum 100
+                 * @maximum 900
                  */
                 weight?: number;
                 /**
@@ -6223,6 +6595,9 @@ export interface GetBrandIdentitySuccess {
   tagline?:
     | string
     | {
+        /**
+         * @minLength 1
+         */
         [k: string]: string | undefined;
       }[];
   /**
@@ -6328,10 +6703,13 @@ export interface GetBrandIdentityError {
 export interface GetRightsRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
    * Natural language description of desired rights. The agent interprets intent, budget signals, and compatibility from this text.
+   * @maxLength 2000
    */
   query: string;
   /**
@@ -6362,6 +6740,8 @@ export interface GetRightsRequest {
 export interface PaginationRequest {
   /**
    * Maximum number of items to return per page
+   * @minimum 1
+   * @maximum 100
    */
   max_results?: number;
   /**
@@ -6403,6 +6783,8 @@ export interface GetRightsSuccess {
     right_type?: RightType;
     /**
      * Relevance score from 0 to 1
+     * @minimum 0
+     * @maximum 1
      */
     match_score?: number;
     /**
@@ -6479,10 +6861,12 @@ export interface RightsPricingOption {
   model: PricingModel;
   /**
    * Price amount. Interpretation depends on model: CPM = cost per 1,000 impressions, flat_rate = fixed cost per period.
+   * @minimum 0
    */
   price: number;
   /**
    * ISO 4217 currency code
+   * @pattern ^[A-Z]{3}$
    */
   currency: string;
   /**
@@ -6492,10 +6876,12 @@ export interface RightsPricingOption {
   period?: RightsBillingPeriod;
   /**
    * Maximum impressions included in this pricing option per period
+   * @minimum 1
    */
   impression_cap?: number;
   /**
    * CPM rate applied to impressions exceeding the impression_cap
+   * @minimum 0
    */
   overage_cpm?: number;
   /**
@@ -6517,6 +6903,9 @@ export interface GetRightsError {
 export interface RevocationNotification {
   /**
    * Sender-generated key stable across retries of the same revocation notification. Rights holders MUST generate a cryptographically random value (UUID v4 recommended) per distinct revocation event and reuse the same key when retrying delivery. Buyers MUST dedupe by this key, scoped to the authenticated sender identity (HMAC secret or Bearer credential); keys from different senders are independent.
+   * @minLength 16
+   * @maxLength 255
+   * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   idempotency_key: string;
   /**
@@ -6533,6 +6922,7 @@ export interface RevocationNotification {
   reason: string;
   /**
    * When the revocation takes effect. Immediate revocations use current time. Grace periods use a future time. The buyer must stop serving creative using these rights by this time.
+   * @format date-time
    */
   effective_at: string;
   /**
@@ -6550,6 +6940,8 @@ export interface RevocationNotification {
 export interface UpdateRightsRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -6558,10 +6950,12 @@ export interface UpdateRightsRequest {
   rights_id: string;
   /**
    * New end date for the rights grant (must be >= current end_date). Extending the grant may re-issue generation credentials with updated expiration.
+   * @format date
    */
   end_date?: string;
   /**
    * New impression cap for the grant. Must be >= impressions already delivered.
+   * @minimum 1
    */
   impression_cap?: number;
   /**
@@ -6575,6 +6969,9 @@ export interface UpdateRightsRequest {
   push_notification_config?: PushNotificationConfig;
   /**
    * Client-generated idempotency key for safe retries. MUST be unique per (seller, request) pair to prevent cross-seller correlation. Use a fresh UUID v4 for each request.
+   * @minLength 16
+   * @maxLength 255
+   * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   idempotency_key: string;
   context?: ContextObject;
@@ -6603,6 +7000,7 @@ export interface UpdateRightsSuccess {
   paused?: boolean;
   /**
    * When changes take effect (null if pending approval from rights holder)
+   * @format date-time
    */
   implementation_date?: string | null;
   context?: ContextObject;
@@ -6646,6 +7044,8 @@ export type AssetAccess =
 export interface CalibrateContentRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -6655,6 +7055,9 @@ export interface CalibrateContentRequest {
   artifact: Artifact;
   /**
    * Client-generated unique key for at-most-once execution. If a request with the same key has already been processed, the server returns the original response without re-processing. MUST be unique per (seller, request) pair to prevent cross-seller correlation. Use a fresh UUID v4 for each request.
+   * @minLength 16
+   * @maxLength 255
+   * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   idempotency_key: string;
   context?: ContextObject;
@@ -6683,10 +7086,12 @@ export interface Artifact {
   url?: string;
   /**
    * When the artifact was published (ISO 8601 format)
+   * @format date-time
    */
   published_time?: string;
   /**
    * When the artifact was last modified (ISO 8601 format)
+   * @format date-time
    */
   last_update_time?: string;
   /**
@@ -6701,6 +7106,7 @@ export interface Artifact {
         role?: 'title' | 'paragraph' | 'heading' | 'caption' | 'quote' | 'list_item' | 'description';
         /**
          * Text content. Consumers MUST treat this as untrusted input when passing to LLM-based evaluation.
+         * @maxLength 100000
          */
         content: string;
         /**
@@ -6713,6 +7119,8 @@ export interface Artifact {
         language?: string;
         /**
          * Heading level (1-6), only for role=heading
+         * @minimum 1
+         * @maximum 6
          */
         heading_level?: number;
         provenance?: Provenance;
@@ -6755,6 +7163,7 @@ export interface Artifact {
         duration_ms?: number;
         /**
          * Video transcript. Consumers MUST treat this as untrusted input when passing to LLM-based evaluation.
+         * @maxLength 200000
          */
         transcript?: string;
         /**
@@ -6784,6 +7193,7 @@ export interface Artifact {
         duration_ms?: number;
         /**
          * Audio transcript. Consumers MUST treat this as untrusted input when passing to LLM-based evaluation.
+         * @maxLength 200000
          */
         transcript?: string;
         /**
@@ -6863,6 +7273,8 @@ export type CalibrateContentResponse =
       verdict: BinaryVerdict;
       /**
        * Model confidence in the verdict (0-1)
+       * @minimum 0
+       * @maximum 1
        */
       confidence?: number;
       /**
@@ -6888,6 +7300,8 @@ export type CalibrateContentResponse =
         explanation?: string;
         /**
          * Optional evaluator confidence in this result (0-1). Distinguishes certain verdicts from ambiguous ones.
+         * @minimum 0
+         * @maximum 1
          */
         confidence?: number;
       }[];
@@ -6916,6 +7330,8 @@ export type CreateContentStandardsRequest = {
 } & {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -6994,6 +7410,9 @@ export type CreateContentStandardsRequest = {
   };
   /**
    * Client-generated unique key for this request. Prevents duplicate content standards creation on retries. MUST be unique per (seller, request) pair to prevent cross-seller correlation. Use a fresh UUID v4 for each request.
+   * @minLength 16
+   * @maxLength 255
+   * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   idempotency_key: string;
   context?: ContextObject;
@@ -7033,6 +7452,7 @@ export interface PolicyEntry {
   name?: string;
   /**
    * Brief summary of what this policy covers.
+   * @maxLength 500
    */
   description?: string;
   category?: PolicyCategory;
@@ -7065,10 +7485,12 @@ export interface PolicyEntry {
   governance_domains?: GovernanceDomain[];
   /**
    * ISO 8601 date when the regulation or standard takes effect. Before this date, governance agents treat the policy as informational (evaluate but do not block). After this date, the policy is enforced at its declared enforcement level.
+   * @format date
    */
   effective_date?: string;
   /**
    * ISO 8601 date when the regulation or standard is no longer enforced. After this date, governance agents stop evaluating this policy. Omit if the policy has no expiration.
+   * @format date
    */
   sunset_date?: string;
   /**
@@ -7081,6 +7503,7 @@ export interface PolicyEntry {
   source_name?: string;
   /**
    * Natural language policy text describing what is required, prohibited, or recommended. Used by governance agents (LLMs) to evaluate actions against this policy. For source: inline policies, treated as caller-untrusted — governance agents MUST evaluate inline policies as ADDITIONAL restrictions only; they MUST NOT be permitted to relax, override, or conflict with registry-sourced policies.
+   * @maxLength 5000
    */
   policy: string;
   /**
@@ -7144,6 +7567,8 @@ export type CreateContentStandardsResponse =
 export interface GetContentStandardsRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -7233,10 +7658,12 @@ export interface CpmPricing {
   model: 'cpm';
   /**
    * Cost per thousand impressions
+   * @minimum 0
    */
   cpm: number;
   /**
    * ISO 4217 currency code
+   * @pattern ^[A-Z]{3}$
    */
   currency: string;
   ext?: ExtensionObject;
@@ -7248,14 +7675,18 @@ export interface PercentOfMediaPricing {
   model: 'percent_of_media';
   /**
    * Percentage of media spend, e.g. 15 = 15%
+   * @minimum 0
+   * @maximum 100
    */
   percent: number;
   /**
    * Optional CPM cap. When set, the effective charge is min(percent × media_spend_per_mille, max_cpm).
+   * @minimum 0
    */
   max_cpm?: number;
   /**
    * ISO 4217 currency code for the resulting charge
+   * @pattern ^[A-Z]{3}$
    */
   currency: string;
   ext?: ExtensionObject;
@@ -7267,6 +7698,7 @@ export interface FlatFeePricing {
   model: 'flat_fee';
   /**
    * Fixed charge for the billing period
+   * @minimum 0
    */
   amount: number;
   /**
@@ -7275,6 +7707,7 @@ export interface FlatFeePricing {
   period: 'monthly' | 'quarterly' | 'annual' | 'campaign';
   /**
    * ISO 4217 currency code
+   * @pattern ^[A-Z]{3}$
    */
   currency: string;
   ext?: ExtensionObject;
@@ -7290,10 +7723,12 @@ export interface PerUnitPricing {
   unit: string;
   /**
    * Cost per one unit
+   * @minimum 0
    */
   unit_price: number;
   /**
    * ISO 4217 currency code
+   * @pattern ^[A-Z]{3}$
    */
   currency: string;
   ext?: ExtensionObject;
@@ -7305,6 +7740,7 @@ export interface CustomPricing {
   model: 'custom';
   /**
    * Human-readable description of the custom pricing model. Buyers display this to the operator when requesting approval.
+   * @minLength 1
    */
   description: string;
   /**
@@ -7313,11 +7749,13 @@ export interface CustomPricing {
   metadata: {
     /**
      * One or two sentences describing the pricing construct in plain language, displayed to the buyer's operator when requesting approval. Should not repeat the top-level `description` verbatim — summarize the charge mechanic instead (e.g., 'Base $12 CPM plus $0.50 per qualifying post-view conversion, capped at $45 CPM').
+     * @minLength 1
      */
     summary_for_operator?: string;
   };
   /**
    * ISO 4217 currency code. Present when the pricing resolves to a monetary charge in a specific currency.
+   * @pattern ^[A-Z]{3}$
    */
   currency?: string;
   ext?: ExtensionObject;
@@ -7338,6 +7776,7 @@ export type AccountReference =
       brand: BrandReference;
       /**
        * Domain of the entity operating on the brand's behalf. When the brand operates directly, this is the brand's domain.
+       * @pattern ^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$
        */
       operator: string;
       /**
@@ -7351,6 +7790,8 @@ export type AccountReference =
 export interface GetMediaBuyArtifactsRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   account?: AccountReference;
@@ -7372,10 +7813,12 @@ export interface GetMediaBuyArtifactsRequest {
   time_range?: {
     /**
      * Start of time range (inclusive)
+     * @format date-time
      */
     start?: string;
     /**
      * End of time range (exclusive)
+     * @format date-time
      */
     end?: string;
   };
@@ -7385,6 +7828,8 @@ export interface GetMediaBuyArtifactsRequest {
   pagination?: {
     /**
      * Maximum number of artifacts to return per page
+     * @minimum 1
+     * @maximum 10000
      */
     max_results?: number;
     /**
@@ -7416,6 +7861,7 @@ export type GetMediaBuyArtifactsResponse =
         record_id: string;
         /**
          * When the delivery occurred
+         * @format date-time
          */
         timestamp?: string;
         /**
@@ -7487,6 +7933,8 @@ export type GetMediaBuyArtifactsResponse =
 export interface ListContentStandardsRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -7533,6 +7981,8 @@ export type ListContentStandardsResponse =
 export interface UpdateContentStandardsRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -7617,6 +8067,9 @@ export interface UpdateContentStandardsRequest {
   ext?: ExtensionObject;
   /**
    * Client-generated unique key for at-most-once execution. If a request with the same key has already been processed, the server returns the original response without re-processing. MUST be unique per (seller, request) pair to prevent cross-seller correlation. Use a fresh UUID v4 for each request.
+   * @minLength 16
+   * @maxLength 255
+   * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   idempotency_key: string;
 }
@@ -7663,6 +8116,8 @@ export interface UpdateContentStandardsError {
 export interface ValidateContentDeliveryRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -7683,6 +8138,7 @@ export interface ValidateContentDeliveryRequest {
     media_buy_id?: string;
     /**
      * When the delivery occurred
+     * @format date-time
      */
     timestamp?: string;
     artifact: Artifact;
@@ -7762,6 +8218,8 @@ export type ValidateContentDeliveryResponse =
           explanation?: string;
           /**
            * Optional evaluator confidence in this result (0-1). Distinguishes certain verdicts from ambiguous ones.
+           * @minimum 0
+           * @maximum 1
            */
           confidence?: number;
         }[];
@@ -7782,6 +8240,8 @@ export type ValidateContentDeliveryResponse =
 export interface TasksGetRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -7810,14 +8270,17 @@ export interface TasksGetResponse {
   status: TaskStatus;
   /**
    * When the task was initially created (ISO 8601)
+   * @format date-time
    */
   created_at: string;
   /**
    * When the task was last updated (ISO 8601)
+   * @format date-time
    */
   updated_at: string;
   /**
    * When the task completed (ISO 8601, only for completed/failed/canceled tasks)
+   * @format date-time
    */
   completed_at?: string;
   /**
@@ -7830,6 +8293,8 @@ export interface TasksGetResponse {
   progress?: {
     /**
      * Completion percentage (0-100)
+     * @minimum 0
+     * @maximum 100
      */
     percentage?: number;
     /**
@@ -7838,10 +8303,12 @@ export interface TasksGetResponse {
     current_step?: string;
     /**
      * Total number of steps in the operation
+     * @minimum 1
      */
     total_steps?: number;
     /**
      * Current step number
+     * @minimum 1
      */
     step_number?: number;
   };
@@ -7878,6 +8345,7 @@ export interface TasksGetResponse {
   history?: {
     /**
      * When this exchange occurred (ISO 8601)
+     * @format date-time
      */
     timestamp: string;
     /**
@@ -7905,6 +8373,8 @@ export type SortDirection = 'asc' | 'desc';
 export interface TasksListRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -7928,18 +8398,22 @@ export interface TasksListRequest {
     task_types?: TaskType[];
     /**
      * Filter tasks created after this date (ISO 8601)
+     * @format date-time
      */
     created_after?: string;
     /**
      * Filter tasks created before this date (ISO 8601)
+     * @format date-time
      */
     created_before?: string;
     /**
      * Filter tasks last updated after this date (ISO 8601)
+     * @format date-time
      */
     updated_after?: string;
     /**
      * Filter tasks last updated before this date (ISO 8601)
+     * @format date-time
      */
     updated_before?: string;
     /**
@@ -7985,10 +8459,12 @@ export interface TasksListResponse {
   query_summary: {
     /**
      * Total number of tasks matching filters (across all pages)
+     * @minimum 0
      */
     total_matching?: number;
     /**
      * Number of tasks returned in this response
+     * @minimum 0
      */
     returned?: number;
     /**
@@ -7997,10 +8473,12 @@ export interface TasksListResponse {
     domain_breakdown?: {
       /**
        * Number of media-buy tasks in results
+       * @minimum 0
        */
       'media-buy'?: number;
       /**
        * Number of signals tasks in results
+       * @minimum 0
        */
       signals?: number;
     };
@@ -8008,6 +8486,9 @@ export interface TasksListResponse {
      * Count of tasks by status
      */
     status_breakdown?: {
+      /**
+       * @minimum 0
+       */
       [k: string]: number | undefined;
     };
     /**
@@ -8038,14 +8519,17 @@ export interface TasksListResponse {
     status: TaskStatus;
     /**
      * When the task was initially created (ISO 8601)
+     * @format date-time
      */
     created_at: string;
     /**
      * When the task was last updated (ISO 8601)
+     * @format date-time
      */
     updated_at: string;
     /**
      * When the task completed (ISO 8601, only for completed/failed/canceled tasks)
+     * @format date-time
      */
     completed_at?: string;
     /**
@@ -8067,6 +8551,8 @@ export type GetCreativeDeliveryRequest = {
 } & {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   account?: AccountReference;
@@ -8080,14 +8566,17 @@ export type GetCreativeDeliveryRequest = {
   creative_ids?: string[];
   /**
    * Start date for delivery period (YYYY-MM-DD). Interpreted in the platform's reporting timezone.
+   * @pattern ^\d{4}-\d{2}-\d{2}$
    */
   start_date?: string;
   /**
    * End date for delivery period (YYYY-MM-DD). Interpreted in the platform's reporting timezone.
+   * @pattern ^\d{4}-\d{2}-\d{2}$
    */
   end_date?: string;
   /**
    * Maximum number of variants to return per creative. When omitted, the agent returns all variants. Use this to limit response size for generative creatives that may produce large numbers of variants.
+   * @minimum 1
    */
   max_variants?: number;
   pagination?: PaginationRequest;
@@ -8140,6 +8629,7 @@ export interface GetCreativeDeliveryResponse {
   media_buy_id?: string;
   /**
    * ISO 4217 currency code for monetary values in this response (e.g., 'USD', 'EUR')
+   * @pattern ^[A-Z]{3}$
    */
   currency: string;
   /**
@@ -8148,10 +8638,12 @@ export interface GetCreativeDeliveryResponse {
   reporting_period: {
     /**
      * ISO 8601 start timestamp
+     * @format date-time
      */
     start: string;
     /**
      * ISO 8601 end timestamp
+     * @format date-time
      */
     end: string;
     /**
@@ -8175,6 +8667,7 @@ export interface GetCreativeDeliveryResponse {
     totals?: DeliveryMetrics;
     /**
      * Total number of variants for this creative. When max_variants was specified in the request, this may exceed the number of items in the variants array.
+     * @minimum 0
      */
     variant_count?: number;
     /**
@@ -8188,10 +8681,12 @@ export interface GetCreativeDeliveryResponse {
   pagination?: {
     /**
      * Maximum number of creatives requested
+     * @minimum 1
      */
     limit: number;
     /**
      * Number of creatives skipped
+     * @minimum 0
      */
     offset: number;
     /**
@@ -8200,6 +8695,7 @@ export interface GetCreativeDeliveryResponse {
     has_more: boolean;
     /**
      * Total number of creatives matching the request filters
+     * @minimum 0
      */
     total?: number;
   };
@@ -8216,54 +8712,70 @@ export interface GetCreativeDeliveryResponse {
 export interface DeliveryMetrics {
   /**
    * Impressions delivered
+   * @minimum 0
    */
   impressions?: number;
   /**
    * Amount spent
+   * @minimum 0
    */
   spend?: number;
   /**
    * Total clicks
+   * @minimum 0
    */
   clicks?: number;
   /**
    * Click-through rate (clicks/impressions)
+   * @minimum 0
+   * @maximum 1
    */
   ctr?: number;
   /**
    * Content engagements counted toward the billable view threshold. For video this is a platform-defined view event (e.g., 30 seconds or video midpoint); for audio/podcast it is a stream start; for other formats it follows the pricing model's view definition. When the package uses CPV pricing, spend = views × rate.
+   * @minimum 0
    */
   views?: number;
   /**
    * Video/audio completions. When the package has a completed_views optimization goal with view_duration_seconds, completions are counted at that threshold rather than 100% completion.
+   * @minimum 0
    */
   completed_views?: number;
   /**
    * Completion rate (completed_views/impressions)
+   * @minimum 0
+   * @maximum 1
    */
   completion_rate?: number;
   /**
    * Total conversions attributed to this delivery. When by_event_type is present, this equals the sum of all by_event_type[].count entries.
+   * @minimum 0
    */
   conversions?: number;
   /**
    * Total monetary value of attributed conversions (in the reporting currency)
+   * @minimum 0
    */
   conversion_value?: number;
   /**
    * Return on ad spend (conversion_value / spend)
+   * @minimum 0
    */
   roas?: number;
   /**
    * Cost per conversion (spend / conversions)
+   * @minimum 0
    */
   cost_per_acquisition?: number;
   /**
    * Fraction of conversions from first-time brand buyers (0 = none, 1 = all)
+   * @minimum 0
+   * @maximum 1
    */
   new_to_brand_rate?: number;
   /**
    * Leads generated (convenience alias for by_event_type where event_type='lead')
+   * @minimum 0
    */
   leads?: number;
   /**
@@ -8277,19 +8789,23 @@ export interface DeliveryMetrics {
     event_source_id?: string;
     /**
      * Number of events of this type
+     * @minimum 0
      */
     count: number;
     /**
      * Total monetary value of events of this type
+     * @minimum 0
      */
     value?: number;
   }[];
   /**
    * Gross Rating Points delivered (for CPP)
+   * @minimum 0
    */
   grps?: number;
   /**
    * Unique reach in the units specified by reach_unit. When reach_unit is omitted, units are unspecified — do not compare reach values across packages or media buys without a common reach_unit.
+   * @minimum 0
    */
   reach?: number;
   /**
@@ -8298,6 +8814,7 @@ export interface DeliveryMetrics {
   reach_unit?: ReachUnit;
   /**
    * Average frequency per reach unit (typically measured over campaign duration, but can vary by measurement provider). When reach_unit is 'households', this is average exposures per household; when 'accounts', per logged-in account; etc.
+   * @minimum 0
    */
   frequency?: number;
   /**
@@ -8306,18 +8823,22 @@ export interface DeliveryMetrics {
   quartile_data?: {
     /**
      * 25% completion views
+     * @minimum 0
      */
     q1_views?: number;
     /**
      * 50% completion views
+     * @minimum 0
      */
     q2_views?: number;
     /**
      * 75% completion views
+     * @minimum 0
      */
     q3_views?: number;
     /**
      * 100% completion views
+     * @minimum 0
      */
     q4_views?: number;
   };
@@ -8327,18 +8848,23 @@ export interface DeliveryMetrics {
   dooh_metrics?: {
     /**
      * Number of times ad played in rotation
+     * @minimum 0
      */
     loop_plays?: number;
     /**
      * Number of unique screens displaying the ad
+     * @minimum 0
      */
     screens_used?: number;
     /**
      * Total display time in seconds
+     * @minimum 0
      */
     screen_time_seconds?: number;
     /**
      * Actual share of voice delivered (0.0 to 1.0)
+     * @minimum 0
+     * @maximum 1
      */
     sov_achieved?: number;
     /**
@@ -8363,14 +8889,17 @@ export interface DeliveryMetrics {
       venue_type?: string;
       /**
        * Impressions delivered at this venue
+       * @minimum 0
        */
       impressions: number;
       /**
        * Loop plays at this venue
+       * @minimum 0
        */
       loop_plays?: number;
       /**
        * Number of screens used at this venue
+       * @minimum 0
        */
       screens_used?: number;
     }[];
@@ -8381,40 +8910,51 @@ export interface DeliveryMetrics {
   viewability?: {
     /**
      * Impressions where viewability could be measured. Excludes environments without measurement capability (e.g., non-Intersection Observer browsers, certain app environments).
+     * @minimum 0
      */
     measurable_impressions?: number;
     /**
      * Impressions that met the viewability threshold defined by the measurement standard.
+     * @minimum 0
      */
     viewable_impressions?: number;
     /**
      * Viewable impression rate (viewable_impressions / measurable_impressions). Range 0.0 to 1.0.
+     * @minimum 0
+     * @maximum 1
      */
     viewable_rate?: number;
     standard?: ViewabilityStandard;
   };
   /**
    * Total engagements — direct interactions with the ad beyond viewing. Includes social reactions/comments/shares, story/unit opens, interactive overlay taps on CTV, companion banner interactions on audio. Platform-specific; corresponds to the 'engagements' optimization metric.
+   * @minimum 0
    */
   engagements?: number;
   /**
    * New followers, page likes, artist/podcast/channel subscribes attributed to this delivery.
+   * @minimum 0
    */
   follows?: number;
   /**
    * Saves, bookmarks, playlist adds, pins attributed to this delivery.
+   * @minimum 0
    */
   saves?: number;
   /**
    * Visits to the brand's in-platform page (profile, artist page, channel, or storefront) attributed to this delivery. Does not include external website clicks.
+   * @minimum 0
    */
   profile_visits?: number;
   /**
    * Platform-specific engagement rate (0.0 to 1.0). Typically engagements/impressions, but definition varies by platform.
+   * @minimum 0
+   * @maximum 1
    */
   engagement_rate?: number;
   /**
    * Cost per click (spend / clicks)
+   * @minimum 0
    */
   cost_per_click?: number;
   /**
@@ -8428,10 +8968,12 @@ export interface DeliveryMetrics {
     event_source_id?: string;
     /**
      * Number of conversions from this action source
+     * @minimum 0
      */
     count: number;
     /**
      * Total monetary value of conversions from this action source
+     * @minimum 0
      */
     value?: number;
   }[];
@@ -8454,6 +8996,8 @@ export interface Identifier {
 export interface GetCreativeFeaturesRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   creative_manifest: CreativeManifest;
@@ -8486,10 +9030,12 @@ export type GetCreativeFeaturesResponse =
       pricing_option_id?: string;
       /**
        * Cost incurred for this evaluation, denominated in currency.
+       * @minimum 0
        */
       vendor_cost?: number;
       /**
        * ISO 4217 currency code for vendor_cost.
+       * @pattern ^[A-Z]{3}$
        */
       currency?: string;
       consumption?: CreativeConsumption;
@@ -8520,14 +9066,18 @@ export interface CreativeFeatureResult {
   unit?: string;
   /**
    * Confidence score for this value (0-1)
+   * @minimum 0
+   * @maximum 1
    */
   confidence?: number;
   /**
    * When this feature was evaluated
+   * @format date-time
    */
   measured_at?: string;
   /**
    * When this evaluation expires and should be refreshed
+   * @format date-time
    */
   expires_at?: string;
   /**
@@ -8556,6 +9106,8 @@ export type WCAGLevel = 'A' | 'AA' | 'AAA';
 export interface ListCreativeFormatsRequestCreativeAgent {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -8632,6 +9184,8 @@ export type CreativeSortField = 'created_date' | 'updated_date' | 'name' | 'stat
 export interface ListCreativesRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   filters?: CreativeFilters;
@@ -8715,18 +9269,22 @@ export interface CreativeFilters {
   creative_ids?: string[];
   /**
    * Filter creatives created after this date (ISO 8601)
+   * @format date-time
    */
   created_after?: string;
   /**
    * Filter creatives created before this date (ISO 8601)
+   * @format date-time
    */
   created_before?: string;
   /**
    * Filter creatives last updated after this date (ISO 8601)
+   * @format date-time
    */
   updated_after?: string;
   /**
    * Filter creatives last updated before this date (ISO 8601)
+   * @format date-time
    */
   updated_before?: string;
   /**
@@ -8817,10 +9375,12 @@ export interface ListCreativesResponse {
   query_summary: {
     /**
      * Total number of creatives matching filters (across all pages)
+     * @minimum 0
      */
     total_matching: number;
     /**
      * Number of creatives returned in this response
+     * @minimum 0
      */
     returned: number;
     /**
@@ -8853,10 +9413,12 @@ export interface ListCreativesResponse {
     status: CreativeStatus;
     /**
      * When the creative was created
+     * @format date-time
      */
     created_date: string;
     /**
      * When the creative was last modified
+     * @format date-time
      */
     updated_date: string;
     /**
@@ -8887,6 +9449,7 @@ export interface ListCreativesResponse {
     assignments?: {
       /**
        * Total number of active package assignments
+       * @minimum 0
        */
       assignment_count: number;
       /**
@@ -8899,6 +9462,7 @@ export interface ListCreativesResponse {
         package_id: string;
         /**
          * When this assignment was created
+         * @format date-time
          */
         assigned_date: string;
       }[];
@@ -8909,18 +9473,22 @@ export interface ListCreativesResponse {
     snapshot?: {
       /**
        * When this snapshot was captured by the platform
+       * @format date-time
        */
       as_of: string;
       /**
        * Maximum age of this data in seconds. For example, 3600 means the data may be up to 1 hour old.
+       * @minimum 0
        */
       staleness_seconds: number;
       /**
        * Lifetime impressions across all assignments. Not scoped to any date range.
+       * @minimum 0
        */
       impressions: number;
       /**
        * Last time this creative served an impression. Absent when the creative has never served.
+       * @format date-time
        */
       last_served?: string;
     };
@@ -8940,6 +9508,7 @@ export interface ListCreativesResponse {
   format_summary?: {
     /**
      * Number of creatives with this format
+     * @minimum 0
      *
      * This interface was referenced by `undefined`'s JSON-Schema definition
      * via the `patternProperty` "^[a-zA-Z0-9_-]+$".
@@ -8952,22 +9521,27 @@ export interface ListCreativesResponse {
   status_summary?: {
     /**
      * Number of creatives being processed
+     * @minimum 0
      */
     processing?: number;
     /**
      * Number of approved creatives
+     * @minimum 0
      */
     approved?: number;
     /**
      * Number of creatives pending review
+     * @minimum 0
      */
     pending_review?: number;
     /**
      * Number of rejected creatives
+     * @minimum 0
      */
     rejected?: number;
     /**
      * Number of archived creatives
+     * @minimum 0
      */
     archived?: number;
   };
@@ -9084,6 +9658,8 @@ export type CatalogAsset1 = CatalogAsset;
 export interface PreviewCreativeRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -9119,6 +9695,7 @@ export interface PreviewCreativeRequest {
   output_format?: PreviewOutputFormat;
   /**
    * Maximum number of catalog items to render per preview variant. Used in single mode. Creative agents SHOULD default to a reasonable sample when omitted and the catalog is large.
+   * @minimum 1
    */
   item_limit?: number;
   /**
@@ -9154,6 +9731,7 @@ export interface PreviewCreativeRequest {
     output_format?: PreviewOutputFormat;
     /**
      * Maximum number of catalog items to render in this preview.
+     * @minimum 1
      */
     item_limit?: number;
   }[];
@@ -9223,6 +9801,7 @@ export interface PreviewCreativeSingleResponse {
   interactive_url?: string;
   /**
    * ISO 8601 timestamp when preview links expire
+   * @format date-time
    */
   expires_at: string;
   context?: ContextObject;
@@ -9287,6 +9866,7 @@ export interface PreviewCreativeVariantResponse {
   manifest?: CreativeManifest;
   /**
    * ISO 8601 timestamp when preview links expire
+   * @format date-time
    */
   expires_at?: string;
   context?: ContextObject;
@@ -9302,6 +9882,8 @@ export type ValidationMode = 'strict' | 'lenient';
 export interface SyncCreativesRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   account: AccountReference;
@@ -9327,6 +9909,8 @@ export interface SyncCreativesRequest {
     package_id: string;
     /**
      * Relative delivery weight (0-100). When multiple creatives are assigned to the same package, weights determine impression distribution proportionally. When omitted, the creative receives equal rotation with other unweighted creatives. A weight of 0 means the creative is assigned but paused (receives no delivery).
+     * @minimum 0
+     * @maximum 100
      */
     weight?: number;
     /**
@@ -9336,6 +9920,9 @@ export interface SyncCreativesRequest {
   }[];
   /**
    * Client-generated idempotency key for safe retries. If a sync fails without a response, resending with the same idempotency_key guarantees at-most-once execution. MUST be unique per (seller, request) pair to prevent cross-seller correlation. Use a fresh UUID v4 for each request.
+   * @minLength 16
+   * @maxLength 255
+   * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   idempotency_key: string;
   /**
@@ -9359,6 +9946,8 @@ export interface SyncCreativesRequest {
 export interface BuildCreativeRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -9392,6 +9981,7 @@ export interface BuildCreativeRequest {
   quality?: CreativeQuality;
   /**
    * Maximum number of catalog items to use when generating. When a catalog asset contains more items than this limit, the creative agent selects the top items based on relevance or catalog ordering. When item_limit exceeds the format's max_items, the creative agent SHOULD use the lesser of the two. Ignored when the manifest contains no catalog assets.
+   * @minimum 1
    */
   item_limit?: number;
   /**
@@ -9427,6 +10017,9 @@ export interface BuildCreativeRequest {
   };
   /**
    * Client-generated unique key for this request. Prevents duplicate creative generation on retries. MUST be unique per (seller, request) pair to prevent cross-seller correlation. Use a fresh UUID v4 for each request.
+   * @minLength 16
+   * @maxLength 255
+   * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   idempotency_key: string;
   context?: ContextObject;
@@ -9529,10 +10122,15 @@ export type StartTiming = 'asap' | string;
 export interface CreateMediaBuyRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
    * Client-generated unique key for this request. If a request with the same idempotency_key and account has already been processed, the seller returns the existing media buy rather than creating a duplicate. MUST be unique per (seller, request) pair to prevent cross-seller correlation. Use a fresh UUID v4 for each request.
+   * @minLength 16
+   * @maxLength 255
+   * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   idempotency_key: string;
   /**
@@ -9550,6 +10148,7 @@ export interface CreateMediaBuyRequest {
   total_budget?: {
     /**
      * Total budget amount
+     * @minimum 0
      */
     amount: number;
     /**
@@ -9574,10 +10173,13 @@ export interface CreateMediaBuyRequest {
     io_id: string;
     /**
      * ISO 8601 timestamp when the IO was accepted
+     * @format date-time
      */
     accepted_at: string;
     /**
      * Who accepted the IO — agent identifier or human name
+     * @minLength 1
+     * @maxLength 250
      */
     signatory: string;
     /**
@@ -9591,11 +10193,13 @@ export interface CreateMediaBuyRequest {
   po_number?: string;
   /**
    * Agency estimate or authorization number. Primary financial reference for broadcast buys — links the order to the agency's media plan and billing system. Travels with the order and Ad-IDs through the transaction lifecycle.
+   * @maxLength 100
    */
   agency_estimate_number?: string;
   start_time: StartTiming;
   /**
    * Campaign end date/time in ISO 8601 format
+   * @format date-time
    */
   end_time: string;
   push_notification_config?: PushNotificationConfig;
@@ -9610,6 +10214,7 @@ export interface CreateMediaBuyRequest {
     url: string;
     /**
      * Optional client-provided token for webhook validation. Echoed back in webhook payload to validate request authenticity.
+     * @minLength 16
      */
     token?: string;
     /**
@@ -9622,6 +10227,7 @@ export interface CreateMediaBuyRequest {
       schemes: AuthenticationScheme[];
       /**
        * Credentials for the legacy scheme. For Bearer: token sent in Authorization header. For HMAC-SHA256: shared secret used to generate signature. Minimum 32 characters. Exchanged out-of-band during onboarding.
+       * @minLength 32
        */
       credentials: string;
     };
@@ -9635,6 +10241,8 @@ export interface CreateMediaBuyRequest {
     batch_frequency?: 'hourly' | 'daily';
     /**
      * Fraction of impressions to include (0-1). 1.0 = all impressions, 0.1 = 10% sample. Default: 1.0
+     * @minimum 0
+     * @maximum 1
      */
     sampling_rate?: number;
   };
@@ -9647,6 +10255,8 @@ export interface CreateMediaBuyRequest {
 export interface PackageRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -9659,6 +10269,7 @@ export interface PackageRequest {
   format_ids?: FormatReferenceStructuredObject[];
   /**
    * Budget allocation for this package in the media buy's currency
+   * @minimum 0
    */
   budget: number;
   pacing?: Pacing;
@@ -9668,18 +10279,22 @@ export interface PackageRequest {
   pricing_option_id: string;
   /**
    * Bid price for auction-based pricing options. This is the exact bid/price to honor unless selected pricing_option has max_bid=true, in which case bid_price is the buyer's maximum willingness to pay (ceiling).
+   * @minimum 0
    */
   bid_price?: number;
   /**
    * Impression goal for this package
+   * @minimum 0
    */
   impressions?: number;
   /**
    * Flight start date/time for this package in ISO 8601 format. When omitted, the package inherits the media buy's start_time. Must fall within the media buy's date range.
+   * @format date-time
    */
   start_time?: string;
   /**
    * Flight end date/time for this package in ISO 8601 format. When omitted, the package inherits the media buy's end_time. Must fall within the media buy's date range.
+   * @format date-time
    */
   end_time?: string;
   /**
@@ -9710,6 +10325,7 @@ export interface PackageRequest {
   creatives?: CreativeAsset[];
   /**
    * Agency estimate or authorization number for this package. Overrides the media buy-level estimate number when different packages correspond to different agency estimates (e.g., different stations or flights within the same buy).
+   * @maxLength 100
    */
   agency_estimate_number?: string;
   context?: ContextObject;
@@ -9725,6 +10341,7 @@ export interface ReportingWebhook {
   url: string;
   /**
    * Optional client-provided token for webhook validation. Echoed back in webhook payload to validate request authenticity.
+   * @minLength 16
    */
   token?: string;
   /**
@@ -9737,6 +10354,7 @@ export interface ReportingWebhook {
     schemes: AuthenticationScheme[];
     /**
      * Credentials for the legacy scheme. For Bearer: token sent in Authorization header. For HMAC-SHA256: shared secret used to generate signature. Minimum 32 characters. Exchanged out-of-band during onboarding.
+     * @minLength 32
      */
     credentials: string;
   };
@@ -9792,6 +10410,8 @@ export type SortMetric =
 export interface GetMediaBuyDeliveryRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   account?: AccountReference;
@@ -9805,10 +10425,12 @@ export interface GetMediaBuyDeliveryRequest {
   status_filter?: MediaBuyStatus | MediaBuyStatus[];
   /**
    * Start date for reporting period (YYYY-MM-DD). When omitted along with end_date, returns campaign lifetime data. Only accepted when the product's reporting_capabilities.date_range_support is 'date_range'.
+   * @pattern ^\d{4}-\d{2}-\d{2}$
    */
   start_date?: string;
   /**
    * End date for reporting period (YYYY-MM-DD). When omitted along with start_date, returns campaign lifetime data. Only accepted when the product's reporting_capabilities.date_range_support is 'date_range'.
+   * @pattern ^\d{4}-\d{2}-\d{2}$
    */
   end_date?: string;
   /**
@@ -9844,6 +10466,7 @@ export interface GetMediaBuyDeliveryRequest {
       system?: MetroAreaSystem | PostalCodeSystem;
       /**
        * Maximum number of geo entries to return. Defaults to 25. When truncated, by_geo_truncated is true in the response.
+       * @minimum 1
        */
       limit?: number;
       sort_by?: SortMetric;
@@ -9854,6 +10477,7 @@ export interface GetMediaBuyDeliveryRequest {
     device_type?: {
       /**
        * Maximum number of entries to return. When omitted, all entries are returned (the enum is small and bounded).
+       * @minimum 1
        */
       limit?: number;
       sort_by?: SortMetric;
@@ -9864,6 +10488,7 @@ export interface GetMediaBuyDeliveryRequest {
     device_platform?: {
       /**
        * Maximum number of entries to return. When omitted, all entries are returned (the enum is small and bounded).
+       * @minimum 1
        */
       limit?: number;
       sort_by?: SortMetric;
@@ -9874,6 +10499,7 @@ export interface GetMediaBuyDeliveryRequest {
     audience?: {
       /**
        * Maximum number of entries to return. Defaults to 25.
+       * @minimum 1
        */
       limit?: number;
       sort_by?: SortMetric;
@@ -9884,6 +10510,7 @@ export interface GetMediaBuyDeliveryRequest {
     placement?: {
       /**
        * Maximum number of entries to return. Defaults to 25.
+       * @minimum 1
        */
       limit?: number;
       sort_by?: SortMetric;
@@ -9913,14 +10540,17 @@ export interface GetMediaBuyDeliveryResponse {
   partial_data?: boolean;
   /**
    * Number of media buys with reporting_delayed or failed status (only present in webhook deliveries when partial_data is true)
+   * @minimum 0
    */
   unavailable_count?: number;
   /**
    * Sequential notification number (only present in webhook deliveries, starts at 1)
+   * @minimum 1
    */
   sequence_number?: number;
   /**
    * ISO 8601 timestamp for next expected notification (only present in webhook deliveries when notification_type is not 'final')
+   * @format date-time
    */
   next_expected_at?: string;
   /**
@@ -9929,15 +10559,18 @@ export interface GetMediaBuyDeliveryResponse {
   reporting_period: {
     /**
      * ISO 8601 start timestamp in UTC (e.g., 2024-02-05T00:00:00Z)
+     * @format date-time
      */
     start: string;
     /**
      * ISO 8601 end timestamp in UTC (e.g., 2024-02-05T23:59:59Z)
+     * @format date-time
      */
     end: string;
   };
   /**
    * ISO 4217 currency code
+   * @pattern ^[A-Z]{3}$
    */
   currency?: string;
   attribution_window?: AttributionWindow;
@@ -9947,50 +10580,64 @@ export interface GetMediaBuyDeliveryResponse {
   aggregated_totals?: {
     /**
      * Total impressions delivered across all media buys
+     * @minimum 0
      */
     impressions: number;
     /**
      * Total amount spent across all media buys
+     * @minimum 0
      */
     spend: number;
     /**
      * Total clicks across all media buys (if applicable)
+     * @minimum 0
      */
     clicks?: number;
     /**
      * Total audio/video completions across all media buys (if applicable)
+     * @minimum 0
      */
     completed_views?: number;
     /**
      * Total views across all media buys (if applicable)
+     * @minimum 0
      */
     views?: number;
     /**
      * Total conversions across all media buys (if applicable)
+     * @minimum 0
      */
     conversions?: number;
     /**
      * Total conversion value across all media buys (if applicable)
+     * @minimum 0
      */
     conversion_value?: number;
     /**
      * Aggregate return on ad spend across all media buys (total conversion_value / total spend)
+     * @minimum 0
      */
     roas?: number;
     /**
      * Fraction of total conversions across all media buys from first-time brand buyers (weighted by conversion volume, not a simple average of per-buy rates)
+     * @minimum 0
+     * @maximum 1
      */
     new_to_brand_rate?: number;
     /**
      * Aggregate cost per conversion across all media buys (total spend / total conversions)
+     * @minimum 0
      */
     cost_per_acquisition?: number;
     /**
      * Aggregate completion rate across all media buys (weighted by impressions, not a simple average of per-buy rates)
+     * @minimum 0
+     * @maximum 1
      */
     completion_rate?: number;
     /**
      * Deduplicated reach across all media buys (if the seller can deduplicate across buys; otherwise sum of per-buy reach). Only present when all media buys share the same reach_unit. Omitted when reach units are heterogeneous — use per-buy reach values instead.
+     * @minimum 0
      */
     reach?: number;
     /**
@@ -9999,10 +10646,12 @@ export interface GetMediaBuyDeliveryResponse {
     reach_unit?: ReachUnit;
     /**
      * Average frequency per reach unit across all media buys (impressions / reach when cross-buy deduplication is available). Only present when reach is present.
+     * @minimum 0
      */
     frequency?: number;
     /**
      * Number of media buys included in the response
+     * @minimum 0
      */
     media_buy_count: number;
   };
@@ -10030,6 +10679,7 @@ export interface GetMediaBuyDeliveryResponse {
       | 'reporting_delayed';
     /**
      * When delayed data is expected to be available (only present when status is reporting_delayed)
+     * @format date-time
      */
     expected_availability?: string;
     /**
@@ -10040,6 +10690,7 @@ export interface GetMediaBuyDeliveryResponse {
     totals: DeliveryMetrics & {
       /**
        * Effective rate paid per unit based on pricing_model (e.g., actual CPM for 'cpm', actual cost per completed view for 'cpcv', actual cost per point for 'cpp')
+       * @minimum 0
        */
       effective_rate?: number;
     };
@@ -10053,15 +10704,18 @@ export interface GetMediaBuyDeliveryResponse {
       package_id: string;
       /**
        * Delivery pace (1.0 = on track, <1.0 = behind, >1.0 = ahead)
+       * @minimum 0
        */
       pacing_index?: number;
       pricing_model?: PricingModel;
       /**
        * The pricing rate for this package in the specified currency. For fixed-rate pricing, this is the agreed rate (e.g., CPM rate of 12.50 means $12.50 per 1,000 impressions). For auction-based pricing, this represents the effective rate based on actual delivery.
+       * @minimum 0
        */
       rate?: number;
       /**
        * ISO 4217 currency code (e.g., USD, EUR, GBP) for this package's pricing. Indicates the currency in which the rate and spend values are denominated. Different packages can use different currencies when supported by the publisher.
+       * @pattern ^[A-Z]{3}$
        */
       currency?: string;
       /**
@@ -10078,10 +10732,12 @@ export interface GetMediaBuyDeliveryResponse {
       is_final?: boolean;
       /**
        * Which measurement window this data represents, referencing a window_id from the product's reporting_capabilities.measurement_windows. For broadcast: 'live', 'c3', 'c7'. When absent, the data is not windowed (standard digital reporting). When present with is_final: false, a later report for the same period will provide a wider window or more complete data.
+       * @maxLength 50
        */
       measurement_window?: string;
       /**
        * Which measurement window this data replaces. Present on window_update notifications to indicate progression (e.g., 'live' when reporting C3 data that supersedes live-only numbers). Absent on the first report for a period. Buyers should replace stored data for the superseded window with this report's data.
+       * @maxLength 50
        */
       supersedes_window?: string;
       /**
@@ -10104,6 +10760,8 @@ export interface GetMediaBuyDeliveryResponse {
         creative_id: string;
         /**
          * Observed delivery share for this creative within the package during the reporting period, expressed as a percentage (0-100). Reflects actual delivery distribution, not a configured setting.
+         * @minimum 0
+         * @maximum 100
          */
         weight?: number;
       })[];
@@ -10200,30 +10858,38 @@ export interface GetMediaBuyDeliveryResponse {
       daily_breakdown?: {
         /**
          * Date (YYYY-MM-DD)
+         * @pattern ^\d{4}-\d{2}-\d{2}$
          */
         date: string;
         /**
          * Daily impressions for this package
+         * @minimum 0
          */
         impressions: number;
         /**
          * Daily spend for this package
+         * @minimum 0
          */
         spend: number;
         /**
          * Daily conversions for this package
+         * @minimum 0
          */
         conversions?: number;
         /**
          * Daily conversion value for this package
+         * @minimum 0
          */
         conversion_value?: number;
         /**
          * Daily return on ad spend (conversion_value / spend)
+         * @minimum 0
          */
         roas?: number;
         /**
          * Daily fraction of conversions from first-time brand buyers (0 = none, 1 = all)
+         * @minimum 0
+         * @maximum 1
          */
         new_to_brand_rate?: number;
       }[];
@@ -10234,30 +10900,38 @@ export interface GetMediaBuyDeliveryResponse {
     daily_breakdown?: {
       /**
        * Date (YYYY-MM-DD)
+       * @pattern ^\d{4}-\d{2}-\d{2}$
        */
       date: string;
       /**
        * Daily impressions
+       * @minimum 0
        */
       impressions: number;
       /**
        * Daily spend
+       * @minimum 0
        */
       spend: number;
       /**
        * Daily conversions
+       * @minimum 0
        */
       conversions?: number;
       /**
        * Daily conversion value
+       * @minimum 0
        */
       conversion_value?: number;
       /**
        * Daily return on ad spend (conversion_value / spend)
+       * @minimum 0
        */
       roas?: number;
       /**
        * Daily fraction of conversions from first-time brand buyers (0 = none, 1 = all)
+       * @minimum 0
+       * @maximum 1
        */
       new_to_brand_rate?: number;
     }[];
@@ -10293,6 +10967,8 @@ export interface AttributionWindow {
 export interface GetMediaBuysRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   account?: AccountReference;
@@ -10310,6 +10986,8 @@ export interface GetMediaBuysRequest {
   include_snapshot?: boolean;
   /**
    * When present, include the last N revision history entries for each media buy (returns min(N, available entries)). Each entry contains revision number, timestamp, actor, and a summary of what changed. Omit or set to 0 to exclude history (default). Recommended: 5-10 for monitoring, 50+ for audit.
+   * @minimum 0
+   * @maximum 1000
    */
   include_history?: number;
   pagination?: PaginationRequest;
@@ -10339,26 +11017,32 @@ export interface GetMediaBuysResponse {
     status: MediaBuyStatus;
     /**
      * ISO 4217 currency code (e.g., USD, EUR, GBP) for monetary values at this media buy level. total_budget is always denominated in this currency. Package-level fields may override with package.currency.
+     * @pattern ^[A-Z]{3}$
      */
     currency: string;
     /**
      * Total budget amount across all packages, denominated in media_buy.currency
+     * @minimum 0
      */
     total_budget?: number;
     /**
      * ISO 8601 flight start time for this media buy (earliest package start_time). Avoids requiring buyers to compute min(packages[].start_time).
+     * @format date-time
      */
     start_time?: string;
     /**
      * ISO 8601 flight end time for this media buy (latest package end_time). Avoids requiring buyers to compute max(packages[].end_time).
+     * @format date-time
      */
     end_time?: string;
     /**
      * ISO 8601 timestamp for creative upload deadline
+     * @format date-time
      */
     creative_deadline?: string;
     /**
      * ISO 8601 timestamp when the seller confirmed this media buy. A successful create_media_buy response constitutes order confirmation.
+     * @format date-time
      */
     confirmed_at?: string;
     /**
@@ -10367,24 +11051,29 @@ export interface GetMediaBuysResponse {
     cancellation?: {
       /**
        * ISO 8601 timestamp when this media buy was canceled.
+       * @format date-time
        */
       canceled_at: string;
       canceled_by: CanceledBy;
       /**
        * Reason the media buy was canceled.
+       * @maxLength 500
        */
       reason?: string;
     };
     /**
      * Current revision number. Pass this in update_media_buy for optimistic concurrency.
+     * @minimum 1
      */
     revision?: number;
     /**
      * Creation timestamp
+     * @format date-time
      */
     created_at?: string;
     /**
      * Last update timestamp
+     * @format date-time
      */
     updated_at?: string;
     /**
@@ -10397,10 +11086,12 @@ export interface GetMediaBuysResponse {
     history?: {
       /**
        * Revision number after this change was applied.
+       * @minimum 1
        */
       revision: number;
       /**
        * When this change occurred.
+       * @format date-time
        */
       timestamp: string;
       /**
@@ -10413,6 +11104,7 @@ export interface GetMediaBuysResponse {
       action: string;
       /**
        * Human-readable summary of the change (e.g., 'Budget increased from $5,000 to $7,500 on pkg_abc').
+       * @maxLength 500
        */
       summary?: string;
       /**
@@ -10453,27 +11145,33 @@ export interface PackageStatus {
   product_id?: string;
   /**
    * Package budget amount, denominated in package.currency when present, otherwise media_buy.currency
+   * @minimum 0
    */
   budget?: number;
   /**
    * ISO 4217 currency code for monetary values at this package level (budget, bid_price, snapshot.spend). When absent, inherit media_buy.currency.
+   * @pattern ^[A-Z]{3}$
    */
   currency?: string;
   /**
    * Current bid price for auction-based packages. Denominated in package.currency when present, otherwise media_buy.currency. Relevant for automated price optimization loops.
+   * @minimum 0
    */
   bid_price?: number;
   /**
    * Goal impression count for impression-based packages
+   * @minimum 0
    */
   impressions?: number;
   targeting_overlay?: TargetingOverlay;
   /**
    * ISO 8601 flight start time for this package. Use to determine whether the package is within its scheduled flight before interpreting delivery status.
+   * @format date-time
    */
   start_time?: string;
   /**
    * ISO 8601 flight end time for this package
+   * @format date-time
    */
   end_time?: string;
   /**
@@ -10490,16 +11188,19 @@ export interface PackageStatus {
   cancellation?: {
     /**
      * ISO 8601 timestamp when this package was canceled.
+     * @format date-time
      */
     canceled_at: string;
     canceled_by: CanceledBy;
     /**
      * Reason the package was canceled.
+     * @maxLength 500
      */
     reason?: string;
   };
   /**
    * ISO 8601 timestamp for creative upload or change deadline for this package. After this deadline, creative changes are rejected. When absent, the media buy's creative_deadline applies.
+   * @format date-time
    */
   creative_deadline?: string;
   /**
@@ -10527,30 +11228,37 @@ export interface PackageStatus {
   snapshot?: {
     /**
      * ISO 8601 timestamp when this snapshot was captured by the platform
+     * @format date-time
      */
     as_of: string;
     /**
      * Maximum age of this data in seconds. For example, 900 means the data may be up to 15 minutes old. Use this to interpret zero delivery: a value of 900 means zero impressions is likely real; a value of 14400 means reporting may still be catching up.
+     * @minimum 0
      */
     staleness_seconds: number;
     /**
      * Total impressions delivered since package start
+     * @minimum 0
      */
     impressions: number;
     /**
      * Total spend since package start, denominated in snapshot.currency when present, otherwise package.currency or media_buy.currency
+     * @minimum 0
      */
     spend: number;
     /**
      * ISO 4217 currency code for spend in this snapshot. Optional when unchanged from package.currency or media_buy.currency.
+     * @pattern ^[A-Z]{3}$
      */
     currency?: string;
     /**
      * Total clicks since package start (when available)
+     * @minimum 0
      */
     clicks?: number;
     /**
      * Current delivery pace relative to expected (1.0 = on track, <1.0 = behind, >1.0 = ahead). Absent when pacing cannot be determined.
+     * @minimum 0
      */
     pacing_index?: number;
     /**
@@ -10610,6 +11318,8 @@ export type SignalTargeting =
 export interface GetProductsRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -10631,6 +11341,7 @@ export interface GetProductsRequest {
         scope: 'request';
         /**
          * What the buyer is asking for at the request level (e.g., 'more video options and less display', 'suggest how to combine these products').
+         * @minLength 1
          */
         ask: string;
       }
@@ -10641,6 +11352,7 @@ export interface GetProductsRequest {
         scope: 'product';
         /**
          * Product ID from a previous get_products response.
+         * @minLength 1
          */
         product_id: string;
         /**
@@ -10649,6 +11361,7 @@ export interface GetProductsRequest {
         action?: 'include' | 'omit' | 'more_like_this';
         /**
          * What the buyer is asking for on this product. For 'include': specific changes to request (e.g., 'add 16:9 format'). For 'more_like_this': what 'similar' means (e.g., 'same audience but video format'). Ignored when action is 'omit'.
+         * @minLength 1
          */
         ask?: string;
       }
@@ -10659,6 +11372,7 @@ export interface GetProductsRequest {
         scope: 'proposal';
         /**
          * Proposal ID from a previous get_products response.
+         * @minLength 1
          */
         proposal_id: string;
         /**
@@ -10667,6 +11381,7 @@ export interface GetProductsRequest {
         action?: 'include' | 'omit' | 'finalize';
         /**
          * What the buyer is asking for on this proposal (e.g., 'shift more budget toward video', 'reduce total by 10%'). Ignored when action is 'omit'.
+         * @minLength 1
          */
         ask?: string;
       }
@@ -10747,14 +11462,17 @@ export interface ProductFilters {
   standard_formats_only?: boolean;
   /**
    * Minimum exposures/impressions needed for measurement validity
+   * @minimum 1
    */
   min_exposures?: number;
   /**
    * Campaign start date (ISO 8601 date format: YYYY-MM-DD) for availability checks
+   * @format date
    */
   start_date?: string;
   /**
    * Campaign end date (ISO 8601 date format: YYYY-MM-DD) for availability checks
+   * @format date
    */
   end_date?: string;
   /**
@@ -10857,6 +11575,7 @@ export interface ProductFilters {
   keywords?: {
     /**
      * The keyword to target
+     * @minLength 1
      */
     keyword: string;
     match_type?: MatchType;
@@ -10888,6 +11607,8 @@ export interface MediaBuyFeatures {
 export interface ListCreativeFormatsRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -10957,6 +11678,8 @@ export type UserMatch = {
 export interface LogEventRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -10973,6 +11696,9 @@ export interface LogEventRequest {
   events: Event[];
   /**
    * Client-generated unique key for this request. Prevents duplicate event logging on retries. MUST be unique per (seller, request) pair to prevent cross-seller correlation. Use a fresh UUID v4 for each request.
+   * @minLength 16
+   * @maxLength 255
+   * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   idempotency_key: string;
   context?: ContextObject;
@@ -10984,11 +11710,14 @@ export interface LogEventRequest {
 export interface Event {
   /**
    * Unique identifier for deduplication (scoped to event_type + event_source_id)
+   * @minLength 1
+   * @maxLength 256
    */
   event_id: string;
   event_type: EventType;
   /**
    * ISO 8601 timestamp when the event occurred
+   * @format date-time
    */
   event_time: string;
   user_match?: UserMatch;
@@ -11010,10 +11739,12 @@ export interface Event {
 export interface EventCustomData {
   /**
    * Monetary value of the event (should be accompanied by currency)
+   * @minimum 0
    */
   value?: number;
   /**
    * ISO 4217 currency code
+   * @pattern ^[A-Z]{3}$
    */
   currency?: string;
   /**
@@ -11038,6 +11769,7 @@ export interface EventCustomData {
   content_category?: string;
   /**
    * Number of items in the event
+   * @minimum 0
    */
   num_items?: number;
   /**
@@ -11054,10 +11786,12 @@ export interface EventCustomData {
     id: string;
     /**
      * Quantity of this item
+     * @minimum 1
      */
     quantity?: number;
     /**
      * Price per unit of this item
+     * @minimum 0
      */
     price?: number;
     /**
@@ -11080,10 +11814,12 @@ export type LogEventResponse = LogEventSuccess | LogEventError;
 export interface LogEventSuccess {
   /**
    * Number of events received
+   * @minimum 0
    */
   events_received: number;
   /**
    * Number of events successfully queued for processing
+   * @minimum 0
    */
   events_processed: number;
   /**
@@ -11109,6 +11845,8 @@ export interface LogEventSuccess {
   warnings?: string[];
   /**
    * Overall match quality score for the batch (0.0 = no matches, 1.0 = all matched)
+   * @minimum 0
+   * @maximum 1
    */
   match_quality?: number;
   /**
@@ -11158,27 +11896,36 @@ export type FeedbackSource =
 export interface ProvidePerformanceFeedbackRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
    * Seller's media buy identifier
+   * @minLength 1
    */
   media_buy_id: string;
   /**
    * Client-generated unique key for this request. Prevents duplicate feedback submissions on retries. MUST be unique per (seller, request) pair to prevent cross-seller correlation. Use a fresh UUID v4 for each request.
+   * @minLength 16
+   * @maxLength 255
+   * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   idempotency_key: string;
   measurement_period: DatetimeRange;
   /**
    * Normalized performance score (0.0 = no value, 1.0 = expected, >1.0 = above expected)
+   * @minimum 0
    */
   performance_index: number;
   /**
    * Specific package within the media buy (if feedback is package-specific)
+   * @minLength 1
    */
   package_id?: string;
   /**
    * Specific creative asset (if feedback is creative-specific)
+   * @minLength 1
    */
   creative_id?: string;
   metric_type?: MetricType;
@@ -11192,10 +11939,12 @@ export interface ProvidePerformanceFeedbackRequest {
 export interface DatetimeRange {
   /**
    * Start timestamp (inclusive), ISO 8601
+   * @format date-time
    */
   start: string;
   /**
    * End timestamp (inclusive), ISO 8601
+   * @format date-time
    */
   end: string;
 }
@@ -11251,10 +12000,15 @@ export type ConsentBasis = 'consent' | 'legitimate_interest' | 'contract' | 'leg
 export interface SyncAudiencesRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
    * Client-generated unique key for at-most-once execution. `audience_id` gives resource-level dedup per audience, but the sync envelope emits audit events and may trigger downstream refreshes — this key prevents those side effects from firing twice on retry. Also serves as a request ID on discovery-only calls (when `audiences` is omitted). MUST be unique per (seller, request) pair. Use a fresh UUID v4 for each request.
+   * @minLength 16
+   * @maxLength 255
+   * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   idempotency_key: string;
   account: AccountReference;
@@ -11354,18 +12108,23 @@ export interface SyncAudiencesSuccess {
     status?: AudienceStatus;
     /**
      * Number of members submitted in this sync operation (delta, not cumulative). In discovery-only calls (no audiences array), this is 0.
+     * @minimum 0
      */
     uploaded_count?: number;
     /**
      * Cumulative number of members uploaded across all syncs for this audience. Compare with matched_count to calculate match rate (matched_count / total_uploaded_count). Populated when the seller tracks cumulative upload counts.
+     * @minimum 0
      */
     total_uploaded_count?: number;
     /**
      * Total members matched to platform users across all syncs (cumulative, not just this call). Populated when status is 'ready'.
+     * @minimum 0
      */
     matched_count?: number;
     /**
      * Deduplicated match rate across all identifier types (matched_count / total_uploaded_count after deduplication). A single number for reach estimation. Populated when status is 'ready'.
+     * @minimum 0
+     * @maximum 1
      */
     effective_match_rate?: number;
     /**
@@ -11375,23 +12134,29 @@ export interface SyncAudiencesSuccess {
       id_type: MatchIDType;
       /**
        * Cumulative number of members submitted with this identifier type across all syncs (matches total_uploaded_count semantics, not uploaded_count). Compare with matched to calculate per-type match rate.
+       * @minimum 0
        */
       submitted: number;
       /**
        * Cumulative number of members matched via this identifier type across all syncs.
+       * @minimum 0
        */
       matched: number;
       /**
        * Match rate for this identifier type (matched / submitted). Server-authoritative — consumers should prefer this value over computing their own.
+       * @minimum 0
+       * @maximum 1
        */
       match_rate: number;
     }[];
     /**
      * ISO 8601 timestamp of when the most recent sync operation was accepted by the platform. Useful for agents reasoning about audience freshness. Omitted if the seller does not track this.
+     * @format date-time
      */
     last_synced_at?: string;
     /**
      * Minimum matched audience size required for targeting on this platform. Populated when status is 'too_small'. Helps agents know how many more members are needed.
+     * @minimum 1
      */
     minimum_size?: number;
     /**
@@ -11425,10 +12190,15 @@ export interface SyncAudiencesError {
 export interface SyncCatalogsRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
    * Client-generated unique key for at-most-once execution. `catalog_id` gives resource-level dedup per catalog, but the sync envelope emits audit events and triggers platform review for large feeds — this key prevents those side effects from firing twice on retry. Also serves as a request ID on discovery-only calls (when `catalogs` is omitted). MUST be unique per (seller, request) pair. Use a fresh UUID v4 for each request.
+   * @minLength 16
+   * @maxLength 255
+   * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   idempotency_key: string;
   account: AccountReference;
@@ -11461,10 +12231,15 @@ export interface SyncCatalogsRequest {
 export interface SyncEventSourcesRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
    * Client-generated unique key for at-most-once execution. `event_source_id` gives resource-level dedup per source, but the sync envelope emits audit events and can trigger downstream pixel provisioning — this key prevents those side effects from firing twice on retry. Also serves as a request ID on discovery-only calls (when `event_sources` is omitted). MUST be unique per (seller, request) pair. Use a fresh UUID v4 for each request.
+   * @minLength 16
+   * @maxLength 255
+   * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   idempotency_key: string;
   account: AccountReference;
@@ -11576,10 +12351,12 @@ export interface EventSourceHealth {
   detail?: {
     /**
      * Seller-defined quality score. Scale varies by seller — only compare within the same seller.
+     * @minimum 0
      */
     score: number;
     /**
      * Maximum possible score on this seller's scale.
+     * @minimum 1
      */
     max_score: number;
     /**
@@ -11589,18 +12366,23 @@ export interface EventSourceHealth {
   };
   /**
    * Fraction of events from this source that the seller successfully matched to ad interactions (0.0-1.0). Low match rates indicate weak user_match identifiers. Absent when the seller does not compute match rates.
+   * @minimum 0
+   * @maximum 1
    */
   match_rate?: number;
   /**
    * ISO 8601 timestamp of the most recent event received from this source. Absent when no events have been received.
+   * @format date-time
    */
   last_event_at?: string;
   /**
    * ISO 8601 timestamp of when this health assessment was computed. When health is derived from reporting data, this may lag real-time. Buyer agents can use this to decide whether to trust stale assessments or re-request.
+   * @format date-time
    */
   evaluated_at?: string;
   /**
    * Number of events received from this source in the last 24 hours. Zero indicates the source is configured but not firing.
+   * @minimum 0
    */
   events_received_24h?: number;
   /**
@@ -11627,6 +12409,8 @@ export interface SyncEventSourcesError {
 export interface UpdateMediaBuyRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   account: AccountReference;
@@ -11636,6 +12420,7 @@ export interface UpdateMediaBuyRequest {
   media_buy_id: string;
   /**
    * Expected current revision for optimistic concurrency. When provided, sellers MUST reject the update with CONFLICT if the media buy's current revision does not match. Obtain from get_media_buys or the most recent update response.
+   * @minimum 1
    */
   revision?: number;
   /**
@@ -11648,11 +12433,13 @@ export interface UpdateMediaBuyRequest {
   canceled?: true;
   /**
    * Reason for cancellation. Sellers SHOULD store this and return it in subsequent get_media_buys responses.
+   * @maxLength 500
    */
   cancellation_reason?: string;
   start_time?: StartTiming;
   /**
    * New end date/time in ISO 8601 format
+   * @format date-time
    */
   end_time?: string;
   /**
@@ -11668,6 +12455,9 @@ export interface UpdateMediaBuyRequest {
   push_notification_config?: PushNotificationConfig;
   /**
    * Client-generated idempotency key for safe retries. If an update fails without a response, resending with the same idempotency_key guarantees the update is applied at most once. MUST be unique per (seller, request) pair to prevent cross-seller correlation. Use a fresh UUID v4 for each request.
+   * @minLength 16
+   * @maxLength 255
+   * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   idempotency_key: string;
   context?: ContextObject;
@@ -11683,23 +12473,28 @@ export interface PackageUpdate {
   package_id: string;
   /**
    * Updated budget allocation for this package in the currency specified by the pricing option
+   * @minimum 0
    */
   budget?: number;
   pacing?: Pacing;
   /**
    * Updated bid price for auction-based pricing options. This is the exact bid/price to honor unless selected pricing_option has max_bid=true, in which case bid_price is the buyer's maximum willingness to pay (ceiling).
+   * @minimum 0
    */
   bid_price?: number;
   /**
    * Updated impression goal for this package
+   * @minimum 0
    */
   impressions?: number;
   /**
    * Updated flight start date/time for this package in ISO 8601 format. Must fall within the media buy's date range.
+   * @format date-time
    */
   start_time?: string;
   /**
    * Updated flight end date/time for this package in ISO 8601 format. Must fall within the media buy's date range.
+   * @format date-time
    */
   end_time?: string;
   /**
@@ -11712,6 +12507,7 @@ export interface PackageUpdate {
   canceled?: true;
   /**
    * Reason for canceling this package.
+   * @maxLength 500
    */
   cancellation_reason?: string;
   /**
@@ -11729,11 +12525,13 @@ export interface PackageUpdate {
   keyword_targets_add?: {
     /**
      * The keyword to target
+     * @minLength 1
      */
     keyword: string;
     match_type: MatchType;
     /**
      * Per-keyword bid price. Inherits currency and max_bid interpretation from the package's pricing option.
+     * @minimum 0
      */
     bid_price?: number;
   }[];
@@ -11743,6 +12541,7 @@ export interface PackageUpdate {
   keyword_targets_remove?: {
     /**
      * The keyword to stop targeting
+     * @minLength 1
      */
     keyword: string;
     match_type: MatchType;
@@ -11753,6 +12552,7 @@ export interface PackageUpdate {
   negative_keywords_add?: {
     /**
      * The keyword to exclude
+     * @minLength 1
      */
     keyword: string;
     match_type: MatchType;
@@ -11763,6 +12563,7 @@ export interface PackageUpdate {
   negative_keywords_remove?: {
     /**
      * The keyword to stop excluding
+     * @minLength 1
      */
     keyword: string;
     match_type: MatchType;
@@ -11802,6 +12603,8 @@ export type BasePropertySource = PublisherTagsSource | PublisherPropertyIDsSourc
 export interface CreatePropertyListRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   account?: AccountReference;
@@ -11821,6 +12624,9 @@ export interface CreatePropertyListRequest {
   brand?: BrandReference;
   /**
    * Client-generated unique key for this request. Prevents duplicate property list creation on retries. MUST be unique per (seller, request) pair to prevent cross-seller correlation. Use a fresh UUID v4 for each request.
+   * @minLength 16
+   * @maxLength 255
+   * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   idempotency_key: string;
   context?: ContextObject;
@@ -11836,6 +12642,7 @@ export interface PublisherTagsSource {
   selection_type: 'publisher_tags';
   /**
    * Domain where publisher's adagents.json is hosted (e.g., 'raptive.com')
+   * @pattern ^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$
    */
   publisher_domain: string;
   /**
@@ -11853,6 +12660,7 @@ export interface PublisherPropertyIDsSource {
   selection_type: 'publisher_ids';
   /**
    * Domain where publisher's adagents.json is hosted (e.g., 'raptive.com')
+   * @pattern ^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$
    */
   publisher_domain: string;
   /**
@@ -11972,14 +12780,17 @@ export interface PropertyList {
   webhook_url?: string;
   /**
    * Recommended cache duration for resolved list. Consumers should re-fetch after this period.
+   * @minimum 1
    */
   cache_duration_hours?: number;
   /**
    * When the list was created
+   * @format date-time
    */
   created_at?: string;
   /**
    * When the list was last modified
+   * @format date-time
    */
   updated_at?: string;
   /**
@@ -11999,6 +12810,8 @@ export interface PropertyList {
 export interface DeletePropertyListRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -12010,6 +12823,9 @@ export interface DeletePropertyListRequest {
   ext?: ExtensionObject;
   /**
    * Client-generated unique key for at-most-once execution. If a request with the same key has already been processed, the server returns the original response without re-processing. MUST be unique per (seller, request) pair to prevent cross-seller correlation. Use a fresh UUID v4 for each request.
+   * @minLength 16
+   * @maxLength 255
+   * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   idempotency_key: string;
 }
@@ -12042,6 +12858,8 @@ export interface DeletePropertyListResponse {
 export interface GetPropertyListRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -12059,6 +12877,8 @@ export interface GetPropertyListRequest {
   pagination?: {
     /**
      * Maximum number of identifiers to return per page
+     * @minimum 1
+     * @maximum 10000
      */
     max_results?: number;
     /**
@@ -12083,10 +12903,12 @@ export interface GetPropertyListResponse {
   pagination?: PaginationResponse;
   /**
    * When the list was resolved
+   * @format date-time
    */
   resolved_at?: string;
   /**
    * Cache expiration timestamp. Re-fetch the list after this time to get updated identifiers.
+   * @format date-time
    */
   cache_valid_until?: string;
   /**
@@ -12104,6 +12926,8 @@ export interface GetPropertyListResponse {
 export interface ListPropertyListsRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   account?: AccountReference;
@@ -12137,6 +12961,8 @@ export interface ListPropertyListsResponse {
 export interface UpdatePropertyListRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -12166,6 +12992,9 @@ export interface UpdatePropertyListRequest {
   ext?: ExtensionObject;
   /**
    * Client-generated unique key for at-most-once execution. If a request with the same key has already been processed, the server returns the original response without re-processing. MUST be unique per (seller, request) pair to prevent cross-seller correlation. Use a fresh UUID v4 for each request.
+   * @minLength 16
+   * @maxLength 255
+   * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   idempotency_key: string;
 }
@@ -12191,6 +13020,8 @@ export interface UpdatePropertyListResponse {
 export interface ValidatePropertyDeliveryRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -12216,6 +13047,7 @@ export interface DeliveryRecord {
   identifier: Identifier;
   /**
    * Number of impressions delivered to this identifier
+   * @minimum 0
    */
   impressions: number;
   /**
@@ -12351,10 +13183,12 @@ export interface ValidatePropertyDeliveryResponse {
   results: ValidationResult[];
   /**
    * Timestamp when validation was performed
+   * @format date-time
    */
   validated_at: string;
   /**
    * Timestamp of the property list resolution used for validation
+   * @format date-time
    */
   list_resolved_at?: string;
   context?: ContextObject;
@@ -12375,6 +13209,7 @@ export interface ValidationResult {
   status: 'compliant' | 'non_compliant' | 'not_covered' | 'unidentified';
   /**
    * Number of impressions from this record
+   * @minimum 0
    */
   impressions: number;
   /**
@@ -12413,6 +13248,8 @@ export interface ValidationResult {
     };
     /**
      * Optional evaluator confidence in this result (0-1). Distinguishes certain verdicts from ambiguous ones.
+     * @minimum 0
+     * @maximum 1
      */
     confidence?: number;
   }[];
@@ -12457,6 +13294,8 @@ export interface AuthorizationResult {
 export interface GetAdCPCapabilitiesRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. When provided, the seller validates this against its supported major_versions and returns VERSION_UNSUPPORTED if the version is not in range. When omitted, the seller assumes the highest major version it supports.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -12725,13 +13564,20 @@ export interface GetAdCPCapabilitiesResponse {
       supported_uid_types?: UIDType[];
       /**
        * Minimum matched audience size required for targeting. Audiences below this threshold will have status: too_small. Varies by platform (100–1000 is typical).
+       * @minimum 1
        */
       minimum_audience_size: number;
       /**
        * Expected matching latency range in hours after upload. Use to calibrate polling cadence and set appropriate expectations before configuring push_notification_config.
        */
       matching_latency_hours?: {
+        /**
+         * @minimum 0
+         */
         min?: number;
+        /**
+         * @minimum 0
+         */
         max?: number;
       };
     };
@@ -12809,10 +13655,12 @@ export interface GetAdCPCapabilitiesResponse {
       primary_countries?: string[];
       /**
        * Markdown-formatted description of the inventory portfolio
+       * @maxLength 5000
        */
       description?: string;
       /**
        * Advertising content policies, restrictions, and guidelines
+       * @maxLength 10000
        */
       advertising_policies?: string;
     };
@@ -12842,6 +13690,8 @@ export interface GetAdCPCapabilitiesResponse {
   governance?: {
     /**
      * Trailing window (in days) over which this governance agent aggregates committed spend when evaluating dollar-valued thresholds (reallocation_threshold, human_review triggers, registry-policy floors). Required for fragmentation defense: without aggregation, a buyer can split a single large spend into many sub-threshold commits across plans / task surfaces / time and bypass every dollar-gated escalation. Aggregation is keyed on (buyer_agent, seller_agent, account_id) and spans all spend-commit task types. Upper bound 365 represents a one-year trailing window (fiscal-year alignment with grace); governance agents needing longer scopes negotiate via operator sign-off, not this capability. No schema default: absence of this field indicates the governance agent has not committed to any aggregation window and buyers MUST assume per-commit evaluation only (the fragmentation attack surface is open). A declared value of 30 is a common starting point but is not implied by omission. Buyers depending on a specific window for compliance MUST check this capability before relying on aggregation semantics — an agent declaring 7 days does not defend against fragmentation spread across a 30-day quarter-end push.
+     * @minimum 1
+     * @maximum 365
      */
     aggregation_window_days?: number;
     /**
@@ -12975,6 +13825,7 @@ export interface GetAdCPCapabilitiesResponse {
     generation_providers?: string[];
     /**
      * Description of the agent's brand protocol capabilities
+     * @maxLength 5000
      */
     description?: string;
   };
@@ -13118,6 +13969,7 @@ export interface GetAdCPCapabilitiesResponse {
   experimental_features?: string[];
   /**
    * ISO 8601 timestamp of when capabilities were last updated. Buyers can use this for cache invalidation.
+   * @format date-time
    */
   last_updated?: string;
   /**
@@ -13137,6 +13989,8 @@ export interface IdempotencySupported {
   supported: true;
   /**
    * How long the seller retains a canonical response for an idempotency_key. Within this window, a replay with the same key + equivalent canonical payload returns the cached response; a replay with a different canonical payload returns IDEMPOTENCY_CONFLICT; a replay past the window returns IDEMPOTENCY_EXPIRED when the seller can still distinguish 'seen and evicted' from 'never seen'. Minimum 3600 (1h); recommended 86400 (24h). Maximum 604800 (7 days) — longer windows force buyers to retain secret keys at rest for extended periods and grow the seller's cache table without bounded benefit.
+   * @minimum 3600
+   * @maximum 604800
    */
   replay_ttl_seconds: number;
   /**
@@ -13291,6 +14145,8 @@ export type Destination =
 export interface ActivateSignalRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -13312,6 +14168,9 @@ export interface ActivateSignalRequest {
   account?: AccountReference;
   /**
    * Client-generated unique key for this request. Prevents duplicate activations on retries. MUST be unique per (seller, request) pair to prevent cross-seller correlation. Use a fresh UUID v4 for each request.
+   * @minLength 16
+   * @maxLength 255
+   * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   idempotency_key: string;
   context?: ContextObject;
@@ -13347,10 +14206,12 @@ export type Deployment =
       activation_key?: ActivationKey;
       /**
        * Estimated time to activate if not live, or to complete activation if in progress
+       * @minimum 0
        */
       estimated_activation_duration_minutes?: number;
       /**
        * Timestamp when activation completed (if is_live=true)
+       * @format date-time
        */
       deployed_at?: string;
     }
@@ -13374,10 +14235,12 @@ export type Deployment =
       activation_key?: ActivationKey;
       /**
        * Estimated time to activate if not live, or to complete activation if in progress
+       * @minimum 0
        */
       estimated_activation_duration_minutes?: number;
       /**
        * Timestamp when activation completed (if is_live=true)
+       * @format date-time
        */
       deployed_at?: string;
     };
@@ -13445,6 +14308,8 @@ export type GetSignalsRequest = {
 } & {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   account?: AccountReference;
@@ -13468,6 +14333,7 @@ export type GetSignalsRequest = {
   /**
    * @deprecated
    * DEPRECATED: Use pagination.max_results instead. When both fields are present, agents MUST honor pagination.max_results. When only this field is present without a pagination envelope, agents SHOULD treat it as the page size subject to a maximum of 100 results. This field will be removed in AdCP 4.0.
+   * @minimum 1
    */
   max_results?: number;
   pagination?: PaginationRequest;
@@ -13493,14 +14359,19 @@ export interface SignalFilters {
   data_providers?: string[];
   /**
    * Maximum CPM filter. Applies only to signals with model='cpm'.
+   * @minimum 0
    */
   max_cpm?: number;
   /**
    * Maximum percent-of-media rate filter. Signals where all percent_of_media pricing options exceed this value are excluded. Does not account for max_cpm caps.
+   * @minimum 0
+   * @maximum 100
    */
   max_percent?: number;
   /**
    * Minimum coverage requirement
+   * @minimum 0
+   * @maximum 100
    */
   min_coverage_percentage?: number;
 }
@@ -13556,6 +14427,8 @@ export interface GetSignalsResponse {
     data_provider: string;
     /**
      * Percentage of audience coverage
+     * @minimum 0
+     * @maximum 100
      */
     coverage_percentage: number;
     /**
@@ -13587,6 +14460,8 @@ export interface GetSignalsResponse {
 export interface SIGetOfferingRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -13604,6 +14479,8 @@ export interface SIGetOfferingRequest {
   include_products?: boolean;
   /**
    * Maximum number of matching products to return
+   * @minimum 1
+   * @maximum 50
    */
   product_limit?: number;
   ext?: ExtensionObject;
@@ -13624,10 +14501,12 @@ export interface SIGetOfferingResponse {
   offering_token?: string;
   /**
    * How long this offering information is valid (seconds). Host should re-fetch after TTL expires.
+   * @minimum 0
    */
   ttl_seconds?: number;
   /**
    * When this offering information was retrieved
+   * @format date-time
    */
   checked_at?: string;
   /**
@@ -13652,6 +14531,7 @@ export interface SIGetOfferingResponse {
     tagline?: string;
     /**
      * When this offering expires
+     * @format date-time
      */
     expires_at?: string;
     /**
@@ -13702,6 +14582,7 @@ export interface SIGetOfferingResponse {
   }[];
   /**
    * Total number of products matching the context (may be more than returned in matching_products)
+   * @minimum 0
    */
   total_matching?: number;
   /**
@@ -13727,6 +14608,8 @@ export interface SIGetOfferingResponse {
 export interface SIInitiateSessionRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -13754,6 +14637,9 @@ export interface SIInitiateSessionRequest {
   offering_token?: string;
   /**
    * Client-generated unique key for this request. Prevents duplicate session creation on retries. MUST be unique per (seller, request) pair to prevent cross-seller correlation. Use a fresh UUID v4 for each request.
+   * @minLength 16
+   * @maxLength 255
+   * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   idempotency_key: string;
   ext?: ExtensionObject;
@@ -13768,6 +14654,7 @@ export interface SIIdentity {
   consent_granted: boolean;
   /**
    * When consent was granted (ISO 8601)
+   * @format date-time
    */
   consent_timestamp?: string;
   /**
@@ -13793,6 +14680,7 @@ export interface SIIdentity {
   user?: {
     /**
      * User's email address
+     * @format email
      */
     email?: string;
     /**
@@ -13855,6 +14743,7 @@ export interface SIInitiateSessionResponse {
   session_status: SISessionStatus;
   /**
    * Session inactivity timeout in seconds. After this duration without a message, the brand agent may terminate the session. Hosts SHOULD warn users before timeout when possible.
+   * @minimum 1
    */
   session_ttl_seconds?: number;
   /**
@@ -13895,10 +14784,15 @@ export type SISendMessageRequest = {
 } & {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
    * Client-generated unique key for at-most-once execution. Each conversational turn is a distinct mutation of session transcript — without this key, a timeout-and-retry produces a duplicate turn and a duplicate model response. MUST be unique per (seller, request) pair. Use a fresh UUID v4 for each user turn.
+   * @minLength 16
+   * @maxLength 255
+   * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   idempotency_key: string;
   /**
@@ -14010,6 +14904,8 @@ export interface SISendMessageResponse {
 export interface SITerminateSessionRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -14079,6 +14975,7 @@ export interface SITerminateSessionResponse {
     payload?: {};
     /**
      * When this handoff data expires. Hosts should initiate checkout before this time.
+     * @format date-time
      */
     expires_at?: string;
   };
@@ -14170,6 +15067,7 @@ export interface PublisherCollectionsSource {
   selection_type: 'publisher_collections';
   /**
    * Domain where publisher's adagents.json is hosted
+   * @pattern ^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$
    */
   publisher_domain: string;
   /**
@@ -14187,6 +15085,7 @@ export interface PublisherGenresSource {
   selection_type: 'publisher_genres';
   /**
    * Domain where publisher's adagents.json is hosted
+   * @pattern ^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$
    */
   publisher_domain: string;
   /**
@@ -14204,6 +15103,9 @@ export interface PublisherGenresSource {
 export interface CollectionListChangedWebhook {
   /**
    * Sender-generated key stable across retries of the same webhook event. Governance agents MUST generate a cryptographically random value (UUID v4 recommended) per distinct list-change event and reuse the same key on every retry. Recipients MUST dedupe by this key, scoped to the authenticated sender identity (HMAC secret or Bearer credential) — keys from different governance agents are independent.
+   * @minLength 16
+   * @maxLength 255
+   * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   idempotency_key: string;
   /**
@@ -14237,10 +15139,12 @@ export interface CollectionListChangedWebhook {
   };
   /**
    * When the list was re-resolved
+   * @format date-time
    */
   resolved_at: string;
   /**
    * When the consumer should refresh from the governance agent
+   * @format date-time
    */
   cache_valid_until?: string;
   /**
@@ -14331,14 +15235,17 @@ export interface CollectionList {
   webhook_url?: string;
   /**
    * Recommended cache duration for resolved list. Consumers should re-fetch after this period. Defaults to 168 (one week) because collection metadata changes less frequently than property metadata.
+   * @minimum 1
    */
   cache_duration_hours?: number;
   /**
    * When the list was created
+   * @format date-time
    */
   created_at?: string;
   /**
    * When the list was last modified
+   * @format date-time
    */
   updated_at?: string;
   /**
@@ -14354,6 +15261,9 @@ export interface CollectionList {
 export interface ArtifactWebhookPayload {
   /**
    * Sender-generated key stable across retries of the same webhook event. Sales agents MUST generate a cryptographically random value (UUID v4 recommended) per distinct emission of a batch and reuse the same key on every retry. Recipients MUST dedupe by this key, scoped to the authenticated sender identity (HMAC secret or Bearer credential) — keys from different sales agents are independent. Distinct from `batch_id`, which identifies the logical batch: `idempotency_key` identifies this specific emission event, so a re-emission of the same `batch_id` (e.g., after a correction) is a different event and MUST carry a fresh `idempotency_key`.
+   * @minLength 16
+   * @maxLength 255
+   * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   idempotency_key: string;
   /**
@@ -14366,6 +15276,7 @@ export interface ArtifactWebhookPayload {
   batch_id: string;
   /**
    * When this batch was generated (ISO 8601)
+   * @format date-time
    */
   timestamp: string;
   /**
@@ -14375,6 +15286,7 @@ export interface ArtifactWebhookPayload {
     artifact: Artifact;
     /**
      * When the impression was delivered (ISO 8601)
+     * @format date-time
      */
     delivered_at: string;
     /**
@@ -14413,6 +15325,7 @@ export interface ArtifactWebhookPayload {
 export interface AgentEncryptionKey {
   /**
    * Key identifier. Opaque — MUST NOT encode geographic or deployment information.
+   * @maxLength 8
    */
   kid: string;
   /**
@@ -14477,6 +15390,7 @@ export interface AgentSigningKey {
   e?: string;
   /**
    * Optional revocation timestamp. When present, verifiers MUST reject any signature produced with this key whose signing epoch (or equivalent time reference) is at or after this timestamp. The key may continue to appear in the trust anchor during a grace period so caches that have not yet refreshed still find the key and can evaluate the revocation marker. Keys past their revocation can be removed once the cache TTL (recommended: 5 minutes) has elapsed across all verifiers.
+   * @format date-time
    */
   revoked_at?: string;
 }
@@ -14505,6 +15419,7 @@ export interface AppItem {
   bundle_id?: string;
   /**
    * Numeric Apple App Store ID (e.g., '389801252'). Required for Apple Search Ads and iOS platforms that use the numeric ID rather than bundle_id.
+   * @pattern ^[0-9]+$
    */
   apple_id?: string;
   /**
@@ -14542,10 +15457,13 @@ export interface AppItem {
   price?: Price;
   /**
    * Average store rating (0–5). Use 0 to indicate no ratings yet.
+   * @minimum 0
+   * @maximum 5
    */
   rating?: number;
   /**
    * Total number of store ratings.
+   * @minimum 0
    */
   rating_count?: number;
   /**
@@ -14568,10 +15486,12 @@ export interface AppItem {
 export interface Price {
   /**
    * Monetary amount in the specified currency.
+   * @minimum 0
    */
   amount: number;
   /**
    * ISO 4217 currency code (e.g., 'USD', 'EUR', 'GBP').
+   * @pattern ^[A-Z]{3}$
    */
   currency: string;
   /**
@@ -14627,6 +15547,7 @@ export type Catchment = {
   travel_time?: {
     /**
      * Travel time limit.
+     * @minimum 1
      */
     value: number;
     unit: TravelTimeUnit;
@@ -14771,14 +15692,17 @@ export interface Collection {
 export interface LimitedSeries {
   /**
    * Planned number of installments in the series
+   * @minimum 1
    */
   total_installments: number;
   /**
    * When the series begins (ISO 8601)
+   * @format date-time
    */
   starts?: string;
   /**
    * When the series ends (ISO 8601)
+   * @format date-time
    */
   ends?: string;
 }
@@ -14788,10 +15712,12 @@ export interface LimitedSeries {
 export interface DeadlinePolicy {
   /**
    * Days before scheduled_at by which the placement must be booked
+   * @minimum 0
    */
   booking_lead_days?: number;
   /**
    * Days before scheduled_at by which cancellation is penalty-free
+   * @minimum 0
    */
   cancellation_lead_days?: number;
   /**
@@ -14804,6 +15730,7 @@ export interface DeadlinePolicy {
     stage: string;
     /**
      * Days before scheduled_at this stage is due
+     * @minimum 0
      */
     lead_days: number;
     /**
@@ -14824,10 +15751,12 @@ export interface DeadlinePolicy {
 export interface DateRange {
   /**
    * Start date (inclusive), ISO 8601
+   * @format date
    */
   start: string;
   /**
    * End date (inclusive), ISO 8601
+   * @format date
    */
   end: string;
 }
@@ -14860,6 +15789,7 @@ export interface DestinationItem {
   region?: string;
   /**
    * ISO 3166-1 alpha-2 country code.
+   * @pattern ^[A-Z]{2}$
    */
   country?: string;
   /**
@@ -14868,10 +15798,14 @@ export interface DestinationItem {
   location?: {
     /**
      * Latitude in decimal degrees (WGS 84).
+     * @minimum -90
+     * @maximum 90
      */
     lat: number;
     /**
      * Longitude in decimal degrees (WGS 84).
+     * @minimum -180
+     * @maximum 180
      */
     lng: number;
   };
@@ -14890,6 +15824,8 @@ export interface DestinationItem {
   url?: string;
   /**
    * Destination rating (1–5).
+   * @minimum 1
+   * @maximum 5
    */
   rating?: number;
   /**
@@ -14943,6 +15879,7 @@ export interface EducationItem {
   duration?: string;
   /**
    * Next available start date (ISO 8601 date).
+   * @format date
    */
   start_date?: string;
   /**
@@ -14991,6 +15928,7 @@ export interface FlightItem {
   origin: {
     /**
      * IATA airport code (e.g., 'AMS', 'JFK', 'LHR').
+     * @pattern ^[A-Z]{3}$
      */
     airport_code: string;
     /**
@@ -15004,6 +15942,7 @@ export interface FlightItem {
   destination: {
     /**
      * IATA airport code.
+     * @pattern ^[A-Z]{3}$
      */
     airport_code: string;
     /**
@@ -15022,10 +15961,12 @@ export interface FlightItem {
   description?: string;
   /**
    * Departure date and time (ISO 8601).
+   * @format date-time
    */
   departure_time?: string;
   /**
    * Arrival date and time (ISO 8601).
+   * @format date-time
    */
   arrival_time?: string;
   /**
@@ -15304,6 +16245,7 @@ export interface Format {
           };
           /**
            * Fixed aspect ratio constraint (e.g., '16:9', '4:3', '1:1', '1.91:1')
+           * @pattern ^\d+(\.\d+)?:\d+(\.\d+)?$
            */
           aspect_ratio?: string;
         };
@@ -15454,10 +16396,12 @@ export interface Overlay {
     y: number;
     /**
      * Width of the overlay
+     * @minimum 0
      */
     width: number;
     /**
      * Height of the overlay
+     * @minimum 0
      */
     height: number;
     /**
@@ -15484,10 +16428,12 @@ export interface RepeatableGroupAsset {
   required: boolean;
   /**
    * Minimum number of repetitions required (if group is required) or allowed (if optional)
+   * @minimum 0
    */
   min_count: number;
   /**
    * Maximum number of repetitions allowed
+   * @minimum 1
    */
   max_count: number;
   /**
@@ -15541,10 +16487,14 @@ export interface HotelItem {
   location: {
     /**
      * Latitude in decimal degrees (WGS 84).
+     * @minimum -90
+     * @maximum 90
      */
     lat: number;
     /**
      * Longitude in decimal degrees (WGS 84).
+     * @minimum -180
+     * @maximum 180
      */
     lng: number;
   };
@@ -15570,11 +16520,14 @@ export interface HotelItem {
     postal_code?: string;
     /**
      * ISO 3166-1 alpha-2 country code.
+     * @pattern ^[A-Z]{2}$
      */
     country?: string;
   };
   /**
    * Official star rating (1–5).
+   * @minimum 1
+   * @maximum 5
    */
   star_rating?: number;
   price?: Price;
@@ -15596,10 +16549,12 @@ export interface HotelItem {
   amenities?: string[];
   /**
    * Standard check-in time in HH:MM format (e.g., '15:00').
+   * @pattern ^[0-2][0-9]:[0-5][0-9]$
    */
   check_in_time?: string;
   /**
    * Standard check-out time in HH:MM format (e.g., '11:00').
+   * @pattern ^[0-2][0-9]:[0-5][0-9]$
    */
   check_out_time?: string;
   /**
@@ -15608,10 +16563,12 @@ export interface HotelItem {
   tags?: string[];
   /**
    * Date from which this item is available or this rate applies (ISO 8601, e.g., '2025-03-01'). Used for seasonal availability windows in feed imports.
+   * @format date
    */
   valid_from?: string;
   /**
    * Date until which this item is available or this rate applies (ISO 8601, e.g., '2025-09-30'). Used for seasonal availability windows in feed imports.
+   * @format date
    */
   valid_to?: string;
   /**
@@ -15660,14 +16617,17 @@ export interface JobItem {
   salary?: {
     /**
      * Minimum salary.
+     * @minimum 0
      */
     min?: number;
     /**
      * Maximum salary.
+     * @minimum 0
      */
     max?: number;
     /**
      * ISO 4217 currency code.
+     * @pattern ^[A-Z]{3}$
      */
     currency: string;
     /**
@@ -15677,10 +16637,12 @@ export interface JobItem {
   };
   /**
    * Date the job was posted (ISO 8601 date).
+   * @format date
    */
   date_posted?: string;
   /**
    * Application deadline (ISO 8601 date).
+   * @format date
    */
   valid_through?: string;
   /**
@@ -15729,10 +16691,12 @@ export interface Offering {
   tagline?: string;
   /**
    * When the offering becomes available. If not specified, offering is immediately available.
+   * @format date-time
    */
   valid_from?: string;
   /**
    * When the offering expires. If not specified, offering has no expiration.
+   * @format date-time
    */
   valid_to?: string;
   /**
@@ -15818,15 +16782,18 @@ export interface PerformanceFeedback {
   measurement_period: {
     /**
      * ISO 8601 start timestamp for measurement period
+     * @format date-time
      */
     start: string;
     /**
      * ISO 8601 end timestamp for measurement period
+     * @format date-time
      */
     end: string;
   };
   /**
    * Normalized performance score (0.0 = no value, 1.0 = expected, >1.0 = above expected)
+   * @minimum 0
    */
   performance_index: number;
   metric_type: MetricType;
@@ -15837,10 +16804,12 @@ export interface PerformanceFeedback {
   status: 'accepted' | 'queued' | 'applied' | 'rejected';
   /**
    * ISO 8601 timestamp when feedback was submitted
+   * @format date-time
    */
   submitted_at: string;
   /**
    * ISO 8601 timestamp when feedback was applied to optimization algorithms
+   * @format date-time
    */
   applied_at?: string;
 }
@@ -15908,6 +16877,7 @@ export interface ProtocolEnvelope {
   message?: string;
   /**
    * ISO 8601 timestamp when the response was generated. Useful for debugging, logging, cache validation, and tracking async operation progress.
+   * @format date-time
    */
   timestamp?: string;
   /**
@@ -15921,6 +16891,9 @@ export interface ProtocolEnvelope {
    * Value format: in 3.0 governance agents MUST emit a compact JWS per the AdCP JWS profile (see Security — Signed Governance Context). Sellers MAY verify; sellers that do not verify MUST persist and forward the token unchanged. In 3.1 all sellers MUST verify. Non-JWS values from pre-3.0 governance agents are deprecated.
    *
    * This is the primary correlation key for audit and reporting across the governance lifecycle.
+   * @minLength 1
+   * @maxLength 4096
+   * @pattern ^[\x20-\x7E]+$
    */
   governance_context?: string;
   /**
@@ -15964,6 +16937,7 @@ export interface RealEstateItem {
     postal_code?: string;
     /**
      * ISO 3166-1 alpha-2 country code.
+     * @pattern ^[A-Z]{2}$
      */
     country?: string;
   };
@@ -15978,10 +16952,12 @@ export interface RealEstateItem {
   listing_type?: 'for_sale' | 'for_rent';
   /**
    * Number of bedrooms.
+   * @minimum 0
    */
   bedrooms?: number;
   /**
    * Number of bathrooms (e.g., 2.5 for two full and one half bath).
+   * @minimum 0
    */
   bathrooms?: number;
   /**
@@ -15990,6 +16966,7 @@ export interface RealEstateItem {
   area?: {
     /**
      * Area value.
+     * @minimum 0
      */
     value: number;
     /**
@@ -16007,10 +16984,14 @@ export interface RealEstateItem {
   location?: {
     /**
      * Latitude in decimal degrees (WGS 84).
+     * @minimum -90
+     * @maximum 90
      */
     lat: number;
     /**
      * Longitude in decimal degrees (WGS 84).
+     * @minimum -180
+     * @maximum 180
      */
     lng: number;
   };
@@ -16081,6 +17062,7 @@ export interface ImageAssetRequirements {
   unit?: DimensionUnit;
   /**
    * Required aspect ratio (e.g., '16:9', '1:1', '1.91:1')
+   * @pattern ^\d+(\.\d+)?:\d+(\.\d+)?$
    */
   aspect_ratio?: string;
   /**
@@ -16089,6 +17071,7 @@ export interface ImageAssetRequirements {
   formats?: ('jpg' | 'jpeg' | 'png' | 'gif' | 'webp' | 'svg' | 'avif' | 'tiff' | 'pdf' | 'eps')[];
   /**
    * Minimum resolution in dots per inch. Always in DPI regardless of the dimension unit. Standard print requires 300 DPI, newspaper 150 DPI.
+   * @minimum 1
    */
   min_dpi?: number;
   /**
@@ -16098,13 +17081,26 @@ export interface ImageAssetRequirements {
     | {
         /**
          * Same bleed on all four sides
+         * @minimum 0
          */
         uniform: number;
       }
     | {
+        /**
+         * @minimum 0
+         */
         top: number;
+        /**
+         * @minimum 0
+         */
         right: number;
+        /**
+         * @minimum 0
+         */
         bottom: number;
+        /**
+         * @minimum 0
+         */
         left: number;
       };
   /**
@@ -16113,6 +17109,7 @@ export interface ImageAssetRequirements {
   color_space?: 'rgb' | 'cmyk' | 'grayscale';
   /**
    * Maximum file size in kilobytes
+   * @minimum 1
    */
   max_file_size_kb?: number;
   /**
@@ -16125,6 +17122,7 @@ export interface ImageAssetRequirements {
   animation_allowed?: boolean;
   /**
    * Maximum animation duration in milliseconds (if animation_allowed is true)
+   * @minimum 0
    */
   max_animation_duration_ms?: number;
   /**
@@ -16138,30 +17136,37 @@ export interface ImageAssetRequirements {
 export interface VideoAssetRequirements {
   /**
    * Minimum width in pixels
+   * @minimum 1
    */
   min_width?: number;
   /**
    * Maximum width in pixels
+   * @minimum 1
    */
   max_width?: number;
   /**
    * Minimum height in pixels
+   * @minimum 1
    */
   min_height?: number;
   /**
    * Maximum height in pixels
+   * @minimum 1
    */
   max_height?: number;
   /**
    * Required aspect ratio (e.g., '16:9', '9:16')
+   * @pattern ^\d+:\d+$
    */
   aspect_ratio?: string;
   /**
    * Minimum duration in milliseconds
+   * @minimum 1
    */
   min_duration_ms?: number;
   /**
    * Maximum duration in milliseconds
+   * @minimum 1
    */
   max_duration_ms?: number;
   /**
@@ -16174,14 +17179,17 @@ export interface VideoAssetRequirements {
   codecs?: ('h264' | 'h265' | 'vp8' | 'vp9' | 'av1' | 'prores')[];
   /**
    * Maximum file size in kilobytes
+   * @minimum 1
    */
   max_file_size_kb?: number;
   /**
    * Minimum video bitrate in kilobits per second
+   * @minimum 1
    */
   min_bitrate_kbps?: number;
   /**
    * Maximum video bitrate in kilobits per second
+   * @minimum 1
    */
   max_bitrate_kbps?: number;
   /**
@@ -16197,10 +17205,12 @@ export interface VideoAssetRequirements {
   gop_type?: GOPType;
   /**
    * Minimum keyframe interval in seconds
+   * @minimum 0
    */
   min_gop_interval_seconds?: number;
   /**
    * Maximum keyframe interval in seconds. SSAI typically requires 1-2 second intervals.
+   * @minimum 0
    */
   max_gop_interval_seconds?: number;
   moov_atom_position?: MoovAtomPosition;
@@ -16222,6 +17232,7 @@ export interface VideoAssetRequirements {
   loudness_lufs?: number;
   /**
    * Acceptable deviation from loudness_lufs target in dB (e.g., 2 means -22 to -26 LUFS for a -24 target)
+   * @minimum 0
    */
   loudness_tolerance_db?: number;
   /**
@@ -16235,10 +17246,12 @@ export interface VideoAssetRequirements {
 export interface AudioAssetRequirements {
   /**
    * Minimum duration in milliseconds
+   * @minimum 1
    */
   min_duration_ms?: number;
   /**
    * Maximum duration in milliseconds
+   * @minimum 1
    */
   max_duration_ms?: number;
   /**
@@ -16247,6 +17260,7 @@ export interface AudioAssetRequirements {
   formats?: ('mp3' | 'aac' | 'wav' | 'ogg' | 'flac')[];
   /**
    * Maximum file size in kilobytes
+   * @minimum 1
    */
   max_file_size_kb?: number;
   /**
@@ -16259,10 +17273,12 @@ export interface AudioAssetRequirements {
   channels?: ('mono' | 'stereo')[];
   /**
    * Minimum audio bitrate in kilobits per second
+   * @minimum 1
    */
   min_bitrate_kbps?: number;
   /**
    * Maximum audio bitrate in kilobits per second
+   * @minimum 1
    */
   max_bitrate_kbps?: number;
 }
@@ -16272,18 +17288,22 @@ export interface AudioAssetRequirements {
 export interface TextAssetRequirements {
   /**
    * Minimum character length
+   * @minimum 0
    */
   min_length?: number;
   /**
    * Maximum character length
+   * @minimum 1
    */
   max_length?: number;
   /**
    * Minimum number of lines
+   * @minimum 1
    */
   min_lines?: number;
   /**
    * Maximum number of lines
+   * @minimum 1
    */
   max_lines?: number;
   /**
@@ -16301,6 +17321,7 @@ export interface TextAssetRequirements {
 export interface MarkdownAssetRequirements {
   /**
    * Maximum character length
+   * @minimum 1
    */
   max_length?: number;
 }
@@ -16310,6 +17331,7 @@ export interface MarkdownAssetRequirements {
 export interface HTMLAssetRequirements {
   /**
    * Maximum file size in kilobytes for the HTML asset
+   * @minimum 1
    */
   max_file_size_kb?: number;
   /**
@@ -16331,6 +17353,7 @@ export interface HTMLAssetRequirements {
 export interface CSSAssetRequirements {
   /**
    * Maximum file size in kilobytes
+   * @minimum 1
    */
   max_file_size_kb?: number;
 }
@@ -16340,6 +17363,7 @@ export interface CSSAssetRequirements {
 export interface JavaScriptAssetRequirements {
   /**
    * Maximum file size in kilobytes for the JavaScript asset
+   * @minimum 1
    */
   max_file_size_kb?: number;
   /**
@@ -16401,6 +17425,7 @@ export interface URLAssetRequirements {
   allowed_domains?: string[];
   /**
    * Maximum URL length in characters
+   * @minimum 1
    */
   max_length?: number;
   /**
@@ -16487,10 +17512,12 @@ export interface CatalogRequirements {
   required?: boolean;
   /**
    * Minimum number of items the catalog must contain for this format to render properly (e.g., a carousel might require at least 3 products)
+   * @minimum 1
    */
   min_items?: number;
   /**
    * Maximum number of items the format can render. Items beyond this limit are ignored. Useful for fixed-slot layouts (e.g., a 3-product card) or feed-size constraints.
+   * @minimum 1
    */
   max_items?: number;
   /**
@@ -16525,10 +17552,12 @@ export interface OfferingAssetConstraint {
   required?: boolean;
   /**
    * Minimum number of items required in this group.
+   * @minimum 1
    */
   min_count?: number;
   /**
    * Maximum number of items allowed in this group.
+   * @minimum 1
    */
   max_count?: number;
   asset_requirements?: AssetRequirements;
@@ -16566,6 +17595,8 @@ export interface SellerAgentReference {
   agent_url: string;
   /**
    * Reserved for a future registry-assigned stable seller identifier. Not used today — senders MUST NOT populate this field until a registry is defined. When a future release populates both `agent_url` and `id`, `agent_url` remains authoritative and `id` is advisory.
+   * @minLength 1
+   * @pattern ^[a-zA-Z0-9_-]+$
    */
   id?: string;
 }
@@ -16593,14 +17624,18 @@ export type RestrictedAttribute =
 export interface SignalDefinition {
   /**
    * Signal identifier within this data provider's catalog
+   * @pattern ^[a-zA-Z0-9_-]+$
    */
   id: string;
   /**
    * Human-readable signal name
+   * @minLength 1
+   * @maxLength 255
    */
   name: string;
   /**
    * Detailed description of what this signal represents and how it's derived
+   * @maxLength 2000
    */
   description?: string;
   value_type: SignalValueType;
@@ -16670,10 +17705,14 @@ export interface StoreItem {
   location: {
     /**
      * Latitude in decimal degrees (WGS 84).
+     * @minimum -90
+     * @maximum 90
      */
     lat: number;
     /**
      * Longitude in decimal degrees (WGS 84).
+     * @minimum -180
+     * @maximum 180
      */
     lng: number;
   };
@@ -16699,6 +17738,7 @@ export interface StoreItem {
     postal_code?: string;
     /**
      * ISO 3166-1 alpha-2 country code.
+     * @pattern ^[A-Z]{2}$
      */
     country?: string;
   };
@@ -16753,6 +17793,7 @@ export interface VehicleItem {
   model: string;
   /**
    * Model year.
+   * @minimum 1900
    */
   year: number;
   price?: Price;
@@ -16774,6 +17815,7 @@ export interface VehicleItem {
   mileage?: {
     /**
      * Mileage value.
+     * @minimum 0
      */
     value: number;
     /**
@@ -16807,10 +17849,14 @@ export interface VehicleItem {
   location?: {
     /**
      * Latitude in decimal degrees (WGS 84).
+     * @minimum -90
+     * @maximum 90
      */
     lat: number;
     /**
      * Longitude in decimal degrees (WGS 84).
+     * @minimum -180
+     * @maximum 180
      */
     lng: number;
   };
@@ -17226,6 +18272,7 @@ export interface AdCPExtensionFileSchema {
   $schema: 'http://json-schema.org/draft-07/schema#';
   /**
    * Extension ID following pattern /schemas/extensions/{namespace}.json
+   * @pattern ^\/schemas\/extensions\/[a-z][a-z0-9_]*\.json$
    */
   $id: string;
   /**
@@ -17238,10 +18285,12 @@ export interface AdCPExtensionFileSchema {
   description: string;
   /**
    * Minimum AdCP version this extension is compatible with (e.g., '2.5'). Extension will be included in all versioned schema builds >= this version.
+   * @pattern ^\d+\.\d+$
    */
   valid_from: string;
   /**
    * Last AdCP version this extension is compatible with (e.g., '3.0'). Omit if extension is still valid for current and future versions.
+   * @pattern ^\d+\.\d+$
    */
   valid_until?: string;
   /**
@@ -17274,6 +18323,7 @@ export interface AdCPExtensionFileSchema {
 export interface AttributeDefinition {
   /**
    * Unique identifier for this attribute. Used in plan.restricted_attributes, signal-definition.restricted_attributes, and data marketplace catalog entries.
+   * @pattern ^[a-z][a-z0-9_]*$
    */
   attribute_id: string;
   /**
@@ -17343,6 +18393,7 @@ export interface AudienceConstraints {
 export interface PolicyCategoryDefinition {
   /**
    * Unique identifier for this category. Used in plan.policy_categories, signal-definition.policy_categories, and policy-entry.policy_categories.
+   * @pattern ^[a-z][a-z0-9_]*$
    */
   category_id: string;
   /**
@@ -17434,10 +18485,12 @@ export interface AdCPManifest {
   $schema?: string;
   /**
    * Full semver of the AdCP release this manifest describes.
+   * @pattern ^\d+\.\d+\.\d+(-[A-Za-z0-9.-]+)?$
    */
   adcp_version: string;
   /**
    * ISO-8601 timestamp the manifest was generated. SDKs MAY use this for cache invalidation.
+   * @format date-time
    */
   generated_at: string;
   /**
@@ -17666,6 +18719,7 @@ export interface PropertyFeatureResult {
   coverage_status: 'covered' | 'not_covered' | 'pending';
   /**
    * When features were last evaluated for this property
+   * @format date-time
    */
   last_evaluated?: string;
   ext?: ExtensionObject;
@@ -17684,14 +18738,18 @@ export interface PropertyFeatureValue {
   unit?: string;
   /**
    * Confidence score for this value (0-1)
+   * @minimum 0
+   * @maximum 1
    */
   confidence?: number;
   /**
    * When this specific value was measured
+   * @format date-time
    */
   measured_at?: string;
   /**
    * When this certification/value expires (for time-limited certifications)
+   * @format date-time
    */
   expires_at?: string;
   /**
@@ -17732,6 +18790,9 @@ export interface PropertyFeature {
 export interface PropertyListChangedWebhook {
   /**
    * Sender-generated key stable across retries of the same webhook event. Governance agents MUST generate a cryptographically random value (UUID v4 recommended) per distinct list-change event and reuse the same key on every retry. Recipients MUST dedupe by this key, scoped to the authenticated sender identity (HMAC secret or Bearer credential) — keys from different governance agents are independent.
+   * @minLength 16
+   * @maxLength 255
+   * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   idempotency_key: string;
   /**
@@ -17765,10 +18826,12 @@ export interface PropertyListChangedWebhook {
   };
   /**
    * When the list was re-resolved
+   * @format date-time
    */
   resolved_at: string;
   /**
    * When the consumer should refresh from the governance agent
+   * @format date-time
    */
   cache_valid_until?: string;
   /**

--- a/src/lib/types/schemas.generated.ts
+++ b/src/lib/types/schemas.generated.ts
@@ -1,5 +1,5 @@
 // Generated Zod v4 schemas from TypeScript types
-// Generated at: 2026-05-11T08:48:10.724Z
+// Generated at: 2026-05-16T10:00:13.471Z
 // Sources:
 //   - core.generated.ts (core types)
 //   - tools.generated.ts (tool types)
@@ -45,7 +45,7 @@ export const PostalCodeSystemSchema = z.union([z.literal("us_zip"), z.literal("u
 export const DayOfWeekSchema = z.union([z.literal("monday"), z.literal("tuesday"), z.literal("wednesday"), z.literal("thursday"), z.literal("friday"), z.literal("saturday"), z.literal("sunday")]);
 
 export const DurationSchema = z.object({
-    interval: z.number(),
+    interval: z.number().min(1),
     unit: z.union([z.literal("seconds"), z.literal("minutes"), z.literal("hours"), z.literal("days"), z.literal("campaign")])
 }).passthrough();
 
@@ -78,11 +78,11 @@ export const OptimizationGoalSchema = z.union([z.object({
                 kind: z.literal("threshold_rate"),
                 value: z.number()
             }).passthrough()]).optional(),
-        priority: z.number().optional()
+        priority: z.number().min(1).optional()
     }).passthrough(), z.object({
         kind: z.literal("event"),
         event_sources: z.array(z.object({
-            event_source_id: z.string(),
+            event_source_id: z.string().min(1),
             event_type: EventTypeSchema,
             custom_event_name: z.string().optional(),
             value_field: z.string().optional(),
@@ -101,42 +101,42 @@ export const OptimizationGoalSchema = z.union([z.object({
             post_click: DurationSchema,
             post_view: DurationSchema.optional()
         }).passthrough().optional(),
-        priority: z.number().optional()
+        priority: z.number().min(1).optional()
     }).passthrough()]);
 
 export const ExtensionObjectSchema = z.object({}).passthrough();
 
 export const BrandReferenceSchema = z.object({
-    domain: z.string(),
+    domain: z.string().regex(/^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/),
     brand_id: BrandIDSchema.optional(),
     industries: z.array(z.string()).optional(),
     data_subject_contestation: z.record(z.string(), z.unknown()).optional()
 }).passthrough();
 
 export const BusinessEntitySchema = z.object({
-    legal_name: z.string(),
-    vat_id: z.string().optional(),
-    tax_id: z.string().optional(),
-    registration_number: z.string().optional(),
+    legal_name: z.string().max(200),
+    vat_id: z.string().regex(/^[A-Z]{2}[A-Z0-9]{2,13}$/).optional(),
+    tax_id: z.string().max(30).optional(),
+    registration_number: z.string().max(50).optional(),
     address: z.object({
-        street: z.string(),
-        city: z.string(),
-        postal_code: z.string(),
-        region: z.string().optional(),
-        country: z.string()
+        street: z.string().max(200),
+        city: z.string().max(100),
+        postal_code: z.string().max(20),
+        region: z.string().max(100).optional(),
+        country: z.string().regex(/^[A-Z]{2}$/)
     }).passthrough().optional(),
     contacts: z.array(z.object({
         role: z.union([z.literal("billing"), z.literal("legal"), z.literal("creative"), z.literal("general")]),
-        name: z.string().optional(),
-        email: z.string().optional(),
-        phone: z.string().optional()
+        name: z.string().max(200).optional(),
+        email: z.email().optional(),
+        phone: z.string().max(30).optional()
     }).passthrough()).optional(),
     bank: z.object({
-        account_holder: z.string(),
-        iban: z.string().optional(),
-        bic: z.string().optional(),
-        routing_number: z.string().optional(),
-        account_number: z.string().optional()
+        account_holder: z.string().max(200),
+        iban: z.string().regex(/^[A-Z]{2}[0-9]{2}[A-Z0-9]{4,30}$/).optional(),
+        bic: z.string().regex(/^[A-Z]{4}[A-Z]{2}[A-Z0-9]{2}([A-Z0-9]{3})?$/).optional(),
+        routing_number: z.string().max(30).optional(),
+        account_number: z.string().max(30).optional()
     }).passthrough().optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -148,16 +148,16 @@ export const PriceBreakdownSchema = z.object({
 
 export const FormatReferenceStructuredObjectSchema = z.object({
     agent_url: z.string(),
-    id: z.string(),
-    width: z.number().optional(),
-    height: z.number().optional(),
-    duration_ms: z.number().optional()
+    id: z.string().regex(/^[a-zA-Z0-9_-]+$/),
+    width: z.number().min(1).optional(),
+    height: z.number().min(1).optional(),
+    duration_ms: z.number().min(1).optional()
 }).passthrough();
 
 export const MeasurementTermsSchema = z.object({
     billing_measurement: z.object({
         vendor: BrandReferenceSchema,
-        max_variance_percent: z.number().optional(),
+        max_variance_percent: z.number().min(0).optional(),
         measurement_window: z.string().optional()
     }).passthrough().optional(),
     makegood_policy: z.object({
@@ -167,14 +167,14 @@ export const MeasurementTermsSchema = z.object({
 
 export const PerformanceStandardSchema = z.object({
     metric: PerformanceStandardMetricSchema,
-    threshold: z.number(),
+    threshold: z.number().min(0).max(1),
     standard: ViewabilityStandardSchema.optional(),
     vendor: BrandReferenceSchema
 }).passthrough();
 
 export const CreativeAssignmentSchema = z.object({
     creative_id: z.string(),
-    weight: z.number().optional(),
+    weight: z.number().min(0).max(100).optional(),
     placement_ids: z.array(z.string()).optional()
 }).passthrough();
 
@@ -196,28 +196,28 @@ export const CatalogFieldMappingSchema = z.object({
 
 export const DaypartTargetSchema = z.object({
     days: z.array(DayOfWeekSchema),
-    start_hour: z.number(),
-    end_hour: z.number(),
+    start_hour: z.number().min(0).max(23),
+    end_hour: z.number().min(1).max(24),
     label: z.string().optional()
 }).passthrough();
 
 export const FrequencyCapSchema = z.object({
     suppress: DurationSchema.optional(),
-    suppress_minutes: z.number().optional(),
-    max_impressions: z.number().optional(),
+    suppress_minutes: z.number().min(0).optional(),
+    max_impressions: z.number().min(1).optional(),
     per: ReachUnitSchema.optional(),
     window: DurationSchema.optional()
 }).passthrough();
 
 export const PropertyListReferenceSchema = z.object({
     agent_url: z.string(),
-    list_id: z.string(),
+    list_id: z.string().min(1),
     auth_token: z.string().optional()
 }).passthrough();
 
 export const CollectionListReferenceSchema = z.object({
     agent_url: z.string(),
-    list_id: z.string(),
+    list_id: z.string().min(1),
     auth_token: z.string().optional()
 }).passthrough();
 
@@ -253,8 +253,8 @@ export const ProvenanceSchema = z.object({
         agent_url: z.string().optional(),
         role: z.union([z.literal("creator"), z.literal("advertiser"), z.literal("agency"), z.literal("platform"), z.literal("tool")])
     }).passthrough().optional(),
-    declared_at: z.string().optional(),
-    created_time: z.string().optional(),
+    declared_at: z.iso.datetime().optional(),
+    created_time: z.iso.datetime().optional(),
     c2pa: z.object({
         manifest_url: z.string()
     }).passthrough().optional(),
@@ -267,7 +267,7 @@ export const ProvenanceSchema = z.object({
             label_text: z.string().optional(),
             render_guidance: z.object({
                 persistence: DisclosurePersistenceSchema.optional(),
-                min_duration_ms: z.number().optional(),
+                min_duration_ms: z.number().min(1).optional(),
                 positions: z.array(DisclosurePositionSchema).optional(),
                 ext: ExtensionObjectSchema.optional()
             }).passthrough().optional()
@@ -275,9 +275,9 @@ export const ProvenanceSchema = z.object({
     }).passthrough().optional(),
     verification: z.array(z.object({
         verified_by: z.string(),
-        verified_time: z.string().optional(),
+        verified_time: z.iso.datetime().optional(),
         result: z.union([z.literal("authentic"), z.literal("ai_generated"), z.literal("ai_modified"), z.literal("inconclusive")]),
-        confidence: z.number().optional(),
+        confidence: z.number().min(0).max(1).optional(),
         details_url: z.string().optional()
     }).passthrough()).optional(),
     ext: ExtensionObjectSchema.optional()
@@ -325,14 +325,14 @@ export const CreativeIdentifierTypeSchema = z.union([z.literal("ad_id"), z.liter
 
 export const IndustryIdentifierSchema = z.object({
     type: CreativeIdentifierTypeSchema,
-    value: z.string()
+    value: z.string().max(64)
 }).passthrough();
 
 export const ImageAssetSchema = z.object({
     asset_type: z.literal("image"),
     url: z.string(),
-    width: z.number(),
-    height: z.number(),
+    width: z.number().min(1),
+    height: z.number().min(1),
     format: z.string().optional(),
     alt_text: z.string().optional(),
     provenance: ProvenanceSchema.optional()
@@ -341,13 +341,13 @@ export const ImageAssetSchema = z.object({
 export const VideoAssetSchema = z.object({
     asset_type: z.literal("video"),
     url: z.string(),
-    width: z.number(),
-    height: z.number(),
-    duration_ms: z.number().optional(),
-    file_size_bytes: z.number().optional(),
+    width: z.number().min(1),
+    height: z.number().min(1),
+    duration_ms: z.number().min(1).optional(),
+    file_size_bytes: z.number().min(1).optional(),
     container_format: z.string().optional(),
     video_codec: z.string().optional(),
-    video_bitrate_kbps: z.number().optional(),
+    video_bitrate_kbps: z.number().min(1).optional(),
     frame_rate: z.string().optional(),
     frame_rate_type: FrameRateTypeSchema.optional(),
     scan_type: ScanTypeSchema.optional(),
@@ -363,7 +363,7 @@ export const VideoAssetSchema = z.object({
     audio_sampling_rate_hz: z.number().optional(),
     audio_channels: AudioChannelLayoutSchema.optional(),
     audio_bit_depth: z.union([z.literal(16), z.literal(24), z.literal(32)]).optional(),
-    audio_bitrate_kbps: z.number().optional(),
+    audio_bitrate_kbps: z.number().min(1).optional(),
     audio_loudness_lufs: z.number().optional(),
     audio_true_peak_dbfs: z.number().optional(),
     captions_url: z.string().optional(),
@@ -375,14 +375,14 @@ export const VideoAssetSchema = z.object({
 export const AudioAssetSchema = z.object({
     asset_type: z.literal("audio"),
     url: z.string(),
-    duration_ms: z.number().optional(),
-    file_size_bytes: z.number().optional(),
+    duration_ms: z.number().min(0).optional(),
+    file_size_bytes: z.number().min(1).optional(),
     container_format: z.string().optional(),
     codec: z.string().optional(),
     sampling_rate_hz: z.number().optional(),
     channels: AudioChannelLayoutSchema.optional(),
     bit_depth: z.union([z.literal(16), z.literal(24), z.literal(32)]).optional(),
-    bitrate_kbps: z.number().optional(),
+    bitrate_kbps: z.number().min(1).optional(),
     loudness_lufs: z.number().optional(),
     true_peak_dbfs: z.number().optional(),
     transcript_url: z.string().optional(),
@@ -434,7 +434,7 @@ export const WebhookAssetSchema = z.object({
     asset_type: z.literal("webhook"),
     url: z.string(),
     method: HTTPMethodSchema.optional(),
-    timeout_ms: z.number().optional(),
+    timeout_ms: z.number().min(10).max(5000).optional(),
     supported_macros: z.array(z.union([UniversalMacroSchema, z.string()])).optional(),
     required_macros: z.array(z.union([UniversalMacroSchema, z.string()])).optional(),
     response_type: WebhookResponseTypeSchema,
@@ -467,9 +467,9 @@ export const ReferenceAssetSchema = z.object({
     description: z.string().optional()
 }).passthrough();
 
-export const PropertyIDSchema = z.string();
+export const PropertyIDSchema = z.string().regex(/^[a-z0-9_]+$/);
 
-export const PropertyTagSchema = z.string();
+export const PropertyTagSchema = z.string().regex(/^[a-z0-9_]+$/);
 
 export const MediaChannelSchema = z.union([z.literal("display"), z.literal("olv"), z.literal("social"), z.literal("search"), z.literal("ctv"), z.literal("linear_tv"), z.literal("radio"), z.literal("streaming_audio"), z.literal("podcast"), z.literal("dooh"), z.literal("ooh"), z.literal("print"), z.literal("cinema"), z.literal("email"), z.literal("gaming"), z.literal("retail_media"), z.literal("influencer"), z.literal("affiliate"), z.literal("product_placement"), z.literal("sponsored_intelligence")]);
 
@@ -482,9 +482,9 @@ export const PriceAdjustmentKindSchema = z.union([z.literal("fee"), z.literal("d
 export const DemographicSystemSchema = z.union([z.literal("nielsen"), z.literal("barb"), z.literal("agf"), z.literal("oztam"), z.literal("mediametrie"), z.literal("custom")]);
 
 export const ForecastRangeSchema = z.object({
-    low: z.number().optional(),
-    mid: z.number().optional(),
-    high: z.number().optional()
+    low: z.number().min(0).optional(),
+    mid: z.number().min(0).optional(),
+    high: z.number().min(0).optional()
 }).passthrough();
 
 export const ForecastRangeUnitSchema = z.union([z.literal("spend"), z.literal("availability"), z.literal("reach_freq"), z.literal("weekly"), z.literal("daily"), z.literal("clicks"), z.literal("conversions"), z.literal("package")]);
@@ -500,14 +500,14 @@ export const CoBrandingRequirementSchema = z.union([z.literal("required"), z.lit
 export const LandingPageRequirementSchema = z.union([z.literal("any"), z.literal("retailer_site_only"), z.literal("must_include_retailer")]);
 
 export const DataProviderSignalSelectorSchema = z.union([z.object({
-        data_provider_domain: z.string(),
+        data_provider_domain: z.string().regex(/^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/),
         selection_type: z.literal("all")
     }).passthrough(), z.object({
-        data_provider_domain: z.string(),
+        data_provider_domain: z.string().regex(/^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/),
         selection_type: z.literal("by_id"),
         signal_ids: z.array(z.string())
     }).passthrough(), z.object({
-        data_provider_domain: z.string(),
+        data_provider_domain: z.string().regex(/^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/),
         selection_type: z.literal("by_tag"),
         signal_tags: z.array(z.string())
     }).passthrough()]);
@@ -531,14 +531,14 @@ export const TMPResponseTypeSchema = z.union([z.literal("activation"), z.literal
 export const UIDTypeSchema = z.union([z.literal("rampid"), z.literal("rampid_derived"), z.literal("id5"), z.literal("uid2"), z.literal("euid"), z.literal("pairid"), z.literal("maid"), z.literal("hashed_email"), z.literal("publisher_first_party"), z.literal("other")]);
 
 export const PublisherPropertySelectorSchema = z.union([z.object({
-        publisher_domain: z.string(),
+        publisher_domain: z.string().regex(/^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/),
         selection_type: z.literal("all")
     }).passthrough(), z.object({
-        publisher_domain: z.string(),
+        publisher_domain: z.string().regex(/^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/),
         selection_type: z.literal("by_id"),
         property_ids: z.array(PropertyIDSchema)
     }).passthrough(), z.object({
-        publisher_domain: z.string(),
+        publisher_domain: z.string().regex(/^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/),
         selection_type: z.literal("by_tag"),
         property_tags: z.array(PropertyTagSchema)
     }).passthrough()]);
@@ -562,8 +562,8 @@ export const CancellationPolicySchema = z.object({
     notice_period: DurationSchema,
     cancellation_fee: z.object({
         type: z.union([z.literal("percent_remaining"), z.literal("full_commitment"), z.literal("fixed_fee"), z.literal("none")]),
-        rate: z.number().optional(),
-        amount: z.number().optional()
+        rate: z.number().min(0).max(1).optional(),
+        amount: z.number().min(0).optional()
     }).passthrough()
 }).passthrough();
 
@@ -575,26 +575,26 @@ export const CreativePolicySchema = z.object({
 }).passthrough();
 
 export const CollectionSelectorSchema = z.object({
-    publisher_domain: z.string(),
+    publisher_domain: z.string().regex(/^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/),
     collection_ids: z.array(z.string())
 }).passthrough();
 
 export const PriceGuidanceSchema = z.object({
-    p25: z.number().optional(),
-    p50: z.number().optional(),
-    p75: z.number().optional(),
-    p90: z.number().optional()
+    p25: z.number().min(0).optional(),
+    p50: z.number().min(0).optional(),
+    p75: z.number().min(0).optional(),
+    p90: z.number().min(0).optional()
 }).passthrough();
 
 export const VCPMPricingOptionSchema = z.object({
     pricing_option_id: z.string(),
     pricing_model: z.literal("vcpm"),
-    currency: z.string(),
-    fixed_price: z.number().optional(),
-    floor_price: z.number().optional(),
+    currency: z.string().regex(/^[A-Z]{3}$/),
+    fixed_price: z.number().min(0).optional(),
+    floor_price: z.number().min(0).optional(),
     max_bid: z.boolean().optional(),
     price_guidance: PriceGuidanceSchema.optional(),
-    min_spend_per_package: z.number().optional(),
+    min_spend_per_package: z.number().min(0).optional(),
     price_breakdown: PriceBreakdownSchema.optional(),
     eligible_adjustments: z.array(PriceAdjustmentKindSchema).optional()
 }).passthrough();
@@ -602,12 +602,12 @@ export const VCPMPricingOptionSchema = z.object({
 export const CPCPricingOptionSchema = z.object({
     pricing_option_id: z.string(),
     pricing_model: z.literal("cpc"),
-    currency: z.string(),
-    fixed_price: z.number().optional(),
-    floor_price: z.number().optional(),
+    currency: z.string().regex(/^[A-Z]{3}$/),
+    fixed_price: z.number().min(0).optional(),
+    floor_price: z.number().min(0).optional(),
     max_bid: z.boolean().optional(),
     price_guidance: PriceGuidanceSchema.optional(),
-    min_spend_per_package: z.number().optional(),
+    min_spend_per_package: z.number().min(0).optional(),
     price_breakdown: PriceBreakdownSchema.optional(),
     eligible_adjustments: z.array(PriceAdjustmentKindSchema).optional()
 }).passthrough();
@@ -615,12 +615,12 @@ export const CPCPricingOptionSchema = z.object({
 export const CPCVPricingOptionSchema = z.object({
     pricing_option_id: z.string(),
     pricing_model: z.literal("cpcv"),
-    currency: z.string(),
-    fixed_price: z.number().optional(),
-    floor_price: z.number().optional(),
+    currency: z.string().regex(/^[A-Z]{3}$/),
+    fixed_price: z.number().min(0).optional(),
+    floor_price: z.number().min(0).optional(),
     max_bid: z.boolean().optional(),
     price_guidance: PriceGuidanceSchema.optional(),
-    min_spend_per_package: z.number().optional(),
+    min_spend_per_package: z.number().min(0).optional(),
     price_breakdown: PriceBreakdownSchema.optional(),
     eligible_adjustments: z.array(PriceAdjustmentKindSchema).optional()
 }).passthrough();
@@ -628,17 +628,17 @@ export const CPCVPricingOptionSchema = z.object({
 export const CPVPricingOptionSchema = z.object({
     pricing_option_id: z.string(),
     pricing_model: z.literal("cpv"),
-    currency: z.string(),
-    fixed_price: z.number().optional(),
-    floor_price: z.number().optional(),
+    currency: z.string().regex(/^[A-Z]{3}$/),
+    fixed_price: z.number().min(0).optional(),
+    floor_price: z.number().min(0).optional(),
     max_bid: z.boolean().optional(),
     price_guidance: PriceGuidanceSchema.optional(),
     parameters: z.object({
         view_threshold: z.union([z.number(), z.object({
-                duration_seconds: z.number()
+                duration_seconds: z.number().min(1)
             }).passthrough()])
     }).passthrough(),
-    min_spend_per_package: z.number().optional(),
+    min_spend_per_package: z.number().min(0).optional(),
     price_breakdown: PriceBreakdownSchema.optional(),
     eligible_adjustments: z.array(PriceAdjustmentKindSchema).optional()
 }).passthrough();
@@ -646,16 +646,16 @@ export const CPVPricingOptionSchema = z.object({
 export const CPPPricingOptionSchema = z.object({
     pricing_option_id: z.string(),
     pricing_model: z.literal("cpp"),
-    currency: z.string(),
-    fixed_price: z.number().optional(),
-    floor_price: z.number().optional(),
+    currency: z.string().regex(/^[A-Z]{3}$/),
+    fixed_price: z.number().min(0).optional(),
+    floor_price: z.number().min(0).optional(),
     price_guidance: PriceGuidanceSchema.optional(),
     parameters: z.object({
         demographic_system: DemographicSystemSchema.optional(),
         demographic: z.string(),
-        min_points: z.number().optional()
+        min_points: z.number().min(0).optional()
     }).passthrough(),
-    min_spend_per_package: z.number().optional(),
+    min_spend_per_package: z.number().min(0).optional(),
     price_breakdown: PriceBreakdownSchema.optional(),
     eligible_adjustments: z.array(PriceAdjustmentKindSchema).optional()
 }).passthrough();
@@ -666,44 +666,44 @@ export const CPAPricingOptionSchema = z.object({
     event_type: EventTypeSchema,
     custom_event_name: z.string().optional(),
     event_source_id: z.string().optional(),
-    currency: z.string(),
+    currency: z.string().regex(/^[A-Z]{3}$/),
     fixed_price: z.number(),
-    min_spend_per_package: z.number().optional(),
+    min_spend_per_package: z.number().min(0).optional(),
     price_breakdown: PriceBreakdownSchema.optional(),
     eligible_adjustments: z.array(PriceAdjustmentKindSchema).optional()
 }).passthrough();
 
 export const DoohParametersSchema = z.object({
     type: z.literal("dooh"),
-    sov_percentage: z.number().optional(),
-    loop_duration_seconds: z.number().optional(),
-    min_plays_per_hour: z.number().optional(),
+    sov_percentage: z.number().min(0).max(100).optional(),
+    loop_duration_seconds: z.number().min(1).optional(),
+    min_plays_per_hour: z.number().min(1).optional(),
     venue_package: z.string().optional(),
-    duration_hours: z.number().optional(),
+    duration_hours: z.number().min(0).optional(),
     daypart: z.string().optional(),
-    estimated_impressions: z.number().optional()
+    estimated_impressions: z.number().min(0).optional()
 }).passthrough();
 
 export const TimeBasedPricingOptionSchema = z.object({
     pricing_option_id: z.string(),
     pricing_model: z.literal("time"),
-    currency: z.string(),
-    fixed_price: z.number().optional(),
-    floor_price: z.number().optional(),
+    currency: z.string().regex(/^[A-Z]{3}$/),
+    fixed_price: z.number().min(0).optional(),
+    floor_price: z.number().min(0).optional(),
     price_guidance: PriceGuidanceSchema.optional(),
     parameters: z.object({
         time_unit: z.union([z.literal("hour"), z.literal("day"), z.literal("week"), z.literal("month")]),
-        min_duration: z.number().optional(),
-        max_duration: z.number().optional()
+        min_duration: z.number().min(1).optional(),
+        max_duration: z.number().min(1).optional()
     }).passthrough(),
-    min_spend_per_package: z.number().optional(),
+    min_spend_per_package: z.number().min(0).optional(),
     price_breakdown: PriceBreakdownSchema.optional(),
     eligible_adjustments: z.array(PriceAdjustmentKindSchema).optional()
 }).passthrough();
 
 export const ForecastPointSchema = z.object({
-    label: z.string().optional(),
-    budget: z.number().optional(),
+    label: z.string().max(128).optional(),
+    budget: z.number().min(0).optional(),
     metrics: z.record(z.string(), ForecastRangeSchema).and(z.object({
         audience_size: ForecastRangeSchema.optional(),
         reach: ForecastRangeSchema.optional(),
@@ -732,10 +732,10 @@ export const GeographicBreakdownSupportSchema = z.object({
 }).passthrough();
 
 export const MeasurementWindowSchema = z.object({
-    window_id: z.string(),
-    description: z.string().optional(),
-    duration_days: z.number(),
-    expected_availability_days: z.number().optional(),
+    window_id: z.string().max(50),
+    description: z.string().max(500).optional(),
+    duration_days: z.number().min(0),
+    expected_availability_days: z.number().min(0).optional(),
     is_guarantee_basis: z.boolean().optional()
 }).passthrough();
 
@@ -752,8 +752,8 @@ export const ContentRatingSchema = z.object({
 export const SpecialSchema = z.object({
     name: z.string(),
     category: SpecialCategorySchema.optional(),
-    starts: z.string().optional(),
-    ends: z.string().optional()
+    starts: z.iso.datetime().optional(),
+    ends: z.iso.datetime().optional()
 }).passthrough();
 
 export const TalentSchema = z.object({
@@ -763,16 +763,16 @@ export const TalentSchema = z.object({
 }).passthrough();
 
 export const AdInventoryConfigurationSchema = z.object({
-    expected_breaks: z.number(),
-    total_ad_seconds: z.number().optional(),
-    max_ad_duration_seconds: z.number().optional(),
+    expected_breaks: z.number().min(0),
+    total_ad_seconds: z.number().min(0).optional(),
+    max_ad_duration_seconds: z.number().min(1).optional(),
     unplanned_breaks: z.boolean().optional(),
     supported_formats: z.array(z.string()).optional()
 }).passthrough();
 
 export const MaterialDeadlineSchema = z.object({
     stage: z.string(),
-    due_at: z.string(),
+    due_at: z.iso.datetime(),
     label: z.string().optional()
 }).passthrough();
 
@@ -800,7 +800,7 @@ export const AdCPProtocolSchema = z.union([z.literal("media-buy"), z.literal("si
 export const TaskStatusSchema = z.union([z.literal("submitted"), z.literal("working"), z.literal("input-required"), z.literal("completed"), z.literal("canceled"), z.literal("failed"), z.literal("rejected"), z.literal("auth-required"), z.literal("unknown")]);
 
 export const GetProductsAsyncWorkingSchema = z.object({
-    percentage: z.number().optional(),
+    percentage: z.number().min(0).max(100).optional(),
     current_step: z.string().optional(),
     total_steps: z.number().optional(),
     step_number: z.number().optional(),
@@ -809,16 +809,16 @@ export const GetProductsAsyncWorkingSchema = z.object({
 }).passthrough();
 
 export const GetProductsAsyncSubmittedSchema = z.object({
-    estimated_completion: z.string().optional(),
+    estimated_completion: z.iso.datetime().optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
 export const CreateMediaBuyAsyncWorkingSchema = z.object({
-    percentage: z.number().optional(),
+    percentage: z.number().min(0).max(100).optional(),
     current_step: z.string().optional(),
-    total_steps: z.number().optional(),
-    step_number: z.number().optional(),
+    total_steps: z.number().min(1).optional(),
+    step_number: z.number().min(1).optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -829,10 +829,10 @@ export const CreateMediaBuyAsyncSubmittedSchema = z.object({
 }).passthrough();
 
 export const UpdateMediaBuyAsyncWorkingSchema = z.object({
-    percentage: z.number().optional(),
+    percentage: z.number().min(0).max(100).optional(),
     current_step: z.string().optional(),
-    total_steps: z.number().optional(),
-    step_number: z.number().optional(),
+    total_steps: z.number().min(1).optional(),
+    step_number: z.number().min(1).optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -849,10 +849,10 @@ export const UpdateMediaBuyAsyncSubmittedSchema = z.object({
 }).passthrough();
 
 export const BuildCreativeAsyncWorkingSchema = z.object({
-    percentage: z.number().optional(),
+    percentage: z.number().min(0).max(100).optional(),
     current_step: z.string().optional(),
-    total_steps: z.number().optional(),
-    step_number: z.number().optional(),
+    total_steps: z.number().min(1).optional(),
+    step_number: z.number().min(1).optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -863,12 +863,12 @@ export const BuildCreativeAsyncSubmittedSchema = z.object({
 }).passthrough();
 
 export const SyncCreativesAsyncWorkingSchema = z.object({
-    percentage: z.number().optional(),
+    percentage: z.number().min(0).max(100).optional(),
     current_step: z.string().optional(),
-    total_steps: z.number().optional(),
-    step_number: z.number().optional(),
-    creatives_processed: z.number().optional(),
-    creatives_total: z.number().optional(),
+    total_steps: z.number().min(1).optional(),
+    step_number: z.number().min(1).optional(),
+    creatives_processed: z.number().min(0).optional(),
+    creatives_total: z.number().min(0).optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -885,14 +885,14 @@ export const SyncCreativesAsyncSubmittedSchema = z.object({
 }).passthrough();
 
 export const SyncCatalogsAsyncWorkingSchema = z.object({
-    percentage: z.number().optional(),
+    percentage: z.number().min(0).max(100).optional(),
     current_step: z.string().optional(),
-    total_steps: z.number().optional(),
-    step_number: z.number().optional(),
-    catalogs_processed: z.number().optional(),
-    catalogs_total: z.number().optional(),
-    items_processed: z.number().optional(),
-    items_total: z.number().optional(),
+    total_steps: z.number().min(1).optional(),
+    step_number: z.number().min(1).optional(),
+    catalogs_processed: z.number().min(0).optional(),
+    catalogs_total: z.number().min(0).optional(),
+    items_processed: z.number().min(0).optional(),
+    items_total: z.number().min(0).optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -914,12 +914,12 @@ export const MediaBuyValidActionSchema = z.union([z.literal("pause"), z.literal(
 
 export const SignalIDSchema = z.union([z.object({
         source: z.literal("catalog"),
-        data_provider_domain: z.string(),
-        id: z.string()
+        data_provider_domain: z.string().regex(/^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/),
+        id: z.string().regex(/^[a-zA-Z0-9_-]+$/)
     }).passthrough(), z.object({
         source: z.literal("agent"),
         agent_url: z.string(),
-        id: z.string()
+        id: z.string().regex(/^[a-zA-Z0-9_-]+$/)
     }).passthrough()]);
 
 export const RightUseSchema = z.union([z.literal("likeness"), z.literal("voice"), z.literal("name"), z.literal("endorsement"), z.literal("motion_capture"), z.literal("signature"), z.literal("catchphrase"), z.literal("sync"), z.literal("background_music"), z.literal("editorial"), z.literal("commercial"), z.literal("ai_generated_image")]);
@@ -932,8 +932,8 @@ export const PreviewRenderSchema = z.union([z.object({
         preview_url: z.string(),
         role: z.string(),
         dimensions: z.object({
-            width: z.number(),
-            height: z.number()
+            width: z.number().min(0),
+            height: z.number().min(0)
         }).passthrough().optional(),
         embedding: z.object({
             recommended_sandbox: z.string().optional(),
@@ -947,8 +947,8 @@ export const PreviewRenderSchema = z.union([z.object({
         preview_html: z.string(),
         role: z.string(),
         dimensions: z.object({
-            width: z.number(),
-            height: z.number()
+            width: z.number().min(0),
+            height: z.number().min(0)
         }).passthrough().optional(),
         embedding: z.object({
             recommended_sandbox: z.string().optional(),
@@ -963,8 +963,8 @@ export const PreviewRenderSchema = z.union([z.object({
         preview_html: z.string(),
         role: z.string(),
         dimensions: z.object({
-            width: z.number(),
-            height: z.number()
+            width: z.number().min(0),
+            height: z.number().min(0)
         }).passthrough().optional(),
         embedding: z.object({
             recommended_sandbox: z.string().optional(),
@@ -981,11 +981,11 @@ export const CatalogActionSchema = z.union([z.literal("created"), z.literal("upd
 export const CatalogItemStatusSchema = z.union([z.literal("approved"), z.literal("pending"), z.literal("rejected"), z.literal("warning")]);
 
 export const ErrorSchema = z.object({
-    code: z.string(),
+    code: z.string().min(1).max(64),
     message: z.string(),
     field: z.string().optional(),
     suggestion: z.string().optional(),
-    retry_after: z.number().optional(),
+    retry_after: z.number().min(1).max(3600).optional(),
     issues: z.array(z.object({
         pointer: z.string(),
         message: z.string(),
@@ -999,20 +999,20 @@ export const ErrorSchema = z.object({
 export const PaginationResponseSchema = z.object({
     has_more: z.boolean(),
     cursor: z.string().optional(),
-    total_count: z.number().optional()
+    total_count: z.number().min(0).optional()
 }).passthrough();
 
 export const InsertionOrderSchema = z.object({
-    io_id: z.string(),
+    io_id: z.string().max(255),
     terms: z.object({
-        advertiser: z.string().optional(),
-        publisher: z.string().optional(),
+        advertiser: z.string().max(500).optional(),
+        publisher: z.string().max(500).optional(),
         total_budget: z.object({
-            amount: z.number(),
-            currency: z.string()
+            amount: z.number().min(0),
+            currency: z.string().min(3).max(3)
         }).passthrough().optional(),
-        flight_start: z.string().optional(),
-        flight_end: z.string().optional(),
+        flight_start: z.iso.datetime().optional(),
+        flight_end: z.iso.datetime().optional(),
         payment_terms: z.union([z.literal("net_30"), z.literal("net_60"), z.literal("net_90"), z.literal("prepaid"), z.literal("due_on_receipt")]).optional()
     }).passthrough().optional(),
     terms_url: z.string().optional(),
@@ -1027,22 +1027,22 @@ export const DeliveryForecastSchema = z.object({
     currency: z.string(),
     demographic_system: DemographicSystemSchema.optional(),
     demographic: z.string().optional(),
-    measurement_source: z.string().optional(),
+    measurement_source: z.string().max(64).regex(/^[a-z0-9_]+$/).optional(),
     reach_unit: ReachUnitSchema.optional(),
-    generated_at: z.string().optional(),
-    valid_until: z.string().optional(),
+    generated_at: z.iso.datetime().optional(),
+    valid_until: z.iso.datetime().optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
 export const ProductAllocationSchema = z.object({
     product_id: z.string(),
-    allocation_percentage: z.number(),
+    allocation_percentage: z.number().min(0).max(100),
     pricing_option_id: z.string().optional(),
     rationale: z.string().optional(),
-    sequence: z.number().optional(),
+    sequence: z.number().min(1).optional(),
     tags: z.array(z.string()).optional(),
-    start_time: z.string().optional(),
-    end_time: z.string().optional(),
+    start_time: z.iso.datetime().optional(),
+    end_time: z.iso.datetime().optional(),
     daypart_targets: z.array(DaypartTargetSchema).optional(),
     forecast: DeliveryForecastSchema.optional(),
     ext: ExtensionObjectSchema.optional()
@@ -1055,34 +1055,34 @@ export const AccountSchema = z.object({
     billing_proxy: z.string().optional(),
     status: AccountStatusSchema,
     brand: BrandReferenceSchema.optional(),
-    operator: z.string().optional(),
+    operator: z.string().regex(/^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/).optional(),
     billing: BillingPartySchema.optional(),
     billing_entity: BusinessEntitySchema.optional(),
     rate_card: z.string().optional(),
     payment_terms: PaymentTermsSchema.optional(),
     credit_limit: z.object({
-        amount: z.number(),
-        currency: z.string()
+        amount: z.number().min(0),
+        currency: z.string().regex(/^[A-Z]{3}$/)
     }).passthrough().optional(),
     setup: z.object({
         url: z.string().optional(),
         message: z.string(),
-        expires_at: z.string().optional()
+        expires_at: z.iso.datetime().optional()
     }).passthrough().optional(),
     account_scope: AccountScopeSchema.optional(),
     governance_agents: z.array(z.object({
-        url: z.string(),
+        url: z.string().regex(/^https:\/\//),
         categories: z.array(z.string()).optional()
     }).passthrough()).optional(),
     reporting_bucket: z.object({
         protocol: CloudStorageProtocolSchema,
-        bucket: z.string(),
-        prefix: z.string().optional(),
-        region: z.string().optional(),
+        bucket: z.string().min(3).max(63).regex(/^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$/),
+        prefix: z.string().max(512).regex(/^[a-zA-Z0-9\/_.-]+$/).optional(),
+        region: z.string().max(64).regex(/^[a-z0-9-]+$/).optional(),
         format: z.union([z.literal("jsonl"), z.literal("csv"), z.literal("parquet"), z.literal("avro"), z.literal("orc")]).optional(),
         compression: z.union([z.literal("gzip"), z.literal("none")]).optional(),
-        file_retention_days: z.number(),
-        setup_instructions: z.string().optional()
+        file_retention_days: z.number().min(1),
+        setup_instructions: z.string().regex(/^https:\/\//).optional()
     }).passthrough().optional(),
     sandbox: z.boolean().optional(),
     ext: ExtensionObjectSchema.optional()
@@ -1106,7 +1106,7 @@ export const AudienceSelectorSchema = z.union([z.object({
         max_value: z.number().optional()
     }).passthrough(), z.object({
         type: z.literal("description"),
-        description: z.string(),
+        description: z.string().min(1).max(2000),
         category: z.string().optional()
     }).passthrough()]);
 
@@ -1119,7 +1119,7 @@ export const CreateMediaBuyErrorSchema = z.object({
 export const CreateMediaBuySubmittedSchema = z.object({
     status: z.literal("submitted"),
     task_id: z.string(),
-    message: z.string().optional(),
+    message: z.string().max(2000).optional(),
     errors: z.array(ErrorSchema).optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
@@ -1139,10 +1139,10 @@ export const UpdateMediaBuyErrorSchema = z.object({
 }).passthrough();
 
 export const CreativeConsumptionSchema = z.object({
-    tokens: z.number().optional(),
-    images_generated: z.number().optional(),
-    renders: z.number().optional(),
-    duration_seconds: z.number().optional()
+    tokens: z.number().min(0).optional(),
+    images_generated: z.number().min(0).optional(),
+    renders: z.number().min(0).optional(),
+    duration_seconds: z.number().min(0).optional()
 }).passthrough();
 
 export const RightsConstraintSchema = z.object({
@@ -1151,12 +1151,12 @@ export const RightsConstraintSchema = z.object({
         url: z.string(),
         id: z.string()
     }).passthrough(),
-    valid_from: z.string().optional(),
-    valid_until: z.string().optional(),
+    valid_from: z.iso.datetime().optional(),
+    valid_until: z.iso.datetime().optional(),
     uses: z.array(RightUseSchema),
     countries: z.array(z.string()).optional(),
     excluded_countries: z.array(z.string()).optional(),
-    impression_cap: z.number().optional(),
+    impression_cap: z.number().min(1).optional(),
     right_type: RightTypeSchema.optional(),
     approval_status: z.union([z.literal("pending"), z.literal("approved"), z.literal("rejected")]).optional(),
     verification_url: z.string().optional(),
@@ -1188,7 +1188,7 @@ export const SyncCreativesSuccessSchema = z.object({
         errors: z.array(ErrorSchema).optional(),
         warnings: z.array(z.string()).optional(),
         preview_url: z.string().optional(),
-        expires_at: z.string().optional(),
+        expires_at: z.iso.datetime().optional(),
         assigned_to: z.array(z.string()).optional(),
         assignment_errors: z.record(z.string(), z.string()).optional()
     }).passthrough()),
@@ -1206,7 +1206,7 @@ export const SyncCreativesErrorSchema = z.object({
 export const SyncCreativesSubmittedSchema = z.object({
     status: z.literal("submitted"),
     task_id: z.string(),
-    message: z.string().optional(),
+    message: z.string().max(2000).optional(),
     errors: z.array(ErrorSchema).optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
@@ -1218,17 +1218,17 @@ export const SyncCatalogsSuccessSchema = z.object({
         catalog_id: z.string(),
         action: CatalogActionSchema,
         platform_id: z.string().optional(),
-        item_count: z.number().optional(),
-        items_approved: z.number().optional(),
-        items_pending: z.number().optional(),
-        items_rejected: z.number().optional(),
+        item_count: z.number().min(0).optional(),
+        items_approved: z.number().min(0).optional(),
+        items_pending: z.number().min(0).optional(),
+        items_rejected: z.number().min(0).optional(),
         item_issues: z.array(z.object({
             item_id: z.string(),
             status: CatalogItemStatusSchema,
             reasons: z.array(z.string()).optional()
         }).passthrough()).optional(),
-        last_synced_at: z.string().optional(),
-        next_fetch_at: z.string().optional(),
+        last_synced_at: z.iso.datetime().optional(),
+        next_fetch_at: z.iso.datetime().optional(),
         changes: z.array(z.string()).optional(),
         errors: z.array(ErrorSchema).optional(),
         warnings: z.array(z.string()).optional()
@@ -1283,17 +1283,17 @@ export const A2UIUserActionSchema = z.object({
         name: z.string(),
         context: z.object({}).passthrough().optional()
     }).passthrough(),
-    timestamp: z.string().optional()
+    timestamp: z.iso.datetime().optional()
 }).passthrough();
 
 export const AuthenticationSchemeSchema = z.union([z.literal("Bearer"), z.literal("HMAC-SHA256")]);
 
 export const PushNotificationConfigSchema = z.object({
     url: z.string(),
-    token: z.string().optional(),
+    token: z.string().min(16).optional(),
     authentication: z.object({
         schemes: z.array(AuthenticationSchemeSchema),
-        credentials: z.string()
+        credentials: z.string().min(32)
     }).passthrough().optional()
 }).passthrough();
 
@@ -1327,14 +1327,14 @@ export const RightsBillingPeriodSchema = z.union([z.literal("daily"), z.literal(
 
 export const RightsTermsSchema = z.object({
     pricing_option_id: z.string(),
-    amount: z.number(),
-    currency: z.string(),
+    amount: z.number().min(0),
+    currency: z.string().regex(/^[A-Z]{3}$/),
     period: RightsBillingPeriodSchema.optional(),
     uses: z.array(RightUseSchema),
-    impression_cap: z.number().optional(),
-    overage_cpm: z.number().optional(),
-    start_date: z.string().optional(),
-    end_date: z.string().optional(),
+    impression_cap: z.number().min(1).optional(),
+    overage_cpm: z.number().min(0).optional(),
+    start_date: z.iso.date().optional(),
+    end_date: z.iso.date().optional(),
     exclusivity: z.object({
         scope: z.string().optional(),
         countries: z.array(z.string()).optional()
@@ -1345,20 +1345,20 @@ export const GenerationCredentialSchema = z.object({
     provider: z.string(),
     rights_key: z.string(),
     uses: z.array(RightUseSchema),
-    expires_at: z.string().optional(),
+    expires_at: z.iso.datetime().optional(),
     endpoint: z.string().optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
 export const CreativeApprovalRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
     rights_id: z.string(),
     creative_id: z.string().optional(),
     creative_url: z.string(),
     creative_format: FormatReferenceStructuredObjectSchema.optional(),
     description: z.string().optional(),
     metadata: z.object({}).passthrough().optional(),
-    idempotency_key: z.string(),
+    idempotency_key: z.string().min(16).max(255).regex(/^[A-Za-z0-9_.:-]{16,255}$/),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -1368,7 +1368,7 @@ export const CreativeApprovedSchema = z.object({
     rights_id: z.string(),
     creative_id: z.string().optional(),
     creative_url: z.string().optional(),
-    approved_at: z.string().optional(),
+    approved_at: z.iso.datetime().optional(),
     conditions: z.array(z.string()).optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
@@ -1403,7 +1403,7 @@ export const CreativeApprovalErrorSchema = z.object({
 }).passthrough();
 
 export const GetBrandIdentityRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
     brand_id: z.string(),
     fields: z.array(z.union([z.literal("description"), z.literal("industries"), z.literal("keller_type"), z.literal("logos"), z.literal("colors"), z.literal("fonts"), z.literal("visual_guidelines"), z.literal("tone"), z.literal("tagline"), z.literal("voice_synthesis"), z.literal("assets"), z.literal("rights")])).optional(),
     use_case: z.string().optional(),
@@ -1449,8 +1449,8 @@ export const GetBrandIdentitySuccessSchema = z.object({
     fonts: z.record(z.string(), z.union([z.string(), z.object({
                 family: z.string(),
                 files: z.array(z.object({
-                    url: z.string(),
-                    weight: z.number().optional(),
+                    url: z.string().regex(/^https:\/\//),
+                    weight: z.number().min(100).max(900).optional(),
                     weight_range: z.array(z.number()).optional(),
                     style: z.union([z.literal("normal"), z.literal("italic"), z.literal("oblique")]).optional()
                 }).passthrough()).optional(),
@@ -1460,8 +1460,8 @@ export const GetBrandIdentitySuccessSchema = z.object({
         primary: z.union([z.string(), z.object({
                 family: z.string(),
                 files: z.array(z.object({
-                    url: z.string(),
-                    weight: z.number().optional(),
+                    url: z.string().regex(/^https:\/\//),
+                    weight: z.number().min(100).max(900).optional(),
                     weight_range: z.array(z.number()).optional(),
                     style: z.union([z.literal("normal"), z.literal("italic"), z.literal("oblique")]).optional()
                 }).passthrough()).optional(),
@@ -1471,8 +1471,8 @@ export const GetBrandIdentitySuccessSchema = z.object({
         secondary: z.union([z.string(), z.object({
                 family: z.string(),
                 files: z.array(z.object({
-                    url: z.string(),
-                    weight: z.number().optional(),
+                    url: z.string().regex(/^https:\/\//),
+                    weight: z.number().min(100).max(900).optional(),
                     weight_range: z.array(z.number()).optional(),
                     style: z.union([z.literal("normal"), z.literal("italic"), z.literal("oblique")]).optional()
                 }).passthrough()).optional(),
@@ -1519,7 +1519,7 @@ export const GetBrandIdentitySuccessSchema = z.object({
 }).passthrough();
 
 export const PaginationRequestSchema = z.object({
-    max_results: z.number().optional(),
+    max_results: z.number().min(1).max(100).optional(),
     cursor: z.string().optional()
 }).passthrough();
 
@@ -1534,36 +1534,36 @@ export const PricingModelSchema = z.union([z.literal("cpm"), z.literal("vcpm"), 
 export const RightsPricingOptionSchema = z.object({
     pricing_option_id: z.string(),
     model: PricingModelSchema,
-    price: z.number(),
-    currency: z.string(),
+    price: z.number().min(0),
+    currency: z.string().regex(/^[A-Z]{3}$/),
     uses: z.array(RightUseSchema),
     period: RightsBillingPeriodSchema.optional(),
-    impression_cap: z.number().optional(),
-    overage_cpm: z.number().optional(),
+    impression_cap: z.number().min(1).optional(),
+    overage_cpm: z.number().min(0).optional(),
     description: z.string().optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
 export const RevocationNotificationSchema = z.object({
-    idempotency_key: z.string(),
+    idempotency_key: z.string().min(16).max(255).regex(/^[A-Za-z0-9_.:-]{16,255}$/),
     rights_id: z.string(),
     brand_id: z.string(),
     reason: z.string(),
-    effective_at: z.string(),
+    effective_at: z.iso.datetime(),
     revoked_uses: z.array(RightUseSchema).optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
 export const UpdateRightsRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
     rights_id: z.string(),
-    end_date: z.string().optional(),
-    impression_cap: z.number().optional(),
+    end_date: z.iso.date().optional(),
+    impression_cap: z.number().min(1).optional(),
     pricing_option_id: z.string().optional(),
     paused: z.boolean().optional(),
     push_notification_config: PushNotificationConfigSchema.optional(),
-    idempotency_key: z.string(),
+    idempotency_key: z.string().min(16).max(255).regex(/^[A-Za-z0-9_.:-]{16,255}$/),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -1574,7 +1574,7 @@ export const UpdateRightsSuccessSchema = z.object({
     generation_credentials: z.array(GenerationCredentialSchema).optional(),
     rights_constraint: RightsConstraintSchema.optional(),
     paused: z.boolean().optional(),
-    implementation_date: z.string().optional().nullable(),
+    implementation_date: z.iso.datetime().optional().nullable(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -1602,15 +1602,15 @@ export const ArtifactSchema = z.object({
     variant_id: z.string().optional(),
     format_id: FormatReferenceStructuredObjectSchema.optional(),
     url: z.string().optional(),
-    published_time: z.string().optional(),
-    last_update_time: z.string().optional(),
+    published_time: z.iso.datetime().optional(),
+    last_update_time: z.iso.datetime().optional(),
     assets: z.array(z.union([z.object({
             type: z.literal("text"),
             role: z.union([z.literal("title"), z.literal("paragraph"), z.literal("heading"), z.literal("caption"), z.literal("quote"), z.literal("list_item"), z.literal("description")]).optional(),
-            content: z.string(),
+            content: z.string().max(100000),
             content_format: z.union([z.literal("text/plain"), z.literal("text/markdown"), z.literal("text/html"), z.literal("application/json")]).optional(),
             language: z.string().optional(),
-            heading_level: z.number().optional(),
+            heading_level: z.number().min(1).max(6).optional(),
             provenance: ProvenanceSchema.optional()
         }).passthrough(), z.object({
             type: z.literal("image"),
@@ -1626,7 +1626,7 @@ export const ArtifactSchema = z.object({
             url: z.string(),
             access: AssetAccessSchema.optional(),
             duration_ms: z.number().optional(),
-            transcript: z.string().optional(),
+            transcript: z.string().max(200000).optional(),
             transcript_format: z.union([z.literal("text/plain"), z.literal("text/markdown"), z.literal("application/json")]).optional(),
             transcript_source: z.union([z.literal("original_script"), z.literal("subtitles"), z.literal("closed_captions"), z.literal("dub"), z.literal("generated")]).optional(),
             thumbnail_url: z.string().optional(),
@@ -1636,7 +1636,7 @@ export const ArtifactSchema = z.object({
             url: z.string(),
             access: AssetAccessSchema.optional(),
             duration_ms: z.number().optional(),
-            transcript: z.string().optional(),
+            transcript: z.string().max(200000).optional(),
             transcript_format: z.union([z.literal("text/plain"), z.literal("text/markdown"), z.literal("application/json")]).optional(),
             transcript_source: z.union([z.literal("original_script"), z.literal("closed_captions"), z.literal("generated")]).optional(),
             provenance: ProvenanceSchema.optional()
@@ -1686,7 +1686,7 @@ export const CreateContentStandardsResponseSchema = z.union([z.object({
     }).passthrough()]);
 
 export const GetContentStandardsRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
     standards_id: z.string(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
@@ -1694,42 +1694,42 @@ export const GetContentStandardsRequestSchema = z.object({
 
 export const CpmPricingSchema = z.object({
     model: z.literal("cpm"),
-    cpm: z.number(),
-    currency: z.string(),
+    cpm: z.number().min(0),
+    currency: z.string().regex(/^[A-Z]{3}$/),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
 export const PercentOfMediaPricingSchema = z.object({
     model: z.literal("percent_of_media"),
-    percent: z.number(),
-    max_cpm: z.number().optional(),
-    currency: z.string(),
+    percent: z.number().min(0).max(100),
+    max_cpm: z.number().min(0).optional(),
+    currency: z.string().regex(/^[A-Z]{3}$/),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
 export const FlatFeePricingSchema = z.object({
     model: z.literal("flat_fee"),
-    amount: z.number(),
+    amount: z.number().min(0),
     period: z.union([z.literal("monthly"), z.literal("quarterly"), z.literal("annual"), z.literal("campaign")]),
-    currency: z.string(),
+    currency: z.string().regex(/^[A-Z]{3}$/),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
 export const PerUnitPricingSchema = z.object({
     model: z.literal("per_unit"),
     unit: z.string(),
-    unit_price: z.number(),
-    currency: z.string(),
+    unit_price: z.number().min(0),
+    currency: z.string().regex(/^[A-Z]{3}$/),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
 export const CustomPricingSchema = z.object({
     model: z.literal("custom"),
-    description: z.string(),
+    description: z.string().min(1),
     metadata: z.object({
-        summary_for_operator: z.string().optional()
+        summary_for_operator: z.string().min(1).optional()
     }).passthrough(),
-    currency: z.string().optional(),
+    currency: z.string().regex(/^[A-Z]{3}$/).optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
@@ -1738,7 +1738,7 @@ export const PolicyEntrySchema = z.object({
     source: z.union([z.literal("registry"), z.literal("inline")]).optional(),
     version: z.string().optional(),
     name: z.string().optional(),
-    description: z.string().optional(),
+    description: z.string().max(500).optional(),
     category: PolicyCategorySchema.optional(),
     enforcement: PolicyEnforcementLevelSchema,
     requires_human_review: z.boolean().optional(),
@@ -1747,11 +1747,11 @@ export const PolicyEntrySchema = z.object({
     policy_categories: z.array(z.string()).optional(),
     channels: z.array(MediaChannelSchema).optional(),
     governance_domains: z.array(GovernanceDomainSchema).optional(),
-    effective_date: z.string().optional(),
-    sunset_date: z.string().optional(),
+    effective_date: z.iso.date().optional(),
+    sunset_date: z.iso.date().optional(),
     source_url: z.string().optional(),
     source_name: z.string().optional(),
-    policy: z.string(),
+    policy: z.string().max(5000),
     guidance: z.string().optional(),
     exemplars: z.object({
         pass: z.array(ExemplarSchema).optional(),
@@ -1764,22 +1764,22 @@ export const AccountReferenceSchema = z.union([z.object({
         account_id: z.string()
     }).passthrough(), z.object({
         brand: BrandReferenceSchema,
-        operator: z.string(),
+        operator: z.string().regex(/^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/),
         sandbox: z.boolean().optional()
     }).passthrough()]);
 
 export const GetMediaBuyArtifactsRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
     account: AccountReferenceSchema.optional(),
     media_buy_id: z.string(),
     package_ids: z.array(z.string()).optional(),
     failures_only: z.boolean().optional(),
     time_range: z.object({
-        start: z.string().optional(),
-        end: z.string().optional()
+        start: z.iso.datetime().optional(),
+        end: z.iso.datetime().optional()
     }).passthrough().optional(),
     pagination: z.object({
-        max_results: z.number().optional(),
+        max_results: z.number().min(1).max(10000).optional(),
         cursor: z.string().optional()
     }).passthrough().optional(),
     context: ContextObjectSchema.optional(),
@@ -1790,7 +1790,7 @@ export const GetMediaBuyArtifactsResponseSchema = z.union([z.object({
         media_buy_id: z.string(),
         artifacts: z.array(z.object({
             record_id: z.string(),
-            timestamp: z.string().optional(),
+            timestamp: z.iso.datetime().optional(),
             package_id: z.string().optional(),
             artifact: ArtifactSchema,
             country: z.string().optional(),
@@ -1817,7 +1817,7 @@ export const GetMediaBuyArtifactsResponseSchema = z.union([z.object({
     }).passthrough()]);
 
 export const ListContentStandardsRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
     channels: z.array(MediaChannelSchema).optional(),
     languages: z.array(z.string()).optional(),
     countries: z.array(z.string()).optional(),
@@ -1827,7 +1827,7 @@ export const ListContentStandardsRequestSchema = z.object({
 }).passthrough();
 
 export const UpdateContentStandardsRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
     standards_id: z.string(),
     scope: z.object({
         countries_all: z.array(z.string()).optional(),
@@ -1851,7 +1851,7 @@ export const UpdateContentStandardsRequestSchema = z.object({
     }).passthrough().optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional(),
-    idempotency_key: z.string()
+    idempotency_key: z.string().min(16).max(255).regex(/^[A-Za-z0-9_.:-]{16,255}$/)
 }).passthrough();
 
 export const UpdateContentStandardsSuccessSchema = z.object({
@@ -1870,12 +1870,12 @@ export const UpdateContentStandardsErrorSchema = z.object({
 }).passthrough();
 
 export const ValidateContentDeliveryRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
     standards_id: z.string(),
     records: z.array(z.object({
         record_id: z.string(),
         media_buy_id: z.string().optional(),
-        timestamp: z.string().optional(),
+        timestamp: z.iso.datetime().optional(),
         artifact: ArtifactSchema,
         country: z.string().optional(),
         channel: z.string().optional(),
@@ -1904,7 +1904,7 @@ export const ValidateContentDeliveryResponseSchema = z.union([z.object({
                 status: FeatureCheckStatusSchema,
                 policy_id: z.string().optional(),
                 explanation: z.string().optional(),
-                confidence: z.number().optional()
+                confidence: z.number().min(0).max(1).optional()
             }).passthrough()).optional()
         }).passthrough()),
         context: ContextObjectSchema.optional(),
@@ -1916,7 +1916,7 @@ export const ValidateContentDeliveryResponseSchema = z.union([z.object({
     }).passthrough()]);
 
 export const TasksGetRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
     task_id: z.string(),
     include_history: z.boolean().optional(),
     context: ContextObjectSchema.optional(),
@@ -1928,15 +1928,15 @@ export const TasksGetResponseSchema = z.object({
     task_type: TaskTypeSchema,
     protocol: AdCPProtocolSchema,
     status: TaskStatusSchema,
-    created_at: z.string(),
-    updated_at: z.string(),
-    completed_at: z.string().optional(),
+    created_at: z.iso.datetime(),
+    updated_at: z.iso.datetime(),
+    completed_at: z.iso.datetime().optional(),
     has_webhook: z.boolean().optional(),
     progress: z.object({
-        percentage: z.number().optional(),
+        percentage: z.number().min(0).max(100).optional(),
         current_step: z.string().optional(),
-        total_steps: z.number().optional(),
-        step_number: z.number().optional()
+        total_steps: z.number().min(1).optional(),
+        step_number: z.number().min(1).optional()
     }).passthrough().optional(),
     error: z.object({
         code: z.string(),
@@ -1948,7 +1948,7 @@ export const TasksGetResponseSchema = z.object({
         }).passthrough().optional()
     }).passthrough().optional(),
     history: z.array(z.object({
-        timestamp: z.string(),
+        timestamp: z.iso.datetime(),
         type: z.union([z.literal("request"), z.literal("response")]),
         data: z.object({}).passthrough()
     }).passthrough()).optional(),
@@ -1959,7 +1959,7 @@ export const TasksGetResponseSchema = z.object({
 export const SortDirectionSchema = z.union([z.literal("asc"), z.literal("desc")]);
 
 export const TasksListRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
     filters: z.object({
         protocol: AdCPProtocolSchema.optional(),
         protocols: z.array(AdCPProtocolSchema).optional(),
@@ -1967,10 +1967,10 @@ export const TasksListRequestSchema = z.object({
         statuses: z.array(TaskStatusSchema).optional(),
         task_type: TaskTypeSchema.optional(),
         task_types: z.array(TaskTypeSchema).optional(),
-        created_after: z.string().optional(),
-        created_before: z.string().optional(),
-        updated_after: z.string().optional(),
-        updated_before: z.string().optional(),
+        created_after: z.iso.datetime().optional(),
+        created_before: z.iso.datetime().optional(),
+        updated_after: z.iso.datetime().optional(),
+        updated_before: z.iso.datetime().optional(),
         task_ids: z.array(z.string()).optional(),
         context_contains: z.string().optional(),
         has_webhook: z.boolean().optional()
@@ -1987,11 +1987,11 @@ export const TasksListRequestSchema = z.object({
 
 export const TasksListResponseSchema = z.object({
     query_summary: z.object({
-        total_matching: z.number().optional(),
-        returned: z.number().optional(),
+        total_matching: z.number().min(0).optional(),
+        returned: z.number().min(0).optional(),
         domain_breakdown: z.object({
-            "media-buy": z.number().optional(),
-            signals: z.number().optional()
+            "media-buy": z.number().min(0).optional(),
+            signals: z.number().min(0).optional()
         }).passthrough().optional(),
         status_breakdown: z.record(z.string(), z.number()).optional(),
         filters_applied: z.array(z.string()).optional(),
@@ -2005,9 +2005,9 @@ export const TasksListResponseSchema = z.object({
         task_type: TaskTypeSchema,
         domain: z.union([z.literal("media-buy"), z.literal("signals")]),
         status: TaskStatusSchema,
-        created_at: z.string(),
-        updated_at: z.string(),
-        completed_at: z.string().optional(),
+        created_at: z.iso.datetime(),
+        updated_at: z.iso.datetime(),
+        completed_at: z.iso.datetime().optional(),
         has_webhook: z.boolean().optional()
     }).passthrough()),
     pagination: PaginationResponseSchema,
@@ -2016,80 +2016,80 @@ export const TasksListResponseSchema = z.object({
 }).passthrough();
 
 export const GetCreativeDeliveryRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
     account: AccountReferenceSchema.optional(),
     media_buy_ids: z.array(z.string()).optional(),
     creative_ids: z.array(z.string()).optional(),
-    start_date: z.string().optional(),
-    end_date: z.string().optional(),
-    max_variants: z.number().optional(),
+    start_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+    end_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+    max_variants: z.number().min(1).optional(),
     pagination: PaginationRequestSchema.optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
 export const DeliveryMetricsSchema = z.object({
-    impressions: z.number().optional(),
-    spend: z.number().optional(),
-    clicks: z.number().optional(),
-    ctr: z.number().optional(),
-    views: z.number().optional(),
-    completed_views: z.number().optional(),
-    completion_rate: z.number().optional(),
-    conversions: z.number().optional(),
-    conversion_value: z.number().optional(),
-    roas: z.number().optional(),
-    cost_per_acquisition: z.number().optional(),
-    new_to_brand_rate: z.number().optional(),
-    leads: z.number().optional(),
+    impressions: z.number().min(0).optional(),
+    spend: z.number().min(0).optional(),
+    clicks: z.number().min(0).optional(),
+    ctr: z.number().min(0).max(1).optional(),
+    views: z.number().min(0).optional(),
+    completed_views: z.number().min(0).optional(),
+    completion_rate: z.number().min(0).max(1).optional(),
+    conversions: z.number().min(0).optional(),
+    conversion_value: z.number().min(0).optional(),
+    roas: z.number().min(0).optional(),
+    cost_per_acquisition: z.number().min(0).optional(),
+    new_to_brand_rate: z.number().min(0).max(1).optional(),
+    leads: z.number().min(0).optional(),
     by_event_type: z.array(z.object({
         event_type: EventTypeSchema,
         event_source_id: z.string().optional(),
-        count: z.number(),
-        value: z.number().optional()
+        count: z.number().min(0),
+        value: z.number().min(0).optional()
     }).passthrough()).optional(),
-    grps: z.number().optional(),
-    reach: z.number().optional(),
+    grps: z.number().min(0).optional(),
+    reach: z.number().min(0).optional(),
     reach_unit: ReachUnitSchema.optional(),
-    frequency: z.number().optional(),
+    frequency: z.number().min(0).optional(),
     quartile_data: z.object({
-        q1_views: z.number().optional(),
-        q2_views: z.number().optional(),
-        q3_views: z.number().optional(),
-        q4_views: z.number().optional()
+        q1_views: z.number().min(0).optional(),
+        q2_views: z.number().min(0).optional(),
+        q3_views: z.number().min(0).optional(),
+        q4_views: z.number().min(0).optional()
     }).passthrough().optional(),
     dooh_metrics: z.object({
-        loop_plays: z.number().optional(),
-        screens_used: z.number().optional(),
-        screen_time_seconds: z.number().optional(),
-        sov_achieved: z.number().optional(),
+        loop_plays: z.number().min(0).optional(),
+        screens_used: z.number().min(0).optional(),
+        screen_time_seconds: z.number().min(0).optional(),
+        sov_achieved: z.number().min(0).max(1).optional(),
         calculation_notes: z.string().optional(),
         venue_breakdown: z.array(z.object({
             venue_id: z.string(),
             venue_name: z.string().optional(),
             venue_type: z.string().optional(),
-            impressions: z.number(),
-            loop_plays: z.number().optional(),
-            screens_used: z.number().optional()
+            impressions: z.number().min(0),
+            loop_plays: z.number().min(0).optional(),
+            screens_used: z.number().min(0).optional()
         }).passthrough()).optional()
     }).passthrough().optional(),
     viewability: z.object({
-        measurable_impressions: z.number().optional(),
-        viewable_impressions: z.number().optional(),
-        viewable_rate: z.number().optional(),
+        measurable_impressions: z.number().min(0).optional(),
+        viewable_impressions: z.number().min(0).optional(),
+        viewable_rate: z.number().min(0).max(1).optional(),
         standard: ViewabilityStandardSchema.optional()
     }).passthrough().optional(),
-    engagements: z.number().optional(),
-    follows: z.number().optional(),
-    saves: z.number().optional(),
-    profile_visits: z.number().optional(),
-    engagement_rate: z.number().optional(),
-    cost_per_click: z.number().optional(),
+    engagements: z.number().min(0).optional(),
+    follows: z.number().min(0).optional(),
+    saves: z.number().min(0).optional(),
+    profile_visits: z.number().min(0).optional(),
+    engagement_rate: z.number().min(0).max(1).optional(),
+    cost_per_click: z.number().min(0).optional(),
     by_action_source: z.array(z.object({
         action_source: ActionSourceSchema,
         event_source_id: z.string().optional(),
-        count: z.number(),
-        value: z.number().optional()
+        count: z.number().min(0),
+        value: z.number().min(0).optional()
     }).passthrough()).optional()
 }).passthrough();
 
@@ -2102,9 +2102,9 @@ export const CreativeFeatureResultSchema = z.object({
     feature_id: z.string(),
     value: z.union([z.boolean(), z.number(), z.string()]),
     unit: z.string().optional(),
-    confidence: z.number().optional(),
-    measured_at: z.string().optional(),
-    expires_at: z.string().optional(),
+    confidence: z.number().min(0).max(1).optional(),
+    measured_at: z.iso.datetime().optional(),
+    expires_at: z.iso.datetime().optional(),
     methodology_version: z.string().optional(),
     details: z.object({}).passthrough().optional(),
     policy_id: z.string().optional(),
@@ -2114,7 +2114,7 @@ export const CreativeFeatureResultSchema = z.object({
 export const WCAGLevelSchema = z.union([z.literal("A"), z.literal("AA"), z.literal("AAA")]);
 
 export const ListCreativeFormatsRequestCreativeAgentSchema = z.object({
-    adcp_major_version: z.number().optional(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
     format_ids: z.array(FormatReferenceStructuredObjectSchema).optional(),
     type: z.union([z.literal("audio"), z.literal("video"), z.literal("display"), z.literal("dooh")]).optional(),
     asset_types: z.array(z.union([z.literal("image"), z.literal("video"), z.literal("audio"), z.literal("text"), z.literal("html"), z.literal("javascript"), z.literal("url")])).optional(),
@@ -2145,10 +2145,10 @@ export const CreativeFiltersSchema = z.object({
     tags_any: z.array(z.string()).optional(),
     name_contains: z.string().optional(),
     creative_ids: z.array(z.string()).optional(),
-    created_after: z.string().optional(),
-    created_before: z.string().optional(),
-    updated_after: z.string().optional(),
-    updated_before: z.string().optional(),
+    created_after: z.iso.datetime().optional(),
+    created_before: z.iso.datetime().optional(),
+    updated_after: z.iso.datetime().optional(),
+    updated_before: z.iso.datetime().optional(),
     assigned_to_packages: z.array(z.string()).optional(),
     media_buy_ids: z.array(z.string()).optional(),
     unassigned: z.boolean().optional(),
@@ -2188,7 +2188,7 @@ export const VASTAssetSchema = z.object({
     asset_type: z.literal("vast"),
     vast_version: VASTVersionSchema.optional(),
     vpaid_enabled: z.boolean().optional(),
-    duration_ms: z.number().optional(),
+    duration_ms: z.number().min(0).optional(),
     tracking_events: z.array(VASTTrackingEventSchema).optional(),
     captions_url: z.string().optional(),
     audio_description_url: z.string().optional(),
@@ -2204,7 +2204,7 @@ export const VASTAssetSchema = z.object({
 export const DAASTAssetSchema = z.object({
     asset_type: z.literal("daast"),
     daast_version: DAASTVersionSchema.optional(),
-    duration_ms: z.number().optional(),
+    duration_ms: z.number().min(0).optional(),
     tracking_events: z.array(DAASTTrackingEventSchema).optional(),
     companion_ads: z.boolean().optional(),
     transcript_url: z.string().optional(),
@@ -2233,7 +2233,7 @@ export const PreviewCreativeSingleResponseSchema = z.object({
         }).passthrough()
     }).passthrough()),
     interactive_url: z.string().optional(),
-    expires_at: z.string(),
+    expires_at: z.iso.datetime(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -2254,10 +2254,10 @@ export const StartTimingSchema = z.union([z.literal("asap"), z.string()]);
 
 export const ReportingWebhookSchema = z.object({
     url: z.string(),
-    token: z.string().optional(),
+    token: z.string().min(16).optional(),
     authentication: z.object({
         schemes: z.array(AuthenticationSchemeSchema),
-        credentials: z.string()
+        credentials: z.string().min(32)
     }).passthrough(),
     reporting_frequency: z.union([z.literal("hourly"), z.literal("daily"), z.literal("monthly")]),
     requested_metrics: z.array(AvailableMetricSchema).optional()
@@ -2294,7 +2294,7 @@ export const TargetingOverlaySchema = z.object({
     collection_list: CollectionListReferenceSchema.optional(),
     collection_list_exclude: CollectionListReferenceSchema.optional(),
     age_restriction: z.object({
-        min: z.number(),
+        min: z.number().min(13).max(99),
         verification_required: z.boolean().optional(),
         accepted_methods: z.array(AgeVerificationMethodSchema).optional()
     }).passthrough().optional(),
@@ -2309,12 +2309,12 @@ export const TargetingOverlaySchema = z.object({
     geo_proximity: z.array(z.record(z.string(), z.unknown())).optional(),
     language: z.array(z.string()).optional(),
     keyword_targets: z.array(z.object({
-        keyword: z.string(),
+        keyword: z.string().min(1),
         match_type: MatchTypeSchema,
-        bid_price: z.number().optional()
+        bid_price: z.number().min(0).optional()
     }).passthrough()).optional(),
     negative_keywords: z.array(z.object({
-        keyword: z.string(),
+        keyword: z.string().min(1),
         match_type: MatchTypeSchema
     }).passthrough()).optional()
 }).passthrough();
@@ -2326,12 +2326,12 @@ export const GeographicTargetingLevelSchema = z.union([z.literal("country"), z.l
 export const SortMetricSchema = z.union([z.literal("impressions"), z.literal("spend"), z.literal("clicks"), z.literal("ctr"), z.literal("views"), z.literal("completed_views"), z.literal("completion_rate"), z.literal("conversions"), z.literal("conversion_value"), z.literal("roas"), z.literal("cost_per_acquisition"), z.literal("new_to_brand_rate"), z.literal("leads"), z.literal("grps"), z.literal("reach"), z.literal("frequency"), z.literal("engagements"), z.literal("follows"), z.literal("saves"), z.literal("profile_visits"), z.literal("engagement_rate"), z.literal("cost_per_click")]);
 
 export const GetMediaBuyDeliveryRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
     account: AccountReferenceSchema.optional(),
     media_buy_ids: z.array(z.string()).optional(),
     status_filter: z.union([MediaBuyStatusSchema, z.array(MediaBuyStatusSchema)]).optional(),
-    start_date: z.string().optional(),
-    end_date: z.string().optional(),
+    start_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+    end_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
     include_package_daily_breakdown: z.boolean().optional(),
     attribution_window: z.object({
         post_click: DurationSchema.optional(),
@@ -2342,23 +2342,23 @@ export const GetMediaBuyDeliveryRequestSchema = z.object({
         geo: z.object({
             geo_level: GeographicTargetingLevelSchema,
             system: z.union([MetroAreaSystemSchema, PostalCodeSystemSchema]).optional(),
-            limit: z.number().optional(),
+            limit: z.number().min(1).optional(),
             sort_by: SortMetricSchema.optional()
         }).passthrough().optional(),
         device_type: z.object({
-            limit: z.number().optional(),
+            limit: z.number().min(1).optional(),
             sort_by: SortMetricSchema.optional()
         }).passthrough().optional(),
         device_platform: z.object({
-            limit: z.number().optional(),
+            limit: z.number().min(1).optional(),
             sort_by: SortMetricSchema.optional()
         }).passthrough().optional(),
         audience: z.object({
-            limit: z.number().optional(),
+            limit: z.number().min(1).optional(),
             sort_by: SortMetricSchema.optional()
         }).passthrough().optional(),
         placement: z.object({
-            limit: z.number().optional(),
+            limit: z.number().min(1).optional(),
             sort_by: SortMetricSchema.optional()
         }).passthrough().optional()
     }).passthrough().optional(),
@@ -2375,12 +2375,12 @@ export const AttributionWindowSchema = z.object({
 }).passthrough();
 
 export const GetMediaBuysRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
     account: AccountReferenceSchema.optional(),
     media_buy_ids: z.array(z.string()).optional(),
     status_filter: z.union([MediaBuyStatusSchema, z.array(MediaBuyStatusSchema)]).optional(),
     include_snapshot: z.boolean().optional(),
-    include_history: z.number().optional(),
+    include_history: z.number().min(0).max(1000).optional(),
     pagination: PaginationRequestSchema.optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
@@ -2391,21 +2391,21 @@ export const CreativeApprovalStatusSchema = z.union([z.literal("pending_review")
 export const PackageStatusSchema = z.object({
     package_id: z.string(),
     product_id: z.string().optional(),
-    budget: z.number().optional(),
-    currency: z.string().optional(),
-    bid_price: z.number().optional(),
-    impressions: z.number().optional(),
+    budget: z.number().min(0).optional(),
+    currency: z.string().regex(/^[A-Z]{3}$/).optional(),
+    bid_price: z.number().min(0).optional(),
+    impressions: z.number().min(0).optional(),
     targeting_overlay: TargetingOverlaySchema.optional(),
-    start_time: z.string().optional(),
-    end_time: z.string().optional(),
+    start_time: z.iso.datetime().optional(),
+    end_time: z.iso.datetime().optional(),
     paused: z.boolean().optional(),
     canceled: z.boolean().optional(),
     cancellation: z.object({
-        canceled_at: z.string(),
+        canceled_at: z.iso.datetime(),
         canceled_by: CanceledBySchema,
-        reason: z.string().optional()
+        reason: z.string().max(500).optional()
     }).passthrough().optional(),
-    creative_deadline: z.string().optional(),
+    creative_deadline: z.iso.datetime().optional(),
     creative_approvals: z.array(z.object({
         creative_id: z.string(),
         approval_status: CreativeApprovalStatusSchema.optional(),
@@ -2414,13 +2414,13 @@ export const PackageStatusSchema = z.object({
     format_ids_pending: z.array(FormatReferenceStructuredObjectSchema).optional(),
     snapshot_unavailable_reason: SnapshotUnavailableReasonSchema.optional(),
     snapshot: z.object({
-        as_of: z.string(),
-        staleness_seconds: z.number(),
-        impressions: z.number(),
-        spend: z.number(),
-        currency: z.string().optional(),
-        clicks: z.number().optional(),
-        pacing_index: z.number().optional(),
+        as_of: z.iso.datetime(),
+        staleness_seconds: z.number().min(0),
+        impressions: z.number().min(0),
+        spend: z.number().min(0),
+        currency: z.string().regex(/^[A-Z]{3}$/).optional(),
+        clicks: z.number().min(0).optional(),
+        pacing_index: z.number().min(0).optional(),
         delivery_status: z.union([z.literal("delivering"), z.literal("not_delivering"), z.literal("completed"), z.literal("budget_exhausted"), z.literal("flight_ended"), z.literal("goal_met")]).optional(),
         ext: ExtensionObjectSchema.optional()
     }).passthrough().optional(),
@@ -2449,7 +2449,7 @@ export const MediaBuyFeaturesSchema = z.record(z.string(), z.boolean()).and(z.ob
 }).passthrough());
 
 export const ListCreativeFormatsRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
     format_ids: z.array(FormatReferenceStructuredObjectSchema).optional(),
     asset_types: z.array(AssetContentTypeSchema).optional(),
     max_width: z.number().optional(),
@@ -2473,8 +2473,8 @@ export const UserMatchSchema = z.object({
         type: UIDTypeSchema,
         value: z.string()
     }).passthrough()).optional(),
-    hashed_email: z.string().optional(),
-    hashed_phone: z.string().optional(),
+    hashed_email: z.string().regex(/^[a-f0-9]{64}$/).optional(),
+    hashed_phone: z.string().regex(/^[a-f0-9]{64}$/).optional(),
     click_id: z.string().optional(),
     click_id_type: z.string().optional(),
     client_ip: z.string().optional(),
@@ -2483,34 +2483,34 @@ export const UserMatchSchema = z.object({
 }).passthrough();
 
 export const EventCustomDataSchema = z.object({
-    value: z.number().optional(),
-    currency: z.string().optional(),
+    value: z.number().min(0).optional(),
+    currency: z.string().regex(/^[A-Z]{3}$/).optional(),
     order_id: z.string().optional(),
     content_ids: z.array(z.string()).optional(),
     content_type: z.string().optional(),
     content_name: z.string().optional(),
     content_category: z.string().optional(),
-    num_items: z.number().optional(),
+    num_items: z.number().min(0).optional(),
     search_string: z.string().optional(),
     contents: z.array(z.object({
         id: z.string(),
-        quantity: z.number().optional(),
-        price: z.number().optional(),
+        quantity: z.number().min(1).optional(),
+        price: z.number().min(0).optional(),
         brand: z.string().optional()
     }).passthrough()).optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
 export const LogEventSuccessSchema = z.object({
-    events_received: z.number(),
-    events_processed: z.number(),
+    events_received: z.number().min(0),
+    events_processed: z.number().min(0),
     partial_failures: z.array(z.object({
         event_id: z.string(),
         code: z.string(),
         message: z.string()
     }).passthrough()).optional(),
     warnings: z.array(z.string()).optional(),
-    match_quality: z.number().optional(),
+    match_quality: z.number().min(0).max(1).optional(),
     sandbox: z.boolean().optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
@@ -2527,8 +2527,8 @@ export const MetricTypeSchema = z.union([z.literal("overall_performance"), z.lit
 export const FeedbackSourceSchema = z.union([z.literal("buyer_attribution"), z.literal("third_party_measurement"), z.literal("platform_analytics"), z.literal("verification_partner")]);
 
 export const DatetimeRangeSchema = z.object({
-    start: z.string(),
-    end: z.string()
+    start: z.iso.datetime(),
+    end: z.iso.datetime()
 }).passthrough();
 
 export const ProvidePerformanceFeedbackSuccessSchema = z.object({
@@ -2546,8 +2546,8 @@ export const ProvidePerformanceFeedbackErrorSchema = z.object({
 
 export const AudienceMemberSchema = z.object({
     external_id: z.string(),
-    hashed_email: z.string().optional(),
-    hashed_phone: z.string().optional(),
+    hashed_email: z.string().regex(/^[a-f0-9]{64}$/).optional(),
+    hashed_phone: z.string().regex(/^[a-f0-9]{64}$/).optional(),
     uids: z.array(z.object({
         type: UIDTypeSchema,
         value: z.string()
@@ -2558,8 +2558,8 @@ export const AudienceMemberSchema = z.object({
 export const ConsentBasisSchema = z.union([z.literal("consent"), z.literal("legitimate_interest"), z.literal("contract"), z.literal("legal_obligation")]);
 
 export const SyncAudiencesRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
-    idempotency_key: z.string(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
+    idempotency_key: z.string().min(16).max(255).regex(/^[A-Za-z0-9_.:-]{16,255}$/),
     account: AccountReferenceSchema,
     audiences: z.array(z.object({
         audience_id: z.string(),
@@ -2594,18 +2594,18 @@ export const SyncAudiencesSuccessSchema = z.object({
         seller_id: z.string().optional(),
         action: z.union([z.literal("created"), z.literal("updated"), z.literal("unchanged"), z.literal("deleted"), z.literal("failed")]),
         status: AudienceStatusSchema.optional(),
-        uploaded_count: z.number().optional(),
-        total_uploaded_count: z.number().optional(),
-        matched_count: z.number().optional(),
-        effective_match_rate: z.number().optional(),
+        uploaded_count: z.number().min(0).optional(),
+        total_uploaded_count: z.number().min(0).optional(),
+        matched_count: z.number().min(0).optional(),
+        effective_match_rate: z.number().min(0).max(1).optional(),
         match_breakdown: z.array(z.object({
             id_type: MatchIDTypeSchema,
-            submitted: z.number(),
-            matched: z.number(),
-            match_rate: z.number()
+            submitted: z.number().min(0),
+            matched: z.number().min(0),
+            match_rate: z.number().min(0).max(1)
         }).passthrough()).optional(),
-        last_synced_at: z.string().optional(),
-        minimum_size: z.number().optional(),
+        last_synced_at: z.iso.datetime().optional(),
+        minimum_size: z.number().min(1).optional(),
         errors: z.array(ErrorSchema).optional()
     }).passthrough()),
     sandbox: z.boolean().optional(),
@@ -2614,8 +2614,8 @@ export const SyncAudiencesSuccessSchema = z.object({
 }).passthrough();
 
 export const SyncCatalogsRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
-    idempotency_key: z.string(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
+    idempotency_key: z.string().min(16).max(255).regex(/^[A-Za-z0-9_.:-]{16,255}$/),
     account: AccountReferenceSchema,
     catalogs: z.array(CatalogSchema).optional(),
     catalog_ids: z.array(z.string()).optional(),
@@ -2628,8 +2628,8 @@ export const SyncCatalogsRequestSchema = z.object({
 }).passthrough();
 
 export const SyncEventSourcesRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
-    idempotency_key: z.string(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
+    idempotency_key: z.string().min(16).max(255).regex(/^[A-Za-z0-9_.:-]{16,255}$/),
     account: AccountReferenceSchema,
     event_sources: z.array(z.object({
         event_source_id: z.string(),
@@ -2651,26 +2651,26 @@ export const SyncEventSourcesErrorSchema = z.object({
 export const EventSourceHealthSchema = z.object({
     status: AssessmentStatusSchema,
     detail: z.object({
-        score: z.number(),
-        max_score: z.number(),
+        score: z.number().min(0),
+        max_score: z.number().min(1),
         label: z.string().optional()
     }).passthrough().optional(),
-    match_rate: z.number().optional(),
-    last_event_at: z.string().optional(),
-    evaluated_at: z.string().optional(),
-    events_received_24h: z.number().optional(),
+    match_rate: z.number().min(0).max(1).optional(),
+    last_event_at: z.iso.datetime().optional(),
+    evaluated_at: z.iso.datetime().optional(),
+    events_received_24h: z.number().min(0).optional(),
     issues: z.array(DiagnosticIssueSchema).optional()
 }).passthrough();
 
 export const PublisherTagsSourceSchema = z.object({
     selection_type: z.literal("publisher_tags"),
-    publisher_domain: z.string(),
+    publisher_domain: z.string().regex(/^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/),
     tags: z.array(PropertyTagSchema)
 }).passthrough();
 
 export const PublisherPropertyIDsSourceSchema = z.object({
     selection_type: z.literal("publisher_ids"),
-    publisher_domain: z.string(),
+    publisher_domain: z.string().regex(/^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/),
     property_ids: z.array(PropertyIDSchema)
 }).passthrough();
 
@@ -2699,12 +2699,12 @@ export const PropertyListFiltersSchema = z.object({
 }).passthrough();
 
 export const DeletePropertyListRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
     list_id: z.string(),
     account: AccountReferenceSchema.optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional(),
-    idempotency_key: z.string()
+    idempotency_key: z.string().min(16).max(255).regex(/^[A-Za-z0-9_.:-]{16,255}$/)
 }).passthrough();
 
 export const DeletePropertyListResponseSchema = z.object({
@@ -2716,12 +2716,12 @@ export const DeletePropertyListResponseSchema = z.object({
 }).passthrough();
 
 export const GetPropertyListRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
     list_id: z.string(),
     account: AccountReferenceSchema.optional(),
     resolve: z.boolean().optional(),
     pagination: z.object({
-        max_results: z.number().optional(),
+        max_results: z.number().min(1).max(10000).optional(),
         cursor: z.string().optional()
     }).passthrough().optional(),
     context: ContextObjectSchema.optional(),
@@ -2729,7 +2729,7 @@ export const GetPropertyListRequestSchema = z.object({
 }).passthrough();
 
 export const ListPropertyListsRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
     account: AccountReferenceSchema.optional(),
     name_contains: z.string().optional(),
     pagination: PaginationRequestSchema.optional(),
@@ -2738,7 +2738,7 @@ export const ListPropertyListsRequestSchema = z.object({
 }).passthrough();
 
 export const UpdatePropertyListRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
     list_id: z.string(),
     account: AccountReferenceSchema.optional(),
     name: z.string().optional(),
@@ -2749,12 +2749,12 @@ export const UpdatePropertyListRequestSchema = z.object({
     webhook_url: z.string().optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional(),
-    idempotency_key: z.string()
+    idempotency_key: z.string().min(16).max(255).regex(/^[A-Za-z0-9_.:-]{16,255}$/)
 }).passthrough();
 
 export const DeliveryRecordSchema = z.object({
     identifier: IdentifierSchema,
-    impressions: z.number(),
+    impressions: z.number().min(0),
     record_id: z.string().optional(),
     sales_agent_url: z.string().optional(),
     ext: ExtensionObjectSchema.optional()
@@ -2771,7 +2771,7 @@ export const AuthorizationResultSchema = z.object({
 }).passthrough();
 
 export const GetAdCPCapabilitiesRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
     protocols: z.array(z.union([z.literal("media_buy"), z.literal("signals"), z.literal("governance"), z.literal("sponsored_intelligence"), z.literal("creative")])).optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
@@ -2783,7 +2783,7 @@ export const AdCPSpecialismSchema = z.union([z.literal("audience-sync"), z.liter
 
 export const IdempotencySupportedSchema = z.object({
     supported: z.literal(true),
-    replay_ttl_seconds: z.number(),
+    replay_ttl_seconds: z.number().min(3600).max(604800),
     account_id_is_opaque: z.boolean().optional()
 }).passthrough();
 
@@ -2832,13 +2832,13 @@ export const DestinationSchema = z.union([z.object({
     }).passthrough()]);
 
 export const ActivateSignalRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
     action: z.union([z.literal("activate"), z.literal("deactivate")]).optional(),
     signal_agent_segment_id: z.string(),
     destinations: z.array(DestinationSchema),
     pricing_option_id: z.string().optional(),
     account: AccountReferenceSchema.optional(),
-    idempotency_key: z.string(),
+    idempotency_key: z.string().min(16).max(255).regex(/^[A-Za-z0-9_.:-]{16,255}$/),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -2864,16 +2864,16 @@ export const DeploymentSchema = z.union([z.object({
         account: z.string().optional(),
         is_live: z.boolean(),
         activation_key: ActivationKeySchema.optional(),
-        estimated_activation_duration_minutes: z.number().optional(),
-        deployed_at: z.string().optional()
+        estimated_activation_duration_minutes: z.number().min(0).optional(),
+        deployed_at: z.iso.datetime().optional()
     }).passthrough(), z.object({
         type: z.literal("agent"),
         agent_url: z.string(),
         account: z.string().optional(),
         is_live: z.boolean(),
         activation_key: ActivationKeySchema.optional(),
-        estimated_activation_duration_minutes: z.number().optional(),
-        deployed_at: z.string().optional()
+        estimated_activation_duration_minutes: z.number().min(0).optional(),
+        deployed_at: z.iso.datetime().optional()
     }).passthrough()]);
 
 export const SignalCatalogTypeSchema = z.union([z.literal("marketplace"), z.literal("custom"), z.literal("owned")]);
@@ -2881,34 +2881,34 @@ export const SignalCatalogTypeSchema = z.union([z.literal("marketplace"), z.lite
 export const SignalFiltersSchema = z.object({
     catalog_types: z.array(SignalCatalogTypeSchema).optional(),
     data_providers: z.array(z.string()).optional(),
-    max_cpm: z.number().optional(),
-    max_percent: z.number().optional(),
-    min_coverage_percentage: z.number().optional()
+    max_cpm: z.number().min(0).optional(),
+    max_percent: z.number().min(0).max(100).optional(),
+    min_coverage_percentage: z.number().min(0).max(100).optional()
 }).passthrough();
 
 export const SignalValueTypeSchema = z.union([z.literal("binary"), z.literal("categorical"), z.literal("numeric")]);
 
 export const SIGetOfferingRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
     offering_id: z.string(),
     intent: z.string().optional(),
     context: ContextObjectSchema.optional(),
     include_products: z.boolean().optional(),
-    product_limit: z.number().optional(),
+    product_limit: z.number().min(1).max(50).optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
 export const SIGetOfferingResponseSchema = z.object({
     available: z.boolean(),
     offering_token: z.string().optional(),
-    ttl_seconds: z.number().optional(),
-    checked_at: z.string().optional(),
+    ttl_seconds: z.number().min(0).optional(),
+    checked_at: z.iso.datetime().optional(),
     offering: z.object({
         offering_id: z.string().optional(),
         title: z.string().optional(),
         summary: z.string().optional(),
         tagline: z.string().optional(),
-        expires_at: z.string().optional(),
+        expires_at: z.iso.datetime().optional(),
         price_hint: z.string().optional(),
         image_url: z.string().optional(),
         landing_url: z.string().optional()
@@ -2922,7 +2922,7 @@ export const SIGetOfferingResponseSchema = z.object({
         availability_summary: z.string().optional(),
         url: z.string().optional()
     }).passthrough()).optional(),
-    total_matching: z.number().optional(),
+    total_matching: z.number().min(0).optional(),
     unavailable_reason: z.string().optional(),
     alternative_offering_ids: z.array(z.string()).optional(),
     errors: z.array(ErrorSchema).optional(),
@@ -2932,14 +2932,14 @@ export const SIGetOfferingResponseSchema = z.object({
 
 export const SIIdentitySchema = z.object({
     consent_granted: z.boolean(),
-    consent_timestamp: z.string().optional(),
+    consent_timestamp: z.iso.datetime().optional(),
     consent_scope: z.array(z.union([z.literal("name"), z.literal("email"), z.literal("shipping_address"), z.literal("phone"), z.literal("locale")])).optional(),
     privacy_policy_acknowledged: z.object({
         brand_policy_url: z.string().optional(),
         brand_policy_version: z.string().optional()
     }).passthrough().optional(),
     user: z.object({
-        email: z.string().optional(),
+        email: z.email().optional(),
         name: z.string().optional(),
         locale: z.string().optional(),
         phone: z.string().optional(),
@@ -2962,8 +2962,8 @@ export const SIUIElementSchema = z.object({
 }).passthrough();
 
 export const SISendMessageRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
-    idempotency_key: z.string(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
+    idempotency_key: z.string().min(16).max(255).regex(/^[A-Za-z0-9_.:-]{16,255}$/),
     session_id: z.string(),
     message: z.string().optional(),
     action_response: z.object({
@@ -3004,7 +3004,7 @@ export const SISendMessageResponseSchema = z.object({
 }).passthrough();
 
 export const SITerminateSessionRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
     session_id: z.string(),
     reason: z.union([z.literal("handoff_transaction"), z.literal("handoff_complete"), z.literal("user_exit"), z.literal("session_timeout"), z.literal("host_terminated")]),
     termination_context: z.object({
@@ -3027,7 +3027,7 @@ export const SITerminateSessionResponseSchema = z.object({
         checkout_url: z.string().optional(),
         checkout_token: z.string().optional(),
         payload: z.object({}).passthrough().optional(),
-        expires_at: z.string().optional()
+        expires_at: z.iso.datetime().optional()
     }).passthrough().optional(),
     follow_up: z.object({
         action: z.union([z.literal("save_for_later"), z.literal("set_reminder"), z.literal("subscribe_updates"), z.literal("none")]).optional(),
@@ -3040,7 +3040,7 @@ export const SITerminateSessionResponseSchema = z.object({
 
 export const PublisherCollectionsSourceSchema = z.object({
     selection_type: z.literal("publisher_collections"),
-    publisher_domain: z.string(),
+    publisher_domain: z.string().regex(/^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/),
     collection_ids: z.array(z.string())
 }).passthrough();
 
@@ -3058,13 +3058,13 @@ export const DistributionIDsSourceSchema = z.object({
 
 export const PublisherGenresSourceSchema = z.object({
     selection_type: z.literal("publisher_genres"),
-    publisher_domain: z.string(),
+    publisher_domain: z.string().regex(/^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/),
     genres: z.array(z.string()),
     genre_taxonomy: GenreTaxonomySchema
 }).passthrough();
 
 export const CollectionListChangedWebhookSchema = z.object({
-    idempotency_key: z.string(),
+    idempotency_key: z.string().min(16).max(255).regex(/^[A-Za-z0-9_.:-]{16,255}$/),
     event: z.literal("collection_list_changed"),
     list_id: z.string(),
     list_name: z.string().optional(),
@@ -3073,8 +3073,8 @@ export const CollectionListChangedWebhookSchema = z.object({
         collections_removed: z.number().optional(),
         total_collections: z.number().optional()
     }).passthrough().optional(),
-    resolved_at: z.string(),
-    cache_valid_until: z.string().optional(),
+    resolved_at: z.iso.datetime(),
+    cache_valid_until: z.iso.datetime().optional(),
     signature: z.string(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -3100,13 +3100,13 @@ export const CollectionListFiltersSchema = z.object({
 export const BaseCollectionSourceSchema = z.union([DistributionIDsSourceSchema, PublisherCollectionsSourceSchema, PublisherGenresSourceSchema]);
 
 export const ArtifactWebhookPayloadSchema = z.object({
-    idempotency_key: z.string(),
+    idempotency_key: z.string().min(16).max(255).regex(/^[A-Za-z0-9_.:-]{16,255}$/),
     media_buy_id: z.string(),
     batch_id: z.string(),
-    timestamp: z.string(),
+    timestamp: z.iso.datetime(),
     artifacts: z.array(z.object({
         artifact: ArtifactSchema,
-        delivered_at: z.string(),
+        delivered_at: z.iso.datetime(),
         impression_id: z.string().optional(),
         package_id: z.string().optional()
     }).passthrough()),
@@ -3119,7 +3119,7 @@ export const ArtifactWebhookPayloadSchema = z.object({
 }).passthrough();
 
 export const AgentEncryptionKeySchema = z.object({
-    kid: z.string(),
+    kid: z.string().max(8),
     kty: z.literal("OKP"),
     crv: z.literal("X25519"),
     use: z.literal("enc"),
@@ -3136,12 +3136,12 @@ export const AgentSigningKeySchema = z.object({
     y: z.string().optional(),
     n: z.string().optional(),
     e: z.string().optional(),
-    revoked_at: z.string().optional()
+    revoked_at: z.iso.datetime().optional()
 }).passthrough();
 
 export const PriceSchema = z.object({
-    amount: z.number(),
-    currency: z.string(),
+    amount: z.number().min(0),
+    currency: z.string().regex(/^[A-Z]{3}$/),
     period: z.union([z.literal("night"), z.literal("month"), z.literal("year"), z.literal("one_time")]).optional()
 }).passthrough();
 
@@ -3171,25 +3171,25 @@ export const CollectionStatusSchema = z.union([z.literal("active"), z.literal("h
 export const CollectionRelationshipSchema = z.union([z.literal("spinoff"), z.literal("companion"), z.literal("sequel"), z.literal("prequel"), z.literal("crossover")]);
 
 export const LimitedSeriesSchema = z.object({
-    total_installments: z.number(),
-    starts: z.string().optional(),
-    ends: z.string().optional()
+    total_installments: z.number().min(1),
+    starts: z.iso.datetime().optional(),
+    ends: z.iso.datetime().optional()
 }).passthrough();
 
 export const DeadlinePolicySchema = z.object({
-    booking_lead_days: z.number().optional(),
-    cancellation_lead_days: z.number().optional(),
+    booking_lead_days: z.number().min(0).optional(),
+    cancellation_lead_days: z.number().min(0).optional(),
     material_stages: z.array(z.object({
         stage: z.string(),
-        lead_days: z.number(),
+        lead_days: z.number().min(0),
         label: z.string().optional()
     }).passthrough()).optional(),
     business_days_only: z.boolean().optional()
 }).passthrough();
 
 export const DateRangeSchema = z.object({
-    start: z.string(),
-    end: z.string()
+    start: z.iso.date(),
+    end: z.iso.date()
 }).passthrough();
 
 export const DestinationItemSchema = z.object({
@@ -3198,16 +3198,16 @@ export const DestinationItemSchema = z.object({
     description: z.string().optional(),
     city: z.string().optional(),
     region: z.string().optional(),
-    country: z.string().optional(),
+    country: z.string().regex(/^[A-Z]{2}$/).optional(),
     location: z.object({
-        lat: z.number(),
-        lng: z.number()
+        lat: z.number().min(-90).max(90),
+        lng: z.number().min(-180).max(180)
     }).passthrough().optional(),
     destination_type: z.union([z.literal("beach"), z.literal("mountain"), z.literal("urban"), z.literal("cultural"), z.literal("adventure"), z.literal("wellness"), z.literal("cruise")]).optional(),
     price: PriceSchema.optional(),
     image_url: z.string().optional(),
     url: z.string().optional(),
-    rating: z.number().optional(),
+    rating: z.number().min(1).max(5).optional(),
     tags: z.array(z.string()).optional(),
     assets: z.array(OfferingAssetGroupSchema).optional(),
     ext: ExtensionObjectSchema.optional()
@@ -3223,7 +3223,7 @@ export const EducationItemSchema = z.object({
     level: z.union([z.literal("beginner"), z.literal("intermediate"), z.literal("advanced")]).optional(),
     price: PriceSchema.optional(),
     duration: z.string().optional(),
-    start_date: z.string().optional(),
+    start_date: z.iso.date().optional(),
     language: z.string().optional(),
     modality: z.union([z.literal("online"), z.literal("in_person"), z.literal("hybrid")]).optional(),
     location: z.string().optional(),
@@ -3237,18 +3237,18 @@ export const EducationItemSchema = z.object({
 export const FlightItemSchema = z.object({
     flight_id: z.string(),
     origin: z.object({
-        airport_code: z.string(),
+        airport_code: z.string().regex(/^[A-Z]{3}$/),
         city: z.string().optional()
     }).passthrough(),
     destination: z.object({
-        airport_code: z.string(),
+        airport_code: z.string().regex(/^[A-Z]{3}$/),
         city: z.string().optional()
     }).passthrough(),
     airline: z.string().optional(),
     price: PriceSchema.optional(),
     description: z.string().optional(),
-    departure_time: z.string().optional(),
-    arrival_time: z.string().optional(),
+    departure_time: z.iso.datetime().optional(),
+    arrival_time: z.iso.datetime().optional(),
     image_url: z.string().optional(),
     url: z.string().optional(),
     tags: z.array(z.string()).optional(),
@@ -3266,91 +3266,91 @@ export const ImageAssetRequirementsSchema = z.object({
     min_height: z.number().optional(),
     max_height: z.number().optional(),
     unit: DimensionUnitSchema.optional(),
-    aspect_ratio: z.string().optional(),
+    aspect_ratio: z.string().regex(/^\d+(\.\d+)?:\d+(\.\d+)?$/).optional(),
     formats: z.array(z.union([z.literal("jpg"), z.literal("jpeg"), z.literal("png"), z.literal("gif"), z.literal("webp"), z.literal("svg"), z.literal("avif"), z.literal("tiff"), z.literal("pdf"), z.literal("eps")])).optional(),
-    min_dpi: z.number().optional(),
+    min_dpi: z.number().min(1).optional(),
     bleed: z.union([z.object({
-            uniform: z.number()
+            uniform: z.number().min(0)
         }).passthrough(), z.object({
-            top: z.number(),
-            right: z.number(),
-            bottom: z.number(),
-            left: z.number()
+            top: z.number().min(0),
+            right: z.number().min(0),
+            bottom: z.number().min(0),
+            left: z.number().min(0)
         }).passthrough()]).optional(),
     color_space: z.union([z.literal("rgb"), z.literal("cmyk"), z.literal("grayscale")]).optional(),
-    max_file_size_kb: z.number().optional(),
+    max_file_size_kb: z.number().min(1).optional(),
     transparency_required: z.boolean().optional(),
     animation_allowed: z.boolean().optional(),
-    max_animation_duration_ms: z.number().optional(),
+    max_animation_duration_ms: z.number().min(0).optional(),
     max_weight_grams: z.number().optional()
 }).passthrough();
 
 export const VideoAssetRequirementsSchema = z.object({
-    min_width: z.number().optional(),
-    max_width: z.number().optional(),
-    min_height: z.number().optional(),
-    max_height: z.number().optional(),
-    aspect_ratio: z.string().optional(),
-    min_duration_ms: z.number().optional(),
-    max_duration_ms: z.number().optional(),
+    min_width: z.number().min(1).optional(),
+    max_width: z.number().min(1).optional(),
+    min_height: z.number().min(1).optional(),
+    max_height: z.number().min(1).optional(),
+    aspect_ratio: z.string().regex(/^\d+:\d+$/).optional(),
+    min_duration_ms: z.number().min(1).optional(),
+    max_duration_ms: z.number().min(1).optional(),
     containers: z.array(z.union([z.literal("mp4"), z.literal("webm"), z.literal("mov"), z.literal("avi"), z.literal("mkv")])).optional(),
     codecs: z.array(z.union([z.literal("h264"), z.literal("h265"), z.literal("vp8"), z.literal("vp9"), z.literal("av1"), z.literal("prores")])).optional(),
-    max_file_size_kb: z.number().optional(),
-    min_bitrate_kbps: z.number().optional(),
-    max_bitrate_kbps: z.number().optional(),
+    max_file_size_kb: z.number().min(1).optional(),
+    min_bitrate_kbps: z.number().min(1).optional(),
+    max_bitrate_kbps: z.number().min(1).optional(),
     frame_rates: z.array(z.number()).optional(),
     audio_required: z.boolean().optional(),
     frame_rate_type: FrameRateTypeSchema.optional(),
     scan_type: ScanTypeSchema.optional(),
     gop_type: GOPTypeSchema.optional(),
-    min_gop_interval_seconds: z.number().optional(),
-    max_gop_interval_seconds: z.number().optional(),
+    min_gop_interval_seconds: z.number().min(0).optional(),
+    max_gop_interval_seconds: z.number().min(0).optional(),
     moov_atom_position: MoovAtomPositionSchema.optional(),
     audio_codecs: z.array(z.union([z.literal("aac"), z.literal("pcm"), z.literal("ac3"), z.literal("eac3"), z.literal("mp3"), z.literal("opus"), z.literal("vorbis"), z.literal("flac")])).optional(),
     audio_sample_rates: z.array(z.number()).optional(),
     audio_channels: z.array(AudioChannelLayoutSchema).optional(),
     loudness_lufs: z.number().optional(),
-    loudness_tolerance_db: z.number().optional(),
+    loudness_tolerance_db: z.number().min(0).optional(),
     true_peak_dbfs: z.number().optional()
 }).passthrough();
 
 export const AudioAssetRequirementsSchema = z.object({
-    min_duration_ms: z.number().optional(),
-    max_duration_ms: z.number().optional(),
+    min_duration_ms: z.number().min(1).optional(),
+    max_duration_ms: z.number().min(1).optional(),
     formats: z.array(z.union([z.literal("mp3"), z.literal("aac"), z.literal("wav"), z.literal("ogg"), z.literal("flac")])).optional(),
-    max_file_size_kb: z.number().optional(),
+    max_file_size_kb: z.number().min(1).optional(),
     sample_rates: z.array(z.number()).optional(),
     channels: z.array(z.union([z.literal("mono"), z.literal("stereo")])).optional(),
-    min_bitrate_kbps: z.number().optional(),
-    max_bitrate_kbps: z.number().optional()
+    min_bitrate_kbps: z.number().min(1).optional(),
+    max_bitrate_kbps: z.number().min(1).optional()
 }).passthrough();
 
 export const TextAssetRequirementsSchema = z.object({
-    min_length: z.number().optional(),
-    max_length: z.number().optional(),
-    min_lines: z.number().optional(),
-    max_lines: z.number().optional(),
+    min_length: z.number().min(0).optional(),
+    max_length: z.number().min(1).optional(),
+    min_lines: z.number().min(1).optional(),
+    max_lines: z.number().min(1).optional(),
     character_pattern: z.string().optional(),
     prohibited_terms: z.array(z.string()).optional()
 }).passthrough();
 
 export const MarkdownAssetRequirementsSchema = z.object({
-    max_length: z.number().optional()
+    max_length: z.number().min(1).optional()
 }).passthrough();
 
 export const HTMLAssetRequirementsSchema = z.object({
-    max_file_size_kb: z.number().optional(),
+    max_file_size_kb: z.number().min(1).optional(),
     sandbox: z.union([z.literal("none"), z.literal("iframe"), z.literal("safeframe"), z.literal("fencedframe")]).optional(),
     external_resources_allowed: z.boolean().optional(),
     allowed_external_domains: z.array(z.string()).optional()
 }).passthrough();
 
 export const CSSAssetRequirementsSchema = z.object({
-    max_file_size_kb: z.number().optional()
+    max_file_size_kb: z.number().min(1).optional()
 }).passthrough();
 
 export const JavaScriptAssetRequirementsSchema = z.object({
-    max_file_size_kb: z.number().optional(),
+    max_file_size_kb: z.number().min(1).optional(),
     module_type: z.union([z.literal("script"), z.literal("module"), z.literal("iife")]).optional(),
     strict_mode_required: z.boolean().optional(),
     external_resources_allowed: z.boolean().optional(),
@@ -3369,7 +3369,7 @@ export const URLAssetRequirementsSchema = z.object({
     role: z.union([z.literal("clickthrough"), z.literal("landing_page"), z.literal("impression_tracker"), z.literal("click_tracker"), z.literal("viewability_tracker"), z.literal("third_party_tracker")]).optional(),
     protocols: z.array(z.union([z.literal("https"), z.literal("http")])).optional(),
     allowed_domains: z.array(z.string()).optional(),
-    max_length: z.number().optional(),
+    max_length: z.number().min(1).optional(),
     macro_support: z.boolean().optional()
 }).passthrough();
 
@@ -3388,8 +3388,8 @@ export const OverlaySchema = z.object({
     bounds: z.object({
         x: z.number(),
         y: z.number(),
-        width: z.number(),
-        height: z.number(),
+        width: z.number().min(0),
+        height: z.number().min(0),
         unit: z.union([z.literal("px"), z.literal("fraction"), z.literal("inches"), z.literal("cm"), z.literal("mm"), z.literal("pt")])
     }).passthrough()
 }).passthrough();
@@ -3406,27 +3406,27 @@ export const HotelItemSchema = z.object({
     name: z.string(),
     description: z.string().optional(),
     location: z.object({
-        lat: z.number(),
-        lng: z.number()
+        lat: z.number().min(-90).max(90),
+        lng: z.number().min(-180).max(180)
     }).passthrough(),
     address: z.object({
         street: z.string().optional(),
         city: z.string().optional(),
         region: z.string().optional(),
         postal_code: z.string().optional(),
-        country: z.string().optional()
+        country: z.string().regex(/^[A-Z]{2}$/).optional()
     }).passthrough().optional(),
-    star_rating: z.number().optional(),
+    star_rating: z.number().min(1).max(5).optional(),
     price: PriceSchema.optional(),
     image_url: z.string().optional(),
     url: z.string().optional(),
     phone: z.string().optional(),
     amenities: z.array(z.string()).optional(),
-    check_in_time: z.string().optional(),
-    check_out_time: z.string().optional(),
+    check_in_time: z.string().regex(/^[0-2][0-9]:[0-5][0-9]$/).optional(),
+    check_out_time: z.string().regex(/^[0-2][0-9]:[0-5][0-9]$/).optional(),
     tags: z.array(z.string()).optional(),
-    valid_from: z.string().optional(),
-    valid_to: z.string().optional(),
+    valid_from: z.iso.date().optional(),
+    valid_to: z.iso.date().optional(),
     assets: z.array(OfferingAssetGroupSchema).optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -3440,13 +3440,13 @@ export const JobItemSchema = z.object({
     employment_type: z.union([z.literal("full_time"), z.literal("part_time"), z.literal("contract"), z.literal("temporary"), z.literal("internship"), z.literal("freelance")]).optional(),
     experience_level: z.union([z.literal("entry_level"), z.literal("mid_level"), z.literal("senior"), z.literal("director"), z.literal("executive")]).optional(),
     salary: z.object({
-        min: z.number().optional(),
-        max: z.number().optional(),
-        currency: z.string(),
+        min: z.number().min(0).optional(),
+        max: z.number().min(0).optional(),
+        currency: z.string().regex(/^[A-Z]{3}$/),
         period: z.union([z.literal("hour"), z.literal("month"), z.literal("year")])
     }).passthrough().optional(),
-    date_posted: z.string().optional(),
-    valid_through: z.string().optional(),
+    date_posted: z.iso.date().optional(),
+    valid_through: z.iso.date().optional(),
     apply_url: z.string().optional(),
     job_functions: z.array(z.string()).optional(),
     industries: z.array(z.string()).optional(),
@@ -3460,8 +3460,8 @@ export const OfferingSchema = z.object({
     name: z.string(),
     description: z.string().optional(),
     tagline: z.string().optional(),
-    valid_from: z.string().optional(),
-    valid_to: z.string().optional(),
+    valid_from: z.iso.datetime().optional(),
+    valid_to: z.iso.datetime().optional(),
     checkout_url: z.string().optional(),
     landing_url: z.string().optional(),
     assets: z.array(OfferingAssetGroupSchema).optional(),
@@ -3488,15 +3488,15 @@ export const PerformanceFeedbackSchema = z.object({
     package_id: z.string().optional(),
     creative_id: z.string().optional(),
     measurement_period: z.object({
-        start: z.string(),
-        end: z.string()
+        start: z.iso.datetime(),
+        end: z.iso.datetime()
     }).passthrough(),
-    performance_index: z.number(),
+    performance_index: z.number().min(0),
     metric_type: MetricTypeSchema,
     feedback_source: FeedbackSourceSchema,
     status: z.union([z.literal("accepted"), z.literal("queued"), z.literal("applied"), z.literal("rejected")]),
-    submitted_at: z.string(),
-    applied_at: z.string().optional()
+    submitted_at: z.iso.datetime(),
+    applied_at: z.iso.datetime().optional()
 }).passthrough();
 
 export const PlacementDefinitionSchema = z.object({
@@ -3516,10 +3516,10 @@ export const ProtocolEnvelopeSchema = z.object({
     task_id: z.string().optional(),
     status: TaskStatusSchema,
     message: z.string().optional(),
-    timestamp: z.string().optional(),
+    timestamp: z.iso.datetime().optional(),
     replayed: z.boolean().optional(),
     push_notification_config: PushNotificationConfigSchema.optional(),
-    governance_context: z.string().optional(),
+    governance_context: z.string().min(1).max(4096).regex(/^[\x20-\x7E]+$/).optional(),
     payload: z.object({}).passthrough()
 }).passthrough();
 
@@ -3531,21 +3531,21 @@ export const RealEstateItemSchema = z.object({
         city: z.string().optional(),
         region: z.string().optional(),
         postal_code: z.string().optional(),
-        country: z.string().optional()
+        country: z.string().regex(/^[A-Z]{2}$/).optional()
     }).passthrough(),
     price: PriceSchema.optional(),
     property_type: z.union([z.literal("house"), z.literal("apartment"), z.literal("condo"), z.literal("townhouse"), z.literal("land"), z.literal("commercial")]).optional(),
     listing_type: z.union([z.literal("for_sale"), z.literal("for_rent")]).optional(),
-    bedrooms: z.number().optional(),
-    bathrooms: z.number().optional(),
+    bedrooms: z.number().min(0).optional(),
+    bathrooms: z.number().min(0).optional(),
     area: z.object({
-        value: z.number(),
+        value: z.number().min(0),
         unit: z.union([z.literal("sqft"), z.literal("sqm")])
     }).passthrough().optional(),
     description: z.string().optional(),
     location: z.object({
-        lat: z.number(),
-        lng: z.number()
+        lat: z.number().min(-90).max(90),
+        lng: z.number().min(-180).max(180)
     }).passthrough().optional(),
     image_url: z.string().optional(),
     url: z.string().optional(),
@@ -3576,8 +3576,8 @@ export const OfferingAssetConstraintSchema = z.object({
     asset_group_id: z.string(),
     asset_type: AssetContentTypeSchema,
     required: z.boolean().optional(),
-    min_count: z.number().optional(),
-    max_count: z.number().optional(),
+    min_count: z.number().min(1).optional(),
+    max_count: z.number().min(1).optional(),
     asset_requirements: AssetRequirementsSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -3598,15 +3598,15 @@ export const ProtocolResponseSchema = z.object({
 
 export const SellerAgentReferenceSchema = z.object({
     agent_url: z.string(),
-    id: z.string().optional()
+    id: z.string().min(1).regex(/^[a-zA-Z0-9_-]+$/).optional()
 }).passthrough();
 
 export const RestrictedAttributeSchema = z.union([z.literal("racial_ethnic_origin"), z.literal("political_opinions"), z.literal("religious_beliefs"), z.literal("trade_union_membership"), z.literal("health_data"), z.literal("sex_life_sexual_orientation"), z.literal("genetic_data"), z.literal("biometric_data"), z.literal("age"), z.literal("familial_status")]);
 
 export const SignalDefinitionSchema = z.object({
-    id: z.string(),
-    name: z.string(),
-    description: z.string().optional(),
+    id: z.string().regex(/^[a-zA-Z0-9_-]+$/),
+    name: z.string().min(1).max(255),
+    description: z.string().max(2000).optional(),
     value_type: SignalValueTypeSchema,
     tags: z.array(z.string()).optional(),
     allowed_values: z.array(z.string()).optional(),
@@ -3625,7 +3625,7 @@ export const CatchmentSchema = z.object({
     catchment_id: z.string(),
     label: z.string().optional(),
     travel_time: z.object({
-        value: z.number(),
+        value: z.number().min(1),
         unit: TravelTimeUnitSchema
     }).passthrough().optional(),
     transport_mode: TransportModeSchema.optional(),
@@ -3645,13 +3645,13 @@ export const VehicleItemSchema = z.object({
     title: z.string(),
     make: z.string(),
     model: z.string(),
-    year: z.number(),
+    year: z.number().min(1900),
     price: PriceSchema.optional(),
     condition: z.union([z.literal("new"), z.literal("used"), z.literal("certified_pre_owned")]).optional(),
     vin: z.string().optional(),
     trim: z.string().optional(),
     mileage: z.object({
-        value: z.number(),
+        value: z.number().min(0),
         unit: z.union([z.literal("km"), z.literal("mi")])
     }).passthrough().optional(),
     body_style: z.union([z.literal("sedan"), z.literal("suv"), z.literal("truck"), z.literal("coupe"), z.literal("convertible"), z.literal("wagon"), z.literal("van"), z.literal("hatchback")]).optional(),
@@ -3660,8 +3660,8 @@ export const VehicleItemSchema = z.object({
     exterior_color: z.string().optional(),
     interior_color: z.string().optional(),
     location: z.object({
-        lat: z.number(),
-        lng: z.number()
+        lat: z.number().min(-90).max(90),
+        lng: z.number().min(-180).max(180)
     }).passthrough().optional(),
     image_url: z.string().optional(),
     url: z.string().optional(),
@@ -3757,11 +3757,11 @@ export const VendorErrorCodeRegistrySchema = z.object({
 
 export const AdCPExtensionFileSchemaSchema = z.object({
     $schema: z.literal("http://json-schema.org/draft-07/schema#"),
-    $id: z.string(),
+    $id: z.string().regex(/^\/schemas\/extensions\/[a-z][a-z0-9_]*\.json$/),
     title: z.string(),
     description: z.string(),
-    valid_from: z.string(),
-    valid_until: z.string().optional(),
+    valid_from: z.string().regex(/^\d+\.\d+$/),
+    valid_until: z.string().regex(/^\d+\.\d+$/).optional(),
     docs_url: z.string().optional(),
     type: z.literal("object"),
     properties: z.object({}).passthrough(),
@@ -3770,7 +3770,7 @@ export const AdCPExtensionFileSchemaSchema = z.object({
 }).passthrough();
 
 export const AttributeDefinitionSchema = z.object({
-    attribute_id: z.string(),
+    attribute_id: z.string().regex(/^[a-z][a-z0-9_]*$/),
     name: z.string(),
     description: z.string(),
     regulatory_basis: z.array(z.object({
@@ -3790,7 +3790,7 @@ export const AudienceConstraintsSchema = z.object({
 }).passthrough();
 
 export const PolicyCategoryDefinitionSchema = z.object({
-    category_id: z.string(),
+    category_id: z.string().regex(/^[a-z][a-z0-9_]*$/),
     name: z.string(),
     description: z.string(),
     regulatory_frameworks: z.array(z.object({
@@ -3816,8 +3816,8 @@ export const ManifestSchema = z.record(z.string(), z.unknown());
 
 export const AdCPManifestSchema = z.object({
     $schema: z.string().optional(),
-    adcp_version: z.string(),
-    generated_at: z.string(),
+    adcp_version: z.string().regex(/^\d+\.\d+\.\d+(-[A-Za-z0-9.-]+)?$/),
+    generated_at: z.iso.datetime(),
     tools: z.record(z.string(), z.object({
             protocol: z.union([z.literal("media-buy"), z.literal("signals"), z.literal("governance"), z.literal("account"), z.literal("creative"), z.literal("brand"), z.literal("content-standards"), z.literal("property"), z.literal("collection"), z.literal("sponsored-intelligence"), z.literal("protocol"), z.literal("compliance"), z.literal("tmp"), z.literal("a2ui")]),
             mutating: z.boolean(),
@@ -3874,9 +3874,9 @@ export const PropertyFeatureDefinitionSchema = z.object({
 export const PropertyFeatureValueSchema = z.object({
     value: z.union([z.boolean(), z.number(), z.string()]),
     unit: z.string().optional(),
-    confidence: z.number().optional(),
-    measured_at: z.string().optional(),
-    expires_at: z.string().optional(),
+    confidence: z.number().min(0).max(1).optional(),
+    measured_at: z.iso.datetime().optional(),
+    expires_at: z.iso.datetime().optional(),
     methodology_version: z.string().optional(),
     details: z.object({}).passthrough().optional(),
     ext: ExtensionObjectSchema.optional()
@@ -3889,7 +3889,7 @@ export const PropertyFeatureSchema = z.object({
 }).passthrough();
 
 export const PropertyListChangedWebhookSchema = z.object({
-    idempotency_key: z.string(),
+    idempotency_key: z.string().min(16).max(255).regex(/^[A-Za-z0-9_.:-]{16,255}$/),
     event: z.literal("property_list_changed"),
     list_id: z.string(),
     list_name: z.string().optional(),
@@ -3898,8 +3898,8 @@ export const PropertyListChangedWebhookSchema = z.object({
         properties_removed: z.number().optional(),
         total_properties: z.number().optional()
     }).passthrough().optional(),
-    resolved_at: z.string(),
-    cache_valid_until: z.string().optional(),
+    resolved_at: z.iso.datetime(),
+    cache_valid_until: z.iso.datetime().optional(),
     signature: z.string(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -3970,9 +3970,9 @@ export const ProductFiltersSchema = z.object({
     is_fixed_price: z.boolean().optional(),
     format_ids: z.array(FormatReferenceStructuredObjectSchema).optional(),
     standard_formats_only: z.boolean().optional(),
-    min_exposures: z.number().optional(),
-    start_date: z.string().optional(),
-    end_date: z.string().optional(),
+    min_exposures: z.number().min(1).optional(),
+    start_date: z.iso.date().optional(),
+    end_date: z.iso.date().optional(),
     budget_range: z.record(z.string(), z.unknown()).optional(),
     countries: z.array(z.string()).optional(),
     regions: z.array(z.string()).optional(),
@@ -4003,7 +4003,7 @@ export const ProductFiltersSchema = z.object({
     geo_proximity: z.array(z.record(z.string(), z.unknown())).optional(),
     required_performance_standards: z.array(PerformanceStandardSchema).optional(),
     keywords: z.array(z.object({
-        keyword: z.string(),
+        keyword: z.string().min(1),
         match_type: MatchTypeSchema.optional()
     }).passthrough()).optional()
 }).passthrough();
@@ -4011,12 +4011,12 @@ export const ProductFiltersSchema = z.object({
 export const CPMPricingOptionSchema = z.object({
     pricing_option_id: z.string(),
     pricing_model: z.literal("cpm"),
-    currency: z.string(),
-    fixed_price: z.number().optional(),
-    floor_price: z.number().optional(),
+    currency: z.string().regex(/^[A-Z]{3}$/),
+    fixed_price: z.number().min(0).optional(),
+    floor_price: z.number().min(0).optional(),
     max_bid: z.boolean().optional(),
     price_guidance: PriceGuidanceSchema.optional(),
-    min_spend_per_package: z.number().optional(),
+    min_spend_per_package: z.number().min(0).optional(),
     price_breakdown: PriceBreakdownSchema.optional(),
     eligible_adjustments: z.array(PriceAdjustmentKindSchema).optional()
 }).passthrough();
@@ -4024,31 +4024,31 @@ export const CPMPricingOptionSchema = z.object({
 export const FlatRatePricingOptionSchema = z.object({
     pricing_option_id: z.string(),
     pricing_model: z.literal("flat_rate"),
-    currency: z.string(),
-    fixed_price: z.number().optional(),
-    floor_price: z.number().optional(),
+    currency: z.string().regex(/^[A-Z]{3}$/),
+    fixed_price: z.number().min(0).optional(),
+    floor_price: z.number().min(0).optional(),
     price_guidance: PriceGuidanceSchema.optional(),
     parameters: DoohParametersSchema.optional(),
-    min_spend_per_package: z.number().optional(),
+    min_spend_per_package: z.number().min(0).optional(),
     price_breakdown: PriceBreakdownSchema.optional(),
     eligible_adjustments: z.array(PriceAdjustmentKindSchema).optional()
 }).passthrough();
 
 export const ProposalSchema = z.object({
-    proposal_id: z.string(),
-    name: z.string(),
-    description: z.string().optional(),
+    proposal_id: z.string().max(255),
+    name: z.string().max(500),
+    description: z.string().max(2000).optional(),
     allocations: z.array(ProductAllocationSchema),
     proposal_status: ProposalStatusSchema.optional(),
-    expires_at: z.string().optional(),
+    expires_at: z.iso.datetime().optional(),
     insertion_order: InsertionOrderSchema.optional(),
     total_budget_guidance: z.object({
-        min: z.number().optional(),
-        recommended: z.number().optional(),
-        max: z.number().optional(),
+        min: z.number().min(0).optional(),
+        recommended: z.number().min(0).optional(),
+        max: z.number().min(0).optional(),
         currency: z.string().optional()
     }).passthrough().optional(),
-    brief_alignment: z.string().optional(),
+    brief_alignment: z.string().max(2000).optional(),
     forecast: DeliveryForecastSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -4057,7 +4057,7 @@ export const PricingOptionSchema = z.union([CPMPricingOptionSchema, VCPMPricingO
 
 export const ReportingCapabilitiesSchema = z.object({
     available_reporting_frequencies: z.array(ReportingFrequencySchema),
-    expected_delay_minutes: z.number(),
+    expected_delay_minutes: z.number().min(0),
     timezone: z.string(),
     supports_webhooks: z.boolean(),
     available_metrics: z.array(AvailableMetricSchema),
@@ -4081,8 +4081,8 @@ export const MeasurementReadinessSchema = z.object({
 }).passthrough();
 
 export const InstallmentDeadlinesSchema = z.object({
-    booking_deadline: z.string().optional(),
-    cancellation_deadline: z.string().optional(),
+    booking_deadline: z.iso.datetime().optional(),
+    cancellation_deadline: z.iso.datetime().optional(),
     material_deadlines: z.array(MaterialDeadlineSchema).optional()
 }).passthrough();
 
@@ -4182,7 +4182,7 @@ export const CreativeBriefSchema = z.object({
             position: DisclosurePositionSchema.optional(),
             jurisdictions: z.array(z.string()).optional(),
             regulation: z.string().optional(),
-            min_duration_ms: z.number().optional(),
+            min_duration_ms: z.number().min(1).optional(),
             language: z.string().optional(),
             persistence: DisclosurePersistenceSchema.optional()
         }).passthrough()).optional(),
@@ -4193,12 +4193,12 @@ export const CreativeBriefSchema = z.object({
 export const PackageSchema = z.object({
     package_id: z.string(),
     product_id: z.string().optional(),
-    budget: z.number().optional(),
+    budget: z.number().min(0).optional(),
     pacing: PacingSchema.optional(),
     pricing_option_id: z.string().optional(),
-    bid_price: z.number().optional(),
+    bid_price: z.number().min(0).optional(),
     price_breakdown: PriceBreakdownSchema.optional(),
-    impressions: z.number().optional(),
+    impressions: z.number().min(0).optional(),
     catalogs: z.array(CatalogSchema).optional(),
     format_ids: z.array(FormatReferenceStructuredObjectSchema).optional(),
     targeting_overlay: TargetingOverlaySchema.optional(),
@@ -4207,18 +4207,18 @@ export const PackageSchema = z.object({
     creative_assignments: z.array(CreativeAssignmentSchema).optional(),
     format_ids_to_provide: z.array(FormatReferenceStructuredObjectSchema).optional(),
     optimization_goals: z.array(OptimizationGoalSchema).optional(),
-    start_time: z.string().optional(),
-    end_time: z.string().optional(),
+    start_time: z.iso.datetime().optional(),
+    end_time: z.iso.datetime().optional(),
     paused: z.boolean().optional(),
     canceled: z.boolean().optional(),
     cancellation: z.object({
-        canceled_at: z.string(),
+        canceled_at: z.iso.datetime(),
         canceled_by: CanceledBySchema,
-        reason: z.string().optional(),
-        acknowledged_at: z.string().optional()
+        reason: z.string().max(500).optional(),
+        acknowledged_at: z.iso.datetime().optional()
     }).passthrough().optional(),
-    agency_estimate_number: z.string().optional(),
-    creative_deadline: z.string().optional(),
+    agency_estimate_number: z.string().max(100).optional(),
+    creative_deadline: z.iso.datetime().optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -4229,13 +4229,13 @@ export const PlannedDeliverySchema = z.object({
         regions: z.array(z.string()).optional()
     }).passthrough().optional(),
     channels: z.array(MediaChannelSchema).optional(),
-    start_time: z.string().optional(),
-    end_time: z.string().optional(),
+    start_time: z.iso.datetime().optional(),
+    end_time: z.iso.datetime().optional(),
     frequency_cap: FrequencyCapSchema.optional(),
     audience_summary: z.string().optional(),
     audience_targeting: z.array(AudienceSelectorSchema).optional(),
-    total_budget: z.number().optional(),
-    currency: z.string().optional(),
+    total_budget: z.number().min(0).optional(),
+    currency: z.string().regex(/^[A-Z]{3}$/).optional(),
     enforced_policies: z.array(z.string()).optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -4243,8 +4243,8 @@ export const PlannedDeliverySchema = z.object({
 export const UpdateMediaBuySuccessSchema = z.object({
     media_buy_id: z.string(),
     status: MediaBuyStatusSchema.optional(),
-    revision: z.number().optional(),
-    implementation_date: z.string().optional().nullable(),
+    revision: z.number().min(1).optional(),
+    implementation_date: z.iso.datetime().optional().nullable(),
     invoice_recipient: BusinessEntitySchema.optional(),
     affected_packages: z.array(PackageSchema).optional(),
     valid_actions: z.array(MediaBuyValidActionSchema).optional(),
@@ -4259,27 +4259,27 @@ export const GetMediaBuysResponseSchema = z.object({
         account: AccountSchema.optional(),
         invoice_recipient: BusinessEntitySchema.optional(),
         status: MediaBuyStatusSchema,
-        currency: z.string(),
-        total_budget: z.number().optional(),
-        start_time: z.string().optional(),
-        end_time: z.string().optional(),
-        creative_deadline: z.string().optional(),
-        confirmed_at: z.string().optional(),
+        currency: z.string().regex(/^[A-Z]{3}$/),
+        total_budget: z.number().min(0).optional(),
+        start_time: z.iso.datetime().optional(),
+        end_time: z.iso.datetime().optional(),
+        creative_deadline: z.iso.datetime().optional(),
+        confirmed_at: z.iso.datetime().optional(),
         cancellation: z.object({
-            canceled_at: z.string(),
+            canceled_at: z.iso.datetime(),
             canceled_by: CanceledBySchema,
-            reason: z.string().optional()
+            reason: z.string().max(500).optional()
         }).passthrough().optional(),
-        revision: z.number().optional(),
-        created_at: z.string().optional(),
-        updated_at: z.string().optional(),
+        revision: z.number().min(1).optional(),
+        created_at: z.iso.datetime().optional(),
+        updated_at: z.iso.datetime().optional(),
         valid_actions: z.array(MediaBuyValidActionSchema).optional(),
         history: z.array(z.object({
-            revision: z.number(),
-            timestamp: z.string(),
+            revision: z.number().min(1),
+            timestamp: z.iso.datetime(),
             actor: z.string().optional(),
             action: z.string(),
-            summary: z.string().optional(),
+            summary: z.string().max(500).optional(),
             package_id: z.string().optional(),
             ext: ExtensionObjectSchema.optional()
         }).passthrough()).optional(),
@@ -4296,59 +4296,59 @@ export const GetMediaBuysResponseSchema = z.object({
 export const GetMediaBuyDeliveryResponseSchema = z.object({
     notification_type: z.union([z.literal("scheduled"), z.literal("final"), z.literal("delayed"), z.literal("adjusted"), z.literal("window_update")]).optional(),
     partial_data: z.boolean().optional(),
-    unavailable_count: z.number().optional(),
-    sequence_number: z.number().optional(),
-    next_expected_at: z.string().optional(),
+    unavailable_count: z.number().min(0).optional(),
+    sequence_number: z.number().min(1).optional(),
+    next_expected_at: z.iso.datetime().optional(),
     reporting_period: z.object({
-        start: z.string(),
-        end: z.string()
+        start: z.iso.datetime(),
+        end: z.iso.datetime()
     }).passthrough(),
-    currency: z.string().optional(),
+    currency: z.string().regex(/^[A-Z]{3}$/).optional(),
     attribution_window: AttributionWindowSchema.optional(),
     aggregated_totals: z.object({
-        impressions: z.number(),
-        spend: z.number(),
-        clicks: z.number().optional(),
-        completed_views: z.number().optional(),
-        views: z.number().optional(),
-        conversions: z.number().optional(),
-        conversion_value: z.number().optional(),
-        roas: z.number().optional(),
-        new_to_brand_rate: z.number().optional(),
-        cost_per_acquisition: z.number().optional(),
-        completion_rate: z.number().optional(),
-        reach: z.number().optional(),
+        impressions: z.number().min(0),
+        spend: z.number().min(0),
+        clicks: z.number().min(0).optional(),
+        completed_views: z.number().min(0).optional(),
+        views: z.number().min(0).optional(),
+        conversions: z.number().min(0).optional(),
+        conversion_value: z.number().min(0).optional(),
+        roas: z.number().min(0).optional(),
+        new_to_brand_rate: z.number().min(0).max(1).optional(),
+        cost_per_acquisition: z.number().min(0).optional(),
+        completion_rate: z.number().min(0).max(1).optional(),
+        reach: z.number().min(0).optional(),
         reach_unit: ReachUnitSchema.optional(),
-        frequency: z.number().optional(),
-        media_buy_count: z.number()
+        frequency: z.number().min(0).optional(),
+        media_buy_count: z.number().min(0)
     }).passthrough().optional(),
     media_buy_deliveries: z.array(z.object({
         media_buy_id: z.string(),
         status: z.union([z.literal("pending_creatives"), z.literal("pending_start"), z.literal("pending"), z.literal("active"), z.literal("paused"), z.literal("completed"), z.literal("rejected"), z.literal("canceled"), z.literal("failed"), z.literal("reporting_delayed")]),
-        expected_availability: z.string().optional(),
+        expected_availability: z.iso.datetime().optional(),
         is_adjusted: z.boolean().optional(),
         pricing_model: PricingModelSchema.optional(),
         totals: DeliveryMetricsSchema.and(z.object({
-            effective_rate: z.number().optional()
+            effective_rate: z.number().min(0).optional()
         }).passthrough()),
         by_package: z.array(DeliveryMetricsSchema.and(z.object({
             package_id: z.string(),
-            pacing_index: z.number().optional(),
+            pacing_index: z.number().min(0).optional(),
             pricing_model: PricingModelSchema.optional(),
-            rate: z.number().optional(),
-            currency: z.string().optional(),
+            rate: z.number().min(0).optional(),
+            currency: z.string().regex(/^[A-Z]{3}$/).optional(),
             delivery_status: z.union([z.literal("delivering"), z.literal("completed"), z.literal("budget_exhausted"), z.literal("flight_ended"), z.literal("goal_met")]).optional(),
             paused: z.boolean().optional(),
             is_final: z.boolean().optional(),
-            measurement_window: z.string().optional(),
-            supersedes_window: z.string().optional(),
+            measurement_window: z.string().max(50).optional(),
+            supersedes_window: z.string().max(50).optional(),
             by_catalog_item: z.array(DeliveryMetricsSchema.and(z.object({
                 content_id: z.string().optional(),
                 content_id_type: ContentIDTypeSchema.optional()
             }).passthrough())).optional(),
             by_creative: z.array(DeliveryMetricsSchema.and(z.object({
                 creative_id: z.string(),
-                weight: z.number().optional()
+                weight: z.number().min(0).max(100).optional()
             }).passthrough())).optional(),
             by_keyword: z.array(DeliveryMetricsSchema.and(z.object({
                 keyword: z.string().optional(),
@@ -4381,23 +4381,23 @@ export const GetMediaBuyDeliveryResponseSchema = z.object({
             }).passthrough())).optional(),
             by_placement_truncated: z.boolean().optional(),
             daily_breakdown: z.array(z.object({
-                date: z.string(),
-                impressions: z.number(),
-                spend: z.number(),
-                conversions: z.number().optional(),
-                conversion_value: z.number().optional(),
-                roas: z.number().optional(),
-                new_to_brand_rate: z.number().optional()
+                date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+                impressions: z.number().min(0),
+                spend: z.number().min(0),
+                conversions: z.number().min(0).optional(),
+                conversion_value: z.number().min(0).optional(),
+                roas: z.number().min(0).optional(),
+                new_to_brand_rate: z.number().min(0).max(1).optional()
             }).passthrough()).optional()
         }).passthrough())),
         daily_breakdown: z.array(z.object({
-            date: z.string(),
-            impressions: z.number(),
-            spend: z.number(),
-            conversions: z.number().optional(),
-            conversion_value: z.number().optional(),
-            roas: z.number().optional(),
-            new_to_brand_rate: z.number().optional()
+            date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+            impressions: z.number().min(0),
+            spend: z.number().min(0),
+            conversions: z.number().min(0).optional(),
+            conversion_value: z.number().min(0).optional(),
+            roas: z.number().min(0).optional(),
+            new_to_brand_rate: z.number().min(0).max(1).optional()
         }).passthrough()).optional()
     }).passthrough()),
     errors: z.array(ErrorSchema).optional(),
@@ -4407,13 +4407,13 @@ export const GetMediaBuyDeliveryResponseSchema = z.object({
 }).passthrough();
 
 export const ProvidePerformanceFeedbackRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
-    media_buy_id: z.string(),
-    idempotency_key: z.string(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
+    media_buy_id: z.string().min(1),
+    idempotency_key: z.string().min(16).max(255).regex(/^[A-Za-z0-9_.:-]{16,255}$/),
     measurement_period: DatetimeRangeSchema,
-    performance_index: z.number(),
-    package_id: z.string().optional(),
-    creative_id: z.string().optional(),
+    performance_index: z.number().min(0),
+    package_id: z.string().min(1).optional(),
+    creative_id: z.string().min(1).optional(),
     metric_type: MetricTypeSchema.optional(),
     feedback_source: FeedbackSourceSchema.optional(),
     context: ContextObjectSchema.optional(),
@@ -4445,9 +4445,9 @@ export const SyncEventSourcesSuccessSchema = z.object({
 }).passthrough();
 
 export const EventSchema = z.object({
-    event_id: z.string(),
+    event_id: z.string().min(1).max(256),
     event_type: EventTypeSchema,
-    event_time: z.string(),
+    event_time: z.iso.datetime(),
     user_match: UserMatchSchema.optional(),
     custom_data: EventCustomDataSchema.optional(),
     action_source: ActionSourceSchema.optional(),
@@ -4470,7 +4470,7 @@ export const PreviewCreativeBatchResponseSchema = z.object({
 }).passthrough();
 
 export const ListCreativesRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
     filters: CreativeFiltersSchema.optional(),
     sort: z.object({
         field: CreativeSortFieldSchema.optional(),
@@ -4491,14 +4491,14 @@ export const ListCreativesRequestSchema = z.object({
 export const SyncCreativesResponseSchema = z.union([SyncCreativesSuccessSchema, SyncCreativesErrorSchema, SyncCreativesSubmittedSchema]);
 
 export const GetSignalsRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
     account: AccountReferenceSchema.optional(),
     signal_spec: z.string().optional(),
     signal_ids: z.array(SignalIDSchema).optional(),
     destinations: z.array(DestinationSchema).optional(),
     countries: z.array(z.string()).optional(),
     filters: SignalFiltersSchema.optional(),
-    max_results: z.number().optional(),
+    max_results: z.number().min(1).optional(),
     pagination: PaginationRequestSchema.optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
@@ -4518,7 +4518,7 @@ export const GetSignalsResponseSchema = z.object({
         }).passthrough().optional(),
         signal_type: SignalCatalogTypeSchema,
         data_provider: z.string(),
-        coverage_percentage: z.number(),
+        coverage_percentage: z.number().min(0).max(100),
         deployments: z.array(DeploymentSchema),
         pricing_options: z.array(VendorPricingOptionSchema)
     }).passthrough()),
@@ -4537,14 +4537,14 @@ export const ActivateSignalSuccessSchema = z.object({
 }).passthrough();
 
 export const CreatePropertyListRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
     account: AccountReferenceSchema.optional(),
     name: z.string(),
     description: z.string().optional(),
     base_properties: z.array(BasePropertySourceSchema).optional(),
     filters: PropertyListFiltersSchema.optional(),
     brand: BrandReferenceSchema.optional(),
-    idempotency_key: z.string(),
+    idempotency_key: z.string().min(16).max(255).regex(/^[A-Za-z0-9_.:-]{16,255}$/),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -4558,9 +4558,9 @@ export const PropertyListSchema = z.object({
     filters: PropertyListFiltersSchema.optional(),
     brand: BrandReferenceSchema.optional(),
     webhook_url: z.string().optional(),
-    cache_duration_hours: z.number().optional(),
-    created_at: z.string().optional(),
-    updated_at: z.string().optional(),
+    cache_duration_hours: z.number().min(1).optional(),
+    created_at: z.iso.datetime().optional(),
+    updated_at: z.iso.datetime().optional(),
     property_count: z.number().optional(),
     pricing_options: z.array(VendorPricingOptionSchema).optional()
 }).passthrough();
@@ -4576,8 +4576,8 @@ export const GetPropertyListResponseSchema = z.object({
     list: PropertyListSchema,
     identifiers: z.array(IdentifierSchema).optional(),
     pagination: PaginationResponseSchema.optional(),
-    resolved_at: z.string().optional(),
-    cache_valid_until: z.string().optional(),
+    resolved_at: z.iso.datetime().optional(),
+    cache_valid_until: z.iso.datetime().optional(),
     coverage_gaps: z.record(z.string(), z.array(IdentifierSchema)).optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
@@ -4591,14 +4591,14 @@ export const ListPropertyListsResponseSchema = z.object({
 }).passthrough();
 
 export const CreateCollectionListRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
     account: AccountReferenceSchema.optional(),
     name: z.string(),
     description: z.string().optional(),
     base_collections: z.array(BaseCollectionSourceSchema).optional(),
     filters: CollectionListFiltersSchema.optional(),
     brand: BrandReferenceSchema.optional(),
-    idempotency_key: z.string(),
+    idempotency_key: z.string().min(16).max(255).regex(/^[A-Za-z0-9_.:-]{16,255}$/),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -4612,14 +4612,14 @@ export const CollectionListSchema = z.object({
     filters: CollectionListFiltersSchema.optional(),
     brand: BrandReferenceSchema.optional(),
     webhook_url: z.string().optional(),
-    cache_duration_hours: z.number().optional(),
-    created_at: z.string().optional(),
-    updated_at: z.string().optional(),
+    cache_duration_hours: z.number().min(1).optional(),
+    created_at: z.iso.datetime().optional(),
+    updated_at: z.iso.datetime().optional(),
     collection_count: z.number().optional()
 }).passthrough();
 
 export const UpdateCollectionListRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
     list_id: z.string(),
     account: AccountReferenceSchema.optional(),
     name: z.string().optional(),
@@ -4630,7 +4630,7 @@ export const UpdateCollectionListRequestSchema = z.object({
     webhook_url: z.string().optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional(),
-    idempotency_key: z.string()
+    idempotency_key: z.string().min(16).max(255).regex(/^[A-Za-z0-9_.:-]{16,255}$/)
 }).passthrough();
 
 export const UpdateCollectionListResponseSchema = z.object({
@@ -4641,12 +4641,12 @@ export const UpdateCollectionListResponseSchema = z.object({
 }).passthrough();
 
 export const GetCollectionListRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
     list_id: z.string(),
     account: AccountReferenceSchema.optional(),
     resolve: z.boolean().optional(),
     pagination: z.object({
-        max_results: z.number().optional(),
+        max_results: z.number().min(1).max(10000).optional(),
         cursor: z.string().optional()
     }).passthrough().optional(),
     context: ContextObjectSchema.optional(),
@@ -4668,8 +4668,8 @@ export const GetCollectionListResponseSchema = z.object({
         kind: CollectionKindSchema.optional()
     }).passthrough()).optional(),
     pagination: PaginationResponseSchema.optional(),
-    resolved_at: z.string().optional(),
-    cache_valid_until: z.string().optional(),
+    resolved_at: z.iso.datetime().optional(),
+    cache_valid_until: z.iso.datetime().optional(),
     coverage_gaps: z.record(z.string(), z.array(z.object({
             type: DistributionIdentifierTypeSchema,
             value: z.string()
@@ -4679,7 +4679,7 @@ export const GetCollectionListResponseSchema = z.object({
 }).passthrough();
 
 export const ListCollectionListsRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
     account: AccountReferenceSchema.optional(),
     name_contains: z.string().optional(),
     pagination: PaginationRequestSchema.optional(),
@@ -4695,12 +4695,12 @@ export const ListCollectionListsResponseSchema = z.object({
 }).passthrough();
 
 export const DeleteCollectionListRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
     list_id: z.string(),
     account: AccountReferenceSchema.optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional(),
-    idempotency_key: z.string()
+    idempotency_key: z.string().min(16).max(255).regex(/^[A-Za-z0-9_.:-]{16,255}$/)
 }).passthrough();
 
 export const DeleteCollectionListResponseSchema = z.object({
@@ -4733,7 +4733,7 @@ export const GetContentStandardsResponseSchema = z.union([ContentStandardsSchema
     }).passthrough()]);
 
 export const CreateContentStandardsRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
     scope: z.object({
         countries_all: z.array(z.string()).optional(),
         channels_any: z.array(MediaChannelSchema).optional(),
@@ -4754,7 +4754,7 @@ export const CreateContentStandardsRequestSchema = z.object({
                 language: z.string().optional()
             }).passthrough(), ArtifactSchema])).optional()
     }).passthrough().optional(),
-    idempotency_key: z.string(),
+    idempotency_key: z.string().min(16).max(255).regex(/^[A-Za-z0-9_.:-]{16,255}$/),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -4762,24 +4762,24 @@ export const CreateContentStandardsRequestSchema = z.object({
 export const UpdateContentStandardsResponseSchema = z.union([UpdateContentStandardsSuccessSchema, UpdateContentStandardsErrorSchema]);
 
 export const CalibrateContentRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
     standards_id: z.string(),
     artifact: ArtifactSchema,
-    idempotency_key: z.string(),
+    idempotency_key: z.string().min(16).max(255).regex(/^[A-Za-z0-9_.:-]{16,255}$/),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
 export const CalibrateContentResponseSchema = z.union([z.object({
         verdict: BinaryVerdictSchema,
-        confidence: z.number().optional(),
+        confidence: z.number().min(0).max(1).optional(),
         explanation: z.string().optional(),
         features: z.array(z.object({
             feature_id: z.string(),
             status: FeatureCheckStatusSchema,
             policy_id: z.string().optional(),
             explanation: z.string().optional(),
-            confidence: z.number().optional()
+            confidence: z.number().min(0).max(1).optional()
         }).passthrough()).optional(),
         context: ContextObjectSchema.optional(),
         ext: ExtensionObjectSchema.optional()
@@ -4793,8 +4793,8 @@ export const GetCreativeFeaturesResponseSchema = z.union([z.object({
         results: z.array(CreativeFeatureResultSchema),
         detail_url: z.string().optional(),
         pricing_option_id: z.string().optional(),
-        vendor_cost: z.number().optional(),
-        currency: z.string().optional(),
+        vendor_cost: z.number().min(0).optional(),
+        currency: z.string().regex(/^[A-Z]{3}$/).optional(),
         consumption: CreativeConsumptionSchema.optional(),
         context: ContextObjectSchema.optional(),
         ext: ExtensionObjectSchema.optional()
@@ -4805,20 +4805,20 @@ export const GetCreativeFeaturesResponseSchema = z.union([z.object({
     }).passthrough()]);
 
 export const SyncPlansRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
-    idempotency_key: z.string(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
+    idempotency_key: z.string().min(16).max(255).regex(/^[A-Za-z0-9_.:-]{16,255}$/),
     plans: z.array(z.object({
         plan_id: z.string(),
         brand: BrandReferenceSchema,
-        objectives: z.string(),
+        objectives: z.string().max(2000),
         budget: z.union([z.object({
                 total: z.number(),
                 currency: z.string(),
                 per_seller_max_pct: z.number().optional(),
-                reallocation_threshold: z.number(),
+                reallocation_threshold: z.number().min(0),
                 allocations: z.record(z.string(), z.object({
-                        amount: z.number().optional(),
-                        max_pct: z.number().optional()
+                        amount: z.number().min(0).optional(),
+                        max_pct: z.number().min(0).max(100).optional()
                     }).passthrough()).optional()
             }).passthrough(), z.object({
                 total: z.number(),
@@ -4826,8 +4826,8 @@ export const SyncPlansRequestSchema = z.object({
                 per_seller_max_pct: z.number().optional(),
                 reallocation_unlimited: z.literal(true),
                 allocations: z.record(z.string(), z.object({
-                        amount: z.number().optional(),
-                        max_pct: z.number().optional()
+                        amount: z.number().min(0).optional(),
+                        max_pct: z.number().min(0).max(100).optional()
                     }).passthrough()).optional()
             }).passthrough()]),
         channels: z.object({
@@ -4839,8 +4839,8 @@ export const SyncPlansRequestSchema = z.object({
                 }).passthrough()).optional()
         }).passthrough().optional(),
         flight: z.object({
-            start: z.string(),
-            end: z.string()
+            start: z.iso.datetime(),
+            end: z.iso.datetime()
         }).passthrough(),
         countries: z.array(z.string()).optional(),
         regions: z.array(z.string()).optional(),
@@ -4849,7 +4849,7 @@ export const SyncPlansRequestSchema = z.object({
         audience: AudienceConstraintsSchema.optional(),
         restricted_attributes: z.array(RestrictedAttributeSchema).optional(),
         restricted_attributes_custom: z.array(z.string()).optional(),
-        min_audience_size: z.number().optional(),
+        min_audience_size: z.number().min(1).optional(),
         human_review_required: z.boolean().optional(),
         custom_policies: z.array(PolicyEntrySchema).optional(),
         approved_sellers: z.array(z.string()).optional().nullable(),
@@ -4861,7 +4861,7 @@ export const SyncPlansRequestSchema = z.object({
                 currency: z.string()
             }).passthrough().optional(),
             markets: z.array(z.string()).optional(),
-            expires_at: z.string().optional()
+            expires_at: z.iso.datetime().optional()
         }).passthrough()).optional(),
         portfolio: z.object({
             member_plan_ids: z.array(z.string()),
@@ -4900,27 +4900,27 @@ export const SyncPlansResponseSchema = z.object({
 }).passthrough();
 
 export const ReportPlanOutcomeRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
     plan_id: z.string(),
     check_id: z.string().optional(),
-    idempotency_key: z.string(),
+    idempotency_key: z.string().min(16).max(255).regex(/^[A-Za-z0-9_.:-]{16,255}$/),
     purchase_type: PurchaseTypeSchema.optional(),
     outcome: OutcomeTypeSchema,
     seller_response: z.object({
-        seller_reference: z.string().optional(),
-        committed_budget: z.number().optional(),
+        seller_reference: z.string().max(255).optional(),
+        committed_budget: z.number().min(0).optional(),
         packages: z.array(z.object({
-            budget: z.number().optional()
+            budget: z.number().min(0).optional()
         }).passthrough()).optional(),
         planned_delivery: PlannedDeliverySchema.optional(),
-        creative_deadline: z.string().optional()
+        creative_deadline: z.iso.datetime().optional()
     }).passthrough().optional(),
     delivery: z.object({
         reporting_period: z.object({
-            start: z.string(),
-            end: z.string()
+            start: z.iso.datetime(),
+            end: z.iso.datetime()
         }).passthrough().optional(),
-        impressions: z.number().optional(),
+        impressions: z.number().min(0).optional(),
         spend: z.number().optional(),
         cpm: z.number().optional(),
         viewability_rate: z.number().optional(),
@@ -4930,7 +4930,7 @@ export const ReportPlanOutcomeRequestSchema = z.object({
         code: z.string().optional(),
         message: z.string().optional()
     }).passthrough().optional(),
-    governance_context: z.string(),
+    governance_context: z.string().min(1).max(4096).regex(/^[\x20-\x7E]+$/),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -4955,7 +4955,7 @@ export const ReportPlanOutcomeResponseSchema = z.object({
 }).passthrough();
 
 export const GetPlanAuditLogsRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
     plan_ids: z.array(z.string()).optional(),
     portfolio_plan_ids: z.array(z.string()).optional(),
     governance_contexts: z.array(z.string()).optional(),
@@ -4994,26 +4994,26 @@ export const GetPlanAuditLogsResponseSchema = z.object({
                 check_id: z.string(),
                 reason: z.string(),
                 resolution: z.string().optional(),
-                resolved_at: z.string().optional()
+                resolved_at: z.iso.datetime().optional()
             }).passthrough()).optional(),
             drift_metrics: z.object({
-                escalation_rate: z.number().optional(),
+                escalation_rate: z.number().min(0).max(1).optional(),
                 escalation_rate_trend: z.union([z.literal("increasing"), z.literal("stable"), z.literal("declining")]).optional(),
-                auto_approval_rate: z.number().optional(),
-                human_override_rate: z.number().optional(),
-                mean_confidence: z.number().optional(),
+                auto_approval_rate: z.number().min(0).max(1).optional(),
+                human_override_rate: z.number().min(0).max(1).optional(),
+                mean_confidence: z.number().min(0).max(1).optional(),
                 thresholds: z.object({
-                    escalation_rate_max: z.number().optional(),
-                    escalation_rate_min: z.number().optional(),
-                    auto_approval_rate_max: z.number().optional(),
-                    human_override_rate_max: z.number().optional()
+                    escalation_rate_max: z.number().min(0).max(1).optional(),
+                    escalation_rate_min: z.number().min(0).max(1).optional(),
+                    auto_approval_rate_max: z.number().min(0).max(1).optional(),
+                    human_override_rate_max: z.number().min(0).max(1).optional()
                 }).passthrough().optional()
             }).passthrough().optional()
         }).passthrough(),
         entries: z.array(z.object({
             id: z.string(),
             type: z.union([z.literal("check"), z.literal("outcome")]),
-            timestamp: z.string(),
+            timestamp: z.iso.datetime(),
             plan_id: z.string().optional(),
             caller: z.string().optional(),
             tool: z.string().optional(),
@@ -5028,12 +5028,12 @@ export const GetPlanAuditLogsResponseSchema = z.object({
                 policy_id: z.string().optional(),
                 severity: EscalationSeveritySchema,
                 explanation: z.string(),
-                confidence: z.number().optional()
+                confidence: z.number().min(0).max(1).optional()
             }).passthrough()).optional(),
             outcome: OutcomeTypeSchema.optional(),
             committed_budget: z.number().optional(),
             governance_context: z.string().optional(),
-            plan_hash: z.string().optional(),
+            plan_hash: z.string().regex(/^[A-Za-z0-9_-]{43}$/).optional(),
             purchase_type: PurchaseTypeSchema.optional(),
             outcome_status: z.string().optional()
         }).passthrough()).optional(),
@@ -5051,24 +5051,24 @@ export const GetPlanAuditLogsResponseSchema = z.object({
 }).passthrough();
 
 export const CheckGovernanceRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
     plan_id: z.string(),
     caller: z.string(),
     purchase_type: PurchaseTypeSchema.optional(),
     tool: z.string().optional(),
     payload: z.object({}).passthrough().optional(),
-    governance_context: z.string().optional(),
+    governance_context: z.string().min(1).max(4096).regex(/^[\x20-\x7E]+$/).optional(),
     phase: GovernancePhaseSchema.optional(),
     planned_delivery: PlannedDeliverySchema.optional(),
     delivery_metrics: z.object({
         reporting_period: z.object({
-            start: z.string(),
-            end: z.string()
+            start: z.iso.datetime(),
+            end: z.iso.datetime()
         }).passthrough(),
-        spend: z.number().optional(),
-        cumulative_spend: z.number().optional(),
-        impressions: z.number().optional(),
-        cumulative_impressions: z.number().optional(),
+        spend: z.number().min(0).optional(),
+        cumulative_spend: z.number().min(0).optional(),
+        impressions: z.number().min(0).optional(),
+        cumulative_impressions: z.number().min(0).optional(),
         geo_distribution: z.record(z.string(), z.number()).optional(),
         channel_distribution: z.record(z.string(), z.number()).optional(),
         pacing: z.union([z.literal("ahead"), z.literal("on_track"), z.literal("behind")]).optional(),
@@ -5079,7 +5079,7 @@ export const CheckGovernanceRequestSchema = z.object({
             cumulative_indices: z.record(z.string(), z.number()).optional()
         }).passthrough().optional()
     }).passthrough().optional(),
-    modification_summary: z.string().optional(),
+    modification_summary: z.string().max(1000).optional(),
     invoice_recipient: BusinessEntitySchema.optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
@@ -5097,7 +5097,7 @@ export const CheckGovernanceResponseSchema = z.object({
         severity: EscalationSeveritySchema,
         explanation: z.string(),
         details: z.object({}).passthrough().optional(),
-        confidence: z.number().optional(),
+        confidence: z.number().min(0).max(1).optional(),
         uncertainty_reason: z.string().optional()
     }).passthrough()).optional(),
     conditions: z.array(z.object({
@@ -5105,18 +5105,18 @@ export const CheckGovernanceResponseSchema = z.object({
         required_value: z.unknown().optional(),
         reason: z.string()
     }).passthrough()).optional(),
-    expires_at: z.string().optional(),
-    next_check: z.string().optional(),
+    expires_at: z.iso.datetime().optional(),
+    next_check: z.iso.datetime().optional(),
     categories_evaluated: z.array(z.string()).optional(),
     policies_evaluated: z.array(z.string()).optional(),
     mode: GovernanceModeSchema.optional(),
-    governance_context: z.string().optional(),
+    governance_context: z.string().min(1).max(4096).regex(/^[\x20-\x7E]+$/).optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
 export const SIInitiateSessionRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
     intent: z.string(),
     context: ContextObjectSchema.optional(),
     identity: SIIdentitySchema,
@@ -5125,7 +5125,7 @@ export const SIInitiateSessionRequestSchema = z.object({
     offering_id: z.string().optional(),
     supported_capabilities: SICapabilitiesSchema.optional(),
     offering_token: z.string().optional(),
-    idempotency_key: z.string(),
+    idempotency_key: z.string().min(16).max(255).regex(/^[A-Za-z0-9_.:-]{16,255}$/),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
@@ -5137,7 +5137,7 @@ export const SIInitiateSessionResponseSchema = z.object({
     }).passthrough().optional(),
     negotiated_capabilities: SICapabilitiesSchema.optional(),
     session_status: SISessionStatusSchema,
-    session_ttl_seconds: z.number().optional(),
+    session_ttl_seconds: z.number().min(1).optional(),
     errors: z.array(ErrorSchema).optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
@@ -5218,10 +5218,10 @@ export const GetAdCPCapabilitiesResponseSchema = z.object({
             supported_identifier_types: z.array(z.union([z.literal("hashed_email"), z.literal("hashed_phone")])),
             supports_platform_customer_id: z.boolean().optional(),
             supported_uid_types: z.array(UIDTypeSchema).optional(),
-            minimum_audience_size: z.number(),
+            minimum_audience_size: z.number().min(1),
             matching_latency_hours: z.object({
-                min: z.number().optional(),
-                max: z.number().optional()
+                min: z.number().min(0).optional(),
+                max: z.number().min(0).optional()
             }).passthrough().optional()
         }).passthrough().optional(),
         conversion_tracking: z.object({
@@ -5245,8 +5245,8 @@ export const GetAdCPCapabilitiesResponseSchema = z.object({
             publisher_domains: z.array(z.string()),
             primary_channels: z.array(MediaChannelSchema).optional(),
             primary_countries: z.array(z.string()).optional(),
-            description: z.string().optional(),
-            advertising_policies: z.string().optional()
+            description: z.string().max(5000).optional(),
+            advertising_policies: z.string().max(10000).optional()
         }).passthrough().optional()
     }).passthrough().optional(),
     signals: z.object({
@@ -5256,7 +5256,7 @@ export const GetAdCPCapabilitiesResponseSchema = z.object({
         }).passthrough()).optional()
     }).passthrough().optional(),
     governance: z.object({
-        aggregation_window_days: z.number().optional(),
+        aggregation_window_days: z.number().min(1).max(365).optional(),
         property_features: z.array(z.object({
             feature_id: z.string(),
             type: z.union([z.literal("binary"), z.literal("quantitative"), z.literal("categorical")]),
@@ -5296,7 +5296,7 @@ export const GetAdCPCapabilitiesResponseSchema = z.object({
         right_types: z.array(RightTypeSchema).optional(),
         available_uses: z.array(RightUseSchema).optional(),
         generation_providers: z.array(z.string()).optional(),
-        description: z.string().optional()
+        description: z.string().max(5000).optional()
     }).passthrough().optional(),
     creative: z.object({
         supports_compliance: z.boolean().optional(),
@@ -5336,14 +5336,14 @@ export const GetAdCPCapabilitiesResponseSchema = z.object({
     specialisms: z.array(AdCPSpecialismSchema).optional(),
     extensions_supported: z.array(z.string()).optional(),
     experimental_features: z.array(z.string()).optional(),
-    last_updated: z.string().optional(),
+    last_updated: z.iso.datetime().optional(),
     errors: z.array(ErrorSchema).optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
 export const ListAccountsRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
     status: z.union([z.literal("active"), z.literal("pending_approval"), z.literal("rejected"), z.literal("payment_required"), z.literal("suspended"), z.literal("closed")]).optional(),
     pagination: PaginationRequestSchema.optional(),
     sandbox: z.boolean().optional(),
@@ -5360,11 +5360,11 @@ export const ListAccountsResponseSchema = z.object({
 }).passthrough();
 
 export const SyncAccountsRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
-    idempotency_key: z.string(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
+    idempotency_key: z.string().min(16).max(255).regex(/^[A-Za-z0-9_.:-]{16,255}$/),
     accounts: z.array(z.object({
         brand: BrandReferenceSchema,
-        operator: z.string(),
+        operator: z.string().regex(/^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/),
         billing: BillingPartySchema,
         billing_entity: BusinessEntitySchema.optional(),
         payment_terms: PaymentTermsSchema.optional(),
@@ -5393,13 +5393,13 @@ export const SyncAccountsSuccessSchema = z.object({
         setup: z.object({
             url: z.string().optional(),
             message: z.string(),
-            expires_at: z.string().optional()
+            expires_at: z.iso.datetime().optional()
         }).passthrough().optional(),
         rate_card: z.string().optional(),
         payment_terms: PaymentTermsSchema.optional(),
         credit_limit: z.object({
-            amount: z.number(),
-            currency: z.string()
+            amount: z.number().min(0),
+            currency: z.string().regex(/^[A-Z]{3}$/)
         }).passthrough().optional(),
         errors: z.array(ErrorSchema).optional(),
         warnings: z.array(z.string()).optional(),
@@ -5416,15 +5416,15 @@ export const SyncAccountsErrorSchema = z.object({
 }).passthrough();
 
 export const SyncGovernanceRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
-    idempotency_key: z.string(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
+    idempotency_key: z.string().min(16).max(255).regex(/^[A-Za-z0-9_.:-]{16,255}$/),
     accounts: z.array(z.object({
         account: AccountReferenceSchema,
         governance_agents: z.array(z.object({
-            url: z.string(),
+            url: z.string().regex(/^https:\/\//),
             authentication: z.object({
                 schemes: z.array(AuthenticationSchemeSchema),
-                credentials: z.string()
+                credentials: z.string().min(32)
             }).passthrough(),
             categories: z.array(z.string()).optional()
         }).passthrough())
@@ -5438,7 +5438,7 @@ export const SyncGovernanceSuccessSchema = z.object({
         account: AccountReferenceSchema,
         status: z.union([z.literal("synced"), z.literal("failed")]),
         governance_agents: z.array(z.object({
-            url: z.string(),
+            url: z.string().regex(/^https:\/\//),
             categories: z.array(z.string()).optional()
         }).passthrough()).optional(),
         errors: z.array(ErrorSchema).optional()
@@ -5454,17 +5454,17 @@ export const SyncGovernanceErrorSchema = z.object({
 }).passthrough();
 
 export const ReportUsageRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
     idempotency_key: z.string(),
     reporting_period: DatetimeRangeSchema,
     usage: z.array(z.object({
         account: AccountReferenceSchema,
         media_buy_id: z.string().optional(),
-        vendor_cost: z.number(),
-        currency: z.string(),
+        vendor_cost: z.number().min(0),
+        currency: z.string().regex(/^[A-Z]{3}$/),
         pricing_option_id: z.string().optional(),
-        impressions: z.number().optional(),
-        media_spend: z.number().optional(),
+        impressions: z.number().min(0).optional(),
+        media_spend: z.number().min(0).optional(),
         signal_agent_segment_id: z.string().optional(),
         standards_id: z.string().optional(),
         rights_id: z.string().optional(),
@@ -5476,7 +5476,7 @@ export const ReportUsageRequestSchema = z.object({
 }).passthrough();
 
 export const ReportUsageResponseSchema = z.object({
-    accepted: z.number(),
+    accepted: z.number().min(0),
     errors: z.array(ErrorSchema).optional(),
     sandbox: z.boolean().optional(),
     context: ContextObjectSchema.optional(),
@@ -5484,7 +5484,7 @@ export const ReportUsageResponseSchema = z.object({
 }).passthrough();
 
 export const GetAccountFinancialsRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
     account: AccountReferenceSchema,
     period: DateRangeSchema.optional(),
     context: ContextObjectSchema.optional(),
@@ -5493,23 +5493,23 @@ export const GetAccountFinancialsRequestSchema = z.object({
 
 export const GetAccountFinancialsSuccessSchema = z.object({
     account: AccountReferenceSchema,
-    currency: z.string(),
+    currency: z.string().regex(/^[A-Z]{3}$/),
     period: DateRangeSchema,
     timezone: z.string(),
     spend: z.object({
-        total_spend: z.number(),
-        media_buy_count: z.number().optional()
+        total_spend: z.number().min(0),
+        media_buy_count: z.number().min(0).optional()
     }).passthrough().optional(),
     credit: z.object({
-        credit_limit: z.number(),
+        credit_limit: z.number().min(0),
         available_credit: z.number(),
-        utilization_percent: z.number().optional()
+        utilization_percent: z.number().min(0).max(100).optional()
     }).passthrough().optional(),
     balance: z.object({
-        available: z.number(),
+        available: z.number().min(0),
         last_top_up: z.object({
-            amount: z.number(),
-            date: z.string()
+            amount: z.number().min(0),
+            date: z.iso.date()
         }).passthrough().optional()
     }).passthrough().optional(),
     payment_status: z.union([z.literal("current"), z.literal("past_due"), z.literal("suspended")]).optional(),
@@ -5517,10 +5517,10 @@ export const GetAccountFinancialsSuccessSchema = z.object({
     invoices: z.array(z.object({
         invoice_id: z.string(),
         period: DateRangeSchema.optional(),
-        amount: z.number(),
+        amount: z.number().min(0),
         status: z.union([z.literal("draft"), z.literal("issued"), z.literal("paid"), z.literal("past_due"), z.literal("void")]),
-        due_date: z.string().optional(),
-        paid_date: z.string().optional()
+        due_date: z.iso.date().optional(),
+        paid_date: z.iso.date().optional()
     }).passthrough()).optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
@@ -5563,7 +5563,7 @@ export const ForcedDirectiveSuccessSchema = z.object({
     success: z.literal(true),
     forced: z.object({
         arm: z.union([z.literal("submitted"), z.literal("input-required")]),
-        task_id: z.string().optional()
+        task_id: z.string().max(128).optional()
     }).passthrough(),
     message: z.string().optional(),
     context: ContextObjectSchema.optional(),
@@ -5597,8 +5597,8 @@ export const RepeatableGroupAssetSchema = z.object({
     item_type: z.literal("repeatable_group"),
     asset_group_id: z.string(),
     required: z.boolean(),
-    min_count: z.number(),
-    max_count: z.number(),
+    min_count: z.number().min(0),
+    max_count: z.number().min(1),
     selection_mode: z.union([z.literal("sequential"), z.literal("optimize")]).optional(),
     assets: z.array(GroupAssetSlotSchema)
 }).passthrough();
@@ -5608,19 +5608,19 @@ export const MediaBuySchema = z.object({
     account: AccountSchema.optional(),
     status: MediaBuyStatusSchema,
     rejection_reason: z.string().optional(),
-    confirmed_at: z.string().optional(),
+    confirmed_at: z.iso.datetime().optional(),
     cancellation: z.object({
-        canceled_at: z.string(),
+        canceled_at: z.iso.datetime(),
         canceled_by: CanceledBySchema,
-        reason: z.string().optional()
+        reason: z.string().max(500).optional()
     }).passthrough().optional(),
-    total_budget: z.number(),
+    total_budget: z.number().min(0),
     packages: z.array(PackageSchema),
     invoice_recipient: BusinessEntitySchema.optional(),
-    creative_deadline: z.string().optional(),
-    revision: z.number().optional(),
-    created_at: z.string().optional(),
-    updated_at: z.string().optional(),
+    creative_deadline: z.iso.datetime().optional(),
+    revision: z.number().min(1).optional(),
+    created_at: z.iso.datetime().optional(),
+    updated_at: z.iso.datetime().optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
@@ -5636,11 +5636,11 @@ export const InstallmentSchema = z.object({
     name: z.string().optional(),
     season: z.string().optional(),
     installment_number: z.string().optional(),
-    scheduled_at: z.string().optional(),
+    scheduled_at: z.iso.datetime().optional(),
     status: InstallmentStatusSchema.optional(),
-    duration_seconds: z.number().optional(),
+    duration_seconds: z.number().min(0).optional(),
     flexible_end: z.boolean().optional(),
-    valid_until: z.string().optional(),
+    valid_until: z.iso.datetime().optional(),
     content_rating: ContentRatingSchema.optional(),
     topics: z.array(z.string()).optional(),
     special: SpecialSchema.optional(),
@@ -5659,9 +5659,9 @@ export const CreateMediaBuySuccessSchema = z.object({
     account: AccountSchema.optional(),
     invoice_recipient: BusinessEntitySchema.optional(),
     status: MediaBuyStatusSchema.optional(),
-    confirmed_at: z.string().optional(),
-    creative_deadline: z.string().optional(),
-    revision: z.number().optional(),
+    confirmed_at: z.iso.datetime().optional(),
+    creative_deadline: z.iso.datetime().optional(),
+    revision: z.number().min(1).optional(),
     valid_actions: z.array(MediaBuyValidActionSchema).optional(),
     packages: z.array(PackageSchema),
     planned_delivery: PlannedDeliverySchema.optional(),
@@ -5703,7 +5703,7 @@ export const ProductSchema = z.object({
         supported_view_durations: z.array(z.number()).optional(),
         supported_targets: z.array(z.union([z.literal("cost_per"), z.literal("threshold_rate")])).optional()
     }).passthrough().optional(),
-    max_optimization_goals: z.number().optional(),
+    max_optimization_goals: z.number().min(1).optional(),
     measurement_readiness: MeasurementReadinessSchema.optional(),
     conversion_tracking: z.object({
         action_sources: z.array(ActionSourceSchema).optional(),
@@ -5713,11 +5713,11 @@ export const ProductSchema = z.object({
     catalog_match: z.object({
         matched_gtins: z.array(z.string()).optional(),
         matched_ids: z.array(z.string()).optional(),
-        matched_count: z.number().optional(),
-        submitted_count: z.number()
+        matched_count: z.number().min(0).optional(),
+        submitted_count: z.number().min(0)
     }).passthrough().optional(),
     brief_relevance: z.string().optional(),
-    expires_at: z.string().optional(),
+    expires_at: z.iso.datetime().optional(),
     product_card: z.object({
         format_id: FormatReferenceStructuredObjectSchema,
         manifest: z.object({}).passthrough()
@@ -5744,9 +5744,9 @@ export const ProductSchema = z.object({
         }).passthrough()).optional()
     }).passthrough().optional(),
     material_submission: z.object({
-        url: z.string().optional(),
-        email: z.string().optional(),
-        instructions: z.string().optional(),
+        url: z.string().regex(/^https:\/\//).optional(),
+        email: z.email().optional(),
+        instructions: z.string().max(2000).optional(),
         ext: ExtensionObjectSchema.optional()
     }).passthrough().optional(),
     ext: ExtensionObjectSchema.optional()
@@ -5772,7 +5772,7 @@ export const CreativeManifestSchema = z.object({
 export const BuildCreativeMultiSuccessSchema = z.object({
     creative_manifests: z.array(CreativeManifestSchema),
     sandbox: z.boolean().optional(),
-    expires_at: z.string().optional(),
+    expires_at: z.iso.datetime().optional(),
     preview: z.object({
         previews: z.array(z.object({
             preview_id: z.string(),
@@ -5785,19 +5785,19 @@ export const BuildCreativeMultiSuccessSchema = z.object({
             }).passthrough()
         }).passthrough()),
         interactive_url: z.string().optional(),
-        expires_at: z.string()
+        expires_at: z.iso.datetime()
     }).passthrough().optional(),
     preview_error: ErrorSchema.optional(),
     pricing_option_id: z.string().optional(),
-    vendor_cost: z.number().optional(),
-    currency: z.string().optional(),
+    vendor_cost: z.number().min(0).optional(),
+    currency: z.string().regex(/^[A-Z]{3}$/).optional(),
     consumption: CreativeConsumptionSchema.optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
 export const AcquireRightsRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
     rights_id: z.string(),
     pricing_option_id: z.string(),
     buyer: BrandReferenceSchema,
@@ -5806,13 +5806,13 @@ export const AcquireRightsRequestSchema = z.object({
         uses: z.array(RightUseSchema),
         countries: z.array(z.string()).optional(),
         format_ids: z.array(FormatReferenceStructuredObjectSchema).optional(),
-        estimated_impressions: z.number().optional(),
-        start_date: z.string().optional(),
-        end_date: z.string().optional()
+        estimated_impressions: z.number().min(0).optional(),
+        start_date: z.iso.date().optional(),
+        end_date: z.iso.date().optional()
     }).passthrough(),
     revocation_webhook: PushNotificationConfigSchema,
     push_notification_config: PushNotificationConfigSchema.optional(),
-    idempotency_key: z.string(),
+    idempotency_key: z.string().min(16).max(255).regex(/^[A-Za-z0-9_.:-]{16,255}$/),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -5840,8 +5840,8 @@ export const CreativeApprovalResponseSchema = z.union([CreativeApprovedSchema, C
 export const GetBrandIdentityResponseSchema = z.union([GetBrandIdentitySuccessSchema, GetBrandIdentityErrorSchema]);
 
 export const GetRightsRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
-    query: z.string(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
+    query: z.string().max(2000),
     uses: z.array(RightUseSchema),
     buyer_brand: BrandReferenceSchema.optional(),
     countries: z.array(z.string()).optional(),
@@ -5860,7 +5860,7 @@ export const GetRightsSuccessSchema = z.object({
         name: z.string(),
         description: z.string().optional(),
         right_type: RightTypeSchema.optional(),
-        match_score: z.number().optional(),
+        match_score: z.number().min(0).max(1).optional(),
         match_reasons: z.array(z.string()).optional(),
         available_uses: z.array(RightUseSchema),
         countries: z.array(z.string()).optional(),
@@ -5915,10 +5915,10 @@ export const CreativeVariantSchema = DeliveryMetricsSchema.and(z.object({
 export const GetCreativeDeliveryResponseSchema = z.object({
     account_id: z.string().optional(),
     media_buy_id: z.string().optional(),
-    currency: z.string(),
+    currency: z.string().regex(/^[A-Z]{3}$/),
     reporting_period: z.object({
-        start: z.string(),
-        end: z.string(),
+        start: z.iso.datetime(),
+        end: z.iso.datetime(),
         timezone: z.string().optional()
     }).passthrough(),
     creatives: z.array(z.object({
@@ -5926,14 +5926,14 @@ export const GetCreativeDeliveryResponseSchema = z.object({
         media_buy_id: z.string().optional(),
         format_id: FormatReferenceStructuredObjectSchema.optional(),
         totals: DeliveryMetricsSchema.optional(),
-        variant_count: z.number().optional(),
+        variant_count: z.number().min(0).optional(),
         variants: z.array(CreativeVariantSchema)
     }).passthrough()),
     pagination: z.object({
-        limit: z.number(),
-        offset: z.number(),
+        limit: z.number().min(1),
+        offset: z.number().min(0),
         has_more: z.boolean(),
-        total: z.number().optional()
+        total: z.number().min(0).optional()
     }).passthrough().optional(),
     errors: z.array(ErrorSchema).optional(),
     context: ContextObjectSchema.optional(),
@@ -5941,7 +5941,7 @@ export const GetCreativeDeliveryResponseSchema = z.object({
 }).passthrough();
 
 export const GetCreativeFeaturesRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
     creative_manifest: CreativeManifestSchema,
     feature_ids: z.array(z.string()).optional(),
     account: AccountReferenceSchema.optional(),
@@ -5951,8 +5951,8 @@ export const GetCreativeFeaturesRequestSchema = z.object({
 
 export const ListCreativesResponseSchema = z.object({
     query_summary: z.object({
-        total_matching: z.number(),
-        returned: z.number(),
+        total_matching: z.number().min(0),
+        returned: z.number().min(0),
         filters_applied: z.array(z.string()).optional(),
         sort_applied: z.object({
             field: z.string().optional(),
@@ -5966,25 +5966,25 @@ export const ListCreativesResponseSchema = z.object({
         name: z.string(),
         format_id: FormatReferenceStructuredObjectSchema,
         status: CreativeStatusSchema,
-        created_date: z.string(),
-        updated_date: z.string(),
+        created_date: z.iso.datetime(),
+        updated_date: z.iso.datetime(),
         assets: z.record(z.string(), AssetVariantSchema).optional(),
         tags: z.array(z.string()).optional(),
         concept_id: z.string().optional(),
         concept_name: z.string().optional(),
         variables: z.array(CreativeVariableSchema).optional(),
         assignments: z.object({
-            assignment_count: z.number(),
+            assignment_count: z.number().min(0),
             assigned_packages: z.array(z.object({
                 package_id: z.string(),
-                assigned_date: z.string()
+                assigned_date: z.iso.datetime()
             }).passthrough()).optional()
         }).passthrough().optional(),
         snapshot: z.object({
-            as_of: z.string(),
-            staleness_seconds: z.number(),
-            impressions: z.number(),
-            last_served: z.string().optional()
+            as_of: z.iso.datetime(),
+            staleness_seconds: z.number().min(0),
+            impressions: z.number().min(0),
+            last_served: z.iso.datetime().optional()
         }).passthrough().optional(),
         snapshot_unavailable_reason: SnapshotUnavailableReasonSchema.optional(),
         items: z.array(CreativeItemSchema).optional(),
@@ -5992,11 +5992,11 @@ export const ListCreativesResponseSchema = z.object({
     }).passthrough()),
     format_summary: z.record(z.string(), z.number()).optional(),
     status_summary: z.object({
-        processing: z.number().optional(),
-        approved: z.number().optional(),
-        pending_review: z.number().optional(),
-        rejected: z.number().optional(),
-        archived: z.number().optional()
+        processing: z.number().min(0).optional(),
+        approved: z.number().min(0).optional(),
+        pending_review: z.number().min(0).optional(),
+        rejected: z.number().min(0).optional(),
+        archived: z.number().min(0).optional()
     }).passthrough().optional(),
     errors: z.array(ErrorSchema).optional(),
     sandbox: z.boolean().optional(),
@@ -6015,7 +6015,7 @@ export const BriefAsset1Schema = BriefAssetSchema;
 export const CatalogAsset1Schema = CatalogAssetSchema;
 
 export const PreviewCreativeRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
     request_type: z.union([z.literal("single"), z.literal("batch"), z.literal("variant")]),
     creative_manifest: CreativeManifestSchema.optional(),
     format_id: FormatReferenceStructuredObjectSchema.optional(),
@@ -6027,7 +6027,7 @@ export const PreviewCreativeRequestSchema = z.object({
     template_id: z.string().optional(),
     quality: CreativeQualitySchema.optional(),
     output_format: PreviewOutputFormatSchema.optional(),
-    item_limit: z.number().optional(),
+    item_limit: z.number().min(1).optional(),
     requests: z.array(z.object({
         format_id: FormatReferenceStructuredObjectSchema.optional(),
         creative_manifest: CreativeManifestSchema,
@@ -6039,7 +6039,7 @@ export const PreviewCreativeRequestSchema = z.object({
         template_id: z.string().optional(),
         quality: CreativeQualitySchema.optional(),
         output_format: PreviewOutputFormatSchema.optional(),
-        item_limit: z.number().optional()
+        item_limit: z.number().min(1).optional()
     }).passthrough()).optional(),
     variant_id: z.string().optional(),
     creative_id: z.string().optional(),
@@ -6056,7 +6056,7 @@ export const PreviewCreativeVariantResponseSchema = z.object({
         renders: z.array(PreviewRenderSchema)
     }).passthrough()),
     manifest: CreativeManifestSchema.optional(),
-    expires_at: z.string().optional(),
+    expires_at: z.iso.datetime().optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -6073,14 +6073,14 @@ export const CreativeAssetSchema = z.object({
     }).passthrough()).optional(),
     tags: z.array(z.string()).optional(),
     status: CreativeStatusSchema.optional(),
-    weight: z.number().optional(),
+    weight: z.number().min(0).max(100).optional(),
     placement_ids: z.array(z.string()).optional(),
     industry_identifiers: z.array(IndustryIdentifierSchema).optional(),
     provenance: ProvenanceSchema.optional()
 }).passthrough();
 
 export const BuildCreativeRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
     message: z.string().optional(),
     creative_manifest: CreativeManifestSchema.optional(),
     creative_id: z.string().optional(),
@@ -6092,7 +6092,7 @@ export const BuildCreativeRequestSchema = z.object({
     account: AccountReferenceSchema.optional(),
     brand: BrandReferenceSchema.optional(),
     quality: CreativeQualitySchema.optional(),
-    item_limit: z.number().optional(),
+    item_limit: z.number().min(1).optional(),
     include_preview: z.boolean().optional(),
     preview_inputs: z.array(z.object({
         name: z.string(),
@@ -6102,22 +6102,22 @@ export const BuildCreativeRequestSchema = z.object({
     preview_quality: CreativeQualitySchema.optional(),
     preview_output_format: PreviewOutputFormatSchema.optional(),
     macro_values: z.record(z.string(), z.string()).optional(),
-    idempotency_key: z.string(),
+    idempotency_key: z.string().min(16).max(255).regex(/^[A-Za-z0-9_.:-]{16,255}$/),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
 export const PackageRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
     product_id: z.string(),
     format_ids: z.array(FormatReferenceStructuredObjectSchema).optional(),
-    budget: z.number(),
+    budget: z.number().min(0),
     pacing: PacingSchema.optional(),
     pricing_option_id: z.string(),
-    bid_price: z.number().optional(),
-    impressions: z.number().optional(),
-    start_time: z.string().optional(),
-    end_time: z.string().optional(),
+    bid_price: z.number().min(0).optional(),
+    impressions: z.number().min(0).optional(),
+    start_time: z.iso.datetime().optional(),
+    end_time: z.iso.datetime().optional(),
     paused: z.boolean().optional(),
     catalogs: z.array(CatalogSchema).optional(),
     optimization_goals: z.array(OptimizationGoalSchema).optional(),
@@ -6126,28 +6126,28 @@ export const PackageRequestSchema = z.object({
     performance_standards: z.array(PerformanceStandardSchema).optional(),
     creative_assignments: z.array(CreativeAssignmentSchema).optional(),
     creatives: z.array(CreativeAssetSchema).optional(),
-    agency_estimate_number: z.string().optional(),
+    agency_estimate_number: z.string().max(100).optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
 export const GetProductsRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
     buying_mode: z.union([z.literal("brief"), z.literal("wholesale"), z.literal("refine")]),
     brief: z.string().optional(),
     refine: z.array(z.union([z.object({
             scope: z.literal("request"),
-            ask: z.string()
+            ask: z.string().min(1)
         }).passthrough(), z.object({
             scope: z.literal("product"),
-            product_id: z.string(),
+            product_id: z.string().min(1),
             action: z.union([z.literal("include"), z.literal("omit"), z.literal("more_like_this")]).optional(),
-            ask: z.string().optional()
+            ask: z.string().min(1).optional()
         }).passthrough(), z.object({
             scope: z.literal("proposal"),
-            proposal_id: z.string(),
+            proposal_id: z.string().min(1),
             action: z.union([z.literal("include"), z.literal("omit"), z.literal("finalize")]).optional(),
-            ask: z.string().optional()
+            ask: z.string().min(1).optional()
         }).passthrough()])).optional(),
     brand: BrandReferenceSchema.optional(),
     catalog: CatalogSchema.optional(),
@@ -6164,11 +6164,11 @@ export const GetProductsRequestSchema = z.object({
 }).passthrough();
 
 export const LogEventRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
     event_source_id: z.string(),
     test_event_code: z.string().optional(),
     events: z.array(EventSchema),
-    idempotency_key: z.string(),
+    idempotency_key: z.string().min(16).max(255).regex(/^[A-Za-z0-9_.:-]{16,255}$/),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -6177,33 +6177,33 @@ export const SyncEventSourcesResponseSchema = z.union([SyncEventSourcesSuccessSc
 
 export const PackageUpdateSchema = z.object({
     package_id: z.string(),
-    budget: z.number().optional(),
+    budget: z.number().min(0).optional(),
     pacing: PacingSchema.optional(),
-    bid_price: z.number().optional(),
-    impressions: z.number().optional(),
-    start_time: z.string().optional(),
-    end_time: z.string().optional(),
+    bid_price: z.number().min(0).optional(),
+    impressions: z.number().min(0).optional(),
+    start_time: z.iso.datetime().optional(),
+    end_time: z.iso.datetime().optional(),
     paused: z.boolean().optional(),
     canceled: z.literal(true).optional(),
-    cancellation_reason: z.string().optional(),
+    cancellation_reason: z.string().max(500).optional(),
     catalogs: z.array(CatalogSchema).optional(),
     optimization_goals: z.array(OptimizationGoalSchema).optional(),
     targeting_overlay: TargetingOverlaySchema.optional(),
     keyword_targets_add: z.array(z.object({
-        keyword: z.string(),
+        keyword: z.string().min(1),
         match_type: MatchTypeSchema,
-        bid_price: z.number().optional()
+        bid_price: z.number().min(0).optional()
     }).passthrough()).optional(),
     keyword_targets_remove: z.array(z.object({
-        keyword: z.string(),
+        keyword: z.string().min(1),
         match_type: MatchTypeSchema
     }).passthrough()).optional(),
     negative_keywords_add: z.array(z.object({
-        keyword: z.string(),
+        keyword: z.string().min(1),
         match_type: MatchTypeSchema
     }).passthrough()).optional(),
     negative_keywords_remove: z.array(z.object({
-        keyword: z.string(),
+        keyword: z.string().min(1),
         match_type: MatchTypeSchema
     }).passthrough()).optional(),
     creative_assignments: z.array(CreativeAssignmentSchema).optional(),
@@ -6223,7 +6223,7 @@ export const CreatePropertyListResponseSchema = z.object({
 }).passthrough();
 
 export const ValidatePropertyDeliveryRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
     list_id: z.string(),
     account: AccountReferenceSchema.optional(),
     records: z.array(DeliveryRecordSchema),
@@ -6236,7 +6236,7 @@ export const ValidationResultSchema = z.object({
     identifier: IdentifierSchema,
     record_id: z.string().optional(),
     status: z.union([z.literal("compliant"), z.literal("non_compliant"), z.literal("not_covered"), z.literal("unidentified")]),
-    impressions: z.number(),
+    impressions: z.number().min(0),
     features: z.array(z.object({
         feature_id: z.string(),
         status: FeatureCheckStatusSchema,
@@ -6247,7 +6247,7 @@ export const ValidationResultSchema = z.object({
             max_value: z.number().optional(),
             allowed_values: z.array(z.unknown()).optional()
         }).passthrough().optional(),
-        confidence: z.number().optional()
+        confidence: z.number().min(0).max(1).optional()
     }).passthrough()).optional(),
     authorization: AuthorizationResultSchema.optional(),
     ext: ExtensionObjectSchema.optional()
@@ -6260,7 +6260,7 @@ export const AppItemSchema = z.object({
     name: z.string(),
     platform: z.union([z.literal("ios"), z.literal("android")]),
     bundle_id: z.string().optional(),
-    apple_id: z.string().optional(),
+    apple_id: z.string().regex(/^[0-9]+$/).optional(),
     description: z.string().optional(),
     category: z.string().optional(),
     genre: z.string().optional(),
@@ -6270,8 +6270,8 @@ export const AppItemSchema = z.object({
     store_url: z.string().optional(),
     deep_link_url: z.string().optional(),
     price: PriceSchema.optional(),
-    rating: z.number().optional(),
-    rating_count: z.number().optional(),
+    rating: z.number().min(0).max(5).optional(),
+    rating_count: z.number().min(0).optional(),
     content_rating: z.string().optional(),
     tags: z.array(z.string()).optional(),
     assets: z.array(OfferingAssetGroupSchema).optional(),
@@ -6308,8 +6308,8 @@ export const FormatAssetSlotSchema = z.union([IndividualAssetSlotSchema, Repeata
 export const CatalogRequirementsSchema = z.object({
     catalog_type: CatalogTypeSchema,
     required: z.boolean().optional(),
-    min_items: z.number().optional(),
-    max_items: z.number().optional(),
+    min_items: z.number().min(1).optional(),
+    max_items: z.number().min(1).optional(),
     required_fields: z.array(z.string()).optional(),
     feed_formats: z.array(FeedFormatSchema).optional(),
     offering_asset_constraints: z.array(OfferingAssetConstraintSchema).optional(),
@@ -6324,15 +6324,15 @@ export const StoreItemSchema = z.object({
     store_id: z.string(),
     name: z.string(),
     location: z.object({
-        lat: z.number(),
-        lng: z.number()
+        lat: z.number().min(-90).max(90),
+        lng: z.number().min(-180).max(180)
     }).passthrough(),
     address: z.object({
         street: z.string().optional(),
         city: z.string().optional(),
         region: z.string().optional(),
         postal_code: z.string().optional(),
-        country: z.string().optional()
+        country: z.string().regex(/^[A-Z]{2}$/).optional()
     }).passthrough().optional(),
     catchments: z.array(CatchmentSchema).optional(),
     phone: z.string().optional(),
@@ -6346,7 +6346,7 @@ export const PropertyFeatureResultSchema = z.object({
     property: PropertyIDSchema,
     features: z.record(z.string(), PropertyFeatureValueSchema).optional(),
     coverage_status: z.union([z.literal("covered"), z.literal("not_covered"), z.literal("pending")]),
-    last_evaluated: z.string().optional(),
+    last_evaluated: z.iso.datetime().optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
@@ -6402,7 +6402,7 @@ export const FormatSchema = z.object({
                     width: z.boolean(),
                     height: z.boolean()
                 }).passthrough().optional(),
-                aspect_ratio: z.string().optional()
+                aspect_ratio: z.string().regex(/^\d+(\.\d+)?:\d+(\.\d+)?$/).optional()
             }).passthrough()
         }).passthrough(), z.object({
             role: z.string(),
@@ -6435,13 +6435,13 @@ export const FormatSchema = z.object({
 }).passthrough();
 
 export const CreateMediaBuyRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
-    idempotency_key: z.string(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
+    idempotency_key: z.string().min(16).max(255).regex(/^[A-Za-z0-9_.:-]{16,255}$/),
     plan_id: z.string().optional(),
     account: AccountReferenceSchema,
     proposal_id: z.string().optional(),
     total_budget: z.object({
-        amount: z.number(),
+        amount: z.number().min(0),
         currency: z.string()
     }).passthrough().optional(),
     packages: z.array(PackageRequestSchema).optional(),
@@ -6450,26 +6450,26 @@ export const CreateMediaBuyRequestSchema = z.object({
     invoice_recipient: BusinessEntitySchema.optional(),
     io_acceptance: z.object({
         io_id: z.string(),
-        accepted_at: z.string(),
-        signatory: z.string(),
+        accepted_at: z.iso.datetime(),
+        signatory: z.string().min(1).max(250),
         signature_id: z.string().optional()
     }).passthrough().optional(),
     po_number: z.string().optional(),
-    agency_estimate_number: z.string().optional(),
+    agency_estimate_number: z.string().max(100).optional(),
     start_time: StartTimingSchema,
-    end_time: z.string(),
+    end_time: z.iso.datetime(),
     push_notification_config: PushNotificationConfigSchema.optional(),
     reporting_webhook: ReportingWebhookSchema.optional(),
     artifact_webhook: z.object({
         url: z.string(),
-        token: z.string().optional(),
+        token: z.string().min(16).optional(),
         authentication: z.object({
             schemes: z.array(AuthenticationSchemeSchema),
-            credentials: z.string()
+            credentials: z.string().min(32)
         }).passthrough(),
         delivery_mode: z.union([z.literal("realtime"), z.literal("batched")]),
         batch_frequency: z.union([z.literal("hourly"), z.literal("daily")]).optional(),
-        sampling_rate: z.number().optional()
+        sampling_rate: z.number().min(0).max(1).optional()
     }).passthrough().optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
@@ -6478,21 +6478,21 @@ export const CreateMediaBuyRequestSchema = z.object({
 export const CreateMediaBuyResponseSchema = z.union([CreateMediaBuySuccessSchema, CreateMediaBuyErrorSchema, CreateMediaBuySubmittedSchema]);
 
 export const UpdateMediaBuyRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
     account: AccountReferenceSchema,
     media_buy_id: z.string(),
-    revision: z.number().optional(),
+    revision: z.number().min(1).optional(),
     paused: z.boolean().optional(),
     canceled: z.literal(true).optional(),
-    cancellation_reason: z.string().optional(),
+    cancellation_reason: z.string().max(500).optional(),
     start_time: StartTimingSchema.optional(),
-    end_time: z.string().optional(),
+    end_time: z.iso.datetime().optional(),
     packages: z.array(PackageUpdateSchema).optional(),
     invoice_recipient: BusinessEntitySchema.optional(),
     new_packages: z.array(PackageRequestSchema).optional(),
     reporting_webhook: ReportingWebhookSchema.optional(),
     push_notification_config: PushNotificationConfigSchema.optional(),
-    idempotency_key: z.string(),
+    idempotency_key: z.string().min(16).max(255).regex(/^[A-Za-z0-9_.:-]{16,255}$/),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -6500,7 +6500,7 @@ export const UpdateMediaBuyRequestSchema = z.object({
 export const BuildCreativeSuccessSchema = z.object({
     creative_manifest: CreativeManifestSchema,
     sandbox: z.boolean().optional(),
-    expires_at: z.string().optional(),
+    expires_at: z.iso.datetime().optional(),
     preview: z.object({
         previews: z.array(z.object({
             preview_id: z.string(),
@@ -6512,12 +6512,12 @@ export const BuildCreativeSuccessSchema = z.object({
             }).passthrough()
         }).passthrough()),
         interactive_url: z.string().optional(),
-        expires_at: z.string()
+        expires_at: z.iso.datetime()
     }).passthrough().optional(),
     preview_error: ErrorSchema.optional(),
     pricing_option_id: z.string().optional(),
-    vendor_cost: z.number().optional(),
-    currency: z.string().optional(),
+    vendor_cost: z.number().min(0).optional(),
+    currency: z.string().regex(/^[A-Z]{3}$/).optional(),
     consumption: CreativeConsumptionSchema.optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
@@ -6526,17 +6526,17 @@ export const BuildCreativeSuccessSchema = z.object({
 export const PreviewCreativeResponseSchema = z.union([PreviewCreativeSingleResponseSchema, PreviewCreativeBatchResponseSchema, PreviewCreativeVariantResponseSchema]);
 
 export const SyncCreativesRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
+    adcp_major_version: z.number().min(1).max(99).optional(),
     account: AccountReferenceSchema,
     creatives: z.array(CreativeAssetSchema),
     creative_ids: z.array(z.string()).optional(),
     assignments: z.array(z.object({
         creative_id: z.string(),
         package_id: z.string(),
-        weight: z.number().optional(),
+        weight: z.number().min(0).max(100).optional(),
         placement_ids: z.array(z.string()).optional()
     }).passthrough()).optional(),
-    idempotency_key: z.string(),
+    idempotency_key: z.string().min(16).max(255).regex(/^[A-Za-z0-9_.:-]{16,255}$/),
     delete_missing: z.boolean().optional(),
     dry_run: z.boolean().optional(),
     validation_mode: ValidationModeSchema.optional(),
@@ -6566,13 +6566,13 @@ export const AdCPAsyncResponseDataSchema: z.ZodType = z.union([GetProductsRespon
 export const ComplyTestControllerResponseSchema = z.union([ListScenariosSuccessSchema, StateTransitionSuccessSchema, SimulationSuccessSchema, ForcedDirectiveSuccessSchema, SeedSuccessSchema, ControllerErrorSchema]);
 
 export const MCPWebhookPayloadSchema: z.ZodType = z.object({
-    idempotency_key: z.string(),
+    idempotency_key: z.string().min(16).max(255).regex(/^[A-Za-z0-9_.:-]{16,255}$/),
     operation_id: z.string().optional(),
     task_id: z.string(),
     task_type: TaskTypeSchema,
     protocol: AdCPProtocolSchema.optional(),
     status: TaskStatusSchema,
-    timestamp: z.string(),
+    timestamp: z.iso.datetime(),
     message: z.string().optional(),
     context_id: z.string().optional(),
     result: AdCPAsyncResponseDataSchema.optional()
@@ -6614,8 +6614,8 @@ export const ValidatePropertyDeliveryResponseSchema = z.object({
         unknown_impressions: z.number()
     }).passthrough().optional(),
     results: z.array(ValidationResultSchema),
-    validated_at: z.string(),
-    list_resolved_at: z.string().optional(),
+    validated_at: z.iso.datetime(),
+    list_resolved_at: z.iso.datetime().optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -6648,17 +6648,17 @@ export const ComplyTestControllerRequestSchema = z.object({
         status: z.string().optional(),
         rejection_reason: z.string().optional(),
         termination_reason: z.string().optional(),
-        impressions: z.number().optional(),
-        clicks: z.number().optional(),
-        conversions: z.number().optional(),
+        impressions: z.number().min(0).optional(),
+        clicks: z.number().min(0).optional(),
+        conversions: z.number().min(0).optional(),
         reported_spend: z.object({
-            amount: z.number(),
-            currency: z.string()
+            amount: z.number().min(0),
+            currency: z.string().regex(/^[A-Z]{3}$/)
         }).passthrough().optional(),
-        spend_percentage: z.number().optional(),
+        spend_percentage: z.number().min(0).max(100).optional(),
         arm: z.union([z.literal("submitted"), z.literal("input-required")]).optional(),
-        task_id: z.string().optional(),
-        message: z.string().optional(),
+        task_id: z.string().max(128).optional(),
+        message: z.string().max(2000).optional(),
         format_id: z.string().optional(),
         result: AdCPAsyncResponseDataSchema.optional()
     }).passthrough().optional(),

--- a/src/lib/types/tools.generated.ts
+++ b/src/lib/types/tools.generated.ts
@@ -108,6 +108,7 @@ export type AccountReference =
       brand: BrandReference;
       /**
        * Domain of the entity operating on the brand's behalf. When the brand operates directly, this is the brand's domain.
+       * @pattern ^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$
        */
       operator: string;
       /**
@@ -211,10 +212,12 @@ export type SignalID =
       source: 'catalog';
       /**
        * Domain of the data provider that owns this signal (e.g., 'polk.com', 'experian.com'). The signal definition is published at this domain's /.well-known/adagents.json
+       * @pattern ^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$
        */
       data_provider_domain: string;
       /**
        * Signal identifier within the data provider's catalog (e.g., 'likely_tesla_buyers', 'income_100k_plus')
+       * @pattern ^[a-zA-Z0-9_-]+$
        */
       id: string;
     }
@@ -229,6 +232,7 @@ export type SignalID =
       agent_url: string;
       /**
        * Signal identifier within the agent's signal set (e.g., 'custom_auto_intenders')
+       * @pattern ^[a-zA-Z0-9_-]+$
        */
       id: string;
     };
@@ -266,6 +270,8 @@ export type MatchType = 'broad' | 'phrase' | 'exact';
 export interface GetProductsRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -287,6 +293,7 @@ export interface GetProductsRequest {
         scope: 'request';
         /**
          * What the buyer is asking for at the request level (e.g., 'more video options and less display', 'suggest how to combine these products').
+         * @minLength 1
          */
         ask: string;
       }
@@ -297,6 +304,7 @@ export interface GetProductsRequest {
         scope: 'product';
         /**
          * Product ID from a previous get_products response.
+         * @minLength 1
          */
         product_id: string;
         /**
@@ -305,6 +313,7 @@ export interface GetProductsRequest {
         action?: 'include' | 'omit' | 'more_like_this';
         /**
          * What the buyer is asking for on this product. For 'include': specific changes to request (e.g., 'add 16:9 format'). For 'more_like_this': what 'similar' means (e.g., 'same audience but video format'). Ignored when action is 'omit'.
+         * @minLength 1
          */
         ask?: string;
       }
@@ -315,6 +324,7 @@ export interface GetProductsRequest {
         scope: 'proposal';
         /**
          * Proposal ID from a previous get_products response.
+         * @minLength 1
          */
         proposal_id: string;
         /**
@@ -323,6 +333,7 @@ export interface GetProductsRequest {
         action?: 'include' | 'omit' | 'finalize';
         /**
          * What the buyer is asking for on this proposal (e.g., 'shift more budget toward video', 'reduce total by 10%'). Ignored when action is 'omit'.
+         * @minLength 1
          */
         ask?: string;
       }
@@ -389,6 +400,7 @@ export interface GetProductsRequest {
 export interface BrandReference {
   /**
    * Domain where /.well-known/brand.json is hosted, or the brand's operating domain
+   * @pattern ^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$
    */
   domain: string;
   brand_id?: BrandID;
@@ -526,14 +538,17 @@ export interface ProductFilters {
   standard_formats_only?: boolean;
   /**
    * Minimum exposures/impressions needed for measurement validity
+   * @minimum 1
    */
   min_exposures?: number;
   /**
    * Campaign start date (ISO 8601 date format: YYYY-MM-DD) for availability checks
+   * @format date
    */
   start_date?: string;
   /**
    * Campaign end date (ISO 8601 date format: YYYY-MM-DD) for availability checks
+   * @format date
    */
   end_date?: string;
   /**
@@ -636,6 +651,7 @@ export interface ProductFilters {
   keywords?: {
     /**
      * The keyword to target
+     * @minLength 1
      */
     keyword: string;
     match_type?: MatchType;
@@ -651,18 +667,22 @@ export interface FormatReferenceStructuredObject {
   agent_url: string;
   /**
    * Format identifier within the agent's namespace (e.g., 'display_static', 'video_hosted', 'audio_standard'). When used alone, references a template format. When combined with dimension/duration fields, creates a parameterized format ID for a specific variant.
+   * @pattern ^[a-zA-Z0-9_-]+$
    */
   id: string;
   /**
    * Width in pixels for visual formats. When specified, height must also be specified. Both fields together create a parameterized format ID for dimension-specific variants.
+   * @minimum 1
    */
   width?: number;
   /**
    * Height in pixels for visual formats. When specified, width must also be specified. Both fields together create a parameterized format ID for dimension-specific variants.
+   * @minimum 1
    */
   height?: number;
   /**
    * Duration in milliseconds for time-based formats (video, audio). When specified, creates a parameterized format ID. Omit to reference a template format without parameters.
+   * @minimum 1
    */
   duration_ms?: number;
 }
@@ -691,6 +711,8 @@ export interface PerformanceStandard {
   metric: PerformanceStandardMetric;
   /**
    * Rate threshold as a decimal (e.g., 0.70 for 70%). Whether this is a floor or ceiling depends on the metric: for viewability, completion_rate, brand_safety, attention_score the actual rate must be >= threshold; for ivt the actual rate must be <= threshold.
+   * @minimum 0
+   * @maximum 1
    */
   threshold: number;
   standard?: ViewabilityStandard;
@@ -706,6 +728,7 @@ export interface PropertyListReference {
   agent_url: string;
   /**
    * Identifier for the property list within the agent
+   * @minLength 1
    */
   list_id: string;
   /**
@@ -719,6 +742,7 @@ export interface PropertyListReference {
 export interface Duration {
   /**
    * Number of time units. Must be 1 when unit is 'campaign'.
+   * @minimum 1
    */
   interval: number;
   /**
@@ -732,6 +756,8 @@ export interface Duration {
 export interface PaginationRequest {
   /**
    * Maximum number of items to return per page
+   * @minimum 1
+   * @maximum 100
    */
   max_results?: number;
   /**
@@ -753,6 +779,7 @@ export type PublisherPropertySelector =
   | {
       /**
        * Domain where publisher's adagents.json is hosted (e.g., 'cnn.com')
+       * @pattern ^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$
        */
       publisher_domain: string;
       /**
@@ -763,6 +790,7 @@ export type PublisherPropertySelector =
   | {
       /**
        * Domain where publisher's adagents.json is hosted (e.g., 'cnn.com')
+       * @pattern ^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$
        */
       publisher_domain: string;
       /**
@@ -777,6 +805,7 @@ export type PublisherPropertySelector =
   | {
       /**
        * Domain where publisher's adagents.json is hosted (e.g., 'cnn.com')
+       * @pattern ^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$
        */
       publisher_domain: string;
       /**
@@ -790,10 +819,12 @@ export type PublisherPropertySelector =
     };
 /**
  * Identifier for a publisher property. Must be lowercase alphanumeric with underscores only.
+ * @pattern ^[a-z0-9_]+$
  */
 export type PropertyID = string;
 /**
  * Tag for categorizing publisher properties. Must be lowercase alphanumeric with underscores only.
+ * @pattern ^[a-z0-9_]+$
  */
 export type PropertyTag = string;
 /**
@@ -825,14 +856,17 @@ export type ForecastRange = {
 } & {
   /**
    * Conservative (low-end) forecast value
+   * @minimum 0
    */
   low?: number;
   /**
    * Expected (most likely) forecast value
+   * @minimum 0
    */
   mid?: number;
   /**
    * Optimistic (high-end) forecast value
+   * @minimum 0
    */
   high?: number;
 };
@@ -905,6 +939,7 @@ export type DataProviderSignalSelector =
   | {
       /**
        * Domain where data provider's adagents.json is hosted (e.g., 'polk.com')
+       * @pattern ^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$
        */
       data_provider_domain: string;
       /**
@@ -915,6 +950,7 @@ export type DataProviderSignalSelector =
   | {
       /**
        * Domain where data provider's adagents.json is hosted (e.g., 'polk.com')
+       * @pattern ^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$
        */
       data_provider_domain: string;
       /**
@@ -929,6 +965,7 @@ export type DataProviderSignalSelector =
   | {
       /**
        * Domain where data provider's adagents.json is hosted (e.g., 'polk.com')
+       * @pattern ^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$
        */
       data_provider_domain: string;
       /**
@@ -1252,6 +1289,7 @@ export interface Product {
   };
   /**
    * Maximum number of optimization_goals this product accepts on a package. When absent, no limit is declared. Most social platforms accept only 1 goal — buyers sending arrays longer than this value should expect the seller to use only the highest-priority (lowest priority number) goal.
+   * @minimum 1
    */
   max_optimization_goals?: number;
   measurement_readiness?: MeasurementReadiness;
@@ -1286,10 +1324,12 @@ export interface Product {
     matched_ids?: string[];
     /**
      * Number of catalog items that matched this product's inventory.
+     * @minimum 0
      */
     matched_count?: number;
     /**
      * Total catalog items evaluated from the buyer's catalog.
+     * @minimum 0
      */
     submitted_count: number;
   };
@@ -1299,6 +1339,7 @@ export interface Product {
   brief_relevance?: string;
   /**
    * Expiration timestamp. After this time, the product may no longer be available for purchase and create_media_buy may reject packages referencing it.
+   * @format date-time
    */
   expires_at?: string;
   /**
@@ -1389,14 +1430,17 @@ export interface Product {
   material_submission?: {
     /**
      * HTTPS URL for uploading or submitting physical creative materials
+     * @pattern ^https:\/\/
      */
     url?: string;
     /**
      * Email address for creative material submission
+     * @format email
      */
     email?: string;
     /**
      * Human-readable instructions for material submission (file naming conventions, shipping address, etc.)
+     * @maxLength 2000
      */
     instructions?: string;
     ext?: ExtensionObject;
@@ -1442,14 +1486,17 @@ export interface CPMPricingOption {
   pricing_model: 'cpm';
   /**
    * ISO 4217 currency code
+   * @pattern ^[A-Z]{3}$
    */
   currency: string;
   /**
    * Fixed price per unit. If present, this is fixed pricing. If absent, auction-based.
+   * @minimum 0
    */
   fixed_price?: number;
   /**
    * Minimum acceptable bid for auction pricing (mutually exclusive with fixed_price). Bids below this value will be rejected.
+   * @minimum 0
    */
   floor_price?: number;
   /**
@@ -1459,6 +1506,7 @@ export interface CPMPricingOption {
   price_guidance?: PriceGuidance;
   /**
    * Minimum spend requirement per package using this pricing option, in the specified currency
+   * @minimum 0
    */
   min_spend_per_package?: number;
   price_breakdown?: PriceBreakdown;
@@ -1473,18 +1521,22 @@ export interface CPMPricingOption {
 export interface PriceGuidance {
   /**
    * 25th percentile of recent winning bids
+   * @minimum 0
    */
   p25?: number;
   /**
    * Median of recent winning bids
+   * @minimum 0
    */
   p50?: number;
   /**
    * 75th percentile of recent winning bids
+   * @minimum 0
    */
   p75?: number;
   /**
    * 90th percentile of recent winning bids
+   * @minimum 0
    */
   p90?: number;
 }
@@ -1517,14 +1569,17 @@ export interface VCPMPricingOption {
   pricing_model: 'vcpm';
   /**
    * ISO 4217 currency code
+   * @pattern ^[A-Z]{3}$
    */
   currency: string;
   /**
    * Fixed price per unit. If present, this is fixed pricing. If absent, auction-based.
+   * @minimum 0
    */
   fixed_price?: number;
   /**
    * Minimum acceptable bid for auction pricing (mutually exclusive with fixed_price). Bids below this value will be rejected.
+   * @minimum 0
    */
   floor_price?: number;
   /**
@@ -1534,6 +1589,7 @@ export interface VCPMPricingOption {
   price_guidance?: PriceGuidance;
   /**
    * Minimum spend requirement per package using this pricing option, in the specified currency
+   * @minimum 0
    */
   min_spend_per_package?: number;
   price_breakdown?: PriceBreakdown;
@@ -1556,14 +1612,17 @@ export interface CPCPricingOption {
   pricing_model: 'cpc';
   /**
    * ISO 4217 currency code
+   * @pattern ^[A-Z]{3}$
    */
   currency: string;
   /**
    * Fixed price per click. If present, this is fixed pricing. If absent, auction-based.
+   * @minimum 0
    */
   fixed_price?: number;
   /**
    * Minimum acceptable bid for auction pricing (mutually exclusive with fixed_price). Bids below this value will be rejected.
+   * @minimum 0
    */
   floor_price?: number;
   /**
@@ -1573,6 +1632,7 @@ export interface CPCPricingOption {
   price_guidance?: PriceGuidance;
   /**
    * Minimum spend requirement per package using this pricing option, in the specified currency
+   * @minimum 0
    */
   min_spend_per_package?: number;
   price_breakdown?: PriceBreakdown;
@@ -1595,14 +1655,17 @@ export interface CPCVPricingOption {
   pricing_model: 'cpcv';
   /**
    * ISO 4217 currency code
+   * @pattern ^[A-Z]{3}$
    */
   currency: string;
   /**
    * Fixed price per completed view. If present, this is fixed pricing. If absent, auction-based.
+   * @minimum 0
    */
   fixed_price?: number;
   /**
    * Minimum acceptable bid for auction pricing (mutually exclusive with fixed_price). Bids below this value will be rejected.
+   * @minimum 0
    */
   floor_price?: number;
   /**
@@ -1612,6 +1675,7 @@ export interface CPCVPricingOption {
   price_guidance?: PriceGuidance;
   /**
    * Minimum spend requirement per package using this pricing option, in the specified currency
+   * @minimum 0
    */
   min_spend_per_package?: number;
   price_breakdown?: PriceBreakdown;
@@ -1634,14 +1698,17 @@ export interface CPVPricingOption {
   pricing_model: 'cpv';
   /**
    * ISO 4217 currency code
+   * @pattern ^[A-Z]{3}$
    */
   currency: string;
   /**
    * Fixed price per view. If present, this is fixed pricing. If absent, auction-based.
+   * @minimum 0
    */
   fixed_price?: number;
   /**
    * Minimum acceptable bid for auction pricing (mutually exclusive with fixed_price). Bids below this value will be rejected.
+   * @minimum 0
    */
   floor_price?: number;
   /**
@@ -1658,12 +1725,14 @@ export interface CPVPricingOption {
       | {
           /**
            * Seconds of viewing required
+           * @minimum 1
            */
           duration_seconds: number;
         };
   };
   /**
    * Minimum spend requirement per package using this pricing option, in the specified currency
+   * @minimum 0
    */
   min_spend_per_package?: number;
   price_breakdown?: PriceBreakdown;
@@ -1686,14 +1755,17 @@ export interface CPPPricingOption {
   pricing_model: 'cpp';
   /**
    * ISO 4217 currency code
+   * @pattern ^[A-Z]{3}$
    */
   currency: string;
   /**
    * Fixed price per rating point. If present, this is fixed pricing. If absent, auction-based.
+   * @minimum 0
    */
   fixed_price?: number;
   /**
    * Minimum acceptable bid for auction pricing (mutually exclusive with fixed_price). Bids below this value will be rejected.
+   * @minimum 0
    */
   floor_price?: number;
   price_guidance?: PriceGuidance;
@@ -1708,11 +1780,13 @@ export interface CPPPricingOption {
     demographic: string;
     /**
      * Minimum GRPs/TRPs required
+     * @minimum 0
      */
     min_points?: number;
   };
   /**
    * Minimum spend requirement per package using this pricing option, in the specified currency
+   * @minimum 0
    */
   min_spend_per_package?: number;
   price_breakdown?: PriceBreakdown;
@@ -1747,6 +1821,7 @@ export interface CPAPricingOption {
   event_source_id?: string;
   /**
    * ISO 4217 currency code
+   * @pattern ^[A-Z]{3}$
    */
   currency: string;
   /**
@@ -1755,6 +1830,7 @@ export interface CPAPricingOption {
   fixed_price: number;
   /**
    * Minimum spend requirement per package using this pricing option, in the specified currency
+   * @minimum 0
    */
   min_spend_per_package?: number;
   price_breakdown?: PriceBreakdown;
@@ -1777,20 +1853,24 @@ export interface FlatRatePricingOption {
   pricing_model: 'flat_rate';
   /**
    * ISO 4217 currency code
+   * @pattern ^[A-Z]{3}$
    */
   currency: string;
   /**
    * Flat rate cost. If present, this is fixed pricing. If absent, auction-based.
+   * @minimum 0
    */
   fixed_price?: number;
   /**
    * Minimum acceptable bid for auction pricing (mutually exclusive with fixed_price). Bids below this value will be rejected.
+   * @minimum 0
    */
   floor_price?: number;
   price_guidance?: PriceGuidance;
   parameters?: DoohParameters;
   /**
    * Minimum spend requirement per package using this pricing option, in the specified currency
+   * @minimum 0
    */
   min_spend_per_package?: number;
   price_breakdown?: PriceBreakdown;
@@ -1809,14 +1889,18 @@ export interface DoohParameters {
   type: 'dooh';
   /**
    * Guaranteed share of voice as a percentage (0-100)
+   * @minimum 0
+   * @maximum 100
    */
   sov_percentage?: number;
   /**
    * Duration of the ad loop rotation in seconds
+   * @minimum 1
    */
   loop_duration_seconds?: number;
   /**
    * Minimum number of plays per hour guaranteed
+   * @minimum 1
    */
   min_plays_per_hour?: number;
   /**
@@ -1825,6 +1909,7 @@ export interface DoohParameters {
   venue_package?: string;
   /**
    * Duration of the DOOH slot in hours (e.g., 24 for a full-day takeover)
+   * @minimum 0
    */
   duration_hours?: number;
   /**
@@ -1833,6 +1918,7 @@ export interface DoohParameters {
   daypart?: string;
   /**
    * Estimated audience impressions for this slot (informational, not a delivery guarantee)
+   * @minimum 0
    */
   estimated_impressions?: number;
 }
@@ -1850,14 +1936,17 @@ export interface TimeBasedPricingOption {
   pricing_model: 'time';
   /**
    * ISO 4217 currency code
+   * @pattern ^[A-Z]{3}$
    */
   currency: string;
   /**
    * Cost per time unit. If present, this is fixed pricing. If absent, auction-based.
+   * @minimum 0
    */
   fixed_price?: number;
   /**
    * Minimum acceptable bid per time unit for auction pricing (mutually exclusive with fixed_price). Bids below this value will be rejected.
+   * @minimum 0
    */
   floor_price?: number;
   price_guidance?: PriceGuidance;
@@ -1871,15 +1960,18 @@ export interface TimeBasedPricingOption {
     time_unit: 'hour' | 'day' | 'week' | 'month';
     /**
      * Minimum booking duration in time_units
+     * @minimum 1
      */
     min_duration?: number;
     /**
      * Maximum booking duration in time_units. Must be >= min_duration when both are present.
+     * @minimum 1
      */
     max_duration?: number;
   };
   /**
    * Minimum spend requirement per package using this pricing option, in the specified currency
+   * @minimum 0
    */
   min_spend_per_package?: number;
   price_breakdown?: PriceBreakdown;
@@ -1909,15 +2001,19 @@ export interface DeliveryForecast {
   demographic?: string;
   /**
    * Third-party measurement provider whose data was used to produce this forecast. Distinct from demographic_system, which specifies demographic notation — measurement_source identifies whose data produced the forecast numbers. Should be present when measured_impressions is used. Lowercase slug format.
+   * @maxLength 64
+   * @pattern ^[a-z0-9_]+$
    */
   measurement_source?: string;
   reach_unit?: ReachUnit;
   /**
    * When this forecast was computed
+   * @format date-time
    */
   generated_at?: string;
   /**
    * When this forecast expires. After this time, the forecast should be refreshed. Forecast expiry does not affect proposal executability.
+   * @format date-time
    */
   valid_until?: string;
   ext?: ExtensionObject;
@@ -1928,10 +2024,12 @@ export interface DeliveryForecast {
 export interface ForecastPoint {
   /**
    * Human-readable name for this forecast point. Required when forecast_range_unit is 'package' so buyer agents can identify and reference individual packages. Optional for other forecast types.
+   * @maxLength 128
    */
   label?: string;
   /**
    * Budget amount for this forecast point. Required for spend curves; omit for availability forecasts where the metrics represent total available inventory. For allocation-level forecasts, this is the absolute budget for that allocation (not the percentage). For proposal-level forecasts, this is the total proposal budget. When omitted, use metrics.spend to express the estimated cost of the available inventory.
+   * @minimum 0
    */
   budget?: number;
   /**
@@ -1989,6 +2087,7 @@ export interface MeasurementTerms {
     vendor: BrandReference;
     /**
      * Maximum acceptable variance between the billing vendor's count and the other party's count before resolution is triggered (e.g., 10 means a 10% divergence triggers review).
+     * @minimum 0
      */
     max_variance_percent?: number;
     /**
@@ -2021,10 +2120,13 @@ export interface CancellationPolicy {
     type: 'percent_remaining' | 'full_commitment' | 'fixed_fee' | 'none';
     /**
      * Fee rate as a decimal proportion of remaining committed spend. Required when type is 'percent_remaining' (e.g., 0.5 means 50% of remaining spend).
+     * @minimum 0
+     * @maximum 1
      */
     rate?: number;
     /**
      * Fixed fee amount in the buy's currency. Required when type is 'fixed_fee'.
+     * @minimum 0
      */
     amount?: number;
   };
@@ -2039,6 +2141,7 @@ export interface ReportingCapabilities {
   available_reporting_frequencies: ReportingFrequency[];
   /**
    * Expected delay in minutes before reporting data becomes available (e.g., 240 for 4-hour delay)
+   * @minimum 0
    */
   expected_delay_minutes: number;
   /**
@@ -2118,18 +2221,22 @@ export interface GeographicBreakdownSupport {
 export interface MeasurementWindow {
   /**
    * Identifier for this maturation stage. Standard broadcast values: 'live' (real-time viewers only), 'c3' (live + 3 days time-shifted), 'c7' (live + 7 days time-shifted). Standard values for other channels include 'tentative' (provisional data available quickly), 'final' (post-processing certified data), 'post_ivt' (digital after invalid-traffic filtering), 'post_sivt' (digital after sophisticated-IVT filtering), 'downloads_7d' / 'downloads_30d' (podcast download maturation). Sellers may define custom IDs.
+   * @maxLength 50
    */
   window_id: string;
   /**
    * Human-readable description of what this window measures
+   * @maxLength 500
    */
   description?: string;
   /**
    * Number of days of accumulation included in this window before processing begins. For broadcast, this is DVR accumulation (0 = live only, 3 = live + 3 days DVR, 7 = live + 7 days DVR). For channels without an accumulation period (DOOH tentative→final, digital IVT filtering), this is 0 — maturation is entirely vendor processing time captured in expected_availability_days.
+   * @minimum 0
    */
   duration_days: number;
   /**
    * Expected number of days after delivery before this window's data is available from the measurement vendor. Captures accumulation time plus vendor processing time. Examples: broadcast C7 from VideoAmp ~22 days (7-day accumulation + ~15-day processing); DOOH tentative plays same-day; DOOH final (post-IVT/fraud-check) ~1 day; digital post-SIVT ~2–3 days.
+   * @minimum 0
    */
   expected_availability_days?: number;
   /**
@@ -2193,6 +2300,7 @@ export interface DiagnosticIssue {
 export interface CollectionSelector {
   /**
    * Domain where the adagents.json declaring these collections is hosted (e.g., 'mrbeast.com'). The collections array in that file contains the authoritative collection definitions.
+   * @pattern ^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$
    */
   publisher_domain: string;
   /**
@@ -2226,11 +2334,13 @@ export interface Installment {
   installment_number?: string;
   /**
    * When the installment airs or publishes (ISO 8601)
+   * @format date-time
    */
   scheduled_at?: string;
   status?: InstallmentStatus;
   /**
    * Expected duration of the installment in seconds
+   * @minimum 0
    */
   duration_seconds?: number;
   /**
@@ -2239,6 +2349,7 @@ export interface Installment {
   flexible_end?: boolean;
   /**
    * When this installment data expires and should be re-queried. Agents should re-query before committing budget to products with tentative installments.
+   * @format date-time
    */
   valid_until?: string;
   content_rating?: ContentRating;
@@ -2286,10 +2397,12 @@ export interface Special {
   category?: SpecialCategory;
   /**
    * When the event starts (ISO 8601)
+   * @format date-time
    */
   starts?: string;
   /**
    * When the event ends (ISO 8601). Omit for single-day events.
+   * @format date-time
    */
   ends?: string;
 }
@@ -2313,14 +2426,17 @@ export interface Talent {
 export interface AdInventoryConfiguration {
   /**
    * Number of planned ad breaks in the installment
+   * @minimum 0
    */
   expected_breaks: number;
   /**
    * Total seconds of ad time across all breaks
+   * @minimum 0
    */
   total_ad_seconds?: number;
   /**
    * Maximum duration in seconds for a single ad within a break. Buyers need this to know whether their creative fits.
+   * @minimum 1
    */
   max_ad_duration_seconds?: number;
   /**
@@ -2338,10 +2454,12 @@ export interface AdInventoryConfiguration {
 export interface InstallmentDeadlines {
   /**
    * Last date/time to book a placement in this installment (ISO 8601). After this point, the seller will not accept new bookings.
+   * @format date-time
    */
   booking_deadline?: string;
   /**
    * Last date/time to cancel without penalty (ISO 8601). Cancellations after this point may incur fees per the seller's terms.
+   * @format date-time
    */
   cancellation_deadline?: string;
   /**
@@ -2359,6 +2477,7 @@ export interface MaterialDeadline {
   stage: string;
   /**
    * When materials for this stage are due (ISO 8601)
+   * @format date-time
    */
   due_at: string;
   /**
@@ -2372,14 +2491,17 @@ export interface MaterialDeadline {
 export interface Proposal {
   /**
    * Unique identifier for this proposal. Used to execute it via create_media_buy.
+   * @maxLength 255
    */
   proposal_id: string;
   /**
    * Human-readable name for this media plan proposal
+   * @maxLength 500
    */
   name: string;
   /**
    * Explanation of the proposal strategy and what it achieves
+   * @maxLength 2000
    */
   description?: string;
   /**
@@ -2389,6 +2511,7 @@ export interface Proposal {
   proposal_status?: ProposalStatus;
   /**
    * When this proposal expires and can no longer be executed. For draft proposals, indicates when indicative pricing becomes stale. For committed proposals, indicates when the inventory hold lapses — the buyer must call create_media_buy before this time.
+   * @format date-time
    */
   expires_at?: string;
   insertion_order?: InsertionOrder;
@@ -2398,14 +2521,17 @@ export interface Proposal {
   total_budget_guidance?: {
     /**
      * Minimum recommended budget
+     * @minimum 0
      */
     min?: number;
     /**
      * Recommended budget for optimal performance
+     * @minimum 0
      */
     recommended?: number;
     /**
      * Maximum budget before diminishing returns
+     * @minimum 0
      */
     max?: number;
     /**
@@ -2415,6 +2541,7 @@ export interface Proposal {
   };
   /**
    * Explanation of how this proposal aligns with the campaign brief
+   * @maxLength 2000
    */
   brief_alignment?: string;
   forecast?: DeliveryForecast;
@@ -2430,6 +2557,8 @@ export interface ProductAllocation {
   product_id: string;
   /**
    * Percentage of total budget allocated to this product (0-100)
+   * @minimum 0
+   * @maximum 100
    */
   allocation_percentage: number;
   /**
@@ -2442,6 +2571,7 @@ export interface ProductAllocation {
   rationale?: string;
   /**
    * Optional ordering hint for multi-line-item plans (1-based)
+   * @minimum 1
    */
   sequence?: number;
   /**
@@ -2450,10 +2580,12 @@ export interface ProductAllocation {
   tags?: string[];
   /**
    * Recommended flight start date/time for this allocation in ISO 8601 format. Allows publishers to propose per-flight scheduling within a proposal. When omitted, the allocation applies to the full campaign date range.
+   * @format date-time
    */
   start_time?: string;
   /**
    * Recommended flight end date/time for this allocation in ISO 8601 format. Allows publishers to propose per-flight scheduling within a proposal. When omitted, the allocation applies to the full campaign date range.
+   * @format date-time
    */
   end_time?: string;
   /**
@@ -2473,10 +2605,14 @@ export interface DaypartTarget {
   days: DayOfWeek[];
   /**
    * Start hour (inclusive), 0-23 in 24-hour format. 0 = midnight, 6 = 6:00am, 18 = 6:00pm.
+   * @minimum 0
+   * @maximum 23
    */
   start_hour: number;
   /**
    * End hour (exclusive), 1-24 in 24-hour format. 10 = 10:00am, 24 = midnight. Must be greater than start_hour.
+   * @minimum 1
+   * @maximum 24
    */
   end_hour: number;
   /**
@@ -2490,6 +2626,7 @@ export interface DaypartTarget {
 export interface InsertionOrder {
   /**
    * Unique identifier for this insertion order. Referenced by io_acceptance on create_media_buy.
+   * @maxLength 255
    */
   io_id: string;
   /**
@@ -2498,28 +2635,37 @@ export interface InsertionOrder {
   terms?: {
     /**
      * Advertiser name or identifier
+     * @maxLength 500
      */
     advertiser?: string;
     /**
      * Publisher name or identifier
+     * @maxLength 500
      */
     publisher?: string;
     /**
      * Total committed budget
      */
     total_budget?: {
+      /**
+       * @minimum 0
+       */
       amount: number;
       /**
        * ISO 4217 currency code
+       * @minLength 3
+       * @maxLength 3
        */
       currency: string;
     };
     /**
      * Campaign start date
+     * @format date-time
      */
     flight_start?: string;
     /**
      * Campaign end date
+     * @format date-time
      */
     flight_end?: string;
     /**
@@ -2546,6 +2692,8 @@ export interface InsertionOrder {
 export interface Error {
   /**
    * Error code for programmatic handling. Standard codes are defined in error-code.json and enable autonomous agent recovery. Sellers MAY use codes not in the standard vocabulary for platform-specific errors; agents MUST handle unknown codes gracefully by falling back to the recovery classification.
+   * @minLength 1
+   * @maxLength 64
    */
   code: string;
   /**
@@ -2562,6 +2710,8 @@ export interface Error {
   suggestion?: string;
   /**
    * Seconds to wait before retrying the operation. Sellers MUST return values between 1 and 3600. Clients MUST clamp values outside this range.
+   * @minimum 1
+   * @maximum 3600
    */
   retry_after?: number;
   /**
@@ -2608,6 +2758,7 @@ export interface PaginationResponse {
   cursor?: string;
   /**
    * Total number of items matching the query across all pages. Optional because not all backends can efficiently compute this.
+   * @minimum 0
    */
   total_count?: number;
 }
@@ -2658,6 +2809,8 @@ export type DisclosurePersistence = 'continuous' | 'initial' | 'flexible';
 export interface ListCreativeFormatsRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -3099,6 +3252,7 @@ export interface Format {
           };
           /**
            * Fixed aspect ratio constraint (e.g., '16:9', '4:3', '1:1', '1.91:1')
+           * @pattern ^\d+(\.\d+)?:\d+(\.\d+)?$
            */
           aspect_ratio?: string;
         };
@@ -3249,10 +3403,12 @@ export interface Overlay {
     y: number;
     /**
      * Width of the overlay
+     * @minimum 0
      */
     width: number;
     /**
      * Height of the overlay
+     * @minimum 0
      */
     height: number;
     /**
@@ -3279,10 +3435,12 @@ export interface RepeatableGroupAsset {
   required: boolean;
   /**
    * Minimum number of repetitions required (if group is required) or allowed (if optional)
+   * @minimum 0
    */
   min_count: number;
   /**
    * Maximum number of repetitions allowed
+   * @minimum 1
    */
   max_count: number;
   /**
@@ -3319,10 +3477,12 @@ export interface CpmPricing {
   model: 'cpm';
   /**
    * Cost per thousand impressions
+   * @minimum 0
    */
   cpm: number;
   /**
    * ISO 4217 currency code
+   * @pattern ^[A-Z]{3}$
    */
   currency: string;
   ext?: ExtensionObject;
@@ -3334,14 +3494,18 @@ export interface PercentOfMediaPricing {
   model: 'percent_of_media';
   /**
    * Percentage of media spend, e.g. 15 = 15%
+   * @minimum 0
+   * @maximum 100
    */
   percent: number;
   /**
    * Optional CPM cap. When set, the effective charge is min(percent × media_spend_per_mille, max_cpm).
+   * @minimum 0
    */
   max_cpm?: number;
   /**
    * ISO 4217 currency code for the resulting charge
+   * @pattern ^[A-Z]{3}$
    */
   currency: string;
   ext?: ExtensionObject;
@@ -3353,6 +3517,7 @@ export interface FlatFeePricing {
   model: 'flat_fee';
   /**
    * Fixed charge for the billing period
+   * @minimum 0
    */
   amount: number;
   /**
@@ -3361,6 +3526,7 @@ export interface FlatFeePricing {
   period: 'monthly' | 'quarterly' | 'annual' | 'campaign';
   /**
    * ISO 4217 currency code
+   * @pattern ^[A-Z]{3}$
    */
   currency: string;
   ext?: ExtensionObject;
@@ -3376,10 +3542,12 @@ export interface PerUnitPricing {
   unit: string;
   /**
    * Cost per one unit
+   * @minimum 0
    */
   unit_price: number;
   /**
    * ISO 4217 currency code
+   * @pattern ^[A-Z]{3}$
    */
   currency: string;
   ext?: ExtensionObject;
@@ -3391,6 +3559,7 @@ export interface CustomPricing {
   model: 'custom';
   /**
    * Human-readable description of the custom pricing model. Buyers display this to the operator when requesting approval.
+   * @minLength 1
    */
   description: string;
   /**
@@ -3399,11 +3568,13 @@ export interface CustomPricing {
   metadata: {
     /**
      * One or two sentences describing the pricing construct in plain language, displayed to the buyer's operator when requesting approval. Should not repeat the top-level `description` verbatim — summarize the charge mechanic instead (e.g., 'Base $12 CPM plus $0.50 per qualifying post-view conversion, capped at $45 CPM').
+     * @minLength 1
      */
     summary_for_operator?: string;
   };
   /**
    * ISO 4217 currency code. Present when the pricing resolves to a monetary charge in a specific currency.
+   * @pattern ^[A-Z]{3}$
    */
   currency?: string;
   ext?: ExtensionObject;
@@ -3469,6 +3640,7 @@ export type OptimizationGoal =
           };
       /**
        * Relative priority among all optimization goals on this package. 1 = highest priority (primary goal); higher numbers are lower priority (secondary signals). When omitted, sellers may use array position as priority.
+       * @minimum 1
        */
       priority?: number;
     }
@@ -3480,6 +3652,7 @@ export type OptimizationGoal =
       event_sources: {
         /**
          * Event source to include (must be configured on this account via sync_event_sources)
+         * @minLength 1
          */
         event_source_id: string;
         event_type: EventType;
@@ -3532,6 +3705,7 @@ export type OptimizationGoal =
       };
       /**
        * Relative priority among all optimization goals on this package. 1 = highest priority (primary goal); higher numbers are lower priority (secondary signals). When omitted, sellers may use array position as priority.
+       * @minimum 1
        */
       priority?: number;
     };
@@ -3547,10 +3721,12 @@ export type FrequencyCap = {
   suppress?: Duration;
   /**
    * Deprecated — use suppress instead. Cooldown period in minutes between consecutive exposures to the same entity (e.g. 60 for a 1-hour cooldown).
+   * @minimum 0
    */
   suppress_minutes?: number;
   /**
    * Maximum number of impressions per entity per window. For duration windows, implementations typically use a rolling window; 'campaign' applies a fixed cap across the full flight.
+   * @minimum 1
    */
   max_impressions?: number;
   /**
@@ -3655,6 +3831,7 @@ export type VASTAsset = {
   vpaid_enabled?: boolean;
   /**
    * Expected video duration in milliseconds (if known)
+   * @minimum 0
    */
   duration_ms?: number;
   /**
@@ -3763,6 +3940,7 @@ export type DAASTAsset = {
   daast_version?: DAASTVersion;
   /**
    * Expected audio duration in milliseconds (if known)
+   * @minimum 0
    */
   duration_ms?: number;
   /**
@@ -3960,10 +4138,15 @@ export type AuthenticationScheme = 'Bearer' | 'HMAC-SHA256';
 export interface CreateMediaBuyRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
    * Client-generated unique key for this request. If a request with the same idempotency_key and account has already been processed, the seller returns the existing media buy rather than creating a duplicate. MUST be unique per (seller, request) pair to prevent cross-seller correlation. Use a fresh UUID v4 for each request.
+   * @minLength 16
+   * @maxLength 255
+   * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   idempotency_key: string;
   /**
@@ -3981,6 +4164,7 @@ export interface CreateMediaBuyRequest {
   total_budget?: {
     /**
      * Total budget amount
+     * @minimum 0
      */
     amount: number;
     /**
@@ -4005,10 +4189,13 @@ export interface CreateMediaBuyRequest {
     io_id: string;
     /**
      * ISO 8601 timestamp when the IO was accepted
+     * @format date-time
      */
     accepted_at: string;
     /**
      * Who accepted the IO — agent identifier or human name
+     * @minLength 1
+     * @maxLength 250
      */
     signatory: string;
     /**
@@ -4022,11 +4209,13 @@ export interface CreateMediaBuyRequest {
   po_number?: string;
   /**
    * Agency estimate or authorization number. Primary financial reference for broadcast buys — links the order to the agency's media plan and billing system. Travels with the order and Ad-IDs through the transaction lifecycle.
+   * @maxLength 100
    */
   agency_estimate_number?: string;
   start_time: StartTiming;
   /**
    * Campaign end date/time in ISO 8601 format
+   * @format date-time
    */
   end_time: string;
   push_notification_config?: PushNotificationConfig;
@@ -4041,6 +4230,7 @@ export interface CreateMediaBuyRequest {
     url: string;
     /**
      * Optional client-provided token for webhook validation. Echoed back in webhook payload to validate request authenticity.
+     * @minLength 16
      */
     token?: string;
     /**
@@ -4053,6 +4243,7 @@ export interface CreateMediaBuyRequest {
       schemes: AuthenticationScheme[];
       /**
        * Credentials for the legacy scheme. For Bearer: token sent in Authorization header. For HMAC-SHA256: shared secret used to generate signature. Minimum 32 characters. Exchanged out-of-band during onboarding.
+       * @minLength 32
        */
       credentials: string;
     };
@@ -4066,6 +4257,8 @@ export interface CreateMediaBuyRequest {
     batch_frequency?: 'hourly' | 'daily';
     /**
      * Fraction of impressions to include (0-1). 1.0 = all impressions, 0.1 = 10% sample. Default: 1.0
+     * @minimum 0
+     * @maximum 1
      */
     sampling_rate?: number;
   };
@@ -4078,6 +4271,8 @@ export interface CreateMediaBuyRequest {
 export interface PackageRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -4090,6 +4285,7 @@ export interface PackageRequest {
   format_ids?: FormatReferenceStructuredObject[];
   /**
    * Budget allocation for this package in the media buy's currency
+   * @minimum 0
    */
   budget: number;
   pacing?: Pacing;
@@ -4099,18 +4295,22 @@ export interface PackageRequest {
   pricing_option_id: string;
   /**
    * Bid price for auction-based pricing options. This is the exact bid/price to honor unless selected pricing_option has max_bid=true, in which case bid_price is the buyer's maximum willingness to pay (ceiling).
+   * @minimum 0
    */
   bid_price?: number;
   /**
    * Impression goal for this package
+   * @minimum 0
    */
   impressions?: number;
   /**
    * Flight start date/time for this package in ISO 8601 format. When omitted, the package inherits the media buy's start_time. Must fall within the media buy's date range.
+   * @format date-time
    */
   start_time?: string;
   /**
    * Flight end date/time for this package in ISO 8601 format. When omitted, the package inherits the media buy's end_time. Must fall within the media buy's date range.
+   * @format date-time
    */
   end_time?: string;
   /**
@@ -4141,6 +4341,7 @@ export interface PackageRequest {
   creatives?: CreativeAsset[];
   /**
    * Agency estimate or authorization number for this package. Overrides the media buy-level estimate number when different packages correspond to different agency estimates (e.g., different stations or flights within the same buy).
+   * @maxLength 100
    */
   agency_estimate_number?: string;
   context?: ContextObject;
@@ -4238,6 +4439,8 @@ export interface TargetingOverlay {
   age_restriction?: {
     /**
      * Minimum age required
+     * @minimum 13
+     * @maximum 99
      */
     min: number;
     /**
@@ -4294,11 +4497,13 @@ export interface TargetingOverlay {
   keyword_targets?: {
     /**
      * The keyword to target
+     * @minLength 1
      */
     keyword: string;
     match_type: MatchType;
     /**
      * Per-keyword bid price, denominated in the same currency as the package's pricing option. Overrides the package-level bid_price for this keyword. Inherits the max_bid interpretation from the pricing option: when max_bid is true, this is the keyword's bid ceiling; when false, this is the exact bid. If omitted, the package bid_price applies.
+     * @minimum 0
      */
     bid_price?: number;
   }[];
@@ -4308,6 +4513,7 @@ export interface TargetingOverlay {
   negative_keywords?: {
     /**
      * The keyword to exclude
+     * @minLength 1
      */
     keyword: string;
     match_type: MatchType;
@@ -4323,6 +4529,7 @@ export interface CollectionListReference {
   agent_url: string;
   /**
    * Identifier for the collection list within the agent
+   * @minLength 1
    */
   list_id: string;
   /**
@@ -4340,6 +4547,8 @@ export interface CreativeAssignment {
   creative_id: string;
   /**
    * Relative delivery weight for this creative (0–100). When multiple creatives are assigned to the same package, weights determine impression distribution proportionally — a creative with weight 2 gets twice the delivery of weight 1. When omitted, the creative receives equal rotation with other unweighted creatives. A weight of 0 means the creative is assigned but paused (receives no delivery).
+   * @minimum 0
+   * @maximum 100
    */
   weight?: number;
   /**
@@ -4392,6 +4601,8 @@ export interface CreativeAsset {
   status?: CreativeStatus;
   /**
    * Optional delivery weight for creative rotation when uploading via create_media_buy or update_media_buy (0-100). If omitted, platform determines rotation. Only used during upload to media buy - not stored in creative library.
+   * @minimum 0
+   * @maximum 100
    */
   weight?: number;
   /**
@@ -4418,10 +4629,12 @@ export interface ImageAsset {
   url: string;
   /**
    * Width in pixels
+   * @minimum 1
    */
   width: number;
   /**
    * Height in pixels
+   * @minimum 1
    */
   height: number;
   /**
@@ -4475,10 +4688,12 @@ export interface Provenance {
   };
   /**
    * When this provenance claim was made (ISO 8601). Distinct from created_time, which records when the content itself was produced. A provenance claim may be attached well after content creation, for example when retroactively declaring AI involvement for regulatory compliance.
+   * @format date-time
    */
   declared_at?: string;
   /**
    * When this content was created or generated (ISO 8601)
+   * @format date-time
    */
   created_time?: string;
   /**
@@ -4525,6 +4740,7 @@ export interface Provenance {
         persistence?: DisclosurePersistence;
         /**
          * Minimum display duration in milliseconds for initial persistence. Recommended when persistence is initial — without it, the duration is at the publisher's discretion. At serve time the publisher reads this from provenance since the brief is not available.
+         * @minimum 1
          */
         min_duration_ms?: number;
         /**
@@ -4545,6 +4761,7 @@ export interface Provenance {
     verified_by: string;
     /**
      * When the verification was performed (ISO 8601)
+     * @format date-time
      */
     verified_time?: string;
     /**
@@ -4553,6 +4770,8 @@ export interface Provenance {
     result: 'authentic' | 'ai_generated' | 'ai_modified' | 'inconclusive';
     /**
      * Confidence score of the verification result (0.0 to 1.0)
+     * @minimum 0
+     * @maximum 1
      */
     confidence?: number;
     /**
@@ -4576,18 +4795,22 @@ export interface VideoAsset {
   url: string;
   /**
    * Width in pixels
+   * @minimum 1
    */
   width: number;
   /**
    * Height in pixels
+   * @minimum 1
    */
   height: number;
   /**
    * Video duration in milliseconds
+   * @minimum 1
    */
   duration_ms?: number;
   /**
    * File size in bytes
+   * @minimum 1
    */
   file_size_bytes?: number;
   /**
@@ -4600,6 +4823,7 @@ export interface VideoAsset {
   video_codec?: string;
   /**
    * Video stream bitrate in kilobits per second
+   * @minimum 1
    */
   video_bitrate_kbps?: number;
   /**
@@ -4649,6 +4873,7 @@ export interface VideoAsset {
   audio_bit_depth?: 16 | 24 | 32;
   /**
    * Audio bitrate in kilobits per second
+   * @minimum 1
    */
   audio_bitrate_kbps?: number;
   /**
@@ -4687,10 +4912,12 @@ export interface AudioAsset {
   url: string;
   /**
    * Audio duration in milliseconds
+   * @minimum 0
    */
   duration_ms?: number;
   /**
    * File size in bytes
+   * @minimum 1
    */
   file_size_bytes?: number;
   /**
@@ -4712,6 +4939,7 @@ export interface AudioAsset {
   bit_depth?: 16 | 24 | 32;
   /**
    * Bitrate in kilobits per second
+   * @minimum 1
    */
   bitrate_kbps?: number;
   /**
@@ -4855,6 +5083,8 @@ export interface WebhookAsset {
   method?: HTTPMethod;
   /**
    * Maximum time to wait for response in milliseconds
+   * @minimum 10
+   * @maximum 5000
    */
   timeout_ms?: number;
   /**
@@ -4994,6 +5224,7 @@ export interface CreativeBrief {
       regulation?: string;
       /**
        * Minimum display duration in milliseconds. For video/audio disclosures, how long the disclosure must be visible or audible. For static formats, how long the disclosure must remain on screen before any auto-advance.
+       * @minimum 1
        */
       min_duration_ms?: number;
       /**
@@ -5032,6 +5263,7 @@ export interface IndustryIdentifier {
   type: CreativeIdentifierType;
   /**
    * The identifier value (e.g., 'ABCD1234000H' for Ad-ID)
+   * @maxLength 64
    */
   value: string;
 }
@@ -5041,18 +5273,22 @@ export interface IndustryIdentifier {
 export interface BusinessEntity {
   /**
    * Registered legal name of the business entity
+   * @maxLength 200
    */
   legal_name: string;
   /**
    * VAT identification number (e.g., DE123456789 for Germany, FR12345678901 for France). Required for B2B invoicing in the EU. Must be normalized: no spaces, dots, or dashes.
+   * @pattern ^[A-Z]{2}[A-Z0-9]{2,13}$
    */
   vat_id?: string;
   /**
    * Tax identification number for jurisdictions that do not use VAT (e.g., US EIN)
+   * @maxLength 30
    */
   tax_id?: string;
   /**
    * Company registration number (e.g., HRB 12345 for German Handelsregister)
+   * @maxLength 50
    */
   registration_number?: string;
   /**
@@ -5061,16 +5297,25 @@ export interface BusinessEntity {
   address?: {
     /**
      * Street address including building number
+     * @maxLength 200
      */
     street: string;
+    /**
+     * @maxLength 100
+     */
     city: string;
+    /**
+     * @maxLength 20
+     */
     postal_code: string;
     /**
      * State, province, or region
+     * @maxLength 100
      */
     region?: string;
     /**
      * ISO 3166-1 alpha-2 country code
+     * @pattern ^[A-Z]{2}$
      */
     country: string;
   };
@@ -5084,9 +5329,17 @@ export interface BusinessEntity {
     role: 'billing' | 'legal' | 'creative' | 'general';
     /**
      * Full name of the contact
+     * @maxLength 200
      */
     name?: string;
+    /**
+     * @maxLength 254
+     * @format email
+     */
     email?: string;
+    /**
+     * @maxLength 30
+     */
     phone?: string;
   }[];
   /**
@@ -5095,22 +5348,27 @@ export interface BusinessEntity {
   bank?: {
     /**
      * Name on the bank account
+     * @maxLength 200
      */
     account_holder: string;
     /**
      * International Bank Account Number (SEPA markets)
+     * @pattern ^[A-Z]{2}[0-9]{2}[A-Z0-9]{4,30}$
      */
     iban?: string;
     /**
      * Bank Identifier Code / SWIFT code (SEPA markets)
+     * @pattern ^[A-Z]{4}[A-Z]{2}[A-Z0-9]{2}([A-Z0-9]{3})?$
      */
     bic?: string;
     /**
      * Bank routing number for non-SEPA markets (e.g., US ABA routing number, Canadian transit/institution number)
+     * @maxLength 30
      */
     routing_number?: string;
     /**
      * Bank account number for non-SEPA markets
+     * @maxLength 30
      */
     account_number?: string;
   };
@@ -5126,6 +5384,7 @@ export interface PushNotificationConfig {
   url: string;
   /**
    * Optional client-provided token for webhook validation. Echoed back in webhook payload to validate request authenticity.
+   * @minLength 16
    */
   token?: string;
   /**
@@ -5138,6 +5397,7 @@ export interface PushNotificationConfig {
     schemes: AuthenticationScheme[];
     /**
      * Credentials for the legacy scheme. For Bearer: token sent in Authorization header. For HMAC-SHA256: shared secret used to generate signature. Minimum 32 characters. Exchanged out-of-band during onboarding.
+     * @minLength 32
      */
     credentials: string;
   };
@@ -5152,6 +5412,7 @@ export interface ReportingWebhook {
   url: string;
   /**
    * Optional client-provided token for webhook validation. Echoed back in webhook payload to validate request authenticity.
+   * @minLength 16
    */
   token?: string;
   /**
@@ -5164,6 +5425,7 @@ export interface ReportingWebhook {
     schemes: AuthenticationScheme[];
     /**
      * Credentials for the legacy scheme. For Bearer: token sent in Authorization header. For HMAC-SHA256: shared secret used to generate signature. Minimum 32 characters. Exchanged out-of-band during onboarding.
+     * @minLength 32
      */
     credentials: string;
   };
@@ -5290,6 +5552,8 @@ export type AudienceSelector =
       type: 'description';
       /**
        * Natural language description of the audience (e.g., 'likely EV buyers', 'high net worth individuals', 'vulnerable communities')
+       * @minLength 1
+       * @maxLength 2000
        */
       description: string;
       /**
@@ -5310,14 +5574,17 @@ export interface CreateMediaBuySuccess {
   status?: MediaBuyStatus;
   /**
    * ISO 8601 timestamp when this media buy was confirmed by the seller. A successful create_media_buy response constitutes order confirmation.
+   * @format date-time
    */
   confirmed_at?: string;
   /**
    * ISO 8601 timestamp for creative upload deadline
+   * @format date-time
    */
   creative_deadline?: string;
   /**
    * Initial revision number for this media buy. Use in subsequent update_media_buy requests for optimistic concurrency.
+   * @minimum 1
    */
   revision?: number;
   /**
@@ -5360,6 +5627,7 @@ export interface Account {
   brand?: BrandReference;
   /**
    * Domain of the entity operating this account. When the brand operates directly, this is the brand's domain.
+   * @pattern ^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$
    */
   operator?: string;
   billing?: BillingParty;
@@ -5373,7 +5641,13 @@ export interface Account {
    * Maximum outstanding balance allowed
    */
   credit_limit?: {
+    /**
+     * @minimum 0
+     */
     amount: number;
+    /**
+     * @pattern ^[A-Z]{3}$
+     */
     currency: string;
   };
   /**
@@ -5390,6 +5664,7 @@ export interface Account {
     message: string;
     /**
      * When this setup link expires.
+     * @format date-time
      */
     expires_at?: string;
   };
@@ -5400,6 +5675,7 @@ export interface Account {
   governance_agents?: {
     /**
      * Governance agent endpoint URL. Must use HTTPS.
+     * @pattern ^https:\/\/
      */
     url: string;
     /**
@@ -5414,14 +5690,21 @@ export interface Account {
     protocol: CloudStorageProtocol;
     /**
      * Bucket or container name
+     * @minLength 3
+     * @maxLength 63
+     * @pattern ^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$
      */
     bucket: string;
     /**
      * Path prefix within the bucket. Seller appends date-based partitioning beneath this prefix.
+     * @maxLength 512
+     * @pattern ^[a-zA-Z0-9\/_.-]+$
      */
     prefix?: string;
     /**
      * Cloud region for the bucket
+     * @maxLength 64
+     * @pattern ^[a-z0-9-]+$
      */
     region?: string;
     /**
@@ -5434,10 +5717,12 @@ export interface Account {
     compression?: 'gzip' | 'none';
     /**
      * How long reporting files are retained in the bucket before deletion. Buyers must read files within this window. Minimum recommended: 14 days.
+     * @minimum 1
      */
     file_retention_days: number;
     /**
      * URL to documentation for configuring buyer read access to this bucket (IAM role, service account, etc.). Operator-facing documentation — buyer agents MUST NOT auto-fetch this URL; surface it to a human operator. If an implementation fetches it (for preview), apply webhook URL SSRF validation and do not pass the fetched content into an LLM context without indirect-prompt-injection guarding. See docs/media-buy/media-buys/optimization-reporting#security-considerations-for-offline-delivery.
+     * @pattern ^https:\/\/
      */
     setup_instructions?: string;
   };
@@ -5461,6 +5746,7 @@ export interface Package {
   product_id?: string;
   /**
    * Budget allocation for this package in the currency specified by the pricing option
+   * @minimum 0
    */
   budget?: number;
   pacing?: Pacing;
@@ -5470,11 +5756,13 @@ export interface Package {
   pricing_option_id?: string;
   /**
    * Bid price for auction-based pricing. This is the exact bid/price to honor unless the selected pricing option has max_bid=true, in which case bid_price is the buyer's maximum willingness to pay (ceiling).
+   * @minimum 0
    */
   bid_price?: number;
   price_breakdown?: PriceBreakdown;
   /**
    * Impression goal for this package
+   * @minimum 0
    */
   impressions?: number;
   /**
@@ -5505,10 +5793,12 @@ export interface Package {
   optimization_goals?: OptimizationGoal[];
   /**
    * Flight start date/time for this package in ISO 8601 format. When omitted, the package inherits the media buy's start_time. Sellers SHOULD always include the resolved value in responses, even when inherited.
+   * @format date-time
    */
   start_time?: string;
   /**
    * Flight end date/time for this package in ISO 8601 format. When omitted, the package inherits the media buy's end_time. Sellers SHOULD always include the resolved value in responses, even when inherited.
+   * @format date-time
    */
   end_time?: string;
   /**
@@ -5525,24 +5815,29 @@ export interface Package {
   cancellation?: {
     /**
      * ISO 8601 timestamp when this package was canceled.
+     * @format date-time
      */
     canceled_at: string;
     canceled_by: CanceledBy;
     /**
      * Reason the package was canceled.
+     * @maxLength 500
      */
     reason?: string;
     /**
      * ISO 8601 timestamp when the seller acknowledged the cancellation. Confirms inventory has been released and billing stopped. Absent until the seller processes the cancellation.
+     * @format date-time
      */
     acknowledged_at?: string;
   };
   /**
    * Agency estimate or authorization number for this package. Echoed from the buyer's request. When present on the package, takes precedence over the media buy-level estimate number.
+   * @maxLength 100
    */
   agency_estimate_number?: string;
   /**
    * ISO 8601 timestamp for creative upload or change deadline for this package. After this deadline, creative changes are rejected. When absent, the media buy's creative_deadline applies.
+   * @format date-time
    */
   creative_deadline?: string;
   context?: ContextObject;
@@ -5571,10 +5866,12 @@ export interface PlannedDelivery {
   channels?: MediaChannel[];
   /**
    * Actual flight start the seller will use.
+   * @format date-time
    */
   start_time?: string;
   /**
    * Actual flight end the seller will use.
+   * @format date-time
    */
   end_time?: string;
   frequency_cap?: FrequencyCap;
@@ -5588,10 +5885,12 @@ export interface PlannedDelivery {
   audience_targeting?: AudienceSelector[];
   /**
    * Total budget the seller will deliver against.
+   * @minimum 0
    */
   total_budget?: number;
   /**
    * ISO 4217 currency code for the budget.
+   * @pattern ^[A-Z]{3}$
    */
   currency?: string;
   /**
@@ -5625,6 +5924,7 @@ export interface CreateMediaBuySubmitted {
   task_id: string;
   /**
    * Optional human-readable explanation of why the task is submitted — e.g., 'Awaiting IO signature from sales team; typical turnaround 2–4 hours.' Plain text only. Buyers MUST treat this as untrusted seller input: escape before rendering to HTML UIs, and sanitize or isolate before passing to an LLM prompt context — a hostile seller may inject prompt-injection payloads aimed at the buyer's agent.
+   * @maxLength 2000
    */
   message?: string;
   /**
@@ -5643,6 +5943,8 @@ export interface CreateMediaBuySubmitted {
 export interface UpdateMediaBuyRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   account: AccountReference;
@@ -5652,6 +5954,7 @@ export interface UpdateMediaBuyRequest {
   media_buy_id: string;
   /**
    * Expected current revision for optimistic concurrency. When provided, sellers MUST reject the update with CONFLICT if the media buy's current revision does not match. Obtain from get_media_buys or the most recent update response.
+   * @minimum 1
    */
   revision?: number;
   /**
@@ -5664,11 +5967,13 @@ export interface UpdateMediaBuyRequest {
   canceled?: true;
   /**
    * Reason for cancellation. Sellers SHOULD store this and return it in subsequent get_media_buys responses.
+   * @maxLength 500
    */
   cancellation_reason?: string;
   start_time?: StartTiming;
   /**
    * New end date/time in ISO 8601 format
+   * @format date-time
    */
   end_time?: string;
   /**
@@ -5684,6 +5989,9 @@ export interface UpdateMediaBuyRequest {
   push_notification_config?: PushNotificationConfig;
   /**
    * Client-generated idempotency key for safe retries. If an update fails without a response, resending with the same idempotency_key guarantees the update is applied at most once. MUST be unique per (seller, request) pair to prevent cross-seller correlation. Use a fresh UUID v4 for each request.
+   * @minLength 16
+   * @maxLength 255
+   * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   idempotency_key: string;
   context?: ContextObject;
@@ -5699,23 +6007,28 @@ export interface PackageUpdate {
   package_id: string;
   /**
    * Updated budget allocation for this package in the currency specified by the pricing option
+   * @minimum 0
    */
   budget?: number;
   pacing?: Pacing;
   /**
    * Updated bid price for auction-based pricing options. This is the exact bid/price to honor unless selected pricing_option has max_bid=true, in which case bid_price is the buyer's maximum willingness to pay (ceiling).
+   * @minimum 0
    */
   bid_price?: number;
   /**
    * Updated impression goal for this package
+   * @minimum 0
    */
   impressions?: number;
   /**
    * Updated flight start date/time for this package in ISO 8601 format. Must fall within the media buy's date range.
+   * @format date-time
    */
   start_time?: string;
   /**
    * Updated flight end date/time for this package in ISO 8601 format. Must fall within the media buy's date range.
+   * @format date-time
    */
   end_time?: string;
   /**
@@ -5728,6 +6041,7 @@ export interface PackageUpdate {
   canceled?: true;
   /**
    * Reason for canceling this package.
+   * @maxLength 500
    */
   cancellation_reason?: string;
   /**
@@ -5745,11 +6059,13 @@ export interface PackageUpdate {
   keyword_targets_add?: {
     /**
      * The keyword to target
+     * @minLength 1
      */
     keyword: string;
     match_type: MatchType;
     /**
      * Per-keyword bid price. Inherits currency and max_bid interpretation from the package's pricing option.
+     * @minimum 0
      */
     bid_price?: number;
   }[];
@@ -5759,6 +6075,7 @@ export interface PackageUpdate {
   keyword_targets_remove?: {
     /**
      * The keyword to stop targeting
+     * @minLength 1
      */
     keyword: string;
     match_type: MatchType;
@@ -5769,6 +6086,7 @@ export interface PackageUpdate {
   negative_keywords_add?: {
     /**
      * The keyword to exclude
+     * @minLength 1
      */
     keyword: string;
     match_type: MatchType;
@@ -5779,6 +6097,7 @@ export interface PackageUpdate {
   negative_keywords_remove?: {
     /**
      * The keyword to stop excluding
+     * @minLength 1
      */
     keyword: string;
     match_type: MatchType;
@@ -5809,10 +6128,12 @@ export interface UpdateMediaBuySuccess {
   status?: MediaBuyStatus;
   /**
    * Revision number after this update. Use this value in subsequent update_media_buy requests for optimistic concurrency.
+   * @minimum 1
    */
   revision?: number;
   /**
    * ISO 8601 timestamp when changes take effect (null if pending approval)
+   * @format date-time
    */
   implementation_date?: string | null;
   invoice_recipient?: BusinessEntity;
@@ -5850,6 +6171,8 @@ export interface UpdateMediaBuyError {
 export interface GetMediaBuysRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   account?: AccountReference;
@@ -5867,6 +6190,8 @@ export interface GetMediaBuysRequest {
   include_snapshot?: boolean;
   /**
    * When present, include the last N revision history entries for each media buy (returns min(N, available entries)). Each entry contains revision number, timestamp, actor, and a summary of what changed. Omit or set to 0 to exclude history (default). Recommended: 5-10 for monitoring, 50+ for audit.
+   * @minimum 0
+   * @maximum 1000
    */
   include_history?: number;
   pagination?: PaginationRequest;
@@ -5904,26 +6229,32 @@ export interface GetMediaBuysResponse {
     status: MediaBuyStatus;
     /**
      * ISO 4217 currency code (e.g., USD, EUR, GBP) for monetary values at this media buy level. total_budget is always denominated in this currency. Package-level fields may override with package.currency.
+     * @pattern ^[A-Z]{3}$
      */
     currency: string;
     /**
      * Total budget amount across all packages, denominated in media_buy.currency
+     * @minimum 0
      */
     total_budget?: number;
     /**
      * ISO 8601 flight start time for this media buy (earliest package start_time). Avoids requiring buyers to compute min(packages[].start_time).
+     * @format date-time
      */
     start_time?: string;
     /**
      * ISO 8601 flight end time for this media buy (latest package end_time). Avoids requiring buyers to compute max(packages[].end_time).
+     * @format date-time
      */
     end_time?: string;
     /**
      * ISO 8601 timestamp for creative upload deadline
+     * @format date-time
      */
     creative_deadline?: string;
     /**
      * ISO 8601 timestamp when the seller confirmed this media buy. A successful create_media_buy response constitutes order confirmation.
+     * @format date-time
      */
     confirmed_at?: string;
     /**
@@ -5932,24 +6263,29 @@ export interface GetMediaBuysResponse {
     cancellation?: {
       /**
        * ISO 8601 timestamp when this media buy was canceled.
+       * @format date-time
        */
       canceled_at: string;
       canceled_by: CanceledBy;
       /**
        * Reason the media buy was canceled.
+       * @maxLength 500
        */
       reason?: string;
     };
     /**
      * Current revision number. Pass this in update_media_buy for optimistic concurrency.
+     * @minimum 1
      */
     revision?: number;
     /**
      * Creation timestamp
+     * @format date-time
      */
     created_at?: string;
     /**
      * Last update timestamp
+     * @format date-time
      */
     updated_at?: string;
     /**
@@ -5962,10 +6298,12 @@ export interface GetMediaBuysResponse {
     history?: {
       /**
        * Revision number after this change was applied.
+       * @minimum 1
        */
       revision: number;
       /**
        * When this change occurred.
+       * @format date-time
        */
       timestamp: string;
       /**
@@ -5978,6 +6316,7 @@ export interface GetMediaBuysResponse {
       action: string;
       /**
        * Human-readable summary of the change (e.g., 'Budget increased from $5,000 to $7,500 on pkg_abc').
+       * @maxLength 500
        */
       summary?: string;
       /**
@@ -6018,27 +6357,33 @@ export interface PackageStatus {
   product_id?: string;
   /**
    * Package budget amount, denominated in package.currency when present, otherwise media_buy.currency
+   * @minimum 0
    */
   budget?: number;
   /**
    * ISO 4217 currency code for monetary values at this package level (budget, bid_price, snapshot.spend). When absent, inherit media_buy.currency.
+   * @pattern ^[A-Z]{3}$
    */
   currency?: string;
   /**
    * Current bid price for auction-based packages. Denominated in package.currency when present, otherwise media_buy.currency. Relevant for automated price optimization loops.
+   * @minimum 0
    */
   bid_price?: number;
   /**
    * Goal impression count for impression-based packages
+   * @minimum 0
    */
   impressions?: number;
   targeting_overlay?: TargetingOverlay;
   /**
    * ISO 8601 flight start time for this package. Use to determine whether the package is within its scheduled flight before interpreting delivery status.
+   * @format date-time
    */
   start_time?: string;
   /**
    * ISO 8601 flight end time for this package
+   * @format date-time
    */
   end_time?: string;
   /**
@@ -6055,16 +6400,19 @@ export interface PackageStatus {
   cancellation?: {
     /**
      * ISO 8601 timestamp when this package was canceled.
+     * @format date-time
      */
     canceled_at: string;
     canceled_by: CanceledBy;
     /**
      * Reason the package was canceled.
+     * @maxLength 500
      */
     reason?: string;
   };
   /**
    * ISO 8601 timestamp for creative upload or change deadline for this package. After this deadline, creative changes are rejected. When absent, the media buy's creative_deadline applies.
+   * @format date-time
    */
   creative_deadline?: string;
   /**
@@ -6092,30 +6440,37 @@ export interface PackageStatus {
   snapshot?: {
     /**
      * ISO 8601 timestamp when this snapshot was captured by the platform
+     * @format date-time
      */
     as_of: string;
     /**
      * Maximum age of this data in seconds. For example, 900 means the data may be up to 15 minutes old. Use this to interpret zero delivery: a value of 900 means zero impressions is likely real; a value of 14400 means reporting may still be catching up.
+     * @minimum 0
      */
     staleness_seconds: number;
     /**
      * Total impressions delivered since package start
+     * @minimum 0
      */
     impressions: number;
     /**
      * Total spend since package start, denominated in snapshot.currency when present, otherwise package.currency or media_buy.currency
+     * @minimum 0
      */
     spend: number;
     /**
      * ISO 4217 currency code for spend in this snapshot. Optional when unchanged from package.currency or media_buy.currency.
+     * @pattern ^[A-Z]{3}$
      */
     currency?: string;
     /**
      * Total clicks since package start (when available)
+     * @minimum 0
      */
     clicks?: number;
     /**
      * Current delivery pace relative to expected (1.0 = on track, <1.0 = behind, >1.0 = ahead). Absent when pacing cannot be determined.
+     * @minimum 0
      */
     pacing_index?: number;
     /**
@@ -6162,6 +6517,8 @@ export type SortMetric =
 export interface GetMediaBuyDeliveryRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   account?: AccountReference;
@@ -6175,10 +6532,12 @@ export interface GetMediaBuyDeliveryRequest {
   status_filter?: MediaBuyStatus | MediaBuyStatus[];
   /**
    * Start date for reporting period (YYYY-MM-DD). When omitted along with end_date, returns campaign lifetime data. Only accepted when the product's reporting_capabilities.date_range_support is 'date_range'.
+   * @pattern ^\d{4}-\d{2}-\d{2}$
    */
   start_date?: string;
   /**
    * End date for reporting period (YYYY-MM-DD). When omitted along with start_date, returns campaign lifetime data. Only accepted when the product's reporting_capabilities.date_range_support is 'date_range'.
+   * @pattern ^\d{4}-\d{2}-\d{2}$
    */
   end_date?: string;
   /**
@@ -6214,6 +6573,7 @@ export interface GetMediaBuyDeliveryRequest {
       system?: MetroAreaSystem | PostalCodeSystem;
       /**
        * Maximum number of geo entries to return. Defaults to 25. When truncated, by_geo_truncated is true in the response.
+       * @minimum 1
        */
       limit?: number;
       sort_by?: SortMetric;
@@ -6224,6 +6584,7 @@ export interface GetMediaBuyDeliveryRequest {
     device_type?: {
       /**
        * Maximum number of entries to return. When omitted, all entries are returned (the enum is small and bounded).
+       * @minimum 1
        */
       limit?: number;
       sort_by?: SortMetric;
@@ -6234,6 +6595,7 @@ export interface GetMediaBuyDeliveryRequest {
     device_platform?: {
       /**
        * Maximum number of entries to return. When omitted, all entries are returned (the enum is small and bounded).
+       * @minimum 1
        */
       limit?: number;
       sort_by?: SortMetric;
@@ -6244,6 +6606,7 @@ export interface GetMediaBuyDeliveryRequest {
     audience?: {
       /**
        * Maximum number of entries to return. Defaults to 25.
+       * @minimum 1
        */
       limit?: number;
       sort_by?: SortMetric;
@@ -6254,6 +6617,7 @@ export interface GetMediaBuyDeliveryRequest {
     placement?: {
       /**
        * Maximum number of entries to return. Defaults to 25.
+       * @minimum 1
        */
       limit?: number;
       sort_by?: SortMetric;
@@ -6287,14 +6651,17 @@ export interface GetMediaBuyDeliveryResponse {
   partial_data?: boolean;
   /**
    * Number of media buys with reporting_delayed or failed status (only present in webhook deliveries when partial_data is true)
+   * @minimum 0
    */
   unavailable_count?: number;
   /**
    * Sequential notification number (only present in webhook deliveries, starts at 1)
+   * @minimum 1
    */
   sequence_number?: number;
   /**
    * ISO 8601 timestamp for next expected notification (only present in webhook deliveries when notification_type is not 'final')
+   * @format date-time
    */
   next_expected_at?: string;
   /**
@@ -6303,15 +6670,18 @@ export interface GetMediaBuyDeliveryResponse {
   reporting_period: {
     /**
      * ISO 8601 start timestamp in UTC (e.g., 2024-02-05T00:00:00Z)
+     * @format date-time
      */
     start: string;
     /**
      * ISO 8601 end timestamp in UTC (e.g., 2024-02-05T23:59:59Z)
+     * @format date-time
      */
     end: string;
   };
   /**
    * ISO 4217 currency code
+   * @pattern ^[A-Z]{3}$
    */
   currency?: string;
   attribution_window?: AttributionWindow;
@@ -6321,50 +6691,64 @@ export interface GetMediaBuyDeliveryResponse {
   aggregated_totals?: {
     /**
      * Total impressions delivered across all media buys
+     * @minimum 0
      */
     impressions: number;
     /**
      * Total amount spent across all media buys
+     * @minimum 0
      */
     spend: number;
     /**
      * Total clicks across all media buys (if applicable)
+     * @minimum 0
      */
     clicks?: number;
     /**
      * Total audio/video completions across all media buys (if applicable)
+     * @minimum 0
      */
     completed_views?: number;
     /**
      * Total views across all media buys (if applicable)
+     * @minimum 0
      */
     views?: number;
     /**
      * Total conversions across all media buys (if applicable)
+     * @minimum 0
      */
     conversions?: number;
     /**
      * Total conversion value across all media buys (if applicable)
+     * @minimum 0
      */
     conversion_value?: number;
     /**
      * Aggregate return on ad spend across all media buys (total conversion_value / total spend)
+     * @minimum 0
      */
     roas?: number;
     /**
      * Fraction of total conversions across all media buys from first-time brand buyers (weighted by conversion volume, not a simple average of per-buy rates)
+     * @minimum 0
+     * @maximum 1
      */
     new_to_brand_rate?: number;
     /**
      * Aggregate cost per conversion across all media buys (total spend / total conversions)
+     * @minimum 0
      */
     cost_per_acquisition?: number;
     /**
      * Aggregate completion rate across all media buys (weighted by impressions, not a simple average of per-buy rates)
+     * @minimum 0
+     * @maximum 1
      */
     completion_rate?: number;
     /**
      * Deduplicated reach across all media buys (if the seller can deduplicate across buys; otherwise sum of per-buy reach). Only present when all media buys share the same reach_unit. Omitted when reach units are heterogeneous — use per-buy reach values instead.
+     * @minimum 0
      */
     reach?: number;
     /**
@@ -6373,10 +6757,12 @@ export interface GetMediaBuyDeliveryResponse {
     reach_unit?: ReachUnit;
     /**
      * Average frequency per reach unit across all media buys (impressions / reach when cross-buy deduplication is available). Only present when reach is present.
+     * @minimum 0
      */
     frequency?: number;
     /**
      * Number of media buys included in the response
+     * @minimum 0
      */
     media_buy_count: number;
   };
@@ -6404,6 +6790,7 @@ export interface GetMediaBuyDeliveryResponse {
       | 'reporting_delayed';
     /**
      * When delayed data is expected to be available (only present when status is reporting_delayed)
+     * @format date-time
      */
     expected_availability?: string;
     /**
@@ -6414,6 +6801,7 @@ export interface GetMediaBuyDeliveryResponse {
     totals: DeliveryMetrics & {
       /**
        * Effective rate paid per unit based on pricing_model (e.g., actual CPM for 'cpm', actual cost per completed view for 'cpcv', actual cost per point for 'cpp')
+       * @minimum 0
        */
       effective_rate?: number;
     };
@@ -6427,15 +6815,18 @@ export interface GetMediaBuyDeliveryResponse {
       package_id: string;
       /**
        * Delivery pace (1.0 = on track, <1.0 = behind, >1.0 = ahead)
+       * @minimum 0
        */
       pacing_index?: number;
       pricing_model?: PricingModel;
       /**
        * The pricing rate for this package in the specified currency. For fixed-rate pricing, this is the agreed rate (e.g., CPM rate of 12.50 means $12.50 per 1,000 impressions). For auction-based pricing, this represents the effective rate based on actual delivery.
+       * @minimum 0
        */
       rate?: number;
       /**
        * ISO 4217 currency code (e.g., USD, EUR, GBP) for this package's pricing. Indicates the currency in which the rate and spend values are denominated. Different packages can use different currencies when supported by the publisher.
+       * @pattern ^[A-Z]{3}$
        */
       currency?: string;
       /**
@@ -6452,10 +6843,12 @@ export interface GetMediaBuyDeliveryResponse {
       is_final?: boolean;
       /**
        * Which measurement window this data represents, referencing a window_id from the product's reporting_capabilities.measurement_windows. For broadcast: 'live', 'c3', 'c7'. When absent, the data is not windowed (standard digital reporting). When present with is_final: false, a later report for the same period will provide a wider window or more complete data.
+       * @maxLength 50
        */
       measurement_window?: string;
       /**
        * Which measurement window this data replaces. Present on window_update notifications to indicate progression (e.g., 'live' when reporting C3 data that supersedes live-only numbers). Absent on the first report for a period. Buyers should replace stored data for the superseded window with this report's data.
+       * @maxLength 50
        */
       supersedes_window?: string;
       /**
@@ -6478,6 +6871,8 @@ export interface GetMediaBuyDeliveryResponse {
         creative_id: string;
         /**
          * Observed delivery share for this creative within the package during the reporting period, expressed as a percentage (0-100). Reflects actual delivery distribution, not a configured setting.
+         * @minimum 0
+         * @maximum 100
          */
         weight?: number;
       })[];
@@ -6574,30 +6969,38 @@ export interface GetMediaBuyDeliveryResponse {
       daily_breakdown?: {
         /**
          * Date (YYYY-MM-DD)
+         * @pattern ^\d{4}-\d{2}-\d{2}$
          */
         date: string;
         /**
          * Daily impressions for this package
+         * @minimum 0
          */
         impressions: number;
         /**
          * Daily spend for this package
+         * @minimum 0
          */
         spend: number;
         /**
          * Daily conversions for this package
+         * @minimum 0
          */
         conversions?: number;
         /**
          * Daily conversion value for this package
+         * @minimum 0
          */
         conversion_value?: number;
         /**
          * Daily return on ad spend (conversion_value / spend)
+         * @minimum 0
          */
         roas?: number;
         /**
          * Daily fraction of conversions from first-time brand buyers (0 = none, 1 = all)
+         * @minimum 0
+         * @maximum 1
          */
         new_to_brand_rate?: number;
       }[];
@@ -6608,30 +7011,38 @@ export interface GetMediaBuyDeliveryResponse {
     daily_breakdown?: {
       /**
        * Date (YYYY-MM-DD)
+       * @pattern ^\d{4}-\d{2}-\d{2}$
        */
       date: string;
       /**
        * Daily impressions
+       * @minimum 0
        */
       impressions: number;
       /**
        * Daily spend
+       * @minimum 0
        */
       spend: number;
       /**
        * Daily conversions
+       * @minimum 0
        */
       conversions?: number;
       /**
        * Daily conversion value
+       * @minimum 0
        */
       conversion_value?: number;
       /**
        * Daily return on ad spend (conversion_value / spend)
+       * @minimum 0
        */
       roas?: number;
       /**
        * Daily fraction of conversions from first-time brand buyers (0 = none, 1 = all)
+       * @minimum 0
+       * @maximum 1
        */
       new_to_brand_rate?: number;
     }[];
@@ -6667,54 +7078,70 @@ export interface AttributionWindow {
 export interface DeliveryMetrics {
   /**
    * Impressions delivered
+   * @minimum 0
    */
   impressions?: number;
   /**
    * Amount spent
+   * @minimum 0
    */
   spend?: number;
   /**
    * Total clicks
+   * @minimum 0
    */
   clicks?: number;
   /**
    * Click-through rate (clicks/impressions)
+   * @minimum 0
+   * @maximum 1
    */
   ctr?: number;
   /**
    * Content engagements counted toward the billable view threshold. For video this is a platform-defined view event (e.g., 30 seconds or video midpoint); for audio/podcast it is a stream start; for other formats it follows the pricing model's view definition. When the package uses CPV pricing, spend = views × rate.
+   * @minimum 0
    */
   views?: number;
   /**
    * Video/audio completions. When the package has a completed_views optimization goal with view_duration_seconds, completions are counted at that threshold rather than 100% completion.
+   * @minimum 0
    */
   completed_views?: number;
   /**
    * Completion rate (completed_views/impressions)
+   * @minimum 0
+   * @maximum 1
    */
   completion_rate?: number;
   /**
    * Total conversions attributed to this delivery. When by_event_type is present, this equals the sum of all by_event_type[].count entries.
+   * @minimum 0
    */
   conversions?: number;
   /**
    * Total monetary value of attributed conversions (in the reporting currency)
+   * @minimum 0
    */
   conversion_value?: number;
   /**
    * Return on ad spend (conversion_value / spend)
+   * @minimum 0
    */
   roas?: number;
   /**
    * Cost per conversion (spend / conversions)
+   * @minimum 0
    */
   cost_per_acquisition?: number;
   /**
    * Fraction of conversions from first-time brand buyers (0 = none, 1 = all)
+   * @minimum 0
+   * @maximum 1
    */
   new_to_brand_rate?: number;
   /**
    * Leads generated (convenience alias for by_event_type where event_type='lead')
+   * @minimum 0
    */
   leads?: number;
   /**
@@ -6728,19 +7155,23 @@ export interface DeliveryMetrics {
     event_source_id?: string;
     /**
      * Number of events of this type
+     * @minimum 0
      */
     count: number;
     /**
      * Total monetary value of events of this type
+     * @minimum 0
      */
     value?: number;
   }[];
   /**
    * Gross Rating Points delivered (for CPP)
+   * @minimum 0
    */
   grps?: number;
   /**
    * Unique reach in the units specified by reach_unit. When reach_unit is omitted, units are unspecified — do not compare reach values across packages or media buys without a common reach_unit.
+   * @minimum 0
    */
   reach?: number;
   /**
@@ -6749,6 +7180,7 @@ export interface DeliveryMetrics {
   reach_unit?: ReachUnit;
   /**
    * Average frequency per reach unit (typically measured over campaign duration, but can vary by measurement provider). When reach_unit is 'households', this is average exposures per household; when 'accounts', per logged-in account; etc.
+   * @minimum 0
    */
   frequency?: number;
   /**
@@ -6757,18 +7189,22 @@ export interface DeliveryMetrics {
   quartile_data?: {
     /**
      * 25% completion views
+     * @minimum 0
      */
     q1_views?: number;
     /**
      * 50% completion views
+     * @minimum 0
      */
     q2_views?: number;
     /**
      * 75% completion views
+     * @minimum 0
      */
     q3_views?: number;
     /**
      * 100% completion views
+     * @minimum 0
      */
     q4_views?: number;
   };
@@ -6778,18 +7214,23 @@ export interface DeliveryMetrics {
   dooh_metrics?: {
     /**
      * Number of times ad played in rotation
+     * @minimum 0
      */
     loop_plays?: number;
     /**
      * Number of unique screens displaying the ad
+     * @minimum 0
      */
     screens_used?: number;
     /**
      * Total display time in seconds
+     * @minimum 0
      */
     screen_time_seconds?: number;
     /**
      * Actual share of voice delivered (0.0 to 1.0)
+     * @minimum 0
+     * @maximum 1
      */
     sov_achieved?: number;
     /**
@@ -6814,14 +7255,17 @@ export interface DeliveryMetrics {
       venue_type?: string;
       /**
        * Impressions delivered at this venue
+       * @minimum 0
        */
       impressions: number;
       /**
        * Loop plays at this venue
+       * @minimum 0
        */
       loop_plays?: number;
       /**
        * Number of screens used at this venue
+       * @minimum 0
        */
       screens_used?: number;
     }[];
@@ -6832,40 +7276,51 @@ export interface DeliveryMetrics {
   viewability?: {
     /**
      * Impressions where viewability could be measured. Excludes environments without measurement capability (e.g., non-Intersection Observer browsers, certain app environments).
+     * @minimum 0
      */
     measurable_impressions?: number;
     /**
      * Impressions that met the viewability threshold defined by the measurement standard.
+     * @minimum 0
      */
     viewable_impressions?: number;
     /**
      * Viewable impression rate (viewable_impressions / measurable_impressions). Range 0.0 to 1.0.
+     * @minimum 0
+     * @maximum 1
      */
     viewable_rate?: number;
     standard?: ViewabilityStandard;
   };
   /**
    * Total engagements — direct interactions with the ad beyond viewing. Includes social reactions/comments/shares, story/unit opens, interactive overlay taps on CTV, companion banner interactions on audio. Platform-specific; corresponds to the 'engagements' optimization metric.
+   * @minimum 0
    */
   engagements?: number;
   /**
    * New followers, page likes, artist/podcast/channel subscribes attributed to this delivery.
+   * @minimum 0
    */
   follows?: number;
   /**
    * Saves, bookmarks, playlist adds, pins attributed to this delivery.
+   * @minimum 0
    */
   saves?: number;
   /**
    * Visits to the brand's in-platform page (profile, artist page, channel, or storefront) attributed to this delivery. Does not include external website clicks.
+   * @minimum 0
    */
   profile_visits?: number;
   /**
    * Platform-specific engagement rate (0.0 to 1.0). Typically engagements/impressions, but definition varies by platform.
+   * @minimum 0
+   * @maximum 1
    */
   engagement_rate?: number;
   /**
    * Cost per click (spend / clicks)
+   * @minimum 0
    */
   cost_per_click?: number;
   /**
@@ -6879,10 +7334,12 @@ export interface DeliveryMetrics {
     event_source_id?: string;
     /**
      * Number of conversions from this action source
+     * @minimum 0
      */
     count: number;
     /**
      * Total monetary value of conversions from this action source
+     * @minimum 0
      */
     value?: number;
   }[];
@@ -6916,27 +7373,36 @@ export type FeedbackSource =
 export interface ProvidePerformanceFeedbackRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
    * Seller's media buy identifier
+   * @minLength 1
    */
   media_buy_id: string;
   /**
    * Client-generated unique key for this request. Prevents duplicate feedback submissions on retries. MUST be unique per (seller, request) pair to prevent cross-seller correlation. Use a fresh UUID v4 for each request.
+   * @minLength 16
+   * @maxLength 255
+   * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   idempotency_key: string;
   measurement_period: DatetimeRange;
   /**
    * Normalized performance score (0.0 = no value, 1.0 = expected, >1.0 = above expected)
+   * @minimum 0
    */
   performance_index: number;
   /**
    * Specific package within the media buy (if feedback is package-specific)
+   * @minLength 1
    */
   package_id?: string;
   /**
    * Specific creative asset (if feedback is creative-specific)
+   * @minLength 1
    */
   creative_id?: string;
   metric_type?: MetricType;
@@ -6950,10 +7416,12 @@ export interface ProvidePerformanceFeedbackRequest {
 export interface DatetimeRange {
   /**
    * Start timestamp (inclusive), ISO 8601
+   * @format date-time
    */
   start: string;
   /**
    * End timestamp (inclusive), ISO 8601
+   * @format date-time
    */
   end: string;
 }
@@ -6998,10 +7466,15 @@ export interface ProvidePerformanceFeedbackError {
 export interface SyncEventSourcesRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
    * Client-generated unique key for at-most-once execution. `event_source_id` gives resource-level dedup per source, but the sync envelope emits audit events and can trigger downstream pixel provisioning — this key prevents those side effects from firing twice on retry. Also serves as a request ID on discovery-only calls (when `event_sources` is omitted). MUST be unique per (seller, request) pair. Use a fresh UUID v4 for each request.
+   * @minLength 16
+   * @maxLength 255
+   * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   idempotency_key: string;
   account: AccountReference;
@@ -7113,10 +7586,12 @@ export interface EventSourceHealth {
   detail?: {
     /**
      * Seller-defined quality score. Scale varies by seller — only compare within the same seller.
+     * @minimum 0
      */
     score: number;
     /**
      * Maximum possible score on this seller's scale.
+     * @minimum 1
      */
     max_score: number;
     /**
@@ -7126,18 +7601,23 @@ export interface EventSourceHealth {
   };
   /**
    * Fraction of events from this source that the seller successfully matched to ad interactions (0.0-1.0). Low match rates indicate weak user_match identifiers. Absent when the seller does not compute match rates.
+   * @minimum 0
+   * @maximum 1
    */
   match_rate?: number;
   /**
    * ISO 8601 timestamp of the most recent event received from this source. Absent when no events have been received.
+   * @format date-time
    */
   last_event_at?: string;
   /**
    * ISO 8601 timestamp of when this health assessment was computed. When health is derived from reporting data, this may lag real-time. Buyer agents can use this to decide whether to trust stale assessments or re-request.
+   * @format date-time
    */
   evaluated_at?: string;
   /**
    * Number of events received from this source in the last 24 hours. Zero indicates the source is configured but not firing.
+   * @minimum 0
    */
   events_received_24h?: number;
   /**
@@ -7177,10 +7657,12 @@ export type UserMatch = {
   }[];
   /**
    * SHA-256 hash of lowercase, trimmed email address. Buyer must normalize before hashing: lowercase, trim whitespace. Pseudonymous PII, not anonymous — the email namespace is small enough that an unsalted SHA-256 is recoverable via precomputed dictionaries. Treat as PII for retention, consent, and access-control purposes. See docs/reference/privacy-considerations#unsalted-hashed-identifiers-are-pseudonymous-not-anonymous.
+   * @pattern ^[a-f0-9]{64}$
    */
   hashed_email?: string;
   /**
    * SHA-256 hash of E.164-formatted phone number (e.g. +12065551234). Buyer must normalize to E.164 before hashing. Pseudonymous PII, not anonymous — the E.164 namespace is small enough that an unsalted SHA-256 is recoverable via precomputed dictionaries. Treat as PII for retention, consent, and access-control purposes. See docs/reference/privacy-considerations#unsalted-hashed-identifiers-are-pseudonymous-not-anonymous.
+   * @pattern ^[a-f0-9]{64}$
    */
   hashed_phone?: string;
   /**
@@ -7207,6 +7689,8 @@ export type UserMatch = {
 export interface LogEventRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -7223,6 +7707,9 @@ export interface LogEventRequest {
   events: Event[];
   /**
    * Client-generated unique key for this request. Prevents duplicate event logging on retries. MUST be unique per (seller, request) pair to prevent cross-seller correlation. Use a fresh UUID v4 for each request.
+   * @minLength 16
+   * @maxLength 255
+   * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   idempotency_key: string;
   context?: ContextObject;
@@ -7234,11 +7721,14 @@ export interface LogEventRequest {
 export interface Event {
   /**
    * Unique identifier for deduplication (scoped to event_type + event_source_id)
+   * @minLength 1
+   * @maxLength 256
    */
   event_id: string;
   event_type: EventType;
   /**
    * ISO 8601 timestamp when the event occurred
+   * @format date-time
    */
   event_time: string;
   user_match?: UserMatch;
@@ -7260,10 +7750,12 @@ export interface Event {
 export interface EventCustomData {
   /**
    * Monetary value of the event (should be accompanied by currency)
+   * @minimum 0
    */
   value?: number;
   /**
    * ISO 4217 currency code
+   * @pattern ^[A-Z]{3}$
    */
   currency?: string;
   /**
@@ -7288,6 +7780,7 @@ export interface EventCustomData {
   content_category?: string;
   /**
    * Number of items in the event
+   * @minimum 0
    */
   num_items?: number;
   /**
@@ -7304,10 +7797,12 @@ export interface EventCustomData {
     id: string;
     /**
      * Quantity of this item
+     * @minimum 1
      */
     quantity?: number;
     /**
      * Price per unit of this item
+     * @minimum 0
      */
     price?: number;
     /**
@@ -7330,10 +7825,12 @@ export type LogEventResponse = LogEventSuccess | LogEventError;
 export interface LogEventSuccess {
   /**
    * Number of events received
+   * @minimum 0
    */
   events_received: number;
   /**
    * Number of events successfully queued for processing
+   * @minimum 0
    */
   events_processed: number;
   /**
@@ -7359,6 +7856,8 @@ export interface LogEventSuccess {
   warnings?: string[];
   /**
    * Overall match quality score for the batch (0.0 = no matches, 1.0 = all matched)
+   * @minimum 0
+   * @maximum 1
    */
   match_quality?: number;
   /**
@@ -7393,10 +7892,12 @@ export type AudienceMember = {
   external_id: string;
   /**
    * SHA-256 hash of lowercase, trimmed email address. Pseudonymous PII, not anonymous — the email namespace is small enough that an unsalted SHA-256 is recoverable via precomputed dictionaries. Treat as PII for retention, consent, and access-control purposes. See docs/reference/privacy-considerations#unsalted-hashed-identifiers-are-pseudonymous-not-anonymous.
+   * @pattern ^[a-f0-9]{64}$
    */
   hashed_email?: string;
   /**
    * SHA-256 hash of E.164-formatted phone number (e.g. +12065551234). Pseudonymous PII, not anonymous — the E.164 namespace is small enough that an unsalted SHA-256 is recoverable via precomputed dictionaries. Treat as PII for retention, consent, and access-control purposes. See docs/reference/privacy-considerations#unsalted-hashed-identifiers-are-pseudonymous-not-anonymous.
+   * @pattern ^[a-f0-9]{64}$
    */
   hashed_phone?: string;
   /**
@@ -7422,10 +7923,15 @@ export type ConsentBasis = 'consent' | 'legitimate_interest' | 'contract' | 'leg
 export interface SyncAudiencesRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
    * Client-generated unique key for at-most-once execution. `audience_id` gives resource-level dedup per audience, but the sync envelope emits audit events and may trigger downstream refreshes — this key prevents those side effects from firing twice on retry. Also serves as a request ID on discovery-only calls (when `audiences` is omitted). MUST be unique per (seller, request) pair. Use a fresh UUID v4 for each request.
+   * @minLength 16
+   * @maxLength 255
+   * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   idempotency_key: string;
   account: AccountReference;
@@ -7525,18 +8031,23 @@ export interface SyncAudiencesSuccess {
     status?: AudienceStatus;
     /**
      * Number of members submitted in this sync operation (delta, not cumulative). In discovery-only calls (no audiences array), this is 0.
+     * @minimum 0
      */
     uploaded_count?: number;
     /**
      * Cumulative number of members uploaded across all syncs for this audience. Compare with matched_count to calculate match rate (matched_count / total_uploaded_count). Populated when the seller tracks cumulative upload counts.
+     * @minimum 0
      */
     total_uploaded_count?: number;
     /**
      * Total members matched to platform users across all syncs (cumulative, not just this call). Populated when status is 'ready'.
+     * @minimum 0
      */
     matched_count?: number;
     /**
      * Deduplicated match rate across all identifier types (matched_count / total_uploaded_count after deduplication). A single number for reach estimation. Populated when status is 'ready'.
+     * @minimum 0
+     * @maximum 1
      */
     effective_match_rate?: number;
     /**
@@ -7546,23 +8057,29 @@ export interface SyncAudiencesSuccess {
       id_type: MatchIDType;
       /**
        * Cumulative number of members submitted with this identifier type across all syncs (matches total_uploaded_count semantics, not uploaded_count). Compare with matched to calculate per-type match rate.
+       * @minimum 0
        */
       submitted: number;
       /**
        * Cumulative number of members matched via this identifier type across all syncs.
+       * @minimum 0
        */
       matched: number;
       /**
        * Match rate for this identifier type (matched / submitted). Server-authoritative — consumers should prefer this value over computing their own.
+       * @minimum 0
+       * @maximum 1
        */
       match_rate: number;
     }[];
     /**
      * ISO 8601 timestamp of when the most recent sync operation was accepted by the platform. Useful for agents reasoning about audience freshness. Omitted if the seller does not track this.
+     * @format date-time
      */
     last_synced_at?: string;
     /**
      * Minimum matched audience size required for targeting on this platform. Populated when status is 'too_small'. Helps agents know how many more members are needed.
+     * @minimum 1
      */
     minimum_size?: number;
     /**
@@ -7601,10 +8118,15 @@ export type ValidationMode = 'strict' | 'lenient';
 export interface SyncCatalogsRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
    * Client-generated unique key for at-most-once execution. `catalog_id` gives resource-level dedup per catalog, but the sync envelope emits audit events and triggers platform review for large feeds — this key prevents those side effects from firing twice on retry. Also serves as a request ID on discovery-only calls (when `catalogs` is omitted). MUST be unique per (seller, request) pair. Use a fresh UUID v4 for each request.
+   * @minLength 16
+   * @maxLength 255
+   * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   idempotency_key: string;
   account: AccountReference;
@@ -7667,18 +8189,22 @@ export interface SyncCatalogsSuccess {
     platform_id?: string;
     /**
      * Total number of items in the catalog after sync. Required when action is 'created', 'updated', or 'unchanged'. Omitted on 'failed' and 'deleted'.
+     * @minimum 0
      */
     item_count?: number;
     /**
      * Number of items approved by the platform. Populated when the platform performs item-level review.
+     * @minimum 0
      */
     items_approved?: number;
     /**
      * Number of items pending platform review. Common for product catalogs where items must pass content policy checks.
+     * @minimum 0
      */
     items_pending?: number;
     /**
      * Number of items rejected by the platform. Check item_issues for rejection reasons.
+     * @minimum 0
      */
     items_rejected?: number;
     /**
@@ -7697,10 +8223,12 @@ export interface SyncCatalogsSuccess {
     }[];
     /**
      * ISO 8601 timestamp of when the most recent sync was accepted by the platform
+     * @format date-time
      */
     last_synced_at?: string;
     /**
      * ISO 8601 timestamp of when the platform will next fetch the feed URL. Only present for URL-based catalogs with update_frequency.
+     * @format date-time
      */
     next_fetch_at?: string;
     /**
@@ -7772,6 +8300,8 @@ export type PreviewOutputFormat = 'url' | 'html';
 export interface BuildCreativeRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -7805,6 +8335,7 @@ export interface BuildCreativeRequest {
   quality?: CreativeQuality;
   /**
    * Maximum number of catalog items to use when generating. When a catalog asset contains more items than this limit, the creative agent selects the top items based on relevance or catalog ordering. When item_limit exceeds the format's max_items, the creative agent SHOULD use the lesser of the two. Ignored when the manifest contains no catalog assets.
+   * @minimum 1
    */
   item_limit?: number;
   /**
@@ -7840,6 +8371,9 @@ export interface BuildCreativeRequest {
   };
   /**
    * Client-generated unique key for this request. Prevents duplicate creative generation on retries. MUST be unique per (seller, request) pair to prevent cross-seller correlation. Use a fresh UUID v4 for each request.
+   * @minLength 16
+   * @maxLength 255
+   * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   idempotency_key: string;
   context?: ContextObject;
@@ -7892,10 +8426,12 @@ export interface RightsConstraint {
   };
   /**
    * Start of the rights validity period
+   * @format date-time
    */
   valid_from?: string;
   /**
    * End of the rights validity period. Creative should not be served after this time.
+   * @format date-time
    */
   valid_until?: string;
   /**
@@ -7912,6 +8448,7 @@ export interface RightsConstraint {
   excluded_countries?: string[];
   /**
    * Maximum total impressions allowed for the full validity period (valid_from to valid_until). This is the absolute cap across all creatives using this rights grant, not a per-creative or per-period limit.
+   * @minimum 1
    */
   impression_cap?: number;
   right_type?: RightType;
@@ -7956,7 +8493,13 @@ export type PreviewRender =
        * Dimensions for this rendered piece
        */
       dimensions?: {
+        /**
+         * @minimum 0
+         */
         width: number;
+        /**
+         * @minimum 0
+         */
         height: number;
       };
       /**
@@ -8002,7 +8545,13 @@ export type PreviewRender =
        * Dimensions for this rendered piece
        */
       dimensions?: {
+        /**
+         * @minimum 0
+         */
         width: number;
+        /**
+         * @minimum 0
+         */
         height: number;
       };
       /**
@@ -8052,7 +8601,13 @@ export type PreviewRender =
        * Dimensions for this rendered piece
        */
       dimensions?: {
+        /**
+         * @minimum 0
+         */
         width: number;
+        /**
+         * @minimum 0
+         */
         height: number;
       };
       /**
@@ -8089,6 +8644,7 @@ export interface BuildCreativeSuccess {
   sandbox?: boolean;
   /**
    * ISO 8601 timestamp when generated asset URLs in the manifest expire. Set to the earliest expiration across all generated assets. Re-build the creative after this time to get fresh URLs.
+   * @format date-time
    */
   expires_at?: string;
   /**
@@ -8133,6 +8689,7 @@ export interface BuildCreativeSuccess {
     interactive_url?: string;
     /**
      * ISO 8601 timestamp when preview URLs expire. May differ from the manifest's expires_at.
+     * @format date-time
      */
     expires_at: string;
   };
@@ -8143,10 +8700,12 @@ export interface BuildCreativeSuccess {
   pricing_option_id?: string;
   /**
    * Cost incurred for this build, denominated in currency. May be 0 for CPM-priced creatives where cost accrues at serve time rather than build time.
+   * @minimum 0
    */
   vendor_cost?: number;
   /**
    * ISO 4217 currency code for vendor_cost.
+   * @pattern ^[A-Z]{3}$
    */
   currency?: string;
   consumption?: CreativeConsumption;
@@ -8159,18 +8718,22 @@ export interface BuildCreativeSuccess {
 export interface CreativeConsumption {
   /**
    * LLM or generation tokens consumed during creative generation.
+   * @minimum 0
    */
   tokens?: number;
   /**
    * Number of images produced during generation.
+   * @minimum 0
    */
   images_generated?: number;
   /**
    * Number of render passes performed (video, animation).
+   * @minimum 0
    */
   renders?: number;
   /**
    * Processing time billed, in seconds. For compute-time pricing models.
+   * @minimum 0
    */
   duration_seconds?: number;
 }
@@ -8188,6 +8751,7 @@ export interface BuildCreativeMultiSuccess {
   sandbox?: boolean;
   /**
    * ISO 8601 timestamp when the earliest generated asset URL expires across all manifests. Re-build after this time to get fresh URLs.
+   * @format date-time
    */
   expires_at?: string;
   /**
@@ -8233,6 +8797,7 @@ export interface BuildCreativeMultiSuccess {
     interactive_url?: string;
     /**
      * ISO 8601 timestamp when preview URLs expire. May differ from the manifest's expires_at.
+     * @format date-time
      */
     expires_at: string;
   };
@@ -8243,10 +8808,12 @@ export interface BuildCreativeMultiSuccess {
   pricing_option_id?: string;
   /**
    * Total cost incurred for this multi-format build, denominated in currency. May be 0 for CPM-priced creatives where cost accrues at serve time.
+   * @minimum 0
    */
   vendor_cost?: number;
   /**
    * ISO 4217 currency code for vendor_cost.
+   * @pattern ^[A-Z]{3}$
    */
   currency?: string;
   consumption?: CreativeConsumption;
@@ -8272,6 +8839,8 @@ export interface BuildCreativeError {
 export interface PreviewCreativeRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -8307,6 +8876,7 @@ export interface PreviewCreativeRequest {
   output_format?: PreviewOutputFormat;
   /**
    * Maximum number of catalog items to render per preview variant. Used in single mode. Creative agents SHOULD default to a reasonable sample when omitted and the catalog is large.
+   * @minimum 1
    */
   item_limit?: number;
   /**
@@ -8342,6 +8912,7 @@ export interface PreviewCreativeRequest {
     output_format?: PreviewOutputFormat;
     /**
      * Maximum number of catalog items to render in this preview.
+     * @minimum 1
      */
     item_limit?: number;
   }[];
@@ -8411,6 +8982,7 @@ export interface PreviewCreativeSingleResponse {
   interactive_url?: string;
   /**
    * ISO 8601 timestamp when preview links expire
+   * @format date-time
    */
   expires_at: string;
   context?: ContextObject;
@@ -8475,6 +9047,7 @@ export interface PreviewCreativeVariantResponse {
   manifest?: CreativeManifest;
   /**
    * ISO 8601 timestamp when preview links expire
+   * @format date-time
    */
   expires_at?: string;
   context?: ContextObject;
@@ -8490,6 +9063,8 @@ export type GetCreativeDeliveryRequest = {
 } & {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   account?: AccountReference;
@@ -8503,14 +9078,17 @@ export type GetCreativeDeliveryRequest = {
   creative_ids?: string[];
   /**
    * Start date for delivery period (YYYY-MM-DD). Interpreted in the platform's reporting timezone.
+   * @pattern ^\d{4}-\d{2}-\d{2}$
    */
   start_date?: string;
   /**
    * End date for delivery period (YYYY-MM-DD). Interpreted in the platform's reporting timezone.
+   * @pattern ^\d{4}-\d{2}-\d{2}$
    */
   end_date?: string;
   /**
    * Maximum number of variants to return per creative. When omitted, the agent returns all variants. Use this to limit response size for generative creatives that may produce large numbers of variants.
+   * @minimum 1
    */
   max_variants?: number;
   pagination?: PaginationRequest;
@@ -8589,6 +9167,7 @@ export interface GetCreativeDeliveryResponse {
   media_buy_id?: string;
   /**
    * ISO 4217 currency code for monetary values in this response (e.g., 'USD', 'EUR')
+   * @pattern ^[A-Z]{3}$
    */
   currency: string;
   /**
@@ -8597,10 +9176,12 @@ export interface GetCreativeDeliveryResponse {
   reporting_period: {
     /**
      * ISO 8601 start timestamp
+     * @format date-time
      */
     start: string;
     /**
      * ISO 8601 end timestamp
+     * @format date-time
      */
     end: string;
     /**
@@ -8624,6 +9205,7 @@ export interface GetCreativeDeliveryResponse {
     totals?: DeliveryMetrics;
     /**
      * Total number of variants for this creative. When max_variants was specified in the request, this may exceed the number of items in the variants array.
+     * @minimum 0
      */
     variant_count?: number;
     /**
@@ -8637,10 +9219,12 @@ export interface GetCreativeDeliveryResponse {
   pagination?: {
     /**
      * Maximum number of creatives requested
+     * @minimum 1
      */
     limit: number;
     /**
      * Number of creatives skipped
+     * @minimum 0
      */
     offset: number;
     /**
@@ -8649,6 +9233,7 @@ export interface GetCreativeDeliveryResponse {
     has_more: boolean;
     /**
      * Total number of creatives matching the request filters
+     * @minimum 0
      */
     total?: number;
   };
@@ -8685,6 +9270,8 @@ export type SortDirection = 'asc' | 'desc';
 export interface ListCreativesRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   filters?: CreativeFilters;
@@ -8768,18 +9355,22 @@ export interface CreativeFilters {
   creative_ids?: string[];
   /**
    * Filter creatives created after this date (ISO 8601)
+   * @format date-time
    */
   created_after?: string;
   /**
    * Filter creatives created before this date (ISO 8601)
+   * @format date-time
    */
   created_before?: string;
   /**
    * Filter creatives last updated after this date (ISO 8601)
+   * @format date-time
    */
   updated_after?: string;
   /**
    * Filter creatives last updated before this date (ISO 8601)
+   * @format date-time
    */
   updated_before?: string;
   /**
@@ -8863,10 +9454,12 @@ export interface ListCreativesResponse {
   query_summary: {
     /**
      * Total number of creatives matching filters (across all pages)
+     * @minimum 0
      */
     total_matching: number;
     /**
      * Number of creatives returned in this response
+     * @minimum 0
      */
     returned: number;
     /**
@@ -8899,10 +9492,12 @@ export interface ListCreativesResponse {
     status: CreativeStatus;
     /**
      * When the creative was created
+     * @format date-time
      */
     created_date: string;
     /**
      * When the creative was last modified
+     * @format date-time
      */
     updated_date: string;
     /**
@@ -8933,6 +9528,7 @@ export interface ListCreativesResponse {
     assignments?: {
       /**
        * Total number of active package assignments
+       * @minimum 0
        */
       assignment_count: number;
       /**
@@ -8945,6 +9541,7 @@ export interface ListCreativesResponse {
         package_id: string;
         /**
          * When this assignment was created
+         * @format date-time
          */
         assigned_date: string;
       }[];
@@ -8955,18 +9552,22 @@ export interface ListCreativesResponse {
     snapshot?: {
       /**
        * When this snapshot was captured by the platform
+       * @format date-time
        */
       as_of: string;
       /**
        * Maximum age of this data in seconds. For example, 3600 means the data may be up to 1 hour old.
+       * @minimum 0
        */
       staleness_seconds: number;
       /**
        * Lifetime impressions across all assignments. Not scoped to any date range.
+       * @minimum 0
        */
       impressions: number;
       /**
        * Last time this creative served an impression. Absent when the creative has never served.
+       * @format date-time
        */
       last_served?: string;
     };
@@ -8986,6 +9587,7 @@ export interface ListCreativesResponse {
   format_summary?: {
     /**
      * Number of creatives with this format
+     * @minimum 0
      *
      * This interface was referenced by `undefined`'s JSON-Schema definition
      * via the `patternProperty` "^[a-zA-Z0-9_-]+$".
@@ -8998,22 +9600,27 @@ export interface ListCreativesResponse {
   status_summary?: {
     /**
      * Number of creatives being processed
+     * @minimum 0
      */
     processing?: number;
     /**
      * Number of approved creatives
+     * @minimum 0
      */
     approved?: number;
     /**
      * Number of creatives pending review
+     * @minimum 0
      */
     pending_review?: number;
     /**
      * Number of rejected creatives
+     * @minimum 0
      */
     rejected?: number;
     /**
      * Number of archived creatives
+     * @minimum 0
      */
     archived?: number;
   };
@@ -9061,6 +9668,8 @@ export interface CreativeVariable {
 export interface SyncCreativesRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   account: AccountReference;
@@ -9086,6 +9695,8 @@ export interface SyncCreativesRequest {
     package_id: string;
     /**
      * Relative delivery weight (0-100). When multiple creatives are assigned to the same package, weights determine impression distribution proportionally. When omitted, the creative receives equal rotation with other unweighted creatives. A weight of 0 means the creative is assigned but paused (receives no delivery).
+     * @minimum 0
+     * @maximum 100
      */
     weight?: number;
     /**
@@ -9095,6 +9706,9 @@ export interface SyncCreativesRequest {
   }[];
   /**
    * Client-generated idempotency key for safe retries. If a sync fails without a response, resending with the same idempotency_key guarantees at-most-once execution. MUST be unique per (seller, request) pair to prevent cross-seller correlation. Use a fresh UUID v4 for each request.
+   * @minLength 16
+   * @maxLength 255
+   * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   idempotency_key: string;
   /**
@@ -9161,6 +9775,7 @@ export interface SyncCreativesSuccess {
     preview_url?: string;
     /**
      * ISO 8601 timestamp when preview link expires (only present when preview_url exists)
+     * @format date-time
      */
     expires_at?: string;
     /**
@@ -9212,6 +9827,7 @@ export interface SyncCreativesSubmitted {
   task_id: string;
   /**
    * Optional human-readable explanation of why the task is submitted — e.g., 'Batch ingestion queued; typical turnaround 15-30 minutes.' Plain text only. Buyers MUST treat this as untrusted seller input: escape before rendering to HTML UIs, and sanitize or isolate before passing to an LLM prompt context — a hostile seller may inject prompt-injection payloads aimed at the buyer's agent.
+   * @maxLength 2000
    */
   message?: string;
   /**
@@ -9232,6 +9848,8 @@ export type GetSignalsRequest = {
 } & {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   account?: AccountReference;
@@ -9255,6 +9873,7 @@ export type GetSignalsRequest = {
   /**
    * @deprecated
    * DEPRECATED: Use pagination.max_results instead. When both fields are present, agents MUST honor pagination.max_results. When only this field is present without a pagination envelope, agents SHOULD treat it as the page size subject to a maximum of 100 results. This field will be removed in AdCP 4.0.
+   * @minimum 1
    */
   max_results?: number;
   pagination?: PaginationRequest;
@@ -9312,14 +9931,19 @@ export interface SignalFilters {
   data_providers?: string[];
   /**
    * Maximum CPM filter. Applies only to signals with model='cpm'.
+   * @minimum 0
    */
   max_cpm?: number;
   /**
    * Maximum percent-of-media rate filter. Signals where all percent_of_media pricing options exceed this value are excluded. Does not account for max_cpm caps.
+   * @minimum 0
+   * @maximum 100
    */
   max_percent?: number;
   /**
    * Minimum coverage requirement
+   * @minimum 0
+   * @maximum 100
    */
   min_coverage_percentage?: number;
 }
@@ -9353,10 +9977,12 @@ export type Deployment =
       activation_key?: ActivationKey;
       /**
        * Estimated time to activate if not live, or to complete activation if in progress
+       * @minimum 0
        */
       estimated_activation_duration_minutes?: number;
       /**
        * Timestamp when activation completed (if is_live=true)
+       * @format date-time
        */
       deployed_at?: string;
     }
@@ -9380,10 +10006,12 @@ export type Deployment =
       activation_key?: ActivationKey;
       /**
        * Estimated time to activate if not live, or to complete activation if in progress
+       * @minimum 0
        */
       estimated_activation_duration_minutes?: number;
       /**
        * Timestamp when activation completed (if is_live=true)
+       * @format date-time
        */
       deployed_at?: string;
     };
@@ -9461,6 +10089,8 @@ export interface GetSignalsResponse {
     data_provider: string;
     /**
      * Percentage of audience coverage
+     * @minimum 0
+     * @maximum 100
      */
     coverage_percentage: number;
     /**
@@ -9492,6 +10122,8 @@ export interface GetSignalsResponse {
 export interface ActivateSignalRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -9513,6 +10145,9 @@ export interface ActivateSignalRequest {
   account?: AccountReference;
   /**
    * Client-generated unique key for this request. Prevents duplicate activations on retries. MUST be unique per (seller, request) pair to prevent cross-seller correlation. Use a fresh UUID v4 for each request.
+   * @minLength 16
+   * @maxLength 255
+   * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   idempotency_key: string;
   context?: ContextObject;
@@ -9577,6 +10212,8 @@ export type PropertyType =
 export interface CreatePropertyListRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   account?: AccountReference;
@@ -9596,6 +10233,9 @@ export interface CreatePropertyListRequest {
   brand?: BrandReference;
   /**
    * Client-generated unique key for this request. Prevents duplicate property list creation on retries. MUST be unique per (seller, request) pair to prevent cross-seller correlation. Use a fresh UUID v4 for each request.
+   * @minLength 16
+   * @maxLength 255
+   * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   idempotency_key: string;
   context?: ContextObject;
@@ -9611,6 +10251,7 @@ export interface PublisherTagsSource {
   selection_type: 'publisher_tags';
   /**
    * Domain where publisher's adagents.json is hosted (e.g., 'raptive.com')
+   * @pattern ^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$
    */
   publisher_domain: string;
   /**
@@ -9628,6 +10269,7 @@ export interface PublisherPropertyIDsSource {
   selection_type: 'publisher_ids';
   /**
    * Domain where publisher's adagents.json is hosted (e.g., 'raptive.com')
+   * @pattern ^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$
    */
   publisher_domain: string;
   /**
@@ -9749,14 +10391,17 @@ export interface PropertyList {
   webhook_url?: string;
   /**
    * Recommended cache duration for resolved list. Consumers should re-fetch after this period.
+   * @minimum 1
    */
   cache_duration_hours?: number;
   /**
    * When the list was created
+   * @format date-time
    */
   created_at?: string;
   /**
    * When the list was last modified
+   * @format date-time
    */
   updated_at?: string;
   /**
@@ -9776,6 +10421,8 @@ export interface PropertyList {
 export interface UpdatePropertyListRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -9805,6 +10452,9 @@ export interface UpdatePropertyListRequest {
   ext?: ExtensionObject;
   /**
    * Client-generated unique key for at-most-once execution. If a request with the same key has already been processed, the server returns the original response without re-processing. MUST be unique per (seller, request) pair to prevent cross-seller correlation. Use a fresh UUID v4 for each request.
+   * @minLength 16
+   * @maxLength 255
+   * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   idempotency_key: string;
 }
@@ -9830,6 +10480,8 @@ export interface UpdatePropertyListResponse {
 export interface GetPropertyListRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -9847,6 +10499,8 @@ export interface GetPropertyListRequest {
   pagination?: {
     /**
      * Maximum number of identifiers to return per page
+     * @minimum 1
+     * @maximum 10000
      */
     max_results?: number;
     /**
@@ -9871,10 +10525,12 @@ export interface GetPropertyListResponse {
   pagination?: PaginationResponse;
   /**
    * When the list was resolved
+   * @format date-time
    */
   resolved_at?: string;
   /**
    * Cache expiration timestamp. Re-fetch the list after this time to get updated identifiers.
+   * @format date-time
    */
   cache_valid_until?: string;
   /**
@@ -9894,6 +10550,8 @@ export interface GetPropertyListResponse {
 export interface ListPropertyListsRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   account?: AccountReference;
@@ -9927,6 +10585,8 @@ export interface ListPropertyListsResponse {
 export interface DeletePropertyListRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -9938,6 +10598,9 @@ export interface DeletePropertyListRequest {
   ext?: ExtensionObject;
   /**
    * Client-generated unique key for at-most-once execution. If a request with the same key has already been processed, the server returns the original response without re-processing. MUST be unique per (seller, request) pair to prevent cross-seller correlation. Use a fresh UUID v4 for each request.
+   * @minLength 16
+   * @maxLength 255
+   * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   idempotency_key: string;
 }
@@ -10021,6 +10684,8 @@ export type ProductionQuality = 'professional' | 'prosumer' | 'ugc';
 export interface CreateCollectionListRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   account?: AccountReference;
@@ -10040,6 +10705,9 @@ export interface CreateCollectionListRequest {
   brand?: BrandReference;
   /**
    * Client-generated unique key for this request. Prevents duplicate collection list creation on retries. MUST be unique per (seller, request) pair to prevent cross-seller correlation. Use a fresh UUID v4 for each request.
+   * @minLength 16
+   * @maxLength 255
+   * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   idempotency_key: string;
   context?: ContextObject;
@@ -10074,6 +10742,7 @@ export interface PublisherCollectionsSource {
   selection_type: 'publisher_collections';
   /**
    * Domain where publisher's adagents.json is hosted
+   * @pattern ^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$
    */
   publisher_domain: string;
   /**
@@ -10091,6 +10760,7 @@ export interface PublisherGenresSource {
   selection_type: 'publisher_genres';
   /**
    * Domain where publisher's adagents.json is hosted
+   * @pattern ^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$
    */
   publisher_domain: string;
   /**
@@ -10186,14 +10856,17 @@ export interface CollectionList {
   webhook_url?: string;
   /**
    * Recommended cache duration for resolved list. Consumers should re-fetch after this period. Defaults to 168 (one week) because collection metadata changes less frequently than property metadata.
+   * @minimum 1
    */
   cache_duration_hours?: number;
   /**
    * When the list was created
+   * @format date-time
    */
   created_at?: string;
   /**
    * When the list was last modified
+   * @format date-time
    */
   updated_at?: string;
   /**
@@ -10209,6 +10882,8 @@ export interface CollectionList {
 export interface UpdateCollectionListRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -10238,6 +10913,9 @@ export interface UpdateCollectionListRequest {
   ext?: ExtensionObject;
   /**
    * Client-generated unique key for at-most-once execution. If a request with the same key has already been processed, the server returns the original response without re-processing. MUST be unique per (seller, request) pair to prevent cross-seller correlation. Use a fresh UUID v4 for each request.
+   * @minLength 16
+   * @maxLength 255
+   * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   idempotency_key: string;
 }
@@ -10263,6 +10941,8 @@ export interface UpdateCollectionListResponse {
 export interface GetCollectionListRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -10280,6 +10960,8 @@ export interface GetCollectionListRequest {
   pagination?: {
     /**
      * Maximum number of collections to return per page
+     * @minimum 1
+     * @maximum 10000
      */
     max_results?: number;
     /**
@@ -10330,10 +11012,12 @@ export interface GetCollectionListResponse {
   pagination?: PaginationResponse;
   /**
    * When the list was resolved
+   * @format date-time
    */
   resolved_at?: string;
   /**
    * Cache expiration timestamp. Re-fetch the list after this time to get updated collections.
+   * @format date-time
    */
   cache_valid_until?: string;
   /**
@@ -10359,6 +11043,8 @@ export interface GetCollectionListResponse {
 export interface ListCollectionListsRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   account?: AccountReference;
@@ -10392,6 +11078,8 @@ export interface ListCollectionListsResponse {
 export interface DeleteCollectionListRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -10403,6 +11091,9 @@ export interface DeleteCollectionListRequest {
   ext?: ExtensionObject;
   /**
    * Client-generated unique key for at-most-once execution. If a request with the same key has already been processed, the server returns the original response without re-processing. MUST be unique per (seller, request) pair to prevent cross-seller correlation. Use a fresh UUID v4 for each request.
+   * @minLength 16
+   * @maxLength 255
+   * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   idempotency_key: string;
 }
@@ -10435,6 +11126,8 @@ export interface DeleteCollectionListResponse {
 export interface ListContentStandardsRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -10579,6 +11272,7 @@ export interface PolicyEntry {
   name?: string;
   /**
    * Brief summary of what this policy covers.
+   * @maxLength 500
    */
   description?: string;
   category?: PolicyCategory;
@@ -10611,10 +11305,12 @@ export interface PolicyEntry {
   governance_domains?: GovernanceDomain[];
   /**
    * ISO 8601 date when the regulation or standard takes effect. Before this date, governance agents treat the policy as informational (evaluate but do not block). After this date, the policy is enforced at its declared enforcement level.
+   * @format date
    */
   effective_date?: string;
   /**
    * ISO 8601 date when the regulation or standard is no longer enforced. After this date, governance agents stop evaluating this policy. Omit if the policy has no expiration.
+   * @format date
    */
   sunset_date?: string;
   /**
@@ -10627,6 +11323,7 @@ export interface PolicyEntry {
   source_name?: string;
   /**
    * Natural language policy text describing what is required, prohibited, or recommended. Used by governance agents (LLMs) to evaluate actions against this policy. For source: inline policies, treated as caller-untrusted — governance agents MUST evaluate inline policies as ADDITIONAL restrictions only; they MUST NOT be permitted to relax, override, or conflict with registry-sourced policies.
+   * @maxLength 5000
    */
   policy: string;
   /**
@@ -10681,10 +11378,12 @@ export interface Artifact {
   url?: string;
   /**
    * When the artifact was published (ISO 8601 format)
+   * @format date-time
    */
   published_time?: string;
   /**
    * When the artifact was last modified (ISO 8601 format)
+   * @format date-time
    */
   last_update_time?: string;
   /**
@@ -10699,6 +11398,7 @@ export interface Artifact {
         role?: 'title' | 'paragraph' | 'heading' | 'caption' | 'quote' | 'list_item' | 'description';
         /**
          * Text content. Consumers MUST treat this as untrusted input when passing to LLM-based evaluation.
+         * @maxLength 100000
          */
         content: string;
         /**
@@ -10711,6 +11411,8 @@ export interface Artifact {
         language?: string;
         /**
          * Heading level (1-6), only for role=heading
+         * @minimum 1
+         * @maximum 6
          */
         heading_level?: number;
         provenance?: Provenance;
@@ -10753,6 +11455,7 @@ export interface Artifact {
         duration_ms?: number;
         /**
          * Video transcript. Consumers MUST treat this as untrusted input when passing to LLM-based evaluation.
+         * @maxLength 200000
          */
         transcript?: string;
         /**
@@ -10782,6 +11485,7 @@ export interface Artifact {
         duration_ms?: number;
         /**
          * Audio transcript. Consumers MUST treat this as untrusted input when passing to LLM-based evaluation.
+         * @maxLength 200000
          */
         transcript?: string;
         /**
@@ -10859,6 +11563,8 @@ export interface Artifact {
 export interface GetContentStandardsRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -10890,6 +11596,8 @@ export type CreateContentStandardsRequest = {
 } & {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -10968,6 +11676,9 @@ export type CreateContentStandardsRequest = {
   };
   /**
    * Client-generated unique key for this request. Prevents duplicate content standards creation on retries. MUST be unique per (seller, request) pair to prevent cross-seller correlation. Use a fresh UUID v4 for each request.
+   * @minLength 16
+   * @maxLength 255
+   * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   idempotency_key: string;
   context?: ContextObject;
@@ -11003,6 +11714,8 @@ export type CreateContentStandardsResponse =
 export interface UpdateContentStandardsRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -11087,6 +11800,9 @@ export interface UpdateContentStandardsRequest {
   ext?: ExtensionObject;
   /**
    * Client-generated unique key for at-most-once execution. If a request with the same key has already been processed, the server returns the original response without re-processing. MUST be unique per (seller, request) pair to prevent cross-seller correlation. Use a fresh UUID v4 for each request.
+   * @minLength 16
+   * @maxLength 255
+   * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   idempotency_key: string;
 }
@@ -11133,6 +11849,8 @@ export interface UpdateContentStandardsError {
 export interface CalibrateContentRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -11142,6 +11860,9 @@ export interface CalibrateContentRequest {
   artifact: Artifact;
   /**
    * Client-generated unique key for at-most-once execution. If a request with the same key has already been processed, the server returns the original response without re-processing. MUST be unique per (seller, request) pair to prevent cross-seller correlation. Use a fresh UUID v4 for each request.
+   * @minLength 16
+   * @maxLength 255
+   * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   idempotency_key: string;
   context?: ContextObject;
@@ -11157,6 +11878,8 @@ export type CalibrateContentResponse =
       verdict: BinaryVerdict;
       /**
        * Model confidence in the verdict (0-1)
+       * @minimum 0
+       * @maximum 1
        */
       confidence?: number;
       /**
@@ -11182,6 +11905,8 @@ export type CalibrateContentResponse =
         explanation?: string;
         /**
          * Optional evaluator confidence in this result (0-1). Distinguishes certain verdicts from ambiguous ones.
+         * @minimum 0
+         * @maximum 1
          */
         confidence?: number;
       }[];
@@ -11210,6 +11935,8 @@ export type FeatureCheckStatus = 'passed' | 'failed' | 'warning' | 'unevaluated'
 export interface ValidateContentDeliveryRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -11230,6 +11957,7 @@ export interface ValidateContentDeliveryRequest {
     media_buy_id?: string;
     /**
      * When the delivery occurred
+     * @format date-time
      */
     timestamp?: string;
     artifact: Artifact;
@@ -11309,6 +12037,8 @@ export type ValidateContentDeliveryResponse =
           explanation?: string;
           /**
            * Optional evaluator confidence in this result (0-1). Distinguishes certain verdicts from ambiguous ones.
+           * @minimum 0
+           * @maximum 1
            */
           confidence?: number;
         }[];
@@ -11329,6 +12059,8 @@ export type ValidateContentDeliveryResponse =
 export interface GetMediaBuyArtifactsRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   account?: AccountReference;
@@ -11350,10 +12082,12 @@ export interface GetMediaBuyArtifactsRequest {
   time_range?: {
     /**
      * Start of time range (inclusive)
+     * @format date-time
      */
     start?: string;
     /**
      * End of time range (exclusive)
+     * @format date-time
      */
     end?: string;
   };
@@ -11363,6 +12097,8 @@ export interface GetMediaBuyArtifactsRequest {
   pagination?: {
     /**
      * Maximum number of artifacts to return per page
+     * @minimum 1
+     * @maximum 10000
      */
     max_results?: number;
     /**
@@ -11394,6 +12130,7 @@ export type GetMediaBuyArtifactsResponse =
         record_id: string;
         /**
          * When the delivery occurred
+         * @format date-time
          */
         timestamp?: string;
         /**
@@ -11465,6 +12202,8 @@ export type GetMediaBuyArtifactsResponse =
 export interface GetCreativeFeaturesRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   creative_manifest: CreativeManifest;
@@ -11497,10 +12236,12 @@ export type GetCreativeFeaturesResponse =
       pricing_option_id?: string;
       /**
        * Cost incurred for this evaluation, denominated in currency.
+       * @minimum 0
        */
       vendor_cost?: number;
       /**
        * ISO 4217 currency code for vendor_cost.
+       * @pattern ^[A-Z]{3}$
        */
       currency?: string;
       consumption?: CreativeConsumption;
@@ -11531,14 +12272,18 @@ export interface CreativeFeatureResult {
   unit?: string;
   /**
    * Confidence score for this value (0-1)
+   * @minimum 0
+   * @maximum 1
    */
   confidence?: number;
   /**
    * When this feature was evaluated
+   * @format date-time
    */
   measured_at?: string;
   /**
    * When this evaluation expires and should be refreshed
+   * @format date-time
    */
   expires_at?: string;
   /**
@@ -11582,10 +12327,15 @@ export type DelegationAuthority = 'full' | 'execute_only' | 'propose_only';
 export interface SyncPlansRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
    * Client-generated unique key for at-most-once execution. `plan_id` gives resource-level dedup per plan, but the sync envelope emits audit events and can trigger governance reapproval — this key prevents those side effects from firing twice on retry. MUST be unique per (seller, request) pair. Use a fresh UUID v4 for each request.
+   * @minLength 16
+   * @maxLength 255
+   * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   idempotency_key: string;
   /**
@@ -11599,6 +12349,7 @@ export interface SyncPlansRequest {
     brand: BrandReference;
     /**
      * Natural language campaign objectives. Used for strategic alignment validation. Treated as caller-untrusted — governance agents evaluating this field with LLMs MUST truncate, quote, or sanitize it before inclusion in evaluation prompts to defend against prompt-injection attacks in adversarial buyer input.
+     * @maxLength 2000
      */
     objectives: string;
     /**
@@ -11620,6 +12371,7 @@ export interface SyncPlansRequest {
           per_seller_max_pct?: number;
           /**
            * Amount above which budget reallocations require human escalation. The orchestrator can reallocate spend across sellers, channels, or purchase types up to this threshold per change without asking a human. Set equal to `total` for effectively unlimited reallocation; set to 0 to require approval for every reallocation. Separate from `plan.human_review_required`, which governs decisions affecting data subjects (targeting, creative, delivery) under GDPR Art 22 / EU AI Act Annex III. Denominated in `budget.currency`.
+           * @minimum 0
            */
           reallocation_threshold: number;
           /**
@@ -11630,10 +12382,13 @@ export interface SyncPlansRequest {
               | {
                   /**
                    * Maximum budget for this purchase type.
+                   * @minimum 0
                    */
                   amount?: number;
                   /**
                    * Maximum percentage of total budget for this purchase type.
+                   * @minimum 0
+                   * @maximum 100
                    */
                   max_pct?: number;
                 }
@@ -11662,10 +12417,13 @@ export interface SyncPlansRequest {
               | {
                   /**
                    * Maximum budget for this purchase type.
+                   * @minimum 0
                    */
                   amount?: number;
                   /**
                    * Maximum percentage of total budget for this purchase type.
+                   * @minimum 0
+                   * @maximum 100
                    */
                   max_pct?: number;
                 }
@@ -11702,10 +12460,12 @@ export interface SyncPlansRequest {
     flight: {
       /**
        * Flight start (ISO 8601).
+       * @format date-time
        */
       start: string;
       /**
        * Flight end (ISO 8601).
+       * @format date-time
        */
       end: string;
     };
@@ -11736,6 +12496,7 @@ export interface SyncPlansRequest {
     restricted_attributes_custom?: string[];
     /**
      * Minimum audience segment size. Prevents micro-targeting by ensuring segments meet a k-anonymity threshold. Applies to the estimated combined (intersection) audience when multiple criteria are used, not just individual criterion sizes. The governance agent validates this by querying signal catalog metadata or seller-reported segment sizes. When segment size data is unavailable, the governance agent SHOULD produce a finding with reduced confidence rather than silently passing.
+     * @minimum 1
      */
     min_audience_size?: number;
     /**
@@ -11772,6 +12533,7 @@ export interface SyncPlansRequest {
       markets?: string[];
       /**
        * When this delegation expires. After expiration, the governance agent denies actions from this agent.
+       * @format date-time
        */
       expires_at?: string;
     }[];
@@ -11894,6 +12656,8 @@ export type OutcomeType = 'completed' | 'failed' | 'delivery';
 export interface ReportPlanOutcomeRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -11906,6 +12670,9 @@ export interface ReportPlanOutcomeRequest {
   check_id?: string;
   /**
    * Client-generated unique key for this request. Prevents duplicate outcome reports on retries. MUST be unique per (seller, request) pair to prevent cross-seller correlation. Use a fresh UUID v4 for each request.
+   * @minLength 16
+   * @maxLength 255
+   * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   idempotency_key: string;
   purchase_type?: PurchaseType;
@@ -11916,21 +12683,27 @@ export interface ReportPlanOutcomeRequest {
   seller_response?: {
     /**
      * The seller's identifier for the created resource (e.g., media_buy_id, rights_grant_id, deployment_id). Not interpreted by the governance agent — included in audit logs for human-readable traceability alongside the opaque governance_context.
+     * @maxLength 255
      */
     seller_reference?: string;
     /**
      * Total budget committed across all confirmed packages. When present, the governance agent uses this directly instead of summing package budgets.
+     * @minimum 0
      */
     committed_budget?: number;
     /**
      * Confirmed packages with actual budget and targeting.
      */
     packages?: {
+      /**
+       * @minimum 0
+       */
       budget?: number;
     }[];
     planned_delivery?: PlannedDelivery;
     /**
      * ISO 8601 deadline for creative submission.
+     * @format date-time
      */
     creative_deadline?: string;
   };
@@ -11942,11 +12715,18 @@ export interface ReportPlanOutcomeRequest {
      * Start and end timestamps for the reporting window.
      */
     reporting_period?: {
+      /**
+       * @format date-time
+       */
       start: string;
+      /**
+       * @format date-time
+       */
       end: string;
     };
     /**
      * Impressions delivered in the period.
+     * @minimum 0
      */
     impressions?: number;
     /**
@@ -11981,6 +12761,9 @@ export interface ReportPlanOutcomeRequest {
   };
   /**
    * Opaque governance context from the check_governance response that authorized this action. Enables the governance agent to correlate the outcome to the original check.
+   * @minLength 1
+   * @maxLength 4096
+   * @pattern ^[\x20-\x7E]+$
    */
   governance_context: string;
   context?: ContextObject;
@@ -12057,6 +12840,8 @@ export type GetPlanAuditLogsRequest = {
 } & {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -12196,6 +12981,7 @@ export interface GetPlanAuditLogsResponse {
         resolution?: string;
         /**
          * ISO 8601 resolution timestamp.
+         * @format date-time
          */
         resolved_at?: string;
       }[];
@@ -12205,6 +12991,8 @@ export interface GetPlanAuditLogsResponse {
       drift_metrics?: {
         /**
          * Fraction of checks that resulted in escalation.
+         * @minimum 0
+         * @maximum 1
          */
         escalation_rate?: number;
         /**
@@ -12213,14 +13001,20 @@ export interface GetPlanAuditLogsResponse {
         escalation_rate_trend?: 'increasing' | 'stable' | 'declining';
         /**
          * Fraction of checks approved without human intervention.
+         * @minimum 0
+         * @maximum 1
          */
         auto_approval_rate?: number;
         /**
          * Fraction of escalations where the human overrode the governance agent's recommendation.
+         * @minimum 0
+         * @maximum 1
          */
         human_override_rate?: number;
         /**
          * Average confidence score across all findings. Present when findings include confidence scores.
+         * @minimum 0
+         * @maximum 1
          */
         mean_confidence?: number;
         /**
@@ -12229,18 +13023,26 @@ export interface GetPlanAuditLogsResponse {
         thresholds?: {
           /**
            * Maximum acceptable escalation rate. A rate above this suggests policy miscalibration.
+           * @minimum 0
+           * @maximum 1
            */
           escalation_rate_max?: number;
           /**
            * Minimum acceptable escalation rate. A rate below this may indicate eroding oversight.
+           * @minimum 0
+           * @maximum 1
            */
           escalation_rate_min?: number;
           /**
            * Maximum acceptable auto-approval rate.
+           * @minimum 0
+           * @maximum 1
            */
           auto_approval_rate_max?: number;
           /**
            * Maximum acceptable human override rate. A high rate suggests the governance agent's recommendations are poorly calibrated.
+           * @minimum 0
+           * @maximum 1
            */
           human_override_rate_max?: number;
         };
@@ -12260,6 +13062,7 @@ export interface GetPlanAuditLogsResponse {
       type: 'check' | 'outcome';
       /**
        * ISO 8601 timestamp.
+       * @format date-time
        */
       timestamp: string;
       /**
@@ -12300,6 +13103,10 @@ export interface GetPlanAuditLogsResponse {
         policy_id?: string;
         severity: EscalationSeverity;
         explanation: string;
+        /**
+         * @minimum 0
+         * @maximum 1
+         */
         confidence?: number;
       }[];
       outcome?: OutcomeType;
@@ -12313,6 +13120,7 @@ export interface GetPlanAuditLogsResponse {
       governance_context?: string;
       /**
        * Audit-layer binding to the plan revision this attestation was evaluated over — base64url_no_pad(SHA-256(JCS(plan_payload))) per Plan binding and audit in the campaign-governance specification. Present on check entries. Auditors and buyer-side compliance verify by recomputing over the retained plan revision and byte-comparing the decoded 32-byte digests.
+       * @pattern ^[A-Za-z0-9_-]{43}$
        */
       plan_hash?: string;
       purchase_type?: PurchaseType;
@@ -12363,6 +13171,8 @@ export type GovernancePhase = 'purchase' | 'modification' | 'delivery';
 export interface CheckGovernanceRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -12384,6 +13194,9 @@ export interface CheckGovernanceRequest {
   payload?: {};
   /**
    * Governance context token from a prior check_governance response. Pass this on subsequent checks for the same governed action so the governance agent can maintain continuity across the lifecycle. In 3.0 governance agents MUST emit a compact JWS per the AdCP JWS profile (see Security — Signed Governance Context); callers persist and forward the value verbatim.
+   * @minLength 1
+   * @maxLength 4096
+   * @pattern ^[\x20-\x7E]+$
    */
   governance_context?: string;
   phase?: GovernancePhase;
@@ -12396,35 +13209,53 @@ export interface CheckGovernanceRequest {
      * Start and end timestamps for the reporting window.
      */
     reporting_period: {
+      /**
+       * @format date-time
+       */
       start: string;
+      /**
+       * @format date-time
+       */
       end: string;
     };
     /**
      * Total spend during the reporting period.
+     * @minimum 0
      */
     spend?: number;
     /**
      * Total spend since the governed action started.
+     * @minimum 0
      */
     cumulative_spend?: number;
     /**
      * Impressions delivered during the reporting period.
+     * @minimum 0
      */
     impressions?: number;
     /**
      * Total impressions since the governed action started.
+     * @minimum 0
      */
     cumulative_impressions?: number;
     /**
      * Actual geographic distribution. Keys are ISO 3166-1 alpha-2 codes, values are percentages.
      */
     geo_distribution?: {
+      /**
+       * @minimum 0
+       * @maximum 100
+       */
       [k: string]: number | undefined;
     };
     /**
      * Actual channel distribution. Keys are channel enum values, values are percentages.
      */
     channel_distribution?: {
+      /**
+       * @minimum 0
+       * @maximum 100
+       */
       [k: string]: number | undefined;
     };
     /**
@@ -12447,18 +13278,25 @@ export interface CheckGovernanceRequest {
        * Audience index values for the current reporting period. Keys are seller-defined dimension:value strings (e.g., 'age:25-34', 'gender:female', 'income:high'). The protocol does not mandate a taxonomy — dimensions and value labels vary by seller. Values are index relative to the declared baseline (1.0 = at parity, >1.0 = over-indexed, <1.0 = under-indexed).
        */
       indices: {
+        /**
+         * @minimum 0
+         */
         [k: string]: number | undefined;
       };
       /**
        * Cumulative audience index values since the governed action started. Same key format as indices (dimension:value). Use for detecting sustained bias drift that may not appear in a single reporting period.
        */
       cumulative_indices?: {
+        /**
+         * @minimum 0
+         */
         [k: string]: number | undefined;
       };
     };
   };
   /**
    * Human-readable summary of what changed. SHOULD be present for 'modification' phase.
+   * @maxLength 1000
    */
   modification_summary?: string;
   invoice_recipient?: BusinessEntity;
@@ -12511,6 +13349,8 @@ export interface CheckGovernanceResponse {
     details?: {};
     /**
      * Confidence score (0-1) in this finding. Distinguishes 'this definitely violates the policy' (0.95) from 'this might violate depending on how audience segments resolve' (0.6). When absent, the finding is presented without a confidence qualifier.
+     * @minimum 0
+     * @maximum 1
      */
     confidence?: number;
     /**
@@ -12537,10 +13377,12 @@ export interface CheckGovernanceResponse {
   }[];
   /**
    * When this approval expires. Present when status is 'approved' or 'conditions'. The caller must act before this time or re-call check_governance. A lapsed approval is no approval.
+   * @format date-time
    */
   expires_at?: string;
   /**
    * When the seller should next call check_governance with delivery metrics. Present when the governance agent expects ongoing delivery reporting.
+   * @format date-time
    */
   next_check?: string;
   /**
@@ -12558,6 +13400,9 @@ export interface CheckGovernanceResponse {
    * Value format: in 3.0 governance agents MUST emit a compact JWS per the AdCP JWS profile (see Security — Signed Governance Context). Sellers MAY verify; sellers that do not verify MUST persist and forward the token unchanged so auditors can verify downstream. In 3.1 all sellers MUST verify per the checklist. Non-JWS values from pre-3.0 governance agents are deprecated and will be rejected in 3.1.
    *
    * Sellers that implement verification MUST verify signature, `aud`, `exp`, `jti` replay, and revocation per the profile before treating the request as governance-approved. This is the primary correlation key for audit and reporting across the governance lifecycle — the governance agent decodes its own signed token to look up internal plan state (buyer correlation IDs, policy decision log, etc.).
+   * @minLength 1
+   * @maxLength 4096
+   * @pattern ^[\x20-\x7E]+$
    */
   governance_context?: string;
   context?: ContextObject;
@@ -12571,6 +13416,8 @@ export interface CheckGovernanceResponse {
 export interface SIGetOfferingRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -12588,6 +13435,8 @@ export interface SIGetOfferingRequest {
   include_products?: boolean;
   /**
    * Maximum number of matching products to return
+   * @minimum 1
+   * @maximum 50
    */
   product_limit?: number;
   ext?: ExtensionObject;
@@ -12608,10 +13457,12 @@ export interface SIGetOfferingResponse {
   offering_token?: string;
   /**
    * How long this offering information is valid (seconds). Host should re-fetch after TTL expires.
+   * @minimum 0
    */
   ttl_seconds?: number;
   /**
    * When this offering information was retrieved
+   * @format date-time
    */
   checked_at?: string;
   /**
@@ -12636,6 +13487,7 @@ export interface SIGetOfferingResponse {
     tagline?: string;
     /**
      * When this offering expires
+     * @format date-time
      */
     expires_at?: string;
     /**
@@ -12686,6 +13538,7 @@ export interface SIGetOfferingResponse {
   }[];
   /**
    * Total number of products matching the context (may be more than returned in matching_products)
+   * @minimum 0
    */
   total_matching?: number;
   /**
@@ -12711,6 +13564,8 @@ export interface SIGetOfferingResponse {
 export interface SIInitiateSessionRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -12738,6 +13593,9 @@ export interface SIInitiateSessionRequest {
   offering_token?: string;
   /**
    * Client-generated unique key for this request. Prevents duplicate session creation on retries. MUST be unique per (seller, request) pair to prevent cross-seller correlation. Use a fresh UUID v4 for each request.
+   * @minLength 16
+   * @maxLength 255
+   * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   idempotency_key: string;
   ext?: ExtensionObject;
@@ -12752,6 +13610,7 @@ export interface SIIdentity {
   consent_granted: boolean;
   /**
    * When consent was granted (ISO 8601)
+   * @format date-time
    */
   consent_timestamp?: string;
   /**
@@ -12777,6 +13636,7 @@ export interface SIIdentity {
   user?: {
     /**
      * User's email address
+     * @format email
      */
     email?: string;
     /**
@@ -12937,6 +13797,7 @@ export interface SIInitiateSessionResponse {
   session_status: SISessionStatus;
   /**
    * Session inactivity timeout in seconds. After this duration without a message, the brand agent may terminate the session. Hosts SHOULD warn users before timeout when possible.
+   * @minimum 1
    */
   session_ttl_seconds?: number;
   /**
@@ -12977,10 +13838,15 @@ export type SISendMessageRequest = {
 } & {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
    * Client-generated unique key for at-most-once execution. Each conversational turn is a distinct mutation of session transcript — without this key, a timeout-and-retry produces a duplicate turn and a duplicate model response. MUST be unique per (seller, request) pair. Use a fresh UUID v4 for each user turn.
+   * @minLength 16
+   * @maxLength 255
+   * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   idempotency_key: string;
   /**
@@ -13139,6 +14005,8 @@ export interface A2UIComponent {
 export interface SITerminateSessionRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -13208,6 +14076,7 @@ export interface SITerminateSessionResponse {
     payload?: {};
     /**
      * When this handoff data expires. Hosts should initiate checkout before this time.
+     * @format date-time
      */
     expires_at?: string;
   };
@@ -13233,6 +14102,8 @@ export interface SITerminateSessionResponse {
 export interface GetAdCPCapabilitiesRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. When provided, the seller validates this against its supported major_versions and returns VERSION_UNSUPPORTED if the version is not in range. When omitted, the seller assumes the highest major version it supports.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -13501,13 +14372,20 @@ export interface GetAdCPCapabilitiesResponse {
       supported_uid_types?: UIDType[];
       /**
        * Minimum matched audience size required for targeting. Audiences below this threshold will have status: too_small. Varies by platform (100–1000 is typical).
+       * @minimum 1
        */
       minimum_audience_size: number;
       /**
        * Expected matching latency range in hours after upload. Use to calibrate polling cadence and set appropriate expectations before configuring push_notification_config.
        */
       matching_latency_hours?: {
+        /**
+         * @minimum 0
+         */
         min?: number;
+        /**
+         * @minimum 0
+         */
         max?: number;
       };
     };
@@ -13585,10 +14463,12 @@ export interface GetAdCPCapabilitiesResponse {
       primary_countries?: string[];
       /**
        * Markdown-formatted description of the inventory portfolio
+       * @maxLength 5000
        */
       description?: string;
       /**
        * Advertising content policies, restrictions, and guidelines
+       * @maxLength 10000
        */
       advertising_policies?: string;
     };
@@ -13618,6 +14498,8 @@ export interface GetAdCPCapabilitiesResponse {
   governance?: {
     /**
      * Trailing window (in days) over which this governance agent aggregates committed spend when evaluating dollar-valued thresholds (reallocation_threshold, human_review triggers, registry-policy floors). Required for fragmentation defense: without aggregation, a buyer can split a single large spend into many sub-threshold commits across plans / task surfaces / time and bypass every dollar-gated escalation. Aggregation is keyed on (buyer_agent, seller_agent, account_id) and spans all spend-commit task types. Upper bound 365 represents a one-year trailing window (fiscal-year alignment with grace); governance agents needing longer scopes negotiate via operator sign-off, not this capability. No schema default: absence of this field indicates the governance agent has not committed to any aggregation window and buyers MUST assume per-commit evaluation only (the fragmentation attack surface is open). A declared value of 30 is a common starting point but is not implied by omission. Buyers depending on a specific window for compliance MUST check this capability before relying on aggregation semantics — an agent declaring 7 days does not defend against fragmentation spread across a 30-day quarter-end push.
+     * @minimum 1
+     * @maximum 365
      */
     aggregation_window_days?: number;
     /**
@@ -13751,6 +14633,7 @@ export interface GetAdCPCapabilitiesResponse {
     generation_providers?: string[];
     /**
      * Description of the agent's brand protocol capabilities
+     * @maxLength 5000
      */
     description?: string;
   };
@@ -13894,6 +14777,7 @@ export interface GetAdCPCapabilitiesResponse {
   experimental_features?: string[];
   /**
    * ISO 8601 timestamp of when capabilities were last updated. Buyers can use this for cache invalidation.
+   * @format date-time
    */
   last_updated?: string;
   /**
@@ -13913,6 +14797,8 @@ export interface IdempotencySupported {
   supported: true;
   /**
    * How long the seller retains a canonical response for an idempotency_key. Within this window, a replay with the same key + equivalent canonical payload returns the cached response; a replay with a different canonical payload returns IDEMPOTENCY_CONFLICT; a replay past the window returns IDEMPOTENCY_EXPIRED when the seller can still distinguish 'seen and evicted' from 'never seen'. Minimum 3600 (1h); recommended 86400 (24h). Maximum 604800 (7 days) — longer windows force buyers to retain secret keys at rest for extended periods and grow the seller's cache table without bounded benefit.
+   * @minimum 3600
+   * @maximum 604800
    */
   replay_ttl_seconds: number;
   /**
@@ -13937,6 +14823,8 @@ export interface IdempotencyUnsupported {
 export interface ListAccountsRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -13977,10 +14865,15 @@ export interface ListAccountsResponse {
 export interface SyncAccountsRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
    * Client-generated unique key for at-most-once execution. Natural per-account upsert keys (brand, operator) handle resource-level dedup, but the envelope triggers onboarding webhooks, billing setup, and audit events — this key prevents those side effects from firing twice on retry. MUST be unique per (seller, request) pair. Use a fresh UUID v4 for each request.
+   * @minLength 16
+   * @maxLength 255
+   * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   idempotency_key: string;
   /**
@@ -13990,6 +14883,7 @@ export interface SyncAccountsRequest {
     brand: BrandReference;
     /**
      * Domain of the entity operating on the brand's behalf (e.g., 'pinnacle-media.com'). When the brand operates directly, this is the brand's domain. Verified against the brand's authorized_operators in brand.json.
+     * @pattern ^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$
      */
     operator: string;
     billing: BillingParty;
@@ -14069,6 +14963,7 @@ export interface SyncAccountsSuccess {
       message: string;
       /**
        * When this setup link expires
+       * @format date-time
        */
       expires_at?: string;
     };
@@ -14078,7 +14973,13 @@ export interface SyncAccountsSuccess {
     rate_card?: string;
     payment_terms?: PaymentTerms;
     credit_limit?: {
+      /**
+       * @minimum 0
+       */
       amount: number;
+      /**
+       * @pattern ^[A-Z]{3}$
+       */
       currency: string;
     };
     /**
@@ -14117,10 +15018,15 @@ export interface SyncAccountsError {
 export interface SyncGovernanceRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
    * Client-generated unique key for at-most-once execution. `account` gives resource-level dedup, but governance changes emit audit events and can trigger reapproval flows — this key prevents those side effects from firing twice on retry. MUST be unique per (seller, request) pair. Use a fresh UUID v4 for each request.
+   * @minLength 16
+   * @maxLength 255
+   * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   idempotency_key: string;
   /**
@@ -14134,6 +15040,7 @@ export interface SyncGovernanceRequest {
     governance_agents: {
       /**
        * Governance agent endpoint URL. Must use HTTPS.
+       * @pattern ^https:\/\/
        */
       url: string;
       /**
@@ -14143,6 +15050,7 @@ export interface SyncGovernanceRequest {
         schemes: AuthenticationScheme[];
         /**
          * Authentication credential (e.g., Bearer token).
+         * @minLength 32
          */
         credentials: string;
       };
@@ -14180,6 +15088,7 @@ export interface SyncGovernanceSuccess {
     governance_agents?: {
       /**
        * Governance agent endpoint URL.
+       * @pattern ^https:\/\/
        */
       url: string;
       /**
@@ -14215,6 +15124,8 @@ export interface SyncGovernanceError {
 export interface ReportUsageRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   /**
@@ -14233,10 +15144,12 @@ export interface ReportUsageRequest {
     media_buy_id?: string;
     /**
      * Amount owed to the vendor for this record, denominated in currency.
+     * @minimum 0
      */
     vendor_cost: number;
     /**
      * ISO 4217 currency code.
+     * @pattern ^[A-Z]{3}$
      */
     currency: string;
     /**
@@ -14245,10 +15158,12 @@ export interface ReportUsageRequest {
     pricing_option_id?: string;
     /**
      * Impressions delivered using this vendor service.
+     * @minimum 0
      */
     impressions?: number;
     /**
      * Media spend in currency for the period. Required when a percent_of_media pricing model was used, so the vendor can verify the applied rate.
+     * @minimum 0
      */
     media_spend?: number;
     /**
@@ -14283,6 +15198,7 @@ export interface ReportUsageRequest {
 export interface ReportUsageResponse {
   /**
    * Number of usage records successfully stored.
+   * @minimum 0
    */
   accepted: number;
   /**
@@ -14304,6 +15220,8 @@ export interface ReportUsageResponse {
 export interface GetAccountFinancialsRequest {
   /**
    * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   * @minimum 1
+   * @maximum 99
    */
   adcp_major_version?: number;
   account: AccountReference;
@@ -14317,10 +15235,12 @@ export interface GetAccountFinancialsRequest {
 export interface DateRange {
   /**
    * Start date (inclusive), ISO 8601
+   * @format date
    */
   start: string;
   /**
    * End date (inclusive), ISO 8601
+   * @format date
    */
   end: string;
 }
@@ -14337,6 +15257,7 @@ export interface GetAccountFinancialsSuccess {
   account: AccountReference;
   /**
    * ISO 4217 currency code for all monetary amounts in this response
+   * @pattern ^[A-Z]{3}$
    */
   currency: string;
   period: DateRange;
@@ -14350,10 +15271,12 @@ export interface GetAccountFinancialsSuccess {
   spend?: {
     /**
      * Total spend in the period, in currency
+     * @minimum 0
      */
     total_spend: number;
     /**
      * Number of active media buys in the period
+     * @minimum 0
      */
     media_buy_count?: number;
   };
@@ -14363,6 +15286,7 @@ export interface GetAccountFinancialsSuccess {
   credit?: {
     /**
      * Maximum outstanding balance allowed
+     * @minimum 0
      */
     credit_limit: number;
     /**
@@ -14371,6 +15295,8 @@ export interface GetAccountFinancialsSuccess {
     available_credit: number;
     /**
      * Credit utilization as a percentage (0-100)
+     * @minimum 0
+     * @maximum 100
      */
     utilization_percent?: number;
   };
@@ -14380,6 +15306,7 @@ export interface GetAccountFinancialsSuccess {
   balance?: {
     /**
      * Remaining prepaid balance
+     * @minimum 0
      */
     available: number;
     /**
@@ -14388,10 +15315,12 @@ export interface GetAccountFinancialsSuccess {
     last_top_up?: {
       /**
        * Top-up amount
+       * @minimum 0
        */
       amount: number;
       /**
        * Date of top-up
+       * @format date
        */
       date: string;
     };
@@ -14412,6 +15341,7 @@ export interface GetAccountFinancialsSuccess {
     period?: DateRange;
     /**
      * Invoice total in currency
+     * @minimum 0
      */
     amount: number;
     /**
@@ -14420,10 +15350,12 @@ export interface GetAccountFinancialsSuccess {
     status: 'draft' | 'issued' | 'paid' | 'past_due' | 'void';
     /**
      * Payment due date
+     * @format date
      */
     due_date?: string;
     /**
      * Date payment was received. Present when status is 'paid'.
+     * @format date
      */
     paid_date?: string;
   }[];
@@ -14544,25 +15476,36 @@ export interface ComplyTestControllerRequest {
     termination_reason?: string;
     /**
      * Impressions to simulate. Used by simulate_delivery.
+     * @minimum 0
      */
     impressions?: number;
     /**
      * Clicks to simulate. Used by simulate_delivery.
+     * @minimum 0
      */
     clicks?: number;
     /**
      * Conversions to simulate. Used by simulate_delivery.
+     * @minimum 0
      */
     conversions?: number;
     /**
      * Spend as reported in delivery data. Does not affect budget. Used by simulate_delivery.
      */
     reported_spend?: {
+      /**
+       * @minimum 0
+       */
       amount: number;
+      /**
+       * @pattern ^[A-Z]{3}$
+       */
       currency: string;
     };
     /**
      * Spend to this percentage of budget (0–100). Used by simulate_budget_spend.
+     * @minimum 0
+     * @maximum 100
      */
     spend_percentage?: number;
     /**
@@ -14571,10 +15514,12 @@ export interface ComplyTestControllerRequest {
     arm?: 'submitted' | 'input-required';
     /**
      * Deterministic task handle the seller MUST emit verbatim on the next create_media_buy response when arm is 'submitted'. The seller MUST accept this exact value on subsequent tasks/get calls within the same authenticated sandbox account. Sandbox task_ids are caller-opaque strings — the seller's production task-id format rules do not apply.
+     * @maxLength 128
      */
     task_id?: string;
     /**
      * Optional human-readable explanation surfaced on the next create_media_buy response. Used by force_create_media_buy_arm for the 'submitted' and 'working' arms. Plain text only.
+     * @maxLength 2000
      */
     message?: string;
     /**
@@ -14592,6 +15537,8 @@ export interface ComplyTestControllerRequest {
 export interface GetProductsAsyncWorking {
   /**
    * Progress percentage of the search operation
+   * @minimum 0
+   * @maximum 100
    */
   percentage?: number;
   /**
@@ -14634,6 +15581,7 @@ export interface GetProductsAsyncInputRequired {
 export interface GetProductsAsyncSubmitted {
   /**
    * Estimated completion time for the search
+   * @format date-time
    */
   estimated_completion?: string;
   context?: ContextObject;
@@ -14645,6 +15593,8 @@ export interface GetProductsAsyncSubmitted {
 export interface CreateMediaBuyAsyncWorking {
   /**
    * Completion percentage (0-100)
+   * @minimum 0
+   * @maximum 100
    */
   percentage?: number;
   /**
@@ -14653,10 +15603,12 @@ export interface CreateMediaBuyAsyncWorking {
   current_step?: string;
   /**
    * Total number of steps in the operation
+   * @minimum 1
    */
   total_steps?: number;
   /**
    * Current step number
+   * @minimum 1
    */
   step_number?: number;
   context?: ContextObject;
@@ -14690,6 +15642,8 @@ export interface CreateMediaBuyAsyncSubmitted {
 export interface UpdateMediaBuyAsyncWorking {
   /**
    * Completion percentage (0-100)
+   * @minimum 0
+   * @maximum 100
    */
   percentage?: number;
   /**
@@ -14698,10 +15652,12 @@ export interface UpdateMediaBuyAsyncWorking {
   current_step?: string;
   /**
    * Total number of steps in the operation
+   * @minimum 1
    */
   total_steps?: number;
   /**
    * Current step number
+   * @minimum 1
    */
   step_number?: number;
   context?: ContextObject;
@@ -14731,6 +15687,8 @@ export interface UpdateMediaBuyAsyncSubmitted {
 export interface BuildCreativeAsyncWorking {
   /**
    * Completion percentage (0-100)
+   * @minimum 0
+   * @maximum 100
    */
   percentage?: number;
   /**
@@ -14739,10 +15697,12 @@ export interface BuildCreativeAsyncWorking {
   current_step?: string;
   /**
    * Total number of steps in the operation
+   * @minimum 1
    */
   total_steps?: number;
   /**
    * Current step number
+   * @minimum 1
    */
   step_number?: number;
   context?: ContextObject;
@@ -14776,6 +15736,8 @@ export interface BuildCreativeAsyncSubmitted {
 export interface SyncCreativesAsyncWorking {
   /**
    * Completion percentage (0-100)
+   * @minimum 0
+   * @maximum 100
    */
   percentage?: number;
   /**
@@ -14784,18 +15746,22 @@ export interface SyncCreativesAsyncWorking {
   current_step?: string;
   /**
    * Total number of steps in the operation
+   * @minimum 1
    */
   total_steps?: number;
   /**
    * Current step number
+   * @minimum 1
    */
   step_number?: number;
   /**
    * Number of creatives processed so far
+   * @minimum 0
    */
   creatives_processed?: number;
   /**
    * Total number of creatives to process
+   * @minimum 0
    */
   creatives_total?: number;
   context?: ContextObject;
@@ -14825,6 +15791,8 @@ export interface SyncCreativesAsyncSubmitted {
 export interface SyncCatalogsAsyncWorking {
   /**
    * Completion percentage (0-100)
+   * @minimum 0
+   * @maximum 100
    */
   percentage?: number;
   /**
@@ -14833,26 +15801,32 @@ export interface SyncCatalogsAsyncWorking {
   current_step?: string;
   /**
    * Total number of steps in the operation
+   * @minimum 1
    */
   total_steps?: number;
   /**
    * Current step number
+   * @minimum 1
    */
   step_number?: number;
   /**
    * Number of catalogs processed so far
+   * @minimum 0
    */
   catalogs_processed?: number;
   /**
    * Total number of catalogs to process
+   * @minimum 0
    */
   catalogs_total?: number;
   /**
    * Total number of catalog items processed across all catalogs
+   * @minimum 0
    */
   items_processed?: number;
   /**
    * Total number of catalog items to process across all catalogs
+   * @minimum 0
    */
   items_total?: number;
   context?: ContextObject;
@@ -14969,6 +15943,7 @@ export interface ForcedDirectiveSuccess {
     arm: 'submitted' | 'input-required';
     /**
      * Echo of the registered task_id. Present only when arm is 'submitted' (the arm that emits a task envelope).
+     * @maxLength 128
      */
     task_id?: string;
   };

--- a/test/jsdoc-constraints-codegen.test.js
+++ b/test/jsdoc-constraints-codegen.test.js
@@ -1,0 +1,239 @@
+/**
+ * Tests for the JSDoc constraint injection that bridges JSON Schema validation
+ * keywords (minimum/maximum/pattern/format/etc.) across the lossy
+ * JSON Schema → TypeScript → Zod codegen hop. Fixes adcp-client#1745.
+ *
+ * - Unit slice (via tsx harness): exercises `injectJsdocConstraints` on a
+ *   synthetic schema covering all six supported tag kinds plus a nested
+ *   object, then runs the actual `json-schema-to-typescript` + `ts-to-zod`
+ *   pipeline on the result to confirm the chain end-to-end.
+ *
+ * - Pinning slice (reads schemas.generated.ts): checks that real generated
+ *   Zod schemas (`MediaBuySchema.revision`, `MediaBuySchema.total_budget`)
+ *   reject constraint-violating inputs they previously accepted. If a
+ *   future codegen regression strips constraints again, this fails.
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+
+/**
+ * Run a tsx harness that pipes the JSON Schema fixture through the real
+ * codegen pipeline and emits {ts, zod} as JSON on stdout. Mirrors the
+ * sequence in scripts/generate-types.ts + scripts/generate-zod-from-ts.ts
+ * — same `compile()` options, same `generate()` options.
+ */
+function runCodegenPipeline(schema, typeName = 'Fixture') {
+  const harness = `
+const { compile } = require('json-schema-to-typescript');
+const { generate } = require('ts-to-zod');
+const { injectJsdocConstraints } = require(${JSON.stringify(path.resolve(REPO_ROOT, 'scripts/schema-utils.ts'))});
+
+(async () => {
+  const schema = ${JSON.stringify(schema)};
+  const annotated = injectJsdocConstraints(schema);
+  const ts = await compile(annotated, ${JSON.stringify(typeName)}, {
+    bannerComment: '',
+    style: { semi: true, singleQuote: true },
+    additionalProperties: false,
+  });
+  const zResult = generate({
+    sourceText: ts,
+    skipParseJSDoc: false,
+    getSchemaName: name => name + 'Schema',
+  });
+  process.stdout.write(JSON.stringify({ ts, zod: zResult.getZodSchemasFile(), errors: zResult.errors }));
+})().catch(e => {
+  process.stderr.write(String(e && e.stack || e));
+  process.exit(1);
+});
+`;
+  // Write the harness inside the repo so Node resolves node_modules from
+  // the project root. tsx + `cwd` alone is not enough — module resolution
+  // walks up from the script's own directory.
+  const tmpDir = fs.mkdtempSync(path.join(REPO_ROOT, '.tmp-jsdoc-constraints-'));
+  const harnessPath = path.join(tmpDir, 'harness.cjs');
+  fs.writeFileSync(harnessPath, harness);
+  try {
+    const r = spawnSync('npx', ['tsx', harnessPath], {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+    });
+    if (r.status !== 0) {
+      throw new Error(`harness exited ${r.status}: ${r.stderr}`);
+    }
+    return JSON.parse(r.stdout);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+describe('injectJsdocConstraints — synthetic end-to-end', () => {
+  it('injects all six supported constraint kinds plus walks into nested objects', () => {
+    const schema = {
+      title: 'Fixture',
+      type: 'object',
+      properties: {
+        revision: { type: 'integer', minimum: 1, description: 'revision' },
+        score: { type: 'number', minimum: 0, maximum: 100 },
+        slug: { type: 'string', pattern: '^[a-z0-9_]+$' },
+        short: { type: 'string', minLength: 1, maxLength: 50 },
+        created_at: { type: 'string', format: 'date-time' },
+        nested: {
+          type: 'object',
+          properties: {
+            inner: { type: 'integer', minimum: 5, maximum: 10 },
+          },
+        },
+      },
+      required: ['revision'],
+    };
+
+    const { ts, zod, errors } = runCodegenPipeline(schema);
+    assert.deepEqual(errors, [], `ts-to-zod errors: ${errors.join(', ')}`);
+
+    // TypeScript carries the JSDoc tags
+    assert.match(ts, /@minimum 1/);
+    assert.match(ts, /@minimum 0/);
+    assert.match(ts, /@maximum 100/);
+    assert.match(ts, /@pattern \^\[a-z0-9_\]\+\$/);
+    assert.match(ts, /@minLength 1/);
+    assert.match(ts, /@maxLength 50/);
+    assert.match(ts, /@format date-time/);
+    assert.match(ts, /@minimum 5/, 'nested inner minimum lost — recursion broken');
+    assert.match(ts, /@maximum 10/, 'nested inner maximum lost — recursion broken');
+
+    // Zod renders them as validators
+    assert.match(zod, /revision: z\.number\(\)\.min\(1\)/);
+    assert.match(zod, /score: z\.number\(\)\.min\(0\)\.max\(100\)/);
+    assert.match(zod, /slug: z\.string\(\)\.regex\(\/\^\[a-z0-9_\]\+\$\//);
+    assert.match(zod, /short: z\.string\(\)\.min\(1\)\.max\(50\)/);
+    assert.match(zod, /created_at: z\.iso\.datetime\(\)/);
+    assert.match(zod, /inner: z\.number\(\)\.min\(5\)\.max\(10\)/);
+  });
+
+  it('skips unsupported format values (Ajv enforces them at runtime)', () => {
+    const schema = {
+      title: 'Fixture',
+      type: 'object',
+      properties: {
+        weird: { type: 'string', format: 'iri-reference' },
+      },
+    };
+    const { ts, zod } = runCodegenPipeline(schema);
+    assert.doesNotMatch(ts, /@format iri-reference/);
+    assert.match(zod, /weird: z\.string\(\)\.optional\(\)/);
+  });
+
+  it('escapes forward slashes inside @pattern so the regex literal stays valid', () => {
+    const schema = {
+      title: 'Fixture',
+      type: 'object',
+      properties: {
+        link: { type: 'string', pattern: '^/schemas/' },
+      },
+    };
+    const { ts, zod, errors } = runCodegenPipeline(schema);
+    assert.deepEqual(errors, []);
+    // The pattern in the JSDoc has escaped slashes
+    assert.match(ts, /@pattern \^\\\/schemas\\\//);
+    // Zod regex literal is well-formed
+    assert.match(zod, /\.regex\(\/\^\\\/schemas\\\//);
+  });
+
+  it('preserves the existing description when appending tags', () => {
+    const schema = {
+      title: 'Fixture',
+      type: 'object',
+      properties: {
+        n: { type: 'integer', description: 'existing prose', minimum: 1 },
+      },
+    };
+    const { ts } = runCodegenPipeline(schema);
+    assert.match(ts, /existing prose/);
+    assert.match(ts, /@minimum 1/);
+  });
+
+  it('is idempotent — running twice does not duplicate tags', () => {
+    const schema = {
+      title: 'Fixture',
+      type: 'object',
+      properties: {
+        n: { type: 'integer', minimum: 1 },
+      },
+    };
+    // First pass on raw schema; second pass on the already-annotated schema.
+    const harness = `
+const { injectJsdocConstraints } = require(${JSON.stringify(path.resolve(REPO_ROOT, 'scripts/schema-utils.ts'))});
+const schema = ${JSON.stringify(schema)};
+const once = injectJsdocConstraints(schema);
+const twice = injectJsdocConstraints(once);
+process.stdout.write(JSON.stringify({ once: once.properties.n.description, twice: twice.properties.n.description }));
+`;
+    const tmpDir = fs.mkdtempSync(path.join(REPO_ROOT, '.tmp-jsdoc-constraints-'));
+    const harnessPath = path.join(tmpDir, 'idempotent.cjs');
+    fs.writeFileSync(harnessPath, harness);
+    try {
+      const r = spawnSync('npx', ['tsx', harnessPath], { cwd: REPO_ROOT, encoding: 'utf8' });
+      assert.strictEqual(r.status, 0, r.stderr);
+      const out = JSON.parse(r.stdout);
+      assert.strictEqual(out.once, out.twice, 'second pass mutated annotated description');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('generated Zod schemas — constraint pinning', () => {
+  let MediaBuySchema;
+  let BrandReferenceSchema;
+  let BusinessEntitySchema;
+
+  try {
+    ({ MediaBuySchema, BrandReferenceSchema, BusinessEntitySchema } = require('../dist/lib/types/schemas.generated'));
+  } catch (e) {
+    // Build hasn't run yet — skip the pinning slice rather than fail the unit slice.
+    console.warn(`⏭️  Skipping pinning tests — dist not built: ${e.message}`);
+  }
+
+  it('MediaBuySchema.revision rejects 0 (minimum: 1)', { skip: !MediaBuySchema }, () => {
+    const r = MediaBuySchema.shape.revision.safeParse(0);
+    assert.strictEqual(r.success, false, 'revision=0 should fail min(1)');
+  });
+
+  it('MediaBuySchema.revision accepts 1', { skip: !MediaBuySchema }, () => {
+    const r = MediaBuySchema.shape.revision.safeParse(1);
+    assert.strictEqual(r.success, true, JSON.stringify(r.error));
+  });
+
+  it('MediaBuySchema.total_budget rejects -1 (minimum: 0)', { skip: !MediaBuySchema }, () => {
+    const r = MediaBuySchema.shape.total_budget.safeParse(-1);
+    assert.strictEqual(r.success, false, 'total_budget=-1 should fail min(0)');
+  });
+
+  it('BrandReferenceSchema.domain rejects an invalid domain (pattern)', { skip: !BrandReferenceSchema }, () => {
+    const r = BrandReferenceSchema.shape.domain.safeParse('NOT A DOMAIN');
+    assert.strictEqual(r.success, false, 'invalid domain should fail pattern');
+  });
+
+  it('BusinessEntitySchema.address.country accepts a valid ISO-2 (pattern)', { skip: !BusinessEntitySchema }, () => {
+    const r = BusinessEntitySchema.shape.address.unwrap().shape.country.safeParse('US');
+    assert.strictEqual(r.success, true, JSON.stringify(r.error));
+  });
+
+  it(
+    'BusinessEntitySchema.address.country rejects lowercase (pattern requires ^[A-Z]{2}$)',
+    {
+      skip: !BusinessEntitySchema,
+    },
+    () => {
+      const r = BusinessEntitySchema.shape.address.unwrap().shape.country.safeParse('us');
+      assert.strictEqual(r.success, false, 'lowercase country should fail pattern');
+    }
+  );
+});

--- a/test/jsdoc-constraints-codegen.test.js
+++ b/test/jsdoc-constraints-codegen.test.js
@@ -146,6 +146,40 @@ describe('injectJsdocConstraints — synthetic end-to-end', () => {
     assert.match(zod, /\.regex\(\/\^\\\/schemas\\\//);
   });
 
+  it('preserves regex escape sequences inside @pattern (no double-escape of `\\`)', () => {
+    // JSON Schema pattern `\d+\.\d+` — `\d` is the digit class, `\.` is an
+    // escaped dot. Naive `\\` escaping would turn `\d` into `\\d` (literal
+    // backslash then `d`), breaking validation. ts-to-zod must see the
+    // single-backslash form so the emitted regex still means "digits".
+    const schema = {
+      title: 'Fixture',
+      type: 'object',
+      properties: {
+        version: { type: 'string', pattern: '^\\d+\\.\\d+$' },
+      },
+    };
+    const { ts, zod, errors } = runCodegenPipeline(schema);
+    assert.deepEqual(errors, []);
+    // JSDoc keeps single backslashes (regex-source form).
+    assert.match(ts, /@pattern \^\\d\+\\\.\\d\+\$/);
+    // Emitted Zod regex literal still has single backslashes too.
+    assert.match(zod, /\.regex\(\/\^\\d\+\\\.\\d\+\$\//);
+  });
+
+  it('skips a pattern with an unpaired trailing backslash (would break /PATTERN/ delimiter)', () => {
+    const schema = {
+      title: 'Fixture',
+      type: 'object',
+      properties: {
+        weird: { type: 'string', pattern: 'abc\\' },
+      },
+    };
+    const { ts, zod } = runCodegenPipeline(schema);
+    assert.doesNotMatch(ts, /@pattern abc/);
+    // Zod still emits a string type, just without the .regex() chain.
+    assert.match(zod, /weird: z\.string\(\)\.optional\(\)/);
+  });
+
   it('preserves the existing description when appending tags', () => {
     const schema = {
       title: 'Fixture',


### PR DESCRIPTION
## Summary

- Generated Zod schemas now enforce `minimum`, `maximum`, `minLength`, `maxLength`, `pattern`, and `format` from the upstream JSON Schemas. Before, those keywords were silently lost during the `JSON Schema → TypeScript → Zod` codegen because TypeScript cannot carry a numeric range or regex on a `number`/`string` field. `MediaBuySchema.revision` was emitted as `z.number().optional()` instead of `z.number().min(1).optional()`, so typed validators accepted inputs that AJV correctly rejected.
- New helper `injectJsdocConstraints` (in `scripts/schema-utils.ts`) walks each JSON Schema and encodes the constraints into the `description` field as `@minimum` / `@maximum` / `@minLength` / `@maxLength` / `@pattern` / `@format` JSDoc tags before `json-schema-to-typescript` compiles. `ts-to-zod` natively reads those tags, so the constraints round-trip into `.min()` / `.max()` / `.regex()` / `.iso.datetime()` / `.email()` chains. ~900 new validator chains land across `schemas.generated.ts`.
- `exclusiveMinimum` / `exclusiveMaximum`, patterns containing newlines, and unsupported `format` values (e.g. `iri-reference`) continue to be enforced at runtime by AJV against the unstripped schema.

Closes #1745. This is the bigger of two paired codegen fixes; the sibling PR for #1756 (allOf+$ref merger) also touches `scripts/generate-types.ts` but is independent — merge order doesn't matter.

## Test plan

- [x] New unit test (`test/jsdoc-constraints-codegen.test.js`) exercises `injectJsdocConstraints` on a synthetic schema covering all six tag kinds plus a nested object, then runs the real `json-schema-to-typescript` + `ts-to-zod` pipeline on the result and asserts the emitted TS and Zod.
- [x] New pinning test confirms `MediaBuySchema.revision` rejects `0`, `MediaBuySchema.total_budget` rejects `-1`, `BrandReferenceSchema.domain` rejects an invalid domain, and `BusinessEntitySchema.address.country` rejects lowercase.
- [x] `npm run generate-types && npm run generate-zod-schemas` regenerates cleanly; large additive diff in `core.generated.ts` / `tools.generated.ts` / `schemas.generated.ts` (~1900 lines of new JSDoc + Zod chains).
- [x] `npm run build` passes.
- [x] `npm test` — full suite passes (the previously-flagged flaky perf test `InMemoryReplayStore: has() stays sub-linear` is unrelated and passes on a clean re-run).
- [x] `npm run format:check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)