### PR TITLE
feat: expose SSRF helpers and document 8.1 webhooks

### DIFF
--- a/.changeset/public-net-ssrf-webhook-docs.md
+++ b/.changeset/public-net-ssrf-webhook-docs.md
@@ -1,0 +1,12 @@
+---
+'@adcp/sdk': minor
+---
+
+Re-export SSRF-safe networking helpers from the package root and the new
+`@adcp/sdk/net` public subpath. This includes `ssrfSafeFetch`,
+`SsrfRefusedError`, `SSRF_TRANSIENT_CODES`, `decodeBodyAsJsonOrText`,
+`isPrivateIp`, `isAlwaysBlocked`, and `isLikelyPrivateUrl`.
+
+Docs add the 8.0 -> 8.1 migration guide and a recipe for verifying inbound
+webhooks with RFC 9421, per-agent isolation, multi-replica replay storage, and
+legacy HMAC handling.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ npm install @adcp/sdk        # 7.x (current latest, AdCP 3.0)
 npm install @adcp/sdk@beta   # 8.x beta (AdCP 3.1.0-beta)
 ```
 
-Upgrading from v7? See **[MIGRATION-v8.md](./MIGRATION-v8.md)** — TL;DR is three changes for most adopters; full guide covers wire shape, type shape, and SDK behavior deltas.
+Upgrading from v7? See **[MIGRATION-v8.md](./MIGRATION-v8.md)** — TL;DR is three changes for most adopters; full guide covers wire shape, type shape, and SDK behavior deltas. Moving from 8.0 beta to 8.1? See [`docs/migration-8.0-to-8.1.md`](./docs/migration-8.0-to-8.1.md), plus the inbound webhook recipe at [`docs/recipes/verifying-inbound-webhooks.md`](./docs/recipes/verifying-inbound-webhooks.md).
 
 ### Narrow type imports (`@adcp/sdk/types/<tool>`)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,8 @@ Welcome to the official documentation for `@adcp/sdk`, the TypeScript/JavaScript
 
 ### 📈 Migration Guides
 
+- [8.0 → 8.1](./migration-8.0-to-8.1.md) — AdCP 3.1.0-beta.3 tightening, webhook verification, `TaskStatus` ambiguity
+- [7.11 → 8.0](./migration-7.11-to-8.0.md) — 8.x beta migration notes
 - [6.6 → 6.7](./migration-6.6-to-6.7.md) — fifteen adopter recipes; two breaking (`'implicit'` refusal, `SalesPlatform` split)
 - [5.x → 6.x](./migration-5.x-to-6.x.md) — `createAdcpServerFromPlatform` framework shape
 - [4.x → 5.x](./migration-4.x-to-5.x.md) — `TaskResult` discriminated union + `createAdcpServer`
@@ -52,7 +54,7 @@ Welcome to the official documentation for `@adcp/sdk`, the TypeScript/JavaScript
 - [Real-World Examples](./guides/REAL-WORLD-EXAMPLES.md)
 - [Async Patterns](./guides/ASYNC-DEVELOPER-GUIDE.md) / [Migration](./guides/ASYNC-MIGRATION-GUIDE.md) / [Troubleshooting](./guides/ASYNC-TROUBLESHOOTING-GUIDE.md)
 - [Testing Strategy](./guides/TESTING-STRATEGY.md) / [Multi-Instance Testing](./guides/MULTI-INSTANCE-TESTING.md)
-- [Recipes](./recipes/) — `composeMethod` testing patterns, etc.
+- [Recipes](./recipes/) — inbound webhook verification, `composeMethod` testing patterns, etc.
 
 ### 📦 Resources
 

--- a/docs/migration-8.0-to-8.1.md
+++ b/docs/migration-8.0-to-8.1.md
@@ -1,0 +1,171 @@
+# Migrating from `@adcp/sdk` 8.0 to 8.1
+
+> **Scope.** This guide is for adopters already on the 8.x beta line,
+> moving from the 8.0 beta cut to 8.1. The big theme is AdCP
+> 3.1.0-beta.3 catch-up: response envelopes became stricter, several
+> domain `status` fields were renamed to stop colliding with task status,
+> and webhook verification moved from "example code" to a production recipe.
+
+## TL;DR
+
+- Add envelope `status` everywhere you construct raw wire responses. Server
+  framework users get this stamped for them.
+- Emit release-precision `adcp_version` values such as `3.1-beta.3`, not
+  full semver values such as `3.1.0-beta.3`.
+- Rename domain-level status fields that collided with task status:
+  `MediaBuy.status` -> `media_buy_status`, creative approval `status` ->
+  `approval_status`, rights acquisition `status` -> `rights_status`.
+- Drop `governance_agents[].categories`; 8.1 validates those items as closed.
+- For webhook receivers, move to RFC 9421 verification and a shared replay
+  store before running more than one replica. See
+  [Verifying inbound webhooks](./recipes/verifying-inbound-webhooks.md).
+- If your code extends `ProductSchema`, upgrade to 8.1. `ProductSchema` is
+  intentionally a `ZodObject` again, so `.extend()`, `.omit()`, `.pick()`, and
+  `.shape` work.
+
+## Wire Shape Tightening
+
+### Envelope `status` is required
+
+AdCP 3.1.0-beta.2 requires top-level envelope `status` on every response,
+including error responses. The SDK server framework now defaults success
+responses to `status: 'completed'` and error responses to `status: 'failed'`
+unless a tool explicitly returns a richer task state such as `submitted` or
+`working`.
+
+Raw-handler adopters should audit for hand-constructed responses:
+
+```bash
+rg -n "return \\{|status:" src
+```
+
+If the object is a protocol response envelope, it needs a task-status value.
+If it is a domain object nested inside a response, use the renamed domain
+fields below rather than overloading `status`.
+
+### `adcp_version` uses release precision
+
+Wire `adcp_version` values use `MAJOR.MINOR` precision with an optional
+prerelease suffix. Examples:
+
+| Internal bundle/version | Wire value |
+|---|---|
+| `3.1.0-beta.3` | `3.1-beta.3` |
+| `3.1.0` | `3.1` |
+
+The SDK framework normalizes this automatically. Custom emitters should not
+copy package or schema-cache semver strings directly into wire envelopes.
+
+### Domain status fields no longer share the task-status key
+
+Top-level `status` is the task envelope. Domain resources use their own names:
+
+| Old 8.0 beta field | 8.1 field |
+|---|---|
+| `media_buy.status` | `media_buy.media_buy_status` |
+| `creative_approvals[].status` | `creative_approvals[].approval_status` |
+| `acquire_rights.status` | `acquire_rights.rights_status` |
+
+This removes the ambiguity where `status` could mean either the task lifecycle
+(`completed`, `failed`, `submitted`) or a business lifecycle (`active`,
+`approved`, `licensed`).
+
+### `governance_agents[].categories` was removed
+
+The 3.1 schema now treats governance-agent entries as closed objects and
+removes the legacy `categories` field. If you used that field for operator
+metadata, move it to your own registry or extension store; do not emit it in
+`sync_governance`, account responses, or test fixtures.
+
+### Mutating request schemas allow extensions
+
+Mutating request validation now follows the AdCP 3.1 rule that vendor
+extensions can travel on request shapes. Runtime validation accepts unknown
+extension keys on those mutating requests, while SDK-owned fields are still
+validated strictly. If you had tests asserting "unknown key rejected" on
+mutating requests, update them to assert that known fields still validate and
+that extension keys are carried intentionally. Do not use this as a place for
+credentials; `ctx_metadata` and extension objects can still land in logs and
+error envelopes.
+
+## Type-Level Changes
+
+### `ProductSchema` is a `ZodObject` again
+
+8.0's generated `ProductSchema` could appear as a marker-only intersection,
+which made object helpers disappear even though validation behavior was still
+object-shaped. 8.1 collapses those marker-only intersections during codegen.
+
+This is intentional: the schema keeps the same runtime validation semantics,
+but TypeScript users can again write:
+
+```ts
+import { ProductSchema } from '@adcp/sdk';
+import { z } from 'zod';
+
+const ProductWithLocalField = ProductSchema.extend({
+  local_score: z.number(),
+});
+```
+
+Use this for local validation/adaptation. Do not infer that extension fields
+belong on the AdCP wire unless the relevant request schema permits extensions.
+
+### `SyncAccountsRequest.accounts[]` branches are typed
+
+The generated TypeScript now narrows the mutually exclusive
+`SyncAccountsRequest.accounts[]` branches correctly. `ProvisioningMode` and
+`SettingsUpdateMode` expose their real fields instead of a loose passthrough
+shape, including `notification_configs[]` for account-scoped events. Existing
+valid payloads keep working; the adopter-visible change is better
+autocomplete/type-checking and fewer accidental unknown-field escapes.
+
+### `get_products` response shape
+
+`products` can be absent in valid response arms such as unchanged/cache-hit
+responses. Any response that does carry `products` must now also carry
+`cache_scope`. Test fixtures that assumed `products` was always present or
+omitted `cache_scope` on populated product responses need to be updated.
+
+## The Two `TaskStatus` Types
+
+There are two similarly named concepts:
+
+| Import/source | Use it for |
+|---|---|
+| `TaskResult['status']` from the root client API | Handling SDK call results, including client result states like `deferred` and `governance-denied`. |
+| `TaskStatus` from `@adcp/sdk`'s conversation/client types | Legacy client-side status vocabulary used inside the SDK, including compatibility states such as `pending`, `running`, `needs_input`, and `aborted`. |
+| Protocol `TaskStatus` from generated protocol types / server payload helpers | Wire envelope `status` values on AdCP responses and webhook payloads. |
+
+Do not use the root client `TaskStatus` alias as the schema for wire
+responses. It intentionally includes client-side compatibility states. For
+server handler domain payloads, prefer the SDK's server payload aliases so
+envelope fields owned by the framework are stripped from handler return types.
+
+## Webhook Verification
+
+8.1 keeps the legacy HMAC helper for older `push_notification_config` buyers,
+but the spec-current path is RFC 9421 webhook signing with
+`adcp_use: "webhook-signing"` keys. The short version:
+
+- Capture raw request bytes before JSON parsing.
+- Resolve the expected sending agent from your operation state or route, not
+  from attacker-controlled signature headers.
+- Verify with `createWebhookVerifier` / `verifyWebhookSignature`.
+- Use a shared `ReplayStore` for multi-replica receivers.
+- Keep HMAC as an explicit legacy branch only; do not fail open from one scheme
+  to another.
+
+Full recipe: [Verifying inbound webhooks](./recipes/verifying-inbound-webhooks.md).
+
+## Checklist
+
+- [ ] Raw response fixtures include envelope `status`.
+- [ ] Raw error fixtures include `status: 'failed'`.
+- [ ] Wire `adcp_version` is release-precision.
+- [ ] Business lifecycle fields use `media_buy_status`, `approval_status`, and
+  `rights_status`.
+- [ ] `governance_agents[]` fixtures no longer emit `categories`.
+- [ ] `get_products` fixtures with products include `cache_scope`.
+- [ ] Webhook receivers capture raw body bytes and verify before processing.
+- [ ] Multi-replica webhook receivers use Redis/Postgres replay storage.

--- a/docs/recipes/verifying-inbound-webhooks.md
+++ b/docs/recipes/verifying-inbound-webhooks.md
@@ -1,0 +1,287 @@
+# Verifying Inbound Webhooks
+
+This recipe is for buyers and orchestrators receiving AdCP webhooks from
+seller agents. It covers the spec-current RFC 9421 profile and the legacy
+HMAC profile that remains for older `push_notification_config.authentication`
+registrations.
+
+New integrations should use RFC 9421. The HMAC branch below is only for
+operations that were explicitly registered with legacy
+`push_notification_config.authentication`.
+
+## Invariants
+
+| Invariant | Requirement |
+|---|---|
+| Raw body | Verify the exact bytes received on the wire, before JSON parsing or re-serialization. |
+| Per-agent isolation | Choose the expected sending agent from trusted state: operation ID, route segment, tenant table, or the outbound request you created. Do not let `keyid` choose the counterparty. |
+| Replay protection | A `(keyid, target-uri, nonce)` accepted once must be rejected everywhere until it expires. Multi-replica deployments need a shared replay store. |
+| Dual scheme | RFC 9421 and legacy HMAC are separate profiles. If one is present and fails, reject. Do not fall back to the other scheme after a failed verification. |
+
+## Recommended RFC 9421 Setup
+
+Create one verifier per expected sending agent. The resolver is bound to that
+agent's `brand.json` and selector, so a webhook for one seller cannot be
+verified with another seller's keys.
+
+```ts
+import {
+  BrandJsonJwksResolver,
+  createWebhookVerifier,
+  type BrandAgentType,
+  type RequestLike,
+} from '@adcp/sdk/signing/server';
+
+const verifiers = new Map<string, ReturnType<typeof createWebhookVerifier>>();
+
+type SenderRecord = {
+  agentId: string;
+  agentType: BrandAgentType;
+  brandJsonUrl: string;
+  brandId?: string;
+  webhookAuth: 'rfc9421' | 'legacy-hmac';
+  legacyHmacSecret?: string;
+};
+
+function verifierFor(sender: SenderRecord) {
+  const cacheKey = `${sender.brandJsonUrl}#${sender.brandId ?? '-'}#${sender.agentType}:${sender.agentId}`;
+  let verifier = verifiers.get(cacheKey);
+  if (!verifier) {
+    const jwks = new BrandJsonJwksResolver(sender.brandJsonUrl, {
+      agentType: sender.agentType,
+      agentId: sender.agentId,
+      ...(sender.brandId ? { brandId: sender.brandId } : {}),
+    });
+    verifier = createWebhookVerifier({ jwks });
+    verifiers.set(cacheKey, verifier);
+  }
+  return verifier;
+}
+
+async function verifyRfc9421Webhook(sender: SenderRecord, request: RequestLike) {
+  return verifierFor(sender)(request);
+}
+```
+
+`createWebhookVerifier` defaults replay and revocation stores once at factory
+creation time. That is safe for a single process. It is not enough behind a
+load balancer.
+
+`SenderRecord`, `lookupSenderForOperation()`, and `processWebhook()` are
+application-owned. Persist the expected `agentId`, `agentType`,
+`brandJsonUrl`, optional `brandId`, and exact `webhookAuth` mode when you
+initiate or register the operation. The webhook receiver should read that
+state by operation ID before looking at any signature header.
+
+## Express Receiver
+
+Capture the raw body and build an absolute URL that matches the URL the seller
+signed. The example uses `requestContextFromExpress()` so the host allowlist
+and HTTPS checks live in the SDK helper instead of handwritten string
+assembly. If you terminate TLS at a proxy, configure `app.set('trust proxy',
+...)` with your trusted proxy addresses before relying on `req.protocol`.
+
+```ts
+import express from 'express';
+import { verifyWebhookRequest } from '@adcp/sdk/webhooks';
+import { requestContextFromExpress, type RequestLike } from '@adcp/sdk/signing/server';
+
+const app = express();
+app.set('trust proxy', 'loopback');
+
+app.post(
+  '/adcp/webhooks/:agent_id/:operation_id',
+  express.raw({ type: '*/*', limit: '1mb' }),
+  async (req, res) => {
+    const sender = await lookupSenderForOperation(req.params.operation_id);
+    if (!sender || sender.agentId !== req.params.agent_id) {
+      return res.status(404).end();
+    }
+
+    const rawBody = req.body as Buffer;
+
+    try {
+      const hasRfc9421 = hasRfc9421Headers(req.headers);
+      const hasLegacyHmac = hasLegacyHmacHeaders(req.headers);
+
+      if (sender.webhookAuth === 'rfc9421') {
+        if (!hasRfc9421 || hasLegacyHmac) {
+          return res.status(401).json({ error: 'unexpected_signature_scheme' });
+        }
+        const context = requestContextFromExpress(req, {
+          hostAllowlist: ['buyer.example.com'],
+        });
+        const request: RequestLike = {
+          ...context,
+          headers: normalizeHeaders(req.headers),
+          body: rawBody.toString('utf8'),
+        };
+        await verifyRfc9421Webhook(sender, request);
+      } else {
+        if (!hasLegacyHmac || hasRfc9421 || !sender.legacyHmacSecret) {
+          return res.status(401).json({ error: 'unexpected_signature_scheme' });
+        }
+        const result = verifyWebhookRequest({
+          rawBody,
+          secret: sender.legacyHmacSecret,
+          headers: req.headers,
+        });
+        if (!result.ok) {
+          return res.status(401).json({ error: result.reason });
+        }
+      }
+    } catch {
+      return res.status(401).json({ error: 'invalid_signature' });
+    }
+
+    const payload = JSON.parse(rawBody.toString('utf8'));
+    await processWebhook(sender, payload);
+    res.status(204).end();
+  }
+);
+
+function hasRfc9421Headers(headers: Record<string, unknown>): boolean {
+  return Boolean(headers.signature || headers['signature-input']);
+}
+
+function hasLegacyHmacHeaders(headers: Record<string, unknown>): boolean {
+  return Boolean(headers['x-adcp-signature'] || headers['x-adcp-timestamp']);
+}
+
+function normalizeHeaders(headers: Record<string, unknown>): Record<string, string | string[] | undefined> {
+  const out: Record<string, string | string[] | undefined> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (Array.isArray(value)) out[key] = value.map(String);
+    else if (value !== undefined) out[key] = String(value);
+  }
+  return out;
+}
+```
+
+Important details:
+
+- `lookupSenderForOperation()` is the trust boundary. It should read the sender
+  you registered when you initiated the task, not a value from the signature.
+- `sender.webhookAuth` is per operation. During migrations, choose one expected
+  scheme for each operation and reject the other, even if the sender also has
+  legacy credentials on file.
+- A failed RFC 9421 signature returns `401`; it does not retry HMAC.
+- Legacy HMAC is allowed only when the sender record says that operation was
+  registered with a legacy secret.
+- Parse JSON only after verification succeeds.
+
+## Multi-Replica Replay Store
+
+For more than one receiver process, pass a shared replay store to every
+verifier instance.
+
+Postgres:
+
+```ts
+import { Pool } from 'pg';
+import {
+  BrandJsonJwksResolver,
+  PostgresReplayStore,
+  createWebhookVerifier,
+  getReplayStoreMigration,
+  sweepExpiredReplays,
+} from '@adcp/sdk/signing/server';
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+await pool.query(getReplayStoreMigration());
+setInterval(() => sweepExpiredReplays(pool).catch(console.error), 60_000);
+
+const replayStore = new PostgresReplayStore(pool);
+
+function buildVerifier(sender: SenderRecord) {
+  return createWebhookVerifier({
+    jwks: new BrandJsonJwksResolver(sender.brandJsonUrl, {
+      agentType: sender.agentType,
+      agentId: sender.agentId,
+      ...(sender.brandId ? { brandId: sender.brandId } : {}),
+    }),
+    replayStore,
+  });
+}
+```
+
+Redis:
+
+```ts
+import { createClient } from 'redis';
+import { BrandJsonJwksResolver, RedisReplayStore, createWebhookVerifier } from '@adcp/sdk/signing/server';
+
+const redis = createClient({ url: process.env.REDIS_URL });
+await redis.connect();
+
+const replayStore = new RedisReplayStore(redis);
+
+function buildVerifier(sender: SenderRecord) {
+  return createWebhookVerifier({
+    jwks: new BrandJsonJwksResolver(sender.brandJsonUrl, {
+      agentType: sender.agentType,
+      agentId: sender.agentId,
+      ...(sender.brandId ? { brandId: sender.brandId } : {}),
+    }),
+    replayStore,
+  });
+}
+```
+
+Redis handles expiry itself. Postgres needs the sweeper because it has no
+native row TTL.
+
+## Legacy HMAC
+
+Legacy HMAC validates `x-adcp-timestamp` and `x-adcp-signature:
+sha256=<hex>` over `${timestamp}.${rawBody}`.
+
+```ts
+import { verifyWebhookRequest } from '@adcp/sdk/webhooks';
+
+const result = verifyWebhookRequest({
+  rawBody,
+  secret: sender.legacyHmacSecret,
+  headers: req.headers,
+});
+
+if (!result.ok) {
+  return res.status(401).json({ error: result.reason });
+}
+```
+
+Keep secrets per sending agent or per operation registration. A single global
+secret breaks per-agent isolation: compromising one sender's secret lets it
+sign payloads that look like another sender's webhooks.
+
+Legacy HMAC provides freshness, not nonce-based replay protection. Deduplicate
+by `idempotency_key` or by your operation state before applying side effects:
+
+```ts
+const payload = JSON.parse(rawBody.toString('utf8'));
+
+if (payload.idempotency_key) {
+  const firstSeen = await dedupStore.setIfAbsent(`adcp:webhook:${payload.idempotency_key}`, 86_400);
+  if (!firstSeen) return res.status(204).end();
+}
+
+await processWebhook(sender, payload);
+```
+
+## Failure Responses
+
+Use `401` for signature failures. Do not include resolved private IPs, raw
+signature bases, JWKS bodies, secrets, or raw payload bytes in the response.
+Log correlation IDs and typed error codes; keep detailed material in a secure
+debug sink with redaction.
+
+## Receiver Checklist
+
+- [ ] Webhook route includes or resolves an operation ID.
+- [ ] Operation state stores the expected sender agent and auth scheme.
+- [ ] Raw body bytes are captured before JSON parsing.
+- [ ] RFC 9421 resolver is bound to the expected sender's `brand.json`.
+- [ ] Legacy HMAC secret is per sender/registration, not global.
+- [ ] Multi-replica deployments use Redis or Postgres replay storage.
+- [ ] Signature failure never falls back to another auth scheme.
+- [ ] JSON parsing and side effects happen only after verification succeeds.

--- a/package.json
+++ b/package.json
@@ -88,6 +88,11 @@
       "require": "./dist/lib/webhooks/index.js",
       "types": "./dist/lib/webhooks/index.d.ts"
     },
+    "./net": {
+      "import": "./dist/lib/net/index.js",
+      "require": "./dist/lib/net/index.js",
+      "types": "./dist/lib/net/index.d.ts"
+    },
     "./server": {
       "import": "./dist/lib/server/index.js",
       "require": "./dist/lib/server/index.js",
@@ -195,6 +200,9 @@
       ],
       "webhooks": [
         "dist/lib/webhooks/index.d.ts"
+      ],
+      "net": [
+        "dist/lib/net/index.d.ts"
       ],
       "server": [
         "dist/lib/server/index.d.ts"

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -218,6 +218,24 @@ export {
   REGULATED_HUMAN_REVIEW_CATEGORIES,
   ANNEX_III_POLICY_IDS,
 } from './governance';
+
+// ====== NETWORKING / SSRF GUARDS ======
+// Public so adopters can converge on the SDK's DNS-pinning and address
+// classification behavior instead of copying partial guards. Use
+// `ssrfSafeFetch` as the security boundary; address classifiers are advisory
+// helpers and do not protect raw fetches from DNS rebinding.
+export {
+  ssrfSafeFetch,
+  decodeBodyAsJsonOrText,
+  SSRF_TRANSIENT_CODES,
+  SsrfRefusedError,
+  isPrivateIp,
+  isAlwaysBlocked,
+  isLikelyPrivateUrl,
+  type SsrfRefusedCode,
+  type SsrfFetchOptions,
+  type SsrfFetchResult,
+} from './net';
 export type {
   BuildHumanReviewPlanInput,
   BuildHumanOverrideInput,

--- a/src/lib/net/index.ts
+++ b/src/lib/net/index.ts
@@ -6,6 +6,7 @@
 export {
   ssrfSafeFetch,
   decodeBodyAsJsonOrText,
+  SSRF_TRANSIENT_CODES,
   SsrfRefusedError,
   type SsrfRefusedCode,
   type SsrfFetchOptions,

--- a/test/lib/net-public-export.test.js
+++ b/test/lib/net-public-export.test.js
@@ -1,0 +1,48 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const pkg = require('../../package.json');
+
+describe('net SSRF helpers public exports', () => {
+  it('exports the SSRF helpers from the package root and @adcp/sdk/net', () => {
+    const sdk = require('@adcp/sdk');
+    const net = require('@adcp/sdk/net');
+
+    assert.strictEqual(typeof sdk.ssrfSafeFetch, 'function');
+    assert.strictEqual(typeof sdk.decodeBodyAsJsonOrText, 'function');
+    assert.strictEqual(typeof sdk.SsrfRefusedError, 'function');
+    assert.strictEqual(typeof sdk.isPrivateIp, 'function');
+    assert.strictEqual(typeof sdk.isAlwaysBlocked, 'function');
+    assert.strictEqual(typeof sdk.isLikelyPrivateUrl, 'function');
+    assert.ok(sdk.SSRF_TRANSIENT_CODES instanceof Set);
+    assert.strictEqual(sdk.isPrivateIp('127.0.0.1'), true);
+
+    assert.strictEqual(typeof net.ssrfSafeFetch, 'function');
+    assert.strictEqual(typeof net.decodeBodyAsJsonOrText, 'function');
+    assert.strictEqual(typeof net.SsrfRefusedError, 'function');
+    assert.strictEqual(typeof net.isPrivateIp, 'function');
+    assert.strictEqual(typeof net.isAlwaysBlocked, 'function');
+    assert.strictEqual(typeof net.isLikelyPrivateUrl, 'function');
+    assert.ok(net.SSRF_TRANSIENT_CODES instanceof Set);
+    assert.strictEqual(net.isAlwaysBlocked('169.254.169.254'), true);
+
+    assert.strictEqual(sdk.ssrfSafeFetch, net.ssrfSafeFetch);
+    assert.strictEqual(sdk.SsrfRefusedError, net.SsrfRefusedError);
+    assert.strictEqual(sdk.SSRF_TRANSIENT_CODES, net.SSRF_TRANSIENT_CODES);
+  });
+
+  it('publishes runtime and declaration paths for @adcp/sdk/net', () => {
+    assert.deepStrictEqual(pkg.exports['./net'], {
+      import: './dist/lib/net/index.js',
+      require: './dist/lib/net/index.js',
+      types: './dist/lib/net/index.d.ts',
+    });
+    assert.deepStrictEqual(pkg.typesVersions['*'].net, ['dist/lib/net/index.d.ts']);
+
+    const distRoot = path.join(__dirname, '..', '..', 'dist', 'lib', 'net');
+    assert.ok(fs.existsSync(path.join(distRoot, 'index.js')), 'dist/lib/net/index.js must exist');
+    assert.ok(fs.existsSync(path.join(distRoot, 'index.d.ts')), 'dist/lib/net/index.d.ts must exist');
+  });
+});


### PR DESCRIPTION
## Summary

- Re-export SSRF-safe networking helpers from the package root and add the public `@adcp/sdk/net` subpath.
- Add an 8.0 -> 8.1 migration guide covering envelope status, release-precision `adcp_version`, domain status renames, ProductSchema ergonomics, TaskStatus ambiguity, and webhook verification.
- Add an inbound webhook verification recipe with per-operation auth scheme binding, per-agent/brand JWKS isolation, shared replay-store guidance, and legacy HMAC replay dedup notes.

## Expert review

Ran code, protocol, security, and docs specialist reviews before commit. Addressed their actionable findings: changeset bump type, stronger export test, request-context helper usage, explicit `webhookAuth` scheme binding, `brandId` isolation, and HMAC replay guidance.

## Validation

- `npm run build:lib`
- `node --test test/lib/net-public-export.test.js test/lib/net-ssrf-fetch.test.js`
- `node --test test/lib/net-public-export.test.js test/request-context-helpers.test.js`
- `NODE_ENV=test node --test test/server-create-adcp-server.test.js`
- `git diff --check`

Note: running `test/server-create-adcp-server.test.js` without `NODE_ENV=test` trips the expected in-memory state-store guard; rerun with `NODE_ENV=test` passed.