### PR TITLE
feat(brand): add asset mapping helpers

### DIFF
--- a/.changeset/brand-asset-mapping-helpers.md
+++ b/.changeset/brand-asset-mapping-helpers.md
@@ -1,0 +1,5 @@
+---
+"@adcp/sdk": minor
+---
+
+Add brand JSON asset mapping helpers for validating PDF/model extraction output, applying approved logo mappings, selecting logos by slot, checking slot coverage, and saving updated brand manifests through the registry client.

--- a/package.json
+++ b/package.json
@@ -88,6 +88,11 @@
       "require": "./dist/lib/webhooks/index.js",
       "types": "./dist/lib/webhooks/index.d.ts"
     },
+    "./brand": {
+      "import": "./dist/lib/brand/index.js",
+      "require": "./dist/lib/brand/index.js",
+      "types": "./dist/lib/brand/index.d.ts"
+    },
     "./net": {
       "import": "./dist/lib/net/index.js",
       "require": "./dist/lib/net/index.js",
@@ -205,6 +210,9 @@
       ],
       "webhooks": [
         "dist/lib/webhooks/index.d.ts"
+      ],
+      "brand": [
+        "dist/lib/brand/index.d.ts"
       ],
       "net": [
         "dist/lib/net/index.d.ts"

--- a/src/lib/brand/index.ts
+++ b/src/lib/brand/index.ts
@@ -1,0 +1,561 @@
+import type { RegistryClient, SaveBrandResponse } from '../registry';
+import type { GetBrandIdentitySuccess } from '../types/core.generated';
+
+export type BrandJsonRecord = Record<string, unknown>;
+type ProtocolBrandLogo = NonNullable<GetBrandIdentitySuccess['logos']>[number];
+
+export type BrandLogoOrientation = ProtocolBrandLogo['orientation'];
+export type BrandLogoBackground = ProtocolBrandLogo['background'];
+export type BrandLogoVariant = ProtocolBrandLogo['variant'];
+
+export type BrandAssetExtractionMethod = 'embedded_pdf_image' | 'rendered_page_crop' | 'uploaded_asset' | 'manual';
+
+export interface BrandAssetCropBox {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  coordinate_space?: 'pixels' | 'normalized_1000';
+}
+
+export interface BrandAssetCandidate {
+  asset_id: string;
+  asset_group_id?: string;
+  url?: string;
+  file?: string;
+  source_page?: number;
+  extraction_method?: BrandAssetExtractionMethod;
+  width?: number;
+  height?: number;
+  crop_box?: BrandAssetCropBox;
+  metadata?: BrandJsonRecord;
+}
+
+export type BrandAssetMappingTarget = 'logos[]';
+export type BrandAssetReviewStatus = 'needs_review' | 'approved' | 'rejected';
+
+export interface BrandLogoProposal extends Omit<ProtocolBrandLogo, 'url'> {
+  id: string;
+  url?: string;
+  slots?: string[];
+  [key: string]: unknown;
+}
+
+export interface BrandAssetMapping {
+  asset_id: string;
+  target: BrandAssetMappingTarget;
+  review_status?: BrandAssetReviewStatus;
+  confidence?: number;
+  proposed_logo?: BrandLogoProposal;
+  evidence?: BrandJsonRecord;
+}
+
+export interface BrandAssetMappingIssue {
+  asset_id?: string;
+  message: string;
+}
+
+export interface BrandAssetMappingValidationResult {
+  valid: boolean;
+  errors: BrandAssetMappingIssue[];
+  warnings: BrandAssetMappingIssue[];
+  approvedMappings: BrandAssetMapping[];
+}
+
+export type ResolveBrandAssetUrl = (
+  candidate: BrandAssetCandidate | undefined,
+  mapping: BrandAssetMapping
+) => string | undefined;
+
+export interface ApplyBrandAssetMappingsOptions {
+  candidates?: BrandAssetCandidate[];
+  mappings: BrandAssetMapping[];
+  brandId?: string;
+  assetsBaseUrl?: string;
+  resolveAssetUrl?: ResolveBrandAssetUrl;
+  approvedOnly?: boolean;
+}
+
+export interface AppliedBrandAssetMapping {
+  asset_id: string;
+  target: BrandAssetMappingTarget;
+  logo_id: string;
+  url: string;
+}
+
+export interface SkippedBrandAssetMapping {
+  asset_id?: string;
+  target?: BrandAssetMappingTarget;
+  reason: string;
+}
+
+export interface ApplyBrandAssetMappingsResult<TBrandJson extends BrandJsonRecord = BrandJsonRecord> {
+  brandJson: TBrandJson;
+  appliedMappings: AppliedBrandAssetMapping[];
+  skippedMappings: SkippedBrandAssetMapping[];
+  warnings: BrandAssetMappingIssue[];
+  errors: BrandAssetMappingIssue[];
+}
+
+export interface LogoSelectionOptions {
+  requestedSlot: string;
+  brandId?: string;
+  background?: BrandLogoBackground;
+  preferredVariant?: BrandLogoVariant;
+}
+
+export interface LogoSlotCoverageOptions {
+  brandId?: string;
+}
+
+export interface LogoSlotCoverage {
+  present: string[];
+  missing: string[];
+}
+
+export interface UpdateBrandJsonFromMappingsOptions {
+  registryClient: Pick<RegistryClient, 'getBrandJson' | 'saveBrand'>;
+  domain: string;
+  brandName?: string;
+  existingBrandJson?: BrandJsonRecord | null;
+  candidates?: BrandAssetCandidate[];
+  mappings: BrandAssetMapping[];
+  brandId?: string;
+  assetsBaseUrl?: string;
+  resolveAssetUrl?: ResolveBrandAssetUrl;
+  dryRun?: boolean;
+}
+
+export interface UpdateBrandJsonFromMappingsResult extends ApplyBrandAssetMappingsResult {
+  saved: boolean;
+  saveResponse?: SaveBrandResponse;
+}
+
+export const COMMON_LOGO_SLOTS = [
+  'logo_card_light',
+  'logo_card_dark',
+  'nav_header',
+  'marketplace_listing',
+  'ad_end_card',
+] as const;
+
+export function validateBrandAssetMappings(input: {
+  candidates?: BrandAssetCandidate[];
+  mappings: BrandAssetMapping[];
+}): BrandAssetMappingValidationResult {
+  const errors: BrandAssetMappingIssue[] = [];
+  const warnings: BrandAssetMappingIssue[] = [];
+  const candidatesById = indexCandidates(input.candidates ?? [], errors);
+  const hasCandidates = (input.candidates?.length ?? 0) > 0;
+  const approvedMappings: BrandAssetMapping[] = [];
+
+  for (const mapping of input.mappings) {
+    if (!mapping.asset_id?.trim()) {
+      errors.push({ message: 'mapping.asset_id is required' });
+      continue;
+    }
+
+    if (hasCandidates && !candidatesById.has(mapping.asset_id)) {
+      errors.push({ asset_id: mapping.asset_id, message: 'mapping asset_id does not match a candidate asset_id' });
+    }
+
+    if (mapping.target !== 'logos[]') {
+      errors.push({ asset_id: mapping.asset_id, message: `unsupported mapping target: ${String(mapping.target)}` });
+      continue;
+    }
+
+    if (mapping.review_status === 'approved') {
+      if (!mapping.proposed_logo) {
+        errors.push({ asset_id: mapping.asset_id, message: 'approved logo mapping requires proposed_logo' });
+        continue;
+      }
+      let approvedMappingIsUsable = true;
+      if (!mapping.proposed_logo.id?.trim()) {
+        errors.push({ asset_id: mapping.asset_id, message: 'approved logo mapping requires proposed_logo.id' });
+        approvedMappingIsUsable = false;
+      }
+      if (approvedMappingIsUsable) approvedMappings.push(mapping);
+    } else if (!mapping.review_status) {
+      warnings.push({
+        asset_id: mapping.asset_id,
+        message: 'review_status is missing; mapping will not be applied by default',
+      });
+    }
+  }
+
+  return { valid: errors.length === 0, errors, warnings, approvedMappings };
+}
+
+export function applyBrandAssetMappings<TBrandJson extends BrandJsonRecord>(
+  brandJson: TBrandJson,
+  options: ApplyBrandAssetMappingsOptions
+): ApplyBrandAssetMappingsResult<TBrandJson> {
+  const result = cloneJson(brandJson);
+  const warnings: BrandAssetMappingIssue[] = [];
+  const errors: BrandAssetMappingIssue[] = [];
+  const skippedMappings: SkippedBrandAssetMapping[] = [];
+  const appliedMappings: AppliedBrandAssetMapping[] = [];
+  const candidatesById = indexCandidates(options.candidates ?? [], errors);
+  const targetBrand = resolveWritableBrandRecord(result, options.brandId);
+
+  if (!targetBrand.record) {
+    return {
+      brandJson: result,
+      appliedMappings,
+      skippedMappings: options.mappings.map(mapping => ({
+        asset_id: mapping.asset_id,
+        target: mapping.target,
+        reason: 'brand record not found',
+      })),
+      warnings,
+      errors: [{ message: targetBrand.reason }],
+    };
+  }
+
+  for (const mapping of options.mappings) {
+    if (options.approvedOnly !== false && mapping.review_status !== 'approved') {
+      skippedMappings.push({ asset_id: mapping.asset_id, target: mapping.target, reason: 'mapping is not approved' });
+      continue;
+    }
+
+    if (mapping.target !== 'logos[]') {
+      skippedMappings.push({
+        asset_id: mapping.asset_id,
+        target: mapping.target,
+        reason: 'unsupported mapping target',
+      });
+      continue;
+    }
+
+    if (!mapping.proposed_logo?.id?.trim()) {
+      skippedMappings.push({ asset_id: mapping.asset_id, target: mapping.target, reason: 'missing proposed_logo.id' });
+      continue;
+    }
+
+    const candidate = candidatesById.get(mapping.asset_id);
+    if (!candidate && (options.candidates?.length ?? 0) > 0) {
+      skippedMappings.push({
+        asset_id: mapping.asset_id,
+        target: mapping.target,
+        reason: 'candidate asset_id not found',
+      });
+      continue;
+    }
+
+    const url = resolveLogoUrl(candidate, mapping, options);
+    if (!url) {
+      skippedMappings.push({
+        asset_id: mapping.asset_id,
+        target: mapping.target,
+        reason: 'no durable URL resolved for logo',
+      });
+      warnings.push({
+        asset_id: mapping.asset_id,
+        message: 'logo mapping needs proposed_logo.url, candidate.url, or assetsBaseUrl',
+      });
+      continue;
+    }
+
+    if (!url.startsWith('https://')) {
+      warnings.push({ asset_id: mapping.asset_id, message: 'logo URL is not HTTPS' });
+    }
+
+    const logo = buildLogoRecord(mapping.proposed_logo, candidate, url);
+    upsertLogo(targetBrand.record, logo);
+    appliedMappings.push({
+      asset_id: mapping.asset_id,
+      target: mapping.target,
+      logo_id: mapping.proposed_logo.id,
+      url,
+    });
+  }
+
+  return { brandJson: result, appliedMappings, skippedMappings, warnings, errors };
+}
+
+export function selectLogoForSlot(
+  brandJsonOrBrand: BrandJsonRecord,
+  options: LogoSelectionOptions
+): BrandJsonRecord | null {
+  const brand = resolveReadableBrandRecord(brandJsonOrBrand, options.brandId);
+  if (!brand.record) return null;
+
+  const logos = readLogos(brand.record);
+  let best: { logo: BrandJsonRecord; score: number } | null = null;
+
+  for (const logo of logos) {
+    const slotScore = scoreLogoForSlot(logo, options.requestedSlot);
+    if (slotScore == null) continue;
+
+    let score = slotScore;
+    if (options.background && logo.background === options.background) score += 30;
+    if (options.preferredVariant && logo.variant === options.preferredVariant) score += 10;
+
+    if (!best || score > best.score) best = { logo, score };
+  }
+
+  return best?.logo ?? null;
+}
+
+export function checkLogoSlotCoverage(
+  brandJsonOrBrand: BrandJsonRecord,
+  requiredSlots: string[],
+  options?: LogoSlotCoverageOptions
+): LogoSlotCoverage {
+  const present = new Set(
+    requiredSlots.filter(slot =>
+      selectLogoForSlot(brandJsonOrBrand, { requestedSlot: slot, brandId: options?.brandId })
+    )
+  );
+
+  return {
+    present: requiredSlots.filter(slot => present.has(slot)),
+    missing: requiredSlots.filter(slot => !present.has(slot)),
+  };
+}
+
+export async function updateBrandJsonFromMappings(
+  options: UpdateBrandJsonFromMappingsOptions
+): Promise<UpdateBrandJsonFromMappingsResult> {
+  if (!options.domain?.trim()) throw new Error('domain is required');
+
+  const existingBrandJson =
+    options.existingBrandJson !== undefined
+      ? options.existingBrandJson
+      : await options.registryClient.getBrandJson(options.domain);
+  const baseBrandJson = existingBrandJson ?? { domain: options.domain, name: options.brandName ?? options.domain };
+
+  const applied = applyBrandAssetMappings(baseBrandJson, {
+    candidates: options.candidates,
+    mappings: options.mappings,
+    brandId: options.brandId,
+    assetsBaseUrl: options.assetsBaseUrl,
+    resolveAssetUrl: options.resolveAssetUrl,
+  });
+
+  if (options.dryRun || applied.errors.length > 0) {
+    return { ...applied, saved: false };
+  }
+
+  const brandName = options.brandName ?? inferBrandName(applied.brandJson, options.brandId) ?? options.domain;
+  const saveResponse = await options.registryClient.saveBrand({
+    domain: options.domain,
+    brand_name: brandName,
+    brand_manifest: applied.brandJson,
+  });
+
+  return { ...applied, saved: true, saveResponse };
+}
+
+function indexCandidates(
+  candidates: BrandAssetCandidate[],
+  errors: BrandAssetMappingIssue[]
+): Map<string, BrandAssetCandidate> {
+  const indexed = new Map<string, BrandAssetCandidate>();
+
+  for (const candidate of candidates) {
+    if (!candidate.asset_id?.trim()) {
+      errors.push({ message: 'candidate.asset_id is required' });
+      continue;
+    }
+    if (indexed.has(candidate.asset_id)) {
+      errors.push({ asset_id: candidate.asset_id, message: 'duplicate candidate asset_id' });
+      continue;
+    }
+    indexed.set(candidate.asset_id, candidate);
+  }
+
+  return indexed;
+}
+
+function cloneJson<TBrandJson extends BrandJsonRecord>(value: TBrandJson): TBrandJson {
+  return JSON.parse(JSON.stringify(value)) as TBrandJson;
+}
+
+function resolveWritableBrandRecord(
+  root: BrandJsonRecord,
+  brandId?: string
+): { record: BrandJsonRecord | null; reason: string } {
+  if (isNonEditableBrandJsonVariant(root)) {
+    return { record: null, reason: 'brand.json variant is not editable by logo asset mappings' };
+  }
+
+  if (Array.isArray(root.brands)) {
+    const brands = root.brands.filter(isRecord);
+    if (brandId) {
+      const brand = brands.find(matchesBrandId(brandId)) ?? null;
+      return { record: brand, reason: brand ? '' : `brand not found for brandId: ${brandId}` };
+    }
+    if (Array.isArray(root.logos)) return { record: root, reason: '' };
+    if (brands.length === 1) return { record: brands[0] ?? null, reason: '' };
+    return { record: null, reason: 'brandId is required for multi-brand brand.json documents' };
+  }
+
+  if (Array.isArray(root.logos)) return { record: root, reason: '' };
+
+  if (!isTopLevelBrandIdentity(root)) {
+    return { record: null, reason: 'brand record not found' };
+  }
+  root.logos = [];
+  return { record: root, reason: '' };
+}
+
+function resolveLogoUrl(
+  candidate: BrandAssetCandidate | undefined,
+  mapping: BrandAssetMapping,
+  options: ApplyBrandAssetMappingsOptions
+): string | undefined {
+  const resolved = options.resolveAssetUrl?.(candidate, mapping);
+  if (resolved) return resolved;
+  if (mapping.proposed_logo?.url) return mapping.proposed_logo.url;
+  if (candidate?.url) return candidate.url;
+
+  const baseUrl = options.assetsBaseUrl?.replace(/\/+$/, '');
+  if (!baseUrl || !candidate) return undefined;
+
+  const path = candidate.file ?? candidate.asset_id;
+  return `${baseUrl}/${path
+    .split('/')
+    .filter(Boolean)
+    .map(segment => encodeURIComponent(segment))
+    .join('/')}`;
+}
+
+function buildLogoRecord(
+  proposal: BrandLogoProposal,
+  candidate: BrandAssetCandidate | undefined,
+  url: string
+): BrandJsonRecord {
+  const logo: BrandJsonRecord = { ...proposal, url };
+  if (logo.width === undefined && candidate?.width !== undefined) logo.width = candidate.width;
+  if (logo.height === undefined && candidate?.height !== undefined) logo.height = candidate.height;
+  return logo;
+}
+
+function upsertLogo(brand: BrandJsonRecord, logo: BrandJsonRecord): void {
+  const currentLogos = Array.isArray(brand.logos) ? brand.logos : [];
+  const logos = currentLogos.filter(isRecord);
+  const logoId = typeof logo.id === 'string' ? logo.id : undefined;
+  const existingIndex = logoId ? logos.findIndex(existing => existing.id === logoId) : -1;
+
+  if (existingIndex >= 0) {
+    logos[existingIndex] = { ...logos[existingIndex], ...logo };
+  } else {
+    logos.push(logo);
+  }
+
+  brand.logos = logos;
+}
+
+function readLogos(brandJsonOrBrand: BrandJsonRecord): BrandJsonRecord[] {
+  if (Array.isArray(brandJsonOrBrand.logos)) return brandJsonOrBrand.logos.filter(isRecord);
+  return [];
+}
+
+function scoreLogoForSlot(logo: BrandJsonRecord, requestedSlot: string): number | null {
+  if (arrayOfStrings(logo.slots).includes(requestedSlot)) return 100;
+
+  switch (requestedSlot) {
+    case 'logo_card_light':
+      return logo.background === 'light-bg' || logo.background === 'transparent-bg' ? 50 : null;
+    case 'logo_card_dark':
+      return logo.background === 'dark-bg' || logo.background === 'transparent-bg' ? 50 : null;
+    case 'nav_header':
+      return logo.orientation === 'horizontal' || logo.variant === 'wordmark' || logo.variant === 'full-lockup'
+        ? 40
+        : null;
+    case 'marketplace_listing':
+      return logo.variant === 'primary' || logo.variant === 'full-lockup' || logo.variant === 'icon' ? 30 : null;
+    case 'ad_end_card':
+      return logo.background === 'dark-bg' || logo.background === 'light-bg' || logo.background === 'transparent-bg'
+        ? 20
+        : null;
+    default:
+      return null;
+  }
+}
+
+function arrayOfStrings(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : [];
+}
+
+function inferBrandName(brandJson: BrandJsonRecord, brandId?: string): string | undefined {
+  const brandRecord = findReadableBrandRecord(brandJson, brandId);
+  if (typeof brandRecord?.name === 'string' && brandRecord.name.trim()) return brandRecord.name;
+  if (typeof brandRecord?.brand_name === 'string' && brandRecord.brand_name.trim()) return brandRecord.brand_name;
+  const localizedBrandName = readLocalizedName(brandRecord?.names);
+  if (localizedBrandName) return localizedBrandName;
+  if (typeof brandJson.name === 'string' && brandJson.name.trim()) return brandJson.name;
+  if (typeof brandJson.brand_name === 'string' && brandJson.brand_name.trim()) return brandJson.brand_name;
+  const localizedRootName = readLocalizedName(brandJson.names);
+  if (localizedRootName) return localizedRootName;
+  return undefined;
+}
+
+function findReadableBrandRecord(root: BrandJsonRecord, brandId?: string): BrandJsonRecord | null {
+  return resolveReadableBrandRecord(root, brandId).record;
+}
+
+function resolveReadableBrandRecord(
+  root: BrandJsonRecord,
+  brandId?: string
+): { record: BrandJsonRecord | null; reason: string } {
+  if (Array.isArray(root.brands)) {
+    const brands = root.brands.filter(isRecord);
+    if (brandId) {
+      const brand = brands.find(matchesBrandId(brandId)) ?? null;
+      return { record: brand, reason: brand ? '' : `brand not found for brandId: ${brandId}` };
+    }
+    if (Array.isArray(root.logos)) return { record: root, reason: '' };
+    if (brands.length === 1) return { record: brands[0] ?? null, reason: '' };
+    return { record: null, reason: 'brandId is required for multi-brand brand.json documents' };
+  }
+
+  return { record: root, reason: '' };
+}
+
+function matchesBrandId(brandId: string): (brand: BrandJsonRecord) => boolean {
+  return brand => brand.id === brandId || brand.brand_id === brandId || brand.domain === brandId;
+}
+
+function isNonEditableBrandJsonVariant(root: BrandJsonRecord): boolean {
+  if (typeof root.authoritative_location === 'string') return true;
+  if (typeof root.house === 'string') return true;
+
+  const hasIdentityFields =
+    Array.isArray(root.brands) ||
+    Array.isArray(root.logos) ||
+    typeof root.domain === 'string' ||
+    typeof root.name === 'string' ||
+    typeof root.brand_name === 'string' ||
+    Array.isArray(root.names);
+
+  return Array.isArray(root.agents) && !hasIdentityFields;
+}
+
+function isTopLevelBrandIdentity(root: BrandJsonRecord): boolean {
+  return (
+    typeof root.domain === 'string' ||
+    typeof root.name === 'string' ||
+    typeof root.brand_name === 'string' ||
+    Array.isArray(root.names)
+  );
+}
+
+function isRecord(value: unknown): value is BrandJsonRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readLocalizedName(value: unknown): string | undefined {
+  if (!Array.isArray(value)) return undefined;
+
+  for (const entry of value) {
+    if (!isRecord(entry)) continue;
+    if (typeof entry.en === 'string' && entry.en.trim()) return entry.en;
+    for (const name of Object.values(entry)) {
+      if (typeof name === 'string' && name.trim()) return name;
+    }
+  }
+
+  return undefined;
+}

--- a/src/lib/brand/index.ts
+++ b/src/lib/brand/index.ts
@@ -410,7 +410,7 @@ function resolveLogoUrl(
   if (mapping.proposed_logo?.url) return mapping.proposed_logo.url;
   if (candidate?.url) return candidate.url;
 
-  const baseUrl = options.assetsBaseUrl?.replace(/\/+$/, '');
+  const baseUrl = removeTrailingSlashes(options.assetsBaseUrl);
   if (!baseUrl || !candidate) return undefined;
 
   const path = candidate.file ?? candidate.asset_id;
@@ -419,6 +419,16 @@ function resolveLogoUrl(
     .filter(Boolean)
     .map(segment => encodeURIComponent(segment))
     .join('/')}`;
+}
+
+function removeTrailingSlashes(value: string | undefined): string | undefined {
+  if (!value) return value;
+
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 47) {
+    end -= 1;
+  }
+  return value.slice(0, end);
 }
 
 function buildLogoRecord(

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -58,6 +58,41 @@ export type {
   GetAgentStoryboardStatusBulkResponse,
 } from './registry';
 
+// ====== BRAND JSON HELPERS ======
+export {
+  COMMON_LOGO_SLOTS,
+  applyBrandAssetMappings,
+  checkLogoSlotCoverage,
+  selectLogoForSlot,
+  updateBrandJsonFromMappings,
+  validateBrandAssetMappings,
+} from './brand';
+export type {
+  AppliedBrandAssetMapping,
+  ApplyBrandAssetMappingsOptions,
+  ApplyBrandAssetMappingsResult,
+  BrandAssetCandidate,
+  BrandAssetCropBox,
+  BrandAssetExtractionMethod,
+  BrandAssetMapping,
+  BrandAssetMappingIssue,
+  BrandAssetMappingTarget,
+  BrandAssetMappingValidationResult,
+  BrandAssetReviewStatus,
+  BrandJsonRecord,
+  BrandLogoBackground,
+  BrandLogoOrientation,
+  BrandLogoProposal,
+  BrandLogoVariant,
+  LogoSelectionOptions,
+  LogoSlotCoverage,
+  LogoSlotCoverageOptions,
+  ResolveBrandAssetUrl,
+  SkippedBrandAssetMapping,
+  UpdateBrandJsonFromMappingsOptions,
+  UpdateBrandJsonFromMappingsResult,
+} from './brand';
+
 // ====== PROPERTY DISCOVERY (AdCP v2.2.0) ======
 export {
   PropertyIndex,

--- a/test/lib/brand-asset-mapping.test.js
+++ b/test/lib/brand-asset-mapping.test.js
@@ -1,0 +1,300 @@
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+
+const {
+  applyBrandAssetMappings,
+  checkLogoSlotCoverage,
+  selectLogoForSlot,
+  updateBrandJsonFromMappings,
+  validateBrandAssetMappings,
+} = require('../../dist/lib/brand/index.js');
+
+describe('brand asset mapping helpers', () => {
+  test('validates approved mappings against candidate asset ids', () => {
+    const result = validateBrandAssetMappings({
+      candidates: [{ asset_id: 'candidate_logo_0001' }],
+      mappings: [
+        {
+          asset_id: 'candidate_logo_0001',
+          target: 'logos[]',
+          review_status: 'approved',
+          proposed_logo: { id: 'primary_horizontal' },
+        },
+      ],
+    });
+
+    assert.strictEqual(result.valid, true);
+    assert.strictEqual(result.approvedMappings.length, 1);
+  });
+
+  test('reports mappings that do not point at extracted candidates', () => {
+    const result = validateBrandAssetMappings({
+      candidates: [{ asset_id: 'candidate_logo_0001' }],
+      mappings: [
+        {
+          asset_id: 'missing_logo',
+          target: 'logos[]',
+          review_status: 'approved',
+          proposed_logo: { id: 'primary_horizontal' },
+        },
+      ],
+    });
+
+    assert.strictEqual(result.valid, false);
+    assert.match(result.errors[0].message, /does not match/);
+  });
+
+  test('allows direct URL mappings when no candidate list is supplied', () => {
+    const result = validateBrandAssetMappings({
+      mappings: [
+        {
+          asset_id: 'hosted_logo',
+          target: 'logos[]',
+          review_status: 'approved',
+          proposed_logo: { id: 'primary_horizontal', url: 'https://assets.example/acme/logo.svg' },
+        },
+      ],
+    });
+
+    assert.strictEqual(result.valid, true);
+  });
+
+  test('applies approved logo mappings without mutating the input brand json', () => {
+    const brandJson = { domain: 'acme.example', name: 'Acme' };
+    const result = applyBrandAssetMappings(brandJson, {
+      candidates: [
+        {
+          asset_id: 'candidate_logo_0001',
+          asset_group_id: 'logo',
+          url: 'https://assets.example/acme/logo.svg',
+          width: 640,
+          height: 220,
+        },
+      ],
+      mappings: [
+        {
+          asset_id: 'candidate_logo_0001',
+          target: 'logos[]',
+          review_status: 'approved',
+          proposed_logo: {
+            id: 'primary_horizontal',
+            variant: 'primary',
+            background: 'light-bg',
+            slots: ['logo_card_light', 'marketplace_listing'],
+          },
+        },
+      ],
+    });
+
+    assert.strictEqual(brandJson.logos, undefined);
+    assert.strictEqual(result.appliedMappings.length, 1);
+    assert.deepStrictEqual(result.skippedMappings, []);
+    assert.deepStrictEqual(result.errors, []);
+    assert.strictEqual(result.brandJson.logos[0].id, 'primary_horizontal');
+    assert.strictEqual(result.brandJson.logos[0].url, 'https://assets.example/acme/logo.svg');
+    assert.strictEqual(result.brandJson.logos[0].width, 640);
+  });
+
+  test('selects logos by rendering slot and checks required slot coverage', () => {
+    const brandJson = {
+      logos: [
+        {
+          id: 'primary_horizontal',
+          url: 'https://assets.example/acme/logo.svg',
+          background: 'light-bg',
+          variant: 'primary',
+          slots: ['logo_card_light', 'marketplace_listing'],
+        },
+        {
+          id: 'knockout_horizontal',
+          url: 'https://assets.example/acme/logo-knockout.svg',
+          background: 'dark-bg',
+          variant: 'secondary',
+          slots: ['logo_card_dark', 'ad_end_card'],
+        },
+      ],
+    };
+
+    const logo = selectLogoForSlot(brandJson, {
+      requestedSlot: 'logo_card_dark',
+      background: 'dark-bg',
+      preferredVariant: 'secondary',
+    });
+    const coverage = checkLogoSlotCoverage(brandJson, ['logo_card_light', 'logo_card_dark', 'nav_header']);
+
+    assert.strictEqual(logo.id, 'knockout_horizontal');
+    assert.deepStrictEqual(coverage.present, ['logo_card_light', 'logo_card_dark']);
+    assert.deepStrictEqual(coverage.missing, ['nav_header']);
+  });
+
+  test('falls back to protocol logo fields when slots are absent', () => {
+    const brandJson = {
+      logos: [
+        {
+          id: 'primary_horizontal',
+          url: 'https://assets.example/acme/logo.svg',
+          orientation: 'horizontal',
+          background: 'light-bg',
+          variant: 'primary',
+        },
+      ],
+    };
+
+    const logo = selectLogoForSlot(brandJson, {
+      requestedSlot: 'logo_card_light',
+      background: 'light-bg',
+    });
+    const coverage = checkLogoSlotCoverage(brandJson, ['logo_card_light', 'nav_header', 'logo_card_dark']);
+
+    assert.strictEqual(logo.id, 'primary_horizontal');
+    assert.deepStrictEqual(coverage.present, ['logo_card_light', 'nav_header']);
+    assert.deepStrictEqual(coverage.missing, ['logo_card_dark']);
+  });
+
+  test('updates the requested brand in a house brand json', () => {
+    const result = applyBrandAssetMappings(
+      {
+        house: { domain: 'house.example' },
+        brands: [
+          { id: 'spark', name: 'Spark', logos: [] },
+          { id: 'bolt', name: 'Bolt', logos: [] },
+        ],
+      },
+      {
+        brandId: 'spark',
+        assetsBaseUrl: 'https://assets.example/brand-assets',
+        candidates: [{ asset_id: 'candidate_logo_0002', file: 'spark/logo.png' }],
+        mappings: [
+          {
+            asset_id: 'candidate_logo_0002',
+            target: 'logos[]',
+            review_status: 'approved',
+            proposed_logo: { id: 'spark_primary', slots: ['logo_card_light'] },
+          },
+        ],
+      }
+    );
+
+    assert.strictEqual(result.brandJson.brands[0].logos[0].url, 'https://assets.example/brand-assets/spark/logo.png');
+    assert.deepStrictEqual(result.brandJson.brands[1].logos, []);
+
+    const logo = selectLogoForSlot(result.brandJson, { brandId: 'spark', requestedSlot: 'logo_card_light' });
+    const coverage = checkLogoSlotCoverage(result.brandJson, ['logo_card_light', 'logo_card_dark'], {
+      brandId: 'spark',
+    });
+
+    assert.strictEqual(logo.id, 'spark_primary');
+    assert.deepStrictEqual(coverage.present, ['logo_card_light']);
+    assert.deepStrictEqual(coverage.missing, ['logo_card_dark']);
+  });
+
+  test('fails closed on redirect and agent-only brand json variants', async () => {
+    const mappingOptions = {
+      candidates: [{ asset_id: 'candidate_logo_0001', url: 'https://assets.example/acme/logo.svg' }],
+      mappings: [
+        {
+          asset_id: 'candidate_logo_0001',
+          target: 'logos[]',
+          review_status: 'approved',
+          proposed_logo: { id: 'primary_horizontal', slots: ['logo_card_light'] },
+        },
+      ],
+    };
+    const redirectResult = applyBrandAssetMappings({ house: 'house.example', note: 'Redirect' }, mappingOptions);
+    const agentOnlyResult = applyBrandAssetMappings(
+      { agents: [{ type: 'brand', url: 'https://agent.example.com', id: 'brand_agent' }] },
+      mappingOptions
+    );
+
+    assert.match(redirectResult.errors[0].message, /not editable/);
+    assert.strictEqual(redirectResult.brandJson.logos, undefined);
+    assert.match(agentOnlyResult.errors[0].message, /not editable/);
+
+    let saveCalled = false;
+    const updateResult = await updateBrandJsonFromMappings({
+      registryClient: {
+        async getBrandJson() {
+          return { authoritative_location: 'https://cdn.example.com/brand.json' };
+        },
+        async saveBrand() {
+          saveCalled = true;
+          return { success: true, message: 'saved' };
+        },
+      },
+      domain: 'acme.example',
+      ...mappingOptions,
+    });
+
+    assert.strictEqual(updateResult.saved, false);
+    assert.strictEqual(saveCalled, false);
+    assert.match(updateResult.errors[0].message, /not editable/);
+  });
+
+  test('can fetch, update, and save a brand json through the registry client', async () => {
+    let savedPayload;
+    const registryClient = {
+      async getBrandJson(domain) {
+        assert.strictEqual(domain, 'acme.example');
+        return { domain, name: 'Acme', logos: [] };
+      },
+      async saveBrand(payload) {
+        savedPayload = payload;
+        return { success: true, message: 'saved', domain: payload.domain, id: 'brand_123' };
+      },
+    };
+
+    const result = await updateBrandJsonFromMappings({
+      registryClient,
+      domain: 'acme.example',
+      candidates: [{ asset_id: 'candidate_logo_0001', url: 'https://assets.example/acme/logo.svg' }],
+      mappings: [
+        {
+          asset_id: 'candidate_logo_0001',
+          target: 'logos[]',
+          review_status: 'approved',
+          proposed_logo: { id: 'primary_horizontal', slots: ['logo_card_light'] },
+        },
+      ],
+    });
+
+    assert.strictEqual(result.saved, true);
+    assert.strictEqual(savedPayload.domain, 'acme.example');
+    assert.strictEqual(savedPayload.brand_name, 'Acme');
+    assert.strictEqual(savedPayload.brand_manifest.logos[0].id, 'primary_horizontal');
+  });
+
+  test('infers registry brand_name from localized names when saving a brand entry', async () => {
+    let savedPayload;
+    const registryClient = {
+      async getBrandJson() {
+        throw new Error('existingBrandJson should be used');
+      },
+      async saveBrand(payload) {
+        savedPayload = payload;
+        return { success: true, message: 'saved', domain: payload.domain, id: 'brand_456' };
+      },
+    };
+
+    const result = await updateBrandJsonFromMappings({
+      registryClient,
+      domain: 'house.example',
+      brandId: 'spark',
+      existingBrandJson: {
+        house: { domain: 'house.example', name: 'House' },
+        brands: [{ id: 'spark', names: [{ en: 'Spark' }], logos: [] }],
+      },
+      candidates: [{ asset_id: 'candidate_logo_0001', url: 'https://assets.example/spark/logo.svg' }],
+      mappings: [
+        {
+          asset_id: 'candidate_logo_0001',
+          target: 'logos[]',
+          review_status: 'approved',
+          proposed_logo: { id: 'spark_primary', slots: ['logo_card_light'] },
+        },
+      ],
+    });
+
+    assert.strictEqual(result.saved, true);
+    assert.strictEqual(savedPayload.brand_name, 'Spark');
+  });
+});

--- a/test/lib/brand-asset-mapping.test.js
+++ b/test/lib/brand-asset-mapping.test.js
@@ -162,7 +162,7 @@ describe('brand asset mapping helpers', () => {
       },
       {
         brandId: 'spark',
-        assetsBaseUrl: 'https://assets.example/brand-assets',
+        assetsBaseUrl: 'https://assets.example/brand-assets///',
         candidates: [{ asset_id: 'candidate_logo_0002', file: 'spark/logo.png' }],
         mappings: [
           {

--- a/test/lib/brand-public-export.test.js
+++ b/test/lib/brand-public-export.test.js
@@ -1,0 +1,42 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const pkg = require('../../package.json');
+
+describe('brand helpers public exports', () => {
+  it('exports brand helpers from the package root and @adcp/sdk/brand', () => {
+    const sdk = require('@adcp/sdk');
+    const brand = require('@adcp/sdk/brand');
+
+    assert.strictEqual(typeof sdk.applyBrandAssetMappings, 'function');
+    assert.strictEqual(typeof sdk.validateBrandAssetMappings, 'function');
+    assert.strictEqual(typeof sdk.selectLogoForSlot, 'function');
+    assert.strictEqual(typeof sdk.checkLogoSlotCoverage, 'function');
+    assert.strictEqual(typeof sdk.updateBrandJsonFromMappings, 'function');
+
+    assert.strictEqual(typeof brand.applyBrandAssetMappings, 'function');
+    assert.strictEqual(typeof brand.validateBrandAssetMappings, 'function');
+    assert.strictEqual(typeof brand.selectLogoForSlot, 'function');
+    assert.strictEqual(typeof brand.checkLogoSlotCoverage, 'function');
+    assert.strictEqual(typeof brand.updateBrandJsonFromMappings, 'function');
+
+    assert.strictEqual(sdk.applyBrandAssetMappings, brand.applyBrandAssetMappings);
+    assert.strictEqual(sdk.selectLogoForSlot, brand.selectLogoForSlot);
+    assert.deepStrictEqual([...sdk.COMMON_LOGO_SLOTS], [...brand.COMMON_LOGO_SLOTS]);
+  });
+
+  it('publishes runtime and declaration paths for @adcp/sdk/brand', () => {
+    assert.deepStrictEqual(pkg.exports['./brand'], {
+      import: './dist/lib/brand/index.js',
+      require: './dist/lib/brand/index.js',
+      types: './dist/lib/brand/index.d.ts',
+    });
+    assert.deepStrictEqual(pkg.typesVersions['*'].brand, ['dist/lib/brand/index.d.ts']);
+
+    const distRoot = path.join(__dirname, '..', '..', 'dist', 'lib', 'brand');
+    assert.ok(fs.existsSync(path.join(distRoot, 'index.js')), 'dist/lib/brand/index.js must exist');
+    assert.ok(fs.existsSync(path.join(distRoot, 'index.d.ts')), 'dist/lib/brand/index.d.ts must exist');
+  });
+});


### PR DESCRIPTION
## Summary
- Add a public `@adcp/sdk/brand` module for model/PDF asset mapping workflows without bundling PDF or Gemini dependencies.
- Provide helpers to validate candidate-to-logo mappings, apply approved mappings into brand.json, select logos by rendering slot, check slot coverage, and save updated manifests through `RegistryClient.saveBrand`.
- Add tests for protocol logo values, house-of-brands `brandId` handling, non-slotted logo fallback, redirect/agent-only fail-closed behavior, registry save behavior, and public export wiring.

## Validation
- `npm run format:check`
- `npm run build:lib`
- `npm run typecheck`
- `node --test test/lib/brand-asset-mapping.test.js test/lib/brand-public-export.test.js`
- `node --test test/lib/brand-asset-mapping.test.js test/lib/brand-public-export.test.js test/lib/net-public-export.test.js`
- pre-push hook: formatting, typecheck, build

## Notes
This is the upstream SDK half of the brand PDF ingestion work: extraction/classification stays caller-owned, while the SDK owns the reusable brand.json mapping/update mechanics.