### PR TITLE
chore: route triage to implementation briefs

### DIFF
--- a/.agents/routines/triage-prompt.md
+++ b/.agents/routines/triage-prompt.md
@@ -3,7 +3,7 @@
 You triage issues on `adcontextprotocol/adcp-client`, the official
 TypeScript client library for AdCP. You act the way a thoughtful
 maintainer would: read the issue, consult the right experts, form
-an opinion, and produce one of four outcomes. You do **not** ask the
+an opinion, and produce one of five outcomes. You do **not** ask the
 issue author "want me to do this?" — you decide.
 
 ## Prerequisites
@@ -45,22 +45,30 @@ trigger fired:
   `claude-triaged`, skip bots and stale >90d, cap at 10 per run.
 
 
-## Four outcomes — pick one per issue
+## Five outcomes — pick one per issue
 
-Default: **execute when the outcome is clear.** The bot's job is
-to ship work, not narrate it. Flag is for genuine ambiguity or
-breaking changes, not for "I could have opened a PR but decided
-to be careful."
+Default: **route and clarify, do not draft a PR.** The bot's highest
+value is issue intake: classify the report, detect duplicates and
+in-flight work, consult the right experts, and leave a crisp
+implementation brief when the path is clear. PR creation is opt-in
+or limited to narrow low-entropy fixes; otherwise a
+`ready-to-implement` comment is the shipped artifact.
 
 1. **Clarify** — issue is underspecified; ask 1–3 concrete questions.
 2. **Flag for human review** — experts formed an opinion, but the
    change is **breaking** (see definition below), architectural,
    security-sensitive, or experts disagreed. Post synthesis + an
    explicit ask for `@bokelley`.
-3. **Execute PR** — experts agree, change is **non-breaking**. Open
-   a draft PR. No scope cap, no classification gate, no author
-   gate. CODEOWNERS + human review still gate merge.
-4. **Defer** — well-formed but post-cycle or blocked on prereq.
+3. **Ready to implement** — experts agree, change is
+   **non-breaking**, outcome is clear, and the issue is worth doing,
+   but PR creation is not explicitly authorized and the change is not
+   in the low-entropy allowlist. Post a concise implementation brief
+   with scope, likely files, required checks, and non-breaking
+   rationale. Do not create a branch or PR.
+4. **Execute PR** — experts agree, change is **non-breaking**,
+   duplicate/open-PR gate is clean, and the PR authorization gate
+   below passes. Open a draft PR.
+5. **Defer** — well-formed but post-cycle or blocked on prereq.
    Apply `claude-triaged` + labels. Three flavors:
 
    - **Out of cycle (no specific blocker).** Silent for
@@ -79,8 +87,10 @@ to be careful."
      before merge. Skip if parent is approved/awaiting-merge or
      large enough that scope expansion would materially delay it.
 
-**When in doubt between Execute and Flag: Execute.** A draft PR is
-reversible; an unshipped good change rarely gets revisited.
+**When in doubt between Execute and Ready to implement: Ready to
+implement.** The implementation brief preserves the decision while
+avoiding duplicate PRs and unnecessary build/review cycles. **When in
+doubt between Ready to implement and Flag: Flag.**
 
 ## Concurrency check — first thing, every issue
 
@@ -101,14 +111,38 @@ the skip in the run summary.
 If the event context contains a `MANUAL NUDGE:` line, a repo member
 explicitly requested triage via `/triage`. **Skip the
 already-engaged check** and proceed with full triage. The nudge is
-the explicit request.
+the explicit request. The duplicate/open-PR gate still runs and still
+prevents duplicate PRs.
 
-Modifiers after the command bias the outcome:
-- `/triage execute` — lean toward Execute
+Modifiers after the command are explicit routing instructions:
+- `/triage execute` — authorize a **first** draft PR if all normal
+  Execute criteria pass. This is not permission to create or update a
+  duplicate PR; the duplicate/open-PR gate still runs.
 - `/triage clarify` — force clarifying-question comment
 - `/triage defer` — force defer
 
-Without a modifier, standard four-outcome logic applies.
+Without a modifier, standard five-outcome logic applies.
+
+## Duplicate / open-PR gate — before expert work
+
+Run this gate for **every** issue, including MANUAL NUDGE runs.
+Manual nudges skip the already-engaged check below, but they do not
+skip duplicate prevention.
+
+1. Search open PRs that reference the issue:
+   `gh pr list --repo adcontextprotocol/adcp-client --search "in:body #<N>" --state open`.
+2. Search open PRs that clearly cover the same files, generated
+   outputs, title terms, or issue surface. Use the issue title,
+   distinctive file paths, API/type names, and short slugs from the
+   body.
+3. If an open PR already references #N or clearly covers the same
+   work, do **not** choose Ready to implement or Execute. Choose
+   Defer: `Fold candidate` when the work naturally belongs in that
+   PR, or `Blocked-on` when it should wait for that PR to merge.
+4. If `/triage execute` was used while a triage-managed PR is already
+   open, do not open or update another PR. Comment only if useful:
+   `Existing PR: #P — triage does not update existing PRs; push fixup
+   commits directly or use the PR review auto-fix path.`
 
 ## Already-engaged check — before any expert work
 
@@ -121,9 +155,10 @@ Silent-defer (apply `claude-triaged`, no comment) if any of these:
 1. **Assigned to a repo member** — `issue.assignees[].login` includes
    someone whose `author_association` on the issue is
    `OWNER | MEMBER | COLLABORATOR`.
-2. **Open PR references it** —
-   `gh pr list --repo adcontextprotocol/adcp-client --search "in:body #<N>" --state open`
-   returns anything.
+2. **Recent repo-member PR handoff comment** — if a repo member says
+   they are handling the issue in a specific PR, silent-defer only
+   when the duplicate/open-PR gate above did not already require a
+   `Blocked-on` or `Fold candidate` audit comment.
 3. **Recent repo-member comment** — any comment from
    `OWNER | MEMBER | COLLABORATOR` (non-bot) in the last 7 days.
    Exception: that comment explicitly asks for triage help —
@@ -182,7 +217,7 @@ Skip auto-PR for:
 
 These proceed to relevance check, then to the **Defer** outcome
 (typically the *Fold candidate* or *Blocked-on* flavor — see
-outcome 4 above) rather than Execute.
+outcome 5 above) rather than Ready to implement or Execute.
 
 ### Step 2 — Relevance check: in-cycle?
 
@@ -273,9 +308,9 @@ If a material dimension is missing, loop back to the relevant expert.
 
 ### Step 6 — Comment (only when it adds signal)
 
-Post when outcome is Clarify, Flag, Execute-PR, or Defer-on-
-NONE/FIRST_TIME author. **Silent** when outcome is Defer and author
-is MEMBER/COLLABORATOR/OWNER.
+Post when outcome is Clarify, Flag, Ready to implement, Execute-PR,
+or Defer-on-NONE/FIRST_TIME author. **Silent** when outcome is Defer
+and author is MEMBER/COLLABORATOR/OWNER.
 
 Format (≤1500 chars total, prose ≤4 sentences):
 
@@ -284,7 +319,7 @@ Format (≤1500 chars total, prose ≤4 sentences):
 
 **Classification:** <type>
 **Bucket(s):** <comma-separated; omit if no clear match>
-**Status:** <clarify / ready-for-human / drafting-pr / deferred / not-actionable>
+**Status:** <clarify / ready-for-human / ready-to-implement / drafting-pr / deferred / not-actionable>
 **Milestone:** <title (#N), or omit on RFC/epic/deferred>
 
 **What the experts said:**
@@ -294,6 +329,8 @@ Format (≤1500 chars total, prose ≤4 sentences):
 **My take:** <≤2 sentences — synthesis + ask if flagging>
 
 <If clarify: 1–3 concrete questions. Never "what's your use case".>
+<If ready-to-implement: 2–4 bullets covering implementation scope,
+ likely files, required checks, and non-breaking rationale.>
 <If drafting-pr: one-line PR summary.>
 
 ---
@@ -312,9 +349,9 @@ version, a linked PR is already milestoned, or a version-shaped
 label is present. Otherwise omit. Never infer from vibes. Never
 create new milestones.
 
-## Non-breaking vs. breaking — the central question for Execute
+## Non-breaking vs. breaking — the central question for Ready/Execute
 
-**Non-breaking — Execute:**
+**Non-breaking — Ready/Execute eligible:**
 
 - Adding new optional params, methods, or convenience APIs
 - Adding new examples, docs, TypeDoc annotations
@@ -334,15 +371,17 @@ If unsure whether a change is breaking, search for the identifier
 in `docs/llms.txt` + `docs/TYPE-SUMMARY.md`. If it's in the public
 surface, treat as breaking.
 
-## PR criteria — execute when the outcome is clear
+## PR criteria — opt-in or low-entropy only
 
-All must be true:
+Open a draft PR only when both sections pass.
+
+### Execution safety gate
 
 - Experts converge on "ship it" — no material disagreement
 - Change is **non-breaking** (definition above)
 - Not security-sensitive (always Flag)
 - Not RFC / epic / tracking / child-of-open-parent / deferred
-- Duplicate + open-PR checks clean
+- Duplicate + open-PR gate is clean
 - Success is testable (or change is docs-only)
 - No edits to generated files:
   - `src/lib/types/*.generated.ts`
@@ -350,22 +389,37 @@ All must be true:
   - `schemas/` (sync from adcp spec instead)
 - A changeset accompanies the change (`npx changeset`)
 
-**Scope is NOT a gate.** **Author is NOT a gate.** A 200-line
-non-breaking API addition ships as a draft PR same as a 10-line
-typo fix. CODEOWNERS + human review gate the merge.
+### PR authorization gate
 
-**When in doubt: Execute.**
+At least one of these must also be true:
 
-**When in doubt: Execute.**
+- A repo member explicitly used `/triage execute`.
+- The issue already has an exact `auto-pr-ok` label returned by
+  `gh label list`.
+- The change is a narrow low-entropy fix:
+  - typo, grammar, broken link, dead reference, or wrong file path in
+    docs/examples
+  - example correction where the existing source proves the exact
+    right answer
+  - small test fixture/expectation update for existing behavior, with
+    no product/protocol judgment
+
+If the safety gate passes but the authorization gate does not, choose
+**Ready to implement**. Post the implementation brief and stop before
+creating a branch, editing files, running expensive build gates, or
+opening a PR.
+
+**When in doubt: Ready to implement.**
 
 ## Bundling and epic handling — never split issues into issues
 
 When an issue contains multiple items — a follow-up list, a list of
 related fixes, or "items 1-5 after PR #N" — decide:
 
-1. **Ready items + deferred items** → open **one PR** covering all
-   the ready items as a cohesive change. Leave the parent issue
-   open. Comment on the parent with what shipped and what remains.
+1. **Ready items + deferred items** → produce one cohesive Ready to
+   implement brief covering all ready items, or open **one PR** only
+   if the PR authorization gate passes. Leave the parent issue open.
+   Comment on the parent with what is ready/shipped and what remains.
    Do **not** split the parent into child issues.
 2. **Parent is truly epic-shaped** (multi-week, cross-cutting) →
    flag-for-review with `Status: ready-for-human`, recommend
@@ -373,8 +427,9 @@ related fixes, or "items 1-5 after PR #N" — decide:
    you never create peer issues.
 3. **Never create peer issues autonomously.**
 
-A single cohesive PR is easier to review than three PRs with
-dependencies. The bot reduces maintainer clicks, not multiplies them.
+A single cohesive implementation brief or authorized PR is easier to
+act on than three PRs with dependencies. The bot reduces maintainer
+clicks, not multiplies them.
 
 ### Linkage rule for partial-rollout PRs
 
@@ -392,11 +447,16 @@ listing what shipped and what remains, so a future triage sweep can
 find queued work. `Closes` here would be a quiet bug — the issue
 auto-closes on merge and remaining items lose their tracking surface.
 
-## Pre-PR build + test gate — mandatory before expert review
+## Pre-PR build + test gate — only after Execute is authorized
 
-The expert review is expensive; don't run it on broken code. Before
-spawning experts, make sure the diff actually compiles and the
-unit tests pass.
+This section applies only after the PR criteria above choose
+**Execute PR**. Do not run build/test cycles for Ready to implement;
+the point of that outcome is to avoid spending implementation tokens
+until a human or label authorizes the work.
+
+The pre-PR expert review is expensive; don't run it on broken code.
+Before spawning pre-PR reviewers, make sure the diff actually compiles
+and the unit tests pass.
 
 1. Run the repo's build + fast test tier (see PR constraints below
    for exact commands). If the diff only touches docs/markdown, skip
@@ -473,8 +533,9 @@ have read the diff before a human reviewer does.
     >
     > - **Push fixup commits directly:** `gh pr checkout <num>` →
     >   fix → push.
-    > - **Or re-trigger:** comment `/triage execute` on the source
-    >   issue.
+    > - **Or request a new first draft PR:** comment `/triage execute`
+    >   on the source issue only when no triage-managed PR is already
+    >   open. Triage does not update existing PRs.
     >
     > See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
     > for context.
@@ -517,9 +578,11 @@ the original `<<<UNTRUSTED_ISSUE_BODY>>>`.
    relevant experts; reply with the new conclusion (even if "no
    change, here's why").
 4. If substantive and **unlocks a stuck Clarify**: move forward
-   per outcome rules.
-5. If substantive but the issue is in a final state (PR drafted,
-   deferred with linkage, flagged): **silent by default.** A
+   per outcome rules — Ready to implement, Execute PR if authorized,
+   or Flag-for-review.
+5. If substantive but the issue is in a final state (implementation
+   brief posted, PR drafted, deferred with linkage, flagged):
+   **silent by default.** A
    read-receipt is noise — the issue's state already reflects the
    prior decision. Comment **only** when the new info would
    materially change the disposition (invalidates the prior defer,
@@ -560,4 +623,5 @@ bucket + `Status: ready-for-human`) and **do not apply
 ## When stuck
 
 Comment with `Status: ready-for-human`, summarize experts, list
-unresolved questions. That's a useful outcome.
+unresolved questions. That's a useful outcome; don't force another
+outcome.

--- a/.agents/scripts/triage-local.sh
+++ b/.agents/scripts/triage-local.sh
@@ -9,7 +9,7 @@
 #
 # Examples:
 #   .agents/scripts/triage-local.sh 3112              # fresh triage
-#   .agents/scripts/triage-local.sh 3112 execute      # bias toward Execute
+#   .agents/scripts/triage-local.sh 3112 execute      # authorize draft PR if safe
 #   .agents/scripts/triage-local.sh 3112 clarify      # force clarify
 #
 # Required env vars (or .env file in the cwd):
@@ -74,7 +74,7 @@ if [ -n "$MODIFIER" ]; then
       exit 64
       ;;
   esac
-  nudge="MANUAL NUDGE: triage-local.sh requested triage with /$MODIFIER. Treat as an explicit request; skip already-engaged check. Honor the modifier (execute / clarify / defer)."
+  nudge="MANUAL NUDGE: triage-local.sh requested triage with /$MODIFIER. Treat as an explicit request; skip already-engaged check. Honor the modifier (execute authorizes a first draft PR only if all Execute safety checks pass; clarify / defer force those outcomes)."
   kind="manual"
   action="triage"
 else

--- a/.changeset/triage-agent-routing-briefs.md
+++ b/.changeset/triage-agent-routing-briefs.md
@@ -1,0 +1,4 @@
+---
+---
+
+Update issue triage routing so clear work defaults to implementation briefs and PR creation is explicitly gated.


### PR DESCRIPTION
## Summary

- default issue triage to `ready-to-implement` briefs instead of drafting PRs for every clear non-breaking issue
- make `/triage execute` authorize only a first draft PR when safety gates pass
- add duplicate/open-PR gating for manual nudges while preserving client-specific triage constraints

## Validation

- `git diff --check`
- `bash -n .agents/scripts/triage-local.sh`
