### PR TITLE
fix(cli): resolve --base to origin/<branch> so diffs are never against a stale local copy

### DIFF
--- a/docs/development/REVIEW-STACKS.md
+++ b/docs/development/REVIEW-STACKS.md
@@ -44,6 +44,12 @@ npm run review:codex -- --persona security --base main
 npm run review:codex -- --all --base main
 ```
 
+> **Staleness note:** bare branch names like `main` are automatically resolved
+> to `origin/main` (the script fetches the remote branch before diffing). If
+> the fetch fails (network outage, CI runner without remote access), a warning
+> is printed and the diff falls back to whatever `origin/main` was last
+> fetched. Pass `--base origin/main` explicitly to skip the automatic fetch.
+
 Persona prompts live in `scripts/codex-review-prompts/{dx,protocol,code,security}.md`. Output goes to `$TMPDIR/codex-review-<persona>.txt`. `--all` skips `dx` because the Claude DX-expert has codebase-specific rubric knowledge that's hard to replicate in a general-purpose agent — if you want a codex DX second opinion, run `--persona dx` explicitly.
 
 ### Claude side

--- a/docs/development/REVIEW-STACKS.md
+++ b/docs/development/REVIEW-STACKS.md
@@ -46,9 +46,10 @@ npm run review:codex -- --all --base main
 
 > **Staleness note:** bare branch names like `main` are automatically resolved
 > to `origin/main` (the script fetches the remote branch before diffing). If
-> the fetch fails (network outage, CI runner without remote access), a warning
-> is printed and the diff falls back to whatever `origin/main` was last
-> fetched. Pass `--base origin/main` explicitly to skip the automatic fetch.
+> the fetch fails, a warning is printed and the diff falls back to the
+> last-fetched `origin/main` — or fails outright if `origin/main` has never
+> been fetched in this clone. Pass `--base origin/main` explicitly to skip the
+> auto-fetch.
 
 Persona prompts live in `scripts/codex-review-prompts/{dx,protocol,code,security}.md`. Output goes to `$TMPDIR/codex-review-<persona>.txt`. `--all` skips `dx` because the Claude DX-expert has codebase-specific rubric knowledge that's hard to replicate in a general-purpose agent — if you want a codex DX second opinion, run `--persona dx` explicitly.
 

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -92,6 +92,17 @@ else
   validate_persona "$PERSONA"
 fi
 
+# Resolve BASE_BRANCH to origin/<branch> so the diff is never against a stale
+# local copy. A bare branch name like "main" is automatically normalized;
+# pass "origin/main" explicitly to skip the fetch.
+if [[ -n "$BASE_BRANCH" && "$BASE_BRANCH" != origin/* && "$BASE_BRANCH" != refs/remotes/* ]]; then
+  echo "[codex-review] fetching origin/$BASE_BRANCH..." >&2
+  if ! git fetch origin "$BASE_BRANCH"; then
+    echo "[codex-review] warning: fetch failed — diff may include stale commits" >&2
+  fi
+  BASE_BRANCH="origin/$BASE_BRANCH"
+fi
+
 # Gather PR context. Either piped via stdin, or auto-built from git diff
 # against the base branch if --base is provided. Auto-built context names
 # changed files so codex knows where to look without manual setup.
@@ -114,7 +125,7 @@ elif [[ -n "$BASE_BRANCH" ]]; then
     git log --oneline "$BASE_BRANCH"..HEAD
   } > "$CONTEXT_FILE"
 else
-  echo "No stdin and no --base — supply one." >&2
+  echo "No stdin and no --base — supply one (e.g. --base origin/main)." >&2
   exit 2
 fi
 

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -92,17 +92,6 @@ else
   validate_persona "$PERSONA"
 fi
 
-# Resolve BASE_BRANCH to origin/<branch> so the diff is never against a stale
-# local copy. A bare branch name like "main" is automatically normalized;
-# pass "origin/main" explicitly to skip the fetch.
-if [[ -n "$BASE_BRANCH" && "$BASE_BRANCH" != origin/* && "$BASE_BRANCH" != refs/remotes/* ]]; then
-  echo "[codex-review] fetching origin/$BASE_BRANCH..." >&2
-  if ! git fetch origin "$BASE_BRANCH"; then
-    echo "[codex-review] warning: fetch failed — diff may include stale commits" >&2
-  fi
-  BASE_BRANCH="origin/$BASE_BRANCH"
-fi
-
 # Gather PR context. Either piped via stdin, or auto-built from git diff
 # against the base branch if --base is provided. Auto-built context names
 # changed files so codex knows where to look without manual setup.
@@ -112,6 +101,16 @@ trap 'rm -f "$CONTEXT_FILE"' EXIT
 if [[ ! -t 0 ]]; then
   cat > "$CONTEXT_FILE"
 elif [[ -n "$BASE_BRANCH" ]]; then
+  # Resolve BASE_BRANCH to origin/<branch> so the diff is never against a stale
+  # local copy. A bare branch name like "main" is automatically normalized;
+  # pass "origin/main" explicitly to skip the auto-fetch.
+  if [[ "$BASE_BRANCH" != origin/* && "$BASE_BRANCH" != refs/remotes/* ]]; then
+    echo "[codex-review] fetching origin/$BASE_BRANCH..." >&2
+    if ! git fetch origin "$BASE_BRANCH"; then
+      echo "[codex-review] warning: fetch failed — diff may include stale commits" >&2
+    fi
+    BASE_BRANCH="origin/$BASE_BRANCH"
+  fi
   {
     echo "## Changes on this branch vs \`$BASE_BRANCH\`"
     echo


### PR DESCRIPTION
Closes #1871

When `--base main` is passed to `scripts/codex-review.sh`, the script was diffing against the **local** `main` branch rather than `origin/main`. On a typical developer machine where `git pull` hasn't run recently, this produces a fabricated diff spanning every commit since the last fetch — causing codex to review entirely the wrong files with no warning.

The fix moves the normalization block inside the `elif [[ -n "$BASE_BRANCH" ]]` branch (so stdin callers don't trigger a spurious fetch), fetches the remote branch with a visible log line, rewrites `BASE_BRANCH` to `origin/$BASE_BRANCH`, and warns on fetch failure rather than silently continuing with stale state. The error message and `REVIEW-STACKS.md` doc note are updated to make `origin/main` the canonical example.

## What was tested

- `bash -n scripts/codex-review.sh` — syntax clean
- `npx tsx scripts/check-doc-links.ts` — all SDK→docs URLs resolve
- `npm run format:check` — clean
- `npm run typecheck` / `npm run ci:quick` — pre-existing `@types/node` environment gap in container; unrelated to this diff (bash + markdown only)

**Pre-PR review:**
- code-reviewer: approved — no blockers; flagged (and fixed) spurious fetch when stdin is used; two nits noted in PR body
- dx-expert: approved — no blockers; nit on doc fallback language addressed in second commit

**Nits noted (not fixed — low signal value):**
- `refs/remotes/*` guard is not documented in the staleness note; a `refs/remotes/origin/main` form also bypasses the auto-fetch but isn't mentioned
- On success the fetch message prints before the operation completes; a "confirmed fresh" message on success only would match the script's existing silent-on-success convention

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01RZZWXSe1cQ7KjkdgbS5ef7

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZZWXSe1cQ7KjkdgbS5ef7)_