### PR TITLE
feat: add legacy webhook HMAC verifier

### DIFF
--- a/.changeset/webhook-hmac-helper.md
+++ b/.changeset/webhook-hmac-helper.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': minor
+---
+
+Add `@adcp/sdk/webhooks` with `verifyWebhookRequest`, a standalone verifier for legacy HMAC-SHA256 webhook deliveries. The helper verifies exact raw body bytes, normalizes `x-adcp-*` header casing, enforces timestamp skew, uses constant-time comparison, and returns structured failure reasons for receiver endpoints that need diagnostic responses.

--- a/docs/guides/PUSH-NOTIFICATION-CONFIG.md
+++ b/docs/guides/PUSH-NOTIFICATION-CONFIG.md
@@ -96,16 +96,38 @@ All async operations produce the same `push_notification_config` shape on the wi
 
 ## Authentication
 
-The client always uses `HMAC-SHA256`. The agent signs webhook payloads with the shared secret so you can verify delivery on receipt.
+When `webhookSecret` is configured, the legacy webhook authentication path uses `HMAC-SHA256`. The agent signs `${timestamp}.${raw_body_bytes}` with the shared secret and sends:
+
+- `x-adcp-signature: sha256=<hex digest>`
+- `x-adcp-timestamp: <unix seconds>`
+
+Capture the raw request body before JSON parsing and verify it with the SDK helper:
 
 ```typescript
-import { createHmac } from 'crypto';
+import { verifyWebhookRequest } from '@adcp/sdk/webhooks';
 
-function verifyWebhook(payload: string, signature: string, secret: string): boolean {
-  const expected = createHmac('sha256', secret).update(payload).digest('hex');
-  return expected === signature;
-}
+app.post('/adcp/webhook/:task_type/:agent_id/:operation_id', async (req, res) => {
+  const check = verifyWebhookRequest({
+    rawBody: req.rawBody,
+    headers: req.headers,
+    globalSecret: process.env.WEBHOOK_SECRET,
+  });
+
+  if (!check.ok) {
+    return res.status(401).json({ error: check.reason });
+  }
+
+  const handled = await client
+    .agent(req.params.agent_id)
+    .handleWebhook(req.body, req.params.task_type, req.params.operation_id, check.signature, check.timestamp, req.rawBody);
+
+  res.status(200).json({ received: handled });
+});
 ```
+
+`verifyWebhookRequest` normalizes header casing, rejects missing or ambiguous signature headers, enforces a 300s timestamp freshness window by default, and compares signatures in constant time. It does not maintain a replay cache; use `webhookDedup` below to drop duplicate webhook events by `idempotency_key`.
+
+For spec-current RFC 9421 webhook signatures, use `createWebhookVerifier` / `verifyWebhookSignature` from `@adcp/sdk/signing/server` instead of the HMAC helper.
 
 ## Deduplication
 

--- a/package.json
+++ b/package.json
@@ -80,6 +80,11 @@
       "require": "./dist/lib/auth/index.js",
       "types": "./dist/lib/auth/index.d.ts"
     },
+    "./webhooks": {
+      "import": "./dist/lib/webhooks/index.js",
+      "require": "./dist/lib/webhooks/index.js",
+      "types": "./dist/lib/webhooks/index.d.ts"
+    },
     "./server": {
       "import": "./dist/lib/server/index.js",
       "require": "./dist/lib/server/index.js",
@@ -184,6 +189,9 @@
       ],
       "auth": [
         "dist/lib/auth/index.d.ts"
+      ],
+      "webhooks": [
+        "dist/lib/webhooks/index.d.ts"
       ],
       "server": [
         "dist/lib/server/index.d.ts"

--- a/src/lib/core/ADCPMultiAgentClient.ts
+++ b/src/lib/core/ADCPMultiAgentClient.ts
@@ -9,6 +9,7 @@ import { ConfigurationManager } from './ConfigurationManager';
 import { CreativeAgentClient, STANDARD_CREATIVE_AGENTS } from './CreativeAgentClient';
 import type { CreativeFormat } from './CreativeAgentClient';
 import type { InputHandler, TaskOptions, TaskResult, TaskInfo } from './ConversationTypes';
+import type { WebhookHeaderValue } from '../webhooks';
 import type {
   GetProductsRequest,
   GetProductsResponse,
@@ -956,12 +957,25 @@ export class ADCPMultiAgentClient {
    *
    * @example
    * ```typescript
-   * app.post('/webhook', async (req, res) => {
-   *   const signature = req.headers['x-adcp-signature'];
-   *   const timestamp = req.headers['x-adcp-timestamp'];
+   * import { verifyWebhookRequest } from '@adcp/sdk/webhooks';
    *
+   * app.post('/webhook', async (req, res) => {
    *   try {
-   *     const handled = await client.handleWebhook(req.body, signature, timestamp);
+   *     const check = verifyWebhookRequest({
+   *       rawBody: req.rawBody,
+   *       headers: req.headers,
+   *       globalSecret: process.env.WEBHOOK_SECRET,
+   *     });
+   *     if (!check.ok) return res.status(401).json({ error: check.reason });
+   *
+   *     const handled = await client.handleWebhook(
+   *       req.body,
+   *       req.params.taskType,
+   *       req.params.operationId,
+   *       check.signature,
+   *       check.timestamp,
+   *       req.rawBody
+   *     );
    *     res.status(200).json({ received: handled });
    *   } catch (error) {
    *     res.status(401).json({ error: error.message });
@@ -973,9 +987,9 @@ export class ADCPMultiAgentClient {
     payload: any,
     taskType: string,
     operationId: string,
-    signature?: string,
-    timestamp?: string | number,
-    rawBody?: string
+    signature?: WebhookHeaderValue,
+    timestamp?: WebhookHeaderValue,
+    rawBody?: string | Buffer | Uint8Array
   ): Promise<boolean> {
     // Extract agent ID from payload
     // Webhook payloads include agent_id or we can infer from operation_id pattern

--- a/src/lib/core/AgentClient.ts
+++ b/src/lib/core/AgentClient.ts
@@ -8,6 +8,7 @@ import type { Task as A2ATask, TaskStatusUpdateEvent } from '@a2a-js/sdk';
 import { SingleAgentClient, type SingleAgentClientConfig } from './SingleAgentClient';
 import type { InputHandler, TaskOptions, TaskResult, TaskInfo, Message } from './ConversationTypes';
 import type { AdcpCapabilities } from '../utils/capabilities';
+import type { WebhookHeaderValue } from '../webhooks';
 import type {
   GetProductsRequest,
   GetProductsResponse,
@@ -433,9 +434,9 @@ export class AgentClient {
     payload: MCPWebhookPayload | A2ATask | TaskStatusUpdateEvent,
     taskType: string,
     operationId: string,
-    signature?: string,
-    timestamp?: string | number,
-    rawBody?: string
+    signature?: WebhookHeaderValue,
+    timestamp?: WebhookHeaderValue,
+    rawBody?: string | Buffer | Uint8Array
   ): Promise<boolean> {
     return this.client.handleWebhook(payload, taskType, operationId, signature, timestamp, rawBody);
   }
@@ -452,7 +453,11 @@ export class AgentClient {
    * @param timestamp - X-ADCP-Timestamp header value (Unix timestamp)
    * @returns true if signature is valid
    */
-  verifyWebhookSignature(rawBodyOrPayload: string | unknown, signature: string, timestamp: string | number): boolean {
+  verifyWebhookSignature(
+    rawBodyOrPayload: string | Buffer | Uint8Array | unknown,
+    signature: WebhookHeaderValue,
+    timestamp: WebhookHeaderValue
+  ): boolean {
     return this.client.verifyWebhookSignature(rawBodyOrPayload, signature, timestamp);
   }
 

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -105,6 +105,7 @@ import { discoverOAuthMetadata } from '../auth/oauth/discovery';
 import type { InputHandler, TaskOptions, TaskResult, ConversationConfig, TaskInfo } from './ConversationTypes';
 import type { Activity, AsyncHandlerConfig, WebhookMetadata } from './AsyncHandler';
 import { AsyncHandler } from './AsyncHandler';
+import { verifyWebhookRequest, type WebhookHeaderValue } from '../webhooks';
 import { unwrapProtocolResponse } from '../utils/response-unwrapper';
 import {
   isWellKnownAgentCardUrl as isWellKnownCardUrl,
@@ -847,12 +848,25 @@ export class SingleAgentClient {
    *
    * @example
    * ```typescript
-   * app.post('/webhook/:taskType', async (req, res) => {
-   *   const signature = req.headers['x-adcp-signature'];
-   *   const timestamp = req.headers['x-adcp-timestamp'];
+   * import { verifyWebhookRequest } from '@adcp/sdk/webhooks';
    *
+   * app.post('/webhook/:taskType', async (req, res) => {
    *   try {
-   *     const handled = await client.handleWebhook(req.body, signature, timestamp, req.params.taskType);
+   *     const check = verifyWebhookRequest({
+   *       rawBody: req.rawBody,
+   *       headers: req.headers,
+   *       globalSecret: process.env.WEBHOOK_SECRET,
+   *     });
+   *     if (!check.ok) return res.status(401).json({ error: check.reason });
+   *
+   *     const handled = await client.handleWebhook(
+   *       req.body,
+   *       req.params.taskType,
+   *       req.params.operationId,
+   *       check.signature,
+   *       check.timestamp,
+   *       req.rawBody
+   *     );
    *     res.status(200).json({ received: handled });
    *   } catch (error) {
    *     res.status(401).json({ error: error.message });
@@ -864,9 +878,9 @@ export class SingleAgentClient {
     payload: MCPWebhookPayload | A2ATask | TaskStatusUpdateEvent,
     taskType: string,
     operationId: string,
-    signature?: string,
-    timestamp?: string | number,
-    rawBody?: string
+    signature?: WebhookHeaderValue,
+    timestamp?: WebhookHeaderValue,
+    rawBody?: string | Buffer | Uint8Array
   ): Promise<boolean> {
     // Verify signature if secret is configured
     if (this.config.webhookSecret) {
@@ -1058,7 +1072,7 @@ export class SingleAgentClient {
    * Create an HTTP webhook handler that automatically verifies signatures
    *
    * This helper creates a standard HTTP handler (Express/Next.js/etc.) that:
-   * - Extracts X-ADCP-Signature and X-ADCP-Timestamp headers
+   * - Reads the full header bag so duplicate/conflicting signature headers are rejected
    * - Verifies HMAC signature (if webhookSecret configured)
    * - Validates timestamp freshness
    * - Calls handleWebhook() with proper error handling
@@ -1086,7 +1100,12 @@ export class SingleAgentClient {
    */
   createWebhookHandler() {
     return async (
-      req: { headers: Record<string, string | undefined>; body: unknown; params?: Record<string, string> },
+      req: {
+        headers: Record<string, WebhookHeaderValue>;
+        body: unknown;
+        rawBody?: string | Buffer | Uint8Array;
+        params?: Record<string, string>;
+      },
       res: {
         status: (code: number) => { json: (body: unknown) => void };
         json?: unknown;
@@ -1095,19 +1114,44 @@ export class SingleAgentClient {
       }
     ) => {
       try {
-        // Extract headers (case-insensitive)
-        const signature = req.headers['x-adcp-signature'] || req.headers['X-ADCP-Signature'];
-        const timestamp = req.headers['x-adcp-timestamp'] || req.headers['X-ADCP-Timestamp'];
-
-        // Capture raw body for signature verification, then parse
-        const rawBody = typeof req.body === 'string' ? req.body : JSON.stringify(req.body);
-        const payload = typeof req.body === 'string' ? JSON.parse(req.body) : req.body;
+        // Capture raw body bytes for signature verification, then parse.
+        const rawBody =
+          req.rawBody ??
+          (typeof req.body === 'string' || Buffer.isBuffer(req.body) || req.body instanceof Uint8Array
+            ? req.body
+            : undefined);
+        if (this.config.webhookSecret && rawBody === undefined) {
+          throw new Error(
+            'Raw webhook body required for HMAC signature verification; capture bytes before JSON parsing.'
+          );
+        }
+        const payload =
+          typeof req.body === 'string'
+            ? JSON.parse(req.body)
+            : Buffer.isBuffer(req.body) || req.body instanceof Uint8Array
+              ? JSON.parse(Buffer.from(req.body).toString('utf8'))
+              : req.body;
 
         // Extract routing params if available (e.g., Express route params)
         const taskType = req.params?.task_type || req.params?.taskType || 'unknown';
         const operationId = req.params?.operation_id || req.params?.operationId || 'unknown';
 
-        // Handle webhook with automatic verification using raw body bytes
+        let signature: WebhookHeaderValue;
+        let timestamp: WebhookHeaderValue;
+        if (this.config.webhookSecret) {
+          const check = verifyWebhookRequest({
+            rawBody: rawBody!,
+            secret: this.config.webhookSecret,
+            headers: req.headers,
+          });
+          if (!check.ok) {
+            throw new Error(check.message);
+          }
+          signature = check.signature;
+          timestamp = check.timestamp;
+        }
+
+        // Handle webhook with automatic verification using raw body bytes.
         const handled = await this.handleWebhook(payload, taskType, operationId, signature, timestamp, rawBody);
 
         // Return success
@@ -1152,37 +1196,29 @@ export class SingleAgentClient {
    * @param timestamp - X-ADCP-Timestamp header value (Unix timestamp)
    * @returns true if signature is valid
    */
-  verifyWebhookSignature(rawBodyOrPayload: string | unknown, signature: string, timestamp: string | number): boolean {
+  verifyWebhookSignature(
+    rawBodyOrPayload: string | Buffer | Uint8Array | unknown,
+    signature: WebhookHeaderValue,
+    timestamp: WebhookHeaderValue
+  ): boolean {
     if (!this.config.webhookSecret) {
       return false;
     }
 
-    // Validate timestamp freshness (reject requests older than 5 minutes)
-    const now = Math.floor(Date.now() / 1000);
-    const ts = typeof timestamp === 'string' ? parseInt(timestamp) : timestamp;
-
-    if (Math.abs(now - ts) > 300) {
-      return false; // Request too old or from future
-    }
-
     // Use raw body bytes when available; fall back to JSON.stringify for backward compat
-    const body = typeof rawBodyOrPayload === 'string' ? rawBodyOrPayload : JSON.stringify(rawBodyOrPayload);
+    const rawBody =
+      typeof rawBodyOrPayload === 'string' ||
+      Buffer.isBuffer(rawBodyOrPayload) ||
+      rawBodyOrPayload instanceof Uint8Array
+        ? rawBodyOrPayload
+        : String(JSON.stringify(rawBodyOrPayload));
 
-    // Build message per AdCP spec: {timestamp}.{raw_body}
-    const message = `${ts}.${body}`;
-
-    // Calculate expected signature
-    const hmac = crypto.createHmac('sha256', this.config.webhookSecret);
-    hmac.update(message);
-    const expectedSignature = `sha256=${hmac.digest('hex')}`;
-
-    // Constant-time comparison to prevent timing attacks
-    // Check length first to avoid timingSafeEqual error
-    if (signature.length !== expectedSignature.length) {
-      return false;
-    }
-
-    return crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(expectedSignature));
+    return verifyWebhookRequest({
+      rawBody,
+      secret: this.config.webhookSecret,
+      signature,
+      timestamp,
+    }).ok;
   }
 
   /**

--- a/src/lib/webhooks/index.ts
+++ b/src/lib/webhooks/index.ts
@@ -1,0 +1,210 @@
+import { createHmac, timingSafeEqual } from 'crypto';
+
+export type WebhookHeaderValue = string | number | readonly string[] | null | undefined;
+export type WebhookHeadersLike = Headers | Record<string, WebhookHeaderValue>;
+
+export type VerifyWebhookFailureReason =
+  | 'missing_secret'
+  | 'missing_headers'
+  | 'ambiguous_headers'
+  | 'invalid_timestamp'
+  | 'stale_timestamp'
+  | 'malformed_signature'
+  | 'bad_signature';
+
+export interface VerifyWebhookRequestOptions {
+  /**
+   * Raw HTTP body bytes captured before JSON parsing. Strings are interpreted
+   * as UTF-8; pass Buffer/Uint8Array when your framework exposes bytes.
+   */
+  rawBody: string | Buffer | Uint8Array;
+  /**
+   * Shared HMAC secret. `globalSecret` is accepted as an alias for callers
+   * matching ADCP_WEBHOOK_SECRET naming.
+   */
+  secret?: string;
+  globalSecret?: string;
+  /**
+   * Headers object from your framework. Header names are matched
+   * case-insensitively.
+   */
+  headers?: WebhookHeadersLike;
+  /** Explicit x-adcp-signature header value. When `headers` is also provided, it must match. */
+  signature?: WebhookHeaderValue;
+  /** Explicit x-adcp-timestamp header value. When `headers` is also provided, it must match. */
+  timestamp?: WebhookHeaderValue;
+  /** Allowed absolute timestamp skew in seconds. Defaults to 300. */
+  skewSeconds?: number;
+  /** Current unix time in seconds. Defaults to `Date.now() / 1000`. */
+  now?: () => number;
+}
+
+export type VerifyWebhookRequestResult =
+  | {
+      ok: true;
+      signature: string;
+      timestamp: number;
+      verifiedAt: number;
+    }
+  | {
+      ok: false;
+      reason: VerifyWebhookFailureReason;
+      message: string;
+    };
+
+/**
+ * Verify a legacy AdCP HMAC-SHA256 webhook request.
+ *
+ * This verifies the deprecated `x-adcp-signature: sha256=...` +
+ * `x-adcp-timestamp` profile. Spec-current webhook verification uses RFC 9421
+ * via `verifyWebhookSignature` / `createWebhookVerifier` from
+ * `@adcp/sdk/signing/server`.
+ */
+export function verifyWebhookRequest(options: VerifyWebhookRequestOptions): VerifyWebhookRequestResult {
+  const secret = options.secret ?? options.globalSecret;
+  if (!secret) {
+    return fail('missing_secret', 'A webhook HMAC secret is required.');
+  }
+
+  const signature = resolveHeader('x-adcp-signature', options.signature, options.headers);
+  if (signature.reason) return fail(signature.reason, signature.message);
+
+  const timestamp = resolveHeader('x-adcp-timestamp', options.timestamp, options.headers);
+  if (timestamp.reason) return fail(timestamp.reason, timestamp.message);
+
+  if (!signature.value || !timestamp.value) {
+    return fail('missing_headers', 'Webhook is missing x-adcp-signature or x-adcp-timestamp.');
+  }
+
+  const parsedTimestamp = parseTimestamp(timestamp.value);
+  if (parsedTimestamp === undefined) {
+    return fail('invalid_timestamp', 'x-adcp-timestamp must be an integer unix timestamp in seconds.');
+  }
+
+  const now = options.now ? Math.floor(options.now()) : Math.floor(Date.now() / 1000);
+  const skewSeconds = options.skewSeconds ?? 300;
+  if (!Number.isFinite(skewSeconds) || skewSeconds < 0) {
+    return fail('invalid_timestamp', 'skewSeconds must be a non-negative number.');
+  }
+  if (Math.abs(now - parsedTimestamp) > skewSeconds) {
+    return fail('stale_timestamp', `Webhook timestamp is outside the allowed ${skewSeconds}s skew window.`);
+  }
+
+  if (!/^sha256=[a-f0-9]{64}$/.test(signature.value)) {
+    return fail('malformed_signature', 'x-adcp-signature must match sha256=<64 lowercase hex chars>.');
+  }
+
+  const hmac = createHmac('sha256', secret);
+  hmac.update(String(parsedTimestamp), 'utf8');
+  hmac.update('.', 'utf8');
+  hmac.update(toBodyBytes(options.rawBody));
+  const expected = `sha256=${hmac.digest('hex')}`;
+
+  const expectedBytes = Buffer.from(expected, 'utf8');
+  const actualBytes = Buffer.from(signature.value, 'utf8');
+  if (actualBytes.length !== expectedBytes.length || !timingSafeEqual(actualBytes, expectedBytes)) {
+    return fail('bad_signature', 'Webhook HMAC signature does not match the request body and timestamp.');
+  }
+
+  return {
+    ok: true,
+    signature: signature.value,
+    timestamp: parsedTimestamp,
+    verifiedAt: now,
+  };
+}
+
+function fail(reason: VerifyWebhookFailureReason, message: string): VerifyWebhookRequestResult {
+  return { ok: false, reason, message };
+}
+
+function toBodyBytes(rawBody: string | Buffer | Uint8Array): Buffer | Uint8Array {
+  return typeof rawBody === 'string' ? Buffer.from(rawBody, 'utf8') : rawBody;
+}
+
+function parseTimestamp(value: string): number | undefined {
+  if (!/^\d+$/.test(value)) return undefined;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) ? parsed : undefined;
+}
+
+function resolveHeader(
+  name: string,
+  explicit: WebhookHeaderValue,
+  headers: WebhookHeadersLike | undefined
+): { value?: string; reason?: VerifyWebhookFailureReason; message: string } {
+  const explicitValue = normalizeHeaderValue(explicit);
+  const headerValue: { value?: string; reason?: VerifyWebhookFailureReason; message: string } = headers
+    ? readHeader(headers, name)
+    : { message: '' };
+
+  if (explicitValue.reason) return explicitValue;
+  if (headerValue.reason) return headerValue;
+  if (explicitValue.value && headerValue.value && explicitValue.value !== headerValue.value) {
+    return {
+      reason: 'ambiguous_headers',
+      message: `Explicit ${name} does not match the header bag.`,
+    };
+  }
+  return explicitValue.value ? explicitValue : headerValue;
+}
+
+function readHeader(
+  headers: WebhookHeadersLike,
+  name: string
+): { value?: string; reason?: VerifyWebhookFailureReason; message: string } {
+  if (isHeaders(headers)) {
+    const value = headers.get(name);
+    if (value?.includes(',')) {
+      return {
+        reason: 'ambiguous_headers',
+        message: `Multiple ${name} header values were provided.`,
+      };
+    }
+    return normalizeHeaderValue(value);
+  }
+
+  const matches: WebhookHeaderValue[] = [];
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() === name) matches.push(value);
+  }
+
+  if (matches.length > 1) {
+    return {
+      reason: 'ambiguous_headers',
+      message: `Multiple ${name} headers were provided with different casing.`,
+    };
+  }
+
+  const normalized = normalizeHeaderValue(matches[0]);
+  if (normalized.value?.includes(',')) {
+    return {
+      reason: 'ambiguous_headers',
+      message: `Multiple ${name} header values were provided.`,
+    };
+  }
+  return normalized;
+}
+
+function normalizeHeaderValue(value: WebhookHeaderValue): {
+  value?: string;
+  reason?: VerifyWebhookFailureReason;
+  message: string;
+} {
+  if (value == null) return { message: '' };
+  if (Array.isArray(value)) {
+    if (value.length !== 1) {
+      return {
+        reason: 'ambiguous_headers',
+        message: 'Expected exactly one webhook header value.',
+      };
+    }
+    return normalizeHeaderValue(value[0]);
+  }
+  const normalized = String(value).trim();
+  return normalized ? { value: normalized, message: '' } : { message: '' };
+}
+
+function isHeaders(headers: WebhookHeadersLike): headers is Headers {
+  return typeof (headers as Headers).get === 'function';
+}

--- a/test/webhook-request-helper.test.js
+++ b/test/webhook-request-helper.test.js
@@ -1,0 +1,209 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const crypto = require('node:crypto');
+
+const { verifyWebhookRequest } = require('@adcp/sdk/webhooks');
+
+const secret = 'test-secret-key-minimum-32-characters-long';
+const now = 1_700_000_000;
+
+function sign(rawBody, timestamp = now) {
+  const hmac = crypto.createHmac('sha256', secret);
+  hmac.update(`${timestamp}.`, 'utf8');
+  hmac.update(Buffer.isBuffer(rawBody) ? rawBody : Buffer.from(rawBody, 'utf8'));
+  return `sha256=${hmac.digest('hex')}`;
+}
+
+describe('verifyWebhookRequest', () => {
+  it('verifies a legacy HMAC webhook over exact raw body bytes', () => {
+    const rawBody = '{"key": "value",  "num": 1.0}';
+    const result = verifyWebhookRequest({
+      rawBody,
+      secret,
+      headers: {
+        'X-ADCP-Signature': sign(rawBody),
+        'X-ADCP-Timestamp': String(now),
+      },
+      now: () => now,
+    });
+
+    assert.deepStrictEqual(result, {
+      ok: true,
+      signature: sign(rawBody),
+      timestamp: now,
+      verifiedAt: now,
+    });
+  });
+
+  it('accepts globalSecret alias and explicit header values', () => {
+    const rawBody = Buffer.from('{"event":"done"}', 'utf8');
+    const result = verifyWebhookRequest({
+      rawBody,
+      globalSecret: secret,
+      signature: sign(rawBody),
+      timestamp: now,
+      now: () => now,
+    });
+
+    assert.strictEqual(result.ok, true);
+  });
+
+  it('returns missing_headers when signature or timestamp is absent', () => {
+    const result = verifyWebhookRequest({
+      rawBody: '{}',
+      secret,
+      headers: { 'x-adcp-signature': sign('{}') },
+      now: () => now,
+    });
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.reason, 'missing_headers');
+  });
+
+  it('returns ambiguous_headers for multi-value signature headers', () => {
+    const result = verifyWebhookRequest({
+      rawBody: '{}',
+      secret,
+      signature: [sign('{}'), sign('{}')],
+      timestamp: now,
+      now: () => now,
+    });
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.reason, 'ambiguous_headers');
+  });
+
+  it('returns ambiguous_headers for comma-joined Headers values', () => {
+    const headers = new Headers();
+    headers.append('x-adcp-signature', sign('{}'));
+    headers.append('x-adcp-signature', sign('{}'));
+    headers.set('x-adcp-timestamp', String(now));
+
+    const result = verifyWebhookRequest({
+      rawBody: '{}',
+      secret,
+      headers,
+      now: () => now,
+    });
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.reason, 'ambiguous_headers');
+  });
+
+  it('returns ambiguous_headers for comma-joined Node-style header values', () => {
+    const result = verifyWebhookRequest({
+      rawBody: '{}',
+      secret,
+      headers: {
+        'x-adcp-signature': `${sign('{}')}, ${sign('{}')}`,
+        'x-adcp-timestamp': String(now),
+      },
+      now: () => now,
+    });
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.reason, 'ambiguous_headers');
+  });
+
+  it('still rejects ambiguous header bags when explicit values are provided', () => {
+    const headers = new Headers();
+    headers.append('x-adcp-signature', sign('{}'));
+    headers.append('x-adcp-signature', sign('{}'));
+    headers.set('x-adcp-timestamp', String(now));
+
+    const result = verifyWebhookRequest({
+      rawBody: '{}',
+      secret,
+      headers,
+      signature: sign('{}'),
+      timestamp: now,
+      now: () => now,
+    });
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.reason, 'ambiguous_headers');
+  });
+
+  it('rejects explicit values that disagree with the header bag', () => {
+    const result = verifyWebhookRequest({
+      rawBody: '{}',
+      secret,
+      headers: {
+        'x-adcp-signature': sign('{}'),
+        'x-adcp-timestamp': String(now),
+      },
+      signature: sign('{"changed":true}'),
+      timestamp: now,
+      now: () => now,
+    });
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.reason, 'ambiguous_headers');
+  });
+
+  it('returns invalid_timestamp for non-integer timestamps', () => {
+    const result = verifyWebhookRequest({
+      rawBody: '{}',
+      secret,
+      signature: sign('{}'),
+      timestamp: '1700000000abc',
+      now: () => now,
+    });
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.reason, 'invalid_timestamp');
+  });
+
+  it('returns stale_timestamp outside the replay window', () => {
+    const oldTimestamp = now - 301;
+    const result = verifyWebhookRequest({
+      rawBody: '{}',
+      secret,
+      signature: sign('{}', oldTimestamp),
+      timestamp: oldTimestamp,
+      now: () => now,
+    });
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.reason, 'stale_timestamp');
+  });
+
+  it('returns malformed_signature before comparing malformed values', () => {
+    const result = verifyWebhookRequest({
+      rawBody: '{}',
+      secret,
+      signature: 'sha256=not-hex',
+      timestamp: now,
+      now: () => now,
+    });
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.reason, 'malformed_signature');
+  });
+
+  it('returns malformed_signature for uppercase hex to match handleWebhook behavior', () => {
+    const result = verifyWebhookRequest({
+      rawBody: '{}',
+      secret,
+      signature: sign('{}').toUpperCase().replace('SHA256=', 'sha256='),
+      timestamp: now,
+      now: () => now,
+    });
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.reason, 'malformed_signature');
+  });
+
+  it('returns bad_signature for well-formed signatures over different bytes', () => {
+    const result = verifyWebhookRequest({
+      rawBody: '{"different":true}',
+      secret,
+      signature: sign('{}'),
+      timestamp: now,
+      now: () => now,
+    });
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.reason, 'bad_signature');
+  });
+});

--- a/test/webhook-signature-verification.test.js
+++ b/test/webhook-signature-verification.test.js
@@ -1,6 +1,7 @@
 const { test, describe } = require('node:test');
 const assert = require('node:assert');
 const { AdCPClient } = require('../dist/lib/index.js');
+const { SingleAgentClient } = require('../dist/lib/core/SingleAgentClient.js');
 const crypto = require('crypto');
 
 describe('Webhook Signature Verification (PR #86 Spec)', () => {
@@ -12,6 +13,26 @@ describe('Webhook Signature Verification (PR #86 Spec)', () => {
   };
 
   const webhookSecret = 'test-secret-key-minimum-32-characters-long';
+
+  function makeResponse() {
+    return {
+      statusCode: undefined,
+      body: undefined,
+      status(code) {
+        this.statusCode = code;
+        return this;
+      },
+      json(body) {
+        this.body = body;
+      },
+      writeHead(code) {
+        this.statusCode = code;
+      },
+      end(body) {
+        this.body = JSON.parse(body);
+      },
+    };
+  }
 
   test('should verify valid webhook signature using raw body string', () => {
     const client = new AdCPClient([agent], { webhookSecret });
@@ -31,6 +52,92 @@ describe('Webhook Signature Verification (PR #86 Spec)', () => {
     // Verify signature using raw body string
     const isValid = agentClient.verifyWebhookSignature(rawBody, signature, timestamp);
     assert.strictEqual(isValid, true);
+  });
+
+  test('should verify valid webhook signature using raw body Buffer', () => {
+    const client = new AdCPClient([agent], { webhookSecret });
+    const agentClient = client.agent('test_agent');
+
+    const rawBody = Buffer.from('{"event":"creative.status_changed","status":"approved"}', 'utf8');
+    const timestamp = Math.floor(Date.now() / 1000);
+
+    const hmac = crypto.createHmac('sha256', webhookSecret);
+    hmac.update(`${timestamp}.`, 'utf8');
+    hmac.update(rawBody);
+    const signature = `sha256=${hmac.digest('hex')}`;
+
+    const isValid = agentClient.verifyWebhookSignature(rawBody, signature, timestamp);
+    assert.strictEqual(isValid, true);
+  });
+
+  test('createWebhookHandler rejects ambiguous signature headers from Node-style header bag', async () => {
+    const client = new SingleAgentClient(agent, { webhookSecret });
+    const handler = client.createWebhookHandler();
+
+    const rawBody = JSON.stringify({
+      operation_id: 'op_1',
+      task_id: 'task_1',
+      task_type: 'create_media_buy',
+      status: 'completed',
+      timestamp: new Date().toISOString(),
+      result: { media_buy_id: 'mb_1' },
+    });
+    const timestamp = Math.floor(Date.now() / 1000);
+    const hmac = crypto.createHmac('sha256', webhookSecret);
+    hmac.update(`${timestamp}.${rawBody}`);
+    const signature = `sha256=${hmac.digest('hex')}`;
+
+    const res = makeResponse();
+    await handler(
+      {
+        headers: {
+          'x-adcp-signature': `${signature}, ${signature}`,
+          'x-adcp-timestamp': String(timestamp),
+        },
+        body: rawBody,
+        params: { task_type: 'create_media_buy', operation_id: 'op_1' },
+      },
+      res
+    );
+
+    assert.strictEqual(res.statusCode, 401);
+    assert.strictEqual(res.body.error, 'Multiple x-adcp-signature header values were provided.');
+  });
+
+  test('createWebhookHandler requires raw bytes when HMAC verification is enabled', async () => {
+    const client = new SingleAgentClient(agent, { webhookSecret });
+    const handler = client.createWebhookHandler();
+
+    const payload = {
+      operation_id: 'op_1',
+      task_id: 'task_1',
+      task_type: 'create_media_buy',
+      status: 'completed',
+      timestamp: new Date().toISOString(),
+      result: { media_buy_id: 'mb_1' },
+    };
+    const rawBody =
+      '{ "operation_id": "op_1", "task_id": "task_1", "task_type": "create_media_buy", "status": "completed", "result": {"media_buy_id":"mb_1"} }';
+    const timestamp = Math.floor(Date.now() / 1000);
+    const hmac = crypto.createHmac('sha256', webhookSecret);
+    hmac.update(`${timestamp}.${rawBody}`);
+    const signature = `sha256=${hmac.digest('hex')}`;
+
+    const res = makeResponse();
+    await handler(
+      {
+        headers: {
+          'x-adcp-signature': signature,
+          'x-adcp-timestamp': String(timestamp),
+        },
+        body: payload,
+        params: { task_type: 'create_media_buy', operation_id: 'op_1' },
+      },
+      res
+    );
+
+    assert.strictEqual(res.statusCode, 401);
+    assert.match(res.body.error, /Raw webhook body required/);
   });
 
   test('should verify signature when raw body has different formatting than JSON.stringify', () => {


### PR DESCRIPTION
## Summary

Adds a public `@adcp/sdk/webhooks` subpath with `verifyWebhookRequest` for legacy HMAC-SHA256 webhook receivers. The helper verifies exact raw body bytes, normalizes `x-adcp-*` header casing, rejects ambiguous or conflicting header values, enforces timestamp freshness, and returns structured failure reasons.

Also routes the existing client HMAC verification path through the helper so `handleWebhook` and the standalone API share semantics, including Buffer/Uint8Array raw-body handling.

Updates the push notification guide to use the SDK helper and clarify that HMAC timestamp freshness is not replay-cache dedup; `webhookDedup` remains the event-level duplicate suppression path.

Closes #1926.

## Validation

- `npm run build:lib`
- `node --test-timeout=60000 --test test/webhook-request-helper.test.js test/webhook-signature-verification.test.js`
- `npx prettier --check .changeset/webhook-hmac-helper.md docs/guides/PUSH-NOTIFICATION-CONFIG.md src/lib/webhooks/index.ts test/webhook-request-helper.test.js test/webhook-signature-verification.test.js package.json src/lib/core/SingleAgentClient.ts src/lib/core/AgentClient.ts src/lib/core/ADCPMultiAgentClient.ts`
- `node -e "const { verifyWebhookRequest } = require('@adcp/sdk/webhooks'); console.log(typeof verifyWebhookRequest)"`
- pre-push hook: `npm run typecheck`, library build

## Notes

`package-lock.json` was already dirty in this workspace before this change and is intentionally not included in the commit.