### PR TITLE
chore: release package (beta)

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -78,6 +78,7 @@
     "remove-rfc9421-response-signing",
     "request-signing-conformance-cache",
     "resolve-3-1-blocked-issues",
+    "restore-response-signing",
     "schema-loader-strip-nested-ids",
     "server-handler-payload-types",
     "signed-requests-specialism-notice",

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -30,7 +30,7 @@ jobs:
           changed_files="$(git diff --name-only origin/main...HEAD)"
           package_changes="$(
             printf '%s\n' "$changed_files" |
-              grep -Ev '^(\.changeset/pre\.json|src/lib/version\.ts|docs/(llms\.txt|TYPE-SUMMARY\.md)|\.github/workflows/(changeset-check|release)\.yml)$' ||
+              grep -Ev '^(\.changeset/pre\.json|CHANGELOG\.md|package(-lock)?\.json|packages/[^/]+/(CHANGELOG\.md|package\.json)|src/lib/version\.ts|docs/(llms\.txt|TYPE-SUMMARY\.md)|\.github/workflows/(changeset-check|release)\.yml)$' ||
               true
           )"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 8.1.0-beta.16
+
+### Patch Changes
+
+- cbaebbc: Restore signing-only response helpers under `@adcp/sdk/signing` for adopters that sign JSON transport responses and publish
+  `response-signing` JWKs.
+
 ## 8.1.0-beta.15
 
 ### Minor Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/sdk",
-  "version": "8.1.0-beta.15",
+  "version": "8.1.0-beta.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/sdk",
-      "version": "8.1.0-beta.15",
+      "version": "8.1.0-beta.16",
       "license": "Apache-2.0",
       "workspaces": [
         ".",
@@ -7356,7 +7356,7 @@
       "version": "6.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adcp/sdk": "^8.1.0-beta.15"
+        "@adcp/sdk": "^8.1.0-beta.16"
       },
       "bin": {
         "adcp": "bin/adcp.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adcp/sdk",
-  "version": "8.1.0-beta.15",
+  "version": "8.1.0-beta.16",
   "description": "AdCP SDK — client, server, and compliance harnesses for the AdContext Protocol (MCP + A2A)",
   "workspaces": [
     ".",

--- a/packages/client-shim/package.json
+++ b/packages/client-shim/package.json
@@ -106,7 +106,7 @@
     "LICENSE"
   ],
   "dependencies": {
-    "@adcp/sdk": "^8.1.0-beta.15"
+    "@adcp/sdk": "^8.1.0-beta.16"
   },
   "keywords": [
     "adcp",

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP SDK library version
  */
-export const LIBRARY_VERSION = '8.1.0-beta.15';
+export const LIBRARY_VERSION = '8.1.0-beta.16';
 
 /**
  * AdCP specification version this library is built for
@@ -65,10 +65,10 @@ export type AdcpVersion = (typeof COMPATIBLE_ADCP_VERSIONS)[number];
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '8.1.0-beta.15',
+  library: '8.1.0-beta.16',
   adcp: '3.1.0-beta.7',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-05-28T13:22:59.427Z',
+  generatedAt: '2026-05-28T23:03:56.878Z',
 } as const;
 
 /**


### PR DESCRIPTION
## Summary
- cut @adcp/sdk 8.1.0-beta.16 from the restore response signing changeset
- update changelog, package metadata, lockfile, client shim dependency, and pre-release state

## Validation
- npm run build:lib
- npm test
- npx commitlint --from HEAD~1 --to HEAD --verbose
- pre-push hook: typecheck + build
