### PR TITLE
fix: harden format schema regex budget

### DIFF
--- a/.changeset/canonical-reference-regex-budget.md
+++ b/.changeset/canonical-reference-regex-budget.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Reject catastrophic `format_schema` regex patterns in canonical reference resolution with `invalid_schema` / `budget_exceeded`.

--- a/docs/guides/CANONICAL-REFERENCE-RESOLVER.md
+++ b/docs/guides/CANONICAL-REFERENCE-RESOLVER.md
@@ -45,13 +45,13 @@ The API is structured and non-throwing. Branch on `result.ok` first, then `resul
 
 Successful results include `document`, `body`, `text`, `httpStatus`, `contentType`, `cacheKey`, and `fromCache`. `resolveFormatSchema()` additionally returns `schemaMeta` with draft, `$ref` count, max `$ref` depth observed, keyword count, and compile time.
 
-Failure statuses are coarse buckets: `unresolvable`, `invalid_document`, `invalid_schema`, `digest_mismatch`, `blocked_unsafe_url`, and `invalid_ref`. The more precise field is `error.code`, including `http_error`, `network_error`, `invalid_json`, `external_ref_unpinned`, `ref_sandbox_violation`, `keyword_limit_exceeded`, and `digest_mismatch`.
+Failure statuses are coarse buckets: `unresolvable`, `invalid_document`, `invalid_schema`, `digest_mismatch`, `blocked_unsafe_url`, and `invalid_ref`. The more precise field is `error.code`, including `http_error`, `network_error`, `invalid_json`, `external_ref_unpinned`, `ref_sandbox_violation`, `keyword_limit_exceeded`, `budget_exceeded`, and `digest_mismatch`.
 
 Transient network and 5xx failures return `unresolvable` with `error.retryable: true`. Digest mismatch returns `digest_mismatch` with `error.securitySignal: 'substitution_attack'`.
 
 ## Format Schemas
 
-`resolveFormatSchema()` requires an explicit `$schema` and validates the fetched document as Draft-07 or Draft 2020-12 JSON Schema. It sandboxes `$ref` to intra-document, same-origin, or trusted Agentic Advertising mirror refs, rejects `file://`, `http://`, private-network and metadata refs by default, and enforces `$ref` depth/count plus keyword and compile-time bounds.
+`resolveFormatSchema()` requires an explicit `$schema` and validates the fetched document as Draft-07 or Draft 2020-12 JSON Schema. It sandboxes `$ref` to intra-document, same-origin, or trusted Agentic Advertising mirror refs, rejects `file://`, `http://`, private-network and metadata refs by default, and enforces `$ref` depth/count plus keyword, regex-safety, and compile-time bounds. Regexes with known catastrophic shapes, such as nested unbounded quantifiers in a repeated group, fail as `invalid_schema` with `error.code: 'budget_exceeded'`.
 
 External `$ref` bodies are mutable unless pinned. The canonical resolver therefore requires `externalRefDigests` for every external `$ref` URI. Missing pins return `invalid_schema` with `error.code: 'external_ref_unpinned'`; mismatched pins return `digest_mismatch`. Successful external refs share the same policy-scoped cache as root canonical references.
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -122,7 +122,7 @@ if (!result.ok) {
 }
 ```
 
-For `format_schema`, the resolver requires an explicit `$schema`, validates Draft-07 / Draft 2020-12 JSON Schema, inlines only pinned safe `$ref` targets, and returns `schemaMeta` on success. Failure statuses are coarse (`unresolvable`, `invalid_document`, `invalid_schema`, `digest_mismatch`, `blocked_unsafe_url`, `invalid_ref`); branch on `error.code` for precise handling. See `docs/guides/CANONICAL-REFERENCE-RESOLVER.md`.
+For `format_schema`, the resolver requires an explicit `$schema`, validates Draft-07 / Draft 2020-12 JSON Schema, inlines only pinned safe `$ref` targets, rejects known catastrophic regex patterns with `error.code: 'budget_exceeded'`, and returns `schemaMeta` on success. Failure statuses are coarse (`unresolvable`, `invalid_document`, `invalid_schema`, `digest_mismatch`, `blocked_unsafe_url`, `invalid_ref`); branch on `error.code` for precise handling. See `docs/guides/CANONICAL-REFERENCE-RESOLVER.md`.
 
 ## Transport auth
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/sdk",
-  "version": "8.1.0-beta.13",
+  "version": "8.1.0-beta.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/sdk",
-      "version": "8.1.0-beta.13",
+      "version": "8.1.0-beta.14",
       "license": "Apache-2.0",
       "workspaces": [
         ".",
@@ -7348,7 +7348,7 @@
       "version": "6.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adcp/sdk": "^8.1.0-beta.13"
+        "@adcp/sdk": "^8.1.0-beta.14"
       },
       "bin": {
         "adcp": "bin/adcp.js"

--- a/scripts/generate-agent-docs.ts
+++ b/scripts/generate-agent-docs.ts
@@ -678,7 +678,7 @@ function generateLlmsTxt(
   ln('```');
   ln();
   ln(
-    `For \`format_schema\`, the resolver requires an explicit \`$schema\`, validates Draft-07 / Draft 2020-12 JSON Schema, inlines only pinned safe \`$ref\` targets, and returns \`schemaMeta\` on success. Failure statuses are coarse (\`unresolvable\`, \`invalid_document\`, \`invalid_schema\`, \`digest_mismatch\`, \`blocked_unsafe_url\`, \`invalid_ref\`); branch on \`error.code\` for precise handling. See \`docs/guides/CANONICAL-REFERENCE-RESOLVER.md\`.`
+    `For \`format_schema\`, the resolver requires an explicit \`$schema\`, validates Draft-07 / Draft 2020-12 JSON Schema, inlines only pinned safe \`$ref\` targets, rejects known catastrophic regex patterns with \`error.code: 'budget_exceeded'\`, and returns \`schemaMeta\` on success. Failure statuses are coarse (\`unresolvable\`, \`invalid_document\`, \`invalid_schema\`, \`digest_mismatch\`, \`blocked_unsafe_url\`, \`invalid_ref\`); branch on \`error.code\` for precise handling. See \`docs/guides/CANONICAL-REFERENCE-RESOLVER.md\`.`
   );
   ln();
 

--- a/src/lib/canonical-references/index.ts
+++ b/src/lib/canonical-references/index.ts
@@ -22,6 +22,7 @@ import {
   SchemaRefSandboxError,
   type ResolveSchemaRefsOptions,
 } from '../v2/format-schema/sandbox-refs';
+import { findUnsafeRegexPattern } from '../v2/format-schema/regex-safety';
 
 export interface CanonicalReference {
   uri: string;
@@ -54,6 +55,7 @@ export type CanonicalReferenceErrorCode =
   | 'ref_sandbox_violation'
   | 'external_ref_unpinned'
   | 'keyword_limit_exceeded'
+  | 'budget_exceeded'
   | 'digest_mismatch';
 
 export interface CanonicalReferenceError {
@@ -635,6 +637,19 @@ async function validateFormatSchema(
         message: `format_schema keyword count exceeded ${maxKeywords}`,
         retryable: false,
         details: { keywordCount, maxKeywords },
+      },
+    };
+  }
+
+  const unsafeRegex = findUnsafeRegexPattern(resolved.schema);
+  if (unsafeRegex) {
+    return {
+      ok: false,
+      error: {
+        code: 'budget_exceeded',
+        message: 'format_schema regex safety budget exceeded',
+        retryable: false,
+        details: { ...unsafeRegex },
       },
     };
   }

--- a/src/lib/canonical-references/index.ts
+++ b/src/lib/canonical-references/index.ts
@@ -22,7 +22,7 @@ import {
   SchemaRefSandboxError,
   type ResolveSchemaRefsOptions,
 } from '../v2/format-schema/sandbox-refs';
-import { findUnsafeRegexPattern } from '../v2/format-schema/regex-safety';
+import { findUnsafeRegexPattern, unsafeRegexDetails } from '../v2/format-schema/regex-safety';
 
 export interface CanonicalReference {
   uri: string;
@@ -649,7 +649,7 @@ async function validateFormatSchema(
         code: 'budget_exceeded',
         message: 'format_schema regex safety budget exceeded',
         retryable: false,
-        details: { ...unsafeRegex },
+        details: unsafeRegexDetails(unsafeRegex),
       },
     };
   }

--- a/src/lib/v2/format-schema/index.ts
+++ b/src/lib/v2/format-schema/index.ts
@@ -66,3 +66,5 @@ export {
   type CanonicalReferenceResolverOptions,
   type ResolveCanonicalReferenceOptions,
 } from './resolver';
+
+export { findUnsafeRegexPattern, type UnsafeRegexPattern } from './regex-safety';

--- a/src/lib/v2/format-schema/index.ts
+++ b/src/lib/v2/format-schema/index.ts
@@ -67,4 +67,4 @@ export {
   type ResolveCanonicalReferenceOptions,
 } from './resolver';
 
-export { findUnsafeRegexPattern, type UnsafeRegexPattern } from './regex-safety';
+export { findUnsafeRegexPattern, unsafeRegexDetails, type UnsafeRegexPattern } from './regex-safety';

--- a/src/lib/v2/format-schema/regex-safety.ts
+++ b/src/lib/v2/format-schema/regex-safety.ts
@@ -1,0 +1,236 @@
+export interface UnsafeRegexPattern {
+  location: string;
+  pattern: string;
+  reason: 'nested_unbounded_quantifier' | 'ambiguous_repeated_alternation';
+}
+
+interface RegexGroup {
+  body: string;
+  end: number;
+}
+
+export function findUnsafeRegexPattern(root: unknown): UnsafeRegexPattern | undefined {
+  const seen = new Set<unknown>();
+
+  function walk(node: unknown, pointer: string): UnsafeRegexPattern | undefined {
+    if (!node || typeof node !== 'object') return undefined;
+    if (seen.has(node)) return undefined;
+    seen.add(node);
+
+    if (Array.isArray(node)) {
+      for (let index = 0; index < node.length; index += 1) {
+        const unsafe = walk(node[index], `${pointer}/${index}`);
+        if (unsafe) return unsafe;
+      }
+      return undefined;
+    }
+
+    const obj = node as Record<string, unknown>;
+    for (const [key, value] of Object.entries(obj)) {
+      const keyPointer = `${pointer}/${escapeJsonPointer(key)}`;
+      if (key === 'pattern' && typeof value === 'string') {
+        const unsafe = analyzeRegexPattern(value, keyPointer);
+        if (unsafe) return unsafe;
+      }
+      if (key === 'patternProperties' && value && typeof value === 'object' && !Array.isArray(value)) {
+        for (const pattern of Object.keys(value as Record<string, unknown>)) {
+          const unsafe = analyzeRegexPattern(pattern, `${keyPointer}/${escapeJsonPointer(pattern)}`);
+          if (unsafe) return unsafe;
+        }
+      }
+      const unsafe = walk(value, keyPointer);
+      if (unsafe) return unsafe;
+    }
+    return undefined;
+  }
+
+  return walk(root, '');
+}
+
+function analyzeRegexPattern(pattern: string, location: string): UnsafeRegexPattern | undefined {
+  for (const group of collectGroups(pattern)) {
+    const quantifier = readQuantifier(pattern, group.end + 1);
+    if (!quantifier.unbounded) continue;
+
+    if (containsUnboundedQuantifier(group.body)) {
+      return { location, pattern, reason: 'nested_unbounded_quantifier' };
+    }
+    if (hasAmbiguousAlternation(group.body)) {
+      return { location, pattern, reason: 'ambiguous_repeated_alternation' };
+    }
+  }
+  return undefined;
+}
+
+function collectGroups(pattern: string): RegexGroup[] {
+  const groups: RegexGroup[] = [];
+  const stack: number[] = [];
+  let escaped = false;
+  let inClass = false;
+
+  for (let index = 0; index < pattern.length; index += 1) {
+    const char = pattern[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (char === '[') {
+      inClass = true;
+      continue;
+    }
+    if (char === ']' && inClass) {
+      inClass = false;
+      continue;
+    }
+    if (inClass) continue;
+    if (char === '(') {
+      stack.push(index);
+      continue;
+    }
+    if (char === ')') {
+      const start = stack.pop();
+      if (start !== undefined) {
+        groups.push({ body: pattern.slice(start + 1, index), end: index });
+      }
+    }
+  }
+
+  return groups;
+}
+
+function containsUnboundedQuantifier(source: string): boolean {
+  let escaped = false;
+  let inClass = false;
+
+  for (let index = 0; index < source.length; index += 1) {
+    const char = source[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (char === '[') {
+      inClass = true;
+      continue;
+    }
+    if (char === ']' && inClass) {
+      inClass = false;
+      continue;
+    }
+    if (inClass) continue;
+    if (char === '*' || char === '+') return true;
+    if (char === '{' && readQuantifier(source, index).unbounded) return true;
+  }
+
+  return false;
+}
+
+function readQuantifier(source: string, index: number): { unbounded: boolean } {
+  const char = source[index];
+  if (char === '*' || char === '+') return { unbounded: true };
+  if (char !== '{') return { unbounded: false };
+
+  const match = /^\{(\d+)(?:,(\d*))?\}/.exec(source.slice(index));
+  if (!match) return { unbounded: false };
+  return { unbounded: match[2] === '' };
+}
+
+function hasAmbiguousAlternation(source: string): boolean {
+  const alternatives = splitTopLevelAlternatives(stripGroupPrefix(source));
+  if (alternatives.length < 2) return false;
+
+  const prefixes = alternatives.map(literalPrefix).filter(prefix => prefix.length > 0);
+  for (let left = 0; left < prefixes.length; left += 1) {
+    for (let right = 0; right < prefixes.length; right += 1) {
+      const leftPrefix = prefixes[left];
+      const rightPrefix = prefixes[right];
+      if (leftPrefix && rightPrefix && left !== right && rightPrefix.startsWith(leftPrefix)) return true;
+    }
+  }
+  return false;
+}
+
+function splitTopLevelAlternatives(source: string): string[] {
+  const alternatives: string[] = [];
+  let start = 0;
+  let escaped = false;
+  let inClass = false;
+  let depth = 0;
+
+  for (let index = 0; index < source.length; index += 1) {
+    const char = source[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (char === '[') {
+      inClass = true;
+      continue;
+    }
+    if (char === ']' && inClass) {
+      inClass = false;
+      continue;
+    }
+    if (inClass) continue;
+    if (char === '(') {
+      depth += 1;
+      continue;
+    }
+    if (char === ')' && depth > 0) {
+      depth -= 1;
+      continue;
+    }
+    if (char === '|' && depth === 0) {
+      alternatives.push(source.slice(start, index));
+      start = index + 1;
+    }
+  }
+  alternatives.push(source.slice(start));
+  return alternatives;
+}
+
+function literalPrefix(source: string): string {
+  let prefix = '';
+  let escaped = false;
+
+  for (const char of source) {
+    if (escaped) {
+      prefix += `\\${char}`;
+      escaped = false;
+      continue;
+    }
+    if (char === '\\') {
+      escaped = true;
+      continue;
+    }
+    if ('^$.*+?()[]{}|'.includes(char)) break;
+    prefix += char;
+  }
+
+  return prefix;
+}
+
+function stripGroupPrefix(source: string): string {
+  if (source.startsWith('?:') || source.startsWith('?=') || source.startsWith('?!')) return source.slice(2);
+  if (source.startsWith('?<=') || source.startsWith('?<!')) return source.slice(3);
+  if (source.startsWith('?<')) {
+    const end = source.indexOf('>');
+    if (end > 2) return source.slice(end + 1);
+  }
+  return source;
+}
+
+function escapeJsonPointer(value: string): string {
+  return value.replace(/~/g, '~0').replace(/\//g, '~1');
+}

--- a/src/lib/v2/format-schema/regex-safety.ts
+++ b/src/lib/v2/format-schema/regex-safety.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'crypto';
+
 export interface UnsafeRegexPattern {
   location: string;
   pattern: string;
@@ -9,53 +11,135 @@ interface RegexGroup {
   end: number;
 }
 
+type QuantifierInfo = {
+  min: number;
+  max: number | null;
+  end: number;
+  unbounded: boolean;
+  variable: boolean;
+};
+
+const SCHEMA_VALUE_KEYWORDS = new Set([
+  'additionalItems',
+  'additionalProperties',
+  'contains',
+  'contentSchema',
+  'else',
+  'if',
+  'items',
+  'not',
+  'propertyNames',
+  'then',
+  'unevaluatedItems',
+  'unevaluatedProperties',
+]);
+
+const SCHEMA_ARRAY_KEYWORDS = new Set(['allOf', 'anyOf', 'oneOf', 'prefixItems']);
+const SCHEMA_MAP_KEYWORDS = new Set(['$defs', 'definitions', 'dependentSchemas', 'properties']);
+
+export function unsafeRegexDetails(pattern: UnsafeRegexPattern): Record<string, unknown> {
+  return {
+    location: pattern.location,
+    reason: pattern.reason,
+    patternLength: pattern.pattern.length,
+    patternPreview: pattern.pattern.replace(/[\u0000-\u001f\u007f-\u009f]/g, '?').slice(0, 120),
+    patternSha256: createHash('sha256').update(pattern.pattern).digest('hex'),
+  };
+}
+
 export function findUnsafeRegexPattern(root: unknown): UnsafeRegexPattern | undefined {
   const seen = new Set<unknown>();
 
-  function walk(node: unknown, pointer: string): UnsafeRegexPattern | undefined {
+  function walkSchema(node: unknown, pointer: string): UnsafeRegexPattern | undefined {
     if (!node || typeof node !== 'object') return undefined;
     if (seen.has(node)) return undefined;
     seen.add(node);
 
-    if (Array.isArray(node)) {
-      for (let index = 0; index < node.length; index += 1) {
-        const unsafe = walk(node[index], `${pointer}/${index}`);
-        if (unsafe) return unsafe;
-      }
-      return undefined;
-    }
+    if (Array.isArray(node)) return walkSchemaArray(node, pointer);
 
     const obj = node as Record<string, unknown>;
-    for (const [key, value] of Object.entries(obj)) {
-      const keyPointer = `${pointer}/${escapeJsonPointer(key)}`;
-      if (key === 'pattern' && typeof value === 'string') {
-        const unsafe = analyzeRegexPattern(value, keyPointer);
+
+    if (typeof obj.pattern === 'string') {
+      const unsafe = analyzeRegexPattern(obj.pattern, `${pointer}/pattern`);
+      if (unsafe) return unsafe;
+    }
+
+    const patternProperties = obj.patternProperties;
+    if (patternProperties && typeof patternProperties === 'object' && !Array.isArray(patternProperties)) {
+      const basePointer = `${pointer}/patternProperties`;
+      for (const [pattern, subschema] of Object.entries(patternProperties as Record<string, unknown>)) {
+        const patternPointer = `${basePointer}/${escapeJsonPointer(pattern)}`;
+        const unsafe = analyzeRegexPattern(pattern, patternPointer) ?? walkSchema(subschema, patternPointer);
         if (unsafe) return unsafe;
       }
-      if (key === 'patternProperties' && value && typeof value === 'object' && !Array.isArray(value)) {
-        for (const pattern of Object.keys(value as Record<string, unknown>)) {
-          const unsafe = analyzeRegexPattern(pattern, `${keyPointer}/${escapeJsonPointer(pattern)}`);
-          if (unsafe) return unsafe;
-        }
+    }
+
+    for (const keyword of SCHEMA_VALUE_KEYWORDS) {
+      const unsafe = walkSchemaValue(obj[keyword], `${pointer}/${keyword}`);
+      if (unsafe) return unsafe;
+    }
+
+    for (const keyword of SCHEMA_ARRAY_KEYWORDS) {
+      const unsafe = walkSchemaArrayValue(obj[keyword], `${pointer}/${keyword}`);
+      if (unsafe) return unsafe;
+    }
+
+    for (const keyword of SCHEMA_MAP_KEYWORDS) {
+      const unsafe = walkSchemaMap(obj[keyword], `${pointer}/${keyword}`);
+      if (unsafe) return unsafe;
+    }
+
+    const dependencies = obj.dependencies;
+    if (dependencies && typeof dependencies === 'object' && !Array.isArray(dependencies)) {
+      for (const [key, value] of Object.entries(dependencies as Record<string, unknown>)) {
+        if (!value || typeof value !== 'object' || Array.isArray(value)) continue;
+        const unsafe = walkSchema(value, `${pointer}/dependencies/${escapeJsonPointer(key)}`);
+        if (unsafe) return unsafe;
       }
-      const unsafe = walk(value, keyPointer);
+    }
+
+    return undefined;
+  }
+
+  function walkSchemaValue(value: unknown, pointer: string): UnsafeRegexPattern | undefined {
+    if (Array.isArray(value)) return walkSchemaArray(value, pointer);
+    return walkSchema(value, pointer);
+  }
+
+  function walkSchemaArrayValue(value: unknown, pointer: string): UnsafeRegexPattern | undefined {
+    if (!Array.isArray(value)) return undefined;
+    return walkSchemaArray(value, pointer);
+  }
+
+  function walkSchemaArray(value: readonly unknown[], pointer: string): UnsafeRegexPattern | undefined {
+    for (let index = 0; index < value.length; index += 1) {
+      const unsafe = walkSchema(value[index], `${pointer}/${index}`);
       if (unsafe) return unsafe;
     }
     return undefined;
   }
 
-  return walk(root, '');
+  function walkSchemaMap(value: unknown, pointer: string): UnsafeRegexPattern | undefined {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+    for (const [key, subschema] of Object.entries(value as Record<string, unknown>)) {
+      const unsafe = walkSchema(subschema, `${pointer}/${escapeJsonPointer(key)}`);
+      if (unsafe) return unsafe;
+    }
+    return undefined;
+  }
+
+  return walkSchema(root, '');
 }
 
 function analyzeRegexPattern(pattern: string, location: string): UnsafeRegexPattern | undefined {
   for (const group of collectGroups(pattern)) {
     const quantifier = readQuantifier(pattern, group.end + 1);
-    if (!quantifier.unbounded) continue;
+    if (!quantifier?.unbounded) continue;
 
-    if (containsUnboundedQuantifier(group.body)) {
+    if (isSingleVariableRepeat(group.body)) {
       return { location, pattern, reason: 'nested_unbounded_quantifier' };
     }
-    if (hasAmbiguousAlternation(group.body)) {
+    if (hasAmbiguousAlternationByTokenPrefix(group.body)) {
       return { location, pattern, reason: 'ambiguous_repeated_alternation' };
     }
   }
@@ -102,12 +186,60 @@ function collectGroups(pattern: string): RegexGroup[] {
   return groups;
 }
 
-function containsUnboundedQuantifier(source: string): boolean {
+function isSingleVariableRepeat(source: string): boolean {
+  const normalized = stripGroupPrefix(source);
+  const first = readRegexAtom(normalized, 0);
+  if (!first) return false;
+
+  const quantifier = readQuantifier(normalized, first.end);
+  if (!quantifier?.variable) return false;
+
+  return quantifier.end === normalized.length;
+}
+
+function readRegexAtom(source: string, index: number): { end: number } | undefined {
+  const char = source[index];
+  if (!char) return undefined;
+
+  if (char === '\\') {
+    return index + 1 < source.length ? { end: index + 2 } : undefined;
+  }
+  if (char === '[') {
+    return readCharacterClass(source, index);
+  }
+  if (char === '(') {
+    return readGroup(source, index);
+  }
+  if ('^$|?*+{}'.includes(char)) return undefined;
+  return { end: index + 1 };
+}
+
+function readCharacterClass(source: string, index: number): { end: number } | undefined {
+  let escaped = false;
+
+  for (let cursor = index + 1; cursor < source.length; cursor += 1) {
+    const char = source[cursor];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (char === ']') return { end: cursor + 1 };
+  }
+
+  return undefined;
+}
+
+function readGroup(source: string, index: number): { end: number } | undefined {
   let escaped = false;
   let inClass = false;
+  let depth = 0;
 
-  for (let index = 0; index < source.length; index += 1) {
-    const char = source[index];
+  for (let cursor = index; cursor < source.length; cursor += 1) {
+    const char = source[cursor];
     if (escaped) {
       escaped = false;
       continue;
@@ -125,36 +257,77 @@ function containsUnboundedQuantifier(source: string): boolean {
       continue;
     }
     if (inClass) continue;
-    if (char === '*' || char === '+') return true;
-    if (char === '{' && readQuantifier(source, index).unbounded) return true;
+    if (char === '(') {
+      depth += 1;
+      continue;
+    }
+    if (char === ')') {
+      depth -= 1;
+      if (depth === 0) return { end: cursor + 1 };
+    }
   }
 
-  return false;
+  return undefined;
 }
 
-function readQuantifier(source: string, index: number): { unbounded: boolean } {
+function readQuantifier(source: string, index: number): QuantifierInfo | undefined {
   const char = source[index];
-  if (char === '*' || char === '+') return { unbounded: true };
-  if (char !== '{') return { unbounded: false };
+  if (char === '?') return { min: 0, max: 1, end: index + 1, unbounded: false, variable: true };
+  if (char === '*') return { min: 0, max: null, end: index + 1, unbounded: true, variable: true };
+  if (char === '+') return { min: 1, max: null, end: index + 1, unbounded: true, variable: true };
+  if (char !== '{') return undefined;
 
   const match = /^\{(\d+)(?:,(\d*))?\}/.exec(source.slice(index));
-  if (!match) return { unbounded: false };
-  return { unbounded: match[2] === '' };
+  if (!match) return undefined;
+
+  const min = Number(match[1]);
+  const max = match[2] === '' ? null : Number(match[2] ?? match[1]);
+  return {
+    min,
+    max,
+    end: index + match[0].length,
+    unbounded: max === null,
+    variable: max === null || min !== max,
+  };
 }
 
-function hasAmbiguousAlternation(source: string): boolean {
+function hasAmbiguousAlternationByTokenPrefix(source: string): boolean {
   const alternatives = splitTopLevelAlternatives(stripGroupPrefix(source));
   if (alternatives.length < 2) return false;
 
-  const prefixes = alternatives.map(literalPrefix).filter(prefix => prefix.length > 0);
-  for (let left = 0; left < prefixes.length; left += 1) {
-    for (let right = 0; right < prefixes.length; right += 1) {
-      const leftPrefix = prefixes[left];
-      const rightPrefix = prefixes[right];
-      if (leftPrefix && rightPrefix && left !== right && rightPrefix.startsWith(leftPrefix)) return true;
+  const tokenized = alternatives.map(tokenizeRegexAtoms).filter(tokens => tokens.length > 0);
+  for (let left = 0; left < tokenized.length; left += 1) {
+    for (let right = 0; right < tokenized.length; right += 1) {
+      const leftTokens = tokenized[left];
+      const rightTokens = tokenized[right];
+      if (leftTokens && rightTokens && left !== right && tokensStartWith(rightTokens, leftTokens)) return true;
     }
   }
   return false;
+}
+
+function tokenizeRegexAtoms(source: string): string[] {
+  const tokens: string[] = [];
+  let cursor = 0;
+
+  while (cursor < source.length) {
+    const atom = readRegexAtom(source, cursor);
+    if (!atom) break;
+    const raw = source.slice(cursor, atom.end);
+    const quantifier = readQuantifier(source, atom.end);
+    tokens.push(`${raw}${quantifier ? source.slice(atom.end, quantifier.end) : ''}`);
+    cursor = quantifier?.end ?? atom.end;
+  }
+
+  return tokens;
+}
+
+function tokensStartWith(tokens: readonly string[], prefix: readonly string[]): boolean {
+  if (prefix.length >= tokens.length) return false;
+  for (let index = 0; index < prefix.length; index += 1) {
+    if (tokens[index] !== prefix[index]) return false;
+  }
+  return true;
 }
 
 function splitTopLevelAlternatives(source: string): string[] {
@@ -198,27 +371,6 @@ function splitTopLevelAlternatives(source: string): string[] {
   }
   alternatives.push(source.slice(start));
   return alternatives;
-}
-
-function literalPrefix(source: string): string {
-  let prefix = '';
-  let escaped = false;
-
-  for (const char of source) {
-    if (escaped) {
-      prefix += `\\${char}`;
-      escaped = false;
-      continue;
-    }
-    if (char === '\\') {
-      escaped = true;
-      continue;
-    }
-    if ('^$.*+?()[]{}|'.includes(char)) break;
-    prefix += char;
-  }
-
-  return prefix;
 }
 
 function stripGroupPrefix(source: string): string {

--- a/src/lib/v2/format-schema/resolver.ts
+++ b/src/lib/v2/format-schema/resolver.ts
@@ -19,6 +19,7 @@ import {
   type ResolveSchemaRefsOptions,
   type SchemaRefSandboxErrorCode,
 } from './sandbox-refs';
+import { findUnsafeRegexPattern } from './regex-safety';
 
 export type CanonicalReferenceKind = 'format_schema' | 'platform_extensions';
 export type CanonicalRef = FormatSchemaRef;
@@ -36,7 +37,8 @@ export type CanonicalReferenceResolutionCode =
   | SchemaRefSandboxErrorCode
   | 'schema_dialect_unsupported'
   | 'schema_compile_failed'
-  | 'schema_keyword_limit_exceeded';
+  | 'schema_keyword_limit_exceeded'
+  | 'budget_exceeded';
 
 export interface CanonicalReferenceResolvedResult {
   ok: true;
@@ -306,6 +308,16 @@ function validateJsonSchema(
       code: 'schema_keyword_limit_exceeded',
       message: `JSON Schema keyword count ${keywordCount} exceeds limit ${maxKeywords}`,
       details: { keywordCount, maxKeywords },
+    };
+  }
+
+  const unsafeRegex = findUnsafeRegexPattern(schema);
+  if (unsafeRegex) {
+    return {
+      ok: false,
+      code: 'budget_exceeded',
+      message: 'JSON Schema regex safety budget exceeded',
+      details: { ...unsafeRegex },
     };
   }
 

--- a/src/lib/v2/format-schema/resolver.ts
+++ b/src/lib/v2/format-schema/resolver.ts
@@ -19,7 +19,7 @@ import {
   type ResolveSchemaRefsOptions,
   type SchemaRefSandboxErrorCode,
 } from './sandbox-refs';
-import { findUnsafeRegexPattern } from './regex-safety';
+import { findUnsafeRegexPattern, unsafeRegexDetails } from './regex-safety';
 
 export type CanonicalReferenceKind = 'format_schema' | 'platform_extensions';
 export type CanonicalRef = FormatSchemaRef;
@@ -317,7 +317,7 @@ function validateJsonSchema(
       ok: false,
       code: 'budget_exceeded',
       message: 'JSON Schema regex safety budget exceeded',
-      details: { ...unsafeRegex },
+      details: unsafeRegexDetails(unsafeRegex),
     };
   }
 

--- a/test/lib/canonical-reference-resolver.test.js
+++ b/test/lib/canonical-reference-resolver.test.js
@@ -263,6 +263,42 @@ describe('canonical reference resolver', () => {
     assert.strictEqual(result.error.code, 'invalid_json_schema');
   });
 
+  test('rejects the catastrophic-regex fetch-contract fixture as budget_exceeded', async () => {
+    const fixture = {
+      test_id: 'fetch-contract-neg-09-catastrophic-regex',
+      category: 'compile_budget',
+      expected_outcome: 'fail:budget_exceeded',
+      setup: {
+        response_body: {
+          $schema: 'http://json-schema.org/draft-07/schema#',
+          $id: '/schemas/test/bad-regex.json',
+          type: 'object',
+          properties: {
+            input: {
+              type: 'string',
+              pattern: '^(a+)+$',
+            },
+          },
+        },
+      },
+    };
+    const body = jsonBody(fixture.setup.response_body);
+    routes.set('/catastrophic-regex.json', (_req, res) => {
+      res.writeHead(200, { 'content-type': 'application/schema+json' });
+      res.end(body);
+    });
+
+    const result = await resolveFormatSchemaReference(ref(baseUrl, '/catastrophic-regex.json', body), unsafeLocal);
+
+    assert.strictEqual(fixture.expected_outcome, 'fail:budget_exceeded');
+    assert.strictEqual(result.status, 'invalid_schema');
+    assert.strictEqual(result.error.code, 'budget_exceeded');
+    assert.strictEqual(result.error.retryable, false);
+    assert.strictEqual(result.error.details.pattern, '^(a+)+$');
+    assert.strictEqual(result.error.details.location, '/properties/input/pattern');
+    assert.strictEqual(result.error.details.reason, 'nested_unbounded_quantifier');
+  });
+
   test('off-origin and file:// $refs are rejected by the format_schema sandbox', async () => {
     const offOriginBody = jsonBody({
       $schema: 'http://json-schema.org/draft-07/schema#',

--- a/test/lib/canonical-reference-resolver.test.js
+++ b/test/lib/canonical-reference-resolver.test.js
@@ -294,9 +294,67 @@ describe('canonical reference resolver', () => {
     assert.strictEqual(result.status, 'invalid_schema');
     assert.strictEqual(result.error.code, 'budget_exceeded');
     assert.strictEqual(result.error.retryable, false);
-    assert.strictEqual(result.error.details.pattern, '^(a+)+$');
     assert.strictEqual(result.error.details.location, '/properties/input/pattern');
     assert.strictEqual(result.error.details.reason, 'nested_unbounded_quantifier');
+    assert.strictEqual(result.error.details.patternPreview, '^(a+)+$');
+    assert.strictEqual(result.error.details.patternLength, '^(a+)+$'.length);
+    assert.strictEqual(result.error.details.patternSha256, createHash('sha256').update('^(a+)+$').digest('hex'));
+    assert.strictEqual(result.error.details.pattern, undefined);
+  });
+
+  test('rejects ambiguous repeated character-class and bounded-repeat regexes', async () => {
+    const cases = [
+      { route: '/ambiguous-alternation-regex.json', pattern: '^(?:[0-9]|[0-9][0-9])+$' },
+      { route: '/bounded-repeat-regex.json', pattern: '^(?:[0-9]{1,2})+$' },
+    ];
+
+    for (const item of cases) {
+      const body = jsonBody({
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        type: 'object',
+        properties: {
+          input: {
+            type: 'string',
+            pattern: item.pattern,
+          },
+        },
+      });
+      routes.set(item.route, (_req, res) => {
+        res.writeHead(200, { 'content-type': 'application/schema+json' });
+        res.end(body);
+      });
+
+      const result = await resolveFormatSchemaReference(ref(baseUrl, item.route, body), unsafeLocal);
+
+      assert.strictEqual(result.status, 'invalid_schema');
+      assert.strictEqual(result.error.code, 'budget_exceeded');
+      assert.strictEqual(result.error.details.location, '/properties/input/pattern');
+      assert.strictEqual(result.error.details.patternPreview, item.pattern);
+      assert.strictEqual(result.error.details.pattern, undefined);
+    }
+  });
+
+  test('ignores annotation examples and accepts delimiter-separated regex patterns', async () => {
+    const body = jsonBody({
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      type: 'object',
+      examples: [{ pattern: '^(a+)+$' }],
+      default: { pattern: '^(a+)+$' },
+      properties: {
+        csv: {
+          type: 'string',
+          pattern: '^(?:[^,]+,)*[^,]+$',
+        },
+      },
+    });
+    routes.set('/safe-regex.json', (_req, res) => {
+      res.writeHead(200, { 'content-type': 'application/schema+json' });
+      res.end(body);
+    });
+
+    const result = await resolveFormatSchemaReference(ref(baseUrl, '/safe-regex.json', body), unsafeLocal);
+
+    assert.strictEqual(result.status, 'resolved');
   });
 
   test('off-origin and file:// $refs are rejected by the format_schema sandbox', async () => {

--- a/test/lib/v2-canonical-reference-resolver.test.js
+++ b/test/lib/v2-canonical-reference-resolver.test.js
@@ -225,6 +225,28 @@ describe('createCanonicalReferenceResolver', () => {
     assert.strictEqual(result.code, 'schema_compile_failed');
   });
 
+  test('returns invalid_schema budget_exceeded for catastrophic format_schema regexes', async () => {
+    const bad = serve('/bad-regex.json', {
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      type: 'object',
+      properties: {
+        input: {
+          type: 'string',
+          pattern: '^(a+)+$',
+        },
+      },
+    });
+
+    const result = await resolveFormatSchema({ uri: bad.uri, digest: bad.digest });
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.status, 'invalid_schema');
+    assert.strictEqual(result.code, 'budget_exceeded');
+    assert.strictEqual(result.retryable, false);
+    assert.strictEqual(result.details.pattern, '^(a+)+$');
+    assert.strictEqual(result.details.location, '/properties/input/pattern');
+  });
+
   test('returns blocked_unsafe_url for unsafe format_schema refs', async () => {
     const schema = serve('/file-ref.json', {
       $schema: 'http://json-schema.org/draft-07/schema#',

--- a/test/lib/v2-canonical-reference-resolver.test.js
+++ b/test/lib/v2-canonical-reference-resolver.test.js
@@ -243,8 +243,58 @@ describe('createCanonicalReferenceResolver', () => {
     assert.strictEqual(result.status, 'invalid_schema');
     assert.strictEqual(result.code, 'budget_exceeded');
     assert.strictEqual(result.retryable, false);
-    assert.strictEqual(result.details.pattern, '^(a+)+$');
     assert.strictEqual(result.details.location, '/properties/input/pattern');
+    assert.strictEqual(result.details.patternPreview, '^(a+)+$');
+    assert.strictEqual(result.details.patternSha256, createHash('sha256').update('^(a+)+$').digest('hex'));
+    assert.strictEqual(result.details.pattern, undefined);
+  });
+
+  test('returns invalid_schema budget_exceeded for ambiguous repeated regexes', async () => {
+    const cases = [
+      { path: '/ambiguous-alternation-regex.json', pattern: '^(?:[0-9]|[0-9][0-9])+$' },
+      { path: '/bounded-repeat-regex.json', pattern: '^(?:[0-9]{1,2})+$' },
+    ];
+
+    for (const item of cases) {
+      const schema = serve(item.path, {
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        type: 'object',
+        properties: {
+          input: {
+            type: 'string',
+            pattern: item.pattern,
+          },
+        },
+      });
+
+      const result = await resolveFormatSchema({ uri: schema.uri, digest: schema.digest });
+
+      assert.strictEqual(result.ok, false);
+      assert.strictEqual(result.status, 'invalid_schema');
+      assert.strictEqual(result.code, 'budget_exceeded');
+      assert.strictEqual(result.details.location, '/properties/input/pattern');
+      assert.strictEqual(result.details.patternPreview, item.pattern);
+      assert.strictEqual(result.details.pattern, undefined);
+    }
+  });
+
+  test('accepts safe delimiter-separated regexes and ignores annotation examples', async () => {
+    const schema = serve('/safe-regex.json', {
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      type: 'object',
+      examples: [{ pattern: '^(a+)+$' }],
+      default: { pattern: '^(a+)+$' },
+      properties: {
+        csv: {
+          type: 'string',
+          pattern: '^(?:[^,]+,)*[^,]+$',
+        },
+      },
+    });
+
+    const result = await resolveFormatSchema({ uri: schema.uri, digest: schema.digest });
+
+    assert.strictEqual(result.status, 'resolved');
   });
 
   test('returns blocked_unsafe_url for unsafe format_schema refs', async () => {


### PR DESCRIPTION
## Summary
Rejects catastrophic regex patterns in `format_schema` resolution by scanning `pattern` and `patternProperties` before Ajv compilation and returning `invalid_schema` / `budget_exceeded` with details.
Keeps the legacy v2 format-schema resolver aligned, documents the new error code, adds a patch changeset, and includes the beta.14 lockfile alignment already present in this workspace.
Adds regression coverage for the canonical fetch-contract fixture shape and the v2 resolver path.

## Validation
Ran `npm run build:lib`, `node --test-timeout=60000 --test test/lib/canonical-reference-resolver.test.js test/lib/v2-canonical-reference-resolver.test.js`, `git diff --check`, and the pre-push typecheck/build hook.