### PR TITLE
feat(storyboard): add `present:` matcher to requires_capability gates (#1811)

### DIFF
--- a/.changeset/requires-capability-present-matcher.md
+++ b/.changeset/requires-capability-present-matcher.md
@@ -1,0 +1,57 @@
+---
+'@adcp/sdk': minor
+---
+
+feat(storyboard): add `present:` matcher to `requires_capability` gates
+
+Extends the storyboard runner's `requires_capability` predicate with a
+presence-only matcher for spec capabilities whose contract is "presence
+of this object indicates support" — adcp-client#1811.
+
+The motivating case is `media_buy.conversion_tracking`, which the spec
+defines as:
+
+> Seller-level conversion tracking capabilities. Presence of this object
+> indicates the seller supports sync_event_sources and log_event for
+> conversion event tracking.
+
+There is no boolean to test with `equals`. Sub-properties like
+`multi_source_event_dedup` or `supported_event_types` are not faithful
+proxies for the presence signal. The same shape will appear for future
+capability surfaces that the spec defines as "presence means support."
+
+New form (mutually exclusive with `equals:` on a single gate):
+
+```yaml
+requires_capability:
+  path: media_buy.conversion_tracking
+  present: true
+```
+
+Semantics:
+
+- `present: true` — the value at `path` MUST exist (non-null,
+  non-undefined). Empty object `{}` counts as present (the spec's
+  presence-is-the-signal contract). Absent fields skip the storyboard
+  with `skip_reason: 'capability_unsupported'`. This DIFFERS from
+  `equals:` absence semantics — for presence matchers, silence IS the
+  spec-defined opt-out, so a missing field is not_applicable rather
+  than a coverage gap.
+- `present: false` — the value at `path` MUST NOT exist. Useful for
+  scenarios that only apply to agents that explicitly do NOT advertise
+  a capability.
+
+Existing `equals:` scenarios are unchanged; the discriminator is the
+presence of `equals` vs `present` on the gate object. TypeScript
+authors get a discriminated union that enforces mutual exclusion at
+type level.
+
+The predicate logic is factored into a new exported helper
+`evaluateCapabilityPredicate(predicate, actual): string | null` so the
+matcher semantics can be unit-tested directly without a full
+`runStoryboard()` roundtrip.
+
+Concrete consumer (filed under adcp#4569): a
+`media_buy_seller/performance_buy_flow` scenario that gates on
+`media_buy.conversion_tracking` and exercises the end-to-end
+event-source → buy → log → attributed delivery flow.

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -2184,7 +2184,14 @@ async function handleStoryboardShow(args) {
       console.log(`Resolves to ${resolved.storyboards.length} storyboard(s):`);
       for (const sb of resolved.storyboards) {
         const gating = sb.requires_capability
-          ? ` (gated on ${sb.requires_capability.path} = ${sb.requires_capability.equals})`
+          ? ' (gated on ' +
+            sb.requires_capability.path +
+            ('present' in sb.requires_capability
+              ? sb.requires_capability.present
+                ? ' present'
+                : ' absent'
+              : ' = ' + sb.requires_capability.equals) +
+            ')'
           : ' (always graded)';
         const trackTag = sb.track ? ` [track: ${sb.track}]` : '';
         console.log(`  - ${sb.id}${trackTag}${gating}`);

--- a/src/lib/testing/storyboard/index.ts
+++ b/src/lib/testing/storyboard/index.ts
@@ -95,6 +95,7 @@ export {
   summarizeStrictValidation,
   listStrictOnlyFailures,
   resolveCapabilityPath,
+  evaluateCapabilityPredicate,
   buildDiscoveryFailedResult,
 } from './runner';
 

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -184,6 +184,64 @@ export function resolveCapabilityPath(raw: unknown, dottedPath: string): unknown
   return current;
 }
 
+/**
+ * Evaluate a `requires_capability` predicate against the value already
+ * resolved from the agent's raw capabilities. Returns `null` when the
+ * predicate is satisfied (or unresolvable, per `equals` absence semantics)
+ * and a human-readable detail string when the storyboard should be skipped.
+ *
+ * Two matcher forms — see `Storyboard.requires_capability` for full semantics:
+ *
+ * - `equals: V` — skip only when `actual` is declared AND disagrees with `V`.
+ *   Absent fields (`undefined`) RUN the storyboard so the failure surfaces
+ *   an under-declared agent.
+ *
+ * - `present: B` — presence is the load-bearing signal. `present: true`
+ *   skips when the field is absent (treats `undefined` and `null` as absent).
+ *   `present: false` skips when the field is present. Empty object `{}`
+ *   counts as present, per the spec's "presence of this object indicates
+ *   support" wording. Note: an explicit `null` on the wire is technically
+ *   non-conformant for object-typed capabilities (`"type": "object"` rejects
+ *   null in JSON Schema), but is coalesced with absent here in the spirit of
+ *   Postel — agents that misdeclare a not-supported capability as `null`
+ *   get the same not_applicable skip as agents that omit the field.
+ *
+ * Exported for direct testing so the predicate semantics are pinned without
+ * needing a full runStoryboard() roundtrip.
+ */
+export function evaluateCapabilityPredicate(
+  predicate: { path: string; equals: boolean | string | number | null } | { path: string; present: boolean },
+  actual: unknown
+): string | null {
+  if ('present' in predicate) {
+    const isPresent = actual !== undefined && actual !== null;
+    if (predicate.present && !isPresent) {
+      return `Capability predicate \`${predicate.path}\` must be present: ` + `agent did not declare it.`;
+    }
+    if (!predicate.present && isPresent) {
+      return (
+        `Capability predicate \`${predicate.path}\` must be absent: ` + `agent declared ${JSON.stringify(actual)}.`
+      );
+    }
+    return null;
+  }
+  // `equals` form — absence semantics are load-bearing. `actual === undefined`
+  // means the agent didn't declare the capability at all (field missing from
+  // `get_adcp_capabilities` response). We deliberately RUN the storyboard in
+  // that case rather than skip it: an agent that pre-dates the capability
+  // field hasn't explicitly opted out, so the storyboard's failures surface
+  // a real spec-coverage gap (under-declared agent) rather than a behavior
+  // the agent affirmatively refused. Skip ONLY when the agent declared a
+  // value AND that value disagrees with the predicate.
+  if (actual !== undefined && actual !== predicate.equals) {
+    return (
+      `Capability predicate \`${predicate.path} === ${JSON.stringify(predicate.equals)}\` not satisfied: ` +
+      `agent declared ${JSON.stringify(actual)}.`
+    );
+  }
+  return null;
+}
+
 function buildSkip(reason: RunnerSkipReason, detail?: string): { reason: RunnerSkipReason; detail: string } {
   return { reason, detail: detail ?? SKIP_DETAILS[reason] };
 }
@@ -1486,23 +1544,15 @@ async function executeStoryboardPass(
   if (storyboard.requires_capability) {
     const rawCaps = profile?.raw_capabilities;
     if (rawCaps !== undefined) {
-      const { path, equals } = storyboard.requires_capability;
-      const actual = resolveCapabilityPath(rawCaps, path);
-      // Absence semantics — load-bearing. `actual === undefined` means
-      // the agent didn't declare the capability at all (field missing
-      // from `get_adcp_capabilities` response). We deliberately RUN the
-      // storyboard in that case rather than skip it: an agent that
-      // pre-dates the capability field hasn't explicitly opted out, so
-      // the storyboard's failures surface a real spec-coverage gap
-      // (under-declared agent) rather than a behavior the agent
-      // affirmatively refused. Skip ONLY when the agent declared a
-      // value AND that value disagrees with the predicate.
-      if (actual !== undefined && actual !== equals) {
-        const detail =
-          `Capability predicate \`${path} === ${JSON.stringify(equals)}\` not satisfied: ` +
-          `agent declared ${JSON.stringify(actual)}.`;
+      const cap = storyboard.requires_capability;
+      const actual = resolveCapabilityPath(rawCaps, cap.path);
+      const unmetDetail = evaluateCapabilityPredicate(cap, actual);
+      if (unmetDetail !== null) {
         if (!options._client) await closeConnections(options.protocol);
-        return { ...buildCapabilityUnsupportedResult(agentUrls, storyboard, detail), notices: preflightNotices };
+        return {
+          ...buildCapabilityUnsupportedResult(agentUrls, storyboard, unmetDetail),
+          notices: preflightNotices,
+        };
       }
     }
   }

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -96,17 +96,31 @@ export interface Storyboard {
    * when the storyboard tests behavior the agent explicitly opted out of.
    *
    * `path` is a dotted key path into the raw `get_adcp_capabilities` response
-   * (e.g. `"adcp.idempotency.supported"`). `equals` is the scalar value the
-   * path must resolve to for the storyboard to run.
+   * (e.g. `"adcp.idempotency.supported"`).
    *
-   * When the path resolves to `undefined` (field absent), the predicate is
-   * treated as unresolvable and the storyboard runs — absence means the agent
-   * hasn't explicitly opted out, so failing the storyboard surfaces the gap.
+   * Two matcher forms — mutually exclusive on a single gate:
+   *
+   * - `equals: V` — scalar equality. The path's resolved value must equal `V`
+   *   for the storyboard to run. When the path resolves to `undefined` (field
+   *   absent), the predicate is treated as unresolvable and the storyboard
+   *   runs — absence means the agent hasn't explicitly opted out, so failing
+   *   the storyboard surfaces the gap.
+   *
+   * - `present: true|false` — presence-only matcher for spec capabilities whose
+   *   contract is "presence of this object indicates support" (e.g.
+   *   `media_buy.conversion_tracking`). `present: true` requires the value at
+   *   `path` to exist (non-null, non-undefined); empty object `{}` counts as
+   *   present. `present: false` requires the value to be absent — useful for
+   *   scenarios that only apply to agents that explicitly do NOT advertise a
+   *   capability. Unlike `equals`, absence is the load-bearing signal: when
+   *   `present: true` and the field is missing, the storyboard is skipped
+   *   (not_applicable) rather than run, because the seller's silence is the
+   *   spec-defined opt-out.
    *
    * When `raw_capabilities` is not available (e.g. the agent doesn't expose
    * `get_adcp_capabilities`), the gate is a no-op and the storyboard runs.
    */
-  requires_capability?: { path: string; equals: boolean | string | number | null };
+  requires_capability?: { path: string; equals: boolean | string | number | null } | { path: string; present: boolean };
   /** Scenario IDs that must pass alongside this storyboard (loaded from storyboards/scenarios/) */
   requires_scenarios?: string[];
   agent: {

--- a/test/lib/storyboard-capability-gate.test.js
+++ b/test/lib/storyboard-capability-gate.test.js
@@ -9,7 +9,11 @@
 const { describe, test } = require('node:test');
 const assert = require('node:assert/strict');
 
-const { runStoryboard, resolveCapabilityPath } = require('../../dist/lib/testing/storyboard/index.js');
+const {
+  runStoryboard,
+  resolveCapabilityPath,
+  evaluateCapabilityPredicate,
+} = require('../../dist/lib/testing/storyboard/index.js');
 const { DETAILED_SKIP_TO_CANONICAL } = require('../../dist/lib/testing/storyboard/types.js');
 
 // Storyboard that requires adcp.idempotency.supported === true — the shape that
@@ -140,6 +144,152 @@ describe('requires_capability storyboard skip gate (#933)', () => {
       DETAILED_SKIP_TO_CANONICAL['capability_unsupported'],
       'unsatisfied_contract',
       'canonical spec reason for capability_unsupported'
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// `present:` matcher (adcp-client#1811) — presence-only capability gates for
+// spec capabilities whose contract is "presence of this object indicates
+// support" (e.g. `media_buy.conversion_tracking`).
+// ─────────────────────────────────────────────────────────────────────────────
+
+const conversionTrackingGatedStoryboard = {
+  id: 'conversion_tracking_present_gate_test',
+  version: '1.0.0',
+  title: 'Conversion tracking (presence-gated)',
+  category: 'test',
+  summary: 'Runs only when the seller advertises media_buy.conversion_tracking.',
+  narrative: '',
+  agent: { interaction_model: 'sync', capabilities: [] },
+  caller: { role: 'buyer_agent' },
+  requires_capability: { path: 'media_buy.conversion_tracking', present: true },
+  phases: [
+    {
+      id: 'attribution',
+      title: 'Attribution phase',
+      steps: [
+        {
+          id: 'log_event_step',
+          title: 'Log conversion event',
+          task: 'log_event',
+          sample_request: {},
+        },
+      ],
+    },
+  ],
+};
+
+const presentAbsentGatedStoryboard = {
+  ...conversionTrackingGatedStoryboard,
+  id: 'conversion_tracking_absent_gate_test',
+  requires_capability: { path: 'media_buy.conversion_tracking', present: false },
+};
+
+describe('requires_capability `present:` matcher (#1811)', () => {
+  test('present: true — skips when agent does not declare the capability at all', async () => {
+    const profile = {
+      name: 'Test Agent (no conversion tracking declared)',
+      tools: ['get_adcp_capabilities', 'log_event'],
+      raw_capabilities: { media_buy: {} },
+    };
+    const result = await runStoryboard('http://fake-local-99998', conversionTrackingGatedStoryboard, {
+      _profile: profile,
+    });
+    assert.equal(result.overall_passed, true);
+    assert.equal(result.skipped_count, 1);
+    const step = result.phases[0].steps[0];
+    assert.equal(step.skipped, true);
+    assert.equal(step.skip_reason, 'capability_unsupported');
+    assert.equal(step.skip.reason, 'unsatisfied_contract');
+    assert.ok(
+      step.skip.detail.includes('media_buy.conversion_tracking'),
+      `detail must mention the capability path: ${step.skip.detail}`
+    );
+    assert.ok(
+      step.skip.detail.includes('must be present'),
+      `detail must explain presence requirement: ${step.skip.detail}`
+    );
+  });
+
+  test('present: true — skips when agent declares the field as null', async () => {
+    // null is the explicit "not supported" wire signal for object-typed
+    // capabilities; presence-only matcher treats it the same as absent.
+    const profile = {
+      name: 'Test Agent (conversion tracking explicitly null)',
+      tools: ['get_adcp_capabilities', 'log_event'],
+      raw_capabilities: { media_buy: { conversion_tracking: null } },
+    };
+    const result = await runStoryboard('http://fake-local-99997', conversionTrackingGatedStoryboard, {
+      _profile: profile,
+    });
+    assert.equal(result.skipped_count, 1);
+    assert.equal(result.phases[0].steps[0].skip_reason, 'capability_unsupported');
+  });
+
+  test('present: true — empty object counts as present (storyboard runs, gate does not skip)', () => {
+    // Spec: "Presence of this object indicates support." An empty {} IS
+    // presence. We use the predicate helper directly because asserting "the
+    // gate didn't skip" without a real wire path requires running phases.
+    assert.equal(
+      evaluateCapabilityPredicate({ path: 'media_buy.conversion_tracking', present: true }, {}),
+      null,
+      'empty object satisfies `present: true`'
+    );
+    assert.equal(
+      evaluateCapabilityPredicate(
+        { path: 'media_buy.conversion_tracking', present: true },
+        { multi_source_event_dedup: true }
+      ),
+      null,
+      'populated object satisfies `present: true`'
+    );
+  });
+
+  test('present: false — skips when agent declares the capability', async () => {
+    const profile = {
+      name: 'Test Agent (does declare conversion tracking)',
+      tools: ['get_adcp_capabilities', 'log_event'],
+      raw_capabilities: { media_buy: { conversion_tracking: {} } },
+    };
+    const result = await runStoryboard('http://fake-local-99996', presentAbsentGatedStoryboard, {
+      _profile: profile,
+    });
+    assert.equal(result.skipped_count, 1);
+    const step = result.phases[0].steps[0];
+    assert.equal(step.skipped, true);
+    assert.equal(step.skip_reason, 'capability_unsupported');
+    assert.ok(
+      step.skip.detail.includes('must be absent'),
+      `detail must explain absence requirement: ${step.skip.detail}`
+    );
+  });
+
+  test('evaluateCapabilityPredicate: pins matcher semantics', () => {
+    const presentTrue = { path: 'x.y', present: true };
+    const presentFalse = { path: 'x.y', present: false };
+    const equalsTrue = { path: 'x.y', equals: true };
+
+    // present: true
+    assert.equal(evaluateCapabilityPredicate(presentTrue, undefined)?.includes('must be present'), true);
+    assert.equal(evaluateCapabilityPredicate(presentTrue, null)?.includes('must be present'), true);
+    assert.equal(evaluateCapabilityPredicate(presentTrue, false), null, 'false is present (declared scalar)');
+    assert.equal(evaluateCapabilityPredicate(presentTrue, 0), null, '0 is present');
+    assert.equal(evaluateCapabilityPredicate(presentTrue, ''), null, "'' is present");
+    assert.equal(evaluateCapabilityPredicate(presentTrue, {}), null, '{} is present');
+
+    // present: false
+    assert.equal(evaluateCapabilityPredicate(presentFalse, undefined), null);
+    assert.equal(evaluateCapabilityPredicate(presentFalse, null), null);
+    assert.equal(evaluateCapabilityPredicate(presentFalse, {})?.includes('must be absent'), true);
+
+    // equals semantics unchanged: absence is unresolvable, run the storyboard.
+    assert.equal(evaluateCapabilityPredicate(equalsTrue, undefined), null, 'absent: equals runs the storyboard');
+    assert.equal(evaluateCapabilityPredicate(equalsTrue, true), null);
+    assert.equal(
+      evaluateCapabilityPredicate(equalsTrue, false)?.includes('not satisfied'),
+      true,
+      'declared mismatch skips with `not satisfied` detail'
     );
   });
 });


### PR DESCRIPTION
## Summary

- Extends the storyboard runner's `requires_capability` predicate with a `present:` form for spec capabilities whose contract is "presence of this object indicates support" (e.g. `media_buy.conversion_tracking`).
- Existing `equals:` form is unchanged. The two forms are mutually exclusive on a single gate, enforced at the TS type level via a discriminated union.
- Factors the predicate into `evaluateCapabilityPredicate()` (exported) so the matcher semantics are pinned by unit tests without a full `runStoryboard()` roundtrip.

Closes #1811.

## Semantics

```yaml
# existing — scalar equality, absence runs (surfaces under-declared agents)
requires_capability: { path: adcp.idempotency.supported, equals: true }

# new — presence-only, absence skips (spec's silence-is-opt-out contract)
requires_capability: { path: media_buy.conversion_tracking, present: true }
```

- `present: true` — value must exist (non-null, non-undefined). Empty `{}` counts as present.
- `present: false` — value must be absent. For scenarios that only apply to agents who do NOT advertise the capability.
- Absence-skip asymmetry is intentional: for `present:` matchers, silence IS the spec-defined opt-out, so absent → `not_applicable` rather than coverage-gap.
- `null` is technically non-conformant under `"type": "object"` but is coalesced with absent in the spirit of Postel.

## Concrete consumer

`media_buy_seller/performance_buy_flow` (adcp#4569) — sellers who don't advertise `conversion_tracking` get `not_applicable`; sellers who do MUST run the event-source → buy → log → attributed delivery flow.

## Expert reviews

Reviewed in parallel by ad-tech-protocol-expert, code-reviewer, and adtech-product-expert. All three: land as-is.

- Protocol: semantics match spec's "presence indicates support" pattern; `null` coalescing is the right call.
- Code: prior `equals` behavior preserved verbatim in extracted helper; backwards-compat with `storyboard-notices.test.js:162` intact.
- Product: `equals`/`present` absence asymmetry is correctly motivated by the underlying spec shape, not protocol aesthetic. `present: false` is cheap symmetry worth shipping.

Two follow-ups punted (not blockers): runtime YAML validation of the discriminator mutual-exclusion, and Python parity (called out in the issue as explicit follow-up).

## Test plan

- [x] `node --test test/lib/storyboard-capability-gate.test.js` — 9/9 pass (4 existing + 5 new)
- [x] `npm run typecheck` clean
- [x] `npm run format:check` clean
- [x] Existing `equals:` storyboards untouched (verified via `storyboard-notices.test.js:162`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)