### PR TITLE
ci: add Go reference seller interop row

### DIFF
--- a/.github/workflows/interop-python.yml
+++ b/.github/workflows/interop-python.yml
@@ -98,8 +98,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Add Go here only after adcp-go has shipped a tagged, known-good
-          # reusable harness.
           - language: python
             repository: adcontextprotocol/adcp-client-python
             ref: ${{ inputs.python_ref || '92b1618c3bebfef481f3deef423cbe29d8820de3' }}
@@ -112,6 +110,12 @@ jobs:
             harness: scripts/ci/run_storyboard_reference_seller.sh
             port: 3002
             advisory: true
+          - language: go
+            repository: adcontextprotocol/adcp-go
+            ref: adcp-v2.0.1
+            harness: scripts/ci/run_storyboard_reference_seller.sh
+            port: 3004
+            advisory: false
     env:
       STORYBOARD_RESULT_PATH: ${{ github.workspace }}/storyboard-result-${{ matrix.language }}.json
       SELLER_LOG_PATH: ${{ github.workspace }}/storyboard-seller-${{ matrix.language }}.log
@@ -127,6 +131,12 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.12'
+
+      - name: Setup Go
+        if: matrix.language == 'go'
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.2'
 
       - name: Download SDK runner tarball
         uses: actions/download-artifact@v7


### PR DESCRIPTION
## Summary

- add `adcp-go@adcp-v2.0.1` as the blocking Go row in the reference-seller interop matrix
- install Go only for the Go matrix row via `actions/setup-go@v6`
- remove the stale placeholder comment now that Go has a tagged known-good harness

Refs #1996.

## Validation

- `npx prettier --check .github/workflows/interop-python.yml`
- `git diff --check`
- `npm run build:lib`
- pre-push hook: `npm run format:check`, `npm run typecheck`, library build
- local cross-repo harness using packed `@adcp/sdk@8.1.0-beta.18` + `adcp-go@adcp-v2.0.1`: `Status: passing`, `105 passed / 0 failed / 1 skipped`, `controller_detected: true`

## Notes

The previous Go tag `adcp-v2.0.0` failed the current 8.1 / 3.1 RC runner; `adcp-go#353` tracked that blocker and is now closed after validating `adcp-v2.0.1`.
