### PR TITLE
fix: dedupe codegen shared types

### DIFF
--- a/.changeset/dedupe-core-shared-types.md
+++ b/.changeset/dedupe-core-shared-types.md
@@ -1,0 +1,5 @@
+---
+"@adcp/sdk": patch
+---
+
+Dedupe core-authored shared schemas from generated tool types while preserving compatibility re-exports.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/sdk",
-  "version": "8.1.0-beta.12",
+  "version": "8.1.0-beta.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/sdk",
-      "version": "8.1.0-beta.12",
+      "version": "8.1.0-beta.13",
       "license": "Apache-2.0",
       "workspaces": [
         ".",
@@ -7348,7 +7348,7 @@
       "version": "6.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adcp/sdk": "^8.1.0-beta.12"
+        "@adcp/sdk": "^8.1.0-beta.13"
       },
       "bin": {
         "adcp": "bin/adcp.js"

--- a/scripts/generate-per-tool-types.ts
+++ b/scripts/generate-per-tool-types.ts
@@ -80,6 +80,7 @@ interface ExportInfo {
   kind: 'interface' | 'type' | 'enum';
   body: string;
   sourceFile: string;
+  sourceSection?: string;
 }
 
 /**
@@ -97,7 +98,15 @@ function parseExports(filePath: string): Map<string, ExportInfo> {
   const exports = new Map<string, ExportInfo>();
 
   let i = 0;
+  let sourceSection: string | undefined;
   while (i < lines.length) {
+    const sectionMatch = (lines[i] ?? '').match(/^\/\/ (.+\.json)$/);
+    if (sectionMatch) {
+      sourceSection = sectionMatch[1];
+      i++;
+      continue;
+    }
+
     // Skip past JSDoc block immediately preceding an export. The closing
     // `*/` is matched anywhere on the line (not just end-of-line) so a
     // single-line JSDoc like `/** brief */ export interface X` parses
@@ -197,11 +206,37 @@ function parseExports(filePath: string): Map<string, ExportInfo> {
     }
 
     const body = lines.slice(blockStart, blockEnd + 1).join('\n');
-    exports.set(name, { name, kind, body, sourceFile: filePath });
+    exports.set(name, { name, kind, body, sourceFile: filePath, sourceSection });
     i = blockEnd + 1;
   }
 
   return exports;
+}
+
+function isBundledMirrorExport(info: ExportInfo): boolean {
+  return info.sourceSection?.startsWith('bundled/') ?? false;
+}
+
+function loadBundledMirrorExportNames(): Set<string> {
+  const sourceCoreTypes = path.join(REPO_ROOT, 'src', 'lib', 'types', 'core.generated.ts');
+  if (!existsSync(sourceCoreTypes)) return new Set();
+
+  return new Set(
+    [...parseExports(sourceCoreTypes).values()].filter(info => isBundledMirrorExport(info)).map(info => info.name)
+  );
+}
+
+function shouldWarnOnExportCollision(
+  existing: ExportInfo,
+  info: ExportInfo,
+  bundledMirrorExportNames: Set<string>
+): boolean {
+  return (
+    stripComments(existing.body).trim() !== stripComments(info.body).trim() &&
+    !isBundledMirrorExport(existing) &&
+    !isBundledMirrorExport(info) &&
+    !bundledMirrorExportNames.has(info.name)
+  );
 }
 
 /**
@@ -456,6 +491,7 @@ function main(): void {
   }
 
   const allExports = new Map<string, ExportInfo>();
+  const bundledMirrorExportNames = loadBundledMirrorExportNames();
   for (const file of sources) {
     const parsed = parseExports(file);
     for (const [name, info] of parsed) {
@@ -471,11 +507,7 @@ function main(): void {
         // (same type emitted from two JSON Schema sources with different
         // descriptions) does not produce a false-positive warning.
         // Structural type drift still triggers the warn.
-        // TODO: root-cause fix — seed generateToolTypes with generatedCoreTypes
-        // so shared schemas (PurchaseType, AudienceConstraints, …) are not
-        // re-emitted in tools.generated.ts in the first place.
-        // Tracked in adcp-client#1976.
-        if (stripComments(existing.body).trim() !== stripComments(info.body).trim()) {
+        if (shouldWarnOnExportCollision(existing, info, bundledMirrorExportNames)) {
           console.warn(
             `[per-tool-types] export-name collision (different bodies): \`${name}\` defined ` +
               `in both ${path.relative(REPO_ROOT, existing.sourceFile)} and ` +
@@ -532,4 +564,4 @@ if (require.main === module) {
   main();
 }
 
-export const __test__ = { stripComments };
+export const __test__ = { stripComments, shouldWarnOnExportCollision };

--- a/scripts/generate-types.ts
+++ b/scripts/generate-types.ts
@@ -42,6 +42,11 @@ const ADCP_CORE_SCHEMAS = ['media-buy', 'creative-asset', 'product', 'targeting'
 // The adagents schema re-declares types that are already in property schema
 const STANDALONE_SCHEMAS: string[] = []; // ['adagents']
 
+// Shared schemas that are authoritative in core.generated.ts but are also
+// pulled into tool compilation through request/response $refs. Keep them out
+// of tools.generated.ts and import references from core.generated.ts instead.
+const CORE_AUTHORED_TOOL_SHARED_TYPES = new Set(['AudienceConstraints', 'PurchaseType']);
+
 // Load schema from cache - handles both /schemas/v1/ and /schemas/X.Y.Z/ paths
 function loadCachedSchema(schemaRef: string): any {
   try {
@@ -1147,7 +1152,77 @@ function loadCoreSchema(schemaName: string): any {
   }
 }
 
-async function generateToolTypes(tools: ToolDefinition[]) {
+function stripCommentsAndStringLiterals(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/\/\/.*$/gm, ' ')
+    .replace(/(['"`])(?:\\[\s\S]|(?!\1)[\s\S])*?\1/g, ' ');
+}
+
+function collectExportedTypeNames(typeDefinitions: string): Set<string> {
+  const names = new Set<string>();
+  const typePattern = /^export (?:type|interface) (\w+)/gm;
+  let match: RegExpExecArray | null;
+  while ((match = typePattern.exec(typeDefinitions)) !== null) {
+    names.add(match[1]);
+  }
+  return names;
+}
+
+function addCoreGeneratedTypeImports(typeDefinitions: string, typeNames: Iterable<string>): string {
+  const importNames = new Set<string>();
+  let body = typeDefinitions;
+  const importPattern = /^import type \{([\s\S]*?)\} from ['"]\.\/core\.generated['"]; ?\n*/gm;
+
+  body = body.replace(importPattern, (_match, imports: string) => {
+    for (const name of imports.split(',')) {
+      const trimmed = name.trim();
+      if (trimmed) importNames.add(trimmed);
+    }
+    return '';
+  });
+
+  for (const name of typeNames) {
+    importNames.add(name);
+  }
+
+  if (importNames.size === 0) return body;
+
+  const sortedImports = [...importNames].sort();
+  const importBlock = `import type {\n${sortedImports.map(name => `  ${name},`).join('\n')}\n} from './core.generated';\n\n`;
+  return importBlock + body.trimStart();
+}
+
+function addReferencedCoreTypeImports(typeDefinitions: string, coreTypeNames: Set<string>): string {
+  if (coreTypeNames.size === 0) return typeDefinitions;
+
+  const locallyDeclaredTypes = collectExportedTypeNames(typeDefinitions);
+  const searchable = stripCommentsAndStringLiterals(typeDefinitions);
+  const referencedCoreTypes = [...coreTypeNames].filter(name => {
+    if (locallyDeclaredTypes.has(name)) return false;
+    return new RegExp(`\\b${name}\\b`).test(searchable);
+  });
+
+  return addCoreGeneratedTypeImports(typeDefinitions, referencedCoreTypes);
+}
+
+function addCoreGeneratedTypeReExports(typeDefinitions: string, typeNames: Iterable<string>): string {
+  const reExportNames = [...new Set(typeNames)].sort();
+  if (reExportNames.length === 0) return typeDefinitions;
+
+  const exportStatement = `export type { ${reExportNames.join(', ')} } from './core.generated';`;
+  if (typeDefinitions.includes(exportStatement)) return typeDefinitions;
+
+  const importPattern = /^import type \{[\s\S]*?\} from ['"]\.\/core\.generated['"]; ?\n*/m;
+  const importMatch = typeDefinitions.match(importPattern);
+  if (importMatch?.[0]) {
+    return typeDefinitions.replace(importPattern, `${importMatch[0]}${exportStatement}\n\n`);
+  }
+
+  return `${exportStatement}\n\n${typeDefinitions}`;
+}
+
+async function generateToolTypes(tools: ToolDefinition[], preGeneratedTypes: Set<string> = new Set()) {
   console.log('🔧 Generating tool parameter and response types...');
 
   let toolTypes = '// Tool Parameter and Response Types\n';
@@ -1169,8 +1244,10 @@ async function generateToolTypes(tools: ToolDefinition[]) {
     },
   };
 
-  // Track generated types to avoid duplicates
-  const generatedTypes = new Set<string>();
+  // Track generated types to avoid duplicates. Some shared schemas are owned by
+  // core.generated.ts but are reached through tool request/response $refs; seed
+  // this set to keep those declarations out of tools.generated.ts.
+  const generatedTypes = new Set<string>(preGeneratedTypes);
   const allGeneratedCode: string[] = [];
 
   for (const tool of tools) {
@@ -1444,6 +1521,31 @@ export function removeNumberedTypeDuplicates(typeDefinitions: string): string {
   );
 
   return filterDuplicateTypeDefinitions(current, new Set<string>());
+}
+
+function removeNumberedCoreTypeDuplicates(typeDefinitions: string, coreTypeNames: Set<string>): string {
+  const locallyDeclaredTypes = collectExportedTypeNames(typeDefinitions);
+  const numberedCoreTypes = [...locallyDeclaredTypes]
+    .map(name => {
+      const numberedMatch = name.match(/^(.+?)(\d+)$/);
+      const base = numberedMatch?.[1];
+      return base ? { numbered: name, base } : null;
+    })
+    .filter((entry): entry is { numbered: string; base: string } => entry !== null && coreTypeNames.has(entry.base));
+
+  if (numberedCoreTypes.length === 0) return typeDefinitions;
+
+  let result = typeDefinitions;
+  for (const { numbered, base } of numberedCoreTypes) {
+    result = result.replace(new RegExp(`\\b${numbered}\\b`, 'g'), base);
+  }
+
+  console.log(
+    `🔢 Deduplicating ${numberedCoreTypes.length} numbered core type(s): ` +
+      numberedCoreTypes.map(t => `${t.numbered}→${t.base}`).join(', ')
+  );
+
+  return filterDuplicateTypeDefinitions(result, new Set(coreTypeNames));
 }
 
 // Helper function to filter duplicate type definitions properly
@@ -1794,12 +1896,8 @@ export function applyIndividualAssetDiscriminators(typeDefinitions: string): str
     }
   }
 
-  // tools.generated.ts has no existing `import` statements — we only inject one when
-  // we actually emitted a reference to a non-local requirements type.
   if (importedRequirementsTypes.length > 0) {
-    const sortedImports = [...new Set(importedRequirementsTypes)].sort();
-    const importBlock = `import type {\n${sortedImports.map(name => `  ${name},`).join('\n')}\n} from './core.generated';\n\n`;
-    result = importBlock + result;
+    result = addCoreGeneratedTypeImports(result, importedRequirementsTypes);
   }
 
   // Emit named union aliases for the slot shapes so ts-to-zod produces named
@@ -2357,7 +2455,7 @@ async function generateTypes() {
   const tools = loadAdCPTools();
 
   // Generate tool types
-  let toolTypes = await generateToolTypes(tools);
+  let toolTypes = await generateToolTypes(tools, CORE_AUTHORED_TOOL_SHARED_TYPES);
 
   // Remove index signature types that were incorrectly generated from oneOf schemas
   // These occur when JSON Schema has additionalProperties: false but oneOf with only required constraints
@@ -2365,7 +2463,10 @@ async function generateTypes() {
   // Remove numbered type duplicates (e.g., EventType1 -> EventType) caused by multiple $ref
   // occurrences of the same schema within a single compilation unit
   toolTypes = removeNumberedTypeDuplicates(toolTypes);
+  toolTypes = removeNumberedCoreTypeDuplicates(toolTypes, CORE_AUTHORED_TOOL_SHARED_TYPES);
   toolTypes = fixTypedIndexSignatures(toolTypes);
+  toolTypes = addReferencedCoreTypeImports(toolTypes, CORE_AUTHORED_TOOL_SHARED_TYPES);
+  toolTypes = addCoreGeneratedTypeReExports(toolTypes, CORE_AUTHORED_TOOL_SHARED_TYPES);
 
   // Compile gap schemas: all schemas not already generated by root schema passes.
   // Only dedup against core types (not tool types) because gap schemas go into

--- a/scripts/generate-zod-from-ts.ts
+++ b/scripts/generate-zod-from-ts.ts
@@ -1448,12 +1448,13 @@ async function generateZodSchemas() {
 
     // tools.generated.ts imports a handful of *AssetRequirements types from
     // core.generated.ts (injected by scripts/generate-types.ts so the standalone
-    // file typechecks). Since we concatenate both sources for ts-to-zod, those
-    // imports are redundant — worse, ts-to-zod treats imported names as external
-    // and emits `z.any()` stubs even when the actual interfaces are present in
-    // the combined source. Strip cross-file imports before merging.
+    // file typechecks) and may re-export core-owned compatibility aliases. Since
+    // we concatenate both sources for ts-to-zod, those cross-file statements are
+    // redundant — worse, ts-to-zod treats imported names as external and emits
+    // `z.any()` stubs even when the actual interfaces are present in the combined
+    // source. Strip cross-file imports/re-exports before merging.
     const toolsWithoutCrossImports = toolsContent.replace(
-      /^import type \{[^}]*\} from ['"]\.\/core\.generated['"]; ?\n+/gm,
+      /^(?:import type|export type) \{[^}]*\} from ['"]\.\/core\.generated['"]; ?\n+/gm,
       ''
     );
     // Defensive: if the injector in scripts/generate-types.ts ever changes shape

--- a/src/lib/types/core.generated.ts
+++ b/src/lib/types/core.generated.ts
@@ -1,5 +1,5 @@
 // Generated AdCP core types from official schemas v3.1.0-beta.5
-// Generated at: 2026-05-26T10:22:46.800Z
+// Generated at: 2026-05-27T01:20:01.388Z
 
 // MEDIA-BUY SCHEMA
 /**

--- a/src/lib/types/schemas.generated.ts
+++ b/src/lib/types/schemas.generated.ts
@@ -1,5 +1,5 @@
 // Generated Zod v4 schemas from TypeScript types
-// Generated at: 2026-05-26T09:10:35.983Z
+// Generated at: 2026-05-27T01:21:02.997Z
 // Sources:
 //   - core.generated.ts (core types)
 //   - tools.generated.ts (tool types)

--- a/src/lib/types/tools.generated.ts
+++ b/src/lib/types/tools.generated.ts
@@ -1,4 +1,5 @@
 import type {
+  AudienceConstraints,
   AudioAssetRequirements,
   CSSAssetRequirements,
   DAASTAssetRequirements,
@@ -6,12 +7,15 @@ import type {
   ImageAssetRequirements,
   JavaScriptAssetRequirements,
   MarkdownAssetRequirements,
+  PurchaseType,
   TextAssetRequirements,
   URLAssetRequirements,
   VASTAssetRequirements,
   VideoAssetRequirements,
   WebhookAssetRequirements,
 } from './core.generated';
+
+export type { AudienceConstraints, PurchaseType } from './core.generated';
 
 // Tool Parameter and Response Types
 // Generated from official AdCP schemas
@@ -18445,19 +18449,6 @@ export interface SyncPlansRequest {
   context?: ContextObject;
   ext?: ExtensionObject;
 }
-/**
- * Audience targeting constraints. Defines who the campaign should reach (include) and must not reach (exclude). The governance agent evaluates seller targeting against these constraints.
- */
-export interface AudienceConstraints {
-  /**
-   * Desired audience criteria. The seller's targeting should align with these. Each criterion is evaluated independently — the combined targeting should satisfy at least one inclusion criterion.
-   */
-  include?: AudienceSelector[];
-  /**
-   * Excluded audience criteria. The seller's targeting must not overlap with these. Exclusions take precedence over inclusions. Used for protected groups, vulnerable communities, regulatory restrictions, or brand safety.
-   */
-  exclude?: AudienceSelector[];
-}
 
 // sync_plans response
 /**
@@ -18560,10 +18551,6 @@ export interface SyncPlansResponse {
 }
 
 // report_plan_outcome parameters
-/**
- * The type of financial commitment this outcome is for. Determines which budget allocation (if any) to charge against. Defaults to 'media_buy' when omitted.
- */
-export type PurchaseType = 'media_buy' | 'rights_license' | 'signal_activation' | 'creative_services';
 /**
  * Outcome type.
  */

--- a/src/lib/utils/media-buy-delivery-notification-builders.ts
+++ b/src/lib/utils/media-buy-delivery-notification-builders.ts
@@ -3,7 +3,7 @@
 // re-send / supersession semantics:
 //   `scheduled` / `final` / `delayed` / `adjusted` / `window_update`.
 
-import type { GetMediaBuyDeliveryResponse } from '../types/core.generated';
+import type { GetMediaBuyDeliveryResponse } from '../types/tools.generated';
 
 type NotificationFields = Omit<GetMediaBuyDeliveryResponse, 'notification_type'>;
 type Tagged<Tag extends string> = NotificationFields & { notification_type: Tag };

--- a/src/lib/utils/preview-creative-builders.ts
+++ b/src/lib/utils/preview-creative-builders.ts
@@ -6,7 +6,7 @@ import type {
   PreviewCreativeSingleResponse,
   PreviewCreativeBatchResponse,
   PreviewCreativeVariantResponse,
-} from '../types/core.generated';
+} from '../types/tools.generated';
 
 type Tagged<T, Tag extends string> = Omit<T, 'response_type'> & { response_type: Tag };
 

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP SDK library version
  */
-export const LIBRARY_VERSION = '8.1.0-beta.12';
+export const LIBRARY_VERSION = '8.1.0-beta.13';
 
 /**
  * AdCP specification version this library is built for
@@ -64,10 +64,10 @@ export type AdcpVersion = (typeof COMPATIBLE_ADCP_VERSIONS)[number];
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '8.1.0-beta.12',
+  library: '8.1.0-beta.13',
   adcp: '3.1.0-beta.5',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-05-26T08:43:30.534Z',
+  generatedAt: '2026-05-27T01:03:44.757Z',
 } as const;
 
 /**

--- a/test/generate-per-tool-collision.test.js
+++ b/test/generate-per-tool-collision.test.js
@@ -41,16 +41,41 @@ const RESULTS = (() => {
   fs.writeFileSync(
     scriptPath,
     `
-import { writeFileSync } from 'fs';
+import { readFileSync, writeFileSync } from 'fs';
 import { __test__ } from ${JSON.stringify(targetPath)};
 
-const { stripComments } = __test__;
+const { stripComments, shouldWarnOnExportCollision } = __test__;
 const cases = ${JSON.stringify(cases)};
-const results = cases.map(({ label, a, b }) => ({
+const stripResults = cases.map(({ label, a, b }) => ({
   label,
   strippedDiffer: stripComments(a).trim() !== stripComments(b).trim(),
 }));
-writeFileSync(${JSON.stringify(outPath)}, JSON.stringify(results));
+const collisionResults = [
+  {
+    label: 'structural-difference-warns',
+    warns: shouldWarnOnExportCollision(
+      { name: 'NotBundled', kind: 'type', body: "export type NotBundled = 'a';", sourceFile: 'tools.generated.d.ts' },
+      { name: 'NotBundled', kind: 'type', body: "export type NotBundled = 'b';", sourceFile: 'core.generated.d.ts' },
+      new Set()
+    ),
+  },
+  {
+    label: 'bundled-mirror-name-suppressed',
+    warns: shouldWarnOnExportCollision(
+      { name: 'PurchaseType', kind: 'type', body: "export type PurchaseType = 'a';", sourceFile: 'tools.generated.d.ts' },
+      { name: 'PurchaseType', kind: 'type', body: "export type PurchaseType = 'b';", sourceFile: 'core.generated.d.ts' },
+      new Set(['PurchaseType'])
+    ),
+  },
+];
+const toolsGenerated = readFileSync(${JSON.stringify(path.join(REPO_ROOT, 'src/lib/types/tools.generated.ts'))}, 'utf8');
+const generatedSurface = {
+  importsCoreSharedTypes: /import type \\{[\\s\\S]*\\bAudienceConstraints\\b[\\s\\S]*\\bPurchaseType\\b[\\s\\S]*\\} from '\\.\\/core\\.generated';/.test(toolsGenerated),
+  reExportsCoreSharedTypes: toolsGenerated.includes("export type { AudienceConstraints, PurchaseType } from './core.generated';"),
+  declaresAudienceConstraints: /export interface AudienceConstraints\\b/.test(toolsGenerated),
+  declaresPurchaseType: /export type PurchaseType\\b/.test(toolsGenerated),
+};
+writeFileSync(${JSON.stringify(outPath)}, JSON.stringify({ stripResults, collisionResults, generatedSurface }));
 `
   );
 
@@ -71,7 +96,7 @@ writeFileSync(${JSON.stringify(outPath)}, JSON.stringify(results));
 })();
 
 test('stripComments: JSDoc-only difference does not make stripped bodies differ', () => {
-  const jsdocCase = RESULTS.find(r => r.label === 'jsdoc-only-difference');
+  const jsdocCase = RESULTS.stripResults.find(r => r.label === 'jsdoc-only-difference');
   assert.ok(jsdocCase, 'jsdoc-only-difference case should exist');
   assert.strictEqual(
     jsdocCase.strippedDiffer,
@@ -81,7 +106,7 @@ test('stripComments: JSDoc-only difference does not make stripped bodies differ'
 });
 
 test('stripComments: structural type difference still makes stripped bodies differ', () => {
-  const structCase = RESULTS.find(r => r.label === 'structural-difference');
+  const structCase = RESULTS.stripResults.find(r => r.label === 'structural-difference');
   assert.ok(structCase, 'structural-difference case should exist');
   assert.strictEqual(
     structCase.strippedDiffer,
@@ -91,17 +116,33 @@ test('stripComments: structural type difference still makes stripped bodies diff
 });
 
 test('stripComments: identical bodies produce no difference', () => {
-  const identCase = RESULTS.find(r => r.label === 'identical');
+  const identCase = RESULTS.stripResults.find(r => r.label === 'identical');
   assert.ok(identCase, 'identical case should exist');
   assert.strictEqual(identCase.strippedDiffer, false, 'Identical bodies should compare equal');
 });
 
 test('stripComments: asymmetric JSDoc (one body has it, other does not) produces no difference', () => {
-  const asymCase = RESULTS.find(r => r.label === 'asymmetric-jsdoc');
+  const asymCase = RESULTS.stripResults.find(r => r.label === 'asymmetric-jsdoc');
   assert.ok(asymCase, 'asymmetric-jsdoc case should exist');
   assert.strictEqual(
     asymCase.strippedDiffer,
     false,
     'Bodies where only one has JSDoc should compare equal after stripComments + trim'
   );
+});
+
+test('collision warning: structural drift still warns unless it is a bundled mirror export', () => {
+  const structuralCase = RESULTS.collisionResults.find(r => r.label === 'structural-difference-warns');
+  const bundledCase = RESULTS.collisionResults.find(r => r.label === 'bundled-mirror-name-suppressed');
+  assert.ok(structuralCase, 'structural-difference-warns case should exist');
+  assert.ok(bundledCase, 'bundled-mirror-name-suppressed case should exist');
+  assert.strictEqual(structuralCase.warns, true, 'Non-bundled structural drift should still warn');
+  assert.strictEqual(bundledCase.warns, false, 'Bundled mirror export names should not warn');
+});
+
+test('tools.generated: core-authored shared types are imported and re-exported without local duplicates', () => {
+  assert.strictEqual(RESULTS.generatedSurface.importsCoreSharedTypes, true);
+  assert.strictEqual(RESULTS.generatedSurface.reExportsCoreSharedTypes, true);
+  assert.strictEqual(RESULTS.generatedSurface.declaresAudienceConstraints, false);
+  assert.strictEqual(RESULTS.generatedSurface.declaresPurchaseType, false);
 });


### PR DESCRIPTION
## Summary

Fixes #1976.

- keep core-authored shared schemas (`AudienceConstraints`, `PurchaseType`) out of `tools.generated.ts` while importing references from `core.generated.ts`
- re-export those types from `tools.generated.ts` to preserve the legacy import surface
- strip cross-file type re-exports before Zod generation so schemas still resolve from the concatenated source
- suppress per-tool collision warnings for bundled mirror exports only, while keeping structural drift warnings for other duplicate export names
- add regression coverage for JSDoc-only comparisons, bundled mirror suppression, and the `tools.generated` compatibility re-export

## Validation

- Expert code review: no issues found
- Expert protocol review: no issues found
- `npm run generate-types`
- `npm run build:lib`
- `node --test-timeout=60000 --test test/generate-per-tool-collision.test.js`
- `npm run check:adopter-types`
- `npm run check:adopter-types-narrow`
- `git diff --check`