### PR TITLE
fix(cli): storyboard run banner shows 'basic' not 'bearer' for --auth-scheme basic

### DIFF
--- a/.changeset/fix-storyboard-basic-auth-label.md
+++ b/.changeset/fix-storyboard-basic-auth-label.md
@@ -1,0 +1,7 @@
+---
+"@adcp/sdk": patch
+---
+
+fix(cli): storyboard run banner shows 'basic' instead of 'bearer' when --auth-scheme basic is used
+
+The chained ternary that builds the `Auth:` label in the `adcp storyboard run` run-header had no `'basic'` branch. When `buildResolvedAuthOption` returned `{ type: 'basic', … }`, the chain fell through to the `'bearer'` default, printing `Auth: bearer` even though the correct Basic header was sent on the wire. Fixed by adding an explicit `authOption.type === 'basic' ? 'basic' :` branch before the `'bearer'` fallback.

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -4216,7 +4216,9 @@ async function runFullAssessment(agentArg, rawArgs, parsedOpts) {
         ? 'oauth (auto-refresh)'
         : authOption.type === 'oauth_client_credentials'
           ? 'oauth client credentials (auto-refresh)'
-          : 'bearer';
+          : authOption.type === 'basic'
+            ? 'basic'
+            : 'bearer';
     console.log(`\nRunning storyboard assessment against ${agentUrl}`);
     console.log(`   Protocol: ${protocol.toUpperCase()}`);
     if (storyboards) console.log(`   Storyboards: ${storyboards.join(', ')}`);

--- a/test/lib/cli-auth-scheme.test.js
+++ b/test/lib/cli-auth-scheme.test.js
@@ -336,6 +336,44 @@ test('401 path surfaces the --auth-scheme basic hint before bouncing to OAuth', 
   );
 });
 
+test('storyboard run banner shows "Auth: basic" not "Auth: bearer" when --auth-scheme basic', async t => {
+  // The banner at bin/adcp.js:4213 previously had no 'basic' branch and fell
+  // through to 'bearer', misleading operators into thinking --auth-scheme
+  // wasn't being picked up even though the wire auth was correct (issue #1865).
+  const server = http.createServer((req, res) => {
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({}));
+  });
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  const port = server.address().port;
+  const url = `http://127.0.0.1:${port}/mcp`;
+  t.after(async () => {
+    if (typeof server.closeAllConnections === 'function') server.closeAllConnections();
+    await new Promise(resolve => server.close(() => resolve()));
+  });
+
+  const run = await new Promise(resolve => {
+    const child = spawn(
+      'node',
+      [CLI, 'storyboard', 'run', url, '--auth', 'user:pass', '--auth-scheme', 'basic', '--allow-http'],
+      { env: { ...process.env, HOME: tmpHome } }
+    );
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', d => (stdout += d.toString()));
+    child.stderr.on('data', d => (stderr += d.toString()));
+    // Kill after 8s — the banner appears immediately; we don't need a full run.
+    const killer = setTimeout(() => child.kill('SIGTERM'), 8000);
+    child.on('exit', code => {
+      clearTimeout(killer);
+      resolve({ status: code, stdout, stderr });
+    });
+  });
+
+  assert.match(run.stdout, /Auth: basic/, `banner must show 'Auth: basic'; stdout: ${run.stdout}`);
+  assert.doesNotMatch(run.stdout, /Auth: bearer/, `banner must not say 'bearer'; stdout: ${run.stdout}`);
+});
+
 test('wire test: basic alias sends Authorization: Basic <b64(user:pass)>, not Bearer', async t => {
   // Spin up a tiny MCP-ish server that captures every Authorization header
   // it sees and returns 401 so the CLI exits quickly. The /mcp probe and the


### PR DESCRIPTION
Closes #1865

## Summary

The `adcp storyboard run` run-header banner printed `Auth: bearer` even when `--auth-scheme basic` was passed. The chained ternary that builds the label had branches for `oauth`, `oauth_client_credentials`, and a bare `'bearer'` fallback — but no `'basic'` branch. `buildResolvedAuthOption` returns `{ type: 'basic', username, password }` for basic auth, so `authOption.type === 'basic'` fell through to the `'bearer'` default, printing a misleading label while the correct `Authorization: Basic <b64>` header was sent on the wire.

Fix: add `authOption.type === 'basic' ? 'basic' :` before the `'bearer'` fallback in the `authLabel` ternary at `bin/adcp.js:4216`. No wire behavior changed — display only.

Note: the debug-block label at line 5815 uses `authScheme` (a different variable) and already handles basic correctly — not affected.

## What was tested

- `npm run format:check` — clean
- `npm run typecheck` — clean (pre-existing TS5107 deprecation warning on main is unrelated)
- Pre-push hook passed (format + typecheck + build:lib)
- `node --test test/lib/cli-auth-scheme.test.js` — **16/16 pass**, including new banner regression test

New test (`cli-auth-scheme.test.js`): spins up a local HTTP server, runs `adcp storyboard run <url> --auth user:pass --auth-scheme basic --allow-http`, and asserts stdout contains `Auth: basic` and not `Auth: bearer`. The banner is printed synchronously before any storyboard execution, so the 8 s kill is just cleanup — the assertion fires immediately.

**Pre-PR review:**
- code-reviewer: approved — fix is correct and complete; only four `authOption.type` values exist in the registry (`bearer | basic | oauth | oauth_client_credentials`); nit: `'bearer'` fallback is now unreachable in practice
- dx-expert: approved — fix is minimal and correct; nit: inconsistency between banner (`'basic'`) and debug block (`'basic (user:pass)'`) is pre-existing and out of scope for this PR; follow-up to extract a shared `formatAuthLabel` helper suggested

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_017PZa8NSZ9Jnih5wYVS1Kmp

---
_Generated by [Claude Code](https://claude.ai/code/session_017PZa8NSZ9Jnih5wYVS1Kmp)_