### PR TITLE
feat(testing): opt-in `discovery_resilient` for multi-agent storyboard runs (#1367)

### DIFF
--- a/.changeset/discovery-resilient-1367.md
+++ b/.changeset/discovery-resilient-1367.md
@@ -1,0 +1,50 @@
+---
+'@adcp/sdk': minor
+---
+
+feat(testing): opt-in `discovery_resilient` for multi-agent storyboard runs (#1367)
+
+Hello-cluster CI and exploratory multi-agent runs no longer fail the whole storyboard when one tenant's `get_adcp_capabilities` probe hangs or rejects. Opt in with `StoryboardRunOptions.discovery_resilient: true`; the runner then:
+
+- Logs discovery failures but does not throw.
+- Excludes failed agents from the protocol-claim index.
+- Surfaces a per-step `RoutingError` only when a step's protocol resolves to a failed agent — unrelated storyboards complete normally.
+- Echoes the failed agents on `StoryboardResult.discovery_failures[]` so operators see the topology breakage without correlating across log lines.
+
+**Default behavior is unchanged.** Production multi-tenant flows where every tenant in the map is load-bearing keep their hard-failure contract; flipping the flag is the explicit "I accept partial topology" signal.
+
+**Surfaces:**
+- `StoryboardRunOptions.discovery_resilient?: boolean` — new opt-in flag.
+- `StoryboardResult.discovery_failures?: Array<{ agent_key, url, error }>` — new optional field. Present only when resilient mode is on AND ≥1 agent failed; absent otherwise.
+- `AgentRoutingContext.discoveryFailures: DiscoveryFailure[]` — internal field on the routing context; framework consumers should read `StoryboardResult.discovery_failures` instead.
+- `resolveAgentForStep` `RoutingError` message now mentions which agents failed discovery when their absence caused the protocol to be unclaimed — so the operator sees the connection between the probe failure and the per-step error without correlating.
+
+**Security:**
+- The `discovery_failures[].error` string is upstream-agent-derived and may carry attacker-influenced content. Runner bounds it at ~512 chars and runs the existing auth-secret scrub; JSDoc carries the "untrusted; validate before LLM templating" warning at the read site.
+- The `discovery_failures[].url` is scrubbed of userinfo (`//user:pass@host` → `//[REDACTED]@host`) so operator-encoded credentials don't leak to dashboards.
+
+**Step-override safety:** `resolveAgentForStep` now checks whether a `step.agent` override targets an agent whose discovery failed under resilient mode. Before this guard, the override returned verbatim and the dispatcher handed back a transport client to a broken tenant, failing at the wire layer with a misleading transport error. The override-time check makes the failure attributable to topology.
+
+**Default-mode discoverability:** When `discovery_resilient` is unset (default), the `DiscoveryFailure` thrown by the runner now appends a one-line signposted suggestion to set the flag for hello-cluster / exploratory CI — with the explicit "NOT for production" warning attached. Adopters discover the escape hatch at the throw site, not by grep'ing JSDoc.
+
+**Tests:** 5 new regression tests in `test/lib/agent-routing-discovery-resilient.test.js` covering default-mode hard-failure preservation, resilient-mode failure collection on `discoveryFailures`, the improved `RoutingError` message naming failed agents, the `step.agent` override safety check, and `default_agent` fallback under resilient mode.
+
+**Adopter usage:**
+
+```ts
+import { runStoryboard } from '@adcp/sdk/testing/storyboard';
+
+const result = await runStoryboard(storyboard, [], {
+  agents: {
+    sales: { url: 'http://localhost:3001/mcp' },
+    signals: { url: 'http://localhost:3002/mcp' },
+    creative: { url: 'http://localhost:3003/mcp' }, // bind-flaky in CI
+    // ...
+  },
+  discovery_resilient: true, // accept partial topology for hello-cluster
+});
+
+if (result.discovery_failures?.length) {
+  console.warn(`Discovery missed: ${result.discovery_failures.map(f => f.agent_key).join(', ')}`);
+}
+```

--- a/src/lib/testing/storyboard/agent-routing.ts
+++ b/src/lib/testing/storyboard/agent-routing.ts
@@ -125,6 +125,15 @@ export interface AgentRoutingContext {
   protocolIndex: Map<AdcpProtocol, string[]>;
   /** Resolved (key → URL) for echo on the storyboard result. */
   agentMap: Record<string, string>;
+  /**
+   * Agents whose discovery failed when `discovery_resilient: true` was set.
+   * Empty in the default (hard-failure) mode — if any agent failed and
+   * resilient mode is off, `buildRoutingContext` throws `DiscoveryFailure`
+   * instead of returning. The runner echoes this list onto
+   * `StoryboardResult.discovery_failures` so operators see the topology
+   * breakage even when the storyboard otherwise completes.
+   */
+  discoveryFailures: DiscoveryFailure[];
 }
 
 export class RoutingError extends Error {
@@ -154,10 +163,18 @@ export class DiscoveryFailure extends Error {
  * Discover every agent in the map in parallel and build the routing index.
  *
  * Failure modes:
- *   - any agent's discovery fails → `DiscoveryFailure` (caller surfaces as
- *     a hard storyboard failure, never a per-step skip)
+ *   - default (`options.discovery_resilient !== true`): any agent's
+ *     discovery failure → throw `DiscoveryFailure` (caller surfaces as a
+ *     hard storyboard failure, never a per-step skip). Correct for
+ *     production multi-tenant flows where every tenant is load-bearing.
+ *   - resilient (`options.discovery_resilient === true`, #1367): failed
+ *     agents are excluded from `profiles` + `protocolIndex` and reported
+ *     on `AgentRoutingContext.discoveryFailures`. Per-step routing then
+ *     surfaces failures only for storyboards that actually need the
+ *     broken tenant — unrelated storyboards complete normally.
  *   - protocol claimed by 2+ agents AND ≥1 storyboard step that needs it
- *     lacks `step.agent` → `RoutingError` (conflict)
+ *     lacks `step.agent` → `RoutingError` (conflict). Independent of
+ *     resilient mode.
  */
 export async function buildRoutingContext(
   storyboard: Storyboard,
@@ -165,6 +182,7 @@ export async function buildRoutingContext(
 ): Promise<AgentRoutingContext> {
   const agents = options.agents!;
   const entries = Object.entries(agents);
+  const resilient = options.discovery_resilient === true;
 
   const clients = new Map<string, TestClient>();
   const agentMap: Record<string, string> = {};
@@ -176,6 +194,7 @@ export async function buildRoutingContext(
 
   // Parallel discovery — one tenant's slowness does not block another.
   const profiles = new Map<string, AgentProfile>();
+  const discoveryFailures: DiscoveryFailure[] = [];
   const discoveryResults = await Promise.all(
     entries.map(async ([key, entry]) => {
       const perAgentOptions = buildAgentOptions(entry, options);
@@ -197,13 +216,28 @@ export async function buildRoutingContext(
   );
   for (const r of discoveryResults) {
     if (!r.profile || r.step.passed === false) {
-      const detail = scrubAuthSecrets(r.step.error ?? 'Discovery returned no profile.');
-      throw new DiscoveryFailure(
-        `Discovery failed for agent "${r.key}" (${agents[r.key]!.url}): ${detail}`,
-        r.key,
-        agents[r.key]!.url,
-        detail
-      );
+      // Bound the attacker-influenced upstream string. A malicious agent
+      // could return an arbitrarily large error body during the discovery
+      // probe; the unbounded string would flow into
+      // `StoryboardResult.discovery_failures[].error` where downstream
+      // dashboards / LLM contexts ingest it. 512 chars is enough for a
+      // human to read the failure and grep logs for more.
+      const rawDetail = scrubAuthSecrets(r.step.error ?? 'Discovery returned no profile.');
+      const detail = rawDetail.length > 512 ? `${rawDetail.slice(0, 512)} …(truncated)` : rawDetail;
+      // Default mode appends a signposted escape hatch so CI operators
+      // discover the resilient flag without grep'ing the JSDoc. Suppressed
+      // in resilient mode (the operator already opted in) so the hint
+      // doesn't appear in every per-agent failure attached to the result.
+      const baseMessage = `Discovery failed for agent "${r.key}" (${agents[r.key]!.url}): ${detail}`;
+      const message = resilient
+        ? baseMessage
+        : `${baseMessage}\n\nIf this is hello-cluster / exploratory CI and you want unrelated storyboards to complete despite this failure, ` +
+          `set \`StoryboardRunOptions.discovery_resilient: true\`. Do NOT set it in production — a topology with a broken tenant ` +
+          `is a hard misconfiguration there.`;
+      const failure = new DiscoveryFailure(message, r.key, agents[r.key]!.url, detail);
+      if (!resilient) throw failure;
+      discoveryFailures.push(failure);
+      continue;
     }
     profiles.set(r.key, r.profile);
   }
@@ -211,7 +245,7 @@ export async function buildRoutingContext(
   const protocolIndex = buildProtocolIndex(profiles);
   detectMultiClaimConflicts(storyboard, protocolIndex);
 
-  return { clients, profiles, protocolIndex, agentMap };
+  return { clients, profiles, protocolIndex, agentMap, discoveryFailures };
 }
 
 /**
@@ -234,7 +268,7 @@ export function buildRoutingContextFromProfiles(
   const protocolIndex = buildProtocolIndex(profiles);
   detectMultiClaimConflicts(storyboard, protocolIndex);
   // Empty client map — callers that only test routing shouldn't dispatch.
-  return { clients: new Map(), profiles, protocolIndex, agentMap };
+  return { clients: new Map(), profiles, protocolIndex, agentMap, discoveryFailures: [] };
 }
 
 /**
@@ -334,7 +368,24 @@ export function resolveAgentForStep(
   ctx: AgentRoutingContext
 ): string {
   if (step.agent !== undefined) {
-    // Already validated at runStoryboard entry; trust here.
+    // If the override targets an agent whose discovery failed under
+    // resilient mode, surface that explicitly rather than handing
+    // dispatch a transport client to a broken tenant (which would
+    // otherwise fail at the wire layer with a misleading transport
+    // error). Only meaningful when `discoveryFailures` is non-empty;
+    // under default (hard-failure) mode `buildRoutingContext` throws
+    // before we reach this branch.
+    const failed = ctx.discoveryFailures.find(f => f.agentKey === step.agent);
+    if (failed) {
+      throw new RoutingError(
+        `Step "${step.id}" targets agent "${step.agent}" via \`step.agent\` override, ` +
+          `but that agent's discovery failed: ${failed.underlying} ` +
+          `(${failed.url}). Either remove the override, fix the agent, or ` +
+          `route the step to a healthy agent.`,
+        step.task,
+        `agent "${step.agent}" failed discovery`
+      );
+    }
     return step.agent;
   }
   const protocol = primaryProtocolFor(step.task);
@@ -355,11 +406,18 @@ export function resolveAgentForStep(
     }
     // Zero candidates — no agent in the map claims this protocol.
     if (options.default_agent) return options.default_agent;
+    // Under `discovery_resilient`, an agent that was supposed to claim
+    // this protocol may have been excluded by a failed probe. Suffix the
+    // error so the operator sees the connection without correlating logs.
+    const failedHint =
+      ctx.discoveryFailures.length > 0
+        ? ` Discovery failed for: ${ctx.discoveryFailures.map(f => `${f.agentKey} (${f.url})`).join(', ')}.`
+        : '';
     throw new RoutingError(
       `No agent in the map claims protocol "${protocol}" required by tool ` +
         `"${step.task}" (step "${step.id}"). Available agents: ` +
-        `${[...ctx.profiles.keys()].join(', ')}. Add an agent that supports ` +
-        `${protocol}, or set \`default_agent\` to fall back.`,
+        `${[...ctx.profiles.keys()].join(', ') || '(none — every agent failed discovery)'}.${failedHint} ` +
+        `Add an agent that supports ${protocol}, or set \`default_agent\` to fall back.`,
       step.task,
       `protocol ${protocol} unclaimed`
     );

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -2586,6 +2586,19 @@ async function executeStoryboardPass(
     ...(assertionResults.length > 0 ? { assertions: assertionResults } : {}),
     strict_validation_summary: strictSummary,
     notices,
+    ...(routingContext && routingContext.discoveryFailures.length > 0
+      ? {
+          discovery_failures: routingContext.discoveryFailures.map(f => ({
+            agent_key: f.agentKey,
+            // Scrub URL userinfo (`https://user:pass@host/`) before
+            // echoing onto the result — an operator may legitimately
+            // encode credentials in the URL, and the leaderboard /
+            // dashboard surface mustn't carry them.
+            url: f.url.replace(/\/\/[^/@\s]+@/, '//[REDACTED]@'),
+            error: f.underlying,
+          })),
+        }
+      : {}),
   };
 
   // Close protocol connections when the runner created its own client. The

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -1244,6 +1244,29 @@ export interface StoryboardRunOptions extends TestOptions {
    */
   default_agent?: string;
   /**
+   * Opt into resilient discovery (#1367). When `false` (default), any agent
+   * whose `get_adcp_capabilities` probe fails causes the whole storyboard
+   * to fail — correct for production multi-tenant flows where every tenant
+   * in the map is load-bearing.
+   *
+   * When `true`:
+   *   - Discovery failures are logged but not fatal.
+   *   - Failed agents are excluded from the protocol-claim index.
+   *   - Routing throws `RoutingError` only if a step's protocol resolves
+   *     to a failed agent — surfaces as a per-step failure, not a
+   *     storyboard-wide hard failure.
+   *   - A `discovery_failures[]` summary on `StoryboardResult` lists which
+   *     agents failed, so the operator still sees the topology breakage.
+   *
+   * Intended for hello-cluster CI and exploratory runs where one flaky
+   * tenant shouldn't gate a 6-tenant smoke. Production runs should NEVER
+   * set this — a topology with one broken tenant is a hard misconfig.
+   *
+   * Only consulted when `agents` is set (multi-agent routing); single-URL
+   * runs have no roster to be resilient about.
+   */
+  discovery_resilient?: boolean;
+  /**
    * Host an ephemeral webhook receiver during the run so `expect_webhook*`
    * pseudo-steps can observe outbound webhooks from the agent under test.
    * Enables the `webhook_receiver_runner` contract referenced by the
@@ -2350,6 +2373,33 @@ export interface StoryboardResult {
    * deduplicated by `code`. Spec: adcp-client#1704.
    */
   notices: RunnerNotice[];
+  /**
+   * Agents in the routing map whose `get_adcp_capabilities` probe failed
+   * when `StoryboardRunOptions.discovery_resilient: true` was set. Absent
+   * when resilient mode is off (because failures throw before result
+   * construction) and absent when no failures occurred. Each entry carries
+   * the agent key, URL, and the scrubbed underlying error so operators
+   * see the topology breakage without correlating across log lines.
+   *
+   * **Read together with `overall_passed`.** A passing storyboard with a
+   * non-empty `discovery_failures` means the storyboard did NOT touch any
+   * tools that needed the failed agents — it does NOT mean the topology
+   * was healthy. Dashboards and procurement reports should surface both
+   * fields; a green check next to a populated `discovery_failures` is
+   * legitimate but misleading without the second-axis signal.
+   *
+   * **Buyer-controlled untrusted content.** The `error` string is
+   * upstream-agent-derived and may contain attacker-influenced text from
+   * a malicious or compromised agent. The runner bounds the string
+   * (~512 chars) and runs the existing auth-secret scrub, but the
+   * remaining content is untrusted — validate / fence before templating
+   * into LLM prompts. The `url` field is scrubbed of userinfo
+   * (`//user:pass@host` → `//[REDACTED]@host`) so operator-encoded
+   * credentials don't leak to dashboards.
+   *
+   * Spec: adcp-client#1367.
+   */
+  discovery_failures?: Array<{ agent_key: string; url: string; error: string }>;
 }
 
 export interface StrictValidationSummary {

--- a/test/lib/agent-routing-discovery-resilient.test.js
+++ b/test/lib/agent-routing-discovery-resilient.test.js
@@ -1,0 +1,170 @@
+// Resilient discovery for multi-agent routing (#1367). When a tenant's
+// `get_adcp_capabilities` probe fails, the default contract is hard-failure
+// — correct for production multi-tenant flows. Hello-cluster CI and
+// exploratory runs opt in via `discovery_resilient: true`, which:
+//   - excludes failed agents from the protocol-claim index
+//   - records failures on `routingContext.discoveryFailures`
+//   - lets unrelated storyboards complete normally
+//   - surfaces `discovery_failures[]` on `StoryboardResult`
+// This test exercises the routing seam directly. End-to-end coverage of
+// the runner result surface lives alongside the existing multi-agent
+// runner tests once hello-cluster gains a CI flake injection point.
+
+process.env.NODE_ENV = 'test';
+
+const { test, describe, after } = require('node:test');
+const assert = require('node:assert');
+
+const {
+  buildRoutingContext,
+  resolveAgentForStep,
+  RoutingError,
+  DiscoveryFailure,
+} = require('../../dist/lib/testing/storyboard/agent-routing.js');
+const { closeConnections } = require('../../dist/lib/protocols/index.js');
+
+// Pre-existing tests in agent-routing.test.js use `buildRoutingContextFromProfiles`
+// for unit-level seams that don't need live discovery. The resilient-mode
+// path runs the discovery side of `buildRoutingContext`, so this test
+// drives that function directly with stub agent URLs that fail discovery.
+
+// Stub URLs: nothing is listening on this loopback port pair, so the
+// agent client's discovery probe rejects fast. Each URL is unique so the
+// per-agent failure-collection path can be observed.
+const STUB_FAILING_URL_1 = 'http://127.0.0.1:1/mcp';
+const STUB_FAILING_URL_2 = 'http://127.0.0.1:2/mcp';
+
+function makeStoryboard(steps) {
+  return {
+    id: 'test_storyboard',
+    title: 'Test',
+    phases: [{ id: 'p1', title: 'Phase 1', steps }],
+  };
+}
+
+describe('agent-routing: discovery_resilient (#1367)', () => {
+  // Discovery instantiates MCP clients via `getOrCreateClient` which keep
+  // transport references alive past the test body. Without an explicit
+  // teardown the suite hangs until `--test-force-exit` triggers in CI.
+  after(async () => {
+    // MCP is the only transport this file uses today; A2A is closed too
+    // for forward-compat in case a future test adds an A2A stub agent.
+    await closeConnections('mcp');
+    await closeConnections('a2a');
+  });
+
+  test('default mode (discovery_resilient unset): any agent failing discovery throws DiscoveryFailure', async () => {
+    const storyboard = makeStoryboard([{ id: 's1', title: 'probe', task: 'get_signals' }]);
+    const options = {
+      agents: {
+        signals: { url: STUB_FAILING_URL_1, auth_token: 't1' },
+      },
+      // discovery_resilient omitted (=== undefined). Hard-failure preserved.
+    };
+
+    await assert.rejects(
+      () => buildRoutingContext(storyboard, options),
+      err => err instanceof DiscoveryFailure
+    );
+  });
+
+  test('discovery_resilient: true — failed agents excluded from protocolIndex but the context is returned', async () => {
+    const storyboard = makeStoryboard([{ id: 's1', title: 'probe', task: 'get_signals' }]);
+    const options = {
+      agents: {
+        broken_a: { url: STUB_FAILING_URL_1, auth_token: 't1' },
+        broken_b: { url: STUB_FAILING_URL_2, auth_token: 't2' },
+      },
+      discovery_resilient: true,
+    };
+
+    const ctx = await buildRoutingContext(storyboard, options);
+    // Both agents failed → none in profiles.
+    assert.strictEqual(ctx.profiles.size, 0);
+    // Both surface on discoveryFailures with stable agent keys.
+    assert.strictEqual(ctx.discoveryFailures.length, 2);
+    const keys = ctx.discoveryFailures.map(f => f.agentKey).sort();
+    assert.deepStrictEqual(keys, ['broken_a', 'broken_b']);
+    assert.ok(ctx.discoveryFailures.every(f => f instanceof DiscoveryFailure));
+    // Each failure echoes the original URL so operators can match against
+    // their topology config without correlating logs.
+    const urlsByKey = Object.fromEntries(ctx.discoveryFailures.map(f => [f.agentKey, f.url]));
+    assert.strictEqual(urlsByKey.broken_a, STUB_FAILING_URL_1);
+    assert.strictEqual(urlsByKey.broken_b, STUB_FAILING_URL_2);
+    // agentMap remains complete — failures don't remove the agent from the
+    // declared topology, only from the protocol-claim index.
+    assert.deepStrictEqual(Object.keys(ctx.agentMap).sort(), ['broken_a', 'broken_b']);
+  });
+
+  test('resilient mode + a step needing the failed protocol: RoutingError mentions which agent broke discovery', async () => {
+    const storyboard = makeStoryboard([{ id: 's1', title: 'probe', task: 'get_signals' }]);
+    const options = {
+      agents: {
+        signals: { url: STUB_FAILING_URL_1, auth_token: 't1' },
+      },
+      discovery_resilient: true,
+    };
+
+    const ctx = await buildRoutingContext(storyboard, options);
+    // Routing for a step requiring `signals` protocol now fails per-step
+    // (not at context-build time) — that's the whole point of the resilient
+    // mode. The error must mention the failed agent so the operator sees
+    // the connection without correlating logs.
+    assert.throws(
+      () => resolveAgentForStep(storyboard.phases[0].steps[0], options, ctx),
+      err => err instanceof RoutingError && err.message.includes('signals') && err.message.includes(STUB_FAILING_URL_1)
+    );
+  });
+
+  test('resilient mode + step.agent override targeting a failed-discovery agent: RoutingError surfaces the override mistake', async () => {
+    // Without this guard, the override would return verbatim and the
+    // dispatcher would hand back a transport client to a broken tenant,
+    // failing at the wire layer with a misleading transport error. The
+    // override-time check makes the failure attributable to topology.
+    const storyboard = makeStoryboard([{ id: 's1', title: 'probe', task: 'get_signals', agent: 'broken' }]);
+    const options = {
+      agents: {
+        broken: { url: STUB_FAILING_URL_1, auth_token: 't1' },
+        healthy: { url: STUB_FAILING_URL_2, auth_token: 't2' },
+      },
+      discovery_resilient: true,
+    };
+
+    const ctx = await buildRoutingContext(storyboard, options);
+    // Both stubs fail in this test, but the assertion is about the
+    // override-targeted agent specifically — even if `healthy` succeeded,
+    // the failure here belongs to `broken`.
+    assert.strictEqual(ctx.discoveryFailures.length, 2);
+    assert.throws(
+      () => resolveAgentForStep(storyboard.phases[0].steps[0], options, ctx),
+      err =>
+        err instanceof RoutingError &&
+        err.message.includes('step.agent') &&
+        err.message.includes('broken') &&
+        err.message.includes('failed')
+    );
+  });
+
+  test('resilient mode + default_agent set: unrouted protocol falls back through default_agent path', async () => {
+    // Sanity: resilient mode doesn't interfere with the existing
+    // default_agent fallback. A step whose protocol is unclaimed (because
+    // discovery failed) but has a default_agent still routes there. The
+    // default_agent itself may or may not exist on profiles; routing
+    // returns the key regardless and per-step dispatch surfaces the
+    // problem if the agent isn't reachable.
+    const storyboard = makeStoryboard([{ id: 's1', title: 'probe', task: 'get_signals' }]);
+    const options = {
+      agents: {
+        broken: { url: STUB_FAILING_URL_1, auth_token: 't1' },
+      },
+      default_agent: 'broken',
+      discovery_resilient: true,
+    };
+
+    const ctx = await buildRoutingContext(storyboard, options);
+    assert.strictEqual(ctx.discoveryFailures.length, 1);
+    // No protocols are claimed (every agent failed), so the step falls
+    // through to default_agent rather than failing at routing time.
+    assert.strictEqual(resolveAgentForStep(storyboard.phases[0].steps[0], options, ctx), 'broken');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1367. Hello-cluster CI and exploratory multi-agent storyboard runs no longer fail the whole storyboard when one tenant's `get_adcp_capabilities` probe hangs or rejects.

```ts
const result = await runStoryboard(storyboard, [], {
  agents: {
    sales: { url: 'http://localhost:3001/mcp' },
    signals: { url: 'http://localhost:3002/mcp' },
    creative: { url: 'http://localhost:3003/mcp' }, // bind-flaky in CI
  },
  discovery_resilient: true, // accept partial topology for hello-cluster
});

if (result.discovery_failures?.length) {
  console.warn(`Discovery missed: ${result.discovery_failures.map(f => f.agent_key).join(', ')}`);
}
```

**Default behavior is unchanged.** Production multi-tenant flows where every tenant is load-bearing keep their hard-failure contract; flipping the flag is the explicit "I accept partial topology" signal.

## What this PR does

- New `StoryboardRunOptions.discovery_resilient?: boolean` (default `false`).
- New `StoryboardResult.discovery_failures?: Array<{ agent_key, url, error }>` — present only when resilient mode is on AND ≥1 agent failed.
- Failed agents excluded from `protocolIndex`; per-step `RoutingError` fires only when a step actually needs a failed agent's protocol.
- `RoutingError` message now names the failed agents when their absence caused a protocol to be unclaimed — so operators see the connection between probe failure and per-step error without correlating logs.

## Pre-merge expert review (4 parallel)

| Reviewer | Verdict | Key findings folded in |
|---|---|---|
| ad-tech-protocol-expert | SHIP after fixes | **BLOCKER:** `step.agent` override silently routes to a failed-discovery agent. Fixed by adding override-vs-discoveryFailures check in `resolveAgentForStep`. |
| code-reviewer | SHIP-WITH-NITS | Test teardown also closes A2A for forward-compat; minor JSDoc + format nits folded |
| adtech-product-expert | SHIP-WITH-NITS | **SUGGEST:** append "Try `discovery_resilient: true`" hint at the `DiscoveryFailure` throw site — folded in |
| security-reviewer | SHIP-WITH-NITS | **SUGGEST:** bound attacker-influenced error string + scrub URL userinfo — both folded in |

**Not folded (with reasoning):**
- Protocol reviewer suggested emitting a `RunnerNotice` for partial-topology runs. `NoticeCode` is a closed union per type-system contract (`types.ts:1606-1612`), and the JSDoc says "Coordinate with the upstream spec (adcp#4418) before extending." Strengthened the JSDoc on `StoryboardResult.discovery_failures` to explicitly tell dashboards "read together with `overall_passed` — a green check next to a populated `discovery_failures` is legitimate but misleading without the second-axis signal." When adcp#4418 settles the notice catalog, a follow-up can add `discovery.partial_topology` cleanly.
- Product reviewer suggested renaming to `tolerate_discovery_failures`. `discovery_resilient` matches the operational pattern (resilience) and the `discovery_failures[]` result field name; renaming both would be churn.

## Files changed

| File | What |
|---|---|
| `src/lib/testing/storyboard/types.ts` | `StoryboardRunOptions.discovery_resilient`, `StoryboardResult.discovery_failures` + JSDoc with security warnings |
| `src/lib/testing/storyboard/agent-routing.ts` | `AgentRoutingContext.discoveryFailures`, `buildRoutingContext` branching, error string bounding, override-safety check |
| `src/lib/testing/storyboard/runner.ts` | Surfaces `discovery_failures` on result; scrubs URL userinfo |
| `test/lib/agent-routing-discovery-resilient.test.js` | 5 regression tests |
| `.changeset/discovery-resilient-1367.md` | minor release note |

## Test plan

- [x] `npm run build` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm run format:check` — clean
- [x] `npm test` — 9198 pass, 0 fail, 3 unrelated skipped
- [x] 5 new regression tests cover: default-mode hard-failure preservation, resilient-mode failure collection, RoutingError naming failed agents, `step.agent` override safety, `default_agent` fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)