### PR TITLE
fix(v2/projection): look in dist/lib/schemas-data for registry and canonical schemas

### DIFF
--- a/.changeset/registry-path-fix-dist.md
+++ b/.changeset/registry-path-fix-dist.md
@@ -1,0 +1,11 @@
+---
+"@adcp/sdk": patch
+---
+
+fix(v2/projection): resolve v1-canonical-mapping.json and 3.1+ schema cache from dist/lib/schemas-data in published npm tarball
+
+`registry.ts` and `canonical-properties.ts` looked for their data files at `../../../../schemas/cache/<version>/` (relative to the compiled loader), which resolves to the package root's `schemas/cache/` directory — a path that does not exist in the published npm tarball. The files are actually shipped at `dist/lib/schemas-data/<version>/`.
+
+Both loaders now check `../../schemas-data/<version>/` first (the npm-tarball path), then fall back to `../../../../schemas/cache/<version>/` for source-checkout development workflows where schemas are synced locally. Mirrors the two-candidate resolution pattern already in `catalog.ts` after #1909.
+
+Fixes storyboard crashes on `get_products` for v3.1-beta projection paths: `v1-canonical-mapping.json not found`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/sdk",
-  "version": "7.10.0",
+  "version": "7.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/sdk",
-      "version": "7.10.0",
+      "version": "7.10.1",
       "license": "Apache-2.0",
       "workspaces": [
         ".",
@@ -7348,7 +7348,7 @@
       "version": "6.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adcp/sdk": "^7.10.0"
+        "@adcp/sdk": "^7.10.1"
       },
       "bin": {
         "adcp": "bin/adcp.js"

--- a/src/lib/v2/projection/canonical-properties.ts
+++ b/src/lib/v2/projection/canonical-properties.ts
@@ -44,7 +44,10 @@ function findCacheRoot(): string {
   // points at a cache that lacks canonical-format schemas — the loader
   // would silently return `true` for every v1_translatable check and miss
   // the 4 inherently-v2 canonicals.
-  const candidates = BETA_VERSIONS_TO_TRY.map(v => path.join(__dirname, '..', '..', '..', '..', 'schemas', 'cache', v));
+  const candidates = BETA_VERSIONS_TO_TRY.flatMap(v => [
+    path.join(__dirname, '..', '..', 'schemas-data', v),
+    path.join(__dirname, '..', '..', '..', '..', 'schemas', 'cache', v),
+  ]);
   for (const c of candidates) {
     if (existsSync(c)) return c;
   }

--- a/src/lib/v2/projection/registry.ts
+++ b/src/lib/v2/projection/registry.ts
@@ -69,9 +69,10 @@ export function loadRegistry(cacheRoot?: string): CanonicalMappingRegistry {
   if (cached) return cached;
   const candidates = cacheRoot
     ? [path.join(cacheRoot, 'registries', 'v1-canonical-mapping.json')]
-    : BETA_VERSIONS_TO_TRY.map(v =>
-        path.join(__dirname, '..', '..', '..', '..', 'schemas', 'cache', v, 'registries', 'v1-canonical-mapping.json')
-      );
+    : BETA_VERSIONS_TO_TRY.flatMap(v => [
+        path.join(__dirname, '..', '..', 'schemas-data', v, 'registries', 'v1-canonical-mapping.json'),
+        path.join(__dirname, '..', '..', '..', '..', 'schemas', 'cache', v, 'registries', 'v1-canonical-mapping.json'),
+      ]);
   for (const file of candidates) {
     if (existsSync(file)) {
       cached = JSON.parse(readFileSync(file, 'utf-8')) as CanonicalMappingRegistry;

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP SDK library version
  */
-export const LIBRARY_VERSION = '7.10.0';
+export const LIBRARY_VERSION = '7.10.1';
 
 /**
  * AdCP specification version this library is built for
@@ -62,10 +62,10 @@ export type AdcpVersion = (typeof COMPATIBLE_ADCP_VERSIONS)[number];
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '7.10.0',
+  library: '7.10.1',
   adcp: '3.0.12',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-05-21T16:04:43.348Z',
+  generatedAt: '2026-05-21T16:48:53.409Z',
 } as const;
 
 /**

--- a/test/lib/v1-to-v2-projection.test.js
+++ b/test/lib/v1-to-v2-projection.test.js
@@ -21,7 +21,7 @@ const CATALOG_PATH = path.join(FIXTURE_DIR, 'aao-reference-formats.json');
 // registry loader (`src/lib/v2/projection/registry.ts`) reads from
 // whichever exists.
 const SCHEMAS_CACHE_ROOT = path.join(__dirname, '..', '..', 'schemas', 'cache');
-const REGISTRY_EXISTS = ['3.1.0-beta.1', '3.1.0-beta.0', 'latest'].some(v =>
+const REGISTRY_EXISTS = ['3.1.0-beta.2', '3.1.0-beta.1', '3.1.0-beta.0', 'latest'].some(v =>
   existsSync(path.join(SCHEMAS_CACHE_ROOT, v, 'registries', 'v1-canonical-mapping.json'))
 );
 

--- a/test/lib/v2-to-v1-projection.test.js
+++ b/test/lib/v2-to-v1-projection.test.js
@@ -27,7 +27,7 @@ const FIXTURE_DIR = path.join(__dirname, 'v2-projection-fixtures');
 // `npm run sync-schemas:3.1-beta`; the loader (registry.ts) tracks
 // whichever 3.1 beta the workspace has.
 const SCHEMAS_CACHE_ROOT = path.join(__dirname, '..', '..', 'schemas', 'cache');
-const REGISTRY_EXISTS = ['3.1.0-beta.1', '3.1.0-beta.0', 'latest'].some(v =>
+const REGISTRY_EXISTS = ['3.1.0-beta.2', '3.1.0-beta.1', '3.1.0-beta.0', 'latest'].some(v =>
   existsSync(path.join(SCHEMAS_CACHE_ROOT, v, 'registries', 'v1-canonical-mapping.json'))
 );
 const SKIP_REASON = REGISTRY_EXISTS


### PR DESCRIPTION
Closes #1917

## Summary

`registry.ts` and `canonical-properties.ts` resolved data-file paths as `../../../../schemas/cache/<v>/` from `__dirname`. When compiled to `dist/lib/v2/projection/`, going four levels up reaches the package root — but `schemas/cache/` does not exist in the published npm tarball. The files are shipped at `dist/lib/schemas-data/<version>/`, placed there by `scripts/copy-schemas-to-dist.ts` during `build:lib`.

Both loaders now check `../../schemas-data/<version>/` first (the dist-tarball path), then fall back to `../../../../schemas/cache/<version>/` for source-checkout dev workflows where schemas are synced locally. The existing `cacheRoot` explicit override path in `loadRegistry()` is unchanged.

Also fixes the test skip-guards in `v2-to-v1-projection.test.js` and `v1-to-v2-projection.test.js`: both probed `['3.1.0-beta.1', ...]` while `BETA_VERSIONS_TO_TRY` leads with `3.1.0-beta.2` — a workspace with only `3.1.0-beta.2` synced would have falsely skipped those test suites.

## What was tested

- `npm run format:check` — clean
- `npm run typecheck` (`tsc --noEmit`) — pre-existing env errors (`@types/node` missing, `moduleResolution=node10` deprecated), confirmed identical on `main` baseline, unrelated to this change
- `npm run build:lib` — succeeds; compiled dist reflects new candidate paths
- `node --test test/lib/v2-to-v1-projection.test.js test/lib/v1-to-v2-projection.test.js test/lib/v2-write-side.test.js test/lib/adcp-client.test.js` — 40/40 pass (schema-dependent suites skip as expected without a local 3.1+ schema sync)
- `node --test test/lib/adcp-client.test.js test/lib/validation.test.js test/lib/zod-schemas.test.js` — 77/77 pass

**Pre-PR review:**
- code-reviewer: approved — no blockers; nit on `schemas-data/latest/` being a harmless dead candidate (existsSync handles it cleanly); blocker on test skip-guard fixed in second commit
- ad-tech-protocol-expert: approved — non-breaking per spec wire contract; `cacheRoot` override path preserved; nit on PR description overstating similarity to #1909 (catalog fix uses adjacent-file vendoring, not flatMap; no code consequence)

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01FBDJH85WkmfneojWjkgdev

---
_Generated by [Claude Code](https://claude.ai/code/session_01FBDJH85WkmfneojWjkgdev)_