### PR TITLE
ci: add Python reference seller interop gate

### DIFF
--- a/.changeset/python-reference-seller-interop.md
+++ b/.changeset/python-reference-seller-interop.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add a Python reference seller interop workflow that gates release publishing on the candidate SDK storyboard runner.

--- a/.github/workflows/interop-python.yml
+++ b/.github/workflows/interop-python.yml
@@ -1,0 +1,111 @@
+name: Python Reference Seller Interop
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      python_ref:
+        description: 'adcp-client-python tag, branch, or commit SHA to test against'
+        required: false
+        default: 'v6.1.0-beta.2'
+  workflow_call:
+    inputs:
+      python_ref:
+        description: 'adcp-client-python tag, branch, or commit SHA to test against'
+        required: false
+        type: string
+        default: 'v6.1.0-beta.2'
+
+permissions:
+  contents: read
+
+jobs:
+  python-reference-seller:
+    name: Python reference seller
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      ADCP_CLIENT_PYTHON_REF: ${{ inputs.python_ref || 'v6.1.0-beta.2' }}
+      STORYBOARD_RESULT_PATH: ${{ github.workspace }}/storyboard-result.json
+      SELLER_LOG_PATH: ${{ github.workspace }}/storyboard-seller.log
+
+    steps:
+      - name: Checkout @adcp/sdk
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build candidate SDK
+        run: npm run build:lib
+
+      - name: Pack candidate SDK
+        id: pack
+        shell: bash
+        run: |
+          set -euo pipefail
+          pack_dir="$RUNNER_TEMP/adcp-sdk-pack"
+          mkdir -p "$pack_dir"
+          npm pack --pack-destination "$pack_dir" --silent
+          mapfile -t tarballs < <(find "$pack_dir" -maxdepth 1 -type f -name '*.tgz' -print)
+          if [[ "${#tarballs[@]}" -ne 1 ]]; then
+            echo "::error::Expected one packed SDK tarball in $pack_dir, found ${#tarballs[@]}."
+            printf '%s\n' "${tarballs[@]}"
+            exit 1
+          fi
+          tarball_path="${tarballs[0]}"
+          test -f "$tarball_path"
+          echo "tarball=$tarball_path" >> "$GITHUB_OUTPUT"
+          echo "Packed candidate SDK at $tarball_path"
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Checkout Python reference seller
+        uses: actions/checkout@v5
+        with:
+          repository: adcontextprotocol/adcp-client-python
+          ref: ${{ env.ADCP_CLIENT_PYTHON_REF }}
+          path: reference-python
+
+      - name: Verify Python storyboard harness
+        shell: bash
+        run: |
+          set -euo pipefail
+          harness="reference-python/scripts/ci/run_storyboard_reference_seller.sh"
+          if [[ ! -f "$harness" ]]; then
+            echo "::error::Pinned adcp-client-python ref '$ADCP_CLIENT_PYTHON_REF' does not contain $harness."
+            echo "::error::Pin a tag or commit that includes adcontextprotocol/adcp-client-python#818."
+            exit 1
+          fi
+          chmod +x "$harness"
+
+      - name: Run Python reference seller storyboard
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd reference-python
+          ADCP_SDK_TARBALL="${{ steps.pack.outputs.tarball }}" \
+            ADCP_PORT=3001 \
+            STORYBOARD_RESULT_PATH="$STORYBOARD_RESULT_PATH" \
+            SELLER_LOG_PATH="$SELLER_LOG_PATH" \
+            ./scripts/ci/run_storyboard_reference_seller.sh
+
+      - name: Upload storyboard artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-reference-seller-storyboard
+          if-no-files-found: ignore
+          path: |
+            storyboard-result.json
+            storyboard-seller.log

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,13 @@ permissions:
   id-token: write
 
 jobs:
+  python-interop:
+    name: Python reference seller interop
+    uses: ./.github/workflows/interop-python.yml
+
   release:
     name: Release
+    needs: python-interop
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo

--- a/scripts/schemas-ensure.ts
+++ b/scripts/schemas-ensure.ts
@@ -26,10 +26,12 @@ const CACHE_ROOT = path.join(REPO_ROOT, 'schemas/cache');
 
 function hasV3Cache(): boolean {
   if (!existsSync(CACHE_ROOT)) return false;
-  // Any `<major>.<minor>.<patch>` directory under cache satisfies the v3
-  // bundle — `sync-schemas` writes the exact upstream version, currently
-  // 3.0.1, but pin updates land here without needing a script change.
-  return readdirSync(CACHE_ROOT, { withFileTypes: true }).some(e => e.isDirectory() && /^\d+\.\d+\.\d+$/.test(e.name));
+  // Any semver-looking directory under cache satisfies the v3 bundle.
+  // `sync-schemas` writes the exact upstream version, including prerelease
+  // pins like `3.1.0-beta.3`.
+  return readdirSync(CACHE_ROOT, { withFileTypes: true }).some(
+    e => e.isDirectory() && /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(e.name)
+  );
 }
 
 function hasV25Cache(): boolean {


### PR DESCRIPTION
## Summary

- add a reusable Python reference seller interop workflow for TS candidates
- wire release publishing to depend on the Python interop gate
- pin the Python harness to `adcp-client-python@v6.1.0-beta.2`, the first known-good tag with the 3.1 reference seller fix
- allow prerelease schema cache directories in `schemas:ensure` so `3.1.0-beta.3` cache satisfies local/CI builds

Closes #1916.

## Validation

- `npx prettier --check .github/workflows/interop-python.yml .github/workflows/release.yml .changeset/python-reference-seller-interop.md scripts/schemas-ensure.ts`
- YAML parse for `.github/workflows/interop-python.yml` and `.github/workflows/release.yml`
- `npm run build:lib`
- local cross-repo harness using packed `@adcp/sdk@8.1.0-beta.8` + `adcp-client-python@v6.1.0-beta.2`: `Status: passing`, `88 passed / 0 failed / 2 skipped`, `controller_detected: true`
- pre-push hook: `npm run typecheck`, library build
