### PR TITLE
feat: add canonical reference resolver

### DIFF
--- a/.changeset/canonical-reference-resolver.md
+++ b/.changeset/canonical-reference-resolver.md
@@ -1,0 +1,5 @@
+---
+"@adcp/sdk": minor
+---
+
+Add a caller-scoped canonical reference resolver for AdCP 3.1 `format_schema` and `platform_extensions` URI+digest references with structured resolution statuses.

--- a/docs/development/v3.1-sdk-design.md
+++ b/docs/development/v3.1-sdk-design.md
@@ -242,18 +242,29 @@ for (const d of result.diagnostics) console.warn(d.code, d.details);
 
 `format_kind: "custom"` declarations carry `format_schema: { uri, digest }`. The spec's normative fetch contract is long, security-critical, and identical across all SDKs (HTTPS-only, SSRF guards, no redirects, 1 MiB body cap, 5s timeout, sha256 hard-fail, $ref sandbox with same-origin + depth ≤8 + count ≤256, re2 regex, ≤250 ms compile-time budget). If every SDK ships its own, the protocol's security posture is the weakest implementation.
 
-The SDK ships `fetchFormatSchema` as the single approved fetcher:
+The SDK ships `createCanonicalReferenceResolver` as the approved
+high-level path for both `format_schema` and `platform_extensions`
+URI+digest references:
 
 ```ts
-import { fetchFormatSchema, CustomFormatFetchError } from '@adcp/sdk/v2';
+import { createCanonicalReferenceResolver } from '@adcp/sdk/v2/format-schema';
 
-const schema = await fetchFormatSchema(declaration.format_schema, {
-  cache: customFormatCache,        // caller-supplied — sane default for in-process
-  fetchPolicy: 'allowed' | 'disabled',  // default 'allowed'
+const resolver = createCanonicalReferenceResolver({
+  cache: customReferenceCache, // caller-scoped; omitted means resolver-local Map
 });
+
+const result = await resolver.resolveFormatSchema(declaration.format_schema);
+if (!result.ok) {
+  // invalid_ref | blocked_unsafe_url | digest_mismatch |
+  // invalid_schema | unresolvable
+  surfaceDiagnostic(result.status, result.code);
+}
 ```
 
-Default policy is `allowed` — the spec is opinionated that buyers SHOULD fetch and validate. Adopters who can't run an outbound HTTPS fetch path (firewalled environments) flip to `disabled` and the SDK skips validation, surfacing `CUSTOM_FORMAT_FETCH_FAILED` with `reason: 'fetch_disabled'`.
+The resolver returns structured statuses instead of throwing. It
+degrades gracefully on 404/network partitions with `unresolvable`,
+keeps digest mismatch separate as a substitution signal, and shares the
+same transport hardening for informational `platform_extensions`.
 
 When auto-negotiation lands the buyer on a 3.0-only seller, this code path is unreachable — `format_kind: "custom"` only exists in 3.1 `format_options`.
 

--- a/docs/migration-7.9-to-7.10.md
+++ b/docs/migration-7.9-to-7.10.md
@@ -242,11 +242,79 @@ The publisher catalog is the cross-publisher equivalent of a single
 seller's `format_options[]`. Same `format_option_id` discipline; one extra
 hop to fetch the publisher's adagents.json.
 
-## 4. `format_schema` references
+## 4. `format_schema` and `platform_extensions` references
 
 Custom format declarations carry a URI+digest reference to an
-out-of-tree JSON Schema document. 7.10 ships the spec's normative fetch
-contract + `$ref` sandboxer.
+out-of-tree JSON Schema document. `platform_extensions[]` uses the
+same immutable `{ uri, digest }` reference shape for extension
+definitions. 7.10 ships a shared resolver for both fields so adopters
+do not hand-roll the fetch path.
+
+```ts
+import { createCanonicalReferenceResolver } from '@adcp/sdk/v2/format-schema';
+
+const resolver = createCanonicalReferenceResolver({
+  // Optional caller-scoped cache; omitted means a resolver-local Map.
+  // No process-global singleton is required.
+  timeoutMs: 5_000,
+  maxBodyBytes: 1024 * 1024,
+  // Test/storyboard runners that intentionally use loopback fixtures can
+  // opt in per resolver. Production callers should omit this.
+  allowInternalReferences: false,
+});
+
+const schemaResult = await resolver.resolveFormatSchema(formatSchemaRef);
+if (!schemaResult.ok) {
+  // Stable statuses: invalid_ref, blocked_unsafe_url,
+  // digest_mismatch, invalid_schema, unresolvable.
+  reportFormatDiagnostic(schemaResult.status, schemaResult.code);
+} else {
+  // `document` is digest-verified, `$ref`-resolved, bounded, and
+  // compiled as Draft-07 / Draft 2019-09 JSON Schema.
+  validateManifest(schemaResult.document);
+}
+
+const extensionResult = await resolver.resolvePlatformExtension(platformExtensionRef);
+```
+
+The transport contract is identical for both fields: HTTPS-only in
+production, SSRF guarded, DNS pinned, redirects disabled, 1 MiB default
+body cap, 5 second default timeout, SHA-256 digest verification, and
+immutable `uri@digest` caching. Transient fetch failures return
+`status: 'unresolvable'`; digest mismatches return
+`status: 'digest_mismatch'` so callers can treat them as substitution
+signals.
+
+`platform_extensions` may also be bundled on `get_products` responses
+under `extensions`, keyed by `<uri>@<digest>`. Prefer the bundled
+definition when present, and fall back to the resolver only for missing
+definitions:
+
+```ts
+const key = `${platformExtensionRef.uri}@${platformExtensionRef.digest}`;
+const bundled = getProductsResponse.extensions?.[key];
+const resolvedExtension = bundled ? undefined : await resolver.resolvePlatformExtension(platformExtensionRef);
+const extension = bundled ?? (resolvedExtension?.ok ? resolvedExtension.document : undefined);
+```
+
+Resolver statuses are stable:
+
+| Status | Meaning | Retry |
+|---|---|---|
+| `resolved` | Reference fetched, digest-verified, and parsed. `format_schema` is also `$ref`-resolved and compiled. | n/a |
+| `invalid_ref` | Local `{ uri, digest }` shape is malformed. | no |
+| `blocked_unsafe_url` | SSRF/redirect/sandbox policy blocked the URI or a `$ref`. | no |
+| `digest_mismatch` | Body hash did not match the supplied digest. Treat as substitution. | no |
+| `invalid_schema` | Body is not usable as the expected JSON object/schema. | no |
+| `unresolvable` | DNS, timeout, 5xx, body-cap, 404, or another fetch failure. | check `retryable` |
+
+For cache reuse, keep a `createCanonicalReferenceResolver()` instance
+around. The one-shot `resolveFormatSchema()` and
+`resolvePlatformExtension()` helpers are convenient for scripts but
+create a fresh resolver each call.
+
+Low-level helpers remain exported when you need to split the steps
+manually:
 
 ```ts
 import { fetchFormatSchema, resolveSchemaRefs } from '@adcp/sdk/v2/format-schema';
@@ -265,9 +333,9 @@ const { schema: resolved, refCount, maxDepthSeen } = await resolveSchemaRefs(sch
 // `resolved` is safe to feed to Ajv. Every $ref already inlined.
 ```
 
-The sandboxer accepts a custom `fetchExternal` if you want per-`$ref`
-digest enforcement (e.g., from an internal registry of `uri@digest`
-pairs):
+The resolver and sandboxer both accept a custom `fetchExternal` if you
+want per-`$ref` digest enforcement (e.g., from an internal registry of
+`uri@digest` pairs):
 
 ```ts
 const { schema: resolved } = await resolveSchemaRefs(schema, ref.uri, {
@@ -279,9 +347,10 @@ const { schema: resolved } = await resolveSchemaRefs(schema, ref.uri, {
 ```
 
 `DEFAULT_MAX_KEYWORDS` (10 000) and `DEFAULT_VALIDATION_BUDGET_MS`
-(250) are exported for the eventual Ajv-wiring layer — actual
-enforcement of the schema-compile DoS bounds is the manifest
-validator's job and lands in a future release.
+(250) are exported for manifest validation. The canonical reference
+resolver enforces `DEFAULT_MAX_KEYWORDS` before compiling custom
+format schemas; the validation budget remains the caller's per-manifest
+runtime concern.
 
 ## 5. AdCP 3.1.0-beta.5 opt-in
 

--- a/src/lib/v2/format-schema/fetch.ts
+++ b/src/lib/v2/format-schema/fetch.ts
@@ -20,11 +20,13 @@
  *     `digest`. Mismatch is a hard fail.
  *   - **Cache**: keyed by `uri@digest`; immutable.
  *
- * Out of scope (deferred to a future follow-up):
- *   - `$ref` resolution + depth/count bounds — Ajv loaderHook job.
- *   - Schema-compile DoS bounds (re2 pattern engine, allOf expansion
- *     bounds, per-manifest validation budget) — applied at the Ajv
- *     compile step in the manifest validator, not here.
+ * Higher-level helper:
+ *   - `createCanonicalReferenceResolver()` wraps this fetcher with
+ *     per-caller caching, `$ref` sandboxing, JSON Schema compilation,
+ *     and non-throwing structured statuses for both `format_schema` and
+ *     `platform_extensions` references.
+ *
+ * Out of scope for this low-level fetcher:
  *   - Stronger transparency-log / signed-body verification — tracked
  *     separately in the spec; mirror-trust hardening is future work.
  */
@@ -110,6 +112,12 @@ export interface FetchFormatSchemaOptions {
    */
   maxBodyBytes?: number;
   /**
+   * Caller-scoped test/dev opt-in for loopback/private HTTP fetches.
+   * Production callers should leave this false. IMDS/link-local
+   * metadata endpoints remain blocked by `ssrfSafeFetch`.
+   */
+  allowInternalReferences?: boolean;
+  /**
    * Override the module-level cache. Useful when callers want
    * per-session caches or to disable caching entirely
    * (`{ get: () => undefined, set: () => {} }`).
@@ -127,25 +135,33 @@ const DEFAULT_TIMEOUT_MS = 5_000;
 const DEFAULT_MAX_BODY_BYTES = 1024 * 1024;
 const DIGEST_RE = /^sha256:[0-9a-f]{64}$/;
 
+function cloneJsonRecord<T extends Record<string, unknown>>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function cloneFetchResult(result: FormatSchemaFetchResult, fromCache: boolean): FormatSchemaFetchResult {
+  return {
+    schema: cloneJsonRecord(result.schema),
+    ref: { ...result.ref },
+    fromCache,
+  };
+}
+
 function defaultCache(): FormatSchemaCache {
   const store = new Map<string, FormatSchemaFetchResult>();
   return {
     get: key => store.get(key),
     set: (key, value) => {
-      store.set(key, value);
+      store.set(key, cloneFetchResult(value, false));
     },
   };
 }
 
-const moduleCache = defaultCache();
+let moduleCache = defaultCache();
 
 /** Test hook: drop the module-level cache. */
 export function _resetFormatSchemaCache(): void {
-  // We can't actually drop a Map referenced by the closure; expose a
-  // recreate-the-store path that callers can use in tests.
-  // Module re-initialization is the supported reset mechanism for the
-  // default cache.
-  // For now consumers needing isolation should pass a fresh cache via options.
+  moduleCache = defaultCache();
 }
 
 /**
@@ -165,7 +181,7 @@ export async function fetchFormatSchema(
   // Production: HTTPS-only per spec. Loopback test runs (gated by
   // ADCP_ALLOW_INTERNAL_PROBES=1) may use `http://` against a 127.0.0.1
   // mock — same opt-in pattern as the discovery layer.
-  const allowHttp = isInternalProbesAllowed();
+  const allowHttp = options.allowInternalReferences === true || isInternalProbesAllowed();
   if (!ref.uri.startsWith('https://') && !(allowHttp && ref.uri.startsWith('http://'))) {
     throw new FormatSchemaFetchError('invalid_ref', 'format_schema.uri must use https:// (spec normative)', {
       uri: ref.uri,
@@ -183,7 +199,7 @@ export async function fetchFormatSchema(
   const cacheKey = `${ref.uri}@${ref.digest}`;
   const cached = cache.get(cacheKey);
   if (cached) {
-    return { ...cached, fromCache: true };
+    return cloneFetchResult(cached, true);
   }
 
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
@@ -204,6 +220,9 @@ export async function fetchFormatSchema(
     });
   } catch (err) {
     if (err instanceof SsrfRefusedError) {
+      if (err.code === 'body_exceeds_limit') {
+        throw new FormatSchemaFetchError('body_too_large', err.message, { uri: ref.uri, digest: ref.digest });
+      }
       throw new FormatSchemaFetchError('ssrf_refused', `SSRF guard refused: ${err.message}`, {
         uri: ref.uri,
         digest: ref.digest,
@@ -271,9 +290,9 @@ export async function fetchFormatSchema(
 
   const result: FormatSchemaFetchResult = {
     schema: parsed as Record<string, unknown>,
-    ref,
+    ref: { ...ref },
     fromCache: false,
   };
   cache.set(cacheKey, result);
-  return result;
+  return cloneFetchResult(result, false);
 }

--- a/src/lib/v2/format-schema/index.ts
+++ b/src/lib/v2/format-schema/index.ts
@@ -1,19 +1,20 @@
 /**
- * Format-schema fetcher for AdCP 3.1's
- * `ProductFormatDeclaration.format_schema` references — the URI+digest
- * pointer to an out-of-tree JSON Schema document describing a custom
- * format's `params` and `slots` shape.
+ * Canonical reference resolver for AdCP 3.1 `format_schema` and
+ * `platform_extensions` URI+digest references.
  *
- * Use after `projectV1ProductToV2` or directly on V2 declarations whose
- * `format_kind: "custom"` carries a `format_schema` reference:
+ * Use the high-level resolver after `projectV1ProductToV2` or directly
+ * on V2 declarations. It returns structured statuses instead of
+ * throwing, keeps a caller-scoped immutable cache, resolves and compiles
+ * custom format schemas, and uses the same hardened transport for
+ * platform-extension definitions.
  *
  * ```ts
- * import { fetchFormatSchema } from '@adcp/sdk/v2/format-schema';
+ * import { createCanonicalReferenceResolver } from '@adcp/sdk/v2/format-schema';
  *
- * const { format_schema } = decl;
- * if (format_schema) {
- *   const { schema, fromCache } = await fetchFormatSchema(format_schema);
- *   // Use `schema` to validate the placement manifest at runtime.
+ * const resolver = createCanonicalReferenceResolver();
+ * const result = await resolver.resolveFormatSchema(decl.format_schema);
+ * if (result.ok) {
+ *   // Use `result.document` to validate the placement manifest.
  * }
  * ```
  *
@@ -46,3 +47,22 @@ export {
   type ResolveSchemaRefsOptions,
   type ResolveSchemaRefsResult,
 } from './sandbox-refs';
+
+export {
+  createCanonicalRefResolver,
+  createCanonicalReferenceResolver,
+  createMemoryCanonicalReferenceCache,
+  resolveFormatSchema,
+  resolvePlatformExtension,
+  type CanonicalReferenceCache,
+  type CanonicalRef,
+  type CanonicalReferenceFailureResult,
+  type CanonicalReferenceKind,
+  type CanonicalReferenceResolvedResult,
+  type CanonicalReferenceResolutionCode,
+  type CanonicalReferenceResolutionResult,
+  type CanonicalReferenceResolutionStatus,
+  type CanonicalReferenceResolver,
+  type CanonicalReferenceResolverOptions,
+  type ResolveCanonicalReferenceOptions,
+} from './resolver';

--- a/src/lib/v2/format-schema/resolver.ts
+++ b/src/lib/v2/format-schema/resolver.ts
@@ -1,0 +1,437 @@
+import Ajv2019 from 'ajv/dist/2019';
+import addFormats from 'ajv-formats';
+import draft7MetaSchema from 'ajv/dist/refs/json-schema-draft-07.json';
+import {
+  fetchFormatSchema,
+  FormatSchemaFetchError,
+  type FetchFormatSchemaOptions,
+  type FormatSchemaCache,
+  type FormatSchemaFetchErrorCode,
+  type FormatSchemaFetchResult,
+  type FormatSchemaRef,
+} from './fetch';
+import {
+  DEFAULT_MAX_KEYWORDS,
+  DEFAULT_MAX_REF_COUNT,
+  DEFAULT_MAX_REF_DEPTH,
+  resolveSchemaRefs,
+  SchemaRefSandboxError,
+  type ResolveSchemaRefsOptions,
+  type SchemaRefSandboxErrorCode,
+} from './sandbox-refs';
+
+export type CanonicalReferenceKind = 'format_schema' | 'platform_extensions';
+export type CanonicalRef = FormatSchemaRef;
+
+export type CanonicalReferenceResolutionStatus =
+  | 'resolved'
+  | 'invalid_ref'
+  | 'blocked_unsafe_url'
+  | 'digest_mismatch'
+  | 'invalid_schema'
+  | 'unresolvable';
+
+export type CanonicalReferenceResolutionCode =
+  | FormatSchemaFetchErrorCode
+  | SchemaRefSandboxErrorCode
+  | 'schema_dialect_unsupported'
+  | 'schema_compile_failed'
+  | 'schema_keyword_limit_exceeded';
+
+export interface CanonicalReferenceResolvedResult {
+  ok: true;
+  status: 'resolved';
+  kind: CanonicalReferenceKind;
+  ref: FormatSchemaRef;
+  /**
+   * Resolved document. For `format_schema`, every allowed `$ref` has
+   * been inlined and the result has compiled as JSON Schema. For
+   * `platform_extensions`, this is the fetched JSON object.
+   */
+  document: Record<string, unknown>;
+  /** Original digest-verified document, before `$ref` inlining. */
+  rawDocument: Record<string, unknown>;
+  /** True when returned from the caller-scoped immutable cache. */
+  fromCache: boolean;
+  /** `format_schema` only: count of `$ref` occurrences resolved. */
+  refCount?: number;
+  /** `format_schema` only: deepest transitive `$ref` depth observed. */
+  maxDepthSeen?: number;
+}
+
+export interface CanonicalReferenceFailureResult {
+  ok: false;
+  status: Exclude<CanonicalReferenceResolutionStatus, 'resolved'>;
+  kind: CanonicalReferenceKind;
+  ref: Partial<FormatSchemaRef>;
+  /** Stable transport/schema subreason. Same value as `code`. */
+  reason: CanonicalReferenceResolutionCode;
+  code: CanonicalReferenceResolutionCode;
+  /** True for transient network/server/cap failures callers may retry. */
+  retryable: boolean;
+  message: string;
+  httpStatus?: number;
+  details?: Record<string, unknown>;
+}
+
+export type CanonicalReferenceResolutionResult = CanonicalReferenceResolvedResult | CanonicalReferenceFailureResult;
+
+export interface CanonicalReferenceCache {
+  get(key: string): CanonicalReferenceResolvedResult | undefined;
+  set(key: string, value: CanonicalReferenceResolvedResult): void;
+}
+
+export interface CanonicalReferenceResolverOptions {
+  timeoutMs?: number;
+  maxBodyBytes?: number;
+  cache?: CanonicalReferenceCache;
+  maxRefDepth?: number;
+  maxRefCount?: number;
+  maxKeywords?: number;
+  allowInternalReferences?: boolean;
+  mirrorHost?: ResolveSchemaRefsOptions['mirrorHost'];
+  mirrorHosts?: ResolveSchemaRefsOptions['mirrorHosts'];
+  fetchExternal?: ResolveSchemaRefsOptions['fetchExternal'];
+}
+
+export interface ResolveCanonicalReferenceOptions extends CanonicalReferenceResolverOptions {
+  kind: CanonicalReferenceKind;
+}
+
+export interface CanonicalReferenceResolver {
+  resolveReference(
+    ref: FormatSchemaRef,
+    options: ResolveCanonicalReferenceOptions
+  ): Promise<CanonicalReferenceResolutionResult>;
+  resolveFormatSchema(
+    ref: FormatSchemaRef,
+    options?: CanonicalReferenceResolverOptions
+  ): Promise<CanonicalReferenceResolutionResult>;
+  resolvePlatformExtension(
+    ref: FormatSchemaRef,
+    options?: CanonicalReferenceResolverOptions
+  ): Promise<CanonicalReferenceResolutionResult>;
+}
+
+export function createMemoryCanonicalReferenceCache(): CanonicalReferenceCache {
+  const store = new Map<string, CanonicalReferenceResolvedResult>();
+  return {
+    get: key => {
+      const cached = store.get(key);
+      return cached ? cloneResolvedResult(cached, false) : undefined;
+    },
+    set: (key, value) => {
+      store.set(key, cloneResolvedResult(value, false));
+    },
+  };
+}
+
+function createMemoryFormatSchemaCache(): FormatSchemaCache {
+  const store = new Map<string, FormatSchemaFetchResult>();
+  return {
+    get: key => store.get(key),
+    set: (key, value) => {
+      store.set(key, value);
+    },
+  };
+}
+
+function cacheKey(kind: CanonicalReferenceKind, ref: FormatSchemaRef): string {
+  return `${kind}:${ref.uri}@${ref.digest}`;
+}
+
+function cloneJsonRecord<T extends Record<string, unknown>>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function cloneResolvedResult(
+  result: CanonicalReferenceResolvedResult,
+  fromCache: boolean
+): CanonicalReferenceResolvedResult {
+  return {
+    ...result,
+    ref: { ...result.ref },
+    document: cloneJsonRecord(result.document),
+    rawDocument: cloneJsonRecord(result.rawDocument),
+    fromCache,
+  };
+}
+
+function toFetchOptions(
+  options: CanonicalReferenceResolverOptions,
+  fetchCache: FormatSchemaCache
+): FetchFormatSchemaOptions {
+  return {
+    timeoutMs: options.timeoutMs,
+    maxBodyBytes: options.maxBodyBytes,
+    allowInternalReferences: options.allowInternalReferences,
+    cache: fetchCache,
+  };
+}
+
+function fail(
+  kind: CanonicalReferenceKind,
+  ref: Partial<FormatSchemaRef>,
+  status: CanonicalReferenceFailureResult['status'],
+  code: CanonicalReferenceResolutionCode,
+  message: string,
+  meta: { httpStatus?: number; details?: Record<string, unknown>; retryable?: boolean } = {}
+): CanonicalReferenceFailureResult {
+  return {
+    ok: false,
+    status,
+    kind,
+    ref,
+    reason: code,
+    code,
+    retryable: meta.retryable ?? status === 'unresolvable',
+    message,
+    httpStatus: meta.httpStatus,
+    details: meta.details,
+  };
+}
+
+function mapFetchError(kind: CanonicalReferenceKind, ref: Partial<FormatSchemaRef>, err: FormatSchemaFetchError) {
+  if (err.code === 'digest_mismatch') {
+    return fail(kind, ref, 'digest_mismatch', err.code, err.message, {
+      details: err.details,
+      retryable: false,
+    });
+  }
+  if (
+    err.code === 'ssrf_refused' &&
+    (err.details?.code === 'dns_lookup_failed' ||
+      err.details?.code === 'dns_empty' ||
+      err.details?.code === 'body_exceeds_limit')
+  ) {
+    return fail(kind, ref, 'unresolvable', err.code, err.message, {
+      details: err.details,
+      retryable: true,
+    });
+  }
+  if (
+    err.code === 'ssrf_refused' ||
+    err.code === 'redirect_blocked' ||
+    (err.code === 'invalid_ref' && /uri must use https/i.test(err.message))
+  ) {
+    return fail(kind, ref, 'blocked_unsafe_url', err.code, err.message, {
+      httpStatus: err.httpStatus,
+      details: err.details,
+      retryable: false,
+    });
+  }
+  if (err.code === 'invalid_ref') {
+    return fail(kind, ref, 'invalid_ref', err.code, err.message, { details: err.details, retryable: false });
+  }
+  if (err.code === 'invalid_json') {
+    return fail(kind, ref, 'invalid_schema', err.code, err.message, { details: err.details, retryable: false });
+  }
+  return fail(kind, ref, 'unresolvable', err.code, err.message, {
+    httpStatus: err.httpStatus,
+    details: err.details,
+    retryable: true,
+  });
+}
+
+function mapSandboxError(kind: CanonicalReferenceKind, ref: FormatSchemaRef, err: SchemaRefSandboxError) {
+  if (err.code === 'fetch_failed' && err.details?.transient === true) {
+    return fail(kind, ref, 'unresolvable', err.code, err.message, { details: err.details, retryable: true });
+  }
+  if (err.code === 'fetch_failed' && typeof err.details?.httpStatus === 'number') {
+    const httpStatus = err.details.httpStatus;
+    if (httpStatus >= 300 && httpStatus < 400) {
+      return fail(kind, ref, 'blocked_unsafe_url', err.code, err.message, { details: err.details, retryable: false });
+    }
+    return fail(kind, ref, 'unresolvable', err.code, err.message, {
+      details: err.details,
+      retryable: httpStatus === 404 || httpStatus >= 500,
+    });
+  }
+  const status =
+    err.code === 'file_scheme_rejected' || err.code === 'cross_origin_rejected'
+      ? 'blocked_unsafe_url'
+      : 'invalid_schema';
+  return fail(kind, ref, status, err.code, err.message, { details: err.details, retryable: false });
+}
+
+const DRAFT_07_DIALECTS = new Set([
+  'http://json-schema.org/draft-07/schema',
+  'https://json-schema.org/draft-07/schema',
+]);
+const DRAFT_2019_09_DIALECTS = new Set([
+  'http://json-schema.org/draft/2019-09/schema',
+  'https://json-schema.org/draft/2019-09/schema',
+]);
+
+function normalizeDialect(dialect: string | undefined): 'draft-07' | 'draft-2019-09' | undefined {
+  if (!dialect) return 'draft-2019-09';
+  const normalized = dialect.endsWith('#') ? dialect.slice(0, -1) : dialect;
+  if (DRAFT_07_DIALECTS.has(normalized)) return 'draft-07';
+  if (DRAFT_2019_09_DIALECTS.has(normalized)) return 'draft-2019-09';
+  return undefined;
+}
+
+function countSchemaKeywords(node: unknown): number {
+  if (node === null || typeof node !== 'object') return 0;
+  if (Array.isArray(node)) return node.reduce((sum, item) => sum + countSchemaKeywords(item), 0);
+  let count = 0;
+  for (const value of Object.values(node as Record<string, unknown>)) {
+    count += 1;
+    count += countSchemaKeywords(value);
+  }
+  return count;
+}
+
+function validateJsonSchema(
+  schema: Record<string, unknown>,
+  maxKeywords: number
+):
+  | { ok: true }
+  | { ok: false; code: CanonicalReferenceResolutionCode; message: string; details?: Record<string, unknown> } {
+  const dialect = typeof schema.$schema === 'string' ? schema.$schema : undefined;
+  const normalizedDialect = normalizeDialect(dialect);
+  if (!normalizedDialect) {
+    return {
+      ok: false,
+      code: 'schema_dialect_unsupported',
+      message: `unsupported JSON Schema dialect${dialect ? `: ${dialect}` : ''}; expected Draft-07 or Draft 2019-09`,
+      details: { dialect },
+    };
+  }
+
+  const keywordCount = countSchemaKeywords(schema);
+  if (keywordCount > maxKeywords) {
+    return {
+      ok: false,
+      code: 'schema_keyword_limit_exceeded',
+      message: `JSON Schema keyword count ${keywordCount} exceeds limit ${maxKeywords}`,
+      details: { keywordCount, maxKeywords },
+    };
+  }
+
+  const ajv = new Ajv2019({ strict: false, allErrors: true, validateSchema: true });
+  addFormats(ajv);
+  ajv.addMetaSchema(draft7MetaSchema);
+  ajv.addMetaSchema({ ...draft7MetaSchema, $id: 'https://json-schema.org/draft-07/schema#' });
+  const schemaToCompile =
+    normalizedDialect === 'draft-07'
+      ? { ...schema, $schema: 'http://json-schema.org/draft-07/schema#' }
+      : { ...schema, $schema: 'https://json-schema.org/draft/2019-09/schema' };
+  try {
+    ajv.compile(schemaToCompile);
+  } catch (err) {
+    return {
+      ok: false,
+      code: 'schema_compile_failed',
+      message: err instanceof Error ? err.message : String(err),
+      details: { errors: ajv.errors?.slice(0, 10) ?? [] },
+    };
+  }
+  return { ok: true };
+}
+
+export function createCanonicalReferenceResolver(
+  defaultOptions: CanonicalReferenceResolverOptions = {}
+): CanonicalReferenceResolver {
+  const cache = defaultOptions.cache ?? createMemoryCanonicalReferenceCache();
+  const fetchCache = createMemoryFormatSchemaCache();
+
+  async function resolveReference(
+    ref: FormatSchemaRef,
+    options: ResolveCanonicalReferenceOptions
+  ): Promise<CanonicalReferenceResolutionResult> {
+    const merged: CanonicalReferenceResolverOptions = { ...defaultOptions, ...options };
+    const kind = options.kind;
+    const key = ref && typeof ref.uri === 'string' && typeof ref.digest === 'string' ? cacheKey(kind, ref) : undefined;
+    if (key) {
+      const cached = cache.get(key);
+      if (cached) return cloneResolvedResult(cached, true);
+    }
+
+    let fetched: FormatSchemaFetchResult;
+    try {
+      fetched = await fetchFormatSchema(ref, toFetchOptions(merged, fetchCache));
+    } catch (err) {
+      if (err instanceof FormatSchemaFetchError) return mapFetchError(kind, ref ?? {}, err);
+      return fail(kind, ref ?? {}, 'unresolvable', 'network_error', err instanceof Error ? err.message : String(err));
+    }
+
+    let document = fetched.schema;
+    let refCount: number | undefined;
+    let maxDepthSeen: number | undefined;
+
+    if (kind === 'format_schema') {
+      try {
+        const resolved = await resolveSchemaRefs(document, fetched.ref.uri, {
+          maxDepth: merged.maxRefDepth ?? DEFAULT_MAX_REF_DEPTH,
+          maxRefCount: merged.maxRefCount ?? DEFAULT_MAX_REF_COUNT,
+          mirrorHost: merged.mirrorHost,
+          mirrorHosts: merged.mirrorHosts,
+          timeoutMs: merged.timeoutMs,
+          maxBodyBytes: merged.maxBodyBytes,
+          allowInternalReferences: merged.allowInternalReferences,
+          fetchExternal: merged.fetchExternal,
+        });
+        document = resolved.schema;
+        refCount = resolved.refCount;
+        maxDepthSeen = resolved.maxDepthSeen;
+      } catch (err) {
+        if (err instanceof SchemaRefSandboxError) return mapSandboxError(kind, fetched.ref, err);
+        return fail(
+          kind,
+          fetched.ref,
+          'invalid_schema',
+          'fetch_failed',
+          err instanceof Error ? err.message : String(err)
+        );
+      }
+
+      const schemaValidation = validateJsonSchema(document, merged.maxKeywords ?? DEFAULT_MAX_KEYWORDS);
+      if (!schemaValidation.ok) {
+        return fail(kind, fetched.ref, 'invalid_schema', schemaValidation.code, schemaValidation.message, {
+          details: schemaValidation.details,
+        });
+      }
+    }
+
+    const resolved: CanonicalReferenceResolvedResult = {
+      ok: true,
+      status: 'resolved',
+      kind,
+      ref: fetched.ref,
+      document,
+      rawDocument: fetched.schema,
+      fromCache: false,
+      refCount,
+      maxDepthSeen,
+    };
+    if (key) cache.set(key, resolved);
+    return cloneResolvedResult(resolved, false);
+  }
+
+  return {
+    resolveReference,
+    resolveFormatSchema(ref, options = {}) {
+      return resolveReference(ref, { ...options, kind: 'format_schema' });
+    },
+    resolvePlatformExtension(ref, options = {}) {
+      return resolveReference(ref, { ...options, kind: 'platform_extensions' });
+    },
+  };
+}
+
+export async function resolveFormatSchema(
+  ref: FormatSchemaRef,
+  options: CanonicalReferenceResolverOptions = {}
+): Promise<CanonicalReferenceResolutionResult> {
+  return createCanonicalReferenceResolver(options).resolveFormatSchema(ref);
+}
+
+export async function resolvePlatformExtension(
+  ref: FormatSchemaRef,
+  options: CanonicalReferenceResolverOptions = {}
+): Promise<CanonicalReferenceResolutionResult> {
+  return createCanonicalReferenceResolver(options).resolvePlatformExtension(ref);
+}
+
+export const createCanonicalRefResolver = createCanonicalReferenceResolver;

--- a/src/lib/v2/format-schema/sandbox-refs.ts
+++ b/src/lib/v2/format-schema/sandbox-refs.ts
@@ -116,6 +116,12 @@ export interface ResolveSchemaRefsOptions {
    */
   maxBodyBytes?: number;
   /**
+   * Caller-scoped test/dev opt-in for loopback/private HTTP `$ref`
+   * fetches. Production callers should leave this false. IMDS/link-local
+   * metadata endpoints remain blocked by `ssrfSafeFetch`.
+   */
+  allowInternalReferences?: boolean;
+  /**
    * Optional custom fetcher for external `$ref` URIs. Defaults to a
    * built-in that uses `ssrfSafeFetch` with HTTPS-only + 1 MiB cap +
    * 5 s timeout. Callers can swap this for a digest-enforcing variant
@@ -276,6 +282,7 @@ function resolveJsonPointer(root: Record<string, unknown>, pointer: string): unk
 
 interface ResolveContext {
   parentRoot: Record<string, unknown>;
+  currentUri: string;
   parentOrigin: NormalizedOrigin;
   /** Lowercased AAO mirror hosts that are accepted as `$ref` targets. */
   mirrorHosts: ReadonlySet<string>;
@@ -300,9 +307,10 @@ interface ResolveContext {
  */
 function makeDefaultFetcher(
   timeoutMs: number,
-  maxBodyBytes: number
+  maxBodyBytes: number,
+  allowInternalReferences: boolean
 ): (uri: string) => Promise<Record<string, unknown>> {
-  const allowHttp = isInternalProbesAllowed();
+  const allowHttp = allowInternalReferences || isInternalProbesAllowed();
   return async (uri: string) => {
     let res;
     try {
@@ -315,15 +323,17 @@ function makeDefaultFetcher(
       });
     } catch (err) {
       if (err instanceof SsrfRefusedError) {
+        const isTransient =
+          err.code === 'dns_lookup_failed' || err.code === 'dns_empty' || err.code === 'body_exceeds_limit';
         throw new SchemaRefSandboxError('fetch_failed', `\`$ref: ${uri}\` — SSRF guard refused: ${err.message}`, {
           ref: uri,
-          details: { ssrfCode: err.code },
+          details: { ssrfCode: err.code, transient: isTransient },
         });
       }
       throw new SchemaRefSandboxError(
         'fetch_failed',
         `\`$ref: ${uri}\` — ${err instanceof Error ? err.message : String(err)}`,
-        { ref: uri }
+        { ref: uri, details: { transient: true } }
       );
     }
     if (res.status >= 300 && res.status < 400) {
@@ -339,7 +349,7 @@ function makeDefaultFetcher(
     if (res.status < 200 || res.status >= 300) {
       throw new SchemaRefSandboxError('fetch_failed', `\`$ref: ${uri}\` — HTTP ${res.status}`, {
         ref: uri,
-        details: { httpStatus: res.status },
+        details: { httpStatus: res.status, transient: res.status >= 500 },
       });
     }
     let parsed: unknown;
@@ -362,9 +372,9 @@ function makeDefaultFetcher(
 /**
  * Validate that an external (non-`#/`) `$ref` target is in the
  * allowed set: same-origin as parent OR under the AAO mirror namespace.
- * Returns the normalized target origin on success; throws otherwise.
+ * Returns the absolute target URI on success; throws otherwise.
  */
-function assertRefAllowed(ref: string, ctx: ResolveContext): NormalizedOrigin {
+function assertRefAllowed(ref: string, ctx: ResolveContext): string {
   if (ref.toLowerCase().startsWith('file:')) {
     throw new SchemaRefSandboxError(
       'file_scheme_rejected',
@@ -374,18 +384,24 @@ function assertRefAllowed(ref: string, ctx: ResolveContext): NormalizedOrigin {
       }
     );
   }
-  const target = normalizeOrigin(ref);
+  let targetUri: string;
+  try {
+    targetUri = new URL(ref, ctx.currentUri).href;
+  } catch {
+    throw new SchemaRefSandboxError('invalid_ref', `\`$ref: ${ref}\` — could not parse as a URI`, { ref });
+  }
+  const target = normalizeOrigin(targetUri);
   if (!target) {
     throw new SchemaRefSandboxError('invalid_ref', `\`$ref: ${ref}\` — could not parse as a URI`, { ref });
   }
   // Same-origin?
   if (target.origin === ctx.parentOrigin.origin) {
-    return target;
+    return targetUri;
   }
   // AAO mirror namespace? Spec is `https://` only — `http://` mirror
   // refs are rejected even when the host matches.
-  if (ctx.mirrorHosts.has(target.hostname) && ref.toLowerCase().startsWith('https://')) {
-    return target;
+  if (ctx.mirrorHosts.has(target.hostname) && targetUri.toLowerCase().startsWith('https://')) {
+    return targetUri;
   }
   const mirrorList = [...ctx.mirrorHosts].join(', ');
   throw new SchemaRefSandboxError(
@@ -471,19 +487,32 @@ async function walk(node: unknown, depth: number, ctx: ResolveContext): Promise<
       // Parent digest is the trust anchor; same-origin / mirror refs
       // inherit trust. Callers wanting per-`$ref` digest verification
       // pass a custom `fetchExternal` that enforces it.
-      assertRefAllowed(ref, ctx);
+      const refUri = assertRefAllowed(ref, ctx);
       let body: Record<string, unknown>;
-      const cached = ctx.externalCache.get(ref);
+      const cached = ctx.externalCache.get(refUri);
       if (cached) {
         body = cached;
       } else {
-        body = await ctx.fetchExternal(ref);
-        ctx.externalCache.set(ref, body);
+        try {
+          body = await ctx.fetchExternal(refUri);
+        } catch (err) {
+          if (err instanceof SchemaRefSandboxError) throw err;
+          throw new SchemaRefSandboxError(
+            'fetch_failed',
+            `\`$ref: ${refUri}\` — ${err instanceof Error ? err.message : String(err)}`,
+            {
+              ref: refUri,
+              details: { transient: true },
+            }
+          );
+        }
+        ctx.externalCache.set(refUri, body);
       }
       // External fetch opens a new document layer. We treat each
       // external fetch as one depth step.
       const refCtx: ResolveContext = {
         ...ctx,
+        currentUri: refUri,
         // The fetched document becomes the parent for its own intra-doc
         // pointers. Same-origin checks for its own external $refs still
         // use the ORIGINAL parent origin (the trust root). Per spec the
@@ -542,8 +571,10 @@ export async function resolveSchemaRefs(
   }
   const timeoutMs = options.timeoutMs ?? 5_000;
   const maxBodyBytes = options.maxBodyBytes ?? 1024 * 1024;
+  const allowInternalReferences = options.allowInternalReferences === true;
   const ctx: ResolveContext = {
     parentRoot: schema,
+    currentUri: parentUri,
     parentOrigin,
     mirrorHosts: new Set(
       (options.mirrorHosts ?? (options.mirrorHost ? [options.mirrorHost] : DEFAULT_MIRROR_HOSTS)).map(h =>
@@ -552,7 +583,7 @@ export async function resolveSchemaRefs(
     ),
     maxDepth: options.maxDepth ?? DEFAULT_MAX_REF_DEPTH,
     maxRefCount: options.maxRefCount ?? DEFAULT_MAX_REF_COUNT,
-    fetchExternal: options.fetchExternal ?? makeDefaultFetcher(timeoutMs, maxBodyBytes),
+    fetchExternal: options.fetchExternal ?? makeDefaultFetcher(timeoutMs, maxBodyBytes, allowInternalReferences),
     externalCache: new Map(),
     count: { value: 0 },
     maxDepthSeen: { value: 0 },

--- a/test/lib/public-barrel-exports.test.js
+++ b/test/lib/public-barrel-exports.test.js
@@ -27,6 +27,11 @@ import type {
   SyncCreativesPayload as ServerSyncCreativesPayload,
 } from '@adcp/sdk/server';
 import {
+  createCanonicalReferenceResolver,
+  type CanonicalRef,
+  type CanonicalReferenceResolutionResult,
+} from '@adcp/sdk/v2/format-schema';
+import {
   AuthInvalidError,
   AuthMissingError,
   AuthRequiredError,
@@ -58,6 +63,16 @@ const acceptsListPayload = (_payload: ListCreativeFormatsPayload) => {};
 acceptsListPayload({ formats: [] });
 
 const authErrors = [new AuthMissingError(), new AuthInvalidError(), new AuthRequiredError()];
+
+const canonicalResolver = createCanonicalReferenceResolver();
+const canonicalRef: CanonicalRef = {
+  uri: 'https://creative.adcontextprotocol.org/schemas/example.json',
+  digest: 'sha256:0000000000000000000000000000000000000000000000000000000000000000',
+};
+const acceptsCanonicalResult = (_result: CanonicalReferenceResolutionResult) => {};
+void canonicalResolver;
+void canonicalRef;
+void acceptsCanonicalResult;
 
 const scoped = ensureGetProductsCacheScope({ products: [], cache_scope: 'legacy' as string });
 const scope: 'public' | 'account' = scoped.cache_scope;
@@ -105,6 +120,7 @@ void generatedInjectedScope;
             '@adcp/sdk': ['dist/lib/index'],
             '@adcp/sdk/server': ['dist/lib/server/index'],
             '@adcp/sdk/types': ['dist/lib/types/index'],
+            '@adcp/sdk/v2/format-schema': ['dist/lib/v2/format-schema/index'],
           },
         },
         files: ['public-barrel-smoke.ts'],

--- a/test/lib/v2-canonical-reference-resolver.test.js
+++ b/test/lib/v2-canonical-reference-resolver.test.js
@@ -1,0 +1,398 @@
+// High-level canonical reference resolver for AdCP 3.1
+// `format_schema` and `platform_extensions` URI+digest refs.
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const http = require('node:http');
+const { createHash } = require('node:crypto');
+
+process.env.ADCP_ALLOW_INTERNAL_PROBES = '1';
+
+const {
+  createCanonicalReferenceResolver,
+  resolveFormatSchema,
+  resolvePlatformExtension,
+  fetchFormatSchema,
+  _resetFormatSchemaCache,
+} = require('../../dist/lib/v2/format-schema/index.js');
+
+function digest(buf) {
+  return `sha256:${createHash('sha256').update(buf).digest('hex')}`;
+}
+
+function jsonBody(value) {
+  return Buffer.from(JSON.stringify(value));
+}
+
+let server;
+let baseUrl;
+const routes = new Map();
+
+before(async () => {
+  server = http.createServer((req, res) => {
+    const handler = routes.get(req.url);
+    if (!handler) {
+      res.writeHead(404).end();
+      return;
+    }
+    handler(req, res);
+  });
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  baseUrl = `http://127.0.0.1:${server.address().port}`;
+});
+
+after(() => server.close());
+
+function serve(path, body, headers = { 'content-type': 'application/json' }) {
+  const buf = Buffer.isBuffer(body) ? body : jsonBody(body);
+  routes.set(path, (_req, res) => {
+    res.writeHead(200, headers);
+    res.end(buf);
+  });
+  return { uri: `${baseUrl}${path}`, digest: digest(buf), body: buf };
+}
+
+describe('createCanonicalReferenceResolver', () => {
+  test('resolves and caches Draft 2019-09 format_schema results per resolver instance', async () => {
+    let hits = 0;
+    const schema = {
+      $schema: 'https://json-schema.org/draft/2019-09/schema',
+      type: 'object',
+      properties: { headline: { type: 'string' } },
+    };
+    const buf = jsonBody(schema);
+    routes.set('/format-schema.json', (_req, res) => {
+      hits += 1;
+      res.writeHead(200, { 'content-type': 'application/schema+json' });
+      res.end(buf);
+    });
+    const ref = { uri: `${baseUrl}/format-schema.json`, digest: digest(buf) };
+
+    const resolver = createCanonicalReferenceResolver();
+    const first = await resolver.resolveFormatSchema(ref);
+    const second = await resolver.resolveFormatSchema(ref);
+    const otherResolver = createCanonicalReferenceResolver();
+    const third = await otherResolver.resolveFormatSchema(ref);
+
+    assert.strictEqual(first.status, 'resolved');
+    assert.strictEqual(first.ok, true);
+    assert.deepStrictEqual(first.document, schema);
+    assert.strictEqual(first.fromCache, false);
+    assert.strictEqual(second.status, 'resolved');
+    assert.strictEqual(second.fromCache, true);
+    assert.strictEqual(third.status, 'resolved');
+    assert.strictEqual(third.fromCache, false, 'cache is resolver-scoped, not process-global');
+    assert.strictEqual(hits, 2);
+  });
+
+  test('resolves Draft-07 format_schema with same-origin refs before compiling', async () => {
+    const defs = serve('/defs.json', {
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      type: 'string',
+      minLength: 1,
+    });
+    void defs;
+    const parent = serve('/parent.json', {
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      type: 'object',
+      properties: { title: { $ref: `${baseUrl}/defs.json` } },
+    });
+
+    const result = await resolveFormatSchema({ uri: parent.uri, digest: parent.digest });
+    assert.strictEqual(result.status, 'resolved');
+    assert.strictEqual(result.ok, true);
+    assert.deepStrictEqual(result.document.properties.title, {
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      type: 'string',
+      minLength: 1,
+    });
+    assert.strictEqual(result.refCount, 1);
+  });
+
+  test('accepts common Draft-07 and Draft 2019-09 $schema URI variants', async () => {
+    const draft7 = serve('/draft7-https.json', {
+      $schema: 'https://json-schema.org/draft-07/schema#',
+      type: 'object',
+    });
+    const draft2019 = serve('/draft2019-fragment.json', {
+      $schema: 'https://json-schema.org/draft/2019-09/schema#',
+      type: 'object',
+    });
+
+    const a = await resolveFormatSchema({ uri: draft7.uri, digest: draft7.digest }, { allowInternalReferences: true });
+    const b = await resolveFormatSchema(
+      { uri: draft2019.uri, digest: draft2019.digest },
+      { allowInternalReferences: true }
+    );
+
+    assert.strictEqual(a.status, 'resolved');
+    assert.strictEqual(b.status, 'resolved');
+  });
+
+  test('resolves relative same-origin refs against the current document URI', async () => {
+    serve('/defs/relative.json', {
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      type: 'number',
+    });
+    const parent = serve('/schemas/parent-relative.json', {
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      type: 'object',
+      properties: { price: { $ref: '../defs/relative.json' } },
+    });
+
+    const result = await resolveFormatSchema({ uri: parent.uri, digest: parent.digest });
+    assert.strictEqual(result.status, 'resolved');
+    assert.deepStrictEqual(result.document.properties.price, {
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      type: 'number',
+    });
+  });
+
+  test('returns blocked_unsafe_url for nested same-origin redirects', async () => {
+    routes.set('/defs/redirect.json', (_req, res) => {
+      res.writeHead(302, { location: '/defs/relative.json' });
+      res.end();
+    });
+    const parent = serve('/parent-redirect-ref.json', {
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      type: 'object',
+      properties: { x: { $ref: `${baseUrl}/defs/redirect.json` } },
+    });
+
+    const result = await resolveFormatSchema({ uri: parent.uri, digest: parent.digest });
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.status, 'blocked_unsafe_url');
+    assert.strictEqual(result.code, 'fetch_failed');
+    assert.strictEqual(result.retryable, false);
+  });
+
+  test('returns unresolvable for nested same-origin 404 refs', async () => {
+    const parent = serve('/parent-missing-ref.json', {
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      type: 'object',
+      properties: { x: { $ref: `${baseUrl}/defs/missing.json` } },
+    });
+
+    const result = await resolveFormatSchema({ uri: parent.uri, digest: parent.digest });
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.status, 'unresolvable');
+    assert.strictEqual(result.code, 'fetch_failed');
+    assert.strictEqual(result.retryable, true);
+  });
+
+  test('resolves platform_extensions through the same transport and cache path without schema compilation', async () => {
+    const extension = serve('/extension.json', {
+      extends: 'tracking',
+      version: '1.0.0',
+      fields: { pixel_id: { type: 'string' } },
+    });
+    const resolver = createCanonicalReferenceResolver();
+
+    const first = await resolver.resolvePlatformExtension({ uri: extension.uri, digest: extension.digest });
+    const second = await resolver.resolvePlatformExtension({ uri: extension.uri, digest: extension.digest });
+
+    assert.strictEqual(first.status, 'resolved');
+    assert.strictEqual(first.ok, true);
+    assert.strictEqual(first.kind, 'platform_extensions');
+    assert.deepStrictEqual(first.document.extends, 'tracking');
+    assert.strictEqual(second.status, 'resolved');
+    assert.strictEqual(second.fromCache, true);
+  });
+
+  test('returns digest_mismatch instead of throwing on substitution failure', async () => {
+    const ref = serve('/mismatch.json', { type: 'object' });
+    const result = await resolvePlatformExtension({
+      uri: ref.uri,
+      digest: `sha256:${'0'.repeat(64)}`,
+    });
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.status, 'digest_mismatch');
+    assert.strictEqual(result.code, 'digest_mismatch');
+    assert.strictEqual(result.reason, 'digest_mismatch');
+    assert.strictEqual(result.retryable, false);
+  });
+
+  test('returns invalid_schema for malformed JSON Schema documents', async () => {
+    const bad = serve('/bad-schema.json', {
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      type: 'definitely-not-a-json-schema-type',
+    });
+
+    const result = await resolveFormatSchema({ uri: bad.uri, digest: bad.digest });
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.status, 'invalid_schema');
+    assert.strictEqual(result.code, 'schema_compile_failed');
+  });
+
+  test('returns blocked_unsafe_url for unsafe format_schema refs', async () => {
+    const schema = serve('/file-ref.json', {
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      $ref: 'file:///etc/passwd',
+    });
+
+    const result = await resolveFormatSchema({ uri: schema.uri, digest: schema.digest });
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.status, 'blocked_unsafe_url');
+    assert.strictEqual(result.code, 'file_scheme_rejected');
+  });
+
+  test('returns blocked_unsafe_url for metadata-service fetch targets', async () => {
+    const result = await resolvePlatformExtension({
+      uri: 'http://169.254.169.254/latest/meta-data/',
+      digest: `sha256:${'0'.repeat(64)}`,
+    });
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.status, 'blocked_unsafe_url');
+    assert.ok(['ssrf_refused', 'invalid_ref'].includes(result.code));
+  });
+
+  test('returns unresolvable for body-size cap failures', async () => {
+    const big = Buffer.alloc(2048, 'x');
+    routes.set('/too-big.json', (_req, res) => {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(big);
+    });
+
+    const result = await resolvePlatformExtension(
+      { uri: `${baseUrl}/too-big.json`, digest: digest(big) },
+      { maxBodyBytes: 64 }
+    );
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.status, 'unresolvable');
+    assert.strictEqual(result.code, 'body_too_large');
+    assert.strictEqual(result.retryable, true);
+  });
+
+  test('returns unresolvable for DNS failures', async () => {
+    const result = await resolvePlatformExtension({
+      uri: 'https://does-not-resolve.example.invalid/schema.json',
+      digest: `sha256:${'0'.repeat(64)}`,
+    });
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.status, 'unresolvable');
+    assert.strictEqual(result.retryable, true);
+  });
+
+  test('returns unresolvable for timeout failures', async () => {
+    const body = jsonBody({ type: 'object' });
+    routes.set('/slow.json', (_req, res) => {
+      setTimeout(() => {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(body);
+      }, 100);
+    });
+
+    const result = await resolvePlatformExtension(
+      { uri: `${baseUrl}/slow.json`, digest: digest(body) },
+      { timeoutMs: 10 }
+    );
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.status, 'unresolvable');
+    assert.strictEqual(result.retryable, true);
+  });
+
+  test('returns unresolvable for transient nested same-origin ref failures', async () => {
+    routes.set('/defs/flaky.json', (_req, res) => {
+      res.writeHead(500).end('retry later');
+    });
+    const parent = serve('/parent-flaky-ref.json', {
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      type: 'object',
+      properties: { x: { $ref: `${baseUrl}/defs/flaky.json` } },
+    });
+
+    const result = await resolveFormatSchema({ uri: parent.uri, digest: parent.digest });
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.status, 'unresolvable');
+    assert.strictEqual(result.code, 'fetch_failed');
+    assert.strictEqual(result.retryable, true);
+  });
+
+  test('returns unresolvable for nested same-origin ref timeout failures', async () => {
+    const nestedBody = jsonBody({ type: 'string' });
+    routes.set('/defs/slow-nested.json', (_req, res) => {
+      setTimeout(() => {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(nestedBody);
+      }, 100);
+    });
+    const parent = serve('/parent-slow-ref.json', {
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      type: 'object',
+      properties: { x: { $ref: `${baseUrl}/defs/slow-nested.json` } },
+    });
+
+    const result = await resolveFormatSchema({ uri: parent.uri, digest: parent.digest }, { timeoutMs: 10 });
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.status, 'unresolvable');
+    assert.strictEqual(result.code, 'fetch_failed');
+    assert.strictEqual(result.retryable, true);
+  });
+
+  test('returns unresolvable when a custom nested ref fetcher throws', async () => {
+    const parent = serve('/parent-custom-fetcher-throws.json', {
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      type: 'object',
+      properties: { x: { $ref: `${baseUrl}/defs/custom.json` } },
+    });
+
+    const result = await resolveFormatSchema(
+      { uri: parent.uri, digest: parent.digest },
+      {
+        fetchExternal: async () => {
+          throw new Error('registry temporarily unavailable');
+        },
+      }
+    );
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.status, 'unresolvable');
+    assert.strictEqual(result.code, 'fetch_failed');
+    assert.strictEqual(result.retryable, true);
+  });
+
+  test('cached resolver results are immutable snapshots', async () => {
+    const schema = serve('/immutable.json', {
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      type: 'object',
+      properties: { original: { type: 'string' } },
+    });
+    const resolver = createCanonicalReferenceResolver();
+    const first = await resolver.resolveFormatSchema({ uri: schema.uri, digest: schema.digest });
+    assert.strictEqual(first.status, 'resolved');
+    first.document.properties.original.type = 'number';
+    first.ref.uri = 'https://mutated.example/schema.json';
+
+    const second = await resolver.resolveFormatSchema({ uri: schema.uri, digest: schema.digest });
+    assert.strictEqual(second.status, 'resolved');
+    assert.strictEqual(second.fromCache, true);
+    assert.strictEqual(second.ref.uri, schema.uri);
+    assert.strictEqual(second.document.properties.original.type, 'string');
+  });
+
+  test('low-level fetch cache can be reset and returns immutable snapshots', async () => {
+    _resetFormatSchemaCache();
+    let hits = 0;
+    const body = jsonBody({ $schema: 'http://json-schema.org/draft-07/schema#', type: 'object' });
+    routes.set('/fetch-cache.json', (_req, res) => {
+      hits += 1;
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(body);
+    });
+    const ref = { uri: `${baseUrl}/fetch-cache.json`, digest: digest(body) };
+
+    const first = await fetchFormatSchema(ref);
+    first.schema.type = 'array';
+    const second = await fetchFormatSchema(ref);
+    _resetFormatSchemaCache();
+    const third = await fetchFormatSchema(ref);
+
+    assert.strictEqual(second.fromCache, true);
+    assert.strictEqual(second.schema.type, 'object');
+    assert.strictEqual(third.fromCache, false);
+    assert.strictEqual(hits, 2);
+  });
+});


### PR DESCRIPTION
Closes #2063

## Summary
- add a caller-scoped canonical reference resolver for AdCP 3.1 `format_schema` and `platform_extensions` refs
- validate custom format schemas as Draft-07 / Draft 2019-09 after `$ref` sandboxing, with immutable cache snapshots and structured statuses
- cover transient vs policy failures, relative refs, digest mismatch, bundled extension guidance, and public subpath typing

## Expert review
- JavaScript/protocol expert: Go after follow-up fixes
- DX/docs expert: Go after follow-up fixes

## Validation
- `npm run build:lib`
- `npm run format:check`
- `npm run typecheck`
- `node --test --test-timeout=60000 test/lib/v2-canonical-reference-resolver.test.js test/lib/v2-format-schema-fetch.test.js test/lib/v2-format-schema-sandbox-refs.test.js test/lib/net-ssrf-fetch.test.js test/lib/public-barrel-exports.test.js`
- pre-push validation passed