### PR TITLE
feat(signing): SigningProvider.adcpUse for async-path purpose binding (#1827)

### DIFF
--- a/.changeset/provider-purpose-gate-1827.md
+++ b/.changeset/provider-purpose-gate-1827.md
@@ -1,0 +1,28 @@
+---
+'@adcp/sdk': minor
+---
+
+signing: extend `SigningProvider` with optional `adcpUse` for async-path purpose binding (#1827)
+
+Closes the asymmetry between sync and async signing paths flagged by the security + protocol reviews of #1823 / #1832. Sync helpers (`signRequest`, `signWebhook`, `signResponse`) refuse keys with wrong `adcp_use` via `assertKeyPurpose`. Async helpers (`signRequestAsync` / `signWebhookAsync` / `signResponseAsync`) could not enforce because `SigningProvider` exposed `keyid` + `algorithm` but no purpose binding — KMS adapters were unprotected against IAM-mistake cross-purpose reuse, the exact situation where signer-side defense-in-depth matters most.
+
+```ts
+import { signResponseAsync } from '@adcp/sdk/signing/client';
+
+const provider = new InMemorySigningProvider({
+  keyid: 'kid_42',
+  algorithm: 'ed25519',
+  privateKey: privateJwk,
+  adcpUse: 'response-signing',  // NEW — enforced at the gate
+});
+
+await signResponseAsync(response, provider);
+// Throws ResponseSignatureError('response_signature_key_purpose_invalid')
+// if you call signRequestAsync or signWebhookAsync with this provider.
+```
+
+**Optional and backward-compatible.** Providers that omit `adcpUse` skip the gate — no breakage for adapters that pre-date this field. Adapter authors who want defense-in-depth set it; the async helpers then enforce purpose binding parallel to the sync path with the same error codes (`*_signature_key_purpose_invalid` at step 8).
+
+`InMemorySigningProvider` auto-inherits `adcpUse` from `privateKey.adcp_use` when present, so keys minted via `pemToAdcpJwk({ adcp_use: ... })` get the binding for free. Explicit `adcpUse` option on the provider constructor takes precedence — useful when the test key material doesn't match the helper being exercised.
+
+9 new tests across all three async helpers covering match / mismatch / explicit-override paths.

--- a/src/lib/signing/provider.ts
+++ b/src/lib/signing/provider.ts
@@ -1,3 +1,4 @@
+import type { AdcpUse } from './jwks-helpers';
 import type { AdcpSignAlg } from './types';
 
 /**
@@ -54,6 +55,23 @@ export interface SigningProvider {
    * Wire-format algorithm identifier. Same vocabulary as `ALLOWED_ALGS`.
    */
   readonly algorithm: AdcpSignAlg;
+
+  /**
+   * Purpose binding for the underlying key, parallel to the sync-path
+   * `SignerKey.privateKey.adcp_use` gate. When set, the async helpers
+   * (`signRequestAsync`, `signWebhookAsync`, `signResponseAsync`) refuse
+   * keys whose `adcpUse` doesn't match the helper, with the same error
+   * codes the verifier raises at step 8.
+   *
+   * **Optional and backward-compatible.** Existing providers that omit
+   * `adcpUse` skip the gate (no breakage, but no defense-in-depth either).
+   * Adapter authors who care about catching IAM misconfig at the signer
+   * rather than the verifier should set this — KMS is exactly where one
+   * IAM mistake silently grants a single key cross-purpose access, and
+   * `request-signing` / `webhook-signing` / `response-signing` keys MUST
+   * stay distinct per AdCP step-8 purpose-binding.
+   */
+  readonly adcpUse?: AdcpUse;
 
   /**
    * Stable opaque identifier disambiguating this signer from others

--- a/src/lib/signing/signer-async.ts
+++ b/src/lib/signing/signer-async.ts
@@ -8,6 +8,7 @@ import type {
   SignWebhookOptions,
 } from './signer';
 import {
+  assertProviderPurpose,
   finalizeRequestSignature,
   finalizeResponseSignature,
   prepareRequestSignature,
@@ -32,6 +33,7 @@ export async function signRequestAsync(
   provider: SigningProvider,
   options: SignRequestOptions = {}
 ): Promise<SignedRequest> {
+  assertProviderPurpose(provider, 'request-signing');
   const prepared = prepareRequestSignature(request, { keyid: provider.keyid, alg: provider.algorithm }, options);
   const signature = await provider.sign(Buffer.from(prepared.base, 'utf8'));
   return finalizeRequestSignature(prepared, signature);
@@ -48,6 +50,7 @@ export async function signWebhookAsync(
   provider: SigningProvider,
   options: SignWebhookOptions = {}
 ): Promise<SignedRequest> {
+  assertProviderPurpose(provider, 'webhook-signing');
   const prepared = prepareWebhookSignature(request, { keyid: provider.keyid, alg: provider.algorithm }, options);
   const signature = await provider.sign(Buffer.from(prepared.base, 'utf8'));
   return finalizeRequestSignature(prepared, signature);
@@ -63,6 +66,7 @@ export async function signResponseAsync(
   provider: SigningProvider,
   options: SignResponseOptions = {}
 ): Promise<SignedResponse> {
+  assertProviderPurpose(provider, 'response-signing');
   const prepared = prepareResponseSignature(response, { keyid: provider.keyid, alg: provider.algorithm }, options);
   const signature = await provider.sign(Buffer.from(prepared.base, 'utf8'));
   return finalizeResponseSignature(prepared, signature);

--- a/src/lib/signing/signer.ts
+++ b/src/lib/signing/signer.ts
@@ -52,10 +52,32 @@ export interface SignerKey {
  * scrapers across signer / verifier see consistent vocabulary.
  */
 function assertKeyPurpose(key: SignerKey, expected: AdcpUse): void {
-  const actual = key.privateKey.adcp_use;
+  throwIfPurposeMismatch(key.keyid, key.privateKey.adcp_use, expected);
+}
+
+/**
+ * Async-path equivalent. Mirrors {@link assertKeyPurpose} but reads
+ * `adcpUse` from a {@link SigningProvider} rather than a `SignerKey`.
+ *
+ * **Optional binding.** When `provider.adcpUse` is `undefined`, the gate
+ * is skipped — preserves backward compat with adapters that pre-date the
+ * `SigningProvider.adcpUse` field. Adapter authors who want signer-side
+ * defense-in-depth set `adcpUse` on their provider; the async helpers
+ * (`signRequestAsync` / `signWebhookAsync` / `signResponseAsync`) then
+ * enforce the binding parallel to the sync path.
+ */
+function assertProviderPurpose(
+  provider: { readonly keyid: string; readonly adcpUse?: AdcpUse },
+  expected: AdcpUse
+): void {
+  if (provider.adcpUse === undefined) return;
+  throwIfPurposeMismatch(provider.keyid, provider.adcpUse, expected);
+}
+
+function throwIfPurposeMismatch(keyid: string, actual: string | undefined, expected: AdcpUse): void {
   if (actual === expected) return;
   const message =
-    `Signing key '${key.keyid}' has adcp_use=${actual === undefined ? '<missing>' : `'${actual}'`} ` +
+    `Signing key '${keyid}' has adcp_use=${actual === undefined ? '<missing>' : `'${actual}'`} ` +
     `but the helper requires '${expected}'. Mint a key scoped for '${expected}' via ` +
     `pemToAdcpJwk({ adcp_use: '${expected}' }) — sharing keys across purposes is intentionally refused.`;
   switch (expected) {
@@ -74,6 +96,8 @@ function assertKeyPurpose(key: SignerKey, expected: AdcpUse): void {
     }
   }
 }
+
+export { assertProviderPurpose };
 
 export interface SignRequestOptions {
   coverContentDigest?: boolean;

--- a/src/lib/signing/testing.ts
+++ b/src/lib/signing/testing.ts
@@ -12,6 +12,11 @@ import type { AdcpJsonWebKey, AdcpSignAlg } from './types';
  */
 export const ALLOW_IN_MEMORY_SIGNER_ENV = 'ADCP_ALLOW_IN_MEMORY_SIGNER';
 
+const ADCP_USE_VALUES = new Set<AdcpUse>(['request-signing', 'webhook-signing', 'response-signing']);
+function isAdcpUse(value: unknown): value is AdcpUse {
+  return typeof value === 'string' && ADCP_USE_VALUES.has(value as AdcpUse);
+}
+
 export interface InMemorySigningProviderOptions {
   /** `kid` published in `Signature-Input`. */
   keyid: string;
@@ -19,6 +24,15 @@ export interface InMemorySigningProviderOptions {
   algorithm: AdcpSignAlg;
   /** Private JWK including the `d` scalar. */
   privateKey: AdcpJsonWebKey;
+  /**
+   * Optional purpose binding. When supplied, the async signing helpers
+   * (`signRequestAsync` / `signWebhookAsync` / `signResponseAsync`) refuse
+   * to sign with a mismatched purpose — same defense-in-depth gate the
+   * sync path's `SignerKey.privateKey.adcp_use` provides. Defaults to the
+   * value carried on `privateKey.adcp_use` when present, so adapters
+   * minted via `pemToAdcpJwk({ adcp_use: ... })` get the binding for free.
+   */
+  adcpUse?: AdcpUse;
 }
 
 /**
@@ -36,6 +50,7 @@ export class InMemorySigningProvider implements SigningProvider {
   readonly keyid: string;
   readonly algorithm: AdcpSignAlg;
   readonly fingerprint: string;
+  readonly adcpUse?: AdcpUse;
   private readonly privateKey: AdcpJsonWebKey;
 
   constructor(options: InMemorySigningProviderOptions) {
@@ -58,6 +73,10 @@ export class InMemorySigningProvider implements SigningProvider {
     this.keyid = options.keyid;
     this.algorithm = options.algorithm;
     this.privateKey = options.privateKey;
+    // Prefer explicit `adcpUse` option; fall back to the JWK's `adcp_use`
+    // metadata so keys minted via `pemToAdcpJwk` get the binding for free.
+    const jwkUse = options.privateKey.adcp_use;
+    this.adcpUse = options.adcpUse ?? (isAdcpUse(jwkUse) ? jwkUse : undefined);
     // Mirrors the historical `privateKeyFingerprint` derivation — same input,
     // same 64-bit cache disambiguator, so behavior carries over for callers
     // who switch from the inline `request_signing` shape to a provider while

--- a/test/request-signing-provider.test.js
+++ b/test/request-signing-provider.test.js
@@ -628,12 +628,13 @@ describe('end-to-end: provider-signed request verifies under the SDK verifier', 
     const webhookKey = keysData.keys.find(k => k.adcp_use === 'webhook-signing');
     if (!webhookKey) {
       // Conformance vectors don't include a separate webhook-signing key; reuse
-      // the request-signing key with a synthetic adcp_use override for the
-      // verifier's purpose check.
+      // the request-signing key but explicitly override `adcpUse` on the
+      // provider so signWebhookAsync's purpose gate accepts it.
       const provider = new InMemorySigningProvider({
         keyid: kid,
         algorithm: 'ed25519',
         privateKey: privateJwkFor(kid),
+        adcpUse: 'webhook-signing',
       });
       const signed = await signWebhookAsync(SAMPLE_REQUEST, provider, SAMPLE_OPTIONS);
       // Just assert headers shape — full verifier round-trip needs a webhook-purpose key.

--- a/test/signing-provider-purpose-gate.test.js
+++ b/test/signing-provider-purpose-gate.test.js
@@ -1,0 +1,175 @@
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const { readFileSync } = require('node:fs');
+const path = require('node:path');
+
+const {
+  signRequestAsync,
+  signWebhookAsync,
+  signResponseAsync,
+  RequestSignatureError,
+  WebhookSignatureError,
+  ResponseSignatureError,
+} = require('../dist/lib/signing/index.js');
+
+const { InMemorySigningProvider } = require('../dist/lib/signing/testing.js');
+
+const KEYS_PATH = path.join(
+  __dirname,
+  '..',
+  'compliance',
+  'cache',
+  'latest',
+  'test-vectors',
+  'request-signing',
+  'keys.json'
+);
+const keysByKid = new Map(JSON.parse(readFileSync(KEYS_PATH, 'utf8')).keys.map(k => [k.kid, k]));
+
+function privateJwk(kid, overrides = {}) {
+  const k = keysByKid.get(kid);
+  const { _private_d_for_test_only, ...rest } = k;
+  return { ...rest, d: _private_d_for_test_only, ...overrides };
+}
+
+const SAMPLE_REQUEST = {
+  method: 'POST',
+  url: 'https://seller.example.com/adcp/create_media_buy',
+  headers: { 'Content-Type': 'application/json' },
+  body: '{"plan_id":"p_1"}',
+};
+
+const SAMPLE_RESPONSE = {
+  status: 200,
+  headers: { 'Content-Type': 'application/json' },
+  body: '{"ok":true}',
+  request: { method: 'POST', url: 'https://seller.example.com/adcp/get_products' },
+};
+
+const SIGN_OPTIONS = { now: () => 1776520800, nonce: 'KXYnfEfJ0PBRZXQyVXfVQA', windowSeconds: 300 };
+const KID = 'test-ed25519-2026';
+
+describe('SigningProvider.adcpUse — purpose gate, async path', () => {
+  describe('signRequestAsync', () => {
+    test('accepts a provider with adcpUse="request-signing"', async () => {
+      const provider = new InMemorySigningProvider({
+        keyid: KID,
+        algorithm: 'ed25519',
+        privateKey: privateJwk(KID, { adcp_use: 'request-signing' }),
+      });
+      const signed = await signRequestAsync(SAMPLE_REQUEST, provider, SIGN_OPTIONS);
+      assert.ok(signed.headers.Signature);
+    });
+
+    test('rejects a provider with adcpUse="webhook-signing"', async () => {
+      const provider = new InMemorySigningProvider({
+        keyid: KID,
+        algorithm: 'ed25519',
+        privateKey: privateJwk(KID, { adcp_use: 'webhook-signing' }),
+      });
+      await assert.rejects(
+        () => signRequestAsync(SAMPLE_REQUEST, provider, SIGN_OPTIONS),
+        err =>
+          err instanceof RequestSignatureError &&
+          err.code === 'request_signature_key_purpose_invalid' &&
+          err.failedStep === 8 &&
+          /webhook-signing/.test(err.message)
+      );
+    });
+
+    test('rejects a provider with adcpUse="response-signing"', async () => {
+      const provider = new InMemorySigningProvider({
+        keyid: KID,
+        algorithm: 'ed25519',
+        privateKey: privateJwk(KID, { adcp_use: 'response-signing' }),
+      });
+      await assert.rejects(
+        () => signRequestAsync(SAMPLE_REQUEST, provider, SIGN_OPTIONS),
+        err => err.code === 'request_signature_key_purpose_invalid'
+      );
+    });
+
+    test('legacy provider without adcpUse skips the gate (backward-compat)', async () => {
+      // Hand-built provider that omits adcpUse — simulates a pre-existing
+      // adapter that pre-dates this field. Gate must be a no-op.
+      const provider = {
+        keyid: KID,
+        algorithm: 'ed25519',
+        fingerprint: 'test-fp',
+        sign: payload =>
+          require('node:crypto').sign(
+            null,
+            Buffer.from(payload),
+            require('node:crypto').createPrivateKey({ key: privateJwk(KID), format: 'jwk' })
+          ),
+      };
+      const signed = await signRequestAsync(SAMPLE_REQUEST, provider, SIGN_OPTIONS);
+      assert.ok(signed.headers.Signature);
+    });
+  });
+
+  describe('signWebhookAsync', () => {
+    test('accepts a provider with adcpUse="webhook-signing"', async () => {
+      const provider = new InMemorySigningProvider({
+        keyid: KID,
+        algorithm: 'ed25519',
+        privateKey: privateJwk(KID, { adcp_use: 'webhook-signing' }),
+      });
+      const signed = await signWebhookAsync(SAMPLE_REQUEST, provider, SIGN_OPTIONS);
+      assert.ok(signed.headers.Signature);
+    });
+
+    test('rejects a provider with adcpUse="request-signing"', async () => {
+      const provider = new InMemorySigningProvider({
+        keyid: KID,
+        algorithm: 'ed25519',
+        privateKey: privateJwk(KID, { adcp_use: 'request-signing' }),
+      });
+      await assert.rejects(
+        () => signWebhookAsync(SAMPLE_REQUEST, provider, SIGN_OPTIONS),
+        err =>
+          err instanceof WebhookSignatureError &&
+          err.code === 'webhook_signature_key_purpose_invalid' &&
+          /request-signing/.test(err.message)
+      );
+    });
+  });
+
+  describe('signResponseAsync', () => {
+    test('accepts a provider with adcpUse="response-signing"', async () => {
+      const provider = new InMemorySigningProvider({
+        keyid: KID,
+        algorithm: 'ed25519',
+        privateKey: privateJwk(KID, { adcp_use: 'response-signing' }),
+      });
+      const signed = await signResponseAsync(SAMPLE_RESPONSE, provider, SIGN_OPTIONS);
+      assert.ok(signed.headers.Signature);
+    });
+
+    test('rejects a provider with adcpUse="request-signing"', async () => {
+      const provider = new InMemorySigningProvider({
+        keyid: KID,
+        algorithm: 'ed25519',
+        privateKey: privateJwk(KID, { adcp_use: 'request-signing' }),
+      });
+      await assert.rejects(
+        () => signResponseAsync(SAMPLE_RESPONSE, provider, SIGN_OPTIONS),
+        err => err instanceof ResponseSignatureError && err.code === 'response_signature_key_purpose_invalid'
+      );
+    });
+  });
+});
+
+describe('SigningProvider.adcpUse — explicit option overrides JWK metadata', () => {
+  test('options.adcpUse takes precedence over privateKey.adcp_use', async () => {
+    // JWK says webhook-signing but caller asserts request-signing.
+    const provider = new InMemorySigningProvider({
+      keyid: KID,
+      algorithm: 'ed25519',
+      privateKey: privateJwk(KID, { adcp_use: 'webhook-signing' }),
+      adcpUse: 'request-signing',
+    });
+    const signed = await signRequestAsync(SAMPLE_REQUEST, provider, SIGN_OPTIONS);
+    assert.ok(signed.headers.Signature);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1827. Closes the asymmetry between sync and async signing flagged by the security + protocol reviews on #1823 / #1832.

| Path | Purpose-binding gate |
|---|---|
| Sync (\`signRequest\` / \`signWebhook\` / \`signResponse\`) | ✅ already shipped (closes #1825) — refuses wrong-purpose keys via \`assertKeyPurpose\` |
| **Async (\`signRequestAsync\` / \`signWebhookAsync\` / \`signResponseAsync\`)** | **this PR** — refuses wrong-purpose providers via \`assertProviderPurpose\` when \`provider.adcpUse\` is set |

KMS-backed deployments were previously unprotected against IAM-mistake cross-purpose reuse — exactly where signer-side defense-in-depth matters most.

### API

\`\`\`ts
import { signResponseAsync } from '@adcp/sdk/signing/client';

const provider = new InMemorySigningProvider({
  keyid: 'kid_42',
  algorithm: 'ed25519',
  privateKey: privateJwk,
  adcpUse: 'response-signing',  // NEW — enforced at the gate
});

await signResponseAsync(response, provider);
// Throws ResponseSignatureError('response_signature_key_purpose_invalid')
// if you call signRequestAsync or signWebhookAsync with this provider.
\`\`\`

### Backward compatibility

Optional field — providers that omit \`adcpUse\` skip the gate. No breakage for adapters that pre-date this field; adapter authors who want the defense-in-depth set it explicitly. The async helpers then enforce purpose binding parallel to the sync path with the same error codes (\`*_signature_key_purpose_invalid\` at step 8).

\`InMemorySigningProvider\` auto-inherits \`adcpUse\` from \`privateKey.adcp_use\` when present, so keys minted via \`pemToAdcpJwk({ adcp_use: ... })\` get the binding for free. Explicit \`adcpUse\` option on the provider constructor takes precedence.

## Test plan

- [x] 9 new tests in \`test/signing-provider-purpose-gate.test.js\` covering all three async helpers × match/mismatch/legacy-no-purpose paths
- [x] 340 existing signing tests pass — found one pre-existing test bug (\`request-signing-provider.test.js\` webhook async round-trip was reusing a request-signing key); fixed with explicit \`adcpUse: 'webhook-signing'\` override
- [x] \`tsc --noEmit\` clean
- [x] \`prettier --check\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)