### PR TITLE
fix: support strict legacy AdCP storyboards

### DIFF
--- a/.changeset/strict-legacy-storyboards.md
+++ b/.changeset/strict-legacy-storyboards.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Fix compliance storyboard negotiation for strict legacy AdCP 3.0 sellers by using a major-only version envelope and validating responses against the negotiated server version.

--- a/.github/workflows/interop-python.yml
+++ b/.github/workflows/interop-python.yml
@@ -289,3 +289,94 @@ jobs:
           path: |
             storyboard-result-typescript.json
             storyboard-seller-typescript.log
+
+  typescript-strict-adcp-3-0-reference-seller:
+    name: TypeScript strict AdCP 3.0 reference seller
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call'
+    needs: pack-sdk-runner
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      STORYBOARD_RESULT_PATH: ${{ github.workspace }}/storyboard-result-typescript-strict-3-0.json
+      SELLER_LOG_PATH: ${{ github.workspace }}/storyboard-seller-typescript-strict-3-0.log
+      # v5.22.0 is the final tagged TypeScript SDK release line pinned to
+      # AdCP 3.0.x before the 3.1 beta envelope shipped. The harness runs it
+      # behind a strict proxy that rejects the 3.1-only adcp_version marker.
+      STRICT_ADCP_3_0_REF: 88bacfdcc0fca4066462d5b621ffc2d7f7a5d348
+
+    steps:
+      - name: Checkout candidate @adcp/sdk
+        uses: actions/checkout@v5
+        with:
+          path: candidate-sdk
+          persist-credentials: false
+
+      - name: Checkout pinned strict AdCP 3.0 TypeScript reference seller
+        uses: actions/checkout@v5
+        with:
+          repository: adcontextprotocol/adcp-client
+          ref: ${{ env.STRICT_ADCP_3_0_REF }}
+          path: reference-typescript-strict-3-0
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+
+      - name: Download SDK runner tarball
+        uses: actions/download-artifact@v4
+        with:
+          name: adcp-sdk-runner-tarball
+          path: ${{ runner.temp }}/adcp-sdk-pack
+
+      - name: Resolve SDK runner tarball
+        id: pack
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t tarballs < <(find "$RUNNER_TEMP/adcp-sdk-pack" -maxdepth 1 -type f -name '*.tgz' -print)
+          if [[ "${#tarballs[@]}" -ne 1 ]]; then
+            echo "::error::Expected one SDK runner tarball, found ${#tarballs[@]}."
+            printf '%s\n' "${tarballs[@]}"
+            exit 1
+          fi
+          echo "tarball=${tarballs[0]}" >> "$GITHUB_OUTPUT"
+          echo "Using SDK runner tarball ${tarballs[0]}"
+
+      - name: Run strict AdCP 3.0 reference seller storyboard
+        shell: bash
+        run: |
+          set -euo pipefail
+          chmod +x candidate-sdk/scripts/ci/run_storyboard_strict_3_0_reference_seller.sh
+          ADCP_SDK_TARBALL="${{ steps.pack.outputs.tarball }}" \
+            ADCP_REFERENCE_REPO_ROOT="${{ github.workspace }}/reference-typescript-strict-3-0" \
+            ADCP_PORT=3003 \
+            ADCP_INTERNAL_PORT=3004 \
+            STORYBOARD_RESULT_PATH="$STORYBOARD_RESULT_PATH" \
+            SELLER_LOG_PATH="$SELLER_LOG_PATH" \
+            candidate-sdk/scripts/ci/run_storyboard_strict_3_0_reference_seller.sh
+
+      - name: Add interop summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "### Strict AdCP 3.0 reference seller interop"
+            echo ""
+            echo "- Repository: \`adcontextprotocol/adcp-client\`"
+            echo "- Ref: \`${STRICT_ADCP_3_0_REF}\`"
+            echo "- Protocol pin: AdCP 3.0.x"
+            echo "- Harness: \`scripts/ci/run_storyboard_strict_3_0_reference_seller.sh\`"
+            echo "- Advisory: \`false\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload storyboard artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: typescript-strict-adcp-3-0-reference-seller-storyboard
+          if-no-files-found: ignore
+          path: |
+            storyboard-result-typescript-strict-3-0.json
+            storyboard-seller-typescript-strict-3-0.log

--- a/scripts/ci/run_storyboard_strict_3_0_reference_seller.sh
+++ b/scripts/ci/run_storyboard_strict_3_0_reference_seller.sh
@@ -1,0 +1,370 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CALLER_CWD="$(pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SDK_REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+REFERENCE_REPO_ROOT="${ADCP_REFERENCE_REPO_ROOT:-}"
+
+if [[ -z "$REFERENCE_REPO_ROOT" ]]; then
+  echo "ADCP_REFERENCE_REPO_ROOT must point at a pinned AdCP 3.0 reference checkout." >&2
+  exit 1
+fi
+
+case "$REFERENCE_REPO_ROOT" in
+  /*) ;;
+  *) REFERENCE_REPO_ROOT="$CALLER_CWD/$REFERENCE_REPO_ROOT" ;;
+esac
+
+ADCP_PORT="${ADCP_PORT:-3003}"
+ADCP_INTERNAL_PORT="${ADCP_INTERNAL_PORT:-3004}"
+ADCP_AUTH_TOKEN="${ADCP_AUTH_TOKEN:-sk_harness_do_not_use_in_prod}"
+ADCP_STORYBOARD_ID="${ADCP_STORYBOARD_ID:-capability_discovery}"
+ADCP_RUNNER_TIMEOUT_SECONDS="${ADCP_RUNNER_TIMEOUT_SECONDS:-120}"
+
+make_absolute_path() {
+  case "$1" in
+    /*) printf '%s\n' "$1" ;;
+    *) printf '%s/%s\n' "$CALLER_CWD" "$1" ;;
+  esac
+}
+
+if [[ -n "${ADCP_SDK_TARBALL:-}" ]]; then
+  ADCP_SDK_TARBALL="$(make_absolute_path "$ADCP_SDK_TARBALL")"
+fi
+if [[ -n "${ADCP_RUNNER_DIR:-}" ]]; then
+  ADCP_RUNNER_DIR="$(make_absolute_path "$ADCP_RUNNER_DIR")"
+fi
+if [[ -n "${ADCP_RUNNER_BIN:-}" && "$ADCP_RUNNER_BIN" == */* ]]; then
+  ADCP_RUNNER_BIN="$(make_absolute_path "$ADCP_RUNNER_BIN")"
+fi
+
+STORYBOARD_RESULT_PATH="$(make_absolute_path "${STORYBOARD_RESULT_PATH:-storyboard-result-strict-3-0.json}")"
+SELLER_LOG_PATH="$(make_absolute_path "${SELLER_LOG_PATH:-storyboard-seller-strict-3-0.log}")"
+mkdir -p "$(dirname "$STORYBOARD_RESULT_PATH")" "$(dirname "$SELLER_LOG_PATH")"
+: >"$SELLER_LOG_PATH"
+
+TMP_ROOT_CREATED=0
+if [[ -n "${ADCP_HARNESS_TMPDIR:-}" ]]; then
+  TMP_ROOT="$(make_absolute_path "$ADCP_HARNESS_TMPDIR")"
+  mkdir -p "$TMP_ROOT"
+else
+  TMP_ROOT="$(mktemp -d)"
+  TMP_ROOT_CREATED=1
+fi
+
+SELLER_PID=""
+PROXY_PID=""
+RUNNER_PACKAGE_ROOT=""
+
+cleanup() {
+  local status=$?
+  for pid in "$PROXY_PID" "$SELLER_PID"; do
+    if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+      kill "$pid" 2>/dev/null || true
+      sleep 0.5
+      kill -9 "$pid" 2>/dev/null || true
+    fi
+  done
+  if [[ "$TMP_ROOT_CREATED" == "1" && "${ADCP_KEEP_HARNESS_TMP:-0}" != "1" ]]; then
+    rm -rf "$TMP_ROOT"
+  fi
+  exit "$status"
+}
+trap cleanup EXIT INT TERM
+
+log() {
+  printf '[strict-3-0-reference-seller] %s\n' "$*" >&2
+  printf '[strict-3-0-reference-seller] %s\n' "$*" >>"$SELLER_LOG_PATH"
+}
+
+wait_for_port() {
+  local host="$1"
+  local port="$2"
+  local timeout_seconds="$3"
+  local deadline=$((SECONDS + timeout_seconds))
+  while (( SECONDS < deadline )); do
+    if node -e "const s=require('node:net').connect($port, '$host', () => { s.end(); process.exit(0); }); s.on('error', () => process.exit(1)); setTimeout(() => process.exit(1), 1000);" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+resolve_runner_cmd() {
+  if [[ -n "${ADCP_RUNNER_BIN:-}" ]]; then
+    if [[ "$ADCP_RUNNER_BIN" == */* ]]; then
+      if [[ ! -f "$ADCP_RUNNER_BIN" ]]; then
+        log "ADCP_RUNNER_BIN does not exist: $ADCP_RUNNER_BIN"
+        return 1
+      fi
+      RUNNER_CMD=("$ADCP_RUNNER_BIN")
+      RUNNER_PACKAGE_ROOT="$SDK_REPO_ROOT"
+    else
+      local resolved_bin
+      resolved_bin="$(command -v "$ADCP_RUNNER_BIN" || true)"
+      if [[ -z "$resolved_bin" ]]; then
+        log "ADCP_RUNNER_BIN is not on PATH: $ADCP_RUNNER_BIN"
+        return 1
+      fi
+      RUNNER_CMD=("$resolved_bin")
+      RUNNER_PACKAGE_ROOT="$SDK_REPO_ROOT"
+    fi
+    return 0
+  fi
+
+  if [[ -n "${ADCP_RUNNER_DIR:-}" ]]; then
+    local runner_js="$ADCP_RUNNER_DIR/node_modules/@adcp/sdk/bin/adcp.js"
+    if [[ ! -f "$runner_js" ]]; then
+      log "ADCP_RUNNER_DIR does not contain node_modules/@adcp/sdk/bin/adcp.js: $ADCP_RUNNER_DIR"
+      return 1
+    fi
+    RUNNER_CMD=(node "$runner_js")
+    RUNNER_PACKAGE_ROOT="$ADCP_RUNNER_DIR/node_modules/@adcp/sdk"
+    return 0
+  fi
+
+  if [[ -n "${ADCP_SDK_TARBALL:-}" ]]; then
+    if [[ ! -f "$ADCP_SDK_TARBALL" ]]; then
+      log "ADCP_SDK_TARBALL does not exist: $ADCP_SDK_TARBALL"
+      return 1
+    fi
+    local runner_dir="$TMP_ROOT/candidate-runner"
+    mkdir -p "$runner_dir"
+    log "Installing candidate SDK runner from $ADCP_SDK_TARBALL"
+    (
+      cd "$runner_dir"
+      npm init -y >/dev/null
+      npm install --no-audit --no-fund --ignore-scripts "$ADCP_SDK_TARBALL" >>"$SELLER_LOG_PATH" 2>&1
+    )
+    RUNNER_CMD=(node "$runner_dir/node_modules/@adcp/sdk/bin/adcp.js")
+    RUNNER_PACKAGE_ROOT="$runner_dir/node_modules/@adcp/sdk"
+    return 0
+  fi
+
+  RUNNER_CMD=(node "$SDK_REPO_ROOT/bin/adcp.js")
+  RUNNER_PACKAGE_ROOT="$SDK_REPO_ROOT"
+}
+
+PROXY_AUDIT_PATH="$TMP_ROOT/strict-proxy-audit.json"
+
+check_storyboard_result() {
+  node - "$STORYBOARD_RESULT_PATH" <<'NODE'
+const fs = require('node:fs');
+const path = process.argv[2];
+let result;
+try {
+  result = JSON.parse(fs.readFileSync(path, 'utf8'));
+} catch (err) {
+  console.error(`[strict-3-0-reference-seller] Could not parse storyboard result JSON at ${path}: ${err.message}`);
+  process.exit(1);
+}
+const status = result.overall_status;
+const passed = result.passed_count ?? result.summary?.steps_passed ?? 0;
+const failed = result.failed_count ?? result.summary?.steps_failed ?? 0;
+const skipped = result.skipped_count ?? result.summary?.steps_skipped ?? 0;
+console.error(`[strict-3-0-reference-seller] overall_status=${status} passed=${passed} failed=${failed} skipped=${skipped}`);
+if (!['passing', 'partial'].includes(status) || failed !== 0 || skipped !== 0 || passed < 2) {
+  process.exit(1);
+}
+NODE
+}
+
+check_proxy_audit() {
+  node - "$PROXY_AUDIT_PATH" <<'NODE'
+const fs = require('node:fs');
+const path = process.argv[2];
+let audit;
+try {
+  audit = JSON.parse(fs.readFileSync(path, 'utf8'));
+} catch (err) {
+  console.error(`[strict-3-0-reference-seller] Could not parse strict proxy audit at ${path}: ${err.message}`);
+  process.exit(1);
+}
+const forwardedTools = audit.forwardedTools ?? {};
+const capabilitiesCalls = forwardedTools.get_adcp_capabilities ?? 0;
+const getProductsCalls = forwardedTools.get_products ?? 0;
+console.error(
+  `[strict-3-0-reference-seller] strict_proxy forwarded=${audit.forwardedToolCallCount ?? 0} ` +
+    `get_adcp_capabilities=${capabilitiesCalls} get_products=${getProductsCalls}`
+);
+if (capabilitiesCalls < 1 || getProductsCalls < 1) {
+  process.exit(1);
+}
+NODE
+}
+
+probe_get_products_with_candidate_sdk() {
+  node - "$RUNNER_PACKAGE_ROOT" "http://127.0.0.1:$ADCP_PORT/mcp" <<'NODE'
+const path = require('node:path');
+const packageRoot = process.argv[2];
+const agentUrl = process.argv[3];
+const { ProtocolClient } = require(path.join(packageRoot, 'dist/lib/index.js'));
+
+ProtocolClient.callTool(
+  {
+    id: 'strict-3-0-probe',
+    name: 'Strict 3.0 Probe',
+    protocol: 'mcp',
+    agent_uri: agentUrl,
+  },
+  'get_products',
+  {
+    buying_mode: 'brief',
+    brief: 'Return a small representative sample of available advertising products',
+    context: { correlation_id: 'strict-adcp-3-0--sdk-probe-get-products' },
+  },
+  { adcpVersion: '3.1.0-beta.5', versionEnvelope: 'major-only' }
+)
+  .then(response => {
+    const serialized = JSON.stringify(response);
+    if (/Unexpected keyword argument 'adcp_version'/.test(serialized)) {
+      console.error(`[strict-3-0-reference-seller] candidate SDK get_products probe leaked adcp_version: ${serialized}`);
+      process.exit(1);
+    }
+    process.exit(0);
+  })
+  .catch(err => {
+    console.error(`[strict-3-0-reference-seller] candidate SDK get_products probe failed: ${err.message}`);
+    process.exit(1);
+  });
+NODE
+}
+
+assert_strict_proxy_rejects_unknown_arguments() {
+  node - "http://127.0.0.1:$ADCP_PORT/mcp" <<'NODE'
+const url = process.argv[2];
+
+async function assertRejected(tool, field, value) {
+  const payload = {
+    jsonrpc: '2.0',
+    id: `strict-proxy-probe-${tool}-${field}`,
+    method: 'tools/call',
+    params: {
+      name: tool,
+      arguments: { [field]: value },
+    },
+  };
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  const body = await response.json();
+  if (!body.error || !String(body.error.message).includes(field)) {
+    console.error(`[strict-3-0-reference-seller] strict proxy probe did not reject ${field}: ${JSON.stringify(body)}`);
+    process.exit(1);
+  }
+}
+
+Promise.all([
+  assertRejected('get_adcp_capabilities', 'adcp_version', '3.1.0-beta.5'),
+  assertRejected('get_adcp_capabilities', 'definitely_not_adcp_3_0', true),
+  assertRejected('get_products', 'adcp_version', '3.1.0-beta.5'),
+  assertRejected('get_products', 'get_products_extra_field', true),
+]).catch(err => {
+  console.error(`[strict-3-0-reference-seller] strict proxy probe failed: ${err.message}`);
+  process.exit(1);
+});
+NODE
+}
+
+log "SDK repo root: $SDK_REPO_ROOT"
+log "Reference repo root: $REFERENCE_REPO_ROOT"
+log "Storyboards: $ADCP_STORYBOARD_ID"
+log "Proxy port: $ADCP_PORT"
+log "Internal seller port: $ADCP_INTERNAL_PORT"
+log "Result path: $STORYBOARD_RESULT_PATH"
+log "Seller log path: $SELLER_LOG_PATH"
+
+if [[ "$(tr -d '\n\r' <"$REFERENCE_REPO_ROOT/ADCP_VERSION")" != 3.0.* ]]; then
+  log "Reference checkout is not pinned to an AdCP 3.0.x protocol version"
+  cat "$REFERENCE_REPO_ROOT/ADCP_VERSION" >&2 || true
+  exit 1
+fi
+
+if [[ "${ADCP_SKIP_NPM_CI:-0}" != "1" ]]; then
+  log "Installing pinned 3.0 reference seller dependencies with npm ci"
+  (
+    cd "$REFERENCE_REPO_ROOT"
+    npm ci >>"$SELLER_LOG_PATH" 2>&1
+  )
+fi
+
+if [[ "${ADCP_SKIP_BUILD:-0}" != "1" ]]; then
+  log "Building pinned 3.0 reference seller checkout"
+  (
+    cd "$REFERENCE_REPO_ROOT"
+    npm run build:test-agents >>"$SELLER_LOG_PATH" 2>&1
+  )
+fi
+
+resolve_runner_cmd
+
+SELLER_ENTRY="$REFERENCE_REPO_ROOT/test-agents/dist/seller-agent.js"
+if [[ ! -f "$SELLER_ENTRY" ]]; then
+  SELLER_ENTRY="$REFERENCE_REPO_ROOT/dist/seller-agent.js"
+fi
+if [[ ! -f "$SELLER_ENTRY" ]]; then
+  log "Could not find built 3.0 seller entrypoint at test-agents/dist/seller-agent.js or dist/seller-agent.js"
+  exit 1
+fi
+
+log "Starting pinned AdCP 3.0 TypeScript seller"
+(
+  cd "$REFERENCE_REPO_ROOT"
+  NODE_ENV=development \
+    ADCP_SANDBOX=1 \
+    PORT="$ADCP_INTERNAL_PORT" \
+    node "$SELLER_ENTRY"
+) >>"$SELLER_LOG_PATH" 2>&1 &
+SELLER_PID=$!
+
+if ! wait_for_port 127.0.0.1 "$ADCP_INTERNAL_PORT" 30; then
+  log "Timed out waiting for pinned 3.0 seller on port $ADCP_INTERNAL_PORT"
+  tail -200 "$SELLER_LOG_PATH" >&2 || true
+  exit 1
+fi
+
+log "Starting strict AdCP 3.0 envelope proxy"
+ADCP_STRICT_PROXY_PORT="$ADCP_PORT" \
+  ADCP_STRICT_PROXY_TARGET_PORT="$ADCP_INTERNAL_PORT" \
+  ADCP_STRICT_PROXY_AUDIT_PATH="$PROXY_AUDIT_PATH" \
+  node "$SDK_REPO_ROOT/scripts/ci/strict_adcp_3_0_proxy.mjs" >>"$SELLER_LOG_PATH" 2>&1 &
+PROXY_PID=$!
+
+if ! wait_for_port 127.0.0.1 "$ADCP_PORT" 30; then
+  log "Timed out waiting for strict proxy on port $ADCP_PORT"
+  tail -200 "$SELLER_LOG_PATH" >&2 || true
+  exit 1
+fi
+
+assert_strict_proxy_rejects_unknown_arguments
+
+log "Running candidate SDK storyboard runner against strict 3.0 seller"
+RUN_STATUS=0
+ADCP_AUTH_TOKEN="$ADCP_AUTH_TOKEN" "${RUNNER_CMD[@]}" storyboard run "http://127.0.0.1:$ADCP_PORT/mcp" "$ADCP_STORYBOARD_ID" \
+  --json \
+  --allow-http \
+  --timeout "$ADCP_RUNNER_TIMEOUT_SECONDS" >"$STORYBOARD_RESULT_PATH" 2>>"$SELLER_LOG_PATH" || RUN_STATUS=$?
+
+log "Probing get_products through candidate SDK with major-only envelope"
+PROBE_STATUS=0
+probe_get_products_with_candidate_sdk >>"$SELLER_LOG_PATH" 2>&1 || PROBE_STATUS=$?
+
+set +e
+check_storyboard_result
+RESULT_STATUS=$?
+check_proxy_audit
+AUDIT_STATUS=$?
+set -e
+
+if [[ "$RUN_STATUS" != "0" || "$PROBE_STATUS" != "0" || "$RESULT_STATUS" != "0" || "$AUDIT_STATUS" != "0" ]]; then
+  log "Storyboard run failed (runner exit=$RUN_STATUS, probe exit=$PROBE_STATUS, status check=$RESULT_STATUS, audit check=$AUDIT_STATUS)"
+  tail -200 "$SELLER_LOG_PATH" >&2 || true
+  exit 1
+fi
+
+log "Strict AdCP 3.0 reference seller storyboard passed"

--- a/scripts/ci/strict_adcp_3_0_proxy.mjs
+++ b/scripts/ci/strict_adcp_3_0_proxy.mjs
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+import http from 'node:http';
+import fs from 'node:fs';
+
+const listenPort = Number.parseInt(process.env.ADCP_STRICT_PROXY_PORT ?? process.env.ADCP_PORT ?? '3003', 10);
+const targetPort = Number.parseInt(process.env.ADCP_STRICT_PROXY_TARGET_PORT ?? '3001', 10);
+
+if (!Number.isInteger(listenPort) || listenPort < 1 || listenPort > 65535) {
+  throw new Error(`Invalid ADCP_STRICT_PROXY_PORT/ADCP_PORT: ${process.env.ADCP_STRICT_PROXY_PORT ?? process.env.ADCP_PORT}`);
+}
+if (!Number.isInteger(targetPort) || targetPort < 1 || targetPort > 65535) {
+  throw new Error(`Invalid ADCP_STRICT_PROXY_TARGET_PORT: ${process.env.ADCP_STRICT_PROXY_TARGET_PORT}`);
+}
+
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    req.on('data', chunk => chunks.push(Buffer.from(chunk)));
+    req.on('end', () => resolve(Buffer.concat(chunks)));
+    req.on('error', reject);
+  });
+}
+
+function decodeJsonBody(buffer) {
+  if (buffer.length === 0) return undefined;
+  try {
+    return JSON.parse(buffer.toString('utf8'));
+  } catch {
+    return undefined;
+  }
+}
+
+function iterJsonRpcMessages(body) {
+  if (Array.isArray(body)) return body;
+  if (body && typeof body === 'object') return [body];
+  return [];
+}
+
+const STRICT_ARGUMENT_KEYS_BY_TOOL = new Map([
+  ['get_adcp_capabilities', new Set(['adcp_major_version', 'context', 'ext', 'protocols'])],
+  [
+    'get_products',
+    new Set(['account', 'adcp_major_version', 'brand', 'brief', 'buying_mode', 'context', 'ext', 'pagination']),
+  ],
+]);
+
+const auditPath = process.env.ADCP_STRICT_PROXY_AUDIT_PATH;
+const audit = {
+  forwardedToolCallCount: 0,
+  rejectedToolCallCount: 0,
+  forwardedTools: {},
+  rejectedTools: {},
+};
+
+function writeAudit() {
+  if (!auditPath) return;
+  fs.writeFileSync(auditPath, JSON.stringify(audit, null, 2));
+}
+
+function recordToolCalls(body, bucketName) {
+  for (const message of iterJsonRpcMessages(body)) {
+    if (!message || typeof message !== 'object') continue;
+    if (message.method !== 'tools/call') continue;
+    const toolName = typeof message.params?.name === 'string' ? message.params.name : '<unknown>';
+    if (bucketName === 'forwarded') {
+      audit.forwardedToolCallCount += 1;
+      audit.forwardedTools[toolName] = (audit.forwardedTools[toolName] ?? 0) + 1;
+    } else {
+      audit.rejectedToolCallCount += 1;
+      audit.rejectedTools[toolName] = (audit.rejectedTools[toolName] ?? 0) + 1;
+    }
+  }
+  writeAudit();
+}
+
+function findUnexpectedArgument(body) {
+  for (const message of iterJsonRpcMessages(body)) {
+    if (!message || typeof message !== 'object') continue;
+    if (message.method !== 'tools/call') continue;
+    const toolName = message.params?.name;
+    const allowed = STRICT_ARGUMENT_KEYS_BY_TOOL.get(toolName);
+    if (!allowed) continue;
+    const args = message.params?.arguments;
+    if (!args || typeof args !== 'object' || Array.isArray(args)) continue;
+    for (const key of Object.keys(args)) {
+      if (!allowed.has(key)) return key;
+    }
+  }
+  return undefined;
+}
+
+function firstRpcId(body) {
+  for (const message of iterJsonRpcMessages(body)) {
+    if (message && typeof message === 'object' && Object.hasOwn(message, 'id')) {
+      return message.id;
+    }
+  }
+  return null;
+}
+
+function rejectUnexpectedArgument(res, body, field) {
+  const response = {
+    jsonrpc: '2.0',
+    id: firstRpcId(body),
+    error: {
+      code: -32602,
+      message: `Unexpected keyword argument '${field}'`,
+    },
+  };
+  const payload = JSON.stringify(response);
+  res.writeHead(200, {
+    'content-type': 'application/json',
+    'content-length': Buffer.byteLength(payload),
+  });
+  res.end(payload);
+}
+
+function forwardRequest(req, res, bodyBuffer) {
+  const headers = { ...req.headers };
+  headers.host = `127.0.0.1:${targetPort}`;
+  headers['content-length'] = String(bodyBuffer.length);
+
+  const proxyReq = http.request(
+    {
+      hostname: '127.0.0.1',
+      port: targetPort,
+      method: req.method,
+      path: req.url,
+      headers,
+    },
+    proxyRes => {
+      res.writeHead(proxyRes.statusCode ?? 502, proxyRes.headers);
+      proxyRes.pipe(res);
+    }
+  );
+
+  proxyReq.on('error', err => {
+    const payload = JSON.stringify({ error: `strict 3.0 proxy upstream error: ${err.message}` });
+    res.writeHead(502, {
+      'content-type': 'application/json',
+      'content-length': Buffer.byteLength(payload),
+    });
+    res.end(payload);
+  });
+
+  proxyReq.end(bodyBuffer);
+}
+
+const server = http.createServer(async (req, res) => {
+  if (req.method === 'POST' && req.url?.startsWith('/mcp')) {
+    const bodyBuffer = await readBody(req);
+    const body = decodeJsonBody(bodyBuffer);
+    const unexpectedArgument = findUnexpectedArgument(body);
+    if (unexpectedArgument) {
+      recordToolCalls(body, 'rejected');
+      rejectUnexpectedArgument(res, body, unexpectedArgument);
+      return;
+    }
+    recordToolCalls(body, 'forwarded');
+    forwardRequest(req, res, bodyBuffer);
+    return;
+  }
+
+  forwardRequest(req, res, Buffer.alloc(0));
+});
+
+server.listen(listenPort, '127.0.0.1', () => {
+  process.stderr.write(
+    `[strict-adcp-3-0-proxy] listening on http://127.0.0.1:${listenPort}, forwarding to ${targetPort}\n`
+  );
+});

--- a/src/lib/core/ResponseValidator.ts
+++ b/src/lib/core/ResponseValidator.ts
@@ -7,7 +7,7 @@
 
 import { z } from 'zod';
 import { getBestUnionErrors } from '../utils/union-errors';
-import { TOOL_RESPONSE_SCHEMAS } from '../utils/response-schemas';
+import { prepareResponseForSchemaValidation, TOOL_RESPONSE_SCHEMAS } from '../utils/response-schemas';
 import { injectLegacyEnvelopeStatus } from '../utils/envelope-status-compat';
 import { getLatestA2ADataPartFromResponse } from '../utils/a2a-artifacts';
 
@@ -28,6 +28,8 @@ export interface ValidationOptions {
   allowEmpty?: boolean;
   /** Validate against AdCP Zod schemas */
   validateSchema?: boolean;
+  /** Server-declared AdCP version for response-shape compatibility. */
+  responseAdcpVersion?: string;
 }
 
 export class ResponseValidator {
@@ -71,7 +73,7 @@ export class ResponseValidator {
     // Schema validation if enabled
     let schemaErrors: z.ZodIssue[] | undefined;
     if (options.validateSchema !== false && toolName) {
-      const schemaResult = this.validateWithSchema(response, toolName, protocol);
+      const schemaResult = this.validateWithSchema(response, toolName, protocol, options.responseAdcpVersion);
       if (schemaResult) {
         schemaErrors = schemaResult.issues;
 
@@ -314,7 +316,12 @@ export class ResponseValidator {
   /**
    * Validate response data against AdCP Zod schema
    */
-  private validateWithSchema(response: any, toolName: string, protocol: string): z.ZodError | null {
+  private validateWithSchema(
+    response: any,
+    toolName: string,
+    protocol: string,
+    responseAdcpVersion?: string
+  ): z.ZodError | null {
     const data = this.extractDataForValidation(response, protocol);
 
     if (!data) {
@@ -335,7 +342,7 @@ export class ResponseValidator {
         : data;
 
     // Validate
-    const result = schema.safeParse(validatePayload);
+    const result = schema.safeParse(prepareResponseForSchemaValidation(toolName, validatePayload, responseAdcpVersion));
     return result.success ? null : result.error;
   }
 

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -971,6 +971,9 @@ export class TaskExecutor {
       // Now unwrap the response
       const unwrapped = unwrapProtocolResponse(response, toolName, undefined, {
         filterInvalidProducts: this.config.filterInvalidProducts,
+        ...(this.responseAdcpVersionForValidation() && {
+          responseAdcpVersion: this.responseAdcpVersionForValidation(),
+        }),
       });
 
       // Log successful extraction with result details
@@ -1989,7 +1992,10 @@ export class TaskExecutor {
       // `pricing_options must NOT have fewer than 1 items` and similar
       // shape mismatches that don't exist in v2.5. The v3 → v2 path is
       // already correctly version-pinned via lastKnownServerVersion.
-      const validationVersion = this.lastKnownServerVersion === 'v2' ? 'v2.5' : this.config.adcpVersion;
+      const validationVersion =
+        this.lastKnownServerVersion === 'v2'
+          ? 'v2.5'
+          : (this.responseAdcpVersionForValidation() ?? this.config.adcpVersion);
       const outcome = validateIncomingResponse(taskName, normalizedResponse, mode, debugLogs, validationVersion);
       if (outcome.valid) return { valid: true, errors: [] };
 
@@ -2023,6 +2029,11 @@ export class TaskExecutor {
         errors: mode === 'strict' ? [`Validation error: ${errorMessage}`] : [],
       };
     }
+  }
+
+  private responseAdcpVersionForValidation(): string | undefined {
+    if (this.config.versionEnvelope === 'major-only') return '3.0';
+    return undefined;
   }
 
   /**

--- a/src/lib/protocols/index.ts
+++ b/src/lib/protocols/index.ts
@@ -50,7 +50,7 @@ import { resolveBundleKey, toReleasePrecisionWire, validateAdcpVersionWire } fro
 import { buildAgentSigningContext, CAPABILITY_OP, ensureCapabilityLoaded } from '../signing/client';
 import { withResponseSizeLimit } from './responseSizeLimit';
 
-export type VersionEnvelopeMode = 'auto' | 'none';
+export type VersionEnvelopeMode = 'auto' | 'none' | 'major-only';
 
 /**
  * Derive the wire-level `adcp_major_version` integer from a caller-supplied
@@ -130,6 +130,16 @@ function buildVersionEnvelope(
   // emitting a non-spec wire string.
   validateAdcpVersionWire(wireValue);
   return { adcp_major_version: wireMajor, adcp_version: wireValue };
+}
+
+function buildVersionEnvelopeForMode(
+  mode: VersionEnvelopeMode,
+  adcpVersion: string | undefined,
+  serverVersion: 'v2' | 'v3' | undefined
+): Record<string, unknown> {
+  if (mode === 'none' || serverVersion === 'v2') return {};
+  if (mode === 'major-only') return { adcp_major_version: resolveWireMajor(adcpVersion) };
+  return buildVersionEnvelope(adcpVersion, serverVersion);
 }
 
 /**
@@ -238,7 +248,9 @@ export interface CallToolOptions {
    * Controls whether the SDK injects AdCP version envelope fields into the
    * outgoing request. Defaults to `auto`. 3.0 pins emit only the legacy
    * `adcp_major_version`; 3.1+ pins emit both the legacy major and exact
-   * `adcp_version` marker.
+   * `adcp_version` marker. `major-only` forces the legacy integer marker
+   * without the 3.1 string marker for strict pre-3.1 peers discovered at
+   * runtime.
    */
   versionEnvelope?: VersionEnvelopeMode;
   /**
@@ -283,7 +295,7 @@ export class ProtocolClient {
     // `ProtocolClient.callTool` directly (test harnesses, the in-process
     // MCP path). Returns `{ adcp_major_version }` for 3.0 pins and
     // `{ adcp_major_version, adcp_version }` for 3.1+ pins.
-    const versionEnvelope = versionEnvelopeMode === 'none' ? {} : buildVersionEnvelope(adcpVersion, serverVersion);
+    const versionEnvelope = buildVersionEnvelopeForMode(versionEnvelopeMode, adcpVersion, serverVersion);
     // Enter the response-size-limit ALS slot once for this call. The slot is
     // read by `wrapFetchWithSizeLimit` in both protocol transports, so the
     // cap applies regardless of which path (MCP / A2A / OAuth refresh) the
@@ -553,7 +565,7 @@ export const createMCPClient = (
   // Validate the pin at factory time so a typo surfaces here rather than at
   // first call. `buildVersionEnvelope` throws via `resolveWireMajor` on bad
   // input — call it once to surface, then close over the envelope.
-  const versionEnvelope = versionEnvelopeMode === 'none' ? {} : buildVersionEnvelope(adcpVersion, serverVersion);
+  const versionEnvelope = buildVersionEnvelopeForMode(versionEnvelopeMode, adcpVersion, serverVersion);
   return {
     callTool: (toolName: string, args: Record<string, unknown>, debugLogs?: DebugLogEntry[]) =>
       withResponseSizeLimit(transport?.maxResponseBytes, () =>
@@ -578,7 +590,7 @@ export const createA2AClient = (
   transport?: TransportOptions,
   versionEnvelopeMode: VersionEnvelopeMode = 'auto'
 ) => {
-  const versionEnvelope = versionEnvelopeMode === 'none' ? {} : buildVersionEnvelope(adcpVersion, serverVersion);
+  const versionEnvelope = buildVersionEnvelopeForMode(versionEnvelopeMode, adcpVersion, serverVersion);
   return {
     callTool: (toolName: string, parameters: Record<string, unknown>, debugLogs?: DebugLogEntry[]) =>
       withResponseSizeLimit(transport?.maxResponseBytes, () =>

--- a/src/lib/testing/client.ts
+++ b/src/lib/testing/client.ts
@@ -16,7 +16,7 @@ import type {
   BrandReference,
 } from '../types/tools.generated';
 import type { TestOptions, TestStepResult, AgentProfile, TaskResult, Logger } from './types';
-import { TOOL_RESPONSE_SCHEMAS } from '../utils/response-schemas';
+import { prepareResponseForSchemaValidation, TOOL_RESPONSE_SCHEMAS } from '../utils/response-schemas';
 import { injectLegacyEnvelopeStatus } from '../utils/envelope-status-compat';
 import { parseCapabilitiesResponse } from '../utils/capabilities';
 import { classifyProbeUrl } from '../utils/probe-policy';
@@ -401,6 +401,7 @@ export async function discoverAgentProfile(
         profile.adcp_version = parsed.version;
         profile.adcp_major_versions = parsed.majorVersions;
         if (parsed.supportedVersions !== undefined) profile.adcp_supported_versions = parsed.supportedVersions;
+        if (parsed.buildVersion !== undefined) profile.adcp_build_version = parsed.buildVersion;
         profile.supported_protocols = parsed.protocols;
         profile.supports_governance = parsed.protocols.includes('governance');
         profile.supports_si = parsed.protocols.includes('sponsored_intelligence');
@@ -724,7 +725,7 @@ export async function discoverSignals(
  *  - constraint keyword (`minimum`, `maximum`, `enum`, `format`, …) — the
  *    field is present but violates a JSON Schema keyword constraint.
  */
-export function validateResponseSchema(toolName: string, data: unknown): TestStepResult {
+export function validateResponseSchema(toolName: string, data: unknown, responseAdcpVersion?: string): TestStepResult {
   const schema = TOOL_RESPONSE_SCHEMAS[toolName];
   if (!schema) {
     return {
@@ -743,7 +744,7 @@ export function validateResponseSchema(toolName: string, data: unknown): TestSte
     data && typeof data === 'object' && !Array.isArray(data)
       ? injectLegacyEnvelopeStatus(data as Record<string, unknown>, { toolName })
       : data;
-  const result = schema.safeParse(compatData);
+  const result = schema.safeParse(prepareResponseForSchemaValidation(toolName, compatData, responseAdcpVersion));
   if (result.success) {
     return {
       step: `Schema validation: ${toolName}`,

--- a/src/lib/testing/compliance/comply.ts
+++ b/src/lib/testing/compliance/comply.ts
@@ -26,6 +26,7 @@ import {
   resolveBundleOrStoryboard,
   listAllComplianceStoryboards,
   loadComplianceIndex,
+  isComplianceVersionSupported,
 } from '../storyboard/compliance';
 import type { NotApplicableStoryboard, ResolveOptions } from '../storyboard/compliance';
 import type {
@@ -49,9 +50,11 @@ import type {
   OverallStatus,
 } from './types';
 import { closeConnections } from '../../protocols';
+import type { VersionEnvelopeMode } from '../../protocols';
 import { detectController, hasTestController } from '../test-controller';
 import type { ControllerDetection } from '../test-controller';
 import { randomBytes } from 'crypto';
+import { isPre31AdcpVersion } from '../../utils/adcp-version-config';
 
 /**
  * All compliance tracks in display order.
@@ -636,6 +639,95 @@ function resolveFromCapabilities(
   return { storyboards, not_applicable };
 }
 
+export function applyNegotiatedComplianceVersionOptions(
+  profile: AgentProfile,
+  options: TestOptions,
+  params: {
+    complianceVersion: string;
+    callerAdcpVersion?: string;
+    callerVersionEnvelope?: VersionEnvelopeMode;
+  }
+): TestOptions {
+  const responseAdcpVersion = inferServerAdcpVersion(profile, params.complianceVersion, params.callerAdcpVersion);
+  let next: TestOptions =
+    responseAdcpVersion && options._serverAdcpVersion !== responseAdcpVersion
+      ? { ...options, _serverAdcpVersion: responseAdcpVersion }
+      : options;
+
+  if (params.callerVersionEnvelope !== undefined) return next;
+
+  const negotiatedEnvelope = negotiateVersionEnvelope(profile, params.complianceVersion);
+  if (negotiatedEnvelope && next.versionEnvelope !== negotiatedEnvelope) {
+    next = { ...next, versionEnvelope: negotiatedEnvelope };
+  }
+  return next;
+}
+
+function inferServerAdcpVersion(
+  profile: AgentProfile,
+  complianceVersion: string,
+  callerAdcpVersion: string | undefined
+): string | undefined {
+  const discoveredVersion = inferDiscoveredServerAdcpVersion(profile, complianceVersion);
+  if (discoveredVersion) return discoveredVersion;
+  if (callerAdcpVersion) return callerAdcpVersion;
+  return complianceVersion;
+}
+
+function inferDiscoveredServerAdcpVersion(profile: AgentProfile, complianceVersion: string): string | undefined {
+  const supported = profile.adcp_supported_versions;
+  if (supported?.length) {
+    if (isComplianceVersionSupported(complianceVersion, supported)) return complianceVersion;
+    const sorted = [...supported].sort(compareAdcpVersionStrings);
+    return sorted[sorted.length - 1];
+  }
+  if (profile.adcp_build_version) return profile.adcp_build_version;
+  if (isLegacyPre31TypescriptSdkProfile(profile)) return '3.0';
+  if (isLegacyV2Profile(profile)) return 'v2.5';
+  return undefined;
+}
+
+function negotiateVersionEnvelope(profile: AgentProfile, complianceVersion: string): VersionEnvelopeMode | undefined {
+  if (isLegacyV2Profile(profile)) return 'none';
+  const supported = profile.adcp_supported_versions;
+  if (supported?.length && supported.every(isPre31AdcpVersion)) return 'major-only';
+  if (profile.adcp_build_version && isPre31AdcpVersion(profile.adcp_build_version)) return 'major-only';
+  if (isLegacyPre31TypescriptSdkProfile(profile)) return 'major-only';
+  if (isPre31AdcpVersion(complianceVersion) && isLegacyV3Profile(profile)) return 'major-only';
+  return undefined;
+}
+
+function isLegacyV2Profile(profile: AgentProfile): boolean {
+  if (profile.adcp_version === 'v2') return true;
+  const majors = profile.adcp_major_versions ?? [];
+  if (majors.length > 0) return majors.includes(2) && !majors.includes(3);
+  return !profile.tools.includes('get_adcp_capabilities');
+}
+
+function isLegacyV3Profile(profile: AgentProfile): boolean {
+  if (profile.adcp_version === 'v3') return true;
+  if (profile.adcp_major_versions?.includes(3)) return true;
+  return profile.tools.includes('get_adcp_capabilities') && !profile.adcp_supported_versions?.length;
+}
+
+function isLegacyPre31TypescriptSdkProfile(profile: AgentProfile): boolean {
+  const match = /^@adcp\/(?:client|sdk)@(\d+)\./.exec(profile.library_version ?? '');
+  if (!match?.[1]) return false;
+  const major = Number.parseInt(match[1], 10);
+  return Number.isFinite(major) && major < 8;
+}
+
+function compareAdcpVersionStrings(a: string, b: string): number {
+  const parse = (value: string): [number, number] => {
+    const trimmed = value.startsWith('v') ? value.slice(1) : value;
+    const match = /^(\d+)(?:\.(\d+))?/.exec(trimmed);
+    return [Number.parseInt(match?.[1] ?? '0', 10), Number.parseInt(match?.[2] ?? '0', 10)];
+  };
+  const [aMajor, aMinor] = parse(a);
+  const [bMajor, bMinor] = parse(b);
+  return aMajor - bMajor || aMinor - bMinor || a.localeCompare(b);
+}
+
 /**
  * Expand `requires_scenarios` references against the full compliance cache.
  * A specialism bundle may reference scenarios that live in its parent protocol
@@ -938,7 +1030,7 @@ async function complyImpl(agentUrl: string, options: ComplyOptions): Promise<Com
   const signal = abortController?.signal;
 
   try {
-    const effectiveOptions: TestOptions = applyAdcpVersionRunOptions(complianceIndex.adcp_version, {
+    let effectiveOptions: TestOptions = applyAdcpVersionRunOptions(complianceIndex.adcp_version, {
       ...testOptions,
       sandbox: testOptions.sandbox !== false,
       test_session_id: testOptions.test_session_id || `comply-${Date.now()}`,
@@ -955,10 +1047,15 @@ async function complyImpl(agentUrl: string, options: ComplyOptions): Promise<Com
     // comply pipeline past its own timeout (adcp-client#1612).
     const discoveryOptions =
       testOptions.versionEnvelope === undefined
-        ? { ...effectiveOptions, versionEnvelope: 'none' as const }
+        ? { ...effectiveOptions, versionEnvelope: 'major-only' as const }
         : effectiveOptions;
     const discoveryClient = createTestClient(agentUrl, effectiveOptions.protocol ?? 'mcp', discoveryOptions);
     const { profile, step: profileStep } = await discoverAgentProfile(discoveryClient, signal);
+    effectiveOptions = applyNegotiatedComplianceVersionOptions(profile, effectiveOptions, {
+      complianceVersion: complianceIndex.adcp_version,
+      ...(testOptions.adcpVersion !== undefined && { callerAdcpVersion: testOptions.adcpVersion }),
+      ...(testOptions.versionEnvelope !== undefined && { callerVersionEnvelope: testOptions.versionEnvelope }),
+    });
     const client =
       discoveryOptions === effectiveOptions
         ? discoveryClient

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -3901,6 +3901,7 @@ async function executeStep(
     const vctx: ValidationContext = {
       taskName: effectiveStep.task,
       ...(options.adcpVersion && { adcpVersion: options.adcpVersion }),
+      ...(options._serverAdcpVersion && { responseAdcpVersion: options._serverAdcpVersion }),
       ...(taskResult && { taskResult }),
       ...(httpResult && { httpResult }),
       agentUrl: runState.agentUrl,
@@ -4366,6 +4367,7 @@ async function executeProbeStep(
   const vctx: ValidationContext = {
     taskName: step.task,
     ...(options.adcpVersion && { adcpVersion: options.adcpVersion }),
+    ...(options._serverAdcpVersion && { responseAdcpVersion: options._serverAdcpVersion }),
     httpResult,
     agentUrl: runState.agentUrl,
     contributions: runState.contributions,

--- a/src/lib/testing/storyboard/validations.ts
+++ b/src/lib/testing/storyboard/validations.ts
@@ -8,11 +8,13 @@
  * `static/compliance/source/universal/runner-output-contract.yaml`.
  */
 
-import { TOOL_RESPONSE_SCHEMAS } from '../../utils/response-schemas';
+import { prepareResponseForSchemaValidation, TOOL_RESPONSE_SCHEMAS } from '../../utils/response-schemas';
 import { injectLegacyEnvelopeStatus } from '../../utils/envelope-status-compat';
 import { TRANSPORT_SUFFIX_REGEX } from '../../utils/a2a-discovery';
 import { validateResponse, type ValidationIssue } from '../../validation/schema-validator';
+import { hasSchemaBundle } from '../../validation/schema-loader';
 import { ADCP_VERSION } from '../../version';
+import { isPre31AdcpVersion } from '../../utils/adcp-version-config';
 import type { TaskResult } from '../types';
 import type {
   A2ATaskEnvelope,
@@ -43,6 +45,8 @@ export interface ValidationContext {
   taskName: string;
   /** AdCP schema bundle to use for strict AJV validation. */
   adcpVersion?: string;
+  /** Server-declared AdCP version to use for response-shape compatibility decisions. */
+  responseAdcpVersion?: string;
   taskResult?: TaskResult;
   httpResult?: HttpProbeResult;
   agentUrl: string;
@@ -483,14 +487,17 @@ function validateResponseSchema(
   const dataForValidation = Array.isArray(dataWithoutMessage)
     ? dataWithoutMessage
     : injectLegacyEnvelopeStatus(dataWithoutMessage as Record<string, unknown>, { toolName: taskName });
-  const parseResult = schema.safeParse(dataForValidation);
+  const responseAdcpVersion = ctx.responseAdcpVersion ?? ctx.adcpVersion;
+  const parseResult = schema.safeParse(
+    prepareResponseForSchemaValidation(taskName, dataForValidation, responseAdcpVersion)
+  );
 
   // Strict (AJV) verdict runs alongside the lenient Zod check so the run
   // report surfaces strictness deltas (issue #820 follow-up). The AJV path
   // enforces `format` keywords and `additionalProperties: false` that Zod's
   // `passthrough()` omits — a response can pass Zod and fail AJV. The step's
   // overall pass/fail stays Zod-driven to preserve backwards compatibility.
-  const strict = computeStrictVerdict(taskName, dataWithoutMessage, ctx.adcpVersion);
+  const strict = computeStrictVerdict(taskName, dataWithoutMessage, ctx.adcpVersion, ctx.responseAdcpVersion);
 
   // Shape-drift no longer rides on `ValidationResult.warning` — issue #935
   // moved that diagnostic to `StoryboardStepResult.hints[]` as a structured
@@ -547,9 +554,16 @@ function validateResponseSchema(
 function computeStrictVerdict(
   taskName: string,
   payload: unknown,
-  adcpVersion?: string
+  adcpVersion?: string,
+  responseAdcpVersion?: string
 ): StrictValidationVerdict | undefined {
-  const outcome = validateResponse(taskName, payload, adcpVersion);
+  const validationVersion =
+    responseAdcpVersion && hasSchemaBundle(responseAdcpVersion) ? responseAdcpVersion : adcpVersion;
+  if (responseAdcpVersion && isPre31AdcpVersion(responseAdcpVersion) && !hasSchemaBundle(responseAdcpVersion)) {
+    return undefined;
+  }
+  const payloadForValidation = prepareResponseForSchemaValidation(taskName, payload, responseAdcpVersion);
+  const outcome = validateResponse(taskName, payloadForValidation, validationVersion);
   // `variant: 'skipped'` means no AJV validator compiled for this task (no
   // strictness signal to emit); treat the same as "no AJV schema available".
   if (outcome.variant === 'skipped') return undefined;

--- a/src/lib/testing/types.ts
+++ b/src/lib/testing/types.ts
@@ -84,7 +84,8 @@ export interface TestOptions {
   /**
    * Version-envelope emission mode. Defaults to `auto`; 3.0 storyboards emit
    * the legacy major marker only, while 3.1 storyboards also emit the exact
-   * `adcp_version` marker.
+   * `adcp_version` marker. Compliance discovery may negotiate `major-only`
+   * for strict pre-3.1 agents.
    */
   versionEnvelope?: VersionEnvelopeMode;
   /** Custom User-Agent string sent with all outbound requests */
@@ -227,6 +228,13 @@ export interface TestOptions {
   _client?: unknown;
   /** @internal Pre-discovered profile from comply() — skips per-scenario discovery */
   _profile?: AgentProfile;
+  /**
+   * @internal Server-declared AdCP version learned during capability discovery.
+   * Storyboard response validation uses this for version-skew compatibility
+   * without forcing the transport client to pin a schema bundle that may not
+   * ship with the installed SDK.
+   */
+  _serverAdcpVersion?: string;
   /** @internal Test controller capabilities from comply() — set when comply_test_controller detected */
   _controllerCapabilities?: ControllerDetection;
   /** @internal Pre-created webhook receiver, used for unit-test injection. When
@@ -303,6 +311,11 @@ export interface AgentProfile {
    * `get_adcp_capabilities.adcp.supported_versions`.
    */
   adcp_supported_versions?: string[];
+  /**
+   * Seller's full AdCP build version from
+   * `get_adcp_capabilities.adcp.build_version`.
+   */
+  adcp_build_version?: string;
   supported_protocols?: string[];
   /** Specialism claims from get_adcp_capabilities.specialisms */
   specialisms?: string[];

--- a/src/lib/utils/adcp-version-config.ts
+++ b/src/lib/utils/adcp-version-config.ts
@@ -100,6 +100,24 @@ export function isAdcpVersionSupported(version: string, supportedVersions: reado
   });
 }
 
+export function isPre31AdcpVersion(version: string | undefined): boolean {
+  if (version === undefined) return false;
+  const trimmed = version.trim();
+  if (trimmed.length === 0) return false;
+
+  const withoutLegacyPrefix = trimmed.startsWith('v') ? trimmed.slice(1) : trimmed;
+  const match = /^(\d+)(?:\.(\d+))?/.exec(withoutLegacyPrefix);
+  if (!match?.[1]) return false;
+
+  const major = Number.parseInt(match[1], 10);
+  if (!Number.isFinite(major)) return false;
+  if (major < 3) return true;
+  if (major > 3) return false;
+
+  const minor = match[2] === undefined ? 0 : Number.parseInt(match[2], 10);
+  return Number.isFinite(minor) && minor < 1;
+}
+
 function prereleaseFamilyAlias(version: string): string | undefined {
   const match = /^(\d+\.\d+-[0-9A-Za-z-]+)\.\d+$/.exec(version);
   return match?.[1];

--- a/src/lib/utils/response-schemas.ts
+++ b/src/lib/utils/response-schemas.ts
@@ -8,6 +8,7 @@
 import { z } from 'zod';
 import * as schemas from '../types/schemas.generated';
 import { SyncCreativesResponseStrictSchema } from '../validation/sync-creatives';
+import { isPre31AdcpVersion } from './adcp-version-config';
 
 function declaresLegacy30xPayload(response: Record<string, unknown>): boolean {
   const adcpVersion = response.adcp_version;
@@ -17,6 +18,20 @@ function declaresLegacy30xPayload(response: Record<string, unknown>): boolean {
     );
   }
   return response.adcp_major_version === 3;
+}
+
+export function prepareResponseForSchemaValidation(
+  toolName: string,
+  data: unknown,
+  responseAdcpVersion?: string
+): unknown {
+  if (toolName !== 'get_products') return data;
+  if (!isPre31AdcpVersion(responseAdcpVersion)) return data;
+  if (data == null || typeof data !== 'object' || Array.isArray(data)) return data;
+
+  const response = data as Record<string, unknown>;
+  if (response.adcp_version !== undefined || response.adcp_major_version !== undefined) return data;
+  return { ...response, adcp_version: '3.0' };
 }
 
 const GetProductsResponseStrictSchema = schemas.GetProductsResponseSchema.superRefine((value, ctx) => {

--- a/src/lib/utils/response-unwrapper.ts
+++ b/src/lib/utils/response-unwrapper.ts
@@ -32,7 +32,7 @@ import type {
   GetSignalsResponse,
   ActivateSignalResponse,
 } from '../types/tools.generated';
-import { TOOL_RESPONSE_SCHEMAS } from './response-schemas';
+import { prepareResponseForSchemaValidation, TOOL_RESPONSE_SCHEMAS } from './response-schemas';
 import { injectLegacyEnvelopeStatus, normalizeLegacyMediaBuyStatusForReturn } from './envelope-status-compat';
 import { getLatestA2ADataPartFromResponse } from './a2a-artifacts';
 
@@ -211,7 +211,7 @@ export function unwrapProtocolResponse(
   protocolResponse: any,
   toolName?: string,
   protocol?: 'mcp' | 'a2a',
-  options?: { filterInvalidProducts?: boolean }
+  options?: { filterInvalidProducts?: boolean; responseAdcpVersion?: string }
 ): AdCPResponse & { _message?: string } {
   if (!protocolResponse) {
     throw new Error('Protocol response is null or undefined');
@@ -267,7 +267,11 @@ export function unwrapProtocolResponse(
       // Back-compat: 3.0.x sellers may omit envelope `status` (made REQUIRED
       // in 3.1.0-beta.2). Inject a synthetic status only when the response
       // declares itself as 3.0.x (or carries no version field at all).
-      const dataToValidate = injectLegacyEnvelopeStatus(stripped, { toolName });
+      const dataToValidate = prepareResponseForSchemaValidation(
+        toolName,
+        injectLegacyEnvelopeStatus(stripped, { toolName }),
+        options?.responseAdcpVersion
+      ) as Record<string, unknown>;
       const result = schema.safeParse(dataToValidate);
       if (!result.success) {
         // When filterInvalidArrayItems is enabled and this is a get_products response,
@@ -283,6 +287,10 @@ export function unwrapProtocolResponse(
               validated = rest as unknown as typeof validated;
             } else {
               validated = restoreLegacyMediaBuyStatusForReturn(validated, stripped, dataToValidate, toolName);
+            }
+            if (!('adcp_version' in stripped)) {
+              const { adcp_version: _v, ...rest } = validated as unknown as Record<string, unknown>;
+              validated = rest as unknown as typeof validated;
             }
             if (_msg) validated._message = _msg as string;
             return retag(validated);
@@ -317,6 +325,10 @@ export function unwrapProtocolResponse(
         validated = rest as unknown as typeof validated;
       } else {
         validated = restoreLegacyMediaBuyStatusForReturn(validated, stripped, dataToValidate, toolName);
+      }
+      if (!('adcp_version' in stripped)) {
+        const { adcp_version: _v, ...rest } = validated as unknown as Record<string, unknown>;
+        validated = rest as unknown as typeof validated;
       }
       if (_msg) validated._message = _msg as string;
       return retag(validated);
@@ -707,7 +719,7 @@ export function isAdcpError(response: any): boolean {
  * Uses Zod schemas to validate the response structure matches the expected
  * success response format for the given task.
  */
-export function isAdcpSuccess(response: any, taskName: string): boolean {
+export function isAdcpSuccess(response: any, taskName: string, responseAdcpVersion?: string): boolean {
   // First check if it's an error response
   if (isTerminalAdcpError(response, taskName)) {
     return false;
@@ -719,7 +731,11 @@ export function isAdcpSuccess(response: any, taskName: string): boolean {
     const { _message: _, ...stripped } = (response ?? {}) as Record<string, unknown>;
     // Apply the same 3.0.x envelope-status leniency as unwrapProtocolResponse
     // so success detection stays consistent across the two entry points.
-    const dataToValidate = injectLegacyEnvelopeStatus(stripped, { toolName: taskName });
+    const dataToValidate = prepareResponseForSchemaValidation(
+      taskName,
+      injectLegacyEnvelopeStatus(stripped, { toolName: taskName }),
+      responseAdcpVersion
+    );
     const result = schema.safeParse(dataToValidate);
     return result.success;
   }

--- a/test/lib/interop-workflow.test.js
+++ b/test/lib/interop-workflow.test.js
@@ -1,0 +1,23 @@
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+
+test('reference seller interop keeps strict AdCP 3.0 lane blocking', () => {
+  const workflow = fs.readFileSync(path.join(REPO_ROOT, '.github/workflows/interop-python.yml'), 'utf8');
+
+  assert.match(workflow, /typescript-strict-adcp-3-0-reference-seller:/);
+  assert.match(workflow, /STRICT_ADCP_3_0_REF:\s+88bacfdcc0fca4066462d5b621ffc2d7f7a5d348/);
+  assert.match(workflow, /run_storyboard_strict_3_0_reference_seller\.sh/);
+  assert.match(workflow, /github\.event_name == 'workflow_call'/);
+  assert.match(workflow, /Advisory: \\`false\\`/);
+
+  const jobStart = workflow.indexOf('typescript-strict-adcp-3-0-reference-seller:');
+  const nextJobMatch = /\n  [a-zA-Z0-9_-]+:/.exec(workflow.slice(jobStart + 1));
+  const nextJob = nextJobMatch ? jobStart + 1 + nextJobMatch.index : -1;
+  const jobBody = nextJob === -1 ? workflow.slice(jobStart) : workflow.slice(jobStart, nextJob);
+
+  assert.doesNotMatch(jobBody, /advisory:\s+true/);
+});

--- a/test/lib/response-schema-validation.test.js
+++ b/test/lib/response-schema-validation.test.js
@@ -95,6 +95,11 @@ describe('validateResponseSchema', () => {
       assert.ok(result.error.includes('cache_scope'), `Expected cache_scope error, got: ${result.error}`);
     });
 
+    it('passes when cache_scope is missing on a server-declared 3.0 products response', () => {
+      const result = validateResponseSchema('get_products', { products: [] }, '3.0');
+      assert.strictEqual(result.passed, true);
+    });
+
     it('passes for unchanged wholesale-feed responses without products', () => {
       const result = validateResponseSchema('get_products', {
         unchanged: true,

--- a/test/lib/response-unwrapper.test.js
+++ b/test/lib/response-unwrapper.test.js
@@ -83,6 +83,49 @@ describe('Response Unwrapper', () => {
       assert.strictEqual(result.products[0].name, 'Test Product');
     });
 
+    test('should unwrap markerless 3.0 get_products MCP response without cache_scope', () => {
+      const mcpResponse = {
+        structuredContent: {
+          products: [],
+        },
+      };
+
+      const result = unwrapProtocolResponse(mcpResponse, 'get_products', 'mcp', {
+        responseAdcpVersion: '3.0',
+      });
+
+      assert.deepStrictEqual(result.products, []);
+      assert.strictEqual(result.cache_scope, undefined);
+      assert.strictEqual(result.adcp_version, undefined);
+    });
+
+    test('should unwrap markerless 3.0 get_products A2A response without cache_scope', () => {
+      const a2aResponse = {
+        result: {
+          artifacts: [
+            {
+              parts: [
+                {
+                  kind: 'data',
+                  data: {
+                    products: [],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      };
+
+      const result = unwrapProtocolResponse(a2aResponse, 'get_products', 'a2a', {
+        responseAdcpVersion: '3.0',
+      });
+
+      assert.deepStrictEqual(result.products, []);
+      assert.strictEqual(result.cache_scope, undefined);
+      assert.strictEqual(result.adcp_version, undefined);
+    });
+
     test('should unwrap nested response field in A2A data part', () => {
       // Some agents wrap AdCP responses in an extra { response: { ... } } layer
       const a2aResponse = {

--- a/test/lib/storyboard-strict-validation.test.js
+++ b/test/lib/storyboard-strict-validation.test.js
@@ -24,6 +24,10 @@ function ctx(taskName, data, responseSchemaRef) {
   };
 }
 
+function ctxWith(taskName, data, responseSchemaRef, extra) {
+  return { ...ctx(taskName, data, responseSchemaRef), ...extra };
+}
+
 describe('storyboard validations: strict/lenient response_schema delta', () => {
   test('clean response: strict.valid=true, passed=true, no issues emitted', () => {
     // Minimal valid list_creative_formats response — `formats` is the only
@@ -58,6 +62,28 @@ describe('storyboard validations: strict/lenient response_schema delta', () => {
       assert.ok(issue.keyword, 'every AJV issue carries a keyword');
       assert.ok(typeof issue.message === 'string', 'every AJV issue has a message');
     }
+  });
+
+  test('server-declared 3.0 get_products response may omit 3.1 cache_scope without echoing version', () => {
+    const results = runValidations(
+      [{ check: 'response_schema', description: 'response conforms' }],
+      ctxWith('get_products', { products: [] }, 'media-buy/get-products-response.json', {
+        responseAdcpVersion: '3.0',
+      })
+    );
+    const v = results[0];
+    assert.strictEqual(v.passed, true, v.error);
+    if (v.strict) assert.strictEqual(v.strict.valid, true, 'strict validation must not apply 3.1 cache_scope');
+  });
+
+  test('current 3.1 get_products response still requires cache_scope', () => {
+    const results = runValidations(
+      [{ check: 'response_schema', description: 'response conforms' }],
+      ctx('get_products', { products: [] }, 'media-buy/get-products-response.json')
+    );
+    const v = results[0];
+    assert.strictEqual(v.passed, false);
+    assert.match(v.error, /cache_scope/);
   });
 
   test('strictness-delta scenario: Zod accepts a bad URI, AJV rejects format: uri', () => {

--- a/test/lib/storyboard-version-negotiation.test.js
+++ b/test/lib/storyboard-version-negotiation.test.js
@@ -70,6 +70,59 @@ describe('storyboard runner AdCP version negotiation', () => {
     );
   });
 
+  test('major-only version envelope suppresses exact adcp_version while preserving legacy marker', async () => {
+    const { McpServer } = require('@modelcontextprotocol/sdk/server/mcp.js');
+    const { Client } = require('@modelcontextprotocol/sdk/client/index.js');
+    const { InMemoryTransport } = require('@modelcontextprotocol/sdk/inMemory.js');
+    const { ProtocolClient } = require('../../dist/lib/index.js');
+    const z = require('zod');
+
+    let captured;
+    const server = new McpServer({ name: 'storyboard-version-test', version: '1.0.0' });
+    server.registerTool(
+      'get_adcp_capabilities',
+      {
+        inputSchema: {
+          adcp_major_version: z.number().optional(),
+          adcp_version: z.string().optional(),
+        },
+      },
+      async args => {
+        captured = args;
+        return {
+          content: [{ type: 'text', text: '{}' }],
+          structuredContent: {
+            status: 'completed',
+            adcp: { major_versions: [3] },
+            supported_protocols: ['media_buy'],
+          },
+        };
+      }
+    );
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    const mcpClient = new Client({ name: 'test-client', version: '1.0.0' });
+    await mcpClient.connect(clientTransport);
+
+    await ProtocolClient.callTool(
+      {
+        id: 'storyboard-version-test',
+        protocol: 'mcp',
+        agent_uri: 'in-process://storyboard-version-test',
+        _inProcessMcpClient: mcpClient,
+      },
+      'get_adcp_capabilities',
+      {},
+      { adcpVersion: '3.1.0-beta.5', versionEnvelope: 'major-only' }
+    );
+
+    assert.strictEqual(captured.adcp_major_version, 3);
+    assert.strictEqual(captured.adcp_version, undefined);
+
+    await mcpClient.close();
+    await server.close();
+  });
+
   test('3.0 storyboards suppress exact adcp_version while preserving legacy major marker', async () => {
     const { McpServer } = require('@modelcontextprotocol/sdk/server/mcp.js');
     const { Client } = require('@modelcontextprotocol/sdk/client/index.js');
@@ -131,6 +184,65 @@ describe('storyboard runner AdCP version negotiation', () => {
     assert.strictEqual(isComplianceVersionSupported('3.0.12', ['3.0.0']), true);
     assert.strictEqual(isComplianceVersionSupported('3.1.1', ['3.1.0']), true);
     assert.strictEqual(isComplianceVersionSupported('3.1.0-beta.5', ['3.0']), false);
+  });
+
+  test('compliance negotiation uses major-only envelope for strict 3.0 capability profiles', () => {
+    const { applyNegotiatedComplianceVersionOptions } = require('../../dist/lib/testing/compliance/comply.js');
+
+    const options = applyNegotiatedComplianceVersionOptions(
+      {
+        name: 'Strict 3.0',
+        tools: ['get_adcp_capabilities', 'get_products'],
+        adcp_version: 'v3',
+        adcp_major_versions: [3],
+        supported_protocols: ['media_buy'],
+        library_version: '@adcp/client@5.22.0',
+      },
+      { adcpVersion: '3.1.0-beta.5', versionEnvelope: 'auto' },
+      { complianceVersion: '3.1.0-beta.5' }
+    );
+
+    assert.strictEqual(options.versionEnvelope, 'major-only');
+    assert.strictEqual(options._serverAdcpVersion, '3.0');
+  });
+
+  test('missing supported_versions alone does not downgrade a v3 seller', () => {
+    const { applyNegotiatedComplianceVersionOptions } = require('../../dist/lib/testing/compliance/comply.js');
+
+    const options = applyNegotiatedComplianceVersionOptions(
+      {
+        name: '3.1 seller during SHOULD-emit phase',
+        tools: ['get_adcp_capabilities', 'get_products'],
+        adcp_version: 'v3',
+        adcp_major_versions: [3],
+        supported_protocols: ['media_buy'],
+      },
+      { adcpVersion: '3.1.0-beta.5', versionEnvelope: 'auto' },
+      { complianceVersion: '3.1.0-beta.5' }
+    );
+
+    assert.strictEqual(options.versionEnvelope, 'auto');
+    assert.strictEqual(options._serverAdcpVersion, '3.1.0-beta.5');
+  });
+
+  test('pre-3.1 build_version is positive downgrade evidence', () => {
+    const { applyNegotiatedComplianceVersionOptions } = require('../../dist/lib/testing/compliance/comply.js');
+
+    const options = applyNegotiatedComplianceVersionOptions(
+      {
+        name: 'Strict 3.0',
+        tools: ['get_adcp_capabilities', 'get_products'],
+        adcp_version: 'v3',
+        adcp_major_versions: [3],
+        adcp_build_version: '3.0.12',
+        supported_protocols: ['media_buy'],
+      },
+      { adcpVersion: '3.1.0-beta.5', versionEnvelope: 'auto' },
+      { complianceVersion: '3.1.0-beta.5' }
+    );
+
+    assert.strictEqual(options.versionEnvelope, 'major-only');
+    assert.strictEqual(options._serverAdcpVersion, '3.0.12');
   });
 
   test('capability resolution fails loudly on exact version mismatch', () => {


### PR DESCRIPTION
## Summary

Fixes storyboard/compliance runs against strict legacy AdCP 3.0 sellers by negotiating a major-only version envelope instead of sending the 3.1-only `adcp_version` marker.

Closes #2028.

## What changed

- Added a `major-only` version-envelope mode for strict pre-3.1 peers.
- Threaded negotiated server AdCP version into storyboard and runtime response validation.
- Added compatibility handling for markerless 3.0 `get_products` responses without 3.1 `cache_scope`.
- Added a blocking strict AdCP 3.0 TypeScript reference-seller CI lane with a proxy that rejects unexpected 3.1 fields.
- Added regression tests for negotiation, response unwrapping, strict validation, schema validation, and workflow coverage.

## Validation

- `npm run build:lib`
- `node --test-timeout=60000 --test test/lib/interop-workflow.test.js test/lib/storyboard-version-negotiation.test.js test/lib/storyboard-strict-validation.test.js test/lib/response-unwrapper.test.js test/lib/response-schema-validation.test.js`
- `bash -n scripts/ci/run_storyboard_strict_3_0_reference_seller.sh`
- `node --check scripts/ci/strict_adcp_3_0_proxy.mjs`
- `git diff --check`
