### PR TITLE
fix(types): handle OutcomeMeasurement rename (1/5 of #1902 sweep)

### DIFF
--- a/.changeset/outcome-measurement-rename.md
+++ b/.changeset/outcome-measurement-rename.md
@@ -1,0 +1,11 @@
+---
+'@adcp/sdk': major
+---
+
+fix(types): handle `OutcomeMeasurement` → `OutcomeMeasurementDeprecated` rename (AdCP 3.1.0-beta.2)
+
+3.1.0-beta.2 renamed the `OutcomeMeasurement` interface to `OutcomeMeasurementDeprecated` to signal the surface is on the 4.0 removal track. The rename broke the index.ts re-export and the compat.ts `Measurement` alias.
+
+**Adopter-facing:** purely additive. The original `OutcomeMeasurement` name continues to resolve (re-exported from `OutcomeMeasurementDeprecated`); adopters who imported the old name keep working unchanged. New code SHOULD import `OutcomeMeasurementDeprecated` to make the deprecation visible at the call site.
+
+Part of the #1902 8.0-beta sweep (closes one of the 5 structural breaks listed in the foundation PR).

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -545,7 +545,11 @@ export type {
   OptimizationGoal,
   ReachUnit,
   TargetingOverlay,
-  OutcomeMeasurement,
+  // 3.1.0-beta.2 renamed `OutcomeMeasurement` → `OutcomeMeasurementDeprecated`
+  // to signal the surface is on the 4.0 removal track. Re-export under both
+  // names so adopters' existing `import { OutcomeMeasurement }` keeps working.
+  OutcomeMeasurementDeprecated,
+  OutcomeMeasurementDeprecated as OutcomeMeasurement,
   Duration,
   DeviceType,
   DigitalSourceType,

--- a/src/lib/types/compat.ts
+++ b/src/lib/types/compat.ts
@@ -3,12 +3,23 @@
  */
 
 import type { BrandReference, Catalog } from './tools.generated';
-import type { OutcomeMeasurement } from './core.generated';
+import type { OutcomeMeasurementDeprecated } from './core.generated';
 
-// ===== Measurement → OutcomeMeasurement rename =====
+// ===== Measurement → OutcomeMeasurement rename (3.1.0-beta.2: OutcomeMeasurement renamed to OutcomeMeasurementDeprecated) =====
 
-/** @deprecated Use OutcomeMeasurement instead. */
-export type Measurement = OutcomeMeasurement;
+/**
+ * @deprecated Use `OutcomeMeasurementDeprecated` (renamed by AdCP 3.1.0-beta.2;
+ * the measurement surface itself is being phased out in favor of explicit
+ * post-buy reporting flows).
+ */
+export type Measurement = OutcomeMeasurementDeprecated;
+
+/**
+ * @deprecated AdCP 3.1.0-beta.2 renamed this type to `OutcomeMeasurementDeprecated`
+ * to signal that the measurement surface is on the 4.0 removal track. The alias
+ * is preserved so 7.x adopters' imports still resolve through the 8.0-beta cycle.
+ */
+export type OutcomeMeasurement = OutcomeMeasurementDeprecated;
 
 // ===== PromotedOfferings / PromotedProducts migration =====
 // promoted_offerings was replaced by a top-level brand field + per-package catalog field.


### PR DESCRIPTION
**Stacked on #1902** (the 8.0-beta foundation). First of five structural-break follow-ups.

AdCP 3.1.0-beta.2 renamed the \`OutcomeMeasurement\` interface to \`OutcomeMeasurementDeprecated\` to signal the surface is on the 4.0 removal track ([generated diff](https://github.com/adcontextprotocol/adcp/releases/tag/v3.1.0-beta.2)). Two compile errors in this codebase referenced the old name.

## Changes

**\`src/lib/types/compat.ts\`** — \`Measurement\` alias now points at \`OutcomeMeasurementDeprecated\`. Added \`OutcomeMeasurement\` alias for adopters' existing imports.

**\`src/lib/index.ts\`** — re-exports both \`OutcomeMeasurementDeprecated\` (new) and \`OutcomeMeasurement\` (alias) so existing \`import { OutcomeMeasurement }\` calls keep working.

## Adopter migration

Purely additive at the type surface. The original \`OutcomeMeasurement\` import keeps working through 8.0-beta. New code SHOULD import \`OutcomeMeasurementDeprecated\` to make the deprecation visible at the call site.

## Verification

- Local tsc: foundation had 17 errors, this PR drops it to 15 (the 2 OutcomeMeasurement errors are gone).
- prettier --check clean.
- Note: CI will still be red on the remaining 15 structural breaks until each gets its own follow-up PR. Same as #1902.

## Remaining structural breaks (separate PRs)

- Brand \`categories\` field (7 sites) — spec migration
- \`AssetVariant\` union (3 sites) — handle new union/array shape
- \`creative-asset.format_id/manifest\` (4 sites) — spec migration
- \`ControllerScenario\` exhaustiveness (1 site) — add new scenarios

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>