### PR TITLE
feat(testing): emit not_applicable hint for impairment.coherence deferred-inverse families

### DIFF
--- a/.changeset/impairment-coherence-not-applicable-hint.md
+++ b/.changeset/impairment-coherence-not-applicable-hint.md
@@ -1,0 +1,52 @@
+---
+'@adcp/sdk': minor
+---
+
+testing(impairment.coherence): emit `not_applicable` step result for deferred-inverse families
+
+When a storyboard transitions an `audience`, `catalog_item`, or `event_source`
+resource into its offline status (`suspended` / `withdrawn` / `insufficient`),
+the runner now emits a step-level `AssertionResult` with `status: 'not_applicable'`
+and a structured `ImpairmentCoherenceNotApplicableHint`:
+
+```ts
+{
+  assertion_id: 'impairment.coherence',
+  status: 'not_applicable',
+  passed: true,
+  step_id: '<transition step>',
+  hint: {
+    kind: 'impairment_coherence_not_applicable',
+    violation: 'inverse',
+    reason: 'resource_traversal_deferred',
+    resource_type: 'audience' | 'catalog_item' | 'event_source',
+    resource_id: '<id>',
+    resource_status: '<offline value>',
+    resource_step_id: '<transition step>',
+    message: '... Tracked in adcontextprotocol/adcp#2860.',
+  },
+}
+```
+
+Before this change, the inverse-rule evaluator silently skipped these three
+families (a storyboard that suspended an audience and read a buy missing it
+from `impairments[]` would pass silently). The forward rule already grades
+them and is unchanged; the inverse rule still defers to the larger
+`adcp#2860` work, but the gap is now visible in run output instead of buried
+in PR prose.
+
+Single emission per `(resource_type, resource_id)` per run — re-syncs of an
+already-offline resource don't re-fire. Recovery followed by a new offline
+transition does re-fire. The existing `onEnd` run-level deferred-coverage
+notice still emits the family-level aggregate.
+
+API additions:
+
+- `AssertionResult.status` gains `'not_applicable'` as a fourth value
+  (previously `'pass' | 'silent' | 'fail'`).
+- New `ImpairmentCoherenceNotApplicableHint` member added to the
+  `StoryboardStepHint` discriminated union (`kind: 'impairment_coherence_not_applicable'`),
+  exported from `@adcp/sdk/testing`.
+
+Closes adcp-client#1806. Inverse-rule coverage itself is still tracked by
+adcontextprotocol/adcp#2860.

--- a/src/lib/testing/storyboard/default-invariants.ts
+++ b/src/lib/testing/storyboard/default-invariants.ts
@@ -1121,6 +1121,16 @@ registerOnce('impairment.coherence', {
 
     const state = getImpairmentState(ctx);
 
+    type CoherenceResult = {
+      passed: boolean;
+      description: string;
+      step_id: string;
+      error?: string;
+      status?: 'not_applicable';
+      hint?: import('./types').ImpairmentCoherenceHint | import('./types').ImpairmentCoherenceNotApplicableHint;
+    };
+    const deferredCoverageResults: CoherenceResult[] = [];
+
     // Direct, dedicated extractor for the four families this invariant cares
     // about. NOT routed through `extractStatusObservations` (which is bound
     // to the `status.monotonic` transition graphs and therefore excludes
@@ -1133,12 +1143,51 @@ registerOnce('impairment.coherence', {
       state.resourceStatus.set(key, { status: ob.status, stepId: stepResult.step_id });
       const offline = IMPAIRMENT_OFFLINE_STATUS.get(ob.resource_type);
       if (offline?.has(ob.status)) {
+        const wasOffline = state.offlineResources.has(key);
         state.offlineResources.set(key, { status: ob.status, stepId: stepResult.step_id });
         state.observedTransition = true;
         state.offlineObservationsByFamily.set(
           ob.resource_type,
           (state.offlineObservationsByFamily.get(ob.resource_type) ?? 0) + 1
         );
+
+        // Issue #1806: surface deferred inverse-rule coverage at the
+        // transition step. When a resource family the runner can't yet
+        // reverse-traverse (`audience` / `catalog_item` / `event_source`)
+        // enters an offline state for the first time in this run, emit a
+        // `not_applicable` step-level result so reviewers see the gap in
+        // run output instead of having to read PR prose. One emission per
+        // (resource_type, resource_id) per run — re-syncs of an already
+        // offline resource don't re-fire.
+        if (
+          !wasOffline &&
+          (ob.resource_type === 'audience' ||
+            ob.resource_type === 'catalog_item' ||
+            ob.resource_type === 'event_source')
+        ) {
+          const message =
+            `inverse-rule coverage for ${ob.resource_type} ${ob.resource_id} ` +
+            `(status="${ob.status}", step "${stepResult.step_id}") is deferred — ` +
+            `buy → resource traversal not yet implemented for this family. ` +
+            `Tracked in adcontextprotocol/adcp#2860.`;
+          deferredCoverageResults.push({
+            passed: true,
+            status: 'not_applicable',
+            description:
+              'inverse-rule coverage deferred for non-creative offline resource (resource_traversal_deferred)',
+            step_id: stepResult.step_id,
+            hint: {
+              kind: 'impairment_coherence_not_applicable',
+              violation: 'inverse',
+              reason: 'resource_traversal_deferred',
+              message,
+              resource_type: ob.resource_type,
+              resource_id: ob.resource_id,
+              resource_status: ob.status,
+              resource_step_id: stepResult.step_id,
+            },
+          });
+        }
       } else {
         // Resource recovered from offline → drop the entry so the inverse
         // rule no longer expects it in impairments[].
@@ -1148,17 +1197,10 @@ registerOnce('impairment.coherence', {
 
     // Extract media-buy snapshots and run the three coherence checks.
     const snapshots = extractBuySnapshots(stepResult.task, body as Record<string, unknown>, stepResult.step_id);
-    if (snapshots.length === 0) return [];
+    if (snapshots.length === 0) return deferredCoverageResults;
     state.observedBuySnapshot = true;
 
     const description = 'media_buy.impairments[] coheres with resource state and buy health';
-    type CoherenceResult = {
-      passed: boolean;
-      description: string;
-      step_id: string;
-      error?: string;
-      hint?: import('./types').ImpairmentCoherenceHint;
-    };
     const results: CoherenceResult[] = [];
 
     for (const snap of snapshots) {
@@ -1280,9 +1322,9 @@ registerOnce('impairment.coherence', {
     }
 
     if (results.length === 0) {
-      return [{ passed: true, description, step_id: stepResult.step_id }];
+      return [...deferredCoverageResults, { passed: true, description, step_id: stepResult.step_id }];
     }
-    return results;
+    return [...deferredCoverageResults, ...results];
   },
   // Emit a run-level summary so the track rollup can distinguish
   // "wired and exercised" from "wired but neither side observed". When

--- a/src/lib/testing/storyboard/index.ts
+++ b/src/lib/testing/storyboard/index.ts
@@ -39,6 +39,7 @@ export type {
   FormatMismatchHint,
   MonotonicViolationHint,
   ImpairmentCoherenceHint,
+  ImpairmentCoherenceNotApplicableHint,
   StoryboardContext,
   StoryboardRunOptions,
   ValidationResult,

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -1798,7 +1798,8 @@ export type StoryboardStepHint =
   | MissingRequiredFieldHint
   | FormatMismatchHint
   | MonotonicViolationHint
-  | ImpairmentCoherenceHint;
+  | ImpairmentCoherenceHint
+  | ImpairmentCoherenceNotApplicableHint;
 
 /**
  * A seller rejected a request value that the runner traced back to a
@@ -2118,6 +2119,51 @@ export interface ImpairmentCoherenceHint extends StoryboardStepHintBase {
   impairments_count: number;
 }
 
+/**
+ * The `impairment.coherence` invariant observed an offline-state transition
+ * for a resource family whose buy → resource reverse-traversal isn't yet
+ * implemented (audience / catalog_item / event_source). The forward rule
+ * still grades these families; the inverse rule cannot, so the runner
+ * surfaces the deferred coverage at the transition step instead of skipping
+ * silently. Tracked in adcontextprotocol/adcp#2860.
+ */
+export interface ImpairmentCoherenceNotApplicableHint extends StoryboardStepHintBase {
+  kind: 'impairment_coherence_not_applicable';
+  /**
+   * Always `'inverse'` for this hint — the rule that can't grade.
+   * @provenance runner
+   */
+  violation: 'inverse';
+  /**
+   * Machine-readable reason code. Consumers can filter on this without
+   * matching prose.
+   * @provenance runner
+   */
+  reason: 'resource_traversal_deferred';
+  /**
+   * Resource family the transition was observed on. One of the three
+   * deferred families.
+   * @provenance runner
+   */
+  resource_type: 'audience' | 'catalog_item' | 'event_source';
+  /**
+   * Resource id the transition was observed on.
+   * @provenance seller
+   */
+  resource_id: string;
+  /**
+   * Offline status the resource transitioned to (`suspended` / `withdrawn`
+   * / `insufficient`).
+   * @provenance seller
+   */
+  resource_status: string;
+  /**
+   * Step id that recorded the offline transition.
+   * @provenance runner
+   */
+  resource_step_id: string;
+}
+
 export interface StoryboardPhaseResult {
   phase_id: string;
   phase_title: string;
@@ -2298,9 +2344,17 @@ export interface AssertionResult {
    * `'pass'` when `observation_count > 0` AND `passed === true`,
    * `'fail'` when `passed === false`. Absent on assertions that don't
    * model observation counts (their `passed` flag is sufficient).
-   * Companion to adcontextprotocol/adcp#2834.
+   *
+   * `'not_applicable'` is emitted at step scope by an invariant that
+   * recognises an observation it could grade in principle but whose
+   * grading path isn't yet implemented in the runner (e.g.
+   * `impairment.coherence` inverse rule for audience / catalog_item /
+   * event_source — tracked in adcontextprotocol/adcp#2860). The
+   * accompanying `hint` carries the deferral reason and resource family
+   * so renderers can distinguish a deferred coverage hint from a clean
+   * pass. Companion to adcontextprotocol/adcp#2834.
    */
-  status?: 'pass' | 'silent' | 'fail';
+  status?: 'pass' | 'silent' | 'fail' | 'not_applicable';
 }
 
 /**

--- a/test/lib/storyboard-default-invariants.test.js
+++ b/test/lib/storyboard-default-invariants.test.js
@@ -2055,6 +2055,147 @@ describe('default-invariants: impairment.coherence', () => {
     assert.equal(out[0].passed, true);
   });
 
+  // adcp-client#1806 — inverse-rule coverage gap is surfaced at the
+  // transition step itself via a `not_applicable` step-level result, so
+  // reviewers see the gap in run output instead of only in the run-level
+  // onEnd summary.
+  for (const [family, syncStep] of [
+    [
+      'audience',
+      s => ({ task: 'sync_audiences', response: { audiences: [{ audience_id: s.id, status: 'suspended' }] } }),
+    ],
+    [
+      'catalog_item',
+      s => ({
+        task: 'sync_catalogs',
+        response: { catalogs: [{ items: [{ item_id: s.id, status: 'withdrawn' }] }] },
+      }),
+    ],
+    [
+      'event_source',
+      s => ({
+        task: 'sync_event_sources',
+        response: { event_sources: [{ event_source_id: s.id, health: { status: 'insufficient' } }] },
+      }),
+    ],
+  ]) {
+    test(`inverse: offline ${family} transition emits a not_applicable hint at the transition step`, () => {
+      const id = `${family.replace('_', '-')}-1`;
+      const out = run([step({ step_id: 'transition', ...syncStep({ id }) })]);
+      const na = out[0].output.find(o => o.status === 'not_applicable');
+      assert.ok(na, `expected a not_applicable result for ${family}; got ${JSON.stringify(out[0].output)}`);
+      assert.equal(na.passed, true);
+      assert.equal(na.step_id, 'transition');
+      assert.equal(na.hint.kind, 'impairment_coherence_not_applicable');
+      assert.equal(na.hint.violation, 'inverse');
+      assert.equal(na.hint.reason, 'resource_traversal_deferred');
+      assert.equal(na.hint.resource_type, family);
+      assert.equal(na.hint.resource_id, id);
+      assert.equal(na.hint.resource_step_id, 'transition');
+      assert.match(na.hint.message, /adcp#2860/);
+      assert.match(na.description, /resource_traversal_deferred/);
+    });
+  }
+
+  test('inverse: deferred-family hint emits once per resource across re-syncs', () => {
+    // Re-syncs of an already-offline resource don't re-fire the hint —
+    // the trigger is the transition into offline, not subsequent observations.
+    const out = run([
+      step({
+        step_id: 'first',
+        task: 'sync_audiences',
+        response: { audiences: [{ audience_id: 'aud-1', status: 'suspended' }] },
+      }),
+      step({
+        step_id: 'resync',
+        task: 'sync_audiences',
+        response: { audiences: [{ audience_id: 'aud-1', status: 'suspended' }] },
+      }),
+    ]);
+    const firstNa = out[0].output.filter(o => o.status === 'not_applicable');
+    const resyncNa = out[1].output.filter(o => o.status === 'not_applicable');
+    assert.equal(firstNa.length, 1, 'first transition emits one hint');
+    assert.equal(resyncNa.length, 0, 're-sync of already-offline resource does not re-emit');
+  });
+
+  test('inverse: recovery then re-transition emits the hint twice (per transition)', () => {
+    // recover → re-suspend re-enters the offline state, which is a new
+    // transition and re-fires the hint.
+    const out = run([
+      step({
+        step_id: 'suspend1',
+        task: 'sync_audiences',
+        response: { audiences: [{ audience_id: 'aud-1', status: 'suspended' }] },
+      }),
+      step({
+        step_id: 'recover',
+        task: 'sync_audiences',
+        response: { audiences: [{ audience_id: 'aud-1', status: 'ready' }] },
+      }),
+      step({
+        step_id: 'suspend2',
+        task: 'sync_audiences',
+        response: { audiences: [{ audience_id: 'aud-1', status: 'suspended' }] },
+      }),
+    ]);
+    assert.equal(out[0].output.filter(o => o.status === 'not_applicable').length, 1);
+    assert.equal(out[1].output.filter(o => o.status === 'not_applicable').length, 0);
+    assert.equal(out[2].output.filter(o => o.status === 'not_applicable').length, 1);
+  });
+
+  test('inverse: creative offline transition does NOT emit not_applicable (family is graded)', () => {
+    const out = run([
+      step({
+        step_id: 'reject',
+        task: 'sync_creatives',
+        response: { creatives: [{ creative_id: 'cr-1', status: 'rejected' }] },
+      }),
+    ]);
+    assert.equal(
+      out[0].output.filter(o => o.status === 'not_applicable').length,
+      0,
+      'creative inverse rule is graded — no not_applicable hint'
+    );
+  });
+
+  test('inverse: deferred-family hint coexists with a buy snapshot in the same step', () => {
+    // When a sync_* step somehow also returns a media-buy snapshot (rare,
+    // but the runner unions the two paths cleanly), the hint and the
+    // snapshot grading both surface in the same step output.
+    const out = run([
+      step({
+        step_id: 'reject',
+        task: 'sync_creatives',
+        response: { creatives: [{ creative_id: 'cr-1', status: 'rejected' }] },
+      }),
+      step({
+        step_id: 'aud',
+        task: 'sync_audiences',
+        response: { audiences: [{ audience_id: 'aud-1', status: 'suspended' }] },
+      }),
+      // Buy snapshot follows — forward rule should pass, inverse silent.
+      step({
+        step_id: 'buy',
+        task: 'create_media_buy',
+        response: mb('mb-1', {
+          health: 'impaired',
+          impairments: [
+            { resource_type: 'creative', resource_id: 'cr-1' },
+            { resource_type: 'audience', resource_id: 'aud-1' },
+          ],
+          packages: [{ creative_assignments: [{ creative_id: 'cr-1' }] }],
+        }),
+      }),
+    ]);
+    const audNa = out[1].output.find(o => o.status === 'not_applicable');
+    assert.ok(audNa, 'audience transition emits not_applicable');
+    assert.equal(audNa.hint.resource_type, 'audience');
+    assert.ok(
+      out[2].output.every(o => o.passed),
+      'buy snapshot grades pass on the forward leg'
+    );
+  });
+
   test('onEnd: surfaces partial inverse coverage when a deferred-family offline observation lands', () => {
     // adcp#2860: inverse rule only grades creative today; audience /
     // catalog_item / event_source references on a buy are forward-only.


### PR DESCRIPTION
## Summary

Closes #1806. When the `impairment.coherence` invariant observes an offline
transition for a resource family the inverse rule can't reverse-traverse
(`audience` / `catalog_item` / `event_source`), the runner now emits a
step-level `AssertionResult` with `status: 'not_applicable'` carrying a
structured `ImpairmentCoherenceNotApplicableHint`. Before this change, the
inverse rule silently skipped these three families — a storyboard that
suspended an audience and read a buy missing it from `impairments[]` would
pass silently.

## API additions

- `AssertionResult.status` gains `'not_applicable'` as a fourth value (was `'pass' | 'silent' | 'fail'`).
- New `ImpairmentCoherenceNotApplicableHint` discriminator on the `StoryboardStepHint` union, exported from `@adcp/sdk/testing`:

  ```ts
  {
    kind: 'impairment_coherence_not_applicable',
    violation: 'inverse',
    reason: 'resource_traversal_deferred',
    resource_type: 'audience' | 'catalog_item' | 'event_source',
    resource_id: string,
    resource_status: string,
    resource_step_id: string,
    message: string,
  }
  ```

## Design notes

- **Emission trigger**: at the *transition step* itself, when a resource in one of the three deferred families enters its offline status. Single emission per `(resource_type, resource_id)` per run — re-syncs of an already-offline resource don't re-fire, but recovery + re-transition does.
- **Coexists with onEnd notice**: the existing run-level deferred-coverage notice on `onEnd` is unchanged; the step-level hint is additive. The step hint names the specific resource and is anchored to the transition; the onEnd notice is the family-level aggregate.
- **Forward rule unchanged**: forward grading already worked for all four families (the resource type is on the impairment entry itself; no buy-side traversal needed).
- **Creative inverse unchanged**: the creative family is fully graded today via `packages[].creative_assignments[]`.

## Acceptance checklist (from #1806)

- [x] Inverse rule emits `not_applicable` with `reason: 'resource_traversal_deferred'` for audience/catalog_item/event_source transitions
- [x] Hint includes `resource_type` so consumers can filter by family
- [x] Targeted test exercising one transition per deferred family confirms the hint shape (table-driven across all three)
- [x] Storyboard report renders the hint distinctly from `pass` — `AssertionResult.status: 'not_applicable'` + dedicated hint `kind` give renderers a discriminator they can branch on

The inverse-rule coverage itself remains tracked by adcontextprotocol/adcp#2860 (parent dependency-impact storyboard work).

## Test plan

- [x] Targeted: `node --test test/lib/storyboard-default-invariants.test.js` — 153/153 pass (38 in the `impairment.coherence` section, +7 new covering the three families, single-emission dedupe, recovery+re-transition, creative non-emission, and snapshot coexistence)
- [x] Full lib sweep: `npm run test:lib` — 6,814/6,819 pass (3 pre-existing skips, 2 cancelled, 0 failures)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run format:check` — clean
- [x] `npm run lint` — 2 pre-existing errors in unrelated files (eslint-plugin, task-map.test.ts); no new errors
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)