### PR TITLE
fix: allow catalog-only adagents mirrors to validate

### DIFF
--- a/.changeset/catalog-mirror-adagents-schema.md
+++ b/.changeset/catalog-mirror-adagents-schema.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Allow packaged catalog-era `adagents.json` schemas to validate community mirror catalogs with `authorized_agents: []`, while preserving the stricter non-empty authorization requirement for legacy authorization-only schema bundles.

--- a/scripts/copy-schemas-to-dist.ts
+++ b/scripts/copy-schemas-to-dist.ts
@@ -26,7 +26,7 @@
  * Invoked by the `build:lib` npm script after tsc emits JS.
  */
 
-import { cpSync, existsSync, lstatSync, mkdirSync, readdirSync } from 'fs';
+import { cpSync, existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'fs';
 import path from 'path';
 
 interface ParsedVersion {
@@ -109,6 +109,34 @@ function selectVersionsToCopy(parsed: ParsedVersion[]): { source: ParsedVersion;
   return [...winnerByKey.entries()].map(([key, source]) => ({ source, key }));
 }
 
+function relaxAdagentsAuthorizedAgentsMinItems(schemaRoot: string): void {
+  const adagentsPath = path.join(schemaRoot, 'adagents.json');
+  if (!existsSync(adagentsPath)) return;
+
+  const schema = JSON.parse(readFileSync(adagentsPath, 'utf8'));
+  const inlineVariant = Array.isArray(schema.oneOf)
+    ? schema.oneOf.find((variant: any) => variant?.properties?.authorized_agents)
+    : undefined;
+  const inlineProperties = inlineVariant?.properties;
+
+  // Compatibility patch for the 3.1 catalog-era adagents.json schema:
+  // community mirrors can publish formats/placements before any seller is
+  // authorized, so `authorized_agents: []` is a valid inline file. Older
+  // authorization-only schema bundles keep minItems:1. Remove this once the
+  // upstream schema ships the same constraint directly.
+  if (!inlineProperties?.catalog_etag || !inlineProperties?.formats) return;
+
+  const authorizedAgents = inlineProperties.authorized_agents;
+  if (!authorizedAgents || authorizedAgents.minItems == null) return;
+
+  delete authorizedAgents.minItems;
+  writeFileSync(adagentsPath, `${JSON.stringify(schema, null, 2)}\n`);
+  console.log(
+    `[copy-schemas-to-dist] relaxed adagents.json authorized_agents minItems in ${adagentsPath} ` +
+      `(empty catalog-only mirrors are valid)`
+  );
+}
+
 function main(): void {
   const repoRoot = path.resolve(__dirname, '..');
   const cacheRoot = path.join(repoRoot, 'schemas', 'cache');
@@ -173,6 +201,7 @@ function main(): void {
         return true;
       },
     });
+    relaxAdagentsAuthorizedAgentsMinItems(destRoot);
     const note = key === source.version ? '' : ` (key collapsed from ${source.version})`;
     console.log(`[copy-schemas-to-dist] copied ${srcRoot} → ${destRoot}${note}`);
   }

--- a/test/lib/adagents-json-schema.test.js
+++ b/test/lib/adagents-json-schema.test.js
@@ -1,0 +1,99 @@
+const { describe, test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const Ajv = require('ajv').default;
+const addFormats = require('ajv-formats').default;
+
+const { buildCommunityMirrorAdagents } = require('../../dist/lib/registry/index.js');
+const { resolveBundleKey } = require('../../dist/lib/validation/schema-loader.js');
+const { ADCP_VERSION } = require('../../dist/lib/version.js');
+
+const SCHEMA_ROOT = path.resolve(__dirname, '..', '..', 'dist', 'lib', 'schemas-data', resolveBundleKey(ADCP_VERSION));
+const LEGACY_SCHEMA_ROOT = path.resolve(__dirname, '..', '..', 'dist', 'lib', 'schemas-data', 'v2.5');
+
+function walkJsonFiles(dir) {
+  const out = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...walkJsonFiles(full));
+    else if (entry.isFile() && entry.name.endsWith('.json')) out.push(full);
+  }
+  return out;
+}
+
+function loadAjv() {
+  const ajv = new Ajv({ allErrors: true, strict: false });
+  addFormats(ajv);
+
+  for (const file of walkJsonFiles(SCHEMA_ROOT)) {
+    const rel = path.relative(SCHEMA_ROOT, file);
+    const top = rel.split(path.sep)[0];
+    if (top === 'bundled') continue;
+
+    const raw = JSON.parse(fs.readFileSync(file, 'utf8'));
+    if (typeof raw.$id === 'string' && !ajv.getSchema(raw.$id)) {
+      ajv.addSchema(raw);
+    }
+  }
+
+  return ajv;
+}
+
+function formatAjvErrors(errors) {
+  return (errors ?? [])
+    .slice(0, 8)
+    .map(e => `path=${e.instancePath || '(root)'} keyword=${e.keyword} msg=${e.message}`)
+    .join('\n');
+}
+
+describe('packaged adagents.json schema', () => {
+  test('relaxes authorized_agents only for catalog-capable schema bundles', () => {
+    const current = JSON.parse(fs.readFileSync(path.join(SCHEMA_ROOT, 'adagents.json'), 'utf8'));
+    const currentInline = current.oneOf.find(variant => variant?.properties?.authorized_agents);
+    assert.strictEqual(currentInline.properties.authorized_agents.minItems, undefined);
+    assert.ok(currentInline.properties.catalog_etag, 'current schema must expose catalog_etag');
+    assert.ok(currentInline.properties.formats, 'current schema must expose formats');
+
+    if (fs.existsSync(path.join(LEGACY_SCHEMA_ROOT, 'adagents.json'))) {
+      const legacy = JSON.parse(fs.readFileSync(path.join(LEGACY_SCHEMA_ROOT, 'adagents.json'), 'utf8'));
+      const legacyInline = legacy.oneOf.find(variant => variant?.properties?.authorized_agents);
+      assert.strictEqual(legacyInline.properties.authorized_agents.minItems, 1);
+      assert.strictEqual(legacyInline.properties.catalog_etag, undefined);
+      assert.strictEqual(legacyInline.properties.formats, undefined);
+    }
+  });
+
+  test('accepts catalog-only community mirrors with no authorized sellers yet', () => {
+    const adagentsPath = path.join(SCHEMA_ROOT, 'adagents.json');
+    const schema = JSON.parse(fs.readFileSync(adagentsPath, 'utf8'));
+    const ajv = loadAjv();
+    const validate = (typeof schema.$id === 'string' && ajv.getSchema(schema.$id)) || ajv.compile(schema);
+
+    const catalog = buildCommunityMirrorAdagents({
+      catalog_etag: 'meta-creative-formats-2026-05',
+      formats: [
+        {
+          format_option_id: 'meta-feed-image',
+          format_kind: 'image',
+          params: {
+            width: 1080,
+            height: 1080,
+          },
+          v1_format_ref: [
+            {
+              agent_url: 'https://creative.adcontextprotocol.org/translated/meta',
+              id: 'feed_image',
+            },
+          ],
+        },
+      ],
+    });
+
+    assert.deepStrictEqual(catalog.authorized_agents, []);
+    assert.ok(
+      validate(catalog),
+      `community mirror helper output must validate against packaged adagents.json schema:\n${formatAjvErrors(validate.errors)}`
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- relax packaged catalog-era `adagents.json` schemas so `authorized_agents: []` validates for community mirrors
- keep legacy authorization-only bundles strict by feature-detecting catalog fields before patching
- add an AJV regression that validates `buildCommunityMirrorAdagents()` output against the packaged schema data

## Root Cause
The helper emitted the intended catalog-only shape, but coverage only exercised the helper and generated Zod surfaces. The stricter packaged JSON Schema path still copied the raw upstream schema with `authorized_agents.minItems: 1`, so the SDK could emit a descriptor that AJV consumers rejected.

## Validation
- `npm run build:lib`
- `node --test test/lib/adagents-json-schema.test.js`
- `node --test test/lib/brand-json-schema.test.js`
- `node --test test/lib/registry.test.js --test-name-pattern "community mirror|createCommunityMirror|buildCommunityMirror|creates adagents"`
- `npm run typecheck`
- `git diff --check`