### PR TITLE
fix: tighten beta11 server payload migration

### DIFF
--- a/.changeset/tighten-beta11-cache-scope.md
+++ b/.changeset/tighten-beta11-cache-scope.md
@@ -1,0 +1,17 @@
+---
+'@adcp/sdk': patch
+---
+
+Tighten beta.11 server payload migration around `get_products.cache_scope`.
+
+Server-facing `get_products` payload aliases and `productsResponse()` now require
+`cache_scope` whenever `products` are returned or a wholesale-feed response is
+`unchanged`. Unchanged responses still omit `products`, but must echo
+`cache_scope`. Strict response validation catches plain JavaScript adopters that
+bypass TypeScript.
+
+Framework response defaulting now infers `cache_scope: 'public'` only when there
+is no inline account and no auth-derived/resolved account. Account-scoped
+requests fail closed unless the adapter explicitly chooses `public` or
+`account`, and sandbox/test-controller seeded merges no longer hide missing
+account-scoped scope.

--- a/MIGRATION-v8.md
+++ b/MIGRATION-v8.md
@@ -138,13 +138,15 @@ product_card: {
 
 ### `get_products.products` is now optional
 
-3.1.0-beta.3's `unchanged: true` wholesale-feed branch legitimately omits `products`. The Zod schema is `ZodOptional<ZodArray<...>>`. If you had code asserting `products.length`, narrow first.
+3.1.0-beta.3's `unchanged: true` wholesale-feed branch legitimately omits `products`, but it must still echo `cache_scope`. The Zod schema is `ZodOptional<ZodArray<...>>`. If you had code asserting `products.length`, narrow first.
 
 The SDK's `filterInvalidProducts: true` unwrapper option now correctly handles the optional shape (silent dead-feature regression fixed in 8.1.0-beta.3).
 
-### `cache_scope` is required on populated `get_products` responses
+### `cache_scope` is required on product and unchanged `get_products` responses
 
-The populated-products branch of `get_products` now requires `cache_scope: 'public' | 'account'`. Server handlers must set it.
+The populated-products branch and the `unchanged: true` wholesale-feed branch of `get_products` now require `cache_scope: 'public' | 'account'`. Server handlers must set it.
+
+Use `public` for responses with no inline account and no auth-derived/resolved account context, or for account requests that still use the universal rate card. Use `account` when account-specific rate cards or pricing overlays are present. The SDK may infer `public` only when no account context exists; account-scoped product responses must be explicit.
 
 ### Union responses are now intersection-wrapped
 
@@ -220,7 +222,7 @@ Quick scan for the adopter who knows which tools their code touches:
 If you want belt-and-braces against accidentally consuming a beta on `latest`, pin exactly:
 
 ```bash
-npm install @adcp/sdk@8.1.0-beta.8
+npm install @adcp/sdk@8.1.0-beta.11
 ```
 
 The beta line is API-stable across patch bumps within a single beta (same npm dist-tag); the field renames and reshapes above all landed by 8.1.0-beta.3.

--- a/docs/TYPE-SUMMARY.md
+++ b/docs/TYPE-SUMMARY.md
@@ -1,7 +1,7 @@
 # AdCP Type Summary
 
-> Generated at: 2026-05-22
-> @adcp/sdk v8.1.0-beta.0
+> Generated at: 2026-05-26
+> @adcp/sdk v8.1.0-beta.11
 
 Curated reference of the types that matter for using the AdCP client. For full generated types see `src/lib/types/tools.generated.ts` and `src/lib/types/core.generated.ts`.
 
@@ -265,6 +265,10 @@ _Response (success branch):_
 }
 ```
 
+_Watch out:_
+- `cache_scope` is required whenever the response includes `products` or `unchanged: true`. Use `public` for the universal rate card and `account` for account-specific rate cards or pricing overlays.
+- SDK server handlers may omit `cache_scope` only for no-account product feeds; the framework can safely infer `public` only when there is no inline account and no auth-derived/resolved account.
+
 **`list_creative_formats`** — Request parameters for discovering format IDs and creative agents supported by this sales agent.
 
 _Request:_
@@ -302,6 +306,11 @@ _Response (success branch):_
   context: Context
 }
 ```
+
+_Watch out:_
+- Each `renders[]` entry satisfies a `oneOf` — exactly one of `dimensions` (object) OR `parameters_from_format_id: true`. A render with only `{ role }` (or `{ role, duration_seconds }`) fails validation.
+- Use the typed factories from `@adcp/sdk`: `displayRender({ role, dimensions })` for display/video; `parameterizedRender({ role })` for audio and template formats (auto-injects `parameters_from_format_id: true`).
+- Audio formats (`type: "audio"`) have no width/height — declare `renders: [parameterizedRender({ role: "primary" })]` and encode duration/codec in `format_id.parameters` (declared via `accepts_parameters`).
 
 **`create_media_buy`** — Request parameters for creating a media buy.
 
@@ -351,6 +360,9 @@ _Response (success branch):_
 }
 ```
 
+_Watch out:_
+- Server handlers should return business lifecycle state as `media_buy_status`. The framework owns the task envelope `status`; do not return top-level `status` as the media-buy state.
+
 **`update_media_buy`** — Request parameters for updating campaign and package settings.
 
 _Request:_
@@ -392,6 +404,9 @@ _Response (success branch):_
   context: Context
 }
 ```
+
+_Watch out:_
+- Server handlers should return business lifecycle state as `media_buy_status`. The framework owns the task envelope `status`; do not return top-level `status` as the media-buy state.
 
 **`get_media_buys`** — Request parameters for retrieving media buy status, creative approvals, and delivery snapshots.
 
@@ -627,6 +642,11 @@ _Response (success branch):_
 }
 ```
 
+_Watch out:_
+- Response is ALWAYS `{ creative_manifest }` (single) or `{ creative_manifests }` (multi). Platform-native fields at the top level (`tag_url`, `creative_id`, `media_type`) are invalid.
+- Use `buildCreativeResponse({ creative_manifest })` / `buildCreativeMultiResponse({ creative_manifests })` from `@adcp/sdk/server` to enforce the shape at compile time.
+- Each asset under `creative_manifest.assets` needs an `asset_type` discriminator — use the factories: `imageAsset`, `videoAsset`, `audioAsset`, `htmlAsset`, `urlAsset`, `textAsset` (or `Asset.image(...)`).
+
 **`preview_creative`** — Request parameters for generating creative previews.
 
 _Request:_
@@ -657,6 +677,9 @@ _Response (success branch):_
   context: Context
 }
 ```
+
+_Watch out:_
+- Each `renders[]` entry is a oneOf on `output_format` — use `urlRender({...})`, `htmlRender({...})`, or `bothRender({...})` to inject the discriminator and require the matching `preview_url`/`preview_html` field.
 
 **`list_creative_formats`** — Request parameters for discovering creative formats from this creative agent.
 
@@ -694,6 +717,11 @@ _Response (success branch):_
   context: Context
 }
 ```
+
+_Watch out:_
+- Each `renders[]` entry satisfies a `oneOf` — exactly one of `dimensions` (object) OR `parameters_from_format_id: true`. A render with only `{ role }` (or `{ role, duration_seconds }`) fails validation.
+- Use the typed factories from `@adcp/sdk`: `displayRender({ role, dimensions })` for display/video; `parameterizedRender({ role })` for audio and template formats (auto-injects `parameters_from_format_id: true`).
+- Audio formats (`type: "audio"`) have no width/height — declare `renders: [parameterizedRender({ role: "primary" })]` and encode duration/codec in `format_id.parameters` (declared via `accepts_parameters`).
 
 **`get_creative_delivery`** — Request parameters for retrieving creative delivery data with variant-level breakdowns.
 

--- a/docs/guides/BUILD-AN-AGENT.md
+++ b/docs/guides/BUILD-AN-AGENT.md
@@ -9,7 +9,7 @@ We'll build a **signals agent** that serves audience segments via the `get_signa
 ## Prerequisites
 
 - Node.js 18+
-- `@adcp/sdk` installed (`npm install @adcp/sdk`)
+- `@adcp/sdk` installed from the beta line while validating AdCP 3.1 (`npm install @adcp/sdk@beta`)
 - `@modelcontextprotocol/sdk` (installed as a dependency of `@adcp/sdk`)
 
 ## The server entry point
@@ -86,8 +86,8 @@ Start it and test immediately:
 
 ```bash
 npx tsx agent.ts
-npx @adcp/sdk@latest http://localhost:3001/mcp                    # discover tools
-npx @adcp/sdk@latest http://localhost:3001/mcp get_signals '{}'   # call get_signals
+npx @adcp/sdk@beta http://localhost:3001/mcp                    # discover tools
+npx @adcp/sdk@beta http://localhost:3001/mcp get_signals '{}'   # call get_signals
 ```
 
 `definePlatform` / `defineSignalsPlatform` (and the sibling
@@ -133,14 +133,20 @@ const platform = definePlatform({
     list: async (filter, ctx) => db.listAccounts(filter, { agentUrl: ctx?.agent?.agent_url }),
   },
   sales: defineSalesCorePlatform({
-    getProducts: async (req, ctx) => ({ products: catalog.search(req) }), // req typed ✓
+    getProducts: async (req, ctx) => {
+      const result = catalog.search(req);
+      return {
+        products: result.products,
+        cache_scope: result.usesAccountSpecificPricing ? 'account' : 'public',
+      };
+    }, // req typed ✓
     createMediaBuy: async (req, ctx) => ({
       media_buy_id: `mb_${Date.now()}`,
-      status: 'pending_creatives',
+      media_buy_status: 'pending_creatives',
       confirmed_at: new Date().toISOString(),
       packages: [],
     }),
-    updateMediaBuy: async (id, patch, ctx) => ({ media_buy_id: id, status: 'active' }),
+    updateMediaBuy: async (id, patch, ctx) => ({ media_buy_id: id, media_buy_status: 'active' }),
     getMediaBuyDelivery: async (req, ctx) => ({ media_buys: [] }),
     getMediaBuys: async (req, ctx) => ({ media_buys: [] }),
   }),
@@ -299,9 +305,13 @@ Every handler receives `ctx.store` — a key-value store for persisting domain o
 ```typescript
 mediaBuy: {
   createMediaBuy: async (params, ctx) => {
-    const mediaBuy = { media_buy_id: `mb_${Date.now()}`, status: 'pending', packages: [] };
+    const mediaBuy = { media_buy_id: `mb_${Date.now()}`, status: 'pending_creatives', packages: [] };
     await ctx.store.put('media_buys', mediaBuy.media_buy_id, mediaBuy);
-    return mediaBuy;
+    return {
+      media_buy_id: mediaBuy.media_buy_id,
+      media_buy_status: mediaBuy.status,
+      packages: mediaBuy.packages,
+    };
   },
   getMediaBuys: async (params, ctx) => {
     if (params.media_buy_ids?.length) {
@@ -346,7 +356,7 @@ const platform = definePlatform({
     getProducts: async (req, ctx) => {
       // ctx.account is the resolved account
       const products = await catalog.search(req, ctx.account.id);
-      return { products };
+      return { products, cache_scope: 'account' };
     },
     /* ... */
   }),
@@ -575,12 +585,18 @@ return wrapEnvelope(
 
 ### Response Builders
 
-With `createAdcpServerFromPlatform`, response builders are applied automatically — return raw data and the framework wraps it. If you need manual control (e.g., with `createTaskCapableServer`), builders are available:
+With `createAdcpServerFromPlatform`, return handler payloads, not full wire envelopes. The framework owns protocol fields such as task `status`, `task_id`, `adcp_version`, context echoing, and response validation. Domain lifecycle fields remain part of your payload: for media buys use `media_buy_status`, while nested resources such as accounts, creatives, audiences, and `media_buys[]` keep their resource `status` fields.
+
+For `getProducts`, any response that includes `products` or `unchanged: true` must also include `cache_scope`. Use `public` for a universal rate card and `account` when the response includes account-specific rate cards or pricing overlays. The framework can safely infer `public` only when there is no inline account and no auth-derived/resolved account; account-scoped product responses should set the field explicitly.
+
+If you need manual control (e.g., with `createTaskCapableServer`), builders are available:
 
 ```typescript
 import { productsResponse, mediaBuyResponse, deliveryResponse, taskToolResponse } from '@adcp/sdk';
 // For error envelopes, throw a typed error class — `AuthRequiredError`,
 // `PermissionDeniedError`, `RateLimitedError`, etc. — from `@adcp/sdk/server`.
+
+const response = productsResponse({ products, cache_scope: 'public' });
 ```
 
 ### Task Statuses (Server-Side Contract)
@@ -708,7 +724,7 @@ const httpServer = createServer(async (req, res) => {
 ### Tool Discovery
 
 ```bash
-npx @adcp/sdk@latest http://localhost:3001/mcp
+npx @adcp/sdk@beta http://localhost:3001/mcp
 ```
 
 This lists all tools your agent exposes, their descriptions, and parameters. If `get_signals` appears with the correct schema, your agent is wired up correctly.
@@ -717,16 +733,16 @@ This lists all tools your agent exposes, their descriptions, and parameters. If 
 
 ```bash
 # All segments
-npx @adcp/sdk@latest http://localhost:3001/mcp get_signals '{"signal_spec":"audience segments"}'
+npx @adcp/sdk@beta http://localhost:3001/mcp get_signals '{"signal_spec":"audience segments"}'
 
 # Filtered by text
-npx @adcp/sdk@latest http://localhost:3001/mcp get_signals '{"signal_spec":"shoppers"}'
+npx @adcp/sdk@beta http://localhost:3001/mcp get_signals '{"signal_spec":"shoppers"}'
 
 # Filtered by catalog type
-npx @adcp/sdk@latest http://localhost:3001/mcp get_signals '{"filters":{"catalog_types":["marketplace"]}}'
+npx @adcp/sdk@beta http://localhost:3001/mcp get_signals '{"filters":{"catalog_types":["marketplace"]}}'
 
 # JSON output for scripting
-npx @adcp/sdk@latest http://localhost:3001/mcp get_signals '{}' --json
+npx @adcp/sdk@beta http://localhost:3001/mcp get_signals '{}' --json
 ```
 
 ```bash
@@ -734,7 +750,7 @@ npx @adcp/sdk@latest http://localhost:3001/mcp get_signals '{}' --json
 # Schema traps: idempotency_key must be 16-255 chars (UUID v4 recommended);
 # package-level budget is a plain number (not {amount,currency}); brand uses {domain} (not {brand_id});
 # packages require product_id, budget, and pricing_option_id
-npx @adcp/sdk@latest http://localhost:3001/mcp create_media_buy '{
+npx @adcp/sdk@beta http://localhost:3001/mcp create_media_buy '{
   "idempotency_key": "550e8400-e29b-41d4-a716-446655440000",
   "account": { "account_id": "acct_123" },
   "brand": { "domain": "acme.example" },
@@ -749,7 +765,7 @@ npx @adcp/sdk@latest http://localhost:3001/mcp create_media_buy '{
 ### Compliance Check
 
 ```bash
-npx @adcp/sdk@latest storyboard run http://localhost:3001/mcp
+npx @adcp/sdk@beta storyboard run http://localhost:3001/mcp
 ```
 
 This runs a standard validation suite against your agent to check AdCP compliance. For the full validation picture — storyboard runner, property-based fuzzing (`adcp fuzz`), multi-instance testing, webhook conformance, request-signing, schema-driven validation, and the skill→agent→grader dogfood harness — see [**VALIDATE-YOUR-AGENT.md**](./VALIDATE-YOUR-AGENT.md).

--- a/docs/guides/MULTI-INSTANCE-TESTING.md
+++ b/docs/guides/MULTI-INSTANCE-TESTING.md
@@ -20,7 +20,7 @@ A single-URL storyboard never sees this. Multi-instance mode round-robins steps 
 ## Usage
 
 ```
-npx @adcp/sdk@latest storyboard run \
+npx @adcp/sdk@beta storyboard run \
   --url https://a.your-agent.example/mcp/ \
   --url https://b.your-agent.example/mcp/ \
   account_and_audience \
@@ -67,7 +67,7 @@ For local dev without Docker, the simplest setup is two `node` processes listeni
 Quick way to verify the multi-instance code path end-to-end against the AdCP public test agent:
 
 ```bash
-npx @adcp/sdk@latest storyboard run \
+npx @adcp/sdk@beta storyboard run \
   --url "https://test-agent.adcontextprotocol.org/mcp/?replica=a" \
   --url "https://test-agent.adcontextprotocol.org/mcp/?replica=b" \
   property_lists \

--- a/docs/guides/VALIDATE-LOCALLY.md
+++ b/docs/guides/VALIDATE-LOCALLY.md
@@ -56,10 +56,10 @@ Prefer a one-shot from the shell? Point the CLI at a module file:
 
 ```bash
 # agent.mjs exports `createAgent`
-npx @adcp/sdk@latest storyboard run --local-agent ./agent.mjs
+npx @adcp/sdk@beta storyboard run --local-agent ./agent.mjs
 
 # Single storyboard, CI-friendly JUnit output
-npx @adcp/sdk@latest storyboard run --local-agent ./agent.mjs capability_discovery \
+npx @adcp/sdk@beta storyboard run --local-agent ./agent.mjs capability_discovery \
   --format junit > junit.xml
 ```
 
@@ -169,7 +169,7 @@ for (const sb of result.results) {
 Or emit JSON for richer tooling:
 
 ```bash
-npx @adcp/sdk@latest storyboard run --local-agent ./agent.mjs --json | jq '.results[] | select(.overall_passed | not)'
+npx @adcp/sdk@beta storyboard run --local-agent ./agent.mjs --json | jq '.results[] | select(.overall_passed | not)'
 ```
 
 ## Related

--- a/docs/guides/VALIDATE-YOUR-AGENT.md
+++ b/docs/guides/VALIDATE-YOUR-AGENT.md
@@ -6,22 +6,22 @@ Your checklist to get from "agent boots" to "agent ships." Every tool below is a
 
 ```bash
 # 1. Does it answer at all? (60s)
-npx @adcp/sdk@latest http://localhost:3001/mcp get_adcp_capabilities '{}'              # MCP
-npx @adcp/sdk@latest --protocol a2a http://localhost:3001 get_adcp_capabilities '{}'   # A2A (preview)
+npx @adcp/sdk@beta http://localhost:3001/mcp get_adcp_capabilities '{}'              # MCP
+npx @adcp/sdk@beta --protocol a2a http://localhost:3001 get_adcp_capabilities '{}'   # A2A (preview)
 
 # 2. Does it walk the golden path? (2–5 min)
-npx @adcp/sdk@latest storyboard run http://localhost:3001/mcp --auth $TOKEN            # MCP
-npx @adcp/sdk@latest storyboard run --protocol a2a http://localhost:3001 --auth $TOKEN # A2A (preview)
+npx @adcp/sdk@beta storyboard run http://localhost:3001/mcp --auth $TOKEN            # MCP
+npx @adcp/sdk@beta storyboard run --protocol a2a http://localhost:3001 --auth $TOKEN # A2A (preview)
 
 # 3. Does it crash on weird inputs? (1–3 min)
-npx @adcp/sdk@latest fuzz http://localhost:3001/mcp --auth-token $TOKEN
+npx @adcp/sdk@beta fuzz http://localhost:3001/mcp --auth-token $TOKEN
 
 # 4. Does webhook/async conformance pass? (2–5 min)
-npx @adcp/sdk@latest storyboard run http://localhost:3001/mcp \
+npx @adcp/sdk@beta storyboard run http://localhost:3001/mcp \
   --webhook-receiver --auth $TOKEN
 
 # 5. Does it survive horizontal scaling? (same as 2, two URLs)
-npx @adcp/sdk@latest storyboard run \
+npx @adcp/sdk@beta storyboard run \
   --url https://a.agent.example/mcp --url https://b.agent.example/mcp \
   sales-guaranteed --auth $TOKEN
 ```
@@ -32,7 +32,7 @@ If all five pass and your skill's specialism-specific checks below pass, you're 
 
 **Working on the agent locally?** Before you reach for the remote-agent commands above, see [`VALIDATE-LOCALLY.md`](./VALIDATE-LOCALLY.md) — the same storyboards, zero tunnel setup, ten lines of code. Point `--local-agent <module>` at your handlers or call `runAgainstLocalAgent` directly from a test file.
 
-**Why `@latest` in every `npx` command?** Without the pin, `npx` reuses whatever version happens to be cached in `~/.npm/_npx/` — and it never re-checks. If you ran `npx @adcp/sdk` six months ago, you're still on that version today. `npx @adcp/sdk@latest` forces npx to resolve the `latest` dist-tag against the registry on every run. If an old cache is causing confusing behavior, `rm -rf ~/.npm/_npx` clears all cached CLI versions.
+**Why `@beta` in every `npx` command?** The 8.1 line is still on the npm `beta` dist-tag while AdCP 3.1 is prerelease; `@latest` resolves to the last GA SDK and will not exercise the 3.1 validation surface. The explicit tag also avoids stale `npx` cache reuse from `~/.npm/_npx/`. If an old cache is causing confusing behavior, `rm -rf ~/.npm/_npx` clears all cached CLI versions.
 
 ---
 
@@ -60,22 +60,22 @@ The main compliance entry point. Runs every storyboard that applies to your agen
 
 ```bash
 # Full capability-driven run — resolves bundles from your capabilities
-npx @adcp/sdk@latest storyboard run http://localhost:3001/mcp --auth $TOKEN
+npx @adcp/sdk@beta storyboard run http://localhost:3001/mcp --auth $TOKEN
 
 # Single bundle or storyboard by id
-npx @adcp/sdk@latest storyboard run http://localhost:3001/mcp sales-guaranteed --auth $TOKEN
+npx @adcp/sdk@beta storyboard run http://localhost:3001/mcp sales-guaranteed --auth $TOKEN
 
 # Specific tracks only (faster feedback when iterating)
-npx @adcp/sdk@latest storyboard run http://localhost:3001/mcp --tracks core,products --auth $TOKEN
+npx @adcp/sdk@beta storyboard run http://localhost:3001/mcp --tracks core,products --auth $TOKEN
 
 # Pin a specific compliance cache/spec line
-npx @adcp/sdk@latest storyboard run http://localhost:3001/mcp --compliance-version 3.0.12 --auth $TOKEN
+npx @adcp/sdk@beta storyboard run http://localhost:3001/mcp --compliance-version 3.0.12 --auth $TOKEN
 
 # Ad-hoc YAML (new storyboards under development)
-npx @adcp/sdk@latest storyboard run http://localhost:3001/mcp --file ./my-wip.yaml --auth $TOKEN
+npx @adcp/sdk@beta storyboard run http://localhost:3001/mcp --file ./my-wip.yaml --auth $TOKEN
 
 # JSON report for CI / tooling
-npx @adcp/sdk@latest storyboard run http://localhost:3001/mcp --json > report.json
+npx @adcp/sdk@beta storyboard run http://localhost:3001/mcp --json > report.json
 ```
 
 **Flags you'll actually use:**
@@ -96,12 +96,12 @@ npx @adcp/sdk@latest storyboard run http://localhost:3001/mcp --json > report.js
 
 ```bash
 # (a) pre-save tokens
-npx @adcp/sdk@latest --save-auth my-agent https://agent.example.com/mcp --oauth
-npx @adcp/sdk@latest storyboard run my-agent
+npx @adcp/sdk@beta --save-auth my-agent https://agent.example.com/mcp --oauth
+npx @adcp/sdk@beta storyboard run my-agent
 
 # (b) inline on first run
-npx @adcp/sdk@latest --save-auth my-agent https://agent.example.com/mcp --no-auth
-npx @adcp/sdk@latest storyboard run my-agent --oauth
+npx @adcp/sdk@beta --save-auth my-agent https://agent.example.com/mcp --no-auth
+npx @adcp/sdk@beta storyboard run my-agent --oauth
 ```
 
 Either way, subsequent runs reuse the cached tokens (auto-refresh on expiry via the stored `refresh_token`). Raw URLs don't support `--oauth` — save an alias first.
@@ -116,27 +116,27 @@ Generates schema-valid requests, calls your agent, checks every response under t
 
 ```bash
 # Tier 1 + Tier 2 stateless + referential (safe, no mutation)
-npx @adcp/sdk@latest fuzz http://localhost:3001/mcp --auth-token $TOKEN
+npx @adcp/sdk@beta fuzz http://localhost:3001/mcp --auth-token $TOKEN
 
 # Reproducible (rerun with same seed to repro a failure)
-npx @adcp/sdk@latest fuzz http://localhost:3001/mcp --seed 42 --auth-token $TOKEN
+npx @adcp/sdk@beta fuzz http://localhost:3001/mcp --seed 42 --auth-token $TOKEN
 
 # Pre-seeded ID pools for referential tools (Tier 2)
-npx @adcp/sdk@latest fuzz http://localhost:3001/mcp \
+npx @adcp/sdk@beta fuzz http://localhost:3001/mcp \
   --fixture creative_ids=cre_a,cre_b \
   --fixture media_buy_ids=mb_1
 
 # Auto-seed + Tier 3 update-tool fuzzing (mutates agent state — SANDBOX ONLY)
-npx @adcp/sdk@latest fuzz http://localhost:3001/mcp --auto-seed --auth-token $TOKEN
+npx @adcp/sdk@beta fuzz http://localhost:3001/mcp --auto-seed --auth-token $TOKEN
 
 # Uniform-error-response invariant in full cross-tenant mode
-npx @adcp/sdk@latest fuzz http://localhost:3001/mcp \
+npx @adcp/sdk@beta fuzz http://localhost:3001/mcp \
   --auto-seed \
   --auth-token            $TENANT_A_TOKEN \
   --auth-token-cross-tenant $TENANT_B_TOKEN
 
 # Inspect the tool list + tier classification
-npx @adcp/sdk@latest fuzz --list-tools
+npx @adcp/sdk@beta fuzz --list-tools
 ```
 
 See [`docs/guides/CONFORMANCE.md`](./CONFORMANCE.md) for the fixture map, tier-by-tier tool list, and failure interpretation.
@@ -183,16 +183,16 @@ If you claim the `signed-requests` specialism, run the RFC 9421 grader. The grad
 
 ```bash
 # All 38 vectors
-npx @adcp/sdk@latest grade request-signing https://sandbox.agent.example/mcp
+npx @adcp/sdk@beta grade request-signing https://sandbox.agent.example/mcp
 
 # Skip rate-abuse (vector 020 fires cap+1 requests; skip in dev loops)
-npx @adcp/sdk@latest grade request-signing https://sandbox.agent.example/mcp --skip-rate-abuse
+npx @adcp/sdk@beta grade request-signing https://sandbox.agent.example/mcp --skip-rate-abuse
 
 # MCP transport (wraps vectors in JSON-RPC envelopes)
-npx @adcp/sdk@latest grade request-signing https://sandbox.agent.example/mcp --transport mcp
+npx @adcp/sdk@beta grade request-signing https://sandbox.agent.example/mcp --transport mcp
 
 # Isolate a single vector
-npx @adcp/sdk@latest grade request-signing https://sandbox.agent.example/mcp --only 016-replayed-nonce
+npx @adcp/sdk@beta grade request-signing https://sandbox.agent.example/mcp --only 016-replayed-nonce
 ```
 
 ### Multi-instance testing
@@ -200,7 +200,7 @@ npx @adcp/sdk@latest grade request-signing https://sandbox.agent.example/mcp --o
 Exposes `(brand, account)`-scoped state that lives per-process instead of in a shared store — a class of bug that single-URL runs never catch. See [`docs/guides/MULTI-INSTANCE-TESTING.md`](./MULTI-INSTANCE-TESTING.md).
 
 ```bash
-npx @adcp/sdk@latest storyboard run \
+npx @adcp/sdk@beta storyboard run \
   --url https://a.agent.example/mcp \
   --url https://b.agent.example/mcp \
   sales-guaranteed --auth $TOKEN
@@ -336,7 +336,7 @@ Use `--invariants` to load modules that assert properties across storyboard step
 
 ```bash
 # Load ./my-invariants.js (relative path) or a bare specifier (npm package)
-npx @adcp/sdk@latest storyboard run http://localhost:3001/mcp \
+npx @adcp/sdk@beta storyboard run http://localhost:3001/mcp \
   --invariants ./assertions/idempotency.js,@my-org/adcp-invariants
 ```
 
@@ -463,18 +463,18 @@ Hints also land in machine-readable output:
 
 ```yaml
 - name: Storyboard (core + products)
-  run: npx @adcp/sdk@latest storyboard run $AGENT_URL --tracks core,products --auth $TOKEN
+  run: npx @adcp/sdk@beta storyboard run $AGENT_URL --tracks core,products --auth $TOKEN
 - name: Fuzz (fixed seed)
-  run: npx @adcp/sdk@latest fuzz $AGENT_URL --seed 42 --auth-token $TOKEN --format json
+  run: npx @adcp/sdk@beta fuzz $AGENT_URL --seed 42 --auth-token $TOKEN --format json
 ```
 
 ### Nightly (slow, broader coverage)
 
 ```yaml
 - name: Fuzz (random seed, auto-seed)
-  run: npx @adcp/sdk@latest fuzz $AGENT_URL --auto-seed --auth-token $TOKEN
+  run: npx @adcp/sdk@beta fuzz $AGENT_URL --auto-seed --auth-token $TOKEN
 - name: Full storyboard assessment
-  run: npx @adcp/sdk@latest storyboard run $AGENT_URL --auth $TOKEN --json > report.json
+  run: npx @adcp/sdk@beta storyboard run $AGENT_URL --auth $TOKEN --json > report.json
 ```
 
 Random seed on nightly broadens the surface; fixed seed on per-PR keeps reproducibility.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,7 +1,7 @@
 # Ad Context Protocol (AdCP)
 
-> Generated at: 2026-05-22
-> Library: @adcp/sdk v8.1.0-beta.0
+> Generated at: 2026-05-26
+> Library: @adcp/sdk v8.1.0-beta.11
 > AdCP major version: 3
 > Canonical URL: https://adcontextprotocol.github.io/adcp-client/llms.txt
 > Note: the `Library` stamp reflects the package.json version at doc-generation time. The narrative below describes the surface that lands on the next-published minor — including any 6.7 helpers documented here ahead of the release tag.
@@ -312,6 +312,10 @@ Request parameters for discovering available advertising products.
 **Response (success branch):**
 - Optional: `products: object[]`, `extensions: object`, `proposals: object[]`, `errors: object[]`, `property_list_applied: boolean`, `catalog_applied: boolean`, `refinement_applied: object[]`, `incomplete: object[]`, +8 more
 
+**Watch out:**
+- `cache_scope` is required whenever the response includes `products` or `unchanged: true`. Use `public` for the universal rate card and `account` for account-specific rate cards or pricing overlays.
+- SDK server handlers may omit `cache_scope` only for no-account product feeds; the framework can safely infer `public` only when there is no inline account and no auth-derived/resolved account.
+
 #### `list_creative_formats`
 
 Request parameters for discovering format IDs and creative agents supported by this sales agent.
@@ -340,6 +344,9 @@ Request parameters for creating a media buy.
 - Required: `media_buy_id: string`, `packages: object[]`
 - Optional: `account: Account`, `invoice_recipient: Business Entity`, `media_buy_status: Media Buy Status`, `status: Media Buy Status`, `confirmed_at: string`, `creative_deadline: string`, `revision: integer`, `currency: string`, +6 more
 
+**Watch out:**
+- Server handlers should return business lifecycle state as `media_buy_status`. The framework owns the task envelope `status`; do not return top-level `status` as the media-buy state.
+
 #### `update_media_buy`
 
 Request parameters for updating campaign and package settings.
@@ -351,6 +358,9 @@ Request parameters for updating campaign and package settings.
 **Response (success branch):**
 - Required: `media_buy_id: string`
 - Optional: `media_buy_status: Media Buy Status`, `status: Media Buy Status`, `revision: integer`, `currency: string`, `total_budget: number`, `implementation_date: string,null`, `invoice_recipient: Business Entity`, `affected_packages: object[]`, +4 more
+
+**Watch out:**
+- Server handlers should return business lifecycle state as `media_buy_status`. The framework owns the task envelope `status`; do not return top-level `status` as the media-buy state.
 
 #### `get_media_buys`
 
@@ -1416,4 +1426,4 @@ JSON schemas (source of truth): `schemas/cache/latest/index.json` (local only)
 - Documentation: https://adcontextprotocol.github.io/adcp-client/
 - npm: https://www.npmjs.com/package/@adcp/sdk
 - Spec: https://adcontextprotocol.org
-- CLI: `npx @adcp/sdk@latest`
+- CLI: `npx @adcp/sdk@beta` for the 8.1 / AdCP 3.1 beta line

--- a/docs/migration-8.0-to-8.1.md
+++ b/docs/migration-8.0-to-8.1.md
@@ -123,9 +123,43 @@ autocomplete/type-checking and fewer accidental unknown-field escapes.
 ### `get_products` response shape
 
 `products` can be absent in valid response arms such as unchanged/cache-hit
-responses. Any response that does carry `products` must now also carry
-`cache_scope`. Test fixtures that assumed `products` was always present or
-omitted `cache_scope` on populated product responses need to be updated.
+responses. Any response that carries `products` or `unchanged: true` must now
+also carry `cache_scope`. Test fixtures that assumed `products` was always
+present or omitted `cache_scope` on populated or unchanged responses need to be
+updated.
+
+Use this decision table for server payloads:
+
+| Request / pricing shape | `cache_scope` |
+|---|---|
+| No inline `account` and no auth-derived/resolved account context | `public` |
+| Request has `account`, but response uses the universal rate card | `public` |
+| Request has `account` and response includes account-specific pricing or overlays | `account` |
+
+The SDK framework may fill `public` only when there is no inline `account`
+and no auth-derived/resolved account context. It does **not** infer `public`
+for account-scoped requests because agents may omit overlay capability
+declarations for confidentiality; account-scoped product responses should set
+`cache_scope` explicitly.
+
+## Handler Payloads vs Wire Envelopes
+
+Framework server adopters should return SDK server payload aliases from
+handlers. Do not hand-stamp protocol envelope fields such as `status`,
+`task_id`, or `adcp_version` when using `createAdcpServerFromPlatform`; the
+framework owns those fields and validates after wrapping.
+
+Raw/manual server adopters using response builders still need to pass
+schema-valid payloads into the builder. For example:
+
+```ts
+productsResponse({ products, cache_scope: 'public' });
+mediaBuyResponse({ media_buy_id, media_buy_status: 'pending_creatives', packages: [] });
+```
+
+Buyer, CLI, and testing users should use `@adcp/sdk@beta` or an exact
+`8.1.0-beta.N` pin while validating AdCP 3.1 behavior. `@latest` remains on
+the last GA line until 8.1 exits prerelease.
 
 ## The Two `TaskStatus` Types
 

--- a/examples/decisioning-platform-broadcast-tv.ts
+++ b/examples/decisioning-platform-broadcast-tv.ts
@@ -34,11 +34,11 @@ import {
   type SalesCorePlatform,
   type SalesIngestionPlatform,
   type AccountStore,
+  type GetProductsPayload,
   type SyncCreativesRow,
 } from '@adcp/sdk/server';
 import type {
   GetProductsRequest,
-  GetProductsResponse,
   CreateMediaBuyRequest,
   CreateMediaBuySuccess,
   UpdateMediaBuyRequest,
@@ -117,7 +117,7 @@ export class BroadcastTvSeller implements DecisioningPlatform<BroadcastTvConfig,
      * the eventual products via `publishStatusChange` on
      * `resource_type: 'proposal'`.
      */
-    getProducts: async (req: GetProductsRequest): Promise<GetProductsResponse> => {
+    getProducts: async (req: GetProductsRequest): Promise<GetProductsPayload> => {
       const promotedOffering = (req as { promoted_offering?: string }).promoted_offering ?? '';
       if (/political|cannabis|gambling/i.test(promotedOffering)) {
         throw new AdcpError('POLICY_VIOLATION', {
@@ -129,7 +129,7 @@ export class BroadcastTvSeller implements DecisioningPlatform<BroadcastTvConfig,
       }
 
       return {
-        status: 'completed' as const,
+        cache_scope: 'account' as const,
         products: [
           {
             product_id: 'prod_primetime_30s',

--- a/examples/decisioning-platform-mock-seller.ts
+++ b/examples/decisioning-platform-mock-seller.ts
@@ -47,11 +47,11 @@ import {
   type SalesIngestionPlatform,
   type AccountStore,
   type AdcpStructuredError,
+  type GetProductsPayload,
   type SyncCreativesRow,
 } from '@adcp/sdk/server';
 import type {
   GetProductsRequest,
-  GetProductsResponse,
   CreateMediaBuyRequest,
   CreateMediaBuySuccess,
   UpdateMediaBuyRequest,
@@ -146,8 +146,8 @@ function rejectPreflight(errors: AdcpStructuredError[]): never {
   });
 }
 
-const SHARED_GET_PRODUCTS = async (_req: GetProductsRequest): Promise<GetProductsResponse> => ({
-  status: 'completed' as const,
+const SHARED_GET_PRODUCTS = async (_req: GetProductsRequest): Promise<GetProductsPayload> => ({
+  cache_scope: 'account' as const,
   products: [
     {
       product_id: 'prod_premium_video',

--- a/examples/decisioning-platform-programmatic.ts
+++ b/examples/decisioning-platform-programmatic.ts
@@ -28,11 +28,11 @@ import {
   type SalesCorePlatform,
   type SalesIngestionPlatform,
   type AccountStore,
+  type GetProductsPayload,
   type SyncCreativesRow,
 } from '@adcp/sdk/server';
 import type {
   GetProductsRequest,
-  GetProductsResponse,
   CreateMediaBuyRequest,
   CreateMediaBuySuccess,
   UpdateMediaBuyRequest,
@@ -97,8 +97,8 @@ export class ProgrammaticSeller implements DecisioningPlatform<ProgrammaticConfi
 
   sales: SalesCorePlatform<ProgrammaticMeta> & SalesIngestionPlatform<ProgrammaticMeta> = {
     /** Sync discovery: catalog read; no async ceremony. */
-    getProducts: async (_req: GetProductsRequest): Promise<GetProductsResponse> => ({
-      status: 'completed' as const,
+    getProducts: async (_req: GetProductsRequest): Promise<GetProductsPayload> => ({
+      cache_scope: 'account' as const,
       products: [
         {
           product_id: 'prod_run_of_network_display',

--- a/examples/hello_seller_adapter_proposal_mode.ts
+++ b/examples/hello_seller_adapter_proposal_mode.ts
@@ -47,6 +47,7 @@ import {
   type DecisioningPlatform,
   type FinalizeProposalRequest,
   type FinalizeProposalSuccess,
+  type GetProductsPayload,
   type ProposalManager,
   type SalesCorePlatform,
 } from '@adcp/sdk/server';
@@ -349,11 +350,11 @@ const proposalManager: ProposalManager<GAMLikeRecipe, NetworkMeta> = {
     availabilityReservations: true,
   },
 
-  async getProducts(req: GetProductsRequest, ctx): Promise<GetProductsResponse> {
+  async getProducts(req: GetProductsRequest, ctx): Promise<GetProductsPayload> {
     const networkCode = ctx.account.ctx_metadata.network_code;
     const publisherDomain = ctx.account.ctx_metadata.publisher_domain;
     const products = await upstream.listProducts(networkCode);
-    if (products.length === 0) return { status: 'completed', products: [], cache_scope: 'account' };
+    if (products.length === 0) return { products: [], cache_scope: 'account' };
 
     // brief + total_budget signals → curated proposal. Without a brief
     // the buyer is browsing the catalog; skip proposal generation.
@@ -362,7 +363,7 @@ const proposalManager: ProposalManager<GAMLikeRecipe, NetworkMeta> = {
     if (!brief) {
       // Catalog mode — return products with recipes, no proposals.
       const productsOut = products.map(p => projectProduct(p, publisherDomain, buildGAMLikeRecipe(p)));
-      return { status: 'completed', products: productsOut, cache_scope: 'account' };
+      return { products: productsOut, cache_scope: 'account' };
     }
 
     const draft = await upstream.createProposal(networkCode, {
@@ -374,14 +375,13 @@ const proposalManager: ProposalManager<GAMLikeRecipe, NetworkMeta> = {
       .filter(p => referencedIds.has(p.product_id))
       .map(p => projectProduct(p, publisherDomain, buildGAMLikeRecipe(p)));
     return {
-      status: 'completed',
       products: productsOut,
       proposals: [projectProposal(draft, totalBudget)],
       cache_scope: 'account',
     };
   },
 
-  async refineProducts(req: GetProductsRequest, ctx): Promise<GetProductsResponse> {
+  async refineProducts(req: GetProductsRequest, ctx): Promise<GetProductsPayload> {
     const networkCode = ctx.account.ctx_metadata.network_code;
     const publisherDomain = ctx.account.ctx_metadata.publisher_domain;
     const refine =
@@ -402,7 +402,6 @@ const proposalManager: ProposalManager<GAMLikeRecipe, NetworkMeta> = {
       .filter(p => referencedIds.has(p.product_id))
       .map(p => projectProduct(p, publisherDomain, buildGAMLikeRecipe(p)));
     return {
-      status: 'completed',
       products: productsOut,
       proposals: [projectProposal(refined)],
       cache_scope: 'account',
@@ -463,7 +462,7 @@ const sales: SalesCorePlatform<NetworkMeta> = {
   // getProducts is owned by proposalManager when wired; the framework
   // routes there. We keep this empty at the type level — the framework
   // never reaches it.
-  getProducts: async () => ({ status: 'completed', products: [], cache_scope: 'account' }),
+  getProducts: async () => ({ products: [], cache_scope: 'account' }),
 
   async createMediaBuy(req: CreateMediaBuyRequest, ctx): Promise<CreateMediaBuySuccess> {
     const networkCode = ctx.account.ctx_metadata.network_code;

--- a/scripts/generate-agent-docs.ts
+++ b/scripts/generate-agent-docs.ts
@@ -48,6 +48,16 @@ const SKIP_TOOLS = new Set(['comply-test-controller']);
 // still carries the operational lessons that bit real integrators.
 // Keep each entry under ~5 lines — llms.txt is a scan surface, not a tutorial.
 const TOOL_GOTCHAS: Record<string, string[]> = {
+  get_products: [
+    '`cache_scope` is required whenever the response includes `products` or `unchanged: true`. Use `public` for the universal rate card and `account` for account-specific rate cards or pricing overlays.',
+    'SDK server handlers may omit `cache_scope` only for no-account product feeds; the framework can safely infer `public` only when there is no inline account and no auth-derived/resolved account.',
+  ],
+  create_media_buy: [
+    'Server handlers should return business lifecycle state as `media_buy_status`. The framework owns the task envelope `status`; do not return top-level `status` as the media-buy state.',
+  ],
+  update_media_buy: [
+    'Server handlers should return business lifecycle state as `media_buy_status`. The framework owns the task envelope `status`; do not return top-level `status` as the media-buy state.',
+  ],
   build_creative: [
     'Response is ALWAYS `{ creative_manifest }` (single) or `{ creative_manifests }` (multi). Platform-native fields at the top level (`tag_url`, `creative_id`, `media_type`) are invalid.',
     'Use `buildCreativeResponse({ creative_manifest })` / `buildCreativeMultiResponse({ creative_manifests })` from `@adcp/sdk/server` to enforce the shape at compile time.',
@@ -1099,7 +1109,7 @@ function generateLlmsTxt(
   ln(`- Documentation: ${DOCS_BASE_URL}/`);
   ln(`- npm: https://www.npmjs.com/package/@adcp/sdk`);
   ln(`- Spec: https://adcontextprotocol.org`);
-  ln(`- CLI: \`npx @adcp/sdk@latest\``);
+  ln(`- CLI: \`npx @adcp/sdk@beta\` for the 8.1 / AdCP 3.1 beta line`);
   ln();
 
   return lines.join('\n');
@@ -1235,6 +1245,15 @@ function generateTypeSummary(index: SchemaIndex, tools: ToolInfo[]): string {
         ln('```');
       }
       ln();
+
+      const gotchas = TOOL_GOTCHAS[tool.name];
+      if (gotchas?.length) {
+        ln(`_Watch out:_`);
+        for (const note of gotchas) {
+          ln(`- ${note}`);
+        }
+        ln();
+      }
     }
   }
 

--- a/skills/build-decisioning-platform/SKILL.md
+++ b/skills/build-decisioning-platform/SKILL.md
@@ -104,6 +104,7 @@ class MyPlatform implements DecisioningPlatform {
     getProducts: async (req, ctx) => {
       const products = await this.platform.searchInventory(req.brief, req.promoted_offering);
       return {
+        cache_scope: 'account',
         products: products.map(p => ({
           product_id: p.id,
           name: p.name,

--- a/skills/build-decisioning-platform/advanced/REFERENCE.md
+++ b/skills/build-decisioning-platform/advanced/REFERENCE.md
@@ -57,6 +57,7 @@ const platform = {
   sales: {
     getProducts: async (req, ctx) => ({
       status: 'completed',
+      cache_scope: 'account',
       products: [
         {
           product_id: 'p_homepage',
@@ -139,7 +140,7 @@ getProducts: async (req, ctx) => {
   for (const p of products) {
     await ctx.ctxMetadata?.set('product', p.id, { gam: { ad_unit_ids: p.adUnitIds } });
   }
-  return { products: products.map(toAdcpProduct) };
+  return { products: products.map(toAdcpProduct), cache_scope: 'account' };
 },
 
 // Read on the way in (subsequent call referencing the same ID):

--- a/skills/call-adcp-agent/SKILL.md
+++ b/skills/call-adcp-agent/SKILL.md
@@ -136,7 +136,7 @@ Every validation failure produces:
 }
 ```
 
-Returns `{ products: [{ product_id, name, description, delivery_type, pricing_options, ... }] }`.
+Returns `{ cache_scope: "public" | "account", products: [{ product_id, name, description, delivery_type, pricing_options, ... }] }`.
 
 ### create_media_buy
 

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -117,7 +117,7 @@ function hasIdempotencyClearAll(store: IdempotencyStore): boolean {
   return typeof store.clearAll === 'function';
 }
 import { isMutatingTask, IDEMPOTENCY_KEY_PATTERN, MUTATING_TASKS } from '../utils/idempotency';
-import { validateRequest, validateResponse, formatIssues } from '../validation/schema-validator';
+import { validateRequest, validateResponse, formatIssues, type ValidationIssue } from '../validation/schema-validator';
 import { buildAdcpValidationErrorPayload } from '../validation/schema-errors';
 import type { IdempotencyStore } from './idempotency';
 import {
@@ -310,7 +310,7 @@ import type {
 
 import type { AdcpProtocol, MediaBuyFeatures, AccountCapabilities, CreativeCapabilities } from '../utils/capabilities';
 import type { MediaChannel } from '../types/tools.generated';
-import type { ServerPayload } from '../types/server-payload';
+import type { RequireCacheScopeWhenProducts, ServerPayload } from '../types/server-payload';
 import {
   MEDIA_BUY_TOOLS,
   SIGNALS_TOOLS,
@@ -506,7 +506,7 @@ export function requireSessionKey<TAccount = unknown>(ctx: HandlerContext<TAccou
 export interface AdcpToolMap {
   get_products: {
     params: z.input<typeof GetProductsRequestSchema>;
-    result: ServerPayload<GetProductsResponse>;
+    result: RequireCacheScopeWhenProducts<ServerPayload<GetProductsResponse>>;
     response: GetProductsResponse;
   };
   create_media_buy: {
@@ -2596,12 +2596,10 @@ function applyArmDiscriminators(sc: Record<string, unknown>, descriptor: ErrorAr
 }
 
 /**
- * Mirror a mutated `structuredContent` back into the L2 JSON text
- * fallback so MCP clients reading either transport layer see the same
- * shape. Same pattern as `sanitizeAdcpErrorEnvelope` and
- * `injectContextIntoResponse`. Silent no-op when the L2 text isn't a
- * JSON envelope (legitimate for non-JSON `content[0].text` summaries
- * from `wrapErrorArm`).
+ * Mirror a mutated `structuredContent` back into the L2 JSON text fallback
+ * so MCP clients reading either transport layer see the same shape. Silent
+ * no-op when the L2 text isn't a JSON envelope (legitimate for non-JSON
+ * `content[0].text` summaries from `wrapErrorArm`).
  */
 function syncContentJsonText(response: McpToolResponse, structuredContent: Record<string, unknown>): void {
   if (!Array.isArray(response.content)) return;
@@ -2617,11 +2615,50 @@ function syncContentJsonText(response: McpToolResponse, structuredContent: Recor
     // still extract the code via pattern match.
     return;
   }
-  if (parsed == null || typeof parsed !== 'object') return;
-  const obj = parsed as Record<string, unknown>;
-  if ('adcp_error' in structuredContent) obj.adcp_error = structuredContent.adcp_error;
-  if ('errors' in structuredContent) obj.errors = structuredContent.errors;
-  first.text = JSON.stringify(obj);
+  if (parsed == null || typeof parsed !== 'object' || Array.isArray(parsed)) return;
+  first.text = JSON.stringify(structuredContent);
+}
+
+function missingGetProductsCacheScopeIssue(): ValidationIssue {
+  return {
+    pointer: '/cache_scope',
+    message: "must have required property 'cache_scope'",
+    keyword: 'required',
+    schemaPath: '#/required',
+    hint: '`get_products` responses with `products` or `unchanged: true` must include `cache_scope`: use `public` for the universal rate card, `account` for account-specific overlays.',
+  };
+}
+
+function normalizeGetProductsCacheScope(
+  response: McpToolResponse,
+  params: unknown,
+  account: unknown,
+  authInfo: unknown,
+  exposeSchemaPath: boolean
+): McpToolResponse | undefined {
+  const sc = response.structuredContent as Record<string, unknown> | undefined;
+  if (!sc || typeof sc !== 'object') return undefined;
+  if (!Array.isArray(sc.products) && sc.unchanged !== true) return undefined;
+  if (sc.cache_scope !== undefined) return undefined;
+
+  const request =
+    params && typeof params === 'object' && !Array.isArray(params) ? (params as Record<string, unknown>) : {};
+  if (request.account != null || account != null || authInfo != null) {
+    return adcpError(
+      'VALIDATION_ERROR',
+      buildAdcpValidationErrorPayload('get_products', 'response', [missingGetProductsCacheScopeIssue()], {
+        exposeSchemaPath,
+      })
+    );
+  }
+
+  // Safe inference only: a product feed with neither an inline account nor an
+  // auth context cannot contain an account-specific overlay, so it is cacheable
+  // as the public layer. Any account or auth context makes omission ambiguous;
+  // strict response validation should surface that.
+  sc.cache_scope = 'public';
+  syncContentJsonText(response, sc);
+  return undefined;
 }
 
 // Echo the request context into a formatted MCP tool response so buyers can
@@ -4727,8 +4764,15 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
           }
 
           if (!isErrorResponse(formatted)) {
-            normalizeMediaBuyStatusCollision(formatted, toolName);
-            injectEnvelopeStatusIntoResponse(formatted);
+            if (toolName === 'get_products') {
+              formatted =
+                normalizeGetProductsCacheScope(formatted, params, ctx.account, ctx.authInfo, exposeErrorDetails) ??
+                formatted;
+            }
+            if (!isErrorResponse(formatted)) {
+              normalizeMediaBuyStatusCollision(formatted, toolName);
+              injectEnvelopeStatusIntoResponse(formatted);
+            }
           }
 
           // --- Response schema validation (opt-in) ---

--- a/src/lib/server/decisioning/decisioning.type-checks.ts
+++ b/src/lib/server/decisioning/decisioning.type-checks.ts
@@ -343,7 +343,7 @@ function _define_sales_platform_identity(p: SalesPlatform<_SocialMeta>): SalesPl
 // assignment site.
 function _sales_guaranteed_field_annotation_pattern() {
   const sales: SalesCorePlatform<_SocialMeta> & SalesIngestionPlatform<_SocialMeta> = {
-    getProducts: async () => ({ status: 'completed' as const, products: [] }),
+    getProducts: async () => ({ status: 'completed' as const, products: [], cache_scope: 'public' as const }),
     createMediaBuy: async () => ({ media_buy_id: 'x', packages: [] }),
     updateMediaBuy: async () => ({ media_buy_id: 'x' }),
     getMediaBuyDelivery: async () => ({
@@ -368,7 +368,7 @@ function _sales_guaranteed_field_annotation_pattern() {
 function _sales_guaranteed_spread_helpers_pattern() {
   const sales = {
     ...defineSalesCorePlatform<_SocialMeta>({
-      getProducts: async () => ({ status: 'completed' as const, products: [] }),
+      getProducts: async () => ({ status: 'completed' as const, products: [], cache_scope: 'public' as const }),
       createMediaBuy: async () => ({ media_buy_id: 'x', packages: [] }),
       updateMediaBuy: async () => ({ media_buy_id: 'x' }),
       getMediaBuyDelivery: async () => ({
@@ -606,7 +606,7 @@ function _operational_platform_payload_returns_do_not_require_protocol_status():
       reporting_period: { start: '2026-01-01', end: '2026-01-31' },
       media_buy_deliveries: [],
     }),
-    getProducts: async () => ({ products: [] }),
+    getProducts: async () => ({ products: [], cache_scope: 'public' as const }),
   };
 }
 
@@ -618,7 +618,7 @@ function _operational_platform_payload_returns_do_not_require_protocol_status():
 // inference-through-defaults don't silently regress the adopter migration.
 function _define_sales_platform_widens_post_1341() {
   const sales = defineSalesPlatform<_SocialMeta>({
-    getProducts: async () => ({ status: 'completed' as const, products: [] }),
+    getProducts: async () => ({ status: 'completed' as const, products: [], cache_scope: 'public' as const }),
     createMediaBuy: async () => ({ media_buy_id: 'x', packages: [] }),
     updateMediaBuy: async () => ({ media_buy_id: 'x' }),
     getMediaBuyDelivery: async () => ({

--- a/src/lib/server/decisioning/proposal/dispatch.ts
+++ b/src/lib/server/decisioning/proposal/dispatch.ts
@@ -36,8 +36,7 @@
  */
 
 import { AdcpError, isTaskHandoff, type TaskHandoff } from '../async-outcome';
-import type { GetProductsRequest, GetProductsResponse, Product, Proposal } from '../../../types/tools.generated';
-import type { ServerPayload } from '../../../types/server-payload';
+import type { GetProductsRequest, Product, Proposal } from '../../../types/tools.generated';
 import {
   detectFinalizeAction,
   enforceProposalExpiry,
@@ -48,7 +47,13 @@ import {
   validateOverlapSubsetOfWire,
 } from './lifecycle';
 import type { ProposalRecord, ProposalStore } from './store';
-import type { FinalizeProposalRequest, FinalizeProposalSuccess, ProposalManager, Recipe } from './types';
+import type {
+  FinalizeProposalRequest,
+  FinalizeProposalSuccess,
+  ProposalGetProductsPayload,
+  ProposalManager,
+  Recipe,
+} from './types';
 
 // ---------------------------------------------------------------------------
 // Capability detection
@@ -95,7 +100,7 @@ export type FinalizeInterceptResult<TRecipe extends Recipe = Recipe> =
   | {
       kind: 'intercepted';
       result: FinalizeProposalSuccess<TRecipe> | TaskHandoff<FinalizeProposalSuccess<TRecipe>>;
-      project: (success: FinalizeProposalSuccess<TRecipe>) => Promise<ServerPayload<GetProductsResponse>>;
+      project: (success: FinalizeProposalSuccess<TRecipe>) => Promise<ProposalGetProductsPayload>;
     }
   | { kind: 'pass' };
 
@@ -175,7 +180,7 @@ export async function maybeInterceptFinalize<TRecipe extends Recipe, TCtxMeta>(a
   const path: 'inline' | 'handoff' = isTaskHandoff(result) ? 'handoff' : 'inline';
   const finalizeProposalId = finalizeEntry.proposalId;
 
-  const project = async (success: FinalizeProposalSuccess<TRecipe>): Promise<ServerPayload<GetProductsResponse>> => {
+  const project = async (success: FinalizeProposalSuccess<TRecipe>): Promise<ProposalGetProductsPayload> => {
     if (!isFinalizeSuccess<TRecipe>(success)) {
       throw new AdcpError('INTERNAL_ERROR', {
         recovery: 'terminal',
@@ -214,7 +219,7 @@ function projectFinalizeResponse(args: {
   request: GetProductsRequest;
   committedProposal: Record<string, unknown>;
   finalizeProposalId: string;
-}): ServerPayload<GetProductsResponse> {
+}): ProposalGetProductsPayload {
   const refineEntries = (args.request as { refine?: ReadonlyArray<Record<string, unknown>> }).refine;
   const refinementApplied: Array<Record<string, unknown>> = [];
   if (refineEntries) {
@@ -252,7 +257,7 @@ function projectFinalizeResponse(args: {
     products: [],
     proposals: [args.committedProposal as unknown as Proposal],
     refinement_applied: refinementApplied,
-  } as unknown as ServerPayload<GetProductsResponse>;
+  } as unknown as ProposalGetProductsPayload;
 }
 
 // ---------------------------------------------------------------------------
@@ -270,7 +275,7 @@ function projectFinalizeResponse(args: {
  * @public
  */
 export async function maybePersistDraftAfterGetProducts<TRecipe extends Recipe>(args: {
-  response: ServerPayload<GetProductsResponse>;
+  response: ProposalGetProductsPayload;
   store: ProposalStore<TRecipe> | undefined;
   ctx: { account: { id: string } };
 }): Promise<void> {

--- a/src/lib/server/decisioning/proposal/mock-manager.ts
+++ b/src/lib/server/decisioning/proposal/mock-manager.ts
@@ -29,9 +29,14 @@
 
 import type { Account } from '../account';
 import type { RequestContext } from '../context';
-import type { GetProductsRequest, GetProductsResponse } from '../../../types/tools.generated';
-import type { ServerPayload } from '../../../types/server-payload';
-import type { ProposalCapabilities, ProposalManager, ProposalSalesSpecialism, Recipe } from './types';
+import type { GetProductsRequest } from '../../../types/tools.generated';
+import type {
+  ProposalCapabilities,
+  ProposalGetProductsPayload,
+  ProposalManager,
+  ProposalSalesSpecialism,
+  Recipe,
+} from './types';
 
 /**
  * Construction options for {@link MockProposalManager}.
@@ -126,14 +131,14 @@ export class MockProposalManager<TRecipe extends Recipe = Recipe, TCtxMeta = unk
   async getProducts(
     req: GetProductsRequest,
     _ctx: RequestContext<Account<TCtxMeta>>
-  ): Promise<ServerPayload<GetProductsResponse>> {
+  ): Promise<ProposalGetProductsPayload> {
     return this.forward('/get_products', req);
   }
 
   async refineProducts(
     req: GetProductsRequest,
     _ctx: RequestContext<Account<TCtxMeta>>
-  ): Promise<ServerPayload<GetProductsResponse>> {
+  ): Promise<ProposalGetProductsPayload> {
     if (!this.capabilities.refine) {
       // Adopter wired the manager without refine but the framework
       // dispatched here anyway — surface the inconsistency rather than
@@ -146,7 +151,7 @@ export class MockProposalManager<TRecipe extends Recipe = Recipe, TCtxMeta = unk
     return this.forward('/refine_products', req);
   }
 
-  private async forward(path: string, body: unknown): Promise<ServerPayload<GetProductsResponse>> {
+  private async forward(path: string, body: unknown): Promise<ProposalGetProductsPayload> {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), this.timeoutMs);
     try {
@@ -167,7 +172,7 @@ export class MockProposalManager<TRecipe extends Recipe = Recipe, TCtxMeta = unk
             (text ? `: ${text.slice(0, 500)}` : '')
         );
       }
-      const json = (await response.json()) as ServerPayload<GetProductsResponse>;
+      const json = (await response.json()) as ProposalGetProductsPayload;
       return json;
     } finally {
       clearTimeout(timer);

--- a/src/lib/server/decisioning/proposal/types.ts
+++ b/src/lib/server/decisioning/proposal/types.ts
@@ -33,8 +33,10 @@ import type { MaybePromise } from '../../create-adcp-server';
 import type { Account } from '../account';
 import type { RequestContext } from '../context';
 import type { GetProductsRequest, GetProductsResponse } from '../../../types/tools.generated';
-import type { ServerPayload } from '../../../types/server-payload';
+import type { RequireCacheScopeWhenProducts, ServerPayload } from '../../../types/server-payload';
 import type { TaskHandoff } from '../async-outcome';
+
+export type ProposalGetProductsPayload = RequireCacheScopeWhenProducts<ServerPayload<GetProductsResponse>>;
 
 // ---------------------------------------------------------------------------
 // Capabilities
@@ -409,7 +411,7 @@ export interface ProposalManager<TRecipe extends Recipe = Recipe, TCtxMeta = unk
    * buyer drives the finalize transition via subsequent refine calls
    * with `action: 'finalize'`.
    */
-  getProducts(req: GetProductsRequest, ctx: Ctx<TCtxMeta>): MaybePromise<ServerPayload<GetProductsResponse>>;
+  getProducts(req: GetProductsRequest, ctx: Ctx<TCtxMeta>): MaybePromise<ProposalGetProductsPayload>;
 
   /**
    * Refine-mode iteration on a previous `getProducts` response.
@@ -430,7 +432,7 @@ export interface ProposalManager<TRecipe extends Recipe = Recipe, TCtxMeta = unk
    * see those entries intercepted by the framework before this method
    * is called.
    */
-  refineProducts?(req: GetProductsRequest, ctx: Ctx<TCtxMeta>): MaybePromise<ServerPayload<GetProductsResponse>>;
+  refineProducts?(req: GetProductsRequest, ctx: Ctx<TCtxMeta>): MaybePromise<ProposalGetProductsPayload>;
 
   /**
    * Commit a draft proposal to firm pricing + inventory hold.

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -98,7 +98,7 @@ import type {
   GetAdCPCapabilitiesResponse,
   SyncGovernanceRequest,
 } from '../../../types/tools.generated';
-import type { ServerPayload } from '../../../types/server-payload';
+import type { RequireCacheScopeWhenProducts, ServerPayload } from '../../../types/server-payload';
 import { adcpError, type AdcpErrorResponse } from '../../errors';
 import { validatePlatform, PlatformConfigError } from './validate-platform';
 import { validateSpecialismRequiredTools, formatSpecialismIssue } from '../validate-specialisms';
@@ -3576,7 +3576,9 @@ function buildMediaBuyHandlers<P extends DecisioningPlatform<any, any>>(
             // Refine routing per Python's _select_proposal_method:
             // refine_products iff buying_mode='refine' AND
             // capabilities.refine AND the manager implements it.
-            let result: ServerPayload<import('../../../types/tools.generated').GetProductsResponse>;
+            let result: RequireCacheScopeWhenProducts<
+              ServerPayload<import('../../../types/tools.generated').GetProductsResponse>
+            >;
             if (proposalManager) {
               const buyingMode = (params as { buying_mode?: string }).buying_mode;
               const useRefine =

--- a/src/lib/server/decisioning/specialisms/sales.ts
+++ b/src/lib/server/decisioning/specialisms/sales.ts
@@ -63,7 +63,7 @@
 import type { Account, NoAccountCtx } from '../account';
 import type { RequestContext } from '../context';
 import type { TaskHandoff } from '../async-outcome';
-import type { ServerPayload } from '../../../types/server-payload';
+import type { RequireCacheScopeWhenProducts, ServerPayload } from '../../../types/server-payload';
 import type {
   GetProductsRequest,
   GetProductsResponse,
@@ -94,7 +94,7 @@ import type {
 type Creative = CreativeAsset;
 type Ctx<TCtxMeta> = RequestContext<Account<TCtxMeta>>;
 
-export type GetProductsPayload = ServerPayload<GetProductsResponse>;
+export type GetProductsPayload = RequireCacheScopeWhenProducts<ServerPayload<GetProductsResponse>>;
 export type CreateMediaBuyPayload = ServerPayload<CreateMediaBuySuccess>;
 export type UpdateMediaBuyPayload = ServerPayload<UpdateMediaBuySuccess>;
 export type GetMediaBuyDeliveryPayload = ServerPayload<GetMediaBuyDeliveryResponse>;

--- a/src/lib/server/operational-platform.ts
+++ b/src/lib/server/operational-platform.ts
@@ -53,7 +53,7 @@ import type {
   UpdateMediaBuyRequest,
   UpdateMediaBuyResponse,
 } from '../types/tools.generated';
-import type { ServerPayload } from '../types/server-payload';
+import type { RequireCacheScopeWhenProducts, ServerPayload } from '../types/server-payload';
 import type { AudienceStatus } from './decisioning/specialisms/audiences';
 
 /**
@@ -223,7 +223,7 @@ export interface OperationalPlatform<TCtx extends OperationalContext = Operation
     contextId?: string,
     brand?: Record<string, unknown>,
     sourceChain?: readonly string[]
-  ): Promise<ServerPayload<GetProductsResponse>>;
+  ): Promise<RequireCacheScopeWhenProducts<ServerPayload<GetProductsResponse>>>;
 }
 
 /**

--- a/src/lib/server/responses.ts
+++ b/src/lib/server/responses.ts
@@ -43,7 +43,7 @@ import type { GetAdCPCapabilitiesResponse } from '../types/tools.generated';
 import type { GetProductsResponse } from '../types/core.generated';
 import type { CreateMediaBuySuccess } from '../types/core.generated';
 import type { GetMediaBuyDeliveryResponse } from '../types/tools.generated';
-import type { ServerPayload } from '../types/server-payload';
+import type { RequireCacheScopeWhenProducts, ServerPayload } from '../types/server-payload';
 import { validActionsForStatus } from './media-buy-helpers';
 import type { CancelMediaBuyInput } from './media-buy-helpers';
 import type {
@@ -249,10 +249,15 @@ export function capabilitiesResponse(
  * Build a get_products response.
  */
 /** @deprecated v6: `createAdcpServerFromPlatform` constructs wire responses from typed platform returns. Direct use is for v5 raw-handler adopters mid-migration only. */
-export function productsResponse(data: ServerPayload<GetProductsResponse>, summary?: string): McpToolResponse {
+export function productsResponse(
+  data: RequireCacheScopeWhenProducts<ServerPayload<GetProductsResponse>>,
+  summary?: string
+): McpToolResponse {
   const structured = completedStructuredContent(data);
+  const defaultSummary =
+    data.unchanged === true ? 'Product feed unchanged' : `Found ${(data.products ?? []).length} products`;
   return {
-    content: [{ type: 'text', text: summary ?? `Found ${(data.products ?? []).length} products` }],
+    content: [{ type: 'text', text: summary ?? defaultSummary }],
     structuredContent: structured,
   };
 }

--- a/src/lib/types/server-payload-aliases.ts
+++ b/src/lib/types/server-payload-aliases.ts
@@ -75,7 +75,7 @@ import type {
   GetRightsSuccess,
   UpdateRightsSuccess,
 } from './core.generated';
-import type { ServerPayload } from './server-payload';
+import type { RequireCacheScopeWhenProducts, ServerPayload } from './server-payload';
 
 export type GetAdCPCapabilitiesPayload = ServerPayload<GetAdCPCapabilitiesResponse>;
 
@@ -88,7 +88,7 @@ export type ReportUsagePayload = ServerPayload<ReportUsageResponse>;
 export type GetAccountFinancialsPayload = ServerPayload<GetAccountFinancialsResponse>;
 export type GetAccountFinancialsSuccessPayload = ServerPayload<GetAccountFinancialsSuccess>;
 
-export type GetProductsPayload = ServerPayload<GetProductsResponse>;
+export type GetProductsPayload = RequireCacheScopeWhenProducts<ServerPayload<GetProductsResponse>>;
 export type CreateMediaBuyPayload = ServerPayload<CreateMediaBuySuccess>;
 export type UpdateMediaBuyPayload = ServerPayload<UpdateMediaBuySuccess>;
 export type GetMediaBuysPayload = ServerPayload<GetMediaBuysResponse>;

--- a/src/lib/types/server-payload.ts
+++ b/src/lib/types/server-payload.ts
@@ -69,3 +69,37 @@ type StripWriteOnlyResponseFields<T> = T extends JsonPrimitive
 export type ServerPayload<T> = T extends unknown
   ? StripWriteOnlyResponseFields<Omit<T, ProtocolEnvelopeKeys<T>>>
   : never;
+
+/**
+ * Product-feed payloads have one response-shape invariant that the generated
+ * TypeScript currently cannot express: when `products` is present or a
+ * wholesale feed is `unchanged`, 3.1 requires `cache_scope` so buyers do not
+ * key account-specific overlays under the public cache. Keep the stricter
+ * server-facing alias here until the generated schema types learn that
+ * conditional requirement directly.
+ */
+export type RequireCacheScopeWhenProducts<T> = T extends {
+  products?: infer TProducts;
+  cache_scope?: infer TScope;
+  unchanged?: infer TUnchanged;
+}
+  ?
+      | (Omit<T, 'products' | 'cache_scope' | 'unchanged'> & {
+          products: Exclude<TProducts, undefined>;
+          unchanged?: undefined;
+          cache_scope: NonNullable<TScope>;
+        })
+      | (Omit<T, 'products' | 'cache_scope' | 'unchanged'> & {
+          products?: undefined;
+          unchanged: Extract<TUnchanged, true>;
+          cache_scope: NonNullable<TScope>;
+        })
+      | (Omit<T, 'products' | 'unchanged'> & { products?: undefined; unchanged?: undefined })
+  : T extends { products?: infer TProducts; cache_scope?: infer TScope }
+    ?
+        | (Omit<T, 'products' | 'cache_scope'> & {
+            products: Exclude<TProducts, undefined>;
+            cache_scope: NonNullable<TScope>;
+          })
+        | (Omit<T, 'products'> & { products?: undefined })
+    : T;

--- a/src/lib/utils/envelope-status-compat.ts
+++ b/src/lib/utils/envelope-status-compat.ts
@@ -44,7 +44,7 @@ const MEDIA_BUY_STATUS_RESPONSE_TOOLS = new Set(['create_media_buy', 'update_med
  *  - No version fields at all → treated as legacy (3.0.x leniency applies)
  *  - `adcp_version` declares a major other than 3 → NOT 3.0.x (no leniency)
  */
-function isLegacy30xPayload(payload: Record<string, unknown>): boolean {
+export function isLegacy30xPayload(payload: Record<string, unknown>): boolean {
   const adcpVersion = payload.adcp_version;
   if (typeof adcpVersion === 'string') {
     if (

--- a/src/lib/utils/response-schemas.ts
+++ b/src/lib/utils/response-schemas.ts
@@ -9,9 +9,32 @@ import { z } from 'zod';
 import * as schemas from '../types/schemas.generated';
 import { SyncCreativesResponseStrictSchema } from '../validation/sync-creatives';
 
+function declaresLegacy30xPayload(response: Record<string, unknown>): boolean {
+  const adcpVersion = response.adcp_version;
+  if (typeof adcpVersion === 'string') {
+    return (
+      adcpVersion === '3' || adcpVersion === '3.0' || adcpVersion.startsWith('3.0.') || adcpVersion.startsWith('3.0-')
+    );
+  }
+  return response.adcp_major_version === 3;
+}
+
+const GetProductsResponseStrictSchema = schemas.GetProductsResponseSchema.superRefine((value, ctx) => {
+  if (value == null || typeof value !== 'object' || Array.isArray(value)) return;
+  const response = value as { products?: unknown; cache_scope?: unknown; unchanged?: unknown };
+  if (declaresLegacy30xPayload(response)) return;
+  if ((Array.isArray(response.products) || response.unchanged === true) && response.cache_scope === undefined) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['cache_scope'],
+      message: '`cache_scope` is required when `products` is present or `unchanged` is true',
+    });
+  }
+});
+
 export const TOOL_RESPONSE_SCHEMAS: Partial<Record<string, z.ZodType>> = {
   // Product discovery & media buy
-  get_products: schemas.GetProductsResponseSchema,
+  get_products: GetProductsResponseStrictSchema,
   create_media_buy: schemas.CreateMediaBuyResponseSchema,
   update_media_buy: schemas.UpdateMediaBuyResponseSchema,
   get_media_buys: schemas.GetMediaBuysResponseSchema,

--- a/src/lib/validation/hints.ts
+++ b/src/lib/validation/hints.ts
@@ -26,6 +26,9 @@
  *      `daast_url`.
  *   9. Mutating tool missing `idempotency_key` — required UUID, reused
  *      on retries.
+ *   10. `get_products.cache_scope` — required whenever `products` is
+ *       present or `unchanged: true` so buyers key public feeds separately
+ *       from account overlays.
  *
  * Quality bar: a hint earns its slot if at least three adopters or
  * blind-LLM matrix runs hit the same shape and lost ≥1 iteration to
@@ -195,6 +198,14 @@ const RULES: readonly HintRule[] = [
     keyword: 'type',
     pointerPattern: /\/signal_ids\/\d+$/,
     hint: '`signal_ids` is an array of provenance objects: `{ source: "catalog", data_provider_domain, id }` or `{ source: "agent", agent_url, id }`. Bare ID strings are rejected.',
+  },
+  // 10. get_products.cache_scope — required on populated and unchanged product responses.
+  {
+    tool: 'get_products',
+    keyword: 'required',
+    pointerEquals: '/cache_scope',
+    missingProperty: 'cache_scope',
+    hint: '`get_products` responses with `products` or `unchanged: true` must include `cache_scope`: use `public` for the universal rate card, `account` for account-specific overlays.',
   },
 ];
 

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -66,7 +66,7 @@ export const VERSION_INFO = {
   library: '8.1.0-beta.11',
   adcp: '3.1.0-beta.3',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-05-25T12:17:50.885Z',
+  generatedAt: '2026-05-26T01:46:27.140Z',
 } as const;
 
 /**

--- a/src/type-tests/server-payload-aliases.type-test.ts
+++ b/src/type-tests/server-payload-aliases.type-test.ts
@@ -15,6 +15,7 @@ import type {
 } from '../lib/types';
 import type { CreateMediaBuySuccess } from '../lib/types';
 import type { GetProductsPayload as DecisioningGetProductsPayload } from '../lib/server/decisioning/specialisms/sales';
+import { productsResponse } from '../lib/server';
 
 const rootCreateMediaBuyPayload: RootCreateMediaBuyPayload = {
   media_buy_id: 'mb_1',
@@ -33,12 +34,32 @@ const rootGetProductsPayload: RootGetProductsPayload = {
 const serverGetProductsPayload: ServerGetProductsPayload = rootGetProductsPayload;
 const typesGetProductsPayload: TypesGetProductsPayload = serverGetProductsPayload;
 void typesGetProductsPayload;
+
+const unchangedGetProductsPayload: RootGetProductsPayload = {
+  unchanged: true,
+  wholesale_feed_version: 'wf_v1',
+  cache_scope: 'public',
+};
+const unchangedServerGetProductsPayload: ServerGetProductsPayload = unchangedGetProductsPayload;
+void unchangedServerGetProductsPayload;
+
 declare const publicTypesGetProductsPayload: TypesGetProductsPayload;
 declare const decisioningGetProductsPayload: DecisioningGetProductsPayload;
 const decisioningPayloadFromPublicAlias: DecisioningGetProductsPayload = publicTypesGetProductsPayload;
 const publicAliasFromDecisioningPayload: TypesGetProductsPayload = decisioningGetProductsPayload;
 void decisioningPayloadFromPublicAlias;
 void publicAliasFromDecisioningPayload;
+
+// @ts-expect-error get_products payloads with products must declare cache_scope.
+const missingCacheScopeWithProducts: RootGetProductsPayload = { products: [] };
+void missingCacheScopeWithProducts;
+
+// @ts-expect-error get_products unchanged wholesale-feed payloads must echo cache_scope.
+const missingCacheScopeWithUnchanged: RootGetProductsPayload = { unchanged: true, wholesale_feed_version: 'wf_v1' };
+void missingCacheScopeWithUnchanged;
+
+// @ts-expect-error productsResponse also enforces cache_scope at the manual builder callsite.
+productsResponse({ products: [] });
 
 declare const serverPreviewCreativePayload: ServerPreviewCreativePayload;
 const typesPreviewCreativePayload: TypesPreviewCreativePayload = serverPreviewCreativePayload;

--- a/test/in-memory-implicit-account-store.test.js
+++ b/test/in-memory-implicit-account-store.test.js
@@ -195,6 +195,7 @@ describe('InMemoryImplicitAccountStore — wired into a server', () => {
         statusMappers: {},
         sales: {
           getProducts: async (_req, ctx) => ({
+            cache_scope: ctx?.account?.id ? 'account' : 'public',
             products: [{ product_id: `p:${ctx?.account?.id ?? 'none'}`, name: 'p', formats: [] }],
           }),
           createMediaBuy: async () => ({ media_buy_id: 'mb_1' }),

--- a/test/lib/bridge-marker.test.js
+++ b/test/lib/bridge-marker.test.js
@@ -78,7 +78,9 @@ describe('_bridge marker — append-merge tools', () => {
     const server = createAdcpServer({
       name: 'Test',
       version: '1.0.0',
-      mediaBuy: { getProducts: async () => ({ products: [{ product_id: 'h-1', name: 'Handler' }] }) },
+      mediaBuy: {
+        getProducts: async () => ({ cache_scope: 'account', products: [{ product_id: 'h-1', name: 'Handler' }] }),
+      },
       testController: {
         getSeededProducts: () => [
           { product_id: 's-1', name: 'S1' },
@@ -422,7 +424,7 @@ describe('_bridge marker — absent when no merge ran', () => {
     const server = createAdcpServer({
       name: 'Test',
       version: '1.0.0',
-      mediaBuy: { getProducts: async () => ({ products: [{ product_id: 'h-1', name: 'H' }] }) },
+      mediaBuy: { getProducts: async () => ({ cache_scope: 'account', products: [{ product_id: 'h-1', name: 'H' }] }) },
       testController: {},
     });
     const res = await dispatch(server, 'get_products', {
@@ -437,7 +439,7 @@ describe('_bridge marker — absent when no merge ran', () => {
     const server = createAdcpServer({
       name: 'Test',
       version: '1.0.0',
-      mediaBuy: { getProducts: async () => ({ products: [{ product_id: 'h-1', name: 'H' }] }) },
+      mediaBuy: { getProducts: async () => ({ cache_scope: 'account', products: [{ product_id: 'h-1', name: 'H' }] }) },
       testController: { getSeededProducts: () => [{ product_id: 's-1', name: 'S' }] },
     });
     const res = await dispatch(server, 'get_products', {
@@ -481,7 +483,7 @@ describe('_bridge marker — absent when no merge ran', () => {
     const server = createAdcpServer({
       name: 'Test',
       version: '1.0.0',
-      mediaBuy: { getProducts: async () => ({ products: [{ product_id: 'h-1', name: 'H' }] }) },
+      mediaBuy: { getProducts: async () => ({ cache_scope: 'account', products: [{ product_id: 'h-1', name: 'H' }] }) },
       testController: { getSeededProducts: () => [] },
     });
     const res = await dispatch(server, 'get_products', {

--- a/test/lib/response-schema-validation.test.js
+++ b/test/lib/response-schema-validation.test.js
@@ -80,32 +80,56 @@ describe('validateResponseSchema', () => {
   // ---- get_products (#371) ----
   describe('get_products — required fields (#371)', () => {
     it('passes for valid response', () => {
-      const result = validateResponseSchema('get_products', { products: [validProduct] });
+      const result = validateResponseSchema('get_products', { products: [validProduct], cache_scope: 'public' });
       assert.strictEqual(result.passed, true);
     });
 
     it('passes for empty products array', () => {
-      const result = validateResponseSchema('get_products', { products: [] });
+      const result = validateResponseSchema('get_products', { products: [], cache_scope: 'public' });
       assert.strictEqual(result.passed, true);
+    });
+
+    it('fails when cache_scope is missing on a products response', () => {
+      const result = validateResponseSchema('get_products', { products: [] });
+      assert.strictEqual(result.passed, false);
+      assert.ok(result.error.includes('cache_scope'), `Expected cache_scope error, got: ${result.error}`);
+    });
+
+    it('passes for unchanged wholesale-feed responses without products', () => {
+      const result = validateResponseSchema('get_products', {
+        unchanged: true,
+        wholesale_feed_version: 'wf_v1',
+        cache_scope: 'public',
+      });
+      assert.strictEqual(result.passed, true);
+    });
+
+    it('fails when cache_scope is missing on an unchanged wholesale-feed response', () => {
+      const result = validateResponseSchema('get_products', {
+        unchanged: true,
+        wholesale_feed_version: 'wf_v1',
+      });
+      assert.strictEqual(result.passed, false);
+      assert.ok(result.error.includes('cache_scope'), `Expected cache_scope error, got: ${result.error}`);
     });
 
     it('fails when product_id is missing', () => {
       const { product_id, ...without } = validProduct;
-      const result = validateResponseSchema('get_products', { products: [without] });
+      const result = validateResponseSchema('get_products', { products: [without], cache_scope: 'public' });
       assert.strictEqual(result.passed, false);
       assert.ok(result.error.includes('product_id'), `Expected product_id error, got: ${result.error}`);
     });
 
     it('fails when name is missing', () => {
       const { name, ...without } = validProduct;
-      const result = validateResponseSchema('get_products', { products: [without] });
+      const result = validateResponseSchema('get_products', { products: [without], cache_scope: 'public' });
       assert.strictEqual(result.passed, false);
       assert.ok(result.error.includes('name'), `Expected name error, got: ${result.error}`);
     });
 
     // 3.1.0-beta.3 made `products` OPTIONAL on the get_products response
-    // envelope: a wholesale-feed unchanged response legitimately omits it
-    // (see the top-level if/then on `unchanged: true`), and an error
+    // envelope: a wholesale-feed unchanged response legitimately omits
+    // products (while still requiring cache_scope), and an error
     // response carries `errors[]` instead of `products[]`. The "absent
     // products is a failure" assertion no longer matches the spec.
     // Constraint coverage when products IS provided remains in the
@@ -573,7 +597,7 @@ describe('validateResponseSchema', () => {
   //     missing-field message these tests assert on.
   //   - The "non-union schemas" guard (`get_products` with `{ not_products: true }`)
   //     also flips: 3.1.0-beta.3 made `products` OPTIONAL on the get_products
-  //     response (the `unchanged: true` shape legitimately omits it), so the
+  //     response (the `unchanged: true` shape legitimately omits products), so the
   //     payload now validates and no missing-field message is produced.
   //   - The Zod-internals canary fails for the same reason — the schema is no
   //     longer a `ZodUnion`, so `_def.options` is intentionally absent.

--- a/test/lib/response-unwrapper.test.js
+++ b/test/lib/response-unwrapper.test.js
@@ -36,6 +36,7 @@ describe('Response Unwrapper', () => {
                 {
                   kind: 'data',
                   data: {
+                    cache_scope: 'public',
                     products: [createTestProduct({ product_id: 'prod1', name: 'Test Product' })],
                   },
                 },
@@ -64,6 +65,7 @@ describe('Response Unwrapper', () => {
                   kind: 'data',
                   data: {
                     response: {
+                      cache_scope: 'public',
                       products: [createTestProduct({ product_id: 'prod1', name: 'Test Product' })],
                     },
                   },
@@ -194,6 +196,7 @@ describe('Response Unwrapper', () => {
                 {
                   kind: 'data',
                   data: {
+                    cache_scope: 'public',
                     products: [createTestProduct({ product_id: 'p1' }), createTestProduct({ product_id: 'p2' })],
                   },
                 },
@@ -218,6 +221,7 @@ describe('Response Unwrapper', () => {
           },
         ],
         structuredContent: {
+          cache_scope: 'public',
           products: [createTestProduct({ product_id: 'p1' })],
         },
       };
@@ -238,6 +242,7 @@ describe('Response Unwrapper', () => {
                 {
                   kind: 'data',
                   data: {
+                    cache_scope: 'public',
                     products: [createTestProduct({ product_id: 'old', name: 'Old Product' })],
                   },
                 },
@@ -249,6 +254,7 @@ describe('Response Unwrapper', () => {
                 {
                   kind: 'data',
                   data: {
+                    cache_scope: 'public',
                     products: [createTestProduct({ product_id: 'new', name: 'New Product' })],
                   },
                 },
@@ -313,6 +319,7 @@ describe('Response Unwrapper', () => {
                 {
                   kind: 'data',
                   data: {
+                    cache_scope: 'public',
                     products: [createTestProduct({ product_id: 'p1' })],
                   },
                 },
@@ -345,6 +352,7 @@ describe('Response Unwrapper', () => {
                 {
                   kind: 'data',
                   data: {
+                    cache_scope: 'public',
                     products: [createTestProduct({ product_id: 'prod1', name: 'Test Product' })],
                   },
                 },
@@ -389,6 +397,7 @@ describe('Response Unwrapper', () => {
                 {
                   kind: 'data',
                   data: {
+                    cache_scope: 'public',
                     products: [createTestProduct({ product_id: 'prod1', name: 'Test Product' })],
                   },
                 },
@@ -418,6 +427,7 @@ describe('Response Unwrapper', () => {
             {
               kind: 'data',
               data: {
+                cache_scope: 'public',
                 products: [createTestProduct({ product_id: `prod${i}`, name: `Product ${i}` })],
               },
             },
@@ -707,6 +717,7 @@ describe('Response Unwrapper', () => {
                 {
                   kind: 'data',
                   data: {
+                    cache_scope: 'public',
                     products: [createTestProduct({ product_id: 'prod-1' })],
                   },
                 },
@@ -723,9 +734,51 @@ describe('Response Unwrapper', () => {
       assert.strictEqual(result.products[0].product_id, 'prod-1');
     });
 
+    test('should accept legacy 3.0 MCP get_products without cache_scope', () => {
+      const mcpResponse = {
+        structuredContent: {
+          adcp_version: '3.0.12',
+          products: [createTestProduct({ product_id: 'prod-1' })],
+        },
+      };
+
+      const result = unwrapProtocolResponse(mcpResponse, 'get_products', 'mcp');
+      assert.ok(result.products, 'Should return validated products');
+      assert.strictEqual(result.products.length, 1);
+      assert.strictEqual(result.cache_scope, undefined);
+      assert.strictEqual(result.status, undefined);
+    });
+
+    test('should accept legacy 3.0 A2A get_products without cache_scope', () => {
+      const a2aResponse = {
+        result: {
+          artifacts: [
+            {
+              parts: [
+                {
+                  kind: 'data',
+                  data: {
+                    adcp_version: '3.0.12',
+                    products: [createTestProduct({ product_id: 'prod-1' })],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      };
+
+      const result = unwrapProtocolResponse(a2aResponse, 'get_products', 'a2a');
+      assert.ok(result.products, 'Should return validated products');
+      assert.strictEqual(result.products.length, 1);
+      assert.strictEqual(result.cache_scope, undefined);
+      assert.strictEqual(result.status, undefined);
+    });
+
     test('should reject get_products response with non-array products', () => {
       const mcpResponse = {
         structuredContent: {
+          cache_scope: 'public',
           products: 'not an array',
         },
       };
@@ -817,6 +870,7 @@ describe('Response Unwrapper', () => {
 
       const mcpResponse = {
         structuredContent: {
+          cache_scope: 'public',
           products: [validProduct, invalidProduct],
         },
       };
@@ -839,6 +893,7 @@ describe('Response Unwrapper', () => {
 
       const mcpResponse = {
         structuredContent: {
+          cache_scope: 'public',
           products: [invalidProduct1, invalidProduct2],
         },
       };
@@ -855,6 +910,7 @@ describe('Response Unwrapper', () => {
 
       const mcpResponse = {
         structuredContent: {
+          cache_scope: 'public',
           products: [product1, product2],
         },
       };
@@ -898,6 +954,7 @@ describe('Response Unwrapper', () => {
                 {
                   kind: 'data',
                   data: {
+                    cache_scope: 'public',
                     products: [validProduct, invalidProduct],
                   },
                 },
@@ -917,6 +974,7 @@ describe('Response Unwrapper', () => {
     test('should return null from filtering when products field is not an array', () => {
       const mcpResponse = {
         structuredContent: {
+          cache_scope: 'public',
           products: 'not-an-array',
         },
       };
@@ -1104,6 +1162,7 @@ describe('Response Unwrapper', () => {
 
     test('should validate get_products success response', () => {
       const successResponse = {
+        cache_scope: 'public',
         products: [createTestProduct({ product_id: 'prod1' })],
       };
 
@@ -1134,6 +1193,7 @@ describe('Response Unwrapper', () => {
           {
             type: 'text',
             text: JSON.stringify({
+              cache_scope: 'public',
               products: [createTestProduct({ product_id: 'p1' })],
               extra_field: 'unexpected',
             }),

--- a/test/lib/response-validator.test.js
+++ b/test/lib/response-validator.test.js
@@ -71,6 +71,7 @@ describe('ResponseValidator Tests', () => {
     it('should validate valid MCP response with structuredContent', () => {
       const response = {
         structuredContent: {
+          cache_scope: 'public',
           products: [createValidProduct()],
         },
       };
@@ -127,7 +128,10 @@ describe('ResponseValidator Tests', () => {
               parts: [
                 {
                   kind: 'data',
-                  data: { products: [createValidProduct()] },
+                  data: {
+                    cache_scope: 'public',
+                    products: [createValidProduct()],
+                  },
                 },
               ],
             },
@@ -212,6 +216,7 @@ describe('ResponseValidator Tests', () => {
     it('should validate expected fields in MCP response', () => {
       const response = {
         structuredContent: {
+          cache_scope: 'public',
           products: [createValidProduct()],
         },
       };
@@ -242,6 +247,7 @@ describe('ResponseValidator Tests', () => {
     it('should warn on empty arrays for expected fields', () => {
       const response = {
         structuredContent: {
+          cache_scope: 'public',
           products: [],
         },
       };
@@ -282,6 +288,20 @@ describe('ResponseValidator Tests', () => {
     it('should validate get_products response', () => {
       const response = {
         structuredContent: {
+          cache_scope: 'public',
+          products: [createValidProduct()],
+        },
+      };
+
+      const result = validator.validate(response, 'get_products');
+
+      assert.strictEqual(result.valid, true);
+    });
+
+    it('should validate legacy 3.0 get_products responses without cache_scope', () => {
+      const response = {
+        structuredContent: {
+          adcp_version: '3.0.12',
           products: [createValidProduct()],
         },
       };
@@ -375,6 +395,7 @@ describe('ResponseValidator Tests', () => {
     it('should fail in strict mode with warnings', () => {
       const response = {
         structuredContent: {
+          cache_scope: 'public',
           products: [], // Empty array triggers warning
         },
       };
@@ -391,6 +412,7 @@ describe('ResponseValidator Tests', () => {
     it('should pass in non-strict mode with warnings', () => {
       const response = {
         structuredContent: {
+          cache_scope: 'public',
           products: [],
         },
       };
@@ -419,6 +441,7 @@ describe('ResponseValidator Tests', () => {
     it('validateOrThrow should not throw on valid response', () => {
       const response = {
         structuredContent: {
+          cache_scope: 'public',
           products: [createValidProduct()],
         },
       };

--- a/test/lib/seed-get-products-wiring.test.js
+++ b/test/lib/seed-get-products-wiring.test.js
@@ -40,7 +40,10 @@ describe('createAdcpServer — test-controller seeded get_products wiring', () =
       name: 'Test',
       version: '1.0.0',
       mediaBuy: {
-        getProducts: async () => ({ products: [{ product_id: 'handler-1', name: 'Handler Own' }] }),
+        getProducts: async () => ({
+          products: [{ product_id: 'handler-1', name: 'Handler Own' }],
+          cache_scope: 'account',
+        }),
       },
       testController: {
         getSeededProducts: () => seeded,
@@ -63,7 +66,10 @@ describe('createAdcpServer — test-controller seeded get_products wiring', () =
       name: 'Test',
       version: '1.0.0',
       mediaBuy: {
-        getProducts: async () => ({ products: [{ product_id: 'handler-1', name: 'Handler Own' }] }),
+        getProducts: async () => ({
+          products: [{ product_id: 'handler-1', name: 'Handler Own' }],
+          cache_scope: 'account',
+        }),
       },
       testController: {
         getSeededProducts: () => {
@@ -92,7 +98,7 @@ describe('createAdcpServer — test-controller seeded get_products wiring', () =
       name: 'Test',
       version: '1.0.0',
       mediaBuy: {
-        getProducts: async () => ({ products: [] }),
+        getProducts: async () => ({ products: [], cache_scope: 'public' }),
       },
       testController: {
         getSeededProducts: () => [makeSeededProduct('seed-1')],
@@ -120,6 +126,7 @@ describe('createAdcpServer — test-controller seeded get_products wiring', () =
             { product_id: 'shared', name: 'Handler Copy' },
             { product_id: 'handler-only', name: 'Handler Only' },
           ],
+          cache_scope: 'account',
         }),
       },
       testController: {
@@ -142,7 +149,10 @@ describe('createAdcpServer — test-controller seeded get_products wiring', () =
       name: 'Test',
       version: '1.0.0',
       mediaBuy: {
-        getProducts: async () => ({ products: [{ product_id: 'handler-1', name: 'Handler Own' }] }),
+        getProducts: async () => ({
+          products: [{ product_id: 'handler-1', name: 'Handler Own' }],
+          cache_scope: 'account',
+        }),
       },
       testController: {}, // no getSeededProducts → bridge stays off
     });
@@ -165,7 +175,10 @@ describe('createAdcpServer — test-controller seeded get_products wiring', () =
       version: '1.0.0',
       resolveAccount: async () => ({ account_id: 'prod-999', sandbox: false }),
       mediaBuy: {
-        getProducts: async () => ({ products: [{ product_id: 'handler-1', name: 'Handler Own' }] }),
+        getProducts: async () => ({
+          products: [{ product_id: 'handler-1', name: 'Handler Own' }],
+          cache_scope: 'account',
+        }),
       },
       testController: {
         getSeededProducts: () => {
@@ -193,7 +206,7 @@ describe('createAdcpServer — test-controller seeded get_products wiring', () =
       name: 'Test',
       version: '1.0.0',
       mediaBuy: {
-        getProducts: async () => ({ products: [] }),
+        getProducts: async () => ({ products: [], cache_scope: 'account' }),
       },
       testController: {
         getSeededProducts: () => [
@@ -220,7 +233,10 @@ describe('createAdcpServer — test-controller seeded get_products wiring', () =
       name: 'Test',
       version: '1.0.0',
       mediaBuy: {
-        getProducts: async () => ({ products: [{ product_id: 'handler-1', name: 'Handler Own' }] }),
+        getProducts: async () => ({
+          products: [{ product_id: 'handler-1', name: 'Handler Own' }],
+          cache_scope: 'account',
+        }),
       },
       testController: {
         getSeededProducts: () => 'not-an-array',
@@ -290,7 +306,7 @@ describe('createAdcpServer — test-controller seeded get_products wiring', () =
       version: '1.0.0',
       resolveAccount: async () => ({ account_id: 'resolved-123', sandbox: true }),
       mediaBuy: {
-        getProducts: async () => ({ products: [] }),
+        getProducts: async () => ({ products: [], cache_scope: 'account' }),
       },
       testController: {
         getSeededProducts: ctx => {
@@ -314,7 +330,10 @@ describe('createAdcpServer — test-controller seeded get_products wiring', () =
       name: 'Test',
       version: '1.0.0',
       mediaBuy: {
-        getProducts: async () => ({ products: [{ product_id: 'handler-1', name: 'Handler Own' }] }),
+        getProducts: async () => ({
+          products: [{ product_id: 'handler-1', name: 'Handler Own' }],
+          cache_scope: 'account',
+        }),
       },
     });
     const result = await callGetProducts(server, {
@@ -390,6 +409,35 @@ describe('createAdcpServer — seeded get_products under strict response validat
       ['handler-1', 'seed-1', 'seed-2']
     );
     assert.strictEqual(payload.sandbox, true);
+  });
+
+  it('does not default cache_scope on account-scoped seeded sandbox merges', async () => {
+    const server = _createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      validation: { requests: 'off', responses: 'strict' },
+      mediaBuy: {
+        getProducts: async () => ({ products: [] }),
+      },
+      testController: {
+        getSeededProducts: () => [makeStrictProduct('seed-1')],
+      },
+    });
+    const result = await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'get_products',
+        arguments: {
+          brief: 'premium',
+          buying_mode: 'brief',
+          account: { brand: { domain: 'example.com' }, operator: 'example.com', sandbox: true },
+        },
+      },
+    });
+    assert.strictEqual(result.isError, true);
+    assert.strictEqual(result.structuredContent.adcp_error.code, 'VALIDATION_ERROR');
+    const issue = result.structuredContent.adcp_error.issues.find(i => i.pointer === '/cache_scope');
+    assert.ok(issue, `expected missing cache_scope issue, got: ${JSON.stringify(result.structuredContent)}`);
   });
 
   // ---------------------------------------------------------------------------

--- a/test/lib/validation-hints.test.js
+++ b/test/lib/validation-hints.test.js
@@ -144,6 +144,17 @@ describe('curated validation hints (issue #1309)', () => {
     assert.match(issue.hint ?? '', /Bare ID strings are rejected/);
   });
 
+  test('get_products with products missing cache_scope fires the cache-scope hint', () => {
+    const outcome = validateResponse('get_products', {
+      status: 'completed',
+      products: [],
+    });
+    const issue = outcome.issues.find(i => i.pointer === '/cache_scope' && i.keyword === 'required');
+    assert.ok(issue, `expected /cache_scope required issue, got: ${JSON.stringify(outcome.issues)}`);
+    assert.match(issue.hint ?? '', /responses with `products` or `unchanged: true` must include `cache_scope`/);
+    assert.match(issue.hint ?? '', /universal rate card/);
+  });
+
   test('VAST asset missing delivery_type fires the inline-vs-redirect hint', () => {
     // Synthetic — the issue path the rule matches happens deep inside
     // sync_creatives' nested asset oneOf cascade. Direct findHint()

--- a/test/lib/version-sync.test.js
+++ b/test/lib/version-sync.test.js
@@ -1,0 +1,18 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { readFileSync } = require('node:fs');
+const path = require('node:path');
+
+const { LIBRARY_VERSION, VERSION_INFO, toReleasePrecisionVersion } = require('../../dist/lib/version.js');
+
+test('exported SDK library version matches package.json', () => {
+  const pkg = JSON.parse(readFileSync(path.join(__dirname, '../../package.json'), 'utf8'));
+  assert.equal(LIBRARY_VERSION, pkg.version);
+  assert.equal(VERSION_INFO.library, pkg.version);
+});
+
+test('AdCP semver pins normalize to release-precision wire values', () => {
+  assert.equal(toReleasePrecisionVersion('3.1.0-beta.3'), '3.1-beta.3');
+  assert.equal(toReleasePrecisionVersion('3.1.0'), '3.1');
+  assert.equal(toReleasePrecisionVersion('3.1-beta.3'), '3.1-beta.3');
+});

--- a/test/server-buyer-agent-credential-synthesis.test.js
+++ b/test/server-buyer-agent-credential-synthesis.test.js
@@ -46,6 +46,7 @@ function buildPlatform(overrides = {}) {
     statusMappers: {},
     sales: {
       getProducts: async (_req, ctx) => ({
+        cache_scope: 'account',
         products: [],
         _ctxAgent: ctx?.agent,
       }),
@@ -478,7 +479,7 @@ describe('Stage 3 — BuyerAgentRegistry routes on the credential', () => {
         list: async () => ({ items: [], nextCursor: null }),
       },
       sales: {
-        getProducts: async (_req, ctx) => ({ products: [], _ctxAgent: ctx?.agent }),
+        getProducts: async (_req, ctx) => ({ cache_scope: 'account', products: [], _ctxAgent: ctx?.agent }),
         createMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
         updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
         syncCreatives: async () => [],

--- a/test/server-buyer-agent-resolve-seam.test.js
+++ b/test/server-buyer-agent-resolve-seam.test.js
@@ -35,6 +35,7 @@ function buildPlatform(overrides = {}) {
     statusMappers: {},
     sales: {
       getProducts: async (_req, ctx) => ({
+        cache_scope: 'account',
         products: [
           {
             product_id: 'p1',
@@ -184,7 +185,7 @@ describe('buyer-agent registry resolve seam — Stage 2 of #1269', () => {
       sales: {
         getProducts: async () => {
           handlerInvoked = true;
-          return { products: [] };
+          return { cache_scope: 'account', products: [] };
         },
         createMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
         updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
@@ -303,7 +304,7 @@ describe('buyer-agent registry resolve seam — Stage 2 of #1269', () => {
         list: async () => ({ items: [], nextCursor: null }),
       },
       sales: {
-        getProducts: async () => ({ products: [] }),
+        getProducts: async () => ({ cache_scope: 'account', products: [] }),
         createMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
         updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
         syncCreatives: async () => [],

--- a/test/server-buyer-agent-sandbox-only.test.js
+++ b/test/server-buyer-agent-sandbox-only.test.js
@@ -56,6 +56,7 @@ function buildPlatform(overrides = {}) {
     statusMappers: {},
     sales: {
       getProducts: async (_req, ctx) => ({
+        cache_scope: 'account',
         products: [],
         _ctxAgent: ctx?.agent,
         _accountSandbox: ctx?.account?.sandbox,
@@ -117,7 +118,7 @@ describe('Phase 1.5 — sandbox-only buyer agent enforcement', () => {
       sales: {
         getProducts: async () => {
           handlerInvoked = true;
-          return { products: [] };
+          return { cache_scope: 'account', products: [] };
         },
         createMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
         updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
@@ -187,7 +188,7 @@ describe('Phase 1.5 — sandbox-only buyer agent enforcement', () => {
       sales: {
         getProducts: async () => {
           handlerInvoked = true;
-          return { products: [] };
+          return { cache_scope: 'account', products: [] };
         },
         createMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
         updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),

--- a/test/server-buyer-agent-status-and-redaction.test.js
+++ b/test/server-buyer-agent-status-and-redaction.test.js
@@ -41,7 +41,7 @@ function buildPlatform(overrides = {}) {
     },
     statusMappers: {},
     sales: {
-      getProducts: async (_req, ctx) => ({ products: [], _ctxAgent: ctx?.agent }),
+      getProducts: async (_req, ctx) => ({ cache_scope: 'account', products: [], _ctxAgent: ctx?.agent }),
       createMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
       updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
       syncCreatives: async () => [],
@@ -104,7 +104,7 @@ describe('Stage 4 — status enforcement', () => {
       sales: {
         getProducts: async () => {
           handlerInvoked = true;
-          return { products: [] };
+          return { cache_scope: 'account', products: [] };
         },
         createMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
         updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
@@ -228,7 +228,7 @@ describe('Stage 4 — status enforcement', () => {
           // request mutating the agent record in the seller's DB.
           registryStatus = 'suspended';
           handlerCompleted = true;
-          return { products: [] };
+          return { cache_scope: 'account', products: [] };
         },
         createMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
         updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),

--- a/test/server-create-adcp-server.test.js
+++ b/test/server-create-adcp-server.test.js
@@ -36,11 +36,14 @@ async function callTool(server, toolName, params) {
   return raw.structuredContent;
 }
 
-async function callToolRaw(server, toolName, params) {
-  return server.dispatchTestRequest({
-    method: 'tools/call',
-    params: { name: toolName, arguments: params ?? {} },
-  });
+async function callToolRaw(server, toolName, params, extras) {
+  return server.dispatchTestRequest(
+    {
+      method: 'tools/call',
+      params: { name: toolName, arguments: params ?? {} },
+    },
+    extras
+  );
 }
 
 function registeredTools(server) {
@@ -401,6 +404,105 @@ describe('createAdcpServer', () => {
       });
       assert.strictEqual(result.content[0].text, 'Found 1 products');
       assert.strictEqual(result.structuredContent.products.length, 1);
+    });
+
+    it('defaults get_products cache_scope to public only when request has no account', async () => {
+      const server = createAdcpServer({
+        name: 'Test',
+        version: '1.0.0',
+        validation: { responses: 'strict' },
+        mediaBuy: {
+          getProducts: async () => ({ products: [] }),
+        },
+      });
+      const result = await callTool(server, 'get_products', {
+        buying_mode: 'brief',
+        brief: 'test',
+      });
+      assert.strictEqual(result.cache_scope, 'public');
+    });
+
+    it('syncs inferred get_products cache_scope into JSON text fallback', async () => {
+      const server = createAdcpServer({
+        name: 'Test',
+        version: '1.0.0',
+        mediaBuy: {
+          getProducts: async () => ({
+            content: [{ type: 'text', text: JSON.stringify({ products: [] }) }],
+            structuredContent: { products: [] },
+          }),
+        },
+      });
+      const result = await callToolRaw(server, 'get_products', {
+        buying_mode: 'brief',
+        brief: 'test',
+      });
+      assert.strictEqual(result.structuredContent.cache_scope, 'public');
+      assert.strictEqual(JSON.parse(result.content[0].text).cache_scope, 'public');
+    });
+
+    it('fails closed for auth-scoped get_products responses missing cache_scope without response validation', async () => {
+      const server = createAdcpServer({
+        name: 'Test',
+        version: '1.0.0',
+        mediaBuy: {
+          getProducts: async () => ({ products: [] }),
+        },
+      });
+      const result = await callToolRaw(
+        server,
+        'get_products',
+        {
+          buying_mode: 'brief',
+          brief: 'test',
+        },
+        {
+          authInfo: { token: 'caller-token', clientId: 'buyer-1', scopes: ['adcp.media_buy'] },
+        }
+      );
+      assert.strictEqual(result.isError, true);
+      assert.strictEqual(result.structuredContent.adcp_error.code, 'VALIDATION_ERROR');
+      const issue = result.structuredContent.adcp_error.issues.find(i => i.pointer === '/cache_scope');
+      assert.ok(issue, `expected missing cache_scope issue, got: ${JSON.stringify(result.structuredContent)}`);
+    });
+
+    it('does not infer get_products cache_scope for auth-derived account context', async () => {
+      const server = createAdcpServer({
+        name: 'Test',
+        version: '1.0.0',
+        resolveAccountFromAuth: async () => ({ account_id: 'derived_acct' }),
+        mediaBuy: {
+          getProducts: async () => ({ products: [] }),
+        },
+      });
+      const result = await callToolRaw(server, 'get_products', {
+        buying_mode: 'brief',
+        brief: 'test',
+      });
+      assert.strictEqual(result.isError, true);
+      assert.strictEqual(result.structuredContent.adcp_error.code, 'VALIDATION_ERROR');
+      const issue = result.structuredContent.adcp_error.issues.find(i => i.pointer === '/cache_scope');
+      assert.ok(issue, `expected missing cache_scope issue, got: ${JSON.stringify(result.structuredContent)}`);
+    });
+
+    it('does not infer get_products cache_scope for account-scoped requests', async () => {
+      const server = createAdcpServer({
+        name: 'Test',
+        version: '1.0.0',
+        mediaBuy: {
+          getProducts: async () => ({ products: [] }),
+        },
+      });
+      const result = await callToolRaw(server, 'get_products', {
+        buying_mode: 'brief',
+        brief: 'test',
+        account: { account_id: 'acct_1' },
+      });
+      assert.strictEqual(result.isError, true);
+      assert.strictEqual(result.structuredContent.adcp_error.code, 'VALIDATION_ERROR');
+      const issue = result.structuredContent.adcp_error.issues.find(i => i.pointer === '/cache_scope');
+      assert.ok(issue, `expected missing cache_scope issue, got: ${JSON.stringify(result.structuredContent)}`);
+      assert.match(issue.hint ?? '', /public.*account-specific overlays/);
     });
 
     it('wraps create_media_buy with mediaBuyResponse defaults', async () => {
@@ -980,7 +1082,7 @@ describe('createAdcpServer', () => {
         mediaBuy: {
           getProducts: async (_params, ctx) => {
             assert.strictEqual(ctx.account.id, 'legacy-1');
-            return { products: [] };
+            return { products: [], cache_scope: 'account' };
           },
         },
       });

--- a/test/server-decisioning-comply-auto-seed.test.js
+++ b/test/server-decisioning-comply-auto-seed.test.js
@@ -43,7 +43,7 @@ function basePlatform({ getProducts } = {}) {
       }),
     },
     sales: {
-      getProducts: getProducts ?? (async () => ({ products: [] })),
+      getProducts: getProducts ?? (async () => ({ cache_scope: 'account', products: [] })),
       createMediaBuy: async () => ({
         media_buy_id: 'mb_1',
         status: 'pending_creatives',

--- a/test/server-decisioning-ctx-input-wire-envelope.test.js
+++ b/test/server-decisioning-ctx-input-wire-envelope.test.js
@@ -33,7 +33,7 @@ function basePlatform(overrides = {}) {
       list: async () => ({ items: [], nextCursor: null }),
     },
     sales: {
-      getProducts: async () => ({ products: [] }),
+      getProducts: async () => ({ cache_scope: 'account', products: [] }),
       createMediaBuy: async () => ({
         media_buy_id: 'mb_1',
         status: 'pending_creatives',
@@ -65,7 +65,7 @@ describe('ctx.input — un-destructured wire envelope on every v6 dispatch', () 
     let observedCtx;
     const platform = basePlatform({
       sales: {
-        getProducts: async () => ({ products: [] }),
+        getProducts: async () => ({ cache_scope: 'account', products: [] }),
         createMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
         updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
         syncCreatives: async (creatives, ctx) => {
@@ -155,7 +155,7 @@ describe('ctx.input — un-destructured wire envelope on every v6 dispatch', () 
     let observedCtx;
     const platform = basePlatform({
       sales: {
-        getProducts: async () => ({ products: [] }),
+        getProducts: async () => ({ cache_scope: 'account', products: [] }),
         createMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
         updateMediaBuy: async (buyId, patch, ctx) => {
           observedBuyId = buyId;
@@ -242,7 +242,7 @@ describe('ctx.input — un-destructured wire envelope on every v6 dispatch', () 
       sales: {
         getProducts: async (req, ctx) => {
           observedCtx = ctx;
-          return { products: [] };
+          return { cache_scope: 'account', products: [] };
         },
         createMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
         updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),

--- a/test/server-decisioning-from-platform.test.js
+++ b/test/server-decisioning-from-platform.test.js
@@ -49,6 +49,7 @@ function buildPlatform(overrides = {}) {
             pricing_options: [{ pricing_model: 'cpm', rate: 5.0, currency: 'USD' }],
           },
         ],
+        cache_scope: 'account',
       }),
       createMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
       updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
@@ -90,6 +91,7 @@ describe('createAdcpServerFromPlatform — v6.0 alpha', () => {
                 pricing_options: [{ pricing_model: 'cpm', rate: 1, currency: 'USD' }],
               },
             ],
+            cache_scope: 'account',
           };
         },
         createMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
@@ -121,6 +123,54 @@ describe('createAdcpServerFromPlatform — v6.0 alpha', () => {
     assert.ok(sawCtx.account, 'ctx.account should be populated from accounts.resolve');
     assert.strictEqual(typeof sawCtx.state.workflowSteps, 'function');
     assert.strictEqual(typeof sawCtx.resolve.creativeFormat, 'function');
+  });
+
+  it('fails closed for auth-derived get_products responses missing cache_scope', async () => {
+    let sawCtx;
+    const base = buildPlatform();
+    const platform = buildPlatform({
+      sales: {
+        ...base.sales,
+        getProducts: async (req, ctx) => {
+          sawCtx = ctx;
+          return {
+            products: [
+              {
+                product_id: 'p_auth_scoped',
+                name: 'auth scoped',
+                description: '',
+                format_ids: [{ id: 'standard', agent_url: 'https://example.com/mcp' }],
+                delivery_type: 'non_guaranteed',
+                publisher_properties: { reportable: true },
+                reporting_capabilities: { available_dimensions: ['geo'] },
+                pricing_options: [{ pricing_model: 'cpm', rate: 1, currency: 'USD' }],
+              },
+            ],
+          };
+        },
+      },
+    });
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'spike',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'strict' },
+    });
+    const result = await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'get_products',
+        arguments: {
+          buying_mode: 'brief',
+          brief: 'premium',
+        },
+      },
+    });
+
+    assert.ok(sawCtx?.account, 'auth-derived platform path should populate ctx.account before response defaults');
+    assert.strictEqual(result.isError, true);
+    assert.strictEqual(result.structuredContent.adcp_error.code, 'VALIDATION_ERROR');
+    const issue = result.structuredContent.adcp_error.issues.find(i => i.pointer === '/cache_scope');
+    assert.ok(issue, `expected missing cache_scope issue, got: ${JSON.stringify(result.structuredContent)}`);
   });
 
   it('catches AccountNotFoundError from accounts.resolve and returns ACCOUNT_NOT_FOUND envelope', async () => {
@@ -171,7 +221,7 @@ describe('SalesPlatform — full surface dispatch', () => {
       },
       statusMappers: {},
       sales: {
-        getProducts: async () => ({ products: [] }),
+        getProducts: async () => ({ products: [], cache_scope: 'account' }),
         createMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
         updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
         syncCreatives: async () => [],
@@ -577,7 +627,7 @@ describe('HITL dual-method dispatch — *Task variants', () => {
       statusMappers: {},
       sales: {
         // Default sync createMediaBuy; tests override with handoff variant.
-        getProducts: async () => ({ products: [] }),
+        getProducts: async () => ({ products: [], cache_scope: 'account' }),
         createMediaBuy: async () => ({ media_buy_id: 'mb_default' }),
         updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
         syncCreatives: async () => [],
@@ -800,7 +850,7 @@ describe('NODE_ENV gate on default in-memory task registry', () => {
       },
       statusMappers: {},
       sales: {
-        getProducts: async () => ({ products: [] }),
+        getProducts: async () => ({ products: [], cache_scope: 'account' }),
         createMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
         updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
         syncCreatives: async () => [],
@@ -931,7 +981,7 @@ describe('SalesPlatform optional methods (v1.0 gap-fill for rc.1)', () => {
     let sawCtx;
     const platform = buildPlatform({
       sales: {
-        getProducts: async () => ({ products: [] }),
+        getProducts: async () => ({ products: [], cache_scope: 'account' }),
         createMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
         updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
         syncCreatives: async () => [],
@@ -968,7 +1018,7 @@ describe('SalesPlatform optional methods (v1.0 gap-fill for rc.1)', () => {
         },
       },
       sales: {
-        getProducts: async () => ({ products: [] }),
+        getProducts: async () => ({ products: [], cache_scope: 'account' }),
         createMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
         updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
         syncCreatives: async () => [],
@@ -1014,7 +1064,7 @@ describe('SalesPlatform optional methods (v1.0 gap-fill for rc.1)', () => {
         }),
       },
       sales: {
-        getProducts: async () => ({ products: [] }),
+        getProducts: async () => ({ products: [], cache_scope: 'account' }),
         createMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
         updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
         syncCreatives: async () => [],
@@ -1684,6 +1734,7 @@ describe('Custom-handler merge seam (incremental migration)', () => {
               pricing_options: [{ pricing_model: 'cpm', rate: 1, currency: 'USD' }],
             },
           ],
+          cache_scope: 'account',
         }),
         createMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
         updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
@@ -1711,6 +1762,7 @@ describe('Custom-handler merge seam (incremental migration)', () => {
               pricing_options: [],
             },
           ],
+          cache_scope: 'account',
         }),
       },
     });
@@ -1792,7 +1844,7 @@ describe('SalesPlatform retail-media tools (M2)', () => {
     let received;
     const platform = buildPlatform({
       sales: {
-        getProducts: async () => ({ products: [] }),
+        getProducts: async () => ({ products: [], cache_scope: 'account' }),
         createMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
         updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
         syncCreatives: async () => [],
@@ -1836,7 +1888,7 @@ describe('SalesPlatform retail-media tools (M2)', () => {
         }),
       },
       sales: {
-        getProducts: async () => ({ products: [] }),
+        getProducts: async () => ({ products: [], cache_scope: 'account' }),
         createMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
         updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
         syncCreatives: async () => [],
@@ -1868,7 +1920,7 @@ describe('SalesPlatform retail-media tools (M2)', () => {
   it('syncEventSources dispatches via sales.syncEventSources', async () => {
     const platform = buildPlatform({
       sales: {
-        getProducts: async () => ({ products: [] }),
+        getProducts: async () => ({ products: [], cache_scope: 'account' }),
         createMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
         updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
         syncCreatives: async () => [],
@@ -1952,7 +2004,7 @@ describe('Merge-seam collision warning (M3)', () => {
     const warnings = [];
     const platform = buildPlatform({
       sales: {
-        getProducts: async () => ({ products: [] }),
+        getProducts: async () => ({ products: [], cache_scope: 'account' }),
         createMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
         updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
         syncCreatives: async () => [],
@@ -1982,7 +2034,7 @@ describe('Merge-seam collision warning (M3)', () => {
   it('throws PlatformConfigError on collision in strict mode', () => {
     const platform = buildPlatform({
       sales: {
-        getProducts: async () => ({ products: [] }),
+        getProducts: async () => ({ products: [], cache_scope: 'account' }),
         createMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
         updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
         syncCreatives: async () => [],
@@ -2012,7 +2064,7 @@ describe('Merge-seam collision warning (M3)', () => {
     function buildCollidingPlatform() {
       return buildPlatform({
         sales: {
-          getProducts: async () => ({ products: [] }),
+          getProducts: async () => ({ products: [], cache_scope: 'account' }),
           createMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
           updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
           syncCreatives: async () => [],
@@ -2053,7 +2105,7 @@ describe('Merge-seam collision warning (M3)', () => {
     const warnings = [];
     const platform = buildPlatform({
       sales: {
-        getProducts: async () => ({ products: [] }),
+        getProducts: async () => ({ products: [], cache_scope: 'account' }),
         createMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
         updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
         syncCreatives: async () => [],
@@ -2101,7 +2153,7 @@ describe('Observability hooks (DecisioningObservabilityHooks)', () => {
         }),
       },
       sales: {
-        getProducts: async () => ({ products: [] }),
+        getProducts: async () => ({ products: [], cache_scope: 'account' }),
         createMediaBuy: (_req, ctx) => ctx.handoffToTask(async () => taskFn()),
         updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
         syncCreatives: async () => [],
@@ -2150,7 +2202,7 @@ describe('Observability hooks (DecisioningObservabilityHooks)', () => {
         }),
       },
       sales: {
-        getProducts: async () => ({ products: [] }),
+        getProducts: async () => ({ products: [], cache_scope: 'account' }),
         createMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
         updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
         syncCreatives: async () => [],
@@ -2466,7 +2518,7 @@ describe('HITL push notification webhook on terminal state', () => {
         }),
       },
       sales: {
-        getProducts: async () => ({ products: [] }),
+        getProducts: async () => ({ products: [], cache_scope: 'account' }),
         createMediaBuy: (_req, ctx) => ctx.handoffToTask(async () => taskFn()),
         updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
         syncCreatives: async () => [],
@@ -2630,7 +2682,7 @@ describe('Push notification webhook URL/token validation (B5/B6)', () => {
         }),
       },
       sales: {
-        getProducts: async () => ({ products: [] }),
+        getProducts: async () => ({ products: [], cache_scope: 'account' }),
         createMediaBuy: (_req, ctx) => ctx.handoffToTask(async () => taskFn()),
         updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
         syncCreatives: async () => [],
@@ -2811,7 +2863,7 @@ describe('tasks_get wire tool (B9)', () => {
         }),
       },
       sales: {
-        getProducts: async () => ({ products: [] }),
+        getProducts: async () => ({ products: [], cache_scope: 'account' }),
         createMediaBuy: (_req, ctx) => ctx.handoffToTask(async () => taskFn()),
         updateMediaBuy: async () => ({ media_buy_id: 'mb_42' }),
         syncCreatives: async () => [],
@@ -2919,7 +2971,7 @@ describe('tasks_get wire tool (B9)', () => {
           }),
         },
         sales: {
-          getProducts: async () => ({ products: [] }),
+          getProducts: async () => ({ products: [], cache_scope: 'account' }),
           createMediaBuy: (req, ctx) => ctx.handoffToTask(async () => ({ media_buy_id: 'mb_42' })),
           updateMediaBuy: async () => ({ media_buy_id: 'mb_42' }),
           syncCreatives: async () => [],
@@ -2967,7 +3019,7 @@ describe('tasks_get wire tool (B9)', () => {
           },
         },
         sales: {
-          getProducts: async () => ({ products: [] }),
+          getProducts: async () => ({ products: [], cache_scope: 'account' }),
           createMediaBuy: (req, ctx) => ctx.handoffToTask(async () => ({ media_buy_id: 'mb_42', status: 'active' })),
           updateMediaBuy: async () => ({ media_buy_id: 'mb_42' }),
           syncCreatives: async () => [],
@@ -3023,7 +3075,7 @@ describe('getTaskState account-scoping (B7)', () => {
         }),
       },
       sales: {
-        getProducts: async () => ({ products: [] }),
+        getProducts: async () => ({ products: [], cache_scope: 'account' }),
         createMediaBuy: (req, ctx) => ctx.handoffToTask(async () => ({ media_buy_id: 'mb_42' })),
         updateMediaBuy: async () => ({ media_buy_id: 'mb_42' }),
         syncCreatives: async () => [],
@@ -3184,7 +3236,7 @@ describe('validatePlatform', () => {
     // the specialism declaration matches the implemented interfaces.
     const platform = buildPlatform({
       sales: {
-        getProducts: async () => ({ products: [] }),
+        getProducts: async () => ({ products: [], cache_scope: 'account' }),
         createMediaBuy: (req, ctx) => ctx.handoffToTask(async () => ({ media_buy_id: 'mb_1' })),
         updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
         syncCreatives: async () => [],
@@ -3378,7 +3430,7 @@ describe('createAdcpServerFromPlatform — default resolveIdempotencyPrincipal',
         }),
       },
       sales: {
-        getProducts: async () => ({ products: [] }),
+        getProducts: async () => ({ products: [], cache_scope: 'account' }),
         createMediaBuy: async () => ({
           media_buy_id: 'mb_1',
           status: 'pending_creatives',
@@ -3457,7 +3509,7 @@ describe('signed-requests specialism forwarding (#1886)', () => {
       },
       statusMappers: {},
       sales: {
-        getProducts: async () => ({ products: [] }),
+        getProducts: async () => ({ products: [], cache_scope: 'account' }),
         createMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
         updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
         syncCreatives: async () => [],

--- a/test/server-decisioning-implicit-account-id.test.js
+++ b/test/server-decisioning-implicit-account-id.test.js
@@ -33,6 +33,7 @@ function buildImplicitPlatform(overrides = {}) {
     statusMappers: {},
     sales: {
       getProducts: async () => ({
+        cache_scope: 'account',
         products: [
           {
             product_id: 'p1',

--- a/test/server-responses.test.js
+++ b/test/server-responses.test.js
@@ -25,6 +25,7 @@ const {
   cancelMediaBuyResponse,
 } = require('../dist/lib/server/responses');
 const { validActionsForStatus } = require('../dist/lib/server/media-buy-helpers');
+const { validateResponse } = require('../dist/lib/validation/schema-validator');
 
 describe('capabilitiesResponse', () => {
   it('returns MCP-compatible shape with structuredContent', () => {
@@ -73,10 +74,23 @@ describe('productsResponse', () => {
     assert.strictEqual(result.content[0].text, 'Found 0 products');
   });
 
-  it('does not default cache_scope when omitted', () => {
+  it('describes unchanged wholesale-feed responses without a zero-product summary', () => {
+    const result = productsResponse({ unchanged: true, wholesale_feed_version: 'wf_v1', cache_scope: 'public' });
+    assert.strictEqual(result.content[0].text, 'Product feed unchanged');
+  });
+
+  it('leaves cache_scope unset for plain JS direct builder callers', () => {
     const result = productsResponse({ products: [{ product_id: 'p1' }] });
     assert.strictEqual(result.structuredContent.status, 'completed');
     assert.strictEqual(result.structuredContent.cache_scope, undefined);
+  });
+
+  it('runtime validation catches plain JS direct callers that omit cache_scope with products', () => {
+    const result = productsResponse({ products: [] });
+    const outcome = validateResponse('get_products', result.structuredContent);
+    assert.strictEqual(outcome.valid, false);
+    const issue = outcome.issues.find(i => i.pointer === '/cache_scope' && i.keyword === 'required');
+    assert.ok(issue, `expected missing cache_scope, got: ${JSON.stringify(outcome.issues)}`);
   });
 });
 

--- a/test/testing-personas.test.js
+++ b/test/testing-personas.test.js
@@ -122,7 +122,7 @@ describe('Personas — end-to-end against a DecisioningPlatform', () => {
           observed.brief = req.brief;
           observed.brand_domain = req.brand?.domain;
           observed.account_id = ctx.account?.id;
-          return { products: [] };
+          return { cache_scope: 'account', products: [] };
         },
         createMediaBuy: async () => ({
           media_buy_id: 'mb_1',


### PR DESCRIPTION
## Summary
- make `get_products` server payload aliases and `productsResponse()` require `cache_scope` whenever `products` is present
- make framework defaulting protocol-safe by inferring `public` only when there is no inline account and no auth-derived/resolved account
- stop sandbox/test-controller seeded merges from masking account-scoped cache-scope omissions
- add strict response validation, validation hints, migration docs, generated agent-doc caveats, and beta install guidance

## Why
DX and protocol review flagged that beta.11 was close but still allowed adopters to compile or normalize invalid 3.1 payloads. The main risk was account-specific product/pricing overlays being silently labeled as public cacheable responses.

## Validation
- `npm run build:lib`
- `npm run typecheck`
- focused server/validation tests
- `npm test`
- `npm run check:adopter-types`
- `npm run generate-agent-docs`
- `npm run ci:docs-check`
- `git diff --check`