### PR TITLE
chore: enter changesets pre-mode (tag: beta) — recover from accidental 8.0.0 GA publish

### DIFF
--- a/.changeset/enter-pre-mode-beta.md
+++ b/.changeset/enter-pre-mode-beta.md
@@ -1,0 +1,11 @@
+---
+'@adcp/sdk': patch
+---
+
+chore: enter changesets pre-mode (tag `beta`) on `main`
+
+Following the accidental GA publish of `8.0.0`, the 8.x line moves into a beta cycle. From this commit forward, every changeset on `main` accumulates into a prerelease (`8.0.1-beta.N` for patch, `8.1.0-beta.N` for minor, `9.0.0-beta.N` for major) and ships under the `@beta` npm dist-tag.
+
+The `latest` dist-tag is moved back to `7.11.0` separately via `npm dist-tag add @adcp/sdk@7.11.0 latest`, so `npm install @adcp/sdk` continues to resolve to the stable `7.x` line.
+
+To exit pre-mode and ship a real GA, run `npx changeset pre exit` on `main` and merge the resulting Release PR.

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,10 @@
+{
+  "mode": "pre",
+  "tag": "beta",
+  "initialVersions": {
+    "@adcp/sdk": "8.0.0",
+    "@adcp/client": "6.0.0",
+    "@adcp/eslint-plugin": "0.1.2"
+  },
+  "changesets": []
+}


### PR DESCRIPTION
**Recovery for the accidental \`8.0.0\` GA publish.** Enters changesets pre-mode on \`main\` so every subsequent release accumulates as a \`@beta\` prerelease instead of going out as a GA.

## Background

\`8.0.0\` shipped to npm as a regular GA release via release PR #1930, driven by a single \`major\` changeset on PR #1932 (catalog-sync → wholesale-feed-sync rename). The 8.0-beta foundation work (#1902 — full \`3.1.0-beta.2\` pin flip) was never merged; the 8.0.0 that exists is **just the rename plus a few minor/patch items**, not the full 3.1 adoption sweep.

## What this PR does

- Adds \`.changeset/pre.json\` (mode: \`pre\`, tag: \`beta\`).
- After merge, every changeset on \`main\` accumulates into a prerelease:
  - \`patch\` → \`8.0.1-beta.N\`
  - \`minor\` → \`8.1.0-beta.N\`
  - \`major\` → \`9.0.0-beta.N\`
- Releases publish under the \`@beta\` npm dist-tag automatically.

## Required npm-side moves (run from a publish-credentialed shell)

\`\`\`bash
npm dist-tag add @adcp/sdk@7.11.0 latest
npm dist-tag add @adcp/sdk@8.0.0   beta
npm deprecate @adcp/sdk@8.0.0 "Released as GA prematurely; treat as 8.0.0-beta. The 8.x line iterates as 8.0.1-beta.N under @beta dist-tag before re-promoting to @latest. For stable, pin to 7.11.0."
\`\`\`

After those run:
- \`npm install @adcp/sdk\` → 7.11.0 (stable)
- \`npm install @adcp/sdk@beta\` → 8.0.0 today, 8.0.1-beta.N after the first post-merge release

## Exit criteria

When the 3.1.0-beta.x adoption work is complete and dogfooded, run on \`main\`:

\`\`\`bash
npx changeset pre exit
# commit + push the resulting .changeset/pre.json removal
# merge the auto-generated Release PR → ships as 8.0.x or 8.1.0 (depending on accumulated changeset types)
# move @latest dist-tag forward: npm dist-tag add @adcp/sdk@<new-version> latest
\`\`\`

## Coordinates with the existing 8.0-beta foundation work

\`bokelley/cut-8-0-beta\` (PR #1902) was scoped to the \`3.1.0-beta.2\` pin flip + 5 structural-break follow-ups (all already merged into that branch). After this pre-mode PR lands, that branch should be rebased on the new main. The foundation's \`major\` changeset means the first release after foundation-merge will be \`9.0.0-beta.0\` (semver-wise) — or you can demote the changeset to \`minor\` if you want to stay on the 8.x line.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>