### PR TITLE
feat(errors): adopt AGENT_SUSPENDED / AGENT_BLOCKED typed codes (#1406)

### DIFF
--- a/.changeset/agent-suspended-blocked-codes.md
+++ b/.changeset/agent-suspended-blocked-codes.md
@@ -1,0 +1,29 @@
+---
+'@adcp/sdk': minor
+---
+
+feat(errors): adopt `AGENT_SUSPENDED` / `AGENT_BLOCKED` typed codes (adcp#3906 consolidates the 3.0.5 placeholder)
+
+Adopt the dedicated 3.1 error codes for buyer-agent commercial-status rejections. Closes #1406.
+
+**Wire-level changes (server-side emission):**
+- Suspended buyer agents now reject with `code: 'AGENT_SUSPENDED'` instead of `code: 'PERMISSION_DENIED', details: { scope: 'agent', status: 'suspended' }`.
+- Blocked buyer agents now reject with `code: 'AGENT_BLOCKED'` instead of `code: 'PERMISSION_DENIED', details: { scope: 'agent', status: 'blocked' }`.
+- Both codes carry `recovery: 'terminal'` at the wire envelope. The 3.0.5 placeholder shape's `recovery: 'transient'` for suspended contradicted the no-retry MUST; the transient-vs-permanent distinction lives at the seller's `BuyerAgent.status` record, not on the wire.
+- The `details.status` field is removed — envelopes carrying it fail schema validation against AdCP 3.1.
+- The `PERMISSION_DENIED + scope: 'agent' + reason: 'sandbox-only'` path is unchanged.
+
+**Typed surface (forward-compat overlay extension):**
+- New typed error classes: `AgentSuspendedError`, `AgentBlockedError` (in `src/lib/server/decisioning/errors-typed.ts`).
+- Both codes added to the forward-compat overlay (`src/lib/types/forward-compat-error-codes.ts`) with `sinceAdcpVersion: '3.1.0'` and `recovery: 'terminal'`.
+- `BuyerRetryPolicy.DEFAULT_CODE_POLICY` now maps both codes to `{ action: 'escalate', escalateReason: 'terminal' }` — auto-retry is refused by default.
+
+**Adopter migration:**
+- Code that parsed `error.code === 'PERMISSION_DENIED' && error.details?.status === 'suspended'` should switch to `error.code === 'AGENT_SUSPENDED'`. Same for `'blocked'`.
+- The `details.status` field will no longer be present.
+- Adopters using `BuyerRetryPolicy` defaults get the correct terminal-escalate behavior automatically.
+
+**References:**
+- Spec PR: [adcontextprotocol/adcp#3906](https://github.com/adcontextprotocol/adcp/pull/3906)
+- 3.0.5 placeholder registration: [adcontextprotocol/adcp#3887](https://github.com/adcontextprotocol/adcp/pull/3887)
+- Closes spec issue: [adcontextprotocol/adcp#3871](https://github.com/adcontextprotocol/adcp/issues/3871)

--- a/docs/migration-buyer-agent-registry.md
+++ b/docs/migration-buyer-agent-registry.md
@@ -328,9 +328,11 @@ You set `sandbox_only: true` on a buyer agent but your `accounts.resolve` doesn'
 
 The verifier needs an `agentUrlForKeyid` callback to stamp `credential.agent_url`. Without it, the credential is omitted and the registry has nothing to look up. See § "Verifier-side" above.
 
-### "I'm getting `PERMISSION_DENIED + scope: 'agent' + status: 'suspended'` on a buyer I just unsuspended"
+### "I'm getting `AGENT_SUSPENDED` on a buyer I just unsuspended"
 
 The cache is serving the stale `status: 'suspended'` for up to `ttlSeconds`. Call `registry.invalidate(credential)` after you mutate the row, OR set a shorter TTL.
+
+> Note: as of AdCP 3.1 (adcp#3906), suspended/blocked agents are rejected with dedicated codes `AGENT_SUSPENDED` / `AGENT_BLOCKED` instead of the 3.0.5 placeholder `PERMISSION_DENIED + details.scope: 'agent' + details.status: 'suspended' | 'blocked'`. Recovery is `terminal` for both — re-onboarding lifts the status at the seller, not on the wire.
 
 ## Reference
 

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -3475,7 +3475,9 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
 
               // --- Status enforcement (Stage 4 of #1269) ---
               // Reject new requests from `suspended` / `blocked` agents
-              // with PERMISSION_DENIED + `details.scope: 'agent'`.
+              // with the dedicated 3.1 codes `AGENT_SUSPENDED` /
+              // `AGENT_BLOCKED` (adcp#3906 consolidates the 3.0.5
+              // `PERMISSION_DENIED + details.status` placeholder shape).
               // In-flight tasks owned by a now-suspended agent are NOT
               // retroactively cancelled — this seam runs once per
               // synchronous request, not on `tasks_get` polls or
@@ -3484,30 +3486,21 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
               // `BuyerAgent.status` checks (the resolved record is
               // available on every method that takes ctx.agent).
               //
-              // Phase 2 (#1292) may swap to upstream `AGENT_SUSPENDED` /
-              // `AGENT_BLOCKED` codes if those land via separate spec PR;
-              // until then, `PERMISSION_DENIED + scope:'agent'` carries
-              // the structured signal a buyer can dispatch on without
-              // parsing prose.
+              // Recovery is `terminal` for both — a buyer cannot
+              // "wait out" a suspension by retrying the same request.
+              // The transient-vs-permanent distinction lives at the
+              // seller's `BuyerAgent.status` record (suspension may
+              // lift via re-onboarding), not on the wire envelope.
+              // The placeholder shape's `recovery: 'transient'` for
+              // suspended contradicted the no-retry MUST.
               if (resolved.status === 'suspended' || resolved.status === 'blocked') {
-                // `PERMISSION_DENIED`'s spec-default `recovery` is
-                // `correctable`, but the agent-status semantics are
-                // different per status:
-                //   - `'suspended'` is transient: re-onboarding /
-                //     contacting the seller may restore access.
-                //   - `'blocked'` is terminal: a buyer agent that's
-                //     been permanently denied SHOULD NOT loop.
-                // Setting recovery explicitly per status lets buyers
-                // dispatch retry-vs-escalate without parsing
-                // `details.status` prose.
                 return finalize(
-                  adcpError('PERMISSION_DENIED', {
+                  adcpError(resolved.status === 'suspended' ? 'AGENT_SUSPENDED' : 'AGENT_BLOCKED', {
                     message:
                       resolved.status === 'suspended'
                         ? 'Buyer agent is suspended. Contact the seller to restore access.'
                         : 'Buyer agent is blocked.',
-                    recovery: resolved.status === 'suspended' ? 'transient' : 'terminal',
-                    details: { scope: 'agent', status: resolved.status },
+                    recovery: 'terminal',
                   })
                 );
               }

--- a/src/lib/server/decisioning/buyer-agent.ts
+++ b/src/lib/server/decisioning/buyer-agent.ts
@@ -64,16 +64,22 @@ export type AdcpCredential =
  *
  * - `'active'` — normal operation; requests dispatch.
  * - `'suspended'` — temporarily paused; new requests rejected with
- *   `PERMISSION_DENIED` and `error.details.scope: 'agent'`. In-flight tasks
- *   are NOT retroactively cancelled — webhooks fire, status updates flow.
+ *   `AGENT_SUSPENDED` (recovery: `terminal`). In-flight tasks are NOT
+ *   retroactively cancelled — webhooks fire, status updates flow.
  *   Sellers who need hard cutoff implement that in their platform method
  *   via `BuyerAgent.status` check.
- * - `'blocked'` — permanently denied; new requests rejected the same way as
- *   `'suspended'`. Recovery requires re-onboarding.
+ * - `'blocked'` — permanently denied; new requests rejected with
+ *   `AGENT_BLOCKED` (recovery: `terminal`). Lifting requires re-onboarding
+ *   under a new agent identity.
  *
- * Phase 1 emits `PERMISSION_DENIED + scope:'agent'` for both rejection
- * states. Phase 2 (#1292) may swap to upstream `AGENT_SUSPENDED` /
- * `AGENT_BLOCKED` codes if those land via separate spec PR.
+ * Both `AGENT_SUSPENDED` and `AGENT_BLOCKED` are terminal at the wire level
+ * (the buyer cannot recover by retrying the same request). The transient-
+ * vs-permanent distinction lives in the seller's `BuyerAgent.status` record
+ * — suspension may lift via re-onboarding, blocked does not.
+ *
+ * Adopted from AdCP 3.1 spec PR adcp#3906, which consolidated the 3.0.5
+ * placeholder shape `PERMISSION_DENIED + details.scope:'agent' + details.status`
+ * into the dedicated codes.
  *
  * @public
  */

--- a/src/lib/server/decisioning/errors-typed.ts
+++ b/src/lib/server/decisioning/errors-typed.ts
@@ -288,6 +288,50 @@ export class PermissionDeniedError extends AdcpError {
   }
 }
 
+/**
+ * The buyer agent's commercial relationship with the seller is suspended.
+ * Recovery: terminal at the wire level — a buyer cannot "wait out" a
+ * suspension by retrying the same request. The transient-vs-permanent
+ * distinction lives at the seller's `BuyerAgent.status` record, not on the
+ * wire.
+ *
+ * Consolidates the 3.0.5 placeholder shape
+ * `PERMISSION_DENIED + details.scope:'agent' + details.status:'suspended'`,
+ * which is removed in 3.1 (envelopes carrying `details.status` fail schema
+ * validation).
+ *
+ * @since AdCP 3.1 (adcp#3906 consolidates the `details.status` placeholder).
+ */
+export class AgentSuspendedError extends AdcpError {
+  constructor(opts: CommonOpts = {}) {
+    super('AGENT_SUSPENDED', {
+      message: opts.message ?? 'Buyer agent is suspended. Contact the seller to restore access.',
+      ...(opts.suggestion !== undefined && { suggestion: opts.suggestion }),
+      ...(opts.details !== undefined && { details: opts.details }),
+    });
+  }
+}
+
+/**
+ * The buyer agent is permanently denied by the seller. Recovery: terminal —
+ * re-onboarding under a new agent identity is the only recovery path.
+ *
+ * Consolidates the 3.0.5 placeholder shape
+ * `PERMISSION_DENIED + details.scope:'agent' + details.status:'blocked'`,
+ * which is removed in 3.1.
+ *
+ * @since AdCP 3.1 (adcp#3906 consolidates the `details.status` placeholder).
+ */
+export class AgentBlockedError extends AdcpError {
+  constructor(opts: CommonOpts = {}) {
+    super('AGENT_BLOCKED', {
+      message: opts.message ?? 'Buyer agent is blocked.',
+      ...(opts.suggestion !== undefined && { suggestion: opts.suggestion }),
+      ...(opts.details !== undefined && { details: opts.details }),
+    });
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Throttling / availability family
 // ---------------------------------------------------------------------------

--- a/src/lib/types/forward-compat-error-codes.ts
+++ b/src/lib/types/forward-compat-error-codes.ts
@@ -75,6 +75,40 @@ export const FORWARD_COMPAT_ERROR_CODES = {
       'do NOT auto-retry — credentials were rejected; rotate keys, refresh OAuth tokens once if applicable, otherwise escalate to a human',
     sinceAdcpVersion: '3.1.0',
   },
+  /**
+   * Introduced by adcp#3906 (AdCP 3.1). Consolidates the 3.0.5 placeholder
+   * shape `PERMISSION_DENIED + details.scope:'agent' + details.status:'suspended'`
+   * into a dedicated code. The placeholder's `details.status` field is
+   * removed in 3.1 — envelopes carrying it fail schema validation.
+   *
+   * Recovery is `terminal` at the wire level (the placeholder's inherited
+   * `correctable` contradicted the no-retry MUST). The transient-vs-permanent
+   * distinction lives at the buyer-agent record's `status` field in the
+   * seller's database, not at the error-code wire level — a buyer cannot
+   * "wait out" a suspension by retrying the same request.
+   */
+  AGENT_SUSPENDED: {
+    description:
+      "The buyer agent's commercial relationship with the seller is suspended. New requests rejected; in-flight tasks proceed. Recovery: terminal — re-onboarding or contacting the seller is required; no auto-retry of the same request will succeed.",
+    recovery: 'terminal' as ErrorRecovery,
+    suggestion: 'contact the seller to restore access; do NOT auto-retry the same request',
+    sinceAdcpVersion: '3.1.0',
+  },
+  /**
+   * Introduced by adcp#3906 (AdCP 3.1). Consolidates the 3.0.5 placeholder
+   * shape `PERMISSION_DENIED + details.scope:'agent' + details.status:'blocked'`
+   * into a dedicated code. See {@link AGENT_SUSPENDED} for the rationale.
+   *
+   * Recovery is `terminal` — `blocked` is permanent at the agent level;
+   * re-onboarding under a new agent identity is the only recovery path.
+   */
+  AGENT_BLOCKED: {
+    description:
+      'The buyer agent is permanently denied by the seller. New requests rejected. Recovery: terminal — re-onboarding under a new agent identity is the only recovery path.',
+    recovery: 'terminal' as ErrorRecovery,
+    suggestion: 're-onboard under a new agent identity; auto-retry will not recover',
+    sinceAdcpVersion: '3.1.0',
+  },
 } as const satisfies Record<string, ForwardCompatErrorCodeInfo>;
 
 /**

--- a/src/lib/utils/buyer-retry-policy.ts
+++ b/src/lib/utils/buyer-retry-policy.ts
@@ -236,6 +236,14 @@ const DEFAULT_CODE_POLICY: Record<ErrorCode, CodePolicy> = {
   AUTH_MISSING: { action: 'escalate', escalateReason: 'auth' },
   AUTH_INVALID: { action: 'escalate', escalateReason: 'terminal' },
   PERMISSION_DENIED: { action: 'escalate', escalateReason: 'auth' },
+
+  // Agent-status terminals — adcp#3906 consolidates the 3.0.5 placeholder
+  // shape (PERMISSION_DENIED + details.status:'suspended'|'blocked') into
+  // dedicated codes. Both are terminal at the wire level — a buyer cannot
+  // recover by retrying. Suspension lifts at the seller's BuyerAgent record,
+  // not in response to client behavior.
+  AGENT_SUSPENDED: { action: 'escalate', escalateReason: 'terminal' },
+  AGENT_BLOCKED: { action: 'escalate', escalateReason: 'terminal' },
 };
 
 // ---------------------------------------------------------------------------

--- a/test/server-buyer-agent-sandbox-only.test.js
+++ b/test/server-buyer-agent-sandbox-only.test.js
@@ -316,11 +316,10 @@ describe('Phase 1.5 — sandbox-only buyer agent enforcement', () => {
     });
     const result = await dispatch(server, 'prod_acc_1');
     assert.equal(result.isError, true);
-    assert.equal(result.structuredContent.adcp_error.code, 'PERMISSION_DENIED');
-    // Status enforcement fires first — `details.reason` should be absent
-    // (status enforcement doesn't set `reason`), and `details.status`
-    // should be 'suspended'.
-    assert.equal(result.structuredContent.adcp_error.details.status, 'suspended');
+    // Status enforcement fires first — the dedicated 3.1 `AGENT_SUSPENDED`
+    // code (adcp#3906) wins over the sandbox-only `PERMISSION_DENIED`.
+    assert.equal(result.structuredContent.adcp_error.code, 'AGENT_SUSPENDED');
+    assert.equal(result.structuredContent.adcp_error.details?.reason, undefined);
   });
 
   it('null registry result (no agent) → no sandbox-only check; default request flow', async () => {

--- a/test/server-buyer-agent-status-and-redaction.test.js
+++ b/test/server-buyer-agent-status-and-redaction.test.js
@@ -98,7 +98,7 @@ describe('Stage 4 — status enforcement', () => {
     assert.equal(result.structuredContent._ctxAgent.status, 'active');
   });
 
-  it('suspended agent → 403 PERMISSION_DENIED with details.scope=agent', async () => {
+  it('suspended agent → 403 AGENT_SUSPENDED (adcp#3906 consolidates the 3.0.5 placeholder)', async () => {
     let handlerInvoked = false;
     const platform = buildPlatform({
       sales: {
@@ -127,13 +127,15 @@ describe('Stage 4 — status enforcement', () => {
       extra: { credential: sigCredential() },
     });
     assert.equal(result.isError, true);
-    assert.equal(result.structuredContent.adcp_error.code, 'PERMISSION_DENIED');
-    assert.equal(result.structuredContent.adcp_error.details.scope, 'agent');
-    assert.equal(result.structuredContent.adcp_error.details.status, 'suspended');
+    assert.equal(result.structuredContent.adcp_error.code, 'AGENT_SUSPENDED');
+    // adcp#3906 removes the `details.status` placeholder field — envelopes
+    // carrying it fail schema validation in 3.1. Buyers branch on
+    // `error.code` instead.
+    assert.equal(result.structuredContent.adcp_error.details?.status, undefined);
     assert.equal(handlerInvoked, false, 'handler MUST NOT run for suspended agent');
   });
 
-  it('blocked agent → 403 PERMISSION_DENIED with details.status=blocked AND recovery=terminal', async () => {
+  it('blocked agent → 403 AGENT_BLOCKED with recovery=terminal', async () => {
     const platform = buildPlatform({
       agentRegistry: BuyerAgentRegistry.signingOnly({
         resolveByAgentUrl: async () => sampleAgent({ status: 'blocked' }),
@@ -151,14 +153,14 @@ describe('Stage 4 — status enforcement', () => {
       extra: { credential: sigCredential() },
     });
     assert.equal(result.isError, true);
-    assert.equal(result.structuredContent.adcp_error.code, 'PERMISSION_DENIED');
-    assert.equal(result.structuredContent.adcp_error.details.status, 'blocked');
+    assert.equal(result.structuredContent.adcp_error.code, 'AGENT_BLOCKED');
+    assert.equal(result.structuredContent.adcp_error.details?.status, undefined);
     // Blocked is terminal — buyers MUST NOT auto-retry; recovery dispatches
-    // correctly without parsing details.status.
+    // correctly off `error.code`.
     assert.equal(result.structuredContent.adcp_error.recovery, 'terminal');
   });
 
-  it('suspended agent → recovery=transient (re-onboarding may resolve)', async () => {
+  it('suspended agent → recovery=terminal (adcp#3906: placeholder transient recovery contradicted no-retry MUST)', async () => {
     const platform = buildPlatform({
       agentRegistry: BuyerAgentRegistry.signingOnly({
         resolveByAgentUrl: async () => sampleAgent({ status: 'suspended' }),
@@ -175,7 +177,12 @@ describe('Stage 4 — status enforcement', () => {
       scopes: [],
       extra: { credential: sigCredential() },
     });
-    assert.equal(result.structuredContent.adcp_error.recovery, 'transient');
+    // The transient-vs-permanent distinction lives at the seller's
+    // `BuyerAgent.status` record (re-onboarding may flip suspended→active),
+    // NOT at the wire-level `recovery` field. A buyer cannot recover by
+    // retrying the same request, so `recovery: terminal` is correct.
+    assert.equal(result.structuredContent.adcp_error.recovery, 'terminal');
+    assert.equal(result.structuredContent.adcp_error.code, 'AGENT_SUSPENDED');
   });
 
   it('status enforcement runs BEFORE accounts.resolve (no tenant lookup wasted)', async () => {
@@ -253,7 +260,7 @@ describe('Stage 4 — status enforcement', () => {
       extra: { credential: sigCredential() },
     });
     assert.equal(nextResult.isError, true);
-    assert.equal(nextResult.structuredContent.adcp_error.details.status, 'suspended');
+    assert.equal(nextResult.structuredContent.adcp_error.code, 'AGENT_SUSPENDED');
   });
 
   it('null registry result (no recognized agent) does NOT trigger status enforcement', async () => {


### PR DESCRIPTION
Closes #1406. Companion to #1883 (AUTH split) — second adoption of the forward-compat overlay pattern for 3.1 codes.

## What's in scope (per adcp#3906)

AdCP 3.1 consolidates the 3.0.5 placeholder shape:

| Before (3.0.5 placeholder) | After (3.1, this PR) |
|---|---|
| `code: PERMISSION_DENIED, details: { scope: 'agent', status: 'suspended' }, recovery: 'transient'` | `code: AGENT_SUSPENDED, recovery: 'terminal'` |
| `code: PERMISSION_DENIED, details: { scope: 'agent', status: 'blocked' }, recovery: 'terminal'` | `code: AGENT_BLOCKED, recovery: 'terminal'` |

The `details.status` field is **removed in 3.1** — envelopes carrying it fail schema validation. The `recovery: 'transient'` value the placeholder inherited for suspended contradicted the no-retry MUST and has been corrected to `terminal` for both codes.

The unrelated `PERMISSION_DENIED + scope: 'agent' + reason: 'sandbox-only'` path is unchanged.

## Implementation

**Wire emission** (`src/lib/server/create-adcp-server.ts:3492`)
- Status-enforcement gate now emits `AGENT_SUSPENDED` / `AGENT_BLOCKED` instead of the placeholder shape.
- Both `recovery: 'terminal'` — buyer-agent state lives in the seller's DB, not the wire.

**Typed surface** (the second use of #1883's overlay pattern)
- `AgentSuspendedError` / `AgentBlockedError` typed classes in `errors-typed.ts`.
- Both codes added to `FORWARD_COMPAT_ERROR_CODES` with `sinceAdcpVersion: '3.1.0'`.
- `BuyerRetryPolicy.DEFAULT_CODE_POLICY` maps both to `{ action: 'escalate', escalateReason: 'terminal' }` — auto-retry refused by default.

**Tests** (3 updates, 0 new)
- `test/server-buyer-agent-status-and-redaction.test.js` — 4 tests updated to assert new codes + `recovery: 'terminal'` for both statuses + absence of `details.status`.
- `test/server-buyer-agent-sandbox-only.test.js` — precedence test updated: `AGENT_SUSPENDED` wins over sandbox-only `PERMISSION_DENIED`.

**Docs**
- `docs/migration-buyer-agent-registry.md` troubleshooting section updated to reference the new code with migration note.

## Verification

- `tsc --noEmit --project tsconfig.lib.json` — clean.
- Affected tests: 27/27 status + sandbox tests pass; 42/42 retry-policy + drift tests pass; 151/151 typed-error / decisioning tests pass.
- `prettier --check` clean on all touched files.
- Drift test (`test/lib/standard-error-codes-drift.test.js`) automatically validates the overlay union now contains both new codes.

## Adopter migration

```diff
- if (error.code === 'PERMISSION_DENIED' && error.details?.status === 'suspended') {
+ if (error.code === 'AGENT_SUSPENDED') {
    /* handle */
  }
```

Adopters using `BuyerRetryPolicy` defaults need no code changes — the new entries make auto-retry refused automatically.

## References

- Spec PR consolidating placeholder: [adcontextprotocol/adcp#3906](https://github.com/adcontextprotocol/adcp/pull/3906)
- Placeholder registration (3.0.5): [adcontextprotocol/adcp#3887](https://github.com/adcontextprotocol/adcp/pull/3887)
- Closes spec issue: [adcontextprotocol/adcp#3871](https://github.com/adcontextprotocol/adcp/issues/3871)
- Companion overlay PR: #1883 (AUTH_REQUIRED split)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>