### PR TITLE
fix: stabilize storyboard request enrichment clock

### DIFF
--- a/.changeset/deterministic-storyboard-run-clock.md
+++ b/.changeset/deterministic-storyboard-run-clock.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Capture a per-run storyboard clock and use it during request enrichment so stale media-buy fixture windows and generated fallback IDs stay deterministic across replay steps.

--- a/src/lib/testing/storyboard/context.ts
+++ b/src/lib/testing/storyboard/context.ts
@@ -363,6 +363,8 @@ export function forwardAliasCache(from: StoryboardContext, to: StoryboardContext
  *     allocated when expanding `{{runner.webhook_url:<step_id>}}`.
  */
 export interface RunnerVariables {
+  /** Millisecond timestamp captured once at run start for deterministic enrichment. */
+  runStartMs?: number;
   /** Base URL of the runner's webhook receiver, when enabled. */
   webhookBase?: string;
   /** step_id → operation_id, filled lazily on expansion. */
@@ -380,6 +382,7 @@ export interface RunnerVariables {
 
 export function createRunnerVariables(opts: { webhookBase?: string } = {}): RunnerVariables {
   return {
+    runStartMs: Date.now(),
     ...(opts.webhookBase !== undefined && { webhookBase: opts.webhookBase }),
     stepOperationIds: new Map(),
     runState: new Map(),

--- a/src/lib/testing/storyboard/request-builder.ts
+++ b/src/lib/testing/storyboard/request-builder.ts
@@ -23,6 +23,7 @@
  * payload" pattern.
  */
 
+import { createHash } from 'node:crypto';
 import { resolveBrand, resolveAccount } from '../client';
 import type { TestOptions } from '../types';
 import type { StoryboardContext, StoryboardStep } from './types';
@@ -142,8 +143,8 @@ function runClockMs(runnerVars: RunnerVariables | undefined): number {
 function generatedIdSuffix(step: StoryboardStep, runnerVars: RunnerVariables | undefined, nowMs?: number): string {
   const timestamp = nowMs ?? runClockMs(runnerVars);
   if (runnerVars?.runStartMs === undefined) return String(timestamp);
-  const stepId = step.id.replace(/[^A-Za-z0-9_.:-]/g, '_') || 'step';
-  return `${timestamp}-${stepId}`;
+  const stepHash = createHash('sha256').update(step.id).digest('hex').slice(0, 12);
+  return `${timestamp}-${stepHash}`;
 }
 
 /**

--- a/src/lib/testing/storyboard/request-builder.ts
+++ b/src/lib/testing/storyboard/request-builder.ts
@@ -31,7 +31,8 @@ import { injectContext, type RunnerVariables } from './context';
 type RequestEnricher = (
   step: StoryboardStep,
   context: StoryboardContext,
-  options: TestOptions
+  options: TestOptions,
+  runnerVars?: RunnerVariables
 ) => Record<string, unknown>;
 
 /** Legacy alias kept for external consumers pinned to the old terminology. */
@@ -108,12 +109,13 @@ function parseTime(value: string | undefined): number | undefined {
 
 function resolveMediaBuyWindow(
   sampleStart: string | undefined,
-  sampleEnd: string | undefined
+  sampleEnd: string | undefined,
+  nowMs?: number
 ): {
   startTime: string;
   endTime: string;
 } {
-  const now = Date.now();
+  const now = nowMs ?? Date.now();
   const defaultStart = new Date(now + DAY_MS).toISOString();
   const defaultEnd = new Date(now + 8 * DAY_MS).toISOString();
   const sampleStartMs = parseTime(sampleStart);
@@ -131,6 +133,17 @@ function resolveMediaBuyWindow(
   }
 
   return { startTime, endTime };
+}
+
+function runClockMs(runnerVars: RunnerVariables | undefined): number {
+  return runnerVars?.runStartMs ?? Date.now();
+}
+
+function generatedIdSuffix(step: StoryboardStep, runnerVars: RunnerVariables | undefined, nowMs?: number): string {
+  const timestamp = nowMs ?? runClockMs(runnerVars);
+  if (runnerVars?.runStartMs === undefined) return String(timestamp);
+  const stepId = step.id.replace(/[^A-Za-z0-9_.:-]/g, '_') || 'step';
+  return `${timestamp}-${stepId}`;
 }
 
 /**
@@ -175,7 +188,7 @@ const REQUEST_ENRICHERS: Record<string, RequestEnricher> = {
     };
   },
 
-  sync_audiences(step, context, options) {
+  sync_audiences(step, context, options, runnerVars) {
     // Honor hand-authored sample_request so storyboards can register a
     // specific audience_id that downstream steps reference. Without this,
     // add-shaped sample_request blocks (authored with audience_id + add[])
@@ -190,7 +203,7 @@ const REQUEST_ENRICHERS: Record<string, RequestEnricher> = {
       account: context.account ?? resolveAccount(options),
       audiences: [
         {
-          audience_id: context.audience_id ?? `test-audience-${Date.now()}`,
+          audience_id: context.audience_id ?? `test-audience-${generatedIdSuffix(step, runnerVars)}`,
           name: 'E2E Test Audience',
           add: [
             {
@@ -259,7 +272,7 @@ const REQUEST_ENRICHERS: Record<string, RequestEnricher> = {
 
   // ── Media Buy ──────────────────────────────────────────
 
-  create_media_buy(step, context, options) {
+  create_media_buy(step, context, options, runnerVars) {
     const product = selectProduct(context);
     const pricingOption = selectPricingOption(product);
 
@@ -268,13 +281,13 @@ const REQUEST_ENRICHERS: Record<string, RequestEnricher> = {
     // produce byte-for-byte identical canonical payloads. Two calls
     // generated 5ms apart with `Date.now()` would hash differently,
     // triggering IDEMPOTENCY_CONFLICT on replay. Stale sample dates
-    // (authored before the run date) fall back to the dynamic default.
-    // Resolve the pair together so a stale start and same-day future end
-    // cannot produce start_time > end_time.
+    // (authored before the run date) fall back to the run-start-relative
+    // default. Resolve the pair together so a stale start and same-day
+    // future end cannot produce start_time > end_time.
     const sampleStart =
       typeof step.sample_request?.start_time === 'string' ? step.sample_request.start_time : undefined;
     const sampleEnd = typeof step.sample_request?.end_time === 'string' ? step.sample_request.end_time : undefined;
-    const { startTime, endTime } = resolveMediaBuyWindow(sampleStart, sampleEnd);
+    const { startTime, endTime } = resolveMediaBuyWindow(sampleStart, sampleEnd, runnerVars?.runStartMs);
 
     // Merge hand-authored package fields from sample_request (targeting_overlay,
     // measurement_terms, creative_assignments, performance_standards, etc.) so
@@ -490,7 +503,7 @@ const REQUEST_ENRICHERS: Record<string, RequestEnricher> = {
 
   // ── Catalogs & Events ─────────────────────────────────
 
-  sync_catalogs(step, context, options) {
+  sync_catalogs(step, context, options, runnerVars) {
     // Prefer the fixture's sample_request — it's the authoritative request
     // shape for the storyboard step. The fallback's hardcoded feed_format
     // ('json') is NOT in the spec's 5-literal union and its `type` is
@@ -500,7 +513,7 @@ const REQUEST_ENRICHERS: Record<string, RequestEnricher> = {
       account: context.account ?? resolveAccount(options),
       catalogs: [
         {
-          catalog_id: `test-catalog-${Date.now()}`,
+          catalog_id: `test-catalog-${generatedIdSuffix(step, runnerVars)}`,
           name: 'E2E Test Catalog',
           type: 'product',
           feed_url: 'https://test-assets.adcontextprotocol.org/feeds/test-catalog.json',
@@ -510,12 +523,12 @@ const REQUEST_ENRICHERS: Record<string, RequestEnricher> = {
     };
   },
 
-  sync_event_sources(_step, context, options) {
+  sync_event_sources(step, context, options, runnerVars) {
     return {
       account: context.account ?? resolveAccount(options),
       event_sources: [
         {
-          event_source_id: `test-source-${Date.now()}`,
+          event_source_id: `test-source-${generatedIdSuffix(step, runnerVars)}`,
           name: 'E2E Test Event Source',
           event_types: ['purchase', 'add_to_cart'],
         },
@@ -523,7 +536,7 @@ const REQUEST_ENRICHERS: Record<string, RequestEnricher> = {
     };
   },
 
-  log_event(step, context, _options) {
+  log_event(step, context, _options, runnerVars) {
     // Storyboards routinely ship spec-conformant event payloads with
     // event_time, content_ids, and custom_data siblings that only the
     // author knows. Honor sample_request when present.
@@ -531,21 +544,21 @@ const REQUEST_ENRICHERS: Record<string, RequestEnricher> = {
       event_source_id: context.event_source_id ?? 'test-source',
       events: [
         {
-          event_id: `evt-${Date.now()}`,
+          event_id: `evt-${generatedIdSuffix(step, runnerVars)}`,
           event_type: 'purchase',
-          event_time: new Date().toISOString(),
+          event_time: new Date(runClockMs(runnerVars)).toISOString(),
           custom_data: { value: 49.99, currency: 'USD' },
         },
       ],
     };
   },
 
-  report_usage(step, context, options) {
+  report_usage(step, context, options, runnerVars) {
     // Prefer the fixture's sample_request — creative-ad-server and other
     // specialisms carry per-usage-entry fields (vendor_cost, currency,
     // pricing_option_id) that the hardcoded fallback here omits, causing
     // agents running the generated Zod schema to reject every step.
-    const now = new Date();
+    const now = new Date(runClockMs(runnerVars));
     const monthAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
     return {
       account: context.account ?? resolveAccount(options),
@@ -602,25 +615,25 @@ const REQUEST_ENRICHERS: Record<string, RequestEnricher> = {
     };
   },
 
-  sync_creatives(step, context, options) {
+  sync_creatives(step, context, options, runnerVars) {
     // Honor hand-authored sample_request for scenarios that require specific
     // creative shapes (delete/patch flows, format-scoped uploads, etc).
     const formats = (context.formats as Array<Record<string, unknown>> | undefined) ?? [];
-    const now = Date.now();
+    const idSuffix = generatedIdSuffix(step, runnerVars);
 
     // Send one creative per discovered format so downstream steps
     // (e.g., build_video_tag) can find creatives in every format.
     const creatives =
       formats.length > 0
         ? formats.map((fmt, i) => ({
-            creative_id: `test-creative-${now}-${i}`,
+            creative_id: `test-creative-${idSuffix}-${i}`,
             name: `E2E Test Creative ${i + 1}`,
             format_id: fmt.format_id ?? context.format_id ?? UNKNOWN_FORMAT_ID,
             assets: buildAssetsForFormat(fmt),
           }))
         : [
             {
-              creative_id: `test-creative-${now}`,
+              creative_id: `test-creative-${idSuffix}`,
               name: 'E2E Test Creative',
               format_id: context.format_id ?? UNKNOWN_FORMAT_ID,
               assets: {
@@ -734,17 +747,18 @@ const REQUEST_ENRICHERS: Record<string, RequestEnricher> = {
     };
   },
 
-  sync_plans(step, context, options) {
+  sync_plans(step, context, options, runnerVars) {
     // Governance storyboards define scenario-specific plans in sample_request
     // (e.g., custom_policies for conditions, reallocation_threshold for denied).
     // Delegate to sample_request when present.
-    const now = Date.now();
+    const now = runClockMs(runnerVars);
     const startDate = new Date(now + 24 * 60 * 60 * 1000).toISOString();
     const endDate = new Date(now + 90 * 24 * 60 * 60 * 1000).toISOString();
+    const idSuffix = generatedIdSuffix(step, runnerVars, now);
     return {
       plans: [
         {
-          plan_id: `test-plan-${Date.now()}`,
+          plan_id: `test-plan-${idSuffix}`,
           brand: resolveBrand(options),
           objectives: 'E2E test campaign — maximize reach across digital channels',
           budget: { total: options.budget ?? 10000, currency: 'USD', reallocation_unlimited: true },
@@ -779,7 +793,7 @@ const REQUEST_ENRICHERS: Record<string, RequestEnricher> = {
     };
   },
 
-  create_content_standards(step, context, _options) {
+  create_content_standards(step, context, _options, runnerVars) {
     // `anyOf: [{required: [policies]}, {required: [registry_policy_ids]}]` —
     // one must be present. Emit a minimal inline bespoke policy rather than
     // pinning a registry id the agent may not carry; storyboards that want
@@ -797,7 +811,7 @@ const REQUEST_ENRICHERS: Record<string, RequestEnricher> = {
       },
       policies: [
         {
-          policy_id: `e2e-fallback-${Date.now()}`,
+          policy_id: `e2e-fallback-${generatedIdSuffix(step, runnerVars)}`,
           enforcement: 'should',
           policy: 'E2E fallback policy — storyboard author did not supply sample_request.',
         },
@@ -871,7 +885,7 @@ const REQUEST_ENRICHERS: Record<string, RequestEnricher> = {
     };
   },
 
-  si_initiate_session(step, context, options) {
+  si_initiate_session(step, context, options, runnerVars) {
     // `intent` is required and represents the user's ask. Default to a
     // semantically plausible one so agents that dispatch on intent still
     // behave sensibly; storyboards override via sample_request when
@@ -881,7 +895,7 @@ const REQUEST_ENRICHERS: Record<string, RequestEnricher> = {
       offering_token: context.offering_token,
       identity: {
         consent_granted: false,
-        anonymous_session_id: `e2e-anon-${Date.now()}`,
+        anonymous_session_id: `e2e-anon-${generatedIdSuffix(step, runnerVars)}`,
       },
       intent: options.si_context ?? 'Browse available offerings',
       placement: 'e2e-test',
@@ -973,7 +987,7 @@ export function enrichRequest(
 
   if (!enricher) return fixture ?? {};
 
-  const enriched = enricher(step, context, options);
+  const enriched = enricher(step, context, options, runnerVars);
 
   // Fixture-aware enrichers already did the body merge internally and know
   // the array/nested shapes better than a generic top-level overlay can.

--- a/test/lib/request-builder.test.js
+++ b/test/lib/request-builder.test.js
@@ -582,8 +582,8 @@ describe('Request Builder', () => {
         runnerVars
       );
 
-      assert.strictEqual(first.catalogs[0].catalog_id, 'test-catalog-1780272000100-sync_catalogs_first');
-      assert.strictEqual(second.catalogs[0].catalog_id, 'test-catalog-1780272000100-sync_catalogs_second');
+      assert.match(first.catalogs[0].catalog_id, /^test-catalog-1780272000100-[a-f0-9]{12}$/);
+      assert.match(second.catalogs[0].catalog_id, /^test-catalog-1780272000100-[a-f0-9]{12}$/);
       assert.notStrictEqual(first.catalogs[0].catalog_id, second.catalogs[0].catalog_id);
     });
 
@@ -748,6 +748,17 @@ describe('Request Builder', () => {
       assert.strictEqual(replay.events[0].event_id, initial.events[0].event_id);
       assert.strictEqual(replay.events[0].event_time, initial.events[0].event_time);
       assert.strictEqual(initial.events[0].event_time, '2026-06-01T00:00:00.100Z');
+    });
+
+    test('fallback event_id remains bounded when step id is long', () => {
+      const runnerVars = createRunnerVariables();
+      const result = buildRequest(
+        step('log_event', { id: 'log_event_' + 'x'.repeat(240) }),
+        {},
+        DEFAULT_OPTIONS,
+        runnerVars
+      );
+      assert.ok(result.events[0].event_id.length <= 256, `event_id length was ${result.events[0].event_id.length}`);
     });
   });
 

--- a/test/lib/request-builder.test.js
+++ b/test/lib/request-builder.test.js
@@ -9,6 +9,7 @@ const { describe, test } = require('node:test');
 const assert = require('node:assert');
 
 const { buildRequest, hasRequestBuilder } = require('../../dist/lib/testing/storyboard/request-builder.js');
+const { createRunnerVariables } = require('../../dist/lib/testing/storyboard/context.js');
 
 const DEFAULT_OPTIONS = {
   brand: { domain: 'acmeoutdoor.example' },
@@ -105,6 +106,34 @@ describe('Request Builder', () => {
         assert.ok(resolvedStart < resolvedEnd, 'start should remain before end');
         assert.strictEqual(resolvedEnd - resolvedStart, Date.parse(sampleEnd) - Date.parse(sampleStart));
       });
+    });
+
+    test('resolves stale fixture window deterministically for idempotency replay (#2147)', () => {
+      let runnerVars;
+      withDateNow('2026-06-01T00:00:00.100Z', () => {
+        runnerVars = createRunnerVariables();
+      });
+
+      const s = step('create_media_buy', {
+        sample_request: {
+          start_time: '2026-06-01T00:00:00Z',
+          end_time: '2026-06-08T00:00:00Z',
+          packages: [{ product_id: 'p1', budget: 1000, pricing_option_id: 'opt' }],
+        },
+      });
+
+      let initial;
+      let replay;
+      withDateNow('2026-06-01T00:00:00.200Z', () => {
+        initial = buildRequest(s, {}, DEFAULT_OPTIONS, runnerVars);
+      });
+      withDateNow('2026-06-01T00:00:00.900Z', () => {
+        replay = buildRequest(s, {}, DEFAULT_OPTIONS, runnerVars);
+      });
+
+      assert.strictEqual(initial.start_time, '2026-06-02T00:00:00.100Z');
+      assert.strictEqual(replay.start_time, initial.start_time);
+      assert.strictEqual(replay.end_time, initial.end_time);
     });
 
     test('emits every package when sample_request authors multiple', () => {
@@ -539,6 +568,25 @@ describe('Request Builder', () => {
       );
     });
 
+    test('fallback catalog IDs are deterministic but distinct per step', () => {
+      let runnerVars;
+      withDateNow('2026-06-01T00:00:00.100Z', () => {
+        runnerVars = createRunnerVariables();
+      });
+
+      const first = buildRequest(step('sync_catalogs', { id: 'sync_catalogs_first' }), {}, DEFAULT_OPTIONS, runnerVars);
+      const second = buildRequest(
+        step('sync_catalogs', { id: 'sync_catalogs_second' }),
+        {},
+        DEFAULT_OPTIONS,
+        runnerVars
+      );
+
+      assert.strictEqual(first.catalogs[0].catalog_id, 'test-catalog-1780272000100-sync_catalogs_first');
+      assert.strictEqual(second.catalogs[0].catalog_id, 'test-catalog-1780272000100-sync_catalogs_second');
+      assert.notStrictEqual(first.catalogs[0].catalog_id, second.catalogs[0].catalog_id);
+    });
+
     test('honors step.sample_request when present', () => {
       const fixture = {
         account: { account_id: 'acct_x' },
@@ -592,6 +640,25 @@ describe('Request Builder', () => {
       };
       const result = buildRequest(step('report_usage', { sample_request: fixture }), {}, DEFAULT_OPTIONS);
       assert.strictEqual(result.usage[0].vendor_cost, 42);
+    });
+
+    test('fallback reporting_period is deterministic with runner variables', () => {
+      let runnerVars;
+      withDateNow('2026-06-01T00:00:00.100Z', () => {
+        runnerVars = createRunnerVariables();
+      });
+
+      let initial;
+      let replay;
+      withDateNow('2026-06-01T00:00:00.200Z', () => {
+        initial = buildRequest(step('report_usage'), {}, DEFAULT_OPTIONS, runnerVars);
+      });
+      withDateNow('2026-06-01T00:00:00.900Z', () => {
+        replay = buildRequest(step('report_usage'), {}, DEFAULT_OPTIONS, runnerVars);
+      });
+
+      assert.deepStrictEqual(replay.reporting_period, initial.reporting_period);
+      assert.strictEqual(initial.reporting_period.end, '2026-06-01T00:00:00.100Z');
     });
   });
 
@@ -661,6 +728,26 @@ describe('Request Builder', () => {
       const context = { event_source_id: 'resolved-source-id' };
       const result = buildRequest(step('log_event', { sample_request: fixture }), context, DEFAULT_OPTIONS);
       assert.strictEqual(result.event_source_id, 'resolved-source-id');
+    });
+
+    test('fallback event_id and event_time are deterministic with runner variables', () => {
+      let runnerVars;
+      withDateNow('2026-06-01T00:00:00.100Z', () => {
+        runnerVars = createRunnerVariables();
+      });
+
+      let initial;
+      let replay;
+      withDateNow('2026-06-01T00:00:00.200Z', () => {
+        initial = buildRequest(step('log_event'), {}, DEFAULT_OPTIONS, runnerVars);
+      });
+      withDateNow('2026-06-01T00:00:00.900Z', () => {
+        replay = buildRequest(step('log_event'), {}, DEFAULT_OPTIONS, runnerVars);
+      });
+
+      assert.strictEqual(replay.events[0].event_id, initial.events[0].event_id);
+      assert.strictEqual(replay.events[0].event_time, initial.events[0].event_time);
+      assert.strictEqual(initial.events[0].event_time, '2026-06-01T00:00:00.100Z');
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes #2147.

- captures a per-run storyboard clock in `RunnerVariables` without making the public type field required
- uses that clock for stale `create_media_buy` window normalization so idempotency replay steps resolve identical `start_time` / `end_time`
- stabilizes fallback `log_event` and `report_usage` time fields under runner variables
- makes fallback generated IDs deterministic, distinct per step, and bounded with a short hash suffix to avoid same-run collisions without violating schema length caps

## Root Cause

The storyboard request builder recomputed `Date.now()` independently for each enriched step. Once frozen fixture dates moved into the past, the runner fell back to now-relative defaults, so initial and replay requests using the same idempotency key could differ by milliseconds and trigger `IDEMPOTENCY_CONFLICT`.

## Expert Review

- code-reviewer and protocol_reviewer reviewed the first diff and found blockers around public type compatibility, remaining live-clock fields, and same-run generated ID collisions.
- Updated the patch to make `runStartMs` optional, add step-aware deterministic ID suffixing, and stabilize `log_event` / `report_usage`.
- protocol_reviewer re-reviewed the updated diff and reported no remaining must-fix issues.
- code-reviewer caught a late schema-length risk from raw step IDs in generated suffixes; updated suffixing to use a bounded SHA-256 hash prefix and added a long-step-ID regression test.

## Validation

- `NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/lib/request-builder.test.js test/lib/request-builder-schema-roundtrip.test.js test/lib/request-builder-jsonschema-roundtrip.test.js`
- `npm run ci:quick`
- pre-push validation: `npm run typecheck` + `npm run build:lib`