### PR TITLE
fix(signing): restore response signing helpers

### DIFF
--- a/.changeset/restore-response-signing.md
+++ b/.changeset/restore-response-signing.md
@@ -1,0 +1,6 @@
+---
+'@adcp/sdk': patch
+---
+
+Restore signing-only response helpers under `@adcp/sdk/signing` for adopters that sign JSON transport responses and publish
+`response-signing` JWKs.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
   generated-checks:
     name: Generated, Docs & Formatting
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
 
     steps:
       - name: Checkout code
@@ -225,7 +225,7 @@ jobs:
   unit-tests-fast:
     name: Unit Tests Fast (${{ matrix.shard }})
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -282,7 +282,7 @@ jobs:
   eslint-plugin-tests:
     name: ESLint Plugin Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15
 
     steps:
       - name: Checkout code

--- a/docs/migration-7.11-to-8.0.md
+++ b/docs/migration-7.11-to-8.0.md
@@ -31,24 +31,19 @@ The beta-era direct feed polling options were removed from the config shape: `fe
 
 `ResolvedCapabilities.catalogVersioning` was also removed. Use `ResolvedCapabilities.wholesaleFeedVersioning`.
 
-## Current 8.x Beta Follow-up: RFC 9421 Transport Response Signing Removed
+## Current 8.x Beta Follow-up: RFC 9421 Transport Response Verification
 
-This was not part of the original 8.0 beta cut. It was removed in the 8.1 beta line because AdCP 3.x does not authorize RFC 9421 §2.2.9 transport response signing as a protocol surface. If you are upgrading from 7.11 directly to the current 8.x beta (`@adcp/sdk@beta`), apply this change along with the rest of the v8 migration.
+This was not part of the original 8.0 beta cut. Generic response verification remains unsupported in the 8.1 beta line because AdCP 3.x does not authorize RFC 9421 §2.2.9 transport response signing as a protocol surface. If you are upgrading from 7.11 directly to the current 8.x beta (`@adcp/sdk@beta`), apply this change along with the rest of the v8 migration.
 
-Removed from `@adcp/sdk/signing`, `@adcp/sdk/signing/client`, and `@adcp/sdk/signing/server`:
+The SDK keeps signing-only compatibility helpers for adopters that already sign JSON transport responses and publish `adcp_use: 'response-signing'` JWKs: `signResponse`, `signResponseAsync`, `buildResponseSignatureBase`, `ResponseLike`, `ResponseSignatureError`, `RESPONSE_SIGNING_TAG`, `RESPONSE_MANDATORY_COMPONENTS`, `prepareResponseSignature`, `finalizeResponseSignature`, `SignResponseOptions`, `PreparedResponseSignature`, and `SignedResponse`.
 
-| Removed API | Replacement |
+Still unsupported:
+
+| Unsupported API | Replacement |
 | --- | --- |
-| `signResponse`, `signResponseAsync` | None for generic transport responses |
 | `verifyResponseSignature`, `createResponseVerifier` | None for generic transport responses |
-| `ResponseSignatureError`, `ResponseSignatureErrorCode` | None |
-| `RESPONSE_SIGNING_TAG`, `RESPONSE_MANDATORY_COMPONENTS` | None |
-| `buildResponseSignatureBase`, `ResponseLike` | None |
-| `prepareResponseSignature`, `finalizeResponseSignature` | None |
-| `SignResponseOptions`, `PreparedResponseSignature`, `SignedResponse` | None |
 | `VerifyResponseOptions`, `VerifyResponseResult`, `CreateResponseVerifierOptions` | None |
-| `AdcpUse` value `'response-signing'` | None |
 
-Runtime helpers also reject the retired purpose. `pemToAdcpJwk({ adcp_use: 'response-signing' })` and `mintEphemeralEd25519Key({ adcp_use: 'response-signing' })` now throw, and `InMemorySigningProvider` preserves retired or unknown raw purpose strings so `signRequestAsync()` and `signWebhookAsync()` still fail closed instead of silently treating the key as unscoped.
+`pemToAdcpJwk({ adcp_use: 'response-signing' })` and `mintEphemeralEd25519Key({ adcp_use: 'response-signing' })` are accepted for this compatibility signing path. `signRequestAsync()` and `signWebhookAsync()` still fail closed when given response-signing keys. `signResponseAsync()` also requires providers to declare `adcpUse: 'response-signing'`; legacy providers that omit `adcpUse` remain accepted by request/webhook helpers but are refused for response signing.
 
-There is no conformant AdCP 3.x replacement for generic transport response signing. Request signing and webhook signing are unchanged. Future designated-task payload JWS support should be added under a fresh spec-defined purpose and helper surface, not by reusing the removed response-signing purpose or tag.
+There is no conformant AdCP 3.x replacement for generic transport response verification. Request signing and webhook signing are unchanged. Future designated-task payload JWS support should be added under a fresh spec-defined purpose and helper surface rather than expanding this compatibility signing path.

--- a/docs/migration-8.0-to-8.1.md
+++ b/docs/migration-8.0-to-8.1.md
@@ -24,8 +24,9 @@
 - For webhook receivers, move to RFC 9421 verification and a shared replay
   store before running more than one replica. See
   [Verifying inbound webhooks](./recipes/verifying-inbound-webhooks.md).
-- Remove any use of the preview RFC 9421 transport response-signing helpers.
-  AdCP 3.x does not support generic transport response signing.
+- Generic response verification remains unsupported in AdCP 3.x. The SDK
+  keeps signing-only response helpers for compatibility with adopters that
+  publish signed JSON responses.
 - If your code extends `ProductSchema`, upgrade to 8.1. `ProductSchema` is
   intentionally a `ZodObject` again, so `.extend()`, `.omit()`, `.pick()`, and
   `.shape` work.
@@ -39,38 +40,39 @@
 
 ## Signing Surface Changes
 
-### RFC 9421 transport response signing was removed
+### RFC 9421 transport response verification remains unsupported
 
-8.1 removes the preview-only generic response-signing API because AdCP 3.x does
-not authorize RFC 9421 §2.2.9 transport response signing as a protocol surface.
-Request signing and webhook signing are unchanged.
+8.1 does not support generic transport response verification because AdCP 3.x
+does not authorize RFC 9421 §2.2.9 transport response signing as a protocol
+surface. Request signing and webhook signing are unchanged.
 
-Removed from `@adcp/sdk/signing`, `@adcp/sdk/signing/client`, and
-`@adcp/sdk/signing/server`:
+The SDK keeps the signing-only compatibility surface for agents that already
+sign JSON transport responses and publish `adcp_use: 'response-signing'` JWKs:
+`signResponse`, `signResponseAsync`, `buildResponseSignatureBase`,
+`ResponseLike`, `ResponseSignatureError`, `RESPONSE_SIGNING_TAG`,
+`RESPONSE_MANDATORY_COMPONENTS`, `prepareResponseSignature`,
+`finalizeResponseSignature`, `SignResponseOptions`,
+`PreparedResponseSignature`, and `SignedResponse`.
 
-| Removed API | Replacement |
+Still unsupported:
+
+| Unsupported API | Replacement |
 |---|---|
-| `signResponse`, `signResponseAsync` | None for generic transport responses |
 | `verifyResponseSignature`, `createResponseVerifier` | None for generic transport responses |
-| `ResponseSignatureError`, `ResponseSignatureErrorCode` | None |
-| `RESPONSE_SIGNING_TAG`, `RESPONSE_MANDATORY_COMPONENTS` | None |
-| `buildResponseSignatureBase`, `ResponseLike` | None |
-| `prepareResponseSignature`, `finalizeResponseSignature` | None |
-| `SignResponseOptions`, `PreparedResponseSignature`, `SignedResponse` | None |
 | `VerifyResponseOptions`, `VerifyResponseResult`, `CreateResponseVerifierOptions` | None |
-| `AdcpUse` value `'response-signing'` | None |
 
-Runtime helpers also reject the retired purpose. `pemToAdcpJwk({ adcp_use:
-'response-signing' })` and `mintEphemeralEd25519Key({ adcp_use:
-'response-signing' })` now throw, and `InMemorySigningProvider` preserves
-retired or unknown raw purpose strings so `signRequestAsync()` and
-`signWebhookAsync()` still fail closed instead of silently treating the key as
-unscoped.
+`pemToAdcpJwk({ adcp_use: 'response-signing' })` and
+`mintEphemeralEd25519Key({ adcp_use: 'response-signing' })` are accepted for
+this compatibility signing path. `signRequestAsync()` and `signWebhookAsync()`
+still fail closed when given response-signing keys. `signResponseAsync()` also
+requires providers to declare `adcpUse: 'response-signing'`; legacy providers
+that omit `adcpUse` remain accepted by request/webhook helpers but are refused
+for response signing.
 
 There is no conformant AdCP 3.x replacement for generic transport response
-signing. Future designated-task payload JWS support should be added under a
-fresh spec-defined purpose and helper surface, not by reusing the removed
-response-signing purpose or tag.
+verification. Future designated-task payload JWS support should be added under a
+fresh spec-defined purpose and helper surface rather than expanding this
+compatibility signing path.
 
 ## Wire Shape Tightening
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/sdk",
-  "version": "8.1.0-beta.14",
+  "version": "8.1.0-beta.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/sdk",
-      "version": "8.1.0-beta.14",
+      "version": "8.1.0-beta.15",
       "license": "Apache-2.0",
       "workspaces": [
         ".",
@@ -7356,7 +7356,7 @@
       "version": "6.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adcp/sdk": "^8.1.0-beta.14"
+        "@adcp/sdk": "^8.1.0-beta.15"
       },
       "bin": {
         "adcp": "bin/adcp.js"

--- a/scripts/sync-3-1-beta-schemas.ts
+++ b/scripts/sync-3-1-beta-schemas.ts
@@ -85,9 +85,21 @@ function restoreFromHead(paths: readonly string[]): void {
   console.log(`♻️  Restored ${tracked.length} side-effect path(s) from HEAD (primary-pin state preserved).`);
 }
 
+function hasBetaCache(): boolean {
+  return (
+    existsSync(path.join(SCHEMA_CACHE_DIR, BETA_VERSION)) && existsSync(path.join(COMPLIANCE_CACHE_DIR, BETA_VERSION))
+  );
+}
+
 async function main(): Promise<void> {
   const primary = getPrimaryAdcpVersion();
   console.log(`🔄 Opt-in sync: AdCP ${BETA_VERSION} (primary pin stays at ${primary})`);
+  if (primary === BETA_VERSION && hasBetaCache()) {
+    console.log(`✅ ${BETA_VERSION} is already synced as the primary pin; skipping duplicate beta sync.`);
+    restoreLatestSymlink(SCHEMA_CACHE_DIR, primary);
+    restoreLatestSymlink(COMPLIANCE_CACHE_DIR, primary);
+    return;
+  }
   const delegatedToFallback = await syncBetaSchemasWithFallback();
   if (delegatedToFallback) return;
   // `syncSchemas` repointed `latest/` at the beta. Move it back so the

--- a/src/lib/signing/canonicalize.ts
+++ b/src/lib/signing/canonicalize.ts
@@ -19,9 +19,11 @@ export interface ResponseLike {
   body?: string;
   /**
    * Originating request context. `url` must be absolute because
-   * `@target-uri` and `@authority` are parsed with `new URL(...)`.
+   * `@target-uri` and `@authority` are parsed with `new URL(...)`. Supply
+   * `headers` when signing request-qualified header components such as
+   * `authorization;req`.
    */
-  request: { method: string; url: string };
+  request: { method: string; url: string; headers?: Record<string, string | string[] | undefined> };
 }
 
 export interface SignatureParams {
@@ -131,7 +133,8 @@ export function buildSignatureBase(
  *
  * Resolves `@status` from `response.status`; request-qualified components
  * such as `@method;req`, `@target-uri;req`, and `@authority;req` bind to
- * `response.request`, and header components resolve against
+ * `response.request`, request-qualified headers bind to
+ * `response.request.headers`, and response header components resolve against
  * `response.headers`. `signatureParamsValue` has the same verifier-path
  * meaning as in {@link buildSignatureBase}.
  */
@@ -144,18 +147,12 @@ export function buildResponseSignatureBase(
   const requestView: RequestLike = {
     method: response.request.method,
     url: response.request.url,
-    headers: response.headers,
-    body: response.body,
+    headers: response.request.headers ?? {},
   };
   const lines: string[] = [];
   for (const component of components) {
     const { bare, requestBound } = parseComponentIdentifier(component);
-    const value =
-      bare === '@status'
-        ? String(response.status)
-        : requestBound || bare.startsWith('@')
-          ? resolveComponentValue(bare, requestView)
-          : getHeaderValue(response.headers, bare);
+    const value = resolveResponseComponentValue(bare, requestBound, response, requestView);
     if (value === undefined) {
       throw new RequestSignatureError(
         'request_signature_components_incomplete',
@@ -184,6 +181,14 @@ export function formatSignatureParams(components: ReadonlyArray<string>, params:
 function parseComponentIdentifier(component: string): { bare: string; requestBound: boolean } {
   if (!component.includes(';')) return { bare: component, requestBound: false };
   const [bare, ...params] = component.split(';');
+  const unsupported = params.filter(param => param !== 'req');
+  if (unsupported.length > 0) {
+    throw new RequestSignatureError(
+      'request_signature_components_unexpected',
+      6,
+      `Covered component "${component}" uses unsupported component parameters`
+    );
+  }
   return {
     bare: bare ?? component,
     requestBound: params.includes('req'),
@@ -193,6 +198,35 @@ function parseComponentIdentifier(component: string): { bare: string; requestBou
 function formatComponentIdentifier(component: string): string {
   const { bare, requestBound } = parseComponentIdentifier(component);
   return `"${bare}"${requestBound ? ';req' : ''}`;
+}
+
+function resolveResponseComponentValue(
+  bare: string,
+  requestBound: boolean,
+  response: ResponseLike,
+  requestView: RequestLike
+): string | undefined {
+  if (bare === '@status') {
+    if (requestBound) {
+      throw new RequestSignatureError(
+        'request_signature_components_unexpected',
+        6,
+        '"@status" cannot use the request-bound ;req parameter'
+      );
+    }
+    return String(response.status);
+  }
+  if (bare.startsWith('@')) {
+    if (!requestBound) {
+      throw new RequestSignatureError(
+        'request_signature_components_unexpected',
+        6,
+        `Response derived component "${bare}" must use the request-bound ;req parameter`
+      );
+    }
+    return resolveComponentValue(bare, requestView);
+  }
+  return getHeaderValue(requestBound ? requestView.headers : response.headers, bare);
 }
 
 function resolveComponentValue(component: string, request: RequestLike): string | undefined {

--- a/src/lib/signing/canonicalize.ts
+++ b/src/lib/signing/canonicalize.ts
@@ -7,6 +7,23 @@ export interface RequestLike {
   body?: string;
 }
 
+/**
+ * RFC 9421 response-signing context. Carries the response status and
+ * headers/body, plus the originating request method + URL so derived
+ * components that bind back to the request context (`@method`,
+ * `@target-uri`, `@authority`) resolve correctly.
+ */
+export interface ResponseLike {
+  status: number;
+  headers: Record<string, string | string[] | undefined>;
+  body?: string;
+  /**
+   * Originating request context. `url` must be absolute because
+   * `@target-uri` and `@authority` are parsed with `new URL(...)`.
+   */
+  request: { method: string; url: string };
+}
+
 export interface SignatureParams {
   created: number;
   expires: number;
@@ -27,7 +44,7 @@ const DEFAULT_PARAM_ORDER: ReadonlyArray<keyof SignatureParams> = [
 
 const STRING_PARAMS = new Set<keyof SignatureParams>(['nonce', 'keyid', 'alg', 'tag']);
 
-const SUPPORTED_DERIVED = new Set(['@method', '@target-uri', '@authority']);
+const SUPPORTED_DERIVED = new Set(['@method', '@target-uri', '@authority', '@status']);
 
 export function canonicalTargetUri(rawUrl: string): string {
   rejectNonAsciiHost(rawUrl);
@@ -102,7 +119,51 @@ export function buildSignatureBase(
         `Covered component "${component}" not present in request`
       );
     }
-    lines.push(`"${component}": ${value}`);
+    lines.push(`${formatComponentIdentifier(component)}: ${value}`);
+  }
+  const paramsString = signatureParamsValue ?? formatSignatureParams(components, params);
+  lines.push(`"@signature-params": ${paramsString}`);
+  return lines.join('\n');
+}
+
+/**
+ * Build the RFC 9421 §2.5 signature base for a response.
+ *
+ * Resolves `@status` from `response.status`; request-qualified components
+ * such as `@method;req`, `@target-uri;req`, and `@authority;req` bind to
+ * `response.request`, and header components resolve against
+ * `response.headers`. `signatureParamsValue` has the same verifier-path
+ * meaning as in {@link buildSignatureBase}.
+ */
+export function buildResponseSignatureBase(
+  components: ReadonlyArray<string>,
+  response: ResponseLike,
+  params: SignatureParams,
+  signatureParamsValue?: string
+): string {
+  const requestView: RequestLike = {
+    method: response.request.method,
+    url: response.request.url,
+    headers: response.headers,
+    body: response.body,
+  };
+  const lines: string[] = [];
+  for (const component of components) {
+    const { bare, requestBound } = parseComponentIdentifier(component);
+    const value =
+      bare === '@status'
+        ? String(response.status)
+        : requestBound || bare.startsWith('@')
+          ? resolveComponentValue(bare, requestView)
+          : getHeaderValue(response.headers, bare);
+    if (value === undefined) {
+      throw new RequestSignatureError(
+        'request_signature_components_incomplete',
+        6,
+        `Covered component "${component}" not present in response`
+      );
+    }
+    lines.push(`${formatComponentIdentifier(component)}: ${value}`);
   }
   const paramsString = signatureParamsValue ?? formatSignatureParams(components, params);
   lines.push(`"@signature-params": ${paramsString}`);
@@ -110,7 +171,7 @@ export function buildSignatureBase(
 }
 
 export function formatSignatureParams(components: ReadonlyArray<string>, params: SignatureParams): string {
-  const componentList = components.map(c => `"${c}"`).join(' ');
+  const componentList = components.map(formatComponentIdentifier).join(' ');
   const paramPairs: string[] = [];
   for (const key of DEFAULT_PARAM_ORDER) {
     const raw = params[key];
@@ -118,6 +179,20 @@ export function formatSignatureParams(components: ReadonlyArray<string>, params:
     paramPairs.push(STRING_PARAMS.has(key) ? `${key}="${raw}"` : `${key}=${raw}`);
   }
   return `(${componentList});${paramPairs.join(';')}`;
+}
+
+function parseComponentIdentifier(component: string): { bare: string; requestBound: boolean } {
+  if (!component.includes(';')) return { bare: component, requestBound: false };
+  const [bare, ...params] = component.split(';');
+  return {
+    bare: bare ?? component,
+    requestBound: params.includes('req'),
+  };
+}
+
+function formatComponentIdentifier(component: string): string {
+  const { bare, requestBound } = parseComponentIdentifier(component);
+  return `"${bare}"${requestBound ? ';req' : ''}`;
 }
 
 function resolveComponentValue(component: string, request: RequestLike): string | undefined {
@@ -136,6 +211,12 @@ function resolveComponentValue(component: string, request: RequestLike): string 
         return canonicalTargetUri(request.url);
       case '@authority':
         return canonicalAuthority(request.url);
+      case '@status':
+        throw new RequestSignatureError(
+          'request_signature_components_unexpected',
+          6,
+          '"@status" is only valid in response-signing context; use buildResponseSignatureBase'
+        );
     }
   }
   return getHeaderValue(request.headers, component);

--- a/src/lib/signing/client.ts
+++ b/src/lib/signing/client.ts
@@ -7,6 +7,7 @@
  * The aggregate `@adcp/sdk/signing` barrel re-exports both for back-compat.
  */
 export {
+  buildResponseSignatureBase,
   buildSignatureBase,
   canonicalAuthority,
   canonicalMethod,
@@ -14,6 +15,7 @@ export {
   formatSignatureParams,
   getHeaderValue,
   type RequestLike,
+  type ResponseLike,
   type SignatureParams,
 } from './canonicalize';
 export { computeContentDigest, contentDigestMatches, parseContentDigest } from './content-digest';
@@ -29,18 +31,24 @@ export {
 } from './request-context';
 export {
   finalizeRequestSignature,
+  finalizeResponseSignature,
   prepareRequestSignature,
+  prepareResponseSignature,
   prepareWebhookSignature,
   signRequest,
+  signResponse,
   signWebhook,
   type PreparedRequestSignature,
+  type PreparedResponseSignature,
   type SignatureIdentity,
   type SignedRequest,
+  type SignedResponse,
   type SignerKey,
   type SignRequestOptions,
+  type SignResponseOptions,
   type SignWebhookOptions,
 } from './signer';
-export { signRequestAsync, signWebhookAsync } from './signer-async';
+export { signRequestAsync, signResponseAsync, signWebhookAsync } from './signer-async';
 export { derEcdsaToP1363 } from './ecdsa-encoding';
 export { WEBHOOK_MANDATORY_COMPONENTS, WEBHOOK_SIGNING_TAG } from './webhook-verifier';
 export { createSigningFetch, type CoverContentDigestPredicate, type SigningFetchOptions } from './fetch';
@@ -49,6 +57,8 @@ export type { SigningProvider } from './provider';
 export {
   RequestSignatureError,
   type RequestSignatureErrorCode,
+  ResponseSignatureError,
+  type ResponseSignatureErrorCode,
   SigningProviderAlgorithmMismatchError,
   type SigningProviderErrorCode,
   WebhookSignatureError,
@@ -60,6 +70,8 @@ export {
   MANDATORY_COMPONENTS,
   MAX_SIGNATURE_WINDOW_SECONDS,
   REQUEST_SIGNING_TAG,
+  RESPONSE_MANDATORY_COMPONENTS,
+  RESPONSE_SIGNING_TAG,
   type AdcpJsonWebKey,
   type AdcpSignAlg,
   type ContentDigestPolicy,

--- a/src/lib/signing/errors.ts
+++ b/src/lib/signing/errors.ts
@@ -81,6 +81,19 @@ export class WebhookSignatureError extends ADCPError {
   }
 }
 
+export type ResponseSignatureErrorCode = 'response_signature_key_purpose_invalid';
+
+export class ResponseSignatureError extends ADCPError {
+  readonly code: ResponseSignatureErrorCode;
+  readonly failedStep: number;
+
+  constructor(code: ResponseSignatureErrorCode, failedStep: number, message: string, details?: unknown) {
+    super(message, details);
+    this.code = code;
+    this.failedStep = failedStep;
+  }
+}
+
 /**
  * SDK-side error codes for the `SigningProvider` integration path. Distinct
  * namespace from `RequestSignatureErrorCode` / `WebhookSignatureErrorCode`

--- a/src/lib/signing/jwks-helpers.ts
+++ b/src/lib/signing/jwks-helpers.ts
@@ -17,9 +17,14 @@ const WIRE_ALG_TO_JOSE: Record<AdcpSignAlg, string> = {
   'ecdsa-p256-sha256': 'ES256',
 };
 
-export type AdcpUse = 'request-signing' | 'webhook-signing' | 'governance-signing';
+export type AdcpUse = 'request-signing' | 'webhook-signing' | 'response-signing' | 'governance-signing';
 
-const ADCP_USE_VALUES = new Set<AdcpUse>(['request-signing', 'webhook-signing', 'governance-signing']);
+const ADCP_USE_VALUES = new Set<AdcpUse>([
+  'request-signing',
+  'webhook-signing',
+  'response-signing',
+  'governance-signing',
+]);
 
 export function assertAdcpUse(value: unknown, helperName: string): asserts value is AdcpUse {
   if (typeof value !== 'string' || !ADCP_USE_VALUES.has(value as AdcpUse)) {
@@ -39,6 +44,8 @@ export interface PemToAdcpJwkOptions {
    * Purpose binding, enforced by AdCP verifiers at step 8.
    * - `'request-signing'` — for JWKs published at the buyer's `jwks_uri`.
    * - `'webhook-signing'` — for JWKs used to sign outbound webhook callbacks.
+   * - `'response-signing'` — for compatibility with agents that sign JSON
+   *   transport responses directly.
    * - `'governance-signing'` — for JWKs used to sign governance context
    *   (JWS-signed, not RFC 9421). Declared on JWKs published in a tenant's
    *   aggregated JWKS so JSON-typed consumers (e.g., third-party verifiers

--- a/src/lib/signing/parser.ts
+++ b/src/lib/signing/parser.ts
@@ -50,9 +50,9 @@ export function parseSignatureInput(headerValue: string): ParsedSignatureInput {
     malformed('Signature-Input value must be a parenthesized component list');
   }
   const components: string[] = [];
-  for (const [bare] of entry[0]) {
+  for (const [bare, itemParams] of entry[0]) {
     if (typeof bare !== 'string') malformed('Signature-Input components must all be strings');
-    components.push(bare);
+    components.push(itemParams instanceof Map && itemParams.get('req') === true ? `${bare};req` : bare);
   }
   const params: Record<string, string | number> = {};
   for (const [key, value] of entry[1]) {

--- a/src/lib/signing/provider.ts
+++ b/src/lib/signing/provider.ts
@@ -58,19 +58,22 @@ export interface SigningProvider {
   /**
    * Purpose binding for the underlying key, parallel to the sync-path
    * `SignerKey.privateKey.adcp_use` gate. When set, the async helpers
-   * (`signRequestAsync`, `signWebhookAsync`) refuse keys whose `adcpUse`
-   * doesn't match the helper, with the same error codes the verifier raises
-   * at step 8.
+   * (`signRequestAsync`, `signWebhookAsync`, `signResponseAsync`) refuse keys
+   * whose `adcpUse` doesn't match the helper, with the same error codes the
+   * verifier raises at step 8.
    *
-   * **Optional and backward-compatible.** Existing providers that omit
-   * `adcpUse` skip the gate (no breakage, but no defense-in-depth either).
+   * **Optional and backward-compatible for request/webhook helpers.** Existing
+   * providers that omit `adcpUse` skip the request/webhook gate (no breakage,
+   * but no defense-in-depth either). `signResponseAsync` is stricter and
+   * requires `adcpUse: 'response-signing'`, because response signing is a
+   * compatibility surface without an SDK verifier later in the pipeline.
    * When present, it is intentionally typed as a raw string so retired or
    * unknown purpose values still fail closed instead of being erased before
    * the signer-side gate runs. Adapter authors who care about catching IAM
    * misconfig at the signer rather than the verifier should set this — KMS is
    * exactly where one IAM mistake silently grants a single key cross-purpose
-   * access, and `request-signing` / `webhook-signing` keys MUST stay distinct
-   * per AdCP step-8 purpose-binding.
+   * access, and `request-signing` / `webhook-signing` / `response-signing`
+   * keys MUST stay distinct per AdCP step-8 purpose-binding.
    */
   readonly adcpUse?: string;
 

--- a/src/lib/signing/server.ts
+++ b/src/lib/signing/server.ts
@@ -9,6 +9,7 @@
  * both for back-compat.
  */
 export {
+  buildResponseSignatureBase,
   buildSignatureBase,
   canonicalAuthority,
   canonicalMethod,
@@ -16,6 +17,7 @@ export {
   formatSignatureParams,
   getHeaderValue,
   type RequestLike,
+  type ResponseLike,
   type SignatureParams,
 } from './canonicalize';
 export { computeContentDigest, contentDigestMatches, parseContentDigest } from './content-digest';
@@ -33,6 +35,8 @@ export { jwkToPublicKey, verifySignature } from './crypto';
 export {
   RequestSignatureError,
   type RequestSignatureErrorCode,
+  ResponseSignatureError,
+  type ResponseSignatureErrorCode,
   WebhookSignatureError,
   type WebhookSignatureErrorCode,
 } from './errors';
@@ -74,6 +78,8 @@ export {
   MANDATORY_COMPONENTS,
   MAX_SIGNATURE_WINDOW_SECONDS,
   REQUEST_SIGNING_TAG,
+  RESPONSE_MANDATORY_COMPONENTS,
+  RESPONSE_SIGNING_TAG,
   type AdcpJsonWebKey,
   type ContentDigestPolicy,
   type RevocationSnapshot,
@@ -92,6 +98,15 @@ export {
   type VerifyWebhookResult,
 } from './webhook-verifier';
 export { createExpressVerifier, type ExpressLike, type ExpressMiddlewareOptions } from './middleware';
+export {
+  finalizeResponseSignature,
+  prepareResponseSignature,
+  signResponse,
+  type PreparedResponseSignature,
+  type SignedResponse,
+  type SignResponseOptions,
+} from './signer';
+export { signResponseAsync } from './signer-async';
 export {
   resolveAgent,
   getAgentJwks,

--- a/src/lib/signing/signer-async.ts
+++ b/src/lib/signing/signer-async.ts
@@ -1,10 +1,18 @@
-import type { RequestLike } from './canonicalize';
+import type { RequestLike, ResponseLike } from './canonicalize';
 import type { SigningProvider } from './provider';
-import type { SignedRequest, SignRequestOptions, SignWebhookOptions } from './signer';
+import type {
+  SignedRequest,
+  SignedResponse,
+  SignRequestOptions,
+  SignResponseOptions,
+  SignWebhookOptions,
+} from './signer';
 import {
   assertProviderPurpose,
   finalizeRequestSignature,
+  finalizeResponseSignature,
   prepareRequestSignature,
+  prepareResponseSignature,
   prepareWebhookSignature,
 } from './signer';
 
@@ -46,4 +54,19 @@ export async function signWebhookAsync(
   const prepared = prepareWebhookSignature(request, { keyid: provider.keyid, alg: provider.algorithm }, options);
   const signature = await provider.sign(Buffer.from(prepared.base, 'utf8'));
   return finalizeRequestSignature(prepared, signature);
+}
+
+/**
+ * Async variant of `signResponse`. Reuses the sync canonicalization path;
+ * `provider.sign(payload)` is the only difference.
+ */
+export async function signResponseAsync(
+  response: ResponseLike,
+  provider: SigningProvider,
+  options: SignResponseOptions = {}
+): Promise<SignedResponse> {
+  assertProviderPurpose(provider, 'response-signing', { requirePurpose: true });
+  const prepared = prepareResponseSignature(response, { keyid: provider.keyid, alg: provider.algorithm }, options);
+  const signature = await provider.sign(Buffer.from(prepared.base, 'utf8'));
+  return finalizeResponseSignature(prepared, signature);
 }

--- a/src/lib/signing/signer.ts
+++ b/src/lib/signing/signer.ts
@@ -1,12 +1,21 @@
 import { createPrivateKey, randomBytes, sign as nodeSign, type JsonWebKey } from 'crypto';
-import { buildSignatureBase, formatSignatureParams, type RequestLike, type SignatureParams } from './canonicalize';
+import {
+  buildResponseSignatureBase,
+  buildSignatureBase,
+  formatSignatureParams,
+  type RequestLike,
+  type ResponseLike,
+  type SignatureParams,
+} from './canonicalize';
 import { computeContentDigest } from './content-digest';
-import { RequestSignatureError, WebhookSignatureError } from './errors';
+import { RequestSignatureError, ResponseSignatureError, WebhookSignatureError } from './errors';
 import type { AdcpUse } from './jwks-helpers';
 import {
   MANDATORY_COMPONENTS,
   MAX_SIGNATURE_WINDOW_SECONDS,
   REQUEST_SIGNING_TAG,
+  RESPONSE_MANDATORY_COMPONENTS,
+  RESPONSE_SIGNING_TAG,
   type AdcpJsonWebKey,
   type AdcpSignAlg,
 } from './types';
@@ -19,6 +28,7 @@ export interface SignerKey {
    * Private JWK. MUST carry `adcp_use` matching the helper being called:
    * - `signRequest` requires `adcp_use: 'request-signing'`
    * - `signWebhook` requires `adcp_use: 'webhook-signing'`
+   * - `signResponse` requires `adcp_use: 'response-signing'`
    *
    * Mismatched or missing `adcp_use` throws at the signer with the same
    * error code the verifier raises at step 8 — failure surfaces at
@@ -68,9 +78,10 @@ function assertKeyPurpose(key: SignerKey, expected: Rfc9421AdcpUse): void {
  */
 function assertProviderPurpose(
   provider: { readonly keyid: string; readonly adcpUse?: string },
-  expected: Rfc9421AdcpUse
+  expected: Rfc9421AdcpUse,
+  options: { requirePurpose?: boolean } = {}
 ): void {
-  if (provider.adcpUse === undefined) return;
+  if (provider.adcpUse === undefined && !options.requirePurpose) return;
   throwIfPurposeMismatch(provider.keyid, provider.adcpUse, expected);
 }
 
@@ -85,6 +96,8 @@ function throwIfPurposeMismatch(keyid: string, actual: string | undefined, expec
       throw new RequestSignatureError('request_signature_key_purpose_invalid', 8, message);
     case 'webhook-signing':
       throw new WebhookSignatureError('webhook_signature_key_purpose_invalid', 8, message);
+    case 'response-signing':
+      throw new ResponseSignatureError('response_signature_key_purpose_invalid', 8, message);
     default: {
       // Compile-time exhaustiveness: a future widening of `Rfc9421AdcpUse`
       // (typically because `AdcpUse` grew an RFC-9421 member) must add a
@@ -282,6 +295,114 @@ export function signWebhook(request: RequestLike, key: SignerKey, options: SignW
   const prepared = prepareWebhookSignature(request, { keyid: key.keyid, alg: key.alg }, options);
   const signature = produceSignature(key, Buffer.from(prepared.base, 'utf8'));
   return finalizeRequestSignature(prepared, signature);
+}
+
+export interface SignResponseOptions {
+  /**
+   * Cover a `Content-Digest` of the response body. Defaults to `true` when
+   * the response has a body.
+   */
+  coverContentDigest?: boolean;
+  /**
+   * Additional derived/header components to cover beyond
+   * {@link RESPONSE_MANDATORY_COMPONENTS}. The defaults include `@status`,
+   * `@method;req`, `@authority;req`, and `@target-uri;req`.
+   */
+  additionalComponents?: ReadonlyArray<string>;
+  label?: string;
+  windowSeconds?: number;
+  now?: () => number;
+  nonce?: string;
+  /**
+   * Override the signature tag. Defaults to `adcp/response-signing/v1`.
+   */
+  tag?: string;
+}
+
+export interface SignedResponse {
+  status: number;
+  headers: Record<string, string>;
+  signatureBase: string;
+  params: SignatureParams;
+}
+
+export interface PreparedResponseSignature {
+  status: number;
+  components: string[];
+  params: SignatureParams;
+  /**
+   * Outbound response headers including `Content-Digest` when covered, but
+   * not yet including `Signature-Input` / `Signature`.
+   */
+  headers: Record<string, string>;
+  /** Canonical signature base bytes (UTF-8). Pass to the signer/provider. */
+  base: string;
+  label: string;
+}
+
+/**
+ * Canonicalize a response for RFC 9421 response signing. This compatibility
+ * helper is signing-only; it does not imply a generic AdCP response-verifier
+ * protocol surface.
+ */
+export function prepareResponseSignature(
+  response: ResponseLike,
+  identity: SignatureIdentity,
+  options: SignResponseOptions = {}
+): PreparedResponseSignature {
+  const now = options.now ? options.now() : Math.floor(Date.now() / 1000);
+  const windowSeconds = Math.min(options.windowSeconds ?? 300, MAX_SIGNATURE_WINDOW_SECONDS);
+  const nonce = options.nonce ?? base64UrlRandom(16);
+  const label = options.label ?? 'sig1';
+  const hasBody = (response.body ?? '').length > 0;
+  const coverDigest = (options.coverContentDigest ?? true) && hasBody;
+
+  const headers: Record<string, string> = { ...flattenHeaders(response.headers) };
+  if (coverDigest) {
+    headers['Content-Digest'] = computeContentDigest(response.body ?? '');
+  }
+
+  const components = [...RESPONSE_MANDATORY_COMPONENTS];
+  if (hasBody) components.push('content-type');
+  if (coverDigest) components.push('content-digest');
+  if (options.additionalComponents) {
+    for (const component of options.additionalComponents) {
+      if (!components.includes(component)) components.push(component);
+    }
+  }
+
+  const params: SignatureParams = {
+    created: now,
+    expires: now + windowSeconds,
+    nonce,
+    keyid: identity.keyid,
+    alg: identity.alg,
+    tag: options.tag ?? RESPONSE_SIGNING_TAG,
+  };
+
+  const normalizedResponse: ResponseLike = { ...response, headers };
+  const base = buildResponseSignatureBase(components, normalizedResponse, params);
+
+  return { status: response.status, components, params, headers, base, label };
+}
+
+export function finalizeResponseSignature(prepared: PreparedResponseSignature, signature: Uint8Array): SignedResponse {
+  const headers = { ...prepared.headers };
+  const sigB64 = Buffer.from(signature).toString('base64url');
+  headers['Signature-Input'] = `${prepared.label}=${formatSignatureParams(prepared.components, prepared.params)}`;
+  headers['Signature'] = `${prepared.label}=:${sigB64}:`;
+  return { status: prepared.status, headers, signatureBase: prepared.base, params: prepared.params };
+}
+
+export function signResponse(
+  response: ResponseLike,
+  key: SignerKey,
+  options: SignResponseOptions = {}
+): SignedResponse {
+  assertKeyPurpose(key, 'response-signing');
+  const prepared = prepareResponseSignature(response, { keyid: key.keyid, alg: key.alg }, options);
+  const signature = produceSignature(key, Buffer.from(prepared.base, 'utf8'));
+  return finalizeResponseSignature(prepared, signature);
 }
 
 function produceSignature(key: SignerKey, data: Buffer): Uint8Array {

--- a/src/lib/signing/signer.ts
+++ b/src/lib/signing/signer.ts
@@ -306,7 +306,9 @@ export interface SignResponseOptions {
   /**
    * Additional derived/header components to cover beyond
    * {@link RESPONSE_MANDATORY_COMPONENTS}. The defaults include `@status`,
-   * `@method;req`, `@authority;req`, and `@target-uri;req`.
+   * `@method;req`, `@authority;req`, and `@target-uri;req`. Only the
+   * RFC 9421 `;req` component parameter is supported; other component
+   * parameters are rejected rather than silently round-tripped.
    */
   additionalComponents?: ReadonlyArray<string>;
   label?: string;

--- a/src/lib/signing/testing.ts
+++ b/src/lib/signing/testing.ts
@@ -137,8 +137,7 @@ export interface MintEphemeralEd25519KeyOptions {
   kid?: string;
   /**
    * AdCP purpose binding tagged on both JWKs. Accepts every member of
-   * {@link AdcpUse} — see that type for the canonical list (currently
-   * `'webhook-signing'`, `'request-signing'`, and `'governance-signing'`).
+   * {@link AdcpUse} — see that type for the canonical list.
    * Defaults to `'webhook-signing'`.
    *
    * For production request-signing keys use `pemToAdcpJwk()` or a KMS-backed

--- a/src/lib/signing/types.ts
+++ b/src/lib/signing/types.ts
@@ -85,6 +85,7 @@ export interface VerifiedSigner {
 export type VerifyResult = ({ status: 'verified' } & VerifiedSigner) | { status: 'unsigned'; verified_at: number };
 
 export const REQUEST_SIGNING_TAG = 'adcp/request-signing/v1';
+export const RESPONSE_SIGNING_TAG = 'adcp/response-signing/v1';
 export const ALLOWED_ALGS = new Set(['ed25519', 'ecdsa-p256-sha256']);
 /**
  * Wire-format algorithm identifier — the string that appears in
@@ -94,3 +95,9 @@ export type AdcpSignAlg = 'ed25519' | 'ecdsa-p256-sha256';
 export const MAX_SIGNATURE_WINDOW_SECONDS = 300;
 export const CLOCK_SKEW_TOLERANCE_SECONDS = 60;
 export const MANDATORY_COMPONENTS: ReadonlyArray<string> = ['@method', '@target-uri', '@authority'];
+export const RESPONSE_MANDATORY_COMPONENTS: ReadonlyArray<string> = [
+  '@status',
+  '@method;req',
+  '@authority;req',
+  '@target-uri;req',
+];

--- a/test/lib/jwks-helpers.test.js
+++ b/test/lib/jwks-helpers.test.js
@@ -77,17 +77,14 @@ describe('pemToAdcpJwk', () => {
     assert.strictEqual(jwk.adcp_use, 'governance-signing');
   });
 
-  test('retired response-signing adcp_use is rejected at runtime', () => {
+  test('response-signing adcp_use is preserved verbatim', () => {
     const kp = generateKeyPairSync('ed25519');
-    assert.throws(
-      () =>
-        pemToAdcpJwk(spkiPem(kp), {
-          kid: 'addie',
-          algorithm: 'ed25519',
-          adcp_use: 'response-signing',
-        }),
-      err => err instanceof TypeError && /unsupported adcp_use.*response-signing/i.test(err.message)
-    );
+    const jwk = pemToAdcpJwk(spkiPem(kp), {
+      kid: 'addie-response-2026-04',
+      algorithm: 'ed25519',
+      adcp_use: 'response-signing',
+    });
+    assert.strictEqual(jwk.adcp_use, 'response-signing');
   });
 
   test('unknown adcp_use is rejected at runtime', () => {

--- a/test/request-signing-provider.test.js
+++ b/test/request-signing-provider.test.js
@@ -792,11 +792,10 @@ describe('mintEphemeralEd25519Key', () => {
     assert.strictEqual(privateKey.adcp_use, 'governance-signing');
   });
 
-  test('retired response-signing adcp_use is rejected at runtime', async () => {
-    await assert.rejects(
-      () => mintEphemeralEd25519Key({ adcp_use: 'response-signing' }),
-      err => err instanceof TypeError && /unsupported adcp_use.*response-signing/i.test(err.message)
-    );
+  test('adcp_use: response-signing is reflected in both JWKs', async () => {
+    const { publicKey, privateKey } = await mintEphemeralEd25519Key({ adcp_use: 'response-signing' });
+    assert.strictEqual(publicKey.adcp_use, 'response-signing');
+    assert.strictEqual(privateKey.adcp_use, 'response-signing');
   });
 
   test('unknown adcp_use is rejected at runtime', async () => {

--- a/test/response-signing.test.js
+++ b/test/response-signing.test.js
@@ -1,0 +1,286 @@
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const { readFileSync } = require('node:fs');
+const path = require('node:path');
+
+const {
+  signResponse,
+  signResponseAsync,
+  prepareResponseSignature,
+  finalizeResponseSignature,
+  buildResponseSignatureBase,
+  parseSignatureInput,
+  parseSignature,
+  jwkToPublicKey,
+  verifySignature,
+  RESPONSE_SIGNING_TAG,
+  RESPONSE_MANDATORY_COMPONENTS,
+  ResponseSignatureError,
+  RequestSignatureError,
+  WebhookSignatureError,
+  signRequest,
+  signWebhook,
+  computeContentDigest,
+} = require('../dist/lib/signing/index.js');
+
+const { InMemorySigningProvider } = require('../dist/lib/signing/testing.js');
+const signingClient = require('../dist/lib/signing/client.js');
+const signingServer = require('../dist/lib/signing/server.js');
+
+const KEYS_PATH = path.join(
+  __dirname,
+  '..',
+  'compliance',
+  'cache',
+  'latest',
+  'test-vectors',
+  'request-signing',
+  'keys.json'
+);
+const keysByKid = new Map(JSON.parse(readFileSync(KEYS_PATH, 'utf8')).keys.map(k => [k.kid, k]));
+const STRIP_ADCP_USE = Symbol('strip-adcp-use');
+
+function privateJwkFor(kid, adcpUse = 'response-signing') {
+  const k = keysByKid.get(kid);
+  const { _private_d_for_test_only, ...rest } = k;
+  const out = { ...rest, d: _private_d_for_test_only };
+  if (adcpUse === STRIP_ADCP_USE) {
+    delete out.adcp_use;
+  } else {
+    out.adcp_use = adcpUse;
+  }
+  return out;
+}
+
+function publicJwkFor(kid) {
+  const k = keysByKid.get(kid);
+  const { _private_d_for_test_only, ...publicPart } = k;
+  return { ...publicPart, adcp_use: 'response-signing' };
+}
+
+const ORIGINATING_REQUEST = {
+  method: 'POST',
+  url: 'https://seller.example.com/adcp/get_products',
+};
+
+const SAMPLE_RESPONSE = {
+  status: 200,
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({ products: [{ id: 'prod_001' }] }),
+  request: ORIGINATING_REQUEST,
+};
+
+const FIXED_OPTIONS = {
+  now: () => 1776520800,
+  nonce: 'KXYnfEfJ0PBRZXQyVXfVQA',
+  windowSeconds: 300,
+};
+
+describe('response-signing compatibility exports', () => {
+  test('restores response-signing helpers on client and server subpaths', () => {
+    for (const subpath of [signingClient, signingServer]) {
+      assert.strictEqual(typeof subpath.signResponse, 'function');
+      assert.strictEqual(typeof subpath.signResponseAsync, 'function');
+      assert.strictEqual(typeof subpath.prepareResponseSignature, 'function');
+      assert.strictEqual(typeof subpath.finalizeResponseSignature, 'function');
+      assert.strictEqual(typeof subpath.buildResponseSignatureBase, 'function');
+      assert.strictEqual(typeof subpath.ResponseSignatureError, 'function');
+      assert.strictEqual(subpath.RESPONSE_SIGNING_TAG, RESPONSE_SIGNING_TAG);
+    }
+  });
+
+  test('signResponse covers status, request binding, type, and digest by default', () => {
+    const kid = 'test-ed25519-2026';
+    const key = { keyid: kid, alg: 'ed25519', privateKey: privateJwkFor(kid) };
+    const signed = signResponse(SAMPLE_RESPONSE, key, FIXED_OPTIONS);
+
+    const parsed = parseSignatureInput(signed.headers['Signature-Input']);
+    assert.deepStrictEqual(parsed.components, [
+      '@status',
+      '@method;req',
+      '@authority;req',
+      '@target-uri;req',
+      'content-type',
+      'content-digest',
+    ]);
+    assert.strictEqual(parsed.params.tag, RESPONSE_SIGNING_TAG);
+    assert.strictEqual(signed.headers['Content-Digest'], computeContentDigest(SAMPLE_RESPONSE.body));
+  });
+
+  test('buildResponseSignatureBase round-trips to a valid Ed25519 signature', () => {
+    const kid = 'test-ed25519-2026';
+    const key = { keyid: kid, alg: 'ed25519', privateKey: privateJwkFor(kid) };
+    const signed = signResponse(SAMPLE_RESPONSE, key, FIXED_OPTIONS);
+    const parsedInput = parseSignatureInput(signed.headers['Signature-Input']);
+    const parsedSig = parseSignature(signed.headers.Signature, parsedInput.label);
+
+    const base = buildResponseSignatureBase(
+      parsedInput.components,
+      { ...SAMPLE_RESPONSE, headers: signed.headers },
+      parsedInput.params,
+      parsedInput.signatureParamsValue
+    );
+
+    assert.strictEqual(base, signed.signatureBase);
+    assert.strictEqual(
+      verifySignature(
+        parsedInput.params.alg,
+        jwkToPublicKey(publicJwkFor(kid)),
+        Buffer.from(base, 'utf8'),
+        parsedSig.bytes
+      ),
+      true
+    );
+  });
+
+  test('buildResponseSignatureBase round-trips to a valid ECDSA-P256 signature', () => {
+    const kid = 'test-es256-2026';
+    const key = { keyid: kid, alg: 'ecdsa-p256-sha256', privateKey: privateJwkFor(kid) };
+    const signed = signResponse(SAMPLE_RESPONSE, key, FIXED_OPTIONS);
+    const parsedInput = parseSignatureInput(signed.headers['Signature-Input']);
+    const parsedSig = parseSignature(signed.headers.Signature, parsedInput.label);
+    const base = buildResponseSignatureBase(
+      parsedInput.components,
+      { ...SAMPLE_RESPONSE, headers: signed.headers },
+      parsedInput.params,
+      parsedInput.signatureParamsValue
+    );
+
+    assert.strictEqual(
+      verifySignature(
+        parsedInput.params.alg,
+        jwkToPublicKey(publicJwkFor(kid)),
+        Buffer.from(base, 'utf8'),
+        parsedSig.bytes
+      ),
+      true
+    );
+  });
+
+  test('pins the response signature base byte format', () => {
+    const kid = 'test-ed25519-2026';
+    const key = { keyid: kid, alg: 'ed25519', privateKey: privateJwkFor(kid) };
+    const signed = signResponse(SAMPLE_RESPONSE, key, FIXED_OPTIONS);
+    const expectedDigest = computeContentDigest(SAMPLE_RESPONSE.body);
+    const expectedBase = [
+      '"@status": 200',
+      '"@method";req: POST',
+      '"@authority";req: seller.example.com',
+      '"@target-uri";req: https://seller.example.com/adcp/get_products',
+      '"content-type": application/json',
+      `"content-digest": ${expectedDigest}`,
+      `"@signature-params": ("@status" "@method";req "@authority";req "@target-uri";req "content-type" "content-digest");created=${FIXED_OPTIONS.now()};expires=${FIXED_OPTIONS.now() + FIXED_OPTIONS.windowSeconds};nonce="${FIXED_OPTIONS.nonce}";keyid="${kid}";alg="ed25519";tag="${RESPONSE_SIGNING_TAG}"`,
+    ].join('\n');
+
+    assert.strictEqual(signed.signatureBase, expectedBase);
+  });
+
+  test('changing the originating request method changes the signature base', () => {
+    const kid = 'test-ed25519-2026';
+    const key = { keyid: kid, alg: 'ed25519', privateKey: privateJwkFor(kid) };
+    const postSigned = signResponse(SAMPLE_RESPONSE, key, FIXED_OPTIONS);
+    const getSigned = signResponse(
+      { ...SAMPLE_RESPONSE, request: { ...ORIGINATING_REQUEST, method: 'GET' } },
+      key,
+      FIXED_OPTIONS
+    );
+
+    assert.notStrictEqual(postSigned.signatureBase, getSigned.signatureBase);
+    assert.match(postSigned.signatureBase, /"@method";req: POST/);
+    assert.match(getSigned.signatureBase, /"@method";req: GET/);
+  });
+
+  test('omits content components when body is empty', () => {
+    const kid = 'test-ed25519-2026';
+    const key = { keyid: kid, alg: 'ed25519', privateKey: privateJwkFor(kid) };
+    const signed = signResponse({ status: 204, headers: {}, request: ORIGINATING_REQUEST }, key, FIXED_OPTIONS);
+    const parsed = parseSignatureInput(signed.headers['Signature-Input']);
+    assert.deepStrictEqual(parsed.components, [...RESPONSE_MANDATORY_COMPONENTS]);
+    assert.strictEqual(signed.headers['Content-Digest'], undefined);
+  });
+
+  test('prepare/finalize split matches signResponse', () => {
+    const kid = 'test-ed25519-2026';
+    const privateKey = privateJwkFor(kid);
+    const prepared = prepareResponseSignature(SAMPLE_RESPONSE, { keyid: kid, alg: 'ed25519' }, FIXED_OPTIONS);
+    const { createPrivateKey, sign } = require('node:crypto');
+    const sig = sign(null, Buffer.from(prepared.base, 'utf8'), createPrivateKey({ key: privateKey, format: 'jwk' }));
+    const finalized = finalizeResponseSignature(prepared, new Uint8Array(sig));
+    const direct = signResponse(SAMPLE_RESPONSE, { keyid: kid, alg: 'ed25519', privateKey }, FIXED_OPTIONS);
+    assert.deepStrictEqual(finalized, direct);
+  });
+
+  test('signResponseAsync matches signResponse', async () => {
+    const kid = 'test-ed25519-2026';
+    const privateKey = privateJwkFor(kid);
+    const provider = new InMemorySigningProvider({ keyid: kid, algorithm: 'ed25519', privateKey });
+    const direct = signResponse(SAMPLE_RESPONSE, { keyid: kid, alg: 'ed25519', privateKey }, FIXED_OPTIONS);
+    const asyncSigned = await signResponseAsync(SAMPLE_RESPONSE, provider, FIXED_OPTIONS);
+    assert.deepStrictEqual(asyncSigned, direct);
+  });
+
+  test('signResponseAsync rejects providers without explicit response-signing purpose', async () => {
+    const kid = 'test-ed25519-2026';
+    const privateKey = privateJwkFor(kid);
+    const provider = {
+      keyid: kid,
+      algorithm: 'ed25519',
+      fingerprint: 'legacy-provider-without-purpose',
+      sign: payload =>
+        require('node:crypto').sign(
+          null,
+          Buffer.from(payload),
+          require('node:crypto').createPrivateKey({ key: privateKey, format: 'jwk' })
+        ),
+    };
+
+    await assert.rejects(
+      () => signResponseAsync(SAMPLE_RESPONSE, provider, FIXED_OPTIONS),
+      err =>
+        err instanceof ResponseSignatureError &&
+        err.code === 'response_signature_key_purpose_invalid' &&
+        /<missing>/.test(err.message)
+    );
+  });
+});
+
+describe('response-signing purpose binding', () => {
+  test('signResponse requires a response-signing key', () => {
+    const kid = 'test-ed25519-2026';
+    const wrongPurpose = { keyid: kid, alg: 'ed25519', privateKey: privateJwkFor(kid, 'webhook-signing') };
+    assert.throws(
+      () => signResponse(SAMPLE_RESPONSE, wrongPurpose, FIXED_OPTIONS),
+      err =>
+        err instanceof ResponseSignatureError &&
+        err.code === 'response_signature_key_purpose_invalid' &&
+        err.failedStep === 8 &&
+        /webhook-signing/.test(err.message) &&
+        /response-signing/.test(err.message)
+    );
+  });
+
+  test('signResponse rejects a missing adcp_use', () => {
+    const kid = 'test-ed25519-2026';
+    const missingPurpose = { keyid: kid, alg: 'ed25519', privateKey: privateJwkFor(kid, STRIP_ADCP_USE) };
+    assert.throws(
+      () => signResponse(SAMPLE_RESPONSE, missingPurpose, FIXED_OPTIONS),
+      err =>
+        err instanceof ResponseSignatureError &&
+        err.code === 'response_signature_key_purpose_invalid' &&
+        /<missing>/.test(err.message)
+    );
+  });
+
+  test('request and webhook signers still reject response-signing keys', () => {
+    const kid = 'test-ed25519-2026';
+    const key = { keyid: kid, alg: 'ed25519', privateKey: privateJwkFor(kid, 'response-signing') };
+    assert.throws(
+      () => signRequest({ method: 'POST', url: ORIGINATING_REQUEST.url, headers: {}, body: '{}' }, key, FIXED_OPTIONS),
+      err => err instanceof RequestSignatureError && err.code === 'request_signature_key_purpose_invalid'
+    );
+    assert.throws(
+      () => signWebhook({ method: 'POST', url: ORIGINATING_REQUEST.url, headers: {}, body: '{}' }, key, FIXED_OPTIONS),
+      err => err instanceof WebhookSignatureError && err.code === 'webhook_signature_key_purpose_invalid'
+    );
+  });
+});

--- a/test/response-signing.test.js
+++ b/test/response-signing.test.js
@@ -61,6 +61,10 @@ function publicJwkFor(kid) {
 const ORIGINATING_REQUEST = {
   method: 'POST',
   url: 'https://seller.example.com/adcp/get_products',
+  headers: {
+    Authorization: 'Bearer request-token',
+    'X-Request-Scope': 'request-scope',
+  },
 };
 
 const SAMPLE_RESPONSE = {
@@ -188,6 +192,66 @@ describe('response-signing compatibility exports', () => {
     assert.notStrictEqual(postSigned.signatureBase, getSigned.signatureBase);
     assert.match(postSigned.signatureBase, /"@method";req: POST/);
     assert.match(getSigned.signatureBase, /"@method";req: GET/);
+  });
+
+  test('request-qualified header components resolve against request headers', () => {
+    const kid = 'test-ed25519-2026';
+    const key = { keyid: kid, alg: 'ed25519', privateKey: privateJwkFor(kid) };
+    const signed = signResponse(
+      {
+        ...SAMPLE_RESPONSE,
+        headers: {
+          ...SAMPLE_RESPONSE.headers,
+          Authorization: 'Bearer response-token',
+        },
+      },
+      key,
+      { ...FIXED_OPTIONS, additionalComponents: ['authorization;req'] }
+    );
+
+    assert.match(signed.signatureBase, /"authorization";req: Bearer request-token/);
+    assert.doesNotMatch(signed.signatureBase, /Bearer response-token/);
+  });
+
+  test('request-qualified header components require request headers', () => {
+    const kid = 'test-ed25519-2026';
+    const key = { keyid: kid, alg: 'ed25519', privateKey: privateJwkFor(kid) };
+    assert.throws(
+      () =>
+        signResponse(
+          { ...SAMPLE_RESPONSE, request: { method: ORIGINATING_REQUEST.method, url: ORIGINATING_REQUEST.url } },
+          key,
+          { ...FIXED_OPTIONS, additionalComponents: ['authorization;req'] }
+        ),
+      err =>
+        err instanceof RequestSignatureError &&
+        err.code === 'request_signature_components_incomplete' &&
+        /authorization;req/.test(err.message)
+    );
+  });
+
+  test('unsupported response component parameters are rejected', () => {
+    const kid = 'test-ed25519-2026';
+    const key = { keyid: kid, alg: 'ed25519', privateKey: privateJwkFor(kid) };
+    assert.throws(
+      () => signResponse(SAMPLE_RESPONSE, key, { ...FIXED_OPTIONS, additionalComponents: ['content-type;sf'] }),
+      err =>
+        err instanceof RequestSignatureError &&
+        err.code === 'request_signature_components_unexpected' &&
+        /unsupported component parameters/.test(err.message)
+    );
+  });
+
+  test('bare request-derived components are rejected in response signatures', () => {
+    const kid = 'test-ed25519-2026';
+    const key = { keyid: kid, alg: 'ed25519', privateKey: privateJwkFor(kid) };
+    assert.throws(
+      () => signResponse(SAMPLE_RESPONSE, key, { ...FIXED_OPTIONS, additionalComponents: ['@method'] }),
+      err =>
+        err instanceof RequestSignatureError &&
+        err.code === 'request_signature_components_unexpected' &&
+        /must use the request-bound ;req parameter/.test(err.message)
+    );
   });
 
   test('omits content components when body is empty', () => {

--- a/test/signing-provider-purpose-gate.test.js
+++ b/test/signing-provider-purpose-gate.test.js
@@ -68,7 +68,7 @@ describe('SigningProvider.adcpUse — purpose gate, async path', () => {
       );
     });
 
-    test('rejects a legacy provider key with adcpUse="response-signing"', async () => {
+    test('rejects a response-signing provider key', async () => {
       const provider = new InMemorySigningProvider({
         keyid: KID,
         algorithm: 'ed25519',
@@ -145,7 +145,7 @@ describe('SigningProvider.adcpUse — purpose gate, async path', () => {
       );
     });
 
-    test('rejects a legacy provider key with adcpUse="response-signing"', async () => {
+    test('rejects a response-signing provider key', async () => {
       const provider = new InMemorySigningProvider({
         keyid: KID,
         algorithm: 'ed25519',
@@ -192,7 +192,7 @@ describe('SigningProvider.adcpUse — explicit option overrides JWK metadata', (
     assert.ok(signed.headers.Signature);
   });
 
-  test('explicit retired adcpUse fails closed even when JWK metadata is valid', async () => {
+  test('explicit response-signing adcpUse fails closed for request signing even when JWK metadata is valid', async () => {
     const provider = new InMemorySigningProvider({
       keyid: KID,
       algorithm: 'ed25519',


### PR DESCRIPTION
Restores the signing-only response helper surface requested in #2097 across the aggregate, client, and server signing subpaths while keeping generic response verification unsupported.
The implementation adds RFC-shaped response canonicalization with request-qualified components, response-signing JWK purpose support, and stricter async provider purpose binding for response signing.
It also updates migration docs and adds regression coverage for exports, Ed25519/ES256 response signing, purpose gates, and helper JWK behavior.
Validated with build, typecheck, focused signing tests, expert review, second-model review, and pre-push validation.
