### PR TITLE
fix: handle storyboard version negotiation

### DIFF
--- a/.changeset/storyboard-version-negotiation.md
+++ b/.changeset/storyboard-version-negotiation.md
@@ -1,0 +1,7 @@
+---
+'@adcp/sdk': patch
+---
+
+fix: make storyboard runner version negotiation explicit
+
+Storyboards now inherit the AdCP version from the selected compliance cache, suppress the exact `adcp_version` marker for 3.0 cache runs, and opt into explicit 3.1 markers only when running 3.1 storyboards. The compliance runner and CLI also expose cache selection so the runner does not infer the spec line solely from the installed package version.

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -313,6 +313,28 @@ function parseAuthSchemeFlag(args) {
   return value;
 }
 
+function readFlagValue(args, flag) {
+  const idx = args.indexOf(flag);
+  if (idx !== -1 && idx + 1 < args.length && !args[idx + 1].startsWith('--')) {
+    return args[idx + 1];
+  }
+  const eqArg = args.find(a => a.startsWith(`${flag}=`));
+  return eqArg ? eqArg.slice(flag.length + 1) : null;
+}
+
+function parseComplianceSelection(args) {
+  const complianceVersion = readFlagValue(args, '--compliance-version');
+  const complianceDir = readFlagValue(args, '--compliance-dir');
+  return {
+    complianceVersion,
+    complianceDir,
+    resolveOptions: {
+      ...(complianceVersion && { version: complianceVersion }),
+      ...(complianceDir && { complianceDir }),
+    },
+  };
+}
+
 /**
  * Warn when `ADCP_AUTH_SCHEME` was set in the environment but the resolved
  * scheme didn't end up applied (because no token / no credential resolved to
@@ -925,6 +947,8 @@ function parseAgentOptions(args) {
     storyboardsValue = args[storyboardsIndex + 1];
   }
 
+  const { complianceVersion, complianceDir } = parseComplianceSelection(args);
+
   const platformTypeIndex = args.indexOf('--platform-type');
   let platformTypeValue = null;
   if (
@@ -1083,6 +1107,8 @@ function parseAgentOptions(args) {
     requestValue,
     tracksValue,
     storyboardsValue,
+    complianceVersion,
+    complianceDir,
     platformTypeValue,
     timeoutValue,
     multiInstanceStrategyValue,
@@ -1123,6 +1149,8 @@ function parseAgentOptions(args) {
     summaryFile,
     summaryFileExplicit,
     softFail,
+    complianceVersion,
+    complianceDir,
   };
 }
 
@@ -1701,6 +1729,12 @@ SUBCOMMANDS:
 RUN OPTIONS (full assessment):
   --tracks TRACKS     Comma-separated tracks to include in the report
   --storyboards IDS   Comma-separated storyboard/bundle IDs to run
+  --compliance-version VERSION
+                      Select a compliance cache version, e.g. 3.0.12 or
+                      3.1.0-beta.3. The runner uses this cache for
+                      storyboard resolution and wire-version defaults.
+  --compliance-dir PATH
+                      Use a specific compliance cache directory
   --file PATH         Run an ad-hoc storyboard YAML (spec evolution)
   --timeout SECONDS   Timeout in seconds (default: 120)
   --brief TEXT        Custom brief for product discovery
@@ -2047,6 +2081,7 @@ async function handleSpecialismShow(args) {
 async function handleStoryboardList(args) {
   const { listBundles, loadBundleStoryboards } = await import('../dist/lib/testing/storyboard/index.js');
   const jsonOutput = args.includes('--json');
+  const { resolveOptions } = parseComplianceSelection(args);
   // --stateful: keep only storyboards that contain at least one step marked
   // `stateful: true`. That's the same predicate the multi-instance runner
   // uses to identify storyboards whose write→read chains surface in-process
@@ -2055,7 +2090,7 @@ async function handleStoryboardList(args) {
 
   let bundles;
   try {
-    bundles = listBundles();
+    bundles = listBundles(resolveOptions);
   } catch (err) {
     console.error(`ERROR: ${err.message}`);
     process.exit(1);
@@ -2129,6 +2164,7 @@ async function handleStoryboardShow(args) {
     PROTOCOL_TO_PATH,
   } = await import('../dist/lib/testing/storyboard/index.js');
   const jsonOutput = args.includes('--json');
+  const { complianceVersion, complianceDir, resolveOptions } = parseComplianceSelection(args);
 
   // --specialism <slug>: resolve which storyboards are graded for a given specialism claim.
   const specialismIdx = args.indexOf('--specialism');
@@ -2141,12 +2177,16 @@ async function handleStoryboardShow(args) {
   // Guard: only exclude index specialismIdx+1 when --specialism was actually present (specialismIdx !== -1),
   // otherwise -1+1=0 would silently drop the first positional (the storyboard ID) on plain `show <id>` calls.
   const positionalArgs = args.filter(
-    (a, i) => !a.startsWith('--') && (specialismSlug === null || i !== specialismIdx + 1)
+    (a, i) =>
+      !a.startsWith('--') &&
+      a !== complianceVersion &&
+      a !== complianceDir &&
+      (specialismSlug === null || i !== specialismIdx + 1)
   );
   const storyboardId = positionalArgs[0];
 
   if (specialismSlug) {
-    const index = loadComplianceIndex();
+    const index = loadComplianceIndex(resolveOptions);
     const entry = index.specialisms.find(s => s.id === specialismSlug);
     if (!entry) {
       const known = index.specialisms.map(s => s.id).join(', ');
@@ -2164,10 +2204,13 @@ async function handleStoryboardShow(args) {
     }
     let resolved;
     try {
-      resolved = resolveStoryboardsForCapabilities({
-        specialisms: [specialismSlug],
-        supported_protocols: [snakeCaseProtocol],
-      });
+      resolved = resolveStoryboardsForCapabilities(
+        {
+          specialisms: [specialismSlug],
+          supported_protocols: [snakeCaseProtocol],
+        },
+        resolveOptions
+      );
     } catch (err) {
       console.error(`Failed to resolve specialism "${specialismSlug}": ${err.message}`);
       process.exit(1);
@@ -2216,11 +2259,11 @@ async function handleStoryboardShow(args) {
     process.exit(2);
   }
 
-  const matches = resolveBundleOrStoryboard(storyboardId);
+  const matches = resolveBundleOrStoryboard(storyboardId, resolveOptions);
   if (matches.length === 0) {
     console.error(`Storyboard or bundle not found: ${storyboardId}`);
     console.error(
-      `Available: ${listAllComplianceStoryboards()
+      `Available: ${listAllComplianceStoryboards(resolveOptions)
         .map(s => s.id)
         .join(', ')}`
     );
@@ -2228,7 +2271,7 @@ async function handleStoryboardShow(args) {
   }
 
   const storyboard = matches[0];
-  const bundle = findBundleById(storyboardId);
+  const bundle = findBundleById(storyboardId, resolveOptions);
   if (bundle && matches.length > 1 && !jsonOutput) {
     console.log(
       `\n[${bundle.kind} bundle "${bundle.id}"] contains ${matches.length} storyboards: ${matches
@@ -3332,6 +3375,7 @@ async function handleLocalAgentStoryboardRun(modulePath, args, opts) {
 
   const { runAgainstLocalAgent } = await import('../dist/lib/testing/index.js');
   const { setAgentTesterLogger } = await import('../dist/lib/testing/client.js');
+  const { resolveOptions } = parseComplianceSelection(args);
   if (!debug && !jsonOutput) {
     setAgentTesterLogger({ info: () => {}, error: () => {}, warn: () => {}, debug: () => {} });
   }
@@ -3343,9 +3387,11 @@ async function handleLocalAgentStoryboardRun(modulePath, args, opts) {
     result = await runAgainstLocalAgent({
       createAgent,
       storyboards: storyboardsSpec,
-      ...(opts.noSandbox || opts.assertsSeededState
+      compliance: resolveOptions,
+      ...(opts.complianceVersion || opts.noSandbox || opts.assertsSeededState
         ? {
             runStoryboardOptions: {
+              ...(opts.complianceVersion && { adcpVersion: opts.complianceVersion }),
               ...(opts.noSandbox && { sandbox: false, disable_sandbox: true }),
               ...(opts.assertsSeededState && { assertsSeededState: true }),
             },
@@ -3521,6 +3567,7 @@ function aggregateStrictSummaries(summaries) {
 
 async function handleMultiInstanceStoryboardRun(args, opts, urls) {
   const { authToken, authScheme, protocolFlag, jsonOutput, dryRun, positionalArgs, file: filePath } = opts;
+  const { resolveOptions } = parseComplianceSelection(args);
 
   if (urls.length < 2) {
     console.error('ERROR: Multi-instance mode requires 2+ --url flags. Drop --url for single-instance.');
@@ -3585,16 +3632,16 @@ async function handleMultiInstanceStoryboardRun(args, opts, urls) {
       process.exit(2);
     }
   } else {
-    const bundle = findBundleById(storyboardId);
+    const bundle = findBundleById(storyboardId, resolveOptions);
     if (bundle) {
-      const bundleStoryboards = loadBundleStoryboards(storyboardId);
+      const bundleStoryboards = loadBundleStoryboards(bundle);
       if (!bundleStoryboards || bundleStoryboards.length === 0) {
         console.error(`ERROR: Bundle "${storyboardId}" is empty.`);
         process.exit(2);
       }
       storyboards.push(...bundleStoryboards);
     } else {
-      const sb = getComplianceStoryboardById(storyboardId);
+      const sb = getComplianceStoryboardById(storyboardId, resolveOptions);
       if (!sb) {
         console.error(
           `ERROR: Unknown storyboard or bundle ID: ${storyboardId}\n` + `Run 'adcp storyboard list' to see all options.`
@@ -3733,6 +3780,7 @@ async function handleMultiInstanceStoryboardRun(args, opts, urls) {
     ...(opts.allowHttp && { allow_http: true }),
     multi_instance_strategy: strategy,
     ...(webhookReceiverOpts ?? {}),
+    ...(opts.complianceVersion && { adcpVersion: opts.complianceVersion }),
     ...(opts.noSandbox && { sandbox: false, disable_sandbox: true }),
     ...(opts.assertsSeededState && { assertsSeededState: true }),
   };
@@ -3841,6 +3889,7 @@ async function handleMultiInstanceStoryboardRun(args, opts, urls) {
  */
 async function handleAgentsRoutedStoryboardRun(args, opts, routing) {
   const { authToken, authScheme, protocolFlag, jsonOutput, dryRun, positionalArgs, file: filePath, format } = opts;
+  const { resolveOptions } = parseComplianceSelection(args);
 
   const webhookAutoTunnel = args.includes('--webhook-receiver-auto-tunnel');
   const webhookReceiverBase = extractWebhookReceiverOptions(args);
@@ -3887,16 +3936,16 @@ async function handleAgentsRoutedStoryboardRun(args, opts, routing) {
       process.exit(2);
     }
   } else {
-    const bundle = findBundleById(storyboardId);
+    const bundle = findBundleById(storyboardId, resolveOptions);
     if (bundle) {
-      const bundleStoryboards = loadBundleStoryboards(storyboardId);
+      const bundleStoryboards = loadBundleStoryboards(bundle);
       if (!bundleStoryboards || bundleStoryboards.length === 0) {
         console.error(`ERROR: Bundle "${storyboardId}" is empty.`);
         process.exit(2);
       }
       storyboards.push(...bundleStoryboards);
     } else {
-      const sb = getComplianceStoryboardById(storyboardId);
+      const sb = getComplianceStoryboardById(storyboardId, resolveOptions);
       if (!sb) {
         console.error(
           `ERROR: Unknown storyboard or bundle ID: ${storyboardId}\n` + `Run 'adcp storyboard list' to see all options.`
@@ -3992,6 +4041,7 @@ async function handleAgentsRoutedStoryboardRun(args, opts, routing) {
     agents: routing.agents,
     ...(routing.default_agent ? { default_agent: routing.default_agent } : {}),
     ...(webhookReceiverOpts ?? {}),
+    ...(opts.complianceVersion && { adcpVersion: opts.complianceVersion }),
     ...(opts.noSandbox && { sandbox: false, disable_sandbox: true }),
     ...(opts.assertsSeededState && { assertsSeededState: true }),
   };
@@ -4137,11 +4187,12 @@ async function runFullAssessment(agentArg, rawArgs, parsedOpts) {
   if (!storyboards && storyboardsIndex !== -1 && storyboardsIndex + 1 < rawArgs.length) {
     storyboards = rawArgs[storyboardsIndex + 1].split(',');
   }
+  const complianceResolveOptions = parseComplianceSelection(rawArgs).resolveOptions;
   if (storyboards?.length) {
     const { listAllComplianceStoryboards, listBundles } = await import('../dist/lib/testing/storyboard/index.js');
     try {
-      const knownStoryboardIds = new Set(listAllComplianceStoryboards().map(s => s.id));
-      const knownBundleIds = new Set(listBundles().map(b => b.id));
+      const knownStoryboardIds = new Set(listAllComplianceStoryboards(complianceResolveOptions).map(s => s.id));
+      const knownBundleIds = new Set(listBundles(complianceResolveOptions).map(b => b.id));
       const unknown = storyboards.filter(id => !knownStoryboardIds.has(id) && !knownBundleIds.has(id));
       if (unknown.length > 0) {
         console.error(`ERROR: Unknown storyboard or bundle ID(s): ${unknown.join(', ')}`);
@@ -4207,6 +4258,8 @@ async function runFullAssessment(agentArg, rawArgs, parsedOpts) {
     ...(opts.assertsSeededState && { assertsSeededState: true }),
     ...(mergedAssessmentHeaders && { headers: mergedAssessmentHeaders }),
     ...(loadedTestKit && { test_kit: loadedTestKit }),
+    ...(opts.complianceVersion && { version: opts.complianceVersion }),
+    ...(opts.complianceDir && { complianceDir: opts.complianceDir }),
   };
 
   if (!opts.jsonOutput) {
@@ -4301,7 +4354,7 @@ async function runFullAssessment(agentArg, rawArgs, parsedOpts) {
     // `|| true` shenanigans.
     const summary = buildComplianceSummary(result, {
       sdkVersion: LIBRARY_VERSION,
-      adcpVersion: ADCP_VERSION,
+      adcpVersion: result.adcp_version || ADCP_VERSION,
     });
     emitSummary(summary);
 
@@ -4347,6 +4400,7 @@ async function runFullAssessment(agentArg, rawArgs, parsedOpts) {
 async function handleStoryboardStepCmd(args) {
   const { getComplianceStoryboardById, runStoryboardStep } = await import('../dist/lib/testing/storyboard/index.js');
   const { authToken, authScheme, protocolFlag, jsonOutput, debug, positionalArgs } = parseAgentOptions(args);
+  const { resolveOptions } = parseComplianceSelection(args);
 
   enforceStrictFlags(args, warnRemovedFlags(args));
 
@@ -4359,7 +4413,7 @@ async function handleStoryboardStepCmd(args) {
     process.exit(2);
   }
 
-  const storyboard = getComplianceStoryboardById(storyboardId);
+  const storyboard = getComplianceStoryboardById(storyboardId, resolveOptions);
   if (!storyboard) {
     console.error(`Storyboard not found: ${storyboardId}`);
     process.exit(2);

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -257,6 +257,9 @@ adcp storyboard run myagent --storyboards creative-template
 # Limit to a subset of tracks
 adcp storyboard run myagent --tracks core,products,media_buy
 
+# Pin the compliance cache/spec line used for storyboard resolution
+adcp storyboard run myagent --compliance-version 3.0.12
+
 # Recommended for CI: --json for machine-readable output + --strict-flags
 # so stale flags fail the build instead of passing advisory warnings.
 adcp storyboard run https://agent.example.com/mcp --auth "$ADCP_AUTH_TOKEN" --json --strict-flags
@@ -278,6 +281,8 @@ Useful flags:
 
 - `--storyboards ID,...`: Run specific storyboard or bundle IDs instead of capability-driven selection
 - `--tracks core,products,...`: Restrict the run to specific tracks
+- `--compliance-version VERSION`: Select the compliance cache/spec line, for example `3.0.12` or `3.1.0-beta.3`; use the same flag with `storyboard list`, `show`, and `step` when reproducing a pinned run
+- `--compliance-dir PATH`: Use a specific compliance cache directory, mainly for local protocol/cache development
 - `--brief TEXT`: Override the default sample discovery brief
 - `--dry-run`: Preview steps without executing
 - `--json`: Emit machine-readable output for automation

--- a/docs/guides/VALIDATE-YOUR-AGENT.md
+++ b/docs/guides/VALIDATE-YOUR-AGENT.md
@@ -68,6 +68,9 @@ npx @adcp/sdk@latest storyboard run http://localhost:3001/mcp sales-guaranteed -
 # Specific tracks only (faster feedback when iterating)
 npx @adcp/sdk@latest storyboard run http://localhost:3001/mcp --tracks core,products --auth $TOKEN
 
+# Pin a specific compliance cache/spec line
+npx @adcp/sdk@latest storyboard run http://localhost:3001/mcp --compliance-version 3.0.12 --auth $TOKEN
+
 # Ad-hoc YAML (new storyboards under development)
 npx @adcp/sdk@latest storyboard run http://localhost:3001/mcp --file ./my-wip.yaml --auth $TOKEN
 
@@ -79,6 +82,8 @@ npx @adcp/sdk@latest storyboard run http://localhost:3001/mcp --json > report.js
 
 - `--tracks <a,b,c>` — limit to named tracks (e.g., `core,products,security_baseline`)
 - `--storyboards <id1,id2>` — limit to specific storyboard IDs
+- `--compliance-version <version>` — select the compliance cache/spec line used for resolution and request version intent; pass the same flag to `storyboard list`, `show`, and `step` when reproducing a pinned run
+- `--compliance-dir <path>` — use a specific compliance cache directory for local protocol/cache development
 - `--webhook-receiver [loopback|proxy]` — host a webhook sink so async steps grade instead of skip
 - `--webhook-receiver-auto-tunnel` — autodetect `ngrok`/`cloudflared` on `PATH`, spawn and plug into proxy mode
 - `--invariants <mod1,mod2>` — load custom cross-step assertion modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/sdk",
-  "version": "8.1.0-beta.8",
+  "version": "8.1.0-beta.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/sdk",
-      "version": "8.1.0-beta.8",
+      "version": "8.1.0-beta.9",
       "license": "Apache-2.0",
       "workspaces": [
         ".",
@@ -7348,7 +7348,7 @@
       "version": "6.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adcp/sdk": "^8.1.0-beta.8"
+        "@adcp/sdk": "^8.1.0-beta.9"
       },
       "bin": {
         "adcp": "bin/adcp.js"

--- a/src/lib/core/AgentClient.ts
+++ b/src/lib/core/AgentClient.ts
@@ -167,6 +167,7 @@ export type AdcpTaskName = keyof TaskResponseTypeMap;
 export type InProcessAgentClientConfig = Pick<
   SingleAgentClientConfig,
   | 'adcpVersion'
+  | 'versionEnvelope'
   | 'debug'
   | 'validation'
   | 'governance'

--- a/src/lib/core/GovernanceMiddleware.ts
+++ b/src/lib/core/GovernanceMiddleware.ts
@@ -129,7 +129,8 @@ export class GovernanceMiddleware {
      * Defaults to `undefined`, which `ProtocolClient.callTool` resolves
      * to the SDK constant — same shape as a no-pin call.
      */
-    private adcpVersion?: string
+    private adcpVersion?: string,
+    private versionEnvelope?: import('../protocols').VersionEnvelopeMode
   ) {}
 
   /**
@@ -214,6 +215,7 @@ export class GovernanceMiddleware {
       const response = await ProtocolClient.callTool(config.agent, 'check_governance', request as Record<string, any>, {
         debugLogs,
         adcpVersion: this.adcpVersion,
+        ...(this.versionEnvelope !== undefined && { versionEnvelope: this.versionEnvelope }),
       });
 
       // Unwrap protocol response (MCP text content, structuredContent, A2A artifacts)
@@ -332,7 +334,11 @@ export class GovernanceMiddleware {
         config.agent,
         'report_plan_outcome',
         request as Record<string, any>,
-        { debugLogs, adcpVersion: this.adcpVersion }
+        {
+          debugLogs,
+          adcpVersion: this.adcpVersion,
+          ...(this.versionEnvelope !== undefined && { versionEnvelope: this.versionEnvelope }),
+        }
       );
 
       const responseData = unwrapProtocolResponse(response) as unknown as ReportPlanOutcomeResponse;

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -5,8 +5,7 @@ import * as schemas from '../types/schemas.generated';
 import type { AgentConfig } from '../types';
 import { ADCP_ENVELOPE_FIELDS } from '../types/adcp';
 import { parseAdcpMajorVersion, type AdcpVersion } from '../version';
-import { resolveAdcpVersion } from '../utils/adcp-version-config';
-import { resolveBundleKey } from '../validation/schema-loader';
+import { isAdcpVersionSupported, resolveAdcpVersion } from '../utils/adcp-version-config';
 import type {
   GetProductsRequest,
   GetProductsResponse,
@@ -198,6 +197,12 @@ export interface SingleAgentClientConfig extends ConversationConfig {
    * accepting forward-compatible strings.
    */
   adcpVersion?: AdcpVersion | (string & {});
+  /**
+   * Controls emission of AdCP version envelope fields. Defaults to `auto`.
+   * `none` is primarily for conformance harnesses that need to send a
+   * request exactly as authored, without SDK-managed version fields.
+   */
+  versionEnvelope?: import('../protocols').VersionEnvelopeMode;
   /** Enable debug logging */
   debug?: boolean;
   /** Custom User-Agent header sent with all outbound protocol requests.
@@ -453,6 +458,7 @@ export class SingleAgentClient {
       onActivity: config.onActivity,
       governance: config.governance,
       adcpVersion: this.resolvedAdcpVersion,
+      ...(config.versionEnvelope !== undefined && { versionEnvelope: config.versionEnvelope }),
       transport: config.transport,
     });
 
@@ -3277,8 +3283,7 @@ export class SingleAgentClient {
     // matches only against another `'3.1.0-beta.1'`, not `'3.1'`.
     const supportedVersions = capabilities.supportedVersions;
     if (supportedVersions !== undefined && supportedVersions.length > 0) {
-      const expectedKey = resolveBundleKey(this.resolvedAdcpVersion);
-      if (!supportedVersions.includes(expectedKey)) {
+      if (!isAdcpVersionSupported(this.resolvedAdcpVersion, supportedVersions)) {
         throw new VersionUnsupportedError(taskType, 'version', capabilities.version, this.agent.agent_uri);
       }
     } else {

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -319,6 +319,7 @@ export class TaskExecutor {
        * truth for both validation and wire-level major.
        */
       adcpVersion?: string;
+      versionEnvelope?: import('../protocols').VersionEnvelopeMode;
       /**
        * Transport-level safeguards applied to every call this executor
        * dispatches. Per-call options can override individual fields.
@@ -331,7 +332,12 @@ export class TaskExecutor {
       this.conversationStorage = new Map();
     }
     if (config.governance) {
-      this.governanceMiddleware = new GovernanceMiddleware(config.governance, config.onActivity, config.adcpVersion);
+      this.governanceMiddleware = new GovernanceMiddleware(
+        config.governance,
+        config.onActivity,
+        config.adcpVersion,
+        config.versionEnvelope
+      );
     }
     const modes = resolveValidationModes(config.validation);
     this.requestValidationMode = modes.requests;
@@ -585,6 +591,7 @@ export class TaskExecutor {
         serverVersion,
         session: { contextId: options.contextId, taskId: options.taskId },
         adcpVersion: this.config.adcpVersion,
+        ...(this.config.versionEnvelope !== undefined && { versionEnvelope: this.config.versionEnvelope }),
         transport: options.transport ?? this.config.transport,
       });
 
@@ -1333,6 +1340,7 @@ export class TaskExecutor {
       {
         serverVersion: this.lastKnownServerVersion,
         adcpVersion: this.config.adcpVersion,
+        ...(this.config.versionEnvelope !== undefined && { versionEnvelope: this.config.versionEnvelope }),
         transport: transport ?? this.config.transport,
       }
     )) as Record<string, unknown>;
@@ -1394,6 +1402,7 @@ export class TaskExecutor {
       {
         serverVersion: this.lastKnownServerVersion,
         adcpVersion: this.config.adcpVersion,
+        ...(this.config.versionEnvelope !== undefined && { versionEnvelope: this.config.versionEnvelope }),
         transport: transport ?? this.config.transport,
       }
     )) as Record<string, unknown>;
@@ -1683,6 +1692,7 @@ export class TaskExecutor {
         debugLogs,
         serverVersion: this.lastKnownServerVersion,
         adcpVersion: this.config.adcpVersion,
+        ...(this.config.versionEnvelope !== undefined && { versionEnvelope: this.config.versionEnvelope }),
         transport: options.transport ?? this.config.transport,
       }
     );

--- a/src/lib/protocols/index.ts
+++ b/src/lib/protocols/index.ts
@@ -50,6 +50,8 @@ import { resolveBundleKey, toReleasePrecisionWire, validateAdcpVersionWire } fro
 import { buildAgentSigningContext, CAPABILITY_OP, ensureCapabilityLoaded } from '../signing/client';
 import { withResponseSizeLimit } from './responseSizeLimit';
 
+export type VersionEnvelopeMode = 'auto' | 'none';
+
 /**
  * Derive the wire-level `adcp_major_version` integer from a caller-supplied
  * pin. Returns the SDK default when no pin is provided; throws on a pin
@@ -233,6 +235,13 @@ export interface CallToolOptions {
    */
   adcpVersion?: string;
   /**
+   * Controls whether the SDK injects AdCP version envelope fields into the
+   * outgoing request. Defaults to `auto`. 3.0 pins emit only the legacy
+   * `adcp_major_version`; 3.1+ pins emit both the legacy major and exact
+   * `adcp_version` marker.
+   */
+  versionEnvelope?: VersionEnvelopeMode;
+  /**
    * Transport-level safeguards (size caps, etc.). Per-call override of any
    * matching field on the client constructor's `transport` option.
    */
@@ -265,6 +274,7 @@ export class ProtocolClient {
       serverVersion,
       session,
       adcpVersion,
+      versionEnvelope: versionEnvelopeMode = 'auto',
       transport,
     } = options;
     // Per-instance version envelope. Throws on unparseable pins via
@@ -273,7 +283,7 @@ export class ProtocolClient {
     // `ProtocolClient.callTool` directly (test harnesses, the in-process
     // MCP path). Returns `{ adcp_major_version }` for 3.0 pins and
     // `{ adcp_major_version, adcp_version }` for 3.1+ pins.
-    const versionEnvelope = buildVersionEnvelope(adcpVersion, serverVersion);
+    const versionEnvelope = versionEnvelopeMode === 'none' ? {} : buildVersionEnvelope(adcpVersion, serverVersion);
     // Enter the response-size-limit ALS slot once for this call. The slot is
     // read by `wrapFetchWithSizeLimit` in both protocol transports, so the
     // cap applies regardless of which path (MCP / A2A / OAuth refresh) the
@@ -336,6 +346,7 @@ export class ProtocolClient {
                 debugLogs,
                 serverVersion,
                 adcpVersion,
+                ...(versionEnvelopeMode !== 'auto' && { versionEnvelope: versionEnvelopeMode }),
               })
             );
           }
@@ -536,12 +547,13 @@ export const createMCPClient = (
   headers?: Record<string, string>,
   serverVersion?: 'v2' | 'v3',
   adcpVersion?: string,
-  transport?: TransportOptions
+  transport?: TransportOptions,
+  versionEnvelopeMode: VersionEnvelopeMode = 'auto'
 ) => {
   // Validate the pin at factory time so a typo surfaces here rather than at
   // first call. `buildVersionEnvelope` throws via `resolveWireMajor` on bad
   // input — call it once to surface, then close over the envelope.
-  const versionEnvelope = buildVersionEnvelope(adcpVersion, serverVersion);
+  const versionEnvelope = versionEnvelopeMode === 'none' ? {} : buildVersionEnvelope(adcpVersion, serverVersion);
   return {
     callTool: (toolName: string, args: Record<string, unknown>, debugLogs?: DebugLogEntry[]) =>
       withResponseSizeLimit(transport?.maxResponseBytes, () =>
@@ -563,9 +575,10 @@ export const createA2AClient = (
   headers?: Record<string, string>,
   serverVersion?: 'v2' | 'v3',
   adcpVersion?: string,
-  transport?: TransportOptions
+  transport?: TransportOptions,
+  versionEnvelopeMode: VersionEnvelopeMode = 'auto'
 ) => {
-  const versionEnvelope = buildVersionEnvelope(adcpVersion, serverVersion);
+  const versionEnvelope = versionEnvelopeMode === 'none' ? {} : buildVersionEnvelope(adcpVersion, serverVersion);
   return {
     callTool: (toolName: string, parameters: Record<string, unknown>, debugLogs?: DebugLogEntry[]) =>
       withResponseSizeLimit(transport?.maxResponseBytes, () =>

--- a/src/lib/testing/client.ts
+++ b/src/lib/testing/client.ts
@@ -21,6 +21,15 @@ import { injectLegacyEnvelopeStatus } from '../utils/envelope-status-compat';
 import { parseCapabilitiesResponse } from '../utils/capabilities';
 import { classifyProbeUrl } from '../utils/probe-policy';
 import { SsrfRefusedError } from '../net/ssrf-fetch';
+import { ADCP_VERSION } from '../version';
+import type { VersionEnvelopeMode } from '../protocols';
+
+const TEST_CLIENT_VERSION_OPTIONS = Symbol('adcp.testClientVersionOptions');
+
+interface TestClientVersionOptions {
+  adcpVersion: string;
+  versionEnvelope: VersionEnvelopeMode;
+}
 
 /**
  * Extract a principal identifier from TestOptions auth.
@@ -177,13 +186,27 @@ export function createTestClient(agentUrl: string, protocol: 'mcp' | 'a2a' = 'mc
   const multiClient = new ADCPMultiAgentClient([agentConfig], {
     headers,
     validation: { logSchemaViolations: false },
+    ...(options.adcpVersion !== undefined && { adcpVersion: options.adcpVersion }),
+    ...(options.versionEnvelope !== undefined && { versionEnvelope: options.versionEnvelope }),
     ...(options.userAgent && { userAgent: options.userAgent }),
   });
 
-  return multiClient.agent('test');
+  const client = multiClient.agent('test');
+  Object.defineProperty(client, TEST_CLIENT_VERSION_OPTIONS, {
+    value: {
+      adcpVersion: multiClient.getAdcpVersion(),
+      versionEnvelope: options.versionEnvelope ?? 'auto',
+    } satisfies TestClientVersionOptions,
+    enumerable: false,
+  });
+  return client;
 }
 
 export type TestClient = ReturnType<typeof createTestClient>;
+export interface TestClientResolution {
+  client: TestClient;
+  reusedShared: boolean;
+}
 
 /**
  * Return a shared client from options (set by comply()) or create a fresh one.
@@ -191,7 +214,25 @@ export type TestClient = ReturnType<typeof createTestClient>;
  * so scenarios reuse the same MCP connection instead of opening 36+ connections.
  */
 export function getOrCreateClient(agentUrl: string, options: TestOptions): TestClient {
-  return (options._client as TestClient) ?? createTestClient(agentUrl, options.protocol || 'mcp', options);
+  return getOrCreateClientResolution(agentUrl, options).client;
+}
+
+export function getOrCreateClientResolution(agentUrl: string, options: TestOptions): TestClientResolution {
+  const shared = options._client as TestClient | undefined;
+  if (shared && testClientMatchesVersionOptions(shared, options)) {
+    return { client: shared, reusedShared: true };
+  }
+  return { client: createTestClient(agentUrl, options.protocol || 'mcp', options), reusedShared: false };
+}
+
+function testClientMatchesVersionOptions(client: TestClient, options: TestOptions): boolean {
+  const meta = (client as unknown as { [TEST_CLIENT_VERSION_OPTIONS]?: TestClientVersionOptions })[
+    TEST_CLIENT_VERSION_OPTIONS
+  ];
+  if (!meta) return options.adcpVersion === undefined && options.versionEnvelope === undefined;
+  const expectedAdcpVersion = options.adcpVersion ?? ADCP_VERSION;
+  const expectedVersionEnvelope = options.versionEnvelope ?? 'auto';
+  return meta.adcpVersion === expectedAdcpVersion && meta.versionEnvelope === expectedVersionEnvelope;
 }
 
 /**
@@ -358,6 +399,8 @@ export async function discoverAgentProfile(
         profile.raw_capabilities = caps.data;
         const parsed = parseCapabilitiesResponse(caps.data);
         profile.adcp_version = parsed.version;
+        profile.adcp_major_versions = parsed.majorVersions;
+        if (parsed.supportedVersions !== undefined) profile.adcp_supported_versions = parsed.supportedVersions;
         profile.supported_protocols = parsed.protocols;
         profile.supports_governance = parsed.protocols.includes('governance');
         profile.supports_si = parsed.protocols.includes('sponsored_intelligence');

--- a/src/lib/testing/compliance/comply.ts
+++ b/src/lib/testing/compliance/comply.ts
@@ -11,7 +11,7 @@
 import { createTestClient, discoverAgentProfile } from '../client';
 import type { TestOptions, TestResult, AgentProfile } from '../types';
 import { mapStoryboardResultsToTrackResult, TRACK_LABELS } from './storyboard-tracks';
-import { runStoryboard } from '../storyboard/runner';
+import { applyAdcpVersionRunOptions, runStoryboard } from '../storyboard/runner';
 import { validateTestKit } from '../storyboard/test-kit';
 import { checkAccountDiscoveryGate } from './spec-conformance';
 
@@ -25,8 +25,9 @@ import {
   resolveStoryboardsForCapabilities,
   resolveBundleOrStoryboard,
   listAllComplianceStoryboards,
+  loadComplianceIndex,
 } from '../storyboard/compliance';
-import type { NotApplicableStoryboard } from '../storyboard/compliance';
+import type { NotApplicableStoryboard, ResolveOptions } from '../storyboard/compliance';
 import type { RunnerNotice, Storyboard, StoryboardResult, StoryboardRunOptions } from '../storyboard/types';
 import type {
   ComplianceTrack,
@@ -494,6 +495,10 @@ export interface ComplyOptions extends TestOptions {
    * `runStoryboard`. See `StoryboardRunOptions.contracts`.
    */
   contracts?: StoryboardRunOptions['contracts'];
+  /** Explicit compliance cache version override. */
+  version?: string;
+  /** Explicit compliance cache directory override. */
+  complianceDir?: string;
 }
 
 /**
@@ -578,13 +583,13 @@ function fenceAgentText(text: string, max = 500): string {
 // Storyboard resolution
 // ────────────────────────────────────────────────────────────────────────────
 
-function resolveExplicitStoryboards(ids: string[]): Storyboard[] {
+function resolveExplicitStoryboards(ids: string[], resolveOptions: ResolveOptions = {}): Storyboard[] {
   const resolved: Storyboard[] = [];
   const seen = new Set<string>();
   for (const id of ids) {
-    const matched = resolveBundleOrStoryboard(id);
+    const matched = resolveBundleOrStoryboard(id, resolveOptions);
     if (matched.length === 0) {
-      const available = listAllComplianceStoryboards();
+      const available = listAllComplianceStoryboards(resolveOptions);
       throw new Error(
         `Unknown storyboard or bundle ID: "${id}". ` +
           `Available IDs include: ${available
@@ -602,15 +607,22 @@ function resolveExplicitStoryboards(ids: string[]): Storyboard[] {
   return resolved;
 }
 
-function resolveFromCapabilities(profile: AgentProfile): {
+function resolveFromCapabilities(
+  profile: AgentProfile,
+  resolveOptions: ResolveOptions = {}
+): {
   storyboards: Storyboard[];
   not_applicable: NotApplicableStoryboard[];
 } {
-  const { storyboards, not_applicable } = resolveStoryboardsForCapabilities({
-    supported_protocols: profile.supported_protocols,
-    specialisms: profile.specialisms,
-    major_versions: profile.adcp_major_versions,
-  });
+  const { storyboards, not_applicable } = resolveStoryboardsForCapabilities(
+    {
+      supported_protocols: profile.supported_protocols,
+      specialisms: profile.specialisms,
+      major_versions: profile.adcp_major_versions,
+      supported_versions: profile.adcp_supported_versions,
+    },
+    resolveOptions
+  );
   return { storyboards, not_applicable };
 }
 
@@ -620,12 +632,12 @@ function resolveFromCapabilities(profile: AgentProfile): {
  * bundle (e.g., `sales-guaranteed` → `media_buy_seller/governance_approved`),
  * so the lookup spans every cached storyboard — not just the declared set.
  */
-function expandScenarios(storyboards: Storyboard[]): Storyboard[] {
+function expandScenarios(storyboards: Storyboard[], resolveOptions: ResolveOptions = {}): Storyboard[] {
   const seen = new Set(storyboards.map(s => s.id));
   const expanded: Storyboard[] = [];
   let allStoryboardsCache: Storyboard[] | null = null;
   const lookupById = (id: string): Storyboard | undefined => {
-    if (!allStoryboardsCache) allStoryboardsCache = listAllComplianceStoryboards();
+    if (!allStoryboardsCache) allStoryboardsCache = listAllComplianceStoryboards(resolveOptions);
     return allStoryboardsCache.find(s => s.id === id);
   };
 
@@ -778,7 +790,8 @@ function buildNotApplicableStoryboardResult(agentUrl: string, na: NotApplicableS
 export function extractFailures(
   results: StoryboardResult[],
   storyboards: Storyboard[],
-  agentRef: string
+  agentRef: string,
+  fixOptions: { complianceVersion?: string; complianceDir?: string } = {}
 ): ComplianceFailure[] {
   const failures: ComplianceFailure[] = [];
 
@@ -831,7 +844,7 @@ export function extractFailures(
           error: step.error,
           ...(step.adcp_error && { adcp_error: step.adcp_error }),
           expected,
-          fix_command: `adcp storyboard step ${agentRef} ${result.storyboard_id} ${step.step_id} --json`,
+          fix_command: buildFixCommand(agentRef, result.storyboard_id, step.step_id, fixOptions),
           ...(validationSummary && { validation: validationSummary }),
         });
       }
@@ -839,6 +852,22 @@ export function extractFailures(
   }
 
   return failures;
+}
+
+function buildFixCommand(
+  agentRef: string,
+  storyboardId: string,
+  stepId: string,
+  options: { complianceVersion?: string; complianceDir?: string }
+): string {
+  const parts = ['adcp', 'storyboard', 'step', agentRef, storyboardId, stepId, '--json'];
+  if (options.complianceVersion) parts.push('--compliance-version', options.complianceVersion);
+  if (options.complianceDir) parts.push('--compliance-dir', options.complianceDir);
+  return parts.map(shellArg).join(' ');
+}
+
+function shellArg(value: string): string {
+  return /^[A-Za-z0-9_./:@%+=,-]+$/.test(value) ? value : `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -854,8 +883,15 @@ async function complyImpl(agentUrl: string, options: ComplyOptions): Promise<Com
     signal: externalSignal,
     webhook_receiver,
     contracts,
+    version,
+    complianceDir,
     ...testOptions
   } = options;
+  const resolveOptions: ResolveOptions = {
+    ...(version !== undefined && { version }),
+    ...(complianceDir !== undefined && { complianceDir }),
+  };
+  const complianceIndex = loadComplianceIndex(resolveOptions);
 
   // Validate timeout_ms
   if (timeout_ms !== undefined) {
@@ -891,11 +927,11 @@ async function complyImpl(agentUrl: string, options: ComplyOptions): Promise<Com
   const signal = abortController?.signal;
 
   try {
-    const effectiveOptions: TestOptions = {
+    const effectiveOptions: TestOptions = applyAdcpVersionRunOptions(complianceIndex.adcp_version, {
       ...testOptions,
       sandbox: testOptions.sandbox !== false,
       test_session_id: testOptions.test_session_id || `comply-${Date.now()}`,
-    };
+    });
 
     // Check for abort before starting
     signal?.throwIfAborted();
@@ -906,8 +942,16 @@ async function complyImpl(agentUrl: string, options: ComplyOptions): Promise<Com
     // Discover agent capabilities once and share across all storyboards.
     // Pass the combined signal so a slow/unresponsive agent can't hold the
     // comply pipeline past its own timeout (adcp-client#1612).
-    const client = createTestClient(agentUrl, effectiveOptions.protocol ?? 'mcp', effectiveOptions);
-    const { profile, step: profileStep } = await discoverAgentProfile(client, signal);
+    const discoveryOptions =
+      testOptions.versionEnvelope === undefined
+        ? { ...effectiveOptions, versionEnvelope: 'none' as const }
+        : effectiveOptions;
+    const discoveryClient = createTestClient(agentUrl, effectiveOptions.protocol ?? 'mcp', discoveryOptions);
+    const { profile, step: profileStep } = await discoverAgentProfile(discoveryClient, signal);
+    const client =
+      discoveryOptions === effectiveOptions
+        ? discoveryClient
+        : createTestClient(agentUrl, effectiveOptions.protocol ?? 'mcp', effectiveOptions);
     effectiveOptions._client = client;
     effectiveOptions._profile = profile;
 
@@ -983,8 +1027,8 @@ async function complyImpl(agentUrl: string, options: ComplyOptions): Promise<Com
       if (authCheck.isAuth) {
         const degraded: AgentProfile = { name: profile.name || 'Unknown (auth required)', tools: [] };
         const candidate = explicitStoryboards?.length
-          ? resolveExplicitStoryboards(explicitStoryboards)
-          : resolveFromCapabilities(degraded).storyboards;
+          ? resolveExplicitStoryboards(explicitStoryboards, resolveOptions)
+          : resolveFromCapabilities(degraded, resolveOptions).storyboards;
         const runnable = candidate.filter(sb => (sb.required_tools?.length ?? 0) === 0 || sb.track === 'security');
         if (runnable.length > 0) {
           allObservations.push(...authCheck.observations);
@@ -1000,11 +1044,20 @@ async function complyImpl(agentUrl: string, options: ComplyOptions): Promise<Com
             effectiveOptions,
             allObservations,
             start,
+            complianceIndex.adcp_version,
             signal
           );
         }
       }
-      return buildUnreachableResult(agentUrl, profile, profileStep.error, start, effectiveOptions, signal);
+      return buildUnreachableResult(
+        agentUrl,
+        profile,
+        profileStep.error,
+        start,
+        effectiveOptions,
+        complianceIndex.adcp_version,
+        signal
+      );
     }
 
     // Resolve storyboards: explicit IDs override capability-driven selection.
@@ -1012,13 +1065,13 @@ async function complyImpl(agentUrl: string, options: ComplyOptions): Promise<Com
     let notApplicable: NotApplicableStoryboard[] = [];
     let missingToolStoryboards: NotApplicableStoryboard[] = [];
     if (explicitStoryboards?.length) {
-      initialStoryboards = resolveExplicitStoryboards(explicitStoryboards);
+      initialStoryboards = resolveExplicitStoryboards(explicitStoryboards, resolveOptions);
     } else {
-      const resolved = resolveFromCapabilities(profile);
+      const resolved = resolveFromCapabilities(profile, resolveOptions);
       initialStoryboards = resolved.storyboards;
       notApplicable = resolved.not_applicable;
     }
-    const applicableStoryboards = expandScenarios(initialStoryboards);
+    const applicableStoryboards = expandScenarios(initialStoryboards, resolveOptions);
 
     // For capability-resolved runs, exclude storyboards and injected scenarios whose
     // required_tools are absent from the agent's discovered toolset. These are
@@ -1151,7 +1204,10 @@ async function complyImpl(agentUrl: string, options: ComplyOptions): Promise<Com
     const overallStatus = computeOverallStatus(summary);
 
     const agentRef = options.agent_alias || agentUrl;
-    const failures = extractFailures(storyboardResults, runnableStoryboards, agentRef);
+    const failures = extractFailures(storyboardResults, runnableStoryboards, agentRef, {
+      complianceVersion: complianceIndex.adcp_version,
+      ...(complianceDir !== undefined && { complianceDir }),
+    });
 
     // Aggregate notices from all storyboard runs. Dedup is by `code` (each
     // notice type appears once in the rollup), but the per-occurrence
@@ -1178,6 +1234,7 @@ async function complyImpl(agentUrl: string, options: ComplyOptions): Promise<Com
 
     return {
       agent_url: agentUrl,
+      adcp_version: complianceIndex.adcp_version,
       agent_profile: profile,
       overall_status: overallStatus,
       tracks: trackResults,
@@ -1322,6 +1379,7 @@ async function runWithDegradedProfile(
   effectiveOptions: TestOptions,
   seededObservations: AdvisoryObservation[],
   start: number,
+  adcpVersion: string,
   signal?: AbortSignal
 ): Promise<ComplianceResult> {
   const allObservations: AdvisoryObservation[] = [...seededObservations];
@@ -1362,7 +1420,10 @@ async function runWithDegradedProfile(
   const summary = buildSummary(trackResults, storyboardResults);
   const overallStatus = computeOverallStatus(summary);
   const agentRef = options.agent_alias || agentUrl;
-  const failures = extractFailures(storyboardResults, storyboards, agentRef);
+  const failures = extractFailures(storyboardResults, storyboards, agentRef, {
+    complianceVersion: adcpVersion,
+    ...(options.complianceDir !== undefined && { complianceDir: options.complianceDir }),
+  });
 
   // Tag canonical vs reference views to disambiguate the same
   // TrackResult appearing in both `tracks` and `tested_tracks`
@@ -1370,6 +1431,7 @@ async function runWithDegradedProfile(
   for (const t of trackResults) t._view = 'canonical';
   return {
     agent_url: agentUrl,
+    adcp_version: adcpVersion,
     agent_profile: profile,
     overall_status: overallStatus,
     tracks: trackResults,
@@ -1401,6 +1463,7 @@ async function buildUnreachableResult(
   errorMsg: string | undefined,
   start: number,
   _effectiveOptions: TestOptions,
+  adcpVersion: string,
   signal?: AbortSignal
 ): Promise<ComplianceResult> {
   const { isAuth, observations } = await detectAuthRejection(agentUrl, errorMsg, signal);
@@ -1408,6 +1471,7 @@ async function buildUnreachableResult(
   const headline = isAuth ? `Authentication required` : `Agent unreachable — ${err}`;
   return {
     agent_url: agentUrl,
+    adcp_version: adcpVersion,
     agent_profile: profile,
     overall_status: (isAuth ? 'auth_required' : 'unreachable') as OverallStatus,
     tracks: [],

--- a/src/lib/testing/compliance/types.ts
+++ b/src/lib/testing/compliance/types.ts
@@ -127,6 +127,8 @@ export interface ComplianceFailure {
 
 export interface ComplianceResult {
   agent_url: string;
+  /** AdCP compliance cache version used for this assessment. */
+  adcp_version?: string;
   agent_profile: AgentProfile;
   /** Machine-readable overall status */
   overall_status: OverallStatus;

--- a/src/lib/testing/index.ts
+++ b/src/lib/testing/index.ts
@@ -230,6 +230,8 @@ export {
   // Runner
   runStoryboard,
   runStoryboardStep,
+  applyAdcpVersionRunOptions,
+  applyStoryboardVersionOptions,
   getFirstStepPreview,
   // Parser (single-file load for spec evolution)
   parseStoryboard,
@@ -244,6 +246,7 @@ export {
   findBundleById,
   resolveBundleOrStoryboard,
   resolveStoryboardsForCapabilities,
+  isComplianceVersionSupported,
   CapabilityResolutionError,
   // Task mapping
   TASK_TO_METHOD,

--- a/src/lib/testing/storyboard/compliance.ts
+++ b/src/lib/testing/storyboard/compliance.ts
@@ -13,6 +13,7 @@ import { join, resolve } from 'path';
 import { loadStoryboardFile } from './loader';
 import { ADCP_VERSION } from '../../version';
 import { ADCPError } from '../../errors';
+import { isAdcpVersionSupported } from '../../utils/adcp-version-config';
 import { synthesizeRequestSigningSteps } from './request-signing/synthesize';
 import type { Storyboard } from './types';
 
@@ -21,7 +22,11 @@ import type { Storyboard } from './types';
  * surfaces. `unknown_protocol` is reserved for future use — today it emits a
  * `console.warn` rather than throwing.
  */
-export type CapabilityResolutionCode = 'specialism_parent_protocol_missing' | 'unknown_specialism' | 'unknown_protocol';
+export type CapabilityResolutionCode =
+  | 'specialism_parent_protocol_missing'
+  | 'unknown_specialism'
+  | 'unknown_protocol'
+  | 'unsupported_adcp_version';
 
 /**
  * Thrown when the agent's declared capabilities cannot be mapped onto the
@@ -103,6 +108,8 @@ export interface BundleRef {
   id: string;
   /** Path to the bundle directory (or YAML file, for universal bundles). */
   path: string;
+  /** AdCP cache version this bundle came from. */
+  adcp_version?: string;
 }
 
 export interface AgentCapabilities {
@@ -117,6 +124,12 @@ export interface AgentCapabilities {
    * run against an agent that predates them. Unset → no version gating.
    */
   major_versions?: number[];
+  /**
+   * Exact/release-precision AdCP versions the seller supports, from
+   * `get_adcp_capabilities.adcp.supported_versions`. When present, the
+   * runner treats it as more specific than `major_versions`.
+   */
+  supported_versions?: string[];
 }
 
 /** Reason a storyboard was not run against an agent. */
@@ -246,7 +259,11 @@ function loadStoryboardsFromDir(dir: string): Storyboard[] {
 /** Load storyboards for a single bundle (universal YAML file, domain dir, or specialism dir). */
 export function loadBundleStoryboards(ref: BundleRef): Storyboard[] {
   const raw = ref.kind === 'universal' ? safeLoadUniversal(ref.path) : loadStoryboardsFromDir(ref.path);
-  return raw.map(postProcessStoryboard);
+  return raw.map(sb => annotateStoryboardVersion(postProcessStoryboard(sb), ref.adcp_version));
+}
+
+function annotateStoryboardVersion(storyboard: Storyboard, adcpVersion: string | undefined): Storyboard {
+  return adcpVersion === undefined ? storyboard : { ...storyboard, adcp_version: adcpVersion };
 }
 
 function safeLoadUniversal(path: string): Storyboard[] {
@@ -312,6 +329,7 @@ export function listBundles(options: ResolveOptions = {}): BundleRef[] {
       kind: 'universal',
       id: name,
       path: join(dir, 'universal', `${name}.yaml`),
+      adcp_version: index.adcp_version,
     });
   }
   for (const protocol of index.protocols) {
@@ -320,6 +338,7 @@ export function listBundles(options: ResolveOptions = {}): BundleRef[] {
       kind: 'protocol',
       id: protocol.id,
       path: join(dir, 'protocols', protocol.id),
+      adcp_version: index.adcp_version,
     });
   }
   for (const specialism of index.specialisms) {
@@ -327,6 +346,7 @@ export function listBundles(options: ResolveOptions = {}): BundleRef[] {
       kind: 'specialism',
       id: specialism.id,
       path: join(dir, 'specialisms', specialism.id),
+      adcp_version: index.adcp_version,
     });
   }
   return bundles;
@@ -399,6 +419,7 @@ export function loadSpecialismDetail(slug: string, options: ResolveOptions = {})
     kind: 'specialism',
     id: slug,
     path: join(getComplianceCacheDir(options), 'specialisms', slug),
+    adcp_version: index.adcp_version,
   });
   const storyboard = bundleStoryboards.find(sb => sb.category === entry.id.replace(/-/g, '_')) ?? bundleStoryboards[0];
   if (!storyboard) {
@@ -481,6 +502,7 @@ export function resolveStoryboardsForCapabilities(
   options: ResolveOptions = {}
 ): ResolvedStoryboards {
   const index = loadComplianceIndex(options);
+  assertSupportedComplianceVersion(index.adcp_version, caps.supported_versions);
   const cacheDir = getComplianceCacheDir(options);
   const bundles: ResolvedBundle[] = [];
   const storyboards: Storyboard[] = [];
@@ -512,6 +534,7 @@ export function resolveStoryboardsForCapabilities(
       kind: 'universal',
       id: name,
       path: join(cacheDir, 'universal', `${name}.yaml`),
+      adcp_version: index.adcp_version,
     });
   }
 
@@ -541,6 +564,7 @@ export function resolveStoryboardsForCapabilities(
       kind: 'protocol',
       id: protocolId,
       path: join(cacheDir, 'protocols', protocolId),
+      adcp_version: index.adcp_version,
     });
   }
 
@@ -577,10 +601,27 @@ export function resolveStoryboardsForCapabilities(
       kind: 'specialism',
       id: specialism,
       path: join(cacheDir, 'specialisms', specialism),
+      adcp_version: index.adcp_version,
     });
   }
 
   return { bundles, storyboards, not_applicable: notApplicable };
+}
+
+export function isComplianceVersionSupported(cacheVersion: string, supportedVersions: readonly string[]): boolean {
+  return isAdcpVersionSupported(cacheVersion, supportedVersions);
+}
+
+function assertSupportedComplianceVersion(cacheVersion: string, supportedVersions: string[] | undefined): void {
+  if (!supportedVersions || supportedVersions.length === 0) return;
+  if (isComplianceVersionSupported(cacheVersion, supportedVersions)) return;
+  throw new CapabilityResolutionError({
+    code: 'unsupported_adcp_version',
+    message:
+      `Compliance cache version ${cacheVersion} is not supported by this seller. ` +
+      `Seller advertises adcp.supported_versions [${supportedVersions.join(', ')}]. ` +
+      `Install or select a compatible compliance cache instead of relying on major_versions alone.`,
+  });
 }
 
 /**

--- a/src/lib/testing/storyboard/index.ts
+++ b/src/lib/testing/storyboard/index.ts
@@ -92,6 +92,8 @@ export { WEBHOOK_ASSERTION_TASKS } from './webhook-assertions';
 export {
   runStoryboard,
   runStoryboardStep,
+  applyAdcpVersionRunOptions,
+  applyStoryboardVersionOptions,
   getFirstStepPreview,
   summarizeStrictValidation,
   listStrictOnlyFailures,
@@ -114,6 +116,7 @@ export {
   findBundleById,
   resolveBundleOrStoryboard,
   resolveStoryboardsForCapabilities,
+  isComplianceVersionSupported,
   loadSpecialismDetail,
   listSpecialisms,
   CapabilityResolutionError,

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -6,8 +6,8 @@
  * - runStoryboardStep(): run a single step (stateless, LLM-friendly)
  */
 
-import { getOrCreateClient, getOrDiscoverProfile, runStep, type TestClient } from '../client';
-import { closeConnections } from '../../protocols';
+import { getOrCreateClientResolution, getOrDiscoverProfile, runStep, type TestClient } from '../client';
+import { closeConnections, type VersionEnvelopeMode } from '../../protocols';
 import { getCapturesFromError, withRawResponseCapture, type RawHttpCapture } from '../../protocols/rawResponseCapture';
 import { executeStoryboardTask } from './task-map';
 import {
@@ -37,7 +37,8 @@ import { queryUpstreamTraffic, type ControllerScenario, type UpstreamTrafficSucc
 import { enrichRequest, hasRequestEnricher } from './request-builder';
 import { resolveAccount, resolveBrand } from '../client';
 import { isMutatingTask, generateIdempotencyKey } from '../../utils/idempotency';
-import { schemaAllowsTopLevelField } from '../../validation/schema-loader';
+import { resolveBundleKey, schemaAllowsTopLevelField } from '../../validation/schema-loader';
+import { parseAdcpMajorVersion } from '../../version';
 import {
   PROBE_TASKS,
   probeProtectedResourceMetadata,
@@ -139,6 +140,35 @@ const CONTROLLER_SEEDING_FAILED_DETAIL =
 
 const OAUTH_NOT_ADVERTISED_DETAIL =
   'Skipped: agent does not advertise OAuth — /.well-known/oauth-protected-resource returned 404 (RFC 9728 §3). API-key path must carry auth_mechanism_verified for this storyboard to pass.';
+
+export function applyStoryboardVersionOptions(
+  storyboard: Storyboard,
+  options: StoryboardRunOptions
+): StoryboardRunOptions {
+  return applyAdcpVersionRunOptions(storyboard.adcp_version, options);
+}
+
+export function applyAdcpVersionRunOptions(
+  defaultAdcpVersion: string | undefined,
+  options: StoryboardRunOptions
+): StoryboardRunOptions {
+  const adcpVersion = options.adcpVersion ?? defaultAdcpVersion;
+  if (adcpVersion === undefined) return options;
+
+  const versionEnvelope = options.versionEnvelope ?? storyboardVersionEnvelopeMode(adcpVersion);
+
+  if (options.adcpVersion === adcpVersion && options.versionEnvelope === versionEnvelope) {
+    return options;
+  }
+  return { ...options, adcpVersion, versionEnvelope };
+}
+
+function storyboardVersionEnvelopeMode(adcpVersion: string): VersionEnvelopeMode {
+  const bundleKey = resolveBundleKey(adcpVersion);
+  const major = parseAdcpMajorVersion(bundleKey);
+  if (Number.isFinite(major) && major < 3) return 'none';
+  return 'auto';
+}
 
 /**
  * Suffix appended to the skip detail when the sole-stateful-step exemption
@@ -857,6 +887,7 @@ export async function runStoryboard(
   storyboard: Storyboard,
   options: StoryboardRunOptions = {}
 ): Promise<StoryboardResult> {
+  options = applyStoryboardVersionOptions(storyboard, options);
   validateTestKit(options.test_kit);
   // Enforce authoring-time branch_set invariants regardless of how the
   // storyboard reached us. YAML callers already ran these rules in
@@ -1571,6 +1602,7 @@ async function executeStoryboardPass(
   let clients: TestClient[];
   let routingContext: AgentRoutingContext | undefined;
   let profile: AgentProfile | undefined;
+  let callerOwnsClients = false;
 
   if (useRouting) {
     try {
@@ -1586,7 +1618,7 @@ async function executeStoryboardPass(
         duration_ms: 0,
         error: detail,
       };
-      if (!options._client) await closeConnections(options.protocol);
+      await closeConnections(options.protocol);
       return buildDiscoveryFailedResult(agentUrls, storyboard, failedStep);
     }
     clients = [...routingContext.clients.values()];
@@ -1615,7 +1647,9 @@ async function executeStoryboardPass(
   } else {
     // Build one client per URL. In single-URL mode `_client` (from comply()) is
     // honored so the shared MCP transport is reused across storyboards.
-    clients = agentUrls.map(url => getOrCreateClient(url, options));
+    const clientResolutions = agentUrls.map(url => getOrCreateClientResolution(url, options));
+    clients = clientResolutions.map(r => r.client);
+    callerOwnsClients = clientResolutions.some(r => r.reusedShared);
 
     // Drop any retained A2A session ids before this storyboard's first call.
     // `comply()` shares one client across N storyboards for transport reuse;
@@ -1632,7 +1666,7 @@ async function executeStoryboardPass(
     // expected to run the same code behind a shared state store, so one probe
     // is sufficient. For multi-instance runs, skipping N-1 redundant
     // get_agent_info calls also keeps CI output clean.
-    if (!options._client) {
+    if (!callerOwnsClients) {
       const discovered = await getOrDiscoverProfile(clients[0]!, options);
       // Discovery failure must surface as a HARD STORYBOARD FAILURE, not a
       // silent empty `agentTools: []` that lets every step skip with
@@ -1641,7 +1675,7 @@ async function executeStoryboardPass(
       // (auth misconfig, MCP transport-fallback bugs, network policy, etc.).
       // See: https://github.com/adcontextprotocol/adcp-client/issues/...
       if (discovered.step.passed === false) {
-        if (!options._client) await closeConnections(options.protocol);
+        await closeConnections(options.protocol);
         return buildDiscoveryFailedResult(agentUrls, storyboard, discovered.step);
       }
       profile = discovered.profile;
@@ -1687,7 +1721,7 @@ async function executeStoryboardPass(
   if (allRequires.length) {
     const unmet = checkRequires(allRequires, options, profile);
     if (unmet) {
-      if (!options._client) await closeConnections(options.protocol);
+      if (!callerOwnsClients) await closeConnections(options.protocol);
       return {
         ...buildRequirementUnmetResult(agentUrls, storyboard, unmet.requirement, unmet.detail),
         notices: preflightNotices,
@@ -1706,7 +1740,7 @@ async function executeStoryboardPass(
       const actual = resolveCapabilityPath(rawCaps, cap.path);
       const unmetDetail = evaluateCapabilityPredicate(cap, actual);
       if (unmetDetail !== null) {
-        if (!options._client) await closeConnections(options.protocol);
+        if (!callerOwnsClients) await closeConnections(options.protocol);
         return {
           ...buildCapabilityUnsupportedResult(agentUrls, storyboard, unmetDetail),
           notices: preflightNotices,
@@ -1729,7 +1763,7 @@ async function executeStoryboardPass(
   if (storyboard.required_tools?.length && options.agentTools) {
     const hasAnyRequired = storyboard.required_tools.some(t => options.agentTools!.includes(t));
     if (!hasAnyRequired) {
-      if (!options._client) await closeConnections(options.protocol);
+      if (!callerOwnsClients) await closeConnections(options.protocol);
       return {
         ...buildRequiredToolsMissingResult(
           agentUrls,
@@ -2741,7 +2775,7 @@ async function executeStoryboardPass(
   // Close protocol connections when the runner created its own client. The
   // connection pool is keyed by URL+auth, so a single closeConnections() call
   // evicts every instance's transport regardless of how many URLs we used.
-  if (!options._client) {
+  if (!callerOwnsClients) {
     await closeConnections(options.protocol);
   }
 
@@ -2786,7 +2820,7 @@ async function runMultiPass(
   // only the first pass attaches the synthetic `__controller_seeding__`
   // phase to its `phaseResults`, so the aggregated top-level counts reflect
   // a single seeding pass across the whole run.
-  const preSeedClients = agentUrls.map(url => getOrCreateClient(url, options));
+  const preSeedClients = agentUrls.map(url => getOrCreateClientResolution(url, options).client);
   const preSeedContext: StoryboardContext = { ...options.context };
   const preSeededResult = await runControllerSeeding(preSeedClients[0]!, storyboard, options, preSeedContext);
 
@@ -2998,8 +3032,10 @@ export async function runStoryboardStep(
   stepId: string,
   options: StoryboardRunOptions = {}
 ): Promise<StoryboardStepResult> {
+  options = applyStoryboardVersionOptions(storyboard, options);
   validateTestKit(options.test_kit);
-  const client = getOrCreateClient(agentUrl, options);
+  const clientResolution = getOrCreateClientResolution(agentUrl, options);
+  const client = clientResolution.client;
 
   // Discover agent profile for standalone step execution. Captured so the
   // executeStep call below can thread `library_version` through to
@@ -3007,7 +3043,7 @@ export async function runStoryboardStep(
   // options so capability-based skip gates in executeStep (e.g. account-mode
   // branching) can read raw_capabilities, mirroring executeStoryboardPass.
   let profile: AgentProfile | undefined;
-  if (!options._client) {
+  if (!clientResolution.reusedShared) {
     const discovered = await getOrDiscoverProfile(client, options);
     profile = discovered.profile;
     if (profile && !options._profile) {
@@ -3073,7 +3109,7 @@ export async function runStoryboardStep(
     agentLibraryVersion: profile?.library_version,
   });
 
-  if (!options._client) {
+  if (!clientResolution.reusedShared) {
     await closeConnections(options.protocol);
   }
 

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -15,6 +15,12 @@ import type { TestOptions } from '../types';
 export interface Storyboard {
   id: string;
   version: string;
+  /**
+   * AdCP compliance cache version this storyboard was loaded from, e.g.
+   * "3.0.12" or "3.1.0-beta.3". Injected by the local cache loader; not
+   * authored in storyboard YAML.
+   */
+  adcp_version?: string;
   title: string;
   category: string;
   summary: string;

--- a/src/lib/testing/types.ts
+++ b/src/lib/testing/types.ts
@@ -5,6 +5,8 @@
 import type { FormatReferenceStructuredObject as FormatID } from '../types/core.generated';
 import type { ControllerDetection } from './test-controller';
 import type { WebhookReceiver } from './storyboard/webhook-receiver';
+import type { AdcpVersion } from '../version';
+import type { VersionEnvelopeMode } from '../protocols';
 
 // Test scenarios that can be run
 export type TestScenario =
@@ -73,6 +75,18 @@ export type TestScenario =
 export interface TestOptions {
   // Protocol to use for testing (default: 'mcp')
   protocol?: 'mcp' | 'a2a';
+  /**
+   * AdCP protocol version the test client should speak. Storyboard runners
+   * set this from the compliance cache version instead of relying on the
+   * installed package default.
+   */
+  adcpVersion?: AdcpVersion | (string & {});
+  /**
+   * Version-envelope emission mode. Defaults to `auto`; 3.0 storyboards emit
+   * the legacy major marker only, while 3.1 storyboards also emit the exact
+   * `adcp_version` marker.
+   */
+  versionEnvelope?: VersionEnvelopeMode;
   /** Custom User-Agent string sent with all outbound requests */
   userAgent?: string;
   // Brand reference for product discovery (preferred over brand_manifest)
@@ -278,6 +292,11 @@ export interface AgentProfile {
    * storyboard introduced in a later minor version.
    */
   adcp_major_versions?: number[];
+  /**
+   * Exact/release-precision versions from
+   * `get_adcp_capabilities.adcp.supported_versions`.
+   */
+  adcp_supported_versions?: string[];
   supported_protocols?: string[];
   /** Specialism claims from get_adcp_capabilities.specialisms */
   specialisms?: string[];

--- a/src/lib/utils/adcp-version-config.ts
+++ b/src/lib/utils/adcp-version-config.ts
@@ -14,7 +14,7 @@
 
 import { ADCP_VERSION, COMPATIBLE_ADCP_VERSIONS, parseAdcpMajorVersion } from '../version';
 import { ConfigurationError } from '../errors';
-import { hasSchemaBundle, resolveBundleKey } from '../validation/schema-loader';
+import { hasSchemaBundle, resolveBundleKey, toReleasePrecisionWire } from '../validation/schema-loader';
 
 /**
  * Resolve and validate a configured `adcpVersion`. Returns the value to store
@@ -64,6 +64,45 @@ export function resolveAdcpVersion(adcpVersion: string | undefined): string {
   }
 
   return adcpVersion;
+}
+
+export function adcpVersionAliases(version: string, includeFamilyAlias = true): Set<string> {
+  const aliases = new Set<string>([version]);
+  const add = (value: string) => {
+    aliases.add(value);
+    if (includeFamilyAlias) {
+      const family = prereleaseFamilyAlias(value);
+      if (family) aliases.add(family);
+    }
+  };
+
+  try {
+    add(resolveBundleKey(version));
+  } catch {
+    // Keep the raw version only; the caller will report the mismatch.
+  }
+  try {
+    add(toReleasePrecisionWire(version));
+  } catch {
+    // Keep the raw version only; the caller will report the mismatch.
+  }
+  return aliases;
+}
+
+export function isAdcpVersionSupported(version: string, supportedVersions: readonly string[]): boolean {
+  if (supportedVersions.length === 0) return true;
+  const aliases = adcpVersionAliases(version);
+  return supportedVersions.some(v => {
+    for (const supportedAlias of adcpVersionAliases(v, false)) {
+      if (aliases.has(supportedAlias)) return true;
+    }
+    return false;
+  });
+}
+
+function prereleaseFamilyAlias(version: string): string | undefined {
+  const match = /^(\d+\.\d+-[0-9A-Za-z-]+)\.\d+$/.exec(version);
+  return match?.[1];
 }
 
 /**

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP SDK library version
  */
-export const LIBRARY_VERSION = '8.1.0-beta.8';
+export const LIBRARY_VERSION = '8.1.0-beta.9';
 
 /**
  * AdCP specification version this library is built for
@@ -63,10 +63,10 @@ export type AdcpVersion = (typeof COMPATIBLE_ADCP_VERSIONS)[number];
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '8.1.0-beta.8',
+  library: '8.1.0-beta.9',
   adcp: '3.1.0-beta.3',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-05-24T12:39:59.880Z',
+  generatedAt: '2026-05-24T21:24:19.781Z',
 } as const;
 
 /**

--- a/test/lib/adcp-version-option.test.js
+++ b/test/lib/adcp-version-option.test.js
@@ -194,5 +194,19 @@ describe('adcpVersion constructor option', () => {
       await wrapper.requireV3('b');
       assert.deepStrictEqual(seen, ['a', 'b']);
     });
+
+    test('SingleAgentClient.requireSupportedMajor accepts release-precision prerelease supported_versions', async () => {
+      const client = new SingleAgentClient(TEST_AGENT, { adcpVersion: '3.1.0-beta.3' });
+      client.getCapabilities = async () => ({
+        version: 'v3',
+        majorVersions: [3],
+        supportedVersions: ['3.1-beta.3'],
+        protocols: [],
+        features: {},
+        idempotency: { replayTtlSeconds: 86400 },
+      });
+
+      await client.requireSupportedMajor('get_products');
+    });
   });
 });

--- a/test/lib/storyboard-version-negotiation.test.js
+++ b/test/lib/storyboard-version-negotiation.test.js
@@ -1,0 +1,152 @@
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+
+describe('storyboard runner AdCP version negotiation', () => {
+  test('derives legacy-major-only version envelope for 3.0 storyboards', () => {
+    const { applyStoryboardVersionOptions } = require('../../dist/lib/testing/storyboard/index.js');
+
+    const options = applyStoryboardVersionOptions({ adcp_version: '3.0.12' }, {});
+
+    assert.strictEqual(options.adcpVersion, '3.0.12');
+    assert.strictEqual(options.versionEnvelope, 'auto');
+  });
+
+  test('derives explicit opt-in envelope for 3.1 storyboards', () => {
+    const { applyStoryboardVersionOptions } = require('../../dist/lib/testing/storyboard/index.js');
+
+    const options = applyStoryboardVersionOptions({ adcp_version: '3.1.0-beta.3' }, {});
+
+    assert.strictEqual(options.adcpVersion, '3.1.0-beta.3');
+    assert.strictEqual(options.versionEnvelope, 'auto');
+  });
+
+  test('caller-supplied version envelope mode wins', () => {
+    const { applyStoryboardVersionOptions } = require('../../dist/lib/testing/storyboard/index.js');
+
+    const options = applyStoryboardVersionOptions(
+      { adcp_version: '3.0.12' },
+      { adcpVersion: '3.0.12', versionEnvelope: 'auto' }
+    );
+
+    assert.strictEqual(options.adcpVersion, '3.0.12');
+    assert.strictEqual(options.versionEnvelope, 'auto');
+  });
+
+  test('legacy v3 alias keeps integer version marker behavior', () => {
+    const { applyAdcpVersionRunOptions } = require('../../dist/lib/testing/storyboard/index.js');
+
+    const options = applyAdcpVersionRunOptions(undefined, { adcpVersion: 'v3' });
+
+    assert.strictEqual(options.adcpVersion, 'v3');
+    assert.strictEqual(options.versionEnvelope, 'auto');
+  });
+
+  test('shared test client is reused only when version options match', () => {
+    const { createTestClient, getOrCreateClient } = require('../../dist/lib/testing/client.js');
+
+    const shared = createTestClient('https://example.com/mcp', 'mcp', {
+      adcpVersion: '3.1.0-beta.3',
+      versionEnvelope: 'auto',
+    });
+
+    assert.strictEqual(
+      getOrCreateClient('https://example.com/mcp', {
+        _client: shared,
+        adcpVersion: '3.1.0-beta.3',
+        versionEnvelope: 'auto',
+      }),
+      shared
+    );
+    assert.notStrictEqual(
+      getOrCreateClient('https://example.com/mcp', {
+        _client: shared,
+        adcpVersion: '3.1.0-beta.3',
+        versionEnvelope: 'none',
+      }),
+      shared
+    );
+  });
+
+  test('3.0 storyboards suppress exact adcp_version while preserving legacy major marker', async () => {
+    const { McpServer } = require('@modelcontextprotocol/sdk/server/mcp.js');
+    const { Client } = require('@modelcontextprotocol/sdk/client/index.js');
+    const { InMemoryTransport } = require('@modelcontextprotocol/sdk/inMemory.js');
+    const { ProtocolClient } = require('../../dist/lib/index.js');
+    const z = require('zod');
+
+    let captured;
+    const server = new McpServer({ name: 'storyboard-version-test', version: '1.0.0' });
+    server.registerTool(
+      'get_products',
+      {
+        inputSchema: {
+          brief: z.string().optional(),
+          adcp_major_version: z.number().optional(),
+          adcp_version: z.string().optional(),
+        },
+      },
+      async args => {
+        captured = args;
+        return {
+          content: [{ type: 'text', text: '{}' }],
+          structuredContent: { success: true, products: [] },
+        };
+      }
+    );
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    const mcpClient = new Client({ name: 'test-client', version: '1.0.0' });
+    await mcpClient.connect(clientTransport);
+
+    await ProtocolClient.callTool(
+      {
+        id: 'storyboard-version-test',
+        protocol: 'mcp',
+        agent_uri: 'in-process://storyboard-version-test',
+        _inProcessMcpClient: mcpClient,
+      },
+      'get_products',
+      { brief: 'legacy 3.0 storyboard' },
+      { adcpVersion: '3.0.12' }
+    );
+
+    assert.strictEqual(captured.adcp_major_version, 3);
+    assert.strictEqual(captured.adcp_version, undefined);
+
+    await mcpClient.close();
+    await server.close();
+  });
+
+  test('exact seller supported_versions are matched against cache version aliases', () => {
+    const { isComplianceVersionSupported } = require('../../dist/lib/testing/storyboard/index.js');
+
+    assert.strictEqual(isComplianceVersionSupported('3.1.0-beta.3', ['3.1.0-beta.3']), true);
+    assert.strictEqual(isComplianceVersionSupported('3.1.0-beta.3', ['3.1-beta.3']), true);
+    assert.strictEqual(isComplianceVersionSupported('3.1.0-beta.3', ['3.1-beta']), true);
+    assert.strictEqual(isComplianceVersionSupported('3.1.0-beta.3', ['3.1-beta.2']), false);
+    assert.strictEqual(isComplianceVersionSupported('3.1.0-beta.3', ['3.1.0-beta.2']), false);
+    assert.strictEqual(isComplianceVersionSupported('3.0.12', ['3.0.0']), true);
+    assert.strictEqual(isComplianceVersionSupported('3.1.1', ['3.1.0']), true);
+    assert.strictEqual(isComplianceVersionSupported('3.1.0-beta.3', ['3.0']), false);
+  });
+
+  test('capability resolution fails loudly on exact version mismatch', () => {
+    const {
+      CapabilityResolutionError,
+      resolveStoryboardsForCapabilities,
+    } = require('../../dist/lib/testing/storyboard/index.js');
+
+    assert.throws(
+      () =>
+        resolveStoryboardsForCapabilities({
+          supported_protocols: [],
+          supported_versions: ['3.0'],
+        }),
+      err =>
+        err instanceof CapabilityResolutionError &&
+        err.code === 'unsupported_adcp_version' &&
+        /Compliance cache version/.test(err.message) &&
+        /supported_versions \[3\.0\]/.test(err.message)
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- derive storyboard runner ADCP version options from the compliance cache, with 3.0 storyboards suppressing version markers and 3.1 storyboards opting into explicit markers
- pass version-envelope configuration through protocol clients, task execution, governance middleware, and shared test clients
- add compliance cache version selection for comply()/CLI and supported-version alias matching for prerelease and release-precision values

## Validation
- npm run build:lib
- NODE_ENV=test node --test-timeout=60000 --test test/lib/storyboard-version-negotiation.test.js test/lib/adcp-major-version.test.js test/lib/adcp-version-option.test.js
- NODE_ENV=test node --test-timeout=60000 --test --test-name-pattern='resolveStoryboardsForCapabilities' test/lib/storyboard-security.test.js
- NODE_ENV=test node --test-timeout=60000 --test test/lib/storyboard-capability-gate.test.js
- node --check bin/adcp.js
- git diff --check

Covers #1987