### PR TITLE
fix: keep storyboard media buy windows ordered

### DIFF
--- a/.changeset/fix-storyboard-media-buy-window.md
+++ b/.changeset/fix-storyboard-media-buy-window.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Fix the storyboard `create_media_buy` request builder so stale fixture `start_time` values and same-day fixture `end_time` values cannot resolve to an inverted media-buy window.

--- a/src/lib/testing/storyboard/request-builder.ts
+++ b/src/lib/testing/storyboard/request-builder.ts
@@ -92,10 +92,45 @@ const FIXTURE_AWARE_ENRICHERS = new Set<string>([
  */
 const PRODUCT_ID_SENTINELS = new Set(['test-product']);
 const PRICING_OPTION_ID_SENTINELS = new Set(['test-pricing']);
+const DAY_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_MEDIA_BUY_WINDOW_MS = 7 * DAY_MS;
 
 function asNonSentinel(value: unknown, sentinels: Set<string>): string | undefined {
   if (typeof value !== 'string') return undefined;
   return sentinels.has(value) ? undefined : value;
+}
+
+function parseTime(value: string | undefined): number | undefined {
+  if (value === undefined) return undefined;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function resolveMediaBuyWindow(
+  sampleStart: string | undefined,
+  sampleEnd: string | undefined
+): {
+  startTime: string;
+  endTime: string;
+} {
+  const now = Date.now();
+  const defaultStart = new Date(now + DAY_MS).toISOString();
+  const defaultEnd = new Date(now + 8 * DAY_MS).toISOString();
+  const sampleStartMs = parseTime(sampleStart);
+  const sampleEndMs = parseTime(sampleEnd);
+
+  const startTime = sampleStart && sampleStartMs !== undefined && sampleStartMs >= now ? sampleStart : defaultStart;
+  let endTime = sampleEnd && sampleEndMs !== undefined && sampleEndMs >= now ? sampleEnd : defaultEnd;
+
+  if (Date.parse(endTime) <= Date.parse(startTime)) {
+    const sampleDurationMs =
+      sampleStartMs !== undefined && sampleEndMs !== undefined && sampleEndMs > sampleStartMs
+        ? sampleEndMs - sampleStartMs
+        : DEFAULT_MEDIA_BUY_WINDOW_MS;
+    endTime = new Date(Date.parse(startTime) + sampleDurationMs).toISOString();
+  }
+
+  return { startTime, endTime };
 }
 
 /**
@@ -228,21 +263,18 @@ const REQUEST_ENRICHERS: Record<string, RequestEnricher> = {
     const product = selectProduct(context);
     const pricingOption = selectPricingOption(product);
 
-    const now = Date.now();
-    const defaultStart = new Date(now + 24 * 60 * 60 * 1000).toISOString();
-    const defaultEnd = new Date(now + 8 * 24 * 60 * 60 * 1000).toISOString();
-
     // Respect sample_request dates when they're future-dated — needed for
     // storyboards that test replay semantics where initial + replay must
     // produce byte-for-byte identical canonical payloads. Two calls
     // generated 5ms apart with `Date.now()` would hash differently,
     // triggering IDEMPOTENCY_CONFLICT on replay. Stale sample dates
     // (authored before the run date) fall back to the dynamic default.
+    // Resolve the pair together so a stale start and same-day future end
+    // cannot produce start_time > end_time.
     const sampleStart =
       typeof step.sample_request?.start_time === 'string' ? step.sample_request.start_time : undefined;
     const sampleEnd = typeof step.sample_request?.end_time === 'string' ? step.sample_request.end_time : undefined;
-    const startTime = sampleStart && Date.parse(sampleStart) >= now ? sampleStart : defaultStart;
-    const endTime = sampleEnd && Date.parse(sampleEnd) >= now ? sampleEnd : defaultEnd;
+    const { startTime, endTime } = resolveMediaBuyWindow(sampleStart, sampleEnd);
 
     // Merge hand-authored package fields from sample_request (targeting_overlay,
     // measurement_terms, creative_assignments, performance_standards, etc.) so

--- a/test/lib/request-builder.test.js
+++ b/test/lib/request-builder.test.js
@@ -26,6 +26,16 @@ function step(task, overrides = {}) {
   return { id: `test-${task}`, title: `Test ${task}`, task, ...overrides };
 }
 
+function withDateNow(iso, fn) {
+  const original = Date.now;
+  Date.now = () => Date.parse(iso);
+  try {
+    return fn();
+  } finally {
+    Date.now = original;
+  }
+}
+
 describe('Request Builder', () => {
   describe('create_media_buy', () => {
     test('always includes pricing_option_id from discovered context', () => {
@@ -59,6 +69,42 @@ describe('Request Builder', () => {
       assert.ok(result.start_time, 'should have start_time');
       assert.ok(result.end_time, 'should have end_time');
       assert.ok(new Date(result.start_time) < new Date(result.end_time), 'start should be before end');
+    });
+
+    test('preserves future fixture start_time and end_time byte-for-byte', () => {
+      const s = step('create_media_buy', {
+        sample_request: {
+          start_time: FUTURE_START,
+          end_time: FUTURE_END,
+          packages: [{ product_id: 'p1', budget: 1000, pricing_option_id: 'opt' }],
+        },
+      });
+      const result = buildRequest(s, {}, DEFAULT_OPTIONS);
+      assert.strictEqual(result.start_time, FUTURE_START);
+      assert.strictEqual(result.end_time, FUTURE_END);
+    });
+
+    test('keeps create_media_buy window ordered when stale start meets same-day future end (#2143)', () => {
+      withDateNow('2026-05-31T12:28:07.525Z', () => {
+        const sampleStart = '2026-05-01T00:00:00Z';
+        const sampleEnd = '2026-05-31T23:59:59Z';
+        const s = step('create_media_buy', {
+          sample_request: {
+            start_time: sampleStart,
+            end_time: sampleEnd,
+            packages: [{ product_id: 'p1', budget: 1000, pricing_option_id: 'opt' }],
+          },
+        });
+
+        const result = buildRequest(s, {}, DEFAULT_OPTIONS);
+        const resolvedStart = Date.parse(result.start_time);
+        const resolvedEnd = Date.parse(result.end_time);
+
+        assert.strictEqual(result.start_time, '2026-06-01T12:28:07.525Z');
+        assert.notStrictEqual(result.end_time, sampleEnd, 'same-day sample end would invert the defaulted start');
+        assert.ok(resolvedStart < resolvedEnd, 'start should remain before end');
+        assert.strictEqual(resolvedEnd - resolvedStart, Date.parse(sampleEnd) - Date.parse(sampleStart));
+      });
     });
 
     test('emits every package when sample_request authors multiple', () => {


### PR DESCRIPTION
## Summary

Fixes the storyboard `create_media_buy` request builder so `start_time` and `end_time` are resolved as a pair, preventing stale-start/same-day-end fixtures from inverting the flight window.
Preserves future fixture windows byte-for-byte for replay determinism and adds regression coverage for the May 31, 2026 case from #2143.
Adds a patch changeset for `@adcp/sdk`.

## Tests

- `npm run build:lib`
- `NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/lib/request-builder.test.js`
- `NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/lib/request-builder-schema-roundtrip.test.js test/lib/request-builder-jsonschema-roundtrip.test.js`
- pre-push hook: `npm run typecheck` and `npm run build:lib`
