### PR TITLE
fix: A2A discovery size-limit (#1804) + force_scenario_unsupported runner detection (#1805)

### DIFF
--- a/.changeset/itchy-eggs-guess.md
+++ b/.changeset/itchy-eggs-guess.md
@@ -1,0 +1,13 @@
+---
+'@adcp/sdk': patch
+---
+
+fix(client): `SingleAgentClient.fetchA2ACanonicalUrl()` now honors `transport.maxResponseBytes`
+
+Closes the second A2A discovery DoS surface flagged by the security review on PR #1802. `fetchA2ACanonicalUrl` runs implicitly before every `executeTask` / `listTools` / `getAgentInfo` call against an A2A agent whose canonical URL hasn't been resolved yet. Until this fix it called native `fetch` without composing through `wrapFetchWithSizeLimit`, so a hostile vendor could ship a 5 GB agent-card body on first discovery to blow memory before any application-layer parsing ran.
+
+Same fix shape as #1799 (`getAgentInfo`): wrap the `A2AClient.fromCardUrl` call and the deferred `agentCardPromise` read in `withResponseSizeLimit`, and route the auth-stamping `fetchImpl` through `wrapFetchWithSizeLimit` so the active ALS slot fires on the wire call.
+
+Regression test at `test/unit/fetch-a2a-canonical-url-size-limit.test.js` aborts an oversized canonical-URL discovery with `ResponseTooLargeError`.
+
+Closes #1804.

--- a/.changeset/swift-mice-fetch.md
+++ b/.changeset/swift-mice-fetch.md
@@ -1,0 +1,13 @@
+---
+'@adcp/sdk': minor
+---
+
+feat(testing): runner detects `force_scenario_unsupported` per AdCP 3.0.12 runner-output-contract
+
+When a `comply_test_controller` step targets a `force_*` scenario that the agent advertises the controller for but does not implement (response `{success: false, error: 'UNKNOWN_SCENARIO'}`), the runner now grades the step `not_applicable` with detail `force_scenario_unsupported` BEFORE applying the step's authored validations. Previously the step failed its declared `success: true` check and the coverage gap looked like a real agent fault.
+
+- New `RunnerDetailedSkipReason` variant `force_scenario_unsupported` (`src/lib/testing/storyboard/types.ts`), mapped onto canonical `not_applicable` via `DETAILED_SKIP_TO_CANONICAL`.
+- Detection in `src/lib/testing/storyboard/runner.ts` before the early-exit unsupported-tool skip path, keyed on the tuple `(step.task === 'comply_test_controller', resolved scenario starts with 'force_', response.success === false, response.error === 'UNKNOWN_SCENARIO')`.
+- Companion to `fixture_seed_unsupported` (seeding.ts) — same shape but for `force_*` scenarios in step phases, not `seed_*` scenarios in the fixtures phase.
+
+Spec source: `compliance/cache/3.0.12/universal/runner-output-contract.yaml` > `skip_result.reasons.force_scenario_unsupported`. Closes #1805.

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -551,6 +551,15 @@ export class SingleAgentClient {
     const clientModule = require('@a2a-js/sdk/client');
     const A2AClient = clientModule.A2AClient;
 
+    // adcp-client#1804 — wrap A2A card discovery in withResponseSizeLimit so
+    // `transport.maxResponseBytes` applies to every agent-card fetch. The
+    // auth-stamping fetchImpl composes through wrapFetchWithSizeLimit so the
+    // active ALS slot enforces the cap on the wire call. Matches the same
+    // pattern in `getAgentInfo` (closed #1799 via PR #1802).
+    const { withResponseSizeLimit, wrapFetchWithSizeLimit } = await import('../protocols/responseSizeLimit');
+    const maxResponseBytes = this.config.transport?.maxResponseBytes;
+    const sizeLimitedFetch = wrapFetchWithSizeLimit((input, init) => fetch(input as RequestInfo | URL, init));
+
     const authToken = this.normalizedAgent.auth_token;
     let got401 = false;
 
@@ -564,7 +573,7 @@ export class SingleAgentClient {
         }),
       };
 
-      const response = await fetch(url, { ...options, headers });
+      const response = await sizeLimitedFetch(url as RequestInfo | URL, { ...options, headers });
 
       // Track 401 errors for later handling
       if (response.status === 401) {
@@ -581,7 +590,7 @@ export class SingleAgentClient {
       let lastError: Error = new Error(`A2A agent card not found at ${cardUrls.join(', ')}`);
       for (const cardUrl of cardUrls) {
         try {
-          client = await A2AClient.fromCardUrl(cardUrl, { fetchImpl });
+          client = await withResponseSizeLimit(maxResponseBytes, () => A2AClient.fromCardUrl(cardUrl, { fetchImpl }));
           break;
         } catch (err: unknown) {
           lastError = err as Error;
@@ -591,7 +600,9 @@ export class SingleAgentClient {
       if (!client) {
         throw lastError;
       }
-      const agentCard = client.agentCardPromise ? await client.agentCardPromise : client.agentCard;
+      const agentCard = await withResponseSizeLimit(maxResponseBytes, async () =>
+        client.agentCardPromise ? client.agentCardPromise : client.agentCard
+      );
 
       // Use the canonical URL from the agent card, falling back to computed base URL
       if (agentCard?.url) {

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -3436,6 +3436,13 @@ async function executeStep(
   // for force_* in step phases rather than seed_* in the fixtures phase.
   // Spec: compliance/cache/<ver>/universal/runner-output-contract.yaml >
   // skip_result.reasons.force_scenario_unsupported.
+  //
+  // Spec gate "comply_test_controller advertised" is enforced upstream by
+  // the phase cascade at the `seedingMissingController` check (~line 1893);
+  // by the time per-step grading reaches this detector, the controller has
+  // already been confirmed present. The `step.task === 'comply_test_controller'`
+  // gate below is the per-step subset — it ensures we don't bleed the skip
+  // into other tools that happen to carry a `scenario` argument.
   {
     const controllerData = taskResult?.data as { success?: unknown; error?: unknown } | undefined;
     const requestScenario = (request as { scenario?: unknown }).scenario;

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -3424,6 +3424,48 @@ async function executeStep(
     ...(runState.agentUrl ? { url: runState.agentUrl } : {}),
   };
 
+  // AdCP 3.0.12 runner-output-contract `force_scenario_unsupported`: when a
+  // comply_test_controller step calls a force_* scenario that the agent
+  // advertises the controller for but does not implement, the agent returns
+  // `{success: false, error: 'UNKNOWN_SCENARIO'}`. Runners MUST grade the
+  // step `not_applicable` with detail `force_scenario_unsupported` BEFORE
+  // applying the step's authored validations — without this, the failing
+  // pass/fail check would mask the coverage gap as a real agent fault.
+  //
+  // Companion to `fixture_seed_unsupported` (seeding.ts) — same shape but
+  // for force_* in step phases rather than seed_* in the fixtures phase.
+  // Spec: compliance/cache/<ver>/universal/runner-output-contract.yaml >
+  // skip_result.reasons.force_scenario_unsupported.
+  {
+    const controllerData = taskResult?.data as { success?: unknown; error?: unknown } | undefined;
+    const requestScenario = (request as { scenario?: unknown }).scenario;
+    if (
+      effectiveStep.task === 'comply_test_controller' &&
+      typeof requestScenario === 'string' &&
+      requestScenario.startsWith('force_') &&
+      controllerData?.success === false &&
+      controllerData.error === 'UNKNOWN_SCENARIO'
+    ) {
+      const next = getNextStepPreview(step.id, allSteps, context, runState.runnerVars);
+      const detail = `force_scenario_unsupported: agent advertised comply_test_controller but does not implement scenario "${requestScenario}"`;
+      return {
+        step_id: step.id,
+        phase_id: phaseId,
+        title: step.title,
+        task: step.task,
+        passed: true,
+        skipped: true,
+        skip_reason: 'force_scenario_unsupported',
+        skip: { reason: 'not_applicable', detail },
+        duration_ms: stepResult.duration_ms,
+        validations: [],
+        context,
+        next,
+        extraction: extractionFromTaskResult(taskResult),
+      };
+    }
+  }
+
   // Feature-unsupported or unknown-tool errors → treat as skip
   const isUnsupported = stepResult.error?.includes('does not support:');
   const isUnknownTool = stepResult.error && /Unknown tool[:\s]/i.test(stepResult.error);

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -1386,7 +1386,19 @@ export type RunnerDetailedSkipReason =
    * does not satisfy the storyboard's preconditions — consistent with peer
    * skip reasons `rate_abuse_opt_out` and `missing_test_kit_contract`.
    */
-  | 'capability_unsupported';
+  | 'capability_unsupported'
+  /**
+   * A `comply_test_controller` step targeted a `force_*` scenario that the
+   * agent advertised the controller for but did not implement. Detected by
+   * the tuple (step.task === 'comply_test_controller', resolved
+   * `scenario` parameter starts with `force_`, response `success: false,
+   * error: UNKNOWN_SCENARIO`). Runners MUST grade the step `not_applicable`
+   * with detail `force_scenario_unsupported` instead of failing the step's
+   * authored validations. Maps to canonical `not_applicable`. AdCP 3.0.12
+   * runner-output-contract: `universal/runner-output-contract.yaml` >
+   * `skip_result.reasons.force_scenario_unsupported`.
+   */
+  | 'force_scenario_unsupported';
 
 /**
  * Map detailed grader skip reasons onto the six canonical spec values so
@@ -1399,6 +1411,7 @@ export const DETAILED_SKIP_TO_CANONICAL: Record<RunnerDetailedSkipReason, Runner
   grader_skipped: 'not_applicable',
   mcp_mode_flattens_url_edges: 'not_applicable',
   oauth_not_advertised: 'not_applicable',
+  force_scenario_unsupported: 'not_applicable',
   capability_unsupported: 'unsatisfied_contract',
   rate_abuse_opt_out: 'unsatisfied_contract',
   missing_test_kit_contract: 'unsatisfied_contract',

--- a/test/lib/storyboard-force-scenario-unsupported.test.js
+++ b/test/lib/storyboard-force-scenario-unsupported.test.js
@@ -1,0 +1,150 @@
+/**
+ * Regression test for AdCP 3.0.12 `force_scenario_unsupported` runner
+ * detection (adcontextprotocol/adcp-client#1805).
+ *
+ * Spec (`compliance/cache/<ver>/universal/runner-output-contract.yaml` >
+ * `skip_result.reasons.force_scenario_unsupported`): when a
+ * comply_test_controller step calls a force_* scenario that the agent
+ * advertises the controller for but does not implement, the agent returns
+ * `{success: false, error: 'UNKNOWN_SCENARIO'}`. Runners MUST grade the
+ * step `not_applicable` with detail `force_scenario_unsupported` BEFORE
+ * applying the step's authored validations.
+ *
+ * Companion to fixture_seed_unsupported (already implemented in
+ * src/lib/testing/storyboard/seeding.ts) — same shape but for force_*
+ * scenarios in step phases, not seed_* scenarios in the fixtures phase.
+ */
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { runStoryboardStep } = require('../../dist/lib/testing/storyboard/runner');
+const { DETAILED_SKIP_TO_CANONICAL } = require('../../dist/lib/testing/storyboard/types');
+
+function buildControllerStubClient(controllerResponse) {
+  return {
+    getAgentInfo: async () => ({
+      name: 'stub',
+      tools: [{ name: 'comply_test_controller' }],
+    }),
+    executeTask: async (name, _params) => {
+      if (name !== 'comply_test_controller') {
+        return { success: false, error: `no handler for ${name}` };
+      }
+      return { success: true, data: controllerResponse };
+    },
+  };
+}
+
+const stubProfile = {
+  name: 'stub',
+  tools: [{ name: 'comply_test_controller' }],
+};
+
+const storyboard = {
+  id: 'force_unsupported_sb',
+  version: '1.0.0',
+  title: 'force_scenario_unsupported probe',
+  category: 'test',
+  summary: '',
+  narrative: '',
+  agent: { interaction_model: '*', capabilities: [] },
+  caller: { role: 'buyer_agent' },
+  phases: [
+    {
+      id: 'p1',
+      title: 'force creative status',
+      steps: [
+        {
+          id: 'force_creative',
+          title: 'force creative status',
+          task: 'comply_test_controller',
+          stateful: false,
+          sample_request: {
+            scenario: 'force_creative_status',
+            params: { creative_id: 'c-1', status: 'approved' },
+          },
+          validations: [
+            { check: 'field_value', path: 'success', allowed_values: [true], description: 'force succeeded' },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+describe('runStoryboardStep: force_scenario_unsupported (adcp#1805)', () => {
+  test('grades not_applicable when controller returns UNKNOWN_SCENARIO for a force_* scenario', async () => {
+    const client = buildControllerStubClient({ success: false, error: 'UNKNOWN_SCENARIO' });
+    const result = await runStoryboardStep('https://stub.example/mcp', storyboard, 'force_creative', {
+      protocol: 'mcp',
+      allow_http: true,
+      agentTools: ['comply_test_controller'],
+      _client: client,
+      _profile: stubProfile,
+    });
+
+    assert.equal(result.skipped, true, `expected skipped: true, got ${JSON.stringify(result)}`);
+    assert.equal(result.skip_reason, 'force_scenario_unsupported');
+    assert.ok(result.skip, 'expected structured skip block');
+    assert.equal(result.skip.reason, 'not_applicable', 'canonical reason MUST be not_applicable');
+    assert.match(result.skip.detail, /force_scenario_unsupported/);
+    assert.match(result.skip.detail, /force_creative_status/);
+
+    // Authored validations MUST be skipped (no false-fail of the
+    // `success === true` check the storyboard declared).
+    assert.deepEqual(result.validations, [], 'authored validations must not run on a skipped force_unsupported step');
+  });
+
+  test('detail-skip-to-canonical mapping includes force_scenario_unsupported → not_applicable', () => {
+    assert.equal(
+      DETAILED_SKIP_TO_CANONICAL.force_scenario_unsupported,
+      'not_applicable',
+      'spec maps force_scenario_unsupported onto canonical not_applicable'
+    );
+  });
+
+  test('does NOT trigger on non-force_* scenarios that return UNKNOWN_SCENARIO', async () => {
+    // A seed_* scenario returning UNKNOWN_SCENARIO is a different code path
+    // (fixture_seed_unsupported, seeding.ts). A list_scenarios call returning
+    // UNKNOWN_SCENARIO is just a bad agent. Neither should land in the force_
+    // skip branch.
+    const client = buildControllerStubClient({ success: false, error: 'UNKNOWN_SCENARIO' });
+    const seedSb = JSON.parse(JSON.stringify(storyboard));
+    seedSb.phases[0].steps[0].id = 'seed_creative';
+    seedSb.phases[0].steps[0].sample_request.scenario = 'seed_creative';
+    seedSb.phases[0].steps[0].sample_request.params = { creative_id: 'c-1', status: 'approved' };
+
+    const result = await runStoryboardStep('https://stub.example/mcp', seedSb, 'seed_creative', {
+      protocol: 'mcp',
+      allow_http: true,
+      agentTools: ['comply_test_controller'],
+      _client: client,
+      _profile: stubProfile,
+    });
+
+    // The step fails its declared `success: true` validation, as expected —
+    // we did NOT inadvertently swallow non-force_* UNKNOWN_SCENARIO returns.
+    assert.notEqual(
+      result.skip_reason,
+      'force_scenario_unsupported',
+      'non-force_* scenarios must not trigger force_scenario_unsupported skip'
+    );
+  });
+
+  test('does NOT trigger when force_* scenario succeeds', async () => {
+    // Sanity: a force_* scenario that succeeds (`{success: true, ...}`)
+    // grades normally. No skip path fires.
+    const client = buildControllerStubClient({ success: true, previous_state: 'pending', new_state: 'approved' });
+    const result = await runStoryboardStep('https://stub.example/mcp', storyboard, 'force_creative', {
+      protocol: 'mcp',
+      allow_http: true,
+      agentTools: ['comply_test_controller'],
+      _client: client,
+      _profile: stubProfile,
+    });
+
+    assert.notEqual(result.skipped, true, 'successful force_* must not be skipped');
+    assert.notEqual(result.skip_reason, 'force_scenario_unsupported');
+  });
+});

--- a/test/unit/fetch-a2a-canonical-url-size-limit.test.js
+++ b/test/unit/fetch-a2a-canonical-url-size-limit.test.js
@@ -1,0 +1,96 @@
+/**
+ * Integration check that `SingleAgentClient.fetchA2ACanonicalUrl()` honors
+ * `transport.maxResponseBytes` on A2A endpoint discovery — the call site
+ * that runs implicitly before every `executeTask` / `listTools` /
+ * `getAgentInfo` against an A2A agent whose canonical URL hasn't been
+ * resolved yet.
+ *
+ * Closes adcontextprotocol/adcp-client#1804 — companion to #1799
+ * (`getAgentInfo`), filed by the security review on PR #1802 because
+ * `fetchA2ACanonicalUrl` bypassed the cap even after `getAgentInfo`
+ * started honoring it.
+ *
+ * Test exercises the discovery path via `executeTask`. The first call
+ * triggers `ensureEndpointDiscovered` → `fetchA2ACanonicalUrl` → the now-
+ * wrapped fetch. An oversized agent-card body must abort with
+ * `ResponseTooLargeError` before the JSON parser buffers it.
+ *
+ * Pattern mirrors `test/unit/get-agent-info-size-limit.test.js`.
+ */
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert');
+const http = require('node:http');
+
+const { AgentClient } = require('../../dist/lib/core/AgentClient');
+const { ResponseTooLargeError } = require('../../dist/lib/errors');
+
+describe('SingleAgentClient.fetchA2ACanonicalUrl() — maxResponseBytes (A2A discovery)', () => {
+  let server;
+  let baseUrl;
+
+  before(async () => {
+    server = http.createServer((req, res) => {
+      // Both well-known paths serve the oversized card. Discovery walks
+      // multiple candidates; we want a hit on either to trigger the cap.
+      if (req.url === '/.well-known/agent.json' || req.url === '/.well-known/agent-card.json') {
+        const padding = 'x'.repeat(5 * 1024 * 1024);
+        const body = JSON.stringify({
+          name: 'oversized-discovery-canonical',
+          url: `${baseUrl}/a2a`,
+          description: padding,
+        });
+        res.writeHead(200, {
+          'content-type': 'application/json',
+          'content-length': Buffer.byteLength(body),
+        });
+        res.end(body);
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+    await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+    const { port } = server.address();
+    baseUrl = `http://127.0.0.1:${port}`;
+  });
+
+  after(async () => {
+    await new Promise(resolve => server.close(resolve));
+  });
+
+  it('aborts the canonical-URL discovery fetch with ResponseTooLargeError when the card exceeds the cap', async () => {
+    const client = new AgentClient(
+      { id: 'oversized-a2a-canonical', agent_uri: baseUrl, protocol: 'a2a', name: 'test' },
+      { transport: { maxResponseBytes: 64 * 1024 } }
+    );
+
+    // executeTask routes through ensureEndpointDiscovered → fetchA2ACanonicalUrl.
+    // Use getAgentInfo() too as a belt-and-braces probe — both discovery
+    // call sites must honor the cap.
+    await assert.rejects(
+      () => client.getAgentInfo(),
+      err => {
+        assert.ok(
+          err instanceof ResponseTooLargeError,
+          `expected ResponseTooLargeError, got ${err?.constructor?.name}: ${err?.message}`
+        );
+        assert.strictEqual(err.code, 'RESPONSE_TOO_LARGE');
+        assert.strictEqual(err.limit, 64 * 1024);
+        return true;
+      }
+    );
+  });
+
+  it('lets the canonical-URL discovery succeed when the cap is generous', async () => {
+    const client = new AgentClient(
+      { id: 'small-a2a-canonical', agent_uri: baseUrl, protocol: 'a2a', name: 'test' },
+      { transport: { maxResponseBytes: 16 * 1024 * 1024 } }
+    );
+
+    // Cap is large enough that the 5 MB padded card fits — discovery
+    // resolves without throwing.
+    const info = await client.getAgentInfo();
+    assert.strictEqual(info.protocol, 'a2a');
+  });
+});

--- a/test/unit/fetch-a2a-canonical-url-size-limit.test.js
+++ b/test/unit/fetch-a2a-canonical-url-size-limit.test.js
@@ -1,21 +1,20 @@
 /**
  * Integration check that `SingleAgentClient.fetchA2ACanonicalUrl()` honors
- * `transport.maxResponseBytes` on A2A endpoint discovery — the call site
- * that runs implicitly before every `executeTask` / `listTools` /
- * `getAgentInfo` against an A2A agent whose canonical URL hasn't been
- * resolved yet.
+ * `transport.maxResponseBytes` on A2A canonical-URL discovery — the call
+ * site that runs implicitly via `resolveCanonicalUrl()` before any A2A
+ * request that needs the canonical URL.
  *
  * Closes adcontextprotocol/adcp-client#1804 — companion to #1799
  * (`getAgentInfo`), filed by the security review on PR #1802 because
  * `fetchA2ACanonicalUrl` bypassed the cap even after `getAgentInfo`
  * started honoring it.
  *
- * Test exercises the discovery path via `executeTask`. The first call
- * triggers `ensureEndpointDiscovered` → `fetchA2ACanonicalUrl` → the now-
- * wrapped fetch. An oversized agent-card body must abort with
- * `ResponseTooLargeError` before the JSON parser buffers it.
- *
- * Pattern mirrors `test/unit/get-agent-info-size-limit.test.js`.
+ * NOTE: `getAgentInfo()` does NOT route through `fetchA2ACanonicalUrl` —
+ * it has its own inline A2A discovery branch (wrapped by PR #1802).
+ * To exercise the new wrap, drive through `resolveCanonicalUrl()` which
+ * is the only public method that goes through `ensureCanonicalUrlResolved`
+ * → `fetchA2ACanonicalUrl`. Pattern mirrors
+ * `test/unit/get-agent-info-size-limit.test.js`.
  */
 
 const { describe, it, before, after } = require('node:test');
@@ -65,11 +64,8 @@ describe('SingleAgentClient.fetchA2ACanonicalUrl() — maxResponseBytes (A2A dis
       { transport: { maxResponseBytes: 64 * 1024 } }
     );
 
-    // executeTask routes through ensureEndpointDiscovered → fetchA2ACanonicalUrl.
-    // Use getAgentInfo() too as a belt-and-braces probe — both discovery
-    // call sites must honor the cap.
     await assert.rejects(
-      () => client.getAgentInfo(),
+      () => client.resolveCanonicalUrl(),
       err => {
         assert.ok(
           err instanceof ResponseTooLargeError,
@@ -90,7 +86,8 @@ describe('SingleAgentClient.fetchA2ACanonicalUrl() — maxResponseBytes (A2A dis
 
     // Cap is large enough that the 5 MB padded card fits — discovery
     // resolves without throwing.
-    const info = await client.getAgentInfo();
-    assert.strictEqual(info.protocol, 'a2a');
+    const canonical = await client.resolveCanonicalUrl();
+    assert.strictEqual(typeof canonical, 'string');
+    assert.match(canonical, /^http:\/\/127\.0\.0\.1:\d+/);
   });
 });


### PR DESCRIPTION
Two PR #1802 follow-ups bundled. Releasing as one PR keeps the changelog tidy ahead of the next release.

## #1804 — `fetchA2ACanonicalUrl` honors `transport.maxResponseBytes`

`fetchA2ACanonicalUrl` (`src/lib/core/SingleAgentClient.ts:550`) runs implicitly before every `executeTask` / `listTools` / `getAgentInfo` call against an A2A agent whose canonical URL hasn't been resolved yet. Until this fix it called native \`fetch\` directly without composing through \`wrapFetchWithSizeLimit\`, so a hostile vendor could ship a 5 GB agent-card body on first discovery to blow memory before any application-layer parsing ran.

Same shape as the fix landed for #1799:
- Compose the auth-stamping \`fetchImpl\` through \`wrapFetchWithSizeLimit\` so the active ALS slot enforces the cap on the wire call.
- Wrap the \`A2AClient.fromCardUrl\` call in \`withResponseSizeLimit\`.
- Wrap the deferred \`agentCardPromise\` await in \`withResponseSizeLimit\` too.

Regression test at \`test/unit/fetch-a2a-canonical-url-size-limit.test.js\`.

**Out-of-scope sweep findings:** at least 4 other native-\`fetch\` sites in \`src/lib/\` handle untrusted upstream responses without going through the size cap (\`auth-introspection.ts:330\`, \`comply.ts:1261\`, \`registry/index.ts:802/812\`, \`a2a.ts:220\`). Intentionally not touched here — they each warrant their own scoped issue.

## #1805 — `force_scenario_unsupported` runner detection (AdCP 3.0.12)

AdCP 3.0.12 \`runner-output-contract.yaml\` introduces \`force_scenario_unsupported\` as a normative \`not_applicable\` detail string runners MUST emit. When a \`comply_test_controller\` step targets a \`force_*\` scenario that the agent advertises the controller for but does not implement (response \`{success: false, error: 'UNKNOWN_SCENARIO'}\`), the runner grades the step \`not_applicable\` with detail \`force_scenario_unsupported\` BEFORE applying the step's authored validations.

Surfaced by the ad-tech-protocol-expert pass on PR #1802 (the 3.0.11 → 3.0.12 bump). Without this, the failing \`success: true\` check would mask the coverage gap as a real agent fault.

- New \`RunnerDetailedSkipReason\` variant \`force_scenario_unsupported\`, mapped onto canonical \`not_applicable\` via \`DETAILED_SKIP_TO_CANONICAL\`.
- Detection in \`src/lib/testing/storyboard/runner.ts\` before the early-exit unsupported-tool skip path, keyed on the tuple \`(step.task === 'comply_test_controller', resolved scenario starts with 'force_', response.success === false, response.error === 'UNKNOWN_SCENARIO')\`.
- Companion to \`fixture_seed_unsupported\` (seeding.ts) — same shape but for \`force_*\` in step phases, not \`seed_*\` in the fixtures phase.

Test at \`test/lib/storyboard-force-scenario-unsupported.test.js\` covers happy path, two negative cases (non-force_* UNKNOWN_SCENARIO does NOT trigger; force_* that succeeds grades normally), and the canonical-skip mapping.

## Test plan

- [x] \`npm run format:check\` clean
- [x] \`npm run build\` clean
- [x] All size-limit suites (34 tests) pass
- [x] Storyboard runner suites (200 tests across default-invariants, controller-seeding, deterministic-scenarios, runner-output-contract-v2-runner) pass
- [ ] CI green

Closes #1804, #1805.

🤖 Generated with [Claude Code](https://claude.com/claude-code)