### PR TITLE
fix(bridge): debug log on sandbox-gate reject across 13 dispatcher branches

### DIFF
--- a/.changeset/bridge-debug-log-gate-reject.md
+++ b/.changeset/bridge-debug-log-gate-reject.md
@@ -1,0 +1,13 @@
+---
+'@adcp/sdk': patch
+---
+
+fix(bridge): emit `logger.debug` when sandbox-gate rejects a sandbox-flagged request
+
+When an adopter sets `account.sandbox: true` (or `context.sandbox: true`) on a request but the resolved `ctx.account` is explicitly `sandbox: false`, the dispatcher's `TestControllerBridge` gate rejects the merge silently. Adopters chasing "why aren't my fixtures showing in storyboards" had no diagnostic surface — the request looked sandbox-shaped but no fixtures appeared and no logs explained the gap. That was the #1 adopter support question after #1753 shipped.
+
+Adds a single `logger.debug` line inside `src/lib/server/create-adcp-server.ts` covering all 13 dispatcher branches in one shot — the diagnostic fires after the request-sandbox check passes but before the resolved-account check. Production traffic (no sandbox marker on request) fails the first gate and never reaches this branch, so the log surface is dev-only.
+
+Three regression tests verify: gate-mismatch fires `debug`; production traffic does not fire `debug`; gate-pass does not fire `debug` and merge proceeds normally.
+
+Product-review-driven during the post-merge review of (now-closed) #1754.

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -3931,9 +3931,21 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
               (ctx.account as { sandbox?: unknown }).sandbox === true
             )
           ) {
+            // Include the resolved account_id so the log line is self-
+            // diagnostic — an adopter chasing "why aren't my fixtures
+            // showing" can match the rejected account against their
+            // resolveAccount source without correlating across log lines.
+            // account_ids appear in normal request logs already; no new
+            // PII surface.
+            const resolvedAccountId =
+              typeof ctx.account === 'object' &&
+              ctx.account !== null &&
+              typeof (ctx.account as { account_id?: unknown }).account_id === 'string'
+                ? ((ctx.account as { account_id?: unknown }).account_id as string)
+                : undefined;
             logger.debug(
               'test-controller bridge: request is sandbox-flagged but resolved account is not sandbox; skipping merge',
-              { tool: toolName }
+              { tool: toolName, resolved_account_id: resolvedAccountId }
             );
           }
 

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -3913,6 +3913,30 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
           // `get_account_financials` is the exception — singleton response, so the
           // seeded entry REPLACES the handler payload when its `account.account_id`
           // matches the request's `account.account_id`.
+          // Diagnostic for adopters chasing "why aren't my fixtures showing":
+          // when the request carries a sandbox marker but the resolved account
+          // is explicitly non-sandbox, the gate rejects silently. Emit a
+          // `debug` line so the rejection is observable in dev logs without
+          // adding noise to production traffic (where the gate's first check
+          // — `isSandboxRequestForSeeding` — fails first and never reaches
+          // this branch).
+          if (
+            testControllerBridge &&
+            !isErrorResponse(formatted) &&
+            isSandboxRequestForSeeding(params) &&
+            ctx.account !== undefined &&
+            !(
+              typeof ctx.account === 'object' &&
+              ctx.account !== null &&
+              (ctx.account as { sandbox?: unknown }).sandbox === true
+            )
+          ) {
+            logger.debug(
+              'test-controller bridge: request is sandbox-flagged but resolved account is not sandbox; skipping merge',
+              { tool: toolName }
+            );
+          }
+
           if (
             testControllerBridge &&
             !isErrorResponse(formatted) &&

--- a/test/lib/seed-per-tool-wiring.test.js
+++ b/test/lib/seed-per-tool-wiring.test.js
@@ -3447,6 +3447,7 @@ describe('createAdcpServer — sandbox-gate debug log on resolved-account mismat
     );
     assert.ok(hit, 'expected sandbox-gate debug log');
     assert.equal(hit.data.tool, 'list_creatives');
+    assert.equal(hit.data.resolved_account_id, 'prod-acct', 'log should include resolved account_id for diagnostics');
   });
 
   it('does not emit debug when request lacks sandbox marker (gate fails first)', async () => {

--- a/test/lib/seed-per-tool-wiring.test.js
+++ b/test/lib/seed-per-tool-wiring.test.js
@@ -3388,3 +3388,111 @@ describe('bridgeFromSessionStore — brand-rights + SI selectors', () => {
     assert.equal(bridge.getSeededSiOffering, undefined);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Sandbox-gate diagnostic
+//
+// When the request carries a sandbox marker (`account.sandbox === true` or
+// `context.sandbox === true`) but the resolved `ctx.account` is explicitly
+// non-sandbox, the dispatcher rejects the merge silently. Emit a `debug`
+// line so dev logs surface the rejection without adding production-traffic
+// noise (the first gate, `isSandboxRequest`, fails first there and never
+// reaches this branch).
+// ---------------------------------------------------------------------------
+
+describe('createAdcpServer — sandbox-gate debug log on resolved-account mismatch', () => {
+  function makeRecordingLogger() {
+    const records = { debug: [], info: [], warn: [], error: [] };
+    return {
+      logger: {
+        debug: (msg, data) => records.debug.push({ msg, data }),
+        info: (msg, data) => records.info.push({ msg, data }),
+        warn: (msg, data) => records.warn.push({ msg, data }),
+        error: (msg, data) => records.error.push({ msg, data }),
+      },
+      records,
+    };
+  }
+
+  function handlerListCreatives() {
+    return async () => ({
+      query_summary: { total_matching: 0, returned: 0 },
+      pagination: { limit: 50, offset: 0, has_more: false },
+      creatives: [],
+    });
+  }
+
+  it('emits debug when request is sandbox-flagged but resolved account is sandbox:false', async () => {
+    const { logger, records } = makeRecordingLogger();
+    let bridgeCalled = false;
+    const server = createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      logger,
+      resolveAccount: () => ({ account_id: 'prod-acct', sandbox: false }),
+      creative: { listCreatives: handlerListCreatives() },
+      testController: {
+        getSeededCreatives: () => {
+          bridgeCalled = true;
+          return [{ creative_id: 'leaked-fixture', name: 'should not appear' }];
+        },
+      },
+    });
+
+    await dispatch(server, 'list_creatives', { account: SANDBOX_ACCOUNT });
+
+    assert.equal(bridgeCalled, false);
+    const hit = records.debug.find(r =>
+      r.msg.includes('request is sandbox-flagged but resolved account is not sandbox')
+    );
+    assert.ok(hit, 'expected sandbox-gate debug log');
+    assert.equal(hit.data.tool, 'list_creatives');
+  });
+
+  it('does not emit debug when request lacks sandbox marker (gate fails first)', async () => {
+    const { logger, records } = makeRecordingLogger();
+    const server = createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      logger,
+      resolveAccount: () => ({ account_id: 'prod-acct', sandbox: false }),
+      creative: { listCreatives: handlerListCreatives() },
+      testController: {
+        getSeededCreatives: () => [{ creative_id: 's-1', name: 'X' }],
+      },
+    });
+
+    await dispatch(server, 'list_creatives', {
+      account: { brand: { domain: 'example.com' }, operator: 'example.com' /* no sandbox */ },
+    });
+
+    const hit = records.debug.find(r =>
+      r.msg.includes('request is sandbox-flagged but resolved account is not sandbox')
+    );
+    assert.equal(hit, undefined, 'should not log gate-mismatch when production traffic');
+  });
+
+  it('does not emit debug when resolved account is sandbox (gate passes)', async () => {
+    const { logger, records } = makeRecordingLogger();
+    const server = createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      logger,
+      resolveAccount: () => ({ account_id: 'sandbox-acct', sandbox: true }),
+      creative: { listCreatives: handlerListCreatives() },
+      testController: {
+        getSeededCreatives: () => [{ creative_id: 's-1', name: 'X' }],
+      },
+    });
+
+    const res = await dispatch(server, 'list_creatives', { account: SANDBOX_ACCOUNT });
+    const hit = records.debug.find(r =>
+      r.msg.includes('request is sandbox-flagged but resolved account is not sandbox')
+    );
+    assert.equal(hit, undefined, 'should not log when the gate passes');
+    assert.deepEqual(
+      res.structuredContent.creatives.map(c => c.creative_id),
+      ['s-1']
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Single `logger.debug` line in `src/lib/server/create-adcp-server.ts` that fires when the request carries a sandbox marker but the resolved `ctx.account` is explicitly `sandbox: false`.
- Covers all 13 dispatcher branches in one shot — the debug emit sits between the request-sandbox check and the resolved-account check, so every per-tool branch inherits it without per-branch wiring.
- Three regression tests in `test/lib/seed-per-tool-wiring.test.js`: gate-mismatch fires, production traffic does not fire, gate-pass does not fire and merge proceeds.

## Why

After #1753 shipped, the #1 adopter support question was "why aren't my fixtures showing in storyboards" when their request was sandbox-shaped but their resolved account was production. The gate rejected silently and adopters had no diagnostic surface. The dev-only `debug` line surfaces the rejection without adding production-traffic noise — production traffic fails the first gate (`isSandboxRequest`) and never reaches this branch.

Product-review-driven during the post-merge review of (now-closed) #1754.

## Test plan

- [x] `NODE_ENV=test node --test test/lib/seed-per-tool-wiring.test.js` — 138/138 pass (3 new + 135 existing).
- [x] `tsc --noEmit` clean.
- [x] `prettier --check` clean.
- [x] Pre-push validation (build + typecheck) clean.