### PR TITLE
docs: address two follow-up comments from #1902 review

### DIFF
--- a/.changeset/post-1902-cleanup.md
+++ b/.changeset/post-1902-cleanup.md
@@ -1,0 +1,12 @@
+---
+---
+
+docs: address two follow-up comments from #1902 review
+
+Both spotted by @nastassiafulconis during the 8.0-beta foundation cut and acknowledged at the time; landing now as a small cleanup.
+
+1. **`getAssetSlot` JSDoc / behavior mismatch** (`src/lib/server/decisioning/manifest-helpers.ts`). The doc said "Returns `undefined` if the slot is missing or empty" but `![]` is falsy in JS, so an empty array slot flows past the guard and returns `[]` (the filter result on an empty array). Behavior is fine — returning `[]` for an empty slot matches the "filter result" contract more consistently than collapsing to `undefined`, and empty arrays are spec-invalid by the `minItems: 1` constraint anyway. Updated the JSDoc to reflect what the function actually does, with the empty-array rationale called out.
+
+2. **`updatePackageJsonVersion` NaN footgun** (`scripts/sync-version.ts`). `adcpVersion.split('.').map(Number)` produces `NaN` for prerelease versions like `'3.1.0-beta.3'` because `'0-beta'` isn't numeric. Today only `[newMajor, newMinor]` are destructured so the NaN at index 2 is silently discarded — but the next maintainer to add `newPatch` would get `NaN` for every prerelease. Added a one-line comment block making the discarded NaN intentional and pointing at the prerelease-aware regex helper higher in the file.
+
+Empty changeset — docs/comments only, no behavior change.

--- a/scripts/sync-version.ts
+++ b/scripts/sync-version.ts
@@ -356,7 +356,14 @@ function updatePackageJsonVersion(adcpVersion: string, autoUpdate: boolean = fal
     // Auto-increment library version when AdCP version changes
     const [major, minor, patch] = currentLibraryVersion.split('.').map(Number);
 
-    // Determine version bump strategy based on AdCP version change
+    // Determine version bump strategy based on AdCP version change.
+    // Note: `'3.1.0-beta.3'.split('.').map(Number)` produces
+    // `[3, 1, NaN, NaN, 3]` for prerelease versions because `'0-beta'`
+    // and `'beta'` aren't numeric. We only destructure `[major, minor]`,
+    // so the NaN at index 2 is intentionally discarded. If a future
+    // edit adds `newPatch` here, it will be `NaN` for prereleases and
+    // needs explicit prerelease handling (see semverMatch above) — do
+    // NOT extend this destructure without that fix.
     const [currentMajor, currentMinor] = (currentAdcpVersion || '0.0.0').split('.').map(Number);
     const [newMajor, newMinor] = adcpVersion.split('.').map(Number);
 

--- a/src/lib/server/decisioning/manifest-helpers.ts
+++ b/src/lib/server/decisioning/manifest-helpers.ts
@@ -57,8 +57,14 @@ export function getAsset<T extends AssetInstanceType>(
  * array — every element must match `assetType`; mixed-type slots are
  * the adopter's responsibility to discriminate per-element.
  *
- * Returns `undefined` if the slot is missing or empty. Returns `[]` if
- * the slot is present but every element fails the asset_type check.
+ * Returns `undefined` only when the slot is missing from the manifest
+ * (`manifest.assets[assetId]` is absent). Returns `[]` when the slot
+ * is present but empty, or present and non-empty with no elements
+ * matching `assetType`. Empty arrays are spec-invalid per the
+ * `minItems: 1` constraint on slot arrays, but the helper accepts
+ * malformed input defensively — returning `[]` is more consistent
+ * with the "filter result on the slot" contract than collapsing it
+ * to `undefined`.
  *
  * @since AdCP 3.1.0-beta.2 (slot widening to `AssetVariant | AssetVariant[]`).
  */


### PR DESCRIPTION
## Summary

Two small follow-up fixes for comments @nastassiafulconis left on #1902 during the 8.0-beta foundation cut.

1. **`getAssetSlot` JSDoc / behavior mismatch** (`src/lib/server/decisioning/manifest-helpers.ts`). Doc said "Returns \`undefined\` if the slot is missing or empty" but `![]` is falsy in JS, so an empty array slot flows past the guard and returns `[]` (the filter result on an empty array). Behavior is fine — returning `[]` for an empty slot matches the "filter result" contract more consistently than collapsing to `undefined`, and empty arrays are spec-invalid by the `minItems: 1` constraint anyway. Updated the JSDoc to reflect what the function actually does, with the empty-array rationale called out.

2. **`updatePackageJsonVersion` NaN footgun** (`scripts/sync-version.ts`). `adcpVersion.split('.').map(Number)` produces `NaN` for prerelease versions like `'3.1.0-beta.3'` because `'0-beta'` isn't numeric. Today only `[newMajor, newMinor]` are destructured so the NaN at index 2 is silently discarded — but the next maintainer to add `newPatch` would get `NaN` for every prerelease. Added a one-line comment block making the discarded NaN intentional and pointing at the prerelease-aware regex helper higher in the file.

Empty changeset — docs/comments only, no behavior change.

## Test plan
- [ ] CI green (no functional changes)
- [ ] Changeset Check passes (empty changeset committed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)