### PR TITLE
fix(test): update context-extractor fixtures to 3.1.0-beta.3 field names

### DIFF
--- a/.changeset/context-extractors-verdict-outcome-state-fixtures.md
+++ b/.changeset/context-extractors-verdict-outcome-state-fixtures.md
@@ -1,0 +1,16 @@
+---
+---
+
+fix(test): update context-extractor fixtures to use 3.1.0-beta.3 field names (`verdict`, `outcome_state`)
+
+`src/lib/testing/storyboard/context.ts` reads `d.verdict` for `check_governance` and `d.outcome_state` for `report_plan_outcome` — the post-3.1.0-beta.3 wire field names. The test fixtures in `test/lib/context-extractors.test.js` still sent `status:` (the pre-3.1 names), so the extractors saw nothing and returned `{}`, failing every assertion.
+
+3 fixtures updated:
+
+- `check_governance` — `status: 'approved'` → `verdict: 'approved'`
+- `check_governance` — `status: 'denied'` → `verdict: 'denied'`
+- `report_plan_outcome` — `status: 'completed'` → `outcome_state: 'completed'`
+
+Plus 2 test-description renames (`...and status` → `...and verdict`; `when status is missing` → `when outcome_state is missing`).
+
+No runtime/API impact — pure test-fixture catch-up to 3.1.0-beta.3. Empty changeset satisfies the gate. Part of issue #1943's 3.1.0-beta.3 unit-test sweep.

--- a/test/lib/context-extractors.test.js
+++ b/test/lib/context-extractors.test.js
@@ -91,9 +91,9 @@ describe('context extractors', () => {
   });
 
   describe('check_governance', () => {
-    it('extracts governance_context, check_id, plan_id, and status', () => {
+    it('extracts governance_context, check_id, plan_id, and verdict', () => {
       const data = {
-        status: 'approved',
+        verdict: 'approved',
         check_id: 'chk_123',
         plan_id: 'plan_1',
         governance_context: 'opaque-ctx-abc123',
@@ -108,7 +108,7 @@ describe('context extractors', () => {
     });
 
     it('extracts only present fields', () => {
-      const data = { status: 'denied' };
+      const data = { verdict: 'denied' };
       const result = extractContext('check_governance', data);
       assert.deepStrictEqual(result, { governance_status: 'denied' });
     });
@@ -154,13 +154,13 @@ describe('context extractors', () => {
   });
 
   describe('report_plan_outcome', () => {
-    it('extracts outcome_id and outcome_status', () => {
-      const data = { status: 'completed', outcome_id: 'out_456' };
+    it('extracts outcome_id and outcome_state', () => {
+      const data = { outcome_state: 'completed', outcome_id: 'out_456' };
       const result = extractContext('report_plan_outcome', data);
       assert.deepStrictEqual(result, { outcome_id: 'out_456', outcome_status: 'completed' });
     });
 
-    it('returns empty object when status is missing', () => {
+    it('returns empty object when outcome_state is missing', () => {
       assert.deepStrictEqual(extractContext('report_plan_outcome', {}), {});
     });
   });


### PR DESCRIPTION
## Summary

`src/lib/testing/storyboard/context.ts` reads `d.verdict` for `check_governance` and `d.outcome_state` for `report_plan_outcome` — the post-3.1.0-beta.3 wire field names. The test fixtures in `test/lib/context-extractors.test.js` still sent `status:` (the pre-3.1 names), so the extractors saw nothing and returned `{}`, failing every assertion.

3 fixtures updated:
- `check_governance` — `status: 'approved'` → `verdict: 'approved'`
- `check_governance` — `status: 'denied'` → `verdict: 'denied'`
- `report_plan_outcome` — `status: 'completed'` → `outcome_state: 'completed'`

Plus 2 test-description renames to match.

No runtime/API impact — pure test-fixture catch-up to 3.1.0-beta.3. Empty changeset satisfies the gate.

Part of issue #1943's 3.1.0-beta.3 unit-test sweep.

## Test plan

- [x] 20/20 tests pass locally on the updated fixtures
- [x] `npm run typecheck` clean
- [x] `npm run format:check` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)