### PR TITLE
docs(bridge): trust-boundary + multi-tenant adopter responsibility

### DIFF
--- a/.changeset/bridge-jsdoc-trust-boundary.md
+++ b/.changeset/bridge-jsdoc-trust-boundary.md
@@ -1,0 +1,13 @@
+---
+'@adcp/sdk': patch
+---
+
+docs(bridge): name `resolveAccount` as the trust boundary + multi-tenant keying as adopter responsibility
+
+Adds two paragraphs to the top-of-file JSDoc on `src/lib/server/test-controller-bridge.ts`:
+
+- **Scope of verification.** A storyboard pass through this bridge proves protocol conformance against fixture data — wire shape, error envelopes, idempotency, signed-request handling, sandbox stamping. It does **not** prove the seller's adapter against the real upstream platform works; that code path is bypassed by the post-handler merge. Sellers should pair this with a live-OAuth sandbox-runner to cover adapter health. Cross-references the runner-visible-bridge-marker ask at adcp-client#1775.
+
+- **Adopter responsibilities.** Names two patterns the SDK can't enforce: (1) `resolveAccount` is the trust boundary — production bindings MUST configure it or the request-signal check (`account.sandbox === true` OR `context.sandbox === true`) is the only line of defense, because the dispatcher gate falls through to permissive when `ctx.account === undefined`; (2) multi-tenant keying is the adopter's job — callbacks must key their fixture store on `ctx.account` and the SDK does no defensive cross-check between fixture-entry account IDs and the resolved `ctx.account`.
+
+No code change. Security-review-driven (4 of 4 experts during PR #1754 post-merge review flagged the missing public-surface warning).

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -1676,6 +1676,12 @@ export interface AdcpServerConfig<TAccount = unknown> {
    * See `src/lib/server/test-controller-bridge.ts` for the sandbox-marker
    * predicate and the merge contract.
    *
+   * **Trust boundary:** production bindings MUST also configure
+   * `resolveAccount`. Without it, the sandbox gate falls through to
+   * the buyer-supplied marker and the bridge can be triggered by any
+   * authenticated buyer. See the top-of-file JSDoc on `TestControllerBridge`
+   * for the full adopter-responsibility note (#1779).
+   *
    * @example
    * ```ts
    * import { createAdcpServer, bridgeFromTestControllerStore } from '@adcp/sdk/server/legacy/v5';

--- a/src/lib/server/test-controller-bridge.ts
+++ b/src/lib/server/test-controller-bridge.ts
@@ -24,8 +24,9 @@
  * the response verifies **protocol conformance against fixture data**:
  * wire shape, error envelopes, idempotency, signed-request handling,
  * sandbox stamping. It does **not** verify that the seller's adapter
- * against the real upstream (Snap, Meta, TikTok, Google Ads, etc.) is
- * working — the upstream code path is bypassed by the post-handler merge.
+ * against the real upstream (e.g., social / search / programmatic
+ * inventory APIs) is working — the upstream response is shadowed by the
+ * post-handler merge.
  *
  * Treat this bridge as the conformance equivalent of a recorded-fixtures
  * unit test, not an end-to-end integration test. Sellers should still
@@ -46,7 +47,7 @@
  * `context.sandbox: true` on a request and trigger the merge. That's the
  * intended behavior for storyboard runners with no account scoping, but
  * means **production bindings must always configure `resolveAccount`** —
- * otherwise the request-signal check is the only line of defense.
+ * otherwise the buyer-supplied sandbox marker is the only gate.
  *
  * **Multi-tenant isolation is the adopter's job.** Callbacks receive
  * `ctx.account` and must key their fixture store on it. The SDK does no

--- a/src/lib/server/test-controller-bridge.ts
+++ b/src/lib/server/test-controller-bridge.ts
@@ -17,6 +17,44 @@
  * Sellers provide a `getSeededProducts` callback that returns the list the
  * SDK should merge — which lets the same wiring work whether the backing
  * store is in-memory, Postgres, Redis, or a mock.
+ *
+ * ## Scope of verification (storyboard pass through this bridge)
+ *
+ * A storyboard run that succeeds because seeded fixtures were merged into
+ * the response verifies **protocol conformance against fixture data**:
+ * wire shape, error envelopes, idempotency, signed-request handling,
+ * sandbox stamping. It does **not** verify that the seller's adapter
+ * against the real upstream (Snap, Meta, TikTok, Google Ads, etc.) is
+ * working — the upstream code path is bypassed by the post-handler merge.
+ *
+ * Treat this bridge as the conformance equivalent of a recorded-fixtures
+ * unit test, not an end-to-end integration test. Sellers should still
+ * exercise their adapters against a real (or sandbox) upstream OAuth tier
+ * separately; the typical pattern is a CLI runner pointed at a deployed
+ * sandbox URL with live credentials. The two together — storyboard-via-
+ * bridge plus live-OAuth runner — give wire conformance and adapter
+ * health respectively. See adcp-client#1775 for the cross-repo
+ * coordination on making bridge participation visible in storyboard
+ * run records.
+ *
+ * ## Adopter responsibilities
+ *
+ * **`resolveAccount` is the trust boundary.** The dispatcher's sandbox
+ * gate is "request carries a sandbox marker AND (resolved account is
+ * sandbox OR no account was resolved)." If you deploy a server with this
+ * bridge registered but no `resolveAccount` configured, a buyer can stamp
+ * `context.sandbox: true` on a request and trigger the merge. That's the
+ * intended behavior for storyboard runners with no account scoping, but
+ * means **production bindings must always configure `resolveAccount`** —
+ * otherwise the request-signal check is the only line of defense.
+ *
+ * **Multi-tenant isolation is the adopter's job.** Callbacks receive
+ * `ctx.account` and must key their fixture store on it. The SDK does no
+ * defensive cross-check between the account on the response entries and
+ * the `ctx.account` that asked for them. A sloppy session-store keying
+ * can return tenant A's fixtures to tenant B; nothing in this module
+ * will notice. Treat fixture stores like any other multi-tenant data
+ * layer.
  */
 
 import type {


### PR DESCRIPTION
## Summary

- Adds two paragraphs to the top-of-file JSDoc on `src/lib/server/test-controller-bridge.ts`:
  1. **Scope of verification** — storyboard pass via the bridge proves wire conformance against fixture data, NOT adapter health against the real upstream. Cross-references #1775.
  2. **Adopter responsibilities** — names `resolveAccount` as the trust boundary (production bindings MUST configure it; otherwise the request-signal check is the only line of defense) and multi-tenant keying as the adopter's job (SDK does no defensive cross-check).
- No code change.

## Background

After #1753 + phases #1759/#1761/#1772 grew the bridge surface to 13 tools on `main`, the four-expert review of (now-closed) #1754 found that the public-surface JSDoc didn't name either trust pattern. Security review flagged the `ctx.account === undefined` permissive branch in the dispatcher gate at `src/lib/server/create-adcp-server.ts:3913-3917` as a real adopter footgun — adopters who deploy the bridge to a production binding without `resolveAccount` configured can have buyers stamp `context.sandbox:true` and trigger the merge.

The patterns themselves are intentional (storyboard runners often have no account scoping); the gap was naming them on the public surface so adopters don't deploy through them by accident.

## Test plan

- [x] `tsc --noEmit` clean (docs-only change).
- [x] `prettier --check` clean.
- [x] Diff is +43/-4 in `test-controller-bridge.ts`, all inside the leading `/** ... */` block.