### PR TITLE
fix: read canonical media buy status in invariants

### DIFF
--- a/.changeset/canonical-media-buy-status.md
+++ b/.changeset/canonical-media-buy-status.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+fix(testing): read `media_buy_status` before legacy `status` when storyboard invariants extract media-buy lifecycle observations.

--- a/src/lib/testing/storyboard/default-invariants.ts
+++ b/src/lib/testing/storyboard/default-invariants.ts
@@ -743,7 +743,13 @@ function extractStatusObservations(task: string, body: Record<string, unknown>):
 
 function pushMediaBuy(obs: StatusObservation[], record: Record<string, unknown>): void {
   const id = asString(record.media_buy_id);
-  const status = asString(record.status);
+  // 3.1+: `media_buy_status` (body) carries MediaBuyStatus; top-level
+  // `status` (envelope) carries TaskStatus. Pre-3.1 + nested fields on
+  // `get_media_buys` / `get_media_buy_delivery`: `status` still carries
+  // MediaBuyStatus. Read the canonical 3.1 field first, fall back to
+  // legacy. Refs adcontextprotocol/adcp#4895 (3.1 additive-deprecate),
+  // #4906 (3.2 legacy removal), #4905 (4.0 nested cascade).
+  const status = asString(record.media_buy_status) ?? asString(record.status);
   if (id && status) {
     obs.push({
       resource_type: 'media_buy',

--- a/test/lib/storyboard-default-invariants.test.js
+++ b/test/lib/storyboard-default-invariants.test.js
@@ -979,6 +979,47 @@ describe('default-invariants: status.monotonic', () => {
     assert.ok(out.every(r => r.output.every(o => o.passed)));
   });
 
+  test('reads media_buy_status (3.1 canonical) on create_media_buy responses', () => {
+    const ctx = makeCtx();
+    spec.onStart(ctx);
+    spec.onStep(
+      ctx,
+      step({
+        step_id: 'create',
+        task: 'create_media_buy',
+        response: {
+          status: 'completed',
+          media_buy_id: 'mb-test',
+          media_buy_status: 'pending_creatives',
+          packages: [],
+        },
+      })
+    );
+
+    assert.deepStrictEqual(ctx.state.history.get('media_buy:mb-test'), {
+      stepId: 'create',
+      status: 'pending_creatives',
+    });
+  });
+
+  test('falls back to legacy media_buy status when media_buy_status is absent', () => {
+    const ctx = makeCtx();
+    spec.onStart(ctx);
+    spec.onStep(
+      ctx,
+      step({
+        step_id: 'create',
+        task: 'create_media_buy',
+        response: { media_buy_id: 'mb-test', status: 'active', packages: [] },
+      })
+    );
+
+    assert.deepStrictEqual(ctx.state.history.get('media_buy:mb-test'), {
+      stepId: 'create',
+      status: 'active',
+    });
+  });
+
   test('media_buy backward transition fails with actionable error (legal targets + enum URL)', () => {
     const out = run([
       step({ step_id: 'create', task: 'create_media_buy', response: mb('mb-1', 'active') }),


### PR DESCRIPTION
## Summary

- Read canonical `media_buy_status` before legacy `status` when extracting media-buy lifecycle observations.
- Preserve fallback behavior for pre-3.1 sellers and nested legacy response shapes.
- Add regression coverage for canonical 3.1 create-media-buy responses and legacy fallback.

## Root Cause

AdCP 3.1 separates the task envelope `status` from the media-buy lifecycle status. The default storyboard invariant was still reading `status` as the lifecycle field, so a `create_media_buy` response with `status: "completed"` and `media_buy_status: "pending_creatives"` could record the task status as a media-buy status.

## Validation

- `npm run build:lib`
- `NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/lib/storyboard-default-invariants.test.js`
- pre-push hook: `npm run typecheck`, library build
