### PR TITLE
fix: split not-selected storyboard steps

### DIFF
--- a/.changeset/storyboard-not-selected-summary.md
+++ b/.changeset/storyboard-not-selected-summary.md
@@ -1,0 +1,9 @@
+---
+'@adcp/sdk': patch
+---
+
+Split storyboard runner exclusions from selected-but-skipped steps in compliance summaries.
+
+Runs now report caller-excluded work, such as version gates, explicit request-signing vector filters, live-side-effect opt-outs, and profile exclusions, under `steps_not_selected` / `not_selected_by_reason` instead of inflating `steps_skipped`. Selected steps that could not execute, such as missing tools or missing `comply_test_controller`, remain skipped.
+
+The narrow compliance summary artifact is bumped to schema version 2 and now exposes `not_selected_count`, optional `not_selected` records, `not_selected_by_reason`, and `skipped_by_reason`.

--- a/bin/adcp-storyboard-summary.js
+++ b/bin/adcp-storyboard-summary.js
@@ -37,8 +37,13 @@ function buildComplianceSummaryMarkdown(result, agentUrl) {
   lines.push('');
   lines.push(
     `**Overall:** ${result.overall_status} — ` +
-      `${s.steps_passed ?? 0} passed / ${s.steps_failed ?? 0} failed / ${s.steps_skipped ?? 0} skipped`
+      `${s.steps_passed ?? 0} passed / ${s.steps_failed ?? 0} failed / ${s.steps_skipped ?? 0} skipped / ` +
+      `${s.steps_not_selected ?? 0} not selected`
   );
+  const notSelectedReasons = formatReasonCounts(s.not_selected_by_reason);
+  if (notSelectedReasons) lines.push(`**Not selected:** ${notSelectedReasons}`);
+  const skippedReasons = formatReasonCounts(s.skipped_by_reason);
+  if (skippedReasons) lines.push(`**Skipped:** ${skippedReasons}`);
   const specialisms = result.agent_profile?.specialisms;
   if (specialisms?.length) {
     lines.push(`**Specialisms:** ${specialisms.join(', ')}`);
@@ -62,6 +67,16 @@ function buildComplianceSummaryMarkdown(result, agentUrl) {
     lines.push('');
   }
   return lines.join('\n');
+}
+
+function formatReasonCounts(counts) {
+  if (!counts) return undefined;
+  const entries = Object.entries(counts).filter(([, count]) => count > 0);
+  if (entries.length === 0) return undefined;
+  return entries
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([reason, count]) => `${reason}=${count}`)
+    .join(', ');
 }
 
 /**

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,7 +11,7 @@ import tseslint from 'typescript-eslint';
 export default tseslint.config(
   // Global ignores
   {
-    ignores: ['dist/', 'node_modules/', '**/*.js', '!eslint.config.js'],
+    ignores: ['dist/', 'node_modules/', '**/*.js', '!eslint.config.js', '**/*.test.ts'],
   },
 
   // Base TypeScript rules (all .ts files)

--- a/src/lib/testing/compliance/comply.ts
+++ b/src/lib/testing/compliance/comply.ts
@@ -28,8 +28,18 @@ import {
   loadComplianceIndex,
 } from '../storyboard/compliance';
 import type { NotApplicableStoryboard, ResolveOptions } from '../storyboard/compliance';
-import type { RunnerNotice, Storyboard, StoryboardResult, StoryboardRunOptions } from '../storyboard/types';
 import type {
+  RunnerSelectionReason,
+  RunnerSkipReason,
+  Storyboard,
+  StoryboardPassResult,
+  StoryboardResult,
+  StoryboardRunOptions,
+  StoryboardStepResult,
+  RunnerNotice,
+} from '../storyboard/types';
+import type {
+  ComplianceNotSelectedRecord,
   ComplianceTrack,
   ComplianceFailure,
   TrackResult,
@@ -751,6 +761,7 @@ function buildNotApplicableStoryboardResult(agentUrl: string, na: NotApplicableS
             skipped: true,
             skip_reason: 'not_applicable',
             skip: { reason: 'not_applicable', detail: na.reason },
+            ...(na.selection_result && { selection_result: na.selection_result }),
             duration_ms: 0,
             validations: [],
             context: {},
@@ -1063,7 +1074,7 @@ async function complyImpl(agentUrl: string, options: ComplyOptions): Promise<Com
     // Resolve storyboards: explicit IDs override capability-driven selection.
     let initialStoryboards: Storyboard[];
     let notApplicable: NotApplicableStoryboard[] = [];
-    let missingToolStoryboards: NotApplicableStoryboard[] = [];
+    const missingToolStoryboards: NotApplicableStoryboard[] = [];
     if (explicitStoryboards?.length) {
       initialStoryboards = resolveExplicitStoryboards(explicitStoryboards, resolveOptions);
     } else {
@@ -1544,9 +1555,11 @@ function buildSummary(tracks: TrackResult[], storyboardResults: StoryboardResult
   // locally against the same artifacts.
   const stepsPassed = storyboardResults.reduce((s, r) => s + r.passed_count, 0);
   const stepsFailed = storyboardResults.reduce((s, r) => s + r.failed_count, 0);
-  const stepsSkipped = storyboardResults.reduce((s, r) => s + r.skipped_count, 0);
+  const stepDisposition = summarizeStepDisposition(storyboardResults);
+  const stepsSkipped = stepDisposition.stepsSkipped;
+  const stepsNotSelected = stepDisposition.notSelected.length;
   const validationsNotApplicable = storyboardResults.reduce((s, r) => s + (r.validations_not_applicable ?? 0), 0);
-  const totalSteps = stepsPassed + stepsFailed + stepsSkipped;
+  const totalSteps = stepsPassed + stepsFailed + stepsSkipped + stepsNotSelected;
   const schemasUsed: Array<{ schema_id: string; schema_url: string }> = [];
   const seenSchemas = new Set<string>();
   for (const r of storyboardResults) {
@@ -1568,9 +1581,90 @@ function buildSummary(tracks: TrackResult[], storyboardResults: StoryboardResult
     steps_passed: stepsPassed,
     steps_failed: stepsFailed,
     steps_skipped: stepsSkipped,
+    steps_not_selected: stepsNotSelected,
+    not_selected: stepDisposition.notSelected,
+    not_selected_by_reason: stepDisposition.notSelectedByReason,
+    skipped_by_reason: stepDisposition.skippedByReason,
     ...(validationsNotApplicable > 0 ? { validations_not_applicable: validationsNotApplicable } : {}),
     ...(schemasUsed.length > 0 ? { schemas_used: schemasUsed } : {}),
   };
+}
+
+function summarizeStepDisposition(storyboardResults: StoryboardResult[]): {
+  stepsSkipped: number;
+  skippedByReason: Partial<Record<RunnerSkipReason | string, number>>;
+  notSelected: ComplianceNotSelectedRecord[];
+  notSelectedByReason: Partial<Record<RunnerSelectionReason, number>>;
+} {
+  let stepsSkipped = 0;
+  const skippedByReason: Partial<Record<RunnerSkipReason | string, number>> = {};
+  const notSelected: ComplianceNotSelectedRecord[] = [];
+  const notSelectedByReason: Partial<Record<RunnerSelectionReason, number>> = {};
+
+  for (const result of storyboardResults) {
+    for (const step of iterateResultSteps(result)) {
+      if (!step.skipped) continue;
+
+      const selection = step.selection_result ?? selectionForDetailedSkip(step.skip_reason);
+      if (selection) {
+        notSelected.push({
+          reason: selection.reason,
+          detail: selection.detail,
+          storyboard_id: step.storyboard_id ?? result.storyboard_id,
+          phase_id: step.phase_id,
+          step_id: step.step_id,
+        });
+        notSelectedByReason[selection.reason] = (notSelectedByReason[selection.reason] ?? 0) + 1;
+        continue;
+      }
+
+      stepsSkipped++;
+      const reason = step.skip?.reason ?? step.skip_reason ?? 'unknown';
+      skippedByReason[reason] = (skippedByReason[reason] ?? 0) + 1;
+    }
+  }
+
+  return { stepsSkipped, skippedByReason, notSelected, notSelectedByReason };
+}
+
+function* iterateResultSteps(result: StoryboardResult): Iterable<StoryboardStepResult> {
+  const passLikeResults: Array<Pick<StoryboardPassResult, 'phases'>> =
+    result.passes && result.passes.length > 0 ? result.passes : [{ phases: result.phases }];
+  for (const pass of passLikeResults) {
+    for (const phase of pass.phases ?? []) {
+      for (const step of phase.steps ?? []) {
+        yield step;
+      }
+    }
+  }
+}
+
+function selectionForDetailedSkip(
+  reason: StoryboardStepResult['skip_reason'] | undefined
+): { reason: RunnerSelectionReason; detail: string } | undefined {
+  switch (reason) {
+    case 'live_side_effect_opt_in_required':
+      return {
+        reason: 'run_mode_excluded',
+        detail: 'Step requires live side effects and this run did not opt into live execution.',
+      };
+    case 'not_in_only_vectors':
+    case 'mcp_mode_flattens_url_edges':
+    case 'capability_profile_mismatch':
+    case 'transport_ungradable':
+      return {
+        reason: 'profile_excluded',
+        detail: 'Step is outside the selected verification profile for this run.',
+      };
+    case 'operator_skip':
+    case 'rate_abuse_opt_out':
+      return {
+        reason: 'explicit_scope_excluded',
+        detail: 'Step was excluded by an explicit operator selection option.',
+      };
+    default:
+      return undefined;
+  }
 }
 
 /**
@@ -1605,6 +1699,23 @@ export function formatComplianceResults(result: ComplianceResult): string {
 
   // Summary line
   output += `${result.summary.headline}\n\n`;
+  if (
+    result.summary.steps_passed !== undefined ||
+    result.summary.steps_failed !== undefined ||
+    result.summary.steps_skipped !== undefined ||
+    result.summary.steps_not_selected !== undefined
+  ) {
+    output +=
+      `Steps: ${result.summary.steps_passed ?? 0} passed, ` +
+      `${result.summary.steps_failed ?? 0} failed, ` +
+      `${result.summary.steps_skipped ?? 0} skipped, ` +
+      `${result.summary.steps_not_selected ?? 0} not selected\n\n`;
+    const notSelectedReasons = formatReasonCounts(result.summary.not_selected_by_reason);
+    if (notSelectedReasons) output += `Not selected: ${notSelectedReasons}\n`;
+    const skippedReasons = formatReasonCounts(result.summary.skipped_by_reason);
+    if (skippedReasons) output += `Skipped: ${skippedReasons}\n`;
+    if (notSelectedReasons || skippedReasons) output += '\n';
+  }
 
   // Track results
   output += `Capability Tracks\n`;
@@ -1722,6 +1833,18 @@ export function formatComplianceResults(result: ComplianceResult): string {
 
   output += '\n';
   return output;
+}
+
+function formatReasonCounts(counts: Partial<Record<string, number>> | undefined): string | undefined {
+  if (!counts) return undefined;
+  const entries = Object.entries(counts).filter(
+    (entry): entry is [string, number] => typeof entry[1] === 'number' && entry[1] > 0
+  );
+  if (entries.length === 0) return undefined;
+  return entries
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([reason, count]) => `${reason}=${count}`)
+    .join(', ');
 }
 
 /**

--- a/src/lib/testing/compliance/storyboard-tracks.ts
+++ b/src/lib/testing/compliance/storyboard-tracks.ts
@@ -126,6 +126,7 @@ function mapStepToTestStep(stepResult: StoryboardStepResult): TestStepResult {
       : undefined,
     ...(stepResult.skipped && { skipped: true as const }),
     ...(stepResult.skip_reason && { skip_reason: stepResult.skip_reason }),
+    ...(stepResult.selection_result?.reason && { selection_reason: stepResult.selection_result.reason }),
     ...(stepResult.skip?.requirement && { requirement: stepResult.skip.requirement }),
   };
 }

--- a/src/lib/testing/compliance/summary.ts
+++ b/src/lib/testing/compliance/summary.ts
@@ -11,16 +11,23 @@
  *   - `formatComplianceSummaryText`   → stderr block with greppable `STORYBOARD-FAIL` prefix
  *   - `formatComplianceSummaryMarkdown` → table for $GITHUB_STEP_SUMMARY
  *
- * The `skip_causes` field on `ComplianceSummaryArtifact` is an additive v1
- * extension — treat unknown fields as ignorable per schema_version semantics.
+ * The v2 summary separates selected-but-skipped steps from not-selected
+ * exclusions. Treat unknown fields as ignorable per schema_version semantics.
  * Crash-path summaries built by `buildCrashSummary` omit `skip_causes`
  * because the runner never reached the storyboard execution phase.
  */
 
-import type { ComplianceFailure, ComplianceResult, ComplianceTrack, OverallStatus } from './types';
+import type {
+  ComplianceFailure,
+  ComplianceNotSelectedRecord,
+  ComplianceResult,
+  ComplianceTrack,
+  OverallStatus,
+} from './types';
+import type { RunnerSelectionReason, RunnerSkipReason } from '../storyboard/types';
 import { DETAILED_SKIP_TO_CANONICAL, type RunnerDetailedSkipReason } from '../storyboard/types';
 
-const SUMMARY_SCHEMA_VERSION = 1;
+const SUMMARY_SCHEMA_VERSION = 2;
 
 /**
  * A grouped skip-cause entry for the always-on summary block.
@@ -48,6 +55,10 @@ export interface ComplianceSummaryArtifact {
   passed: number;
   failed: number;
   skipped: number;
+  not_selected_count: number;
+  not_selected_by_reason: Partial<Record<RunnerSelectionReason, number>>;
+  skipped_by_reason: Partial<Record<RunnerSkipReason | string, number>>;
+  not_selected?: ComplianceNotSelectedRecord[];
   total_duration_ms: number;
   tested_at: string;
   storyboards_executed: string[];
@@ -90,6 +101,10 @@ export function buildComplianceSummary(result: ComplianceResult, opts: BuildSumm
     passed: result.summary.steps_passed ?? 0,
     failed: result.summary.steps_failed ?? 0,
     skipped: result.summary.steps_skipped ?? 0,
+    not_selected_count: result.summary.steps_not_selected ?? 0,
+    not_selected_by_reason: result.summary.not_selected_by_reason ?? {},
+    skipped_by_reason: result.summary.skipped_by_reason ?? {},
+    ...(result.summary.not_selected?.length ? { not_selected: result.summary.not_selected } : {}),
     total_duration_ms: result.total_duration_ms,
     tested_at: result.tested_at,
     storyboards_executed: result.storyboards_executed ?? [],
@@ -227,6 +242,7 @@ function buildSkipCauses(result: ComplianceResult): ComplianceSummarySkipCause[]
       const scenarioId = String(scenario.scenario);
       for (const step of scenario.steps ?? []) {
         if (!step.skipped || !step.skip_reason) continue;
+        if (step.selection_reason) continue;
         if (!isActionableSkipReason(step.skip_reason)) continue;
 
         // missing_tool: sub-group by tool name. Storyboard-level matches
@@ -283,6 +299,18 @@ function isHardFail(s: ComplianceSummaryArtifact): boolean {
   return HARD_FAIL_STATUSES.has(s.overall_status) || s.failures.length > 0;
 }
 
+function formatReasonCounts(counts: Partial<Record<string, number>> | undefined): string | undefined {
+  if (!counts) return undefined;
+  const entries = Object.entries(counts).filter(
+    (entry): entry is [string, number] => typeof entry[1] === 'number' && entry[1] > 0
+  );
+  if (entries.length === 0) return undefined;
+  return entries
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([reason, count]) => `${reason}=${count}`)
+    .join(', ');
+}
+
 /**
  * stderr-style summary block. Always starts with `STORYBOARD-FAIL` (kebab,
  * no spaces) on any hard-failing run, so CI scripts can `grep -q STORYBOARD-FAIL`
@@ -297,7 +325,13 @@ export function formatComplianceSummaryText(s: ComplianceSummaryArtifact): strin
   lines.push(`Agent:     ${s.agent_url}`);
   lines.push(`SDK:       @adcp/sdk ${s.sdk_version} (AdCP ${s.adcp_version})`);
   lines.push(`Status:    ${s.overall_status}`);
-  lines.push(`Steps:     ${s.passed} passed, ${s.failed} failed, ${s.skipped} skipped`);
+  lines.push(
+    `Steps:     ${s.passed} passed, ${s.failed} failed, ${s.skipped} skipped, ${s.not_selected_count} not selected`
+  );
+  const notSelectedReasons = formatReasonCounts(s.not_selected_by_reason);
+  if (notSelectedReasons) lines.push(`Not selected: ${notSelectedReasons}`);
+  const skippedReasons = formatReasonCounts(s.skipped_by_reason);
+  if (skippedReasons) lines.push(`Skipped:   ${skippedReasons}`);
   if (s.skip_causes?.length) {
     const countWidth = String(Math.max(...s.skip_causes.map(c => c.count))).length;
     // "    [" + countWidth chars + "] " — derived so Affected: aligns under the cause text
@@ -323,7 +357,7 @@ export function formatComplianceSummaryText(s: ComplianceSummaryArtifact): strin
 
   if (!isHardFail(s)) {
     if (s.overall_status === 'passing') {
-      lines.push(`STORYBOARD-OK ${s.passed}/${s.passed + s.failed + s.skipped} steps passed`);
+      lines.push(`STORYBOARD-OK ${s.passed}/${s.passed + s.failed + s.skipped} selected steps passed`);
     } else {
       // `partial` and `silent` — some tracks were wired but not exercised.
       // Distinct marker so dashboards can surface this without lighting CI red.
@@ -363,7 +397,13 @@ export function formatComplianceSummaryMarkdown(s: ComplianceSummaryArtifact): s
   lines.push(`- **Agent:** \`${s.agent_url}\``);
   lines.push(`- **SDK:** \`@adcp/sdk ${s.sdk_version}\` (AdCP \`${s.adcp_version}\`)`);
   lines.push(`- **Status:** \`${s.overall_status}\``);
-  lines.push(`- **Steps:** ${s.passed} passed, ${s.failed} failed, ${s.skipped} skipped`);
+  lines.push(
+    `- **Steps:** ${s.passed} passed, ${s.failed} failed, ${s.skipped} skipped, ${s.not_selected_count} not selected`
+  );
+  const notSelectedReasons = formatReasonCounts(s.not_selected_by_reason);
+  if (notSelectedReasons) lines.push(`- **Not selected:** ${notSelectedReasons}`);
+  const skippedReasons = formatReasonCounts(s.skipped_by_reason);
+  if (skippedReasons) lines.push(`- **Skipped:** ${skippedReasons}`);
   lines.push(`- **Duration:** ${(s.total_duration_ms / 1000).toFixed(1)}s`);
   lines.push('');
 
@@ -414,7 +454,7 @@ function escapeTableCell(s: string): string {
 /**
  * Synthesize a summary artifact when the runner itself crashed before
  * `comply()` produced a result (network down, capabilities parse error,
- * auth handshake exception). Schema-stable on the same `schema_version: 1`
+ * auth handshake exception). Schema-stable on the same summary artifact
  * contract so a Slack bot built against the artifact sees a valid payload
  * — rather than nothing — precisely when the agent is broken hardest.
  */
@@ -436,6 +476,9 @@ export function buildCrashSummary(opts: BuildCrashSummaryOptions): ComplianceSum
     passed: 0,
     failed: 1,
     skipped: 0,
+    not_selected_count: 0,
+    not_selected_by_reason: {},
+    skipped_by_reason: {},
     total_duration_ms: opts.durationMs,
     tested_at: opts.startedAt,
     storyboards_executed: [],

--- a/src/lib/testing/compliance/types.ts
+++ b/src/lib/testing/compliance/types.ts
@@ -4,7 +4,7 @@
 
 import type { AgentProfile, TestResult, TestScenario } from '../types';
 import type { AdcpErrorInfo } from '../../core/ConversationTypes';
-import type { RunnerNotice } from '../storyboard/types';
+import type { RunnerNotice, RunnerSelectionReason, RunnerSkipReason } from '../storyboard/types';
 
 // ============================================================
 // COMPLY: Capability Tracks
@@ -201,6 +201,14 @@ export interface ComplianceSummary {
   steps_failed?: number;
   /** Storyboard steps that were skipped. */
   steps_skipped?: number;
+  /** Storyboard steps excluded before execution by run selection. */
+  steps_not_selected?: number;
+  /** Machine-readable selection exclusions, one record per excluded step/item. */
+  not_selected?: ComplianceNotSelectedRecord[];
+  /** Aggregate counts by selection-exclusion reason. */
+  not_selected_by_reason?: Partial<Record<RunnerSelectionReason, number>>;
+  /** Aggregate counts by canonical selected-but-skipped reason. */
+  skipped_by_reason?: Partial<Record<RunnerSkipReason | string, number>>;
   /**
    * Validation results graded `not_applicable` because the runner did not
    * implement the storyboard's authored `check` kind (forward-compat
@@ -214,6 +222,14 @@ export interface ComplianceSummary {
    * locally against the same artifacts the runner used.
    */
   schemas_used?: Array<{ schema_id: string; schema_url: string }>;
+}
+
+export interface ComplianceNotSelectedRecord {
+  reason: RunnerSelectionReason;
+  detail: string;
+  storyboard_id?: string;
+  phase_id?: string;
+  step_id?: string;
 }
 
 // ============================================================

--- a/src/lib/testing/storyboard/compliance.ts
+++ b/src/lib/testing/storyboard/compliance.ts
@@ -15,7 +15,7 @@ import { ADCP_VERSION } from '../../version';
 import { ADCPError } from '../../errors';
 import { isAdcpVersionSupported } from '../../utils/adcp-version-config';
 import { synthesizeRequestSigningSteps } from './request-signing/synthesize';
-import type { Storyboard } from './types';
+import type { RunnerSelectionResult, Storyboard } from './types';
 
 /**
  * Discriminator for configuration faults `resolveStoryboardsForCapabilities`
@@ -139,6 +139,8 @@ export interface NotApplicableStoryboard {
   /** Track this storyboard would have contributed to, if known. */
   track?: string;
   reason: string;
+  /** Selection reason when the storyboard was excluded before execution. */
+  selection_result?: RunnerSelectionResult;
 }
 
 export interface ResolveOptions {
@@ -522,6 +524,7 @@ export function resolveStoryboardsForCapabilities(
           storyboard_title: sb.title,
           track: sb.track,
           reason: gate,
+          selection_result: { reason: 'version_excluded', detail: gate },
         });
         continue;
       }

--- a/src/lib/testing/storyboard/request-signing/probe-dispatch.ts
+++ b/src/lib/testing/storyboard/request-signing/probe-dispatch.ts
@@ -1,4 +1,4 @@
-import type { HttpProbeResult, StoryboardRunOptions } from '../types';
+import type { HttpProbeResult, RunnerDetailedSkipReason, StoryboardRunOptions } from '../types';
 import { gradeOneVector } from './grader';
 import { parseRequestSigningStepId } from './synthesize';
 import { loadRequestSigningVectors } from './vector-loader';
@@ -33,14 +33,14 @@ export async function probeRequestSigningVector(
       const loaded = loadRequestSigningVectors();
       const vector = loaded.negative.find(v => v.id === parsed.vector_id);
       if (vector?.requires_contract === 'rate_abuse') {
-        return skipProbe(agentUrl, `${parsed.vector_id} skipped via request_signing.skipRateAbuse`);
+        return skipProbe(agentUrl, 'rate_abuse_opt_out');
       }
     } catch {
       // fall through — surfaces as a grader error below
     }
   }
   if (rsOpts.skipVectors?.includes(parsed.vector_id)) {
-    return skipProbe(agentUrl, `${parsed.vector_id} skipped via request_signing.skipVectors`);
+    return skipProbe(agentUrl, 'operator_skip');
   }
   try {
     const result = await gradeOneVector(parsed.vector_id, parsed.kind, agentUrl, {
@@ -53,7 +53,7 @@ export async function probeRequestSigningVector(
       ...(rsOpts.transport && { transport: rsOpts.transport }),
     });
     if (result.skipped) {
-      return skipProbe(agentUrl, result.skip_reason ?? 'grader_skipped');
+      return skipProbe(agentUrl, (result.skip_reason as RunnerDetailedSkipReason | undefined) ?? 'grader_skipped');
     }
     const headers: Record<string, string> = {};
     if (result.actual_error_code) {
@@ -77,6 +77,6 @@ export async function probeRequestSigningVector(
   }
 }
 
-function skipProbe(url: string, reason: string): HttpProbeResult {
+function skipProbe(url: string, reason: RunnerDetailedSkipReason): HttpProbeResult {
   return { url, status: 0, headers: {}, body: null, skipped: true, skip_reason: reason };
 }

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -81,6 +81,7 @@ import type {
   RunnerExtractionRecord,
   RunnerRequestRecord,
   RunnerResponseRecord,
+  RunnerSelectionResult,
   RequirementName,
   RunnerSkipReason,
   RunnerNotice,
@@ -194,7 +195,28 @@ function soleStatefulExemptionDetail(phaseId: string): string {
 const DETAILED_SKIP_DETAILS: Partial<Record<RunnerDetailedSkipReason, string>> = {
   oauth_not_advertised: OAUTH_NOT_ADVERTISED_DETAIL,
   controller_seeding_failed: CONTROLLER_SEEDING_FAILED_DETAIL,
+  operator_skip: 'Step was excluded by request_signing.skipVectors.',
+  rate_abuse_opt_out: 'Rate-abuse vector was excluded by request_signing.skipRateAbuse.',
+  capability_profile_mismatch: 'Vector is outside the agent capability profile selected for this run.',
+  transport_ungradable: 'Vector cannot be graded faithfully by the selected transport.',
 };
+
+function selectionForProbeSkip(reason: RunnerDetailedSkipReason, detail: string): RunnerSelectionResult | undefined {
+  switch (reason) {
+    case 'live_side_effect_opt_in_required':
+      return { reason: 'run_mode_excluded', detail };
+    case 'operator_skip':
+    case 'rate_abuse_opt_out':
+      return { reason: 'explicit_scope_excluded', detail };
+    case 'not_in_only_vectors':
+    case 'mcp_mode_flattens_url_edges':
+    case 'capability_profile_mismatch':
+    case 'transport_ungradable':
+      return { reason: 'profile_excluded', detail };
+    default:
+      return undefined;
+  }
+}
 
 /**
  * Walk a dotted key path (e.g. `"adcp.idempotency.supported"`) through a
@@ -4327,6 +4349,7 @@ async function executeProbeStep(
     const detailedReason = (httpResult.skip_reason ?? 'probe_skipped') as RunnerDetailedSkipReason;
     const canonicalReason = DETAILED_SKIP_TO_CANONICAL[detailedReason] ?? 'not_applicable';
     const detail = httpResult.error ?? DETAILED_SKIP_DETAILS[detailedReason] ?? SKIP_DETAILS[canonicalReason];
+    const selectionResult = selectionForProbeSkip(detailedReason, detail);
     return {
       step_id: step.id,
       phase_id: phaseId,
@@ -4336,6 +4359,7 @@ async function executeProbeStep(
       skipped: true,
       skip_reason: detailedReason,
       skip: { reason: canonicalReason, detail },
+      ...(selectionResult && { selection_result: selectionResult }),
       duration_ms: duration,
       response: httpResult,
       validations: [],

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -1532,6 +1532,10 @@ export type RunnerDetailedSkipReason =
   | 'operator_skip'
   | 'not_in_only_vectors'
   | 'grader_skipped'
+  /** Request-signing vector is outside the agent's declared signing capability profile. */
+  | 'capability_profile_mismatch'
+  /** Request-signing vector cannot be graded faithfully by the selected transport. */
+  | 'transport_ungradable'
   /** Request-signing grader's MCP-transport mode collapses URL-edge vectors (#617). */
   | 'mcp_mode_flattens_url_edges'
   /** RFC 9728 protected-resource metadata returned 404 → agent is not advertising OAuth, cascade-skip oauth_discovery (#677). */
@@ -1578,6 +1582,8 @@ export const DETAILED_SKIP_TO_CANONICAL: Record<RunnerDetailedSkipReason, Runner
   probe_skipped: 'not_applicable',
   not_in_only_vectors: 'not_applicable',
   grader_skipped: 'not_applicable',
+  capability_profile_mismatch: 'not_applicable',
+  transport_ungradable: 'not_applicable',
   mcp_mode_flattens_url_edges: 'not_applicable',
   oauth_not_advertised: 'not_applicable',
   force_scenario_unsupported: 'not_applicable',
@@ -1600,6 +1606,17 @@ export interface RunnerSkipResult {
    * cause. Absent for every other skip reason. Spec: adcp-client#1626.
    */
   requirement?: RequirementName;
+}
+
+export type RunnerSelectionReason =
+  | 'run_mode_excluded'
+  | 'explicit_scope_excluded'
+  | 'version_excluded'
+  | 'profile_excluded';
+
+export interface RunnerSelectionResult {
+  reason: RunnerSelectionReason;
+  detail: string;
 }
 
 /**
@@ -1864,6 +1881,12 @@ export interface StoryboardStepResult {
   skip_reason?: RunnerSkipReason | RunnerDetailedSkipReason;
   /** Structured skip result with canonical spec reason + human-readable detail. */
   skip?: RunnerSkipResult;
+  /**
+   * Structured selection result for steps that were outside the caller's
+   * requested run before execution. Kept separate from `skip`: skipped means
+   * selected-but-not-executed, selection means not selected for this run.
+   */
+  selection_result?: RunnerSelectionResult;
   /** True when the step expected an error (inverted pass/fail) */
   expect_error?: boolean;
   duration_ms: number;

--- a/src/lib/testing/types.ts
+++ b/src/lib/testing/types.ts
@@ -255,6 +255,12 @@ export interface TestStepResult {
   /** Canonical skip reason when `skipped` is true; maps to `RunnerSkipReason`. */
   skip_reason?: string;
   /**
+   * Selection reason when a skipped-looking step was intentionally outside
+   * the caller's requested run. Summary artifacts use this to keep
+   * not-selected steps out of actionable skip-cause rollups.
+   */
+  selection_reason?: string;
+  /**
    * Names the unmet runtime requirement when `skip_reason` is
    * `'requirement_unmet'` (per adcp-client#1626). Carries the same value
    * the storyboard authored in `Storyboard.requires`. Lets skip-cause

--- a/test/lib/cli-summary-markdown.test.js
+++ b/test/lib/cli-summary-markdown.test.js
@@ -28,15 +28,35 @@ test('compliance summary: passing result with no failures field omits the table'
   const md = buildComplianceSummaryMarkdown(
     {
       overall_status: 'passing',
-      summary: { steps_passed: 8, steps_failed: 0, steps_skipped: 1 },
+      summary: { steps_passed: 8, steps_failed: 0, steps_skipped: 1, steps_not_selected: 2 },
     },
     'https://agent.example.com'
   );
 
   assert.match(md, /^# Storyboard run: https:\/\/agent\.example\.com$/m);
-  assert.match(md, /\*\*Overall:\*\* passing — 8 passed \/ 0 failed \/ 1 skipped/);
+  assert.match(md, /\*\*Overall:\*\* passing — 8 passed \/ 0 failed \/ 1 skipped \/ 2 not selected/);
   assert.doesNotMatch(md, /## Failures/);
   assert.doesNotMatch(md, /No per-step failure details/);
+});
+
+test('compliance summary: renders skip and not-selected reason counts', () => {
+  const md = buildComplianceSummaryMarkdown(
+    {
+      overall_status: 'passing',
+      summary: {
+        steps_passed: 8,
+        steps_failed: 0,
+        steps_skipped: 1,
+        steps_not_selected: 2,
+        skipped_by_reason: { missing_tool: 1 },
+        not_selected_by_reason: { explicit_scope_excluded: 2 },
+      },
+    },
+    'https://agent.example.com'
+  );
+
+  assert.match(md, /\*\*Not selected:\*\* explicit_scope_excluded=2/);
+  assert.match(md, /\*\*Skipped:\*\* missing_tool=1/);
 });
 
 test('compliance summary: failing result with undefined failures emits placeholder', () => {

--- a/test/lib/compliance-summary.test.js
+++ b/test/lib/compliance-summary.test.js
@@ -15,6 +15,7 @@ const {
   formatComplianceSummaryText,
   formatComplianceSummaryMarkdown,
 } = require('../../dist/lib/testing/compliance/index.js');
+const { mapStoryboardResultsToTrackResult } = require('../../dist/lib/testing/compliance/storyboard-tracks.js');
 
 function passingResult() {
   return {
@@ -88,6 +89,9 @@ describe('buildComplianceSummary', () => {
     assert.deepStrictEqual(s.failures, []);
     assert.strictEqual(s.overall_status, 'passing');
     assert.strictEqual(s.passed, 5);
+    assert.strictEqual(s.not_selected_count, 0);
+    assert.deepStrictEqual(s.not_selected_by_reason, {});
+    assert.deepStrictEqual(s.skipped_by_reason, {});
   });
 
   test('failing run flattens failures into the contract shape', () => {
@@ -107,9 +111,9 @@ describe('buildComplianceSummary', () => {
     assert.strictEqual(s.failures[1].reason_kind, 'validation');
   });
 
-  test('schema_version is stable at 1', () => {
+  test('schema_version is stable at 2', () => {
     const s = buildComplianceSummary(passingResult(), { sdkVersion: '6.9.0', adcpVersion: '3.0.6' });
-    assert.strictEqual(s.schema_version, 1);
+    assert.strictEqual(s.schema_version, 2);
   });
 
   test('includes agent_url + sdk_version + adcp_version for paste-friendliness', () => {
@@ -154,6 +158,38 @@ describe('formatComplianceSummaryText', () => {
     assert.match(text, /STORYBOARD-PARTIAL/);
     assert.doesNotMatch(text, /STORYBOARD-FAIL/);
     assert.doesNotMatch(text, /STORYBOARD-OK/);
+  });
+
+  test('renders skipped and not selected as separate step terms', () => {
+    const result = passingResult();
+    result.summary = {
+      ...result.summary,
+      steps_skipped: 2,
+      steps_not_selected: 3,
+      skipped_by_reason: { missing_tool: 2 },
+      not_selected_by_reason: { run_mode_excluded: 3 },
+      not_selected: [
+        {
+          reason: 'run_mode_excluded',
+          detail: 'live-only probe excluded from sandbox run',
+          storyboard_id: 'signed_requests',
+          phase_id: 'negative',
+          step_id: 'negative-016-replayed-nonce',
+        },
+      ],
+    };
+    const s = buildComplianceSummary(result, { sdkVersion: '6.9.0', adcpVersion: '3.0.6' });
+    assert.strictEqual(s.skipped, 2);
+    assert.strictEqual(s.not_selected_count, 3);
+    assert.deepStrictEqual(s.skipped_by_reason, { missing_tool: 2 });
+    assert.deepStrictEqual(s.not_selected_by_reason, { run_mode_excluded: 3 });
+    assert.strictEqual(s.not_selected.length, 1);
+
+    const text = formatComplianceSummaryText(s);
+    assert.match(text, /2 skipped, 3 not selected/);
+    assert.match(text, /Not selected: run_mode_excluded=3/);
+    assert.match(text, /Skipped:\s+missing_tool=2/);
+    assert.match(text, /selected steps passed/);
   });
 
   test('always names the agent and sdk version', () => {
@@ -561,6 +597,122 @@ describe('buildComplianceSummary — skip causes', () => {
     assert.ok(csf, 'controller_seeding_failed should be present (maps canonical prerequisite_failed)');
   });
 
+  test('excludes not-selected steps from actionable skip causes', () => {
+    const base = passingResult();
+    const result = {
+      ...base,
+      summary: {
+        ...base.summary,
+        steps_skipped: 0,
+        steps_not_selected: 1,
+        not_selected_by_reason: { run_mode_excluded: 1 },
+        not_selected: [
+          {
+            reason: 'run_mode_excluded',
+            detail: 'Step requires live side effects and this run did not opt into live execution.',
+            storyboard_id: 'signed_requests',
+            phase_id: 'negative',
+            step_id: 'negative-020-rate-abuse',
+          },
+        ],
+      },
+      tracks: [
+        {
+          track: 'core',
+          status: 'skip',
+          label: 'Core Protocol',
+          observations: [],
+          duration_ms: 0,
+          scenarios: [
+            {
+              agent_url: 'https://agent.example/mcp',
+              scenario: 'signed_requests/negative',
+              overall_passed: true,
+              summary: 'ok',
+              total_duration_ms: 0,
+              tested_at: base.tested_at,
+              steps: [
+                {
+                  step: 'rate-abuse',
+                  passed: true,
+                  skipped: true,
+                  skip_reason: 'live_side_effect_opt_in_required',
+                  selection_reason: 'run_mode_excluded',
+                  duration_ms: 0,
+                },
+              ],
+            },
+          ],
+          skipped_scenarios: [],
+        },
+      ],
+    };
+    const s = buildComplianceSummary(result, { sdkVersion: '6.9.0', adcpVersion: '3.0.6' });
+    assert.strictEqual(s.not_selected_count, 1);
+    assert.strictEqual(s.skip_causes, undefined);
+  });
+
+  test('storyboard track mapping preserves selection_reason for not-selected skips', () => {
+    const base = passingResult();
+    const storyboardResult = {
+      storyboard_id: 'signed_requests',
+      storyboard_title: 'Signed requests',
+      agent_url: 'https://agent.example/mcp',
+      overall_passed: true,
+      phases: [
+        {
+          phase_id: 'negative',
+          phase_title: 'Negative',
+          passed: true,
+          duration_ms: 0,
+          steps: [
+            {
+              step_id: 'negative-020-rate-abuse',
+              phase_id: 'negative',
+              title: 'Rate abuse',
+              task: 'request_signing_probe',
+              passed: true,
+              skipped: true,
+              skip_reason: 'live_side_effect_opt_in_required',
+              skip: {
+                reason: 'unsatisfied_contract',
+                detail: 'Step requires live side effects and this run did not opt into live execution.',
+              },
+              selection_result: {
+                reason: 'run_mode_excluded',
+                detail: 'Step requires live side effects and this run did not opt into live execution.',
+              },
+              duration_ms: 0,
+              validations: [],
+              context: {},
+              extraction: { path: 'none' },
+            },
+          ],
+        },
+      ],
+      context: {},
+      total_duration_ms: 0,
+      passed_count: 0,
+      failed_count: 0,
+      skipped_count: 1,
+      tested_at: base.tested_at,
+    };
+    const track = mapStoryboardResultsToTrackResult('core', [storyboardResult], { name: 'Agent', tools: [] });
+    assert.strictEqual(track.scenarios[0].steps[0].selection_reason, 'run_mode_excluded');
+
+    const result = {
+      ...base,
+      summary: {
+        ...base.summary,
+        steps_not_selected: 1,
+        not_selected_by_reason: { run_mode_excluded: 1 },
+      },
+      tracks: [track],
+    };
+    const s = buildComplianceSummary(result, { sdkVersion: '6.9.0', adcpVersion: '3.0.6' });
+    assert.strictEqual(s.skip_causes, undefined);
+  });
+
   test('caps affected list at SKIP_CAUSE_AFFECTED_LIMIT in the JSON artifact', () => {
     const base = passingResult();
     const steps = Array.from({ length: 10 }, (_, i) => ({
@@ -679,7 +831,7 @@ describe('formatComplianceSummaryMarkdown — skip causes', () => {
 });
 
 describe('buildCrashSummary', () => {
-  test('produces a schema_version-1 artifact when comply() throws', () => {
+  test('produces a schema_version-2 artifact when comply() throws', () => {
     const summary = buildCrashSummary({
       sdkVersion: '6.9.0',
       adcpVersion: '3.0.6',
@@ -688,9 +840,10 @@ describe('buildCrashSummary', () => {
       startedAt: '2026-01-01T00:00:00Z',
       durationMs: 42,
     });
-    assert.strictEqual(summary.schema_version, 1);
+    assert.strictEqual(summary.schema_version, 2);
     assert.strictEqual(summary.overall_status, 'unreachable');
     assert.strictEqual(summary.failed, 1);
+    assert.strictEqual(summary.not_selected_count, 0);
     assert.strictEqual(summary.failures.length, 1);
     assert.strictEqual(summary.failures[0].storyboard_id, 'pre-flight');
     assert.strictEqual(summary.failures[0].reason_kind, 'error');

--- a/test/request-signing-runner-integration.test.js
+++ b/test/request-signing-runner-integration.test.js
@@ -231,7 +231,7 @@ describe('request-signing: runner dispatch against reference verifier', () => {
       request_signing: { skipRateAbuse: true },
     });
     assert.strictEqual(result.skipped, true, `expected skipped, got: ${JSON.stringify(result)}`);
-    assert.match(result.skip_reason ?? '', /rate_abuse_opt_out|skipRateAbuse/);
+    assert.strictEqual(result.skip_reason, 'rate_abuse_opt_out');
     assert.strictEqual(result.error, undefined, 'skipped probe should not set error');
   });
 
@@ -241,7 +241,7 @@ describe('request-signing: runner dispatch against reference verifier', () => {
       request_signing: { skipVectors: ['003-expired-signature'] },
     });
     assert.strictEqual(result.skipped, true, `expected skipped, got: ${JSON.stringify(result)}`);
-    assert.match(result.skip_reason ?? '', /operator_skip|skipVectors/);
+    assert.strictEqual(result.skip_reason, 'operator_skip');
   });
 
   test('probe dispatch rejects unknown step id', async () => {
@@ -325,7 +325,8 @@ describe('request-signing: runner dispatch against reference verifier', () => {
       // Skipped ≠ failed — this is the bug the review caught.
       assert.strictEqual(result.skipped, true, 'step marked skipped');
       assert.strictEqual(result.passed, true, 'skipped steps do not count as failures');
-      assert.match(result.skip_reason ?? '', /rate_abuse_opt_out|skipRateAbuse/);
+      assert.strictEqual(result.skip_reason, 'rate_abuse_opt_out');
+      assert.strictEqual(result.selection_result?.reason, 'explicit_scope_excluded');
     } finally {
       fresh.server.close();
     }


### PR DESCRIPTION
## Summary
- split runner-selected skips from not-selected exclusions in compliance summaries
- carry structured selection results through request-signing probes, storyboard track mapping, and summary artifacts
- add reason rollups for skipped and not-selected steps and bump summary artifact schema to v2
- align ESLint ignores with tsconfig so repo lint exits cleanly

Fixes #2012.

## Validation
- npm run ci:quick
- npm run lint
- NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/lib/compliance-summary.test.js test/lib/cli-summary-markdown.test.js test/request-signing-runner-integration.test.js test/lib/storyboard-skip-counting.test.js test/lib/compliance.test.js