### PR TITLE
fix(v2/projection): ship aao-reference-formats.json in published bundle (#1909)

### DIFF
--- a/.changeset/fix-aao-catalog-not-shipped.md
+++ b/.changeset/fix-aao-catalog-not-shipped.md
@@ -1,0 +1,21 @@
+---
+'@adcp/sdk': patch
+---
+
+fix(v2/projection): vendor `aao-reference-formats.json` into the published bundle
+
+The v1↔v2 projection loader (`v2/projection/catalog.ts`, new in 7.10) requires
+the AAO canonical-formats catalog at runtime. The previous build resolved it
+from `test/lib/v2-projection-fixtures/aao-reference-formats.json` (not in the
+published `files` glob) and `.context/adcp-3307/...` (a dev-machine path),
+so any consumer that exercised `get_products`-class augmentation
+(`augmentProductWithFormatOptions` / `withFormatOptions`) crashed with
+`AAO catalog (reference-formats.json) not found`.
+
+The build now copies the fixture to `dist/lib/v2/projection/aao-reference-formats.json`
+via `scripts/copy-v2-projection-catalog.ts`, and the loader looks adjacent to
+its compiled location first. The source-tree `test/` path is retained as a
+dev fallback (tsx / vitest / source checkouts) but is not required for the
+published bundle to function.
+
+Reported as adcontextprotocol/adcp-client#1909.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/sdk",
-  "version": "7.9.0",
+  "version": "7.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/sdk",
-      "version": "7.9.0",
+      "version": "7.10.0",
       "license": "Apache-2.0",
       "workspaces": [
         ".",
@@ -7348,7 +7348,7 @@
       "version": "6.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adcp/sdk": "^7.9.0"
+        "@adcp/sdk": "^7.10.0"
       },
       "bin": {
         "adcp": "bin/adcp.js"

--- a/package.json
+++ b/package.json
@@ -245,7 +245,7 @@
     "sync:agents": "node scripts/import-claude-agents.mjs",
     "prepublishOnly": "npm run clean && npm run sync-schemas:all && (test -f src/lib/types/tools.generated.ts || npm run generate-types) && npm run build:lib && node --test-timeout=60000 --test-force-exit --test test/lib/adcp-client.test.js test/lib/validation.test.js test/lib/zod-schemas.test.js",
     "build": "npm run build:lib",
-    "build:lib": "npm run sync-version && npm run schemas:ensure && tsx scripts/generate-wire-spec-fields.ts && tsc --project tsconfig.lib.json && tsx scripts/copy-schemas-to-dist.ts",
+    "build:lib": "npm run sync-version && npm run schemas:ensure && tsx scripts/generate-wire-spec-fields.ts && tsc --project tsconfig.lib.json && tsx scripts/copy-schemas-to-dist.ts && tsx scripts/copy-v2-projection-catalog.ts",
     "build:test-agents": "npm run build:lib && tsc -p test-agents/tsconfig.json --rootDir test-agents",
     "pretest": "npm run schemas:ensure",
     "test": "NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/*.test.js test/lib/*.test.js && npm test --workspace=packages/eslint-plugin --if-present",

--- a/scripts/copy-v2-projection-catalog.ts
+++ b/scripts/copy-v2-projection-catalog.ts
@@ -1,0 +1,38 @@
+#!/usr/bin/env tsx
+/**
+ * Vendor the AAO canonical-formats catalog
+ * (`test/lib/v2-projection-fixtures/aao-reference-formats.json`) into
+ * `dist/lib/v2/projection/aao-reference-formats.json` so the v1↔v2
+ * projection loader can find it after `npm install`.
+ *
+ * The loader at `src/lib/v2/projection/catalog.ts` looks adjacent to its
+ * compiled location first; the source-tree `test/` path stays as a dev
+ * fallback (tests, tsx, vitest) but is not in the published `files`
+ * glob.
+ *
+ * Invoked by `build:lib` after `tsc` emits the loader.
+ */
+
+import { copyFileSync, existsSync, mkdirSync } from 'fs';
+import path from 'path';
+
+function main(): void {
+  const repoRoot = path.resolve(__dirname, '..');
+  const src = path.join(repoRoot, 'test', 'lib', 'v2-projection-fixtures', 'aao-reference-formats.json');
+  const destDir = path.join(repoRoot, 'dist', 'lib', 'v2', 'projection');
+  const dest = path.join(destDir, 'aao-reference-formats.json');
+
+  if (!existsSync(src)) {
+    throw new Error(
+      `[copy-v2-projection-catalog] source fixture missing: ${src}. ` +
+        `The published bundle requires this file — see ` +
+        `src/lib/v2/projection/catalog.ts loader resolution order.`
+    );
+  }
+
+  mkdirSync(destDir, { recursive: true });
+  copyFileSync(src, dest);
+  console.log(`[copy-v2-projection-catalog] copied ${src} → ${dest}`);
+}
+
+main();

--- a/src/lib/v2/projection/catalog.ts
+++ b/src/lib/v2/projection/catalog.ts
@@ -152,8 +152,11 @@ export function loadCatalog(explicitPath?: string): CatalogIndex {
   }
 
   throw new Error(
-    `AAO catalog (reference-formats.json) not found. Looked in: ${candidates.join(', ')}. ` +
-      `Vendor a copy at test/lib/v2-projection-fixtures/aao-reference-formats.json.`
+    `AAO catalog (aao-reference-formats.json) not found. Looked in: ${candidates.join(', ')}. ` +
+      `This indicates a corrupted @adcp/sdk install or an SDK packaging regression — ` +
+      `please file an issue at https://github.com/adcontextprotocol/adcp-client/issues with ` +
+      `your install method (npm/yarn/pnpm) and Node version. ` +
+      `If you're working from a source checkout, run \`npm run build:lib\` first.`
   );
 }
 

--- a/src/lib/v2/projection/catalog.ts
+++ b/src/lib/v2/projection/catalog.ts
@@ -100,10 +100,19 @@ function indexKey(agentUrl: string, id: string): string {
 }
 
 /**
- * Load the catalog from a known path. Tries the test-fixture location
- * (vendored copy) first, then the workspace `.context/adcp-3307/`
- * checkout if present. Memoized — catalog is small and immutable per
- * spec version.
+ * Load the catalog from a known path. Resolution order:
+ *
+ *   1. Caller-supplied `explicitPath` (test hook).
+ *   2. Adjacent to the compiled loader — `dist/lib/v2/projection/
+ *      aao-reference-formats.json`. This is the path that ships in the
+ *      published npm tarball; `scripts/copy-v2-projection-catalog.ts`
+ *      vendors the file here during `build:lib`.
+ *   3. Source-tree test fixture at
+ *      `test/lib/v2-projection-fixtures/aao-reference-formats.json`,
+ *      relative to the loader's source location. Used when running from
+ *      a source checkout (e.g., `tsx` / vitest) before `build:lib`.
+ *
+ * Memoized — catalog is small and immutable per spec version.
  *
  * @param explicitPath caller-supplied path; takes precedence over
  *                     fallback resolution.
@@ -114,6 +123,7 @@ export function loadCatalog(explicitPath?: string): CatalogIndex {
   const candidates = explicitPath
     ? [explicitPath]
     : [
+        path.join(__dirname, 'aao-reference-formats.json'),
         path.join(
           __dirname,
           '..',
@@ -124,19 +134,6 @@ export function loadCatalog(explicitPath?: string): CatalogIndex {
           'lib',
           'v2-projection-fixtures',
           'aao-reference-formats.json'
-        ),
-        path.join(
-          __dirname,
-          '..',
-          '..',
-          '..',
-          '..',
-          '.context',
-          'adcp-3307',
-          'server',
-          'src',
-          'creative-agent',
-          'reference-formats.json'
         ),
       ];
 

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP SDK library version
  */
-export const LIBRARY_VERSION = '7.9.0';
+export const LIBRARY_VERSION = '7.10.0';
 
 /**
  * AdCP specification version this library is built for
@@ -62,10 +62,10 @@ export type AdcpVersion = (typeof COMPATIBLE_ADCP_VERSIONS)[number];
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '7.9.0',
+  library: '7.10.0',
   adcp: '3.0.12',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-05-21T11:54:25.006Z',
+  generatedAt: '2026-05-21T16:04:43.348Z',
 } as const;
 
 /**


### PR DESCRIPTION
## Summary

Fixes adcontextprotocol/adcp-client#1909 — `@adcp/sdk@7.10.0` ships the v1↔v2 projection loader but not its catalog fixture. Any consumer that hits `get_products`-class augmentation crashes with:

```
AAO catalog (reference-formats.json) not found.
```

This PR vendors the catalog file alongside the compiled loader so it ships in the published tarball.

## Changes

- **`scripts/copy-v2-projection-catalog.ts`** (new) — copies `test/lib/v2-projection-fixtures/aao-reference-formats.json` to `dist/lib/v2/projection/aao-reference-formats.json` during `build:lib`. Fails loudly if the source fixture goes missing (committed source — different from `copy-schemas-to-dist.ts`'s warn-skip, whose input is network-fetched by `sync-schemas`).
- **`src/lib/v2/projection/catalog.ts`** — loader looks adjacent to its compiled location first (the published location). Source-tree `test/` path retained as a dev fallback for `tsx` / `vitest`. Removed the stale `.context/adcp-3307/` dev-machine fallback. Error message rewritten post-fix to point adopters at the issue tracker (file-a-bug) rather than asking them to vendor a copy themselves.
- **`package.json`** — wires the new script into `build:lib`.
- **`package-lock.json` / `src/lib/version.ts`** — caught up to 7.10.0 (auto-synced by `sync-version` on first `build:lib`; these were stale on `main`).
- **Changeset** — `patch`.

## Verification

```
npm run build:lib
# → [copy-v2-projection-catalog] copied .../test/lib/v2-projection-fixtures/aao-reference-formats.json
#                                 → .../dist/lib/v2/projection/aao-reference-formats.json

npm pack --dry-run | grep aao-reference
# npm notice 145.0kB dist/lib/v2/projection/aao-reference-formats.json

node -e "
const { _resetCatalogCache, loadCatalog, lookupV1Format } = require('./dist/lib/v2/projection/catalog');
_resetCatalogCache();
console.log('entries:', loadCatalog().entries.length);
console.log('display_image:', lookupV1Format({ agent_url: 'https://creative.adcontextprotocol.org/', id: 'display_image' }).canonical.kind);
"
# entries: 50
# display_image: image
```

## Test plan

- [x] `npm run build:lib` — vendored file lands in `dist/lib/v2/projection/aao-reference-formats.json`
- [x] `npm pack --dry-run` — fixture is in the tarball under `dist/lib/v2/projection/`
- [x] `npm run typecheck` — clean
- [x] `npm run format:check` — clean
- [x] `node --test test/lib/v2-to-v1-projection.test.js` — passes
- [x] `node --test test/lib/v2-publisher-catalog.test.js` — 12/12 pass
- [x] `node --test test/lib/adcp-client.test.js test/lib/validation.test.js test/lib/zod-schemas.test.js` — 77/77 pass (the prepublish smoke suite)
- [x] Runtime smoke: loader resolves catalog from the vendored path with cache reset

## Reviewed

Independent reviews by `code-reviewer` and `dx-expert` subagents — both converged on ship-with-action-items. Net additions from review (commit `dfe651f4`): error message rewritten so the not-found branch points adopters at the issue tracker rather than asking them to vendor a copy themselves.

## Forward-port note

`main` is currently the 7.x line at 7.10.0; no separate 8.x branch exists, so this lands on `main` directly. If 8.x is cut later before this merges, the same patch applies cleanly.

## Follow-up filed: #1911

`src/lib/v2/projection/registry.ts` and `src/lib/v2/projection/canonical-properties.ts` have the **same** packaging bug shape — they read from `__dirname/../../../../schemas/cache/<beta>/...` (source layout) instead of the vendored `dist/lib/schemas-data/<key>/...` produced by `copy-schemas-to-dist.ts`. The #1909 storyboards didn't trip them because AAO format_ids resolve at Step 1 (catalog), before Steps 2/3 (registry / canonical-properties). Non-AAO format_ids and `v1_translatable` checks for the 4 inherently-v2 canonicals at 3.1 GA will hit the second crash.

Tracked in adcontextprotocol/adcp-client#1911 — filed before merge so the same adopter doesn't get burned twice. Includes a proposal for a packaging smoke test (`npm pack` → fresh sandbox → `require()` each loader) that would catch this entire class of bug going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)