### PR TITLE
fix: tighten 3.1 beta sync accounts notification types

### DIFF
--- a/.changeset/catalog-sync-webhook-notifications.md
+++ b/.changeset/catalog-sync-webhook-notifications.md
@@ -1,5 +1,5 @@
 ---
-'@adcp/sdk': minor
+'@adcp/sdk': patch
 ---
 
-Allow AdCP 3.1 beta `sync_accounts` notification subscribers to register catalog change events (`product.*`, `signal.*`, and `catalog.bulk_change`) and validate the opt-in runtime/type surfaces.
+Tighten the opt-in AdCP 3.1 beta `sync_accounts.accounts[]` TypeScript surface so provisioning and settings-update entries expose account `notification_configs`.

--- a/.changeset/catalog-sync-webhook-notifications.md
+++ b/.changeset/catalog-sync-webhook-notifications.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': minor
+---
+
+Allow AdCP 3.1 beta `sync_accounts` notification subscribers to register catalog change events (`product.*`, `signal.*`, and `catalog.bulk_change`) and validate the opt-in runtime/type surfaces.

--- a/scripts/generate-3-1-beta-types.ts
+++ b/scripts/generate-3-1-beta-types.ts
@@ -32,17 +32,6 @@ const BETA_VERSION = '3.1.0-beta.2';
 const BETA_CACHE_DIR = path.join(REPO_ROOT, 'schemas/cache', BETA_VERSION);
 const OUTPUT_DIR = path.join(REPO_ROOT, 'src/lib/types/v3-1-beta');
 const OUTPUT_FILE = path.join(OUTPUT_DIR, 'tools.generated.ts');
-const CATALOG_NOTIFICATION_TYPES = [
-  'product.created',
-  'product.updated',
-  'product.priced',
-  'product.removed',
-  'signal.created',
-  'signal.updated',
-  'signal.priced',
-  'signal.removed',
-  'catalog.bulk_change',
-] as const;
 
 interface TaskRef {
   request?: { $ref?: string };
@@ -337,28 +326,12 @@ function widenIndexSignaturesOnAnonymousObjects(src: string): string {
 }
 
 /**
- * The current 3.1 beta schema cache has catalog-change webhook support split
- * across two surfaces: `catalog_change_feed.event_types` already declares the
- * product/signal/catalog event literals, while `NotificationConfig.event_types`
- * still points at the older account-notification enum. Keep the opt-in TS
- * surface aligned with the intended sync_accounts settings-update flow until
- * the upstream enum catches up.
+ * `json-schema-to-typescript` collapses the `sync_accounts.accounts[]` oneOf
+ * mode arms to `{ [k: string]: unknown | undefined }` because the beta schema
+ * uses conditional constraints to distinguish provisioning vs settings-update
+ * mode. AJV still enforces those conditionals at runtime; this restores the
+ * opt-in TS surface so beta adopters can type account notification updates.
  */
-function widenCatalogNotificationTypes(src: string): string {
-  let replacements = 0;
-  const next = src.replace(/export type NotificationType =\n([\s\S]*?);/, (_match, members: string) => {
-    replacements += 1;
-    const existing = [...members.matchAll(/'([^']+)'/g)].map(match => match[1]);
-    const merged = Array.from(new Set([...existing, ...CATALOG_NOTIFICATION_TYPES]));
-    const lines = merged.map((value, index) => `  | '${value}'${index === merged.length - 1 ? ';' : ''}`);
-    return `export type NotificationType =\n${lines.join('\n')}`;
-  });
-  if (replacements !== 1) {
-    throw new Error(`Expected to rewrite NotificationType exactly once, rewrote ${replacements} times.`);
-  }
-  return next;
-}
-
 function tightenSyncAccountsModeTypes(src: string): string {
   const provisioning = `export interface ProvisioningMode {
   brand: BrandReference;
@@ -445,7 +418,6 @@ async function main(): Promise<void> {
   let body = compiled.replace(wrapperPattern, '').trim();
   body = removeNumberedTypeDuplicates(body);
   body = widenIndexSignaturesOnAnonymousObjects(body);
-  body = widenCatalogNotificationTypes(body);
   body = tightenSyncAccountsModeTypes(body);
 
   const banner = `// AdCP 3.1.0-beta.2 tool request/response types — DO NOT EDIT

--- a/scripts/generate-3-1-beta-types.ts
+++ b/scripts/generate-3-1-beta-types.ts
@@ -32,6 +32,17 @@ const BETA_VERSION = '3.1.0-beta.2';
 const BETA_CACHE_DIR = path.join(REPO_ROOT, 'schemas/cache', BETA_VERSION);
 const OUTPUT_DIR = path.join(REPO_ROOT, 'src/lib/types/v3-1-beta');
 const OUTPUT_FILE = path.join(OUTPUT_DIR, 'tools.generated.ts');
+const CATALOG_NOTIFICATION_TYPES = [
+  'product.created',
+  'product.updated',
+  'product.priced',
+  'product.removed',
+  'signal.created',
+  'signal.updated',
+  'signal.priced',
+  'signal.removed',
+  'catalog.bulk_change',
+] as const;
 
 interface TaskRef {
   request?: { $ref?: string };
@@ -325,6 +336,68 @@ function widenIndexSignaturesOnAnonymousObjects(src: string): string {
   return src.replace(/(\[k: string\]:\s+)([A-Z][\w.]*(?:\[\])?);/g, '$1$2 | undefined;');
 }
 
+/**
+ * The current 3.1 beta schema cache has catalog-change webhook support split
+ * across two surfaces: `catalog_change_feed.event_types` already declares the
+ * product/signal/catalog event literals, while `NotificationConfig.event_types`
+ * still points at the older account-notification enum. Keep the opt-in TS
+ * surface aligned with the intended sync_accounts settings-update flow until
+ * the upstream enum catches up.
+ */
+function widenCatalogNotificationTypes(src: string): string {
+  let replacements = 0;
+  const next = src.replace(/export type NotificationType =\n([\s\S]*?);/, (_match, members: string) => {
+    replacements += 1;
+    const existing = [...members.matchAll(/'([^']+)'/g)].map(match => match[1]);
+    const merged = Array.from(new Set([...existing, ...CATALOG_NOTIFICATION_TYPES]));
+    const lines = merged.map((value, index) => `  | '${value}'${index === merged.length - 1 ? ';' : ''}`);
+    return `export type NotificationType =\n${lines.join('\n')}`;
+  });
+  if (replacements !== 1) {
+    throw new Error(`Expected to rewrite NotificationType exactly once, rewrote ${replacements} times.`);
+  }
+  return next;
+}
+
+function tightenSyncAccountsModeTypes(src: string): string {
+  const provisioning = `export interface ProvisioningMode {
+  brand: BrandReference;
+  operator: string;
+  billing: BillingParty;
+  account?: never;
+  billing_entity?: BusinessEntity;
+  payment_terms?: PaymentTerms;
+  sandbox?: boolean;
+  preferred_reporting_protocol?: CloudStorageProtocol;
+  notification_configs?: NotificationConfig[];
+  ext?: ExtensionObject;
+}`;
+  const settingsUpdate = `export interface SettingsUpdateMode {
+  account: AccountReference;
+  brand?: never;
+  operator?: never;
+  billing?: never;
+  billing_entity?: BusinessEntity;
+  payment_terms?: PaymentTerms;
+  notification_configs?: NotificationConfig[];
+  ext?: ExtensionObject;
+}`;
+
+  let replacements = 0;
+  let next = src.replace(/export interface ProvisioningMode \{\n\s+\[k: string\]: unknown \| undefined;\n\}/, () => {
+    replacements += 1;
+    return provisioning;
+  });
+  next = next.replace(/export interface SettingsUpdateMode \{\n\s+\[k: string\]: unknown \| undefined;\n\}/, () => {
+    replacements += 1;
+    return settingsUpdate;
+  });
+  if (replacements !== 2) {
+    throw new Error(`Expected to rewrite sync_accounts mode interfaces exactly twice, rewrote ${replacements} times.`);
+  }
+  return next;
+}
+
 async function main(): Promise<void> {
   console.log('🔧 Generating AdCP 3.1-beta TypeScript types...');
   const tools = loadTools();
@@ -372,6 +445,8 @@ async function main(): Promise<void> {
   let body = compiled.replace(wrapperPattern, '').trim();
   body = removeNumberedTypeDuplicates(body);
   body = widenIndexSignaturesOnAnonymousObjects(body);
+  body = widenCatalogNotificationTypes(body);
+  body = tightenSyncAccountsModeTypes(body);
 
   const banner = `// AdCP 3.1.0-beta.2 tool request/response types — DO NOT EDIT
 // Generated from schemas/cache/${BETA_VERSION}/ via scripts/generate-3-1-beta-types.ts

--- a/src/lib/types/v3-1-beta/tools.generated.ts
+++ b/src/lib/types/v3-1-beta/tools.generated.ts
@@ -102,7 +102,7 @@ export type AccountScope = 'operator' | 'brand' | 'operator_brand' | 'agent';
  */
 export type CloudStorageProtocol = 's3' | 'gcs' | 'azure_blob';
 /**
- * Type of push notification fired by a seller agent. Media-buy-anchored notifications (`scheduled`, `final`, `delayed`, `adjusted`, `impairment`) fire against a media buy's `push_notification_config`. Account-anchored notifications (`creative.status_changed`, `creative.purged`) fire against an account's `notification_configs[]` entries whose `event_types` include the value — these outlive any single media buy and anchor at the account. New notification types added to this enum MUST declare their anchor (media-buy or account) and per-type `notification_id` semantics in the enumDescription. Sellers MUST reject `notification_configs[]` entries whose `event_types` include any media-buy-anchored type, and MUST reject `push_notification_config` registrations for account-anchored types.
+ * Type of push notification fired by a seller agent. Media-buy-anchored notifications (`scheduled`, `final`, `delayed`, `adjusted`, `impairment`) fire against a media buy's `push_notification_config`. Account-anchored notifications (`creative.status_changed`, `creative.purged`) and catalog-change events (`product.*`, `signal.*`, `catalog.bulk_change`) fire against an account's `notification_configs[]` entries whose `event_types` include the value — these outlive any single media buy and anchor at the account. New notification types added to this enum MUST declare their anchor (media-buy or account) and per-type `notification_id` semantics in the enumDescription. Sellers MUST reject `notification_configs[]` entries whose `event_types` include any media-buy-anchored type, and MUST reject `push_notification_config` registrations for account-anchored types.
  */
 export type NotificationType =
   | 'scheduled'
@@ -111,7 +111,16 @@ export type NotificationType =
   | 'adjusted'
   | 'impairment'
   | 'creative.status_changed'
-  | 'creative.purged';
+  | 'creative.purged'
+  | 'product.created'
+  | 'product.updated'
+  | 'product.priced'
+  | 'product.removed'
+  | 'signal.created'
+  | 'signal.updated'
+  | 'signal.priced'
+  | 'signal.removed'
+  | 'catalog.bulk_change';
 /**
  * Legacy authentication schemes for the webhook auth block. Bearer: token sent in Authorization header. HMAC-SHA256: legacy shared-secret signing. Both are deprecated; new integrations SHOULD omit the authentication block and use the RFC 9421 webhook signing profile (applicable on schemas where authentication is optional). Removed in AdCP 4.0.
  */
@@ -10860,7 +10869,7 @@ export interface BusinessEntity {
   ext?: ExtensionObject;
 }
 /**
- * Account-level webhook subscription for notifications whose lifecycle outlives any single media buy — creative state changes, library purges, future org-level signals. Distinct from `push-notification-config.json`, which anchors at a per-resource operation (a single task or media buy). An account MAY register multiple notification configs to fan a single seller's events out to multiple buyer-side endpoints; each entry filters by `event_types`. As with push-notification-config, the default signing scheme is the AdCP RFC 9421 webhook profile against the seller's brand.json `agents[]` JWKS; the optional `authentication` block opts into the deprecated Bearer / HMAC-SHA256 fallback for compatibility. Credentials and shared secrets in `authentication.credentials` are write-only — sellers MUST NOT echo them back in `list_accounts` responses.
+ * Account-level webhook subscription for notifications whose lifecycle outlives any single media buy — creative state changes, library purges, and wholesale product/signal catalog changes. Distinct from `push-notification-config.json`, which anchors at a per-resource operation (a single task or media buy). An account MAY register multiple notification configs to fan a single seller's events out to multiple buyer-side endpoints; each entry filters by `event_types`. As with push-notification-config, the default signing scheme is the AdCP RFC 9421 webhook profile against the seller's brand.json `agents[]` JWKS; the optional `authentication` block opts into the deprecated Bearer / HMAC-SHA256 fallback for compatibility. Credentials and shared secrets in `authentication.credentials` are write-only — sellers MUST NOT echo them back in `list_accounts` responses.
  */
 export interface NotificationConfig {
   /**
@@ -10872,7 +10881,7 @@ export interface NotificationConfig {
    */
   url: string;
   /**
-   * Notification types this subscriber wishes to receive on the registered `url`. The seller MUST NOT fire other types against this endpoint, and MUST NOT silently widen the filter when new types are added to `notification-type.json`. When omitted, the seller MUST default to a no-fire policy and surface an `errors[]` entry on `sync_accounts` so the buyer notices the missing filter. Values are drawn from `notification-type.json`, but only types whose contract anchors at the account scope are valid here — media-buy-anchored types (`scheduled`, `final`, `delayed`, `adjusted`, `impairment`) belong on a media buy's `push_notification_config`, not on this surface; sellers MUST reject those entries with an `errors[]` warning rather than silently dropping them.
+   * Notification types this subscriber wishes to receive on the registered `url`. The seller MUST NOT fire other types against this endpoint, and MUST NOT silently widen the filter when new types are added to `notification-type.json`. When omitted, the seller MUST default to a no-fire policy and surface an `errors[]` entry on `sync_accounts` so the buyer notices the missing filter. Values are drawn from `notification-type.json` and catalog-change events, but only types whose contract anchors at the account scope are valid here — media-buy-anchored types (`scheduled`, `final`, `delayed`, `adjusted`, `impairment`) belong on a media buy's `push_notification_config`, not on this surface; sellers MUST reject those entries with an `errors[]` warning rather than silently dropping them.
    */
   event_types: NotificationType[];
   /**
@@ -11037,13 +11046,29 @@ export interface PaginationResponse {
  * Provisioning-mode entry — natural-key trio is required, `account` is forbidden.
  */
 export interface ProvisioningMode {
-  [k: string]: unknown | undefined;
+  brand: BrandReference;
+  operator: string;
+  billing: BillingParty;
+  account?: never;
+  billing_entity?: BusinessEntity;
+  payment_terms?: PaymentTerms;
+  sandbox?: boolean;
+  preferred_reporting_protocol?: CloudStorageProtocol;
+  notification_configs?: NotificationConfig[];
+  ext?: ExtensionObject;
 }
 /**
  * Settings-update entry — `account` (AccountRef) is required, provisioning trio fields are forbidden.
  */
 export interface SettingsUpdateMode {
-  [k: string]: unknown | undefined;
+  account: AccountReference;
+  brand?: never;
+  operator?: never;
+  billing?: never;
+  billing_entity?: BusinessEntity;
+  payment_terms?: PaymentTerms;
+  notification_configs?: NotificationConfig[];
+  ext?: ExtensionObject;
 }
 /**
  * Webhook for async notifications when account status changes (e.g., pending_approval transitions to active).

--- a/src/lib/types/v3-1-beta/tools.generated.ts
+++ b/src/lib/types/v3-1-beta/tools.generated.ts
@@ -102,7 +102,7 @@ export type AccountScope = 'operator' | 'brand' | 'operator_brand' | 'agent';
  */
 export type CloudStorageProtocol = 's3' | 'gcs' | 'azure_blob';
 /**
- * Type of push notification fired by a seller agent. Media-buy-anchored notifications (`scheduled`, `final`, `delayed`, `adjusted`, `impairment`) fire against a media buy's `push_notification_config`. Account-anchored notifications (`creative.status_changed`, `creative.purged`) and catalog-change events (`product.*`, `signal.*`, `catalog.bulk_change`) fire against an account's `notification_configs[]` entries whose `event_types` include the value — these outlive any single media buy and anchor at the account. New notification types added to this enum MUST declare their anchor (media-buy or account) and per-type `notification_id` semantics in the enumDescription. Sellers MUST reject `notification_configs[]` entries whose `event_types` include any media-buy-anchored type, and MUST reject `push_notification_config` registrations for account-anchored types.
+ * Type of push notification fired by a seller agent. Media-buy-anchored notifications (`scheduled`, `final`, `delayed`, `adjusted`, `impairment`) fire against a media buy's `push_notification_config`. Account-anchored notifications (`creative.status_changed`, `creative.purged`) fire against an account's `notification_configs[]` entries whose `event_types` include the value — these outlive any single media buy and anchor at the account. New notification types added to this enum MUST declare their anchor (media-buy or account) and per-type `notification_id` semantics in the enumDescription. Sellers MUST reject `notification_configs[]` entries whose `event_types` include any media-buy-anchored type, and MUST reject `push_notification_config` registrations for account-anchored types.
  */
 export type NotificationType =
   | 'scheduled'
@@ -111,16 +111,7 @@ export type NotificationType =
   | 'adjusted'
   | 'impairment'
   | 'creative.status_changed'
-  | 'creative.purged'
-  | 'product.created'
-  | 'product.updated'
-  | 'product.priced'
-  | 'product.removed'
-  | 'signal.created'
-  | 'signal.updated'
-  | 'signal.priced'
-  | 'signal.removed'
-  | 'catalog.bulk_change';
+  | 'creative.purged';
 /**
  * Legacy authentication schemes for the webhook auth block. Bearer: token sent in Authorization header. HMAC-SHA256: legacy shared-secret signing. Both are deprecated; new integrations SHOULD omit the authentication block and use the RFC 9421 webhook signing profile (applicable on schemas where authentication is optional). Removed in AdCP 4.0.
  */
@@ -10869,7 +10860,7 @@ export interface BusinessEntity {
   ext?: ExtensionObject;
 }
 /**
- * Account-level webhook subscription for notifications whose lifecycle outlives any single media buy — creative state changes, library purges, and wholesale product/signal catalog changes. Distinct from `push-notification-config.json`, which anchors at a per-resource operation (a single task or media buy). An account MAY register multiple notification configs to fan a single seller's events out to multiple buyer-side endpoints; each entry filters by `event_types`. As with push-notification-config, the default signing scheme is the AdCP RFC 9421 webhook profile against the seller's brand.json `agents[]` JWKS; the optional `authentication` block opts into the deprecated Bearer / HMAC-SHA256 fallback for compatibility. Credentials and shared secrets in `authentication.credentials` are write-only — sellers MUST NOT echo them back in `list_accounts` responses.
+ * Account-level webhook subscription for notifications whose lifecycle outlives any single media buy — creative state changes, library purges, future org-level signals. Distinct from `push-notification-config.json`, which anchors at a per-resource operation (a single task or media buy). An account MAY register multiple notification configs to fan a single seller's events out to multiple buyer-side endpoints; each entry filters by `event_types`. As with push-notification-config, the default signing scheme is the AdCP RFC 9421 webhook profile against the seller's brand.json `agents[]` JWKS; the optional `authentication` block opts into the deprecated Bearer / HMAC-SHA256 fallback for compatibility. Credentials and shared secrets in `authentication.credentials` are write-only — sellers MUST NOT echo them back in `list_accounts` responses.
  */
 export interface NotificationConfig {
   /**
@@ -10881,7 +10872,7 @@ export interface NotificationConfig {
    */
   url: string;
   /**
-   * Notification types this subscriber wishes to receive on the registered `url`. The seller MUST NOT fire other types against this endpoint, and MUST NOT silently widen the filter when new types are added to `notification-type.json`. When omitted, the seller MUST default to a no-fire policy and surface an `errors[]` entry on `sync_accounts` so the buyer notices the missing filter. Values are drawn from `notification-type.json` and catalog-change events, but only types whose contract anchors at the account scope are valid here — media-buy-anchored types (`scheduled`, `final`, `delayed`, `adjusted`, `impairment`) belong on a media buy's `push_notification_config`, not on this surface; sellers MUST reject those entries with an `errors[]` warning rather than silently dropping them.
+   * Notification types this subscriber wishes to receive on the registered `url`. The seller MUST NOT fire other types against this endpoint, and MUST NOT silently widen the filter when new types are added to `notification-type.json`. When omitted, the seller MUST default to a no-fire policy and surface an `errors[]` entry on `sync_accounts` so the buyer notices the missing filter. Values are drawn from `notification-type.json`, but only types whose contract anchors at the account scope are valid here — media-buy-anchored types (`scheduled`, `final`, `delayed`, `adjusted`, `impairment`) belong on a media buy's `push_notification_config`, not on this surface; sellers MUST reject those entries with an `errors[]` warning rather than silently dropping them.
    */
   event_types: NotificationType[];
   /**

--- a/src/lib/validation/schema-loader.ts
+++ b/src/lib/validation/schema-loader.ts
@@ -36,6 +36,18 @@ const SCHEMA_FILENAME_SUFFIX: Record<Direction, string> = {
   'input-required': 'async-response-input-required',
 };
 
+const CATALOG_NOTIFICATION_TYPES = [
+  'product.created',
+  'product.updated',
+  'product.priced',
+  'product.removed',
+  'signal.created',
+  'signal.updated',
+  'signal.priced',
+  'signal.removed',
+  'catalog.bulk_change',
+] as const;
+
 /**
  * Map a consumer-provided version pin to the loader's bundle key.
  *
@@ -328,6 +340,39 @@ function loadJson(file: string): LoadedSchema {
   return JSON.parse(readFileSync(file, 'utf-8')) as LoadedSchema;
 }
 
+// Matches the 3.1-beta type surface widening for sync_accounts webhook
+// subscriptions while the upstream beta enum is still catching up.
+function supportsCatalogNotificationWidening(version: string, file: string): boolean {
+  if (!/^3\.1(?:\.0)?-beta(?:\.|$)/.test(version)) return false;
+  const normalized = file.split(path.sep).join('/');
+  return (
+    normalized.endsWith('/enums/notification-type.json') ||
+    normalized.endsWith('/account/sync-accounts-request.json') ||
+    normalized.endsWith('/bundled/account/sync-accounts-request.json')
+  );
+}
+
+function widenCatalogNotificationEnums(node: unknown): void {
+  if (node === null || typeof node !== 'object') return;
+  if (Array.isArray(node)) {
+    for (const item of node) widenCatalogNotificationEnums(item);
+    return;
+  }
+
+  const obj = node as Record<string, unknown>;
+  if (
+    Array.isArray(obj.enum) &&
+    obj.enum.includes('creative.status_changed') &&
+    obj.enum.includes('creative.purged')
+  ) {
+    obj.enum = Array.from(new Set([...obj.enum, ...CATALOG_NOTIFICATION_TYPES]));
+  }
+
+  for (const value of Object.values(obj)) {
+    widenCatalogNotificationEnums(value);
+  }
+}
+
 /**
  * Clear `additionalProperties: false` at the response root so envelope
  * fields (`replayed`, `context`, `ext`, and future envelope additions)
@@ -511,6 +556,9 @@ function ensureCoreLoaded(s: LoaderState): void {
     for (const file of walkJsonFiles(abs)) {
       if (responseToolFiles.has(file)) continue;
       const schema = loadJson(file);
+      if (supportsCatalogNotificationWidening(s.version, file)) {
+        widenCatalogNotificationEnums(schema);
+      }
       if (typeof schema.$id === 'string' && !s.ajv.getSchema(schema.$id)) {
         s.ajv.addSchema(schema);
       }
@@ -550,6 +598,9 @@ export function getValidator(
   if (!fromBundled) ensureCoreLoaded(s);
 
   const rawSchema = loadJson(file);
+  if (supportsCatalogNotificationWidening(s.version, file)) {
+    widenCatalogNotificationEnums(rawSchema);
+  }
   const schema = direction === 'request' ? rawSchema : relaxResponseRoot(rawSchema);
   const existing = typeof schema.$id === 'string' ? s.ajv.getSchema(schema.$id) : undefined;
   const compiled = existing ?? s.ajv.compile(schema);

--- a/src/lib/validation/schema-loader.ts
+++ b/src/lib/validation/schema-loader.ts
@@ -360,11 +360,7 @@ function widenCatalogNotificationEnums(node: unknown): void {
   }
 
   const obj = node as Record<string, unknown>;
-  if (
-    Array.isArray(obj.enum) &&
-    obj.enum.includes('creative.status_changed') &&
-    obj.enum.includes('creative.purged')
-  ) {
+  if (Array.isArray(obj.enum) && obj.enum.includes('creative.status_changed') && obj.enum.includes('creative.purged')) {
     obj.enum = Array.from(new Set([...obj.enum, ...CATALOG_NOTIFICATION_TYPES]));
   }
 

--- a/src/lib/validation/schema-loader.ts
+++ b/src/lib/validation/schema-loader.ts
@@ -36,18 +36,6 @@ const SCHEMA_FILENAME_SUFFIX: Record<Direction, string> = {
   'input-required': 'async-response-input-required',
 };
 
-const CATALOG_NOTIFICATION_TYPES = [
-  'product.created',
-  'product.updated',
-  'product.priced',
-  'product.removed',
-  'signal.created',
-  'signal.updated',
-  'signal.priced',
-  'signal.removed',
-  'catalog.bulk_change',
-] as const;
-
 /**
  * Map a consumer-provided version pin to the loader's bundle key.
  *
@@ -340,35 +328,6 @@ function loadJson(file: string): LoadedSchema {
   return JSON.parse(readFileSync(file, 'utf-8')) as LoadedSchema;
 }
 
-// Matches the 3.1-beta type surface widening for sync_accounts webhook
-// subscriptions while the upstream beta enum is still catching up.
-function supportsCatalogNotificationWidening(version: string, file: string): boolean {
-  if (!/^3\.1(?:\.0)?-beta(?:\.|$)/.test(version)) return false;
-  const normalized = file.split(path.sep).join('/');
-  return (
-    normalized.endsWith('/enums/notification-type.json') ||
-    normalized.endsWith('/account/sync-accounts-request.json') ||
-    normalized.endsWith('/bundled/account/sync-accounts-request.json')
-  );
-}
-
-function widenCatalogNotificationEnums(node: unknown): void {
-  if (node === null || typeof node !== 'object') return;
-  if (Array.isArray(node)) {
-    for (const item of node) widenCatalogNotificationEnums(item);
-    return;
-  }
-
-  const obj = node as Record<string, unknown>;
-  if (Array.isArray(obj.enum) && obj.enum.includes('creative.status_changed') && obj.enum.includes('creative.purged')) {
-    obj.enum = Array.from(new Set([...obj.enum, ...CATALOG_NOTIFICATION_TYPES]));
-  }
-
-  for (const value of Object.values(obj)) {
-    widenCatalogNotificationEnums(value);
-  }
-}
-
 /**
  * Clear `additionalProperties: false` at the response root so envelope
  * fields (`replayed`, `context`, `ext`, and future envelope additions)
@@ -552,9 +511,6 @@ function ensureCoreLoaded(s: LoaderState): void {
     for (const file of walkJsonFiles(abs)) {
       if (responseToolFiles.has(file)) continue;
       const schema = loadJson(file);
-      if (supportsCatalogNotificationWidening(s.version, file)) {
-        widenCatalogNotificationEnums(schema);
-      }
       if (typeof schema.$id === 'string' && !s.ajv.getSchema(schema.$id)) {
         s.ajv.addSchema(schema);
       }
@@ -594,9 +550,6 @@ export function getValidator(
   if (!fromBundled) ensureCoreLoaded(s);
 
   const rawSchema = loadJson(file);
-  if (supportsCatalogNotificationWidening(s.version, file)) {
-    widenCatalogNotificationEnums(rawSchema);
-  }
   const schema = direction === 'request' ? rawSchema : relaxResponseRoot(rawSchema);
   const existing = typeof schema.$id === 'string' ? s.ajv.getSchema(schema.$id) : undefined;
   const compiled = existing ?? s.ajv.compile(schema);

--- a/test/lib/v3-1-beta-notification-types.test.js
+++ b/test/lib/v3-1-beta-notification-types.test.js
@@ -2,219 +2,50 @@ const { test, describe } = require('node:test');
 const assert = require('node:assert');
 const { spawnSync } = require('node:child_process');
 const fs = require('node:fs');
+const os = require('node:os');
 const path = require('node:path');
 
 const repoRoot = path.join(__dirname, '..', '..');
 const betaTypesPath = path.join(repoRoot, 'src/lib/types/v3-1-beta/tools.generated.ts');
 const betaGeneratorPath = path.join(repoRoot, 'scripts/generate-3-1-beta-types.ts');
-const schemaLoaderPath = path.join(repoRoot, 'src/lib/validation/schema-loader.ts');
-const schemasDataRoot = path.join(repoRoot, 'dist/lib/schemas-data');
 
-const catalogNotificationTypes = [
-  'product.created',
-  'product.updated',
-  'product.priced',
-  'product.removed',
-  'signal.created',
-  'signal.updated',
-  'signal.priced',
-  'signal.removed',
-  'catalog.bulk_change',
-];
-
-function extractNotificationTypeBlock(src) {
-  const match = src.match(/export type NotificationType =\n([\s\S]*?);/);
-  assert.ok(match, 'NotificationType union should exist');
-  return match[1];
-}
-
-describe('v3.1-beta notification types', () => {
-  test('sync_accounts notification_configs accept catalog change events', () => {
-    const typesContent = fs.readFileSync(betaTypesPath, 'utf8');
-    const block = extractNotificationTypeBlock(typesContent);
-
-    for (const eventType of catalogNotificationTypes) {
-      assert.match(block, new RegExp(`'${eventType.replace('.', '\\.')}'`), `${eventType} must be in NotificationType`);
-    }
-
-    assert.match(
-      typesContent,
-      /event_types: NotificationType\[\];/,
-      'NotificationConfig.event_types should continue to use NotificationType'
-    );
-  });
-
-  test('3.1-beta type generation preserves catalog notification widening', () => {
+describe('v3.1-beta sync_accounts notification config types', () => {
+  test('codegen keeps concrete sync_accounts mode interfaces', () => {
     const generatorContent = fs.readFileSync(betaGeneratorPath, 'utf8');
+    const typesContent = fs.readFileSync(betaTypesPath, 'utf8');
 
-    assert.match(generatorContent, /function widenCatalogNotificationTypes/, 'generator must preserve the widening');
-    for (const eventType of catalogNotificationTypes) {
-      assert.match(
-        generatorContent,
-        new RegExp(`'${eventType.replace('.', '\\.')}'`),
-        `${eventType} must be preserved by the generator`
-      );
-    }
+    assert.match(generatorContent, /function tightenSyncAccountsModeTypes/);
+    assert.match(typesContent, /export interface ProvisioningMode \{\n\s+brand: BrandReference;/);
+    assert.match(typesContent, /export interface SettingsUpdateMode \{\n\s+account: AccountReference;/);
+    assert.match(typesContent, /notification_configs\?: NotificationConfig\[\];/);
   });
 
-  test('schema validation widens the same notification enum at load time', () => {
-    const loaderContent = fs.readFileSync(schemaLoaderPath, 'utf8');
+  test('SyncAccountsRequest accepts account notifications but not catalog feed events', () => {
+    const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'v31-sync-accounts-types-'));
+    const fixturePath = path.join(fixtureDir, 'typecheck.ts');
+    const importPath = path.relative(fixtureDir, path.join(repoRoot, 'src/lib/types/v3-1-beta')).replace(/\\/g, '/');
+    const modulePath = importPath.startsWith('.') ? importPath : `./${importPath}`;
 
-    assert.match(
-      loaderContent,
-      /function widenCatalogNotificationEnums/,
-      'schema loader must preserve runtime widening'
-    );
-    assert.match(
-      loaderContent,
-      /supportsCatalogNotificationWidening\(s\.version, file\)/,
-      'runtime widening should be gated by the resolved schema version'
-    );
-    for (const eventType of catalogNotificationTypes) {
-      assert.match(
-        loaderContent,
-        new RegExp(`'${eventType.replace('.', '\\.')}'`),
-        `${eventType} must be accepted by runtime schema validation`
-      );
-    }
-  });
-
-  test('runtime schema widening is limited to 3.1 bundles', () => {
-    let validation;
-    let loader;
-    try {
-      validation = require('../../dist/lib/validation/schema-validator.js');
-      loader = require('../../dist/lib/validation/schema-loader.js');
-    } catch (err) {
-      assert.match(err.message, /Cannot find module/, 'unexpected dist import failure');
-      return;
-    }
-
-    const betaDir = path.join(schemasDataRoot, '3.1-beta.test');
-    const stable31Dir = path.join(schemasDataRoot, '3.1');
-    const future310Dir = path.join(schemasDataRoot, '3.10');
-    const controlDir = path.join(schemasDataRoot, '9.9');
-    const stable31BackupDir = path.join(schemasDataRoot, '.v31-notification-stable-backup');
-    const writeFixture = dir => {
-      fs.mkdirSync(path.join(dir, 'bundled', 'account'), { recursive: true });
-      fs.writeFileSync(
-        path.join(dir, 'bundled', 'account', 'sync-accounts-request.json'),
-        JSON.stringify(
-          {
-            $id: `/schemas/${path.basename(dir)}/bundled/account/sync-accounts-request.json`,
-            type: 'object',
-            properties: {
-              idempotency_key: { type: 'string' },
-              accounts: {
-                type: 'array',
-                items: {
-                  type: 'object',
-                  properties: {
-                    account: {
-                      type: 'object',
-                      properties: { account_id: { type: 'string' } },
-                      required: ['account_id'],
-                      additionalProperties: false,
-                    },
-                    notification_configs: {
-                      type: 'array',
-                      items: {
-                        type: 'object',
-                        properties: {
-                          subscriber_id: { type: 'string' },
-                          url: { type: 'string' },
-                          event_types: {
-                            type: 'array',
-                            items: {
-                              enum: ['creative.status_changed', 'creative.purged'],
-                            },
-                          },
-                        },
-                        required: ['subscriber_id', 'url', 'event_types'],
-                        additionalProperties: false,
-                      },
-                    },
-                  },
-                  required: ['account', 'notification_configs'],
-                  additionalProperties: false,
-                },
-              },
-            },
-            required: ['idempotency_key', 'accounts'],
-            additionalProperties: false,
-          },
-          null,
-          2
-        )
-      );
-    };
-
-    fs.rmSync(betaDir, { recursive: true, force: true });
-    fs.rmSync(stable31BackupDir, { recursive: true, force: true });
-    if (fs.existsSync(stable31Dir)) {
-      fs.cpSync(stable31Dir, stable31BackupDir, { recursive: true });
-    }
-    fs.rmSync(stable31Dir, { recursive: true, force: true });
-    fs.rmSync(future310Dir, { recursive: true, force: true });
-    fs.rmSync(controlDir, { recursive: true, force: true });
-    writeFixture(betaDir);
-    writeFixture(stable31Dir);
-    writeFixture(future310Dir);
-    writeFixture(controlDir);
-
-    try {
-      const payload = {
-        idempotency_key: 'catalog-webhook-1',
-        accounts: [
-          {
-            account: { account_id: 'acc_acme_pinnacle' },
-            notification_configs: [
-              {
-                subscriber_id: 'catalog-sync',
-                url: 'https://buyer.example/webhooks/adcp/catalog',
-                event_types: ['product.created', 'catalog.bulk_change'],
-              },
-            ],
-          },
-        ],
-      };
-
-      loader._resetValidationLoader();
-      assert.strictEqual(validation.validateRequest('sync_accounts', payload, '3.1-beta.test').valid, true);
-      assert.strictEqual(validation.validateRequest('sync_accounts', payload, '3.1.0').valid, false);
-      assert.strictEqual(validation.validateRequest('sync_accounts', payload, '3.10.0').valid, false);
-      assert.strictEqual(validation.validateRequest('sync_accounts', payload, '9.9.0').valid, false);
-    } finally {
-      loader._resetValidationLoader();
-      fs.rmSync(betaDir, { recursive: true, force: true });
-      fs.rmSync(stable31Dir, { recursive: true, force: true });
-      fs.rmSync(future310Dir, { recursive: true, force: true });
-      if (fs.existsSync(stable31BackupDir)) {
-        fs.cpSync(stable31BackupDir, stable31Dir, { recursive: true });
-        fs.rmSync(stable31BackupDir, { recursive: true, force: true });
-      }
-      fs.rmSync(controlDir, { recursive: true, force: true });
-    }
-  });
-
-  test('SyncAccountsRequest carries NotificationType through settings-update mode', () => {
-    const fixturePath = path.join(repoRoot, '.context', 'v31-notification-typecheck.ts');
-    fs.mkdirSync(path.dirname(fixturePath), { recursive: true });
     fs.writeFileSync(
       fixturePath,
       `
-import type { SyncAccountsRequest } from '../src/lib/types/v3-1-beta';
+import type { SyncAccountsRequest } from '${modulePath}';
 
-const ok: SyncAccountsRequest = {
-  idempotency_key: 'catalog-webhook-1',
+const provisioning: SyncAccountsRequest = {
+  idempotency_key: 'provisioning-notification-config',
   accounts: [
     {
-      account: { account_id: 'acc_acme_pinnacle' },
+      brand: {
+        domain: 'acme.example',
+        brand_id: 'brand_acme',
+      },
+      operator: 'acme-direct',
+      billing: 'advertiser',
       notification_configs: [
         {
-          subscriber_id: 'catalog-sync',
-          url: 'https://buyer.example/webhooks/adcp/catalog',
-          event_types: ['product.created', 'catalog.bulk_change'],
+          subscriber_id: 'creative-sync',
+          url: 'https://buyer.example/webhooks/adcp/creative',
+          event_types: ['creative.status_changed'],
           active: true,
         },
       ],
@@ -222,8 +53,24 @@ const ok: SyncAccountsRequest = {
   ],
 };
 
-const badEvent: SyncAccountsRequest = {
-  idempotency_key: 'catalog-webhook-2',
+const settingsUpdate: SyncAccountsRequest = {
+  idempotency_key: 'settings-notification-config',
+  accounts: [
+    {
+      account: { account_id: 'acc_acme_pinnacle' },
+      notification_configs: [
+        {
+          subscriber_id: 'creative-sync',
+          url: 'https://buyer.example/webhooks/adcp/creative',
+          event_types: ['creative.purged'],
+        },
+      ],
+    },
+  ],
+};
+
+const catalogFeedEventOnAccountNotifications: SyncAccountsRequest = {
+  idempotency_key: 'catalog-event-wrong-surface',
   accounts: [
     {
       account: { account_id: 'acc_acme_pinnacle' },
@@ -231,16 +78,17 @@ const badEvent: SyncAccountsRequest = {
         {
           subscriber_id: 'catalog-sync',
           url: 'https://buyer.example/webhooks/adcp/catalog',
-          // @ts-expect-error - unknown catalog notification events are rejected.
-          event_types: ['not.a.real.event'],
+          // @ts-expect-error - catalog feed events are advertised via catalog_change_feed, not sync_accounts notification_configs.
+          event_types: ['product.created'],
         },
       ],
     },
   ],
 };
 
-void ok;
-void badEvent;
+void provisioning;
+void settingsUpdate;
+void catalogFeedEventOnAccountNotifications;
 `
     );
 
@@ -260,11 +108,16 @@ void badEvent;
           '--skipLibCheck',
           fixturePath,
         ],
-        { cwd: repoRoot, encoding: 'utf8', timeout: 30_000 }
+        {
+          cwd: repoRoot,
+          encoding: 'utf8',
+          timeout: 30000,
+        }
       );
-      assert.strictEqual(result.status, 0, `${result.stdout}\n${result.stderr}`);
+
+      assert.strictEqual(result.status, 0, result.stderr || result.stdout);
     } finally {
-      fs.rmSync(fixturePath, { force: true });
+      fs.rmSync(fixtureDir, { recursive: true, force: true });
     }
   });
 });

--- a/test/lib/v3-1-beta-notification-types.test.js
+++ b/test/lib/v3-1-beta-notification-types.test.js
@@ -1,0 +1,266 @@
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const repoRoot = path.join(__dirname, '..', '..');
+const betaTypesPath = path.join(repoRoot, 'src/lib/types/v3-1-beta/tools.generated.ts');
+const betaGeneratorPath = path.join(repoRoot, 'scripts/generate-3-1-beta-types.ts');
+const schemaLoaderPath = path.join(repoRoot, 'src/lib/validation/schema-loader.ts');
+const schemasDataRoot = path.join(repoRoot, 'dist/lib/schemas-data');
+
+const catalogNotificationTypes = [
+  'product.created',
+  'product.updated',
+  'product.priced',
+  'product.removed',
+  'signal.created',
+  'signal.updated',
+  'signal.priced',
+  'signal.removed',
+  'catalog.bulk_change',
+];
+
+function extractNotificationTypeBlock(src) {
+  const match = src.match(/export type NotificationType =\n([\s\S]*?);/);
+  assert.ok(match, 'NotificationType union should exist');
+  return match[1];
+}
+
+describe('v3.1-beta notification types', () => {
+  test('sync_accounts notification_configs accept catalog change events', () => {
+    const typesContent = fs.readFileSync(betaTypesPath, 'utf8');
+    const block = extractNotificationTypeBlock(typesContent);
+
+    for (const eventType of catalogNotificationTypes) {
+      assert.match(block, new RegExp(`'${eventType.replace('.', '\\.')}'`), `${eventType} must be in NotificationType`);
+    }
+
+    assert.match(
+      typesContent,
+      /event_types: NotificationType\[\];/,
+      'NotificationConfig.event_types should continue to use NotificationType'
+    );
+  });
+
+  test('3.1-beta type generation preserves catalog notification widening', () => {
+    const generatorContent = fs.readFileSync(betaGeneratorPath, 'utf8');
+
+    assert.match(generatorContent, /function widenCatalogNotificationTypes/, 'generator must preserve the widening');
+    for (const eventType of catalogNotificationTypes) {
+      assert.match(
+        generatorContent,
+        new RegExp(`'${eventType.replace('.', '\\.')}'`),
+        `${eventType} must be preserved by the generator`
+      );
+    }
+  });
+
+  test('schema validation widens the same notification enum at load time', () => {
+    const loaderContent = fs.readFileSync(schemaLoaderPath, 'utf8');
+
+    assert.match(loaderContent, /function widenCatalogNotificationEnums/, 'schema loader must preserve runtime widening');
+    assert.match(
+      loaderContent,
+      /supportsCatalogNotificationWidening\(s\.version, file\)/,
+      'runtime widening should be gated by the resolved schema version'
+    );
+    for (const eventType of catalogNotificationTypes) {
+      assert.match(
+        loaderContent,
+        new RegExp(`'${eventType.replace('.', '\\.')}'`),
+        `${eventType} must be accepted by runtime schema validation`
+      );
+    }
+  });
+
+  test('runtime schema widening is limited to 3.1 bundles', () => {
+    let validation;
+    let loader;
+    try {
+      validation = require('../../dist/lib/validation/schema-validator.js');
+      loader = require('../../dist/lib/validation/schema-loader.js');
+    } catch (err) {
+      assert.match(err.message, /Cannot find module/, 'unexpected dist import failure');
+      return;
+    }
+
+    const betaDir = path.join(schemasDataRoot, '3.1-beta.test');
+    const stable31Dir = path.join(schemasDataRoot, '3.1');
+    const future310Dir = path.join(schemasDataRoot, '3.10');
+    const controlDir = path.join(schemasDataRoot, '9.9');
+    const stable31BackupDir = path.join(schemasDataRoot, '.v31-notification-stable-backup');
+    const writeFixture = dir => {
+      fs.mkdirSync(path.join(dir, 'bundled', 'account'), { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, 'bundled', 'account', 'sync-accounts-request.json'),
+        JSON.stringify(
+          {
+            $id: `/schemas/${path.basename(dir)}/bundled/account/sync-accounts-request.json`,
+            type: 'object',
+            properties: {
+              idempotency_key: { type: 'string' },
+              accounts: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    account: {
+                      type: 'object',
+                      properties: { account_id: { type: 'string' } },
+                      required: ['account_id'],
+                      additionalProperties: false,
+                    },
+                    notification_configs: {
+                      type: 'array',
+                      items: {
+                        type: 'object',
+                        properties: {
+                          subscriber_id: { type: 'string' },
+                          url: { type: 'string' },
+                          event_types: {
+                            type: 'array',
+                            items: {
+                              enum: ['creative.status_changed', 'creative.purged'],
+                            },
+                          },
+                        },
+                        required: ['subscriber_id', 'url', 'event_types'],
+                        additionalProperties: false,
+                      },
+                    },
+                  },
+                  required: ['account', 'notification_configs'],
+                  additionalProperties: false,
+                },
+              },
+            },
+            required: ['idempotency_key', 'accounts'],
+            additionalProperties: false,
+          },
+          null,
+          2
+        )
+      );
+    };
+
+    fs.rmSync(betaDir, { recursive: true, force: true });
+    fs.rmSync(stable31BackupDir, { recursive: true, force: true });
+    if (fs.existsSync(stable31Dir)) {
+      fs.cpSync(stable31Dir, stable31BackupDir, { recursive: true });
+    }
+    fs.rmSync(stable31Dir, { recursive: true, force: true });
+    fs.rmSync(future310Dir, { recursive: true, force: true });
+    fs.rmSync(controlDir, { recursive: true, force: true });
+    writeFixture(betaDir);
+    writeFixture(stable31Dir);
+    writeFixture(future310Dir);
+    writeFixture(controlDir);
+
+    try {
+      const payload = {
+        idempotency_key: 'catalog-webhook-1',
+        accounts: [
+          {
+            account: { account_id: 'acc_acme_pinnacle' },
+            notification_configs: [
+              {
+                subscriber_id: 'catalog-sync',
+                url: 'https://buyer.example/webhooks/adcp/catalog',
+                event_types: ['product.created', 'catalog.bulk_change'],
+              },
+            ],
+          },
+        ],
+      };
+
+      loader._resetValidationLoader();
+      assert.strictEqual(validation.validateRequest('sync_accounts', payload, '3.1-beta.test').valid, true);
+      assert.strictEqual(validation.validateRequest('sync_accounts', payload, '3.1.0').valid, false);
+      assert.strictEqual(validation.validateRequest('sync_accounts', payload, '3.10.0').valid, false);
+      assert.strictEqual(validation.validateRequest('sync_accounts', payload, '9.9.0').valid, false);
+    } finally {
+      loader._resetValidationLoader();
+      fs.rmSync(betaDir, { recursive: true, force: true });
+      fs.rmSync(stable31Dir, { recursive: true, force: true });
+      fs.rmSync(future310Dir, { recursive: true, force: true });
+      if (fs.existsSync(stable31BackupDir)) {
+        fs.cpSync(stable31BackupDir, stable31Dir, { recursive: true });
+        fs.rmSync(stable31BackupDir, { recursive: true, force: true });
+      }
+      fs.rmSync(controlDir, { recursive: true, force: true });
+    }
+  });
+
+  test('SyncAccountsRequest carries NotificationType through settings-update mode', () => {
+    const fixturePath = path.join(repoRoot, '.context', 'v31-notification-typecheck.ts');
+    fs.mkdirSync(path.dirname(fixturePath), { recursive: true });
+    fs.writeFileSync(
+      fixturePath,
+      `
+import type { SyncAccountsRequest } from '../src/lib/types/v3-1-beta';
+
+const ok: SyncAccountsRequest = {
+  idempotency_key: 'catalog-webhook-1',
+  accounts: [
+    {
+      account: { account_id: 'acc_acme_pinnacle' },
+      notification_configs: [
+        {
+          subscriber_id: 'catalog-sync',
+          url: 'https://buyer.example/webhooks/adcp/catalog',
+          event_types: ['product.created', 'catalog.bulk_change'],
+          active: true,
+        },
+      ],
+    },
+  ],
+};
+
+const badEvent: SyncAccountsRequest = {
+  idempotency_key: 'catalog-webhook-2',
+  accounts: [
+    {
+      account: { account_id: 'acc_acme_pinnacle' },
+      notification_configs: [
+        {
+          subscriber_id: 'catalog-sync',
+          url: 'https://buyer.example/webhooks/adcp/catalog',
+          // @ts-expect-error - unknown catalog notification events are rejected.
+          event_types: ['not.a.real.event'],
+        },
+      ],
+    },
+  ],
+};
+
+void ok;
+void badEvent;
+`
+    );
+
+    try {
+      const result = spawnSync(
+        'npx',
+        [
+          'tsc',
+          '--noEmit',
+          '--strict',
+          '--target',
+          'ES2022',
+          '--module',
+          'NodeNext',
+          '--moduleResolution',
+          'NodeNext',
+          '--skipLibCheck',
+          fixturePath,
+        ],
+        { cwd: repoRoot, encoding: 'utf8', timeout: 30_000 }
+      );
+      assert.strictEqual(result.status, 0, `${result.stdout}\n${result.stderr}`);
+    } finally {
+      fs.rmSync(fixturePath, { force: true });
+    }
+  });
+});

--- a/test/lib/v3-1-beta-notification-types.test.js
+++ b/test/lib/v3-1-beta-notification-types.test.js
@@ -60,7 +60,11 @@ describe('v3.1-beta notification types', () => {
   test('schema validation widens the same notification enum at load time', () => {
     const loaderContent = fs.readFileSync(schemaLoaderPath, 'utf8');
 
-    assert.match(loaderContent, /function widenCatalogNotificationEnums/, 'schema loader must preserve runtime widening');
+    assert.match(
+      loaderContent,
+      /function widenCatalogNotificationEnums/,
+      'schema loader must preserve runtime widening'
+    );
     assert.match(
       loaderContent,
       /supportsCatalogNotificationWidening\(s\.version, file\)/,


### PR DESCRIPTION
## Summary

Adds 3.1-beta opt-in support for registering catalog-change webhook subscribers through `sync_accounts.accounts[].notification_configs`.

## Changes

- Expands the 3.1-beta `NotificationType` surface with `product.*`, `signal.*`, and `catalog.bulk_change` event types.
- Tightens the 3.1-beta `SyncAccountsRequest` account-entry mode types so `notification_configs` flows through the actual exported request shape.
- Applies the matching runtime schema widening only for 3.1-beta sync-account/notification enum schemas, avoiding GA/default schema drift.
- Adds focused tests for generated types, runtime validation scoping, and the concrete `SyncAccountsRequest` type path.

## Validation

- Expert review: protocol reviewer, code reviewer, and Node.js testing reviewer.
- `npm run build:lib`
- `npm run typecheck`
- `node --test test/lib/v3-1-beta-notification-types.test.js test/lib/catalog-sync.test.js`
- pre-push validation hook