### PR TITLE
fix(argus): support fork PR reviews safely

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -19,7 +19,7 @@ name: AI PR Review (Argus)
 # Adapted from adcontextprotocol/adcp's Argus workflow (PR #4816).
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - labeled
@@ -39,8 +39,13 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
+      # This workflow uses pull_request_target so fork PRs can access the
+      # review App token and Anthropic secret. Never check out the PR head or
+      # execute PR-controlled code in this job. Keep the workspace pinned to the
+      # trusted base SHA and inspect the PR through GitHub APIs / gh pr diff.
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 0
 
       # ─────────────────────────────────────────────────────────────────────
@@ -56,6 +61,58 @@ jobs:
           private-key: ${{ secrets.IPR_APP_PRIVATE_KEY }}
 
       # ─────────────────────────────────────────────────────────────────────
+      # Self-modification gate. If the PR's cumulative diff touches Argus's
+      # own configuration (`.github/workflows/ai-review.yml` or any file
+      # under `.github/ai-review/**`), skip Argus entirely and post a
+      # notice that a human reviewer is required.
+      # ─────────────────────────────────────────────────────────────────────
+      - name: Self-modification check
+        id: self-mod
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          TOUCHED="$(gh pr diff "$PR_NUMBER" --repo "$REPO" --name-only \
+            | grep -E '^(\.github/workflows/ai-review\.yml|\.github/ai-review/)' || true)"
+          if [ -n "$TOUCHED" ]; then
+            echo "touches=true" >> "$GITHUB_OUTPUT"
+            echo "Argus paths touched — pausing Argus on this PR. Files:"
+            echo "$TOUCHED"
+          else
+            echo "touches=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Post Argus-paused notice
+        if: steps.self-mod.outputs.touches == 'true'
+        uses: actions/github-script@v7
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const marker = '<!-- argus-self-mod-notice -->';
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            if (comments.some(c => c.body && c.body.includes(marker))) {
+              core.info('Notice already posted on this PR — skipping.');
+              return;
+            }
+            const runUrl = process.env.RUN_URL;
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `${marker}\n🛑 **Argus paused on this PR.**\n\nThis PR modifies Argus's own configuration (\`.github/workflows/ai-review.yml\` or \`.github/ai-review/**\`). Argus will not post an approving review on changes to its own gates — a human reviewer must take this PR.\n\n[Workflow run](${runUrl})\n\n<sub>Automated by the Argus self-modification gate.</sub>`,
+            });
+
+      # ─────────────────────────────────────────────────────────────────────
       # Skip re-runs on `synchronize` when the last bot review on this PR
       # was APPROVED and the new commits only touch trivial paths (docs,
       # changesets, tests, generated files). Cuts thrash on rebases and
@@ -64,7 +121,7 @@ jobs:
       # ─────────────────────────────────────────────────────────────────────
       - name: Check for skippable re-run
         id: skip-check
-        if: github.event.action == 'synchronize'
+        if: github.event.action == 'synchronize' && steps.self-mod.outputs.touches != 'true'
         continue-on-error: true
         shell: bash
         env:
@@ -82,18 +139,11 @@ jobs:
             echo "No prior bot APPROVED review — running full review."
             exit 0
           fi
-          if ! git cat-file -e "$PRIOR_SHA" 2>/dev/null; then
-            git fetch --quiet origin "$PRIOR_SHA" 2>/dev/null || true
-          fi
-          if ! git cat-file -e "$PRIOR_SHA" 2>/dev/null; then
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-            echo "Prior review SHA $PRIOR_SHA unreachable (likely force-pushed) — running full review."
-            exit 0
-          fi
-          CHANGED="$(git diff --name-only "$PRIOR_SHA" "$HEAD_SHA")"
+          CHANGED="$(gh api "/repos/${REPO}/compare/${PRIOR_SHA}...${HEAD_SHA}" \
+            --jq '.files[]?.filename' 2>/dev/null || true)"
           if [ -z "$CHANGED" ]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "No file changes since prior approval at $PRIOR_SHA — skipping."
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "Could not compare $PRIOR_SHA...$HEAD_SHA (likely force-pushed or fork edge case) — running full review."
             exit 0
           fi
           # Trivial paths in adcp-client — re-pushes touching only these skip re-review.
@@ -133,18 +183,24 @@ jobs:
           fi
 
       - name: Build Argus review prompt
-        if: steps.skip-check.outputs.skip != 'true'
+        if: steps.self-mod.outputs.touches != 'true' && steps.skip-check.outputs.skip != 'true'
         id: build-prompt
         shell: bash
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          PROMPT_BODY="$(cat .github/ai-review/expert-adcp-reviewer.md)"
+          if ! git cat-file -e "${BASE_SHA}:.github/ai-review/expert-adcp-reviewer.md" 2>/dev/null; then
+            echo "::error::Prompt file does not exist at base SHA ${BASE_SHA}. Self-modification gate should have caught this."
+            exit 1
+          fi
+          PROMPT_BODY="$(git show "${BASE_SHA}:.github/ai-review/expert-adcp-reviewer.md")"
+          SENTINEL="ARGUS_$(openssl rand -hex 8)_EOF"
           {
-            echo 'ARGUS_PROMPT<<ARGUS_EOF'
+            echo "ARGUS_PROMPT<<${SENTINEL}"
             echo "$PROMPT_BODY"
             echo ''
             echo '---'
@@ -154,12 +210,12 @@ jobs:
             echo "- PR_NUMBER: $PR_NUMBER"
             echo "- REPO: $REPO"
             echo "- PR_BASE_REF: $PR_BASE_REF"
-            echo 'ARGUS_EOF'
+            echo "${SENTINEL}"
           } >> "$GITHUB_OUTPUT"
 
       - name: Run Argus PR Review
         id: ai-review
-        if: steps.skip-check.outputs.skip != 'true'
+        if: steps.self-mod.outputs.touches != 'true' && steps.skip-check.outputs.skip != 'true'
         continue-on-error: true
         uses: anthropics/claude-code-action@v1
         with:
@@ -175,7 +231,7 @@ jobs:
 
       - name: Verify Argus posted a review
         id: verify
-        if: always() && steps.app-token.outcome == 'success' && steps.skip-check.outputs.skip != 'true'
+        if: always() && steps.app-token.outcome == 'success' && steps.self-mod.outputs.touches != 'true' && steps.skip-check.outputs.skip != 'true'
         shell: bash
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -205,7 +261,7 @@ jobs:
           echo "review_state=$STATE" >> "$GITHUB_OUTPUT"
 
       - name: Comment on PR if Argus review failed
-        if: steps.skip-check.outputs.skip != 'true' && (steps.ai-review.outcome == 'failure' || steps.verify.outputs.review_posted != 'true')
+        if: steps.self-mod.outputs.touches != 'true' && steps.skip-check.outputs.skip != 'true' && (steps.ai-review.outcome == 'failure' || steps.verify.outputs.review_posted != 'true')
         uses: actions/github-script@v7
         env:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
## Summary
- run Argus on pull_request_target so fork PRs can access the review App token and Anthropic secret
- keep checkout pinned to the trusted base SHA and inspect PR changes through GitHub APIs
- add a self-modification gate so Argus does not approve changes to its own workflow or prompt
- avoid local prior-SHA diffs in the skip check, falling back to full review when compare data is unavailable

## Validation
- git diff --check