### PR TITLE
feat(server): expose ctx.input — un-destructured wire envelope on every v6 dispatch (#1842)

### DIFF
--- a/.changeset/ctx-input-wire-envelope-1842.md
+++ b/.changeset/ctx-input-wire-envelope-1842.md
@@ -1,0 +1,56 @@
+---
+'@adcp/sdk': minor
+---
+
+feat(server): expose `ctx.input` — un-destructured wire envelope on every v6 platform-method dispatch
+
+Closes the silent-drop bug audited in adcp-client#1842. The v6 framework wrapper at `src/lib/server/decisioning/runtime/from-platform.ts` destructures the payload array out of `sync_*` requests and forwards only that to the platform method, dropping spec-meaningful modifiers the typed signature doesn't model. Adopters look conformant on `/mcp` (their v5 handler reads the full envelope) and silently fail on `/sales/mcp` (the v6 path strips the field).
+
+**Surface bug.** Four platform methods drop spec-meaningful fields:
+
+| Method | Wire schema | Dropped fields (now reachable on `ctx.input`) |
+|---|---|---|
+| `sales.syncCreatives` / `creative.syncCreatives` | `sync_creatives_request` | `assignments[]`, `creative_ids[]`, `delete_missing`, `dry_run`, `validation_mode` |
+| `audiences.syncAudiences` | `sync_audiences_request` | `delete_missing` |
+| `accounts.upsert` (→ `sync_accounts`) | `sync_accounts_request` | `delete_missing`, `dry_run` |
+
+**Fix.** Two parallel fields, same shape: `RequestContext.input?: Readonly<Record<string, unknown>>` carries the request payload on the sales/creative/signals/governance/SI handler families; `ResolveContext.input?: Readonly<Record<string, unknown>>` carries it on the account-handler family (`syncAccounts`, `syncGovernance`, `listAccounts`, `reportUsage`, `getAccountFinancials`) — those use a separate context type because `accounts.resolve` produces the account rather than receiving it. Adopters who need a field the typed signature drops read it from `ctx.input`:
+
+```ts
+syncCreatives: async (creatives, ctx) => {
+  const wire = ctx.input as SyncCreativesRequest;
+  for (const a of wire.assignments ?? []) {
+    await this.bindCreativeToPackages(a.creative_id, a.package_ids);
+  }
+  if (wire.delete_missing) {
+    await this.deleteCreativesNotIn(creatives.map(c => c.creative_id));
+  }
+  // …
+}
+```
+
+**Why this shape:**
+
+1. **Envelope-shaped, not method-shaped.** Every drop is the same concept: "the method got the array; it didn't get the modifiers on the same request." One `ctx.input` covers every drop in the table above plus any future field the SDK doesn't yet model.
+2. **Additive, non-breaking.** Adopters who don't read `ctx.input` keep working; adopters who need the dropped fields opt in. No signature churn.
+3. **Composes with hydrate seams.** `hydrateForTool` / `hydratePackagesWithProducts` write *to* `params`; `ctx.input` reads *from* the unmodified wire envelope. Both are present on every dispatch.
+
+**Same reference as the typed payload arg, not a snapshot.** `ctx.input` is the request payload as the platform method sees it. It is set BEFORE the framework's auto-hydrate seams (`hydratePackagesWithProducts`, `hydrateForTool`) run, but those seams mutate the same object in place. By the time the platform method's body executes, `ctx.input` and the first positional arg are the same reference and both reflect framework hydration. JSDoc on `RequestContext.input` calls this out so adopters don't write logic that assumes `ctx.input` is a frozen pre-hydration snapshot.
+
+**Hoist asymmetry.** For methods that hoist a field to a positional arg (e.g. `updateMediaBuy(media_buy_id, patch, ctx)` hoists `media_buy_id` out of the envelope), that field is still present at the top level of `ctx.input` — the wire envelope is hoist-included, NOT residual. Adopters should prefer the positional arg for fields present on both, and reach for `ctx.input` only for fields the typed signature drops.
+
+**Typed as unknown.** Matches the `comply_test_controller` bridge precedent (`TestControllerBridgeContext.input: Record<string, unknown>` at `src/lib/server/test-controller-bridge.ts:198`) and avoids coupling adopters to specific schema versions. Cast at the read site or run a runtime validator — the framework already validated the envelope on inbound; re-validating on read isn't the framework's job.
+
+**Optional in the type signature** so adopters constructing ad-hoc `RequestContext` / `ResolveContext` for unit tests aren't forced to set it. The framework always sets it on real dispatches.
+
+**Security note.** `ctx.input` is buyer-controlled and may carry secrets — mutating-tool envelopes include `push_notification_config.token` (the buyer's webhook-signature secret); free-text fields (`brief`, `message`, creative snippets) are attacker-controlled. Do NOT log `ctx.input` wholesale — read named fields. When templating into LLM prompts, validate or fence rather than string-interpolating. JSDoc carries the warning at the read site.
+
+**Test coverage:** 5 regression tests in `test/server-decisioning-ctx-input-wire-envelope.test.js`:
+
+- `sync_creatives` end-to-end with `assignments[]`, `delete_missing`, `dry_run`, `validation_mode` all surviving to the platform method.
+- `sync_audiences` with `delete_missing`.
+- `sync_accounts` with `delete_missing` + `dry_run` — proves the `ResolveContext` path also carries `ctx.input` (account handlers route through a separate context type).
+- `update_media_buy` proving the hoist asymmetry — `media_buy_id` is the positional first arg AND still present on `ctx.input`.
+- `get_products` proving the universal pattern works on methods that already pass `params` whole.
+
+**Adopter migration.** No code change required to keep working. Adopters who already implement `assignments[]` / `delete_missing` / `dry_run` / `validation_mode` via a v5 handler (and want to serve the same wire contract on `/sales/mcp`) read those fields from `ctx.input` in the v6 platform method.

--- a/src/lib/server/decisioning/account.ts
+++ b/src/lib/server/decisioning/account.ts
@@ -300,6 +300,33 @@ export interface ResolveContext {
    * registry returns null for the request's credential.
    */
   agent?: BuyerAgent;
+  /**
+   * Un-destructured wire request envelope. Set by the framework so account
+   * tool handlers (`syncAccounts`, `syncGovernance`, `listAccounts`,
+   * `reportUsage`, `getAccountFinancials`) can read request fields the
+   * typed signature doesn't model — e.g. `sync_accounts.delete_missing`
+   * and `sync_accounts.dry_run`, which the framework destructures the
+   * payload array out of before calling the handler.
+   *
+   * Same shape and read-site cast pattern as `RequestContext.input` (see
+   * `decisioning/context.ts`). Same caveats:
+   *
+   * - **Identical reference to the typed payload arg.** This is the same
+   *   request body object the platform method's first positional arg
+   *   projects from. Framework auto-hydrate seams mutate this object
+   *   before the platform method runs; treat fields the buyer sent as
+   *   authoritative, but expect framework-injected entities (e.g.
+   *   hydrated product / media-buy refs) to be visible here too.
+   * - **Buyer-controlled untrusted data.** Free-text fields (`brief`,
+   *   `message`, creative snippets, etc.) are attacker-controlled.
+   *   Don't log `ctx.input` wholesale — secret fields like
+   *   `push_notification_config.token` are present on mutating requests.
+   *   When templating into LLM prompts, validate or fence the field
+   *   rather than string-interpolating.
+   *
+   * @public
+   */
+  input?: Readonly<Record<string, unknown>>;
 }
 
 /**

--- a/src/lib/server/decisioning/context.ts
+++ b/src/lib/server/decisioning/context.ts
@@ -102,6 +102,72 @@ export interface RequestContext<TAccount = Account> {
   ctxMetadata?: CtxMetadataAccessor;
 
   /**
+   * Request payload as the platform method sees it. The framework sets
+   * this on every v6 platform-method dispatch so methods can read request
+   * fields the typed signature doesn't model.
+   *
+   * **Why it exists.** Several `sync_*` request schemas carry modifier
+   * fields (`assignments[]` on `sync_creatives`; `delete_missing`,
+   * `dry_run`, `validation_mode` on the same; `delete_missing` on
+   * `sync_audiences` and `sync_accounts`) that the platform method's
+   * typed signature drops — the framework destructures the payload array
+   * and passes only that. Without `ctx.input`, adopters implementing
+   * those fields at the wire layer would see them silently disappear on
+   * the `/sales/mcp` route while working on `/mcp` — a silent-conformance
+   * trap. Read the field from `ctx.input` and the modifier survives to
+   * the adapter.
+   *
+   * **Same reference as the typed payload arg, not a snapshot.** `ctx.input`
+   * is set BEFORE the framework's auto-hydrate seams
+   * (`hydratePackagesWithProducts`, `hydrateForTool`) run, but those
+   * seams mutate the same object in place. By the time the platform
+   * method's body executes, `ctx.input` and the first positional arg are
+   * the same reference and both reflect framework hydration. Fields the
+   * buyer sent are authoritative; framework-injected entities
+   * (`pkg.product`, `req.media_buy`) are present too — distinguish by
+   * field shape, not by which path you read from.
+   *
+   * **For methods that hoist a field to a positional arg** (e.g.
+   * `updateMediaBuy(media_buy_id, patch, ctx)` hoists `media_buy_id` out
+   * of the wire envelope), that field is still present at the top level
+   * of `ctx.input`. `ctx.input` is NOT "what the method didn't get" — it
+   * is the full envelope, hoist included. Prefer reading any field
+   * present on both the positional arg and `ctx.input` from the
+   * positional arg; reach for `ctx.input` only for fields the typed
+   * signature drops.
+   *
+   * **Typed as unknown** to match the `comply_test_controller` bridge
+   * precedent (`TestControllerBridgeContext.input`) and to avoid coupling
+   * adopters to specific schema versions. Cast at the read site:
+   *
+   * ```ts
+   * syncCreatives: async (creatives, ctx) => {
+   *   const wire = ctx.input as SyncCreativesRequest;
+   *   if (wire.delete_missing) { ... }
+   *   for (const assignment of wire.assignments ?? []) { ... }
+   * }
+   * ```
+   *
+   * **Security — `ctx.input` is buyer-controlled and may carry secrets.**
+   * Mutating-tool envelopes can include `push_notification_config.token`
+   * (the buyer's webhook-signature secret); `sync_*` requests can carry
+   * `ctx_metadata` blobs the adopter persisted on a prior turn. Do NOT
+   * log `ctx.input` wholesale — read named fields. Free-text fields
+   * (`brief` on `getProducts`, `message` on `si_send_message`, creative
+   * snippets, etc.) are attacker-controlled; when templating into LLM
+   * prompts, validate or fence — don't string-interpolate. See
+   * `docs/guides/CTX-METADATA-SAFETY.md` for the broader policy on
+   * buyer-controlled inputs.
+   *
+   * **Optional in the type signature** so adopters constructing ad-hoc
+   * `RequestContext` for unit tests aren't forced to set it; the
+   * framework always sets it on real dispatches.
+   *
+   * @public
+   */
+  input?: Readonly<Record<string, unknown>>;
+
+  /**
    * Hydrated typed recipes (`product_id -> Recipe`) for proposal-mode
    * dispatch. Populated by the framework's v1.5 ProposalManager seams:
    *

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -2719,13 +2719,20 @@ function bucketWebhookError(msg: string): string {
 /**
  * Per-server `ctxFor` builder. `createAdcpServerFromPlatform` constructs
  * one closure per server (capturing `opts.ctxMetadata` if wired) and
- * threads it into each handler-builder. Handler bodies invoke `ctxFor(ctx)`
- * at request time to derive the per-call `RequestContext`.
+ * threads it into each handler-builder. Handler bodies invoke
+ * `ctxFor(ctx, params)` at request time to derive the per-call
+ * `RequestContext`. The `params` argument is the un-destructured wire
+ * envelope; it lands on `RequestContext.input` so platform methods can
+ * read request fields the typed signature doesn't model (`assignments[]`
+ * on `sync_creatives`, `delete_missing` on `sync_audiences`, etc.).
  */
-type CtxForFn = (handlerCtx: HandlerContext<Account>) => RequestContext<Account>;
+type CtxForFn = (
+  handlerCtx: HandlerContext<Account>,
+  input?: Readonly<Record<string, unknown>>
+) => RequestContext<Account>;
 
 function makeCtxFor(ctxMetadataStore?: CtxMetadataStore): CtxForFn {
-  return handlerCtx => buildRequestContext(handlerCtx, ctxMetadataStore);
+  return (handlerCtx, input) => buildRequestContext(handlerCtx, ctxMetadataStore, input);
 }
 
 /**
@@ -2746,11 +2753,16 @@ function makeCtxFor(ctxMetadataStore?: CtxMetadataStore): CtxForFn {
  * `authInfo` / `agent` keys absent rather than `undefined` — adopters
  * can use `'authInfo' in ctx` as a presence check.
  */
-function toResolveCtx(ctx: { authInfo?: ResolvedAuthInfo; agent?: BuyerAgent }, toolName: string): ResolveContext {
+function toResolveCtx(
+  ctx: { authInfo?: ResolvedAuthInfo; agent?: BuyerAgent },
+  toolName: string,
+  input?: Readonly<Record<string, unknown>>
+): ResolveContext {
   return {
     ...(ctx.authInfo !== undefined && { authInfo: ctx.authInfo }),
     toolName,
     ...(ctx.agent != null && { agent: ctx.agent }),
+    ...(input != null && { input }),
   };
 }
 
@@ -3444,7 +3456,7 @@ function buildMediaBuyHandlers<P extends DecisioningPlatform<any, any>>(
   return {
     ...((sales?.getProducts || proposalManager) && {
       getProducts: async (params, ctx) => {
-        const reqCtx = ctxFor(ctx);
+        const reqCtx = ctxFor(ctx, params);
         // v1.5 seam: intercept refine[i].action='finalize' before
         // dispatching to the manager / sales. When the framework
         // commits the proposal inline, project the response directly.
@@ -3550,7 +3562,7 @@ function buildMediaBuyHandlers<P extends DecisioningPlatform<any, any>>(
 
     ...(sales?.createMediaBuy && {
       createMediaBuy: async (params, ctx) => {
-        const reqCtx = ctxFor(ctx);
+        const reqCtx = ctxFor(ctx, params);
         // Auto-hydrate: walk `params.packages`, attach the full Product object
         // (including `ctx_metadata`) at `pkg.product`. Publisher reads
         // `pkg.product.format_ids`, `pkg.product.ctx_metadata?.gam?.ad_unit_ids`
@@ -3640,7 +3652,7 @@ function buildMediaBuyHandlers<P extends DecisioningPlatform<any, any>>(
 
     ...(sales?.updateMediaBuy && {
       updateMediaBuy: async (params, ctx) => {
-        const reqCtx = ctxFor(ctx);
+        const reqCtx = ctxFor(ctx, params);
         // `media_buy_id` is required on the wire schema, but `validation: 'off'`
         // mode skips the schema parse — guard at the seam so platform code can
         // trust the value rather than re-checking. Also catches buyers calling
@@ -3716,7 +3728,7 @@ function buildMediaBuyHandlers<P extends DecisioningPlatform<any, any>>(
     }),
 
     syncCreatives: async (params, ctx) => {
-      const reqCtx = ctxFor(ctx);
+      const reqCtx = ctxFor(ctx, params);
       const creatives = params.creatives ?? [];
       if (!sales?.syncCreatives) {
         return adcpError('UNSUPPORTED_FEATURE', {
@@ -3749,7 +3761,7 @@ function buildMediaBuyHandlers<P extends DecisioningPlatform<any, any>>(
 
     ...(sales?.getMediaBuyDelivery && {
       getMediaBuyDelivery: async (params, ctx) => {
-        const reqCtx = ctxFor(ctx);
+        const reqCtx = ctxFor(ctx, params);
         // v1.5 seam: hydrate ctx.recipes for delivery reads. Per
         // Resolutions §5, recipe-driven delivery aggregation needs the
         // same recipe view the originating createMediaBuy used.
@@ -3802,7 +3814,7 @@ function buildMediaBuyHandlers<P extends DecisioningPlatform<any, any>>(
     // `sales.getMediaBuys is not a function`.
     ...(sales?.getMediaBuys && {
       getMediaBuys: async (params, ctx) => {
-        const reqCtx = ctxFor(ctx);
+        const reqCtx = ctxFor(ctx, params);
         return projectSync(
           async () => {
             const result = await sales!.getMediaBuys!(params, reqCtx);
@@ -3830,7 +3842,7 @@ function buildMediaBuyHandlers<P extends DecisioningPlatform<any, any>>(
     }),
     ...(sales?.providePerformanceFeedback && {
       providePerformanceFeedback: async (params, ctx) => {
-        const reqCtx = ctxFor(ctx);
+        const reqCtx = ctxFor(ctx, params);
         // Auto-hydrate `req.media_buy` from the prior createMediaBuy /
         // getMediaBuys store entry, plus `req.creative` when the buyer
         // scoped feedback to a specific creative, plus `req.package`
@@ -3848,7 +3860,7 @@ function buildMediaBuyHandlers<P extends DecisioningPlatform<any, any>>(
     }),
     ...(sales?.listCreativeFormats && {
       listCreativeFormats: async (params, ctx) => {
-        const reqCtx = ctxFor(ctx);
+        const reqCtx = ctxFor(ctx, params);
         return projectSync(
           () => sales!.listCreativeFormats!(params, reqCtx),
           r => r
@@ -3857,7 +3869,7 @@ function buildMediaBuyHandlers<P extends DecisioningPlatform<any, any>>(
     }),
     ...(sales?.listCreatives && {
       listCreatives: async (params, ctx) => {
-        const reqCtx = ctxFor(ctx);
+        const reqCtx = ctxFor(ctx, params);
         return projectSync(
           async () => {
             const result = await sales!.listCreatives!(params, reqCtx);
@@ -3920,7 +3932,7 @@ function buildCreativeHandlers<P extends DecisioningPlatform<any, any>>(
 
   return {
     buildCreative: async (params, ctx) => {
-      const reqCtx = ctxFor(ctx);
+      const reqCtx = ctxFor(ctx, params);
       return projectSync(
         () => creative.buildCreative(params, reqCtx),
         ret => projectBuildCreativeReturn(ret)
@@ -3935,7 +3947,7 @@ function buildCreativeHandlers<P extends DecisioningPlatform<any, any>>(
             'Add `previewCreative(req, ctx)` to your CreativeBuilderPlatform / CreativeAdServerPlatform literal.',
         });
       }
-      const reqCtx = ctxFor(ctx);
+      const reqCtx = ctxFor(ctx, params);
       return projectSync(
         () => (creative as CreativeBuilderPlatform).previewCreative!(params, reqCtx),
         preview => preview
@@ -3956,7 +3968,7 @@ function buildCreativeHandlers<P extends DecisioningPlatform<any, any>>(
             'or delegate via `capabilities.creative_agents`.',
         });
       }
-      const reqCtx = ctxFor(ctx);
+      const reqCtx = ctxFor(ctx, params);
       return projectSync(
         () => (creative as CreativeBuilderPlatform).listCreativeFormats!(params, reqCtx),
         r => r
@@ -3970,7 +3982,7 @@ function buildCreativeHandlers<P extends DecisioningPlatform<any, any>>(
     // buildAccountHandlers — see comment at line 4544.
     ...(creative.syncCreatives != null && {
       syncCreatives: async (params, ctx) => {
-        const reqCtx = ctxFor(ctx);
+        const reqCtx = ctxFor(ctx, params);
         const creatives = params.creatives ?? [];
         return projectSync(
           async () => {
@@ -4007,7 +4019,7 @@ function buildCreativeHandlers<P extends DecisioningPlatform<any, any>>(
     ...('listCreatives' in creative &&
       (creative as CreativeAdServerPlatform).listCreatives != null && {
         listCreatives: async (params, ctx) => {
-          const reqCtx = ctxFor(ctx);
+          const reqCtx = ctxFor(ctx, params);
           return projectSync(
             async () => {
               const result = await (creative as CreativeAdServerPlatform).listCreatives(params, reqCtx);
@@ -4028,7 +4040,7 @@ function buildCreativeHandlers<P extends DecisioningPlatform<any, any>>(
     ...('getCreativeDelivery' in creative &&
       (creative as CreativeAdServerPlatform).getCreativeDelivery != null && {
         getCreativeDelivery: async (params, ctx) => {
-          const reqCtx = ctxFor(ctx);
+          const reqCtx = ctxFor(ctx, params);
           return projectSync(
             async () => {
               const result = await (creative as CreativeAdServerPlatform).getCreativeDelivery(params, reqCtx);
@@ -4065,7 +4077,7 @@ function buildEventTrackingHandlers<P extends DecisioningPlatform<any, any>>(
 
   if (audiences) {
     handlers.syncAudiences = async (params, ctx) => {
-      const reqCtx = ctxFor(ctx);
+      const reqCtx = ctxFor(ctx, params);
       const audienceList = (params.audiences ?? []) as Audience[];
       return projectSync(
         () => audiences.syncAudiences(audienceList, reqCtx),
@@ -4076,7 +4088,7 @@ function buildEventTrackingHandlers<P extends DecisioningPlatform<any, any>>(
 
   if (sales?.syncCatalogs) {
     handlers.syncCatalogs = async (params, ctx) => {
-      const reqCtx = ctxFor(ctx);
+      const reqCtx = ctxFor(ctx, params);
       return projectSync(
         () => sales.syncCatalogs!(params, reqCtx),
         r => r
@@ -4086,7 +4098,7 @@ function buildEventTrackingHandlers<P extends DecisioningPlatform<any, any>>(
 
   if (sales?.logEvent) {
     handlers.logEvent = async (params, ctx) => {
-      const reqCtx = ctxFor(ctx);
+      const reqCtx = ctxFor(ctx, params);
       return projectSync(
         () => sales.logEvent!(params, reqCtx),
         r => r
@@ -4096,7 +4108,7 @@ function buildEventTrackingHandlers<P extends DecisioningPlatform<any, any>>(
 
   if (sales?.syncEventSources) {
     handlers.syncEventSources = async (params, ctx) => {
-      const reqCtx = ctxFor(ctx);
+      const reqCtx = ctxFor(ctx, params);
       return projectSync(
         () => sales.syncEventSources!(params, reqCtx),
         r => r
@@ -4117,7 +4129,7 @@ function buildSignalsHandlers<P extends DecisioningPlatform<any, any>>(
   if (!signals) return undefined;
   return {
     getSignals: async (params, ctx) => {
-      const reqCtx = ctxFor(ctx);
+      const reqCtx = ctxFor(ctx, params);
       return projectSync(
         async () => {
           const result = await signals.getSignals(params, reqCtx);
@@ -4147,7 +4159,7 @@ function buildSignalsHandlers<P extends DecisioningPlatform<any, any>>(
       );
     },
     activateSignal: async (params, ctx) => {
-      const reqCtx = ctxFor(ctx);
+      const reqCtx = ctxFor(ctx, params);
       // Auto-hydrate `req.signal` from the prior getSignals store entry —
       // publisher reads pricing options, agent segment id, ctx_metadata
       // directly without the buyer round-tripping the full signal object.
@@ -4188,14 +4200,14 @@ function buildSponsoredIntelligenceHandlers<P extends DecisioningPlatform<any, a
   if (!si) return undefined;
   return {
     getOffering: async (params, ctx) => {
-      const reqCtx = ctxFor(ctx);
+      const reqCtx = ctxFor(ctx, params);
       return projectSync(
         () => si.getOffering(params, reqCtx),
         r => r
       );
     },
     initiateSession: async (params, ctx) => {
-      const reqCtx = ctxFor(ctx);
+      const reqCtx = ctxFor(ctx, params);
       return projectSync(
         async () => {
           const result = await si.initiateSession(params, reqCtx);
@@ -4244,7 +4256,7 @@ function buildSponsoredIntelligenceHandlers<P extends DecisioningPlatform<any, a
       );
     },
     sendMessage: async (params, ctx) => {
-      const reqCtx = ctxFor(ctx);
+      const reqCtx = ctxFor(ctx, params);
       // Auto-hydrate `req.session` from the stored si_session record. The
       // schema-driven hydrator reads `params.session_id` and attaches the
       // stored session at `params.session` (via the `_id` → strip
@@ -4256,7 +4268,7 @@ function buildSponsoredIntelligenceHandlers<P extends DecisioningPlatform<any, a
       );
     },
     terminateSession: async (params, ctx) => {
-      const reqCtx = ctxFor(ctx);
+      const reqCtx = ctxFor(ctx, params);
       await hydrateForTool(ctxMetadataStore, reqCtx.account?.id, 'si_terminate_session', params, logger);
       return projectSync(
         async () => {
@@ -4307,14 +4319,14 @@ function buildBrandRightsHandlers<P extends DecisioningPlatform<any, any>>(
   if (!br) return undefined;
   return {
     getBrandIdentity: async (params, ctx) => {
-      const reqCtx = ctxFor(ctx);
+      const reqCtx = ctxFor(ctx, params);
       return projectSync(
         () => br.getBrandIdentity(params, reqCtx),
         r => r
       );
     },
     getRights: async (params, ctx) => {
-      const reqCtx = ctxFor(ctx);
+      const reqCtx = ctxFor(ctx, params);
       return projectSync(
         async () => {
           const result = await br.getRights(params, reqCtx);
@@ -4340,7 +4352,7 @@ function buildBrandRightsHandlers<P extends DecisioningPlatform<any, any>>(
     // PendingApproval arm rides the buyer's `push_notification_config` webhook
     // (the spec doesn't define a polling tool for `acquire_rights`).
     acquireRights: async (params, ctx) => {
-      const reqCtx = ctxFor(ctx);
+      const reqCtx = ctxFor(ctx, params);
       // Auto-hydrate `req.rights` from the prior getRights catalog entry.
       // Publisher reads selected pricing option + ctx_metadata directly.
       // Schema-driven via `x-entity` (#1109); destination field stays at
@@ -4365,7 +4377,7 @@ function buildBrandRightsHandlers<P extends DecisioningPlatform<any, any>>(
     // the immediate response carries `implementation_date: null` to
     // signal pending state.
     updateRights: async (params, ctx) => {
-      const reqCtx = ctxFor(ctx);
+      const reqCtx = ctxFor(ctx, params);
       await hydrateForTool(ctxMetadataStore, reqCtx.account?.id, 'update_rights', params, logger);
       return projectSync(
         () => br.updateRights(params, reqCtx),
@@ -4389,28 +4401,28 @@ function buildGovernanceHandlers<P extends DecisioningPlatform<any, any>>(
 
   if (cg) {
     handlers.checkGovernance = async (params, ctx) => {
-      const reqCtx = ctxFor(ctx);
+      const reqCtx = ctxFor(ctx, params);
       return projectSync(
         () => cg.checkGovernance(params, reqCtx),
         r => r
       );
     };
     handlers.syncPlans = async (params, ctx) => {
-      const reqCtx = ctxFor(ctx);
+      const reqCtx = ctxFor(ctx, params);
       return projectSync(
         () => cg.syncPlans(params, reqCtx),
         r => r
       );
     };
     handlers.reportPlanOutcome = async (params, ctx) => {
-      const reqCtx = ctxFor(ctx);
+      const reqCtx = ctxFor(ctx, params);
       return projectSync(
         () => cg.reportPlanOutcome(params, reqCtx),
         r => r
       );
     };
     handlers.getPlanAuditLogs = async (params, ctx) => {
-      const reqCtx = ctxFor(ctx);
+      const reqCtx = ctxFor(ctx, params);
       return projectSync(
         () => cg.getPlanAuditLogs(params, reqCtx),
         r => r
@@ -4420,35 +4432,35 @@ function buildGovernanceHandlers<P extends DecisioningPlatform<any, any>>(
 
   if (pl) {
     handlers.createPropertyList = async (params, ctx) => {
-      const reqCtx = ctxFor(ctx);
+      const reqCtx = ctxFor(ctx, params);
       return projectSync(
         () => pl.createPropertyList(params, reqCtx),
         r => r
       );
     };
     handlers.updatePropertyList = async (params, ctx) => {
-      const reqCtx = ctxFor(ctx);
+      const reqCtx = ctxFor(ctx, params);
       return projectSync(
         () => pl.updatePropertyList(params, reqCtx),
         r => r
       );
     };
     handlers.getPropertyList = async (params, ctx) => {
-      const reqCtx = ctxFor(ctx);
+      const reqCtx = ctxFor(ctx, params);
       return projectSync(
         () => pl.getPropertyList(params, reqCtx),
         r => r
       );
     };
     handlers.listPropertyLists = async (params, ctx) => {
-      const reqCtx = ctxFor(ctx);
+      const reqCtx = ctxFor(ctx, params);
       return projectSync(
         () => pl.listPropertyLists(params, reqCtx),
         r => r
       );
     };
     handlers.deletePropertyList = async (params, ctx) => {
-      const reqCtx = ctxFor(ctx);
+      const reqCtx = ctxFor(ctx, params);
       return projectSync(
         () => pl.deletePropertyList(params, reqCtx),
         r => r
@@ -4458,35 +4470,35 @@ function buildGovernanceHandlers<P extends DecisioningPlatform<any, any>>(
 
   if (cl) {
     handlers.createCollectionList = async (params, ctx) => {
-      const reqCtx = ctxFor(ctx);
+      const reqCtx = ctxFor(ctx, params);
       return projectSync(
         () => cl.createCollectionList(params, reqCtx),
         r => r
       );
     };
     handlers.updateCollectionList = async (params, ctx) => {
-      const reqCtx = ctxFor(ctx);
+      const reqCtx = ctxFor(ctx, params);
       return projectSync(
         () => cl.updateCollectionList(params, reqCtx),
         r => r
       );
     };
     handlers.getCollectionList = async (params, ctx) => {
-      const reqCtx = ctxFor(ctx);
+      const reqCtx = ctxFor(ctx, params);
       return projectSync(
         () => cl.getCollectionList(params, reqCtx),
         r => r
       );
     };
     handlers.listCollectionLists = async (params, ctx) => {
-      const reqCtx = ctxFor(ctx);
+      const reqCtx = ctxFor(ctx, params);
       return projectSync(
         () => cl.listCollectionLists(params, reqCtx),
         r => r
       );
     };
     handlers.deleteCollectionList = async (params, ctx) => {
-      const reqCtx = ctxFor(ctx);
+      const reqCtx = ctxFor(ctx, params);
       return projectSync(
         () => cl.deleteCollectionList(params, reqCtx),
         r => r
@@ -4496,42 +4508,42 @@ function buildGovernanceHandlers<P extends DecisioningPlatform<any, any>>(
 
   if (cs) {
     handlers.listContentStandards = async (params, ctx) => {
-      const reqCtx = ctxFor(ctx);
+      const reqCtx = ctxFor(ctx, params);
       return projectSync(
         () => cs.listContentStandards(params, reqCtx),
         r => r
       );
     };
     handlers.getContentStandards = async (params, ctx) => {
-      const reqCtx = ctxFor(ctx);
+      const reqCtx = ctxFor(ctx, params);
       return projectSync(
         () => cs.getContentStandards(params, reqCtx),
         r => r
       );
     };
     handlers.createContentStandards = async (params, ctx) => {
-      const reqCtx = ctxFor(ctx);
+      const reqCtx = ctxFor(ctx, params);
       return projectSync(
         () => cs.createContentStandards(params, reqCtx),
         r => r
       );
     };
     handlers.updateContentStandards = async (params, ctx) => {
-      const reqCtx = ctxFor(ctx);
+      const reqCtx = ctxFor(ctx, params);
       return projectSync(
         () => cs.updateContentStandards(params, reqCtx),
         r => r
       );
     };
     handlers.calibrateContent = async (params, ctx) => {
-      const reqCtx = ctxFor(ctx);
+      const reqCtx = ctxFor(ctx, params);
       return projectSync(
         () => cs.calibrateContent(params, reqCtx),
         r => r
       );
     };
     handlers.validateContentDelivery = async (params, ctx) => {
-      const reqCtx = ctxFor(ctx);
+      const reqCtx = ctxFor(ctx, params);
       return projectSync(
         () => cs.validateContentDelivery(params, reqCtx),
         r => r
@@ -4539,7 +4551,7 @@ function buildGovernanceHandlers<P extends DecisioningPlatform<any, any>>(
     };
     if (cs.getMediaBuyArtifacts) {
       handlers.getMediaBuyArtifacts = async (params, ctx) => {
-        const reqCtx = ctxFor(ctx);
+        const reqCtx = ctxFor(ctx, params);
         return projectSync(
           () => cs.getMediaBuyArtifacts!(params, reqCtx),
           r => r
@@ -4548,7 +4560,7 @@ function buildGovernanceHandlers<P extends DecisioningPlatform<any, any>>(
     }
     if (cs.getCreativeFeatures) {
       handlers.getCreativeFeatures = async (params, ctx) => {
-        const reqCtx = ctxFor(ctx);
+        const reqCtx = ctxFor(ctx, params);
         return projectSync(
           () => cs.getCreativeFeatures!(params, reqCtx),
           r => r
@@ -4581,7 +4593,7 @@ function buildAccountHandlers<P extends DecisioningPlatform<any, any>>(
   if (accounts.upsert) {
     handlers.syncAccounts = async (params, ctx) => {
       const refs = (params.accounts ?? []) as AccountReference[];
-      const resolveCtx = toResolveCtx(ctx, 'sync_accounts');
+      const resolveCtx = toResolveCtx(ctx, 'sync_accounts', params);
       return projectSync(
         () => accounts.upsert!(refs, resolveCtx),
         rows => ({ accounts: rows.map(toWireSyncAccountRow) })
@@ -4592,7 +4604,7 @@ function buildAccountHandlers<P extends DecisioningPlatform<any, any>>(
   if (accounts.syncGovernance) {
     handlers.syncGovernance = async (params, ctx) => {
       const entries = params.accounts as SyncGovernanceRequest['accounts'];
-      const resolveCtx = toResolveCtx(ctx, 'sync_governance');
+      const resolveCtx = toResolveCtx(ctx, 'sync_governance', params);
       return projectSync(
         () => accounts.syncGovernance!(entries, resolveCtx),
         rows => ({ accounts: rows.map(toWireSyncGovernanceRow) })
@@ -4603,7 +4615,7 @@ function buildAccountHandlers<P extends DecisioningPlatform<any, any>>(
   if (accounts.list) {
     handlers.listAccounts = async (params, ctx) => {
       const filter = params as Parameters<NonNullable<typeof accounts.list>>[0];
-      const resolveCtx = toResolveCtx(ctx, 'list_accounts');
+      const resolveCtx = toResolveCtx(ctx, 'list_accounts', params);
       // Wrap in projectSync so adopter `throw new AdcpError('PERMISSION_DENIED', ...)`
       // from the list impl projects to the structured wire envelope rather
       // than falling through to the framework's `SERVICE_UNAVAILABLE` mapping.
@@ -4619,7 +4631,7 @@ function buildAccountHandlers<P extends DecisioningPlatform<any, any>>(
 
   if (accounts.reportUsage) {
     handlers.reportUsage = async (params, ctx) => {
-      const resolveCtx = toResolveCtx(ctx, 'report_usage');
+      const resolveCtx = toResolveCtx(ctx, 'report_usage', params);
       return projectSync(
         () => accounts.reportUsage!(params, resolveCtx),
         r => r
@@ -4633,7 +4645,7 @@ function buildAccountHandlers<P extends DecisioningPlatform<any, any>>(
       // platform method runs. Adopters fronting an upstream platform read
       // tokens / upstream IDs off `ctx.account.ctx_metadata` without
       // having to re-resolve from `params.account`.
-      const resolveCtx = toResolveCtx(ctx, 'get_account_financials');
+      const resolveCtx = toResolveCtx(ctx, 'get_account_financials', params);
       refuseInlineAccountIdWhenForbidden(accounts.resolution, params.account);
       const resolved = await accounts.resolve(params.account, resolveCtx);
       if (!resolved) {

--- a/src/lib/server/decisioning/runtime/to-context.ts
+++ b/src/lib/server/decisioning/runtime/to-context.ts
@@ -87,7 +87,8 @@ function buildCtxMetadataAccessor(store: CtxMetadataStore, accountId: string): C
 
 export function buildRequestContext<TCtxMeta = Record<string, unknown>>(
   handlerCtx: HandlerContext<Account<TCtxMeta>>,
-  ctxMetadataStore?: CtxMetadataStore
+  ctxMetadataStore?: CtxMetadataStore,
+  input?: Readonly<Record<string, unknown>>
 ): RequestContext<Account<TCtxMeta>> {
   // `account` may legitimately be undefined for tools whose wire request
   // doesn't carry an `account` field AND whose `resolveAccountFromAuth`
@@ -129,6 +130,7 @@ export function buildRequestContext<TCtxMeta = Record<string, unknown>>(
   return {
     account,
     ...(handlerCtx.agent != null && { agent: handlerCtx.agent }),
+    ...(input != null && { input }),
     state: {
       findByObject: () => [],
       findProposalById: () => null,

--- a/test/server-decisioning-ctx-input-wire-envelope.test.js
+++ b/test/server-decisioning-ctx-input-wire-envelope.test.js
@@ -1,0 +1,275 @@
+// Regression: every v6 platform-method dispatch must expose the
+// un-destructured wire request envelope on `ctx.input` so adopters can
+// read request fields the typed signature doesn't model. The audit in
+// adcp-client#1842 enumerated four `sync_*` methods that drop
+// spec-meaningful modifiers (`assignments[]`, `delete_missing`, `dry_run`,
+// `validation_mode`) because the framework only forwards the payload
+// array. Without these tests, a future refactor of `ctxFor` could
+// silently re-introduce the same drop.
+
+process.env.NODE_ENV = 'test';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { createAdcpServerFromPlatform } = require('../dist/lib/server/decisioning/runtime/from-platform');
+
+function basePlatform(overrides = {}) {
+  return {
+    capabilities: {
+      specialisms: ['sales-non-guaranteed'],
+      creative_agents: [{ agent_url: 'https://example.com/creative-agent/mcp' }],
+      channels: ['display'],
+      pricingModels: ['cpm'],
+      config: {},
+    },
+    statusMappers: {},
+    accounts: {
+      resolve: async () => ({
+        id: 'acc_1',
+        metadata: {},
+        authInfo: { kind: 'api_key' },
+      }),
+      upsert: async () => [],
+      list: async () => ({ items: [], nextCursor: null }),
+    },
+    sales: {
+      getProducts: async () => ({ products: [] }),
+      createMediaBuy: async () => ({
+        media_buy_id: 'mb_1',
+        status: 'pending_creatives',
+        confirmed_at: '2026-04-28T00:00:00Z',
+        packages: [],
+      }),
+      updateMediaBuy: async () => ({ media_buy_id: 'mb_1', status: 'active' }),
+      syncCreatives: async () => [],
+      getMediaBuyDelivery: async () => ({
+        currency: 'USD',
+        reporting_period: { start: '2026-04-01', end: '2026-04-30' },
+        media_buy_deliveries: [],
+      }),
+    },
+    ...overrides,
+  };
+}
+
+function buildServer(platform) {
+  return createAdcpServerFromPlatform(platform, {
+    name: 'ctx-input-test',
+    version: '0.0.1',
+    validation: { requests: 'off', responses: 'off' },
+  });
+}
+
+describe('ctx.input — un-destructured wire envelope on every v6 dispatch', () => {
+  it('exposes sync_creatives.assignments[] on ctx.input even though the typed signature only takes creatives[]', async () => {
+    let observedCtx;
+    const platform = basePlatform({
+      sales: {
+        getProducts: async () => ({ products: [] }),
+        createMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
+        updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
+        syncCreatives: async (creatives, ctx) => {
+          observedCtx = ctx;
+          return [{ creative_id: creatives[0].creative_id, action: 'unchanged' }];
+        },
+        getMediaBuyDelivery: async () => ({ media_buy_deliveries: [] }),
+      },
+    });
+
+    const result = await buildServer(platform).dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'sync_creatives',
+        arguments: {
+          account: { account_id: 'acc_1' },
+          idempotency_key: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+          creatives: [{ creative_id: 'cr_1', format_id: { id: 'f', agent_url: 'https://x' } }],
+          assignments: [{ creative_id: 'cr_1', package_ids: ['pkg_1', 'pkg_2'] }],
+          delete_missing: true,
+          dry_run: false,
+          validation_mode: 'strict',
+        },
+      },
+    });
+
+    assert.notStrictEqual(result.isError, true, JSON.stringify(result.structuredContent));
+    assert.ok(observedCtx, 'sales.syncCreatives should receive a RequestContext');
+    assert.ok(observedCtx.input, 'ctx.input should be set on every v6 dispatch');
+    assert.deepStrictEqual(
+      observedCtx.input.assignments,
+      [{ creative_id: 'cr_1', package_ids: ['pkg_1', 'pkg_2'] }],
+      'assignments[] from the wire envelope must survive to the platform method'
+    );
+    assert.strictEqual(observedCtx.input.delete_missing, true);
+    assert.strictEqual(observedCtx.input.dry_run, false);
+    assert.strictEqual(observedCtx.input.validation_mode, 'strict');
+    // Sanity: the typed first-arg projection still works.
+    assert.strictEqual(observedCtx.input.creatives.length, 1);
+  });
+
+  it('exposes sync_audiences.delete_missing on ctx.input', async () => {
+    let observedCtx;
+    const platform = basePlatform({
+      capabilities: {
+        specialisms: ['sales-non-guaranteed', 'audience-sync'],
+        creative_agents: [{ agent_url: 'https://example.com/creative-agent/mcp' }],
+        channels: ['display'],
+        pricingModels: ['cpm'],
+        config: {},
+      },
+      audiences: {
+        syncAudiences: async (audiences, ctx) => {
+          observedCtx = ctx;
+          return audiences.map(a => ({ audience_id: a.audience_id, action: 'unchanged' }));
+        },
+      },
+    });
+
+    const result = await buildServer(platform).dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'sync_audiences',
+        arguments: {
+          account: { account_id: 'acc_1' },
+          idempotency_key: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+          audiences: [{ audience_id: 'aud_1', name: 'a' }],
+          delete_missing: true,
+        },
+      },
+    });
+
+    assert.notStrictEqual(result.isError, true, JSON.stringify(result.structuredContent));
+    assert.ok(observedCtx, 'audiences.syncAudiences should receive a RequestContext');
+    assert.ok(observedCtx.input, 'ctx.input should be set on sync_audiences');
+    assert.strictEqual(observedCtx.input.delete_missing, true);
+    assert.ok(Array.isArray(observedCtx.input.audiences));
+  });
+
+  it('exposes the full envelope on update_media_buy — including media_buy_id which the framework hoists to a positional arg', async () => {
+    // Asymmetry callout from the audit: `updateMediaBuy(buyId, patch, ctx)`
+    // hoists `media_buy_id` out of the wire envelope to a positional. The
+    // typed `patch` arg also still carries it. `ctx.input` is the
+    // un-destructured wire envelope; `media_buy_id` is present at the
+    // top level there, NOT residual.
+    let observedBuyId;
+    let observedCtx;
+    const platform = basePlatform({
+      sales: {
+        getProducts: async () => ({ products: [] }),
+        createMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
+        updateMediaBuy: async (buyId, patch, ctx) => {
+          observedBuyId = buyId;
+          observedCtx = ctx;
+          return { media_buy_id: buyId, status: 'active' };
+        },
+        syncCreatives: async () => [],
+        getMediaBuyDelivery: async () => ({ media_buy_deliveries: [] }),
+      },
+    });
+
+    const result = await buildServer(platform).dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'update_media_buy',
+        arguments: {
+          account: { account_id: 'acc_1' },
+          idempotency_key: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+          media_buy_id: 'mb_42',
+          active: true,
+        },
+      },
+    });
+
+    assert.notStrictEqual(result.isError, true, JSON.stringify(result.structuredContent));
+    assert.strictEqual(observedBuyId, 'mb_42');
+    assert.ok(observedCtx, 'sales.updateMediaBuy should receive a RequestContext');
+    assert.ok(observedCtx.input, 'ctx.input should be set on update_media_buy');
+    assert.strictEqual(
+      observedCtx.input.media_buy_id,
+      'mb_42',
+      'media_buy_id must still be present on ctx.input even though the framework hoists it'
+    );
+    assert.strictEqual(observedCtx.input.active, true);
+  });
+
+  it('exposes sync_accounts.delete_missing + dry_run on ctx.input — account handlers route through ResolveContext, not RequestContext', async () => {
+    // Audit follow-up: account tool handlers (`syncAccounts`,
+    // `syncGovernance`, `listAccounts`, `reportUsage`, `getAccountFinancials`)
+    // use `toResolveCtx` → `ResolveContext`, not `ctxFor` →
+    // `RequestContext`. The fix wires `input` onto `ResolveContext` too,
+    // so the silent-drop closes symmetrically for `sync_accounts.delete_missing`
+    // / `dry_run` and any future modifier fields on account requests.
+    let observedCtx;
+    const platform = basePlatform({
+      accounts: {
+        resolve: async () => ({
+          id: 'acc_1',
+          metadata: {},
+          authInfo: { kind: 'api_key' },
+        }),
+        upsert: async (refs, ctx) => {
+          observedCtx = ctx;
+          return refs.map(r => ({ account_id: r.account_id ?? 'acc_x', action: 'unchanged' }));
+        },
+        list: async () => ({ items: [], nextCursor: null }),
+      },
+    });
+
+    const result = await buildServer(platform).dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'sync_accounts',
+        arguments: {
+          idempotency_key: 'dddddddd-dddd-dddd-dddd-dddddddddddd',
+          accounts: [{ account_id: 'acc_42' }],
+          delete_missing: true,
+          dry_run: false,
+        },
+      },
+    });
+
+    assert.notStrictEqual(result.isError, true, JSON.stringify(result.structuredContent));
+    assert.ok(observedCtx, 'accounts.upsert should receive a ResolveContext');
+    assert.ok(observedCtx.input, 'ctx.input should be set on sync_accounts (ResolveContext path)');
+    assert.strictEqual(observedCtx.input.delete_missing, true);
+    assert.strictEqual(observedCtx.input.dry_run, false);
+    assert.ok(Array.isArray(observedCtx.input.accounts));
+  });
+
+  it('exposes the original envelope on get_products (methods that already pass params whole)', async () => {
+    let observedCtx;
+    const platform = basePlatform({
+      sales: {
+        getProducts: async (req, ctx) => {
+          observedCtx = ctx;
+          return { products: [] };
+        },
+        createMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
+        updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
+        syncCreatives: async () => [],
+        getMediaBuyDelivery: async () => ({ media_buy_deliveries: [] }),
+      },
+    });
+
+    const result = await buildServer(platform).dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'get_products',
+        arguments: {
+          account: { account_id: 'acc_1' },
+          brief: 'premium homepage',
+          promoted_offering: 'cars',
+        },
+      },
+    });
+
+    assert.notStrictEqual(result.isError, true, JSON.stringify(result.structuredContent));
+    assert.ok(observedCtx, 'sales.getProducts should receive a RequestContext');
+    assert.ok(observedCtx.input, 'ctx.input should be set on get_products too');
+    // For methods that already forward `params` whole, `ctx.input` is
+    // semantically identical to the first arg — but it's still set, so
+    // adopters can use a single read pattern across the surface.
+    assert.strictEqual(observedCtx.input.brief, 'premium homepage');
+    assert.strictEqual(observedCtx.input.promoted_offering, 'cars');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1842. Adds `RequestContext.input` (and `ResolveContext.input`) so v6 platform methods can read request fields the typed signature drops — fixes the silent-drop trap on `sync_creatives.assignments[]`, `sync_audiences.delete_missing`, `sync_accounts.delete_missing`, and friends.

The v6 framework wrapper destructures the payload array out of `sync_*` requests and forwards only that to the platform method, dropping spec-meaningful modifiers the typed signature doesn't model. Adopters look conformant on `/mcp` (their v5 handler reads the full envelope) and silently fail on `/sales/mcp`. With `ctx.input`, adopters who need those fields cast at the read site:

```ts
syncCreatives: async (creatives, ctx) => {
  const wire = ctx.input as SyncCreativesRequest;
  for (const a of wire.assignments ?? []) {
    await this.bindCreativeToPackages(a.creative_id, a.package_ids);
  }
  if (wire.delete_missing) {
    await this.deleteCreativesNotIn(creatives.map(c => c.creative_id));
  }
}
```

## Two parallel fields, same shape

- **`RequestContext.input`** — sales / creative / signals / governance / SI handler families.
- **`ResolveContext.input`** — account-handler family (`syncAccounts`, `syncGovernance`, `listAccounts`, `reportUsage`, `getAccountFinancials`). Those use a separate context type because `accounts.resolve` produces the account rather than receiving it.

Spotted in expert review: an earlier version of this PR only wired the `RequestContext` path and would have left `sync_accounts.delete_missing` still dropped. Fixed before push.

## JSDoc lands three callouts

1. **Same reference as the typed payload arg, not a snapshot.** `ctx.input` is set before the auto-hydrate seams (`hydratePackagesWithProducts`, `hydrateForTool`) run, but those seams mutate the same object in place. By the time the platform method's body executes, `ctx.input` and the first positional arg are the same reference. Treat as request payload "as the method sees it," not "what the buyer originally sent."
2. **Hoist asymmetry.** For methods that hoist a field to a positional arg (e.g. `updateMediaBuy(media_buy_id, patch, ctx)`), that field is still present at the top level of `ctx.input`. Prefer the positional arg when both are available; reach for `ctx.input` only for fields the typed signature drops.
3. **Security.** `ctx.input` is buyer-controlled and may carry secrets — mutating-tool envelopes include `push_notification_config.token`; free-text fields (`brief`, `message`, creative snippets) are attacker-controlled. Don't log wholesale; don't template into LLM prompts without fencing.

## Files changed

| File | What |
|---|---|
| `src/lib/server/decisioning/context.ts` | `RequestContext.input` field + JSDoc |
| `src/lib/server/decisioning/account.ts` | `ResolveContext.input` field + JSDoc |
| `src/lib/server/decisioning/runtime/to-context.ts` | `buildRequestContext(handlerCtx, ctxMetadataStore, input?)` |
| `src/lib/server/decisioning/runtime/from-platform.ts` | `CtxForFn` signature, `toResolveCtx` signature, 56 call sites updated to pass `params` |
| `test/server-decisioning-ctx-input-wire-envelope.test.js` | 5 regression tests |
| `.changeset/ctx-input-wire-envelope-1842.md` | minor release note |

## Test plan

- [x] `npm run build` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm run format:check` — clean
- [x] `npm test` — 9234 pass, 0 fail, 3 unrelated skipped
- [x] 5 new regression tests pass (sync_creatives, sync_audiences, sync_accounts, update_media_buy hoist asymmetry, get_products universal pattern)
- [x] 4 expert reviews — protocol, code, product, security — concerns folded back in before push

## Review trail (folded in pre-push)

- **Protocol + code reviewers (converged blocker):** Initial PR only wired `RequestContext`, leaving `sync_accounts` etc. on `ResolveContext` still dropping fields. Fixed by adding `input` to `ResolveContext` and threading `params` through `toResolveCtx`.
- **Product reviewer (blocker):** Original JSDoc claimed `ctx.input` was "the un-destructured wire envelope" — but it's the same reference as `params`, which gets mutated by framework hydrators. Rewrote JSDoc to be honest: "request payload as the method sees it; same reference as the typed payload arg; framework hydration writes pass through."
- **Security reviewer (nits, folded in):** Added warnings on `ctx.input` containing `push_notification_config.token` + attacker-controlled free-text fields. Don't-log-wholesale and don't-string-interpolate-into-LLM-prompts guidance now lives in JSDoc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)