### PR TITLE
fix: handle AdCP advisory errors by task

### DIFF
--- a/.changeset/advisory-errors-vendor-metrics.md
+++ b/.changeset/advisory-errors-vendor-metrics.md
@@ -1,0 +1,5 @@
+---
+"@adcp/sdk": patch
+---
+
+Accept AdCP 3.1 `vendor_metric` optimization goals in `create_media_buy` validation and treat top-level `errors[]` as advisory when a task-aware success or submitted payload is present.

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -17,7 +17,7 @@ import {
   type ValidationMode,
 } from '../validation/client-hooks';
 import { formatIssues } from '../validation/schema-validator';
-import { unwrapProtocolResponse, isAdcpError } from '../utils/response-unwrapper';
+import { unwrapProtocolResponse, isAdcpError, isTerminalAdcpError } from '../utils/response-unwrapper';
 import { extractAdcpErrorInfo, extractCorrelationId } from '../utils/error-extraction';
 import { generateIdempotencyKey, isMutatingTask, redactIdempotencyKeyInArgs } from '../utils/idempotency';
 import { normalizeGetProductsResponse } from '../utils/pricing-adapter';
@@ -732,7 +732,7 @@ export class TaskExecutor {
         const completedData = this.extractResponseData(response, debugLogs, taskName);
         this.updateTaskStatus(taskId, 'completed', completedData);
 
-        const operationSuccess = this.isOperationSuccess(completedData);
+        const operationSuccess = this.isOperationSuccess(completedData, taskName);
 
         // Validate response against AdCP schema - validate extracted data, not protocol wrapper
         const validationResult = this.validateResponseSchema(completedData, taskName, debugLogs);
@@ -866,7 +866,7 @@ export class TaskExecutor {
           defaultData &&
           (defaultData !== response || response.structuredContent || response.result || response.data)
         ) {
-          const defaultSuccess = this.isOperationSuccess(defaultData);
+          const defaultSuccess = this.isOperationSuccess(defaultData, taskName);
 
           // Validate response against AdCP schema - validate extracted data, not protocol wrapper
           const defaultValidation = this.validateResponseSchema(defaultData, taskName, debugLogs);
@@ -1010,8 +1010,8 @@ export class TaskExecutor {
    * Check if extracted response data represents a successful operation.
    * Handles singular `error`, plural `errors` (AdCP schema), and `success: false`.
    */
-  private isOperationSuccess(data: any): boolean {
-    return data?.success !== false && !data?.error && !data?.adcp_error && !isAdcpError(data);
+  private isOperationSuccess(data: any, taskName?: string): boolean {
+    return data?.success !== false && !data?.error && !data?.adcp_error && !isTerminalAdcpError(data, taskName);
   }
 
   /**
@@ -1506,7 +1506,7 @@ export class TaskExecutor {
       }
 
       if (status.status === ADCP_STATUS.COMPLETED) {
-        const pollSuccess = this.isOperationSuccess(status.result);
+        const pollSuccess = this.isOperationSuccess(status.result, status.taskType);
 
         if (pollSuccess) {
           return attachMatch({

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1044,6 +1044,8 @@ export {
   unwrapProtocolResponse,
   isAdcpError,
   isAdcpSuccess,
+  isTerminalAdcpError,
+  hasAdvisorySuccessPayload,
   getAuthoritativeMediaBuyStatus,
   isMediaBuyStatus,
 } from './utils';

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -135,7 +135,13 @@ export function getStandardFormats(): CreativeFormat[] {
 }
 
 // Re-export response unwrapping utilities
-export { unwrapProtocolResponse, isAdcpError, isAdcpSuccess } from './response-unwrapper';
+export {
+  unwrapProtocolResponse,
+  isAdcpError,
+  isAdcpSuccess,
+  isTerminalAdcpError,
+  hasAdvisorySuccessPayload,
+} from './response-unwrapper';
 export type { AdCPResponse } from './response-unwrapper';
 export { getAuthoritativeMediaBuyStatus, isMediaBuyStatus } from './media-buy-status';
 

--- a/src/lib/utils/response-unwrapper.ts
+++ b/src/lib/utils/response-unwrapper.ts
@@ -94,6 +94,109 @@ export type AdCPResponse =
   | GetSignalsResponse
   | ActivateSignalResponse;
 
+const SUCCESS_PAYLOAD_FIELD_GROUPS_BY_TOOL: Readonly<Record<string, readonly (readonly string[])[]>> = {
+  get_adcp_capabilities: [['adcp', 'supported_protocols']],
+  list_accounts: [['accounts']],
+  sync_accounts: [['accounts']],
+  sync_governance: [['accounts']],
+  report_usage: [['accepted']],
+  get_account_financials: [['account', 'currency', 'period', 'timezone']],
+  get_products: [['products'], ['unchanged']],
+  list_creative_formats: [['formats']],
+  create_media_buy: [['media_buy_id', 'packages']],
+  update_media_buy: [['media_buy_id']],
+  get_media_buys: [['media_buys']],
+  get_media_buy_delivery: [['reporting_period', 'currency', 'media_buy_deliveries']],
+  provide_performance_feedback: [['success']],
+  sync_event_sources: [['event_sources']],
+  log_event: [['events_received', 'events_processed']],
+  sync_audiences: [['audiences']],
+  sync_catalogs: [['catalogs']],
+  sync_creatives: [['creatives']],
+  list_creatives: [['query_summary', 'pagination', 'creatives']],
+  build_creative: [['creative_manifest'], ['creative_manifests']],
+  preview_creative: [['response_type', 'previews']],
+  get_creative_delivery: [['currency', 'reporting_period', 'creatives']],
+  validate_input: [['results']],
+  get_signals: [['signals'], ['unchanged']],
+  activate_signal: [['deployments']],
+  create_property_list: [['list', 'auth_token']],
+  update_property_list: [['list']],
+  get_property_list: [['list']],
+  list_property_lists: [['lists']],
+  delete_property_list: [['deleted', 'list_id']],
+  create_collection_list: [['list', 'auth_token']],
+  update_collection_list: [['list']],
+  get_collection_list: [['list']],
+  list_collection_lists: [['lists']],
+  delete_collection_list: [['deleted', 'list_id']],
+  list_content_standards: [['standards']],
+  create_content_standards: [['standards_id']],
+  update_content_standards: [['success', 'standards_id']],
+  calibrate_content: [['verdict']],
+  validate_content_delivery: [['summary', 'results']],
+  get_media_buy_artifacts: [['media_buy_id', 'artifacts']],
+  get_creative_features: [['results']],
+  sync_plans: [['plans']],
+  check_governance: [['check_id', 'verdict', 'plan_id', 'explanation']],
+  report_plan_outcome: [['outcome_id', 'outcome_state']],
+  get_plan_audit_logs: [['plans']],
+  si_get_offering: [['available']],
+  si_initiate_session: [['session_id', 'session_status']],
+  si_send_message: [['session_id', 'session_status']],
+  si_terminate_session: [['session_id', 'terminated']],
+  comply_test_controller: [['success']],
+  validate_property_delivery: [['list_id', 'summary', 'results', 'validated_at']],
+  get_brand_identity: [['brand_id', 'house', 'names']],
+  verify_brand_claim: [['claim_type', 'verification_status']],
+  get_rights: [['rights']],
+  acquire_rights: [['rights_id', 'rights_status', 'brand_id']],
+  update_rights: [['rights_id']],
+  creative_approval: [['decision']],
+  verify_brand_claims: [['results']],
+  search_brands: [['brands']],
+};
+
+function hasOwnField(value: Record<string, unknown>, field: string): boolean {
+  return Object.prototype.hasOwnProperty.call(value, field);
+}
+
+/**
+ * Top-level `errors[]` can be either a terminal Error arm or non-fatal
+ * advisory diagnostics on a Success/Submitted arm. Envelope-only fields
+ * (`status`, `context`, `ext`, version fields) do not prove success, so this
+ * requires per-tool success-field evidence or the universal submitted envelope.
+ * Completed payloads still flow through normal tool-schema validation after
+ * this check.
+ */
+export function hasAdvisorySuccessPayload(response: unknown, toolName?: string): boolean {
+  if (response == null || typeof response !== 'object' || Array.isArray(response)) return false;
+  const obj = response as Record<string, unknown>;
+
+  if (obj.status === 'failed' || obj.status === 'rejected') return false;
+  if (obj.success === false) return false;
+
+  if (obj.status === 'submitted' && (typeof obj.task_id === 'string' || typeof obj.taskId === 'string')) {
+    return true;
+  }
+
+  if (!toolName) return false;
+
+  const successFieldGroups = SUCCESS_PAYLOAD_FIELD_GROUPS_BY_TOOL[toolName];
+  if (!successFieldGroups) return false;
+  return successFieldGroups.some(group => group.every(field => hasOwnField(obj, field)));
+}
+
+export function isTerminalAdcpError(response: unknown, toolName?: string): boolean {
+  const obj = response as Record<string, unknown> | null | undefined;
+  if (obj?.status === 'failed' || obj?.status === 'rejected') return true;
+  if (obj?.adcp_error && typeof (obj.adcp_error as { code?: unknown }).code === 'string') return true;
+  if (Array.isArray(obj?.errors) && obj.errors.length > 0) {
+    return !hasAdvisorySuccessPayload(obj, toolName);
+  }
+  return false;
+}
+
 /**
  * Extract raw AdCP response from protocol wrapper
  *
@@ -150,7 +253,7 @@ export function unwrapProtocolResponse(
   // Skip schema validation for error responses — they don't include
   // tool-specific fields like `products`. Handles both AdCP-standard
   // { errors: [...] } and legacy singular { error: "..." } patterns.
-  if (isAdcpError(unwrapped) || (unwrapped?.error && typeof unwrapped.error === 'string')) {
+  if (isTerminalAdcpError(unwrapped, toolName) || (unwrapped?.error && typeof unwrapped.error === 'string')) {
     return retag(unwrapped);
   }
 
@@ -586,6 +689,11 @@ function unwrapA2AResponse(response: any): AdCPResponse {
  * Check if a response is an AdCP error response.
  * Recognizes both `{ adcp_error: { code: string } }` (MCP structured errors)
  * and `{ errors: [{ code, message }] }` (legacy/A2A format).
+ *
+ * This helper is structural and intentionally does not know which tool
+ * produced the payload. For AdCP 3.1 success/submitted payloads that can
+ * carry advisory `errors[]`, prefer {@link isTerminalAdcpError} with a
+ * `toolName`.
  */
 export function isAdcpError(response: any): boolean {
   if (Array.isArray(response?.errors) && response.errors.length > 0) return true;
@@ -601,7 +709,7 @@ export function isAdcpError(response: any): boolean {
  */
 export function isAdcpSuccess(response: any, taskName: string): boolean {
   // First check if it's an error response
-  if (isAdcpError(response)) {
+  if (isTerminalAdcpError(response, taskName)) {
     return false;
   }
 

--- a/test/lib/poll-task-completion-terminal-states.test.js
+++ b/test/lib/poll-task-completion-terminal-states.test.js
@@ -6,6 +6,7 @@
 
 const { test, describe, beforeEach, afterEach, mock } = require('node:test');
 const assert = require('node:assert');
+const { createTestProduct } = require('./test-fixtures');
 
 describe('pollTaskCompletion terminal state handling', () => {
   let TaskExecutor;
@@ -181,6 +182,82 @@ describe('pollTaskCompletion terminal state handling', () => {
     assert.strictEqual(result.success, true);
     assert.strictEqual(result.data.status, undefined);
     assert.strictEqual(result.data.media_buy_status, 'pending_creatives');
+  });
+
+  test('returns success when completed task result has advisory errors[]', async () => {
+    ProtocolClient.callTool = mock.fn(async () => ({
+      task: {
+        taskId: 'task-advisory-success',
+        status: 'completed',
+        taskType: 'get_products',
+        result: {
+          status: 'completed',
+          cache_scope: 'public',
+          products: [createTestProduct({ product_id: 'prod-advisory-polled' })],
+          errors: [{ code: 'FORMAT_DECLARATION_DIVERGENT', message: 'advisory only' }],
+        },
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      },
+    }));
+
+    const executor = new TaskExecutor();
+    const result = await executor.pollTaskCompletion(mockAgent, 'task-advisory-success', 10);
+
+    assert.strictEqual(result.success, true);
+    assert.strictEqual(result.status, 'completed');
+    assert.strictEqual(result.data.products[0].product_id, 'prod-advisory-polled');
+    assert.strictEqual(result.data.errors[0].code, 'FORMAT_DECLARATION_DIVERGENT');
+    assert.strictEqual(result.adcpError, undefined);
+  });
+
+  test('returns failure when completed task result has explicit failed status', async () => {
+    ProtocolClient.callTool = mock.fn(async () => ({
+      task: {
+        taskId: 'task-terminal-payload',
+        status: 'completed',
+        taskType: 'report_usage',
+        result: {
+          status: 'failed',
+          accepted: 0,
+          errors: [{ code: 'INVALID_USAGE_ROW', message: 'all rows rejected' }],
+        },
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      },
+    }));
+
+    const executor = new TaskExecutor();
+    const result = await executor.pollTaskCompletion(mockAgent, 'task-terminal-payload', 10);
+
+    assert.strictEqual(result.success, false);
+    assert.strictEqual(result.status, 'failed');
+    assert.match(result.error, /all rows rejected/);
+    assert.strictEqual(result.adcpError.code, 'INVALID_USAGE_ROW');
+  });
+
+  test('returns failure when completed create_media_buy result lacks media_buy_id', async () => {
+    ProtocolClient.callTool = mock.fn(async () => ({
+      task: {
+        taskId: 'task-invalid-media-buy',
+        status: 'completed',
+        taskType: 'create_media_buy',
+        result: {
+          status: 'completed',
+          packages: [],
+          errors: [{ code: 'INVALID_RESPONSE', message: 'missing media_buy_id' }],
+        },
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      },
+    }));
+
+    const executor = new TaskExecutor();
+    const result = await executor.pollTaskCompletion(mockAgent, 'task-invalid-media-buy', 10);
+
+    assert.strictEqual(result.success, false);
+    assert.strictEqual(result.status, 'failed');
+    assert.match(result.error, /missing media_buy_id/);
   });
 
   test('exits on first poll without retries when tasks/get returns rejected', async () => {

--- a/test/lib/request-validation.test.js
+++ b/test/lib/request-validation.test.js
@@ -275,6 +275,94 @@ describe('SingleAgentClient Request Validation', () => {
         }
       }, 'brand takes precedence; brand_manifest stripped without causing a validation error');
     });
+
+    test('should accept vendor_metric optimization goals with vendor committed_metrics', async () => {
+      const originalCallTool = ProtocolClient.callTool;
+      const captured = [];
+      ProtocolClient.callTool = async (_agentConfig, toolName, args) => {
+        captured.push({ toolName, args });
+        return {
+          status: 'completed',
+          media_buy_id: 'mb-vendor-metric',
+          packages: [],
+        };
+      };
+
+      const mockMCPAgent = {
+        ...mockAgent,
+        agent_uri: 'https://test.example/mcp',
+        protocol: 'mcp',
+      };
+      const client = new AdCPClient([mockMCPAgent]);
+      const agent = client.agent(mockMCPAgent.id);
+      const inner = agent.client;
+      inner.discoveredEndpoint = mockMCPAgent.agent_uri;
+      inner.cachedCapabilities = {
+        version: 'v3',
+        majorVersions: [3],
+        protocols: ['media_buy'],
+        features: {
+          inlineCreativeManagement: false,
+          conversionTracking: false,
+          audienceTargeting: false,
+          propertyListFiltering: false,
+          contentStandards: false,
+        },
+        extensions: [],
+        _synthetic: false,
+      };
+
+      try {
+        await assert.doesNotReject(async () => {
+          await agent.createMediaBuy({
+            account: { account_id: 'test-account' },
+            brand: { domain: 'example.com' },
+            start_time: 'asap',
+            end_time: '2026-06-01T00:00:00Z',
+            packages: [
+              {
+                product_id: 'prod123',
+                pricing_option_id: 'cpm-fixed',
+                budget: 5000,
+                optimization_goals: [
+                  {
+                    kind: 'vendor_metric',
+                    vendor: { domain: 'attentionvendor.example' },
+                    metric_id: 'attention_score',
+                    target: { kind: 'threshold_rate', value: 70 },
+                    priority: 1,
+                  },
+                ],
+                committed_metrics: [
+                  {
+                    scope: 'vendor',
+                    vendor: { domain: 'attentionvendor.example' },
+                    metric_id: 'attention_score',
+                  },
+                ],
+              },
+            ],
+          });
+        }, 'vendor_metric optimization goal shape should not trigger SDK request validation');
+      } finally {
+        ProtocolClient.callTool = originalCallTool;
+      }
+
+      const call = captured.find(c => c.toolName === 'create_media_buy');
+      assert.ok(call, 'create_media_buy should be dispatched after validation');
+      assert.deepStrictEqual(call.args.packages[0].optimization_goals[0], {
+        kind: 'vendor_metric',
+        vendor: { domain: 'attentionvendor.example' },
+        metric_id: 'attention_score',
+        target: { kind: 'threshold_rate', value: 70 },
+        priority: 1,
+      });
+      assert.deepStrictEqual(call.args.packages[0].committed_metrics[0], {
+        scope: 'vendor',
+        vendor: { domain: 'attentionvendor.example' },
+        metric_id: 'attention_score',
+      });
+    });
   });
 
   // AdCP v3 schemas have additionalProperties: true for extensibility.

--- a/test/lib/response-unwrapper.test.js
+++ b/test/lib/response-unwrapper.test.js
@@ -3,7 +3,13 @@ const { test, describe } = require('node:test');
 const assert = require('node:assert');
 
 // Import the unwrapper utilities
-const { unwrapProtocolResponse, isAdcpError, isAdcpSuccess } = require('../../dist/lib/utils/index.js');
+const {
+  unwrapProtocolResponse,
+  isAdcpError,
+  isAdcpSuccess,
+  isTerminalAdcpError,
+  hasAdvisorySuccessPayload,
+} = require('../../dist/lib/utils/index.js');
 const { createTestProduct, createTestCreative, createTestFormat, createTestPackage } = require('./test-fixtures');
 
 describe('Response Unwrapper', () => {
@@ -25,6 +31,29 @@ describe('Response Unwrapper', () => {
       assert.ok(result.packages);
       assert.strictEqual(result.packages[0].package_id, 'pkg1');
       assert.strictEqual(result._message, 'Media buy created successfully');
+    });
+
+    test('should preserve get_products success payloads with advisory errors[]', () => {
+      const mcpResponse = {
+        structuredContent: {
+          status: 'completed',
+          cache_scope: 'public',
+          products: [createTestProduct({ product_id: 'canonical_formats_divergent_display' })],
+          errors: [
+            {
+              code: 'FORMAT_DECLARATION_DIVERGENT',
+              source: 'producer',
+              message: 'Dual-emitted canonical format metadata differs from the v1 projection',
+            },
+          ],
+        },
+      };
+
+      const result = unwrapProtocolResponse(mcpResponse, 'get_products', 'mcp');
+
+      assert.strictEqual(result.products[0].product_id, 'canonical_formats_divergent_display');
+      assert.strictEqual(result.errors[0].code, 'FORMAT_DECLARATION_DIVERGENT');
+      assert.strictEqual(isAdcpSuccess(result, 'get_products'), true);
     });
 
     test('should unwrap A2A result.artifacts response with validation', () => {
@@ -1151,6 +1180,66 @@ describe('Response Unwrapper', () => {
     test('should return false for adcp_error without code', () => {
       assert.strictEqual(isAdcpError({ adcp_error: {} }), false);
     });
+
+    test('isAdcpError remains structural; isTerminalAdcpError is task-aware for advisory errors[]', () => {
+      const advisorySuccess = {
+        status: 'completed',
+        cache_scope: 'public',
+        products: [createTestProduct({ product_id: 'prod-advisory' })],
+        errors: [{ code: 'FORMAT_DECLARATION_DIVERGENT', message: 'advisory' }],
+      };
+
+      assert.strictEqual(isAdcpError(advisorySuccess), true);
+      assert.strictEqual(hasAdvisorySuccessPayload(advisorySuccess, 'get_products'), true);
+      assert.strictEqual(isTerminalAdcpError(advisorySuccess, 'get_products'), false);
+    });
+
+    test('task-aware terminal detection accepts report_usage partial success errors[]', () => {
+      const partialSuccess = {
+        status: 'completed',
+        accepted: 2,
+        errors: [{ code: 'INVALID_USAGE_ROW', message: 'one row rejected' }],
+      };
+
+      assert.strictEqual(isAdcpError(partialSuccess), true);
+      assert.strictEqual(hasAdvisorySuccessPayload(partialSuccess, 'report_usage'), true);
+      assert.strictEqual(isTerminalAdcpError(partialSuccess, 'report_usage'), false);
+      assert.strictEqual(isAdcpSuccess(partialSuccess, 'report_usage'), true);
+    });
+
+    test('explicit terminal status wins over advisory success fields', () => {
+      const terminalPayload = {
+        status: 'failed',
+        accepted: 0,
+        errors: [{ code: 'INVALID_USAGE_ROW', message: 'all rows rejected' }],
+      };
+
+      assert.strictEqual(hasAdvisorySuccessPayload(terminalPayload, 'report_usage'), false);
+      assert.strictEqual(isTerminalAdcpError(terminalPayload, 'report_usage'), true);
+      assert.strictEqual(isAdcpSuccess(terminalPayload, 'report_usage'), false);
+    });
+
+    test('task-aware terminal detection rejects envelope-only errors[] as failures', () => {
+      const envelopeOnly = {
+        status: 'completed',
+        context: { correlation_id: 'corr-envelope-only' },
+        errors: [{ code: 'INVALID_REQUEST', message: 'no success payload' }],
+      };
+
+      assert.strictEqual(hasAdvisorySuccessPayload(envelopeOnly, 'get_products'), false);
+      assert.strictEqual(isTerminalAdcpError(envelopeOnly, 'get_products'), true);
+    });
+
+    test('submitted envelopes can carry advisory errors[] without becoming terminal failures', () => {
+      const submitted = {
+        status: 'submitted',
+        task_id: 'task-advisory',
+        errors: [{ code: 'GOVERNANCE_OBSERVATION', message: 'queued with advisory' }],
+      };
+
+      assert.strictEqual(hasAdvisorySuccessPayload(submitted, 'create_media_buy'), true);
+      assert.strictEqual(isTerminalAdcpError(submitted, 'create_media_buy'), false);
+    });
   });
 
   describe('isAdcpSuccess', () => {
@@ -1243,6 +1332,49 @@ describe('Response Unwrapper', () => {
       assert.strictEqual(result.products[0].product_id, 'p1');
       // Should NOT have protocol envelope fields
       assert.strictEqual(result.content, undefined, 'Should not return raw MCP envelope');
+    });
+
+    test('executeTask returns completed success when get_products has advisory errors[]', async () => {
+      const { TaskExecutor } = require('../../dist/lib/core/TaskExecutor');
+      const { ProtocolClient } = require('../../dist/lib/protocols');
+      const executor = new TaskExecutor({ validation: { responses: 'strict' } });
+      const originalCallTool = ProtocolClient.callTool;
+
+      ProtocolClient.callTool = async () => ({
+        structuredContent: {
+          status: 'completed',
+          cache_scope: 'public',
+          products: [createTestProduct({ product_id: 'canonical_formats_divergent_display' })],
+          errors: [
+            {
+              code: 'FORMAT_DECLARATION_DIVERGENT',
+              source: 'producer',
+              message: 'Dual-emitted canonical format metadata differs from the v1 projection',
+            },
+          ],
+        },
+      });
+
+      try {
+        const result = await executor.executeTask(
+          {
+            id: 'agent-1',
+            name: 'Agent 1',
+            agent_uri: 'https://seller.example/mcp',
+            protocol: 'mcp',
+          },
+          'get_products',
+          {}
+        );
+
+        assert.strictEqual(result.success, true);
+        assert.strictEqual(result.status, 'completed');
+        assert.strictEqual(result.data.products[0].product_id, 'canonical_formats_divergent_display');
+        assert.strictEqual(result.data.errors[0].code, 'FORMAT_DECLARATION_DIVERGENT');
+        assert.strictEqual(result.adcpError, undefined);
+      } finally {
+        ProtocolClient.callTool = originalCallTool;
+      }
     });
 
     test('should return raw response when unwrapping fails completely', () => {


### PR DESCRIPTION
## Summary
- accept AdCP 3.1 vendor_metric optimization_goals and vendor committed_metrics in create_media_buy validation
- distinguish terminal AdCP errors from advisory errors[] on task-aware success/submitted payloads
- add public task-aware helpers for advisory-success detection and terminal error detection
- add regression coverage for get_products advisory errors, report_usage partial success, polled tasks/get completions, terminal payload statuses, and media-buy required success evidence

## Root Cause
The SDK used structural errors[] detection as terminal failure detection. In AdCP 3.1, success/submitted payloads can carry advisory errors[], so callers need task-aware success evidence before treating errors[] as fatal. The fix keeps isAdcpError() structural for compatibility and routes operation success through isTerminalAdcpError(toolName).

## Validation
- npm run build:lib
- NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/lib/response-unwrapper.test.js test/lib/request-validation.test.js test/lib/poll-task-completion-terminal-states.test.js test/lib/protocol-response-parser-status.test.js
- NODE_ENV=test node --test-timeout=120000 --test-force-exit --test test/lib/*.test.js

## Expert Review
- protocol review found missing success-evidence coverage and polled-completion gaps; fixed with field groups and tests
- code review found terminal payload status and cancel_media_buy enum-collision edge cases; fixed and covered

Fixes #2013
Fixes #2014