### PR TITLE
fix(codegen): pre-merge allOf[$ref] siblings to unbreak jsts union emission

### DIFF
--- a/.changeset/codegen-allof-ref-merge.md
+++ b/.changeset/codegen-allof-ref-merge.md
@@ -1,0 +1,17 @@
+---
+'@adcp/sdk': patch
+---
+
+fix(codegen): pre-merge `allOf: [{ $ref }]` siblings into parent shape (#1756)
+
+`json-schema-to-typescript` mishandles JSON Schema objects that combine `properties` / `required` at their own level with an `allOf: [{ $ref }]` sibling — instead of emitting `BaseFields & { variant-specific }` it emits a broken union `( BaseFields | { variant-specific + duplicated base fields } )`. This is most visible inside `oneOf` discriminator variants, where the success arm of `get_content_standards` collapsed to bare `ContentStandards`, silently dropping the variant's own `context` and `ext` fields.
+
+`enforceStrictSchema` now pre-merges any `allOf` member that is a single `$ref` into the parent schema when the parent already declares its own `properties` / `required` — variant-level fields win on collision, and the base schema's `additionalProperties` is inherited only when the variant didn't override it. Refs we can't resolve through the cache (local `#/$defs/...` fragments, missing schemas) are left in place for jsts to handle as before. The `vendor-pricing-option`-style schemas — allOf-only at root, no sibling properties — are intentionally untouched.
+
+Side effects on existing emitted types:
+
+- `BriefAsset` and `CatalogAsset` change from `CreativeBrief & { asset_type: 'brief' }` / `Catalog & { asset_type: 'catalog' }` aliases to flat interfaces with the merged shape. Field set is identical; the named base reference is gone. Tracked as option 2 in the adcp#4510 acceptance criteria.
+- `GetContentStandardsResponse` success variant now correctly includes its own `context?` and `ext?` fields alongside the merged `ContentStandards` shape (the bug this PR fixes).
+- `CreativeBrief` is no longer transitively pulled into `tools.generated.ts` (it's still emitted in `core.generated.ts`); `src/lib/index.ts` re-exports it from `core.generated` instead.
+
+Unblocks adcp#4510 (schema dedup spike), which the spec team reverted on the bug surfaced by this codegen path.

--- a/scripts/generate-types.ts
+++ b/scripts/generate-types.ts
@@ -192,6 +192,37 @@ function tightenMutualExclusionOneOf(schema: any): any {
 }
 
 /**
+ * Resolve an external `$ref` for the purpose of pre-merging an
+ * `allOf: [{ $ref }]` member into its parent. Returns `null` for
+ * unresolvable refs (including local `#/$defs/...` refs, which require
+ * document context this helper doesn't have). Suppresses the warning that
+ * `loadCachedSchema` would emit for unresolvable paths — a miss here just
+ * means we leave the `allOf` member in place for jsts to handle.
+ */
+function resolveAllOfRefForMerge(ref: string): any | null {
+  if (!ref || typeof ref !== 'string') return null;
+  // Only external schema refs are resolvable through the cache. Local
+  // `#/$defs/...` and other fragment-only refs are left to jsts.
+  if (!ref.startsWith('/schemas/')) return null;
+  // Suppress the warn from loadCachedSchema for legitimate misses (e.g. a
+  // schema path we don't have cached yet). The original `allOf` member stays
+  // in place if resolution fails.
+  const originalWarn = console.warn;
+  console.warn = () => {};
+  let raw: any;
+  try {
+    raw = loadCachedSchema(ref);
+  } finally {
+    console.warn = originalWarn;
+  }
+  if (!raw) return null;
+  // Apply the same preprocessing the ref resolver uses for normal $ref reads —
+  // otherwise minItems/maxItems constraints from the base schema would leak
+  // through the merge and resurrect as `@minItems`/tuple types in jsts output.
+  return removeArrayLengthConstraints(raw);
+}
+
+/**
  * Recursively remove additionalProperties: true from schema to enforce strict typing
  * This prevents [k: string]: unknown in generated TypeScript types
  *
@@ -298,6 +329,69 @@ export function enforceStrictSchema(schema: any): any {
       strictSchema.items = strictSchema.items.map(enforceStrictSchema);
     } else {
       strictSchema.items = enforceStrictSchema(strictSchema.items);
+    }
+  }
+
+  // Pre-merge `allOf: [{ $ref }, ...]` members when the parent has its own
+  // `properties` or `required` at the same level. json-schema-to-typescript
+  // mishandles this pattern (especially inside `oneOf` variants) and emits a
+  // broken union `( BaseFields | { variant-specific + duplicated base fields } )`
+  // where the intent is an intersection `BaseFields & { variant-specific }`.
+  //
+  // Resolving the `$ref` at the JSON Schema level lets jsts see a single flat
+  // shape and emit a clean discriminated-union variant. We only resolve refs
+  // we can load (external `/schemas/...` paths via the cache). Local
+  // `#/$defs/...` refs are left in place — without the parent document we
+  // can't resolve them here, and the existing post-processors handle the
+  // common Individual*Asset alias case.
+  //
+  // The merged shape loses the named base type alias in the emitted TS
+  // (option 2 in the adcp#4510 acceptance criteria: "flattens the allOf into
+  // a single merged shape — less ideal but acceptable"). Recovering the
+  // intersection form would be a follow-up polish pass.
+  //
+  // We only apply this merge when the parent already declares its own
+  // `properties` or `required` siblings — the `vendor-pricing-option` style
+  // (allOf-only at root, no sibling properties) compiles correctly today and
+  // is left untouched.
+  if (
+    Array.isArray(strictSchema.allOf) &&
+    (strictSchema.properties || strictSchema.required) &&
+    !mustPreserveProperties
+  ) {
+    const remaining: any[] = [];
+    for (const member of strictSchema.allOf) {
+      if (member && typeof member === 'object' && typeof member.$ref === 'string' && Object.keys(member).length === 1) {
+        const resolved = resolveAllOfRefForMerge(member.$ref);
+        if (resolved) {
+          // Variant-level fields win on collision — `properties`, `required`,
+          // and `additionalProperties` are merged with variant precedence.
+          strictSchema.properties = {
+            ...(resolved.properties ?? {}),
+            ...(strictSchema.properties ?? {}),
+          };
+          const mergedRequired = [...(resolved.required ?? []), ...(strictSchema.required ?? [])];
+          if (mergedRequired.length > 0) {
+            strictSchema.required = [...new Set(mergedRequired)];
+          }
+          if (strictSchema.additionalProperties === undefined && resolved.additionalProperties !== undefined) {
+            strictSchema.additionalProperties = resolved.additionalProperties;
+          }
+          continue;
+        }
+      }
+      remaining.push(member);
+    }
+    strictSchema.allOf = remaining;
+    if (strictSchema.allOf.length === 0) {
+      delete strictSchema.allOf;
+    }
+    // Re-run property recursion now that we've merged in base properties —
+    // they may themselves carry allOf/$ref patterns that need normalizing.
+    if (strictSchema.properties) {
+      strictSchema.properties = Object.fromEntries(
+        Object.entries(strictSchema.properties).map(([key, value]) => [key, enforceStrictSchema(value)])
+      );
     }
   }
 

--- a/scripts/generate-types.ts
+++ b/scripts/generate-types.ts
@@ -219,7 +219,17 @@ function resolveAllOfRefForMerge(ref: string): any | null {
   // Apply the same preprocessing the ref resolver uses for normal $ref reads —
   // otherwise minItems/maxItems constraints from the base schema would leak
   // through the merge and resurrect as `@minItems`/tuple types in jsts output.
-  return removeArrayLengthConstraints(raw);
+  const preprocessed = removeArrayLengthConstraints(raw);
+  // Normalize the resolved base through the same strict-schema pipeline the
+  // parent went through. Without this, a base schema's top-level
+  // `additionalProperties: true` (e.g. creative-brief.json, catalog.json)
+  // would propagate into the merged shape and emit a
+  // `[k: string]: unknown | undefined` index signature on the resulting flat
+  // interface — wider than the pre-merge intersection form. Recursion is
+  // safe: `loadCachedSchema` reads a fresh JSON document per call (no shared
+  // mutable cache), and AdCP schemas aren't cyclic at the `allOf:[{ $ref }]`
+  // sibling level, so transitive base resolution terminates.
+  return enforceStrictSchema(preprocessed);
 }
 
 /**

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -477,7 +477,6 @@ export type {
   // Format Assets
   Overlay,
   // Creative Agent Domain
-  CreativeBrief,
   CreativeManifest,
   CreativeVariable,
   BuildCreativeRequest,
@@ -542,6 +541,10 @@ export type {
   CatalogAction,
   CatalogItemStatus,
   MediaBuyStatus,
+  // CreativeBrief is its own top-level schema (creative-brief.json) — emitted
+  // in core.generated, no longer transitively pulled into tools.generated now
+  // that BriefAsset merges its allOf[$ref] base inline.
+  CreativeBrief,
 } from './types/core.generated';
 
 // ====== ERROR CODES ======

--- a/src/lib/types/core.generated.ts
+++ b/src/lib/types/core.generated.ts
@@ -1,5 +1,5 @@
 // Generated AdCP core types from official schemas v3.0.11
-// Generated at: 2026-05-16T10:00:09.042Z
+// Generated at: 2026-05-16T11:37:34.319Z
 
 // MEDIA-BUY SCHEMA
 /**
@@ -1574,24 +1574,6 @@ export type DAASTTrackingEvent =
  */
 export type MarkdownFlavor = 'commonmark' | 'gfm';
 /**
- * Campaign-level creative context as an asset. Carries the creative brief through the manifest so it travels with the creative through regeneration, resizing, and auditing.
- */
-export type BriefAsset = CreativeBrief & {
-  /**
-   * Discriminator identifying this as a brief asset. See /schemas/creative/asset-types for the registry.
-   */
-  asset_type: 'brief';
-};
-/**
- * A typed data feed as a creative asset. Carries catalog context (products, stores, jobs, etc.) within the manifest's assets map.
- */
-export type CatalogAsset = Catalog & {
-  /**
-   * Discriminator identifying this as a catalog asset. See /schemas/creative/asset-types for the registry.
-   */
-  asset_type: 'catalog';
-};
-/**
  * For generative creatives: set to 'approved' to finalize, 'rejected' to request regeneration with updated assets/message. Omit for non-generative creatives (system will set based on processing state).
  */
 export type CreativeStatus = 'processing' | 'pending_review' | 'approved' | 'rejected' | 'archived';
@@ -2197,9 +2179,9 @@ export interface MarkdownAsset {
   allow_raw_html?: boolean;
 }
 /**
- * Campaign-level creative context for AI-powered creative generation. Provides the layer between brand identity (stable across campaigns) and individual creative execution (per-request). A brand has one identity (defined in brand.json) but different creative briefs for each campaign or flight.
+ * Campaign-level creative context as an asset. Carries the creative brief through the manifest so it travels with the creative through regeneration, resizing, and auditing.
  */
-export interface CreativeBrief {
+export interface BriefAsset {
   /**
    * Campaign or flight name for identification
    */
@@ -2268,7 +2250,6 @@ export interface CreativeBrief {
       regulation?: string;
       /**
        * Minimum display duration in milliseconds. For video/audio disclosures, how long the disclosure must be visible or audible. For static formats, how long the disclosure must remain on screen before any auto-advance.
-       * @minimum 1
        */
       min_duration_ms?: number;
       /**
@@ -2282,6 +2263,10 @@ export interface CreativeBrief {
      */
     prohibited_claims?: string[];
   };
+  /**
+   * Discriminator identifying this as a brief asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'brief';
 }
 /**
  * A reference asset that provides creative context. Carries visual materials (mood boards, product shots, example creatives) with semantic roles that tell creative agents how to use them.
@@ -2299,6 +2284,63 @@ export interface ReferenceAsset {
    * Human-readable description of the asset and how it should inform creative generation
    */
   description?: string;
+}
+/**
+ * A typed data feed as a creative asset. Carries catalog context (products, stores, jobs, etc.) within the manifest's assets map.
+ */
+export interface CatalogAsset {
+  /**
+   * Buyer's identifier for this catalog. Required when syncing via sync_catalogs. When used in creatives, references a previously synced catalog on the account.
+   */
+  catalog_id?: string;
+  /**
+   * Human-readable name for this catalog (e.g., 'Summer Products 2025', 'Amsterdam Store Locations').
+   */
+  name?: string;
+  type: CatalogType;
+  /**
+   * URL to an external catalog feed. The platform fetches and resolves items from this URL. For offering-type catalogs, the feed contains an array of Offering objects. For other types, the feed format is determined by feed_format. When omitted with type 'product', the platform uses its synced copy of the brand's product catalog.
+   */
+  url?: string;
+  feed_format?: FeedFormat;
+  update_frequency?: UpdateFrequency;
+  /**
+   * Inline catalog data. The item schema depends on the catalog type: Offering objects for 'offering', StoreItem for 'store', HotelItem for 'hotel', FlightItem for 'flight', JobItem for 'job', VehicleItem for 'vehicle', RealEstateItem for 'real_estate', EducationItem for 'education', DestinationItem for 'destination', AppItem for 'app', or freeform objects for 'product', 'inventory', and 'promotion'. Mutually exclusive with url — provide one or the other, not both. Implementations should validate items against the type-specific schema.
+   */
+  items?: {}[];
+  /**
+   * Filter catalog to specific item IDs. For offering-type catalogs, these are offering_id values. For product-type catalogs, these are SKU identifiers.
+   */
+  ids?: string[];
+  /**
+   * Filter product-type catalogs by GTIN identifiers for cross-retailer catalog matching. Accepts standard GTIN formats (GTIN-8, UPC-A/GTIN-12, EAN-13/GTIN-13, GTIN-14). Only applicable when type is 'product'.
+   */
+  gtins?: string[];
+  /**
+   * Filter catalog to items with these tags. Tags are matched using OR logic — items matching any tag are included.
+   */
+  tags?: string[];
+  /**
+   * Filter catalog to items in this category (e.g., 'beverages/soft-drinks', 'chef-positions').
+   */
+  category?: string;
+  /**
+   * Natural language filter for catalog items (e.g., 'all pasta sauces under $5', 'amsterdam vacancies').
+   */
+  query?: string;
+  /**
+   * Event types that represent conversions for items in this catalog. Declares what events the platform should attribute to catalog items — e.g., a job catalog converts via submit_application, a product catalog via purchase. The event's content_ids field carries the item IDs that connect back to catalog items. Use content_id_type to declare what identifier type content_ids values represent.
+   */
+  conversion_events?: EventType[];
+  content_id_type?: ContentIDType;
+  /**
+   * Declarative normalization rules for external feeds. Maps non-standard feed field names, date formats, price encodings, and image URLs to the AdCP catalog item schema. Applied during sync_catalogs ingestion. Supports field renames, named transforms (date, divide, boolean, split), static literal injection, and assignment of image URLs to typed asset pools.
+   */
+  feed_field_mappings?: CatalogFieldMapping[];
+  /**
+   * Discriminator identifying this as a catalog asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'catalog';
 }
 /**
  * An industry-standard identifier for an advertising creative (e.g., Ad-ID, ISCI, Clearcast clock number). These identifiers are managed by external registries and used across the supply chain to track and reference specific creative assets.
@@ -8977,6 +9019,93 @@ export interface DeliveryMetrics {
      */
     value?: number;
   }[];
+}
+/**
+ * Campaign-level creative context for AI-powered creative generation. Provides the layer between brand identity (stable across campaigns) and individual creative execution (per-request). A brand has one identity (defined in brand.json) but different creative briefs for each campaign or flight.
+ */
+export interface CreativeBrief {
+  /**
+   * Campaign or flight name for identification
+   */
+  name: string;
+  /**
+   * Campaign objective that guides creative tone and call-to-action strategy
+   */
+  objective?: 'awareness' | 'consideration' | 'conversion' | 'retention' | 'engagement';
+  /**
+   * Desired tone for this campaign, modulating the brand's base tone (e.g., 'playful and festive', 'premium and aspirational')
+   */
+  tone?: string;
+  /**
+   * Target audience description for this campaign
+   */
+  audience?: string;
+  /**
+   * Creative territory or positioning the campaign should occupy
+   */
+  territory?: string;
+  /**
+   * Messaging framework for the campaign
+   */
+  messaging?: {
+    /**
+     * Primary headline
+     */
+    headline?: string;
+    /**
+     * Supporting tagline or sub-headline
+     */
+    tagline?: string;
+    /**
+     * Call-to-action text
+     */
+    cta?: string;
+    /**
+     * Key messages to communicate in priority order
+     */
+    key_messages?: string[];
+  };
+  /**
+   * Visual and strategic reference materials such as mood boards, product shots, example creatives, and strategy documents
+   */
+  reference_assets?: ReferenceAsset[];
+  /**
+   * Regulatory and legal compliance requirements for this campaign. Campaign-specific, regional, and product-based — distinct from brand-level disclaimers in brand.json.
+   */
+  compliance?: {
+    /**
+     * Disclosures that must appear in creatives for this campaign. Each disclosure specifies the text, where it should appear, and which jurisdictions require it.
+     */
+    required_disclosures?: {
+      /**
+       * The disclosure text that must appear in the creative
+       */
+      text: string;
+      position?: DisclosurePosition;
+      /**
+       * Jurisdictions where this disclosure is required. ISO 3166-1 alpha-2 country codes or ISO 3166-2 subdivision codes (e.g., 'US', 'GB', 'US-NJ', 'CA-QC'). If omitted, the disclosure applies to all jurisdictions in the campaign.
+       */
+      jurisdictions?: string[];
+      /**
+       * The regulation or legal authority requiring this disclosure (e.g., 'SEC Rule 156', 'FCA COBS 4.5', 'FDA 21 CFR 202')
+       */
+      regulation?: string;
+      /**
+       * Minimum display duration in milliseconds. For video/audio disclosures, how long the disclosure must be visible or audible. For static formats, how long the disclosure must remain on screen before any auto-advance.
+       * @minimum 1
+       */
+      min_duration_ms?: number;
+      /**
+       * Language of the disclosure text as a BCP 47 language tag (e.g., 'en', 'fr-CA', 'es'). When omitted, the disclosure is assumed to match the creative's language.
+       */
+      language?: string;
+      persistence?: DisclosurePersistence;
+    }[];
+    /**
+     * Claims that must not appear in creatives for this campaign. Creative agents should ensure generated content avoids these claims.
+     */
+    prohibited_claims?: string[];
+  };
 }
 /**
  * Property where the artifact appears

--- a/src/lib/types/inline-enums.generated.ts
+++ b/src/lib/types/inline-enums.generated.ts
@@ -39,6 +39,11 @@ export const AudioAssetRequirements_FormatsValues = ["mp3", "aac", "wav", "ogg",
 /** single | AuthorizationResult.status */
 export const AuthorizationResult_StatusValues = ["authorized", "unauthorized", "unknown"] as const;
 
+// ====== BriefAsset ======
+
+/** single | BriefAsset.objective */
+export const BriefAsset_ObjectiveValues = ["awareness", "consideration", "conversion", "retention", "engagement"] as const;
+
 // ====== BuildCreativeAsyncInputRequired ======
 
 /** single | BuildCreativeAsyncInputRequired.reason */
@@ -63,11 +68,6 @@ export const ControllerError_ErrorValues = ["INVALID_TRANSITION", "INVALID_STATE
 
 /** single | CreateMediaBuyAsyncInputRequired.reason */
 export const CreateMediaBuyAsyncInputRequired_ReasonValues = ["APPROVAL_REQUIRED", "BUDGET_EXCEEDS_LIMIT"] as const;
-
-// ====== CreativeBrief ======
-
-/** single | CreativeBrief.objective */
-export const CreativeBrief_ObjectiveValues = ["awareness", "consideration", "conversion", "retention", "engagement"] as const;
 
 // ====== CreativeVariable ======
 
@@ -355,6 +355,12 @@ export const VideoAssetRequirements_ContainersValues = ["mp4", "webm", "mov", "a
 // imports to the canonical name; aliases remain for one minor
 // version. (adcp-client#941)
 
+// --- BriefAsset1 ---
+/** @deprecated use `BriefAsset_ObjectiveValues` — same literal set, BriefAsset1.objective duplicates the canonical export. */
+export const BriefAsset1_ObjectiveValues = BriefAsset_ObjectiveValues;
+// --- CreativeBrief ---
+/** @deprecated use `BriefAsset_ObjectiveValues` — same literal set, CreativeBrief.objective duplicates the canonical export. */
+export const CreativeBrief_ObjectiveValues = BriefAsset_ObjectiveValues;
 // --- GetBrandIdentitySuccess ---
 /** @deprecated use `GetBrandIdentityRequest_FieldsValues` — same literal set, GetBrandIdentitySuccess.available_fields duplicates the canonical export. */
 export const GetBrandIdentitySuccess_AvailableFieldsValues = GetBrandIdentityRequest_FieldsValues;

--- a/src/lib/types/schemas.generated.ts
+++ b/src/lib/types/schemas.generated.ts
@@ -1,5 +1,5 @@
 // Generated Zod v4 schemas from TypeScript types
-// Generated at: 2026-05-16T10:00:13.471Z
+// Generated at: 2026-05-16T11:37:37.881Z
 // Sources:
 //   - core.generated.ts (core types)
 //   - tools.generated.ts (tool types)
@@ -221,6 +221,25 @@ export const CollectionListReferenceSchema = z.object({
     auth_token: z.string().optional()
 }).passthrough();
 
+export const CatalogAssetSchema = z.object({
+    catalog_id: z.string().optional(),
+    name: z.string().optional(),
+    type: CatalogTypeSchema,
+    url: z.string().optional(),
+    feed_format: FeedFormatSchema.optional(),
+    update_frequency: UpdateFrequencySchema.optional(),
+    items: z.array(z.object({}).passthrough()).optional(),
+    ids: z.array(z.string()).optional(),
+    gtins: z.array(z.string()).optional(),
+    tags: z.array(z.string()).optional(),
+    category: z.string().optional(),
+    query: z.string().optional(),
+    conversion_events: z.array(EventTypeSchema).optional(),
+    content_id_type: ContentIDTypeSchema.optional(),
+    feed_field_mappings: z.array(CatalogFieldMappingSchema).optional(),
+    asset_type: z.literal("catalog")
+}).passthrough();
+
 export const DigitalSourceTypeSchema = z.union([z.literal("digital_capture"), z.literal("digital_creation"), z.literal("trained_algorithmic_media"), z.literal("composite_with_trained_algorithmic_media"), z.literal("algorithmic_media"), z.literal("composite_capture"), z.literal("composite_synthetic"), z.literal("human_edits"), z.literal("data_driven_media")]);
 
 export const DisclosurePersistenceSchema = z.union([z.literal("continuous"), z.literal("initial"), z.literal("flexible")]);
@@ -300,24 +319,6 @@ export const DAASTVersionSchema = z.union([z.literal("1.0"), z.literal("1.1")]);
 export const DAASTTrackingEventSchema = z.union([z.literal("impression"), z.literal("creativeView"), z.literal("loaded"), z.literal("start"), z.literal("firstQuartile"), z.literal("midpoint"), z.literal("thirdQuartile"), z.literal("complete"), z.literal("mute"), z.literal("unmute"), z.literal("pause"), z.literal("resume"), z.literal("skip"), z.literal("progress"), z.literal("clickTracking"), z.literal("customClick"), z.literal("close"), z.literal("error"), z.literal("viewable"), z.literal("notViewable"), z.literal("viewUndetermined"), z.literal("measurableImpression"), z.literal("viewableImpression")]);
 
 export const MarkdownFlavorSchema = z.union([z.literal("commonmark"), z.literal("gfm")]);
-
-export const CatalogSchema = z.object({
-    catalog_id: z.string().optional(),
-    name: z.string().optional(),
-    type: CatalogTypeSchema,
-    url: z.string().optional(),
-    feed_format: FeedFormatSchema.optional(),
-    update_frequency: UpdateFrequencySchema.optional(),
-    items: z.array(z.object({}).passthrough()).optional(),
-    ids: z.array(z.string()).optional(),
-    gtins: z.array(z.string()).optional(),
-    tags: z.array(z.string()).optional(),
-    category: z.string().optional(),
-    query: z.string().optional(),
-    conversion_events: z.array(EventTypeSchema).optional(),
-    content_id_type: ContentIDTypeSchema.optional(),
-    feed_field_mappings: z.array(CatalogFieldMappingSchema).optional()
-}).passthrough();
 
 export const CreativeStatusSchema = z.union([z.literal("processing"), z.literal("pending_review"), z.literal("approved"), z.literal("rejected"), z.literal("archived")]);
 
@@ -2098,6 +2099,33 @@ export const IdentifierSchema = z.object({
     value: z.string()
 }).passthrough();
 
+export const CreativeBriefSchema = z.object({
+    name: z.string(),
+    objective: z.union([z.literal("awareness"), z.literal("consideration"), z.literal("conversion"), z.literal("retention"), z.literal("engagement")]).optional(),
+    tone: z.string().optional(),
+    audience: z.string().optional(),
+    territory: z.string().optional(),
+    messaging: z.object({
+        headline: z.string().optional(),
+        tagline: z.string().optional(),
+        cta: z.string().optional(),
+        key_messages: z.array(z.string()).optional()
+    }).passthrough().optional(),
+    reference_assets: z.array(ReferenceAssetSchema).optional(),
+    compliance: z.object({
+        required_disclosures: z.array(z.object({
+            text: z.string(),
+            position: DisclosurePositionSchema.optional(),
+            jurisdictions: z.array(z.string()).optional(),
+            regulation: z.string().optional(),
+            min_duration_ms: z.number().min(1).optional(),
+            language: z.string().optional(),
+            persistence: DisclosurePersistenceSchema.optional()
+        }).passthrough()).optional(),
+        prohibited_claims: z.array(z.string()).optional()
+    }).passthrough().optional()
+}).passthrough();
+
 export const CreativeFeatureResultSchema = z.object({
     feature_id: z.string(),
     value: z.union([z.boolean(), z.number(), z.string()]),
@@ -2217,9 +2245,35 @@ export const DAASTAssetSchema = z.object({
         content: z.string()
     }).passthrough()]));
 
-export const CatalogAssetSchema = CatalogSchema.and(z.object({
-    asset_type: z.literal("catalog")
-}).passthrough());
+export const BriefAssetSchema = z.object({
+    name: z.string(),
+    objective: z.union([z.literal("awareness"), z.literal("consideration"), z.literal("conversion"), z.literal("retention"), z.literal("engagement")]).optional(),
+    tone: z.string().optional(),
+    audience: z.string().optional(),
+    territory: z.string().optional(),
+    messaging: z.object({
+        headline: z.string().optional(),
+        tagline: z.string().optional(),
+        cta: z.string().optional(),
+        key_messages: z.array(z.string()).optional()
+    }).passthrough().optional(),
+    reference_assets: z.array(ReferenceAssetSchema).optional(),
+    compliance: z.object({
+        required_disclosures: z.array(z.object({
+            text: z.string(),
+            position: DisclosurePositionSchema.optional(),
+            jurisdictions: z.array(z.string()).optional(),
+            regulation: z.string().optional(),
+            min_duration_ms: z.number().optional(),
+            language: z.string().optional(),
+            persistence: DisclosurePersistenceSchema.optional()
+        }).passthrough()).optional(),
+        prohibited_claims: z.array(z.string()).optional()
+    }).passthrough().optional(),
+    asset_type: z.literal("brief")
+}).passthrough();
+
+export const CatalogAsset1Schema = CatalogAssetSchema;
 
 export const PreviewCreativeSingleResponseSchema = z.object({
     response_type: z.literal("single"),
@@ -2261,6 +2315,24 @@ export const ReportingWebhookSchema = z.object({
     }).passthrough(),
     reporting_frequency: z.union([z.literal("hourly"), z.literal("daily"), z.literal("monthly")]),
     requested_metrics: z.array(AvailableMetricSchema).optional()
+}).passthrough();
+
+export const CatalogSchema = z.object({
+    catalog_id: z.string().optional(),
+    name: z.string().optional(),
+    type: CatalogTypeSchema,
+    url: z.string().optional(),
+    feed_format: FeedFormatSchema.optional(),
+    update_frequency: UpdateFrequencySchema.optional(),
+    items: z.array(z.object({}).passthrough()).optional(),
+    ids: z.array(z.string()).optional(),
+    gtins: z.array(z.string()).optional(),
+    tags: z.array(z.string()).optional(),
+    category: z.string().optional(),
+    query: z.string().optional(),
+    conversion_events: z.array(EventTypeSchema).optional(),
+    content_id_type: ContentIDTypeSchema.optional(),
+    feed_field_mappings: z.array(CatalogFieldMappingSchema).optional()
 }).passthrough();
 
 export const TargetingOverlaySchema = z.object({
@@ -4163,31 +4235,24 @@ export const VendorPricingOptionSchema = z.object({
 
 export const GroupAssetSlotSchema = z.union([GroupImageAssetSchema, GroupVideoAssetSchema, GroupAudioAssetSchema, GroupTextAssetSchema, GroupMarkdownAssetSchema, GroupHtmlAssetSchema, GroupCssAssetSchema, GroupJavaScriptAssetSchema, GroupVastAssetSchema, GroupDaastAssetSchema, GroupUrlAssetSchema, GroupWebhookAssetSchema]);
 
-export const CreativeBriefSchema = z.object({
+export const AssetVariantSchema = z.union([ImageAssetSchema, VideoAssetSchema, AudioAssetSchema, VASTAssetSchema, TextAssetSchema, URLAssetSchema, HTMLAssetSchema, JavaScriptAssetSchema, WebhookAssetSchema, CSSAssetSchema, DAASTAssetSchema, MarkdownAssetSchema, BriefAssetSchema, CatalogAssetSchema]);
+
+export const CreativeAssetSchema = z.object({
+    creative_id: z.string(),
     name: z.string(),
-    objective: z.union([z.literal("awareness"), z.literal("consideration"), z.literal("conversion"), z.literal("retention"), z.literal("engagement")]).optional(),
-    tone: z.string().optional(),
-    audience: z.string().optional(),
-    territory: z.string().optional(),
-    messaging: z.object({
-        headline: z.string().optional(),
-        tagline: z.string().optional(),
-        cta: z.string().optional(),
-        key_messages: z.array(z.string()).optional()
-    }).passthrough().optional(),
-    reference_assets: z.array(ReferenceAssetSchema).optional(),
-    compliance: z.object({
-        required_disclosures: z.array(z.object({
-            text: z.string(),
-            position: DisclosurePositionSchema.optional(),
-            jurisdictions: z.array(z.string()).optional(),
-            regulation: z.string().optional(),
-            min_duration_ms: z.number().min(1).optional(),
-            language: z.string().optional(),
-            persistence: DisclosurePersistenceSchema.optional()
-        }).passthrough()).optional(),
-        prohibited_claims: z.array(z.string()).optional()
-    }).passthrough().optional()
+    format_id: FormatReferenceStructuredObjectSchema,
+    assets: z.record(z.string(), AssetVariantSchema),
+    inputs: z.array(z.object({
+        name: z.string(),
+        macros: z.record(z.string(), z.string()).optional(),
+        context_description: z.string().optional()
+    }).passthrough()).optional(),
+    tags: z.array(z.string()).optional(),
+    status: CreativeStatusSchema.optional(),
+    weight: z.number().min(0).max(100).optional(),
+    placement_ids: z.array(z.string()).optional(),
+    industry_identifiers: z.array(IndustryIdentifierSchema).optional(),
+    provenance: ProvenanceSchema.optional()
 }).passthrough();
 
 export const PackageSchema = z.object({
@@ -4237,6 +4302,67 @@ export const PlannedDeliverySchema = z.object({
     total_budget: z.number().min(0).optional(),
     currency: z.string().regex(/^[A-Z]{3}$/).optional(),
     enforced_policies: z.array(z.string()).optional(),
+    ext: ExtensionObjectSchema.optional()
+}).passthrough();
+
+export const PackageUpdateSchema = z.object({
+    package_id: z.string(),
+    budget: z.number().min(0).optional(),
+    pacing: PacingSchema.optional(),
+    bid_price: z.number().min(0).optional(),
+    impressions: z.number().min(0).optional(),
+    start_time: z.iso.datetime().optional(),
+    end_time: z.iso.datetime().optional(),
+    paused: z.boolean().optional(),
+    canceled: z.literal(true).optional(),
+    cancellation_reason: z.string().max(500).optional(),
+    catalogs: z.array(CatalogSchema).optional(),
+    optimization_goals: z.array(OptimizationGoalSchema).optional(),
+    targeting_overlay: TargetingOverlaySchema.optional(),
+    keyword_targets_add: z.array(z.object({
+        keyword: z.string().min(1),
+        match_type: MatchTypeSchema,
+        bid_price: z.number().min(0).optional()
+    }).passthrough()).optional(),
+    keyword_targets_remove: z.array(z.object({
+        keyword: z.string().min(1),
+        match_type: MatchTypeSchema
+    }).passthrough()).optional(),
+    negative_keywords_add: z.array(z.object({
+        keyword: z.string().min(1),
+        match_type: MatchTypeSchema
+    }).passthrough()).optional(),
+    negative_keywords_remove: z.array(z.object({
+        keyword: z.string().min(1),
+        match_type: MatchTypeSchema
+    }).passthrough()).optional(),
+    creative_assignments: z.array(CreativeAssignmentSchema).optional(),
+    creatives: z.array(CreativeAssetSchema).optional(),
+    context: ContextObjectSchema.optional(),
+    ext: ExtensionObjectSchema.optional()
+}).passthrough();
+
+export const PackageRequestSchema = z.object({
+    adcp_major_version: z.number().min(1).max(99).optional(),
+    product_id: z.string(),
+    format_ids: z.array(FormatReferenceStructuredObjectSchema).optional(),
+    budget: z.number().min(0),
+    pacing: PacingSchema.optional(),
+    pricing_option_id: z.string(),
+    bid_price: z.number().min(0).optional(),
+    impressions: z.number().min(0).optional(),
+    start_time: z.iso.datetime().optional(),
+    end_time: z.iso.datetime().optional(),
+    paused: z.boolean().optional(),
+    catalogs: z.array(CatalogSchema).optional(),
+    optimization_goals: z.array(OptimizationGoalSchema).optional(),
+    targeting_overlay: TargetingOverlaySchema.optional(),
+    measurement_terms: MeasurementTermsSchema.optional(),
+    performance_standards: z.array(PerformanceStandardSchema).optional(),
+    creative_assignments: z.array(CreativeAssignmentSchema).optional(),
+    creatives: z.array(CreativeAssetSchema).optional(),
+    agency_estimate_number: z.string().max(100).optional(),
+    context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
@@ -4462,9 +4588,159 @@ export const SyncAudiencesResponseSchema = z.union([SyncAudiencesSuccessSchema, 
 
 export const SyncCatalogsResponseSchema = z.union([SyncCatalogsSuccessSchema, SyncCatalogsErrorSchema]);
 
+export const CreativeManifestSchema = z.object({
+    format_id: FormatReferenceStructuredObjectSchema,
+    assets: z.record(z.string(), AssetVariantSchema),
+    rights: z.array(RightsConstraintSchema).optional(),
+    industry_identifiers: z.array(IndustryIdentifierSchema).optional(),
+    provenance: ProvenanceSchema.optional(),
+    ext: ExtensionObjectSchema.optional()
+}).passthrough();
+
+export const BuildCreativeSuccessSchema = z.object({
+    creative_manifest: CreativeManifestSchema,
+    sandbox: z.boolean().optional(),
+    expires_at: z.iso.datetime().optional(),
+    preview: z.object({
+        previews: z.array(z.object({
+            preview_id: z.string(),
+            renders: z.array(PreviewRenderSchema),
+            input: z.object({
+                name: z.string(),
+                macros: z.record(z.string(), z.string()).optional(),
+                context_description: z.string().optional()
+            }).passthrough()
+        }).passthrough()),
+        interactive_url: z.string().optional(),
+        expires_at: z.iso.datetime()
+    }).passthrough().optional(),
+    preview_error: ErrorSchema.optional(),
+    pricing_option_id: z.string().optional(),
+    vendor_cost: z.number().min(0).optional(),
+    currency: z.string().regex(/^[A-Z]{3}$/).optional(),
+    consumption: CreativeConsumptionSchema.optional(),
+    context: ContextObjectSchema.optional(),
+    ext: ExtensionObjectSchema.optional()
+}).passthrough();
+
+export const BuildCreativeMultiSuccessSchema = z.object({
+    creative_manifests: z.array(CreativeManifestSchema),
+    sandbox: z.boolean().optional(),
+    expires_at: z.iso.datetime().optional(),
+    preview: z.object({
+        previews: z.array(z.object({
+            preview_id: z.string(),
+            format_id: FormatReferenceStructuredObjectSchema,
+            renders: z.array(PreviewRenderSchema),
+            input: z.object({
+                name: z.string(),
+                macros: z.record(z.string(), z.string()).optional(),
+                context_description: z.string().optional()
+            }).passthrough()
+        }).passthrough()),
+        interactive_url: z.string().optional(),
+        expires_at: z.iso.datetime()
+    }).passthrough().optional(),
+    preview_error: ErrorSchema.optional(),
+    pricing_option_id: z.string().optional(),
+    vendor_cost: z.number().min(0).optional(),
+    currency: z.string().regex(/^[A-Z]{3}$/).optional(),
+    consumption: CreativeConsumptionSchema.optional(),
+    context: ContextObjectSchema.optional(),
+    ext: ExtensionObjectSchema.optional()
+}).passthrough();
+
+export const PreviewCreativeRequestSchema = z.object({
+    adcp_major_version: z.number().min(1).max(99).optional(),
+    request_type: z.union([z.literal("single"), z.literal("batch"), z.literal("variant")]),
+    creative_manifest: CreativeManifestSchema.optional(),
+    format_id: FormatReferenceStructuredObjectSchema.optional(),
+    inputs: z.array(z.object({
+        name: z.string(),
+        macros: z.record(z.string(), z.string()).optional(),
+        context_description: z.string().optional()
+    }).passthrough()).optional(),
+    template_id: z.string().optional(),
+    quality: CreativeQualitySchema.optional(),
+    output_format: PreviewOutputFormatSchema.optional(),
+    item_limit: z.number().min(1).optional(),
+    requests: z.array(z.object({
+        format_id: FormatReferenceStructuredObjectSchema.optional(),
+        creative_manifest: CreativeManifestSchema,
+        inputs: z.array(z.object({
+            name: z.string(),
+            macros: z.record(z.string(), z.string()).optional(),
+            context_description: z.string().optional()
+        }).passthrough()).optional(),
+        template_id: z.string().optional(),
+        quality: CreativeQualitySchema.optional(),
+        output_format: PreviewOutputFormatSchema.optional(),
+        item_limit: z.number().min(1).optional()
+    }).passthrough()).optional(),
+    variant_id: z.string().optional(),
+    creative_id: z.string().optional(),
+    context: ContextObjectSchema.optional(),
+    ext: ExtensionObjectSchema.optional()
+}).passthrough();
+
 export const PreviewCreativeBatchResponseSchema = z.object({
     response_type: z.literal("batch"),
     results: z.array(z.union([PreviewBatchResultSuccessSchema, PreviewBatchResultErrorSchema])),
+    context: ContextObjectSchema.optional(),
+    ext: ExtensionObjectSchema.optional()
+}).passthrough();
+
+export const PreviewCreativeVariantResponseSchema = z.object({
+    response_type: z.literal("variant"),
+    variant_id: z.string(),
+    creative_id: z.string().optional(),
+    previews: z.array(z.object({
+        preview_id: z.string(),
+        renders: z.array(PreviewRenderSchema)
+    }).passthrough()),
+    manifest: CreativeManifestSchema.optional(),
+    expires_at: z.iso.datetime().optional(),
+    context: ContextObjectSchema.optional(),
+    ext: ExtensionObjectSchema.optional()
+}).passthrough();
+
+export const CreativeVariantSchema = DeliveryMetricsSchema.and(z.object({
+    variant_id: z.string(),
+    manifest: CreativeManifestSchema.optional(),
+    generation_context: z.object({
+        context_type: z.string().optional(),
+        artifact: z.object({
+            property_id: IdentifierSchema,
+            artifact_id: z.string()
+        }).passthrough().optional(),
+        ext: ExtensionObjectSchema.optional()
+    }).passthrough().optional()
+}).passthrough());
+
+export const GetCreativeDeliveryResponseSchema = z.object({
+    account_id: z.string().optional(),
+    media_buy_id: z.string().optional(),
+    currency: z.string().regex(/^[A-Z]{3}$/),
+    reporting_period: z.object({
+        start: z.iso.datetime(),
+        end: z.iso.datetime(),
+        timezone: z.string().optional()
+    }).passthrough(),
+    creatives: z.array(z.object({
+        creative_id: z.string(),
+        media_buy_id: z.string().optional(),
+        format_id: FormatReferenceStructuredObjectSchema.optional(),
+        totals: DeliveryMetricsSchema.optional(),
+        variant_count: z.number().min(0).optional(),
+        variants: z.array(CreativeVariantSchema)
+    }).passthrough()),
+    pagination: z.object({
+        limit: z.number().min(1),
+        offset: z.number().min(0),
+        has_more: z.boolean(),
+        total: z.number().min(0).optional()
+    }).passthrough().optional(),
+    errors: z.array(ErrorSchema).optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -4484,6 +4760,81 @@ export const ListCreativesRequestSchema = z.object({
     include_pricing: z.boolean().optional(),
     account: AccountReferenceSchema.optional(),
     fields: z.array(z.union([z.literal("creative_id"), z.literal("name"), z.literal("format_id"), z.literal("status"), z.literal("created_date"), z.literal("updated_date"), z.literal("tags"), z.literal("assignments"), z.literal("snapshot"), z.literal("items"), z.literal("variables"), z.literal("concept"), z.literal("pricing_options")])).optional(),
+    context: ContextObjectSchema.optional(),
+    ext: ExtensionObjectSchema.optional()
+}).passthrough();
+
+export const ListCreativesResponseSchema = z.object({
+    query_summary: z.object({
+        total_matching: z.number().min(0),
+        returned: z.number().min(0),
+        filters_applied: z.array(z.string()).optional(),
+        sort_applied: z.object({
+            field: z.string().optional(),
+            direction: SortDirectionSchema.optional()
+        }).passthrough().optional()
+    }).passthrough(),
+    pagination: PaginationResponseSchema,
+    creatives: z.array(z.object({
+        creative_id: z.string(),
+        account: AccountSchema.optional(),
+        name: z.string(),
+        format_id: FormatReferenceStructuredObjectSchema,
+        status: CreativeStatusSchema,
+        created_date: z.iso.datetime(),
+        updated_date: z.iso.datetime(),
+        assets: z.record(z.string(), AssetVariantSchema).optional(),
+        tags: z.array(z.string()).optional(),
+        concept_id: z.string().optional(),
+        concept_name: z.string().optional(),
+        variables: z.array(CreativeVariableSchema).optional(),
+        assignments: z.object({
+            assignment_count: z.number().min(0),
+            assigned_packages: z.array(z.object({
+                package_id: z.string(),
+                assigned_date: z.iso.datetime()
+            }).passthrough()).optional()
+        }).passthrough().optional(),
+        snapshot: z.object({
+            as_of: z.iso.datetime(),
+            staleness_seconds: z.number().min(0),
+            impressions: z.number().min(0),
+            last_served: z.iso.datetime().optional()
+        }).passthrough().optional(),
+        snapshot_unavailable_reason: SnapshotUnavailableReasonSchema.optional(),
+        items: z.array(CreativeItemSchema).optional(),
+        pricing_options: z.array(VendorPricingOptionSchema).optional()
+    }).passthrough()),
+    format_summary: z.record(z.string(), z.number()).optional(),
+    status_summary: z.object({
+        processing: z.number().min(0).optional(),
+        approved: z.number().min(0).optional(),
+        pending_review: z.number().min(0).optional(),
+        rejected: z.number().min(0).optional(),
+        archived: z.number().min(0).optional()
+    }).passthrough().optional(),
+    errors: z.array(ErrorSchema).optional(),
+    sandbox: z.boolean().optional(),
+    context: ContextObjectSchema.optional(),
+    ext: ExtensionObjectSchema.optional()
+}).passthrough();
+
+export const SyncCreativesRequestSchema = z.object({
+    adcp_major_version: z.number().min(1).max(99).optional(),
+    account: AccountReferenceSchema,
+    creatives: z.array(CreativeAssetSchema),
+    creative_ids: z.array(z.string()).optional(),
+    assignments: z.array(z.object({
+        creative_id: z.string(),
+        package_id: z.string(),
+        weight: z.number().min(0).max(100).optional(),
+        placement_ids: z.array(z.string()).optional()
+    }).passthrough()).optional(),
+    idempotency_key: z.string().min(16).max(255).regex(/^[A-Za-z0-9_.:-]{16,255}$/),
+    delete_missing: z.boolean().optional(),
+    dry_run: z.boolean().optional(),
+    validation_mode: ValidationModeSchema.optional(),
+    push_notification_config: PushNotificationConfigSchema.optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -4726,7 +5077,21 @@ export const ContentStandardsSchema = z.object({
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
-export const GetContentStandardsResponseSchema = z.union([ContentStandardsSchema, z.object({
+export const GetContentStandardsResponseSchema = z.union([z.object({
+        standards_id: z.string(),
+        name: z.string().optional(),
+        countries_all: z.array(z.string()).optional(),
+        channels_any: z.array(MediaChannelSchema).optional(),
+        languages_any: z.array(z.string()).optional(),
+        policies: z.array(PolicyEntrySchema).optional(),
+        calibration_exemplars: z.object({
+            pass: z.array(ArtifactSchema).optional(),
+            fail: z.array(ArtifactSchema).optional()
+        }).passthrough().optional(),
+        pricing_options: z.array(VendorPricingOptionSchema).optional(),
+        ext: ExtensionObjectSchema.optional(),
+        context: ContextObjectSchema.optional()
+    }).passthrough(), z.object({
         errors: z.array(ErrorSchema),
         context: ContextObjectSchema.optional(),
         ext: ExtensionObjectSchema.optional()
@@ -4788,6 +5153,15 @@ export const CalibrateContentResponseSchema = z.union([z.object({
         context: ContextObjectSchema.optional(),
         ext: ExtensionObjectSchema.optional()
     }).passthrough()]);
+
+export const GetCreativeFeaturesRequestSchema = z.object({
+    adcp_major_version: z.number().min(1).max(99).optional(),
+    creative_manifest: CreativeManifestSchema,
+    feature_ids: z.array(z.string()).optional(),
+    account: AccountReferenceSchema.optional(),
+    context: ContextObjectSchema.optional(),
+    ext: ExtensionObjectSchema.optional()
+}).passthrough();
 
 export const GetCreativeFeaturesResponseSchema = z.union([z.object({
         results: z.array(CreativeFeatureResultSchema),
@@ -5534,6 +5908,8 @@ export const GetAccountFinancialsErrorSchema = z.object({
 
 export const UpdateMediaBuyResponseSchema = z.union([UpdateMediaBuySuccessSchema, UpdateMediaBuyErrorSchema]);
 
+export const BuildCreativeResponseSchema = z.union([BuildCreativeSuccessSchema, BuildCreativeMultiSuccessSchema, BuildCreativeErrorSchema]);
+
 export const ListScenariosSuccessSchema = z.object({
     success: z.literal(true),
     scenarios: z.array(z.union([z.literal("force_creative_status"), z.literal("force_account_status"), z.literal("force_media_buy_status"), z.literal("force_create_media_buy_arm"), z.literal("force_task_completion"), z.literal("force_session_status"), z.literal("simulate_delivery"), z.literal("simulate_budget_spend"), z.literal("seed_product"), z.literal("seed_pricing_option"), z.literal("seed_creative"), z.literal("seed_plan"), z.literal("seed_media_buy"), z.literal("seed_creative_format")])),
@@ -5623,12 +5999,6 @@ export const MediaBuySchema = z.object({
     updated_at: z.iso.datetime().optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
-
-export const BriefAssetSchema = CreativeBriefSchema.and(z.object({
-    asset_type: z.literal("brief")
-}).passthrough());
-
-export const AssetVariantSchema = z.union([ImageAssetSchema, VideoAssetSchema, AudioAssetSchema, VASTAssetSchema, TextAssetSchema, URLAssetSchema, HTMLAssetSchema, JavaScriptAssetSchema, WebhookAssetSchema, CSSAssetSchema, DAASTAssetSchema, MarkdownAssetSchema, BriefAssetSchema, CatalogAssetSchema]);
 
 export const InstallmentSchema = z.object({
     installment_id: z.string(),
@@ -5760,42 +6130,6 @@ export const GetProductsAsyncInputRequiredSchema = z.object({
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
-export const CreativeManifestSchema = z.object({
-    format_id: FormatReferenceStructuredObjectSchema,
-    assets: z.record(z.string(), AssetVariantSchema),
-    rights: z.array(RightsConstraintSchema).optional(),
-    industry_identifiers: z.array(IndustryIdentifierSchema).optional(),
-    provenance: ProvenanceSchema.optional(),
-    ext: ExtensionObjectSchema.optional()
-}).passthrough();
-
-export const BuildCreativeMultiSuccessSchema = z.object({
-    creative_manifests: z.array(CreativeManifestSchema),
-    sandbox: z.boolean().optional(),
-    expires_at: z.iso.datetime().optional(),
-    preview: z.object({
-        previews: z.array(z.object({
-            preview_id: z.string(),
-            format_id: FormatReferenceStructuredObjectSchema,
-            renders: z.array(PreviewRenderSchema),
-            input: z.object({
-                name: z.string(),
-                macros: z.record(z.string(), z.string()).optional(),
-                context_description: z.string().optional()
-            }).passthrough()
-        }).passthrough()),
-        interactive_url: z.string().optional(),
-        expires_at: z.iso.datetime()
-    }).passthrough().optional(),
-    preview_error: ErrorSchema.optional(),
-    pricing_option_id: z.string().optional(),
-    vendor_cost: z.number().min(0).optional(),
-    currency: z.string().regex(/^[A-Z]{3}$/).optional(),
-    consumption: CreativeConsumptionSchema.optional(),
-    context: ContextObjectSchema.optional(),
-    ext: ExtensionObjectSchema.optional()
-}).passthrough();
-
 export const AcquireRightsRequestSchema = z.object({
     adcp_major_version: z.number().min(1).max(99).optional(),
     rights_id: z.string(),
@@ -5899,111 +6233,6 @@ export const ListContentStandardsResponseSchema = z.union([z.object({
         ext: ExtensionObjectSchema.optional()
     }).passthrough()]);
 
-export const CreativeVariantSchema = DeliveryMetricsSchema.and(z.object({
-    variant_id: z.string(),
-    manifest: CreativeManifestSchema.optional(),
-    generation_context: z.object({
-        context_type: z.string().optional(),
-        artifact: z.object({
-            property_id: IdentifierSchema,
-            artifact_id: z.string()
-        }).passthrough().optional(),
-        ext: ExtensionObjectSchema.optional()
-    }).passthrough().optional()
-}).passthrough());
-
-export const GetCreativeDeliveryResponseSchema = z.object({
-    account_id: z.string().optional(),
-    media_buy_id: z.string().optional(),
-    currency: z.string().regex(/^[A-Z]{3}$/),
-    reporting_period: z.object({
-        start: z.iso.datetime(),
-        end: z.iso.datetime(),
-        timezone: z.string().optional()
-    }).passthrough(),
-    creatives: z.array(z.object({
-        creative_id: z.string(),
-        media_buy_id: z.string().optional(),
-        format_id: FormatReferenceStructuredObjectSchema.optional(),
-        totals: DeliveryMetricsSchema.optional(),
-        variant_count: z.number().min(0).optional(),
-        variants: z.array(CreativeVariantSchema)
-    }).passthrough()),
-    pagination: z.object({
-        limit: z.number().min(1),
-        offset: z.number().min(0),
-        has_more: z.boolean(),
-        total: z.number().min(0).optional()
-    }).passthrough().optional(),
-    errors: z.array(ErrorSchema).optional(),
-    context: ContextObjectSchema.optional(),
-    ext: ExtensionObjectSchema.optional()
-}).passthrough();
-
-export const GetCreativeFeaturesRequestSchema = z.object({
-    adcp_major_version: z.number().min(1).max(99).optional(),
-    creative_manifest: CreativeManifestSchema,
-    feature_ids: z.array(z.string()).optional(),
-    account: AccountReferenceSchema.optional(),
-    context: ContextObjectSchema.optional(),
-    ext: ExtensionObjectSchema.optional()
-}).passthrough();
-
-export const ListCreativesResponseSchema = z.object({
-    query_summary: z.object({
-        total_matching: z.number().min(0),
-        returned: z.number().min(0),
-        filters_applied: z.array(z.string()).optional(),
-        sort_applied: z.object({
-            field: z.string().optional(),
-            direction: SortDirectionSchema.optional()
-        }).passthrough().optional()
-    }).passthrough(),
-    pagination: PaginationResponseSchema,
-    creatives: z.array(z.object({
-        creative_id: z.string(),
-        account: AccountSchema.optional(),
-        name: z.string(),
-        format_id: FormatReferenceStructuredObjectSchema,
-        status: CreativeStatusSchema,
-        created_date: z.iso.datetime(),
-        updated_date: z.iso.datetime(),
-        assets: z.record(z.string(), AssetVariantSchema).optional(),
-        tags: z.array(z.string()).optional(),
-        concept_id: z.string().optional(),
-        concept_name: z.string().optional(),
-        variables: z.array(CreativeVariableSchema).optional(),
-        assignments: z.object({
-            assignment_count: z.number().min(0),
-            assigned_packages: z.array(z.object({
-                package_id: z.string(),
-                assigned_date: z.iso.datetime()
-            }).passthrough()).optional()
-        }).passthrough().optional(),
-        snapshot: z.object({
-            as_of: z.iso.datetime(),
-            staleness_seconds: z.number().min(0),
-            impressions: z.number().min(0),
-            last_served: z.iso.datetime().optional()
-        }).passthrough().optional(),
-        snapshot_unavailable_reason: SnapshotUnavailableReasonSchema.optional(),
-        items: z.array(CreativeItemSchema).optional(),
-        pricing_options: z.array(VendorPricingOptionSchema).optional()
-    }).passthrough()),
-    format_summary: z.record(z.string(), z.number()).optional(),
-    status_summary: z.object({
-        processing: z.number().min(0).optional(),
-        approved: z.number().min(0).optional(),
-        pending_review: z.number().min(0).optional(),
-        rejected: z.number().min(0).optional(),
-        archived: z.number().min(0).optional()
-    }).passthrough().optional(),
-    errors: z.array(ErrorSchema).optional(),
-    sandbox: z.boolean().optional(),
-    context: ContextObjectSchema.optional(),
-    ext: ExtensionObjectSchema.optional()
-}).passthrough();
-
 export const AssetVariant1Schema = AssetVariantSchema;
 
 export const VASTAsset1Schema = VASTAssetSchema;
@@ -6012,72 +6241,7 @@ export const DAASTAsset1Schema = DAASTAssetSchema;
 
 export const BriefAsset1Schema = BriefAssetSchema;
 
-export const CatalogAsset1Schema = CatalogAssetSchema;
-
-export const PreviewCreativeRequestSchema = z.object({
-    adcp_major_version: z.number().min(1).max(99).optional(),
-    request_type: z.union([z.literal("single"), z.literal("batch"), z.literal("variant")]),
-    creative_manifest: CreativeManifestSchema.optional(),
-    format_id: FormatReferenceStructuredObjectSchema.optional(),
-    inputs: z.array(z.object({
-        name: z.string(),
-        macros: z.record(z.string(), z.string()).optional(),
-        context_description: z.string().optional()
-    }).passthrough()).optional(),
-    template_id: z.string().optional(),
-    quality: CreativeQualitySchema.optional(),
-    output_format: PreviewOutputFormatSchema.optional(),
-    item_limit: z.number().min(1).optional(),
-    requests: z.array(z.object({
-        format_id: FormatReferenceStructuredObjectSchema.optional(),
-        creative_manifest: CreativeManifestSchema,
-        inputs: z.array(z.object({
-            name: z.string(),
-            macros: z.record(z.string(), z.string()).optional(),
-            context_description: z.string().optional()
-        }).passthrough()).optional(),
-        template_id: z.string().optional(),
-        quality: CreativeQualitySchema.optional(),
-        output_format: PreviewOutputFormatSchema.optional(),
-        item_limit: z.number().min(1).optional()
-    }).passthrough()).optional(),
-    variant_id: z.string().optional(),
-    creative_id: z.string().optional(),
-    context: ContextObjectSchema.optional(),
-    ext: ExtensionObjectSchema.optional()
-}).passthrough();
-
-export const PreviewCreativeVariantResponseSchema = z.object({
-    response_type: z.literal("variant"),
-    variant_id: z.string(),
-    creative_id: z.string().optional(),
-    previews: z.array(z.object({
-        preview_id: z.string(),
-        renders: z.array(PreviewRenderSchema)
-    }).passthrough()),
-    manifest: CreativeManifestSchema.optional(),
-    expires_at: z.iso.datetime().optional(),
-    context: ContextObjectSchema.optional(),
-    ext: ExtensionObjectSchema.optional()
-}).passthrough();
-
-export const CreativeAssetSchema = z.object({
-    creative_id: z.string(),
-    name: z.string(),
-    format_id: FormatReferenceStructuredObjectSchema,
-    assets: z.record(z.string(), AssetVariantSchema),
-    inputs: z.array(z.object({
-        name: z.string(),
-        macros: z.record(z.string(), z.string()).optional(),
-        context_description: z.string().optional()
-    }).passthrough()).optional(),
-    tags: z.array(z.string()).optional(),
-    status: CreativeStatusSchema.optional(),
-    weight: z.number().min(0).max(100).optional(),
-    placement_ids: z.array(z.string()).optional(),
-    industry_identifiers: z.array(IndustryIdentifierSchema).optional(),
-    provenance: ProvenanceSchema.optional()
-}).passthrough();
+export const PreviewCreativeResponseSchema = z.union([PreviewCreativeSingleResponseSchema, PreviewCreativeBatchResponseSchema, PreviewCreativeVariantResponseSchema]);
 
 export const BuildCreativeRequestSchema = z.object({
     adcp_major_version: z.number().min(1).max(99).optional(),
@@ -6107,26 +6271,43 @@ export const BuildCreativeRequestSchema = z.object({
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
-export const PackageRequestSchema = z.object({
+export const CreateMediaBuyRequestSchema = z.object({
     adcp_major_version: z.number().min(1).max(99).optional(),
-    product_id: z.string(),
-    format_ids: z.array(FormatReferenceStructuredObjectSchema).optional(),
-    budget: z.number().min(0),
-    pacing: PacingSchema.optional(),
-    pricing_option_id: z.string(),
-    bid_price: z.number().min(0).optional(),
-    impressions: z.number().min(0).optional(),
-    start_time: z.iso.datetime().optional(),
-    end_time: z.iso.datetime().optional(),
-    paused: z.boolean().optional(),
-    catalogs: z.array(CatalogSchema).optional(),
-    optimization_goals: z.array(OptimizationGoalSchema).optional(),
-    targeting_overlay: TargetingOverlaySchema.optional(),
-    measurement_terms: MeasurementTermsSchema.optional(),
-    performance_standards: z.array(PerformanceStandardSchema).optional(),
-    creative_assignments: z.array(CreativeAssignmentSchema).optional(),
-    creatives: z.array(CreativeAssetSchema).optional(),
+    idempotency_key: z.string().min(16).max(255).regex(/^[A-Za-z0-9_.:-]{16,255}$/),
+    plan_id: z.string().optional(),
+    account: AccountReferenceSchema,
+    proposal_id: z.string().optional(),
+    total_budget: z.object({
+        amount: z.number().min(0),
+        currency: z.string()
+    }).passthrough().optional(),
+    packages: z.array(PackageRequestSchema).optional(),
+    brand: BrandReferenceSchema,
+    advertiser_industry: AdvertiserIndustrySchema.optional(),
+    invoice_recipient: BusinessEntitySchema.optional(),
+    io_acceptance: z.object({
+        io_id: z.string(),
+        accepted_at: z.iso.datetime(),
+        signatory: z.string().min(1).max(250),
+        signature_id: z.string().optional()
+    }).passthrough().optional(),
+    po_number: z.string().optional(),
     agency_estimate_number: z.string().max(100).optional(),
+    start_time: StartTimingSchema,
+    end_time: z.iso.datetime(),
+    push_notification_config: PushNotificationConfigSchema.optional(),
+    reporting_webhook: ReportingWebhookSchema.optional(),
+    artifact_webhook: z.object({
+        url: z.string(),
+        token: z.string().min(16).optional(),
+        authentication: z.object({
+            schemes: z.array(AuthenticationSchemeSchema),
+            credentials: z.string().min(32)
+        }).passthrough(),
+        delivery_mode: z.union([z.literal("realtime"), z.literal("batched")]),
+        batch_frequency: z.union([z.literal("hourly"), z.literal("daily")]).optional(),
+        sampling_rate: z.number().min(0).max(1).optional()
+    }).passthrough().optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -6175,39 +6356,22 @@ export const LogEventRequestSchema = z.object({
 
 export const SyncEventSourcesResponseSchema = z.union([SyncEventSourcesSuccessSchema, SyncEventSourcesErrorSchema]);
 
-export const PackageUpdateSchema = z.object({
-    package_id: z.string(),
-    budget: z.number().min(0).optional(),
-    pacing: PacingSchema.optional(),
-    bid_price: z.number().min(0).optional(),
-    impressions: z.number().min(0).optional(),
-    start_time: z.iso.datetime().optional(),
-    end_time: z.iso.datetime().optional(),
+export const UpdateMediaBuyRequestSchema = z.object({
+    adcp_major_version: z.number().min(1).max(99).optional(),
+    account: AccountReferenceSchema,
+    media_buy_id: z.string(),
+    revision: z.number().min(1).optional(),
     paused: z.boolean().optional(),
     canceled: z.literal(true).optional(),
     cancellation_reason: z.string().max(500).optional(),
-    catalogs: z.array(CatalogSchema).optional(),
-    optimization_goals: z.array(OptimizationGoalSchema).optional(),
-    targeting_overlay: TargetingOverlaySchema.optional(),
-    keyword_targets_add: z.array(z.object({
-        keyword: z.string().min(1),
-        match_type: MatchTypeSchema,
-        bid_price: z.number().min(0).optional()
-    }).passthrough()).optional(),
-    keyword_targets_remove: z.array(z.object({
-        keyword: z.string().min(1),
-        match_type: MatchTypeSchema
-    }).passthrough()).optional(),
-    negative_keywords_add: z.array(z.object({
-        keyword: z.string().min(1),
-        match_type: MatchTypeSchema
-    }).passthrough()).optional(),
-    negative_keywords_remove: z.array(z.object({
-        keyword: z.string().min(1),
-        match_type: MatchTypeSchema
-    }).passthrough()).optional(),
-    creative_assignments: z.array(CreativeAssignmentSchema).optional(),
-    creatives: z.array(CreativeAssetSchema).optional(),
+    start_time: StartTimingSchema.optional(),
+    end_time: z.iso.datetime().optional(),
+    packages: z.array(PackageUpdateSchema).optional(),
+    invoice_recipient: BusinessEntitySchema.optional(),
+    new_packages: z.array(PackageRequestSchema).optional(),
+    reporting_webhook: ReportingWebhookSchema.optional(),
+    push_notification_config: PushNotificationConfigSchema.optional(),
+    idempotency_key: z.string().min(16).max(255).regex(/^[A-Za-z0-9_.:-]{16,255}$/),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -6434,116 +6598,7 @@ export const FormatSchema = z.object({
     pricing_options: z.array(VendorPricingOptionSchema).optional()
 }).passthrough();
 
-export const CreateMediaBuyRequestSchema = z.object({
-    adcp_major_version: z.number().min(1).max(99).optional(),
-    idempotency_key: z.string().min(16).max(255).regex(/^[A-Za-z0-9_.:-]{16,255}$/),
-    plan_id: z.string().optional(),
-    account: AccountReferenceSchema,
-    proposal_id: z.string().optional(),
-    total_budget: z.object({
-        amount: z.number().min(0),
-        currency: z.string()
-    }).passthrough().optional(),
-    packages: z.array(PackageRequestSchema).optional(),
-    brand: BrandReferenceSchema,
-    advertiser_industry: AdvertiserIndustrySchema.optional(),
-    invoice_recipient: BusinessEntitySchema.optional(),
-    io_acceptance: z.object({
-        io_id: z.string(),
-        accepted_at: z.iso.datetime(),
-        signatory: z.string().min(1).max(250),
-        signature_id: z.string().optional()
-    }).passthrough().optional(),
-    po_number: z.string().optional(),
-    agency_estimate_number: z.string().max(100).optional(),
-    start_time: StartTimingSchema,
-    end_time: z.iso.datetime(),
-    push_notification_config: PushNotificationConfigSchema.optional(),
-    reporting_webhook: ReportingWebhookSchema.optional(),
-    artifact_webhook: z.object({
-        url: z.string(),
-        token: z.string().min(16).optional(),
-        authentication: z.object({
-            schemes: z.array(AuthenticationSchemeSchema),
-            credentials: z.string().min(32)
-        }).passthrough(),
-        delivery_mode: z.union([z.literal("realtime"), z.literal("batched")]),
-        batch_frequency: z.union([z.literal("hourly"), z.literal("daily")]).optional(),
-        sampling_rate: z.number().min(0).max(1).optional()
-    }).passthrough().optional(),
-    context: ContextObjectSchema.optional(),
-    ext: ExtensionObjectSchema.optional()
-}).passthrough();
-
 export const CreateMediaBuyResponseSchema = z.union([CreateMediaBuySuccessSchema, CreateMediaBuyErrorSchema, CreateMediaBuySubmittedSchema]);
-
-export const UpdateMediaBuyRequestSchema = z.object({
-    adcp_major_version: z.number().min(1).max(99).optional(),
-    account: AccountReferenceSchema,
-    media_buy_id: z.string(),
-    revision: z.number().min(1).optional(),
-    paused: z.boolean().optional(),
-    canceled: z.literal(true).optional(),
-    cancellation_reason: z.string().max(500).optional(),
-    start_time: StartTimingSchema.optional(),
-    end_time: z.iso.datetime().optional(),
-    packages: z.array(PackageUpdateSchema).optional(),
-    invoice_recipient: BusinessEntitySchema.optional(),
-    new_packages: z.array(PackageRequestSchema).optional(),
-    reporting_webhook: ReportingWebhookSchema.optional(),
-    push_notification_config: PushNotificationConfigSchema.optional(),
-    idempotency_key: z.string().min(16).max(255).regex(/^[A-Za-z0-9_.:-]{16,255}$/),
-    context: ContextObjectSchema.optional(),
-    ext: ExtensionObjectSchema.optional()
-}).passthrough();
-
-export const BuildCreativeSuccessSchema = z.object({
-    creative_manifest: CreativeManifestSchema,
-    sandbox: z.boolean().optional(),
-    expires_at: z.iso.datetime().optional(),
-    preview: z.object({
-        previews: z.array(z.object({
-            preview_id: z.string(),
-            renders: z.array(PreviewRenderSchema),
-            input: z.object({
-                name: z.string(),
-                macros: z.record(z.string(), z.string()).optional(),
-                context_description: z.string().optional()
-            }).passthrough()
-        }).passthrough()),
-        interactive_url: z.string().optional(),
-        expires_at: z.iso.datetime()
-    }).passthrough().optional(),
-    preview_error: ErrorSchema.optional(),
-    pricing_option_id: z.string().optional(),
-    vendor_cost: z.number().min(0).optional(),
-    currency: z.string().regex(/^[A-Z]{3}$/).optional(),
-    consumption: CreativeConsumptionSchema.optional(),
-    context: ContextObjectSchema.optional(),
-    ext: ExtensionObjectSchema.optional()
-}).passthrough();
-
-export const PreviewCreativeResponseSchema = z.union([PreviewCreativeSingleResponseSchema, PreviewCreativeBatchResponseSchema, PreviewCreativeVariantResponseSchema]);
-
-export const SyncCreativesRequestSchema = z.object({
-    adcp_major_version: z.number().min(1).max(99).optional(),
-    account: AccountReferenceSchema,
-    creatives: z.array(CreativeAssetSchema),
-    creative_ids: z.array(z.string()).optional(),
-    assignments: z.array(z.object({
-        creative_id: z.string(),
-        package_id: z.string(),
-        weight: z.number().min(0).max(100).optional(),
-        placement_ids: z.array(z.string()).optional()
-    }).passthrough()).optional(),
-    idempotency_key: z.string().min(16).max(255).regex(/^[A-Za-z0-9_.:-]{16,255}$/),
-    delete_missing: z.boolean().optional(),
-    dry_run: z.boolean().optional(),
-    validation_mode: ValidationModeSchema.optional(),
-    push_notification_config: PushNotificationConfigSchema.optional(),
-    context: ContextObjectSchema.optional(),
-    ext: ExtensionObjectSchema.optional()
-}).passthrough();
 
 export const CreateCollectionListResponseSchema = z.object({
     list: CollectionListSchema,
@@ -6559,9 +6614,39 @@ export const SyncGovernanceResponseSchema = z.union([SyncGovernanceSuccessSchema
 
 export const GetAccountFinancialsResponseSchema = z.union([GetAccountFinancialsSuccessSchema, GetAccountFinancialsErrorSchema]);
 
-export const BuildCreativeResponseSchema = z.union([BuildCreativeSuccessSchema, BuildCreativeMultiSuccessSchema, BuildCreativeErrorSchema]);
-
 export const AdCPAsyncResponseDataSchema: z.ZodType = z.union([GetProductsResponseSchema, GetProductsAsyncWorkingSchema, GetProductsAsyncInputRequiredSchema, GetProductsAsyncSubmittedSchema, CreateMediaBuyResponseSchema, CreateMediaBuyAsyncWorkingSchema, CreateMediaBuyAsyncInputRequiredSchema, CreateMediaBuyAsyncSubmittedSchema, UpdateMediaBuyResponseSchema, UpdateMediaBuyAsyncWorkingSchema, UpdateMediaBuyAsyncInputRequiredSchema, UpdateMediaBuyAsyncSubmittedSchema, BuildCreativeResponseSchema, BuildCreativeAsyncWorkingSchema, BuildCreativeAsyncInputRequiredSchema, BuildCreativeAsyncSubmittedSchema, SyncCreativesResponseSchema, SyncCreativesAsyncWorkingSchema, SyncCreativesAsyncInputRequiredSchema, SyncCreativesAsyncSubmittedSchema, SyncCatalogsResponseSchema, SyncCatalogsAsyncWorkingSchema, SyncCatalogsAsyncInputRequiredSchema, SyncCatalogsAsyncSubmittedSchema]);
+
+export const ComplyTestControllerRequestSchema = z.object({
+    scenario: z.union([z.literal("list_scenarios"), z.literal("force_creative_status"), z.literal("force_account_status"), z.literal("force_media_buy_status"), z.literal("force_create_media_buy_arm"), z.literal("force_task_completion"), z.literal("force_session_status"), z.literal("simulate_delivery"), z.literal("simulate_budget_spend"), z.literal("seed_product"), z.literal("seed_pricing_option"), z.literal("seed_creative"), z.literal("seed_plan"), z.literal("seed_media_buy"), z.literal("seed_creative_format")]),
+    params: z.object({
+        creative_id: z.string().optional(),
+        account_id: z.string().optional(),
+        media_buy_id: z.string().optional(),
+        session_id: z.string().optional(),
+        product_id: z.string().optional(),
+        pricing_option_id: z.string().optional(),
+        plan_id: z.string().optional(),
+        fixture: z.object({}).passthrough().optional(),
+        status: z.string().optional(),
+        rejection_reason: z.string().optional(),
+        termination_reason: z.string().optional(),
+        impressions: z.number().min(0).optional(),
+        clicks: z.number().min(0).optional(),
+        conversions: z.number().min(0).optional(),
+        reported_spend: z.object({
+            amount: z.number().min(0),
+            currency: z.string().regex(/^[A-Z]{3}$/)
+        }).passthrough().optional(),
+        spend_percentage: z.number().min(0).max(100).optional(),
+        arm: z.union([z.literal("submitted"), z.literal("input-required")]).optional(),
+        task_id: z.string().max(128).optional(),
+        message: z.string().max(2000).optional(),
+        format_id: z.string().optional(),
+        result: AdCPAsyncResponseDataSchema.optional()
+    }).passthrough().optional(),
+    context: ContextObjectSchema.optional(),
+    ext: ExtensionObjectSchema.optional()
+}).passthrough();
 
 export const ComplyTestControllerResponseSchema = z.union([ListScenariosSuccessSchema, StateTransitionSuccessSchema, SimulationSuccessSchema, ForcedDirectiveSuccessSchema, SeedSuccessSchema, ControllerErrorSchema]);
 
@@ -6630,38 +6715,6 @@ export const ListCreativeFormatsResponseSchema = z.object({
     errors: z.array(ErrorSchema).optional(),
     pagination: PaginationResponseSchema.optional(),
     sandbox: z.boolean().optional(),
-    context: ContextObjectSchema.optional(),
-    ext: ExtensionObjectSchema.optional()
-}).passthrough();
-
-export const ComplyTestControllerRequestSchema = z.object({
-    scenario: z.union([z.literal("list_scenarios"), z.literal("force_creative_status"), z.literal("force_account_status"), z.literal("force_media_buy_status"), z.literal("force_create_media_buy_arm"), z.literal("force_task_completion"), z.literal("force_session_status"), z.literal("simulate_delivery"), z.literal("simulate_budget_spend"), z.literal("seed_product"), z.literal("seed_pricing_option"), z.literal("seed_creative"), z.literal("seed_plan"), z.literal("seed_media_buy"), z.literal("seed_creative_format")]),
-    params: z.object({
-        creative_id: z.string().optional(),
-        account_id: z.string().optional(),
-        media_buy_id: z.string().optional(),
-        session_id: z.string().optional(),
-        product_id: z.string().optional(),
-        pricing_option_id: z.string().optional(),
-        plan_id: z.string().optional(),
-        fixture: z.object({}).passthrough().optional(),
-        status: z.string().optional(),
-        rejection_reason: z.string().optional(),
-        termination_reason: z.string().optional(),
-        impressions: z.number().min(0).optional(),
-        clicks: z.number().min(0).optional(),
-        conversions: z.number().min(0).optional(),
-        reported_spend: z.object({
-            amount: z.number().min(0),
-            currency: z.string().regex(/^[A-Z]{3}$/)
-        }).passthrough().optional(),
-        spend_percentage: z.number().min(0).max(100).optional(),
-        arm: z.union([z.literal("submitted"), z.literal("input-required")]).optional(),
-        task_id: z.string().max(128).optional(),
-        message: z.string().max(2000).optional(),
-        format_id: z.string().optional(),
-        result: AdCPAsyncResponseDataSchema.optional()
-    }).passthrough().optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();

--- a/src/lib/types/tools.generated.ts
+++ b/src/lib/types/tools.generated.ts
@@ -5206,7 +5206,6 @@ export interface BriefAsset {
       regulation?: string;
       /**
        * Minimum display duration in milliseconds. For video/audio disclosures, how long the disclosure must be visible or audible. For static formats, how long the disclosure must remain on screen before any auto-advance.
-       * @minimum 1
        */
       min_duration_ms?: number;
       /**
@@ -5224,7 +5223,6 @@ export interface BriefAsset {
    * Discriminator identifying this as a brief asset. See /schemas/creative/asset-types for the registry.
    */
   asset_type: 'brief';
-  [k: string]: unknown | undefined;
 }
 /**
  * A reference asset that provides creative context. Carries visual materials (mood boards, product shots, example creatives) with semantic roles that tell creative agents how to use them.
@@ -5299,7 +5297,6 @@ export interface CatalogAsset {
    * Discriminator identifying this as a catalog asset. See /schemas/creative/asset-types for the registry.
    */
   asset_type: 'catalog';
-  [k: string]: unknown | undefined;
 }
 /**
  * An industry-standard identifier for an advertising creative (e.g., Ad-ID, ISCI, Clearcast clock number). These identifiers are managed by external registries and used across the supply chain to track and reference specific creative assets.

--- a/src/lib/types/tools.generated.ts
+++ b/src/lib/types/tools.generated.ts
@@ -4014,24 +4014,6 @@ export type DAASTTrackingEvent =
  */
 export type MarkdownFlavor = 'commonmark' | 'gfm';
 /**
- * Campaign-level creative context as an asset. Carries the creative brief through the manifest so it travels with the creative through regeneration, resizing, and auditing.
- */
-export type BriefAsset = CreativeBrief & {
-  /**
-   * Discriminator identifying this as a brief asset. See /schemas/creative/asset-types for the registry.
-   */
-  asset_type: 'brief';
-};
-/**
- * A typed data feed as a creative asset. Carries catalog context (products, stores, jobs, etc.) within the manifest's assets map.
- */
-export type CatalogAsset = Catalog & {
-  /**
-   * Discriminator identifying this as a catalog asset. See /schemas/creative/asset-types for the registry.
-   */
-  asset_type: 'catalog';
-};
-/**
  * For generative creatives: set to 'approved' to finalize, 'rejected' to request regeneration with updated assets/message. Omit for non-generative creatives (system will set based on processing state).
  */
 export type CreativeStatus = 'processing' | 'pending_review' | 'approved' | 'rejected' | 'archived';
@@ -5153,9 +5135,9 @@ export interface MarkdownAsset {
   allow_raw_html?: boolean;
 }
 /**
- * Campaign-level creative context for AI-powered creative generation. Provides the layer between brand identity (stable across campaigns) and individual creative execution (per-request). A brand has one identity (defined in brand.json) but different creative briefs for each campaign or flight.
+ * Campaign-level creative context as an asset. Carries the creative brief through the manifest so it travels with the creative through regeneration, resizing, and auditing.
  */
-export interface CreativeBrief {
+export interface BriefAsset {
   /**
    * Campaign or flight name for identification
    */
@@ -5238,6 +5220,11 @@ export interface CreativeBrief {
      */
     prohibited_claims?: string[];
   };
+  /**
+   * Discriminator identifying this as a brief asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'brief';
+  [k: string]: unknown | undefined;
 }
 /**
  * A reference asset that provides creative context. Carries visual materials (mood boards, product shots, example creatives) with semantic roles that tell creative agents how to use them.
@@ -5255,6 +5242,64 @@ export interface ReferenceAsset {
    * Human-readable description of the asset and how it should inform creative generation
    */
   description?: string;
+}
+/**
+ * A typed data feed as a creative asset. Carries catalog context (products, stores, jobs, etc.) within the manifest's assets map.
+ */
+export interface CatalogAsset {
+  /**
+   * Buyer's identifier for this catalog. Required when syncing via sync_catalogs. When used in creatives, references a previously synced catalog on the account.
+   */
+  catalog_id?: string;
+  /**
+   * Human-readable name for this catalog (e.g., 'Summer Products 2025', 'Amsterdam Store Locations').
+   */
+  name?: string;
+  type: CatalogType;
+  /**
+   * URL to an external catalog feed. The platform fetches and resolves items from this URL. For offering-type catalogs, the feed contains an array of Offering objects. For other types, the feed format is determined by feed_format. When omitted with type 'product', the platform uses its synced copy of the brand's product catalog.
+   */
+  url?: string;
+  feed_format?: FeedFormat;
+  update_frequency?: UpdateFrequency;
+  /**
+   * Inline catalog data. The item schema depends on the catalog type: Offering objects for 'offering', StoreItem for 'store', HotelItem for 'hotel', FlightItem for 'flight', JobItem for 'job', VehicleItem for 'vehicle', RealEstateItem for 'real_estate', EducationItem for 'education', DestinationItem for 'destination', AppItem for 'app', or freeform objects for 'product', 'inventory', and 'promotion'. Mutually exclusive with url — provide one or the other, not both. Implementations should validate items against the type-specific schema.
+   */
+  items?: {}[];
+  /**
+   * Filter catalog to specific item IDs. For offering-type catalogs, these are offering_id values. For product-type catalogs, these are SKU identifiers.
+   */
+  ids?: string[];
+  /**
+   * Filter product-type catalogs by GTIN identifiers for cross-retailer catalog matching. Accepts standard GTIN formats (GTIN-8, UPC-A/GTIN-12, EAN-13/GTIN-13, GTIN-14). Only applicable when type is 'product'.
+   */
+  gtins?: string[];
+  /**
+   * Filter catalog to items with these tags. Tags are matched using OR logic — items matching any tag are included.
+   */
+  tags?: string[];
+  /**
+   * Filter catalog to items in this category (e.g., 'beverages/soft-drinks', 'chef-positions').
+   */
+  category?: string;
+  /**
+   * Natural language filter for catalog items (e.g., 'all pasta sauces under $5', 'amsterdam vacancies').
+   */
+  query?: string;
+  /**
+   * Event types that represent conversions for items in this catalog. Declares what events the platform should attribute to catalog items — e.g., a job catalog converts via submit_application, a product catalog via purchase. The event's content_ids field carries the item IDs that connect back to catalog items. Use content_id_type to declare what identifier type content_ids values represent.
+   */
+  conversion_events?: EventType[];
+  content_id_type?: ContentIDType;
+  /**
+   * Declarative normalization rules for external feeds. Maps non-standard feed field names, date formats, price encodings, and image URLs to the AdCP catalog item schema. Applied during sync_catalogs ingestion. Supports field renames, named transforms (date, divide, boolean, split), static literal injection, and assignment of image URLs to typed asset pools.
+   */
+  feed_field_mappings?: CatalogFieldMapping[];
+  /**
+   * Discriminator identifying this as a catalog asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'catalog';
+  [k: string]: unknown | undefined;
 }
 /**
  * An industry-standard identifier for an advertising creative (e.g., Ad-ID, ISCI, Clearcast clock number). These identifiers are managed by external registries and used across the supply chain to track and reference specific creative assets.
@@ -11580,7 +11625,51 @@ export interface GetContentStandardsRequest {
  * Response payload with content safety policies
  */
 export type GetContentStandardsResponse =
-  | ContentStandards
+  | {
+      /**
+       * Unique identifier for this standards configuration
+       */
+      standards_id: string;
+      /**
+       * Human-readable name for this standards configuration
+       */
+      name?: string;
+      /**
+       * ISO 3166-1 alpha-2 country codes. Standards apply in ALL listed countries (AND logic).
+       */
+      countries_all?: string[];
+      /**
+       * Advertising channels. Standards apply to ANY of the listed channels (OR logic).
+       */
+      channels_any?: MediaChannel[];
+      /**
+       * BCP 47 language tags (e.g., 'en', 'de', 'fr'). Standards apply to content in ANY of these languages (OR logic). Content in unlisted languages is not covered by these standards.
+       */
+      languages_any?: string[];
+      /**
+       * Bespoke policies for this content-standards configuration, using the same shape as registry entries. Each policy is addressable by policy_id; governance findings reference the policy_id that triggered them.
+       */
+      policies?: PolicyEntry[];
+      /**
+       * Training/test set to calibrate policy interpretation. Provides concrete examples of pass/fail decisions.
+       */
+      calibration_exemplars?: {
+        /**
+         * Artifacts that pass the content standards
+         */
+        pass?: Artifact[];
+        /**
+         * Artifacts that fail the content standards
+         */
+        fail?: Artifact[];
+      };
+      /**
+       * Pricing options for this content standards service. The buyer passes the selected pricing_option_id in report_usage for billing verification.
+       */
+      pricing_options?: VendorPricingOption[];
+      ext?: ExtensionObject;
+      context?: ContextObject;
+    }
   | {
       errors: Error[];
       context?: ContextObject;

--- a/test/type-generator-allof-ref-merge.test.js
+++ b/test/type-generator-allof-ref-merge.test.js
@@ -116,6 +116,48 @@ writeFileSync(__OUT_PATH__, JSON.stringify({
   );
 });
 
+test('enforceStrictSchema drops resolved-base additionalProperties:true when merging', () => {
+  // Regression: creative-brief.json and catalog.json both declare top-level
+  // `additionalProperties: true`. Without normalizing the resolved base, that
+  // flag propagated into the merged shape and emitted a
+  // `[k: string]: unknown | undefined` index signature on `BriefAsset` /
+  // `CatalogAsset` — wider than the pre-merge intersection form. The fix
+  // applies `enforceStrictSchema` to the resolved base inside
+  // `resolveAllOfRefForMerge` so the strip happens before the merge.
+  const result = runHarness(`
+import { writeFileSync } from 'fs';
+import { enforceStrictSchema } from '__GENERATE_TYPES__';
+
+const input = {
+  type: 'object',
+  properties: {
+    asset_type: { type: 'string', const: 'brief' },
+  },
+  required: ['asset_type'],
+  allOf: [
+    { $ref: '/schemas/3.0.11/core/creative-brief.json' },
+  ],
+};
+const out = enforceStrictSchema(JSON.parse(JSON.stringify(input)));
+writeFileSync(__OUT_PATH__, JSON.stringify({
+  hasAllOf: !!out.allOf,
+  additionalProperties: out.additionalProperties,
+  hasIndexSignatureFlag: out.additionalProperties === true,
+}));
+`);
+  assert.strictEqual(result.hasAllOf, false, 'allOf must be consumed by the merge');
+  assert.notStrictEqual(
+    result.additionalProperties,
+    true,
+    'resolved base additionalProperties:true must not propagate into merged shape'
+  );
+  assert.strictEqual(
+    result.hasIndexSignatureFlag,
+    false,
+    'merged shape must not carry the index-signature widening flag'
+  );
+});
+
 test('compiled oneOf with two broken-pattern variants emits a clean discriminated union', () => {
   // Uses a real cached schema (signal-pricing.json) so the cache resolver
   // path is exercised end-to-end without depending on every $ref the base

--- a/test/type-generator-allof-ref-merge.test.js
+++ b/test/type-generator-allof-ref-merge.test.js
@@ -1,0 +1,191 @@
+/**
+ * Regression test for adcp-client#1756.
+ *
+ * `enforceStrictSchema` pre-merges `allOf: [{ $ref }]` patterns when the
+ * parent declares its own `properties` / `required` siblings. Without this
+ * merge, `json-schema-to-typescript` emits broken unions
+ * (`( BaseFields | { variant + duplicated base fields } )`) where the
+ * intent is `BaseFields & { variant }`. This blocks adcp#4510 (schema
+ * dedup spike) until the codegen path can absorb the new shape.
+ *
+ * The test covers three scenarios:
+ *
+ *   1. Pure `allOf: [{ $ref }]` at root with no sibling properties — the
+ *      `vendor-pricing-option.json` shape — must pass through untouched
+ *      because jsts handles it correctly.
+ *   2. The broken pattern (properties + required + allOf[$ref] siblings)
+ *      with an external ref the cache can resolve — must merge into a flat
+ *      shape with `allOf` consumed.
+ *   3. A `oneOf` with two broken-pattern variants must emit a clean
+ *      discriminated union, no broken `( Base | { variant } )` arms.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const path = require('node:path');
+const fs = require('node:fs');
+const { spawnSync } = require('node:child_process');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+
+/**
+ * Drives the test via a short tsx script that imports the production
+ * `enforceStrictSchema` + `compile` and writes the result to a temp file.
+ * Keeps the test runner CommonJS while still exercising the TS export.
+ */
+function runHarness(harnessSource) {
+  // The harness must live under the repo so `tsx` resolves bare specifiers
+  // (`json-schema-to-typescript`, etc.) against the project node_modules.
+  const harnessDir = fs.mkdtempSync(path.join(REPO_ROOT, '.allof-ref-merge-harness-'));
+  const scriptPath = path.join(harnessDir, 'harness.ts');
+  const outPath = path.join(harnessDir, 'out.json');
+  const generateTypesPath = path.join(REPO_ROOT, 'scripts/generate-types.ts');
+  const prepared = harnessSource
+    .replace(/__OUT_PATH__/g, JSON.stringify(outPath))
+    .replace(/__GENERATE_TYPES__/g, generateTypesPath);
+  fs.writeFileSync(scriptPath, prepared);
+  try {
+    const r = spawnSync('npx', ['tsx', scriptPath], {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+    });
+    if (r.status !== 0) {
+      throw new Error(`harness failed (${r.status}): ${r.stderr}\n${r.stdout}`);
+    }
+    return JSON.parse(fs.readFileSync(outPath, 'utf8'));
+  } finally {
+    fs.rmSync(harnessDir, { recursive: true, force: true });
+  }
+}
+
+test('enforceStrictSchema leaves allOf-only root (no sibling properties) untouched', () => {
+  const result = runHarness(`
+import { writeFileSync } from 'fs';
+import { enforceStrictSchema } from '__GENERATE_TYPES__';
+
+const input = {
+  type: 'object',
+  description: 'Vendor pricing option style',
+  allOf: [
+    { type: 'object', properties: { pricing_option_id: { type: 'string' } }, required: ['pricing_option_id'] },
+    { $ref: '/schemas/3.0.11/core/signal-pricing.json' },
+  ],
+};
+const out = enforceStrictSchema(JSON.parse(JSON.stringify(input)));
+writeFileSync(__OUT_PATH__, JSON.stringify({
+  hasAllOf: !!out.allOf,
+  allOfLen: out.allOf?.length ?? 0,
+  ownProperties: Object.keys(out.properties ?? {}),
+}));
+`);
+  assert.strictEqual(result.hasAllOf, true, 'vendor-pricing-option style must keep its allOf');
+  assert.strictEqual(result.allOfLen, 2, 'both allOf members must remain');
+  assert.deepStrictEqual(result.ownProperties, [], 'parent must not gain inlined properties');
+});
+
+test('enforceStrictSchema merges allOf[$ref] siblings into parent properties/required', () => {
+  const result = runHarness(`
+import { writeFileSync } from 'fs';
+import { enforceStrictSchema } from '__GENERATE_TYPES__';
+
+const input = {
+  type: 'object',
+  properties: {
+    asset_type: { type: 'string', const: 'brief' },
+  },
+  required: ['asset_type'],
+  allOf: [
+    { $ref: '/schemas/3.0.11/core/creative-brief.json' },
+  ],
+};
+const out = enforceStrictSchema(JSON.parse(JSON.stringify(input)));
+writeFileSync(__OUT_PATH__, JSON.stringify({
+  hasAllOf: !!out.allOf,
+  propertyKeys: Object.keys(out.properties ?? {}),
+  hasAssetType: !!out.properties?.asset_type,
+  requiredIncludesAssetType: (out.required ?? []).includes('asset_type'),
+}));
+`);
+  assert.strictEqual(result.hasAllOf, false, 'allOf[$ref] must be consumed by the merge');
+  assert.ok(result.hasAssetType, 'variant-level asset_type discriminator must be preserved');
+  assert.ok(result.requiredIncludesAssetType, 'variant required[] must survive the merge');
+  // Base properties from creative-brief.json should have been merged in.
+  assert.ok(
+    result.propertyKeys.length > 1,
+    'base properties must merge into parent (got: ' + result.propertyKeys.join(',') + ')'
+  );
+});
+
+test('compiled oneOf with two broken-pattern variants emits a clean discriminated union', () => {
+  // Uses a real cached schema (signal-pricing.json) so the cache resolver
+  // path is exercised end-to-end without depending on every $ref the base
+  // schema transitively pulls in.
+  const result = runHarness(`
+import { writeFileSync } from 'fs';
+import { readFileSync } from 'fs';
+import { compile } from 'json-schema-to-typescript';
+import { enforceStrictSchema } from '__GENERATE_TYPES__';
+
+// Two minimal "broken-pattern" variants share a real cached base schema
+// (ext.json — leaf schema with no nested $refs so jsts doesn't need a
+// resolver wired in for the compile step). The variant root carries its own
+// \`properties\` + \`required\` AND an \`allOf: [{ $ref }]\` sibling —
+// exactly the shape adcp#4510 introduces.
+const schema = {
+  title: 'AuthorizedAgent',
+  type: 'object',
+  oneOf: [
+    {
+      title: 'AuthorizedAgentBrief',
+      type: 'object',
+      properties: {
+        authorization_type: { type: 'string', const: 'brief' },
+        property_ids: { type: 'array', items: { type: 'string' } },
+      },
+      required: ['authorization_type', 'property_ids'],
+      allOf: [{ $ref: '/schemas/3.0.11/core/ext.json' }],
+    },
+    {
+      title: 'AuthorizedAgentCatalog',
+      type: 'object',
+      properties: {
+        authorization_type: { type: 'string', const: 'catalog' },
+        catalog_ids: { type: 'array', items: { type: 'string' } },
+      },
+      required: ['authorization_type', 'catalog_ids'],
+      allOf: [{ $ref: '/schemas/3.0.11/core/ext.json' }],
+    },
+  ],
+};
+
+async function main() {
+  const strict = enforceStrictSchema(JSON.parse(JSON.stringify(schema)));
+  const ts = await compile(strict, 'AuthorizedAgent', {
+    bannerComment: '',
+    additionalProperties: false,
+    strictIndexSignatures: true,
+  });
+  writeFileSync(__OUT_PATH__, JSON.stringify({ ts, strict }));
+}
+main().catch((err) => { console.error(err); process.exit(1); });
+`);
+  // The merge must have consumed allOf at both variants.
+  assert.ok(
+    !result.strict.oneOf[0].allOf || result.strict.oneOf[0].allOf.length === 0,
+    'oneOf[0] allOf must be consumed by the merge'
+  );
+  // Both discriminator constants must surface in the emitted union.
+  assert.match(
+    result.ts,
+    /authorization_type\s*:\s*['"]brief['"]/,
+    'union must surface the brief variant discriminator'
+  );
+  assert.match(
+    result.ts,
+    /authorization_type\s*:\s*['"]catalog['"]/,
+    'union must surface the catalog variant discriminator'
+  );
+  // Variant-specific fields must still surface in the emitted output.
+  assert.match(result.ts, /property_ids/, 'variant property_ids must surface in emitted TS');
+  assert.match(result.ts, /catalog_ids/, 'variant catalog_ids must surface in emitted TS');
+});


### PR DESCRIPTION
Closes #1756. Unblocks adcp#4510 (the spec-side schema dedup spike that reverted on this codegen bug).

## Summary

JSON Schema objects that mix sibling `properties`/`required` with `allOf: [{ $ref }]` make `json-schema-to-typescript` emit a broken union `( Base | { variant + duplicated base fields } )` where the intent is `Base & { variant }`. This is most visible inside `oneOf` discriminator variants — `GetContentStandardsResponse` collapsed its success arm to bare `ContentStandards`, silently dropping the variant's own `context` and `ext` fields.

`enforceStrictSchema` now pre-merges any `allOf` member that is a single `$ref` into the parent shape when the parent already declares its own `properties`/`required` — variant-level fields win on collision; the base's `additionalProperties` is inherited only when the variant didn't override it. Local `#/$defs/...` fragments are left in place (existing Individual*Asset post-processor handles them). `vendor-pricing-option`-style allOf-only roots stay untouched (jsts handles those correctly today).

This is paired with the sibling PR for #1745 (JSDoc constraint injection) — independent edits to different parts of `scripts/generate-types.ts`, mergeable in either order.

## Knock-on type changes (intentional)

- `BriefAsset` / `CatalogAsset` flatten from `Base & { ... }` to merged interfaces. Field set is identical; the named base type is no longer referenced via intersection. **This matches option 2 in the issue's acceptance criteria** ("flattens the allOf into a single merged shape — less ideal but acceptable"). Recovering the `Base & { variant }` intersection form would be a follow-up polish pass and is out of scope here.
- `GetContentStandardsResponse` success arm regains its `context?` / `ext?` fields — the bug this PR fixes.
- `CreativeBrief` no longer transitively reaches `tools.generated.ts`; `src/lib/index.ts` re-exports it from `core.generated` instead. Existing import sites are unaffected.

## Test plan

- [x] Unit tests for `enforceStrictSchema` cover three scenarios — `vendor-pricing-option`-style pass-through, single-variant merge, and a two-variant `oneOf` ending in a clean discriminated union (`test/type-generator-allof-ref-merge.test.js`).
- [x] `npm run generate-types` regenerates cleanly; diff confined to the four type changes listed above plus their downstream Zod schemas.
- [x] `npm test` passes (1 known-flaky perf-test unrelated to this change: `request-signing-replay-perf.test.js`'s `has() sub-linear` assertion — passes in isolation).
- [x] `npm run format:check` passes.
- [x] Pre-push validation (`tsc --noEmit` + `build:lib`) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)