### PR TITLE
feat(comply-controller): add force.audience_status + force.catalog_item_status slots (#1819)

### DIFF
--- a/.changeset/comply-controller-audience-catalog-slots.md
+++ b/.changeset/comply-controller-audience-catalog-slots.md
@@ -1,0 +1,11 @@
+---
+'@adcp/sdk': minor
+---
+
+Add `force.audience_status` and `force.catalog_item_status` slots to `ComplyControllerConfig` (issue #1819).
+
+Adopters wiring `comply_test_controller` through `createComplyController` now have a registration slot for the two resource families that previously forced hand-rolled dispatchers — audience-sync (`forceAudienceStatus`) and catalog-driven seller (`forceCatalogItemStatus`). Both are exposed via the same domain-grouped `force` block as the existing creative/account/media-buy/session slots, and the underlying `TestControllerStore` interface gains matching optional methods so flat-store callers can opt in the same way.
+
+The new scenarios (`force_audience_status`, `force_catalog_item_status`) are treated as extension scenarios — accepted by the dispatcher under `TOOL_INPUT_SHAPE.scenario: z.string()` and advertised via `list_scenarios` when the adapter is registered, but not yet members of `CONTROLLER_SCENARIOS` because the schema cache's `ListScenariosSuccess['scenarios']` union hasn't picked them up. Same pattern as `query_upstream_traffic`. Status values validate against the spec-shipped `AudienceStatusSchema` / `CatalogItemStatusSchema`, so when adcp#2860's offline values (`suspended` / `withdrawn`) land in the spec and codegen reruns, the new transitions flow through with no further SDK change.
+
+Purely additive — existing adopters keep working without modification.

--- a/src/lib/server/test-controller.ts
+++ b/src/lib/server/test-controller.ts
@@ -106,8 +106,20 @@ import type {
   ControllerError,
   ComplyTestControllerResponse,
 } from '../types/tools.generated';
-import type { AccountStatus, MediaBuyStatus, CreativeStatus } from '../types/core.generated';
-import { AccountStatusSchema, MediaBuyStatusSchema, CreativeStatusSchema } from '../types/schemas.generated';
+import type {
+  AccountStatus,
+  AudienceStatus,
+  CatalogItemStatus,
+  MediaBuyStatus,
+  CreativeStatus,
+} from '../types/core.generated';
+import {
+  AccountStatusSchema,
+  AudienceStatusSchema,
+  CatalogItemStatusSchema,
+  MediaBuyStatusSchema,
+  CreativeStatusSchema,
+} from '../types/schemas.generated';
 import type { McpToolResponse } from './responses';
 import { toStructuredContent } from './responses';
 
@@ -252,6 +264,53 @@ export interface TestControllerStore {
    * buyer's `push_notification_config.url` per the AdCP 3.0 completion path.
    */
   forceTaskCompletion?(taskId: string, result: Record<string, unknown>): Promise<StateTransitionSuccess>;
+
+  /**
+   * Transition a synced audience to the specified matching status. Backs
+   * the `impairment.coherence` audience inverse-rule traversal — storyboards
+   * flip an audience offline to verify that downstream segments / activations
+   * reflect the upstream state change. Advertised as `force_audience_status`
+   * via `list_scenarios`.
+   *
+   * Extension scenario: not yet a member of `CONTROLLER_SCENARIOS` because
+   * the schema cache's `ListScenariosSuccess['scenarios']` union doesn't
+   * include `force_audience_status` (open-for-extension per spec). The
+   * dispatcher accepts the literal string under `TOOL_INPUT_SHAPE.scenario:
+   * z.string()`. Status values are validated against the spec-shipped
+   * `AudienceStatusSchema` — when the spec adds offline values
+   * (e.g. `suspended` for adcp#2860), codegen widens the schema and this
+   * adapter automatically accepts them.
+   *
+   * Wire param convention: the dispatcher accepts `reason` (this issue's
+   * proposed name, neutral across non-rejection transitions like
+   * `processing → ready`) OR `rejection_reason` (the field name used by
+   * `force_creative_status` / `force_media_buy_status`). Adapters receive
+   * whichever was supplied as the single `reason` argument.
+   *
+   * TODO(adcp#2860): when the spec PR lands populated effects
+   * (`matched_count`, `effective_match_rate`) on the `ready` transition,
+   * the return shape may widen from plain `StateTransitionSuccess` to a
+   * variant carrying `effects?`. Track the spec PR and update once the
+   * schema cache picks it up.
+   */
+  forceAudienceStatus?(audienceId: string, status: AudienceStatus, reason?: string): Promise<StateTransitionSuccess>;
+
+  /**
+   * Transition a single catalog item to the specified review status. Backs
+   * the catalog-side `impairment.coherence` traversal (item-level approval
+   * flipping). Advertised as `force_catalog_item_status` via
+   * `list_scenarios`.
+   *
+   * Extension scenario; see {@link forceAudienceStatus} for the rationale.
+   * Status validated against `CatalogItemStatusSchema`. Same dual
+   * `reason` / `rejection_reason` acceptance as `forceAudienceStatus`.
+   *
+   * Param name note: `catalog_item_id` (not `item_id`). Storyboard runner
+   * bindings in `sales-catalog-driven` reference catalog items by this
+   * name; the wire entity field is `item_id`, but the controller layer is
+   * driven by storyboards, so we follow the binding convention.
+   */
+  forceCatalogItemStatus?(itemId: string, status: CatalogItemStatus, reason?: string): Promise<StateTransitionSuccess>;
 
   /** Inject synthetic delivery data for a media buy. */
   simulateDelivery?(
@@ -480,6 +539,17 @@ export function enforceMapCap<V>(
  */
 const QUERY_UPSTREAM_TRAFFIC_SCENARIO = 'query_upstream_traffic';
 
+/**
+ * Force-transition extension scenarios for resource families whose status
+ * enum exists in the spec but isn't yet a member of
+ * `ListScenariosSuccess['scenarios']`. Issue #1819 — unblocks the
+ * dependency-impairment storyboard cluster (adcp#2860) by giving adopters
+ * a registration slot today; the value list expands automatically when the
+ * spec adds offline values and codegen reruns.
+ */
+const FORCE_AUDIENCE_STATUS_SCENARIO = 'force_audience_status';
+const FORCE_CATALOG_ITEM_STATUS_SCENARIO = 'force_catalog_item_status';
+
 /** Map store method presence to scenario names. */
 const SCENARIO_MAP: Array<[keyof TestControllerStore, ControllerScenario]> = [
   ['forceCreativeStatus', CONTROLLER_SCENARIOS.FORCE_CREATIVE_STATUS],
@@ -512,6 +582,8 @@ function scenariosFromStore(store: TestControllerStore): ControllerScenario[] {
  */
 function allScenariosFromStore(store: TestControllerStore): string[] {
   const out: string[] = scenariosFromStore(store);
+  if (typeof store.forceAudienceStatus === 'function') out.push(FORCE_AUDIENCE_STATUS_SCENARIO);
+  if (typeof store.forceCatalogItemStatus === 'function') out.push(FORCE_CATALOG_ITEM_STATUS_SCENARIO);
   if (typeof store.queryUpstreamTraffic === 'function') out.push(QUERY_UPSTREAM_TRAFFIC_SCENARIO);
   return out;
 }
@@ -991,8 +1063,57 @@ async function handleTestControllerRequestImpl(
 
       // Extension scenarios — accepted by the dispatcher but not yet
       // members of CONTROLLER_SCENARIOS. Promoted to first-class constants
-      // once a release ships the schema. Today: just `query_upstream_traffic`
-      // (spec PR adcp#3816).
+      // once a release ships the schema. Today: `query_upstream_traffic`
+      // (spec PR adcp#3816), `force_audience_status` /
+      // `force_catalog_item_status` (issue #1819 / spec adcp#2860).
+      case FORCE_AUDIENCE_STATUS_SCENARIO: {
+        if (!store.forceAudienceStatus) {
+          return controllerError('UNKNOWN_SCENARIO', `Scenario not supported: ${scenario}`);
+        }
+        if (!params?.audience_id || !params?.status) {
+          return controllerError(
+            'INVALID_PARAMS',
+            'force_audience_status requires params.audience_id and params.status'
+          );
+        }
+        const audienceStatus = AudienceStatusSchema.safeParse(params.status);
+        if (!audienceStatus.success) {
+          return controllerError('INVALID_PARAMS', `Invalid audience status: ${params.status}`);
+        }
+        // Accept either `reason` (this issue's proposed shape, neutral across
+        // transitions like processing→ready) or `rejection_reason` (the field
+        // name used by force_creative_status / force_media_buy_status). The
+        // adapter receives whichever was supplied — de-risks the eventual spec
+        // PR (adcp#2860) picking either name.
+        return await store.forceAudienceStatus(
+          params.audience_id as string,
+          audienceStatus.data,
+          (params.reason ?? params.rejection_reason) as string | undefined
+        );
+      }
+
+      case FORCE_CATALOG_ITEM_STATUS_SCENARIO: {
+        if (!store.forceCatalogItemStatus) {
+          return controllerError('UNKNOWN_SCENARIO', `Scenario not supported: ${scenario}`);
+        }
+        if (!params?.catalog_item_id || !params?.status) {
+          return controllerError(
+            'INVALID_PARAMS',
+            'force_catalog_item_status requires params.catalog_item_id and params.status'
+          );
+        }
+        const itemStatus = CatalogItemStatusSchema.safeParse(params.status);
+        if (!itemStatus.success) {
+          return controllerError('INVALID_PARAMS', `Invalid catalog item status: ${params.status}`);
+        }
+        // See force_audience_status above — same dual-name acceptance.
+        return await store.forceCatalogItemStatus(
+          params.catalog_item_id as string,
+          itemStatus.data,
+          (params.reason ?? params.rejection_reason) as string | undefined
+        );
+      }
+
       case QUERY_UPSTREAM_TRAFFIC_SCENARIO: {
         if (!store.queryUpstreamTraffic) {
           return controllerError('UNKNOWN_SCENARIO', `Scenario not supported: ${scenario}`);

--- a/src/lib/testing/comply-controller.ts
+++ b/src/lib/testing/comply-controller.ts
@@ -64,7 +64,13 @@ import type {
   SimulationSuccess,
   StateTransitionSuccess,
 } from '../types/tools.generated';
-import type { AccountStatus, CreativeStatus, MediaBuyStatus } from '../types/core.generated';
+import type {
+  AccountStatus,
+  AudienceStatus,
+  CatalogItemStatus,
+  CreativeStatus,
+  MediaBuyStatus,
+} from '../types/core.generated';
 import type { McpToolResponse } from '../server/responses';
 
 // ────────────────────────────────────────────────────────────
@@ -144,6 +150,25 @@ export interface ForceCreateMediaBuyArmParams {
 export interface ForceTaskCompletionParams {
   task_id: string;
   result: Record<string, unknown>;
+}
+
+/**
+ * Params for `force_audience_status` (extension scenario; issue #1819).
+ * `status` is typed against the spec-shipped `AudienceStatus`; offline
+ * values (e.g. `suspended` for adcp#2860's impairment storyboard) flow
+ * through automatically once the spec ships them and codegen reruns.
+ */
+export interface ForceAudienceStatusParams {
+  audience_id: string;
+  status: AudienceStatus;
+  reason?: string;
+}
+
+/** Params for `force_catalog_item_status` (extension scenario; issue #1819). */
+export interface ForceCatalogItemStatusParams {
+  catalog_item_id: string;
+  status: CatalogItemStatus;
+  reason?: string;
 }
 
 export interface SimulateDeliveryParams {
@@ -280,6 +305,14 @@ export interface ComplyControllerConfig {
      * payload. The seller delivers `result` to the buyer's push-notification
      * URL per the AdCP 3.0 async completion path. */
     task_completion?: ForceAdapter<ForceTaskCompletionParams>;
+    /** Transition a synced audience to a matching status. Backs the
+     * `impairment.coherence` audience inverse-rule traversal (issue #1819).
+     * Advertised as `force_audience_status`. */
+    audience_status?: ForceAdapter<ForceAudienceStatusParams>;
+    /** Transition a single catalog item to a review status. Backs the
+     * catalog-side `impairment.coherence` traversal (issue #1819).
+     * Advertised as `force_catalog_item_status`. */
+    catalog_item_status?: ForceAdapter<ForceCatalogItemStatusParams>;
   };
 
   /** Simulation adapters (synthetic delivery/budget data). */
@@ -444,6 +477,14 @@ function buildStore(config: ComplyControllerConfig, ctx: ComplyControllerContext
     store.forceTaskCompletion = (taskId, result) =>
       Promise.resolve(force.task_completion!({ task_id: taskId, result }, ctx));
   }
+  if (force?.audience_status) {
+    store.forceAudienceStatus = (audienceId, status, reason) =>
+      Promise.resolve(force.audience_status!({ audience_id: audienceId, status, reason }, ctx));
+  }
+  if (force?.catalog_item_status) {
+    store.forceCatalogItemStatus = (itemId, status, reason) =>
+      Promise.resolve(force.catalog_item_status!({ catalog_item_id: itemId, status, reason }, ctx));
+  }
 
   if (simulate?.delivery) {
     store.simulateDelivery = (mediaBuyId, params) =>
@@ -472,13 +513,15 @@ function advertisedScenarios(config: ComplyControllerConfig): ControllerScenario
   if (config.force?.task_completion) out.push(CONTROLLER_SCENARIOS.FORCE_TASK_COMPLETION);
   if (config.simulate?.delivery) out.push(CONTROLLER_SCENARIOS.SIMULATE_DELIVERY);
   if (config.simulate?.budget_spend) out.push(CONTROLLER_SCENARIOS.SIMULATE_BUDGET_SPEND);
-  // `query_upstream_traffic` is an extension scenario (spec PR
-  // adcontextprotocol/adcp#3816) — not yet in the schema cache's
-  // `ControllerScenario` enum, but the dispatcher accepts it under
-  // `TOOL_INPUT_SHAPE.scenario: z.string()`'s open-extension pattern.
-  // Cast through unknown until the schema lands, then this becomes a
-  // `CONTROLLER_SCENARIOS.QUERY_UPSTREAM_TRAFFIC` reference like the
-  // others above.
+  // Extension scenarios (not yet in the schema cache's `ControllerScenario`
+  // enum — dispatcher accepts them under `TOOL_INPUT_SHAPE.scenario:
+  // z.string()`'s open-extension pattern). Cast through unknown until the
+  // schemas land, then these become `CONTROLLER_SCENARIOS.*` references.
+  // Bundle the cleanup when codegen catches up:
+  //   - audience_status / catalog_item_status: issue #1819 + spec adcp#2860
+  //   - query_upstream_traffic: spec adcp#3816
+  if (config.force?.audience_status) out.push('force_audience_status' as unknown as ControllerScenario);
+  if (config.force?.catalog_item_status) out.push('force_catalog_item_status' as unknown as ControllerScenario);
   if (config.queryUpstreamTraffic) out.push('query_upstream_traffic' as unknown as ControllerScenario);
   return out;
 }

--- a/src/lib/testing/index.ts
+++ b/src/lib/testing/index.ts
@@ -133,6 +133,8 @@ export type {
   DirectiveAdapter,
   ForceAccountStatusParams,
   ForceAdapter,
+  ForceAudienceStatusParams,
+  ForceCatalogItemStatusParams,
   ForceCreateMediaBuyArmParams,
   ForceCreativeStatusParams,
   ForceMediaBuyStatusParams,

--- a/test/comply-controller.test.js
+++ b/test/comply-controller.test.js
@@ -184,6 +184,73 @@ describe('createComplyController — dispatch', () => {
     assert.strictEqual(result.success, false);
     assert.strictEqual(result.error, 'UNKNOWN_SCENARIO');
   });
+
+  // ── force.audience_status + force.catalog_item_status (issue #1819) ──
+
+  it('routes force.audience_status to the adapter with typed params', async () => {
+    let captured;
+    const controller = createComplyController({
+      force: {
+        audience_status: params => {
+          captured = params;
+          return { success: true, previous_state: 'processing', current_state: params.status };
+        },
+      },
+    });
+    const result = await controller.handleRaw({
+      scenario: 'force_audience_status',
+      params: { audience_id: 'aud-1', status: 'ready', reason: 'matching complete' },
+    });
+    assert.strictEqual(result.success, true);
+    assert.strictEqual(result.current_state, 'ready');
+    assert.deepStrictEqual(captured, { audience_id: 'aud-1', status: 'ready', reason: 'matching complete' });
+  });
+
+  it('advertises force_audience_status via list_scenarios when registered', async () => {
+    const controller = createComplyController({
+      force: { audience_status: () => ({ success: true, previous_state: 'processing', current_state: 'ready' }) },
+    });
+    const result = await controller.handleRaw({ scenario: 'list_scenarios' });
+    assert.ok(result.scenarios.includes('force_audience_status'));
+  });
+
+  it('returns UNKNOWN_SCENARIO for force_audience_status when adapter not registered', async () => {
+    const controller = createComplyController({});
+    const result = await controller.handleRaw({
+      scenario: 'force_audience_status',
+      params: { audience_id: 'aud-1', status: 'ready' },
+    });
+    assert.strictEqual(result.error, 'UNKNOWN_SCENARIO');
+  });
+
+  it('routes force.catalog_item_status to the adapter with typed params', async () => {
+    let captured;
+    const controller = createComplyController({
+      force: {
+        catalog_item_status: params => {
+          captured = params;
+          return { success: true, previous_state: 'pending', current_state: params.status };
+        },
+      },
+    });
+    const result = await controller.handleRaw({
+      scenario: 'force_catalog_item_status',
+      params: { catalog_item_id: 'sku-42', status: 'rejected', reason: 'policy violation' },
+    });
+    assert.strictEqual(result.success, true);
+    assert.strictEqual(result.current_state, 'rejected');
+    assert.deepStrictEqual(captured, { catalog_item_id: 'sku-42', status: 'rejected', reason: 'policy violation' });
+  });
+
+  it('advertises force_catalog_item_status via list_scenarios when registered', async () => {
+    const controller = createComplyController({
+      force: {
+        catalog_item_status: () => ({ success: true, previous_state: 'pending', current_state: 'approved' }),
+      },
+    });
+    const result = await controller.handleRaw({ scenario: 'list_scenarios' });
+    assert.ok(result.scenarios.includes('force_catalog_item_status'));
+  });
 });
 
 describe('createComplyController — seed idempotency', () => {

--- a/test/server-test-controller.test.js
+++ b/test/server-test-controller.test.js
@@ -168,6 +168,169 @@ describe('handleTestControllerRequest', () => {
     });
   });
 
+  // ── force_audience_status (extension; issue #1819) ──────
+
+  describe('force_audience_status', () => {
+    it('calls store and returns transition result', async () => {
+      const store = {
+        async forceAudienceStatus(id, status, reason) {
+          return { success: true, previous_state: 'processing', current_state: status };
+        },
+      };
+      const result = await handleTestControllerRequest(store, {
+        scenario: 'force_audience_status',
+        params: { audience_id: 'aud-1', status: 'ready' },
+      });
+      assert.strictEqual(result.success, true);
+      assert.strictEqual(result.current_state, 'ready');
+    });
+
+    it('passes reason to store', async () => {
+      let capturedReason;
+      const store = {
+        async forceAudienceStatus(id, status, reason) {
+          capturedReason = reason;
+          return { success: true, previous_state: 'ready', current_state: 'too_small' };
+        },
+      };
+      await handleTestControllerRequest(store, {
+        scenario: 'force_audience_status',
+        params: { audience_id: 'aud-1', status: 'too_small', reason: 'Member churn' },
+      });
+      assert.strictEqual(capturedReason, 'Member churn');
+    });
+
+    it('returns UNKNOWN_SCENARIO when store lacks method', async () => {
+      const result = await handleTestControllerRequest(
+        {},
+        {
+          scenario: 'force_audience_status',
+          params: { audience_id: 'aud-1', status: 'ready' },
+        }
+      );
+      assert.strictEqual(result.error, 'UNKNOWN_SCENARIO');
+    });
+
+    it('returns INVALID_PARAMS when audience_id is missing', async () => {
+      const store = { async forceAudienceStatus() {} };
+      const result = await handleTestControllerRequest(store, {
+        scenario: 'force_audience_status',
+        params: { status: 'ready' },
+      });
+      assert.strictEqual(result.error, 'INVALID_PARAMS');
+    });
+
+    it('returns INVALID_PARAMS when status is missing', async () => {
+      const store = { async forceAudienceStatus() {} };
+      const result = await handleTestControllerRequest(store, {
+        scenario: 'force_audience_status',
+        params: { audience_id: 'aud-1' },
+      });
+      assert.strictEqual(result.error, 'INVALID_PARAMS');
+    });
+
+    it('accepts rejection_reason as an alias for reason', async () => {
+      // Dual-name acceptance — the spec PR adcp#2860 may pick either field
+      // name; the dispatcher forwards whichever was supplied. Guards against
+      // a future-breaking rename.
+      let captured;
+      const store = {
+        async forceAudienceStatus(id, status, reason) {
+          captured = reason;
+          return { success: true, previous_state: 'ready', current_state: 'too_small' };
+        },
+      };
+      await handleTestControllerRequest(store, {
+        scenario: 'force_audience_status',
+        params: { audience_id: 'aud-1', status: 'too_small', rejection_reason: 'Audit failed' },
+      });
+      assert.strictEqual(captured, 'Audit failed');
+    });
+
+    it('rejects invalid audience status', async () => {
+      const store = { async forceAudienceStatus() {} };
+      const result = await handleTestControllerRequest(store, {
+        scenario: 'force_audience_status',
+        params: { audience_id: 'aud-1', status: 'banana' },
+      });
+      assert.strictEqual(result.error, 'INVALID_PARAMS');
+      assert.match(result.error_detail, /Invalid audience status/);
+    });
+
+    it('is advertised via list_scenarios when store implements it', async () => {
+      const store = { async forceAudienceStatus() {} };
+      const result = await handleTestControllerRequest(store, { scenario: 'list_scenarios' });
+      assert.ok(result.scenarios.includes('force_audience_status'));
+    });
+  });
+
+  // ── force_catalog_item_status (extension; issue #1819) ──
+
+  describe('force_catalog_item_status', () => {
+    it('calls store and returns transition result', async () => {
+      const store = {
+        async forceCatalogItemStatus(id, status) {
+          return { success: true, previous_state: 'pending', current_state: status };
+        },
+      };
+      const result = await handleTestControllerRequest(store, {
+        scenario: 'force_catalog_item_status',
+        params: { catalog_item_id: 'sku-42', status: 'approved' },
+      });
+      assert.strictEqual(result.success, true);
+      assert.strictEqual(result.current_state, 'approved');
+    });
+
+    it('returns INVALID_PARAMS when catalog_item_id is missing', async () => {
+      const store = { async forceCatalogItemStatus() {} };
+      const result = await handleTestControllerRequest(store, {
+        scenario: 'force_catalog_item_status',
+        params: { status: 'approved' },
+      });
+      assert.strictEqual(result.error, 'INVALID_PARAMS');
+    });
+
+    it('returns INVALID_PARAMS when status is missing', async () => {
+      const store = { async forceCatalogItemStatus() {} };
+      const result = await handleTestControllerRequest(store, {
+        scenario: 'force_catalog_item_status',
+        params: { catalog_item_id: 'sku-42' },
+      });
+      assert.strictEqual(result.error, 'INVALID_PARAMS');
+    });
+
+    it('accepts rejection_reason as an alias for reason', async () => {
+      let captured;
+      const store = {
+        async forceCatalogItemStatus(id, status, reason) {
+          captured = reason;
+          return { success: true, previous_state: 'pending', current_state: 'rejected' };
+        },
+      };
+      await handleTestControllerRequest(store, {
+        scenario: 'force_catalog_item_status',
+        params: { catalog_item_id: 'sku-42', status: 'rejected', rejection_reason: 'Missing image' },
+      });
+      assert.strictEqual(captured, 'Missing image');
+    });
+
+    it('rejects invalid catalog item status', async () => {
+      const store = { async forceCatalogItemStatus() {} };
+      const result = await handleTestControllerRequest(store, {
+        scenario: 'force_catalog_item_status',
+        params: { catalog_item_id: 'sku-42', status: 'banana' },
+      });
+      assert.strictEqual(result.error, 'INVALID_PARAMS');
+      assert.match(result.error_detail, /Invalid catalog item status/);
+    });
+
+    it('is advertised via list_scenarios when store implements it', async () => {
+      const store = { async forceCatalogItemStatus() {} };
+      const result = await handleTestControllerRequest(store, { scenario: 'list_scenarios' });
+      assert.ok(result.scenarios.includes('force_catalog_item_status'));
+    });
+  });
+
   // ── simulate_delivery ───────────────────────────────────
 
   describe('simulate_delivery', () => {


### PR DESCRIPTION
Closes #1819.

## Summary

- Adds `force.audience_status` and `force.catalog_item_status` slots to `ComplyControllerConfig`, plus matching `forceAudienceStatus` / `forceCatalogItemStatus` methods on the flat `TestControllerStore` interface.
- Treated as extension scenarios under the existing `query_upstream_traffic` precedent — accepted by the dispatcher under `TOOL_INPUT_SHAPE.scenario: z.string()` but not yet members of `CONTROLLER_SCENARIOS` (schema cache at 3.0.12 hasn't picked them up). Status values validate against the spec-shipped `AudienceStatusSchema` / `CatalogItemStatusSchema`; when adcp#2860 lands the offline values (`suspended` / `withdrawn`) and codegen reruns, the new transitions flow through with no further SDK change.
- Dispatcher accepts both `reason` and `rejection_reason` to de-risk the spec PR picking either field name (forwarded as a single `reason` arg to the adapter).
- `event_source_status` deliberately omitted per the issue's own "no spec-side scenario name yet" caveat.

## Why

Unblocks adopters from hand-rolling `comply_test_controller` dispatchers to exercise the `impairment.coherence` inverse-rule traversal in the `audience-sync` and `sales-catalog-driven` storyboards. The training agent in `adcontextprotocol/adcp` hit this gap when grading adcp#2860's dependency-impairment cluster.

## Expert review (parallel pre-PR)

- **ad-tech-protocol-expert**: sound-with-caveats. All three actionable items applied: dual-accept `reason` / `rejection_reason`, JSDoc note on `catalog_item_id` naming choice, TODO comment about future `effects?` widening on the `ready` transition.
- **code-reviewer**: two real items applied — added missing-`status` INVALID_PARAMS tests for symmetry with `force_creative_status` precedent, and reverted unrelated `version.ts` drift the build script touched.
- **security-reviewer**: no blockers. One follow-up noted (apply `sanitizeLabel` to all status echo sites including the existing creative/account/media-buy branches) — explicitly out of scope for #1819, left for a follow-up PR.

## Test plan

- [x] `npm run build` — clean
- [x] `npm run format:check` — clean
- [x] `NODE_ENV=test node --test test/server-test-controller.test.js test/comply-controller.test.js` — 158/158 pass
- [x] Full repo suite — 8978/8982 pass; only failure is a pre-existing `EADDRINUSE` flake in `local-agent-runner.test.js:66`, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)