### PR TITLE
docs(development): 7.x dual-mode interim before the 8.0 V2-only break

### DIFF
--- a/.changeset/v3.1-sdk-design-7x-interim.md
+++ b/.changeset/v3.1-sdk-design-7x-interim.md
@@ -1,0 +1,8 @@
+---
+---
+
+docs(development): clarify 7.x dual-mode interim before the 8.0 V2-only break
+
+Docs-only revision to `docs/development/v3.1-sdk-design.md`. No library
+code changes; empty changeset satisfies the CI gate that requires a
+changeset on every PR.

--- a/docs/development/v3.1-sdk-design.md
+++ b/docs/development/v3.1-sdk-design.md
@@ -42,7 +42,15 @@ AdCP 3.1's canonical-formats system isn't a new feature alongside the old creati
 - **What can this publisher's inventory accept?** Read `Product.format_options` — declarations are tied to inventory, not seller-agent capability.
 - **What can this creative agent build or transform?** Read `get_adcp_capabilities.creative.supported_formats` on the creative agent — separate from the seller's inventory.
 
-The right product call for 8.0 is **to flip every SDK consumer to the V2 model**. We don't expose both vocabularies and let adopters pick — that's the engineer's compromise, and it leaves the ecosystem stuck in two minds forever. 8.0 is the major where adopters learn V2. The SDK's job is to make every seller — even ones still emitting v1 named formats on the wire — look V2-shaped to the adopter.
+**V2 is the destination. The SDK gets there in two stages, not one major bump.**
+
+**Why staged.** The spec's v1 deprecation calendar is **2027-Q4 floor / 2029-Q1 ceiling** per `v1-canonical-mapping.json`. v1 stays valid on the wire for 2+ years. Forcing V2-only on the SDK before the spec retires v1 makes our SDK harder to adopt for buyers with existing v1 code — without unifying the ecosystem, because the spec maintains both shapes anyway.
+
+- **7.x (additive dual-mode)** — 3.1 capabilities (canonical-format types, multi-size, validate_input, custom format_schema, publisher catalog) ship as additive minor releases. `Product` carries BOTH `format_ids` (v1, unchanged from 7.5) AND `format_options` (v2, newly populated when the SDK has 3.1-shaped data). Old v1 code keeps working line-for-line; new code reads the v2 surface. The same projection layer that the V2-only design needs ships in 7.x and powers the dual surface.
+
+- **8.0 (V2-only break)** — happens when the spec's v1 deprecation calendar tightens (likely 2027 or later). `Product.format_ids` is removed from the public type. Adopters who wrote V2 code in 7.x have no migration; v1-only readers get a search-and-replace per call site. The major bump signals "v1 is gone from the wire too" rather than introducing v1's removal arbitrarily ahead of the spec.
+
+The V2-only architecture described in the rest of this doc IS the 8.0 target. The 7.x interim ships the same projection / publisher-catalog / fetch / diagnostic substance, just behind an additive surface that preserves v1 reads. Adopters who want V2 mental model today get it via the new fields; adopters who can't migrate yet get more time.
 
 ## What V2 actually changes for the buyer's mental model
 
@@ -274,14 +282,17 @@ The `format_kind` discriminator becomes a clean TypeScript tagged union (12 bran
 
 | Line | What changes | Adopter action |
 |---|---|---|
-| 7.x | Defensive wire-envelope fix (PR #1807 — already shipped). Loose ends from any 3.1 work backported as patches when safe. | None. |
-| **8.0** | The major that flips you to the V2 mental model. Public `Product` carries `format_options` only. Projection layer hides v1 sellers behind the V2 shape. Auto-negotiation, `fetchFormatSchema`, versioned codegen (3.1 public; 3.0 internal). `ADCP_VERSION` moves to `3.1.0`; `COMPATIBLE_ADCP_VERSIONS` adds `3.0.x` and `3.1.x`. | `npm install @adcp/sdk@^8`. Migrate any code reading `Product.format_ids` to read `Product.format_options` (and `format_options[i].v1_format_ref` when you need the legacy named-format string). The codegen layout shift is the only mechanical break; everything else feels the same. |
+| 7.5–7.9 | Wire-envelope fix (PR #1807), wire-version followups (PR #1814), all 7.x cycle baseline including ctx-metadata + Redis backends + impairment coherence. | None — released as patches/minors as merged. |
+| **7.10** | First additive 3.1 ship. Adds `3.1.0-beta.0` to `COMPATIBLE_ADCP_VERSIONS`; `Product.format_options?` shipped as optional alongside the existing `Product.format_ids`. Projection layer lands under `src/lib/v2/projection/` (internal; populates `format_options` when SDK sees 3.1-shaped wire data). AdAgentsJson gains `formats?` field. New `src/lib/v2/publisher-catalog/` module ships scope + capability_id resolution helpers (built on existing `validateAdAgents`). | `npm install @adcp/sdk@^7.10`. v1-only code keeps reading `Product.format_ids` unchanged. V2-aware code starts reading `Product.format_options`. No breaking changes. |
+| **7.11** | `fetchFormatSchema` security utility (full normative fetch contract: HTTPS-only, SSRF guards, sha256 digest, $ref sandbox, compile budgets). `validate_input` task wired. Diagnostic surface added as optional `TaskResult.diagnostics?` property. | None — additive. Adopters opt into `format_kind: "custom"` declarations by calling `fetchFormatSchema`; diagnostics read by the keen, ignored by everyone else. |
+| **7.12+** | Auto-negotiation per agent + `get_adcp_capabilities` caching (so SDK picks the right wire version automatically); capability_id resolution between placements and adagents formats wired into the projection. Asset-slot translation via `asset_group_vocabulary` aliases (creative-manifest layer). | None — additive. |
+| **8.0** | The V2-only break, scheduled to land **when the spec's v1 deprecation calendar tightens** (2027-Q4 floor / 2029-Q1 ceiling per `v1-canonical-mapping.json`). Removes `Product.format_ids` from the public type. Projection layer (already shipped) keeps doing the wire-level translation; nothing about it changes — only the public surface narrows. Auto-negotiation becomes the default; explicit `adcpVersion` pinning stays as an escape hatch. `ADCP_VERSION` moves to whatever the latest 3.x release is at the time. | Search-and-replace `Product.format_ids` → `Product.format_options` per call site (and `format_options[i].v1_format_ref` for the legacy named-format string). Adopters who already wrote v2 code in 7.10+ have nothing to migrate. |
 | 8.x | Hardening: additional registry entries as upstream adds them; codegen refinements; performance work on the projection layer. | None — additive. |
-| **9.0** | AdCP 4.0 lands. `list_creative_formats` and v1 `format_ids` removed from the spec. SDK retires the v1 projection layer (internal); public API doesn't change because adopters never saw v1 in the first place. | None for adopter code. Adopters who relied on `format_options[i].v1_format_ref` for ops traceability need to switch to another identifier (likely `capability_id` or the seller's own product_id). |
+| **9.0** | AdCP 4.0 lands. `list_creative_formats` and v1 `format_ids` removed from the spec. SDK retires the v1 projection layer (internal); public API doesn't change because 8.0 already removed `Product.format_ids` from the public type. | None for adopter code. Adopters who relied on `format_options[i].v1_format_ref` for ops traceability need to switch to another identifier (likely `capability_id` or the seller's own product_id). |
 
-The 8.0 → 9.0 gap is sized by spec deprecation timing. Per `v1-canonical-mapping.json` notes, v1 named formats remain valid through 4.x — so 8.0 lives until 4.0 is GA and 9.0 cuts when v1 leaves the spec. The crucial property: because adopters wrote V2 code on 8.0, 9.0 is mostly an internal retirement, not a second mental-model migration.
+The 7.x → 8.0 gap is sized by spec deprecation timing. v1 named formats remain valid through 4.x — so the 7.x dual-mode line lives until adopter migration is sufficient and v1 deprecation actually tightens. The crucial property: **all the architectural substance lands in 7.x**; 8.0 is just the public-surface narrowing.
 
-### Coverage adopters can expect at 8.0 GA
+### Coverage adopters can expect (7.10 onward; same numbers carry forward to 8.0)
 
 From the prototype against the latest spec PR HEAD:
 
@@ -298,11 +309,13 @@ The architectural commitment the spec made between draft and lock — broadcast,
 
 ## What we explicitly don't do
 
-### We don't expose v1 vocabulary on the public type
+### We don't expose v1 vocabulary on the public type — *at 8.0*
 
-The compromise of exposing both `format_ids` and `format_options` on `Product` looks helpful — old code keeps reading the old field, new code reads the new — but it freezes the ecosystem in two minds forever. Library authors writing on top of `@adcp/sdk` have to support both. Docs have to explain both. Examples have to pick. And the V2 mental model never lands.
+The compromise of exposing both `format_ids` and `format_options` on `Product` indefinitely would freeze the ecosystem in two minds forever — library authors writing on top of `@adcp/sdk` have to support both, docs have to explain both, examples have to pick. The V2 mental model never lands.
 
-The major bump is the moment to commit. Adopters update their `Product.format_ids[]` reads to `Product.format_options[]` reads (one search-and-replace per call site). They never write v1 code again. The SDK does the wire-level translation.
+**But the 8.0 break is timed to the spec, not to the SDK's preference.** The 7.x line carries both fields because the spec carries both wire shapes through 2027+. When the spec's v1 deprecation calendar tightens, 8.0 narrows the public type to V2-only. Adopters update their `Product.format_ids[]` reads to `Product.format_options[]` reads (one search-and-replace per call site) on a schedule the spec sets, not one we invent.
+
+**During 7.x**, we encourage adopters to read `format_options` for new code (docs and examples lead with it; v1 fields stay available but `@deprecated` once 8.0 is on the horizon). The dual surface is interim, not architectural; the projection layer and diagnostic surface ship in their 8.0 shape from 7.10 onward.
 
 ### We don't ship two namespaces
 
@@ -326,7 +339,7 @@ If `fetchFormatSchema` doesn't apply the full normative fetch contract (SSRF, di
 
 2. **`adcpVersion` constructor option semantics.** Today the option pins the wire emit. With auto-negotiation, do we keep the pin (caller overrides the negotiated version) or treat it as "the buyer's maximum"? Pin semantics are simpler and match the spec's "buyer pins, seller downshifts" model.
 
-3. **Where does the projection layer hook in?** Read-time at the response boundary is the only honest answer once we commit to V2-only public types — the adopter is always reading `format_options`, so the projection has to be complete before the SDK hands the response back. (Lazy projection would mean the adopter sees `format_options: undefined` until they touch it, which is exactly the two-minds problem the V2-only stance is designed to avoid.) Benchmark and revisit only if hot-path cost matters in practice.
+3. **Where does the projection layer hook in?** Read-time at the response boundary is the only honest answer. In the 7.x dual-mode interim, the SDK still populates `format_options` eagerly on read — adopters who haven't migrated to v2 yet just don't read it. (Lazy projection would mean v2-aware code sees `format_options: undefined` until they touch it, surprise-async behavior that's worse than paying the projection cost upfront.) Benchmark and revisit only if hot-path cost matters in practice. Same answer at 8.0.
 
 4. **Per-agent vs per-call cache for `get_adcp_capabilities`.** Today the SDK fetches capabilities lazily and caches per-agent. Auto-negotiation makes this load-bearing. TTL? Cache invalidation on `VERSION_UNSUPPORTED` (seller signals they've moved on)? Probably yes to both.
 
@@ -336,14 +349,32 @@ If `fetchFormatSchema` doesn't apply the full normative fetch contract (SSRF, di
 
 ```
 PR-1807 (merged)         wire-envelope normalize (defensive)             7.x patch
+PR-1814 (merged)         release-precision pin + validator + namespace   7.x minor
+PR-1809 (merged)         this design doc                                 docs-only
    ↓
-adcp#3307 lands          upstream 3.1.0-beta.0 published                  spec event
+adcp 3.1.0-beta.0        published at adcontextprotocol.org              spec event ✓
    ↓
-PR-NEXT-A                add 3.1.0-beta.0 to COMPATIBLE_ADCP_VERSIONS,    8.0.0-alpha.1
-                         versioned codegen, no projection yet
-PR-NEXT-B                v1↔v2 projection layer + Diagnostic surface     8.0.0-alpha.2
-PR-NEXT-C                fetchFormatSchema with full normative contract  8.0.0-alpha.3
-PR-NEXT-D                auto-negotiation + per-agent capabilities cache 8.0.0-rc.1
+PR-NEXT-A                COMPATIBLE_ADCP_VERSIONS adds 3.1.0-beta.0;     7.10 minor
+                         Product.format_options? optional field added
+                         alongside Product.format_ids; projection
+                         layer ships under src/lib/v2/projection/;
+                         AdAgentsJson formats? + publisher-catalog
+                         scope + capability_id resolve helpers
+PR-NEXT-B                fetchFormatSchema with full normative           7.11 minor
+                         contract; validate_input task wired;
+                         TaskResult.diagnostics? property added
+PR-NEXT-C                auto-negotiation per agent + capabilities       7.12+ minor(s)
+                         cache; capability_id resolution wired into
+                         projection; asset-slot translation
+                          ↓
+                         (multi-quarter dual-mode window — v1 + v2
+                         coexist on the public type; adopters
+                         migrate at their own pace)
+                          ↓
+spec v1 deprecation tightens (2027-Q4 floor / 2029-Q1 ceiling)
+   ↓
+PR-NEXT-D                remove Product.format_ids from public type;     8.0.0 major
+                         flip to V2-only mental model
                           ↓
                          8.0.0 GA
 ```


### PR DESCRIPTION
## Summary

Revises the 8.0 design doc at `docs/development/v3.1-sdk-design.md` after reconsidering the release plan: starting the 3.1 integration doesn't require a major bump. The spec's v1 deprecation calendar runs **2027-Q4 floor / 2029-Q1 ceiling** — 2+ years of legitimate v1 use ahead. Forcing V2-only in the SDK before the spec retires v1 makes our SDK harder to adopt without unifying the ecosystem.

## What changed

- **"The position" reframed** as a two-stage migration. 7.x ships 3.1 capabilities as additive minor releases (Product carries both `format_ids` and `format_options`). 8.0 narrows the public type to V2-only when the spec's v1 deprecation tightens.
- **Migration table** replaces the single 8.0 row with concrete **7.10 / 7.11 / 7.12+** rows covering each substantive piece (projection layer, publisher catalog, fetchFormatSchema, auto-negotiation). 8.0 row scopes to public-surface narrowing only.
- **"We don't expose v1 vocabulary on the public type"** softens to *"...at 8.0"* — explicit that 7.x interim carries both fields, with v1 fields deprecated-then-removed on the spec's schedule.
- **Sequencing diagram** replaces `8.0.0-alpha.N` with 7.10/7.11/7.12+ staging followed by the 8.0 break when v1 deprecation tightens.
- **Coverage section** heading updated: numbers apply 7.10 onward, same shape carries to 8.0.

## What's unchanged

The architectural substance — projection layer, refinement-over-multiplication, 12-branch discriminated union, 100% catalog coverage, structured diagnostic surface, custom-format fetch contract — is identical. It just ships earlier behind additive surface in 7.x, with the V2-only break deferred to when the spec actually requires it.

## Why this is better

- **Adopter-friendly**: no major bump for an additive spec feature. v1-only code keeps working line-for-line through 7.x.
- **Spec-aligned**: the SDK's deprecation calendar follows the protocol's, rather than inventing one.
- **Same destination**: V2 is still the recommended path, examples lead with it, the architecture targets it. The flip just happens when the spec is ready.

## Test plan

- [x] `npm run format:check` clean
- [x] `npm run typecheck` clean
- [ ] CI green