### PR TITLE
feat(codegen): surface typed shapes for allOf-of-nots oneOf branches (notification_configs et al.)

### DIFF
--- a/.changeset/codegen-flatten-allof-not-branches.md
+++ b/.changeset/codegen-flatten-allof-not-branches.md
@@ -1,0 +1,48 @@
+---
+'@adcp/sdk': minor
+---
+
+feat(codegen): surface typed shapes for `oneOf` branches that express their forbidden-field set via `allOf:[{not:{required:[X]}}, ...]`
+
+Several AdCP 3.1.0-beta.3 request/response schemas use a `oneOf` of titled
+mutual-exclusion branches where each branch declares "these fields are
+forbidden" as an `allOf` of single-key `not.required` clauses. Until now,
+the codegen tightener only recognized the simpler `not: { required: [X] }`
+shape — when it saw an `allOf`, it bailed and `json-schema-to-typescript`
+emitted the branch as `{ [k: string]: unknown | undefined }`, dropping
+every typed field at the parent `items.properties` level.
+
+**Most visible impact:** `SyncAccountsRequest.accounts[]` — the two
+branches `ProvisioningMode` and `SettingsUpdateMode` now surface their
+actual fields instead of being loose passthroughs:
+
+- `ProvisioningMode`: `brand`, `operator`, `billing`, `billing_entity`,
+  `payment_terms`, `sandbox`, `preferred_reporting_protocol`,
+  `notification_configs`
+- `SettingsUpdateMode`: `account`, `billing_entity`, `payment_terms`,
+  `sandbox`, `preferred_reporting_protocol`, `notification_configs`
+
+Buyers writing typed sync-accounts payloads now get autocomplete and
+type-checking on the webhook-subscription field
+(`notification_configs[]`) that 3.1 introduced for account-scoped
+events (`creative.status_changed`, `creative.purged`, wholesale-feed
+events). Previously the field would compile against the passthrough
+arm but the typed shape was invisible to adopter tooling.
+
+**Also surfaces:** named typed shapes for the same idiom inside
+`CreativeAsset` (`V1CreativeNamedFormatReference` /
+`V2CreativeCanonicalFormatKind`) and `CreativeManifest`
+(`V1ManifestNamedFormatReference` / `V2ManifestCanonicalFormatKind`).
+
+**Why the two forms aren't interchangeable upstream:**
+`not: { required: [X, Y, Z] }` matches only when ALL three fields are
+present (forbids only the conjunction). The `allOf:[{not:{required:
+[X]}}, {not:{required:[Y]}}, {not:{required:[Z]}}]` form forbids each
+field independently — "none of them may be present." That's the
+authorial intent for `SettingsUpdateMode`, so the spec uses idiom #2.
+The codegen now recognizes both forms when collecting per-branch
+forbidden-name sets; semantics on the wire are unchanged (Ajv enforces
+the unstripped schema at runtime).
+
+No source changes required for adopters — regenerated types are
+strictly more typed in the affected places.

--- a/scripts/generate-types.ts
+++ b/scripts/generate-types.ts
@@ -123,22 +123,29 @@ interface ToolDefinition {
 }
 
 /**
- * Rewrite a discriminated `oneOf` whose branches are bare `required` + `not.required`
- * mutual-exclusion clauses into explicit closed shapes. Without this, json-schema-to-typescript
- * sees a branch with no own `properties`/`type` and falls back to
+ * Rewrite a discriminated `oneOf` whose branches are mutual-exclusion clauses
+ * into explicit closed shapes. Without this, json-schema-to-typescript sees a
+ * branch with no own `properties`/`type` and falls back to
  * `{ [k: string]: unknown | undefined }`, which is incompatible with closed-shape values
  * returned by typed builders (e.g. `displayRender({...})` cannot satisfy
- * `Format.renders[number]`'s loose first variant). See adcp-client#1325.
+ * `Format.renders[number]`'s loose first variant). See adcp-client#1325 and
+ * adcp-client#1940 (sync_accounts ProvisioningMode/SettingsUpdateMode).
  *
- * Applies only when the parent `items`-style schema has:
- *   - a sibling `properties` map declaring the candidate fields
- *   - every `oneOf` branch shaped as `{ required: [X], not: { required: [Y] } }`
- *     with no own `properties`/`type`/`$ref`
+ * Applies when the parent `items`-style schema has a sibling `properties` map
+ * and every `oneOf` branch expresses its forbidden-field set in one of two
+ * authorial idioms upstream uses:
+ *
+ *   1. `not: { required: [X, ...] }` — used by `Format.renders[]` etc.
+ *   2. `allOf: [{ not: { required: [X] } }, ...]` — used by
+ *      `SyncAccountsRequest.accounts[].oneOf[SettingsUpdateMode]` because
+ *      `{required:[X,Y,Z]}` matches only when ALL three are present, while
+ *      the authorial intent is "none of them may be present" (each field
+ *      independently forbidden). The two forms aren't semantically equivalent.
  *
  * Each branch is rewritten to inline the parent's properties (minus those the
- * branch's `not.required` excludes), with the branch's own `required` items
- * added to the parent's `required`. The original `oneOf` is retained but each
- * branch is now a complete closed shape — jsts emits a clean union.
+ * branch's forbidden-name set excludes), with the branch's own `required`
+ * items added to the parent's `required`. The original `oneOf` is retained
+ * but each branch is now a complete closed shape — jsts emits a clean union.
  *
  * Idempotent: a second pass over a transformed branch (which now has its own
  * `properties`) is a no-op because the predicate above no longer matches.
@@ -151,24 +158,54 @@ function tightenMutualExclusionOneOf(schema: any): any {
   const parentProps = schema.properties as Record<string, any>;
   const parentRequired: string[] = Array.isArray(schema.required) ? [...schema.required] : [];
 
+  // Returns the union of forbidden field names a branch declares — collected
+  // from either `not.required` (idiom 1) or every entry of an `allOf` of
+  // `{not:{required:[X]}}` clauses (idiom 2). Returns null when the branch
+  // carries any other not/allOf shape — preserving the existing strict-bail
+  // behavior so Ajv stays the source of truth at runtime.
+  const extractBranchForbidden = (branch: any): string[] | null => {
+    const forbidden = new Set<string>();
+    let sawForbid = false;
+
+    if (branch.not !== undefined) {
+      if (!branch.not || typeof branch.not !== 'object') return null;
+      if (!Array.isArray(branch.not.required) || branch.not.required.length === 0) return null;
+      if (Object.keys(branch.not).some(k => k !== 'required')) return null;
+      for (const name of branch.not.required) forbidden.add(name);
+      sawForbid = true;
+    }
+
+    if (branch.allOf !== undefined) {
+      if (!Array.isArray(branch.allOf) || branch.allOf.length === 0) return null;
+      for (const entry of branch.allOf) {
+        if (!entry || typeof entry !== 'object') return null;
+        const entryKeys = Object.keys(entry);
+        if (entryKeys.length !== 1 || entryKeys[0] !== 'not') return null;
+        if (!entry.not || typeof entry.not !== 'object') return null;
+        if (!Array.isArray(entry.not.required) || entry.not.required.length === 0) return null;
+        if (Object.keys(entry.not).some(k => k !== 'required')) return null;
+        for (const name of entry.not.required) forbidden.add(name);
+      }
+      sawForbid = true;
+    }
+
+    return sawForbid && forbidden.size > 0 ? Array.from(forbidden) : null;
+  };
+
   const isMutualExclusionBranch = (branch: any): boolean => {
     if (!branch || typeof branch !== 'object') return false;
-    if (branch.type || branch.$ref || branch.oneOf || branch.anyOf || branch.allOf) {
-      return false;
-    }
+    // Branches that already declare their own type/ref/combinator have a
+    // closed shape; nothing to tighten.
+    if (branch.type || branch.$ref || branch.oneOf || branch.anyOf) return false;
     if (!Array.isArray(branch.required) || branch.required.length === 0) return false;
-    if (!branch.not || typeof branch.not !== 'object') return false;
-    if (!Array.isArray(branch.not.required) || branch.not.required.length === 0) return false;
-    // Branch may declare its own `properties` (typically to assert `const` on
-    // the discriminator field) — we'll merge those in.
-    return true;
+    return extractBranchForbidden(branch) !== null;
   };
 
   if (!schema.oneOf.every(isMutualExclusionBranch)) return schema;
 
   const rewritten = schema.oneOf.map((branch: any) => {
     const branchRequired: string[] = branch.required;
-    const forbidden: string[] = branch.not.required;
+    const forbidden = extractBranchForbidden(branch) as string[];
     const branchOwnProps: Record<string, any> =
       branch.properties && typeof branch.properties === 'object' ? branch.properties : {};
     const newProperties: Record<string, any> = {};
@@ -181,11 +218,17 @@ function tightenMutualExclusionOneOf(schema: any): any {
     for (const [key, prop] of Object.entries(branchOwnProps)) {
       if (!(key in newProperties)) newProperties[key] = prop;
     }
-    return {
+    const out: Record<string, unknown> = {
       type: 'object',
       properties: newProperties,
       required: Array.from(new Set([...parentRequired, ...branchRequired])),
     };
+    // Preserve titled-branch metadata so the emitted TS keeps named
+    // interfaces (`ProvisioningMode`, `SettingsUpdateMode`) instead of
+    // anonymous union arms.
+    if (branch.title) out.title = branch.title;
+    if (branch.description) out.description = branch.description;
+    return out;
   });
 
   return { ...schema, oneOf: rewritten };
@@ -507,29 +550,82 @@ export function enforceStrictSchema(schema: any): any {
  * Schemas this affects today: `Format.renders[]`, `sync_plans` plan budget.
  * Both share the same authorial idiom upstream (adcontextprotocol/adcp).
  */
+/**
+ * Pull a branch's forbidden-field set out of either authorial idiom upstream
+ * uses:
+ *
+ *   1. `not: { required: [X, ...] }` — single not-required clause.
+ *   2. `allOf: [{ not: { required: [X] } }, { not: { required: [Y] } }, ...]`
+ *      — an allOf of single-key not-required clauses.
+ *
+ * Returns the union of forbidden names, or `null` if the branch carries any
+ * other not/allOf shape we don't recognize (in which case the flattener bails
+ * to preserve runtime behavior under Ajv).
+ *
+ * Idiom (2) appears on `SyncAccountsRequest.accounts[].oneOf[SettingsUpdateMode]`
+ * (adcp 3.1.0-beta.3) — its three forbidden fields can't compress into a
+ * single `not: {required: [X, Y, Z]}` because `{required:[X,Y,Z]}` matches
+ * only when ALL three are present, while the authorial intent is "none of
+ * them may be present" (each field independently forbidden).
+ */
+function extractBranchExcludedNames(branch: any): Set<string> | null {
+  const excluded = new Set<string>();
+  let sawForbid = false;
+
+  // Form 1: top-level `not: { required: [...] }`
+  if (branch.not !== undefined) {
+    if (!branch.not || typeof branch.not !== 'object') return null;
+    if (!Array.isArray(branch.not.required) || branch.not.required.length === 0) return null;
+    if (Object.keys(branch.not).some(k => k !== 'required')) return null;
+    for (const name of branch.not.required) excluded.add(name);
+    sawForbid = true;
+  }
+
+  // Form 2: `allOf: [{ not: { required: [...] } }, ...]`
+  if (branch.allOf !== undefined) {
+    if (!Array.isArray(branch.allOf) || branch.allOf.length === 0) return null;
+    for (const entry of branch.allOf) {
+      if (!entry || typeof entry !== 'object') return null;
+      if (Object.keys(entry).length !== 1 || !entry.not) return null;
+      if (typeof entry.not !== 'object') return null;
+      if (!Array.isArray(entry.not.required) || entry.not.required.length === 0) return null;
+      if (Object.keys(entry.not).some(k => k !== 'required')) return null;
+      for (const name of entry.not.required) excluded.add(name);
+    }
+    sawForbid = true;
+  }
+
+  return sawForbid && excluded.size > 0 ? excluded : null;
+}
+
 function flattenMutualExclusiveOneOf(schema: any): any {
   if (!schema || typeof schema !== 'object') return schema;
   if (!schema.properties || !schema.oneOf || !Array.isArray(schema.oneOf)) return schema;
   const branches = schema.oneOf;
   if (branches.length < 2) return schema;
 
-  const ALLOWED_BRANCH_KEYS = new Set(['required', 'not', 'properties', 'title', 'description']);
-  const allBranchesAreMutex = branches.every((b: any) => {
-    if (!b || typeof b !== 'object') return false;
-    if (!Array.isArray(b.required) || b.required.length === 0) return false;
-    if (!b.not || typeof b.not !== 'object') return false;
-    if (!Array.isArray(b.not.required) || b.not.required.length === 0) return false;
-    if (Object.keys(b).some(k => !ALLOWED_BRANCH_KEYS.has(k))) return false;
-    if (Object.keys(b.not).some(k => k !== 'required')) return false;
-    return true;
+  const ALLOWED_BRANCH_KEYS = new Set(['required', 'not', 'allOf', 'properties', 'title', 'description']);
+  const excludedByBranch: Array<Set<string> | null> = branches.map((b: any) => {
+    if (!b || typeof b !== 'object') return null;
+    if (!Array.isArray(b.required) || b.required.length === 0) return null;
+    if (Object.keys(b).some(k => !ALLOWED_BRANCH_KEYS.has(k))) return null;
+    return extractBranchExcludedNames(b);
   });
-  if (!allBranchesAreMutex) return schema;
+  if (excludedByBranch.some(s => s === null)) return schema;
 
   const outerProps = schema.properties as Record<string, any>;
   const outerRequired: string[] = Array.isArray(schema.required) ? schema.required : [];
+  // Preserve openness when the parent items schema is intentionally open.
+  // SyncAccountsRequest's accounts entries set `additionalProperties: true`
+  // because future per-account fields land in the parent properties bag,
+  // not in branch-specific shapes. Forcing `additionalProperties: false`
+  // on flattened branches would reject any future field until the SDK
+  // regenerates — runtime Ajv would still accept it on the unstripped
+  // schema, creating wire-vs-type drift.
+  const parentAdditional = schema.additionalProperties;
 
-  const newOneOf = branches.map((branch: any) => {
-    const excluded = new Set<string>(branch.not.required);
+  const newOneOf = branches.map((branch: any, i: number) => {
+    const excluded = excludedByBranch[i] as Set<string>;
     const branchOwnProps: Record<string, any> = branch.properties ?? {};
     const branchProps: Record<string, any> = {};
     for (const [name, prop] of Object.entries(outerProps)) {
@@ -547,11 +643,7 @@ function flattenMutualExclusiveOneOf(schema: any): any {
     if (branch.description) out.description = branch.description;
     out.properties = branchProps;
     if (required.length > 0) out.required = required;
-    // Closed shape — branches must enumerate their fields. If a future
-    // upstream schema needs an open branch, file an issue and either widen
-    // detection (require explicit `additionalProperties: true` on the branch)
-    // or skip flattening.
-    out.additionalProperties = false;
+    out.additionalProperties = parentAdditional === true ? true : false;
     return out;
   });
 

--- a/src/lib/types/core.generated.ts
+++ b/src/lib/types/core.generated.ts
@@ -1,5 +1,5 @@
 // Generated AdCP core types from official schemas v3.1.0-beta.3
-// Generated at: 2026-05-22T14:22:05.693Z
+// Generated at: 2026-05-22T16:27:18.517Z
 
 // MEDIA-BUY SCHEMA
 /**
@@ -1877,136 +1877,7 @@ export type CreativeAsset = {
    */
   industry_identifiers?: IndustryIdentifier[];
   provenance?: Provenance;
-} & (
-  | {
-      /**
-       * Unique identifier for the creative. Stable across v1 and v2 paths — a creative registered against v1 `format_id` retains the same `creative_id` when later viewed via v2 flatten.
-       */
-      creative_id: string;
-      /**
-       * Human-readable creative name
-       */
-      name: string;
-      format_id: FormatReferenceStructuredObject;
-      /**
-       * v2 path, optional. Stable identifier matching one of the seller's product `format_options[i].capability_id` values. REQUIRED only when the target product has multiple `format_options` entries sharing the same `format_kind`.
-       */
-      capability_id?: string;
-      /**
-       * Assets required by the format, keyed by asset_id. Each slot value is either a single asset object or an array of asset objects (for slots with `min`/`max > 1` like carousel `cards` or responsive_creative `headlines`). Each asset value carries an `asset_type` discriminator that selects the matching asset schema.
-       */
-      assets: {
-        /**
-         * This interface was referenced by `undefined`'s JSON-Schema definition
-         * via the `patternProperty` "^[a-z0-9_]+$".
-         */
-        [k: string]: AssetVariant | AssetVariant[];
-      };
-      /**
-       * Preview contexts for generative formats - defines what scenarios to generate previews for
-       */
-      inputs?: {
-        /**
-         * Human-readable name for this preview variant
-         */
-        name: string;
-        /**
-         * Macro values to apply for this preview
-         */
-        macros?: {
-          [k: string]: string | undefined;
-        };
-        /**
-         * Natural language description of the context for AI-generated content
-         */
-        context_description?: string;
-      }[];
-      /**
-       * User-defined tags for organization and searchability
-       */
-      tags?: string[];
-      status?: CreativeStatus;
-      /**
-       * Optional delivery weight for creative rotation when uploading via create_media_buy or update_media_buy (0-100). If omitted, platform determines rotation. Only used during upload to media buy - not stored in creative library.
-       * @minimum 0
-       * @maximum 100
-       */
-      weight?: number;
-      /**
-       * Optional array of placement IDs where this creative should run when uploading via create_media_buy or update_media_buy. References placement_id values from the product's placements array. If omitted, creative runs on all placements. Only used during upload to media buy - not stored in creative library.
-       */
-      placement_ids?: string[];
-      /**
-       * Industry-standard identifiers for this creative (e.g., Ad-ID, ISCI, Clearcast clock number). In broadcast buying, these identifiers tie the creative to rotation instructions and traffic systems. A creative may have multiple identifiers when different systems reference the same asset.
-       */
-      industry_identifiers?: IndustryIdentifier[];
-      provenance?: Provenance;
-    }
-  | {
-      /**
-       * Unique identifier for the creative. Stable across v1 and v2 paths — a creative registered against v1 `format_id` retains the same `creative_id` when later viewed via v2 flatten.
-       */
-      creative_id: string;
-      /**
-       * Human-readable creative name
-       */
-      name: string;
-      format_kind: CanonicalFormatKind;
-      /**
-       * v2 path, optional. Stable identifier matching one of the seller's product `format_options[i].capability_id` values. REQUIRED only when the target product has multiple `format_options` entries sharing the same `format_kind`.
-       */
-      capability_id?: string;
-      /**
-       * Assets required by the format, keyed by asset_id. Each slot value is either a single asset object or an array of asset objects (for slots with `min`/`max > 1` like carousel `cards` or responsive_creative `headlines`). Each asset value carries an `asset_type` discriminator that selects the matching asset schema.
-       */
-      assets: {
-        /**
-         * This interface was referenced by `undefined`'s JSON-Schema definition
-         * via the `patternProperty` "^[a-z0-9_]+$".
-         */
-        [k: string]: AssetVariant | AssetVariant[];
-      };
-      /**
-       * Preview contexts for generative formats - defines what scenarios to generate previews for
-       */
-      inputs?: {
-        /**
-         * Human-readable name for this preview variant
-         */
-        name: string;
-        /**
-         * Macro values to apply for this preview
-         */
-        macros?: {
-          [k: string]: string | undefined;
-        };
-        /**
-         * Natural language description of the context for AI-generated content
-         */
-        context_description?: string;
-      }[];
-      /**
-       * User-defined tags for organization and searchability
-       */
-      tags?: string[];
-      status?: CreativeStatus;
-      /**
-       * Optional delivery weight for creative rotation when uploading via create_media_buy or update_media_buy (0-100). If omitted, platform determines rotation. Only used during upload to media buy - not stored in creative library.
-       * @minimum 0
-       * @maximum 100
-       */
-      weight?: number;
-      /**
-       * Optional array of placement IDs where this creative should run when uploading via create_media_buy or update_media_buy. References placement_id values from the product's placements array. If omitted, creative runs on all placements. Only used during upload to media buy - not stored in creative library.
-       */
-      placement_ids?: string[];
-      /**
-       * Industry-standard identifiers for this creative (e.g., Ad-ID, ISCI, Clearcast clock number). In broadcast buying, these identifiers tie the creative to rotation instructions and traffic systems. A creative may have multiple identifiers when different systems reference the same asset.
-       */
-      industry_identifiers?: IndustryIdentifier[];
-      provenance?: Provenance;
-    }
-);
+} & (V1CreativeNamedFormatReference | V2CreativeCanonicalFormatKind);
 /**
  * v2 path. The canonical format name this creative targets (e.g., `image`, `video_hosted`). Mutually exclusive with `format_id`.
  */
@@ -3000,6 +2871,140 @@ export interface IndustryIdentifier {
    * @maxLength 64
    */
   value: string;
+}
+/**
+ * Creative references a named format via the structured `format_id` object. The v1 path; remains supported through 4.x.
+ */
+export interface V1CreativeNamedFormatReference {
+  /**
+   * Unique identifier for the creative. Stable across v1 and v2 paths — a creative registered against v1 `format_id` retains the same `creative_id` when later viewed via v2 flatten.
+   */
+  creative_id: string;
+  /**
+   * Human-readable creative name
+   */
+  name: string;
+  format_id: FormatReferenceStructuredObject;
+  /**
+   * v2 path, optional. Stable identifier matching one of the seller's product `format_options[i].capability_id` values. REQUIRED only when the target product has multiple `format_options` entries sharing the same `format_kind`.
+   */
+  capability_id?: string;
+  /**
+   * Assets required by the format, keyed by asset_id. Each slot value is either a single asset object or an array of asset objects (for slots with `min`/`max > 1` like carousel `cards` or responsive_creative `headlines`). Each asset value carries an `asset_type` discriminator that selects the matching asset schema.
+   */
+  assets: {
+    /**
+     * This interface was referenced by `undefined`'s JSON-Schema definition
+     * via the `patternProperty` "^[a-z0-9_]+$".
+     */
+    [k: string]: AssetVariant | AssetVariant[];
+  };
+  /**
+   * Preview contexts for generative formats - defines what scenarios to generate previews for
+   */
+  inputs?: {
+    /**
+     * Human-readable name for this preview variant
+     */
+    name: string;
+    /**
+     * Macro values to apply for this preview
+     */
+    macros?: {
+      [k: string]: string | undefined;
+    };
+    /**
+     * Natural language description of the context for AI-generated content
+     */
+    context_description?: string;
+  }[];
+  /**
+   * User-defined tags for organization and searchability
+   */
+  tags?: string[];
+  status?: CreativeStatus;
+  /**
+   * Optional delivery weight for creative rotation when uploading via create_media_buy or update_media_buy (0-100). If omitted, platform determines rotation. Only used during upload to media buy - not stored in creative library.
+   * @minimum 0
+   * @maximum 100
+   */
+  weight?: number;
+  /**
+   * Optional array of placement IDs where this creative should run when uploading via create_media_buy or update_media_buy. References placement_id values from the product's placements array. If omitted, creative runs on all placements. Only used during upload to media buy - not stored in creative library.
+   */
+  placement_ids?: string[];
+  /**
+   * Industry-standard identifiers for this creative (e.g., Ad-ID, ISCI, Clearcast clock number). In broadcast buying, these identifiers tie the creative to rotation instructions and traffic systems. A creative may have multiple identifiers when different systems reference the same asset.
+   */
+  industry_identifiers?: IndustryIdentifier[];
+  provenance?: Provenance;
+}
+/**
+ * Creative declares which canonical format it targets via `format_kind` (e.g., `image`). The v2 path introduced by RFC #3305.
+ */
+export interface V2CreativeCanonicalFormatKind {
+  /**
+   * Unique identifier for the creative. Stable across v1 and v2 paths — a creative registered against v1 `format_id` retains the same `creative_id` when later viewed via v2 flatten.
+   */
+  creative_id: string;
+  /**
+   * Human-readable creative name
+   */
+  name: string;
+  format_kind: CanonicalFormatKind;
+  /**
+   * v2 path, optional. Stable identifier matching one of the seller's product `format_options[i].capability_id` values. REQUIRED only when the target product has multiple `format_options` entries sharing the same `format_kind`.
+   */
+  capability_id?: string;
+  /**
+   * Assets required by the format, keyed by asset_id. Each slot value is either a single asset object or an array of asset objects (for slots with `min`/`max > 1` like carousel `cards` or responsive_creative `headlines`). Each asset value carries an `asset_type` discriminator that selects the matching asset schema.
+   */
+  assets: {
+    /**
+     * This interface was referenced by `undefined`'s JSON-Schema definition
+     * via the `patternProperty` "^[a-z0-9_]+$".
+     */
+    [k: string]: AssetVariant | AssetVariant[];
+  };
+  /**
+   * Preview contexts for generative formats - defines what scenarios to generate previews for
+   */
+  inputs?: {
+    /**
+     * Human-readable name for this preview variant
+     */
+    name: string;
+    /**
+     * Macro values to apply for this preview
+     */
+    macros?: {
+      [k: string]: string | undefined;
+    };
+    /**
+     * Natural language description of the context for AI-generated content
+     */
+    context_description?: string;
+  }[];
+  /**
+   * User-defined tags for organization and searchability
+   */
+  tags?: string[];
+  status?: CreativeStatus;
+  /**
+   * Optional delivery weight for creative rotation when uploading via create_media_buy or update_media_buy (0-100). If omitted, platform determines rotation. Only used during upload to media buy - not stored in creative library.
+   * @minimum 0
+   * @maximum 100
+   */
+  weight?: number;
+  /**
+   * Optional array of placement IDs where this creative should run when uploading via create_media_buy or update_media_buy. References placement_id values from the product's placements array. If omitted, creative runs on all placements. Only used during upload to media buy - not stored in creative library.
+   */
+  placement_ids?: string[];
+  /**
+   * Industry-standard identifiers for this creative (e.g., Ad-ID, ISCI, Clearcast clock number). In broadcast buying, these identifiers tie the creative to rotation instructions and traffic systems. A creative may have multiple identifiers when different systems reference the same asset.
+   */
+  industry_identifiers?: IndustryIdentifier[];
+  provenance?: Provenance;
 }
 /**
  * Represents available advertising inventory
@@ -6866,68 +6871,7 @@ export type CreativeManifest = {
   industry_identifiers?: IndustryIdentifier[];
   provenance?: Provenance;
   ext?: ExtensionObject;
-} & (
-  | {
-      format_id: FormatReferenceStructuredObject;
-      /**
-       * v2 path, optional. Stable identifier matching one of the seller's product `format_options[i].capability_id` values. REQUIRED when the target product carries multiple `format_options` entries sharing the same `format_kind` (the buyer must disambiguate which option this manifest matches). When the product's `format_options` has a single entry — or multiple entries with distinct `format_kind` values — `capability_id` is OPTIONAL because `format_kind` alone routes the manifest to the right declaration.
-       */
-      capability_id?: string;
-      /**
-       * Map of slot keys to actual asset content. v1 path: each key matches an `asset_id` from the format's `assets` array (e.g., 'banner_image', 'clickthrough_url', 'video_file', 'vast_tag'). v2 path: each key matches an `asset_group_id` from the format's `slots` declaration drawn from the canonical vocabulary registry (e.g., 'images_landscape', 'video', 'landing_page_url', 'vast_tag', 'script', 'creative_brief'). Either path produces the same envelope shape; only the slot-key vocabulary differs.
-       *
-       * Each slot value is **either** a single asset object (most slots — image, video, vast_tag, landing_page_url, etc.) **or** an array of asset objects (slots with `min`/`max` counts on the format declaration — `cards` on `image_carousel`, `headlines` / `descriptions` / `images_landscape` on `responsive_creative`, etc.). Single-vs-array shape is governed by the format's `slots[].min` and `slots[].max` parameters: when `max > 1` (or when the slot is conceptually a pool), the value MUST be an array; when the slot is single-valued, the value MUST be a single object. Each asset value (single or array element) carries an `asset_type` discriminator (image, video, audio, vast, daast, text, markdown, url, html, css, webhook, javascript, brief, catalog, zip, card) that selects the matching asset schema. Validators with OpenAPI-style discriminator support use `asset_type` to report errors against only the selected branch instead of all branches.
-       */
-      assets: {
-        /**
-         * This interface was referenced by `undefined`'s JSON-Schema definition
-         * via the `patternProperty` "^[a-z0-9_]+$".
-         */
-        [k: string]: AssetVariant | AssetVariant[];
-      };
-      brand?: BrandReference;
-      /**
-       * Rights constraints attached to this creative. Each entry represents constraints from a single rights holder. A creative may combine multiple rights constraints (e.g., talent likeness + music license). For v1, rights constraints are informational metadata — the buyer/orchestrator manages creative lifecycle against these terms.
-       */
-      rights?: RightsConstraint[];
-      /**
-       * Industry-standard identifiers for this specific manifest (e.g., Ad-ID, ISCI, Clearcast clock number). When present, overrides creative-level identifiers. Use when different format versions of the same source creative have distinct Ad-IDs (e.g., the :15 and :30 cuts).
-       */
-      industry_identifiers?: IndustryIdentifier[];
-      provenance?: Provenance;
-      ext?: ExtensionObject;
-    }
-  | {
-      format_kind: CanonicalFormatKind;
-      /**
-       * v2 path, optional. Stable identifier matching one of the seller's product `format_options[i].capability_id` values. REQUIRED when the target product carries multiple `format_options` entries sharing the same `format_kind` (the buyer must disambiguate which option this manifest matches). When the product's `format_options` has a single entry — or multiple entries with distinct `format_kind` values — `capability_id` is OPTIONAL because `format_kind` alone routes the manifest to the right declaration.
-       */
-      capability_id?: string;
-      /**
-       * Map of slot keys to actual asset content. v1 path: each key matches an `asset_id` from the format's `assets` array (e.g., 'banner_image', 'clickthrough_url', 'video_file', 'vast_tag'). v2 path: each key matches an `asset_group_id` from the format's `slots` declaration drawn from the canonical vocabulary registry (e.g., 'images_landscape', 'video', 'landing_page_url', 'vast_tag', 'script', 'creative_brief'). Either path produces the same envelope shape; only the slot-key vocabulary differs.
-       *
-       * Each slot value is **either** a single asset object (most slots — image, video, vast_tag, landing_page_url, etc.) **or** an array of asset objects (slots with `min`/`max` counts on the format declaration — `cards` on `image_carousel`, `headlines` / `descriptions` / `images_landscape` on `responsive_creative`, etc.). Single-vs-array shape is governed by the format's `slots[].min` and `slots[].max` parameters: when `max > 1` (or when the slot is conceptually a pool), the value MUST be an array; when the slot is single-valued, the value MUST be a single object. Each asset value (single or array element) carries an `asset_type` discriminator (image, video, audio, vast, daast, text, markdown, url, html, css, webhook, javascript, brief, catalog, zip, card) that selects the matching asset schema. Validators with OpenAPI-style discriminator support use `asset_type` to report errors against only the selected branch instead of all branches.
-       */
-      assets: {
-        /**
-         * This interface was referenced by `undefined`'s JSON-Schema definition
-         * via the `patternProperty` "^[a-z0-9_]+$".
-         */
-        [k: string]: AssetVariant | AssetVariant[];
-      };
-      brand?: BrandReference;
-      /**
-       * Rights constraints attached to this creative. Each entry represents constraints from a single rights holder. A creative may combine multiple rights constraints (e.g., talent likeness + music license). For v1, rights constraints are informational metadata — the buyer/orchestrator manages creative lifecycle against these terms.
-       */
-      rights?: RightsConstraint[];
-      /**
-       * Industry-standard identifiers for this specific manifest (e.g., Ad-ID, ISCI, Clearcast clock number). When present, overrides creative-level identifiers. Use when different format versions of the same source creative have distinct Ad-IDs (e.g., the :15 and :30 cuts).
-       */
-      industry_identifiers?: IndustryIdentifier[];
-      provenance?: Provenance;
-      ext?: ExtensionObject;
-    }
-);
+} & (V1ManifestNamedFormatReference | V2ManifestCanonicalFormatKind);
 /**
  * Types of rights usage that can be licensed through the brand protocol. Aligned with DDEX UseType direction for interoperability with music and media rights systems.
  */
@@ -8414,6 +8358,72 @@ export interface RightsConstraint {
    * URL where downstream supply chain participants can verify this rights grant is active. Returns HTTP 200 with the current grant status, or 404 if revoked. Enables SSPs and verification vendors to confirm rights before serving.
    */
   verification_url?: string;
+  ext?: ExtensionObject;
+}
+/**
+ * Manifest references a named format via the structured `format_id` object. The v1 path; remains supported through 4.x.
+ */
+export interface V1ManifestNamedFormatReference {
+  format_id: FormatReferenceStructuredObject;
+  /**
+   * v2 path, optional. Stable identifier matching one of the seller's product `format_options[i].capability_id` values. REQUIRED when the target product carries multiple `format_options` entries sharing the same `format_kind` (the buyer must disambiguate which option this manifest matches). When the product's `format_options` has a single entry — or multiple entries with distinct `format_kind` values — `capability_id` is OPTIONAL because `format_kind` alone routes the manifest to the right declaration.
+   */
+  capability_id?: string;
+  /**
+   * Map of slot keys to actual asset content. v1 path: each key matches an `asset_id` from the format's `assets` array (e.g., 'banner_image', 'clickthrough_url', 'video_file', 'vast_tag'). v2 path: each key matches an `asset_group_id` from the format's `slots` declaration drawn from the canonical vocabulary registry (e.g., 'images_landscape', 'video', 'landing_page_url', 'vast_tag', 'script', 'creative_brief'). Either path produces the same envelope shape; only the slot-key vocabulary differs.
+   *
+   * Each slot value is **either** a single asset object (most slots — image, video, vast_tag, landing_page_url, etc.) **or** an array of asset objects (slots with `min`/`max` counts on the format declaration — `cards` on `image_carousel`, `headlines` / `descriptions` / `images_landscape` on `responsive_creative`, etc.). Single-vs-array shape is governed by the format's `slots[].min` and `slots[].max` parameters: when `max > 1` (or when the slot is conceptually a pool), the value MUST be an array; when the slot is single-valued, the value MUST be a single object. Each asset value (single or array element) carries an `asset_type` discriminator (image, video, audio, vast, daast, text, markdown, url, html, css, webhook, javascript, brief, catalog, zip, card) that selects the matching asset schema. Validators with OpenAPI-style discriminator support use `asset_type` to report errors against only the selected branch instead of all branches.
+   */
+  assets: {
+    /**
+     * This interface was referenced by `undefined`'s JSON-Schema definition
+     * via the `patternProperty` "^[a-z0-9_]+$".
+     */
+    [k: string]: AssetVariant | AssetVariant[];
+  };
+  brand?: BrandReference;
+  /**
+   * Rights constraints attached to this creative. Each entry represents constraints from a single rights holder. A creative may combine multiple rights constraints (e.g., talent likeness + music license). For v1, rights constraints are informational metadata — the buyer/orchestrator manages creative lifecycle against these terms.
+   */
+  rights?: RightsConstraint[];
+  /**
+   * Industry-standard identifiers for this specific manifest (e.g., Ad-ID, ISCI, Clearcast clock number). When present, overrides creative-level identifiers. Use when different format versions of the same source creative have distinct Ad-IDs (e.g., the :15 and :30 cuts).
+   */
+  industry_identifiers?: IndustryIdentifier[];
+  provenance?: Provenance;
+  ext?: ExtensionObject;
+}
+/**
+ * Manifest declares which canonical format it targets via `format_kind` (e.g., `image`). The v2 path introduced by RFC #3305.
+ */
+export interface V2ManifestCanonicalFormatKind {
+  format_kind: CanonicalFormatKind;
+  /**
+   * v2 path, optional. Stable identifier matching one of the seller's product `format_options[i].capability_id` values. REQUIRED when the target product carries multiple `format_options` entries sharing the same `format_kind` (the buyer must disambiguate which option this manifest matches). When the product's `format_options` has a single entry — or multiple entries with distinct `format_kind` values — `capability_id` is OPTIONAL because `format_kind` alone routes the manifest to the right declaration.
+   */
+  capability_id?: string;
+  /**
+   * Map of slot keys to actual asset content. v1 path: each key matches an `asset_id` from the format's `assets` array (e.g., 'banner_image', 'clickthrough_url', 'video_file', 'vast_tag'). v2 path: each key matches an `asset_group_id` from the format's `slots` declaration drawn from the canonical vocabulary registry (e.g., 'images_landscape', 'video', 'landing_page_url', 'vast_tag', 'script', 'creative_brief'). Either path produces the same envelope shape; only the slot-key vocabulary differs.
+   *
+   * Each slot value is **either** a single asset object (most slots — image, video, vast_tag, landing_page_url, etc.) **or** an array of asset objects (slots with `min`/`max` counts on the format declaration — `cards` on `image_carousel`, `headlines` / `descriptions` / `images_landscape` on `responsive_creative`, etc.). Single-vs-array shape is governed by the format's `slots[].min` and `slots[].max` parameters: when `max > 1` (or when the slot is conceptually a pool), the value MUST be an array; when the slot is single-valued, the value MUST be a single object. Each asset value (single or array element) carries an `asset_type` discriminator (image, video, audio, vast, daast, text, markdown, url, html, css, webhook, javascript, brief, catalog, zip, card) that selects the matching asset schema. Validators with OpenAPI-style discriminator support use `asset_type` to report errors against only the selected branch instead of all branches.
+   */
+  assets: {
+    /**
+     * This interface was referenced by `undefined`'s JSON-Schema definition
+     * via the `patternProperty` "^[a-z0-9_]+$".
+     */
+    [k: string]: AssetVariant | AssetVariant[];
+  };
+  brand?: BrandReference;
+  /**
+   * Rights constraints attached to this creative. Each entry represents constraints from a single rights holder. A creative may combine multiple rights constraints (e.g., talent likeness + music license). For v1, rights constraints are informational metadata — the buyer/orchestrator manages creative lifecycle against these terms.
+   */
+  rights?: RightsConstraint[];
+  /**
+   * Industry-standard identifiers for this specific manifest (e.g., Ad-ID, ISCI, Clearcast clock number). When present, overrides creative-level identifiers. Use when different format versions of the same source creative have distinct Ad-IDs (e.g., the :15 and :30 cuts).
+   */
+  industry_identifiers?: IndustryIdentifier[];
+  provenance?: Provenance;
   ext?: ExtensionObject;
 }
 /**
@@ -13189,6 +13199,72 @@ export interface CreativeBrief {
      */
     prohibited_claims?: string[];
   };
+}
+/**
+ * Manifest references a named format via the structured `format_id` object. The v1 path; remains supported through 4.x.
+ */
+export interface V1ManifestNamedFormatReference1 {
+  format_id: FormatReferenceStructuredObject;
+  /**
+   * v2 path, optional. Stable identifier matching one of the seller's product `format_options[i].capability_id` values. REQUIRED when the target product carries multiple `format_options` entries sharing the same `format_kind` (the buyer must disambiguate which option this manifest matches). When the product's `format_options` has a single entry — or multiple entries with distinct `format_kind` values — `capability_id` is OPTIONAL because `format_kind` alone routes the manifest to the right declaration.
+   */
+  capability_id?: string;
+  /**
+   * Map of slot keys to actual asset content. v1 path: each key matches an `asset_id` from the format's `assets` array (e.g., 'banner_image', 'clickthrough_url', 'video_file', 'vast_tag'). v2 path: each key matches an `asset_group_id` from the format's `slots` declaration drawn from the canonical vocabulary registry (e.g., 'images_landscape', 'video', 'landing_page_url', 'vast_tag', 'script', 'creative_brief'). Either path produces the same envelope shape; only the slot-key vocabulary differs.
+   *
+   * Each slot value is **either** a single asset object (most slots — image, video, vast_tag, landing_page_url, etc.) **or** an array of asset objects (slots with `min`/`max` counts on the format declaration — `cards` on `image_carousel`, `headlines` / `descriptions` / `images_landscape` on `responsive_creative`, etc.). Single-vs-array shape is governed by the format's `slots[].min` and `slots[].max` parameters: when `max > 1` (or when the slot is conceptually a pool), the value MUST be an array; when the slot is single-valued, the value MUST be a single object. Each asset value (single or array element) carries an `asset_type` discriminator (image, video, audio, vast, daast, text, markdown, url, html, css, webhook, javascript, brief, catalog, zip, card) that selects the matching asset schema. Validators with OpenAPI-style discriminator support use `asset_type` to report errors against only the selected branch instead of all branches.
+   */
+  assets: {
+    /**
+     * This interface was referenced by `undefined`'s JSON-Schema definition
+     * via the `patternProperty` "^[a-z0-9_]+$".
+     */
+    [k: string]: AssetVariant4 | AssetVariant5[];
+  };
+  brand?: BrandReference;
+  /**
+   * Rights constraints attached to this creative. Each entry represents constraints from a single rights holder. A creative may combine multiple rights constraints (e.g., talent likeness + music license). For v1, rights constraints are informational metadata — the buyer/orchestrator manages creative lifecycle against these terms.
+   */
+  rights?: RightsConstraint[];
+  /**
+   * Industry-standard identifiers for this specific manifest (e.g., Ad-ID, ISCI, Clearcast clock number). When present, overrides creative-level identifiers. Use when different format versions of the same source creative have distinct Ad-IDs (e.g., the :15 and :30 cuts).
+   */
+  industry_identifiers?: IndustryIdentifier[];
+  provenance?: Provenance;
+  ext?: ExtensionObject;
+}
+/**
+ * Manifest declares which canonical format it targets via `format_kind` (e.g., `image`). The v2 path introduced by RFC #3305.
+ */
+export interface V2ManifestCanonicalFormatKind1 {
+  format_kind: CanonicalFormatKind;
+  /**
+   * v2 path, optional. Stable identifier matching one of the seller's product `format_options[i].capability_id` values. REQUIRED when the target product carries multiple `format_options` entries sharing the same `format_kind` (the buyer must disambiguate which option this manifest matches). When the product's `format_options` has a single entry — or multiple entries with distinct `format_kind` values — `capability_id` is OPTIONAL because `format_kind` alone routes the manifest to the right declaration.
+   */
+  capability_id?: string;
+  /**
+   * Map of slot keys to actual asset content. v1 path: each key matches an `asset_id` from the format's `assets` array (e.g., 'banner_image', 'clickthrough_url', 'video_file', 'vast_tag'). v2 path: each key matches an `asset_group_id` from the format's `slots` declaration drawn from the canonical vocabulary registry (e.g., 'images_landscape', 'video', 'landing_page_url', 'vast_tag', 'script', 'creative_brief'). Either path produces the same envelope shape; only the slot-key vocabulary differs.
+   *
+   * Each slot value is **either** a single asset object (most slots — image, video, vast_tag, landing_page_url, etc.) **or** an array of asset objects (slots with `min`/`max` counts on the format declaration — `cards` on `image_carousel`, `headlines` / `descriptions` / `images_landscape` on `responsive_creative`, etc.). Single-vs-array shape is governed by the format's `slots[].min` and `slots[].max` parameters: when `max > 1` (or when the slot is conceptually a pool), the value MUST be an array; when the slot is single-valued, the value MUST be a single object. Each asset value (single or array element) carries an `asset_type` discriminator (image, video, audio, vast, daast, text, markdown, url, html, css, webhook, javascript, brief, catalog, zip, card) that selects the matching asset schema. Validators with OpenAPI-style discriminator support use `asset_type` to report errors against only the selected branch instead of all branches.
+   */
+  assets: {
+    /**
+     * This interface was referenced by `undefined`'s JSON-Schema definition
+     * via the `patternProperty` "^[a-z0-9_]+$".
+     */
+    [k: string]: AssetVariant6 | AssetVariant7[];
+  };
+  brand?: BrandReference;
+  /**
+   * Rights constraints attached to this creative. Each entry represents constraints from a single rights holder. A creative may combine multiple rights constraints (e.g., talent likeness + music license). For v1, rights constraints are informational metadata — the buyer/orchestrator manages creative lifecycle against these terms.
+   */
+  rights?: RightsConstraint[];
+  /**
+   * Industry-standard identifiers for this specific manifest (e.g., Ad-ID, ISCI, Clearcast clock number). When present, overrides creative-level identifiers. Use when different format versions of the same source creative have distinct Ad-IDs (e.g., the :15 and :30 cuts).
+   */
+  industry_identifiers?: IndustryIdentifier[];
+  provenance?: Provenance;
+  ext?: ExtensionObject;
 }
 /**
  * Progress payload for active build_creative task. Returned during AI generation, format transformation, or complex library retrieval with macro resolution.

--- a/src/lib/types/schemas.generated.ts
+++ b/src/lib/types/schemas.generated.ts
@@ -1,5 +1,5 @@
 // Generated Zod v4 schemas from TypeScript types
-// Generated at: 2026-05-22T14:22:16.292Z
+// Generated at: 2026-05-22T16:27:28.443Z
 // Sources:
 //   - core.generated.ts (core types)
 //   - tools.generated.ts (tool types)
@@ -2977,6 +2977,14 @@ export const UpdateMediaBuyInputRequiredSchema = z.object({
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
+export const AssetVariant4Schema = z.union([ImageAssetSchema, VideoAssetSchema, AudioAssetSchema, VASTAsset4Schema, TextAssetSchema, URLAssetSchema, HTMLAssetSchema, JavaScriptAssetSchema, ZipAssetSchema, WebhookAssetSchema, CSSAssetSchema, DAASTAsset4Schema, MarkdownAssetSchema, BriefAsset4Schema, CatalogAsset4Schema, CardAssetSchema]);
+
+export const AssetVariant5Schema = z.union([ImageAssetSchema, VideoAssetSchema, AudioAssetSchema, VASTAsset5Schema, TextAssetSchema, URLAssetSchema, HTMLAssetSchema, JavaScriptAssetSchema, ZipAssetSchema, WebhookAssetSchema, CSSAssetSchema, DAASTAsset5Schema, MarkdownAssetSchema, BriefAsset5Schema, CatalogAsset5Schema, CardAssetSchema]);
+
+export const AssetVariant6Schema = z.union([ImageAssetSchema, VideoAssetSchema, AudioAssetSchema, VASTAsset6Schema, TextAssetSchema, URLAssetSchema, HTMLAssetSchema, JavaScriptAssetSchema, ZipAssetSchema, WebhookAssetSchema, CSSAssetSchema, DAASTAsset6Schema, MarkdownAssetSchema, BriefAsset6Schema, CatalogAsset6Schema, CardAssetSchema]);
+
+export const AssetVariant7Schema = z.union([ImageAssetSchema, VideoAssetSchema, AudioAssetSchema, VASTAsset7Schema, TextAssetSchema, URLAssetSchema, HTMLAssetSchema, JavaScriptAssetSchema, ZipAssetSchema, WebhookAssetSchema, CSSAssetSchema, DAASTAsset7Schema, MarkdownAssetSchema, BriefAsset7Schema, CatalogAsset7Schema, CardAssetSchema]);
+
 export const BuildCreativeWorkingSchema = z.object({
     percentage: z.number().min(0).max(100).optional(),
     current_step: z.string().optional(),
@@ -3171,36 +3179,6 @@ export const WebhookActivityRecordSchema = z.object({
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
-export const CreativeManifestSchema = z.object({
-    format_id: FormatReferenceStructuredObjectSchema.optional(),
-    format_kind: CanonicalFormatKindSchema.optional(),
-    capability_id: z.string().optional(),
-    assets: z.record(z.string(), z.union([AssetVariantSchema, z.array(AssetVariantSchema)])),
-    brand: BrandReferenceSchema.optional(),
-    rights: z.array(RightsConstraintSchema).optional(),
-    industry_identifiers: z.array(IndustryIdentifierSchema).optional(),
-    provenance: ProvenanceSchema.optional(),
-    ext: ExtensionObjectSchema.optional()
-}).passthrough().and(z.union([z.object({
-        format_id: FormatReferenceStructuredObjectSchema,
-        capability_id: z.string().optional(),
-        assets: z.record(z.string(), z.union([AssetVariantSchema, z.array(AssetVariantSchema)])),
-        brand: BrandReferenceSchema.optional(),
-        rights: z.array(RightsConstraintSchema).optional(),
-        industry_identifiers: z.array(IndustryIdentifierSchema).optional(),
-        provenance: ProvenanceSchema.optional(),
-        ext: ExtensionObjectSchema.optional()
-    }).passthrough(), z.object({
-        format_kind: CanonicalFormatKindSchema,
-        capability_id: z.string().optional(),
-        assets: z.record(z.string(), z.union([AssetVariantSchema, z.array(AssetVariantSchema)])),
-        brand: BrandReferenceSchema.optional(),
-        rights: z.array(RightsConstraintSchema).optional(),
-        industry_identifiers: z.array(IndustryIdentifierSchema).optional(),
-        provenance: ProvenanceSchema.optional(),
-        ext: ExtensionObjectSchema.optional()
-    }).passthrough()]));
-
 export const CreativeQualitySchema = z.union([z.literal("draft"), z.literal("production")]);
 
 export const PreviewOutputFormatSchema = z.union([z.literal("url"), z.literal("html")]);
@@ -3222,20 +3200,6 @@ export const PreviewCreativeSingleResponseSchema = z.object({
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
-export const PreviewCreativeVariantResponseSchema = z.object({
-    response_type: z.literal("variant"),
-    variant_id: z.string(),
-    creative_id: z.string().optional(),
-    previews: z.array(z.object({
-        preview_id: z.string(),
-        renders: z.array(PreviewRenderSchema)
-    }).passthrough()),
-    manifest: CreativeManifestSchema.optional(),
-    expires_at: z.iso.datetime().optional(),
-    context: ContextObjectSchema.optional(),
-    ext: ExtensionObjectSchema.optional()
-}).passthrough();
-
 export const PreviewBatchResultSuccessSchema = z.object({
     success: z.literal(true).optional()
 }).passthrough();
@@ -3243,60 +3207,6 @@ export const PreviewBatchResultSuccessSchema = z.object({
 export const PreviewBatchResultErrorSchema = z.object({
     success: z.literal(false).optional()
 }).passthrough();
-
-export const CreativeAssetSchema = z.object({
-    creative_id: z.string(),
-    name: z.string(),
-    format_id: FormatReferenceStructuredObjectSchema.optional(),
-    format_kind: CanonicalFormatKindSchema.optional(),
-    capability_id: z.string().optional(),
-    assets: z.record(z.string(), z.union([AssetVariantSchema, z.array(AssetVariantSchema)])),
-    inputs: z.array(z.object({
-        name: z.string(),
-        macros: z.record(z.string(), z.string()).optional(),
-        context_description: z.string().optional()
-    }).passthrough()).optional(),
-    tags: z.array(z.string()).optional(),
-    status: CreativeStatusSchema.optional(),
-    weight: z.number().min(0).max(100).optional(),
-    placement_ids: z.array(z.string()).optional(),
-    industry_identifiers: z.array(IndustryIdentifierSchema).optional(),
-    provenance: ProvenanceSchema.optional()
-}).passthrough().and(z.union([z.object({
-        creative_id: z.string(),
-        name: z.string(),
-        format_id: FormatReferenceStructuredObjectSchema,
-        capability_id: z.string().optional(),
-        assets: z.record(z.string(), z.union([AssetVariantSchema, z.array(AssetVariantSchema)])),
-        inputs: z.array(z.object({
-            name: z.string(),
-            macros: z.record(z.string(), z.string()).optional(),
-            context_description: z.string().optional()
-        }).passthrough()).optional(),
-        tags: z.array(z.string()).optional(),
-        status: CreativeStatusSchema.optional(),
-        weight: z.number().min(0).max(100).optional(),
-        placement_ids: z.array(z.string()).optional(),
-        industry_identifiers: z.array(IndustryIdentifierSchema).optional(),
-        provenance: ProvenanceSchema.optional()
-    }).passthrough(), z.object({
-        creative_id: z.string(),
-        name: z.string(),
-        format_kind: CanonicalFormatKindSchema,
-        capability_id: z.string().optional(),
-        assets: z.record(z.string(), z.union([AssetVariantSchema, z.array(AssetVariantSchema)])),
-        inputs: z.array(z.object({
-            name: z.string(),
-            macros: z.record(z.string(), z.string()).optional(),
-            context_description: z.string().optional()
-        }).passthrough()).optional(),
-        tags: z.array(z.string()).optional(),
-        status: CreativeStatusSchema.optional(),
-        weight: z.number().min(0).max(100).optional(),
-        placement_ids: z.array(z.string()).optional(),
-        industry_identifiers: z.array(IndustryIdentifierSchema).optional(),
-        provenance: ProvenanceSchema.optional()
-    }).passthrough()]));
 
 export const ValidationModeSchema = z.union([z.literal("strict"), z.literal("lenient")]);
 
@@ -3328,35 +3238,6 @@ export const ValidateInputResultSchema = z.object({
         field: z.string(),
         retry_with: z.object({}).passthrough().optional()
     }).passthrough()).optional()
-}).passthrough();
-
-export const BuildCreativeRequestSchema = z.object({
-    adcp_version: z.string().optional(),
-    adcp_major_version: z.number().optional(),
-    message: z.string().optional(),
-    creative_manifest: CreativeManifestSchema.optional(),
-    creative_id: z.string().optional(),
-    concept_id: z.string().optional(),
-    media_buy_id: z.string().optional(),
-    package_id: z.string().optional(),
-    target_format_id: FormatReferenceStructuredObjectSchema.optional(),
-    target_format_ids: z.array(FormatReferenceStructuredObjectSchema).optional(),
-    account: AccountReferenceSchema.optional(),
-    brand: BrandReferenceSchema.optional(),
-    quality: CreativeQualitySchema.optional(),
-    item_limit: z.number().min(1).optional(),
-    include_preview: z.boolean().optional(),
-    preview_inputs: z.array(z.object({
-        name: z.string(),
-        macros: z.record(z.string(), z.string()).optional(),
-        context_description: z.string().optional()
-    }).passthrough()).optional(),
-    preview_quality: CreativeQualitySchema.optional(),
-    preview_output_format: PreviewOutputFormatSchema.optional(),
-    macro_values: z.record(z.string(), z.string()).optional(),
-    idempotency_key: z.string().min(16).max(255).regex(/^[A-Za-z0-9_.:-]{16,255}$/),
-    context: ContextObjectSchema.optional(),
-    ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
 export const StartTimingSchema = z.union([z.literal("asap"), z.string()]);
@@ -5684,46 +5565,63 @@ export const GroupZipAssetSchema = BaseGroupAssetSchema;
 
 export const GroupAssetSlotSchema = z.union([GroupImageAssetSchema, GroupVideoAssetSchema, GroupAudioAssetSchema, GroupTextAssetSchema, GroupMarkdownAssetSchema, GroupHtmlAssetSchema, GroupCssAssetSchema, GroupJavaScriptAssetSchema, GroupVastAssetSchema, GroupDaastAssetSchema, GroupUrlAssetSchema, GroupWebhookAssetSchema]);
 
-export const PackageRequestSchema = z.object({
-    adcp_version: z.string().optional(),
-    adcp_major_version: z.number().optional(),
-    product_id: z.string(),
-    format_ids: z.array(FormatReferenceStructuredObjectSchema).optional(),
-    capability_ids: z.array(z.string()).optional(),
-    budget: z.number().min(0),
-    pacing: PacingSchema.optional(),
-    pricing_option_id: z.string(),
-    bid_price: z.number().min(0).optional(),
-    impressions: z.number().min(0).optional(),
-    start_time: z.iso.datetime().optional(),
-    end_time: z.iso.datetime().optional(),
-    paused: z.boolean().optional(),
-    catalogs: z.array(CatalogSchema).optional(),
-    optimization_goals: z.array(OptimizationGoalSchema).optional(),
-    targeting_overlay: TargetingOverlaySchema.optional(),
-    measurement_terms: MeasurementTermsSchema.optional(),
-    performance_standards: z.array(PerformanceStandardSchema).optional(),
-    committed_metrics: z.array(z.union([z.object({
-            scope: z.literal("standard"),
-            metric_id: AvailableMetricSchema,
-            qualifier: z.object({
-                viewability_standard: ViewabilityStandardSchema.optional(),
-                completion_source: CompletionSourceSchema.optional(),
-                attribution_methodology: AttributionMethodologySchema.optional(),
-                attribution_window: DurationSchema.optional(),
-                lift_dimension: LiftDimensionSchema.optional()
-            }).passthrough().optional()
-        }).passthrough(), z.object({
-            scope: z.literal("vendor"),
-            vendor: BrandReferenceSchema,
-            metric_id: VendorMetricIDSchema
-        }).passthrough()])).optional(),
-    creative_assignments: z.array(CreativeAssignmentSchema).optional(),
-    creatives: z.array(CreativeAssetSchema).optional(),
-    agency_estimate_number: z.string().max(100).optional(),
-    context: ContextObjectSchema.optional(),
-    ext: ExtensionObjectSchema.optional()
+export const V1CreativeNamedFormatReferenceSchema = z.object({
+    creative_id: z.string(),
+    name: z.string(),
+    format_id: FormatReferenceStructuredObjectSchema,
+    capability_id: z.string().optional(),
+    assets: z.record(z.string(), z.union([AssetVariantSchema, z.array(AssetVariantSchema)])),
+    inputs: z.array(z.object({
+        name: z.string(),
+        macros: z.record(z.string(), z.string()).optional(),
+        context_description: z.string().optional()
+    }).passthrough()).optional(),
+    tags: z.array(z.string()).optional(),
+    status: CreativeStatusSchema.optional(),
+    weight: z.number().min(0).max(100).optional(),
+    placement_ids: z.array(z.string()).optional(),
+    industry_identifiers: z.array(IndustryIdentifierSchema).optional(),
+    provenance: ProvenanceSchema.optional()
 }).passthrough();
+
+export const V2CreativeCanonicalFormatKindSchema = z.object({
+    creative_id: z.string(),
+    name: z.string(),
+    format_kind: CanonicalFormatKindSchema,
+    capability_id: z.string().optional(),
+    assets: z.record(z.string(), z.union([AssetVariantSchema, z.array(AssetVariantSchema)])),
+    inputs: z.array(z.object({
+        name: z.string(),
+        macros: z.record(z.string(), z.string()).optional(),
+        context_description: z.string().optional()
+    }).passthrough()).optional(),
+    tags: z.array(z.string()).optional(),
+    status: CreativeStatusSchema.optional(),
+    weight: z.number().min(0).max(100).optional(),
+    placement_ids: z.array(z.string()).optional(),
+    industry_identifiers: z.array(IndustryIdentifierSchema).optional(),
+    provenance: ProvenanceSchema.optional()
+}).passthrough();
+
+export const CreativeAssetSchema = z.object({
+    creative_id: z.string(),
+    name: z.string(),
+    format_id: FormatReferenceStructuredObjectSchema.optional(),
+    format_kind: CanonicalFormatKindSchema.optional(),
+    capability_id: z.string().optional(),
+    assets: z.record(z.string(), z.union([AssetVariantSchema, z.array(AssetVariantSchema)])),
+    inputs: z.array(z.object({
+        name: z.string(),
+        macros: z.record(z.string(), z.string()).optional(),
+        context_description: z.string().optional()
+    }).passthrough()).optional(),
+    tags: z.array(z.string()).optional(),
+    status: CreativeStatusSchema.optional(),
+    weight: z.number().min(0).max(100).optional(),
+    placement_ids: z.array(z.string()).optional(),
+    industry_identifiers: z.array(IndustryIdentifierSchema).optional(),
+    provenance: ProvenanceSchema.optional()
+}).passthrough().and(z.union([V1CreativeNamedFormatReferenceSchema, V2CreativeCanonicalFormatKindSchema]));
 
 export const PackageSchema = z.object({
     package_id: z.string(),
@@ -5825,6 +5723,47 @@ export const PackageUpdateSchema = z.object({
     }).passthrough()).optional(),
     creative_assignments: z.array(CreativeAssignmentSchema).optional(),
     creatives: z.array(CreativeAssetSchema).optional(),
+    context: ContextObjectSchema.optional(),
+    ext: ExtensionObjectSchema.optional()
+}).passthrough();
+
+export const PackageRequestSchema = z.object({
+    adcp_version: z.string().optional(),
+    adcp_major_version: z.number().optional(),
+    product_id: z.string(),
+    format_ids: z.array(FormatReferenceStructuredObjectSchema).optional(),
+    capability_ids: z.array(z.string()).optional(),
+    budget: z.number().min(0),
+    pacing: PacingSchema.optional(),
+    pricing_option_id: z.string(),
+    bid_price: z.number().min(0).optional(),
+    impressions: z.number().min(0).optional(),
+    start_time: z.iso.datetime().optional(),
+    end_time: z.iso.datetime().optional(),
+    paused: z.boolean().optional(),
+    catalogs: z.array(CatalogSchema).optional(),
+    optimization_goals: z.array(OptimizationGoalSchema).optional(),
+    targeting_overlay: TargetingOverlaySchema.optional(),
+    measurement_terms: MeasurementTermsSchema.optional(),
+    performance_standards: z.array(PerformanceStandardSchema).optional(),
+    committed_metrics: z.array(z.union([z.object({
+            scope: z.literal("standard"),
+            metric_id: AvailableMetricSchema,
+            qualifier: z.object({
+                viewability_standard: ViewabilityStandardSchema.optional(),
+                completion_source: CompletionSourceSchema.optional(),
+                attribution_methodology: AttributionMethodologySchema.optional(),
+                attribution_window: DurationSchema.optional(),
+                lift_dimension: LiftDimensionSchema.optional()
+            }).passthrough().optional()
+        }).passthrough(), z.object({
+            scope: z.literal("vendor"),
+            vendor: BrandReferenceSchema,
+            metric_id: VendorMetricIDSchema
+        }).passthrough()])).optional(),
+    creative_assignments: z.array(CreativeAssignmentSchema).optional(),
+    creatives: z.array(CreativeAssetSchema).optional(),
+    agency_estimate_number: z.string().max(100).optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -6243,6 +6182,40 @@ export const SyncCatalogsResponseSchema = z.object({
     adcp_major_version: z.number().optional()
 }).passthrough().and(z.union([SyncCatalogsSuccessSchema, SyncCatalogsErrorSchema, SyncCatalogsSubmittedSchema]));
 
+export const V1ManifestNamedFormatReferenceSchema = z.object({
+    format_id: FormatReferenceStructuredObjectSchema,
+    capability_id: z.string().optional(),
+    assets: z.record(z.string(), z.union([AssetVariantSchema, z.array(AssetVariantSchema)])),
+    brand: BrandReferenceSchema.optional(),
+    rights: z.array(RightsConstraintSchema).optional(),
+    industry_identifiers: z.array(IndustryIdentifierSchema).optional(),
+    provenance: ProvenanceSchema.optional(),
+    ext: ExtensionObjectSchema.optional()
+}).passthrough();
+
+export const V2ManifestCanonicalFormatKindSchema = z.object({
+    format_kind: CanonicalFormatKindSchema,
+    capability_id: z.string().optional(),
+    assets: z.record(z.string(), z.union([AssetVariantSchema, z.array(AssetVariantSchema)])),
+    brand: BrandReferenceSchema.optional(),
+    rights: z.array(RightsConstraintSchema).optional(),
+    industry_identifiers: z.array(IndustryIdentifierSchema).optional(),
+    provenance: ProvenanceSchema.optional(),
+    ext: ExtensionObjectSchema.optional()
+}).passthrough();
+
+export const CreativeManifestSchema = z.object({
+    format_id: FormatReferenceStructuredObjectSchema.optional(),
+    format_kind: CanonicalFormatKindSchema.optional(),
+    capability_id: z.string().optional(),
+    assets: z.record(z.string(), z.union([AssetVariantSchema, z.array(AssetVariantSchema)])),
+    brand: BrandReferenceSchema.optional(),
+    rights: z.array(RightsConstraintSchema).optional(),
+    industry_identifiers: z.array(IndustryIdentifierSchema).optional(),
+    provenance: ProvenanceSchema.optional(),
+    ext: ExtensionObjectSchema.optional()
+}).passthrough().and(z.union([V1ManifestNamedFormatReferenceSchema, V2ManifestCanonicalFormatKindSchema]));
+
 export const BuildCreativeSuccessSchema = z.object({
     creative_manifest: CreativeManifestSchema,
     sandbox: z.boolean().optional(),
@@ -6333,6 +6306,20 @@ export const PreviewCreativeRequestSchema: z.ZodType<PreviewCreativeRequest & Re
 export const PreviewCreativeBatchResponseSchema = z.object({
     response_type: z.literal("batch"),
     results: z.array(z.union([PreviewBatchResultSuccessSchema, PreviewBatchResultErrorSchema])),
+    context: ContextObjectSchema.optional(),
+    ext: ExtensionObjectSchema.optional()
+}).passthrough();
+
+export const PreviewCreativeVariantResponseSchema = z.object({
+    response_type: z.literal("variant"),
+    variant_id: z.string(),
+    creative_id: z.string().optional(),
+    previews: z.array(z.object({
+        preview_id: z.string(),
+        renders: z.array(PreviewRenderSchema)
+    }).passthrough()),
+    manifest: CreativeManifestSchema.optional(),
+    expires_at: z.iso.datetime().optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -7742,9 +7729,25 @@ export const ListAccountsResponseSchema = z.object({
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
-export const ProvisioningModeSchema = z.record(z.string(), z.unknown());
+export const ProvisioningModeSchema = z.object({
+    brand: BrandReferenceSchema,
+    operator: z.string().regex(/^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/),
+    billing: BillingPartySchema,
+    billing_entity: BusinessEntitySchema.optional(),
+    payment_terms: PaymentTermsSchema.optional(),
+    sandbox: z.boolean().optional(),
+    preferred_reporting_protocol: CloudStorageProtocolSchema.optional(),
+    notification_configs: z.array(NotificationConfigSchema).optional()
+}).passthrough();
 
-export const SettingsUpdateModeSchema = z.record(z.string(), z.unknown());
+export const SettingsUpdateModeSchema = z.object({
+    account: AccountReferenceSchema,
+    billing_entity: BusinessEntitySchema.optional(),
+    payment_terms: PaymentTermsSchema.optional(),
+    sandbox: z.boolean().optional(),
+    preferred_reporting_protocol: CloudStorageProtocolSchema.optional(),
+    notification_configs: z.array(NotificationConfigSchema).optional()
+}).passthrough();
 
 export const SyncAccountsSuccessSchema = z.object({
     dry_run: z.boolean().optional(),
@@ -8390,19 +8393,33 @@ export const CatalogAsset2Schema = CatalogSchema;
 
 export const AssetVariant3Schema = z.union([ImageAssetSchema, VideoAssetSchema, AudioAssetSchema, VASTAsset3Schema, TextAssetSchema, URLAssetSchema, HTMLAssetSchema, JavaScriptAssetSchema, ZipAssetSchema, WebhookAssetSchema, CSSAssetSchema, DAASTAsset3Schema, MarkdownAssetSchema, BriefAsset3Schema, CatalogAsset3Schema, CardAssetSchema]);
 
-export const AssetVariant4Schema = z.union([ImageAssetSchema, VideoAssetSchema, AudioAssetSchema, VASTAsset4Schema, TextAssetSchema, URLAssetSchema, HTMLAssetSchema, JavaScriptAssetSchema, ZipAssetSchema, WebhookAssetSchema, CSSAssetSchema, DAASTAsset4Schema, MarkdownAssetSchema, BriefAsset4Schema, CatalogAsset4Schema, CardAssetSchema]);
-
-export const AssetVariant5Schema = z.union([ImageAssetSchema, VideoAssetSchema, AudioAssetSchema, VASTAsset5Schema, TextAssetSchema, URLAssetSchema, HTMLAssetSchema, JavaScriptAssetSchema, ZipAssetSchema, WebhookAssetSchema, CSSAssetSchema, DAASTAsset5Schema, MarkdownAssetSchema, BriefAsset5Schema, CatalogAsset5Schema, CardAssetSchema]);
-
-export const AssetVariant6Schema = z.union([ImageAssetSchema, VideoAssetSchema, AudioAssetSchema, VASTAsset6Schema, TextAssetSchema, URLAssetSchema, HTMLAssetSchema, JavaScriptAssetSchema, ZipAssetSchema, WebhookAssetSchema, CSSAssetSchema, DAASTAsset6Schema, MarkdownAssetSchema, BriefAsset6Schema, CatalogAsset6Schema, CardAssetSchema]);
-
-export const AssetVariant7Schema = z.union([ImageAssetSchema, VideoAssetSchema, AudioAssetSchema, VASTAsset7Schema, TextAssetSchema, URLAssetSchema, HTMLAssetSchema, JavaScriptAssetSchema, ZipAssetSchema, WebhookAssetSchema, CSSAssetSchema, DAASTAsset7Schema, MarkdownAssetSchema, BriefAsset7Schema, CatalogAsset7Schema, CardAssetSchema]);
-
 export const GetProductsInputRequiredSchema = z.object({
     reason: z.union([z.literal("CLARIFICATION_NEEDED"), z.literal("BUDGET_REQUIRED")]).optional(),
     partial_results: z.array(ProductSchema).optional(),
     suggestions: z.array(z.string()).optional(),
     context: ContextObjectSchema.optional(),
+    ext: ExtensionObjectSchema.optional()
+}).passthrough();
+
+export const V1ManifestNamedFormatReference1Schema = z.object({
+    format_id: FormatReferenceStructuredObjectSchema,
+    capability_id: z.string().optional(),
+    assets: z.record(z.string(), z.union([AssetVariant4Schema, z.array(AssetVariant5Schema)])),
+    brand: BrandReferenceSchema.optional(),
+    rights: z.array(RightsConstraintSchema).optional(),
+    industry_identifiers: z.array(IndustryIdentifierSchema).optional(),
+    provenance: ProvenanceSchema.optional(),
+    ext: ExtensionObjectSchema.optional()
+}).passthrough();
+
+export const V2ManifestCanonicalFormatKind1Schema = z.object({
+    format_kind: CanonicalFormatKindSchema,
+    capability_id: z.string().optional(),
+    assets: z.record(z.string(), z.union([AssetVariant6Schema, z.array(AssetVariant7Schema)])),
+    brand: BrandReferenceSchema.optional(),
+    rights: z.array(RightsConstraintSchema).optional(),
+    industry_identifiers: z.array(IndustryIdentifierSchema).optional(),
+    provenance: ProvenanceSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
@@ -8469,6 +8486,35 @@ export const PreviewCreativeResponseSchema = z.object({
     adcp_version: z.string().optional(),
     adcp_major_version: z.number().optional()
 }).passthrough().and(z.union([PreviewCreativeSingleResponseSchema, PreviewCreativeBatchResponseSchema, PreviewCreativeVariantResponseSchema]));
+
+export const BuildCreativeRequestSchema = z.object({
+    adcp_version: z.string().optional(),
+    adcp_major_version: z.number().optional(),
+    message: z.string().optional(),
+    creative_manifest: CreativeManifestSchema.optional(),
+    creative_id: z.string().optional(),
+    concept_id: z.string().optional(),
+    media_buy_id: z.string().optional(),
+    package_id: z.string().optional(),
+    target_format_id: FormatReferenceStructuredObjectSchema.optional(),
+    target_format_ids: z.array(FormatReferenceStructuredObjectSchema).optional(),
+    account: AccountReferenceSchema.optional(),
+    brand: BrandReferenceSchema.optional(),
+    quality: CreativeQualitySchema.optional(),
+    item_limit: z.number().min(1).optional(),
+    include_preview: z.boolean().optional(),
+    preview_inputs: z.array(z.object({
+        name: z.string(),
+        macros: z.record(z.string(), z.string()).optional(),
+        context_description: z.string().optional()
+    }).passthrough()).optional(),
+    preview_quality: CreativeQualitySchema.optional(),
+    preview_output_format: PreviewOutputFormatSchema.optional(),
+    macro_values: z.record(z.string(), z.string()).optional(),
+    idempotency_key: z.string().min(16).max(255).regex(/^[A-Za-z0-9_.:-]{16,255}$/),
+    context: ContextObjectSchema.optional(),
+    ext: ExtensionObjectSchema.optional()
+}).passthrough();
 
 export const CreateMediaBuyRequestSchema = z.object({
     adcp_version: z.string().optional(),

--- a/src/lib/types/tools.generated.ts
+++ b/src/lib/types/tools.generated.ts
@@ -6472,136 +6472,7 @@ export type CreativeAsset = {
    */
   industry_identifiers?: IndustryIdentifier[];
   provenance?: Provenance;
-} & (
-  | {
-      /**
-       * Unique identifier for the creative. Stable across v1 and v2 paths — a creative registered against v1 `format_id` retains the same `creative_id` when later viewed via v2 flatten.
-       */
-      creative_id: string;
-      /**
-       * Human-readable creative name
-       */
-      name: string;
-      format_id: FormatReferenceStructuredObject;
-      /**
-       * v2 path, optional. Stable identifier matching one of the seller's product `format_options[i].capability_id` values. REQUIRED only when the target product has multiple `format_options` entries sharing the same `format_kind`.
-       */
-      capability_id?: string;
-      /**
-       * Assets required by the format, keyed by asset_id. Each slot value is either a single asset object or an array of asset objects (for slots with `min`/`max > 1` like carousel `cards` or responsive_creative `headlines`). Each asset value carries an `asset_type` discriminator that selects the matching asset schema.
-       */
-      assets: {
-        /**
-         * This interface was referenced by `undefined`'s JSON-Schema definition
-         * via the `patternProperty` "^[a-z0-9_]+$".
-         */
-        [k: string]: AssetVariant | AssetVariant[];
-      };
-      /**
-       * Preview contexts for generative formats - defines what scenarios to generate previews for
-       */
-      inputs?: {
-        /**
-         * Human-readable name for this preview variant
-         */
-        name: string;
-        /**
-         * Macro values to apply for this preview
-         */
-        macros?: {
-          [k: string]: string | undefined;
-        };
-        /**
-         * Natural language description of the context for AI-generated content
-         */
-        context_description?: string;
-      }[];
-      /**
-       * User-defined tags for organization and searchability
-       */
-      tags?: string[];
-      status?: CreativeStatus;
-      /**
-       * Optional delivery weight for creative rotation when uploading via create_media_buy or update_media_buy (0-100). If omitted, platform determines rotation. Only used during upload to media buy - not stored in creative library.
-       * @minimum 0
-       * @maximum 100
-       */
-      weight?: number;
-      /**
-       * Optional array of placement IDs where this creative should run when uploading via create_media_buy or update_media_buy. References placement_id values from the product's placements array. If omitted, creative runs on all placements. Only used during upload to media buy - not stored in creative library.
-       */
-      placement_ids?: string[];
-      /**
-       * Industry-standard identifiers for this creative (e.g., Ad-ID, ISCI, Clearcast clock number). In broadcast buying, these identifiers tie the creative to rotation instructions and traffic systems. A creative may have multiple identifiers when different systems reference the same asset.
-       */
-      industry_identifiers?: IndustryIdentifier[];
-      provenance?: Provenance;
-    }
-  | {
-      /**
-       * Unique identifier for the creative. Stable across v1 and v2 paths — a creative registered against v1 `format_id` retains the same `creative_id` when later viewed via v2 flatten.
-       */
-      creative_id: string;
-      /**
-       * Human-readable creative name
-       */
-      name: string;
-      format_kind: CanonicalFormatKind;
-      /**
-       * v2 path, optional. Stable identifier matching one of the seller's product `format_options[i].capability_id` values. REQUIRED only when the target product has multiple `format_options` entries sharing the same `format_kind`.
-       */
-      capability_id?: string;
-      /**
-       * Assets required by the format, keyed by asset_id. Each slot value is either a single asset object or an array of asset objects (for slots with `min`/`max > 1` like carousel `cards` or responsive_creative `headlines`). Each asset value carries an `asset_type` discriminator that selects the matching asset schema.
-       */
-      assets: {
-        /**
-         * This interface was referenced by `undefined`'s JSON-Schema definition
-         * via the `patternProperty` "^[a-z0-9_]+$".
-         */
-        [k: string]: AssetVariant | AssetVariant[];
-      };
-      /**
-       * Preview contexts for generative formats - defines what scenarios to generate previews for
-       */
-      inputs?: {
-        /**
-         * Human-readable name for this preview variant
-         */
-        name: string;
-        /**
-         * Macro values to apply for this preview
-         */
-        macros?: {
-          [k: string]: string | undefined;
-        };
-        /**
-         * Natural language description of the context for AI-generated content
-         */
-        context_description?: string;
-      }[];
-      /**
-       * User-defined tags for organization and searchability
-       */
-      tags?: string[];
-      status?: CreativeStatus;
-      /**
-       * Optional delivery weight for creative rotation when uploading via create_media_buy or update_media_buy (0-100). If omitted, platform determines rotation. Only used during upload to media buy - not stored in creative library.
-       * @minimum 0
-       * @maximum 100
-       */
-      weight?: number;
-      /**
-       * Optional array of placement IDs where this creative should run when uploading via create_media_buy or update_media_buy. References placement_id values from the product's placements array. If omitted, creative runs on all placements. Only used during upload to media buy - not stored in creative library.
-       */
-      placement_ids?: string[];
-      /**
-       * Industry-standard identifiers for this creative (e.g., Ad-ID, ISCI, Clearcast clock number). In broadcast buying, these identifiers tie the creative to rotation instructions and traffic systems. A creative may have multiple identifiers when different systems reference the same asset.
-       */
-      industry_identifiers?: IndustryIdentifier[];
-      provenance?: Provenance;
-    }
-);
+} & (V1CreativeNamedFormatReference | V2CreativeCanonicalFormatKind);
 /**
  * Canonical union of all asset variant schemas. Referenced from creative-asset.json and creative-manifest.json to ensure a single named type is emitted by schema-to-TypeScript tooling. Add new asset types here and to the creative/asset-types registry.
  */
@@ -8070,6 +7941,140 @@ export interface IndustryIdentifier {
    * @maxLength 64
    */
   value: string;
+}
+/**
+ * Creative references a named format via the structured `format_id` object. The v1 path; remains supported through 4.x.
+ */
+export interface V1CreativeNamedFormatReference {
+  /**
+   * Unique identifier for the creative. Stable across v1 and v2 paths — a creative registered against v1 `format_id` retains the same `creative_id` when later viewed via v2 flatten.
+   */
+  creative_id: string;
+  /**
+   * Human-readable creative name
+   */
+  name: string;
+  format_id: FormatReferenceStructuredObject;
+  /**
+   * v2 path, optional. Stable identifier matching one of the seller's product `format_options[i].capability_id` values. REQUIRED only when the target product has multiple `format_options` entries sharing the same `format_kind`.
+   */
+  capability_id?: string;
+  /**
+   * Assets required by the format, keyed by asset_id. Each slot value is either a single asset object or an array of asset objects (for slots with `min`/`max > 1` like carousel `cards` or responsive_creative `headlines`). Each asset value carries an `asset_type` discriminator that selects the matching asset schema.
+   */
+  assets: {
+    /**
+     * This interface was referenced by `undefined`'s JSON-Schema definition
+     * via the `patternProperty` "^[a-z0-9_]+$".
+     */
+    [k: string]: AssetVariant | AssetVariant[];
+  };
+  /**
+   * Preview contexts for generative formats - defines what scenarios to generate previews for
+   */
+  inputs?: {
+    /**
+     * Human-readable name for this preview variant
+     */
+    name: string;
+    /**
+     * Macro values to apply for this preview
+     */
+    macros?: {
+      [k: string]: string | undefined;
+    };
+    /**
+     * Natural language description of the context for AI-generated content
+     */
+    context_description?: string;
+  }[];
+  /**
+   * User-defined tags for organization and searchability
+   */
+  tags?: string[];
+  status?: CreativeStatus;
+  /**
+   * Optional delivery weight for creative rotation when uploading via create_media_buy or update_media_buy (0-100). If omitted, platform determines rotation. Only used during upload to media buy - not stored in creative library.
+   * @minimum 0
+   * @maximum 100
+   */
+  weight?: number;
+  /**
+   * Optional array of placement IDs where this creative should run when uploading via create_media_buy or update_media_buy. References placement_id values from the product's placements array. If omitted, creative runs on all placements. Only used during upload to media buy - not stored in creative library.
+   */
+  placement_ids?: string[];
+  /**
+   * Industry-standard identifiers for this creative (e.g., Ad-ID, ISCI, Clearcast clock number). In broadcast buying, these identifiers tie the creative to rotation instructions and traffic systems. A creative may have multiple identifiers when different systems reference the same asset.
+   */
+  industry_identifiers?: IndustryIdentifier[];
+  provenance?: Provenance;
+}
+/**
+ * Creative declares which canonical format it targets via `format_kind` (e.g., `image`). The v2 path introduced by RFC #3305.
+ */
+export interface V2CreativeCanonicalFormatKind {
+  /**
+   * Unique identifier for the creative. Stable across v1 and v2 paths — a creative registered against v1 `format_id` retains the same `creative_id` when later viewed via v2 flatten.
+   */
+  creative_id: string;
+  /**
+   * Human-readable creative name
+   */
+  name: string;
+  format_kind: CanonicalFormatKind;
+  /**
+   * v2 path, optional. Stable identifier matching one of the seller's product `format_options[i].capability_id` values. REQUIRED only when the target product has multiple `format_options` entries sharing the same `format_kind`.
+   */
+  capability_id?: string;
+  /**
+   * Assets required by the format, keyed by asset_id. Each slot value is either a single asset object or an array of asset objects (for slots with `min`/`max > 1` like carousel `cards` or responsive_creative `headlines`). Each asset value carries an `asset_type` discriminator that selects the matching asset schema.
+   */
+  assets: {
+    /**
+     * This interface was referenced by `undefined`'s JSON-Schema definition
+     * via the `patternProperty` "^[a-z0-9_]+$".
+     */
+    [k: string]: AssetVariant | AssetVariant[];
+  };
+  /**
+   * Preview contexts for generative formats - defines what scenarios to generate previews for
+   */
+  inputs?: {
+    /**
+     * Human-readable name for this preview variant
+     */
+    name: string;
+    /**
+     * Macro values to apply for this preview
+     */
+    macros?: {
+      [k: string]: string | undefined;
+    };
+    /**
+     * Natural language description of the context for AI-generated content
+     */
+    context_description?: string;
+  }[];
+  /**
+   * User-defined tags for organization and searchability
+   */
+  tags?: string[];
+  status?: CreativeStatus;
+  /**
+   * Optional delivery weight for creative rotation when uploading via create_media_buy or update_media_buy (0-100). If omitted, platform determines rotation. Only used during upload to media buy - not stored in creative library.
+   * @minimum 0
+   * @maximum 100
+   */
+  weight?: number;
+  /**
+   * Optional array of placement IDs where this creative should run when uploading via create_media_buy or update_media_buy. References placement_id values from the product's placements array. If omitted, creative runs on all placements. Only used during upload to media buy - not stored in creative library.
+   */
+  placement_ids?: string[];
+  /**
+   * Industry-standard identifiers for this creative (e.g., Ad-ID, ISCI, Clearcast clock number). In broadcast buying, these identifiers tie the creative to rotation instructions and traffic systems. A creative may have multiple identifiers when different systems reference the same asset.
+   */
+  industry_identifiers?: IndustryIdentifier[];
+  provenance?: Provenance;
 }
 /**
  * Override the account's default billing entity for this specific buy. When provided, the seller invoices this entity instead. The seller MUST validate the invoice recipient is authorized for this account. When governance_agents are configured, the seller MUST include invoice_recipient in the check_governance request.
@@ -12090,68 +12095,7 @@ export type CreativeManifest = {
   industry_identifiers?: IndustryIdentifier[];
   provenance?: Provenance;
   ext?: ExtensionObject;
-} & (
-  | {
-      format_id: FormatReferenceStructuredObject;
-      /**
-       * v2 path, optional. Stable identifier matching one of the seller's product `format_options[i].capability_id` values. REQUIRED when the target product carries multiple `format_options` entries sharing the same `format_kind` (the buyer must disambiguate which option this manifest matches). When the product's `format_options` has a single entry — or multiple entries with distinct `format_kind` values — `capability_id` is OPTIONAL because `format_kind` alone routes the manifest to the right declaration.
-       */
-      capability_id?: string;
-      /**
-       * Map of slot keys to actual asset content. v1 path: each key matches an `asset_id` from the format's `assets` array (e.g., 'banner_image', 'clickthrough_url', 'video_file', 'vast_tag'). v2 path: each key matches an `asset_group_id` from the format's `slots` declaration drawn from the canonical vocabulary registry (e.g., 'images_landscape', 'video', 'landing_page_url', 'vast_tag', 'script', 'creative_brief'). Either path produces the same envelope shape; only the slot-key vocabulary differs.
-       *
-       * Each slot value is **either** a single asset object (most slots — image, video, vast_tag, landing_page_url, etc.) **or** an array of asset objects (slots with `min`/`max` counts on the format declaration — `cards` on `image_carousel`, `headlines` / `descriptions` / `images_landscape` on `responsive_creative`, etc.). Single-vs-array shape is governed by the format's `slots[].min` and `slots[].max` parameters: when `max > 1` (or when the slot is conceptually a pool), the value MUST be an array; when the slot is single-valued, the value MUST be a single object. Each asset value (single or array element) carries an `asset_type` discriminator (image, video, audio, vast, daast, text, markdown, url, html, css, webhook, javascript, brief, catalog, zip, card) that selects the matching asset schema. Validators with OpenAPI-style discriminator support use `asset_type` to report errors against only the selected branch instead of all branches.
-       */
-      assets: {
-        /**
-         * This interface was referenced by `undefined`'s JSON-Schema definition
-         * via the `patternProperty` "^[a-z0-9_]+$".
-         */
-        [k: string]: AssetVariant | AssetVariant[];
-      };
-      brand?: BrandReference;
-      /**
-       * Rights constraints attached to this creative. Each entry represents constraints from a single rights holder. A creative may combine multiple rights constraints (e.g., talent likeness + music license). For v1, rights constraints are informational metadata — the buyer/orchestrator manages creative lifecycle against these terms.
-       */
-      rights?: RightsConstraint[];
-      /**
-       * Industry-standard identifiers for this specific manifest (e.g., Ad-ID, ISCI, Clearcast clock number). When present, overrides creative-level identifiers. Use when different format versions of the same source creative have distinct Ad-IDs (e.g., the :15 and :30 cuts).
-       */
-      industry_identifiers?: IndustryIdentifier[];
-      provenance?: Provenance;
-      ext?: ExtensionObject;
-    }
-  | {
-      format_kind: CanonicalFormatKind;
-      /**
-       * v2 path, optional. Stable identifier matching one of the seller's product `format_options[i].capability_id` values. REQUIRED when the target product carries multiple `format_options` entries sharing the same `format_kind` (the buyer must disambiguate which option this manifest matches). When the product's `format_options` has a single entry — or multiple entries with distinct `format_kind` values — `capability_id` is OPTIONAL because `format_kind` alone routes the manifest to the right declaration.
-       */
-      capability_id?: string;
-      /**
-       * Map of slot keys to actual asset content. v1 path: each key matches an `asset_id` from the format's `assets` array (e.g., 'banner_image', 'clickthrough_url', 'video_file', 'vast_tag'). v2 path: each key matches an `asset_group_id` from the format's `slots` declaration drawn from the canonical vocabulary registry (e.g., 'images_landscape', 'video', 'landing_page_url', 'vast_tag', 'script', 'creative_brief'). Either path produces the same envelope shape; only the slot-key vocabulary differs.
-       *
-       * Each slot value is **either** a single asset object (most slots — image, video, vast_tag, landing_page_url, etc.) **or** an array of asset objects (slots with `min`/`max` counts on the format declaration — `cards` on `image_carousel`, `headlines` / `descriptions` / `images_landscape` on `responsive_creative`, etc.). Single-vs-array shape is governed by the format's `slots[].min` and `slots[].max` parameters: when `max > 1` (or when the slot is conceptually a pool), the value MUST be an array; when the slot is single-valued, the value MUST be a single object. Each asset value (single or array element) carries an `asset_type` discriminator (image, video, audio, vast, daast, text, markdown, url, html, css, webhook, javascript, brief, catalog, zip, card) that selects the matching asset schema. Validators with OpenAPI-style discriminator support use `asset_type` to report errors against only the selected branch instead of all branches.
-       */
-      assets: {
-        /**
-         * This interface was referenced by `undefined`'s JSON-Schema definition
-         * via the `patternProperty` "^[a-z0-9_]+$".
-         */
-        [k: string]: AssetVariant | AssetVariant[];
-      };
-      brand?: BrandReference;
-      /**
-       * Rights constraints attached to this creative. Each entry represents constraints from a single rights holder. A creative may combine multiple rights constraints (e.g., talent likeness + music license). For v1, rights constraints are informational metadata — the buyer/orchestrator manages creative lifecycle against these terms.
-       */
-      rights?: RightsConstraint[];
-      /**
-       * Industry-standard identifiers for this specific manifest (e.g., Ad-ID, ISCI, Clearcast clock number). When present, overrides creative-level identifiers. Use when different format versions of the same source creative have distinct Ad-IDs (e.g., the :15 and :30 cuts).
-       */
-      industry_identifiers?: IndustryIdentifier[];
-      provenance?: Provenance;
-      ext?: ExtensionObject;
-    }
-);
+} & (V1ManifestNamedFormatReference | V2ManifestCanonicalFormatKind);
 /**
  * Types of rights usage that can be licensed through the brand protocol. Aligned with DDEX UseType direction for interoperability with music and media rights systems.
  */
@@ -12325,6 +12269,72 @@ export interface RightsConstraint {
    * URL where downstream supply chain participants can verify this rights grant is active. Returns HTTP 200 with the current grant status, or 404 if revoked. Enables SSPs and verification vendors to confirm rights before serving.
    */
   verification_url?: string;
+  ext?: ExtensionObject;
+}
+/**
+ * Manifest references a named format via the structured `format_id` object. The v1 path; remains supported through 4.x.
+ */
+export interface V1ManifestNamedFormatReference {
+  format_id: FormatReferenceStructuredObject;
+  /**
+   * v2 path, optional. Stable identifier matching one of the seller's product `format_options[i].capability_id` values. REQUIRED when the target product carries multiple `format_options` entries sharing the same `format_kind` (the buyer must disambiguate which option this manifest matches). When the product's `format_options` has a single entry — or multiple entries with distinct `format_kind` values — `capability_id` is OPTIONAL because `format_kind` alone routes the manifest to the right declaration.
+   */
+  capability_id?: string;
+  /**
+   * Map of slot keys to actual asset content. v1 path: each key matches an `asset_id` from the format's `assets` array (e.g., 'banner_image', 'clickthrough_url', 'video_file', 'vast_tag'). v2 path: each key matches an `asset_group_id` from the format's `slots` declaration drawn from the canonical vocabulary registry (e.g., 'images_landscape', 'video', 'landing_page_url', 'vast_tag', 'script', 'creative_brief'). Either path produces the same envelope shape; only the slot-key vocabulary differs.
+   *
+   * Each slot value is **either** a single asset object (most slots — image, video, vast_tag, landing_page_url, etc.) **or** an array of asset objects (slots with `min`/`max` counts on the format declaration — `cards` on `image_carousel`, `headlines` / `descriptions` / `images_landscape` on `responsive_creative`, etc.). Single-vs-array shape is governed by the format's `slots[].min` and `slots[].max` parameters: when `max > 1` (or when the slot is conceptually a pool), the value MUST be an array; when the slot is single-valued, the value MUST be a single object. Each asset value (single or array element) carries an `asset_type` discriminator (image, video, audio, vast, daast, text, markdown, url, html, css, webhook, javascript, brief, catalog, zip, card) that selects the matching asset schema. Validators with OpenAPI-style discriminator support use `asset_type` to report errors against only the selected branch instead of all branches.
+   */
+  assets: {
+    /**
+     * This interface was referenced by `undefined`'s JSON-Schema definition
+     * via the `patternProperty` "^[a-z0-9_]+$".
+     */
+    [k: string]: AssetVariant | AssetVariant[];
+  };
+  brand?: BrandReference;
+  /**
+   * Rights constraints attached to this creative. Each entry represents constraints from a single rights holder. A creative may combine multiple rights constraints (e.g., talent likeness + music license). For v1, rights constraints are informational metadata — the buyer/orchestrator manages creative lifecycle against these terms.
+   */
+  rights?: RightsConstraint[];
+  /**
+   * Industry-standard identifiers for this specific manifest (e.g., Ad-ID, ISCI, Clearcast clock number). When present, overrides creative-level identifiers. Use when different format versions of the same source creative have distinct Ad-IDs (e.g., the :15 and :30 cuts).
+   */
+  industry_identifiers?: IndustryIdentifier[];
+  provenance?: Provenance;
+  ext?: ExtensionObject;
+}
+/**
+ * Manifest declares which canonical format it targets via `format_kind` (e.g., `image`). The v2 path introduced by RFC #3305.
+ */
+export interface V2ManifestCanonicalFormatKind {
+  format_kind: CanonicalFormatKind;
+  /**
+   * v2 path, optional. Stable identifier matching one of the seller's product `format_options[i].capability_id` values. REQUIRED when the target product carries multiple `format_options` entries sharing the same `format_kind` (the buyer must disambiguate which option this manifest matches). When the product's `format_options` has a single entry — or multiple entries with distinct `format_kind` values — `capability_id` is OPTIONAL because `format_kind` alone routes the manifest to the right declaration.
+   */
+  capability_id?: string;
+  /**
+   * Map of slot keys to actual asset content. v1 path: each key matches an `asset_id` from the format's `assets` array (e.g., 'banner_image', 'clickthrough_url', 'video_file', 'vast_tag'). v2 path: each key matches an `asset_group_id` from the format's `slots` declaration drawn from the canonical vocabulary registry (e.g., 'images_landscape', 'video', 'landing_page_url', 'vast_tag', 'script', 'creative_brief'). Either path produces the same envelope shape; only the slot-key vocabulary differs.
+   *
+   * Each slot value is **either** a single asset object (most slots — image, video, vast_tag, landing_page_url, etc.) **or** an array of asset objects (slots with `min`/`max` counts on the format declaration — `cards` on `image_carousel`, `headlines` / `descriptions` / `images_landscape` on `responsive_creative`, etc.). Single-vs-array shape is governed by the format's `slots[].min` and `slots[].max` parameters: when `max > 1` (or when the slot is conceptually a pool), the value MUST be an array; when the slot is single-valued, the value MUST be a single object. Each asset value (single or array element) carries an `asset_type` discriminator (image, video, audio, vast, daast, text, markdown, url, html, css, webhook, javascript, brief, catalog, zip, card) that selects the matching asset schema. Validators with OpenAPI-style discriminator support use `asset_type` to report errors against only the selected branch instead of all branches.
+   */
+  assets: {
+    /**
+     * This interface was referenced by `undefined`'s JSON-Schema definition
+     * via the `patternProperty` "^[a-z0-9_]+$".
+     */
+    [k: string]: AssetVariant | AssetVariant[];
+  };
+  brand?: BrandReference;
+  /**
+   * Rights constraints attached to this creative. Each entry represents constraints from a single rights holder. A creative may combine multiple rights constraints (e.g., talent likeness + music license). For v1, rights constraints are informational metadata — the buyer/orchestrator manages creative lifecycle against these terms.
+   */
+  rights?: RightsConstraint[];
+  /**
+   * Industry-standard identifiers for this specific manifest (e.g., Ad-ID, ISCI, Clearcast clock number). When present, overrides creative-level identifiers. Use when different format versions of the same source creative have distinct Ad-IDs (e.g., the :15 and :30 cuts).
+   */
+  industry_identifiers?: IndustryIdentifier[];
+  provenance?: Provenance;
   ext?: ExtensionObject;
 }
 
@@ -20840,13 +20850,45 @@ export interface SyncAccountsRequest {
  * Provisioning-mode entry — natural-key trio is required, `account` is forbidden.
  */
 export interface ProvisioningMode {
-  [k: string]: unknown | undefined;
+  brand: BrandReference;
+  /**
+   * Domain of the entity operating on the brand's behalf (e.g., 'pinnacle-media.com'). When the brand operates directly, this is the brand's domain. Verified against the brand's authorized_operators in brand.json. Required for **provisioning mode**; MUST be absent in settings-update mode.
+   * @pattern ^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$
+   */
+  operator: string;
+  billing: BillingParty;
+  billing_entity?: BusinessEntity;
+  payment_terms?: PaymentTerms;
+  /**
+   * When true, provision this as a sandbox account with no real platform calls or billing. Only applicable to implicit accounts (require_operator_auth: false) in provisioning mode. For explicit accounts, sandbox accounts are pre-existing test accounts discovered via list_accounts.
+   */
+  sandbox?: boolean;
+  preferred_reporting_protocol?: CloudStorageProtocol;
+  /**
+   * Account-level webhook subscriptions for notifications whose lifecycle outlives any single media buy (`creative.status_changed`, `creative.purged`, wholesale feed change payloads, future account-scoped events). Declarative replace semantics: the buyer sends the full desired array; the seller diffs against persisted state. Omit this field to leave existing subscribers unchanged; send `[]` to remove all subscribers. Permitted in both provisioning and settings-update modes. Each entry registers a URL, the event types the subscriber wants, and optional legacy auth — see [`notification-config.json`](/schemas/core/notification-config.json). The seller MUST echo applied state on the response and on `list_accounts` reads, with `authentication.credentials` omitted (write-only). Sellers MUST reject entries whose `event_types` include any type whose contract anchors at a media buy or below (today: `scheduled`, `final`, `delayed`, `adjusted`, `impairment`) as per-account validation failures with `INVALID_REQUEST` or `VALIDATION_ERROR` and `error.field` pointing at the invalid `event_types` entry — those events belong on a media buy's `push_notification_config`. Wholesale feed webhook registrations carry the actual change payload in `/schemas/core/wholesale-feed-webhook.json`; receivers use `get_products` / `get_signals` with `if_wholesale_feed_version` to repair or reconcile. This is distinct from sync_catalogs, which manages buyer-provided campaign input feeds on a seller account.
+   *
+   * **Cap rationale:** `maxItems: 16` is a practical fan-out cap (governance + buyer ingestion + audit bus + dx team + a few partner hooks). The cap exists to prevent unbounded subscriber arrays in storage and to bound the seller's per-event fan-out work. Sellers that hit the cap with legitimate subscribers should surface this on the protocol roadmap rather than work around it.
+   */
+  notification_configs?: NotificationConfig[];
 }
 /**
  * Settings-update entry — `account` (AccountRef) is required, provisioning trio fields are forbidden.
  */
 export interface SettingsUpdateMode {
-  [k: string]: unknown | undefined;
+  account: AccountReference;
+  billing_entity?: BusinessEntity;
+  payment_terms?: PaymentTerms;
+  /**
+   * When true, provision this as a sandbox account with no real platform calls or billing. Only applicable to implicit accounts (require_operator_auth: false) in provisioning mode. For explicit accounts, sandbox accounts are pre-existing test accounts discovered via list_accounts.
+   */
+  sandbox?: boolean;
+  preferred_reporting_protocol?: CloudStorageProtocol;
+  /**
+   * Account-level webhook subscriptions for notifications whose lifecycle outlives any single media buy (`creative.status_changed`, `creative.purged`, wholesale feed change payloads, future account-scoped events). Declarative replace semantics: the buyer sends the full desired array; the seller diffs against persisted state. Omit this field to leave existing subscribers unchanged; send `[]` to remove all subscribers. Permitted in both provisioning and settings-update modes. Each entry registers a URL, the event types the subscriber wants, and optional legacy auth — see [`notification-config.json`](/schemas/core/notification-config.json). The seller MUST echo applied state on the response and on `list_accounts` reads, with `authentication.credentials` omitted (write-only). Sellers MUST reject entries whose `event_types` include any type whose contract anchors at a media buy or below (today: `scheduled`, `final`, `delayed`, `adjusted`, `impairment`) as per-account validation failures with `INVALID_REQUEST` or `VALIDATION_ERROR` and `error.field` pointing at the invalid `event_types` entry — those events belong on a media buy's `push_notification_config`. Wholesale feed webhook registrations carry the actual change payload in `/schemas/core/wholesale-feed-webhook.json`; receivers use `get_products` / `get_signals` with `if_wholesale_feed_version` to repair or reconcile. This is distinct from sync_catalogs, which manages buyer-provided campaign input feeds on a seller account.
+   *
+   * **Cap rationale:** `maxItems: 16` is a practical fan-out cap (governance + buyer ingestion + audit bus + dx team + a few partner hooks). The cap exists to prevent unbounded subscriber arrays in storage and to bound the seller's per-event fan-out work. Sellers that hit the cap with legitimate subscribers should surface this on the protocol roadmap rather than work around it.
+   */
+  notification_configs?: NotificationConfig[];
 }
 
 // sync_accounts response


### PR DESCRIPTION
## Summary

- `tightenMutualExclusionOneOf` in `scripts/generate-types.ts` now recognizes the `allOf:[{not:{required:[X]}}, ...]` idiom that 3.1.0-beta.3 uses for "none of these fields may be present" mutual-exclusion branches — previously it only handled the simpler `not:{required:[X]}` form and bailed on `allOf`, letting jsts emit the branch as `{ [k: string]: unknown }`.
- Most visible payoff: `SyncAccountsRequest.accounts[].ProvisioningMode` and `SettingsUpdateMode` now surface their actual fields including `notification_configs[]` (the 3.1 account-scoped webhook subscription field). Buyers writing typed sync-accounts payloads get autocomplete and type-checking on it instead of the opaque-record passthrough.
- Also surfaces named interfaces (`V1CreativeNamedFormatReference`, `V2CreativeCanonicalFormatKind`, `V1ManifestNamedFormatReference`, `V2ManifestCanonicalFormatKind`) for the same idiom inside `CreativeAsset` and `CreativeManifest`.
- Wire semantics unchanged — Ajv enforces the unstripped schema at runtime; this is a TS-emission widening only.

## Why the two forms aren't interchangeable upstream

`not: { required: [X, Y, Z] }` matches only when ALL three fields are present (forbids only the conjunction). The `allOf:[{not:{required:[X]}}, ...]` form forbids each field independently (none present). The authorial intent for `SettingsUpdateMode` is the latter, so the spec uses the allOf idiom and the codegen now has to handle it.

## Test plan

- [x] `npm run generate-types` regenerates the three affected `*.generated.ts` files
- [x] `npm run ci:codegen-strict` (check-no-loose-oneof) — clean
- [x] `npx tsc --noEmit` — clean
- [x] prepublishOnly test suite (adcp-client + validation + zod-schemas, 77 tests) — pass
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)