### PR TITLE
fix(validation): strip nested $id on bundled responses (#1950 item 1)

### DIFF
--- a/.changeset/schema-loader-strip-nested-ids.md
+++ b/.changeset/schema-loader-strip-nested-ids.md
@@ -1,0 +1,17 @@
+---
+'@adcp/sdk': patch
+---
+
+fix(validation): unblock 14 tool validators from Ajv ambiguous-ref on bundled responses (#1950 item 1)
+
+The production schema-loader compiles each tool's response/request schema lazily via Ajv. For tools whose responses live in the spec's `bundled/` subtree (those whose `$ref`s the spec publishes fully inlined), the bundled `.json` file embeds every referenced subschema with its **canonical `$id`** — e.g. `core/version-envelope.json` appears as a nested schema inside `bundled/signals/activate-signal-response.json`, with the same `$id` as the standalone `core/version-envelope.json`.
+
+Once `ensureCoreLoaded` has run (which happens whenever any non-bundled tool, like `acquire_rights` / `get_brand_identity` / property-list tasks, is compiled — they live in flat domain trees and need `core/*` pre-registered for `$ref` resolution), the standalone core schemas are in Ajv's registry. Subsequent compile of a bundled tool response then trips Ajv's `checkAmbiguousRef` on every nested `$id` that already exists standalone.
+
+Net effect: 14 tools (`activate_signal`, `build_creative`, `create_media_buy`, `get_adcp_capabilities`, `get_creative_delivery`, `get_media_buys`, `list_creative_formats`, `list_creatives`, `preview_creative`, `sync_audiences`, `sync_catalogs`, `sync_creatives`, `sync_event_sources`, `update_media_buy`) could not have their responses validated at all on the SDK's production loader once any flat-tree tool had been touched in the same process. Validation calls would throw `reference "/schemas/3.1.0-beta.3/core/<x>.json" resolves to more than one schema`.
+
+**The fix**: bundled response files explicitly declare themselves as inlined (`"note": "This is a bundled schema with all $ref resolved inline"`) and carry **no internal `$ref`s** at all. The nested `$id`s are vestigial spec-build artifacts — Ajv only needs the root `$id` for validator lookup. The loader now strips every nested `$id` from bundled files before passing them to `ajv.compile`, preserving only the root `$id`.
+
+The strip is a deep-copy walk so the on-disk schema cache is untouched, and is gated on `file.includes('/bundled/')` so flat-tree schemas (which DO have `$ref`s and need their nested registrations to resolve) are unaffected.
+
+**Tests flipped back on**: `test/validation-oneof-cascade.test.js` — the 14-tool `SCHEMA_LOADER_AMBIGUOUS_REF_SKIP` carve-out added in #1949 is removed; all 31 tests now run and pass.

--- a/src/lib/validation/schema-loader.ts
+++ b/src/lib/validation/schema-loader.ts
@@ -550,11 +550,54 @@ export function getValidator(
   if (!fromBundled) ensureCoreLoaded(s);
 
   const rawSchema = loadJson(file);
-  const schema = direction === 'request' ? rawSchema : relaxResponseRoot(rawSchema);
+  // Bundled files inline every referenced subschema with the original
+  // canonical `$id` (e.g. `core/version-envelope.json` appears nested
+  // inside every bundled tool response). Bundled files carry NO
+  // internal `$ref`s — the spec publishes them fully resolved, see
+  // the `note: "This is a bundled schema with all $ref resolved inline"`
+  // tag on every bundled file. Once `ensureCoreLoaded` has registered
+  // any of those core schemas standalone (which it does for the flat-
+  // tree governance / brand / property domains), Ajv's compile of a
+  // bundled file trips the ambiguous-ref check on every nested $id.
+  //
+  // The fix: strip nested `$id` fields before compile on bundled
+  // schemas. The root `$id` is kept (it's the validator's lookup key);
+  // every other `$id` in the tree was just metadata anyway.
+  const prepared = fromBundled ? stripNestedIds(rawSchema) : rawSchema;
+  const schema = direction === 'request' ? prepared : relaxResponseRoot(prepared);
   const existing = typeof schema.$id === 'string' ? s.ajv.getSchema(schema.$id) : undefined;
   const compiled = existing ?? s.ajv.compile(schema);
   s.validators.set(cacheKey, compiled);
   return compiled;
+}
+
+/**
+ * Strip `$id` from every subschema of a bundled response file, preserving
+ * the root `$id`. Bundled files are fully inlined (no internal `$ref`s),
+ * so the nested `$id`s are vestigial metadata — Ajv only cares about the
+ * root `$id` for validator lookup. Without this strip, Ajv's
+ * `checkAmbiguousRef` throws when an inlined nested `$id` matches one
+ * already registered standalone via `ensureCoreLoaded`.
+ *
+ * Returns a deep-copied tree; the input is not mutated.
+ */
+function stripNestedIds(schema: LoadedSchema): LoadedSchema {
+  const root = JSON.parse(JSON.stringify(schema)) as LoadedSchema;
+  const rootId = typeof root.$id === 'string' ? root.$id : undefined;
+  const walk = (node: unknown): void => {
+    if (Array.isArray(node)) {
+      for (const item of node) walk(item);
+      return;
+    }
+    if (!node || typeof node !== 'object') return;
+    const obj = node as Record<string, unknown>;
+    if (typeof obj.$id === 'string' && obj.$id !== rootId) {
+      delete obj.$id;
+    }
+    for (const value of Object.values(obj)) walk(value);
+  };
+  walk(root);
+  return root;
 }
 
 /** List of (toolName, direction) pairs that have schemas. Used by tests. */

--- a/test/validation-oneof-cascade.test.js
+++ b/test/validation-oneof-cascade.test.js
@@ -221,37 +221,9 @@ const RESPONSES_WITH_NOT_CLAUSE = [
   'update_rights',
 ];
 
-// Tools whose response root currently trips the production schema-loader's
-// Ajv "resolves to more than one schema" check on `core/{business-entity,
-// deployment, format-id}.json`. These core schemas appear both standalone
-// (registered via `ensureCoreLoaded`) and embedded inside bundled response
-// `.json` files with the same `$id`. The compile path can't disambiguate
-// once both are seen, so any tool whose response embeds one of them fails
-// to compile at all — and the #1383 invariant can't be measured.
-//
-// Skipped here pending a source-side fix to the schema-loader's
-// embedded-vs-standalone $id registration. Tracking: cluster-3 follow-up.
-const SCHEMA_LOADER_AMBIGUOUS_REF_SKIP = new Set([
-  'activate_signal',
-  'build_creative',
-  'create_media_buy',
-  'get_adcp_capabilities',
-  'get_creative_delivery',
-  'get_media_buys',
-  'list_creative_formats',
-  'list_creatives',
-  'preview_creative',
-  'sync_audiences',
-  'sync_catalogs',
-  'sync_creatives',
-  'sync_event_sources',
-  'update_media_buy',
-]);
-
 describe('#1383 — `not`-keyword exclusion sweep across all Success/Error response unions', () => {
   for (const toolName of RESPONSES_WITH_NOT_CLAUSE) {
-    const skip = SCHEMA_LOADER_AMBIGUOUS_REF_SKIP.has(toolName);
-    it(`${toolName}: empty payload surfaces no \`not\`-keyword issue`, { skip }, () => {
+    it(`${toolName}: empty payload surfaces no \`not\`-keyword issue`, () => {
       // Empty payload is a near-miss for both arms — it satisfies the
       // Error variant's `not.required` clause vacuously (has none of
       // the Success-only fields) and fails the Error variant's


### PR DESCRIPTION
## Summary

Fourth and highest-impact of the four #1950 source-side regressions: 14 tools couldn't validate their responses at all on the production schema-loader once any flat-tree tool had been compiled in the same process.

## The bug

Bundled response files (those the spec publishes fully inlined under \`schemas/cache/<ver>/bundled/\`) embed every referenced subschema with its canonical \`\$id\`. For example, \`bundled/signals/activate-signal-response.json\` contains a nested copy of \`core/version-envelope.json\` carrying \`"\$id": "/schemas/3.1.0-beta.3/core/version-envelope.json"\`.

The loader's \`ensureCoreLoaded\` pre-registers every standalone \`core/*.json\` whenever any non-bundled (flat-tree) tool is compiled — flat-tree tools have unresolved \`\$ref\`s that need the standalone registrations to resolve.

Sequence that trips Ajv's ambiguous-ref check:
1. Adopter validates any flat-tree tool (e.g. \`acquire_rights\`, \`get_brand_identity\`, any property-list task) — triggers \`ensureCoreLoaded\`, registers \`core/*\` standalone
2. Adopter validates a bundled tool (e.g. \`activate_signal\`) — Ajv compiles the bundled file, walks the nested \`\$id\`s, hits one already registered standalone with different body → throws \`reference "/schemas/3.1.0-beta.3/core/version-envelope.json" resolves to more than one schema\`

**14 tools blocked**: \`activate_signal\`, \`build_creative\`, \`create_media_buy\`, \`get_adcp_capabilities\`, \`get_creative_delivery\`, \`get_media_buys\`, \`list_creative_formats\`, \`list_creatives\`, \`preview_creative\`, \`sync_audiences\`, \`sync_catalogs\`, \`sync_creatives\`, \`sync_event_sources\`, \`update_media_buy\`. Production adopters would hit this depending on call order.

## The fix

Bundled response files declare themselves explicitly: \`"note": "This is a bundled schema with all \$ref resolved inline. For the modular version with references, use the parent directory."\` — and inspection confirms they contain **zero internal \`\$ref\`s**. The nested \`\$id\`s are vestigial spec-build artifacts; Ajv only needs the root \`\$id\` for validator lookup.

The loader now strips every nested \`\$id\` from bundled files before \`ajv.compile\`. The root \`\$id\` is preserved (it's the validator's lookup key). Three guardrails:

- **Path-gated**: only files under \`/bundled/\` are stripped. Flat-tree files (governance, brand, property-lists, etc.) still need their nested \`\$id\` registrations for \`\$ref\` resolution — they're untouched.
- **Deep-copy**: \`JSON.parse(JSON.stringify(schema))\` so the on-disk schema cache and any other handle to the LoadedSchema aren't mutated.
- **Root-id-preserved**: an explicit comparison \`obj.\$id !== rootId\` ensures the root \`\$id\` survives the walk.

## Tests flipped back on

\`test/validation-oneof-cascade.test.js\` — the 14-tool \`SCHEMA_LOADER_AMBIGUOUS_REF_SKIP\` carve-out added in #1949 is removed. All 31 tests in the \`#1383 — \`not\`-keyword exclusion sweep\` describe block now run and pass.

## Test plan

- [x] Reproduction script confirms the fix: \`acquire_rights::sync\` + \`activate_signal::sync\` both compile cleanly in the same process
- [x] \`test/validation-oneof-cascade.test.js\` — 31/31 pass (was 17 pass / 14 skipped)
- [x] Schema-validation sibling tests — 265 tests across the cluster, 255 pass / 10 skipped (the 10 skips are #1951's domain — un-skipped over there)
- [x] Validator siblings — 76/76 pass (\`request-validation\`, \`response-validator\`, \`protocol-schema-validation\`)
- [x] \`npm run typecheck\` clean
- [x] \`npm run format:check\` clean
- [x] Pre-push hook (typecheck + build) passed
- [ ] CI green (expect red on remaining #1943 clusters 1, 4, 6, 7 — unchanged)

Patch-level change. No new public API. Adopters using affected tools see validation start working again with no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)