### PR TITLE
fix(mcp): reuse OAuth sessions by default

### DIFF
--- a/.changeset/oauth-mcp-session-cache.md
+++ b/.changeset/oauth-mcp-session-cache.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': minor
+---
+
+Reuse authorization-code OAuth MCP sessions across related tool calls and export `closeOAuthConnections()` for scoped cleanup.

--- a/src/lib/canonical-references/index.ts
+++ b/src/lib/canonical-references/index.ts
@@ -655,7 +655,7 @@ async function validateFormatSchema(
   }
 
   const ajv = draft.draft === '2020-12' ? getDraft2020Ajv() : getDraft07Ajv();
-  const started = Date.now();
+  const started = process.cpuUsage();
   try {
     ajv.compile(resolved.schema);
   } catch (err) {
@@ -669,7 +669,9 @@ async function validateFormatSchema(
       },
     };
   }
-  const validationTimeMs = Date.now() - started;
+  // Ajv compilation is synchronous; CPU time avoids false budget failures when
+  // the process is descheduled during highly parallel test or CI runs.
+  const validationTimeMs = cpuUsageMs(started);
   const validationBudgetMs = options.validationBudgetMs ?? DEFAULT_VALIDATION_BUDGET_MS;
   if (validationTimeMs > validationBudgetMs) {
     return {
@@ -694,6 +696,11 @@ async function validateFormatSchema(
       validationTimeMs,
     },
   };
+}
+
+function cpuUsageMs(started: NodeJS.CpuUsage): number {
+  const elapsed = process.cpuUsage(started);
+  return (elapsed.user + elapsed.system) / 1000;
 }
 
 function detectDraft(

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -502,6 +502,7 @@ export class SingleAgentClient {
   private asyncHandler?: AsyncHandler;
   private normalizedAgent: InternalAgentConfig;
   private discoveredEndpoint?: string; // Cache discovered MCP endpoint
+  private discoveredAgent?: AgentConfig; // Stable post-discovery config for protocol/provider caches
   private canonicalBaseUrl?: string; // Cache canonical base URL (from agent card or stripped /mcp)
   private cachedCapabilities?: AdcpCapabilities; // Cache detected server capabilities
   private cachedToolSchemas?: Map<string, Record<string, unknown>>; // inputSchema.properties per tool name
@@ -588,11 +589,15 @@ export class SingleAgentClient {
     }
 
     // Already discovered? Use cached value
+    if (this.discoveredAgent) {
+      return this.discoveredAgent;
+    }
     if (this.discoveredEndpoint) {
-      return {
+      this.discoveredAgent = {
         ...this.normalizedAgent,
         agent_uri: this.discoveredEndpoint,
       };
+      return this.discoveredAgent;
     }
 
     // Perform discovery
@@ -601,10 +606,11 @@ export class SingleAgentClient {
     // Compute canonical base URL by stripping /mcp suffix
     this.canonicalBaseUrl = this.computeBaseUrl(this.discoveredEndpoint);
 
-    return {
+    this.discoveredAgent = {
       ...this.normalizedAgent,
       agent_uri: this.discoveredEndpoint,
     };
+    return this.discoveredAgent;
   }
 
   /**

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1134,6 +1134,7 @@ export {
   createMCPClient,
   createA2AClient,
   closeMCPConnections,
+  closeOAuthConnections,
   bundleSupportsAdcpVersionField,
 } from './protocols';
 export { toReleasePrecisionWire, validateAdcpVersionWire } from './validation/schema-loader';

--- a/src/lib/protocols/index.ts
+++ b/src/lib/protocols/index.ts
@@ -1,5 +1,12 @@
 // Unified Protocol Interface for AdCP
-export { callMCPTool, callMCPToolWithOAuth, connectMCP, closeMCPConnections, UnauthorizedError } from './mcp';
+export {
+  callMCPTool,
+  callMCPToolWithOAuth,
+  connectMCP,
+  closeMCPConnections,
+  closeOAuthConnections,
+  UnauthorizedError,
+} from './mcp';
 
 import { closeMCPConnections } from './mcp';
 import { closeA2AConnections } from './a2a';
@@ -51,6 +58,24 @@ import { buildAgentSigningContext, CAPABILITY_OP, ensureCapabilityLoaded } from 
 import { withResponseSizeLimit } from './responseSizeLimit';
 
 export type VersionEnvelopeMode = 'auto' | 'none' | 'major-only';
+
+const nonInteractiveOAuthProviderCache = new WeakMap<
+  AgentConfig,
+  ReturnType<typeof createNonInteractiveOAuthProvider>
+>();
+
+function getNonInteractiveOAuthProvider(agent: AgentConfig): ReturnType<typeof createNonInteractiveOAuthProvider> {
+  let provider = nonInteractiveOAuthProviderCache.get(agent);
+  if (!provider) {
+    const storage = getAgentStorage(agent);
+    provider = createNonInteractiveOAuthProvider(agent, {
+      agentHint: agent.id,
+      storage,
+    });
+    nonInteractiveOAuthProviderCache.set(agent, provider);
+  }
+  return provider;
+}
 
 /**
  * Derive the wire-level `adcp_major_version` integer from a caller-supplied
@@ -410,11 +435,7 @@ export class ProtocolClient {
             // and their refresh path is a secret re-exchange (handled above),
             // not the SDK's refresh_token grant.
             if (agent.oauth_tokens && !agent.oauth_client_credentials) {
-              const storage = getAgentStorage(agent);
-              const authProvider = createNonInteractiveOAuthProvider(agent, {
-                agentHint: agent.id,
-                storage,
-              });
+              const authProvider = getNonInteractiveOAuthProvider(agent);
               try {
                 return await callMCPToolWithOAuth({
                   agentUrl: agent.agent_uri,

--- a/src/lib/protocols/mcp.ts
+++ b/src/lib/protocols/mcp.ts
@@ -46,7 +46,11 @@ type CallToolResponse = {
  */
 const connectionCache = new Map<string, MCPClient>();
 const pendingConnections = new Map<string, Promise<MCPClient>>();
+const oauthConnectionCache = new Map<string, MCPClient>();
+const pendingOAuthConnections = new Map<string, Promise<MCPClient>>();
+const oauthProviderIds = new WeakMap<OAuthClientProvider, string>();
 const MAX_CACHED_CONNECTIONS = 20;
+let nextOAuthProviderId = 0;
 
 /**
  * Track URLs where StreamableHTTP has previously connected successfully.
@@ -160,6 +164,32 @@ function evictLeastRecentlyUsed(): void {
   oldClient?.close().catch(() => {});
 }
 
+function evictLeastRecentlyUsedOAuth(): void {
+  if (oauthConnectionCache.size <= MAX_CACHED_CONNECTIONS) return;
+  const lruKey = oauthConnectionCache.keys().next().value;
+  if (!lruKey) return;
+  const oldClient = oauthConnectionCache.get(lruKey);
+  oauthConnectionCache.delete(lruKey);
+  oldClient?.close().catch(() => {});
+}
+
+/**
+ * Close all cached OAuth MCP connections.
+ * Call this when tearing down long-lived service-to-service workflows that
+ * used authorization-code OAuth sessions.
+ */
+export async function closeOAuthConnections(): Promise<void> {
+  const entries = [...oauthConnectionCache.entries()];
+  oauthConnectionCache.clear();
+  for (const [, client] of entries) {
+    try {
+      await client.close();
+    } catch {
+      /* ignore close errors */
+    }
+  }
+}
+
 /**
  * Close all cached MCP connections.
  * Call this at the end of comply/test runs or before process exit.
@@ -175,6 +205,7 @@ export async function closeMCPConnections(): Promise<void> {
       /* ignore close errors */
     }
   }
+  await closeOAuthConnections();
 }
 
 /**
@@ -207,6 +238,144 @@ async function getOrCreateConnection(
 
   pendingConnections.set(cacheKey, promise);
   return promise;
+}
+
+function getOAuthProviderDisambiguator(authProvider: OAuthClientProvider): string {
+  let id = oauthProviderIds.get(authProvider);
+  if (!id) {
+    id = cacheDisambiguator(`oauth-provider:${++nextOAuthProviderId}`);
+    oauthProviderIds.set(authProvider, id);
+  }
+  return id;
+}
+
+function customHeadersDisambiguator(customHeaders?: Record<string, string>): string | undefined {
+  const entries = Object.entries(customHeaders ?? {})
+    .filter(([key]) => key.toLowerCase() !== 'authorization')
+    .map(([key, value]) => [key.toLowerCase(), value] as const)
+    .sort(([a], [b]) => a.localeCompare(b));
+  return entries.length > 0 ? cacheDisambiguator(JSON.stringify(entries)) : undefined;
+}
+
+function oauthConnectionCacheKey(
+  agentUrl: string,
+  authProvider: OAuthClientProvider,
+  signingCacheKey?: string,
+  customHeaders?: Record<string, string>
+): string {
+  const parts = [`${agentUrl}::oauth:${getOAuthProviderDisambiguator(authProvider)}`];
+  if (signingCacheKey) parts.push(signingCacheKey);
+  const headersKey = customHeadersDisambiguator(customHeaders);
+  if (headersKey) parts.push(`headers:${headersKey}`);
+  return parts.join('::');
+}
+
+/** Get a cached OAuth connection, refreshing its LRU position. */
+function getCachedOAuthConnection(key: string): MCPClient | undefined {
+  const client = oauthConnectionCache.get(key);
+  if (client) {
+    oauthConnectionCache.delete(key);
+    oauthConnectionCache.set(key, client);
+  }
+  return client;
+}
+
+async function getOrCreateOAuthConnection(
+  cacheKey: string,
+  options: {
+    agentUrl: string;
+    authProvider: OAuthClientProvider;
+    debugLogs: DebugLogEntry[];
+    customHeaders?: Record<string, string>;
+    signingContext?: AgentSigningContext;
+  }
+): Promise<MCPClient> {
+  const cached = getCachedOAuthConnection(cacheKey);
+  if (cached) return cached;
+
+  const pending = pendingOAuthConnections.get(cacheKey);
+  if (pending) return pending;
+
+  const promise = connectMCP(options)
+    .then(({ client }) => {
+      oauthConnectionCache.set(cacheKey, client);
+      evictLeastRecentlyUsedOAuth();
+      return client;
+    })
+    .finally(() => {
+      pendingOAuthConnections.delete(cacheKey);
+    });
+
+  pendingOAuthConnections.set(cacheKey, promise);
+  return promise;
+}
+
+async function withCachedOAuthConnection<T>(
+  options: {
+    agentUrl: string;
+    authProvider: OAuthClientProvider;
+    debugLogs: DebugLogEntry[];
+    customHeaders?: Record<string, string>;
+    signingContext?: AgentSigningContext;
+  },
+  label: string,
+  fn: (client: MCPClient) => Promise<T>
+): Promise<T> {
+  const cacheKey = oauthConnectionCacheKey(
+    options.agentUrl,
+    options.authProvider,
+    options.signingContext?.cacheKey,
+    options.customHeaders
+  );
+  const mcpClient = await getOrCreateOAuthConnection(cacheKey, options);
+
+  try {
+    return await fn(mcpClient);
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    options.debugLogs.push({
+      type: 'error',
+      message: `MCP: ${label} OAuth call failed: ${errorMessage}`,
+      timestamp: new Date().toISOString(),
+      error,
+    });
+
+    if (is401Error(error)) {
+      oauthConnectionCache.delete(cacheKey);
+      try {
+        await mcpClient.close();
+      } catch {
+        /* ignore */
+      }
+      options.debugLogs.push({
+        type: 'warning',
+        message: `MCP: OAuth authentication issue detected for ${label}; evicted cached connection`,
+        timestamp: new Date().toISOString(),
+      });
+      throw error;
+    }
+
+    oauthConnectionCache.delete(cacheKey);
+    try {
+      await mcpClient.close();
+    } catch {
+      /* ignore */
+    }
+
+    const retryClient = await getOrCreateOAuthConnection(cacheKey, {
+      ...options,
+      debugLogs: options.debugLogs,
+    });
+
+    try {
+      return await fn(retryClient);
+    } catch (retryError) {
+      if (retryError instanceof Error && error instanceof Error) {
+        retryError.cause = error;
+      }
+      throw retryError;
+    }
+  }
 }
 
 /**
@@ -787,17 +956,17 @@ export async function connectMCP(options: {
 /**
  * Call an MCP tool with OAuth support.
  *
- * Note: OAuth connections are NOT cached (each call creates a fresh connection)
- * because OAuth token refresh requires transport-level coordination that is
- * incompatible with connection pooling. This is acceptable because OAuth flows
- * are interactive and infrequent.
+ * OAuth connections are cached by agent URL and OAuth provider identity so a
+ * service-to-service workflow can reuse the initialized MCP session across
+ * related tool calls. Reuse the same OAuthClientProvider instance for a
+ * session/source/principal; the provider owns token refresh state for the
+ * cached transport.
  *
  * Signing: this path consumes `options.signingContext` via the transport —
  * `connectMCP` attaches a signing-fetch wrapper at transport-creation time —
- * rather than via `signingContextStorage`. Because each OAuth call creates a
- * fresh transport that isn't shared across calls, there's no cache-key
- * disambiguation concern and no need to seed ALS. The non-OAuth fallback
- * (`callMCPTool`) does enter ALS.
+ * rather than via `signingContextStorage`. The OAuth cache key includes the
+ * signing cache key so different signing identities do not share a transport.
+ * The non-OAuth fallback (`callMCPTool`) does enter ALS.
  *
  * @param options Call options
  * @returns Tool response
@@ -811,45 +980,36 @@ export async function callMCPToolWithOAuth(options: MCPCallOptions): Promise<unk
     return callMCPTool(agentUrl, toolName, args, authToken, debugLogs, customHeaders, signingContext);
   }
 
-  let client: MCPClient | undefined;
-  let transport: StreamableHTTPClientTransport | undefined;
-
-  try {
-    const result = await connectMCP({
+  const response = await withCachedOAuthConnection(
+    {
       agentUrl,
       authProvider,
       debugLogs,
       customHeaders,
       signingContext,
-    });
-    client = result.client;
-    transport = result.transport;
+    },
+    toolName,
+    async client => {
+      debugLogs.push({
+        type: 'info',
+        message: `MCP: Calling tool ${toolName}`,
+        timestamp: new Date().toISOString(),
+      });
 
-    debugLogs.push({
-      type: 'info',
-      message: `MCP: Calling tool ${toolName}`,
-      timestamp: new Date().toISOString(),
-    });
+      const response = await client.callTool({
+        name: toolName,
+        arguments: args,
+      });
 
-    const response = await client.callTool({
-      name: toolName,
-      arguments: args,
-    });
+      debugLogs.push({
+        type: response?.isError ? 'error' : 'success',
+        message: `MCP: Tool ${toolName} response received`,
+        timestamp: new Date().toISOString(),
+      });
 
-    debugLogs.push({
-      type: response?.isError ? 'error' : 'success',
-      message: `MCP: Tool ${toolName} response received`,
-      timestamp: new Date().toISOString(),
-    });
-
-    return response;
-  } finally {
-    if (client) {
-      try {
-        await client.close();
-      } catch {
-        // Ignore close errors
-      }
+      return response;
     }
-  }
+  );
+
+  return response;
 }

--- a/src/lib/testing/local-agent-runner.ts
+++ b/src/lib/testing/local-agent-runner.ts
@@ -264,15 +264,17 @@ export async function runAgainstLocalAgent(options: RunAgainstLocalAgentOptions)
     // produce fresh servers. Closing is idempotent.
     await bootstrapAgent.close();
 
-    // serve() validates publicUrl path against mountPath synchronously, so
-    // we need the port known before the call. Grab a free port first.
-    const port = await allocatePort();
-    const publicUrl = `http://127.0.0.1:${port}${mountPath}`;
-    const agentUrl = publicUrl;
-
     const protectedResource: ProtectedResourceMetadata | undefined = auth
       ? { authorization_servers: [auth.issuer] }
       : undefined;
+    // For the common unauthenticated local-agent path, bind port 0 directly
+    // and read the assigned port after listen. This avoids the allocate-then-
+    // bind race where another parallel test can claim the probed port.
+    // OAuth protected-resource metadata still needs a publicUrl before
+    // serve() construction, so that path keeps the preallocated port.
+    const port = protectedResource ? await allocatePort() : 0;
+    const publicUrl = `http://127.0.0.1:${port}${mountPath}`;
+    let agentUrl = publicUrl;
 
     httpServer = serve(options.createAgent, {
       ...options.serveOptions,
@@ -285,6 +287,13 @@ export async function runAgainstLocalAgent(options: RunAgainstLocalAgentOptions)
     });
 
     await waitForListening(httpServer);
+    if (!protectedResource) {
+      const address = httpServer.address();
+      if (!address || typeof address === 'string') {
+        throw new Error('runAgainstLocalAgent: local HTTP server did not expose a TCP address');
+      }
+      agentUrl = `http://127.0.0.1:${address.port}${mountPath}`;
+    }
 
     if (options.onListening) {
       await options.onListening({ agentUrl, auth });

--- a/test/lib/mcp-oauth-connection-cache.test.js
+++ b/test/lib/mcp-oauth-connection-cache.test.js
@@ -1,0 +1,385 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const http = require('node:http');
+const { randomUUID } = require('node:crypto');
+
+const { McpServer } = require('@modelcontextprotocol/sdk/server/mcp.js');
+const { StreamableHTTPServerTransport } = require('@modelcontextprotocol/sdk/server/streamableHttp.js');
+
+const { callMCPToolWithOAuth, closeMCPConnections, closeOAuthConnections } = require('../../dist/lib/protocols/mcp.js');
+const { ProtocolClient } = require('../../dist/lib/protocols/index.js');
+const { SingleAgentClient } = require('../../dist/lib/index.js');
+
+function createStaticOAuthProvider(token) {
+  return {
+    get redirectUrl() {
+      return undefined;
+    },
+    get clientMetadata() {
+      return {
+        client_name: 'oauth-cache-test',
+        redirect_uris: [],
+      };
+    },
+    async clientInformation() {
+      return { client_id: `client_${token}` };
+    },
+    async tokens() {
+      return { access_token: token, token_type: 'Bearer' };
+    },
+    async saveTokens(tokens) {
+      token = tokens.access_token;
+    },
+    async redirectToAuthorization() {
+      throw new Error('unexpected interactive OAuth flow');
+    },
+    async saveCodeVerifier() {},
+    async codeVerifier() {
+      return 'verifier';
+    },
+    async invalidateCredentials() {},
+  };
+}
+
+function countMethod(state, parsedBody) {
+  const messages = Array.isArray(parsedBody) ? parsedBody : [parsedBody];
+  for (const message of messages) {
+    if (message?.method) {
+      state.methodCounts.set(message.method, (state.methodCounts.get(message.method) ?? 0) + 1);
+    }
+  }
+}
+
+async function readJsonBody(req) {
+  let body = '';
+  for await (const chunk of req) {
+    body += chunk;
+  }
+  return body ? JSON.parse(body) : undefined;
+}
+
+async function startMcpOAuthStub() {
+  const state = {
+    authHeaders: [],
+    methodCounts: new Map(),
+    toolCalls: 0,
+  };
+
+  const httpServer = http.createServer(async (req, res) => {
+    if (!req.url || (req.url !== '/mcp' && req.url !== '/mcp/')) {
+      res.statusCode = 404;
+      res.end('not found');
+      return;
+    }
+
+    state.authHeaders.push(req.headers.authorization ?? '');
+    const parsedBody = req.method === 'POST' ? await readJsonBody(req) : undefined;
+    if (parsedBody) countMethod(state, parsedBody);
+
+    const mcp = new McpServer({ name: 'oauth-cache-stub', version: '1.0.0' });
+    mcp.registerTool('ping', { inputSchema: {} }, async () => {
+      state.toolCalls++;
+      return { content: [{ type: 'text', text: JSON.stringify({ ok: true }) }] };
+    });
+
+    const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+    try {
+      await mcp.connect(transport);
+      await transport.handleRequest(req, res, parsedBody);
+    } catch (error) {
+      if (!res.headersSent) {
+        res.writeHead(500, { 'content-type': 'text/plain' });
+      }
+      res.end(error instanceof Error ? error.stack : String(error));
+    } finally {
+      await mcp.close();
+    }
+  });
+
+  await new Promise(resolve => httpServer.listen(0, '127.0.0.1', resolve));
+  const addr = httpServer.address();
+  return {
+    url: `http://127.0.0.1:${addr.port}/mcp`,
+    state,
+    stop: () => {
+      if (typeof httpServer.closeAllConnections === 'function') httpServer.closeAllConnections();
+      return new Promise(resolve => httpServer.close(() => resolve()));
+    },
+  };
+}
+
+function isInitializeRequest(parsedBody) {
+  const messages = Array.isArray(parsedBody) ? parsedBody : [parsedBody];
+  return messages.some(message => message?.method === 'initialize');
+}
+
+function registerSessionTools(mcp, state) {
+  for (const toolName of ['ping', 'get_products', 'create_media_buy', 'sync_creatives']) {
+    mcp.registerTool(toolName, { inputSchema: {} }, async () => {
+      state.toolCalls++;
+      return { content: [{ type: 'text', text: JSON.stringify({ ok: true, tool: toolName }) }] };
+    });
+  }
+}
+
+async function startStatefulMcpOAuthStub() {
+  const sessions = new Map();
+  const state = {
+    authHeaders: [],
+    methodCounts: new Map(),
+    sessionHeaders: [],
+    initializedSessionIds: [],
+    toolCalls: 0,
+  };
+
+  async function createSession() {
+    const mcp = new McpServer({ name: 'oauth-stateful-cache-stub', version: '1.0.0' });
+    registerSessionTools(mcp, state);
+
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: () => randomUUID(),
+      onsessioninitialized: sessionId => {
+        state.initializedSessionIds.push(sessionId);
+        sessions.set(sessionId, { mcp, transport });
+      },
+    });
+    transport.onclose = () => {
+      if (transport.sessionId) sessions.delete(transport.sessionId);
+    };
+    await mcp.connect(transport);
+    return { mcp, transport };
+  }
+
+  const httpServer = http.createServer(async (req, res) => {
+    if (!req.url || (req.url !== '/mcp' && req.url !== '/mcp/')) {
+      res.statusCode = 404;
+      res.end('not found');
+      return;
+    }
+
+    state.authHeaders.push(req.headers.authorization ?? '');
+    const sessionHeader = req.headers['mcp-session-id'];
+    if (sessionHeader) state.sessionHeaders.push(sessionHeader);
+
+    const parsedBody = req.method === 'POST' ? await readJsonBody(req) : undefined;
+    if (parsedBody) countMethod(state, parsedBody);
+
+    const isInit = parsedBody ? isInitializeRequest(parsedBody) : false;
+    let session;
+    if (typeof sessionHeader === 'string') {
+      session = sessions.get(sessionHeader);
+      if (!session) {
+        res.writeHead(404, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ jsonrpc: '2.0', error: { code: -32001, message: 'Session not found' }, id: null }));
+        return;
+      }
+    } else if (isInit) {
+      session = await createSession();
+    } else {
+      res.writeHead(400, { 'content-type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          error: { code: -32000, message: 'Mcp-Session-Id header is required' },
+          id: null,
+        })
+      );
+      return;
+    }
+
+    try {
+      await session.transport.handleRequest(req, res, parsedBody);
+    } catch (error) {
+      if (!res.headersSent) {
+        res.writeHead(500, { 'content-type': 'text/plain' });
+      }
+      res.end(error instanceof Error ? error.stack : String(error));
+    }
+  });
+
+  await new Promise(resolve => httpServer.listen(0, '127.0.0.1', resolve));
+  const addr = httpServer.address();
+  return {
+    url: `http://127.0.0.1:${addr.port}/mcp`,
+    state,
+    stop: async () => {
+      for (const { mcp, transport } of [...sessions.values()]) {
+        await transport.close().catch(() => {});
+        await mcp.close().catch(() => {});
+      }
+      sessions.clear();
+      if (typeof httpServer.closeAllConnections === 'function') httpServer.closeAllConnections();
+      await new Promise(resolve => httpServer.close(() => resolve()));
+    },
+  };
+}
+
+function resetStatefulMcpCounters(state) {
+  state.authHeaders.length = 0;
+  state.methodCounts.clear();
+  state.sessionHeaders.length = 0;
+  state.initializedSessionIds.length = 0;
+  state.toolCalls = 0;
+}
+
+test('OAuth MCP calls reuse one initialized session for the same provider', async () => {
+  await closeMCPConnections();
+  const server = await startMcpOAuthStub();
+  const authProvider = createStaticOAuthProvider('tok_same');
+
+  try {
+    await callMCPToolWithOAuth({ agentUrl: server.url, toolName: 'ping', args: {}, authProvider });
+    await callMCPToolWithOAuth({ agentUrl: server.url, toolName: 'ping', args: {}, authProvider });
+
+    assert.strictEqual(server.state.methodCounts.get('initialize'), 1, 'same OAuth provider should initialize once');
+    assert.strictEqual(
+      server.state.methodCounts.get('tools/call'),
+      2,
+      'both logical tool calls should reach the server'
+    );
+    assert.ok(
+      server.state.authHeaders.every(header => header === 'Bearer tok_same'),
+      `expected every request to use tok_same, saw ${JSON.stringify(server.state.authHeaders)}`
+    );
+
+    await closeMCPConnections();
+    await callMCPToolWithOAuth({ agentUrl: server.url, toolName: 'ping', args: {}, authProvider });
+    assert.strictEqual(
+      server.state.methodCounts.get('initialize'),
+      2,
+      'closeMCPConnections should drain the OAuth cache'
+    );
+  } finally {
+    await closeMCPConnections();
+    await server.stop();
+  }
+});
+
+test('OAuth MCP cache separates different providers for the same agent URL', async () => {
+  await closeMCPConnections();
+  const server = await startMcpOAuthStub();
+  const providerA = createStaticOAuthProvider('tok_a');
+  const providerB = createStaticOAuthProvider('tok_b');
+
+  try {
+    await callMCPToolWithOAuth({ agentUrl: server.url, toolName: 'ping', args: {}, authProvider: providerA });
+    await callMCPToolWithOAuth({ agentUrl: server.url, toolName: 'ping', args: {}, authProvider: providerB });
+
+    assert.strictEqual(server.state.methodCounts.get('initialize'), 2, 'different providers need distinct sessions');
+    assert.ok(server.state.authHeaders.includes('Bearer tok_a'), 'provider A token reached the server');
+    assert.ok(server.state.authHeaders.includes('Bearer tok_b'), 'provider B token reached the server');
+  } finally {
+    await closeOAuthConnections();
+    await server.stop();
+  }
+});
+
+test('ProtocolClient default OAuth path reuses the stateful MCP session across workflow tools', async () => {
+  await closeMCPConnections();
+  const server = await startStatefulMcpOAuthStub();
+  const agent = {
+    id: 'default-oauth-session',
+    name: 'Default OAuth Session',
+    agent_uri: server.url,
+    protocol: 'mcp',
+    oauth_tokens: {
+      access_token: 'tok_default',
+      refresh_token: 'rt_default',
+      token_type: 'Bearer',
+    },
+    oauth_client: { client_id: 'client_default' },
+  };
+
+  try {
+    await ProtocolClient.callTool(agent, 'get_products', {});
+    await ProtocolClient.callTool(agent, 'create_media_buy', {});
+    await ProtocolClient.callTool(agent, 'sync_creatives', {});
+
+    assert.strictEqual(
+      server.state.methodCounts.get('initialize'),
+      1,
+      'default ProtocolClient OAuth flow should initialize one MCP session'
+    );
+    assert.strictEqual(
+      server.state.initializedSessionIds.length,
+      1,
+      'stateful MCP server should issue exactly one session id'
+    );
+    assert.strictEqual(server.state.methodCounts.get('tools/call'), 3, 'all workflow tools should use tools/call');
+    assert.ok(
+      server.state.sessionHeaders.length >= 3,
+      'stateful MCP tool calls should carry the server-issued mcp-session-id'
+    );
+    assert.ok(
+      server.state.sessionHeaders.every(sessionId => sessionId === server.state.initializedSessionIds[0]),
+      `expected all calls to reuse session ${server.state.initializedSessionIds[0]}, saw ${JSON.stringify(
+        server.state.sessionHeaders
+      )}`
+    );
+    assert.ok(
+      server.state.authHeaders.every(header => header === 'Bearer tok_default'),
+      `expected every request to use tok_default, saw ${JSON.stringify(server.state.authHeaders)}`
+    );
+  } finally {
+    await closeMCPConnections();
+    await server.stop();
+  }
+});
+
+test('SingleAgentClient default OAuth path reuses the stateful MCP session after discovery', async () => {
+  await closeMCPConnections();
+  const server = await startStatefulMcpOAuthStub();
+  const client = new SingleAgentClient(
+    {
+      id: 'single-agent-default-oauth-session',
+      name: 'SingleAgent Default OAuth Session',
+      agent_uri: server.url,
+      protocol: 'mcp',
+      oauth_tokens: {
+        access_token: 'tok_single_agent',
+        refresh_token: 'rt_single_agent',
+        token_type: 'Bearer',
+      },
+      oauth_client: { client_id: 'client_single_agent' },
+    },
+    { allowV2: true }
+  );
+
+  try {
+    await client.getCapabilities();
+    resetStatefulMcpCounters(server.state);
+
+    await client.executeTask('ping', {});
+    await client.executeTask('ping', {});
+    await client.executeTask('ping', {});
+
+    assert.strictEqual(
+      server.state.methodCounts.get('initialize'),
+      1,
+      'SingleAgentClient should keep one OAuth MCP session across default executeTask calls'
+    );
+    assert.strictEqual(
+      server.state.initializedSessionIds.length,
+      1,
+      'stateful MCP server should issue one session id for the executeTask workflow'
+    );
+    assert.strictEqual(server.state.methodCounts.get('tools/call'), 3, 'all executeTask calls should use tools/call');
+    assert.ok(
+      server.state.sessionHeaders.length >= 3,
+      'stateful MCP executeTask calls should carry the server-issued mcp-session-id'
+    );
+    assert.ok(
+      server.state.sessionHeaders.every(sessionId => sessionId === server.state.initializedSessionIds[0]),
+      `expected all executeTask calls to reuse session ${server.state.initializedSessionIds[0]}, saw ${JSON.stringify(
+        server.state.sessionHeaders
+      )}`
+    );
+    assert.ok(
+      server.state.authHeaders.every(header => header === 'Bearer tok_single_agent'),
+      `expected every request to use tok_single_agent, saw ${JSON.stringify(server.state.authHeaders)}`
+    );
+  } finally {
+    await closeMCPConnections();
+    await server.stop();
+  }
+});

--- a/test/lib/serve.test.js
+++ b/test/lib/serve.test.js
@@ -23,7 +23,17 @@ function waitForListening(server) {
   });
 }
 
-describe('serve()', () => {
+function closeServer(server) {
+  if (!server.listening) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    server.close(err => {
+      if (err) reject(err);
+      else resolve();
+    });
+  });
+}
+
+describe('serve()', { concurrency: false }, () => {
   let serve;
   let McpServer;
 
@@ -49,7 +59,7 @@ describe('serve()', () => {
     await makeRequest(port, '/mcp');
     assert.strictEqual(callCount, 2, 'factory should be called once per request');
 
-    server.close();
+    await closeServer(server);
   });
 
   test('matches path with trailing slash', async () => {
@@ -62,7 +72,7 @@ describe('serve()', () => {
     // Should not be 404 — it reached the MCP handler (may error, but not 404)
     assert.notStrictEqual(res.status, 404, '/mcp/ should match the mount path');
 
-    server.close();
+    await closeServer(server);
   });
 
   test('matches path with query string', async () => {
@@ -74,7 +84,7 @@ describe('serve()', () => {
     const res = await makeRequest(port, '/mcp?foo=bar');
     assert.notStrictEqual(res.status, 404, '/mcp?foo=bar should match the mount path');
 
-    server.close();
+    await closeServer(server);
   });
 
   test('returns 404 for non-matching paths', async () => {
@@ -86,7 +96,7 @@ describe('serve()', () => {
     const res = await makeRequest(port, '/other');
     assert.strictEqual(res.status, 404);
 
-    server.close();
+    await closeServer(server);
   });
 
   test('custom path option', async () => {
@@ -101,7 +111,7 @@ describe('serve()', () => {
     const found = await makeRequest(port, '/v1/agent');
     assert.notStrictEqual(found.status, 404, 'custom path should match');
 
-    server.close();
+    await closeServer(server);
   });
 
   test('onListening callback receives URL', async () => {
@@ -118,7 +128,7 @@ describe('serve()', () => {
     const port = server.address().port;
     assert.strictEqual(url, `http://localhost:${port}/mcp`);
 
-    server.close();
+    await closeServer(server);
   });
 
   test('invalid PORT env var throws', () => {
@@ -154,6 +164,6 @@ describe('serve()', () => {
     const body = JSON.parse(res.body);
     assert.strictEqual(body.error, 'Internal server error');
 
-    server.close();
+    await closeServer(server);
   });
 });

--- a/test/lib/storyboard-idempotency-invariant.test.js
+++ b/test/lib/storyboard-idempotency-invariant.test.js
@@ -22,6 +22,12 @@ const {
 
 const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
+function closeServer(server) {
+  return new Promise((resolve, reject) => {
+    server.close(err => (err ? reject(err) : resolve()));
+  });
+}
+
 describe('applyIdempotencyInvariant', () => {
   test('injects a UUID v4 on mutating tasks when the request omits one', () => {
     const result = applyIdempotencyInvariant({ name: 'p1' }, 'create_property_list', {});
@@ -89,7 +95,7 @@ describe('applyIdempotencyInvariant', () => {
  * fix, the server's required-field check would short-circuit and the
  * handler under test would never run.
  */
-describe('runStoryboard: idempotency_key invariant on the wire', () => {
+describe('runStoryboard: idempotency_key invariant on the wire', { concurrency: false }, () => {
   it('auto-injects idempotency_key on mutating steps whose sample_request omits it, including untyped tasks (acquire_rights) that fall through to executeTask', async () => {
     const seen = [];
     const server = http.createServer(async (req, res) => {
@@ -175,7 +181,7 @@ describe('runStoryboard: idempotency_key invariant on the wire', () => {
       const readOnly = seen.find(c => c.name === 'get_products');
       assert.strictEqual(readOnly.args.idempotency_key, undefined, 'read-only task must not receive idempotency_key');
     } finally {
-      server.close();
+      await closeServer(server);
     }
   });
 
@@ -242,7 +248,7 @@ describe('runStoryboard: idempotency_key invariant on the wire', () => {
         'expect_error step on mutating task must still receive auto-injected idempotency_key'
       );
     } finally {
-      server.close();
+      await closeServer(server);
     }
   });
 
@@ -310,7 +316,7 @@ describe('runStoryboard: idempotency_key invariant on the wire', () => {
         'omit_idempotency_key step must not receive auto-injected idempotency_key'
       );
     } finally {
-      server.close();
+      await closeServer(server);
     }
   });
 
@@ -474,7 +480,7 @@ describe('defaultAuthHeadersForRawProbe', () => {
  * URL would indicate leakage; we assert by observing the SDK's failure shape
  * (no raw probe body ever lands).
  */
-describe('runStoryboard dispatch: A2A + omit_idempotency_key stays on SDK path', () => {
+describe('runStoryboard dispatch: A2A + omit_idempotency_key stays on SDK path', { concurrency: false }, () => {
   it('does not invoke the raw MCP probe for A2A steps', async () => {
     const mcpJsonRpcCallsSeen = [];
     const server = http.createServer(async (req, res) => {
@@ -541,7 +547,7 @@ describe('runStoryboard dispatch: A2A + omit_idempotency_key stays on SDK path',
         `A2A run must not emit MCP JSON-RPC tools/call; saw ${mcpJsonRpcCallsSeen.length}`
       );
     } finally {
-      server.close();
+      await closeServer(server);
     }
   });
 });

--- a/test/request-signing-replay-perf.test.js
+++ b/test/request-signing-replay-perf.test.js
@@ -8,16 +8,18 @@ const { InMemoryReplayStore } = require('../dist/lib/signing/index.js');
 // target. The time-bucketed store evicts whole buckets at a time, so
 // amortized cost is O(1) per op.
 //
-// Timing on CI runners is noisy; we cap the growth ratio generously (<4x) and
-// take the median of multiple measurement windows.
+// Timing on CI runners is noisy; measure CPU time instead of wall-clock time,
+// cap the growth ratio generously (<4x), and take the median of multiple
+// measurement windows.
 
 function timeBatch(fn, iterations) {
   const samples = [];
   for (let run = 0; run < 5; run++) {
-    const start = process.hrtime.bigint();
+    const start = process.cpuUsage();
     for (let i = 0; i < iterations; i++) fn(i);
-    const elapsed = Number(process.hrtime.bigint() - start);
-    samples.push(elapsed / iterations);
+    const elapsed = process.cpuUsage(start);
+    const elapsedNs = (elapsed.user + elapsed.system) * 1000;
+    samples.push(elapsedNs / iterations);
   }
   samples.sort((a, b) => a - b);
   return samples[Math.floor(samples.length / 2)];

--- a/test/server-a2a-submitted-end-to-end.test.js
+++ b/test/server-a2a-submitted-end-to-end.test.js
@@ -21,6 +21,7 @@
 const { describe, it } = require('node:test');
 const assert = require('node:assert');
 const express = require('express');
+const { z } = require('zod');
 
 const { createAdcpServer: _createAdcpServer } = require('../dist/lib/server/create-adcp-server');
 const { createA2AAdapter } = require('../dist/lib/server/a2a-adapter');
@@ -80,42 +81,43 @@ describe('A2A submitted → completed end-to-end (#966 + #967 + #973)', () => {
       },
       // Custom AdCP `tasks/get` tool dispatched as a buyer-callable
       // tool over `message/send`. First two polls return working;
-      // third returns completed with the result data.
+      // third returns completed with the result data. Keeping this on
+      // the fixture server avoids process-global ProtocolClient monkey
+      // patches, which are fragile in the broad parallel test runner.
+      customTools: {
+        'tasks/get': {
+          inputSchema: { task_id: z.string() },
+          handler: async params => {
+            observedPollSkill = 'tasks/get';
+            observedPollParam = params;
+            pollCount += 1;
+            const response =
+              pollCount < 3
+                ? {
+                    task_id: params.task_id,
+                    task_type: 'create_media_buy',
+                    protocol: 'media-buy',
+                    status: 'working',
+                    created_at: '2026-04-25T10:00:00Z',
+                    updated_at: new Date().toISOString(),
+                  }
+                : {
+                    task_id: params.task_id,
+                    task_type: 'create_media_buy',
+                    protocol: 'media-buy',
+                    status: 'completed',
+                    created_at: '2026-04-25T10:00:00Z',
+                    updated_at: new Date().toISOString(),
+                    result: { media_buy_id: SELLER_MEDIA_BUY_ID, packages: [] },
+                  };
+            return {
+              content: [{ type: 'text', text: JSON.stringify(response) }],
+              structuredContent: response,
+            };
+          },
+        },
+      },
     });
-    // Drive polls via a `ProtocolClient.callTool` monkey-patch
-    // rather than registering a `tasks/get` tool on the seller —
-    // we want to assert on the exact arguments the SDK dispatches
-    // (snake_case `task_id`), and a real seller-side tool
-    // registration would obscure that surface.
-    const { ProtocolClient } = require('../dist/lib/index');
-    const originalCallTool = ProtocolClient.callTool;
-    ProtocolClient.callTool = async (agent, toolName, params, ...rest) => {
-      if (toolName === 'tasks/get') {
-        observedPollSkill = toolName;
-        observedPollParam = params;
-        pollCount += 1;
-        if (pollCount < 3) {
-          return {
-            task_id: params.task_id,
-            task_type: 'create_media_buy',
-            protocol: 'media-buy',
-            status: 'working',
-            created_at: '2026-04-25T10:00:00Z',
-            updated_at: new Date().toISOString(),
-          };
-        }
-        return {
-          task_id: params.task_id,
-          task_type: 'create_media_buy',
-          protocol: 'media-buy',
-          status: 'completed',
-          created_at: '2026-04-25T10:00:00Z',
-          updated_at: new Date().toISOString(),
-          result: { media_buy_id: SELLER_MEDIA_BUY_ID, packages: [] },
-        };
-      }
-      return originalCallTool.call(ProtocolClient, agent, toolName, params, ...rest);
-    };
 
     try {
       const executor = new TaskExecutor({ pollingInterval: 5 });
@@ -159,7 +161,6 @@ describe('A2A submitted → completed end-to-end (#966 + #967 + #973)', () => {
       assert.deepStrictEqual(completion.data, { media_buy_id: SELLER_MEDIA_BUY_ID, packages: [] });
       assert.ok(pollCount >= 3, `expected ≥3 polls (working/working/completed), got ${pollCount}`);
     } finally {
-      ProtocolClient.callTool = originalCallTool;
       await fixture.close();
     }
   });


### PR DESCRIPTION
## Summary

Reuse authorization-code OAuth MCP sessions across default client calls, export `closeOAuthConnections()`, and add stateful regression coverage proving related tool calls share one initialized MCP session.
The PR also hardens unrelated CI failures found during validation by removing global protocol monkey-patches, awaiting local server teardown, using CPU-time budgets for flaky timing checks, and avoiding local-agent port allocation races.

## Validation

`npm run ci:quick`
