### PR TITLE
fix(test): update governance fixtures for 3.1.0-beta.3 verdict rename

### DIFF
--- a/.changeset/governance-fixtures-verdict-rename.md
+++ b/.changeset/governance-fixtures-verdict-rename.md
@@ -1,0 +1,14 @@
+---
+---
+
+fix(test): update governance test fixtures to 3.1.0-beta.3 `verdict` rename
+
+`parseCheckResponse` and `GovernanceAgentStub` emit `verdict:` for the governance decision (3.1.0-beta.3 envelope/decision split — envelope `status` is now task-state {completed,failed,...}; decision verdict is the operational answer {approved,denied,conditions}). The test fixtures still asserted `status: 'approved'`-shaped output, so every parse/round-trip test failed.
+
+**`test/lib/governance.test.js`** — 5 input-fixture renames in `parseCheckResponse` tests (`status:` → `verdict:`), plus 1 `GovernanceAdapter.checkCommitted` assertion update: now expects both `status: 'failed'` (envelope: not-configured = task failure) AND `verdict: 'denied'` (decision: denied). Added an inline comment explaining the split.
+
+**`test/lib/governance-stub.test.js`** — 3 output-assertion renames (`parsed.status` → `parsed.verdict`) on the MCP/HTTPS stub round-trip checks.
+
+No runtime/API impact — pure test-fixture catch-up. 52/52 across both files pass locally after the change. Empty changeset satisfies the gate.
+
+Part of issue #1943's 3.1.0-beta.3 unit-test sweep (cluster 2, governance).

--- a/test/lib/governance-stub.test.js
+++ b/test/lib/governance-stub.test.js
@@ -43,7 +43,7 @@ describe('GovernanceAgentStub', () => {
 
     assert.ok(result, 'should get a response');
     const parsed = JSON.parse(result.content[0].text);
-    assert.equal(parsed.status, 'approved');
+    assert.equal(parsed.verdict, 'approved');
     assert.equal(parsed.plan_id, 'plan-test-1');
   });
 
@@ -89,7 +89,7 @@ describe('GovernanceAgentStub', () => {
       media_buy_id: 'mb_123',
     });
     const secondParsed = JSON.parse(secondResult.content[0].text);
-    assert.equal(secondParsed.status, 'approved');
+    assert.equal(secondParsed.verdict, 'approved');
 
     // Verify the stub recorded the governance_context
     assert.ok(stub.hasGovernanceContext(gc), 'stub should have recorded the governance_context');
@@ -206,7 +206,7 @@ describe('GovernanceAgentStub HTTPS', () => {
     });
 
     const parsed = JSON.parse(result.content[0].text);
-    assert.equal(parsed.status, 'approved');
+    assert.equal(parsed.verdict, 'approved');
     assert.ok(parsed.governance_context);
   });
 });

--- a/test/lib/governance.test.js
+++ b/test/lib/governance.test.js
@@ -72,7 +72,7 @@ describe('parseCheckResponse', () => {
   it('parses an approved response', () => {
     const response = {
       check_id: 'chk-1',
-      status: 'approved',
+      verdict: 'approved',
       explanation: 'All checks passed',
       expires_at: '2026-04-01T00:00:00Z',
     };
@@ -87,7 +87,7 @@ describe('parseCheckResponse', () => {
   it('parses findings with snake_case to camelCase conversion', () => {
     const response = {
       check_id: 'chk-2',
-      status: 'denied',
+      verdict: 'denied',
       explanation: 'Budget exceeded',
       findings: [
         {
@@ -115,7 +115,7 @@ describe('parseCheckResponse', () => {
   it('parses conditions with required_value', () => {
     const response = {
       check_id: 'chk-3',
-      status: 'conditions',
+      verdict: 'conditions',
       explanation: 'Budget adjustment required',
       conditions: [{ field: 'budget.total', required_value: 6000, reason: 'Per-seller max exceeded' }],
     };
@@ -130,7 +130,7 @@ describe('parseCheckResponse', () => {
   it('handles missing optional fields', () => {
     const response = {
       check_id: 'chk-6',
-      status: 'approved',
+      verdict: 'approved',
       explanation: 'OK',
     };
 
@@ -144,7 +144,7 @@ describe('parseCheckResponse', () => {
   it('captures governance_context from response', () => {
     const response = {
       check_id: 'chk-7',
-      status: 'approved',
+      verdict: 'approved',
       explanation: 'OK',
       governance_context: 'opaque-gc-token-abc123',
     };
@@ -337,7 +337,12 @@ describe('GovernanceAdapter', () => {
       governanceContext: 'gc-token-123',
       plannedDelivery: { impressions: 1000, budget: 500 },
     });
-    assert.equal(result.status, 'denied');
+    // 3.1.0-beta.3 splits envelope `status` (task state: failed) from
+    // governance `verdict` (decision: denied). When governance isn't
+    // configured, the adapter synthesizes a task-state failure carrying a
+    // denial verdict.
+    assert.equal(result.status, 'failed');
+    assert.equal(result.verdict, 'denied');
     assert.equal(result.binding, 'committed');
     assert.match(result.explanation, /not configured/i);
     assert.equal(result.error_code, 'governance_not_supported');


### PR DESCRIPTION
## Summary

\`parseCheckResponse\` and \`GovernanceAgentStub\` emit \`verdict:\` for the governance decision per AdCP 3.1.0-beta.3's envelope/decision split:
- envelope \`status\` carries task state (\`completed\` / \`failed\`)
- decision \`verdict\` carries the operational answer (\`approved\` / \`denied\` / \`conditions\`)

Test fixtures still used pre-3.1 \`status:\` for both axes, so every parse/round-trip test failed.

## Changes

**\`test/lib/governance.test.js\`**:
- 5 \`parseCheckResponse\` input-fixture renames (\`status:\` → \`verdict:\`)
- 1 \`GovernanceAdapter.checkCommitted\` assertion update: now expects both envelope \`status: 'failed'\` (no-governance-configured task failure) AND decision \`verdict: 'denied'\` (the operational answer). Inline comment explains the split.

**\`test/lib/governance-stub.test.js\`**:
- 3 output-assertion renames on MCP/HTTPS stub round-trip checks (\`parsed.status\` → \`parsed.verdict\`)

No runtime/API impact — pure test-fixture catch-up.

## Test plan

- [x] 52/52 across both files pass locally
- [x] \`npm run typecheck\` clean
- [x] \`npm run format:check\` clean
- [ ] CI green

Part of issue #1943 cluster 2 (context-extractors + governance, 4 files). Sibling PR: #1946 (context-extractors fixtures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)