### PR TITLE
fix(storyboard): backport basic step auth to 7.11

### DIFF
--- a/.changeset/step-basic-auth-storyboard.md
+++ b/.changeset/step-basic-auth-storyboard.md
@@ -1,0 +1,5 @@
+---
+"@adcp/sdk": patch
+---
+
+Add storyboard runner support for step-level HTTP Basic auth directives.

--- a/.changeset/step-basic-auth-storyboard.md
+++ b/.changeset/step-basic-auth-storyboard.md
@@ -1,5 +1,0 @@
----
-"@adcp/sdk": patch
----
-
-Add storyboard runner support for step-level HTTP Basic auth directives.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 7.11.1
+
+### Patch Changes
+
+- f26971e: Add storyboard runner support for step-level HTTP Basic auth directives.
+
 ## 7.11.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adcp/sdk",
-  "version": "7.11.0",
+  "version": "7.11.1",
   "description": "AdCP SDK — client, server, and compliance harnesses for the AdContext Protocol (MCP + A2A)",
   "workspaces": [
     ".",

--- a/packages/client-shim/package.json
+++ b/packages/client-shim/package.json
@@ -106,7 +106,7 @@
     "LICENSE"
   ],
   "dependencies": {
-    "@adcp/sdk": "^7.11.0"
+    "@adcp/sdk": "^7.11.1"
   },
   "keywords": [
     "adcp",

--- a/src/lib/testing/storyboard/default-invariants.ts
+++ b/src/lib/testing/storyboard/default-invariants.ts
@@ -137,12 +137,13 @@ registerOnce('context.no_secret_echo', {
       auth_token?: string;
       auth?: unknown;
       secrets?: string[];
-      test_kit?: { auth?: { api_key?: string } };
+      test_kit?: { auth?: { api_key?: string; basic?: unknown } };
     };
     addIfSecret(secrets, optAny.auth_token);
     for (const s of extractAuthSecrets(optAny.auth)) addIfSecret(secrets, s);
     for (const s of optAny.secrets ?? []) addIfSecret(secrets, s);
     addIfSecret(secrets, optAny.test_kit?.auth?.api_key);
+    for (const s of extractBasicSecrets(optAny.test_kit?.auth?.basic)) addIfSecret(secrets, s);
     ctx.state.secrets = secrets;
   },
   onStep: (ctx, stepResult) => {
@@ -527,6 +528,27 @@ function extractAuthSecrets(auth: unknown): string[] {
     // the AS sees, not the reference string. client_id is NOT extracted
     // (RFC 6749 §2.2 — public identifier).
     pushCredentialValue(out, c.client_secret);
+  }
+  return out;
+}
+
+function extractBasicSecrets(basic: unknown): string[] {
+  if (!basic || typeof basic !== 'object') return [];
+  const b = basic as Record<string, unknown>;
+  const out: string[] = [];
+  if (typeof b.credentials === 'string' && b.credentials) {
+    const colonIndex = b.credentials.indexOf(':');
+    if (colonIndex > 0 && colonIndex < b.credentials.length - 1) {
+      out.push(b.credentials.slice(colonIndex + 1));
+      out.push(Buffer.from(b.credentials, 'utf8').toString('base64'));
+    }
+    return out;
+  }
+  if (typeof b.password === 'string' && b.password) {
+    out.push(b.password);
+    if (typeof b.username === 'string' && b.username) {
+      out.push(Buffer.from(`${b.username}:${b.password}`, 'utf8').toString('base64'));
+    }
   }
   return out;
 }

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -4294,32 +4294,14 @@ function resolveTaskName(step: StoryboardStep, options: StoryboardRunOptions): s
  * `skipIdempotencyAutoInject` on that path anyway.
  */
 function defaultAuthHeadersForRawProbe(options: StoryboardRunOptions): Record<string, string> | undefined {
-  // Reject control chars and non-printable ASCII. Without this, undici's header
-  // validator throws a message that includes the offending value — landing
-  // secrets in logs. Validate raw inputs before encoding so the field name in
-  // the error identifies which input to fix without echoing the value.
-  const assertSafe = (value: string, field: string) => {
-    if (/[\r\n]|[^\x20-\x7E]/.test(value)) {
-      throw new Error(`${field} contains invalid characters (control chars or non-printable ASCII)`);
-    }
-  };
-
   const headers: Record<string, string> = {};
   if (options.auth) {
     if (options.auth.type === 'bearer') {
       if (!options.auth.token) throw new Error('options.auth.token is required for bearer auth');
-      assertSafe(options.auth.token, 'options.auth.token');
+      assertSafeAuthHeaderPart(options.auth.token, 'options.auth.token');
       headers.authorization = `Bearer ${options.auth.token}`;
     } else if (options.auth.type === 'basic') {
-      // RFC 7617 bans `:` in the userid — a colon would decode ambiguously on
-      // the server. Fail loudly rather than silently producing a mangled header.
-      if (options.auth.username.includes(':')) {
-        throw new Error('options.auth.username must not contain colon (RFC 7617)');
-      }
-      assertSafe(options.auth.username, 'options.auth.username');
-      assertSafe(options.auth.password, 'options.auth.password');
-      const encoded = Buffer.from(`${options.auth.username}:${options.auth.password}`).toString('base64');
-      headers.authorization = `Basic ${encoded}`;
+      headers.authorization = encodeBasicAuthHeader(options.auth, 'options.auth');
     } else {
       return undefined;
     }
@@ -4328,11 +4310,11 @@ function defaultAuthHeadersForRawProbe(options: StoryboardRunOptions): Record<st
   // from an SDK-shaped one at the transport boundary. HTTP is case-insensitive;
   // this is purely for parity with capture/diff tooling.
   if (options.test_session_id) {
-    assertSafe(options.test_session_id, 'options.test_session_id');
+    assertSafeAuthHeaderPart(options.test_session_id, 'options.test_session_id');
     headers['X-Test-Session-ID'] = options.test_session_id;
   }
   if (options.userAgent) {
-    assertSafe(options.userAgent, 'options.userAgent');
+    assertSafeAuthHeaderPart(options.userAgent, 'options.userAgent');
     headers['User-Agent'] = options.userAgent;
   }
   return headers;
@@ -4343,9 +4325,13 @@ function defaultAuthHeadersForRawProbe(options: StoryboardRunOptions): Record<st
  * - `'none'` returns an empty object and the probe sends no `Authorization`.
  * - `api_key` / `oauth_bearer` resolve the value from `value`, `from_test_kit`,
  *   or `value_strategy` — in that order — and produce `Authorization: Bearer <value>`.
+ * - `basic` resolves explicit credentials, `from_test_kit`, or
+ *   `value_strategy: random_invalid` and produces `Authorization: Basic <base64>`.
  */
 function authHeadersForStep(directive: StepAuthDirective, options: StoryboardRunOptions): Record<string, string> {
   if (directive === 'none') return {};
+  if (directive.type === 'basic') return basicAuthHeadersForStep(directive, options);
+
   let value: string | undefined;
   if ('value' in directive && directive.value) {
     value = directive.value;
@@ -4364,6 +4350,100 @@ function authHeadersForStep(directive: StepAuthDirective, options: StoryboardRun
     throw new Error('test_kit.auth.api_key contains invalid characters (control chars or non-printable ASCII)');
   }
   return { authorization: `Bearer ${value}` };
+}
+
+function basicAuthHeadersForStep(
+  directive: Extract<StepAuthDirective, { type: 'basic' }>,
+  options: StoryboardRunOptions
+): Record<string, string> {
+  if (directive.value_strategy) {
+    if (directive.value_strategy !== 'random_invalid') return {};
+    return {
+      authorization: encodeBasicAuthHeader(
+        {
+          username: generateRandomInvalidApiKey(),
+          password: generateRandomInvalidApiKey(),
+        },
+        'step.auth.basic'
+      ),
+    };
+  }
+
+  const source =
+    directive.from_test_kit !== undefined
+      ? resolveStepBasicFromTestKit(directive.from_test_kit, options)
+      : directive.basic !== undefined
+        ? directive.basic
+        : directive;
+  if (source === undefined) return {};
+  return { authorization: encodeBasicAuthHeader(source, 'step.auth.basic') };
+}
+
+function resolveStepBasicFromTestKit(
+  fromTestKit: string | boolean,
+  options: StoryboardRunOptions
+): BasicCredentialInput | undefined {
+  const path = typeof fromTestKit === 'string' && fromTestKit.length > 0 ? fromTestKit : 'auth.basic';
+  const segments = path.split('.');
+  let value: unknown = options.test_kit;
+  for (const segment of segments) {
+    if (value == null || typeof value !== 'object') return undefined;
+    value = (value as Record<string, unknown>)[segment];
+  }
+  if (value === undefined || value === null) return undefined;
+  return value as BasicCredentialInput;
+}
+
+interface BasicCredentialInput {
+  username?: unknown;
+  password?: unknown;
+  credentials?: unknown;
+}
+
+function encodeBasicAuthHeader(input: BasicCredentialInput, fieldPrefix: string): string {
+  const userpass = normalizeBasicCredentials(input, fieldPrefix);
+  return `Basic ${Buffer.from(userpass).toString('base64')}`;
+}
+
+function normalizeBasicCredentials(input: BasicCredentialInput, fieldPrefix: string): string {
+  const hasCredentials = input.credentials !== undefined;
+  const hasUserPass = input.username !== undefined || input.password !== undefined;
+  if (hasCredentials && hasUserPass) {
+    throw new Error(`${fieldPrefix} must use either credentials or username/password, not both`);
+  }
+  if (hasCredentials) {
+    if (typeof input.credentials !== 'string' || input.credentials.length === 0) {
+      throw new Error(`${fieldPrefix}.credentials must be a non-empty string`);
+    }
+    assertSafeAuthHeaderPart(input.credentials, `${fieldPrefix}.credentials`);
+    const colonIndex = input.credentials.indexOf(':');
+    if (colonIndex <= 0 || colonIndex >= input.credentials.length - 1) {
+      throw new Error(`${fieldPrefix}.credentials must be in unencoded username:password form`);
+    }
+    return input.credentials;
+  }
+  if (typeof input.username !== 'string' || input.username.length === 0) {
+    throw new Error(`${fieldPrefix}.username must be a non-empty string`);
+  }
+  if (typeof input.password !== 'string' || input.password.length === 0) {
+    throw new Error(`${fieldPrefix}.password must be a non-empty string`);
+  }
+  if (input.username.includes(':')) {
+    throw new Error(`${fieldPrefix}.username must not contain colon (RFC 7617)`);
+  }
+  assertSafeAuthHeaderPart(input.username, `${fieldPrefix}.username`);
+  assertSafeAuthHeaderPart(input.password, `${fieldPrefix}.password`);
+  return `${input.username}:${input.password}`;
+}
+
+// Reject control chars and non-printable ASCII. Without this, undici's header
+// validator throws a message that includes the offending value — landing
+// secrets in logs. Validate raw inputs before encoding so the field name in
+// the error identifies which input to fix without echoing the value.
+function assertSafeAuthHeaderPart(value: string, field: string): void {
+  if (/[\r\n\x00]|[^\x20-\x7E]/.test(value)) {
+    throw new Error(`${field} contains invalid characters (control chars or non-printable ASCII)`);
+  }
 }
 
 /**

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -399,6 +399,28 @@ export type StepAuthDirective =
        *   - `random_invalid_jwt` — three base64url segments; valid JSON header/payload, random signature.
        */
       value_strategy?: 'random_invalid_jwt';
+    }
+  | {
+      type: 'basic';
+      /** Pull the Basic credential object from the runtime test kit, e.g. `auth.basic`. */
+      from_test_kit?: string | boolean;
+      /** Explicit username. Mutually exclusive with `credentials`. */
+      username?: string;
+      /** Explicit password. Mutually exclusive with `credentials`. */
+      password?: string;
+      /** Unencoded `username:password` pair. Mutually exclusive with `username`/`password`. */
+      credentials?: string;
+      /** Nested Basic credential shape accepted for authoring parity with test kits. */
+      basic?: {
+        username?: string;
+        password?: string;
+        credentials?: string;
+      };
+      /**
+       * Runner-generated value. Current strategies:
+       *   - `random_invalid` — random username/password pair.
+       */
+      value_strategy?: 'random_invalid';
     };
 
 export interface StoryboardStep {

--- a/src/lib/testing/types.ts
+++ b/src/lib/testing/types.ts
@@ -198,6 +198,15 @@ export interface TestOptions {
     auth?: {
       /** API key the runner presents on API-key probes. */
       api_key?: string;
+      /** HTTP Basic credential the runner presents on Basic-auth probes. */
+      basic?: {
+        /** Username portion of the Basic credential. */
+        username?: string;
+        /** Password portion of the Basic credential. */
+        password?: string;
+        /** Unencoded `username:password` pair. */
+        credentials?: string;
+      };
       /**
        * Auth-required, read-only tool the runner uses for unauth + invalid-key probes.
        * Required whenever `auth` is declared — no default is substituted. Must be one of

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP SDK library version
  */
-export const LIBRARY_VERSION = '7.10.2';
+export const LIBRARY_VERSION = '7.11.1';
 
 /**
  * AdCP specification version this library is built for
@@ -62,10 +62,10 @@ export type AdcpVersion = (typeof COMPATIBLE_ADCP_VERSIONS)[number];
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '7.10.2',
+  library: '7.11.1',
   adcp: '3.0.12',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-05-22T08:03:10.515Z',
+  generatedAt: '2026-05-30T01:12:40.097Z',
 } as const;
 
 /**

--- a/test/lib/storyboard-security.test.js
+++ b/test/lib/storyboard-security.test.js
@@ -862,6 +862,162 @@ describe('storyboard runner: auth-override dispatch', () => {
     }
   });
 
+  it('step auth.type=basic sends Basic from test_kit.auth.basic credentials', async () => {
+    let seenAuth = null;
+    const server = http.createServer(async (req, res) => {
+      seenAuth = req.headers.authorization ?? null;
+      const chunks = [];
+      for await (const c of req) chunks.push(c);
+      const rpc = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: rpc.id,
+          result: { structuredContent: { context: rpc.params.arguments.context } },
+        })
+      );
+    });
+    await new Promise(r => server.listen(0, r));
+    const agentUrl = `http://127.0.0.1:${server.address().port}/mcp`;
+    try {
+      const storyboard = {
+        id: 'basic_step_auth',
+        version: '1.0.0',
+        title: 'Basic auth step',
+        category: 'security',
+        summary: '',
+        narrative: '',
+        agent: { interaction_model: '*', capabilities: [] },
+        caller: { role: 'buyer_agent' },
+        phases: [
+          {
+            id: 'basic_path',
+            title: 'basic',
+            steps: [
+              {
+                id: 'probe_basic',
+                title: 'basic probe',
+                task: '$test_kit.auth.probe_task',
+                task_default: 'list_creatives',
+                auth: { type: 'basic', from_test_kit: 'auth.basic' },
+                sample_request: { context: { correlation_id: 'basic-step' } },
+                validations: [
+                  { check: 'http_status', value: 200, description: 'accepted' },
+                  {
+                    check: 'field_value',
+                    path: 'context.correlation_id',
+                    value: 'basic-step',
+                    description: 'context echoed',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      const result = await runStoryboard(agentUrl, storyboard, {
+        protocol: 'mcp',
+        allow_http: true,
+        agentTools: ['list_creatives'],
+        test_kit: {
+          auth: {
+            probe_task: 'list_creatives',
+            basic: { credentials: 'demo-user:demo-password' },
+          },
+        },
+        _profile: { name: 'T', tools: ['list_creatives'] },
+        _client: { getAgentInfo: async () => ({ name: 'T', tools: [{ name: 'list_creatives' }] }) },
+      });
+      assert.strictEqual(result.overall_passed, true, JSON.stringify(result.phases[0].steps[0]));
+      assert.strictEqual(seenAuth, `Basic ${Buffer.from('demo-user:demo-password').toString('base64')}`);
+      assert.doesNotMatch(seenAuth, /^Bearer /);
+    } finally {
+      server.close();
+    }
+  });
+
+  it('step auth.type=basic supports explicit username/password and random-invalid credentials', async () => {
+    const observed = [];
+    const server = http.createServer(async (req, res) => {
+      observed.push(req.headers.authorization ?? null);
+      const chunks = [];
+      for await (const c of req) chunks.push(c);
+      const rpc = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+      const isFirst = observed.length === 1;
+      res.writeHead(isFirst ? 200 : 401, {
+        'content-type': 'application/json',
+        ...(isFirst ? {} : { 'www-authenticate': 'Basic realm="test"' }),
+      });
+      res.end(
+        JSON.stringify(
+          isFirst
+            ? { jsonrpc: '2.0', id: rpc.id, result: { structuredContent: { ok: true } } }
+            : { jsonrpc: '2.0', id: rpc.id, error: { code: -32001, message: 'unauthorized' } }
+        )
+      );
+    });
+    await new Promise(r => server.listen(0, r));
+    const agentUrl = `http://127.0.0.1:${server.address().port}/mcp`;
+    try {
+      const storyboard = {
+        id: 'basic_step_auth_explicit',
+        version: '1.0.0',
+        title: 'Basic auth explicit',
+        category: 'security',
+        summary: '',
+        narrative: '',
+        agent: { interaction_model: '*', capabilities: [] },
+        caller: { role: 'buyer_agent' },
+        phases: [
+          {
+            id: 'basic_path',
+            title: 'basic',
+            optional: true,
+            steps: [
+              {
+                id: 'probe_basic',
+                title: 'basic probe',
+                task: 'list_creatives',
+                auth: { type: 'basic', username: 'direct-user', password: 'direct-password' },
+                validations: [{ check: 'http_status', value: 200, description: 'accepted' }],
+              },
+              {
+                id: 'probe_invalid_basic',
+                title: 'invalid basic probe',
+                task: 'list_creatives',
+                auth: { type: 'basic', value_strategy: 'random_invalid' },
+                expect_error: true,
+                validations: [
+                  { check: 'http_status_in', allowed_values: [401, 403], description: 'rejects invalid basic' },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      const result = await runStoryboard(agentUrl, storyboard, {
+        protocol: 'mcp',
+        allow_http: true,
+        agentTools: ['list_creatives'],
+        _profile: { name: 'T', tools: ['list_creatives'] },
+        _client: { getAgentInfo: async () => ({ name: 'T', tools: [{ name: 'list_creatives' }] }) },
+      });
+      assert.strictEqual(
+        result.phases[0].steps.every(step => step.passed),
+        true,
+        JSON.stringify(result.phases[0].steps)
+      );
+      assert.strictEqual(observed[0], `Basic ${Buffer.from('direct-user:direct-password').toString('base64')}`);
+      assert.match(observed[1], /^Basic /);
+      assert.doesNotMatch(observed[1], /^Bearer /);
+      const decodedInvalid = Buffer.from(observed[1].slice('Basic '.length), 'base64').toString('utf8');
+      assert.match(decodedInvalid, /^invalid-[0-9a-f]{64}:invalid-[0-9a-f]{64}$/);
+    } finally {
+      server.close();
+    }
+  });
+
   it('phase optional: true failures do not fail overall pass', async () => {
     // Three-step storyboard:
     //   Phase A (optional): one step that passes and contributes a flag,


### PR DESCRIPTION
## Summary

- backport step-level `auth.type: basic` storyboard runner support to the published 7.11.x / AdCP 3.0 line
- version `@adcp/sdk` to 7.11.1 via changesets
- keeps the patch scoped to the runner and tests needed by the 3.0.x compliance Basic-auth path

Backport for #2114.

## Validation

- npm run build, with cosign hidden from PATH because the upstream 3.0.12 cosign sidecar fails verification locally and the 7.11 sync script supports checksum-only fallback when cosign is absent
- node --test --test-name-pattern "storyboard runner: auth-override dispatch" test/lib/storyboard-security.test.js
- git diff --check
- git push pre-push validation: typecheck + build passed

## Notes

- npm `@adcp/sdk@adcp-3.0` currently points at 7.11.0; this branch prepares 7.11.1 for that tag.
- local npm auth is not configured in this workspace (`npm whoami` returns E401), so registry publish/dist-tag movement still needs an authenticated environment.