### PR TITLE
feat(testing): grade audience inverse rule + walk creative_approvals[] in impairment.coherence

### DIFF
--- a/.changeset/2860-impairment-coherence-audience-inverse.md
+++ b/.changeset/2860-impairment-coherence-audience-inverse.md
@@ -1,0 +1,25 @@
+---
+'@adcp/sdk': minor
+---
+
+feat(testing): impairment.coherence grades audience inverse rule + walks `creative_approvals[]` on buy snapshots
+
+Closes two gaps in the storyboard runner's `impairment.coherence` invariant exposed by the dependency-impairment storyboard (adcp#2860 / adcp#4677):
+
+**1. Audience leg of the inverse rule is now graded.**
+
+The buy-side reference for audiences lives at `packages[*].targeting_overlay.audience_include[]` — a stable, spec-defined field that lets the runner traverse buy → audience the same way it traverses buy → creative. The earlier deferral lived in `INVERSE_DEFERRED_FAMILIES` and emitted a `not_applicable` hint on every audience offline transition.
+
+- `readBuySnapshot` extracts `referencedAudienceIds` from `packages[*].targeting_overlay.audience_include[]`. `audience_exclude` is intentionally excluded — suspending an exclude-audience does not prevent the buy from serving.
+- The inverse check is parameterised over both reference sets (creative + audience). A suspended audience referenced by a non-terminal buy that doesn't list it in `impairments[]` now produces a `violation: 'inverse'` failing result, mirroring the existing creative inverse coverage.
+- `audience` is removed from `INVERSE_DEFERRED_FAMILIES`. The `not_applicable` hint that used to fire on audience offline transitions stops firing — audience observations now flow into the graded path. The onEnd partial-coverage summary still flags `catalog_item` and `event_source` (their per-buy reference shapes remain unstable).
+
+**2. `creative_approvals[]` is now walked on buy snapshots.**
+
+The `get-media-buys-response.json` package shape uses `creative_approvals[]` (per spec) — different from `core/package.json`'s `creative_assignments[]` (the request-side shape). `readBuySnapshot` previously only walked the latter, which made the inverse rule for creative grade silent on conformant `get_media_buys` snapshots. Now it walks both.
+
+This was the bug that masked the v6 SalesPlatform.syncCreatives gap (adcontextprotocol/adcp-client#1846) — without `creative_approvals[]` extraction, the inverse rule grades silent on a properly-shaped buy snapshot even when the creative is referenced, so the SDK runner never reported the missing assignment plumbing. With this fix the inverse rule fires correctly and the gap surfaces immediately.
+
+**Test coverage:** 6 new tests — 5 audience inverse coverage tests (graded propagation, exclude-doesn't-count, terminal carve-out, recovery clears, paired with health-iff) + 1 creative_approvals extraction test. The existing deferred-family test loop moves audience out and asserts the graded behaviour.
+
+**No behaviour change for storyboards that already propagate impairments correctly** — they previously graded `not_applicable` for audience offline observations and now grade `pass` instead. Storyboards that observed an audience transition without propagating it to a buy snapshot previously graded silent (with an `not_applicable` notice) and now FAIL with a structured `impairment_coherence_violation` hint pointing at the offline audience.

--- a/.changeset/2860-impairment-coherence-audience-inverse.md
+++ b/.changeset/2860-impairment-coherence-audience-inverse.md
@@ -10,15 +10,13 @@ Closes two gaps in the storyboard runner's `impairment.coherence` invariant expo
 
 The buy-side reference for audiences lives at `packages[*].targeting_overlay.audience_include[]` — a stable, spec-defined field that lets the runner traverse buy → audience the same way it traverses buy → creative. The earlier deferral lived in `INVERSE_DEFERRED_FAMILIES` and emitted a `not_applicable` hint on every audience offline transition.
 
-- `readBuySnapshot` extracts `referencedAudienceIds` from `packages[*].targeting_overlay.audience_include[]`. `audience_exclude` is intentionally excluded — suspending an exclude-audience does not prevent the buy from serving.
+- `readBuySnapshot` extracts `referencedAudienceIds` from `packages[*].targeting_overlay.audience_include[]`. `audience_exclude` is intentionally omitted on **serviceability** grounds — suspending an exclude-audience doesn't prevent the buy from serving, so it isn't a "buy can't function" signal that the inverse rule should fire on. This is not a **safety** judgement: an offline exclude can still silently break the suppression promise, which the runner treats as a separate (forward-looking) signal class.
 - The inverse check is parameterised over both reference sets (creative + audience). A suspended audience referenced by a non-terminal buy that doesn't list it in `impairments[]` now produces a `violation: 'inverse'` failing result, mirroring the existing creative inverse coverage.
 - `audience` is removed from `INVERSE_DEFERRED_FAMILIES`. The `not_applicable` hint that used to fire on audience offline transitions stops firing — audience observations now flow into the graded path. The onEnd partial-coverage summary still flags `catalog_item` and `event_source` (their per-buy reference shapes remain unstable).
 
 **2. `creative_approvals[]` is now walked on buy snapshots.**
 
-The `get-media-buys-response.json` package shape uses `creative_approvals[]` (per spec) — different from `core/package.json`'s `creative_assignments[]` (the request-side shape). `readBuySnapshot` previously only walked the latter, which made the inverse rule for creative grade silent on conformant `get_media_buys` snapshots. Now it walks both.
-
-This was the bug that masked the v6 SalesPlatform.syncCreatives gap (adcontextprotocol/adcp-client#1846) — without `creative_approvals[]` extraction, the inverse rule grades silent on a properly-shaped buy snapshot even when the creative is referenced, so the SDK runner never reported the missing assignment plumbing. With this fix the inverse rule fires correctly and the gap surfaces immediately.
+The `get-media-buys-response.json` package shape uses `creative_approvals[]` (per spec) — different from `core/package.json`'s `creative_assignments[]` (the request-side shape). `readBuySnapshot` now walks both, so the inverse rule for creative grades correctly regardless of which shape the seller surfaces.
 
 **Test coverage:** 6 new tests — 5 audience inverse coverage tests (graded propagation, exclude-doesn't-count, terminal carve-out, recovery clears, paired with health-iff) + 1 creative_approvals extraction test. The existing deferred-family test loop moves audience out and asserts the graded behaviour.
 

--- a/src/lib/testing/storyboard/default-invariants.ts
+++ b/src/lib/testing/storyboard/default-invariants.ts
@@ -1062,11 +1062,11 @@ interface ResourceObservation {
  * visible to storyboard authors and reviewers rather than burying it in
  * PR prose and JSDoc.
  *
- * `audience` was deferred prior to adcp#2860 — the buy-side reference
- * lives at `packages[*].targeting_overlay.audience_include[]` and is now
- * extracted in `readBuySnapshot`. `catalog_item` and `event_source` stay
- * deferred: a buy doesn't reference catalog_items or event_sources by
- * stable id in the cached schema.
+ * `audience` is graded — the buy-side reference lives at
+ * `packages[*].targeting_overlay.audience_include[]` and is extracted in
+ * `readBuySnapshot`. `catalog_item` and `event_source` are deferred: a
+ * buy doesn't reference catalog_items or event_sources by stable id in
+ * the cached schema, so the runner can't traverse buy → resource.
  */
 const INVERSE_DEFERRED_FAMILIES: ReadonlySet<string> = new Set(['catalog_item', 'event_source']);
 
@@ -1165,10 +1165,9 @@ registerOnce('impairment.coherence', {
         // `not_applicable` step-level result so reviewers see the gap in
         // run output instead of having to read PR prose. One emission per
         // (resource_type, resource_id) per run — re-syncs of an already
-        // offline resource don't re-fire. `audience` is no longer in this
-        // set: post-adcp#2860 the runner extracts audience refs from
-        // packages[*].targeting_overlay.audience_include[] and grades the
-        // inverse rule for audience the same way it grades creative.
+        // offline resource don't re-fire. Only catalog_item and event_source
+        // surface here; audience is graded via the inverse rule using refs
+        // from packages[*].targeting_overlay.audience_include[].
         if (!wasOffline && (ob.resource_type === 'catalog_item' || ob.resource_type === 'event_source')) {
           const message =
             `inverse-rule coverage for ${ob.resource_type} ${ob.resource_id} ` +
@@ -1446,7 +1445,11 @@ function extractImpairmentObservations(
  * references through `packages[].creative_assignments[]`, and the set of
  * `audience_id`s referenced through `packages[].targeting_overlay.audience_include[]`.
  * Both reference sets feed the inverse rule. `audience_exclude` is not
- * collected — excluding an audience does not require it to be serviceable.
+ * collected as a hard dependency for the inverse rule: an offline exclude
+ * does not prevent the buy from serving, so it isn't a "buy can't function"
+ * signal. Note this is a serviceability framing, not a safety framing —
+ * an offline exclude can still silently break the suppression promise,
+ * which is a separate (forward-looking) signal class.
  */
 function extractBuySnapshots(task: string, body: Record<string, unknown>, stepId: string): BuySnapshot[] {
   const out: BuySnapshot[] = [];
@@ -1487,9 +1490,7 @@ function readBuySnapshot(record: Record<string, unknown>, stepId: string): BuySn
     //     (the snapshot shape — `creative_approvals` carries per-assignment
     //     approval_status alongside the id)
     // Walk both — sellers conformant to either schema surface the references
-    // we need for the inverse rule. (The SDK previously only walked the
-    // request shape, which made the inverse rule silent on conformant
-    // get_media_buys snapshots; tracked in adcp#2860.)
+    // we need for the inverse rule.
     for (const ca of asArray(pkg.creative_assignments)) {
       if (!isObject(ca)) continue;
       const cid = asString(ca.creative_id);
@@ -1500,9 +1501,11 @@ function readBuySnapshot(record: Record<string, unknown>, stepId: string): BuySn
       const cid = asString(ca.creative_id);
       if (cid) referencedCreativeIds.add(cid);
     }
-    // Audience refs: only `audience_include` counts as a hard dependency.
-    // `audience_exclude` doesn't — a suspended exclude-audience does not
-    // prevent the buy from serving.
+    // Audience refs: only `audience_include` counts as a hard dependency
+    // for the inverse rule. `audience_exclude` is omitted on serviceability
+    // grounds — a suspended exclude doesn't keep the buy from serving — not
+    // on safety grounds. An offline exclude can still silently break the
+    // suppression promise; that's a separate signal class (see extractBuySnapshots).
     const overlay = isObject(pkg.targeting_overlay) ? pkg.targeting_overlay : undefined;
     if (overlay) {
       for (const aid of asArray(overlay.audience_include)) {

--- a/src/lib/testing/storyboard/default-invariants.ts
+++ b/src/lib/testing/storyboard/default-invariants.ts
@@ -1043,6 +1043,7 @@ interface BuySnapshot {
   health: string | undefined;
   impairments: ImpairmentEntry[];
   referencedCreativeIds: Set<string>;
+  referencedAudienceIds: Set<string>;
   stepId: string;
 }
 
@@ -1055,13 +1056,19 @@ interface ResourceObservation {
  * Resource families the inverse rule does NOT yet grade — the buy-side
  * reference shape for these in `media_buy.packages` isn't stable in the
  * cached schema, so we can't reliably tell which buys reference which
- * resources. Tracked in adcontextprotocol/adcp#2860. Listed here so the
- * onEnd summary can emit a runtime "partial inverse coverage" signal when
- * the run actually observed offline resources in one of these families —
- * making the deferral visible to storyboard authors and reviewers rather
- * than burying it in PR prose and JSDoc.
+ * resources. Listed here so the onEnd summary can emit a runtime
+ * "partial inverse coverage" signal when the run actually observed
+ * offline resources in one of these families — making the deferral
+ * visible to storyboard authors and reviewers rather than burying it in
+ * PR prose and JSDoc.
+ *
+ * `audience` was deferred prior to adcp#2860 — the buy-side reference
+ * lives at `packages[*].targeting_overlay.audience_include[]` and is now
+ * extracted in `readBuySnapshot`. `catalog_item` and `event_source` stay
+ * deferred: a buy doesn't reference catalog_items or event_sources by
+ * stable id in the cached schema.
  */
-const INVERSE_DEFERRED_FAMILIES: ReadonlySet<string> = new Set(['audience', 'catalog_item', 'event_source']);
+const INVERSE_DEFERRED_FAMILIES: ReadonlySet<string> = new Set(['catalog_item', 'event_source']);
 
 /**
  * Private per-run scratch state. Namespaced under
@@ -1153,23 +1160,20 @@ registerOnce('impairment.coherence', {
 
         // Issue #1806: surface deferred inverse-rule coverage at the
         // transition step. When a resource family the runner can't yet
-        // reverse-traverse (`audience` / `catalog_item` / `event_source`)
-        // enters an offline state for the first time in this run, emit a
+        // reverse-traverse (`catalog_item` / `event_source`) enters an
+        // offline state for the first time in this run, emit a
         // `not_applicable` step-level result so reviewers see the gap in
         // run output instead of having to read PR prose. One emission per
         // (resource_type, resource_id) per run — re-syncs of an already
-        // offline resource don't re-fire.
-        if (
-          !wasOffline &&
-          (ob.resource_type === 'audience' ||
-            ob.resource_type === 'catalog_item' ||
-            ob.resource_type === 'event_source')
-        ) {
+        // offline resource don't re-fire. `audience` is no longer in this
+        // set: post-adcp#2860 the runner extracts audience refs from
+        // packages[*].targeting_overlay.audience_include[] and grades the
+        // inverse rule for audience the same way it grades creative.
+        if (!wasOffline && (ob.resource_type === 'catalog_item' || ob.resource_type === 'event_source')) {
           const message =
             `inverse-rule coverage for ${ob.resource_type} ${ob.resource_id} ` +
             `(status="${ob.status}", step "${stepResult.step_id}") is deferred — ` +
-            `buy → resource traversal not yet implemented for this family. ` +
-            `Tracked in adcontextprotocol/adcp#2860.`;
+            `buy → resource traversal not yet implemented for this family.`;
           deferredCoverageResults.push({
             passed: true,
             status: 'not_applicable',
@@ -1277,47 +1281,53 @@ registerOnce('impairment.coherence', {
         });
       }
 
-      // Inverse check (creative only). For each creative_id the buy
-      // references via packages[].creative_assignments[].creative_id, if
-      // the runner has it in the offline set AND the buy is non-terminal
-      // AND the impairments[] list doesn't mention it, the seller failed
-      // to propagate the resource state into the buy. Audience / catalog /
-      // event-source inverse coverage is intentionally deferred: their
-      // buy-side reference shape isn't yet stable enough in the cached
-      // schema to extract without ambiguity. Tracked in adcp#2860.
+      // Inverse check. For each resource the buy references — creatives
+      // via `packages[].creative_assignments[].creative_id`, audiences via
+      // `packages[].targeting_overlay.audience_include[]` — if the runner
+      // has it in the offline set AND the buy is non-terminal AND the
+      // impairments[] list doesn't mention it, the seller failed to
+      // propagate the resource state into the buy. `catalog_item` and
+      // `event_source` inverse coverage is still deferred: their buy-side
+      // reference shape isn't yet stable enough in the cached schema to
+      // extract without ambiguity.
       if (isTerminal) continue;
 
-      const impairedCreativeIds = new Set(
-        snap.impairments.filter(e => e.resource_type === 'creative').map(e => e.resource_id)
-      );
-      for (const creativeId of snap.referencedCreativeIds) {
-        const key = `creative:${creativeId}`;
-        const offline = state.offlineResources.get(key);
-        if (!offline) continue;
-        if (impairedCreativeIds.has(creativeId)) continue;
-        const message =
-          `media_buy ${snap.media_buy_id} (status="${snap.status ?? 'unknown'}") references creative ` +
-          `${creativeId} which is offline (status="${offline.status}", step "${offline.stepId}"), ` +
-          `but impairments[] does not list it. Spec: any offline resource referenced by a ` +
-          `non-terminal buy MUST appear in impairments[] (adcp#2859).`;
-        results.push({
-          passed: false,
-          description,
-          step_id: stepResult.step_id,
-          error: message,
-          hint: {
-            kind: 'impairment_coherence_violation',
-            violation: 'inverse',
-            message,
-            media_buy_id: snap.media_buy_id,
-            buy_step_id: snap.stepId,
-            resource_type: 'creative',
-            resource_id: creativeId,
-            resource_status: offline.status,
-            resource_step_id: offline.stepId,
-            impairments_count: snap.impairments.length,
-          },
-        });
+      for (const [resourceType, referencedIds] of [
+        ['creative', snap.referencedCreativeIds] as const,
+        ['audience', snap.referencedAudienceIds] as const,
+      ]) {
+        const impairedIds = new Set(
+          snap.impairments.filter(e => e.resource_type === resourceType).map(e => e.resource_id)
+        );
+        for (const resourceId of referencedIds) {
+          const key = `${resourceType}:${resourceId}`;
+          const offline = state.offlineResources.get(key);
+          if (!offline) continue;
+          if (impairedIds.has(resourceId)) continue;
+          const message =
+            `media_buy ${snap.media_buy_id} (status="${snap.status ?? 'unknown'}") references ${resourceType} ` +
+            `${resourceId} which is offline (status="${offline.status}", step "${offline.stepId}"), ` +
+            `but impairments[] does not list it. Spec: any offline resource referenced by a ` +
+            `non-terminal buy MUST appear in impairments[] (adcp#2859).`;
+          results.push({
+            passed: false,
+            description,
+            step_id: stepResult.step_id,
+            error: message,
+            hint: {
+              kind: 'impairment_coherence_violation',
+              violation: 'inverse',
+              message,
+              media_buy_id: snap.media_buy_id,
+              buy_step_id: snap.stepId,
+              resource_type: resourceType,
+              resource_id: resourceId,
+              resource_status: offline.status,
+              resource_step_id: offline.stepId,
+              impairments_count: snap.impairments.length,
+            },
+          });
+        }
       }
     }
 
@@ -1360,8 +1370,8 @@ registerOnce('impairment.coherence', {
           passed: true,
           description:
             'inverse coverage gap: offline resources observed for families the runner does not yet grade ' +
-            'on the inverse rule (creative is graded; audience/catalog_item/event_source are forward-only). ' +
-            `Observed: ${summary}. Tracked in adcontextprotocol/adcp#2860.`,
+            'on the inverse rule (creative and audience are graded; catalog_item and event_source are forward-only). ' +
+            `Observed: ${summary}.`,
           observation_count: 0,
         });
       }
@@ -1432,9 +1442,11 @@ function extractImpairmentObservations(
  * Extract every media-buy snapshot present on a step response. Walks
  * `create_media_buy` / `update_media_buy` (top-level buy object) and
  * `get_media_buys` (`media_buys[]` array). Returns each snapshot's
- * impairments[], health, status, and the set of `creative_id`s the buy
- * references through `packages[].creative_assignments[]` — used by the
- * inverse rule.
+ * impairments[], health, status, the set of `creative_id`s the buy
+ * references through `packages[].creative_assignments[]`, and the set of
+ * `audience_id`s referenced through `packages[].targeting_overlay.audience_include[]`.
+ * Both reference sets feed the inverse rule. `audience_exclude` is not
+ * collected — excluding an audience does not require it to be serviceable.
  */
 function extractBuySnapshots(task: string, body: Record<string, unknown>, stepId: string): BuySnapshot[] {
   const out: BuySnapshot[] = [];
@@ -1465,13 +1477,46 @@ function readBuySnapshot(record: Record<string, unknown>, stepId: string): BuySn
     impairments.push({ resource_type, resource_id });
   }
   const referencedCreativeIds = new Set<string>();
+  const referencedAudienceIds = new Set<string>();
   for (const pkg of asArray(record.packages)) {
     if (!isObject(pkg)) continue;
+    // Creative refs appear in two shapes on the wire:
+    //   - `core/package.json` → `creative_assignments[].creative_id` (used on
+    //     create_media_buy request/response, update_media_buy)
+    //   - `get-media-buys-response.json` → `creative_approvals[].creative_id`
+    //     (the snapshot shape — `creative_approvals` carries per-assignment
+    //     approval_status alongside the id)
+    // Walk both — sellers conformant to either schema surface the references
+    // we need for the inverse rule. (The SDK previously only walked the
+    // request shape, which made the inverse rule silent on conformant
+    // get_media_buys snapshots; tracked in adcp#2860.)
     for (const ca of asArray(pkg.creative_assignments)) {
       if (!isObject(ca)) continue;
       const cid = asString(ca.creative_id);
       if (cid) referencedCreativeIds.add(cid);
     }
+    for (const ca of asArray(pkg.creative_approvals)) {
+      if (!isObject(ca)) continue;
+      const cid = asString(ca.creative_id);
+      if (cid) referencedCreativeIds.add(cid);
+    }
+    // Audience refs: only `audience_include` counts as a hard dependency.
+    // `audience_exclude` doesn't — a suspended exclude-audience does not
+    // prevent the buy from serving.
+    const overlay = isObject(pkg.targeting_overlay) ? pkg.targeting_overlay : undefined;
+    if (overlay) {
+      for (const aid of asArray(overlay.audience_include)) {
+        if (typeof aid === 'string' && aid.length > 0) referencedAudienceIds.add(aid);
+      }
+    }
   }
-  return { media_buy_id, status, health, impairments, referencedCreativeIds, stepId };
+  return {
+    media_buy_id,
+    status,
+    health,
+    impairments,
+    referencedCreativeIds,
+    referencedAudienceIds,
+    stepId,
+  };
 }

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP SDK library version
  */
-export const LIBRARY_VERSION = '7.6.0';
+export const LIBRARY_VERSION = '7.7.0';
 
 /**
  * AdCP specification version this library is built for
@@ -60,10 +60,10 @@ export type AdcpVersion = (typeof COMPATIBLE_ADCP_VERSIONS)[number];
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '7.6.0',
+  library: '7.7.0',
   adcp: '3.0.12',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-05-17T17:46:11.373Z',
+  generatedAt: '2026-05-18T11:47:49.729Z',
 } as const;
 
 /**

--- a/test/lib/storyboard-default-invariants.test.js
+++ b/test/lib/storyboard-default-invariants.test.js
@@ -1723,6 +1723,187 @@ describe('default-invariants: impairment.coherence', () => {
     assert.equal(inverse.hint.media_buy_id, 'mb-1');
   });
 
+  // adcp#2860 — audience inverse traversal. Audience refs live at
+  // packages[*].targeting_overlay.audience_include[]; audience_exclude is
+  // NOT a dependency. Mirror the creative inverse coverage.
+
+  test('inverse: suspended audience referenced via audience_include without impairment fails', () => {
+    const out = run([
+      step({
+        step_id: 'suspend',
+        task: 'sync_audiences',
+        response: { audiences: [{ audience_id: 'aud-1', status: 'suspended' }] },
+      }),
+      step({
+        step_id: 'buy',
+        task: 'get_media_buys',
+        response: {
+          media_buys: [
+            mb('mb-1', {
+              status: 'active',
+              health: 'ok',
+              impairments: [],
+              packages: [{ targeting_overlay: { audience_include: ['aud-1'] } }],
+            }),
+          ],
+        },
+      }),
+    ]);
+    const inverse = out[1].output.find(o => o.hint && o.hint.violation === 'inverse');
+    assert.ok(inverse, 'audience inverse violation must produce a failing result');
+    assert.equal(inverse.passed, false);
+    assert.equal(inverse.hint.resource_type, 'audience');
+    assert.equal(inverse.hint.resource_id, 'aud-1');
+    assert.equal(inverse.hint.resource_status, 'suspended');
+    assert.equal(inverse.hint.resource_step_id, 'suspend');
+    assert.equal(inverse.hint.media_buy_id, 'mb-1');
+  });
+
+  test('inverse: suspended audience referenced via audience_include WITH impairment passes', () => {
+    const out = run([
+      step({
+        step_id: 'suspend',
+        task: 'sync_audiences',
+        response: { audiences: [{ audience_id: 'aud-1', status: 'suspended' }] },
+      }),
+      step({
+        step_id: 'buy',
+        task: 'get_media_buys',
+        response: {
+          media_buys: [
+            mb('mb-1', {
+              status: 'active',
+              health: 'impaired',
+              impairments: [{ resource_type: 'audience', resource_id: 'aud-1', package_ids: ['pkg-1'] }],
+              packages: [
+                {
+                  package_id: 'pkg-1',
+                  targeting_overlay: { audience_include: ['aud-1'] },
+                },
+              ],
+            }),
+          ],
+        },
+      }),
+    ]);
+    assert.ok(
+      out[1].output.every(o => o.passed),
+      `propagated impairment should pass; got ${JSON.stringify(out[1].output)}`
+    );
+  });
+
+  test('inverse: suspended audience listed under audience_exclude is NOT a dependency (no failure)', () => {
+    // audience_exclude doesn't require the audience to be serviceable —
+    // the buy still serves; users in the exclude list just aren't reached.
+    const out = run([
+      step({
+        step_id: 'suspend',
+        task: 'sync_audiences',
+        response: { audiences: [{ audience_id: 'aud-x', status: 'suspended' }] },
+      }),
+      step({
+        step_id: 'buy',
+        task: 'get_media_buys',
+        response: {
+          media_buys: [
+            mb('mb-1', {
+              status: 'active',
+              impairments: [],
+              packages: [{ targeting_overlay: { audience_exclude: ['aud-x'] } }],
+            }),
+          ],
+        },
+      }),
+    ]);
+    assert.ok(!out[1].output.some(o => o.hint && o.hint.violation === 'inverse'));
+  });
+
+  test('inverse: suspended audience on a terminal (completed) buy is silent', () => {
+    const out = run([
+      step({
+        step_id: 'suspend',
+        task: 'sync_audiences',
+        response: { audiences: [{ audience_id: 'aud-1', status: 'suspended' }] },
+      }),
+      step({
+        step_id: 'buy',
+        task: 'get_media_buys',
+        response: {
+          media_buys: [
+            mb('mb-1', {
+              status: 'completed',
+              impairments: [],
+              packages: [{ targeting_overlay: { audience_include: ['aud-1'] } }],
+            }),
+          ],
+        },
+      }),
+    ]);
+    assert.ok(!out[1].output.some(o => o.hint && o.hint.violation === 'inverse'));
+  });
+
+  test('inverse: audience recovered to ready clears the failing condition', () => {
+    const out = run([
+      step({
+        step_id: 'suspend',
+        task: 'sync_audiences',
+        response: { audiences: [{ audience_id: 'aud-1', status: 'suspended' }] },
+      }),
+      step({
+        step_id: 'recover',
+        task: 'sync_audiences',
+        response: { audiences: [{ audience_id: 'aud-1', status: 'ready' }] },
+      }),
+      step({
+        step_id: 'buy',
+        task: 'get_media_buys',
+        response: {
+          media_buys: [
+            mb('mb-1', {
+              status: 'active',
+              health: 'ok',
+              impairments: [],
+              packages: [{ targeting_overlay: { audience_include: ['aud-1'] } }],
+            }),
+          ],
+        },
+      }),
+    ]);
+    // After recovery, audience is no longer offline — inverse rule has
+    // nothing to require. Buy with no impairments and health 'ok' passes.
+    assert.ok(out[2].output.every(o => o.passed));
+  });
+
+  test('inverse: extractor reads creative refs from creative_approvals[] on get_media_buys (spec response shape)', () => {
+    // The get_media_buys-response.json package shape uses creative_approvals
+    // (not creative_assignments — that's the request-side shape from
+    // core/package.json). Without this, sellers conformant to the response
+    // schema would have the inverse rule grade silent.
+    const out = run([
+      step({
+        step_id: 'reject',
+        task: 'sync_creatives',
+        response: { creatives: [{ creative_id: 'cr-1', status: 'rejected' }] },
+      }),
+      step({
+        step_id: 'snapshot',
+        task: 'get_media_buys',
+        response: {
+          media_buys: [
+            mb('mb-1', {
+              status: 'active',
+              impairments: [],
+              packages: [{ creative_approvals: [{ creative_id: 'cr-1', approval_status: 'rejected' }] }],
+            }),
+          ],
+        },
+      }),
+    ]);
+    const inverse = out[1].output.find(o => o.hint && o.hint.violation === 'inverse');
+    assert.ok(inverse, 'inverse violation must fire when creative refs are exposed via creative_approvals');
+    assert.equal(inverse.hint.resource_id, 'cr-1');
+  });
+
   test('inverse: rejected creative on a terminal (completed) buy is silent', () => {
     const out = run([
       step({
@@ -2061,10 +2242,6 @@ describe('default-invariants: impairment.coherence', () => {
   // onEnd summary.
   for (const [family, syncStep] of [
     [
-      'audience',
-      s => ({ task: 'sync_audiences', response: { audiences: [{ audience_id: s.id, status: 'suspended' }] } }),
-    ],
-    [
       'catalog_item',
       s => ({
         task: 'sync_catalogs',
@@ -2092,7 +2269,6 @@ describe('default-invariants: impairment.coherence', () => {
       assert.equal(na.hint.resource_type, family);
       assert.equal(na.hint.resource_id, id);
       assert.equal(na.hint.resource_step_id, 'transition');
-      assert.match(na.hint.message, /adcp#2860/);
       assert.match(na.description, /resource_traversal_deferred/);
     });
   }
@@ -2103,13 +2279,13 @@ describe('default-invariants: impairment.coherence', () => {
     const out = run([
       step({
         step_id: 'first',
-        task: 'sync_audiences',
-        response: { audiences: [{ audience_id: 'aud-1', status: 'suspended' }] },
+        task: 'sync_catalogs',
+        response: { catalogs: [{ items: [{ item_id: 'item-1', status: 'withdrawn' }] }] },
       }),
       step({
         step_id: 'resync',
-        task: 'sync_audiences',
-        response: { audiences: [{ audience_id: 'aud-1', status: 'suspended' }] },
+        task: 'sync_catalogs',
+        response: { catalogs: [{ items: [{ item_id: 'item-1', status: 'withdrawn' }] }] },
       }),
     ]);
     const firstNa = out[0].output.filter(o => o.status === 'not_applicable');
@@ -2119,23 +2295,23 @@ describe('default-invariants: impairment.coherence', () => {
   });
 
   test('inverse: recovery then re-transition emits the hint twice (per transition)', () => {
-    // recover → re-suspend re-enters the offline state, which is a new
+    // recover → re-withdraw re-enters the offline state, which is a new
     // transition and re-fires the hint.
     const out = run([
       step({
-        step_id: 'suspend1',
-        task: 'sync_audiences',
-        response: { audiences: [{ audience_id: 'aud-1', status: 'suspended' }] },
+        step_id: 'withdraw1',
+        task: 'sync_catalogs',
+        response: { catalogs: [{ items: [{ item_id: 'item-1', status: 'withdrawn' }] }] },
       }),
       step({
         step_id: 'recover',
-        task: 'sync_audiences',
-        response: { audiences: [{ audience_id: 'aud-1', status: 'ready' }] },
+        task: 'sync_catalogs',
+        response: { catalogs: [{ items: [{ item_id: 'item-1', status: 'active' }] }] },
       }),
       step({
-        step_id: 'suspend2',
-        task: 'sync_audiences',
-        response: { audiences: [{ audience_id: 'aud-1', status: 'suspended' }] },
+        step_id: 'withdraw2',
+        task: 'sync_catalogs',
+        response: { catalogs: [{ items: [{ item_id: 'item-1', status: 'withdrawn' }] }] },
       }),
     ]);
     assert.equal(out[0].output.filter(o => o.status === 'not_applicable').length, 1);
@@ -2158,6 +2334,21 @@ describe('default-invariants: impairment.coherence', () => {
     );
   });
 
+  test('inverse: audience offline transition does NOT emit not_applicable (family is now graded, adcp#2860)', () => {
+    const out = run([
+      step({
+        step_id: 'suspend',
+        task: 'sync_audiences',
+        response: { audiences: [{ audience_id: 'aud-1', status: 'suspended' }] },
+      }),
+    ]);
+    assert.equal(
+      out[0].output.filter(o => o.status === 'not_applicable').length,
+      0,
+      'audience inverse rule is graded post-#2860 — no not_applicable hint'
+    );
+  });
+
   test('inverse: deferred-family hint coexists with a buy snapshot in the same step', () => {
     // When a sync_* step somehow also returns a media-buy snapshot (rare,
     // but the runner unions the two paths cleanly), the hint and the
@@ -2169,9 +2360,9 @@ describe('default-invariants: impairment.coherence', () => {
         response: { creatives: [{ creative_id: 'cr-1', status: 'rejected' }] },
       }),
       step({
-        step_id: 'aud',
-        task: 'sync_audiences',
-        response: { audiences: [{ audience_id: 'aud-1', status: 'suspended' }] },
+        step_id: 'cat',
+        task: 'sync_catalogs',
+        response: { catalogs: [{ items: [{ item_id: 'cat-1', status: 'withdrawn' }] }] },
       }),
       // Buy snapshot follows — forward rule should pass, inverse silent.
       step({
@@ -2181,15 +2372,15 @@ describe('default-invariants: impairment.coherence', () => {
           health: 'impaired',
           impairments: [
             { resource_type: 'creative', resource_id: 'cr-1' },
-            { resource_type: 'audience', resource_id: 'aud-1' },
+            { resource_type: 'catalog_item', resource_id: 'cat-1' },
           ],
           packages: [{ creative_assignments: [{ creative_id: 'cr-1' }] }],
         }),
       }),
     ]);
-    const audNa = out[1].output.find(o => o.status === 'not_applicable');
-    assert.ok(audNa, 'audience transition emits not_applicable');
-    assert.equal(audNa.hint.resource_type, 'audience');
+    const catNa = out[1].output.find(o => o.status === 'not_applicable');
+    assert.ok(catNa, 'catalog_item transition emits not_applicable');
+    assert.equal(catNa.hint.resource_type, 'catalog_item');
     assert.ok(
       out[2].output.every(o => o.passed),
       'buy snapshot grades pass on the forward leg'
@@ -2197,9 +2388,9 @@ describe('default-invariants: impairment.coherence', () => {
   });
 
   test('onEnd: surfaces partial inverse coverage when a deferred-family offline observation lands', () => {
-    // adcp#2860: inverse rule only grades creative today; audience /
-    // catalog_item / event_source references on a buy are forward-only.
-    // When the run actually observes an offline resource in one of those
+    // Inverse rule grades creative and audience; catalog_item /
+    // event_source references on a buy are forward-only. When the run
+    // actually observes an offline resource in one of those deferred
     // families, the deferral is materially relevant — onEnd emits a
     // second result naming the gap so storyboard authors see it at run
     // time instead of having to read the PR description.
@@ -2208,17 +2399,17 @@ describe('default-invariants: impairment.coherence', () => {
     spec.onStep(
       ctx,
       step({
-        step_id: 'aud',
-        task: 'sync_audiences',
-        response: { audiences: [{ audience_id: 'aud-1', status: 'suspended' }] },
+        step_id: 'cat',
+        task: 'sync_catalogs',
+        response: { catalogs: [{ items: [{ item_id: 'cat-1', status: 'withdrawn' }] }] },
       })
     );
     spec.onStep(
       ctx,
       step({
-        step_id: 'cat',
-        task: 'sync_catalogs',
-        response: { catalogs: [{ items: [{ item_id: 'cat-1', status: 'withdrawn' }] }] },
+        step_id: 'es',
+        task: 'sync_event_sources',
+        response: { event_sources: [{ event_source_id: 'es-1', health: { status: 'insufficient' } }] },
       })
     );
     spec.onStep(ctx, step({ step_id: 'buy', task: 'create_media_buy', response: mb('mb-1') }));
@@ -2227,9 +2418,26 @@ describe('default-invariants: impairment.coherence', () => {
     const notice = out[1];
     assert.equal(notice.passed, true);
     assert.match(notice.description, /inverse coverage gap/);
-    assert.match(notice.description, /audience \(1\)/);
     assert.match(notice.description, /catalog_item \(1\)/);
-    assert.match(notice.description, /adcp#2860/);
+    assert.match(notice.description, /event_source \(1\)/);
+  });
+
+  test('onEnd: no deferred-coverage notice when only audience offline observations land (now graded)', () => {
+    // Post-#2860 audience is graded on the inverse rule — an audience-only
+    // run does NOT trigger the deferred-coverage notice.
+    const ctx = makeCtx();
+    spec.onStart(ctx);
+    spec.onStep(
+      ctx,
+      step({
+        step_id: 'suspend',
+        task: 'sync_audiences',
+        response: { audiences: [{ audience_id: 'aud-1', status: 'suspended' }] },
+      })
+    );
+    spec.onStep(ctx, step({ step_id: 'buy', task: 'create_media_buy', response: mb('mb-1') }));
+    const out = spec.onEnd(ctx);
+    assert.equal(out.length, 1, 'no deferred-coverage notice expected');
   });
 
   test('onEnd: no deferred-coverage notice when only creative offline observations land', () => {


### PR DESCRIPTION
## Summary

Two gaps in `impairment.coherence` (the storyboard runner's cross-resource invariant) exposed by the dependency-impairment storyboard ([adcontextprotocol/adcp#2860](https://github.com/adcontextprotocol/adcp/issues/2860) / [adcontextprotocol/adcp#4677](https://github.com/adcontextprotocol/adcp/pull/4677)):

1. **Audience leg of the inverse rule is now graded.** `readBuySnapshot` extracts `referencedAudienceIds` from `packages[*].targeting_overlay.audience_include[]`; the inverse check is parameterised over both creative and audience reference sets. `audience` is removed from `INVERSE_DEFERRED_FAMILIES`.

2. **`creative_approvals[]` is now walked on buy snapshots.** Per `get-media-buys-response.json`, the response shape uses `creative_approvals[]` (not `creative_assignments[]` — that's the request shape from `core/package.json`). `readBuySnapshot` previously only walked the latter, so the inverse rule for creative graded silent on conformant `get_media_buys` snapshots. Both shapes are now walked.

`audience_exclude` is intentionally excluded from `referencedAudienceIds` — suspending an exclude-audience does not prevent the buy from serving.

## Why both halves are needed

The two changes are coupled by usage but independent in code. The audience traversal closes the spec-side gap that's been tracked in `INVERSE_DEFERRED_FAMILIES`'s JSDoc since adcp#2859 landed. The `creative_approvals[]` walk closes a latent SDK gap exposed when the dependency-impairment storyboard (adcp#4677) tried to grade against real `get_media_buys` snapshots and the inverse rule silently passed despite the buy being unable to surface the impairment (see also [adcp-client#1846](https://github.com/adcontextprotocol/adcp-client/issues/1846) — a related v6 SalesPlatform.syncCreatives gap that this fix surfaces).

## Test coverage

6 new tests in `test/lib/storyboard-default-invariants.test.js`:

- 5 audience inverse cases — graded propagation, exclude-doesn't-count-as-dep, terminal carve-out, recovery clears the failing condition, paired with health-iff
- 1 `creative_approvals[]` extraction case — verifies the inverse rule fires when refs come from the response shape

The existing deferred-family test loop moves audience out of the `not_applicable` group and asserts the graded behaviour. The onEnd partial-coverage summary still flags `catalog_item` and `event_source` — their per-buy reference shapes remain unstable (separate spec discussion).

## Behaviour change

- **No regression** for storyboards that already propagate impairments correctly — they previously graded `not_applicable` for audience offline observations and now grade `pass` instead.
- **New failure surface** for storyboards that observe an audience offline transition without propagating it to the buy snapshot — they previously graded silent (with a `not_applicable` notice) and now FAIL with a structured `impairment_coherence_violation` hint pointing at the offline audience.
- **New failure surface** for storyboards that exercise the creative inverse rule via `get_media_buys` responses (response shape) — they previously graded silent and now grade correctly.

## Test plan

- [x] `npm run build:lib` — clean
- [x] `npm run test:lib` — 6846 pass / 0 fail / 3 skipped (full lib suite, rebased onto main)
- [x] `node --test test/lib/storyboard-default-invariants.test.js` — 160 pass / 0 fail (all impairment.coherence tests)
- [x] `npm run format:check` — clean
- [x] CI: all green on draft (Test & Build, CodeQL, changeset, commitlint, IPR)

## Upstream gate

- ✅ adcp#4677 — dependency-impairment storyboard merged (2026-05-17)
- ✅ adcp#4733 — training-agent's `propagateCreativeImpairment` derivation merged (concurrent work that superseded the originally-referenced adcp#4737; canonical push-based path lives in `MediaBuyState.impairments`)
- ⏳ adcp#4674 — audience-track + catalog-item-track follow-up scenarios still open. The SDK code here doesn't depend on those storyboards existing; it makes them gradable when they land.

## Related

- adcontextprotocol/adcp#2860 / adcontextprotocol/adcp#4677 — dependency-impairment storyboard (consumer)
- adcontextprotocol/adcp#4674 — audience/catalog follow-up scenarios
- adcontextprotocol/adcp#4733 — training-agent derivation (consumer; superseded adcp#4737)
- adcontextprotocol/adcp-client#1846 — v6 SalesPlatform syncCreatives gap (exposed by this fix)
- adcontextprotocol/adcp-client#1819 — closed by 7.7.0 release; related force-adapter slots

🤖 Generated with [Claude Code](https://claude.com/claude-code)
