### PR TITLE
fix(server): stamp envelope status at sync dispatch chokepoint

### DIFF
--- a/.changeset/envelope-status-sweep-1897.md
+++ b/.changeset/envelope-status-sweep-1897.md
@@ -1,0 +1,17 @@
+---
+'@adcp/sdk': patch
+---
+
+fix(server): stamp v3 envelope `status: "completed"` on every sync wire response at the dispatch chokepoint
+
+`createAdcpServer`'s handler dispatcher now stamps the v3 protocol envelope's required `status: "completed"` field at the `finalize()` chokepoint, immediately before context/version injection. Closes the SDK-wide gap audit-missed in #1895 (which fixed only `get_adcp_capabilities`): `projectSync` returns `mapResult(result)` verbatim and 19 `*Response` helpers (`productsResponse`, `listAccountsResponse`, `listCreativeFormatsResponse`, `performanceFeedbackResponse`, `buildCreativeResponse`, `deliveryResponse`, `getMediaBuysResponse`, `listCreativesResponse`, `previewCreativeResponse`, `creativeDeliveryResponse`, `syncCreativesResponse`, `getSignalsResponse`, `activateSignalResponse`, `listPropertyListsResponse`, `listCollectionListsResponse`, `listContentStandardsResponse`, `getPlanAuditLogsResponse`, `reportUsageResponse`, plus `genericResponse` for the ~30 governance / SI / brand tools without a dedicated builder) all built `structuredContent: toStructuredContent(data)` with no envelope status. The storyboard step `v3_envelope_integrity/no_legacy_status_fields` only asserts on `get_adcp_capabilities` today; @kapoost's one-tool failure masked a SDK-wide gap that would have lit up the moment the assertion generalised.
+
+Centralised at `finalize()` rather than per-helper so:
+
+- The seam is single — every framework-registered tool inherits envelope conformance whether wrapped through `productsResponse`, `mediaBuyResponse`, `genericResponse`, the test-controller bridge's `wrap(merged)` rewrites, or future helpers added without remembering to stamp.
+- The MediaBuyStatus/TaskStatus collision on `CreateMediaBuySuccess.status` / `UpdateMediaBuySuccess.status` / `cancelMediaBuyResponse`'s hard-coded `status: 'canceled'` is preserved verbatim: the chokepoint only stamps when `structuredContent.status` is missing, so a buy returning `status: 'active'` (valid `MediaBuyStatus`, not a valid `TaskStatus`) ships unchanged. The spec-level ambiguity at the same top-level key is filed for adcp.
+- Error envelopes (`isError: true`) are skipped — their status semantics (`failed` / `rejected`) belong to the adcp_error path, not this seam.
+
+Submitted envelopes (HITL handoff) keep their handler-set `status: 'submitted'`. Auto-registered `get_adcp_capabilities` continues to stamp via `capabilitiesResponse` directly (it bypasses `finalize()`); both layers reinforce.
+
+Tracks adcp-client#1897. Sibling to adcontextprotocol/adcp#4877 (spec contract) and #1895 (narrow `get_adcp_capabilities` fix).

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -2653,6 +2653,50 @@ function injectContextIntoResponse(response: McpToolResponse, context: unknown):
  * `resolveBundleKey(adcpVersion)`). For now it always reflects the seller's
  * own pin; downshift (3.1 seller serving a 3.0 buyer at 3.0) is a follow-up.
  */
+/**
+ * Stamp the v3 protocol envelope's required `status` field on success
+ * responses. Per AdCP #4876, every task response envelope MUST carry
+ * `status`; synchronous calls emit `"completed"`. Mirrors
+ * `injectContextIntoResponse`'s structuredContent + L2-text-fallback
+ * dual write so MCP clients reading either layer see the field.
+ *
+ * Skipped when:
+ * - `isError: true` — error envelopes carry their own status semantics
+ *   (`failed` / `rejected` / etc.). Wired separately by the adcp_error
+ *   path; not this seam's concern.
+ * - `structuredContent.status` already present — handler-declared status
+ *   takes precedence. Preserves:
+ *     • the Submitted envelope's `status: 'submitted'`,
+ *     • payloads whose typed shape carries its own top-level `status`
+ *       discriminator (`CreateMediaBuySuccess.status: MediaBuyStatus`,
+ *       `UpdateMediaBuySuccess.status: MediaBuyStatus`, the
+ *       `cancelMediaBuyResponse` builder's hard-coded `status: 'canceled'`).
+ *   The MediaBuyStatus/TaskStatus collision at the same top-level key is
+ *   a spec ambiguity tracked at adcp-client#1897; this seam refuses to
+ *   destroy payload semantics until the spec disambiguates.
+ */
+function injectEnvelopeStatusIntoResponse(response: McpToolResponse): void {
+  if (response.isError === true) return;
+  const sc = response.structuredContent as Record<string, unknown> | undefined;
+  if (!sc || typeof sc !== 'object') return;
+  if ('status' in sc) return;
+  sc.status = 'completed';
+  if (Array.isArray(response.content)) {
+    const first = response.content[0];
+    if (first && first.type === 'text' && typeof first.text === 'string') {
+      try {
+        const parsed = JSON.parse(first.text);
+        if (parsed && typeof parsed === 'object' && !('status' in parsed)) {
+          parsed.status = 'completed';
+          first.text = JSON.stringify(parsed);
+        }
+      } catch {
+        // Text isn't JSON — leave it alone
+      }
+    }
+  }
+}
+
 function injectVersionIntoResponse(response: McpToolResponse, servedVersion: string | undefined): void {
   if (!servedVersion) return;
   const sc = response.structuredContent as Record<string, unknown> | undefined;
@@ -3412,6 +3456,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
           // the allowlist-filtered envelope; BEFORE context/version
           // injection so those run on the final two-layer payload.
           enrichErrorTwoLayer(response, toolName, toolsWithErrorArm);
+          injectEnvelopeStatusIntoResponse(response);
           injectContextIntoResponse(response, params.context);
           injectVersionIntoResponse(response, servedAdcpVersion);
           return response;

--- a/test/server-create-adcp-server.test.js
+++ b/test/server-create-adcp-server.test.js
@@ -432,6 +432,69 @@ describe('createAdcpServer', () => {
       const result = await callToolRaw(server, 'get_signals', {});
       assert.strictEqual(result.content[0].text, 'Found 1 signal');
     });
+  });
+
+  describe('envelope status (AdCP #4876 / adcp-client#1897)', () => {
+    // The v3 protocol envelope requires top-level `status` on every task
+    // response. The framework stamps `status: "completed"` at the dispatch
+    // chokepoint when the handler-projected payload doesn't already carry one,
+    // so every per-tool wrap helper + the genericResponse fallback inherit
+    // envelope conformance without needing per-helper edits.
+
+    it('stamps status: "completed" on get_products (productsResponse path)', async () => {
+      const server = createAdcpServer({
+        name: 'Test',
+        version: '1.0.0',
+        mediaBuy: { getProducts: async () => ({ products: [{ product_id: 'p1' }] }) },
+      });
+      const caps = await callTool(server, 'get_products', { buying_mode: 'brief', brief: 't' });
+      assert.strictEqual(caps.status, 'completed');
+    });
+
+    it('stamps status: "completed" on get_signals (getSignalsResponse path)', async () => {
+      const server = createAdcpServer({
+        name: 'Test',
+        version: '1.0.0',
+        signals: { getSignals: async () => ({ signals: [{ signal_id: 's1' }] }) },
+      });
+      const caps = await callTool(server, 'get_signals', {});
+      assert.strictEqual(caps.status, 'completed');
+    });
+
+    it('stamps status: "completed" on list_property_lists (genericResponse fallback)', async () => {
+      const server = createAdcpServer({
+        name: 'Test',
+        version: '1.0.0',
+        governance: {
+          listPropertyLists: async () => ({ property_lists: [] }),
+        },
+      });
+      const caps = await callTool(server, 'list_property_lists', {});
+      assert.strictEqual(caps.status, 'completed');
+    });
+
+    it('preserves MediaBuyStatus on create_media_buy (does NOT clobber payload status)', async () => {
+      // `CreateMediaBuySuccess.status` carries MediaBuyStatus, which partly
+      // overlaps but is not equal to TaskStatus. The chokepoint must NOT
+      // overwrite a handler-declared payload `status` — until the spec
+      // disambiguates envelope vs payload status at the same key, the
+      // MediaBuy lifecycle value wins.
+      const server = createAdcpServer({
+        name: 'Test',
+        version: '1.0.0',
+        mediaBuy: {
+          getProducts: async () => ({ products: [] }),
+          createMediaBuy: async () => ({ media_buy_id: 'mb_1', packages: [], status: 'active' }),
+        },
+      });
+      const caps = await callTool(server, 'create_media_buy', {
+        account: { account_id: 'a1' },
+        brand: { brand_id: 'b1' },
+        start_time: '2026-01-01T00:00:00Z',
+        end_time: '2026-02-01T00:00:00Z',
+      });
+      assert.strictEqual(caps.status, 'active');
+    });
 
     it('uses generic wrapper for tools without dedicated builders', async () => {
       const server = createAdcpServer({


### PR DESCRIPTION
## Summary

Closes #1897 (the SDK-wide gap the #1895 audit missed).

- Adds `injectEnvelopeStatusIntoResponse` at the `finalize()` chokepoint in `createAdcpServer`'s tool dispatcher. One seam — every framework-registered tool gets envelope `status: \"completed\"` without per-helper edits, whether it dispatches through `productsResponse`, `mediaBuyResponse`, `genericResponse`, or the test-controller bridge's `wrap(merged)` rewrites.
- Chokepoint placement preserves the `MediaBuyStatus` / `TaskStatus` collision at the same top-level key — only stamps when `structuredContent.status` is missing. So `CreateMediaBuySuccess.status: 'active'` (valid `MediaBuyStatus`, not a valid `TaskStatus`) ships verbatim; the spec-level ambiguity is filed for adcontextprotocol/adcp separately.
- Error envelopes (`isError: true`) are skipped — their status semantics (`failed` / `rejected`) belong to the adcp_error path. Submitted envelopes keep their handler-set `status: 'submitted'`. Auto-registered `get_adcp_capabilities` continues to stamp via `capabilitiesResponse` directly (bypasses `finalize()`); both layers reinforce.

## Why the chokepoint instead of fixing each helper

19 of 21 `*Response` helpers had the gap, and the ~30 `wrap: null` tools in `TOOL_META` fell through to `genericResponse` with the same gap. Touching every helper would be near-mechanical churn and would still miss future helpers added without remembering the envelope. The `finalize()` chokepoint already runs `sanitizeAdcpErrorEnvelope` / `enrichErrorTwoLayer` / `injectContextIntoResponse` / `injectVersionIntoResponse` — envelope status belongs in the same row.

## Test plan

- [x] New: 4 targeted tests in `test/server-create-adcp-server.test.js` covering productsResponse path, getSignalsResponse path, genericResponse fallback (list_property_lists), and the MediaBuyStatus collision case (create_media_buy returning `status: 'active'` ships unchanged)
- [x] `NODE_ENV=test node --test test/server-create-adcp-server.test.js` — 97/97
- [x] `NODE_ENV=test node --test test/server-responses.test.js test/server-decisioning-from-platform.test.js test/server-idempotency.test.js` — 312/312
- [x] `NODE_ENV=test node --test test/lib/storyboard-validations.test.js test/lib/idempotency.test.js test/lib/capabilities-tools-drift.test.js test/lib/governance-e2e.test.js test/server-decisioning-capability-projections.test.js` — 96/96
- [x] `npm test` full suite: 9409/9417 pass; 5 unrelated failures (all `v1-canonical-mapping.json not found` in 3.1.0-beta schema cache — confirmed pre-existing on origin/main, not introduced by this change)
- [x] `npm run format:check` clean

## Follow-up

Spec-level question for adcontextprotocol/adcp: envelope-level `status` (TaskStatus) collides with payload-level `status` (MediaBuyStatus) at the same top-level key on `mediaBuyResponse` / `updateMediaBuyResponse` / `cancelMediaBuyResponse`. Either nest payload under `payload` (matches the normative envelope example in `protocol-envelope.json`) or rename the payload field. Tracking issue inbound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)