### PR TITLE
fix(scripts): codex-review.sh --base resolves to origin/<branch>

### DIFF
--- a/.changeset/codex-review-base-origin.md
+++ b/.changeset/codex-review-base-origin.md
@@ -1,0 +1,11 @@
+---
+'@adcp/sdk': patch
+---
+
+chore(scripts): `codex-review.sh --base <branch>` now resolves to `origin/<branch>` after a fetch
+
+Tooling-only. Fixes a footgun caught while reviewing #1866: `--base main` was reading the local `main` branch, not `origin/main`. Stale local `main` (the default state on most dev machines) produced a fabricated diff that included every commit between the user's last `git pull` and HEAD — codex returned a review about Redis backends from PRs that had already merged, with no signal to the reviewer that the diff was wrong.
+
+The script now resolves `--base <local-branch>` to `refs/remotes/origin/<branch>` after `git fetch origin <branch>`. Pass an already-qualified ref (`origin/main`, a SHA, a tag) to bypass resolution; pass `--no-fetch` to skip the fetch entirely. Stderr prints the resolved form so callers can confirm: `codex-review: --base main → origin/main`.
+
+`scripts/` is not in `package.json` `files`, so this isn't published. Patch-bump because the changeset CI gate requires a non-empty changeset on every PR. Closes #1871.

--- a/docs/development/REVIEW-STACKS.md
+++ b/docs/development/REVIEW-STACKS.md
@@ -46,6 +46,8 @@ npm run review:codex -- --all --base main
 
 Persona prompts live in `scripts/codex-review-prompts/{dx,protocol,code,security}.md`. Output goes to `$TMPDIR/codex-review-<persona>.txt`. `--all` skips `dx` because the Claude DX-expert has codebase-specific rubric knowledge that's hard to replicate in a general-purpose agent — if you want a codex DX second opinion, run `--persona dx` explicitly.
 
+**`--base` resolves to the remote-tracking ref.** When you pass `--base main`, the script fetches `origin/main` and diffs against that — not your locally-checked-out `main`. This matters because stale local `main` produces fabricated diffs that include already-merged PRs (caught while reviewing #1866 — codex returned findings about Redis backends from PRs that had already merged because my local `main` was four PRs behind). Pass an already-qualified ref (`origin/main`, a SHA, a tag) to bypass resolution, or `--no-fetch` to skip the fetch entirely.
+
 ### Claude side
 
 Use the `Agent` tool with four parallel calls — DX, protocol, code-reviewer, security — in a single message. Pattern documented in `~/.claude/projects/.../memory/feedback_parallel_expert_review.md` (see also `feedback_codex_dual_stack.md` for when to add codex).

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -8,6 +8,13 @@
 # PR-specific context is supplied via stdin OR auto-built from
 # `git diff --stat $BASE...HEAD` when `--base` is given.
 #
+# When `--base` is a local branch name (e.g. `main`), the script resolves
+# it to `refs/remotes/origin/<branch>` after a fetch — comparing against
+# the locally-checked-out branch is a footgun (stale local `main` produces
+# fabricated diffs that include already-merged PRs). Pass `--base
+# origin/main` explicitly to skip resolution; pass `--no-fetch` to skip
+# the fetch entirely.
+#
 # Personas (each maps to a prompt file in scripts/codex-review-prompts/):
 #   dx        — adopter ergonomics, JSDoc copy-paste-ability, error actionability
 #   protocol  — atomicity, ordering, parity with sibling backends
@@ -35,6 +42,7 @@ OUT_DIR="${TMPDIR:-/tmp}"
 PERSONA=""
 RUN_ALL=0
 BASE_BRANCH=""
+NO_FETCH=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -52,8 +60,12 @@ while [[ $# -gt 0 ]]; do
       BASE_BRANCH="$2"
       shift 2
       ;;
+    --no-fetch)
+      NO_FETCH=1
+      shift
+      ;;
     --help|-h)
-      sed -n '2,28p' "$0"
+      sed -n '2,36p' "$0"
       exit 0
       ;;
     *)
@@ -62,6 +74,47 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+# Resolve --base to the remote-tracking ref so the diff reflects shipped
+# state, not whatever the user happens to have locally checked out. The
+# only escape hatch is passing an already-qualified ref (e.g. `origin/main`
+# or a SHA) — those bypass resolution and are used verbatim.
+resolve_base_branch() {
+  local raw="$1"
+  if [[ -z "$raw" ]]; then
+    echo ""
+    return 0
+  fi
+  # If it's not a local branch (SHA, tag, or already-qualified ref like
+  # `origin/main`), use it verbatim.
+  if ! git show-ref --verify -q "refs/heads/$raw"; then
+    echo "$raw"
+    return 0
+  fi
+  # Plain local-branch name — fetch and resolve to origin/<branch>.
+  if [[ "$NO_FETCH" -eq 0 ]]; then
+    git fetch --quiet origin "$raw" 2>/dev/null || {
+      echo "codex-review: warning: 'git fetch origin $raw' failed; using local '$raw'." >&2
+      echo "$raw"
+      return 0
+    }
+  fi
+  local remote_ref="origin/$raw"
+  if git rev-parse --verify -q "$remote_ref^{commit}" >/dev/null; then
+    echo "$remote_ref"
+  else
+    echo "codex-review: warning: '$remote_ref' not found after fetch; falling back to local '$raw'." >&2
+    echo "$raw"
+  fi
+}
+
+if [[ -n "$BASE_BRANCH" ]]; then
+  RESOLVED_BASE="$(resolve_base_branch "$BASE_BRANCH")"
+  if [[ "$RESOLVED_BASE" != "$BASE_BRANCH" ]]; then
+    echo "codex-review: --base $BASE_BRANCH → $RESOLVED_BASE" >&2
+  fi
+  BASE_BRANCH="$RESOLVED_BASE"
+fi
 
 if [[ "$RUN_ALL" -eq 0 && -z "$PERSONA" ]]; then
   echo "Usage: scripts/codex-review.sh --persona <dx|protocol|code|security> [--base <branch>]" >&2


### PR DESCRIPTION
## Summary

Closes #1871. Caught while reviewing PR #1866 — `--base main` was reading the local `main` branch, not `origin/main`. Stale local main (default state on most dev machines) produced a fabricated diff that included every commit between the last local pull and HEAD. Codex returned a review about Redis backends from PRs that had already merged, with no signal to the reviewer that the diff was wrong.

## Fix

When `--base` names a local branch, resolve to `origin/<branch>` after `git fetch origin <branch>`. Already-qualified refs (`origin/main`, SHAs, tags) bypass resolution. New `--no-fetch` flag skips the fetch entirely.

The resolved form prints to stderr so callers can confirm what was used:

```
codex-review: --base main → origin/main
```

## Test plan

- [x] Resolver unit-tested locally on five cases: `main` → `origin/main`, `origin/main` → `origin/main`, `HEAD` → `HEAD`, an unpushed local branch → itself, a nonexistent name → itself
- [x] `bash -n scripts/codex-review.sh` clean
- [x] `--help` reflects new behavior and `--no-fetch` flag
- [x] `npm run format:check` passes (shell scripts skipped by prettier)
- [ ] Will exercise on the next safety-critical PR review

🤖 Generated with [Claude Code](https://claude.com/claude-code)