### PR TITLE
test: guard storyboard fixture regressions

### DIFF
--- a/.changeset/storyboard-fixture-regressions.md
+++ b/.changeset/storyboard-fixture-regressions.md
@@ -1,0 +1,7 @@
+---
+---
+
+test(storyboard): guard fixture lookup and request isolation regressions.
+
+Empty changeset because this PR adds regression coverage and corrects an issue
+reference comment only; it does not change the published SDK runtime API.

--- a/src/lib/mock-server/sales-guaranteed/seed-data.ts
+++ b/src/lib/mock-server/sales-guaranteed/seed-data.ts
@@ -51,7 +51,7 @@ export const NETWORKS: MockNetwork[] = [
   // sends payloads with these publisher domains. Without them, every
   // `_lookup/network` returns 404 and a blind agent has to invent a fallback
   // that contradicts the skill's "fail closed on 404" advice. Issue
-  // adcontextprotocol/adcp#3822. Until the storyboard runner exposes a
+  // adcontextprotocol/adcp#3821. Until the storyboard runner exposes a
   // setup phase that primes the upstream, we seed the fixture domains
   // here so blind agents can pass the traffic gate without contradiction.
   {
@@ -103,7 +103,7 @@ export const AD_UNITS: MockAdUnit[] = [
     environment: 'web',
     targetable: true,
   },
-  // Storyboard-fixture-aligned ad units (see NETWORKS comment + adcp#3822).
+  // Storyboard-fixture-aligned ad units (see NETWORKS comment + adcp#3821).
   {
     ad_unit_id: 'au_acmeoutdoor_billboards',
     name: 'Acme Outdoor — Programmatic DOOH Billboards',
@@ -165,7 +165,7 @@ export const PRODUCTS: MockProduct[] = [
     ad_unit_ids: ['au_us_display_300x250'],
     pricing: { model: 'cpm', cpm: 4.5, currency: 'USD' },
   },
-  // Storyboard-fixture-aligned products (see NETWORKS comment + adcp#3822).
+  // Storyboard-fixture-aligned products (see NETWORKS comment + adcp#3821).
   {
     product_id: 'acme_dooh_billboards_q2',
     name: 'Acme Outdoor — DOOH Billboards Q2',

--- a/test/lib/mock-server/sales-guaranteed.test.js
+++ b/test/lib/mock-server/sales-guaranteed.test.js
@@ -51,6 +51,16 @@ describe('mock-server sales-guaranteed', () => {
     assert.equal(res.status, 403);
   });
 
+  it('resolves storyboard fixture publisher domains via lookup endpoint (#3821)', async () => {
+    for (const domain of ['acmeoutdoor.example', 'pinnacle-agency.example']) {
+      const res = await fetch(`${handle.url}/_lookup/network?adcp_publisher=${encodeURIComponent(domain)}`);
+      assert.equal(res.status, 200, `${domain} should resolve`);
+      const body = await res.json();
+      assert.equal(body.adcp_publisher, domain);
+      assert.ok(body.network_code);
+    }
+  });
+
   it('lists network-scoped inventory', async () => {
     const res = await fetch(`${handle.url}/v1/inventory`, { headers: authHeaders() });
     assert.equal(res.status, 200);

--- a/test/lib/storyboard-brand-invariant.test.js
+++ b/test/lib/storyboard-brand-invariant.test.js
@@ -138,6 +138,16 @@ describe('applyBrandInvariant', () => {
         true,
         'get_products must declare brand at the request root (positive control)'
       );
+      assert.strictEqual(
+        schemaAllowsTopLevelField('sync_creatives', 'brand'),
+        false,
+        'sync_creatives must not declare brand at the request root'
+      );
+      assert.strictEqual(
+        schemaAllowsTopLevelField('sync_creatives', 'account'),
+        true,
+        'sync_creatives must declare account at the request root'
+      );
     });
 
     test('skips top-level brand and synthetic account for sync_plans', () => {
@@ -157,6 +167,22 @@ describe('applyBrandInvariant', () => {
     test('injects top-level brand for get_products (positive control)', () => {
       const result = applyBrandInvariant({}, { brand: BRAND }, 'get_products');
       assert.deepStrictEqual(result.brand, BRAND, 'brand must be injected for get_products');
+    });
+
+    test('skips top-level brand but keeps account-scoped brand for sync_creatives (#3342)', () => {
+      const result = applyBrandInvariant(
+        {
+          account: { operator: 'pinnacle-agency.example' },
+          creatives: [{ creative_id: 'cr-1', assets: {} }],
+        },
+        { brand: BRAND },
+        'sync_creatives'
+      );
+      assert.strictEqual(result.brand, undefined, 'brand must not be injected for sync_creatives');
+      assert.deepStrictEqual(result.account, {
+        operator: 'pinnacle-agency.example',
+        brand: BRAND,
+      });
     });
   });
 
@@ -317,6 +343,104 @@ describe('runStoryboard: brand invariant on the wire', () => {
           `step ${call.name} brand not reachable from wire: top-level=${JSON.stringify(topBrand)} account.brand=${JSON.stringify(accountBrand)}`
         );
       }
+    } finally {
+      server.close();
+    }
+  });
+
+  it('does not bleed create_media_buy top-level brand into a later sync_creatives request (#3342)', async () => {
+    const seen = [];
+    const server = http.createServer(async (req, res) => {
+      const chunks = [];
+      for await (const c of req) chunks.push(c);
+      const rpc = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+      seen.push({ name: rpc.params.name, args: rpc.params.arguments });
+      res.writeHead(401, { 'content-type': 'application/json', 'www-authenticate': 'Bearer realm="x"' });
+      res.end('{}');
+    });
+    await new Promise(r => server.listen(0, r));
+    const agentUrl = `http://127.0.0.1:${server.address().port}/mcp`;
+    try {
+      const storyboard = {
+        id: 'sync_creatives_isolated_request_sb',
+        version: '1.0.0',
+        title: 'Sync creatives request isolation',
+        category: 'compliance',
+        summary: '',
+        narrative: '',
+        agent: { interaction_model: '*', capabilities: [] },
+        caller: { role: 'buyer_agent' },
+        phases: [
+          {
+            id: 'p',
+            title: 'media buy then creative sync',
+            steps: [
+              {
+                id: 'create_buy_no_creatives',
+                title: 'create buy carries top-level brand',
+                task: 'create_media_buy',
+                auth: 'none',
+                expect_error: true,
+                sample_request: {
+                  account: { brand: { domain: 'other.example' }, operator: 'pinnacle-agency.example' },
+                  brand: { domain: 'other.example' },
+                  start_time: '2026-06-01T00:00:00Z',
+                  end_time: '2026-06-08T00:00:00Z',
+                  packages: [{ buyer_ref: 'pkg-1', product_id: 'prod-1', pricing_option_id: 'cpm-1', budget: 1000 }],
+                },
+                validations: [{ check: 'http_status_in', allowed_values: [401], description: '' }],
+              },
+              {
+                id: 'supply_creatives',
+                title: 'sync creatives has no top-level brand',
+                task: 'sync_creatives',
+                auth: 'none',
+                expect_error: true,
+                sample_request: {
+                  account: { brand: { domain: 'other.example' }, operator: 'pinnacle-agency.example' },
+                  creatives: [
+                    {
+                      creative_id: 'cr-1',
+                      name: 'Creative 1',
+                      assets: {},
+                    },
+                  ],
+                },
+                validations: [{ check: 'http_status_in', allowed_values: [401], description: '' }],
+              },
+            ],
+          },
+        ],
+      };
+      await runStoryboard(agentUrl, storyboard, {
+        protocol: 'mcp',
+        allow_http: true,
+        brand: BRAND,
+        agentTools: ['create_media_buy', 'sync_creatives'],
+        _profile: { name: 'Test', tools: ['create_media_buy', 'sync_creatives'] },
+        _client: {
+          getAgentInfo: async () => ({
+            name: 'Test',
+            tools: [{ name: 'create_media_buy' }, { name: 'sync_creatives' }],
+          }),
+        },
+      });
+
+      const createCall = seen.find(call => call.name === 'create_media_buy');
+      const syncCall = seen.find(call => call.name === 'sync_creatives');
+      assert.ok(createCall, `expected create_media_buy call; saw ${seen.map(call => call.name).join(', ')}`);
+      assert.ok(syncCall, `expected sync_creatives call; saw ${seen.map(call => call.name).join(', ')}`);
+      assert.deepStrictEqual(
+        createCall.args.brand,
+        BRAND,
+        'create_media_buy should retain schema-valid top-level brand'
+      );
+      assert.strictEqual(
+        Object.prototype.hasOwnProperty.call(syncCall.args, 'brand'),
+        false,
+        'sync_creatives must not receive top-level brand from prior step context'
+      );
+      assert.deepStrictEqual(syncCall.args.account.brand, BRAND, 'sync_creatives should carry brand through account');
     } finally {
       server.close();
     }


### PR DESCRIPTION
Adds regression coverage for the sales-guaranteed storyboard fixture domains so the mock lookup resolves acmeoutdoor.example and pinnacle-agency.example.

Adds runner coverage proving a create_media_buy top-level brand does not bleed into later sync_creatives requests; sync_creatives keeps brand scoped through account.

Validated with npm run build:lib, focused Node tests, commitlint, and the pre-push typecheck/build hook.