### PR TITLE
fix(server): avoid MCP tasks_get warning

### DIFF
--- a/.changeset/quiet-tasks-get-mcp.md
+++ b/.changeset/quiet-tasks-get-mcp.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Avoid advertising the slash-based `tasks/get` compatibility alias as an MCP tool and poll MCP agents through the `tasks_get` alias. A2A callers and agent cards keep the spec `tasks/get` skill; the A2A adapter maps it to the server's `tasks_get` handler at lookup time.

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -1382,9 +1382,8 @@ export class TaskExecutor {
   ): Promise<TaskStatusPollResult> {
     // AdCP `tasks/get` is the cross-protocol work-status interface
     // (`schemas/cache/<v>/bundled/core/tasks-get-{request,response}.json`).
-    // Dispatched as a buyer-callable tool over the agent's transport
-    // — `ProtocolClient.callTool` selects MCP `tools/call` or A2A
-    // `message/send` per `agent.protocol`.
+    // MCP tool names cannot contain `/`, so MCP servers advertise the
+    // SDK-owned `tasks_get` alias; A2A continues to use the spec slash name.
     //
     // The previous implementation tried MCP's `experimental.tasks.getTask`
     // first for MCP agents and fell through to the AdCP tool path on
@@ -1392,7 +1391,7 @@ export class TaskExecutor {
     // lifecycle (MCP analog of A2A `Task.state`) — not AdCP work
     // lifecycle. For submitted-arm polling we need work status; the
     // two interfaces are not substitutes, so we always use the AdCP
-    // tool here. MCP sellers that haven't registered `tasks/get` as
+    // tool here. MCP sellers that haven't registered `tasks_get` as
     // an AdCP tool will surface a tool-not-found error rather than
     // silently polling the wrong lifecycle.
     //
@@ -1407,9 +1406,10 @@ export class TaskExecutor {
     // sellers ignore the unknown request field; the response mapper
     // falls back to the informal `additionalProperties` passthrough
     // for those.
+    const toolName = agent.protocol === 'mcp' ? 'tasks_get' : 'tasks/get';
     const response = (await ProtocolClient.callTool(
       agent,
-      'tasks/get',
+      toolName,
       { task_id: taskId, include_result: true },
       {
         serverVersion: this.lastKnownServerVersion,

--- a/src/lib/server/a2a-adapter.ts
+++ b/src/lib/server/a2a-adapter.ts
@@ -417,19 +417,45 @@ class AdcpA2AAgentExecutor implements AgentExecutor {
         return;
       }
 
-      let response: McpToolResponse;
+      let response: McpToolResponse | undefined;
+      const toolNames = a2aSkillToServerToolNames(invocation.skill);
+      let invokedToolName: string | undefined;
       try {
-        response = await this.server.invoke({
-          toolName: invocation.skill,
-          args: invocation.input,
-          ...(authInfo && { authInfo }),
-        });
+        for (const toolName of toolNames) {
+          try {
+            invokedToolName = toolName;
+            response = await this.server.invoke({
+              // Platform servers register `tasks_get`; older/custom A2A
+              // fixtures may still register the slash name directly.
+              toolName,
+              args: invocation.input,
+              ...(authInfo && { authInfo }),
+            });
+            break;
+          } catch (err) {
+            if (toolName === 'tasks_get' && invocation.skill === 'tasks/get' && isToolNotRegistered(err, toolName)) {
+              continue;
+            }
+            throw err;
+          }
+        }
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        this.logger.error('A2A adapter: handler invocation threw', { toolName: invocation.skill, error: message });
+        this.logger.error('A2A adapter: handler invocation threw', {
+          toolName: invokedToolName ?? invocation.skill,
+          requestedToolName: invocation.skill,
+          error: message,
+        });
         this.emitFailure(eventBus, taskId, contextId, {
           reason: 'HANDLER_THREW',
           message,
+        });
+        return;
+      }
+      if (response === undefined) {
+        this.emitFailure(eventBus, taskId, contextId, {
+          reason: 'HANDLER_THREW',
+          message: `No handler registered for ${invocation.skill}`,
         });
         return;
       }
@@ -576,6 +602,14 @@ class AdcpA2AAgentExecutor implements AgentExecutor {
   }
 }
 
+function isToolNotRegistered(err: unknown, toolName: string): boolean {
+  return err instanceof Error && err.message.includes(`tool "${toolName}" is not registered`);
+}
+
+function a2aSkillToServerToolNames(skill: string): string[] {
+  return skill === 'tasks/get' ? ['tasks_get', 'tasks/get'] : [skill];
+}
+
 // ---------------------------------------------------------------------------
 // Agent card
 // ---------------------------------------------------------------------------
@@ -591,12 +625,17 @@ const PUBLIC_AGENT_CARD_EXCLUDED_SKILLS = new Set(['get_adcp_capabilities', 'com
  * are expected to enrich via `agentCard.skills` in production.
  */
 function deriveSkills(toolNames: string[]): AgentSkill[] {
-  return toolNames.map(name => ({
+  const publicNames = new Set(toolNames.map(toA2ASkillName));
+  return [...publicNames].map(name => ({
     id: name,
     name,
     description: `AdCP tool: ${name}. Send { skill: "${name}", input: { ... } } as a DataPart.`,
     tags: ['adcp'],
   }));
+}
+
+function toA2ASkillName(toolName: string): string {
+  return toolName === 'tasks_get' ? 'tasks/get' : toolName;
 }
 
 function listRegisteredTools(server: AdcpServer): string[] {

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -1404,20 +1404,12 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
       mergeOpts
     ),
     customTools: (() => {
-      // Register the AdCP `tasks/get` work-status interface under BOTH names:
-      //   - `tasks/get` (slash) — the spec name; what `TaskExecutor.getTaskStatus`
-      //     calls (`src/lib/core/TaskExecutor.ts:1374`). The buyer-side SDK
-      //     uses the spec name verbatim because A2A's transport-native
-      //     `tasks/get` method shares it.
-      //   - `tasks_get`  (underscore) — the snake-case substitute kept for
-      //     adopters who built buyer code against the underscore name in
-      //     pre-6.8 SDKs. Native MCP method dispatch (where `tasks/get`
-      //     lands as a transport method, not a tool) is tracked for v6.1.
-      // Same handler factory; second registration is a no-op alias.
+      // MCP tool names cannot contain `/`, so expose the AdCP work-status
+      // polling surface under the MCP-safe `tasks_get` alias only. A2A keeps
+      // using the transport-native `tasks/get` method name on its own path.
       const tasksGetTool = buildTasksGetTool(platform, taskRegistry, platform.agentRegistry, fwLogger);
       return {
         ...opts.customTools,
-        'tasks/get': tasksGetTool,
         tasks_get: tasksGetTool,
       };
     })(),
@@ -1954,8 +1946,6 @@ function buildTasksGetTool<P extends DecisioningPlatform<any, any>>(
       args: { task_id: string; account?: { account_id?: string } },
       extra: { authInfo?: ResolvedAuthInfo }
     ) => {
-      // eslint-disable-next-line no-console
-      console.log('[trace.tasks_get]', JSON.stringify({ args, hasAuth: !!extra?.authInfo }));
       const ref = args.account;
       // Resolve the buyer agent (when an `agentRegistry` is configured) so
       // adopters' `accounts.resolve` impl sees `ctx.agent` — same contract as

--- a/test/lib/async-patterns-master.test.js
+++ b/test/lib/async-patterns-master.test.js
@@ -167,7 +167,7 @@ describe.skip('TaskExecutor Async Patterns - Master Test Suite', () => {
         if (taskName === 'continue_task') {
           // After input, go to working state
           return { status: 'working' };
-        } else if (taskName === 'tasks/get') {
+        } else if (taskName === 'tasks/get' || taskName === 'tasks_get') {
           // After working, complete
           return {
             task: {

--- a/test/lib/error-scenarios.test.js
+++ b/test/lib/error-scenarios.test.js
@@ -58,7 +58,7 @@ describe('TaskExecutor Error Scenarios', { skip: process.env.CI ? 'Slow tests - 
       // TaskExecutor now returns 'working' status immediately as a valid intermediate state
       // Callers can use taskId to poll for completion or set up webhooks
       ProtocolClient.callTool = mock.fn(async (agent, taskName) => {
-        if (taskName === 'tasks/get') {
+        if (taskName === 'tasks/get' || taskName === 'tasks_get') {
           return { task: { status: ADCP_STATUS.WORKING } };
         } else {
           return { status: ADCP_STATUS.WORKING };
@@ -110,7 +110,7 @@ describe('TaskExecutor Error Scenarios', { skip: process.env.CI ? 'Slow tests - 
 
       let pollCount = 0;
       ProtocolClient.callTool = mock.fn(async (agent, taskName) => {
-        if (taskName === 'tasks/get') {
+        if (taskName === 'tasks/get' || taskName === 'tasks_get') {
           pollCount++;
           // After a few polls, complete to avoid infinite polling
           if (pollCount > 3) {

--- a/test/lib/idempotency-client.test.js
+++ b/test/lib/idempotency-client.test.js
@@ -142,7 +142,7 @@ describe('TaskExecutor surfaces response adcp_version on result metadata', () =>
     const capture = [];
     const restore = stubProtocolClient({
       response: toolName => {
-        if (toolName === 'tasks/get') {
+        if (toolName === 'tasks/get' || toolName === 'tasks_get') {
           return {
             structuredContent: {
               status: 'completed',
@@ -187,7 +187,7 @@ describe('TaskExecutor surfaces response adcp_version on result metadata', () =>
     const capture = [];
     const restore = stubProtocolClient({
       response: toolName => {
-        if (toolName === 'tasks/get') {
+        if (toolName === 'tasks/get' || toolName === 'tasks_get') {
           return {
             task: {
               status: 'completed',

--- a/test/lib/protocol-response-parser-a2a-submitted.test.js
+++ b/test/lib/protocol-response-parser-a2a-submitted.test.js
@@ -525,7 +525,7 @@ describe('TaskExecutor — A2A update_media_buy canceled domain payload (#2009)'
 
   test('A2A wrapped tasks/get adcp_version flows through submitted waitForCompletion metadata', async () => {
     ProtocolClient.callTool = mock.fn(async (_agent, taskName) => {
-      if (taskName === 'tasks/get') {
+      if (taskName === 'tasks/get' || taskName === 'tasks_get') {
         return a2aWrappedCompletedArtifactData({
           status: 'completed',
           task_id: 'tk_poll_a2a',

--- a/test/lib/task-executor-async-patterns.test.js
+++ b/test/lib/task-executor-async-patterns.test.js
@@ -349,7 +349,7 @@ describe(
         };
 
         ProtocolClient.callTool = mock.fn(async (agent, taskName, params) => {
-          if (taskName === 'tasks/get') {
+          if (taskName === 'tasks/get' || taskName === 'tasks_get') {
             return mockTaskStatus;
           } else {
             return mockSubmitResponse;

--- a/test/lib/task-executor-mocking-strategy.test.js
+++ b/test/lib/task-executor-mocking-strategy.test.js
@@ -74,7 +74,7 @@ describe('TaskExecutor Mocking Strategies', { skip: process.env.CI ? 'Slow tests
       };
 
       ProtocolClient.callTool = mock.fn(async (agent, taskName, params) => {
-        if (taskName === 'tasks/get') {
+        if (taskName === 'tasks/get' || taskName === 'tasks_get') {
           // First poll - still working, then completed
           return {
             task: webhookReceived ? { status: 'completed', result: webhookData.result } : { status: 'working' },
@@ -117,7 +117,7 @@ describe('TaskExecutor Mocking Strategies', { skip: process.env.CI ? 'Slow tests
 
       let pollCount = 0;
       ProtocolClient.callTool = mock.fn(async (agent, taskName, params) => {
-        if (taskName === 'tasks/get') {
+        if (taskName === 'tasks/get' || taskName === 'tasks_get') {
           pollCount++;
           // Return working a few times then complete to avoid infinite loop
           if (pollCount > 3) {
@@ -340,7 +340,7 @@ describe('TaskExecutor Mocking Strategies', { skip: process.env.CI ? 'Slow tests
       const pollStates = ['working', 'working', 'completed'];
 
       ProtocolClient.callTool = mock.fn(async (agent, taskName, params) => {
-        if (taskName === 'tasks/get') {
+        if (taskName === 'tasks/get' || taskName === 'tasks_get') {
           const state = pollStates[Math.min(pollCount++, pollStates.length - 1)];
           return {
             task:
@@ -385,7 +385,7 @@ describe('TaskExecutor Mocking Strategies', { skip: process.env.CI ? 'Slow tests
       let quickPollCount = 0;
 
       ProtocolClient.callTool = mock.fn(async (agent, taskName) => {
-        if (taskName === 'tasks/get') {
+        if (taskName === 'tasks/get' || taskName === 'tasks_get') {
           quickPollCount++;
           return {
             task:
@@ -432,7 +432,7 @@ describe('TaskExecutor Mocking Strategies', { skip: process.env.CI ? 'Slow tests
           throw new Error('Network timeout');
         }
 
-        if (taskName === 'tasks/get') {
+        if (taskName === 'tasks/get' || taskName === 'tasks_get') {
           return {
             task: {
               status: 'completed',
@@ -560,7 +560,7 @@ describe('TaskExecutor Mocking Strategies', { skip: process.env.CI ? 'Slow tests
       let stepTransitionScheduled = false;
 
       ProtocolClient.callTool = mock.fn(async (agent, taskName) => {
-        if (taskName === 'tasks/get') {
+        if (taskName === 'tasks/get' || taskName === 'tasks_get') {
           // Simulate realistic timing - only schedule one transition per step
           const currentStep = Math.min(stepIndex, realWorldSteps.length - 1);
           const step = realWorldSteps[currentStep];

--- a/test/lib/type-safety-verification.test.js
+++ b/test/lib/type-safety-verification.test.js
@@ -420,7 +420,7 @@ describe(
         };
 
         ProtocolClient.callTool = mock.fn(async (agent, taskName, params) => {
-          if (taskName === 'tasks/get') {
+          if (taskName === 'tasks/get' || taskName === 'tasks_get') {
             const processingResult = {
               processed: true,
               itemsCount: 1000,
@@ -525,7 +525,7 @@ describe(
         };
 
         ProtocolClient.callTool = mock.fn(async (agent, taskName) => {
-          if (taskName === 'tasks/get') {
+          if (taskName === 'tasks/get' || taskName === 'tasks_get') {
             pollCount++;
             return {
               task:

--- a/test/server-a2a-adapter.test.js
+++ b/test/server-a2a-adapter.test.js
@@ -210,6 +210,8 @@ describe('createA2AAdapter', () => {
       const card = await a2a.getAgentCard();
       const skillIds = card.skills.map(s => s.id);
       assert.ok(skillIds.includes('get_products'), 'ordinary AdCP tools remain advertised');
+      assert.ok(skillIds.includes('tasks/get'), 'A2A card advertises the spec slash task polling skill');
+      assert.ok(!skillIds.includes('tasks_get'), 'MCP-safe task polling alias is not advertised as an A2A skill');
       assert.ok(!skillIds.includes('comply_test_controller'), 'compliance controller is not public-card discoverable');
       assert.ok(!skillIds.includes('get_adcp_capabilities'), 'capabilities tool excluded from public card');
     });

--- a/test/server-a2a-submitted-end-to-end.test.js
+++ b/test/server-a2a-submitted-end-to-end.test.js
@@ -25,6 +25,7 @@ const { z } = require('zod');
 
 const { createAdcpServer: _createAdcpServer } = require('../dist/lib/server/create-adcp-server');
 const { createA2AAdapter } = require('../dist/lib/server/a2a-adapter');
+const { createAdcpServerFromPlatform } = require('../dist/lib/server/decisioning/runtime/from-platform');
 const { InMemoryStateStore } = require('../dist/lib/server/state-store');
 const { TaskExecutor } = require('../dist/lib/index');
 
@@ -38,6 +39,10 @@ function createAdcpServer(config) {
 
 async function startA2aFixture(handlers) {
   const adcp = createAdcpServer(handlers);
+  return startA2aServer(adcp);
+}
+
+async function startA2aServer(adcp) {
   const app = express();
   app.use(express.json());
   const server = app.listen(0);
@@ -69,7 +74,7 @@ describe('A2A submitted → completed end-to-end (#966 + #967 + #973)', () => {
     const SELLER_MEDIA_BUY_ID = 'mb_completed_42';
     let pollCount = 0;
     let observedPollParam;
-    let observedPollSkill;
+    let observedPollToolName;
 
     const fixture = await startA2aFixture({
       mediaBuy: {
@@ -79,16 +84,19 @@ describe('A2A submitted → completed end-to-end (#966 + #967 + #973)', () => {
           message: 'IO signature pending',
         }),
       },
-      // Custom AdCP `tasks/get` tool dispatched as a buyer-callable
-      // tool over `message/send`. First two polls return working;
-      // third returns completed with the result data. Keeping this on
-      // the fixture server avoids process-global ProtocolClient monkey
-      // patches, which are fragile in the broad parallel test runner.
+      // Custom AdCP task-polling tool dispatched as a buyer-callable
+      // A2A `tasks/get` skill over `message/send`. The server registers
+      // the MCP-safe handler name, matching framework servers; the A2A
+      // adapter maps the slash skill to this handler at lookup time.
+      // First two polls return working; third returns completed with
+      // the result data. Keeping this on the fixture server avoids
+      // process-global ProtocolClient monkey patches, which are fragile
+      // in the broad parallel test runner.
       customTools: {
-        'tasks/get': {
+        tasks_get: {
           inputSchema: { task_id: z.string() },
           handler: async params => {
-            observedPollSkill = 'tasks/get';
+            observedPollToolName = 'tasks_get';
             observedPollParam = params;
             pollCount += 1;
             const response =
@@ -126,7 +134,7 @@ describe('A2A submitted → completed end-to-end (#966 + #967 + #973)', () => {
         'create_media_buy',
         {
           brand: { brand_id: 'b' },
-          account: { account_id: 'a' },
+          account: { account_id: 'acc_1' },
           start_time: '2026-01-01T00:00:00Z',
           end_time: '2026-02-01T00:00:00Z',
         }
@@ -145,9 +153,10 @@ describe('A2A submitted → completed end-to-end (#966 + #967 + #973)', () => {
       // Poll through to completion.
       const completion = await submittedResult.submitted.waitForCompletion(5);
 
-      // (4): poll dispatched `tasks/get` with snake_case `task_id`
-      // carrying the AdCP handle.
-      assert.strictEqual(observedPollSkill, 'tasks/get');
+      // (4): poll carried the AdCP handle as snake_case `task_id`;
+      // the A2A adapter routed the slash skill to the MCP-safe server
+      // handler name.
+      assert.strictEqual(observedPollToolName, 'tasks_get');
       assert.strictEqual(
         observedPollParam.task_id,
         SELLER_TASK_ID,
@@ -160,6 +169,73 @@ describe('A2A submitted → completed end-to-end (#966 + #967 + #973)', () => {
       assert.strictEqual(completion.status, 'completed');
       assert.deepStrictEqual(completion.data, { media_buy_id: SELLER_MEDIA_BUY_ID, packages: [] });
       assert.ok(pollCount >= 3, `expected ≥3 polls (working/working/completed), got ${pollCount}`);
+    } finally {
+      await fixture.close();
+    }
+  });
+
+  it('polls createAdcpServerFromPlatform tasks through the A2A slash skill', async () => {
+    const SELLER_MEDIA_BUY_ID = 'mb_platform_completed_42';
+    let createCalled = false;
+
+    const platform = {
+      capabilities: {
+        specialisms: ['sales-non-guaranteed'],
+        creative_agents: [],
+        channels: ['display'],
+        pricingModels: ['cpm'],
+        config: {},
+      },
+      accounts: {
+        resolve: async ref => ({
+          id: ref?.account_id ?? 'acc_1',
+          metadata: {},
+          authInfo: { kind: 'api_key' },
+        }),
+      },
+      sales: {
+        getProducts: async () => ({ products: [], cache_scope: 'account' }),
+        createMediaBuy: async (_req, ctx) => {
+          createCalled = true;
+          return ctx.handoffToTask(async () => ({
+            media_buy_id: SELLER_MEDIA_BUY_ID,
+            packages: [],
+          }));
+        },
+        updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
+        syncCreatives: async () => [],
+        getMediaBuyDelivery: async () => ({ media_buys: [] }),
+      },
+    };
+
+    const fixture = await startA2aServer(
+      createAdcpServerFromPlatform(platform, {
+        name: 'platform-a2a-seller',
+        version: '1.0.0',
+        validation: { requests: 'off', responses: 'off' },
+      })
+    );
+
+    try {
+      const executor = new TaskExecutor({ pollingInterval: 5 });
+      const submittedResult = await executor.executeTask(
+        { id: 't', name: 't', agent_uri: fixture.url, protocol: 'a2a' },
+        'create_media_buy',
+        {
+          brand: { brand_id: 'b' },
+          account: { account_id: 'acc_1' },
+          start_time: '2026-01-01T00:00:00Z',
+          end_time: '2026-02-01T00:00:00Z',
+        }
+      );
+
+      assert.strictEqual(createCalled, true);
+      assert.strictEqual(submittedResult.status, 'submitted');
+
+      const completion = await submittedResult.submitted.waitForCompletion(5);
+      assert.strictEqual(completion.success, true);
+      assert.strictEqual(completion.status, 'completed');
+      assert.deepStrictEqual(completion.data, { media_buy_id: SELLER_MEDIA_BUY_ID, packages: [] });
     } finally {
       await fixture.close();
     }

--- a/test/server-decisioning-from-platform.test.js
+++ b/test/server-decisioning-from-platform.test.js
@@ -3126,6 +3126,21 @@ describe('tasks_get wire tool (B9)', () => {
     return result.structuredContent.task_id;
   }
 
+  it('advertises only the MCP-safe tasks_get tool name', async () => {
+    const server = createAdcpServerFromPlatform(
+      buildHitlPlatform(async () => ({ media_buy_id: 'mb_42' })),
+      {
+        name: 'p',
+        version: '0.0.1',
+        validation: { requests: 'off', responses: 'off' },
+      }
+    );
+    const listed = await server.dispatchTestRequest({ method: 'tools/list' });
+    const toolNames = listed.tools.map(tool => tool.name);
+    assert.ok(toolNames.includes('tasks_get'), 'tasks_get should be advertised');
+    assert.ok(!toolNames.includes('tasks/get'), 'slash alias should not be registered as an MCP tool');
+  });
+
   it('returns spec-flat lifecycle shape for a completed task', async () => {
     const server = createAdcpServerFromPlatform(
       buildHitlPlatform(async () => ({ media_buy_id: 'mb_42', status: 'active' })),

--- a/test/server-task-id-plumbing.test.js
+++ b/test/server-task-id-plumbing.test.js
@@ -43,7 +43,7 @@ describe('SubmittedContinuation: server-assigned task_id plumbing (#966)', () =>
     const SERVER_TASK_ID = 'tk_seller_assigned_42';
 
     ProtocolClient.callTool = mock.fn(async (_agent, taskName, _params) => {
-      if (taskName === 'tasks/get') {
+      if (taskName === 'tasks/get' || taskName === 'tasks_get') {
         return { task: { status: 'completed', result: { ok: true } } };
       }
       // Initial submitted-arm response carries the seller's task handle.
@@ -67,7 +67,7 @@ describe('SubmittedContinuation: server-assigned task_id plumbing (#966)', () =>
     const polledIds = [];
 
     ProtocolClient.callTool = mock.fn(async (_agent, taskName, params) => {
-      if (taskName === 'tasks/get') {
+      if (taskName === 'tasks/get' || taskName === 'tasks_get') {
         // Capture the id the SDK polls with — that's the regression
         // surface. Pre-fix it was the runner-side UUID; post-fix it
         // must be the seller's task handle.
@@ -95,7 +95,7 @@ describe('SubmittedContinuation: server-assigned task_id plumbing (#966)', () =>
     let trackedId;
 
     ProtocolClient.callTool = mock.fn(async (_agent, taskName, params) => {
-      if (taskName === 'tasks/get') {
+      if (taskName === 'tasks/get' || taskName === 'tasks_get') {
         trackedId = params?.taskId ?? params?.task_id;
         return { task: { status: 'working' } };
       }
@@ -116,7 +116,7 @@ describe('SubmittedContinuation: server-assigned task_id plumbing (#966)', () =>
     // so operators grepping for "task_id" / "spec violation" can
     // pinpoint the offending seller call.
     ProtocolClient.callTool = mock.fn(async (_agent, taskName) => {
-      if (taskName === 'tasks/get') {
+      if (taskName === 'tasks/get' || taskName === 'tasks_get') {
         return { task: { status: 'completed', result: {} } };
       }
       return { status: 'submitted' }; // no task_id
@@ -149,7 +149,7 @@ describe('SubmittedContinuation: server-assigned task_id plumbing (#966)', () =>
     const FLAT_TASK_ID = 'flat-task-id-should-be-ignored';
 
     ProtocolClient.callTool = mock.fn(async (_agent, taskName) => {
-      if (taskName === 'tasks/get') {
+      if (taskName === 'tasks/get' || taskName === 'tasks_get') {
         return { task: { status: 'completed', result: {} } };
       }
       // The wrapped envelope branch: `result.kind === 'task'` wins
@@ -178,7 +178,7 @@ describe('SubmittedContinuation: server-assigned task_id plumbing (#966)', () =>
     const MCP_TASK_ID = 'mcp-structured-content-task-id';
 
     ProtocolClient.callTool = mock.fn(async (_agent, taskName) => {
-      if (taskName === 'tasks/get') {
+      if (taskName === 'tasks/get' || taskName === 'tasks_get') {
         return { task: { status: 'completed', result: {} } };
       }
       return { structuredContent: { status: 'submitted', task_id: MCP_TASK_ID } };
@@ -202,7 +202,7 @@ describe('SubmittedContinuation: server-assigned task_id plumbing (#966)', () =>
     let pollCount = 0;
 
     ProtocolClient.callTool = mock.fn(async (_agent, taskName, params) => {
-      if (taskName === 'tasks/get') {
+      if (taskName === 'tasks/get' || taskName === 'tasks_get') {
         polledIds.push(params?.taskId ?? params?.task_id);
         const state = sequence[Math.min(pollCount++, sequence.length - 1)];
         return state === 'completed'
@@ -235,7 +235,7 @@ describe('SubmittedContinuation: server-assigned task_id plumbing (#966)', () =>
     let nextSeller = SERVER_A;
 
     ProtocolClient.callTool = mock.fn(async (_agent, taskName, params) => {
-      if (taskName === 'tasks/get') {
+      if (taskName === 'tasks/get' || taskName === 'tasks_get') {
         const id = params?.taskId ?? params?.task_id;
         if (id === SERVER_A) polledFor.A.push(id);
         if (id === SERVER_B) polledFor.B.push(id);
@@ -289,7 +289,7 @@ describe('SubmittedContinuation: server-assigned task_id plumbing (#966)', () =>
     };
 
     ProtocolClient.callTool = mock.fn(async (_agent, taskName) => {
-      if (taskName === 'tasks/get') {
+      if (taskName === 'tasks/get' || taskName === 'tasks_get') {
         return { task: { status: 'working' } };
       }
       return { status: 'submitted', task_id: SERVER_TASK_ID };
@@ -323,7 +323,7 @@ describe('SubmittedContinuation: server-assigned task_id plumbing (#966)', () =>
     const SERVER_TASK_ID = 'tk_error_path';
 
     ProtocolClient.callTool = mock.fn(async (_agent, taskName) => {
-      if (taskName === 'tasks/get') {
+      if (taskName === 'tasks/get' || taskName === 'tasks_get') {
         // Returns a failed task — within the poll loop's normal
         // failed-status handling path.
         return { task: { status: 'failed', error: 'simulated seller failure' } };

--- a/test/server-tasks-get-spec-shape.test.js
+++ b/test/server-tasks-get-spec-shape.test.js
@@ -1,7 +1,7 @@
 // Regression test for adcp-client#967.
 //
 // Anchors the contract that `getTaskStatus` dispatches the AdCP
-// `tasks/get` tool with snake_case `task_id` per AdCP 3.0
+// work-status polling surface with snake_case `task_id` per AdCP 3.0
 // (`schemas/cache/3.0.0/bundled/core/tasks-get-request.json`) and
 // maps the spec's flat snake_case response shape
 // (`schemas/cache/3.0.0/bundled/core/tasks-get-response.json`) to
@@ -47,12 +47,14 @@ describe('getTaskStatus: AdCP tasks/get spec-shape mapping (#967)', () => {
     if (originalCallTool) ProtocolClient.callTool = originalCallTool;
   });
 
-  test('dispatches tasks/get with snake_case task_id (not camelCase taskId)', async () => {
+  test('dispatches MCP polling as tasks_get with snake_case task_id (not camelCase taskId)', async () => {
     const SERVER_TASK_ID = 'tk_snake_case_test';
     let observedParams;
+    let observedTaskName;
 
     ProtocolClient.callTool = mock.fn(async (_agent, taskName, params) => {
-      if (taskName === 'tasks/get') {
+      if (taskName === 'tasks/get' || taskName === 'tasks_get') {
+        observedTaskName = taskName;
         observedParams = params;
         // AdCP 3.0 spec response (flat snake_case)
         return {
@@ -71,9 +73,36 @@ describe('getTaskStatus: AdCP tasks/get spec-shape mapping (#967)', () => {
     const result = await executor.executeTask(mockAgent, 'pollSnakeCaseTest', {});
     await result.submitted.waitForCompletion(5);
 
-    assert.ok(observedParams, 'tasks/get was dispatched');
+    assert.strictEqual(observedTaskName, 'tasks_get', 'MCP polling must use the MCP-safe tasks_get tool name');
+    assert.ok(observedParams, 'tasks_get was dispatched');
     assert.strictEqual(observedParams.task_id, SERVER_TASK_ID, 'request must use snake_case task_id per AdCP 3.0 spec');
     assert.strictEqual(observedParams.taskId, undefined, 'request must NOT include legacy camelCase taskId');
+  });
+
+  test('keeps A2A polling on the spec tasks/get name', async () => {
+    const SERVER_TASK_ID = 'tk_a2a_slash_name';
+    let observedTaskName;
+
+    ProtocolClient.callTool = mock.fn(async (_agent, taskName) => {
+      if (taskName === 'tasks/get' || taskName === 'tasks_get') {
+        observedTaskName = taskName;
+        return {
+          task_id: SERVER_TASK_ID,
+          task_type: 'create_media_buy',
+          protocol: 'media-buy',
+          status: 'completed',
+          created_at: '2026-04-25T10:00:00Z',
+          updated_at: '2026-04-25T10:05:00Z',
+        };
+      }
+      return { status: 'submitted', task_id: SERVER_TASK_ID };
+    });
+
+    const executor = new TaskExecutor({ pollingInterval: 5 });
+    const result = await executor.executeTask({ ...mockAgent, protocol: 'a2a' }, 'pollA2aNameTest', {});
+    await result.submitted.waitForCompletion(5);
+
+    assert.strictEqual(observedTaskName, 'tasks/get', 'A2A polling must keep the spec slash task name');
   });
 
   test('maps the AdCP-spec flat response shape correctly', async () => {
@@ -82,7 +111,7 @@ describe('getTaskStatus: AdCP tasks/get spec-shape mapping (#967)', () => {
     const UPDATED = '2026-04-25T10:05:30Z';
 
     ProtocolClient.callTool = mock.fn(async (_agent, taskName) => {
-      if (taskName === 'tasks/get') {
+      if (taskName === 'tasks/get' || taskName === 'tasks_get') {
         return {
           task_id: SERVER_TASK_ID,
           task_type: 'create_media_buy',
@@ -115,7 +144,7 @@ describe('getTaskStatus: AdCP tasks/get spec-shape mapping (#967)', () => {
     const COMPLETION_DATA = { media_buy_id: 'mb_42', packages: [] };
 
     ProtocolClient.callTool = mock.fn(async (_agent, taskName) => {
-      if (taskName === 'tasks/get') {
+      if (taskName === 'tasks/get' || taskName === 'tasks_get') {
         return {
           task_id: SERVER_TASK_ID,
           task_type: 'create_media_buy',
@@ -140,7 +169,7 @@ describe('getTaskStatus: AdCP tasks/get spec-shape mapping (#967)', () => {
     const SERVER_TASK_ID = 'tk_error_mapping';
 
     ProtocolClient.callTool = mock.fn(async (_agent, taskName) => {
-      if (taskName === 'tasks/get') {
+      if (taskName === 'tasks/get' || taskName === 'tasks_get') {
         return {
           task_id: SERVER_TASK_ID,
           task_type: 'create_media_buy',
@@ -169,7 +198,7 @@ describe('getTaskStatus: AdCP tasks/get spec-shape mapping (#967)', () => {
     const SERVER_TASK_ID = 'tk_canceled_test';
 
     ProtocolClient.callTool = mock.fn(async (_agent, taskName) => {
-      if (taskName === 'tasks/get') {
+      if (taskName === 'tasks/get' || taskName === 'tasks_get') {
         return {
           task_id: SERVER_TASK_ID,
           task_type: 'create_media_buy',
@@ -201,7 +230,7 @@ describe('getTaskStatus: AdCP tasks/get spec-shape mapping (#967)', () => {
     const SERVER_TASK_ID = 'tk_mcp_wrapped';
 
     ProtocolClient.callTool = mock.fn(async (_agent, taskName) => {
-      if (taskName === 'tasks/get') {
+      if (taskName === 'tasks/get' || taskName === 'tasks_get') {
         return {
           structuredContent: {
             task_id: SERVER_TASK_ID,
@@ -232,7 +261,7 @@ describe('getTaskStatus: AdCP tasks/get spec-shape mapping (#967)', () => {
     const SERVER_TASK_ID = 'tk_a2a_wrapped';
 
     ProtocolClient.callTool = mock.fn(async (_agent, taskName) => {
-      if (taskName === 'tasks/get') {
+      if (taskName === 'tasks/get' || taskName === 'tasks_get') {
         return {
           jsonrpc: '2.0',
           id: 1,
@@ -288,7 +317,7 @@ describe('getTaskStatus: AdCP tasks/get spec-shape mapping (#967)', () => {
     let observedParams;
 
     ProtocolClient.callTool = mock.fn(async (_agent, taskName, params) => {
-      if (taskName === 'tasks/get') {
+      if (taskName === 'tasks/get' || taskName === 'tasks_get') {
         observedParams = params;
         return {
           task_id: SERVER_TASK_ID,
@@ -321,7 +350,7 @@ describe('getTaskStatus: AdCP tasks/get spec-shape mapping (#967)', () => {
     const SERVER_TASK_ID = 'tk_legacy_shape';
 
     ProtocolClient.callTool = mock.fn(async (_agent, taskName) => {
-      if (taskName === 'tasks/get') {
+      if (taskName === 'tasks/get' || taskName === 'tasks_get') {
         // Legacy nested wrapper with camelCase TaskInfo fields
         return {
           task: {
@@ -364,7 +393,7 @@ describe('getTaskStatus: AdCP tasks/get spec-shape mapping (#967)', () => {
 
     try {
       ProtocolClient.callTool = mock.fn(async (_agent, taskName) => {
-        if (taskName === 'tasks/get') {
+        if (taskName === 'tasks/get' || taskName === 'tasks_get') {
           return {
             task_id: 'tk_no_experimental',
             task_type: 'create_media_buy',


### PR DESCRIPTION
## Summary
- stop registering the slash-based `tasks/get` alias as an MCP tool
- make MCP submitted-task polling call the existing `tasks_get` tool while preserving `tasks/get` for A2A
- remove the bare `[trace.tasks_get]` production poll log
- add regression coverage for MCP `tools/list` and protocol-specific polling names

## Validation
- npm run build:lib
- focused node tests for task polling/server paths
- npm run ci:quick (format/typecheck/build passed; first fast-suite run exited nonzero with 0 failures and 2 canceled tests)
- npm run test:node:fast (rerun passed: 11,550 pass, 8 skipped, 0 canceled)
- npm run test:node:slow
- npm test --workspace=packages/eslint-plugin --if-present
- git diff --check
- npx commitlint --from origin/main --to HEAD --verbose