### PR TITLE
fix: align decisioning known error codes

### DIFF
--- a/.changeset/action-not-allowed-known-code.md
+++ b/.changeset/action-not-allowed-known-code.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Recognize `ACTION_NOT_ALLOWED` through the shared standard error-code runtime table so decisioning `AdcpError` construction does not warn for the AdCP 3.1 code.

--- a/src/lib/server/decisioning/async-outcome.ts
+++ b/src/lib/server/decisioning/async-outcome.ts
@@ -15,24 +15,15 @@
  * @public
  */
 
-import { ErrorCodeValues } from '../../types/enums.generated';
-import { FORWARD_COMPAT_ERROR_CODES } from '../../types/forward-compat-error-codes';
-import { getErrorRecovery, type StandardErrorCode } from '../../types/error-codes';
+import { getErrorRecovery, STANDARD_ERROR_CODES, type StandardErrorCode } from '../../types/error-codes';
 
 /**
- * Error code vocabulary the SDK recognizes. Composes the manifest-derived
- * `ErrorCodeValues` (codes in the SDK's primary `ADCP_VERSION` pin) with
- * the forward-compat overlay (codes from newer AdCP releases the SDK
- * pre-emptively knows about). Adding a code to the spec lights up
- * everywhere downstream (typo warn, `ErrorCode` union, autocomplete)
- * without a hand-edit. Adopters can return platform-specific codes too —
- * agents fall back to the `recovery` classification on unknowns via the
- * `(string & {})` escape hatch on `AdcpStructuredError.code`.
+ * Error code vocabulary the SDK recognizes. Uses the same runtime table as
+ * `isStandardErrorCode` / `getErrorRecovery` so decisioning warnings cannot
+ * drift from the SDK's standard-code lookup when manifest-derived codes or
+ * forward-compat overlay entries are refreshed independently.
  */
-export const KNOWN_ERROR_CODES = [
-  ...ErrorCodeValues,
-  ...(Object.keys(FORWARD_COMPAT_ERROR_CODES) as readonly string[]),
-] as readonly string[];
+export const KNOWN_ERROR_CODES = Object.keys(STANDARD_ERROR_CODES) as readonly string[];
 
 export type ErrorCode = StandardErrorCode;
 
@@ -59,7 +50,7 @@ function maybeWarnUnknownErrorCode(code: string): void {
   // eslint-disable-next-line no-console
   console.warn(
     `[adcp/decisioning] AdcpError code "${code}" is not in the known ErrorCode set ` +
-      `(${KNOWN_ERROR_CODES.length} standard codes per schemas/cache/<version>/enums/error-code.json). ` +
+      `(${KNOWN_ERROR_CODES.length} standard codes in the SDK runtime table). ` +
       `If this is intentional (vendor-specific code), set ADCP_DECISIONING_ALLOW_CUSTOM_CODES=1. ` +
       `Otherwise check spelling against the ErrorCode union.`
   );

--- a/test/lib/v3-compatibility.test.js
+++ b/test/lib/v3-compatibility.test.js
@@ -2097,6 +2097,12 @@ describe('Standard Error Codes', () => {
     assert.ok(STANDARD_ERROR_CODES.IDEMPOTENCY_EXPIRED);
   });
 
+  test('includes ACTION_NOT_ALLOWED as a standard AdCP 3.1 code', () => {
+    assert.ok(STANDARD_ERROR_CODES.ACTION_NOT_ALLOWED);
+    assert.strictEqual(STANDARD_ERROR_CODES.ACTION_NOT_ALLOWED.recovery, 'correctable');
+    assert.strictEqual(isStandardErrorCode('ACTION_NOT_ALLOWED'), true);
+  });
+
   test('every code has description and recovery', () => {
     for (const [code, info] of Object.entries(STANDARD_ERROR_CODES)) {
       assert.ok(info.description, `${code} missing description`);
@@ -2134,6 +2140,7 @@ describe('Standard Error Codes', () => {
     assert.strictEqual(isStandardErrorCode('RATE_LIMITED'), true);
     assert.strictEqual(isStandardErrorCode('BUDGET_EXHAUSTED'), true);
     assert.strictEqual(isStandardErrorCode('CONFLICT'), true);
+    assert.strictEqual(isStandardErrorCode('ACTION_NOT_ALLOWED'), true);
   });
 
   test('isStandardErrorCode returns false for custom codes', () => {
@@ -2144,6 +2151,7 @@ describe('Standard Error Codes', () => {
   test('getErrorRecovery returns correct recovery for known codes', () => {
     assert.strictEqual(getErrorRecovery('RATE_LIMITED'), 'transient');
     assert.strictEqual(getErrorRecovery('INVALID_REQUEST'), 'correctable');
+    assert.strictEqual(getErrorRecovery('ACTION_NOT_ALLOWED'), 'correctable');
     assert.strictEqual(getErrorRecovery('ACCOUNT_SUSPENDED'), 'terminal');
   });
 

--- a/test/server-typed-errors.test.js
+++ b/test/server-typed-errors.test.js
@@ -24,7 +24,8 @@ const {
   GovernanceDeniedError,
   PolicyViolationError,
 } = require('../dist/lib/server');
-const { getErrorRecovery } = require('../dist/lib/types/error-codes');
+const { KNOWN_ERROR_CODES } = require('../dist/lib/server/decisioning/async-outcome');
+const { getErrorRecovery, STANDARD_ERROR_CODES } = require('../dist/lib/types/error-codes');
 
 // Recovery is no longer hardcoded in typed-error classes — it's inherited
 // from STANDARD_ERROR_CODES via getErrorRecovery(code). These assertions
@@ -259,9 +260,27 @@ describe('Typed AdcpError subclasses — code + spec-correct recovery shape', ()
 });
 
 describe('AdcpError — recovery defaults from spec when omitted', () => {
+  it('uses the standard error-code runtime table for known-code warnings', () => {
+    assert.deepEqual(new Set(KNOWN_ERROR_CODES), new Set(Object.keys(STANDARD_ERROR_CODES)));
+  });
+
   it('omitting recovery falls back to getErrorRecovery(code) for standard codes', () => {
     const e = new AdcpError('TERMS_REJECTED', { message: 'omitted recovery' });
     assert.equal(e.recovery, 'correctable');
+  });
+
+  it('recognizes ACTION_NOT_ALLOWED without warning as a standard code', () => {
+    const warnings = [];
+    const originalWarn = console.warn;
+    console.warn = (...args) => warnings.push(args.join(' '));
+    try {
+      const e = new AdcpError('ACTION_NOT_ALLOWED', { message: 'not available for this buy' });
+      assert.equal(e.recovery, 'correctable');
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    assert.deepEqual(warnings, []);
   });
 
   it('omitting recovery for a non-standard code falls back to terminal', () => {


### PR DESCRIPTION
## Summary
- Derive decisioning `KNOWN_ERROR_CODES` from `STANDARD_ERROR_CODES` so the `AdcpError` warning path uses the same runtime table as `isStandardErrorCode` and `getErrorRecovery`.
- Add regression coverage that `ACTION_NOT_ALLOWED` is treated as a standard AdCP 3.1 code with `correctable` recovery and does not emit the custom-code warning.
- Add a patch changeset for the SDK behavior fix.

## Root cause
The decisioning warning path had its own known-code list assembled from generated enum values plus the forward-compat overlay. That can drift from the composed standard error-code runtime table used elsewhere in the SDK.

Closes #2003.

## Validation
- Expert review: code-reviewer and protocol_reviewer
- `npm run build`
- `NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/server-typed-errors.test.js test/lib/v3-compatibility.test.js test/lib/action-not-allowed-error.test.js test/lib/standard-error-codes-drift.test.js`
- pre-push hook: `npm run typecheck`, library build

## Notes
- Left the pre-existing local `package-lock.json` version-sync change out of this PR scope.