### PR TITLE
fix: cluster-7 server-decisioning sweep — wire version normalization + envelope status on errors (#1955)

### DIFF
--- a/.changeset/cluster-7-server-decisioning.md
+++ b/.changeset/cluster-7-server-decisioning.md
@@ -1,0 +1,26 @@
+---
+'@adcp/sdk': patch
+---
+
+fix: cluster-7 server-decisioning sweep — release-precision wire `adcp_version`, envelope status on error responses, plus test catch-up for 3.1.0-beta.3 field renames (#1955)
+
+Two source-side fixes and four test catch-ups for the 3.1.0-beta.3 spec changes.
+
+## Source-side
+
+**`adcp_version` wire normalization** (`src/lib/version.ts` + wire emission in `src/lib/server/create-adcp-server.ts`). Per the spec note on `adcp_version`: "SDKs that read full-semver values from bundle metadata (e.g. `ComplianceIndex.published_version = "3.1.0-beta.1"`) MUST normalize to release-precision (`"3.1-beta.1"`) before emitting on the wire — meta-field values are NOT valid wire values." The wire regex (`^\d+\.\d+(-[a-zA-Z0-9.-]+)?$`) rejects strings with a patch digit, but the SDK was reading `ADCP_VERSION` ("3.1.0-beta.3") and stamping that verbatim on every response, failing schema validation on the receiver side.
+
+New helper `toReleasePrecisionVersion()` strips the patch digit: `3.1.0-beta.3` → `3.1-beta.3`. Wired into `injectVersionIntoResponse` so every framework-emitted response carries a wire-valid version string. Legacy aliases (`v2.5`, `v3`) pass through unchanged (v2.5 uses `adcp_major_version` for transport instead).
+
+**Envelope `status` on error responses** (`src/lib/server/create-adcp-server.ts`). `injectEnvelopeStatusIntoResponse` previously bailed when `response.isError === true`, leaving error responses without envelope `status`. AdCP 3.1.0-beta.2+ requires envelope `status` on EVERY response — success or error. The injector now maps `isError === true` → `status: 'failed'`, defaulting `'completed'` otherwise. Tools that need richer states (`submitted`, `working`, `input-required`) still set them explicitly; this injector only fills in the default.
+
+## Test catch-up
+
+- `test/server-assembly-helpers.test.js` — fixture gains `cache_scope: 'public'` on `get_products` validation call (required on populated-products branch since 3.1.0-beta.3).
+- `test/server-decisioning-brand-rights.test.js` — 2 `buildAcquired` fixtures + 2 dispatch-result assertions rename `status` → `rights_status` (AcquireRights discriminator rename in 3.1.0-beta.3).
+- `test/server-decisioning-to-wire-account.test.js` — 2 `governance_agents[]` fixtures drop `categories` (3.1.0-beta.3 tightened items to `additionalProperties: false` and dropped the deprecated field per the single-agent-owns-full-lifecycle clarification).
+- `test/lib/update-rights-creative-approval.test.js` — `CreativeApprovalResponseSchema` 4-arm fixture: discriminator rename `status` → `approval_status` (adcp#4878), plus envelope `status: 'completed' | 'failed'` added on each arm.
+
+110/110 across all 5 cluster-7 files pass; sibling regression check on 277 schema/storyboard/governance/extractor tests — 0 fail.
+
+Closes #1955 cluster-7 contribution. Remaining clusters (1, 4 storyboard-completeness/security, 6) tracked separately.

--- a/scripts/sync-version.ts
+++ b/scripts/sync-version.ts
@@ -286,6 +286,44 @@ export function parseAdcpMajorVersion(version: string): number {
   const major = parseInt(semverLike.split('.')[0] ?? '', 10);
   return Number.isFinite(major) ? major : NaN;
 }
+
+/**
+ * Normalize a full-semver AdCP version (\`MAJOR.MINOR.PATCH[-prerelease]\`) to
+ * the release-precision form that AdCP 3.1+ requires on the wire:
+ * \`MAJOR.MINOR[-prerelease]\` — the patch digit is dropped.
+ *
+ * Per the spec note on \`adcp_version\`: "SDKs that read full-semver values
+ * from bundle metadata (e.g. \`ComplianceIndex.published_version =
+ * "3.1.0-beta.1"\`) MUST normalize to release-precision (\`"3.1-beta.1"\`)
+ * before emitting on the wire — meta-field values are NOT valid wire
+ * values." The wire regex (\`^\\d+\\.\\d+(-[a-zA-Z0-9.-]+)?$\`) rejects strings
+ * with a patch digit.
+ *
+ * Behavior:
+ *   - \`"3.1.0-beta.3"\` → \`"3.1-beta.3"\`
+ *   - \`"3.1.0"\`        → \`"3.1"\`
+ *   - \`"3.0.12"\`       → \`"3.0"\`
+ *   - Already-release-precision input (\`"3.1"\`, \`"3.1-beta.3"\`) passes through
+ *   - Legacy aliases (\`"v2.5"\`, \`"v3"\`) pass through unchanged — the wire
+ *     regex doesn't accept them anyway; the v2.5 path uses
+ *     \`adcp_major_version\` instead of \`adcp_version\` for transport.
+ *   - Unrecognized strings pass through unchanged so callers can detect drift
+ *     via the wire validator rather than have it masked by this helper.
+ */
+export function toReleasePrecisionVersion(version: string): string {
+  const trimmed = version.trim();
+  // Pre-release form \`MAJOR.MINOR.PATCH-prerelease\` → \`MAJOR.MINOR-prerelease\`
+  const semverMatch = trimmed.match(/^(\\d+)\\.(\\d+)\\.\\d+(-[A-Za-z0-9.-]+)?$/);
+  if (semverMatch) {
+    const [, major, minor, pre = ''] = semverMatch;
+    return \`\${major}.\${minor}\${pre}\`;
+  }
+  // Already release-precision (no patch digit). Includes \`3.1\`, \`3.1-beta.3\`.
+  if (/^\\d+\\.\\d+(-[A-Za-z0-9.-]+)?$/.test(trimmed)) return trimmed;
+  // Legacy aliases (\`v3\`, \`v2.5\`, \`v2.6\`) and anything we don't recognize —
+  // pass through so the wire validator can flag genuine drift.
+  return version;
+}
 `;
 
   const versionChanged = writeFileIfChanged(versionFilePath, versionContent);

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -37,7 +37,7 @@
 
 import { z } from 'zod';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { parseAdcpMajorVersion, type AdcpVersion } from '../version';
+import { parseAdcpMajorVersion, toReleasePrecisionVersion, type AdcpVersion } from '../version';
 import { resolveAdcpVersion } from '../utils/adcp-version-config';
 import { resolveBundleKey } from '../validation/schema-loader';
 import { bundleSupportsAdcpVersionField } from '../protocols';
@@ -2676,18 +2676,25 @@ function injectContextIntoResponse(response: McpToolResponse, context: unknown):
  *   destroy payload semantics until the spec disambiguates.
  */
 function injectEnvelopeStatusIntoResponse(response: McpToolResponse): void {
-  if (response.isError === true) return;
   const sc = response.structuredContent as Record<string, unknown> | undefined;
   if (!sc || typeof sc !== 'object') return;
   if ('status' in sc) return;
-  sc.status = 'completed';
+  // AdCP 3.1.0-beta.2+ requires envelope `status` on EVERY response, error
+  // or otherwise. Map MCP's `isError` to the wire-level task state:
+  //   - `isError: true`           → `'failed'`  (task explicitly failed)
+  //   - `isError: false`/absent   → `'completed'` (default for success path)
+  // Tools that need richer states (`submitted`, `working`, `input-required`)
+  // should set `status` themselves; this injector only fills in the default
+  // when the handler hasn't.
+  const status = response.isError === true ? 'failed' : 'completed';
+  sc.status = status;
   if (Array.isArray(response.content)) {
     const first = response.content[0];
     if (first && first.type === 'text' && typeof first.text === 'string') {
       try {
         const parsed = JSON.parse(first.text);
         if (parsed && typeof parsed === 'object' && !('status' in parsed)) {
-          parsed.status = 'completed';
+          parsed.status = status;
           first.text = JSON.stringify(parsed);
         }
       } catch {
@@ -2699,16 +2706,21 @@ function injectEnvelopeStatusIntoResponse(response: McpToolResponse): void {
 
 function injectVersionIntoResponse(response: McpToolResponse, servedVersion: string | undefined): void {
   if (!servedVersion) return;
+  // Normalize to release-precision (`3.1-beta.3`) before emitting — the wire
+  // regex rejects full-semver (`3.1.0-beta.3`). Bundle metadata is published
+  // with the patch digit; on-the-wire `adcp_version` is not. See the spec
+  // note on `adcp_version` in `core.generated.ts` and the helper itself.
+  const wireVersion = toReleasePrecisionVersion(servedVersion);
   const sc = response.structuredContent as Record<string, unknown> | undefined;
   if (sc && typeof sc === 'object' && !('adcp_version' in sc)) {
-    sc.adcp_version = servedVersion;
+    sc.adcp_version = wireVersion;
     if (Array.isArray(response.content)) {
       const first = response.content[0];
       if (first && first.type === 'text' && typeof first.text === 'string') {
         try {
           const parsed = JSON.parse(first.text);
           if (parsed && typeof parsed === 'object' && !('adcp_version' in parsed)) {
-            parsed.adcp_version = servedVersion;
+            parsed.adcp_version = wireVersion;
             first.text = JSON.stringify(parsed);
           }
         } catch {

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP SDK library version
  */
-export const LIBRARY_VERSION = '8.1.0-beta.0';
+export const LIBRARY_VERSION = '8.1.0-beta.4';
 
 /**
  * AdCP specification version this library is built for
@@ -63,10 +63,10 @@ export type AdcpVersion = (typeof COMPATIBLE_ADCP_VERSIONS)[number];
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '8.1.0-beta.0',
+  library: '8.1.0-beta.4',
   adcp: '3.1.0-beta.3',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-05-22T15:58:01.281Z',
+  generatedAt: '2026-05-23T13:02:49.732Z',
 } as const;
 
 /**
@@ -111,4 +111,42 @@ export function parseAdcpMajorVersion(version: string): number {
   const semverLike = trimmed.startsWith('v') ? trimmed.slice(1) : trimmed;
   const major = parseInt(semverLike.split('.')[0] ?? '', 10);
   return Number.isFinite(major) ? major : NaN;
+}
+
+/**
+ * Normalize a full-semver AdCP version (`MAJOR.MINOR.PATCH[-prerelease]`) to
+ * the release-precision form that AdCP 3.1+ requires on the wire:
+ * `MAJOR.MINOR[-prerelease]` — the patch digit is dropped.
+ *
+ * Per the spec note on `adcp_version`: "SDKs that read full-semver values
+ * from bundle metadata (e.g. `ComplianceIndex.published_version =
+ * "3.1.0-beta.1"`) MUST normalize to release-precision (`"3.1-beta.1"`)
+ * before emitting on the wire — meta-field values are NOT valid wire
+ * values." The wire regex (`^\d+\.\d+(-[a-zA-Z0-9.-]+)?$`) rejects strings
+ * with a patch digit.
+ *
+ * Behavior:
+ *   - `"3.1.0-beta.3"` → `"3.1-beta.3"`
+ *   - `"3.1.0"`        → `"3.1"`
+ *   - `"3.0.12"`       → `"3.0"`
+ *   - Already-release-precision input (`"3.1"`, `"3.1-beta.3"`) passes through
+ *   - Legacy aliases (`"v2.5"`, `"v3"`) pass through unchanged — the wire
+ *     regex doesn't accept them anyway; the v2.5 path uses
+ *     `adcp_major_version` instead of `adcp_version` for transport.
+ *   - Unrecognized strings pass through unchanged so callers can detect drift
+ *     via the wire validator rather than have it masked by this helper.
+ */
+export function toReleasePrecisionVersion(version: string): string {
+  const trimmed = version.trim();
+  // Pre-release form `MAJOR.MINOR.PATCH-prerelease` → `MAJOR.MINOR-prerelease`
+  const semverMatch = trimmed.match(/^(\d+)\.(\d+)\.\d+(-[A-Za-z0-9.-]+)?$/);
+  if (semverMatch) {
+    const [, major, minor, pre = ''] = semverMatch;
+    return `${major}.${minor}${pre}`;
+  }
+  // Already release-precision (no patch digit). Includes `3.1`, `3.1-beta.3`.
+  if (/^\d+\.\d+(-[A-Za-z0-9.-]+)?$/.test(trimmed)) return trimmed;
+  // Legacy aliases (`v3`, `v2.5`, `v2.6`) and anything we don't recognize —
+  // pass through so the wire validator can flag genuine drift.
+  return version;
 }

--- a/test/lib/update-rights-creative-approval.test.js
+++ b/test/lib/update-rights-creative-approval.test.js
@@ -189,10 +189,20 @@ describe('creative_approval webhook builders', () => {
   });
 
   it('Zod CreativeApprovalResponseSchema accepts each of the four arms', () => {
-    const approved = { status: 'approved', rights_id: 'rights_grant_123' };
-    const rejected = { status: 'rejected', rights_id: 'rights_grant_123', reason: 'r' };
-    const pending = { status: 'pending_review', rights_id: 'rights_grant_123' };
-    const error = { errors: [{ code: 'INVALID_REQUEST', message: 'm' }] };
+    // 3.1.0-beta.3 renamed the decision discriminator from `status` to
+    // `approval_status` so the top-level `status` is free for the envelope
+    // task-status (TaskStatus) under MCP flat-on-the-wire serialization
+    // (adcp#4878). The schema also requires envelope `status: 'completed'`
+    // on every non-error arm.
+    const approved = { status: 'completed', approval_status: 'approved', rights_id: 'rights_grant_123' };
+    const rejected = {
+      status: 'completed',
+      approval_status: 'rejected',
+      rights_id: 'rights_grant_123',
+      reason: 'r',
+    };
+    const pending = { status: 'completed', approval_status: 'pending_review', rights_id: 'rights_grant_123' };
+    const error = { status: 'failed', errors: [{ code: 'INVALID_REQUEST', message: 'm' }] };
     for (const candidate of [approved, rejected, pending, error]) {
       const parsed = schemas.CreativeApprovalResponseSchema.safeParse(candidate);
       assert.ok(

--- a/test/server-assembly-helpers.test.js
+++ b/test/server-assembly-helpers.test.js
@@ -42,7 +42,10 @@ describe('buildProduct — emits correct wire shape', () => {
       publisher_domain: 'sports.example',
       agentUrl: 'http://127.0.0.1:4200/mcp',
     });
-    const result = validateResponse('get_products', { products: [product] });
+    // `cache_scope: 'public'` is required on the populated-products branch
+    // of `get-products-response.json`'s top-level `if (unchanged) ... else`
+    // since 3.1.0-beta.3.
+    const result = validateResponse('get_products', { products: [product], cache_scope: 'public' });
     if (!result.valid) {
       // eslint-disable-next-line no-console
       console.error('validation issues:', JSON.stringify(result.issues, null, 2));

--- a/test/server-decisioning-brand-rights.test.js
+++ b/test/server-decisioning-brand-rights.test.js
@@ -54,7 +54,7 @@ const RIGHTS_OFFERING = {
 function buildAcquired(rightsId, brandId, pricingOptionId) {
   return {
     rights_id: rightsId,
-    status: 'acquired',
+    rights_status: 'acquired',
     brand_id: brandId,
     terms: {
       pricing_option_id: pricingOptionId,
@@ -107,7 +107,7 @@ function brandRightsPlatform(brOverrides = {}) {
         }
         return {
           rights_id: req.rights_id,
-          status: 'pending_approval',
+          rights_status: 'pending_approval',
           brand_id: RIGHTS_OFFERING.brand_id,
           detail: 'Awaiting rights-holder counter-signature',
           estimated_response_time: '48h',
@@ -193,7 +193,9 @@ describe('BrandRightsPlatform — 3-method specialism', () => {
     });
 
     assert.notStrictEqual(result.isError, true, JSON.stringify(result.structuredContent));
-    assert.strictEqual(result.structuredContent.status, 'acquired');
+    // 3.1.0-beta.3 renamed the discriminator from `status` to `rights_status`
+    // (envelope `status` is now reserved for task-state: completed/failed/...).
+    assert.strictEqual(result.structuredContent.rights_status, 'acquired');
     assert.strictEqual(result.structuredContent.rights_id, 'rights_endorsement_us');
     assert.strictEqual(result.structuredContent.brand_id, 'brand_acme_42');
     assert.ok(result.structuredContent.terms, 'Acquired arm requires terms');
@@ -224,7 +226,7 @@ describe('BrandRightsPlatform — 3-method specialism', () => {
     });
 
     assert.notStrictEqual(result.isError, true, JSON.stringify(result.structuredContent));
-    assert.strictEqual(result.structuredContent.status, 'pending_approval');
+    assert.strictEqual(result.structuredContent.rights_status, 'pending_approval');
     assert.strictEqual(result.structuredContent.estimated_response_time, '48h');
   });
 

--- a/test/server-decisioning-to-wire-account.test.js
+++ b/test/server-decisioning-to-wire-account.test.js
@@ -201,20 +201,25 @@ describe('toWireAccount', () => {
     });
 
     it('projects account_scope and governance_agents', () => {
+      // 3.1.0-beta.3 tightened `governance_agents[]` items to
+      // `additionalProperties: false` and dropped `categories` (the single-
+      // agent-owns-full-lifecycle clarification). Only `url` + `authentication`
+      // are permitted on the wire; the projection strips anything else.
       const wire = toWireAccount({
         ...baseAccount(),
         account_scope: 'operator_brand',
-        governance_agents: [{ url: 'https://gov.acme.com/mcp', categories: ['budget_authority'] }],
+        governance_agents: [{ url: 'https://gov.acme.com/mcp' }],
       });
       assert.equal(wire.account_scope, 'operator_brand');
-      assert.deepEqual(wire.governance_agents, [{ url: 'https://gov.acme.com/mcp', categories: ['budget_authority'] }]);
+      assert.deepEqual(wire.governance_agents, [{ url: 'https://gov.acme.com/mcp' }]);
     });
 
     it('drops unknown keys on governance_agents elements (credential smuggling guard)', () => {
       // Schema notes governance auth credentials are write-only; the wire type
       // already excludes them, but adopters using JS / `as any` could otherwise
       // smuggle a credentials field straight to the wire. Element-level
-      // projection closes that gap.
+      // projection closes that gap. Same projection also drops the now-
+      // deprecated `categories` field (removed in 3.1.0-beta.3).
       const wire = toWireAccount({
         ...baseAccount(),
         governance_agents: [
@@ -228,8 +233,8 @@ describe('toWireAccount', () => {
       });
       assert.equal('credentials' in wire.governance_agents[0], false);
       assert.equal('api_key' in wire.governance_agents[0], false);
+      assert.equal('categories' in wire.governance_agents[0], false);
       assert.equal(wire.governance_agents[0].url, 'https://gov.acme.com/mcp');
-      assert.deepEqual(wire.governance_agents[0].categories, ['budget_authority']);
     });
 
     it('projects reporting_bucket', () => {


### PR DESCRIPTION
## Summary

Cluster-7 from #1943 / #1955. Two source-side fixes + four test catch-ups for 3.1.0-beta.3 changes. **110/110 cluster tests pass; 277 sibling tests across schema/storyboard/governance/extractor — 0 regressions.**

## Source-side fixes

### 1. `adcp_version` wire normalization

\`src/lib/version.ts\` adds \`toReleasePrecisionVersion()\` and \`src/lib/server/create-adcp-server.ts\`'s \`injectVersionIntoResponse\` calls it before stamping.

Per the spec note on \`adcp_version\`: "SDKs that read full-semver values from bundle metadata (e.g. \`ComplianceIndex.published_version = "3.1.0-beta.1"\`) MUST normalize to release-precision (\`"3.1-beta.1"\`) before emitting on the wire — meta-field values are NOT valid wire values."

The SDK was reading \`ADCP_VERSION\` (\`"3.1.0-beta.3"\`) and stamping it verbatim on every response. The wire regex (\`^\\d+\\.\\d+(-[a-zA-Z0-9.-]+)?$\`) rejects strings with a patch digit, so every framework-emitted response failed schema validation on the receiver side.

The helper strips the patch digit: \`3.1.0-beta.3\` → \`3.1-beta.3\`. Legacy aliases (\`v2.5\`, \`v3\`) pass through unchanged (v2.5 uses \`adcp_major_version\` for transport instead).

### 2. Envelope `status` on error responses

\`injectEnvelopeStatusIntoResponse\` in \`src/lib/server/create-adcp-server.ts\` previously bailed when \`response.isError === true\`. AdCP 3.1.0-beta.2+ requires envelope \`status\` on **every** response — success or error. The injector now maps:

- \`isError === true\` → \`status: 'failed'\`
- otherwise → \`status: 'completed'\`

Tools that need richer states (\`submitted\`, \`working\`, \`input-required\`) still set them explicitly; this only fills in the default.

## Test catch-up

| File | Change |
|---|---|
| \`server-assembly-helpers.test.js\` | \`get_products\` validation fixture gains \`cache_scope: 'public'\` (required on populated-products branch since 3.1.0-beta.3) |
| \`server-decisioning-brand-rights.test.js\` | 2 \`buildAcquired\` fixtures + 2 dispatch assertions rename \`status\` → \`rights_status\` (AcquireRights discriminator rename per 3.1.0-beta.3) |
| \`server-decisioning-to-wire-account.test.js\` | 2 \`governance_agents[]\` fixtures drop \`categories\` (deprecated per single-agent-owns-full-lifecycle clarification) |
| \`lib/update-rights-creative-approval.test.js\` | \`CreativeApprovalResponseSchema\` 4-arm fixture: discriminator \`status\` → \`approval_status\` (adcp#4878) + envelope \`status: 'completed' \\| 'failed'\` on each arm |

## Test plan

- [x] All 5 cluster-7 files: 110/110 pass
- [x] Sibling regression check: 277 tests across response-unwrapper, response-schema-validation, schema-validation, storyboard-brand-invariant, validation-oneof-cascade, governance, context-extractors — 0 fail
- [x] \`npm run typecheck\` clean
- [x] \`npm run format:check\` clean
- [x] Pre-push hook (typecheck + build) passed
- [ ] CI green (expect red on remaining #1943 clusters 1, 4 storyboard-completeness/security, 6)

Patch-level. The source-side changes correct genuine spec-noncompliance the SDK had been silently emitting since the 3.1.0-beta cut — adopters get fixed wire shape on every framework response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)