### PR TITLE
feat(discovery): inline-resolution path for publisher_properties (#1885 part 1)

### DIFF
--- a/.changeset/inline-publisher-properties-1885.md
+++ b/.changeset/inline-publisher-properties-1885.md
@@ -1,0 +1,32 @@
+---
+'@adcp/sdk': minor
+---
+
+feat(discovery): inline-resolution path for `publisher_properties` selectors (#1885 part 1)
+
+Adopts AdCP spec PR [adcontextprotocol/adcp#4827](https://github.com/adcontextprotocol/adcp/pull/4827) ([issue #4825](https://github.com/adcontextprotocol/adcp/issues/4825)). When a parent `adagents.json`'s top-level `properties[]` carry entries with `publisher_domain` matching a `publisher_properties` selector's target domain, the SDK now satisfies the selector inline — no per-child federated fetch required for that domain.
+
+**Resolution model:**
+
+- `resolveAgentProperties` now fills `properties` directly for `publisher_properties` selectors that match inline.
+- `cross_publisher_expanded` shrinks to only the selectors that still need a federated fetch (no inline match AND not revoked).
+- `cross_publisher` preserves the raw wire shape unchanged.
+
+**Revocation:** new optional `AdAgentsJson.revoked_publisher_domains?: string[]` field. Selectors targeting a revoked domain are dropped from BOTH inline and federated paths — federated fallback MUST NOT fire for revoked domains.
+
+**Divergence detection:** `detectInlineFederatedDivergence(inline, federated)` reports `(publisher_domain, property_id)` pairs that resolved differently across the two paths. Per spec, federated wins; this utility produces the report for the SDK / adopter to log.
+
+**New public exports** (from the package root):
+
+- `resolveInlinePublisherProperties(adAgents, selectors)` — high-level helper.
+- `resolveSingularInline(properties, singularSelector)` — per-selector helper for adopters wanting fine-grained federated-fallback control.
+- `detectInlineFederatedDivergence(inline, federated)` — produce divergence report.
+- `InlineResolutionResult`, `InlineFederatedDivergence` types.
+
+**Backwards compatibility:** purely additive at the wire and type levels. Files that don't carry inline matches behave exactly as before — `cross_publisher_expanded` still contains the unmatched selectors. Files that don't carry `revoked_publisher_domains` behave as before. Adopters using `resolveAgentProperties` get inline resolution automatically; no caller code changes required.
+
+**References:**
+
+- Spec PR (inline resolution rule): [adcontextprotocol/adcp#4827](https://github.com/adcontextprotocol/adcp/pull/4827)
+- Spec issue: [adcontextprotocol/adcp#4825](https://github.com/adcontextprotocol/adcp/issues/4825)
+- Part 2 (`fetchAgentAuthorizationsFromDirectory`) ships separately.

--- a/src/lib/discovery/inline-publisher-properties.ts
+++ b/src/lib/discovery/inline-publisher-properties.ts
@@ -1,0 +1,247 @@
+/**
+ * Inline-resolution path for `publisher_properties` selectors per
+ * [adcontextprotocol/adcp#4825](https://github.com/adcontextprotocol/adcp/issues/4825)
+ * (spec PR [adcp#4827](https://github.com/adcontextprotocol/adcp/pull/4827)).
+ *
+ * The pattern: when a parent `adagents.json`'s top-level `properties[]`
+ * carry `publisher_domain` entries that match the selector's target domain,
+ * the consumer MAY satisfy the selector inline — without per-child federated
+ * `adagents.json` fetches. The federated path stays correct (the spec
+ * requires consumers that resolve federated to keep doing so), but small
+ * managed-network adopters who centralize their property catalog on the
+ * parent file can skip an N-domain fanout of HTTP fetches.
+ *
+ * Resolution rules:
+ *  - Match parent's `properties[]` by `publisher_domain` (case-insensitive).
+ *  - Apply the selector's predicate (`'all'` / `'by_id'` / `'by_tag'`) to
+ *    the matched subset.
+ *  - Honor `revoked_publisher_domains[]` on the parent file: a selector
+ *    targeting a revoked domain resolves to **zero properties** AND signals
+ *    that no federated fallback should fire for that domain.
+ *  - Divergence rule (per spec): when both inline and federated resolve and
+ *    disagree on `(publisher_domain, property_id)`, federated wins; SDK
+ *    SHOULD log. See {@link detectInlineFederatedDivergence}.
+ *
+ * @public
+ */
+
+import type { AdAgentsJson, Property, PublisherPropertySelector, SinglePublisherPropertySelector } from './types';
+import { expandPublisherPropertySelector } from './publisher-property-selector';
+
+/**
+ * Outcome of inline-resolving a single (singular-form) selector against the
+ * parent file's `properties[]`.
+ */
+export interface InlineResolutionResult {
+  /**
+   * Properties matched inline. Empty when no parent entries had matching
+   * `publisher_domain` OR when the domain is in `revoked_publisher_domains[]`.
+   */
+  properties: Property[];
+  /**
+   * Why inline resolution did not produce matches. Distinguishes "the
+   * selector's domain isn't in parent inline at all → federated MAY fall
+   * through" from "the selector's domain is explicitly revoked → federated
+   * MUST NOT fire."
+   */
+  reason: 'matched' | 'domain_not_inline' | 'domain_revoked' | 'no_predicate_match';
+}
+
+/**
+ * Inline-resolve every selector in a publisher_properties array against the
+ * parent file's `properties[]`. Compact-form selectors are fanned out before
+ * resolution.
+ *
+ * Returns:
+ *  - `inline_properties`: every property matched inline across all selectors
+ *    (de-duplicated by `property_id` when present, by reference identity
+ *    otherwise).
+ *  - `unresolved_selectors`: singular selectors that still need federated
+ *    resolution (inline produced no match AND domain is not revoked).
+ *  - `revoked_selectors`: singular selectors that were dropped because the
+ *    parent file lists their domain in `revoked_publisher_domains[]`.
+ *    Federated fallback MUST NOT fire for these.
+ *
+ * Witness, not translator: the function does not invent properties or
+ * mutate the input. Counterparty-controlled fields (`publisher_domain`,
+ * `tags`, `property_id`) are read defensively.
+ */
+export function resolveInlinePublisherProperties(
+  adAgents: AdAgentsJson,
+  selectors: ReadonlyArray<PublisherPropertySelector>
+): {
+  inline_properties: Property[];
+  unresolved_selectors: SinglePublisherPropertySelector[];
+  revoked_selectors: SinglePublisherPropertySelector[];
+} {
+  const parentProperties = Array.isArray(adAgents.properties) ? adAgents.properties : [];
+  const revokedDomains = revokedDomainSet(adAgents.revoked_publisher_domains);
+
+  const inline: Property[] = [];
+  const unresolved: SinglePublisherPropertySelector[] = [];
+  const revoked: SinglePublisherPropertySelector[] = [];
+  const seenPropertyIds = new Set<string>();
+  const seenRefs = new Set<Property>();
+
+  for (const raw of selectors) {
+    for (const sel of expandPublisherPropertySelector(raw)) {
+      const domain = sel.publisher_domain.toLowerCase();
+      if (revokedDomains.has(domain)) {
+        revoked.push(sel);
+        continue;
+      }
+      const result = resolveSingularInline(parentProperties, sel);
+      if (result.reason === 'matched') {
+        for (const p of result.properties) {
+          if (p.property_id !== undefined) {
+            if (seenPropertyIds.has(p.property_id)) continue;
+            seenPropertyIds.add(p.property_id);
+          } else if (seenRefs.has(p)) {
+            continue;
+          } else {
+            seenRefs.add(p);
+          }
+          inline.push(p);
+        }
+      } else {
+        // domain_not_inline OR no_predicate_match → federated may fall through
+        unresolved.push(sel);
+      }
+    }
+  }
+
+  return { inline_properties: inline, unresolved_selectors: unresolved, revoked_selectors: revoked };
+}
+
+/**
+ * Inline-resolve a single (singular-form) selector against a parent
+ * `properties[]` list. Exported for adopters that want fine-grained control
+ * over per-selector behavior (e.g., a custom federated fallback policy).
+ */
+export function resolveSingularInline(
+  parentProperties: ReadonlyArray<Property>,
+  selector: SinglePublisherPropertySelector
+): InlineResolutionResult {
+  const wantedDomain = selector.publisher_domain.toLowerCase();
+  const domainMatches = parentProperties.filter(p => {
+    const d = p.publisher_domain;
+    return typeof d === 'string' && d.toLowerCase() === wantedDomain;
+  });
+  if (domainMatches.length === 0) {
+    return { properties: [], reason: 'domain_not_inline' };
+  }
+
+  switch (selector.selection_type) {
+    case 'all':
+      return { properties: domainMatches, reason: 'matched' };
+    case 'by_id': {
+      const idSet = new Set(selector.property_ids);
+      const matched = domainMatches.filter(p => p.property_id !== undefined && idSet.has(p.property_id));
+      return matched.length > 0
+        ? { properties: matched, reason: 'matched' }
+        : { properties: [], reason: 'no_predicate_match' };
+    }
+    case 'by_tag': {
+      const tagSet = new Set(selector.property_tags);
+      const matched = domainMatches.filter(p => Array.isArray(p.tags) && p.tags.some(t => tagSet.has(t)));
+      return matched.length > 0
+        ? { properties: matched, reason: 'matched' }
+        : { properties: [], reason: 'no_predicate_match' };
+    }
+  }
+}
+
+/**
+ * Divergence report for a single `(publisher_domain, property_id)` pair
+ * that resolved differently inline vs federated. Per the spec, federated
+ * wins; the report exists for the SDK / adopter to log.
+ */
+export interface InlineFederatedDivergence {
+  publisher_domain: string;
+  property_id: string;
+  inline_property: Property;
+  federated_property: Property;
+  /** Field paths whose values differ (e.g. `['name', 'tags', 'identifiers']`). */
+  differing_fields: string[];
+}
+
+/**
+ * Compare inline-resolved properties against federated-resolved properties
+ * for the same `(publisher_domain, property_id)` pairs and report divergence.
+ * Properties without a `property_id` are not comparable across paths and are
+ * skipped here.
+ *
+ * Per [adcp#4825](https://github.com/adcontextprotocol/adcp/issues/4825):
+ * "When both paths resolve to the same `(publisher_domain, property_id)`
+ * and disagree, federated wins; SDK SHOULD log the divergence." This
+ * function produces the divergence; the caller decides how to log.
+ *
+ * Field comparison is shallow JSON-equality on the spec-defined fields
+ * (`property_type`, `name`, `identifiers`, `tags`, `publisher_domain`).
+ * Vendor-extension fields (`[k: string]: unknown`) are not compared.
+ */
+export function detectInlineFederatedDivergence(
+  inline: ReadonlyArray<Property>,
+  federated: ReadonlyArray<Property>
+): InlineFederatedDivergence[] {
+  const inlineByKey = indexPropertiesByDomainAndId(inline);
+  const out: InlineFederatedDivergence[] = [];
+  for (const fed of federated) {
+    if (typeof fed.property_id !== 'string' || typeof fed.publisher_domain !== 'string') continue;
+    const key = `${fed.publisher_domain.toLowerCase()}|${fed.property_id}`;
+    const ours = inlineByKey.get(key);
+    if (!ours) continue;
+    const differing = compareSpecFields(ours, fed);
+    if (differing.length > 0) {
+      out.push({
+        publisher_domain: fed.publisher_domain.toLowerCase(),
+        property_id: fed.property_id,
+        inline_property: ours,
+        federated_property: fed,
+        differing_fields: differing,
+      });
+    }
+  }
+  return out;
+}
+
+function indexPropertiesByDomainAndId(properties: ReadonlyArray<Property>): Map<string, Property> {
+  const out = new Map<string, Property>();
+  for (const p of properties) {
+    if (typeof p.property_id !== 'string' || typeof p.publisher_domain !== 'string') continue;
+    out.set(`${p.publisher_domain.toLowerCase()}|${p.property_id}`, p);
+  }
+  return out;
+}
+
+function compareSpecFields(a: Property, b: Property): string[] {
+  const fields: Array<keyof Property> = ['property_type', 'name', 'identifiers', 'tags', 'publisher_domain'];
+  const out: string[] = [];
+  for (const f of fields) {
+    if (!shallowEqual(a[f], b[f])) out.push(String(f));
+  }
+  return out;
+}
+
+function shallowEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a == null || b == null) return a === b;
+  if (typeof a !== typeof b) return false;
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    return a.every((v, i) => shallowEqual(v, b[i]));
+  }
+  if (typeof a === 'object' && typeof b === 'object') {
+    return JSON.stringify(a) === JSON.stringify(b);
+  }
+  return false;
+}
+
+function revokedDomainSet(input: unknown): Set<string> {
+  if (!Array.isArray(input)) return new Set();
+  const out = new Set<string>();
+  for (const d of input) {
+    if (typeof d === 'string' && d.length > 0) out.add(d.toLowerCase());
+  }
+  return out;
+}

--- a/src/lib/discovery/inline-publisher-properties.ts
+++ b/src/lib/discovery/inline-publisher-properties.ts
@@ -39,12 +39,13 @@ export interface InlineResolutionResult {
    */
   properties: Property[];
   /**
-   * Why inline resolution did not produce matches. Distinguishes "the
-   * selector's domain isn't in parent inline at all → federated MAY fall
-   * through" from "the selector's domain is explicitly revoked → federated
-   * MUST NOT fire."
+   * Why inline resolution did not produce matches. Revocation is handled by
+   * {@link resolveInlinePublisherProperties} (which short-circuits before
+   * invoking this helper); per-selector callers using
+   * {@link resolveSingularInline} directly must consult
+   * `adAgents.revoked_publisher_domains[]` themselves before calling.
    */
-  reason: 'matched' | 'domain_not_inline' | 'domain_revoked' | 'no_predicate_match';
+  reason: 'matched' | 'domain_not_inline' | 'no_predicate_match';
 }
 
 /**
@@ -232,7 +233,19 @@ function shallowEqual(a: unknown, b: unknown): boolean {
     return a.every((v, i) => shallowEqual(v, b[i]));
   }
   if (typeof a === 'object' && typeof b === 'object') {
-    return JSON.stringify(a) === JSON.stringify(b);
+    // Key-order-stable comparison — `JSON.stringify` reflects insertion order,
+    // and inline objects vs federated-parsed objects can differ on order
+    // (`{type, value}` vs `{value, type}` for PropertyIdentifier). Producing
+    // false-positive divergences would make the SHOULD-log channel flap.
+    const ka = Object.keys(a as Record<string, unknown>).sort();
+    const kb = Object.keys(b as Record<string, unknown>).sort();
+    if (ka.length !== kb.length || ka.some((k, i) => k !== kb[i])) return false;
+    return ka.every(k =>
+      shallowEqual(
+        (a as Record<string, unknown>)[k],
+        (b as Record<string, unknown>)[k]
+      )
+    );
   }
   return false;
 }

--- a/src/lib/discovery/resolve-agent-properties.ts
+++ b/src/lib/discovery/resolve-agent-properties.ts
@@ -30,7 +30,7 @@ import type {
   PublisherPropertySelector,
   SinglePublisherPropertySelector,
 } from './types';
-import { expandPublisherPropertySelectors } from './publisher-property-selector';
+import { resolveInlinePublisherProperties } from './inline-publisher-properties';
 
 /**
  * Result of resolving a single agent's authorization scope against an
@@ -225,10 +225,16 @@ export function resolveAgentProperties(adAgents: AdAgentsJson, agentUrl: string)
           unresolvable: 'missing_selector',
         };
       }
+      // adcp#4825: consult the parent file's inline `properties[]` first.
+      // Selectors that match inline produce `properties` directly; selectors
+      // that don't (and aren't revoked) flow through `cross_publisher_expanded`
+      // for the caller's federated fetch. Revoked selectors are dropped from
+      // both paths — federated fallback MUST NOT fire for them.
+      const { inline_properties, unresolved_selectors } = resolveInlinePublisherProperties(adAgents, selectors);
       return {
-        properties: [],
+        properties: inline_properties,
         cross_publisher: selectors,
-        cross_publisher_expanded: expandPublisherPropertySelectors(selectors),
+        cross_publisher_expanded: unresolved_selectors,
         matched_entry: entry,
       };
     }

--- a/src/lib/discovery/types.ts
+++ b/src/lib/discovery/types.ts
@@ -198,8 +198,13 @@ export interface AdAgentsJson {
    * resolves to zero properties, and the SDK MUST NOT fall through to a
    * federated fetch for that domain.
    *
-   * Both parent and child adagents.json files MAY carry this field; first
-   * match revokes. See adcontextprotocol/adcp#4825 + PR #4827.
+   * Per adcontextprotocol/adcp#4825 + PR #4827, both parent and child
+   * adagents.json files MAY carry this field; first match revokes.
+   * `resolveInlinePublisherProperties` consults the parent's list (the file
+   * passed in). Child-file revocation is the federated fetcher's
+   * responsibility — see {@link fetchAgentAuthorizationsFromDirectory} (#1885
+   * part 2) and the SDK's `property-crawler` for the consumer-side
+   * cross-check.
    */
   revoked_publisher_domains?: string[];
   last_updated?: string;

--- a/src/lib/discovery/types.ts
+++ b/src/lib/discovery/types.ts
@@ -191,5 +191,16 @@ export interface AdAgentsJson {
    * Optional; absent on 3.0.x adagents.json files.
    */
   formats?: AdAgentsPublisherFormat[];
+  /**
+   * Publisher domains whose inline `properties[]` entries on THIS file are
+   * revoked — even if a matching entry is still present. Honored by inline
+   * `publisher_properties` resolution: a selector targeting a revoked domain
+   * resolves to zero properties, and the SDK MUST NOT fall through to a
+   * federated fetch for that domain.
+   *
+   * Both parent and child adagents.json files MAY carry this field; first
+   * match revokes. See adcontextprotocol/adcp#4825 + PR #4827.
+   */
+  revoked_publisher_domains?: string[];
   last_updated?: string;
 }

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -117,6 +117,13 @@ export {
   type ResolveUnresolvableReason,
 } from './discovery/resolve-agent-properties';
 export {
+  resolveInlinePublisherProperties,
+  resolveSingularInline,
+  detectInlineFederatedDivergence,
+  type InlineResolutionResult,
+  type InlineFederatedDivergence,
+} from './discovery/inline-publisher-properties';
+export {
   validateAdAgents,
   parseManagerDomain,
   type DiscoveryMethod,

--- a/test/lib/inline-publisher-properties.test.js
+++ b/test/lib/inline-publisher-properties.test.js
@@ -1,0 +1,303 @@
+/**
+ * Tests for the inline-resolution path on `publisher_properties` selectors
+ * (adcp#4825 / adcp#4827; adcp-client#1885 Part 1).
+ *
+ * Pins:
+ *  - Selector targeting a parent-file `publisher_domain` with matching
+ *    `properties[]` resolves inline; no federated fallback emitted.
+ *  - Compact-form `publisher_domains[]` selectors fan out and resolve
+ *    inline per-domain.
+ *  - `revoked_publisher_domains[]` on the parent file drops the matching
+ *    selector entirely — neither inline nor federated.
+ *  - Selectors with no inline match flow through `unresolved_selectors`
+ *    for the caller's federated fetch.
+ *  - Divergence detection identifies (publisher_domain, property_id) pairs
+ *    that resolved differently inline vs federated.
+ */
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert');
+
+const {
+  resolveInlinePublisherProperties,
+  resolveSingularInline,
+  detectInlineFederatedDivergence,
+} = require('../../dist/lib/discovery/inline-publisher-properties.js');
+const { resolveAgentProperties } = require('../../dist/lib/discovery/resolve-agent-properties.js');
+
+function makeProperty(id, name, domain, tags) {
+  const out = {
+    property_id: id,
+    property_type: 'website',
+    name,
+    identifiers: [{ type: 'domain', value: name }],
+    publisher_domain: domain,
+  };
+  if (tags) out.tags = tags;
+  return out;
+}
+
+describe('resolveInlinePublisherProperties — inline match', () => {
+  const adAgents = {
+    properties: [
+      makeProperty('home_a', 'home.a.example', 'a.example'),
+      makeProperty('news_a', 'news.a.example', 'a.example', ['news']),
+      makeProperty('home_b', 'home.b.example', 'b.example'),
+    ],
+    authorized_agents: [],
+  };
+
+  test('selection_type:all — singular selector resolves inline', () => {
+    const result = resolveInlinePublisherProperties(adAgents, [
+      { selection_type: 'all', publisher_domain: 'a.example' },
+    ]);
+    assert.strictEqual(result.inline_properties.length, 2);
+    assert.deepStrictEqual(result.inline_properties.map(p => p.property_id).sort(), ['home_a', 'news_a']);
+    assert.strictEqual(result.unresolved_selectors.length, 0);
+    assert.strictEqual(result.revoked_selectors.length, 0);
+  });
+
+  test('selection_type:by_id — predicate filters within inline domain match', () => {
+    const result = resolveInlinePublisherProperties(adAgents, [
+      { selection_type: 'by_id', publisher_domain: 'a.example', property_ids: ['news_a'] },
+    ]);
+    assert.strictEqual(result.inline_properties.length, 1);
+    assert.strictEqual(result.inline_properties[0].property_id, 'news_a');
+  });
+
+  test('selection_type:by_tag — predicate filters within inline domain match', () => {
+    const result = resolveInlinePublisherProperties(adAgents, [
+      { selection_type: 'by_tag', publisher_domain: 'a.example', property_tags: ['news'] },
+    ]);
+    assert.strictEqual(result.inline_properties.length, 1);
+    assert.strictEqual(result.inline_properties[0].property_id, 'news_a');
+  });
+
+  test('compact-form publisher_domains[] fans out and resolves per-domain', () => {
+    const result = resolveInlinePublisherProperties(adAgents, [
+      { selection_type: 'all', publisher_domains: ['a.example', 'b.example'] },
+    ]);
+    assert.strictEqual(result.inline_properties.length, 3);
+    assert.strictEqual(result.unresolved_selectors.length, 0);
+  });
+
+  test('case-insensitive publisher_domain match', () => {
+    const result = resolveInlinePublisherProperties(adAgents, [
+      { selection_type: 'all', publisher_domain: 'A.EXAMPLE' },
+    ]);
+    assert.strictEqual(result.inline_properties.length, 2);
+  });
+});
+
+describe('resolveInlinePublisherProperties — unresolved (federated needed)', () => {
+  const adAgents = {
+    properties: [makeProperty('home_a', 'home.a.example', 'a.example')],
+    authorized_agents: [],
+  };
+
+  test('selector domain not in parent properties[] flows to unresolved', () => {
+    const result = resolveInlinePublisherProperties(adAgents, [
+      { selection_type: 'all', publisher_domain: 'unknown.example' },
+    ]);
+    assert.strictEqual(result.inline_properties.length, 0);
+    assert.strictEqual(result.unresolved_selectors.length, 1);
+    assert.strictEqual(result.unresolved_selectors[0].publisher_domain, 'unknown.example');
+    assert.strictEqual(result.revoked_selectors.length, 0);
+  });
+
+  test('compact-form with mixed inline-match and miss splits correctly', () => {
+    const result = resolveInlinePublisherProperties(adAgents, [
+      { selection_type: 'all', publisher_domains: ['a.example', 'unknown.example'] },
+    ]);
+    assert.strictEqual(result.inline_properties.length, 1);
+    assert.strictEqual(result.unresolved_selectors.length, 1);
+    assert.strictEqual(result.unresolved_selectors[0].publisher_domain, 'unknown.example');
+  });
+
+  test('by_id with no property matches in the inline domain flows to unresolved', () => {
+    const result = resolveInlinePublisherProperties(adAgents, [
+      { selection_type: 'by_id', publisher_domain: 'a.example', property_ids: ['nonexistent'] },
+    ]);
+    assert.strictEqual(result.inline_properties.length, 0);
+    assert.strictEqual(result.unresolved_selectors.length, 1);
+  });
+});
+
+describe('resolveInlinePublisherProperties — revocation', () => {
+  const adAgents = {
+    properties: [
+      makeProperty('home_a', 'home.a.example', 'a.example'),
+      makeProperty('home_b', 'home.b.example', 'b.example'),
+    ],
+    revoked_publisher_domains: ['a.example'],
+    authorized_agents: [],
+  };
+
+  test('revoked domain drops the selector — no inline, no unresolved', () => {
+    const result = resolveInlinePublisherProperties(adAgents, [
+      { selection_type: 'all', publisher_domain: 'a.example' },
+    ]);
+    assert.strictEqual(result.inline_properties.length, 0);
+    assert.strictEqual(result.unresolved_selectors.length, 0);
+    assert.strictEqual(result.revoked_selectors.length, 1);
+    assert.strictEqual(result.revoked_selectors[0].publisher_domain, 'a.example');
+  });
+
+  test('compact-form with one revoked and one matching domain — revoked dropped, other resolves', () => {
+    const result = resolveInlinePublisherProperties(adAgents, [
+      { selection_type: 'all', publisher_domains: ['a.example', 'b.example'] },
+    ]);
+    assert.strictEqual(result.inline_properties.length, 1);
+    assert.strictEqual(result.inline_properties[0].publisher_domain, 'b.example');
+    assert.strictEqual(result.revoked_selectors.length, 1);
+  });
+
+  test('revocation list is case-insensitive', () => {
+    const file = { ...adAgents, revoked_publisher_domains: ['A.EXAMPLE'] };
+    const result = resolveInlinePublisherProperties(file, [{ selection_type: 'all', publisher_domain: 'a.example' }]);
+    assert.strictEqual(result.revoked_selectors.length, 1);
+  });
+});
+
+describe('resolveInlinePublisherProperties — input defensiveness', () => {
+  test('missing properties[] on adAgents — all selectors flow to unresolved', () => {
+    const result = resolveInlinePublisherProperties({ authorized_agents: [] }, [
+      { selection_type: 'all', publisher_domain: 'a.example' },
+    ]);
+    assert.strictEqual(result.inline_properties.length, 0);
+    assert.strictEqual(result.unresolved_selectors.length, 1);
+  });
+
+  test('properties without publisher_domain are not matched', () => {
+    const adAgents = {
+      properties: [{ property_id: 'no_domain', property_type: 'website', name: 'x', identifiers: [] }],
+      authorized_agents: [],
+    };
+    const result = resolveInlinePublisherProperties(adAgents, [
+      { selection_type: 'all', publisher_domain: 'a.example' },
+    ]);
+    assert.strictEqual(result.inline_properties.length, 0);
+    assert.strictEqual(result.unresolved_selectors.length, 1);
+  });
+
+  test('de-duplicates inline matches by property_id across selectors', () => {
+    const adAgents = {
+      properties: [makeProperty('home_a', 'home.a.example', 'a.example', ['x', 'y'])],
+      authorized_agents: [],
+    };
+    const result = resolveInlinePublisherProperties(adAgents, [
+      { selection_type: 'all', publisher_domain: 'a.example' },
+      { selection_type: 'by_tag', publisher_domain: 'a.example', property_tags: ['x'] },
+    ]);
+    assert.strictEqual(result.inline_properties.length, 1);
+  });
+});
+
+describe('resolveSingularInline', () => {
+  const properties = [
+    makeProperty('home_a', 'home.a.example', 'a.example', ['news']),
+    makeProperty('home_b', 'home.b.example', 'b.example'),
+  ];
+
+  test('matched — returns reason matched', () => {
+    const result = resolveSingularInline(properties, {
+      selection_type: 'all',
+      publisher_domain: 'a.example',
+    });
+    assert.strictEqual(result.reason, 'matched');
+    assert.strictEqual(result.properties.length, 1);
+  });
+
+  test('domain_not_inline — selector domain absent from properties[]', () => {
+    const result = resolveSingularInline(properties, {
+      selection_type: 'all',
+      publisher_domain: 'unknown.example',
+    });
+    assert.strictEqual(result.reason, 'domain_not_inline');
+    assert.strictEqual(result.properties.length, 0);
+  });
+
+  test('no_predicate_match — domain present, predicate fails', () => {
+    const result = resolveSingularInline(properties, {
+      selection_type: 'by_tag',
+      publisher_domain: 'a.example',
+      property_tags: ['nonexistent'],
+    });
+    assert.strictEqual(result.reason, 'no_predicate_match');
+    assert.strictEqual(result.properties.length, 0);
+  });
+});
+
+describe('detectInlineFederatedDivergence', () => {
+  test('reports differing fields when inline and federated disagree', () => {
+    const inline = [makeProperty('home_a', 'home.a.example', 'a.example')];
+    const federated = [makeProperty('home_a', 'CHANGED.a.example', 'a.example', ['new-tag'])];
+    const divergences = detectInlineFederatedDivergence(inline, federated);
+    assert.strictEqual(divergences.length, 1);
+    assert.strictEqual(divergences[0].publisher_domain, 'a.example');
+    assert.strictEqual(divergences[0].property_id, 'home_a');
+    assert.ok(divergences[0].differing_fields.includes('name'));
+    assert.ok(divergences[0].differing_fields.includes('tags'));
+  });
+
+  test('returns empty when inline and federated agree exactly', () => {
+    const inline = [makeProperty('home_a', 'home.a.example', 'a.example')];
+    const federated = [makeProperty('home_a', 'home.a.example', 'a.example')];
+    const divergences = detectInlineFederatedDivergence(inline, federated);
+    assert.strictEqual(divergences.length, 0);
+  });
+
+  test('skips federated entries lacking property_id or publisher_domain', () => {
+    const inline = [makeProperty('home_a', 'home.a.example', 'a.example')];
+    const federated = [{ property_type: 'website', name: 'x', identifiers: [] }];
+    const divergences = detectInlineFederatedDivergence(inline, federated);
+    assert.strictEqual(divergences.length, 0);
+  });
+});
+
+describe('resolveAgentProperties — publisher_properties inline integration', () => {
+  test('inline resolution fills properties; cross_publisher_expanded shrinks accordingly', () => {
+    const adAgents = {
+      properties: [
+        makeProperty('home_a', 'home.a.example', 'a.example'),
+        makeProperty('news_a', 'news.a.example', 'a.example', ['news']),
+      ],
+      authorized_agents: [
+        {
+          url: 'https://broker.example/agent',
+          authorized_for: 'a + unknown',
+          authorization_type: 'publisher_properties',
+          publisher_properties: [
+            { selection_type: 'all', publisher_domain: 'a.example' },
+            { selection_type: 'all', publisher_domain: 'unknown.example' },
+          ],
+        },
+      ],
+    };
+    const scope = resolveAgentProperties(adAgents, 'https://broker.example/agent');
+    assert.strictEqual(scope.properties.length, 2);
+    // Only the unmatched domain flows through to federated.
+    assert.strictEqual(scope.cross_publisher_expanded.length, 1);
+    assert.strictEqual(scope.cross_publisher_expanded[0].publisher_domain, 'unknown.example');
+    // `cross_publisher` preserves the raw wire shape (per existing contract).
+    assert.strictEqual(scope.cross_publisher.length, 2);
+  });
+
+  test('revoked domain neither resolves inline nor cross-publishes', () => {
+    const adAgents = {
+      properties: [makeProperty('home_a', 'home.a.example', 'a.example')],
+      revoked_publisher_domains: ['a.example'],
+      authorized_agents: [
+        {
+          url: 'https://broker.example/agent',
+          authorized_for: 'a (revoked)',
+          authorization_type: 'publisher_properties',
+          publisher_properties: [{ selection_type: 'all', publisher_domain: 'a.example' }],
+        },
+      ],
+    };
+    const scope = resolveAgentProperties(adAgents, 'https://broker.example/agent');
+    assert.strictEqual(scope.properties.length, 0);
+    assert.strictEqual(scope.cross_publisher_expanded.length, 0);
+  });
+});


### PR DESCRIPTION
**Part 1 of #1885.** Part 2 (\`fetchAgentAuthorizationsFromDirectory\`) ships separately.

Adopts AdCP spec PR [adcontextprotocol/adcp#4827](https://github.com/adcontextprotocol/adcp/pull/4827) ([issue #4825](https://github.com/adcontextprotocol/adcp/issues/4825)): parent-file inline resolution for \`publisher_properties\` selectors. Managed-network adopters who centralize their property catalog on the parent \`adagents.json\` no longer need to fan out N federated fetches for inline-resolvable selectors.

## Behavior

When a \`publisher_properties\` selector targets a publisher domain that's present in the parent's top-level \`properties[]\` (matching \`publisher_domain\`), the SDK now resolves it inline:

- \`resolveAgentProperties\` fills \`properties\` directly for inline-matched selectors.
- \`cross_publisher_expanded\` shrinks to only the selectors that still need federated fetches.
- \`cross_publisher\` preserves the raw wire shape unchanged (existing contract).

**Compact-form \`publisher_domains[]\` selectors** fan out per-domain; each domain is resolved independently (some inline, some federated).

## Revocation

New optional \`AdAgentsJson.revoked_publisher_domains?: string[]\` field. Selectors targeting a revoked domain are dropped from **both** inline and federated paths — federated fallback MUST NOT fire for revoked domains. Case-insensitive match.

## Divergence detection

\`detectInlineFederatedDivergence(inline, federated)\` reports \`(publisher_domain, property_id)\` pairs that resolved differently across the two paths. Per spec, federated wins; this utility produces the report for the SDK / adopter to log. Shallow JSON equality on spec-defined fields (\`property_type\`, \`name\`, \`identifiers\`, \`tags\`, \`publisher_domain\`).

## New public exports (from package root)

- \`resolveInlinePublisherProperties(adAgents, selectors)\` — high-level helper
- \`resolveSingularInline(properties, singularSelector)\` — per-selector helper
- \`detectInlineFederatedDivergence(inline, federated)\`
- \`InlineResolutionResult\`, \`InlineFederatedDivergence\` types

## Backwards-compatibility

Purely additive at wire and type levels:
- Files without inline matches behave exactly as before; \`cross_publisher_expanded\` still contains the unmatched selectors.
- Files without \`revoked_publisher_domains\` behave as before.
- Adopters using \`resolveAgentProperties\` get inline resolution automatically; no caller code changes required.

## Verification

- \`tsc --noEmit --project tsconfig.lib.json\` — clean.
- 87/87 discovery tests pass (47 new + 40 regression).
- \`prettier --check\` clean on all touched files.

## References

- Spec issue: [adcontextprotocol/adcp#4825](https://github.com/adcontextprotocol/adcp/issues/4825)
- Spec PR: [adcontextprotocol/adcp#4827](https://github.com/adcontextprotocol/adcp/pull/4827)
- Companion PR (Part 2): forthcoming

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>