### PR TITLE
fix(types): deprecate schema barrel exports

### DIFF
--- a/.changeset/deprecate-schema-barrel-exports.md
+++ b/.changeset/deprecate-schema-barrel-exports.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Deprecate schema re-exports from the root package and `@adcp/sdk/types` in favor of the dedicated `@adcp/sdk/schemas` subpath. This keeps backwards compatibility while documenting lower-footprint import paths for large TypeScript monorepos.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,19 @@ Why bother: the full `@adcp/sdk` type surface is ~45,000 lines and crashes `tsc`
 
 Slices use kebab-case filenames matching the schema cache (`sync_accounts` → `@adcp/sdk/types/sync-accounts`). Requires `moduleResolution: "node16"` / `"nodenext"` / `"bundler"` on the adopter side. A machine-readable index of available slices ships at `@adcp/sdk/types/per-tool-index.json`.
 
+### TypeScript footprint in monorepos
+
+Large workspaces should keep the generated schema surface out of the default type-check path unless they actually need runtime Zod validators. The root `@adcp/sdk` export and `@adcp/sdk/types` still re-export schemas for backwards compatibility, but those compatibility exports are deprecated because they can pull the full generated schema declaration set into `tsc`.
+
+| Need                                          | Recommended import                                                                      |
+| --------------------------------------------- | --------------------------------------------------------------------------------------- |
+| Client, server, signing, and response helpers | `@adcp/sdk`, `@adcp/sdk/client`, `@adcp/sdk/server`, or another focused runtime subpath |
+| One tool's request/response types             | `@adcp/sdk/types/<tool>` such as `@adcp/sdk/types/sync-accounts`                        |
+| Runtime Zod schemas and tool input shapes     | `@adcp/sdk/schemas`                                                                     |
+| Broad generated protocol type barrel          | `@adcp/sdk/types`                                                                       |
+
+For application monorepos, keep `skipLibCheck: true` unless you are intentionally auditing SDK declarations. If a package only needs request/response types for a few tools, prefer the per-tool slices over importing generated types through the root package or the broad `@adcp/sdk/types` barrel.
+
 ## Quick Start: Distributed Operations
 
 ```typescript

--- a/examples/error-compliant-server.ts
+++ b/examples/error-compliant-server.ts
@@ -19,11 +19,15 @@ import {
   mediaBuyResponse,
   deliveryResponse,
   serve,
+  DEFAULT_REPORTING_CAPABILITIES,
+} from '@adcp/sdk';
+import {
   GetProductsRequestSchema,
   CreateMediaBuyRequestSchema,
   GetMediaBuyDeliveryRequestSchema,
-} from '@adcp/sdk';
-import type { Product, GetAdCPCapabilitiesResponse } from '@adcp/sdk';
+} from '@adcp/sdk/schemas';
+import type { Product, ServerPayload } from '@adcp/sdk';
+import type { GetAdCPCapabilitiesResponse } from '@adcp/sdk/types';
 
 // CreateMediaBuyRequestSchema requires account/brand per spec, but a lenient
 // version lets intentionally-incomplete requests reach the handler so it can
@@ -56,6 +60,7 @@ const PRODUCTS: Product[] = [
         min_spend_per_package: 500,
       },
     ],
+    reporting_capabilities: DEFAULT_REPORTING_CAPABILITIES,
   },
   {
     product_id: 'prod_video_pre_roll',
@@ -74,6 +79,7 @@ const PRODUCTS: Product[] = [
         min_spend_per_package: 1000,
       },
     ],
+    reporting_capabilities: DEFAULT_REPORTING_CAPABILITIES,
   },
 ];
 
@@ -113,8 +119,8 @@ function createAgentServer() {
     const limited = checkRateLimit();
     if (limited) return limited;
 
-    const capabilities: GetAdCPCapabilitiesResponse = {
-      adcp: { major_versions: [3] },
+    const capabilities: ServerPayload<GetAdCPCapabilitiesResponse> = {
+      adcp: { major_versions: [3], idempotency: { supported: true, replay_ttl_seconds: 86400 } },
       supported_protocols: ['media_buy'],
       media_buy: {
         features: {
@@ -139,7 +145,7 @@ function createAgentServer() {
   server.registerTool(
     'create_media_buy',
     { inputSchema: LenientCreateMediaBuyInput.shape },
-    async ({ buyer_ref, start_time, end_time, packages }) => {
+    async ({ start_time, end_time, packages }) => {
       const limited = checkRateLimit();
       if (limited) return limited;
 
@@ -193,10 +199,8 @@ function createAgentServer() {
 
       return mediaBuyResponse({
         media_buy_id: mediaBuyId,
-        buyer_ref,
         packages: (packages ?? []).map((pkg, i) => ({
           package_id: `pkg_${i}_${Date.now()}`,
-          buyer_ref: pkg.buyer_ref,
           product_id: pkg.product_id,
           pricing_option_id: pkg.pricing_option_id,
           budget: pkg.budget,

--- a/examples/zod-validation-example.ts
+++ b/examples/zod-validation-example.ts
@@ -18,7 +18,7 @@ import {
   GetProductsResponseSchema,
   CreateMediaBuyRequestSchema,
   CreateMediaBuyResponseSchema,
-} from '../src/lib/types/schemas.generated';
+} from '@adcp/sdk/schemas';
 
 // Example 1: Validate a media buy structure
 console.log('📦 Example 1: Validating a MediaBuy\n');
@@ -96,7 +96,7 @@ const responseResult = GetProductsResponseSchema.safeParse(getProductsResponse);
 
 if (responseResult.success) {
   console.log('✅ Response is valid!');
-  console.log('Number of products:', responseResult.data.products.length);
+  console.log('Number of products:', responseResult.data.products?.length ?? 0);
 } else {
   console.log('❌ Response validation failed:');
   console.log(responseResult.error.format());

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/sdk",
-  "version": "8.1.0-beta.19",
+  "version": "8.1.0-beta.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/sdk",
-      "version": "8.1.0-beta.19",
+      "version": "8.1.0-beta.20",
       "license": "Apache-2.0",
       "workspaces": [
         ".",
@@ -7356,7 +7356,7 @@
       "version": "6.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adcp/sdk": "^8.1.0-beta.19"
+        "@adcp/sdk": "^8.1.0-beta.20"
       },
       "bin": {
         "adcp": "bin/adcp.js"

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1028,7 +1028,11 @@ export {
 } from './utils/get-products-cache-scope';
 
 // ====== ZOD SCHEMAS (for runtime validation) ======
-// Re-export all Zod schemas for user validation needs
+/**
+ * @deprecated Import Zod schemas from `@adcp/sdk/schemas` instead. The root
+ * barrel re-export is kept for backwards compatibility, but it can force the
+ * full generated schema declaration set into TypeScript programs.
+ */
 export * from './types/schemas.generated';
 
 // ====== ENUM VALUE ARRAYS ======

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -319,7 +319,11 @@ export * from './asset-instances';
 // (e.g., SyncAccountsResponseRow.action) reachable to handler authors.
 export * from './sync-rows';
 
-// Re-export Zod schemas for runtime validation
+/**
+ * @deprecated Import Zod schemas from `@adcp/sdk/schemas` instead. This
+ * compatibility re-export can force the full generated schema declaration set
+ * into TypeScript programs that only need common SDK types.
+ */
 export * from './schemas.generated';
 
 // Re-export const-array enum values (e.g., MediaChannelValues, PacingValues)


### PR DESCRIPTION
Deprecates generated schema re-exports from the root package and @adcp/sdk/types, pointing consumers to @adcp/sdk/schemas for runtime validators. Documents lower-footprint TypeScript import paths for large monorepos and updates examples to use the schema subpath while keeping them current with the generated types. Includes the existing package-lock beta version alignment in this workspace. Validated with npm run build:lib, npm run typecheck, focused strict example typecheck, commitlint, and the pre-push hook.