### PR TITLE
fix: enforce portable upstream identifier paths

### DIFF
--- a/.changeset/portable-upstream-identifier-paths.md
+++ b/.changeset/portable-upstream-identifier-paths.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Enforce the portable 3.1 `upstream_traffic.identifier_paths` grammar in storyboard runner resolution and digest prefetch.

--- a/src/lib/testing/storyboard/path.ts
+++ b/src/lib/testing/storyboard/path.ts
@@ -134,6 +134,90 @@ export function resolvePathAll(obj: unknown, path: string): unknown[] {
   return results;
 }
 
+const PORTABLE_IDENTIFIER_SEGMENT_RE = /^[A-Za-z_][A-Za-z0-9_]*(?:\[\*\])?$/;
+const RESERVED_IDENTIFIER_ROOTS = new Set(['request', 'response', 'context']);
+
+export interface PortableIdentifierPathIssue {
+  path: string;
+  reason: string;
+}
+
+/**
+ * Validate the portable `upstream_traffic.identifier_paths` grammar.
+ *
+ * These paths are intentionally narrower than the general storyboard path
+ * helpers: request-payload-relative dotted keys, with at most one `[*]`
+ * wildcard suffix per segment. They are exchanged across independent
+ * storyboard runners, so permissive JSONPath conveniences would create
+ * non-portable grading.
+ */
+export function validatePortableIdentifierPath(path: string): string | null {
+  if (typeof path !== 'string' || path.length === 0) return 'must be a non-empty string';
+  if (path.length > MAX_PATH_LENGTH) return `must be ${MAX_PATH_LENGTH} characters or fewer`;
+  if (path.startsWith('$')) return 'must be request-payload-relative; explicit roots like "$.foo" are not allowed';
+  if (path.startsWith('.') || path.endsWith('.') || path.includes('..')) {
+    return 'must not contain empty segments or recursive descent';
+  }
+
+  const segments = path.split('.');
+  const first = segments[0]!;
+  const firstKey = first.endsWith('[*]') ? first.slice(0, -3) : first;
+  if (RESERVED_IDENTIFIER_ROOTS.has(firstKey)) {
+    return `must not use reserved root "${firstKey}"`;
+  }
+
+  for (const segment of segments) {
+    if (segment.includes('["') || segment.includes("['")) return 'must not use bracket-quoted keys';
+    if (/\[\d+\]/.test(segment)) return 'must not use numeric array indexes';
+    if (!PORTABLE_IDENTIFIER_SEGMENT_RE.test(segment)) {
+      return `segment "${segment}" must be an identifier key optionally followed by [*]`;
+    }
+    const key = segment.endsWith('[*]') ? segment.slice(0, -3) : segment;
+    if (FORBIDDEN_KEYS.has(key)) return `must not use forbidden key "${key}"`;
+  }
+
+  return null;
+}
+
+/**
+ * Resolve a path that has already been restricted to the portable
+ * `identifier_paths` grammar. Invalid paths return no values; callers that
+ * need author-facing diagnostics should call `validatePortableIdentifierPath`
+ * first and surface the reason.
+ */
+export function resolvePortableIdentifierPathAll(obj: unknown, path: string): unknown[] {
+  if (obj === undefined || validatePortableIdentifierPath(path) !== null) return [];
+  const segments = path.split('.').map(segment => ({
+    key: segment.endsWith('[*]') ? segment.slice(0, -3) : segment,
+    wildcard: segment.endsWith('[*]'),
+  }));
+
+  let frontier: unknown[] = [obj];
+  for (const segment of segments) {
+    const next: unknown[] = [];
+    for (const current of frontier) {
+      if (next.length >= RESOLVE_PATH_ALL_MAX) break;
+      if (current === undefined || current === null || typeof current !== 'object') continue;
+      if (FORBIDDEN_KEYS.has(segment.key)) continue;
+      if (!Object.prototype.hasOwnProperty.call(current, segment.key)) continue;
+      const value = (current as Record<string, unknown>)[segment.key];
+      if (segment.wildcard) {
+        if (Array.isArray(value)) {
+          for (const item of value) {
+            if (next.length >= RESOLVE_PATH_ALL_MAX) break;
+            next.push(item);
+          }
+        }
+      } else {
+        next.push(value);
+      }
+    }
+    frontier = next.slice(0, RESOLVE_PATH_ALL_MAX).filter(value => value !== undefined);
+  }
+
+  return frontier;
+}
+
 function walk(current: unknown, segments: Array<string | number | typeof WILDCARD>, i: number, out: unknown[]): void {
   if (out.length >= RESOLVE_PATH_ALL_MAX) return;
   if (i === segments.length) {

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -31,7 +31,13 @@ import {
   type UpstreamTrafficQueryResult,
 } from './validations';
 import { PARALLEL_DISPATCH_CONTRACT, runParallelDispatches, validateParallelDispatchSpec } from './parallel-dispatch';
-import { resolvePath, resolvePathAll, toJsonPointer } from './path';
+import {
+  resolvePath,
+  resolvePathAll,
+  resolvePortableIdentifierPathAll,
+  toJsonPointer,
+  validatePortableIdentifierPath,
+} from './path';
 import { redactSecrets } from '../../utils/redact-secrets';
 import { ResponseSchemaValidationError } from '../../utils/response-unwrapper';
 import { injectLegacyEnvelopeStatus, normalizeLegacyMediaBuyStatusForReturn } from '../../utils/envelope-status-compat';
@@ -5105,6 +5111,9 @@ async function prefetchUpstreamTraffic(
 ): Promise<UpstreamTrafficValidationContext | undefined> {
   const upstreamChecks = resolvedValidations.filter(v => v.check === 'upstream_traffic');
   if (upstreamChecks.length === 0) return undefined;
+  if (upstreamChecks.some(check => (check.identifier_paths ?? []).some(path => validatePortableIdentifierPath(path)))) {
+    return undefined;
+  }
 
   const advertised =
     options._controllerCapabilities?.detected === true &&
@@ -5213,7 +5222,7 @@ function collectUpstreamIdentifierDigests(
   if (!sample) return out;
   for (const validation of validations) {
     for (const path of validation.identifier_paths ?? []) {
-      const vectors = resolvePathAll(sample, normalizeStoryboardJsonPath(path));
+      const vectors = resolvePortableIdentifierPathAll(sample, path);
       for (const vector of vectors) {
         if (typeof vector !== 'string') continue;
         if (!out.has(vector)) out.set(vector, sha256Hex(vector));
@@ -5222,14 +5231,6 @@ function collectUpstreamIdentifierDigests(
     }
   }
   return out;
-}
-
-function normalizeStoryboardJsonPath(path: string): string {
-  let p = path;
-  if (p.startsWith('$.')) p = p.slice(2);
-  else if (p.startsWith('$')) p = p.slice(1);
-  if (p.startsWith('.')) p = p.slice(1);
-  return p;
 }
 
 function sha256Hex(value: string): string {

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -33,7 +33,6 @@ import {
 import { PARALLEL_DISPATCH_CONTRACT, runParallelDispatches, validateParallelDispatchSpec } from './parallel-dispatch';
 import {
   resolvePath,
-  resolvePathAll,
   resolvePortableIdentifierPathAll,
   toJsonPointer,
   validatePortableIdentifierPath,

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -31,12 +31,7 @@ import {
   type UpstreamTrafficQueryResult,
 } from './validations';
 import { PARALLEL_DISPATCH_CONTRACT, runParallelDispatches, validateParallelDispatchSpec } from './parallel-dispatch';
-import {
-  resolvePath,
-  resolvePortableIdentifierPathAll,
-  toJsonPointer,
-  validatePortableIdentifierPath,
-} from './path';
+import { resolvePath, resolvePortableIdentifierPathAll, toJsonPointer, validatePortableIdentifierPath } from './path';
 import { redactSecrets } from '../../utils/redact-secrets';
 import { ResponseSchemaValidationError } from '../../utils/response-unwrapper';
 import { injectLegacyEnvelopeStatus, normalizeLegacyMediaBuyStatusForReturn } from '../../utils/envelope-status-compat';

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -1044,9 +1044,13 @@ export interface StoryboardValidation {
    * least one matching `recorded_call`'s payload at any depth. Each path
    * MAY resolve to a single value or an array; ALL resolved values MUST be
    * present in the recorded payload — single-placeholder fabrication is
-   * the threat model. Path syntax: same dotted-with-`[*]` form as
-   * `payload_must_contain.path`. Per spec PR adcontextprotocol/adcp#3816,
-   * replaces the earlier `buyer_identifier_echo: boolean` shorthand.
+   * the threat model. Path syntax is the portable 3.1 grammar:
+   * request-payload-relative dotted identifier keys, with each segment
+   * optionally followed by `[*]`. Explicit roots (`$.foo`), reserved roots
+   * (`request.*`, `response.*`, `context.*`), bracket-quoted keys, numeric
+   * indexes, recursive descent, and empty segments are storyboard authoring
+   * errors. Per spec PR adcontextprotocol/adcp#3816, replaces the earlier
+   * `buyer_identifier_echo: boolean` shorthand.
    */
   identifier_paths?: string[];
   /**

--- a/src/lib/testing/storyboard/validations.ts
+++ b/src/lib/testing/storyboard/validations.ts
@@ -31,7 +31,14 @@ import type {
 import type { RecordedCall, UpstreamTrafficSuccess } from '../test-controller';
 import { isJsonContentType } from '../test-controller';
 import { globToRegExp } from '../../utils/glob';
-import { resolvePath, resolvePathAll, toJsonPointer } from './path';
+import {
+  resolvePath,
+  resolvePathAll,
+  resolvePortableIdentifierPathAll,
+  toJsonPointer,
+  validatePortableIdentifierPath,
+  type PortableIdentifierPathIssue,
+} from './path';
 import { detectShapeDriftHints } from './shape-drift-hints';
 import { PROBE_TASK_ALLOWLIST } from './test-kit';
 
@@ -2614,6 +2621,29 @@ function validateFieldEqualsContext(validation: StoryboardValidation, ctx: Valid
  */
 function validateUpstreamTraffic(validation: StoryboardValidation, ctx: ValidationContext): ValidationResult {
   const expected = buildUpstreamTrafficExpected(validation);
+  const invalidIdentifierPaths = collectInvalidIdentifierPaths(validation.identifier_paths);
+  if (invalidIdentifierPaths.length > 0) {
+    return {
+      check: 'upstream_traffic',
+      passed: false,
+      description: validation.description,
+      error:
+        'storyboard authoring error: invalid upstream_traffic.identifier_paths: ' +
+        invalidIdentifierPaths.map(issue => `${issue.path} (${issue.reason})`).join('; '),
+      json_pointer: null,
+      expected,
+      actual: {
+        matched_count: 0,
+        total_calls: 0,
+        missing_payload_paths: [],
+        missing_identifier_values: [],
+        invalid_identifier_paths: invalidIdentifierPaths,
+      },
+      schema_id: null,
+      schema_url: null,
+    };
+  }
+
   const upstream = ctx.upstreamTraffic;
   // Adopter opted out (or controller wasn't detected): grade not_applicable.
   // missing_test_controller controller-side, not failed — opt-in by adopter
@@ -2729,7 +2759,7 @@ function validateUpstreamTraffic(validation: StoryboardValidation, ctx: Validati
         ? (requestPayload as Record<string, unknown>)
         : ctx.storyboardStep?.sample_request;
     for (const path of validation.identifier_paths) {
-      const vectors = sample !== undefined ? resolveJsonPathLite(sample, path) : [];
+      const vectors = sample !== undefined ? resolvePortableIdentifierPathAll(sample, path) : [];
       for (const vector of vectors) {
         if (vector === undefined || vector === null) continue;
         const digest = typeof vector === 'string' ? upstream.identifierDigestByValue?.get(vector) : undefined;
@@ -2841,6 +2871,15 @@ function validateUpstreamTraffic(validation: StoryboardValidation, ctx: Validati
     request: query.request,
     response: query.response,
   };
+}
+
+function collectInvalidIdentifierPaths(paths: string[] | undefined): PortableIdentifierPathIssue[] {
+  const invalid: PortableIdentifierPathIssue[] = [];
+  for (const path of paths ?? []) {
+    const reason = validatePortableIdentifierPath(path);
+    if (reason) invalid.push({ path, reason });
+  }
+  return invalid;
 }
 
 /**

--- a/test/lib/storyboard-runner-output-contract-v2-runner.test.js
+++ b/test/lib/storyboard-runner-output-contract-v2-runner.test.js
@@ -222,6 +222,47 @@ describe('runStoryboardStep — upstream_traffic pre-fetch end-to-end', () => {
     assert.deepEqual(upstreamValidation.actual.missing_identifier_values, []);
   });
 
+  test('invalid identifier_paths fail as authoring errors without querying controller', async () => {
+    const invalidStoryboard = JSON.parse(JSON.stringify(storyboard));
+    invalidStoryboard.phases[0].steps[0].validations = [
+      {
+        check: 'upstream_traffic',
+        description: 'invalid path should short-circuit before controller query',
+        min_count: 1,
+        identifier_paths: ['$.audiences[*].add[*].hashed_email'],
+      },
+    ];
+    const { client, calls } = buildStubClient(
+      {
+        sync_audiences: async () => ({
+          success: true,
+          data: { audiences: [{ audience_id: 'aud_1', status: 'syncing' }] },
+        }),
+      },
+      () => {
+        throw new Error('controller should not be queried for invalid identifier_paths');
+      }
+    );
+
+    const result = await runStoryboardStep('https://stub.example/mcp', invalidStoryboard, 'sync', {
+      protocol: 'mcp',
+      _client: client,
+      _profile: stubProfile,
+      _controllerCapabilities: { detected: true, scenarios: ['query_upstream_traffic'] },
+    });
+
+    assert.equal(calls.filter(c => c.name === 'comply_test_controller').length, 0);
+    const upstreamValidation = result.validations.find(v => v.check === 'upstream_traffic');
+    assert.ok(upstreamValidation);
+    assert.equal(upstreamValidation.passed, false);
+    assert.match(upstreamValidation.error, /storyboard authoring error/);
+    assert.equal(upstreamValidation.actual.matched_count, 0);
+    assert.equal(
+      upstreamValidation.actual.invalid_identifier_paths[0].path,
+      '$.audiences[*].add[*].hashed_email'
+    );
+  });
+
   test('grades raw-required payload assertions not_applicable when controller returns digest only', async () => {
     const { client } = buildStubClient(
       {

--- a/test/lib/storyboard-runner-output-contract-v2-runner.test.js
+++ b/test/lib/storyboard-runner-output-contract-v2-runner.test.js
@@ -257,10 +257,7 @@ describe('runStoryboardStep — upstream_traffic pre-fetch end-to-end', () => {
     assert.equal(upstreamValidation.passed, false);
     assert.match(upstreamValidation.error, /storyboard authoring error/);
     assert.equal(upstreamValidation.actual.matched_count, 0);
-    assert.equal(
-      upstreamValidation.actual.invalid_identifier_paths[0].path,
-      '$.audiences[*].add[*].hashed_email'
-    );
+    assert.equal(upstreamValidation.actual.invalid_identifier_paths[0].path, '$.audiences[*].add[*].hashed_email');
   });
 
   test('grades digest canonicalization failure on non-finite numbers as not_applicable', async () => {

--- a/test/lib/storyboard-runner-output-contract-v2.test.js
+++ b/test/lib/storyboard-runner-output-contract-v2.test.js
@@ -12,6 +12,7 @@ const assert = require('node:assert/strict');
 
 const { runValidations } = require('../../dist/lib/testing/storyboard/validations');
 const { applyContextOutputs, applyContextOutputsWithProvenance } = require('../../dist/lib/testing/storyboard/context');
+const { RESOLVE_PATH_ALL_MAX, resolvePortableIdentifierPathAll } = require('../../dist/lib/testing/storyboard/path');
 const { isJsonContentType } = require('../../dist/lib/testing/test-controller');
 
 // ────────────────────────────────────────────────────────────
@@ -619,6 +620,92 @@ describe('upstream_traffic — controller-backed anti-façade assertion', () => 
       ctx
     );
     assert.equal(result.passed, true);
+  });
+
+  test('identifier_paths rejects non-portable path grammar as storyboard authoring errors', () => {
+    const invalidPaths = [
+      '$.audiences[*].add[*].hashed_email',
+      'request.audiences',
+      'response.audiences',
+      'context.audiences',
+      'audiences[0].add[*].hashed_email',
+      'audiences[*].add[0].hashed_email',
+      'audiences["add"].hashed_email',
+      'audiences..hashed_email',
+      '.audiences',
+      'audiences.',
+    ];
+
+    for (const path of invalidPaths) {
+      const ctx = ctxWithTraffic(
+        {
+          success: true,
+          total_count: 1,
+          recorded_calls: [makeCall({ payload: { users: [{ hashed_email: 'vec_1' }] } })],
+        },
+        {
+          storyboardStep: {
+            sample_request: { audiences: [{ add: [{ hashed_email: 'vec_1' }] }] },
+          },
+        }
+      );
+      const [result] = runValidations(
+        [
+          {
+            check: 'upstream_traffic',
+            description: `invalid identifier path ${path}`,
+            identifier_paths: [path],
+          },
+        ],
+        ctx
+      );
+      assert.equal(result.passed, false, path);
+      assert.match(result.error, /storyboard authoring error/);
+      assert.equal(result.actual.matched_count, 0);
+      assert.deepEqual(result.actual.missing_identifier_values, []);
+      assert.equal(result.actual.invalid_identifier_paths[0].path, path);
+      assert.equal(typeof result.actual.invalid_identifier_paths[0].reason, 'string');
+      assert.ok(result.actual.invalid_identifier_paths[0].reason.length > 0);
+    }
+  });
+
+  test('identifier_paths authoring errors are surfaced before adopter opt-out', () => {
+    const ctx = ctxWithTraffic(
+      { success: true, recorded_calls: [], total_count: 0 },
+      {
+        advertised: false,
+        storyboardStep: {
+          sample_request: { audiences: [{ add: [{ hashed_email: 'vec_1' }] }] },
+        },
+      }
+    );
+    const [result] = runValidations(
+      [
+        {
+          check: 'upstream_traffic',
+          description: 'invalid even when controller absent',
+          identifier_paths: ['audiences[0].add[*].hashed_email'],
+        },
+      ],
+      ctx
+    );
+    assert.equal(result.passed, false);
+    assert.equal(result.not_applicable, undefined);
+    assert.match(result.error, /storyboard authoring error/);
+  });
+
+  test('identifier_paths portable resolver caps wildcard fan-out', () => {
+    const sample = {
+      audiences: [
+        {
+          add: Array.from({ length: RESOLVE_PATH_ALL_MAX + 5000 }, (_, i) => ({ hashed_email: `vec_${i}` })),
+        },
+      ],
+    };
+    const vectors = resolvePortableIdentifierPathAll(sample, 'audiences[*].add[*].hashed_email');
+    assert.equal(vectors.length, RESOLVE_PATH_ALL_MAX);
+    assert.equal(vectors[0], 'vec_0');
+    assert.equal(vectors[vectors.length - 1], `vec_${RESOLVE_PATH_ALL_MAX - 1}`);
   });
 
   test('identifier_paths fails when ANY resolved value is missing (anti-fabrication)', () => {


### PR DESCRIPTION
Fixes #2057.\n\nThis enforces the portable 3.1 upstream_traffic identifier_paths grammar in the storyboard runner, rejects invalid paths as authoring errors, and prevents invalid paths from triggering query_upstream_traffic prefetches. It also bounds wildcard fan-out in the portable resolver and updates the identifier_paths type comment.\n\nTests: npm run build:lib; NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/lib/storyboard-runner-output-contract-v2.test.js test/lib/storyboard-runner-output-contract-v2-runner.test.js. Pre-push validation also passed.