### PR TITLE
fix: support external 3.0 compliance bundles

### DIFF
--- a/.changeset/external-compliance-schema-bundle.md
+++ b/.changeset/external-compliance-schema-bundle.md
@@ -1,0 +1,7 @@
+---
+'@adcp/sdk': patch
+---
+
+fix: let external compliance dirs provide their matching schema bundle
+
+When `--compliance-dir` points at another SDK package or checkout, the storyboard runner now registers the sibling schema bundle before constructing the test client. This allows a beta runner that ships only the 3.1 cache to execute a supplied 3.0 compliance bundle without failing the `adcpVersion` schema-bundle preflight.

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -3391,7 +3391,7 @@ async function handleLocalAgentStoryboardRun(modulePath, args, opts) {
       ...(opts.complianceVersion || opts.noSandbox || opts.assertsSeededState
         ? {
             runStoryboardOptions: {
-              ...(opts.complianceVersion && { adcpVersion: opts.complianceVersion }),
+              ...(opts.complianceVersion && !opts.complianceDir && { adcpVersion: opts.complianceVersion }),
               ...(opts.noSandbox && { sandbox: false, disable_sandbox: true }),
               ...(opts.assertsSeededState && { assertsSeededState: true }),
             },
@@ -3780,7 +3780,7 @@ async function handleMultiInstanceStoryboardRun(args, opts, urls) {
     ...(opts.allowHttp && { allow_http: true }),
     multi_instance_strategy: strategy,
     ...(webhookReceiverOpts ?? {}),
-    ...(opts.complianceVersion && { adcpVersion: opts.complianceVersion }),
+    ...(opts.complianceVersion && !opts.complianceDir && { adcpVersion: opts.complianceVersion }),
     ...(opts.noSandbox && { sandbox: false, disable_sandbox: true }),
     ...(opts.assertsSeededState && { assertsSeededState: true }),
   };
@@ -4041,7 +4041,7 @@ async function handleAgentsRoutedStoryboardRun(args, opts, routing) {
     agents: routing.agents,
     ...(routing.default_agent ? { default_agent: routing.default_agent } : {}),
     ...(webhookReceiverOpts ?? {}),
-    ...(opts.complianceVersion && { adcpVersion: opts.complianceVersion }),
+    ...(opts.complianceVersion && !opts.complianceDir && { adcpVersion: opts.complianceVersion }),
     ...(opts.noSandbox && { sandbox: false, disable_sandbox: true }),
     ...(opts.assertsSeededState && { assertsSeededState: true }),
   };

--- a/src/lib/testing/storyboard/compliance.ts
+++ b/src/lib/testing/storyboard/compliance.ts
@@ -9,11 +9,12 @@
  */
 
 import { readFileSync, readdirSync, existsSync, statSync } from 'fs';
-import { join, resolve } from 'path';
+import { dirname, join, resolve } from 'path';
 import { loadStoryboardFile } from './loader';
 import { ADCP_VERSION } from '../../version';
 import { ADCPError } from '../../errors';
 import { isAdcpVersionSupported } from '../../utils/adcp-version-config';
+import { registerExternalSchemaRoot, resolveBundleKey } from '../../validation/schema-loader';
 import { synthesizeRequestSigningSteps } from './request-signing/synthesize';
 import type { RunnerSelectionResult, Storyboard } from './types';
 
@@ -210,7 +211,31 @@ export function loadComplianceIndex(options: ResolveOptions = {}): ComplianceInd
   if (!existsSync(indexPath)) {
     throw new Error(complianceMissingMessage('Compliance cache', dir));
   }
-  return JSON.parse(readFileSync(indexPath, 'utf-8')) as ComplianceIndex;
+  const index = JSON.parse(readFileSync(indexPath, 'utf-8')) as ComplianceIndex;
+  registerExternalComplianceSchemaRoot(options.complianceDir, index.adcp_version);
+  return index;
+}
+
+function registerExternalComplianceSchemaRoot(complianceDir: string | undefined, adcpVersion: string): void {
+  if (!complianceDir) return;
+  const root = findExternalSchemaRoot(complianceDir, adcpVersion);
+  if (root) registerExternalSchemaRoot(adcpVersion, root);
+}
+
+function findExternalSchemaRoot(complianceDir: string, adcpVersion: string): string | undefined {
+  const key = resolveBundleKey(adcpVersion);
+  const packageRoot = dirname(dirname(dirname(resolve(complianceDir))));
+  const candidates = [
+    complianceDir,
+    join(packageRoot, 'dist', 'lib', 'schemas-data', key),
+    join(packageRoot, 'schemas', 'cache', adcpVersion),
+    join(packageRoot, 'schemas', 'cache', key),
+  ];
+  return candidates.find(hasSchemaRootShape);
+}
+
+function hasSchemaRootShape(root: string): boolean {
+  return existsSync(join(root, 'bundled')) || existsSync(join(root, 'core'));
 }
 
 /**

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -3900,6 +3900,7 @@ async function executeStep(
 
     const vctx: ValidationContext = {
       taskName: effectiveStep.task,
+      ...(options.adcpVersion && { adcpVersion: options.adcpVersion }),
       ...(taskResult && { taskResult }),
       ...(httpResult && { httpResult }),
       agentUrl: runState.agentUrl,
@@ -4364,6 +4365,7 @@ async function executeProbeStep(
 
   const vctx: ValidationContext = {
     taskName: step.task,
+    ...(options.adcpVersion && { adcpVersion: options.adcpVersion }),
     httpResult,
     agentUrl: runState.agentUrl,
     contributions: runState.contributions,

--- a/src/lib/testing/storyboard/validations.ts
+++ b/src/lib/testing/storyboard/validations.ts
@@ -41,6 +41,8 @@ import { PROBE_TASK_ALLOWLIST } from './test-kit';
  */
 export interface ValidationContext {
   taskName: string;
+  /** AdCP schema bundle to use for strict AJV validation. */
+  adcpVersion?: string;
   taskResult?: TaskResult;
   httpResult?: HttpProbeResult;
   agentUrl: string;
@@ -488,7 +490,7 @@ function validateResponseSchema(
   // enforces `format` keywords and `additionalProperties: false` that Zod's
   // `passthrough()` omits — a response can pass Zod and fail AJV. The step's
   // overall pass/fail stays Zod-driven to preserve backwards compatibility.
-  const strict = computeStrictVerdict(taskName, dataWithoutMessage);
+  const strict = computeStrictVerdict(taskName, dataWithoutMessage, ctx.adcpVersion);
 
   // Shape-drift no longer rides on `ValidationResult.warning` — issue #935
   // moved that diagnostic to `StoryboardStepResult.hints[]` as a structured
@@ -542,8 +544,12 @@ function validateResponseSchema(
  * the SDK — notably the brand-rights and governance schemas that live
  * outside the `bundled/` tree the loader walks today).
  */
-function computeStrictVerdict(taskName: string, payload: unknown): StrictValidationVerdict | undefined {
-  const outcome = validateResponse(taskName, payload);
+function computeStrictVerdict(
+  taskName: string,
+  payload: unknown,
+  adcpVersion?: string
+): StrictValidationVerdict | undefined {
+  const outcome = validateResponse(taskName, payload, adcpVersion);
   // `variant: 'skipped'` means no AJV validator compiled for this task (no
   // strictness signal to emit); treat the same as "no AJV schema available".
   if (outcome.variant === 'skipped') return undefined;

--- a/src/lib/validation/index.ts
+++ b/src/lib/validation/index.ts
@@ -7,7 +7,14 @@ export { validateRequest, validateResponse, formatIssues } from './schema-valida
 export type { ValidationIssue, ValidationOutcome } from './schema-validator';
 export { buildValidationError, buildAdcpValidationErrorPayload } from './schema-errors';
 export type { ValidationErrorDetails, AdcpValidationErrorDetails } from './schema-errors';
-export { getValidator, listValidatorKeys, resolveBundleKey, hasSchemaBundle } from './schema-loader';
+export {
+  getValidator,
+  listValidatorKeys,
+  resolveBundleKey,
+  hasSchemaBundle,
+  registerExternalSchemaRoot,
+  unregisterExternalSchemaRoot,
+} from './schema-loader';
 export type { Direction, ResponseVariant } from './schema-loader';
 export { validateOutgoingRequest, validateIncomingResponse, resolveValidationModes } from './client-hooks';
 export type { ValidationMode, ValidationHookConfig } from './client-hooks';

--- a/src/lib/validation/schema-loader.ts
+++ b/src/lib/validation/schema-loader.ts
@@ -232,6 +232,9 @@ export function toReleasePrecisionWire(bundleKeyOrVersion: string): string {
  */
 function resolveSchemaRoot(version: string): string {
   const key = resolveBundleKey(version);
+  const externalRoot = externalSchemaRoots.get(key);
+  if (externalRoot && existsSync(externalRoot)) return externalRoot;
+
   const distCandidate = path.join(__dirname, '..', 'schemas-data', key);
   if (existsSync(distCandidate)) return distCandidate;
 
@@ -312,6 +315,39 @@ interface LoaderState {
 }
 
 const states: Map<string, LoaderState> = new Map();
+const externalSchemaRoots: Map<string, string> = new Map();
+
+function hasSchemaRootShape(root: string): boolean {
+  if (!existsSync(root)) return false;
+  const bundledRoot = path.join(root, 'bundled');
+  if (existsSync(bundledRoot) && walkJsonFiles(bundledRoot).length > 0) return true;
+  return walkJsonFiles(root).length > 0;
+}
+
+/**
+ * Register a schema bundle supplied outside the installed SDK package.
+ *
+ * Compliance runners use this when `--compliance-dir` points at another
+ * package/check-out whose storyboards and schema bundle should be used
+ * together. The root must be the schema-data directory itself, e.g.
+ * `.../dist/lib/schemas-data/3.0`.
+ */
+export function registerExternalSchemaRoot(version: string, root: string): void {
+  const key = resolveBundleKey(version);
+  if (!hasSchemaRootShape(root)) {
+    throw new Error(`External AdCP schema root for version "${version}" not found or empty at ${root}`);
+  }
+  const previous = externalSchemaRoots.get(key);
+  externalSchemaRoots.set(key, root);
+  if (previous !== root) states.delete(key);
+}
+
+/** Test/helper hook for unregistering an external schema bundle. */
+export function unregisterExternalSchemaRoot(version: string): void {
+  const key = resolveBundleKey(version);
+  externalSchemaRoots.delete(key);
+  states.delete(key);
+}
 
 function walkJsonFiles(dir: string): string[] {
   if (!existsSync(dir)) return [];

--- a/test/lib/storyboard-version-negotiation.test.js
+++ b/test/lib/storyboard-version-negotiation.test.js
@@ -1,5 +1,8 @@
 const { test, describe } = require('node:test');
 const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 describe('storyboard runner AdCP version negotiation', () => {
   test('derives legacy-major-only version envelope for 3.0 storyboards', () => {
@@ -148,5 +151,49 @@ describe('storyboard runner AdCP version negotiation', () => {
         /Compliance cache version/.test(err.message) &&
         /supported_versions \[3\.0\]/.test(err.message)
     );
+  });
+
+  test('external compliance dir registers its sibling schema bundle', () => {
+    const { loadComplianceIndex } = require('../../dist/lib/testing/storyboard/index.js');
+    const {
+      getValidator,
+      unregisterExternalSchemaRoot,
+      _resetValidationLoader,
+    } = require('../../dist/lib/validation/schema-loader.js');
+    const { resolveAdcpVersion } = require('../../dist/lib/utils/adcp-version-config.js');
+
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'adcp-external-compliance-'));
+    const complianceDir = path.join(tempRoot, 'package', 'compliance', 'cache', '3.0.12');
+    const schemaRoot = path.join(tempRoot, 'package', 'dist', 'lib', 'schemas-data', '3.0');
+    try {
+      fs.mkdirSync(complianceDir, { recursive: true });
+      fs.mkdirSync(path.join(schemaRoot, 'bundled', 'media-buy'), { recursive: true });
+      fs.writeFileSync(
+        path.join(complianceDir, 'index.json'),
+        JSON.stringify({ adcp_version: '3.0.12', universal: [], protocols: [], specialisms: [] })
+      );
+      fs.writeFileSync(
+        path.join(schemaRoot, 'bundled', 'media-buy', 'get-products-request.json'),
+        JSON.stringify({
+          $id: '/schemas/3.0/bundled/media-buy/get-products-request.json',
+          type: 'object',
+          properties: { sentinel: { const: 'external' } },
+          required: ['sentinel'],
+          additionalProperties: false,
+        })
+      );
+
+      loadComplianceIndex({ complianceDir });
+
+      assert.strictEqual(resolveAdcpVersion('3.0.12'), '3.0.12');
+      const validator = getValidator('get_products', 'request', '3.0.12');
+      assert.ok(validator, 'external 3.0 request validator should compile');
+      assert.strictEqual(validator({ sentinel: 'external' }), true);
+      assert.strictEqual(validator({ sentinel: 'installed-sdk-default' }), false);
+    } finally {
+      unregisterExternalSchemaRoot('3.0.12');
+      _resetValidationLoader('3.0.12');
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary

Fixes #2010 by letting a modern 3.1 beta runner execute an externally supplied 3.0 compliance bundle.

## What changed

- Register a schema bundle discovered next to an explicit `--compliance-dir` before `adcpVersion` validation runs.
- Keep the CLI from forcing `adcpVersion` into run options when `--compliance-dir` is present; the loaded storyboard/cache version remains authoritative.
- Thread the storyboard run's AdCP version into strict AJV response validation so 3.0 runs validate against the supplied 3.0 schema bundle instead of the installed SDK default.
- Add a regression test that builds a synthetic external `compliance/cache/3.0.12` plus sibling `dist/lib/schemas-data/3.0` bundle and verifies the runner can resolve `3.0.12`.

## Validation

- `npm run build:lib`
- `node --test test/lib/storyboard-version-negotiation.test.js`
- `node --test test/lib/schema-loader-per-version.test.js`
- `npm run lint` (passes with existing warnings)
