### PR TITLE
fix: handle A2A artifact domain statuses

### DIFF
--- a/.changeset/a2a-artifact-domain-status.md
+++ b/.changeset/a2a-artifact-domain-status.md
@@ -1,0 +1,5 @@
+---
+"@adcp/sdk": patch
+---
+
+Disambiguate A2A artifact `status` fields so domain payloads like `update_media_buy` returning `status: "canceled"` are treated as completed tool responses, not task lifecycle cancellations. Parser, validator, task polling, and signing discovery logic now consistently read the latest structured DataPart.

--- a/src/lib/core/ProtocolResponseParser.ts
+++ b/src/lib/core/ProtocolResponseParser.ts
@@ -4,6 +4,7 @@
  */
 
 import type { InputRequest } from './ConversationTypes';
+import { getLatestA2ADataPartFromTask } from '../utils/a2a-artifacts';
 
 /**
  * ADCP standardized status values as per spec PR #78
@@ -33,7 +34,8 @@ export type ADCPStatus = (typeof ADCP_STATUS)[keyof typeof ADCP_STATUS];
  * `errors` / `context` / `ext` fields that AdCP task-response schemas place at
  * envelope level. Used to disambiguate `structuredContent.status` from AdCP v3
  * domain status enums (MediaBuyStatus, CreativeStatus, etc.) that share
- * literals like `completed` / `canceled` / `failed` / `rejected` — see #646.
+ * literals like `completed` / `canceled` / `failed` / `rejected` — see #646
+ * and #2009.
  */
 const TASK_ENVELOPE_FIELDS: ReadonlySet<string> = new Set([
   'status',
@@ -52,7 +54,8 @@ const TASK_ENVELOPE_FIELDS: ReadonlySet<string> = new Set([
 
 /**
  * ADCP task-lifecycle statuses that never overlap with AdCP domain status
- * enums and can be trusted from `structuredContent.status` unconditionally.
+ * enums and can be trusted from `structuredContent.status` or A2A DataPart
+ * `status` unconditionally.
  * The other literals (`completed` / `canceled` / `failed` / `rejected`) share
  * values with `MediaBuyStatus` et al and require envelope-shape disambiguation.
  */
@@ -89,11 +92,18 @@ function isSafeSessionId(v: unknown): v is string {
 
 /**
  * Extract the AdCP work-layer status from an A2A wrapped Task result,
- * if present. The AdCP `submitted` / `working` / `completed` lifecycle
- * lives on `artifact.parts[0].data.status` (per adcp-client#899's
- * two-lifecycle contract); the transport-layer `result.status.state`
- * tracks the HTTP-call lifecycle and is `'completed'` for AdCP
- * submitted arms.
+ * if present. Exclusive AdCP task statuses (`submitted` / `working` /
+ * `input-required` / `auth-required`) live on the latest structured DataPart
+ * `status` (per adcp-client#899's two-lifecycle contract); the transport-layer
+ * `result.status.state` tracks the HTTP-call lifecycle and is `'completed'`
+ * for AdCP submitted arms.
+ *
+ * Shared literals (`completed` / `canceled` / `failed` / `rejected`) are
+ * ambiguous in A2A artifact data because domain payloads also have a
+ * `status` field. A completed `update_media_buy` task can return
+ * `{ media_buy_id, status: "canceled" }`; that means the media buy was
+ * canceled, not the A2A task. Use the same envelope-shape guard as MCP
+ * structuredContent. See issue #2009.
  *
  * Returns `undefined` for non-AdCP A2A responses (no artifact, no
  * DataPart, or `data.status` not in the AdCP enum) so callers can
@@ -102,18 +112,18 @@ function isSafeSessionId(v: unknown): v is string {
 function extractAdcpStatusFromA2aTaskResult(result: any): ADCPStatus | undefined {
   if (result == null || typeof result !== 'object' || Array.isArray(result)) return undefined;
   if (result.kind !== 'task') return undefined;
-  const artifacts = result.artifacts;
-  if (!Array.isArray(artifacts) || artifacts.length === 0) return undefined;
-  const artifact = artifacts[0];
-  if (artifact == null || typeof artifact !== 'object') return undefined;
-  const parts = artifact.parts;
-  if (!Array.isArray(parts) || parts.length === 0) return undefined;
-  const firstPart = parts[0];
-  if (firstPart == null || typeof firstPart !== 'object' || firstPart.kind !== 'data') return undefined;
-  const data = firstPart.data;
-  if (data == null || typeof data !== 'object' || Array.isArray(data)) return undefined;
-  const status = (data as Record<string, unknown>).status;
+  const extracted = getLatestA2ADataPartFromTask(result);
+  if (!extracted) return undefined;
+  const data = extracted.data;
+  const status = data.status;
   if (typeof status === 'string' && (Object.values(ADCP_STATUS) as string[]).includes(status)) {
+    if (EXCLUSIVE_TASK_STATUSES.has(status)) {
+      return status as ADCPStatus;
+    }
+    const hasDomainPayload = Object.keys(data).some(k => !TASK_ENVELOPE_FIELDS.has(k));
+    if (hasDomainPayload) {
+      return undefined;
+    }
     return status as ADCPStatus;
   }
   return undefined;
@@ -121,21 +131,25 @@ function extractAdcpStatusFromA2aTaskResult(result: any): ADCPStatus | undefined
 
 /**
  * Extract the AdCP task handle from an A2A wrapped Task result. The
- * handle lives on `artifact.metadata.adcp_task_id` (per
- * adcp-client#899). Returns `undefined` for non-AdCP A2A responses or
- * when the metadata extension wasn't emitted, so callers fall back
- * to the transport-layer `result.id`.
+ * handle lives on artifact `metadata.adcp_task_id` (per adcp-client#899).
+ * Walk artifacts backward so trailing text-only artifacts with metadata still
+ * win, while responses with metadata only on the latest DataPart-bearing
+ * artifact continue to work.
  */
 function extractAdcpTaskIdFromA2aTaskResult(result: any): string | undefined {
   if (result == null || typeof result !== 'object' || Array.isArray(result)) return undefined;
   if (result.kind !== 'task') return undefined;
   const artifacts = result.artifacts;
-  if (!Array.isArray(artifacts) || artifacts.length === 0) return undefined;
-  const artifact = artifacts[0];
-  if (artifact == null || typeof artifact !== 'object') return undefined;
-  const metadata = artifact.metadata;
-  if (metadata == null || typeof metadata !== 'object' || Array.isArray(metadata)) return undefined;
-  return firstSafeSessionId((metadata as Record<string, unknown>).adcp_task_id);
+  if (!Array.isArray(artifacts)) return undefined;
+  for (let i = artifacts.length - 1; i >= 0; i -= 1) {
+    const artifact = artifacts[i];
+    if (artifact == null || typeof artifact !== 'object' || Array.isArray(artifact)) continue;
+    const metadata = (artifact as { metadata?: unknown }).metadata;
+    if (metadata == null || typeof metadata !== 'object' || Array.isArray(metadata)) continue;
+    const taskId = firstSafeSessionId((metadata as Record<string, unknown>).adcp_task_id);
+    if (taskId) return taskId;
+  }
+  return undefined;
 }
 
 /** Return the first argument that passes {@link isSafeSessionId}, else `undefined`. */

--- a/src/lib/core/ResponseValidator.ts
+++ b/src/lib/core/ResponseValidator.ts
@@ -9,6 +9,7 @@ import { z } from 'zod';
 import { getBestUnionErrors } from '../utils/union-errors';
 import { TOOL_RESPONSE_SCHEMAS } from '../utils/response-schemas';
 import { injectLegacyEnvelopeStatus } from '../utils/envelope-status-compat';
+import { getLatestA2ADataPartFromResponse } from '../utils/a2a-artifacts';
 
 export interface ValidationResult {
   valid: boolean;
@@ -174,31 +175,32 @@ export class ResponseValidator {
       return;
     }
 
-    // Validate first artifact structure
-    const firstArtifact = response.result.artifacts[0];
-    if (!firstArtifact.parts) {
+    // Validate latest artifact structure. A2A conversational tasks append
+    // artifacts over time, and the final artifact is authoritative.
+    const latestArtifact = response.result.artifacts[response.result.artifacts.length - 1];
+    if (!latestArtifact || typeof latestArtifact !== 'object') {
+      errors.push('A2A response must have at least one artifact');
+      return;
+    }
+
+    if (!latestArtifact.parts) {
       errors.push('A2A artifact missing parts field');
       return;
     }
 
-    if (!Array.isArray(firstArtifact.parts)) {
+    if (!Array.isArray(latestArtifact.parts)) {
       errors.push('A2A artifact.parts must be an array');
       return;
     }
 
-    if (firstArtifact.parts.length === 0) {
+    if (latestArtifact.parts.length === 0) {
       warnings.push('A2A artifact parts array is empty');
       return;
     }
 
-    // Validate first part
-    const firstPart = firstArtifact.parts[0];
-    if (!firstPart.kind && !firstPart.type) {
-      warnings.push('A2A part missing kind/type field');
-    }
-
-    if (!firstPart.data) {
-      warnings.push('A2A part missing data field');
+    const hasDataPart = getLatestA2ADataPartFromResponse(response) !== undefined;
+    if (!hasDataPart) {
+      warnings.push('A2A artifact missing DataPart with data field');
     }
   }
 
@@ -218,7 +220,7 @@ export class ResponseValidator {
     if (protocol === 'mcp') {
       data = response.structuredContent;
     } else if (protocol === 'a2a') {
-      data = response.result?.artifacts?.[0]?.parts?.[0]?.data;
+      data = getLatestA2ADataPartFromResponse(response)?.data;
     } else {
       data = response.data || response;
     }
@@ -249,8 +251,9 @@ export class ResponseValidator {
       }
     }
 
-    if (protocol === 'a2a' && response.result?.artifacts?.[0]?.parts?.[0]?.data) {
-      const data = response.result.artifacts[0].parts[0].data;
+    if (protocol === 'a2a') {
+      const data = getLatestA2ADataPartFromResponse(response)?.data;
+      if (!data) return;
       const keys = Object.keys(data);
       if (keys.length === 0) {
         warnings.push('A2A data is empty object');
@@ -302,7 +305,7 @@ export class ResponseValidator {
     if (protocol === 'mcp') {
       return response.structuredContent;
     } else if (protocol === 'a2a') {
-      return response.result?.artifacts?.[0]?.parts?.[0]?.data;
+      return getLatestA2ADataPartFromResponse(response)?.data;
     } else {
       return response.data || response;
     }

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -22,6 +22,7 @@ import { extractAdcpErrorInfo, extractCorrelationId } from '../utils/error-extra
 import { generateIdempotencyKey, isMutatingTask, redactIdempotencyKeyInArgs } from '../utils/idempotency';
 import { normalizeGetProductsResponse } from '../utils/pricing-adapter';
 import { normalizeLegacyMediaBuyStatusForReturn } from '../utils/envelope-status-compat';
+import { getLatestA2ADataPartFromResponse } from '../utils/a2a-artifacts';
 import { cancelA2ATask } from '../protocols/a2a';
 import type {
   Message,
@@ -105,7 +106,7 @@ function mapTasksGetResponseToTaskInfo(payload: unknown): TaskInfo {
   const obj = payload as Record<string, unknown>;
   // Walk the transport-level wrappers in priority order:
   //   1. MCP `structuredContent` — the typed AdCP payload from `tools/call`
-  //   2. A2A `result.artifacts[0].parts[0].data` — the AdCP payload
+  //   2. A2A latest structured DataPart — the AdCP payload
   //      surfaced via the artifact (per #899)
   //   3. Legacy nested `{ task: TaskInfo }` — pre-3.0 sellers and
   //      existing test mocks
@@ -174,25 +175,14 @@ function unwrapTasksGetEnvelope(obj: Record<string, unknown>, depth = 0): Record
     return unwrapTasksGetEnvelope(sc as Record<string, unknown>, depth + 1);
   }
   // A2A: `message/send` response is a JSON-RPC envelope wrapping a
-  // Task; the AdCP payload sits on the first artifact's first
-  // DataPart.
+  // Task; the AdCP payload sits on the latest structured DataPart.
   const result = obj.result;
   if (result != null && typeof result === 'object' && !Array.isArray(result)) {
     const r = result as Record<string, unknown>;
     if (r.kind === 'task') {
-      if (Array.isArray(r.artifacts) && r.artifacts.length > 0) {
-        const artifact = r.artifacts[0] as Record<string, unknown> | null;
-        if (
-          artifact != null &&
-          typeof artifact === 'object' &&
-          Array.isArray(artifact.parts) &&
-          artifact.parts.length > 0
-        ) {
-          const firstPart = artifact.parts[0] as Record<string, unknown> | null;
-          if (firstPart?.kind === 'data' && firstPart.data != null && typeof firstPart.data === 'object') {
-            return unwrapTasksGetEnvelope(firstPart.data as Record<string, unknown>, depth + 1);
-          }
-        }
+      const extracted = getLatestA2ADataPartFromResponse(obj);
+      if (extracted) {
+        return unwrapTasksGetEnvelope(extracted.data, depth + 1);
       }
       // adcp-client#1612: When the A2A Task has no DataPart artifacts (e.g. the
       // seller returns an A2A transport-level state without an AdCP DataPart
@@ -959,9 +949,9 @@ export class TaskExecutor {
             return sum + (artifact.parts?.length || 0);
           }, 0);
 
-          // Extract data keys from first part for debugging
-          const firstPart = artifacts[0]?.parts?.[0];
-          const dataKeys = firstPart?.data ? Object.keys(firstPart.data) : [];
+          // Extract canonical DataPart keys for debugging.
+          const latestDataPart = getLatestA2ADataPartFromResponse(response);
+          const dataKeys = latestDataPart?.data ? Object.keys(latestDataPart.data) : [];
 
           this.logDebug(debugLogs, 'info', 'Processing A2A artifact structure', {
             artifactCount: artifacts.length,
@@ -1422,7 +1412,7 @@ export class TaskExecutor {
     // request rejection), so we map the raw response directly. The
     // mapper handles the AdCP-spec flat shape, the legacy
     // `{ task: ... }` nested wrapper, and MCP `structuredContent` /
-    // A2A `result.artifacts[0].parts[0].data` envelopes.
+    // A2A latest structured DataPart envelopes.
     return mapTasksGetResponseToTaskInfo(response);
   }
 

--- a/src/lib/protocols/a2a.ts
+++ b/src/lib/protocols/a2a.ts
@@ -19,6 +19,7 @@ import type { AgentConfig } from '../types/adcp';
 import { redactIdempotencyKeyInArgs } from '../utils/idempotency';
 import { wrapFetchWithCapture } from './rawResponseCapture';
 import { wrapFetchWithSizeLimit } from './responseSizeLimit';
+import { getLatestA2ADataPartFromResponse } from '../utils/a2a-artifacts';
 
 if (!A2AClient) {
   throw new Error('A2A SDK client is required. Please install @a2a-js/sdk');
@@ -408,18 +409,7 @@ function hasTerminalTaskWithDataArtifact(response: unknown): boolean {
   if (r.kind !== 'task') return false;
   const status = r.status as { state?: unknown } | undefined;
   if (typeof status?.state !== 'string' || !TERMINAL_A2A_STATES.has(status.state)) return false;
-  if (!Array.isArray(r.artifacts) || r.artifacts.length === 0) return false;
-  for (const artifact of r.artifacts) {
-    if (!artifact || typeof artifact !== 'object') continue;
-    const parts = (artifact as { parts?: unknown }).parts;
-    if (!Array.isArray(parts)) continue;
-    for (const part of parts) {
-      if (!part || typeof part !== 'object') continue;
-      const p = part as { kind?: unknown; data?: unknown };
-      if (p.kind === 'data' && p.data && typeof p.data === 'object') return true;
-    }
-  }
-  return false;
+  return getLatestA2ADataPartFromResponse(response) !== undefined;
 }
 
 /**

--- a/src/lib/signing/protocol-response.ts
+++ b/src/lib/signing/protocol-response.ts
@@ -6,14 +6,16 @@
  *
  *   - MCP `CallToolResult` — `structuredContent` wins when present;
  *     otherwise the first `content[].text` chunk is parsed as JSON.
- *   - A2A JSON-RPC `SendMessageResponse` — `result` is a `Task` (with
- *     `artifacts[].parts[].data`) or a `Message` (with `parts[].data`).
+ *   - A2A JSON-RPC `SendMessageResponse` — `result` is a `Task` or `Message`
+ *     with latest structured DataPart data.
  *   - Already-unwrapped payload — returned as-is.
  *
  * Lives in its own module so the two callers (`capability-priming` and
  * `agent-resolver`) share one source of truth instead of forking the
  * envelope walk.
  */
+
+import { getLatestA2ADataPartFromTask } from '../utils/a2a-artifacts';
 
 export function unwrapProtocolResponse(response: unknown): unknown {
   if (!response || typeof response !== 'object') return response;
@@ -36,25 +38,23 @@ export function unwrapProtocolResponse(response: unknown): unknown {
 
   const result = r.result;
   if (result && typeof result === 'object') {
-    const artifacts = (result as Record<string, unknown>).artifacts;
-    if (Array.isArray(artifacts)) {
-      for (const artifact of artifacts) {
-        const parts = (artifact as { parts?: unknown }).parts;
-        const data = findFirstDataPart(parts);
-        if (data) return data;
-      }
+    const artifactData = getLatestA2ADataPartFromTask(result)?.data;
+    if (artifactData) {
+      return artifactData;
     }
+
     const parts = (result as { parts?: unknown }).parts;
-    const data = findFirstDataPart(parts);
+    const data = findLatestDataPart(parts);
     if (data) return data;
   }
 
   return response;
 }
 
-function findFirstDataPart(parts: unknown): unknown {
+function findLatestDataPart(parts: unknown): unknown {
   if (!Array.isArray(parts)) return undefined;
-  for (const part of parts) {
+  for (let i = parts.length - 1; i >= 0; i -= 1) {
+    const part = parts[i];
     if (part && typeof part === 'object') {
       const p = part as { kind?: unknown; data?: unknown };
       if (p.kind === 'data' && p.data && typeof p.data === 'object') return p.data;

--- a/src/lib/utils/a2a-artifacts.ts
+++ b/src/lib/utils/a2a-artifacts.ts
@@ -1,0 +1,50 @@
+/**
+ * Shared A2A artifact extraction helpers.
+ *
+ * A2A conversational tasks append artifacts over time. The SDK's canonical
+ * data path is the latest DataPart found by walking artifacts backward, then
+ * parts backward. Trailing text-only artifacts can carry explanatory copy, but
+ * they must not hide the latest structured AdCP payload.
+ */
+
+export interface A2ADataPartExtraction {
+  artifact: Record<string, unknown>;
+  part: Record<string, unknown>;
+  data: Record<string, unknown>;
+}
+
+export function getLatestA2ADataPartFromTask(result: unknown): A2ADataPartExtraction | undefined {
+  if (result == null || typeof result !== 'object' || Array.isArray(result)) return undefined;
+
+  const artifacts = (result as { artifacts?: unknown }).artifacts;
+  if (!Array.isArray(artifacts) || artifacts.length === 0) return undefined;
+
+  for (let artifactIndex = artifacts.length - 1; artifactIndex >= 0; artifactIndex -= 1) {
+    const artifact = artifacts[artifactIndex];
+    if (artifact == null || typeof artifact !== 'object' || Array.isArray(artifact)) continue;
+
+    const parts = (artifact as { parts?: unknown }).parts;
+    if (!Array.isArray(parts) || parts.length === 0) continue;
+
+    for (let partIndex = parts.length - 1; partIndex >= 0; partIndex -= 1) {
+      const part = parts[partIndex];
+      if (part == null || typeof part !== 'object' || Array.isArray(part)) continue;
+      const record = part as Record<string, unknown>;
+      if (record.kind !== 'data') continue;
+      const data = record.data;
+      if (data == null || typeof data !== 'object' || Array.isArray(data)) continue;
+      return {
+        artifact: artifact as Record<string, unknown>,
+        part: record,
+        data: data as Record<string, unknown>,
+      };
+    }
+  }
+
+  return undefined;
+}
+
+export function getLatestA2ADataPartFromResponse(response: unknown): A2ADataPartExtraction | undefined {
+  if (response == null || typeof response !== 'object' || Array.isArray(response)) return undefined;
+  return getLatestA2ADataPartFromTask((response as { result?: unknown }).result);
+}

--- a/src/lib/utils/response-unwrapper.ts
+++ b/src/lib/utils/response-unwrapper.ts
@@ -34,6 +34,7 @@ import type {
 } from '../types/tools.generated';
 import { TOOL_RESPONSE_SCHEMAS } from './response-schemas';
 import { injectLegacyEnvelopeStatus, normalizeLegacyMediaBuyStatusForReturn } from './envelope-status-compat';
+import { getLatestA2ADataPartFromResponse } from './a2a-artifacts';
 
 /**
  * Typed error thrown when the response unwrapper's Zod schema rejects an
@@ -497,18 +498,7 @@ function hasTerminalTaskWithDataArtifact(response: unknown): boolean {
   if (r.kind !== 'task') return false;
   const status = r.status as { state?: unknown } | undefined;
   if (typeof status?.state !== 'string' || !TERMINAL_A2A_STATES.has(status.state)) return false;
-  if (!Array.isArray(r.artifacts) || r.artifacts.length === 0) return false;
-  for (const artifact of r.artifacts) {
-    if (!artifact || typeof artifact !== 'object') continue;
-    const parts = (artifact as { parts?: unknown }).parts;
-    if (!Array.isArray(parts)) continue;
-    for (const part of parts) {
-      if (!part || typeof part !== 'object') continue;
-      const p = part as { kind?: unknown; data?: unknown };
-      if (p.kind === 'data' && p.data && typeof p.data === 'object') return true;
-    }
-  }
-  return false;
+  return getLatestA2ADataPartFromResponse(response) !== undefined;
 }
 
 function unwrapA2AResponse(response: any): AdCPResponse {
@@ -554,29 +544,29 @@ function unwrapA2AResponse(response: any): AdCPResponse {
     throw new Error('A2A response must have at least one artifact');
   }
 
-  // Take last artifact (conversational protocols append artifacts over time)
-  // Note: A2A artifacts don't have a status field - only Tasks have status.
   const artifact = artifacts[artifacts.length - 1];
-  if (!artifact) {
+  if (!artifact || typeof artifact !== 'object' || Array.isArray(artifact)) {
     throw new Error('A2A response must have at least one artifact');
   }
 
-  if (!artifact.parts || !Array.isArray(artifact.parts)) {
+  if (!('parts' in artifact) || !Array.isArray((artifact as { parts?: unknown }).parts)) {
     throw new Error('A2A artifact missing parts array');
   }
 
-  // Extract DataPart (required) and TextParts (optional)
-  // Get last data part to be consistent with taking last artifact in conversational protocol
-  const dataParts = artifact.parts.filter((p: any) => p.kind === 'data');
-  const dataPart = dataParts[dataParts.length - 1];
-  if (!dataPart?.data) {
+  // Extract DataPart (required) and TextParts (optional). Use the shared
+  // latest structured DataPart helper so parser and validator agree.
+  const extracted = getLatestA2ADataPartFromResponse(response);
+  if (!extracted) {
     throw new Error('A2A response must have a DataPart with AdCP data');
   }
 
-  const textParts = artifact.parts.filter((p: any) => p.kind === 'text' && p.text).map((p: any) => p.text);
+  const parts = (artifact as { parts: unknown[] }).parts;
+  const textParts = parts
+    .filter((p: any) => p && typeof p === 'object' && p.kind === 'text' && p.text)
+    .map((p: any) => p.text);
 
   // Unwrap nested response field if present (some agents wrap AdCP responses)
-  let data = dataPart.data;
+  let data: any = extracted.data;
   if (data?.response && typeof data.response === 'object' && !Array.isArray(data.response)) {
     data = data.response;
   }

--- a/test/lib/poll-task-completion-terminal-states.test.js
+++ b/test/lib/poll-task-completion-terminal-states.test.js
@@ -103,6 +103,62 @@ describe('pollTaskCompletion terminal state handling', () => {
     assert.strictEqual(result.data.media_buy_status, 'pending_creatives');
   });
 
+  test('tasks/get A2A envelope uses latest artifact result, not stale first artifact', async () => {
+    ProtocolClient.callTool = mock.fn(async () => ({
+      result: {
+        kind: 'task',
+        id: 'a2a-task-id',
+        status: { state: 'completed' },
+        artifacts: [
+          {
+            artifactId: 'stale',
+            parts: [
+              {
+                kind: 'data',
+                data: {
+                  task_id: 'task-latest-artifact',
+                  task_type: 'create_media_buy',
+                  status: 'completed',
+                  result: {
+                    media_buy_id: 'mb_stale',
+                    status: 'pending_creatives',
+                    packages: [],
+                  },
+                },
+              },
+            ],
+          },
+          {
+            artifactId: 'final',
+            parts: [
+              {
+                kind: 'data',
+                data: {
+                  task_id: 'task-latest-artifact',
+                  task_type: 'create_media_buy',
+                  status: 'completed',
+                  result: {
+                    media_buy_id: 'mb_latest',
+                    status: 'active',
+                    packages: [],
+                  },
+                },
+              },
+            ],
+          },
+        ],
+      },
+    }));
+
+    const executor = new TaskExecutor();
+    const result = await executor.pollTaskCompletion(mockAgent, 'task-latest-artifact', 10);
+
+    assert.strictEqual(result.success, true);
+    assert.strictEqual(result.status, 'completed');
+    assert.strictEqual(result.data.media_buy_id, 'mb_latest');
+    assert.strictEqual(result.data.status, 'active');
+  });
+
   test('does not add synthetic status to completed task result with media_buy_status only', async () => {
     ProtocolClient.callTool = mock.fn(async () => ({
       task: {

--- a/test/lib/protocol-response-parser-a2a-submitted.test.js
+++ b/test/lib/protocol-response-parser-a2a-submitted.test.js
@@ -23,10 +23,10 @@
 // branch. `getTaskId` returned the A2A Task.id (which the seller's
 // AdCP `tasks/get` tool would not recognize).
 
-const { test, describe } = require('node:test');
+const { test, describe, beforeEach, afterEach, mock } = require('node:test');
 const assert = require('node:assert');
 
-const { ProtocolResponseParser, ADCP_STATUS } = require('../../dist/lib/index.js');
+const { ProtocolResponseParser, ADCP_STATUS, TaskExecutor, ProtocolClient } = require('../../dist/lib/index.js');
 
 const parser = new ProtocolResponseParser();
 
@@ -52,6 +52,25 @@ function a2aWrappedSubmittedResponse({ adcpTaskId = 'tk_X', a2aTaskId = 'a2a-uui
             },
           ],
           metadata: { adcp_task_id: adcpTaskId },
+        },
+      ],
+    },
+  };
+}
+
+function a2aWrappedCompletedArtifactData(data) {
+  return {
+    jsonrpc: '2.0',
+    id: 1,
+    result: {
+      kind: 'task',
+      id: 'a2a-uuid',
+      contextId: 'ctx-uuid',
+      status: { state: 'completed', timestamp: '2026-05-26T00:00:00Z' },
+      artifacts: [
+        {
+          artifactId: 'art-uuid',
+          parts: [{ kind: 'data', data }],
         },
       ],
     },
@@ -120,6 +139,81 @@ describe('ProtocolResponseParser.getStatus — A2A submitted arm (#973)', () => 
   });
 });
 
+describe('ProtocolResponseParser.getStatus — A2A artifact domain status collision (#2009)', () => {
+  test('domain payload status="canceled" falls back to completed transport state', () => {
+    const response = a2aWrappedCompletedArtifactData({
+      media_buy_id: 'mb_canceled',
+      status: 'canceled',
+      affected_packages: [],
+      context: { correlation_id: 'corr-1' },
+    });
+    assert.strictEqual(parser.getStatus(response), ADCP_STATUS.COMPLETED);
+  });
+
+  for (const status of ['failed', 'rejected']) {
+    test(`domain payload status="${status}" falls back to completed transport state`, () => {
+      const response = a2aWrappedCompletedArtifactData({
+        creative_id: `cr_${status}`,
+        status,
+        review_feedback: 'Domain object status, not task lifecycle status',
+      });
+
+      assert.strictEqual(parser.getStatus(response), ADCP_STATUS.COMPLETED);
+    });
+  }
+
+  test('envelope-only artifact status="canceled" remains a task cancellation', () => {
+    const response = a2aWrappedCompletedArtifactData({
+      status: 'canceled',
+      message: 'Task canceled by caller',
+      task_id: 'tk_canceled',
+    });
+    assert.strictEqual(parser.getStatus(response), ADCP_STATUS.CANCELED);
+  });
+
+  test('exclusive task status wins even when other fields are present', () => {
+    const response = a2aWrappedCompletedArtifactData({
+      status: 'submitted',
+      media_buy_id: 'mb_async',
+      task_id: 'tk_submitted',
+    });
+    assert.strictEqual(parser.getStatus(response), ADCP_STATUS.SUBMITTED);
+  });
+
+  test('uses latest artifact status, not stale first artifact status', () => {
+    const response = a2aWrappedCompletedArtifactData({
+      status: 'submitted',
+      task_id: 'tk_stale',
+    });
+    response.result.artifacts.push({
+      artifactId: 'art-final',
+      parts: [
+        {
+          kind: 'data',
+          data: {
+            media_buy_id: 'mb_canceled',
+            status: 'canceled',
+            affected_packages: [],
+          },
+        },
+      ],
+    });
+
+    assert.strictEqual(parser.getStatus(response), ADCP_STATUS.COMPLETED);
+  });
+
+  test('ignores trailing text-only artifact when reading task status', () => {
+    const response = a2aWrappedSubmittedResponse({ adcpStatus: 'submitted', adcpTaskId: 'tk_submitted' });
+    response.result.artifacts.push({
+      artifactId: 'art-progress-text',
+      metadata: { adcp_task_id: 'tk_latest_text' },
+      parts: [{ kind: 'text', text: 'Submitted for async processing' }],
+    });
+
+    assert.strictEqual(parser.getStatus(response), ADCP_STATUS.SUBMITTED);
+  });
+});
+
 describe('ProtocolResponseParser.getTaskId — A2A submitted arm (#973)', () => {
   test('reads `artifact.metadata.adcp_task_id` for AdCP submitted arms (NOT A2A `result.id`)', () => {
     const response = a2aWrappedSubmittedResponse({ adcpTaskId: 'tk_seller', a2aTaskId: 'a2a-transport-id' });
@@ -144,6 +238,28 @@ describe('ProtocolResponseParser.getTaskId — A2A submitted arm (#973)', () => 
     assert.strictEqual(parser.getTaskId(response), 'a2a-uuid');
   });
 
+  test('reads adcp_task_id from the latest artifact metadata', () => {
+    const response = a2aWrappedSubmittedResponse({ adcpTaskId: 'tk_stale' });
+    response.result.artifacts.push({
+      artifactId: 'art-final',
+      metadata: { adcp_task_id: 'tk_latest' },
+      parts: [{ kind: 'data', data: { status: 'submitted', task_id: 'tk_latest' } }],
+    });
+
+    assert.strictEqual(parser.getTaskId(response), 'tk_latest');
+  });
+
+  test('reads adcp_task_id from trailing text-only artifact metadata', () => {
+    const response = a2aWrappedSubmittedResponse({ adcpTaskId: 'tk_stale' });
+    response.result.artifacts.push({
+      artifactId: 'art-progress-text',
+      metadata: { adcp_task_id: 'tk_latest_text' },
+      parts: [{ kind: 'text', text: 'Submitted for async processing' }],
+    });
+
+    assert.strictEqual(parser.getTaskId(response), 'tk_latest_text');
+  });
+
   test('rejects malformed `adcp_task_id` (control chars, overlong) and falls back', () => {
     const response = a2aWrappedSubmittedResponse();
     response.result.artifacts[0].metadata.adcp_task_id = 'tk\x00with-null';
@@ -160,5 +276,66 @@ describe('ProtocolResponseParser.getTaskId — A2A submitted arm (#973)', () => 
   test('flat AdCP envelope (no result wrapping) reads response.task_id directly', () => {
     const response = { task_id: 'flat-tk-2' };
     assert.strictEqual(parser.getTaskId(response), 'flat-tk-2');
+  });
+});
+
+describe('TaskExecutor — A2A update_media_buy canceled domain payload (#2009)', () => {
+  const mockAgent = {
+    id: 'test-a2a-seller',
+    name: 'Test A2A Seller',
+    agent_uri: 'https://seller.test',
+    protocol: 'a2a',
+  };
+  let originalCallTool;
+
+  beforeEach(() => {
+    originalCallTool = ProtocolClient.callTool;
+  });
+
+  afterEach(() => {
+    if (originalCallTool) ProtocolClient.callTool = originalCallTool;
+  });
+
+  test('returns success when completed A2A task artifact has domain status="canceled"', async () => {
+    const payload = {
+      media_buy_id: 'mb_canceled',
+      status: 'canceled',
+      affected_packages: [],
+      context: { correlation_id: 'corr-1' },
+      _message: 'Completed update_media_buy',
+    };
+    ProtocolClient.callTool = mock.fn(async () => a2aWrappedCompletedArtifactData(payload));
+
+    const executor = new TaskExecutor({ strictSchemaValidation: false });
+    const result = await executor.executeTask(mockAgent, 'update_media_buy', {
+      media_buy_id: 'mb_canceled',
+      canceled: true,
+      cancellation_reason: 'buyer_cancel',
+    });
+
+    assert.strictEqual(result.success, true, 'should succeed, not terminal-fail');
+    assert.strictEqual(result.status, 'completed');
+    assert.deepStrictEqual(result.data, { ...payload, media_buy_status: 'canceled' });
+    assert.notStrictEqual(result.error, 'Task canceled');
+  });
+
+  test('keeps submitted continuation when a text-only artifact follows the submitted DataPart', async () => {
+    const response = a2aWrappedSubmittedResponse({ adcpStatus: 'submitted', adcpTaskId: 'tk_submitted' });
+    response.result.artifacts.push({
+      artifactId: 'art-progress-text',
+      metadata: { adcp_task_id: 'tk_latest_text' },
+      parts: [{ kind: 'text', text: 'Submitted for async processing' }],
+    });
+    ProtocolClient.callTool = mock.fn(async () => response);
+
+    const executor = new TaskExecutor({ strictSchemaValidation: false });
+    const result = await executor.executeTask(mockAgent, 'create_media_buy', {
+      buyer_ref: 'buyer-ref',
+      packages: [],
+    });
+
+    assert.strictEqual(result.success, true);
+    assert.strictEqual(result.status, 'submitted');
+    assert.strictEqual(result.submitted.taskId, 'tk_latest_text');
   });
 });

--- a/test/lib/response-unwrapper.test.js
+++ b/test/lib/response-unwrapper.test.js
@@ -270,6 +270,38 @@ describe('Response Unwrapper', () => {
       assert.strictEqual(result.products[0].name, 'New Product');
     });
 
+    test('should ignore trailing text-only artifact when extracting A2A data', () => {
+      const a2aResponse = {
+        result: {
+          kind: 'task',
+          status: { state: 'completed' },
+          artifacts: [
+            {
+              artifactId: 'result',
+              parts: [
+                {
+                  kind: 'data',
+                  data: {
+                    cache_scope: 'public',
+                    products: [createTestProduct({ product_id: 'final', name: 'Final Product' })],
+                  },
+                },
+              ],
+            },
+            {
+              artifactId: 'message',
+              parts: [{ kind: 'text', text: 'Query completed successfully' }],
+            },
+          ],
+        },
+      };
+
+      const result = unwrapProtocolResponse(a2aResponse, 'get_products', 'a2a');
+
+      assert.strictEqual(result.products[0].product_id, 'final');
+      assert.strictEqual(result._message, 'Query completed successfully');
+    });
+
     test('should throw error when A2A artifact has no DataPart', () => {
       const a2aResponse = {
         result: {

--- a/test/lib/response-validator.test.js
+++ b/test/lib/response-validator.test.js
@@ -146,6 +146,38 @@ describe('ResponseValidator Tests', () => {
       assert.strictEqual(result.errors.length, 0);
     });
 
+    it('should validate latest A2A artifact in conversational responses', () => {
+      const response = {
+        result: {
+          artifacts: [
+            {
+              artifactId: 'stale',
+              parts: [{ kind: 'text', text: 'old progress' }],
+            },
+            {
+              artifactId: 'final',
+              parts: [
+                {
+                  kind: 'data',
+                  data: {
+                    cache_scope: 'public',
+                    products: [createValidProduct({ product_id: 'latest' })],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      };
+
+      const result = validator.validate(response, 'get_products', {
+        expectedFields: ['products'],
+      });
+
+      assert.strictEqual(result.valid, true);
+      assert.strictEqual(result.errors.length, 0);
+    });
+
     it('should detect A2A JSON-RPC errors', () => {
       const response = {
         error: {
@@ -266,6 +298,7 @@ describe('ResponseValidator Tests', () => {
             {
               parts: [
                 {
+                  kind: 'data',
                   data: {
                     creatives: [{ creative_id: 'c1' }],
                   },
@@ -281,6 +314,42 @@ describe('ResponseValidator Tests', () => {
       });
 
       assert.strictEqual(result.valid, true);
+    });
+
+    it('should validate expected fields against latest A2A artifact', () => {
+      const response = {
+        result: {
+          artifacts: [
+            {
+              parts: [
+                {
+                  kind: 'data',
+                  data: {
+                    creatives: [],
+                  },
+                },
+              ],
+            },
+            {
+              parts: [
+                {
+                  kind: 'data',
+                  data: {
+                    products: [createValidProduct()],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      };
+
+      const result = validator.validate(response, null, {
+        expectedFields: ['products'],
+      });
+
+      assert.strictEqual(result.valid, true);
+      assert.strictEqual(result.errors.length, 0);
     });
   });
 

--- a/test/lib/signing-protocol-response.test.js
+++ b/test/lib/signing-protocol-response.test.js
@@ -1,0 +1,79 @@
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+
+const { unwrapProtocolResponse } = require('../../dist/lib/signing/protocol-response.js');
+
+describe('signing protocol response unwrap', () => {
+  test('uses latest A2A artifact DataPart for capability discovery', () => {
+    const response = {
+      result: {
+        kind: 'task',
+        id: 'a2a-task-id',
+        status: { state: 'completed' },
+        artifacts: [
+          {
+            artifactId: 'stale-capabilities',
+            parts: [
+              {
+                kind: 'data',
+                data: {
+                  request_signing: { supported: false },
+                  identity: { brand_json_url: 'https://seller.example/stale-brand.json' },
+                },
+              },
+            ],
+          },
+          {
+            artifactId: 'final-capabilities',
+            parts: [
+              {
+                kind: 'data',
+                data: {
+                  request_signing: { supported: false },
+                  identity: { brand_json_url: 'https://seller.example/stale-final-part.json' },
+                },
+              },
+              {
+                kind: 'data',
+                data: {
+                  request_signing: { supported: true, required_for: ['create_media_buy'] },
+                  identity: { brand_json_url: 'https://seller.example/final-brand.json' },
+                },
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    const payload = unwrapProtocolResponse(response);
+
+    assert.deepStrictEqual(payload.request_signing, {
+      supported: true,
+      required_for: ['create_media_buy'],
+    });
+    assert.strictEqual(payload.identity.brand_json_url, 'https://seller.example/final-brand.json');
+  });
+
+  test('uses latest DataPart for A2A Message responses', () => {
+    const response = {
+      result: {
+        kind: 'message',
+        parts: [
+          {
+            kind: 'data',
+            data: { request_signing: { supported: false } },
+          },
+          {
+            kind: 'data',
+            data: { request_signing: { supported: true } },
+          },
+        ],
+      },
+    };
+
+    const payload = unwrapProtocolResponse(response);
+
+    assert.deepStrictEqual(payload, { request_signing: { supported: true } });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #2009 by disambiguating A2A artifact `status` fields from AdCP task lifecycle status.

- Treat A2A artifact payloads like `update_media_buy` returning `status: "canceled"` as completed domain responses, not task cancellation.
- Add a shared A2A DataPart selector that walks artifacts and parts backward to find the latest structured payload, while tolerating trailing text-only artifacts.
- Use that selector consistently across parser, response validator, response unwrapper, `tasks/get` polling, protocol terminal guards, and signing capability discovery.
- Preserve latest artifact metadata lookup for `adcp_task_id`, including trailing text-only progress artifacts.

## Root Cause

The A2A parser trusted `artifact.parts[0].data.status` as task lifecycle status. Some domain responses also use `status` for business state, so a completed `update_media_buy` response with media-buy status `canceled` was interpreted as task cancellation.

## Validation

- Expert review: protocol, code, and Node test coverage reviewers ran against the diff; actionable findings were addressed before PR creation.
- `npm run build:lib`
- Focused regression suite: `172` tests passed
  - `test/lib/signing-protocol-response.test.js`
  - `test/lib/protocol-response-parser-a2a-submitted.test.js`
  - `test/lib/protocol-response-parser-status.test.js`
  - `test/lib/response-validator.test.js`
  - `test/lib/response-unwrapper.test.js`
  - `test/lib/poll-task-completion-terminal-states.test.js`
  - `test/server-tasks-get-spec-shape.test.js`
- `npm run ci:quick`
  - format check passed
  - typecheck passed
  - build passed
  - root tests passed: `10401` pass, `7` skipped, `0` fail
  - eslint-plugin workspace tests passed: `30` pass, `0` fail

## Notes

`package-lock.json` had pre-existing beta.11 to beta.12 drift in the local workspace and is intentionally not included in this PR.
