### PR TITLE
fix(testing): register validate_input response schema

### DIFF
--- a/.changeset/validate-input-response-schema.md
+++ b/.changeset/validate-input-response-schema.md
@@ -1,0 +1,5 @@
+---
+"@adcp/sdk": patch
+---
+
+Register the generated validate_input response schema for storyboard response validation.

--- a/src/lib/utils/response-schemas.ts
+++ b/src/lib/utils/response-schemas.ts
@@ -59,6 +59,7 @@ export const TOOL_RESPONSE_SCHEMAS: Partial<Record<string, z.ZodType>> = {
   // Creative
   list_creative_formats: schemas.ListCreativeFormatsResponseSchema,
   build_creative: schemas.BuildCreativeResponseSchema,
+  validate_input: schemas.ValidateInputResponseSchema,
   preview_creative: schemas.PreviewCreativeResponseSchema,
   // Override the generated schema — it degrades creatives[] to a bare
   // record because the JSON Schema inlines the item shape. The strict

--- a/test/lib/response-schema-validation.test.js
+++ b/test/lib/response-schema-validation.test.js
@@ -10,6 +10,7 @@
 const { describe, it } = require('node:test');
 const assert = require('node:assert');
 const { validateResponseSchema } = require('../../dist/lib/testing/client');
+const schemas = require('../../dist/lib/types/schemas.generated');
 const { TOOL_RESPONSE_SCHEMAS } = require('../../dist/lib/utils/response-schemas');
 
 // --- Fixtures ---
@@ -450,6 +451,28 @@ describe('validateResponseSchema', () => {
 
   // ---- Schema registry completeness ----
   describe('schema registry', () => {
+    const NON_TOOL_RESPONSE_SCHEMAS = new Set([
+      'AAODirectoryAgentPublishersInverseLookupResponseSchema',
+      'PaginationResponseSchema',
+      'PreviewCreativeBatchResponseSchema',
+      'PreviewCreativeSingleResponseSchema',
+      'PreviewCreativeVariantResponseSchema',
+      'ProtocolResponseSchema',
+      'TasksGetResponseSchema',
+      'TasksListResponseSchema',
+      'WebhookChallengeResponseSchema',
+    ]);
+
+    const TOOL_NAME_OVERRIDES = new Map([['GetAdCPCapabilitiesResponseSchema', 'get_adcp_capabilities']]);
+
+    function schemaNameToToolName(schemaName) {
+      const baseName = schemaName.replace(/ResponseSchema$/, '');
+      return baseName
+        .replace(/([A-Z]+)([A-Z][a-z])/g, '$1_$2')
+        .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+        .toLowerCase();
+    }
+
     it('has schemas for all tools used in compliance scenarios', () => {
       const scenarioTools = [
         'get_products',
@@ -462,6 +485,17 @@ describe('validateResponseSchema', () => {
       ];
       for (const tool of scenarioTools) {
         assert.ok(TOOL_RESPONSE_SCHEMAS[tool], `Missing schema for scenario tool: ${tool}`);
+      }
+    });
+
+    it('registers every generated tool response schema', () => {
+      const generatedToolSchemas = Object.keys(schemas)
+        .filter(name => name.endsWith('ResponseSchema'))
+        .filter(name => !NON_TOOL_RESPONSE_SCHEMAS.has(name));
+
+      for (const schemaName of generatedToolSchemas) {
+        const toolName = TOOL_NAME_OVERRIDES.get(schemaName) ?? schemaNameToToolName(schemaName);
+        assert.ok(TOOL_RESPONSE_SCHEMAS[toolName], `Missing schema registration for tool: ${toolName}`);
       }
     });
   });


### PR DESCRIPTION
## Summary

Refs #2059.

This wires the generated `ValidateInputResponseSchema` into `TOOL_RESPONSE_SCHEMAS` so storyboard response-schema validation can validate `validate_input` steps instead of failing with a missing schema registration.

## What changed

- Added `validate_input: schemas.ValidateInputResponseSchema` to the shared tool response schema map.
- Added a regression check that generated tool response schemas are registered, with an explicit allowlist for generated response schemas that are not top-level AdCP tools.
- Added a patch changeset.

## Testing

- `npm run build:lib`
- `npm run format:check`
- `npm run typecheck`
- `node --test-timeout=60000 --test test/lib/response-schema-validation.test.js --test-reporter=spec`
- pre-push validation passed: format, typecheck, build
- GitHub Actions: `check / check` passed

Note: `npm run ci:quick` was started locally, but I interrupted the broad `test:node:fast` run while diagnosing a long no-output interval. The PR was kept draft until GitHub Actions confirmed the repository check, then marked ready.
