### PR TITLE
fix(client): forward custom headers on getAgentInfo path (basic-auth MCP agents broken)

### DIFF
--- a/.changeset/fix-basic-auth-header-1864.md
+++ b/.changeset/fix-basic-auth-header-1864.md
@@ -1,0 +1,25 @@
+---
+"@adcp/sdk": patch
+---
+
+fix(client): forward custom headers to connectMCP on getAgentInfo path
+
+Basic-auth MCP agents were completely broken via `SingleAgentClient.executeTask`.
+Two cooperating defects caused the `Authorization: Basic …` header to be silently
+dropped on the `getCapabilities()` precheck that every `executeTask` invocation
+runs before dispatching the actual tool call:
+
+**Defect A** (`SingleAgentClient.getAgentInfo`): `connectOptions` was built
+without `this.normalizedAgent.headers`, so `connectMCP` received `{ agentUrl }`
+only when neither OAuth nor a bearer token was present. Fixed by always forwarding
+`normalizedAgent.headers` as `customHeaders`.
+
+**Defect B** (`connectMCP`): the `transportOptions.requestInit.headers` assignment
+was nested inside `else if (authToken)`, so caller-supplied `customHeaders` were
+silently dropped whenever `authToken` was absent. Fixed by computing `authHeaders`
+unconditionally (merging with token headers when present) and setting
+`requestInit` whenever the result is non-empty. As a bonus, `authProvider` is no
+longer exclusive with `requestInit.headers` — OAuth callers with custom routing
+headers (x-tenant-id, x-api-key, etc.) now get them forwarded too.
+
+Fixes #1864.

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -2726,6 +2726,9 @@ export class SingleAgentClient {
       } else if (this.normalizedAgent.auth_token) {
         connectOptions.authToken = this.normalizedAgent.auth_token;
       }
+      if (this.normalizedAgent.headers) {
+        connectOptions.customHeaders = this.normalizedAgent.headers;
+      }
 
       const { client: mcpClient } = await connectMCP(connectOptions);
       try {

--- a/src/lib/protocols/mcp.ts
+++ b/src/lib/protocols/mcp.ts
@@ -653,7 +653,7 @@ export async function connectMCP(options: {
     type: 'info',
     message: `MCP: Connecting to ${baseUrl}`,
     timestamp: new Date().toISOString(),
-    authMethod: authProvider ? 'oauth' : authToken ? 'token' : 'none',
+    authMethod: authProvider ? 'oauth' : authToken ? 'token' : extractAuthHeader(customHeaders) ? 'custom' : 'none',
   });
 
   const mcpClient = new MCPClient({

--- a/src/lib/protocols/mcp.ts
+++ b/src/lib/protocols/mcp.ts
@@ -664,21 +664,28 @@ export async function connectMCP(options: {
   // Build transport options
   const transportOptions: StreamableHTTPClientTransportOptions = {};
 
+  // Set requestInit.headers whenever any custom or auth headers are present.
+  // authProvider and requestInit.headers are not mutually exclusive — the MCP
+  // SDK's _commonHeaders() spreads requestInit.headers alongside any
+  // OAuth-issued Authorization, so OAuth callers with custom routing headers
+  // (x-tenant-id, x-api-key, etc.) also get them forwarded.
+  const authHeaders = authToken ? { ...customHeaders, ...createMCPAuthHeaders(authToken) } : { ...customHeaders };
+  if (Object.keys(authHeaders).length > 0) {
+    transportOptions.requestInit = { headers: authHeaders };
+    debugLogs.push({
+      type: 'info',
+      message: authToken
+        ? 'MCP: Using static token for authentication'
+        : 'MCP: Using custom headers for authentication',
+      timestamp: new Date().toISOString(),
+    });
+  }
   if (authProvider) {
     // Use OAuth provider
     transportOptions.authProvider = authProvider;
     debugLogs.push({
       type: 'info',
       message: 'MCP: Using OAuth provider for authentication',
-      timestamp: new Date().toISOString(),
-    });
-  } else if (authToken) {
-    // Use static token, merged with any custom headers (auth takes precedence)
-    const authHeaders = { ...customHeaders, ...createMCPAuthHeaders(authToken) };
-    transportOptions.requestInit = { headers: authHeaders };
-    debugLogs.push({
-      type: 'info',
-      message: 'MCP: Using static token for authentication',
       timestamp: new Date().toISOString(),
     });
   }

--- a/test/lib/connect-mcp-custom-headers.test.js
+++ b/test/lib/connect-mcp-custom-headers.test.js
@@ -1,0 +1,158 @@
+/**
+ * Regression tests for #1864: custom headers (including Authorization: Basic)
+ * must be forwarded to the MCP server on the connectMCP path (used by
+ * getAgentInfo / SingleAgentClient.getCapabilities).
+ *
+ * Prior to the fix, connectMCP only set requestInit.headers inside
+ * `else if (authToken)` — pure-header auth schemes (Basic, x-api-key, etc.)
+ * were silently dropped, breaking every basic-auth MCP agent on every
+ * executeTask precheck. The connectMCPWithFallback path (used by callMCPTool)
+ * was already correct and does not need coverage here.
+ */
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert');
+const http = require('node:http');
+
+const { connectMCP, closeMCPConnections } = require('../../dist/lib/protocols/mcp');
+const { AgentClient } = require('../../dist/lib/core/AgentClient');
+
+// Minimal MCP-over-StreamableHTTP server: handles initialize + notifications/initialized + tools/list.
+function createMcpServer(onRequest) {
+  return http.createServer((req, res) => {
+    onRequest(req);
+    let body = '';
+    req.on('data', chunk => (body += chunk));
+    req.on('end', () => {
+      let msg;
+      try {
+        msg = JSON.parse(body);
+      } catch {
+        res.writeHead(400);
+        return res.end();
+      }
+      if (!msg || typeof msg !== 'object') {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        return res.end(JSON.stringify({ jsonrpc: '2.0', id: null, result: {} }));
+      }
+      const id = msg.id ?? null;
+      let result;
+      if (msg.method === 'initialize') {
+        result = {
+          protocolVersion: '2024-11-05',
+          serverInfo: { name: 'test', version: '1.0.0' },
+          capabilities: { tools: {} },
+        };
+      } else if (msg.method === 'notifications/initialized') {
+        res.writeHead(202);
+        return res.end();
+      } else if (msg.method === 'tools/list') {
+        result = { tools: [] };
+      } else {
+        result = {};
+      }
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ jsonrpc: '2.0', id, result }));
+    });
+  });
+}
+
+describe('connectMCP — custom headers forwarding (issue #1864)', () => {
+  let server;
+  let baseUrl;
+  // Per-test capture callback — reassigned in each test to avoid mutating
+  // server listener state between tests.
+  let captureHeader = () => {};
+
+  before(async () => {
+    server = createMcpServer(req => captureHeader(req));
+    await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+    baseUrl = `http://127.0.0.1:${server.address().port}/mcp`;
+  });
+
+  after(async () => {
+    await closeMCPConnections();
+    if (typeof server.closeAllConnections === 'function') server.closeAllConnections();
+    await new Promise(resolve => server.close(resolve));
+  });
+
+  it('forwards Authorization: Basic header when no authToken or authProvider is set', async () => {
+    const capturedAuths = [];
+    captureHeader = req => capturedAuths.push(req.headers.authorization ?? '');
+
+    const basicCred = 'Basic ' + Buffer.from('user:pass').toString('base64');
+    const { client } = await connectMCP({
+      agentUrl: baseUrl,
+      customHeaders: { Authorization: basicCred },
+    });
+    await client.close();
+
+    assert.ok(
+      capturedAuths.some(h => h === basicCred),
+      `expected server to receive Authorization: Basic header. Got: ${JSON.stringify(capturedAuths)}`
+    );
+  });
+
+  it('forwards custom x-api-key header when no authToken is set', async () => {
+    const seenXApiKey = [];
+    captureHeader = req => seenXApiKey.push(req.headers['x-api-key'] ?? '');
+
+    const { client } = await connectMCP({
+      agentUrl: baseUrl,
+      customHeaders: { 'x-api-key': 'tenant-key-123' },
+    });
+    await client.close();
+
+    assert.ok(
+      seenXApiKey.some(v => v === 'tenant-key-123'),
+      `expected server to receive x-api-key header. Got: ${JSON.stringify(seenXApiKey)}`
+    );
+  });
+});
+
+describe('SingleAgentClient.getAgentInfo() — custom headers forwarded (issue #1864, Defect A)', () => {
+  let server;
+  let baseUrl;
+  const seenAuths = [];
+
+  before(async () => {
+    server = createMcpServer(req => {
+      seenAuths.push(req.headers.authorization ?? '');
+    });
+    await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+    baseUrl = `http://127.0.0.1:${server.address().port}/mcp`;
+  });
+
+  after(async () => {
+    await closeMCPConnections();
+    if (typeof server.closeAllConnections === 'function') server.closeAllConnections();
+    await new Promise(resolve => server.close(resolve));
+  });
+
+  it('sends Authorization: Basic header on the getAgentInfo (tools/list) request', async () => {
+    seenAuths.length = 0;
+    const basicCred = 'Basic ' + Buffer.from('agent-user:agent-pass').toString('base64');
+
+    const client = new AgentClient(
+      {
+        id: 'basic-auth-agent',
+        protocol: 'mcp',
+        agent_uri: baseUrl,
+        name: 'Basic Auth Test Agent',
+        headers: { Authorization: basicCred },
+        // auth_token intentionally absent — CLI suppresses it for basic-auth
+      },
+      {}
+    );
+
+    const info = await client.getAgentInfo();
+
+    assert.strictEqual(info.protocol, 'mcp');
+    assert.ok(Array.isArray(info.tools));
+    assert.ok(
+      seenAuths.some(h => h === basicCred),
+      `getAgentInfo must forward Authorization: Basic to the MCP server on the tools/list request. ` +
+        `Saw: ${JSON.stringify(seenAuths)} — regression means Defect A is back`
+    );
+  });
+});


### PR DESCRIPTION
Closes #1864

## Summary

Two cooperating defects silently dropped `Authorization: Basic …` headers on the `getCapabilities()` precheck that `SingleAgentClient.executeTask` runs before every tool dispatch, making every basic-auth MCP agent completely unusable.

**Defect A — `SingleAgentClient.getAgentInfo` didn't forward `customHeaders`** (`src/lib/core/SingleAgentClient.ts:~2726`): `connectOptions` was assembled without `this.normalizedAgent.headers`, so `connectMCP` received `{ agentUrl }` only when neither OAuth tokens nor a bearer token were present. Fixed by unconditionally forwarding `normalizedAgent.headers` as `customHeaders`.

**Defect B — `connectMCP` only set `requestInit.headers` inside `else if (authToken)`** (`src/lib/protocols/mcp.ts:~664`): caller-supplied `customHeaders` were silently dropped when `authToken` was absent. Fixed by computing `authHeaders` unconditionally (merged with token headers when present) and setting `requestInit` whenever the result is non-empty. As a bonus, `authProvider` is no longer exclusive with `requestInit.headers` — OAuth callers with custom routing headers (`x-tenant-id`, `x-api-key`) now get them forwarded too.

Also fixed: the initial debug log now emits `authMethod: 'custom'` (rather than `'none'`) when only `customHeaders` carry an `Authorization` header, so basic-auth failures are diagnosable from debug output.

## What was tested

- `npm run format:check` — clean
- `tsc --project tsconfig.lib.json` — clean (pre-existing `moduleResolution=node10` deprecation warning is not new)
- `node --test test/lib/connect-mcp-custom-headers.test.js` — 3/3 pass
  - `connectMCP` forwards `Authorization: Basic` with no `authToken`
  - `connectMCP` forwards `x-api-key` with no `authToken`
  - `SingleAgentClient.getAgentInfo` sends `Authorization: Basic` to the MCP server (Defect A end-to-end)
- Full test suite baseline: 669 failures before and after (pre-existing env issues — Redis/Postgres/schema CDN not available in this environment; CI runs the complete suite)

## Pre-PR review

- **code-reviewer**: approved — both blockers (authMethod misreport, missing regression test) resolved; nit about `removeAllListeners` test isolation fixed
- **dx-expert**: approved for the core fix — noted pre-existing `auth_token` + `customHeaders.Authorization` spread-order precedence (same in `callMCPToolImpl`; CLI prevents the combination for basic-auth by suppressing `auth_token`)

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01DAtQqcuNuyaFB7EUDVXJH1

---
_Generated by [Claude Code](https://claude.ai/code/session_01DAtQqcuNuyaFB7EUDVXJH1)_