### PR TITLE
feat: expose compliance schema root override

### DIFF
--- a/.changeset/public-schema-root.md
+++ b/.changeset/public-schema-root.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': minor
+---
+
+Expose a public schema-root override for hosted compliance runs via `schemaRoot` options and `registerExternalSchemaRoot` from `@adcp/sdk/testing`.

--- a/docs/guides/VALIDATE-YOUR-AGENT.md
+++ b/docs/guides/VALIDATE-YOUR-AGENT.md
@@ -92,6 +92,21 @@ npx @adcp/sdk@adcp-3.1 storyboard run http://localhost:3001/mcp --json > report.
 - `--auth <token>` — bearer token (also accepts `$ADCP_AUTH_TOKEN`)
 - `--oauth` — run the browser OAuth flow inline when the saved alias has no valid tokens (MCP only; equivalent to `adcp --save-auth <alias> <url> --oauth` then re-running)
 
+**Hosted compliance bundles.** Programmatic runners that mount compliance
+assets outside the installed SDK can pair the storyboard cache and schema cache
+explicitly:
+
+```ts
+import { comply } from '@adcp/sdk/testing';
+
+await comply(agentUrl, {
+  version: '3.0.12',
+  complianceDir: '/app/dist/compliance/3.0.12',
+  schemaRoot: '/app/dist/schemas/3.0.12',
+  adcpVersion: '3.0.12',
+});
+```
+
 **OAuth-protected agents.** Storyboard runs reuse tokens saved under an alias. Two supported flows:
 
 ```bash

--- a/src/lib/testing/compliance/comply.ts
+++ b/src/lib/testing/compliance/comply.ts
@@ -512,6 +512,8 @@ export interface ComplyOptions extends TestOptions {
   version?: string;
   /** Explicit compliance cache directory override. */
   complianceDir?: string;
+  /** Explicit schema bundle root to pair with the selected compliance cache. */
+  schemaRoot?: string;
 }
 
 /**
@@ -988,11 +990,13 @@ async function complyImpl(agentUrl: string, options: ComplyOptions): Promise<Com
     contracts,
     version,
     complianceDir,
+    schemaRoot,
     ...testOptions
   } = options;
   const resolveOptions: ResolveOptions = {
     ...(version !== undefined && { version }),
     ...(complianceDir !== undefined && { complianceDir }),
+    ...(schemaRoot !== undefined && { schemaRoot }),
   };
   const complianceIndex = loadComplianceIndex(resolveOptions);
 

--- a/src/lib/testing/index.ts
+++ b/src/lib/testing/index.ts
@@ -225,6 +225,9 @@ export type {
 export { runAgainstLocalAgent } from './local-agent-runner';
 export type { LocalAgentRunResult, PerStoryboardOverride, RunAgainstLocalAgentOptions } from './local-agent-runner';
 
+// External schema bundles for hosted compliance/certification runs.
+export { registerExternalSchemaRoot, unregisterExternalSchemaRoot } from '../validation';
+
 // Storyboard-driven testing
 export {
   // Runner

--- a/src/lib/testing/storyboard/compliance.ts
+++ b/src/lib/testing/storyboard/compliance.ts
@@ -149,6 +149,12 @@ export interface ResolveOptions {
   version?: string;
   /** Override the compliance cache root (tests use this to point at fixtures). */
   complianceDir?: string;
+  /**
+   * Explicit schema bundle root to use with the selected compliance cache.
+   * The path must point at the schema-data directory for the cache version,
+   * for example `.../dist/lib/schemas-data/3.0`.
+   */
+  schemaRoot?: string;
 }
 
 export interface ResolvedBundle {
@@ -212,13 +218,17 @@ export function loadComplianceIndex(options: ResolveOptions = {}): ComplianceInd
     throw new Error(complianceMissingMessage('Compliance cache', dir));
   }
   const index = JSON.parse(readFileSync(indexPath, 'utf-8')) as ComplianceIndex;
-  registerExternalComplianceSchemaRoot(options.complianceDir, index.adcp_version);
+  registerExternalComplianceSchemaRoot(options, index.adcp_version);
   return index;
 }
 
-function registerExternalComplianceSchemaRoot(complianceDir: string | undefined, adcpVersion: string): void {
-  if (!complianceDir) return;
-  const root = findExternalSchemaRoot(complianceDir, adcpVersion);
+function registerExternalComplianceSchemaRoot(options: ResolveOptions, adcpVersion: string): void {
+  if (options.schemaRoot) {
+    registerExternalSchemaRoot(adcpVersion, options.schemaRoot);
+    return;
+  }
+  if (!options.complianceDir) return;
+  const root = findExternalSchemaRoot(options.complianceDir, adcpVersion);
   if (root) registerExternalSchemaRoot(adcpVersion, root);
 }
 

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -38,7 +38,11 @@ import { queryUpstreamTraffic, type ControllerScenario, type UpstreamTrafficSucc
 import { enrichRequest, hasRequestEnricher } from './request-builder';
 import { resolveAccount, resolveBrand } from '../client';
 import { isMutatingTask, generateIdempotencyKey } from '../../utils/idempotency';
-import { resolveBundleKey, schemaAllowsTopLevelField } from '../../validation/schema-loader';
+import {
+  registerExternalSchemaRoot,
+  resolveBundleKey,
+  schemaAllowsTopLevelField,
+} from '../../validation/schema-loader';
 import { parseAdcpMajorVersion } from '../../version';
 import {
   PROBE_TASKS,
@@ -163,6 +167,17 @@ export function applyAdcpVersionRunOptions(
     return options;
   }
   return { ...options, adcpVersion, versionEnvelope };
+}
+
+function registerRunSchemaRoot(options: StoryboardRunOptions): void {
+  if (!options.schemaRoot) return;
+  const adcpVersion = options.adcpVersion ?? options._serverAdcpVersion;
+  if (!adcpVersion) {
+    throw new Error(
+      'schemaRoot requires an AdCP version. Pass adcpVersion, or run a storyboard/compliance bundle with adcp_version set.'
+    );
+  }
+  registerExternalSchemaRoot(adcpVersion, options.schemaRoot);
 }
 
 function storyboardVersionEnvelopeMode(adcpVersion: string): VersionEnvelopeMode {
@@ -931,6 +946,7 @@ export async function runStoryboard(
   options: StoryboardRunOptions = {}
 ): Promise<StoryboardResult> {
   options = applyStoryboardVersionOptions(storyboard, options);
+  registerRunSchemaRoot(options);
   validateTestKit(options.test_kit);
   // Enforce authoring-time branch_set invariants regardless of how the
   // storyboard reached us. YAML callers already ran these rules in
@@ -3076,6 +3092,7 @@ export async function runStoryboardStep(
   options: StoryboardRunOptions = {}
 ): Promise<StoryboardStepResult> {
   options = applyStoryboardVersionOptions(storyboard, options);
+  registerRunSchemaRoot(options);
   validateTestKit(options.test_kit);
   const clientResolution = getOrCreateClientResolution(agentUrl, options);
   const client = clientResolution.client;

--- a/src/lib/testing/types.ts
+++ b/src/lib/testing/types.ts
@@ -88,6 +88,12 @@ export interface TestOptions {
    * for strict pre-3.1 agents.
    */
   versionEnvelope?: VersionEnvelopeMode;
+  /**
+   * External schema bundle root used for request/response validation during
+   * storyboard and compliance runs. The root is registered against
+   * `adcpVersion` (or the storyboard/compliance version when omitted).
+   */
+  schemaRoot?: string;
   /** Custom User-Agent string sent with all outbound requests */
   userAgent?: string;
   // Brand reference for product discovery (preferred over brand_manifest)

--- a/src/lib/validation/schema-loader.ts
+++ b/src/lib/validation/schema-loader.ts
@@ -320,8 +320,52 @@ const externalSchemaRoots: Map<string, string> = new Map();
 function hasSchemaRootShape(root: string): boolean {
   if (!existsSync(root)) return false;
   const bundledRoot = path.join(root, 'bundled');
-  if (existsSync(bundledRoot) && walkJsonFiles(bundledRoot).length > 0) return true;
-  return walkJsonFiles(root).length > 0;
+  const files = existsSync(bundledRoot) ? walkJsonFiles(bundledRoot) : walkJsonFiles(root);
+  return files.some(file => {
+    try {
+      const schema = loadJson(file);
+      return typeof schema.$id === 'string' || typeof schema.$schema === 'string';
+    } catch {
+      return false;
+    }
+  });
+}
+
+function schemaIdVersionHint(schemaId: string): string | undefined {
+  return schemaId.match(/\/schemas\/([^/]+)\//)?.[1];
+}
+
+function collectSchemaRootVersionKeys(root: string): Set<string> {
+  const keys = new Set<string>();
+  for (const file of walkJsonFiles(root)) {
+    let schema: LoadedSchema;
+    try {
+      schema = loadJson(file);
+    } catch {
+      continue;
+    }
+    if (typeof schema.$id !== 'string') continue;
+    const hint = schemaIdVersionHint(schema.$id);
+    if (!hint) continue;
+    try {
+      keys.add(resolveBundleKey(hint));
+    } catch {
+      // Ignore non-AdCP schema ids; root shape validation already guarantees
+      // the directory contains JSON schemas, and the loader will surface any
+      // actual compile failure later with the file context.
+    }
+  }
+  return keys;
+}
+
+function assertSchemaRootMatchesVersion(version: string, root: string): void {
+  const expectedKey = resolveBundleKey(version);
+  const keys = collectSchemaRootVersionKeys(root);
+  if (keys.size === 0 || keys.has(expectedKey)) return;
+  throw new Error(
+    `External AdCP schema root for version "${version}" at ${root} does not match the requested version. ` +
+      `Expected schema ids for bundle "${expectedKey}", found ${Array.from(keys).sort().join(', ')}.`
+  );
 }
 
 /**
@@ -337,6 +381,7 @@ export function registerExternalSchemaRoot(version: string, root: string): void 
   if (!hasSchemaRootShape(root)) {
     throw new Error(`External AdCP schema root for version "${version}" not found or empty at ${root}`);
   }
+  assertSchemaRootMatchesVersion(version, root);
   const previous = externalSchemaRoots.get(key);
   externalSchemaRoots.set(key, root);
   if (previous !== root) states.delete(key);

--- a/test/lib/storyboard-version-negotiation.test.js
+++ b/test/lib/storyboard-version-negotiation.test.js
@@ -4,6 +4,28 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 
+function writeComplianceIndex(complianceDir, version = '3.0.12') {
+  fs.mkdirSync(complianceDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(complianceDir, 'index.json'),
+    JSON.stringify({ adcp_version: version, universal: [], protocols: [], specialisms: [] })
+  );
+}
+
+function writeGetProductsRequestSchema(schemaRoot, idVersion, sentinel = 'external') {
+  fs.mkdirSync(path.join(schemaRoot, 'bundled', 'media-buy'), { recursive: true });
+  fs.writeFileSync(
+    path.join(schemaRoot, 'bundled', 'media-buy', 'get-products-request.json'),
+    JSON.stringify({
+      $id: `/schemas/${idVersion}/bundled/media-buy/get-products-request.json`,
+      type: 'object',
+      properties: { sentinel: { const: sentinel } },
+      required: ['sentinel'],
+      additionalProperties: false,
+    })
+  );
+}
+
 describe('storyboard runner AdCP version negotiation', () => {
   test('derives legacy-major-only version envelope for 3.0 storyboards', () => {
     const { applyStoryboardVersionOptions } = require('../../dist/lib/testing/storyboard/index.js');
@@ -267,33 +289,16 @@ describe('storyboard runner AdCP version negotiation', () => {
 
   test('external compliance dir registers its sibling schema bundle', () => {
     const { loadComplianceIndex } = require('../../dist/lib/testing/storyboard/index.js');
-    const {
-      getValidator,
-      unregisterExternalSchemaRoot,
-      _resetValidationLoader,
-    } = require('../../dist/lib/validation/schema-loader.js');
+    const { getValidator, _resetValidationLoader } = require('../../dist/lib/validation/schema-loader.js');
+    const { unregisterExternalSchemaRoot } = require('../../dist/lib/testing/index.js');
     const { resolveAdcpVersion } = require('../../dist/lib/utils/adcp-version-config.js');
 
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'adcp-external-compliance-'));
     const complianceDir = path.join(tempRoot, 'package', 'compliance', 'cache', '3.0.12');
     const schemaRoot = path.join(tempRoot, 'package', 'dist', 'lib', 'schemas-data', '3.0');
     try {
-      fs.mkdirSync(complianceDir, { recursive: true });
-      fs.mkdirSync(path.join(schemaRoot, 'bundled', 'media-buy'), { recursive: true });
-      fs.writeFileSync(
-        path.join(complianceDir, 'index.json'),
-        JSON.stringify({ adcp_version: '3.0.12', universal: [], protocols: [], specialisms: [] })
-      );
-      fs.writeFileSync(
-        path.join(schemaRoot, 'bundled', 'media-buy', 'get-products-request.json'),
-        JSON.stringify({
-          $id: '/schemas/3.0/bundled/media-buy/get-products-request.json',
-          type: 'object',
-          properties: { sentinel: { const: 'external' } },
-          required: ['sentinel'],
-          additionalProperties: false,
-        })
-      );
+      writeComplianceIndex(complianceDir);
+      writeGetProductsRequestSchema(schemaRoot, '3.0');
 
       loadComplianceIndex({ complianceDir });
 
@@ -302,6 +307,63 @@ describe('storyboard runner AdCP version negotiation', () => {
       assert.ok(validator, 'external 3.0 request validator should compile');
       assert.strictEqual(validator({ sentinel: 'external' }), true);
       assert.strictEqual(validator({ sentinel: 'installed-sdk-default' }), false);
+    } finally {
+      unregisterExternalSchemaRoot('3.0.12');
+      _resetValidationLoader('3.0.12');
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('explicit schemaRoot registers a non-sibling external schema bundle', () => {
+    const { loadComplianceIndex } = require('../../dist/lib/testing/storyboard/index.js');
+    const { unregisterExternalSchemaRoot } = require('../../dist/lib/testing/index.js');
+    const { getValidator, _resetValidationLoader } = require('../../dist/lib/validation/schema-loader.js');
+
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'adcp-explicit-schema-root-'));
+    const complianceDir = path.join(tempRoot, 'compliance-cache', '3.0.12');
+    const schemaRoot = path.join(tempRoot, 'schema-bundles', '3.0');
+    try {
+      writeComplianceIndex(complianceDir);
+      writeGetProductsRequestSchema(schemaRoot, '3.0', 'explicit');
+
+      loadComplianceIndex({ complianceDir, schemaRoot });
+
+      const validator = getValidator('get_products', 'request', '3.0.12');
+      assert.ok(validator, 'explicit schema root validator should compile');
+      assert.strictEqual(validator({ sentinel: 'explicit' }), true);
+      assert.strictEqual(validator({ sentinel: 'external' }), false);
+    } finally {
+      unregisterExternalSchemaRoot('3.0.12');
+      _resetValidationLoader('3.0.12');
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('explicit schemaRoot fails fast when missing or version-mismatched', () => {
+    const { loadComplianceIndex } = require('../../dist/lib/testing/storyboard/index.js');
+    const { unregisterExternalSchemaRoot } = require('../../dist/lib/testing/index.js');
+    const { _resetValidationLoader } = require('../../dist/lib/validation/schema-loader.js');
+
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'adcp-bad-schema-root-'));
+    const complianceDir = path.join(tempRoot, 'compliance-cache', '3.0.12');
+    const wrongSchemaRoot = path.join(tempRoot, 'schema-bundles', '3.1');
+    try {
+      writeComplianceIndex(complianceDir);
+
+      assert.throws(
+        () => loadComplianceIndex({ complianceDir, schemaRoot: path.join(tempRoot, 'missing') }),
+        /External AdCP schema root for version "3\.0\.12" not found or empty/
+      );
+      assert.throws(
+        () => loadComplianceIndex({ complianceDir, schemaRoot: complianceDir }),
+        /External AdCP schema root for version "3\.0\.12" not found or empty/
+      );
+
+      writeGetProductsRequestSchema(wrongSchemaRoot, '3.1.0-beta.5');
+      assert.throws(
+        () => loadComplianceIndex({ complianceDir, schemaRoot: wrongSchemaRoot }),
+        /does not match the requested version.*3\.1\.0-beta\.5/
+      );
     } finally {
       unregisterExternalSchemaRoot('3.0.12');
       _resetValidationLoader('3.0.12');

--- a/test/lib/test-helpers.test.js
+++ b/test/lib/test-helpers.test.js
@@ -35,6 +35,7 @@ describe('Test Helpers', () => {
       TEST_AGENT_MCP_CONFIG,
       TEST_AGENT_A2A_CONFIG,
       creativeAgent,
+      registerExternalSchemaRoot,
     } = require('../../dist/lib/testing/index.js');
 
     assert.ok(testAgent, 'testAgent should be exported from /testing');
@@ -45,6 +46,7 @@ describe('Test Helpers', () => {
     assert.ok(TEST_AGENT_MCP_CONFIG, 'TEST_AGENT_MCP_CONFIG should be exported from /testing');
     assert.ok(TEST_AGENT_A2A_CONFIG, 'TEST_AGENT_A2A_CONFIG should be exported from /testing');
     assert.ok(creativeAgent, 'creativeAgent should be exported from /testing');
+    assert.strictEqual(typeof registerExternalSchemaRoot, 'function', 'registerExternalSchemaRoot should be public');
   });
 
   test('TEST_AGENT_MCP_CONFIG should have correct structure', () => {


### PR DESCRIPTION
## Summary

Expose a public schema-root override for hosted compliance runs.

Closes #2029.

## What changed

- Added `schemaRoot` to compliance/storyboard version options so external compliance caches can be paired with matching external schema bundles.
- Re-exported `registerExternalSchemaRoot` and `unregisterExternalSchemaRoot` from `@adcp/sdk/testing`.
- Added explicit missing-root and version-mismatch errors for external schema roots.
- Documented the hosted compliance usage pattern.

## Validation

- `npm run build:lib`
- `node --test-timeout=60000 --test test/lib/storyboard-version-negotiation.test.js test/lib/test-helpers.test.js`
- `npm run format:check`
- `npx changeset status --since=origin/main`
- `git diff --check`
