### PR TITLE
fix(release): unblock beta.15 publish

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -53,6 +53,7 @@
     "media-buy-3-1-types",
     "migration-v8-guide",
     "mock-server-scenario-controller",
+    "node24-artifact-actions",
     "object-schema-intersections",
     "outcome-measurement-rename",
     "parallel-ci-workflow",

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -23,17 +23,53 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Node.js
+      - name: Detect release metadata-only change
         if: github.head_ref != 'changeset-release/main'
+        id: release-metadata
+        run: |
+          changed_files="$(git diff --name-only origin/main...HEAD)"
+          package_changes="$(
+            printf '%s\n' "$changed_files" |
+              grep -Ev '^(\.changeset/pre\.json|src/lib/version\.ts|docs/(llms\.txt|TYPE-SUMMARY\.md)|\.github/workflows/(changeset-check|release)\.yml)$' ||
+              true
+          )"
+
+          if [ -z "$package_changes" ]; then
+            if printf '%s\n' "$changed_files" | grep -qx 'src/lib/version.ts'; then
+              node -e '
+                const fs = require("node:fs");
+                const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+                const source = fs.readFileSync("src/lib/version.ts", "utf8");
+                const quote = String.fromCharCode(39);
+                const hasLibraryVersion = source.includes(`LIBRARY_VERSION = ${quote}${pkg.version}${quote}`);
+                const hasVersionInfoLibrary = source.includes(`library: ${quote}${pkg.version}${quote}`);
+
+                if (!hasLibraryVersion || !hasVersionInfoLibrary) {
+                  console.error(
+                    `src/lib/version.ts is not synced with package.json version ${pkg.version}.`
+                  );
+                  process.exit(1);
+                }
+              '
+            fi
+
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Only release metadata changed; changeset not required."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup Node.js
+        if: github.head_ref != 'changeset-release/main' && steps.release-metadata.outputs.skip != 'true'
         uses: actions/setup-node@v5
         with:
           node-version: '20.x'
           cache: 'npm'
 
       - name: Install dependencies
-        if: github.head_ref != 'changeset-release/main'
+        if: github.head_ref != 'changeset-release/main' && steps.release-metadata.outputs.skip != 'true'
         run: npm ci
 
       - name: Check for changeset
-        if: github.head_ref != 'changeset-release/main'
+        if: github.head_ref != 'changeset-release/main' && steps.release-metadata.outputs.skip != 'true'
         run: npx changeset status --since=origin/main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,7 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
+          version: npm run version
           publish: npm run release
           title: 'chore: release package'
           commit: 'chore: release package'

--- a/docs/TYPE-SUMMARY.md
+++ b/docs/TYPE-SUMMARY.md
@@ -1,7 +1,7 @@
 # AdCP Type Summary
 
 > Generated at: 2026-05-28
-> @adcp/sdk v8.1.0-beta.14
+> @adcp/sdk v8.1.0-beta.15
 
 Curated reference of the types that matter for using the AdCP client. For full generated types see `src/lib/types/tools.generated.ts` and `src/lib/types/core.generated.ts`.
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,7 +1,7 @@
 # Ad Context Protocol (AdCP)
 
 > Generated at: 2026-05-28
-> Library: @adcp/sdk v8.1.0-beta.14
+> Library: @adcp/sdk v8.1.0-beta.15
 > AdCP major version: 3
 > Canonical URL: https://adcontextprotocol.github.io/adcp-client/llms.txt
 > Note: the `Library` stamp reflects the package.json version at doc-generation time. The narrative below describes the surface that lands on the next-published minor — including any 6.7 helpers documented here ahead of the release tag.

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP SDK library version
  */
-export const LIBRARY_VERSION = '8.1.0-beta.14';
+export const LIBRARY_VERSION = '8.1.0-beta.15';
 
 /**
  * AdCP specification version this library is built for
@@ -65,10 +65,10 @@ export type AdcpVersion = (typeof COMPATIBLE_ADCP_VERSIONS)[number];
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '8.1.0-beta.14',
+  library: '8.1.0-beta.15',
   adcp: '3.1.0-beta.7',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-05-28T10:31:40.792Z',
+  generatedAt: '2026-05-28T13:22:59.427Z',
 } as const;
 
 /**


### PR DESCRIPTION
## Summary

This unblocks the `8.1.0-beta.15` publish after the release workflow no-op'd on `main`.

It marks the Node 24 artifact-actions empty changeset as consumed in prerelease state, syncs checked-in version/docs metadata with `package.json`, and makes future Changesets release PRs use the repo's `npm run version` script so generated version metadata stays current.

The changeset PR gate now skips only release metadata/version-sync-only changes and verifies `src/lib/version.ts` matches `package.json` before skipping.

## Validation

- release metadata-only guard simulation
- `npm run release -- --dry-run`
- `npm run format:check -- .github/workflows/changeset-check.yml .github/workflows/release.yml src/lib/version.ts docs/llms.txt docs/TYPE-SUMMARY.md`
- `npm run ci:docs-check`
- `git diff --check`
- pre-push `tsc --noEmit`
