### PR TITLE
ci: refresh TypeScript reference seller pin

### DIFF
--- a/.github/workflows/interop-python.yml
+++ b/.github/workflows/interop-python.yml
@@ -108,7 +108,7 @@ jobs:
             advisory: true
           - language: typescript
             repository: adcontextprotocol/adcp-client
-            ref: 97aef9f9561983b21605e77c3377bbdc0641b61c # @adcp/sdk@8.1.0-beta.12
+            ref: df7b5837896154002bb5a4941b4b07c828521001 # @adcp/sdk@8.1.0-beta.17
             harness: scripts/ci/run_storyboard_reference_seller.sh
             port: 3002
             advisory: true
@@ -277,7 +277,7 @@ jobs:
             echo "- Ref: current checkout \`${{ github.sha }}\`"
             echo "- Seller: \`examples/hello_seller_adapter_guaranteed.ts\`"
             echo "- Harness: \`scripts/ci/run_storyboard_reference_seller.sh\`"
-            echo "- Note: tagged TypeScript release compatibility is covered by the matrix row pinned to @adcp/sdk@8.1.0-beta.12."
+            echo "- Note: tagged TypeScript release compatibility is covered by the matrix row pinned to @adcp/sdk@8.1.0-beta.17."
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload storyboard artifacts


### PR DESCRIPTION
## Summary
- updates the release interop TypeScript reference seller pin from the stale beta.12 commit to the known-good beta.17 release commit
- updates the workflow summary note to match the new pin

## Root cause
The TypeScript seller in current main already passes the rc4 storyboard. The release warning came from the workflow matrix checking out an older pinned TypeScript reference seller commit that still fails two media-buy storyboard assertions under the current SDK runner.

## Validation
- ADCP_SKIP_NPM_CI=1 ADCP_SKIP_BUILD=1 ./scripts/ci/run_storyboard_reference_seller.sh
- npm run lint:workflows
- git diff --check
- npx commitlint --from origin/main --to HEAD --verbose
- pre-push typecheck/build