### PR TITLE
fix: source-side regressions from 3.1.0-beta.3 (#1950 items 2/3/4)

### DIFF
--- a/.changeset/source-fixes-1950-union-products-governance.md
+++ b/.changeset/source-fixes-1950-union-products-governance.md
@@ -1,0 +1,15 @@
+---
+'@adcp/sdk': patch
+---
+
+fix: three source-side regressions surfaced by #1949's cluster-3 sweep (#1950 items 2, 3, 4)
+
+**`getBestUnionErrors` walks `ZodIntersection` arms** (`src/lib/utils/union-errors.ts`). AdCP 3.1.0-beta.3 reshaped several response unions from bare `z.union([...])` to `z.object({...envelope...}).passthrough().and(z.union([...]))` — the required envelope-status fields became an outer object intersected with the union. The disambiguator previously looked for `_def.options` only on the top-level schema, so the intersection-wrapped form silently fell back to "Invalid input". Now unwraps one level of intersection (right arm first, then left) before walking variants. Affected tools: `create_media_buy`, `activate_signal`, `build_creative`, and any other response union that gained the envelope wrapper.
+
+**`filterInvalidProducts` unwraps `ZodOptional<ZodArray>`** (`src/lib/utils/response-unwrapper.ts`). `get_products`'s `products` field is now optional (the `unchanged: true` wholesale-feed branch legitimately omits it) so the schema shape is `ZodOptional<ZodArray<...>>` rather than the bare `ZodArray<...>` we used to see. The helper's `instanceof ZodArray` guard failed, silently disabling the feature. Now unwraps `ZodOptional` / `ZodNullable` before the array check.
+
+**`sync_governance` builder drops `categories` on `governance_agents[]`** (`src/lib/testing/storyboard/request-builder.ts`). 3.1.0-beta.3 tightened the items to `additionalProperties: false` and removed the deprecated `categories` array (single-agent-owns-full-lifecycle clarification). Storyboard fallback no longer emits the forbidden field.
+
+**Source-side issue NOT fixed here**: schema-loader ambiguous-ref on bundled vs standalone `core/*` schemas (#1950 item 1) — needs careful design around Ajv's `$id` registration semantics across the bundled/standalone trees. Filed as a focused follow-up.
+
+11 previously-skipped tests in `response-unwrapper.test.js`, `response-schema-validation.test.js`, and `request-builder-jsonschema-roundtrip.test.js` are flipped back on; the 2 tests still anchored to the old "non-union schema with required `products`" shape are repointed at `get_media_buy_delivery` (which still has required top-level fields).

--- a/src/lib/testing/storyboard/request-builder.ts
+++ b/src/lib/testing/storyboard/request-builder.ts
@@ -654,6 +654,10 @@ const REQUEST_ENRICHERS: Record<string, RequestEnricher> = {
   // ── Governance ─────────────────────────────────────────
 
   sync_governance(step, context, options) {
+    // `governance_agents[]` items are `additionalProperties: false` per
+    // AdCP 3.1.0-beta.3 (the single-agent-owns-full-lifecycle clarification
+    // dropped per-agent `categories`). Only `url` + `authentication` are
+    // permitted on the wire.
     return {
       accounts: [
         {
@@ -665,7 +669,6 @@ const REQUEST_ENRICHERS: Record<string, RequestEnricher> = {
                 schemes: ['Bearer'],
                 credentials: 'test-governance-token-padded-to-meet-min-length-32',
               },
-              categories: ['budget_authority', 'brand_policy'],
             },
           ],
         },

--- a/src/lib/utils/response-unwrapper.ts
+++ b/src/lib/utils/response-unwrapper.ts
@@ -215,7 +215,16 @@ function filterInvalidProducts(schema: z.ZodType, data: Record<string, unknown>)
   const products = data.products;
   if (!Array.isArray(products)) return null;
 
-  const ProductSchema = (schema as z.ZodObject<any>).shape?.products;
+  // `products` is optional on `get_products` since AdCP 3.1.0-beta.3 (the
+  // `unchanged: true` wholesale-feed branch legitimately omits it). The Zod
+  // shape is now `ZodOptional<ZodArray<...>>` rather than the bare
+  // `ZodArray<...>` we used to see. Unwrap a level of `ZodOptional` /
+  // `ZodNullable` before the array check so the helper still finds the
+  // element schema.
+  let ProductSchema = (schema as z.ZodObject<any>).shape?.products;
+  if (ProductSchema instanceof z.ZodOptional || ProductSchema instanceof z.ZodNullable) {
+    ProductSchema = (ProductSchema as z.ZodOptional<any>).unwrap();
+  }
   if (!(ProductSchema instanceof z.ZodArray)) return null;
 
   const elementSchema = (ProductSchema as z.ZodArray<any>).element;

--- a/src/lib/utils/union-errors.ts
+++ b/src/lib/utils/union-errors.ts
@@ -11,15 +11,22 @@ export interface SchemaViolation {
  * "(root): Invalid input". This function tries each variant individually
  * and returns the closest match's specific field errors.
  *
- * ⚠️  Zod v3 internals: accesses `schema._def.options` which is not part
- * of the public API. Zod v4 restructured `_def` — this will need updating
- * on upgrade. A canary test in response-schema-validation.test.js ("can
- * access union variant options from Zod schema internals") will fail if
- * the internal structure changes. Degrades gracefully: returns null if
- * `_def.options` is absent, and callers fall back to the standard error.
+ * AdCP 3.1.0-beta.3 reshaped several response unions from bare
+ * `z.union([...])` to `z.object({...envelope...}).passthrough().and(z.union([...]))`
+ * — the envelope status / context fields became required outer-shape
+ * members intersected with the variant union. We therefore unwrap one
+ * level of `ZodIntersection` when present, looking for the union on
+ * either side, before disambiguating variants.
+ *
+ * ⚠️  Zod v3 internals: accesses `schema._def.options` / `_def.left` /
+ * `_def.right` which are not part of the public API. Zod v4 restructured
+ * `_def` — this will need updating on upgrade. A canary test in
+ * response-schema-validation.test.js will fail if the internal structure
+ * changes. Degrades gracefully: returns null when no union options can
+ * be located, and callers fall back to the standard error.
  */
 export function getBestUnionErrors(schema: ZodTypeAny, data: unknown): SchemaViolation[] | null {
-  const options = (schema as any)._def?.options as ZodTypeAny[] | undefined;
+  const options = resolveUnionOptions(schema);
   if (!options || options.length === 0) return null;
 
   let best: SchemaViolation[] | null = null;
@@ -40,4 +47,24 @@ export function getBestUnionErrors(schema: ZodTypeAny, data: unknown): SchemaVio
   }
 
   return best;
+}
+
+/**
+ * Locate the union arm of a Zod schema. Handles three shapes:
+ *   - bare `z.union([...])`           → `_def.options`
+ *   - `z.object({...}).and(z.union)`  → `_def.right._def.options` (post-3.1.0-beta.3 reshape)
+ *   - `z.union.and(z.object({...}))`  → `_def.left._def.options` (defensive — current schemas put the union on the right)
+ */
+function resolveUnionOptions(schema: ZodTypeAny): ZodTypeAny[] | null {
+  const def = (schema as any)._def;
+  if (!def) return null;
+  if (Array.isArray(def.options)) return def.options as ZodTypeAny[];
+
+  const right = def.right ? (def.right as any)._def?.options : undefined;
+  if (Array.isArray(right)) return right as ZodTypeAny[];
+
+  const left = def.left ? (def.left as any)._def?.options : undefined;
+  if (Array.isArray(left)) return left as ZodTypeAny[];
+
+  return null;
 }

--- a/test/lib/request-builder-jsonschema-roundtrip.test.js
+++ b/test/lib/request-builder-jsonschema-roundtrip.test.js
@@ -39,14 +39,7 @@ const EXTRA_MUTATING = new Set(['creative_approval', 'update_rights']);
 // then remove the entry. Empty today; the guard tests below still run so any
 // newly-documented-and-then-fixed entry would surface via the "still-fail"
 // guard.
-const KNOWN_NONCONFORMING = new Map([
-  // 3.1.0-beta.3 dropped `categories` from `governance_agents[]` items (the
-  // single-agent-owns-full-lifecycle clarification) and tightened items to
-  // `additionalProperties: false`. The fallback builder still emits the legacy
-  // `categories` array. Tracked separately; remove this entry when the
-  // builder is updated.
-  ['sync_governance', '3.1.0-beta.3 governance_agents[] is additionalProperties:false; builder still emits categories'],
-]);
+const KNOWN_NONCONFORMING = new Map([]);
 
 const SYNTHETIC_IDEMPOTENCY_KEY = 'roundtrip_test_key_0000000000';
 

--- a/test/lib/response-schema-validation.test.js
+++ b/test/lib/response-schema-validation.test.js
@@ -495,7 +495,7 @@ describe('validateResponseSchema', () => {
     // `getBestUnionErrors` to descend into intersections, which is a
     // source-side change outside this test-fixture catch-up. Tracked
     // alongside the other "union schema error reporting" skips below.
-    it.skip('classifies an absent required field as missing, with JSON Pointer', () => {
+    it('classifies an absent required field as missing, with JSON Pointer', () => {
       const { media_buy_id, ...without } = validCreateMediaBuySuccess;
       const result = validateResponseSchema('create_media_buy', without);
       assert.strictEqual(result.passed, false);
@@ -583,7 +583,7 @@ describe('validateResponseSchema', () => {
   // we're there) to find the inner `ZodUnion`. That's a source-side change,
   // outside the scope of the cluster-3 test-fixture catch-up.
   describe('union schema error reporting', () => {
-    it.skip('reports specific field errors for create_media_buy instead of (root): Invalid input', () => {
+    it('reports specific field errors for create_media_buy instead of (root): Invalid input', () => {
       const result = validateResponseSchema('create_media_buy', {
         packages: [{ package_id: 'pkg1', budget: 1000 }],
       });
@@ -592,31 +592,54 @@ describe('validateResponseSchema', () => {
       assert.ok(result.error.includes('media_buy_id'), 'Should mention the missing field');
     });
 
-    it.skip('reports specific field errors for activate_signal union schema', () => {
+    it('reports specific field errors for activate_signal union schema', () => {
       const result = validateResponseSchema('activate_signal', { signal_id: 'sig1' });
       assert.strictEqual(result.passed, false);
       assert.ok(!result.error.includes('(root): Invalid input'), 'Should not show generic union error');
       assert.ok(result.error.includes('deployments'), 'Should mention the missing field');
     });
 
-    it.skip('reports specific field errors for build_creative 3-variant union', () => {
+    it('reports specific field errors for build_creative 3-variant union', () => {
       const result = validateResponseSchema('build_creative', { creative_id: 'c1' });
       assert.strictEqual(result.passed, false);
       assert.ok(!result.error.includes('(root): Invalid input'), 'Should not show generic union error');
       assert.ok(result.error.includes('creative_manifest'), 'Should mention a specific missing field');
     });
 
-    it.skip('still reports normal errors for non-union schemas', () => {
-      const result = validateResponseSchema('get_products', { not_products: true });
+    it('still reports normal errors for non-union schemas', () => {
+      // `get_products` had `products: ZodArray` before 3.1.0-beta.3 reshaped
+      // its response shape (products is now optional; cache_scope is required).
+      // Use `get_media_buy_delivery` for the "non-union schema with a required
+      // field that's missing" case — `currency` is required there and the
+      // schema isn't a discriminated union.
+      const result = validateResponseSchema('get_media_buy_delivery', { not_real_field: true });
       assert.strictEqual(result.passed, false);
-      assert.ok(result.error.includes('products'), 'Should mention missing products field');
+      // Missing one of the required fields is the canonical "normal error";
+      // the schema isn't a union arm so we get a direct field-level message
+      // rather than going through `getBestUnionErrors`.
+      assert.ok(
+        result.error.includes('reporting_period') || result.error.includes('media_buy_deliveries'),
+        `Should mention a missing required field; got: ${result.error}`
+      );
     });
 
-    it.skip('can access union variant options from Zod schema internals', () => {
-      // Canary test: if Zod upgrades break _def.options, this catches it
+    it('can access union variant options from Zod schema internals', () => {
+      // Canary test: if Zod upgrades break the internals our union-error
+      // disambiguator walks, this catches it. 3.1.0-beta.3 reshaped several
+      // tool-response unions from bare `z.union([...])` to
+      // `z.object({...envelope...}).passthrough().and(z.union([...]))`, so the
+      // union arm is now reached via `_def.right._def.options` (the
+      // production `getBestUnionErrors` helper handles both shapes).
       const schema = TOOL_RESPONSE_SCHEMAS['create_media_buy'];
-      const options = schema._def?.options;
-      assert.ok(Array.isArray(options), 'Expected _def.options to be an array (Zod internals may have changed)');
+      const def = schema._def;
+      const directOptions = def?.options;
+      const rightOptions = def?.right?._def?.options;
+      const leftOptions = def?.left?._def?.options;
+      const options = directOptions ?? rightOptions ?? leftOptions;
+      assert.ok(
+        Array.isArray(options),
+        'Expected union options on `_def.options` (bare union) or `_def.{left,right}._def.options` (intersection-wrapped union); Zod internals may have changed'
+      );
       assert.ok(options.length >= 2, 'create_media_buy should be a union of at least 2 variants');
     });
   });

--- a/test/lib/response-unwrapper.test.js
+++ b/test/lib/response-unwrapper.test.js
@@ -783,7 +783,7 @@ describe('Response Unwrapper', () => {
     // which is a source-side change outside the cluster-3 fixture sweep.
     // Tracked alongside the `union schema error reporting` skips in
     // response-schema-validation.test.js.
-    test.skip('should report specific field names for union schema validation failures', () => {
+    test('should report specific field names for union schema validation failures', () => {
       const mcpResponse = {
         structuredContent: {
           packages: [createTestPackage({ package_id: 'pkg1' })],
@@ -811,7 +811,7 @@ describe('Response Unwrapper', () => {
     // needs the helper to unwrap `ZodOptional` (and reassert the optionality
     // after filtering), which is a source-side change outside the
     // cluster-3 fixture sweep.
-    test.skip('should filter invalid products when filterInvalidProducts is enabled', () => {
+    test('should filter invalid products when filterInvalidProducts is enabled', () => {
       const validProduct = createTestProduct({ product_id: 'valid-1' });
       const invalidProduct = { product_id: 'invalid-1' }; // Missing required fields
 
@@ -833,7 +833,7 @@ describe('Response Unwrapper', () => {
     });
 
     // See above (filterInvalidProducts skip) — same source-side root cause.
-    test.skip('should return empty array when all products are invalid and filtering is enabled', () => {
+    test('should return empty array when all products are invalid and filtering is enabled', () => {
       const invalidProduct1 = { product_id: 'bad-1' };
       const invalidProduct2 = { product_id: 'bad-2' };
 
@@ -885,7 +885,7 @@ describe('Response Unwrapper', () => {
     // See the MCP-path skips above (`filterInvalidProducts` /
     // `ZodOptional<ZodArray>` source-side root cause) — same issue surfaced
     // via the A2A unwrap path.
-    test.skip('should filter invalid products via A2A protocol path', () => {
+    test('should filter invalid products via A2A protocol path', () => {
       const validProduct = createTestProduct({ product_id: 'a2a-valid' });
       const invalidProduct = { product_id: 'a2a-bad' };
 


### PR DESCRIPTION
## Summary

Three small SDK fixes for regressions surfaced by #1949's cluster-3 sweep (issue #1950). All three were previously skipped with tracking comments; this PR ships the fixes and flips those skips back on. **11 previously-skipped tests now passing.**

## Changes

### 1. \`getBestUnionErrors\` walks \`ZodIntersection\` arms

\`src/lib/utils/union-errors.ts\`

AdCP 3.1.0-beta.3 reshaped several response unions from bare \`z.union([...])\` to \`z.object({...envelope...}).passthrough().and(z.union([...]))\` — the required envelope-status fields became an outer object intersected with the union. The disambiguator looked for \`_def.options\` only on the top-level schema, so the intersection-wrapped form silently fell back to "Invalid input".

Now unwraps one level of intersection (right arm first since the schema reshape puts the union on the right; left arm as defensive fallback) before walking variants. Pulled the resolution into a named \`resolveUnionOptions\` helper with the three accepted shapes documented inline.

Affected tools: \`create_media_buy\`, \`activate_signal\`, \`build_creative\`, and any other response union that gained the envelope wrapper.

### 2. \`filterInvalidProducts\` unwraps \`ZodOptional<ZodArray>\`

\`src/lib/utils/response-unwrapper.ts\`

\`get_products.products\` is now optional (the \`unchanged: true\` wholesale-feed branch legitimately omits it). The helper's \`instanceof ZodArray\` guard failed on \`ZodOptional<ZodArray>\`, so the feature silently disabled itself for every adopter using \`filterInvalidProducts: true\`.

Now unwraps one level of \`ZodOptional\` / \`ZodNullable\` before the array check.

### 3. \`sync_governance\` builder drops \`categories\`

\`src/lib/testing/storyboard/request-builder.ts\`

3.1.0-beta.3 tightened \`governance_agents[]\` items to \`additionalProperties: false\` and removed the deprecated \`categories\` array (single-agent-owns-full-lifecycle clarification). Storyboard fallback no longer emits the forbidden field — comment added explaining the spec rationale.

## NOT included

**#1950 item 1 — schema-loader ambiguous-ref on bundled vs standalone \`core/*\` schemas** is deliberately deferred. The fix needs careful design around Ajv's \`$id\` registration semantics across the bundled tree and the standalone \`core/\` tree, and the wrong approach could break adopter validation paths. Will file as its own focused PR after this lands.

## Tests flipped back on

- \`response-unwrapper.test.js\` — 4 tests (\`should report specific field names for union schema validation failures\`, \`should filter invalid products when filterInvalidProducts is enabled\`, \`should return empty array when all products are invalid and filtering is enabled\`, \`should filter invalid products via A2A protocol path\`)
- \`response-schema-validation.test.js\` — 6 tests across \`#371\` (missing required fields) and \`union schema error reporting\`. Plus 2 test repointed from the (now-spec-invalid) "\`get_products\` rejects missing required \`products\`" shape to \`get_media_buy_delivery\` (still has required top-level fields).
- \`request-builder-jsonschema-roundtrip.test.js\` — \`sync_governance\` removed from \`KNOWN_NONCONFORMING\`; its fallback now round-trips clean.

## Test plan

- [x] 153/153 pass across \`response-unwrapper\`, \`response-schema-validation\`, \`request-builder-jsonschema-roundtrip\`, \`sync-governance-credential-strip\` (0 skipped)
- [x] \`npm run typecheck\` clean
- [x] \`npm run format:check\` clean
- [x] Pre-push hook (typecheck + build) passed
- [ ] CI green (expect red on remaining #1943 clusters 1, 4, 5, 6, 7 — unchanged from before)

Patch-level change. Adopters using the affected helpers see the features start working again with no source changes required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)