### PR TITLE
fix(bridge): guard mergeSeededProductsIntoResponse against the Submitted arm

### DIFF
--- a/.changeset/bridge-guard-submitted-arm-on-products.md
+++ b/.changeset/bridge-guard-submitted-arm-on-products.md
@@ -1,0 +1,13 @@
+---
+'@adcp/sdk': patch
+---
+
+fix(bridge): `mergeSeededProductsIntoResponse` short-circuits on the Submitted arm
+
+`get_products` formally permits an async Submitted arm in the AdCP 3.0.11 spec (`schemas/cache/3.0.11/media-buy/get-products-async-response-submitted.json`) for queued custom / bespoke product curation. When a handler returns `{ status: 'submitted', task_id, message? }`, the dispatcher's `isSubmittedEnvelope` predicate routes the response through `wrapSubmittedEnvelope` rather than the success-arm builder — but the `TestControllerBridge` merge runs after that wrap step, and without a guard `mergeSeededProductsIntoResponse` would spread `products: [...]` into the Submitted envelope, producing a `{ status: 'submitted', task_id, products: [...], sandbox: true }` hybrid that violates the wire schema (no Submitted arm carries a `products` field, and `sandbox: true` shouldn't stamp onto a tasking acknowledgement).
+
+Detect the Submitted shape (`{ status: 'submitted', task_id: string }`) in the merge helper and return the handler response reference-equal so the dispatcher's existing skip-on-reference-equality wrap-avoidance kicks in. No other behavior change; sync success-arm responses merge exactly as before.
+
+Scope is `get_products`-specific by design — none of the other 12 bridged read tools (`list_creatives`, `get_media_buys`, `get_media_buy_delivery`, `list_accounts`, `get_account_financials`, `list_creative_formats`, `list_property_lists`, `get_property_list`, `list_collection_lists`, `get_collection_list`, `list_content_standards`, `get_content_standards`, `get_signals`, `get_creative_delivery`, `get_creative_features`) have a formal Submitted arm in 3.0.11, so applying the same guard uniformly would defend against a spec violation the SDK should surface via response validation rather than silently route around.
+
+Regression test in `test/lib/seed-get-products-wiring.test.js` verifies the bridge leaves a `{ status: 'submitted', task_id, message }` envelope unmodified — no `products` spread, no `sandbox` stamp.

--- a/src/lib/server/test-controller-bridge.ts
+++ b/src/lib/server/test-controller-bridge.ts
@@ -490,13 +490,19 @@ function isSubmittedArm(value: unknown): boolean {
  *
  * **Submitted-arm short-circuit.** `get_products` formally permits an
  * async Submitted arm per `schemas/cache/3.0.11/media-buy/get-products-async-response-submitted.json`
- * (queued custom/bespoke curation). When the handler returns
- * `{ status: 'submitted', task_id }`, spreading `products: [...]` into
- * that envelope produces an invalid hybrid wire shape. Detect the
- * Submitted shape and return the handler response reference-equal,
- * which signals the dispatcher to skip the re-wrap. None of the other
- * 12 bridged read tools have a formal Submitted arm in 3.0.11; this
- * guard is `get_products`-specific defense rather than a uniform
+ * (queued custom/bespoke curation). The dispatcher routes
+ * `{ status: 'submitted', task_id }` handler returns through
+ * `wrapSubmittedEnvelope`, but the bridge merge then receives the
+ * unwrapped Submitted body from `formatted.structuredContent`. Without
+ * this guard, the merge would spread `products: [...]` into that body
+ * and produce a `{ status: 'submitted', task_id, products: [...], sandbox: true }`
+ * hybrid that violates the wire schema. Detect the Submitted shape and
+ * return the handler response reference-equal so the dispatcher's
+ * skip-on-reference-equality wrap-avoidance kicks in.
+ *
+ * None of the other 12 bridged read tools have a formal Submitted arm
+ * in 3.0.11 per `schemas/cache/3.0.11/core/async-response-data.json`;
+ * this guard is `get_products`-specific defense rather than a uniform
  * pattern across helpers.
  */
 export function mergeSeededProductsIntoResponse(

--- a/src/lib/server/test-controller-bridge.ts
+++ b/src/lib/server/test-controller-bridge.ts
@@ -457,6 +457,25 @@ export function isSandboxRequest(input: Record<string, unknown>): boolean {
 }
 
 /**
+ * Detect the Submitted-arm shape (`{ status: 'submitted', task_id }`) on a
+ * read-tool response payload. `get_products` formally permits this arm per
+ * `schemas/cache/3.0.11/media-buy/get-products-async-response-submitted.json`
+ * (queued custom/bespoke product curation); the dispatcher's
+ * `isSubmittedEnvelope` routes the wrap, but the bridge merge runs after
+ * wrap and would spread `products: [...]` into the Submitted envelope
+ * without this guard.
+ *
+ * Mirrors the `isSubmittedEnvelope` predicate at
+ * `src/lib/server/create-adcp-server.ts` — kept local rather than imported
+ * because that helper lives inside the dispatcher closure.
+ */
+function isSubmittedArm(value: unknown): boolean {
+  if (value == null || typeof value !== 'object') return false;
+  const obj = value as Record<string, unknown>;
+  return obj.status === 'submitted' && typeof obj.task_id === 'string';
+}
+
+/**
  * Merge seeded products into a `get_products` response payload.
  *
  * Existing products from the handler come first; seeded entries append
@@ -468,12 +487,24 @@ export function isSandboxRequest(input: Record<string, unknown>): boolean {
  * handler explicitly declared `sandbox: false` (which stays authoritative
  * — a handler that has already decided the request is non-sandbox
  * shouldn't be overridden by the bridge).
+ *
+ * **Submitted-arm short-circuit.** `get_products` formally permits an
+ * async Submitted arm per `schemas/cache/3.0.11/media-buy/get-products-async-response-submitted.json`
+ * (queued custom/bespoke curation). When the handler returns
+ * `{ status: 'submitted', task_id }`, spreading `products: [...]` into
+ * that envelope produces an invalid hybrid wire shape. Detect the
+ * Submitted shape and return the handler response reference-equal,
+ * which signals the dispatcher to skip the re-wrap. None of the other
+ * 12 bridged read tools have a formal Submitted arm in 3.0.11; this
+ * guard is `get_products`-specific defense rather than a uniform
+ * pattern across helpers.
  */
 export function mergeSeededProductsIntoResponse(
   response: GetProductsResponse,
   seeded: readonly Product[]
 ): GetProductsResponse {
   if (!seeded.length) return response;
+  if (isSubmittedArm(response)) return response;
 
   const seededIds = new Set<string>();
   for (const p of seeded) seededIds.add(p.product_id);

--- a/test/lib/seed-get-products-wiring.test.js
+++ b/test/lib/seed-get-products-wiring.test.js
@@ -391,4 +391,51 @@ describe('createAdcpServer — seeded get_products under strict response validat
     );
     assert.strictEqual(payload.sandbox, true);
   });
+
+  // ---------------------------------------------------------------------------
+  // Submitted-arm guard
+  //
+  // `get_products` formally permits an async Submitted arm per
+  // `schemas/cache/3.0.11/media-buy/get-products-async-response-submitted.json`
+  // (queued custom / bespoke product curation). When the handler returns
+  // `{ status: 'submitted', task_id }`, the dispatcher's `isSubmittedEnvelope`
+  // routes it through `wrapSubmittedEnvelope` rather than the success-arm
+  // builder — but the bridge merge runs after that, and without a guard would
+  // spread `products: [...]` into the Submitted envelope, producing a
+  // `{ status: 'submitted', task_id, products: [...], sandbox: true }`
+  // hybrid that violates the wire schema. Verify the merge helper detects
+  // the Submitted shape and leaves the envelope unmodified.
+  // ---------------------------------------------------------------------------
+  it('leaves a Submitted envelope unmodified (does not spread products into async arm)', async () => {
+    const server = createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      mediaBuy: {
+        getProducts: async () => ({
+          status: 'submitted',
+          task_id: 'task-abc-123',
+          message: 'Custom product curation queued',
+        }),
+      },
+      testController: {
+        getSeededProducts: () => [makeSeededProduct('seed-leaked', { name: 'Should not appear' })],
+      },
+    });
+    const result = await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'get_products',
+        arguments: {
+          brief: 'premium',
+          buying_mode: 'brief',
+          account: { brand: { domain: 'example.com' }, operator: 'example.com', sandbox: true },
+        },
+      },
+    });
+    const payload = result.structuredContent;
+    assert.strictEqual(payload.status, 'submitted');
+    assert.strictEqual(payload.task_id, 'task-abc-123');
+    assert.strictEqual(payload.products, undefined, 'merge must not spread products into Submitted envelope');
+    assert.strictEqual(payload.sandbox, undefined, 'merge must not stamp sandbox onto Submitted envelope');
+  });
 });


### PR DESCRIPTION
## Summary

- `get_products` formally permits an async Submitted arm per AdCP 3.0.11 (`schemas/cache/3.0.11/media-buy/get-products-async-response-submitted.json`) for queued custom / bespoke product curation.
- When a handler returns `{ status: 'submitted', task_id, message? }`, the dispatcher routes it through `wrapSubmittedEnvelope` — but the bridge merge runs after wrap and would spread `products: [...]` into the Submitted envelope, producing an invalid hybrid wire shape: `{ status: 'submitted', task_id, products: [...], sandbox: true }`.
- Detect the Submitted shape in the merge helper and short-circuit (reference-equal return). One regression test.

## Scope

`get_products` only. The other 12 bridged read tools (`list_creatives`, `get_media_buys`, `get_media_buy_delivery`, `list_accounts`, `get_account_financials`, `list_creative_formats`, `list_property_lists`, `get_property_list`, `list_collection_lists`, `get_collection_list`, `list_content_standards`, `get_content_standards`, `get_signals`, `get_creative_delivery`, `get_creative_features`) do NOT have a formal Submitted arm in 3.0.11 — a uniform guard across all helpers would defend against a spec violation the SDK should surface via response validation rather than silently route around.

## Background

Identified during the post-merge expert review of (now-closed) #1754. Verified during the same review against `schemas/cache/3.0.11/`: only `get_products`, `build_creative`, `create_media_buy`, `update_media_buy`, `sync_creatives`, and `sync_catalogs` have formal Submitted arms in 3.0.11; of those, only `get_products` is bridged. So this is a real latent bug reachable today by any spec-compliant `get_products` handler that defers curation.

## Test plan

- [x] `NODE_ENV=test node --test test/lib/seed-get-products-wiring.test.js` — 14/14 pass (1 new + 13 existing).
- [x] `tsc --noEmit` clean.
- [x] `prettier --check` clean.