### PR TITLE
fix(test): unblock 8.1.0-beta.0 publish — envelope status on prepublish zod fixtures

### DIFF
--- a/.changeset/fix-zod-schemas-test-envelope-status.md
+++ b/.changeset/fix-zod-schemas-test-envelope-status.md
@@ -1,0 +1,9 @@
+---
+'@adcp/sdk': patch
+---
+
+fix(test): add envelope `status: 'completed'` to zod-schemas test fixtures
+
+`test/lib/zod-schemas.test.js` is part of the `prepublishOnly` gate (one of the 3 test files the publish script runs). Its fixtures predate AdCP 3.1.0-beta.2's envelope-`status`-required change, so they fail to validate against the regenerated `*ResponseSchema` Zod schemas. This blocks `8.1.0-beta.0` from publishing.
+
+8 fixtures (across `GetProductsResponse`, `GetMediaBuysResponse`, `GetMediaBuyDeliveryResponse`, `GetSignalsResponse`) now carry `status: 'completed'` as the first field. No other test logic changes.

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP SDK library version
  */
-export const LIBRARY_VERSION = '8.0.0';
+export const LIBRARY_VERSION = '8.1.0-beta.0';
 
 /**
  * AdCP specification version this library is built for
@@ -63,10 +63,10 @@ export type AdcpVersion = (typeof COMPATIBLE_ADCP_VERSIONS)[number];
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '8.0.0',
+  library: '8.1.0-beta.0',
   adcp: '3.1.0-beta.3',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-05-22T14:21:47.972Z',
+  generatedAt: '2026-05-22T15:58:01.281Z',
 } as const;
 
 /**

--- a/test/lib/zod-schemas.test.js
+++ b/test/lib/zod-schemas.test.js
@@ -87,6 +87,7 @@ describe('Zod Schema Validation', () => {
     }
 
     const validResponse = {
+      status: 'completed',
       products: [],
     };
 
@@ -176,6 +177,7 @@ describe('Zod Schema Validation', () => {
     assert.ok(schemas.GetMediaBuysResponseSchema, 'GetMediaBuysResponseSchema should exist');
 
     const validResponse = {
+      status: 'completed',
       media_buys: [
         {
           media_buy_id: 'mb_123',
@@ -213,6 +215,7 @@ describe('Zod Schema Validation', () => {
     }
 
     const validResponse = {
+      status: 'completed',
       media_buys: [
         {
           media_buy_id: 'mb_123',
@@ -249,6 +252,7 @@ describe('Zod Schema Validation', () => {
     }
 
     const invalidResponse = {
+      status: 'completed',
       media_buys: [
         {
           media_buy_id: 'mb_123',
@@ -281,6 +285,7 @@ describe('Zod Schema Validation', () => {
 
     // Missing required: status, currency, total_budget, packages
     const invalidResponse = {
+      status: 'completed',
       media_buys: [
         {
           media_buy_id: 'mb_123',
@@ -317,6 +322,7 @@ describe('Zod Schema Validation', () => {
     }
 
     const validResponse = {
+      status: 'completed',
       media_buys: [
         {
           media_buy_id: 'mb_123',
@@ -350,6 +356,7 @@ describe('Zod Schema Validation', () => {
     }
 
     const validResponse = {
+      status: 'completed',
       media_buys: [
         {
           media_buy_id: 'mb_456',
@@ -389,6 +396,7 @@ describe('Zod Schema Validation', () => {
     }
 
     const validResponse = {
+      status: 'completed',
       media_buys: [
         {
           media_buy_id: 'mb_789',
@@ -849,6 +857,7 @@ describe('Zod Schema Validation', () => {
     }
 
     const response = {
+      status: 'completed',
       signals: [
         {
           signal_id: { source: 'agent', agent_url: 'https://signals.example.com', id: 'sig-001' },


### PR DESCRIPTION
**Root cause of the failed 8.1.0-beta.0 publish.**

After #1936 (Release PR) merged, the publish workflow ran the \`prepublishOnly\` gate:

\`\`\`
npm run clean && sync-schemas:all && build:lib && node --test test/lib/{adcp-client,validation,zod-schemas}.test.js
\`\`\`

\`test/lib/zod-schemas.test.js\` had **7 fixtures** that build response shapes (\`GetProductsResponse\`, \`GetMediaBuysResponse\`, \`GetMediaBuyDeliveryResponse\`, \`GetSignalsResponse\`) without the envelope \`status\` field. AdCP 3.1.0-beta.2 made \`status\` REQUIRED, so these fixtures fail validation against the regenerated schemas. The publish workflow exited 1 and \`@adcp/sdk@8.1.0-beta.0\` never reached npm — while \`@adcp/eslint-plugin@0.1.3-beta.0\` did publish (no prepublish gate).

Fix: inject \`status: 'completed'\` as the first field on the 8 failing fixtures (one was added separately for the signals path). All 77 prepublish tests pass after the change.

**Why I missed this in the foundation sweep**: the file is in \`test/lib/\` not \`test/server-decisioning/\` where the earlier sweep focused, and its fixtures are direct \`safeParse()\` calls rather than going through \`from-platform\` builders. No-op for normal CI; only the publish gate caught it.

**After merge** the release workflow will re-run and (assuming changesets recomputes correctly) cut a fresh prerelease (likely \`8.1.0-beta.1\` since 8.1.0-beta.0 is "consumed" by the failed publish attempt's git tag).