### PR TITLE
docs(8.0-beta): plan to pull V2-only forward (proposal)

### DIFF
--- a/docs/development/v8.0-beta-plan.md
+++ b/docs/development/v8.0-beta-plan.md
@@ -1,0 +1,138 @@
+# 8.0-beta release plan — pull V2-only forward
+
+**Status:** proposal. Decision needed: GO/NO-GO on cutting 8.0-beta now rather than waiting on the multi-quarter dual-mode window described in [v3.1-sdk-design.md](./v3.1-sdk-design.md).
+
+**Audience:** SDK maintainers and the human who has to sign off on the timing pull-forward.
+
+## The change being proposed
+
+Current plan ([v3.1-sdk-design.md](./v3.1-sdk-design.md), 396 lines): ship 3.1 capabilities additively across 7.10 → 7.12+ minors, keeping the GA pin at 3.0.12, with the V2-only break deferred to whenever the spec's v1 deprecation calendar tightens (2027-Q4 floor / 2029-Q1 ceiling).
+
+This proposal: cut `8.0.0-beta.0` now, pinned to AdCP `3.1.0-beta.1`. Ship under the `@beta` npm dist-tag. Move 7.x to maintenance-mode. Promote 8.0-beta → 8.0 when adcp 3.1 goes GA upstream.
+
+## Why the dual-mode-forever stance is over-cautious
+
+The `v3.1-sdk-design.md` stance was written before 3.1 beta had landed and before we had real-world overlay experience. Two things have changed:
+
+1. **Wire-level cross-version compat is free.** AdCP says `error.code` is open `string` and receivers MUST handle unknown codes via the `recovery` field. A 3.1-pinned SDK talking to a 3.0 seller (or vice versa) survives — the wire is open by design. The "keep 3.0 receivers safe forever" anxiety was misplaced: nothing about the SDK's GA pin affects wire compat for adopters using `error.code` correctly.
+
+2. **The overlay-per-feature pattern doesn't scale.** PR #1883 introduced the forward-compat overlay for the `AUTH_REQUIRED` split. ~150 LOC for 2 codes. The `needs:adcp-3.1` queue has ~12 more items — `AGENT_SUSPENDED/BLOCKED`, `supported_optimization_metrics`, `frequency_capping`, `format.assets.output_only`, `query_upstream_traffic`, the catalog-sync cluster, the publisher_properties inline-resolution path, the directory inverse-lookup endpoint. Some are enum additions (overlay-able cheaply). Most involve **typed shapes or schema fields** (`output_only`, `frequency_capping`, `AgentDirectoryLookup`) where the overlay pattern turns into "invent a parallel type system for 3.1." That's the work 8.0-beta makes mechanical.
+
+3. **Real adopters need somewhere to dogfood 3.1.** The opt-in `v3-1-beta` types bundle (PR #1879) is awkward — it's a parallel import path, not a release line. Adopters who want to use 3.1 in production need a versioned, released artifact. `@adcp/client@beta` is the standard pattern; let's use it.
+
+## The plan
+
+### Cut order
+
+1. **Branch `release/8.0-beta` from main.** Stays open until 8.0 GA.
+2. **Flip the GA pin** in `src/lib/version.ts` and codegen config from `3.0.12` to `3.1.0-beta.1`. Regenerate types. Fix the resulting compile errors — this is the **first useful audit** of what 3.1 actually changes in the typed surface.
+3. **Remove the v3-1-beta opt-in bundle** (`src/lib/types/v3-1-beta/`) — it's redundant once the main pin is 3.1.
+4. **Remove the forward-compat overlay** (`src/lib/types/forward-compat-error-codes.ts`) — it's redundant once 3.1 codes are in the canonical `StandardErrorCode` union. (#1883's typed `AuthMissingError` / `AuthInvalidError` classes stay; the overlay scaffolding doesn't.)
+5. **Sweep the `needs:adcp-3.1` queue** against the new pin. Each item becomes a separate PR against the `release/8.0-beta` branch. Most should be one-screen-of-code mechanical fixes.
+6. **Cut `8.0.0-beta.0`** via changesets (`npm publish --tag beta`). Subsequent betas advance the prerelease number.
+7. **Promote to `8.0.0`** when adcp `3.1.0` goes GA upstream.
+
+### Release semantics
+
+| Tag | Version | Pin | Contents |
+|---|---|---|---|
+| `@adcp/client@latest` | 7.x | 3.0.12 | Maintenance-mode |
+| `@adcp/client@beta` | 8.0.0-beta.N | 3.1.0-beta.1 | 3.1 features land here |
+| (eventually) `@adcp/client@latest` | 8.0.0 | 3.1.0 | When upstream goes GA |
+
+Adopters who want 3.1 features: `npm install @adcp/client@beta`. Adopters who want stability: `npm install @adcp/client` (resolves to 7.x).
+
+### 7.x maintenance scope
+
+Effective on the day 8.0-beta.0 ships:
+- **Yes**: security advisories, critical bug fixes, regression fixes.
+- **No**: new features, new spec adoption, new typed surface area. Adopters who want those move to `@beta`.
+- **PR #1406** (AGENT_SUSPENDED / AGENT_BLOCKED) lands in 7.x using the existing overlay pattern — already in flight. Likely the last 7.x feature.
+- **PR #1885** (publisher_properties inline + directory inverse-lookup) is 7.x-compat (behavioral + new wrapper, no new typed schema fields). Decision: land in 7.x as the *actual* last 7.x feature OR defer to 8.0-beta. Recommend 7.x — it's a real adopter ask, the work is done in either branch, and shipping in 7.x means existing adopters get it without changing dist-tag.
+
+### Promotion criteria (8.0-beta → 8.0)
+
+Promote when **all** of:
+- AdCP `3.1.0` is GA upstream (not beta).
+- No open `needs:adcp-3.1` issues against the SDK.
+- At least one external adopter has run `@beta` against a production seller for ≥2 weeks without finding blocker bugs.
+- CHANGELOG entry exists for every wire-level behavior change adopters need to know about.
+
+The first criterion gives us an external trigger; the other three are signals we're not GA'ing against a half-baked surface.
+
+## Risk register
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Upstream 3.1 spec churns between beta.1 and GA | High | Rebase `release/8.0-beta` on each adcp 3.1 spec change. Document the churn in the 8.0-beta CHANGELOG. **This is the cost of pulling 8.0 forward — pay it knowingly.** |
+| 7.x adopters resist moving to `@beta` | Medium | Don't force migration. 7.x supported until 8.0 GA + a reasonable grace period. New features only on `@beta` is a soft pressure, not a hard cutoff. |
+| Two-line maintenance burden | Medium | Strict 7.x scope (security/critical only). If a security fix touches code that diverged between 7.x and 8.0-beta, port carefully — but most security fixes will be in shared infrastructure. |
+| 8.0-beta accidentally ships breakage that prerelease consumers find painfully | Low | That's literally what `@beta` is for. Document semver-of-beta rules: each beta can break the previous beta. |
+| Adopters confused by which version to use | Low | Clear top-of-README guidance. `latest` = stable, `beta` = previewing 3.1. Anthropic SDK does this; Stripe does this; nobody is confused. |
+
+## What 8.0-beta unblocks
+
+The queue of structural items that don't fit overlay-per-feature:
+
+- **#1525** — `format.assets[]` `output_only` flag (4 sites; new field on a schema-defined type)
+- **#1853** — `supported_optimization_metrics` + `frequency_capping` projection (new capability fields)
+- **#1818** — Auto-derive seller-level rollup capabilities from catalog (depends on #1853)
+- **#1353** — `query_upstream_traffic` first-class (new schema in 3.1.x, not in 3.0.x)
+- **#1481** (partial) — Drop SI workarounds (`'sponsored-intelligence'` enum value only in 3.1)
+- **Catalog-sync cluster** (adcp#4761/4762/4763) — per-format error attribution in `build_creative`
+- **#1642** — Storyboard-tag conformance migration (upstream `required_any_of_tools` key)
+- **#1292** (parts) — BuyerAgentRegistry Phase 2 billing-capability codes
+
+Each becomes a 1-PR mechanical fix against `release/8.0-beta` instead of an overlay-design exercise.
+
+## What stays in 7.x maintenance-mode
+
+- Bug fixes against the 3.0.12-pinned code.
+- Security advisories.
+- PR #1406 (AGENT_SUSPENDED/BLOCKED overlay) — already in flight, low-risk, completes the AUTH-overlay set.
+- PR #1885 (publisher_properties + directory) if we choose to land it here — see open questions.
+
+## Migration story for adopters
+
+Today's `@adcp/client@7.9.0`:
+```typescript
+import { Client } from '@adcp/client';
+const client = new Client({ ... });
+const products = await client.getProducts({ brief: '...' });
+// products[i].format_ids: string[]  ← v1 wire shape
+```
+
+Tomorrow's `@adcp/client@8.0.0-beta.0` (same code, mostly):
+```typescript
+import { Client } from '@adcp/client';
+const client = new Client({ ... });
+const products = await client.getProducts({ brief: '...' });
+// products[i].format_options: FormatDeclaration[]  ← v2 wire shape
+// products[i].format_ids: REMOVED from public type
+```
+
+Adopters with v1 reads: rename `format_ids` → derive from `format_options[].v1_format_ref` per the existing migration utility. The projection layer (PR #1882) already exists and produces clean conversions for 41/57 (72%) of AAO catalog entries. The remaining 16/57 (broadcast/native/DOOH/cards) carry a structured diagnostic explaining what couldn't project.
+
+This is the same migration the original `v3.1-sdk-design.md` 8.0 transition describes — we're just doing it now instead of in 2027.
+
+## Open questions
+
+1. **PR #1885: land in 7.x or 8.0-beta?** Both work. 7.x means existing adopters get it without dist-tag change; 8.0-beta keeps 7.x truly frozen. Recommend 7.x.
+
+2. **Should 7.x get a final `7.10.0` release that bundles #1406 and #1885 with a clear "this is the last 7.x feature release" CHANGELOG note?** Yes — clean handoff signal for adopters.
+
+3. **How do we handle the `comply-controller.ts` / `governance-agent-stub.ts` Zod typecheck errors that currently exist on `main`?** They're not blocking anything on `main` (test/dev code, not lib build). But they should get fixed before the 8.0-beta cut so the new release line starts clean. File as a separate fix-it issue.
+
+4. **Stacking `8.0.0-beta.N` versions vs `8.0.0-rc.N` cutover.** Recommend `-beta.N` while upstream is still on `3.1.0-beta.N`. Cut over to `8.0.0-rc.0` when upstream goes `3.1.0-rc.0`. Promote to `8.0.0` only when upstream is GA.
+
+5. **Does the existing `v3.1-sdk-design.md` get rewritten or kept as historical context?** Recommend rewriting after 8.0-beta.0 ships — the doc's "multi-quarter dual-mode window" framing will be obsolete. Until then, this proposal serves as the addendum.
+
+## Decision needed
+
+Sign off on:
+- [ ] Yes, cut 8.0-beta now (pull 8.0 forward from the 2027 timeline)
+- [ ] Yes, ship under `@beta` dist-tag, 7.x to maintenance mode
+- [ ] Yes, land PR #1885 in 7.x as the last feature release (7.10.0)
+- [ ] OR: stay on the existing multi-quarter dual-mode plan; defer 8.0-beta decision
+
+Once signed off, the cut is mechanical (estimated 1-2 days of pin-flip + compile-error sweep) and the `needs:adcp-3.1` queue sweep starts.


### PR DESCRIPTION
**Status:** proposal / decision-needed. Not implemented.

## TL;DR

Cut `8.0.0-beta.0` now (pinned to AdCP 3.1.0-beta.1, shipped under the `@beta` npm dist-tag) instead of riding out the multi-quarter dual-mode window described in [`v3.1-sdk-design.md`](https://github.com/adcontextprotocol/adcp-client/blob/main/docs/development/v3.1-sdk-design.md).

7.x goes into maintenance-mode after #1406 (AGENT_SUSPENDED/BLOCKED overlay) and #1885 (publisher_properties inline + directory inverse-lookup) ship. Promote 8.0-beta → 8.0 when adcp 3.1 goes GA upstream.

## Why now

Two things changed since the dual-mode plan was written:

1. **Wire-level cross-version compat is free** per spec — `error.code` is open `string` with mandatory `recovery` fallback, so a 3.1-pinned SDK talking to a 3.0 seller already works. The "keep 3.0 receivers safe forever" anxiety was misplaced; nothing about the GA pin affects wire compat for adopters using `error.code` correctly.

2. **The overlay-per-feature pattern doesn't scale.** #1883's AUTH overlay is ~150 LOC for 2 codes. The remaining `needs:adcp-3.1` queue is mostly typed-shape items (`output_only`, `frequency_capping`, `AgentDirectoryLookup`, capability bits) where overlay becomes "invent a parallel type system for 3.1." That's the work 8.0-beta makes mechanical.

3. **Real adopters want a versioned 3.1 artifact** via the standard `@beta` dist-tag (Stripe / Twilio / Anthropic SDK precedent). The opt-in `v3-1-beta` bundle (#1879) is a parallel import path, not a release line.

## What's in the doc

- Cut order (branch, pin flip, sweep, npm publish)
- Release semantics (`@latest` = 7.x, `@beta` = 8.0.0-beta.N)
- 7.x maintenance scope (security/critical fixes only)
- Promotion criteria
- Risk register (spec churn is the real cost — paid knowingly)
- What 8.0-beta unblocks (~8 queued issues become mechanical)
- Migration story (one search-and-replace per call site)
- 5 open questions, including #1885's home (7.x vs 8.0-beta)

## Decision needed

Sign-off on the pull-forward before any pin flip. Doc has explicit checkboxes for the four sub-decisions.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>