### PR TITLE
feat(storyboard): add `array_length` check kind for cardinality assertions (#1830)

### DIFF
--- a/.changeset/array-length-check-1830.md
+++ b/.changeset/array-length-check-1830.md
@@ -1,0 +1,37 @@
+---
+'@adcp/sdk': minor
+---
+
+storyboard runner: add `array_length` check kind for cardinality assertions (#1830)
+
+Cardinality scenarios can now assert "exactly N entries" directly:
+
+```yaml
+- check: array_length
+  path: media_buys[0].impairments
+  value: 2
+  description: Exactly two impairments — one per rejected creative
+```
+
+Range form is also supported (`min` / `max`, either or both, both inclusive):
+
+```yaml
+- check: array_length
+  path: media_buys[0].impairments
+  min: 1
+  max: 1
+  description: Exactly one impairment
+```
+
+The previous workaround (`field_present arr[N-1]` paired with
+`field_value_or_absent arr[N] value: null`) is unsound for cardinality: the
+`field_value_or_absent` clause passes when a seller emits a literal `null`
+pad at `arr[N]`. `array_length` reads `array.length` directly and rejects
+non-array resolutions, so a `null` pad fails the check as it should.
+
+Specifying both `value` and `min`/`max` is rejected as a misconfigured
+check. Specifying none of the three is also rejected. Resolved-path-is-not-an-array
+fails with a type error rather than passing silently.
+
+Follow-up to adcontextprotocol/adcp#4685 protocol review; spec-side YAML
+schema addition tracked separately.

--- a/scripts/conformance-replay.ts
+++ b/scripts/conformance-replay.ts
@@ -332,31 +332,48 @@ async function runStep(
         result.failures.push(`${check} ${v.path}: got ${JSON.stringify(actual)}, want ${JSON.stringify(v.value)}`);
       }
     } else if (check === 'array_length') {
-      const actual = getByPath(structured, v.path as string);
-      if (!Array.isArray(actual)) {
+      const hasExact = typeof v.value === 'number';
+      const hasMin = typeof (v as { min?: unknown }).min === 'number';
+      const hasMax = typeof (v as { max?: unknown }).max === 'number';
+      const min = hasMin ? (v as { min: number }).min : undefined;
+      const max = hasMax ? (v as { max: number }).max : undefined;
+      const isValidCount = (n: unknown): n is number => typeof n === 'number' && Number.isInteger(n) && n >= 0;
+      if (!hasExact && !hasMin && !hasMax) {
         allPassed = false;
-        result.failures.push(
-          `array_length ${v.path}: not an array (got ${actual === undefined ? 'undefined' : typeof actual})`
-        );
+        result.failures.push(`array_length ${v.path}: misconfigured (need value or min/max)`);
+      } else if (hasExact && (hasMin || hasMax)) {
+        allPassed = false;
+        result.failures.push(`array_length ${v.path}: misconfigured (value and min/max are mutually exclusive)`);
+      } else if (hasExact && !isValidCount(v.value)) {
+        allPassed = false;
+        result.failures.push(`array_length ${v.path}: misconfigured (value must be a non-negative integer)`);
+      } else if (hasMin && !isValidCount(min)) {
+        allPassed = false;
+        result.failures.push(`array_length ${v.path}: misconfigured (min must be a non-negative integer)`);
+      } else if (hasMax && !isValidCount(max)) {
+        allPassed = false;
+        result.failures.push(`array_length ${v.path}: misconfigured (max must be a non-negative integer)`);
+      } else if (hasMin && hasMax && (min as number) > (max as number)) {
+        allPassed = false;
+        result.failures.push(`array_length ${v.path}: impossible range (min ${min} > max ${max})`);
       } else {
-        const len = actual.length;
-        const hasExact = typeof v.value === 'number';
-        const hasMin = typeof (v as { min?: unknown }).min === 'number';
-        const hasMax = typeof (v as { max?: unknown }).max === 'number';
-        const min = hasMin ? (v as { min: number }).min : undefined;
-        const max = hasMax ? (v as { max: number }).max : undefined;
-        if (hasExact && len !== v.value) {
+        const actual = getByPath(structured, v.path as string);
+        if (!Array.isArray(actual)) {
           allPassed = false;
-          result.failures.push(`array_length ${v.path}: got ${len}, want ${v.value}`);
-        } else if (!hasExact && min !== undefined && len < min) {
-          allPassed = false;
-          result.failures.push(`array_length ${v.path}: got ${len}, want >= ${min}`);
-        } else if (!hasExact && max !== undefined && len > max) {
-          allPassed = false;
-          result.failures.push(`array_length ${v.path}: got ${len}, want <= ${max}`);
-        } else if (!hasExact && !hasMin && !hasMax) {
-          allPassed = false;
-          result.failures.push(`array_length ${v.path}: misconfigured (need value or min/max)`);
+          const ty = actual === undefined ? 'undefined' : actual === null ? 'null' : typeof actual;
+          result.failures.push(`array_length ${v.path}: not an array (got ${ty})`);
+        } else {
+          const len = actual.length;
+          if (hasExact && len !== v.value) {
+            allPassed = false;
+            result.failures.push(`array_length ${v.path}: got ${len}, want ${v.value}`);
+          } else if (!hasExact && min !== undefined && len < min) {
+            allPassed = false;
+            result.failures.push(`array_length ${v.path}: got ${len}, want >= ${min}`);
+          } else if (!hasExact && max !== undefined && len > max) {
+            allPassed = false;
+            result.failures.push(`array_length ${v.path}: got ${len}, want <= ${max}`);
+          }
         }
       }
     } else if (TRANSPORT_ONLY_CHECKS.has(check)) {

--- a/scripts/conformance-replay.ts
+++ b/scripts/conformance-replay.ts
@@ -224,6 +224,8 @@ const IMPLEMENTED_CHECKS = new Set([
   // `replayed`, etc.); the distinction is for static drift detection.
   'envelope_field_present',
   'envelope_field_value',
+  // Cardinality assertions (adcp#4685 / adcp-client#1830).
+  'array_length',
 ]);
 
 // Check types that fundamentally need transport-layer state (HTTP status,
@@ -328,6 +330,34 @@ async function runStep(
       if (actual !== v.value) {
         allPassed = false;
         result.failures.push(`${check} ${v.path}: got ${JSON.stringify(actual)}, want ${JSON.stringify(v.value)}`);
+      }
+    } else if (check === 'array_length') {
+      const actual = getByPath(structured, v.path as string);
+      if (!Array.isArray(actual)) {
+        allPassed = false;
+        result.failures.push(
+          `array_length ${v.path}: not an array (got ${actual === undefined ? 'undefined' : typeof actual})`
+        );
+      } else {
+        const len = actual.length;
+        const hasExact = typeof v.value === 'number';
+        const hasMin = typeof (v as { min?: unknown }).min === 'number';
+        const hasMax = typeof (v as { max?: unknown }).max === 'number';
+        const min = hasMin ? (v as { min: number }).min : undefined;
+        const max = hasMax ? (v as { max: number }).max : undefined;
+        if (hasExact && len !== v.value) {
+          allPassed = false;
+          result.failures.push(`array_length ${v.path}: got ${len}, want ${v.value}`);
+        } else if (!hasExact && min !== undefined && len < min) {
+          allPassed = false;
+          result.failures.push(`array_length ${v.path}: got ${len}, want >= ${min}`);
+        } else if (!hasExact && max !== undefined && len > max) {
+          allPassed = false;
+          result.failures.push(`array_length ${v.path}: got ${len}, want <= ${max}`);
+        } else if (!hasExact && !hasMin && !hasMax) {
+          allPassed = false;
+          result.failures.push(`array_length ${v.path}: misconfigured (need value or min/max)`);
+        }
       }
     } else if (TRANSPORT_ONLY_CHECKS.has(check)) {
       // Transport-only checks require an HTTP-mode harness; permanently

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -717,10 +717,17 @@ export type StoryboardValidationCheck =
    * supported: exact-count via `value: N` (passes only when the resolved
    * array has exactly N entries) and range via `min` / `max` (either bound
    * is optional; both inclusive). Specifying both `value` and `min`/`max` is
-   * rejected as a misconfigured check. Fails with a type error when the
+   * rejected as a misconfigured check; so are non-integer, negative, NaN,
+   * or impossible (`min > max`) operands. Fails with a type error when the
    * resolved path is absent or not an array — `field_present` paired with
    * `field_value_or_absent value: null` is unsound for cardinality because
    * it passes when a seller emits a literal-null pad at `arr[N]`.
+   *
+   * **Non-optional by design.** This check has no tolerant arm — an absent
+   * path fails. Use `field_value_or_absent` (or omit the check) when the
+   * field itself is spec-optional; `array_length` is for asserting the
+   * cardinality of an array that MUST be present.
+   *
    * Spec: adcp#4685 (cardinality assertions); SDK adcp-client#1830.
    */
   | 'array_length';

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -711,7 +711,19 @@ export type StoryboardValidationCheck =
    * dispatch resolved successfully. Spec:
    * test-kits/parallel-dispatch-runner.yaml.
    */
-  | 'cross_response_count_distinct';
+  | 'cross_response_count_distinct'
+  /**
+   * Assert the cardinality of the array at `path`. Two configurations are
+   * supported: exact-count via `value: N` (passes only when the resolved
+   * array has exactly N entries) and range via `min` / `max` (either bound
+   * is optional; both inclusive). Specifying both `value` and `min`/`max` is
+   * rejected as a misconfigured check. Fails with a type error when the
+   * resolved path is absent or not an array — `field_present` paired with
+   * `field_value_or_absent value: null` is unsound for cardinality because
+   * it passes when a seller emits a literal-null pad at `arr[N]`.
+   * Spec: adcp#4685 (cardinality assertions); SDK adcp-client#1830.
+   */
+  | 'array_length';
 
 /**
  * Configuration for a step that fans out to N concurrent dispatches against
@@ -921,6 +933,17 @@ export interface StoryboardValidation {
    * for cumulative-effect assertions.
    */
   since?: string;
+  // ─── array_length fields ──────────────────────────────────
+  /**
+   * Inclusive lower bound for `array_length`. Mutually exclusive with
+   * `value`. Pass with `max` omitted to assert "at least N entries."
+   */
+  min?: number;
+  /**
+   * Inclusive upper bound for `array_length`. Mutually exclusive with
+   * `value`. Pass with `min` omitted to assert "at most N entries."
+   */
+  max?: number;
 }
 
 // ────────────────────────────────────────────────────────────

--- a/src/lib/testing/storyboard/validations.ts
+++ b/src/lib/testing/storyboard/validations.ts
@@ -269,6 +269,8 @@ function runValidation(validation: StoryboardValidation, ctx: ValidationContext)
       return validateCrossResponseFieldEqual(validation, ctx);
     case 'cross_response_count_distinct':
       return validateCrossResponseCountDistinct(validation, ctx);
+    case 'array_length':
+      return validateArrayLength(validation, resolveTarget(ctx));
     default:
       // Forward-compat default per runner-output-contract.yaml v2.0.0:
       // when the runner does not implement an authored check kind (e.g. a
@@ -976,6 +978,144 @@ function validateFieldContains(validation: StoryboardValidation, taskResult: Tas
     json_pointer: pointer,
     expected,
     actual: resolved,
+  };
+}
+
+// ────────────────────────────────────────────────────────────
+// array_length: assert cardinality of the array at `path`
+//
+// Configurations:
+//   - `value: N`       → exact match (array.length === N)
+//   - `min` / `max`    → inclusive bounds (either or both)
+//   - both             → misconfigured, fails the check
+//
+// Cardinality is unsound to express via `field_present arr[N-1]` +
+// `field_value_or_absent arr[N] value: null` because the second clause
+// passes when a seller emits a literal `null` pad at `arr[N]`. This check
+// reads `array.length` directly and rejects non-array resolutions instead.
+// Spec: adcp#4685; SDK adcp-client#1830.
+// ────────────────────────────────────────────────────────────
+
+function validateArrayLength(validation: StoryboardValidation, taskResult: TaskResult): ValidationResult {
+  const checkName = 'array_length' as const;
+  if (!validation.path) {
+    return {
+      check: checkName,
+      passed: false,
+      description: validation.description,
+      path: validation.path,
+      error: 'No path specified for array_length validation',
+      json_pointer: null,
+      expected: 'path must be set in storyboard validation entry',
+      actual: null,
+    };
+  }
+
+  const pointer = toJsonPointer(validation.path);
+
+  const hasExact = typeof validation.value === 'number';
+  const hasMin = typeof validation.min === 'number';
+  const hasMax = typeof validation.max === 'number';
+
+  if (!hasExact && !hasMin && !hasMax) {
+    return {
+      check: checkName,
+      passed: false,
+      description: validation.description,
+      path: validation.path,
+      error: 'array_length requires `value` (exact count) or `min`/`max` (bounds)',
+      json_pointer: pointer,
+      expected: '`value: N` or `min`/`max`',
+      actual: null,
+    };
+  }
+
+  if (hasExact && (hasMin || hasMax)) {
+    return {
+      check: checkName,
+      passed: false,
+      description: validation.description,
+      path: validation.path,
+      error: 'array_length accepts either `value` OR `min`/`max`, not both',
+      json_pointer: pointer,
+      expected: '`value` or `min`/`max`, not both',
+      actual: { value: validation.value, min: validation.min, max: validation.max },
+    };
+  }
+
+  const resolved = resolvePath(taskResult.data, validation.path);
+  if (!Array.isArray(resolved)) {
+    return {
+      check: checkName,
+      passed: false,
+      description: validation.description,
+      path: validation.path,
+      error: `array_length requires an array at path; got ${resolved === undefined ? 'undefined' : typeof resolved === 'object' && resolved !== null ? 'object' : typeof resolved}`,
+      json_pointer: pointer,
+      expected: 'array',
+      actual: resolved ?? null,
+    };
+  }
+
+  const length = resolved.length;
+
+  if (hasExact) {
+    const target = validation.value as number;
+    if (length === target) {
+      return {
+        check: checkName,
+        passed: true,
+        description: validation.description,
+        path: validation.path,
+        json_pointer: pointer,
+      };
+    }
+    return {
+      check: checkName,
+      passed: false,
+      description: validation.description,
+      path: validation.path,
+      error: `Expected array length ${target}, got ${length}`,
+      json_pointer: pointer,
+      expected: target,
+      actual: length,
+    };
+  }
+
+  const min = hasMin ? (validation.min as number) : undefined;
+  const max = hasMax ? (validation.max as number) : undefined;
+
+  if (min !== undefined && length < min) {
+    return {
+      check: checkName,
+      passed: false,
+      description: validation.description,
+      path: validation.path,
+      error: `Expected array length >= ${min}, got ${length}`,
+      json_pointer: pointer,
+      expected: { min, max },
+      actual: length,
+    };
+  }
+  if (max !== undefined && length > max) {
+    return {
+      check: checkName,
+      passed: false,
+      description: validation.description,
+      path: validation.path,
+      error: `Expected array length <= ${max}, got ${length}`,
+      json_pointer: pointer,
+      expected: { min, max },
+      actual: length,
+    };
+  }
+
+  return {
+    check: checkName,
+    passed: true,
+    description: validation.description,
+    path: validation.path,
+    json_pointer: pointer,
   };
 }
 

--- a/src/lib/testing/storyboard/validations.ts
+++ b/src/lib/testing/storyboard/validations.ts
@@ -1043,6 +1043,62 @@ function validateArrayLength(validation: StoryboardValidation, taskResult: TaskR
     };
   }
 
+  // Reject NaN, fractional, and negative bounds at the config gate. `array.length`
+  // is always a non-negative integer, so any other comparand makes the check
+  // impossible to satisfy — fail loudly at authoring time rather than silently
+  // every run.
+  const isValidCount = (n: unknown): n is number => typeof n === 'number' && Number.isInteger(n) && n >= 0;
+  const badOperand = (label: string, n: number) =>
+    `array_length \`${label}\` must be a non-negative integer; got ${Number.isNaN(n) ? 'NaN' : String(n)}`;
+  if (hasExact && !isValidCount(validation.value)) {
+    return {
+      check: checkName,
+      passed: false,
+      description: validation.description,
+      path: validation.path,
+      error: badOperand('value', validation.value as unknown as number),
+      json_pointer: pointer,
+      expected: 'non-negative integer',
+      actual: (validation.value as unknown) ?? null,
+    };
+  }
+  if (hasMin && !isValidCount(validation.min)) {
+    return {
+      check: checkName,
+      passed: false,
+      description: validation.description,
+      path: validation.path,
+      error: badOperand('min', validation.min as unknown as number),
+      json_pointer: pointer,
+      expected: 'non-negative integer',
+      actual: (validation.min as unknown) ?? null,
+    };
+  }
+  if (hasMax && !isValidCount(validation.max)) {
+    return {
+      check: checkName,
+      passed: false,
+      description: validation.description,
+      path: validation.path,
+      error: badOperand('max', validation.max as unknown as number),
+      json_pointer: pointer,
+      expected: 'non-negative integer',
+      actual: (validation.max as unknown) ?? null,
+    };
+  }
+  if (hasMin && hasMax && (validation.min as number) > (validation.max as number)) {
+    return {
+      check: checkName,
+      passed: false,
+      description: validation.description,
+      path: validation.path,
+      error: `array_length range is impossible: min ${validation.min} > max ${validation.max}`,
+      json_pointer: pointer,
+      expected: '`min <= max`',
+      actual: { min: validation.min, max: validation.max },
+    };
+  }
+
   const resolved = resolvePath(taskResult.data, validation.path);
   if (!Array.isArray(resolved)) {
     return {

--- a/test/lib/storyboard-validations.test.js
+++ b/test/lib/storyboard-validations.test.js
@@ -640,4 +640,45 @@ describe('array_length (adcp#4685 / adcp-client#1830)', () => {
     assert.strictEqual(result.passed, false);
     assert.match(result.error, /either `value` OR `min`\/`max`, not both/);
   });
+
+  it('rejects NaN operand at the config gate', () => {
+    const [result] = runOne(
+      [{ check: 'array_length', path: 'items', value: NaN, description: 'NaN value' }],
+      'sync_creatives',
+      { success: true, data: { items: [1] } }
+    );
+    assert.strictEqual(result.passed, false);
+    assert.match(result.error, /must be a non-negative integer/);
+    assert.match(result.error, /NaN/);
+  });
+
+  it('rejects fractional `value` at the config gate', () => {
+    const [result] = runOne(
+      [{ check: 'array_length', path: 'items', value: 2.5, description: 'fractional value' }],
+      'sync_creatives',
+      { success: true, data: { items: [1, 2] } }
+    );
+    assert.strictEqual(result.passed, false);
+    assert.match(result.error, /must be a non-negative integer/);
+  });
+
+  it('rejects negative `min` at the config gate', () => {
+    const [result] = runOne(
+      [{ check: 'array_length', path: 'items', min: -1, description: 'negative min' }],
+      'sync_creatives',
+      { success: true, data: { items: [1] } }
+    );
+    assert.strictEqual(result.passed, false);
+    assert.match(result.error, /`min` must be a non-negative integer/);
+  });
+
+  it('rejects impossible range when `min > max`', () => {
+    const [result] = runOne(
+      [{ check: 'array_length', path: 'items', min: 5, max: 1, description: 'impossible' }],
+      'sync_creatives',
+      { success: true, data: { items: [1, 2, 3] } }
+    );
+    assert.strictEqual(result.passed, false);
+    assert.match(result.error, /impossible: min 5 > max 1/);
+  });
 });

--- a/test/lib/storyboard-validations.test.js
+++ b/test/lib/storyboard-validations.test.js
@@ -455,3 +455,189 @@ describe('field_contains (adcp#3803 item 2)', () => {
     assert.strictEqual(result.json_pointer, '/creatives/0/errors/*/code');
   });
 });
+
+describe('array_length (adcp#4685 / adcp-client#1830)', () => {
+  // Cardinality assertion that reads `array.length` directly. Necessary
+  // because `field_present arr[N-1]` + `field_value_or_absent arr[N]
+  // value: null` is unsound: it passes when the seller emits a literal
+  // null pad at arr[N]. This check rejects non-array resolutions instead.
+  it('passes with exact value match', () => {
+    const taskResult = {
+      success: true,
+      data: { media_buys: [{ impairments: [{ id: 'a' }, { id: 'b' }] }] },
+    };
+    const [result] = runOne(
+      [
+        {
+          check: 'array_length',
+          path: 'media_buys[0].impairments',
+          value: 2,
+          description: 'exactly two impairments',
+        },
+      ],
+      'create_media_buy',
+      taskResult
+    );
+    assert.strictEqual(result.passed, true, result.error);
+    assert.strictEqual(result.check, 'array_length');
+    assert.strictEqual(result.json_pointer, '/media_buys/0/impairments');
+  });
+
+  it('fails when exact value does not match', () => {
+    const taskResult = {
+      success: true,
+      data: { media_buys: [{ impairments: [{ id: 'a' }, { id: 'b' }, { id: 'c' }] }] },
+    };
+    const [result] = runOne(
+      [
+        {
+          check: 'array_length',
+          path: 'media_buys[0].impairments',
+          value: 2,
+          description: 'exactly two impairments',
+        },
+      ],
+      'create_media_buy',
+      taskResult
+    );
+    assert.strictEqual(result.passed, false);
+    assert.match(result.error, /Expected array length 2, got 3/);
+    assert.strictEqual(result.expected, 2);
+    assert.strictEqual(result.actual, 3);
+  });
+
+  it('refuses to false-pass on a literal null pad (the unsound workaround case)', () => {
+    // Seller emits `[ {…}, null ]` — under the old workaround
+    // (field_value_or_absent arr[1] value: null) this passes silently.
+    // array_length value: 1 must fail because length is 2.
+    const taskResult = {
+      success: true,
+      data: { media_buys: [{ impairments: [{ id: 'a' }, null] }] },
+    };
+    const [result] = runOne(
+      [
+        {
+          check: 'array_length',
+          path: 'media_buys[0].impairments',
+          value: 1,
+          description: 'exactly one impairment (null pad should be caught)',
+        },
+      ],
+      'create_media_buy',
+      taskResult
+    );
+    assert.strictEqual(result.passed, false);
+    assert.strictEqual(result.actual, 2);
+  });
+
+  it('passes within inclusive min/max bounds', () => {
+    const taskResult = { success: true, data: { items: [1, 2, 3] } };
+    const [result] = runOne(
+      [{ check: 'array_length', path: 'items', min: 1, max: 5, description: 'bounded' }],
+      'sync_creatives',
+      taskResult
+    );
+    assert.strictEqual(result.passed, true, result.error);
+  });
+
+  it('passes with only `min` set when length meets the lower bound', () => {
+    const taskResult = { success: true, data: { items: [1, 2, 3] } };
+    const [result] = runOne(
+      [{ check: 'array_length', path: 'items', min: 3, description: 'at least three' }],
+      'sync_creatives',
+      taskResult
+    );
+    assert.strictEqual(result.passed, true, result.error);
+  });
+
+  it('passes with only `max` set when length meets the upper bound', () => {
+    const taskResult = { success: true, data: { items: [] } };
+    const [result] = runOne(
+      [{ check: 'array_length', path: 'items', max: 0, description: 'at most zero' }],
+      'sync_creatives',
+      taskResult
+    );
+    assert.strictEqual(result.passed, true, result.error);
+  });
+
+  it('fails when length is below `min`', () => {
+    const taskResult = { success: true, data: { items: [1] } };
+    const [result] = runOne(
+      [{ check: 'array_length', path: 'items', min: 2, max: 5, description: 'bounded' }],
+      'sync_creatives',
+      taskResult
+    );
+    assert.strictEqual(result.passed, false);
+    assert.match(result.error, />= 2, got 1/);
+  });
+
+  it('fails when length is above `max`', () => {
+    const taskResult = { success: true, data: { items: [1, 2, 3, 4, 5, 6] } };
+    const [result] = runOne(
+      [{ check: 'array_length', path: 'items', min: 0, max: 5, description: 'bounded' }],
+      'sync_creatives',
+      taskResult
+    );
+    assert.strictEqual(result.passed, false);
+    assert.match(result.error, /<= 5, got 6/);
+  });
+
+  it('fails when the resolved path is not an array', () => {
+    const taskResult = { success: true, data: { items: 'not-an-array' } };
+    const [result] = runOne(
+      [{ check: 'array_length', path: 'items', value: 0, description: 'wrong type' }],
+      'sync_creatives',
+      taskResult
+    );
+    assert.strictEqual(result.passed, false);
+    assert.match(result.error, /requires an array at path/);
+  });
+
+  it('fails when the resolved path is absent', () => {
+    const taskResult = { success: true, data: {} };
+    const [result] = runOne(
+      [{ check: 'array_length', path: 'items', value: 0, description: 'absent' }],
+      'sync_creatives',
+      taskResult
+    );
+    assert.strictEqual(result.passed, false);
+    assert.match(result.error, /got undefined/);
+  });
+
+  it('fails when path is missing', () => {
+    const [result] = runOne([{ check: 'array_length', value: 1, description: 'no path' }], 'sync_creatives', {
+      success: true,
+      data: { items: [1] },
+    });
+    assert.strictEqual(result.passed, false);
+    assert.match(result.error, /No path specified for array_length/);
+  });
+
+  it('rejects misconfigured check with no value/min/max', () => {
+    const [result] = runOne(
+      [{ check: 'array_length', path: 'items', description: 'no expectation' }],
+      'sync_creatives',
+      { success: true, data: { items: [1] } }
+    );
+    assert.strictEqual(result.passed, false);
+    assert.match(result.error, /requires `value`.*or `min`\/`max`/);
+  });
+
+  it('rejects misconfigured check when both `value` and bounds are set', () => {
+    const [result] = runOne(
+      [
+        {
+          check: 'array_length',
+          path: 'items',
+          value: 2,
+          min: 1,
+          description: 'mutually exclusive',
+        },
+      ],
+      'sync_creatives',
+      { success: true, data: { items: [1, 2] } }
+    );
+    assert.strictEqual(result.passed, false);
+    assert.match(result.error, /either `value` OR `min`\/`max`, not both/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1830. Adds an `array_length` check kind to the storyboard runner so cardinality scenarios can assert "exactly N entries" directly.

The previous workaround — `field_present arr[N-1]` + `field_value_or_absent arr[N] value: null` — is unsound: the second clause passes when a seller emits a literal `null` pad at `arr[N]`. `array_length` reads `array.length` and rejects non-array resolutions, so the null-pad path fails the check as it should.

Two configurations:

```yaml
- check: array_length
  path: media_buys[0].impairments
  value: 2
  description: Exactly two impairments — one per rejected creative
```

```yaml
- check: array_length
  path: media_buys[0].impairments
  min: 1
  max: 1
  description: Exactly one impairment
```

`value` and `min`/`max` are mutually exclusive — specifying both, or specifying neither, fails the check as misconfigured. Both bounds are inclusive; either is optional.

Wired through:

- `src/lib/testing/storyboard/types.ts` — new `'array_length'` variant on `StoryboardValidationCheck`; new optional `min` / `max` fields on `StoryboardValidation`.
- `src/lib/testing/storyboard/validations.ts` — `validateArrayLength` with type checking, exact/range modes, and misconfiguration errors.
- `scripts/conformance-replay.ts` — in-process replay harness honours the new check.
- `test/lib/storyboard-validations.test.js` — 13 new tests covering exact match, both bounds, null-pad rejection, type errors, and misconfiguration paths.

Follow-up to [adcontextprotocol/adcp#4685](https://github.com/adcontextprotocol/adcp/pull/4685) protocol review. Spec-side YAML schema addition tracked separately on the adcp repo — storyboards adopting `array_length` will land once that ships.

## Test plan

- [x] `node --test test/lib/storyboard-validations.test.js` — 43 pass (13 new)
- [x] `node --test test/lib/storyboard-drift.test.js test/lib/storyboard-runner-contract.test.js` — 536/537 pass (1 pre-existing skip)
- [x] `node --test test/lib/storyboard-runner-output-contract-v2.test.js test/lib/storyboard-strict-validation.test.js test/lib/comply-vs-storyboard-parity.test.js` — 60/60 pass
- [x] `npx tsc --noEmit` clean
- [x] `npm run format:check` clean
- [x] Changeset included (minor bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)