### PR TITLE
fix(server): emit envelope status on get_adcp_capabilities responses

### DIFF
--- a/.changeset/fix-capabilities-envelope-status-4877.md
+++ b/.changeset/fix-capabilities-envelope-status-4877.md
@@ -1,0 +1,11 @@
+---
+'@adcp/sdk': patch
+---
+
+fix(server): emit envelope `status: "completed"` on `get_adcp_capabilities` responses
+
+`capabilitiesResponse` (and the framework's auto-registered `get_adcp_capabilities` handler that uses it) now stamps the v3 protocol envelope's required `status: "completed"` field at the top level of `structuredContent`. Synchronous task responses MUST carry `status` per `protocol-envelope.json` (AdCP #4876); the helper previously built `structuredContent` from the typed `GetAdCPCapabilitiesResponse` payload alone, never threading the envelope-level status. Adopters who didn't override the helper hit `v3_envelope_integrity/no_legacy_status_fields` conformance failure.
+
+The auto-registered handler in `createAdcpServer` inherits the fix because it calls `capabilitiesResponse` for its wire output. v5 raw-handler adopters still calling `capabilitiesResponse` directly also get the fix for free. Adopters who hand-rolled their own `get_adcp_capabilities` MCP tool (not using the helper) must add `status: "completed"` to their structuredContent themselves.
+
+Fixes adcontextprotocol/adcp#4877. Reported by @kapoost (`@adcp/sdk@7.7.0`, 117/121 storyboards passing; this was the remaining `v3_envelope_integrity` failure surfaced in adcontextprotocol/adcp#4832).

--- a/src/lib/server/responses.ts
+++ b/src/lib/server/responses.ts
@@ -128,12 +128,20 @@ function assertNoTopLevelSetup(data: unknown, builder: string): void {
  *
  * `supported_protocols` lists AdCP domain protocols (media_buy, signals, governance, etc.),
  * NOT transport protocols (mcp, a2a).
+ *
+ * Stamps the v3 protocol envelope's required `status: "completed"` field at
+ * the top level of `structuredContent`. Synchronous task responses MUST carry
+ * `status` per `protocol-envelope.json` (AdCP #4876); without it the
+ * `v3_envelope_integrity/no_legacy_status_fields` conformance step fails.
+ * The status is injected here rather than added to `GetAdCPCapabilitiesResponse`
+ * because it's an envelope concern, not a payload field — the wire shape and
+ * the typed payload model live at different layers.
  */
 /** @deprecated v6: `createAdcpServerFromPlatform` constructs wire responses from typed platform returns. Direct use is for v5 raw-handler adopters mid-migration only. */
 export function capabilitiesResponse(data: GetAdCPCapabilitiesResponse, summary?: string): McpToolResponse {
   return {
     content: [{ type: 'text', text: summary ?? 'Agent capabilities retrieved' }],
-    structuredContent: toStructuredContent(data),
+    structuredContent: { ...toStructuredContent(data), status: 'completed' },
   };
 }
 

--- a/test/server-create-adcp-server.test.js
+++ b/test/server-create-adcp-server.test.js
@@ -347,6 +347,19 @@ describe('createAdcpServer', () => {
       assert.ok(caps.supported_protocols.includes('media_buy'));
     });
 
+    it('emits envelope status: "completed" on the auto-registered handler', async () => {
+      // AdCP #4876 made envelope `status` required on every task response;
+      // the auto-registered get_adcp_capabilities handler must satisfy it
+      // for sync wire conformance. Tracks #4877.
+      const server = createAdcpServer({
+        name: 'Test',
+        version: '1.0.0',
+        mediaBuy: { getProducts: async () => ({ products: [] }) },
+      });
+      const caps = await callTool(server, 'get_adcp_capabilities', {});
+      assert.strictEqual(caps.status, 'completed');
+    });
+
     it('detects multiple protocols', async () => {
       const server = createAdcpServer({
         name: 'Test',

--- a/test/server-responses.test.js
+++ b/test/server-responses.test.js
@@ -44,6 +44,18 @@ describe('capabilitiesResponse', () => {
     const result = capabilitiesResponse({ supported_protocols: [] }, 'Custom summary');
     assert.strictEqual(result.content[0].text, 'Custom summary');
   });
+
+  it('stamps envelope status: "completed" on structuredContent', () => {
+    // Per AdCP #4876, the v3 protocol envelope requires `status` on every
+    // task response — including synchronous metadata calls like
+    // get_adcp_capabilities. The `v3_envelope_integrity/no_legacy_status_fields`
+    // storyboard step fails without it (#4877).
+    const result = capabilitiesResponse({
+      adcp: { major_versions: [3] },
+      supported_protocols: ['media_buy'],
+    });
+    assert.strictEqual(result.structuredContent.status, 'completed');
+  });
 });
 
 describe('productsResponse', () => {


### PR DESCRIPTION
## Summary

- Fixes [adcontextprotocol/adcp#4877](https://github.com/adcontextprotocol/adcp/issues/4877). The framework's auto-registered `get_adcp_capabilities` handler bypassed v6 envelope-threading and never stamped the v3 envelope's required `status` field — adopters hit `v3_envelope_integrity/no_legacy_status_fields` (originally surfaced by @kapoost on `@adcp/sdk@7.7.0` via adcontextprotocol/adcp#4832).
- `capabilitiesResponse` now stamps `status: "completed"` at the top level of `structuredContent`. The auto-registered handler inherits the fix because it dispatches through `capabilitiesResponse`; v5 raw-handler adopters still importing the helper directly get the fix for free.
- Audited the other sync auto-registered helpers: `tasks_get` already emits `status` (from-platform.ts:1854-1888), and domain tools flow through `projectSync` + typed response builders whose payload shapes carry their own discriminator. `get_adcp_capabilities` was the only gap.

## Test plan

- [x] `NODE_ENV=test node --test test/server-responses.test.js test/server-create-adcp-server.test.js test/server-idempotency.test.js test/server-decisioning-from-platform.test.js test/lib/capabilities-tools-drift.test.js` — 315/315 pass
- [x] Added a unit test on `capabilitiesResponse` (envelope status stamp)
- [x] Added an integration test against the auto-registered handler — the path @kapoost's seller agent actually exercises
- [x] `npm run format:check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)