### PR TITLE
feat(signing): requestContextFromExpress / -Fetch / -Lambda helpers (#1828)

### DIFF
--- a/.changeset/request-context-helpers-1828.md
+++ b/.changeset/request-context-helpers-1828.md
@@ -1,0 +1,38 @@
+---
+'@adcp/sdk': minor
+---
+
+signing: add `requestContextFromExpress` / `-Fetch` / `-Lambda` helpers (#1828)
+
+Closes #1828. Makes the safe path the default path for constructing `ResponseLike.request` (and any other RFC 9421 binding that needs an originating-request URL) on each major Node platform.
+
+The JSDoc warning on `ResponseLike.request.url` (shipped in #1823) flags the trap: under proxy termination, `req.protocol` lies and `req.get('host')` is attacker-controllable. JSDoc warnings rot. These helpers enforce the hardening at construction time.
+
+```ts
+import { requestContextFromExpress, signResponse } from '@adcp/sdk/signing/client';
+
+app.post('/adcp/get_products', (req, res) => {
+  const signed = signResponse(
+    {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+      body,
+      request: requestContextFromExpress(req, {
+        hostAllowlist: ['seller.example.com'],
+      }),
+    },
+    key
+  );
+  res.set(signed.headers).send(body);
+});
+```
+
+**Three helpers:**
+
+- `requestContextFromExpress(req, options)` — throws when `Host` is missing / not in `hostAllowlist`, or when `req.protocol` is not `https` (unless `forceHttps: false` for local dev). **You MUST configure `app.set('trust proxy', ...)`** with your trusted proxy IPs; the helper trusts what Express tells it.
+- `requestContextFromFetch(request)` — passes through `method` + `url` from a WHATWG `Request`. Trivial; included for API symmetry. No proxy hardening needed (Workers / Deno / Bun terminate TLS at the edge and own URL construction).
+- `requestContextFromLambda(event, options)` — reads `requestContext.domainName` for authority, `rawPath` + `rawQueryString` (v2 / ALB) or `path` + `queryStringParameters` (v1) for the target. Always emits `https://` — Lambda isn't HTTP-addressable through API Gateway / ALB. `hostAllowlist` catches multi-tenant API Gateway misroutes.
+
+Exported from both `@adcp/sdk/signing/client` (signer-side adopters) and `@adcp/sdk/signing/server` (verifier-side adopters reconstructing the originating-request URL for `verifyResponseSignature`).
+
+18 tests covering happy path, host-allowlist enforcement, protocol enforcement, query-string preservation + URL encoding, and an end-to-end Express helper → `signResponse` → `verifyResponseSignature` round-trip.

--- a/src/lib/signing/client.ts
+++ b/src/lib/signing/client.ts
@@ -20,6 +20,16 @@ export {
 } from './canonicalize';
 export { computeContentDigest, contentDigestMatches, parseContentDigest } from './content-digest';
 export {
+  requestContextFromExpress,
+  requestContextFromFetch,
+  requestContextFromLambda,
+  type ExpressRequestLike,
+  type FetchRequestLike,
+  type LambdaRequestEvent,
+  type RequestContextFromExpressOptions,
+  type RequestContextFromLambdaOptions,
+} from './request-context';
+export {
   finalizeRequestSignature,
   finalizeResponseSignature,
   prepareRequestSignature,

--- a/src/lib/signing/request-context.ts
+++ b/src/lib/signing/request-context.ts
@@ -76,14 +76,14 @@ export function requestContextFromExpress(
   req: ExpressRequestLike,
   options: RequestContextFromExpressOptions = {}
 ): { method: string; url: string } {
-  const host = req.get('host')?.trim().toLowerCase();
+  const host = normalizeHost(req.get('host'));
   if (!host) {
     throw new TypeError(
       'requestContextFromExpress: Host header is missing. ' +
         'Express returned no `host` — either the inbound request omitted it, or your reverse proxy stripped it.'
     );
   }
-  if (options.hostAllowlist && !options.hostAllowlist.some(h => h.trim().toLowerCase() === host)) {
+  if (options.hostAllowlist && !hostMatchesAllowlist(host, options.hostAllowlist)) {
     throw new TypeError(
       `requestContextFromExpress: Host "${host}" is not in hostAllowlist. ` +
         `A hostile peer may be trying to rebind your signature origin via Host-header injection. ` +
@@ -98,6 +98,13 @@ export function requestContextFromExpress(
         `Set app.set('trust proxy', ...) so Express sees the X-Forwarded-Proto header, ` +
         `or pass forceHttps: false for local dev (loopback / mock-server testing).`
     );
+  }
+  // Defense-in-depth: reject userinfo in originalUrl. A malicious middleware
+  // could mutate req.originalUrl to inject `user@` between host and path —
+  // canonicalAuthority would then sign the userinfo-bearing variant. Express
+  // doesn't normally carry userinfo here but we check rather than trust.
+  if (/[@]/.test(req.originalUrl.split('?')[0] ?? '')) {
+    throw new TypeError('requestContextFromExpress: originalUrl path must not embed userinfo (@).');
   }
   return { method: req.method, url: `${protocol}://${host}${req.originalUrl}` };
 }
@@ -120,6 +127,24 @@ export interface FetchRequestLike {
  * terminate TLS at the edge so `https` is honest.
  */
 export function requestContextFromFetch(request: FetchRequestLike): { method: string; url: string } {
+  // WHATWG accepts `https://user:pw@host/path` as a valid Request URL and
+  // echoes it back verbatim. `canonicalAuthority` would then sign the
+  // userinfo-bearing form, splitting the signature namespace between
+  // userinfo and userinfo-stripped variants of the same logical origin.
+  // Reject at construction time — userinfo never belongs in a signed
+  // `@authority` / `@target-uri`.
+  let parsed: URL;
+  try {
+    parsed = new URL(request.url);
+  } catch {
+    throw new TypeError(`requestContextFromFetch: request.url "${request.url}" is not a parseable URL.`);
+  }
+  if (parsed.username || parsed.password) {
+    throw new TypeError(
+      'requestContextFromFetch: request.url must not embed userinfo. ' +
+        'A signed @authority component with userinfo creates a verifier-splitting confusion vector.'
+    );
+  }
   return { method: request.method, url: request.url };
 }
 
@@ -174,8 +199,11 @@ export function requestContextFromLambda(
         'is this event shaped like something else?'
     );
   }
-  const host = domainName.trim().toLowerCase();
-  if (options.hostAllowlist && !options.hostAllowlist.some(h => h.trim().toLowerCase() === host)) {
+  const host = normalizeHost(domainName);
+  if (!host) {
+    throw new TypeError('requestContextFromLambda: domainName is empty after normalization.');
+  }
+  if (options.hostAllowlist && !hostMatchesAllowlist(host, options.hostAllowlist)) {
     throw new TypeError(
       `requestContextFromLambda: domainName "${host}" is not in hostAllowlist. ` +
         `Multi-tenant API Gateway misroute? Add the legitimate value, or fix the API mapping.`
@@ -186,6 +214,8 @@ export function requestContextFromLambda(
     throw new TypeError('requestContextFromLambda: HTTP method is missing from the event.');
   }
   const path = event.rawPath ?? event.path ?? '/';
+  // Lambda's domainName won't carry a trailing dot in supported configs but
+  // we normalize here so a future shape change can't bypass the allowlist.
   let url = `https://${host}${path}`;
   if (event.rawQueryString) {
     url += `?${event.rawQueryString}`;
@@ -196,4 +226,24 @@ export function requestContextFromLambda(
     if (params.length) url += `?${params.join('&')}`;
   }
   return { method, url };
+}
+
+/**
+ * Normalize a Host / domainName value for allowlist comparison. Lowercase
+ * + trim handle the obvious cases; trailing-dot stripping closes a
+ * documented Host-header bypass where `example.com.` is a distinct string
+ * from `example.com` on some stacks. IPv6 brackets are preserved so the
+ * allowlist entry and the inbound value agree on bracket presence.
+ */
+function normalizeHost(raw: string | undefined): string {
+  if (!raw) return '';
+  let h = raw.trim().toLowerCase();
+  // Strip trailing dot from FQDN. Bracketed IPv6 cannot legitimately
+  // carry a trailing dot, so this only fires on hostnames.
+  if (h.endsWith('.') && !h.endsWith(']')) h = h.slice(0, -1);
+  return h;
+}
+
+function hostMatchesAllowlist(host: string, allowlist: ReadonlyArray<string>): boolean {
+  return allowlist.some(entry => normalizeHost(entry) === host);
 }

--- a/src/lib/signing/request-context.ts
+++ b/src/lib/signing/request-context.ts
@@ -1,0 +1,199 @@
+/**
+ * Adapter helpers that construct the `{ method, url }` shape that
+ * `ResponseLike.request` (and any other caller binding RFC 9421 derived
+ * components back to an originating request) requires.
+ *
+ * Why this exists: `ResponseLike.request.url` MUST be an absolute URL —
+ * `canonicalAuthority` / `canonicalTargetUri` parse via `new URL(...)` and
+ * throw on a relative path. Express handlers ship `req.url` / `req.originalUrl`
+ * as path-only, so adopters reconstruct via
+ * `${req.protocol}://${req.get('host')}${req.originalUrl}`. But `req.protocol`
+ * lies behind a TLS-terminating proxy unless `trust proxy` is set, and
+ * `req.get('host')` is attacker-controllable absent a Host allowlist. A
+ * hostile peer that controls these headers can rebind a signature to
+ * `attacker.example.com` while the operator believes they're signing for
+ * `seller.example.com`.
+ *
+ * The library can warn (JSDoc on `ResponseLike.request`) but can't enforce.
+ * These helpers make the safe path the default path — pass them an inbound
+ * request handle from your platform and they emit a hardened
+ * `{ method, url }` shape.
+ */
+
+/**
+ * Minimal Express request shape this helper consumes. Kept narrow so
+ * `@adcp/sdk` doesn't pull in `@types/express`; importing Express's own
+ * `Request` type is safe in adopter code, since structural typing accepts
+ * the wider shape anywhere this narrower one is expected.
+ */
+export interface ExpressRequestLike {
+  readonly method: string;
+  readonly protocol: string;
+  readonly originalUrl: string;
+  /** Express's typed `Request.get('host')` overload. */
+  get(name: 'host'): string | undefined;
+}
+
+export interface RequestContextFromExpressOptions {
+  /**
+   * Allowed `Host` header values. When set, the helper throws if the
+   * inbound `Host` doesn't match. Strongly recommended in production —
+   * absent this, a hostile peer controlling the `Host` header can rebind
+   * the signature origin (see file header).
+   *
+   * Each entry is compared verbatim against `req.get('host')` after
+   * trimming and lowercasing. Include port suffixes where applicable
+   * (`api.example.com:8080`).
+   */
+  hostAllowlist?: ReadonlyArray<string>;
+
+  /**
+   * When `true` (default), the helper throws if the reconstructed URL
+   * scheme is not `https`. AdCP response / webhook signatures bound to
+   * `http://` will fail strict-HTTPS verifier profiles, so this catches
+   * the misconfig at construction time. Disable only for local dev /
+   * loopback mock servers.
+   */
+  forceHttps?: boolean;
+}
+
+/**
+ * Construct a hardened `{ method, url }` from an Express request.
+ *
+ * **You MUST configure `app.set('trust proxy', ...)`** with the IPs of
+ * your trusted reverse proxies before relying on this helper. Without
+ * `trust proxy`, Express returns the literal `req.connection.remoteAddress`
+ * for `req.protocol` and `req.ip` — which a TLS-terminating proxy will
+ * always set to the proxy's address, leaving you blind to whether the
+ * original request actually arrived over HTTPS. This helper trusts what
+ * Express tells it; the operator is responsible for telling Express what
+ * to trust.
+ *
+ * Throws when the `Host` header is missing, doesn't match `hostAllowlist`,
+ * or when the scheme is not `https` (unless `forceHttps: false`).
+ */
+export function requestContextFromExpress(
+  req: ExpressRequestLike,
+  options: RequestContextFromExpressOptions = {}
+): { method: string; url: string } {
+  const host = req.get('host')?.trim().toLowerCase();
+  if (!host) {
+    throw new TypeError(
+      'requestContextFromExpress: Host header is missing. ' +
+        'Express returned no `host` — either the inbound request omitted it, or your reverse proxy stripped it.'
+    );
+  }
+  if (options.hostAllowlist && !options.hostAllowlist.some(h => h.trim().toLowerCase() === host)) {
+    throw new TypeError(
+      `requestContextFromExpress: Host "${host}" is not in hostAllowlist. ` +
+        `A hostile peer may be trying to rebind your signature origin via Host-header injection. ` +
+        `Add the legitimate value to hostAllowlist, or fix your proxy's Host handling.`
+    );
+  }
+  const protocol = req.protocol;
+  const forceHttps = options.forceHttps !== false;
+  if (forceHttps && protocol !== 'https') {
+    throw new TypeError(
+      `requestContextFromExpress: protocol is "${protocol}", not "https". ` +
+        `Set app.set('trust proxy', ...) so Express sees the X-Forwarded-Proto header, ` +
+        `or pass forceHttps: false for local dev (loopback / mock-server testing).`
+    );
+  }
+  return { method: req.method, url: `${protocol}://${host}${req.originalUrl}` };
+}
+
+/**
+ * Fetch / Workers / Deno / Bun `Request` shape. `request.url` is already
+ * an absolute URL per WHATWG spec, so there's no host-spoofing surface
+ * here — the runtime owns URL construction, not the caller.
+ */
+export interface FetchRequestLike {
+  readonly method: string;
+  readonly url: string;
+}
+
+/**
+ * Construct `{ method, url }` from a Fetch / WHATWG `Request`. Trivial
+ * passthrough; included for API symmetry with the Express / Lambda
+ * helpers. No proxy hardening needed — `request.url` is the absolute URL
+ * the runtime constructed from the wire, and Workers / Deno / Bun all
+ * terminate TLS at the edge so `https` is honest.
+ */
+export function requestContextFromFetch(request: FetchRequestLike): { method: string; url: string } {
+  return { method: request.method, url: request.url };
+}
+
+/**
+ * AWS Lambda API Gateway v2 / ALB event shape. Narrow rather than
+ * importing `@types/aws-lambda` — adopter code that ships against the
+ * full Lambda types can pass the wider object verbatim.
+ */
+export interface LambdaRequestEvent {
+  readonly requestContext: {
+    readonly domainName?: string;
+    readonly http?: { readonly method?: string };
+    readonly httpMethod?: string;
+  };
+  readonly rawPath?: string;
+  readonly rawQueryString?: string;
+  readonly path?: string;
+  readonly httpMethod?: string;
+  readonly queryStringParameters?: { readonly [key: string]: string | undefined };
+}
+
+export interface RequestContextFromLambdaOptions {
+  /**
+   * Same semantics as the Express helper — allowed `domainName` values.
+   * Lambda's `event.requestContext.domainName` is set by API Gateway from
+   * the matched custom-domain configuration; it's not attacker-controllable
+   * the way Express's `req.get('host')` is, but pinning it still catches
+   * misrouted traffic (e.g. one tenant's Lambda receiving another tenant's
+   * domain via a misconfigured shared API Gateway).
+   */
+  hostAllowlist?: ReadonlyArray<string>;
+}
+
+/**
+ * Construct `{ method, url }` from an AWS Lambda API Gateway v2 / ALB
+ * event. Reads `requestContext.domainName` for the authority, `rawPath` +
+ * `rawQueryString` for the target (v2 / ALB), falling back to `path` +
+ * `queryStringParameters` reconstruction (v1).
+ *
+ * Always emits `https://` — Lambda is not addressable over plain HTTP
+ * through API Gateway / ALB in any documented configuration.
+ */
+export function requestContextFromLambda(
+  event: LambdaRequestEvent,
+  options: RequestContextFromLambdaOptions = {}
+): { method: string; url: string } {
+  const domainName = event.requestContext.domainName;
+  if (!domainName) {
+    throw new TypeError(
+      'requestContextFromLambda: event.requestContext.domainName is missing. ' +
+        'API Gateway v2 / ALB events should always carry this; ' +
+        'is this event shaped like something else?'
+    );
+  }
+  const host = domainName.trim().toLowerCase();
+  if (options.hostAllowlist && !options.hostAllowlist.some(h => h.trim().toLowerCase() === host)) {
+    throw new TypeError(
+      `requestContextFromLambda: domainName "${host}" is not in hostAllowlist. ` +
+        `Multi-tenant API Gateway misroute? Add the legitimate value, or fix the API mapping.`
+    );
+  }
+  const method = event.requestContext.http?.method ?? event.requestContext.httpMethod ?? event.httpMethod;
+  if (!method) {
+    throw new TypeError('requestContextFromLambda: HTTP method is missing from the event.');
+  }
+  const path = event.rawPath ?? event.path ?? '/';
+  let url = `https://${host}${path}`;
+  if (event.rawQueryString) {
+    url += `?${event.rawQueryString}`;
+  } else if (event.queryStringParameters) {
+    const params = Object.entries(event.queryStringParameters)
+      .filter(([, v]) => v !== undefined)
+      .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v as string)}`);
+    if (params.length) url += `?${params.join('&')}`;
+  }
+  return { method, url };
+}

--- a/src/lib/signing/server.ts
+++ b/src/lib/signing/server.ts
@@ -21,6 +21,16 @@ export {
   type SignatureParams,
 } from './canonicalize';
 export { computeContentDigest, contentDigestMatches, parseContentDigest } from './content-digest';
+export {
+  requestContextFromExpress,
+  requestContextFromFetch,
+  requestContextFromLambda,
+  type ExpressRequestLike,
+  type FetchRequestLike,
+  type LambdaRequestEvent,
+  type RequestContextFromExpressOptions,
+  type RequestContextFromLambdaOptions,
+} from './request-context';
 export { jwkToPublicKey, verifySignature } from './crypto';
 export {
   RequestSignatureError,

--- a/test/request-context-helpers.test.js
+++ b/test/request-context-helpers.test.js
@@ -1,0 +1,237 @@
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+
+const {
+  requestContextFromExpress,
+  requestContextFromFetch,
+  requestContextFromLambda,
+} = require('../dist/lib/signing/index.js');
+
+// Mock Express request — only the fields the helper reads.
+function expressReq({ method = 'POST', protocol = 'https', host, originalUrl = '/adcp/get_products' } = {}) {
+  return {
+    method,
+    protocol,
+    originalUrl,
+    get(name) {
+      if (name === 'host') return host;
+      throw new Error(`unexpected req.get(${name})`);
+    },
+  };
+}
+
+describe('requestContextFromExpress', () => {
+  test('reconstructs an absolute URL from protocol + host + originalUrl', () => {
+    const ctx = requestContextFromExpress(expressReq({ host: 'seller.example.com' }));
+    assert.deepStrictEqual(ctx, {
+      method: 'POST',
+      url: 'https://seller.example.com/adcp/get_products',
+    });
+  });
+
+  test('lowercases the host for canonical equivalence', () => {
+    const ctx = requestContextFromExpress(expressReq({ host: 'Seller.Example.COM' }));
+    assert.strictEqual(ctx.url, 'https://seller.example.com/adcp/get_products');
+  });
+
+  test('throws when Host header is missing', () => {
+    assert.throws(() => requestContextFromExpress(expressReq({ host: undefined })), /Host header is missing/);
+  });
+
+  test('throws when host fails hostAllowlist check', () => {
+    assert.throws(
+      () =>
+        requestContextFromExpress(expressReq({ host: 'attacker.example.com' }), {
+          hostAllowlist: ['seller.example.com'],
+        }),
+      /not in hostAllowlist/
+    );
+  });
+
+  test('accepts host that matches hostAllowlist case-insensitively', () => {
+    const ctx = requestContextFromExpress(expressReq({ host: 'seller.example.com' }), {
+      hostAllowlist: ['Seller.Example.COM'],
+    });
+    assert.strictEqual(ctx.url, 'https://seller.example.com/adcp/get_products');
+  });
+
+  test('throws when protocol is http (forceHttps default)', () => {
+    assert.throws(
+      () => requestContextFromExpress(expressReq({ protocol: 'http', host: 'seller.example.com' })),
+      /protocol is "http"/
+    );
+  });
+
+  test('forceHttps: false allows http for local dev', () => {
+    const ctx = requestContextFromExpress(expressReq({ protocol: 'http', host: '127.0.0.1:3000' }), {
+      forceHttps: false,
+    });
+    assert.strictEqual(ctx.url, 'http://127.0.0.1:3000/adcp/get_products');
+  });
+
+  test('preserves query string in originalUrl', () => {
+    const ctx = requestContextFromExpress(
+      expressReq({ host: 'seller.example.com', originalUrl: '/adcp/get_products?filter=video&limit=10' })
+    );
+    assert.strictEqual(ctx.url, 'https://seller.example.com/adcp/get_products?filter=video&limit=10');
+  });
+});
+
+describe('requestContextFromFetch', () => {
+  test('passes through method + absolute url', () => {
+    const ctx = requestContextFromFetch({
+      method: 'POST',
+      url: 'https://seller.example.com/adcp/get_products',
+    });
+    assert.deepStrictEqual(ctx, {
+      method: 'POST',
+      url: 'https://seller.example.com/adcp/get_products',
+    });
+  });
+
+  test('accepts a real WHATWG Request', () => {
+    const req = new Request('https://seller.example.com/adcp/get_products', { method: 'POST' });
+    const ctx = requestContextFromFetch(req);
+    assert.strictEqual(ctx.url, 'https://seller.example.com/adcp/get_products');
+    assert.strictEqual(ctx.method, 'POST');
+  });
+});
+
+describe('requestContextFromLambda', () => {
+  test('v2 event: reads requestContext.http.method + domainName + rawPath + rawQueryString', () => {
+    const ctx = requestContextFromLambda({
+      requestContext: {
+        domainName: 'api.example.com',
+        http: { method: 'POST' },
+      },
+      rawPath: '/adcp/get_products',
+      rawQueryString: 'filter=video&limit=10',
+    });
+    assert.deepStrictEqual(ctx, {
+      method: 'POST',
+      url: 'https://api.example.com/adcp/get_products?filter=video&limit=10',
+    });
+  });
+
+  test('v1 event: falls back to httpMethod + path + queryStringParameters', () => {
+    const ctx = requestContextFromLambda({
+      requestContext: { domainName: 'api.example.com', httpMethod: 'POST' },
+      path: '/adcp/get_products',
+      httpMethod: 'POST',
+      queryStringParameters: { filter: 'video', limit: '10' },
+    });
+    assert.strictEqual(ctx.method, 'POST');
+    // Order isn't guaranteed by Object.entries on plain objects spec-wise,
+    // but Node's V8 iterates string-keyed props in insertion order — both
+    // params are present and properly URL-encoded.
+    assert.match(ctx.url, /^https:\/\/api\.example\.com\/adcp\/get_products\?/);
+    assert.match(ctx.url, /filter=video/);
+    assert.match(ctx.url, /limit=10/);
+  });
+
+  test('throws when domainName is missing', () => {
+    assert.throws(
+      () =>
+        requestContextFromLambda({
+          requestContext: { http: { method: 'POST' } },
+          rawPath: '/foo',
+        }),
+      /domainName is missing/
+    );
+  });
+
+  test('throws when domainName fails hostAllowlist check', () => {
+    assert.throws(
+      () =>
+        requestContextFromLambda(
+          {
+            requestContext: { domainName: 'rogue.example.com', http: { method: 'POST' } },
+            rawPath: '/foo',
+          },
+          { hostAllowlist: ['api.example.com'] }
+        ),
+      /not in hostAllowlist/
+    );
+  });
+
+  test('always emits https:// (no http override needed; Lambda is not http-addressable)', () => {
+    const ctx = requestContextFromLambda({
+      requestContext: { domainName: 'api.example.com', http: { method: 'GET' } },
+      rawPath: '/',
+    });
+    assert.ok(ctx.url.startsWith('https://'));
+  });
+
+  test('throws when method cannot be determined', () => {
+    assert.throws(
+      () =>
+        requestContextFromLambda({
+          requestContext: { domainName: 'api.example.com' },
+          rawPath: '/foo',
+        }),
+      /HTTP method is missing/
+    );
+  });
+
+  test('URL-encodes special characters in queryStringParameters', () => {
+    const ctx = requestContextFromLambda({
+      requestContext: { domainName: 'api.example.com', http: { method: 'POST' } },
+      rawPath: '/search',
+      queryStringParameters: { q: 'hello world & friends' },
+    });
+    assert.match(ctx.url, /q=hello%20world%20%26%20friends/);
+  });
+});
+
+describe('end-to-end: helpers produce a URL that ResponseLike.request accepts', () => {
+  test('Express helper output verifies against signResponse → verifyResponseSignature', async () => {
+    const {
+      signResponse,
+      verifyResponseSignature,
+      StaticJwksResolver,
+      InMemoryReplayStore,
+      InMemoryRevocationStore,
+    } = require('../dist/lib/signing/index.js');
+    const { readFileSync } = require('node:fs');
+    const path = require('node:path');
+    const keysData = JSON.parse(
+      readFileSync(
+        path.join(__dirname, '..', 'compliance', 'cache', 'latest', 'test-vectors', 'request-signing', 'keys.json'),
+        'utf8'
+      )
+    );
+    const k = keysData.keys.find(x => x.kid === 'test-ed25519-2026');
+    const privateKey = { ...k, d: k._private_d_for_test_only, adcp_use: 'response-signing' };
+    delete privateKey._private_d_for_test_only;
+    const publicJwk = { ...k, adcp_use: 'response-signing', key_ops: ['verify'] };
+    delete publicJwk._private_d_for_test_only;
+
+    const reqCtx = requestContextFromExpress(expressReq({ host: 'seller.example.com' }));
+    const responseLike = {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+      body: '{"ok":true}',
+      request: reqCtx,
+    };
+    const signed = signResponse(
+      responseLike,
+      { keyid: 'test-ed25519-2026', alg: 'ed25519', privateKey },
+      {
+        now: () => 1776520800,
+        nonce: 'ctxtest',
+        windowSeconds: 300,
+      }
+    );
+
+    const result = await verifyResponseSignature(
+      { ...responseLike, headers: { ...responseLike.headers, ...signed.headers } },
+      {
+        jwks: new StaticJwksResolver([publicJwk]),
+        replayStore: new InMemoryReplayStore(),
+        revocationStore: new InMemoryRevocationStore(),
+        now: () => 1776520800,
+      }
+    );
+    assert.strictEqual(result.status, 'verified');
+  });
+});

--- a/test/request-context-helpers.test.js
+++ b/test/request-context-helpers.test.js
@@ -234,4 +234,176 @@ describe('end-to-end: helpers produce a URL that ResponseLike.request accepts', 
     );
     assert.strictEqual(result.status, 'verified');
   });
+
+  test('verifier-side helper reconstructs against a different req object; verification still succeeds', async () => {
+    // Symmetric helper use: the signer used `requestContextFromExpress` on
+    // its inbound req; the verifier uses the same helper on its own inbound
+    // req (representing the same logical request). The reconstructed URL
+    // must canonicalize identically so the signature still verifies.
+    const {
+      signResponse,
+      verifyResponseSignature,
+      StaticJwksResolver,
+      InMemoryReplayStore,
+      InMemoryRevocationStore,
+    } = require('../dist/lib/signing/index.js');
+    const { readFileSync } = require('node:fs');
+    const path = require('node:path');
+    const keysData = JSON.parse(
+      readFileSync(
+        path.join(__dirname, '..', 'compliance', 'cache', 'latest', 'test-vectors', 'request-signing', 'keys.json'),
+        'utf8'
+      )
+    );
+    const k = keysData.keys.find(x => x.kid === 'test-ed25519-2026');
+    const privateKey = { ...k, d: k._private_d_for_test_only, adcp_use: 'response-signing' };
+    delete privateKey._private_d_for_test_only;
+    const publicJwk = { ...k, adcp_use: 'response-signing', key_ops: ['verify'] };
+    delete publicJwk._private_d_for_test_only;
+
+    // Signer side: one req instance.
+    const signerCtx = requestContextFromExpress(expressReq({ host: 'seller.example.com' }));
+    const responseLike = {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+      body: '{"ok":true}',
+      request: signerCtx,
+    };
+    const signed = signResponse(
+      responseLike,
+      { keyid: 'test-ed25519-2026', alg: 'ed25519', privateKey },
+      {
+        now: () => 1776520800,
+        nonce: 'sym-test',
+        windowSeconds: 300,
+      }
+    );
+
+    // Verifier side: a completely different req instance representing the
+    // same logical request. The helper must produce the same canonical URL.
+    const verifierCtx = requestContextFromExpress(expressReq({ host: 'seller.example.com' }));
+    assert.deepStrictEqual(signerCtx, verifierCtx);
+
+    const result = await verifyResponseSignature(
+      { ...responseLike, request: verifierCtx, headers: { ...responseLike.headers, ...signed.headers } },
+      {
+        jwks: new StaticJwksResolver([publicJwk]),
+        replayStore: new InMemoryReplayStore(),
+        revocationStore: new InMemoryRevocationStore(),
+        now: () => 1776520800,
+      }
+    );
+    assert.strictEqual(result.status, 'verified');
+  });
+
+  test('cross-host negative: signature bound to seller.example.com fails when verifier reconstructs attacker.example.com', async () => {
+    const {
+      signResponse,
+      verifyResponseSignature,
+      StaticJwksResolver,
+      InMemoryReplayStore,
+      InMemoryRevocationStore,
+    } = require('../dist/lib/signing/index.js');
+    const { readFileSync } = require('node:fs');
+    const path = require('node:path');
+    const keysData = JSON.parse(
+      readFileSync(
+        path.join(__dirname, '..', 'compliance', 'cache', 'latest', 'test-vectors', 'request-signing', 'keys.json'),
+        'utf8'
+      )
+    );
+    const k = keysData.keys.find(x => x.kid === 'test-ed25519-2026');
+    const privateKey = { ...k, d: k._private_d_for_test_only, adcp_use: 'response-signing' };
+    delete privateKey._private_d_for_test_only;
+    const publicJwk = { ...k, adcp_use: 'response-signing', key_ops: ['verify'] };
+    delete publicJwk._private_d_for_test_only;
+
+    // Signer binds to seller.example.com.
+    const sellerCtx = requestContextFromExpress(expressReq({ host: 'seller.example.com' }));
+    const responseLike = {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+      body: '{"ok":true}',
+      request: sellerCtx,
+    };
+    const signed = signResponse(
+      responseLike,
+      { keyid: 'test-ed25519-2026', alg: 'ed25519', privateKey },
+      {
+        now: () => 1776520800,
+        nonce: 'cross-host',
+        windowSeconds: 300,
+      }
+    );
+
+    // Verifier reconstructs against attacker.example.com.
+    const attackerCtx = requestContextFromExpress(expressReq({ host: 'attacker.example.com' }));
+    await assert.rejects(
+      () =>
+        verifyResponseSignature(
+          { ...responseLike, request: attackerCtx, headers: { ...responseLike.headers, ...signed.headers } },
+          {
+            jwks: new StaticJwksResolver([publicJwk]),
+            replayStore: new InMemoryReplayStore(),
+            revocationStore: new InMemoryRevocationStore(),
+            now: () => 1776520800,
+          }
+        ),
+      err => err.code === 'response_signature_invalid'
+    );
+  });
+});
+
+describe('hostAllowlist hardening (trailing-dot bypass)', () => {
+  test('Express helper: trailing-dot Host matches a non-trailing-dot allowlist entry', () => {
+    const ctx = requestContextFromExpress(expressReq({ host: 'seller.example.com.' }), {
+      hostAllowlist: ['seller.example.com'],
+    });
+    assert.strictEqual(ctx.url, 'https://seller.example.com/adcp/get_products');
+  });
+
+  test('Express helper: trailing-dot allowlist entry matches a non-trailing-dot Host', () => {
+    const ctx = requestContextFromExpress(expressReq({ host: 'seller.example.com' }), {
+      hostAllowlist: ['seller.example.com.'],
+    });
+    assert.strictEqual(ctx.url, 'https://seller.example.com/adcp/get_products');
+  });
+
+  test('Lambda helper: same trailing-dot normalization', () => {
+    const ctx = requestContextFromLambda(
+      {
+        requestContext: { domainName: 'api.example.com.', http: { method: 'POST' } },
+        rawPath: '/foo',
+      },
+      { hostAllowlist: ['api.example.com'] }
+    );
+    assert.ok(ctx.url.startsWith('https://api.example.com/'));
+  });
+});
+
+describe('userinfo rejection (signature-namespace confusion vector)', () => {
+  test('Fetch helper: rejects URL with username', () => {
+    assert.throws(
+      () => requestContextFromFetch({ method: 'POST', url: 'https://attacker@seller.example.com/path' }),
+      /userinfo/
+    );
+  });
+
+  test('Fetch helper: rejects URL with password', () => {
+    assert.throws(
+      () => requestContextFromFetch({ method: 'POST', url: 'https://user:pw@seller.example.com/path' }),
+      /userinfo/
+    );
+  });
+
+  test('Fetch helper: rejects non-parseable URL', () => {
+    assert.throws(() => requestContextFromFetch({ method: 'POST', url: 'not-a-url' }), /not a parseable URL/);
+  });
+
+  test('Express helper: rejects originalUrl with @ in path', () => {
+    assert.throws(
+      () => requestContextFromExpress(expressReq({ host: 'seller.example.com', originalUrl: '/path/with@injection' })),
+      /userinfo/
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Closes #1828. Makes the safe path the default for constructing \`ResponseLike.request\` on each major Node platform.

The JSDoc warning on \`ResponseLike.request.url\` (shipped in #1823) flags the trap: under proxy termination, \`req.protocol\` lies and \`req.get('host')\` is attacker-controllable. JSDoc warnings rot. These helpers enforce hardening at construction time.

\`\`\`ts
import { requestContextFromExpress, signResponse } from '@adcp/sdk/signing/client';

app.post('/adcp/get_products', (req, res) => {
  const signed = signResponse(
    {
      status: 200,
      headers: { 'content-type': 'application/json' },
      body,
      request: requestContextFromExpress(req, {
        hostAllowlist: ['seller.example.com'],
      }),
    },
    key
  );
  res.set(signed.headers).send(body);
});
\`\`\`

### Three helpers

| Helper | Hardening |
|---|---|
| \`requestContextFromExpress(req, options)\` | Throws on missing \`Host\` / \`hostAllowlist\` mismatch / non-https protocol (unless \`forceHttps: false\`). Adopters MUST configure \`app.set('trust proxy', ...)\` — the helper trusts what Express tells it. |
| \`requestContextFromFetch(request)\` | Trivial passthrough. Workers / Deno / Bun terminate TLS at the edge and own URL construction; no hardening needed. |
| \`requestContextFromLambda(event, options)\` | Reads \`requestContext.domainName\` for authority; \`rawPath\` + \`rawQueryString\` (v2 / ALB) or \`path\` + \`queryStringParameters\` (v1) for the target. Always emits \`https://\`. \`hostAllowlist\` catches multi-tenant API Gateway misroutes. |

Exported from both \`@adcp/sdk/signing/client\` (signer-side adopters using \`signResponse\`) and \`@adcp/sdk/signing/server\` (verifier-side adopters reconstructing the originating-request URL for \`verifyResponseSignature\`).

## Test plan

- [x] 18 tests in \`test/request-context-helpers.test.js\`:
  - Express: happy path, host lowercasing, missing Host, allowlist enforcement (case-insensitive), \`forceHttps\` default + override, query-string preservation
  - Fetch: passthrough + real WHATWG \`Request\`
  - Lambda: v2 event shape, v1 fallback, missing \`domainName\`, allowlist enforcement, always-https, missing method, URL-encoded query params
  - **End-to-end**: Express helper output → \`signResponse\` → \`verifyResponseSignature\` round-trip verifies, proving the helper produces a URL the verifier accepts
- [x] \`tsc --noEmit\` clean
- [x] \`prettier --check\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)