### PR TITLE
docs(server): operational guidance for cached credentials + Redis memory policy

### DIFF
--- a/.changeset/idem-redis-ops-guidance.md
+++ b/.changeset/idem-redis-ops-guidance.md
@@ -1,0 +1,21 @@
+---
+'@adcp/sdk': patch
+---
+
+docs(server): operational guidance for cached-response credentials and Redis memory policy
+
+Closes adcp-client#1856 (cached credentials) and adcp-client#1857 (cache-fill DoS / maxmemory-policy).
+
+**No code behavior changes** — only JSDoc + the `CTX-METADATA-SAFETY` guide gain the operational guidance that PR #1858's security review surfaced as deferred follow-ups. Adopters reading the entrypoint docstrings now see both classes of footgun at the read site.
+
+**`IdempotencyStoreConfig` JSDoc (`src/lib/server/idempotency/store.ts`):** names the cached-response-at-rest concern explicitly. The hash-exclusion list strips credentials from the *hash* but the *stored response* is the handler's verbatim output. If a handler returns refreshed bearer tokens, signed governance payloads, or echoed `push_notification_config` credentials, those sit in the backend for `ttlSeconds`. Adopters: don't return credentials in handler responses; if you must, wrap with a scrubber or use a custom `IdempotencyBackend`. The SDK does not ship a built-in scrubber because it would change wire shape silently.
+
+**`docs/guides/CTX-METADATA-SAFETY.md`:** new "Related: handler responses are cached for `ttlSeconds`" section cross-links to the idempotency JSDoc and the #1856 tracking issue. The two surfaces (`ctx_metadata` cache and idempotency response cache) have the same at-rest concern; one guide covers both.
+
+**`redisBackend` JSDoc (`src/lib/server/idempotency/backends/redis.ts`):** Redis `maxmemory-policy` recommendation matrix — `volatile-lru` (recommended, evicts only TTL'd keys = AdCP's keyspace), `allkeys-lru` (dedicated db only), `noeviction` (fail-closed, paging instead of silent eviction). Pair with per-principal `VALIDATION_ERROR` rate alerting because a drifted handler under retry amplifies cache fill via `saveTransientError`.
+
+**`RedisReplayStore` JSDoc (`src/lib/signing/redis-replay-store.ts`):** same memory-policy matrix, plus the eviction-on-replay caveat — if `volatile-lru` evicts a sorted set before its members would have expired naturally, an attacker's later replay sees a fresh set and gets `ok`. The per-`(keyid, scope)` cap (default 100k) is the primary defense; eviction is a secondary recovery mode. Size Redis to keep working set in memory; treat eviction as scale-up pressure, not a feature.
+
+**`redisCtxMetadataStore` JSDoc (`src/lib/server/ctx-metadata/backends/redis.ts`):** memory-policy guidance tuned to ctx_metadata's durable-by-default semantics. `allkeys-lru` recommended on a dedicated db (re-hydration is automatic on miss, so eviction is safer here than for the replay store).
+
+Pre-existing protocol-store issues, not Redis-introduced regressions; the docs now name them so adopters don't have to discover them in production.

--- a/docs/guides/CTX-METADATA-SAFETY.md
+++ b/docs/guides/CTX-METADATA-SAFETY.md
@@ -494,19 +494,23 @@ returns:
 
 - a refreshed bearer / OAuth access token,
 - a signed governance / auth payload,
-- `push_notification_config.authentication.credentials` (echoed back),
+- `push_notification_config.authentication.credentials` — a write-only
+  buyer-supplied secret that the spec contract says sellers MUST NOT
+  echo back. Receipt correlation uses `push_notification_config.token`
+  instead. If your adapter is echoing `credentials`, that's the bug to
+  fix, not the cache,
 - any other secret material,
 
 those secrets sit at rest in the backend for the replay window. On
 Redis without TLS, they're plaintext over the wire too.
 
-**Don't return credentials in handler responses.** The spec doesn't
-require it for any AdCP tool; if your adapter is echoing them back,
-refactor. If a buyer-supplied credential must be echoed (e.g., to
-confirm receipt of `push_notification_config`), wrap your handler to
-scrub before returning OR use a custom `IdempotencyBackend` that
-transforms entries on the write path. JSDoc on
-`IdempotencyStoreConfig` carries the full version of this warning at
-the read site.
+**Don't return credentials in handler responses.** No AdCP tool's
+response schema asks for them; if your adapter is echoing them back,
+refactor. If a handler nonetheless must produce a secret-bearing
+response (e.g., an internal-only echo for adapter debugging), wrap
+your handler to scrub before returning OR use a custom
+`IdempotencyBackend` that transforms entries on the write path. JSDoc
+on `IdempotencyStoreConfig` carries the full version of this warning
+at the read site.
 
 See also [GitHub #1856](https://github.com/adcontextprotocol/adcp-client/issues/1856) — the SDK does not ship a built-in response scrubber because it would change the wire shape of legitimate adopter responses without warning. The track-record-of-shipped-credentials-in-responses issue is rare enough that opting into a scrubber per-deployment is the right shape.

--- a/docs/guides/CTX-METADATA-SAFETY.md
+++ b/docs/guides/CTX-METADATA-SAFETY.md
@@ -477,3 +477,36 @@ org-gating check themselves. See
 
 If your resolver doesn't gate on the principal's authorized accounts,
 `credentialPolicy: 'authInfo-only'` will not save you.
+
+---
+
+## Related: handler responses are cached for `ttlSeconds`
+
+`ctx_metadata` isn't the only cache surface that holds adopter values at
+rest. The **idempotency cache** stores whatever the handler returned as
+the response payload, in the configured backend, for the declared
+`ttlSeconds` (default 24h, max 7d per spec). The hash-exclusion list
+strips `idempotency_key`, `governance_context`, and
+`push_notification_config.authentication.credentials` from the **hash**
+so a rotated credential on retry doesn't false-conflict — but the
+**stored response** is the handler's verbatim output. If the handler
+returns:
+
+- a refreshed bearer / OAuth access token,
+- a signed governance / auth payload,
+- `push_notification_config.authentication.credentials` (echoed back),
+- any other secret material,
+
+those secrets sit at rest in the backend for the replay window. On
+Redis without TLS, they're plaintext over the wire too.
+
+**Don't return credentials in handler responses.** The spec doesn't
+require it for any AdCP tool; if your adapter is echoing them back,
+refactor. If a buyer-supplied credential must be echoed (e.g., to
+confirm receipt of `push_notification_config`), wrap your handler to
+scrub before returning OR use a custom `IdempotencyBackend` that
+transforms entries on the write path. JSDoc on
+`IdempotencyStoreConfig` carries the full version of this warning at
+the read site.
+
+See also [GitHub #1856](https://github.com/adcontextprotocol/adcp-client/issues/1856) — the SDK does not ship a built-in response scrubber because it would change the wire shape of legitimate adopter responses without warning. The track-record-of-shipped-credentials-in-responses issue is rare enough that opting into a scrubber per-deployment is the right shape.

--- a/src/lib/server/ctx-metadata/backends/redis.ts
+++ b/src/lib/server/ctx-metadata/backends/redis.ts
@@ -157,8 +157,9 @@ interface SerializedEntry {
  *
  * - **`maxmemory-policy allkeys-lru`** on a Redis db dedicated to AdCP
  *   ctx_metadata — evicts the oldest entries to make room. Acceptable
- *   for ctx_metadata because re-hydration is automatic on next read;
- *   adopters lose the cache, not the data.
+ *   for ctx_metadata because the next call referencing the same
+ *   resource will write a fresh entry; evicted entries are recoverable
+ *   as publisher traffic re-derives them, not lost permanently.
  * - **`maxmemory-policy volatile-lru`** if you mostly use `expiresAt`
  *   on entries — bounds growth to TTL'd keys only.
  * - **`maxmemory-policy noeviction`** (Redis default) — fail-closed:
@@ -167,7 +168,11 @@ interface SerializedEntry {
  *
  * For ctx_metadata specifically, evicting cached entries is safer than
  * for the idempotency cache (which uses eviction as a feature) because
- * the framework re-hydrates on miss. `allkeys-lru` is the recommended
+ * publisher re-derivation refills the cache on the next reference.
+ * Note that this isn't synchronous "re-hydrate on miss" — the
+ * framework reads `null` for a missing entry and falls through to the
+ * publisher's adapter, which may or may not produce a fresh
+ * `ctx_metadata` value on that path. `allkeys-lru` is the recommended
  * default on a dedicated db.
  */
 export function redisCtxMetadataStore(

--- a/src/lib/server/ctx-metadata/backends/redis.ts
+++ b/src/lib/server/ctx-metadata/backends/redis.ts
@@ -147,6 +147,28 @@ interface SerializedEntry {
  * ```ts
  * client.on('error', (err) => console.error('redis error', err));
  * ```
+ *
+ * **Redis memory policy — set this on the deployment.** ctx_metadata
+ * entries default to durable (no TTL) when no `expiresAt` is provided,
+ * matching the pg sibling's `expires_at = NULL` semantic. Without a
+ * memory policy, an adopter who writes many durable entries can
+ * pressure Redis memory; once `maxmemory` is hit, default `noeviction`
+ * makes new writes fail. Choose deliberately:
+ *
+ * - **`maxmemory-policy allkeys-lru`** on a Redis db dedicated to AdCP
+ *   ctx_metadata — evicts the oldest entries to make room. Acceptable
+ *   for ctx_metadata because re-hydration is automatic on next read;
+ *   adopters lose the cache, not the data.
+ * - **`maxmemory-policy volatile-lru`** if you mostly use `expiresAt`
+ *   on entries — bounds growth to TTL'd keys only.
+ * - **`maxmemory-policy noeviction`** (Redis default) — fail-closed:
+ *   writes start erroring at the limit, mutating tools fail. Pages
+ *   you instead of silently evicting.
+ *
+ * For ctx_metadata specifically, evicting cached entries is safer than
+ * for the idempotency cache (which uses eviction as a feature) because
+ * the framework re-hydrates on miss. `allkeys-lru` is the recommended
+ * default on a dedicated db.
  */
 export function redisCtxMetadataStore(
   client: CtxMetadataRedisBackendClient,

--- a/src/lib/server/idempotency/backends/redis.ts
+++ b/src/lib/server/idempotency/backends/redis.ts
@@ -201,6 +201,28 @@ export function __resetDefaultPrefixWarningForTests(): void {
  * ```ts
  * client.on('error', (err) => console.error('redis error', err));
  * ```
+ *
+ * **Redis memory policy — set this on the deployment.** A buyer with a
+ * valid principal can mint unbounded distinct `idempotency_key` values
+ * and hit any mutating tool; each write adds a key to Redis with the
+ * configured `ttlSeconds` (default 24h). A sufficient rate can pressure
+ * Redis memory before TTLs evict naturally. Configure your Redis with:
+ *
+ * - **`maxmemory-policy volatile-lru`** (recommended) — evicts only
+ *   TTL'd keys, containing blast radius to AdCP's keyspace if the
+ *   instance is shared with other apps. All keys this backend writes
+ *   carry TTL, so this is safe.
+ * - **`maxmemory-policy allkeys-lru`** — only on a Redis db dedicated
+ *   to AdCP. Will evict your other keys if shared.
+ * - **`maxmemory-policy noeviction`** (Redis default) — fail-closed:
+ *   the backend's writes will start erroring once memory fills, and
+ *   mutating requests will fail. Operationally noisy but never serves
+ *   stale data; choose this only if you'd rather page than evict.
+ *
+ * Pair with alerting on a per-principal `VALIDATION_ERROR` rate — a
+ * drifted handler hit by a retrying buyer writes 10s-TTL entries on
+ * every fresh key, amplifying the rate of cache fill. Steady-state
+ * `VALIDATION_ERROR` should be zero.
  */
 export function redisBackend(client: RedisBackendClient, options: RedisBackendOptions = {}): IdempotencyBackend {
   // The function calls only the four methods on RedisLikeClient. The

--- a/src/lib/server/idempotency/store.ts
+++ b/src/lib/server/idempotency/store.ts
@@ -193,7 +193,10 @@ export type IdempotencyCheckResult =
  *
  * - a refreshed bearer / OAuth access token,
  * - a signed governance / auth payload,
- * - `push_notification_config.authentication.credentials` (echoed back),
+ * - `push_notification_config.authentication.credentials` (a buyer-
+ *   supplied write-only secret — the contract is that sellers MUST
+ *   NOT echo it back; receipt correlation uses
+ *   `push_notification_config.token` instead),
  * - any other secret material,
  *
  * those secrets sit at rest in the backend for `ttlSeconds`. On Redis
@@ -204,14 +207,15 @@ export type IdempotencyCheckResult =
  *
  * Practical guidance:
  *
- * - **Don't return credentials in handler responses.** The spec
- *   doesn't require it for any tool; if your adapter is echoing
- *   them back, refactor.
- * - If you must return them (e.g., a buyer-supplied webhook
- *   credential that the spec asks you to echo so the buyer can
- *   confirm receipt), wrap your handler to scrub before
- *   returning, OR use a custom `IdempotencyBackend` that
- *   transforms entries on the write path.
+ * - **Don't return credentials in handler responses.** No AdCP tool's
+ *   response schema asks for them; if your adapter is echoing them
+ *   back, refactor. `push_notification_config.credentials` in
+ *   particular is write-only — `token` is the field a seller uses to
+ *   confirm receipt.
+ * - If a handler nonetheless must produce a secret-bearing response
+ *   (e.g., an internal-only echo for adapter debugging), wrap your
+ *   handler to scrub before returning, OR use a custom
+ *   `IdempotencyBackend` that transforms entries on the write path.
  *
  * See also `docs/guides/CTX-METADATA-SAFETY.md` for related guidance
  * on what NOT to put in `ctx_metadata` (which has its own caching

--- a/src/lib/server/idempotency/store.ts
+++ b/src/lib/server/idempotency/store.ts
@@ -177,6 +177,46 @@ export type IdempotencyCheckResult =
       payloadHash: string;
     };
 
+/**
+ * Configuration for `createIdempotencyStore`.
+ *
+ * **Cached responses at rest — handler responsibility.** The store
+ * caches whatever the handler returned as the response payload, then
+ * `JSON.stringify`-s it into the configured backend for the declared
+ * `ttlSeconds` (default 24h, max 7d). The hash-exclusion list strips
+ * `idempotency_key`, `governance_context`, and
+ * `push_notification_config.authentication.credentials` from the
+ * **hash** so a rotated credential on retry doesn't false-conflict,
+ * but the **stored response** is the handler's verbatim output.
+ *
+ * If a handler returns a response that includes:
+ *
+ * - a refreshed bearer / OAuth access token,
+ * - a signed governance / auth payload,
+ * - `push_notification_config.authentication.credentials` (echoed back),
+ * - any other secret material,
+ *
+ * those secrets sit at rest in the backend for `ttlSeconds`. On Redis
+ * without TLS, they're also plaintext over the wire. The framework
+ * does not scrub responses before caching — the AdCP spec doesn't
+ * require it of either party, and a built-in scrubber would change
+ * the wire shape of legitimate adopter responses without warning.
+ *
+ * Practical guidance:
+ *
+ * - **Don't return credentials in handler responses.** The spec
+ *   doesn't require it for any tool; if your adapter is echoing
+ *   them back, refactor.
+ * - If you must return them (e.g., a buyer-supplied webhook
+ *   credential that the spec asks you to echo so the buyer can
+ *   confirm receipt), wrap your handler to scrub before
+ *   returning, OR use a custom `IdempotencyBackend` that
+ *   transforms entries on the write path.
+ *
+ * See also `docs/guides/CTX-METADATA-SAFETY.md` for related guidance
+ * on what NOT to put in `ctx_metadata` (which has its own caching
+ * surface with the same at-rest concern).
+ */
 export interface IdempotencyStoreConfig {
   /** Storage backend. Use `memoryBackend()` for tests, `pgBackend(pool)` for production. */
   backend: IdempotencyBackend;

--- a/src/lib/signing/redis-replay-store.ts
+++ b/src/lib/signing/redis-replay-store.ts
@@ -32,6 +32,31 @@
  * to see exactly one `'ok'` and one `'replayed'` — matches the
  * `InMemoryReplayStore` semantics the spec mandates.
  *
+ * **Redis memory policy — set this on the deployment.** Each
+ * `(keyid, scope)` sorted set is capped (default 100k nonces). A
+ * hostile signer with a valid keyid + scope can fill the set to its
+ * cap; legitimate fan-out (many sibling verifiers, many scopes) grows
+ * the number of sets. Configure your Redis with:
+ *
+ * - **`maxmemory-policy volatile-lru`** (recommended) — evicts only
+ *   TTL'd keys. All sets this store writes carry `PEXPIREAT`, so
+ *   they're all evictable. Safe on a shared Redis instance.
+ * - **`maxmemory-policy allkeys-lru`** — only on a dedicated db.
+ *   Otherwise evicts unrelated app keys.
+ * - **`maxmemory-policy noeviction`** (Redis default) — fail-closed:
+ *   writes start erroring at the memory limit; the verifier will
+ *   throw and the middleware will return 500 (replay protection
+ *   stays intact — never fail-open). Operationally noisy but
+ *   never serves stale replay decisions.
+ *
+ * Eviction-on-replay implication: if `volatile-lru` evicts a sorted
+ * set before its members would have expired naturally, an attacker's
+ * later replay of one of those nonces sees a fresh set with no prior
+ * entry, returns `'ok'`. The cap is the primary defense; memory-policy
+ * eviction is a secondary recovery mode. Size Redis to keep the
+ * working set in memory under normal traffic and treat eviction as
+ * pressure to scale up, not as a feature.
+ *
  * @example
  * ```typescript
  * import { createClient } from 'redis';


### PR DESCRIPTION
Closes #1856 + #1857.

## Summary

Doc-only PR. No code behavior changes. PR #1858's security review flagged two operational gotchas as deferred follow-ups; JSDoc at every Redis-backend entrypoint and the CTX-METADATA-SAFETY guide now name them at the read site.

## What changed

- **`IdempotencyStoreConfig` JSDoc** (`src/lib/server/idempotency/store.ts`) — the cached-response-at-rest concern (#1856). Hash-exclusion strips credentials from the *hash* but the *stored response* is the handler's verbatim output. Refreshed bearer tokens / signed governance payloads / echoed `push_notification_config` credentials sit at rest for `ttlSeconds` if a handler returns them. Adopter guidance: don't return credentials; wrap a scrubber if you must.
- **`docs/guides/CTX-METADATA-SAFETY.md`** — new section cross-links to the idempotency JSDoc and the #1856 tracking issue. Both surfaces (ctx_metadata cache + idempotency response cache) have the same at-rest concern.
- **`redisBackend`, `RedisReplayStore`, `redisCtxMetadataStore` JSDoc** — `maxmemory-policy` matrix on each (#1857). `volatile-lru` recommended on shared instances (AdCP keys all carry TTL), `allkeys-lru` only on dedicated db, `noeviction` for fail-closed paging-vs-eviction operators. `RedisReplayStore` additionally calls out the eviction-on-replay caveat — an evicted sorted set looks empty to `has()`, so a later replay returns `ok`; the per-`(keyid, scope)` cap is the primary defense, eviction is secondary recovery.

## Why the SDK doesn't ship a built-in response scrubber

A built-in scrubber would change the wire shape of legitimate adopter responses without warning. The track-record-of-shipped-credentials-in-responses issue is rare enough that opting into a scrubber per-deployment is the right shape. The JSDoc names two opt-in paths: wrap the handler, or use a custom `IdempotencyBackend` that transforms entries on write.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `npm run build:lib` clean
- [x] `npm run format:check` clean
- [x] 71/71 across idempotency-store + Redis replay + Redis ctx-metadata tests — JSDoc changes don't touch behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)