### PR TITLE
fix: resolve MCP idempotency storyboard failures

### DIFF
--- a/.changeset/mcp-idempotency-session-recovery.md
+++ b/.changeset/mcp-idempotency-session-recovery.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Fix idempotency storyboard grading for MCP sellers by keeping missing-field vectors on the initialized SDK transport, and allow standard `recovery` metadata on `IDEMPOTENCY_CONFLICT` error envelopes.

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -56,7 +56,7 @@ import {
 } from './adcp-server';
 import { createTaskCapableServer } from './tasks';
 import type { TaskStore, TaskMessageQueue } from './tasks';
-import { adcpError } from './errors';
+import { adcpError, applyAdcpErrorAllowlist } from './errors';
 import type { BuyerAgent, BuyerAgentRegistry } from './decisioning/buyer-agent';
 import type { ResolvedAuthInfo } from './decisioning/account';
 import { AdcpError } from './decisioning/async-outcome';
@@ -2425,16 +2425,16 @@ function sanitizeAdcpErrorEnvelope(response: McpToolResponse): void {
   const allow = ADCP_ERROR_FIELD_ALLOWLIST[code];
   if (!allow) return;
 
-  const filtered: Record<string, unknown> = {};
-  let droppedAny = false;
-  for (const [k, v] of Object.entries(err)) {
-    if (allow.has(k)) {
-      filtered[k] = v;
-    } else {
-      droppedAny = true;
+  const filtered = applyAdcpErrorAllowlist(code, err);
+  const filteredRecord = filtered as unknown as Record<string, unknown>;
+  let changed = false;
+  for (const key of new Set([...Object.keys(err), ...Object.keys(filtered)])) {
+    if (err[key] !== filteredRecord[key]) {
+      changed = true;
+      break;
     }
   }
-  if (!droppedAny) return;
+  if (!changed) return;
 
   sc.adcp_error = filtered;
   if (Array.isArray(response.content)) {

--- a/src/lib/server/envelope-allowlist.ts
+++ b/src/lib/server/envelope-allowlist.ts
@@ -87,17 +87,14 @@ export const ERROR_ENVELOPE_FIELD_ALLOWLIST: Readonly<Record<string, ReadonlySet
  * by falling back to the recovery classification" — so dropping
  * `recovery` on a vendor / non-standard code makes the response
  * genuinely lossy for any buyer agent that doesn't have the code in
- * its local vocabulary. `IDEMPOTENCY_CONFLICT` is safe because it is
- * a standard code whose `recovery` (`correctable`) is fixed in the
- * enum schema and derivable client-side.
+ * its local vocabulary.
  *
  * `IDEMPOTENCY_CONFLICT` is narrow on purpose: a conflict response MUST
  * NOT echo the prior request payload or cached response (stolen-key
- * read oracle defence). `recovery` is deliberately excluded — the
- * classifier is redundant with `code` (same information, derivable from
- * the standard error-code table), and adding it widens the surface the
- * invariant has to defend for future fields. `retry_after` is excluded
- * too: no framework path currently emits it on conflict, and a seller
+ * read oracle defence). Standard recovery metadata is allowed because it
+ * is normalized to the fixed classifier, not trusted as caller-provided
+ * prior request or cached response data.
+ * `retry_after` is excluded: no framework path currently emits it on conflict, and a seller
  * that computed `retry_after = cached_entry_age` would leak the prior
  * payload's creation time (a distinguisher between "key never seen" vs
  * "key seen N seconds ago"). Retry hints belong on transient codes
@@ -105,7 +102,15 @@ export const ERROR_ENVELOPE_FIELD_ALLOWLIST: Readonly<Record<string, ReadonlySet
  * `adcpError()` and the dispatcher sanitizer both enforce this.
  */
 export const ADCP_ERROR_FIELD_ALLOWLIST: Readonly<Record<string, ReadonlySet<string>>> = Object.freeze({
-  IDEMPOTENCY_CONFLICT: new Set(['code', 'message', 'status', 'correlation_id', 'request_id', 'operation_id']),
+  IDEMPOTENCY_CONFLICT: new Set([
+    'code',
+    'message',
+    'recovery',
+    'status',
+    'correlation_id',
+    'request_id',
+    'operation_id',
+  ]),
   // `IDEMPOTENCY_IN_FLIGHT` (AdCP 3.1) carries `recovery: transient` plus a
   // store-derived `retry_after` so transient-aware buyer SDKs can replay
   // shortly. Allowlist registration is defense-in-depth — `adcpError()` at

--- a/src/lib/server/errors.ts
+++ b/src/lib/server/errors.ts
@@ -20,8 +20,8 @@ export interface AdcpErrorOptions {
    * Override the recovery classification. Defaults to
    * `STANDARD_ERROR_CODES[code].recovery` for known codes, `'terminal'`
    * otherwise. Dropped from the wire shape for codes whose entry in
-   * `ADCP_ERROR_FIELD_ALLOWLIST` excludes it (`IDEMPOTENCY_CONFLICT`
-   * excludes `recovery` — the classifier is derivable from the code).
+   * `ADCP_ERROR_FIELD_ALLOWLIST` excludes it; normalized back to the
+   * standard table value for allowlisted standard-code envelopes.
    */
   recovery?: ErrorRecovery;
   /**
@@ -69,9 +69,8 @@ export interface AdcpErrorPayload {
    * Closed-enum classifier. Populated by `adcpError()` from
    * `STANDARD_ERROR_CODES[code].recovery` unless the caller provides an
    * override. Marked optional because per-code inside-`adcp_error`
-   * allowlists (e.g. `IDEMPOTENCY_CONFLICT`) deliberately drop it from the
-   * wire shape — consumers reading a payload parsed off the wire MUST
-   * tolerate `undefined`.
+   * allowlists may deliberately drop it from the wire shape — consumers
+   * reading a payload parsed off the wire MUST tolerate `undefined`.
    */
   recovery?: ErrorRecovery;
   field?: string;
@@ -109,9 +108,10 @@ export interface AdcpErrorResponse {
  * {@link ADCP_ERROR_FIELD_ALLOWLIST} is dropped — sellers get the builder's
  * ergonomics for every code AND the strict wire shape for codes that have
  * a registered allowlist. `IDEMPOTENCY_CONFLICT` is the canonical case:
- * `recovery`, `field`, `suggestion`, and `details` all silently drop so
- * the envelope can't become a stolen-key read oracle. Codes without a
- * registered allowlist pass through unchanged.
+ * payload-shaped diagnostics like `field`, `suggestion`, and `details`
+ * silently drop while standard `recovery` metadata is preserved as the
+ * canonical standard-table value. Codes without a registered allowlist
+ * pass through unchanged.
  *
  * **Two-layer wire shape.** This builder emits the envelope layer
  * (`structuredContent.adcp_error`) only. For tools whose response
@@ -140,9 +140,7 @@ export interface AdcpErrorResponse {
  * ```
  */
 export function adcpError(code: StandardErrorCode | (string & {}), options: AdcpErrorOptions): AdcpErrorResponse {
-  const recovery: ErrorRecovery =
-    options.recovery ??
-    (isStandardErrorCode(code) ? STANDARD_ERROR_CODES[code as StandardErrorCode].recovery : 'terminal');
+  const recovery = normalizeRecoveryForCode(code, options.recovery);
 
   const adcp_error: AdcpErrorPayload = {
     code,
@@ -155,7 +153,7 @@ export function adcpError(code: StandardErrorCode | (string & {}), options: Adcp
     ...(options.details != null && { details: options.details }),
   };
 
-  const filtered = applyAdcpErrorAllowlist(code, adcp_error);
+  const filtered = applyAdcpErrorAllowlist(code, adcp_error as unknown as Record<string, unknown>);
 
   return {
     content: [{ type: 'text', text: JSON.stringify({ adcp_error: filtered }) }],
@@ -166,6 +164,9 @@ export function adcpError(code: StandardErrorCode | (string & {}), options: Adcp
 
 /**
  * Drop every field not in {@link ADCP_ERROR_FIELD_ALLOWLIST} for `code`.
+ * When an allowlisted standard code carries `recovery`, normalize it to
+ * the fixed classifier from `STANDARD_ERROR_CODES` instead of trusting a
+ * caller-supplied value.
  * Codes without an entry pass through unchanged — the allowlist is
  * opt-in per code, not a global filter. The returned object is re-typed
  * as `AdcpErrorPayload` on the assumption that `code` and `message`
@@ -173,12 +174,28 @@ export function adcpError(code: StandardErrorCode | (string & {}), options: Adcp
  * invariant is re-asserted at runtime by the module-load check in
  * `envelope-allowlist.ts`.
  */
-function applyAdcpErrorAllowlist(code: string, payload: AdcpErrorPayload): AdcpErrorPayload {
+export function applyAdcpErrorAllowlist(code: string, payload: Record<string, unknown>): AdcpErrorPayload {
   const allowlist = ADCP_ERROR_FIELD_ALLOWLIST[code];
-  if (!allowlist) return payload;
+  if (!allowlist) return payload as unknown as AdcpErrorPayload;
   const out: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(payload)) {
-    if (allowlist.has(key)) out[key] = value;
+    if (!allowlist.has(key)) continue;
+    out[key] = key === 'recovery' ? normalizeAllowlistedRecoveryForCode(code, value) : value;
   }
   return out as unknown as AdcpErrorPayload;
+}
+
+function isErrorRecovery(value: unknown): value is ErrorRecovery {
+  return value === 'transient' || value === 'correctable' || value === 'terminal';
+}
+
+function normalizeRecoveryForCode(code: string, value: unknown): ErrorRecovery {
+  return isErrorRecovery(value) ? value : isStandardErrorCode(code) ? STANDARD_ERROR_CODES[code].recovery : 'terminal';
+}
+
+function normalizeAllowlistedRecoveryForCode(code: string, value: unknown): ErrorRecovery {
+  if (isStandardErrorCode(code)) {
+    return STANDARD_ERROR_CODES[code].recovery;
+  }
+  return normalizeRecoveryForCode(code, value);
 }

--- a/src/lib/server/wrap-envelope.ts
+++ b/src/lib/server/wrap-envelope.ts
@@ -23,6 +23,7 @@
  */
 
 import { DEFAULT_ERROR_ENVELOPE_FIELDS, ERROR_ENVELOPE_FIELD_ALLOWLIST } from './envelope-allowlist';
+import { applyAdcpErrorAllowlist } from './errors';
 
 /**
  * Options accepted by {@link wrapEnvelope}.
@@ -123,7 +124,7 @@ function isEchoableContext(value: unknown): boolean {
  *       // Conflict is NOT a replay — replayed is dropped by the allowlist,
  *       // but context still echoes for correlation tracing.
  *       return wrapEnvelope(
- *         { adcp_error: { code: 'IDEMPOTENCY_CONFLICT', message: err.message, recovery: 'terminal' } },
+ *         { adcp_error: { code: 'IDEMPOTENCY_CONFLICT', message: err.message, recovery: 'correctable' } },
  *         { context: request.context }
  *       );
  *     }
@@ -153,7 +154,7 @@ function isEchoableContext(value: unknown): boolean {
  * @example Conflict error — `replayed` is dropped, `context` is echoed
  * ```ts
  * const response = wrapEnvelope(
- *   { adcp_error: { code: 'IDEMPOTENCY_CONFLICT', message: '...', recovery: 'terminal' } },
+ *   { adcp_error: { code: 'IDEMPOTENCY_CONFLICT', message: '...', recovery: 'correctable' } },
  *   { replayed: true, context: { correlation_id: 'abc' }, operationId: 'op_123' }
  * );
  * // `replayed: true` is intentionally dropped — IDEMPOTENCY_CONFLICT's
@@ -184,6 +185,11 @@ export function wrapEnvelope<T extends object>(
   };
 
   const errorCode = detectErrorCode(inner, opts.errorCode);
+  const adcpError = clone.adcp_error;
+  if (errorCode != null && adcpError != null && typeof adcpError === 'object' && !Array.isArray(adcpError)) {
+    clone.adcp_error = applyAdcpErrorAllowlist(errorCode, adcpError as Record<string, unknown>);
+  }
+
   // Error responses: registered codes use their explicit allowlist;
   // unregistered codes fail closed to DEFAULT_ERROR_ENVELOPE_FIELDS
   // (context only). Success responses (no error code) allow all fields.

--- a/src/lib/testing/storyboard/default-invariants.ts
+++ b/src/lib/testing/storyboard/default-invariants.ts
@@ -42,6 +42,7 @@
 
 import { ADCP_VERSION } from '../../version';
 import { CONFLICT_ADCP_ERROR_ALLOWLIST } from '../../server/envelope-allowlist';
+import { STANDARD_ERROR_CODES } from '../../types/error-codes';
 import {
   CREATIVE_ASSET_TRANSITIONS as CREATIVE_ASSET_TRANSITIONS_TYPED,
   MEDIA_BUY_TRANSITIONS as MEDIA_BUY_TRANSITIONS_TYPED,
@@ -72,6 +73,19 @@ registerOnce('idempotency.conflict_no_payload_leak', {
     const leaked: string[] = [];
     for (const key of Object.keys(err.details)) {
       if (!CONFLICT_ADCP_ERROR_ALLOWLIST.has(key)) leaked.push(key);
+    }
+    const expectedRecovery = STANDARD_ERROR_CODES.IDEMPOTENCY_CONFLICT.recovery;
+    if ('recovery' in err.details && err.details.recovery !== expectedRecovery) {
+      return [
+        {
+          passed: false,
+          description,
+          step_id: stepResult.step_id,
+          error:
+            `IDEMPOTENCY_CONFLICT error envelope carried non-standard recovery metadata: ` +
+            `expected ${JSON.stringify(expectedRecovery)}.`,
+        },
+      ];
     }
     if (leaked.length === 0) {
       return [{ passed: true, description, step_id: stepResult.step_id }];

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -3483,25 +3483,16 @@ async function executeStep(
   // `omit_account: true` the runner has already suppressed account synthesis
   // in `applyBrandInvariant` (above — ordering is load-bearing: this must
   // come after `applyBrandInvariant` so the comment "above" stays accurate
-  // if either block is reordered). Track the flag here so the raw-probe
-  // defense-in-depth path is also triggered and no SDK-layer normalization
-  // can silently re-inject an account before the wire call.
+  // if either block is reordered). Track the flag here so the SDK call below
+  // can also skip client-side account validation/injection before the wire call.
   const testsMissingAccount = step.omit_account === true && effectiveStep.task === 'create_media_buy';
 
-  // Defense-in-depth for the missing-field vectors: when a step sets
-  // `omit_idempotency_key: true` or `omit_account: true` and `step.auth` is
-  // unset, route via `rawMcpProbe` anyway so no SDK-layer normalization can
-  // slip the missing field onto the wire. The SDK's `skipIdempotencyAutoInject`
-  // / `skipAccountValidation` plumbing already honors these flags, but the
-  // raw-HTTP path removes the escape hatch entirely. A2A and oauth stay on
-  // the SDK path — their dispatch can't be replicated here (A2A uses a
-  // different envelope; oauth needs refresh semantics).
+  // Raw MCP dispatch is reserved for steps that explicitly override auth.
+  // Missing-field vectors stay on the SDK transport with the skip flags below
+  // so Streamable HTTP session setup completes before the malformed tool call
+  // reaches the seller handler.
   const rawProbeHeaders: Record<string, string> | undefined =
-    step.auth !== undefined
-      ? authHeadersForStep(step.auth, options)
-      : (testsMissingIdempotencyKey || testsMissingAccount) && options.protocol !== 'a2a'
-        ? defaultAuthHeadersForRawProbe(options)
-        : undefined;
+    step.auth !== undefined ? authHeadersForStep(step.auth, options) : undefined;
   const useRawProbe = rawProbeHeaders !== undefined;
 
   let taskResult: TaskResult | undefined;
@@ -4687,11 +4678,10 @@ function resolveTaskName(step: StoryboardStep, options: StoryboardRunOptions): s
 }
 
 /**
- * Build headers for the raw MCP probe when a step needs raw dispatch without
- * an explicit `auth` override (defense-in-depth for `omit_idempotency_key`).
- * Returns `undefined` for `oauth` so the caller falls back to the SDK path —
- * refreshable-token semantics can't be replicated here and the SDK honors
- * `skipIdempotencyAutoInject` on that path anyway.
+ * Build SDK-equivalent default headers for raw MCP probe tests. Runtime raw
+ * probe dispatch is reserved for explicit per-step `auth` overrides; ordinary
+ * missing-field vectors stay on the SDK path so Streamable HTTP sessions are
+ * initialized before the malformed tool call.
  */
 function defaultAuthHeadersForRawProbe(options: StoryboardRunOptions): Record<string, string> | undefined {
   // Reject control chars and non-printable ASCII. Without this, undici's header

--- a/test/lib/adcp-error-allowlist.test.js
+++ b/test/lib/adcp-error-allowlist.test.js
@@ -3,10 +3,10 @@
  *
  * The builder consults the per-code inside-`adcp_error` allowlist and
  * drops any field not listed for the given code. `IDEMPOTENCY_CONFLICT`
- * is the canonical strict case — `recovery`, `field`, `suggestion`, and
- * `details` all silently drop so the envelope can't become a stolen-key
- * read oracle. Codes without a registered allowlist pass through
- * unchanged (default behavior).
+ * is the canonical strict case — `field`, `suggestion`, and `details`
+ * all silently drop so the envelope can't become a stolen-key read
+ * oracle, while standard `recovery` metadata is preserved. Codes without
+ * a registered allowlist pass through unchanged (default behavior).
  */
 
 const { describe, it } = require('node:test');
@@ -19,12 +19,28 @@ const {
 } = require('../../dist/lib/server/index.js');
 
 describe('adcpError: IDEMPOTENCY_CONFLICT allowlist', () => {
-  it('drops recovery even though STANDARD_ERROR_CODES declares it "correctable"', () => {
+  it('preserves recovery from STANDARD_ERROR_CODES', () => {
     const res = adcpError('IDEMPOTENCY_CONFLICT', { message: 'key reused' });
     const payload = res.structuredContent.adcp_error;
     assert.equal(payload.code, 'IDEMPOTENCY_CONFLICT');
     assert.equal(payload.message, 'key reused');
-    assert.ok(!('recovery' in payload), 'recovery must be dropped on conflict');
+    assert.equal(payload.recovery, 'correctable');
+  });
+
+  it('normalizes caller-supplied conflict recovery to the standard classifier', () => {
+    const res = adcpError('IDEMPOTENCY_CONFLICT', {
+      message: 'key reused',
+      recovery: 'terminal',
+    });
+    assert.equal(res.structuredContent.adcp_error.recovery, 'correctable');
+  });
+
+  it('does not allow recovery to carry payload-shaped data', () => {
+    const res = adcpError('IDEMPOTENCY_CONFLICT', {
+      message: 'key reused',
+      recovery: { prior_payload: { secret: 'tok-123' } },
+    });
+    assert.equal(res.structuredContent.adcp_error.recovery, 'correctable');
   });
 
   it('drops field, suggestion, details even when the caller passes them', () => {
@@ -93,10 +109,10 @@ describe('adcpError: unlisted codes pass through unchanged', () => {
 });
 
 describe('ADCP_ERROR_FIELD_ALLOWLIST: registered shape', () => {
-  it('IDEMPOTENCY_CONFLICT entry is frozen and excludes recovery', () => {
+  it('IDEMPOTENCY_CONFLICT entry is frozen and includes recovery', () => {
     const conflict = ADCP_ERROR_FIELD_ALLOWLIST.IDEMPOTENCY_CONFLICT;
     assert.ok(conflict instanceof Set);
-    assert.ok(!conflict.has('recovery'));
+    assert.ok(conflict.has('recovery'));
     assert.ok(conflict.has('code'));
     assert.ok(conflict.has('message'));
   });

--- a/test/lib/storyboard-account-invariant.test.js
+++ b/test/lib/storyboard-account-invariant.test.js
@@ -213,81 +213,69 @@ describe('runStoryboard: omit_account wire-level behavior', () => {
     }
   });
 
-  it('bypasses the SDK via raw probe when omit_account=true (defense-in-depth for SDK account injection)', async () => {
+  it('uses the SDK transport when omit_account=true without a per-step auth override', async () => {
     const seen = [];
-    const server = http.createServer(async (req, res) => {
-      const chunks = [];
-      for await (const c of req) chunks.push(c);
-      const rpc = JSON.parse(Buffer.concat(chunks).toString('utf8'));
-      seen.push({
-        name: rpc.params.name,
-        args: rpc.params.arguments,
-        authorization: req.headers['authorization'],
-      });
-      res.writeHead(400, { 'content-type': 'application/json' });
-      res.end(
-        JSON.stringify({
-          jsonrpc: '2.0',
-          id: rpc.id,
-          error: { code: -32000, message: 'INVALID_REQUEST: account is required' },
-        })
-      );
-    });
-    await new Promise(r => server.listen(0, r));
-    const agentUrl = `http://127.0.0.1:${server.address().port}/mcp`;
-    try {
-      const storyboard = {
-        id: 'raw_probe_account_sb',
-        version: '1.0.0',
-        title: 'Raw probe: missing account (bearer auth)',
-        category: 'compliance',
-        summary: '',
-        narrative: '',
-        agent: { interaction_model: '*', capabilities: [] },
-        caller: { role: 'buyer_agent' },
-        phases: [
-          {
-            id: 'p',
-            title: 'error',
-            steps: [
-              {
-                id: 's1_bearer_missing_account',
-                title: 'bearer-authenticated missing-account vector must reach the server',
-                task: 'create_media_buy',
-                expect_error: true,
-                omit_account: true,
-                sample_request: {
-                  brand: { name: 'Acme', domain: 'acme.com' },
-                  packages: [],
-                },
-                validations: [],
+    const storyboard = {
+      id: 'sdk_account_sb',
+      version: '1.0.0',
+      title: 'SDK path: missing account (bearer auth)',
+      category: 'compliance',
+      summary: '',
+      narrative: '',
+      agent: { interaction_model: '*', capabilities: [] },
+      caller: { role: 'buyer_agent' },
+      phases: [
+        {
+          id: 'p',
+          title: 'error',
+          steps: [
+            {
+              id: 's1_bearer_missing_account',
+              title: 'bearer-authenticated missing-account vector must reach the server',
+              task: 'create_media_buy',
+              expect_error: true,
+              omit_account: true,
+              sample_request: {
+                brand: { name: 'Acme', domain: 'acme.com' },
+                packages: [],
               },
-            ],
-          },
-        ],
-      };
-      await runStoryboard(agentUrl, storyboard, {
-        protocol: 'mcp',
-        allow_http: true,
-        auth: { type: 'bearer', token: 'tok-1696' },
-        brand: { name: 'Acme', domain: 'acme.com' },
-        agentTools: ['create_media_buy'],
-        _profile: { name: 'Test', tools: ['create_media_buy'] },
-        _client: {
-          getAgentInfo: async () => ({ name: 'Test', tools: [{ name: 'create_media_buy' }] }),
+              validations: [],
+            },
+          ],
         },
-      });
+      ],
+    };
+    await runStoryboard('http://127.0.0.1:1/mcp', storyboard, {
+      protocol: 'mcp',
+      allow_http: true,
+      auth: { type: 'bearer', token: 'tok-1696' },
+      brand: { name: 'Acme', domain: 'acme.com' },
+      agentTools: ['create_media_buy'],
+      _profile: { name: 'Test', tools: ['create_media_buy'] },
+      _client: {
+        getAgentInfo: async () => ({ name: 'Test', tools: [{ name: 'create_media_buy' }] }),
+        createMediaBuy: async (args, _inputHandler, options) => {
+          seen.push({ args, options });
+          return {
+            success: false,
+            error: 'INVALID_REQUEST: account is required',
+            adcpError: { code: 'INVALID_REQUEST', message: 'account is required' },
+          };
+        },
+      },
+    });
 
-      assert.strictEqual(seen.length, 1, `expected 1 tool call, got ${seen.length}`);
-      assert.strictEqual(
-        seen[0].args.account,
-        undefined,
-        'SDK-layer normalization must not inject account when omit_account=true'
-      );
-      assert.strictEqual(seen[0].authorization, 'Bearer tok-1696', 'raw probe must forward the bearer token');
-    } finally {
-      server.close();
-    }
+    assert.strictEqual(seen.length, 1, `expected 1 SDK tool call, got ${seen.length}`);
+    assert.strictEqual(
+      seen[0].args.account,
+      undefined,
+      'SDK-layer normalization must not inject account when omit_account=true'
+    );
+    assert.strictEqual(
+      seen[0].options.skipAccountValidation,
+      true,
+      'runner must signal the SDK transport to leave account absent'
+    );
   });
 });
 

--- a/test/lib/storyboard-default-invariants.test.js
+++ b/test/lib/storyboard-default-invariants.test.js
@@ -703,28 +703,45 @@ describe('default-invariants: idempotency.conflict_no_payload_leak (widened allo
     assert.strictEqual(out[0].passed, true);
   });
 
-  test('passes on the exact shape adcpError() emits (code+message, recovery dropped)', () => {
-    // `adcpError()` consults ADCP_ERROR_FIELD_ALLOWLIST and drops
-    // `recovery` for IDEMPOTENCY_CONFLICT — the classifier is redundant
-    // with `code` and would widen the stolen-key-read surface. The SDK's
-    // own builder output must therefore pass the invariant with just
-    // `code + message` on the wire.
-    const out = spec.onStep({ state: {} }, step({ code: 'IDEMPOTENCY_CONFLICT', message: 'conflict' }));
-    assert.strictEqual(out.length, 1);
-    assert.strictEqual(out[0].passed, true, out[0].error);
-  });
-
-  test('flags recovery when a non-SDK handler emits it (invariant stays strict)', () => {
-    // If a seller hand-rolls an envelope with `recovery` on conflict,
-    // the invariant catches it — option-1 posture from #826: the
-    // allowlist is the contract, the SDK's own builder respects it, and
-    // non-SDK emitters are held to the same bar.
+  test('passes on the exact shape adcpError() emits, including standard recovery metadata', () => {
     const out = spec.onStep(
       { state: {} },
       step({ code: 'IDEMPOTENCY_CONFLICT', message: 'conflict', recovery: 'correctable' })
     );
+    assert.strictEqual(out.length, 1);
+    assert.strictEqual(out[0].passed, true, out[0].error);
+  });
+
+  test('passes recovery when a non-SDK handler emits standard metadata', () => {
+    const out = spec.onStep(
+      { state: {} },
+      step({ code: 'IDEMPOTENCY_CONFLICT', message: 'conflict', recovery: 'correctable' })
+    );
+    assert.strictEqual(out[0].passed, true, out[0].error);
+  });
+
+  test('flags non-standard recovery metadata', () => {
+    const out = spec.onStep(
+      { state: {} },
+      step({ code: 'IDEMPOTENCY_CONFLICT', message: 'conflict', recovery: 'terminal' })
+    );
     assert.strictEqual(out[0].passed, false);
-    assert.match(out[0].error, /recovery/);
+    assert.match(out[0].error, /non-standard recovery metadata/);
+    assert.doesNotMatch(out[0].error, /terminal/);
+  });
+
+  test('flags payload-shaped recovery metadata without echoing the value', () => {
+    const out = spec.onStep(
+      { state: {} },
+      step({
+        code: 'IDEMPOTENCY_CONFLICT',
+        message: 'conflict',
+        recovery: { prior_payload: { secret: 'tok-123' } },
+      })
+    );
+    assert.strictEqual(out[0].passed, false);
+    assert.match(out[0].error, /non-standard recovery metadata/);
+    assert.doesNotMatch(out[0].error, /tok-123/);
   });
 
   test('flags retry_after as a cached-entry-age oracle', () => {

--- a/test/lib/storyboard-idempotency-invariant.test.js
+++ b/test/lib/storyboard-idempotency-invariant.test.js
@@ -314,91 +314,71 @@ describe('runStoryboard: idempotency_key invariant on the wire', () => {
     }
   });
 
-  // Defense-in-depth (issue #678): an agent that authenticates with a bearer
-  // token (no per-step auth override) MUST still see a missing-key request
-  // when the storyboard declares omit_idempotency_key: true. Before this fix,
-  // the SDK's request normalizer/adapter had three injection sites — any one
-  // failing to honor skipIdempotencyAutoInject would silently populate a key
-  // and the compliance vector would pass vacuously. The runner now routes
-  // the call via the raw MCP probe so no SDK layer can touch the body.
-  it('bypasses the SDK via raw probe when omit_idempotency_key=true on a bearer-authenticated mutating step (defense-in-depth for SDK injection)', async () => {
+  // A bearer-authenticated agent with no per-step auth override MUST still
+  // see a missing-key request when the storyboard declares
+  // omit_idempotency_key: true. The runner keeps this on the SDK transport so
+  // strict Streamable HTTP servers get the initialize/session handshake before
+  // the intentionally malformed tools/call request.
+  it('uses the SDK transport when omit_idempotency_key=true on a bearer-authenticated mutating step', async () => {
     const seen = [];
-    const server = http.createServer(async (req, res) => {
-      const chunks = [];
-      for await (const c of req) chunks.push(c);
-      const rpc = JSON.parse(Buffer.concat(chunks).toString('utf8'));
-      seen.push({
-        name: rpc.params.name,
-        args: rpc.params.arguments,
-        authorization: req.headers['authorization'],
-        sessionId: req.headers['x-test-session-id'],
-      });
-      res.writeHead(400, { 'content-type': 'application/json' });
-      res.end(
-        JSON.stringify({
-          jsonrpc: '2.0',
-          id: rpc.id,
-          error: { code: -32000, message: 'INVALID_REQUEST: idempotency_key is required' },
-        })
-      );
-    });
-    await new Promise(r => server.listen(0, r));
-    const agentUrl = `http://127.0.0.1:${server.address().port}/mcp`;
-    try {
-      const storyboard = {
-        id: 'missing_key_bearer_sb',
-        version: '1.0.0',
-        title: 'Missing key (bearer auth, no step auth override)',
-        category: 'compliance',
-        summary: '',
-        narrative: '',
-        agent: { interaction_model: '*', capabilities: [] },
-        caller: { role: 'buyer_agent' },
-        phases: [
-          {
-            id: 'p',
-            title: 'error',
-            steps: [
-              {
-                id: 's1_bearer_missing_key',
-                title: 'bearer-authenticated missing-key vector must reach the server without a key',
-                task: 'create_property_list',
-                expect_error: true,
-                omit_idempotency_key: true,
-                sample_request: { name: 'pl-bearer', entries: [] },
-                validations: [],
-              },
-            ],
-          },
-        ],
-      };
-      await runStoryboard(agentUrl, storyboard, {
-        protocol: 'mcp',
-        allow_http: true,
-        auth: { type: 'bearer', token: 'tok-678' },
-        test_session_id: 'sess-678',
-        agentTools: ['create_property_list'],
-        _profile: { name: 'Test', tools: ['create_property_list'] },
-        _client: {
-          getAgentInfo: async () => ({ name: 'Test', tools: [{ name: 'create_property_list' }] }),
+    const storyboard = {
+      id: 'missing_key_bearer_sb',
+      version: '1.0.0',
+      title: 'Missing key (bearer auth, no step auth override)',
+      category: 'compliance',
+      summary: '',
+      narrative: '',
+      agent: { interaction_model: '*', capabilities: [] },
+      caller: { role: 'buyer_agent' },
+      phases: [
+        {
+          id: 'p',
+          title: 'error',
+          steps: [
+            {
+              id: 's1_bearer_missing_key',
+              title: 'bearer-authenticated missing-key vector must reach the server without a key',
+              task: 'create_property_list',
+              expect_error: true,
+              omit_idempotency_key: true,
+              sample_request: { name: 'pl-bearer', entries: [] },
+              validations: [],
+            },
+          ],
         },
-      });
+      ],
+    };
+    await runStoryboard('http://127.0.0.1:1/mcp', storyboard, {
+      protocol: 'mcp',
+      allow_http: true,
+      auth: { type: 'bearer', token: 'tok-678' },
+      test_session_id: 'sess-678',
+      agentTools: ['create_property_list'],
+      _profile: { name: 'Test', tools: ['create_property_list'] },
+      _client: {
+        getAgentInfo: async () => ({ name: 'Test', tools: [{ name: 'create_property_list' }] }),
+        createPropertyList: async (args, _inputHandler, options) => {
+          seen.push({ args, options });
+          return {
+            success: false,
+            error: 'INVALID_REQUEST: idempotency_key is required',
+            adcpError: { code: 'INVALID_REQUEST', message: 'idempotency_key is required' },
+          };
+        },
+      },
+    });
 
-      assert.strictEqual(seen.length, 1, `expected 1 tool call, got ${seen.length}`);
-      assert.strictEqual(
-        seen[0].args.idempotency_key,
-        undefined,
-        'SDK-layer normalization must not inject idempotency_key when omit_idempotency_key=true'
-      );
-      assert.strictEqual(
-        seen[0].authorization,
-        'Bearer tok-678',
-        'raw probe must forward the bearer token so the agent can still authenticate'
-      );
-      assert.strictEqual(seen[0].sessionId, 'sess-678', 'raw probe must forward X-Test-Session-ID for test isolation');
-    } finally {
-      server.close();
-    }
+    assert.strictEqual(seen.length, 1, `expected 1 SDK tool call, got ${seen.length}`);
+    assert.strictEqual(
+      seen[0].args.idempotency_key,
+      undefined,
+      'SDK-layer normalization must not inject idempotency_key when omit_idempotency_key=true'
+    );
+    assert.strictEqual(
+      seen[0].options.skipIdempotencyAutoInject,
+      true,
+      'runner must signal the SDK transport to leave idempotency_key absent'
+    );
   });
 });
 
@@ -407,10 +387,9 @@ describe('runStoryboard: idempotency_key invariant on the wire', () => {
 // ────────────────────────────────────────────────────────────
 
 /**
- * The helper the dispatcher consults to decide whether the defense-in-depth
- * raw-probe path is available (non-undefined return) and what headers to send
- * when it is. Direct unit coverage keeps the gates explicit without requiring
- * a full MCP handshake to run through the SDK.
+ * The helper mirrors SDK default auth/session headers for raw-probe tests.
+ * Runtime missing-field vectors now use the SDK path; direct unit coverage
+ * keeps the non-echoing header validation behavior pinned.
  */
 describe('defaultAuthHeadersForRawProbe', () => {
   test('no auth → empty headers (public agent; raw dispatch still valid)', () => {

--- a/test/lib/wrap-envelope.test.js
+++ b/test/lib/wrap-envelope.test.js
@@ -114,6 +114,7 @@ describe('wrapEnvelope: error envelopes', () => {
       context: { correlation_id: 'corr_1' },
     });
     assert.equal(out.adcp_error.code, 'IDEMPOTENCY_CONFLICT');
+    assert.equal(out.adcp_error.recovery, 'correctable');
     assert.deepEqual(out.context, { correlation_id: 'corr_1' });
   });
 
@@ -135,6 +136,7 @@ describe('wrapEnvelope: error envelopes', () => {
       operationId: 'op_xyz',
     });
     assert.ok(!('replayed' in out), 'replayed must be stripped');
+    assert.equal(out.adcp_error.recovery, 'correctable');
     assert.deepEqual(out.context, { correlation_id: 'corr_1' });
     assert.equal(out.operation_id, 'op_xyz');
   });
@@ -149,6 +151,19 @@ describe('wrapEnvelope: error envelopes', () => {
     };
     const out = wrapEnvelope(err, { operationId: 'op_abc' });
     assert.equal(out.operation_id, 'op_abc');
+    assert.equal(out.adcp_error.recovery, 'correctable');
+  });
+
+  it('normalizes payload-shaped conflict recovery metadata', () => {
+    const err = {
+      adcp_error: {
+        code: 'IDEMPOTENCY_CONFLICT',
+        message: 'key reused',
+        recovery: { prior_payload: { secret: 'tok-123' } },
+      },
+    };
+    const out = wrapEnvelope(err, {});
+    assert.equal(out.adcp_error.recovery, 'correctable');
   });
 
   it('unknown error code fails closed — only context echoes', () => {
@@ -255,7 +270,7 @@ describe('CONFLICT_ADCP_ERROR_ALLOWLIST: exported shape', () => {
     // response must NOT echo the prior request payload inside adcp_error.
     // Only spec-defined metadata keys are permitted.
     assert.ok(CONFLICT_ADCP_ERROR_ALLOWLIST instanceof Set);
-    for (const expected of ['code', 'message', 'status', 'correlation_id', 'request_id', 'operation_id']) {
+    for (const expected of ['code', 'message', 'recovery', 'status', 'correlation_id', 'request_id', 'operation_id']) {
       assert.ok(CONFLICT_ADCP_ERROR_ALLOWLIST.has(expected), `missing ${expected}`);
     }
     // Common payload fields that would leak prior state must NOT be in the set.
@@ -264,13 +279,8 @@ describe('CONFLICT_ADCP_ERROR_ALLOWLIST: exported shape', () => {
     }
   });
 
-  it('excludes recovery — adcpError() drops it on IDEMPOTENCY_CONFLICT', () => {
-    // The `recovery` classifier is redundant with `code` (derivable from
-    // STANDARD_ERROR_CODES) and widens the surface the stolen-key-read
-    // invariant has to defend. `adcpError()` consults this allowlist
-    // per-code and strips `recovery` from the output on conflict, so the
-    // allowlist stays strict (keeping option 1 from #826).
-    assert.ok(!CONFLICT_ADCP_ERROR_ALLOWLIST.has('recovery'));
+  it('allows recovery — standard metadata is not a payload leak', () => {
+    assert.ok(CONFLICT_ADCP_ERROR_ALLOWLIST.has('recovery'));
   });
 
   it('excludes retry_after — a computed value would leak cached-entry age', () => {

--- a/test/server-create-adcp-server.test.js
+++ b/test/server-create-adcp-server.test.js
@@ -1357,7 +1357,7 @@ describe('createAdcpServer', () => {
               adcp_error: {
                 code: 'IDEMPOTENCY_CONFLICT',
                 message: 'key reused',
-                recovery: 'correctable',
+                recovery: { prior_payload: { secret: 'tok-123' } },
                 retry_after: 30,
                 details: { prior_budget: 5000, prior_account: 'acct_123' },
               },
@@ -1368,7 +1368,7 @@ describe('createAdcpServer', () => {
           adcp_error: {
             code: 'IDEMPOTENCY_CONFLICT',
             message: 'key reused',
-            recovery: 'correctable',
+            recovery: { prior_payload: { secret: 'tok-123' } },
             retry_after: 30,
             details: { prior_budget: 5000, prior_account: 'acct_123' },
           },
@@ -1389,11 +1389,12 @@ describe('createAdcpServer', () => {
       const sanitized = result.structuredContent.adcp_error;
       assert.strictEqual(sanitized.code, 'IDEMPOTENCY_CONFLICT');
       assert.strictEqual(sanitized.message, 'key reused');
-      assert.ok(!('recovery' in sanitized));
+      assert.strictEqual(sanitized.recovery, 'correctable');
       assert.ok(!('retry_after' in sanitized));
       assert.ok(!('details' in sanitized));
       // L2 text payload stays in lockstep.
       const text = JSON.parse(result.content[0].text).adcp_error;
+      assert.strictEqual(text.recovery, 'correctable');
       assert.ok(!('details' in text));
       assert.ok(!('retry_after' in text));
     });


### PR DESCRIPTION
## Summary

- keep MCP missing-field idempotency/account storyboard vectors on the initialized SDK transport unless a step explicitly overrides auth
- allow standard `recovery` metadata on `IDEMPOTENCY_CONFLICT`, normalized to the canonical `correctable` classifier, while continuing to strip payload-shaped fields such as `details`, `field`, `suggestion`, and `retry_after`
- apply the same conflict sanitizer to `adcpError()`, hand-rolled createAdcpServer envelopes, and `wrapEnvelope()`
- update regression coverage and add a patch changeset

## Root Cause

The storyboard runner used the raw MCP probe for ordinary missing-field vectors. That bypassed Streamable HTTP session initialization, so strict MCP servers could reject the request before the seller tool handler saw the intentionally malformed payload. Separately, the conflict leak invariant rejected `recovery`, even though it is standard error metadata and not prior payload data.

## Expert Review

- Protocol and security review found that accepting `recovery` by key alone could make it seller-controlled; fixed by normalizing allowlisted standard-code recovery to the standard table value and by rejecting non-standard conflict recovery in the invariant.
- Code review found no blocking issues; stale runner comments were corrected.

## Validation

- `npm run build:lib`
- `NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/lib/adcp-error-allowlist.test.js test/lib/wrap-envelope.test.js test/lib/storyboard-default-invariants.test.js test/server-create-adcp-server.test.js test/lib/storyboard-idempotency-invariant.test.js test/lib/storyboard-account-invariant.test.js`
- `npm run ci:quick`
- GitHub PR checks are passing on commit `c388d949`