### PR TITLE
feat(types): export ProductObjectSchema and extractObjectSchema to restore .extend() on intersection schemas

### DIFF
--- a/.changeset/product-schema-extract-object-helper.md
+++ b/.changeset/product-schema-extract-object-helper.md
@@ -1,0 +1,12 @@
+---
+"@adcp/sdk": minor
+---
+
+Export `ProductObjectSchema` and `extractObjectSchema` to restore `.extend()` / `.omit()` / `.pick()` for consumers affected by the 8.1.0 `ProductSchema` shape change from `ZodObject` to `ZodIntersection`.
+
+`ProductSchema` in 8.1.0-beta.* became a `ZodIntersection` (to accommodate V1/V2 format variants), which drops the `.extend()` / `.omit()` / `.pick()` methods that `ZodObject` exposes. Two additive exports restore the lost ergonomics without changing any existing schema shapes:
+
+- **`ProductObjectSchema`** — a concrete `ZodObject` export for the most common case (`ProductSchema.extend(...)` → `ProductObjectSchema.extend(...)`).
+- **`extractObjectSchema(schema)`** — a generic helper that extracts the right-side `ZodObject` from any `ZodIntersection<L, ZodObject<R>>` produced by the codegen, for the other 96 intersection-shaped schemas in 8.1+.
+
+Also fixes the broken `ProductSchema.extend(...)` example in `docs/ZOD-SCHEMAS.md`.

--- a/docs/ZOD-SCHEMAS.md
+++ b/docs/ZOD-SCHEMAS.md
@@ -103,11 +103,29 @@ const PartialMediaBuy = MediaBuySchema.partial(); // All fields optional
 ```
 
 ### Schema Extension
+
+Some schemas (including `ProductSchema` in 8.1+) are `ZodIntersection` shapes
+rather than plain `ZodObject`, which means `.extend()`, `.omit()`, and `.pick()`
+are not directly available.  Use the exported `ProductObjectSchema` (or the
+generic `extractObjectSchema` helper) instead:
+
 ```typescript
-const ProductWithCache = ProductSchema.extend({
+import { ProductObjectSchema, extractObjectSchema, ProductSchema } from '@adcp/sdk';
+
+// Named export for the most common case:
+const ProductWithCache = ProductObjectSchema.extend({
   _cached_at: z.string().datetime()
 });
+
+// Generic helper for other intersection schemas:
+const MySchema = extractObjectSchema(SomeIntersectionSchema).extend({
+  my_field: z.string()
+});
 ```
+
+If you see `TS2339: Property 'extend' does not exist on type 'ZodIntersection<...>'`,
+use `ProductObjectSchema` (for products) or `extractObjectSchema(schema)` for other
+intersection-shaped schemas.
 
 ### Custom Transforms
 ```typescript
@@ -311,9 +329,11 @@ node -e "console.log(require('@adcp/sdk').MediaBuySchema)"
 **Solution**: Install zod as a peer dependency: `npm install zod`
 
 ### Schema Validation Fails on Valid Data
-Some complex nested schemas may need:
+Some complex nested schemas may need `.passthrough()` to allow extra fields.
+Note that `ProductSchema` is a `ZodIntersection` in 8.1+, so use `ProductObjectSchema`:
 ```typescript
-const FlexibleProduct = ProductSchema.passthrough(); // Allow extra fields
+import { ProductObjectSchema } from '@adcp/sdk';
+const FlexibleProduct = ProductObjectSchema.passthrough(); // Allow extra fields
 ```
 
 ### Schema Updates After Protocol Changes

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -317,6 +317,11 @@ export * from './sync-rows';
 // Re-export Zod schemas for runtime validation
 export * from './schemas.generated';
 
+// Helpers for intersection-shaped schemas (e.g., ProductSchema in 8.1+).
+// Exported separately so they're tree-shakeable and don't pollute the
+// generated-schema namespace.
+export { extractObjectSchema, ProductObjectSchema } from './schema-helpers';
+
 // Re-export const-array enum values (e.g., MediaChannelValues, PacingValues)
 // for consumers that need to enumerate or validate against the spec's
 // literal sets without re-deriving them from Zod schemas.

--- a/src/lib/types/schema-helpers.ts
+++ b/src/lib/types/schema-helpers.ts
@@ -1,0 +1,47 @@
+import { z } from 'zod';
+import { ProductSchema } from './schemas.generated';
+
+/**
+ * Extracts the right-side `ZodObject` from a `ZodIntersection` produced by
+ * the AdCP schema codegen.  Several schemas in 8.1+ use
+ * `z.union([V1..., V2...]).and(z.object({ ... }))` to express V1/V2 format
+ * variants, which creates a `ZodIntersection` that no longer exposes `.extend()`,
+ * `.omit()`, or `.pick()`.
+ *
+ * Use this helper when you need to extend an AdCP schema with your own fields:
+ *
+ * @example
+ * // Instead of: ProductSchema.extend({ _cached_at: z.string() })  // ❌ TS2339
+ * const MyProductSchema = extractObjectSchema(ProductSchema).extend({ _cached_at: z.string() });
+ *
+ * @note Relies on `_def.right` which is Zod's internal intersection structure.
+ *   A canary test in test/lib/zod-schemas.test.js verifies this stays intact
+ *   across Zod minor bumps.
+ */
+export function extractObjectSchema<L extends z.ZodTypeAny, R extends z.ZodRawShape>(
+  schema: z.ZodIntersection<L, z.ZodObject<R>>
+): z.ZodObject<R> {
+  const right = schema._def.right;
+  if (!(right instanceof z.ZodObject)) {
+    throw new Error(
+      `extractObjectSchema: expected ZodObject on the right side of ZodIntersection, got ${right?.constructor?.name ?? typeof right}. ` +
+        `The codegen may have changed the schema shape. Check schema-helpers.ts and update if needed.`
+    );
+  }
+  return right;
+}
+
+/**
+ * The core `ZodObject` shape of `ProductSchema` — use when you need
+ * `.extend()`, `.omit()`, or `.pick()` on the product schema.
+ *
+ * In 8.1+, `ProductSchema` became a `ZodIntersection` (to accommodate V1/V2
+ * format variants), which does not expose those methods. This named export
+ * gives you the underlying object schema directly.
+ *
+ * @example
+ * const ProductWithCache = ProductObjectSchema.extend({
+ *   _cached_at: z.string().datetime(),
+ * });
+ */
+export const ProductObjectSchema = extractObjectSchema(ProductSchema);

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP SDK library version
  */
-export const LIBRARY_VERSION = '8.1.0-beta.6';
+export const LIBRARY_VERSION = '8.1.0-beta.7';
 
 /**
  * AdCP specification version this library is built for
@@ -63,10 +63,10 @@ export type AdcpVersion = (typeof COMPATIBLE_ADCP_VERSIONS)[number];
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '8.1.0-beta.6',
+  library: '8.1.0-beta.7',
   adcp: '3.1.0-beta.3',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-05-23T21:46:44.955Z',
+  generatedAt: '2026-05-24T01:31:09.932Z',
 } as const;
 
 /**

--- a/test/lib/zod-schemas.test.js
+++ b/test/lib/zod-schemas.test.js
@@ -1,6 +1,73 @@
 const { test, describe } = require('node:test');
 const assert = require('node:assert');
 
+// Canary: verifies that extractObjectSchema and ProductObjectSchema remain
+// functional across Zod minor bumps (they rely on _def.right internals).
+describe('schema-helpers — extractObjectSchema / ProductObjectSchema', () => {
+  test('ProductObjectSchema is exported and is a ZodObject (has .extend)', async () => {
+    const { ProductObjectSchema } = await import('../../dist/lib/index.js');
+    assert.ok(ProductObjectSchema, 'ProductObjectSchema should be exported');
+    assert.strictEqual(
+      typeof ProductObjectSchema.extend,
+      'function',
+      'ProductObjectSchema must be a ZodObject with .extend()'
+    );
+    assert.strictEqual(
+      typeof ProductObjectSchema.omit,
+      'function',
+      'ProductObjectSchema must be a ZodObject with .omit()'
+    );
+    assert.strictEqual(
+      typeof ProductObjectSchema.pick,
+      'function',
+      'ProductObjectSchema must be a ZodObject with .pick()'
+    );
+  });
+
+  test('ProductObjectSchema.extend() produces a working schema', async () => {
+    const { ProductObjectSchema } = await import('../../dist/lib/index.js');
+    const Extended = ProductObjectSchema.extend({ _test_field: (await import('zod')).z.string() });
+    const result = Extended.safeParse({
+      product_id: 'p1',
+      name: 'Test',
+      description: 'A test product',
+      publisher_properties: [],
+      delivery_type: 'guaranteed',
+      pricing_options: [],
+      reporting_capabilities: {
+        available_reporting_frequencies: ['daily'],
+        expected_delay_minutes: 60,
+        timezone: 'UTC',
+        supports_webhooks: false,
+        available_metrics: ['impressions'],
+        date_range_support: 'date_range',
+      },
+      _test_field: 'hello',
+    });
+    assert.ok(
+      result.success,
+      `Extended ProductObjectSchema should parse a valid product: ${JSON.stringify(result.error?.issues)}`
+    );
+  });
+
+  test('extractObjectSchema works on ProductSchema and yields a ZodObject', async () => {
+    const { extractObjectSchema, ProductSchema } = await import('../../dist/lib/index.js');
+    assert.strictEqual(typeof extractObjectSchema, 'function', 'extractObjectSchema should be exported');
+    // Canary: if this assertion fails, ProductSchema is no longer a ZodIntersection with .right
+    // and extractObjectSchema's implementation needs updating (see schema-helpers.ts).
+    assert.ok(
+      ProductSchema._def && ProductSchema._def.right,
+      'ProductSchema must be a ZodIntersection with _def.right — if this fails, schema-helpers.ts needs updating'
+    );
+    const obj = extractObjectSchema(ProductSchema);
+    assert.strictEqual(
+      typeof obj.extend,
+      'function',
+      'extractObjectSchema(ProductSchema) must return a ZodObject with .extend()'
+    );
+  });
+});
+
 describe('Zod Schema Validation', () => {
   let schemas;
 


### PR DESCRIPTION
Closes #1970

## Summary

`ProductSchema` changed from `ZodObject` to `ZodIntersection` in 8.1.0-beta.* to accommodate V1/V2 format variants, silently breaking any downstream that called `.extend()`, `.omit()`, or `.pick()` on it directly. This PR restores the ergonomics via two additive, non-breaking exports and fixes two broken examples in the docs.

**New exports:**

- **`ProductObjectSchema`** — concrete `ZodObject` for the most common case (`ProductSchema.extend(...)` → `ProductObjectSchema.extend(...)`). Directly replaces the documented pattern.
- **`extractObjectSchema(schema)`** — generic helper that extracts the right-side `ZodObject` from any `ZodIntersection<L, ZodObject<R>>` produced by the codegen, for the other 96 intersection-shaped schemas in 8.1+.

**Docs fixed:**

- `docs/ZOD-SCHEMAS.md` — corrected the broken `ProductSchema.extend(...)` example in the Advanced Usage section.
- `docs/ZOD-SCHEMAS.md` — corrected the broken `ProductSchema.passthrough()` example in the Troubleshooting section (`.passthrough()` is also `ZodObject`-only).

Both exports include JSDoc examples and are available at `import { ProductObjectSchema, extractObjectSchema } from '@adcp/sdk'`.

## What was tested

- `tsc --project tsconfig.lib.json --noEmit` — clean (pre-existing deprecation warnings only, unrelated to this change)
- `prettier --check` — clean on all changed files
- Canary tests added to `test/lib/zod-schemas.test.js` verifying:
  - `ProductObjectSchema` has `.extend`, `.omit`, `.pick`
  - `ProductObjectSchema.extend({ _test_field: z.string() }).safeParse(...)` succeeds on a valid product
  - `extractObjectSchema(ProductSchema)` returns a `ZodObject` with `.extend`
  - The canary explicitly asserts `ProductSchema._def.right` exists, so a future codegen shape change surfaces as a readable test failure rather than a silent runtime error
- Minor changeset included

## Pre-PR review

- **code-reviewer:** approved — export chain verified intact (`schema-helpers.ts` → named export in `types/index.ts` → `export * from './types'` in `index.ts`); runtime `instanceof` guard added per review feedback; canary test strengthened with `_def.right` pre-assertion.
- **dx-expert:** approved — naming follows `*Schema` conventions; doc examples corrected including the `passthrough()` case that was equally broken; `TS2339 → ProductObjectSchema` mapping added.

## Notes (not blocking)

- A `migration-8.0-to-8.1.md` doc doesn't exist yet. Developers upgrading from 8.0 will find the fix via the corrected `ZOD-SCHEMAS.md` example, but a migration doc would be a useful follow-up.
- `extractObjectSchema` does not handle chained intersections (`.and().and()`) — TypeScript's type system will surface this at compile time since the argument type won't match `ZodIntersection<L, ZodObject<R>>`.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01A2Thvmn8bFTS5gvJixQS2P

---
_Generated by [Claude Code](https://claude.ai/code/session_01A2Thvmn8bFTS5gvJixQS2P)_