### PR TITLE
feat(server): construction-time warn when testController lacks resolveAccount (#1784)

### DIFF
--- a/.changeset/bridge-warn-no-resolve-account.md
+++ b/.changeset/bridge-warn-no-resolve-account.md
@@ -4,9 +4,11 @@
 
 feat(server): construction-time warn when `testController` is registered without an account resolver (#1784)
 
-`createAdcpServer` now emits a one-shot `logger.warn` at construction when `config.testController` is present but neither `config.resolveAccount` nor `config.resolveAccountFromAuth` is configured. In that setup, the dispatch-time sandbox gate's account-side check has no teeth — the gate admits requests where `ctx.account === undefined`, so the only remaining check is buyer-supplied `account.sandbox` / `context.sandbox` on the request body, which is caller-controlled and not a trust boundary.
+`createAdcpServer` now emits a one-shot construction-time warning when `config.testController` is present but neither `config.resolveAccount` nor `config.resolveAccountFromAuth` is configured. In that setup, the dispatch-time sandbox gate's account-side check has no teeth — the gate admits requests where `ctx.account === undefined`, so the only remaining check is buyer-supplied `account.sandbox` / `context.sandbox` on the request body, which is caller-controlled and not a trust boundary.
 
-The warn makes that silent misconfiguration loud once at startup, where any logging setup will surface it. It's deliberately not a hard error: storyboard-runner deployments without account scoping are a legitimate and intentional configuration (the runner drives state directly, no buyer authentication path needed), and failing construction would break that case. The warn message tells storyboard runners they can ignore it.
+The warning **dual-emits** via `process.emitWarning(message, { type: 'AdcpServerConfigWarning', code: 'ADCP_BRIDGE_NO_RESOLVER' })` AND `logger.warn(message)`. The `process.emitWarning` channel writes to stderr by default so the signal is visible even when `logger` is the default `noopLogger` (the day-one case where the misconfig is most likely). The `logger.warn` channel routes the same signal through any adopter-configured logging pipeline. Storyboard runners that knowingly run without account scoping can silence via `node --no-warnings=ADCP_BRIDGE_NO_RESOLVER`.
+
+It's deliberately not a hard error: storyboard-runner deployments without account scoping are a legitimate and intentional configuration (the runner drives state directly, no buyer authentication path needed), and failing construction would break that case. The warning message tells storyboard runners they can ignore it.
 
 The check gates on `resolveAccountFromAuth` as well as `resolveAccount`, so OAuth-passthrough setups (`createOAuthPassthroughResolver`, the canonical Shape-B adopter path) don't get a spurious warn — either resolver populates `ctx.account` at dispatch time and gives the gate its account-side teeth.
 

--- a/.changeset/bridge-warn-no-resolve-account.md
+++ b/.changeset/bridge-warn-no-resolve-account.md
@@ -1,0 +1,13 @@
+---
+'@adcp/sdk': minor
+---
+
+feat(server): construction-time warn when `testController` is registered without an account resolver (#1784)
+
+`createAdcpServer` now emits a one-shot `logger.warn` at construction when `config.testController` is present but neither `config.resolveAccount` nor `config.resolveAccountFromAuth` is configured. In that setup, the dispatch-time sandbox gate's account-side check has no teeth — the gate admits requests where `ctx.account === undefined`, so the only remaining check is buyer-supplied `account.sandbox` / `context.sandbox` on the request body, which is caller-controlled and not a trust boundary.
+
+The warn makes that silent misconfiguration loud once at startup, where any logging setup will surface it. It's deliberately not a hard error: storyboard-runner deployments without account scoping are a legitimate and intentional configuration (the runner drives state directly, no buyer authentication path needed), and failing construction would break that case. The warn message tells storyboard runners they can ignore it.
+
+The check gates on `resolveAccountFromAuth` as well as `resolveAccount`, so OAuth-passthrough setups (`createOAuthPassthroughResolver`, the canonical Shape-B adopter path) don't get a spurious warn — either resolver populates `ctx.account` at dispatch time and gives the gate its account-side teeth.
+
+JSDoc on `TestControllerBridge` (in `test-controller-bridge.ts`) and on `AdcpServerConfig.testController` (in `create-adcp-server.ts` § "Security — trust boundary") already document the trust model from #1779 and #1786; this PR adds the runtime equivalent so the failure mode surfaces before an adopter discovers it from a security review or a misconfigured prod deployment.

--- a/.changeset/bridge-warn-no-resolve-account.md
+++ b/.changeset/bridge-warn-no-resolve-account.md
@@ -8,6 +8,8 @@ feat(server): construction-time warn when `testController` is registered without
 
 The warning **dual-emits** via `process.emitWarning(message, { type: 'AdcpServerConfigWarning', code: 'ADCP_BRIDGE_NO_RESOLVER' })` AND `logger.warn(message)`. The `process.emitWarning` channel writes to stderr by default so the signal is visible even when `logger` is the default `noopLogger` (the day-one case where the misconfig is most likely). The `logger.warn` channel routes the same signal through any adopter-configured logging pipeline. Storyboard runners that knowingly run without account scoping can silence via `node --no-warnings=ADCP_BRIDGE_NO_RESOLVER`.
 
+**Warning-code convention** (established by this PR): `ADCP_*` prefix for any framework-emitted `process.emitWarning` code, scoped further by subsystem (`ADCP_BRIDGE_*` for `TestControllerBridge`-related, `ADCP_<subsystem>_*` for future). The `type` field stays consistent at `'AdcpServerConfigWarning'` for `createAdcpServer`-level misconfig signals so adopters can install one `process.on('warning')` handler that routes all framework warnings.
+
 It's deliberately not a hard error: storyboard-runner deployments without account scoping are a legitimate and intentional configuration (the runner drives state directly, no buyer authentication path needed), and failing construction would break that case. The warning message tells storyboard runners they can ignore it.
 
 The check gates on `resolveAccountFromAuth` as well as `resolveAccount`, so OAuth-passthrough setups (`createOAuthPassthroughResolver`, the canonical Shape-B adopter path) don't get a spurious warn — either resolver populates `ctx.account` at dispatch time and gives the gate its account-side teeth.

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -2940,6 +2940,22 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
     testController: testControllerBridge,
   } = config;
 
+  // One-shot construction-time warn when `testController` is wired without
+  // any account resolver. The dispatch-time sandbox gate admits requests
+  // where `ctx.account === undefined`, so without a resolver the only
+  // remaining check is buyer-supplied `account.sandbox` / `context.sandbox`
+  // on the request — caller-controlled, not a trust boundary. Storyboard
+  // runners legitimately have no account scoping and should ignore this
+  // warning; production bindings need to wire `resolveAccount` (or
+  // `resolveAccountFromAuth` for OAuth-passthrough setups) so the gate's
+  // account-side check has teeth. See `AdcpServerConfig.testController`
+  // JSDoc § "Security — trust boundary" and #1784.
+  if (testControllerBridge != null && resolveAccount === undefined && resolveAccountFromAuth === undefined) {
+    logger.warn(
+      'testController is registered but no account resolver is configured. The sandbox gate falls through to the buyer-supplied `account.sandbox` / `context.sandbox` marker — caller-controlled, not a trust boundary. Production bindings should configure `resolveAccount` (or `resolveAccountFromAuth`); storyboard-runner bindings without account scoping can ignore this warning. See `AdcpServerConfig.testController` JSDoc § "Security — trust boundary" for the full model.'
+    );
+  }
+
   // Pre-resolve credential-policy patterns once. The patterns config is
   // a stable property of `CredentialPolicyConfig`; pulling it out here
   // keeps the per-call hot path (`scanArgsForCredentials`) free of the

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -2948,12 +2948,21 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
   // runners legitimately have no account scoping and should ignore this
   // warning; production bindings need to wire `resolveAccount` (or
   // `resolveAccountFromAuth` for OAuth-passthrough setups) so the gate's
-  // account-side check has teeth. See `AdcpServerConfig.testController`
+  // account-side check has teeth.
+  //
+  // Dual-emit: `process.emitWarning` writes to stderr by default so the
+  // signal is visible even when `logger` is the default `noopLogger`
+  // (the day-one case where the misconfig is most likely). `logger.warn`
+  // also fires so adopters with configured logging pipelines see it in
+  // their normal channel. The `code` lets adopters silence it via
+  // `--no-warnings=ADCP_BRIDGE_NO_RESOLVER` if they're knowingly running
+  // a storyboard-runner config. See `AdcpServerConfig.testController`
   // JSDoc § "Security — trust boundary" and #1784.
   if (testControllerBridge != null && resolveAccount === undefined && resolveAccountFromAuth === undefined) {
-    logger.warn(
-      'testController is registered but no account resolver is configured. The sandbox gate falls through to the buyer-supplied `account.sandbox` / `context.sandbox` marker — caller-controlled, not a trust boundary. Production bindings should configure `resolveAccount` (or `resolveAccountFromAuth`); storyboard-runner bindings without account scoping can ignore this warning. See `AdcpServerConfig.testController` JSDoc § "Security — trust boundary" for the full model.'
-    );
+    const message =
+      '[adcp/createAdcpServer] testController is wired but no account resolver — configure resolveAccount (or resolveAccountFromAuth) for production. Storyboard runners without account scoping can ignore. Details: https://github.com/adcontextprotocol/adcp-client/blob/main/docs/guides/VALIDATE-YOUR-AGENT.md';
+    process.emitWarning(message, { type: 'AdcpServerConfigWarning', code: 'ADCP_BRIDGE_NO_RESOLVER' });
+    logger.warn(message);
   }
 
   // Pre-resolve credential-policy patterns once. The patterns config is

--- a/src/lib/server/test-controller-bridge.ts
+++ b/src/lib/server/test-controller-bridge.ts
@@ -207,6 +207,16 @@ export interface TestControllerBridgeContext<TAccount = unknown> {
  * Set on `AdcpServerConfig.testController`; when absent, behavior is
  * unchanged. The bridge is opt-in via the presence of `getSeededProducts`
  * — omit it to hold seeded state without changing response shape.
+ *
+ * **Construction-time misconfiguration warn.** `createAdcpServer` emits a
+ * one-shot `logger.warn` at construction when this bridge is registered
+ * without either `resolveAccount` or `resolveAccountFromAuth` configured —
+ * the dispatch-time sandbox gate's account-side check has no teeth in that
+ * setup, so caller-supplied `account.sandbox` becomes the only line of
+ * defense against fixture leakage. Storyboard runners without account
+ * scoping can ignore the warning; production bindings should wire a
+ * resolver. See `AdcpServerConfig.testController` JSDoc § "Security —
+ * trust boundary" and `adcp-client#1784`.
  */
 export interface TestControllerBridge<TAccount = unknown> {
   /**

--- a/test/lib/seed-per-tool-wiring.test.js
+++ b/test/lib/seed-per-tool-wiring.test.js
@@ -3523,7 +3523,7 @@ describe('createAdcpServer — trust-boundary warn when testController lacks res
     };
   }
 
-  const MATCH = /testController is registered but no account resolver is configured/;
+  const MATCH = /testController is wired but no account resolver/;
 
   it('warns once at construction when testController is set and neither resolver is configured', () => {
     const { logger, records } = makeRecordingLogger();
@@ -3605,5 +3605,36 @@ describe('createAdcpServer — trust-boundary warn when testController lacks res
     });
     const hits = records.warn.filter(r => MATCH.test(r.msg));
     assert.equal(hits.length, 1, 'warn fires once across construction + N requests');
+  });
+
+  // The default `logger` is `noopLogger`, which swallows `.warn`. The
+  // misconfig is most likely on day one when no logger is wired yet —
+  // so the warn also goes through `process.emitWarning` (stderr by
+  // default, dedupable via `code`). Spy on `process.emitWarning` itself
+  // for synchronous capture — `process.on('warning')` would also work
+  // but adds event-loop-flush timing dependencies.
+  it('also emits via process.emitWarning so the signal is visible without configured logging', () => {
+    const calls = [];
+    const original = process.emitWarning;
+    process.emitWarning = (...args) => {
+      calls.push(args);
+      return original.apply(process, args);
+    };
+    try {
+      _createAdcpServer({
+        name: 'Test',
+        version: '1.0.0',
+        // no `logger` → defaults to noopLogger
+        validation: { requests: 'off', responses: 'off' },
+        mediaBuy: { getProducts: async () => ({ products: [] }) },
+        testController: { getSeededProducts: () => [] },
+      });
+      const ours = calls.filter(args => args[1]?.code === 'ADCP_BRIDGE_NO_RESOLVER');
+      assert.equal(ours.length, 1, 'exactly one process.emitWarning call');
+      assert.match(ours[0][0], MATCH);
+      assert.equal(ours[0][1].type, 'AdcpServerConfigWarning');
+    } finally {
+      process.emitWarning = original;
+    }
   });
 });

--- a/test/lib/seed-per-tool-wiring.test.js
+++ b/test/lib/seed-per-tool-wiring.test.js
@@ -3497,3 +3497,113 @@ describe('createAdcpServer — sandbox-gate debug log on resolved-account mismat
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// #1784 — construction-time warn when `testController` is registered without
+// any account resolver. The dispatch-time sandbox gate admits requests where
+// `ctx.account === undefined`, so without `resolveAccount` (or
+// `resolveAccountFromAuth`) the only remaining check is the buyer-supplied
+// `account.sandbox` / `context.sandbox` marker — caller-controlled, not a
+// trust boundary. The warn makes that silent failure mode loud once, without
+// breaking the legitimate storyboard-runner case (runner-without-resolver
+// configs simply ignore the warning).
+// ---------------------------------------------------------------------------
+
+describe('createAdcpServer — trust-boundary warn when testController lacks resolveAccount (#1784)', () => {
+  function makeRecordingLogger() {
+    const records = { debug: [], info: [], warn: [], error: [] };
+    return {
+      logger: {
+        debug: (msg, data) => records.debug.push({ msg, data }),
+        info: (msg, data) => records.info.push({ msg, data }),
+        warn: (msg, data) => records.warn.push({ msg, data }),
+        error: (msg, data) => records.error.push({ msg, data }),
+      },
+      records,
+    };
+  }
+
+  const MATCH = /testController is registered but no account resolver is configured/;
+
+  it('warns once at construction when testController is set and neither resolver is configured', () => {
+    const { logger, records } = makeRecordingLogger();
+    _createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      logger,
+      validation: { requests: 'off', responses: 'off' },
+      mediaBuy: { getProducts: async () => ({ products: [] }) },
+      testController: { getSeededProducts: () => [] },
+    });
+    const hits = records.warn.filter(r => MATCH.test(r.msg));
+    assert.equal(hits.length, 1, 'warn fires exactly once');
+  });
+
+  it('does not warn when testController is omitted (state-local seller)', () => {
+    const { logger, records } = makeRecordingLogger();
+    _createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      logger,
+      validation: { requests: 'off', responses: 'off' },
+      mediaBuy: { getProducts: async () => ({ products: [] }) },
+      // no testController, no resolver — state-local seller path
+    });
+    const hits = records.warn.filter(r => MATCH.test(r.msg));
+    assert.equal(hits.length, 0);
+  });
+
+  it('does not warn when resolveAccount is configured', () => {
+    const { logger, records } = makeRecordingLogger();
+    _createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      logger,
+      validation: { requests: 'off', responses: 'off' },
+      resolveAccount: () => ({ account_id: 'a', sandbox: true }),
+      mediaBuy: { getProducts: async () => ({ products: [] }) },
+      testController: { getSeededProducts: () => [] },
+    });
+    const hits = records.warn.filter(r => MATCH.test(r.msg));
+    assert.equal(hits.length, 0);
+  });
+
+  it('does not warn when resolveAccountFromAuth is configured (OAuth-passthrough setups)', () => {
+    const { logger, records } = makeRecordingLogger();
+    _createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      logger,
+      validation: { requests: 'off', responses: 'off' },
+      resolveAccountFromAuth: () => ({ account_id: 'a', sandbox: true }),
+      mediaBuy: { getProducts: async () => ({ products: [] }) },
+      testController: { getSeededProducts: () => [] },
+    });
+    const hits = records.warn.filter(r => MATCH.test(r.msg));
+    assert.equal(hits.length, 0);
+  });
+
+  it('does not re-warn on subsequent dispatches', async () => {
+    const { logger, records } = makeRecordingLogger();
+    const server = _createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      logger,
+      validation: { requests: 'off', responses: 'off' },
+      mediaBuy: { getProducts: async () => ({ products: [] }) },
+      testController: { getSeededProducts: () => [] },
+    });
+    await dispatch(server, 'get_products', {
+      brief: 'x',
+      buying_mode: 'brief',
+      account: SANDBOX_ACCOUNT,
+    });
+    await dispatch(server, 'get_products', {
+      brief: 'x',
+      buying_mode: 'brief',
+      account: SANDBOX_ACCOUNT,
+    });
+    const hits = records.warn.filter(r => MATCH.test(r.msg));
+    assert.equal(hits.length, 1, 'warn fires once across construction + N requests');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1784. When `createAdcpServer` is called with `testController` set but neither `resolveAccount` nor `resolveAccountFromAuth` configured, emit a one-shot `logger.warn` at construction.

The dispatch-time sandbox gate (`src/lib/server/create-adcp-server.ts:3973-3981`) admits requests where `ctx.account === undefined`. Without an account resolver, `ctx.account` is always `undefined`, so the only remaining check is the buyer-supplied `account.sandbox` / `context.sandbox` marker — caller-controlled, not a trust boundary. This is the gap the security review on #1786 flagged as M1; the JSDoc updates in #1786 and #1787 document it, but JSDoc doesn't fire when adopters misconfigure. This PR adds the runtime equivalent.

## Why a warn, not a throw

Storyboard-runner deployments without account scoping are a legitimate and intentional configuration — the runner drives state directly, no buyer authentication path needed. Failing construction would break that case. The warn is the right severity: visible in any logging setup, ignorable for runners, actionable for adopters.

## OAuth-passthrough handling

The check gates on `resolveAccountFromAuth` as well as `resolveAccount`. OAuth-passthrough setups (`createOAuthPassthroughResolver`, the canonical Shape-B adopter path from the v6.7 → 6.9 migration) only configure the latter — either resolver populates `ctx.account` at dispatch and gives the gate its account-side teeth, so warning on `resolveAccountFromAuth`-only setups would be a spurious noise floor.

## JSDoc cross-link

`TestControllerBridge` (in `test-controller-bridge.ts`) now mentions the construction-time warn so adopters know what triggers it and how to silence it.

## Test plan

- [x] Five regression tests in `test/lib/seed-per-tool-wiring.test.js`:
  - warn fires once when `testController` + neither resolver
  - no warn when `testController` is omitted
  - no warn when `resolveAccount` is configured
  - no warn when `resolveAccountFromAuth` is configured (OAuth passthrough)
  - warn fires **exactly once** across construction + multiple dispatches (not per-request)
- [x] All 143 existing tests in the file pass unchanged
- [x] `tsc --noEmit` clean
- [x] `prettier --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)