### PR TITLE
fix: tighten sync_accounts follow-up edges

### DIFF
--- a/.changeset/sync-accounts-followups.md
+++ b/.changeset/sync-accounts-followups.md
@@ -1,0 +1,6 @@
+---
+'@adcp/sdk': patch
+---
+
+Tighten sync_accounts commercial filtering diagnostics and replay caching for
+stable rejected rows.

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -2029,7 +2029,7 @@ function hasUncacheableSyncAccountRejection(response: McpToolResponse): boolean 
     const record = row as Record<string, unknown>;
     if (record.status !== 'rejected' && record.action !== 'failed') return false;
     const errors = record.errors;
-    if (!Array.isArray(errors)) return record.status === 'rejected';
+    if (!Array.isArray(errors)) return false;
     return errors.some(error => {
       if (!error || typeof error !== 'object') return false;
       return UNCACHEABLE_SYNC_ACCOUNT_ERROR_CODES.has(String((error as Record<string, unknown>).code));

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -5045,6 +5045,15 @@ function buildAccountHandlers<P extends DecisioningPlatform<any, any>>(
             ? accounts.upsert!(policy.acceptedEntries as AccountReference[], dispatchCtx)
             : Promise.resolve([]),
         rows => {
+          if (rows.length !== policy.acceptedEntries.length) {
+            throw new Error(
+              `sync_accounts accounts.upsert returned ${rows.length} ${
+                rows.length === 1 ? 'row' : 'rows'
+              } for ${policy.acceptedEntries.length} accepted account ${
+                policy.acceptedEntries.length === 1 ? 'entry' : 'entries'
+              }`
+            );
+          }
           if (policy.failedRows.size === 0) {
             return { accounts: rows.map(toWireSyncAccountRow) };
           }

--- a/test/server-buyer-agent-billing.test.js
+++ b/test/server-buyer-agent-billing.test.js
@@ -77,7 +77,7 @@ function createServer(platform, opts = {}) {
   });
 }
 
-function syncAccounts(server, account, extra = {}) {
+function syncAccountsBatch(server, accounts, extra = {}) {
   return server.dispatchTestRequest(
     {
       method: 'tools/call',
@@ -85,7 +85,7 @@ function syncAccounts(server, account, extra = {}) {
         name: 'sync_accounts',
         arguments: {
           idempotency_key: extra.idempotency_key ?? '11111111-1111-1111-1111-111111111111',
-          accounts: [account],
+          accounts,
         },
       },
     },
@@ -96,6 +96,10 @@ function syncAccounts(server, account, extra = {}) {
       },
     }
   );
+}
+
+function syncAccounts(server, account, extra = {}) {
+  return syncAccountsBatch(server, [account], extra);
 }
 
 describe('BuyerAgent billing suggestions', () => {
@@ -202,6 +206,82 @@ describe('sync_accounts billing enforcement', () => {
     });
 
     assert.equal(result.structuredContent.accounts[0].errors[0].code, 'PAYMENT_TERMS_NOT_SUPPORTED');
+  });
+
+  it('preserves original order when commercial policy filters a mixed batch', async () => {
+    const captures = {};
+    const server = createServer(
+      buildPlatform({ agent: sampleAgent({ billing_capabilities: new Set(['operator']) }), captures })
+    );
+
+    const result = await syncAccountsBatch(server, [
+      {
+        brand: { domain: 'ok-1.example' },
+        operator: 'agency.example',
+        billing: 'operator',
+      },
+      {
+        brand: { domain: 'blocked.example' },
+        operator: 'agency.example',
+        billing: 'agent',
+      },
+      {
+        brand: { domain: 'ok-2.example' },
+        operator: 'agency.example',
+        billing: 'operator',
+      },
+    ]);
+
+    assert.notEqual(result.isError, true, JSON.stringify(result.structuredContent));
+    assert.equal(captures.upsertCalls, 1);
+    assert.deepEqual(
+      captures.lastUpsertRefs.map(ref => ref.brand.domain),
+      ['ok-1.example', 'ok-2.example']
+    );
+
+    const rows = result.structuredContent.accounts;
+    assert.equal(rows.length, 3);
+    assert.equal(rows[0].status, 'active');
+    assert.equal(rows[0].brand.domain, 'ok-1.example');
+    assert.equal(rows[1].status, 'rejected');
+    assert.equal(rows[1].brand.domain, 'blocked.example');
+    assert.equal(rows[1].errors[0].code, 'BILLING_NOT_PERMITTED_FOR_AGENT');
+    assert.equal(rows[2].status, 'active');
+    assert.equal(rows[2].brand.domain, 'ok-2.example');
+  });
+
+  it('returns a service diagnostic when accounts.upsert omits accepted batch rows', async () => {
+    const platform = buildPlatform({ agent: sampleAgent({ billing_capabilities: new Set(['operator']) }) });
+    platform.accounts.upsert = async refs =>
+      refs.slice(0, 1).map(ref => ({
+        account_id: 'acc_1',
+        brand: ref.brand,
+        operator: ref.operator,
+        action: 'created',
+        status: 'active',
+        billing: ref.billing,
+      }));
+    const server = createServer(platform, { exposeErrorDetails: true });
+
+    const result = await syncAccountsBatch(server, [
+      {
+        brand: { domain: 'ok-1.example' },
+        operator: 'agency.example',
+        billing: 'operator',
+      },
+      {
+        brand: { domain: 'ok-2.example' },
+        operator: 'agency.example',
+        billing: 'operator',
+      },
+    ]);
+
+    assert.equal(result.isError, true);
+    assert.equal(result.structuredContent.adcp_error.code, 'SERVICE_UNAVAILABLE');
+    assert.match(
+      result.structuredContent.adcp_error.message,
+      /sync_accounts accounts\.upsert returned 1 row for 2 accepted account entries/
+    );
   });
 
   it('emits BRAND_REQUIRED when a billable account sync entry has no brand or account_id', async () => {

--- a/test/server-idempotency.test.js
+++ b/test/server-idempotency.test.js
@@ -48,6 +48,29 @@ function makeServer({ handler, resolveIdempotencyPrincipal } = {}) {
   return { server, idempotency, calls };
 }
 
+function makeSyncAccountsServer({ handler } = {}) {
+  const idempotency = createIdempotencyStore({
+    backend: memoryBackend({ sweepIntervalMs: 0 }),
+    ttlSeconds: 86400,
+  });
+  const calls = [];
+  const server = createAdcpServer({
+    name: 'Test',
+    version: '1.0.0',
+    idempotency,
+    resolveSessionKey: () => 'tenant_a',
+    accounts: {
+      syncAccounts: async (params, ctx) => {
+        calls.push({ params, ctx });
+        if (handler) return handler(params, ctx);
+        return { accounts: [] };
+      },
+    },
+  });
+
+  return { server, idempotency, calls };
+}
+
 const basePayload = {
   account: { brand: { domain: 'acme.example' }, operator: 'op.example' },
   brand: { domain: 'acme.example' },
@@ -425,6 +448,31 @@ describe('createAdcpServer with idempotency', () => {
       start_time: '2026-06-01T00:00:00Z',
     });
     assert.equal(conflict.adcp_error?.code, 'IDEMPOTENCY_CONFLICT');
+  });
+
+  it('caches sync_accounts rejected rows that do not carry commercial bypass errors', async () => {
+    const { server, calls } = makeSyncAccountsServer({
+      handler: params => ({
+        accounts: params.accounts.map(account => ({
+          brand: account.brand,
+          operator: account.operator,
+          action: 'failed',
+          status: 'rejected',
+        })),
+      }),
+    });
+    const req = {
+      idempotency_key: 'sync_rejected_cache_01',
+      accounts: [{ brand: { domain: 'acme.example' }, operator: 'op.example' }],
+    };
+
+    const first = await callTool(server, 'sync_accounts', req);
+    const second = await callTool(server, 'sync_accounts', req);
+
+    assert.equal(calls.length, 1, 'stable rejected rows without errors[] should be replay cached');
+    assert.equal(first.accounts[0].status, 'rejected');
+    assert.equal(second.replayed, true);
+    assert.equal(second.accounts[0].status, 'rejected');
   });
 
   it('strict-mode parallel retries of a drifted handler see in-flight, not re-execution', async () => {


### PR DESCRIPTION
## Summary

- Assert that `accounts.upsert` returns exactly one row per accepted `sync_accounts` entry before merging framework-generated rejection rows.
- Keep stable rejected `sync_accounts` rows replay-cacheable when they do not include explicit commercial bypass error codes.
- Add regression coverage for mixed accepted/rejected batches, row-count diagnostics, and rejected-row idempotency replay.

Closes #2075.
Closes #2076.

## Validation

- `npm run build:lib`
- `NODE_ENV=test node --test test/server-buyer-agent-billing.test.js`
- `NODE_ENV=test node --test test/server-idempotency.test.js`
- `npm run test:node:fast`
- `npx prettier --check src/lib/server/create-adcp-server.ts src/lib/server/decisioning/runtime/from-platform.ts test/server-buyer-agent-billing.test.js test/server-idempotency.test.js .changeset/sync-accounts-followups.md`
