### PR TITLE
docs: clarify schema helper typing follow-ups

### DIFF
--- a/.changeset/product-schema-object-helpers.md
+++ b/.changeset/product-schema-object-helpers.md
@@ -3,3 +3,5 @@
 ---
 
 Restore ZodObject helper access on ProductSchema and marker-backed canonical format schemas by collapsing marker-only intersections during schema generation.
+
+Also preserve exact known-key typing for exported tool request/input schema maps while keeping dynamic string lookups explicitly nullable.

--- a/scripts/generate-zod-from-ts.ts
+++ b/scripts/generate-zod-from-ts.ts
@@ -74,6 +74,9 @@ function postProcessUndefinedImports(content: string): string {
  * of `z.ZodType<...>` so call sites that need ZodObject methods (like
  * `withOptionalAccount(...)` which constrains to `z.ZodObject<any>`)
  * keep working.
+ *
+ * Generated annotations are intentionally verbose; add new TS7056 cases here
+ * instead of hand-authoring equivalent schema declarations elsewhere.
  */
 const TS7056_SCHEMAS: Array<{ name: string; tsType?: string; objectShape?: boolean }> = [
   { name: 'AdCPAsyncResponseDataSchema' },

--- a/scripts/schemas-ensure.ts
+++ b/scripts/schemas-ensure.ts
@@ -28,8 +28,10 @@ function hasV3Cache(): boolean {
   if (!existsSync(CACHE_ROOT)) return false;
   // Any `<major>.<minor>.<patch>` directory under cache satisfies the v3
   // bundle — `sync-schemas` writes the exact upstream version, currently
-  // 3.0.1, but pin updates land here without needing a script change.
-  return readdirSync(CACHE_ROOT, { withFileTypes: true }).some(e => e.isDirectory() && /^\d+\.\d+\.\d+$/.test(e.name));
+  // 3.1.0-beta.3, but pin updates land here without needing a script change.
+  return readdirSync(CACHE_ROOT, { withFileTypes: true }).some(
+    e => e.isDirectory() && /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(e.name)
+  );
 }
 
 function hasV25Cache(): boolean {

--- a/src/lib/schemas/index.ts
+++ b/src/lib/schemas/index.ts
@@ -48,7 +48,6 @@ type ToolInputShapes = {
   [K in keyof KnownToolRequestSchemas]: ShapeOf<KnownToolRequestSchemas[K]>;
 } & {
   creative_approval: typeof schemas.CreativeApprovalRequestSchema.shape;
-  update_rights: typeof schemas.UpdateRightsRequestSchema.shape;
 } & {
   readonly [toolName: string]: Readonly<InputShape> | undefined;
 };
@@ -70,6 +69,10 @@ function shapeOf<T extends { shape?: InputShape }>(s: T | undefined): T['shape']
  * et al.) PLUS the two tools the spec models as customTool-only
  * extensions — `creative_approval` and `update_rights` — so sellers
  * don't have to hand-author shapes for those either.
+ *
+ * Known tool names retain exact `.shape` field types for IDE completion and
+ * handler inference. Arbitrary string lookups return `undefined` until callers
+ * narrow the tool name to a known key.
  *
  * If a future AdCP release adds a new tool with a generated request
  * schema, add its entry here (or to `TOOL_REQUEST_SCHEMAS` if it's

--- a/src/lib/utils/tool-request-schemas.ts
+++ b/src/lib/utils/tool-request-schemas.ts
@@ -37,6 +37,11 @@ function withOptionalAccount<TShape extends InputShape & { account: z.ZodType }>
 const CreateMediaBuyToolRequestSchema = withOptionalAccount(schemas.CreateMediaBuyRequestSchema);
 const UpdateMediaBuyToolRequestSchema = withOptionalAccount(schemas.UpdateMediaBuyRequestSchema);
 
+/**
+ * Exact schema types for tool names known at build time. Prefer this type for
+ * key-preserving helpers; use {@link ToolRequestSchemas} when accepting a
+ * runtime string that may not match a known tool.
+ */
 export type KnownToolRequestSchemas = {
   get_products: typeof schemas.GetProductsRequestSchema;
   create_media_buy: typeof CreateMediaBuyToolRequestSchema;
@@ -97,6 +102,8 @@ export type KnownToolRequestSchemas = {
 };
 
 export type ToolRequestSchemas = Readonly<KnownToolRequestSchemas> & {
+  // Dynamic lookups are supported for callers that receive tool names at
+  // runtime, but they must narrow the result before dereferencing `.shape`.
   readonly [toolName: string]: z.ZodObject<any> | undefined;
 };
 

--- a/src/type-tests/zod-object-intersections.type-test.ts
+++ b/src/type-tests/zod-object-intersections.type-test.ts
@@ -26,14 +26,17 @@ void productShape.product_id;
 
 const productPick = ProductSchema.pick({ product_id: true, name: true });
 void productPick;
+void productPick.shape.product_id;
 
 const productOmit = ProductSchema.omit({ forecast: true });
 void productOmit;
+void productOmit.shape.product_id;
 
 const productExtend = ProductSchema.extend({
   audit_id: z.string().optional(),
 });
 void productExtend;
+void productExtend.shape.audit_id;
 
 const canonicalFormatImageShape = CanonicalFormatImageSchema.shape;
 void canonicalFormatImageShape.image_formats;


### PR DESCRIPTION
## Summary
- clarify the schema helper changeset and public JSDoc for exact known-key schema maps plus nullable dynamic lookups
- point future TS7056 fixes at the generator allowlist instead of hand-authored schema declarations
- drop a redundant update_rights type intersection and strengthen ProductSchema helper-return type assertions
- make schemas:ensure recognize prerelease schema cache directories like 3.1.0-beta.3 so local builds do not refetch unnecessarily

## Validation
- npm run typecheck
- npm run build:lib
- npm run check:adopter-types