### PR TITLE
fix(v2/projection): ship registry + canonical loaders that work in published tarballs

### DIFF
--- a/.changeset/fix-projection-registry-loader-paths.md
+++ b/.changeset/fix-projection-registry-loader-paths.md
@@ -1,0 +1,11 @@
+---
+'@adcp/sdk': patch
+---
+
+fix(v2/projection): resolve v1-canonical-mapping.json and canonical schemas from `dist/lib/schemas-data/` in published tarballs
+
+The v1↔v2 projection loaders (`registry.ts`, `canonical-properties.ts`) walked `schemas/cache/<version>/registries/` and `schemas/cache/<version>/formats/canonical/` relative to their source location — paths that exist in the SDK author's worktree but NOT in the published npm tarball (the `files` glob ships `dist/lib/schemas-data/<version>/...` per `scripts/copy-schemas-to-dist.ts`). Same shape of bug as the AAO catalog regression fixed in 7.10.1; this is the sibling.
+
+After `npm install @adcp/sdk@7.10.1` and exercising `get_products`-class augmentation on a 3.1.0-beta.2-aware product, both loaders threw at first call — manifested in compliance matrices as cascading failures off the first product-discovery step (45/280 on `/sales` vs the 74/380 floor regardless of which fixture was missing, because the failure cascades the same way).
+
+Both loaders now try the published-tarball path (`dist/lib/schemas-data/<version>/...`) first and fall through to the source-tree path (`schemas/cache/<version>/...`) only when running from a checkout pre-`build:lib`. Error messages updated to point at the issue tracker rather than asking adopters to vendor the SDK's packaging gap themselves.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/sdk",
-  "version": "7.10.0",
+  "version": "7.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/sdk",
-      "version": "7.10.0",
+      "version": "7.10.1",
       "license": "Apache-2.0",
       "workspaces": [
         ".",
@@ -7348,7 +7348,7 @@
       "version": "6.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adcp/sdk": "^7.10.0"
+        "@adcp/sdk": "^7.10.1"
       },
       "bin": {
         "adcp": "bin/adcp.js"

--- a/src/lib/v2/projection/canonical-properties.ts
+++ b/src/lib/v2/projection/canonical-properties.ts
@@ -1,8 +1,10 @@
 /**
  * Read structural properties off the canonical format schemas at
- * `schemas/cache/<version>/formats/canonical/<kind>.json`. The
- * projection layer needs `v1_translatable` per canonical to honor the
- * normative rule from `v1-canonical-mapping.json`:
+ * `dist/lib/schemas-data/<version>/formats/canonical/<kind>.json` in
+ * published tarballs, or `schemas/cache/<version>/formats/canonical/...`
+ * in a source checkout. The projection layer needs `v1_translatable`
+ * per canonical to honor the normative rule from
+ * `v1-canonical-mapping.json`:
  *
  *   > SDKs encountering `v1_translatable: false` on a canonical SHOULD
  *   > NOT emit `FORMAT_PROJECTION_FAILED` (which signals registry-
@@ -39,18 +41,33 @@ function loadCanonicalSchema(kind: CanonicalFormatKind, cacheRoot: string): Cano
 }
 
 function findCacheRoot(): string {
-  // Track whichever 3.1+ cache the workspace has synced. `latest` is the
-  // last-resort candidate because in workspaces pinned to a 3.0.x GA it
-  // points at a cache that lacks canonical-format schemas — the loader
-  // would silently return `true` for every v1_translatable check and miss
-  // the 4 inherently-v2 canonicals.
-  const candidates = BETA_VERSIONS_TO_TRY.map(v => path.join(__dirname, '..', '..', '..', '..', 'schemas', 'cache', v));
+  // Resolution order:
+  //   1. Published-tarball path adjacent to the compiled loader —
+  //      `dist/lib/schemas-data/<version>/`. Populated by
+  //      `scripts/copy-schemas-to-dist.ts` during `build:lib`.
+  //   2. Source-tree path `schemas/cache/<version>/` relative to the
+  //      loader's source location. Used when running from a source
+  //      checkout (e.g. `tsx`, vitest) before `build:lib`.
+  //
+  // Within both, versions are tried in `BETA_VERSIONS_TO_TRY` order:
+  // current beta wins; older betas survive for adopters who haven't
+  // synced; `latest` is last-resort and skipped in dist (the symlink
+  // is intentionally not copied — adopters pinned to 3.0.x GA hit the
+  // throw below rather than silently picking up a v3.0 cache that
+  // lacks canonical-format schemas).
+  const candidates = [
+    ...BETA_VERSIONS_TO_TRY.map(v => path.join(__dirname, '..', '..', 'schemas-data', v)),
+    ...BETA_VERSIONS_TO_TRY.map(v => path.join(__dirname, '..', '..', '..', '..', 'schemas', 'cache', v)),
+  ];
   for (const c of candidates) {
     if (existsSync(c)) return c;
   }
   throw new Error(
-    `No 3.1+ schema cache found. Run \`npm run sync-schemas\` for a 3.1+ AdCP version. ` +
-      `Looked in: ${candidates.join(', ')}.`
+    `No 3.1+ schema cache found. Looked in: ${candidates.join(', ')}. ` +
+      `This indicates a corrupted @adcp/sdk install or an SDK packaging regression — ` +
+      `please file an issue at https://github.com/adcontextprotocol/adcp-client/issues with ` +
+      `your install method (npm/yarn/pnpm) and Node version. ` +
+      `If you're working from a source checkout, run \`npm run sync-schemas:3.1-beta\` then \`npm run build:lib\`.`
   );
 }
 

--- a/src/lib/v2/projection/registry.ts
+++ b/src/lib/v2/projection/registry.ts
@@ -1,6 +1,8 @@
 /**
  * Loader + reverse-lookup for the v1↔v2 canonical-format registry
- * (`schemas/cache/<version>/registries/v1-canonical-mapping.json`).
+ * (`dist/lib/schemas-data/<version>/registries/v1-canonical-mapping.json`
+ * in published tarballs; `schemas/cache/<version>/registries/...` in a
+ * source checkout).
  *
  * The spec authors the registry **forward** — given a v1 named format,
  * find the v2 canonical. v2 → v1 projection needs the inverse direction,
@@ -57,11 +59,19 @@ interface CanonicalMappingRegistry {
 let cached: CanonicalMappingRegistry | null = null;
 
 /**
- * Load the registry from a known schema-cache version. Tries `3.1.0-beta.2`
- * first (current beta), then `3.1.0-beta.1`, then `3.1.0-beta.0`, then the
- * `latest` symlink — whichever ships `registries/v1-canonical-mapping.json`
- * is the source of truth. The pin floats deliberately so the registry tracks
- * whichever 3.1+ cache the workspace has synced.
+ * Load the registry from a known schema-cache version. Resolution order:
+ *
+ *   1. Caller-supplied `cacheRoot` (test hook / explicit pin).
+ *   2. Published-tarball path adjacent to the compiled loader —
+ *      `dist/lib/schemas-data/<version>/registries/v1-canonical-mapping.json`.
+ *      Populated by `scripts/copy-schemas-to-dist.ts` during `build:lib`.
+ *   3. Source-tree path `schemas/cache/<version>/registries/...` relative
+ *      to the loader's source location. Used when running from a source
+ *      checkout (e.g. `tsx`, vitest) before `build:lib`.
+ *
+ * Within (2) and (3), versions are tried in `BETA_VERSIONS_TO_TRY` order
+ * — current beta wins; older betas survive for adopters who haven't
+ * synced; `latest` is last-resort.
  *
  * Memoized — the registry is small and immutable per version.
  */
@@ -69,9 +79,14 @@ export function loadRegistry(cacheRoot?: string): CanonicalMappingRegistry {
   if (cached) return cached;
   const candidates = cacheRoot
     ? [path.join(cacheRoot, 'registries', 'v1-canonical-mapping.json')]
-    : BETA_VERSIONS_TO_TRY.map(v =>
-        path.join(__dirname, '..', '..', '..', '..', 'schemas', 'cache', v, 'registries', 'v1-canonical-mapping.json')
-      );
+    : [
+        ...BETA_VERSIONS_TO_TRY.map(v =>
+          path.join(__dirname, '..', '..', 'schemas-data', v, 'registries', 'v1-canonical-mapping.json')
+        ),
+        ...BETA_VERSIONS_TO_TRY.map(v =>
+          path.join(__dirname, '..', '..', '..', '..', 'schemas', 'cache', v, 'registries', 'v1-canonical-mapping.json')
+        ),
+      ];
   for (const file of candidates) {
     if (existsSync(file)) {
       cached = JSON.parse(readFileSync(file, 'utf-8')) as CanonicalMappingRegistry;
@@ -80,7 +95,10 @@ export function loadRegistry(cacheRoot?: string): CanonicalMappingRegistry {
   }
   throw new Error(
     `v1-canonical-mapping.json not found. Looked in: ${candidates.join(', ')}. ` +
-      `Run \`npm run sync-schemas\` for a 3.1+ AdCP version.`
+      `This indicates a corrupted @adcp/sdk install or an SDK packaging regression — ` +
+      `please file an issue at https://github.com/adcontextprotocol/adcp-client/issues with ` +
+      `your install method (npm/yarn/pnpm) and Node version. ` +
+      `If you're working from a source checkout, run \`npm run sync-schemas:3.1-beta\` then \`npm run build:lib\`.`
   );
 }
 

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP SDK library version
  */
-export const LIBRARY_VERSION = '7.10.0';
+export const LIBRARY_VERSION = '7.10.1';
 
 /**
  * AdCP specification version this library is built for
@@ -62,10 +62,10 @@ export type AdcpVersion = (typeof COMPATIBLE_ADCP_VERSIONS)[number];
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '7.10.0',
+  library: '7.10.1',
   adcp: '3.0.12',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-05-21T16:04:43.348Z',
+  generatedAt: '2026-05-21T16:56:59.187Z',
 } as const;
 
 /**

--- a/test/lib/v2-projection-loader-paths.test.js
+++ b/test/lib/v2-projection-loader-paths.test.js
@@ -1,0 +1,106 @@
+// Regression test for adcp-client#1909-sibling: the v1↔v2 projection
+// loaders (`registry.ts`, `canonical-properties.ts`) must resolve their
+// JSON sources via the published-tarball path
+// `dist/lib/schemas-data/<version>/...` and NOT depend on the source-tree
+// `schemas/cache/<version>/...` directory.
+//
+// The original 7.10.0 loaders only knew the source-tree path. After `npm
+// install`, the tarball ships `dist/lib/schemas-data/<version>/...` (per
+// `scripts/copy-schemas-to-dist.ts`) but no `schemas/cache/`. The loaders
+// would throw at first call — manifested as cascading product-discovery
+// failures in compliance matrices.
+//
+// 7.10.1 fixed the sibling catalog loader the same way. This test fakes a
+// published-tarball layout (only the dist files exist; no schemas/cache)
+// in a temp directory and confirms both registry + canonical-properties
+// loaders resolve without falling back to source-tree paths.
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const SRC_DIST = path.join(REPO_ROOT, 'dist');
+const SRC_SCHEMAS_DATA = path.join(SRC_DIST, 'lib', 'schemas-data');
+
+let tmpRoot;
+
+before(() => {
+  if (!fs.existsSync(path.join(SRC_DIST, 'lib', 'v2', 'projection', 'registry.js'))) {
+    throw new Error('Test setup expects dist/ to be built. Run `npm run build:lib` first.');
+  }
+  if (!fs.existsSync(path.join(SRC_SCHEMAS_DATA, '3.1.0-beta.2', 'registries', 'v1-canonical-mapping.json'))) {
+    throw new Error(
+      'Test setup expects dist/lib/schemas-data/3.1.0-beta.2/registries/v1-canonical-mapping.json. ' +
+        'Run `npm run sync-schemas:3.1-beta && npm run build:lib` first.'
+    );
+  }
+
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'adcp-projection-loader-paths-'));
+  // Mimic node_modules/@adcp/sdk/dist by copying only the dist tree.
+  // Intentionally do NOT copy schemas/cache — that's the bug we're guarding.
+  fs.cpSync(SRC_DIST, path.join(tmpRoot, 'dist'), { recursive: true });
+});
+
+after(() => {
+  if (tmpRoot && fs.existsSync(tmpRoot)) {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});
+
+/**
+ * Run a snippet in a child process whose CWD is the fake-install temp dir.
+ * Requires the compiled loader from the temp dir, so __dirname inside the
+ * loader resolves under tmpRoot — exactly the situation a consumer hits
+ * after `npm install @adcp/sdk` (no source-tree fallback available).
+ */
+function runInFakeInstall(snippet) {
+  const result = spawnSync(process.execPath, ['-e', snippet], {
+    cwd: tmpRoot,
+    encoding: 'utf-8',
+  });
+  return { code: result.status, stdout: result.stdout, stderr: result.stderr };
+}
+
+describe('v1↔v2 projection loaders resolve from published-tarball paths', () => {
+  test('registry.ts loadRegistry() finds v1-canonical-mapping.json in dist/lib/schemas-data', () => {
+    const registryPath = path.join(tmpRoot, 'dist', 'lib', 'v2', 'projection', 'registry.js').replace(/\\/g, '/');
+    const { code, stdout, stderr } = runInFakeInstall(
+      `const { loadRegistry } = require(${JSON.stringify(registryPath)});` +
+        `const reg = loadRegistry();` +
+        `console.log(JSON.stringify({ ok: true, mappings: reg.mappings.length }));`
+    );
+    assert.strictEqual(code, 0, `loadRegistry threw under fake install:\nstdout:${stdout}\nstderr:${stderr}`);
+    const parsed = JSON.parse(stdout.trim());
+    assert.strictEqual(parsed.ok, true);
+    assert.ok(parsed.mappings > 0, `expected non-empty mappings, got ${parsed.mappings}`);
+  });
+
+  test('canonical-properties.ts isCanonicalV1Translatable() finds canonical schemas in dist/lib/schemas-data', () => {
+    const cpPath = path.join(tmpRoot, 'dist', 'lib', 'v2', 'projection', 'canonical-properties.js').replace(/\\/g, '/');
+    const { code, stdout, stderr } = runInFakeInstall(
+      `const { isCanonicalV1Translatable } = require(${JSON.stringify(cpPath)});` +
+        // image_carousel is one of the 4 inherently-v2 canonicals
+        `const carousel = isCanonicalV1Translatable('image_carousel');` +
+        `const image = isCanonicalV1Translatable('image');` +
+        `console.log(JSON.stringify({ carousel, image }));`
+    );
+    assert.strictEqual(
+      code,
+      0,
+      `isCanonicalV1Translatable threw under fake install:\nstdout:${stdout}\nstderr:${stderr}`
+    );
+    const parsed = JSON.parse(stdout.trim());
+    assert.strictEqual(parsed.carousel, false, 'image_carousel must report v1_translatable: false');
+    assert.strictEqual(parsed.image, true, 'image must report v1_translatable: true (base default)');
+  });
+
+  test('loaders do NOT depend on schemas/cache/ in the fake-install tree', () => {
+    // Sanity assertion — if this directory ever appears under tmpRoot the
+    // test isn't actually exercising the published-tarball path.
+    assert.ok(!fs.existsSync(path.join(tmpRoot, 'schemas')), 'fake install must not contain schemas/');
+  });
+});


### PR DESCRIPTION
## Summary

- Sibling of #1909 / #1910. 7.10.1 fixed the AAO catalog loader's packaging miss; the v1↔v2 **registry** loader (`registry.ts`) and **canonical-properties** loader (`canonical-properties.ts`) had the same shape of bug and got missed.
- Both walked `__dirname/../../../../schemas/cache/<ver>/...` — exists in the source tree, not in the npm tarball (which ships `dist/lib/schemas-data/<ver>/...` per `scripts/copy-schemas-to-dist.ts`).
- After `npm install`, both threw at first call. Manifested in compliance matrices as identical 45/280 numbers on `/sales` regardless of which fixture was missing because the failure cascades off the first product-discovery step.

## Fix

Both loaders now try the published-tarball path first and fall back to the source-tree path for dev / tsx / vitest. Same pattern as `catalog.ts` in PR #1910. Error messages redirect to the issue tracker rather than telling adopters to vendor the SDK's packaging gap themselves.

## Test plan

- [x] `node --test test/lib/v2-projection-loader-paths.test.js` — new regression that fakes a `node_modules/@adcp/sdk/dist` layout with no `schemas/cache/` and proves both loaders resolve. Verified by reverting each loader independently: test fails under the buggy code, passes under the fix.
- [x] `npm run compliance:fork-matrix` — 27/27 pass (9 hello-adapter examples × tsc + storyboard + façade-gate + auth-gate).
- [x] `node --test test/lib/v1-v2-roundtrip-matrix.test.js test/lib/v1-to-v2-projection.test.js test/lib/v2-to-v1-projection.test.js test/lib/v2-publisher-catalog.test.js` — all pass.
- [x] Changeset attached (patch bump).
- [x] `prettier --check` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)