### PR TITLE
feat(discovery): fetchAgentAuthorizationsFromDirectory wrapper (#1885 part 2)

### DIFF
--- a/.changeset/agent-directory-lookup-1885.md
+++ b/.changeset/agent-directory-lookup-1885.md
@@ -1,0 +1,44 @@
+---
+'@adcp/sdk': minor
+---
+
+feat(discovery): `fetchAgentAuthorizationsFromDirectory` for AAO inverse-lookup (#1885 part 2)
+
+Adopts AdCP spec PR [adcontextprotocol/adcp#4828](https://github.com/adcontextprotocol/adcp/pull/4828) ([issue #4823](https://github.com/adcontextprotocol/adcp/issues/4823)). Given an `agent_url`, fetch the set of publishers whose `adagents.json` authorizes it from an AAO-compatible directory via `GET /v1/agents/{agent_url}/publishers`. Part 2 of #1885; Part 1 (inline resolution) shipped separately as #1891.
+
+**API**
+
+```ts
+import { fetchAgentAuthorizationsFromDirectory } from '@adcp/sdk';
+
+for await (const publisher of fetchAgentAuthorizationsFromDirectory(myAgentUrl, {
+  directoryUrl: 'https://aao.example.com',
+  status: ['authorized'],
+})) {
+  console.log(publisher.publisher_domain, publisher.properties_authorized);
+}
+```
+
+The returned iterator transparently pages — consumers iterate `DirectoryPublisherEntry` values without managing cursors. A `.toArray()` convenience drains the iterator for small directories.
+
+**Options:** `directoryUrl` (required), `since`, `status`, `cursor`, `limit`, `timeoutMs`, `userAgent`, `signal`.
+
+**Trust model.** The directory is discovery, not authorization. Each `DirectoryPublisherEntry` tells the operator which publisher's `adagents.json` to verify directly via the SDK's per-domain primitives. The publisher's own file remains the trust root; `properties_authorized` / `status` are operator-facing summaries.
+
+**Defensive parsing.** Counterparty-controlled response fields are validated per the AAO `agent-publishers.json` schema; malformed publisher entries are dropped (witness, not translator). HTTP 4xx/5xx and non-JSON-object responses surface as errors.
+
+**SSRF safety.** Outbound HTTP routes through the SDK's existing `ssrfSafeFetch` — private IPs, link-local, loopback, and metadata-service hosts are refused. Adopters with internal directories enable internal probes via the SDK's probe policy.
+
+**No default `directoryUrl`.** The SDK does not default to a canonical AAO host — directory choice is an operator trust decision. Adopters explicitly opt into a specific directory.
+
+**New public exports:**
+
+- `fetchAgentAuthorizationsFromDirectory(agentUrl, options)`
+- `DirectoryPublisherEntry`, `DirectoryLookupPage`, `FetchAgentAuthorizationsOptions`, `AgentAuthorizationsIterator`, `DirectoryDiscoveryMethod`, `DirectoryPublisherStatus` types
+
+**References:**
+
+- Spec issue: [adcontextprotocol/adcp#4823](https://github.com/adcontextprotocol/adcp/issues/4823)
+- Spec PR: [adcontextprotocol/adcp#4828](https://github.com/adcontextprotocol/adcp/pull/4828)
+- Schema: [`agent-publishers.json`](https://github.com/adcontextprotocol/adcp/blob/main/static/schemas/source/aao/agent-publishers.json)
+- Companion PR (Part 1, merged): #1891

--- a/src/lib/discovery/agent-directory.ts
+++ b/src/lib/discovery/agent-directory.ts
@@ -1,0 +1,401 @@
+/**
+ * AAO Directory inverse-lookup wrapper per
+ * [adcontextprotocol/adcp#4823](https://github.com/adcontextprotocol/adcp/issues/4823)
+ * (spec PR [adcp#4828](https://github.com/adcontextprotocol/adcp/pull/4828)).
+ *
+ * Given an `agent_url`, fetch the set of publishers whose adagents.json
+ * authorizes it from an AAO-compatible directory via
+ * `GET /v1/agents/{agent_url}/publishers`. Returns an async iterator that
+ * pages transparently — consumers iterate `PublisherEntry` values without
+ * managing cursors.
+ *
+ * **Trust model.** The directory is discovery, not authorization. Each
+ * `PublisherEntry` tells the operator which publisher's adagents.json to
+ * verify directly via the SDK's per-domain primitives (`fetchAdAgents`,
+ * `resolveAgentProperties`). The directory's `properties_authorized` and
+ * `status` are operator-facing summaries; the publisher's own file remains
+ * the trust root.
+ *
+ * **SSRF safety.** Outbound HTTP routes through {@link ssrfSafeFetch} —
+ * private IPs, link-local, loopback, and metadata-service hosts are
+ * refused. Adopters who centralize their directory on an internal host
+ * must enable internal probes via the SDK's probe-policy.
+ *
+ * @public
+ */
+
+import { ssrfSafeFetch, SsrfRefusedError, decodeBodyAsJsonOrText } from '../net/ssrf-fetch';
+import { isInternalProbesAllowed } from '../utils/probe-policy';
+import { LIBRARY_VERSION } from '../version';
+import { validateUserAgent } from '../utils/validate-user-agent';
+
+/**
+ * Discovery provenance for a publisher → agent edge. Mirrors the
+ * `discovery_method` enum on the AAO directory response. See the AAO
+ * `agent-publishers.json` schema for trust-profile notes per value.
+ */
+export type DirectoryDiscoveryMethod =
+  | 'direct'
+  | 'authoritative_location'
+  | 'adagents_authoritative'
+  | 'ads_txt_managerdomain';
+
+/** Lifecycle state for a publisher → agent edge. */
+export type DirectoryPublisherStatus = 'authorized' | 'revoked';
+
+/** Per-publisher entry in the directory's inverse-lookup response. */
+export interface DirectoryPublisherEntry {
+  publisher_domain: string;
+  discovery_method: DirectoryDiscoveryMethod;
+  /**
+   * Manager file domain. Required when `discovery_method` is not `direct`;
+   * null/absent for direct discovery.
+   */
+  manager_domain?: string | null;
+  /**
+   * Count of properties under THIS `publisher_domain` only that the
+   * agent's selectors resolve to. Per-publisher count, never network-wide.
+   */
+  properties_authorized: number;
+  /**
+   * Count of properties under THIS `publisher_domain` only — total
+   * inventory the publisher's file declares. Per-publisher count.
+   */
+  properties_total: number;
+  /**
+   * Whether the publisher's adagents.json entry for this agent pins
+   * `signing_keys[]`. When true, signed responses MUST verify against
+   * the pinned key set regardless of the agent's own JWKS.
+   */
+  signing_keys_pinned?: boolean;
+  status: DirectoryPublisherStatus;
+  /**
+   * When the directory last fetched and validated this publisher's
+   * adagents.json. Per-publisher freshness, distinct from the envelope's
+   * `directory_indexed_at`.
+   */
+  last_verified_at: string;
+}
+
+/**
+ * Single-page response envelope from
+ * `GET /v1/agents/{agent_url}/publishers`. Mirrors the AAO
+ * `agent-publishers.json` schema.
+ */
+export interface DirectoryLookupPage {
+  /** Canonicalized echo of the agent_url that was looked up. */
+  agent_url: string;
+  /**
+   * When the directory last completed a refresh of any publisher in this
+   * result. NULL on empty pages — treat null as "no freshness assertion"
+   * and do not advance local cache freshness.
+   */
+  directory_indexed_at: string | null;
+  publishers: DirectoryPublisherEntry[];
+  /** Opaque pagination cursor. Absent or null on the terminal page. */
+  next_cursor?: string | null;
+}
+
+/**
+ * Options for {@link fetchAgentAuthorizationsFromDirectory}.
+ */
+export interface FetchAgentAuthorizationsOptions {
+  /**
+   * Base URL of the AAO-compatible directory (e.g.
+   * `https://aao.example.com`). Required — adopters explicitly pick which
+   * directory they trust. The SDK does not default to a canonical AAO
+   * host because directory choice is an operator decision.
+   */
+  directoryUrl: string;
+  /** Return only entries verified after this timestamp. */
+  since?: Date;
+  /** Filter by lifecycle status. Default is server-defined. */
+  status?: ReadonlyArray<DirectoryPublisherStatus>;
+  /** Resume from a specific cursor (use the value from a prior page's `next_cursor`). */
+  cursor?: string;
+  /** Per-page size hint. The directory MAY enforce a lower cap. */
+  limit?: number;
+  /** Per-request timeout in milliseconds. Defaults to 30_000. */
+  timeoutMs?: number;
+  /** Custom `User-Agent` for outbound requests. */
+  userAgent?: string;
+  /**
+   * AbortSignal that cancels both in-flight requests and the async
+   * iterator. Once aborted, the iterator throws on the next `.next()` call.
+   */
+  signal?: AbortSignal;
+}
+
+/**
+ * Iteration result. The iterator yields entries one-at-a-time across all
+ * pages. After the terminal page is exhausted, iteration ends — no
+ * sentinel value is emitted.
+ */
+export interface AgentAuthorizationsIterator extends AsyncIterableIterator<DirectoryPublisherEntry> {
+  /**
+   * Drain the iterator into an array. Convenience for small result sets;
+   * adopters with potentially-large directories should iterate to bound
+   * memory.
+   */
+  toArray(): Promise<DirectoryPublisherEntry[]>;
+}
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+/** Cap on a single directory response. AAO pages are typically <100 KiB. */
+const MAX_RESPONSE_BYTES = 4 * 1024 * 1024;
+/**
+ * Safety bound on total pages fetched. Prevents an infinite-loop bug in
+ * the directory (or a hostile directory) from running the iterator forever.
+ */
+const MAX_PAGES = 10_000;
+
+/**
+ * Fetch the set of publishers whose adagents.json authorizes `agentUrl`,
+ * from an AAO-compatible directory. Returns an async iterator that yields
+ * `DirectoryPublisherEntry` values across all pages.
+ *
+ * @example
+ * ```ts
+ * for await (const pub of fetchAgentAuthorizationsFromDirectory(myAgentUrl, {
+ *   directoryUrl: 'https://aao.example.com',
+ *   status: ['authorized'],
+ * })) {
+ *   console.log(pub.publisher_domain, pub.properties_authorized);
+ * }
+ * ```
+ *
+ * @example Drain to array (small directories only):
+ * ```ts
+ * const iter = fetchAgentAuthorizationsFromDirectory(myAgentUrl, {
+ *   directoryUrl: 'https://aao.example.com',
+ * });
+ * const allPublishers = await iter.toArray();
+ * ```
+ */
+export function fetchAgentAuthorizationsFromDirectory(
+  agentUrl: string,
+  options: FetchAgentAuthorizationsOptions
+): AgentAuthorizationsIterator {
+  if (typeof agentUrl !== 'string' || agentUrl.length === 0) {
+    throw new TypeError('fetchAgentAuthorizationsFromDirectory: agentUrl is required');
+  }
+  if (!options || typeof options.directoryUrl !== 'string' || options.directoryUrl.length === 0) {
+    throw new TypeError('fetchAgentAuthorizationsFromDirectory: options.directoryUrl is required');
+  }
+  if (options.userAgent !== undefined) {
+    validateUserAgent(options.userAgent);
+  }
+
+  const state: IteratorState = {
+    agentUrl,
+    options,
+    cursor: options.cursor,
+    pageIndex: 0,
+    currentBatch: [],
+    nextBatchIndex: 0,
+    done: false,
+  };
+
+  const iter: AgentAuthorizationsIterator = {
+    next: () => advance(state),
+    return: async (value?: unknown) => {
+      state.done = true;
+      return { value, done: true } as IteratorResult<DirectoryPublisherEntry, unknown>;
+    },
+    throw: async (err?: unknown) => {
+      state.done = true;
+      throw err;
+    },
+    [Symbol.asyncIterator](): AgentAuthorizationsIterator {
+      return this;
+    },
+    async toArray(): Promise<DirectoryPublisherEntry[]> {
+      const out: DirectoryPublisherEntry[] = [];
+      for await (const entry of this) out.push(entry);
+      return out;
+    },
+  };
+
+  return iter;
+}
+
+interface IteratorState {
+  agentUrl: string;
+  options: FetchAgentAuthorizationsOptions;
+  cursor: string | undefined;
+  pageIndex: number;
+  currentBatch: DirectoryPublisherEntry[];
+  nextBatchIndex: number;
+  done: boolean;
+}
+
+async function advance(state: IteratorState): Promise<IteratorResult<DirectoryPublisherEntry>> {
+  if (state.done) return { value: undefined, done: true };
+
+  while (state.nextBatchIndex >= state.currentBatch.length) {
+    if (state.pageIndex > 0 && state.cursor === undefined) {
+      state.done = true;
+      return { value: undefined, done: true };
+    }
+    if (state.pageIndex >= MAX_PAGES) {
+      throw new Error(
+        `fetchAgentAuthorizationsFromDirectory: refused to fetch beyond ${MAX_PAGES} pages — directory may be looping`
+      );
+    }
+    const page = await fetchPage(state.agentUrl, state.options, state.cursor);
+    state.pageIndex++;
+    state.currentBatch = page.publishers;
+    state.nextBatchIndex = 0;
+    state.cursor = page.next_cursor ?? undefined;
+    if (page.publishers.length === 0 && (state.cursor === undefined || state.cursor === null)) {
+      state.done = true;
+      return { value: undefined, done: true };
+    }
+  }
+
+  const entry = state.currentBatch[state.nextBatchIndex];
+  state.nextBatchIndex++;
+  return { value: entry as DirectoryPublisherEntry, done: false };
+}
+
+async function fetchPage(
+  agentUrl: string,
+  options: FetchAgentAuthorizationsOptions,
+  cursor: string | undefined
+): Promise<DirectoryLookupPage> {
+  const url = buildDirectoryUrl(options.directoryUrl, agentUrl, {
+    since: options.since,
+    status: options.status,
+    cursor,
+    limit: options.limit,
+  });
+
+  const headers: Record<string, string> = {
+    accept: 'application/json',
+    'user-agent': options.userAgent ?? `@adcp/client/${LIBRARY_VERSION}`,
+  };
+
+  let response;
+  try {
+    response = await ssrfSafeFetch(url, {
+      method: 'GET',
+      headers,
+      timeoutMs: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+      maxBodyBytes: MAX_RESPONSE_BYTES,
+      allowPrivateIp: isInternalProbesAllowed(),
+      signal: options.signal,
+    });
+  } catch (err) {
+    if (err instanceof SsrfRefusedError) {
+      throw new Error(`fetchAgentAuthorizationsFromDirectory: SSRF guard refused ${url}: ${err.code}`);
+    }
+    throw err;
+  }
+
+  if (response.status < 200 || response.status >= 300) {
+    throw new Error(`fetchAgentAuthorizationsFromDirectory: directory returned HTTP ${response.status} for ${url}`);
+  }
+
+  const decoded = decodeBodyAsJsonOrText(response.body, response.headers['content-type']);
+  if (decoded === null || typeof decoded !== 'object' || Array.isArray(decoded)) {
+    throw new Error(`fetchAgentAuthorizationsFromDirectory: directory response was not a JSON object (${url})`);
+  }
+
+  return parseDirectoryPage(decoded, url);
+}
+
+/**
+ * Parse a raw directory response into a {@link DirectoryLookupPage},
+ * applying defensive checks on counterparty-controlled fields. Throws
+ * descriptive errors when the response shape violates the schema; the
+ * iterator surfaces these unchanged.
+ */
+function parseDirectoryPage(raw: unknown, url: string): DirectoryLookupPage {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error(`directory response is not a JSON object (${url})`);
+  }
+  const obj = raw as Record<string, unknown>;
+
+  const agent_url = obj.agent_url;
+  if (typeof agent_url !== 'string') {
+    throw new Error(`directory response missing 'agent_url' string (${url})`);
+  }
+  const indexed = obj.directory_indexed_at;
+  if (indexed !== null && typeof indexed !== 'string') {
+    throw new Error(`directory response 'directory_indexed_at' must be string or null (${url})`);
+  }
+  const publishersRaw = obj.publishers;
+  if (!Array.isArray(publishersRaw)) {
+    throw new Error(`directory response 'publishers' must be an array (${url})`);
+  }
+
+  const publishers: DirectoryPublisherEntry[] = [];
+  for (const p of publishersRaw) {
+    const entry = parsePublisherEntry(p);
+    if (entry !== null) publishers.push(entry);
+  }
+
+  const next_cursor =
+    typeof obj.next_cursor === 'string' ? obj.next_cursor : obj.next_cursor === null ? null : undefined;
+
+  return {
+    agent_url,
+    directory_indexed_at: indexed ?? null,
+    publishers,
+    next_cursor,
+  };
+}
+
+function parsePublisherEntry(raw: unknown): DirectoryPublisherEntry | null {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+  const o = raw as Record<string, unknown>;
+  if (typeof o.publisher_domain !== 'string') return null;
+  if (typeof o.discovery_method !== 'string') return null;
+  if (!isDiscoveryMethod(o.discovery_method)) return null;
+  if (typeof o.properties_authorized !== 'number' || o.properties_authorized < 0) return null;
+  if (typeof o.properties_total !== 'number' || o.properties_total < 0) return null;
+  if (o.status !== 'authorized' && o.status !== 'revoked') return null;
+  if (typeof o.last_verified_at !== 'string') return null;
+
+  const entry: DirectoryPublisherEntry = {
+    publisher_domain: o.publisher_domain,
+    discovery_method: o.discovery_method as DirectoryDiscoveryMethod,
+    properties_authorized: o.properties_authorized,
+    properties_total: o.properties_total,
+    status: o.status as DirectoryPublisherStatus,
+    last_verified_at: o.last_verified_at,
+  };
+  if (typeof o.manager_domain === 'string') entry.manager_domain = o.manager_domain;
+  else if (o.manager_domain === null) entry.manager_domain = null;
+  if (typeof o.signing_keys_pinned === 'boolean') entry.signing_keys_pinned = o.signing_keys_pinned;
+  return entry;
+}
+
+function isDiscoveryMethod(s: string): s is DirectoryDiscoveryMethod {
+  return (
+    s === 'direct' || s === 'authoritative_location' || s === 'adagents_authoritative' || s === 'ads_txt_managerdomain'
+  );
+}
+
+function buildDirectoryUrl(
+  base: string,
+  agentUrl: string,
+  query: {
+    since?: Date;
+    status?: ReadonlyArray<DirectoryPublisherStatus>;
+    cursor?: string;
+    limit?: number;
+  }
+): string {
+  const trimmed = base.endsWith('/') ? base.slice(0, -1) : base;
+  const u = new URL(`${trimmed}/v1/agents/${encodeURIComponent(agentUrl)}/publishers`);
+  if (query.since) u.searchParams.set('since', query.since.toISOString());
+  if (query.status && query.status.length > 0) {
+    for (const s of query.status) u.searchParams.append('status', s);
+  }
+  if (query.cursor) u.searchParams.set('cursor', query.cursor);
+  if (typeof query.limit === 'number' && query.limit > 0) {
+    u.searchParams.set('limit', String(Math.floor(query.limit)));
+  }
+  return u.toString();
+}

--- a/src/lib/discovery/agent-directory.ts
+++ b/src/lib/discovery/agent-directory.ts
@@ -352,16 +352,25 @@ function parsePublisherEntry(raw: unknown): DirectoryPublisherEntry | null {
   if (typeof o.publisher_domain !== 'string') return null;
   if (typeof o.discovery_method !== 'string') return null;
   if (!isDiscoveryMethod(o.discovery_method)) return null;
-  if (typeof o.properties_authorized !== 'number' || o.properties_authorized < 0) return null;
-  if (typeof o.properties_total !== 'number' || o.properties_total < 0) return null;
+  if (!Number.isFinite(o.properties_authorized) || (o.properties_authorized as number) < 0) return null;
+  if (!Number.isFinite(o.properties_total) || (o.properties_total as number) < 0) return null;
   if (o.status !== 'authorized' && o.status !== 'revoked') return null;
   if (typeof o.last_verified_at !== 'string') return null;
+
+  // Per the `agent-publishers.json` schema's `allOf` conditional: when
+  // `discovery_method` is anything other than `direct`, `manager_domain`
+  // is required. Drop rows that violate this — the directory has nothing
+  // to anchor the cross-publisher trust on, and a downstream consumer
+  // would have no manager file to verify against. Witness, not translator.
+  if (o.discovery_method !== 'direct' && typeof o.manager_domain !== 'string') {
+    return null;
+  }
 
   const entry: DirectoryPublisherEntry = {
     publisher_domain: o.publisher_domain,
     discovery_method: o.discovery_method as DirectoryDiscoveryMethod,
-    properties_authorized: o.properties_authorized,
-    properties_total: o.properties_total,
+    properties_authorized: o.properties_authorized as number,
+    properties_total: o.properties_total as number,
     status: o.status as DirectoryPublisherStatus,
     last_verified_at: o.last_verified_at,
   };

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -124,6 +124,15 @@ export {
   type InlineFederatedDivergence,
 } from './discovery/inline-publisher-properties';
 export {
+  fetchAgentAuthorizationsFromDirectory,
+  type AgentAuthorizationsIterator,
+  type FetchAgentAuthorizationsOptions,
+  type DirectoryLookupPage,
+  type DirectoryPublisherEntry,
+  type DirectoryDiscoveryMethod,
+  type DirectoryPublisherStatus,
+} from './discovery/agent-directory';
+export {
   validateAdAgents,
   parseManagerDomain,
   type DiscoveryMethod,

--- a/test/lib/agent-directory.test.js
+++ b/test/lib/agent-directory.test.js
@@ -191,6 +191,41 @@ describe('fetchAgentAuthorizationsFromDirectory — pagination', () => {
     }
   });
 
+  test('empty page with next_cursor present continues to next page (iterator state-machine branch)', async () => {
+    // The trickiest iterator branch: a page can be empty (no publishers)
+    // but still have a non-null next_cursor — the iterator must advance to
+    // the next page rather than terminate. The termination check requires
+    // BOTH `publishers.length === 0` AND cursor undefined/null.
+    const pages = [
+      {
+        agent_url: 'a',
+        directory_indexed_at: '2026-05-20T10:00:00Z',
+        publishers: [],
+        next_cursor: 'cursor-1',
+      },
+      {
+        agent_url: 'a',
+        directory_indexed_at: '2026-05-20T10:00:00Z',
+        publishers: [publisherEntry({ publisher_domain: 'late.example' })],
+        next_cursor: null,
+      },
+    ];
+    let pageIndex = 0;
+    const server = await startServer((_req, res) => {
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify(pages[pageIndex++]));
+    });
+    try {
+      const iter = fetchAgentAuthorizationsFromDirectory('a', { directoryUrl: server.url });
+      const out = await iter.toArray();
+      assert.strictEqual(pageIndex, 2, 'iterator MUST advance past empty page when next_cursor is present');
+      assert.strictEqual(out.length, 1);
+      assert.strictEqual(out[0].publisher_domain, 'late.example');
+    } finally {
+      await server.close();
+    }
+  });
+
   test('terminates on empty first page with null next_cursor', async () => {
     let requestCount = 0;
     const server = await startServer((_req, res) => {
@@ -258,6 +293,12 @@ describe('fetchAgentAuthorizationsFromDirectory — parsing', () => {
             publisherEntry({ publisher_domain: 'good.example' }),
             { publisher_domain: 'bad.example' /* missing required fields */ },
             publisherEntry({ status: 'bogus' }),
+            // discovery_method !== 'direct' requires manager_domain per schema allOf
+            publisherEntry({
+              publisher_domain: 'no-manager.example',
+              discovery_method: 'authoritative_location',
+              // manager_domain intentionally omitted
+            }),
             null,
           ],
         })

--- a/test/lib/agent-directory.test.js
+++ b/test/lib/agent-directory.test.js
@@ -1,0 +1,349 @@
+// Unit tests for fetchAgentAuthorizationsFromDirectory (#1885 part 2).
+//
+// Adopts AdCP spec PR adcp#4828 (issue adcp#4823): inverse-lookup endpoint
+// `GET /v1/agents/{agent_url}/publishers` against an AAO-compatible
+// directory. Tests pin:
+//  - URL construction (path encoding, query parameters)
+//  - Async iteration across paginated responses
+//  - Defensive parsing of counterparty-controlled fields
+//  - SSRF-safe transport via the same loopback pattern as PropertyCrawler
+
+// `ssrfSafeFetch` refuses non-https (loopback HTTP) unless the runtime has
+// opted in to internal probes. Set BEFORE the SDK loads.
+process.env.ADCP_ALLOW_INTERNAL_PROBES = '1';
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert');
+const http = require('node:http');
+
+const { fetchAgentAuthorizationsFromDirectory } = require('../../dist/lib/discovery/agent-directory.js');
+
+function startServer(handler) {
+  return new Promise(resolve => {
+    const server = http.createServer(handler);
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      resolve({
+        url: `http://127.0.0.1:${port}`,
+        close: () => new Promise(r => server.close(() => r())),
+      });
+    });
+  });
+}
+
+function publisherEntry(overrides = {}) {
+  return {
+    publisher_domain: 'news.example',
+    discovery_method: 'direct',
+    properties_authorized: 3,
+    properties_total: 5,
+    status: 'authorized',
+    last_verified_at: '2026-05-20T10:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('fetchAgentAuthorizationsFromDirectory — URL construction', () => {
+  test('builds GET /v1/agents/{encoded}/publishers with no query params by default', async () => {
+    let capturedPath = null;
+    const server = await startServer((req, res) => {
+      capturedPath = req.url;
+      res.setHeader('content-type', 'application/json');
+      res.end(
+        JSON.stringify({
+          agent_url: 'https://agent.example/mcp',
+          directory_indexed_at: '2026-05-20T10:00:00Z',
+          publishers: [],
+        })
+      );
+    });
+    try {
+      const iter = fetchAgentAuthorizationsFromDirectory('https://agent.example/mcp', {
+        directoryUrl: server.url,
+      });
+      await iter.toArray();
+      assert.strictEqual(capturedPath, '/v1/agents/' + encodeURIComponent('https://agent.example/mcp') + '/publishers');
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('appends since, status, cursor, limit query parameters', async () => {
+    let capturedQuery = null;
+    const server = await startServer((req, res) => {
+      capturedQuery = new URL(req.url, 'http://127.0.0.1').searchParams;
+      res.setHeader('content-type', 'application/json');
+      res.end(
+        JSON.stringify({
+          agent_url: 'https://agent.example/mcp',
+          directory_indexed_at: null,
+          publishers: [],
+        })
+      );
+    });
+    try {
+      const iter = fetchAgentAuthorizationsFromDirectory('https://agent.example/mcp', {
+        directoryUrl: server.url,
+        since: new Date('2026-05-01T00:00:00Z'),
+        status: ['authorized', 'revoked'],
+        cursor: 'opaque-cursor',
+        limit: 50,
+      });
+      await iter.toArray();
+      assert.strictEqual(capturedQuery.get('since'), '2026-05-01T00:00:00.000Z');
+      assert.deepStrictEqual(capturedQuery.getAll('status'), ['authorized', 'revoked']);
+      assert.strictEqual(capturedQuery.get('cursor'), 'opaque-cursor');
+      assert.strictEqual(capturedQuery.get('limit'), '50');
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('handles trailing slash on directoryUrl', async () => {
+    let capturedPath = null;
+    const server = await startServer((req, res) => {
+      capturedPath = req.url;
+      res.setHeader('content-type', 'application/json');
+      res.end(
+        JSON.stringify({
+          agent_url: 'a',
+          directory_indexed_at: null,
+          publishers: [],
+        })
+      );
+    });
+    try {
+      const iter = fetchAgentAuthorizationsFromDirectory('a', {
+        directoryUrl: server.url + '/',
+      });
+      await iter.toArray();
+      assert.strictEqual(capturedPath, '/v1/agents/a/publishers');
+    } finally {
+      await server.close();
+    }
+  });
+});
+
+describe('fetchAgentAuthorizationsFromDirectory — pagination', () => {
+  test('iterator yields entries across multiple pages, transparent cursor handling', async () => {
+    const pages = [
+      {
+        agent_url: 'https://agent.example/mcp',
+        directory_indexed_at: '2026-05-20T10:00:00Z',
+        publishers: [publisherEntry({ publisher_domain: 'a.example' })],
+        next_cursor: 'cursor-1',
+      },
+      {
+        agent_url: 'https://agent.example/mcp',
+        directory_indexed_at: '2026-05-20T10:00:00Z',
+        publishers: [publisherEntry({ publisher_domain: 'b.example' })],
+        next_cursor: 'cursor-2',
+      },
+      {
+        agent_url: 'https://agent.example/mcp',
+        directory_indexed_at: '2026-05-20T10:00:00Z',
+        publishers: [publisherEntry({ publisher_domain: 'c.example' })],
+        next_cursor: null,
+      },
+    ];
+    let pageIndex = 0;
+    const cursorsSeen = [];
+    const server = await startServer((req, res) => {
+      const url = new URL(req.url, 'http://127.0.0.1');
+      cursorsSeen.push(url.searchParams.get('cursor'));
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify(pages[pageIndex++]));
+    });
+    try {
+      const iter = fetchAgentAuthorizationsFromDirectory('https://agent.example/mcp', {
+        directoryUrl: server.url,
+      });
+      const domains = [];
+      for await (const entry of iter) domains.push(entry.publisher_domain);
+      assert.deepStrictEqual(domains, ['a.example', 'b.example', 'c.example']);
+      assert.deepStrictEqual(cursorsSeen, [null, 'cursor-1', 'cursor-2']);
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('terminates on absent next_cursor', async () => {
+    let requestCount = 0;
+    const server = await startServer((_req, res) => {
+      requestCount++;
+      res.setHeader('content-type', 'application/json');
+      res.end(
+        JSON.stringify({
+          agent_url: 'a',
+          directory_indexed_at: '2026-05-20T10:00:00Z',
+          publishers: [publisherEntry()],
+          // no next_cursor field at all
+        })
+      );
+    });
+    try {
+      const iter = fetchAgentAuthorizationsFromDirectory('a', { directoryUrl: server.url });
+      const out = await iter.toArray();
+      assert.strictEqual(out.length, 1);
+      assert.strictEqual(requestCount, 1);
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('terminates on empty first page with null next_cursor', async () => {
+    let requestCount = 0;
+    const server = await startServer((_req, res) => {
+      requestCount++;
+      res.setHeader('content-type', 'application/json');
+      res.end(
+        JSON.stringify({
+          agent_url: 'a',
+          directory_indexed_at: null,
+          publishers: [],
+          next_cursor: null,
+        })
+      );
+    });
+    try {
+      const iter = fetchAgentAuthorizationsFromDirectory('a', { directoryUrl: server.url });
+      const out = await iter.toArray();
+      assert.strictEqual(out.length, 0);
+      assert.strictEqual(requestCount, 1);
+    } finally {
+      await server.close();
+    }
+  });
+});
+
+describe('fetchAgentAuthorizationsFromDirectory — parsing', () => {
+  test('preserves all spec fields including optional manager_domain and signing_keys_pinned', async () => {
+    const server = await startServer((_req, res) => {
+      res.setHeader('content-type', 'application/json');
+      res.end(
+        JSON.stringify({
+          agent_url: 'https://agent.example/mcp',
+          directory_indexed_at: '2026-05-20T10:00:00Z',
+          publishers: [
+            publisherEntry({
+              discovery_method: 'authoritative_location',
+              manager_domain: 'manager.example',
+              signing_keys_pinned: true,
+            }),
+          ],
+        })
+      );
+    });
+    try {
+      const iter = fetchAgentAuthorizationsFromDirectory('https://agent.example/mcp', {
+        directoryUrl: server.url,
+      });
+      const [entry] = await iter.toArray();
+      assert.strictEqual(entry.discovery_method, 'authoritative_location');
+      assert.strictEqual(entry.manager_domain, 'manager.example');
+      assert.strictEqual(entry.signing_keys_pinned, true);
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('drops malformed publisher entries (defensive, witness-not-translator)', async () => {
+    const server = await startServer((_req, res) => {
+      res.setHeader('content-type', 'application/json');
+      res.end(
+        JSON.stringify({
+          agent_url: 'a',
+          directory_indexed_at: '2026-05-20T10:00:00Z',
+          publishers: [
+            publisherEntry({ publisher_domain: 'good.example' }),
+            { publisher_domain: 'bad.example' /* missing required fields */ },
+            publisherEntry({ status: 'bogus' }),
+            null,
+          ],
+        })
+      );
+    });
+    try {
+      const iter = fetchAgentAuthorizationsFromDirectory('a', { directoryUrl: server.url });
+      const out = await iter.toArray();
+      assert.strictEqual(out.length, 1);
+      assert.strictEqual(out[0].publisher_domain, 'good.example');
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('rejects non-JSON-object response', async () => {
+    const server = await startServer((_req, res) => {
+      res.setHeader('content-type', 'application/json');
+      res.end('"not an object"');
+    });
+    try {
+      const iter = fetchAgentAuthorizationsFromDirectory('a', { directoryUrl: server.url });
+      await assert.rejects(iter.next(), /not a JSON object/);
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('rejects response missing agent_url', async () => {
+    const server = await startServer((_req, res) => {
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify({ directory_indexed_at: null, publishers: [] }));
+    });
+    try {
+      const iter = fetchAgentAuthorizationsFromDirectory('a', { directoryUrl: server.url });
+      await assert.rejects(iter.next(), /missing 'agent_url'/);
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('rejects HTTP 4xx/5xx responses', async () => {
+    const server = await startServer((_req, res) => {
+      res.statusCode = 503;
+      res.end('Service Unavailable');
+    });
+    try {
+      const iter = fetchAgentAuthorizationsFromDirectory('a', { directoryUrl: server.url });
+      await assert.rejects(iter.next(), /HTTP 503/);
+    } finally {
+      await server.close();
+    }
+  });
+});
+
+describe('fetchAgentAuthorizationsFromDirectory — argument validation', () => {
+  test('throws on missing agentUrl', () => {
+    assert.throws(
+      () => fetchAgentAuthorizationsFromDirectory('', { directoryUrl: 'https://x' }),
+      /agentUrl is required/
+    );
+  });
+
+  test('throws on missing directoryUrl', () => {
+    assert.throws(() => fetchAgentAuthorizationsFromDirectory('a', { directoryUrl: '' }), /directoryUrl is required/);
+  });
+});
+
+describe('fetchAgentAuthorizationsFromDirectory — toArray drain', () => {
+  test('returns empty array for empty directory', async () => {
+    const server = await startServer((_req, res) => {
+      res.setHeader('content-type', 'application/json');
+      res.end(
+        JSON.stringify({
+          agent_url: 'a',
+          directory_indexed_at: null,
+          publishers: [],
+        })
+      );
+    });
+    try {
+      const iter = fetchAgentAuthorizationsFromDirectory('a', { directoryUrl: server.url });
+      const out = await iter.toArray();
+      assert.deepStrictEqual(out, []);
+    } finally {
+      await server.close();
+    }
+  });
+});


### PR DESCRIPTION
**Part 2 of #1885.** Part 1 (inline resolution) shipped as #1891. This PR closes the issue.

Adopts AdCP spec PR [adcontextprotocol/adcp#4828](https://github.com/adcontextprotocol/adcp/pull/4828) ([issue #4823](https://github.com/adcontextprotocol/adcp/issues/4823)): the AAO directory inverse-lookup endpoint \`GET /v1/agents/{agent_url}/publishers\`.

## API

\`\`\`ts
import { fetchAgentAuthorizationsFromDirectory } from '@adcp/sdk';

for await (const pub of fetchAgentAuthorizationsFromDirectory(myAgentUrl, {
  directoryUrl: 'https://aao.example.com',
  status: ['authorized'],
})) {
  console.log(pub.publisher_domain, pub.properties_authorized);
}
\`\`\`

The iterator pages transparently — consumers iterate \`DirectoryPublisherEntry\` values without managing cursors. A \`.toArray()\` convenience drains for small directories. Options: \`directoryUrl\` (required), \`since\`, \`status\`, \`cursor\`, \`limit\`, \`timeoutMs\`, \`userAgent\`, \`signal\`.

## Design notes

- **Trust model.** The directory is *discovery*, not *authorization*. Each \`DirectoryPublisherEntry\` tells the operator which publisher's adagents.json to verify directly via the SDK's per-domain primitives. The publisher's own file remains the trust root.
- **No default \`directoryUrl\`.** Directory choice is an operator trust decision; adopters explicitly opt in.
- **SSRF safety.** Outbound HTTP via \`ssrfSafeFetch\` with \`allowPrivateIp\` gated by \`isInternalProbesAllowed()\` — same pattern as \`PropertyCrawler\`.
- **Defensive parsing.** Counterparty-controlled fields validated per the [agent-publishers.json](https://github.com/adcontextprotocol/adcp/blob/main/static/schemas/source/aao/agent-publishers.json) schema. Malformed publisher entries are dropped (witness, not translator). HTTP 4xx/5xx and non-JSON responses surface as errors.
- **\`MAX_PAGES\` safety bound** (10,000) prevents a hostile or broken directory from running the iterator forever.

## New public exports

- \`fetchAgentAuthorizationsFromDirectory(agentUrl, options)\`
- Types: \`DirectoryPublisherEntry\`, \`DirectoryLookupPage\`, \`FetchAgentAuthorizationsOptions\`, \`AgentAuthorizationsIterator\`, \`DirectoryDiscoveryMethod\`, \`DirectoryPublisherStatus\`

## Verification

- \`tsc --noEmit --project tsconfig.lib.json\` clean.
- 14/14 tests pass — URL construction, pagination, parsing, argument validation, drain.
- \`prettier --check\` clean on all touched files.

## References

- Spec issue: [adcontextprotocol/adcp#4823](https://github.com/adcontextprotocol/adcp/issues/4823)
- Spec PR: [adcontextprotocol/adcp#4828](https://github.com/adcontextprotocol/adcp/pull/4828)
- Schema: [\`agent-publishers.json\`](https://github.com/adcontextprotocol/adcp/blob/main/static/schemas/source/aao/agent-publishers.json)
- Part 1 (merged): #1891

Closes #1885.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>