### PR TITLE
feat(testing): add rate-limit trip observer

### DIFF
--- a/.changeset/rate-limit-trip-observer.md
+++ b/.changeset/rate-limit-trip-observer.md
@@ -1,0 +1,7 @@
+---
+'@adcp/sdk': minor
+---
+
+Add the rate-limit trip/replay observer for the AdCP 3.1 `rate_limit_trip_runner` storyboard contract.
+
+The storyboard runner now executes `expect_rate_limit_not_replayed` by bursting fresh idempotency keys until `RATE_LIMITED`, waiting the advertised `retry_after`, replaying the same key, and grading the new `replay_not_cached_rate_limit` check. If the burst exhausts `max_attempts` without a rate-limit response, the step emits `skip_reason: "rate_limit_not_triggered"` and canonical `skip.reason: "not_applicable"`. The public `RateLimitTripObserver` helper is exported from both `@adcp/sdk` and `@adcp/sdk/testing`.

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1578,5 +1578,22 @@ export {
   hasBrandRightsTools,
   expectControllerError,
   expectControllerSuccess,
+  RateLimitTripObserver,
+  RATE_LIMIT_TRIP_CONTRACT,
+  RATE_LIMIT_TRIP_DEFAULT_REPLAY_MAX_WAIT_SECONDS,
+  RATE_LIMIT_TRIP_MAX_ATTEMPTS_MAX,
+  RATE_LIMIT_TRIP_MAX_ATTEMPTS_MIN,
+  validateRateLimitTripSpec,
 } from './testing/index';
-export type { ControllerErrorWithDetail } from './testing/index';
+export type {
+  ControllerErrorWithDetail,
+  TestClient,
+  RateLimitTripSpec,
+  RateLimitTripClient,
+  RateLimitTripFailureCode,
+  RateLimitTripObservation,
+  RateLimitTripObserverOptions,
+  RateLimitTripResponseSnapshot,
+  RateLimitTripStructuredResult,
+  RateLimitTripTaskOptions,
+} from './testing/index';

--- a/src/lib/testing/agent-tester.ts
+++ b/src/lib/testing/agent-tester.ts
@@ -33,6 +33,7 @@ export type {
   TaskResult,
   Logger,
 } from './types';
+export type { TestClient } from './client';
 
 // Re-export client utilities
 export { setAgentTesterLogger, getLogger, createTestClient, runStep } from './client';

--- a/src/lib/testing/index.ts
+++ b/src/lib/testing/index.ts
@@ -91,6 +91,7 @@ export {
   type TestStepResult,
   type AgentProfile,
   type TaskResult,
+  type TestClient,
   type Logger,
 } from './agent-tester';
 
@@ -261,6 +262,13 @@ export {
   // Validations
   runValidations,
   resolvePath,
+  // Rate-limit trip/replay observer
+  RateLimitTripObserver,
+  RATE_LIMIT_TRIP_CONTRACT,
+  RATE_LIMIT_TRIP_DEFAULT_REPLAY_MAX_WAIT_SECONDS,
+  RATE_LIMIT_TRIP_MAX_ATTEMPTS_MAX,
+  RATE_LIMIT_TRIP_MAX_ATTEMPTS_MIN,
+  validateRateLimitTripSpec,
   // Sandbox entities
   getSandboxEntities,
   getSandboxBrands,
@@ -287,7 +295,15 @@ export {
   type StepInvariantsObject,
   type StoryboardPhase,
   type StoryboardStep,
+  type RateLimitTripSpec,
   type StoryboardValidation,
+  type RateLimitTripClient,
+  type RateLimitTripFailureCode,
+  type RateLimitTripObservation,
+  type RateLimitTripObserverOptions,
+  type RateLimitTripResponseSnapshot,
+  type RateLimitTripStructuredResult,
+  type RateLimitTripTaskOptions,
   type StoryboardContext,
   type StoryboardRunOptions,
   type ValidationResult,

--- a/src/lib/testing/storyboard/index.ts
+++ b/src/lib/testing/storyboard/index.ts
@@ -25,6 +25,7 @@ export type {
   StepInvariantsObject,
   StoryboardPhase,
   StoryboardStep,
+  RateLimitTripSpec,
   StoryboardValidation,
   StoryboardValidationCheck,
   WebhookFilterSpec,
@@ -164,6 +165,22 @@ export { buildRequest, hasRequestBuilder } from './request-builder';
 
 // Validations
 export { runValidations } from './validations';
+export {
+  RateLimitTripObserver,
+  RATE_LIMIT_TRIP_CONTRACT,
+  RATE_LIMIT_TRIP_DEFAULT_REPLAY_MAX_WAIT_SECONDS,
+  RATE_LIMIT_TRIP_MAX_ATTEMPTS_MAX,
+  RATE_LIMIT_TRIP_MAX_ATTEMPTS_MIN,
+  extractTaskAdcpError,
+  validateRateLimitTripSpec,
+  type RateLimitTripFailureCode,
+  type RateLimitTripClient,
+  type RateLimitTripObservation,
+  type RateLimitTripObserverOptions,
+  type RateLimitTripResponseSnapshot,
+  type RateLimitTripStructuredResult,
+  type RateLimitTripTaskOptions,
+} from './rate-limit-trip';
 
 // `./junit` is deliberately NOT re-exported. The CLI requires it
 // directly from `dist/lib/testing/storyboard/junit.js` and the function

--- a/src/lib/testing/storyboard/rate-limit-trip.ts
+++ b/src/lib/testing/storyboard/rate-limit-trip.ts
@@ -1,0 +1,384 @@
+/**
+ * Sequential rate-limit trip/replay support for the
+ * `rate_limit_trip_runner` test-kit contract.
+ *
+ * The observer sends fresh-idempotency-key requests until a seller returns
+ * `RATE_LIMITED`, waits the advertised retry_after, then replays the same
+ * key/payload to verify the transient rate-limit response was not cached as
+ * the idempotency replay result.
+ */
+
+import { randomUUID } from 'node:crypto';
+import type { AdcpErrorInfo } from '../../core/ConversationTypes';
+import { ADCPError, ProtocolError, ResponseTooLargeError, TaskTimeoutError } from '../../errors';
+import { extractAdcpErrorInfo } from '../../utils/error-extraction';
+import { isTerminalAdcpError } from '../../utils/response-unwrapper';
+import type { TaskResult } from '../types';
+import { executeStoryboardTask } from './task-map';
+import type { RateLimitTripSpec } from './types';
+
+export const RATE_LIMIT_TRIP_CONTRACT = 'rate_limit_trip_runner';
+export const RATE_LIMIT_TRIP_MAX_ATTEMPTS_MIN = 50;
+export const RATE_LIMIT_TRIP_MAX_ATTEMPTS_MAX = 500;
+export const RATE_LIMIT_TRIP_DEFAULT_REPLAY_MAX_WAIT_SECONDS = 30;
+
+export type RateLimitTripFailureCode =
+  | 'rate_limit_trip_misconfigured'
+  | 'rate_limit_trip_request_error'
+  | 'rate_limit_trip_transport_error'
+  | 'missing_retry_after'
+  | 'replay_wait_exceeded';
+
+export interface RateLimitTripResponseSnapshot {
+  success: boolean;
+  data?: unknown;
+  /** Structured AdCP error when one was present; otherwise omitted. */
+  error?: Pick<AdcpErrorInfo, 'code' | 'message' | 'recovery' | 'field' | 'suggestion' | 'retry_after' | 'details'>;
+  /** Original TaskResult.error string, retained for diagnostics. */
+  error_message?: string;
+  adcp_error?: AdcpErrorInfo;
+}
+
+export interface RateLimitTripStructuredResult {
+  attempts: number;
+  target_task?: string;
+  target_transport?: 'mcp' | 'a2a';
+  trip_request?: Record<string, unknown>;
+  replay_request?: Record<string, unknown>;
+  rate_limited_request?: {
+    task: string;
+    attempt: number;
+    idempotency_key: string;
+  };
+  trip_response?: RateLimitTripResponseSnapshot;
+  replay_response?: RateLimitTripResponseSnapshot;
+}
+
+export type RateLimitTripObservation =
+  | {
+      status: 'completed';
+      body: RateLimitTripStructuredResult;
+    }
+  | {
+      status: 'not_applicable';
+      skip_reason: 'rate_limit_not_triggered';
+      message: string;
+      body: RateLimitTripStructuredResult;
+    }
+  | {
+      status: 'failed';
+      error: RateLimitTripFailureCode;
+      message: string;
+      body: RateLimitTripStructuredResult;
+    };
+
+export interface RateLimitTripObserverOptions {
+  /** Mint fresh idempotency keys for each burst attempt. */
+  keyMinter?: () => string;
+  /** Injectable sleep for fast deterministic tests. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Prefix for context.correlation_id tags. */
+  correlationPrefix?: string;
+  /** Transport label for runner output diagnostics. */
+  transport?: 'mcp' | 'a2a';
+}
+
+export interface RateLimitTripTaskOptions {
+  skipIdempotencyAutoInject?: boolean;
+  skipAccountValidation?: boolean;
+}
+
+/**
+ * Minimal client surface required by {@link RateLimitTripObserver}. The
+ * easiest way to obtain one is `createTestClient(...)` from
+ * `@adcp/sdk/testing`, but `SingleAgentClient` and compatible test doubles
+ * also satisfy this interface.
+ */
+export interface RateLimitTripClient {
+  executeTask(
+    taskName: string,
+    params: Record<string, unknown>,
+    inputHandler?: unknown,
+    options?: RateLimitTripTaskOptions
+  ): Promise<TaskResult>;
+  [methodName: string]: unknown;
+}
+
+export function validateRateLimitTripSpec(spec: RateLimitTripSpec | undefined): string | null {
+  if (!spec || typeof spec !== 'object') {
+    return 'rate_limit_trip is required for expect_rate_limit_not_replayed';
+  }
+  if (typeof spec.trip_target_task !== 'string' || spec.trip_target_task.length === 0) {
+    return 'rate_limit_trip.trip_target_task must be a non-empty string';
+  }
+  if (
+    !spec.trip_target_sample_request ||
+    typeof spec.trip_target_sample_request !== 'object' ||
+    Array.isArray(spec.trip_target_sample_request)
+  ) {
+    return 'rate_limit_trip.trip_target_sample_request must be an object';
+  }
+  if (!Number.isInteger(spec.max_attempts)) {
+    return `rate_limit_trip.max_attempts must be an integer; received ${spec.max_attempts}`;
+  }
+  if (spec.max_attempts < RATE_LIMIT_TRIP_MAX_ATTEMPTS_MIN || spec.max_attempts > RATE_LIMIT_TRIP_MAX_ATTEMPTS_MAX) {
+    return (
+      `rate_limit_trip.max_attempts must be in [${RATE_LIMIT_TRIP_MAX_ATTEMPTS_MIN}, ` +
+      `${RATE_LIMIT_TRIP_MAX_ATTEMPTS_MAX}] per test-kits/rate-limit-trip-runner.yaml; ` +
+      `received ${spec.max_attempts}`
+    );
+  }
+  if (spec.replay_max_wait_seconds !== undefined) {
+    if (!Number.isFinite(spec.replay_max_wait_seconds) || spec.replay_max_wait_seconds <= 0) {
+      return `rate_limit_trip.replay_max_wait_seconds must be a positive finite number; received ${spec.replay_max_wait_seconds}`;
+    }
+  }
+  return null;
+}
+
+const defaultSleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, Math.max(0, ms)));
+
+/**
+ * Public primitive for the rate-limit trip/replay contract. Callers supply a
+ * {@link RateLimitTripClient}; use `createTestClient(...)` for the standard
+ * compliance-runner client.
+ */
+export class RateLimitTripObserver {
+  constructor(
+    private readonly client: RateLimitTripClient,
+    private readonly defaults: RateLimitTripObserverOptions = {}
+  ) {}
+
+  async run(spec: RateLimitTripSpec, opts: RateLimitTripObserverOptions = {}): Promise<RateLimitTripObservation> {
+    const validationError = validateRateLimitTripSpec(spec);
+    if (validationError) {
+      return {
+        status: 'failed',
+        error: 'rate_limit_trip_misconfigured',
+        message: validationError,
+        body: { attempts: 0 },
+      };
+    }
+
+    const keyMinter = opts.keyMinter ?? this.defaults.keyMinter ?? defaultKeyMinter;
+    const sleep = opts.sleep ?? this.defaults.sleep ?? defaultSleep;
+    const correlationPrefix = opts.correlationPrefix ?? this.defaults.correlationPrefix ?? 'rate_limit_trip';
+    const replayMaxWaitSeconds = spec.replay_max_wait_seconds ?? RATE_LIMIT_TRIP_DEFAULT_REPLAY_MAX_WAIT_SECONDS;
+    const baseRequest = cloneRequest(spec.trip_target_sample_request);
+    const baseBody: RateLimitTripStructuredResult = {
+      attempts: 0,
+      target_task: spec.trip_target_task,
+      target_transport: opts.transport ?? this.defaults.transport,
+    };
+
+    let trip:
+      | {
+          attempt: number;
+          idempotencyKey: string;
+          response: TaskResult;
+          error: AdcpErrorInfo;
+        }
+      | undefined;
+    let lastTripRequest: Record<string, unknown> | undefined;
+
+    for (let attempt = 1; attempt <= spec.max_attempts; attempt++) {
+      const idempotencyKey = keyMinter();
+      const request = withTripEnvelope(baseRequest, idempotencyKey, `${correlationPrefix}#trip-${attempt}`);
+      lastTripRequest = request;
+      let response: TaskResult;
+      try {
+        response = await executeStoryboardTask(this.client, spec.trip_target_task, request);
+      } catch (err) {
+        return transportFailureObservation(err, { ...baseBody, attempts: attempt, trip_request: request });
+      }
+      const error = extractTaskAdcpError(response, spec.trip_target_task);
+      if (error?.code === 'RATE_LIMITED') {
+        trip = { attempt, idempotencyKey, response, error };
+        break;
+      }
+      if (error) {
+        return {
+          status: 'failed',
+          error: 'rate_limit_trip_request_error',
+          message: `Target task returned ${error.code}: ${error.message}`,
+          body: {
+            ...baseBody,
+            attempts: attempt,
+            trip_request: request,
+            trip_response: snapshotTaskResult(response, spec.trip_target_task),
+          },
+        };
+      }
+    }
+
+    if (!trip) {
+      return {
+        status: 'not_applicable',
+        skip_reason: 'rate_limit_not_triggered',
+        message: `No RATE_LIMITED response observed within ${spec.max_attempts} attempt(s).`,
+        body: { ...baseBody, attempts: spec.max_attempts, ...(lastTripRequest && { trip_request: lastTripRequest }) },
+      };
+    }
+
+    const commonBody: RateLimitTripStructuredResult = {
+      ...baseBody,
+      attempts: trip.attempt,
+      trip_request: withTripEnvelope(baseRequest, trip.idempotencyKey, `${correlationPrefix}#trip-${trip.attempt}`),
+      rate_limited_request: {
+        task: spec.trip_target_task,
+        attempt: trip.attempt,
+        idempotency_key: trip.idempotencyKey,
+      },
+      trip_response: snapshotTaskResult(trip.response, spec.trip_target_task),
+    };
+
+    const retryAfterSeconds = readRetryAfterSeconds(trip.error);
+    if (retryAfterSeconds === undefined || retryAfterSeconds <= 0) {
+      return {
+        status: 'failed',
+        error: 'missing_retry_after',
+        message: 'RATE_LIMITED response did not include a positive retry_after value.',
+        body: commonBody,
+      };
+    }
+    if (retryAfterSeconds > replayMaxWaitSeconds) {
+      return {
+        status: 'failed',
+        error: 'replay_wait_exceeded',
+        message:
+          `RATE_LIMITED retry_after (${retryAfterSeconds}s) exceeds ` +
+          `rate_limit_trip.replay_max_wait_seconds (${replayMaxWaitSeconds}s).`,
+        body: commonBody,
+      };
+    }
+
+    await sleep(Math.max(1, Math.ceil(retryAfterSeconds * 1000)));
+    const replayRequest = withTripEnvelope(baseRequest, trip.idempotencyKey, `${correlationPrefix}#replay`);
+    let replayResponse: TaskResult;
+    try {
+      replayResponse = await executeStoryboardTask(this.client, spec.trip_target_task, replayRequest);
+    } catch (err) {
+      return transportFailureObservation(err, { ...commonBody, replay_request: replayRequest });
+    }
+
+    return {
+      status: 'completed',
+      body: {
+        ...commonBody,
+        replay_request: replayRequest,
+        replay_response: snapshotTaskResult(replayResponse, spec.trip_target_task),
+      },
+    };
+  }
+}
+
+function transportFailureObservation(
+  err: unknown,
+  body: RateLimitTripStructuredResult
+): Extract<RateLimitTripObservation, { status: 'failed' }> {
+  const message = err instanceof Error ? err.message : String(err);
+  const error =
+    err instanceof ADCPError && !isTransportAdcpError(err)
+      ? 'rate_limit_trip_request_error'
+      : 'rate_limit_trip_transport_error';
+  return {
+    status: 'failed',
+    error,
+    message,
+    body,
+  };
+}
+
+function isTransportAdcpError(err: ADCPError): boolean {
+  return err instanceof ProtocolError || err instanceof ResponseTooLargeError || err instanceof TaskTimeoutError;
+}
+
+function defaultKeyMinter(): string {
+  return randomUUID();
+}
+
+function cloneRequest(request: Record<string, unknown>): Record<string, unknown> {
+  if (typeof globalThis.structuredClone === 'function') {
+    return globalThis.structuredClone(request);
+  }
+  return JSON.parse(JSON.stringify(request)) as Record<string, unknown>;
+}
+
+function withTripEnvelope(
+  baseRequest: Record<string, unknown>,
+  idempotencyKey: string,
+  correlationId: string
+): Record<string, unknown> {
+  const request = cloneRequest(baseRequest);
+  request.idempotency_key = idempotencyKey;
+  const existingContext = request.context;
+  if (existingContext && typeof existingContext === 'object' && !Array.isArray(existingContext)) {
+    request.context = { ...(existingContext as Record<string, unknown>), correlation_id: correlationId };
+  } else if (existingContext === undefined) {
+    request.context = { correlation_id: correlationId };
+  }
+  return request;
+}
+
+export function extractTaskAdcpError(taskResult: TaskResult, taskName?: string): AdcpErrorInfo | undefined {
+  if (taskResult.adcp_error) return taskResult.adcp_error;
+  const data = taskResult.data as Record<string, unknown> | undefined;
+  if (Array.isArray(data?.errors)) {
+    if (taskResult.success !== false && taskName && !isTerminalAdcpError(data, taskName)) {
+      return undefined;
+    }
+    const first = data.errors[0];
+    if (first && typeof first === 'object' && typeof (first as Record<string, unknown>).code === 'string') {
+      return buildAdcpErrorInfo(first as Record<string, unknown>);
+    }
+  }
+  const extracted = extractAdcpErrorInfo(data);
+  if (extracted) return extracted;
+  const dataError = data?.error;
+  if (dataError && typeof dataError === 'object' && typeof (dataError as Record<string, unknown>).code === 'string') {
+    return buildAdcpErrorInfo(dataError as Record<string, unknown>);
+  }
+  return undefined;
+}
+
+function buildAdcpErrorInfo(obj: Record<string, unknown>): AdcpErrorInfo {
+  const code = String(obj.code);
+  const message = typeof obj.message === 'string' ? obj.message : code;
+  const info: AdcpErrorInfo = { code, message };
+  if (obj.recovery === 'transient' || obj.recovery === 'correctable' || obj.recovery === 'terminal') {
+    info.recovery = obj.recovery;
+  }
+  if (typeof obj.field === 'string') info.field = obj.field;
+  if (typeof obj.suggestion === 'string') info.suggestion = obj.suggestion;
+  if (typeof obj.retry_after === 'number' && Number.isFinite(obj.retry_after)) info.retry_after = obj.retry_after;
+  if (obj.details && typeof obj.details === 'object') info.details = obj.details as Record<string, unknown>;
+  return info;
+}
+
+function readRetryAfterSeconds(error: AdcpErrorInfo): number | undefined {
+  if (typeof error.retry_after === 'number' && Number.isFinite(error.retry_after)) return error.retry_after;
+  const detailsRetry = error.details?.retry_after;
+  if (typeof detailsRetry === 'number' && Number.isFinite(detailsRetry)) return detailsRetry;
+  return undefined;
+}
+
+function snapshotTaskResult(taskResult: TaskResult, taskName?: string): RateLimitTripResponseSnapshot {
+  const adcpError = extractTaskAdcpError(taskResult, taskName);
+  return {
+    success: taskResult.success,
+    ...(taskResult.data !== undefined && { data: taskResult.data }),
+    ...(adcpError && {
+      error: {
+        code: adcpError.code,
+        message: adcpError.message,
+        ...(adcpError.recovery && { recovery: adcpError.recovery }),
+        ...(adcpError.field && { field: adcpError.field }),
+        ...(adcpError.suggestion && { suggestion: adcpError.suggestion }),
+        ...(adcpError.retry_after !== undefined && { retry_after: adcpError.retry_after }),
+        ...(adcpError.details && { details: adcpError.details }),
+      },
+      adcp_error: adcpError,
+    }),
+    ...(taskResult.error && { error_message: taskResult.error }),
+  };
+}

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -32,6 +32,7 @@ import {
 } from './validations';
 import { PARALLEL_DISPATCH_CONTRACT, runParallelDispatches, validateParallelDispatchSpec } from './parallel-dispatch';
 import { resolvePath, resolvePortableIdentifierPathAll, toJsonPointer, validatePortableIdentifierPath } from './path';
+import { RateLimitTripObserver, validateRateLimitTripSpec, type RateLimitTripObservation } from './rate-limit-trip';
 import { redactSecrets } from '../../utils/redact-secrets';
 import { ResponseSchemaValidationError } from '../../utils/response-unwrapper';
 import { injectLegacyEnvelopeStatus, normalizeLegacyMediaBuyStatusForReturn } from '../../utils/envelope-status-compat';
@@ -107,6 +108,7 @@ import type {
   StrictValidationSummary,
   SchemaValidationError,
   ValidationResult,
+  RunnerTransport,
 } from './types';
 import {
   buildRoutingContext,
@@ -216,6 +218,7 @@ const DETAILED_SKIP_DETAILS: Partial<Record<RunnerDetailedSkipReason, string>> =
   rate_abuse_opt_out: 'Rate-abuse vector was excluded by request_signing.skipRateAbuse.',
   capability_profile_mismatch: 'Vector is outside the agent capability profile selected for this run.',
   transport_ungradable: 'Vector cannot be graded faithfully by the selected transport.',
+  rate_limit_not_triggered: 'No RATE_LIMITED response was observed within the configured max_attempts.',
 };
 
 function selectionForProbeSkip(reason: RunnerDetailedSkipReason, detail: string): RunnerSelectionResult | undefined {
@@ -3369,7 +3372,7 @@ async function executeStep(
 
   // HTTP probe tasks bypass the MCP client entirely.
   if (PROBE_TASKS.has(step.task)) {
-    return executeProbeStep(step, phaseId, context, allSteps, options, runState);
+    return executeProbeStep(client, step, phaseId, context, allSteps, options, runState);
   }
 
   // Webhook-assertion pseudo-tasks observe the shared receiver instead of
@@ -4377,6 +4380,8 @@ async function executeStep(
 // ────────────────────────────────────────────────────────────
 
 async function executeProbeStep(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- client type varies (TestClient)
+  client: any,
   step: StoryboardStep,
   phaseId: string,
   context: StoryboardContext,
@@ -4387,6 +4392,7 @@ async function executeProbeStep(
   const start = Date.now();
   let httpResult: HttpProbeResult | undefined;
   const probeOpts = { allowPrivateIp: options.allow_http === true };
+  let requestRecordOverride: RunnerRequestRecord | undefined;
 
   if (step.requires_contract) {
     const contracts = new Set(options.contracts ?? []);
@@ -4432,33 +4438,114 @@ async function executeProbeStep(
   } else if (step.task === 'assert_jwks_purpose') {
     httpResult = assertJwksPurpose(runState.priorProbes.get('fetch_brand_jwks'), 'webhook-signing');
   } else if (step.task === 'expect_rate_limit_not_replayed') {
-    httpResult = {
-      url: runState.agentUrl,
-      status: 0,
-      headers: {},
-      body: null,
-      error:
-        'rate_limit_trip_runner contract is configured, but this SDK runner does not yet implement live rate-limit trip/replay probing.',
-    };
+    const specError = validateRateLimitTripSpec(step.rate_limit_trip);
+    if (specError) {
+      httpResult = {
+        url: runState.agentUrl,
+        status: 0,
+        headers: {},
+        body: { attempts: 0, error: 'rate_limit_trip_misconfigured' },
+        error: specError,
+      };
+    } else {
+      const rateLimitTrip = step.rate_limit_trip!;
+      const targetStep: StoryboardStep = {
+        ...step,
+        task: rateLimitTrip.trip_target_task,
+        sample_request: rateLimitTrip.trip_target_sample_request,
+        omit_idempotency_key: true,
+      };
+      const resolvedTargetRequest = buildEffectiveStepRequest(targetStep, context, options, runState);
+      const unresolvedVars = findUnresolvedContextVars(resolvedTargetRequest);
+      if (unresolvedVars.length > 0 && !targetStep.expect_error) {
+        const next = getNextStepPreview(step.id, allSteps, context, runState.runnerVars);
+        const detail = `Skipped: unresolved context variables from rate_limit_trip.trip_target_sample_request: ${unresolvedVars
+          .map(v => v.key)
+          .join(', ')}.`;
+        return {
+          step_id: step.id,
+          phase_id: phaseId,
+          title: step.title,
+          task: step.task,
+          passed: false,
+          skipped: true,
+          skip_reason: 'prerequisite_failed',
+          skip: buildSkip('prerequisite_failed', detail),
+          duration_ms: Date.now() - start,
+          validations: [],
+          context,
+          next,
+          extraction: { path: 'none' },
+          error: detail,
+        };
+      }
+      const advertisedTools = resolveAdvertisedTools(options);
+      if (advertisedTools && !advertisedTools.includes(rateLimitTrip.trip_target_task)) {
+        const next = getNextStepPreview(step.id, allSteps, context, runState.runnerVars);
+        const detail = `Agent did not advertise tool "${rateLimitTrip.trip_target_task}"; agent tools: [${advertisedTools.join(', ')}].`;
+        return {
+          step_id: step.id,
+          phase_id: phaseId,
+          title: step.title,
+          task: step.task,
+          passed: true,
+          skipped: true,
+          skip_reason: 'missing_tool',
+          skip: buildSkip('missing_tool', detail),
+          duration_ms: Date.now() - start,
+          validations: [],
+          context,
+          next,
+          extraction: { path: 'none' },
+        };
+      }
+      const resolvedSpec = {
+        ...rateLimitTrip,
+        trip_target_sample_request: resolvedTargetRequest,
+      };
+      const targetTransport: Extract<RunnerTransport, 'mcp' | 'a2a'> = options.protocol === 'a2a' ? 'a2a' : 'mcp';
+      const observer = new RateLimitTripObserver(client, {
+        keyMinter: generateIdempotencyKey,
+        correlationPrefix: step.id,
+        transport: targetTransport,
+      });
+      const observation = await observer.run(resolvedSpec);
+      httpResult = rateLimitTripObservationToProbeResult(runState.agentUrl, observation);
+      const observedRequest = observation.body.replay_request ?? observation.body.trip_request ?? resolvedTargetRequest;
+      requestRecordOverride = {
+        transport: targetTransport,
+        operation: rateLimitTrip.trip_target_task,
+        payload: redactSecrets(observedRequest),
+        ...(runState.agentUrl ? { url: runState.agentUrl } : {}),
+      };
+    }
   }
 
   if (httpResult) runState.priorProbes.set(step.task, httpResult);
 
   const duration = Date.now() - start;
-  const requestRecord: RunnerRequestRecord = {
+  const requestRecord: RunnerRequestRecord = requestRecordOverride ?? {
     transport: 'http',
     operation: step.task,
     payload: null,
     ...(httpResult?.url ? { url: httpResult.url } : runState.agentUrl ? { url: runState.agentUrl } : {}),
   };
   const filteredProbeHeaders = filterResponseHeaders(httpResult?.headers);
+  const responseTransport = requestRecordOverride?.transport ?? 'http';
   const responseRecord: RunnerResponseRecord | undefined = httpResult
     ? {
-        transport: 'http',
+        transport: responseTransport,
         payload: redactSecrets(httpResult.body),
-        status: httpResult.status,
+        ...(responseTransport === 'http' && { status: httpResult.status }),
         ...(filteredProbeHeaders && { headers: filteredProbeHeaders }),
         duration_ms: duration,
+      }
+    : undefined;
+  const redactedHttpResult = httpResult
+    ? {
+        ...httpResult,
+        body: redactSecrets(httpResult.body),
+        ...(responseTransport !== 'http' && { status: undefined }),
       }
     : undefined;
 
@@ -4483,7 +4570,7 @@ async function executeProbeStep(
       skip: { reason: canonicalReason, detail },
       ...(selectionResult && { selection_result: selectionResult }),
       duration_ms: duration,
-      response: httpResult,
+      response: redactedHttpResult,
       validations: [],
       context,
       next: getNextStepPreview(step.id, allSteps, context, runState.runnerVars),
@@ -4497,7 +4584,7 @@ async function executeProbeStep(
     taskName: step.task,
     ...(options.adcpVersion && { adcpVersion: options.adcpVersion }),
     ...(options._serverAdcpVersion && { responseAdcpVersion: options._serverAdcpVersion }),
-    httpResult,
+    httpResult: redactedHttpResult,
     agentUrl: runState.agentUrl,
     contributions: runState.contributions,
     request: requestRecord,
@@ -4526,7 +4613,7 @@ async function executeProbeStep(
     task: step.task,
     passed,
     duration_ms: duration,
-    response: httpResult ?? undefined,
+    response: redactedHttpResult ?? undefined,
     validations,
     context,
     error: httpResult?.error ?? (passed ? undefined : 'Probe validations failed.'),
@@ -4534,6 +4621,70 @@ async function executeProbeStep(
     request: requestRecord,
     ...(responseRecord && { response_record: responseRecord }),
     extraction,
+  };
+}
+
+function buildEffectiveStepRequest(
+  step: StoryboardStep,
+  context: StoryboardContext,
+  options: StoryboardRunOptions,
+  runState: ExecutionState
+): Record<string, unknown> {
+  let request: Record<string, unknown>;
+  if (options.request) {
+    request = { ...options.request };
+  } else if (step.expect_error && step.sample_request) {
+    request = injectContext({ ...step.sample_request }, context, runState.runnerVars);
+  } else if (hasRequestEnricher(step.task)) {
+    request = enrichRequest(step, context, options, runState.runnerVars);
+  } else if (step.sample_request) {
+    request = injectContext({ ...step.sample_request }, context, runState.runnerVars);
+  } else {
+    request = {};
+  }
+  if (step.context_inputs?.length) {
+    request = applyContextInputs(request, step.context_inputs, context);
+  }
+  request = applyBrandInvariant(request, options, step.task, { omit_account: step.omit_account });
+  if (options.disable_sandbox === true) {
+    request = applyDisableSandboxHint(request, step.task);
+  }
+  return applyIdempotencyInvariant(request, step.task, step);
+}
+
+function resolveAdvertisedTools(options: StoryboardRunOptions): string[] | undefined {
+  return options.agentTools ?? normalizeAgentToolNames(options._profile?.tools);
+}
+
+function rateLimitTripObservationToProbeResult(
+  agentUrl: string,
+  observation: RateLimitTripObservation
+): HttpProbeResult {
+  if (observation.status === 'not_applicable') {
+    return {
+      url: agentUrl,
+      status: 0,
+      headers: {},
+      body: observation.body,
+      skipped: true,
+      skip_reason: observation.skip_reason,
+      error: observation.message,
+    };
+  }
+  if (observation.status === 'failed') {
+    return {
+      url: agentUrl,
+      status: 0,
+      headers: {},
+      body: { ...observation.body, error: observation.error },
+      error: observation.message,
+    };
+  }
+  return {
+    url: agentUrl,
+    status: 200,
+    headers: {},
+    body: observation.body,
   };
 }
 

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -658,6 +658,29 @@ export interface StoryboardStep {
    * {@link ParallelDispatchSpec}.
    */
   parallel_dispatch?: ParallelDispatchSpec;
+  /**
+   * Sequential rate-limit trip/replay probe config. When set on
+   * `expect_rate_limit_not_replayed`, the runner sends fresh-key requests
+   * until the seller returns `RATE_LIMITED`, waits the response
+   * `retry_after`, then replays the same idempotency key to assert the
+   * transient rate-limit response was not cached as the canonical replay.
+   * Requires the `rate_limit_trip_runner` test-kit contract.
+   */
+  rate_limit_trip?: RateLimitTripSpec;
+}
+
+/**
+ * Contract payload for `test-kits/rate-limit-trip-runner.yaml`.
+ */
+export interface RateLimitTripSpec {
+  /** Mutating AdCP task to burst, e.g. `create_media_buy`. */
+  trip_target_task: string;
+  /** Base request payload; the observer rewrites only idempotency_key and correlation_id. */
+  trip_target_sample_request: Record<string, unknown>;
+  /** Sequential fresh-key attempts before grading the probe `rate_limit_not_triggered`; must be in [50, 500]. */
+  max_attempts: number;
+  /** Maximum retry_after wait the runner will honor. Defaults to 30 seconds. */
+  replay_max_wait_seconds?: number;
 }
 
 export type StoryboardValidationCheck =
@@ -765,6 +788,8 @@ export type StoryboardValidationCheck =
    * "upstream_traffic".
    */
   | 'upstream_traffic'
+  /** Contract check for `rate_limit_trip_runner`: RATE_LIMITED must not replay from the idempotency cache. */
+  | 'replay_not_cached_rate_limit'
   /**
    * Cross-response: every resolved response from a `parallel_dispatch` step
    * carries the same value at the named `path`. Used to assert
@@ -1586,6 +1611,8 @@ export type RunnerDetailedSkipReason =
   | 'mcp_mode_flattens_url_edges'
   /** RFC 9728 protected-resource metadata returned 404 → agent is not advertising OAuth, cascade-skip oauth_discovery (#677). */
   | 'oauth_not_advertised'
+  /** rate_limit_trip_runner did not observe RATE_LIMITED within max_attempts. */
+  | 'rate_limit_not_triggered'
   /**
    * Pre-flight `comply_test_controller` seeding failed (adcp-client#778), so
    * every real phase cascade-skipped rather than run against an unseeded
@@ -1632,6 +1659,7 @@ export const DETAILED_SKIP_TO_CANONICAL: Record<RunnerDetailedSkipReason, Runner
   transport_ungradable: 'not_applicable',
   mcp_mode_flattens_url_edges: 'not_applicable',
   oauth_not_advertised: 'not_applicable',
+  rate_limit_not_triggered: 'not_applicable',
   force_scenario_unsupported: 'not_applicable',
   capability_unsupported: 'unsatisfied_contract',
   rate_abuse_opt_out: 'unsatisfied_contract',

--- a/src/lib/testing/storyboard/validations.ts
+++ b/src/lib/testing/storyboard/validations.ts
@@ -41,6 +41,7 @@ import {
 } from './path';
 import { detectShapeDriftHints } from './shape-drift-hints';
 import { PROBE_TASK_ALLOWLIST } from './test-kit';
+import { extractTaskAdcpError } from './rate-limit-trip';
 
 /**
  * Broader validation context that carries the run-level state a single
@@ -298,6 +299,8 @@ function runValidation(validation: StoryboardValidation, ctx: ValidationContext)
       return validateFieldEqualsContext(validation, ctx);
     case 'upstream_traffic':
       return validateUpstreamTraffic(validation, ctx);
+    case 'replay_not_cached_rate_limit':
+      return validateReplayNotCachedRateLimit(validation, ctx);
     case 'cross_response_field_equal':
       return validateCrossResponseFieldEqual(validation, ctx);
     case 'cross_response_count_distinct':
@@ -3205,6 +3208,81 @@ function validateCrossResponseFieldEqual(validation: StoryboardValidation, ctx: 
     schema_id: null,
     schema_url: null,
   };
+}
+
+function validateReplayNotCachedRateLimit(validation: StoryboardValidation, ctx: ValidationContext): ValidationResult {
+  const payload = resolveTarget(ctx).data as Record<string, unknown> | undefined;
+  const tripResponse = payload?.trip_response;
+  const replayResponse = payload?.replay_response;
+  const targetTask = typeof payload?.target_task === 'string' ? payload.target_task : undefined;
+  if (!tripResponse || typeof tripResponse !== 'object' || !replayResponse || typeof replayResponse !== 'object') {
+    const missing = [
+      !tripResponse || typeof tripResponse !== 'object' ? 'trip_response' : undefined,
+      !replayResponse || typeof replayResponse !== 'object' ? 'replay_response' : undefined,
+    ].filter((field): field is string => typeof field === 'string');
+    return {
+      check: validation.check,
+      passed: true,
+      not_applicable: true,
+      description: validation.description,
+      note: `step did not produce rate_limit_trip_runner ${missing.join(' and ')}; replay_not_cached_rate_limit grades not_applicable`,
+      json_pointer: null,
+    };
+  }
+
+  const tripCode = extractSnapshotErrorCode(tripResponse as Record<string, unknown>, targetTask);
+  const replayCode = extractSnapshotErrorCode(replayResponse as Record<string, unknown>, targetTask);
+  if (tripCode !== 'RATE_LIMITED') {
+    return {
+      check: validation.check,
+      passed: false,
+      description: validation.description,
+      json_pointer: '/trip_response/error/code',
+      expected: 'RATE_LIMITED trip_response error code',
+      actual: tripCode ?? null,
+      schema_id: null,
+      schema_url: null,
+    };
+  }
+  if (replayCode === 'RATE_LIMITED') {
+    return {
+      check: validation.check,
+      passed: false,
+      description: validation.description,
+      error: 'rate_limit_response_cached_as_replay',
+      json_pointer: '/replay_response/error/code',
+      expected: 'replay_response must not return RATE_LIMITED from the idempotency cache',
+      actual: replayCode,
+      schema_id: null,
+      schema_url: null,
+    };
+  }
+  return {
+    check: validation.check,
+    passed: true,
+    description: validation.description,
+    json_pointer: '/replay_response/error/code',
+    actual: replayCode ?? null,
+  };
+}
+
+function extractSnapshotErrorCode(snapshot: Record<string, unknown>, taskName?: string): string | undefined {
+  const structuredError = snapshot.error;
+  if (structuredError && typeof structuredError === 'object') {
+    const code = (structuredError as Record<string, unknown>).code;
+    if (typeof code === 'string') return code;
+  }
+  const adcpError = snapshot.adcp_error;
+  if (adcpError && typeof adcpError === 'object') {
+    const code = (adcpError as Record<string, unknown>).code;
+    if (typeof code === 'string') return code;
+  }
+  const data = snapshot.data;
+  if (data && typeof data === 'object') {
+    const extracted = extractTaskAdcpError({ success: snapshot.success === true, data }, taskName);
+    if (extracted) return extracted.code;
+  }
+  return undefined;
 }
 
 /**

--- a/test/lib/storyboard-rate-limit-trip.test.js
+++ b/test/lib/storyboard-rate-limit-trip.test.js
@@ -1,0 +1,518 @@
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { runStoryboardStep } = require('../../dist/lib/testing/storyboard/runner');
+const { ResponseTooLargeError, ValidationError } = require('../../dist/lib/errors');
+const rootExports = require('../../dist/lib/index');
+const testingExports = require('../../dist/lib/testing/index');
+const {
+  RateLimitTripObserver,
+  validateRateLimitTripSpec,
+} = require('../../dist/lib/testing/storyboard/rate-limit-trip');
+
+function rateLimited(retryAfter = 0.001) {
+  return {
+    success: false,
+    data: {
+      adcp_error: {
+        code: 'RATE_LIMITED',
+        message: 'slow down',
+        retry_after: retryAfter,
+      },
+    },
+    error: 'RATE_LIMITED: slow down',
+  };
+}
+
+function makeStoryboard(overrides = {}) {
+  return {
+    id: 'rate_limit_trip_storyboard',
+    version: '1.0.0',
+    title: 'Rate limit trip replay',
+    category: 'test',
+    summary: '',
+    narrative: '',
+    agent: { interaction_model: '*', capabilities: [] },
+    caller: { role: 'buyer_agent' },
+    phases: [
+      {
+        id: 'p1',
+        title: 'phase 1',
+        steps: [
+          {
+            id: 'trip',
+            title: 'rate limit replay is not cached',
+            task: 'expect_rate_limit_not_replayed',
+            requires_contract: 'rate_limit_trip_runner',
+            rate_limit_trip: {
+              trip_target_task: 'create_media_buy',
+              trip_target_sample_request: {
+                buyer_ref: 'buyer-rate-limit-test',
+                packages: [{ product_id: 'prod_1', budget: 1000 }],
+              },
+              max_attempts: 50,
+              replay_max_wait_seconds: 1,
+              ...overrides.rate_limit_trip,
+            },
+            validations: [
+              {
+                check: 'replay_not_cached_rate_limit',
+                description: 'RATE_LIMITED is not cached as the idempotent replay response',
+              },
+            ],
+            ...overrides.step,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function runTripStep(client, storyboard = makeStoryboard(), options = {}) {
+  return runStoryboardStep('https://stub.example/mcp', storyboard, 'trip', {
+    protocol: 'mcp',
+    _client: client,
+    _profile: { name: 'stub', tools: ['create_media_buy'] },
+    contracts: ['rate_limit_trip_runner'],
+    ...options,
+  });
+}
+
+describe('RateLimitTripObserver', () => {
+  test('public root and testing entrypoints export the observer surface', () => {
+    assert.equal(rootExports.RateLimitTripObserver, RateLimitTripObserver);
+    assert.equal(testingExports.RateLimitTripObserver, RateLimitTripObserver);
+    assert.equal(rootExports.RATE_LIMIT_TRIP_CONTRACT, 'rate_limit_trip_runner');
+    assert.equal(testingExports.RATE_LIMIT_TRIP_MAX_ATTEMPTS_MIN, 50);
+  });
+
+  test('validates the contract max_attempts bounds', () => {
+    const error = validateRateLimitTripSpec({
+      trip_target_task: 'create_media_buy',
+      trip_target_sample_request: {},
+      max_attempts: 49,
+    });
+    assert.match(error, /max_attempts must be in \[50, 500\]/);
+  });
+
+  test('runs trip plus clean replay on the public primitive', async () => {
+    const calls = [];
+    const client = {
+      executeTask: async (_taskName, params) => {
+        calls.push(params);
+        if (calls.length === 2) return rateLimited();
+        return { success: true, data: { media_buy_id: `mb_${calls.length}` } };
+      },
+    };
+    const observer = new RateLimitTripObserver(client, {
+      keyMinter: () => `key_${calls.length + 1}`,
+      sleep: async () => {},
+      correlationPrefix: 'direct',
+    });
+
+    const result = await observer.run({
+      trip_target_task: 'create_media_buy',
+      trip_target_sample_request: { buyer_ref: 'buyer_1' },
+      max_attempts: 50,
+      replay_max_wait_seconds: 1,
+    });
+
+    assert.equal(result.status, 'completed');
+    assert.equal(result.body.rate_limited_request.idempotency_key, 'key_2');
+    assert.equal(result.body.trip_response.error.code, 'RATE_LIMITED');
+    assert.equal(result.body.replay_response.success, true);
+    assert.equal(calls[1].idempotency_key, calls[2].idempotency_key);
+    assert.notEqual(calls[0].idempotency_key, calls[1].idempotency_key);
+    assert.equal(calls[2].context.correlation_id, 'direct#replay');
+  });
+
+  test('honors retry_after from errors[0].details on legacy envelopes', async () => {
+    let calls = 0;
+    const client = {
+      executeTask: async () => {
+        calls++;
+        if (calls === 1) {
+          return {
+            success: false,
+            data: {
+              errors: [{ code: 'RATE_LIMITED', message: 'slow down', details: { retry_after: 0.001 } }],
+            },
+          };
+        }
+        return { success: true, data: { media_buy_id: 'mb_replay' } };
+      },
+    };
+    const observer = new RateLimitTripObserver(client, {
+      keyMinter: () => 'trip_key',
+      sleep: async () => {},
+    });
+
+    const result = await observer.run({
+      trip_target_task: 'create_media_buy',
+      trip_target_sample_request: { buyer_ref: 'buyer_1' },
+      max_attempts: 50,
+      replay_max_wait_seconds: 1,
+    });
+
+    assert.equal(result.status, 'completed');
+    assert.equal(result.body.trip_response.error.details.retry_after, 0.001);
+    assert.equal(result.body.replay_response.success, true);
+  });
+
+  test('fails fast when target returns a structured non-rate-limit AdCP error', async () => {
+    let calls = 0;
+    const client = {
+      executeTask: async () => {
+        calls++;
+        return {
+          success: false,
+          data: {
+            adcp_error: {
+              code: 'VALIDATION_ERROR',
+              message: 'packages[0].product_id is required',
+            },
+          },
+          error: 'VALIDATION_ERROR: packages[0].product_id is required',
+        };
+      },
+    };
+    const observer = new RateLimitTripObserver(client, {
+      keyMinter: () => `key_${calls + 1}`,
+      sleep: async () => {},
+    });
+
+    const result = await observer.run({
+      trip_target_task: 'create_media_buy',
+      trip_target_sample_request: { buyer_ref: 'buyer_1' },
+      max_attempts: 50,
+      replay_max_wait_seconds: 1,
+    });
+
+    assert.equal(result.status, 'failed');
+    assert.equal(result.error, 'rate_limit_trip_request_error');
+    assert.equal(result.body.attempts, 1);
+    assert.equal(result.body.trip_response.error.code, 'VALIDATION_ERROR');
+    assert.equal(calls, 1);
+  });
+
+  test('ignores advisory errors on submitted task payloads', async () => {
+    let calls = 0;
+    const client = {
+      executeTask: async () => {
+        calls++;
+        if (calls === 1) {
+          return {
+            success: true,
+            data: {
+              status: 'submitted',
+              task_id: 'task-advisory',
+              errors: [{ code: 'GOVERNANCE_OBSERVATION', message: 'queued with advisory' }],
+            },
+          };
+        }
+        if (calls === 2) return rateLimited();
+        return { success: true, data: { media_buy_id: 'mb_replay' } };
+      },
+    };
+    const observer = new RateLimitTripObserver(client, {
+      keyMinter: () => `key_${calls + 1}`,
+      sleep: async () => {},
+    });
+
+    const result = await observer.run({
+      trip_target_task: 'create_media_buy',
+      trip_target_sample_request: { buyer_ref: 'buyer_1' },
+      max_attempts: 50,
+      replay_max_wait_seconds: 1,
+    });
+
+    assert.equal(result.status, 'completed');
+    assert.equal(result.body.attempts, 2);
+    assert.equal(result.body.trip_response.error.code, 'RATE_LIMITED');
+    assert.equal(calls, 3);
+  });
+});
+
+describe('storyboard rate_limit_trip_runner wiring', () => {
+  test('trip plus clean replay passes replay_not_cached_rate_limit', async () => {
+    const calls = [];
+    const client = {
+      executeTask: async (_taskName, params) => {
+        calls.push(params);
+        if (calls.length === 2) return rateLimited();
+        return { success: true, data: { media_buy_id: `mb_${calls.length}` } };
+      },
+    };
+
+    const result = await runTripStep(client);
+
+    assert.equal(result.passed, true);
+    assert.equal(result.validations[0].passed, true);
+    assert.equal(result.response.body.trip_response.error.code, 'RATE_LIMITED');
+    assert.equal(result.response.body.replay_response.success, true);
+    assert.equal(result.request.transport, 'mcp');
+    assert.equal(result.request.operation, 'create_media_buy');
+    assert.equal(result.request.payload.buyer_ref, 'buyer-rate-limit-test');
+    assert.deepEqual(result.request.payload, calls[2], 'request record reflects the actual replay dispatch');
+    assert.equal(result.response.status, undefined);
+    assert.equal(result.response_record.transport, 'mcp');
+    assert.equal(result.response_record.status, undefined);
+    assert.equal(result.response_record.payload.target_task, 'create_media_buy');
+    assert.equal(result.response_record.payload.target_transport, 'mcp');
+    assert.deepEqual(result.response_record.payload.trip_request, calls[1]);
+    assert.deepEqual(result.response_record.payload.replay_request, calls[2]);
+    assert.equal(calls.length, 3);
+    assert.equal(calls[1].idempotency_key, calls[2].idempotency_key);
+    assert.notEqual(calls[0].idempotency_key, calls[1].idempotency_key);
+    assert.equal(calls[1].context.correlation_id, 'trip#trip-2');
+    assert.equal(calls[2].context.correlation_id, 'trip#replay');
+  });
+
+  test('a2a run records target task transport without synthetic status', async () => {
+    const calls = [];
+    const client = {
+      executeTask: async (_taskName, params) => {
+        calls.push(params);
+        if (calls.length === 1) return rateLimited();
+        return { success: true, data: { media_buy_id: 'mb_replay' } };
+      },
+    };
+
+    const result = await runTripStep(client, makeStoryboard(), { protocol: 'a2a' });
+
+    assert.equal(result.passed, true);
+    assert.equal(result.request.transport, 'a2a');
+    assert.equal(result.request.operation, 'create_media_buy');
+    assert.deepEqual(result.request.payload, calls[1]);
+    assert.equal(result.response.status, undefined);
+    assert.equal(result.response_record.transport, 'a2a');
+    assert.equal(result.response_record.status, undefined);
+    assert.equal(result.response_record.payload.target_transport, 'a2a');
+    assert.deepEqual(result.response_record.payload.trip_request, calls[0]);
+    assert.deepEqual(result.response_record.payload.replay_request, calls[1]);
+  });
+
+  test('cached RATE_LIMITED replay fails replay_not_cached_rate_limit', async () => {
+    const calls = [];
+    const client = {
+      executeTask: async (_taskName, params) => {
+        calls.push(params);
+        return rateLimited();
+      },
+    };
+
+    const result = await runTripStep(client);
+
+    assert.equal(result.passed, false);
+    assert.equal(result.validations[0].passed, false);
+    assert.equal(result.validations[0].error, 'rate_limit_response_cached_as_replay');
+    assert.equal(result.validations[0].actual, 'RATE_LIMITED');
+    assert.equal(calls.length, 2);
+    assert.equal(calls[0].idempotency_key, calls[1].idempotency_key);
+  });
+
+  test('advisory RATE_LIMITED errors on submitted replay do not fail replay validation', async () => {
+    const calls = [];
+    const client = {
+      executeTask: async (_taskName, params) => {
+        calls.push(params);
+        if (calls.length === 1) return rateLimited();
+        return {
+          success: true,
+          data: {
+            status: 'submitted',
+            task_id: 'task-advisory-replay',
+            errors: [{ code: 'RATE_LIMITED', message: 'queued with advisory' }],
+          },
+        };
+      },
+    };
+
+    const result = await runTripStep(client);
+
+    assert.equal(result.passed, true);
+    assert.equal(result.validations[0].passed, true);
+    assert.equal(result.response_record.payload.replay_response.error, undefined);
+    assert.equal(calls.length, 2);
+  });
+
+  test('no RATE_LIMITED emits skip_reason rate_limit_not_triggered and skip.reason not_applicable', async () => {
+    const calls = [];
+    const client = {
+      executeTask: async (_taskName, params) => {
+        calls.push(params);
+        return { success: true, data: { media_buy_id: `mb_${calls.length}` } };
+      },
+    };
+
+    const result = await runTripStep(client);
+
+    assert.equal(result.passed, true);
+    assert.equal(result.skipped, true);
+    assert.equal(result.skip_reason, 'rate_limit_not_triggered');
+    assert.equal(result.skip.reason, 'not_applicable');
+    assert.equal(calls.length, 50);
+    assert.equal(new Set(calls.map(c => c.idempotency_key)).size, 50);
+    assert.deepEqual(result.request.payload, calls[49]);
+    assert.equal(result.response_record.payload.trip_request.context.correlation_id, 'trip#trip-50');
+  });
+
+  test('uses normal request enrichment for sentinel product and pricing ids', async () => {
+    const calls = [];
+    const client = {
+      executeTask: async (_taskName, params) => {
+        calls.push(params);
+        return rateLimited();
+      },
+    };
+    const storyboard = makeStoryboard({
+      rate_limit_trip: {
+        trip_target_sample_request: {
+          buyer_ref: 'buyer-rate-limit-test',
+          packages: [{ product_id: 'test-product', pricing_option_id: 'test-pricing', budget: 1000 }],
+        },
+      },
+    });
+
+    await runStoryboardStep('https://stub.example/mcp', storyboard, 'trip', {
+      protocol: 'mcp',
+      _client: client,
+      _profile: { name: 'stub', tools: ['create_media_buy'] },
+      contracts: ['rate_limit_trip_runner'],
+      context: {
+        products: [{ product_id: 'prod_real', pricing_options: [{ pricing_option_id: 'price_real' }] }],
+      },
+    });
+
+    assert.equal(calls[0].packages[0].product_id, 'prod_real');
+    assert.equal(calls[0].packages[0].pricing_option_id, 'price_real');
+  });
+
+  test('redacts secret-like fields from legacy response and response_record', async () => {
+    const client = {
+      executeTask: async () => ({
+        success: false,
+        data: {
+          adcp_error: {
+            code: 'RATE_LIMITED',
+            message: 'slow down',
+            retry_after: 0.001,
+            details: { access_token: 'secret-token' },
+          },
+          access_token: 'secret-token',
+        },
+      }),
+    };
+
+    const result = await runTripStep(client);
+
+    assert.equal(result.response.body.trip_response.data.access_token, '[redacted]');
+    assert.equal(result.response.body.trip_response.error.details.access_token, '[redacted]');
+    assert.equal(result.response_record.payload.trip_response.data.access_token, '[redacted]');
+  });
+
+  test('missing trip target tool uses standard missing_tool skip', async () => {
+    const client = {
+      executeTask: async () => {
+        throw new Error('should not dispatch');
+      },
+    };
+
+    const result = await runStoryboardStep('https://stub.example/mcp', makeStoryboard(), 'trip', {
+      protocol: 'mcp',
+      _client: client,
+      _profile: { name: 'stub', tools: ['get_products'] },
+      contracts: ['rate_limit_trip_runner'],
+    });
+
+    assert.equal(result.passed, true);
+    assert.equal(result.skipped, true);
+    assert.equal(result.skip_reason, 'missing_tool');
+    assert.equal(result.skip.reason, 'missing_tool');
+  });
+
+  test('transport throw returns a failed step instead of aborting the run', async () => {
+    const client = {
+      executeTask: async () => {
+        throw new Error('network down');
+      },
+    };
+
+    const result = await runTripStep(client);
+
+    assert.equal(result.passed, false);
+    assert.match(result.error, /network down/);
+    assert.equal(result.response.body.error, 'rate_limit_trip_transport_error');
+  });
+
+  test('request override feeds the rate-limit target request', async () => {
+    const calls = [];
+    const client = {
+      executeTask: async (_taskName, params) => {
+        calls.push(params);
+        return rateLimited();
+      },
+    };
+
+    const result = await runTripStep(client, makeStoryboard(), {
+      request: { buyer_ref: 'override-ref', packages: [{ product_id: 'override-prod', budget: 1234 }] },
+    });
+
+    assert.equal(result.passed, false);
+    assert.equal(calls[0].buyer_ref, 'override-ref');
+    assert.equal(calls[0].packages[0].product_id, 'override-prod');
+    assert.equal(result.response_record.payload.trip_request.buyer_ref, 'override-ref');
+  });
+
+  test('expect_error trip target preserves authored sample request without enrichment', async () => {
+    const calls = [];
+    const client = {
+      executeTask: async (_taskName, params) => {
+        calls.push(params);
+        if (calls.length === 1) return rateLimited();
+        return { success: true, data: { media_buy_id: 'mb_clean_replay' } };
+      },
+    };
+
+    const result = await runTripStep(
+      client,
+      makeStoryboard({
+        step: { expect_error: true },
+        rate_limit_trip: {
+          trip_target_sample_request: { buyer_ref: 'intentionally-invalid' },
+        },
+      })
+    );
+
+    assert.equal(result.passed, true);
+    assert.equal(calls[0].buyer_ref, 'intentionally-invalid');
+    assert.equal(calls[0].packages, undefined);
+    assert.equal(result.response_record.payload.trip_request.packages, undefined);
+  });
+
+  test('client-side validation throw is classified separately from transport errors', async () => {
+    const client = {
+      executeTask: async () => {
+        throw new ValidationError('packages[0].product_id', undefined, 'required');
+      },
+    };
+
+    const result = await runTripStep(client);
+
+    assert.equal(result.passed, false);
+    assert.equal(result.response.body.error, 'rate_limit_trip_request_error');
+  });
+
+  test('transport-side SDK ADCP errors remain transport errors', async () => {
+    const client = {
+      executeTask: async () => {
+        throw new ResponseTooLargeError(1024, 2048, 'https://stub.example/mcp');
+      },
+    };
+
+    const result = await runTripStep(client);
+
+    assert.equal(result.passed, false);
+    assert.equal(result.response.body.error, 'rate_limit_trip_transport_error');
+  });
+});


### PR DESCRIPTION
## Summary
- add public `RateLimitTripObserver` support for the AdCP 3.1 `rate_limit_trip_runner` contract
- wire `expect_rate_limit_not_replayed` through the storyboard runner with real A2A/MCP dispatches, request enrichment, tool skips, redacted output records, and non-HTTP status handling
- add `replay_not_cached_rate_limit` validation plus focused regression coverage for advisory errors, request overrides, error classification, and no-rate-limit skips

Fixes #1765.

## Validation
- `npm run build:lib`
- `npm run typecheck`
- `npm run format:check`
- `git diff --check`
- `node --test --test-timeout=60000 test/lib/storyboard-rate-limit-trip.test.js`
- `node --test --test-timeout=60000 test/lib/storyboard-validations.test.js`
- `node --test --test-timeout=60000 test/lib/storyboard-parallel-dispatch.test.js`

## Reviews
- DX review: clean
- JavaScript/protocol final review: no blockers or nits
- Code review final review: no blockers or nits