### PR TITLE
feat: surface response adcp_version metadata

### DIFF
--- a/.changeset/taskresult-adcp-version.md
+++ b/.changeset/taskresult-adcp-version.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': minor
+---
+
+Surface the seller-served, release-precision response `adcp_version` echo as `result.metadata.adcpVersion`.

--- a/docs/API_README.md
+++ b/docs/API_README.md
@@ -79,6 +79,7 @@ interface TaskResult<T> {
     clarificationRounds: number;
     status: TaskStatus;
     inputRequest?: InputRequest;  // Present when status === 'input-required'
+    adcpVersion?: string;         // Seller-served release-precision response adcp_version
   };
 }
 ```

--- a/docs/TYPE-SUMMARY.md
+++ b/docs/TYPE-SUMMARY.md
@@ -34,6 +34,7 @@ interface TaskResult<T = any> {
     responseTimeMs: number;
     timestamp: string;
     clarificationRounds: number;
+    adcpVersion?: string;        // Seller-served release-precision response adcp_version
   };
   conversation?: Message[];
 }

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1385,7 +1385,7 @@ See docs/TYPE-SUMMARY.md for field-level detail. Key types at a glance:
 | Type | Purpose |
 |------|---------|
 | `AgentConfig` | Agent connection config (uri, protocol, auth) |
-| `TaskResult<T>` | Return type of every tool call (status + data/error/adcpError/correlationId/deferred/submitted) |
+| `TaskResult<T>` | Return type of every tool call (status + data/error/adcpError/correlationId/deferred/submitted; metadata includes seller-served `adcpVersion`) |
 | `InputHandler` | Callback for agent clarification requests |
 | `ConversationContext` | Passed to InputHandler with messages, question, helpers |
 | `Product` | Advertising inventory item with formats, pricing, targeting |

--- a/scripts/generate-agent-docs.ts
+++ b/scripts/generate-agent-docs.ts
@@ -1021,7 +1021,7 @@ function generateLlmsTxt(
   ln(`|------|---------|`);
   ln(`| \`AgentConfig\` | Agent connection config (uri, protocol, auth) |`);
   ln(
-    `| \`TaskResult<T>\` | Return type of every tool call (status + data/error/adcpError/correlationId/deferred/submitted) |`
+    `| \`TaskResult<T>\` | Return type of every tool call (status + data/error/adcpError/correlationId/deferred/submitted; metadata includes seller-served \`adcpVersion\`) |`
   );
   ln(`| \`InputHandler\` | Callback for agent clarification requests |`);
   ln(`| \`ConversationContext\` | Passed to InputHandler with messages, question, helpers |`);
@@ -1170,6 +1170,7 @@ function generateTypeSummary(index: SchemaIndex, tools: ToolInfo[]): string {
   ln(`    responseTimeMs: number;`);
   ln(`    timestamp: string;`);
   ln(`    clarificationRounds: number;`);
+  ln(`    adcpVersion?: string;        // Seller-served release-precision response adcp_version`);
   ln(`  };`);
   ln(`  conversation?: Message[];`);
   ln(`}`);

--- a/src/lib/core/ConversationTypes.ts
+++ b/src/lib/core/ConversationTypes.ts
@@ -404,6 +404,13 @@ export interface TaskResultMetadata {
    * acting, or retries will re-fire side effects.
    */
   replayed?: boolean;
+  /**
+   * Seller-served, release-precision AdCP version echoed on the response
+   * envelope. Present when the seller emits `adcp_version` (3.1+). Compare
+   * with the request's wire-normalized version, not a raw full-semver
+   * configuration pin, when detecting same-major downshift.
+   */
+  adcpVersion?: string;
 }
 
 /** Fields shared across all TaskResult variants. */

--- a/src/lib/core/ProtocolResponseParser.ts
+++ b/src/lib/core/ProtocolResponseParser.ts
@@ -51,6 +51,7 @@ const TASK_ENVELOPE_FIELDS: ReadonlySet<string> = new Set([
   'context',
   'ext',
 ]);
+const NESTED_TASK_ENVELOPE_FIELDS: ReadonlySet<string> = new Set([...TASK_ENVELOPE_FIELDS, 'taskId', 'adcp_error']);
 
 /**
  * ADCP task-lifecycle statuses that never overlap with AdCP domain status
@@ -156,6 +157,78 @@ function extractAdcpTaskIdFromA2aTaskResult(result: any): string | undefined {
 function firstSafeSessionId(...candidates: unknown[]): string | undefined {
   for (const c of candidates) {
     if (isSafeSessionId(c)) return c;
+  }
+  return undefined;
+}
+
+function getAdcpVersionFromPayload(payload: unknown): string | undefined {
+  if (payload == null || typeof payload !== 'object' || Array.isArray(payload)) return undefined;
+  const record = payload as Record<string, unknown>;
+  if (typeof record.adcp_version === 'string') return record.adcp_version;
+
+  const nested = record.response;
+  if (nested != null && typeof nested === 'object' && !Array.isArray(nested)) {
+    const envelope = nested as Record<string, unknown>;
+    const status = typeof envelope.status === 'string' ? envelope.status : undefined;
+    const isAdcpStatus = status !== undefined && (Object.values(ADCP_STATUS) as string[]).includes(status);
+    const hasOnlyEnvelopeFields = Object.keys(envelope).every(key => NESTED_TASK_ENVELOPE_FIELDS.has(key));
+    const looksLikeEnvelope =
+      typeof envelope.task_id === 'string' ||
+      typeof envelope.taskId === 'string' ||
+      Array.isArray(envelope.errors) ||
+      (envelope.adcp_error != null && typeof envelope.adcp_error === 'object') ||
+      (isAdcpStatus && hasOnlyEnvelopeFields);
+
+    if (looksLikeEnvelope && typeof envelope.adcp_version === 'string') {
+      return envelope.adcp_version;
+    }
+  }
+
+  return undefined;
+}
+
+function getLatestDataPartFromParts(parts: unknown): Record<string, unknown> | undefined {
+  if (!Array.isArray(parts)) return undefined;
+  for (let i = parts.length - 1; i >= 0; i -= 1) {
+    const part = parts[i];
+    if (part == null || typeof part !== 'object' || Array.isArray(part)) continue;
+    const record = part as Record<string, unknown>;
+    if (record.kind !== 'data') continue;
+    const data = record.data;
+    if (data == null || typeof data !== 'object' || Array.isArray(data)) continue;
+    return data as Record<string, unknown>;
+  }
+  return undefined;
+}
+
+function getA2AResultAdcpVersion(result: unknown): string | undefined {
+  if (result == null || typeof result !== 'object' || Array.isArray(result)) return undefined;
+
+  const taskData = getLatestA2ADataPartFromTask(result)?.data;
+  const taskVersion = getAdcpVersionFromPayload(taskData);
+  if (taskVersion) return taskVersion;
+
+  const resultRecord = result as Record<string, unknown>;
+  const messageData = getLatestDataPartFromParts(resultRecord.parts);
+  const messageVersion = getAdcpVersionFromPayload(messageData);
+  if (messageVersion) return messageVersion;
+
+  return getAdcpVersionFromPayload(result);
+}
+
+function getMcpTextContentAdcpVersion(content: unknown): string | undefined {
+  if (!Array.isArray(content)) return undefined;
+  for (const item of content) {
+    if (item == null || typeof item !== 'object' || Array.isArray(item)) continue;
+    const text = (item as { type?: unknown; text?: unknown }).text;
+    if ((item as { type?: unknown }).type !== 'text' || typeof text !== 'string') continue;
+    try {
+      const parsed = JSON.parse(text);
+      const version = getAdcpVersionFromPayload(parsed);
+      if (version) return version;
+    } catch {
+      // Non-JSON text chunks are advisory copy, not AdCP envelopes.
+    }
   }
   return undefined;
 }
@@ -291,6 +364,43 @@ export class ProtocolResponseParser {
     // Top-level envelope (A2A direct, REST)
     if (typeof response.replayed === 'boolean') {
       return response.replayed;
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Extract the seller-served AdCP release echo from the response envelope.
+   *
+   * This is the response-side `adcp_version` value, not necessarily the
+   * caller's configured pin. Multi-version sellers can downshift within the
+   * same major; callers that care should compare this value to their request's
+   * release-precision wire version (for example, `wireVersion.normalize(pin)`),
+   * not to a raw full-semver configuration value.
+   */
+  getAdcpVersion(response: any): string | undefined {
+    if (response == null) return undefined;
+
+    // A2A wrapped Task/Message responses carry AdCP payloads in DataParts.
+    const a2aVersion = getA2AResultAdcpVersion(response.result);
+    if (a2aVersion) return a2aVersion;
+
+    // MCP structuredContent.
+    if (typeof response.structuredContent?.adcp_version === 'string') {
+      return response.structuredContent.adcp_version;
+    }
+
+    // MCP text content fallback.
+    const textContentVersion = getMcpTextContentAdcpVersion(response.content);
+    if (textContentVersion) return textContentVersion;
+
+    // Legacy tasks/get wrapper.
+    const taskVersion = getAdcpVersionFromPayload(response.task);
+    if (taskVersion) return taskVersion;
+
+    // Flat AdCP envelope.
+    if (typeof response.adcp_version === 'string') {
+      return response.adcp_version;
     }
 
     return undefined;

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -257,6 +257,11 @@ interface DeferredTaskState {
   createdAt: number;
 }
 
+interface TaskStatusPollResult {
+  task: TaskInfo;
+  rawResponse: Record<string, unknown>;
+}
+
 /**
  * Core task execution engine that handles the conversation loop with agents
  */
@@ -420,6 +425,8 @@ export class TaskExecutor {
     if (args.response !== undefined) {
       const replayed = this.responseParser.getReplayed(args.response);
       if (replayed !== undefined) meta.replayed = replayed;
+      const adcpVersion = this.responseParser.getAdcpVersion(args.response);
+      if (adcpVersion) meta.adcpVersion = adcpVersion;
       const serverContextId = this.responseParser.getContextId(args.response);
       if (serverContextId) meta.contextId = serverContextId;
       const serverTaskId = this.responseParser.getTaskId(args.response);
@@ -1295,6 +1302,7 @@ export class TaskExecutor {
           startTime,
           status: 'deferred',
           clarificationRounds: 1,
+          response,
         }),
         conversation: messages,
         debug_logs: debugLogs,
@@ -1364,11 +1372,11 @@ export class TaskExecutor {
     }
   }
 
-  async getTaskStatus(
+  private async getTaskStatusWithRawResponse(
     agent: AgentConfig,
     taskId: string,
     transport?: import('../protocols').TransportOptions
-  ): Promise<TaskInfo> {
+  ): Promise<TaskStatusPollResult> {
     // AdCP `tasks/get` is the cross-protocol work-status interface
     // (`schemas/cache/<v>/bundled/core/tasks-get-{request,response}.json`).
     // Dispatched as a buyer-callable tool over the agent's transport
@@ -1416,7 +1424,18 @@ export class TaskExecutor {
     // mapper handles the AdCP-spec flat shape, the legacy
     // `{ task: ... }` nested wrapper, and MCP `structuredContent` /
     // A2A latest structured DataPart envelopes.
-    return mapTasksGetResponseToTaskInfo(response);
+    return {
+      task: mapTasksGetResponseToTaskInfo(response),
+      rawResponse: response,
+    };
+  }
+
+  async getTaskStatus(
+    agent: AgentConfig,
+    taskId: string,
+    transport?: import('../protocols').TransportOptions
+  ): Promise<TaskInfo> {
+    return (await this.getTaskStatusWithRawResponse(agent, taskId, transport)).task;
   }
 
   async pollTaskCompletion<T>(
@@ -1484,8 +1503,11 @@ export class TaskExecutor {
       // `TaskResult` so the caller sees an actionable error instead of an
       // opaque uncaught exception escaping from the polling loop.
       let status: TaskInfo;
+      let rawResponse: Record<string, unknown> | undefined;
       try {
-        status = await this.getTaskStatus(agent, taskId, transport);
+        const pollResult = await this.getTaskStatusWithRawResponse(agent, taskId, transport);
+        status = pollResult.task;
+        rawResponse = pollResult.rawResponse;
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         // Bounded `\S{1,128}` task-id segment (no `.*`) keeps the match
@@ -1522,7 +1544,7 @@ export class TaskExecutor {
               agent,
               responseTimeMs: Date.now() - status.createdAt,
               status: 'completed',
-              response: status.result,
+              response: rawResponse,
             }),
           });
         }
@@ -1541,7 +1563,7 @@ export class TaskExecutor {
             agent,
             responseTimeMs: Date.now() - status.createdAt,
             status: 'failed',
-            response: status.result,
+            response: rawResponse,
           }),
         });
       }
@@ -1566,7 +1588,7 @@ export class TaskExecutor {
             agent,
             responseTimeMs: Date.now() - status.createdAt,
             status: 'failed',
-            response: status.result,
+            response: rawResponse,
           }),
         });
       }
@@ -1591,7 +1613,7 @@ export class TaskExecutor {
             agent,
             responseTimeMs: Date.now() - status.createdAt,
             status: status.status,
-            response: status.result,
+            response: rawResponse,
           }),
         });
       }
@@ -1617,6 +1639,7 @@ export class TaskExecutor {
             agent,
             startTime: pollStartTime,
             status: 'failed',
+            response: rawResponse,
           }),
         });
       }

--- a/test/lib/idempotency-client.test.js
+++ b/test/lib/idempotency-client.test.js
@@ -16,11 +16,12 @@ const protocols = require('../../dist/lib/protocols/index.js');
 const { isMutatingTask } = require('../../dist/lib/utils/idempotency.js');
 const { IdempotencyConflictError, IdempotencyExpiredError } = require('../../dist/lib/index.js');
 
-function buildResponse({ replayed } = {}) {
+function buildResponse({ replayed, adcpVersion } = {}) {
   return {
     structuredContent: {
       status: 'completed',
       ...(replayed !== undefined && { replayed }),
+      ...(adcpVersion !== undefined && { adcp_version: adcpVersion }),
       payload: { media_buy_id: 'mb_42', packages: [] },
       media_buy_id: 'mb_42',
       packages: [],
@@ -118,6 +119,143 @@ describe('TaskExecutor surfaces replayed on result metadata', () => {
       const executor = new TaskExecutor();
       const result = await executor.executeTask(agent, 'create_media_buy', baseParams);
       assert.equal(result.metadata.replayed, undefined);
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe('TaskExecutor surfaces response adcp_version on result metadata', () => {
+  it('adcp_version on envelope flows to result.metadata.adcpVersion', async () => {
+    const capture = [];
+    const restore = stubProtocolClient({ response: buildResponse({ adcpVersion: '3.1-beta.5' }), capture });
+    try {
+      const executor = new TaskExecutor();
+      const result = await executor.executeTask(agent, 'create_media_buy', baseParams);
+      assert.equal(result.metadata.adcpVersion, '3.1-beta.5');
+    } finally {
+      restore();
+    }
+  });
+
+  it('tasks/get envelope adcp_version flows through submitted waitForCompletion metadata', async () => {
+    const capture = [];
+    const restore = stubProtocolClient({
+      response: toolName => {
+        if (toolName === 'tasks/get') {
+          return {
+            structuredContent: {
+              status: 'completed',
+              task_id: 'task-polled-version',
+              task_type: 'create_media_buy',
+              created_at: Date.now(),
+              updated_at: Date.now(),
+              adcp_version: '3.1-beta.5',
+              replayed: true,
+              context_id: 'ctx-polled-version',
+              result: {
+                media_buy_id: 'mb_polled_version',
+                media_buy_status: 'pending_creatives',
+                packages: [],
+              },
+            },
+          };
+        }
+        return {
+          structuredContent: {
+            status: 'submitted',
+            task_id: 'task-polled-version',
+          },
+        };
+      },
+      capture,
+    });
+    try {
+      const executor = new TaskExecutor();
+      const submitted = await executor.executeTask(agent, 'create_media_buy', baseParams);
+      const result = await submitted.submitted.waitForCompletion(10);
+      assert.equal(result.metadata.adcpVersion, '3.1-beta.5');
+      assert.equal(result.metadata.replayed, true);
+      assert.equal(result.metadata.contextId, 'ctx-polled-version');
+      assert.equal(result.metadata.serverTaskId, 'task-polled-version');
+    } finally {
+      restore();
+    }
+  });
+
+  it('legacy tasks/get task wrapper adcp_version flows through submitted waitForCompletion metadata', async () => {
+    const capture = [];
+    const restore = stubProtocolClient({
+      response: toolName => {
+        if (toolName === 'tasks/get') {
+          return {
+            task: {
+              status: 'completed',
+              taskId: 'task-polled-legacy-version',
+              taskType: 'create_media_buy',
+              createdAt: Date.now(),
+              updatedAt: Date.now(),
+              adcp_version: '3.1-beta.5',
+              result: {
+                media_buy_id: 'mb_polled_legacy_version',
+                media_buy_status: 'pending_creatives',
+                packages: [],
+              },
+            },
+          };
+        }
+        return {
+          structuredContent: {
+            status: 'submitted',
+            task_id: 'task-polled-legacy-version',
+          },
+        };
+      },
+      capture,
+    });
+    try {
+      const executor = new TaskExecutor();
+      const submitted = await executor.executeTask(agent, 'create_media_buy', baseParams);
+      const result = await submitted.submitted.waitForCompletion(10);
+      assert.equal(result.metadata.adcpVersion, '3.1-beta.5');
+    } finally {
+      restore();
+    }
+  });
+
+  it('input handler deferral preserves response adcp_version metadata', async () => {
+    const capture = [];
+    const restore = stubProtocolClient({
+      response: {
+        structuredContent: {
+          status: 'input-required',
+          question: 'Approve this buy?',
+          field: 'approval',
+          adcp_version: '3.1-beta.5',
+        },
+      },
+      capture,
+    });
+    try {
+      const executor = new TaskExecutor();
+      const result = await executor.executeTask(agent, 'create_media_buy', baseParams, async () => ({
+        defer: true,
+        token: 'deferred-token-1',
+      }));
+      assert.equal(result.status, 'deferred');
+      assert.equal(result.metadata.adcpVersion, '3.1-beta.5');
+    } finally {
+      restore();
+    }
+  });
+
+  it('adcp_version omitted is surfaced as undefined', async () => {
+    const capture = [];
+    const restore = stubProtocolClient({ response: buildResponse(), capture });
+    try {
+      const executor = new TaskExecutor();
+      const result = await executor.executeTask(agent, 'create_media_buy', baseParams);
+      assert.equal(result.metadata.adcpVersion, undefined);
     } finally {
       restore();
     }

--- a/test/lib/protocol-response-parser-a2a-submitted.test.js
+++ b/test/lib/protocol-response-parser-a2a-submitted.test.js
@@ -30,7 +30,12 @@ const { ProtocolResponseParser, ADCP_STATUS, TaskExecutor, ProtocolClient } = re
 
 const parser = new ProtocolResponseParser();
 
-function a2aWrappedSubmittedResponse({ adcpTaskId = 'tk_X', a2aTaskId = 'a2a-uuid', adcpStatus = 'submitted' } = {}) {
+function a2aWrappedSubmittedResponse({
+  adcpTaskId = 'tk_X',
+  a2aTaskId = 'a2a-uuid',
+  adcpStatus = 'submitted',
+  adcpVersion,
+} = {}) {
   return {
     jsonrpc: '2.0',
     id: 1,
@@ -48,7 +53,7 @@ function a2aWrappedSubmittedResponse({ adcpTaskId = 'tk_X', a2aTaskId = 'a2a-uui
           parts: [
             {
               kind: 'data',
-              data: { status: adcpStatus, task_id: adcpTaskId },
+              data: { status: adcpStatus, task_id: adcpTaskId, ...(adcpVersion && { adcp_version: adcpVersion }) },
             },
           ],
           metadata: { adcp_task_id: adcpTaskId },
@@ -279,6 +284,163 @@ describe('ProtocolResponseParser.getTaskId — A2A submitted arm (#973)', () => 
   });
 });
 
+describe('ProtocolResponseParser.getAdcpVersion', () => {
+  test('reads adcp_version from MCP structuredContent', () => {
+    assert.strictEqual(parser.getAdcpVersion({ structuredContent: { adcp_version: '3.1-beta.5' } }), '3.1-beta.5');
+  });
+
+  test('reads adcp_version from flat AdCP envelope', () => {
+    assert.strictEqual(parser.getAdcpVersion({ adcp_version: '3.0' }), '3.0');
+  });
+
+  test('reads adcp_version from A2A task DataPart', () => {
+    const response = a2aWrappedSubmittedResponse({ adcpVersion: '3.1' });
+    assert.strictEqual(parser.getAdcpVersion(response), '3.1');
+  });
+
+  test('reads adcp_version from nested A2A task DataPart response wrapper', () => {
+    const response = a2aWrappedSubmittedResponse();
+    response.result.artifacts[0].parts[0].data = {
+      response: {
+        status: 'completed',
+        adcp_version: '3.1-beta.2',
+      },
+    };
+    assert.strictEqual(parser.getAdcpVersion(response), '3.1-beta.2');
+  });
+
+  test('reads adcp_version from latest A2A message DataPart', () => {
+    assert.strictEqual(
+      parser.getAdcpVersion({
+        result: {
+          kind: 'message',
+          parts: [
+            {
+              kind: 'data',
+              data: { adcp_version: '3.0' },
+            },
+            {
+              kind: 'data',
+              data: { adcp_version: '3.1' },
+            },
+          ],
+        },
+      }),
+      '3.1'
+    );
+  });
+
+  test('reads adcp_version from MCP JSON text fallback', () => {
+    assert.strictEqual(
+      parser.getAdcpVersion({
+        content: [{ type: 'text', text: JSON.stringify({ status: 'completed', adcp_version: '3.1-beta.5' }) }],
+      }),
+      '3.1-beta.5'
+    );
+  });
+
+  test('reads adcp_version from legacy tasks/get task wrapper', () => {
+    assert.strictEqual(
+      parser.getAdcpVersion({
+        task: {
+          status: 'completed',
+          adcp_version: '3.1-beta.5',
+        },
+      }),
+      '3.1-beta.5'
+    );
+  });
+
+  test('reads adcp_version from nested legacy tasks/get task response wrapper', () => {
+    assert.strictEqual(
+      parser.getAdcpVersion({
+        task: {
+          response: {
+            status: 'completed',
+            adcp_version: '3.1-beta.5',
+          },
+        },
+      }),
+      '3.1-beta.5'
+    );
+  });
+
+  test('ignores response.adcp_version when response is domain payload data', () => {
+    assert.strictEqual(
+      parser.getAdcpVersion({
+        result: {
+          kind: 'task',
+          artifacts: [
+            {
+              parts: [
+                {
+                  kind: 'data',
+                  data: {
+                    session_id: 'si_session_1',
+                    session_status: 'active',
+                    response: {
+                      text: 'Business payload, not an AdCP envelope',
+                      adcp_version: 'domain-data-not-envelope',
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      }),
+      undefined
+    );
+
+    assert.strictEqual(
+      parser.getAdcpVersion({
+        result: {
+          kind: 'task',
+          artifacts: [
+            {
+              parts: [
+                {
+                  kind: 'data',
+                  data: {
+                    session_id: 'si_session_2',
+                    session_status: 'active',
+                    response: {
+                      status: 'active',
+                      adcp_version: 'domain-status-not-envelope',
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      }),
+      undefined
+    );
+  });
+
+  test('reads nested response.adcp_version when nested response is envelope-like', () => {
+    assert.strictEqual(
+      parser.getAdcpVersion({
+        task: {
+          response: {
+            status: 'completed',
+            errors: [],
+            adcp_version: '3.1-beta.5',
+          },
+        },
+      }),
+      '3.1-beta.5'
+    );
+  });
+
+  test('returns undefined when adcp_version is absent or non-string', () => {
+    assert.strictEqual(parser.getAdcpVersion({ structuredContent: { adcp_version: 3.1 } }), undefined);
+    assert.strictEqual(parser.getAdcpVersion({ content: [{ type: 'text', text: 'not json' }] }), undefined);
+    assert.strictEqual(parser.getAdcpVersion({}), undefined);
+  });
+});
+
 describe('TaskExecutor — A2A update_media_buy canceled domain payload (#2009)', () => {
   const mockAgent = {
     id: 'test-a2a-seller',
@@ -337,5 +499,56 @@ describe('TaskExecutor — A2A update_media_buy canceled domain payload (#2009)'
     assert.strictEqual(result.success, true);
     assert.strictEqual(result.status, 'submitted');
     assert.strictEqual(result.submitted.taskId, 'tk_latest_text');
+  });
+
+  test('surfaces A2A DataPart adcp_version on result metadata', async () => {
+    ProtocolClient.callTool = mock.fn(async () =>
+      a2aWrappedCompletedArtifactData({
+        adcp_version: '3.1-beta.5',
+        media_buy_id: 'mb_a2a_version',
+        media_buy_status: 'pending_creatives',
+        packages: [],
+      })
+    );
+
+    const executor = new TaskExecutor({ strictSchemaValidation: false });
+    const result = await executor.executeTask(mockAgent, 'create_media_buy', {
+      buyer_ref: 'buyer-ref',
+      packages: [],
+    });
+
+    assert.strictEqual(result.success, true);
+    assert.strictEqual(result.status, 'completed');
+    assert.strictEqual(result.metadata.adcpVersion, '3.1-beta.5');
+  });
+
+  test('A2A wrapped tasks/get adcp_version flows through submitted waitForCompletion metadata', async () => {
+    ProtocolClient.callTool = mock.fn(async (_agent, taskName) => {
+      if (taskName === 'tasks/get') {
+        return a2aWrappedCompletedArtifactData({
+          status: 'completed',
+          task_id: 'tk_poll_a2a',
+          task_type: 'create_media_buy',
+          adcp_version: '3.1-beta.5',
+          result: {
+            media_buy_id: 'mb_poll_a2a',
+            media_buy_status: 'pending_creatives',
+            packages: [],
+          },
+        });
+      }
+      return a2aWrappedSubmittedResponse({ adcpStatus: 'submitted', adcpTaskId: 'tk_poll_a2a' });
+    });
+
+    const executor = new TaskExecutor({ strictSchemaValidation: false });
+    const submitted = await executor.executeTask(mockAgent, 'create_media_buy', {
+      buyer_ref: 'buyer-ref',
+      packages: [],
+    });
+    const result = await submitted.submitted.waitForCompletion(10);
+
+    assert.strictEqual(result.success, true);
+    assert.strictEqual(result.status, 'completed');
+    assert.strictEqual(result.metadata.adcpVersion, '3.1-beta.5');
   });
 });


### PR DESCRIPTION
## Summary
- add `TaskResultMetadata.adcpVersion` for seller-served response `adcp_version` echoes
- extract the value across MCP structured/text fallback, A2A task/message DataParts, flat envelopes, and legacy tasks/get wrappers
- preserve raw `tasks/get` polling responses so completed/failed/paused poll results can surface envelope metadata consistently
- update curated docs/generator and add a minor changeset

## Validation
- npm run build:lib
- node --test --test-timeout=60000 test/lib/protocol-response-parser-a2a-submitted.test.js
- node --test --test-timeout=60000 test/lib/idempotency-client.test.js
- node --test --test-timeout=60000 test/lib/poll-task-completion-terminal-states.test.js
- node --test --test-timeout=60000 test/lib/signing-protocol-response.test.js
- npm run typecheck
- npm run format:check
- npm run ci:docs-check
- git diff --check

Refs #1069