### PR TITLE
chore(eslint-plugin): pin publishConfig.access to public

### DIFF
--- a/.changeset/eslint-plugin-publish-config.md
+++ b/.changeset/eslint-plugin-publish-config.md
@@ -1,0 +1,9 @@
+---
+'@adcp/eslint-plugin': patch
+---
+
+chore(eslint-plugin): pin `publishConfig.access` to `public`
+
+Adds `"publishConfig": { "access": "public" }` to `packages/eslint-plugin/package.json`. The 0.1.0 release workflow first-publish failed with `E404` because npm defaults brand-new scoped packages to **restricted** access, which requires either a paid org or an explicit `--access public` flag. With `publishConfig.access` set, future automated `changeset publish` runs publish the package as public without needing the CLI flag — same posture as `@adcp/sdk`, which has been public since first publish.
+
+No runtime change. Rule logic, exports, and dependencies are unchanged.

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -35,6 +35,9 @@
   "bugs": {
     "url": "https://github.com/adcontextprotocol/adcp-client/issues"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "peerDependencies": {
     "eslint": "^8.0.0 || ^9.0.0 || ^10.0.0"
   },


### PR DESCRIPTION
## Summary

Adds `\"publishConfig\": { \"access\": \"public\" }` to `packages/eslint-plugin/package.json`.

## Why

The Release workflow on PR #1749 attempted to publish `@adcp/eslint-plugin@0.1.0` and failed with `E404` because npm defaults brand-new scoped packages to **restricted** access. Without a paid org or an explicit `--access public` flag, the registry rejected the PUT.

The package has since been seeded manually on npm (under the `brianokelley` user, with the `@adcp` org's trusted publisher configured for the `adcontextprotocol/adcp-client` repo's `release.yml` workflow). The failed Release workflow has been re-triggered to publish `0.1.0` over the manual `0.0.0` seed via OIDC.

This PR is the **hygiene follow-up**: pinning `publishConfig.access` to `\"public\"` ensures future automated `changeset publish` runs publish the package as public without needing the CLI flag — same posture as `@adcp/sdk`, which has been public from first publish.

## What changed

- `packages/eslint-plugin/package.json` — added the `publishConfig` block (3 lines).
- `.changeset/eslint-plugin-publish-config.md` — patch changeset on `@adcp/eslint-plugin`.

## What did NOT change

- Rule logic — `no-credential-read-from-args` is untouched.
- Dependencies, peer deps, exports — all unchanged.
- No runtime behavior shift for anyone consuming the plugin.

## Test plan

- [x] `prettier --check` clean
- [ ] CI green
- [ ] Release PR consumes the changeset, bumps `@adcp/eslint-plugin` to `0.1.1`
- [ ] Auto-publish on Release-PR merge succeeds without `--access public` CLI flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)