### PR TITLE
ci: split unit tests across lanes

### DIFF
--- a/.changeset/parallel-unit-tests.md
+++ b/.changeset/parallel-unit-tests.md
@@ -1,0 +1,7 @@
+---
+---
+
+ci: split unit tests into faster parallel lanes.
+
+Empty changeset because this only affects repository automation, not the
+published SDK package.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,8 +131,39 @@ jobs:
             console.log('✅ Package exports are valid');
           "
 
-  unit-tests:
-    name: Unit Tests
+  unit-tests-fast:
+    name: Unit Tests Fast (${{ matrix.shard }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ['1/3', '2/3', '3/3']
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build library
+        run: npm run build:lib
+
+      - name: Run fast unit test shard
+        run: node scripts/run-test-with-summary.js --title "Unit Tests Fast $TEST_SHARD" -- npm run test:node:fast:shard
+        env:
+          CI: true
+          TEST_SHARD: ${{ matrix.shard }}
+
+  unit-tests-slow:
+    name: Unit Tests Slow
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -152,10 +183,66 @@ jobs:
       - name: Build library
         run: npm run build:lib
 
-      - name: Run unit tests
-        run: npm test
+      - name: Run slow unit tests
+        run: node scripts/run-test-with-summary.js --title "Unit Tests Slow" -- npm run test:node:slow
         env:
           CI: true
+
+  eslint-plugin-tests:
+    name: ESLint Plugin Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build library
+        run: npm run build:lib
+
+      - name: Run ESLint plugin tests
+        run: node scripts/run-test-with-summary.js --title "ESLint Plugin Tests" -- npm test --workspace=packages/eslint-plugin --if-present
+        env:
+          CI: true
+
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    needs:
+      - unit-tests-fast
+      - unit-tests-slow
+      - eslint-plugin-tests
+    if: ${{ always() }}
+    timeout-minutes: 2
+
+    steps:
+      - name: Verify unit test lanes
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          node - <<'NODE'
+          const needs = JSON.parse(process.env.NEEDS_JSON);
+          const failed = Object.entries(needs).filter(([, job]) => job.result !== 'success');
+
+          if (failed.length > 0) {
+            console.error('One or more unit test lanes failed:');
+            for (const [name, job] of failed) {
+              console.error(`- ${name}: ${job.result}`);
+            }
+            process.exit(1);
+          }
+
+          console.log('All unit test lanes passed.');
+          NODE
 
   example-integration-tests:
     name: Example Adapter Integration Tests

--- a/package.json
+++ b/package.json
@@ -282,6 +282,7 @@
     "test": "npm run test:node && npm test --workspace=packages/eslint-plugin --if-present",
     "test:node": "npm run test:node:fast && npm run test:node:slow",
     "test:node:fast": "NODE_ENV=test node --test-timeout=60000 --test-force-exit --test $(find test -maxdepth 1 -name '*.test.js' ! -name 'generate-zod-object-intersections.test.js' -print) $(find test/lib -maxdepth 1 -name '*.test.js' ! -name 'cli-auth-scheme.test.js' ! -name 'cli-webhook-receiver-flag.test.js' ! -name 'conformance-cli.test.js' -print)",
+    "test:node:fast:shard": "test -n \"$TEST_SHARD\" && NODE_ENV=test node --test-timeout=60000 --test-force-exit --test-shard=$TEST_SHARD --test $(find test -maxdepth 1 -name '*.test.js' ! -name 'generate-zod-object-intersections.test.js' -print) $(find test/lib -maxdepth 1 -name '*.test.js' ! -name 'cli-auth-scheme.test.js' ! -name 'cli-webhook-receiver-flag.test.js' ! -name 'conformance-cli.test.js' -print)",
     "test:node:slow": "NODE_ENV=test node --test-timeout=180000 --test-force-exit --test test/generate-zod-object-intersections.test.js test/lib/cli-auth-scheme.test.js test/lib/cli-webhook-receiver-flag.test.js test/lib/conformance-cli.test.js",
     "pretest:lib": "npm run schemas:ensure",
     "test:lib": "npm run test:lib:fast && npm run test:lib:slow",

--- a/scripts/run-test-with-summary.js
+++ b/scripts/run-test-with-summary.js
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+
+const { spawn } = require('node:child_process');
+const { appendFileSync } = require('node:fs');
+
+function usage() {
+  console.error('Usage: node scripts/run-test-with-summary.js --title <title> -- <command> [args...]');
+  process.exit(2);
+}
+
+const separatorIndex = process.argv.indexOf('--');
+const titleIndex = process.argv.indexOf('--title');
+
+if (separatorIndex === -1 || titleIndex === -1 || titleIndex + 1 >= separatorIndex) {
+  usage();
+}
+
+const title = process.argv[titleIndex + 1];
+const command = process.argv[separatorIndex + 1];
+const commandArgs = process.argv.slice(separatorIndex + 2);
+
+if (!command) {
+  usage();
+}
+
+let output = '';
+const child = spawn(command, commandArgs, {
+  env: process.env,
+  shell: false,
+  stdio: ['ignore', 'pipe', 'pipe'],
+});
+
+child.stdout.on('data', chunk => {
+  process.stdout.write(chunk);
+  output += chunk.toString('utf8');
+});
+
+child.stderr.on('data', chunk => {
+  process.stderr.write(chunk);
+  output += chunk.toString('utf8');
+});
+
+child.on('error', error => {
+  console.error(error.message);
+  process.exit(1);
+});
+
+child.on('close', (code, signal) => {
+  writeSummary(title, output);
+
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+
+  process.exit(code ?? 1);
+});
+
+function writeSummary(summaryTitle, rawOutput) {
+  const rows = parseDurations(rawOutput)
+    .sort((a, b) => b.durationMs - a.durationMs)
+    .slice(0, 20);
+
+  if (rows.length === 0) {
+    return;
+  }
+
+  const markdown = [
+    `### ${escapeMarkdown(summaryTitle)} slowest tests`,
+    '',
+    '| Duration | Type | Test |',
+    '| ---: | --- | --- |',
+    ...rows.map(row => {
+      const seconds = (row.durationMs / 1000).toFixed(2);
+      return `| ${seconds}s | ${escapeCell(row.type || 'test')} | ${escapeCell(row.name)} |`;
+    }),
+    '',
+  ].join('\n');
+
+  console.log(`\n${markdown}`);
+
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${markdown}\n`);
+  }
+}
+
+function parseDurations(rawOutput) {
+  const lines = rawOutput
+    .replace(/\u001b\[[0-9;]*m/g, '')
+    .split(/\r?\n/)
+    .map(line => line.replace(/\s+$/, ''));
+  const rows = [];
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const match = lines[index].match(/^(\s*)(?:ok|not ok) \d+ - (.+)$/);
+
+    if (!match) {
+      continue;
+    }
+
+    const indent = match[1];
+    const detailIndent = `${indent}  `;
+    let durationMs = null;
+    let type = '';
+
+    for (let lookahead = index + 1; lookahead < Math.min(lines.length, index + 10); lookahead += 1) {
+      if (lines[lookahead] === `${detailIndent}...`) {
+        break;
+      }
+
+      const durationMatch = lines[lookahead].match(new RegExp(`^${escapeRegExp(detailIndent)}duration_ms: ([0-9.]+)$`));
+      const typeMatch = lines[lookahead].match(new RegExp(`^${escapeRegExp(detailIndent)}type: '([^']+)'$`));
+
+      if (durationMatch) {
+        durationMs = Number(durationMatch[1]);
+      }
+
+      if (typeMatch) {
+        type = typeMatch[1];
+      }
+    }
+
+    if (Number.isFinite(durationMs)) {
+      rows.push({ name: match[2], durationMs, type });
+    }
+  }
+
+  return rows;
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function escapeCell(value) {
+  return escapeMarkdown(value).replace(/\\/g, '\\\\').replace(/\|/g, '\\|');
+}
+
+function escapeMarkdown(value) {
+  return String(value).replace(/\r?\n/g, ' ').trim();
+}


### PR DESCRIPTION
Splits the unit-test lane into three fast Node test shards, a slow Node test lane, and a separate ESLint plugin test lane while preserving the aggregate `Unit Tests` check.
Adds `scripts/run-test-with-summary.js` so CI step summaries show the slowest TAP tests for each lane.
Keeps the required `Test & Build` aggregate gate unchanged and adds an empty changeset because this is CI-only automation.
Validation: workflow lint, Prettier/YAML/diff checks, shard smoke test, slow unit lane, ESLint plugin lane, changeset status, and the pre-push typecheck/build hook.
