### PR TITLE
fix(mcp): connectMCP 401s carry auth-scheme context

### DIFF
--- a/.changeset/connect-mcp-auth-error-context.md
+++ b/.changeset/connect-mcp-auth-error-context.md
@@ -1,0 +1,19 @@
+---
+'@adcp/sdk': patch
+---
+
+fix(mcp): connectMCP 401 errors now carry auth-scheme context
+
+When `connectMCP` received a non-OAuth 401 from an agent, the rethrown error was a bare `Error POSTing to endpoint (HTTP 401): unauthorized` — no signal of which auth scheme the SDK actually selected, no remediation hint. The #1864 reporter cited this as a 30+ minute debugging cost: the bug landed at the precheck path, the failure mode was a silent 401, and the on-screen evidence pointed away from the actual cause.
+
+Non-OAuth 401s are now wrapped with:
+
+- `error.code === 'MCP_AUTH_REJECTED'` — programmatic dispatch tag.
+- `error.scheme` — one of `'bearer' | 'header' | 'oauth' | 'none'`. Tells the caller what the SDK actually put on the wire so they can diff against curl / the gateway's expectations.
+- `error.agentUrl` — the URL that rejected the credential.
+- `error.cause` — the original transport error, so existing `is401Error` / `err.status` checks downstream still resolve.
+- A scheme-specific hint in `error.message` (e.g. `--auth-scheme basic`, `verify the bearer token`, `OAuth provider returned tokens that the agent rejected`).
+
+Credential values are never included in the error message — verified by a regression test that asserts both the raw `Bearer …` and the decoded basic-auth payload are absent from the thrown message string.
+
+OAuth `UnauthorizedError` propagation (the SDK's flow-initiation signal) is unchanged. Closes #1869.

--- a/src/lib/protocols/mcp.ts
+++ b/src/lib/protocols/mcp.ts
@@ -744,6 +744,42 @@ export async function connectMCP(options: {
       // Return transport so caller can call finishAuth
       throw Object.assign(error, { transport, client: mcpClient });
     }
+
+    // Non-OAuth 401 — the SDK sent credentials that the agent rejected (or
+    // sent none when it needed them). The raw transport error is shaped like
+    // `Error POSTing to endpoint (HTTP 401): unauthorized`, which omits the
+    // crucial piece of debug data: *which auth scheme did the SDK actually
+    // use*. Without that, a caller can't diff against curl. Wrap the error
+    // with a scheme tag and a remediation hint, preserving the original
+    // under `.cause` so existing `is401Error` / `error.status` checks
+    // downstream still resolve.
+    if (is401Error(error)) {
+      const scheme = authProvider
+        ? 'oauth'
+        : authToken
+          ? 'bearer'
+          : Object.keys(authHeaders).length > 0
+            ? 'header'
+            : 'none';
+      const hint =
+        scheme === 'none'
+          ? 'No credentials were sent. Configure auth_token, headers, or oauth_tokens on the agent config (or pass --auth on the CLI).'
+          : scheme === 'header'
+            ? "Verify the Authorization header value matches the gateway (basic-auth: 'Basic ' + base64(user:pass); pair with --auth-scheme basic on the CLI)."
+            : scheme === 'bearer'
+              ? "Verify the bearer token matches the agent's expected credential."
+              : 'OAuth provider returned tokens that the agent rejected — check the provider configuration and token scopes.';
+      const detail = `MCP connect rejected with HTTP 401 from ${agentUrl}. SDK sent auth scheme: ${scheme}. ${hint}`;
+      const wrapped = Object.assign(new Error(detail), {
+        cause: error,
+        code: 'MCP_AUTH_REJECTED',
+        scheme,
+        agentUrl,
+        originalError: error,
+      });
+      throw wrapped;
+    }
+
     throw error;
   }
 }

--- a/test/lib/connect-mcp-401-context.test.js
+++ b/test/lib/connect-mcp-401-context.test.js
@@ -1,0 +1,123 @@
+/**
+ * Regression test for adcontextprotocol/adcp-client#1869.
+ *
+ * When `connectMCP` receives a 401 from the agent, the rethrown error must
+ * include the auth scheme the SDK actually used. The pre-fix behavior was a
+ * bare `Error POSTing to endpoint (HTTP 401): unauthorized` with no clue
+ * about whether the SDK selected bearer / basic / oauth / none — which sent
+ * the #1864 reporter chasing the wrong root cause for 30+ minutes.
+ *
+ * This test stands up an MCP loopback server that always returns 401, then
+ * exercises three credential shapes (bearer / header-only / none) and
+ * asserts the wrapped error tags each one correctly. The OAuth path is not
+ * exercised here — it requires `UnauthorizedError` semantics from the MCP
+ * SDK's auth flow, which is tested separately.
+ */
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert');
+const http = require('node:http');
+
+const { connectMCP, closeMCPConnections } = require('../../dist/lib/protocols');
+
+describe('connectMCP — 401 errors carry auth-scheme context', () => {
+  let server;
+  let baseUrl;
+
+  before(async () => {
+    server = http.createServer((req, res) => {
+      res.writeHead(401, { 'WWW-Authenticate': 'Basic realm="test"' });
+      res.end('unauthorized');
+    });
+    await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+    const { port } = server.address();
+    baseUrl = `http://127.0.0.1:${port}`;
+  });
+
+  after(async () => {
+    closeMCPConnections();
+    await new Promise(resolve => server.close(resolve));
+  });
+
+  it('wraps bearer-auth 401s with scheme="bearer"', async () => {
+    await assert.rejects(
+      () => connectMCP({ agentUrl: baseUrl, authToken: 'wrong-token' }),
+      err => {
+        assert.strictEqual(err.code, 'MCP_AUTH_REJECTED');
+        assert.strictEqual(err.scheme, 'bearer');
+        assert.match(err.message, /HTTP 401/);
+        assert.match(err.message, /scheme: bearer/);
+        assert.ok(err.cause, 'cause should be the original transport error');
+        return true;
+      }
+    );
+  });
+
+  it('wraps header-only 401s with scheme="header"', async () => {
+    await assert.rejects(
+      () =>
+        connectMCP({
+          agentUrl: baseUrl,
+          customHeaders: { Authorization: 'Basic ' + Buffer.from('user:wrong').toString('base64') },
+        }),
+      err => {
+        assert.strictEqual(err.code, 'MCP_AUTH_REJECTED');
+        assert.strictEqual(err.scheme, 'header');
+        assert.match(err.message, /scheme: header/);
+        assert.match(err.message, /--auth-scheme basic/);
+        return true;
+      }
+    );
+  });
+
+  it('wraps unauthenticated 401s with scheme="none"', async () => {
+    await assert.rejects(
+      () => connectMCP({ agentUrl: baseUrl }),
+      err => {
+        assert.strictEqual(err.code, 'MCP_AUTH_REJECTED');
+        assert.strictEqual(err.scheme, 'none');
+        assert.match(err.message, /scheme: none/);
+        assert.match(err.message, /No credentials were sent/);
+        return true;
+      }
+    );
+  });
+
+  it('exposes the agent URL on the wrapped error', async () => {
+    await assert.rejects(
+      () => connectMCP({ agentUrl: baseUrl, authToken: 'wrong' }),
+      err => {
+        assert.strictEqual(err.agentUrl, baseUrl);
+        return true;
+      }
+    );
+  });
+
+  it('does not leak the credential value in the error message', async () => {
+    const sensitiveToken = 'super-secret-token-do-not-leak';
+    await assert.rejects(
+      () => connectMCP({ agentUrl: baseUrl, authToken: sensitiveToken }),
+      err => {
+        assert.ok(!err.message.includes(sensitiveToken), `bearer token leaked into error message: ${err.message}`);
+        return true;
+      }
+    );
+
+    const sensitiveBasic = 'Basic ' + Buffer.from('user:sensitive-password').toString('base64');
+    await assert.rejects(
+      () =>
+        connectMCP({
+          agentUrl: baseUrl,
+          customHeaders: { Authorization: sensitiveBasic },
+        }),
+      err => {
+        assert.ok(!err.message.includes(sensitiveBasic), `basic credential leaked into error message: ${err.message}`);
+        assert.ok(
+          !err.message.includes('sensitive-password'),
+          `basic credential (post-decode) leaked into error message: ${err.message}`
+        );
+        return true;
+      }
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1869. Follow-up from #1864/#1866 expert review.

Pre-fix, a 401 on `connectMCP` rethrew the raw transport error:

```
Error POSTing to endpoint (HTTP 401): unauthorized
```

No signal of which auth scheme the SDK actually selected, no remediation hint. The #1864 reporter cited this as a 30+ minute debugging cost.

## Fix

Non-OAuth 401s are now wrapped with:

- `error.code === 'MCP_AUTH_REJECTED'` — programmatic dispatch tag.
- `error.scheme` — one of `'bearer' | 'header' | 'oauth' | 'none'`. Tells the caller what the SDK actually put on the wire.
- `error.agentUrl` — the URL that rejected the credential.
- `error.cause` — original transport error preserved (so `is401Error` / `err.status` checks downstream still resolve).
- A scheme-specific hint in `error.message`. Examples:
  - `bearer` → "Verify the bearer token matches the agent's expected credential."
  - `header` → "Verify the Authorization header value matches the gateway (basic-auth: 'Basic ' + base64(user:pass); pair with --auth-scheme basic on the CLI)."
  - `none` → "No credentials were sent. Configure auth_token, headers, or oauth_tokens on the agent config (or pass --auth on the CLI)."
  - `oauth` → "OAuth provider returned tokens that the agent rejected — check the provider configuration and token scopes."

Credential values are **never** included in the error message. Regression test asserts both the raw `Bearer …` and the decoded basic-auth payload are absent from the thrown message string.

OAuth `UnauthorizedError` propagation (the SDK's flow-initiation signal) is unchanged.

## Test plan

- [x] New tests (5) cover bearer / header / none schemes + agentUrl exposure + no-credential-leak
- [x] Broader MCP/agent cohort runs clean: 44 tests across 10 suites
- [x] `npm run format:check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)