### PR TITLE
fix(client): enrich connectMCP 401 errors with typed MCPAuthRejectedError

### DIFF
--- a/.changeset/mcp-auth-rejected-error.md
+++ b/.changeset/mcp-auth-rejected-error.md
@@ -2,4 +2,4 @@
 "@adcp/sdk": patch
 ---
 
-`connectMCP` now throws a typed `McpAuthRejectedError` (code `MCP_AUTH_REJECTED`) instead of a raw MCP SDK error when the server returns an HTTP 401. The error carries a `scheme` property (`'oauth' | 'bearer' | 'header' | 'none'`) identifying which credential the SDK sent, so the caller can immediately diff against their config without tracing the SDK internals.
+`connectMCP` now throws a typed `MCPAuthRejectedError` (code `MCP_AUTH_REJECTED`) instead of a raw MCP SDK error when the server returns an HTTP 401. The error carries a `scheme` property (`'oauth' | 'bearer' | 'header' | 'none'`) identifying which credential the SDK sent, so the caller can immediately diff against their config without tracing the SDK internals.

--- a/.changeset/mcp-auth-rejected-error.md
+++ b/.changeset/mcp-auth-rejected-error.md
@@ -1,0 +1,5 @@
+---
+"@adcp/sdk": patch
+---
+
+`connectMCP` now throws a typed `McpAuthRejectedError` (code `MCP_AUTH_REJECTED`) instead of a raw MCP SDK error when the server returns an HTTP 401. The error carries a `scheme` property (`'oauth' | 'bearer' | 'header' | 'none'`) identifying which credential the SDK sent, so the caller can immediately diff against their config without tracing the SDK internals.

--- a/.changeset/mcp-auth-rejected-error.md
+++ b/.changeset/mcp-auth-rejected-error.md
@@ -1,5 +1,5 @@
 ---
-"@adcp/sdk": patch
+"@adcp/sdk": minor
 ---
 
 `connectMCP` now throws a typed `MCPAuthRejectedError` (code `MCP_AUTH_REJECTED`) instead of a raw MCP SDK error when the server returns an HTTP 401. The error carries a `scheme` property (`'oauth' | 'bearer' | 'header' | 'none'`) identifying which credential the SDK sent, so the caller can immediately diff against their config without tracing the SDK internals.

--- a/docs/API_README.md
+++ b/docs/API_README.md
@@ -194,7 +194,8 @@ The library also provides exception classes for transport-level failures:
 
 - [`TaskTimeoutError`](./classes/TaskTimeoutError.html) - Operation timeouts
 - [`AgentNotFoundError`](./classes/AgentNotFoundError.html) - Invalid agent ID
-- [`AuthenticationRequiredError`](./classes/AuthenticationRequiredError.html) - OAuth required
+- [`AuthenticationRequiredError`](./classes/AuthenticationRequiredError.html) - OAuth required (discovery-time 401)
+- [`MCPAuthRejectedError`](./classes/MCPAuthRejectedError.html) - Credentials sent but rejected (connect-time 401); `.scheme` identifies which credential was used
 
 ## Type Safety
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/sdk",
-  "version": "7.3.0",
+  "version": "npm:@adcp/sdk@7.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/sdk",
-      "version": "7.3.0",
+      "version": "7.8.0",
       "license": "Apache-2.0",
       "workspaces": [
         ".",
@@ -45,6 +45,7 @@
         "openapi-typescript": "^7.13.0",
         "pg": "^8.20.0",
         "prettier": "^3.6.2",
+        "redis": "^4.7.0",
         "tar": "^7.5.13",
         "ts-to-zod": "^5.0.1",
         "tsx": "^4.6.0",
@@ -62,6 +63,7 @@
         "@modelcontextprotocol/sdk": "^1.17.5",
         "@opentelemetry/api": "^1.0.0",
         "pg": "^8.0.0",
+        "redis": "^4.6.0 || ^5.0.0",
         "zod": "^4.1.5"
       },
       "peerDependenciesMeta": {
@@ -69,6 +71,9 @@
           "optional": true
         },
         "pg": {
+          "optional": true
+        },
+        "redis": {
           "optional": true
         }
       }
@@ -1014,6 +1019,78 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@redis/bloom": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
+      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
+      "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2",
+        "generic-pool": "3.9.0",
+        "yallist": "4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@redis/client/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@redis/graph": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.1.tgz",
+      "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.7.tgz",
+      "integrity": "sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.2.0.tgz",
+      "integrity": "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.1.0.tgz",
+      "integrity": "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
       }
     },
     "node_modules/@redocly/ajv": {
@@ -2051,6 +2128,16 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/color-convert": {
@@ -3482,6 +3569,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "dev": true,
@@ -4838,7 +4935,6 @@
     },
     "node_modules/pg-cloudflare": {
       "version": "1.3.0",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -5137,6 +5233,24 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/redis": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.1.tgz",
+      "integrity": "sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "./packages/*"
+      ],
+      "dependencies": {
+        "@redis/bloom": "1.2.0",
+        "@redis/client": "1.6.1",
+        "@redis/graph": "1.1.1",
+        "@redis/json": "1.0.7",
+        "@redis/search": "1.2.0",
+        "@redis/time-series": "1.1.0"
       }
     },
     "node_modules/require-directory": {
@@ -6318,25 +6432,10 @@
       "version": "6.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adcp/sdk": "^7.3.0"
+        "@adcp/sdk": "^7.8.0"
       },
       "bin": {
         "adcp": "bin/adcp.js"
-      }
-    },
-    "packages/eslint-plugin": {
-      "name": "@adcp/eslint-plugin",
-      "version": "0.0.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@adcp/sdk": "^7.3.0",
-        "@typescript-eslint/utils": "^8.0.0"
-      },
-      "devDependencies": {
-        "typescript": "^5.3.0"
-      },
-      "peerDependencies": {
-        "eslint": "^8.0.0 || ^9.0.0 || ^10.0.0"
       }
     },
     "packages/eslint-plugin/node_modules/@adcp/sdk": {

--- a/src/lib/errors/index.ts
+++ b/src/lib/errors/index.ts
@@ -337,14 +337,14 @@ function buildAuthRequiredMessage(
  * try {
  *   await connectMCP({ agentUrl, authToken: 'tok_...' });
  * } catch (error) {
- *   if (error instanceof McpAuthRejectedError) {
+ *   if (error instanceof MCPAuthRejectedError) {
  *     console.log(`Sent scheme: ${error.scheme}`); // 'bearer'
  *     // token was sent but rejected — check the token value
  *   }
  * }
  * ```
  */
-export class McpAuthRejectedError extends ADCPError {
+export class MCPAuthRejectedError extends ADCPError {
   readonly code = 'MCP_AUTH_REJECTED';
 
   constructor(

--- a/src/lib/errors/index.ts
+++ b/src/lib/errors/index.ts
@@ -324,6 +324,46 @@ function buildAuthRequiredMessage(
 }
 
 /**
+ * Error thrown when `connectMCP` receives an HTTP 401 after sending credentials.
+ *
+ * Distinct from `AuthenticationRequiredError` (which fires when the server
+ * requests auth during MCP discovery with no or mismatched scheme metadata).
+ * This error fires when credentials *were* configured and sent but the server
+ * rejected them — giving the caller a typed handle on which credential the
+ * SDK actually used.
+ *
+ * @example
+ * ```typescript
+ * try {
+ *   await connectMCP({ agentUrl, authToken: 'tok_...' });
+ * } catch (error) {
+ *   if (error instanceof McpAuthRejectedError) {
+ *     console.log(`Sent scheme: ${error.scheme}`); // 'bearer'
+ *     // token was sent but rejected — check the token value
+ *   }
+ * }
+ * ```
+ */
+export class McpAuthRejectedError extends ADCPError {
+  readonly code = 'MCP_AUTH_REJECTED';
+
+  constructor(
+    public readonly scheme: 'oauth' | 'bearer' | 'header' | 'none',
+    cause?: unknown
+  ) {
+    const detail =
+      scheme === 'none'
+        ? 'MCP transport returned HTTP 401. No auth credentials were configured ' +
+          '(authToken, authProvider, or customHeaders.Authorization). ' +
+          'Check that you are passing auth options to connectMCP.'
+        : `MCP transport returned HTTP 401 using scheme '${scheme}'. ` +
+          'The server rejected the credential. Verify the token/OAuth client matches what the agent expects.';
+    super(detail);
+    this.details = { scheme, cause };
+  }
+}
+
+/**
  * Error thrown when a request reused an `idempotency_key` with a different
  * canonical payload within the seller's replay window.
  *

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -271,6 +271,7 @@ export {
   InvalidContextError,
   ConfigurationError,
   AuthenticationRequiredError,
+  McpAuthRejectedError,
   FeatureUnsupportedError,
   VersionUnsupportedError,
   IdempotencyConflictError,

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -271,7 +271,7 @@ export {
   InvalidContextError,
   ConfigurationError,
   AuthenticationRequiredError,
-  McpAuthRejectedError,
+  MCPAuthRejectedError,
   FeatureUnsupportedError,
   VersionUnsupportedError,
   IdempotencyConflictError,

--- a/src/lib/protocols/mcp.ts
+++ b/src/lib/protocols/mcp.ts
@@ -10,7 +10,7 @@ import { UnauthorizedError } from '@modelcontextprotocol/sdk/client/auth.js';
 import type { OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.js';
 import { createHmac } from 'node:crypto';
 import { createMCPAuthHeaders } from '../auth';
-import { is401Error } from '../errors';
+import { is401Error, McpAuthRejectedError } from '../errors';
 import type { DebugLogEntry } from '../types/adcp';
 import { withSpan, injectTraceHeaders } from '../observability/tracing';
 import { buildAgentSigningFetch, signingContextStorage, type AgentSigningContext } from '../signing/client';
@@ -718,6 +718,14 @@ export async function connectMCP(options: {
       });
       // Return transport so caller can call finishAuth
       throw Object.assign(error, { transport, client: mcpClient });
+    }
+    // Non-OAuth 401: enrich with which auth scheme the SDK sent so the caller
+    // doesn't need to chase the opaque MCP SDK message ("Error POSTing to
+    // endpoint (HTTP 401): unauthorized") back to their auth config.
+    if (is401Error(error)) {
+      const hasCustomAuthHeader = extractAuthHeader(customHeaders) !== undefined;
+      const scheme = authProvider ? 'oauth' : authToken ? 'bearer' : hasCustomAuthHeader ? 'header' : 'none';
+      throw new McpAuthRejectedError(scheme, error);
     }
     throw error;
   }

--- a/src/lib/protocols/mcp.ts
+++ b/src/lib/protocols/mcp.ts
@@ -10,7 +10,7 @@ import { UnauthorizedError } from '@modelcontextprotocol/sdk/client/auth.js';
 import type { OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.js';
 import { createHmac } from 'node:crypto';
 import { createMCPAuthHeaders } from '../auth';
-import { is401Error, McpAuthRejectedError } from '../errors';
+import { is401Error, MCPAuthRejectedError } from '../errors';
 import type { DebugLogEntry } from '../types/adcp';
 import { withSpan, injectTraceHeaders } from '../observability/tracing';
 import { buildAgentSigningFetch, signingContextStorage, type AgentSigningContext } from '../signing/client';
@@ -725,7 +725,7 @@ export async function connectMCP(options: {
     if (is401Error(error)) {
       const hasCustomAuthHeader = extractAuthHeader(customHeaders) !== undefined;
       const scheme = authProvider ? 'oauth' : authToken ? 'bearer' : hasCustomAuthHeader ? 'header' : 'none';
-      throw new McpAuthRejectedError(scheme, error);
+      throw new MCPAuthRejectedError(scheme, error);
     }
     throw error;
   }

--- a/test/unit/mcp-connect-401-enrichment.test.js
+++ b/test/unit/mcp-connect-401-enrichment.test.js
@@ -1,0 +1,150 @@
+/**
+ * Unit tests for connectMCP 401 error enrichment (issue #1869).
+ *
+ * When connectMCP receives an HTTP 401, it now throws McpAuthRejectedError
+ * with a `scheme` property identifying which auth credential the SDK sent
+ * (oauth / bearer / header / none). This eliminates the opaque
+ * "Error POSTing to endpoint (HTTP 401): unauthorized" message that cost
+ * the reporter 30+ minutes of debugging time.
+ *
+ * Tests the McpAuthRejectedError class directly (from dist) and replicates
+ * the scheme-detection logic inline (same pattern as
+ * mcp-connect-retry-predicate.test.js) to cover edge cases without
+ * requiring a live MCP transport.
+ */
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+
+// ---------- helpers replicating the scheme-detection from mcp.ts ----------
+
+// Replicates extractAuthHeader() from mcp.ts (case-insensitive Authorization search)
+function extractAuthHeader(headers) {
+  if (!headers) return undefined;
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() === 'authorization' && value) return value;
+  }
+  return undefined;
+}
+
+// Replicates the scheme derivation added to connectMCP's catch block
+function deriveScheme({ authProvider, authToken, customHeaders }) {
+  const hasCustomAuthHeader = extractAuthHeader(customHeaders) !== undefined;
+  return authProvider ? 'oauth' : authToken ? 'bearer' : hasCustomAuthHeader ? 'header' : 'none';
+}
+
+// ---------- McpAuthRejectedError class tests (against compiled dist) ------
+
+describe('McpAuthRejectedError', () => {
+  const { McpAuthRejectedError, ADCPError } = require('../../dist/lib/index.js');
+
+  test('is exported from @adcp/sdk public surface', () => {
+    assert.ok(McpAuthRejectedError, 'McpAuthRejectedError should be exported');
+  });
+
+  test('extends ADCPError', () => {
+    const err = new McpAuthRejectedError('bearer');
+    assert.ok(err instanceof Error);
+    assert.ok(err instanceof ADCPError);
+    assert.ok(err instanceof McpAuthRejectedError);
+  });
+
+  test('has code MCP_AUTH_REJECTED', () => {
+    const err = new McpAuthRejectedError('bearer');
+    assert.strictEqual(err.code, 'MCP_AUTH_REJECTED');
+  });
+
+  test('carries the scheme as a typed property', () => {
+    for (const scheme of ['oauth', 'bearer', 'header', 'none']) {
+      const err = new McpAuthRejectedError(scheme);
+      assert.strictEqual(err.scheme, scheme);
+    }
+  });
+
+  test('message names the scheme for credentialed cases', () => {
+    const err = new McpAuthRejectedError('bearer');
+    assert.ok(err.message.includes("scheme 'bearer'"), `message: ${err.message}`);
+    assert.ok(err.message.includes('rejected the credential'), `message: ${err.message}`);
+  });
+
+  test('message explains misconfiguration for scheme=none', () => {
+    const err = new McpAuthRejectedError('none');
+    assert.ok(err.message.includes('No auth credentials were configured'), `message: ${err.message}`);
+    assert.ok(err.message.includes('connectMCP'), `message: ${err.message}`);
+  });
+
+  test('message does not include raw token values', () => {
+    const err = new McpAuthRejectedError('bearer', new Error('tok_secret'));
+    // scheme name only; the raw cause error (which might contain token fragments)
+    // is in details.cause, not in the main message
+    assert.ok(!err.message.includes('tok_secret'), 'message should not leak cause content');
+  });
+});
+
+// ---------- scheme derivation logic tests (inline replica) ----------------
+
+describe('connectMCP scheme derivation', () => {
+  test('oauth when authProvider is set', () => {
+    assert.strictEqual(deriveScheme({ authProvider: {}, authToken: undefined, customHeaders: undefined }), 'oauth');
+  });
+
+  test('bearer when authToken is set', () => {
+    assert.strictEqual(
+      deriveScheme({ authProvider: undefined, authToken: 'tok_test', customHeaders: undefined }),
+      'bearer'
+    );
+  });
+
+  test('header when Authorization is in customHeaders (canonical case)', () => {
+    assert.strictEqual(
+      deriveScheme({
+        authProvider: undefined,
+        authToken: undefined,
+        customHeaders: { Authorization: 'ApiKey secret' },
+      }),
+      'header'
+    );
+  });
+
+  test('header when Authorization is in customHeaders (lowercase)', () => {
+    assert.strictEqual(
+      deriveScheme({
+        authProvider: undefined,
+        authToken: undefined,
+        customHeaders: { authorization: 'ApiKey secret' },
+      }),
+      'header'
+    );
+  });
+
+  test('header when Authorization is in customHeaders (UPPERCASE)', () => {
+    assert.strictEqual(
+      deriveScheme({ authProvider: undefined, authToken: undefined, customHeaders: { AUTHORIZATION: 'Bearer tok' } }),
+      'header'
+    );
+  });
+
+  test('none when no credentials configured', () => {
+    assert.strictEqual(
+      deriveScheme({ authProvider: undefined, authToken: undefined, customHeaders: undefined }),
+      'none'
+    );
+  });
+
+  test('bearer wins over customHeaders.Authorization (authToken takes precedence)', () => {
+    // When both are present, the ternary chain reports the first match ('bearer').
+    // This is correct: createMCPAuthHeaders(authToken) produces the Authorization header,
+    // so authToken IS the bearer credential and customHeaders is supplemental context.
+    assert.strictEqual(
+      deriveScheme({ authProvider: undefined, authToken: 'tok', customHeaders: { Authorization: 'Bearer tok' } }),
+      'bearer'
+    );
+  });
+
+  test('none when customHeaders only has non-auth headers', () => {
+    assert.strictEqual(
+      deriveScheme({ authProvider: undefined, authToken: undefined, customHeaders: { 'x-custom': 'value' } }),
+      'none'
+    );
+  });
+});

--- a/test/unit/mcp-connect-401-enrichment.test.js
+++ b/test/unit/mcp-connect-401-enrichment.test.js
@@ -1,13 +1,13 @@
 /**
  * Unit tests for connectMCP 401 error enrichment (issue #1869).
  *
- * When connectMCP receives an HTTP 401, it now throws McpAuthRejectedError
+ * When connectMCP receives an HTTP 401, it now throws MCPAuthRejectedError
  * with a `scheme` property identifying which auth credential the SDK sent
  * (oauth / bearer / header / none). This eliminates the opaque
  * "Error POSTing to endpoint (HTTP 401): unauthorized" message that cost
  * the reporter 30+ minutes of debugging time.
  *
- * Tests the McpAuthRejectedError class directly (from dist) and replicates
+ * Tests the MCPAuthRejectedError class directly (from dist) and replicates
  * the scheme-detection logic inline (same pattern as
  * mcp-connect-retry-predicate.test.js) to cover edge cases without
  * requiring a live MCP transport.
@@ -33,48 +33,48 @@ function deriveScheme({ authProvider, authToken, customHeaders }) {
   return authProvider ? 'oauth' : authToken ? 'bearer' : hasCustomAuthHeader ? 'header' : 'none';
 }
 
-// ---------- McpAuthRejectedError class tests (against compiled dist) ------
+// ---------- MCPAuthRejectedError class tests (against compiled dist) ------
 
-describe('McpAuthRejectedError', () => {
-  const { McpAuthRejectedError, ADCPError } = require('../../dist/lib/index.js');
+describe('MCPAuthRejectedError', () => {
+  const { MCPAuthRejectedError, ADCPError } = require('../../dist/lib/index.js');
 
   test('is exported from @adcp/sdk public surface', () => {
-    assert.ok(McpAuthRejectedError, 'McpAuthRejectedError should be exported');
+    assert.ok(MCPAuthRejectedError, 'MCPAuthRejectedError should be exported');
   });
 
   test('extends ADCPError', () => {
-    const err = new McpAuthRejectedError('bearer');
+    const err = new MCPAuthRejectedError('bearer');
     assert.ok(err instanceof Error);
     assert.ok(err instanceof ADCPError);
-    assert.ok(err instanceof McpAuthRejectedError);
+    assert.ok(err instanceof MCPAuthRejectedError);
   });
 
   test('has code MCP_AUTH_REJECTED', () => {
-    const err = new McpAuthRejectedError('bearer');
+    const err = new MCPAuthRejectedError('bearer');
     assert.strictEqual(err.code, 'MCP_AUTH_REJECTED');
   });
 
   test('carries the scheme as a typed property', () => {
     for (const scheme of ['oauth', 'bearer', 'header', 'none']) {
-      const err = new McpAuthRejectedError(scheme);
+      const err = new MCPAuthRejectedError(scheme);
       assert.strictEqual(err.scheme, scheme);
     }
   });
 
   test('message names the scheme for credentialed cases', () => {
-    const err = new McpAuthRejectedError('bearer');
+    const err = new MCPAuthRejectedError('bearer');
     assert.ok(err.message.includes("scheme 'bearer'"), `message: ${err.message}`);
     assert.ok(err.message.includes('rejected the credential'), `message: ${err.message}`);
   });
 
   test('message explains misconfiguration for scheme=none', () => {
-    const err = new McpAuthRejectedError('none');
+    const err = new MCPAuthRejectedError('none');
     assert.ok(err.message.includes('No auth credentials were configured'), `message: ${err.message}`);
     assert.ok(err.message.includes('connectMCP'), `message: ${err.message}`);
   });
 
   test('message does not include raw token values', () => {
-    const err = new McpAuthRejectedError('bearer', new Error('tok_secret'));
+    const err = new MCPAuthRejectedError('bearer', new Error('tok_secret'));
     // scheme name only; the raw cause error (which might contain token fragments)
     // is in details.cause, not in the main message
     assert.ok(!err.message.includes('tok_secret'), 'message should not leak cause content');


### PR DESCRIPTION
Closes #1869

## Summary

When `connectMCP` received a transport-level HTTP 401, it rethrew the raw MCP SDK error with no context:

```
Error POSTing to endpoint (HTTP 401): unauthorized
```

No indication of which auth scheme was sent (`bearer` / `oauth` / `header` / `none`), which credential source was used, or whether the failure was SDK-level vs. a corporate proxy. Reporter cited a 30+ minute debugging cost (#1864).

This PR adds a typed `MCPAuthRejectedError extends ADCPError` (code `MCP_AUTH_REJECTED`) thrown instead of the raw error. The error carries `scheme` — which credential the SDK actually sent — so the caller can immediately diff against their config:

```ts
try {
  await connectMCP({ agentUrl, authToken: 'tok_...' });
} catch (error) {
  if (error instanceof MCPAuthRejectedError) {
    console.log(error.scheme);   // 'bearer'
    console.log(error.message);  // "MCP transport returned HTTP 401 using scheme 'bearer'. The server rejected the credential..."
  }
}
```

## Changes

- `src/lib/errors/index.ts` — `MCPAuthRejectedError extends ADCPError` with `scheme: 'oauth' | 'bearer' | 'header' | 'none'`; message branches on none (misconfiguration) vs. credentialed (server rejected)
- `src/lib/protocols/mcp.ts` — catch block enriches non-OAuth 401s using existing `is401Error()` + `extractAuthHeader()` helpers (case-insensitive Authorization scan)
- `src/lib/index.ts` — exports `MCPAuthRejectedError` on the public surface
- `docs/API_README.md` — adds `MCPAuthRejectedError` to the exception table alongside `AuthenticationRequiredError`
- `test/unit/mcp-connect-401-enrichment.test.js` — 15 unit tests: class shape, scheme derivation (all four arms + case-insensitive Authorization)
- `.changeset/mcp-auth-rejected-error.md` — minor bump (new export + throwing-surface behavior change)

## What tested

- `npm run format:check` — ✅
- `tsc --project tsconfig.lib.json` — ✅ (pre-existing TS config deprecation warnings unrelated)
- `node --test test/unit/mcp-connect-401-enrichment.test.js` — ✅ 15/15 pass
- `npm run build:lib` — ✅ (full hook pass)

## Pre-PR review

- code-reviewer: approved — no blockers; noted `callMCPTool`/`connectMCPWithFallbackImpl` still rethrow raw 401s (out of scope, called out below), changeset bumped to minor per recommendation, docs updated
- dx-expert: approved after rename from `McpAuthRejectedError` → `MCPAuthRejectedError` (convention: all MCP-prefixed exports use all-caps MCP)

## Out of scope — intentional

`callMCPTool` and `connectMCPWithFallbackImpl` have parallel `is401Error` catch sites that still rethrow raw SDK errors. Enriching those paths is follow-on work and would expand scope significantly (different callers, different failure modes). This PR targets `connectMCP` specifically, which is the surface the reporter hit.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/f5909aeb-e505-4366-826e-14cda1d8fcd7

---
_Generated by [Claude Code](https://claude.ai/code/session_01HfqCz5AS9sKbCG2Lc9t6cb)_