### PR TITLE
docs(agents): clarify commitlint requirements

### DIFF
--- a/.changeset/slimy-cars-rest.md
+++ b/.changeset/slimy-cars-rest.md
@@ -1,0 +1,7 @@
+---
+---
+
+docs(agents): clarify commitlint requirements for coding agents.
+
+Empty changeset because this only updates repository agent guidance and lockfile
+metadata alignment, not the published SDK runtime.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,6 +11,7 @@ This is **@adcp/sdk** - the official TypeScript client library for the Ad Contex
 - ✅ Always use official `@a2a-js/sdk` and `@modelcontextprotocol/sdk` clients
 - ❌ Never use mock data - return exactly what agents provide
 - ✅ Use changesets for version management (never edit package.json version manually)
+- ✅ Use Conventional Commits for commit messages and PR titles; do not prefix PR titles with agent/tool labels like `[Codex]` or `[Claude]`
 
 ## Project Components
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,6 +206,31 @@ npm run changeset          # Create changeset for changes
 - `package.json` version = **Library version** (managed by changesets)
 - `src/lib/version.ts` ADCP_VERSION = **AdCP schema version** (can differ from library version)
 
+### Commit and PR Titles
+
+**🚨 Commitlint is CI-gated on every PR**. Before opening or updating a PR, make sure both the PR title and every commit message use Conventional Commits.
+
+- Use one of the allowed types from `commitlint.config.js`: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`
+- Format commit messages and PR titles as `type(scope): subject` or `type: subject`
+- Do **NOT** prefix PR titles with agent/tool labels like `[Codex]`, `[Claude]`, `Codex:`, or `Claude:`
+- Keep the header at 120 characters or less
+
+Good examples:
+
+```bash
+fix: handle MCP connection timeouts gracefully
+docs(agents): clarify commitlint requirements
+test: add media buy lifecycle regression coverage
+```
+
+Validate before submitting:
+
+```bash
+node .github/scripts/check-pr-title.cjs "fix: concise PR title"
+echo "fix: concise PR title" | npx commitlint --config commitlint.config.js
+npx commitlint --from origin/main --to HEAD --verbose
+```
+
 ### Schema Generation Workflow
 
 Library types auto-generated from AdCP schemas:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/sdk",
-  "version": "8.1.0-beta.13",
+  "version": "8.1.0-beta.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/sdk",
-      "version": "8.1.0-beta.13",
+      "version": "8.1.0-beta.14",
       "license": "Apache-2.0",
       "workspaces": [
         ".",
@@ -7348,7 +7348,7 @@
       "version": "6.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adcp/sdk": "^8.1.0-beta.13"
+        "@adcp/sdk": "^8.1.0-beta.14"
       },
       "bin": {
         "adcp": "bin/adcp.js"


### PR DESCRIPTION
## Summary

Clarifies agent-facing instructions so commits and PR titles follow the repository commitlint rules before submission. Adds the same short reminder to Copilot instructions, including the no agent/tool PR title prefix rule. Carries forward the lockfile beta-version alignment already present in the workspace diff.

## Validation

Ran PR title prefix validation, title commitlint, commit-range commitlint, and the pre-push typecheck/build hook.