### PR TITLE
feat: add webhook and signal discovery helpers

### DIFF
--- a/.changeset/wholesale-feed-webhook-normalizer.md
+++ b/.changeset/wholesale-feed-webhook-normalizer.md
@@ -1,0 +1,14 @@
+---
+'@adcp/sdk': minor
+---
+
+Export `parseWholesaleFeedWebhookNotification` /
+`normalizeWholesaleFeedWebhookNotification` helpers for canonical wholesale-feed
+webhook receivers and align `WholesaleFeedSync` dedupe semantics with delivery
+`idempotency_key` plus canonical logical event identity
+`notification_id === event.event_id`.
+
+Add buyer-side signal discovery helpers that normalize `get_signals` rows,
+expose the canonical `activate_signal.signal_agent_segment_id` handle, and
+build activation requests without confusing `signal_id` provenance for the
+activation key.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/sdk",
-  "version": "8.1.0-beta.10",
+  "version": "8.1.0-beta.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/sdk",
-      "version": "8.1.0-beta.10",
+      "version": "8.1.0-beta.11",
       "license": "Apache-2.0",
       "workspaces": [
         ".",
@@ -7348,7 +7348,7 @@
       "version": "6.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adcp/sdk": "^8.1.0-beta.10"
+        "@adcp/sdk": "^8.1.0-beta.11"
       },
       "bin": {
         "adcp": "bin/adcp.js"

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -273,6 +273,21 @@ export type {
 } from './core/AsyncHandler';
 export { AsyncHandler, createAsyncHandler } from './core/AsyncHandler';
 
+// ====== WHOLESALE FEED WEBHOOKS ======
+export {
+  normalizeWholesaleFeedWebhookNotification,
+  parseWholesaleFeedWebhookNotification,
+  WholesaleFeedWebhookNotificationError,
+} from './wholesale-feed-sync/webhook-notification';
+export type {
+  NormalizedWholesaleFeedWebhookNotification,
+  WholesaleFeedWebhookAffectedEntityType,
+  WholesaleFeedWebhookCacheScope,
+  WholesaleFeedWebhookNotificationErrorCode,
+  WholesaleFeedWebhookNotificationErrorDetails,
+  WholesaleFeedWebhookNotificationType,
+} from './wholesale-feed-sync/webhook-notification';
+
 // ====== INPUT HANDLERS ======
 export * from './handlers/types';
 
@@ -1158,6 +1173,17 @@ export { activationKey, segmentIdActivationKey, keyValueActivationKey } from './
 // To read fields from a received `SignalID`, use `getSignalId` (segment id)
 // and `getSignalIssuer` (data_provider_domain or agent_url).
 export { signalId, catalogSignalId, agentSignalId, getSignalId, getSignalIssuer } from './utils/signal-id-builders';
+export {
+  buildActivateSignalRequest,
+  getSignalActivationId,
+  getSignalPricingOptionIds,
+  normalizeDiscoveredSignal,
+} from './utils/signal-discovery-helpers';
+export type {
+  BuildActivateSignalRequestOptions,
+  DiscoveredSignal,
+  NormalizedDiscoveredSignal,
+} from './utils/signal-discovery-helpers';
 
 // ====== BUILD CREATIVE RETURN BUILDERS ======
 // Typed factories for the four return shapes accepted by the framework

--- a/src/lib/utils/signal-discovery-helpers.ts
+++ b/src/lib/utils/signal-discovery-helpers.ts
@@ -1,0 +1,140 @@
+import type { ActivateSignalRequest, GetSignalsResponse, SignalID } from '../types/tools.generated';
+import { getSignalId, getSignalIssuer } from './signal-id-builders';
+import type { MutatingRequestInput } from './idempotency';
+
+export type DiscoveredSignal = NonNullable<GetSignalsResponse['signals']>[number];
+
+export interface NormalizedDiscoveredSignal {
+  /** Original get_signals row. Preserved so helpers never hide seller data. */
+  raw: DiscoveredSignal;
+  /** Canonical value to pass as activate_signal.signal_agent_segment_id. */
+  signalAgentSegmentId: string;
+  /** Provenance object returned as signal_id, when the seller provides one. */
+  signalId?: SignalID;
+  /** signal_id.id, when signal_id is present. Not the activation key. */
+  signalIdValue?: string;
+  /** signal_id.source, when signal_id is present. */
+  signalSource?: SignalID['source'];
+  /** data_provider_domain for catalog signals, agent_url for agent-native signals. */
+  signalIssuer?: string;
+  /** pricing_options[].pricing_option_id values in response order. */
+  pricingOptionIds: string[];
+  /** Governance metadata copied from the signal row when present. */
+  restrictedAttributes: string[];
+  /** Governance metadata copied from the signal row when present. */
+  policyCategories: string[];
+}
+
+export type BuildActivateSignalRequestOptions = Omit<
+  MutatingRequestInput<ActivateSignalRequest>,
+  'signal_agent_segment_id' | 'pricing_option_id'
+> & {
+  /** Snake-case wire field. Takes precedence over pricingOptionId when both are present. */
+  pricing_option_id?: string;
+  /** Camel-case convenience alias for pricing_option_id. */
+  pricingOptionId?: string;
+};
+
+/**
+ * Normalize one `get_signals` row into the semantic fields buyers need for
+ * the next call. The important invariant: `signalAgentSegmentId` is the
+ * activation handle; nested `signalId` is provenance and may differ.
+ */
+export function normalizeDiscoveredSignal(signal: DiscoveredSignal): NormalizedDiscoveredSignal {
+  const signalAgentSegmentId = getSignalActivationId(signal);
+  const signalId = readSignalId(signal);
+  const pricingOptionIds = getSignalPricingOptionIds(signal);
+
+  return {
+    raw: signal,
+    signalAgentSegmentId,
+    ...(signalId && {
+      signalId,
+      signalIdValue: getSignalId(signalId),
+      signalSource: signalId.source,
+      signalIssuer: getSignalIssuer(signalId),
+    }),
+    pricingOptionIds,
+    restrictedAttributes: readStringArray(signal, 'restricted_attributes'),
+    policyCategories: readStringArray(signal, 'policy_categories'),
+  };
+}
+
+/**
+ * Build an `activate_signal` request from a discovered signal row. The
+ * returned object is suitable for `agent.activateSignal(...)`; the SDK will
+ * inject `idempotency_key` unless the caller supplied one.
+ */
+export function buildActivateSignalRequest(
+  signal: DiscoveredSignal | NormalizedDiscoveredSignal,
+  options: BuildActivateSignalRequestOptions
+): MutatingRequestInput<ActivateSignalRequest> {
+  const normalized = isNormalizedDiscoveredSignal(signal) ? signal : normalizeDiscoveredSignal(signal);
+  const { pricingOptionId, ...wireOptions } = options;
+  const pricing_option_id = wireOptions.pricing_option_id ?? pricingOptionId;
+
+  return {
+    ...wireOptions,
+    signal_agent_segment_id: normalized.signalAgentSegmentId,
+    ...(pricing_option_id !== undefined && { pricing_option_id }),
+  };
+}
+
+/** Return the canonical activation handle from one `get_signals` row. */
+export function getSignalActivationId(signal: DiscoveredSignal): string {
+  const value = (signal as { signal_agent_segment_id?: unknown }).signal_agent_segment_id;
+  if (typeof value === 'string' && value.length > 0) return value;
+  throw new Error('getSignalActivationId: signal.signal_agent_segment_id is required.');
+}
+
+/** Return pricing option ids from one discovered signal, preserving response order. */
+export function getSignalPricingOptionIds(signal: DiscoveredSignal): string[] {
+  const pricingOptions = (signal as { pricing_options?: unknown }).pricing_options;
+  if (!Array.isArray(pricingOptions)) return [];
+  return pricingOptions
+    .map(option =>
+      option && typeof option === 'object' ? (option as { pricing_option_id?: unknown }).pricing_option_id : undefined
+    )
+    .filter((id): id is string => typeof id === 'string' && id.length > 0);
+}
+
+function isNormalizedDiscoveredSignal(
+  signal: DiscoveredSignal | NormalizedDiscoveredSignal
+): signal is NormalizedDiscoveredSignal {
+  return (
+    signal != null &&
+    typeof signal === 'object' &&
+    'raw' in signal &&
+    typeof (signal as { signalAgentSegmentId?: unknown }).signalAgentSegmentId === 'string'
+  );
+}
+
+function readSignalId(signal: DiscoveredSignal): SignalID | undefined {
+  const value = (signal as { signal_id?: unknown }).signal_id;
+  if (isSignalId(value)) return value;
+  return undefined;
+}
+
+function isSignalId(value: unknown): value is SignalID {
+  if (!value || typeof value !== 'object') return false;
+  const source = (value as { source?: unknown }).source;
+  if (source === 'catalog') {
+    return (
+      typeof (value as { id?: unknown }).id === 'string' &&
+      typeof (value as { data_provider_domain?: unknown }).data_provider_domain === 'string'
+    );
+  }
+  if (source === 'agent') {
+    return (
+      typeof (value as { id?: unknown }).id === 'string' &&
+      typeof (value as { agent_url?: unknown }).agent_url === 'string'
+    );
+  }
+  return false;
+}
+
+function readStringArray(signal: DiscoveredSignal, field: 'restricted_attributes' | 'policy_categories'): string[] {
+  const value = (signal as Record<string, unknown>)[field];
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === 'string' && item.length > 0);
+}

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP SDK library version
  */
-export const LIBRARY_VERSION = '8.1.0-beta.10';
+export const LIBRARY_VERSION = '8.1.0-beta.11';
 
 /**
  * AdCP specification version this library is built for
@@ -63,10 +63,10 @@ export type AdcpVersion = (typeof COMPATIBLE_ADCP_VERSIONS)[number];
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '8.1.0-beta.10',
+  library: '8.1.0-beta.11',
   adcp: '3.1.0-beta.3',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-05-25T03:30:47.538Z',
+  generatedAt: '2026-05-25T12:17:50.885Z',
 } as const;
 
 /**

--- a/src/lib/webhooks/index.ts
+++ b/src/lib/webhooks/index.ts
@@ -1,5 +1,19 @@
 import { createHmac, timingSafeEqual } from 'crypto';
 
+export {
+  normalizeWholesaleFeedWebhookNotification,
+  parseWholesaleFeedWebhookNotification,
+  WholesaleFeedWebhookNotificationError,
+} from '../wholesale-feed-sync/webhook-notification';
+export type {
+  NormalizedWholesaleFeedWebhookNotification,
+  WholesaleFeedWebhookAffectedEntityType,
+  WholesaleFeedWebhookCacheScope,
+  WholesaleFeedWebhookNotificationErrorCode,
+  WholesaleFeedWebhookNotificationErrorDetails,
+  WholesaleFeedWebhookNotificationType,
+} from '../wholesale-feed-sync/webhook-notification';
+
 export type WebhookHeaderValue = string | number | readonly string[] | null | undefined;
 export type WebhookHeadersLike = Headers | Record<string, WebhookHeaderValue>;
 

--- a/src/lib/wholesale-feed-sync/index.ts
+++ b/src/lib/wholesale-feed-sync/index.ts
@@ -9,6 +9,11 @@
 // agents.
 
 export { WholesaleFeedSync } from './sync';
+export {
+  normalizeWholesaleFeedWebhookNotification,
+  parseWholesaleFeedWebhookNotification,
+  WholesaleFeedWebhookNotificationError,
+} from './webhook-notification';
 export type {
   WholesaleFeedSyncClient,
   WholesaleFeedSyncConfig,
@@ -19,3 +24,11 @@ export type {
   ResolvedCapabilities,
   SignalFilter,
 } from './types';
+export type {
+  NormalizedWholesaleFeedWebhookNotification,
+  WholesaleFeedWebhookAffectedEntityType,
+  WholesaleFeedWebhookCacheScope,
+  WholesaleFeedWebhookNotificationErrorCode,
+  WholesaleFeedWebhookNotificationErrorDetails,
+  WholesaleFeedWebhookNotificationType,
+} from './webhook-notification';

--- a/src/lib/wholesale-feed-sync/sync.ts
+++ b/src/lib/wholesale-feed-sync/sync.ts
@@ -669,7 +669,7 @@ export class WholesaleFeedSync extends EventEmitter<WholesaleFeedSyncEvents> {
       this.webhookScope?.senderId ?? 'default',
       webhook.account_id,
       webhook.subscriber_id,
-      webhook.notification_id,
+      webhook.event.event_id,
     ].join(':');
   }
 

--- a/src/lib/wholesale-feed-sync/webhook-notification.ts
+++ b/src/lib/wholesale-feed-sync/webhook-notification.ts
@@ -1,0 +1,379 @@
+import { ADCPError } from '../errors';
+import type * as V31Beta from '../types/v3-1-beta';
+
+export type WholesaleFeedWebhookNotificationType = V31Beta.WholesaleFeedWebhook['notification_type'];
+export type WholesaleFeedWebhookAffectedEntityType = 'product' | 'signal';
+export type WholesaleFeedWebhookCacheScope = V31Beta.WholesaleFeedWebhook['cache_scope'];
+
+export type WholesaleFeedWebhookNotificationErrorCode =
+  | 'wholesale_feed_webhook_body_malformed'
+  | 'wholesale_feed_webhook_field_missing'
+  | 'wholesale_feed_webhook_field_invalid'
+  | 'wholesale_feed_webhook_notification_type_mismatch'
+  | 'wholesale_feed_webhook_entity_type_mismatch'
+  | 'wholesale_feed_webhook_cache_scope_mismatch'
+  | 'wholesale_feed_webhook_bulk_change_invalid';
+
+export interface WholesaleFeedWebhookNotificationErrorDetails {
+  field?: string;
+  expected?: unknown;
+  actual?: unknown;
+}
+
+export class WholesaleFeedWebhookNotificationError extends ADCPError {
+  readonly code: WholesaleFeedWebhookNotificationErrorCode;
+  readonly field: string | undefined;
+
+  constructor(
+    code: WholesaleFeedWebhookNotificationErrorCode,
+    message: string,
+    details: WholesaleFeedWebhookNotificationErrorDetails = {}
+  ) {
+    super(message, details);
+    this.code = code;
+    this.field = details.field;
+  }
+}
+
+export interface NormalizedWholesaleFeedWebhookNotification {
+  /** Delivery replay/dedupe key. Scope this to the authenticated sender identity. */
+  idempotencyKey: string;
+  /** Envelope notification identifier. Must match the nested domain event id. */
+  notificationId: string;
+  /** Envelope notification type. Guaranteed to match `event.event_type`. */
+  notificationType: WholesaleFeedWebhookNotificationType;
+  /** Tenant/account identifier for the receiving subscription. */
+  accountId: string;
+  /** Registered account notification subscriber id. */
+  subscriberId: string;
+  /** ISO timestamp when this webhook delivery was fired. */
+  firedAt: string;
+  wholesaleFeedVersion: string;
+  previousWholesaleFeedVersion?: string;
+  cacheScope: WholesaleFeedWebhookCacheScope;
+  /** Stable domain event id nested under `event`. Not the delivery dedupe key. */
+  eventId: string;
+  eventType: WholesaleFeedWebhookNotificationType;
+  entityType: 'product' | 'signal' | 'feed';
+  entityId: string;
+  eventCreatedAt: string;
+  /** Present for `wholesale_feed.bulk_change` notifications. */
+  affectedEntityType?: WholesaleFeedWebhookAffectedEntityType;
+  event: V31Beta.WholesaleFeedEvent;
+  webhook: V31Beta.WholesaleFeedWebhook;
+}
+
+const WHOLESALE_FEED_NOTIFICATION_TYPES = new Set<WholesaleFeedWebhookNotificationType>([
+  'product.created',
+  'product.updated',
+  'product.priced',
+  'product.removed',
+  'signal.created',
+  'signal.updated',
+  'signal.priced',
+  'signal.removed',
+  'wholesale_feed.bulk_change',
+]);
+
+/**
+ * Parse and normalize a canonical wholesale-feed webhook notification.
+ *
+ * The normalized shape intentionally separates `idempotencyKey` (delivery
+ * replay/dedupe) from `eventId` / `notificationId` (domain event identity).
+ * It validates envelope-level invariants, including the canonical
+ * `notification_id === event.event_id` match.
+ */
+export function parseWholesaleFeedWebhookNotification(input: unknown): NormalizedWholesaleFeedWebhookNotification {
+  const parsed = parseInput(input);
+  const webhook = readRecord(parsed, '$');
+  const event = readRecord(webhook.event, 'event');
+
+  const idempotencyKey = readRequiredString(webhook, 'idempotency_key');
+  const notificationId = readRequiredString(webhook, 'notification_id');
+  const notificationType = readNotificationType(readRequiredString(webhook, 'notification_type'), 'notification_type');
+  const firedAt = readRequiredString(webhook, 'fired_at');
+  const subscriberId = readRequiredString(webhook, 'subscriber_id');
+  const accountId = readRequiredString(webhook, 'account_id');
+  const wholesaleFeedVersion = readRequiredString(webhook, 'wholesale_feed_version');
+  const previousWholesaleFeedVersion = readOptionalString(webhook, 'previous_wholesale_feed_version');
+  const cacheScope = readCacheScope(readRequiredString(webhook, 'cache_scope'), 'cache_scope');
+
+  const eventId = readRequiredString(event, 'event.event_id');
+  if (notificationId !== eventId) {
+    throw new WholesaleFeedWebhookNotificationError(
+      'wholesale_feed_webhook_field_invalid',
+      'wholesale-feed webhook notification_id must match event.event_id.',
+      { field: 'notification_id', expected: eventId, actual: notificationId }
+    );
+  }
+
+  const eventType = readNotificationType(readRequiredString(event, 'event.event_type'), 'event.event_type');
+  if (notificationType !== eventType) {
+    throw new WholesaleFeedWebhookNotificationError(
+      'wholesale_feed_webhook_notification_type_mismatch',
+      'wholesale-feed webhook notification_type must match event.event_type.',
+      { field: 'notification_type', expected: eventType, actual: notificationType }
+    );
+  }
+
+  const entityType = readEntityType(readRequiredString(event, 'event.entity_type'), 'event.entity_type');
+  assertEntityTypeMatchesNotification(notificationType, entityType);
+  const entityId = readRequiredString(event, 'event.entity_id');
+  const eventCreatedAt = readRequiredString(event, 'event.created_at');
+  const payload = readRecord(event.payload, 'event.payload');
+
+  const payloadScope = readRequiredPayloadScope(payload);
+  if (payloadScope !== cacheScope) {
+    throw new WholesaleFeedWebhookNotificationError(
+      'wholesale_feed_webhook_cache_scope_mismatch',
+      'wholesale-feed webhook cache_scope must match event.payload.applies_to.scope.',
+      { field: 'cache_scope', expected: payloadScope, actual: cacheScope }
+    );
+  }
+
+  const affectedEntityType = validatePayloadForEvent(notificationType, entityId, payload);
+
+  return {
+    idempotencyKey,
+    notificationId,
+    notificationType,
+    accountId,
+    subscriberId,
+    firedAt,
+    wholesaleFeedVersion,
+    ...(previousWholesaleFeedVersion !== undefined && { previousWholesaleFeedVersion }),
+    cacheScope,
+    eventId,
+    eventType,
+    entityType,
+    entityId,
+    eventCreatedAt,
+    ...(affectedEntityType !== undefined && { affectedEntityType }),
+    event: event as V31Beta.WholesaleFeedEvent,
+    webhook: webhook as V31Beta.WholesaleFeedWebhook,
+  };
+}
+
+export const normalizeWholesaleFeedWebhookNotification = parseWholesaleFeedWebhookNotification;
+
+function parseInput(input: unknown): unknown {
+  if (typeof input === 'string') return parseJson(input);
+  if (input instanceof Uint8Array) return parseJson(new TextDecoder().decode(input));
+  return input;
+}
+
+function parseJson(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch (err) {
+    throw new WholesaleFeedWebhookNotificationError(
+      'wholesale_feed_webhook_body_malformed',
+      'wholesale-feed webhook body must be valid JSON.',
+      { field: '$', actual: err instanceof Error ? err.message : String(err) }
+    );
+  }
+}
+
+function readRecord(value: unknown, field: string): Record<string, unknown> {
+  if (value && typeof value === 'object' && !Array.isArray(value)) return value as Record<string, unknown>;
+  throw new WholesaleFeedWebhookNotificationError(
+    field === '$' ? 'wholesale_feed_webhook_body_malformed' : 'wholesale_feed_webhook_field_invalid',
+    field === '$'
+      ? 'wholesale-feed webhook body must be a JSON object.'
+      : `wholesale-feed webhook field ${field} must be an object.`,
+    { field, expected: 'object', actual: describeValue(value) }
+  );
+}
+
+function readRequiredRecord(obj: Record<string, unknown>, field: string): Record<string, unknown> {
+  const key = field.includes('.') ? field.slice(field.lastIndexOf('.') + 1) : field;
+  const value = obj[key];
+  if (value === undefined) {
+    throw new WholesaleFeedWebhookNotificationError(
+      'wholesale_feed_webhook_field_missing',
+      `wholesale-feed webhook field ${field} must be an object.`,
+      { field, expected: 'object', actual: describeValue(value) }
+    );
+  }
+  return readRecord(value, field);
+}
+
+function readRequiredString(obj: Record<string, unknown>, field: string): string {
+  const key = field.includes('.') ? field.slice(field.lastIndexOf('.') + 1) : field;
+  const value = obj[key];
+  if (typeof value === 'string' && value.length > 0) return value;
+  throw new WholesaleFeedWebhookNotificationError(
+    value === undefined ? 'wholesale_feed_webhook_field_missing' : 'wholesale_feed_webhook_field_invalid',
+    `wholesale-feed webhook field ${field} must be a non-empty string.`,
+    { field, expected: 'non-empty string', actual: describeValue(value) }
+  );
+}
+
+function readRequiredNonEmptyArray(obj: Record<string, unknown>, field: string): unknown[] {
+  const key = field.includes('.') ? field.slice(field.lastIndexOf('.') + 1) : field;
+  const value = obj[key];
+  if (Array.isArray(value) && value.length > 0) return value;
+  throw new WholesaleFeedWebhookNotificationError(
+    value === undefined ? 'wholesale_feed_webhook_field_missing' : 'wholesale_feed_webhook_field_invalid',
+    `wholesale-feed webhook field ${field} must be a non-empty array.`,
+    { field, expected: 'non-empty array', actual: describeValue(value) }
+  );
+}
+
+function readRequiredPositiveInteger(obj: Record<string, unknown>, field: string): number {
+  const key = field.includes('.') ? field.slice(field.lastIndexOf('.') + 1) : field;
+  const value = obj[key];
+  if (Number.isInteger(value) && (value as number) > 0) return value as number;
+  throw new WholesaleFeedWebhookNotificationError(
+    value === undefined ? 'wholesale_feed_webhook_field_missing' : 'wholesale_feed_webhook_field_invalid',
+    `wholesale-feed webhook field ${field} must be a positive integer.`,
+    { field, expected: 'positive integer', actual: describeValue(value) }
+  );
+}
+
+function readOptionalString(obj: Record<string, unknown>, field: string): string | undefined {
+  const value = obj[field];
+  if (value === undefined) return undefined;
+  if (typeof value === 'string' && value.length > 0) return value;
+  throw new WholesaleFeedWebhookNotificationError(
+    'wholesale_feed_webhook_field_invalid',
+    `wholesale-feed webhook field ${field} must be a non-empty string when present.`,
+    { field, expected: 'non-empty string', actual: describeValue(value) }
+  );
+}
+
+function readNotificationType(value: string, field: string): WholesaleFeedWebhookNotificationType {
+  if (WHOLESALE_FEED_NOTIFICATION_TYPES.has(value as WholesaleFeedWebhookNotificationType)) {
+    return value as WholesaleFeedWebhookNotificationType;
+  }
+  throw new WholesaleFeedWebhookNotificationError(
+    'wholesale_feed_webhook_field_invalid',
+    `wholesale-feed webhook field ${field} is not a supported wholesale-feed notification type.`,
+    { field, expected: [...WHOLESALE_FEED_NOTIFICATION_TYPES], actual: value }
+  );
+}
+
+function readCacheScope(value: string, field: string): WholesaleFeedWebhookCacheScope {
+  if (value === 'public' || value === 'account') return value;
+  throw new WholesaleFeedWebhookNotificationError(
+    'wholesale_feed_webhook_field_invalid',
+    `wholesale-feed webhook field ${field} must be "public" or "account".`,
+    { field, expected: ['public', 'account'], actual: value }
+  );
+}
+
+function readEntityType(value: string, field: string): NormalizedWholesaleFeedWebhookNotification['entityType'] {
+  if (value === 'product' || value === 'signal' || value === 'feed') return value;
+  throw new WholesaleFeedWebhookNotificationError(
+    'wholesale_feed_webhook_field_invalid',
+    `wholesale-feed webhook field ${field} must be "product", "signal", or "feed".`,
+    { field, expected: ['product', 'signal', 'feed'], actual: value }
+  );
+}
+
+function assertEntityTypeMatchesNotification(
+  notificationType: WholesaleFeedWebhookNotificationType,
+  entityType: NormalizedWholesaleFeedWebhookNotification['entityType']
+): void {
+  const expected = notificationType.startsWith('product.')
+    ? 'product'
+    : notificationType.startsWith('signal.')
+      ? 'signal'
+      : 'feed';
+
+  if (entityType !== expected) {
+    throw new WholesaleFeedWebhookNotificationError(
+      'wholesale_feed_webhook_entity_type_mismatch',
+      'wholesale-feed webhook event.entity_type does not match event.event_type.',
+      { field: 'event.entity_type', expected, actual: entityType }
+    );
+  }
+}
+
+function validatePayloadForEvent(
+  notificationType: WholesaleFeedWebhookNotificationType,
+  entityId: string,
+  payload: Record<string, unknown>
+): WholesaleFeedWebhookAffectedEntityType | undefined {
+  switch (notificationType) {
+    case 'product.created':
+    case 'product.updated': {
+      assertEntityIdMatchesPayload(entityId, readRequiredString(payload, 'event.payload.product_id'), 'product_id');
+      readRequiredRecord(payload, 'event.payload.product');
+      return undefined;
+    }
+    case 'product.priced': {
+      assertEntityIdMatchesPayload(entityId, readRequiredString(payload, 'event.payload.product_id'), 'product_id');
+      readRequiredNonEmptyArray(payload, 'event.payload.pricing_options');
+      return undefined;
+    }
+    case 'product.removed': {
+      assertEntityIdMatchesPayload(entityId, readRequiredString(payload, 'event.payload.product_id'), 'product_id');
+      return undefined;
+    }
+    case 'signal.created':
+    case 'signal.updated': {
+      assertEntityIdMatchesPayload(
+        entityId,
+        readRequiredString(payload, 'event.payload.signal_agent_segment_id'),
+        'signal_agent_segment_id'
+      );
+      readRequiredRecord(payload, 'event.payload.signal');
+      return undefined;
+    }
+    case 'signal.priced': {
+      assertEntityIdMatchesPayload(
+        entityId,
+        readRequiredString(payload, 'event.payload.signal_agent_segment_id'),
+        'signal_agent_segment_id'
+      );
+      readRequiredNonEmptyArray(payload, 'event.payload.pricing_options');
+      return undefined;
+    }
+    case 'signal.removed': {
+      assertEntityIdMatchesPayload(
+        entityId,
+        readRequiredString(payload, 'event.payload.signal_agent_segment_id'),
+        'signal_agent_segment_id'
+      );
+      return undefined;
+    }
+    case 'wholesale_feed.bulk_change':
+      readRequiredString(payload, 'event.payload.summary');
+      readRequiredPositiveInteger(payload, 'event.payload.affected_count');
+      return readBulkChangeAffectedEntityType(payload);
+  }
+}
+
+function assertEntityIdMatchesPayload(entityId: string, payloadEntityId: string, payloadField: string): void {
+  if (entityId === payloadEntityId) return;
+  throw new WholesaleFeedWebhookNotificationError(
+    'wholesale_feed_webhook_field_invalid',
+    `wholesale-feed webhook event.entity_id must match event.payload.${payloadField}.`,
+    { field: 'event.entity_id', expected: payloadEntityId, actual: entityId }
+  );
+}
+
+function readRequiredPayloadScope(payload: Record<string, unknown>): WholesaleFeedWebhookCacheScope {
+  const appliesToRecord = readRequiredRecord(payload, 'event.payload.applies_to');
+  return readCacheScope(
+    readRequiredString(appliesToRecord, 'event.payload.applies_to.scope'),
+    'event.payload.applies_to.scope'
+  );
+}
+
+function readBulkChangeAffectedEntityType(payload: Record<string, unknown>): WholesaleFeedWebhookAffectedEntityType {
+  const affected = payload.affected_entity_type;
+  if (affected === 'product' || affected === 'signal') return affected;
+  throw new WholesaleFeedWebhookNotificationError(
+    'wholesale_feed_webhook_bulk_change_invalid',
+    'wholesale_feed.bulk_change payload requires affected_entity_type of "product" or "signal".',
+    { field: 'event.payload.affected_entity_type', expected: ['product', 'signal'], actual: describeValue(affected) }
+  );
+}
+
+function describeValue(value: unknown): string {
+  if (value === null) return 'null';
+  if (Array.isArray(value)) return 'array';
+  return typeof value;
+}

--- a/test/lib/signal-discovery-helpers.test.js
+++ b/test/lib/signal-discovery-helpers.test.js
@@ -1,0 +1,113 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+const {
+  buildActivateSignalRequest,
+  getSignalActivationId,
+  getSignalPricingOptionIds,
+  normalizeDiscoveredSignal,
+  signalId,
+} = require('../../dist/lib/index.js');
+
+function makeSignal(overrides = {}) {
+  return {
+    signal_agent_segment_id: 'activation-handle-123',
+    signal_id: signalId.catalog({ data_provider_domain: 'polk.com', id: 'likely_ev_buyers' }),
+    name: 'Likely EV buyers',
+    signal_type: 'marketplace',
+    data_provider: 'Polk',
+    pricing_options: [
+      { pricing_option_id: 'po_cpm', model: 'cpm', cpm: 2.5, currency: 'USD' },
+      { pricing_option_id: 'po_flat', model: 'flat_rate', amount: 500, currency: 'USD' },
+    ],
+    restricted_attributes: ['precise_location'],
+    policy_categories: ['automotive'],
+    ...overrides,
+  };
+}
+
+test('normalizeDiscoveredSignal separates activation handle from signal_id provenance', () => {
+  const normalized = normalizeDiscoveredSignal(makeSignal());
+
+  assert.strictEqual(normalized.signalAgentSegmentId, 'activation-handle-123');
+  assert.strictEqual(normalized.signalIdValue, 'likely_ev_buyers');
+  assert.notStrictEqual(normalized.signalAgentSegmentId, normalized.signalIdValue);
+  assert.strictEqual(normalized.signalSource, 'catalog');
+  assert.strictEqual(normalized.signalIssuer, 'polk.com');
+  assert.deepStrictEqual(normalized.pricingOptionIds, ['po_cpm', 'po_flat']);
+  assert.deepStrictEqual(normalized.restrictedAttributes, ['precise_location']);
+  assert.deepStrictEqual(normalized.policyCategories, ['automotive']);
+});
+
+test('normalizeDiscoveredSignal handles agent-native signal_id provenance', () => {
+  const normalized = normalizeDiscoveredSignal(
+    makeSignal({
+      signal_id: signalId.agent({
+        agent_url: 'https://signals.example.com/.well-known/adcp/signals',
+        id: 'agent-native-intenders',
+      }),
+    })
+  );
+
+  assert.strictEqual(normalized.signalSource, 'agent');
+  assert.strictEqual(normalized.signalIdValue, 'agent-native-intenders');
+  assert.strictEqual(normalized.signalIssuer, 'https://signals.example.com/.well-known/adcp/signals');
+});
+
+test('normalizeDiscoveredSignal handles rows without signal_id provenance', () => {
+  const { signal_id, ...signal } = makeSignal();
+  void signal_id;
+  const normalized = normalizeDiscoveredSignal(signal);
+
+  assert.strictEqual(normalized.signalAgentSegmentId, 'activation-handle-123');
+  assert.strictEqual(normalized.signalId, undefined);
+  assert.strictEqual(normalized.signalIssuer, undefined);
+  assert.deepStrictEqual(normalized.pricingOptionIds, ['po_cpm', 'po_flat']);
+});
+
+test('buildActivateSignalRequest uses signal_agent_segment_id and preserves activation options', () => {
+  const req = buildActivateSignalRequest(makeSignal(), {
+    destinations: [{ type: 'platform', platform: 'dv360' }],
+    account: { account_id: 'acc_acme' },
+    action: 'activate',
+    pricingOptionId: 'po_cpm',
+    context: { buyer_ref: 'sig-activation-1' },
+  });
+
+  assert.deepStrictEqual(req, {
+    signal_agent_segment_id: 'activation-handle-123',
+    destinations: [{ type: 'platform', platform: 'dv360' }],
+    account: { account_id: 'acc_acme' },
+    action: 'activate',
+    pricing_option_id: 'po_cpm',
+    context: { buyer_ref: 'sig-activation-1' },
+  });
+});
+
+test('buildActivateSignalRequest accepts a pre-normalized signal and snake-case pricing takes precedence', () => {
+  const normalized = normalizeDiscoveredSignal(makeSignal());
+  const req = buildActivateSignalRequest(normalized, {
+    destinations: [{ type: 'platform', platform: 'meta' }],
+    pricing_option_id: 'po_flat',
+    pricingOptionId: 'po_cpm',
+    idempotency_key: 'signal-activation-key-123',
+  });
+
+  assert.strictEqual(req.signal_agent_segment_id, 'activation-handle-123');
+  assert.strictEqual(req.pricing_option_id, 'po_flat');
+  assert.strictEqual(req.idempotency_key, 'signal-activation-key-123');
+});
+
+test('signal discovery accessors expose activation and pricing ids', () => {
+  const signal = makeSignal();
+
+  assert.strictEqual(getSignalActivationId(signal), 'activation-handle-123');
+  assert.deepStrictEqual(getSignalPricingOptionIds(signal), ['po_cpm', 'po_flat']);
+});
+
+test('getSignalActivationId fails clearly when the discovery row is not activatable', () => {
+  const { signal_agent_segment_id, ...signal } = makeSignal();
+  void signal_agent_segment_id;
+
+  assert.throws(() => getSignalActivationId(signal), /signal_agent_segment_id is required/);
+});

--- a/test/lib/wholesale-feed-sync.test.js
+++ b/test/lib/wholesale-feed-sync.test.js
@@ -78,10 +78,13 @@ function makeSignal(signal_agent_segment_id, overrides = {}) {
   };
 }
 
-function makeWebhook(event, { version = 'v2', previous = 'v1', cache_scope = 'public' } = {}) {
+function makeWebhook(
+  event,
+  { version = 'v2', previous = 'v1', cache_scope = 'public', notification_id = event.event_id } = {}
+) {
   return {
     idempotency_key: `idem-${event.event_id}`,
-    notification_id: event.event_id,
+    notification_id,
     notification_type: event.event_type,
     fired_at: '2026-05-22T12:00:00Z',
     subscriber_id: 'wholesale-feed-sync',

--- a/test/lib/wholesale-feed-webhook-notification.test.js
+++ b/test/lib/wholesale-feed-webhook-notification.test.js
@@ -1,0 +1,199 @@
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+
+const {
+  normalizeWholesaleFeedWebhookNotification,
+  parseWholesaleFeedWebhookNotification,
+  WholesaleFeedWebhookNotificationError,
+} = require('../../dist/lib/wholesale-feed-sync/index.js');
+
+function makeNotification(overrides = {}) {
+  const event = overrides.event ?? {
+    event_id: 'evt_01HZNX6R4R6ZJ65TP8W4D2H4WQ',
+    event_type: 'wholesale_feed.bulk_change',
+    entity_type: 'feed',
+    entity_id: 'bulk-2026-q3',
+    created_at: '2026-05-25T12:00:00Z',
+    payload: {
+      summary: 'Q3 refresh',
+      affected_count: 12,
+      affected_entity_type: 'product',
+      applies_to: { scope: 'account', account_ids: ['acc_acme'] },
+    },
+  };
+
+  return {
+    idempotency_key: 'delivery-01HZNX6T5H0R3GX7X7R54PKNPS',
+    notification_id: event.event_id,
+    notification_type: event.event_type,
+    fired_at: '2026-05-25T12:00:03Z',
+    subscriber_id: 'storefront-catalog',
+    account_id: 'acc_acme',
+    wholesale_feed_version: 'wf-v2',
+    previous_wholesale_feed_version: 'wf-v1',
+    cache_scope: 'account',
+    event,
+    ...overrides,
+  };
+}
+
+describe('wholesale-feed webhook notification normalizer', () => {
+  test('is exported from the root, webhooks, and wholesale-feed-sync entrypoints', () => {
+    const root = require('../../dist/lib/index.js');
+    const webhooks = require('../../dist/lib/webhooks/index.js');
+
+    assert.strictEqual(root.parseWholesaleFeedWebhookNotification, parseWholesaleFeedWebhookNotification);
+    assert.strictEqual(root.normalizeWholesaleFeedWebhookNotification, normalizeWholesaleFeedWebhookNotification);
+    assert.strictEqual(root.WholesaleFeedWebhookNotificationError, WholesaleFeedWebhookNotificationError);
+    assert.strictEqual(webhooks.parseWholesaleFeedWebhookNotification, parseWholesaleFeedWebhookNotification);
+    assert.strictEqual(webhooks.normalizeWholesaleFeedWebhookNotification, normalizeWholesaleFeedWebhookNotification);
+    assert.strictEqual(webhooks.WholesaleFeedWebhookNotificationError, WholesaleFeedWebhookNotificationError);
+  });
+
+  test('normalizes canonical deliveries with distinct delivery and event identifiers', () => {
+    const normalized = parseWholesaleFeedWebhookNotification(makeNotification());
+
+    assert.strictEqual(normalized.idempotencyKey, 'delivery-01HZNX6T5H0R3GX7X7R54PKNPS');
+    assert.strictEqual(normalized.notificationId, 'evt_01HZNX6R4R6ZJ65TP8W4D2H4WQ');
+    assert.strictEqual(normalized.notificationType, 'wholesale_feed.bulk_change');
+    assert.strictEqual(normalized.accountId, 'acc_acme');
+    assert.strictEqual(normalized.eventId, 'evt_01HZNX6R4R6ZJ65TP8W4D2H4WQ');
+    assert.strictEqual(normalized.affectedEntityType, 'product');
+    assert.notStrictEqual(normalized.idempotencyKey, normalized.eventId);
+    assert.strictEqual(normalized.notificationId, normalized.eventId);
+  });
+
+  test('accepts raw JSON strings and exposes the same normalized shape through the alias', () => {
+    const raw = JSON.stringify(makeNotification());
+    const normalized = normalizeWholesaleFeedWebhookNotification(raw);
+
+    assert.strictEqual(normalized.subscriberId, 'storefront-catalog');
+    assert.strictEqual(normalized.cacheScope, 'account');
+    assert.strictEqual(normalized.previousWholesaleFeedVersion, 'wf-v1');
+  });
+
+  test('accepts raw JSON bytes', () => {
+    const raw = Buffer.from(JSON.stringify(makeNotification()), 'utf8');
+    const normalized = parseWholesaleFeedWebhookNotification(raw);
+
+    assert.strictEqual(normalized.idempotencyKey, 'delivery-01HZNX6T5H0R3GX7X7R54PKNPS');
+    assert.strictEqual(normalized.eventId, 'evt_01HZNX6R4R6ZJ65TP8W4D2H4WQ');
+  });
+
+  test('throws typed errors when notification_id does not match event.event_id', () => {
+    assert.throws(
+      () => parseWholesaleFeedWebhookNotification(makeNotification({ notification_id: 'different-notification-id' })),
+      err => {
+        assert.ok(err instanceof WholesaleFeedWebhookNotificationError);
+        assert.strictEqual(err.code, 'wholesale_feed_webhook_field_invalid');
+        assert.strictEqual(err.field, 'notification_id');
+        return true;
+      }
+    );
+  });
+
+  test('throws typed errors for notification type mismatches', () => {
+    assert.throws(
+      () =>
+        parseWholesaleFeedWebhookNotification(
+          makeNotification({
+            notification_type: 'product.updated',
+          })
+        ),
+      err => {
+        assert.ok(err instanceof WholesaleFeedWebhookNotificationError);
+        assert.strictEqual(err.code, 'wholesale_feed_webhook_notification_type_mismatch');
+        assert.strictEqual(err.field, 'notification_type');
+        return true;
+      }
+    );
+  });
+
+  test('throws typed errors when bulk_change omits affected_entity_type', () => {
+    const notification = makeNotification({
+      event: {
+        ...makeNotification().event,
+        payload: {
+          summary: 'Q3 refresh',
+          affected_count: 12,
+          applies_to: { scope: 'account', account_ids: ['acc_acme'] },
+        },
+      },
+    });
+
+    assert.throws(
+      () => parseWholesaleFeedWebhookNotification(notification),
+      err => {
+        assert.ok(err instanceof WholesaleFeedWebhookNotificationError);
+        assert.strictEqual(err.code, 'wholesale_feed_webhook_bulk_change_invalid');
+        assert.strictEqual(err.field, 'event.payload.affected_entity_type');
+        return true;
+      }
+    );
+  });
+
+  test('throws typed errors when a branch payload omits applies_to', () => {
+    const notification = makeNotification({
+      event: {
+        event_id: 'evt_product_update',
+        event_type: 'product.updated',
+        entity_type: 'product',
+        entity_id: 'prod_ctv',
+        created_at: '2026-05-25T12:00:00Z',
+        payload: {
+          product_id: 'prod_ctv',
+          product: {},
+        },
+      },
+    });
+
+    assert.throws(
+      () => parseWholesaleFeedWebhookNotification(notification),
+      err => {
+        assert.ok(err instanceof WholesaleFeedWebhookNotificationError);
+        assert.strictEqual(err.code, 'wholesale_feed_webhook_field_missing');
+        assert.strictEqual(err.field, 'event.payload.applies_to');
+        return true;
+      }
+    );
+  });
+
+  test('throws typed errors when entity_id does not match the branch payload identifier', () => {
+    const notification = makeNotification({
+      event: {
+        event_id: 'evt_product_update',
+        event_type: 'product.updated',
+        entity_type: 'product',
+        entity_id: 'prod_ctv_old',
+        created_at: '2026-05-25T12:00:00Z',
+        payload: {
+          product_id: 'prod_ctv_new',
+          product: {},
+          applies_to: { scope: 'account', account_ids: ['acc_acme'] },
+        },
+      },
+    });
+
+    assert.throws(
+      () => parseWholesaleFeedWebhookNotification(notification),
+      err => {
+        assert.ok(err instanceof WholesaleFeedWebhookNotificationError);
+        assert.strictEqual(err.code, 'wholesale_feed_webhook_field_invalid');
+        assert.strictEqual(err.field, 'event.entity_id');
+        return true;
+      }
+    );
+  });
+
+  test('throws typed errors when envelope cache_scope contradicts payload scope', () => {
+    assert.throws(
+      () => parseWholesaleFeedWebhookNotification(makeNotification({ cache_scope: 'public' })),
+      err => {
+        assert.ok(err instanceof WholesaleFeedWebhookNotificationError);
+        assert.strictEqual(err.code, 'wholesale_feed_webhook_cache_scope_mismatch');
+        assert.strictEqual(err.field, 'cache_scope');
+        return true;
+      }
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add parse/normalize helpers for canonical wholesale-feed webhook notifications with typed invariant errors
- export the helper from root, webhooks, and wholesale-feed-sync entrypoints
- add signal discovery helpers that keep signal_agent_segment_id separate from signal_id provenance and build activate_signal requests

Closes #2005

## Expert review
- protocol review: addressed canonical notification_id === event.event_id and made the changeset minor
- code review: tightened per-event webhook payload validation and fixed signal destination examples
- testing review: added barrel export, raw JSON bytes, signal/no-signal branches, and helper option precedence coverage

## Validation
- npm run build:lib
- npm run typecheck
- git diff --check
- npx prettier --check src/lib/index.ts src/lib/webhooks/index.ts src/lib/wholesale-feed-sync/index.ts src/lib/wholesale-feed-sync/sync.ts src/lib/wholesale-feed-sync/webhook-notification.ts src/lib/utils/signal-discovery-helpers.ts test/lib/wholesale-feed-sync.test.js test/lib/wholesale-feed-webhook-notification.test.js test/lib/signal-discovery-helpers.test.js .changeset/wholesale-feed-webhook-normalizer.md
- node --test-timeout=60000 --test-force-exit --test test/lib/signal-discovery-helpers.test.js test/lib/signal-id-builders.test.js test/lib/wholesale-feed-webhook-notification.test.js test/lib/wholesale-feed-sync.test.js

Note: a full local npm test run still hits existing file-level 60s timeouts/cancellations in CLI-heavy tests (cli-auth-scheme, cli-webhook-receiver-flag, conformance-cli); no assertion failures in this change path.