### PR TITLE
fix(test): add envelope status to test-agents/*.ts (3.1.0-beta.3 sweep)

### DIFF
--- a/.changeset/test-agents-envelope-status.md
+++ b/.changeset/test-agents-envelope-status.md
@@ -1,0 +1,15 @@
+---
+---
+
+fix(test): add envelope status to `test-agents/*.ts` (3.1.0-beta.3 sweep)
+
+Same envelope-status sweep we applied to `examples/*.ts` (commit e03dda0b5) and `skills/**/SKILL.md` code samples (commit e482638d4) — `test-agents/*.ts` lagged. With AdCP 3.1.0-beta.2 making envelope `status` required, the test-agents typecheck step in CI's `Run unit tests` job started failing with 9 TS2322/TS2741 errors, masking the actual unit-test results.
+
+**Changes**:
+
+- `seller-agent-signed-mcp.ts` — `getProducts` gains `status: 'completed'`
+- `seller-agent.ts` — `syncAccounts`, `getProducts`, `getMediaBuys`, `listCreativeFormats`, `getMediaBuyDelivery` each gain `status: 'completed'` on their response objects (5 sites)
+- `seller-agent.ts` — `syncAccounts` adds a narrow cast for `acct.brand` / `acct.operator` since `ProvisioningMode` / `SettingsUpdateMode` are typed as passthrough `Record<string, unknown>` on main (until #1941 lands the typed-fields fix at the next codegen)
+- `signals-agent.ts` — `type Signal = GetSignalsResponse['signals'][number]` becomes `NonNullable<GetSignalsResponse['signals']>[number]` (the field is now optional); `getSignals` gains envelope `status: 'completed'`
+
+No runtime/API impact. Pure test-agent catch-up. `npx tsc --noEmit` clean against `test-agents/tsconfig.json`. Part of issue #1943's 3.1.0-beta.3 unit-test sweep — clears the early-bail in the `Run unit tests` step so subsequent test failures can be observed and triaged.

--- a/test-agents/seller-agent-signed-mcp.ts
+++ b/test-agents/seller-agent-signed-mcp.ts
@@ -121,7 +121,7 @@ function createAgent({ taskStore }: ServeContext) {
       return result.items[0] ?? null;
     },
     mediaBuy: {
-      getProducts: async () => ({ products: [], context: {} }),
+      getProducts: async () => ({ status: 'completed' as const, products: [], context: {} }),
       createMediaBuy: async params => ({
         media_buy_id: `mb-${Date.now()}`,
         status: 'active' as const,

--- a/test-agents/seller-agent.ts
+++ b/test-agents/seller-agent.ts
@@ -96,7 +96,8 @@ function createAgent({ taskStore }: ServeContext) {
     accounts: {
       syncAccounts: async (params, ctx) => {
         const results = [];
-        for (const acct of params.accounts) {
+        for (const acctRaw of params.accounts) {
+          const acct = acctRaw as { brand: { domain: string }; operator: string };
           const accountId = `acct_${acct.brand.domain}_${acct.operator}`;
           const existing = await ctx.store.get('accounts', accountId);
           await ctx.store.put('accounts', accountId, {
@@ -113,7 +114,7 @@ function createAgent({ taskStore }: ServeContext) {
             status: 'active' as const,
           });
         }
-        return { accounts: results, context: params.context ?? undefined };
+        return { status: 'completed' as const, accounts: results, context: params.context ?? undefined };
       },
 
       syncGovernance: async (params, ctx) => {
@@ -131,7 +132,12 @@ function createAgent({ taskStore }: ServeContext) {
 
     mediaBuy: {
       getProducts: async (params, ctx) => {
-        return { products: PRODUCTS, sandbox: true, context: params.context ?? undefined };
+        return {
+          status: 'completed' as const,
+          products: PRODUCTS,
+          sandbox: true,
+          context: params.context ?? undefined,
+        };
       },
 
       createMediaBuy: async (params, ctx) => {
@@ -204,6 +210,7 @@ function createAgent({ taskStore }: ServeContext) {
           buys = result.items;
         }
         return {
+          status: 'completed' as const,
           media_buys: buys.map(b => ({
             media_buy_id: b.media_buy_id as string,
             status: b.status as any,
@@ -215,7 +222,7 @@ function createAgent({ taskStore }: ServeContext) {
       },
 
       listCreativeFormats: async (params, ctx) => {
-        return { formats: FORMATS, context: params.context ?? undefined };
+        return { status: 'completed' as const, formats: FORMATS, context: params.context ?? undefined };
       },
 
       syncCreatives: async (params, ctx) => {
@@ -239,6 +246,7 @@ function createAgent({ taskStore }: ServeContext) {
         const now = new Date();
         const yesterday = new Date(now.getTime() - 86400000);
         return {
+          status: 'completed' as const,
           reporting_period: { start: yesterday.toISOString(), end: now.toISOString() },
           media_buy_deliveries: ids.map(id => ({
             media_buy_id: id,

--- a/test-agents/signals-agent.ts
+++ b/test-agents/signals-agent.ts
@@ -6,7 +6,7 @@
 import { createAdcpServer, serve, adcpError } from '@adcp/sdk/server/legacy/v5';
 import type { GetSignalsResponse } from '@adcp/sdk';
 
-type Signal = GetSignalsResponse['signals'][number];
+type Signal = NonNullable<GetSignalsResponse['signals']>[number];
 
 const SIGNALS: Signal[] = [
   {
@@ -96,7 +96,7 @@ serve(() =>
           results = results.slice(0, params.max_results);
         }
 
-        return { signals: results, sandbox: true };
+        return { status: 'completed' as const, signals: results, sandbox: true };
       },
 
       activateSignal: async (params, ctx) => {


### PR DESCRIPTION
## Summary

Same envelope-status sweep we applied to \`examples/*.ts\` (commit e03dda0b5) and \`skills/**/SKILL.md\` code samples (commit e482638d4) — \`test-agents/*.ts\` lagged. AdCP 3.1.0-beta.2 made envelope \`status\` required; the test-agent typecheck step in CI's \`Run unit tests\` job has been failing with 9 TS2322/TS2741 errors before the actual unit tests run.

This unblocks CI from a tsc-level early-bail so subsequent test failures can be observed and triaged — directly relevant to working through #1943's remaining clusters.

## Changes

- \`seller-agent-signed-mcp.ts\` — \`getProducts\` gains envelope \`status: 'completed'\`
- \`seller-agent.ts\` — \`syncAccounts\`, \`getProducts\`, \`getMediaBuys\`, \`listCreativeFormats\`, \`getMediaBuyDelivery\` each gain envelope \`status: 'completed'\` (5 sites). Plus a narrow cast on \`acct.brand\` / \`acct.operator\` inside \`syncAccounts\` — \`ProvisioningMode\` / \`SettingsUpdateMode\` are typed as passthrough \`Record<string, unknown>\` on main; the typed-fields fix landed in #1941 but won't reach this code path until the next codegen.
- \`signals-agent.ts\` — \`type Signal = GetSignalsResponse['signals'][number]\` wrapped as \`NonNullable<...>['signals']\` (the field is now optional). \`getSignals\` gains envelope \`status: 'completed'\`.

## Test plan

- [x] \`npx tsc --noEmit\` clean inside \`test-agents/\`
- [x] \`npm run format:check\` clean
- [ ] CI green (will likely still red on remaining backlog from #1943)

Part of issue #1943's 3.1.0-beta.3 unit-test sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)