### PR TITLE
fix(protocols): normalize adcp_version to release-precision on the wire

### DIFF
--- a/.changeset/wire-version-release-precision.md
+++ b/.changeset/wire-version-release-precision.md
@@ -1,0 +1,41 @@
+---
+'@adcp/sdk': patch
+---
+
+fix(protocols): normalize `adcp_version` to release-precision on the wire
+
+The `adcp_version` envelope field added in AdCP 3.1 (spec PR
+adcontextprotocol/adcp#3493) is constrained to release-precision strings
+by `core/version-envelope.json`'s pattern `^\d+\.\d+(-[a-zA-Z0-9.-]+)?$`.
+Full-semver bundle keys (`'3.1.0-beta.0'`) are explicitly NOT valid wire
+values per the envelope schema's own normalization rule:
+
+> SDKs that read full-semver values from bundle metadata MUST normalize
+> to release-precision before emitting on the wire — meta-field values
+> are NOT valid wire values.
+
+Before this fix, `buildVersionEnvelope` emitted the bundle key verbatim
+for prerelease pins. A 3.1.0-beta-pinned client would send
+`adcp_version: "3.1.0-beta.0"`, which sellers AJV-reject with a pattern
+mismatch. The bug was latent: today's `COMPATIBLE_ADCP_VERSIONS` doesn't
+include any 3.1.x release, so no public-pin path could hit it — but a
+caller manually overriding `adcpVersion` past the compat gate (or the
+SDK's eventual 3.1 enablement) would silently break.
+
+This change introduces `toReleasePrecisionWire(bundleKeyOrVersion)`:
+
+- Stable bundle keys (`'3.0'`, `'3.1'`) pass through unchanged.
+- Prerelease semver collapses the PATCH segment, preserving the
+  prerelease tag: `'3.1.0-beta.0'` → `'3.1-beta.0'`.
+- Full stable semver collapses to minor: `'3.0.11'` → `'3.0'`.
+- Legacy aliases (`'v3'`) pass through (they're gated out of the wire
+  field by `bundleSupportsAdcpVersionField` anyway).
+
+`buildVersionEnvelope` now applies the normalizer at the single emit
+site. The function is also exported publicly so adopters that hand-roll
+their own wire envelopes (storyboard fixtures, conformance harnesses)
+get the same shape the SDK emits.
+
+Added `test/lib/adcp-version-release-precision.test.js` covering the
+seven shape cases plus a cross-check that every non-legacy output
+matches the spec's wire pattern.

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -886,6 +886,7 @@ export {
   closeMCPConnections,
   bundleSupportsAdcpVersionField,
 } from './protocols';
+export { toReleasePrecisionWire } from './validation/schema-loader';
 export type { CallToolOptions, TransportOptions } from './protocols';
 
 // ====== RESPONSE UTILITIES ======

--- a/src/lib/protocols/index.ts
+++ b/src/lib/protocols/index.ts
@@ -46,7 +46,7 @@ import { validateAgentUrl } from '../validation';
 import { withSpan } from '../observability/tracing';
 import { ADCP_MAJOR_VERSION, ADCP_VERSION, parseAdcpMajorVersion } from '../version';
 import { ConfigurationError } from '../errors';
-import { resolveBundleKey } from '../validation/schema-loader';
+import { resolveBundleKey, toReleasePrecisionWire } from '../validation/schema-loader';
 import { buildAgentSigningContext, CAPABILITY_OP, ensureCapabilityLoaded } from '../signing/client';
 import { withResponseSizeLimit } from './responseSizeLimit';
 
@@ -102,9 +102,12 @@ export function bundleSupportsAdcpVersionField(bundleKey: string): boolean {
  * define the string field, so a 3.0-pinned client emits the integer only —
  * matches the 3.0 spec exactly.
  *
- * Release-precision string follows `resolveBundleKey`: `'3.0'`, `'3.1'`,
- * `'3.1.0-beta.1'` (prereleases stay verbatim — spec rule: pre-release pins
- * matched exactly).
+ * Wire string is release-precision (MAJOR.MINOR with optional prerelease tag),
+ * per `core/version-envelope.json`'s pattern `^\d+\.\d+(-[a-zA-Z0-9.-]+)?$`.
+ * Full-semver bundle keys (`'3.1.0-beta.1'`) are collapsed via
+ * `toReleasePrecisionWire` to `'3.1-beta.1'` before emit — meta-field shapes
+ * are explicitly NOT valid wire values per the envelope schema's own
+ * normalization rule.
  *
  * Returns `{}` for v2 callers (predates the major-version field entirely).
  */
@@ -118,7 +121,7 @@ function buildVersionEnvelope(
   if (!bundleSupportsAdcpVersionField(bundleKey)) {
     return { adcp_major_version: wireMajor };
   }
-  return { adcp_major_version: wireMajor, adcp_version: bundleKey };
+  return { adcp_major_version: wireMajor, adcp_version: toReleasePrecisionWire(bundleKey) };
 }
 
 /**

--- a/src/lib/validation/schema-loader.ts
+++ b/src/lib/validation/schema-loader.ts
@@ -85,6 +85,58 @@ export function resolveBundleKey(version: string): string {
 }
 
 /**
+ * Collapse a bundle key to the release-precision string the AdCP wire schema
+ * accepts for the `adcp_version` envelope field (spec PR
+ * `adcontextprotocol/adcp#3493`). The wire pattern is
+ * `^\d+\.\d+(-[a-zA-Z0-9.-]+)?$` — release-precision (MAJOR.MINOR with
+ * optional prerelease), never full MAJOR.MINOR.PATCH semver.
+ *
+ *   - Stable bundle key `'3.0'` / `'3.1'` → returned verbatim.
+ *   - Prerelease bundle key `'3.1.0-beta.0'` → `'3.1-beta.0'` (PATCH segment
+ *     dropped; the prerelease tag is the wire-meaningful release identifier,
+ *     PATCH is implementation-internal).
+ *   - Full stable semver `'3.0.11'` → `'3.0'` (patches don't change wire
+ *     shape; surface them via `build_version` on capabilities instead).
+ *   - Legacy alias `'v3'` / `'v2.5'` — returned verbatim. The wire spec
+ *     predates the envelope field, so legacy-aliased clients won't emit
+ *     `adcp_version` anyway (gated by `bundleSupportsAdcpVersionField`).
+ *
+ * The normalization rule is declared in `core/version-envelope.json`:
+ *
+ *   > SDKs that read full-semver values from bundle metadata (e.g.
+ *   > ComplianceIndex.published_version = "3.1.0-beta.1") MUST normalize to
+ *   > release-precision ("3.1-beta.1") before emitting on the wire —
+ *   > meta-field values are NOT valid wire values.
+ *
+ * Defense: rejecting unrecognized shapes here surfaces SDK-internal misuse
+ * (someone calling this with raw garbage) loudly instead of silently
+ * emitting a non-spec wire string.
+ */
+export function toReleasePrecisionWire(bundleKeyOrVersion: string): string {
+  // Bare release-precision (MAJOR.MINOR or MAJOR.MINOR-PRE) — already wire-shaped.
+  const releasePrecision = bundleKeyOrVersion.match(/^(\d+)\.(\d+)(-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/);
+  if (releasePrecision) {
+    const [, major, minor, prerelease = ''] = releasePrecision;
+    return `${major}.${minor}${prerelease}`;
+  }
+  // Full semver — collapse PATCH segment. Prerelease (if any) is preserved.
+  const fullSemver = bundleKeyOrVersion.match(/^(\d+)\.(\d+)\.\d+(-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/);
+  if (fullSemver) {
+    const [, major, minor, prerelease = ''] = fullSemver;
+    return `${major}.${minor}${prerelease}`;
+  }
+  // Legacy alias passthrough. Callers that reach here with a legacy alias
+  // shouldn't be emitting `adcp_version` (no version-envelope support), but
+  // returning the input verbatim is least-surprise.
+  if (/^v\d+(\.\d+)?$/.test(bundleKeyOrVersion)) return bundleKeyOrVersion;
+  throw new ConfigurationError(
+    `Cannot normalize ${JSON.stringify(bundleKeyOrVersion)} to release-precision wire format. ` +
+      `Expected a bundle key or AdCP version string.`,
+    'adcpVersion'
+  );
+}
+
+/**
  * Resolve the directory that holds the bundled + core schemas for a given
  * AdCP version. Source layout (dev):
  *   schemas/cache/<exact-version>/{bundled,core}

--- a/src/lib/validation/schema-loader.ts
+++ b/src/lib/validation/schema-loader.ts
@@ -108,6 +108,20 @@ export function resolveBundleKey(version: string): string {
  *   > release-precision ("3.1-beta.1") before emitting on the wire —
  *   > meta-field values are NOT valid wire values.
  *
+ * **Idempotent.** Re-applying to an already-wire-shaped value is a no-op:
+ * `toReleasePrecisionWire('3.1-beta.0') === '3.1-beta.0'`. Safe to call
+ * defensively on values a caller read off the wire and is passing back.
+ *
+ * **Prerelease regex is stricter than the wire pattern by design.** The wire
+ * pattern allows `[a-zA-Z0-9.-]+` (any mix of dots and hyphens), but this
+ * function only accepts SemVer §9-shaped prerelease tags
+ * (`[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*`) — disallowing leading dots, double
+ * dots, or trailing dots. Mirrors the path-traversal hardening on
+ * {@link resolveBundleKey} (`'3.0.0-/../etc'`-style strings can't reach the
+ * filesystem there, and shouldn't be silently mirrored to the wire here).
+ * A future reader who wants to "fix" this to match the wire regex
+ * character-for-character should NOT — the strictness is intentional.
+ *
  * Defense: rejecting unrecognized shapes here surfaces SDK-internal misuse
  * (someone calling this with raw garbage) loudly instead of silently
  * emitting a non-spec wire string.

--- a/test/lib/adcp-version-release-precision.test.js
+++ b/test/lib/adcp-version-release-precision.test.js
@@ -1,0 +1,91 @@
+// toReleasePrecisionWire normalizes bundle keys / version strings to the
+// release-precision shape the AdCP 3.1 envelope schema accepts. The wire
+// pattern (declared in core/version-envelope.json) is
+// `^\d+\.\d+(-[a-zA-Z0-9.-]+)?$` — full-semver bundle keys
+// (`'3.1.0-beta.0'`) are NOT valid wire values per the schema's own
+// normalization rule, and a 3.1-pinned client must collapse the PATCH
+// segment before emitting `adcp_version`.
+//
+// Without this normalization, buildVersionEnvelope emits the bundle key
+// verbatim, sellers AJV-reject the request body with a pattern error,
+// and 3.1+ pinning is silently broken.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+
+const { toReleasePrecisionWire } = require('../../dist/lib/index.js');
+
+// The exact pattern from /schemas/3.1.0-beta.0/core/version-envelope.json.
+// Pinned here so the test catches a wire-emit regression even if a future
+// schema cache isn't present in CI.
+const WIRE_PATTERN = /^\d+\.\d+(-[a-zA-Z0-9.-]+)?$/;
+
+describe('toReleasePrecisionWire — release-precision normalization', () => {
+  test('stable bundle keys pass through unchanged', () => {
+    assert.strictEqual(toReleasePrecisionWire('3.0'), '3.0');
+    assert.strictEqual(toReleasePrecisionWire('3.1'), '3.1');
+    assert.strictEqual(toReleasePrecisionWire('4.0'), '4.0');
+  });
+
+  test('full stable semver collapses PATCH segment', () => {
+    assert.strictEqual(toReleasePrecisionWire('3.0.0'), '3.0');
+    assert.strictEqual(toReleasePrecisionWire('3.0.11'), '3.0');
+    assert.strictEqual(toReleasePrecisionWire('3.1.2'), '3.1');
+  });
+
+  test('prerelease semver collapses PATCH, preserves prerelease tag', () => {
+    assert.strictEqual(toReleasePrecisionWire('3.1.0-beta.0'), '3.1-beta.0');
+    assert.strictEqual(toReleasePrecisionWire('3.1.0-beta.1'), '3.1-beta.1');
+    assert.strictEqual(toReleasePrecisionWire('3.1.0-rc.2'), '3.1-rc.2');
+    assert.strictEqual(toReleasePrecisionWire('3.0.0-beta.3'), '3.0-beta.3');
+  });
+
+  test('release-precision-shaped input passes through unchanged', () => {
+    // Sellers advertise supported_versions in this exact shape — buyers
+    // pinning to a string they read off the wire must be idempotent.
+    assert.strictEqual(toReleasePrecisionWire('3.1-beta'), '3.1-beta');
+    assert.strictEqual(toReleasePrecisionWire('3.1-beta.0'), '3.1-beta.0');
+    assert.strictEqual(toReleasePrecisionWire('3.0-rc.1'), '3.0-rc.1');
+  });
+
+  test('legacy aliases pass through unchanged', () => {
+    // Legacy-aliased clients don't carry the envelope field anyway, so
+    // round-tripping these is documentation-only — but the function MUST
+    // not throw on inputs the rest of the version surface accepts.
+    assert.strictEqual(toReleasePrecisionWire('v3'), 'v3');
+    assert.strictEqual(toReleasePrecisionWire('v2.5'), 'v2.5');
+    assert.strictEqual(toReleasePrecisionWire('v2.6'), 'v2.6');
+  });
+
+  test('all valid outputs match the version-envelope.json wire pattern', () => {
+    // Cross-check: every non-legacy output of the normalizer must be
+    // accepted by the schema's own `adcp_version` pattern. Without this
+    // assertion the function could "succeed" while emitting a value
+    // sellers will pattern-reject.
+    const stableBundles = ['3.0', '3.1', '4.0', '5.2'];
+    const fullSemvers = ['3.0.0', '3.0.11', '3.1.2'];
+    const prereleases = ['3.1.0-beta.0', '3.0.0-rc.1', '3.1.0-rc.2'];
+    const releasePrecision = ['3.1-beta', '3.1-beta.0', '3.0-rc.1'];
+
+    for (const input of [...stableBundles, ...fullSemvers, ...prereleases, ...releasePrecision]) {
+      const wire = toReleasePrecisionWire(input);
+      assert.match(
+        wire,
+        WIRE_PATTERN,
+        `toReleasePrecisionWire(${JSON.stringify(input)}) = ${JSON.stringify(wire)} ` +
+          `must satisfy version-envelope.json pattern ${WIRE_PATTERN}`
+      );
+    }
+  });
+
+  test('rejects unrecognized shapes loudly', () => {
+    // Internal misuse surfaces as a ConfigurationError rather than a
+    // silent wire-shape violation. Don't tighten the assertion to a
+    // specific class — the throw is enough.
+    assert.throws(() => toReleasePrecisionWire(''));
+    assert.throws(() => toReleasePrecisionWire('not-a-version'));
+    assert.throws(() => toReleasePrecisionWire('3'));
+    assert.throws(() => toReleasePrecisionWire('3.x'));
+    assert.throws(() => toReleasePrecisionWire('3.0.0.0'));
+  });
+});

--- a/test/lib/adcp-version-release-precision.test.js
+++ b/test/lib/adcp-version-release-precision.test.js
@@ -87,5 +87,19 @@ describe('toReleasePrecisionWire — release-precision normalization', () => {
     assert.throws(() => toReleasePrecisionWire('3'));
     assert.throws(() => toReleasePrecisionWire('3.x'));
     assert.throws(() => toReleasePrecisionWire('3.0.0.0'));
+    // Trailing dot on prerelease — wire regex would accept (`.` is in the
+    // wire char class) but SemVer §9 says prerelease IDs can't be empty,
+    // so this is rejected. Confirms the "stricter than wire pattern" note
+    // in the JSDoc is enforced by code, not just doc.
+    assert.throws(() => toReleasePrecisionWire('3.1.0-beta.'));
+    assert.throws(() => toReleasePrecisionWire('3.0.'));
+  });
+
+  test('leading-zero inputs round-trip (wire-valid by spec pattern)', () => {
+    // The spec wire pattern is `\d+\.\d+` — `'03.01'` matches. The
+    // normalizer follows suit rather than imposing extra structure no
+    // upstream caller is asking for. Documents the precedence story:
+    // we don't normalize numeric components, only the patch-collapse.
+    assert.strictEqual(toReleasePrecisionWire('03.01'), '03.01');
   });
 });


### PR DESCRIPTION
## Summary
- Adds `toReleasePrecisionWire(bundleKeyOrVersion)` next to `resolveBundleKey` in `schema-loader.ts`.
- Wires it into `buildVersionEnvelope` at the single emit site so prerelease pins emit spec-valid wire values.
- Exports it publicly for storyboard fixtures + conformance harnesses that build their own wire envelopes.

## Why this matters

AdCP 3.1's `core/version-envelope.json` constrains the `adcp_version` field to release-precision strings via pattern `^\d+\.\d+(-[a-zA-Z0-9.-]+)?$`. The schema's own description carries the normalization rule:

> SDKs that read full-semver values from bundle metadata (e.g. ComplianceIndex.published_version = "3.1.0-beta.1") MUST normalize to release-precision ("3.1-beta.1") before emitting on the wire — meta-field values are NOT valid wire values.

Before this fix, `buildVersionEnvelope` emitted the bundle key verbatim, so a 3.1.0-beta-pinned client would send `adcp_version: "3.1.0-beta.0"` and sellers would AJV-reject the request body with a pattern mismatch.

The bug is **latent** today — `COMPATIBLE_ADCP_VERSIONS` doesn't include any 3.1.x release, so no public-pin path can hit it. But a caller manually overriding `adcpVersion` past the compat gate, or the SDK's eventual 3.1 enablement, would silently break. Found while staging a local 3.1.0-beta cache from spec PR adcontextprotocol/adcp#3307 and exercising `buildVersionEnvelope` against the real envelope schema.

## How it works

`toReleasePrecisionWire`:
- Stable bundle keys (`'3.0'`, `'3.1'`) pass through unchanged.
- Prerelease semver collapses the PATCH segment, preserving the prerelease tag: `'3.1.0-beta.0'` → `'3.1-beta.0'`.
- Full stable semver collapses to minor: `'3.0.11'` → `'3.0'`.
- Legacy aliases (`'v3'`) pass through (gated out of the wire field by `bundleSupportsAdcpVersionField` anyway).
- Rejects unrecognized shapes loudly rather than silently emitting non-spec values.

## Verification

End-to-end check: emitted envelopes for `bundle = '3.0' | '3.1' | '3.1.0-beta.0' | '3.0.11'` all validate against `core/version-envelope.json` from a locally-built 3.1.0-beta.0 cache.

## Test plan

- [x] 7 unit cases covering stable / prerelease / release-precision / legacy / garbage inputs.
- [x] Cross-check that every non-legacy output matches the spec's wire pattern.
- [x] All 28 existing version-envelope tests still pass.
- [x] `npm run format:check` clean.
- [x] `npm run typecheck` clean.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)