### PR TITLE
chore: sync beta 18 lockfile metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/sdk",
-  "version": "8.1.0-beta.17",
+  "version": "8.1.0-beta.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/sdk",
-      "version": "8.1.0-beta.17",
+      "version": "8.1.0-beta.18",
       "license": "Apache-2.0",
       "workspaces": [
         ".",
@@ -7356,7 +7356,7 @@
       "version": "6.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adcp/sdk": "^8.1.0-beta.17"
+        "@adcp/sdk": "^8.1.0-beta.18"
       },
       "bin": {
         "adcp": "bin/adcp.js"


### PR DESCRIPTION
## Summary

Syncs `package-lock.json` metadata to the published `8.1.0-beta.18` package version.

## Validation

Pre-push validation passed, including TypeScript typecheck and library build.
