### PR TITLE
fix(sdk): re-export BrandJson and AdagentsJson types from main barrel

### DIFF
--- a/.changeset/wellknown-schemas-barrel-export.md
+++ b/.changeset/wellknown-schemas-barrel-export.md
@@ -1,0 +1,9 @@
+---
+'@adcp/sdk': patch
+---
+
+fix(sdk): re-export BrandJson and AdagentsJson types from main barrel
+
+The `wellknown-schemas.generated.ts` module emits `BrandJson` / `AdagentsJson` (inferred types) and `BrandJsonSchema` / `AdagentsJsonSchema` (runtime Zod validators) for the brand.json and adagents.json well-known formats, but at 7.1.0–7.2.0 those exports were unreachable from `@adcp/sdk` — only `@adcp/sdk/types` and `@adcp/sdk/testing` carried them. Consumers doing `import type { BrandJson } from '@adcp/sdk'` (e.g. `adcontextprotocol/adcp` `server/src/types.ts:1`, see adcp#4604) failed with `TS2305: Module '"@adcp/sdk"' has no exported member 'BrandJson'`.
+
+#1740 fixed this in the `src/lib/types/index.ts` sub-barrel and the main barrel picks it up transitively via `export * from './types'`. This change pins the contract explicitly at `src/lib/index.ts` so it is visible at the top-level public API surface and not dependent on the sub-barrel's wildcard re-export, plus adds a smoke test asserting both the runtime exports and the `.d.ts` type declarations resolve from `dist/lib/index.{js,d.ts}`.

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -547,6 +547,16 @@ export type {
   CreativeBrief,
 } from './types/core.generated';
 
+// ====== WELL-KNOWN FILE TYPES ======
+// brand.json / adagents.json shapes inferred from the canonical Zod schemas.
+// Re-exported explicitly here (in addition to the transitive `export * from
+// './types'` above) so the top-level public API contract is visible at the
+// main barrel and not dependent on the sub-barrel's wildcard re-export.
+// Source of truth: schemas/cache/{version}/{brand,adagents}.json — regenerate
+// with `npm run generate-wellknown-schemas` when the spec bumps.
+export type { BrandJson, AdagentsJson } from './types/wellknown-schemas.generated';
+export { BrandJsonSchema, AdagentsJsonSchema } from './types/wellknown-schemas.generated';
+
 // ====== ERROR CODES ======
 // Standard error code vocabulary for programmatic error handling
 export type { Error as TaskErrorDetail } from './types/core.generated';

--- a/test/lib/brand-json-schema.test.js
+++ b/test/lib/brand-json-schema.test.js
@@ -1,5 +1,7 @@
 const { describe, test } = require('node:test');
 const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const {
   BrandJsonSchema,
@@ -176,5 +178,42 @@ describe('Sandbox brand_json validation', () => {
         assert.ok(Array.isArray(entry.names), `${brand.domain}: names must be an array`);
       }
     }
+  });
+});
+
+// Locks the contract that `BrandJson` / `AdagentsJson` (types) and
+// `BrandJsonSchema` / `AdagentsJsonSchema` (runtime Zod validators) are
+// reachable from the top-level `@adcp/sdk` barrel. Pre-7.3.0 these symbols
+// were only reachable via deep imports of `wellknown-schemas.generated`, which
+// broke `import type { BrandJson } from '@adcp/sdk'` in downstream consumers.
+describe('top-level barrel exports', () => {
+  test('BrandJsonSchema and AdagentsJsonSchema resolve from dist/lib/index.js', () => {
+    const barrel = require('../../dist/lib/index.js');
+    assert.strictEqual(
+      typeof barrel.BrandJsonSchema?.safeParse,
+      'function',
+      'BrandJsonSchema missing from top-level barrel'
+    );
+    assert.strictEqual(
+      typeof barrel.AdagentsJsonSchema?.safeParse,
+      'function',
+      'AdagentsJsonSchema missing from top-level barrel'
+    );
+    assert.strictEqual(
+      barrel.BrandJsonSchema,
+      BrandJsonSchema,
+      'top-level and testing-barrel BrandJsonSchema must be the same instance'
+    );
+    assert.strictEqual(
+      barrel.AdagentsJsonSchema,
+      AdagentsJsonSchema,
+      'top-level and testing-barrel AdagentsJsonSchema must be the same instance'
+    );
+  });
+
+  test('BrandJson and AdagentsJson type aliases are declared in dist/lib/index.d.ts', () => {
+    const decls = fs.readFileSync(path.join(__dirname, '..', '..', 'dist', 'lib', 'index.d.ts'), 'utf8');
+    assert.match(decls, /\bBrandJson\b/, 'BrandJson must appear in dist/lib/index.d.ts');
+    assert.match(decls, /\bAdagentsJson\b/, 'AdagentsJson must appear in dist/lib/index.d.ts');
   });
 });


### PR DESCRIPTION
## Summary

- The `wellknown-schemas.generated.ts` module emits `BrandJson` / `AdagentsJson` (inferred types) and `BrandJsonSchema` / `AdagentsJsonSchema` (runtime Zod validators) for brand.json and adagents.json, but at 7.1.0–7.2.0 those exports were unreachable from `@adcp/sdk` — only `@adcp/sdk/types` and `@adcp/sdk/testing` carried them. Consumers doing `import type { BrandJson } from '@adcp/sdk'` failed with `TS2305: Module '"@adcp/sdk"' has no exported member 'BrandJson'`.
- #1740 fixed this in `src/lib/types/index.ts` (the sub-barrel), and the main barrel picks it up transitively via `export * from './types'`. This change pins the contract **explicitly** at `src/lib/index.ts` so it is visible at the top-level public API surface and not dependent on the sub-barrel's wildcard re-export.
- Adds a smoke test that asserts both the runtime exports (`BrandJsonSchema.safeParse` is a function, same instance as the testing sub-barrel) and the `.d.ts` type declarations (`BrandJson`, `AdagentsJson`) resolve from `dist/lib/index.{js,d.ts}`.

## Why now

Downstream consumer `adcontextprotocol/adcp` `server/src/types.ts:1` does `import type { BrandJson } from '@adcp/sdk'` and the pre-commit hook on that repo runs `tsc`. When the consumer is pinned to 7.1.0/7.2.0, every commit on `adcp` is blocked. See `adcontextprotocol/adcp#4604`. Even though 7.3.0+ resolves this transitively, the explicit re-export is the safer contract — wildcard re-exports through `./types` are easy to break in a future refactor.

## Surface area

- `src/lib/index.ts` — adds two lines:
  ```ts
  export type { BrandJson, AdagentsJson } from './types/wellknown-schemas.generated';
  export { BrandJsonSchema, AdagentsJsonSchema } from './types/wellknown-schemas.generated';
  ```
- `test/lib/brand-json-schema.test.js` — appends `describe('top-level barrel exports', ...)` block locking the contract.
- `.changeset/wellknown-schemas-barrel-export.md` — patch-level changeset.
- The codegen script (`scripts/generate-wellknown-schemas.ts`) writes only the generated module; the barrel is hand-maintained, so no codegen change is needed.

## Test plan

- [x] `npm run typecheck` — clean.
- [x] `npm run build:lib` — produces explicit `BrandJsonSchema` / `AdagentsJsonSchema` re-exports in `dist/lib/index.{d.ts,js}`.
- [x] `node --test test/lib/brand-json-schema.test.js` — 16/16 pass, including the two new top-level-barrel tests.
- [x] Full `npm test` — 8882/8882 SDK tests pass (one pre-existing flake in `storyboard-security.test.js` `rawA2aProbe` reproduces only under full-suite concurrency and passes 96/96 when run in isolation, both before and after this change).

## Downstream

- `adcontextprotocol/adcp#4604` — consumer that hit the regression; will pick this up on the next SDK bump.

## Review

Routing to SDK maintainer / spec-owner. Patch-level changeset; the release flow chooses the actual version.