### PR TITLE
chore: sync rc4 lockfile metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/sdk",
-  "version": "8.1.0-beta.16",
+  "version": "8.1.0-beta.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/sdk",
-      "version": "8.1.0-beta.16",
+      "version": "8.1.0-beta.17",
       "license": "Apache-2.0",
       "workspaces": [
         ".",
@@ -7356,7 +7356,7 @@
       "version": "6.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adcp/sdk": "^8.1.0-beta.16"
+        "@adcp/sdk": "^8.1.0-beta.17"
       },
       "bin": {
         "adcp": "bin/adcp.js"


### PR DESCRIPTION
Updates package-lock metadata to match the rc4 package version already present in package.json. This keeps the root package and bundled CLI workspace dependency aligned at 8.1.0-beta.17. The root cause was a stale lockfile after the AdCP 3.1.0-rc.4 version bump. Validated with sync-version, schemas:ensure, build:lib, targeted schema/version tests, and the pre-push typecheck/build hook.