### PR TITLE
feat(capabilities): project supported_optimization_metrics + frequency_capping; add catalog-rollup helper

### DIFF
--- a/.changeset/1853-1818-capability-projection.md
+++ b/.changeset/1853-1818-capability-projection.md
@@ -1,0 +1,44 @@
+---
+'@adcp/sdk': minor
+---
+
+feat(capabilities): project `supported_optimization_metrics` + `frequency_capping`; add catalog-rollup helper
+
+Closes #1853 (projection gap) and #1818 (catalog rollup).
+
+**The projection gap (#1853)**
+
+AdCP 3.1 added two top-level `media_buy.*` capability fields:
+
+- `supported_optimization_metrics` (adcp#4669) — seller-level rollup of optimization metrics
+- `frequency_capping` (adcp#4670) — presence-only object declaring frequency-cap support
+
+`from-platform.ts` only projected three rich blocks (`audience_targeting`, `conversion_tracking`, `content_standards`). Adopters who declared the new fields on `platform.capabilities` saw them silently dropped from the wire response. Now wired into the same `overrides.media_buy` deep-merge seam.
+
+**Typed surface** (`DecisioningCapabilities`):
+
+```ts
+capabilities: {
+  supported_optimization_metrics?: ('clicks' | 'views' | 'completed_views' | ...)[];
+  frequency_capping?: {
+    supported_per_units?: ('impression' | 'click')[];
+    supported_window_units?: ('hour' | 'day' | 'week' | 'month')[];
+  };
+}
+```
+
+Both are optional. Unlike the older three blocks, **the 3.1 additions do NOT force a `features.*` boolean** — buyers gate on presence-of-block directly.
+
+**The catalog rollup helper (#1818)**
+
+New exported helper `rollupOptimizationMetricsFromProducts(products)` computes the seller-level union from a product catalog. Returns a sorted, deduplicated array. Adopters call it at startup or on catalog mutation to keep the seller-level declaration mechanically derived from product-level facts — closes the drift surface called out in #1818.
+
+The `conversion_tracking.supported_targets` portion of #1818 is intentionally deferred — `value_field` support isn't tracked per-product today, so a full rollup isn't mechanical. Adopters declare that field manually until the spec gives us a per-product signal.
+
+**Verification**
+
+- 8 unit tests on the rollup helper (union, dedup, sort, empty, defensive-drop, non-mutating)
+- 3 new integration tests on the projection
+- All 25 affected tests pass; `tsc --noEmit --project tsconfig.lib.json` clean
+
+Part of the 8.1.0-beta.N adoption sweep.

--- a/docs/TYPE-SUMMARY.md
+++ b/docs/TYPE-SUMMARY.md
@@ -1,7 +1,7 @@
 # AdCP Type Summary
 
-> Generated at: 2026-05-17
-> @adcp/sdk v7.5.0
+> Generated at: 2026-05-22
+> @adcp/sdk v8.1.0-beta.0
 
 Curated reference of the types that matter for using the AdCP client. For full generated types see `src/lib/types/tools.generated.ts` and `src/lib/types/core.generated.ts`.
 
@@ -88,13 +88,16 @@ _Response (success branch):_
   request_signing: object
   webhook_signing: object
   identity: object
+  measurement: object
   compliance_testing: object
   specialisms: object[]
   extensions_supported: string[]
   experimental_features: string[]
+  wholesale_feed_versioning: object
   last_updated: string
   errors: object[]
   context: Context
+  wholesale_feed_webhooks: object
 }
 ```
 
@@ -233,6 +236,8 @@ _Request:_
   fields: string[]
   time_budget
   pagination: Pagination Request
+  if_wholesale_feed_version: string
+  if_pricing_version: string
   context: Context
   required_policies: string[]
 }
@@ -241,14 +246,20 @@ _Request:_
 _Response (success branch):_
 ```
 {
-  products: object[]  // required
+  products: object[]
+  extensions: object
   proposals: object[]
   errors: object[]
   property_list_applied: boolean
   catalog_applied: boolean
   refinement_applied: object[]
   incomplete: object[]
+  filter_diagnostics: object
   pagination: Pagination Response
+  wholesale_feed_version: string
+  pricing_version: string
+  cache_scope: 'public' | 'account'
+  unchanged: 'true'
   sandbox: boolean
   context: Context
 }
@@ -267,6 +278,8 @@ _Request:_
   min_height: integer
   is_responsive: boolean
   name_search: string
+  publisher_domain: string
+  property_id: Property Id
   wcag_level: Wcag Level
   disclosure_positions: object[]
   disclosure_persistence: object[]
@@ -281,6 +294,7 @@ _Response (success branch):_
 ```
 {
   formats: object[]  // required
+  source: 'publisher' | 'aao_mirror' | 'agent_derived'
   creative_agents: object[]
   errors: object[]
   pagination: Pagination Response
@@ -322,11 +336,15 @@ _Response (success branch):_
   packages: object[]  // required
   account: Account
   invoice_recipient: Business Entity
+  media_buy_status: Media Buy Status
   status: Media Buy Status
   confirmed_at: string
   creative_deadline: string
   revision: integer
+  currency: string
+  total_budget: number
   valid_actions: object[]
+  available_actions: object[]
   planned_delivery: Planned Delivery
   sandbox: boolean
   context: Context
@@ -360,12 +378,16 @@ _Response (success branch):_
 ```
 {
   media_buy_id: string  // required
+  media_buy_status: Media Buy Status
   status: Media Buy Status
   revision: integer
+  currency: string
+  total_budget: number
   implementation_date: string,null
   invoice_recipient: Business Entity
   affected_packages: object[]
   valid_actions: object[]
+  available_actions: object[]
   sandbox: boolean
   context: Context
 }
@@ -381,6 +403,8 @@ _Request:_
   status_filter: Media Buy Status | object[]
   include_snapshot: boolean
   include_history: integer
+  include_webhook_activity: boolean
+  webhook_activity_limit: integer
   pagination: Pagination Request
   context: Context
 }
@@ -408,6 +432,8 @@ _Request:_
   start_date: string
   end_date: string
   include_package_daily_breakdown: boolean
+  time_granularity: Reporting Frequency
+  include_window_breakdown: boolean
   attribution_window: object
   reporting_dimensions: object
   context: Context
@@ -626,8 +652,8 @@ _Response (success branch):_
 {
   response_type: 'single'  // required
   previews: object[]  // required
-  expires_at: string  // required
   interactive_url: string
+  expires_at: string
   context: Context
 }
 ```
@@ -712,6 +738,9 @@ _Request:_
   include_items: boolean
   include_variables: boolean
   include_pricing: boolean
+  include_purged: boolean
+  include_webhook_activity: boolean
+  webhook_activity_limit: integer
   account: Account Ref
   fields: string[]
   context: Context
@@ -760,6 +789,23 @@ _Response (success branch):_
 }
 ```
 
+**`validate_input`** — Request parameters for validating a creative manifest against canonical formats and/or specific products without committing to a render.
+
+_Request:_
+```
+{
+  manifest: Creative Manifest  // required
+  targets: object[]
+}
+```
+
+_Response (success branch):_
+```
+{
+  results: object[]  // required
+}
+```
+
 ### Signals
 
 **`get_signals`** — Request parameters for discovering signals based on description.
@@ -767,6 +813,7 @@ _Response (success branch):_
 _Request:_
 ```
 {
+  discovery_mode: 'brief' | 'wholesale'
   account: Account Ref
   signal_spec: string
   signal_ids: object[]
@@ -775,6 +822,8 @@ _Request:_
   filters: Signal Filters
   max_results: integer
   pagination: Pagination Request
+  if_wholesale_feed_version: string
+  if_pricing_version: string
   context: Context
 }
 ```
@@ -782,8 +831,13 @@ _Request:_
 _Response (success branch):_
 ```
 {
-  signals: object[]  // required
+  signals: object[]
   errors: object[]
+  incomplete: object[]
+  wholesale_feed_version: string
+  pricing_version: string
+  cache_scope: 'public' | 'account'
+  unchanged: 'true'
   pagination: Pagination Response
   sandbox: boolean
   context: Context
@@ -1283,7 +1337,7 @@ _Response (success branch):_
 ```
 {
   outcome_id: string  // required
-  status: 'accepted' | 'findings'  // required
+  outcome_state: 'accepted' | 'findings'  // required
   committed_budget: number
   findings: object[]
   plan_summary: object
@@ -1338,7 +1392,7 @@ _Response (success branch):_
 ```
 {
   check_id: string  // required
-  status: Governance Decision  // required
+  verdict: Governance Decision  // required
   plan_id: string  // required
   explanation: string  // required
   findings: object[]

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,7 +1,7 @@
 # Ad Context Protocol (AdCP)
 
-> Generated at: 2026-05-17
-> Library: @adcp/sdk v7.5.0
+> Generated at: 2026-05-22
+> Library: @adcp/sdk v8.1.0-beta.0
 > AdCP major version: 3
 > Canonical URL: https://adcontextprotocol.github.io/adcp-client/llms.txt
 > Note: the `Library` stamp reflects the package.json version at doc-generation time. The narrative below describes the surface that lands on the next-published minor — including any 6.7 helpers documented here ahead of the release tag.
@@ -233,7 +233,7 @@ Request parameters for cross-protocol capability discovery.
 
 **Response (success branch):**
 - Required: `adcp: object`, `supported_protocols: string[]`
-- Optional: `account: object`, `media_buy: object`, `signals: object`, `governance: object`, `sponsored_intelligence: object`, `brand: object`, `creative: object`, `request_signing: object`, +9 more
+- Optional: `account: object`, `media_buy: object`, `signals: object`, `governance: object`, `sponsored_intelligence: object`, `brand: object`, `creative: object`, `request_signing: object`, +12 more
 
 ### Account Management
 
@@ -307,22 +307,21 @@ Request parameters for discovering available advertising products.
 
 **Request:**
 - Required: `buying_mode: 'brief' | 'wholesale' | 'refine'`
-- Optional: `brief: string`, `refine: object[]`, `brand: Brand Ref`, `catalog: Catalog`, `account: Account Ref`, `preferred_delivery_types: object[]`, `filters: Product Filters`, `property_list: Property List Ref`, +5 more
+- Optional: `brief: string`, `refine: object[]`, `brand: Brand Ref`, `catalog: Catalog`, `account: Account Ref`, `preferred_delivery_types: object[]`, `filters: Product Filters`, `property_list: Property List Ref`, +7 more
 
 **Response (success branch):**
-- Required: `products: object[]`
-- Optional: `proposals: object[]`, `errors: object[]`, `property_list_applied: boolean`, `catalog_applied: boolean`, `refinement_applied: object[]`, `incomplete: object[]`, `pagination: Pagination Response`, `sandbox: boolean`, +1 more
+- Optional: `products: object[]`, `extensions: object`, `proposals: object[]`, `errors: object[]`, `property_list_applied: boolean`, `catalog_applied: boolean`, `refinement_applied: object[]`, `incomplete: object[]`, +8 more
 
 #### `list_creative_formats`
 
 Request parameters for discovering format IDs and creative agents supported by this sales agent.
 
 **Request:**
-- Optional: `format_ids: object[]`, `asset_types: object[]`, `max_width: integer`, `max_height: integer`, `min_width: integer`, `min_height: integer`, `is_responsive: boolean`, `name_search: string`, +7 more
+- Optional: `format_ids: object[]`, `asset_types: object[]`, `max_width: integer`, `max_height: integer`, `min_width: integer`, `min_height: integer`, `is_responsive: boolean`, `name_search: string`, +9 more
 
 **Response (success branch):**
 - Required: `formats: object[]`
-- Optional: `creative_agents: object[]`, `errors: object[]`, `pagination: Pagination Response`, `sandbox: boolean`, `context: Context`
+- Optional: `source: 'publisher' | 'aao_mirror' | 'agent_derived'`, `creative_agents: object[]`, `errors: object[]`, `pagination: Pagination Response`, `sandbox: boolean`, `context: Context`
 
 **Watch out:**
 - Each `renders[]` entry satisfies a `oneOf` — exactly one of `dimensions` (object) OR `parameters_from_format_id: true`. A render with only `{ role }` (or `{ role, duration_seconds }`) fails validation.
@@ -339,7 +338,7 @@ Request parameters for creating a media buy.
 
 **Response (success branch):**
 - Required: `media_buy_id: string`, `packages: object[]`
-- Optional: `account: Account`, `invoice_recipient: Business Entity`, `status: Media Buy Status`, `confirmed_at: string`, `creative_deadline: string`, `revision: integer`, `valid_actions: object[]`, `planned_delivery: Planned Delivery`, +2 more
+- Optional: `account: Account`, `invoice_recipient: Business Entity`, `media_buy_status: Media Buy Status`, `status: Media Buy Status`, `confirmed_at: string`, `creative_deadline: string`, `revision: integer`, `currency: string`, +6 more
 
 #### `update_media_buy`
 
@@ -351,14 +350,14 @@ Request parameters for updating campaign and package settings.
 
 **Response (success branch):**
 - Required: `media_buy_id: string`
-- Optional: `status: Media Buy Status`, `revision: integer`, `implementation_date: string,null`, `invoice_recipient: Business Entity`, `affected_packages: object[]`, `valid_actions: object[]`, `sandbox: boolean`, `context: Context`
+- Optional: `media_buy_status: Media Buy Status`, `status: Media Buy Status`, `revision: integer`, `currency: string`, `total_budget: number`, `implementation_date: string,null`, `invoice_recipient: Business Entity`, `affected_packages: object[]`, +4 more
 
 #### `get_media_buys`
 
 Request parameters for retrieving media buy status, creative approvals, and delivery snapshots.
 
 **Request:**
-- Optional: `account: Account Ref`, `media_buy_ids: string[]`, `status_filter: Media Buy Status | object[]`, `include_snapshot: boolean`, `include_history: integer`, `pagination: Pagination Request`, `context: Context`
+- Optional: `account: Account Ref`, `media_buy_ids: string[]`, `status_filter: Media Buy Status | object[]`, `include_snapshot: boolean`, `include_history: integer`, `include_webhook_activity: boolean`, `webhook_activity_limit: integer`, `pagination: Pagination Request`, +1 more
 
 **Response (success branch):**
 - Required: `media_buys: object[]`
@@ -369,7 +368,7 @@ Request parameters for retrieving media buy status, creative approvals, and deli
 Request parameters for retrieving comprehensive delivery metrics.
 
 **Request:**
-- Optional: `account: Account Ref`, `media_buy_ids: string[]`, `status_filter: Media Buy Status | object[]`, `start_date: string`, `end_date: string`, `include_package_daily_breakdown: boolean`, `attribution_window: object`, `reporting_dimensions: object`, +1 more
+- Optional: `account: Account Ref`, `media_buy_ids: string[]`, `status_filter: Media Buy Status | object[]`, `start_date: string`, `end_date: string`, `include_package_daily_breakdown: boolean`, `time_granularity: Reporting Frequency`, `include_window_breakdown: boolean`, +3 more
 
 **Response (success branch):**
 - Required: `reporting_period: object`, `currency: string`, `media_buy_deliveries: object[]`
@@ -469,8 +468,8 @@ Request parameters for generating creative previews.
 - Optional: `creative_manifest: Creative Manifest`, `format_id: Format Id`, `inputs: object[]`, `template_id: string`, `quality: Creative Quality`, `output_format: Preview Output Format`, `item_limit: integer`, `requests: object[]`, +3 more
 
 **Response (success branch):**
-- Required: `response_type: 'single'`, `previews: object[]`, `expires_at: string`
-- Optional: `interactive_url: string`, `context: Context`
+- Required: `response_type: 'single'`, `previews: object[]`
+- Optional: `interactive_url: string`, `expires_at: string`, `context: Context`
 
 **Watch out:**
 - Each `renders[]` entry is a oneOf on `output_format` — use `urlRender({...})`, `htmlRender({...})`, or `bothRender({...})` to inject the discriminator and require the matching `preview_url`/`preview_html` field.
@@ -507,7 +506,7 @@ Request parameters for retrieving creative delivery data with variant-level brea
 Request parameters for querying creative library with filtering and pagination.
 
 **Request:**
-- Optional: `filters: Creative Filters`, `sort: object`, `pagination: Pagination Request`, `include_assignments: boolean`, `include_snapshot: boolean`, `include_items: boolean`, `include_variables: boolean`, `include_pricing: boolean`, +3 more
+- Optional: `filters: Creative Filters`, `sort: object`, `pagination: Pagination Request`, `include_assignments: boolean`, `include_snapshot: boolean`, `include_items: boolean`, `include_variables: boolean`, `include_pricing: boolean`, +6 more
 
 **Response (success branch):**
 - Required: `query_summary: object`, `pagination: Pagination Response`, `creatives: object[]`
@@ -525,6 +524,17 @@ Request parameters for syncing creative assets with upsert semantics.
 - Required: `creatives: object[]`
 - Optional: `dry_run: boolean`, `sandbox: boolean`, `context: Context`
 
+#### `validate_input`
+
+Request parameters for validating a creative manifest against canonical formats and/or specific products without committing to a render.
+
+**Request:**
+- Required: `manifest: Creative Manifest`
+- Optional: `targets: object[]`
+
+**Response (success branch):**
+- Required: `results: object[]`
+
 **Deep dive:**
 - docs/guides/BUILD-AN-AGENT.md — building a creative agent (server-side)
 - schemas/cache/latest/creative/asset-types/index.json — asset type definitions
@@ -536,11 +546,10 @@ Request parameters for syncing creative assets with upsert semantics.
 Request parameters for discovering signals based on description.
 
 **Request:**
-- Optional: `account: Account Ref`, `signal_spec: string`, `signal_ids: object[]`, `destinations: object[]`, `countries: string[]`, `filters: Signal Filters`, `max_results: integer`, `pagination: Pagination Request`, +1 more
+- Optional: `discovery_mode: 'brief' | 'wholesale'`, `account: Account Ref`, `signal_spec: string`, `signal_ids: object[]`, `destinations: object[]`, `countries: string[]`, `filters: Signal Filters`, `max_results: integer`, +4 more
 
 **Response (success branch):**
-- Required: `signals: object[]`
-- Optional: `errors: object[]`, `pagination: Pagination Response`, `sandbox: boolean`, `context: Context`
+- Optional: `signals: object[]`, `errors: object[]`, `incomplete: object[]`, `wholesale_feed_version: string`, `pricing_version: string`, `cache_scope: 'public' | 'account'`, `unchanged: 'true'`, `pagination: Pagination Response`, +2 more
 
 #### `activate_signal`
 
@@ -792,7 +801,7 @@ Report the outcome of an action to the governance agent.
 - Optional: `check_id: string`, `purchase_type: Purchase Type`, `seller_response: object`, `delivery: object`, `error: object`, `context: Context`
 
 **Response (success branch):**
-- Required: `outcome_id: string`, `status: 'accepted' | 'findings'`
+- Required: `outcome_id: string`, `outcome_state: 'accepted' | 'findings'`
 - Optional: `committed_budget: number`, `findings: object[]`, `plan_summary: object`, `replayed: boolean`, `context: Context`
 
 #### `get_plan_audit_logs`
@@ -815,7 +824,7 @@ Orchestrator or seller calls the governance agent to validate an action against 
 - Optional: `purchase_type: Purchase Type`, `tool: string`, `payload: object`, `governance_context: string`, `phase: Governance Phase`, `planned_delivery: Planned Delivery`, `delivery_metrics: object`, `modification_summary: string`, +2 more
 
 **Response (success branch):**
-- Required: `check_id: string`, `status: Governance Decision`, `plan_id: string`, `explanation: string`
+- Required: `check_id: string`, `verdict: Governance Decision`, `plan_id: string`, `explanation: string`
 - Optional: `findings: object[]`, `conditions: object[]`, `expires_at: string`, `next_check: string`, `categories_evaluated: string[]`, `policies_evaluated: string[]`, `mode: Governance Mode`, `governance_context: string`, +1 more
 
 **Deep dive:**
@@ -895,7 +904,10 @@ These are the standard tool call sequences from the AdCP storyboards. Each flow 
 **Brand baseline** — Baseline protocol storyboard — every brand agent must declare the brand protocol in capabilities and return a schema-valid brand identity.
 Flow: `get_adcp_capabilities → get_brand_identity`
 
-**Brand agent rejects rights acquisition when governance denies** — Verifies that a brand agent returns AcquireRightsRejected when the buyer's governance plan denies a rights license.
+**Partners MUST NOT extend trust on a single signed verify_brand_claim response** — Red conformance test for the asymmetric trust model on verify_brand_claim. A partner that auto-provisions, propagates governance, or otherwise extends relationship trust on the strength of one signed `owned` response fails — assertion direction requires reciprocation.
+Flow: `comply_test_controller → verify_brand_claim → comply_test_controller → verify_brand_claim → comply_test_controller → verify_brand_claim`
+
+**Brand agent rejects rights acquisition when governance denies** — Verifies that a brand agent propagates GOVERNANCE_DENIED when the buyer's governance plan denies a rights license.
 Flow: `sync_plans → sync_accounts → sync_governance → get_rights → acquire_rights`
 
 ### Creative
@@ -903,8 +915,17 @@ Flow: `sync_plans → sync_accounts → sync_governance → get_rights → acqui
 **Creative lifecycle** — Full creative lifecycle on a stateful platform: sync multiple creatives, list with filtering, build and preview across formats, observe status transitions.
 Flow: `get_adcp_capabilities → list_creative_formats → sync_creatives → list_creatives → preview_creative → build_creative`
 
+**Native in-feed creative lifecycle** — End-to-end native_in_feed conformance: format discovery, full 12-slot asset bundle submission with pixel trackers, per-constraint validation rejection paths, and feed-rendered preview.
+Flow: `get_adcp_capabilities → list_creative_formats → sync_creatives → preview_creative`
+
 **Sales agent with creative capabilities** — Stateful sales agent that accepts pushed creative assets and renders them in its environment.
 Flow: `get_adcp_capabilities → list_creative_formats → sync_creatives → preview_creative`
+
+**Seller enforces provenance_requirements on sync_creatives** — Seller publishes provenance_requirements + accepted_verifiers on a product. Four structural rejections (no provenance, missing digital_source_type, off-list verifier, missing disclosure), then a corrected resubmission with on-list verifier is accepted.
+Flow: `get_products → sync_creatives`
+
+**Seller refutes a buyer's provenance claim via on-list verifier** — Buyer attaches a digital_source_type claim. Seller invokes get_creative_features against an on-list verifier (creative_policy.accepted_verifiers); when the verifier contradicts the claim, seller rejects with PROVENANCE_CLAIM_CONTRADICTED carrying audit-safe error.details.
+Flow: `get_products → sync_creatives`
 
 **Creative ad server** — Stateful ad server with pre-loaded creatives. Generates serving tags per media buy. Optionally bills through AdCP.
 Flow: `get_adcp_capabilities → list_creatives → list_creative_formats → build_creative → get_creative_delivery → report_usage`
@@ -931,11 +952,32 @@ Flow: `get_adcp_capabilities → sync_plans → check_governance → create_medi
 **Media buy seller agent** — Seller agent that receives briefs, returns products, accepts media buys, and reports delivery.
 Flow: `get_adcp_capabilities → sync_accounts → sync_governance → get_products → list_creative_formats → create_media_buy → get_media_buys → list_creative_formats → sync_creatives → get_media_buy_delivery`
 
+**Seller fulfills a media buy with audience targeting from a synced CRM audience** — Verifies that a seller advertising audience_targeting can ingest a CRM audience via sync_audiences, accept a media buy whose targeting_overlay references the bound audience_id, reject malformed audience references, and report delivery for the audience-targeted buy. Sibling to media_buy_seller/performance_buy_flow on the audience side: the unbound-id rejection is the discriminating assertion.
+Flow: `sync_accounts → get_products → sync_audiences → create_media_buy → comply_test_controller → get_media_buy_delivery`
+
+**Seller fulfills a media buy with a clicks optimization goal (target CPC)** — Verifies that a seller advertising clicks in supported_optimization_metrics can accept a media buy whose metric-kind optimization_goal targets cost-per-click and reports clicks + cost_per_click on delivery. Lightweight sibling to the performance scenarios on the click-optimization side: sellers that don't advertise clicks as an optimization metric (rare — most do; pure brand sellers like broadcast TV upper-funnel video are the not_applicable population) grade not_applicable.
+Flow: `sync_accounts → get_products → create_media_buy → comply_test_controller → get_media_buy_delivery`
+
+**Seller fulfills a video media buy with a completed_views optimization goal (target CPCV)** — Verifies that a seller advertising completed_views in supported_optimization_metrics can accept a media buy whose metric-kind optimization_goal targets completed views at a buyer-supplied view_duration_seconds, reject view_duration_seconds values not in the product's metric_optimization.supported_view_durations, and report completed_views + completion_rate on delivery. Sibling to reach_buy_flow on the video-completion side: sellers without video inventory (display-only DSPs, retail-media networks, audio-only sellers without video products) grade not_applicable.
+Flow: `sync_accounts → get_products → create_media_buy → comply_test_controller → get_media_buy_delivery`
+
 **Seller returns submitted task envelope when create_media_buy goes async** — Verifies the AdCP-payload wire shape of the submitted-arm response from create_media_buy: status='submitted', task_id present, no media_buy_id and no packages on the envelope.
 Flow: `comply_test_controller → create_media_buy`
 
 **Creative lifecycle is decoupled from media buy lifecycle** — Validates that canceling a media buy releases package-creative assignments but leaves the underlying creatives in the library with their review state intact, and that buyers can reuse released creatives on a new buy.
 Flow: `get_products → create_media_buy → sync_creatives → list_creatives → update_media_buy → list_creatives → create_media_buy → sync_creatives`
+
+**Dependency impairment end-to-end — resource transition propagates to media buy health** — Forces a creative from approved → rejected on a non-terminal media buy, verifies the buy reflects health: impaired with a matching impairments[] entry, and recovers via assignment swap to a different creative (canonical recovery vector — re-approval of the same creative_id is uncommon in production).
+Flow: `get_products → create_media_buy → sync_creatives → update_media_buy → comply_test_controller → get_media_buys → comply_test_controller → get_media_buys → sync_creatives → comply_test_controller → update_media_buy → get_media_buys`
+
+**Dependency impairment cardinality — impairments[] tracks each offline resource independently** — Two creatives on two packages of the same buy. Rejects them sequentially and verifies impairments[] grows 0 → 1 → 2; recovers them sequentially via swap-assignment and verifies impairments[] shrinks 2 → 1 → 0. Pressure-tests the inverse rule under cardinality — a seller emitting any impairment entry rather than the right one fails.
+Flow: `get_products → create_media_buy → sync_creatives → update_media_buy → comply_test_controller → get_media_buys → comply_test_controller → get_media_buys → comply_test_controller → get_media_buys → sync_creatives → comply_test_controller → update_media_buy → get_media_buys → sync_creatives → comply_test_controller → update_media_buy → get_media_buys`
+
+**Seller deduplicates the same event across multiple registered event sources** — Verifies that a seller advertising conversion_tracking.multi_source_event_dedup can register multiple event sources for the same buy and deduplicate inbound events by event_id so the same conversion from a pixel and a CAPI source counts once, not twice. Sibling to media_buy_seller/performance_buy_flow gated on the dedup sub-capability bit: sellers that don't advertise multi-source dedup grade not_applicable.
+Flow: `sync_accounts → get_products → sync_event_sources → create_media_buy → log_event → comply_test_controller → get_media_buy_delivery`
+
+**Seller honors a package-level frequency cap and reports observed frequency at-or-below the cap** — Verifies that a seller advertising frequency_capping accepts a package-level frequency_cap (max_impressions + per + window form) on create_media_buy and, after simulated delivery, reports observed reach and frequency on get_media_buy_delivery with the observed frequency at-or-below the requested cap. Runtime-enforcement scenario — no rejection arm. Sellers without frequency_capping grade not_applicable.
+Flow: `sync_accounts → get_products → create_media_buy → comply_test_controller → get_media_buy_delivery`
 
 **Seller creates buy when governance approves** — Verifies that the seller creates a media buy when governance approves the transaction.
 Flow: `sync_plans → sync_accounts → sync_governance → get_products → create_media_buy`
@@ -964,8 +1006,23 @@ Flow: `get_products → create_media_buy`
 **Creative sync unblocks pending_creatives → pending_start** — Verifies that a media buy created without creatives sits in pending_creatives until sync_creatives completes, then transitions to pending_start.
 Flow: `get_products → create_media_buy → sync_creatives → update_media_buy → get_media_buys`
 
+**Seller surfaces per-creative conversion attribution in delivery reporting** — Verifies that a seller advertising conversion_tracking.per_creative_attribution can register two creatives on a single package, accept a media buy with a CPA event-kind goal, ingest conversion events, and surface a populated by_package[].by_creative[] breakdown carrying conversions per creative in get_media_buy_delivery. Sibling to media_buy_seller/performance_buy_flow gated on the per_creative_attribution sub-capability: sellers that report attribution only at the line / package / placement / campaign granularity (retail-media, MMP-mediated mobile, CTV performance) grade not_applicable, not failing.
+Flow: `sync_accounts → get_products → sync_event_sources → sync_creatives → create_media_buy → log_event → comply_test_controller → get_media_buy_delivery`
+
+**Seller fulfills a performance (event-kind goal) media buy with a CPA target** — Verifies that a seller advertising conversion_tracking can bind an event source, accept a media buy with an event-kind optimization_goal targeting CPA, reject malformed performance briefs, ingest conversion events, and report conversion-attributed delivery including per-creative breakdown. ROAS / maximize_value goals are out of scope — see media_buy_seller/performance_buy_flow_roas (separate scenario, gated on the supported_target_kinds capability bit from #4639).
+Flow: `sync_accounts → get_products → sync_event_sources → create_media_buy → log_event → comply_test_controller → get_media_buy_delivery`
+
+**Seller fulfills a performance (event-kind goal) media buy with a ROAS target** — Verifies that a seller advertising conversion_tracking with per_ad_spend in supported_targets can accept a media buy whose event-kind optimization_goal carries a ROAS (per_ad_spend) target bound to an event source with value_field, reject ROAS goals that omit value_field on every event-source entry, ingest valued purchase events, and report conversion_value + roas alongside conversions and cost_per_acquisition. Sibling to media_buy_seller/performance_buy_flow gated on the supported_targets sub-capability: sellers that don't advertise per_ad_spend (most broadcast TV, upper-funnel video, signal-only) grade not_applicable.
+Flow: `sync_accounts → get_products → sync_event_sources → create_media_buy → log_event → comply_test_controller → get_media_buy_delivery`
+
 **Seller handles proposal refinement and finalize** — Verifies the full proposal lifecycle: brief with proposals, refine a proposal, finalize to committed, and accept via create_media_buy.
 Flow: `sync_accounts → get_products → create_media_buy`
+
+**Seller handles proposal finalize — asap start_time form** — Variant of proposal_finalize that exercises start_time: 'asap' on create_media_buy, catching wrapper-layer rejections of the spec-defined string literal form.
+Flow: `sync_accounts → get_products → create_media_buy`
+
+**Seller fulfills a media buy with a reach optimization goal** — Verifies that a seller advertising reach in supported_optimization_metrics can accept a media buy whose metric-kind optimization_goal targets unique reach with a buyer-supplied reach_unit, reject reach_unit values not in the product's metric_optimization.supported_reach_units, and report reach + frequency on delivery. Sibling to the performance buy scenarios on the brand-reach side: sellers that don't advertise reach as an optimization metric (most pure performance DSPs, retail-media networks) grade not_applicable.
+Flow: `sync_accounts → get_products → create_media_buy → comply_test_controller → get_media_buy_delivery`
 
 **Seller handles product refinement** — Verifies that a media buy seller supports buying_mode: refine with product-level and request-level changes.
 Flow: `sync_accounts → get_products`
@@ -978,6 +1035,9 @@ Flow: `get_adcp_capabilities → sync_accounts → list_creative_formats → get
 
 **Governance-aware seller** — Seller agent that composes with a campaign-governance agent on the buyer side — accepts sync_governance, calls check_governance before confirming spend, and propagates governance approvals, conditions, and denials unchanged. Optional claim; pure sellers without governance composition do not claim this specialism and skip the governance scenarios as not_applicable.
 Flow: `get_adcp_capabilities`
+
+**Seller rejects sync_governance with more than one governance agent** — Verifies that a governance-aware seller rejects a sync_governance request carrying more than one governance_agents entry, enforcing the maxItems: 1 constraint.
+Flow: `sync_accounts → sync_governance`
 
 **Broadcast linear TV seller agent** — Seller agent for broadcast linear TV inventory — primetime and fringe spots with measurement windows, agency estimate numbers, Ad-ID-based creative sync, and delayed delivery reporting.
 Flow: `get_adcp_capabilities → get_products → create_media_buy → get_media_buys → list_creative_formats → sync_creatives → expect_webhook → get_media_buy_delivery`
@@ -997,6 +1057,12 @@ Flow: `get_adcp_capabilities → sync_accounts → get_products → create_media
 ### Reporting
 
 **Seller returns valid delivery reporting** — Verifies that get_media_buy_delivery returns schema-compliant delivery data after simulated delivery via the test controller.
+Flow: `sync_accounts → get_products → create_media_buy → comply_test_controller → get_media_buy_delivery`
+
+**End-to-end metric accountability through the media buy lifecycle** — Buyer requires specific reporting metrics at discovery; seller filters products to those that can deliver; delivery report exposes any gaps via missing_metrics.
+Flow: `sync_accounts → get_products → create_media_buy → comply_test_controller → get_media_buy_delivery`
+
+**End-to-end vendor-metric accountability: declaration → filter → emission** — Buyer discovers products that declare a vendor metric, creates a media buy, and verifies vendor-metric values appear in the delivery report.
 Flow: `sync_accounts → get_products → create_media_buy → comply_test_controller → get_media_buy_delivery`
 
 ### Signals
@@ -1021,13 +1087,15 @@ Flow: `get_adcp_capabilities → get_signals`
 **Sponsored intelligence baseline** — Baseline domain storyboard — every SI agent must discover offerings, initiate a session, exchange messages, and terminate cleanly.
 Flow: `get_adcp_capabilities → si_get_offering → si_initiate_session → si_send_message → si_terminate_session`
 
+**Sponsored intelligence** — Specialism claim for agents that expose conversational sponsored experiences via the SI session lifecycle. Preview while the underlying SI tools remain `x-status: experimental`; SDK dispatch parity with other specialism IDs.
+
 ### Audiences
 
 **Audience sync** — Full audience lifecycle: account discovery, audience creation with hashed identifiers, and audience deletion.
 Flow: `get_adcp_capabilities → list_accounts → sync_audiences`
 
 **Social platform** — Social media platform that accepts audience segments, native creatives, and conversion events from buyer agents.
-Flow: `get_adcp_capabilities → sync_accounts → list_accounts → sync_audiences → sync_creatives → sync_catalogs → sync_creatives → sync_event_sources → log_event → get_account_financials`
+Flow: `get_adcp_capabilities → sync_accounts → list_accounts → sync_audiences → sync_creatives → sync_catalogs → sync_creatives → sync_catalogs → sync_creatives → preview_creative → expect_substitution_safe → sync_event_sources → log_event → get_account_financials`
 
 ### Core
 
@@ -1049,8 +1117,11 @@ Flow: `get_adcp_capabilities → comply_test_controller → sync_accounts → li
 **Pagination shape — get_media_buys** — Validates that get_media_buys responses carry a well-formed pagination envelope honoring the cursor↔has_more invariant.
 Flow: `get_adcp_capabilities → get_media_buys`
 
-**Idempotency enforcement** — Validates that mutating requests enforce idempotency_key — replays return cached responses, key reuse with a different payload returns IDEMPOTENCY_CONFLICT, and fresh keys create new resources.
-Flow: `get_adcp_capabilities → create_media_buy → expect_webhook → create_media_buy → get_media_buys`
+**Idempotency enforcement** — Validates that mutating requests enforce idempotency_key — replays return cached responses, key reuse with a different payload returns IDEMPOTENCY_CONFLICT, fresh keys create new resources, and concurrent retries with the same key produce exactly one resource (first-insert-wins under rule 9).
+Flow: `get_adcp_capabilities → create_media_buy → expect_webhook → create_media_buy → get_media_buys → expect_rate_limit_not_replayed`
+
+**Notification config event-scope rejection** — Validates that sync_accounts.accounts[].notification_configs[] rejects media-buy-anchored notification types even though they are valid notification-type enum values.
+Flow: `sync_accounts`
 
 **Pagination cursor integrity — list_creative_formats** — Validates the cursor↔has_more invariant on list_creative_formats by seeding two formats and walking pages with max_results=1.
 Flow: `get_adcp_capabilities → comply_test_controller → list_creative_formats`
@@ -1064,14 +1135,20 @@ Flow: `get_adcp_capabilities → list_creatives`
 **Pagination cursor integrity — list_property_lists** — Validates the cursor↔has_more invariant by walking a paginated list_property_lists response from a continuation page to a terminal page.
 Flow: `get_adcp_capabilities → create_property_list → list_property_lists`
 
+**Schema compliance — signals protocol** — Validates that signals agent responses conform to AdCP schemas with all required fields present and correctly typed.
+Flow: `get_adcp_capabilities → get_signals`
+
 **Schema compliance and temporal validation** — Validates that agent responses conform to AdCP schemas and that temporal constraints are enforced.
 Flow: `get_adcp_capabilities → get_products → list_creative_formats → create_media_buy`
 
 **v3 envelope integrity — no legacy status fields** — v3 protocol envelopes MUST NOT carry task_status or response_status — v2 legacy field names that have no semantics in v3.
 Flow: `get_adcp_capabilities`
 
+**Release-precision version negotiation** — Sellers advertise supported releases on capabilities and echo the served release on every response.
+Flow: `get_adcp_capabilities`
+
 **Webhook emission — outbound webhook conformance (signing + idempotency)** — Any agent that emits webhooks MUST carry a stable idempotency_key across retries and — when the buyer has not opted into the deprecated HMAC fallback — MUST sign deliveries under the RFC 9421 webhook profile. Graded by a runner hosting a webhook receiver during storyboard execution.
-Flow: `get_adcp_capabilities → expect_webhook → expect_webhook_retry_keys_stable → expect_webhook_signature_valid`
+Flow: `get_adcp_capabilities → expect_webhook → expect_webhook_retry_keys_stable → fetch_brand_jwks → assert_jwks_purpose → expect_webhook_signature_valid`
 
 ### Governance
 
@@ -1091,17 +1168,23 @@ Flow: `get_adcp_capabilities → list_creative_formats → build_creative → sy
 
 **Runner output contract** — Required failure-detail shape that AdCP storyboard runners MUST emit so implementors can self-diagnose validation failures.
 
+### Error Handling
+
+**Billing-gate dispatch — sync_accounts capability vs per-buyer-agent gate** — Validates the two distinct billing-rejection paths on sync_accounts — seller-wide capability gate (BILLING_NOT_SUPPORTED) and per-buyer-agent commercial-relationship gate (BILLING_NOT_PERMITTED_FOR_AGENT) — and the clamped error.details shape that prevents the per-agent code from acting as a commercial-state oracle.
+Flow: `get_adcp_capabilities → sync_accounts`
+
+**Error handling — signals protocol** — Validates that signals agents return properly structured AdCP errors with correct codes, recovery hints, and transport bindings.
+Flow: `get_adcp_capabilities → activate_signal → get_signals → activate_signal`
+
+**Error handling and compliance** — Validates that agents return properly structured AdCP errors with correct codes, recovery hints, and transport bindings.
+Flow: `get_adcp_capabilities → create_media_buy → get_products → create_media_buy → get_products → create_media_buy`
+
 ### Security
 
 **Comply test controller — live-account denial gate** — Verifies that a seller exposing comply_test_controller refuses calls from live-mode (non-sandbox) accounts with FORBIDDEN.
 Flow: `comply_test_controller`
 
 **Authentication baseline** — Every AdCP agent MUST require authentication on protected operations. At least one of API key or OAuth MUST be implemented and correctly advertised.
-
-### Error Handling
-
-**Error handling and compliance** — Validates that agents return properly structured AdCP errors with correct codes, recovery hints, and transport bindings.
-Flow: `get_adcp_capabilities → create_media_buy → get_products → create_media_buy → get_products → create_media_buy`
 
 ### Security transport
 
@@ -1119,28 +1202,60 @@ Agents use the `recovery` classification to decide what to do: `transient` → r
 | `ACCOUNT_PAYMENT_REQUIRED` | terminal | Account has an outstanding balance requiring payment before new buys. |
 | `ACCOUNT_SETUP_REQUIRED` | correctable | Natural key resolved but the account needs setup before use. |
 | `ACCOUNT_SUSPENDED` | terminal | Account has been suspended. |
+| `ACTION_NOT_ALLOWED` | correctable | The requested mutation maps to an action that is not currently available on this media buy. Sellers MUST populate `error.details` with `attempted_action` (the `media_buy_valid_action` value the request maps to), `reason` (an `action-not-allowed-reason` value: `wrong_status`, `not_supported_on_product`, `not_supported_on_buy`, or `mode_mismatch`), and `currently_available_actions` (echo of the buy's resolved `available_actions[]` so the buyer SDK can offer recovery without a separate get_media_buys round-trip). |
+| `AGENT_BLOCKED` | terminal | The calling buyer agent's commercial relationship with the seller is permanently denied — the agent is blocked. Sibling to `AGENT_SUSPENDED` on the agent-relationship axis but with no recovery path (a suspension may lift via re-onboarding; a block does not). The code itself is the discriminator — same posture as `AGENT_SUSPENDED`: no `error.details` payload, no per-agent commercial state, cross-tenant onboarding oracle clamp + channel-coverage requirements normative in error-handling.mdx Per-Agent Authorization Gate. |
+| `AGENT_SUSPENDED` | terminal | The calling buyer agent's commercial relationship with the seller is temporarily paused — the agent is onboarded but currently suspended. Sibling to `ACCOUNT_SUSPENDED` (account-wide) and `CAMPAIGN_SUSPENDED` (per-plan) but scoped to the agent-relationship axis (orthogonal to any specific account on that agent). The code itself is the discriminator — it does NOT carry an `error.details` payload (mirroring `BILLING_NOT_PERMITTED_FOR_AGENT`'s discriminator-by-code pattern), and MUST NOT carry per-agent commercial state (rate cards, payment terms, credit limit, billing entity, contact channels) since full disclosure of per-agent state in a single probe is a per-agent oracle. Cross-tenant onboarding oracle clamp + channel-coverage requirements (response shape, HTTP/A2A/MCP status, headers, side effects, observability, latency parity, retry-counter side channel) are normative in error-handling.mdx Per-Agent Authorization Gate; this description does not restate them to avoid drift. |
 | `AUDIENCE_TOO_SMALL` | correctable | Audience segment is below the minimum required size for targeting. |
-| `AUTH_REQUIRED` | correctable | Authentication is required, or presented credentials were rejected. Two operational sub-cases share this code: (a) credentials missing — agent provides credentials and retries; (b) credentials presented but rejected (expired / revoked / malformed signature) — agent SHOULD NOT auto-retry, since re-presenting a rejected credential against an SSO endpoint creates retry-storm patterns indistinguishable from brute-force probes. In sub-case (b) the agent SHOULD escalate to operator for credential rotation rather than loop. A future minor release splits this code into AUTH_MISSING (correctable) and AUTH_INVALID (terminal); agents handling 3.0.x sellers SHOULD apply the same operational distinction at the application layer. |
+| `AUTH_INVALID` | terminal | Credentials were presented but rejected — revoked, malformed signature, or a key no longer in the seller's keystore. Sellers MUST return this code when an `Authorization` header was present but verification failed. Exception: agents with a valid OAuth 2.1 refresh grant MAY treat this as correctable when the rejection reason is token expiry — silently refresh and retry once; if the refresh fails or the seller explicitly signals revocation, escalate to human. |
+| `AUTH_MISSING` | correctable | No credentials were presented. Sellers MUST return this code when no `Authorization` header was included in the request. |
+| `AUTH_REQUIRED` | correctable | **Deprecated** — use `AUTH_MISSING` (no credentials presented) or `AUTH_INVALID` (credentials presented and rejected). Retained as a backward-compatible alias during the 3.x deprecation window. |
+| `BILLING_NOT_PERMITTED_FOR_AGENT` | correctable | The seller's `supported_billing` capability accepts the requested model, but the calling buyer agent's commercial relationship with the seller does not — e.g., the agent is onboarded as passthrough-only (no payments relationship — only the operator can be invoiced) and `billing: 'agent'` or `billing: 'advertiser'` is rejected even though the seller supports both at the capability level. Distinct from `BILLING_NOT_SUPPORTED` (seller-wide capability) by being narrowly per-buyer-agent: the gate is the seller's onboarding record for this caller, not the seller's global wire capability. Sellers MUST emit this code only after agent identity has been established via signed-request derivation or a credential-to-agent mapping in the seller's onboarding record; callers without established identity MUST receive `BILLING_NOT_SUPPORTED` instead, to prevent the distinct code from acting as an onboarding oracle. The recovery shape is deliberately minimal — `error.details` MUST conform to `error-details/billing-not-permitted-for-agent.json` (`rejected_billing` plus an optional single `suggested_billing` retry value, typically `operator`) and MUST NOT carry the agent's full permitted-billing subset, rate cards, payment terms, credit limit, billing entity, or any other per-agent commercial state. |
+| `BILLING_NOT_SUPPORTED` | correctable | The seller declines the requested `billing` value either at the seller-wide capability level (`supported_billing` does not include the value) or at the per-account-relationship level (e.g., the seller accepts `operator` billing in general but has no direct billing relationship with the operator on this specific account). The default reject code for billing-value mismatches; `error.details` SHOULD conform to `error-details/billing-not-supported.json` (`scope` ∈ `{"capability", "account"}` plus optional `supported_billing` echo for the `"capability"` scope) so callers can dispatch without parsing prose. Distinct from `BILLING_NOT_PERMITTED_FOR_AGENT`, which is narrowly scoped to the calling buyer agent's commercial relationship with the seller (passthrough-only vs agent-billable) rather than to the seller's capability or per-account state. Sellers MUST emit `BILLING_NOT_PERMITTED_FOR_AGENT` only when agent identity has been established via signed-request derivation or a credential-to-agent mapping in the seller's onboarding record; in all other cases (unauthenticated callers and bearer credentials not mapped to a specific agent record) sellers MUST return `BILLING_NOT_SUPPORTED` and MUST omit `error.details.scope` — emitting the per-agent code or the `"account"`-scope hint without established identity is a cross-tenant onboarding oracle (same uniform-response shape required by the `*_NOT_FOUND` family). |
+| `BILLING_OUT_OF_BAND` | terminal | A creative-agent billing-loop operation (`report_usage` is the canonical case) received a well-formed record that the agent will not bill on because this account bills via a non-AdCP channel — flat license, SaaS contract, bundled enterprise agreement, or any other out-of-band arrangement. The agent returns `accepted: 0` with the offending record(s) listed in `errors[]` carrying this code; the request itself is valid and silent acceptance would break buyer-side reconciliation. Distinct from `BILLING_NOT_SUPPORTED` (the seller declines a specific `billing` value on a media-buy account where AdCP billing is otherwise in scope) and `BILLING_NOT_PERMITTED_FOR_AGENT` (per-buyer-agent commercial gate on an otherwise-billable surface) by signaling that the entire billing surface is offline for this account, not that a specific value or caller is rejected. Buyers SHOULD pre-filter by reading `capabilities.creative.bills_through_adcp` from `get_adcp_capabilities` before issuing `report_usage`; agents that have not yet declared the capability remain in the probe-to-discover mode. The error is returned per-record (in the `report_usage` response `errors[]` array with `field` pointing at `usage[N]` or a specific record subpath), not at the envelope level. The code itself is the discriminator; no `error.details` shape is defined for this code (mirroring `CONFIGURATION_ERROR`'s discriminator-by-code pattern). |
+| `BRAND_REQUIRED` | correctable | A billable operation was attempted without a brand reference. Every billable operation requires either a seller-assigned `account_id` or a natural key including `brand`. |
 | `BUDGET_EXCEEDED` | correctable | Operation would exceed the allocated budget for the media buy or package. Distinct from BUDGET_EXHAUSTED (already spent) and BUDGET_TOO_LOW (below minimum). |
 | `BUDGET_EXHAUSTED` | terminal | Account or campaign budget has been fully spent. Distinct from BUDGET_TOO_LOW (rejected at submission). |
 | `BUDGET_TOO_LOW` | correctable | Budget is below the seller's minimum. |
 | `CAMPAIGN_SUSPENDED` | transient | Campaign governance has been suspended pending human review; the governance agent MUST reject `check_governance` and `report_plan_outcome` calls on the affected plan until the escalation is resolved. Distinct from `ACCOUNT_SUSPENDED` (account-wide) — this is scoped to a single plan/campaign. |
 | `COMPLIANCE_UNSATISFIED` | correctable | A required disclosure from the brief's compliance section cannot be satisfied by the target format — either the required position or the required persistence mode is not in the format's disclosure_capabilities. |
+| `CONFIGURATION_ERROR` | terminal | The seller's deployment is misconfigured in a way that prevents handling the request — the buyer cannot fix it, retrying will not help, and reporting to the seller's operator is the only remediation. Examples: account declared with `mode: 'mock'` but no `mock_upstream_url` populated; platform declared with `mode: 'live'` or `mode: 'sandbox'` but no `upstream_url` declared; required environment variable unset on the seller process. Distinct from `INVALID_REQUEST` (buyer-fixable; the request itself is malformed), `SERVICE_UNAVAILABLE` (transient; retry-with-backoff may succeed), `UNSUPPORTED_FEATURE` (capability mismatch — the seller does not implement the requested specialism), `ACCOUNT_SETUP_REQUIRED` (buyer-side onboarding incomplete; this code is seller-side deployment incomplete), and `GOVERNANCE_UNAVAILABLE` (governance-agent-scoped; transient). Wire placement. The deployment cannot produce a success artifact, so sellers MUST flip transport-level failure markers (HTTP 5xx, MCP `isError: true`, A2A `failed`) and populate both layers per the two-layer model in `error-handling.mdx#envelope-vs-payload-errors-the-two-layer-model`. The code itself is the discriminator; no `error.details` shape is defined for this code (mirroring the minimal-disclosure precedent of `AGENT_SUSPENDED` / `AGENT_BLOCKED`). Sellers SHOULD populate `error.message` with operator-actionable detail (which metadata key is missing, which env var is unset) and MUST NOT include credentials, connection strings, or stack traces — the message is wire-visible to the buyer. |
 | `CONFLICT` | transient | Concurrent modification detected. The resource was modified by another request between read and write. |
 | `CREATIVE_DEADLINE_EXCEEDED` | correctable | Creative change submitted after the package's creative_deadline. Distinct from CREATIVE_REJECTED (content policy failure). |
 | `CREATIVE_NOT_FOUND` | correctable | Referenced creative does not exist in the agent's creative library. Sellers MUST return this code uniformly for any creative_id not owned by the calling account — never distinguish 'exists in another tenant' from 'does not exist', which would enable cross-tenant enumeration. |
 | `CREATIVE_REJECTED` | correctable | Creative failed content policy review. For deadline violations, see CREATIVE_DEADLINE_EXCEEDED. |
+| `CREATIVE_VALUE_NOT_ALLOWED` | correctable | A submitted text-asset value is not in the format's declared `allowed_values` list. Distinct from `CREATIVE_REJECTED` (generic content-policy failure) by being a closed-set constraint violation that the buyer can resolve mechanically without policy interpretation — the seller has published the complete list of acceptable values on the format, and any value outside that list is rejected by definition. The seller MUST set `error.field` to the offending asset's path within the manifest (e.g., `creatives[0].creative_manifest.assets[0].value` or the field name declared by the format) and SHOULD include the format's `allowed_values` array in `error.details.allowed_values` so the buyer agent can re-prompt its LLM with constrained sampling. |
+| `CREDENTIAL_IN_ARGS` | terminal | The seller detected a buyer-principal credential placed in request args (top-level, in `context`, in `ext`, or any other nested location in the task payload) instead of arriving on the transport's authentication channel. Buyer-principal credentials MUST arrive on the transport's authentication channel (`Authorization: Bearer` per RFC 6750 §2 for HTTP, RFC 9421 signature headers for signed requests, MCP/A2A authentication framing per RFC 9728 §3) and MUST NOT travel inside the task payload. Distinct from `AUTH_REQUIRED` (no credentials presented or presented credentials rejected on the transport channel) and `PERMISSION_DENIED` (authenticated caller not authorized for the action). Distinct from the receiver-side credentials carried in `push_notification_config.authentication.credentials`, which configure the seller's webhook callback authentication and are not buyer-principal credentials — those are an explicit carve-out and MUST NOT trigger this code. Sellers SHOULD reject credential-in-args under AdCP 3.1; the requirement upgrades to MUST 90 days after the 3.1 publication date. |
+| `FIELD_NOT_PERMITTED` | correctable | A request field is not in the caller's `field_scopes` allowlist for this task. Sellers declaring `field_scopes` on the account's `authorization` object MUST reject any request that sets a non-allowlisted field with this code. Distinct from `VALIDATION_ERROR` (schema/business-rule violation) - the field is valid, just not writable by this caller. `error.field` MUST identify the exact offending field path (e.g., `packages[0].budget`); when multiple fields are disallowed, sellers SHOULD return one error per field, or MAY enumerate them in `error.details.fields`. |
+| `FORMAT_CAPABILITY_UNRESOLVED` | correctable | Non-fatal advisory raised when a placement in `adagents.json` (or any consumer of `placement-definition.json`) carries `format_options[].capability_id` referencing a `capability_id` that does NOT exist in the file's top-level `formats[]`. The reference is broken — the publisher's catalog claims the placement accepts a capability that isn't declared. **Resolution scope is same-file only.** Cross-file `capability_id` lookup is not supported by design (closes off capability_id squatting across publisher boundaries — a malicious file cannot reference another publisher's capability_id and claim its narrowing). Buyer SDKs MUST fail closed for the placement (drop the format from the placement's accepted format set) and MUST surface this code rather than silently dropping or guessing what the publisher meant. Surface placement: same single-mandate as the other FORMAT_* codes — SDKs that detect on consumption MUST augment the response's `errors[]` with `source: "sdk"`, `sdk_id`, `code: "FORMAT_CAPABILITY_UNRESOLVED"`, `field` pointing at the offending placement (e.g., `placements[2].format_options[1].capability_id`), and `error.details` SHOULD carry `{ placement_id, capability_id, declared_capabilities: [<list of capability_ids actually in formats[]>] }` so the publisher can fix. |
+| `FORMAT_DECLARATION_DIVERGENT` | correctable | Non-fatal advisory raised when a product carries BOTH `format_ids` (v1) AND `format_options` (v2) and the two disagree (different canonical, different dimensions, different orientation) after projection. The producer's contract is that both shapes MUST refer to the same underlying declaration; divergence is a producer bug. Either side MAY emit this code: a SELLER may self-detect on emit (own producer bug; rare), or more commonly a consumer-SDK detects on consumption. SDKs MUST prefer `format_options` (the richer surface) when both are present and MUST surface the divergent product so it's observable rather than silently picked-one-and-dropped-other. Hard-failing the entire `get_products` response is discouraged — it punishes downstream buyers for the producer bug. **Surface placement (normative).** Same single-surface mandate as `FORMAT_PROJECTION_FAILED`: SDKs that detect this on consumption MUST augment the response's `errors[]` array with an entry carrying `source: "sdk"`, `sdk_id: "<package>@<version>"`, `code: "FORMAT_DECLARATION_DIVERGENT"`, and the field+details described below. Logger-only is insufficient; lint-output channels are NOT acceptable as the surface (the multi-hop agent network needs warnings to propagate across SDK boundaries via the wire response). `error.field` MUST point at the offending product; `error.details` SHOULD carry `{ product_id, format_ids, format_options_summary, divergence_reason }` so buyer SDKs can flag the producer for follow-up. **Multi-hop deduplication.** Each hop that detects the same divergence SHOULD deduplicate by `(code, field)` rather than re-emit; the existing entry's `sdk_id` identifies which earlier processor saw it first. |
+| `FORMAT_DECLARATION_V1_AMBIGUOUS` | correctable | Non-fatal advisory raised when an SDK detects that a product's v2 declaration cannot be unambiguously projected back to a single v1 named format because the v1-canonical-mapping registry has only family-level structural entries for this canonical (no invertible `format_id_glob` literal). The family is known (e.g., 'this is a video_vast'); the specific v1 named format isn't pickable mechanically. Distinct from `FORMAT_PROJECTION_FAILED` (registry-coverage gap, correctable by adding a registry entry) — ambiguity is structural: the family is defined but a specific format can't be picked without seller assertion. Surface placement: same single-mandate as `FORMAT_PROJECTION_FAILED` and `FORMAT_DECLARATION_DIVERGENT` — SDKs MUST augment the response's `errors[]` array with an entry carrying `source: "sdk"`, `sdk_id`, `code: "FORMAT_DECLARATION_V1_AMBIGUOUS"`, `field` pointing at the offending declaration, and `error.details` SHOULD carry `{ format_kind, registry_matches: [<list of structural entries that matched at family level>], product_id }` so adopters can see why the inversion was ambiguous. **SDKs MUST NOT synthesize a v1_format_ref** in this case (or any other case). v1↔v2 explicit pairing is seller-asserted only — SDKs encountering family-only registry matches MUST treat the v2 declaration as v1-unreachable and surface this code rather than invent a plausible v1 format_id. The seller's path: author `v1_format_ref` on the v2 declaration to disambiguate (the authoritative pairing per `v1-canonical-mapping.json` resolution step 1), or accept that v1-only buyers won't see this product. |
+| `FORMAT_DECLARATION_V1_LOSSY_MULTI_SIZE` | correctable | Non-fatal advisory raised when a v2 declaration carries `params.sizes[]` with N entries but only M v1_format_ref entries (M < N). The seller has asserted some v1 named formats but not enough to cover all declared sizes — v1-only buyers see partial coverage. Emitted **alongside** the partial v1 emission (NOT in place of it): the product still appears on the v1 wire under the M sizes the seller covered; this code tells v1-aware downstream agents that N-M sizes were dropped from the projection. Surface placement: SDKs that detect on emission OR consumption MUST augment the response's `errors[]` with `source: "sdk"` (or `"producer"` if the seller self-detects on emit), `sdk_id`, `code: "FORMAT_DECLARATION_V1_LOSSY_MULTI_SIZE"`, `field` pointing at the offending declaration, and `error.details` SHOULD carry `{ product_id, declared_sizes: [{w,h}, …], covered_sizes: [{w,h}, …], dropped_sizes: [{w,h}, …] }` so buyer agents see which sizes were lost. **SDKs MAY (non-normative) fan out automatically** by catalog lookup — for each entry in `sizes[]` lacking a corresponding `v1_format_ref`, the SDK consults the AAO catalog for the per-size v1 named format (e.g., for `{width: 728, height: 90}` look up `display_728x90_image`) and emits it under `format_ids[]`. This is opt-in (requires catalog access); when SDKs fan out, they SHOULD still emit this code as a transparency advisory so downstream consumers know the v1 emit was synthesized rather than seller-asserted. Recovery: warning — non-fatal, no retry. Seller fix: add `v1_format_ref[]` entries for the missing sizes. |
+| `FORMAT_PROJECTION_FAILED` | correctable | Non-fatal advisory raised when a v1 named format on a product cannot be projected to a canonical-formats `ProductFormatDeclaration` via the resolution order in `v1-canonical-mapping.json` (explicit `canonical` field → format_id_glob → structural match → fail-closed). The product is still valid on the v1 path; only the v2 `format_options` projection failed. Primarily a **consumer-SDK concern** — the seller didn't fail; the consumer-side SDK couldn't project on their behalf. `error.field` MUST point at the offending product (e.g., `products[3].format_ids[0]`); `error.details` SHOULD carry `{ format_id, product_id, resolution_failure: "no_explicit_canonical" | "no_registry_match" | "no_structural_match" }` so buyer SDKs can route remediation (suggest the seller add an explicit `canonical` field, or file a registry PR). **Surface placement (normative).** SDKs that detect this on consumption MUST augment the response's `errors[]` array with an entry carrying `source: "sdk"`, `sdk_id: "<package>@<version>"`, `code: "FORMAT_PROJECTION_FAILED"`, and the field+details described above. This is the single mandated surface — logger-only is insufficient and a separate lint-output channel is NOT acceptable (AdCP is a multi-hop agent network; warnings need to propagate across hops or each hop has to re-detect locally). Sellers MAY emit this code on their own response when they self-detect a non-projectable format on emit; producer-emitted entries omit `source` (or set `source: "producer"`). The response stays 200/success regardless of who emits; this is non-fatal. **Multi-hop deduplication.** Each hop that detects the same condition SHOULD deduplicate by `(code, field)` rather than re-emit. The existing entry's `sdk_id` identifies which earlier processor saw it first; downstream SDKs SHOULD NOT add a second entry for the same `(code, field)` pair unless they have materially different `error.details` (e.g., a different `resolution_failure` reason from a different registry version). See canonical-formats.mdx 'Dual emission and v2↔v1 projection' for the full rules. |
 | `GOVERNANCE_DENIED` | correctable | A registered governance agent denied the transaction. Sellers MUST place the denial in the task's structured rejection arm when one exists (e.g., `acquire_rights` → `AcquireRightsRejected`, `creative_approval` → `CreativeRejected`); otherwise in `errors[]` + `adcp_error`. Buyers MUST dispatch on the response's discriminated `status` first and fall back to `errors[].code` / `adcp_error.code` only when no rejection arm exists for that task. The buyer may restructure the buy (e.g., reduce budget, split into smaller transactions), escalate to human spending authority, or contact the governance agent for details. Wire placement (full guidance). Governance denial is a structured business outcome, not a system error — the governance call SUCCEEDED and the agent returned a denial verdict. Two cases: 1. Task response defines a structured rejection arm. The arm IS the canonical denial shape. The seller populates `reason` (human-readable, propagating governance findings) and `suggestions` (optional) and does NOT additionally emit `GOVERNANCE_DENIED` in `errors[]` or `adcp_error`. The rejection arms enforce this at the schema layer: e.g., `AcquireRightsRejected` and `CreativeRejected` both declare `not: { required: [errors] }`, so dual-emission is already a schema violation. The code does not appear on the wire when the rejection arm is used. Transport-level success markers MUST NOT be flipped (HTTP 200, MCP `isError: false`, A2A `succeeded`) — the task ran successfully and produced a structured response. 2. Task response has no rejection arm (e.g., `create_media_buy` returns Success / Error / Submitted arms only). The seller populates `errors[].code: GOVERNANCE_DENIED` in the payload AND `adcp_error.code: GOVERNANCE_DENIED` on the envelope per the two-layer model in `error-handling.mdx#envelope-vs-payload-errors-the-two-layer-model`. Transport-level failure markers DO flip in this case (HTTP 4xx, MCP `isError: true`, A2A `failed`) — the task could not produce a success artifact. The rule generalizes to any current or future task whose response defines a discriminated rejection arm. In either placement, sellers SHOULD propagate governance findings verbatim — buyers' recovery decisions depend on what specifically was rejected. `GOVERNANCE_DENIED` is reserved for verdicts received from a reachable governance agent; if the governance call itself failed (timeout, network, config error), use `GOVERNANCE_UNAVAILABLE` instead. |
 | `GOVERNANCE_UNAVAILABLE` | transient | A registered governance agent is unreachable. Sellers MUST place this code in `errors[]` + `adcp_error` (never a structured rejection arm) and flip transport-level failure markers (HTTP 5xx, MCP `isError: true`, A2A `failed`). Distinct from `GOVERNANCE_DENIED` (agent reachable and explicitly denied — see that code's wire-placement guidance). Wire placement (full guidance). Governance unavailability is a system error — the governance call FAILED (timeout, network, config error) and the seller could not get a verdict at all. Always populate both layers per the two-layer model in `error-handling.mdx#envelope-vs-payload-errors-the-two-layer-model`. Do NOT use a structured rejection arm for unavailability even when the task offers one — the buyer's recovery semantics differ (retry-with-backoff for unavailability vs. restructure-or-escalate for denial), and conflating them masks the system-error signal. |
 | `IDEMPOTENCY_CONFLICT` | correctable | An earlier request with the same idempotency_key was processed with a different canonical payload within the seller's replay window. Distinct from CONFLICT (concurrent write) — this indicates the client reused a key across semantically different requests. |
 | `IDEMPOTENCY_EXPIRED` | correctable | The idempotency_key was seen previously but its cached response has been evicted because it is past the seller's declared replay_ttl_seconds. Distinct from IDEMPOTENCY_CONFLICT (different payload within window) — this indicates the retry arrived too late for at-most-once guarantees. If the buyer has any evidence the prior call succeeded (partial response received before crash, entry in the buyer's own DB, a webhook fired), the buyer MUST do the natural-key check BEFORE minting a new key — minting a new key in that situation is exactly how double-creation happens. |
+| `IDEMPOTENCY_IN_FLIGHT` | transient | A prior request with the same `idempotency_key` is still being processed and has not yet produced a cached response. The second request arrived before the first completed. Sellers MAY return this code instead of blocking the second caller until the first finishes — useful when the first call invokes a slow downstream system (SSP, ad server, payment provider). Distinct from IDEMPOTENCY_CONFLICT (different canonical payload — a client bug) and from CONFLICT (concurrent modification of a different resource) — IDEMPOTENCY_IN_FLIGHT is the seller telling the buyer 'your retry was correct but your previous attempt is still running, come back shortly.' Sellers SHOULD populate `error.details.retry_after` (seconds, integer) with a wait hint based on the first request's elapsed time and expected completion. Buyers MUST treat this as transient and MUST NOT mint a fresh `idempotency_key` — minting a new key turns a safe retry into a double-execution race. |
 | `INVALID_REQUEST` | correctable | Request is malformed, missing required fields, or violates schema constraints. |
 | `INVALID_STATE` | correctable | Operation is not permitted for the resource's current status (e.g., updating a completed or canceled media buy, or modifying a canceled package). |
 | `IO_REQUIRED` | correctable | The committed proposal requires a signed insertion order but no io_acceptance was provided. |
 | `MEDIA_BUY_NOT_FOUND` | correctable | Referenced media buy does not exist or is not accessible to the requesting agent. |
+| `MULTI_FINALIZE_UNSUPPORTED` | correctable | Returned by sellers that cannot guarantee atomic commit across multiple proposals in a single `get_products` call (multiple `action: 'finalize'` entries in `refine[]` targeting different `proposal_id` values). The buyer's intent — atomic multi-proposal finalize — is structurally well-formed and per spec atomic, but this seller's downstream stack cannot satisfy the atomicity guarantee (e.g., the proposals route to two different ad servers with no 2PC). More specific than `INVALID_REQUEST` so buyers can distinguish 'this seller doesn't support multi-finalize' from 'the request itself is malformed'. See [refinement guide § Finalize is exclusive](/docs/media-buy/product-discovery/refinement#finalize-is-exclusive-within-refine). |
 | `NOT_CANCELLABLE` | correctable | The media buy or package cannot be canceled in its current state. The seller may have contractual or operational constraints that prevent cancellation. |
 | `PACKAGE_NOT_FOUND` | correctable | Referenced package does not exist within the specified media buy. |
-| `PERMISSION_DENIED` | correctable | The authenticated caller is not authorized for the requested action under the seller's own policies, or a required signed credential (e.g., a `governance_context` token on a spend-commit) is missing, fails verification, or was issued for a different plan, seller, or phase. Distinct from `AUTH_REQUIRED` (no credentials presented) and `GOVERNANCE_DENIED` (governance agent denied). |
+| `PAYMENT_TERMS_NOT_SUPPORTED` | correctable | The seller does not accept the requested `payment_terms` value for this account. Payment terms are never silently remapped — sellers either accept or reject. Distinct from `BILLING_NOT_SUPPORTED` (the `billing` enum) by being narrowly about the `payment_terms` enum on the same account. |
+| `PERMISSION_DENIED` | correctable | The authenticated caller is not authorized for the requested action under the seller's own policies, or a required signed credential (e.g., a `governance_context` token on a spend-commit) is missing, fails verification, or was issued for a different plan, seller, or phase. Distinct from `AUTH_MISSING` (no credentials presented), `AUTH_INVALID` (credentials presented but rejected), `GOVERNANCE_DENIED` (governance agent denied), `AGENT_SUSPENDED` (agent's relationship temporarily paused), and `AGENT_BLOCKED` (agent's relationship permanently denied). When the gate that fired is specifically a non-status per-agent provisioning constraint — e.g., the agent is provisioned for sandbox traffic only and the request was against a non-sandbox account — `error.details` SHOULD conform to `error-details/agent-permission-denied.json` (`scope: "agent"` plus `reason: "sandbox_only"`) so callers can dispatch without parsing prose. Sellers MUST emit `scope: "agent"` only when buyer-agent identity has been established via signed-request derivation or a credential-to-agent mapping in the seller's onboarding record; in all other cases (including bearer credentials not mapped to a specific agent record) sellers MUST return `PERMISSION_DENIED` and MUST omit `error.details.scope` — emitting the per-agent scope without established identity is a cross-tenant onboarding oracle, and the omit MUST be enforced across every observable channel (response shape, HTTP/A2A/MCP status, headers, side effects, observability, latency parity) per the channel-coverage rules in error-handling.mdx Per-Agent Authorization Gate, mirroring the `*_NOT_FOUND` uniform-response rule and `BILLING_NOT_PERMITTED_FOR_AGENT`. The `suspended` and `blocked` per-agent states are NOT carried on this code — sellers MUST emit `AGENT_SUSPENDED` / `AGENT_BLOCKED` instead, each of which is its own discriminator. |
+| `PIXEL_TRACKER_LOSSY_DOWNGRADE` | correctable | Non-fatal advisory raised when a 3.1 buyer SDK downgrades a `pixel_tracker` asset to the v1 `{asset_type: url, url_type: tracker_pixel}` shape for a 3.0.x seller that doesn't recognize the new asset type. The URL is still emitted on the wire and the seller will fire it as a tracker pixel; what's lost is the event/method discrimination. Downgrade rules (normative):
+- `event: impression` + `method: img` → no loss; emit as `{asset_type: url, url_type: tracker_pixel, url, asset_id: impression_tracker}`
+- `event: viewable_mrc_50` / `viewable_mrc_100` / `viewable_video_50` / `audible_video_complete` → emit with `asset_id: viewability_tracker`; advisory `lost_event: <variant>` (specific viewability variant collapses to a single v1 slot)
+- `event: click` → emit with `asset_id: click_tracker`; no meaningful loss
+- `event: custom, custom_event_name: X` → emit with `asset_id: impression_tracker` (default tracker_pixel fires on impression); advisory `lost_event: "custom"`, `lost_custom_event_name: X` (custom event timing collapses to impression timing)
+- `method: js` → emit unchanged shape (url, url_type:tracker_pixel); advisory `lost_method: "js"` (v1 seller will fire as HTTP GET; the URL is hit and any counter-based measurement increments, but the response body won't execute as JS — measurement that depends on JS execution, e.g., OMID-style verification, viewability observers, cross-domain cookie setters, won't work. Simple counter pixels still work.) Surface: SDK that performs the downgrade MUST augment the response's `errors[]` with `source: "sdk"`, `sdk_id`, `code: "PIXEL_TRACKER_LOSSY_DOWNGRADE"`, `field` pointing at the affected manifest asset path, and `error.details` SHOULD carry `{ asset_id, original_event, original_method, original_custom_event_name (if present), downgrade_target: "url+tracker_pixel", lost_fields: [<list>] }`. One advisory per downgraded asset; SDKs SHOULD NOT collapse multiple downgrades into a single advisory entry — per-asset details let the buyer's measurement-plan owner decide whether each loss is tolerable. Recovery: warning — non-fatal, no retry. Buyer-side decision: accept the loss (most simple counter pixels survive), or fail the buy and route to a 3.1-capable seller. Seller-side fix: upgrade to 3.1 and accept `pixel_tracker` natively. |
+| `PIXEL_TRACKER_UPGRADE_INFERRED` | correctable | Non-fatal advisory raised when a 3.1 buyer SDK upgrades a v1 `{asset_type: url, url_type: tracker_pixel}` to a `pixel_tracker` asset by INFERRING the event and method from the v1 asset_id and conventional defaults. The inference is structural — the SDK doesn't have explicit event/method values, only the v1 asset_id hint and `url_type: tracker_pixel` (which implies `method: img` by default). Inference rules (normative):
+- `asset_id: impression_tracker` → `event: impression, method: img`
+- `asset_id: viewability_tracker` → `event: viewable_mrc_50, method: img` (50% is the most common default; specific viewability variant cannot be recovered from v1 shape)
+- `asset_id: click_tracker` → `event: click, method: img`
+- `asset_id: <other>` → `event: custom, custom_event_name: <original asset_id>, method: img` Surface: SDK MUST augment the response's `errors[]` with `code: "PIXEL_TRACKER_UPGRADE_INFERRED"`, `field` pointing at the upgraded asset path, and `error.details` SHOULD carry `{ asset_id, inferred_event, inferred_method, inference_basis: "asset_id_convention" | "default" }`. Buyer agents reading the response can re-prompt the seller for explicit values if precise measurement matters. Recovery: warning — non-fatal, no retry. Seller-side: upgrade emit path to ship pixel_tracker shape directly when 3.1-capable; until then, conventional asset_id values give the SDK enough signal to upgrade without losing critical semantics. |
 | `PLAN_NOT_FOUND` | correctable | Referenced governance plan does not exist or is not accessible to the requesting agent. Sellers MUST return this code uniformly for any plan_id not accessible to the calling account — never distinguish 'exists but unauthorized' from 'does not exist', which would enable cross-tenant enumeration of governance plans. |
 | `POLICY_VIOLATION` | correctable | Request violates the seller's content or advertising policies. |
 | `PRODUCT_EXPIRED` | correctable | One or more referenced products have passed their expires_at timestamp and are no longer available for purchase. |
@@ -1148,17 +1263,29 @@ Agents use the `recovery` classification to decide what to do: `transient` → r
 | `PRODUCT_UNAVAILABLE` | correctable | The requested product is sold out or no longer available. |
 | `PROPOSAL_EXPIRED` | correctable | A referenced proposal ID has passed its expires_at timestamp. |
 | `PROPOSAL_NOT_COMMITTED` | correctable | The referenced proposal has proposal_status 'draft' and cannot be used to create a media buy. |
+| `PROPOSAL_NOT_FOUND` | correctable | The referenced proposal_id is not recognized by the seller — never finalized, belongs to a different tenant, or evicted from the seller's session cache before consumption. Distinct from `PROPOSAL_EXPIRED` (a known proposal whose `expires_at` window has passed) and `PROPOSAL_NOT_COMMITTED` (a known proposal still in `draft`). |
+| `PROVENANCE_CLAIM_CONTRADICTED` | correctable | Seller invoked a governance agent from `creative_policy.accepted_verifiers` via `get_creative_features` and the verifier's result contradicts the buyer's provenance claim - e.g., buyer claims `digital_source_type: digital_capture` but the AI-detection feature returns `ai_generated: true` above the seller's confidence threshold. Distinct from the `PROVENANCE_*_MISSING` family (structural absence) by being an active refutation. `error.details` SHOULD be limited to the audit-safe allowlist `{ agent_url, feature_id, claimed_value, observed_value, confidence }`; sellers MUST NOT forward arbitrary verifier extension fields, `detail_url`, or any verifier response shape that may carry cross-tenant or PII data. When the seller calls a different on-list agent than the buyer nominated (the seller is the verifier-of-record), `error.details.agent_url` is the agent the seller actually called and `error.details.substituted_for` SHOULD carry the buyer's nominated `agent_url` so the buyer can reconcile. |
+| `PROVENANCE_DIGITAL_SOURCE_TYPE_MISSING` | correctable | Seller's `creative_policy.provenance_requirements.require_digital_source_type` is true and the submitted creative's resolved provenance (after inheritance) has no `digital_source_type` value, or has it set to null. Distinct from `PROVENANCE_REQUIRED` (no provenance object at all) - provenance is present, just missing this specific field. `error.field` MUST point at the resolved provenance path that was inspected (e.g., `creatives[0].creative_manifest.provenance.digital_source_type`). |
+| `PROVENANCE_DISCLOSURE_MISSING` | correctable | Seller's `creative_policy.provenance_requirements.require_disclosure_metadata` is true and the submitted creative's resolved provenance has no `disclosure.required` boolean, or `disclosure.required` is true with no `disclosure.jurisdictions` entries. `error.field` MUST point at `provenance.disclosure` (e.g., `creatives[0].creative_manifest.provenance.disclosure`). |
+| `PROVENANCE_EMBEDDED_MISSING` | correctable | Seller's `creative_policy.provenance_requirements.require_embedded_provenance` is true and the submitted creative's resolved provenance has no `embedded_provenance` array, or has it as an empty array. Used in pipelines where sidecar `c2pa.manifest_url` is stripped by intermediaries and the seller requires content-stream-resilient provenance. `error.field` MUST point at `provenance.embedded_provenance` on the resolved manifest. |
+| `PROVENANCE_REQUIRED` | correctable | Seller's `creative_policy.provenance_required` is true and the submitted creative has no `provenance` object on the manifest, on the creative-asset, or on any individual asset. Distinct from `CREATIVE_REJECTED` (generic content-policy failure) by being narrowly about provenance presence. `error.field` MUST point at the path where provenance was expected (e.g., `creatives[0].creative_manifest`). |
+| `PROVENANCE_VERIFIER_NOT_ACCEPTED` | correctable | Buyer attached a `verify_agent.agent_url` on `embedded_provenance[]` or `watermarks[]` that does not match (canonicalized per /docs/reference/url-canonicalization: lowercase scheme and host, strip default port, normalize path dot-segments) any entry in the seller's `creative_policy.accepted_verifiers[].agent_url`. The seller does not call buyer-asserted endpoints outside its allowlist; this is the cross-check that closes the buyer-controlled-URL trust gap. `error.field` MUST point at the offending `verify_agent.agent_url` path; `error.details` SHOULD include a reference to the product whose `creative_policy.accepted_verifiers` the buyer should consult (the buyer already has this from `get_products`). |
 | `RATE_LIMITED` | transient | Request rate exceeded. Retry after the retry_after interval. |
+| `READ_ONLY_SCOPE` | correctable | The caller's scope is read-only; the invoked task would mutate state and was rejected. Distinct from `SCOPE_INSUFFICIENT` (task not in scope at all) — the task is in some scopes this seller supports, just not this caller's. |
 | `REFERENCE_NOT_FOUND` | correctable | Generic fallback for a referenced identifier, grant, session, or other resource that does not exist or is not accessible by the caller. Use when no resource-specific not-found code applies (e.g., property lists, content standards, rights grants, SI offerings, proposals, catalogs, event sources, collection lists, brands, individual properties). Typed parameters that lack a dedicated standard code MUST also use REFERENCE_NOT_FOUND rather than minting a custom *_NOT_FOUND code. See 'Uniform response for inaccessible references' in error-handling.mdx for the full MUST list. Summary of the uniform-response MUST: sellers MUST return the same response for 'exists but the caller lacks access' as for 'does not exist' across every observable channel — error.code/message/field/details (message MUST be generic; error.field MUST be identical across both cases on typed parameters); HTTP status, A2A task.status.state, and MCP isError; response headers (ETag, Cache-Control, per-type rate-limit buckets, CDN tags); side effects (webhook/audit writes, background-job enqueues, per-type quota counters, DB-shard routing); and observability (logs, APM spans, third-party error telemetry like Sentry/Datadog). Sellers MUST perform the same resolution-and-authorization work on both paths (resolve-then-authorize; on true-miss still run an authorization decision of equivalent shape against an empty principal set so authorizer latency is not a side channel). Cache population MUST NOT be gated on authorization. Polymorphism is evaluated against the tool-schema's declared parameter shape before any lookup, and a tool's declared shape MUST be identical across all callers. |
 | `REQUOTE_REQUIRED` | correctable | An update_media_buy request changes the parameter envelope (budget, flight dates, volume, targeting) the original quote was priced against. The pricing_option remains locked; the seller is declining the requested shape at that price. Distinct from TERMS_REJECTED (measurement) and POLICY_VIOLATION (content). Sellers SHOULD populate error.details.envelope_field with the field path(s) that breached the envelope (e.g., 'packages[0].budget', 'end_time') so the buyer's agent can autonomously re-discover. |
+| `SCOPE_INSUFFICIENT` | correctable | The authenticated caller is not authorized for the invoked task — the task is not in the caller's `allowed_tasks` for this account (discoverable via the `authorization` object on sync_accounts / list_accounts responses). Distinct from `PERMISSION_DENIED` (generic authz failure, often credential-shaped) by being narrowly about task-level scope. Sellers SHOULD populate `error.details.introspection_hint` pointing at where the caller can re-read its scope (strawman: `{ task: 'list_accounts', account: {...} }`). |
 | `SERVICE_UNAVAILABLE` | transient | Seller service is temporarily unavailable. Retry with exponential backoff. |
 | `SESSION_NOT_FOUND` | correctable | SI session ID is invalid, expired, or does not exist. |
 | `SESSION_TERMINATED` | correctable | SI session has already been terminated and cannot accept further messages. |
 | `SIGNAL_NOT_FOUND` | correctable | Referenced signal does not exist in the agent's catalog. Sellers MUST return this code uniformly for any signal_id not accessible to the calling account — never distinguish 'exists but unauthorized' from 'does not exist', which would enable cross-tenant enumeration. |
+| `STALE_RESPONSE` | transient | Non-fatal advisory raised when the seller's live fetch to an upstream or sub-agent failed (timeout, connection error, downstream 5xx) and the response payload was satisfied from a cached prior result that is past the seller's freshness target for this surface. Emitted **alongside** a populated success payload — the caller's request still completes from a usable cache hit; this code tells downstream consumers that the data is older than the seller would normally serve. Distinct from `SERVICE_UNAVAILABLE` (seller's own service is down, no payload — transient, retry-with-backoff) by signalling **graceful degradation**: the seller's own service is fine, but one of its dependencies is currently unreachable and the seller chose to honor the request from cache rather than return empty. Sellers MUST emit `STALE_RESPONSE` ONLY when the response payload is non-empty AND derived from a cache entry whose `cache_age_seconds` exceeds the surface's freshness target. When no cached entry exists (or the cache hit is within freshness target), sellers MUST NOT emit this code — return the empty-or-fresh response with whatever upstream-failure code applies (e.g., `SERVICE_UNAVAILABLE`). **Wire placement (normative).** Transport-level success markers stay flipped to success (HTTP 200, MCP `isError: false`, A2A `succeeded`) — the task ran successfully and produced a response, even if from cache. The advisory rides in `errors[]` on the payload and MUST NOT be promoted to `adcp_error` on the envelope (envelope-level errors are reserved for the empty-payload failure case per the two-layer model in `error-handling.mdx#envelope-vs-payload-errors-the-two-layer-model`). `error.field` SHOULD point at the affected payload path (e.g., `formats` for `list_creative_formats`, `products` for `get_products`). `error.details` SHOULD conform to `error-details/stale-response.json` — `served_from_cache` (required, always `true`), `cache_age_seconds` (required), and optionally `freshness_target_seconds`, `upstream` (the dependency that failed), and `original_error` (the underlying failure code/message). **Multiple stale upstreams.** When N sub-agents are stale (e.g., a `list_creative_formats` registry aggregating from multiple creative agents), the seller SHOULD emit **one `STALE_RESPONSE` entry per affected upstream** rather than aggregating — the per-upstream shape mirrors the existing precedent set by `PIXEL_TRACKER_LOSSY_DOWNGRADE` (one advisory per downgraded asset) and lets buyer agents reason about which sub-population of the payload is stale. Each entry's `error.field` SHOULD narrow to the affected slice (e.g., `formats` for formats sourced from the stale upstream). |
 | `TERMS_REJECTED` | correctable | Buyer-proposed measurement_terms were rejected by the seller. The error details SHOULD identify which specific term was rejected and the seller's acceptable range or supported vendors. |
 | `UNSUPPORTED_FEATURE` | correctable | A requested feature or field is not supported by this seller. |
+| `UNSUPPORTED_GRANULARITY` | correctable | The requested `time_granularity` on `get_media_buy_delivery` is not in the product's declared `reporting_capabilities.windowed_pull_granularities`. Distinct from `UNSUPPORTED_FEATURE` (generic capability mismatch) by being narrowly about reporting-window granularity — the buyer asked for hourly pull-recovery on a product that only honors daily pulls, for example. Sellers MAY echo the declared set in `error.details.supported_granularities` when the caller is authorized to read the product's reporting capabilities — the same set is already available via `get_adcp_capabilities`, so the echo is a convenience, not load-bearing. Sellers MUST NOT echo a granularity set the caller could not otherwise read (per-product capability views vary by buyer entitlement). The `error.field` SHOULD point at `time_granularity`. Buyers that need higher-frequency recovery than the seller's pull set supports MUST rely on the webhook channel as primary at that frequency — the seller's `available_reporting_frequencies` may legitimately exceed `windowed_pull_granularities` (e.g., a stream-tap webhook on Kafka with warehouse pulls only at daily). |
+| `UNSUPPORTED_PROVISIONING` | correctable | The seller does not support the `sync_accounts` mode the entry requested. Returned per-entry in the `sync_accounts` response when (a) an entry keyed by the natural-key trio (`brand` + `operator` + `billing`) is sent to a seller that does not provision accounts via AdCP — typical for explicit-account platforms where accounts are pre-provisioned out of band and discovered via `list_accounts`; or (b) an entry keyed by `account` (AccountRef) is sent to a seller that has not implemented the settings-update mode. Distinct from `UNSUPPORTED_FEATURE` (generic capability mismatch) by being narrowly about which of the two `sync_accounts` modes the seller implements. The two modes are mutually exclusive per-entry — the seller MUST NOT silently downgrade or upgrade between them. Sellers MAY declare which modes they implement via `get_adcp_capabilities` (forward-looking — capability declaration shape is open). The `error.field` SHOULD point at the entry index where the unsupported shape was found. |
 | `VALIDATION_ERROR` | correctable | Request contains invalid field values or violates business rules beyond schema validation. |
-| `VERSION_UNSUPPORTED` | correctable | The declared adcp_major_version is not supported by this seller. |
+| `VERSION_UNSUPPORTED` | correctable | The declared adcp_version (release-precision) or adcp_major_version (deprecated) is not supported by this seller. The error details SHOULD follow `error-details/version-unsupported.json` — `supported_versions` (release-precision strings) is authoritative for retry; `supported_majors` is deprecated. |
 
 Unknown codes: fall back to the HTTP status code (4xx = correctable, 5xx = transient).
 

--- a/examples/decisioning-platform-broadcast-tv.ts
+++ b/examples/decisioning-platform-broadcast-tv.ts
@@ -129,6 +129,7 @@ export class BroadcastTvSeller implements DecisioningPlatform<BroadcastTvConfig,
       }
 
       return {
+        status: 'completed' as const,
         products: [
           {
             product_id: 'prod_primetime_30s',
@@ -261,6 +262,7 @@ export class BroadcastTvSeller implements DecisioningPlatform<BroadcastTvConfig,
 
     getMediaBuyDelivery: async (filter: GetMediaBuyDeliveryRequest): Promise<GetMediaBuyDeliveryResponse> => {
       return {
+        status: 'completed' as const,
         currency: 'USD',
         reporting_period: {
           start: filter.start_date ?? '2026-04-01',
@@ -273,7 +275,7 @@ export class BroadcastTvSeller implements DecisioningPlatform<BroadcastTvConfig,
     // Required on SalesPlatform — write-only adopters return an empty array.
     // This affiliate doesn't enumerate buys via this surface (push-channel
     // delivery via webhooks); the empty array is truthful.
-    getMediaBuys: async () => ({ media_buys: [] }),
+    getMediaBuys: async () => ({ status: 'completed' as const, media_buys: [] }),
   };
 
   private preflight(req: CreateMediaBuyRequest): { code: string; recovery: string; message: string; field: string }[] {

--- a/examples/decisioning-platform-mock-seller.ts
+++ b/examples/decisioning-platform-mock-seller.ts
@@ -147,6 +147,7 @@ function rejectPreflight(errors: AdcpStructuredError[]): never {
 }
 
 const SHARED_GET_PRODUCTS = async (_req: GetProductsRequest): Promise<GetProductsResponse> => ({
+  status: 'completed' as const,
   products: [
     {
       product_id: 'prod_premium_video',
@@ -187,6 +188,7 @@ const SHARED_SYNC_CREATIVES = async (creatives: CreativeAsset[]): Promise<SyncCr
 const SHARED_GET_MEDIA_BUY_DELIVERY = async (
   filter: GetMediaBuyDeliveryRequest
 ): Promise<GetMediaBuyDeliveryResponse> => ({
+  status: 'completed' as const,
   currency: 'USD',
   reporting_period: {
     start: filter.start_date ?? '2026-04-01',
@@ -299,7 +301,7 @@ export class MockHybridSeller implements DecisioningPlatform<MockSellerConfig, M
     getMediaBuyDelivery: SHARED_GET_MEDIA_BUY_DELIVERY,
     // Required on SalesPlatform — empty-array stub (mock seller doesn't
     // persist buys across runs; getMediaBuys returns nothing).
-    getMediaBuys: async () => ({ media_buys: [] }),
+    getMediaBuys: async () => ({ status: 'completed' as const, media_buys: [] }),
   };
 }
 
@@ -325,7 +327,7 @@ export function buildHybridServerExample(platform: MockHybridSeller) {
     mediaBuy: {
       // v5 leftover — listCreativeFormats isn't on SalesPlatform v1.0
       // (deferred to rc.1). Custom handler here fills the gap until then.
-      listCreativeFormats: async () => ({ formats: [] }),
+      listCreativeFormats: async () => ({ status: 'completed' as const, formats: [] }),
     },
   });
 }

--- a/examples/decisioning-platform-programmatic.ts
+++ b/examples/decisioning-platform-programmatic.ts
@@ -98,6 +98,7 @@ export class ProgrammaticSeller implements DecisioningPlatform<ProgrammaticConfi
   sales: SalesCorePlatform<ProgrammaticMeta> & SalesIngestionPlatform<ProgrammaticMeta> = {
     /** Sync discovery: catalog read; no async ceremony. */
     getProducts: async (_req: GetProductsRequest): Promise<GetProductsResponse> => ({
+      status: 'completed' as const,
       products: [
         {
           product_id: 'prod_run_of_network_display',
@@ -227,6 +228,7 @@ export class ProgrammaticSeller implements DecisioningPlatform<ProgrammaticConfi
     },
 
     getMediaBuyDelivery: async (filter: GetMediaBuyDeliveryRequest): Promise<GetMediaBuyDeliveryResponse> => ({
+      status: 'completed' as const,
       currency: 'USD',
       reporting_period: {
         start: filter.start_date ?? '2026-04-01',
@@ -237,6 +239,6 @@ export class ProgrammaticSeller implements DecisioningPlatform<ProgrammaticConfi
 
     // Required on SalesPlatform — the example doesn't model persistent buys,
     // so return empty array. Production adopters would query their store.
-    getMediaBuys: async () => ({ media_buys: [] }),
+    getMediaBuys: async () => ({ status: 'completed' as const, media_buys: [] }),
   };
 }

--- a/examples/hello_creative_adapter_ad_server.ts
+++ b/examples/hello_creative_adapter_ad_server.ts
@@ -561,22 +561,25 @@ class CreativeAdServerAdapter implements DecisioningPlatform<Record<string, neve
       const rendered = await upstream.renderCreative(networkCode, creativeId, {});
       // `previewCreative.single({...})` injects
       // `response_type: 'single'`. SHAPE-GOTCHAS §4.
-      return previewCreative.single({
-        previews: [
-          {
-            preview_id: `prv_${creative.creative_id}`,
-            renders: [
-              urlRender({
-                render_id: `rnd_${creative.creative_id}`,
-                preview_url: rendered.preview_url,
-                role: 'primary',
-              }),
-            ],
-            input: { name: 'default' },
-          },
-        ],
-        expires_at: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
-      });
+      return {
+        status: 'completed' as const,
+        ...previewCreative.single({
+          previews: [
+            {
+              preview_id: `prv_${creative.creative_id}`,
+              renders: [
+                urlRender({
+                  render_id: `rnd_${creative.creative_id}`,
+                  preview_url: rendered.preview_url,
+                  role: 'primary',
+                }),
+              ],
+              input: { name: 'default' },
+            },
+          ],
+          expires_at: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+        }),
+      };
     },
 
     listCreativeFormats: async (_req, _ctx): Promise<ListCreativeFormatsResponse> => {
@@ -585,7 +588,7 @@ class CreativeAdServerAdapter implements DecisioningPlatform<Record<string, neve
       // the API key's principal.
       const networkCode = NETWORK_DEFAULT_CODE;
       const upstreamFormats = await upstream.listFormats(networkCode);
-      return { formats: upstreamFormats.map(projectFormat) };
+      return { status: 'completed' as const, formats: upstreamFormats.map(projectFormat) };
     },
 
     syncCreatives: async (creatives: CreativeAsset[], ctx): Promise<SyncCreativesRow[]> => {

--- a/examples/hello_creative_adapter_template.ts
+++ b/examples/hello_creative_adapter_template.ts
@@ -421,7 +421,7 @@ class CreativeTemplateAdapter implements DecisioningPlatform<Record<string, neve
       // workspace tied to the API key's principal. Mock keys templates
       // per workspace, so we hit a default workspace that has the full set.
       const templates = await upstream.listTemplates(workspaceId);
-      return { formats: templates.map(templateToFormat) };
+      return { status: 'completed', formats: templates.map(templateToFormat) };
     },
 
     buildCreative: async (req: BuildCreativeRequest, ctx): Promise<BuildCreativeReturn> => {
@@ -499,6 +499,12 @@ class CreativeTemplateAdapter implements DecisioningPlatform<Record<string, neve
       if (!req.creative_manifest) {
         throw new AdcpError('INVALID_REQUEST', { message: 'creative_manifest required for single preview' });
       }
+      if (!req.creative_manifest.format_id) {
+        throw new AdcpError('INVALID_REQUEST', {
+          message: 'creative_manifest.format_id required for single preview',
+          field: 'creative_manifest.format_id',
+        });
+      }
 
       // Buyer's manifest carries the input format_id; resolve to upstream.
       const sourceFormatId = req.creative_manifest.format_id.id;
@@ -528,25 +534,28 @@ class CreativeTemplateAdapter implements DecisioningPlatform<Record<string, neve
       // `response_type: 'single'`. The render slot's `output_format`
       // discriminator is in turn injected by `urlRender({...})`.
       // SHAPE-GOTCHAS §4.
-      return previewCreative.single({
-        previews: [
-          {
-            preview_id: `prv_${created.render_id}`,
-            renders: [
-              urlRender({
-                render_id: `rnd_${created.render_id}`,
-                preview_url: previewUrl,
-                role: 'primary',
-                ...(template.dimensions
-                  ? { dimensions: { width: template.dimensions.width, height: template.dimensions.height } }
-                  : {}),
-              }),
-            ],
-            input: { name: 'default' },
-          },
-        ],
-        expires_at: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
-      });
+      return {
+        status: 'completed' as const,
+        ...previewCreative.single({
+          previews: [
+            {
+              preview_id: `prv_${created.render_id}`,
+              renders: [
+                urlRender({
+                  render_id: `rnd_${created.render_id}`,
+                  preview_url: previewUrl,
+                  role: 'primary',
+                  ...(template.dimensions
+                    ? { dimensions: { width: template.dimensions.width, height: template.dimensions.height } }
+                    : {}),
+                }),
+              ],
+              input: { name: 'default' },
+            },
+          ],
+          expires_at: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+        }),
+      };
     },
   });
 }

--- a/examples/hello_seller_adapter_guaranteed.ts
+++ b/examples/hello_seller_adapter_guaranteed.ts
@@ -93,7 +93,7 @@ import type {
 
 // `Product` isn't re-exported from `@adcp/sdk/types` (#1254 in the rollup);
 // derive the shape from the response array.
-type Product = GetProductsResponse['products'][number];
+type Product = NonNullable<GetProductsResponse['products']>[number];
 
 const UPSTREAM_URL = process.env['UPSTREAM_URL'] ?? 'http://127.0.0.1:4450';
 const UPSTREAM_API_KEY = process.env['UPSTREAM_API_KEY'] ?? 'mock_sales_guaranteed_key_do_not_use_in_prod';
@@ -751,7 +751,7 @@ class SalesGuaranteedAdapter implements DecisioningPlatform<Record<string, never
         ...(req.filters?.end_date && { flightEnd: req.filters.end_date }),
         ...(briefBudget !== undefined && { budget: briefBudget }),
       });
-      return { products: guaranteed.map(p => projectProduct(p, publisherDomain)) };
+      return { status: 'completed', products: guaranteed.map(p => projectProduct(p, publisherDomain)) };
     },
 
     /**
@@ -1044,7 +1044,7 @@ class SalesGuaranteedAdapter implements DecisioningPlatform<Record<string, never
           };
         })
       );
-      return { media_buys: buys };
+      return { status: 'completed', media_buys: buys };
     },
 
     syncCreatives: async (creatives, ctx): Promise<SyncCreativesRow[]> => {
@@ -1052,6 +1052,12 @@ class SalesGuaranteedAdapter implements DecisioningPlatform<Record<string, never
       const rows: SyncCreativesRow[] = [];
       for (const c of creatives) {
         try {
+          if (!c.format_id) {
+            throw new AdcpError('INVALID_REQUEST', {
+              message: 'format_id required on creative manifest',
+              field: 'format_id',
+            });
+          }
           const created = await upstream.createCreative(networkCode, {
             name: c.name,
             format_id: c.format_id.id,
@@ -1100,6 +1106,7 @@ class SalesGuaranteedAdapter implements DecisioningPlatform<Record<string, never
       const aggregateClicks = present.reduce((s, d) => s + d.totals.clicks, 0);
 
       return {
+        status: 'completed',
         reporting_period: { start: earliest, end: latest },
         currency,
         aggregated_totals: {

--- a/examples/hello_seller_adapter_non_guaranteed.ts
+++ b/examples/hello_seller_adapter_non_guaranteed.ts
@@ -88,7 +88,7 @@ import type {
 } from '@adcp/sdk/types';
 
 // `Product` isn't re-exported from `@adcp/sdk/types`; derive from response.
-type Product = GetProductsResponse['products'][number];
+type Product = NonNullable<GetProductsResponse['products']>[number];
 
 const UPSTREAM_URL = process.env['UPSTREAM_URL'] ?? 'http://127.0.0.1:4451';
 const UPSTREAM_API_KEY = process.env['UPSTREAM_API_KEY'] ?? 'mock_sales_non_guaranteed_key_do_not_use_in_prod';
@@ -593,7 +593,7 @@ class SalesNonGuaranteedAdapter implements DecisioningPlatform<Record<string, ne
         ...(req.filters?.end_date && { flightEnd: req.filters.end_date }),
         ...(briefBudget !== undefined && { budget: briefBudget }),
       });
-      return { products: products.map(p => projectProduct(p, publisherDomain)) };
+      return { status: 'completed', products: products.map(p => projectProduct(p, publisherDomain)) };
     },
 
     /**
@@ -825,6 +825,7 @@ class SalesNonGuaranteedAdapter implements DecisioningPlatform<Record<string, ne
         );
       }
       const response: GetMediaBuyDeliveryResponse = {
+        status: 'completed',
         currency: filtered[0]?.currency ?? 'USD',
         reporting_period: {
           start: filtered[0]?.reporting_period.start ?? new Date().toISOString(),
@@ -891,7 +892,7 @@ class SalesNonGuaranteedAdapter implements DecisioningPlatform<Record<string, ne
           };
         })
       );
-      const response: GetMediaBuysResponse = { media_buys };
+      const response: GetMediaBuysResponse = { status: 'completed', media_buys };
       return response;
     },
 
@@ -959,6 +960,7 @@ class SalesNonGuaranteedAdapter implements DecisioningPlatform<Record<string, ne
         FormatAsset.url({ asset_id: 'click_url', required: true }),
       ];
       return {
+        status: 'completed',
         formats: [
           {
             format_id: { agent_url: FORMAT_AGENT_URL, id: 'display_300x250' },

--- a/examples/hello_seller_adapter_social.ts
+++ b/examples/hello_seller_adapter_social.ts
@@ -605,6 +605,12 @@ class SalesSocialAdapter implements DecisioningPlatform<Record<string, never>, A
       const rows: SyncCreativesRow[] = [];
       for (const c of creatives) {
         try {
+          if (!c.format_id) {
+            throw new AdcpError('INVALID_REQUEST', {
+              message: 'format_id required on creative manifest',
+              field: 'format_id',
+            });
+          }
           // Project AdCP `CreativeAsset.assets` (the asset map keyed by
           // asset_id) onto the upstream native creative shape. Asset values
           // carry an `asset_type` discriminator; we read the typed sub-shapes

--- a/examples/hello_si_adapter_brand.ts
+++ b/examples/hello_si_adapter_brand.ts
@@ -433,6 +433,7 @@ const sponsoredIntelligence = defineSponsoredIntelligencePlatform<SiBrandMeta>({
         }))
       : undefined;
     const response: SIGetOfferingResponse = {
+      status: 'completed',
       available: offering.available,
       ...(offering.offering_query_id !== undefined ? { offering_token: offering.offering_query_id } : {}),
       ...(offering.offering_query_ttl_seconds !== undefined
@@ -473,6 +474,7 @@ const sponsoredIntelligence = defineSponsoredIntelligencePlatform<SiBrandMeta>({
     });
     const initial = conversation.turns[0];
     return {
+      status: 'completed',
       // conversation_id → session_id (rename only — the brand-side and
       // AdCP-side identifiers are the same opaque token).
       session_id: conversation.conversation_id,
@@ -508,6 +510,7 @@ const sponsoredIntelligence = defineSponsoredIntelligencePlatform<SiBrandMeta>({
     // `si_terminate_session` to formally close.
     const closeProjection = turn.close_recommended ? projectCloseHint(turn.close_recommended) : null;
     return {
+      status: 'completed',
       session_id: turn.conversation_id,
       response: {
         message: turn.assistant_message,
@@ -526,6 +529,7 @@ const sponsoredIntelligence = defineSponsoredIntelligencePlatform<SiBrandMeta>({
     });
     const handoff = conversation.close?.transaction_handoff ?? null;
     return {
+      status: 'completed',
       session_id: conversation.conversation_id,
       terminated: conversation.status === 'closed',
       session_status: 'terminated',

--- a/examples/hello_signals_adapter_marketplace.ts
+++ b/examples/hello_signals_adapter_marketplace.ts
@@ -289,7 +289,7 @@ interface OperatorMeta {
   [key: string]: unknown;
 }
 
-function toAdcpSignal(c: UpstreamCohort): GetSignalsResponse['signals'][number] {
+function toAdcpSignal(c: UpstreamCohort): NonNullable<GetSignalsResponse['signals']>[number] {
   const coverage = c.total_universe > 0 ? Math.round((c.member_count / c.total_universe) * 100) : 0;
   return {
     signal_agent_segment_id: c.cohort_id,
@@ -405,7 +405,7 @@ class SignalMarketplaceAdapter implements DecisioningPlatform<Record<string, nev
               sid.id === c.data_provider_id
           );
         });
-        return { signals: filtered.map(toAdcpSignal) } satisfies GetSignalsResponse;
+        return { status: 'completed', signals: filtered.map(toAdcpSignal) } satisfies GetSignalsResponse;
       }),
 
     activateSignal: (req: ActivateSignalRequest, ctx): Promise<ActivateSignalSuccess> =>

--- a/scripts/check-adopter-types.ts
+++ b/scripts/check-adopter-types.ts
@@ -51,8 +51,8 @@ void extractAdcpErrorFromMcp;
 void extractAdcpErrorFromTransport;
 `;
 
-function run(cmd: string, args: string[], cwd: string): void {
-  execFileSync(cmd, args, { cwd, stdio: 'inherit' });
+function run(cmd: string, args: string[], cwd: string, env?: NodeJS.ProcessEnv): void {
+  execFileSync(cmd, args, { cwd, stdio: 'inherit', env: env ?? process.env });
 }
 
 function main(): void {
@@ -110,8 +110,17 @@ function main(): void {
   );
 
   console.log('[adopter-types] running tsc --noEmit against published types...');
+  // Bump node's heap for tsc — `strict + skipLibCheck:false` against the
+  // 21k-line `tools.generated.d.ts` exceeds the default 4GB heap once
+  // multiple `NonNullable<X['k']>` projections off `GetAdCPCapabilitiesResponse`
+  // accumulate. Real adopters override per their environment; we bump here
+  // so the guard reflects what tsc actually needs to typecheck the surface.
+  const tscEnv: NodeJS.ProcessEnv = {
+    ...process.env,
+    NODE_OPTIONS: [process.env.NODE_OPTIONS, '--max-old-space-size=8192'].filter(Boolean).join(' '),
+  };
   try {
-    run('npx', ['--no-install', 'tsc', '--noEmit'], adopterDir);
+    run('npx', ['--no-install', 'tsc', '--noEmit'], adopterDir, tscEnv);
     console.log('[adopter-types] PASS — published .d.ts files type-check cleanly for an adopter.');
   } catch {
     console.error('[adopter-types] FAIL — published .d.ts files do not type-check on a clean adopter project.');

--- a/scripts/check-adopter-types.ts
+++ b/scripts/check-adopter-types.ts
@@ -17,6 +17,16 @@ import { mkdtempSync, writeFileSync, readdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+// Heap ceiling for the adopter tsc pass. The published `.d.ts` surface
+// across `@adcp/sdk` + `@adcp/sdk/server` pulls in the full 3.1 codegen
+// graph (~25K lines of generated types) without the monorepo's
+// project-wide tsconfig optimizations. On Node's default 4 GiB heap, tsc
+// OOMs during type instantiation before it can emit diagnostics — so
+// adopters debugging the published types get a heap-exhaustion stack
+// trace, not a useful tsc error. 8 GiB clears the current surface with
+// headroom; revisit if the schema cache grows substantially further.
+const TSC_HEAP_MB = 8192;
+
 const REPO_ROOT = join(__dirname, '..');
 
 const ADOPTER_TSCONFIG = {
@@ -110,14 +120,9 @@ function main(): void {
   );
 
   console.log('[adopter-types] running tsc --noEmit against published types...');
-  // Bump node's heap for tsc — `strict + skipLibCheck:false` against the
-  // 21k-line `tools.generated.d.ts` exceeds the default 4GB heap once
-  // multiple `NonNullable<X['k']>` projections off `GetAdCPCapabilitiesResponse`
-  // accumulate. Real adopters override per their environment; we bump here
-  // so the guard reflects what tsc actually needs to typecheck the surface.
   const tscEnv: NodeJS.ProcessEnv = {
     ...process.env,
-    NODE_OPTIONS: [process.env.NODE_OPTIONS, '--max-old-space-size=8192'].filter(Boolean).join(' '),
+    NODE_OPTIONS: [process.env.NODE_OPTIONS, `--max-old-space-size=${TSC_HEAP_MB}`].filter(Boolean).join(' '),
   };
   try {
     run('npx', ['--no-install', 'tsc', '--noEmit'], adopterDir, tscEnv);

--- a/skills/build-decisioning-creative-template/SKILL.md
+++ b/skills/build-decisioning-creative-template/SKILL.md
@@ -140,6 +140,7 @@ class WatermarkPlatform implements DecisioningPlatform<WatermarkConfig, Watermar
       // Use `'single'` for one preview-per-request (the common case for
       // stateless template platforms).
       return {
+        status: 'completed',
         response_type: 'single',
         previews: [
           {

--- a/skills/build-decisioning-platform/advanced/REFERENCE.md
+++ b/skills/build-decisioning-platform/advanced/REFERENCE.md
@@ -56,6 +56,7 @@ const platform = {
 
   sales: {
     getProducts: async (req, ctx) => ({
+      status: 'completed',
       products: [
         {
           product_id: 'p_homepage',
@@ -88,6 +89,7 @@ const platform = {
     }),
     syncCreatives: async (creatives, ctx) => creatives.map(c => ({ creative_id: c.creative_id, action: 'created' })),
     getMediaBuyDelivery: async (filter, ctx) => ({
+      status: 'completed',
       currency: 'USD',
       reporting_period: { start: filter.start_date ?? '2026-04-01', end: filter.end_date ?? '2026-04-30' },
       media_buy_deliveries: [],

--- a/skills/build-decisioning-signal-marketplace/SKILL.md
+++ b/skills/build-decisioning-signal-marketplace/SKILL.md
@@ -87,6 +87,7 @@ class DataMatrixPlatform implements DecisioningPlatform<DataMatrixConfig, DataMa
   signals: SignalsPlatform<DataMatrixMeta> = {
     getSignals: async (_req: GetSignalsRequest): Promise<GetSignalsResponse> => {
       return {
+        status: 'completed',
         signals: [
           {
             signal_id: { source: 'agent', agent_url: 'https://datamatrix.example/signals', id: 'in_market_auto' },

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -375,6 +375,7 @@ export {
 export type { IdempotencyCapabilities } from './utils/capabilities';
 export type { MutatingRequestInput } from './utils/idempotency';
 export { canonicalize, canonicalJsonSha256 } from './utils/jcs';
+export { rollupOptimizationMetricsFromProducts } from './utils/capability-rollups';
 
 // ====== CORE TYPES ======
 export * from './types';

--- a/src/lib/server/decisioning/capabilities.ts
+++ b/src/lib/server/decisioning/capabilities.ts
@@ -20,6 +20,16 @@ import type {
   GetAdCPCapabilitiesResponse,
 } from '../../types/tools.generated';
 
+/**
+ * Pre-resolved alias for the wire `media_buy` block. Used as the projection
+ * source for the five `media_buy.*` capability fields below so each typed
+ * field references a single resolved shape instead of re-walking the
+ * `GetAdCPCapabilitiesResponse` type graph independently. Without the
+ * alias, `strict + skipLibCheck:false` adopters hit the TS instantiation
+ * budget on the published `.d.ts` and tsc OOMs.
+ */
+type _MediaBuyCapabilities = NonNullable<GetAdCPCapabilitiesResponse['media_buy']>;
+
 export interface DecisioningCapabilities<TConfig = unknown> {
   /**
    * Specialisms claimed; framework type-checks these against implemented platform
@@ -91,7 +101,7 @@ export interface DecisioningCapabilities<TConfig = unknown> {
    *
    * Wire spec: `core/get-adcp-capabilities-response.json#media_buy.audience_targeting`.
    */
-  audience_targeting?: NonNullable<NonNullable<GetAdCPCapabilitiesResponse['media_buy']>['audience_targeting']>;
+  audience_targeting?: NonNullable<_MediaBuyCapabilities['audience_targeting']>;
 
   /**
    * Conversion-tracking capabilities — projected onto
@@ -103,7 +113,7 @@ export interface DecisioningCapabilities<TConfig = unknown> {
    *
    * Wire spec: `core/get-adcp-capabilities-response.json#media_buy.conversion_tracking`.
    */
-  conversion_tracking?: NonNullable<NonNullable<GetAdCPCapabilitiesResponse['media_buy']>['conversion_tracking']>;
+  conversion_tracking?: NonNullable<_MediaBuyCapabilities['conversion_tracking']>;
 
   /**
    * Content-standards capabilities — projected onto
@@ -115,7 +125,7 @@ export interface DecisioningCapabilities<TConfig = unknown> {
    *
    * Wire spec: `core/get-adcp-capabilities-response.json#media_buy.content_standards`.
    */
-  content_standards?: NonNullable<NonNullable<GetAdCPCapabilitiesResponse['media_buy']>['content_standards']>;
+  content_standards?: NonNullable<_MediaBuyCapabilities['content_standards']>;
 
   /**
    * Seller-level rollup of optimization metrics — projected onto
@@ -132,9 +142,7 @@ export interface DecisioningCapabilities<TConfig = unknown> {
    *
    * Wire spec: `core/get-adcp-capabilities-response.json#media_buy.supported_optimization_metrics`.
    */
-  supported_optimization_metrics?: NonNullable<
-    NonNullable<GetAdCPCapabilitiesResponse['media_buy']>['supported_optimization_metrics']
-  >;
+  supported_optimization_metrics?: NonNullable<_MediaBuyCapabilities['supported_optimization_metrics']>;
 
   /**
    * Frequency-cap support declaration — projected onto
@@ -146,7 +154,7 @@ export interface DecisioningCapabilities<TConfig = unknown> {
    *
    * Wire spec: `core/get-adcp-capabilities-response.json#media_buy.frequency_capping`.
    */
-  frequency_capping?: NonNullable<NonNullable<GetAdCPCapabilitiesResponse['media_buy']>['frequency_capping']>;
+  frequency_capping?: NonNullable<_MediaBuyCapabilities['frequency_capping']>;
 
   /**
    * Brand-protocol capabilities. Projected onto the wire `brand` block of

--- a/src/lib/server/decisioning/capabilities.ts
+++ b/src/lib/server/decisioning/capabilities.ts
@@ -118,6 +118,37 @@ export interface DecisioningCapabilities<TConfig = unknown> {
   content_standards?: NonNullable<NonNullable<GetAdCPCapabilitiesResponse['media_buy']>['content_standards']>;
 
   /**
+   * Seller-level rollup of optimization metrics — projected onto
+   * `get_adcp_capabilities.media_buy.supported_optimization_metrics`.
+   * Added in AdCP 3.1 (adcp#4669). The array union of every product's
+   * `metric_optimization.supported_metrics`. Storyboard runners gate
+   * `metric_optimization`-using scenarios on this field; declaring it
+   * gives buyers an upfront signal of which optimization metrics the
+   * seller can compute against (clicks, views, completed_views, etc.).
+   *
+   * Adopters can compute the rollup from their catalog using the
+   * exported {@link rollupOptimizationMetricsFromProducts} helper —
+   * keeps the declaration in sync with what products actually offer.
+   *
+   * Wire spec: `core/get-adcp-capabilities-response.json#media_buy.supported_optimization_metrics`.
+   */
+  supported_optimization_metrics?: NonNullable<
+    NonNullable<GetAdCPCapabilitiesResponse['media_buy']>['supported_optimization_metrics']
+  >;
+
+  /**
+   * Frequency-cap support declaration — projected onto
+   * `get_adcp_capabilities.media_buy.frequency_capping`. Added in AdCP
+   * 3.1 (adcp#4670). Presence-only object with `supported_per_units` /
+   * `supported_window_units` sub-fields declaring which frequency-cap
+   * shapes the platform honors. Omit when the platform doesn't accept
+   * frequency caps at all; buyers will avoid the field on `pacing.*`.
+   *
+   * Wire spec: `core/get-adcp-capabilities-response.json#media_buy.frequency_capping`.
+   */
+  frequency_capping?: NonNullable<NonNullable<GetAdCPCapabilitiesResponse['media_buy']>['frequency_capping']>;
+
+  /**
    * Brand-protocol capabilities. Projected onto the wire `brand` block of
    * `get_adcp_capabilities` (`brand: { rights, right_types, available_uses,
    * generation_providers, description }`). The framework auto-derives

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -964,23 +964,31 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
   // Project per-domain capability blocks declared on the platform onto
   // get_adcp_capabilities via createAdcpServer's `overrides.media_buy`
   // deep-merge seam. Adopters declare audience_targeting /
-  // conversion_tracking / content_standards on `platform.capabilities`;
-  // the framework wires the deep-merge so buyers see the discovery
-  // fields without an opaque custom get_adcp_capabilities tool (which
-  // the framework refuses anyway).
+  // conversion_tracking / content_standards / supported_optimization_metrics
+  // / frequency_capping on `platform.capabilities`; the framework wires
+  // the deep-merge so buyers see the discovery fields without an opaque
+  // custom get_adcp_capabilities tool (which the framework refuses anyway).
   //
   // Each rich block also forces the corresponding `media_buy.features.*`
   // boolean to `true`. Buyers gating on `features.audience_targeting`
   // (which the framework auto-derives as `false` by default) would
   // otherwise skip the rich block sitting next to it.
+  //
+  // `supported_optimization_metrics` (adcp#4669) and `frequency_capping`
+  // (adcp#4670) are AdCP 3.1 additions. They have no corresponding
+  // `features.*` boolean — buyers gate on presence of the block itself.
   const at = platform.capabilities.audience_targeting;
   const ct = platform.capabilities.conversion_tracking;
   const cs = platform.capabilities.content_standards;
-  const hasMediaBuyProjection = at != null || ct != null || cs != null;
+  const som = platform.capabilities.supported_optimization_metrics;
+  const fc = platform.capabilities.frequency_capping;
+  const hasMediaBuyProjection = at != null || ct != null || cs != null || som != null || fc != null;
   const mediaBuyOverrides: Partial<NonNullable<GetAdCPCapabilitiesResponse['media_buy']>> = {
     ...(at != null && { audience_targeting: at }),
     ...(ct != null && { conversion_tracking: ct }),
     ...(cs != null && { content_standards: cs }),
+    ...(som != null && { supported_optimization_metrics: som }),
+    ...(fc != null && { frequency_capping: fc }),
     ...(hasMediaBuyProjection && {
       features: {
         ...(at != null && { audience_targeting: true }),

--- a/src/lib/utils/capability-rollups.ts
+++ b/src/lib/utils/capability-rollups.ts
@@ -1,0 +1,72 @@
+/**
+ * Helpers for deriving seller-level capability summaries from the
+ * product catalog. Some `get_adcp_capabilities.media_buy.*` fields are
+ * rollups of facts that already live at the product level — hand-
+ * maintaining the rollup is a drift surface (out of sync the moment a
+ * product changes). These helpers compute the rollup so the declaration
+ * stays mechanically derived.
+ *
+ * Adopters call the helpers at startup (or whenever their catalog
+ * mutates) and pass the result to `platform.capabilities.*`:
+ *
+ * ```ts
+ * import { rollupOptimizationMetricsFromProducts } from '@adcp/sdk';
+ *
+ * const products = await loadProductCatalog();
+ * const platform: DecisioningPlatform = {
+ *   capabilities: {
+ *     supported_optimization_metrics: rollupOptimizationMetricsFromProducts(products),
+ *     // ...
+ *   },
+ * };
+ * ```
+ *
+ * @public
+ */
+
+import type { Product } from '../types/tools.generated';
+
+/** Minimum shape needed to derive the rollup — accepts any object that
+ *  carries the spec's `metric_optimization.supported_metrics` array. */
+interface ProductLike {
+  metric_optimization?: {
+    supported_metrics?: ReadonlyArray<string>;
+  };
+}
+
+/**
+ * Compute `media_buy.supported_optimization_metrics` from a product
+ * catalog. Per AdCP 3.1 (adcp#4669), this field is the array union of
+ * every product's `metric_optimization.supported_metrics`.
+ *
+ * Returns a sorted, de-duplicated array. Empty union → empty array;
+ * callers SHOULD treat an empty result as "omit the field" (the wire
+ * description says an absent field means "seller declares no specific
+ * guarantees").
+ *
+ * Stable ordering (alphabetical) so the declaration doesn't churn on
+ * insertion order. Pure function; safe to call repeatedly.
+ *
+ * @example
+ * ```ts
+ * const products: Product[] = [
+ *   { metric_optimization: { supported_metrics: ['clicks', 'views'] } },
+ *   { metric_optimization: { supported_metrics: ['views', 'completed_views'] } },
+ * ];
+ * rollupOptimizationMetricsFromProducts(products);
+ * // → ['clicks', 'completed_views', 'views']
+ * ```
+ */
+export function rollupOptimizationMetricsFromProducts<T extends ProductLike = Product>(
+  products: ReadonlyArray<T>
+): string[] {
+  const seen = new Set<string>();
+  for (const p of products) {
+    const metrics = p.metric_optimization?.supported_metrics;
+    if (!Array.isArray(metrics)) continue;
+    for (const m of metrics) {
+      if (typeof m === 'string' && m.length > 0) seen.add(m);
+    }
+  }
+  return Array.from(seen).sort();
+}

--- a/test/lib/adcp-version-option.test.js
+++ b/test/lib/adcp-version-option.test.js
@@ -32,8 +32,8 @@ describe('adcpVersion constructor option', () => {
     });
 
     test('returns the configured value when provided', () => {
-      const client = new SingleAgentClient(TEST_AGENT, { adcpVersion: '3.0.0' });
-      assert.strictEqual(client.getAdcpVersion(), '3.0.0');
+      const client = new SingleAgentClient(TEST_AGENT, { adcpVersion: '3.1.0-beta.3' });
+      assert.strictEqual(client.getAdcpVersion(), '3.1.0-beta.3');
     });
   });
 
@@ -44,8 +44,8 @@ describe('adcpVersion constructor option', () => {
     });
 
     test('returns the configured value when provided', () => {
-      const client = new AgentClient(TEST_AGENT, { adcpVersion: '3.0.0' });
-      assert.strictEqual(client.getAdcpVersion(), '3.0.0');
+      const client = new AgentClient(TEST_AGENT, { adcpVersion: '3.1.0-beta.3' });
+      assert.strictEqual(client.getAdcpVersion(), '3.1.0-beta.3');
     });
   });
 
@@ -56,8 +56,8 @@ describe('adcpVersion constructor option', () => {
     });
 
     test('returns the configured value when provided', () => {
-      const client = new ADCPMultiAgentClient([TEST_AGENT], { adcpVersion: '3.0.0' });
-      assert.strictEqual(client.getAdcpVersion(), '3.0.0');
+      const client = new ADCPMultiAgentClient([TEST_AGENT], { adcpVersion: '3.1.0-beta.3' });
+      assert.strictEqual(client.getAdcpVersion(), '3.1.0-beta.3');
     });
   });
 
@@ -71,24 +71,24 @@ describe('adcpVersion constructor option', () => {
       const server = createAdcpServer({
         name: 'test-server',
         version: '1.0.0',
-        adcpVersion: '3.0.0',
+        adcpVersion: '3.1.0-beta.3',
       });
-      assert.strictEqual(server.getAdcpVersion(), '3.0.0');
+      assert.strictEqual(server.getAdcpVersion(), '3.1.0-beta.3');
     });
 
     test('config.version (app version) and adcpVersion are independent', () => {
       const server = createAdcpServer({
         name: 'test-server',
         version: '7.4.2', // publisher app version
-        adcpVersion: '3.0.0', // protocol version
+        adcpVersion: '3.1.0-beta.3', // protocol version
       });
-      assert.strictEqual(server.getAdcpVersion(), '3.0.0');
+      assert.strictEqual(server.getAdcpVersion(), '3.1.0-beta.3');
     });
   });
 
   describe('parseAdcpMajorVersion', () => {
     test('extracts major from semver', () => {
-      assert.strictEqual(parseAdcpMajorVersion('3.0.1'), 3);
+      assert.strictEqual(parseAdcpMajorVersion('3.1.0-beta.3'), 3);
       assert.strictEqual(parseAdcpMajorVersion('3.0.0'), 3);
       assert.strictEqual(parseAdcpMajorVersion('4.0.0'), 4);
     });
@@ -110,11 +110,12 @@ describe('adcpVersion constructor option', () => {
     });
 
     test('accepts pins that resolve to a bundled version', () => {
-      // SDK ships bundle for ADCP_VERSION's minor; '3.0.0' / '3.0.1' / '3.0'
-      // all collapse to that bundle and accept.
-      assert.strictEqual(resolveAdcpVersion('3.0.0'), '3.0.0');
-      assert.strictEqual(resolveAdcpVersion('3.0.1'), '3.0.1');
-      assert.strictEqual(resolveAdcpVersion('3.0'), '3.0');
+      // SDK bundles the current ADCP_VERSION ('3.1.0-beta.3'). The full-semver
+      // pin, the release-precision prerelease pin, and the release-precision
+      // pin without a numeric tag all resolve to the same bundle.
+      assert.strictEqual(resolveAdcpVersion('3.1.0-beta.3'), '3.1.0-beta.3');
+      assert.strictEqual(resolveAdcpVersion('3.1-beta.3'), '3.1-beta.3');
+      assert.strictEqual(resolveAdcpVersion('3.1-beta'), '3.1-beta');
     });
 
     test('rejects pins for which no schema bundle ships', () => {

--- a/test/lib/backward-compat-schema.test.js
+++ b/test/lib/backward-compat-schema.test.js
@@ -21,6 +21,7 @@ describe('Backward compat: get_media_buy_delivery schema', () => {
     if (!schemas) schemas = await import('../../dist/lib/types/schemas.generated.js');
 
     const response = {
+      status: 'completed',
       reporting_period: { start: '2026-02-13T00:00:00Z', end: '2026-03-04T00:00:00Z' },
       currency: 'USD',
       media_buy_deliveries: [
@@ -51,6 +52,7 @@ describe('Backward compat: get_media_buy_delivery schema', () => {
     if (!schemas) schemas = await import('../../dist/lib/types/schemas.generated.js');
 
     const response = {
+      status: 'completed',
       reporting_period: { start: '2026-02-13T00:00:00Z', end: '2026-03-04T00:00:00Z' },
       currency: 'USD',
       media_buy_deliveries: [
@@ -82,6 +84,7 @@ describe('Backward compat: get_media_buy_delivery schema', () => {
 
     // Second real failure case from logs: by_package[1] has no rate but by_package[0] does
     const response = {
+      status: 'completed',
       reporting_period: { start: '2026-02-13T00:00:00Z', end: '2026-03-04T00:00:00Z' },
       currency: 'USD',
       media_buy_deliveries: [
@@ -121,6 +124,7 @@ describe('Backward compat: get_media_buy_delivery schema', () => {
     if (!schemas) schemas = await import('../../dist/lib/types/schemas.generated.js');
 
     const response = {
+      status: 'completed',
       reporting_period: { start: '2026-02-13T00:00:00Z', end: '2026-03-04T00:00:00Z' },
       currency: 'USD',
       media_buy_deliveries: [
@@ -152,6 +156,7 @@ describe('Backward compat: get_media_buy_delivery schema', () => {
     if (!schemas) schemas = await import('../../dist/lib/types/schemas.generated.js');
 
     const response = {
+      status: 'completed',
       reporting_period: { start: '2026-02-13T00:00:00Z', end: '2026-03-04T00:00:00Z' },
       currency: 'USD',
       media_buy_deliveries: [
@@ -190,6 +195,7 @@ describe('Backward compat: get_media_buys schema', () => {
     if (!schemas) schemas = await import('../../dist/lib/types/schemas.generated.js');
 
     const response = {
+      status: 'completed',
       media_buys: [
         {
           media_buy_id: 'mb_test',
@@ -209,6 +215,7 @@ describe('Backward compat: get_media_buys schema', () => {
     if (!schemas) schemas = await import('../../dist/lib/types/schemas.generated.js');
 
     const response = {
+      status: 'completed',
       media_buys: [
         {
           media_buy_id: 'mb_test',

--- a/test/lib/capability-rollups.test.js
+++ b/test/lib/capability-rollups.test.js
@@ -1,0 +1,69 @@
+/**
+ * Tests for the seller-level capability rollup helpers
+ * (adcp-client#1818).
+ */
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert');
+
+const { rollupOptimizationMetricsFromProducts } = require('../../dist/lib/utils/capability-rollups.js');
+
+describe('rollupOptimizationMetricsFromProducts', () => {
+  test('returns empty array for empty catalog', () => {
+    assert.deepStrictEqual(rollupOptimizationMetricsFromProducts([]), []);
+  });
+
+  test('unions metrics across products', () => {
+    const result = rollupOptimizationMetricsFromProducts([
+      { metric_optimization: { supported_metrics: ['clicks', 'views'] } },
+      { metric_optimization: { supported_metrics: ['views', 'completed_views'] } },
+    ]);
+    assert.deepStrictEqual(result, ['clicks', 'completed_views', 'views']);
+  });
+
+  test('de-duplicates within and across products', () => {
+    const result = rollupOptimizationMetricsFromProducts([
+      { metric_optimization: { supported_metrics: ['clicks', 'clicks', 'views'] } },
+      { metric_optimization: { supported_metrics: ['clicks'] } },
+    ]);
+    assert.deepStrictEqual(result, ['clicks', 'views']);
+  });
+
+  test('sorts alphabetically for stable declarations', () => {
+    const result = rollupOptimizationMetricsFromProducts([
+      { metric_optimization: { supported_metrics: ['views', 'clicks', 'completed_views'] } },
+    ]);
+    assert.deepStrictEqual(result, ['clicks', 'completed_views', 'views']);
+  });
+
+  test('products without metric_optimization contribute nothing', () => {
+    const result = rollupOptimizationMetricsFromProducts([
+      { metric_optimization: { supported_metrics: ['clicks'] } },
+      {},
+      { name: 'no metric_optimization' },
+    ]);
+    assert.deepStrictEqual(result, ['clicks']);
+  });
+
+  test('products with empty supported_metrics contribute nothing', () => {
+    const result = rollupOptimizationMetricsFromProducts([
+      { metric_optimization: { supported_metrics: [] } },
+      { metric_optimization: {} },
+    ]);
+    assert.deepStrictEqual(result, []);
+  });
+
+  test('drops non-string entries defensively', () => {
+    const result = rollupOptimizationMetricsFromProducts([
+      { metric_optimization: { supported_metrics: ['clicks', null, undefined, '', 42] } },
+    ]);
+    assert.deepStrictEqual(result, ['clicks']);
+  });
+
+  test('does not mutate input', () => {
+    const input = [{ metric_optimization: { supported_metrics: ['views', 'clicks'] } }];
+    const original = JSON.parse(JSON.stringify(input));
+    rollupOptimizationMetricsFromProducts(input);
+    assert.deepStrictEqual(input, original);
+  });
+});

--- a/test/server-decisioning-capability-projections.test.js
+++ b/test/server-decisioning-capability-projections.test.js
@@ -326,7 +326,7 @@ describe('Capability projections — declarative capability blocks on Decisionin
     assert.deepStrictEqual(account.supported_billing, ['agent']);
   });
 
-  it('omitting all three leaves get_adcp_capabilities unchanged (no empty media_buy block)', async () => {
+  it('omitting all five leaves get_adcp_capabilities unchanged (no empty media_buy block)', async () => {
     const server = createAdcpServerFromPlatform(basePlatform(), {
       name: 'h',
       version: '0.0.1',
@@ -335,9 +335,65 @@ describe('Capability projections — declarative capability blocks on Decisionin
     const result = await dispatchCapabilities(server);
     const mb = result.structuredContent?.media_buy;
     // media_buy may exist with framework-derived defaults — what we want is
-    // that the three projection blocks are absent when not declared.
+    // that the projection blocks are absent when not declared.
     assert.strictEqual(mb?.audience_targeting, undefined);
     assert.strictEqual(mb?.conversion_tracking, undefined);
     assert.strictEqual(mb?.content_standards, undefined);
+    assert.strictEqual(mb?.supported_optimization_metrics, undefined);
+    assert.strictEqual(mb?.frequency_capping, undefined);
+  });
+
+  // AdCP 3.1 additions — adcp#4669 (supported_optimization_metrics) +
+  // adcp#4670 (frequency_capping). Closes adcp-client#1853 projection gap.
+
+  it('supported_optimization_metrics projects onto get_adcp_capabilities.media_buy', async () => {
+    const server = createAdcpServerFromPlatform(
+      basePlatform({
+        supported_optimization_metrics: ['clicks', 'completed_views', 'views'],
+      }),
+      { name: 'h', version: '0.0.1', validation: { requests: 'off', responses: 'off' } }
+    );
+    const result = await dispatchCapabilities(server);
+    const som = result.structuredContent?.media_buy?.supported_optimization_metrics;
+    assert.ok(som, `supported_optimization_metrics missing: ${JSON.stringify(result.structuredContent?.media_buy)}`);
+    assert.deepStrictEqual(som, ['clicks', 'completed_views', 'views']);
+  });
+
+  it('frequency_capping projects onto get_adcp_capabilities.media_buy', async () => {
+    const server = createAdcpServerFromPlatform(
+      basePlatform({
+        frequency_capping: {
+          supported_per_units: ['impression'],
+          supported_window_units: ['day', 'week'],
+        },
+      }),
+      { name: 'h', version: '0.0.1', validation: { requests: 'off', responses: 'off' } }
+    );
+    const result = await dispatchCapabilities(server);
+    const fc = result.structuredContent?.media_buy?.frequency_capping;
+    assert.ok(fc, `frequency_capping missing: ${JSON.stringify(result.structuredContent?.media_buy)}`);
+    assert.deepStrictEqual(fc.supported_per_units, ['impression']);
+    assert.deepStrictEqual(fc.supported_window_units, ['day', 'week']);
+  });
+
+  it('the 3.1 additions do NOT flip features.* booleans (presence-of-block is the gate)', async () => {
+    const server = createAdcpServerFromPlatform(
+      basePlatform({
+        supported_optimization_metrics: ['clicks'],
+        frequency_capping: {
+          supported_per_units: ['impression'],
+          supported_window_units: ['day'],
+        },
+      }),
+      { name: 'h', version: '0.0.1', validation: { requests: 'off', responses: 'off' } }
+    );
+    const result = await dispatchCapabilities(server);
+    const features = result.structuredContent?.media_buy?.features ?? {};
+    // Framework auto-derives the existing flags as `false` when no rich
+    // block is declared. The 3.1 additions must NOT flip them to `true` —
+    // their gate is presence-of-block, not a features.* mirror.
+    assert.notStrictEqual(features.audience_targeting, true);
+    assert.notStrictEqual(features.conversion_tracking, true);
+    assert.notStrictEqual(features.content_standards, true);
   });
 });


### PR DESCRIPTION
Closes #1853 and #1818.

## #1853 — Projection gap

AdCP 3.1 added two top-level \`media_buy.*\` capability fields:
- \`supported_optimization_metrics\` ([adcp#4669](https://github.com/adcontextprotocol/adcp/pull/4669))
- \`frequency_capping\` ([adcp#4670](https://github.com/adcontextprotocol/adcp/pull/4670))

\`from-platform.ts\` only projected three rich blocks (\`audience_targeting\`, \`conversion_tracking\`, \`content_standards\`). Adopters who declared the new fields on \`platform.capabilities\` saw them silently dropped from the V6 wire response. Now wired through the same \`overrides.media_buy\` deep-merge seam.

**Typed surface** — both fields added to \`DecisioningCapabilities\` interface with JSDoc + wire-spec refs.

**Subtle:** the 3.1 additions do NOT force a \`features.*\` boolean (unlike the older three blocks). Buyers gate on presence-of-block directly. The new fields slot in beside the existing ones without touching the features mirror.

## #1818 — Catalog rollup helper

New exported helper \`rollupOptimizationMetricsFromProducts(products)\` computes the seller-level union from a product catalog:

\`\`\`ts
import { rollupOptimizationMetricsFromProducts } from '@adcp/sdk';

const products = await loadProductCatalog();
const platform: DecisioningPlatform = {
  capabilities: {
    supported_optimization_metrics: rollupOptimizationMetricsFromProducts(products),
    // ...
  },
};
\`\`\`

Returns a sorted, deduplicated array. Stable alphabetical ordering so declaration doesn't churn on catalog insertion order. Pure function; safe to call repeatedly. Closes the drift surface called out in #1818 — adopters keep the seller-level declaration mechanically derived from product-level facts.

**\`supported_targets\` portion of #1818 deferred** — \`value_field\` support isn't tracked per-product today, so a full rollup isn't mechanical. Adopters declare manually until the spec gives us a per-product signal. Worth filing as a spec-clarification issue upstream.

## Verification

- \`tsc --noEmit --project tsconfig.lib.json\` clean
- \`npm run build:lib\` clean
- 8 unit tests on the rollup helper (union, dedup, sort, empty, defensive-drop, non-mutating)
- 3 new integration tests on the projection
- All 25 affected tests pass
- prettier --check clean

## What it ships as

With pre-mode active on main, this lands as **\`8.1.0-beta.N\`** (minor bump, next prerelease number). Adopters running \`@adcp/sdk@beta\` get the new fields automatically.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>