### PR TITLE
fix: preserve ZodObject ergonomics for schema codegen

### DIFF
--- a/.changeset/zod-object-dx-hardening.md
+++ b/.changeset/zod-object-dx-hardening.md
@@ -1,0 +1,5 @@
+---
+"@adcp/sdk": patch
+---
+
+Preserve ZodObject JavaScript ergonomics for additional record/object schema intersections.

--- a/scripts/generate-zod-from-ts.ts
+++ b/scripts/generate-zod-from-ts.ts
@@ -369,11 +369,16 @@ function postProcessForPassthrough(content: string): string {
 }
 
 /**
- * Replace `z.record(...).and(CONTENT)` with just CONTENT.
+ * Replace `z.record(...).and(CONTENT)` with an object-shaped equivalent.
  *
  * TypeScript types like `{ [k: string]: unknown } & { typed_fields }` produce
  * z.record().and(z.object()) in Zod. Since z.object().passthrough() already
  * preserves unknown keys, the z.record() wrapper is redundant.
+ *
+ * Typed string records like `Record<string, boolean> & { typed_fields }` are not
+ * redundant. Rewrite those to `z.object(...).catchall(z.boolean())` so JavaScript
+ * callers keep ZodObject helpers without losing the additional-property value
+ * constraint.
  *
  * Uses balanced-parenthesis scanning to handle nested schemas correctly.
  */
@@ -405,15 +410,19 @@ function unwrapRecordIntersections(content: string): string {
         else if (content[i] === ')') depth--;
         i++;
       }
-      const recordBody = content.substring(recordBodyStart, i - 1);
-
-      // Only unwrap z.record(z.string(), z.unknown()) — the additionalProperties pattern.
-      // Keep other z.record() types (e.g. z.record(z.string(), z.number())) as-is.
-      const isRedundantRecord = recordBody.trim() === 'z.string(), z.unknown()';
+      const recordEnd = i;
+      const recordBody = content.substring(recordBodyStart, recordEnd - 1);
+      const recordArgs = splitTopLevelCommaList(recordBody);
+      const keySchema = recordArgs[0] ? normalizeSchemaExpression(recordArgs[0]) : undefined;
+      const valueSchema = recordArgs[1]?.trim();
+      const normalizedValueSchema = valueSchema ? normalizeSchemaExpression(valueSchema) : undefined;
+      const isStringKeyRecord = recordArgs.length === 2 && keySchema === 'z.string()';
+      const isRedundantRecord = isStringKeyRecord && normalizedValueSchema === 'z.unknown()';
+      const isTypedStringRecord = isStringKeyRecord && normalizedValueSchema !== 'z.unknown()';
 
       // Check if followed by .and(
-      if (isRedundantRecord && content.startsWith('.and(', i)) {
-        i += '.and('.length;
+      if ((isRedundantRecord || isTypedStringRecord) && content.startsWith('.and(', recordEnd)) {
+        i = recordEnd + '.and('.length;
 
         // Scan balanced parens to extract .and() content
         depth = 1;
@@ -449,11 +458,18 @@ function unwrapRecordIntersections(content: string): string {
           i++;
         }
 
-        // Replace z.record(...).and(CONTENT) with just CONTENT
-        result += andContent;
+        if (isRedundantRecord) {
+          // Replace z.record(z.string(), z.unknown()).and(CONTENT) with just CONTENT.
+          result += andContent;
+        } else if (andContent.trimStart().startsWith('z.object(')) {
+          // Preserve typed additional-property validation in object-shaped form.
+          result += `${andContent}.catchall(${valueSchema})`;
+        } else {
+          result += content.substring(recordStart, i);
+        }
       } else {
         // z.record(...) not followed by .and( — keep as-is
-        result += content.substring(recordStart, i);
+        result += content.substring(recordStart, recordEnd);
       }
     } else {
       result += content[i];
@@ -563,30 +579,68 @@ function collectRedundantRecordSchemaNames(content: string): Set<string> {
   return names;
 }
 
-function isRedundantRecordMember(member: string, recordSchemaNames: Set<string>): boolean {
+function isRedundantRecordMember(
+  member: string,
+  recordSchemaNames: Set<string>,
+  unionSchemaNames: Set<string> = new Set()
+): boolean {
   const trimmed = member.trim();
-  return trimmed === 'z.record(z.string(), z.unknown())' || recordSchemaNames.has(trimmed);
+  if (
+    trimmed === 'z.record(z.string(), z.unknown())' ||
+    recordSchemaNames.has(trimmed) ||
+    unionSchemaNames.has(trimmed)
+  ) {
+    return true;
+  }
+
+  const unionMembers = unionArmsForExpression(trimmed);
+  return (
+    unionMembers !== undefined &&
+    unionMembers.length > 0 &&
+    unionMembers.every(nestedMember => isRedundantRecordMember(nestedMember, recordSchemaNames, unionSchemaNames))
+  );
 }
 
 function collectRedundantRecordUnionSchemaNames(content: string, recordSchemaNames: Set<string>): Set<string> {
   const names = new Set<string>();
-  const unionDeclPattern = /(?:export\s+)?const\s+(\w+)\s*=\s*z\.union\(\[/g;
-  let match: RegExpExecArray | null;
+  const unionMembersByName = new Map<string, string[]>();
 
-  while ((match = unionDeclPattern.exec(content)) !== null) {
-    const name = match[1]!;
-    const unionBodyStart = unionDeclPattern.lastIndex;
-    const unionBody = readBalancedBody(content, unionBodyStart, '[', ']');
-    if (!unionBody || content[unionBody.end] !== ')') continue;
+  for (const { name, expression } of findSchemaExportExpressions(content)) {
+    const members = unionArmsForExpression(expression);
+    if (members) unionMembersByName.set(name, members);
+  }
 
-    const afterUnion = content.slice(unionBody.end + 1).trimStart();
-    if (!afterUnion.startsWith(';')) continue;
+  function isRedundantMember(member: string, visiting: Set<string>): boolean {
+    const trimmed = member.trim();
+    if (isRedundantRecordMember(trimmed, recordSchemaNames, names)) return true;
 
-    const members = splitTopLevelCommaList(unionBody.body);
-    // TODO: one-level only — arms that are themselves z.union(...) are not collected
-    if (members.length > 0 && members.every(member => isRedundantRecordMember(member, recordSchemaNames))) {
-      names.add(name);
+    const namedMembers = unionMembersByName.get(trimmed);
+    if (namedMembers) {
+      return isRedundantUnion(trimmed, namedMembers, visiting);
     }
+
+    const inlineMembers = unionArmsForExpression(trimmed);
+    return (
+      inlineMembers !== undefined &&
+      inlineMembers.length > 0 &&
+      inlineMembers.every(nestedMember => isRedundantMember(nestedMember, visiting))
+    );
+  }
+
+  function isRedundantUnion(name: string, members: string[], visiting: Set<string>): boolean {
+    if (names.has(name)) return true;
+    if (visiting.has(name)) return false;
+
+    visiting.add(name);
+    const result = members.length > 0 && members.every(member => isRedundantMember(member, visiting));
+    visiting.delete(name);
+
+    if (result) names.add(name);
+    return result;
+  }
+
+  for (const [name, members] of unionMembersByName) {
+    isRedundantUnion(name, members, new Set());
   }
 
   return names;
@@ -605,6 +659,7 @@ function collectRedundantRecordUnionSchemaNames(content: string, recordSchemaNam
 function unwrapRecordUnionIntersections(content: string): string {
   const MARKER = 'z.union([';
   const recordSchemaNames = collectRedundantRecordSchemaNames(content);
+  const unionSchemaNames = collectRedundantRecordUnionSchemaNames(content, recordSchemaNames);
   let result = '';
   let i = 0;
 
@@ -623,7 +678,8 @@ function unwrapRecordUnionIntersections(content: string): string {
       const unionEnd = unionBody.end + 1;
       const members = splitTopLevelCommaList(unionBody.body);
       const isRedundantUnion =
-        members.length > 0 && members.every(member => isRedundantRecordMember(member, recordSchemaNames));
+        members.length > 0 &&
+        members.every(member => isRedundantRecordMember(member, recordSchemaNames, unionSchemaNames));
 
       if (isRedundantUnion && content.startsWith('.and(', unionEnd)) {
         const andBodyStart = unionEnd + '.and('.length;
@@ -992,34 +1048,104 @@ function canSafelyMerge(left: ObjectShape, right: ObjectShape): boolean {
   return true;
 }
 
-function extractSchemaExports(content: string): Map<string, string> {
-  const schemas = new Map<string, string>();
-  const exportRegex = /export const (\w+Schema)(?::[^=]+)? = /g;
-  let match: RegExpExecArray | null;
+type SchemaExportExpression = {
+  name: string;
+  expression: string;
+  expressionStart: number;
+  expressionEnd: number;
+};
 
-  while ((match = exportRegex.exec(content))) {
-    const name = match[1];
-    const expressionStart = exportRegex.lastIndex;
+function skipWhitespace(content: string, start: number): number {
+  let i = start;
+  while (i < content.length && /\s/.test(content[i])) i++;
+  return i;
+}
+
+function findSchemaAssignmentStart(content: string, start: number): number | undefined {
+  let i = skipWhitespace(content, start);
+
+  if (content[i] === ':') {
+    i++;
     let depth = 0;
-    let i = expressionStart;
+    let angleDepth = 0;
 
     while (i < content.length) {
       const ch = content[i];
       const literalEnd = skipQuotedOrRegexLiteral(content, i);
       if (literalEnd !== undefined) {
-        i = literalEnd - 1;
-      } else if (ch === '(' || ch === '{' || ch === '[') {
-        depth++;
-      } else if (ch === ')' || ch === '}' || ch === ']') {
-        depth--;
-      } else if (ch === ';' && depth === 0) {
-        schemas.set(name, content.slice(expressionStart, i));
-        break;
+        i = literalEnd;
+        continue;
       }
+
+      if (ch === '(' || ch === '{' || ch === '[') depth++;
+      else if (ch === ')' || ch === '}' || ch === ']') depth--;
+      else if (ch === '<') angleDepth++;
+      else if (ch === '>' && angleDepth > 0) angleDepth--;
+      else if (ch === '=' && content[i + 1] === '>') i++;
+      else if (ch === '=' && depth === 0 && angleDepth === 0) return skipWhitespace(content, i + 1);
+
       i++;
     }
 
-    exportRegex.lastIndex = i;
+    return undefined;
+  }
+
+  if (content[i] !== '=') return undefined;
+  return skipWhitespace(content, i + 1);
+}
+
+function findExpressionEnd(content: string, expressionStart: number): number | undefined {
+  let depth = 0;
+  let i = expressionStart;
+
+  while (i < content.length) {
+    const ch = content[i];
+    const literalEnd = skipQuotedOrRegexLiteral(content, i);
+    if (literalEnd !== undefined) {
+      i = literalEnd - 1;
+    } else if (ch === '(' || ch === '{' || ch === '[') {
+      depth++;
+    } else if (ch === ')' || ch === '}' || ch === ']') {
+      depth--;
+    } else if (ch === ';' && depth === 0) {
+      return i;
+    }
+    i++;
+  }
+
+  return undefined;
+}
+
+function findSchemaExportExpressions(content: string): SchemaExportExpression[] {
+  const exports: SchemaExportExpression[] = [];
+  const exportRegex = /export\s+const\s+(\w+Schema)\b/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = exportRegex.exec(content))) {
+    const name = match[1]!;
+    const expressionStart = findSchemaAssignmentStart(content, exportRegex.lastIndex);
+    if (expressionStart === undefined) continue;
+
+    const expressionEnd = findExpressionEnd(content, expressionStart);
+    if (expressionEnd === undefined) continue;
+
+    exports.push({
+      name,
+      expression: content.slice(expressionStart, expressionEnd),
+      expressionStart,
+      expressionEnd,
+    });
+
+    exportRegex.lastIndex = expressionEnd + 1;
+  }
+
+  return exports;
+}
+
+function extractSchemaExports(content: string): Map<string, string> {
+  const schemas = new Map<string, string>();
+  for (const { name, expression } of findSchemaExportExpressions(content)) {
+    schemas.set(name, expression);
   }
 
   return schemas;
@@ -1110,6 +1236,13 @@ function isOpaqueRecordMarkerExpression(
   const trimmed = normalizeSchemaExpression(expression);
   if (trimmed === 'z.record(z.string(), z.unknown())') return true;
 
+  const arms = unionArmsForExpression(trimmed);
+  if (arms) {
+    return (
+      arms.length > 0 && arms.every(arm => isOpaqueRecordMarkerExpression(arm, schemaExpressions, cache, visiting))
+    );
+  }
+
   const named = trimmed.match(/^(\w+Schema)$/)?.[1];
   if (!named) return false;
   if (cache.has(named)) return cache.get(named) ?? false;
@@ -1191,23 +1324,17 @@ function postProcessMarkerUnionObjectIntersections(content: string): string {
   const schemaExpressions = extractSchemaExports(content);
   const shapeCache = new Map<string, ObjectShape | undefined>();
   const markerCache = new Map<string, boolean>();
-  const exportRegex = /export const (\w+Schema)(?::[^=]+)? = /g;
   let result = '';
   let lastIndex = 0;
-  let match: RegExpExecArray | null;
 
-  while ((match = exportRegex.exec(content))) {
-    const name = match[1];
-    const expressionStart = exportRegex.lastIndex;
+  for (const { name, expressionStart, expressionEnd } of findSchemaExportExpressions(content)) {
     const expression = schemaExpressions.get(name);
     if (!expression) continue;
 
-    const expressionEnd = expressionStart + expression.length;
     const rewritten = rewriteLeadingMarkerUnionObjectAnd(expression, schemaExpressions, shapeCache, markerCache);
 
     result += content.slice(lastIndex, expressionStart) + rewritten;
     lastIndex = expressionEnd;
-    exportRegex.lastIndex = expressionEnd;
   }
 
   result += content.slice(lastIndex);
@@ -1217,23 +1344,17 @@ function postProcessMarkerUnionObjectIntersections(content: string): string {
 function postProcessObjectIntersections(content: string): string {
   const schemaExpressions = extractSchemaExports(content);
   const shapeCache = new Map<string, ObjectShape | undefined>();
-  const exportRegex = /export const (\w+Schema)(?::[^=]+)? = /g;
   let result = '';
   let lastIndex = 0;
-  let match: RegExpExecArray | null;
 
-  while ((match = exportRegex.exec(content))) {
-    const name = match[1];
-    const expressionStart = exportRegex.lastIndex;
+  for (const { name, expressionStart, expressionEnd } of findSchemaExportExpressions(content)) {
     const expression = schemaExpressions.get(name);
     if (!expression) continue;
 
-    const expressionEnd = expressionStart + expression.length;
     const rewritten = rewriteTopLevelObjectAnds(expression, schemaExpressions, shapeCache);
 
     result += content.slice(lastIndex, expressionStart) + rewritten;
     lastIndex = expressionEnd;
-    exportRegex.lastIndex = expressionEnd;
   }
 
   result += content.slice(lastIndex);
@@ -1249,25 +1370,19 @@ function postProcessObjectIntersections(content: string): string {
 function postProcessObjectUnionIntersections(content: string): string {
   const schemaExpressions = extractSchemaExports(content);
   const shapeCache = new Map<string, ObjectShape | undefined>();
-  const exportRegex = /export const (\w+Schema)(?::[^=]+)? = /g;
   let result = '';
   let lastIndex = 0;
-  let match: RegExpExecArray | null;
 
-  while ((match = exportRegex.exec(content))) {
-    const name = match[1];
-    const expressionStart = exportRegex.lastIndex;
+  for (const { name, expressionStart, expressionEnd } of findSchemaExportExpressions(content)) {
     const expression = schemaExpressions.get(name);
     if (!expression) continue;
 
-    const expressionEnd = expressionStart + expression.length;
     const rewritten = name.endsWith('RequestSchema')
       ? rewriteObjectUnionIntersection(expression, schemaExpressions, shapeCache)
       : expression;
 
     result += content.slice(lastIndex, expressionStart) + rewritten;
     lastIndex = expressionEnd;
-    exportRegex.lastIndex = expressionEnd;
   }
 
   result += content.slice(lastIndex);
@@ -1609,6 +1724,7 @@ if (require.main === module) {
 
 export const __test__ = {
   postProcessForNullish,
+  postProcessRecordIntersections,
   postProcessMarkerUnionObjectIntersections,
   postProcessObjectUnionIntersections,
   postProcessObjectIntersections,

--- a/src/lib/types/schemas.generated.ts
+++ b/src/lib/types/schemas.generated.ts
@@ -1,5 +1,5 @@
 // Generated Zod v4 schemas from TypeScript types
-// Generated at: 2026-05-27T01:21:02.997Z
+// Generated at: 2026-05-27T01:52:35.774Z
 // Sources:
 //   - core.generated.ts (core types)
 //   - tools.generated.ts (tool types)
@@ -2138,17 +2138,7 @@ export const GetBrandIdentitySuccessSchema = z.object({
         background: z.union([z.string(), z.array(z.string())]).optional(),
         text: z.union([z.string(), z.array(z.string())]).optional()
     }).passthrough().optional(),
-    fonts: z.record(z.string(), z.union([z.string(), z.object({
-                family: z.string(),
-                files: z.array(z.object({
-                    url: z.string().regex(/^https:\/\//),
-                    weight: z.number().min(100).max(900).optional(),
-                    weight_range: z.array(z.number()).optional(),
-                    style: z.union([z.literal("normal"), z.literal("italic"), z.literal("oblique")]).optional()
-                }).passthrough()).optional(),
-                opentype_features: z.array(z.string()).optional(),
-                fallbacks: z.array(z.string()).optional()
-            }).passthrough()])).and(z.object({
+    fonts: z.object({
         primary: z.union([z.string(), z.object({
                 family: z.string(),
                 files: z.array(z.object({
@@ -2171,7 +2161,17 @@ export const GetBrandIdentitySuccessSchema = z.object({
                 opentype_features: z.array(z.string()).optional(),
                 fallbacks: z.array(z.string()).optional()
             }).passthrough()]).optional()
-    }).passthrough()).optional(),
+    }).passthrough().catchall(z.union([z.string(), z.object({
+                family: z.string(),
+                files: z.array(z.object({
+                    url: z.string().regex(/^https:\/\//),
+                    weight: z.number().min(100).max(900).optional(),
+                    weight_range: z.array(z.number()).optional(),
+                    style: z.union([z.literal("normal"), z.literal("italic"), z.literal("oblique")]).optional()
+                }).passthrough()).optional(),
+                opentype_features: z.array(z.string()).optional(),
+                fallbacks: z.array(z.string()).optional()
+            }).passthrough()])).optional(),
     visual_guidelines: z.object({}).passthrough().optional(),
     tone: z.object({
         voice: z.string().optional(),
@@ -3438,12 +3438,12 @@ export const GetMediaBuysRequestSchema = z.object({
 
 export const CreativeApprovalStatusSchema = z.union([z.literal("pending_review"), z.literal("approved"), z.literal("rejected")]);
 
-export const MediaBuyFeaturesSchema = z.record(z.string(), z.boolean()).and(z.object({
+export const MediaBuyFeaturesSchema = z.object({
     inline_creative_management: z.boolean().optional(),
     property_list_filtering: z.boolean().optional(),
     catalog_management: z.boolean().optional(),
     committed_metrics_supported: z.boolean().optional()
-}).passthrough());
+}).passthrough().catchall(z.boolean());
 
 export const ListCreativeFormatsRequestSchema = z.object({
     adcp_version: z.string().optional(),
@@ -5509,7 +5509,7 @@ export const FlatRatePricingOptionSchema = z.object({
 export const ForecastPointSchema = z.object({
     label: z.string().max(128).optional(),
     budget: z.number().min(0).optional(),
-    metrics: z.record(z.string(), ForecastRangeSchema).and(z.object({
+    metrics: z.object({
         audience_size: ForecastRangeSchema.optional(),
         reach: ForecastRangeSchema.optional(),
         frequency: ForecastRangeSchema.optional(),
@@ -5526,7 +5526,7 @@ export const ForecastPointSchema = z.object({
         measured_impressions: ForecastRangeSchema.optional(),
         downloads: ForecastRangeSchema.optional(),
         plays: ForecastRangeSchema.optional()
-    }).passthrough())
+    }).passthrough().catchall(ForecastRangeSchema)
 }).passthrough();
 
 export const InstallmentDeadlinesSchema = z.object({
@@ -7540,9 +7540,9 @@ export const GetAdCPCapabilitiesResponseSchema = z.object({
     signals: z.object({
         data_provider_domains: z.array(z.string()).optional(),
         discovery_modes: z.array(z.union([z.literal("brief"), z.literal("wholesale")])).optional(),
-        features: z.record(z.string(), z.boolean()).and(z.object({
+        features: z.object({
             catalog_signals: z.boolean().optional()
-        }).passthrough()).optional()
+        }).passthrough().catchall(z.boolean()).optional()
     }).passthrough().optional(),
     governance: z.object({
         aggregation_window_days: z.number().min(1).max(365).optional(),

--- a/src/type-tests/zod-schema-ergonomics.type-test.ts
+++ b/src/type-tests/zod-schema-ergonomics.type-test.ts
@@ -9,6 +9,7 @@ import {
   CanonicalFormatDisplayTagSchema,
   CanonicalFormatHTML5BannerSchema,
   CanonicalFormatImageSchema,
+  MediaBuyFeaturesSchema,
   ProductSchema,
 } from '../lib/types/schemas.generated';
 
@@ -44,3 +45,10 @@ const HTML5BannerOmitted = CanonicalFormatHTML5BannerSchema.omit({
   deprecated: true,
 });
 void HTML5BannerOmitted;
+
+// Typed record/object intersections should also stay object-shaped. The
+// catchall preserves additional-property validation while keeping helpers.
+const MediaBuyFeaturesExtended = MediaBuyFeaturesSchema.extend({
+  _evaluated_at: z.string().datetime(),
+});
+void MediaBuyFeaturesExtended;

--- a/test/generate-zod-object-intersections.test.js
+++ b/test/generate-zod-object-intersections.test.js
@@ -46,6 +46,10 @@ function postProcessForNullish(input) {
   return runPostProcess('postProcessForNullish', input, '.zod-nullish-');
 }
 
+function postProcessRecordIntersections(input) {
+  return runPostProcess('postProcessRecordIntersections', input, '.zod-record-intersections-');
+}
+
 function postProcessMarkerUnionObjectIntersections(input) {
   return runPostProcess('postProcessMarkerUnionObjectIntersections', input, '.zod-marker-union-');
 }
@@ -95,6 +99,61 @@ export const CanonicalFormatImageSchema = SizeModeMutexSchema.and(z.object({
 
   assert.match(output, /export const CanonicalFormatImageSchema = z\.object\(/);
   assert.doesNotMatch(output, /CanonicalFormatImageSchema = SizeModeMutexSchema\.and/);
+});
+
+test('postProcessMarkerUnionObjectIntersections collapses nested opaque marker unions', () => {
+  const output = postProcessMarkerUnionObjectIntersections(`
+export const FixedSchema = z.record(z.string(), z.unknown());
+export const ResponsiveSchema = z.record(z.string(), z.unknown());
+export const FluidSchema = z.record(z.string(), z.unknown());
+export const StaticSizeSchema = z.union([FixedSchema, ResponsiveSchema]);
+export const SizeModeMutexSchema = z.union([
+  StaticSizeSchema,
+  z.union([FluidSchema, z.record(z.string(), z.unknown())])
+]);
+
+export const CanonicalFormatImageSchema = SizeModeMutexSchema.and(z.object({
+  width: z.number().optional(),
+  height: z.number().optional()
+}).passthrough());
+`);
+
+  assert.match(output, /export const CanonicalFormatImageSchema = z\.object\(/);
+  assert.doesNotMatch(output, /CanonicalFormatImageSchema = SizeModeMutexSchema\.and/);
+});
+
+test('postProcessRecordIntersections collapses nested named record-only unions', () => {
+  const output = postProcessRecordIntersections(`
+export const FixedSchema = z.record(z.string(), z.unknown());
+export const ResponsiveSchema = z.record(z.string(), z.unknown());
+export const FluidSchema = z.record(z.string(), z.unknown());
+export const StaticSizeSchema = z.union([FixedSchema, ResponsiveSchema]);
+export const SizeModeMutexSchema = z.union([
+  StaticSizeSchema,
+  z.union([FluidSchema, z.record(z.string(), z.unknown())])
+]);
+
+export const CanonicalFormatImageSchema = SizeModeMutexSchema.and(z.object({
+  width: z.number().optional(),
+  height: z.number().optional()
+}));
+`);
+
+  assert.match(output, /export const CanonicalFormatImageSchema = z\.object\(/);
+  assert.doesNotMatch(output, /CanonicalFormatImageSchema = SizeModeMutexSchema\.and/);
+});
+
+test('postProcessRecordIntersections preserves typed record constraints as object catchalls', () => {
+  const output = postProcessRecordIntersections(`
+export const MediaBuyFeaturesSchema = z.record(z.string(), z.boolean()).and(z.object({
+  inline_creative_management: z.boolean().optional(),
+  audience_targeting: z.boolean().optional()
+}));
+`);
+
+  assert.match(output, /export const MediaBuyFeaturesSchema = z\.object\(/);
+  assert.match(output, /\.catchall\(z\.boolean\(\)\)/);
+  assert.doesNotMatch(output, /MediaBuyFeaturesSchema = z\.record\(z\.string\(\), z\.boolean\(\)\)\.and/);
 });
 
 test('postProcessMarkerUnionObjectIntersections keeps unions once markers gain fields', () => {
@@ -179,6 +238,25 @@ export const ContainerSchema = z.object({
   assert.match(output, /export const SafeSchema = BaseSchema\.merge\(z\.object\(/);
   assert.match(output, /item: BaseSchema\.merge\(z\.object\(/);
   assert.doesNotMatch(output, /SafeSchema = BaseSchema\.and/);
+});
+
+test('postProcessObjectIntersections handles typed exports with equals signs in annotations', () => {
+  const output = postProcessObjectIntersections(`
+export const BaseSchema: z.ZodType<FactoryOptions<DefaultValue = unknown>> = z.object({
+  id: z.string().optional()
+}).passthrough();
+
+export const SafeSchema: z.ZodType<FactoryOptions<DefaultValue = unknown>> = BaseSchema.and(z.object({
+  id: z.string(),
+  name: z.string()
+}).passthrough());
+`);
+
+  assert.match(
+    output,
+    /export const SafeSchema: z\.ZodType<FactoryOptions<DefaultValue = unknown>> = BaseSchema\.merge\(z\.object\(/
+  );
+  assert.doesNotMatch(output, /SafeSchema: z\.ZodType<FactoryOptions<DefaultValue = unknown>> = BaseSchema\.and/);
 });
 
 test('postProcessObjectIntersections keeps conflicting overlaps as intersections', () => {

--- a/test/lib/zod-schemas.test.js
+++ b/test/lib/zod-schemas.test.js
@@ -642,8 +642,7 @@ describe('Zod Schema Validation', () => {
       'UpdateMediaBuyRequestSchema',
       'PackageUpdateSchema',
       'ProvidePerformanceFeedbackRequestSchema',
-      // MediaBuyFeaturesSchema uses z.record(z.string(), z.boolean()) which is a typed
-      // record — correctly kept as intersection to preserve the value type constraint.
+      'MediaBuyFeaturesSchema',
     ];
 
     for (const name of schemasToCheck) {


### PR DESCRIPTION
## Summary

Fixes the remaining Zod codegen DX hardening items from #1979.

- recursively recognizes nested record-only marker unions so object-shaped schemas keep ZodObject helpers
- replaces the shape-fragile schema export regex with a scanner that tolerates `=` inside type annotations
- rewrites typed string-record/object intersections as object schemas with `.catchall(...)`, preserving both JavaScript ergonomics and additional-property validation
- regenerates affected Zod schemas and adds runtime/type-level regression coverage

## Impact

JavaScript and TypeScript adopters can keep using `.shape`, `.extend()`, `.pick()`, and `.omit()` on object-shaped generated schemas. For typed record intersections such as `MediaBuyFeaturesSchema`, extra keys still validate against the original record value type.

## Validation

- `node --test test/generate-zod-object-intersections.test.js`
- `npm run typecheck`
- `git diff --check`
- pre-push validation: typecheck + library build

Fixes #1979.
