### PR TITLE
feat(registry): add community mirror adagents helper

### DIFF
--- a/.changeset/community-mirror-adagents-helper.md
+++ b/.changeset/community-mirror-adagents-helper.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': minor
+---
+
+Add typed registry helpers for community mirror adagents catalogs. `buildCommunityMirrorAdagents()` and `RegistryClient.createCommunityMirrorAdagents()` emit catalog-only descriptors with `authorized_agents: []`, while `CreateAdagentsRequest` now exposes typed `formats`, `placements`, and `placement_tags` shapes for local adopter code.

--- a/README.md
+++ b/README.md
@@ -636,6 +636,49 @@ Build a registry service that:
 
 Library provides discovery logic - you add persistence layer.
 
+### Community Mirror `adagents.json` Catalogs
+
+Use `buildCommunityMirrorAdagents()` when publishing catalog-only AAO/community mirrors for platforms that have not adopted AdCP or published seller-authorized files yet. The helper emits `authorized_agents: []` and refuses caller-supplied authorization entries, so format and placement metadata cannot be mistaken for a seller authorization claim.
+
+```ts
+import { RegistryClient, buildCommunityMirrorAdagents } from '@adcp/sdk';
+
+const catalog = buildCommunityMirrorAdagents({
+  catalog_etag: 'meta-creative-formats-2026-05',
+  formats: [
+    {
+      format_option_id: 'meta-feed-image',
+      format_kind: 'image',
+      params: {
+        width: 1080,
+        height: 1080,
+      },
+      v1_format_ref: [
+        {
+          agent_url: 'https://creative.adcontextprotocol.org/translated/meta',
+          id: 'feed_image',
+        },
+      ],
+    },
+  ],
+  placements: [
+    {
+      placement_id: 'feed',
+      name: 'Feed',
+      property_tags: ['feed'],
+      format_options: [{ format_option_id: 'meta-feed-image' }],
+    },
+  ],
+  placement_tags: {
+    feed: { name: 'Feed', description: 'Main feed placement' },
+  },
+});
+
+await new RegistryClient().createAdagents(catalog);
+```
+
+`RegistryClient.createAdagents()` and `createCommunityMirrorAdagents()` are intended for build-time generation, cache fills, or write-through publishing. Public `/.well-known/adagents.json` routes should serve generated JSON from static storage or an application cache rather than calling the registry on every request.
+
 ## Database Schema
 
 Simple unified event log for all operations:

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -2,7 +2,14 @@
 // A comprehensive type-safe client library for the AdContext Protocol
 
 // ====== REGISTRY LOOKUPS ======
-export { RegistryClient, RegistrySync, PropertyRegistry, InMemoryCursorStore, FileCursorStore } from './registry';
+export {
+  RegistryClient,
+  RegistrySync,
+  PropertyRegistry,
+  InMemoryCursorStore,
+  FileCursorStore,
+  buildCommunityMirrorAdagents,
+} from './registry';
 export type {
   RegistrySyncConfig,
   RegistrySyncState,
@@ -31,6 +38,18 @@ export type {
   ListAgentsOptions,
   ListAgentsResponse,
   ListPublishersResponse,
+  ValidateAdagentsRequest,
+  CreateAdagentsRequest,
+  CreateAdagentsResponse,
+  AdagentsAuthorizedAgent,
+  AdagentsCatalogFormat,
+  AdagentsPlacementDefinition,
+  AdagentsPlacementFormatReference,
+  AdagentsPlacementFormatOption,
+  AdagentsPlacementTag,
+  CreatedAdagentsJson,
+  CommunityMirrorAdagentsConfig,
+  CommunityMirrorAdagentsCatalog,
   PublisherPropertySelector,
   CompanySearchResult,
   FindCompanyResult,

--- a/src/lib/registry/create-adagents.type-checks.ts
+++ b/src/lib/registry/create-adagents.type-checks.ts
@@ -2,11 +2,38 @@
 //
 // Run with `npm run typecheck`. The library build excludes `*.type-checks.ts`.
 
-import { RegistryClient } from './index';
-import type { CreateAdagentsRequest } from './types';
+import { RegistryClient, buildCommunityMirrorAdagents } from './index';
+import type {
+  AdagentsCatalogFormat,
+  AdagentsPlacementDefinition,
+  CreateAdagentsRequest,
+  CommunityMirrorAdagentsConfig,
+} from './types';
 
-const communityMirrorManifest: CreateAdagentsRequest = {
-  authorized_agents: [],
+const metaFeedImageFormat: AdagentsCatalogFormat = {
+  format_option_id: 'meta-feed-image',
+  format_kind: 'image',
+  params: {
+    width: 1080,
+    height: 1080,
+  },
+  v1_format_ref: [
+    {
+      // Namespace for the legacy format shape, not seller authorization.
+      agent_url: 'https://creative.adcontextprotocol.org/translated/meta',
+      id: 'feed_image',
+    },
+  ],
+};
+
+const feedPlacement: AdagentsPlacementDefinition = {
+  placement_id: 'feed',
+  name: 'Feed',
+  property_tags: ['feed'],
+  format_options: [{ format_option_id: 'meta-feed-image' }],
+};
+
+const communityMirrorConfig: CommunityMirrorAdagentsConfig = {
   catalog_etag: 'meta-creative-formats-2026-05',
   properties: [
     {
@@ -15,34 +42,34 @@ const communityMirrorManifest: CreateAdagentsRequest = {
       note: 'AAO community mirror catalog for an unadopted platform',
     },
   ],
-  formats: [
-    {
-      format_option_id: 'meta-feed-image',
-      format_kind: 'display',
-      v1_format_ref: [
-        {
-          // Namespace for the legacy format shape, not seller authorization.
-          agent_url: 'https://creative.adcontextprotocol.org/translated/meta',
-          id: 'feed_image',
-        },
-      ],
-    },
-  ],
-  placements: [
-    {
-      placement_id: 'feed',
-      format_option_ids: ['meta-feed-image'],
-    },
-  ],
+  formats: [metaFeedImageFormat],
+  placements: [feedPlacement],
   placement_tags: {
-    feed: { label: 'Feed' },
+    feed: { name: 'Feed', description: 'Main feed placement' },
   },
 };
 
+const communityMirrorManifest: CreateAdagentsRequest = buildCommunityMirrorAdagents(communityMirrorConfig);
 void communityMirrorManifest;
+
+// @ts-expect-error Community mirror helper must not accept seller authorization claims.
+buildCommunityMirrorAdagents({ ...communityMirrorConfig, authorized_agents: [] });
+
+const directCreateRequest: CreateAdagentsRequest = {
+  authorized_agents: [],
+  catalog_etag: 'meta-creative-formats-2026-05',
+  formats: [metaFeedImageFormat],
+  placements: [feedPlacement],
+  placement_tags: {
+    feed: { name: 'Feed', description: 'Main feed placement' },
+  },
+};
+
+void directCreateRequest;
 
 async function registryListCompatibility(client: RegistryClient): Promise<void> {
   await client.listAgents({ type: 'si' });
+  await client.createCommunityMirrorAdagents(communityMirrorConfig);
 
   const agents = await client.listAgents();
   const agentSources: Record<string, unknown> = agents.sources;

--- a/src/lib/registry/index.ts
+++ b/src/lib/registry/index.ts
@@ -20,6 +20,9 @@ import type {
   ListPublishersResponse,
   ValidateAdagentsRequest,
   CreateAdagentsRequest,
+  CreateAdagentsResponse,
+  CommunityMirrorAdagentsConfig,
+  CommunityMirrorAdagentsCatalog,
   ValidateProductAuthorizationRequest,
   ExpandProductIdentifiersRequest,
   PublisherPropertySelector,
@@ -82,6 +85,16 @@ export type {
   ListPublishersResponse,
   ValidateAdagentsRequest,
   CreateAdagentsRequest,
+  CreateAdagentsResponse,
+  AdagentsAuthorizedAgent,
+  AdagentsCatalogFormat,
+  AdagentsPlacementDefinition,
+  AdagentsPlacementFormatReference,
+  AdagentsPlacementFormatOption,
+  AdagentsPlacementTag,
+  CreatedAdagentsJson,
+  CommunityMirrorAdagentsConfig,
+  CommunityMirrorAdagentsCatalog,
   ValidateProductAuthorizationRequest,
   ExpandProductIdentifiersRequest,
   PublisherPropertySelector,
@@ -159,6 +172,33 @@ const DEFAULT_LARGE_RESPONSE_MAX_BODY_BYTES = 2 * 1024 * 1024;
 const ERROR_BODY_PREVIEW_CHARS = 200;
 const MAX_BULK_DOMAINS = 100;
 const MAX_CHECK_DOMAINS = 10000; // per OpenAPI spec maxItems
+
+/**
+ * Build a catalog-only community mirror adagents.json descriptor.
+ *
+ * Community mirrors are for format, placement, and property discovery when a
+ * platform has not published its own seller-authorized file yet. This helper
+ * always emits `authorized_agents: []` and rejects caller-supplied
+ * authorization claims so the resulting descriptor cannot accidentally imply
+ * platform adoption or seller authorization.
+ */
+export function buildCommunityMirrorAdagents(config: CommunityMirrorAdagentsConfig): CommunityMirrorAdagentsCatalog {
+  const maybeConfig = config as CommunityMirrorAdagentsConfig & { authorized_agents?: unknown };
+  if ('authorized_agents' in maybeConfig) {
+    throw new Error('authorized_agents is not accepted for community mirror adagents catalogs');
+  }
+  if (!config.catalog_etag?.trim()) {
+    throw new Error('catalog_etag is required');
+  }
+  if (!Array.isArray(config.formats) || config.formats.length === 0) {
+    throw new Error('formats must contain at least one catalog format');
+  }
+
+  return {
+    ...config,
+    authorized_agents: [],
+  };
+}
 
 /**
  * Client for the AdCP Registry API.
@@ -661,16 +701,33 @@ export class RegistryClient {
   }
 
   /**
-   * Generate a valid adagents.json from an agent configuration.
+   * Generate a valid adagents.json from an agent or catalog configuration.
    *
    * @remarks
+   * Treat this as a build-time, cache-fill, or write-through operation for
+   * public `.well-known/adagents.json` routes. Public routes should serve the
+   * generated JSON from static storage or an application cache instead of
+   * making a live registry dependency part of every request.
+   *
    * In community mirror catalog files, `v1_format_ref[].agent_url` is a
    * format-shape namespace. It is not a seller authorization claim and does
    * not imply platform adoption. Seller authorization is expressed only by
    * `authorized_agents`.
    */
-  async createAdagents(config: CreateAdagentsRequest): Promise<Record<string, unknown>> {
+  async createAdagents(config: CreateAdagentsRequest): Promise<CreateAdagentsResponse> {
     return this.post(`${this.baseUrl}/api/adagents/create`, config);
+  }
+
+  /**
+   * Build and submit a catalog-only community mirror adagents.json descriptor.
+   *
+   * This is the high-level helper for AAO/community mirror catalog publication.
+   * It emits `authorized_agents: []` and refuses caller-supplied authorization
+   * entries; use `createAdagents()` directly only for seller-authorized hosted
+   * publisher files.
+   */
+  async createCommunityMirrorAdagents(config: CommunityMirrorAdagentsConfig): Promise<CreateAdagentsResponse> {
+    return this.createAdagents(buildCommunityMirrorAdagents(config));
   }
 
   // ====== Search & Discovery ======

--- a/src/lib/registry/types.ts
+++ b/src/lib/registry/types.ts
@@ -49,6 +49,7 @@ export type { paths, operations, components } from './types.generated';
 // Types extracted from inline OpenAPI operation schemas
 
 import type { operations } from './types.generated';
+import type { MediaChannel, ProductFormatDeclaration } from '../types/tools.generated';
 
 /** Request body for POST /api/brands/save */
 export type SaveBrandRequest = NonNullable<operations['saveBrand']['requestBody']>['content']['application/json'];
@@ -68,9 +69,114 @@ export type ValidateAdagentsRequest = NonNullable<
 >['content']['application/json'];
 
 /** Request body for POST /api/adagents/create */
-export type CreateAdagentsRequest = NonNullable<
+type RegistryCreateAdagentsRequest = NonNullable<
   operations['createAdagents']['requestBody']
 >['content']['application/json'];
+
+/** Response from POST /api/adagents/create (200) */
+type RegistryCreateAdagentsResponse = operations['createAdagents']['responses']['200']['content']['application/json'];
+
+/** Agent authorization entry accepted by the registry adagents.json generator. */
+export type AdagentsAuthorizedAgent = RegistryCreateAdagentsRequest['authorized_agents'][number] & {
+  [key: string]: unknown;
+};
+
+/**
+ * Top-level `adagents.json#/formats[]` declaration.
+ *
+ * This reuses the protocol `ProductFormatDeclaration` shape and adds the
+ * publisher-catalog scoping fields allowed in `adagents.json`.
+ */
+export type AdagentsCatalogFormat = ProductFormatDeclaration & {
+  /** Property IDs from this file that this format applies to. Omit for all properties. */
+  applies_to_property_ids?: string[];
+  /** Property tags from this file that this format applies to. Omit for all properties. */
+  applies_to_property_tags?: string[];
+};
+
+/** Reference to a top-level `formats[]` entry from a placement declaration. */
+export type AdagentsPlacementFormatReference = {
+  [key: string]: unknown;
+  format_option_id: string;
+  /** Use a full `AdagentsCatalogFormat` when declaring inline placement-specific format details. */
+  format_kind?: never;
+};
+
+/** Placement-level format declaration or same-file top-level format reference. */
+export type AdagentsPlacementFormatOption = AdagentsPlacementFormatReference | AdagentsCatalogFormat;
+
+type AdagentsPlacementBase = {
+  [key: string]: unknown;
+  /** Stable placement identifier unique within this adagents.json file. */
+  placement_id: string;
+  /** Human-readable placement name. */
+  name: string;
+  description?: string;
+  tags?: string[];
+  collection_ids?: string[];
+  channels?: MediaChannel[];
+  format_options?: AdagentsPlacementFormatOption[];
+  ext?: Record<string, unknown>;
+};
+
+/** Canonical placement declaration published in `adagents.json#/placements[]`. */
+export type AdagentsPlacementDefinition =
+  | (AdagentsPlacementBase & { property_ids: string[]; property_tags?: string[] })
+  | (AdagentsPlacementBase & { property_tags: string[]; property_ids?: string[] });
+
+/** Metadata for one `adagents.json#/placement_tags` entry. */
+export type AdagentsPlacementTag = {
+  [key: string]: unknown;
+  name: string;
+  description: string;
+};
+
+/** Request body for POST /api/adagents/create with typed catalog fields. */
+export type CreateAdagentsRequest = Omit<
+  RegistryCreateAdagentsRequest,
+  'authorized_agents' | 'formats' | 'placements' | 'placement_tags'
+> & {
+  authorized_agents: AdagentsAuthorizedAgent[];
+  formats?: AdagentsCatalogFormat[];
+  placements?: AdagentsPlacementDefinition[];
+  placement_tags?: Record<string, AdagentsPlacementTag>;
+};
+
+/** Generated adagents.json payload returned by the registry generator. */
+export type CreatedAdagentsJson = Record<string, unknown> & Partial<CreateAdagentsRequest>;
+
+/** Response from POST /api/adagents/create (200). */
+export type CreateAdagentsResponse = Omit<RegistryCreateAdagentsResponse, 'data'> & {
+  data: {
+    success: boolean;
+    adagents_json?: CreatedAdagentsJson;
+    validation?: unknown;
+    [key: string]: unknown;
+  };
+};
+
+/** Input for building a catalog-only community mirror adagents.json descriptor. */
+export type CommunityMirrorAdagentsConfig = Omit<
+  CreateAdagentsRequest,
+  'authorized_agents' | 'catalog_etag' | 'formats'
+> & {
+  /** Community mirror catalogs should be cacheable static artifacts with stable content identity. */
+  catalog_etag: string;
+  /** Community mirror catalogs exist to publish format-shape metadata. */
+  formats: [AdagentsCatalogFormat, ...AdagentsCatalogFormat[]];
+  /** Seller authorization claims are intentionally not accepted by this helper. */
+  authorized_agents?: never;
+};
+
+/** Catalog-only community mirror adagents.json descriptor. */
+export type CommunityMirrorAdagentsCatalog = Omit<
+  CreateAdagentsRequest,
+  'authorized_agents' | 'catalog_etag' | 'formats'
+> & {
+  authorized_agents: [];
+  catalog_etag: string;
+  formats: [AdagentsCatalogFormat, ...AdagentsCatalogFormat[]];
+};
 
 /** Request body for POST /api/registry/validate/product-authorization */
 export type ValidateProductAuthorizationRequest = NonNullable<

--- a/test/lib/registry.test.js
+++ b/test/lib/registry.test.js
@@ -1,7 +1,7 @@
 const { test, describe, beforeEach, afterEach } = require('node:test');
 const assert = require('node:assert');
 
-const { RegistryClient } = require('../../dist/lib/registry/index.js');
+const { RegistryClient, buildCommunityMirrorAdagents } = require('../../dist/lib/registry/index.js');
 
 // Helper to mock global fetch
 function mockFetch(handler) {
@@ -1680,6 +1680,67 @@ describe('RegistryClient', () => {
       assert.strictEqual(body.formats[0].format_kind, 'display');
       assert.strictEqual(body.placements[0].format_option_ids[0], 'meta-feed-image');
       assert.strictEqual(body.placement_tags.feed.label, 'Feed');
+    });
+
+    test('builds community mirror catalogs without authorization claims', () => {
+      const catalog = buildCommunityMirrorAdagents({
+        catalog_etag: 'meta-creative-formats-2026-05',
+        formats: [
+          {
+            format_option_id: 'meta-feed-image',
+            format_kind: 'image',
+            params: { width: 1080, height: 1080 },
+            v1_format_ref: [{ agent_url: 'https://creative.adcontextprotocol.org/translated/meta', id: 'feed_image' }],
+          },
+        ],
+        placements: [
+          {
+            placement_id: 'feed',
+            name: 'Feed',
+            property_tags: ['feed'],
+            format_options: [{ format_option_id: 'meta-feed-image' }],
+          },
+        ],
+        placement_tags: { feed: { name: 'Feed', description: 'Main feed placement' } },
+      });
+
+      assert.deepStrictEqual(catalog.authorized_agents, []);
+      assert.strictEqual(catalog.catalog_etag, 'meta-creative-formats-2026-05');
+      assert.strictEqual(catalog.formats[0].format_kind, 'image');
+      assert.strictEqual(catalog.placements[0].format_options[0].format_option_id, 'meta-feed-image');
+    });
+
+    test('rejects authorization claims in community mirror helper', () => {
+      assert.throws(
+        () =>
+          buildCommunityMirrorAdagents({
+            authorized_agents: [{ url: 'https://agent.example.com' }],
+            catalog_etag: 'meta-creative-formats-2026-05',
+            formats: [
+              { format_option_id: 'meta-feed-image', format_kind: 'image', params: { width: 1080, height: 1080 } },
+            ],
+          }),
+        /authorized_agents is not accepted/
+      );
+    });
+
+    test('creates community mirror catalogs via the high-level helper', async () => {
+      const created = { success: true, data: { success: true, adagents_json: {} } };
+      let capturedOpts;
+      restore = mockFetch(async (url, opts) => {
+        capturedOpts = opts;
+        return new Response(JSON.stringify(created), { status: 200 });
+      });
+
+      const client = new RegistryClient();
+      await client.createCommunityMirrorAdagents({
+        catalog_etag: 'meta-creative-formats-2026-05',
+        formats: [{ format_option_id: 'meta-feed-image', format_kind: 'image', params: { width: 1080, height: 1080 } }],
+      });
+
+      const body = JSON.parse(capturedOpts.body);
+      assert.deepStrictEqual(body.authorized_agents, []);
+      assert.strictEqual(body.catalog_etag, 'meta-creative-formats-2026-05');
     });
   });
 


### PR DESCRIPTION
## Summary
- Adds typed registry catalog shapes for adagents formats, placements, placement tags, and create responses.
- Adds `buildCommunityMirrorAdagents()` plus `RegistryClient.createCommunityMirrorAdagents()` so community mirrors emit `authorized_agents: []` and reject seller authorization claims.
- Documents build/cache/write-through usage for public `.well-known/adagents.json` routes and includes a minor changeset.

## Validation
- `npm run typecheck`
- `npm run build:lib`
- `node --test test/lib/registry.test.js`
- `npm run format:check`
- Push hook reran typecheck and build.
