### PR TITLE
feat: hide comply controller from live principals

### DIFF
--- a/.changeset/comply-controller-visibility.md
+++ b/.changeset/comply-controller-visibility.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': minor
+---
+
+Hide `comply_test_controller` and `compliance_testing` discovery from live principals while preserving sandbox/mock controller dispatch and live-target `PERMISSION_DENIED` handling.

--- a/docs/guides/VALIDATE-YOUR-AGENT.md
+++ b/docs/guides/VALIDATE-YOUR-AGENT.md
@@ -268,6 +268,21 @@ controller.register(server);
 
 Omit adapters you don't support — they auto-return `UNKNOWN_SCENARIO`. Throw `TestControllerError('INVALID_TRANSITION', msg, currentState)` when the state machine disallows a transition; the helper emits the typed envelope. `controller.register(server)` auto-emits `capabilities.compliance_testing.scenarios` per AdCP 3.0 — don't declare `compliance_testing` in `supported_protocols`.
 
+If you build with `createAdcpServerFromPlatform`, pass the same adapters as
+`complyTest` instead of calling `controller.register(server)` yourself, keep
+`capabilities.compliance_testing` declared, and make
+`accounts.resolve(undefined, ctx)` resolve the authenticated principal. The
+framework derives `compliance_testing.scenarios`; hides the capability and tool
+from live principals; filters `tools/list`; and makes live direct controller
+calls look like MCP method-not-found. Sandbox/mock principals still see the
+controller. Legacy resolved `{ sandbox: true }` accounts remain visible during
+the migration, and `ADCP_SANDBOX=1` remains a temporary conformance deployment
+bridge that fails closed after a live account is observed. `account.sandbox:
+true` on the request is only an unresolved-target fallback after visibility; it
+never makes a live principal visible and never overrides a resolved live target.
+`PERMISSION_DENIED` is reserved for a visible sandbox/mock principal targeting a
+live or unresolved non-sandbox account.
+
 When a storyboard declares `fixtures.buyer_agents[]`, the runner sends `seed_buyer_agent` before product, pricing, creative, plan, or media-buy seeds. Use it to populate a session- or account-scoped `BuyerAgentRegistry` overlay so `accounts.resolve` / `sync_accounts` gates see the intended per-agent commercial state without inventing a test bearer prefix. Do not store these overlays process-wide by `agent_url` alone; the same compliance runner can seed different buyer-agent states for different sessions or accounts. The shipped AdCP 3.1 billing-gate storyboard still uses a static test-kit precondition until the upstream storyboard switches to this seed; supporting the seed now makes your agent ready for that switch.
 
 ```yaml

--- a/docs/migration-8.0-to-8.1.md
+++ b/docs/migration-8.0-to-8.1.md
@@ -33,6 +33,9 @@
   `AuthMissingError` or `AuthInvalidError`. The SDK still reads legacy
   `AUTH_REQUIRED` responses, and `AuthRequiredError` remains as a deprecated
   `AUTH_REQUIRED` wrapper for source and wire compatibility.
+- `comply_test_controller` is now hidden from live principals. Sandbox/mock
+  principals still see it; targeting a live or unresolved non-sandbox account
+  from that sandbox surface returns `PERMISSION_DENIED`.
 
 ## Signing Surface Changes
 
@@ -181,6 +184,35 @@ default table already escalates `AUTH_MISSING` as an auth problem and
 Buyer code must continue to handle legacy `AUTH_REQUIRED`: older sellers and
 some compatibility helper paths still surface it during the 3.x deprecation
 window.
+
+## Compliance Controller Visibility
+
+AdCP 3.1 tightens deterministic-test discovery: production callers must be
+byte-equivalent to a seller that never wired `comply_test_controller`.
+
+For `createAdcpServerFromPlatform` adopters that supply `complyTest`, the
+framework now resolves the auth-derived principal with
+`platform.accounts.resolve(undefined, ctx)` before answering
+`get_adcp_capabilities`, `tools/list`, or a direct controller call:
+
+| Principal mode | Capability block | `tools/list` | Direct controller call |
+|---|---|---|---|
+| `sandbox` / `mock` | Includes `compliance_testing` | Includes `comply_test_controller` | Dispatches, then target-account gate applies |
+| legacy resolved `{ sandbox: true }` | Includes `compliance_testing` | Includes `comply_test_controller` | Dispatches, then target-account gate applies |
+| `live` / unresolved | Omits `compliance_testing` | Filters the tool | MCP method-not-found |
+
+Within the visible sandbox/mock surface, the target account is resolved from
+the request parameters. If that target resolves to live or cannot be resolved
+as sandbox/mock, the controller returns `PERMISSION_DENIED`; this is the
+intentional denial path for "sandbox caller, non-sandbox target." Keep
+`capabilities.compliance_testing` declared when using `complyTest`, and make
+`accounts.resolve(undefined, ctx)` resolve the authenticated principal if you
+want discovery without the legacy env bridge. Legacy `ADCP_SANDBOX=1` still
+exposes the controller for old conformance deployments, but it fails closed if
+the process has resolved any explicit live-mode account. A buyer-supplied
+`account.sandbox: true` is only consulted as an unresolved target-account
+fallback after the principal visibility check has already passed; it never makes
+a live principal visible and never overrides a resolved live target account.
 
 ### `ProductSchema` is a `ZodObject` again
 

--- a/docs/proposals/lifecycle-state-and-sandbox-authority.md
+++ b/docs/proposals/lifecycle-state-and-sandbox-authority.md
@@ -3,8 +3,13 @@
 ## Status
 
 PARTIALLY IMPLEMENTED — Python ships Phase 1+2 (PRs #483, #487 in
-`adcp-client-python`); JS ships Phase 1 (PR #1453); JS Phase 2 not yet
-implemented. See § Implementation status. Anchors in
+`adcp-client-python`); JS ships the Phase 1 sandbox-authority gate and
+the AdCP 3.1 comply-controller visibility rule: live principals do not
+see `compliance_testing` or `comply_test_controller`, while sandbox/mock
+principals can discover the controller and still get a dispatch-time
+`PERMISSION_DENIED` when their request targets a live or unresolved
+non-sandbox account. Mock-mode
+upstream URL routing remains open. See § Implementation status. Anchors in
 `docs/architecture/adcp-stack.md` (the layered architecture); this doc
 is the SDK-side artifact.
 
@@ -253,6 +258,18 @@ resolver is the seller's authoritative call site for "who is this
 caller, and what tenancy do they have access to?" — answered against
 the seller's tenant store, keyed by the authenticated principal.
 
+AdCP 3.1 adds a visibility rule on top of the dispatch gate:
+production callers must not be able to enumerate the comply controller.
+The JS framework applies that rule by resolving the auth-derived
+principal with `platform.accounts.resolve(undefined, ctx)` for
+`get_adcp_capabilities`, `tools/list`, and direct
+`comply_test_controller` calls. If that principal is not sandbox/mock,
+the capability block is omitted, the tool is filtered from `tools/list`,
+and direct calls fail as MCP method-not-found. Once a sandbox/mock
+principal can see the controller, the per-request target account is
+resolved separately; a target live or unresolved non-sandbox account
+returns `PERMISSION_DENIED`.
+
 Adopters' resolvers MUST NOT spread untrusted input into the resolved
 account. Specifically, an adopter resolver implementation like:
 
@@ -322,12 +339,22 @@ Smallest, most-load-bearing change. Ships first.
   (resolved decision; see § Resolved decisions). `Account.sandbox:
   boolean` either stays as a derived accessor for back-compat or gets
   deprecated outright in a future major.
-- SDK enforces: `comply_test_controller` returns `PERMISSION_DENIED`
-  unless `ctx.account.mode === 'sandbox'` or `ctx.account.mode ===
-  'mock'`. The `ADCP_SANDBOX=1` env-gate becomes vestigial.
-- Add `context.sandbox` fallback for unresolved-account paths
-  (`get_adcp_capabilities`, probe calls, conformance pre-account
-  bootstrap), preserving today's `isSandboxRequest` semantics.
+- SDK enforces the deployment-scoped Path B visibility rule:
+  live/unresolved principals do not see `compliance_testing` in
+  `get_adcp_capabilities`, do not see `comply_test_controller` in
+  `tools/list`, and direct controller calls return MCP method-not-found.
+- Sandbox/mock principals see the controller normally. Once visible,
+  target-account dispatch still requires the target account to resolve
+  to `mode: 'sandbox' | 'mock'`; live or unresolved non-sandbox targets
+  return `PERMISSION_DENIED`.
+- Legacy resolved `{ sandbox: true }` accounts are treated as visible during
+  the migration window, matching the SDK's existing account-mode helper.
+- Legacy fallback is intentionally narrow: `ADCP_SANDBOX=1` exposes the
+  controller for older conformance deployments until explicit
+  `Account.mode` is wired. It fails closed if the process has resolved a
+  live account. The `account.sandbox` wire flag is consulted only for an
+  unresolved target-account ref, never for principal visibility and
+  never over a resolved live account.
 - Migration note: adopters running the conformance harness with
   `ADCP_SANDBOX=1` and otherwise un-flagged accounts must mark
   conformance accounts in their `AccountStore.resolve` implementation.

--- a/examples/hello_creative_adapter_ad_server.ts
+++ b/examples/hello_creative_adapter_ad_server.ts
@@ -378,17 +378,23 @@ class CreativeAdServerAdapter implements DecisioningPlatform<Record<string, neve
   };
 
   accounts: AccountStore<NetworkMeta> = {
-    resolve: async ref => {
+    resolve: async (ref, ctx) => {
       // No-account tools (`previewCreative`, `listCreativeFormats`) hand
       // `undefined` to resolve. Return the default-listing network so
-      // the format catalog query has tenant context.
+      // the format catalog query has tenant context. This worked example
+      // uses the same auth-derived path for the conformance runner's
+      // controller discovery, so authenticated ref-less calls are stamped
+      // sandbox. Production sellers replace this with a real principal →
+      // account lookup and only stamp sandbox for sandbox tenants.
       if (!ref) {
+        if (!ctx?.authInfo) return null;
         const network = await upstream.lookupNetwork(KNOWN_PUBLISHERS[0] ?? 'creative-network.example');
         if (!network) return null;
         return {
           id: network.network_code,
           name: network.display_name,
           status: 'active',
+          mode: 'sandbox',
           brand: { domain: network.adcp_publisher },
           ctx_metadata: { network_code: network.network_code, publisher_domain: network.adcp_publisher },
         };

--- a/examples/hello_seller_adapter_guaranteed.ts
+++ b/examples/hello_seller_adapter_guaranteed.ts
@@ -104,8 +104,8 @@ const ADCP_AUTH_TOKEN = process.env['ADCP_AUTH_TOKEN'] ?? 'sk_harness_do_not_use
 // (adcp#4028). The runner authenticates with this bearer to probe the
 // seller's live-mode denial path. The resolver below stamps
 // `mode: 'live'` on the matching principal so the framework gate inside
-// `createAdcpServerFromPlatform` refuses `comply_test_controller`
-// dispatch with FORBIDDEN. Test-kit value pinned by
+// `createAdcpServerFromPlatform` hides `comply_test_controller` from that
+// principal. Test-kit value pinned by
 // `compliance/cache/<ver>/test-kits/acme-outdoor-live.yaml`.
 //
 // ⚠️ This bearer is published in the open-source SDK and in the public
@@ -571,24 +571,27 @@ class SalesGuaranteedAdapter implements DecisioningPlatform<Record<string, never
         //   (1) the cascade-scenario sandbox arm below, keyed by
         //       `ref.sandbox === true` and stamped with `mode: 'sandbox'`
         //       and a `${SANDBOX_ID_PREFIX}${network_code}` id.
-        //   (2) the production path below, keyed by `ref.brand.domain`
+        //   (2) the conformance principal path here, keyed by auth and
+        //       stamped with `mode: 'sandbox'` but using the bare
+        //       `network_code` id so tasks/get polls match direct-buy tasks.
+        //   (3) the production path below, keyed by `ref.brand.domain`
         //       and stamped with the bare `network_code` id (no mode).
         // The compliance runner exercises path (2) for the
         // sales_guaranteed HITL flow (no `sandbox: true` on the create
         // step's account), so the auth-derived ref-less fallback
-        // returns the matching production account here. Production
-        // sellers key this off `ctx.authInfo.credential.key_id` /
-        // `client_id` against a real tenant store.
+        // returns the matching account id with sandbox principal mode here.
+        // Production sellers key this off `ctx.authInfo.credential.key_id`
+        // / `client_id` against a real tenant store.
         const publisherDomain = 'acmeoutdoor.example';
         const network = await upstream.lookupNetwork(publisherDomain);
         if (!network) return null;
         // Live-mode probe principal (comply_controller_mode_gate
         // storyboard) — stamp `mode: 'live'` so the framework gate inside
-        // `createAdcpServerFromPlatform` refuses `comply_test_controller`
-        // dispatch with FORBIDDEN. The probe never reaches a mutating
-        // dispatch path; the live-mode caller is denied before scenario
-        // execution. Production sellers source `mode` from their tenant
-        // store, not from the principal name.
+        // `createAdcpServerFromPlatform` hides `comply_test_controller`
+        // from that principal. The probe never reaches a mutating dispatch
+        // path; the live-mode caller is denied before scenario execution.
+        // Production sellers source `mode` from their tenant store, not
+        // from the principal name.
         //
         // Detection: ResolvedAuthInfo doesn't surface the principal name
         // directly (the framework propagates AuthPrincipal.principal as
@@ -602,7 +605,7 @@ class SalesGuaranteedAdapter implements DecisioningPlatform<Record<string, never
           name: network.display_name,
           status: 'active',
           brand: { domain: network.adcp_publisher },
-          ...(isLiveModeProbe ? { mode: 'live' as const } : {}),
+          mode: isLiveModeProbe ? 'live' : 'sandbox',
           ctx_metadata: {
             network_code: network.network_code,
             publisher_domain: network.adcp_publisher,
@@ -1246,10 +1249,11 @@ serve(
       // `createAdcpServerFromPlatform` resolves the calling principal
       // through `accounts.resolve` and admits only when the resolved
       // account's `mode` is `'sandbox'` or `'mock'` (per `Account.mode`
-      // in AdCP 6.7+). The synthesis branch in `accounts.resolve` above
-      // stamps `mode: 'sandbox'` on cascade-scenario refs; production
-      // refs flow through the live path with the field unset (default
-      // `'live'`), so the framework gate refuses dispatch for them.
+      // in AdCP 6.7+). The auth-derived conformance branch and the
+      // cascade-scenario ref branch in `accounts.resolve` above stamp
+      // `mode: 'sandbox'`; production refs flow through the live path with
+      // the field unset (default `'live'`), so the framework gate hides the
+      // controller for them.
       // See `docs/proposals/lifecycle-state-and-sandbox-authority.md`.
       complyTest: {
         seed: {
@@ -1306,8 +1310,8 @@ serve(
         [ADCP_AUTH_TOKEN]: { principal: 'compliance-runner' },
         // Live-mode probe principal — see comply_controller_mode_gate
         // storyboard. The resolver below stamps `mode: 'live'` when this
-        // bearer is presented; the framework gate then refuses
-        // comply_test_controller dispatch with FORBIDDEN.
+        // bearer is presented; the framework gate then hides
+        // comply_test_controller from that principal.
         [ADCP_LIVE_MODE_AUTH_TOKEN]: { principal: LIVE_MODE_PROBE_PRINCIPAL },
       },
     }),

--- a/examples/hello_signals_adapter_marketplace.ts
+++ b/examples/hello_signals_adapter_marketplace.ts
@@ -494,20 +494,52 @@ class SignalMarketplaceAdapter implements DecisioningPlatform<Record<string, nev
      *  tenant resolution against the durable buyer-agent identity here
      *  rather than re-deriving from the credential. */
     resolve: async (ref, ctx) => {
-      if (!ref) return null;
+      let effectiveRef = ref;
+      if (!effectiveRef) {
+        const inputAccount = readRequestAccountRef(ctx?.input as Record<string, unknown> | undefined);
+        // TEST-ONLY: comply_test_controller discovery and account-less
+        // controller calls resolve through this auth-derived path. When the
+        // caller supplied an account in the controller payload/context, use
+        // it; otherwise fall back to the single operator this worked example
+        // uses for the conformance harness. Production sellers replace this
+        // with a real principal → sandbox-account lookup.
+        if (inputAccount != null && 'account_id' in inputAccount) return null;
+        const inputBrand = inputAccount?.['brand'];
+        const inputBrandDomain =
+          inputBrand != null && typeof inputBrand === 'object'
+            ? (inputBrand as { domain?: unknown }).domain
+            : undefined;
+        const inputOperator = inputAccount?.['operator'];
+        const inputSandbox = inputAccount?.['sandbox'];
+        effectiveRef =
+          typeof inputOperator === 'string'
+            ? {
+                brand: { domain: typeof inputBrandDomain === 'string' ? inputBrandDomain : 'acmeoutdoor.example' },
+                operator: inputOperator,
+                ...(typeof inputSandbox === 'boolean' && { sandbox: inputSandbox }),
+              }
+            : {
+                brand: { domain: 'acmeoutdoor.example' },
+                operator: 'pinnacle-agency.example',
+                sandbox: true,
+              };
+      }
+      if (!effectiveRef) return null;
       // AccountReference discriminated union: `{ account_id }` post-sync,
       // or `{ brand, operator, sandbox? }` on initial discovery. Mock has
       // no account_id index; SWAP: production keeps an account_id →
       // operator_id index populated during list_accounts.
-      if ('account_id' in ref) return null;
-      const adcpOperator = ref.operator;
+      if ('account_id' in effectiveRef) return null;
+      const adcpOperator = effectiveRef.operator;
       if (!adcpOperator) return null;
       // Optional: gate the operator on the buyer agent's allowed_brands /
       // billing_capabilities. Sellers who don't cross-check operator vs.
       // agent here let any onboarded agent operate on any operator —
       // legitimate for some marketplaces, a leak for others.
       const buyerAgent =
-        ctx?.agent && ctx.input ? overlayBuyerAgent(ctx.agent, ctx.input, ref as Record<string, unknown>) : ctx?.agent;
+        ctx?.agent && ctx.input
+          ? overlayBuyerAgent(ctx.agent, ctx.input, effectiveRef as Record<string, unknown>)
+          : ctx?.agent;
       if (buyerAgent?.status === 'suspended' || buyerAgent?.status === 'blocked') {
         throw new AdcpError(buyerAgent.status === 'suspended' ? 'AGENT_SUSPENDED' : 'AGENT_BLOCKED', {
           message:
@@ -524,6 +556,7 @@ class SignalMarketplaceAdapter implements DecisioningPlatform<Record<string, nev
         name: adcpOperator,
         status: 'active',
         operator: adcpOperator,
+        mode: 'sandbox',
         ctx_metadata: { operator_id: operatorId },
         // The upstream here is the AdCP mock-server. Every account it
         // returns is a sandbox account by definition. Production

--- a/src/lib/server/a2a-adapter.ts
+++ b/src/lib/server/a2a-adapter.ts
@@ -126,7 +126,9 @@ export interface A2AAgentCardOverrides {
    * Override the auto-generated skills list. When omitted the adapter
    * derives one `AgentSkill` per registered AdCP tool from the server's
    * capability object. Supply this to add descriptions, examples, tags,
-   * or per-skill input/output modes the SDK can't infer.
+   * or per-skill input/output modes the SDK can't infer. Framework-private
+   * tools such as `comply_test_controller` are still filtered from the public
+   * A2A agent card.
    */
   skills?: AgentSkill[];
 
@@ -580,6 +582,7 @@ class AdcpA2AAgentExecutor implements AgentExecutor {
 
 const DEFAULT_MODES = ['application/json'] as const;
 const DEFAULT_PROTOCOL_VERSION = '0.3.0';
+const PUBLIC_AGENT_CARD_EXCLUDED_SKILLS = new Set(['get_adcp_capabilities', 'comply_test_controller']);
 
 /**
  * Derive one `AgentSkill` per registered AdCP tool. Skills without
@@ -599,12 +602,23 @@ function deriveSkills(toolNames: string[]): AgentSkill[] {
 function listRegisteredTools(server: AdcpServer): string[] {
   const sdk = getSdkServer(server);
   if (!sdk) return [];
-  return listRegisteredToolNames(sdk).filter(name => name !== 'get_adcp_capabilities');
+  return listRegisteredToolNames(sdk).filter(name => !PUBLIC_AGENT_CARD_EXCLUDED_SKILLS.has(name));
+}
+
+function filterPublicAgentCardSkills(skills: AgentSkill[]): AgentSkill[] {
+  return skills.filter(skill => {
+    const id = typeof skill.id === 'string' ? skill.id : undefined;
+    const name = typeof skill.name === 'string' ? skill.name : undefined;
+    return !(
+      (id != null && PUBLIC_AGENT_CARD_EXCLUDED_SKILLS.has(id)) ||
+      (name != null && PUBLIC_AGENT_CARD_EXCLUDED_SKILLS.has(name))
+    );
+  });
 }
 
 function buildAgentCard(server: AdcpServer, overrides: A2AAgentCardOverrides): AgentCard {
   const tools = listRegisteredTools(server);
-  const skills = overrides.skills ?? deriveSkills(tools);
+  const skills = filterPublicAgentCardSkills(overrides.skills ?? deriveSkills(tools));
 
   const card: AgentCard = {
     name: overrides.name,

--- a/src/lib/server/adcp-server.ts
+++ b/src/lib/server/adcp-server.ts
@@ -448,6 +448,25 @@ function getRegisteredTool(server: McpServer, name: string): RegisteredTool | un
 }
 
 /**
+ * Wrap a registered MCP tool handler without changing the tool definition
+ * advertised by the SDK server.
+ *
+ * @internal
+ * @remarks Pokes an SDK private field — see the "Private-field access" note above.
+ */
+export function wrapRegisteredToolHandler(
+  server: McpServer,
+  name: string,
+  wrapper: (orig: RegisteredTool['handler'], args: unknown, extra: unknown) => unknown | Promise<unknown>
+): boolean {
+  const tool = getRegisteredTool(server, name);
+  if (!tool) return false;
+  const orig = tool.handler;
+  tool.handler = (args, extra) => wrapper(orig, args, extra);
+  return true;
+}
+
+/**
  * Enumerate the tool names registered on the underlying SDK server.
  * Used by transport adapters that need to derive discovery metadata
  * (agent cards, capability listings) from the registered surface
@@ -465,6 +484,29 @@ function getRequestHandler(
   method: string
 ): ((request: { method: string; params?: unknown }, extra: unknown) => unknown | Promise<unknown>) | undefined {
   return (server as unknown as McpServerPrivates).server?._requestHandlers?.get(method);
+}
+
+/**
+ * Wrap an SDK request handler such as `tools/list` while preserving the
+ * original handler's request/extra contract.
+ *
+ * @internal
+ * @remarks Pokes an SDK private field — see the "Private-field access" note above.
+ */
+export function wrapSdkRequestHandler(
+  server: McpServer,
+  method: string,
+  wrapper: (
+    orig: McpRequestHandler,
+    req: { method: string; params?: unknown },
+    extra: unknown
+  ) => unknown | Promise<unknown>
+): boolean {
+  const handlers = (server as unknown as McpServerPrivates).server?._requestHandlers;
+  const orig = handlers?.get(method);
+  if (!handlers || !orig) return false;
+  handlers.set(method, (req, extra) => wrapper(orig, req, extra));
+  return true;
 }
 
 /**

--- a/src/lib/server/decisioning/capabilities.ts
+++ b/src/lib/server/decisioning/capabilities.ts
@@ -199,9 +199,12 @@ export interface DecisioningCapabilities<TConfig = unknown> {
 
   /**
    * Compliance-testing capabilities. The presence of this block declares
-   * the agent supports deterministic state-machine testing via the
-   * `comply_test_controller` wire tool. Omit entirely if the agent
-   * doesn't support compliance testing.
+   * the deployment supports deterministic state-machine testing via the
+   * `comply_test_controller` wire tool. Keep this block declared when using
+   * `createAdcpServerFromPlatform(..., { complyTest })`; the framework makes
+   * live principals byte-identical to a production seller that never wired the
+   * controller by hiding this block, filtering `tools/list`, and returning MCP
+   * method-not-found for direct live calls.
    *
    * When this block is present, `createAdcpServerFromPlatform` REQUIRES
    * `opts.complyTest` (the `ComplyControllerConfig` adapter set) to be
@@ -211,9 +214,8 @@ export interface DecisioningCapabilities<TConfig = unknown> {
    * Inversely, supplying `opts.complyTest` without declaring this
    * capability is also caught — the framework derives `scenarios` from
    * the declared force/simulate/seed adapters and emits the discovery
-   * field on `get_adcp_capabilities` automatically. Adopters who want
-   * to explicitly declare a narrower or wider scenarios list can supply
-   * this block; otherwise the auto-derivation wins.
+   * field on `get_adcp_capabilities` automatically for sandbox/mock
+   * principals. Live principals do not see the block.
    */
   compliance_testing?: ComplianceTestingCapabilities;
 

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -50,6 +50,7 @@
  */
 
 import { randomUUID } from 'node:crypto';
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import type { AdcpServer } from '../../adcp-server';
 import {
   createAdcpServer,
@@ -150,12 +151,12 @@ import { createInMemoryStatusChangeBus, type StatusChangeBus, type PublishStatus
 import { createComplyController, type ComplyControllerConfig } from '../../../testing/comply-controller';
 import type { TestControllerBridge } from '../../test-controller-bridge';
 import { mergeSeedProduct } from '../../../testing/seed-merge';
-import { getSdkServer } from '../../adcp-server';
+import { getSdkServer, wrapRegisteredToolHandler, wrapSdkRequestHandler } from '../../adcp-server';
 import { isSandboxOrMockAccount } from '../../account-mode';
-import { toMcpResponse } from '../../test-controller';
 import { recordResolvedAccountMode, hasObservedLiveMode } from './observed-modes';
 import type { Product } from '../../../types/tools.generated';
 import { normalizeErrors } from '../../normalize-errors';
+import { redactCredentialPatterns } from '../../redact';
 
 /**
  * Apply `normalizeErrors` to a sync_creatives row's optional `errors`
@@ -448,9 +449,10 @@ export interface CreateAdcpServerFromPlatformOptions extends Omit<
 
   /**
    * `comply_test_controller` adapter set. When supplied, the framework
-   * registers the wire tool automatically by composing `createComplyController`
-   * (`@adcp/sdk/testing`) with the adopter's adapters and calling
-   * `controller.register(server)` after platform handlers wire up.
+   * composes `createComplyController` (`@adcp/sdk/testing`) with the adopter's
+   * adapters and registers the wire tool after platform handlers wire up. MCP
+   * registration is framework-owned so principal visibility, `tools/list`
+   * filtering, and direct-call method-not-found behavior can be enforced.
    *
    * Adopter declares the scenarios they support — `seed: { product, … }`,
    * `force: { creative_status, … }`, `simulate: { delivery, … }`. The
@@ -459,13 +461,16 @@ export interface CreateAdcpServerFromPlatformOptions extends Omit<
    * `get_adcp_capabilities` so conformance harnesses see what's
    * supported.
    *
-   * **Sandbox gating.** `complyTest.sandboxGate(input)` is the per-request
-   * gate; tools/list visibility is controlled by whether you supply
-   * `complyTest` at all. Production agents typically gate registration
-   * itself on `process.env.ADCP_SANDBOX === '1'` or wrap construction in
-   * an environment check; the helper logs a loud warning if registered
-   * without a gate AND without an env-flag escape (matches the standalone
-   * `createComplyController` warning behavior).
+   * **Deployment + sandbox gating.** Supplying `complyTest` wires the
+   * controller for sandbox/conformance deployments. The framework then hides
+   * the capability block, filters `tools/list`, and returns MCP method-not-
+   * found for direct controller calls unless the auth-derived principal
+   * resolves to `mode: 'sandbox' | 'mock'` (or legacy resolved
+   * `sandbox: true`, or the legacy deployment bridge `ADCP_SANDBOX=1` is set).
+   * Within a visible sandbox/mock deployment, target-account dispatch still
+   * refuses live or unresolved non-sandbox accounts with `PERMISSION_DENIED`;
+   * a buyer-supplied `account.sandbox: true` is only an unresolved-target
+   * fallback and never overrides a resolved live account.
    *
    * **Capability-vs-adapter consistency.** Both directions are enforced:
    *
@@ -1420,6 +1425,110 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
   };
 
   const server = createAdcpServer(config);
+  const mcp = getSdkServer(server);
+  type McpExtra = { authInfo?: ResolvedAuthInfo } | undefined;
+
+  const resolveComplyBuyerAgent = async (
+    extra: McpExtra,
+    input?: Readonly<Record<string, unknown>>
+  ): Promise<BuyerAgent | undefined> => {
+    if (platform.agentRegistry === undefined) return undefined;
+    try {
+      const inboundCredential = extra?.authInfo?.extra?.credential;
+      const credential =
+        extra?.authInfo?.credential ?? (inboundCredential as ResolvedAuthInfo['credential'] | undefined);
+      const resolved = await platform.agentRegistry.resolve({
+        ...(credential !== undefined && { credential }),
+        ...(extra?.authInfo?.extra !== undefined && { extra: extra.authInfo.extra }),
+        ...(input !== undefined && { input }),
+      });
+      if (resolved == null) return undefined;
+      if (!Object.isFrozen(resolved)) {
+        if (resolved.billing_capabilities instanceof Set) {
+          Object.freeze(resolved.billing_capabilities);
+        }
+        Object.freeze(resolved);
+      }
+      return resolved;
+    } catch (err) {
+      fwLogger.warn?.('Buyer-agent registry resolution failed during comply controller visibility check', {
+        error: redactCredentialPatterns(err instanceof Error ? err.message : String(err)),
+      });
+      return undefined;
+    }
+  };
+
+  const resolveComplyControllerVisible = async (
+    extra: McpExtra,
+    toolName?: string,
+    input?: Readonly<Record<string, unknown>>
+  ): Promise<boolean> => {
+    const agent = await resolveComplyBuyerAgent(extra, input);
+    let principalAccount: Account | null = null;
+    try {
+      principalAccount = await platform.accounts.resolve(
+        undefined,
+        toResolveCtx(
+          {
+            ...(extra?.authInfo !== undefined && { authInfo: extra.authInfo }),
+            ...(agent !== undefined && { agent }),
+          },
+          toolName,
+          input
+        )
+      );
+    } catch {
+      principalAccount = null;
+    }
+
+    recordResolvedAccountMode(principalAccount);
+
+    if (isSandboxOrMockAccount(principalAccount)) return true;
+
+    if (process.env.ADCP_SANDBOX === '1') {
+      if (hasObservedLiveMode()) {
+        throw new Error(
+          'comply_test_controller: ADCP_SANDBOX=1 is set but this process has resolved at least one ' +
+            'live-mode account from platform.accounts.resolve. Remove ADCP_SANDBOX from your prod ' +
+            'environment; gate the controller via mode: "sandbox" on resolved sandbox accounts instead. ' +
+            'See docs/proposals/lifecycle-state-and-sandbox-authority.md.'
+        );
+      }
+      return true;
+    }
+
+    return false;
+  };
+
+  if (mcp != null && hasComplianceTestingProjection) {
+    const wrappedCapabilities = wrapRegisteredToolHandler(mcp, 'get_adcp_capabilities', async (orig, args, extra) => {
+      const response = await orig(args, extra);
+      if (
+        await resolveComplyControllerVisible(
+          extra as McpExtra,
+          'get_adcp_capabilities',
+          args as Readonly<Record<string, unknown>>
+        )
+      ) {
+        return response;
+      }
+      if (response == null || typeof response !== 'object') return response;
+
+      const structured = (response as { structuredContent?: unknown }).structuredContent;
+      if (structured == null || typeof structured !== 'object') return response;
+      if (!Object.hasOwn(structured, 'compliance_testing')) return response;
+
+      const nextStructured = { ...(structured as Record<string, unknown>) };
+      delete nextStructured['compliance_testing'];
+      return { ...(response as Record<string, unknown>), structuredContent: nextStructured };
+    });
+    if (!wrappedCapabilities) {
+      throw new Error(
+        'createAdcpServerFromPlatform: failed to wrap get_adcp_capabilities for comply_test_controller visibility. ' +
+          'The MCP SDK registered-tool internals may have changed.'
+      );
+    }
+  }
 
   // Wire `comply_test_controller` if the adopter supplied adapters.
   // `createComplyController` builds the tool definition + handler + raw
@@ -1522,25 +1631,23 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
     // `account.sandbox === true` on the wire. The resolver is the only
     // thing that names the account's mode; the gate refuses dispatch when
     // mode is `live` (or the resolver fails to produce an account, modulo
-    // the env / context fallbacks below).
+    // the narrow fallbacks below).
     //
     // Fallback paths (deprecated):
-    //   - `context.sandbox === true` admits when no account resolved. Useful
-    //     during the migration window for adopters whose wire shape carries
-    //     sandbox routing in `context` but whose resolver isn't yet returning
-    //     `mode: 'sandbox'`.
-    //   - `process.env.ADCP_SANDBOX === '1'` admits unconditionally — the
-    //     historical pattern. KEPT for back-compat so existing test platforms
-    //     don't break on upgrade. Fails closed if the same process has ever
-    //     resolved an explicit `mode: 'live'` account from the resolver: that
-    //     pairing is a misconfiguration (env var should be unset on prod) and
-    //     leaving it open re-exposes the live principal we just gated against.
+    //   - `account.sandbox === true` admits only for unresolved target-account
+    //     refs after a sandbox/mock principal has already passed the discovery
+    //     visibility gate. A buyer wire claim never overrides a resolved live
+    //     account and is never used for principal visibility.
+    //   - `process.env.ADCP_SANDBOX === '1'` admits the principal visibility
+    //     check and target dispatch for legacy conformance deployments. It
+    //     fails closed if the same process has ever resolved an explicit
+    //     `mode: 'live'` account from the resolver: that pairing is a
+    //     misconfiguration (env var should be unset on prod) and leaving it
+    //     open re-exposes the live principal we just gated against.
     //
-    // `list_scenarios` is exempt — it's the discovery probe used by buyer
-    // tooling to distinguish "controller wired but locked" from "controller
-    // missing entirely". Read-only and reveals nothing beyond which scenarios
-    // the adopter advertised in capabilities.
-    const mcp = getSdkServer(server);
+    // `list_scenarios` is exempt from the target-account gate once the
+    // principal can see the controller. Read-only and reveals nothing beyond
+    // which scenarios the adopter advertised in capabilities.
     if (mcp == null) {
       // Non-MCP server — fall back to the controller's own registration so
       // adopters wiring a custom transport keep the v5 behavior. The gate is
@@ -1585,6 +1692,10 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
           inputSchema: gatedInputSchema,
         },
         (async (input: Record<string, unknown>, extra: { authInfo?: ResolvedAuthInfo } | undefined) => {
+          if (!(await resolveComplyControllerVisible(extra, 'comply_test_controller', input))) {
+            throw new McpError(ErrorCode.MethodNotFound, 'Method not found');
+          }
+
           // Probe exempt — capability discovery, no state mutation.
           if (input.scenario === 'list_scenarios') {
             return controller.handle(input);
@@ -1598,10 +1709,18 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
 
           let resolvedAccount: Account | null = null;
           try {
-            resolvedAccount = await platform.accounts.resolve(accountRef, {
-              ...(extra?.authInfo !== undefined && { authInfo: extra.authInfo }),
-              toolName: 'comply_test_controller',
-            });
+            const agent = await resolveComplyBuyerAgent(extra, input);
+            resolvedAccount = await platform.accounts.resolve(
+              accountRef,
+              toResolveCtx(
+                {
+                  ...(extra?.authInfo !== undefined && { authInfo: extra.authInfo }),
+                  ...(agent !== undefined && { agent }),
+                },
+                'comply_test_controller',
+                input
+              )
+            );
           } catch {
             // Resolver failures fall through to the wire-ref / env fallbacks.
             // Treat as "no account resolved" — fail-closed by default unless a
@@ -1641,10 +1760,10 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
           const allowed = accountIsSandbox || (resolvedAccount == null && refSandbox) || envSandbox;
 
           if (!allowed) {
-            // Echo the request's context (and ext, if present) onto the
-            // refusal so callers can correlate. The comply_controller_mode_gate
-            // storyboard (adcp#4028) asserts `context.correlation_id` is
-            // returned unchanged on the FORBIDDEN response.
+            // Refuse with the standard AdCP permission code once the
+            // sandbox/mock principal can see the controller but the target
+            // account is live or unresolved. Live principals never reach
+            // this branch: they get MCP method-not-found above.
             //
             // `context` and `ext` are open-object on the request schema, so a
             // hostile caller could stuff arbitrarily large payloads. Self-
@@ -1664,21 +1783,71 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
             };
             const requestContext = safeEcho((input as { context?: unknown }).context);
             const requestExt = safeEcho((input as { ext?: unknown }).ext);
-            return toMcpResponse({
-              status: 'failed',
-              success: false,
-              error: 'FORBIDDEN',
-              error_detail:
-                'comply_test_controller requires a sandbox or mock account; ' +
-                'resolved account is in live mode (or no account resolved).',
-              ...(requestContext !== undefined && { context: requestContext }),
-              ...(requestExt !== undefined && { ext: requestExt }),
+            const response = adcpError('PERMISSION_DENIED', {
+              message:
+                'comply_test_controller requires a sandbox or mock target account; ' +
+                'resolved target account is live or unresolved.',
+              recovery: 'terminal',
+              details: {
+                scope: 'sandbox-gate',
+                tool: 'comply_test_controller',
+                reason: 'sandbox-or-mock-required',
+              },
             });
+            if (requestContext !== undefined || requestExt !== undefined) {
+              const structured = response.structuredContent as Record<string, unknown>;
+              if (requestContext !== undefined) structured['context'] = requestContext;
+              if (requestExt !== undefined) structured['ext'] = requestExt;
+              response.content = [{ type: 'text', text: JSON.stringify(structured) }];
+            }
+            return response;
           }
 
           return controller.handle(input);
         }) as Parameters<typeof mcp.registerTool>[2]
       );
+
+      const wrappedToolsCall = wrapSdkRequestHandler(mcp, 'tools/call', async (orig, req, extra) => {
+        const params = (req.params ?? {}) as { name?: unknown; arguments?: unknown };
+        if (params.name === 'comply_test_controller') {
+          const input =
+            params.arguments != null && typeof params.arguments === 'object'
+              ? (params.arguments as Readonly<Record<string, unknown>>)
+              : undefined;
+          if (!(await resolveComplyControllerVisible(extra as McpExtra, 'comply_test_controller', input))) {
+            throw new McpError(ErrorCode.MethodNotFound, 'Method not found');
+          }
+        }
+        return orig(req, extra);
+      });
+      if (!wrappedToolsCall) {
+        throw new Error(
+          'createAdcpServerFromPlatform: failed to wrap MCP tools/call for comply_test_controller visibility. ' +
+            'The MCP SDK request-handler internals may have changed.'
+        );
+      }
+
+      const wrappedToolsList = wrapSdkRequestHandler(mcp, 'tools/list', async (orig, req, extra) => {
+        const response = await orig(req, extra);
+        const input =
+          req.params != null && typeof req.params === 'object'
+            ? (req.params as Readonly<Record<string, unknown>>)
+            : undefined;
+        if (await resolveComplyControllerVisible(extra as McpExtra, undefined, input)) return response;
+        if (response == null || typeof response !== 'object') return response;
+        const tools = (response as { tools?: unknown }).tools;
+        if (!Array.isArray(tools)) return response;
+        return {
+          ...(response as Record<string, unknown>),
+          tools: tools.filter(tool => (tool as { name?: unknown } | null)?.name !== 'comply_test_controller'),
+        };
+      });
+      if (!wrappedToolsList) {
+        throw new Error(
+          'createAdcpServerFromPlatform: failed to wrap MCP tools/list for comply_test_controller visibility. ' +
+            'The MCP SDK request-handler internals may have changed.'
+        );
+      }
     }
   }
 
@@ -2850,12 +3019,12 @@ function makeCtxFor(ctxMetadataStore?: CtxMetadataStore): CtxForFn {
  */
 function toResolveCtx(
   ctx: { authInfo?: ResolvedAuthInfo; agent?: BuyerAgent },
-  toolName: string,
+  toolName: string | undefined,
   input?: Readonly<Record<string, unknown>>
 ): ResolveContext {
   return {
     ...(ctx.authInfo !== undefined && { authInfo: ctx.authInfo }),
-    toolName,
+    ...(toolName !== undefined && { toolName }),
     ...(ctx.agent != null && { agent: ctx.agent }),
     ...(input != null && { input }),
   };

--- a/test/examples/hello-seller-adapter-guaranteed.test.js
+++ b/test/examples/hello-seller-adapter-guaranteed.test.js
@@ -25,6 +25,8 @@
 const path = require('node:path');
 const assert = require('node:assert/strict');
 const test = require('node:test');
+const { Client: McpClient } = require('@modelcontextprotocol/sdk/client/index.js');
+const { StreamableHTTPClientTransport } = require('@modelcontextprotocol/sdk/client/streamableHttp.js');
 const { runHelloAdapterGates } = require('./_helpers/runHelloAdapterGates');
 
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
@@ -37,6 +39,7 @@ const REPO_ROOT = path.resolve(__dirname, '..', '..');
  * not silent).
  */
 const EXPECTED_FAILURES = [];
+const ADCP_LIVE_MODE_AUTH_TOKEN = 'demo-acme-outdoor-live-v1';
 
 function isExpectedFailure(f) {
   return EXPECTED_FAILURES.some(e => e.storyboard_id === (f.storyboard_id || '') && e.step_id === (f.step_id || ''));
@@ -64,17 +67,30 @@ runHelloAdapterGates({
     'GET /v1/orders/{id}',
     'POST /v1/orders/{id}/lineitems',
   ],
-  // adcp#4028 denial gate — verify the framework refuses comply_test_controller
-  // dispatch when the resolver stamps mode: 'live'. The storyboard uses
-  // `auth.from_test_kit: true` so the grader resolves the bearer from the
-  // test-kit (acme-outdoor-live → demo-acme-outdoor-live-v1); the adapter's
-  // resolver recognises that principal and stamps mode: 'live', triggering the
-  // framework's FORBIDDEN refusal in createAdcpServerFromPlatform.
-  extraStoryboards: [
+  extraMcpAssertions: [
     {
-      id: 'comply_controller_mode_gate',
-      label: 'denies live-mode comply_test_controller calls with FORBIDDEN (adcp#4028)',
-      testKitPath: path.join(REPO_ROOT, 'compliance', 'cache', 'latest', 'test-kits', 'acme-outdoor-live.yaml'),
+      label: 'hides comply_test_controller from live-mode principals over MCP (adcp#4028)',
+      run: async ({ agentUrl, authToken }) => {
+        const sandboxList = await withMcpClient(agentUrl, authToken, client => client.listTools());
+        assert.ok(
+          sandboxList.tools.some(tool => tool.name === 'comply_test_controller'),
+          'conformance sandbox principal should discover comply_test_controller'
+        );
+
+        const liveList = await withMcpClient(agentUrl, ADCP_LIVE_MODE_AUTH_TOKEN, client => client.listTools());
+        assert.ok(
+          !liveList.tools.some(tool => tool.name === 'comply_test_controller'),
+          'live-mode principal must not discover comply_test_controller'
+        );
+
+        await assert.rejects(
+          () =>
+            withMcpClient(agentUrl, ADCP_LIVE_MODE_AUTH_TOKEN, client =>
+              client.callTool({ name: 'comply_test_controller', arguments: {} })
+            ),
+          err => err?.code === -32601 && /Method not found/.test(err.message)
+        );
+      },
     },
   ],
   filterFailures: grader => {
@@ -100,3 +116,20 @@ runHelloAdapterGates({
 // Surface assert is a no-op if `node --test` doesn't import it; placed at
 // module top-level to keep the gate self-checking even without invocation.
 void test;
+
+async function withMcpClient(agentUrl, authToken, fn) {
+  const transport = new StreamableHTTPClientTransport(new URL(agentUrl), {
+    requestInit: {
+      headers: {
+        Authorization: `Bearer ${authToken}`,
+      },
+    },
+  });
+  const client = new McpClient({ name: 'hello-seller-adapter-guaranteed-test', version: '0' }, { capabilities: {} });
+  await client.connect(transport);
+  try {
+    return await fn(client);
+  } finally {
+    await client.close().catch(() => {});
+  }
+}

--- a/test/server-a2a-adapter.test.js
+++ b/test/server-a2a-adapter.test.js
@@ -3,6 +3,8 @@ const assert = require('node:assert');
 const express = require('express');
 const { createAdcpServer: _createAdcpServer } = require('../dist/lib/server/create-adcp-server');
 const { createA2AAdapter } = require('../dist/lib/server/a2a-adapter');
+const { createAdcpServerFromPlatform } = require('../dist/lib/server/decisioning/runtime/from-platform');
+const { createInMemoryTaskRegistry } = require('../dist/lib/server/decisioning/runtime/task-registry');
 const { InMemoryStateStore } = require('../dist/lib/server/state-store');
 const { adcpError } = require('../dist/lib/server/errors');
 const { createIdempotencyStore, memoryBackend } = require('../dist/lib/server/idempotency');
@@ -117,6 +119,67 @@ function mountAdapter(a2a) {
   return app;
 }
 
+function createComplianceDecisioningServer({ principalMode = 'sandbox' } = {}) {
+  return createAdcpServerFromPlatform(
+    {
+      capabilities: {
+        specialisms: ['sales-non-guaranteed'],
+        creative_agents: [{ agent_url: 'https://example.com/creative-agent/mcp' }],
+        channels: ['display'],
+        pricingModels: ['cpm'],
+        config: {},
+        compliance_testing: {},
+      },
+      statusMappers: {},
+      accounts: {
+        resolve: async () => ({
+          id: `${principalMode}_acc_1`,
+          operator: 'example.com',
+          mode: principalMode,
+          ctx_metadata: {},
+          authInfo: { kind: 'api_key' },
+        }),
+      },
+      sales: {
+        getProducts: async () => ({ products: [] }),
+        createMediaBuy: async () => ({
+          media_buy_id: 'mb_1',
+          status: 'pending_creatives',
+          confirmed_at: '2026-04-28T00:00:00Z',
+          packages: [],
+        }),
+        updateMediaBuy: async () => ({ media_buy_id: 'mb_1', status: 'active' }),
+        syncCreatives: async () => [],
+        getMediaBuyDelivery: async () => ({
+          currency: 'USD',
+          reporting_period: { start: '2026-04-01', end: '2026-04-30' },
+          media_buy_deliveries: [],
+        }),
+      },
+    },
+    {
+      name: 'a2a-comply-host',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+      stateStore: new InMemoryStateStore(),
+      taskRegistry: createInMemoryTaskRegistry(),
+      resolveIdempotencyPrincipal: () => 'a2a-test-principal',
+      complyTest: {
+        force: {
+          creative_status: async params => ({
+            success: true,
+            transition: 'forced',
+            resource_type: 'creative',
+            resource_id: params.creative_id,
+            previous_state: 'pending_review',
+            current_state: params.status,
+          }),
+        },
+      },
+    }
+  );
+}
+
 describe('createA2AAdapter', () => {
   describe('agent card', () => {
     it('exposes seller identity fields and auto-seeds skills from registered tools', async () => {
@@ -139,6 +202,37 @@ describe('createA2AAdapter', () => {
       assert.strictEqual(res.body.capabilities.streaming, false);
       assert.strictEqual(res.body.capabilities.pushNotifications, false);
       assert.deepStrictEqual(res.body.provider, { organization: 'Test Co', url: 'https://example.com' });
+    });
+
+    it('omits comply_test_controller from public A2A agent-card skills', async () => {
+      const adcp = createComplianceDecisioningServer();
+      const a2a = createA2AAdapter({ server: adcp, agentCard: baseCard() });
+      const card = await a2a.getAgentCard();
+      const skillIds = card.skills.map(s => s.id);
+      assert.ok(skillIds.includes('get_products'), 'ordinary AdCP tools remain advertised');
+      assert.ok(!skillIds.includes('comply_test_controller'), 'compliance controller is not public-card discoverable');
+      assert.ok(!skillIds.includes('get_adcp_capabilities'), 'capabilities tool excluded from public card');
+    });
+
+    it('filters comply_test_controller from seller-supplied A2A skill overrides', async () => {
+      const adcp = createComplianceDecisioningServer();
+      const a2a = createA2AAdapter({
+        server: adcp,
+        agentCard: baseCard({
+          skills: [
+            { id: 'get_products', name: 'get_products', description: 'public sales tool', tags: ['adcp'] },
+            {
+              id: 'comply_test_controller',
+              name: 'comply_test_controller',
+              description: 'private compliance tool',
+              tags: ['adcp'],
+            },
+          ],
+        }),
+      });
+      const card = await a2a.getAgentCard();
+      const skillIds = card.skills.map(s => s.id);
+      assert.deepStrictEqual(skillIds, ['get_products']);
     });
 
     it('allows seller to override skills entirely', async () => {
@@ -470,6 +564,26 @@ describe('createA2AAdapter', () => {
       assert.strictEqual(res.body.result.status.state, 'failed');
       const dataPart = res.body.result.artifacts[0].parts[0];
       assert.strictEqual(dataPart.data.reason, 'INVALID_INVOCATION');
+    });
+
+    it('guessed comply_test_controller skill from a live principal fails as method-not-found', async () => {
+      const adcp = createComplianceDecisioningServer({ principalMode: 'live' });
+      const app = mountAdapter(createA2AAdapter({ server: adcp, agentCard: baseCard() }));
+      const res = await postJsonRpc(
+        app,
+        messageSend(
+          dataPartMessage('comply_test_controller', {
+            scenario: 'force_creative_status',
+            params: { creative_id: 'cr_1', status: 'approved' },
+          })
+        )
+      );
+
+      assert.strictEqual(res.status, 200);
+      assert.strictEqual(res.body.result.status.state, 'failed');
+      const dataPart = res.body.result.artifacts[0].parts[0];
+      assert.strictEqual(dataPart.data.reason, 'HANDLER_THREW');
+      assert.match(dataPart.data.message, /method not found/i);
     });
   });
 

--- a/test/server-decisioning-comply-gate.test.js
+++ b/test/server-decisioning-comply-gate.test.js
@@ -1,12 +1,8 @@
-// Framework-side sandbox-authority gate for `comply_test_controller`.
-// Phase 2 of #1435 — auto-wires the gate inside `createAdcpServerFromPlatform`
-// so the controller refuses live-mode accounts regardless of what the caller
-// claims on the wire. See docs/proposals/lifecycle-state-and-sandbox-authority.md.
-//
-// 5 admit/deny combinations × 3 modes = 15 assertions covering:
-//   - resolver returns mode 'live' / 'sandbox' / 'mock'
-//   - context.sandbox === true when no account resolves
-//   - process.env.ADCP_SANDBOX === '1' fallback (and its fail-closed guard)
+// Framework-side visibility and sandbox-authority gate for
+// `comply_test_controller` in `createAdcpServerFromPlatform`.
+// Covers Path B discovery hiding, direct-call method-not-found, target-account
+// PERMISSION_DENIED, BuyerAgentRegistry context, legacy `sandbox: true`, and
+// the ADCP_SANDBOX env bridge/fail-closed guard.
 
 process.env.NODE_ENV = 'test';
 
@@ -14,8 +10,10 @@ const { describe, it, beforeEach, after } = require('node:test');
 const assert = require('node:assert');
 const { createAdcpServerFromPlatform } = require('../dist/lib/server/decisioning/runtime/from-platform');
 const { __resetObservedAccountModes } = require('../dist/lib/server/decisioning/runtime/observed-modes');
+const { getSdkServer } = require('../dist/lib/server/adcp-server');
+const { BuyerAgentRegistry } = require('../dist/lib/server/decisioning/buyer-agent');
 
-function makePlatform(resolveAccount) {
+function makePlatform(resolveAccount, overrides = {}) {
   return {
     capabilities: {
       specialisms: ['sales-non-guaranteed'],
@@ -29,6 +27,7 @@ function makePlatform(resolveAccount) {
     accounts: {
       resolve: resolveAccount,
     },
+    ...(overrides.agentRegistry !== undefined && { agentRegistry: overrides.agentRegistry }),
     sales: {
       getProducts: async () => ({ products: [] }),
       createMediaBuy: async () => ({
@@ -48,8 +47,8 @@ function makePlatform(resolveAccount) {
   };
 }
 
-function buildServer(resolveAccount) {
-  return createAdcpServerFromPlatform(makePlatform(resolveAccount), {
+function buildServer(resolveAccount, overrides = {}) {
+  return createAdcpServerFromPlatform(makePlatform(resolveAccount, overrides), {
     name: 'gate-host',
     version: '0.0.1',
     validation: { requests: 'off', responses: 'off' },
@@ -68,28 +67,81 @@ function buildServer(resolveAccount) {
   });
 }
 
-async function callForceCreative(server, args = {}) {
-  return server.dispatchTestRequest({
-    method: 'tools/call',
-    params: {
-      name: 'comply_test_controller',
-      arguments: {
-        scenario: 'force_creative_status',
-        params: { creative_id: 'cr_1', status: 'approved' },
-        ...args,
+async function callForceCreative(server, args = {}, extras) {
+  return server.dispatchTestRequest(
+    {
+      method: 'tools/call',
+      params: {
+        name: 'comply_test_controller',
+        arguments: {
+          scenario: 'force_creative_status',
+          params: { creative_id: 'cr_1', status: 'approved' },
+          ...args,
+        },
       },
     },
-  });
+    extras
+  );
 }
 
-async function callListScenarios(server) {
-  return server.dispatchTestRequest({
-    method: 'tools/call',
-    params: {
-      name: 'comply_test_controller',
-      arguments: { scenario: 'list_scenarios' },
+async function callListScenarios(server, extras) {
+  return server.dispatchTestRequest(
+    {
+      method: 'tools/call',
+      params: {
+        name: 'comply_test_controller',
+        arguments: { scenario: 'list_scenarios' },
+      },
     },
-  });
+    extras
+  );
+}
+
+async function callCapabilities(server, extras) {
+  return server.dispatchTestRequest(
+    {
+      method: 'tools/call',
+      params: {
+        name: 'get_adcp_capabilities',
+        arguments: {},
+      },
+    },
+    extras
+  );
+}
+
+async function listTools(server, extras) {
+  return server.dispatchTestRequest(
+    {
+      method: 'tools/list',
+    },
+    extras
+  );
+}
+
+function assertPermissionDenied(result) {
+  assert.strictEqual(result.isError, true);
+  assert.strictEqual(result.structuredContent?.adcp_error?.code, 'PERMISSION_DENIED');
+}
+
+async function callMcpToolsCallHandler(server, args = {}, extra = {}) {
+  const sdk = getSdkServer(server);
+  const handler = sdk?.server?._requestHandlers?.get('tools/call');
+  if (!handler) throw new Error('tools/call request handler not found');
+  return handler(
+    {
+      method: 'tools/call',
+      params: {
+        name: 'comply_test_controller',
+        arguments: {
+          scenario: 'force_creative_status',
+          params: { creative_id: 'cr_1', status: 'approved' },
+          ...args,
+        },
+      },
+    },
+    { signal: new AbortController().signal, ...extra }
+  );
 }
 
 describe('createAdcpServerFromPlatform — sandbox-authority gate (resolver path)', () => {
@@ -98,7 +150,7 @@ describe('createAdcpServerFromPlatform — sandbox-authority gate (resolver path
     __resetObservedAccountModes();
   });
 
-  it("denies when resolver returns mode: 'live'", async () => {
+  it("hides the comply controller when the principal resolves to mode: 'live'", async () => {
     const server = buildServer(async ref => ({
       id: ref?.account_id ?? 'live_acc',
       mode: 'live',
@@ -106,10 +158,21 @@ describe('createAdcpServerFromPlatform — sandbox-authority gate (resolver path
       authInfo: { kind: 'api_key' },
     }));
 
-    const result = await callForceCreative(server, { account: { account_id: 'live_acc' } });
+    const caps = await callCapabilities(server);
+    assert.strictEqual(caps.structuredContent.compliance_testing, undefined);
 
-    assert.strictEqual(result.isError, true, 'live-mode account must be denied');
-    assert.strictEqual(result.structuredContent.error, 'FORBIDDEN');
+    const listed = await listTools(server);
+    assert.ok(!listed.tools.some(tool => tool.name === 'comply_test_controller'));
+
+    await assert.rejects(
+      () => callForceCreative(server, { account: { account_id: 'live_acc' } }),
+      err => err?.code === -32601
+    );
+
+    await assert.rejects(
+      () => callMcpToolsCallHandler(server, { account: { account_id: 'live_acc' } }),
+      err => err?.code === -32601
+    );
   });
 
   it("admits when resolver returns mode: 'sandbox'", async () => {
@@ -119,6 +182,12 @@ describe('createAdcpServerFromPlatform — sandbox-authority gate (resolver path
       ctx_metadata: {},
       authInfo: { kind: 'api_key' },
     }));
+
+    const caps = await callCapabilities(server);
+    assert.ok(caps.structuredContent.compliance_testing);
+
+    const listed = await listTools(server);
+    assert.ok(listed.tools.some(tool => tool.name === 'comply_test_controller'));
 
     const result = await callForceCreative(server, { account: { account_id: 'sb_acc' } });
 
@@ -134,6 +203,9 @@ describe('createAdcpServerFromPlatform — sandbox-authority gate (resolver path
       authInfo: { kind: 'api_key' },
     }));
 
+    const listed = await listTools(server);
+    assert.ok(listed.tools.some(tool => tool.name === 'comply_test_controller'));
+
     const result = await callForceCreative(server, { account: { account_id: 'mock_acc' } });
 
     assert.notStrictEqual(result.isError, true, 'mock-mode account must be admitted');
@@ -148,28 +220,189 @@ describe('createAdcpServerFromPlatform — sandbox-authority gate (resolver path
       authInfo: { kind: 'api_key' },
     }));
 
+    const caps = await callCapabilities(server);
+    assert.ok(caps.structuredContent.compliance_testing);
+
+    const listed = await listTools(server);
+    assert.ok(listed.tools.some(tool => tool.name === 'comply_test_controller'));
+
     const result = await callForceCreative(server, { account: { account_id: 'legacy_sb' } });
 
     assert.notStrictEqual(result.isError, true);
     assert.strictEqual(result.structuredContent.success, true);
   });
 
-  it('ignores caller-supplied account.sandbox claim when resolver says live', async () => {
+  it('returns PERMISSION_DENIED when a sandbox principal targets a live account', async () => {
+    const server = buildServer(async ref => {
+      if (ref?.account_id === 'live_acc') {
+        return {
+          id: 'live_acc',
+          mode: 'live',
+          ctx_metadata: {},
+          authInfo: { kind: 'api_key' },
+        };
+      }
+      return {
+        id: ref?.account_id ?? 'principal_sb',
+        mode: 'sandbox',
+        ctx_metadata: {},
+        authInfo: { kind: 'api_key' },
+      };
+    });
+
+    const result = await callForceCreative(server, {
+      account: { account_id: 'live_acc' },
+      context: { correlation_id: 'corr_1' },
+      ext: { probe: true },
+    });
+
+    assertPermissionDenied(result);
+    assert.deepStrictEqual(result.structuredContent.context, { correlation_id: 'corr_1' });
+    assert.deepStrictEqual(result.structuredContent.ext, { probe: true });
+    const textPayload = JSON.parse(result.content[0].text);
+    assert.deepStrictEqual(textPayload.context, result.structuredContent.context);
+    assert.deepStrictEqual(textPayload.ext, result.structuredContent.ext);
+  });
+
+  it('ignores caller-supplied account.sandbox claim when a sandbox principal targets a live account', async () => {
     // Trust boundary: resolver is authoritative, NOT the wire. Buyer cannot
     // self-promote by stuffing sandbox: true into the account ref.
-    const server = buildServer(async ref => ({
-      id: ref?.account_id ?? 'spoof',
-      mode: 'live',
-      ctx_metadata: {},
-      authInfo: { kind: 'api_key' },
-    }));
+    const server = buildServer(async ref => {
+      if (ref?.account_id === 'spoof') {
+        return {
+          id: 'spoof',
+          mode: 'live',
+          ctx_metadata: {},
+          authInfo: { kind: 'api_key' },
+        };
+      }
+      return {
+        id: ref?.account_id ?? 'principal_sb',
+        mode: 'sandbox',
+        ctx_metadata: {},
+        authInfo: { kind: 'api_key' },
+      };
+    });
 
     const result = await callForceCreative(server, {
       account: { account_id: 'spoof', sandbox: true },
     });
 
-    assert.strictEqual(result.isError, true);
-    assert.strictEqual(result.structuredContent.error, 'FORBIDDEN');
+    assertPermissionDenied(result);
+  });
+
+  it('passes actual discovery context to accounts.resolve when checking visibility', async () => {
+    const calls = [];
+    const server = buildServer(async (ref, ctx) => {
+      calls.push({ ref, toolName: ctx?.toolName });
+      return {
+        id: ref?.account_id ?? 'principal_sb',
+        mode: 'sandbox',
+        ctx_metadata: {},
+        authInfo: { kind: 'api_key' },
+      };
+    });
+
+    await callCapabilities(server);
+    await listTools(server);
+    await callListScenarios(server);
+
+    assert.deepStrictEqual(
+      calls.map(c => c.toolName),
+      ['get_adcp_capabilities', undefined, 'comply_test_controller']
+    );
+    assert.deepStrictEqual(
+      calls.map(c => c.ref),
+      [undefined, undefined, undefined]
+    );
+  });
+
+  it('threads resolved BuyerAgent into comply visibility and target account resolution', async () => {
+    const registryAgent = {
+      agent_url: 'https://buyer.example/agent',
+      display_name: 'Buyer',
+      status: 'active',
+      billing_capabilities: new Set(['operator']),
+      sandbox_only: true,
+    };
+    const seen = [];
+    const server = buildServer(
+      async (ref, ctx) => {
+        seen.push({ ref, agent: ctx?.agent, inputScenario: ctx?.input?.scenario });
+        return {
+          id: ref?.account_id ?? 'principal_sb',
+          mode: ctx?.agent === registryAgent ? 'sandbox' : 'live',
+          ctx_metadata: {},
+          authInfo: { kind: 'api_key' },
+        };
+      },
+      {
+        agentRegistry: {
+          async resolve() {
+            return registryAgent;
+          },
+        },
+      }
+    );
+
+    const result = await callForceCreative(server, { account: { account_id: 'target_sb' } });
+
+    assert.notStrictEqual(result.isError, true);
+    assert.strictEqual(result.structuredContent.success, true);
+    assert.ok(seen.length >= 2, 'visibility and target resolution should both run');
+    assert.ok(seen.every(call => call.agent === registryAgent));
+    assert.ok(seen.some(call => call.ref === undefined));
+    assert.ok(seen.some(call => call.ref?.account_id === 'target_sb'));
+    assert.ok(seen.some(call => call.inputScenario === 'force_creative_status'));
+  });
+
+  it('threads serve-style authInfo.extra.credential into bearerOnly registry for visibility', async () => {
+    const registryAgent = {
+      agent_url: 'https://buyer.example/agent',
+      display_name: 'Buyer',
+      status: 'active',
+      billing_capabilities: new Set(['operator']),
+    };
+    const seenCredentials = [];
+    const server = buildServer(
+      async (ref, ctx) => ({
+        id: ref?.account_id ?? 'principal_from_agent',
+        mode: ctx?.agent === registryAgent ? 'sandbox' : 'live',
+        ctx_metadata: {},
+        authInfo: { kind: 'api_key' },
+      }),
+      {
+        agentRegistry: BuyerAgentRegistry.bearerOnly({
+          async resolveByCredential(credential, extra, input) {
+            seenCredentials.push({ credential, extra, input });
+            return credential?.kind === 'api_key' && credential.key_id === 'sandbox-key' ? registryAgent : null;
+          },
+        }),
+      }
+    );
+    const extra = {
+      authInfo: {
+        clientId: 'buyer_1',
+        extra: {
+          credential: { kind: 'api_key', key_id: 'sandbox-key' },
+          tenant: 'tenant_1',
+        },
+      },
+    };
+
+    const caps = await callCapabilities(server, extra);
+    assert.ok(caps.structuredContent.compliance_testing);
+
+    const listed = await listTools(server, extra);
+    assert.ok(listed.tools.some(tool => tool.name === 'comply_test_controller'));
+
+    const result = await callMcpToolsCallHandler(server, { account: { account_id: 'target_sb' } }, extra);
+    assert.notStrictEqual(result.isError, true);
+    assert.strictEqual(result.structuredContent.success, true);
+    assert.ok(seenCredentials.length >= 3, 'capabilities, tools/list, and controller dispatch resolve agent');
+    assert.ok(seenCredentials.every(call => call.credential?.key_id === 'sandbox-key'));
+    assert.ok(seenCredentials.every(call => call.extra?.tenant === 'tenant_1'));
+    assert.ok(seenCredentials.some(call => call.input?.scenario === 'force_creative_status'));
   });
 });
 
@@ -182,8 +415,30 @@ describe('createAdcpServerFromPlatform — sandbox-authority gate (accountRef.sa
     __resetObservedAccountModes();
   });
 
-  it('admits when no account resolves and accountRef.sandbox === true', async () => {
+  it('hides the controller when no principal resolves and no sandbox deployment flag is set', async () => {
     const server = buildServer(async () => null);
+
+    const caps = await callCapabilities(server);
+    assert.strictEqual(caps.structuredContent.compliance_testing, undefined);
+
+    const listed = await listTools(server);
+    assert.ok(!listed.tools.some(tool => tool.name === 'comply_test_controller'));
+
+    await assert.rejects(
+      () => callForceCreative(server, { account: { sandbox: true } }),
+      err => err?.code === -32601
+    );
+  });
+
+  it('exposes discovery and admits accountRef.sandbox === true in an explicitly sandboxed deployment', async () => {
+    process.env.ADCP_SANDBOX = '1';
+    const server = buildServer(async () => null);
+
+    const caps = await callCapabilities(server);
+    assert.ok(caps.structuredContent.compliance_testing);
+
+    const listed = await listTools(server);
+    assert.ok(listed.tools.some(tool => tool.name === 'comply_test_controller'));
 
     const result = await callForceCreative(server, { account: { sandbox: true } });
 
@@ -191,32 +446,60 @@ describe('createAdcpServerFromPlatform — sandbox-authority gate (accountRef.sa
     assert.strictEqual(result.structuredContent.success, true);
   });
 
-  it('denies when no account resolves and accountRef.sandbox is absent', async () => {
+  it('admits via deployment-scoped ADCP_SANDBOX=1 when no account resolves and accountRef.sandbox is absent', async () => {
+    process.env.ADCP_SANDBOX = '1';
     const server = buildServer(async () => null);
 
     const result = await callForceCreative(server);
 
-    assert.strictEqual(result.isError, true);
-    assert.strictEqual(result.structuredContent.error, 'FORBIDDEN');
+    assert.notStrictEqual(result.isError, true);
+    assert.strictEqual(result.structuredContent.success, true);
+  });
+
+  it('returns PERMISSION_DENIED when a sandbox principal targets an unresolved non-sandbox account', async () => {
+    const server = buildServer(async ref => {
+      if (ref == null) {
+        return {
+          id: 'principal_sb',
+          mode: 'sandbox',
+          ctx_metadata: {},
+          authInfo: { kind: 'api_key' },
+        };
+      }
+      return null;
+    });
+
+    const result = await callForceCreative(server, { account: { account_id: 'missing_live' } });
+
+    assertPermissionDenied(result);
   });
 
   it('does NOT admit on accountRef.sandbox when the resolver names a live account', async () => {
     // The wire flag is a fallback for the *unresolved* path. Once the
     // resolver names the account, the resolver wins and the buyer's wire
     // claim is ignored.
-    const server = buildServer(async ref => ({
-      id: ref?.account_id ?? 'live_acc',
-      mode: 'live',
-      ctx_metadata: {},
-      authInfo: { kind: 'api_key' },
-    }));
+    const server = buildServer(async ref => {
+      if (ref?.account_id === 'live_acc') {
+        return {
+          id: 'live_acc',
+          mode: 'live',
+          ctx_metadata: {},
+          authInfo: { kind: 'api_key' },
+        };
+      }
+      return {
+        id: ref?.account_id ?? 'principal_sb',
+        mode: 'sandbox',
+        ctx_metadata: {},
+        authInfo: { kind: 'api_key' },
+      };
+    });
 
     const result = await callForceCreative(server, {
       account: { account_id: 'live_acc', sandbox: true },
     });
 
-    assert.strictEqual(result.isError, true);
-    assert.strictEqual(result.structuredContent.error, 'FORBIDDEN');
+    assertPermissionDenied(result);
   });
 });
 
@@ -248,8 +531,8 @@ describe('createAdcpServerFromPlatform — sandbox-authority gate (env fallback)
   it('FAILS CLOSED on a live-mode resolve when ADCP_SANDBOX=1 (catches the misconfig immediately)', async () => {
     // The env-fallback was never meant to coexist with a resolver that names
     // live accounts. As soon as such a pairing is observed, the gate throws
-    // loudly so operators notice in their logs — a FORBIDDEN response would
-    // be too quiet for what is fundamentally a deployment-level misconfig.
+    // loudly so operators notice in their logs — a PERMISSION_DENIED
+    // response would be too quiet for what is fundamentally a deployment-level misconfig.
     process.env.ADCP_SANDBOX = '1';
     const server = buildServer(async ref => ({
       id: ref?.account_id ?? 'live_1',
@@ -316,10 +599,15 @@ describe('createAdcpServerFromPlatform — sandbox-authority gate (env fallback)
     );
   });
 
-  it('list_scenarios is exempt from the gate (probe always answers)', async () => {
-    // No env, no context.sandbox, resolver returns null. force_creative_status
-    // would deny — list_scenarios admits as a discovery probe.
-    const server = buildServer(async () => null);
+  it('list_scenarios is exempt from the target-account gate once the sandbox principal can see the controller', async () => {
+    // A sandbox principal can use list_scenarios without a target account.
+    // A live principal cannot see the controller at all.
+    const server = buildServer(async ref => ({
+      id: ref?.account_id ?? 'principal_sb',
+      mode: 'sandbox',
+      ctx_metadata: {},
+      authInfo: { kind: 'api_key' },
+    }));
 
     const probe = await callListScenarios(server);
 

--- a/test/server-decisioning-comply-test.test.js
+++ b/test/server-decisioning-comply-test.test.js
@@ -1,10 +1,10 @@
 // Integration tests for first-class `comply_test_controller` wiring on
 // `createAdcpServerFromPlatform`. Adopters declare `complyTest`
-// adapters; the framework auto-registers the wire tool and projects
-// `compliance_testing.scenarios` onto get_adcp_capabilities.
+// adapters; the framework registers the wire tool and projects
+// `compliance_testing.scenarios` onto sandbox-visible discovery.
 
 process.env.NODE_ENV = 'test';
-process.env.ADCP_SANDBOX = '1'; // suppress the ungated-warning
+process.env.ADCP_SANDBOX = '1'; // legacy conformance deployment visibility bridge
 
 const { describe, it } = require('node:test');
 const assert = require('node:assert');
@@ -51,8 +51,12 @@ function basePlatform({ withComplianceTesting = false } = {}) {
   };
 }
 
+async function listTools(server) {
+  return server.dispatchTestRequest({ method: 'tools/list' });
+}
+
 describe('createAdcpServerFromPlatform — comply_test_controller wiring', () => {
-  it('registers comply_test_controller when complyTest adapters are supplied', async () => {
+  it('registers comply_test_controller when complyTest adapters are supplied under the sandbox env bridge', async () => {
     let forcedCreativeId = null;
     const server = createAdcpServerFromPlatform(basePlatform({ withComplianceTesting: true }), {
       name: 'comply-host',
@@ -92,7 +96,7 @@ describe('createAdcpServerFromPlatform — comply_test_controller wiring', () =>
     assert.strictEqual(result.structuredContent.current_state, 'approved');
   });
 
-  it('list_scenarios returns the auto-derived scenarios from supplied adapters', async () => {
+  it('list_scenarios returns auto-derived scenarios under the sandbox env bridge', async () => {
     const server = createAdcpServerFromPlatform(basePlatform({ withComplianceTesting: true }), {
       name: 'comply-host',
       version: '0.0.1',
@@ -207,7 +211,7 @@ describe('createAdcpServerFromPlatform — comply_test_controller wiring', () =>
     );
   });
 
-  it('projects compliance_testing.scenarios onto get_adcp_capabilities', async () => {
+  it('projects compliance_testing.scenarios onto get_adcp_capabilities under the sandbox env bridge', async () => {
     // Round-5 spike (training-agent): framework validates the
     // capability/adapter consistency but doesn't project scenarios onto
     // wire. Adopter sees compliance_testing: {} on get_adcp_capabilities
@@ -261,9 +265,12 @@ describe('createAdcpServerFromPlatform — comply_test_controller wiring', () =>
     assert.ok(ct.scenarios.includes('force_media_buy_status'));
     assert.ok(ct.scenarios.includes('simulate_delivery'));
     assert.ok(!ct.scenarios.includes('force_account_status'), 'unwired scenario must not appear');
+
+    const listed = await listTools(server);
+    assert.ok(listed.tools.some(tool => tool.name === 'comply_test_controller'));
   });
 
-  it('explicit capabilities.compliance_testing.scenarios overrides auto-derivation', async () => {
+  it('explicit capabilities.compliance_testing.scenarios overrides auto-derivation under the sandbox env bridge', async () => {
     const platform = basePlatform({ withComplianceTesting: true });
     // Adopter wires three adapters but only wants to advertise two.
     platform.capabilities.compliance_testing = {
@@ -324,7 +331,7 @@ describe('createAdcpServerFromPlatform — comply_test_controller wiring', () =>
     assert.strictEqual(result.structuredContent?.compliance_testing, undefined);
   });
 
-  it('sandboxGate denial returns FORBIDDEN', async () => {
+  it('sandboxGate denial returns FORBIDDEN under the sandbox env bridge', async () => {
     const server = createAdcpServerFromPlatform(basePlatform({ withComplianceTesting: true }), {
       name: 'gated-host',
       version: '0.0.1',


### PR DESCRIPTION
## Summary

Closes #1521.

- hide `compliance_testing` and `comply_test_controller` from live or unresolved principals in `createAdcpServerFromPlatform`
- keep sandbox/mock and legacy resolved `{ sandbox: true }` principals visible, with `PERMISSION_DENIED` reserved for visible sandbox/mock principals targeting live or unresolved non-sandbox accounts
- enforce MCP method-not-found at the `tools/call` request-handler layer, filter `tools/list`, and omit public A2A agent-card advertising for the controller
- thread BuyerAgentRegistry context through the visibility checks, including serve-style `authInfo.extra.credential`, and document the Path B visibility model

## Expert Review

- JavaScript/protocol final pass: GO
- DX/docs final pass: GO

Follow-up nits from the review were addressed before opening:

- registry error logs now redact credential-shaped strings
- API docs now say `compliance_testing` stays declared for `createAdcpServerFromPlatform + complyTest`
- `complyTest` JSDoc no longer claims MCP uses `controller.register(server)`

## Validation

- `npm run typecheck`
- `npm run build:lib`
- `node --test --test-timeout=60000 test/server-decisioning-comply-gate.test.js test/server-decisioning-comply-test.test.js test/server-a2a-adapter.test.js`
- `npm run format:check`
- `npx changeset status --since=origin/main`
