### PR TITLE
fix(codegen): guard wire-spec generator on empty schema cache

### DIFF
--- a/.changeset/codegen-empty-cache-guard.md
+++ b/.changeset/codegen-empty-cache-guard.md
@@ -1,0 +1,9 @@
+---
+'@adcp/sdk': patch
+---
+
+fix(codegen): guard `generate-wire-spec-fields` against fresh-clone empty cache
+
+When `schemas/cache/` is gitignored and not yet downloaded (e.g. fresh clone before `npm run sync-schemas`), the codegen previously overwrote the committed `src/lib/server/wire-spec-fields.generated.ts` with an empty stub, breaking `tsc` for every consuming module until the dev manually re-synced. The script now detects the empty-cache + pre-existing-non-empty-output case and leaves the committed file unchanged, with a console line explaining the skip.
+
+No runtime behavior change; build-time only.

--- a/scripts/generate-wire-spec-fields.ts
+++ b/scripts/generate-wire-spec-fields.ts
@@ -222,6 +222,17 @@ function main(): void {
   lines.push('');
 
   const content = lines.join('\n');
+  // Guard: if the schema cache is empty (e.g. gitignored dirs not yet
+  // downloaded in a fresh clone), don't overwrite a pre-existing
+  // non-empty generated file with an empty stub — that would break tsc
+  // for all consuming modules until the dev runs `sync-schemas`.
+  if (sorted.length === 0 && existsSync(OUTPUT_FILE)) {
+    const existing = readFileSync(OUTPUT_FILE, 'utf8');
+    if (existing.includes('WIRE_SPEC_FIELDS') && existing.includes('fields:')) {
+      console.log(`[generate-wire-spec-fields] schema cache empty; keeping existing generated file unchanged`);
+      return;
+    }
+  }
   // Idempotent write — skip if unchanged sans timestamp.
   if (existsSync(OUTPUT_FILE)) {
     const existing = readFileSync(OUTPUT_FILE, 'utf8');

--- a/scripts/generate-wire-spec-fields.ts
+++ b/scripts/generate-wire-spec-fields.ts
@@ -229,7 +229,9 @@ function main(): void {
   if (sorted.length === 0 && existsSync(OUTPUT_FILE)) {
     const existing = readFileSync(OUTPUT_FILE, 'utf8');
     if (existing.includes('WIRE_SPEC_FIELDS') && existing.includes('fields:')) {
-      console.log(`[generate-wire-spec-fields] schema cache empty; keeping existing generated file unchanged`);
+      console.log(
+        `[generate-wire-spec-fields] schema cache empty; keeping existing generated file unchanged: ${path.relative(REPO_ROOT, OUTPUT_FILE)}`
+      );
       return;
     }
   }


### PR DESCRIPTION
## Summary

- On a fresh clone (where `schemas/cache/` is gitignored and not yet downloaded), running the build before `npm run sync-schemas` causes `generate-wire-spec-fields` to overwrite the committed `src/lib/server/wire-spec-fields.generated.ts` with an empty stub.
- An empty stub breaks `tsc` for every consuming module until the dev manually re-syncs.
- Detect the empty-cache + pre-existing-non-empty-output case and leave the committed file untouched, with a console line explaining the skip.

## Background

Originally surfaced during PR #1754 (now closed as superseded by #1753). Carried forward as its own trivial PR per the post-merge expert review.

## Test plan

- [x] `npm run build` against a populated schema cache: codegen behaves as before (idempotent write).
- [x] `npm run build` against an empty schema cache + pre-existing populated generated file: codegen short-circuits, logs skip message, `tsc --noEmit` clean.
- [x] `prettier --check` clean.