### PR TITLE
fix: type server handlers as payloads

### DIFF
--- a/.changeset/server-handler-payload-types.md
+++ b/.changeset/server-handler-payload-types.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Type server/platform handler returns as domain payloads rather than requiring protocol task-envelope fields from generated wire response types. The SDK continues to stamp envelope fields such as `status: "completed"` at dispatch time, and exports `ServerPayload<T>` for adopters that want explicit payload return annotations.

--- a/examples/hello_seller_adapter_guaranteed.ts
+++ b/examples/hello_seller_adapter_guaranteed.ts
@@ -72,6 +72,9 @@ import {
   type DecisioningPlatform,
   type SalesCorePlatform,
   type SalesIngestionPlatform,
+  type GetProductsPayload,
+  type GetMediaBuyDeliveryPayload,
+  type GetMediaBuysPayload,
   type AccountStore,
   type Account,
   type SyncCreativesRow,
@@ -86,9 +89,7 @@ import type {
   UpdateMediaBuyRequest,
   UpdateMediaBuySuccess,
   GetMediaBuysRequest,
-  GetMediaBuysResponse,
   GetMediaBuyDeliveryRequest,
-  GetMediaBuyDeliveryResponse,
 } from '@adcp/sdk/types';
 
 // `Product` isn't re-exported from `@adcp/sdk/types` (#1254 in the rollup);
@@ -730,7 +731,7 @@ class SalesGuaranteedAdapter implements DecisioningPlatform<Record<string, never
   // level. See `decisioning.type-checks.ts` for the regression-locked
   // patterns.
   sales: SalesCorePlatform<NetworkMeta> & SalesIngestionPlatform<NetworkMeta> = {
-    getProducts: async (req: GetProductsRequest, ctx): Promise<GetProductsResponse> => {
+    getProducts: async (req: GetProductsRequest, ctx): Promise<GetProductsPayload> => {
       const networkCode = ctx.account.ctx_metadata.network_code;
       const publisherDomain = ctx.account.ctx_metadata.publisher_domain;
       // Storyboard sends buying_mode: 'brief' with a free-text brief —
@@ -753,7 +754,6 @@ class SalesGuaranteedAdapter implements DecisioningPlatform<Record<string, never
         ...(briefBudget !== undefined && { budget: briefBudget }),
       });
       return {
-        status: 'completed',
         products: guaranteed.map(p => projectProduct(p, publisherDomain)),
         cache_scope: 'account',
       };
@@ -1019,7 +1019,7 @@ class SalesGuaranteedAdapter implements DecisioningPlatform<Record<string, never
       };
     },
 
-    getMediaBuys: async (req: GetMediaBuysRequest, ctx): Promise<GetMediaBuysResponse> => {
+    getMediaBuys: async (req: GetMediaBuysRequest, ctx): Promise<GetMediaBuysPayload> => {
       const networkCode = ctx.account.ctx_metadata.network_code;
       const orders = await upstream.listOrders(networkCode);
       const filtered = req.media_buy_ids ? orders.filter(o => req.media_buy_ids!.includes(o.order_id)) : orders;
@@ -1049,7 +1049,7 @@ class SalesGuaranteedAdapter implements DecisioningPlatform<Record<string, never
           };
         })
       );
-      return { status: 'completed', media_buys: buys };
+      return { media_buys: buys };
     },
 
     syncCreatives: async (creatives, ctx): Promise<SyncCreativesRow[]> => {
@@ -1090,7 +1090,7 @@ class SalesGuaranteedAdapter implements DecisioningPlatform<Record<string, never
       return rows;
     },
 
-    getMediaBuyDelivery: async (req: GetMediaBuyDeliveryRequest, ctx): Promise<GetMediaBuyDeliveryResponse> => {
+    getMediaBuyDelivery: async (req: GetMediaBuyDeliveryRequest, ctx): Promise<GetMediaBuyDeliveryPayload> => {
       const networkCode = ctx.account.ctx_metadata.network_code;
       const ids = req.media_buy_ids ?? [];
       const deliveries = await Promise.all(ids.map(id => upstream.getDelivery(networkCode, id)));
@@ -1111,7 +1111,6 @@ class SalesGuaranteedAdapter implements DecisioningPlatform<Record<string, never
       const aggregateClicks = present.reduce((s, d) => s + d.totals.clicks, 0);
 
       return {
-        status: 'completed',
         reporting_period: { start: earliest, end: latest },
         currency,
         aggregated_totals: {

--- a/examples/hello_seller_adapter_non_guaranteed.ts
+++ b/examples/hello_seller_adapter_non_guaranteed.ts
@@ -66,6 +66,10 @@ import {
   type DecisioningPlatform,
   type SalesCorePlatform,
   type SalesIngestionPlatform,
+  type GetProductsPayload,
+  type GetMediaBuyDeliveryPayload,
+  type GetMediaBuysPayload,
+  type ListCreativeFormatsPayload,
   type AccountStore,
   type Account,
   type AdcpMediaBuyStatus,
@@ -81,10 +85,7 @@ import type {
   UpdateMediaBuyRequest,
   UpdateMediaBuySuccess,
   GetMediaBuysRequest,
-  GetMediaBuysResponse,
   GetMediaBuyDeliveryRequest,
-  GetMediaBuyDeliveryResponse,
-  ListCreativeFormatsResponse,
 } from '@adcp/sdk/types';
 
 // `Product` isn't re-exported from `@adcp/sdk/types`; derive from response.
@@ -580,7 +581,7 @@ class SalesNonGuaranteedAdapter implements DecisioningPlatform<Record<string, ne
   // all-optional and `RequiredPlatformsFor<'sales-non-guaranteed'>` requires
   // the closed shape on the way out.
   sales: SalesCorePlatform<NetworkMeta> & SalesIngestionPlatform<NetworkMeta> = {
-    getProducts: async (req: GetProductsRequest, ctx): Promise<GetProductsResponse> => {
+    getProducts: async (req: GetProductsRequest, ctx): Promise<GetProductsPayload> => {
       const networkCode = ctx.account.ctx_metadata.network_code;
       const publisherDomain = ctx.account.ctx_metadata.publisher_domain;
       // When the buyer provides structured filters (flight dates, budget),
@@ -594,7 +595,6 @@ class SalesNonGuaranteedAdapter implements DecisioningPlatform<Record<string, ne
         ...(briefBudget !== undefined && { budget: briefBudget }),
       });
       return {
-        status: 'completed',
         products: products.map(p => projectProduct(p, publisherDomain)),
         cache_scope: 'account',
       };
@@ -790,7 +790,7 @@ class SalesNonGuaranteedAdapter implements DecisioningPlatform<Record<string, ne
       };
     },
 
-    getMediaBuyDelivery: async (req: GetMediaBuyDeliveryRequest, ctx): Promise<GetMediaBuyDeliveryResponse> => {
+    getMediaBuyDelivery: async (req: GetMediaBuyDeliveryRequest, ctx): Promise<GetMediaBuyDeliveryPayload> => {
       const networkCode = ctx.account.ctx_metadata.network_code;
       const requestedIds = req.media_buy_ids ?? [];
       // Multi-id pass-through per #1342 contract — fan out per id; framework
@@ -828,8 +828,7 @@ class SalesNonGuaranteedAdapter implements DecisioningPlatform<Record<string, ne
           `[sales-non-guaranteed] get_media_buy_delivery: ${missing.length} unknown media_buy_id(s) returned no delivery rows: ${missing.join(', ')}`
         );
       }
-      const response: GetMediaBuyDeliveryResponse = {
-        status: 'completed',
+      const response: GetMediaBuyDeliveryPayload = {
         currency: filtered[0]?.currency ?? 'USD',
         reporting_period: {
           start: filtered[0]?.reporting_period.start ?? new Date().toISOString(),
@@ -858,7 +857,7 @@ class SalesNonGuaranteedAdapter implements DecisioningPlatform<Record<string, ne
       return response;
     },
 
-    getMediaBuys: async (req: GetMediaBuysRequest, ctx): Promise<GetMediaBuysResponse> => {
+    getMediaBuys: async (req: GetMediaBuysRequest, ctx): Promise<GetMediaBuysPayload> => {
       const networkCode = ctx.account.ctx_metadata.network_code;
       const requestedIds = req.media_buy_ids ?? [];
       let orders: UpstreamOrder[];
@@ -896,7 +895,7 @@ class SalesNonGuaranteedAdapter implements DecisioningPlatform<Record<string, ne
           };
         })
       );
-      const response: GetMediaBuysResponse = { status: 'completed', media_buys };
+      const response: GetMediaBuysPayload = { media_buys };
       return response;
     },
 
@@ -943,7 +942,7 @@ class SalesNonGuaranteedAdapter implements DecisioningPlatform<Record<string, ne
       return out;
     },
 
-    listCreativeFormats: async (_req, _ctx): Promise<ListCreativeFormatsResponse> => {
+    listCreativeFormats: async (_req, _ctx): Promise<ListCreativeFormatsPayload> => {
       // Publisher-owned format catalog. The mock doesn't have a discrete
       // formats endpoint (formats live inline on Product); production sellers
       // typically expose `/v1/formats` separately. SWAP: replace with your
@@ -964,7 +963,6 @@ class SalesNonGuaranteedAdapter implements DecisioningPlatform<Record<string, ne
         FormatAsset.url({ asset_id: 'click_url', required: true }),
       ];
       return {
-        status: 'completed',
         formats: [
           {
             format_id: { agent_url: FORMAT_AGENT_URL, id: 'display_300x250' },

--- a/scripts/check-adopter-types.ts
+++ b/scripts/check-adopter-types.ts
@@ -32,8 +32,8 @@ const REPO_ROOT = join(__dirname, '..');
 const ADOPTER_TSCONFIG = {
   compilerOptions: {
     target: 'ES2022',
-    module: 'commonjs',
-    moduleResolution: 'node',
+    module: 'ESNext',
+    moduleResolution: 'bundler',
     esModuleInterop: true,
     strict: true,
     skipLibCheck: false,
@@ -45,20 +45,105 @@ const ADOPTER_TSCONFIG = {
 };
 
 const ADOPTER_SOURCE = `
-// Mirrors the repro from issue #1236 — minimal adopter import via the
-// subpaths that produced TS2304 leaks (\`stripInternal\` deleted the
-// declaration but consumers kept referencing it). Narrow on purpose:
-// pulling \`@adcp/sdk/server\`'s full transitive surface drags in
-// peerDependency type errors (express, @opentelemetry/api) that are
-// orthogonal to this guard's scope. Widen when those are addressed.
-import type { AdcpServer } from '@adcp/sdk/server';
+// Mirrors the repro from issue #1236 and locks the server-side handler
+// payload typing surface that adopters consume from a packed SDK tarball.
+import type {
+  AdcpServer,
+  CheckGovernancePayload,
+  CreatePropertyListPayload,
+  ListContentStandardsPayload,
+  OperationalContext,
+  OperationalPlatform,
+  SalesCorePlatform,
+  SalesIngestionPlatform,
+  ServerPayload,
+  SIGetOfferingPayload,
+} from '@adcp/sdk/server';
+import { createAdcpServerFromPlatform, defineOperationalPlatform } from '@adcp/sdk/server';
+import { createAdcpServer as createLegacyAdcpServer } from '@adcp/sdk/server/legacy/v5';
 import { createSingleAgentClient, extractAdcpErrorFromMcp, extractAdcpErrorFromTransport } from '@adcp/sdk';
+import type { CreateMediaBuySuccess, ServerPayload as ServerPayloadFromTypes } from '@adcp/sdk/types';
 
 declare const _server: AdcpServer;
 void _server;
 void createSingleAgentClient;
 void extractAdcpErrorFromMcp;
 void extractAdcpErrorFromTransport;
+void createAdcpServerFromPlatform;
+
+const _legacyServer = createLegacyAdcpServer({
+  name: 'packed-adopter',
+  version: '1.0.0',
+  mediaBuy: {
+    getProducts: async () => ({ products: [], cache_scope: 'account' }),
+    createMediaBuy: async () => ({ media_buy_id: 'mb_1', packages: [] }),
+    getMediaBuys: async () => ({ media_buys: [] }),
+    getMediaBuyDelivery: async () => ({
+      reporting_period: { start: '2026-01-01', end: '2026-01-31' },
+      media_buy_deliveries: [],
+    }),
+  },
+});
+void _legacyServer;
+
+const _sales: SalesCorePlatform & SalesIngestionPlatform = {
+  getProducts: async () => ({ products: [], cache_scope: 'account' }),
+  createMediaBuy: async () => ({ media_buy_id: 'mb_1', packages: [] }),
+  updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
+  getMediaBuys: async () => ({ media_buys: [] }),
+  getMediaBuyDelivery: async () => ({
+    reporting_period: { start: '2026-01-01', end: '2026-01-31' },
+    media_buy_deliveries: [],
+  }),
+  syncCreatives: async () => [],
+};
+void _sales;
+
+interface OpsCtx extends OperationalContext {
+  advertiserId: string;
+}
+
+const _ops: OperationalPlatform<OpsCtx> = defineOperationalPlatform<OpsCtx>({
+  platformId: 'packed-adopter',
+  extractContext: async () => ({ accessToken: undefined, advertiserId: 'adv_1' }),
+  updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
+  getMediaBuyDelivery: async () => ({
+    reporting_period: { start: '2026-01-01', end: '2026-01-31' },
+    media_buy_deliveries: [],
+  }),
+  getProducts: async () => ({ products: [], cache_scope: 'account' }),
+});
+void _ops;
+
+const _checkGovernancePayload: CheckGovernancePayload = {
+  check_id: 'check_1',
+  verdict: 'approved',
+  plan_id: 'plan_1',
+  explanation: 'Approved',
+  governance_context: 'gc_123',
+};
+const _propertyListPayload: CreatePropertyListPayload = {
+  list: { list_id: 'list_1', name: 'Test list' },
+  auth_token: 'token_1',
+};
+const _contentStandardsPayload: ListContentStandardsPayload = { standards: [] };
+const _siPayload: SIGetOfferingPayload = { available: true };
+void _checkGovernancePayload;
+void _propertyListPayload;
+void _contentStandardsPayload;
+void _siPayload;
+
+const _serverPayload: ServerPayload<CreateMediaBuySuccess> = {
+  media_buy_id: 'mb_1',
+  packages: [],
+  status: 'active',
+};
+const _typesPayload: ServerPayloadFromTypes<CreateMediaBuySuccess> = _serverPayload;
+void _typesPayload;
+
+// @ts-expect-error ServerPayload must preserve required domain fields.
+const _missingRequiredDomainField: ServerPayload<CreateMediaBuySuccess> = { packages: [] };
+void _missingRequiredDomainField;
 `;
 
 function run(cmd: string, args: string[], cwd: string, env?: NodeJS.ProcessEnv): void {

--- a/scripts/schemas-ensure.ts
+++ b/scripts/schemas-ensure.ts
@@ -27,9 +27,11 @@ const CACHE_ROOT = path.join(REPO_ROOT, 'schemas/cache');
 function hasV3Cache(): boolean {
   if (!existsSync(CACHE_ROOT)) return false;
   // Any `<major>.<minor>.<patch>` directory under cache satisfies the v3
-  // bundle — `sync-schemas` writes the exact upstream version, currently
-  // 3.0.1, but pin updates land here without needing a script change.
-  return readdirSync(CACHE_ROOT, { withFileTypes: true }).some(e => e.isDirectory() && /^\d+\.\d+\.\d+$/.test(e.name));
+  // bundle. Pre-release pins such as `3.1.0-beta.3` are valid while the SDK
+  // tracks protocol beta bundles, so accept full semver directory names.
+  return readdirSync(CACHE_ROOT, { withFileTypes: true }).some(
+    e => e.isDirectory() && /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(e.name)
+  );
 }
 
 function hasV25Cache(): boolean {

--- a/src/lib/server/adcp-server.type-checks.ts
+++ b/src/lib/server/adcp-server.type-checks.ts
@@ -6,6 +6,7 @@
 // Run with `npm run typecheck`.
 
 import type { AdcpServer } from './adcp-server';
+import type { MediaBuyHandlers } from './create-adcp-server';
 
 // ── Plain object with same structural shape isn't an AdcpServer ──────────
 
@@ -44,8 +45,20 @@ async function _adcpServerCallSitesStillWork(s: AdcpServer): Promise<void> {
   });
 }
 
+function _legacy_media_buy_handlers_accept_payload_returns(): MediaBuyHandlers {
+  return {
+    getProducts: async () => ({ products: [], cache_scope: 'account' }),
+    getMediaBuys: async () => ({ media_buys: [] }),
+    getMediaBuyDelivery: async () => ({
+      reporting_period: { start: '2026-01-01', end: '2026-01-31' },
+      media_buy_deliveries: [],
+    }),
+  };
+}
+
 export const _references = [
   _imitationCannotBeAdcpServer,
   _registerToolNotOnAdcpServer,
   _adcpServerCallSitesStillWork,
+  _legacy_media_buy_handlers_accept_payload_returns,
 ] as const;

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -310,6 +310,7 @@ import type {
 
 import type { AdcpProtocol, MediaBuyFeatures, AccountCapabilities, CreativeCapabilities } from '../utils/capabilities';
 import type { MediaChannel } from '../types/tools.generated';
+import type { ServerPayload } from '../types/server-payload';
 import {
   MEDIA_BUY_TOOLS,
   SIGNALS_TOOLS,
@@ -505,268 +506,271 @@ export function requireSessionKey<TAccount = unknown>(ctx: HandlerContext<TAccou
 export interface AdcpToolMap {
   get_products: {
     params: z.input<typeof GetProductsRequestSchema>;
-    result: GetProductsResponse;
+    result: ServerPayload<GetProductsResponse>;
     response: GetProductsResponse;
   };
   create_media_buy: {
     params: z.input<typeof CreateMediaBuyRequestSchema>;
-    result: CreateMediaBuySuccess;
+    result: ServerPayload<CreateMediaBuySuccess>;
     response: CreateMediaBuyResponse;
   };
   update_media_buy: {
     params: z.input<typeof UpdateMediaBuyRequestSchema>;
-    result: UpdateMediaBuySuccess;
+    result: ServerPayload<UpdateMediaBuySuccess>;
     response: UpdateMediaBuyResponse;
   };
   get_media_buys: {
     params: z.input<typeof GetMediaBuysRequestSchema>;
-    result: GetMediaBuysResponse;
+    result: ServerPayload<GetMediaBuysResponse>;
     response: GetMediaBuysResponse;
   };
   get_media_buy_delivery: {
     params: z.input<typeof GetMediaBuyDeliveryRequestSchema>;
-    result: GetMediaBuyDeliveryResponse;
+    result: ServerPayload<GetMediaBuyDeliveryResponse>;
     response: GetMediaBuyDeliveryResponse;
   };
   provide_performance_feedback: {
     params: z.input<typeof ProvidePerformanceFeedbackRequestSchema>;
-    result: ProvidePerformanceFeedbackSuccess;
+    result: ServerPayload<ProvidePerformanceFeedbackSuccess>;
     response: ProvidePerformanceFeedbackResponse;
   };
   list_creative_formats: {
     params: z.input<typeof ListCreativeFormatsRequestSchema>;
-    result: ListCreativeFormatsResponse;
+    result: ServerPayload<ListCreativeFormatsResponse>;
     response: ListCreativeFormatsResponse;
   };
   build_creative: {
     params: z.input<typeof BuildCreativeRequestSchema>;
-    result: BuildCreativeSuccess | BuildCreativeMultiSuccess;
+    result: ServerPayload<BuildCreativeSuccess> | ServerPayload<BuildCreativeMultiSuccess>;
     response: BuildCreativeResponse;
   };
   preview_creative: {
     params: z.input<typeof PreviewCreativeRequestSchema>;
-    result: PreviewCreativeResponse;
+    result: ServerPayload<PreviewCreativeResponse>;
     response: PreviewCreativeResponse;
   };
   get_creative_delivery: {
     params: z.input<typeof GetCreativeDeliveryRequestSchema>;
-    result: GetCreativeDeliveryResponse;
+    result: ServerPayload<GetCreativeDeliveryResponse>;
     response: GetCreativeDeliveryResponse;
   };
   list_creatives: {
     params: z.input<typeof ListCreativesRequestSchema>;
-    result: ListCreativesResponse;
+    result: ServerPayload<ListCreativesResponse>;
     response: ListCreativesResponse;
   };
   sync_creatives: {
     params: z.input<typeof SyncCreativesRequestSchema>;
-    result: SyncCreativesSuccess;
+    result: ServerPayload<SyncCreativesSuccess>;
     response: SyncCreativesResponse;
   };
   get_signals: {
     params: z.input<typeof GetSignalsRequestSchema>;
-    result: GetSignalsResponse;
+    result: ServerPayload<GetSignalsResponse>;
     response: GetSignalsResponse;
   };
   activate_signal: {
     params: z.input<typeof ActivateSignalRequestSchema>;
-    result: ActivateSignalSuccess;
+    result: ServerPayload<ActivateSignalSuccess>;
     response: ActivateSignalResponse;
   };
   list_accounts: {
     params: z.input<typeof ListAccountsRequestSchema>;
-    result: ListAccountsResponse;
+    result: ServerPayload<ListAccountsResponse>;
     response: ListAccountsResponse;
   };
   sync_accounts: {
     params: z.input<typeof SyncAccountsRequestSchema>;
-    result: SyncAccountsSuccess;
+    result: ServerPayload<SyncAccountsSuccess>;
     response: SyncAccountsResponse;
   };
   sync_governance: {
     params: z.input<typeof SyncGovernanceRequestSchema>;
-    result: SyncGovernanceSuccess;
+    result: ServerPayload<SyncGovernanceSuccess>;
     response: SyncGovernanceResponse;
   };
   get_account_financials: {
     params: z.input<typeof GetAccountFinancialsRequestSchema>;
-    result: GetAccountFinancialsSuccess;
+    result: ServerPayload<GetAccountFinancialsSuccess>;
     response: GetAccountFinancialsResponse;
   };
   report_usage: {
     params: z.input<typeof ReportUsageRequestSchema>;
-    result: ReportUsageResponse;
+    result: ServerPayload<ReportUsageResponse>;
     response: ReportUsageResponse;
   };
   sync_event_sources: {
     params: z.input<typeof SyncEventSourcesRequestSchema>;
-    result: SyncEventSourcesSuccess;
+    result: ServerPayload<SyncEventSourcesSuccess>;
     response: SyncEventSourcesResponse;
   };
   log_event: {
     params: z.input<typeof LogEventRequestSchema>;
-    result: LogEventSuccess;
+    result: ServerPayload<LogEventSuccess>;
     response: LogEventResponse;
   };
   sync_audiences: {
     params: z.input<typeof SyncAudiencesRequestSchema>;
-    result: SyncAudiencesSuccess;
+    result: ServerPayload<SyncAudiencesSuccess>;
     response: SyncAudiencesResponse;
   };
   sync_catalogs: {
     params: z.input<typeof SyncCatalogsRequestSchema>;
-    result: SyncCatalogsSuccess;
+    result: ServerPayload<SyncCatalogsSuccess>;
     response: SyncCatalogsResponse;
   };
   create_property_list: {
     params: z.input<typeof CreatePropertyListRequestSchema>;
-    result: CreatePropertyListResponse;
+    result: ServerPayload<CreatePropertyListResponse>;
     response: CreatePropertyListResponse;
   };
   update_property_list: {
     params: z.input<typeof UpdatePropertyListRequestSchema>;
-    result: UpdatePropertyListResponse;
+    result: ServerPayload<UpdatePropertyListResponse>;
     response: UpdatePropertyListResponse;
   };
   get_property_list: {
     params: z.input<typeof GetPropertyListRequestSchema>;
-    result: GetPropertyListResponse;
+    result: ServerPayload<GetPropertyListResponse>;
     response: GetPropertyListResponse;
   };
   list_property_lists: {
     params: z.input<typeof ListPropertyListsRequestSchema>;
-    result: ListPropertyListsResponse;
+    result: ServerPayload<ListPropertyListsResponse>;
     response: ListPropertyListsResponse;
   };
   delete_property_list: {
     params: z.input<typeof DeletePropertyListRequestSchema>;
-    result: DeletePropertyListResponse;
+    result: ServerPayload<DeletePropertyListResponse>;
     response: DeletePropertyListResponse;
   };
   create_collection_list: {
     params: z.input<typeof CreateCollectionListRequestSchema>;
-    result: CreateCollectionListResponse;
+    result: ServerPayload<CreateCollectionListResponse>;
     response: CreateCollectionListResponse;
   };
   update_collection_list: {
     params: z.input<typeof UpdateCollectionListRequestSchema>;
-    result: UpdateCollectionListResponse;
+    result: ServerPayload<UpdateCollectionListResponse>;
     response: UpdateCollectionListResponse;
   };
   get_collection_list: {
     params: z.input<typeof GetCollectionListRequestSchema>;
-    result: GetCollectionListResponse;
+    result: ServerPayload<GetCollectionListResponse>;
     response: GetCollectionListResponse;
   };
   list_collection_lists: {
     params: z.input<typeof ListCollectionListsRequestSchema>;
-    result: ListCollectionListsResponse;
+    result: ServerPayload<ListCollectionListsResponse>;
     response: ListCollectionListsResponse;
   };
   delete_collection_list: {
     params: z.input<typeof DeleteCollectionListRequestSchema>;
-    result: DeleteCollectionListResponse;
+    result: ServerPayload<DeleteCollectionListResponse>;
     response: DeleteCollectionListResponse;
   };
   list_content_standards: {
     params: z.input<typeof ListContentStandardsRequestSchema>;
-    result: ListContentStandardsResponse;
+    result: ServerPayload<ListContentStandardsResponse>;
     response: ListContentStandardsResponse;
   };
   get_content_standards: {
     params: z.input<typeof GetContentStandardsRequestSchema>;
-    result: GetContentStandardsResponse;
+    result: ServerPayload<GetContentStandardsResponse>;
     response: GetContentStandardsResponse;
   };
   create_content_standards: {
     params: z.input<typeof CreateContentStandardsRequestSchema>;
-    result: CreateContentStandardsResponse;
+    result: ServerPayload<CreateContentStandardsResponse>;
     response: CreateContentStandardsResponse;
   };
   update_content_standards: {
     params: z.input<typeof UpdateContentStandardsRequestSchema>;
-    result: UpdateContentStandardsResponse;
+    result: ServerPayload<UpdateContentStandardsResponse>;
     response: UpdateContentStandardsResponse;
   };
   calibrate_content: {
     params: z.input<typeof CalibrateContentRequestSchema>;
-    result: CalibrateContentResponse;
+    result: ServerPayload<CalibrateContentResponse>;
     response: CalibrateContentResponse;
   };
   validate_content_delivery: {
     params: z.input<typeof ValidateContentDeliveryRequestSchema>;
-    result: ValidateContentDeliveryResponse;
+    result: ServerPayload<ValidateContentDeliveryResponse>;
     response: ValidateContentDeliveryResponse;
   };
   get_media_buy_artifacts: {
     params: z.input<typeof GetMediaBuyArtifactsRequestSchema>;
-    result: GetMediaBuyArtifactsResponse;
+    result: ServerPayload<GetMediaBuyArtifactsResponse>;
     response: GetMediaBuyArtifactsResponse;
   };
   get_creative_features: {
     params: z.input<typeof GetCreativeFeaturesRequestSchema>;
-    result: GetCreativeFeaturesResponse;
+    result: ServerPayload<GetCreativeFeaturesResponse>;
     response: GetCreativeFeaturesResponse;
   };
   sync_plans: {
     params: z.input<typeof SyncPlansRequestSchema>;
-    result: SyncPlansResponse;
+    result: ServerPayload<SyncPlansResponse>;
     response: SyncPlansResponse;
   };
   check_governance: {
     params: z.input<typeof CheckGovernanceRequestSchema>;
-    result: CheckGovernanceResponse;
+    result: ServerPayload<CheckGovernanceResponse>;
     response: CheckGovernanceResponse;
   };
   report_plan_outcome: {
     params: z.input<typeof ReportPlanOutcomeRequestSchema>;
-    result: ReportPlanOutcomeResponse;
+    result: ServerPayload<ReportPlanOutcomeResponse>;
     response: ReportPlanOutcomeResponse;
   };
   get_plan_audit_logs: {
     params: z.input<typeof GetPlanAuditLogsRequestSchema>;
-    result: GetPlanAuditLogsResponse;
+    result: ServerPayload<GetPlanAuditLogsResponse>;
     response: GetPlanAuditLogsResponse;
   };
   si_get_offering: {
     params: z.input<typeof SIGetOfferingRequestSchema>;
-    result: SIGetOfferingResponse;
+    result: ServerPayload<SIGetOfferingResponse>;
     response: SIGetOfferingResponse;
   };
   si_initiate_session: {
     params: z.input<typeof SIInitiateSessionRequestSchema>;
-    result: SIInitiateSessionResponse;
+    result: ServerPayload<SIInitiateSessionResponse>;
     response: SIInitiateSessionResponse;
   };
   si_send_message: {
     params: z.input<typeof SISendMessageRequestSchema>;
-    result: SISendMessageResponse;
+    result: ServerPayload<SISendMessageResponse>;
     response: SISendMessageResponse;
   };
   si_terminate_session: {
     params: z.input<typeof SITerminateSessionRequestSchema>;
-    result: SITerminateSessionResponse;
+    result: ServerPayload<SITerminateSessionResponse>;
     response: SITerminateSessionResponse;
   };
 
   get_brand_identity: {
     params: z.input<typeof GetBrandIdentityRequestSchema>;
-    result: GetBrandIdentitySuccess;
+    result: ServerPayload<GetBrandIdentitySuccess>;
     response: GetBrandIdentitySuccess;
   };
   get_rights: {
     params: z.input<typeof GetRightsRequestSchema>;
-    result: GetRightsSuccess;
+    result: ServerPayload<GetRightsSuccess>;
     response: GetRightsSuccess;
   };
   acquire_rights: {
     params: z.input<typeof AcquireRightsRequestSchema>;
-    result: AcquireRightsAcquired | AcquireRightsPendingApproval | AcquireRightsRejected;
+    result:
+      | ServerPayload<AcquireRightsAcquired>
+      | ServerPayload<AcquireRightsPendingApproval>
+      | ServerPayload<AcquireRightsRejected>;
     response: AcquireRightsAcquired | AcquireRightsPendingApproval | AcquireRightsRejected;
   };
   update_rights: {
     params: z.input<typeof UpdateRightsRequestSchema>;
-    result: UpdateRightsSuccess;
+    result: ServerPayload<UpdateRightsSuccess>;
     response: UpdateRightsResponse;
   };
 }
@@ -2059,9 +2063,11 @@ function resolveExtraScope(toolName: string, params: Record<string, unknown>): s
 }
 
 function genericResponse(toolName: string, data: object, summary?: string): McpToolResponse {
+  const structuredContent = { ...toStructuredContent(data) };
+  if (structuredContent.status === undefined) structuredContent.status = 'completed';
   return {
     content: [{ type: 'text', text: summary ?? `${toolName} completed` }],
-    structuredContent: toStructuredContent(data),
+    structuredContent,
   };
 }
 

--- a/src/lib/server/decisioning/account.ts
+++ b/src/lib/server/decisioning/account.ts
@@ -29,6 +29,7 @@ import type {
   GetAccountFinancialsRequest,
   GetAccountFinancialsSuccess,
 } from '../../types/tools.generated';
+import type { ServerPayload } from '../../types/server-payload';
 import type { NotificationConfig } from '../../types/v3-1-beta';
 import type { CursorPage, CursorRequest } from './pagination';
 import type { AdcpCredential, BuyerAgent } from './buyer-agent';
@@ -596,7 +597,7 @@ export interface AccountStore<TCtxMeta = Record<string, unknown>> {
    * pattern as `accounts.resolve`. Prefer `ctx.agent` for principal-keyed
    * commercial gates; see `upsert?` for the rationale.
    */
-  reportUsage?(req: ReportUsageRequest, ctx?: ResolveContext): Promise<ReportUsageResponse>;
+  reportUsage?(req: ReportUsageRequest, ctx?: ResolveContext): Promise<ServerPayload<ReportUsageResponse>>;
 
   /**
    * get_account_financials API surface. Operator-billed platforms expose

--- a/src/lib/server/decisioning/decisioning.type-checks.ts
+++ b/src/lib/server/decisioning/decisioning.type-checks.ts
@@ -23,10 +23,14 @@ import type {
   SalesPlatform,
   SalesCorePlatform,
   SalesIngestionPlatform,
+  SponsoredIntelligencePlatform,
   AudiencePlatform,
   CreateAdcpServerFromPlatformOptions,
   ComplianceTestingCapabilities,
+  ServerPayload,
+  CheckGovernancePayload,
 } from './index';
+import type { OperationalContext, OperationalPlatform } from '../operational-platform';
 import {
   AdcpError,
   AccountNotFoundError,
@@ -360,6 +364,81 @@ function _sales_guaranteed_spread_helpers_pattern() {
   return _check;
 }
 
+// Positive: platform handlers return domain payloads. The framework owns
+// protocol envelope fields such as `status: "completed"`, `timestamp`, and
+// `adcp_version`, so these payload returns must compile without status.
+function _sales_platform_payload_returns_do_not_require_protocol_status() {
+  const sales: SalesCorePlatform<_SocialMeta> & SalesIngestionPlatform<_SocialMeta> = {
+    getProducts: async () => ({ products: [], cache_scope: 'account' }),
+    createMediaBuy: async () => ({ media_buy_id: 'x', packages: [] }),
+    updateMediaBuy: async () => ({ media_buy_id: 'x' }),
+    getMediaBuyDelivery: async () => ({
+      reporting_period: { start: '2026-01-01', end: '2026-01-31' },
+      media_buy_deliveries: [],
+    }),
+    getMediaBuys: async () => ({ media_buys: [] }),
+    listCreativeFormats: async () => ({ formats: [] }),
+    syncCreatives: async () => [],
+  };
+  return sales;
+}
+
+function _server_payload_preserves_domain_status_fields(): void {
+  type CreateMediaBuySuccess = import('../../types/tools.generated').CreateMediaBuySuccess;
+  const payload: ServerPayload<CreateMediaBuySuccess> = {
+    media_buy_id: 'x',
+    packages: [],
+    status: 'active',
+  };
+  void payload;
+}
+
+function _server_payload_keeps_required_domain_fields(): void {
+  type CreateMediaBuySuccess = import('../../types/tools.generated').CreateMediaBuySuccess;
+  // @ts-expect-error — ServerPayload removes framework-owned envelope fields,
+  // but it must not make required domain fields optional.
+  const payload: ServerPayload<CreateMediaBuySuccess> = { packages: [] };
+  void payload;
+}
+
+function _server_payload_preserves_governance_context(): void {
+  const payload: CheckGovernancePayload = {
+    check_id: 'check_1',
+    verdict: 'approved',
+    plan_id: 'plan_1',
+    explanation: 'Approved',
+    governance_context: 'eyJhbGciOiJIUzI1NiJ9.test',
+  };
+  void payload;
+}
+
+function _non_sales_platform_payload_returns_do_not_require_protocol_status() {
+  const sponsoredIntelligence: SponsoredIntelligencePlatform<_SocialMeta> = {
+    getOffering: async () => ({ available: true }),
+    initiateSession: async () => ({ session_id: 'si_1', session_status: 'active' }),
+    sendMessage: async () => ({ session_id: 'si_1', session_status: 'active' }),
+    terminateSession: async () => ({ session_id: 'si_1', terminated: true }),
+  };
+  return sponsoredIntelligence;
+}
+
+interface _OperationalMeta extends OperationalContext {
+  advertiserId: string;
+}
+
+function _operational_platform_payload_returns_do_not_require_protocol_status(): OperationalPlatform<_OperationalMeta> {
+  return {
+    platformId: 'test',
+    extractContext: async () => ({ accessToken: undefined, advertiserId: 'adv_1' }),
+    updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
+    getMediaBuyDelivery: async () => ({
+      reporting_period: { start: '2026-01-01', end: '2026-01-31' },
+      media_buy_deliveries: [],
+    }),
+    getProducts: async () => ({ products: [] }),
+  };
+}
+
 // Negative: bare `defineSalesPlatform<Meta>({...})` does NOT preserve the
 // closed shape; its return type is the loose `SalesPlatform<TCtxMeta>`
 // (all-optional after #1341). Adopters claiming `sales-guaranteed` need
@@ -671,6 +750,12 @@ export const _references = [
   _define_sales_platform_identity,
   _sales_guaranteed_field_annotation_pattern,
   _sales_guaranteed_spread_helpers_pattern,
+  _sales_platform_payload_returns_do_not_require_protocol_status,
+  _server_payload_preserves_domain_status_fields,
+  _server_payload_keeps_required_domain_fields,
+  _server_payload_preserves_governance_context,
+  _non_sales_platform_payload_returns_do_not_require_protocol_status,
+  _operational_platform_payload_returns_do_not_require_protocol_status,
   _define_sales_platform_widens_post_1341,
   _define_audience_platform_identity,
   _define_audience_platform_rejects_wrong_shape,

--- a/src/lib/server/decisioning/index.ts
+++ b/src/lib/server/decisioning/index.ts
@@ -22,6 +22,7 @@
 // `*Task` method in the background.
 export { type AdcpStructuredError, type ErrorCode, AdcpError } from './async-outcome';
 export type { TaskHandoffOptions } from './async-outcome';
+export type { ServerPayload } from '../../types/server-payload';
 
 // Typed `AdcpError` subclasses — adopter convenience for the highest-traffic
 // error codes. Each class encodes the canonical code/recovery/field shape.
@@ -155,6 +156,8 @@ export type { ResolveAccountHooks, ResolveGuardOptions } from './resolve-presets
 export type {
   CreativeBuilderPlatform,
   BuildCreativeReturn,
+  PreviewCreativePayload as CreativePreviewCreativePayload,
+  ListCreativeFormatsPayload as CreativeListCreativeFormatsPayload,
   // Deprecated aliases — kept for one-release source compat. Both
   // resolve to CreativeBuilderPlatform; see specialisms/creative.ts.
   CreativeTemplatePlatform,
@@ -163,21 +166,71 @@ export type {
   SyncCreativesRow,
 } from './specialisms/creative';
 
-export type { CreativeAdServerPlatform } from './specialisms/creative-ad-server';
+export type {
+  CreativeAdServerPlatform,
+  PreviewCreativePayload as CreativeAdServerPreviewCreativePayload,
+  ListCreativeFormatsPayload as CreativeAdServerListCreativeFormatsPayload,
+  ListCreativesPayload as CreativeAdServerListCreativesPayload,
+  GetCreativeDeliveryPayload as CreativeAdServerGetCreativeDeliveryPayload,
+} from './specialisms/creative-ad-server';
 
-export type { CampaignGovernancePlatform } from './specialisms/campaign-governance';
+export type {
+  CampaignGovernancePlatform,
+  CheckGovernancePayload,
+  SyncPlansPayload,
+  ReportPlanOutcomePayload,
+  GetPlanAuditLogsPayload,
+} from './specialisms/campaign-governance';
 
-export type { ContentStandardsPlatform } from './specialisms/content-standards';
+export type {
+  ContentStandardsPlatform,
+  ListContentStandardsPayload,
+  GetContentStandardsPayload,
+  CreateContentStandardsPayload,
+  UpdateContentStandardsPayload,
+  CalibrateContentPayload,
+  ValidateContentDeliveryPayload,
+  GetMediaBuyArtifactsPayload,
+  GetCreativeFeaturesPayload,
+} from './specialisms/content-standards';
 
-export type { PropertyListsPlatform, CollectionListsPlatform } from './specialisms/lists';
+export type {
+  PropertyListsPlatform,
+  CollectionListsPlatform,
+  CreatePropertyListPayload,
+  UpdatePropertyListPayload,
+  GetPropertyListPayload,
+  ListPropertyListsPayload,
+  DeletePropertyListPayload,
+  CreateCollectionListPayload,
+  UpdateCollectionListPayload,
+  GetCollectionListPayload,
+  ListCollectionListsPayload,
+  DeleteCollectionListPayload,
+} from './specialisms/lists';
 
-export type { SalesPlatform, SalesCorePlatform, SalesIngestionPlatform } from './specialisms/sales';
+export type {
+  SalesPlatform,
+  SalesCorePlatform,
+  SalesIngestionPlatform,
+  GetProductsPayload,
+  GetMediaBuyDeliveryPayload,
+  GetMediaBuysPayload,
+  ListCreativeFormatsPayload,
+  ListCreativesPayload,
+} from './specialisms/sales';
 
 export type { AudiencePlatform, Audience, SyncAudiencesRow, AudienceStatus } from './specialisms/audiences';
 
-export type { SignalsPlatform } from './specialisms/signals';
+export type { SignalsPlatform, GetSignalsPayload } from './specialisms/signals';
 
-export type { SponsoredIntelligencePlatform } from './specialisms/sponsored-intelligence';
+export type {
+  SponsoredIntelligencePlatform,
+  SIGetOfferingPayload,
+  SIInitiateSessionPayload,
+  SISendMessagePayload,
+  SITerminateSessionPayload,
+} from './specialisms/sponsored-intelligence';
 
 export type { BrandRightsPlatform } from './specialisms/brand-rights';
 

--- a/src/lib/server/decisioning/list-helpers.ts
+++ b/src/lib/server/decisioning/list-helpers.ts
@@ -18,12 +18,13 @@
  */
 
 import type { ListCreativesRequest, ListCreativesResponse, PaginationResponse } from '../../types/tools.generated';
+import type { ServerPayload } from '../../types/server-payload';
 
 export interface BuildListCreativesResponseOpts {
   /** Original request — used to surface `filters_applied` + `sort_applied` summaries. */
   request: ListCreativesRequest;
   /** The page of creative rows. Length determines `query_summary.returned`. */
-  creatives: ListCreativesResponse['creatives'];
+  creatives: ServerPayload<ListCreativesResponse>['creatives'];
   /** Pagination cursor for the next page. Required — pass `{ has_more: false }` when this is the last page. */
   pagination: PaginationResponse;
   /**
@@ -52,7 +53,7 @@ export interface BuildListCreativesResponseOpts {
  * }
  * ```
  */
-export function buildListCreativesResponse(opts: BuildListCreativesResponseOpts): ListCreativesResponse {
+export function buildListCreativesResponse(opts: BuildListCreativesResponseOpts): ServerPayload<ListCreativesResponse> {
   const { request, creatives, pagination, totalMatching } = opts;
 
   const filters = request.filters;
@@ -77,7 +78,7 @@ export function buildListCreativesResponse(opts: BuildListCreativesResponseOpts)
     if (filters.has_variables !== undefined) filtersApplied.push('has_variables');
   }
 
-  const summary: ListCreativesResponse['query_summary'] = {
+  const summary: ServerPayload<ListCreativesResponse>['query_summary'] = {
     total_matching: totalMatching ?? pagination.total_count ?? creatives.length,
     returned: creatives.length,
     ...(filtersApplied.length > 0 && { filters_applied: filtersApplied }),
@@ -90,7 +91,6 @@ export function buildListCreativesResponse(opts: BuildListCreativesResponseOpts)
   };
 
   return {
-    status: 'completed',
     query_summary: summary,
     pagination,
     creatives,

--- a/src/lib/server/decisioning/proposal/dispatch.ts
+++ b/src/lib/server/decisioning/proposal/dispatch.ts
@@ -37,6 +37,7 @@
 
 import { AdcpError, isTaskHandoff, type TaskHandoff } from '../async-outcome';
 import type { GetProductsRequest, GetProductsResponse, Product, Proposal } from '../../../types/tools.generated';
+import type { ServerPayload } from '../../../types/server-payload';
 import {
   detectFinalizeAction,
   enforceProposalExpiry,
@@ -94,7 +95,7 @@ export type FinalizeInterceptResult<TRecipe extends Recipe = Recipe> =
   | {
       kind: 'intercepted';
       result: FinalizeProposalSuccess<TRecipe> | TaskHandoff<FinalizeProposalSuccess<TRecipe>>;
-      project: (success: FinalizeProposalSuccess<TRecipe>) => Promise<GetProductsResponse>;
+      project: (success: FinalizeProposalSuccess<TRecipe>) => Promise<ServerPayload<GetProductsResponse>>;
     }
   | { kind: 'pass' };
 
@@ -174,7 +175,7 @@ export async function maybeInterceptFinalize<TRecipe extends Recipe, TCtxMeta>(a
   const path: 'inline' | 'handoff' = isTaskHandoff(result) ? 'handoff' : 'inline';
   const finalizeProposalId = finalizeEntry.proposalId;
 
-  const project = async (success: FinalizeProposalSuccess<TRecipe>): Promise<GetProductsResponse> => {
+  const project = async (success: FinalizeProposalSuccess<TRecipe>): Promise<ServerPayload<GetProductsResponse>> => {
     if (!isFinalizeSuccess<TRecipe>(success)) {
       throw new AdcpError('INTERNAL_ERROR', {
         recovery: 'terminal',
@@ -213,7 +214,7 @@ function projectFinalizeResponse(args: {
   request: GetProductsRequest;
   committedProposal: Record<string, unknown>;
   finalizeProposalId: string;
-}): GetProductsResponse {
+}): ServerPayload<GetProductsResponse> {
   const refineEntries = (args.request as { refine?: ReadonlyArray<Record<string, unknown>> }).refine;
   const refinementApplied: Array<Record<string, unknown>> = [];
   if (refineEntries) {
@@ -247,12 +248,11 @@ function projectFinalizeResponse(args: {
   // `get_products({ product_ids: [...] })` keyed off
   // `proposals[0].allocations[].product_id`.
   return {
-    status: 'completed',
     cache_scope: 'account',
     products: [],
     proposals: [args.committedProposal as unknown as Proposal],
     refinement_applied: refinementApplied,
-  } as unknown as GetProductsResponse;
+  } as unknown as ServerPayload<GetProductsResponse>;
 }
 
 // ---------------------------------------------------------------------------
@@ -270,7 +270,7 @@ function projectFinalizeResponse(args: {
  * @public
  */
 export async function maybePersistDraftAfterGetProducts<TRecipe extends Recipe>(args: {
-  response: GetProductsResponse;
+  response: ServerPayload<GetProductsResponse>;
   store: ProposalStore<TRecipe> | undefined;
   ctx: { account: { id: string } };
 }): Promise<void> {

--- a/src/lib/server/decisioning/proposal/mock-manager.ts
+++ b/src/lib/server/decisioning/proposal/mock-manager.ts
@@ -30,6 +30,7 @@
 import type { Account } from '../account';
 import type { RequestContext } from '../context';
 import type { GetProductsRequest, GetProductsResponse } from '../../../types/tools.generated';
+import type { ServerPayload } from '../../../types/server-payload';
 import type { ProposalCapabilities, ProposalManager, ProposalSalesSpecialism, Recipe } from './types';
 
 /**
@@ -122,11 +123,17 @@ export class MockProposalManager<TRecipe extends Recipe = Recipe, TCtxMeta = unk
     return this.url;
   }
 
-  async getProducts(req: GetProductsRequest, _ctx: RequestContext<Account<TCtxMeta>>): Promise<GetProductsResponse> {
+  async getProducts(
+    req: GetProductsRequest,
+    _ctx: RequestContext<Account<TCtxMeta>>
+  ): Promise<ServerPayload<GetProductsResponse>> {
     return this.forward('/get_products', req);
   }
 
-  async refineProducts(req: GetProductsRequest, _ctx: RequestContext<Account<TCtxMeta>>): Promise<GetProductsResponse> {
+  async refineProducts(
+    req: GetProductsRequest,
+    _ctx: RequestContext<Account<TCtxMeta>>
+  ): Promise<ServerPayload<GetProductsResponse>> {
     if (!this.capabilities.refine) {
       // Adopter wired the manager without refine but the framework
       // dispatched here anyway — surface the inconsistency rather than
@@ -139,7 +146,7 @@ export class MockProposalManager<TRecipe extends Recipe = Recipe, TCtxMeta = unk
     return this.forward('/refine_products', req);
   }
 
-  private async forward(path: string, body: unknown): Promise<GetProductsResponse> {
+  private async forward(path: string, body: unknown): Promise<ServerPayload<GetProductsResponse>> {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), this.timeoutMs);
     try {
@@ -160,7 +167,7 @@ export class MockProposalManager<TRecipe extends Recipe = Recipe, TCtxMeta = unk
             (text ? `: ${text.slice(0, 500)}` : '')
         );
       }
-      const json = (await response.json()) as GetProductsResponse;
+      const json = (await response.json()) as ServerPayload<GetProductsResponse>;
       return json;
     } finally {
       clearTimeout(timer);

--- a/src/lib/server/decisioning/proposal/types.ts
+++ b/src/lib/server/decisioning/proposal/types.ts
@@ -33,6 +33,7 @@ import type { MaybePromise } from '../../create-adcp-server';
 import type { Account } from '../account';
 import type { RequestContext } from '../context';
 import type { GetProductsRequest, GetProductsResponse } from '../../../types/tools.generated';
+import type { ServerPayload } from '../../../types/server-payload';
 import type { TaskHandoff } from '../async-outcome';
 
 // ---------------------------------------------------------------------------
@@ -408,7 +409,7 @@ export interface ProposalManager<TRecipe extends Recipe = Recipe, TCtxMeta = unk
    * buyer drives the finalize transition via subsequent refine calls
    * with `action: 'finalize'`.
    */
-  getProducts(req: GetProductsRequest, ctx: Ctx<TCtxMeta>): MaybePromise<GetProductsResponse>;
+  getProducts(req: GetProductsRequest, ctx: Ctx<TCtxMeta>): MaybePromise<ServerPayload<GetProductsResponse>>;
 
   /**
    * Refine-mode iteration on a previous `getProducts` response.
@@ -429,7 +430,7 @@ export interface ProposalManager<TRecipe extends Recipe = Recipe, TCtxMeta = unk
    * see those entries intercepted by the framework before this method
    * is called.
    */
-  refineProducts?(req: GetProductsRequest, ctx: Ctx<TCtxMeta>): MaybePromise<GetProductsResponse>;
+  refineProducts?(req: GetProductsRequest, ctx: Ctx<TCtxMeta>): MaybePromise<ServerPayload<GetProductsResponse>>;
 
   /**
    * Commit a draft proposal to firm pricing + inventory hold.

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -98,6 +98,7 @@ import type {
   GetAdCPCapabilitiesResponse,
   SyncGovernanceRequest,
 } from '../../../types/tools.generated';
+import type { ServerPayload } from '../../../types/server-payload';
 import { adcpError, type AdcpErrorResponse } from '../../errors';
 import { validatePlatform, PlatformConfigError } from './validate-platform';
 import { validateSpecialismRequiredTools, formatSpecialismIssue } from '../validate-specialisms';
@@ -3575,7 +3576,7 @@ function buildMediaBuyHandlers<P extends DecisioningPlatform<any, any>>(
             // Refine routing per Python's _select_proposal_method:
             // refine_products iff buying_mode='refine' AND
             // capabilities.refine AND the manager implements it.
-            let result: import('../../../types/tools.generated').GetProductsResponse;
+            let result: ServerPayload<import('../../../types/tools.generated').GetProductsResponse>;
             if (proposalManager) {
               const buyingMode = (params as { buying_mode?: string }).buying_mode;
               const useRefine =

--- a/src/lib/server/decisioning/specialisms/campaign-governance.ts
+++ b/src/lib/server/decisioning/specialisms/campaign-governance.ts
@@ -29,6 +29,7 @@
 
 import type { Account } from '../account';
 import type { RequestContext } from '../context';
+import type { ServerPayload } from '../../../types/server-payload';
 import type {
   CheckGovernanceRequest,
   CheckGovernanceResponse,
@@ -41,6 +42,11 @@ import type {
 } from '../../../types/tools.generated';
 
 type Ctx<TCtxMeta> = RequestContext<Account<TCtxMeta>>;
+
+export type CheckGovernancePayload = ServerPayload<CheckGovernanceResponse>;
+export type SyncPlansPayload = ServerPayload<SyncPlansResponse>;
+export type ReportPlanOutcomePayload = ServerPayload<ReportPlanOutcomeResponse>;
+export type GetPlanAuditLogsPayload = ServerPayload<GetPlanAuditLogsResponse>;
 
 export interface CampaignGovernancePlatform<TCtxMeta = Record<string, unknown>> {
   /**
@@ -57,24 +63,24 @@ export interface CampaignGovernancePlatform<TCtxMeta = Record<string, unknown>> 
    * `status: 'denied'` for governance decisions that ARE the answer
    * (the plan exists and the agent is rejecting the action).
    */
-  checkGovernance(req: CheckGovernanceRequest, ctx: Ctx<TCtxMeta>): Promise<CheckGovernanceResponse>;
+  checkGovernance(req: CheckGovernanceRequest, ctx: Ctx<TCtxMeta>): Promise<CheckGovernancePayload>;
 
   /**
    * Plan CRUD. Buyers sync their campaign plans into the governance
    * agent so the agent can maintain spend authority + delivery context.
    */
-  syncPlans(req: SyncPlansRequest, ctx: Ctx<TCtxMeta>): Promise<SyncPlansResponse>;
+  syncPlans(req: SyncPlansRequest, ctx: Ctx<TCtxMeta>): Promise<SyncPlansPayload>;
 
   /**
    * Outcome reporting. Sellers report what actually happened (impressions
    * delivered, spend incurred, status transitions) so the agent can
    * calibrate future decisions.
    */
-  reportPlanOutcome(req: ReportPlanOutcomeRequest, ctx: Ctx<TCtxMeta>): Promise<ReportPlanOutcomeResponse>;
+  reportPlanOutcome(req: ReportPlanOutcomeRequest, ctx: Ctx<TCtxMeta>): Promise<ReportPlanOutcomePayload>;
 
   /**
    * Audit log read. Returns the chronological history of governance
    * decisions + outcome reports for a plan.
    */
-  getPlanAuditLogs(req: GetPlanAuditLogsRequest, ctx: Ctx<TCtxMeta>): Promise<GetPlanAuditLogsResponse>;
+  getPlanAuditLogs(req: GetPlanAuditLogsRequest, ctx: Ctx<TCtxMeta>): Promise<GetPlanAuditLogsPayload>;
 }

--- a/src/lib/server/decisioning/specialisms/content-standards.ts
+++ b/src/lib/server/decisioning/specialisms/content-standards.ts
@@ -33,6 +33,7 @@
 
 import type { Account } from '../account';
 import type { RequestContext } from '../context';
+import type { ServerPayload } from '../../../types/server-payload';
 import type {
   ListContentStandardsRequest,
   ListContentStandardsResponse,
@@ -54,12 +55,21 @@ import type {
 
 type Ctx<TCtxMeta> = RequestContext<Account<TCtxMeta>>;
 
+export type ListContentStandardsPayload = ServerPayload<ListContentStandardsResponse>;
+export type GetContentStandardsPayload = ServerPayload<GetContentStandardsResponse>;
+export type CreateContentStandardsPayload = ServerPayload<CreateContentStandardsResponse>;
+export type UpdateContentStandardsPayload = ServerPayload<UpdateContentStandardsResponse>;
+export type CalibrateContentPayload = ServerPayload<CalibrateContentResponse>;
+export type ValidateContentDeliveryPayload = ServerPayload<ValidateContentDeliveryResponse>;
+export type GetMediaBuyArtifactsPayload = ServerPayload<GetMediaBuyArtifactsResponse>;
+export type GetCreativeFeaturesPayload = ServerPayload<GetCreativeFeaturesResponse>;
+
 export interface ContentStandardsPlatform<TCtxMeta = Record<string, unknown>> {
   /** Discover content standards published by this agent. */
-  listContentStandards(req: ListContentStandardsRequest, ctx: Ctx<TCtxMeta>): Promise<ListContentStandardsResponse>;
+  listContentStandards(req: ListContentStandardsRequest, ctx: Ctx<TCtxMeta>): Promise<ListContentStandardsPayload>;
 
   /** Read a single content standard by id. */
-  getContentStandards(req: GetContentStandardsRequest, ctx: Ctx<TCtxMeta>): Promise<GetContentStandardsResponse>;
+  getContentStandards(req: GetContentStandardsRequest, ctx: Ctx<TCtxMeta>): Promise<GetContentStandardsPayload>;
 
   /**
    * Create a new content standard. Adopter validates the policy schema
@@ -69,20 +79,20 @@ export interface ContentStandardsPlatform<TCtxMeta = Record<string, unknown>> {
   createContentStandards(
     req: CreateContentStandardsRequest,
     ctx: Ctx<TCtxMeta>
-  ): Promise<CreateContentStandardsResponse>;
+  ): Promise<CreateContentStandardsPayload>;
 
   /** Update an existing content standard. */
   updateContentStandards(
     req: UpdateContentStandardsRequest,
     ctx: Ctx<TCtxMeta>
-  ): Promise<UpdateContentStandardsResponse>;
+  ): Promise<UpdateContentStandardsPayload>;
 
   /**
    * Calibrate content against the published standards. Returns the
    * standard's current calibration profile + any flags raised against
    * the submitted content.
    */
-  calibrateContent(req: CalibrateContentRequest, ctx: Ctx<TCtxMeta>): Promise<CalibrateContentResponse>;
+  calibrateContent(req: CalibrateContentRequest, ctx: Ctx<TCtxMeta>): Promise<CalibrateContentPayload>;
 
   /**
    * Validate that a delivered media-buy / creative meets the buyer's
@@ -93,7 +103,7 @@ export interface ContentStandardsPlatform<TCtxMeta = Record<string, unknown>> {
   validateContentDelivery(
     req: ValidateContentDeliveryRequest,
     ctx: Ctx<TCtxMeta>
-  ): Promise<ValidateContentDeliveryResponse>;
+  ): Promise<ValidateContentDeliveryPayload>;
 
   /**
    * Read content artifacts produced during a media buy's flight (creative
@@ -101,12 +111,12 @@ export interface ContentStandardsPlatform<TCtxMeta = Record<string, unknown>> {
    * who don't expose artifact archival omit. Required by governance
    * receivers running adjacency validation.
    */
-  getMediaBuyArtifacts?(req: GetMediaBuyArtifactsRequest, ctx: Ctx<TCtxMeta>): Promise<GetMediaBuyArtifactsResponse>;
+  getMediaBuyArtifacts?(req: GetMediaBuyArtifactsRequest, ctx: Ctx<TCtxMeta>): Promise<GetMediaBuyArtifactsPayload>;
 
   /**
    * Read per-creative analyzed features (object detection, scene
    * classification, transcript) the agent extracted during calibration.
    * Optional — adopters without analyzer pipelines omit.
    */
-  getCreativeFeatures?(req: GetCreativeFeaturesRequest, ctx: Ctx<TCtxMeta>): Promise<GetCreativeFeaturesResponse>;
+  getCreativeFeatures?(req: GetCreativeFeaturesRequest, ctx: Ctx<TCtxMeta>): Promise<GetCreativeFeaturesPayload>;
 }

--- a/src/lib/server/decisioning/specialisms/creative-ad-server.ts
+++ b/src/lib/server/decisioning/specialisms/creative-ad-server.ts
@@ -27,6 +27,7 @@
 import type { Account, NoAccountCtx } from '../account';
 import type { RequestContext } from '../context';
 import type { TaskHandoff } from '../async-outcome';
+import type { ServerPayload } from '../../../types/server-payload';
 import type {
   BuildCreativeRequest,
   CreativeManifest,
@@ -46,6 +47,11 @@ import type { SyncCreativesRow } from './sales';
 
 type Creative = CreativeAsset;
 type Ctx<TCtxMeta> = RequestContext<Account<TCtxMeta>>;
+
+export type PreviewCreativePayload = ServerPayload<PreviewCreativeResponse>;
+export type ListCreativeFormatsPayload = ServerPayload<ListCreativeFormatsResponse>;
+export type ListCreativesPayload = ServerPayload<ListCreativesResponse>;
+export type GetCreativeDeliveryPayload = ServerPayload<GetCreativeDeliveryResponse>;
 
 export interface CreativeAdServerPlatform<TCtxMeta = Record<string, unknown>> {
   /**
@@ -80,7 +86,7 @@ export interface CreativeAdServerPlatform<TCtxMeta = Record<string, unknown>> {
    * does not carry an `account` field; narrow `ctx.account` before reading
    * `ctx_metadata` / `id`. See {@link NoAccountCtx}.
    */
-  previewCreative(req: PreviewCreativeRequest, ctx: NoAccountCtx<TCtxMeta>): Promise<PreviewCreativeResponse>;
+  previewCreative(req: PreviewCreativeRequest, ctx: NoAccountCtx<TCtxMeta>): Promise<PreviewCreativePayload>;
 
   /**
    * Format catalog. Optional because adopters who delegate format definitions
@@ -92,7 +98,7 @@ export interface CreativeAdServerPlatform<TCtxMeta = Record<string, unknown>> {
   listCreativeFormats?(
     req: ListCreativeFormatsRequest,
     ctx: NoAccountCtx<TCtxMeta>
-  ): Promise<ListCreativeFormatsResponse>;
+  ): Promise<ListCreativeFormatsPayload>;
 
   // sync_creatives: sync OR task — `SyncCreativesResponse` has a Submitted arm.
 
@@ -114,7 +120,7 @@ export interface CreativeAdServerPlatform<TCtxMeta = Record<string, unknown>> {
    * graph. When `req.include_pricing`, include vendor pricing options
    * on each creative.
    */
-  listCreatives(req: ListCreativesRequest, ctx: Ctx<TCtxMeta>): Promise<ListCreativesResponse>;
+  listCreatives(req: ListCreativesRequest, ctx: Ctx<TCtxMeta>): Promise<ListCreativesPayload>;
 
   /**
    * Per-creative delivery actuals (impressions, spend, pacing). Sync —
@@ -135,5 +141,5 @@ export interface CreativeAdServerPlatform<TCtxMeta = Record<string, unknown>> {
    * through and the platform owns fan-out. Sellers that can't compute
    * cross-cuts omit them; buyers fall back to per-row values.
    */
-  getCreativeDelivery(filter: GetCreativeDeliveryRequest, ctx: Ctx<TCtxMeta>): Promise<GetCreativeDeliveryResponse>;
+  getCreativeDelivery(filter: GetCreativeDeliveryRequest, ctx: Ctx<TCtxMeta>): Promise<GetCreativeDeliveryPayload>;
 }

--- a/src/lib/server/decisioning/specialisms/creative.ts
+++ b/src/lib/server/decisioning/specialisms/creative.ts
@@ -18,6 +18,7 @@
 import type { Account, NoAccountCtx } from '../account';
 import type { RequestContext } from '../context';
 import type { TaskHandoff } from '../async-outcome';
+import type { ServerPayload } from '../../../types/server-payload';
 import type {
   CreativeAsset,
   CreativeManifest,
@@ -64,6 +65,9 @@ export type BuildCreativeReturn =
 
 type Creative = CreativeAsset;
 type Ctx<TCtxMeta> = RequestContext<Account<TCtxMeta>>;
+
+export type PreviewCreativePayload = ServerPayload<PreviewCreativeResponse>;
+export type ListCreativeFormatsPayload = ServerPayload<ListCreativeFormatsResponse>;
 
 // Re-export SyncCreativesRow so creative-specialism adopters don't need to
 // reach into the sales module to import the shared row type.
@@ -132,7 +136,7 @@ export interface CreativeBuilderPlatform<TCtxMeta = Record<string, unknown>> {
    * when `accounts.resolve(undefined)` returned null. Narrow before reading
    * `ctx.account.ctx_metadata`. See {@link NoAccountCtx}.
    */
-  previewCreative?(req: PreviewCreativeRequest, ctx: NoAccountCtx<TCtxMeta>): Promise<PreviewCreativeResponse>;
+  previewCreative?(req: PreviewCreativeRequest, ctx: NoAccountCtx<TCtxMeta>): Promise<PreviewCreativePayload>;
 
   /**
    * Format catalog. Buyers call `list_creative_formats` to discover the
@@ -160,7 +164,7 @@ export interface CreativeBuilderPlatform<TCtxMeta = Record<string, unknown>> {
   listCreativeFormats?(
     req: ListCreativeFormatsRequest,
     ctx: NoAccountCtx<TCtxMeta>
-  ): Promise<ListCreativeFormatsResponse>;
+  ): Promise<ListCreativeFormatsPayload>;
 
   /**
    * Refine a prior generation. `taskId` references a prior submission.

--- a/src/lib/server/decisioning/specialisms/lists.ts
+++ b/src/lib/server/decisioning/specialisms/lists.ts
@@ -28,6 +28,7 @@
 
 import type { Account } from '../account';
 import type { RequestContext } from '../context';
+import type { ServerPayload } from '../../../types/server-payload';
 import type {
   CreatePropertyListRequest,
   CreatePropertyListResponse,
@@ -53,22 +54,33 @@ import type {
 
 type Ctx<TCtxMeta> = RequestContext<Account<TCtxMeta>>;
 
+export type CreatePropertyListPayload = ServerPayload<CreatePropertyListResponse>;
+export type UpdatePropertyListPayload = ServerPayload<UpdatePropertyListResponse>;
+export type GetPropertyListPayload = ServerPayload<GetPropertyListResponse>;
+export type ListPropertyListsPayload = ServerPayload<ListPropertyListsResponse>;
+export type DeletePropertyListPayload = ServerPayload<DeletePropertyListResponse>;
+export type CreateCollectionListPayload = ServerPayload<CreateCollectionListResponse>;
+export type UpdateCollectionListPayload = ServerPayload<UpdateCollectionListResponse>;
+export type GetCollectionListPayload = ServerPayload<GetCollectionListResponse>;
+export type ListCollectionListsPayload = ServerPayload<ListCollectionListsResponse>;
+export type DeleteCollectionListPayload = ServerPayload<DeleteCollectionListResponse>;
+
 export interface PropertyListsPlatform<TCtxMeta = Record<string, unknown>> {
   /**
    * Create a property list. Returns a `fetch_token` the buyer stores in
    * their secret manager. Token is scoped to this list_id; MUST NOT be
    * reused across lists.
    */
-  createPropertyList(req: CreatePropertyListRequest, ctx: Ctx<TCtxMeta>): Promise<CreatePropertyListResponse>;
+  createPropertyList(req: CreatePropertyListRequest, ctx: Ctx<TCtxMeta>): Promise<CreatePropertyListPayload>;
 
   /** Patch an existing property list. */
-  updatePropertyList(req: UpdatePropertyListRequest, ctx: Ctx<TCtxMeta>): Promise<UpdatePropertyListResponse>;
+  updatePropertyList(req: UpdatePropertyListRequest, ctx: Ctx<TCtxMeta>): Promise<UpdatePropertyListPayload>;
 
   /** Read a property list by id. Sellers call this with the fetch_token. */
-  getPropertyList(req: GetPropertyListRequest, ctx: Ctx<TCtxMeta>): Promise<GetPropertyListResponse>;
+  getPropertyList(req: GetPropertyListRequest, ctx: Ctx<TCtxMeta>): Promise<GetPropertyListPayload>;
 
   /** Discover property lists the caller is authorized to read. */
-  listPropertyLists(req: ListPropertyListsRequest, ctx: Ctx<TCtxMeta>): Promise<ListPropertyListsResponse>;
+  listPropertyLists(req: ListPropertyListsRequest, ctx: Ctx<TCtxMeta>): Promise<ListPropertyListsPayload>;
 
   /**
    * Delete a property list. MUST revoke the fetch_token immediately and
@@ -76,13 +88,13 @@ export interface PropertyListsPlatform<TCtxMeta = Record<string, unknown>> {
    * a list-changed webhook). Compromise-driven revocation MUST also
    * trigger this path.
    */
-  deletePropertyList(req: DeletePropertyListRequest, ctx: Ctx<TCtxMeta>): Promise<DeletePropertyListResponse>;
+  deletePropertyList(req: DeletePropertyListRequest, ctx: Ctx<TCtxMeta>): Promise<DeletePropertyListPayload>;
 }
 
 export interface CollectionListsPlatform<TCtxMeta = Record<string, unknown>> {
-  createCollectionList(req: CreateCollectionListRequest, ctx: Ctx<TCtxMeta>): Promise<CreateCollectionListResponse>;
-  updateCollectionList(req: UpdateCollectionListRequest, ctx: Ctx<TCtxMeta>): Promise<UpdateCollectionListResponse>;
-  getCollectionList(req: GetCollectionListRequest, ctx: Ctx<TCtxMeta>): Promise<GetCollectionListResponse>;
-  listCollectionLists(req: ListCollectionListsRequest, ctx: Ctx<TCtxMeta>): Promise<ListCollectionListsResponse>;
-  deleteCollectionList(req: DeleteCollectionListRequest, ctx: Ctx<TCtxMeta>): Promise<DeleteCollectionListResponse>;
+  createCollectionList(req: CreateCollectionListRequest, ctx: Ctx<TCtxMeta>): Promise<CreateCollectionListPayload>;
+  updateCollectionList(req: UpdateCollectionListRequest, ctx: Ctx<TCtxMeta>): Promise<UpdateCollectionListPayload>;
+  getCollectionList(req: GetCollectionListRequest, ctx: Ctx<TCtxMeta>): Promise<GetCollectionListPayload>;
+  listCollectionLists(req: ListCollectionListsRequest, ctx: Ctx<TCtxMeta>): Promise<ListCollectionListsPayload>;
+  deleteCollectionList(req: DeleteCollectionListRequest, ctx: Ctx<TCtxMeta>): Promise<DeleteCollectionListPayload>;
 }

--- a/src/lib/server/decisioning/specialisms/sales.ts
+++ b/src/lib/server/decisioning/specialisms/sales.ts
@@ -63,6 +63,7 @@
 import type { Account, NoAccountCtx } from '../account';
 import type { RequestContext } from '../context';
 import type { TaskHandoff } from '../async-outcome';
+import type { ServerPayload } from '../../../types/server-payload';
 import type {
   GetProductsRequest,
   GetProductsResponse,
@@ -92,6 +93,12 @@ import type {
 
 type Creative = CreativeAsset;
 type Ctx<TCtxMeta> = RequestContext<Account<TCtxMeta>>;
+
+export type GetProductsPayload = ServerPayload<GetProductsResponse>;
+export type GetMediaBuyDeliveryPayload = ServerPayload<GetMediaBuyDeliveryResponse>;
+export type GetMediaBuysPayload = ServerPayload<GetMediaBuysResponse>;
+export type ListCreativeFormatsPayload = ServerPayload<ListCreativeFormatsResponse>;
+export type ListCreativesPayload = ServerPayload<ListCreativesResponse>;
 
 /**
  * Wire success-row shape for `sync_creatives`. Returning the array of these
@@ -142,7 +149,7 @@ export interface SalesPlatform<TCtxMeta = Record<string, unknown>> {
   // workflows declare it via `capabilities` so buyers can route
   // appropriately before the first call.
   /** Sync catalog lookup: filters in, products out. NOT for proposal generation. */
-  getProducts?(req: GetProductsRequest, ctx: Ctx<TCtxMeta>): Promise<GetProductsResponse>;
+  getProducts?(req: GetProductsRequest, ctx: Ctx<TCtxMeta>): Promise<GetProductsPayload>;
 
   // ── create_media_buy: unified hybrid shape ──────────────────────────
 
@@ -301,7 +308,7 @@ export interface SalesPlatform<TCtxMeta = Record<string, unknown>> {
    * defaults to `['active']` when omitted; honor the filter in your
    * iteration.
    */
-  getMediaBuyDelivery?(filter: GetMediaBuyDeliveryRequest, ctx: Ctx<TCtxMeta>): Promise<GetMediaBuyDeliveryResponse>;
+  getMediaBuyDelivery?(filter: GetMediaBuyDeliveryRequest, ctx: Ctx<TCtxMeta>): Promise<GetMediaBuyDeliveryPayload>;
 
   // ── get_media_buys: sync only — REQUIRED ──────────────────────────────
   // Read tool — buyers fetch a list of their media buys (often filtered by
@@ -331,7 +338,7 @@ export interface SalesPlatform<TCtxMeta = Record<string, unknown>> {
    * When `media_buy_ids` is omitted, return a paginated set of accessible
    * buys filtered by `status_filter` (defaults to `['active']`).
    */
-  getMediaBuys?(req: GetMediaBuysRequest, ctx: Ctx<TCtxMeta>): Promise<GetMediaBuysResponse>;
+  getMediaBuys?(req: GetMediaBuysRequest, ctx: Ctx<TCtxMeta>): Promise<GetMediaBuysPayload>;
 
   // ── provide_performance_feedback: sync only ─────────────────────────
   // Write tool — buyers report aggregate creative-level performance
@@ -363,7 +370,7 @@ export interface SalesPlatform<TCtxMeta = Record<string, unknown>> {
   listCreativeFormats?(
     req: ListCreativeFormatsRequest,
     ctx: NoAccountCtx<TCtxMeta>
-  ): Promise<ListCreativeFormatsResponse>;
+  ): Promise<ListCreativeFormatsPayload>;
 
   // ── list_creatives: sync only ───────────────────────────────────────
   // Read tool — buyers query the seller's creative library. Optional
@@ -371,7 +378,7 @@ export interface SalesPlatform<TCtxMeta = Record<string, unknown>> {
   // `creative_agents` declared in capabilities; ad-server-style sales
   // platforms implement directly. Note: also lives on `CreativeAdServerPlatform.listCreatives`
   // for the standalone-creative-agent shape.
-  listCreatives?(req: ListCreativesRequest, ctx: Ctx<TCtxMeta>): Promise<ListCreativesResponse>;
+  listCreatives?(req: ListCreativesRequest, ctx: Ctx<TCtxMeta>): Promise<ListCreativesPayload>;
 
   // ── sync_catalogs: sync only ────────────────────────────────────────
   // Retail-media catalog sync. Buyers push product catalogs (SKUs, ASINs,

--- a/src/lib/server/decisioning/specialisms/signals.ts
+++ b/src/lib/server/decisioning/specialisms/signals.ts
@@ -26,6 +26,7 @@
 
 import type { Account } from '../account';
 import type { RequestContext } from '../context';
+import type { ServerPayload } from '../../../types/server-payload';
 import type {
   GetSignalsRequest,
   GetSignalsResponse,
@@ -34,6 +35,8 @@ import type {
 } from '../../../types/tools.generated';
 
 type Ctx<TCtxMeta> = RequestContext<Account<TCtxMeta>>;
+
+export type GetSignalsPayload = ServerPayload<GetSignalsResponse>;
 
 export interface SignalsPlatform<TCtxMeta = Record<string, unknown>> {
   /**
@@ -46,7 +49,7 @@ export interface SignalsPlatform<TCtxMeta = Record<string, unknown>> {
    * `'POLICY_VIOLATION'` if the buyer doesn't have rights to the data
    * category they're requesting).
    */
-  getSignals(req: GetSignalsRequest, ctx: Ctx<TCtxMeta>): Promise<GetSignalsResponse>;
+  getSignals(req: GetSignalsRequest, ctx: Ctx<TCtxMeta>): Promise<GetSignalsPayload>;
 
   /**
    * Provision a signal onto one or more destination platforms (Snap,

--- a/src/lib/server/decisioning/specialisms/sponsored-intelligence.ts
+++ b/src/lib/server/decisioning/specialisms/sponsored-intelligence.ts
@@ -50,6 +50,7 @@
 
 import type { Account } from '../account';
 import type { RequestContext } from '../context';
+import type { ServerPayload } from '../../../types/server-payload';
 import type {
   SIGetOfferingRequest,
   SIGetOfferingResponse,
@@ -62,6 +63,11 @@ import type {
 } from '../../../types/tools.generated';
 
 type Ctx<TCtxMeta> = RequestContext<Account<TCtxMeta>>;
+
+export type SIGetOfferingPayload = ServerPayload<SIGetOfferingResponse>;
+export type SIInitiateSessionPayload = ServerPayload<SIInitiateSessionResponse>;
+export type SISendMessagePayload = ServerPayload<SISendMessageResponse>;
+export type SITerminateSessionPayload = ServerPayload<SITerminateSessionResponse>;
 
 export interface SponsoredIntelligencePlatform<TCtxMeta = Record<string, unknown>> {
   /**
@@ -76,7 +82,7 @@ export interface SponsoredIntelligencePlatform<TCtxMeta = Record<string, unknown
    *   - `'EXPIRED'` — offering past its `expires_at`
    *   - `'REGION_RESTRICTED'` — offering not available in caller's region
    */
-  getOffering(req: SIGetOfferingRequest, ctx: Ctx<TCtxMeta>): Promise<SIGetOfferingResponse>;
+  getOffering(req: SIGetOfferingRequest, ctx: Ctx<TCtxMeta>): Promise<SIGetOfferingPayload>;
 
   /**
    * Start a session. Returns `session_id` plus the brand's first response
@@ -96,7 +102,7 @@ export interface SponsoredIntelligencePlatform<TCtxMeta = Record<string, unknown
    *   - `'CAPABILITY_UNSUPPORTED'` — host advertised capabilities the
    *     brand cannot fulfill (rare; usually downgrades silently)
    */
-  initiateSession(req: SIInitiateSessionRequest, ctx: Ctx<TCtxMeta>): Promise<SIInitiateSessionResponse>;
+  initiateSession(req: SIInitiateSessionRequest, ctx: Ctx<TCtxMeta>): Promise<SIInitiateSessionPayload>;
 
   /**
    * Send a turn. A small session record is auto-attached at
@@ -119,7 +125,7 @@ export interface SponsoredIntelligencePlatform<TCtxMeta = Record<string, unknown
    *   - `'SESSION_TIMEOUT'` — exceeded `session_ttl_seconds` since last
    *     turn (brand may also auto-terminate via `host_terminated`)
    */
-  sendMessage(req: SISendMessageRequest, ctx: Ctx<TCtxMeta>): Promise<SISendMessageResponse>;
+  sendMessage(req: SISendMessageRequest, ctx: Ctx<TCtxMeta>): Promise<SISendMessagePayload>;
 
   /**
    * Terminate a session. Naturally idempotent — `session_id` is the
@@ -134,5 +140,5 @@ export interface SponsoredIntelligencePlatform<TCtxMeta = Record<string, unknown
    * Throw `AdcpError` for buyer-fixable rejection:
    *   - `'SESSION_NOT_FOUND'` — unknown `session_id`
    */
-  terminateSession(req: SITerminateSessionRequest, ctx: Ctx<TCtxMeta>): Promise<SITerminateSessionResponse>;
+  terminateSession(req: SITerminateSessionRequest, ctx: Ctx<TCtxMeta>): Promise<SITerminateSessionPayload>;
 }

--- a/src/lib/server/index.ts
+++ b/src/lib/server/index.ts
@@ -39,6 +39,7 @@ export type { OperationalPlatform, OperationalContext } from './operational-plat
 
 export { pickWireSpecFields, scrubExtensions, WIRE_SPEC_FIELDS } from './wire-safe';
 export type { WireSafe, WireSpecRequestName, ScrubExtensionsOptions } from './wire-safe';
+export type { ServerPayload } from '../types/server-payload';
 
 export { assertNoExampleTlds } from './example-tld-guard';
 export type { AssertNoExampleTldsOptions } from './example-tld-guard';

--- a/src/lib/server/operational-platform.ts
+++ b/src/lib/server/operational-platform.ts
@@ -53,6 +53,7 @@ import type {
   UpdateMediaBuyRequest,
   UpdateMediaBuyResponse,
 } from '../types/tools.generated';
+import type { ServerPayload } from '../types/server-payload';
 import type { AudienceStatus } from './decisioning/specialisms/audiences';
 
 /**
@@ -147,7 +148,7 @@ export interface OperationalPlatform<TCtx extends OperationalContext = Operation
    * Throw `AdcpError` for structured rejection (`NOT_CANCELLABLE`,
    * `CONFLICT`, etc.). Generic thrown errors propagate to the caller.
    */
-  updateMediaBuy(ctx: TCtx, request: UpdateMediaBuyRequest): Promise<UpdateMediaBuyResponse>;
+  updateMediaBuy(ctx: TCtx, request: UpdateMediaBuyRequest): Promise<ServerPayload<UpdateMediaBuyResponse>>;
 
   /**
    * Fetch delivery metrics for one or more media buys. Required for
@@ -171,7 +172,7 @@ export interface OperationalPlatform<TCtx extends OperationalContext = Operation
     startTime: string,
     endTime: string,
     args?: Record<string, unknown>
-  ): Promise<GetMediaBuyDeliveryResponse>;
+  ): Promise<ServerPayload<GetMediaBuyDeliveryResponse>>;
 
   /**
    * Poll upstream for the current status of one or more audiences.
@@ -222,7 +223,7 @@ export interface OperationalPlatform<TCtx extends OperationalContext = Operation
     contextId?: string,
     brand?: Record<string, unknown>,
     sourceChain?: readonly string[]
-  ): Promise<GetProductsResponse>;
+  ): Promise<ServerPayload<GetProductsResponse>>;
 }
 
 /**

--- a/src/lib/server/responses.ts
+++ b/src/lib/server/responses.ts
@@ -43,6 +43,7 @@ import type { GetAdCPCapabilitiesResponse } from '../types/tools.generated';
 import type { GetProductsResponse } from '../types/core.generated';
 import type { CreateMediaBuySuccess } from '../types/core.generated';
 import type { GetMediaBuyDeliveryResponse } from '../types/tools.generated';
+import type { ServerPayload } from '../types/server-payload';
 import { validActionsForStatus } from './media-buy-helpers';
 import type { CancelMediaBuyInput } from './media-buy-helpers';
 import type {
@@ -106,6 +107,30 @@ export interface McpToolResponse {
 // JSON objects are always Records — this bridge is safe.
 export function toStructuredContent(data: object): Record<string, unknown> {
   return data as unknown as Record<string, unknown>;
+}
+
+const MEDIA_BUY_STATUS_VALUES = new Set([
+  'pending_creatives',
+  'pending_start',
+  'active',
+  'paused',
+  'completed',
+  'rejected',
+  'canceled',
+]);
+
+function completedStructuredContent(data: object, opts?: { splitMediaBuyStatus?: boolean }): Record<string, unknown> {
+  const structured = { ...toStructuredContent(data) };
+  if (
+    opts?.splitMediaBuyStatus === true &&
+    typeof structured.status === 'string' &&
+    MEDIA_BUY_STATUS_VALUES.has(structured.status)
+  ) {
+    if (structured.media_buy_status === undefined) structured.media_buy_status = structured.status;
+    delete structured.status;
+  }
+  if (structured.status === undefined) structured.status = 'completed';
+  return structured;
 }
 
 function stripNotificationConfigSecrets<T extends object>(row: T): T {
@@ -172,10 +197,13 @@ function assertNoTopLevelSetup(data: unknown, builder: string): void {
  * the typed payload model live at different layers.
  */
 /** @deprecated v6: `createAdcpServerFromPlatform` constructs wire responses from typed platform returns. Direct use is for v5 raw-handler adopters mid-migration only. */
-export function capabilitiesResponse(data: GetAdCPCapabilitiesResponse, summary?: string): McpToolResponse {
+export function capabilitiesResponse(
+  data: ServerPayload<GetAdCPCapabilitiesResponse>,
+  summary?: string
+): McpToolResponse {
   return {
     content: [{ type: 'text', text: summary ?? 'Agent capabilities retrieved' }],
-    structuredContent: { ...toStructuredContent(data), status: 'completed' },
+    structuredContent: completedStructuredContent(data),
   };
 }
 
@@ -183,9 +211,8 @@ export function capabilitiesResponse(data: GetAdCPCapabilitiesResponse, summary?
  * Build a get_products response.
  */
 /** @deprecated v6: `createAdcpServerFromPlatform` constructs wire responses from typed platform returns. Direct use is for v5 raw-handler adopters mid-migration only. */
-export function productsResponse(data: GetProductsResponse, summary?: string): McpToolResponse {
-  const structured = toStructuredContent(data) as Record<string, unknown>;
-  if (structured.status === undefined) structured.status = 'completed';
+export function productsResponse(data: ServerPayload<GetProductsResponse>, summary?: string): McpToolResponse {
+  const structured = completedStructuredContent(data);
   return {
     content: [{ type: 'text', text: summary ?? `Found ${(data.products ?? []).length} products` }],
     structuredContent: structured,
@@ -202,7 +229,7 @@ export function productsResponse(data: GetProductsResponse, summary?: string): M
  *   `status` is provided but `valid_actions` is not
  */
 /** @deprecated v6: `createAdcpServerFromPlatform` constructs wire responses from typed platform returns. Direct use is for v5 raw-handler adopters mid-migration only. */
-export function mediaBuyResponse(data: CreateMediaBuySuccess, summary?: string): McpToolResponse {
+export function mediaBuyResponse(data: ServerPayload<CreateMediaBuySuccess>, summary?: string): McpToolResponse {
   assertNoTopLevelSetup(data, 'mediaBuyResponse');
   const withDefaults = { ...data };
   if (withDefaults.revision === undefined) {
@@ -216,7 +243,7 @@ export function mediaBuyResponse(data: CreateMediaBuySuccess, summary?: string):
   }
   return {
     content: [{ type: 'text', text: summary ?? `Media buy ${withDefaults.media_buy_id} created` }],
-    structuredContent: toStructuredContent(withDefaults),
+    structuredContent: completedStructuredContent(withDefaults, { splitMediaBuyStatus: true }),
   };
 }
 
@@ -224,7 +251,7 @@ export function mediaBuyResponse(data: CreateMediaBuySuccess, summary?: string):
  * Build a get_media_buy_delivery response.
  */
 /** @deprecated v6: `createAdcpServerFromPlatform` constructs wire responses from typed platform returns. Direct use is for v5 raw-handler adopters mid-migration only. */
-export function deliveryResponse(data: GetMediaBuyDeliveryResponse, summary?: string): McpToolResponse {
+export function deliveryResponse(data: ServerPayload<GetMediaBuyDeliveryResponse>, summary?: string): McpToolResponse {
   return {
     content: [
       {
@@ -234,7 +261,7 @@ export function deliveryResponse(data: GetMediaBuyDeliveryResponse, summary?: st
           `Delivery data for ${data.media_buy_deliveries.length} media buy${data.media_buy_deliveries.length === 1 ? '' : 's'}`,
       },
     ],
-    structuredContent: toStructuredContent(data),
+    structuredContent: completedStructuredContent(data),
   };
 }
 
@@ -242,11 +269,11 @@ export function deliveryResponse(data: GetMediaBuyDeliveryResponse, summary?: st
  * Build a list_accounts response.
  */
 /** @deprecated v6: `createAdcpServerFromPlatform` constructs wire responses from typed platform returns. Direct use is for v5 raw-handler adopters mid-migration only. */
-export function listAccountsResponse(data: ListAccountsResponse, summary?: string): McpToolResponse {
+export function listAccountsResponse(data: ServerPayload<ListAccountsResponse>, summary?: string): McpToolResponse {
   const stripped = stripAccountNotificationConfigSecrets(data);
   return {
     content: [{ type: 'text', text: summary ?? `Found ${stripped.accounts.length} accounts` }],
-    structuredContent: toStructuredContent(stripped),
+    structuredContent: completedStructuredContent(stripped),
   };
 }
 
@@ -254,10 +281,13 @@ export function listAccountsResponse(data: ListAccountsResponse, summary?: strin
  * Build a list_creative_formats response.
  */
 /** @deprecated v6: `createAdcpServerFromPlatform` constructs wire responses from typed platform returns. Direct use is for v5 raw-handler adopters mid-migration only. */
-export function listCreativeFormatsResponse(data: ListCreativeFormatsResponse, summary?: string): McpToolResponse {
+export function listCreativeFormatsResponse(
+  data: ServerPayload<ListCreativeFormatsResponse>,
+  summary?: string
+): McpToolResponse {
   return {
     content: [{ type: 'text', text: summary ?? `Found ${data.formats.length} creative formats` }],
-    structuredContent: toStructuredContent(data),
+    structuredContent: completedStructuredContent(data),
   };
 }
 
@@ -268,7 +298,7 @@ export function listCreativeFormatsResponse(data: ListCreativeFormatsResponse, s
  * `valid_actions` from `validActionsForStatus()`.
  */
 /** @deprecated v6: `createAdcpServerFromPlatform` constructs wire responses from typed platform returns. Direct use is for v5 raw-handler adopters mid-migration only. */
-export function updateMediaBuyResponse(data: UpdateMediaBuySuccess, summary?: string): McpToolResponse {
+export function updateMediaBuyResponse(data: ServerPayload<UpdateMediaBuySuccess>, summary?: string): McpToolResponse {
   assertNoTopLevelSetup(data, 'updateMediaBuyResponse');
   const withDefaults = { ...data };
   if (withDefaults.valid_actions === undefined && withDefaults.status != null) {
@@ -276,7 +306,7 @@ export function updateMediaBuyResponse(data: UpdateMediaBuySuccess, summary?: st
   }
   return {
     content: [{ type: 'text', text: summary ?? `Media buy ${withDefaults.media_buy_id} updated` }],
-    structuredContent: toStructuredContent(withDefaults),
+    structuredContent: completedStructuredContent(withDefaults, { splitMediaBuyStatus: true }),
   };
 }
 
@@ -284,7 +314,7 @@ export function updateMediaBuyResponse(data: UpdateMediaBuySuccess, summary?: st
  * Build a get_media_buys response.
  */
 /** @deprecated v6: `createAdcpServerFromPlatform` constructs wire responses from typed platform returns. Direct use is for v5 raw-handler adopters mid-migration only. */
-export function getMediaBuysResponse(data: GetMediaBuysResponse, summary?: string): McpToolResponse {
+export function getMediaBuysResponse(data: ServerPayload<GetMediaBuysResponse>, summary?: string): McpToolResponse {
   if (Array.isArray(data.media_buys)) {
     for (const buy of data.media_buys) {
       assertNoTopLevelSetup(buy, 'getMediaBuysResponse');
@@ -297,7 +327,7 @@ export function getMediaBuysResponse(data: GetMediaBuysResponse, summary?: strin
         text: summary ?? `Found ${data.media_buys.length} media buy${data.media_buys.length === 1 ? '' : 's'}`,
       },
     ],
-    structuredContent: toStructuredContent(data),
+    structuredContent: completedStructuredContent(data),
   };
 }
 
@@ -306,12 +336,12 @@ export function getMediaBuysResponse(data: GetMediaBuysResponse, summary?: strin
  */
 /** @deprecated v6: `createAdcpServerFromPlatform` constructs wire responses from typed platform returns. Direct use is for v5 raw-handler adopters mid-migration only. */
 export function performanceFeedbackResponse(
-  data: ProvidePerformanceFeedbackSuccess,
+  data: ServerPayload<ProvidePerformanceFeedbackSuccess>,
   summary?: string
 ): McpToolResponse {
   return {
     content: [{ type: 'text', text: summary ?? 'Performance feedback accepted' }],
-    structuredContent: toStructuredContent(data),
+    structuredContent: completedStructuredContent(data),
   };
 }
 
@@ -319,7 +349,7 @@ export function performanceFeedbackResponse(
  * Build a successful build_creative response (single format).
  */
 /** @deprecated v6: `createAdcpServerFromPlatform` constructs wire responses from typed platform returns. Direct use is for v5 raw-handler adopters mid-migration only. */
-export function buildCreativeResponse(data: BuildCreativeSuccess, summary?: string): McpToolResponse {
+export function buildCreativeResponse(data: ServerPayload<BuildCreativeSuccess>, summary?: string): McpToolResponse {
   // Optional-chain the default summary — handler responses that drop
   // `format_id` still reach the wire-level schema validator (which names
   // the missing field), instead of crashing the dispatcher here with an
@@ -327,7 +357,7 @@ export function buildCreativeResponse(data: BuildCreativeSuccess, summary?: stri
   const formatId = data.creative_manifest?.format_id?.id;
   return {
     content: [{ type: 'text', text: summary ?? (formatId ? `Creative built: ${formatId}` : 'Creative built') }],
-    structuredContent: toStructuredContent(data),
+    structuredContent: completedStructuredContent(data),
   };
 }
 
@@ -335,11 +365,14 @@ export function buildCreativeResponse(data: BuildCreativeSuccess, summary?: stri
  * Build a successful build_creative response (multi-format).
  */
 /** @deprecated v6: `createAdcpServerFromPlatform` constructs wire responses from typed platform returns. Direct use is for v5 raw-handler adopters mid-migration only. */
-export function buildCreativeMultiResponse(data: BuildCreativeMultiSuccess, summary?: string): McpToolResponse {
+export function buildCreativeMultiResponse(
+  data: ServerPayload<BuildCreativeMultiSuccess>,
+  summary?: string
+): McpToolResponse {
   const count = data.creative_manifests?.length ?? 0;
   return {
     content: [{ type: 'text', text: summary ?? `Built ${count} creative formats` }],
-    structuredContent: toStructuredContent(data),
+    structuredContent: completedStructuredContent(data),
   };
 }
 
@@ -365,7 +398,7 @@ export function previewCreativeResponse(
         : `Variant preview generated`;
   return {
     content: [{ type: 'text', text: summary ?? defaultSummary }],
-    structuredContent: toStructuredContent(data),
+    structuredContent: completedStructuredContent(data),
   };
 }
 
@@ -373,10 +406,13 @@ export function previewCreativeResponse(
  * Build a get_creative_delivery response.
  */
 /** @deprecated v6: `createAdcpServerFromPlatform` constructs wire responses from typed platform returns. Direct use is for v5 raw-handler adopters mid-migration only. */
-export function creativeDeliveryResponse(data: GetCreativeDeliveryResponse, summary?: string): McpToolResponse {
+export function creativeDeliveryResponse(
+  data: ServerPayload<GetCreativeDeliveryResponse>,
+  summary?: string
+): McpToolResponse {
   return {
     content: [{ type: 'text', text: summary ?? `Creative delivery data for ${data.currency} report` }],
-    structuredContent: toStructuredContent(data),
+    structuredContent: completedStructuredContent(data),
   };
 }
 
@@ -384,7 +420,7 @@ export function creativeDeliveryResponse(data: GetCreativeDeliveryResponse, summ
  * Build a list_creatives response.
  */
 /** @deprecated v6: `createAdcpServerFromPlatform` constructs wire responses from typed platform returns. Direct use is for v5 raw-handler adopters mid-migration only. */
-export function listCreativesResponse(data: ListCreativesResponse, summary?: string): McpToolResponse {
+export function listCreativesResponse(data: ServerPayload<ListCreativesResponse>, summary?: string): McpToolResponse {
   return {
     content: [
       {
@@ -393,7 +429,7 @@ export function listCreativesResponse(data: ListCreativesResponse, summary?: str
           summary ?? `Found ${data.query_summary.total_matching} creatives (${data.query_summary.returned} returned)`,
       },
     ],
-    structuredContent: toStructuredContent(data),
+    structuredContent: completedStructuredContent(data),
   };
 }
 
@@ -404,7 +440,10 @@ export function listCreativesResponse(data: ListCreativesResponse, summary?: str
  * storyboard runner flags as shape drift).
  */
 /** @deprecated v6: `createAdcpServerFromPlatform` constructs wire responses from typed platform returns. Direct use is for v5 raw-handler adopters mid-migration only. */
-export function listPropertyListsResponse(data: ListPropertyListsResponse, summary?: string): McpToolResponse {
+export function listPropertyListsResponse(
+  data: ServerPayload<ListPropertyListsResponse>,
+  summary?: string
+): McpToolResponse {
   return {
     content: [
       {
@@ -412,7 +451,7 @@ export function listPropertyListsResponse(data: ListPropertyListsResponse, summa
         text: summary ?? `Found ${data.lists.length} property list${data.lists.length === 1 ? '' : 's'}`,
       },
     ],
-    structuredContent: toStructuredContent(data),
+    structuredContent: completedStructuredContent(data),
   };
 }
 
@@ -422,7 +461,10 @@ export function listPropertyListsResponse(data: ListPropertyListsResponse, summa
  * governance surface for program-level collections.
  */
 /** @deprecated v6: `createAdcpServerFromPlatform` constructs wire responses from typed platform returns. Direct use is for v5 raw-handler adopters mid-migration only. */
-export function listCollectionListsResponse(data: ListCollectionListsResponse, summary?: string): McpToolResponse {
+export function listCollectionListsResponse(
+  data: ServerPayload<ListCollectionListsResponse>,
+  summary?: string
+): McpToolResponse {
   return {
     content: [
       {
@@ -430,7 +472,7 @@ export function listCollectionListsResponse(data: ListCollectionListsResponse, s
         text: summary ?? `Found ${data.lists.length} collection list${data.lists.length === 1 ? '' : 's'}`,
       },
     ],
-    structuredContent: toStructuredContent(data),
+    structuredContent: completedStructuredContent(data),
   };
 }
 
@@ -447,14 +489,17 @@ export function listCollectionListsResponse(data: ListCollectionListsResponse, s
  * discrimination pattern a few screens down.
  */
 /** @deprecated v6: `createAdcpServerFromPlatform` constructs wire responses from typed platform returns. Direct use is for v5 raw-handler adopters mid-migration only. */
-export function listContentStandardsResponse(data: ListContentStandardsResponse, summary?: string): McpToolResponse {
+export function listContentStandardsResponse(
+  data: ServerPayload<ListContentStandardsResponse>,
+  summary?: string
+): McpToolResponse {
   const defaultSummary =
     'standards' in data
       ? `Found ${data.standards.length} content standard${data.standards.length === 1 ? '' : 's'}`
       : 'Content standards lookup error';
   return {
     content: [{ type: 'text', text: summary ?? defaultSummary }],
-    structuredContent: toStructuredContent(data),
+    structuredContent: completedStructuredContent(data),
   };
 }
 
@@ -464,7 +509,10 @@ export function listContentStandardsResponse(data: ListContentStandardsResponse,
  * storyboard runner's shape-drift hint.
  */
 /** @deprecated v6: `createAdcpServerFromPlatform` constructs wire responses from typed platform returns. Direct use is for v5 raw-handler adopters mid-migration only. */
-export function getPlanAuditLogsResponse(data: GetPlanAuditLogsResponse, summary?: string): McpToolResponse {
+export function getPlanAuditLogsResponse(
+  data: ServerPayload<GetPlanAuditLogsResponse>,
+  summary?: string
+): McpToolResponse {
   return {
     content: [
       {
@@ -472,7 +520,7 @@ export function getPlanAuditLogsResponse(data: GetPlanAuditLogsResponse, summary
         text: summary ?? `Audit data for ${data.plans.length} plan${data.plans.length === 1 ? '' : 's'}`,
       },
     ],
-    structuredContent: toStructuredContent(data),
+    structuredContent: completedStructuredContent(data),
   };
 }
 
@@ -480,7 +528,7 @@ export function getPlanAuditLogsResponse(data: GetPlanAuditLogsResponse, summary
  * Build a successful sync_creatives response.
  */
 /** @deprecated v6: `createAdcpServerFromPlatform` constructs wire responses from typed platform returns. Direct use is for v5 raw-handler adopters mid-migration only. */
-export function syncCreativesResponse(data: SyncCreativesSuccess, summary?: string): McpToolResponse {
+export function syncCreativesResponse(data: ServerPayload<SyncCreativesSuccess>, summary?: string): McpToolResponse {
   return {
     content: [
       {
@@ -488,7 +536,7 @@ export function syncCreativesResponse(data: SyncCreativesSuccess, summary?: stri
         text: summary ?? `Synced ${data.creatives.length} creative${data.creatives.length === 1 ? '' : 's'}`,
       },
     ],
-    structuredContent: toStructuredContent(data),
+    structuredContent: completedStructuredContent(data),
   };
 }
 
@@ -496,7 +544,7 @@ export function syncCreativesResponse(data: SyncCreativesSuccess, summary?: stri
  * Build a get_signals response.
  */
 /** @deprecated v6: `createAdcpServerFromPlatform` constructs wire responses from typed platform returns. Direct use is for v5 raw-handler adopters mid-migration only. */
-export function getSignalsResponse(data: GetSignalsResponse, summary?: string): McpToolResponse {
+export function getSignalsResponse(data: ServerPayload<GetSignalsResponse>, summary?: string): McpToolResponse {
   return {
     content: [
       {
@@ -504,7 +552,7 @@ export function getSignalsResponse(data: GetSignalsResponse, summary?: string): 
         text: summary ?? `Found ${(data.signals ?? []).length} signal${(data.signals ?? []).length === 1 ? '' : 's'}`,
       },
     ],
-    structuredContent: toStructuredContent(data),
+    structuredContent: completedStructuredContent(data),
   };
 }
 
@@ -512,7 +560,7 @@ export function getSignalsResponse(data: GetSignalsResponse, summary?: string): 
  * Build a successful activate_signal response.
  */
 /** @deprecated v6: `createAdcpServerFromPlatform` constructs wire responses from typed platform returns. Direct use is for v5 raw-handler adopters mid-migration only. */
-export function activateSignalResponse(data: ActivateSignalSuccess, summary?: string): McpToolResponse {
+export function activateSignalResponse(data: ServerPayload<ActivateSignalSuccess>, summary?: string): McpToolResponse {
   return {
     content: [
       {
@@ -522,7 +570,7 @@ export function activateSignalResponse(data: ActivateSignalSuccess, summary?: st
           `Signal activated across ${data.deployments.length} deployment${data.deployments.length === 1 ? '' : 's'}`,
       },
     ],
-    structuredContent: toStructuredContent(data),
+    structuredContent: completedStructuredContent(data),
   };
 }
 
@@ -581,7 +629,7 @@ export function cancelMediaBuyResponse(input: CancelMediaBuyInput, summary?: str
 
   return {
     content: [{ type: 'text', text: summary ?? `Media buy ${input.media_buy_id} canceled` }],
-    structuredContent: data,
+    structuredContent: completedStructuredContent(data, { splitMediaBuyStatus: true }),
   };
 }
 
@@ -597,7 +645,7 @@ export function cancelMediaBuyResponse(input: CancelMediaBuyInput, summary?: str
  * becomes the default.
  */
 /** @deprecated v6: `createAdcpServerFromPlatform` constructs wire responses from typed platform returns. Direct use is for v5 raw-handler adopters mid-migration only. */
-export function acquireRightsResponse(data: AcquireRightsResponse, summary?: string): McpToolResponse {
+export function acquireRightsResponse(data: ServerPayload<AcquireRightsResponse>, summary?: string): McpToolResponse {
   const dataAsAny = data as AcquireRightsResponse & { rights_status?: string; rights_id?: string };
   const defaultSummary =
     'errors' in data
@@ -609,7 +657,7 @@ export function acquireRightsResponse(data: AcquireRightsResponse, summary?: str
           : `Rights ${dataAsAny.rights_id} pending approval`;
   return {
     content: [{ type: 'text', text: summary ?? defaultSummary }],
-    structuredContent: toStructuredContent(data),
+    structuredContent: completedStructuredContent(data),
   };
 }
 
@@ -659,7 +707,7 @@ export function acquireRightsRejected(
  * default summary, error pass-through).
  */
 /** @deprecated v6: `createAdcpServerFromPlatform` constructs wire responses from typed platform returns. Direct use is for v5 raw-handler adopters mid-migration only. */
-export function updateRightsResponse(data: UpdateRightsResponse, summary?: string): McpToolResponse {
+export function updateRightsResponse(data: ServerPayload<UpdateRightsResponse>, summary?: string): McpToolResponse {
   const defaultSummary =
     'errors' in data
       ? 'Rights update error'
@@ -668,7 +716,7 @@ export function updateRightsResponse(data: UpdateRightsResponse, summary?: strin
         : `Rights ${data.rights_id} updated`;
   return {
     content: [{ type: 'text', text: summary ?? defaultSummary }],
-    structuredContent: toStructuredContent(data),
+    structuredContent: completedStructuredContent(data),
   };
 }
 
@@ -681,7 +729,7 @@ export function updateRightsResponse(data: UpdateRightsResponse, summary?: strin
  * `rights_constraint`) without crossing the union.
  */
 /** @deprecated v6: `createAdcpServerFromPlatform` constructs wire responses from typed platform returns. Direct use is for v5 raw-handler adopters mid-migration only. */
-export function updateRightsSuccess(data: UpdateRightsSuccess, summary?: string): McpToolResponse {
+export function updateRightsSuccess(data: ServerPayload<UpdateRightsSuccess>, summary?: string): McpToolResponse {
   return updateRightsResponse(data as unknown as UpdateRightsResponse, summary);
 }
 
@@ -731,7 +779,7 @@ export function creativeApprovalError(data: CreativeApprovalError): CreativeAppr
  * `SyncAccountsResponse` union; error payloads pass through.
  */
 /** @deprecated v6: `createAdcpServerFromPlatform` constructs wire responses from typed platform returns. Direct use is for v5 raw-handler adopters mid-migration only. */
-export function syncAccountsResponse(data: SyncAccountsResponse, summary?: string): McpToolResponse {
+export function syncAccountsResponse(data: ServerPayload<SyncAccountsResponse>, summary?: string): McpToolResponse {
   const stripped = 'accounts' in data ? stripAccountNotificationConfigSecrets(data) : data;
   const defaultSummary =
     'errors' in stripped
@@ -739,7 +787,7 @@ export function syncAccountsResponse(data: SyncAccountsResponse, summary?: strin
       : `Synced ${stripped.accounts?.length ?? 0} account${stripped.accounts?.length === 1 ? '' : 's'}`;
   return {
     content: [{ type: 'text', text: summary ?? defaultSummary }],
-    structuredContent: toStructuredContent(stripped),
+    structuredContent: completedStructuredContent(stripped),
   };
 }
 
@@ -759,15 +807,17 @@ export function syncAccountsResponse(data: SyncAccountsResponse, summary?: strin
  * (`AccountStore.syncGovernance`) paths are protected.
  */
 /** @deprecated v6: `createAdcpServerFromPlatform` constructs wire responses from typed platform returns. Direct use is for v5 raw-handler adopters mid-migration only. */
-export function syncGovernanceResponse(data: SyncGovernanceResponse, summary?: string): McpToolResponse {
+export function syncGovernanceResponse(data: ServerPayload<SyncGovernanceResponse>, summary?: string): McpToolResponse {
   const stripped = stripGovernanceAgentSecrets(data);
   return {
     content: [{ type: 'text', text: summary ?? 'Governance registration synced' }],
-    structuredContent: toStructuredContent(stripped),
+    structuredContent: completedStructuredContent(stripped),
   };
 }
 
-function stripGovernanceAgentSecrets(data: SyncGovernanceResponse): SyncGovernanceResponse {
+function stripGovernanceAgentSecrets(
+  data: ServerPayload<SyncGovernanceResponse>
+): ServerPayload<SyncGovernanceResponse> {
   if (!('accounts' in data) || !Array.isArray(data.accounts)) return data;
   return {
     ...data,
@@ -802,12 +852,12 @@ function stripGovernanceAgentSecrets(data: SyncGovernanceResponse): SyncGovernan
  * ```
  */
 /** @deprecated v6: `createAdcpServerFromPlatform` constructs wire responses from typed platform returns. Direct use is for v5 raw-handler adopters mid-migration only. */
-export function reportUsageResponse(data: ReportUsageResponse, summary?: string): McpToolResponse {
+export function reportUsageResponse(data: ServerPayload<ReportUsageResponse>, summary?: string): McpToolResponse {
   return {
     content: [
       { type: 'text', text: summary ?? `Accepted ${data.accepted} usage record${data.accepted === 1 ? '' : 's'}` },
     ],
-    structuredContent: toStructuredContent(data),
+    structuredContent: completedStructuredContent(data),
   };
 }
 

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -26,6 +26,7 @@ export type {
 // so SDK consumers don't break across the version bump.
 export type { FormatReferenceStructuredObject } from './core.generated';
 import type { FormatReferenceStructuredObject } from './core.generated';
+export type { ServerPayload } from './server-payload';
 /**
  * @deprecated AdCP 3.0.1 renamed this type to `FormatReferenceStructuredObject`
  * (the wire shape is identical — pure documentation rename per the spec). This

--- a/src/lib/types/server-payload.ts
+++ b/src/lib/types/server-payload.ts
@@ -1,0 +1,40 @@
+/**
+ * Server-side handler payload helpers.
+ *
+ * Generated AdCP response types describe the transport/wire shape. In v3.1
+ * that includes protocol envelope fields such as `status: TaskStatus`,
+ * `task_id`, and `adcp_version`. Server handlers should return only the
+ * domain payload; the SDK stamps the protocol envelope at dispatch time.
+ */
+
+import type { TaskStatus } from './tools.generated';
+
+type ProtocolTaskStatus = TaskStatus;
+
+type ProtocolStatusKey<T> = 'status' extends keyof T
+  ? NonNullable<T['status']> extends ProtocolTaskStatus
+    ? 'status'
+    : never
+  : never;
+
+type ProtocolEnvelopeKeys<T> =
+  | ProtocolStatusKey<T>
+  | 'context_id'
+  | 'task_id'
+  | 'message'
+  | 'timestamp'
+  | 'replayed'
+  | 'adcp_error'
+  | 'push_notification_config'
+  | 'payload'
+  | 'adcp_version'
+  | 'adcp_major_version';
+
+/**
+ * Domain payload shape a server handler returns for a generated wire response.
+ *
+ * Use this when a generated `*Response` type includes protocol-envelope fields
+ * the SDK owns. Domain-level `status` fields are preserved unless their entire
+ * type is the protocol `TaskStatus` vocabulary.
+ */
+export type ServerPayload<T> = T extends unknown ? Omit<T, ProtocolEnvelopeKeys<T>> : never;

--- a/test/lib/update-rights-creative-approval.test.js
+++ b/test/lib/update-rights-creative-approval.test.js
@@ -89,7 +89,10 @@ describe('updateRightsResponse builder', () => {
       implementation_date: '2026-05-02T19:00:00Z',
     };
     const response = responses.updateRightsResponse(data);
-    assert.deepEqual(response.structuredContent, data);
+    assert.deepEqual(response.structuredContent, {
+      ...data,
+      status: 'completed',
+    });
     assert.match(response.content[0].text, /rights_grant_123 updated/);
   });
 
@@ -114,7 +117,10 @@ describe('updateRightsResponse builder', () => {
       errors: [{ code: 'INVALID_REQUEST', message: 'impression_cap below delivered count' }],
     };
     const response = responses.updateRightsResponse(data);
-    assert.deepEqual(response.structuredContent, data);
+    assert.deepEqual(response.structuredContent, {
+      ...data,
+      status: 'completed',
+    });
     assert.match(response.content[0].text, /update error/i);
   });
 

--- a/test/server-create-adcp-server.test.js
+++ b/test/server-create-adcp-server.test.js
@@ -473,6 +473,25 @@ describe('createAdcpServer', () => {
       assert.strictEqual(caps.status, 'completed');
     });
 
+    it('preserves governance_context on check_governance while stamping envelope status', async () => {
+      const server = createAdcpServer({
+        name: 'Test',
+        version: '1.0.0',
+        governance: {
+          checkGovernance: async () => ({
+            check_id: 'check_1',
+            verdict: 'approved',
+            plan_id: 'plan_1',
+            explanation: 'Approved',
+            governance_context: 'gc_signed_token_123',
+          }),
+        },
+      });
+      const caps = await callTool(server, 'check_governance', {});
+      assert.strictEqual(caps.status, 'completed');
+      assert.strictEqual(caps.governance_context, 'gc_signed_token_123');
+    });
+
     it('splits MediaBuyStatus on create_media_buy into media_buy_status', async () => {
       // Legacy handlers may still return the media-buy lifecycle in `status`.
       // The server response must expose the AdCP envelope status at `status`

--- a/test/server-responses.test.js
+++ b/test/server-responses.test.js
@@ -437,13 +437,14 @@ describe('validActionsForStatus', () => {
 });
 
 describe('cancelMediaBuyResponse', () => {
-  it('sets status to canceled and valid_actions to empty', () => {
+  it('sets protocol status, media_buy_status, and valid_actions', () => {
     const result = cancelMediaBuyResponse({
       media_buy_id: 'mb_1',
       canceled_by: 'buyer',
       revision: 3,
     });
-    assert.strictEqual(result.structuredContent.status, 'canceled');
+    assert.strictEqual(result.structuredContent.status, 'completed');
+    assert.strictEqual(result.structuredContent.media_buy_status, 'canceled');
     assert.deepStrictEqual(result.structuredContent.valid_actions, []);
   });
 


### PR DESCRIPTION
## Summary

Types server and platform handler returns as domain payloads instead of generated protocol wire envelopes. The SDK still stamps envelope fields such as `status: "completed"` during dispatch, while generated wire response types remain intact for transport/client validation.

This also exports `ServerPayload<T>` plus payload aliases for the server specialism surfaces, preserves seller-supplied `governance_context`, updates the flagship seller examples to the payload-return style, and widens the packed-adopter type check to cover public server payload imports.

## Root Cause

The v8 beta generated `*Response` types model the full AdCP task envelope, including required protocol fields like `status`. Server adopters return domain payloads and rely on the SDK server wrapper to add protocol metadata, so typing handlers directly as generated wire responses forced every adapter to hand-author framework-owned fields.

## Validation

- `npm run typecheck`
- `npm run build:lib`
- `npm run typecheck:examples`
- `npm run check:adopter-types`
- `npm run check:adopter-types-narrow`
- `NODE_ENV=test node --test --test-timeout=60000 test/server-create-adcp-server.test.js`
- `npx prettier --check ...`
- `git diff --check`

Note: `build:lib` still prints existing per-tool export-name collision warnings, but exits successfully.