### PR TITLE
fix(media-buy): use generated 3.1 types for available_actions surface

### DIFF
--- a/.changeset/media-buy-3-1-types.md
+++ b/.changeset/media-buy-3-1-types.md
@@ -1,0 +1,15 @@
+---
+'@adcp/sdk': minor
+---
+
+fix(media-buy): use generated 3.1 types for `available_actions[]` surface
+
+The hand-written wire-shape types in `src/lib/media-buy/types.ts` (`MediaBuyValidAction`, `MediaBuyActionMode`, `MediaBuyAvailableAction`, `ActionNotAllowedReason`, `ActionNotAllowedDetails`, and the SLA window) are deleted and replaced with re-exports from `src/lib/types/core.generated.ts` now that the AdCP 3.1.0-beta.3 schema cache produces them.
+
+**Breaking type shape fix.** The previously-shipped `SlaWindow` was `{ unit, value, response_max? }`. The spec evolved to `SLAWindow` (caps, ISO acronym convention) with shape `{ response_max?, completion_max? }` where both are ISO 8601 duration strings. Adopters reading `available_actions[0].sla.response_max` against the prior type would have hit a runtime shape mismatch when sellers actually populated `sla`. `SLAWindow` is the canonical export; `SlaWindow` remains as a deprecated import-compatibility alias to the corrected generated shape.
+
+Helper-local types stay: `LEGACY_COARSE_ACTIONS`, `LegacyCoarseAction`, `MediaBuyActionContext`, `UpdateMediaBuyRequestLike`. These are convenience subsets the preflight resolver reads against and aren't part of the wire schema.
+
+`scripts/generate-media-buy-update-fields.ts` re-ran against the real 3.1.0-beta.3 cache. The generated `enumMetadata.update_fields` table is unchanged from the snapshot taken against the merged-but-pre-release upstream copy.
+
+Preflight logic, boolean gates, `ActionNotAllowedError`, and the compat shim for `valid_actions[]` are unchanged.

--- a/scripts/check-adopter-types.ts
+++ b/scripts/check-adopter-types.ts
@@ -99,6 +99,9 @@ import type {
   AccountReference,
   CreateMediaBuyPayload as RootCreateMediaBuyPayload,
   GetProductsPayload as RootGetProductsPayload,
+  MediaBuyAvailableAction,
+  SLAWindow,
+  SlaWindow,
   UpdateMediaBuyPayload as RootUpdateMediaBuyPayload,
 } from '@adcp/sdk';
 import { customToolFor, customToolForSchema, TOOL_INPUT_SCHEMAS, TOOL_INPUT_SHAPES, TOOL_REQUEST_SCHEMAS } from '@adcp/sdk/schemas';
@@ -293,9 +296,17 @@ const _rootGetProductsPayload: RootGetProductsPayload = { products: [], cache_sc
 const _typesGetProductsPayload: TypesGetProductsPayload = _rootGetProductsPayload;
 const _rootUpdatePayload: RootUpdateMediaBuyPayload = { media_buy_id: 'mb_1' };
 const _typesUpdatePayload: TypesUpdateMediaBuyPayload = _rootUpdatePayload;
+const _slaWindow: SLAWindow = { response_max: 'PT1H', completion_max: 'P1D' };
+const _legacySlaWindow: SlaWindow = _slaWindow;
+const _availableAction: MediaBuyAvailableAction = {
+  action: 'pause',
+  mode: 'self_serve',
+  sla: _legacySlaWindow,
+};
 void _typesPayloadAlias;
 void _typesGetProductsPayload;
 void _typesUpdatePayload;
+void _availableAction;
 // @ts-expect-error named payload aliases must not expose SDK-owned protocol envelope fields
 void _rootPayloadAlias.task_id;
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -327,10 +327,8 @@ export type {
 } from './errors';
 
 // ====== MEDIA BUY ACTIONS (AdCP 3.1 / RFC #4480) ======
-// Note: the 3.1-extended `MediaBuyValidAction` lives in `./media-buy` and is
-// not re-exported here. The top-level `MediaBuyValidAction` continues to
-// reflect whatever the schema-cache codegen produces; import the extended
-// vocabulary from `@adcp/sdk/media-buy` directly to avoid shadowing.
+// Wire-shape action types are generated; helper result/context types live in
+// the media-buy helper module.
 export type {
   ActionNotAllowedDetails,
   ActionNotAllowedReason,
@@ -346,6 +344,7 @@ export type {
   PreflightDenied,
   PreflightResult,
   ResolvedAction,
+  SLAWindow,
   SlaWindow,
   UpdateFieldEntry,
   UpdateMediaBuyRequestLike,

--- a/src/lib/media-buy/index.ts
+++ b/src/lib/media-buy/index.ts
@@ -8,6 +8,7 @@ export type {
   MediaBuyActionMode,
   MediaBuyAvailableAction,
   MediaBuyValidAction,
+  SLAWindow,
   SlaWindow,
   UpdateMediaBuyRequestLike,
 } from './types';

--- a/src/lib/media-buy/types.ts
+++ b/src/lib/media-buy/types.ts
@@ -1,47 +1,34 @@
-// Buyer-side types for the available_actions surface (AdCP 3.1, RFC #4480).
-//
-// Hand-written until schemas/cache/ catches up to the 3.1 release and the
-// codegen regenerates `*.generated.ts`. Mirrors:
-//   - schemas/source/core/media-buy-available-action.json
-//   - schemas/source/core/sla-window.json
-//   - schemas/source/enums/media-buy-action-mode.json
-//   - schemas/source/enums/media-buy-valid-action.json
-//   - schemas/source/enums/action-not-allowed-reason.json
-//   - schemas/source/error-details/action-not-allowed.json
-//
-// When `sync-schemas` next runs and produces the equivalent types under
-// `src/lib/types/*.generated.ts`, this file should be deleted and the public
-// re-exports in `src/lib/media-buy/index.ts` should point at the generated
-// names.
+// Buyer-side type surface for the available_actions / ACTION_NOT_ALLOWED flow.
+// Wire-shape types come from the generated AdCP schema; the helper-local
+// types in this file are convenience subsets that the preflight resolver
+// reads against (kept narrow so a schema bump that adds optional fields
+// to MediaBuy / UpdateMediaBuyRequest doesn't churn the resolver
+// signature).
+
+export type {
+  ActionNotAllowedDetails,
+  ActionNotAllowedReason,
+  MediaBuyActionMode,
+  MediaBuyAvailableAction,
+  MediaBuyValidAction,
+  SLAWindow,
+} from '../types/core.generated';
+
+import type { MediaBuyAvailableAction, MediaBuyValidAction } from '../types/core.generated';
+import type { SLAWindow } from '../types/core.generated';
 
 /**
- * Fine-grained action identifier introduced in AdCP 3.1. Includes the legacy
- * coarse values (`update_budget`, `update_dates`, `update_packages`,
- * `sync_creatives`) so sellers staying on 3.x continue to round-trip.
+ * @deprecated Use `SLAWindow`. Kept as an import-compatibility alias for the
+ * pre-codegen draft export name; the shape is the generated wire contract.
  */
-export type MediaBuyValidAction =
-  | 'pause'
-  | 'resume'
-  | 'cancel'
-  | 'extend_flight'
-  | 'shorten_flight'
-  | 'update_flight_dates'
-  | 'increase_budget'
-  | 'decrease_budget'
-  | 'reallocate_budget'
-  | 'update_targeting'
-  | 'update_pacing'
-  | 'update_frequency_caps'
-  | 'replace_creative'
-  | 'update_creative_assignments'
-  | 'remove_creative'
-  | 'add_packages'
-  | 'remove_packages'
-  | 'update_budget'
-  | 'update_dates'
-  | 'update_packages'
-  | 'sync_creatives';
+export type SlaWindow = SLAWindow;
 
+/**
+ * Coarse-vocabulary actions retained for backwards compatibility with 3.x
+ * sellers that haven't migrated to the fine-grained set. Each rolls up to
+ * one or more fine-grained values per `enumMetadata[<value>].rollup`.
+ * Removed from the spec in 4.0.
+ */
 export const LEGACY_COARSE_ACTIONS = [
   'update_budget',
   'update_dates',
@@ -50,63 +37,6 @@ export const LEGACY_COARSE_ACTIONS = [
 ] as const satisfies readonly MediaBuyValidAction[];
 
 export type LegacyCoarseAction = (typeof LEGACY_COARSE_ACTIONS)[number];
-
-/**
- * How a seller honors a given action on a media buy. Buyers branch on this to
- * pick a synchronous, conditional, proposal, or async-approval flow.
- */
-export type MediaBuyActionMode = 'self_serve' | 'conditional_self_serve' | 'requires_proposal' | 'requires_approval';
-
-/**
- * SLA window expressed as a structured duration. Mirrors `sla-window.json`
- * as a `{ unit, value }` pair (e.g. `{ unit: 'hours', value: 24 }`). The schema
- * landed alongside #4514 but is intentionally minimal; the spec calls out
- * that absence means "no commitment", not "zero commitment".
- */
-export interface SlaWindow {
-  unit: 'minutes' | 'hours' | 'days' | 'business_days';
-  value: number;
-  response_max?: number;
-}
-
-/**
- * One entry of the per-buy `available_actions[]` array. Authoritative for
- * the buy at the moment of emission - sellers MAY resolve to a different
- * mode by the time the mutation arrives, in which case the call is rejected
- * with `ACTION_NOT_ALLOWED` (`reason: mode_mismatch`).
- *
- * The containing array is uniquely keyed by `action` (contract invariant,
- * not enforced by JSON Schema `uniqueItems`).
- */
-export interface MediaBuyAvailableAction {
-  action: MediaBuyValidAction;
-  mode: MediaBuyActionMode;
-  sla?: SlaWindow;
-  /**
-   * Opaque pointer into a buy-terms negotiation. The buy-terms RFC is
-   * separate; until it lands the field is any string.
-   */
-  terms_ref?: string;
-}
-
-/**
- * Reason an `update_media_buy` request was rejected with
- * `ACTION_NOT_ALLOWED`. Buyer SDKs branch on this to choose a recovery path.
- */
-export type ActionNotAllowedReason =
-  | 'wrong_status'
-  | 'not_supported_on_product'
-  | 'not_supported_on_buy'
-  | 'mode_mismatch';
-
-/**
- * Structured details payload for `ACTION_NOT_ALLOWED` errors.
- */
-export interface ActionNotAllowedDetails {
-  attempted_action: MediaBuyValidAction;
-  reason: ActionNotAllowedReason;
-  currently_available_actions?: MediaBuyAvailableAction[];
-}
 
 /**
  * Minimum surface a media buy needs to expose for the preflight helpers to


### PR DESCRIPTION
follow-up to #1849. now that AdCP 3.1.0-beta.3 is the pinned cache and codegen produces the wire-shape types we'd hand-written under uncertainty, swap them out.

## what's in here

- delete the hand-written `MediaBuyValidAction`, `MediaBuyActionMode`, `MediaBuyAvailableAction`, `ActionNotAllowedReason`, `ActionNotAllowedDetails`, `SlaWindow` from `src/lib/media-buy/types.ts`.
- re-export the codegen equivalents from `src/lib/types/core.generated.ts`.
- helper-local types kept: `LEGACY_COARSE_ACTIONS`, `LegacyCoarseAction`, `MediaBuyActionContext`, `UpdateMediaBuyRequestLike`. these are convenience subsets the preflight resolver reads against, not wire-schema types.
- re-ran `scripts/generate-media-buy-update-fields.ts` against the real `schemas/cache/3.1.0-beta.3/` cache. output unchanged from the snapshot taken against the pre-release upstream copy.

## breaking shape fix: `SLAWindow`

the hand-written `SlaWindow` was `{ unit, value, response_max? }`. the spec evolved to `SLAWindow` (caps - ISO acronym convention) with shape `{ response_max?, completion_max? }` where both are ISO 8601 duration strings. adopters reading `available_actions[0].sla.response_max` against the prior type would have hit a runtime shape mismatch the moment sellers populated `sla`. preflight logic doesn't read into `sla`, so internal call sites are unaffected, but the public type was wrong.

renamed export, corrected shape. matches the wire contract now.

## test plan

- [x] `tsc --noEmit` clean
- [x] 49 unit tests pass (no test changes - the resolver, gates, and preflight don't depend on the SLA shape)
- [x] `format:check` clean
- [x] `update-fields.generated.ts` byte-identical after re-running against the real 3.1.0-beta.3 cache

## net diff

3 source files + 1 changeset, +38 / -100.