### PR TITLE
feat: emit signed requests deprecation notice

### DIFF
--- a/.changeset/signed-requests-specialism-notice.md
+++ b/.changeset/signed-requests-specialism-notice.md
@@ -1,0 +1,12 @@
+---
+'@adcp/sdk': minor
+---
+
+Emit the canonical `signed_requests_specialism_deprecated` runner notice when
+agents still advertise the deprecated `signed-requests` specialism on the
+signed-requests storyboard.
+
+The notice is a counter-neutral deprecation advisory with
+`capability_path: "specialisms"` and `effective_version: "4.0"`. This widens
+the public `NoticeCode` union so dashboards and CI gates can handle the new
+canonical code explicitly.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/sdk",
-  "version": "8.1.0-beta.13",
+  "version": "8.1.0-beta.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/sdk",
-      "version": "8.1.0-beta.13",
+      "version": "8.1.0-beta.14",
       "license": "Apache-2.0",
       "workspaces": [
         ".",
@@ -7348,7 +7348,7 @@
       "version": "6.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adcp/sdk": "^8.1.0-beta.13"
+        "@adcp/sdk": "^8.1.0-beta.14"
       },
       "bin": {
         "adcp": "bin/adcp.js"

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -1639,7 +1639,12 @@ function buildRequiredToolsMissingResult(
  * agent's declared capabilities. Returns an empty array when rawCaps is
  * absent (standalone runner without pre-fetched profile).
  *
- * Currently emits two spec-grounded notices (adcp-client#1704):
+ * Currently emits three spec-grounded notices (adcp-client#1704, #2082):
+ *
+ * - `signed_requests_specialism_deprecated`: agent claims deprecated
+ *   `specialisms: ['signed-requests']` alongside `request_signing.supported:
+ *   true` on the signed_requests storyboard. The enum value is removed in
+ *   `effective_version: '4.0'`.
  *
  * - `request_signing.required`: `request_signing.supported` is absent or
  *   false on the signed_requests storyboard. Signing becomes required for
@@ -1648,10 +1653,6 @@ function buildRequiredToolsMissingResult(
  * - `webhook_signing.legacy_hmac_fallback.removed`: agent claims
  *   `webhook_signing.legacy_hmac_fallback: true`, which is removed in
  *   `effective_version: '4.0'`.
- *
- * Note: a third notice (`signed_requests_specialism_deprecated`) is deferred
- * pending upstream deprecation of the `'signed-requests'` specialism value in
- * adcontextprotocol/adcp#4418 — the value is still active in the spec.
  */
 function collectCapabilityNotices(storyboard: Storyboard, rawCaps: unknown): RunnerNotice[] {
   const notices: RunnerNotice[] = [];
@@ -1663,11 +1664,33 @@ function collectCapabilityNotices(storyboard: Storyboard, rawCaps: unknown): Run
   // declared request_signing support. The storyboard is identified by id OR
   // by the presence of a request_signing_probe step (mirrors the implicit-
   // require detection in detectImplicitRequires for PR #1703's gate).
-  const isSignedRequestsStoryboard =
-    storyboard.id === 'signed_requests' ||
+  const isSignedRequestsNoticeStoryboard = storyboard.id === 'signed_requests';
+  const isRequestSigningStoryboard =
+    isSignedRequestsNoticeStoryboard ||
     storyboard.phases.some(p => p.steps.some(s => s.task === 'request_signing_probe'));
-  if (isSignedRequestsStoryboard) {
+  if (isRequestSigningStoryboard) {
     const requestSigning = caps['request_signing'] as Record<string, unknown> | undefined;
+    const specialisms = caps['specialisms'];
+    // Canonical deprecation notice standardized by adcontextprotocol/adcp#4796.
+    if (
+      isSignedRequestsNoticeStoryboard &&
+      requestSigning?.['supported'] === true &&
+      Array.isArray(specialisms) &&
+      specialisms.includes('signed-requests')
+    ) {
+      notices.push({
+        severity: 'deprecation',
+        code: 'signed_requests_specialism_deprecated',
+        message:
+          'The `signed-requests` specialism claim is deprecated and removed in AdCP 4.0. ' +
+          'Drop it and rely on `request_signing.supported: true` instead.',
+        effective_version: '4.0',
+        capability_path: 'specialisms',
+        docs_url: 'https://adcontextprotocol.org/docs/building/implementation/security#signed-requests-transport-layer',
+        storyboard_ids: [storyboard.id],
+      });
+    }
+
     if (requestSigning?.['supported'] !== true) {
       notices.push({
         severity: 'future_required',

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -1768,11 +1768,12 @@ export interface SchemaValidationError {
  * a deprecation or future-required advisory is the kind of thing a CI
  * gate or dashboard SHOULD have explicit handling for.
  *
- * Code naming follows the dot-namespaced convention `<topic>.<event>`
- * (e.g. `request_signing.required`, `webhook_signing.legacy_hmac_fallback.removed`).
- * The *when* lives in the `effective_version` field, never in the code.
- * This keeps the surface stable across spec versions — codes don't proliferate
- * `_in_4_0` / `_in_5_0` siblings as the spec evolves.
+ * Code naming generally follows the dot-namespaced convention `<topic>.<event>`
+ * (e.g. `request_signing.required`, `webhook_signing.legacy_hmac_fallback.removed`);
+ * prefer the upstream runner-output contract's canonical code when it
+ * registers a different spelling. The *when* lives in the `effective_version`
+ * field, never in the code. This keeps the surface stable across spec versions
+ * — codes don't proliferate `_in_4_0` / `_in_5_0` siblings as the spec evolves.
  *
  * Adding a new code is a wire-surface change AND a TypeScript breaking
  * change for adopters who narrowed on `code`. Coordinate with the upstream
@@ -1781,6 +1782,9 @@ export interface SchemaValidationError {
  * Spec: adcp-client#1704.
  */
 export type NoticeCode =
+  /** Agent advertises deprecated `specialisms: ['signed-requests']`. Removed in
+   *  AdCP 4.0 per `effective_version`. */
+  | 'signed_requests_specialism_deprecated'
   /** Agent lacks `request_signing.supported: true`. Required for spend-committing
    *  operations in AdCP 4.0 per `effective_version`. */
   | 'request_signing.required'

--- a/test/lib/storyboard-notices.test.js
+++ b/test/lib/storyboard-notices.test.js
@@ -238,7 +238,11 @@ describe('RunnerNotice: signed_requests_specialism_deprecated (#2082)', () => {
     const deprecation = result.notices.find(n => n.code === 'signed_requests_specialism_deprecated');
     const required = result.notices.find(n => n.code === 'request_signing.required');
     assert.equal(deprecation, undefined, 'deprecated-specialism notice is scoped to the signed_requests storyboard id');
-    assert.equal(required, undefined, 'request signing is declared, so the probe-only storyboard has no required notice');
+    assert.equal(
+      required,
+      undefined,
+      'request signing is declared, so the probe-only storyboard has no required notice'
+    );
   });
 
   test('dedupes notice code across multi-pass runs', async () => {

--- a/test/lib/storyboard-notices.test.js
+++ b/test/lib/storyboard-notices.test.js
@@ -3,7 +3,8 @@
  * and ComplianceResult (adcp-client#1704).
  *
  * Uses `_profile` injection so tests run without the schema cache or a live agent.
- * The two day-one notices tested here are both spec-grounded:
+ * These notices are spec-grounded:
+ *   - signed_requests_specialism_deprecated: universal/signed-requests.yaml
  *   - request_signing.required: get-adcp-capabilities-response.json:892
  *   - webhook_signing.legacy_hmac_fallback.removed: get-adcp-capabilities-response.json:966
  */
@@ -103,6 +104,23 @@ const profileWithSigning = {
   },
 };
 
+const profileWithSignedRequestsSpecialism = {
+  name: 'Test Agent (deprecated specialism)',
+  tools: ['get_adcp_capabilities', 'get_products'],
+  raw_capabilities: {
+    request_signing: { supported: true, required_for: [], supported_for: [] },
+    specialisms: ['signed-requests'],
+  },
+};
+
+const profileWithSignedRequestsSpecialismOnly = {
+  name: 'Test Agent (deprecated specialism only)',
+  tools: ['get_adcp_capabilities', 'get_products'],
+  raw_capabilities: {
+    specialisms: ['signed-requests'],
+  },
+};
+
 const profileWithLegacyHmac = {
   name: 'Test Agent (legacy hmac)',
   tools: ['get_adcp_capabilities', 'get_products'],
@@ -170,6 +188,80 @@ describe('RunnerNotice — notices field always present (#1704)', () => {
     assert.ok(result.overall_passed, 'capability-unsupported is a skip, not a failure');
     assert.ok(Array.isArray(result.notices), 'notices must be an array on early-return paths');
     assert.equal(result.notices.length, 0, 'no notices on a non-webhook, non-signing storyboard');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests: signed_requests_specialism_deprecated
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('RunnerNotice: signed_requests_specialism_deprecated (#2082)', () => {
+  test('emits notice on signed_requests storyboard when specialisms includes signed-requests', async () => {
+    const sb = buildSignedRequestsStoryboard();
+    const result = await runWith(sb, profileWithSignedRequestsSpecialism);
+    const notice = result.notices.find(n => n.code === 'signed_requests_specialism_deprecated');
+    assert.ok(notice, 'notice should be present');
+    assert.equal(notice.severity, 'deprecation');
+    assert.equal(notice.effective_version, '4.0');
+    assert.equal(notice.capability_path, 'specialisms');
+    assert.equal(typeof notice.docs_url, 'string', 'docs_url populated for click-through');
+    assert.deepEqual(notice.storyboard_ids, ['signed_requests'], 'storyboard_ids carries the source');
+    assert.ok(notice.message.length > 0, 'message non-empty for human consumption');
+  });
+
+  test('does NOT emit notice when request_signing.supported is true without deprecated specialism', async () => {
+    const sb = buildSignedRequestsStoryboard();
+    const result = await runWith(sb, profileWithSigning);
+    const notice = result.notices.find(n => n.code === 'signed_requests_specialism_deprecated');
+    assert.equal(notice, undefined, 'request_signing.supported alone is the desired capability shape');
+  });
+
+  test('does NOT emit notice when deprecated specialism is declared without request_signing.supported', async () => {
+    const sb = buildSignedRequestsStoryboard();
+    const result = await runWith(sb, profileWithSignedRequestsSpecialismOnly);
+    const deprecation = result.notices.find(n => n.code === 'signed_requests_specialism_deprecated');
+    const required = result.notices.find(n => n.code === 'request_signing.required');
+    assert.equal(deprecation, undefined, 'deprecated specialism is only redundant once request_signing is declared');
+    assert.ok(required, 'missing request_signing.supported still emits the future-required notice');
+  });
+
+  test('does NOT emit notice on unrelated storyboard even when deprecated specialism is declared', async () => {
+    const sb = buildMinimalStoryboard({ id: 'some_other_storyboard' });
+    const result = await runWith(sb, profileWithSignedRequestsSpecialism);
+    const notice = result.notices.find(n => n.code === 'signed_requests_specialism_deprecated');
+    assert.equal(notice, undefined, 'notice is scoped to signed_requests storyboards only');
+  });
+
+  test('does NOT emit notice on probe-only storyboard even when deprecated specialism is declared', async () => {
+    const sb = buildSigningProbeStoryboard();
+    const result = await runWith(sb, profileWithSignedRequestsSpecialism);
+    const deprecation = result.notices.find(n => n.code === 'signed_requests_specialism_deprecated');
+    const required = result.notices.find(n => n.code === 'request_signing.required');
+    assert.equal(deprecation, undefined, 'deprecated-specialism notice is scoped to the signed_requests storyboard id');
+    assert.equal(required, undefined, 'request signing is declared, so the probe-only storyboard has no required notice');
+  });
+
+  test('dedupes notice code across multi-pass runs', async () => {
+    const sb = buildSignedRequestsStoryboard();
+    const result = await runStoryboard(['http://fake-local-99999', 'http://fake-local-99998'], sb, {
+      _profile: profileWithSignedRequestsSpecialism,
+      agentTools: profileWithSignedRequestsSpecialism.tools,
+      multi_instance_strategy: 'multi-pass',
+    });
+    const notices = result.notices.filter(n => n.code === 'signed_requests_specialism_deprecated');
+    assert.equal(notices.length, 1, 'multi-pass result should dedupe by notice code');
+    assert.deepEqual(notices[0].storyboard_ids, ['signed_requests']);
+  });
+
+  test('notice does not affect pass/fail/skipped counters', async () => {
+    const sb = buildSignedRequestsStoryboard();
+    const baseline = await runWith(sb, profileWithSigning);
+    const withNotice = await runWith(sb, profileWithSignedRequestsSpecialism);
+
+    assert.equal(withNotice.passed_count, baseline.passed_count, 'passed counter unchanged');
+    assert.equal(withNotice.failed_count, baseline.failed_count, 'failed counter unchanged');
+    assert.equal(withNotice.skipped_count, baseline.skipped_count, 'skipped counter unchanged');
+    assert.equal(withNotice.overall_passed, baseline.overall_passed, 'overall pass/fail unchanged');
   });
 });
 


### PR DESCRIPTION
## Summary
Adds the canonical `signed_requests_specialism_deprecated` runner notice for agents that still advertise `specialisms: ["signed-requests"]` alongside `request_signing.supported: true` on the signed-requests storyboard.
Scopes the deprecation notice to the `signed_requests` storyboard while preserving the broader probe-step behavior for `request_signing.required`, and widens `NoticeCode` with a changeset.
Updates the beta lockfile version from 8.1.0-beta.13 to 8.1.0-beta.14.

## Validation
Ran expert review, `npm run build:lib`, focused storyboard notice tests, `git diff --check`, `npm run lint` (existing warnings only), and the pre-push typecheck/build hook.

Closes #2082