### PR TITLE
docs(development): draft 8.0 design proposal for AdCP 3.1 support

### DIFF
--- a/.changeset/v3.1-sdk-design-doc.md
+++ b/.changeset/v3.1-sdk-design-doc.md
@@ -1,0 +1,8 @@
+---
+---
+
+docs(development): 8.0 design proposal for AdCP 3.1 — V2-only public API, projection at the boundary, refinement-over-multiplication
+
+Docs-only addition at `docs/development/v3.1-sdk-design.md`. No library
+or CLI code changes; no release needed. Empty changeset satisfies the
+CI gate that requires changesets on every PR touching tracked files.

--- a/docs/development/v3.1-sdk-design.md
+++ b/docs/development/v3.1-sdk-design.md
@@ -1,28 +1,45 @@
-# SDK 8.0 design proposal — single-API support for AdCP 3.0 + 3.1
+# SDK 8.0 design proposal — flip adopters to the V2 mental model
 
 **Status:** draft for review. Not implemented. References to upstream spec assume PR [`adcontextprotocol/adcp#3307`](https://github.com/adcontextprotocol/adcp/pull/3307) lands as AdCP 3.1.0 substantially as written.
 
 **Audience:** SDK contributors and adopters who want to know what the 3.1 upgrade will feel like before it lands.
 
-## The question
+## The position
 
-AdCP 3.1 adds the canonical-formats system (11 canonicals + custom escape hatch), a release-precision version envelope on every payload, expanded capabilities discovery (`supported_versions`, `creative.supported_formats`, `bills_through_adcp`, `canonical_catalog_version`), and the `validate_input` tool. The wire surface is backwards-compatible — products MAY carry `format_ids`, `format_options`, or both — but the in-memory shape, codegen, and validation flow diverge.
+AdCP 3.1's canonical-formats system isn't a new feature alongside the old creative model — it's a new way to think about creatives, and a better one. The old model conflated two questions ("what formats does this sales agent support?") into one wire surface. The new model separates them cleanly:
 
-**The question this doc answers:** how should the SDK expose 3.1 to adopters so that they don't have to think about v1 vs v2?
+- **What can this publisher's inventory accept?** Read `Product.format_options` — declarations are tied to inventory, not seller-agent capability.
+- **What can this creative agent build or transform?** Read `get_adcp_capabilities.creative.supported_formats` on the creative agent — separate from the seller's inventory.
+
+The right product call for 8.0 is **to flip every SDK consumer to the V2 model**. We don't expose both vocabularies and let adopters pick — that's the engineer's compromise, and it leaves the ecosystem stuck in two minds forever. 8.0 is the major where adopters learn V2. The SDK's job is to make every seller — even ones still emitting v1 named formats on the wire — look V2-shaped to the adopter.
+
+## What V2 actually changes for the buyer's mental model
+
+The most adopter-visible win of V2 isn't the 11 canonical formats — it's that the **two questions about creatives finally have two separate answers** in the protocol.
+
+| Question | V1 answer | V2 answer |
+|---|---|---|
+| What can this publisher's inventory accept? | `list_creative_formats` on the sales agent (conflated — the agent might broker many publishers' inventory with different format support, and you couldn't tell from a single list). | `Product.format_options` — declarations live on the inventory itself, tied to the specific publisher property. |
+| What can this creative agent build or transform? | Same `list_creative_formats` call — but pointed at a creative agent instead of a sales agent. Same call, completely different semantics. The protocol let you read but didn't help you know which question you were asking. | `get_adcp_capabilities.creative.supported_formats` on the creative agent. Distinct from `Product.format_options`. The shape difference reflects the semantic difference. |
+
+The SDK should teach this distinction explicitly. Buyer code that mixed these up in v1 (a real failure mode — surprisingly easy to call `list_creative_formats` against the wrong agent type and get a useless catalog) becomes a typecheck error in V2 because the fields live in different places.
+
+This is what makes V2 worth flipping to. Not "additional functionality." A cleaner protocol vocabulary that maps onto how the business actually works: publishers declare what their inventory accepts; creative agents declare what they can build; buyers shop across both surfaces.
 
 ## Design goals
 
-1. **Zero forced migration.** An adopter sitting on `@adcp/sdk` 7.x with a v1-only codebase upgrades to 8.0 and their code keeps working. No type imports change. No type errors. No new fields they're required to set.
-2. **One mental model.** Adopters don't pick between a v1 client and a v2 client, or a v1 `Product` type and a v2 `Product` type. The SDK exposes one `Product` shape that carries both representations when projectable.
-3. **Opt-in for new functionality.** Adopters who want canonical formats, custom-shape validation, or `bills_through_adcp` routing read the v2 side. Adopters who don't care never see those fields in their hot path.
-4. **Honest about failure.** When v1↔v2 projection isn't possible (no registry match, no explicit canonical, `canonical_formats_only: true`), the SDK surfaces a structured diagnostic. **Never logger-only** — the spec explicitly forbids it (see `v1-canonical-mapping.json` resolution-order description).
-5. **Forward-compatible to 4.0.** The shapes we expose today shouldn't paint us into a corner when v1 paths are removed at 5.0 per the spec's deprecation calendar.
+1. **V2 is the mental model.** The public `Product` type carries `format_options`. Adopters write canonical-format code, period. The wire-level v1 representation is an implementation detail the SDK normalizes at the boundary.
+2. **The SDK is the v1 → v2 teacher.** When a seller emits only `format_ids`, the SDK projects to `format_options` via the spec's `v1-canonical-mapping.json` registry. Adopters don't write projection code; they don't think about v1 named formats. Fail-closed products surface via the diagnostic channel.
+3. **One API surface.** No `client.v1.*` / `client.v2.*` split. No version-tagged type imports. One `Product`, one mental model, one way to write a buyer.
+4. **Honest about failure.** When projection isn't possible (no registry match, no explicit canonical, `canonical_formats_only: true` going to a v1-only consumer), the SDK surfaces a structured diagnostic. **Never logger-only** — the spec explicitly forbids it (see `v1-canonical-mapping.json` resolution-order description).
+5. **Forward-compatible to 4.0.** Because adopters are already in the V2 mindset by the time 4.0 lands and v1 leaves the spec, the 8.0 → 9.0 transition becomes additive (SDK removes its internal v1 projection layer), not a second migration for adopters.
 
 ## Non-goals
 
-- Generating a single union `Product` type that contains all possible 3.0 + 3.1 fields. Codegen will produce versioned types under `src/lib/types/v3.0/` and `src/lib/types/v3.1/`. The public API uses the 3.1 type as the canonical shape; 3.0-only fields are absent (not `undefined`).
-- Two-step migration to canonical formats. We don't ship a "v1-only" 8.x followed by a "v2-aware" 8.x. The 8.0 line is canonical-formats-aware from day one.
-- Exposing the AAO mirror's custom-format hosting model. Adopters that want to publish a custom format follow the spec's hosting rules; the SDK consumes, it doesn't host.
+- **Exposing `Product.format_ids` as a top-level field on the public type.** Adopters who need to trace which v1 named format a seller emitted read `format_options[i].v1_format_ref` (already in the V2 schema for exactly this purpose). Top-level `format_ids` would re-create the "two vocabularies" problem the major bump is designed to resolve.
+- Generating a single union `Product` type that contains all possible 3.0 + 3.1 fields. Codegen produces versioned types under `src/lib/types/v3.0/` (internal-only, used by the projection layer) and `src/lib/types/v3.1/` (the public type). 3.0-only fields are absent from the public surface.
+- Two-step migration to canonical formats. We don't ship a "v1-only" 8.x followed by a "v2-aware" 8.x. The 8.0 line is V2-shaped from day one.
+- Exposing the AAO mirror's custom-format hosting model. Adopters publishing a custom format follow the spec's hosting rules; the SDK consumes, it doesn't host.
 
 ## Architecture
 
@@ -43,19 +60,23 @@ Negotiation algorithm (in order):
 3. If the SDK and seller share no major version, throw a typed `VersionMismatchError` at call time — fail-fast, no auto-downgrade past major boundaries.
 4. Within the same major, prefer release-precision string from the seller (`'3.1-beta'` if advertised) over the SDK's pin (`'3.1'`), so adopters using a 3.1.0 SDK against a `3.1-beta` seller don't get a silent VERSION_UNSUPPORTED.
 
-A 3.0-only seller continues to work: SDK negotiates down to `'3.0'`, doesn't emit `adcp_version` (gated by `bundleSupportsAdcpVersionField`), doesn't expect `format_options` on responses.
+A 3.0-only seller continues to work: SDK negotiates down to `'3.0'`, doesn't emit `adcp_version` (gated by `bundleSupportsAdcpVersionField`), doesn't expect `format_options` on the wire — but the SDK normalizes the v1 response into the V2-shaped `Product` before the adopter sees it.
 
-### Dual-shape `Product`
+### V2-shaped `Product`, transparent v1 normalization
 
-The SDK exposes a single `Product` type that always carries `format_ids` and may carry `format_options`. The seller's wire shape is normalized at the response boundary:
+The public `Product` carries `format_options` (V2). It does NOT carry a top-level `format_ids` field. Adopters write canonical-format code regardless of which version the seller speaks on the wire.
 
-| Seller emits | SDK populates |
+The SDK normalizes at the response boundary:
+
+| Seller emits on the wire | What the SDK presents |
 |---|---|
-| v1 only (`format_ids` populated, `format_options` absent) | v1 + v2 (project v1→v2 via registry; products with `FORMAT_PROJECTION_FAILED` keep `format_options` absent) |
-| v2 only (`format_options` populated, `format_ids` absent) | v1 + v2 (downgrade v2→v1; products with `canonical_formats_only: true` are omitted from v1 readers) |
-| Dual emission (both populated) | both populated, divergence checked (cross-references `v1_format_ref` against the registry; surfaces `FORMAT_DECLARATION_DIVERGENT` on conflict) |
+| v1 only (`format_ids` populated, `format_options` absent) | `Product.format_options` populated via the registry projection. Each entry carries `v1_format_ref` so adopters can trace the underlying named format. Products that fail projection (no registry match, no explicit `canonical`) surface with `format_options: []` and a `FORMAT_PROJECTION_FAILED` diagnostic. |
+| v2 only (`format_options` populated, `format_ids` absent on the wire) | `Product.format_options` passes through unchanged. |
+| Dual emission on the wire (both populated) | `Product.format_options` from the v2 side; `v1_format_ref` cross-checked against the wire's `format_ids` for divergence. Surfaces `FORMAT_DECLARATION_DIVERGENT` on conflict. |
 
-Symmetrically on the buyer's outbound side (`sync_creatives`, `create_media_buy`): if the seller is v1-only, the SDK downgrades the manifest; if v2-only, the SDK upshifts. The buyer code looks the same.
+Symmetrically on the buyer's outbound side (`sync_creatives`, `create_media_buy`): the adopter writes a V2 manifest. When the negotiated version is v1, the SDK downshifts at the wire boundary using `v1_format_ref` from the product's `format_options`. Products carrying `canonical_formats_only: true` are unreachable on a v1-only seller — the SDK surfaces a typed error at call time rather than silently dropping the assignment.
+
+The buyer's code looks identical against a v1 seller and a v2 seller. That's the goal.
 
 ### Projection layer
 
@@ -103,8 +124,20 @@ The diagnostic surface attaches to the response envelope's `errors[]` array per 
 
 ```ts
 const result = await client.getProducts({ brief: '...' });
-result.products;       // dual-shape, projected/normalized
-result.diagnostics;    // Diagnostic[] — empty array on the happy path
+
+// V2-shaped — works the same whether the seller speaks v1 or v2 on the wire.
+for (const product of result.products) {
+  for (const opt of product.format_options) {
+    switch (opt.format_kind) {
+      case 'video_hosted': /* typed params */ break;
+      case 'image': /* typed params */ break;
+      // ... 9 more canonicals + custom
+    }
+  }
+}
+
+// Honest about what didn't project cleanly.
+for (const d of result.diagnostics) console.warn(d.code, d.details);
 ```
 
 ### Custom format fetch utility
@@ -139,31 +172,36 @@ src/lib/types/
 └── index.ts                      # public re-exports: Product = v3.1.Product, etc.
 ```
 
-Public re-exports always use the latest stable version. Adopters who want a specific version import explicitly:
+The `v3.0/` types are **internal-only** — consumed by the projection layer when normalizing wire payloads from a v1 seller. They are NOT part of the public API surface. The only public `Product` is V2-shaped.
 
 ```ts
-import type { Product } from '@adcp/sdk';                      // 3.1 shape
-import type { Product as V30Product } from '@adcp/sdk/v3.0';   // 3.0 shape (rarely needed)
+import type { Product } from '@adcp/sdk';   // V2 shape — `format_options`, no top-level `format_ids`
 ```
 
-The `format_kind` discriminator becomes a clean TypeScript tagged union (12 branches: 11 canonicals + `custom`) so adopters get exhaustive-switch checks for free.
+The `format_kind` discriminator becomes a clean TypeScript tagged union (12 branches: 11 canonicals + `custom`) so adopters get exhaustive-switch checks for free. This is what the major bump buys us — adopters write `switch (opt.format_kind)` and let TypeScript enforce coverage, instead of pattern-matching on string-shaped `format_id.id` values that the seller could spell anything.
 
 ## Migration path
 
 | Line | What changes | Adopter action |
 |---|---|---|
 | 7.x | Defensive wire-envelope fix (PR #1807 — already shipped). Loose ends from any 3.1 work backported as patches when safe. | None. |
-| **8.0** | Full 3.1 enablement: auto-negotiation, dual-shape `Product`, projection layer, `fetchFormatSchema`, versioned codegen. `ADCP_VERSION` moves to `3.1.0`. `COMPATIBLE_ADCP_VERSIONS` adds `3.0.x` and `3.1.x`. | `npm install @adcp/sdk@^8`. Run typecheck — should pass without changes. Optional: read `result.diagnostics` to surface projection issues; opt into v2 fields for canonical-format-aware code. |
+| **8.0** | The major that flips you to the V2 mental model. Public `Product` carries `format_options` only. Projection layer hides v1 sellers behind the V2 shape. Auto-negotiation, `fetchFormatSchema`, versioned codegen (3.1 public; 3.0 internal). `ADCP_VERSION` moves to `3.1.0`; `COMPATIBLE_ADCP_VERSIONS` adds `3.0.x` and `3.1.x`. | `npm install @adcp/sdk@^8`. Migrate any code reading `Product.format_ids` to read `Product.format_options` (and `format_options[i].v1_format_ref` when you need the legacy named-format string). The codegen layout shift is the only mechanical break; everything else feels the same. |
 | 8.x | Hardening: additional registry entries as upstream adds them; codegen refinements; performance work on the projection layer. | None — additive. |
-| **9.0** | AdCP 4.0 lands. `list_creative_formats` and v1 `format_ids` removed per spec. SDK removes v1 projection paths; `Product.format_ids` becomes optional → removed. | Code that read `format_ids` becomes a typecheck error. Easy mechanical fix to read `format_options` instead. |
+| **9.0** | AdCP 4.0 lands. `list_creative_formats` and v1 `format_ids` removed from the spec. SDK retires the v1 projection layer (internal); public API doesn't change because adopters never saw v1 in the first place. | None for adopter code. Adopters who relied on `format_options[i].v1_format_ref` for ops traceability need to switch to another identifier (likely `capability_id` or the seller's own product_id). |
 
-The 8.0 → 9.0 gap is sized by spec deprecation timing. Per `v1-canonical-mapping.json` notes, v1 named formats remain valid through 4.x — so 8.0 lives until 4.0 is GA and 9.0 cuts when v1 leaves the spec.
+The 8.0 → 9.0 gap is sized by spec deprecation timing. Per `v1-canonical-mapping.json` notes, v1 named formats remain valid through 4.x — so 8.0 lives until 4.0 is GA and 9.0 cuts when v1 leaves the spec. The crucial property: because adopters wrote V2 code on 8.0, 9.0 is mostly an internal retirement, not a second mental-model migration.
 
 ## What we explicitly don't do
 
+### We don't expose v1 vocabulary on the public type
+
+The compromise of exposing both `format_ids` and `format_options` on `Product` looks helpful — old code keeps reading the old field, new code reads the new — but it freezes the ecosystem in two minds forever. Library authors writing on top of `@adcp/sdk` have to support both. Docs have to explain both. Examples have to pick. And the V2 mental model never lands.
+
+The major bump is the moment to commit. Adopters update their `Product.format_ids[]` reads to `Product.format_options[]` reads (one search-and-replace per call site). They never write v1 code again. The SDK does the wire-level translation.
+
 ### We don't ship two namespaces
 
-A `client.v1.getProducts()` / `client.v2.getProducts()` split looks honest but breaks goals #1 and #2. Adopters reading docs see two surfaces and have to choose; library authors writing on top of `@adcp/sdk` have to support both; the type system can't express "this is the canonical format if available, the v1 named format otherwise" without a union the adopter unwraps. Single API + dual-shape is strictly more ergonomic.
+A `client.v1.getProducts()` / `client.v2.getProducts()` split is worse than dual-shape — same two-vocabulary problem, plus two call surfaces to maintain. Single API, V2-only types.
 
 ### We don't silently project across the major boundary
 
@@ -183,11 +221,7 @@ If `fetchFormatSchema` doesn't apply the full normative fetch contract (SSRF, di
 
 2. **`adcpVersion` constructor option semantics.** Today the option pins the wire emit. With auto-negotiation, do we keep the pin (caller overrides the negotiated version) or treat it as "the buyer's maximum"? Pin semantics are simpler and match the spec's "buyer pins, seller downshifts" model.
 
-3. **Where does the projection layer hook in?** Two options:
-   - **Read-time** (current proposal): SDK normalizes on the way out of every transport call. Pros: one code path, normalized shape everywhere downstream. Cons: pays projection cost even when caller doesn't read v2 fields.
-   - **Lazy accessor**: `product.format_options` is a getter that runs projection on first access and caches. Pros: zero-cost for v1-only readers. Cons: surprise behavior on serialization; harder to reason about diagnostic timing.
-   
-   Read-time is the conservative choice; benchmark and revisit at 8.1 if hot-path cost matters.
+3. **Where does the projection layer hook in?** Read-time at the response boundary is the only honest answer once we commit to V2-only public types — the adopter is always reading `format_options`, so the projection has to be complete before the SDK hands the response back. (Lazy projection would mean the adopter sees `format_options: undefined` until they touch it, which is exactly the two-minds problem the V2-only stance is designed to avoid.) Benchmark and revisit only if hot-path cost matters in practice.
 
 4. **Per-agent vs per-call cache for `get_adcp_capabilities`.** Today the SDK fetches capabilities lazily and caches per-agent. Auto-negotiation makes this load-bearing. TTL? Cache invalidation on `VERSION_UNSUPPORTED` (seller signals they've moved on)? Probably yes to both.
 

--- a/docs/development/v3.1-sdk-design.md
+++ b/docs/development/v3.1-sdk-design.md
@@ -27,6 +27,14 @@ After this doc landed, we built a working v1↔v2 projection against the latest 
 
 8. **`format_kind` is orthogonal to dimensional identity.** Three size modes (fixed / multi-size / responsive) added to image/html5/display_tag canonicals at 3.1 GA. `format_kind = creative TYPE`; size lives in params; mirrors OpenRTB `banner.format[]`. Affects codegen (types declare `params.sizes?: Size[]` etc.) and adopter mental model (one declaration carries many sizes).
 
+9. **Refinement over multiplication via `canonical-projection-ref` (object shape).** The catalog's `canonical:` field is always an object: `{ kind, asset_source?, slots_override? }`. Asset variants (generative AI, buyer-uploaded native, broadcast video, DOOH image) all express their v1↔v2 projection refinement in sibling fields rather than spawning new canonicals. Coverage went from 41/57 (72%) to **50/50 (100%) of ad formats** in one spec commit; card scaffolding (7 entries) correctly split into a separate `ui-element-formats.json` (they aren't ad formats). Concretely:
+   - **Generative** (8 entries) → `{ kind: 'image', asset_source: 'agent_synthesized', slots_override: [generation_prompt] }`
+   - **Native** (2 entries) → `{ kind: 'image', slots_override: [image, headline, body, cta, brand_name], asset_source: 'buyer_uploaded' }` — same kind, different slot shape
+   - **Broadcast** (3 entries) → `{ kind: 'video_hosted' }` minimal — broadcast-ness lives in `type: video` / product channels, not in the projection
+   - **DOOH** (4 entries) → `{ kind: 'image' }` minimal — DOOH-ness lives in `type: dooh` / product channels
+
+   The architectural principle this validates: **`format_kind` expresses creative asset shape; delivery medium / channels / measurement live in product-level fields, not in `format_kind`.** A buyer doing format-kind switching should always pre-filter products by channel; format_kind is "what shape creative does this product accept," never "where does it run."
+
 ## The position
 
 AdCP 3.1's canonical-formats system isn't a new feature alongside the old creative model — it's a new way to think about creatives, and a better one. The old model conflated two questions ("what formats does this sales agent support?") into one wire surface. The new model separates them cleanly:
@@ -132,7 +140,7 @@ Each agent surfaces **four** independent catalog tiers the SDK merges to a singl
 
 | Tier | Source | Lifecycle |
 |---|---|---|
-| **AAO base catalog** | `creative.adcontextprotocol.org/schemas/.../reference-formats.json` (synced via `npm run sync-schemas`) | Versioned with the spec; immutable per `ADCP_VERSION`. 41/57 entries have `canonical:` annotations at 3.1 GA. |
+| **AAO base catalog** | `creative.adcontextprotocol.org/schemas/.../reference-formats.json` (synced via `npm run sync-schemas`) | Versioned with the spec; immutable per `ADCP_VERSION`. **50/50 entries** carry object-shaped `canonical: { kind, asset_source?, slots_override? }` annotations at 3.1 GA. UI scaffolding (cards) lives in a separate `ui-element-formats.json` and isn't part of `list_creative_formats`. |
 | **AAO community mirror** | `creative.adcontextprotocol.org/translated/<publisher>` — adagents.json-shaped catalog the AAO hosts for publishers who haven't adopted yet | Curated by the AAO; refresh cadence per-publisher. Meta lives here at 3.1 GA. |
 | **Publisher `adagents.json#/formats`** | Fetched from `<publisher>/.well-known/adagents.json` | Authored by the publisher; refresh on capabilities-cache TTL. Each entry has `applies_to_property_ids` / `applies_to_property_tags` scoping. |
 | **Per-placement `placement.format_options[]`** | Inside the seller's `get_products` response | Per-call. Can reference adagents.formats[] entries via `capability_id`, or declare inline. |
@@ -279,10 +287,14 @@ From the prototype against the latest spec PR HEAD:
 
 | Direction | What lands cleanly | What surfaces as a diagnostic |
 |---|---|---|
-| **v1 → v2** (a v1 seller's catalog seen as V2) | **41/57 (72%)** AAO catalog entries project NORMATIVE. **Multi-size catalog entries fan-out automatically** when the seller declares `sizes[]`. | 16/57 catalog entries explicitly "no v2 yet" (broadcast / native / DOOH / cards). Diagnostic distinguishes "spec hasn't decided yet" from "publisher-bespoke; SDK doesn't know." |
-| **v2 → v1** (V2 buyer's manifest seen by a v1 seller) | Every `v1_format_ref`-annotated declaration projects normatively. Multi-size declarations fan out to N v1 format_ids via catalog lookup (image / html5 in 3.1 GA produce 3 emits each per declaration; display_tag falls back to 1 + lossy advisory). | 4 inherently-v2 canonicals (image_carousel / sponsored_placement / responsive_creative / agent_placement) are structurally unreachable; `canonical_formats_only: true` is the seller-asserted opt-out. |
+| **v1 → v2** (a v1 seller's catalog seen as V2) | **50/50 (100%)** AAO ad-format catalog entries project NORMATIVE at 3.1 GA. Generative, native, broadcast, DOOH all covered via the `canonical-projection-ref` object shape. **Multi-size catalog entries fan-out automatically** when the seller declares `sizes[]`. | Publisher-bespoke v1 format_ids not in any catalog tier surface `FORMAT_PROJECTION_FAILED: no_match`. UI scaffolding (cards) is correctly excluded from the catalog (lives in a separate `ui-element-formats.json` file). |
+| **v2 → v1** (V2 buyer's manifest seen by a v1 seller) | Every `v1_format_ref`-annotated declaration projects normatively. Multi-size declarations fan out to N v1 format_ids via catalog lookup (image / html5 in 3.1 GA produce up to 7+ emits per `flex_display`-style product; display_tag falls back to 1 + lossy advisory). | 4 inherently-v2 canonicals (image_carousel / sponsored_placement / responsive_creative / agent_placement) are structurally unreachable; `canonical_formats_only: true` is the seller-asserted opt-out. |
 
-The 72% Day-1 coverage is bounded by adopter authoring: as more publishers add `adagents.json#/formats` and as the AAO catalog grows annotations for broadcast / native / DOOH, the projection layer's coverage grows without any SDK code change. The prototype demonstrates the SDK's behavior is structurally honest at every coverage level.
+100% Day-1 coverage on the AAO ad-format surface. Real-world coverage is bounded by **adopter authoring**: as more publishers ship `adagents.json#/formats` and as the per-placement `format_options[]` ecosystem matures, the SDK's projection coverage extends to the long tail without any SDK code change. The prototype demonstrates the SDK's behavior is structurally honest at every coverage level.
+
+#### Why "no new canonicals" matters
+
+The architectural commitment the spec made between draft and lock — broadcast, DOOH, native, generative all resolved via existing axes (`asset_source`, `slots_override`, `applies_to_channels`) rather than new `format_kind` variants — is what makes the 8.0 mental model durable. **The discriminated union stays at 12 branches (11 canonicals + `custom`)** even as the protocol covers new media types. Future v1 forms (CTV, native-video, audio-host-read, etc.) ride the same `canonical-projection-ref` pattern: pick the closest existing canonical, refine via the sibling fields. An adopter who writes `switch (opt.format_kind)` with 12 cases today is forward-compatible to all those variants — only their `params` reading needs to grow.
 
 ## What we explicitly don't do
 

--- a/docs/development/v3.1-sdk-design.md
+++ b/docs/development/v3.1-sdk-design.md
@@ -1,8 +1,31 @@
 # SDK 8.0 design proposal — flip adopters to the V2 mental model
 
-**Status:** draft for review. Not implemented. References to upstream spec assume PR [`adcontextprotocol/adcp#3307`](https://github.com/adcontextprotocol/adcp/pull/3307) lands as AdCP 3.1.0 substantially as written.
+**Status:** draft for review. Not implemented; **working prototype exists at PR [#1815](https://github.com/adcontextprotocol/adcp-client/pull/1815)** (both v1→v2 and v2→v1 projection directions, against the latest spec PR HEAD). The "Lessons from the prototype" section below captures concrete refinements the implementation surfaced.
 
 **Audience:** SDK contributors and adopters who want to know what the 3.1 upgrade will feel like before it lands.
+
+## Lessons from the prototype (PR #1815)
+
+After this doc landed, we built a working v1↔v2 projection against the latest spec PR HEAD. The prototype validated most of the architecture — V2-only public API, single API + auto-negotiation, structured diagnostics, custom format_schema centralized utility, versioned codegen. Eight refinements worth folding into the design:
+
+1. **Catalog source-of-truth model is 4-tier, not 1-tier.** AAO base catalog (`reference-formats.json`) + AAO community mirror (`creative.adcontextprotocol.org/translated/<publisher>`) + publisher's own `adagents.json#/formats` (with `property_id`/`property_tag` scoping) + per-placement `placement.format_options[]` (with `capability_id` references). The auto-negotiation surface needs to merge these four per publisher per property. Section ["Catalog source-of-truth"](#catalog-source-of-truth) below documents the new architecture.
+
+2. **Multi-size lossy projections need a fourth diagnostic class.** When a v2 declaration declares `sizes: [300×250, 728×90, 970×250]` but `v1_format_ref` is a single catalog entry, the SDK emits an advisory **alongside** the v1 emit (not instead of) so v1 buyers know what coverage was lost. Pattern is fan-out via catalog lookup when sibling per-size catalog entries exist (image + html5 in 3.1 GA), advisory-only when they don't (display_tag's `display_js` is parameterized, no per-size variants). New code: `FORMAT_DECLARATION_V1_LOSSY_MULTI_SIZE`.
+
+3. **Symmetric "not yet" buckets** confirm the design philosophy. v2-side `v1_translatable: false` (the 4 inherently-v2 canonicals) + v1-side `catalog_lacks_canonical_annotation` (broadcast / native / DOOH / cards at 3.1 GA) are mirror images of the same gap. The SDK respects the catalog's silence — refuses to shoehorn semantically-wrong projections (e.g. DOOH billboard → display_tag because of a tracking-url asset would be wrong).
+
+4. **`canonical_formats_only` is semantically overloaded.** Two valid uses: (a) custom shapes with no v1 form possible (NYTimes takeover); (b) standard canonicals where the catalog doesn't have a v1 entry yet (Triton DAAST at one point in the reconciliation cycle, before catalog growth). Same code path; different adopter intent.
+
+5. **Coverage at 3.1 GA is quantified.**
+   - **v1 → v2**: 41/57 (72%) AAO catalog entries project NORMATIVE clean. 16/57 are explicitly "no v2 yet" (broadcast/native/DOOH/cards). 0 fail-closed.
+   - **v2 → v1**: 5/5 single-size seller-annotated fixtures project cleanly. The new flex-display fixture with 3 multi-size format_options produces 7 v1 emits (image: 3, html5: 3, display_tag: 1) via catalog fan-out + 3 lossy advisories.
+   - The migration pattern (sellers add `v1_format_ref`, converge on AAO agent_urls, use multi-size `sizes[]`) is now demonstrated in the reference fixtures.
+
+6. **Registry reverse-lookup is dormant at 3.1 GA.** The spec moved to "SDKs MUST NOT synthesize v1_format_ref" and shrank the registry from 17 entries to 7 pure-structural fallbacks. SDK code stays for forward-compat but never fires for catalog-known formats. Downgraded in this doc.
+
+7. **AAO convergence pattern resolves the per-publisher format-id sprawl concern.** All v1-standard formats now converge on `creative.adcontextprotocol.org/` agent_url. Publisher-specific agent_urls only appear for proprietary platforms (Meta Reels at `creative.adcontextprotocol.org/translated/meta`). The doc's earlier worry about ecosystem fragmentation is normatively addressed.
+
+8. **`format_kind` is orthogonal to dimensional identity.** Three size modes (fixed / multi-size / responsive) added to image/html5/display_tag canonicals at 3.1 GA. `format_kind = creative TYPE`; size lives in params; mirrors OpenRTB `banner.format[]`. Affects codegen (types declare `params.sizes?: Size[]` etc.) and adopter mental model (one declaration carries many sizes).
 
 ## The position
 
@@ -70,55 +93,114 @@ The SDK normalizes at the response boundary:
 
 | Seller emits on the wire | What the SDK presents |
 |---|---|
-| v1 only (`format_ids` populated, `format_options` absent) | `Product.format_options` populated via the registry projection. Each entry carries `v1_format_ref` so adopters can trace the underlying named format. Products that fail projection (no registry match, no explicit `canonical`) surface with `format_options: []` and a `FORMAT_PROJECTION_FAILED` diagnostic. |
+| v1 only (`format_ids` populated, `format_options` absent) | `Product.format_options` populated via the catalog → registry → structural resolution order. Each entry carries `v1_format_ref` so adopters can trace the underlying named format. Products that fail projection surface with `format_options: []` and a `FORMAT_PROJECTION_FAILED` diagnostic that distinguishes `no_match` (publisher-bespoke, no catalog entry) from `catalog_lacks_canonical_annotation` (catalog knows but no v2 mapping yet). |
 | v2 only (`format_options` populated, `format_ids` absent on the wire) | `Product.format_options` passes through unchanged. |
 | Dual emission on the wire (both populated) | `Product.format_options` from the v2 side; `v1_format_ref` cross-checked against the wire's `format_ids` for divergence. Surfaces `FORMAT_DECLARATION_DIVERGENT` on conflict. |
 
-Symmetrically on the buyer's outbound side (`sync_creatives`, `create_media_buy`): the adopter writes a V2 manifest. When the negotiated version is v1, the SDK downshifts at the wire boundary using `v1_format_ref` from the product's `format_options`. Products carrying `canonical_formats_only: true` are unreachable on a v1-only seller — the SDK surfaces a typed error at call time rather than silently dropping the assignment.
+Symmetrically on the buyer's outbound side (`sync_creatives`, `create_media_buy`): the adopter writes a V2 manifest. When the negotiated version is v1, the SDK downshifts at the wire boundary:
+
+- **Single-size declarations** → emit the declaration's `v1_format_ref` verbatim.
+- **Multi-size declarations** (`params.sizes: [...]`) → fan out via catalog lookup. For each declared size, the SDK looks up a catalog entry sharing the seller-asserted ref's `<prefix>_WxH_<suffix>` template. v1 buyers see ALL the sizes the v2 declaration covers (image / html5 in 3.1 GA). The lossy advisory fires regardless, so buyers know the multi-size context.
+- **Responsive declarations** (`params.min_width` etc.) → single emit + advisory; no fan-out (the responsive range doesn't enumerate sizes).
+- **`canonical_formats_only: true`** → no v1 emit; `FORMAT_DECLARATION_V1_NOT_APPLICABLE` diagnostic.
+- **`v1_translatable: false` canonical** → no v1 emit; `CANONICAL_NOT_V1_TRANSLATABLE` diagnostic.
 
 The buyer's code looks identical against a v1 seller and a v2 seller. That's the goal.
 
 ### Projection layer
 
-Lives at `src/lib/v2/projection/`:
+Lives at `src/lib/v2/projection/` (shipped in PR #1815):
 
 ```
 src/lib/v2/
 ├── projection/
-│   ├── v1-to-v2.ts          # named-format registry lookup, structural match, fail-closed diagnostics
-│   ├── v2-to-v1.ts          # canonical_formats_only opt-out, v1_format_ref preference, lossy diagnostics
-│   ├── divergence.ts        # dual-emission invariant check
-│   └── registry.ts          # loads /schemas/3.1.0-beta.0/registries/v1-canonical-mapping.json
+│   ├── v1-to-v2.ts             # forward projection (4-step resolution order)
+│   ├── v2-to-v1.ts             # downgrade projection (6-step resolution + multi-size fan-out)
+│   ├── catalog.ts              # AAO catalog loader + size-and-canonical lookup
+│   ├── canonical-properties.ts # reads v1_translatable per canonical
+│   ├── registry.ts             # v1-canonical-mapping registry (7 structural at 3.1 GA)
+│   └── types.ts                # public Diagnostic union
 ├── canonical-formats/
-│   ├── fetch-schema.ts      # the normative fetch contract (see "Custom format fetch utility")
-│   └── validate.ts          # validate a manifest against a canonical narrowed by params
-└── diagnostics.ts            # structured Diagnostic shape
+│   ├── fetch-schema.ts         # the normative fetch contract (see "Custom format fetch utility")
+│   └── validate.ts             # validate a manifest against a canonical narrowed by params
+└── diagnostics.ts              # public re-exports
 ```
 
-Diagnostics shape (the structured channel; never logger-only):
+#### Catalog source-of-truth
+
+Each agent surfaces **four** independent catalog tiers the SDK merges to a single per-agent format lookup:
+
+| Tier | Source | Lifecycle |
+|---|---|---|
+| **AAO base catalog** | `creative.adcontextprotocol.org/schemas/.../reference-formats.json` (synced via `npm run sync-schemas`) | Versioned with the spec; immutable per `ADCP_VERSION`. 41/57 entries have `canonical:` annotations at 3.1 GA. |
+| **AAO community mirror** | `creative.adcontextprotocol.org/translated/<publisher>` — adagents.json-shaped catalog the AAO hosts for publishers who haven't adopted yet | Curated by the AAO; refresh cadence per-publisher. Meta lives here at 3.1 GA. |
+| **Publisher `adagents.json#/formats`** | Fetched from `<publisher>/.well-known/adagents.json` | Authored by the publisher; refresh on capabilities-cache TTL. Each entry has `applies_to_property_ids` / `applies_to_property_tags` scoping. |
+| **Per-placement `placement.format_options[]`** | Inside the seller's `get_products` response | Per-call. Can reference adagents.formats[] entries via `capability_id`, or declare inline. |
+
+The merge order is **most-specific-wins**: per-placement overrides adagents.json overrides community mirror overrides AAO base. The auto-negotiation surface owns the per-agent cache; projection reads the merged view.
+
+#### Resolution order
+
+**v1 → v2** (every v1 format_id projects to a v2 declaration):
+
+1. Catalog entry has explicit `canonical:` annotation → use it (NORMATIVE).
+2. Catalog entry exists but lacks `canonical:` → `FORMAT_PROJECTION_FAILED` with `resolution_failure: 'catalog_lacks_canonical_annotation'`. Symmetric to v1_translatable: false on the v2 side. **Do not shoehorn** via structural match; the catalog's silence is the AAO saying "no v2 form yet for this category."
+3. Not in catalog → registry literal glob match (rare at 3.1 GA — registry is mostly structural).
+4. Structural match (only for non-catalog ids) → emit canonical + params.
+5. Fail-closed → `FORMAT_PROJECTION_FAILED` with `resolution_failure: 'no_match'`.
+
+**v2 → v1** (every v2 declaration produces at least one of: v1 emit, diagnostic):
+
+1. `canonical_formats_only: true` → `FORMAT_DECLARATION_V1_NOT_APPLICABLE` (seller opt-out; covers both "no v1 form possible" and "no catalog entry yet").
+2. Canonical declares `v1_translatable: false` → `CANONICAL_NOT_V1_TRANSLATABLE` (the 4 inherently-v2 canonicals at 3.1 GA).
+3. `v1_format_ref` present → use verbatim. If `params.sizes[]` is multi-size, **fan out** via catalog lookup (same canonical + suffix as the ref, matching each declared size) and emit the lossy advisory.
+4. Registry has invertible literal match → MAY synthesize (non-normative; dormant at 3.1 GA).
+5. Registry has structural family match → `FORMAT_DECLARATION_V1_AMBIGUOUS`.
+6. Fail-closed → `FORMAT_PROJECTION_FAILED` with `resolution_failure: 'no_registry_match'`.
+
+#### Diagnostic codes
+
+The structured channel; never logger-only. The SDK emits these as `errors[]` augmentations on the response envelope AND surfaces them on `TaskResult` for caller-side handling.
 
 ```ts
 type Diagnostic =
   | {
+      // Spec codes
       code: 'FORMAT_PROJECTION_FAILED';
-      field: string;  // e.g. 'products[0].format_ids[1]'
-      details: {
-        format_id?: string;
-        product_id?: string;
-        resolution_failure: 'no_explicit_canonical' | 'no_registry_match' | 'no_structural_match';
-      };
+      // resolution_failure distinguishes v1→v2 vs v2→v1 failure modes
+      details: { resolution_failure: 'no_match' | 'catalog_lacks_canonical_annotation' | 'no_registry_match' };
+    }
+  | {
+      code: 'FORMAT_DECLARATION_V1_AMBIGUOUS';
+      details: { format_kind; registry_matches: number };
     }
   | {
       code: 'FORMAT_DECLARATION_DIVERGENT';
-      field: string;
-      details: { v1_format_id: string; v2_canonical: string; v2_params: Record<string, unknown> };
+      details: { v1_format_id; v2_canonical; v2_params };
     }
   | {
       code: 'CUSTOM_FORMAT_FETCH_FAILED';
-      field: string;
-      details: { uri: string; reason: 'digest_mismatch' | 'http_error' | 'size_exceeded' | 'ssrf_rejected' | 'schema_invalid' | 'timeout'; status?: number };
+      details: { uri; reason; status? };
+    }
+  // SDK-local codes (no spec equivalent; spec leaves to SDK discretion)
+  | {
+      code: 'FORMAT_DECLARATION_V1_NOT_APPLICABLE';
+      details: { reason: 'canonical_formats_only' };
+    }
+  | {
+      code: 'CANONICAL_NOT_V1_TRANSLATABLE';
+      // Spec: MUST NOT emit FORMAT_PROJECTION_FAILED for v1_translatable: false canonicals
+      details: { format_kind };
+    }
+  | {
+      code: 'FORMAT_DECLARATION_V1_LOSSY_MULTI_SIZE';
+      // Emitted ALONGSIDE the v1 emit (not instead of). Structural invariant
+      // is "at least one of (emit, diagnostic) per declaration", not exactly one.
+      details: { size_mode: 'sizes' | 'responsive_range'; declared_sizes_count; emitted_sizes_count };
     };
 ```
+
+Every diagnostic carries `source: 'sdk'`, `sdk_id: '<package>@<version>'`, `field: '<json-path-into-product>'` for spec-mandated multi-hop deduplication.
 
 The diagnostic surface attaches to the response envelope's `errors[]` array per the spec's resolution-order amendment, and is also exposed on the SDK's `TaskResult` for callers that don't want to walk `errors[]`:
 
@@ -190,6 +272,17 @@ The `format_kind` discriminator becomes a clean TypeScript tagged union (12 bran
 | **9.0** | AdCP 4.0 lands. `list_creative_formats` and v1 `format_ids` removed from the spec. SDK retires the v1 projection layer (internal); public API doesn't change because adopters never saw v1 in the first place. | None for adopter code. Adopters who relied on `format_options[i].v1_format_ref` for ops traceability need to switch to another identifier (likely `capability_id` or the seller's own product_id). |
 
 The 8.0 → 9.0 gap is sized by spec deprecation timing. Per `v1-canonical-mapping.json` notes, v1 named formats remain valid through 4.x — so 8.0 lives until 4.0 is GA and 9.0 cuts when v1 leaves the spec. The crucial property: because adopters wrote V2 code on 8.0, 9.0 is mostly an internal retirement, not a second mental-model migration.
+
+### Coverage adopters can expect at 8.0 GA
+
+From the prototype against the latest spec PR HEAD:
+
+| Direction | What lands cleanly | What surfaces as a diagnostic |
+|---|---|---|
+| **v1 → v2** (a v1 seller's catalog seen as V2) | **41/57 (72%)** AAO catalog entries project NORMATIVE. **Multi-size catalog entries fan-out automatically** when the seller declares `sizes[]`. | 16/57 catalog entries explicitly "no v2 yet" (broadcast / native / DOOH / cards). Diagnostic distinguishes "spec hasn't decided yet" from "publisher-bespoke; SDK doesn't know." |
+| **v2 → v1** (V2 buyer's manifest seen by a v1 seller) | Every `v1_format_ref`-annotated declaration projects normatively. Multi-size declarations fan out to N v1 format_ids via catalog lookup (image / html5 in 3.1 GA produce 3 emits each per declaration; display_tag falls back to 1 + lossy advisory). | 4 inherently-v2 canonicals (image_carousel / sponsored_placement / responsive_creative / agent_placement) are structurally unreachable; `canonical_formats_only: true` is the seller-asserted opt-out. |
+
+The 72% Day-1 coverage is bounded by adopter authoring: as more publishers add `adagents.json#/formats` and as the AAO catalog grows annotations for broadcast / native / DOOH, the projection layer's coverage grows without any SDK code change. The prototype demonstrates the SDK's behavior is structurally honest at every coverage level.
 
 ## What we explicitly don't do
 

--- a/docs/development/v3.1-sdk-design.md
+++ b/docs/development/v3.1-sdk-design.md
@@ -1,0 +1,226 @@
+# SDK 8.0 design proposal — single-API support for AdCP 3.0 + 3.1
+
+**Status:** draft for review. Not implemented. References to upstream spec assume PR [`adcontextprotocol/adcp#3307`](https://github.com/adcontextprotocol/adcp/pull/3307) lands as AdCP 3.1.0 substantially as written.
+
+**Audience:** SDK contributors and adopters who want to know what the 3.1 upgrade will feel like before it lands.
+
+## The question
+
+AdCP 3.1 adds the canonical-formats system (11 canonicals + custom escape hatch), a release-precision version envelope on every payload, expanded capabilities discovery (`supported_versions`, `creative.supported_formats`, `bills_through_adcp`, `canonical_catalog_version`), and the `validate_input` tool. The wire surface is backwards-compatible — products MAY carry `format_ids`, `format_options`, or both — but the in-memory shape, codegen, and validation flow diverge.
+
+**The question this doc answers:** how should the SDK expose 3.1 to adopters so that they don't have to think about v1 vs v2?
+
+## Design goals
+
+1. **Zero forced migration.** An adopter sitting on `@adcp/sdk` 7.x with a v1-only codebase upgrades to 8.0 and their code keeps working. No type imports change. No type errors. No new fields they're required to set.
+2. **One mental model.** Adopters don't pick between a v1 client and a v2 client, or a v1 `Product` type and a v2 `Product` type. The SDK exposes one `Product` shape that carries both representations when projectable.
+3. **Opt-in for new functionality.** Adopters who want canonical formats, custom-shape validation, or `bills_through_adcp` routing read the v2 side. Adopters who don't care never see those fields in their hot path.
+4. **Honest about failure.** When v1↔v2 projection isn't possible (no registry match, no explicit canonical, `canonical_formats_only: true`), the SDK surfaces a structured diagnostic. **Never logger-only** — the spec explicitly forbids it (see `v1-canonical-mapping.json` resolution-order description).
+5. **Forward-compatible to 4.0.** The shapes we expose today shouldn't paint us into a corner when v1 paths are removed at 5.0 per the spec's deprecation calendar.
+
+## Non-goals
+
+- Generating a single union `Product` type that contains all possible 3.0 + 3.1 fields. Codegen will produce versioned types under `src/lib/types/v3.0/` and `src/lib/types/v3.1/`. The public API uses the 3.1 type as the canonical shape; 3.0-only fields are absent (not `undefined`).
+- Two-step migration to canonical formats. We don't ship a "v1-only" 8.x followed by a "v2-aware" 8.x. The 8.0 line is canonical-formats-aware from day one.
+- Exposing the AAO mirror's custom-format hosting model. Adopters that want to publish a custom format follow the spec's hosting rules; the SDK consumes, it doesn't host.
+
+## Architecture
+
+### Auto-negotiation per agent
+
+```ts
+const client = new AdcpClient({ agents: [{ url: 'https://seller.example/.well-known/agent' }] });
+
+// First call to any tool on a seller triggers a cached get_adcp_capabilities probe.
+// SDK reads supported_versions, picks the highest version both sides understand.
+// Result is cached for the agent (TTL configurable, default 1 hour).
+const products = await client.getProducts({ brief: '...' });
+```
+
+Negotiation algorithm (in order):
+1. Caller-supplied `adcpVersion` wins — for storyboard fixtures, conformance harnesses, and intentional pinning.
+2. Otherwise, fetch `get_adcp_capabilities`. Pick the highest release-precision string in `supported_versions[]` that the SDK also supports.
+3. If the SDK and seller share no major version, throw a typed `VersionMismatchError` at call time — fail-fast, no auto-downgrade past major boundaries.
+4. Within the same major, prefer release-precision string from the seller (`'3.1-beta'` if advertised) over the SDK's pin (`'3.1'`), so adopters using a 3.1.0 SDK against a `3.1-beta` seller don't get a silent VERSION_UNSUPPORTED.
+
+A 3.0-only seller continues to work: SDK negotiates down to `'3.0'`, doesn't emit `adcp_version` (gated by `bundleSupportsAdcpVersionField`), doesn't expect `format_options` on responses.
+
+### Dual-shape `Product`
+
+The SDK exposes a single `Product` type that always carries `format_ids` and may carry `format_options`. The seller's wire shape is normalized at the response boundary:
+
+| Seller emits | SDK populates |
+|---|---|
+| v1 only (`format_ids` populated, `format_options` absent) | v1 + v2 (project v1→v2 via registry; products with `FORMAT_PROJECTION_FAILED` keep `format_options` absent) |
+| v2 only (`format_options` populated, `format_ids` absent) | v1 + v2 (downgrade v2→v1; products with `canonical_formats_only: true` are omitted from v1 readers) |
+| Dual emission (both populated) | both populated, divergence checked (cross-references `v1_format_ref` against the registry; surfaces `FORMAT_DECLARATION_DIVERGENT` on conflict) |
+
+Symmetrically on the buyer's outbound side (`sync_creatives`, `create_media_buy`): if the seller is v1-only, the SDK downgrades the manifest; if v2-only, the SDK upshifts. The buyer code looks the same.
+
+### Projection layer
+
+Lives at `src/lib/v2/projection/`:
+
+```
+src/lib/v2/
+├── projection/
+│   ├── v1-to-v2.ts          # named-format registry lookup, structural match, fail-closed diagnostics
+│   ├── v2-to-v1.ts          # canonical_formats_only opt-out, v1_format_ref preference, lossy diagnostics
+│   ├── divergence.ts        # dual-emission invariant check
+│   └── registry.ts          # loads /schemas/3.1.0-beta.0/registries/v1-canonical-mapping.json
+├── canonical-formats/
+│   ├── fetch-schema.ts      # the normative fetch contract (see "Custom format fetch utility")
+│   └── validate.ts          # validate a manifest against a canonical narrowed by params
+└── diagnostics.ts            # structured Diagnostic shape
+```
+
+Diagnostics shape (the structured channel; never logger-only):
+
+```ts
+type Diagnostic =
+  | {
+      code: 'FORMAT_PROJECTION_FAILED';
+      field: string;  // e.g. 'products[0].format_ids[1]'
+      details: {
+        format_id?: string;
+        product_id?: string;
+        resolution_failure: 'no_explicit_canonical' | 'no_registry_match' | 'no_structural_match';
+      };
+    }
+  | {
+      code: 'FORMAT_DECLARATION_DIVERGENT';
+      field: string;
+      details: { v1_format_id: string; v2_canonical: string; v2_params: Record<string, unknown> };
+    }
+  | {
+      code: 'CUSTOM_FORMAT_FETCH_FAILED';
+      field: string;
+      details: { uri: string; reason: 'digest_mismatch' | 'http_error' | 'size_exceeded' | 'ssrf_rejected' | 'schema_invalid' | 'timeout'; status?: number };
+    };
+```
+
+The diagnostic surface attaches to the response envelope's `errors[]` array per the spec's resolution-order amendment, and is also exposed on the SDK's `TaskResult` for callers that don't want to walk `errors[]`:
+
+```ts
+const result = await client.getProducts({ brief: '...' });
+result.products;       // dual-shape, projected/normalized
+result.diagnostics;    // Diagnostic[] — empty array on the happy path
+```
+
+### Custom format fetch utility
+
+`format_kind: "custom"` declarations carry `format_schema: { uri, digest }`. The spec's normative fetch contract is long, security-critical, and identical across all SDKs (HTTPS-only, SSRF guards, no redirects, 1 MiB body cap, 5s timeout, sha256 hard-fail, $ref sandbox with same-origin + depth ≤8 + count ≤256, re2 regex, ≤250 ms compile-time budget). If every SDK ships its own, the protocol's security posture is the weakest implementation.
+
+The SDK ships `fetchFormatSchema` as the single approved fetcher:
+
+```ts
+import { fetchFormatSchema, CustomFormatFetchError } from '@adcp/sdk/v2';
+
+const schema = await fetchFormatSchema(declaration.format_schema, {
+  cache: customFormatCache,        // caller-supplied — sane default for in-process
+  fetchPolicy: 'allowed' | 'disabled',  // default 'allowed'
+});
+```
+
+Default policy is `allowed` — the spec is opinionated that buyers SHOULD fetch and validate. Adopters who can't run an outbound HTTPS fetch path (firewalled environments) flip to `disabled` and the SDK skips validation, surfacing `CUSTOM_FORMAT_FETCH_FAILED` with `reason: 'fetch_disabled'`.
+
+When auto-negotiation lands the buyer on a 3.0-only seller, this code path is unreachable — `format_kind: "custom"` only exists in 3.1 `format_options`.
+
+### Versioned codegen
+
+```
+src/lib/types/
+├── v3.0/
+│   ├── tools.generated.ts        # 3.0 tool request/response types
+│   └── schemas.generated.ts       # 3.0 in-memory types
+├── v3.1/
+│   ├── tools.generated.ts        # 3.1 tool request/response types
+│   └── schemas.generated.ts       # 3.1 in-memory types — includes ProductFormatDeclaration tagged union
+└── index.ts                      # public re-exports: Product = v3.1.Product, etc.
+```
+
+Public re-exports always use the latest stable version. Adopters who want a specific version import explicitly:
+
+```ts
+import type { Product } from '@adcp/sdk';                      // 3.1 shape
+import type { Product as V30Product } from '@adcp/sdk/v3.0';   // 3.0 shape (rarely needed)
+```
+
+The `format_kind` discriminator becomes a clean TypeScript tagged union (12 branches: 11 canonicals + `custom`) so adopters get exhaustive-switch checks for free.
+
+## Migration path
+
+| Line | What changes | Adopter action |
+|---|---|---|
+| 7.x | Defensive wire-envelope fix (PR #1807 — already shipped). Loose ends from any 3.1 work backported as patches when safe. | None. |
+| **8.0** | Full 3.1 enablement: auto-negotiation, dual-shape `Product`, projection layer, `fetchFormatSchema`, versioned codegen. `ADCP_VERSION` moves to `3.1.0`. `COMPATIBLE_ADCP_VERSIONS` adds `3.0.x` and `3.1.x`. | `npm install @adcp/sdk@^8`. Run typecheck — should pass without changes. Optional: read `result.diagnostics` to surface projection issues; opt into v2 fields for canonical-format-aware code. |
+| 8.x | Hardening: additional registry entries as upstream adds them; codegen refinements; performance work on the projection layer. | None — additive. |
+| **9.0** | AdCP 4.0 lands. `list_creative_formats` and v1 `format_ids` removed per spec. SDK removes v1 projection paths; `Product.format_ids` becomes optional → removed. | Code that read `format_ids` becomes a typecheck error. Easy mechanical fix to read `format_options` instead. |
+
+The 8.0 → 9.0 gap is sized by spec deprecation timing. Per `v1-canonical-mapping.json` notes, v1 named formats remain valid through 4.x — so 8.0 lives until 4.0 is GA and 9.0 cuts when v1 leaves the spec.
+
+## What we explicitly don't do
+
+### We don't ship two namespaces
+
+A `client.v1.getProducts()` / `client.v2.getProducts()` split looks honest but breaks goals #1 and #2. Adopters reading docs see two surfaces and have to choose; library authors writing on top of `@adcp/sdk` have to support both; the type system can't express "this is the canonical format if available, the v1 named format otherwise" without a union the adopter unwraps. Single API + dual-shape is strictly more ergonomic.
+
+### We don't silently project across the major boundary
+
+If the SDK is built for 3.x and the seller advertises 4.x only, we throw a typed `VersionMismatchError` rather than guessing. Per-major shape changes are real (the spec carves them out via `oneOf`/`anyOf` patterns at the schema level); auto-downgrading 4.x to 3.x risks silent semantic loss. Major-boundary version mismatch is an adopter signal to upgrade the SDK.
+
+### We don't hide projection failures
+
+`logger.warn('skipped product because format_options projection failed')` is the worst-of-both: the buyer's catalog quietly shrinks, the failure is invisible at runtime, and the operator finds out from a sales-side complaint. Per the spec's resolution-order amendment #3767, the structured diagnostic channel is mandatory. We attach `Diagnostic[]` to the response envelope's `errors[]` AND surface it on the SDK's `TaskResult` so it's reachable from both wire-level inspection and idiomatic code.
+
+### We don't ship custom-format validation piecemeal
+
+If `fetchFormatSchema` doesn't apply the full normative fetch contract (SSRF, digest, $ref sandbox, compile budget), it's a security regression. Either we ship the complete utility or we ship `format_kind: "custom"` declarations behind a feature flag that hard-fails with `CUSTOM_FORMAT_FETCH_FAILED { reason: 'unimplemented' }` until the utility is ready. No half-states.
+
+## Open questions
+
+1. **Custom-format fetch policy default.** Spec says SHOULD fetch; some adopters can't run outbound HTTPS from their service environment. Default to `'allowed'` and let firewalled adopters opt out, or default to `'disabled'` and let aggressive adopters opt in? Leaning toward `'allowed'` (matches spec intent) with very clear errors when blocked.
+
+2. **`adcpVersion` constructor option semantics.** Today the option pins the wire emit. With auto-negotiation, do we keep the pin (caller overrides the negotiated version) or treat it as "the buyer's maximum"? Pin semantics are simpler and match the spec's "buyer pins, seller downshifts" model.
+
+3. **Where does the projection layer hook in?** Two options:
+   - **Read-time** (current proposal): SDK normalizes on the way out of every transport call. Pros: one code path, normalized shape everywhere downstream. Cons: pays projection cost even when caller doesn't read v2 fields.
+   - **Lazy accessor**: `product.format_options` is a getter that runs projection on first access and caches. Pros: zero-cost for v1-only readers. Cons: surprise behavior on serialization; harder to reason about diagnostic timing.
+   
+   Read-time is the conservative choice; benchmark and revisit at 8.1 if hot-path cost matters.
+
+4. **Per-agent vs per-call cache for `get_adcp_capabilities`.** Today the SDK fetches capabilities lazily and caches per-agent. Auto-negotiation makes this load-bearing. TTL? Cache invalidation on `VERSION_UNSUPPORTED` (seller signals they've moved on)? Probably yes to both.
+
+5. **`canonical_catalog_version` skew handling.** When SDK is built against `3.1.0` and the seller advertises `canonical_catalog_version: '3.2'`, the SDK might receive `format_kind` values it doesn't know. Per the spec, `canonical-format-kind.json` is open-enum and unknown values are safe to retain — we surface a soft-warning diagnostic but pass them through to caller code that may want to handle them.
+
+## Sequencing
+
+```
+PR-1807 (merged)         wire-envelope normalize (defensive)             7.x patch
+   ↓
+adcp#3307 lands          upstream 3.1.0-beta.0 published                  spec event
+   ↓
+PR-NEXT-A                add 3.1.0-beta.0 to COMPATIBLE_ADCP_VERSIONS,    8.0.0-alpha.1
+                         versioned codegen, no projection yet
+PR-NEXT-B                v1↔v2 projection layer + Diagnostic surface     8.0.0-alpha.2
+PR-NEXT-C                fetchFormatSchema with full normative contract  8.0.0-alpha.3
+PR-NEXT-D                auto-negotiation + per-agent capabilities cache 8.0.0-rc.1
+                          ↓
+                         8.0.0 GA
+```
+
+Each PR is independently reviewable and bug-bisectable. We don't merge them in a single mega-PR.
+
+## What this doc does NOT do
+
+- Specify the exact public type names. Codegen names follow the schema $id by default; we'll refine once the 3.1 schemas are stable.
+- Specify the projection registry's hot-path behavior under adversarial seller responses (10000-product responses with all-divergent declarations, etc.). That's a benchmarking + hardening exercise during the 8.0 RC cycle.
+- Decide whether to ship adapter-pattern shims for 4.0 the same way `legacy/v2-5/` works today. The 8.0 → 9.0 transition is far enough out that the right answer depends on what 4.0 actually changes.
+
+## Reviewers
+
+- **Adopters writing buyer agents**: does this disappear far enough into the background that you don't have to think about it?
+- **SDK maintainers**: is the projection layer factored correctly to survive the 4.0 transition?
+- **Spec working group**: do the diagnostic codes (`FORMAT_PROJECTION_FAILED`, `FORMAT_DECLARATION_DIVERGENT`, `CUSTOM_FORMAT_FETCH_FAILED`) align with where adcontextprotocol/adcp wants error vocabulary to live? Should these be upstream error codes rather than SDK-local strings?
+
+Comments welcome on the PR that lands this doc.


### PR DESCRIPTION
## Summary

Standalone design proposal at `docs/development/v3.1-sdk-design.md` for how the SDK should expose AdCP 3.1 (canonical formats, version envelope, expanded capabilities discovery) without forcing adopters to think about v1 vs v2 shapes.

**Draft for review only — no code changes in this PR.**

## The question the doc answers

How does the SDK present 3.1 to adopters? Two namespaces (`client.v1.*` / `client.v2.*`)? A new type for `Product`? A single API that auto-routes? The doc commits to the third: single API + dual-shape `Product` + per-agent auto-negotiation + structured projection diagnostics.

## Design choices the doc commits to

- **Auto-negotiation per agent** driven by `get_adcp_capabilities.supported_versions`, cached per-agent.
- **Single dual-shape `Product`** that always carries `format_ids` and populates `format_options` when projectable. Symmetric on write — v1 manifests upshift to 3.1 sellers, v2 manifests downshift to 3.0 sellers honoring `canonical_formats_only: true`.
- **Bidirectional projection layer** at `src/lib/v2/projection/` using the spec's `v1-canonical-mapping.json` registry, with the 5-step resolution order (`v1_format_ref` → explicit `canonical` → registry glob → structural match → fail-closed).
- **Structured `Diagnostic[]` surface** attached to both response `errors[]` AND the SDK's `TaskResult`. Codes: `FORMAT_PROJECTION_FAILED`, `FORMAT_DECLARATION_DIVERGENT`, `CUSTOM_FORMAT_FETCH_FAILED`. **Never logger-only** per the spec's resolution-order amendment.
- **Centralized `fetchFormatSchema` utility** implementing the normative custom-format fetch contract (HTTPS-only, SSRF guards, no redirects, 1 MiB cap, sha256 hard-fail, `\$ref` sandbox, compile-time budget). If every SDK reimplements this, the protocol's security posture is the weakest implementation.
- **Versioned codegen** under `src/lib/types/v3.0/` and `src/lib/types/v3.1/`, with public re-exports always pointing at the latest stable version.

## Explicit non-goals

- No two-namespace split.
- No silent projection across the major boundary — major-version mismatch throws `VersionMismatchError`.
- No logger-only projection failures.
- No piecemeal custom-format validation — either ship the complete `fetchFormatSchema` or hard-fail with `CUSTOM_FORMAT_FETCH_FAILED { reason: 'unimplemented' }`.

## Migration path

| Line | What changes |
|---|---|
| **7.x** | Defensive fixes (wire-envelope normalization in #1807 — already shipped). |
| **8.0** | Full 3.1 enablement. |
| **8.x** | Hardening, additional registry entries. |
| **9.0** | When AdCP 4.0 lands, removes v1 paths per spec deprecation calendar. |

The 8.0 PR sequence is decomposed into four reviewable units in the doc (compat-version + versioned codegen → projection + diagnostics → `fetchFormatSchema` → auto-negotiation).

## Open questions called out

1. Custom-format fetch default policy (`'allowed'` vs `'disabled'`).
2. `adcpVersion` constructor option semantics under auto-negotiation (pin vs maximum).
3. Read-time projection vs lazy accessor.
4. `get_adcp_capabilities` cache TTL + invalidation.
5. `canonical_catalog_version` skew handling (forward-compat with future canonicals).

## Reviewers welcome

- **Adopters writing buyer agents**: does this disappear far enough into the background that you don't have to think about it?
- **SDK maintainers**: is the projection layer factored correctly to survive the 4.0 transition?
- **Spec working group**: should the diagnostic codes be upstream (in the spec's error vocabulary) rather than SDK-local?

Companion to PR #1807 (wire-envelope normalization fix — the defensive 7.x patch this doc references).

## Test plan

- [x] `npm run format:check` clean.
- [x] Pre-push validation (typecheck + build) passed.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)