### PR TITLE
feat: add preferred upstream attestation mode

### DIFF
--- a/.changeset/preferred-attestation-mode.md
+++ b/.changeset/preferred-attestation-mode.md
@@ -1,0 +1,6 @@
+---
+'@adcp/sdk': patch
+---
+
+Add a storyboard-level `preferred_attestation_mode` hint for upstream traffic
+controller prefetches.

--- a/src/lib/testing/storyboard/loader.ts
+++ b/src/lib/testing/storyboard/loader.ts
@@ -74,8 +74,27 @@ export function validateStoryboardShape(storyboard: Storyboard): void {
       validateFixtureForMutatingStep(storyboard.id, phase, step);
       validateOmitFlagCoherence(storyboard.id, phase, step);
       validateContextOutputs(storyboard.id, phase, step);
+      validateUpstreamAttestationMode(storyboard.id, phase, step);
       validateUpstreamIdentifierPaths(storyboard.id, phase, step);
       validatePeerSubstitutesFor(storyboard.id, phase, step);
+    }
+  }
+}
+
+function validateUpstreamAttestationMode(
+  storyboardId: string,
+  phase: { id?: string },
+  step: { id?: string; validations?: any[] }
+): void {
+  const validations = step.validations ?? [];
+  for (let validationIndex = 0; validationIndex < validations.length; validationIndex++) {
+    const validation = validations[validationIndex];
+    if (validation?.check !== 'upstream_traffic') continue;
+    const mode = validation.preferred_attestation_mode;
+    if (mode !== undefined && mode !== 'raw' && mode !== 'digest') {
+      throw new Error(
+        `[${storyboardId}] ${phase.id ?? '?'}.${step.id ?? '?'}.validations[${validationIndex}].preferred_attestation_mode: must be "raw" or "digest"`
+      );
     }
   }
 }

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -5309,8 +5309,14 @@ async function prefetchUpstreamTraffic(
   const requiresRawAttestation = upstreamChecks.some(
     check => check.attestation_mode_required === 'raw' || (check.payload_must_contain?.length ?? 0) > 0
   );
+  const prefersRawAttestation = upstreamChecks.some(check => check.preferred_attestation_mode === 'raw');
+  const prefersDigestAttestation = upstreamChecks.some(check => check.preferred_attestation_mode === 'digest');
   const requestedAttestationMode: 'raw' | 'digest' =
-    !requiresRawAttestation && identifier_value_digests.length > 0 ? 'digest' : 'raw';
+    requiresRawAttestation || prefersRawAttestation
+      ? 'raw'
+      : prefersDigestAttestation || identifier_value_digests.length > 0
+        ? 'digest'
+        : 'raw';
   for (const sinceTs of sinceTimestamps) {
     // Per spec PR adcp#3816: runners SHOULD subtract a clock-skew tolerance
     // (50ms minimum, 250ms recommended) before sending the bound to the

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -1081,6 +1081,14 @@ export interface StoryboardValidation {
    */
   attestation_mode_required?: 'raw';
   /**
+   * Advisory request-mode preference for the runner's
+   * `query_upstream_traffic` prefetch. When omitted, the runner preserves
+   * its legacy inference: digest for identifier-only checks with digestable
+   * vectors, raw otherwise. Raw-required validations and payload
+   * introspection always take precedence over this preference.
+   */
+  preferred_attestation_mode?: 'raw' | 'digest';
+  /**
    * Paths into the effective request payload that name the load-bearing
    * identifiers the adapter MUST forward upstream. When the runner has the
    * actual request payload after context substitution, that payload is the

--- a/src/lib/testing/storyboard/validations.ts
+++ b/src/lib/testing/storyboard/validations.ts
@@ -2957,6 +2957,9 @@ function buildUpstreamTrafficExpected(validation: StoryboardValidation): Record<
   if (validation.attestation_mode_required !== undefined) {
     expected.attestation_mode_required = validation.attestation_mode_required;
   }
+  if (validation.preferred_attestation_mode !== undefined) {
+    expected.preferred_attestation_mode = validation.preferred_attestation_mode;
+  }
   if (validation.identifier_paths !== undefined) expected.identifier_paths = validation.identifier_paths;
   return expected;
 }

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP SDK library version
  */
-export const LIBRARY_VERSION = '8.1.0-beta.13';
+export const LIBRARY_VERSION = '8.1.0-beta.14';
 
 /**
  * AdCP specification version this library is built for
@@ -64,10 +64,10 @@ export type AdcpVersion = (typeof COMPATIBLE_ADCP_VERSIONS)[number];
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '8.1.0-beta.13',
+  library: '8.1.0-beta.14',
   adcp: '3.1.0-beta.5',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-05-27T01:20:44.064Z',
+  generatedAt: '2026-05-28T08:57:32.277Z',
 } as const;
 
 /**

--- a/test/lib/storyboard-requires-gate.test.js
+++ b/test/lib/storyboard-requires-gate.test.js
@@ -251,6 +251,14 @@ phases:
     );
   });
 
+  test('rejects invalid preferred_attestation_mode values', () => {
+    const yaml = storyboardWithIdentifierPath('audiences[*].add[*].hashed_email').replace(
+      'identifier_paths:',
+      'preferred_attestation_mode: compact\n            identifier_paths:'
+    );
+    assert.throws(() => parseStoryboard(yaml), /preferred_attestation_mode.*must be "raw" or "digest"/);
+  });
+
   test('runStoryboardStep invokes identifier_paths authoring validation', async () => {
     const storyboard = buildStoryboard();
     storyboard.phases[0].steps[0].validations = [

--- a/test/lib/storyboard-runner-output-contract-v2-runner.test.js
+++ b/test/lib/storyboard-runner-output-contract-v2-runner.test.js
@@ -222,6 +222,136 @@ describe('runStoryboardStep — upstream_traffic pre-fetch end-to-end', () => {
     assert.deepEqual(upstreamValidation.actual.missing_identifier_values, []);
   });
 
+  test('honors preferred_attestation_mode raw over identifier-only digest inference', async () => {
+    let receivedMode;
+    const { client } = buildStubClient(
+      {
+        sync_audiences: async () => ({
+          success: true,
+          data: { audiences: [{ audience_id: 'aud_1', status: 'syncing' }] },
+        }),
+      },
+      params => {
+        receivedMode = params.params?.attestation_mode;
+        return {
+          success: true,
+          data: {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify({
+                  success: true,
+                  recorded_calls: [
+                    {
+                      method: 'POST',
+                      endpoint: 'POST https://api.example.test/v1/audience/upload',
+                      url: 'https://api.example.test/v1/audience/upload',
+                      content_type: 'application/json',
+                      attestation_mode: 'raw',
+                      payload: {
+                        users: [{ hashed_email: 'vec-real-1' }, { hashed_email: 'vec-real-2' }],
+                      },
+                      payload_length: 68,
+                      timestamp: '2026-05-02T14:30:01.000Z',
+                    },
+                  ],
+                  total_count: 1,
+                  since_timestamp: params.params?.since_timestamp,
+                }),
+              },
+            ],
+          },
+        };
+      }
+    );
+    const rawPreferredStoryboard = JSON.parse(JSON.stringify(storyboard));
+    rawPreferredStoryboard.phases[0].steps[0].validations = [
+      {
+        check: 'upstream_traffic',
+        description: 'hashed emails MUST be proven with raw attestations',
+        min_count: 1,
+        preferred_attestation_mode: 'raw',
+        identifier_paths: ['audiences[*].add[*].hashed_email'],
+      },
+    ];
+
+    const result = await runStoryboardStep('https://stub.example/mcp', rawPreferredStoryboard, 'sync', {
+      protocol: 'mcp',
+      _client: client,
+      _profile: stubProfile,
+      _controllerCapabilities: { detected: true, scenarios: ['query_upstream_traffic'] },
+    });
+
+    assert.equal(receivedMode, 'raw');
+    const upstreamValidation = result.validations.find(v => v.check === 'upstream_traffic');
+    assert.equal(upstreamValidation.passed, true);
+    assert.deepEqual(upstreamValidation.actual.missing_identifier_values, []);
+  });
+
+  test('honors preferred_attestation_mode digest for count-only upstream checks', async () => {
+    let receivedMode;
+    const { client } = buildStubClient(
+      {
+        sync_audiences: async () => ({
+          success: true,
+          data: { audiences: [{ audience_id: 'aud_1', status: 'syncing' }] },
+        }),
+      },
+      params => {
+        receivedMode = params.params?.attestation_mode;
+        return {
+          success: true,
+          data: {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify({
+                  success: true,
+                  recorded_calls: [
+                    {
+                      method: 'POST',
+                      endpoint: 'POST https://api.example.test/v1/audience/upload',
+                      url: 'https://api.example.test/v1/audience/upload',
+                      content_type: 'application/json',
+                      attestation_mode: 'digest',
+                      payload_digest_sha256: sha256Hex('canonical-body'),
+                      payload_length: 68,
+                      timestamp: '2026-05-02T14:30:01.000Z',
+                    },
+                  ],
+                  total_count: 1,
+                  since_timestamp: params.params?.since_timestamp,
+                }),
+              },
+            ],
+          },
+        };
+      }
+    );
+    const digestPreferredStoryboard = JSON.parse(JSON.stringify(storyboard));
+    digestPreferredStoryboard.phases[0].steps[0].validations = [
+      {
+        check: 'upstream_traffic',
+        description: 'count-only upstream traffic can prefer digest attestations',
+        min_count: 1,
+        preferred_attestation_mode: 'digest',
+      },
+    ];
+
+    const result = await runStoryboardStep('https://stub.example/mcp', digestPreferredStoryboard, 'sync', {
+      protocol: 'mcp',
+      _client: client,
+      _profile: stubProfile,
+      _controllerCapabilities: { detected: true, scenarios: ['query_upstream_traffic'] },
+    });
+
+    assert.equal(receivedMode, 'digest');
+    const upstreamValidation = result.validations.find(v => v.check === 'upstream_traffic');
+    assert.equal(upstreamValidation.passed, true);
+    assert.equal(upstreamValidation.expected.preferred_attestation_mode, 'digest');
+    assert.equal(upstreamValidation.actual.matched_count, 1);
+  });
+
   test('invalid identifier_paths fail as authoring errors without querying controller', async () => {
     const invalidStoryboard = JSON.parse(JSON.stringify(storyboard));
     invalidStoryboard.phases[0].steps[0].validations = [


### PR DESCRIPTION
## Summary

- Adds `preferred_attestation_mode` to `upstream_traffic` storyboard validations.
- Validates authored values as `"raw"` or `"digest"`.
- Maps the preference into `query_upstream_traffic.attestation_mode` while preserving existing defaults: raw-required checks and payload introspection still force raw; identifier-only checks still infer digest when no preference is present.
- Echoes the preference in validation `expected` output and adds coverage for raw and digest preference paths.

Closes #2051.

## Validation

- `npx prettier --check src/lib/testing/storyboard/types.ts src/lib/testing/storyboard/loader.ts src/lib/testing/storyboard/runner.ts src/lib/testing/storyboard/validations.ts test/lib/storyboard-requires-gate.test.js test/lib/storyboard-runner-output-contract-v2-runner.test.js .changeset/preferred-attestation-mode.md`
- `npm run build:lib`
- `NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/lib/storyboard-requires-gate.test.js`
- `NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/lib/storyboard-runner-output-contract-v2-runner.test.js`
- `npm run test:lib:fast`
- pre-push hook: `npm run typecheck`, library build
