### PR TITLE
ci: update artifact actions for node 24

### DIFF
--- a/.changeset/node24-artifact-actions.md
+++ b/.changeset/node24-artifact-actions.md
@@ -1,0 +1,7 @@
+---
+---
+
+ci: update GitHub artifact actions for Node 24.
+
+Empty changeset because this only affects repository automation, not the
+published SDK package.

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -39,7 +39,7 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/interop-python.yml
+++ b/.github/workflows/interop-python.yml
@@ -83,7 +83,7 @@ jobs:
           echo "Packed SDK runner at ${tarballs[0]}"
 
       - name: Upload SDK runner tarball
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: adcp-sdk-runner-tarball
           if-no-files-found: error
@@ -129,7 +129,7 @@ jobs:
           python-version: '3.12'
 
       - name: Download SDK runner tarball
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: adcp-sdk-runner-tarball
           path: ${{ runner.temp }}/adcp-sdk-pack
@@ -205,7 +205,7 @@ jobs:
 
       - name: Upload storyboard artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.language }}-reference-seller-storyboard
           if-no-files-found: ignore
@@ -236,7 +236,7 @@ jobs:
           cache: npm
 
       - name: Download SDK runner tarball
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: adcp-sdk-runner-tarball
           path: ${{ runner.temp }}/adcp-sdk-pack
@@ -282,7 +282,7 @@ jobs:
 
       - name: Upload storyboard artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: typescript-reference-seller-storyboard
           if-no-files-found: ignore
@@ -325,7 +325,7 @@ jobs:
           node-version: 24
 
       - name: Download SDK runner tarball
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: adcp-sdk-runner-tarball
           path: ${{ runner.temp }}/adcp-sdk-pack
@@ -373,7 +373,7 @@ jobs:
 
       - name: Upload storyboard artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: typescript-strict-adcp-3-0-reference-seller-storyboard
           if-no-files-found: ignore


### PR DESCRIPTION
## Summary
- update artifact upload/download actions in the reusable reference-seller interop workflow to Node 24-capable majors
- update the AI review checkout action from v4 to v5
- add an empty changeset because this only changes CI automation

## Validation
- npm run lint:workflows
- npx prettier --check .github/workflows/interop-python.yml .github/workflows/ai-review.yml .changeset/node24-artifact-actions.md
- ruby -e "require 'yaml'; %w[.github/workflows/interop-python.yml .github/workflows/ai-review.yml].each { |f| YAML.load_file(f) }; puts 'YAML OK'"
- git diff --check
- npx changeset status --since=origin/main
- git push pre-push validation: npm run typecheck, npm run build:lib