### PR TITLE
ci: split typecheck and build lanes

### DIFF
--- a/.changeset/split-typecheck-build.md
+++ b/.changeset/split-typecheck-build.md
@@ -1,0 +1,7 @@
+---
+---
+
+ci: split typecheck and build checks into parallel lanes.
+
+Empty changeset because this only affects repository automation, not the
+published SDK package.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,10 +79,10 @@ jobs:
       - name: Check SDK→docs URLs resolve (URL-rot guard)
         run: npm run ci:doc-links
 
-  typecheck-build:
-    name: Typecheck & Build
+  typescript-typecheck:
+    name: TypeScript Typecheck
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 8
 
     steps:
       - name: Checkout code
@@ -100,21 +100,26 @@ jobs:
       - name: Run TypeScript type checking
         run: npm run typecheck
 
+  library-build:
+    name: Library Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
       - name: Build library
         run: npm run build:lib
-
-      - name: Adopter type-check (catch d.ts leaks)
-        run: npm run check:adopter-types
-
-      - name: Adopter type-check — narrow per-tool imports (#1944)
-        run: npm run check:adopter-types-narrow
-        timeout-minutes: 10
-
-      - name: Typecheck examples
-        run: npm run typecheck:examples
-
-      - name: Typecheck skill code samples
-        run: npm run typecheck:skill-examples
 
       - name: Validate package exports
         run: |
@@ -130,6 +135,92 @@ jobs:
             }
             console.log('✅ Package exports are valid');
           "
+
+  adopter-typechecks:
+    name: Adopter Typechecks
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build library
+        run: npm run build:lib
+
+      - name: Adopter type-check (catch d.ts leaks)
+        run: npm run check:adopter-types
+
+      - name: Adopter type-check — narrow per-tool imports (#1944)
+        run: npm run check:adopter-types-narrow
+        timeout-minutes: 10
+
+  example-typechecks:
+    name: Example Typechecks
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build library
+        run: npm run build:lib
+
+      - name: Typecheck examples
+        run: npm run typecheck:examples
+
+      - name: Typecheck skill code samples
+        run: npm run typecheck:skill-examples
+
+  typecheck-build:
+    name: Typecheck & Build
+    runs-on: ubuntu-latest
+    needs:
+      - typescript-typecheck
+      - library-build
+      - adopter-typechecks
+      - example-typechecks
+    if: ${{ always() }}
+    timeout-minutes: 2
+
+    steps:
+      - name: Verify typecheck and build lanes
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          node - <<'NODE'
+          const needs = JSON.parse(process.env.NEEDS_JSON);
+          const failed = Object.entries(needs).filter(([, job]) => job.result !== 'success');
+
+          if (failed.length > 0) {
+            console.error('One or more typecheck/build lanes failed:');
+            for (const [name, job] of failed) {
+              console.error(`- ${name}: ${job.result}`);
+            }
+            process.exit(1);
+          }
+
+          console.log('All typecheck/build lanes passed.');
+          NODE
 
   unit-tests-fast:
     name: Unit Tests Fast (${{ matrix.shard }})


### PR DESCRIPTION
## Summary
- split the serial Typecheck & Build job into root typecheck, library build, adopter typecheck, and example typecheck lanes
- keep the aggregate Typecheck & Build check name for branch protection
- add an empty changeset because this only changes CI automation

## Validation
- npm run lint:workflows
- npx prettier --check .github/workflows/ci.yml .changeset/split-typecheck-build.md
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); puts 'YAML OK'"
- git diff --check
- npx changeset status --since=origin/main
- git push pre-push validation: npm run typecheck, npm run build:lib