### PR TITLE
feat(v2): prototype v2 → v1 Product projection layer

### DIFF
--- a/.changeset/v2-to-v1-projection-prototype.md
+++ b/.changeset/v2-to-v1-projection-prototype.md
@@ -1,0 +1,66 @@
+---
+'@adcp/sdk': minor
+---
+
+feat(v2): prototype v2 → v1 Product projection layer
+
+Working prototype of the v2 → v1 Product projection from the 8.0 design
+proposal at `docs/development/v3.1-sdk-design.md` (PR #1809). Used when
+the SDK negotiates to a v1 seller for a buyer that wrote V2 code —
+adopters never see v1 vocabulary; SDK does the wire-level translation.
+
+Implements the resolution order from `v1-canonical-mapping.json`,
+inverted:
+
+1. `format_kind: "custom"` + `canonical_formats_only: true` →
+   `FORMAT_DECLARATION_V1_UNREACHABLE` diagnostic (explicit opt-out).
+2. `v1_format_ref` present → use verbatim (seller-asserted equivalence).
+3. Registry reverse-lookup → invertible match (canonical + params
+   narrow compatibly to a literal v1 named format).
+4. Registry says "family exists but ambiguous" →
+   `FORMAT_DECLARATION_V1_AMBIGUOUS` diagnostic.
+5. Registry says "no entry for this canonical" →
+   `FORMAT_DECLARATION_V1_UNREACHABLE` diagnostic.
+
+Diagnostics emitted on the structured channel (`ProjectionDiagnostic[]`)
+per the spec's resolution-order amendment — never logger-only.
+
+**Exercised against all 13 spec reference fixtures.** Coverage report:
+- 1/13 clean v1 emit (`nytimes_homepage_mrec` — image 300x250 matches
+  the IAB MREC registry entry).
+- 1/13 explicit opt-out (`nytimes_homepage_takeover_custom`).
+- 7/13 ambiguous (the family has registry entries but none invert
+  cleanly — `display_tag`, `video_hosted`, `html5`, `audio_hosted`,
+  `audio_daast`, `video_vast`).
+- 4/13 no registry coverage (`sponsored_placement`, `agent_placement`,
+  `responsive_creative`, `image_carousel` — these are genuinely new
+  canonical concepts in v2 with no v1 equivalent).
+
+Headline implication for the 8.0 design: without sellers adding
+`v1_format_ref` to their declarations, only ~8% of v2 fixtures
+project cleanly. The "v2-only public type with projection at the
+boundary" stance still holds — products that can't downgrade
+gracefully surface via diagnostics — but the migration story for v1
+sellers depends on sellers actively annotating their v2 declarations.
+
+**Surfaced upstream-spec bug**: the IAB-named registry entries
+(`iab/mrec_300x250` etc.) contain slashes, but `format-id.json` only
+allows `^[a-zA-Z0-9_-]+$`. Projecting `nytimes_homepage_mrec` produces
+a synthesized `format_id.id` that wouldn't pass wire validation — this
+is the same cross-schema mismatch flagged in
+adcontextprotocol/adcp upstream.
+
+**Scope notes**:
+
+- Hand-rolled TypeScript types in `src/lib/v2/projection/types.ts`
+  rather than full versioned codegen — separate piece of the 8.0
+  enablement. Types match the schema shape at projection-relevant
+  precision; params bodies stay loose (`Record<string, unknown>`).
+- v1 → v2 (upgrade direction) is the symmetric counterpart and not
+  in this prototype. Will land in a follow-up once we agree on
+  the design surface.
+- No public barrel export yet — the projection layer is internal-only
+  until the auto-negotiation surface lands. Tests import directly
+  from `dist/lib/v2/projection/v2-to-v1.js`.
+- Public types and behavior may change as the 8.0 design firms up
+  (see PR #1809 for the architecture proposal).

--- a/.prettierignore
+++ b/.prettierignore
@@ -11,3 +11,9 @@ docs/
 # would reformat and diverge from the source of truth. Remove once vectors
 # load from compliance/cache/ (already ignored) instead of test/fixtures/.
 test/fixtures/webhook-signing-vectors/
+
+# Vendored v2 canonical-format reference fixtures from adcontextprotocol/adcp#3307
+# (static/examples/products/canonical/). Same byte-fidelity rule as
+# webhook-signing-vectors — these are spec-authored examples and reformatting
+# would diverge from the source of truth.
+test/lib/v2-projection-fixtures/

--- a/src/lib/v2/projection/canonical-properties.ts
+++ b/src/lib/v2/projection/canonical-properties.ts
@@ -1,0 +1,94 @@
+/**
+ * Read structural properties off the canonical format schemas at
+ * `schemas/cache/<version>/formats/canonical/<kind>.json`. The
+ * projection layer needs `v1_translatable` per canonical to honor the
+ * normative rule from `v1-canonical-mapping.json`:
+ *
+ *   > SDKs encountering `v1_translatable: false` on a canonical SHOULD
+ *   > NOT emit `FORMAT_PROJECTION_FAILED` (which signals registry-
+ *   > coverage gap) — instead surface the inherent v1-unreachability
+ *   > as a different diagnostic or skip silently. The 4 inherently-v2
+ *   > canonicals at 3.1 GA: `image_carousel`, `sponsored_placement`,
+ *   > `responsive_creative`, `agent_placement`.
+ *
+ * Cached per canonical kind. Falls back to the `_base.json` default
+ * (`true`) when a canonical doesn't override the field — matches the
+ * spec's default semantics.
+ */
+
+import { readFileSync, existsSync } from 'fs';
+import path from 'path';
+import type { CanonicalFormatKind } from './types';
+
+interface CanonicalSchema {
+  properties?: {
+    v1_translatable?: {
+      default?: boolean;
+    };
+  };
+}
+
+let cache: Map<CanonicalFormatKind, boolean> | null = null;
+let baseDefault: boolean | null = null;
+
+function loadCanonicalSchema(kind: CanonicalFormatKind, cacheRoot: string): CanonicalSchema | null {
+  const file = path.join(cacheRoot, 'formats', 'canonical', `${kind}.json`);
+  if (!existsSync(file)) return null;
+  return JSON.parse(readFileSync(file, 'utf-8')) as CanonicalSchema;
+}
+
+function findCacheRoot(): string {
+  const candidates = [
+    path.join(__dirname, '..', '..', '..', '..', 'schemas', 'cache', '3.1.0-beta.0'),
+    path.join(__dirname, '..', '..', '..', '..', 'schemas', 'cache', 'latest'),
+  ];
+  for (const c of candidates) {
+    if (existsSync(c)) return c;
+  }
+  throw new Error(
+    `No 3.1+ schema cache found. Run \`npm run sync-schemas\` for a 3.1+ AdCP version. ` +
+      `Looked in: ${candidates.join(', ')}.`
+  );
+}
+
+/**
+ * Returns true when this canonical has a v1 named-format equivalent;
+ * false when v2-only. The 4 inherently-v2 canonicals at 3.1 GA are
+ * `image_carousel`, `sponsored_placement`, `responsive_creative`,
+ * `agent_placement`; everything else inherits `true` from
+ * `formats/canonical/_base.json`'s default.
+ *
+ * `custom` returns `true` (the per-declaration `canonical_formats_only`
+ * flag is the actual signal there — custom isn't a baked-in v1/v2
+ * classification).
+ */
+export function isCanonicalV1Translatable(kind: CanonicalFormatKind): boolean {
+  if (cache && cache.has(kind)) return cache.get(kind)!;
+
+  if (cache === null) cache = new Map();
+
+  if (kind === 'custom') {
+    cache.set(kind, true);
+    return true;
+  }
+
+  const cacheRoot = findCacheRoot();
+
+  if (baseDefault === null) {
+    const base = loadCanonicalSchema('_base' as CanonicalFormatKind, cacheRoot);
+    const bd = base?.properties?.v1_translatable?.default;
+    baseDefault = typeof bd === 'boolean' ? bd : true;
+  }
+
+  const schema = loadCanonicalSchema(kind, cacheRoot);
+  const override = schema?.properties?.v1_translatable?.default;
+  const value = typeof override === 'boolean' ? override : baseDefault;
+  cache.set(kind, value);
+  return value;
+}
+
+/** Test hook: reset the memoized canonical properties cache. */
+export function _resetCanonicalPropertiesCache(): void {
+  cache = null;
+  baseDefault = null;
+}

--- a/src/lib/v2/projection/catalog.ts
+++ b/src/lib/v2/projection/catalog.ts
@@ -1,0 +1,152 @@
+/**
+ * Loader for the AAO canonical-formats catalog (`reference-formats.json`).
+ * Source of truth: `server/src/creative-agent/reference-formats.json` in
+ * the adcontextprotocol/adcp repo — published by the AAO with the
+ * `canonical` annotation on entries that have a v2 canonical-format
+ * equivalent.
+ *
+ * The catalog is the v1→v2 direction's primary lookup table: each entry
+ * is a v1 format definition, and 32 of the 57 entries in 3.1-beta carry
+ * a `canonical: <kind>` annotation that names the v2 canonical the v1
+ * format projects to. This is the spec's resolution-order step 2 —
+ * "seller-asserted on the v1 file" — applied to AAO-published v1 formats.
+ *
+ * Loader is keyed by `agent_url` (with trailing-slash normalization) +
+ * `format_id.id`. Same scope as the v2→v1 registry: AAO catalog only.
+ * Seller-specific catalogs (from a publisher's
+ * `list_creative_formats`) are out of scope for the prototype — the
+ * full 8.0 enablement would fetch them via an `AgentClient` injected
+ * by the auto-negotiation surface.
+ */
+
+import { readFileSync, existsSync } from 'fs';
+import path from 'path';
+import type { CanonicalFormatKind, V1FormatId } from './types';
+
+/**
+ * v1 format definition shape from `reference-formats.json`. Only carries
+ * the fields the projection algorithm reads — name/description and the
+ * full asset/macro/requirement bodies are passed through opaquely when
+ * the caller wants them.
+ */
+export interface V1FormatDefinition {
+  format_id: V1FormatId;
+  name?: string;
+  description?: string;
+  type?: string;
+  accepts_parameters?: string[];
+  assets?: Array<{
+    item_type?: string;
+    asset_id?: string;
+    required?: boolean;
+    asset_type?: string;
+    requirements?: Record<string, unknown>;
+  }>;
+  /**
+   * v2 canonical kind this v1 format projects to. Present on 32 of the
+   * 57 AAO catalog entries at 3.1-beta GA. Absent entries fall through
+   * to the registry / structural-match steps of the resolution order.
+   */
+  canonical?: CanonicalFormatKind;
+  // Pass-through for caller code that wants the rest.
+  [k: string]: unknown;
+}
+
+interface CatalogIndex {
+  /** Keyed by `<normalized-agent-url>::<id>` for O(1) lookup. */
+  byKey: Map<string, V1FormatDefinition>;
+  entries: V1FormatDefinition[];
+}
+
+let cached: CatalogIndex | null = null;
+
+/**
+ * Normalize agent_url for indexing. Adds trailing slash when missing.
+ * The AAO publishes the canonical form as `https://creative.adcontextprotocol.org/`
+ * (with slash); some v2 fixtures use the no-slash form. Both refer to
+ * the same agent; this lookup folds them.
+ */
+function normalizeAgentUrl(u: string): string {
+  if (!u) return u;
+  return u.endsWith('/') ? u : u + '/';
+}
+
+function indexKey(agentUrl: string, id: string): string {
+  return `${normalizeAgentUrl(agentUrl)}::${id}`;
+}
+
+/**
+ * Load the catalog from a known path. Tries the test-fixture location
+ * (vendored copy) first, then the workspace `.context/adcp-3307/`
+ * checkout if present. Memoized — catalog is small and immutable per
+ * spec version.
+ *
+ * @param explicitPath caller-supplied path; takes precedence over
+ *                     fallback resolution.
+ */
+export function loadCatalog(explicitPath?: string): CatalogIndex {
+  if (cached) return cached;
+
+  const candidates = explicitPath
+    ? [explicitPath]
+    : [
+        path.join(
+          __dirname,
+          '..',
+          '..',
+          '..',
+          '..',
+          'test',
+          'lib',
+          'v2-projection-fixtures',
+          'aao-reference-formats.json'
+        ),
+        path.join(
+          __dirname,
+          '..',
+          '..',
+          '..',
+          '..',
+          '.context',
+          'adcp-3307',
+          'server',
+          'src',
+          'creative-agent',
+          'reference-formats.json'
+        ),
+      ];
+
+  for (const file of candidates) {
+    if (existsSync(file)) {
+      const raw = JSON.parse(readFileSync(file, 'utf-8')) as V1FormatDefinition[];
+      const byKey = new Map<string, V1FormatDefinition>();
+      for (const entry of raw) {
+        if (entry?.format_id?.agent_url && entry?.format_id?.id) {
+          byKey.set(indexKey(entry.format_id.agent_url, entry.format_id.id), entry);
+        }
+      }
+      cached = { byKey, entries: raw };
+      return cached;
+    }
+  }
+
+  throw new Error(
+    `AAO catalog (reference-formats.json) not found. Looked in: ${candidates.join(', ')}. ` +
+      `Vendor a copy at test/lib/v2-projection-fixtures/aao-reference-formats.json.`
+  );
+}
+
+/**
+ * Look up a v1 format definition by its format_id. Returns undefined
+ * when not in the catalog — caller falls through to registry / structural
+ * match per the resolution order.
+ */
+export function lookupV1Format(formatId: V1FormatId, explicitPath?: string): V1FormatDefinition | undefined {
+  const catalog = loadCatalog(explicitPath);
+  return catalog.byKey.get(indexKey(formatId.agent_url, formatId.id));
+}
+
+/** Test hook: reset the memoized catalog. */
+export function _resetCatalogCache(): void {
+  cached = null;
+}

--- a/src/lib/v2/projection/catalog.ts
+++ b/src/lib/v2/projection/catalog.ts
@@ -150,3 +150,64 @@ export function lookupV1Format(formatId: V1FormatId, explicitPath?: string): V1F
 export function _resetCatalogCache(): void {
   cached = null;
 }
+
+/**
+ * Find a catalog entry matching `(canonical, width, height)` at the same
+ * publisher domain as `agentUrl`. Used by the v2 → v1 multi-size fan-out:
+ * when a v2 declaration says `sizes: [W1×H1, W2×H2, ...]` and the
+ * seller-asserted `v1_format_ref` points at the catalog entry for one of
+ * those sizes, the SDK can look up the entries for the OTHER sizes and
+ * emit additional v1 format_ids — giving v1 buyers full size coverage
+ * instead of just the rep.
+ *
+ * The catalog uses a stable id-pattern convention
+ * (`<prefix>_<W>x<H>_<suffix>`) for per-size entries — image, html5, and
+ * generative all follow it. This function parses ids matching that
+ * pattern and matches on extracted dimensions, so the lookup is
+ * dimensionally honest without requiring the spec to add explicit
+ * width/height fields to catalog entries.
+ *
+ * Returns undefined when no matching entry exists at this publisher.
+ * Caller falls back to the seller-asserted rep + lossy advisory.
+ */
+const SIZED_ID_RE = /^([a-z]+)_(\d+)x(\d+)_([a-z]+)$/;
+
+/**
+ * Extract the `<prefix>_<W>x<H>_<suffix>` template from a sized catalog
+ * id. Used by `findCatalogEntryByCanonicalAndSize` to filter fan-out
+ * candidates to siblings of the seller-asserted ref. Multiple catalog
+ * entries can share the same `canonical:` annotation but represent
+ * different families (e.g., `image` is both `display_*_image` and
+ * `display_*_generative`); without a suffix filter, fan-out would
+ * collide families.
+ */
+export function parseSizedIdTemplate(id: string): { prefix: string; suffix: string } | undefined {
+  const m = id.match(SIZED_ID_RE);
+  if (!m) return undefined;
+  return { prefix: m[1]!, suffix: m[4]! };
+}
+
+export function findCatalogEntryByCanonicalAndSize(
+  canonical: CanonicalFormatKind,
+  width: number,
+  height: number,
+  agentUrl: string,
+  options?: { prefix?: string; suffix?: string; explicitPath?: string }
+): V1FormatDefinition | undefined {
+  const catalog = loadCatalog(options?.explicitPath);
+  const normalizedAgentUrl = normalizeAgentUrl(agentUrl);
+  for (const entry of catalog.entries) {
+    if (entry.canonical !== canonical) continue;
+    if (!entry.format_id?.id || !entry.format_id?.agent_url) continue;
+    if (normalizeAgentUrl(entry.format_id.agent_url) !== normalizedAgentUrl) continue;
+    const m = entry.format_id.id.match(SIZED_ID_RE);
+    if (!m) continue;
+    const [, prefix, wStr, hStr, suffix] = m;
+    if (options?.prefix && prefix !== options.prefix) continue;
+    if (options?.suffix && suffix !== options.suffix) continue;
+    if (parseInt(wStr!, 10) === width && parseInt(hStr!, 10) === height) {
+      return entry;
+    }
+  }
+  return undefined;
+}

--- a/src/lib/v2/projection/registry.ts
+++ b/src/lib/v2/projection/registry.ts
@@ -110,6 +110,96 @@ export function _resetRegistryCache(): void {
 }
 
 /**
+ * Forward registry lookup (v1 → v2). Given a v1 `format_id.id`, find
+ * the registry entry whose `format_id_glob` matches and return the
+ * canonical + parameters. Used by `projectV1ProductToV2` resolution
+ * step 2.
+ *
+ * Glob `*` matches any non-`/` segment (the same minimal-glob shape
+ * the v2→v1 prototype's matcher used). Returns the first matching
+ * entry — registry order is authoritative per the spec ("Ordered list
+ * of v1 → v2 mappings. SDKs apply mappings in order and use the first
+ * match.").
+ */
+export interface ForwardGlobMatch {
+  canonical: CanonicalFormatKind;
+  parameters: Record<string, unknown>;
+  notes?: string;
+}
+
+export function forwardLookupByGlob(formatIdId: string): ForwardGlobMatch | undefined {
+  const registry = loadRegistry();
+  for (const m of registry.mappings) {
+    if (m.deprecated) continue;
+    const glob = m.v1_pattern.format_id_glob;
+    if (!glob) continue;
+    if (globMatches(glob, formatIdId)) {
+      return {
+        canonical: m.v2.canonical as CanonicalFormatKind,
+        parameters: (m.v2.parameters ?? {}) as Record<string, unknown>,
+        notes: m.notes,
+      };
+    }
+  }
+  return undefined;
+}
+
+function globMatches(glob: string, value: string): boolean {
+  // Anchor both ends; '*' matches one or more non-`/` chars.
+  const re = new RegExp('^' + glob.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '[^/]+') + '$');
+  return re.test(value);
+}
+
+/**
+ * Forward structural lookup (v1 → v2). Given a v1 format definition's
+ * declared assets + version constraints, find the first registry
+ * entry whose `structural` pattern matches. Used by
+ * `projectV1ProductToV2` resolution step 3 — the fallback when no
+ * explicit `canonical` annotation and no glob match are available.
+ */
+export interface ForwardStructuralInput {
+  asset_types?: string[];
+  vast_versions?: string[];
+  daast_versions?: string[];
+}
+
+export function forwardLookupByStructural(input: ForwardStructuralInput): ForwardGlobMatch | undefined {
+  const registry = loadRegistry();
+  for (const m of registry.mappings) {
+    if (m.deprecated) continue;
+    const struct = m.v1_pattern.structural;
+    if (!struct) continue;
+    if (struct.asset_types && input.asset_types) {
+      const required = new Set(struct.asset_types);
+      const have = new Set(input.asset_types);
+      let allPresent = true;
+      for (const t of required) {
+        if (!have.has(t)) {
+          allPresent = false;
+          break;
+        }
+      }
+      if (!allPresent) continue;
+    }
+    // Loose-match VAST / DAAST version arrays: any overlap.
+    if (struct.vast_versions && input.vast_versions) {
+      const overlap = input.vast_versions.some(v => struct.vast_versions!.includes(v));
+      if (!overlap) continue;
+    }
+    if (struct.daast_versions && input.daast_versions) {
+      const overlap = input.daast_versions.some(v => struct.daast_versions!.includes(v));
+      if (!overlap) continue;
+    }
+    return {
+      canonical: m.v2.canonical as CanonicalFormatKind,
+      parameters: (m.v2.parameters ?? {}) as Record<string, unknown>,
+      notes: m.notes,
+    };
+  }
+  return undefined;
+}
+
+/**
  * Reverse-lookup outcome. Three buckets the projection algorithm acts on:
  *
  *   - `match`: registry has an invertible entry (literal `format_id_glob`

--- a/src/lib/v2/projection/registry.ts
+++ b/src/lib/v2/projection/registry.ts
@@ -180,10 +180,15 @@ export function reverseLookup(canonical: CanonicalFormatKind, params: Record<str
   };
 }
 
-/** Synthesize a v1 format_id from a literal glob and the registry's recorded params. */
+/**
+ * Synthesize a v1 format_id from a literal glob and the registry's recorded params.
+ * Uses the AAO canonical agent_url base form with trailing slash, matching the
+ * seller-asserted fixtures in the spec's reference set
+ * (`creative.adcontextprotocol.org/`).
+ */
 function synthesizeFormatIdFromGlob(glob: string, registryParams: Record<string, unknown>): V1FormatId {
   const out: V1FormatId = {
-    agent_url: 'https://creative.adcontextprotocol.org',
+    agent_url: 'https://creative.adcontextprotocol.org/',
     id: glob,
   };
   if (typeof registryParams.width === 'number') out.width = registryParams.width;

--- a/src/lib/v2/projection/registry.ts
+++ b/src/lib/v2/projection/registry.ts
@@ -1,0 +1,221 @@
+/**
+ * Loader + reverse-lookup for the v1↔v2 canonical-format registry
+ * (`schemas/cache/<version>/registries/v1-canonical-mapping.json`).
+ *
+ * The spec authors the registry **forward** — given a v1 named format,
+ * find the v2 canonical. v2 → v1 projection needs the inverse direction,
+ * which the registry doesn't directly support: there's no guarantee that
+ * a given canonical shape has a v1 named-format with that exact
+ * narrowing, and most don't.
+ *
+ * This module implements a best-effort reverse-lookup:
+ *
+ *   1. For `format_id_glob` registry entries with no `*`, the v1 `id` is
+ *      a literal — those are *invertible* (canonical + params → exact id).
+ *   2. Globbed entries and `structural` entries are NOT invertible to a
+ *      specific v1 id — they describe families of v1 formats, not single
+ *      ones. The projection layer treats them as evidence that "some" v1
+ *      named format exists for this canonical, but can't pick one without
+ *      additional information (e.g. the seller's `v1_format_ref`).
+ *
+ * Surfaces all three outcomes through the projection's diagnostic
+ * channel so adopters see the difference between
+ * "no v1 mapping exists" and "ambiguous v1 mapping exists."
+ */
+
+import { readFileSync, existsSync } from 'fs';
+import path from 'path';
+import type { CanonicalFormatKind, V1FormatId } from './types';
+
+interface RegistryEntryV1Pattern {
+  format_id_glob?: string;
+  structural?: {
+    asset_types?: string[];
+    vast_versions?: string[];
+    daast_versions?: string[];
+    dimensions?: { width?: number; height?: number };
+  };
+}
+
+interface RegistryEntry {
+  v1_pattern: RegistryEntryV1Pattern;
+  v2: {
+    canonical: string;
+    parameters?: Record<string, unknown>;
+  };
+  deprecated?: boolean;
+  notes?: string;
+}
+
+interface CanonicalMappingRegistry {
+  version: string;
+  last_updated: string;
+  mappings: RegistryEntry[];
+}
+
+let cached: CanonicalMappingRegistry | null = null;
+
+/**
+ * Load the registry from a known schema-cache version. Defaults to the
+ * 3.1.0-beta.0 cache when present; falls back to the latest stable cache
+ * directory that ships a registry (`registries/v1-canonical-mapping.json`).
+ *
+ * Memoized — the registry is small and immutable per version.
+ */
+export function loadRegistry(cacheRoot?: string): CanonicalMappingRegistry {
+  if (cached) return cached;
+  const candidates = cacheRoot
+    ? [path.join(cacheRoot, 'registries', 'v1-canonical-mapping.json')]
+    : [
+        path.join(
+          __dirname,
+          '..',
+          '..',
+          '..',
+          '..',
+          'schemas',
+          'cache',
+          '3.1.0-beta.0',
+          'registries',
+          'v1-canonical-mapping.json'
+        ),
+        path.join(
+          __dirname,
+          '..',
+          '..',
+          '..',
+          '..',
+          'schemas',
+          'cache',
+          'latest',
+          'registries',
+          'v1-canonical-mapping.json'
+        ),
+      ];
+  for (const file of candidates) {
+    if (existsSync(file)) {
+      cached = JSON.parse(readFileSync(file, 'utf-8')) as CanonicalMappingRegistry;
+      return cached;
+    }
+  }
+  throw new Error(
+    `v1-canonical-mapping.json not found. Looked in: ${candidates.join(', ')}. ` +
+      `Run \`npm run sync-schemas\` for a 3.1+ AdCP version.`
+  );
+}
+
+/** Test hook: reset the memoized registry. */
+export function _resetRegistryCache(): void {
+  cached = null;
+}
+
+/**
+ * Reverse-lookup outcome. Three buckets the projection algorithm acts on:
+ *
+ *   - `match`: registry has an invertible entry (literal `format_id_glob`
+ *     with no `*`). Synthesize a v1 `format_id` and emit it.
+ *   - `ambiguous`: registry has entries for this canonical, but none are
+ *     invertible (all globs are wildcarded or structural). Caller knows
+ *     "some v1 mapping exists" but can't pick one.
+ *   - `none`: registry has no entries for this canonical. No v1 emit
+ *     possible without an explicit `v1_format_ref`.
+ */
+export type ReverseLookupResult =
+  | { kind: 'match'; v1: V1FormatId; viaRegistryNote?: string }
+  | { kind: 'ambiguous'; matchedEntries: number; hint: string }
+  | { kind: 'none' };
+
+/**
+ * Attempt to reverse-lookup a v2 declaration against the registry.
+ *
+ * `canonical` is the format_kind. `params` is the declaration's narrowed
+ * parameters — used to disambiguate when the registry's IAB-named entries
+ * carry exact dimensions.
+ *
+ * Returns the highest-confidence match. Picks an invertible entry when
+ * dimensions / VAST versions / DAAST versions match exactly; otherwise
+ * falls back to `ambiguous` when entries exist but none invert cleanly.
+ *
+ * Caveat surfaced by this projection in practice (recorded in the
+ * findings): the spec's IAB-named globs use slashes (`iab/mrec_300x250`),
+ * which the wire-level `format-id.json` pattern (`^[a-zA-Z0-9_-]+$`)
+ * rejects. So even when a match exists, the synthesized id is NOT
+ * wire-valid until upstream resolves that mismatch
+ * (adcontextprotocol/adcp — flagged via the issue we filed earlier).
+ * The reverse lookup still produces it because the projection layer's
+ * job is to surface what the registry says — and surfacing the
+ * inconsistency is more valuable than papering over it.
+ */
+export function reverseLookup(canonical: CanonicalFormatKind, params: Record<string, unknown>): ReverseLookupResult {
+  const registry = loadRegistry();
+  const matches = registry.mappings.filter(m => m.v2.canonical === canonical && !m.deprecated);
+  if (matches.length === 0) return { kind: 'none' };
+
+  // Invertible: literal format_id_glob with no `*`, and its parameters
+  // narrow this declaration's params. For image canonicals the
+  // dimensions are the disambiguator — match width/height exactly.
+  for (const m of matches) {
+    const glob = m.v1_pattern.format_id_glob;
+    if (!glob || glob.includes('*')) continue;
+    const regParams = (m.v2.parameters ?? {}) as Record<string, unknown>;
+    if (!narrowsCompatibly(regParams, params)) continue;
+    return {
+      kind: 'match',
+      v1: synthesizeFormatIdFromGlob(glob, regParams),
+      viaRegistryNote: m.notes,
+    };
+  }
+
+  // No invertible entry — but there ARE entries for this canonical
+  // (structural matches or wildcarded globs). Caller surfaces this as
+  // ambiguous: a v1 mapping exists in the family but can't be picked
+  // mechanically.
+  return {
+    kind: 'ambiguous',
+    matchedEntries: matches.length,
+    hint:
+      `Registry has ${matches.length} entry/entries matching canonical "${canonical}" but none are ` +
+      `invertible (globs are wildcarded or structural). Add v1_format_ref to the declaration to ` +
+      `make the projection deterministic.`,
+  };
+}
+
+/** Synthesize a v1 format_id from a literal glob and the registry's recorded params. */
+function synthesizeFormatIdFromGlob(glob: string, registryParams: Record<string, unknown>): V1FormatId {
+  const out: V1FormatId = {
+    agent_url: 'https://creative.adcontextprotocol.org',
+    id: glob,
+  };
+  if (typeof registryParams.width === 'number') out.width = registryParams.width;
+  if (typeof registryParams.height === 'number') out.height = registryParams.height;
+  if (typeof registryParams.duration_ms === 'number') {
+    out.duration_ms = registryParams.duration_ms;
+  }
+  return out;
+}
+
+/**
+ * Conservative check: does the v2 declaration's params narrow the registry
+ * entry's params? Concretely: every key the registry entry pins must
+ * appear in the declaration with an equal value. Extra keys in the
+ * declaration are fine (it's narrowing, not equality).
+ */
+function narrowsCompatibly(registryParams: Record<string, unknown>, declParams: Record<string, unknown>): boolean {
+  for (const [k, expected] of Object.entries(registryParams)) {
+    const actual = declParams[k];
+    if (actual === undefined) return false;
+    if (typeof expected !== typeof actual) return false;
+    if (expected !== actual) {
+      // Loose array compare for vast_versions etc.
+      if (Array.isArray(expected) && Array.isArray(actual)) {
+        if (expected.length !== actual.length) return false;
+        for (let i = 0; i < expected.length; i++) {
+          if (expected[i] !== actual[i]) return false;
+        }
+        continue;
+      }
+      return false;
+    }
+  }
+  return true;
+}

--- a/src/lib/v2/projection/types.ts
+++ b/src/lib/v2/projection/types.ts
@@ -1,0 +1,114 @@
+/**
+ * Hand-rolled type surface for the v2 → v1 projection prototype.
+ *
+ * These shadow `schemas/cache/3.1.0-beta.0/core/{product,product-format-declaration,format-id}.json`
+ * at the precision the projection layer cares about — slot-level fields
+ * like `slots[]`, `platform_extensions[]`, and per-canonical params blocks
+ * are kept loose (`Record<string, unknown>`) because the projection
+ * algorithm doesn't read them. When the SDK's full versioned codegen
+ * lands (separate piece of 8.0), these get replaced by generated types.
+ *
+ * Not exported from the SDK barrel — projection callers consume the
+ * normalized shape via `projectV2ProductToV1`'s return type.
+ */
+
+/** v1 format_id (`{ agent_url, id }`). Same shape in 3.0 and 3.1. */
+export interface V1FormatId {
+  agent_url: string;
+  id: string;
+  width?: number;
+  height?: number;
+  duration_ms?: number;
+}
+
+/**
+ * 12 canonical `format_kind` values from
+ * `static/schemas/source/formats/canonical/` plus the `custom` escape
+ * hatch. Kept as a literal union so a future canonical gets surfaced at
+ * the projection's switch statement (exhaustive-check).
+ */
+export type CanonicalFormatKind =
+  | 'image'
+  | 'html5'
+  | 'display_tag'
+  | 'image_carousel'
+  | 'video_hosted'
+  | 'video_vast'
+  | 'audio_hosted'
+  | 'audio_daast'
+  | 'sponsored_placement'
+  | 'responsive_creative'
+  | 'agent_placement'
+  | 'custom';
+
+/**
+ * v2 `ProductFormatDeclaration`. The `params` object is canonical-specific
+ * and stays loose at this layer — the projection algorithm reads only
+ * `format_kind`, `v1_format_ref`, and `canonical_formats_only`. Width /
+ * height (for image canonicals) are surfaced as optional top-level fields
+ * the registry reverse-lookup can read without unwrapping params.
+ */
+export interface V2ProductFormatDeclaration {
+  format_kind: CanonicalFormatKind;
+  params: Record<string, unknown>;
+  capability_id?: string;
+  display_name?: string;
+  applies_to_channels?: string[];
+  canonical_formats_only?: boolean;
+  experimental?: boolean;
+  format_shape?: string;
+  v1_format_ref?: V1FormatId;
+  format_schema?: { uri: string; digest: string };
+}
+
+/**
+ * Public-surface Product (V2-shaped per the 8.0 design at
+ * `docs/development/v3.1-sdk-design.md`). All other fields are passthrough.
+ */
+export interface V2Product {
+  product_id: string;
+  name: string;
+  description: string;
+  format_options: V2ProductFormatDeclaration[];
+  [k: string]: unknown;
+}
+
+/**
+ * Wire-level v1 Product. Carries `format_ids` (the v1 path). Other fields
+ * are passthrough; we don't model them at the projection layer.
+ */
+export interface V1Product {
+  product_id: string;
+  name: string;
+  description: string;
+  format_ids: V1FormatId[];
+  [k: string]: unknown;
+}
+
+/**
+ * Structured channel for projection failures and lossy downgrades, per
+ * `v1-canonical-mapping.json`'s resolution-order amendment. **Never
+ * logger-only** — emitted on the response envelope's `errors[]` and on
+ * the SDK's `TaskResult` so callers can react.
+ */
+export type ProjectionDiagnostic =
+  | {
+      code: 'FORMAT_DECLARATION_V1_UNREACHABLE';
+      field: string;
+      details: {
+        format_kind: CanonicalFormatKind;
+        capability_id?: string;
+        reason: 'canonical_formats_only' | 'no_v1_format_ref_or_registry_match';
+        hint?: string;
+      };
+    }
+  | {
+      code: 'FORMAT_DECLARATION_V1_AMBIGUOUS';
+      field: string;
+      details: {
+        format_kind: CanonicalFormatKind;
+        capability_id?: string;
+        matched_registry_entries: number;
+        hint?: string;
+      };
+    };

--- a/src/lib/v2/projection/types.ts
+++ b/src/lib/v2/projection/types.ts
@@ -86,29 +86,99 @@ export interface V1Product {
 }
 
 /**
- * Structured channel for projection failures and lossy downgrades, per
- * `v1-canonical-mapping.json`'s resolution-order amendment. **Never
- * logger-only** — emitted on the response envelope's `errors[]` and on
- * the SDK's `TaskResult` so callers can react.
+ * Structured diagnostic shape matching the spec's `errors[]` augmentation
+ * contract (`source: "sdk"`, `sdk_id`, `code`, `field`, `error.details`).
+ * Spec codes — `FORMAT_PROJECTION_FAILED` and `FORMAT_DECLARATION_V1_AMBIGUOUS`
+ * — come straight from `enums/error-code.json`. The two SDK-local codes
+ * (`*_NOT_APPLICABLE`, `CANONICAL_NOT_V1_TRANSLATABLE`) cover cases the
+ * spec leaves to SDK discretion ("surface as a different diagnostic or
+ * skip silently") but where buyer-side transparency is more useful
+ * than silent product drops.
+ *
+ * **Never logger-only**, per the resolution-order amendment — emitted
+ * on the response envelope's `errors[]` array and surfaced on the
+ * SDK's `TaskResult` for caller-side handling without re-walking
+ * `errors[]`.
  */
+export interface ProjectionDiagnosticBase {
+  /** Spec-mandated origin marker for SDK-augmented diagnostics. */
+  source: 'sdk';
+  /** Spec-mandated SDK identity for multi-hop deduplication. */
+  sdk_id: string;
+  /** Field path into the offending declaration. */
+  field: string;
+}
+
 export type ProjectionDiagnostic =
-  | {
-      code: 'FORMAT_DECLARATION_V1_UNREACHABLE';
-      field: string;
-      details: {
-        format_kind: CanonicalFormatKind;
-        capability_id?: string;
-        reason: 'canonical_formats_only' | 'no_v1_format_ref_or_registry_match';
-        hint?: string;
+  | (ProjectionDiagnosticBase & {
+      /**
+       * Spec code (`enums/error-code.json`): registry-coverage gap.
+       * v1_translatable: true canonical that the registry hasn't covered.
+       * Correctable by adding a registry entry (or by the seller authoring
+       * an explicit `canonical` field on the v1 file).
+       */
+      code: 'FORMAT_PROJECTION_FAILED';
+      error: {
+        details: {
+          format_kind: CanonicalFormatKind;
+          product_id: string;
+          capability_id?: string;
+          resolution_failure: 'no_registry_match';
+        };
       };
-    }
-  | {
+    })
+  | (ProjectionDiagnosticBase & {
+      /**
+       * Spec code (`enums/error-code.json`): registry has family-level
+       * structural entries for this canonical (e.g., the VAST entries
+       * for `video_vast`), but none are invertible to a specific v1
+       * named format. Family is known, specific format isn't pickable.
+       * Correctable by the seller adding `v1_format_ref` to the
+       * declaration.
+       */
       code: 'FORMAT_DECLARATION_V1_AMBIGUOUS';
-      field: string;
-      details: {
-        format_kind: CanonicalFormatKind;
-        capability_id?: string;
-        matched_registry_entries: number;
-        hint?: string;
+      error: {
+        details: {
+          format_kind: CanonicalFormatKind;
+          product_id: string;
+          capability_id?: string;
+          registry_matches: number;
+        };
       };
-    };
+    })
+  | (ProjectionDiagnosticBase & {
+      /**
+       * SDK-local code: declaration has `canonical_formats_only: true`.
+       * Seller explicitly opted out of v1 emission. Not a registry-
+       * coverage gap; not ambiguous. Informational so buyers can see
+       * why a product disappeared from a v1-only catalog.
+       */
+      code: 'FORMAT_DECLARATION_V1_NOT_APPLICABLE';
+      error: {
+        details: {
+          format_kind: CanonicalFormatKind;
+          product_id: string;
+          capability_id?: string;
+          reason: 'canonical_formats_only';
+        };
+      };
+    })
+  | (ProjectionDiagnosticBase & {
+      /**
+       * SDK-local code: canonical declares `v1_translatable: false`.
+       * Structural v1-unreachability — no v1 form is possible for this
+       * canonical regardless of registry coverage. The 4 inherently-v2
+       * canonicals at 3.1 GA: `image_carousel`, `sponsored_placement`,
+       * `responsive_creative`, `agent_placement`. Spec is explicit:
+       * **SDKs MUST NOT emit `FORMAT_PROJECTION_FAILED`** for these
+       * (they're not coverage gaps).
+       */
+      code: 'CANONICAL_NOT_V1_TRANSLATABLE';
+      error: {
+        details: {
+          format_kind: CanonicalFormatKind;
+          product_id: string;
+          capability_id?: string;
+        };
+      };
+    });

--- a/src/lib/v2/projection/types.ts
+++ b/src/lib/v2/projection/types.ts
@@ -222,6 +222,14 @@ export type ProjectionDiagnostic =
           capability_id?: string;
           size_mode: 'sizes' | 'responsive_range';
           declared_sizes_count?: number;
+          /**
+           * How many v1 format_ids the SDK actually emitted. <
+           * `declared_sizes_count` when the catalog doesn't cover every
+           * declared size; equal when the catalog has full coverage.
+           * The fan-out is non-normative — when this equals 1, only the
+           * seller-asserted rep was emitted; v1 buyers lose the rest.
+           */
+          emitted_sizes_count?: number;
           v1_emit_represents_size?: { width?: number; height?: number };
         };
       };

--- a/src/lib/v2/projection/types.ts
+++ b/src/lib/v2/projection/types.ts
@@ -112,10 +112,22 @@ export interface ProjectionDiagnosticBase {
 export type ProjectionDiagnostic =
   | (ProjectionDiagnosticBase & {
       /**
-       * Spec code (`enums/error-code.json`): registry-coverage gap.
-       * v1_translatable: true canonical that the registry hasn't covered.
-       * Correctable by adding a registry entry (or by the seller authoring
-       * an explicit `canonical` field on the v1 file).
+       * Spec code (`enums/error-code.json`): registry-coverage gap or
+       * v1-catalog-coverage gap depending on `resolution_failure`:
+       *
+       *   - `no_registry_match` — v2→v1 direction. Registry has no
+       *     entries for this canonical (and v1_translatable is true).
+       *   - `catalog_lacks_canonical_annotation` — v1→v2 direction.
+       *     The AAO catalog has this v1 format but hasn't annotated
+       *     it with a `canonical:` field. Native, DOOH, broadcast,
+       *     and card-scaffolding categories sit in this bucket at
+       *     3.1 GA. Distinct from a generic registry gap — the
+       *     catalog DOES know the format, it just hasn't blessed a
+       *     v2 canonical mapping yet. Symmetric counterpart to
+       *     CANONICAL_NOT_V1_TRANSLATABLE: that signals "no v1 form
+       *     possible"; this signals "no v2 form yet."
+       *   - `no_match` — v1→v2 direction, format not in catalog or
+       *     registry, no structural match.
        */
       code: 'FORMAT_PROJECTION_FAILED';
       error: {
@@ -123,7 +135,7 @@ export type ProjectionDiagnostic =
           format_kind: CanonicalFormatKind;
           product_id: string;
           capability_id?: string;
-          resolution_failure: 'no_registry_match';
+          resolution_failure: 'no_registry_match' | 'catalog_lacks_canonical_annotation' | 'no_match';
         };
       };
     })

--- a/src/lib/v2/projection/types.ts
+++ b/src/lib/v2/projection/types.ts
@@ -193,4 +193,36 @@ export type ProjectionDiagnostic =
           capability_id?: string;
         };
       };
+    })
+  | (ProjectionDiagnosticBase & {
+      /**
+       * SDK-local code: v2 declaration uses multi-size (`sizes: [...]`)
+       * or responsive (`min_width`/`max_width`/`min_height`/`max_height`)
+       * params, but `v1_format_ref` is a single catalog entry that can
+       * only carry ONE fixed (width, height). The v1 wire emit
+       * represents only the seller-chosen representative size; the
+       * remaining sizes are **silently dropped on the v1 wire**.
+       *
+       * This diagnostic is emitted **alongside** the v1 format_id —
+       * not instead of it — so the v1 buyer still sees the product
+       * but the buyer code is told what coverage was lost. Different
+       * from FORMAT_DECLARATION_V1_AMBIGUOUS (no v1 emit) and
+       * FORMAT_DECLARATION_V1_NOT_APPLICABLE (seller opt-out).
+       *
+       * Surface follow-up: an SDK MAY (non-normative) expand multi-
+       * size to N v1 format_ids by looking up the catalog for each
+       * size. Today's prototype emits only the seller-asserted
+       * representative; multi-emit is a follow-up.
+       */
+      code: 'FORMAT_DECLARATION_V1_LOSSY_MULTI_SIZE';
+      error: {
+        details: {
+          format_kind: CanonicalFormatKind;
+          product_id: string;
+          capability_id?: string;
+          size_mode: 'sizes' | 'responsive_range';
+          declared_sizes_count?: number;
+          v1_emit_represents_size?: { width?: number; height?: number };
+        };
+      };
     });

--- a/src/lib/v2/projection/v1-to-v2.ts
+++ b/src/lib/v2/projection/v1-to-v2.ts
@@ -1,0 +1,217 @@
+/**
+ * v1 → v2 Product projection (the upgrade direction).
+ *
+ * Used when the SDK is talking to a v1 seller but the buyer wrote V2
+ * code. The 8.0 design at `docs/development/v3.1-sdk-design.md` makes
+ * V2 the public mental model — the buyer never sees `Product.format_ids`
+ * directly, only `Product.format_options`. This module is the wire-
+ * boundary translator that makes that promise hold for v1 sellers.
+ *
+ * Resolution order per format_id, mirroring `v1-canonical-mapping.json`
+ * step 1-4 in the forward direction:
+ *
+ *   1. **v1 catalog explicit `canonical` annotation**. If the v1 format
+ *      definition (from `reference-formats.json` or a seller's
+ *      `list_creative_formats`) carries `canonical: <kind>`, that's the
+ *      authoritative pairing. Seller-asserted, normative.
+ *   2. **Registry glob match**. Look up `format_id.id` against the
+ *      registry's `format_id_glob` entries (including wildcards). First
+ *      match wins per the spec's ordering.
+ *   3. **Structural match**. Match against the v1 format's declared
+ *      assets + version constraints. Family-level identification
+ *      yields a canonical (e.g., "vast 4.x → video_vast"). Less
+ *      precise on params; caller may need to fetch additional context.
+ *   4. **Fail closed** → `FORMAT_PROJECTION_FAILED`. v1 product with
+ *      no catalog entry, no registry coverage, and no structural match
+ *      is invisible on the v2 side. SDK surfaces the diagnostic so
+ *      buyers know what got dropped.
+ *
+ * **Asymmetry vs the v2 → v1 direction**: every v1 format_id is a
+ * specific thing, so there's no "ambiguous family" bucket here — if
+ * the structural match identifies a family, the projection is
+ * deterministic for that single format_id.
+ *
+ * **Scope (prototype)**:
+ *   - AAO catalog only — seller-specific catalogs (publisher's own
+ *     `list_creative_formats`) require an AgentClient hook the auto-
+ *     negotiation surface will provide in the full 8.0 enablement.
+ *   - Param extraction is dimensions-only (`width`, `height`,
+ *     `duration_ms`). Full canonical-specific params (slots, codecs,
+ *     char limits, platform_extensions) are not constructed. A v2
+ *     buyer reading the projected declaration's `params` sees the
+ *     minimum needed to identify the variant.
+ *   - Asset slot translation (v1 `assets[]` → v2 `slots[]` via the
+ *     asset_group_vocabulary aliases) is deliberately deferred. This
+ *     is the most adopter-relevant piece for actual creative
+ *     submission flows and lands in a follow-up.
+ */
+
+import type { V1Product, V1FormatId, V2Product, V2ProductFormatDeclaration, ProjectionDiagnostic } from './types';
+import { forwardLookupByGlob, forwardLookupByStructural } from './registry';
+import { lookupV1Format, type V1FormatDefinition } from './catalog';
+import { LIBRARY_VERSION } from '../../version';
+
+const SDK_ID = `@adcp/sdk@${LIBRARY_VERSION}`;
+
+export interface V1ToV2Result {
+  v2: V2Product;
+  diagnostics: ProjectionDiagnostic[];
+}
+
+/**
+ * Build the v2 declaration's `params` block from the v1 format_id's
+ * dimensional overrides + the catalog/registry entry's recorded params.
+ *
+ * Prototype scope: dimensions + duration only. A full implementation
+ * would walk the canonical's parameter schema and populate every field
+ * the catalog entry hints at (codecs, char limits, platform_extensions).
+ */
+function buildParams(
+  fid: V1FormatId,
+  registryParams: Record<string, unknown>,
+  catalogEntry?: V1FormatDefinition
+): Record<string, unknown> {
+  const params: Record<string, unknown> = { ...registryParams };
+  if (typeof fid.width === 'number') params.width = fid.width;
+  if (typeof fid.height === 'number') params.height = fid.height;
+  if (typeof fid.duration_ms === 'number') params.duration_ms_exact = fid.duration_ms;
+  // Catalog entries occasionally pin codec/format requirements at the
+  // asset level. Surface them when present and unambiguous, but don't
+  // try to compose the full v2 param shape — that's caller territory.
+  if (catalogEntry?.accepts_parameters) {
+    params.accepts_parameters = catalogEntry.accepts_parameters;
+  }
+  return params;
+}
+
+/**
+ * Project a single v1 `format_id` to a v2 `ProductFormatDeclaration`,
+ * or to a diagnostic when no projection is possible.
+ */
+function projectFormatId(
+  fid: V1FormatId,
+  productId: string,
+  field: string
+): { decl?: V2ProductFormatDeclaration; diagnostic?: ProjectionDiagnostic } {
+  const catalogEntry = lookupV1Format(fid);
+
+  // Step 1: v1 catalog has an explicit `canonical` annotation. Seller-
+  // asserted, normative.
+  if (catalogEntry?.canonical) {
+    return {
+      decl: {
+        format_kind: catalogEntry.canonical,
+        params: buildParams(fid, {}, catalogEntry),
+        v1_format_ref: fid,
+      },
+    };
+  }
+
+  // Step 1b: catalog HAS the entry but no `canonical:` annotation. This
+  // is the AAO saying "no v2 mapping yet for this category" — at 3.1
+  // GA, native/DOOH/broadcast/card-scaffolding sit in this bucket.
+  // Falling through to structural match would shoehorn the format to
+  // a coarse `display_tag` based on a `url` asset (or similar) — which
+  // contradicts the AAO's deliberate absence of annotation. Fail-closed
+  // honestly so the buyer sees "category not yet v2-mapped" rather than
+  // a semantically wrong projection. Symmetric counterpart to
+  // CANONICAL_NOT_V1_TRANSLATABLE on the v2→v1 side.
+  if (catalogEntry && !catalogEntry.canonical) {
+    return {
+      diagnostic: {
+        source: 'sdk',
+        sdk_id: SDK_ID,
+        field,
+        code: 'FORMAT_PROJECTION_FAILED',
+        error: {
+          details: {
+            format_kind: 'custom',
+            product_id: productId,
+            resolution_failure: 'catalog_lacks_canonical_annotation',
+          },
+        },
+      },
+    };
+  }
+
+  // Step 2: format not in the AAO catalog. Try registry glob match
+  // against format_id.id. Catches publisher-bespoke ids that share the
+  // AAO catalog's naming convention.
+  const globMatch = forwardLookupByGlob(fid.id);
+  if (globMatch) {
+    return {
+      decl: {
+        format_kind: globMatch.canonical,
+        params: buildParams(fid, globMatch.parameters),
+        v1_format_ref: fid,
+      },
+    };
+  }
+
+  // Step 3: structural match — only fires when the format is NOT in the
+  // catalog (Step 1b ate the catalog-known-but-unannotated case). For
+  // truly bespoke publisher formats this is the best signal we have:
+  // a VAST tag is a VAST tag regardless of seller naming.
+  if (catalogEntry?.assets) {
+    const assetTypes = catalogEntry.assets.map(a => a.asset_type).filter((t): t is string => typeof t === 'string');
+    const structMatch = forwardLookupByStructural({ asset_types: assetTypes });
+    if (structMatch) {
+      return {
+        decl: {
+          format_kind: structMatch.canonical,
+          params: buildParams(fid, structMatch.parameters, catalogEntry),
+          v1_format_ref: fid,
+        },
+      };
+    }
+  }
+
+  // Step 4: fail-closed. v1 product is invisible on the v2 side.
+  return {
+    diagnostic: {
+      source: 'sdk',
+      sdk_id: SDK_ID,
+      field,
+      code: 'FORMAT_PROJECTION_FAILED',
+      error: {
+        details: {
+          format_kind: 'custom',
+          product_id: productId,
+          resolution_failure: 'no_match',
+        },
+      },
+    },
+  };
+}
+
+/**
+ * Project a v1 Product to a v2 Product. Drops `format_ids` from the
+ * public output and rebuilds `format_options` per the resolution order.
+ *
+ * Caller decides what to do with the result when `format_options` is
+ * empty — typically filter the product out of the response payload to
+ * a v2-only buyer (the spec requires `format_options` to have
+ * `minItems: 1` when present). The function always returns a Product
+ * shape so adopters can inspect what got dropped via diagnostics.
+ */
+export function projectV1ProductToV2(v1: V1Product): V1ToV2Result {
+  const format_options: V2ProductFormatDeclaration[] = [];
+  const diagnostics: ProjectionDiagnostic[] = [];
+
+  for (let i = 0; i < v1.format_ids.length; i++) {
+    const fid = v1.format_ids[i]!;
+    const field = `products[${v1.product_id}].format_ids[${i}]`;
+    const { decl, diagnostic } = projectFormatId(fid, v1.product_id, field);
+    if (decl) format_options.push(decl);
+    if (diagnostic) diagnostics.push(diagnostic);
+  }
+
+  const { format_ids: _drop, ...rest } = v1;
+  void _drop;
+  const v2Product: V2Product = {
+    ...(rest as Omit<V1Product, 'format_ids'>),
+    format_options,
+  } as V2Product;
+
+  return { v2: v2Product, diagnostics };
+}

--- a/src/lib/v2/projection/v2-to-v1.ts
+++ b/src/lib/v2/projection/v2-to-v1.ts
@@ -66,8 +66,12 @@ function projectDeclaration(
   productId: string,
   field: string
 ): { v1?: V1FormatId; diagnostic?: ProjectionDiagnostic } {
-  // Step 1: seller-asserted product-level opt-out.
-  if (decl.format_kind === 'custom' && decl.canonical_formats_only === true) {
+  // Step 1: seller-asserted product-level opt-out. canonical_formats_only
+  // is REQUIRED on `custom` declarations without v1_format_ref, but it's
+  // ALSO valid on any non-custom canonical when the seller wants to opt
+  // out of v1 emission for this product (e.g. the catalog has no v1 entry
+  // for the format yet — `audio_daast` is the 3.1 example).
+  if (decl.canonical_formats_only === true) {
     return {
       diagnostic: {
         source: 'sdk',

--- a/src/lib/v2/projection/v2-to-v1.ts
+++ b/src/lib/v2/projection/v2-to-v1.ts
@@ -1,0 +1,146 @@
+/**
+ * v2 → v1 Product projection (the downgrade direction).
+ *
+ * Used when the SDK negotiated to a v1 seller for a buyer that wrote V2
+ * code. The 8.0 design at `docs/development/v3.1-sdk-design.md` makes
+ * V2 the public mental model — adopters never see v1 vocabulary on
+ * `Product` — so this is the symmetric counterpart to v1→v2 projection
+ * on the read side.
+ *
+ * Resolution order per declaration (mirrors `v1-canonical-mapping.json`'s
+ * forward order, inverted):
+ *
+ *   1. `format_kind: "custom"` + `canonical_formats_only: true` → no v1
+ *      emit. Diagnostic surfaces explicit opt-out. The buyer's catalog
+ *      simply loses this product when downgraded to a v1-only seller —
+ *      consistent with the spec's "no synthetic aao-synth/ namespace"
+ *      rule.
+ *   2. `v1_format_ref` present → use it verbatim. Highest-confidence path
+ *      — seller has explicitly asserted the v1/v2 equivalence.
+ *   3. Registry reverse-lookup → invertible match (canonical + params
+ *      narrows compatibly to a literal v1 named format).
+ *   4. Registry says "ambiguous" → no v1 emit; diagnostic surfaces that
+ *      a mapping family exists but isn't deterministic.
+ *   5. Registry says "none" → no v1 emit; diagnostic surfaces that no
+ *      registry entry covers this canonical at all.
+ *
+ * In all non-(1,2,3) paths, the resulting v1 Product is **product-shape-
+ * valid but missing this declaration**. Two adopter consequences:
+ *
+ *   - If a product has multiple format_options[] and SOME project: the
+ *     v1 buyer sees the product but with fewer format_ids than the v2
+ *     buyer would see options.
+ *   - If a product has ONLY non-projectable format_options[]: the v1
+ *     buyer doesn't see the product at all (it'd violate the spec's
+ *     "format_ids minItems: 1" if we emitted it empty). Caller should
+ *     filter out v1 Products with empty format_ids before sending.
+ */
+
+import type { V2Product, V2ProductFormatDeclaration, V1Product, V1FormatId, ProjectionDiagnostic } from './types';
+import { reverseLookup } from './registry';
+
+export interface V2ToV1Result {
+  v1: V1Product;
+  diagnostics: ProjectionDiagnostic[];
+}
+
+/**
+ * Project a single V2 declaration to a v1 format_id when possible.
+ * Returns null when the declaration has no clean v1 form (caller drops
+ * it and emits a diagnostic from the outer function).
+ */
+function projectDeclaration(
+  decl: V2ProductFormatDeclaration,
+  field: string
+): { v1?: V1FormatId; diagnostic?: ProjectionDiagnostic } {
+  // Step 1: explicit fail-closed.
+  if (decl.format_kind === 'custom' && decl.canonical_formats_only === true) {
+    return {
+      diagnostic: {
+        code: 'FORMAT_DECLARATION_V1_UNREACHABLE',
+        field,
+        details: {
+          format_kind: decl.format_kind,
+          capability_id: decl.capability_id,
+          reason: 'canonical_formats_only',
+          hint: "This declaration explicitly opts out of v1 emission. v1-only buyers won't see this product.",
+        },
+      },
+    };
+  }
+
+  // Step 2: seller-asserted v1 link.
+  if (decl.v1_format_ref) {
+    return { v1: decl.v1_format_ref };
+  }
+
+  // Steps 3-5: registry reverse-lookup.
+  const result = reverseLookup(decl.format_kind, decl.params);
+  if (result.kind === 'match') {
+    return { v1: result.v1 };
+  }
+  if (result.kind === 'ambiguous') {
+    return {
+      diagnostic: {
+        code: 'FORMAT_DECLARATION_V1_AMBIGUOUS',
+        field,
+        details: {
+          format_kind: decl.format_kind,
+          capability_id: decl.capability_id,
+          matched_registry_entries: result.matchedEntries,
+          hint: result.hint,
+        },
+      },
+    };
+  }
+  // result.kind === 'none'
+  return {
+    diagnostic: {
+      code: 'FORMAT_DECLARATION_V1_UNREACHABLE',
+      field,
+      details: {
+        format_kind: decl.format_kind,
+        capability_id: decl.capability_id,
+        reason: 'no_v1_format_ref_or_registry_match',
+        hint:
+          `No registry entry exists for canonical "${decl.format_kind}". ` +
+          `Add v1_format_ref to the declaration if a v1 named format exists.`,
+      },
+    },
+  };
+}
+
+/**
+ * Project a V2 Product to a v1 Product. Drops format_options from the
+ * output and rebuilds format_ids per the resolution order.
+ *
+ * Caller decides what to do with the result when format_ids is empty —
+ * typically filter the product out of the response payload to a v1-only
+ * seller. The function always returns a Product shape so adopters can
+ * inspect what got dropped via diagnostics without parallel
+ * happy/sad-path branches.
+ */
+export function projectV2ProductToV1(v2: V2Product): V2ToV1Result {
+  const format_ids: V1FormatId[] = [];
+  const diagnostics: ProjectionDiagnostic[] = [];
+
+  for (let i = 0; i < v2.format_options.length; i++) {
+    const decl = v2.format_options[i]!;
+    const field = `products[${v2.product_id}].format_options[${i}]`;
+    const { v1, diagnostic } = projectDeclaration(decl, field);
+    if (v1) format_ids.push(v1);
+    if (diagnostic) diagnostics.push(diagnostic);
+  }
+
+  // Strip format_options from the v1 output. Cast through unknown
+  // because TypeScript can't widen V2Product → V1Product at a value
+  // level (they differ in their required fields).
+  const { format_options: _drop, ...rest } = v2;
+  void _drop;
+  const v1Product: V1Product = {
+    ...(rest as Omit<V2Product, 'format_options'>),
+    format_ids,
+  } as V1Product;
+
+  return { v1: v1Product, diagnostics };
+}

--- a/src/lib/v2/projection/v2-to-v1.ts
+++ b/src/lib/v2/projection/v2-to-v1.ts
@@ -47,6 +47,7 @@
 import type { V2Product, V2ProductFormatDeclaration, V1Product, V1FormatId, ProjectionDiagnostic } from './types';
 import { reverseLookup } from './registry';
 import { isCanonicalV1Translatable } from './canonical-properties';
+import { findCatalogEntryByCanonicalAndSize, parseSizedIdTemplate } from './catalog';
 import { LIBRARY_VERSION } from '../../version';
 
 const SDK_ID = `@adcp/sdk@${LIBRARY_VERSION}`;
@@ -90,15 +91,69 @@ function detectLossyMultiSize(
 }
 
 /**
- * Project a single V2 declaration. Returns either a v1 format_id to
- * emit, or a diagnostic to surface — never both, never neither (the
- * structural invariant the test suite asserts).
+ * Try to fan out a multi-size v2 declaration to N v1 format_ids by
+ * looking up each declared size in the AAO catalog. When successful,
+ * v1 buyers see ALL the sizes the v2 declaration covers — not just
+ * the seller-asserted rep. The spec doesn't require this (the rep +
+ * lossy advisory is the minimum-bar projection) but the catalog
+ * already publishes the per-size entries, so the SDK can use them
+ * without inter-SDK divergence.
+ *
+ * Returns the fanned-out v1 ids when at least 2 sizes resolved
+ * (otherwise the rep alone is fine; no value in fan-out). The lossy
+ * advisory is still emitted — its details now reflect how many
+ * sizes were actually covered vs declared.
+ */
+function tryFanOutMultiSize(decl: V2ProductFormatDeclaration, v1Ref: V1FormatId): V1FormatId[] | null {
+  const sizes = decl.params?.sizes;
+  if (!Array.isArray(sizes) || sizes.length <= 1) return null;
+  // Parse the seller's chosen v1_format_ref id to extract its
+  // `<prefix>_<W>x<H>_<suffix>` template, then constrain the fan-out
+  // to siblings sharing the same prefix + suffix. Otherwise multiple
+  // entries with the same `canonical:` annotation but different
+  // families (e.g., image's `display_*_image` and `display_*_generative`
+  // both annotated `canonical: image`) would collide and the SDK could
+  // emit ids from the wrong family.
+  const template = parseSizedIdTemplate(v1Ref.id);
+  const lookupOpts = template ? { prefix: template.prefix, suffix: template.suffix } : undefined;
+
+  const found: V1FormatId[] = [];
+  for (const size of sizes) {
+    if (!size || typeof size !== 'object') continue;
+    const sz = size as { width?: unknown; height?: unknown };
+    if (typeof sz.width !== 'number' || typeof sz.height !== 'number') continue;
+    const entry = findCatalogEntryByCanonicalAndSize(
+      decl.format_kind,
+      sz.width,
+      sz.height,
+      v1Ref.agent_url,
+      lookupOpts
+    );
+    if (entry) {
+      found.push({
+        agent_url: entry.format_id.agent_url,
+        id: entry.format_id.id,
+        width: sz.width,
+        height: sz.height,
+      });
+    }
+  }
+  return found.length >= 2 ? found : null;
+}
+
+/**
+ * Project a single V2 declaration. Returns one v1 format_id (the
+ * common case) OR a fanned-out list of v1 format_ids (multi-size
+ * fan-out) OR a diagnostic, plus an optional advisory diagnostic
+ * (multi-size loses some sizes). The structural invariant: every
+ * declaration produces AT LEAST ONE of (v1 emit, diagnostic) — may
+ * produce both.
  */
 function projectDeclaration(
   decl: V2ProductFormatDeclaration,
   productId: string,
   field: string
-): { v1?: V1FormatId; diagnostic?: ProjectionDiagnostic } {
+): { v1?: V1FormatId | V1FormatId[]; diagnostic?: ProjectionDiagnostic } {
   // Step 1: seller-asserted product-level opt-out. canonical_formats_only
   // is REQUIRED on `custom` declarations without v1_format_ref, but it's
   // ALSO valid on any non-custom canonical when the seller wants to opt
@@ -151,8 +206,16 @@ function projectDeclaration(
   if (decl.v1_format_ref) {
     const lossy = detectLossyMultiSize(decl);
     if (lossy) {
+      // Try to fan out via catalog lookup. When successful, the v1
+      // emit covers every size the catalog has an entry for. When
+      // only the rep is available, fall back to single-emit. Either
+      // way, surface the advisory so the buyer knows the v2
+      // declaration was multi-size.
+      const fanned = lossy.mode === 'sizes' ? tryFanOutMultiSize(decl, decl.v1_format_ref) : null;
+      const emit = fanned ?? decl.v1_format_ref;
+      const emittedCount = Array.isArray(emit) ? emit.length : 1;
       return {
-        v1: decl.v1_format_ref,
+        v1: emit,
         diagnostic: {
           source: 'sdk',
           sdk_id: SDK_ID,
@@ -165,6 +228,7 @@ function projectDeclaration(
               capability_id: decl.capability_id,
               size_mode: lossy.mode,
               declared_sizes_count: lossy.count,
+              emitted_sizes_count: emittedCount,
               v1_emit_represents_size: {
                 width: decl.v1_format_ref.width,
                 height: decl.v1_format_ref.height,
@@ -241,7 +305,13 @@ export function projectV2ProductToV1(v2: V2Product): V2ToV1Result {
     const decl = v2.format_options[i]!;
     const field = `products[${v2.product_id}].format_options[${i}]`;
     const { v1, diagnostic } = projectDeclaration(decl, v2.product_id, field);
-    if (v1) format_ids.push(v1);
+    if (v1) {
+      if (Array.isArray(v1)) {
+        for (const id of v1) format_ids.push(id);
+      } else {
+        format_ids.push(v1);
+      }
+    }
     if (diagnostic) diagnostics.push(diagnostic);
   }
 

--- a/src/lib/v2/projection/v2-to-v1.ts
+++ b/src/lib/v2/projection/v2-to-v1.ts
@@ -2,42 +2,54 @@
  * v2 → v1 Product projection (the downgrade direction).
  *
  * Used when the SDK negotiated to a v1 seller for a buyer that wrote V2
- * code. The 8.0 design at `docs/development/v3.1-sdk-design.md` makes
- * V2 the public mental model — adopters never see v1 vocabulary on
+ * code. The 8.0 design at `docs/development/v3.1-sdk-design.md` makes V2
+ * the public mental model — adopters never see v1 vocabulary on
  * `Product` — so this is the symmetric counterpart to v1→v2 projection
  * on the read side.
  *
- * Resolution order per declaration (mirrors `v1-canonical-mapping.json`'s
- * forward order, inverted):
+ * Resolution order per declaration (aligns with the normative rules in
+ * `core/registries/v1-canonical-mapping.json` and the canonical schemas'
+ * `v1_translatable` field):
  *
  *   1. `format_kind: "custom"` + `canonical_formats_only: true` → no v1
- *      emit. Diagnostic surfaces explicit opt-out. The buyer's catalog
- *      simply loses this product when downgraded to a v1-only seller —
- *      consistent with the spec's "no synthetic aao-synth/ namespace"
- *      rule.
- *   2. `v1_format_ref` present → use it verbatim. Highest-confidence path
- *      — seller has explicitly asserted the v1/v2 equivalence.
- *   3. Registry reverse-lookup → invertible match (canonical + params
- *      narrows compatibly to a literal v1 named format).
- *   4. Registry says "ambiguous" → no v1 emit; diagnostic surfaces that
- *      a mapping family exists but isn't deterministic.
- *   5. Registry says "none" → no v1 emit; diagnostic surfaces that no
- *      registry entry covers this canonical at all.
+ *      emit. Seller has explicitly opted out. SDK-local diagnostic
+ *      `FORMAT_DECLARATION_V1_NOT_APPLICABLE` surfaces the opt-out so
+ *      v1-only buyers see why a product disappeared.
+ *   2. Canonical declares `v1_translatable: false` (the 4 inherently-v2
+ *      canonicals at 3.1 GA: image_carousel, sponsored_placement,
+ *      responsive_creative, agent_placement) → no v1 emit. SDK-local
+ *      `CANONICAL_NOT_V1_TRANSLATABLE` diagnostic. **Spec is explicit:
+ *      MUST NOT emit FORMAT_PROJECTION_FAILED** — these aren't
+ *      registry-coverage gaps, they're structural unreachability.
+ *   3. `v1_format_ref` present → use verbatim. Seller-asserted v1↔v2
+ *      pairing is the only normative path to a specific v1 `format_id`.
+ *   4. Registry has invertible literal match (`format_id_glob` with no
+ *      `*`, params narrow compatibly) → MAY synthesize a v1 `format_id`,
+ *      but the projection is **non-normative** per the registry's
+ *      direction-of-truth statement. Downstream consumers MUST NOT
+ *      depend on this — and the spec explicitly notes that a synthesized
+ *      `agent_url` is implementation-defined inter-SDK divergence. We
+ *      do synthesize (best-effort, surfaces the registry's invertible
+ *      entries) but flag the result as non-normative via the registry
+ *      lookup return type.
+ *   5. Registry has family-level matches (structural or wildcarded
+ *      globs) but none invertible → `FORMAT_DECLARATION_V1_AMBIGUOUS`.
+ *      Spec code. Seller's path: add `v1_format_ref` to disambiguate.
+ *   6. Registry has no entries for this canonical (and v1_translatable
+ *      is true) → `FORMAT_PROJECTION_FAILED`. Spec code. Registry-
+ *      coverage gap; correctable by filing a registry PR.
  *
- * In all non-(1,2,3) paths, the resulting v1 Product is **product-shape-
- * valid but missing this declaration**. Two adopter consequences:
- *
- *   - If a product has multiple format_options[] and SOME project: the
- *     v1 buyer sees the product but with fewer format_ids than the v2
- *     buyer would see options.
- *   - If a product has ONLY non-projectable format_options[]: the v1
- *     buyer doesn't see the product at all (it'd violate the spec's
- *     "format_ids minItems: 1" if we emitted it empty). Caller should
- *     filter out v1 Products with empty format_ids before sending.
+ * SDK identity for `sdk_id` is read from package.json at module-load
+ * time so multi-hop deduplication can pin diagnostics to the SDK that
+ * emitted them.
  */
 
 import type { V2Product, V2ProductFormatDeclaration, V1Product, V1FormatId, ProjectionDiagnostic } from './types';
 import { reverseLookup } from './registry';
+import { isCanonicalV1Translatable } from './canonical-properties';
+import { LIBRARY_VERSION } from '../../version';
+
+const SDK_ID = `@adcp/sdk@${LIBRARY_VERSION}`;
 
 export interface V2ToV1Result {
   v1: V1Product;
@@ -45,66 +57,101 @@ export interface V2ToV1Result {
 }
 
 /**
- * Project a single V2 declaration to a v1 format_id when possible.
- * Returns null when the declaration has no clean v1 form (caller drops
- * it and emits a diagnostic from the outer function).
+ * Project a single V2 declaration. Returns either a v1 format_id to
+ * emit, or a diagnostic to surface — never both, never neither (the
+ * structural invariant the test suite asserts).
  */
 function projectDeclaration(
   decl: V2ProductFormatDeclaration,
+  productId: string,
   field: string
 ): { v1?: V1FormatId; diagnostic?: ProjectionDiagnostic } {
-  // Step 1: explicit fail-closed.
+  // Step 1: seller-asserted product-level opt-out.
   if (decl.format_kind === 'custom' && decl.canonical_formats_only === true) {
     return {
       diagnostic: {
-        code: 'FORMAT_DECLARATION_V1_UNREACHABLE',
+        source: 'sdk',
+        sdk_id: SDK_ID,
         field,
-        details: {
-          format_kind: decl.format_kind,
-          capability_id: decl.capability_id,
-          reason: 'canonical_formats_only',
-          hint: "This declaration explicitly opts out of v1 emission. v1-only buyers won't see this product.",
+        code: 'FORMAT_DECLARATION_V1_NOT_APPLICABLE',
+        error: {
+          details: {
+            format_kind: decl.format_kind,
+            product_id: productId,
+            capability_id: decl.capability_id,
+            reason: 'canonical_formats_only',
+          },
         },
       },
     };
   }
 
-  // Step 2: seller-asserted v1 link.
+  // Step 2: canonical-level structural unreachability.
+  if (!isCanonicalV1Translatable(decl.format_kind)) {
+    return {
+      diagnostic: {
+        source: 'sdk',
+        sdk_id: SDK_ID,
+        field,
+        code: 'CANONICAL_NOT_V1_TRANSLATABLE',
+        error: {
+          details: {
+            format_kind: decl.format_kind,
+            product_id: productId,
+            capability_id: decl.capability_id,
+          },
+        },
+      },
+    };
+  }
+
+  // Step 3: seller-asserted v1 link — the only normative path to a
+  // specific v1 format_id.
   if (decl.v1_format_ref) {
     return { v1: decl.v1_format_ref };
   }
 
-  // Steps 3-5: registry reverse-lookup.
+  // Steps 4-6: registry lookup.
   const result = reverseLookup(decl.format_kind, decl.params);
   if (result.kind === 'match') {
+    // Step 4: non-normative best-effort. Documented limitation: the
+    // synthesized agent_url is implementation-defined; downstream
+    // consumers MUST NOT depend on this projection.
     return { v1: result.v1 };
   }
   if (result.kind === 'ambiguous') {
+    // Step 5: family known, specific format not pickable.
     return {
       diagnostic: {
-        code: 'FORMAT_DECLARATION_V1_AMBIGUOUS',
+        source: 'sdk',
+        sdk_id: SDK_ID,
         field,
-        details: {
-          format_kind: decl.format_kind,
-          capability_id: decl.capability_id,
-          matched_registry_entries: result.matchedEntries,
-          hint: result.hint,
+        code: 'FORMAT_DECLARATION_V1_AMBIGUOUS',
+        error: {
+          details: {
+            format_kind: decl.format_kind,
+            product_id: productId,
+            capability_id: decl.capability_id,
+            registry_matches: result.matchedEntries,
+          },
         },
       },
     };
   }
-  // result.kind === 'none'
+  // Step 6: registry-coverage gap.
   return {
     diagnostic: {
-      code: 'FORMAT_DECLARATION_V1_UNREACHABLE',
+      source: 'sdk',
+      sdk_id: SDK_ID,
       field,
-      details: {
-        format_kind: decl.format_kind,
-        capability_id: decl.capability_id,
-        reason: 'no_v1_format_ref_or_registry_match',
-        hint:
-          `No registry entry exists for canonical "${decl.format_kind}". ` +
-          `Add v1_format_ref to the declaration if a v1 named format exists.`,
+      code: 'FORMAT_PROJECTION_FAILED',
+      error: {
+        details: {
+          format_kind: decl.format_kind,
+          product_id: productId,
+          capability_id: decl.capability_id,
+          resolution_failure: 'no_registry_match',
+        },
       },
     },
   };
@@ -114,11 +161,11 @@ function projectDeclaration(
  * Project a V2 Product to a v1 Product. Drops format_options from the
  * output and rebuilds format_ids per the resolution order.
  *
- * Caller decides what to do with the result when format_ids is empty —
- * typically filter the product out of the response payload to a v1-only
- * seller. The function always returns a Product shape so adopters can
- * inspect what got dropped via diagnostics without parallel
- * happy/sad-path branches.
+ * The function always returns a Product shape so adopters can inspect
+ * what got dropped via diagnostics without parallel happy/sad-path
+ * branches. Caller filters out v1 Products with empty format_ids before
+ * sending to a v1-only seller (the spec requires `format_ids` to have
+ * minItems: 1).
  */
 export function projectV2ProductToV1(v2: V2Product): V2ToV1Result {
   const format_ids: V1FormatId[] = [];
@@ -127,14 +174,11 @@ export function projectV2ProductToV1(v2: V2Product): V2ToV1Result {
   for (let i = 0; i < v2.format_options.length; i++) {
     const decl = v2.format_options[i]!;
     const field = `products[${v2.product_id}].format_options[${i}]`;
-    const { v1, diagnostic } = projectDeclaration(decl, field);
+    const { v1, diagnostic } = projectDeclaration(decl, v2.product_id, field);
     if (v1) format_ids.push(v1);
     if (diagnostic) diagnostics.push(diagnostic);
   }
 
-  // Strip format_options from the v1 output. Cast through unknown
-  // because TypeScript can't widen V2Product → V1Product at a value
-  // level (they differ in their required fields).
   const { format_options: _drop, ...rest } = v2;
   void _drop;
   const v1Product: V1Product = {

--- a/src/lib/v2/projection/v2-to-v1.ts
+++ b/src/lib/v2/projection/v2-to-v1.ts
@@ -57,6 +57,39 @@ export interface V2ToV1Result {
 }
 
 /**
+ * Inspect a v2 declaration's params for multi-size or responsive-range
+ * shapes that a single v1 `format_id` can't represent. Returns the
+ * detected mode + count so the caller emits the diagnostic with full
+ * context. Returns null when params declare a single fixed (width,
+ * height) — the case that round-trips through v1 cleanly.
+ */
+function detectLossyMultiSize(
+  decl: V2ProductFormatDeclaration
+): { mode: 'sizes' | 'responsive_range'; count?: number } | null {
+  // Only image/html5/display_tag canonicals carry these new size modes
+  // at 3.1 GA. Other canonicals (video_*, audio_*) use their own param
+  // shapes that the v1 format_id can carry inline.
+  if (decl.format_kind !== 'image' && decl.format_kind !== 'html5' && decl.format_kind !== 'display_tag') {
+    return null;
+  }
+  const params = decl.params ?? {};
+  if (Array.isArray(params.sizes) && params.sizes.length > 1) {
+    return { mode: 'sizes', count: params.sizes.length };
+  }
+  // Responsive range mode: any of min_*/max_* present means the v1
+  // format_id (which carries exactly one width+height pair) is lossy.
+  if (
+    typeof params.min_width === 'number' ||
+    typeof params.max_width === 'number' ||
+    typeof params.min_height === 'number' ||
+    typeof params.max_height === 'number'
+  ) {
+    return { mode: 'responsive_range' };
+  }
+  return null;
+}
+
+/**
  * Project a single V2 declaration. Returns either a v1 format_id to
  * emit, or a diagnostic to surface — never both, never neither (the
  * structural invariant the test suite asserts).
@@ -110,8 +143,37 @@ function projectDeclaration(
   }
 
   // Step 3: seller-asserted v1 link — the only normative path to a
-  // specific v1 format_id.
+  // specific v1 format_id. When the v2 params declare a multi-size
+  // (`sizes: [...]`) or responsive range (`min_*`/`max_*`) shape,
+  // the single v1 format_id can't represent the full coverage —
+  // emit both the v1 ref AND a lossy-multi-size diagnostic so the
+  // buyer knows N-1 sizes are missing on the v1 wire.
   if (decl.v1_format_ref) {
+    const lossy = detectLossyMultiSize(decl);
+    if (lossy) {
+      return {
+        v1: decl.v1_format_ref,
+        diagnostic: {
+          source: 'sdk',
+          sdk_id: SDK_ID,
+          field,
+          code: 'FORMAT_DECLARATION_V1_LOSSY_MULTI_SIZE',
+          error: {
+            details: {
+              format_kind: decl.format_kind,
+              product_id: productId,
+              capability_id: decl.capability_id,
+              size_mode: lossy.mode,
+              declared_sizes_count: lossy.count,
+              v1_emit_represents_size: {
+                width: decl.v1_format_ref.width,
+                height: decl.v1_format_ref.height,
+              },
+            },
+          },
+        },
+      };
+    }
     return { v1: decl.v1_format_ref };
   }
 

--- a/test/lib/v1-to-v2-projection.test.js
+++ b/test/lib/v1-to-v2-projection.test.js
@@ -86,32 +86,52 @@ describe('v1 → v2 projection — every catalog entry projects', { skip: SKIP_R
   });
 });
 
-describe('v1 → v2 projection — registry glob fallback for un-annotated formats', { skip: SKIP_REASON }, () => {
-  test('an id that matches a registry literal projects without a catalog entry', () => {
-    // A v1 product whose format_id matches a registry literal but uses
-    // a non-AAO agent_url (so the catalog lookup misses and the
-    // projection has to fall through to Step 2). The registry's
-    // `display_300x250_image` is a literal glob (no `*`), so it matches
-    // exactly.
-    const v1 = {
-      product_id: 'registry_only_fallback',
-      name: 'test',
-      description: 'test',
-      format_ids: [
-        {
-          agent_url: 'https://some-publisher.example/',
-          id: 'display_300x250_image',
-        },
-      ],
-    };
-    const { v2, diagnostics } = projectV1ProductToV2(v1);
-    assert.strictEqual(diagnostics.length, 0);
-    assert.strictEqual(v2.format_options.length, 1);
-    assert.strictEqual(v2.format_options[0].format_kind, 'image');
-    assert.strictEqual(v2.format_options[0].params.width, 300);
-    assert.strictEqual(v2.format_options[0].params.height, 250);
-  });
-});
+describe(
+  'v1 → v2 projection — structural fallback (registry is structural-only post-3.1-GA)',
+  { skip: SKIP_REASON },
+  () => {
+    // After the publisher-scoped format catalog landed (adcp commit
+    // f88522cfc5), the registry shrank from 17 entries to 7 pure-
+    // structural fallbacks. The literal globs (`iab_mrec_300x250` etc.)
+    // moved into per-publisher catalogs declared via
+    // `adagents.json#/formats` (or the AAO community mirror for
+    // publishers who haven't adopted yet). The SDK's
+    // `forwardLookupByGlob` path stays in place for forward-compat —
+    // the registry MAY grow literal entries again — but at 3.1 GA it
+    // never fires for catalog-known formats.
+
+    test('publisher-bespoke id without catalog entry falls through to structural', () => {
+      // A v1 product whose format_id doesn't match the AAO catalog OR
+      // a registry literal, but DOES have a structural signature the
+      // registry recognizes. The SDK needs to know about the format's
+      // assets — we can't fetch them at projection time (auto-
+      // negotiation surface concern), so we expect fail-closed with
+      // `no_match` here. Structural Step 3 only fires when a catalog
+      // lookup returned an entry without a `canonical:` annotation.
+      const v1 = {
+        product_id: 'bespoke_unknown',
+        name: 'test',
+        description: 'test',
+        format_ids: [
+          {
+            agent_url: 'https://some-publisher.example/',
+            id: 'definitely_not_in_catalog_or_registry',
+          },
+        ],
+      };
+      const { v2, diagnostics } = projectV1ProductToV2(v1);
+      // Either fail-closed (the realistic case — we don't know the
+      // publisher's format definition) or a structural fallback.
+      // The prototype's scope means the publisher-fetch side is
+      // deferred to the auto-negotiation surface, so this is fail-
+      // closed today.
+      assert.strictEqual(v2.format_options.length, 0);
+      assert.strictEqual(diagnostics.length, 1);
+      assert.strictEqual(diagnostics[0].code, 'FORMAT_PROJECTION_FAILED');
+      assert.strictEqual(diagnostics[0].error.details.resolution_failure, 'no_match');
+    });
+  }
+);
 
 describe('v1 → v2 projection — fail-closed for fully-unknown formats', { skip: SKIP_REASON }, () => {
   test('a bespoke format with no catalog/registry/structural match surfaces FORMAT_PROJECTION_FAILED', () => {

--- a/test/lib/v1-to-v2-projection.test.js
+++ b/test/lib/v1-to-v2-projection.test.js
@@ -1,0 +1,177 @@
+// Exercise the v1 → v2 projection layer against the full AAO
+// catalog (reference-formats.json). Every catalog entry is a v1 format
+// definition — we wrap each one in a minimal v1 Product and run it
+// through the projection to see how many land cleanly in v2 shape.
+//
+// Skips in CI when the 3.1-beta cache + vendored catalog aren't
+// present — same pattern as the v2 → v1 prototype tests.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const { readFileSync, existsSync } = require('node:fs');
+const path = require('node:path');
+
+const { projectV1ProductToV2 } = require('../../dist/lib/v2/projection/v1-to-v2.js');
+
+const FIXTURE_DIR = path.join(__dirname, 'v2-projection-fixtures');
+const CATALOG_PATH = path.join(FIXTURE_DIR, 'aao-reference-formats.json');
+const REGISTRY_PATH = path.join(
+  __dirname,
+  '..',
+  '..',
+  'schemas',
+  'cache',
+  '3.1.0-beta.0',
+  'registries',
+  'v1-canonical-mapping.json'
+);
+
+const SKIP_REASON =
+  existsSync(CATALOG_PATH) && existsSync(REGISTRY_PATH)
+    ? false
+    : 'requires schemas/cache/3.1.0-beta.0/ + vendored aao-reference-formats.json — only present in workspaces with a local 3.1-beta sync';
+
+function loadCatalog() {
+  return JSON.parse(readFileSync(CATALOG_PATH, 'utf-8'));
+}
+
+/**
+ * Wrap a catalog entry in a minimal v1 Product for the projection. Real
+ * v1 Products carry pricing_options / publisher_properties / etc.;
+ * for a projection test we only need format_ids + a product_id.
+ */
+function v1ProductFor(catalogEntry, productId) {
+  return {
+    product_id: productId,
+    name: catalogEntry.name ?? productId,
+    description: catalogEntry.description ?? '',
+    format_ids: [catalogEntry.format_id],
+  };
+}
+
+describe('v1 → v2 projection — every catalog entry projects', { skip: SKIP_REASON }, () => {
+  test('all entries with `canonical` annotations project via Step 1', () => {
+    const entries = loadCatalog().filter(e => e.canonical);
+    const failures = [];
+    for (const entry of entries) {
+      const v1 = v1ProductFor(entry, `test_${entry.format_id.id}`);
+      const { v2, diagnostics } = projectV1ProductToV2(v1);
+      if (diagnostics.length > 0 || v2.format_options.length !== 1) {
+        failures.push({
+          id: entry.format_id.id,
+          expected_canonical: entry.canonical,
+          diagnostics: diagnostics.map(d => d.code),
+        });
+        continue;
+      }
+      if (v2.format_options[0].format_kind !== entry.canonical) {
+        failures.push({
+          id: entry.format_id.id,
+          expected: entry.canonical,
+          got: v2.format_options[0].format_kind,
+        });
+      }
+    }
+    assert.deepStrictEqual(failures, [], `catalog entries with \`canonical\` MUST all project cleanly`);
+  });
+
+  test('round-trip v1_format_ref preserves the input', () => {
+    const entry = loadCatalog().find(e => e.canonical === 'image' && e.format_id.id === 'display_image');
+    assert.ok(entry, 'expected display_image entry in the catalog');
+    const v1 = v1ProductFor(entry, 'rt_display_image');
+    const { v2 } = projectV1ProductToV2(v1);
+    const decl = v2.format_options[0];
+    assert.strictEqual(decl.v1_format_ref.agent_url, entry.format_id.agent_url);
+    assert.strictEqual(decl.v1_format_ref.id, entry.format_id.id);
+  });
+});
+
+describe('v1 → v2 projection — registry glob fallback for un-annotated formats', { skip: SKIP_REASON }, () => {
+  test('an id that matches a registry literal projects without a catalog entry', () => {
+    // A v1 product whose format_id matches a registry literal but uses
+    // a non-AAO agent_url (so the catalog lookup misses and the
+    // projection has to fall through to Step 2). The registry's
+    // `display_300x250_image` is a literal glob (no `*`), so it matches
+    // exactly.
+    const v1 = {
+      product_id: 'registry_only_fallback',
+      name: 'test',
+      description: 'test',
+      format_ids: [
+        {
+          agent_url: 'https://some-publisher.example/',
+          id: 'display_300x250_image',
+        },
+      ],
+    };
+    const { v2, diagnostics } = projectV1ProductToV2(v1);
+    assert.strictEqual(diagnostics.length, 0);
+    assert.strictEqual(v2.format_options.length, 1);
+    assert.strictEqual(v2.format_options[0].format_kind, 'image');
+    assert.strictEqual(v2.format_options[0].params.width, 300);
+    assert.strictEqual(v2.format_options[0].params.height, 250);
+  });
+});
+
+describe('v1 → v2 projection — fail-closed for fully-unknown formats', { skip: SKIP_REASON }, () => {
+  test('a bespoke format with no catalog/registry/structural match surfaces FORMAT_PROJECTION_FAILED', () => {
+    const v1 = {
+      product_id: 'bespoke_proprietary',
+      name: 'test',
+      description: 'test',
+      format_ids: [
+        {
+          agent_url: 'https://obscure-publisher.example/',
+          id: 'definitely_not_in_catalog_or_registry',
+        },
+      ],
+    };
+    const { v2, diagnostics } = projectV1ProductToV2(v1);
+    assert.strictEqual(v2.format_options.length, 0);
+    assert.strictEqual(diagnostics.length, 1);
+    assert.strictEqual(diagnostics[0].code, 'FORMAT_PROJECTION_FAILED');
+    assert.strictEqual(diagnostics[0].error.details.resolution_failure, 'no_match');
+  });
+});
+
+describe('v1 → v2 projection — every-catalog-entry coverage report', { skip: SKIP_REASON }, () => {
+  test('emit per-canonical coverage', () => {
+    const catalog = loadCatalog();
+    const buckets = {
+      step1_catalog_canonical: [], // seller-asserted, normative
+      catalog_lacks_canonical: [], // catalog has entry, no v2 mapping yet
+      no_match: [], // not in catalog, no registry, no structural
+    };
+    for (const entry of catalog) {
+      const v1 = v1ProductFor(entry, `cov_${entry.format_id.id}`);
+      const { v2, diagnostics } = projectV1ProductToV2(v1);
+      const projectedKind = v2.format_options[0]?.format_kind;
+      const tag = `${entry.format_id.id} → ${projectedKind ?? '✗'}`;
+      if (diagnostics.length === 0) {
+        buckets.step1_catalog_canonical.push(tag);
+        continue;
+      }
+      const reason = diagnostics[0].error.details.resolution_failure;
+      if (reason === 'catalog_lacks_canonical_annotation') {
+        buckets.catalog_lacks_canonical.push(entry.format_id.id);
+      } else {
+        buckets.no_match.push(entry.format_id.id);
+      }
+    }
+    console.log('\n=== v1 → v2 projection coverage (full AAO catalog, 57 entries) ===\n');
+    const line = (label, list) => {
+      console.log(`${label} (${list.length}):`);
+      for (const n of list) console.log(`  ${n}`);
+    };
+    line('Step 1 — catalog `canonical` annotation (NORMATIVE, clean projection)', buckets.step1_catalog_canonical);
+    console.log();
+    line(
+      'catalog_lacks_canonical_annotation (AAO knows the format, no v2 mapping yet — Native/DOOH/broadcast/card categories)',
+      buckets.catalog_lacks_canonical
+    );
+    console.log();
+    line('no_match (not in catalog, no registry hit, no structural)', buckets.no_match);
+    console.log();
+    assert.ok(true);
+  });
+});

--- a/test/lib/v2-projection-fixtures/aao-reference-formats.json
+++ b/test/lib/v2-projection-fixtures/aao-reference-formats.json
@@ -61,7 +61,8 @@
           "description": "Text prompt describing the desired creative"
         }
       }
-    ]
+    ],
+    "canonical": "image"
   },
   {
     "format_id": {
@@ -141,7 +142,8 @@
           "description": "Text prompt describing the desired creative"
         }
       }
-    ]
+    ],
+    "canonical": "image"
   },
   {
     "format_id": {
@@ -221,7 +223,8 @@
           "description": "Text prompt describing the desired creative"
         }
       }
-    ]
+    ],
+    "canonical": "image"
   },
   {
     "format_id": {
@@ -301,7 +304,8 @@
           "description": "Text prompt describing the desired creative"
         }
       }
-    ]
+    ],
+    "canonical": "image"
   },
   {
     "format_id": {
@@ -381,7 +385,8 @@
           "description": "Text prompt describing the desired creative"
         }
       }
-    ]
+    ],
+    "canonical": "image"
   },
   {
     "format_id": {
@@ -461,7 +466,8 @@
           "description": "Text prompt describing the desired creative"
         }
       }
-    ]
+    ],
+    "canonical": "image"
   },
   {
     "format_id": {
@@ -541,7 +547,8 @@
           "description": "Text prompt describing the desired creative"
         }
       }
-    ]
+    ],
+    "canonical": "image"
   },
   {
     "format_id": {
@@ -621,7 +628,8 @@
           "description": "Text prompt describing the desired creative"
         }
       }
-    ]
+    ],
+    "canonical": "image"
   },
   {
     "format_id": {
@@ -4866,6 +4874,7 @@
       "CREATIVE_ID",
       "CACHEBUSTER",
       "CLICK_URL"
-    ]
+    ],
+    "canonical": "agent_placement"
   }
 ]

--- a/test/lib/v2-projection-fixtures/aao-reference-formats.json
+++ b/test/lib/v2-projection-fixtures/aao-reference-formats.json
@@ -1,0 +1,4871 @@
+[
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "display_generative"
+    },
+    "name": "Display Banner - AI Generated",
+    "description": "AI-generated display banner from brand context and prompt (supports any dimensions)",
+    "type": "display",
+    "accepts_parameters": [
+      "dimensions"
+    ],
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "generation_prompt",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Text prompt describing the desired creative"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "tracker_pixel",
+          "description": "3rd party impression tracking pixel URL"
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING"
+    ],
+    "catalog_requirements": [
+      {
+        "catalog_type": "offering",
+        "required": true,
+        "required_fields": [
+          "name"
+        ]
+      }
+    ],
+    "assets_required": [
+      {
+        "asset_id": "generation_prompt",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Text prompt describing the desired creative"
+        }
+      }
+    ]
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "display_300x250_generative"
+    },
+    "name": "Medium Rectangle - AI Generated",
+    "description": "AI-generated 300x250 banner from brand context and prompt",
+    "type": "display",
+    "renders": [
+      {
+        "dimensions": {
+          "height": 250,
+          "responsive": {
+            "height": false,
+            "width": false
+          },
+          "width": 300
+        },
+        "role": "primary"
+      }
+    ],
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "generation_prompt",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Text prompt describing the desired creative"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "tracker_pixel",
+          "description": "3rd party impression tracking pixel URL"
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING"
+    ],
+    "output_format_ids": [
+      {
+        "agent_url": "https://creative.adcontextprotocol.org/",
+        "id": "display_300x250_image"
+      }
+    ],
+    "catalog_requirements": [
+      {
+        "catalog_type": "offering",
+        "required": true,
+        "required_fields": [
+          "name"
+        ]
+      }
+    ],
+    "assets_required": [
+      {
+        "asset_id": "generation_prompt",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Text prompt describing the desired creative"
+        }
+      }
+    ]
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "display_728x90_generative"
+    },
+    "name": "Leaderboard - AI Generated",
+    "description": "AI-generated 728x90 banner from brand context and prompt",
+    "type": "display",
+    "renders": [
+      {
+        "dimensions": {
+          "height": 90,
+          "responsive": {
+            "height": false,
+            "width": false
+          },
+          "width": 728
+        },
+        "role": "primary"
+      }
+    ],
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "generation_prompt",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Text prompt describing the desired creative"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "tracker_pixel",
+          "description": "3rd party impression tracking pixel URL"
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING"
+    ],
+    "output_format_ids": [
+      {
+        "agent_url": "https://creative.adcontextprotocol.org/",
+        "id": "display_728x90_image"
+      }
+    ],
+    "catalog_requirements": [
+      {
+        "catalog_type": "offering",
+        "required": true,
+        "required_fields": [
+          "name"
+        ]
+      }
+    ],
+    "assets_required": [
+      {
+        "asset_id": "generation_prompt",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Text prompt describing the desired creative"
+        }
+      }
+    ]
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "display_320x50_generative"
+    },
+    "name": "Mobile Banner - AI Generated",
+    "description": "AI-generated 320x50 mobile banner from brand context and prompt",
+    "type": "display",
+    "renders": [
+      {
+        "dimensions": {
+          "height": 50,
+          "responsive": {
+            "height": false,
+            "width": false
+          },
+          "width": 320
+        },
+        "role": "primary"
+      }
+    ],
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "generation_prompt",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Text prompt describing the desired creative"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "tracker_pixel",
+          "description": "3rd party impression tracking pixel URL"
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING"
+    ],
+    "output_format_ids": [
+      {
+        "agent_url": "https://creative.adcontextprotocol.org/",
+        "id": "display_320x50_image"
+      }
+    ],
+    "catalog_requirements": [
+      {
+        "catalog_type": "offering",
+        "required": true,
+        "required_fields": [
+          "name"
+        ]
+      }
+    ],
+    "assets_required": [
+      {
+        "asset_id": "generation_prompt",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Text prompt describing the desired creative"
+        }
+      }
+    ]
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "display_160x600_generative"
+    },
+    "name": "Wide Skyscraper - AI Generated",
+    "description": "AI-generated 160x600 wide skyscraper from brand context and prompt",
+    "type": "display",
+    "renders": [
+      {
+        "dimensions": {
+          "height": 600,
+          "responsive": {
+            "height": false,
+            "width": false
+          },
+          "width": 160
+        },
+        "role": "primary"
+      }
+    ],
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "generation_prompt",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Text prompt describing the desired creative"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "tracker_pixel",
+          "description": "3rd party impression tracking pixel URL"
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING"
+    ],
+    "output_format_ids": [
+      {
+        "agent_url": "https://creative.adcontextprotocol.org/",
+        "id": "display_160x600_image"
+      }
+    ],
+    "catalog_requirements": [
+      {
+        "catalog_type": "offering",
+        "required": true,
+        "required_fields": [
+          "name"
+        ]
+      }
+    ],
+    "assets_required": [
+      {
+        "asset_id": "generation_prompt",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Text prompt describing the desired creative"
+        }
+      }
+    ]
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "display_336x280_generative"
+    },
+    "name": "Large Rectangle - AI Generated",
+    "description": "AI-generated 336x280 large rectangle from brand context and prompt",
+    "type": "display",
+    "renders": [
+      {
+        "dimensions": {
+          "height": 280,
+          "responsive": {
+            "height": false,
+            "width": false
+          },
+          "width": 336
+        },
+        "role": "primary"
+      }
+    ],
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "generation_prompt",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Text prompt describing the desired creative"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "tracker_pixel",
+          "description": "3rd party impression tracking pixel URL"
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING"
+    ],
+    "output_format_ids": [
+      {
+        "agent_url": "https://creative.adcontextprotocol.org/",
+        "id": "display_336x280_image"
+      }
+    ],
+    "catalog_requirements": [
+      {
+        "catalog_type": "offering",
+        "required": true,
+        "required_fields": [
+          "name"
+        ]
+      }
+    ],
+    "assets_required": [
+      {
+        "asset_id": "generation_prompt",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Text prompt describing the desired creative"
+        }
+      }
+    ]
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "display_300x600_generative"
+    },
+    "name": "Half Page - AI Generated",
+    "description": "AI-generated 300x600 half page from brand context and prompt",
+    "type": "display",
+    "renders": [
+      {
+        "dimensions": {
+          "height": 600,
+          "responsive": {
+            "height": false,
+            "width": false
+          },
+          "width": 300
+        },
+        "role": "primary"
+      }
+    ],
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "generation_prompt",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Text prompt describing the desired creative"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "tracker_pixel",
+          "description": "3rd party impression tracking pixel URL"
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING"
+    ],
+    "output_format_ids": [
+      {
+        "agent_url": "https://creative.adcontextprotocol.org/",
+        "id": "display_300x600_image"
+      }
+    ],
+    "catalog_requirements": [
+      {
+        "catalog_type": "offering",
+        "required": true,
+        "required_fields": [
+          "name"
+        ]
+      }
+    ],
+    "assets_required": [
+      {
+        "asset_id": "generation_prompt",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Text prompt describing the desired creative"
+        }
+      }
+    ]
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "display_970x250_generative"
+    },
+    "name": "Billboard - AI Generated",
+    "description": "AI-generated 970x250 billboard from brand context and prompt",
+    "type": "display",
+    "renders": [
+      {
+        "dimensions": {
+          "height": 250,
+          "responsive": {
+            "height": false,
+            "width": false
+          },
+          "width": 970
+        },
+        "role": "primary"
+      }
+    ],
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "generation_prompt",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Text prompt describing the desired creative"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "tracker_pixel",
+          "description": "3rd party impression tracking pixel URL"
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING"
+    ],
+    "output_format_ids": [
+      {
+        "agent_url": "https://creative.adcontextprotocol.org/",
+        "id": "display_970x250_image"
+      }
+    ],
+    "catalog_requirements": [
+      {
+        "catalog_type": "offering",
+        "required": true,
+        "required_fields": [
+          "name"
+        ]
+      }
+    ],
+    "assets_required": [
+      {
+        "asset_id": "generation_prompt",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Text prompt describing the desired creative"
+        }
+      }
+    ]
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "video_standard"
+    },
+    "name": "Standard Video",
+    "description": "Video ad in standard aspect ratios (supports any duration)",
+    "type": "video",
+    "accepts_parameters": [
+      "duration"
+    ],
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "video_file",
+        "required": true,
+        "asset_type": "video",
+        "requirements": {
+          "containers": [
+            "mp4",
+            "mov",
+            "webm"
+          ]
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "tracker_pixel",
+          "description": "3rd party impression tracking pixel URL"
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING",
+      "VIDEO_ID",
+      "POD_POSITION",
+      "CONTENT_GENRE"
+    ],
+    "assets_required": [
+      {
+        "asset_id": "video_file",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "video",
+        "requirements": {
+          "containers": [
+            "mp4",
+            "mov",
+            "webm"
+          ]
+        }
+      }
+    ],
+    "canonical": "video_hosted"
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "video_dimensions"
+    },
+    "name": "Video with Dimensions",
+    "description": "Video ad with specific dimensions (supports any size)",
+    "type": "video",
+    "accepts_parameters": [
+      "dimensions"
+    ],
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "video_file",
+        "required": true,
+        "asset_type": "video",
+        "requirements": {
+          "containers": [
+            "mp4",
+            "mov",
+            "webm"
+          ]
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "tracker_pixel",
+          "description": "3rd party impression tracking pixel URL"
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING",
+      "VIDEO_ID",
+      "POD_POSITION",
+      "CONTENT_GENRE"
+    ],
+    "assets_required": [
+      {
+        "asset_id": "video_file",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "video",
+        "requirements": {
+          "containers": [
+            "mp4",
+            "mov",
+            "webm"
+          ]
+        }
+      }
+    ],
+    "canonical": "video_hosted"
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "video_vast"
+    },
+    "name": "VAST Video",
+    "description": "Video ad via VAST tag (supports any duration)",
+    "type": "video",
+    "accepts_parameters": [
+      "duration"
+    ],
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "vast_tag",
+        "required": true,
+        "asset_type": "vast"
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING",
+      "VIDEO_ID",
+      "POD_POSITION",
+      "CONTENT_GENRE"
+    ],
+    "assets_required": [
+      {
+        "asset_id": "vast_tag",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "vast"
+      }
+    ],
+    "canonical": "video_vast"
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "video_standard_30s"
+    },
+    "name": "Standard Video - 30 seconds",
+    "description": "30-second video ad in standard aspect ratios",
+    "type": "video",
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "video_file",
+        "required": true,
+        "asset_type": "video",
+        "requirements": {
+          "min_duration_ms": 30000,
+          "max_duration_ms": 30000,
+          "containers": [
+            "mp4",
+            "mov",
+            "webm"
+          ],
+          "description": "30-second video file"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "tracker_pixel",
+          "description": "3rd party impression tracking pixel URL"
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING",
+      "VIDEO_ID",
+      "POD_POSITION",
+      "CONTENT_GENRE"
+    ],
+    "assets_required": [
+      {
+        "asset_id": "video_file",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "video",
+        "requirements": {
+          "min_duration_ms": 30000,
+          "max_duration_ms": 30000,
+          "containers": [
+            "mp4",
+            "mov",
+            "webm"
+          ],
+          "description": "30-second video file"
+        }
+      }
+    ],
+    "canonical": "video_hosted"
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "video_standard_15s"
+    },
+    "name": "Standard Video - 15 seconds",
+    "description": "15-second video ad in standard aspect ratios",
+    "type": "video",
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "video_file",
+        "required": true,
+        "asset_type": "video",
+        "requirements": {
+          "min_duration_ms": 15000,
+          "max_duration_ms": 15000,
+          "containers": [
+            "mp4",
+            "mov",
+            "webm"
+          ],
+          "description": "15-second video file"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "tracker_pixel",
+          "description": "3rd party impression tracking pixel URL"
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING",
+      "VIDEO_ID",
+      "POD_POSITION",
+      "CONTENT_GENRE"
+    ],
+    "assets_required": [
+      {
+        "asset_id": "video_file",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "video",
+        "requirements": {
+          "min_duration_ms": 15000,
+          "max_duration_ms": 15000,
+          "containers": [
+            "mp4",
+            "mov",
+            "webm"
+          ],
+          "description": "15-second video file"
+        }
+      }
+    ],
+    "canonical": "video_hosted"
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "video_vast_30s"
+    },
+    "name": "VAST Video - 30 seconds",
+    "description": "30-second video ad via VAST tag",
+    "type": "video",
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "vast_tag",
+        "required": true,
+        "asset_type": "vast",
+        "requirements": {
+          "description": "VAST 4.x compatible tag"
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING",
+      "VIDEO_ID",
+      "POD_POSITION",
+      "CONTENT_GENRE"
+    ],
+    "assets_required": [
+      {
+        "asset_id": "vast_tag",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "vast",
+        "requirements": {
+          "description": "VAST 4.x compatible tag"
+        }
+      }
+    ],
+    "canonical": "video_vast"
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "video_1920x1080"
+    },
+    "name": "Full HD Video - 1920x1080",
+    "description": "1920x1080 Full HD video (16:9)",
+    "type": "video",
+    "renders": [
+      {
+        "dimensions": {
+          "height": 1080,
+          "responsive": {
+            "height": false,
+            "width": false
+          },
+          "width": 1920
+        },
+        "role": "primary"
+      }
+    ],
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "video_file",
+        "required": true,
+        "asset_type": "video",
+        "requirements": {
+          "width": 1920,
+          "height": 1080,
+          "containers": [
+            "mp4",
+            "mov",
+            "webm"
+          ],
+          "description": "1920x1080 video file"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "tracker_pixel",
+          "description": "3rd party impression tracking pixel URL"
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING",
+      "VIDEO_ID",
+      "POD_POSITION",
+      "CONTENT_GENRE"
+    ],
+    "assets_required": [
+      {
+        "asset_id": "video_file",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "video",
+        "requirements": {
+          "width": 1920,
+          "height": 1080,
+          "containers": [
+            "mp4",
+            "mov",
+            "webm"
+          ],
+          "description": "1920x1080 video file"
+        }
+      }
+    ],
+    "canonical": "video_hosted"
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "video_1280x720"
+    },
+    "name": "HD Video - 1280x720",
+    "description": "1280x720 HD video (16:9)",
+    "type": "video",
+    "renders": [
+      {
+        "dimensions": {
+          "height": 720,
+          "responsive": {
+            "height": false,
+            "width": false
+          },
+          "width": 1280
+        },
+        "role": "primary"
+      }
+    ],
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "video_file",
+        "required": true,
+        "asset_type": "video",
+        "requirements": {
+          "width": 1280,
+          "height": 720,
+          "containers": [
+            "mp4",
+            "mov",
+            "webm"
+          ],
+          "description": "1280x720 video file"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "tracker_pixel",
+          "description": "3rd party impression tracking pixel URL"
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING",
+      "VIDEO_ID",
+      "POD_POSITION",
+      "CONTENT_GENRE"
+    ],
+    "assets_required": [
+      {
+        "asset_id": "video_file",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "video",
+        "requirements": {
+          "width": 1280,
+          "height": 720,
+          "containers": [
+            "mp4",
+            "mov",
+            "webm"
+          ],
+          "description": "1280x720 video file"
+        }
+      }
+    ],
+    "canonical": "video_hosted"
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "video_1080x1920"
+    },
+    "name": "Vertical Video - 1080x1920",
+    "description": "1080x1920 vertical video (9:16) for mobile stories",
+    "type": "video",
+    "renders": [
+      {
+        "dimensions": {
+          "height": 1920,
+          "responsive": {
+            "height": false,
+            "width": false
+          },
+          "width": 1080
+        },
+        "role": "primary"
+      }
+    ],
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "video_file",
+        "required": true,
+        "asset_type": "video",
+        "requirements": {
+          "width": 1080,
+          "height": 1920,
+          "containers": [
+            "mp4",
+            "mov",
+            "webm"
+          ],
+          "description": "1080x1920 vertical video file"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "tracker_pixel",
+          "description": "3rd party impression tracking pixel URL"
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING",
+      "VIDEO_ID",
+      "POD_POSITION",
+      "CONTENT_GENRE"
+    ],
+    "assets_required": [
+      {
+        "asset_id": "video_file",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "video",
+        "requirements": {
+          "width": 1080,
+          "height": 1920,
+          "containers": [
+            "mp4",
+            "mov",
+            "webm"
+          ],
+          "description": "1080x1920 vertical video file"
+        }
+      }
+    ],
+    "canonical": "video_hosted"
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "video_1080x1080"
+    },
+    "name": "Square Video - 1080x1080",
+    "description": "1080x1080 square video (1:1) for social feeds",
+    "type": "video",
+    "renders": [
+      {
+        "dimensions": {
+          "height": 1080,
+          "responsive": {
+            "height": false,
+            "width": false
+          },
+          "width": 1080
+        },
+        "role": "primary"
+      }
+    ],
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "video_file",
+        "required": true,
+        "asset_type": "video",
+        "requirements": {
+          "width": 1080,
+          "height": 1080,
+          "containers": [
+            "mp4",
+            "mov",
+            "webm"
+          ],
+          "description": "1080x1080 square video file"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "tracker_pixel",
+          "description": "3rd party impression tracking pixel URL"
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING",
+      "VIDEO_ID",
+      "POD_POSITION",
+      "CONTENT_GENRE"
+    ],
+    "assets_required": [
+      {
+        "asset_id": "video_file",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "video",
+        "requirements": {
+          "width": 1080,
+          "height": 1080,
+          "containers": [
+            "mp4",
+            "mov",
+            "webm"
+          ],
+          "description": "1080x1080 square video file"
+        }
+      }
+    ],
+    "canonical": "video_hosted"
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "video_ctv_preroll_30s"
+    },
+    "name": "CTV Pre-Roll - 30 seconds",
+    "description": "30-second pre-roll ad for Connected TV and streaming platforms",
+    "type": "video",
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "video_file",
+        "required": true,
+        "asset_type": "video",
+        "requirements": {
+          "min_duration_ms": 30000,
+          "max_duration_ms": 30000,
+          "containers": [
+            "mp4",
+            "mov"
+          ],
+          "description": "30-second CTV-optimized video file (1920x1080 recommended)"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "tracker_pixel",
+          "description": "3rd party impression tracking pixel URL"
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING",
+      "VIDEO_ID",
+      "POD_POSITION",
+      "CONTENT_GENRE",
+      "PLAYER_SIZE"
+    ],
+    "assets_required": [
+      {
+        "asset_id": "video_file",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "video",
+        "requirements": {
+          "min_duration_ms": 30000,
+          "max_duration_ms": 30000,
+          "containers": [
+            "mp4",
+            "mov"
+          ],
+          "description": "30-second CTV-optimized video file (1920x1080 recommended)"
+        }
+      }
+    ],
+    "canonical": "video_hosted"
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "video_ctv_midroll_30s"
+    },
+    "name": "CTV Mid-Roll - 30 seconds",
+    "description": "30-second mid-roll ad for Connected TV and streaming platforms",
+    "type": "video",
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "video_file",
+        "required": true,
+        "asset_type": "video",
+        "requirements": {
+          "min_duration_ms": 30000,
+          "max_duration_ms": 30000,
+          "containers": [
+            "mp4",
+            "mov"
+          ],
+          "description": "30-second CTV-optimized video file (1920x1080 recommended)"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "tracker_pixel",
+          "description": "3rd party impression tracking pixel URL"
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING",
+      "VIDEO_ID",
+      "POD_POSITION",
+      "CONTENT_GENRE",
+      "PLAYER_SIZE"
+    ],
+    "assets_required": [
+      {
+        "asset_id": "video_file",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "video",
+        "requirements": {
+          "min_duration_ms": 30000,
+          "max_duration_ms": 30000,
+          "containers": [
+            "mp4",
+            "mov"
+          ],
+          "description": "30-second CTV-optimized video file (1920x1080 recommended)"
+        }
+      }
+    ],
+    "canonical": "video_hosted"
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "broadcast_spot_15s"
+    },
+    "name": "Broadcast TV Spot - 15 seconds",
+    "description": "15-second broadcast television spot. H.264 HD video file delivered directly to station — no VAST, no impression tracking, no clickthrough.",
+    "type": "video",
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "video_file",
+        "required": true,
+        "asset_type": "video",
+        "requirements": {
+          "min_duration_ms": 15000,
+          "max_duration_ms": 15000,
+          "containers": [
+            "mp4",
+            "mov"
+          ],
+          "codecs": [
+            "h264"
+          ],
+          "min_width": 1920,
+          "max_width": 1920,
+          "min_height": 1080,
+          "max_height": 1080,
+          "min_bitrate_kbps": 15000,
+          "frame_rates": [
+            29.97,
+            30
+          ],
+          "frame_rate_type": "constant",
+          "scan_type": "progressive",
+          "gop_type": "closed",
+          "min_gop_interval_seconds": 1,
+          "max_gop_interval_seconds": 2,
+          "audio_required": true,
+          "audio_codecs": [
+            "aac",
+            "pcm"
+          ],
+          "audio_sample_rates": [
+            48000
+          ],
+          "audio_channels": [
+            "stereo"
+          ],
+          "loudness_lufs": -24,
+          "loudness_tolerance_db": 2,
+          "true_peak_dbfs": -2,
+          "description": "15-second broadcast spot file (1920x1080 HD)"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "captions_file",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "description": "Closed captions file (SRT or WebVTT)"
+        }
+      }
+    ],
+    "assets_required": [
+      {
+        "asset_id": "video_file",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "video",
+        "requirements": {
+          "min_duration_ms": 15000,
+          "max_duration_ms": 15000,
+          "containers": [
+            "mp4",
+            "mov"
+          ],
+          "codecs": [
+            "h264"
+          ],
+          "description": "15-second broadcast spot file (1920x1080 HD)"
+        }
+      }
+    ]
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "broadcast_spot_30s"
+    },
+    "name": "Broadcast TV Spot - 30 seconds",
+    "description": "30-second broadcast television spot. H.264 HD video file delivered directly to station — no VAST, no impression tracking, no clickthrough.",
+    "type": "video",
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "video_file",
+        "required": true,
+        "asset_type": "video",
+        "requirements": {
+          "min_duration_ms": 30000,
+          "max_duration_ms": 30000,
+          "containers": [
+            "mp4",
+            "mov"
+          ],
+          "codecs": [
+            "h264"
+          ],
+          "min_width": 1920,
+          "max_width": 1920,
+          "min_height": 1080,
+          "max_height": 1080,
+          "min_bitrate_kbps": 15000,
+          "frame_rates": [
+            29.97,
+            30
+          ],
+          "frame_rate_type": "constant",
+          "scan_type": "progressive",
+          "gop_type": "closed",
+          "min_gop_interval_seconds": 1,
+          "max_gop_interval_seconds": 2,
+          "audio_required": true,
+          "audio_codecs": [
+            "aac",
+            "pcm"
+          ],
+          "audio_sample_rates": [
+            48000
+          ],
+          "audio_channels": [
+            "stereo"
+          ],
+          "loudness_lufs": -24,
+          "loudness_tolerance_db": 2,
+          "true_peak_dbfs": -2,
+          "description": "30-second broadcast spot file (1920x1080 HD)"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "captions_file",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "description": "Closed captions file (SRT or WebVTT)"
+        }
+      }
+    ],
+    "assets_required": [
+      {
+        "asset_id": "video_file",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "video",
+        "requirements": {
+          "min_duration_ms": 30000,
+          "max_duration_ms": 30000,
+          "containers": [
+            "mp4",
+            "mov"
+          ],
+          "codecs": [
+            "h264"
+          ],
+          "description": "30-second broadcast spot file (1920x1080 HD)"
+        }
+      }
+    ]
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "broadcast_spot_60s"
+    },
+    "name": "Broadcast TV Spot - 60 seconds",
+    "description": "60-second broadcast television spot. H.264 HD video file delivered directly to station — no VAST, no impression tracking, no clickthrough.",
+    "type": "video",
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "video_file",
+        "required": true,
+        "asset_type": "video",
+        "requirements": {
+          "min_duration_ms": 60000,
+          "max_duration_ms": 60000,
+          "containers": [
+            "mp4",
+            "mov"
+          ],
+          "codecs": [
+            "h264"
+          ],
+          "min_width": 1920,
+          "max_width": 1920,
+          "min_height": 1080,
+          "max_height": 1080,
+          "min_bitrate_kbps": 15000,
+          "frame_rates": [
+            29.97,
+            30
+          ],
+          "frame_rate_type": "constant",
+          "scan_type": "progressive",
+          "gop_type": "closed",
+          "min_gop_interval_seconds": 1,
+          "max_gop_interval_seconds": 2,
+          "audio_required": true,
+          "audio_codecs": [
+            "aac",
+            "pcm"
+          ],
+          "audio_sample_rates": [
+            48000
+          ],
+          "audio_channels": [
+            "stereo"
+          ],
+          "loudness_lufs": -24,
+          "loudness_tolerance_db": 2,
+          "true_peak_dbfs": -2,
+          "description": "60-second broadcast spot file (1920x1080 HD)"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "captions_file",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "description": "Closed captions file (SRT or WebVTT)"
+        }
+      }
+    ],
+    "assets_required": [
+      {
+        "asset_id": "video_file",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "video",
+        "requirements": {
+          "min_duration_ms": 60000,
+          "max_duration_ms": 60000,
+          "containers": [
+            "mp4",
+            "mov"
+          ],
+          "codecs": [
+            "h264"
+          ],
+          "description": "60-second broadcast spot file (1920x1080 HD)"
+        }
+      }
+    ]
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "display_image"
+    },
+    "name": "Display Banner - Image",
+    "description": "Static image banner (supports any dimensions)",
+    "type": "display",
+    "accepts_parameters": [
+      "dimensions"
+    ],
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "banner_image",
+        "required": true,
+        "asset_type": "image",
+        "requirements": {
+          "containers": [
+            "jpg",
+            "png",
+            "gif",
+            "webp"
+          ]
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "click_url",
+        "required": true,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "clickthrough",
+          "description": "Clickthrough destination URL"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "tracker_pixel",
+          "description": "3rd party impression tracking pixel URL"
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING"
+    ],
+    "assets_required": [
+      {
+        "asset_id": "banner_image",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "image",
+        "requirements": {
+          "containers": [
+            "jpg",
+            "png",
+            "gif",
+            "webp"
+          ]
+        }
+      },
+      {
+        "asset_id": "click_url",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "clickthrough",
+          "description": "Clickthrough destination URL"
+        }
+      }
+    ],
+    "canonical": "image"
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "display_300x250_image"
+    },
+    "name": "Medium Rectangle - Image",
+    "description": "300x250 static image banner",
+    "type": "display",
+    "renders": [
+      {
+        "dimensions": {
+          "height": 250,
+          "responsive": {
+            "height": false,
+            "width": false
+          },
+          "width": 300
+        },
+        "role": "primary"
+      }
+    ],
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "banner_image",
+        "required": true,
+        "asset_type": "image",
+        "requirements": {
+          "width": 300,
+          "height": 250,
+          "max_file_size_mb": 0.2,
+          "containers": [
+            "jpg",
+            "png",
+            "gif",
+            "webp"
+          ]
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "click_url",
+        "required": true,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "clickthrough",
+          "description": "Clickthrough destination URL"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "tracker_pixel",
+          "description": "3rd party impression tracking pixel URL"
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING"
+    ],
+    "assets_required": [
+      {
+        "asset_id": "banner_image",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "image",
+        "requirements": {
+          "width": 300,
+          "height": 250,
+          "max_file_size_mb": 0.2,
+          "containers": [
+            "jpg",
+            "png",
+            "gif",
+            "webp"
+          ]
+        }
+      },
+      {
+        "asset_id": "click_url",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "clickthrough",
+          "description": "Clickthrough destination URL"
+        }
+      }
+    ],
+    "canonical": "image"
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "display_728x90_image"
+    },
+    "name": "Leaderboard - Image",
+    "description": "728x90 static image banner",
+    "type": "display",
+    "renders": [
+      {
+        "dimensions": {
+          "height": 90,
+          "responsive": {
+            "height": false,
+            "width": false
+          },
+          "width": 728
+        },
+        "role": "primary"
+      }
+    ],
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "banner_image",
+        "required": true,
+        "asset_type": "image",
+        "requirements": {
+          "width": 728,
+          "height": 90,
+          "max_file_size_mb": 0.15,
+          "containers": [
+            "jpg",
+            "png",
+            "gif",
+            "webp"
+          ]
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "click_url",
+        "required": true,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "clickthrough",
+          "description": "Clickthrough destination URL"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "tracker_pixel",
+          "description": "3rd party impression tracking pixel URL"
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING"
+    ],
+    "assets_required": [
+      {
+        "asset_id": "banner_image",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "image",
+        "requirements": {
+          "width": 728,
+          "height": 90,
+          "max_file_size_mb": 0.15,
+          "containers": [
+            "jpg",
+            "png",
+            "gif",
+            "webp"
+          ]
+        }
+      },
+      {
+        "asset_id": "click_url",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "clickthrough",
+          "description": "Clickthrough destination URL"
+        }
+      }
+    ],
+    "canonical": "image"
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "display_320x50_image"
+    },
+    "name": "Mobile Banner - Image",
+    "description": "320x50 mobile banner",
+    "type": "display",
+    "renders": [
+      {
+        "dimensions": {
+          "height": 50,
+          "responsive": {
+            "height": false,
+            "width": false
+          },
+          "width": 320
+        },
+        "role": "primary"
+      }
+    ],
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "banner_image",
+        "required": true,
+        "asset_type": "image",
+        "requirements": {
+          "width": 320,
+          "height": 50,
+          "max_file_size_mb": 0.05,
+          "containers": [
+            "jpg",
+            "png",
+            "gif",
+            "webp"
+          ]
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "click_url",
+        "required": true,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "clickthrough",
+          "description": "Clickthrough destination URL"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "tracker_pixel",
+          "description": "3rd party impression tracking pixel URL"
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING"
+    ],
+    "assets_required": [
+      {
+        "asset_id": "banner_image",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "image",
+        "requirements": {
+          "width": 320,
+          "height": 50,
+          "max_file_size_mb": 0.05,
+          "containers": [
+            "jpg",
+            "png",
+            "gif",
+            "webp"
+          ]
+        }
+      },
+      {
+        "asset_id": "click_url",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "clickthrough",
+          "description": "Clickthrough destination URL"
+        }
+      }
+    ],
+    "canonical": "image"
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "display_160x600_image"
+    },
+    "name": "Wide Skyscraper - Image",
+    "description": "160x600 wide skyscraper banner",
+    "type": "display",
+    "renders": [
+      {
+        "dimensions": {
+          "height": 600,
+          "responsive": {
+            "height": false,
+            "width": false
+          },
+          "width": 160
+        },
+        "role": "primary"
+      }
+    ],
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "banner_image",
+        "required": true,
+        "asset_type": "image",
+        "requirements": {
+          "width": 160,
+          "height": 600,
+          "max_file_size_mb": 0.15,
+          "containers": [
+            "jpg",
+            "png",
+            "gif",
+            "webp"
+          ]
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "click_url",
+        "required": true,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "clickthrough",
+          "description": "Clickthrough destination URL"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "tracker_pixel",
+          "description": "3rd party impression tracking pixel URL"
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING"
+    ],
+    "assets_required": [
+      {
+        "asset_id": "banner_image",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "image",
+        "requirements": {
+          "width": 160,
+          "height": 600,
+          "max_file_size_mb": 0.15,
+          "containers": [
+            "jpg",
+            "png",
+            "gif",
+            "webp"
+          ]
+        }
+      },
+      {
+        "asset_id": "click_url",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "clickthrough",
+          "description": "Clickthrough destination URL"
+        }
+      }
+    ],
+    "canonical": "image"
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "display_336x280_image"
+    },
+    "name": "Large Rectangle - Image",
+    "description": "336x280 large rectangle banner",
+    "type": "display",
+    "renders": [
+      {
+        "dimensions": {
+          "height": 280,
+          "responsive": {
+            "height": false,
+            "width": false
+          },
+          "width": 336
+        },
+        "role": "primary"
+      }
+    ],
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "banner_image",
+        "required": true,
+        "asset_type": "image",
+        "requirements": {
+          "width": 336,
+          "height": 280,
+          "max_file_size_mb": 0.25,
+          "containers": [
+            "jpg",
+            "png",
+            "gif",
+            "webp"
+          ]
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "click_url",
+        "required": true,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "clickthrough",
+          "description": "Clickthrough destination URL"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "tracker_pixel",
+          "description": "3rd party impression tracking pixel URL"
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING"
+    ],
+    "assets_required": [
+      {
+        "asset_id": "banner_image",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "image",
+        "requirements": {
+          "width": 336,
+          "height": 280,
+          "max_file_size_mb": 0.25,
+          "containers": [
+            "jpg",
+            "png",
+            "gif",
+            "webp"
+          ]
+        }
+      },
+      {
+        "asset_id": "click_url",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "clickthrough",
+          "description": "Clickthrough destination URL"
+        }
+      }
+    ],
+    "canonical": "image"
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "display_300x600_image"
+    },
+    "name": "Half Page - Image",
+    "description": "300x600 half page banner",
+    "type": "display",
+    "renders": [
+      {
+        "dimensions": {
+          "height": 600,
+          "responsive": {
+            "height": false,
+            "width": false
+          },
+          "width": 300
+        },
+        "role": "primary"
+      }
+    ],
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "banner_image",
+        "required": true,
+        "asset_type": "image",
+        "requirements": {
+          "width": 300,
+          "height": 600,
+          "max_file_size_mb": 0.3,
+          "containers": [
+            "jpg",
+            "png",
+            "gif",
+            "webp"
+          ]
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "click_url",
+        "required": true,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "clickthrough",
+          "description": "Clickthrough destination URL"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "tracker_pixel",
+          "description": "3rd party impression tracking pixel URL"
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING"
+    ],
+    "assets_required": [
+      {
+        "asset_id": "banner_image",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "image",
+        "requirements": {
+          "width": 300,
+          "height": 600,
+          "max_file_size_mb": 0.3,
+          "containers": [
+            "jpg",
+            "png",
+            "gif",
+            "webp"
+          ]
+        }
+      },
+      {
+        "asset_id": "click_url",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "clickthrough",
+          "description": "Clickthrough destination URL"
+        }
+      }
+    ],
+    "canonical": "image"
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "display_970x250_image"
+    },
+    "name": "Billboard - Image",
+    "description": "970x250 billboard banner",
+    "type": "display",
+    "renders": [
+      {
+        "dimensions": {
+          "height": 250,
+          "responsive": {
+            "height": false,
+            "width": false
+          },
+          "width": 970
+        },
+        "role": "primary"
+      }
+    ],
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "banner_image",
+        "required": true,
+        "asset_type": "image",
+        "requirements": {
+          "width": 970,
+          "height": 250,
+          "max_file_size_mb": 0.4,
+          "containers": [
+            "jpg",
+            "png",
+            "gif",
+            "webp"
+          ]
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "click_url",
+        "required": true,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "clickthrough",
+          "description": "Clickthrough destination URL"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "tracker_pixel",
+          "description": "3rd party impression tracking pixel URL"
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING"
+    ],
+    "assets_required": [
+      {
+        "asset_id": "banner_image",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "image",
+        "requirements": {
+          "width": 970,
+          "height": 250,
+          "max_file_size_mb": 0.4,
+          "containers": [
+            "jpg",
+            "png",
+            "gif",
+            "webp"
+          ]
+        }
+      },
+      {
+        "asset_id": "click_url",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "clickthrough",
+          "description": "Clickthrough destination URL"
+        }
+      }
+    ],
+    "canonical": "image"
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "display_html"
+    },
+    "name": "Display Banner - HTML5",
+    "description": "HTML5 creative (supports any dimensions)",
+    "type": "display",
+    "accepts_parameters": [
+      "dimensions"
+    ],
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "html_creative",
+        "required": true,
+        "asset_type": "html",
+        "requirements": {
+          "sandbox": "none",
+          "max_file_size_mb": 0.5
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "tracker_pixel",
+          "description": "3rd party impression tracking pixel URL"
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING"
+    ],
+    "assets_required": [
+      {
+        "asset_id": "html_creative",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "html",
+        "requirements": {
+          "sandbox": "none",
+          "max_file_size_mb": 0.5
+        }
+      }
+    ],
+    "canonical": "html5"
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "display_300x250_html"
+    },
+    "name": "Medium Rectangle - HTML5",
+    "description": "300x250 HTML5 creative",
+    "type": "display",
+    "renders": [
+      {
+        "dimensions": {
+          "height": 250,
+          "responsive": {
+            "height": false,
+            "width": false
+          },
+          "width": 300
+        },
+        "role": "primary"
+      }
+    ],
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "html_creative",
+        "required": true,
+        "asset_type": "html",
+        "requirements": {
+          "sandbox": "none",
+          "width": 300,
+          "height": 250,
+          "max_file_size_mb": 0.5,
+          "description": "HTML5 creative code"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "tracker_pixel",
+          "description": "3rd party impression tracking pixel URL"
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING"
+    ],
+    "assets_required": [
+      {
+        "asset_id": "html_creative",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "html",
+        "requirements": {
+          "sandbox": "none",
+          "width": 300,
+          "height": 250,
+          "max_file_size_mb": 0.5,
+          "description": "HTML5 creative code"
+        }
+      }
+    ],
+    "canonical": "html5"
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "display_728x90_html"
+    },
+    "name": "Leaderboard - HTML5",
+    "description": "728x90 HTML5 creative",
+    "type": "display",
+    "renders": [
+      {
+        "dimensions": {
+          "height": 90,
+          "responsive": {
+            "height": false,
+            "width": false
+          },
+          "width": 728
+        },
+        "role": "primary"
+      }
+    ],
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "html_creative",
+        "required": true,
+        "asset_type": "html",
+        "requirements": {
+          "sandbox": "none",
+          "width": 728,
+          "height": 90,
+          "max_file_size_mb": 0.5
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "tracker_pixel",
+          "description": "3rd party impression tracking pixel URL"
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING"
+    ],
+    "assets_required": [
+      {
+        "asset_id": "html_creative",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "html",
+        "requirements": {
+          "sandbox": "none",
+          "width": 728,
+          "height": 90,
+          "max_file_size_mb": 0.5
+        }
+      }
+    ],
+    "canonical": "html5"
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "display_160x600_html"
+    },
+    "name": "Wide Skyscraper - HTML5",
+    "description": "160x600 HTML5 creative",
+    "type": "display",
+    "renders": [
+      {
+        "dimensions": {
+          "height": 600,
+          "responsive": {
+            "height": false,
+            "width": false
+          },
+          "width": 160
+        },
+        "role": "primary"
+      }
+    ],
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "html_creative",
+        "required": true,
+        "asset_type": "html",
+        "requirements": {
+          "sandbox": "none",
+          "width": 160,
+          "height": 600,
+          "max_file_size_mb": 0.5
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "tracker_pixel",
+          "description": "3rd party impression tracking pixel URL"
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING"
+    ],
+    "assets_required": [
+      {
+        "asset_id": "html_creative",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "html",
+        "requirements": {
+          "sandbox": "none",
+          "width": 160,
+          "height": 600,
+          "max_file_size_mb": 0.5
+        }
+      }
+    ],
+    "canonical": "html5"
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "display_336x280_html"
+    },
+    "name": "Large Rectangle - HTML5",
+    "description": "336x280 HTML5 creative",
+    "type": "display",
+    "renders": [
+      {
+        "dimensions": {
+          "height": 280,
+          "responsive": {
+            "height": false,
+            "width": false
+          },
+          "width": 336
+        },
+        "role": "primary"
+      }
+    ],
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "html_creative",
+        "required": true,
+        "asset_type": "html",
+        "requirements": {
+          "sandbox": "none",
+          "width": 336,
+          "height": 280,
+          "max_file_size_mb": 0.5
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "tracker_pixel",
+          "description": "3rd party impression tracking pixel URL"
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING"
+    ],
+    "assets_required": [
+      {
+        "asset_id": "html_creative",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "html",
+        "requirements": {
+          "sandbox": "none",
+          "width": 336,
+          "height": 280,
+          "max_file_size_mb": 0.5
+        }
+      }
+    ],
+    "canonical": "html5"
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "display_300x600_html"
+    },
+    "name": "Half Page - HTML5",
+    "description": "300x600 HTML5 creative",
+    "type": "display",
+    "renders": [
+      {
+        "dimensions": {
+          "height": 600,
+          "responsive": {
+            "height": false,
+            "width": false
+          },
+          "width": 300
+        },
+        "role": "primary"
+      }
+    ],
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "html_creative",
+        "required": true,
+        "asset_type": "html",
+        "requirements": {
+          "sandbox": "none",
+          "width": 300,
+          "height": 600,
+          "max_file_size_mb": 0.5
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "tracker_pixel",
+          "description": "3rd party impression tracking pixel URL"
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING"
+    ],
+    "assets_required": [
+      {
+        "asset_id": "html_creative",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "html",
+        "requirements": {
+          "sandbox": "none",
+          "width": 300,
+          "height": 600,
+          "max_file_size_mb": 0.5
+        }
+      }
+    ],
+    "canonical": "html5"
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "display_970x250_html"
+    },
+    "name": "Billboard - HTML5",
+    "description": "970x250 HTML5 creative",
+    "type": "display",
+    "renders": [
+      {
+        "dimensions": {
+          "height": 250,
+          "responsive": {
+            "height": false,
+            "width": false
+          },
+          "width": 970
+        },
+        "role": "primary"
+      }
+    ],
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "html_creative",
+        "required": true,
+        "asset_type": "html",
+        "requirements": {
+          "sandbox": "none",
+          "width": 970,
+          "height": 250,
+          "max_file_size_mb": 0.5
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "tracker_pixel",
+          "description": "3rd party impression tracking pixel URL"
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING"
+    ],
+    "assets_required": [
+      {
+        "asset_id": "html_creative",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "html",
+        "requirements": {
+          "sandbox": "none",
+          "width": 970,
+          "height": 250,
+          "max_file_size_mb": 0.5
+        }
+      }
+    ],
+    "canonical": "html5"
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "display_js"
+    },
+    "name": "Display Banner - JavaScript",
+    "description": "JavaScript-based display ad (supports any dimensions)",
+    "type": "display",
+    "accepts_parameters": [
+      "dimensions"
+    ],
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "js_creative",
+        "required": true,
+        "asset_type": "javascript"
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "tracker_pixel",
+          "description": "3rd party impression tracking pixel URL"
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING"
+    ],
+    "assets_required": [
+      {
+        "asset_id": "js_creative",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "javascript"
+      }
+    ],
+    "canonical": "display_tag"
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "native_standard"
+    },
+    "name": "IAB Native Standard",
+    "description": "Standard native ad with title, description, image, and CTA",
+    "type": "native",
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "title",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Headline text (25 chars recommended)"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "description",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Body copy (90 chars recommended)"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "main_image",
+        "required": true,
+        "asset_type": "image",
+        "requirements": {
+          "description": "Primary image (1200x627 recommended)"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "icon",
+        "required": false,
+        "asset_type": "image",
+        "requirements": {
+          "description": "Brand icon (square, 200x200 recommended)"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "cta_text",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Call-to-action text"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "sponsored_by",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Advertiser name for disclosure"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "tracker_pixel",
+          "description": "3rd party impression tracking pixel URL"
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING"
+    ],
+    "assets_required": [
+      {
+        "asset_id": "title",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Headline text (25 chars recommended)"
+        }
+      },
+      {
+        "asset_id": "description",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Body copy (90 chars recommended)"
+        }
+      },
+      {
+        "asset_id": "main_image",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "image",
+        "requirements": {
+          "description": "Primary image (1200x627 recommended)"
+        }
+      },
+      {
+        "asset_id": "cta_text",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Call-to-action text"
+        }
+      },
+      {
+        "asset_id": "sponsored_by",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Advertiser name for disclosure"
+        }
+      }
+    ]
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "native_content"
+    },
+    "name": "Native Content Placement",
+    "description": "In-article native ad with editorial styling",
+    "type": "native",
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "headline",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Editorial-style headline (60 chars recommended)"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "body",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Article-style body copy (200 chars recommended)"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "thumbnail",
+        "required": true,
+        "asset_type": "image",
+        "requirements": {
+          "description": "Thumbnail image (square, 300x300 recommended)"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "author",
+        "required": false,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Author name for editorial context"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "click_url",
+        "required": true,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "clickthrough",
+          "description": "Clickthrough destination URL"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "disclosure",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Sponsored content disclosure text"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "tracker_pixel",
+          "description": "3rd party impression tracking pixel URL"
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING"
+    ],
+    "assets_required": [
+      {
+        "asset_id": "headline",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Editorial-style headline (60 chars recommended)"
+        }
+      },
+      {
+        "asset_id": "body",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Article-style body copy (200 chars recommended)"
+        }
+      },
+      {
+        "asset_id": "thumbnail",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "image",
+        "requirements": {
+          "description": "Thumbnail image (square, 300x300 recommended)"
+        }
+      },
+      {
+        "asset_id": "click_url",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "clickthrough",
+          "description": "Clickthrough destination URL"
+        }
+      },
+      {
+        "asset_id": "disclosure",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Sponsored content disclosure text"
+        }
+      }
+    ]
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "audio_standard_15s"
+    },
+    "name": "Standard Audio - 15 seconds",
+    "description": "15-second audio ad",
+    "type": "audio",
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "audio_file",
+        "required": true,
+        "asset_type": "audio",
+        "requirements": {
+          "min_duration_ms": 15000,
+          "max_duration_ms": 15000,
+          "containers": [
+            "mp3",
+            "aac",
+            "m4a"
+          ]
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "tracker_pixel",
+          "description": "3rd party impression tracking pixel URL"
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING",
+      "CONTENT_GENRE"
+    ],
+    "assets_required": [
+      {
+        "asset_id": "audio_file",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "audio",
+        "requirements": {
+          "min_duration_ms": 15000,
+          "max_duration_ms": 15000,
+          "containers": [
+            "mp3",
+            "aac",
+            "m4a"
+          ]
+        }
+      }
+    ],
+    "canonical": "audio_hosted"
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "audio_standard_30s"
+    },
+    "name": "Standard Audio - 30 seconds",
+    "description": "30-second audio ad",
+    "type": "audio",
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "audio_file",
+        "required": true,
+        "asset_type": "audio",
+        "requirements": {
+          "min_duration_ms": 30000,
+          "max_duration_ms": 30000,
+          "containers": [
+            "mp3",
+            "aac",
+            "m4a"
+          ]
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "tracker_pixel",
+          "description": "3rd party impression tracking pixel URL"
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING",
+      "CONTENT_GENRE"
+    ],
+    "assets_required": [
+      {
+        "asset_id": "audio_file",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "audio",
+        "requirements": {
+          "min_duration_ms": 30000,
+          "max_duration_ms": 30000,
+          "containers": [
+            "mp3",
+            "aac",
+            "m4a"
+          ]
+        }
+      }
+    ],
+    "canonical": "audio_hosted"
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "audio_standard_60s"
+    },
+    "name": "Standard Audio - 60 seconds",
+    "description": "60-second audio ad",
+    "type": "audio",
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "audio_file",
+        "required": true,
+        "asset_type": "audio",
+        "requirements": {
+          "min_duration_ms": 60000,
+          "max_duration_ms": 60000,
+          "containers": [
+            "mp3",
+            "aac",
+            "m4a"
+          ]
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "tracker_pixel",
+          "description": "3rd party impression tracking pixel URL"
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING",
+      "CONTENT_GENRE"
+    ],
+    "assets_required": [
+      {
+        "asset_id": "audio_file",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "audio",
+        "requirements": {
+          "min_duration_ms": 60000,
+          "max_duration_ms": 60000,
+          "containers": [
+            "mp3",
+            "aac",
+            "m4a"
+          ]
+        }
+      }
+    ],
+    "canonical": "audio_hosted"
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "dooh_billboard_1920x1080"
+    },
+    "name": "Digital Billboard - 1920x1080",
+    "description": "Full HD digital billboard",
+    "type": "dooh",
+    "renders": [
+      {
+        "dimensions": {
+          "height": 1080,
+          "responsive": {
+            "height": false,
+            "width": false
+          },
+          "width": 1920
+        },
+        "role": "primary"
+      }
+    ],
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "billboard_image",
+        "required": true,
+        "asset_type": "image",
+        "requirements": {
+          "width": 1920,
+          "height": 1080,
+          "containers": [
+            "jpg",
+            "png"
+          ]
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "tracker_pixel",
+          "description": "3rd party impression tracking pixel URL"
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING",
+      "SCREEN_ID",
+      "VENUE_TYPE",
+      "VENUE_LAT",
+      "VENUE_LONG"
+    ],
+    "assets_required": [
+      {
+        "asset_id": "billboard_image",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "image",
+        "requirements": {
+          "width": 1920,
+          "height": 1080,
+          "containers": [
+            "jpg",
+            "png"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "dooh_billboard_landscape"
+    },
+    "name": "Digital Billboard - Landscape",
+    "description": "Landscape-oriented digital billboard (various sizes)",
+    "type": "dooh",
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "billboard_image",
+        "required": true,
+        "asset_type": "image",
+        "requirements": {
+          "containers": [
+            "jpg",
+            "png"
+          ],
+          "description": "Landscape image (1920x1080 or larger)"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "tracker_pixel",
+          "description": "3rd party impression tracking pixel URL"
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING",
+      "SCREEN_ID",
+      "VENUE_TYPE",
+      "VENUE_LAT",
+      "VENUE_LONG"
+    ],
+    "assets_required": [
+      {
+        "asset_id": "billboard_image",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "image",
+        "requirements": {
+          "containers": [
+            "jpg",
+            "png"
+          ],
+          "description": "Landscape image (1920x1080 or larger)"
+        }
+      }
+    ]
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "dooh_billboard_portrait"
+    },
+    "name": "Digital Billboard - Portrait",
+    "description": "Portrait-oriented digital billboard (various sizes)",
+    "type": "dooh",
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "billboard_image",
+        "required": true,
+        "asset_type": "image",
+        "requirements": {
+          "containers": [
+            "jpg",
+            "png"
+          ],
+          "description": "Portrait image (1080x1920 or similar)"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "tracker_pixel",
+          "description": "3rd party impression tracking pixel URL"
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING",
+      "SCREEN_ID",
+      "VENUE_TYPE",
+      "VENUE_LAT",
+      "VENUE_LONG"
+    ],
+    "assets_required": [
+      {
+        "asset_id": "billboard_image",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "image",
+        "requirements": {
+          "containers": [
+            "jpg",
+            "png"
+          ],
+          "description": "Portrait image (1080x1920 or similar)"
+        }
+      }
+    ]
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "dooh_transit_screen"
+    },
+    "name": "Transit Screen",
+    "description": "Transit and subway screen displays",
+    "type": "dooh",
+    "renders": [
+      {
+        "dimensions": {
+          "height": 1080,
+          "responsive": {
+            "height": false,
+            "width": false
+          },
+          "width": 1920
+        },
+        "role": "primary"
+      }
+    ],
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "screen_image",
+        "required": true,
+        "asset_type": "image",
+        "requirements": {
+          "width": 1920,
+          "height": 1080,
+          "containers": [
+            "jpg",
+            "png"
+          ],
+          "description": "Transit screen content"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "tracker_pixel",
+          "description": "3rd party impression tracking pixel URL"
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING",
+      "SCREEN_ID",
+      "VENUE_TYPE",
+      "VENUE_LAT",
+      "VENUE_LONG",
+      "TRANSIT_LINE"
+    ],
+    "assets_required": [
+      {
+        "asset_id": "screen_image",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "image",
+        "requirements": {
+          "width": 1920,
+          "height": 1080,
+          "containers": [
+            "jpg",
+            "png"
+          ],
+          "description": "Transit screen content"
+        }
+      }
+    ]
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "product_card_standard"
+    },
+    "name": "Product Card - Standard",
+    "description": "Standard visual card (300x400px) for displaying ad inventory products",
+    "type": "display",
+    "renders": [
+      {
+        "dimensions": {
+          "height": 400,
+          "responsive": {
+            "height": false,
+            "width": false
+          },
+          "width": 300
+        },
+        "role": "primary"
+      }
+    ],
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "product_image",
+        "required": true,
+        "asset_type": "image",
+        "requirements": {
+          "description": "Primary product image or placement preview"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "product_name",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Display name of the product (e.g., 'Homepage Leaderboard')"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "product_description",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Short description of the product (supports markdown)"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "pricing_model",
+        "required": false,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Pricing model (e.g., 'CPM', 'flat_rate', 'CPC')"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "pricing_amount",
+        "required": false,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Price amount (e.g., '15.00')"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "pricing_currency",
+        "required": false,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Currency code (e.g., 'USD')"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "delivery_type",
+        "required": false,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Delivery type: 'guaranteed' or 'bidded'"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "primary_asset_type",
+        "required": false,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Primary asset type: 'display', 'video', 'audio', 'native'"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "publisher_name",
+        "required": false,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Publisher or property name (e.g., 'Pinnacle News Group')"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "audience_summary",
+        "required": false,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Audience summary (e.g., 'Adults 25-54, 8M monthly uniques')"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "estimated_volume",
+        "required": false,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Estimated available impressions (e.g., '~2M impressions/month')"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "click_url",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "description": "Click-through URL for the product card (e.g., product detail page)"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "tracker_pixel",
+          "description": "3rd party impression tracking pixel URL"
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING"
+    ],
+    "assets_required": [
+      {
+        "asset_id": "product_image",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "image",
+        "requirements": {
+          "description": "Primary product image or placement preview"
+        }
+      },
+      {
+        "asset_id": "product_name",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Display name of the product (e.g., 'Homepage Leaderboard')"
+        }
+      },
+      {
+        "asset_id": "product_description",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Short description of the product (supports markdown)"
+        }
+      }
+    ]
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "product_card_detailed"
+    },
+    "name": "Product Card - Detailed",
+    "description": "Detailed card with carousel and full specifications for rich product presentation",
+    "type": "display",
+    "renders": [
+      {
+        "dimensions": {
+          "responsive": {
+            "height": true,
+            "width": true
+          }
+        },
+        "role": "primary"
+      }
+    ],
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "product_image",
+        "required": true,
+        "asset_type": "image",
+        "requirements": {
+          "description": "Primary product image or placement preview"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "product_name",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Display name of the product (e.g., 'Homepage Leaderboard')"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "product_description",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Detailed description of the product (supports markdown)"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "pricing_model",
+        "required": false,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Pricing model (e.g., 'CPM', 'flat_rate', 'CPC')"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "pricing_amount",
+        "required": false,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Price amount (e.g., '15.00')"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "pricing_currency",
+        "required": false,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Currency code (e.g., 'USD')"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "delivery_type",
+        "required": false,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Delivery type: 'guaranteed' or 'bidded'"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "primary_asset_type",
+        "required": false,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Primary asset type: 'display', 'video', 'audio', 'native'"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "publisher_name",
+        "required": false,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Publisher or property name (e.g., 'Pinnacle News Group')"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "audience_summary",
+        "required": false,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Audience summary (e.g., 'Adults 25-54, 8M monthly uniques')"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "estimated_volume",
+        "required": false,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Estimated available impressions (e.g., '~2M impressions/month')"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "click_url",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "description": "Click-through URL for the product card (e.g., product detail page)"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "tracker_pixel",
+          "description": "3rd party impression tracking pixel URL"
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING"
+    ],
+    "assets_required": [
+      {
+        "asset_id": "product_image",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "image",
+        "requirements": {
+          "description": "Primary product image or placement preview"
+        }
+      },
+      {
+        "asset_id": "product_name",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Display name of the product (e.g., 'Homepage Leaderboard')"
+        }
+      },
+      {
+        "asset_id": "product_description",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Detailed description of the product (supports markdown)"
+        }
+      }
+    ]
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "proposal_card_standard"
+    },
+    "name": "Proposal Card - Standard",
+    "description": "Standard visual card (300x400px) for displaying media plan proposals with allocation bars and budget guidance",
+    "type": "display",
+    "renders": [
+      {
+        "dimensions": {
+          "height": 400,
+          "responsive": {
+            "height": false,
+            "width": false
+          },
+          "width": 300
+        },
+        "role": "primary"
+      }
+    ],
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "proposal_name",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Display name of the proposal"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "proposal_description",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Short description of the proposal"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "allocation_data",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "JSON array of allocations: [{product_id, allocation_percentage, rationale}]"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "budget_min",
+        "required": false,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Minimum budget amount (e.g., '25000')"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "budget_recommended",
+        "required": false,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Recommended budget amount (e.g., '75000')"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "budget_currency",
+        "required": false,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Currency code (e.g., 'USD')"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "brief_alignment",
+        "required": false,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Narrative explanation of how the proposal aligns with the brief"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "proposal_status",
+        "required": false,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Proposal status: 'draft' or 'committed'"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "publisher_name",
+        "required": false,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Publisher or network name (e.g., 'Pinnacle News Group')"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "estimated_delivery",
+        "required": false,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Estimated delivery summary (e.g., 'Est. 3.2M impressions, 1.8M reach')"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "proposal_image",
+        "required": false,
+        "asset_type": "image",
+        "requirements": {
+          "description": "Hero image for the proposal card header"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "click_url",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "description": "Click-through URL for the proposal card (e.g., interactive proposal page)"
+        }
+      }
+    ],
+    "assets_required": [
+      {
+        "asset_id": "proposal_name",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Display name of the proposal"
+        }
+      },
+      {
+        "asset_id": "proposal_description",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Short description of the proposal"
+        }
+      },
+      {
+        "asset_id": "allocation_data",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "JSON array of allocations: [{product_id, allocation_percentage, rationale}]"
+        }
+      }
+    ]
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "proposal_card_detailed"
+    },
+    "name": "Proposal Card - Detailed",
+    "description": "Detailed card with full allocation breakdown, rationale, and budget for rich proposal presentation",
+    "type": "display",
+    "renders": [
+      {
+        "dimensions": {
+          "responsive": {
+            "height": true,
+            "width": true
+          }
+        },
+        "role": "primary"
+      }
+    ],
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "proposal_name",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Display name of the proposal"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "proposal_description",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Detailed description of the proposal"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "allocation_data",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "JSON array of allocations: [{product_id, allocation_percentage, rationale}]"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "budget_min",
+        "required": false,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Minimum budget amount (e.g., '25000')"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "budget_recommended",
+        "required": false,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Recommended budget amount (e.g., '75000')"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "budget_currency",
+        "required": false,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Currency code (e.g., 'USD')"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "brief_alignment",
+        "required": false,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Narrative explanation of how the proposal aligns with the brief"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "proposal_status",
+        "required": false,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Proposal status: 'draft' or 'committed'"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "publisher_name",
+        "required": false,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Publisher or network name (e.g., 'Pinnacle News Group')"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "estimated_delivery",
+        "required": false,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Estimated delivery summary (e.g., 'Est. 3.2M impressions, 1.8M reach')"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "proposal_image",
+        "required": false,
+        "asset_type": "image",
+        "requirements": {
+          "description": "Hero image for the proposal card header"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "click_url",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "description": "Click-through URL for the proposal card (e.g., interactive proposal page)"
+        }
+      }
+    ],
+    "assets_required": [
+      {
+        "asset_id": "proposal_name",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Display name of the proposal"
+        }
+      },
+      {
+        "asset_id": "proposal_description",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Detailed description of the proposal"
+        }
+      },
+      {
+        "asset_id": "allocation_data",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "JSON array of allocations: [{product_id, allocation_percentage, rationale}]"
+        }
+      }
+    ]
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "format_card_standard"
+    },
+    "name": "Format Card - Standard",
+    "description": "Standard visual card (300x400px) for displaying creative formats in user interfaces",
+    "type": "display",
+    "renders": [
+      {
+        "dimensions": {
+          "height": 400,
+          "responsive": {
+            "height": false,
+            "width": false
+          },
+          "width": 300
+        },
+        "role": "primary"
+      }
+    ],
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "format",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Creative format specification to visualize on the card"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "tracker_pixel",
+          "description": "3rd party impression tracking pixel URL"
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING"
+    ],
+    "assets_required": [
+      {
+        "asset_id": "format",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Creative format specification to visualize on the card"
+        }
+      }
+    ]
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "format_card_detailed"
+    },
+    "name": "Format Card - Detailed",
+    "description": "Detailed card with carousel and full specifications for rich format documentation",
+    "type": "display",
+    "renders": [
+      {
+        "dimensions": {
+          "responsive": {
+            "height": true,
+            "width": true
+          }
+        },
+        "role": "primary"
+      }
+    ],
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "format",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Creative format specification with full details for detailed card"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "tracker_pixel",
+          "description": "3rd party impression tracking pixel URL"
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING"
+    ],
+    "assets_required": [
+      {
+        "asset_id": "format",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Creative format specification with full details for detailed card"
+        }
+      }
+    ]
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "sponsored_recommendation"
+    },
+    "name": "Sponsored Recommendation",
+    "description": "AI assistant sponsored recommendation woven into the conversation response. The LLM integrates the brand message naturally into its reply.",
+    "type": "native",
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "headline",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Short headline for the recommendation (50 chars max)"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "body",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Body text describing the product or service. The AI assistant may paraphrase this to fit the conversation tone."
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "cta_text",
+        "required": false,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Call-to-action text (e.g., 'Shop now', 'Learn more')"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "cta_url",
+        "required": true,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "clickthrough",
+          "description": "Destination URL for the recommendation"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "image",
+        "required": false,
+        "asset_type": "image",
+        "requirements": {
+          "description": "Product or brand image (square, 400x400 recommended)"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "sponsored_by",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Sponsor attribution text (e.g., 'Sponsored by Meridian Foods')"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "tracker_pixel",
+          "description": "Impression tracking pixel URL"
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL"
+    ],
+    "canonical": "sponsored_placement"
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "native_product_card"
+    },
+    "name": "Native Product Card",
+    "description": "Product card for AI assistants and retail media surfaces. Displays a product with image, price, and catalog items. Rendered as a card within the conversation or search results.",
+    "type": "native",
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "headline",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Product or offer headline (60 chars max)"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "body",
+        "required": false,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Product description or promotional text"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "image",
+        "required": true,
+        "asset_type": "image",
+        "requirements": {
+          "description": "Product image (square, 800x800 recommended)"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "price",
+        "required": false,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Display price (e.g., '$24.99', 'From $12/mo')"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "cta_text",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Call-to-action text"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "cta_url",
+        "required": true,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "clickthrough",
+          "description": "Product page URL"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "sponsored_by",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Sponsor attribution text"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "badge",
+        "required": false,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Promotional badge (e.g., 'SALE', 'NEW', 'BEST SELLER')"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "tracker_pixel",
+          "description": "Impression tracking pixel URL"
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL"
+    ],
+    "catalog_requirements": [
+      {
+        "catalog_type": "product",
+        "required": false,
+        "required_fields": [
+          "name"
+        ]
+      }
+    ]
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "native_mention"
+    },
+    "name": "Native Brand Mention",
+    "description": "Minimal brand mention for AI assistants. A single line referencing the brand, suitable for light integration where a full product card would be intrusive.",
+    "type": "native",
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "mention_text",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Brand mention text (100 chars max). Should read naturally in conversation context."
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "cta_url",
+        "required": true,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "clickthrough",
+          "description": "Destination URL if user clicks the mention"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "sponsored_by",
+        "required": true,
+        "asset_type": "text",
+        "requirements": {
+          "description": "Sponsor attribution text"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "tracker_pixel",
+          "description": "Impression tracking pixel URL"
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL"
+    ]
+  }
+]

--- a/test/lib/v2-projection-fixtures/amazon_sponsored_products.json
+++ b/test/lib/v2-projection-fixtures/amazon_sponsored_products.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "/schemas/core/product.json",
+  "product_id": "amazon_sp_search",
+  "name": "Amazon Sponsored Products — Search",
+  "description": "Catalog-driven sponsored product placement in Amazon search results. Buyer supplies a product catalog with ASINs; Amazon's surface composes per-item rendering (product image + title + price + rating + Prime badge) using its native placement template. Composition is deterministic — buyer can predict per-slot rendering from the catalog item structure. No buyer creative slots; the catalog reference is the entire input.",
+  "publisher_properties": [
+    {
+      "publisher_domain": "amazon.com",
+      "selection_type": "all"
+    }
+  ],
+  "channels": [
+    "retail_media"
+  ],
+  "delivery_type": "non_guaranteed",
+  "pricing_options": [
+    {
+      "pricing_option_id": "cpc_auction",
+      "pricing_model": "cpc",
+      "currency": "USD",
+      "floor_price": 0.5
+    }
+  ],
+  "reporting_capabilities": {
+    "available_reporting_frequencies": [
+      "hourly",
+      "daily"
+    ],
+    "expected_delay_minutes": 60,
+    "timezone": "America/Los_Angeles",
+    "supports_webhooks": true,
+    "available_metrics": [
+      "impressions",
+      "clicks",
+      "spend",
+      "ctr",
+      "conversions",
+      "conversion_value",
+      "roas",
+      "new_to_brand_rate"
+    ],
+    "date_range_support": "date_range"
+  },
+  "format_options": [
+    {
+      "format_kind": "sponsored_placement",
+      "params": {
+        "supported_catalog_types": [
+          "product"
+        ],
+        "min_items": 1,
+        "max_items": 50,
+        "fanout_mode": "per_item",
+        "required_catalog_fields": [
+          "title",
+          "image_url",
+          "price"
+        ],
+        "supported_id_types": [
+          "asin"
+        ],
+        "hero_asset_supported": false,
+        "composition_model": "deterministic"
+      }
+    }
+  ]
+}

--- a/test/lib/v2-projection-fixtures/chatgpt_brand_mention.json
+++ b/test/lib/v2-projection-fixtures/chatgpt_brand_mention.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "/schemas/core/product.json",
+  "product_id": "openai_chatgpt_sponsored_mention_us",
+  "name": "ChatGPT Sponsored Brand Mention — United States",
+  "description": "AI-surface sponsored placement on ChatGPT. Buyer supplies a BrandRef (resolving brand.json for context) plus optional offering reference; ChatGPT composes a natural-language sponsored mention within its response to a relevant user query. Composition is algorithmic — the agent chooses phrasing and presentation, with disclosure required and no buyer-fixed creative. Distinct from si_chat (which is the user-converses-with-brand's-agent pattern, brand-owned conversational surface). Parallels sponsored_placement structurally (both surface-composed) but for AI/agentic surfaces rather than retail-media catalog.",
+  "publisher_properties": [
+    {
+      "publisher_domain": "openai.com",
+      "selection_type": "all"
+    }
+  ],
+  "channels": [
+    "sponsored_intelligence"
+  ],
+  "delivery_type": "non_guaranteed",
+  "pricing_options": [
+    {
+      "pricing_option_id": "cpm_mention",
+      "pricing_model": "cpm",
+      "currency": "USD",
+      "floor_price": 18
+    }
+  ],
+  "reporting_capabilities": {
+    "available_reporting_frequencies": [
+      "daily"
+    ],
+    "expected_delay_minutes": 1440,
+    "timezone": "UTC",
+    "supports_webhooks": false,
+    "available_metrics": [
+      "impressions",
+      "clicks",
+      "spend",
+      "ctr",
+      "engagement_rate"
+    ],
+    "date_range_support": "date_range"
+  },
+  "format_options": [
+    {
+      "format_kind": "agent_placement",
+      "params": {
+        "output_modality": "text",
+        "max_mention_length_chars": 280,
+        "supports_offering_reference": true,
+        "supports_landing_page_url": true,
+        "tone_constraints": [
+          "factual",
+          "no_superlatives"
+        ],
+        "disclosure_required": true,
+        "composition_model": "algorithmic",
+        "slots": [
+          {
+            "asset_group_id": "offering_ref",
+            "required": false,
+            "asset_type": "text",
+            "description": "Optional offering identifier to focus the mention on a specific product, service, or campaign within the brand."
+          },
+          {
+            "asset_group_id": "landing_page_url",
+            "required": false,
+            "asset_type": "url",
+            "description": "Optional URL the surface MAY attach to mentions as a citation or learn-more link."
+          }
+        ],
+        "platform_extensions": [
+          {
+            "uri": "https://openai.adcp/extensions/chatgpt_response_card",
+            "digest": "sha256:f3a6c9b2e5d8f1a4c7b0e3d6f9a2c5b8e1d4f7a0c3b6e9d2f5a8c1b4e7d0f3a6"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/test/lib/v2-projection-fixtures/chatgpt_brand_mention.json
+++ b/test/lib/v2-projection-fixtures/chatgpt_brand_mention.json
@@ -67,7 +67,7 @@
         ],
         "platform_extensions": [
           {
-            "uri": "https://openai.example/extensions/chatgpt_response_card",
+            "uri": "https://creative.adcontextprotocol.org/translated/openai/extensions/chatgpt_response_card",
             "digest": "sha256:f3a6c9b2e5d8f1a4c7b0e3d6f9a2c5b8e1d4f7a0c3b6e9d2f5a8c1b4e7d0f3a6"
           }
         ]

--- a/test/lib/v2-projection-fixtures/chatgpt_brand_mention.json
+++ b/test/lib/v2-projection-fixtures/chatgpt_brand_mention.json
@@ -67,7 +67,7 @@
         ],
         "platform_extensions": [
           {
-            "uri": "https://openai.adcp/extensions/chatgpt_response_card",
+            "uri": "https://openai.example/extensions/chatgpt_response_card",
             "digest": "sha256:f3a6c9b2e5d8f1a4c7b0e3d6f9a2c5b8e1d4f7a0c3b6e9d2f5a8c1b4e7d0f3a6"
           }
         ]

--- a/test/lib/v2-projection-fixtures/gam_3p_display_tag.json
+++ b/test/lib/v2-projection-fixtures/gam_3p_display_tag.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "/schemas/core/product.json",
+  "product_id": "gam_publisher_3p_display_tag_300x250",
+  "name": "GAM Publisher — 3P Display Tag (300×250)",
+  "description": "Third-party-served display tag (JS or iframe) on a GAM-managed publisher placement. Buyer's adserver hosts the creative; the publisher calls the tag URL at impression time. 200KB max-snippet-size and a runtime allowlist (no eval, no document.write, no setTimeout, no javascript: / data: URLs in click trackers) apply at the GAM level — these are publisher-policy constraints, not protocol-level.",
+  "publisher_properties": [
+    {
+      "publisher_domain": "examplepublisher.example",
+      "selection_type": "all"
+    }
+  ],
+  "channels": [
+    "display"
+  ],
+  "delivery_type": "non_guaranteed",
+  "pricing_options": [
+    {
+      "pricing_option_id": "cpm_floor",
+      "pricing_model": "cpm",
+      "currency": "USD",
+      "floor_price": 1.5
+    }
+  ],
+  "reporting_capabilities": {
+    "available_reporting_frequencies": [
+      "daily"
+    ],
+    "expected_delay_minutes": 240,
+    "timezone": "UTC",
+    "supports_webhooks": false,
+    "available_metrics": [
+      "impressions",
+      "clicks",
+      "spend",
+      "ctr",
+      "viewability"
+    ],
+    "date_range_support": "date_range"
+  },
+  "format_options": [
+    {
+      "format_kind": "display_tag",
+      "params": {
+        "width": 300,
+        "height": 250,
+        "supported_tag_types": [
+          "iframe",
+          "javascript",
+          "1x1_redirect"
+        ],
+        "ssl_required": true,
+        "max_redirect_depth": 4,
+        "max_response_time_ms": 1500,
+        "backup_image_required": true,
+        "backup_image_max_size_kb": 50,
+        "om_sdk_required": false,
+        "composition_model": "deterministic",
+        "slots": [
+          {
+            "asset_group_id": "tag_url",
+            "asset_type": "url",
+            "required": true
+          },
+          {
+            "asset_group_id": "backup_image",
+            "asset_type": "image",
+            "required": true,
+            "max_size_kb": 50
+          },
+          {
+            "asset_group_id": "landing_page_url",
+            "asset_type": "url",
+            "required": false
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/test/lib/v2-projection-fixtures/gam_3p_display_tag.json
+++ b/test/lib/v2-projection-fixtures/gam_3p_display_tag.json
@@ -40,6 +40,10 @@
   "format_options": [
     {
       "format_kind": "display_tag",
+      "v1_format_ref": {
+        "agent_url": "https://creative.adcontextprotocol.org/",
+        "id": "display_js"
+      },
       "params": {
         "width": 300,
         "height": 250,

--- a/test/lib/v2-projection-fixtures/google_performance_max.json
+++ b/test/lib/v2-projection-fixtures/google_performance_max.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "/schemas/core/product.json",
+  "product_id": "google_pmax_us",
+  "name": "Google Performance Max — United States",
+  "description": "Google Performance Max campaign — buyer supplies a pool of typed assets (multiple headlines, descriptions, landscape/square images, videos, logos) and Google's optimizer composes combinations across Search, Display, YouTube, Discover, Gmail, and Maps. Composition is algorithmic — surface picks combinations and reports per-asset performance breakdowns. Industry term: \"Responsive\" (Google) / \"Advantage+ creative\" (Meta) / \"Dynamic Creative\" (older Meta term). Distinct from sponsored_placement (catalog-driven, deterministic) and agent_placement (AI-surface composition).",
+  "publisher_properties": [
+    {
+      "publisher_domain": "google.com",
+      "selection_type": "all"
+    }
+  ],
+  "channels": [
+    "search",
+    "display",
+    "ctv",
+    "olv"
+  ],
+  "delivery_type": "non_guaranteed",
+  "pricing_options": [
+    {
+      "pricing_option_id": "cpa_purchase",
+      "pricing_model": "cpa",
+      "event_type": "purchase",
+      "currency": "USD",
+      "fixed_price": 25
+    }
+  ],
+  "reporting_capabilities": {
+    "available_reporting_frequencies": [
+      "daily"
+    ],
+    "expected_delay_minutes": 240,
+    "timezone": "America/Los_Angeles",
+    "supports_webhooks": false,
+    "available_metrics": [
+      "impressions",
+      "clicks",
+      "spend",
+      "ctr",
+      "conversions",
+      "conversion_value",
+      "cost_per_acquisition",
+      "roas",
+      "viewability"
+    ],
+    "date_range_support": "date_range"
+  },
+  "format_options": [
+    {
+      "format_kind": "responsive_creative",
+      "params": {
+        "headlines_min": 3,
+        "headlines_max": 15,
+        "headline_max_chars": 30,
+        "long_headlines_min": 1,
+        "long_headlines_max": 5,
+        "long_headline_max_chars": 90,
+        "descriptions_min": 2,
+        "descriptions_max": 5,
+        "description_max_chars": 90,
+        "images_landscape_min": 1,
+        "images_landscape_max": 20,
+        "images_landscape_aspect_ratio": "1.91:1",
+        "images_square_min": 1,
+        "images_square_max": 20,
+        "videos_min": 0,
+        "videos_max": 5,
+        "video_min_duration_ms": 10000,
+        "video_max_duration_ms": 600000,
+        "logo_min": 1,
+        "logo_max": 5,
+        "logo_aspect_ratios": [
+          "1:1",
+          "4:1"
+        ],
+        "business_name_max_chars": 25,
+        "asset_image_max_file_size_kb": 5120,
+        "supports_catalog_input": true,
+        "composition_model": "algorithmic",
+        "platform_extensions": [
+          {
+            "uri": "https://google.adcp/extensions/google_conversion_actions",
+            "digest": "sha256:d8f1a4c7b0e3d6f9a2c5b8e1d4f7a0c3b6e9d2f5a8c1b4e7d0f3a6c9b2e5d8f1"
+          },
+          {
+            "uri": "https://google.adcp/extensions/google_audience_signals",
+            "digest": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/test/lib/v2-projection-fixtures/google_performance_max.json
+++ b/test/lib/v2-projection-fixtures/google_performance_max.json
@@ -79,11 +79,11 @@
         "composition_model": "algorithmic",
         "platform_extensions": [
           {
-            "uri": "https://google.adcp/extensions/google_conversion_actions",
+            "uri": "https://google.example/extensions/google_conversion_actions",
             "digest": "sha256:d8f1a4c7b0e3d6f9a2c5b8e1d4f7a0c3b6e9d2f5a8c1b4e7d0f3a6c9b2e5d8f1"
           },
           {
-            "uri": "https://google.adcp/extensions/google_audience_signals",
+            "uri": "https://google.example/extensions/google_audience_signals",
             "digest": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
           }
         ]

--- a/test/lib/v2-projection-fixtures/google_performance_max.json
+++ b/test/lib/v2-projection-fixtures/google_performance_max.json
@@ -79,11 +79,11 @@
         "composition_model": "algorithmic",
         "platform_extensions": [
           {
-            "uri": "https://google.example/extensions/google_conversion_actions",
+            "uri": "https://creative.adcontextprotocol.org/translated/google/extensions/google_conversion_actions",
             "digest": "sha256:d8f1a4c7b0e3d6f9a2c5b8e1d4f7a0c3b6e9d2f5a8c1b4e7d0f3a6c9b2e5d8f1"
           },
           {
-            "uri": "https://google.example/extensions/google_audience_signals",
+            "uri": "https://creative.adcontextprotocol.org/translated/google/extensions/google_audience_signals",
             "digest": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
           }
         ]

--- a/test/lib/v2-projection-fixtures/meta_carousel.json
+++ b/test/lib/v2-projection-fixtures/meta_carousel.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "/schemas/core/product.json",
+  "product_id": "meta_carousel_us",
+  "name": "Meta Carousel — United States",
+  "description": "Multi-card swipeable carousel on Meta feed (Facebook + Instagram). 2-10 cards, square aspect, polymorphic per-card asset (image OR video). Each card carries its own headline + click URL. Surface composes the swipeable presentation; buyer ships the cards array.",
+  "publisher_properties": [
+    {
+      "publisher_domain": "meta.com",
+      "selection_type": "all"
+    }
+  ],
+  "channels": [
+    "social"
+  ],
+  "delivery_type": "non_guaranteed",
+  "pricing_options": [
+    {
+      "pricing_option_id": "cpm_floor",
+      "pricing_model": "cpm",
+      "currency": "USD",
+      "floor_price": 4.5
+    }
+  ],
+  "reporting_capabilities": {
+    "available_reporting_frequencies": [
+      "hourly",
+      "daily"
+    ],
+    "expected_delay_minutes": 60,
+    "timezone": "America/Los_Angeles",
+    "supports_webhooks": true,
+    "available_metrics": [
+      "impressions",
+      "clicks",
+      "spend",
+      "ctr",
+      "engagement_rate",
+      "viewability"
+    ],
+    "date_range_support": "date_range"
+  },
+  "format_options": [
+    {
+      "format_kind": "image_carousel",
+      "params": {
+        "card_aspect_ratio": "1:1",
+        "min_cards": 2,
+        "max_cards": 10,
+        "allowed_card_asset_types": [
+          "image",
+          "video"
+        ],
+        "card_image_max_file_size_kb": 30000,
+        "card_video_max_duration_ms": 240000,
+        "primary_text_max_chars": 125,
+        "card_headline_max_chars": 40,
+        "ssl_required": true,
+        "composition_model": "deterministic",
+        "slots": [
+          {
+            "asset_group_id": "cards",
+            "asset_type": "object",
+            "required": true,
+            "min": 2,
+            "max": 10
+          },
+          {
+            "asset_group_id": "primary_text",
+            "asset_type": "text",
+            "required": false,
+            "max_chars": 125
+          },
+          {
+            "asset_group_id": "landing_page_url",
+            "asset_type": "url",
+            "required": true
+          }
+        ],
+        "platform_extensions": [
+          {
+            "uri": "https://meta.adcp/extensions/meta_pixel",
+            "digest": "sha256:a3f5b7c9d8e2f1a4b6c8d0e2f4a6b8c0d2e4f6a8b0c2d4e6f8a0b2c4d6e8f0a2"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/test/lib/v2-projection-fixtures/meta_carousel.json
+++ b/test/lib/v2-projection-fixtures/meta_carousel.json
@@ -78,7 +78,7 @@
         ],
         "platform_extensions": [
           {
-            "uri": "https://meta.adcp/extensions/meta_pixel",
+            "uri": "https://meta.example/extensions/meta_pixel",
             "digest": "sha256:a3f5b7c9d8e2f1a4b6c8d0e2f4a6b8c0d2e4f6a8b0c2d4e6f8a0b2c4d6e8f0a2"
           }
         ]

--- a/test/lib/v2-projection-fixtures/meta_carousel.json
+++ b/test/lib/v2-projection-fixtures/meta_carousel.json
@@ -78,7 +78,7 @@
         ],
         "platform_extensions": [
           {
-            "uri": "https://meta.example/extensions/meta_pixel",
+            "uri": "https://creative.adcontextprotocol.org/translated/meta/extensions/meta_pixel",
             "digest": "sha256:a3f5b7c9d8e2f1a4b6c8d0e2f4a6b8c0d2e4f6a8b0c2d4e6f8a0b2c4d6e8f0a2"
           }
         ]

--- a/test/lib/v2-projection-fixtures/meta_reels_us.json
+++ b/test/lib/v2-projection-fixtures/meta_reels_us.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "/schemas/core/product.json",
+  "product_id": "meta_reels_us",
+  "name": "Meta Reels — United States",
+  "description": "9:16 vertical short-form video on Meta Reels (Facebook + Instagram). Buyers upload H.264 mp4 (3-90s) plus headline and primary text; Meta serves to Reels feeds with placement-native UI overlays and Meta-specific tracking via the meta_pixel extension.",
+  "publisher_properties": [
+    {
+      "publisher_domain": "meta.com",
+      "selection_type": "all"
+    }
+  ],
+  "channels": [
+    "social"
+  ],
+  "delivery_type": "non_guaranteed",
+  "pricing_options": [
+    {
+      "pricing_option_id": "cpm_floor",
+      "pricing_model": "cpm",
+      "currency": "USD",
+      "floor_price": 5.5
+    }
+  ],
+  "reporting_capabilities": {
+    "available_reporting_frequencies": [
+      "hourly",
+      "daily"
+    ],
+    "expected_delay_minutes": 60,
+    "timezone": "America/Los_Angeles",
+    "supports_webhooks": true,
+    "available_metrics": [
+      "impressions",
+      "clicks",
+      "spend",
+      "completion_rate",
+      "viewability"
+    ],
+    "date_range_support": "date_range"
+  },
+  "format_options": [
+    {
+      "format_kind": "video_hosted",
+      "params": {
+        "orientation": "vertical",
+        "aspect_ratio": "9:16",
+        "duration_ms_range": [
+          3000,
+          90000
+        ],
+        "min_width": 1080,
+        "min_height": 1920,
+        "max_file_size_mb": 200,
+        "video_codecs": [
+          "h264"
+        ],
+        "audio_codecs": [
+          "aac"
+        ],
+        "containers": [
+          "mp4"
+        ],
+        "headline_max_chars": 25,
+        "primary_text_max_chars": 72,
+        "captions": "recommended",
+        "cta_values": [
+          "LEARN_MORE",
+          "SHOP_NOW",
+          "DOWNLOAD",
+          "SIGN_UP"
+        ],
+        "composition_model": "deterministic",
+        "platform_extensions": [
+          {
+            "uri": "https://meta.adcp/extensions/meta_pixel",
+            "digest": "sha256:a3f5b7c9d8e2f1a4b6c8d0e2f4a6b8c0d2e4f6a8b0c2d4e6f8a0b2c4d6e8f0a2"
+          },
+          {
+            "uri": "https://meta.adcp/extensions/meta_placements_reels",
+            "digest": "sha256:b8e1d4f6a9c2b5e8d1f4a7c0b3e6d9f2a5c8b1e4d7f0a3c6b9e2d5f8a1c4b7e0"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/test/lib/v2-projection-fixtures/meta_reels_us.json
+++ b/test/lib/v2-projection-fixtures/meta_reels_us.json
@@ -41,6 +41,10 @@
   "format_options": [
     {
       "format_kind": "video_hosted",
+      "v1_format_ref": {
+        "agent_url": "https://meta.adcp",
+        "id": "meta_reels"
+      },
       "params": {
         "orientation": "vertical",
         "aspect_ratio": "9:16",

--- a/test/lib/v2-projection-fixtures/meta_reels_us.json
+++ b/test/lib/v2-projection-fixtures/meta_reels_us.json
@@ -43,7 +43,7 @@
       "format_kind": "video_hosted",
       "capability_id": "meta_reels",
       "v1_format_ref": {
-        "agent_url": "https://mirror.adcontextprotocol.org/translated/meta",
+        "agent_url": "https://creative.adcontextprotocol.org/translated/meta",
         "id": "meta_reels"
       },
       "params": {
@@ -76,17 +76,7 @@
           "CONTACT_US",
           "BOOK_NOW"
         ],
-        "composition_model": "deterministic",
-        "platform_extensions": [
-          {
-            "uri": "https://mirror.adcontextprotocol.org/translated/meta/extensions/meta_pixel",
-            "digest": "sha256:a3f5b7c9d8e2f1a4b6c8d0e2f4a6b8c0d2e4f6a8b0c2d4e6f8a0b2c4d6e8f0a2"
-          },
-          {
-            "uri": "https://mirror.adcontextprotocol.org/translated/meta/extensions/meta_placements_reels",
-            "digest": "sha256:b8e1d4f6a9c2b5e8d1f4a7c0b3e6d9f2a5c8b1e4d7f0a3c6b9e2d5f8a1c4b7e0"
-          }
-        ]
+        "composition_model": "deterministic"
       }
     }
   ]

--- a/test/lib/v2-projection-fixtures/meta_reels_us.json
+++ b/test/lib/v2-projection-fixtures/meta_reels_us.json
@@ -41,8 +41,9 @@
   "format_options": [
     {
       "format_kind": "video_hosted",
+      "capability_id": "meta_reels",
       "v1_format_ref": {
-        "agent_url": "https://meta.adcp",
+        "agent_url": "https://mirror.adcontextprotocol.org/translated/meta",
         "id": "meta_reels"
       },
       "params": {
@@ -64,23 +65,25 @@
         "containers": [
           "mp4"
         ],
-        "headline_max_chars": 25,
-        "primary_text_max_chars": 72,
+        "headline_max_chars": 40,
+        "primary_text_max_chars": 125,
         "captions": "recommended",
         "cta_values": [
           "LEARN_MORE",
           "SHOP_NOW",
           "DOWNLOAD",
-          "SIGN_UP"
+          "SIGN_UP",
+          "CONTACT_US",
+          "BOOK_NOW"
         ],
         "composition_model": "deterministic",
         "platform_extensions": [
           {
-            "uri": "https://meta.adcp/extensions/meta_pixel",
+            "uri": "https://mirror.adcontextprotocol.org/translated/meta/extensions/meta_pixel",
             "digest": "sha256:a3f5b7c9d8e2f1a4b6c8d0e2f4a6b8c0d2e4f6a8b0c2d4e6f8a0b2c4d6e8f0a2"
           },
           {
-            "uri": "https://meta.adcp/extensions/meta_placements_reels",
+            "uri": "https://mirror.adcontextprotocol.org/translated/meta/extensions/meta_placements_reels",
             "digest": "sha256:b8e1d4f6a9c2b5e8d1f4a7c0b3e6d9f2a5c8b1e4d7f0a3c6b9e2d5f8a1c4b7e0"
           }
         ]

--- a/test/lib/v2-projection-fixtures/nytimes_homepage_html5.json
+++ b/test/lib/v2-projection-fixtures/nytimes_homepage_html5.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "/schemas/core/product.json",
+  "product_id": "nytimes_homepage_html5",
+  "name": "NYTimes.com Homepage HTML5 Banner (300×250)",
+  "description": "IAB Medium Rectangle (300×250) interactive HTML5 banner placement on the NYTimes.com homepage. Buyers upload an HTML5 zip bundle (≤200KB initial load, ≤500KB polite-load with host_initiated_subload, max 30s animation, OM-SDK + clickTag macro). Different canonical from the static image MREC because the tracking model is fundamentally different (MRAID + OM-SDK vs impression pixel + click URL).",
+  "publisher_properties": [
+    {
+      "publisher_domain": "nytimes.com",
+      "selection_type": "by_id",
+      "property_ids": [
+        "homepage_above_fold"
+      ]
+    }
+  ],
+  "channels": [
+    "display"
+  ],
+  "delivery_type": "guaranteed",
+  "pricing_options": [
+    {
+      "pricing_option_id": "cpm_homepage_html5",
+      "pricing_model": "cpm",
+      "currency": "USD",
+      "fixed_price": 28
+    }
+  ],
+  "reporting_capabilities": {
+    "available_reporting_frequencies": [
+      "daily"
+    ],
+    "expected_delay_minutes": 240,
+    "timezone": "America/New_York",
+    "supports_webhooks": false,
+    "available_metrics": [
+      "impressions",
+      "clicks",
+      "spend",
+      "ctr",
+      "viewability",
+      "engagement_rate"
+    ],
+    "date_range_support": "date_range"
+  },
+  "format_options": [
+    {
+      "format_kind": "html5",
+      "params": {
+        "width": 300,
+        "height": 250,
+        "max_initial_load_kb": 200,
+        "max_polite_load_kb": 500,
+        "host_initiated_subload": true,
+        "max_animation_duration_ms": 30000,
+        "max_cpu_load_percent": 30,
+        "om_sdk_required": true,
+        "clicktag_macro": "clickTag",
+        "backup_image_required": true,
+        "backup_image_max_size_kb": 50,
+        "ssl_required": true,
+        "composition_model": "deterministic"
+      }
+    }
+  ]
+}

--- a/test/lib/v2-projection-fixtures/nytimes_homepage_html5.json
+++ b/test/lib/v2-projection-fixtures/nytimes_homepage_html5.json
@@ -44,6 +44,10 @@
   "format_options": [
     {
       "format_kind": "html5",
+      "v1_format_ref": {
+        "agent_url": "https://creative.adcontextprotocol.org/",
+        "id": "display_300x250_html"
+      },
       "params": {
         "width": 300,
         "height": 250,

--- a/test/lib/v2-projection-fixtures/nytimes_homepage_mrec.json
+++ b/test/lib/v2-projection-fixtures/nytimes_homepage_mrec.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "/schemas/core/product.json",
+  "product_id": "nytimes_homepage_mrec",
+  "name": "NYTimes.com Homepage MREC (300×250)",
+  "description": "IAB Medium Rectangle (300×250) static image placement on the NYTimes.com homepage above the fold. Buyers upload jpg/png/gif up to 200KB; HTTPS-only; standard impression pixel + click URL tracking via universal_macros plus IAB Open Measurement viewability via the nytimes_om_strict extension.",
+  "publisher_properties": [
+    {
+      "publisher_domain": "nytimes.com",
+      "selection_type": "by_id",
+      "property_ids": [
+        "homepage_above_fold"
+      ]
+    }
+  ],
+  "channels": [
+    "display"
+  ],
+  "delivery_type": "guaranteed",
+  "pricing_options": [
+    {
+      "pricing_option_id": "cpm_homepage_mrec",
+      "pricing_model": "cpm",
+      "currency": "USD",
+      "fixed_price": 22
+    }
+  ],
+  "reporting_capabilities": {
+    "available_reporting_frequencies": [
+      "daily"
+    ],
+    "expected_delay_minutes": 240,
+    "timezone": "America/New_York",
+    "supports_webhooks": false,
+    "available_metrics": [
+      "impressions",
+      "clicks",
+      "spend",
+      "ctr",
+      "viewability"
+    ],
+    "date_range_support": "date_range"
+  },
+  "format_options": [
+    {
+      "format_kind": "image",
+      "params": {
+        "width": 300,
+        "height": 250,
+        "max_file_size_kb": 200,
+        "image_formats": [
+          "jpg",
+          "png",
+          "gif"
+        ],
+        "ssl_required": true,
+        "cta_values": [
+          "LEARN_MORE",
+          "SHOP_NOW",
+          "GET_OFFER"
+        ],
+        "composition_model": "deterministic",
+        "platform_extensions": [
+          {
+            "uri": "https://nytimes.adcp/extensions/nytimes_om_strict",
+            "digest": "sha256:c9d2f5b8e1a4c7b0e3d6f9a2c5b8e1d4f7a0c3b6e9d2f5a8c1b4e7d0f3a6c9b2"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/test/lib/v2-projection-fixtures/nytimes_homepage_mrec.json
+++ b/test/lib/v2-projection-fixtures/nytimes_homepage_mrec.json
@@ -65,7 +65,7 @@
         "composition_model": "deterministic",
         "platform_extensions": [
           {
-            "uri": "https://nytimes.adcp/extensions/nytimes_om_strict",
+            "uri": "https://nytimes.example/extensions/nytimes_om_strict",
             "digest": "sha256:c9d2f5b8e1a4c7b0e3d6f9a2c5b8e1d4f7a0c3b6e9d2f5a8c1b4e7d0f3a6c9b2"
           }
         ]

--- a/test/lib/v2-projection-fixtures/nytimes_homepage_mrec.json
+++ b/test/lib/v2-projection-fixtures/nytimes_homepage_mrec.json
@@ -1,8 +1,8 @@
 {
   "$schema": "/schemas/core/product.json",
-  "product_id": "nytimes_homepage_mrec",
-  "name": "NYTimes.com Homepage MREC (300×250)",
-  "description": "IAB Medium Rectangle (300×250) static image placement on the NYTimes.com homepage above the fold. Buyers upload jpg/png/gif up to 200KB; HTTPS-only; standard impression pixel + click URL tracking via universal_macros plus IAB Open Measurement viewability via the nytimes_om_strict extension.",
+  "product_id": "nytimes_homepage_flex_display",
+  "name": "NYTimes.com Homepage Above-the-Fold Display",
+  "description": "Flexible above-the-fold display slot on the NYTimes.com homepage. Slot accepts IAB display sizes (300×250 MREC, 728×90 leaderboard, 970×250 billboard) as image, HTML5 zip, or third-party tag — the three creative shapes the same physical placement consumes. Single product, three format_options (one per creative type), each declaring `sizes[]` for the multi-size acceptance. Buyer picks the creative type they ship; size matches one of the listed pairs. Standard impression pixel + click URL tracking via universal_macros plus IAB Open Measurement viewability via the nytimes_om_strict extension.",
   "publisher_properties": [
     {
       "publisher_domain": "nytimes.com",
@@ -18,7 +18,7 @@
   "delivery_type": "guaranteed",
   "pricing_options": [
     {
-      "pricing_option_id": "cpm_homepage_mrec",
+      "pricing_option_id": "cpm_homepage_display",
       "pricing_model": "cpm",
       "currency": "USD",
       "fixed_price": 22
@@ -43,13 +43,18 @@
   "format_options": [
     {
       "format_kind": "image",
+      "capability_id": "nytimes_homepage_image",
+      "display_name": "NYTimes Homepage — Image (multi-size)",
       "v1_format_ref": {
         "agent_url": "https://creative.adcontextprotocol.org/",
         "id": "display_300x250_image"
       },
       "params": {
-        "width": 300,
-        "height": 250,
+        "sizes": [
+          { "width": 300, "height": 250 },
+          { "width": 728, "height": 90 },
+          { "width": 970, "height": 250 }
+        ],
         "max_file_size_kb": 200,
         "image_formats": [
           "jpg",
@@ -62,6 +67,65 @@
           "SHOP_NOW",
           "GET_OFFER"
         ],
+        "composition_model": "deterministic",
+        "platform_extensions": [
+          {
+            "uri": "https://nytimes.example/extensions/nytimes_om_strict",
+            "digest": "sha256:c9d2f5b8e1a4c7b0e3d6f9a2c5b8e1d4f7a0c3b6e9d2f5a8c1b4e7d0f3a6c9b2"
+          }
+        ]
+      }
+    },
+    {
+      "format_kind": "html5",
+      "capability_id": "nytimes_homepage_html5",
+      "display_name": "NYTimes Homepage — HTML5 (multi-size)",
+      "v1_format_ref": {
+        "agent_url": "https://creative.adcontextprotocol.org/",
+        "id": "display_300x250_html"
+      },
+      "params": {
+        "sizes": [
+          { "width": 300, "height": 250 },
+          { "width": 728, "height": 90 },
+          { "width": 970, "height": 250 }
+        ],
+        "max_initial_load_kb": 200,
+        "max_polite_load_kb": 500,
+        "host_initiated_subload": true,
+        "max_animation_duration_ms": 30000,
+        "backup_image_required": true,
+        "om_sdk_required": true,
+        "composition_model": "deterministic",
+        "platform_extensions": [
+          {
+            "uri": "https://nytimes.example/extensions/nytimes_om_strict",
+            "digest": "sha256:c9d2f5b8e1a4c7b0e3d6f9a2c5b8e1d4f7a0c3b6e9d2f5a8c1b4e7d0f3a6c9b2"
+          }
+        ]
+      }
+    },
+    {
+      "format_kind": "display_tag",
+      "capability_id": "nytimes_homepage_3p_tag",
+      "display_name": "NYTimes Homepage — Third-party tag (multi-size)",
+      "v1_format_ref": {
+        "agent_url": "https://creative.adcontextprotocol.org/",
+        "id": "display_js"
+      },
+      "params": {
+        "sizes": [
+          { "width": 300, "height": 250 },
+          { "width": 728, "height": 90 },
+          { "width": 970, "height": 250 }
+        ],
+        "supported_tag_types": [
+          "javascript",
+          "iframe"
+        ],
+        "ssl_required": true,
+        "max_redirect_depth": 2,
+        "om_sdk_required": true,
         "composition_model": "deterministic",
         "platform_extensions": [
           {

--- a/test/lib/v2-projection-fixtures/nytimes_homepage_mrec.json
+++ b/test/lib/v2-projection-fixtures/nytimes_homepage_mrec.json
@@ -43,6 +43,10 @@
   "format_options": [
     {
       "format_kind": "image",
+      "v1_format_ref": {
+        "agent_url": "https://nytimes.adcp",
+        "id": "iab_mrec_300x250"
+      },
       "params": {
         "width": 300,
         "height": 250,

--- a/test/lib/v2-projection-fixtures/nytimes_homepage_mrec.json
+++ b/test/lib/v2-projection-fixtures/nytimes_homepage_mrec.json
@@ -44,8 +44,8 @@
     {
       "format_kind": "image",
       "v1_format_ref": {
-        "agent_url": "https://nytimes.adcp",
-        "id": "iab_mrec_300x250"
+        "agent_url": "https://creative.adcontextprotocol.org/",
+        "id": "display_300x250_image"
       },
       "params": {
         "width": 300,

--- a/test/lib/v2-projection-fixtures/nytimes_homepage_takeover_custom.json
+++ b/test/lib/v2-projection-fixtures/nytimes_homepage_takeover_custom.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "/schemas/core/product.json",
+  "product_id": "nytimes_homepage_takeover_premium",
+  "name": "NYTimes.com Homepage Takeover (Multi-Placement Sponsorship)",
+  "description": "24-hour multi-placement homepage takeover on NYTimes.com — bundles a homepage skin, a preroll video on homepage video assets, and a sponsorship-lockup banner adjacent to top-of-page content. Sold as a unit (exclusivity_window_hours: 24). Demonstrates `format_kind: \"custom\"` with `format_shape: multi_placement_takeover` and a `format_schema` URI+digest reference pointing at NYTimes's hosted schema describing the takeover's components. Required `canonical_formats_only: true` — no v1 named format can express the multi-component shape, so SDKs MUST NOT synthesize a v1 `format_id` for this declaration.",
+  "publisher_properties": [
+    {
+      "publisher_domain": "nytimes.com",
+      "selection_type": "by_id",
+      "property_ids": [
+        "homepage_above_fold"
+      ]
+    }
+  ],
+  "channels": [
+    "display",
+    "olv"
+  ],
+  "delivery_type": "guaranteed",
+  "pricing_options": [
+    {
+      "pricing_option_id": "flat_takeover_24h",
+      "pricing_model": "flat_rate",
+      "currency": "USD",
+      "fixed_price": 250000
+    }
+  ],
+  "reporting_capabilities": {
+    "available_reporting_frequencies": [
+      "daily"
+    ],
+    "expected_delay_minutes": 240,
+    "timezone": "America/New_York",
+    "supports_webhooks": false,
+    "available_metrics": [
+      "impressions",
+      "clicks",
+      "spend",
+      "ctr",
+      "viewability"
+    ],
+    "date_range_support": "date_range"
+  },
+  "format_options": [
+    {
+      "format_kind": "custom",
+      "canonical_formats_only": true,
+      "format_shape": "multi_placement_takeover",
+      "format_schema": {
+        "uri": "https://nytimes.adcp/schemas/formats/homepage_takeover_v3",
+        "digest": "sha256:e1d4f6a9c2b5e8d1f4a7c0b3e6d9f2a5c8b1e4d7f0a3c6b9e2d5f8a1c4b7e0a3"
+      },
+      "capability_id": "nytimes_homepage_takeover_premium",
+      "display_name": "Homepage Takeover — Premium Sponsorship",
+      "applies_to_channels": ["display", "olv"],
+      "params": {
+        "components": [
+          { "placement_type": "homepage_skin", "required": true },
+          { "placement_type": "preroll_video", "required": true },
+          { "placement_type": "sponsorship_lockup", "required": true }
+        ],
+        "exclusivity_window_hours": 24,
+        "ssl_required": true
+      }
+    }
+  ]
+}

--- a/test/lib/v2-projection-fixtures/nytimes_homepage_takeover_custom.json
+++ b/test/lib/v2-projection-fixtures/nytimes_homepage_takeover_custom.json
@@ -47,7 +47,7 @@
       "canonical_formats_only": true,
       "format_shape": "multi_placement_takeover",
       "format_schema": {
-        "uri": "https://nytimes.adcp/schemas/formats/homepage_takeover_v3",
+        "uri": "https://nytimes.example/schemas/formats/homepage_takeover_v3",
         "digest": "sha256:e1d4f6a9c2b5e8d1f4a7c0b3e6d9f2a5c8b1e4d7f0a3c6b9e2d5f8a1c4b7e0a3"
       },
       "capability_id": "nytimes_homepage_takeover_premium",

--- a/test/lib/v2-projection-fixtures/the_daily_30s_host_read.json
+++ b/test/lib/v2-projection-fixtures/the_daily_30s_host_read.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "/schemas/core/product.json",
+  "product_id": "the_daily_30s_host_read_us",
+  "name": "The Daily — 30s Host-Read Pre-roll (US)",
+  "description": "30-second podcast host-read pre-roll on The Daily. Buyer-uploaded audio is rejected (asset_source: publisher_host_recorded); buyer submits a verbatim script (≤800 chars) as a text asset under the `script` slot, plus brand context via the manifest's BrandRef. The publisher's host records the audio, which is dynamically inserted at podcast playback time. 7-business-day production turnaround. A brief-driven host-read product would have the same shape with `creative_brief` (brief asset_type) in the slots instead of `script` (text asset_type).",
+  "publisher_properties": [
+    {
+      "publisher_domain": "thedailypod.example",
+      "selection_type": "all"
+    }
+  ],
+  "channels": [
+    "podcast"
+  ],
+  "delivery_type": "guaranteed",
+  "pricing_options": [
+    {
+      "pricing_option_id": "cpm_host_read",
+      "pricing_model": "cpm",
+      "currency": "USD",
+      "fixed_price": 35
+    }
+  ],
+  "reporting_capabilities": {
+    "available_reporting_frequencies": [
+      "daily"
+    ],
+    "expected_delay_minutes": 1440,
+    "timezone": "America/New_York",
+    "supports_webhooks": false,
+    "available_metrics": [
+      "impressions",
+      "spend",
+      "completion_rate",
+      "completed_views"
+    ],
+    "date_range_support": "date_range"
+  },
+  "format_options": [
+    {
+      "format_kind": "audio_hosted",
+      "params": {
+        "duration_ms_exact": 30000,
+        "audio_codecs": [
+          "mp3",
+          "aac"
+        ],
+        "audio_sample_rates": [
+          44100,
+          48000
+        ],
+        "audio_channels": [
+          "stereo"
+        ],
+        "loudness_lufs": -16,
+        "asset_source": "publisher_host_recorded",
+        "buyer_asset_acceptance": "rejected",
+        "composition_model": "deterministic",
+        "slots": [
+          {
+            "asset_group_id": "script",
+            "required": true,
+            "asset_type": "text",
+            "max_chars": 800,
+            "description": "Verbatim script the host reads — exact wording; no improvisation; legal pre-cleared."
+          },
+          {
+            "asset_group_id": "offering_ref",
+            "required": false,
+            "asset_type": "text",
+            "description": "Optional offering identifier from the buyer's catalog to focus the host-read."
+          }
+        ],
+        "production_window_business_days": 7
+      }
+    }
+  ]
+}

--- a/test/lib/v2-projection-fixtures/triton_daast_audio_30s.json
+++ b/test/lib/v2-projection-fixtures/triton_daast_audio_30s.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "/schemas/core/product.json",
+  "product_id": "triton_daast_audio_30s",
+  "name": "Triton Audio DAAST (30s)",
+  "description": "DAAST 1.1 audio tag on Triton-managed streaming radio inventory. Buyer ships a DAAST tag (URL or inline XML); the streaming server fires DAAST events (impression / quartiles / click / complete / error) inherent to the spec. Audio analog of VAST.",
+  "publisher_properties": [
+    {
+      "publisher_domain": "triton.example",
+      "selection_type": "all"
+    }
+  ],
+  "channels": [
+    "streaming_audio",
+    "radio"
+  ],
+  "delivery_type": "non_guaranteed",
+  "pricing_options": [
+    {
+      "pricing_option_id": "cpm_floor",
+      "pricing_model": "cpm",
+      "currency": "USD",
+      "floor_price": 12
+    }
+  ],
+  "reporting_capabilities": {
+    "available_reporting_frequencies": [
+      "daily"
+    ],
+    "expected_delay_minutes": 1440,
+    "timezone": "UTC",
+    "supports_webhooks": false,
+    "available_metrics": [
+      "impressions",
+      "spend",
+      "completion_rate",
+      "completed_views",
+      "quartile_data"
+    ],
+    "date_range_support": "date_range"
+  },
+  "format_options": [
+    {
+      "format_kind": "audio_daast",
+      "params": {
+        "daast_version": "1.1",
+        "duration_ms_exact": 30000,
+        "linear_required": true,
+        "max_wrapper_depth": 3,
+        "ssl_required": true,
+        "companion_image_required": false,
+        "composition_model": "deterministic",
+        "slots": [
+          {
+            "asset_group_id": "daast_tag",
+            "asset_type": "daast",
+            "required": true
+          },
+          {
+            "asset_group_id": "landing_page_url",
+            "asset_type": "url",
+            "required": false
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/test/lib/v2-projection-fixtures/triton_daast_audio_30s.json
+++ b/test/lib/v2-projection-fixtures/triton_daast_audio_30s.json
@@ -41,6 +41,10 @@
   "format_options": [
     {
       "format_kind": "audio_daast",
+      "v1_format_ref": {
+        "agent_url": "https://triton.adcp",
+        "id": "daast_audio_30s_v1_1"
+      },
       "params": {
         "daast_version": "1.1",
         "duration_ms_exact": 30000,

--- a/test/lib/v2-projection-fixtures/triton_daast_audio_30s.json
+++ b/test/lib/v2-projection-fixtures/triton_daast_audio_30s.json
@@ -41,10 +41,7 @@
   "format_options": [
     {
       "format_kind": "audio_daast",
-      "v1_format_ref": {
-        "agent_url": "https://triton.adcp",
-        "id": "daast_audio_30s_v1_1"
-      },
+      "canonical_formats_only": true,
       "params": {
         "daast_version": "1.1",
         "duration_ms_exact": 30000,

--- a/test/lib/v2-projection-fixtures/veo_generative_video_15s.json
+++ b/test/lib/v2-projection-fixtures/veo_generative_video_15s.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "/schemas/core/product.json",
+  "product_id": "veo_generative_video_vertical_15s",
+  "name": "Veo — 15s Generative Vertical Video",
+  "description": "Generative video synthesis from a creative_brief plus structured scenes. Buyer ships a brief (≤500 chars) and a scenes plan (3 scenes summing to 15s); Veo synthesizes the video. Genuinely nondeterministic — synthesis from in-spec inputs may produce out-of-spec frames; the platform's post-synthesis QA loop validates and reseeds up to N attempts before surfacing output. If the QA loop exhausts, build_creative returns task_failed with synthesis_failed reason. provenance_required: true means every produced asset carries a C2PA provenance manifest attributing synthesis to Veo (not the seller).",
+  "publisher_properties": [
+    {
+      "publisher_domain": "veo.example",
+      "selection_type": "all"
+    }
+  ],
+  "channels": [
+    "social",
+    "olv"
+  ],
+  "delivery_type": "non_guaranteed",
+  "pricing_options": [
+    {
+      "pricing_option_id": "cpm_floor",
+      "pricing_model": "cpm",
+      "currency": "USD",
+      "floor_price": 18
+    }
+  ],
+  "reporting_capabilities": {
+    "available_reporting_frequencies": [
+      "daily"
+    ],
+    "expected_delay_minutes": 240,
+    "timezone": "UTC",
+    "supports_webhooks": false,
+    "available_metrics": [
+      "impressions",
+      "clicks",
+      "spend",
+      "completion_rate",
+      "viewability"
+    ],
+    "date_range_support": "date_range"
+  },
+  "format_options": [
+    {
+      "format_kind": "video_hosted",
+      "params": {
+        "orientation": "vertical",
+        "aspect_ratio": "9:16",
+        "duration_ms_exact": 15000,
+        "min_width": 1080,
+        "min_height": 1920,
+        "video_codecs": [
+          "h264"
+        ],
+        "containers": [
+          "mp4"
+        ],
+        "frame_rates": [
+          24,
+          30
+        ],
+        "asset_source": "agent_synthesized",
+        "buyer_asset_acceptance": "rejected",
+        "captions": "recommended",
+        "composition_model": "deterministic",
+        "synthesis_nondeterministic": true,
+        "provenance_required": true,
+        "production_window_business_days": 0,
+        "slots": [
+          {
+            "asset_group_id": "creative_brief",
+            "asset_type": "brief",
+            "required": true,
+            "max_chars": 500
+          },
+          {
+            "asset_group_id": "scenes",
+            "asset_type": "object",
+            "required": true,
+            "min": 1,
+            "max": 5
+          },
+          {
+            "asset_group_id": "style_reference",
+            "asset_type": "image",
+            "required": false
+          },
+          {
+            "asset_group_id": "landing_page_url",
+            "asset_type": "url",
+            "required": false
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/test/lib/v2-projection-fixtures/youtube_vast_preroll.json
+++ b/test/lib/v2-projection-fixtures/youtube_vast_preroll.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "/schemas/core/product.json",
+  "product_id": "youtube_vast_preroll_15s_skippable",
+  "name": "YouTube VAST Pre-roll (15s skippable, In-Stream)",
+  "description": "VAST tag pre-roll on YouTube In-Stream inventory, 16:9 horizontal, 5-second skippable threshold. Buyer ships a VAST 4.x tag (URL or inline XML); YouTube fires VAST events (impression / quartiles / click / complete / error / skip) inherent to the spec. VPAID 2.0 supported but discouraged — Google deprecates VPAID in 2026.",
+  "publisher_properties": [
+    {
+      "publisher_domain": "youtube.com",
+      "selection_type": "all"
+    }
+  ],
+  "channels": [
+    "olv",
+    "ctv"
+  ],
+  "delivery_type": "non_guaranteed",
+  "pricing_options": [
+    {
+      "pricing_option_id": "cpv_skippable",
+      "pricing_model": "cpv",
+      "currency": "USD",
+      "floor_price": 0.05,
+      "parameters": {
+        "view_threshold": {
+          "duration_seconds": 30
+        }
+      }
+    }
+  ],
+  "reporting_capabilities": {
+    "available_reporting_frequencies": [
+      "daily"
+    ],
+    "expected_delay_minutes": 240,
+    "timezone": "America/Los_Angeles",
+    "supports_webhooks": false,
+    "available_metrics": [
+      "impressions",
+      "completed_views",
+      "spend",
+      "completion_rate",
+      "viewability",
+      "quartile_data"
+    ],
+    "date_range_support": "date_range"
+  },
+  "format_options": [
+    {
+      "format_kind": "video_vast",
+      "params": {
+        "orientation": "horizontal",
+        "aspect_ratio": "16:9",
+        "vast_version": "4.2",
+        "vpaid_enabled": false,
+        "simid_supported": false,
+        "duration_ms_range": [
+          6000,
+          30000
+        ],
+        "min_width": 1280,
+        "min_height": 720,
+        "linear_required": true,
+        "skippable_after_ms": 5000,
+        "max_wrapper_depth": 5,
+        "ssl_required": true,
+        "composition_model": "deterministic",
+        "slots": [
+          {
+            "asset_group_id": "vast_tag",
+            "asset_type": "vast",
+            "required": true
+          },
+          {
+            "asset_group_id": "landing_page_url",
+            "asset_type": "url",
+            "required": false
+          }
+        ],
+        "platform_extensions": [
+          {
+            "uri": "https://google.adcp/extensions/google_universal_ad_id",
+            "digest": "sha256:b3c5e7f9a1c3e5b7d9f1a3c5e7b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/test/lib/v2-projection-fixtures/youtube_vast_preroll.json
+++ b/test/lib/v2-projection-fixtures/youtube_vast_preroll.json
@@ -82,7 +82,7 @@
         ],
         "platform_extensions": [
           {
-            "uri": "https://google.example/extensions/google_universal_ad_id",
+            "uri": "https://creative.adcontextprotocol.org/translated/google/extensions/google_universal_ad_id",
             "digest": "sha256:b3c5e7f9a1c3e5b7d9f1a3c5e7b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5"
           }
         ]

--- a/test/lib/v2-projection-fixtures/youtube_vast_preroll.json
+++ b/test/lib/v2-projection-fixtures/youtube_vast_preroll.json
@@ -82,7 +82,7 @@
         ],
         "platform_extensions": [
           {
-            "uri": "https://google.adcp/extensions/google_universal_ad_id",
+            "uri": "https://google.example/extensions/google_universal_ad_id",
             "digest": "sha256:b3c5e7f9a1c3e5b7d9f1a3c5e7b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5"
           }
         ]

--- a/test/lib/v2-projection-fixtures/youtube_vast_preroll.json
+++ b/test/lib/v2-projection-fixtures/youtube_vast_preroll.json
@@ -47,6 +47,10 @@
   "format_options": [
     {
       "format_kind": "video_vast",
+      "v1_format_ref": {
+        "agent_url": "https://creative.adcontextprotocol.org/",
+        "id": "video_vast_30s"
+      },
       "params": {
         "orientation": "horizontal",
         "aspect_ratio": "16:9",

--- a/test/lib/v2-to-v1-projection.test.js
+++ b/test/lib/v2-to-v1-projection.test.js
@@ -51,13 +51,16 @@ describe('v2 → v1 Product projection — per-fixture structural invariant', { 
     test(name, () => {
       const { v1, diagnostics } = projectV2ProductToV1(product);
       assert.strictEqual(v1.product_id, product.product_id);
-      // Every input declaration produces either a v1 emit or a
-      // diagnostic — never both, never neither.
+      // Every input declaration produces AT LEAST ONE of (v1 emit,
+      // diagnostic). May produce both: a multi-size v2 declaration
+      // emits a single v1 format_id (the representative size) AND a
+      // FORMAT_DECLARATION_V1_LOSSY_MULTI_SIZE advisory so the buyer
+      // knows N-1 sizes were dropped on the v1 wire.
       const declCount = product.format_options.length;
-      assert.strictEqual(
-        v1.format_ids.length + diagnostics.length,
-        declCount,
-        `every format_options[i] must produce either a v1 emit or a diagnostic`
+      assert.ok(
+        v1.format_ids.length + diagnostics.length >= declCount,
+        `every format_options[i] must produce at least one of (v1 emit, diagnostic); ` +
+          `emits=${v1.format_ids.length} diagnostics=${diagnostics.length} declCount=${declCount}`
       );
       // Every diagnostic must carry the spec-mandated source + sdk_id.
       for (const d of diagnostics) {
@@ -70,23 +73,18 @@ describe('v2 → v1 Product projection — per-fixture structural invariant', { 
 });
 
 describe('v2 → v1 projection — seller-asserted v1_format_ref (the only normative path)', { skip: SKIP_REASON }, () => {
-  // After the registry↔catalog reconciliation upstream, 4 IAB-standard
-  // fixtures point at AAO-canonical agent_url + catalog ids; 1 Meta-
-  // specific fixture keeps a publisher-specific agent_url. This is the
-  // explicit pattern the spec now models: converge on AAO ids for
-  // industry-standard formats, keep publisher namespacing for proprietary
-  // platforms.
+  // After the publisher-scoped format catalog landed (adcp commit
+  // e2fae6b086), publisher-specific formats live at the AAO community
+  // mirror under `creative.adcontextprotocol.org/translated/<publisher>`
+  // until the publisher adopts adagents.json#/formats themselves.
+  // Each fixture below is single-size (fixed width+height) so the
+  // projection produces ZERO diagnostics. The multi-size case is
+  // covered by the dedicated nytimes_homepage_flex_display test below.
   const sellerAsserted = [
-    ['nytimes_homepage_mrec', 'https://creative.adcontextprotocol.org/', 'display_300x250_image'],
     ['nytimes_homepage_html5', 'https://creative.adcontextprotocol.org/', 'display_300x250_html'],
     ['gam_3p_display_tag', 'https://creative.adcontextprotocol.org/', 'display_js'],
     ['youtube_vast_preroll', 'https://creative.adcontextprotocol.org/', 'video_vast_30s'],
-    // After the publisher-scoped format catalog landed upstream
-    // (adcp commit e2fae6b086), Meta moved to the AAO community-
-    // mirror tier — `mirror.adcontextprotocol.org/translated/meta`
-    // hosts the catalog until Meta adopts adagents.json#/formats
-    // themselves.
-    ['meta_reels_us', 'https://mirror.adcontextprotocol.org/translated/meta', 'meta_reels'],
+    ['meta_reels_us', 'https://creative.adcontextprotocol.org/translated/meta', 'meta_reels'],
   ];
 
   for (const [fixture, expectedAgentUrl, expectedId] of sellerAsserted) {
@@ -99,6 +97,27 @@ describe('v2 → v1 projection — seller-asserted v1_format_ref (the only norma
       assert.strictEqual(v1.format_ids[0].id, expectedId);
     });
   }
+});
+
+describe('v2 → v1 projection — multi-size lossy advisory', { skip: SKIP_REASON }, () => {
+  // The new flex-display fixture has 3 format_options (image / html5 /
+  // display_tag), each declaring sizes: [3]. Each emits a single
+  // v1_format_ref (the rep size from the AAO catalog) PLUS a
+  // FORMAT_DECLARATION_V1_LOSSY_MULTI_SIZE diagnostic so the buyer
+  // knows the other 2 sizes are dropped on the v1 wire.
+  test('nytimes_homepage_flex_display emits 3 format_ids + 3 lossy advisories', () => {
+    const product = JSON.parse(readFileSync(path.join(FIXTURE_DIR, 'nytimes_homepage_mrec.json'), 'utf-8'));
+    const { v1, diagnostics } = projectV2ProductToV1(product);
+    assert.strictEqual(product.product_id, 'nytimes_homepage_flex_display');
+    assert.strictEqual(product.format_options.length, 3);
+    assert.strictEqual(v1.format_ids.length, 3, 'one v1 format_id per format_option (rep size)');
+    assert.strictEqual(diagnostics.length, 3, 'one lossy advisory per format_option');
+    for (const d of diagnostics) {
+      assert.strictEqual(d.code, 'FORMAT_DECLARATION_V1_LOSSY_MULTI_SIZE');
+      assert.strictEqual(d.error.details.size_mode, 'sizes');
+      assert.strictEqual(d.error.details.declared_sizes_count, 3);
+    }
+  });
 });
 
 describe('v2 → v1 projection — canonical_formats_only opt-out', { skip: SKIP_REASON }, () => {

--- a/test/lib/v2-to-v1-projection.test.js
+++ b/test/lib/v2-to-v1-projection.test.js
@@ -105,18 +105,42 @@ describe('v2 → v1 projection — multi-size lossy advisory', { skip: SKIP_REAS
   // v1_format_ref (the rep size from the AAO catalog) PLUS a
   // FORMAT_DECLARATION_V1_LOSSY_MULTI_SIZE diagnostic so the buyer
   // knows the other 2 sizes are dropped on the v1 wire.
-  test('nytimes_homepage_flex_display emits 3 format_ids + 3 lossy advisories', () => {
+  test('nytimes_homepage_flex_display fans out via catalog lookup', () => {
     const product = JSON.parse(readFileSync(path.join(FIXTURE_DIR, 'nytimes_homepage_mrec.json'), 'utf-8'));
     const { v1, diagnostics } = projectV2ProductToV1(product);
     assert.strictEqual(product.product_id, 'nytimes_homepage_flex_display');
     assert.strictEqual(product.format_options.length, 3);
-    assert.strictEqual(v1.format_ids.length, 3, 'one v1 format_id per format_option (rep size)');
-    assert.strictEqual(diagnostics.length, 3, 'one lossy advisory per format_option');
+
+    // The SDK fans out multi-size declarations by looking each declared
+    // size up in the AAO catalog. image + html5 each have 3 sized
+    // catalog entries → 6 emits total. display_tag has only the
+    // parameterized `display_js` entry → falls back to rep (1 emit).
+    // Total v1 emits: 3 + 3 + 1 = 7. One lossy advisory per format_option.
+    const imageEmits = v1.format_ids.filter(f => f.id.includes('image'));
+    const htmlEmits = v1.format_ids.filter(f => f.id.includes('html'));
+    const tagEmits = v1.format_ids.filter(f => f.id === 'display_js');
+    assert.strictEqual(imageEmits.length, 3, 'image canonical fans to 3 sized catalog entries');
+    assert.strictEqual(htmlEmits.length, 3, 'html5 canonical fans to 3 sized catalog entries');
+    assert.strictEqual(tagEmits.length, 1, 'display_tag has only display_js (parameterized); falls back to rep');
+    assert.strictEqual(v1.format_ids.length, 7, 'total v1 emits across all 3 format_options');
+
+    assert.strictEqual(diagnostics.length, 3, 'one lossy advisory per format_option (sizes was declared multi)');
     for (const d of diagnostics) {
       assert.strictEqual(d.code, 'FORMAT_DECLARATION_V1_LOSSY_MULTI_SIZE');
       assert.strictEqual(d.error.details.size_mode, 'sizes');
       assert.strictEqual(d.error.details.declared_sizes_count, 3);
     }
+    // image + html5 advisories report full coverage (3/3); display_tag reports 1/3.
+    const imageAdvisory = diagnostics.find(d => d.error.details.format_kind === 'image');
+    const htmlAdvisory = diagnostics.find(d => d.error.details.format_kind === 'html5');
+    const tagAdvisory = diagnostics.find(d => d.error.details.format_kind === 'display_tag');
+    assert.strictEqual(imageAdvisory.error.details.emitted_sizes_count, 3);
+    assert.strictEqual(htmlAdvisory.error.details.emitted_sizes_count, 3);
+    assert.strictEqual(
+      tagAdvisory.error.details.emitted_sizes_count,
+      1,
+      'display_tag has only display_js; fan-out finds 0 sized variants and falls back to rep'
+    );
   });
 });
 

--- a/test/lib/v2-to-v1-projection.test.js
+++ b/test/lib/v2-to-v1-projection.test.js
@@ -42,7 +42,8 @@ function loadFixtures() {
     .map(f => ({
       name: f.replace(/\.json$/, ''),
       product: JSON.parse(readFileSync(path.join(FIXTURE_DIR, f), 'utf-8')),
-    }));
+    }))
+    .filter(({ product }) => Array.isArray(product?.format_options));
 }
 
 describe('v2 → v1 Product projection — per-fixture structural invariant', { skip: SKIP_REASON }, () => {

--- a/test/lib/v2-to-v1-projection.test.js
+++ b/test/lib/v2-to-v1-projection.test.js
@@ -54,36 +54,50 @@ describe('v2 → v1 Product projection — per-fixture structural invariant', ()
 });
 
 describe('v2 → v1 projection — seller-asserted v1_format_ref (the only normative path)', () => {
-  test('nytimes_homepage_mrec projects via v1_format_ref', () => {
-    const fixture = JSON.parse(readFileSync(path.join(FIXTURE_DIR, 'nytimes_homepage_mrec.json'), 'utf-8'));
-    const { v1, diagnostics } = projectV2ProductToV1(fixture);
-    assert.strictEqual(diagnostics.length, 0);
-    assert.strictEqual(v1.format_ids.length, 1);
-    // Comes from the declaration's v1_format_ref, not from registry
-    // synthesis — the registry path is non-normative.
-    assert.strictEqual(v1.format_ids[0].agent_url, 'https://nytimes.adcp');
-    assert.strictEqual(v1.format_ids[0].id, 'iab_mrec_300x250');
-  });
+  // After the registry↔catalog reconciliation upstream, 4 IAB-standard
+  // fixtures point at AAO-canonical agent_url + catalog ids; 1 Meta-
+  // specific fixture keeps a publisher-specific agent_url. This is the
+  // explicit pattern the spec now models: converge on AAO ids for
+  // industry-standard formats, keep publisher namespacing for proprietary
+  // platforms.
+  const sellerAsserted = [
+    ['nytimes_homepage_mrec', 'https://creative.adcontextprotocol.org/', 'display_300x250_image'],
+    ['nytimes_homepage_html5', 'https://creative.adcontextprotocol.org/', 'display_300x250_html'],
+    ['gam_3p_display_tag', 'https://creative.adcontextprotocol.org/', 'display_js'],
+    ['youtube_vast_preroll', 'https://creative.adcontextprotocol.org/', 'video_vast_30s'],
+    ['meta_reels_us', 'https://meta.adcp', 'meta_reels'],
+  ];
 
-  test('triton_daast_audio_30s projects via v1_format_ref', () => {
-    const fixture = JSON.parse(readFileSync(path.join(FIXTURE_DIR, 'triton_daast_audio_30s.json'), 'utf-8'));
-    const { v1, diagnostics } = projectV2ProductToV1(fixture);
-    assert.strictEqual(diagnostics.length, 0);
-    assert.strictEqual(v1.format_ids.length, 1);
-    assert.strictEqual(v1.format_ids[0].agent_url, 'https://triton.adcp');
-    assert.strictEqual(v1.format_ids[0].id, 'daast_audio_30s_v1_1');
-  });
+  for (const [fixture, expectedAgentUrl, expectedId] of sellerAsserted) {
+    test(`${fixture} projects via v1_format_ref → ${expectedId}`, () => {
+      const product = JSON.parse(readFileSync(path.join(FIXTURE_DIR, `${fixture}.json`), 'utf-8'));
+      const { v1, diagnostics } = projectV2ProductToV1(product);
+      assert.strictEqual(diagnostics.length, 0, `expected zero diagnostics; got ${JSON.stringify(diagnostics)}`);
+      assert.strictEqual(v1.format_ids.length, 1);
+      assert.strictEqual(v1.format_ids[0].agent_url, expectedAgentUrl);
+      assert.strictEqual(v1.format_ids[0].id, expectedId);
+    });
+  }
 });
 
 describe('v2 → v1 projection — canonical_formats_only opt-out', () => {
-  test('nytimes_homepage_takeover_custom emits FORMAT_DECLARATION_V1_NOT_APPLICABLE', () => {
-    const fixture = JSON.parse(readFileSync(path.join(FIXTURE_DIR, 'nytimes_homepage_takeover_custom.json'), 'utf-8'));
-    const { v1, diagnostics } = projectV2ProductToV1(fixture);
-    assert.strictEqual(v1.format_ids.length, 0);
-    assert.strictEqual(diagnostics.length, 1);
-    assert.strictEqual(diagnostics[0].code, 'FORMAT_DECLARATION_V1_NOT_APPLICABLE');
-    assert.strictEqual(diagnostics[0].error.details.reason, 'canonical_formats_only');
-  });
+  // Two fixtures use this now: the NYTimes custom takeover (no v1 form
+  // possible — multi-placement) and triton_daast (catalog has no DAAST
+  // entry yet, so the seller opted out rather than fabricating an id).
+  const optOuts = [
+    ['nytimes_homepage_takeover_custom', 'custom'],
+    ['triton_daast_audio_30s', 'audio_daast'],
+  ];
+  for (const [fixture, kind] of optOuts) {
+    test(`${fixture} (${kind}) emits FORMAT_DECLARATION_V1_NOT_APPLICABLE`, () => {
+      const product = JSON.parse(readFileSync(path.join(FIXTURE_DIR, `${fixture}.json`), 'utf-8'));
+      const { v1, diagnostics } = projectV2ProductToV1(product);
+      assert.strictEqual(v1.format_ids.length, 0);
+      assert.strictEqual(diagnostics.length, 1);
+      assert.strictEqual(diagnostics[0].code, 'FORMAT_DECLARATION_V1_NOT_APPLICABLE');
+      assert.strictEqual(diagnostics[0].error.details.reason, 'canonical_formats_only');
+    });
+  }
 });
 
 describe('v2 → v1 projection — v1_translatable: false (4 inherently-v2 canonicals)', () => {

--- a/test/lib/v2-to-v1-projection.test.js
+++ b/test/lib/v2-to-v1-projection.test.js
@@ -1,0 +1,126 @@
+// Exercise the v2 → v1 projection layer against the 13 reference
+// fixtures from adcontextprotocol/adcp#3307
+// (static/examples/products/canonical/). These fixtures span the full
+// canonical-format catalog: image, html5, display_tag, image_carousel,
+// video_hosted (×2), video_vast, audio_hosted, audio_daast,
+// sponsored_placement, responsive_creative, agent_placement, custom.
+//
+// The interesting question this test answers: how many of the 13
+// real-world v2 declarations have a clean v1 form, and how many would
+// be unreachable from a v1-only buyer? The answer informs whether the
+// 8.0 design's "v2-only public type with projection at the boundary"
+// is operable today, or whether sellers need to start adding
+// v1_format_ref before the SDK can downgrade gracefully.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const { readFileSync, readdirSync } = require('node:fs');
+const path = require('node:path');
+
+const { projectV2ProductToV1 } = require('../../dist/lib/v2/projection/v2-to-v1.js');
+
+const FIXTURE_DIR = path.join(__dirname, 'v2-projection-fixtures');
+
+function loadFixtures() {
+  return readdirSync(FIXTURE_DIR)
+    .filter(f => f.endsWith('.json'))
+    .map(f => ({
+      name: f.replace(/\.json$/, ''),
+      product: JSON.parse(readFileSync(path.join(FIXTURE_DIR, f), 'utf-8')),
+    }));
+}
+
+describe('v2 → v1 Product projection — per-fixture verdict', () => {
+  for (const { name, product } of loadFixtures()) {
+    test(name, () => {
+      const { v1, diagnostics } = projectV2ProductToV1(product);
+      // Every fixture's product_id passes through unchanged — the
+      // projection rewrites only format_ids / format_options.
+      assert.strictEqual(v1.product_id, product.product_id);
+      // The structural invariant: format_ids count + diagnostic count
+      // equals total format_options count (every input declaration
+      // produces either a format_id OR a diagnostic, never both, never
+      // neither).
+      const declCount = product.format_options.length;
+      assert.strictEqual(
+        v1.format_ids.length + diagnostics.length,
+        declCount,
+        `every format_options[i] must produce either a v1 emit or a diagnostic`
+      );
+    });
+  }
+});
+
+describe('v2 → v1 projection — explicit canonical_formats_only opt-out', () => {
+  test('nytimes_homepage_takeover_custom is unreachable from v1', () => {
+    const fixture = JSON.parse(readFileSync(path.join(FIXTURE_DIR, 'nytimes_homepage_takeover_custom.json'), 'utf-8'));
+    const { v1, diagnostics } = projectV2ProductToV1(fixture);
+    assert.strictEqual(v1.format_ids.length, 0);
+    assert.strictEqual(diagnostics.length, 1);
+    assert.strictEqual(diagnostics[0].code, 'FORMAT_DECLARATION_V1_UNREACHABLE');
+    assert.strictEqual(diagnostics[0].details.reason, 'canonical_formats_only');
+    assert.match(diagnostics[0].details.hint, /opts out of v1/);
+  });
+});
+
+describe('v2 → v1 projection — IAB image with registry-matched dimensions', () => {
+  test('nytimes_homepage_mrec projects to iab/mrec_300x250', () => {
+    // The only fixture whose canonical (image) + params (300x250) lines
+    // up with an invertible registry entry. The synthesized id carries
+    // the slash, surfacing the cross-schema mismatch we filed upstream
+    // (format-id.json pattern rejects slashes).
+    const fixture = JSON.parse(readFileSync(path.join(FIXTURE_DIR, 'nytimes_homepage_mrec.json'), 'utf-8'));
+    const { v1, diagnostics } = projectV2ProductToV1(fixture);
+    assert.strictEqual(diagnostics.length, 0);
+    assert.strictEqual(v1.format_ids.length, 1);
+    const fid = v1.format_ids[0];
+    assert.strictEqual(fid.id, 'iab/mrec_300x250');
+    assert.strictEqual(fid.width, 300);
+    assert.strictEqual(fid.height, 250);
+    assert.strictEqual(fid.agent_url, 'https://creative.adcontextprotocol.org');
+  });
+});
+
+describe('v2 → v1 projection — ecosystem-wide summary', () => {
+  test('emit a coverage report (informational, always passes)', () => {
+    const fixtures = loadFixtures();
+    const buckets = {
+      clean_v1_emit: [],
+      explicit_opt_out: [],
+      ambiguous_registry: [],
+      no_registry_match: [],
+    };
+    for (const { name, product } of fixtures) {
+      const { v1, diagnostics } = projectV2ProductToV1(product);
+      if (diagnostics.length === 0 && v1.format_ids.length > 0) {
+        buckets.clean_v1_emit.push(name);
+        continue;
+      }
+      for (const d of diagnostics) {
+        if (d.code === 'FORMAT_DECLARATION_V1_UNREACHABLE') {
+          if (d.details.reason === 'canonical_formats_only') {
+            buckets.explicit_opt_out.push(`${name} (${d.details.format_kind})`);
+          } else {
+            buckets.no_registry_match.push(`${name} (${d.details.format_kind})`);
+          }
+        } else if (d.code === 'FORMAT_DECLARATION_V1_AMBIGUOUS') {
+          buckets.ambiguous_registry.push(`${name} (${d.details.format_kind})`);
+        }
+      }
+    }
+    console.log('\n=== v2 → v1 projection coverage (13 spec fixtures) ===\n');
+    console.log(`Clean v1 emit (${buckets.clean_v1_emit.length}/${fixtures.length}):`);
+    for (const n of buckets.clean_v1_emit) console.log(`  ✓ ${n}`);
+    console.log(`\nExplicit canonical_formats_only opt-out (${buckets.explicit_opt_out.length}):`);
+    for (const n of buckets.explicit_opt_out) console.log(`  ✗ ${n}`);
+    console.log(
+      `\nAmbiguous registry match — family exists but not invertible (${buckets.ambiguous_registry.length}):`
+    );
+    for (const n of buckets.ambiguous_registry) console.log(`  ? ${n}`);
+    console.log(`\nNo registry entry for the canonical (${buckets.no_registry_match.length}):`);
+    for (const n of buckets.no_registry_match) console.log(`  ✗ ${n}`);
+    console.log('');
+    // Informational test — always passes. Real assertions live above.
+    assert.ok(true);
+  });
+});

--- a/test/lib/v2-to-v1-projection.test.js
+++ b/test/lib/v2-to-v1-projection.test.js
@@ -81,7 +81,12 @@ describe('v2 → v1 projection — seller-asserted v1_format_ref (the only norma
     ['nytimes_homepage_html5', 'https://creative.adcontextprotocol.org/', 'display_300x250_html'],
     ['gam_3p_display_tag', 'https://creative.adcontextprotocol.org/', 'display_js'],
     ['youtube_vast_preroll', 'https://creative.adcontextprotocol.org/', 'video_vast_30s'],
-    ['meta_reels_us', 'https://meta.adcp', 'meta_reels'],
+    // After the publisher-scoped format catalog landed upstream
+    // (adcp commit e2fae6b086), Meta moved to the AAO community-
+    // mirror tier — `mirror.adcontextprotocol.org/translated/meta`
+    // hosts the catalog until Meta adopts adagents.json#/formats
+    // themselves.
+    ['meta_reels_us', 'https://mirror.adcontextprotocol.org/translated/meta', 'meta_reels'],
   ];
 
   for (const [fixture, expectedAgentUrl, expectedId] of sellerAsserted) {

--- a/test/lib/v2-to-v1-projection.test.js
+++ b/test/lib/v2-to-v1-projection.test.js
@@ -5,12 +5,12 @@
 // video_hosted (×2), video_vast, audio_hosted, audio_daast,
 // sponsored_placement, responsive_creative, agent_placement, custom.
 //
-// The interesting question this test answers: how many of the 13
-// real-world v2 declarations have a clean v1 form, and how many would
-// be unreachable from a v1-only buyer? The answer informs whether the
-// 8.0 design's "v2-only public type with projection at the boundary"
-// is operable today, or whether sellers need to start adding
-// v1_format_ref before the SDK can downgrade gracefully.
+// Tests align with the normative rules in
+// `core/registries/v1-canonical-mapping.json` (direction-of-truth
+// statement + step-5 ambiguous family rule) and the `v1_translatable`
+// field on canonical schemas. SDK-local diagnostic codes
+// (`FORMAT_DECLARATION_V1_NOT_APPLICABLE`, `CANONICAL_NOT_V1_TRANSLATABLE`)
+// surface cases the spec leaves to SDK discretion.
 
 const { test, describe } = require('node:test');
 const assert = require('node:assert');
@@ -30,97 +30,142 @@ function loadFixtures() {
     }));
 }
 
-describe('v2 → v1 Product projection — per-fixture verdict', () => {
+describe('v2 → v1 Product projection — per-fixture structural invariant', () => {
   for (const { name, product } of loadFixtures()) {
     test(name, () => {
       const { v1, diagnostics } = projectV2ProductToV1(product);
-      // Every fixture's product_id passes through unchanged — the
-      // projection rewrites only format_ids / format_options.
       assert.strictEqual(v1.product_id, product.product_id);
-      // The structural invariant: format_ids count + diagnostic count
-      // equals total format_options count (every input declaration
-      // produces either a format_id OR a diagnostic, never both, never
-      // neither).
+      // Every input declaration produces either a v1 emit or a
+      // diagnostic — never both, never neither.
       const declCount = product.format_options.length;
       assert.strictEqual(
         v1.format_ids.length + diagnostics.length,
         declCount,
         `every format_options[i] must produce either a v1 emit or a diagnostic`
       );
+      // Every diagnostic must carry the spec-mandated source + sdk_id.
+      for (const d of diagnostics) {
+        assert.strictEqual(d.source, 'sdk');
+        assert.match(d.sdk_id, /^@adcp\/sdk@\d+\.\d+\.\d+/);
+        assert.ok(d.field.includes(product.product_id), 'field must point at offending declaration');
+      }
     });
   }
 });
 
-describe('v2 → v1 projection — explicit canonical_formats_only opt-out', () => {
-  test('nytimes_homepage_takeover_custom is unreachable from v1', () => {
-    const fixture = JSON.parse(readFileSync(path.join(FIXTURE_DIR, 'nytimes_homepage_takeover_custom.json'), 'utf-8'));
-    const { v1, diagnostics } = projectV2ProductToV1(fixture);
-    assert.strictEqual(v1.format_ids.length, 0);
-    assert.strictEqual(diagnostics.length, 1);
-    assert.strictEqual(diagnostics[0].code, 'FORMAT_DECLARATION_V1_UNREACHABLE');
-    assert.strictEqual(diagnostics[0].details.reason, 'canonical_formats_only');
-    assert.match(diagnostics[0].details.hint, /opts out of v1/);
-  });
-});
-
-describe('v2 → v1 projection — IAB image with registry-matched dimensions', () => {
-  test('nytimes_homepage_mrec projects to iab/mrec_300x250', () => {
-    // The only fixture whose canonical (image) + params (300x250) lines
-    // up with an invertible registry entry. The synthesized id carries
-    // the slash, surfacing the cross-schema mismatch we filed upstream
-    // (format-id.json pattern rejects slashes).
+describe('v2 → v1 projection — seller-asserted v1_format_ref (the only normative path)', () => {
+  test('nytimes_homepage_mrec projects via v1_format_ref', () => {
     const fixture = JSON.parse(readFileSync(path.join(FIXTURE_DIR, 'nytimes_homepage_mrec.json'), 'utf-8'));
     const { v1, diagnostics } = projectV2ProductToV1(fixture);
     assert.strictEqual(diagnostics.length, 0);
     assert.strictEqual(v1.format_ids.length, 1);
-    const fid = v1.format_ids[0];
-    assert.strictEqual(fid.id, 'iab/mrec_300x250');
-    assert.strictEqual(fid.width, 300);
-    assert.strictEqual(fid.height, 250);
-    assert.strictEqual(fid.agent_url, 'https://creative.adcontextprotocol.org');
+    // Comes from the declaration's v1_format_ref, not from registry
+    // synthesis — the registry path is non-normative.
+    assert.strictEqual(v1.format_ids[0].agent_url, 'https://nytimes.adcp');
+    assert.strictEqual(v1.format_ids[0].id, 'iab_mrec_300x250');
+  });
+
+  test('triton_daast_audio_30s projects via v1_format_ref', () => {
+    const fixture = JSON.parse(readFileSync(path.join(FIXTURE_DIR, 'triton_daast_audio_30s.json'), 'utf-8'));
+    const { v1, diagnostics } = projectV2ProductToV1(fixture);
+    assert.strictEqual(diagnostics.length, 0);
+    assert.strictEqual(v1.format_ids.length, 1);
+    assert.strictEqual(v1.format_ids[0].agent_url, 'https://triton.adcp');
+    assert.strictEqual(v1.format_ids[0].id, 'daast_audio_30s_v1_1');
   });
 });
 
-describe('v2 → v1 projection — ecosystem-wide summary', () => {
-  test('emit a coverage report (informational, always passes)', () => {
+describe('v2 → v1 projection — canonical_formats_only opt-out', () => {
+  test('nytimes_homepage_takeover_custom emits FORMAT_DECLARATION_V1_NOT_APPLICABLE', () => {
+    const fixture = JSON.parse(readFileSync(path.join(FIXTURE_DIR, 'nytimes_homepage_takeover_custom.json'), 'utf-8'));
+    const { v1, diagnostics } = projectV2ProductToV1(fixture);
+    assert.strictEqual(v1.format_ids.length, 0);
+    assert.strictEqual(diagnostics.length, 1);
+    assert.strictEqual(diagnostics[0].code, 'FORMAT_DECLARATION_V1_NOT_APPLICABLE');
+    assert.strictEqual(diagnostics[0].error.details.reason, 'canonical_formats_only');
+  });
+});
+
+describe('v2 → v1 projection — v1_translatable: false (4 inherently-v2 canonicals)', () => {
+  const inherentlyV2 = [
+    ['amazon_sponsored_products', 'sponsored_placement'],
+    ['chatgpt_brand_mention', 'agent_placement'],
+    ['google_performance_max', 'responsive_creative'],
+    ['meta_carousel', 'image_carousel'],
+  ];
+
+  for (const [fixture, kind] of inherentlyV2) {
+    test(`${fixture} (${kind}) emits CANONICAL_NOT_V1_TRANSLATABLE (not FORMAT_PROJECTION_FAILED)`, () => {
+      const product = JSON.parse(readFileSync(path.join(FIXTURE_DIR, `${fixture}.json`), 'utf-8'));
+      const { v1, diagnostics } = projectV2ProductToV1(product);
+      assert.strictEqual(v1.format_ids.length, 0);
+      assert.strictEqual(diagnostics.length, 1);
+      assert.strictEqual(
+        diagnostics[0].code,
+        'CANONICAL_NOT_V1_TRANSLATABLE',
+        'spec is explicit: MUST NOT emit FORMAT_PROJECTION_FAILED for v1_translatable: false canonicals'
+      );
+      assert.strictEqual(diagnostics[0].error.details.format_kind, kind);
+    });
+  }
+});
+
+describe('v2 → v1 projection — coverage report (informational)', () => {
+  test('emit a bucket-by-bucket coverage report', () => {
     const fixtures = loadFixtures();
     const buckets = {
-      clean_v1_emit: [],
-      explicit_opt_out: [],
-      ambiguous_registry: [],
+      clean_v1_emit_via_v1_format_ref: [],
+      clean_v1_emit_via_registry_match: [],
+      canonical_formats_only_optout: [],
+      canonical_not_v1_translatable: [],
+      ambiguous_registry_match: [],
       no_registry_match: [],
     };
     for (const { name, product } of fixtures) {
       const { v1, diagnostics } = projectV2ProductToV1(product);
       if (diagnostics.length === 0 && v1.format_ids.length > 0) {
-        buckets.clean_v1_emit.push(name);
+        // Distinguish v1_format_ref (normative) from registry synthesis (non-normative).
+        const usedV1FormatRef = product.format_options.some(o => o.v1_format_ref);
+        (usedV1FormatRef ? buckets.clean_v1_emit_via_v1_format_ref : buckets.clean_v1_emit_via_registry_match).push(
+          name
+        );
         continue;
       }
       for (const d of diagnostics) {
-        if (d.code === 'FORMAT_DECLARATION_V1_UNREACHABLE') {
-          if (d.details.reason === 'canonical_formats_only') {
-            buckets.explicit_opt_out.push(`${name} (${d.details.format_kind})`);
-          } else {
-            buckets.no_registry_match.push(`${name} (${d.details.format_kind})`);
-          }
-        } else if (d.code === 'FORMAT_DECLARATION_V1_AMBIGUOUS') {
-          buckets.ambiguous_registry.push(`${name} (${d.details.format_kind})`);
+        const tag = `${name} (${d.error.details.format_kind})`;
+        switch (d.code) {
+          case 'FORMAT_DECLARATION_V1_NOT_APPLICABLE':
+            buckets.canonical_formats_only_optout.push(tag);
+            break;
+          case 'CANONICAL_NOT_V1_TRANSLATABLE':
+            buckets.canonical_not_v1_translatable.push(tag);
+            break;
+          case 'FORMAT_DECLARATION_V1_AMBIGUOUS':
+            buckets.ambiguous_registry_match.push(tag);
+            break;
+          case 'FORMAT_PROJECTION_FAILED':
+            buckets.no_registry_match.push(tag);
+            break;
         }
       }
     }
-    console.log('\n=== v2 → v1 projection coverage (13 spec fixtures) ===\n');
-    console.log(`Clean v1 emit (${buckets.clean_v1_emit.length}/${fixtures.length}):`);
-    for (const n of buckets.clean_v1_emit) console.log(`  ✓ ${n}`);
-    console.log(`\nExplicit canonical_formats_only opt-out (${buckets.explicit_opt_out.length}):`);
-    for (const n of buckets.explicit_opt_out) console.log(`  ✗ ${n}`);
-    console.log(
-      `\nAmbiguous registry match — family exists but not invertible (${buckets.ambiguous_registry.length}):`
-    );
-    for (const n of buckets.ambiguous_registry) console.log(`  ? ${n}`);
-    console.log(`\nNo registry entry for the canonical (${buckets.no_registry_match.length}):`);
-    for (const n of buckets.no_registry_match) console.log(`  ✗ ${n}`);
-    console.log('');
-    // Informational test — always passes. Real assertions live above.
+    console.log('\n=== v2 → v1 projection coverage (13 spec fixtures, post-upstream-fixes) ===\n');
+    const line = (label, list) => {
+      console.log(`${label} (${list.length}):`);
+      for (const n of list) console.log(`  ${n}`);
+    };
+    line('Clean v1 emit via v1_format_ref (NORMATIVE)', buckets.clean_v1_emit_via_v1_format_ref);
+    console.log();
+    line('Clean v1 emit via registry synthesis (NON-NORMATIVE)', buckets.clean_v1_emit_via_registry_match);
+    console.log();
+    line('Seller-asserted canonical_formats_only opt-out', buckets.canonical_formats_only_optout);
+    console.log();
+    line('Inherently v2 — v1_translatable: false on canonical', buckets.canonical_not_v1_translatable);
+    console.log();
+    line('Ambiguous registry family (FORMAT_DECLARATION_V1_AMBIGUOUS)', buckets.ambiguous_registry_match);
+    console.log();
+    line('No registry coverage (FORMAT_PROJECTION_FAILED)', buckets.no_registry_match);
+    console.log();
     assert.ok(true);
   });
 });

--- a/test/lib/v2-to-v1-projection.test.js
+++ b/test/lib/v2-to-v1-projection.test.js
@@ -14,12 +14,27 @@
 
 const { test, describe } = require('node:test');
 const assert = require('node:assert');
-const { readFileSync, readdirSync } = require('node:fs');
+const { readFileSync, readdirSync, existsSync } = require('node:fs');
 const path = require('node:path');
 
 const { projectV2ProductToV1 } = require('../../dist/lib/v2/projection/v2-to-v1.js');
 
 const FIXTURE_DIR = path.join(__dirname, 'v2-projection-fixtures');
+
+// The projection layer reads the v1-canonical-mapping registry and the
+// canonical-format schemas (for v1_translatable). Both live under
+// `schemas/cache/3.1.0-beta.0/` which is gitignored and only present
+// locally — CI only syncs the SDK-pinned stable version (3.0.12).
+//
+// Until adcontextprotocol/adcp#3307 merges and publishes a real 3.1.0
+// tarball that `npm run sync-schemas` can pull, these tests skip in
+// CI with a clear reason. Run locally after rebuilding the 3.1-beta
+// cache (see PR #1815 description).
+const SKIP_REASON = existsSync(
+  path.join(__dirname, '..', '..', 'schemas', 'cache', '3.1.0-beta.0', 'registries', 'v1-canonical-mapping.json')
+)
+  ? false
+  : 'requires schemas/cache/3.1.0-beta.0/ — only present in workspaces with a local 3.1-beta sync';
 
 function loadFixtures() {
   return readdirSync(FIXTURE_DIR)
@@ -30,7 +45,7 @@ function loadFixtures() {
     }));
 }
 
-describe('v2 → v1 Product projection — per-fixture structural invariant', () => {
+describe('v2 → v1 Product projection — per-fixture structural invariant', { skip: SKIP_REASON }, () => {
   for (const { name, product } of loadFixtures()) {
     test(name, () => {
       const { v1, diagnostics } = projectV2ProductToV1(product);
@@ -53,7 +68,7 @@ describe('v2 → v1 Product projection — per-fixture structural invariant', ()
   }
 });
 
-describe('v2 → v1 projection — seller-asserted v1_format_ref (the only normative path)', () => {
+describe('v2 → v1 projection — seller-asserted v1_format_ref (the only normative path)', { skip: SKIP_REASON }, () => {
   // After the registry↔catalog reconciliation upstream, 4 IAB-standard
   // fixtures point at AAO-canonical agent_url + catalog ids; 1 Meta-
   // specific fixture keeps a publisher-specific agent_url. This is the
@@ -80,7 +95,7 @@ describe('v2 → v1 projection — seller-asserted v1_format_ref (the only norma
   }
 });
 
-describe('v2 → v1 projection — canonical_formats_only opt-out', () => {
+describe('v2 → v1 projection — canonical_formats_only opt-out', { skip: SKIP_REASON }, () => {
   // Two fixtures use this now: the NYTimes custom takeover (no v1 form
   // possible — multi-placement) and triton_daast (catalog has no DAAST
   // entry yet, so the seller opted out rather than fabricating an id).
@@ -100,7 +115,7 @@ describe('v2 → v1 projection — canonical_formats_only opt-out', () => {
   }
 });
 
-describe('v2 → v1 projection — v1_translatable: false (4 inherently-v2 canonicals)', () => {
+describe('v2 → v1 projection — v1_translatable: false (4 inherently-v2 canonicals)', { skip: SKIP_REASON }, () => {
   const inherentlyV2 = [
     ['amazon_sponsored_products', 'sponsored_placement'],
     ['chatgpt_brand_mention', 'agent_placement'],
@@ -124,7 +139,7 @@ describe('v2 → v1 projection — v1_translatable: false (4 inherently-v2 canon
   }
 });
 
-describe('v2 → v1 projection — coverage report (informational)', () => {
+describe('v2 → v1 projection — coverage report (informational)', { skip: SKIP_REASON }, () => {
   test('emit a bucket-by-bucket coverage report', () => {
     const fixtures = loadFixtures();
     const buckets = {


### PR DESCRIPTION
**Draft.** Companion to PR #1809 (8.0 design proposal). This implements and stress-tests the v2 → v1 projection layer the design proposes — to see if the "v2-only public API, project to v1 at the boundary" stance is actually operable today.

## What it does

Takes a V2 `Product` (with `format_options[]`) and produces a v1 `Product` (with `format_ids[]`) suitable for sending to a v1-only seller. The resolution order mirrors `v1-canonical-mapping.json`, inverted:

| Step | Path | Outcome |
|---|---|---|
| 1 | `format_kind: "custom"` + `canonical_formats_only: true` | No v1 emit. `FORMAT_DECLARATION_V1_UNREACHABLE` diagnostic. |
| 2 | `v1_format_ref` present on the declaration | Use verbatim (seller-asserted equivalence — highest confidence). |
| 3 | Registry reverse-lookup finds an invertible literal entry | Synthesize a v1 `format_id`. |
| 4 | Registry has entries but none invert (wildcarded / structural) | No v1 emit. `FORMAT_DECLARATION_V1_AMBIGUOUS` diagnostic. |
| 5 | Registry has no entries for this canonical | No v1 emit. `FORMAT_DECLARATION_V1_UNREACHABLE` diagnostic. |

All diagnostics on a structured channel — never logger-only, per the spec's resolution-order amendment.

## Coverage against 13 spec reference fixtures

Vendored from `adcontextprotocol/adcp#3307` `static/examples/products/canonical/`. The fixtures span 12 of the 13 canonical format_kinds.

```
=== v2 → v1 projection coverage (13 spec fixtures) ===

Clean v1 emit (1/13):
  ✓ nytimes_homepage_mrec

Explicit canonical_formats_only opt-out (1):
  ✗ nytimes_homepage_takeover_custom (custom)

Ambiguous registry match — family exists but not invertible (7):
  ? gam_3p_display_tag (display_tag)
  ? meta_reels_us (video_hosted)
  ? nytimes_homepage_html5 (html5)
  ? the_daily_30s_host_read (audio_hosted)
  ? triton_daast_audio_30s (audio_daast)
  ? veo_generative_video_15s (video_hosted)
  ? youtube_vast_preroll (video_vast)

No registry entry for the canonical (4):
  ✗ amazon_sponsored_products (sponsored_placement)
  ✗ chatgpt_brand_mention (agent_placement)
  ✗ google_performance_max (responsive_creative)
  ✗ meta_carousel (image_carousel)
```

## Headline findings

### 1. Only 8% of v2 fixtures project cleanly without seller intervention

92% of the spec's own reference fixtures can't be downgraded today. Implications for the 8.0 design:

- The "V2-only public API, projection at the boundary" stance still works — products that can't downgrade surface via diagnostics; the v1 buyer doesn't see them. Honest.
- But the "make v1 sellers look V2-shaped" promise depends on **sellers actively adding `v1_format_ref`** to their declarations. The current spec reference fixtures don't model this — none of them carry `v1_format_ref`.
- 4 of the 13 canonicals (`sponsored_placement`, `agent_placement`, `responsive_creative`, `image_carousel`) are genuinely new concepts in v2 with no v1 form possible. Those products simply won't exist on the v1 wire — and that's correct.

### 2. The registry's IAB-named entries produce wire-invalid format_ids

The only fixture that projects cleanly (`nytimes_homepage_mrec`) synthesizes `format_id.id: "iab/mrec_300x250"` — but `format-id.json` requires `^[a-zA-Z0-9_-]+$`, which rejects slashes. Same cross-schema mismatch we flagged upstream when surveying the registry earlier. **The clean-emit path itself currently produces wire-invalid output.** The projection layer surfaces this rather than papering over it.

### 3. Registry needs an explicit "v1-unreachable" signal per canonical

Four canonicals (`sponsored_placement`, `agent_placement`, `responsive_creative`, `image_carousel`) have NO registry entries. The projection emits `reason: "no_v1_format_ref_or_registry_match"` — but really, the spec could declare these canonicals as inherently v1-unreachable, the same way `canonical_formats_only: true` declares per-product unreachability. Would let adopters distinguish "spec says no v1 form exists for this canonical" from "spec hasn't filled in this entry yet."

## What's in scope vs not

**In scope** (this PR):
- `src/lib/v2/projection/{types,registry,v2-to-v1}.ts` — projection module.
- `test/lib/v2-to-v1-projection.test.js` — 16 cases across 4 suites.
- Vendored fixtures at `test/lib/v2-projection-fixtures/`.
- Diagnostic surface (typed).
- Hand-rolled TypeScript types matching schema shape at projection precision.

**Explicit non-scope**:
- v1 → v2 (upgrade) direction — symmetric counterpart, follow-up.
- Full versioned codegen — separate piece of the 8.0 enablement; types here are minimal hand-rolls.
- Public barrel export — projection is internal-only until auto-negotiation lands.
- Auto-negotiation per agent — design-doc territory; not implemented here.
- `fetchFormatSchema` for custom shapes — separate piece.

## Test plan
- [x] Typecheck clean.
- [x] All 16 test cases pass (4 suites: per-fixture verdict, opt-out, IAB image, ecosystem coverage).
- [x] `npm run format:check` clean (vendored fixtures added to `.prettierignore` per the same rule as `webhook-signing-vectors/`).
- [x] Structural invariant verified for every fixture: `format_ids.length + diagnostics.length === format_options.length`.
- [ ] CI green.

## Reviewer focus

Treat this as a design-prototype PR, not a feature PR. The key questions:
1. Does the projection algorithm produce honest output for the messy fixtures? (Read the coverage report.)
2. Are the diagnostic codes (`FORMAT_DECLARATION_V1_UNREACHABLE`, `FORMAT_DECLARATION_V1_AMBIGUOUS`) the right vocabulary, or should they unify?
3. Does this confirm the 8.0 design (PR #1809) is workable, or does it surface a flaw?

🤖 Generated with [Claude Code](https://claude.com/claude-code)