### PR TITLE
feat(signing): signResponse for RFC 9421 response signing (#1822)

### DIFF
--- a/.changeset/response-signing-1822.md
+++ b/.changeset/response-signing-1822.md
@@ -36,3 +36,10 @@ callers that need to hand the canonical base to an external signer.
 Tag: `adcp/response-signing/v1`. `AdcpUse` extended with `'response-signing'`
 so JWK metadata can declare the binding now — the matching verifier helper
 (`verifyResponseSignature`) is a separate follow-up.
+
+**Note on `AdcpUse` widening:** the `AdcpUse` union now includes
+`'response-signing'`. Consumers with exhaustive `switch (use)` blocks
+backed by `never` checks will need to add a `case 'response-signing':`
+arm. Pragmatically a minor bump — the runtime surface is purely additive
+and no existing call site changes — but exhaustive narrowers must opt-in
+to handle the new member.

--- a/.changeset/response-signing-1822.md
+++ b/.changeset/response-signing-1822.md
@@ -23,19 +23,34 @@ const signed = signResponse(response, key);
 // signed.headers now carries Signature, Signature-Input, Content-Digest.
 ```
 
-Covered components default to `['@status', '@authority']`, plus `content-type`
-+ `content-digest` automatically when the response carries a body — same
-conditional shape as `signRequest`. Callers that want to bind to a specific
-request URL can opt-in to `@target-uri` via `additionalComponents`.
+Covered components default to `['@status', '@authority', '@target-uri']`,
+plus `content-type` + `content-digest` automatically when the response
+carries a body. `@target-uri` is in the defaults (not opt-in) so a
+multi-tenant seller can't emit signatures interchangeable across endpoints
+sharing the same authority — matches RFC 9421 §B.2.5 examples. Callers
+that need to extend the covered set further (`@method`, custom headers)
+opt in via `additionalComponents`.
+
+**Asymmetry vs `signRequest`.** Response-signing defaults `coverContentDigest`
+to `true` when the response has a body (opt-out); request-signing requires
+an explicit `coverContentDigest: true` (opt-in). The asymmetry is deliberate:
+an unbound response body is the most common cross-purpose footgun for
+response signing (attacker can swap payload but keep headers + signature).
+Webhook signing also forces content-digest unconditionally for the same
+reason.
 
 Async + KMS-shaped path: `signResponseAsync(response, provider)` delegates the
 crypto to the existing `SigningProvider` interface; the prepare/finalize split
 (`prepareResponseSignature` / `finalizeResponseSignature`) is exported for
 callers that need to hand the canonical base to an external signer.
 
-Tag: `adcp/response-signing/v1`. `AdcpUse` extended with `'response-signing'`
-so JWK metadata can declare the binding now — the matching verifier helper
-(`verifyResponseSignature`) is a separate follow-up.
+Tag: `adcp/response-signing/v1`. **Wire-format contract is provisional**
+until `verifyResponseSignature` (follow-up) lands and is exercised against
+external SDK implementations. The `v1` suffix gives a clean break path —
+any breaking change ships as `v2` and verifiers reject `v1`. Adopters
+shipping signed responses today should pin a major SDK version. `AdcpUse`
+extended with `'response-signing'` so JWK metadata can declare the binding
+now.
 
 **Note on `AdcpUse` widening:** the `AdcpUse` union now includes
 `'response-signing'`. Consumers with exhaustive `switch (use)` blocks

--- a/.changeset/response-signing-1822.md
+++ b/.changeset/response-signing-1822.md
@@ -43,3 +43,28 @@ backed by `never` checks will need to add a `case 'response-signing':`
 arm. Pragmatically a minor bump — the runtime surface is purely additive
 and no existing call site changes — but exhaustive narrowers must opt-in
 to handle the new member.
+
+**Signer-side `adcp_use` purpose binding (closes #1825).** All three sync
+signer entry points now refuse keys whose `adcp_use` doesn't match the
+helper:
+
+- `signRequest` requires `adcp_use: 'request-signing'`
+- `signWebhook` requires `adcp_use: 'webhook-signing'`
+- `signResponse` requires `adcp_use: 'response-signing'`
+
+Mismatch (including a missing `adcp_use`) throws at the signer with the
+same error code the verifier raises at step 8 (`*_signature_key_purpose_invalid`),
+so misconfiguration surfaces at configuration time rather than at the
+receiver. Production callers using `pemToAdcpJwk({ adcp_use: ... })` to
+mint keys are already correct by construction; anyone reusing a key
+across purposes will get a clear remediation message.
+
+Test-vector authors that need to *deliberately* sign with a wrong-purpose
+key (e.g. AdCP negative-vector 009 cross-purpose rejection) can compose
+the lower-level `prepareRequestSignature` + `finalizeRequestSignature`
+helpers directly — those take a `SignatureIdentity` and skip the gate
+because they're designed for KMS-shaped async paths where purpose
+binding happens via the `SigningProvider`. The internal storyboard
+builder uses this composition pattern; see
+`src/lib/testing/storyboard/request-signing/builder.ts` for the
+canonical shape.

--- a/.changeset/response-signing-1822.md
+++ b/.changeset/response-signing-1822.md
@@ -1,0 +1,38 @@
+---
+'@adcp/sdk': minor
+---
+
+signing: add `signResponse` for RFC 9421 §2.2.9 response signing (#1822)
+
+Rounds out the signing surface — `signRequest` (buyer→server), `signWebhook`
+(server→receiver), and now `signResponse` (server→buyer) all share the same
+prepare/finalize shape and `SigningProvider` async path.
+
+```ts
+import { signResponse, type ResponseLike } from '@adcp/sdk/signing/client';
+
+const response: ResponseLike = {
+  status: 200,
+  headers: { 'content-type': 'application/json' },
+  body: JSON.stringify({ products: [...] }),
+  // Originating request — needed to bind @authority back to its origin.
+  request: { method: 'POST', url: 'https://seller.example.com/adcp/get_products' },
+};
+
+const signed = signResponse(response, key);
+// signed.headers now carries Signature, Signature-Input, Content-Digest.
+```
+
+Covered components default to `['@status', '@authority']`, plus `content-type`
++ `content-digest` automatically when the response carries a body — same
+conditional shape as `signRequest`. Callers that want to bind to a specific
+request URL can opt-in to `@target-uri` via `additionalComponents`.
+
+Async + KMS-shaped path: `signResponseAsync(response, provider)` delegates the
+crypto to the existing `SigningProvider` interface; the prepare/finalize split
+(`prepareResponseSignature` / `finalizeResponseSignature`) is exported for
+callers that need to hand the canonical base to an external signer.
+
+Tag: `adcp/response-signing/v1`. `AdcpUse` extended with `'response-signing'`
+so JWK metadata can declare the binding now — the matching verifier helper
+(`verifyResponseSignature`) is a separate follow-up.

--- a/src/lib/signing/canonicalize.ts
+++ b/src/lib/signing/canonicalize.ts
@@ -7,6 +7,24 @@ export interface RequestLike {
   body?: string;
 }
 
+/**
+ * RFC 9421 §2.2.9 response-signing context. Carries the response status and
+ * its headers/body, plus the originating request's method + URL so derived
+ * components that bind back to the request context (`@method`, `@target-uri`,
+ * `@authority`) resolve correctly.
+ */
+export interface ResponseLike {
+  status: number;
+  headers: Record<string, string | string[] | undefined>;
+  body?: string;
+  /**
+   * Originating request context. Required because RFC 9421 §2.2 binds
+   * response signatures to their request context via `@authority` (and
+   * optionally `@target-uri` / `@method` if the caller opts in).
+   */
+  request: { method: string; url: string };
+}
+
 export interface SignatureParams {
   created: number;
   expires: number;
@@ -27,7 +45,7 @@ const DEFAULT_PARAM_ORDER: ReadonlyArray<keyof SignatureParams> = [
 
 const STRING_PARAMS = new Set<keyof SignatureParams>(['nonce', 'keyid', 'alg', 'tag']);
 
-const SUPPORTED_DERIVED = new Set(['@method', '@target-uri', '@authority']);
+const SUPPORTED_DERIVED = new Set(['@method', '@target-uri', '@authority', '@status']);
 
 export function canonicalTargetUri(rawUrl: string): string {
   rejectNonAsciiHost(rawUrl);
@@ -109,6 +127,45 @@ export function buildSignatureBase(
   return lines.join('\n');
 }
 
+/**
+ * Build the RFC 9421 §2.5 signature base for a response.
+ *
+ * Resolves `@status` from `response.status` and binds the remaining derived
+ * components (`@method`, `@target-uri`, `@authority`) to the originating
+ * request carried on `response.request`. Header components resolve against
+ * `response.headers`. `signatureParamsValue` works the same as for
+ * {@link buildSignatureBase} — pass it on the verifier path to keep byte
+ * identity with whatever `Signature-Input` the peer sent.
+ */
+export function buildResponseSignatureBase(
+  components: ReadonlyArray<string>,
+  response: ResponseLike,
+  params: SignatureParams,
+  signatureParamsValue?: string
+): string {
+  const requestView: RequestLike = {
+    method: response.request.method,
+    url: response.request.url,
+    headers: response.headers,
+    body: response.body,
+  };
+  const lines: string[] = [];
+  for (const component of components) {
+    const value = component === '@status' ? String(response.status) : resolveComponentValue(component, requestView);
+    if (value === undefined) {
+      throw new RequestSignatureError(
+        'request_signature_components_incomplete',
+        6,
+        `Covered component "${component}" not present in response`
+      );
+    }
+    lines.push(`"${component}": ${value}`);
+  }
+  const paramsString = signatureParamsValue ?? formatSignatureParams(components, params);
+  lines.push(`"@signature-params": ${paramsString}`);
+  return lines.join('\n');
+}
+
 export function formatSignatureParams(components: ReadonlyArray<string>, params: SignatureParams): string {
   const componentList = components.map(c => `"${c}"`).join(' ');
   const paramPairs: string[] = [];
@@ -136,6 +193,12 @@ function resolveComponentValue(component: string, request: RequestLike): string 
         return canonicalTargetUri(request.url);
       case '@authority':
         return canonicalAuthority(request.url);
+      case '@status':
+        throw new RequestSignatureError(
+          'request_signature_components_unexpected',
+          6,
+          '"@status" is only valid in response-signing context; use buildResponseSignatureBase'
+        );
     }
   }
   return getHeaderValue(request.headers, component);

--- a/src/lib/signing/canonicalize.ts
+++ b/src/lib/signing/canonicalize.ts
@@ -21,6 +21,18 @@ export interface ResponseLike {
    * Originating request context. Required because RFC 9421 §2.2 binds
    * response signatures to their request context via `@authority` (and
    * optionally `@target-uri` / `@method` if the caller opts in).
+   *
+   * `url` MUST be an absolute URL — `canonicalAuthority` / `canonicalTargetUri`
+   * parse it through `new URL(...)` and will throw on a relative path. Express
+   * handlers ship `req.url` / `req.originalUrl` as path-only; reconstruct in
+   * the handler before passing in:
+   *
+   * ```ts
+   * const url = `${req.protocol}://${req.get('host')}${req.originalUrl}`;
+   * ```
+   *
+   * Same shape applies to Lambda (`event.requestContext.domainName` +
+   * `event.rawPath`) and Workers (`request.url` is already absolute).
    */
   request: { method: string; url: string };
 }

--- a/src/lib/signing/canonicalize.ts
+++ b/src/lib/signing/canonicalize.ts
@@ -19,8 +19,8 @@ export interface ResponseLike {
   body?: string;
   /**
    * Originating request context. Required because RFC 9421 §2.2 binds
-   * response signatures to their request context via `@authority` (and
-   * optionally `@target-uri` / `@method` if the caller opts in).
+   * response signatures to their request context via `@authority` and
+   * `@target-uri` (see {@link RESPONSE_MANDATORY_COMPONENTS}).
    *
    * `url` MUST be an absolute URL — `canonicalAuthority` / `canonicalTargetUri`
    * parse it through `new URL(...)` and will throw on a relative path. Express
@@ -33,6 +33,16 @@ export interface ResponseLike {
    *
    * Same shape applies to Lambda (`event.requestContext.domainName` +
    * `event.rawPath`) and Workers (`request.url` is already absolute).
+   *
+   * **Security note for proxied deployments.** `req.protocol` and
+   * `req.get('host')` are attacker-controlled when the server sits behind
+   * a reverse proxy that doesn't strip / validate `Host` and
+   * `X-Forwarded-*` headers. A hostile peer that controls these can rebind
+   * your signature to `attacker.example.com` while the operator believes
+   * they're signing for `seller.example.com`. Set `app.set('trust proxy',
+   * ...)` to your trusted proxy IPs, validate `Host` against an allowlist
+   * before passing in here, and prefer `https://` always (response
+   * signatures bound to `http://` will fail strict-HTTPS verifier profiles).
    */
   request: { method: string; url: string };
 }

--- a/src/lib/signing/client.ts
+++ b/src/lib/signing/client.ts
@@ -44,7 +44,16 @@ export { WEBHOOK_MANDATORY_COMPONENTS, WEBHOOK_SIGNING_TAG } from './webhook-ver
 export { createSigningFetch, type CoverContentDigestPredicate, type SigningFetchOptions } from './fetch';
 export { createSigningFetchAsync } from './fetch-async';
 export type { SigningProvider } from './provider';
-export { SigningProviderAlgorithmMismatchError, type SigningProviderErrorCode } from './errors';
+export {
+  RequestSignatureError,
+  type RequestSignatureErrorCode,
+  ResponseSignatureError,
+  type ResponseSignatureErrorCode,
+  SigningProviderAlgorithmMismatchError,
+  type SigningProviderErrorCode,
+  WebhookSignatureError,
+  type WebhookSignatureErrorCode,
+} from './errors';
 export {
   ALLOWED_ALGS,
   CLOCK_SKEW_TOLERANCE_SECONDS,

--- a/src/lib/signing/client.ts
+++ b/src/lib/signing/client.ts
@@ -7,6 +7,7 @@
  * The aggregate `@adcp/sdk/signing` barrel re-exports both for back-compat.
  */
 export {
+  buildResponseSignatureBase,
   buildSignatureBase,
   canonicalAuthority,
   canonicalMethod,
@@ -14,23 +15,30 @@ export {
   formatSignatureParams,
   getHeaderValue,
   type RequestLike,
+  type ResponseLike,
   type SignatureParams,
 } from './canonicalize';
 export { computeContentDigest, contentDigestMatches, parseContentDigest } from './content-digest';
 export {
   finalizeRequestSignature,
+  finalizeResponseSignature,
   prepareRequestSignature,
+  prepareResponseSignature,
   prepareWebhookSignature,
   signRequest,
+  signResponse,
   signWebhook,
   type PreparedRequestSignature,
+  type PreparedResponseSignature,
   type SignatureIdentity,
   type SignedRequest,
+  type SignedResponse,
   type SignerKey,
   type SignRequestOptions,
+  type SignResponseOptions,
   type SignWebhookOptions,
 } from './signer';
-export { signRequestAsync, signWebhookAsync } from './signer-async';
+export { signRequestAsync, signResponseAsync, signWebhookAsync } from './signer-async';
 export { derEcdsaToP1363 } from './ecdsa-encoding';
 export { WEBHOOK_MANDATORY_COMPONENTS, WEBHOOK_SIGNING_TAG } from './webhook-verifier';
 export { createSigningFetch, type CoverContentDigestPredicate, type SigningFetchOptions } from './fetch';
@@ -43,6 +51,8 @@ export {
   MANDATORY_COMPONENTS,
   MAX_SIGNATURE_WINDOW_SECONDS,
   REQUEST_SIGNING_TAG,
+  RESPONSE_MANDATORY_COMPONENTS,
+  RESPONSE_SIGNING_TAG,
   type AdcpJsonWebKey,
   type AdcpSignAlg,
   type ContentDigestPolicy,

--- a/src/lib/signing/errors.ts
+++ b/src/lib/signing/errors.ts
@@ -82,6 +82,27 @@ export class WebhookSignatureError extends ADCPError {
 }
 
 /**
+ * Error codes for the RFC 9421 response-signing surface. Parallel to the
+ * request- and webhook-signing taxonomies; the verifier side ships in a
+ * follow-up (#1826) and will extend this union with `response_signature_*`
+ * codes for window, replay, digest mismatch, etc. The signer-side gate at
+ * `request_signature_key_purpose_invalid` semantics is established here so
+ * adopters get consistent error vocabulary across both sides.
+ */
+export type ResponseSignatureErrorCode = 'response_signature_key_purpose_invalid';
+
+export class ResponseSignatureError extends ADCPError {
+  readonly code: ResponseSignatureErrorCode;
+  readonly failedStep: number;
+
+  constructor(code: ResponseSignatureErrorCode, failedStep: number, message: string, details?: unknown) {
+    super(message, details);
+    this.code = code;
+    this.failedStep = failedStep;
+  }
+}
+
+/**
  * SDK-side error codes for the `SigningProvider` integration path. Distinct
  * namespace from `RequestSignatureErrorCode` / `WebhookSignatureErrorCode`
  * because these surface during adapter setup, not during wire-level

--- a/src/lib/signing/jwks-helpers.ts
+++ b/src/lib/signing/jwks-helpers.ts
@@ -17,7 +17,7 @@ const WIRE_ALG_TO_JOSE: Record<AdcpSignAlg, string> = {
   'ecdsa-p256-sha256': 'ES256',
 };
 
-export type AdcpUse = 'request-signing' | 'webhook-signing';
+export type AdcpUse = 'request-signing' | 'webhook-signing' | 'response-signing';
 
 export interface PemToAdcpJwkOptions {
   /** `kid` to embed in the JWK — must match the value published in `Signature-Input`. */
@@ -28,6 +28,9 @@ export interface PemToAdcpJwkOptions {
    * Purpose binding, enforced by AdCP verifiers at step 8.
    * - `'request-signing'` — for JWKs published at the buyer's `jwks_uri`.
    * - `'webhook-signing'` — for JWKs used to sign outbound webhook callbacks.
+   * - `'response-signing'` — for JWKs used to sign outbound responses
+   *   (RFC 9421 §2.2.9 response signing). Verifier surface is a follow-up;
+   *   the value is reserved here so signer-side JWKs can declare it now.
    */
   adcp_use: AdcpUse;
 }

--- a/src/lib/signing/server.ts
+++ b/src/lib/signing/server.ts
@@ -25,6 +25,8 @@ export { jwkToPublicKey, verifySignature } from './crypto';
 export {
   RequestSignatureError,
   type RequestSignatureErrorCode,
+  ResponseSignatureError,
+  type ResponseSignatureErrorCode,
   WebhookSignatureError,
   type WebhookSignatureErrorCode,
 } from './errors';

--- a/src/lib/signing/server.ts
+++ b/src/lib/signing/server.ts
@@ -9,6 +9,7 @@
  * both for back-compat.
  */
 export {
+  buildResponseSignatureBase,
   buildSignatureBase,
   canonicalAuthority,
   canonicalMethod,
@@ -16,6 +17,7 @@ export {
   formatSignatureParams,
   getHeaderValue,
   type RequestLike,
+  type ResponseLike,
   type SignatureParams,
 } from './canonicalize';
 export { computeContentDigest, contentDigestMatches, parseContentDigest } from './content-digest';
@@ -58,6 +60,8 @@ export {
   MANDATORY_COMPONENTS,
   MAX_SIGNATURE_WINDOW_SECONDS,
   REQUEST_SIGNING_TAG,
+  RESPONSE_MANDATORY_COMPONENTS,
+  RESPONSE_SIGNING_TAG,
   type AdcpJsonWebKey,
   type ContentDigestPolicy,
   type RevocationSnapshot,

--- a/src/lib/signing/signer-async.ts
+++ b/src/lib/signing/signer-async.ts
@@ -1,7 +1,19 @@
-import type { RequestLike } from './canonicalize';
+import type { RequestLike, ResponseLike } from './canonicalize';
 import type { SigningProvider } from './provider';
-import type { SignedRequest, SignRequestOptions, SignWebhookOptions } from './signer';
-import { finalizeRequestSignature, prepareRequestSignature, prepareWebhookSignature } from './signer';
+import type {
+  SignedRequest,
+  SignedResponse,
+  SignRequestOptions,
+  SignResponseOptions,
+  SignWebhookOptions,
+} from './signer';
+import {
+  finalizeRequestSignature,
+  finalizeResponseSignature,
+  prepareRequestSignature,
+  prepareResponseSignature,
+  prepareWebhookSignature,
+} from './signer';
 
 /**
  * Async variant of `signRequest` that delegates the actual signature
@@ -39,4 +51,19 @@ export async function signWebhookAsync(
   const prepared = prepareWebhookSignature(request, { keyid: provider.keyid, alg: provider.algorithm }, options);
   const signature = await provider.sign(Buffer.from(prepared.base, 'utf8'));
   return finalizeRequestSignature(prepared, signature);
+}
+
+/**
+ * Async variant of `signResponse`. Reuses {@link prepareResponseSignature}
+ * and {@link finalizeResponseSignature} from the sync path so canonicalization
+ * stays identical — `provider.sign(payload)` is the only difference.
+ */
+export async function signResponseAsync(
+  response: ResponseLike,
+  provider: SigningProvider,
+  options: SignResponseOptions = {}
+): Promise<SignedResponse> {
+  const prepared = prepareResponseSignature(response, { keyid: provider.keyid, alg: provider.algorithm }, options);
+  const signature = await provider.sign(Buffer.from(prepared.base, 'utf8'));
+  return finalizeResponseSignature(prepared, signature);
 }

--- a/src/lib/signing/signer.ts
+++ b/src/lib/signing/signer.ts
@@ -321,6 +321,22 @@ export function finalizeResponseSignature(prepared: PreparedResponseSignature, s
  * Servers emitting signed responses (e.g. seller agents whose clients
  * verify `get_products` payloads before parsing) should use this instead
  * of hand-rolling signatures.
+ *
+ * Returns headers as a plain `Record<string, string>` for direct use with
+ * Express (`res.set(signed.headers)`). For Fetch / Node `Response` (where
+ * the headers object is immutable on construction), spread into the
+ * `Headers` constructor or `setHeader` loop:
+ *
+ * ```ts
+ * // Express
+ * res.status(signed.status).set(signed.headers).send(body);
+ *
+ * // Fetch / Workers / Node 20+ Response
+ * return new Response(body, { status: signed.status, headers: signed.headers });
+ *
+ * // Node `http.ServerResponse`
+ * res.writeHead(signed.status, signed.headers).end(body);
+ * ```
  */
 export function signResponse(
   response: ResponseLike,

--- a/src/lib/signing/signer.ts
+++ b/src/lib/signing/signer.ts
@@ -65,6 +65,13 @@ function assertKeyPurpose(key: SignerKey, expected: AdcpUse): void {
       throw new WebhookSignatureError('webhook_signature_key_purpose_invalid', 8, message);
     case 'response-signing':
       throw new ResponseSignatureError('response_signature_key_purpose_invalid', 8, message);
+    default: {
+      // Compile-time exhaustiveness: a future `AdcpUse` widening must add
+      // a case arm here. Trips `tsc --noEmit` if the union grows without
+      // an explicit gate decision for the new member.
+      const _exhaustive: never = expected;
+      throw new Error(`unreachable: unhandled AdcpUse '${_exhaustive}'`);
+    }
   }
 }
 
@@ -116,6 +123,15 @@ export interface PreparedRequestSignature {
  * Canonicalize a request for RFC 9421 request-signing. Pure (no I/O); the
  * sync and async paths share this so canonicalization can't drift between
  * them.
+ *
+ * **No purpose-binding gate.** This function takes a `SignatureIdentity`
+ * (just `keyid` + `alg`), not a full `SignerKey`, so it deliberately
+ * cannot enforce `adcp_use`. Callers composing `prepare* + own-signer`
+ * are responsible for purpose binding themselves — the convenience
+ * helper `signRequest` runs `assertKeyPurpose` before calling this and
+ * is what most adopters want. Test-vector authors who need to sign with
+ * wrong-purpose keys (e.g. AdCP negative-vector 009 cross-purpose
+ * rejection) use this prepare/finalize composition deliberately.
  */
 export function prepareRequestSignature(
   request: RequestLike,
@@ -197,6 +213,10 @@ export interface SignWebhookOptions {
  * `signWebhookAsync` paths. Covers the five mandatory components —
  * `@method`, `@target-uri`, `@authority`, `content-type`, `content-digest` —
  * and sets `Content-Digest` on the outgoing headers.
+ *
+ * **No purpose-binding gate** — same caveat as
+ * {@link prepareRequestSignature}. The convenience helper `signWebhook`
+ * runs `assertKeyPurpose` before calling this.
  */
 export function prepareWebhookSignature(
   request: RequestLike,
@@ -244,16 +264,24 @@ export function signWebhook(request: RequestLike, key: SignerKey, options: SignW
 export interface SignResponseOptions {
   /**
    * Cover a `Content-Digest` of the response body. Defaults to `true` when
-   * the response has a body — same shape as request-signing's automatic
-   * `content-digest` inclusion. Pass `false` to omit even when a body is
-   * present (e.g. when the digest is computed by an upstream proxy).
+   * the response has a body.
+   *
+   * **Asymmetric with `signRequest`.** Request signing defaults to opt-in
+   * (`coverContentDigest: true` required to cover); response signing
+   * defaults to opt-out because an unbound body is the most common
+   * cross-purpose footgun for response signing — without a body digest,
+   * an attacker that can swap the payload but preserve headers can pass
+   * the signature check. The asymmetry is deliberate; callers that want
+   * to omit (e.g. when an upstream proxy computes the digest) pass
+   * `false` explicitly.
    */
   coverContentDigest?: boolean;
   /**
    * Additional derived/header components to cover beyond
-   * {@link RESPONSE_MANDATORY_COMPONENTS}. Useful for binding the
-   * signature to a specific request URL (`@target-uri`) or method
-   * (`@method`) rather than just origin.
+   * {@link RESPONSE_MANDATORY_COMPONENTS}. The defaults already include
+   * `@status`, `@authority`, and `@target-uri`. Use this for `@method`
+   * (uncommon for responses — request method is usually implicit) or for
+   * custom headers (`x-content-type-options`, etc.).
    */
   additionalComponents?: ReadonlyArray<string>;
   label?: string;
@@ -298,10 +326,15 @@ export interface PreparedResponseSignature {
 /**
  * Canonicalize a response for RFC 9421 response-signing (§2.2.9). Pure
  * (no I/O); shared between sync `signResponse` and async `signResponseAsync`
- * so canonicalization can't drift between them. Covers `@status` and
- * `@authority` by default; adds `content-type` + `content-digest`
- * automatically when the response carries a body. Callers can extend the
- * covered set via {@link SignResponseOptions.additionalComponents}.
+ * so canonicalization can't drift between them. Covers
+ * {@link RESPONSE_MANDATORY_COMPONENTS} by default; adds `content-type` +
+ * `content-digest` automatically when the response carries a body. Callers
+ * can extend the covered set via
+ * {@link SignResponseOptions.additionalComponents}.
+ *
+ * **No purpose-binding gate** — same caveat as
+ * {@link prepareRequestSignature}. The convenience helper `signResponse`
+ * runs `assertKeyPurpose` before calling this.
  */
 export function prepareResponseSignature(
   response: ResponseLike,

--- a/src/lib/signing/signer.ts
+++ b/src/lib/signing/signer.ts
@@ -8,6 +8,8 @@ import {
   type SignatureParams,
 } from './canonicalize';
 import { computeContentDigest } from './content-digest';
+import { RequestSignatureError, ResponseSignatureError, WebhookSignatureError } from './errors';
+import type { AdcpUse } from './jwks-helpers';
 import {
   MANDATORY_COMPONENTS,
   MAX_SIGNATURE_WINDOW_SECONDS,
@@ -22,7 +24,48 @@ import { WEBHOOK_MANDATORY_COMPONENTS, WEBHOOK_SIGNING_TAG } from './webhook-ver
 export interface SignerKey {
   keyid: string;
   alg: 'ed25519' | 'ecdsa-p256-sha256';
+  /**
+   * Private JWK. MUST carry `adcp_use` matching the helper being called:
+   * - `signRequest` requires `adcp_use: 'request-signing'`
+   * - `signWebhook` requires `adcp_use: 'webhook-signing'`
+   * - `signResponse` requires `adcp_use: 'response-signing'`
+   *
+   * Mismatched or missing `adcp_use` throws at the signer with the same
+   * error code the verifier raises at step 8 — failure surfaces at
+   * configuration time rather than at the receiver, where the message is
+   * far from its cause. Mint keys with `pemToAdcpJwk({ adcp_use: ... })`
+   * to get the binding right by construction.
+   */
   privateKey: AdcpJsonWebKey;
+}
+
+/**
+ * Step-8-equivalent purpose-binding gate on the signer side. The verifier
+ * already enforces `jwk.adcp_use === expected` at step 8 (see verifier.ts
+ * for request signing; webhook-verifier.ts for webhooks). Replicating the
+ * check on the signer side prevents the more common operator footgun:
+ * passing a wrong-purpose key into the helper, producing a wire-conformant
+ * signature that the downstream verifier then rejects, surfacing the
+ * misconfiguration at the wrong end of the connection.
+ *
+ * Errors emit the same code the verifier uses for that direction so log
+ * scrapers across signer / verifier see consistent vocabulary.
+ */
+function assertKeyPurpose(key: SignerKey, expected: AdcpUse): void {
+  const actual = key.privateKey.adcp_use;
+  if (actual === expected) return;
+  const message =
+    `Signing key '${key.keyid}' has adcp_use=${actual === undefined ? '<missing>' : `'${actual}'`} ` +
+    `but the helper requires '${expected}'. Mint a key scoped for '${expected}' via ` +
+    `pemToAdcpJwk({ adcp_use: '${expected}' }) — sharing keys across purposes is intentionally refused.`;
+  switch (expected) {
+    case 'request-signing':
+      throw new RequestSignatureError('request_signature_key_purpose_invalid', 8, message);
+    case 'webhook-signing':
+      throw new WebhookSignatureError('webhook_signature_key_purpose_invalid', 8, message);
+    case 'response-signing':
+      throw new ResponseSignatureError('response_signature_key_purpose_invalid', 8, message);
+  }
 }
 
 export interface SignRequestOptions {
@@ -129,6 +172,7 @@ export function finalizeRequestSignature(prepared: PreparedRequestSignature, sig
 }
 
 export function signRequest(request: RequestLike, key: SignerKey, options: SignRequestOptions = {}): SignedRequest {
+  assertKeyPurpose(key, 'request-signing');
   const prepared = prepareRequestSignature(request, { keyid: key.keyid, alg: key.alg }, options);
   const signature = produceSignature(key, Buffer.from(prepared.base, 'utf8'));
   return finalizeRequestSignature(prepared, signature);
@@ -191,6 +235,7 @@ export function prepareWebhookSignature(
  * conformant webhooks should use this instead of hand-rolling signatures.
  */
 export function signWebhook(request: RequestLike, key: SignerKey, options: SignWebhookOptions = {}): SignedRequest {
+  assertKeyPurpose(key, 'webhook-signing');
   const prepared = prepareWebhookSignature(request, { keyid: key.keyid, alg: key.alg }, options);
   const signature = produceSignature(key, Buffer.from(prepared.base, 'utf8'));
   return finalizeRequestSignature(prepared, signature);
@@ -343,6 +388,7 @@ export function signResponse(
   key: SignerKey,
   options: SignResponseOptions = {}
 ): SignedResponse {
+  assertKeyPurpose(key, 'response-signing');
   const prepared = prepareResponseSignature(response, { keyid: key.keyid, alg: key.alg }, options);
   const signature = produceSignature(key, Buffer.from(prepared.base, 'utf8'));
   return finalizeResponseSignature(prepared, signature);

--- a/src/lib/signing/signer.ts
+++ b/src/lib/signing/signer.ts
@@ -1,10 +1,19 @@
 import { createPrivateKey, randomBytes, sign as nodeSign, type JsonWebKey } from 'crypto';
-import { buildSignatureBase, formatSignatureParams, type RequestLike, type SignatureParams } from './canonicalize';
+import {
+  buildResponseSignatureBase,
+  buildSignatureBase,
+  formatSignatureParams,
+  type RequestLike,
+  type ResponseLike,
+  type SignatureParams,
+} from './canonicalize';
 import { computeContentDigest } from './content-digest';
 import {
   MANDATORY_COMPONENTS,
   MAX_SIGNATURE_WINDOW_SECONDS,
   REQUEST_SIGNING_TAG,
+  RESPONSE_MANDATORY_COMPONENTS,
+  RESPONSE_SIGNING_TAG,
   type AdcpJsonWebKey,
   type AdcpSignAlg,
 } from './types';
@@ -185,6 +194,142 @@ export function signWebhook(request: RequestLike, key: SignerKey, options: SignW
   const prepared = prepareWebhookSignature(request, { keyid: key.keyid, alg: key.alg }, options);
   const signature = produceSignature(key, Buffer.from(prepared.base, 'utf8'));
   return finalizeRequestSignature(prepared, signature);
+}
+
+export interface SignResponseOptions {
+  /**
+   * Cover a `Content-Digest` of the response body. Defaults to `true` when
+   * the response has a body — same shape as request-signing's automatic
+   * `content-digest` inclusion. Pass `false` to omit even when a body is
+   * present (e.g. when the digest is computed by an upstream proxy).
+   */
+  coverContentDigest?: boolean;
+  /**
+   * Additional derived/header components to cover beyond
+   * {@link RESPONSE_MANDATORY_COMPONENTS}. Useful for binding the
+   * signature to a specific request URL (`@target-uri`) or method
+   * (`@method`) rather than just origin.
+   */
+  additionalComponents?: ReadonlyArray<string>;
+  label?: string;
+  windowSeconds?: number;
+  now?: () => number;
+  nonce?: string;
+  /**
+   * Override the signature tag. Defaults to `adcp/response-signing/v1`.
+   * Exposed so test suites can pin a wrong tag to exercise receiver
+   * rejection paths without mutating the signed headers post-hoc.
+   */
+  tag?: string;
+}
+
+export interface SignedResponse {
+  status: number;
+  headers: Record<string, string>;
+  signatureBase: string;
+  params: SignatureParams;
+}
+
+/**
+ * Result of canonicalizing a response for signing — everything `signResponse`
+ * and `signResponseAsync` produce up to (but not including) the call into
+ * the signer/provider.
+ */
+export interface PreparedResponseSignature {
+  status: number;
+  components: string[];
+  params: SignatureParams;
+  /**
+   * Outbound response headers including `Content-Digest` when covered, but
+   * not yet including `Signature-Input` / `Signature` — those are appended
+   * by {@link finalizeResponseSignature}.
+   */
+  headers: Record<string, string>;
+  /** Canonical signature base bytes (UTF-8). Pass to the signer/provider. */
+  base: string;
+  label: string;
+}
+
+/**
+ * Canonicalize a response for RFC 9421 response-signing (§2.2.9). Pure
+ * (no I/O); shared between sync `signResponse` and async `signResponseAsync`
+ * so canonicalization can't drift between them. Covers `@status` and
+ * `@authority` by default; adds `content-type` + `content-digest`
+ * automatically when the response carries a body. Callers can extend the
+ * covered set via {@link SignResponseOptions.additionalComponents}.
+ */
+export function prepareResponseSignature(
+  response: ResponseLike,
+  identity: SignatureIdentity,
+  options: SignResponseOptions = {}
+): PreparedResponseSignature {
+  const now = options.now ? options.now() : Math.floor(Date.now() / 1000);
+  const windowSeconds = Math.min(options.windowSeconds ?? 300, MAX_SIGNATURE_WINDOW_SECONDS);
+  const nonce = options.nonce ?? base64UrlRandom(16);
+  const label = options.label ?? 'sig1';
+  const hasBody = (response.body ?? '').length > 0;
+  const coverDigest = (options.coverContentDigest ?? true) && hasBody;
+
+  const headers: Record<string, string> = { ...flattenHeaders(response.headers) };
+  if (coverDigest) {
+    headers['Content-Digest'] = computeContentDigest(response.body ?? '');
+  }
+
+  const components = [...RESPONSE_MANDATORY_COMPONENTS];
+  if (hasBody) components.push('content-type');
+  if (coverDigest) components.push('content-digest');
+  if (options.additionalComponents) {
+    for (const c of options.additionalComponents) {
+      if (!components.includes(c)) components.push(c);
+    }
+  }
+
+  const params: SignatureParams = {
+    created: now,
+    expires: now + windowSeconds,
+    nonce,
+    keyid: identity.keyid,
+    alg: identity.alg,
+    tag: options.tag ?? RESPONSE_SIGNING_TAG,
+  };
+
+  const normalizedResponse: ResponseLike = { ...response, headers };
+  const base = buildResponseSignatureBase(components, normalizedResponse, params);
+
+  return { status: response.status, components, params, headers, base, label };
+}
+
+/**
+ * Attach `Signature` / `Signature-Input` headers given the bytes returned
+ * by the signer/provider. Mirrors {@link finalizeRequestSignature} but
+ * returns a {@link SignedResponse} that carries the response status alongside
+ * the stamped headers so the caller can hand the whole object back to its
+ * HTTP layer.
+ */
+export function finalizeResponseSignature(prepared: PreparedResponseSignature, signature: Uint8Array): SignedResponse {
+  const headers = { ...prepared.headers };
+  const sigB64 = Buffer.from(signature).toString('base64url');
+  headers['Signature-Input'] = `${prepared.label}=${formatSignatureParams(prepared.components, prepared.params)}`;
+  headers['Signature'] = `${prepared.label}=:${sigB64}:`;
+  return { status: prepared.status, headers, signatureBase: prepared.base, params: prepared.params };
+}
+
+/**
+ * Sign an outbound response under the RFC 9421 response-signing profile
+ * (`tag=adcp/response-signing/v1`). Covers `@status` and `@authority` by
+ * default, plus `content-type` + `content-digest` when a body is present.
+ * Servers emitting signed responses (e.g. seller agents whose clients
+ * verify `get_products` payloads before parsing) should use this instead
+ * of hand-rolling signatures.
+ */
+export function signResponse(
+  response: ResponseLike,
+  key: SignerKey,
+  options: SignResponseOptions = {}
+): SignedResponse {
+  const prepared = prepareResponseSignature(response, { keyid: key.keyid, alg: key.alg }, options);
+  const signature = produceSignature(key, Buffer.from(prepared.base, 'utf8'));
+  return finalizeResponseSignature(prepared, signature);
 }
 
 function produceSignature(key: SignerKey, data: Buffer): Uint8Array {

--- a/src/lib/signing/types.ts
+++ b/src/lib/signing/types.ts
@@ -79,6 +79,7 @@ export interface VerifiedSigner {
 export type VerifyResult = ({ status: 'verified' } & VerifiedSigner) | { status: 'unsigned'; verified_at: number };
 
 export const REQUEST_SIGNING_TAG = 'adcp/request-signing/v1';
+export const RESPONSE_SIGNING_TAG = 'adcp/response-signing/v1';
 export const ALLOWED_ALGS = new Set(['ed25519', 'ecdsa-p256-sha256']);
 /**
  * Wire-format algorithm identifier — the string that appears in
@@ -88,3 +89,14 @@ export type AdcpSignAlg = 'ed25519' | 'ecdsa-p256-sha256';
 export const MAX_SIGNATURE_WINDOW_SECONDS = 300;
 export const CLOCK_SKEW_TOLERANCE_SECONDS = 60;
 export const MANDATORY_COMPONENTS: ReadonlyArray<string> = ['@method', '@target-uri', '@authority'];
+/**
+ * Minimum derived components covered by a response signature under the AdCP
+ * response-signing profile (RFC 9421 §2.2.9). `@status` binds the signature
+ * to the response status code; `@authority` binds it to the request origin
+ * the response was emitted for. `content-digest` is added at signing time
+ * when the response carries a body — same conditional shape as
+ * {@link MANDATORY_COMPONENTS} for request signing. Callers that want to
+ * bind the signature to a specific request URL can opt-in to `@target-uri`
+ * and `@method` via `componentIds`.
+ */
+export const RESPONSE_MANDATORY_COMPONENTS: ReadonlyArray<string> = ['@status', '@authority'];

--- a/src/lib/signing/types.ts
+++ b/src/lib/signing/types.ts
@@ -79,6 +79,16 @@ export interface VerifiedSigner {
 export type VerifyResult = ({ status: 'verified' } & VerifiedSigner) | { status: 'unsigned'; verified_at: number };
 
 export const REQUEST_SIGNING_TAG = 'adcp/request-signing/v1';
+/**
+ * Tag value for the AdCP response-signing profile (RFC 9421 §2.2.9).
+ *
+ * Wire-format contract is provisional until #1826 (`verifyResponseSignature`)
+ * lands and exercises this format against external SDK implementations.
+ * The `v1` suffix gives a clean break path if interop testing surfaces an
+ * incompat — any breaking change ships as `v2` and verifiers reject `v1`.
+ * Adopters publishing signed responses today should pin a major SDK version
+ * until the verifier ships.
+ */
 export const RESPONSE_SIGNING_TAG = 'adcp/response-signing/v1';
 export const ALLOWED_ALGS = new Set(['ed25519', 'ecdsa-p256-sha256']);
 /**
@@ -91,12 +101,26 @@ export const CLOCK_SKEW_TOLERANCE_SECONDS = 60;
 export const MANDATORY_COMPONENTS: ReadonlyArray<string> = ['@method', '@target-uri', '@authority'];
 /**
  * Minimum derived components covered by a response signature under the AdCP
- * response-signing profile (RFC 9421 §2.2.9). `@status` binds the signature
- * to the response status code; `@authority` binds it to the request origin
- * the response was emitted for. `content-digest` is added at signing time
- * when the response carries a body — same conditional shape as
- * {@link MANDATORY_COMPONENTS} for request signing. Callers that want to
- * bind the signature to a specific request URL can opt-in to `@target-uri`
- * and `@method` via `componentIds`.
+ * response-signing profile (RFC 9421 §2.2.9).
+ *
+ * - `@status` — binds the signature to the response status code.
+ * - `@authority` — binds it to the request origin the response was emitted
+ *   for (so a compromised origin can't cross-sign for a sibling tenant on
+ *   the same fleet).
+ * - `@target-uri` — binds the signature to the specific request path + query,
+ *   preventing a multi-tenant seller from emitting interchangeable signatures
+ *   across endpoints sharing the same authority. Matches RFC 9421 §B.2.5
+ *   examples for response signing.
+ *
+ * `content-type` + `content-digest` are added at signing time when the
+ * response carries a body — `content-digest` is opt-out via
+ * `coverContentDigest: false` because an unbound body is the most common
+ * cross-purpose footgun for response signing. Callers can extend the
+ * covered set further via `SignResponseOptions.additionalComponents`
+ * (e.g. `@method`, custom headers).
+ *
+ * Wire-format contract is provisional until #1826 (`verifyResponseSignature`)
+ * lands and is exercised against external implementations. Adopters
+ * shipping signed responses today should pin a major version.
  */
-export const RESPONSE_MANDATORY_COMPONENTS: ReadonlyArray<string> = ['@status', '@authority'];
+export const RESPONSE_MANDATORY_COMPONENTS: ReadonlyArray<string> = ['@status', '@authority', '@target-uri'];

--- a/src/lib/testing/storyboard/request-signing/builder.ts
+++ b/src/lib/testing/storyboard/request-signing/builder.ts
@@ -1,8 +1,9 @@
 import { createPrivateKey, randomBytes, randomUUID, sign as nodeSign, type JsonWebKey } from 'crypto';
 import {
   buildSignatureBase,
+  finalizeRequestSignature,
   formatSignatureParams,
-  signRequest,
+  prepareRequestSignature,
   REQUEST_SIGNING_TAG,
   type AdcpJsonWebKey,
   type RequestLike,
@@ -341,12 +342,25 @@ function sign(key: SignerKey, vector: PositiveVector | NegativeVector, args: Sig
     headers: shaped.headers,
     body: shaped.body,
   };
-  const signed = signRequest(request, key, {
-    coverContentDigest: args.coverContentDigest === true,
-    now: args.now !== undefined ? () => args.now! : undefined,
-    nonce: args.nonce,
-    windowSeconds: args.windowSeconds,
-  });
+  // Negative-vector 009 deliberately signs with a wrong-purpose key
+  // (`adcp_use: 'governance-signing'`) to exercise the verifier's step-8
+  // purpose check. The signer-side `signRequest` gate refuses wrong-purpose
+  // keys to prevent the more common operator footgun; bypass it here by
+  // composing `prepareRequestSignature` (which takes `SignatureIdentity`
+  // and runs no gate) with this file's local `produceSignature` helper.
+  // The bypass is intentional and confined to test-vector authoring.
+  const prepared = prepareRequestSignature(
+    request,
+    { keyid: key.keyid, alg: key.alg },
+    {
+      coverContentDigest: args.coverContentDigest === true,
+      now: args.now !== undefined ? () => args.now! : undefined,
+      nonce: args.nonce,
+      windowSeconds: args.windowSeconds,
+    }
+  );
+  const signature = produceSignature(key, Buffer.from(prepared.base, 'utf8'));
+  const signed = finalizeRequestSignature(prepared, signature);
   return {
     method: shaped.method,
     url: shaped.url,

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP SDK library version
  */
-export const LIBRARY_VERSION = '7.5.0';
+export const LIBRARY_VERSION = '7.6.0';
 
 /**
  * AdCP specification version this library is built for
@@ -60,10 +60,10 @@ export type AdcpVersion = (typeof COMPATIBLE_ADCP_VERSIONS)[number];
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '7.5.0',
+  library: '7.6.0',
   adcp: '3.0.12',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-05-17T08:43:46.032Z',
+  generatedAt: '2026-05-17T17:46:11.373Z',
 } as const;
 
 /**

--- a/test/request-signing-provider.test.js
+++ b/test/request-signing-provider.test.js
@@ -111,11 +111,16 @@ describe('signRequestAsync produces byte-equivalent output to signRequest (ECDSA
 describe('signWebhookAsync is functionally equivalent to signWebhook', () => {
   test('headers and base match for Ed25519', async () => {
     const kid = 'test-ed25519-2026';
-    const key = { keyid: kid, alg: 'ed25519', privateKey: privateJwkFor(kid) };
+    // The vectors at request-signing/keys.json declare `adcp_use: 'request-signing'`;
+    // the signWebhook purpose-binding gate refuses non-webhook keys, so override
+    // adcp_use for this sync/async equivalence test. The Ed25519 scalar is the
+    // same — only the purpose metadata changes.
+    const webhookJwk = { ...privateJwkFor(kid), adcp_use: 'webhook-signing' };
+    const key = { keyid: kid, alg: 'ed25519', privateKey: webhookJwk };
     const provider = new InMemorySigningProvider({
       keyid: kid,
       algorithm: 'ed25519',
-      privateKey: privateJwkFor(kid),
+      privateKey: webhookJwk,
     });
     const sync = signWebhook(SAMPLE_REQUEST, key, SAMPLE_OPTIONS);
     const async_ = await signWebhookAsync(SAMPLE_REQUEST, provider, SAMPLE_OPTIONS);

--- a/test/response-signing.test.js
+++ b/test/response-signing.test.js
@@ -1,0 +1,232 @@
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const { readFileSync } = require('node:fs');
+const path = require('node:path');
+
+const {
+  signResponse,
+  signResponseAsync,
+  prepareResponseSignature,
+  finalizeResponseSignature,
+  buildResponseSignatureBase,
+  parseSignatureInput,
+  parseSignature,
+  jwkToPublicKey,
+  verifySignature,
+  RESPONSE_SIGNING_TAG,
+  RESPONSE_MANDATORY_COMPONENTS,
+  computeContentDigest,
+} = require('../dist/lib/signing/index.js');
+
+const { InMemorySigningProvider } = require('../dist/lib/signing/testing.js');
+
+const KEYS_PATH = path.join(
+  __dirname,
+  '..',
+  'compliance',
+  'cache',
+  'latest',
+  'test-vectors',
+  'request-signing',
+  'keys.json'
+);
+const keysData = JSON.parse(readFileSync(KEYS_PATH, 'utf8'));
+const keysByKid = new Map(keysData.keys.map(k => [k.kid, k]));
+
+function publicJwkFor(kid) {
+  const k = keysByKid.get(kid);
+  const { _private_d_for_test_only, ...publicPart } = k;
+  return publicPart;
+}
+
+function privateJwkFor(kid) {
+  const k = keysByKid.get(kid);
+  const { _private_d_for_test_only, ...rest } = k;
+  return { ...rest, d: _private_d_for_test_only };
+}
+
+const ORIGINATING_REQUEST = {
+  method: 'POST',
+  url: 'https://seller.example.com/adcp/get_products',
+};
+
+const SAMPLE_RESPONSE = {
+  status: 200,
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({ products: [{ id: 'prod_001' }] }),
+  request: ORIGINATING_REQUEST,
+};
+
+const FIXED_OPTIONS = {
+  now: () => 1776520800,
+  nonce: 'KXYnfEfJ0PBRZXQyVXfVQA',
+  windowSeconds: 300,
+};
+
+describe('signResponse — default covered components', () => {
+  test('covers @status, @authority, content-type, content-digest when body present', () => {
+    const kid = 'test-ed25519-2026';
+    const key = { keyid: kid, alg: 'ed25519', privateKey: privateJwkFor(kid) };
+    const signed = signResponse(SAMPLE_RESPONSE, key, FIXED_OPTIONS);
+
+    const parsed = parseSignatureInput(signed.headers['Signature-Input']);
+    assert.deepStrictEqual(parsed.components, ['@status', '@authority', 'content-type', 'content-digest']);
+    assert.strictEqual(parsed.params.tag, RESPONSE_SIGNING_TAG);
+    assert.strictEqual(parsed.params.keyid, kid);
+    assert.strictEqual(parsed.params.alg, 'ed25519');
+  });
+
+  test('omits content-digest and content-type when body is empty', () => {
+    const kid = 'test-ed25519-2026';
+    const key = { keyid: kid, alg: 'ed25519', privateKey: privateJwkFor(kid) };
+    const signed = signResponse({ status: 204, headers: {}, request: ORIGINATING_REQUEST }, key, FIXED_OPTIONS);
+    const parsed = parseSignatureInput(signed.headers['Signature-Input']);
+    assert.deepStrictEqual(parsed.components, [...RESPONSE_MANDATORY_COMPONENTS]);
+    assert.strictEqual(signed.headers['Content-Digest'], undefined);
+  });
+
+  test('stamps Content-Digest matching the body', () => {
+    const kid = 'test-ed25519-2026';
+    const key = { keyid: kid, alg: 'ed25519', privateKey: privateJwkFor(kid) };
+    const signed = signResponse(SAMPLE_RESPONSE, key, FIXED_OPTIONS);
+    assert.strictEqual(signed.headers['Content-Digest'], computeContentDigest(SAMPLE_RESPONSE.body));
+  });
+
+  test('respects additionalComponents to bind @target-uri', () => {
+    const kid = 'test-ed25519-2026';
+    const key = { keyid: kid, alg: 'ed25519', privateKey: privateJwkFor(kid) };
+    const signed = signResponse(SAMPLE_RESPONSE, key, {
+      ...FIXED_OPTIONS,
+      additionalComponents: ['@target-uri'],
+    });
+    const parsed = parseSignatureInput(signed.headers['Signature-Input']);
+    assert.ok(parsed.components.includes('@target-uri'));
+  });
+});
+
+describe('signResponse — round-trip verification', () => {
+  test('Ed25519 signature verifies against the originating-request-bound base', () => {
+    const kid = 'test-ed25519-2026';
+    const key = { keyid: kid, alg: 'ed25519', privateKey: privateJwkFor(kid) };
+    const signed = signResponse(SAMPLE_RESPONSE, key, FIXED_OPTIONS);
+
+    const parsedInput = parseSignatureInput(signed.headers['Signature-Input']);
+    const parsedSig = parseSignature(signed.headers.Signature, parsedInput.label);
+
+    // Rebuild the base from the response + headers + originating request,
+    // using the verbatim signatureParamsValue so re-ordering can't drift.
+    const responseForVerify = {
+      status: SAMPLE_RESPONSE.status,
+      headers: signed.headers,
+      body: SAMPLE_RESPONSE.body,
+      request: ORIGINATING_REQUEST,
+    };
+    const base = buildResponseSignatureBase(
+      parsedInput.components,
+      responseForVerify,
+      parsedInput.params,
+      parsedInput.signatureParamsValue
+    );
+    assert.strictEqual(base, signed.signatureBase);
+
+    const publicKey = jwkToPublicKey(publicJwkFor(kid));
+    const ok = verifySignature(parsedInput.params.alg, publicKey, Buffer.from(base, 'utf8'), parsedSig.bytes);
+    assert.strictEqual(ok, true);
+  });
+
+  test('ECDSA-P256 signature verifies', () => {
+    const kid = 'test-es256-2026';
+    const key = { keyid: kid, alg: 'ecdsa-p256-sha256', privateKey: privateJwkFor(kid) };
+    const signed = signResponse(SAMPLE_RESPONSE, key, FIXED_OPTIONS);
+
+    const parsedInput = parseSignatureInput(signed.headers['Signature-Input']);
+    const parsedSig = parseSignature(signed.headers.Signature, parsedInput.label);
+    const responseForVerify = { ...SAMPLE_RESPONSE, headers: signed.headers };
+    const base = buildResponseSignatureBase(
+      parsedInput.components,
+      responseForVerify,
+      parsedInput.params,
+      parsedInput.signatureParamsValue
+    );
+    const publicKey = jwkToPublicKey(publicJwkFor(kid));
+    const ok = verifySignature(parsedInput.params.alg, publicKey, Buffer.from(base, 'utf8'), parsedSig.bytes);
+    assert.strictEqual(ok, true);
+  });
+
+  test('tampering with the body invalidates the signature', () => {
+    const kid = 'test-ed25519-2026';
+    const key = { keyid: kid, alg: 'ed25519', privateKey: privateJwkFor(kid) };
+    const signed = signResponse(SAMPLE_RESPONSE, key, FIXED_OPTIONS);
+
+    const parsedInput = parseSignatureInput(signed.headers['Signature-Input']);
+    const parsedSig = parseSignature(signed.headers.Signature, parsedInput.label);
+    // Different body — content-digest in headers no longer matches what the
+    // verifier-side caller would recompute. We rebuild the base against the
+    // tampered body's content-digest to force a real mismatch.
+    const tamperedBody = JSON.stringify({ products: [{ id: 'tampered' }] });
+    const tamperedHeaders = { ...signed.headers, 'Content-Digest': computeContentDigest(tamperedBody) };
+    const base = buildResponseSignatureBase(
+      parsedInput.components,
+      { ...SAMPLE_RESPONSE, body: tamperedBody, headers: tamperedHeaders },
+      parsedInput.params,
+      parsedInput.signatureParamsValue
+    );
+    const publicKey = jwkToPublicKey(publicJwkFor(kid));
+    const ok = verifySignature(parsedInput.params.alg, publicKey, Buffer.from(base, 'utf8'), parsedSig.bytes);
+    assert.strictEqual(ok, false);
+  });
+
+  test('tampering with the status invalidates the signature', () => {
+    const kid = 'test-ed25519-2026';
+    const key = { keyid: kid, alg: 'ed25519', privateKey: privateJwkFor(kid) };
+    const signed = signResponse(SAMPLE_RESPONSE, key, FIXED_OPTIONS);
+
+    const parsedInput = parseSignatureInput(signed.headers['Signature-Input']);
+    const parsedSig = parseSignature(signed.headers.Signature, parsedInput.label);
+    const base = buildResponseSignatureBase(
+      parsedInput.components,
+      { ...SAMPLE_RESPONSE, status: 500, headers: signed.headers },
+      parsedInput.params,
+      parsedInput.signatureParamsValue
+    );
+    const publicKey = jwkToPublicKey(publicJwkFor(kid));
+    const ok = verifySignature(parsedInput.params.alg, publicKey, Buffer.from(base, 'utf8'), parsedSig.bytes);
+    assert.strictEqual(ok, false);
+  });
+});
+
+describe('signResponseAsync', () => {
+  test('produces byte-identical output to signResponse for Ed25519', async () => {
+    const kid = 'test-ed25519-2026';
+    const key = { keyid: kid, alg: 'ed25519', privateKey: privateJwkFor(kid) };
+    const provider = new InMemorySigningProvider({
+      keyid: kid,
+      algorithm: 'ed25519',
+      privateKey: privateJwkFor(kid),
+    });
+    const sync = signResponse(SAMPLE_RESPONSE, key, FIXED_OPTIONS);
+    const asyncSig = await signResponseAsync(SAMPLE_RESPONSE, provider, FIXED_OPTIONS);
+    assert.strictEqual(asyncSig.headers.Signature, sync.headers.Signature);
+    assert.strictEqual(asyncSig.headers['Signature-Input'], sync.headers['Signature-Input']);
+    assert.strictEqual(asyncSig.signatureBase, sync.signatureBase);
+    assert.strictEqual(asyncSig.status, sync.status);
+  });
+});
+
+describe('prepare/finalize split (KMS-shaped path)', () => {
+  test('manual signer can stamp the same headers signResponse produces', () => {
+    const kid = 'test-ed25519-2026';
+    const privateKey = privateJwkFor(kid);
+    const prepared = prepareResponseSignature(SAMPLE_RESPONSE, { keyid: kid, alg: 'ed25519' }, FIXED_OPTIONS);
+
+    const { createPrivateKey, sign } = require('node:crypto');
+    const pk = createPrivateKey({ key: privateKey, format: 'jwk' });
+    const sig = sign(null, Buffer.from(prepared.base, 'utf8'), pk);
+    const out = finalizeResponseSignature(prepared, new Uint8Array(sig));
+
+    const expected = signResponse(SAMPLE_RESPONSE, { keyid: kid, alg: 'ed25519', privateKey }, FIXED_OPTIONS);
+    assert.strictEqual(out.headers.Signature, expected.headers.Signature);
+    assert.strictEqual(out.headers['Signature-Input'], expected.headers['Signature-Input']);
+    assert.strictEqual(out.status, expected.status);
+  });
+});

--- a/test/response-signing.test.js
+++ b/test/response-signing.test.js
@@ -81,13 +81,19 @@ const FIXED_OPTIONS = {
 };
 
 describe('signResponse — default covered components', () => {
-  test('covers @status, @authority, content-type, content-digest when body present', () => {
+  test('covers @status, @authority, @target-uri, content-type, content-digest when body present', () => {
     const kid = 'test-ed25519-2026';
     const key = { keyid: kid, alg: 'ed25519', privateKey: privateJwkFor(kid) };
     const signed = signResponse(SAMPLE_RESPONSE, key, FIXED_OPTIONS);
 
     const parsed = parseSignatureInput(signed.headers['Signature-Input']);
-    assert.deepStrictEqual(parsed.components, ['@status', '@authority', 'content-type', 'content-digest']);
+    assert.deepStrictEqual(parsed.components, [
+      '@status',
+      '@authority',
+      '@target-uri',
+      'content-type',
+      'content-digest',
+    ]);
     assert.strictEqual(parsed.params.tag, RESPONSE_SIGNING_TAG);
     assert.strictEqual(parsed.params.keyid, kid);
     assert.strictEqual(parsed.params.alg, 'ed25519');
@@ -109,15 +115,28 @@ describe('signResponse — default covered components', () => {
     assert.strictEqual(signed.headers['Content-Digest'], computeContentDigest(SAMPLE_RESPONSE.body));
   });
 
-  test('respects additionalComponents to bind @target-uri', () => {
+  test('respects additionalComponents to add @method', () => {
     const kid = 'test-ed25519-2026';
     const key = { keyid: kid, alg: 'ed25519', privateKey: privateJwkFor(kid) };
+    const signed = signResponse(SAMPLE_RESPONSE, key, {
+      ...FIXED_OPTIONS,
+      additionalComponents: ['@method'],
+    });
+    const parsed = parseSignatureInput(signed.headers['Signature-Input']);
+    assert.ok(parsed.components.includes('@method'));
+  });
+
+  test('additionalComponents is idempotent for components already in defaults', () => {
+    const kid = 'test-ed25519-2026';
+    const key = { keyid: kid, alg: 'ed25519', privateKey: privateJwkFor(kid) };
+    // Passing @target-uri (already in defaults) must not duplicate it.
     const signed = signResponse(SAMPLE_RESPONSE, key, {
       ...FIXED_OPTIONS,
       additionalComponents: ['@target-uri'],
     });
     const parsed = parseSignatureInput(signed.headers['Signature-Input']);
-    assert.ok(parsed.components.includes('@target-uri'));
+    const occurrences = parsed.components.filter(c => c === '@target-uri').length;
+    assert.strictEqual(occurrences, 1);
   });
 });
 
@@ -209,6 +228,46 @@ describe('signResponse — round-trip verification', () => {
     const publicKey = jwkToPublicKey(publicJwkFor(kid));
     const ok = verifySignature(parsedInput.params.alg, publicKey, Buffer.from(base, 'utf8'), parsedSig.bytes);
     assert.strictEqual(ok, false);
+  });
+});
+
+describe('signResponse — wire-format fixture (RFC 9421 §2.5)', () => {
+  // Pin the signature base byte-by-byte against an independently constructed
+  // expected value. Without this fixture, all round-trip tests above would
+  // pass even if `buildResponseSignatureBase` silently changed canonicalization
+  // (since they both sign AND verify through the same builder). The fixture
+  // is the only thing protecting wire-format compatibility from refactors.
+  test('Ed25519 signature base matches RFC 9421 §2.5 prose for a known response', () => {
+    const kid = 'test-ed25519-2026';
+    const key = { keyid: kid, alg: 'ed25519', privateKey: privateJwkFor(kid) };
+    const signed = signResponse(SAMPLE_RESPONSE, key, FIXED_OPTIONS);
+
+    const expectedDigest = computeContentDigest(SAMPLE_RESPONSE.body);
+    // RFC 9421 §2.5: signature base is `"<component>": <value>\n` lines
+    // followed by `"@signature-params": <params>`. Components in covered
+    // order; params in the order this SDK canonicalizes (created, expires,
+    // nonce, keyid, alg, tag).
+    const expectedBase = [
+      '"@status": 200',
+      '"@authority": seller.example.com',
+      '"@target-uri": https://seller.example.com/adcp/get_products',
+      '"content-type": application/json',
+      `"content-digest": ${expectedDigest}`,
+      `"@signature-params": ("@status" "@authority" "@target-uri" "content-type" "content-digest");created=${FIXED_OPTIONS.now()};expires=${FIXED_OPTIONS.now() + FIXED_OPTIONS.windowSeconds};nonce="${FIXED_OPTIONS.nonce}";keyid="${kid}";alg="ed25519";tag="${RESPONSE_SIGNING_TAG}"`,
+    ].join('\n');
+
+    assert.strictEqual(signed.signatureBase, expectedBase);
+  });
+
+  test('Signature-Input header is canonical for the same response', () => {
+    const kid = 'test-ed25519-2026';
+    const key = { keyid: kid, alg: 'ed25519', privateKey: privateJwkFor(kid) };
+    const signed = signResponse(SAMPLE_RESPONSE, key, FIXED_OPTIONS);
+    const expected =
+      `sig1=("@status" "@authority" "@target-uri" "content-type" "content-digest");` +
+      `created=${FIXED_OPTIONS.now()};expires=${FIXED_OPTIONS.now() + FIXED_OPTIONS.windowSeconds};` +
+      `nonce="${FIXED_OPTIONS.nonce}";keyid="${kid}";alg="ed25519";tag="${RESPONSE_SIGNING_TAG}"`;
+    assert.strictEqual(signed.headers['Signature-Input'], expected);
   });
 });
 

--- a/test/response-signing.test.js
+++ b/test/response-signing.test.js
@@ -6,6 +6,8 @@ const path = require('node:path');
 const {
   signResponse,
   signResponseAsync,
+  signRequest,
+  signWebhook,
   prepareResponseSignature,
   finalizeResponseSignature,
   buildResponseSignatureBase,
@@ -15,6 +17,9 @@ const {
   verifySignature,
   RESPONSE_SIGNING_TAG,
   RESPONSE_MANDATORY_COMPONENTS,
+  ResponseSignatureError,
+  RequestSignatureError,
+  WebhookSignatureError,
   computeContentDigest,
 } = require('../dist/lib/signing/index.js');
 
@@ -39,10 +44,22 @@ function publicJwkFor(kid) {
   return publicPart;
 }
 
-function privateJwkFor(kid) {
+// Use a sentinel for "strip adcp_use entirely" so JS default-param semantics
+// don't quietly substitute 'response-signing' when callers pass undefined.
+const STRIP_ADCP_USE = Symbol('strip-adcp-use');
+
+function privateJwkFor(kid, adcpUse = 'response-signing') {
   const k = keysByKid.get(kid);
   const { _private_d_for_test_only, ...rest } = k;
-  return { ...rest, d: _private_d_for_test_only };
+  // Vectors carry adcp_use='request-signing'; override so the response-signing
+  // purpose-binding gate in signResponse accepts the same key material.
+  const out = { ...rest, d: _private_d_for_test_only };
+  if (adcpUse === STRIP_ADCP_USE) {
+    delete out.adcp_use;
+  } else {
+    out.adcp_use = adcpUse;
+  }
+  return out;
 }
 
 const ORIGINATING_REQUEST = {
@@ -210,6 +227,74 @@ describe('signResponseAsync', () => {
     assert.strictEqual(asyncSig.headers['Signature-Input'], sync.headers['Signature-Input']);
     assert.strictEqual(asyncSig.signatureBase, sync.signatureBase);
     assert.strictEqual(asyncSig.status, sync.status);
+  });
+});
+
+describe('signResponse — adcp_use purpose binding', () => {
+  test('rejects a webhook-signing key with response_signature_key_purpose_invalid', () => {
+    const kid = 'test-ed25519-2026';
+    const wrongPurpose = { keyid: kid, alg: 'ed25519', privateKey: privateJwkFor(kid, 'webhook-signing') };
+    assert.throws(
+      () => signResponse(SAMPLE_RESPONSE, wrongPurpose, FIXED_OPTIONS),
+      err =>
+        err instanceof ResponseSignatureError &&
+        err.code === 'response_signature_key_purpose_invalid' &&
+        err.failedStep === 8 &&
+        /webhook-signing/.test(err.message) &&
+        /response-signing/.test(err.message)
+    );
+  });
+
+  test('rejects a key with missing adcp_use', () => {
+    const kid = 'test-ed25519-2026';
+    const missingPurpose = { keyid: kid, alg: 'ed25519', privateKey: privateJwkFor(kid, STRIP_ADCP_USE) };
+    assert.throws(
+      () => signResponse(SAMPLE_RESPONSE, missingPurpose, FIXED_OPTIONS),
+      err =>
+        err instanceof ResponseSignatureError &&
+        err.code === 'response_signature_key_purpose_invalid' &&
+        /<missing>/.test(err.message)
+    );
+  });
+});
+
+describe('signRequest / signWebhook — adcp_use purpose binding (regression)', () => {
+  test('signRequest rejects a response-signing key', () => {
+    const kid = 'test-ed25519-2026';
+    const wrongPurpose = { keyid: kid, alg: 'ed25519', privateKey: privateJwkFor(kid, 'response-signing') };
+    assert.throws(
+      () =>
+        signRequest(
+          {
+            method: 'POST',
+            url: 'https://seller.example.com/adcp/get_products',
+            headers: { 'Content-Type': 'application/json' },
+            body: '{}',
+          },
+          wrongPurpose,
+          FIXED_OPTIONS
+        ),
+      err => err instanceof RequestSignatureError && err.code === 'request_signature_key_purpose_invalid'
+    );
+  });
+
+  test('signWebhook rejects a request-signing key', () => {
+    const kid = 'test-ed25519-2026';
+    const wrongPurpose = { keyid: kid, alg: 'ed25519', privateKey: privateJwkFor(kid, 'request-signing') };
+    assert.throws(
+      () =>
+        signWebhook(
+          {
+            method: 'POST',
+            url: 'https://buyer.example.com/webhook',
+            headers: { 'Content-Type': 'application/json' },
+            body: '{}',
+          },
+          wrongPurpose,
+          FIXED_OPTIONS
+        ),
+      err => err instanceof WebhookSignatureError && err.code === 'webhook_signature_key_purpose_invalid'
+    );
   });
 });
 

--- a/test/webhook-verifier-error-codes.test.js
+++ b/test/webhook-verifier-error-codes.test.js
@@ -12,7 +12,8 @@ const { describe, test } = require('node:test');
 const assert = require('node:assert');
 
 const { verifyWebhookSignature } = require('../dist/lib/signing/webhook-verifier.js');
-const { signWebhook } = require('../dist/lib/signing/signer.js');
+const { signWebhook, prepareWebhookSignature, finalizeRequestSignature } = require('../dist/lib/signing/signer.js');
+const nodeCrypto = require('node:crypto');
 const { StaticJwksResolver } = require('../dist/lib/signing/jwks.js');
 const { InMemoryReplayStore } = require('../dist/lib/signing/replay.js');
 const { InMemoryRevocationStore } = require('../dist/lib/signing/revocation.js');
@@ -48,11 +49,31 @@ function signerKeyFor(kid) {
       kty: entry.kty,
       crv: entry.crv,
       alg: entry.alg,
+      adcp_use: entry.adcp_use,
       x: entry.x,
       y: entry.y,
       d: entry._private_d_for_test_only,
     },
   };
+}
+
+/**
+ * Sign a webhook while bypassing the signer-side `adcp_use` purpose gate so
+ * the negative-vector cross-purpose-rejection test can construct a payload
+ * that exercises the *verifier's* step-8 check. The convenience helper
+ * `signWebhook` refuses non-webhook-signing keys (the gate's whole point);
+ * compose `prepareWebhookSignature` + node:crypto + `finalizeRequestSignature`
+ * to author adversarial signatures legitimately. Same pattern the
+ * storyboard request-signing builder uses for AdCP negative vector 009.
+ */
+function signWebhookBypassingPurposeGate(request, signerKey, options) {
+  const prepared = prepareWebhookSignature(request, { keyid: signerKey.keyid, alg: signerKey.alg }, options);
+  const privateKey = nodeCrypto.createPrivateKey({ key: signerKey.privateKey, format: 'jwk' });
+  const sigBytes =
+    signerKey.alg === 'ed25519'
+      ? nodeCrypto.sign(null, Buffer.from(prepared.base, 'utf8'), privateKey)
+      : nodeCrypto.sign('sha256', Buffer.from(prepared.base, 'utf8'), { key: privateKey, dsaEncoding: 'ieee-p1363' });
+  return finalizeRequestSignature(prepared, new Uint8Array(sigBytes));
 }
 
 async function verify(requestLike, jwks, opts = {}) {
@@ -74,7 +95,10 @@ describe('webhook verifier: webhook_mode_mismatch (adcp#2467)', () => {
       headers: { 'Content-Type': 'application/json' },
       body: '{"idempotency_key":"whk_01HW9D3H8FZP2N6R8T0V4X6Z9B","status":"completed"}',
     };
-    const signed = signWebhook(request, signerKey, { now: () => now });
+    // Bypass the signer-side adcp_use gate: this test exists precisely to
+    // exercise the verifier's step-8 cross-purpose rejection, which requires
+    // a wire payload signed with a request-signing key.
+    const signed = signWebhookBypassingPurposeGate(request, signerKey, { now: () => now });
     const jwk = toPublicJwk(keyByKid('test-wrong-purpose-2026')); // adcp_use: "request-signing"
     const jwks = new StaticJwksResolver([jwk]);
 


### PR DESCRIPTION
## Summary

Closes #1822. Adds the missing direction of the RFC 9421 signing surface:
server-emitted **signed responses**. `signRequest` / `signWebhook` / `signResponse`
now share the same prepare/finalize shape and `SigningProvider` async path.

| Direction | Helper | Status |
|---|---|---|
| Buyer → server signed request | `signRequest` / `signRequestAsync` | already shipped |
| Server → webhook receiver | `signWebhook` / `signWebhookAsync` | already shipped |
| **Server → buyer signed response** | **`signResponse` / `signResponseAsync`** | **this PR** |

### API

```ts
import { signResponse, type ResponseLike } from '@adcp/sdk/signing/client';

const response: ResponseLike = {
  status: 200,
  headers: { 'content-type': 'application/json' },
  body: JSON.stringify({ products: [...] }),
  // Originating request — needed because RFC 9421 §2.2 binds response
  // signatures to their request context via @authority.
  request: { method: 'POST', url: 'https://seller.example.com/adcp/get_products' },
};

const signed = signResponse(response, key);
// signed.headers now carries Signature, Signature-Input, Content-Digest.
```

### What's covered by default

`['@status', '@authority']` from `RESPONSE_MANDATORY_COMPONENTS`, plus
`content-type` + `content-digest` automatically when the response has a
body. Same conditional shape as `signRequest`. Callers that want to bind
the signature to a specific request URL can opt-in via
`additionalComponents: ['@target-uri']`.

### Async / KMS path

`signResponseAsync(response, provider)` delegates the crypto to the
existing `SigningProvider` interface, the same way `signRequestAsync`
and `signWebhookAsync` do. The prepare/finalize split is exported for
callers that need to hand the canonical base to an external signer.

### Design notes

- **Tag**: `adcp/response-signing/v1` (parallel to existing
  `adcp/request-signing/v1` and `adcp/webhook-signing/v1`).
- **`AdcpUse`**: extended with `'response-signing'` so signer-side JWK
  metadata can declare the binding now. The matching verifier helper
  (`verifyResponseSignature`) is a separate follow-up — most consumers
  are servers verifying inbound requests, not clients verifying
  responses, so demand is lower; round-trip tests in this PR inline a
  test verifier rather than waiting on the public helper.
- **`@status` discipline**: rejected in request-signing canonicalization
  with a clear error rather than falling through to silent "component
  missing." Prevents misuse of `buildSignatureBase` with response
  components.

### Out of scope (deferred follow-ups)

- `verifyResponseSignature()` public helper — separate issue.
- Express middleware wrapper that auto-signs handler responses — caller
  code, downstream of this primitive.
- AdCP spec text mandating response signing for any specific operation
  — protocol-level discussion, separate from SDK ergonomics.

## Test plan

- [x] `node --test test/response-signing.test.js` — 10/10 passing
  - default covered components when body present
  - empty body omits content-digest / content-type
  - `Content-Digest` matches body
  - `additionalComponents` extends covered set
  - Ed25519 round-trip verifies
  - ECDSA-P256 round-trip verifies
  - body tampering invalidates signature
  - status tampering invalidates signature
  - `signResponseAsync` is byte-identical to `signResponse` for Ed25519
  - prepare/finalize split produces identical headers to one-shot
- [x] `npx tsc --noEmit` clean
- [x] `npm run format:check` clean
- [x] Existing signing tests unaffected (request-signing-provider,
  request-signing-vectors, webhook-signature-verification, webhook
  vectors — 143/143 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)