### PR TITLE
fix(types): move schemas off root barrel

### DIFF
--- a/.changeset/remove-schema-root-exports.md
+++ b/.changeset/remove-schema-root-exports.md
@@ -1,0 +1,9 @@
+---
+'@adcp/sdk': major
+---
+
+Remove generated Zod schema exports and tool schema maps from the root package
+and `@adcp/sdk/types`. Import runtime schemas, `TOOL_REQUEST_SCHEMAS`, and
+`TOOL_RESPONSE_SCHEMAS` from `@adcp/sdk/schemas` instead. This keeps ordinary
+SDK imports from forcing the large generated schema declaration bundle into
+TypeScript programs.

--- a/README.md
+++ b/README.md
@@ -49,13 +49,13 @@ Slices use kebab-case filenames matching the schema cache (`sync_accounts` → `
 
 ### TypeScript footprint in monorepos
 
-Large workspaces should keep the generated schema surface out of the default type-check path unless they actually need runtime Zod validators. The root `@adcp/sdk` export and `@adcp/sdk/types` still re-export schemas for backwards compatibility, but those compatibility exports are deprecated because they can pull the full generated schema declaration set into `tsc`.
+Large workspaces should keep the generated schema surface out of the default type-check path unless they actually need runtime Zod validators. The root `@adcp/sdk` export and `@adcp/sdk/types` do not re-export generated Zod schemas; import those schemas from `@adcp/sdk/schemas` so ordinary SDK imports avoid pulling the full generated schema declaration set into `tsc`.
 
 | Need                                          | Recommended import                                                                      |
 | --------------------------------------------- | --------------------------------------------------------------------------------------- |
 | Client, server, signing, and response helpers | `@adcp/sdk`, `@adcp/sdk/client`, `@adcp/sdk/server`, or another focused runtime subpath |
 | One tool's request/response types             | `@adcp/sdk/types/<tool>` such as `@adcp/sdk/types/sync-accounts`                        |
-| Runtime Zod schemas and tool input shapes     | `@adcp/sdk/schemas`                                                                     |
+| Runtime Zod schemas and tool schema maps      | `@adcp/sdk/schemas`                                                                     |
 | Broad generated protocol type barrel          | `@adcp/sdk/types`                                                                       |
 
 For application monorepos, keep `skipLibCheck: true` unless you are intentionally auditing SDK declarations. If a package only needs request/response types for a few tools, prefer the per-tool slices over importing generated types through the root package or the broad `@adcp/sdk/types` barrel.
@@ -361,7 +361,8 @@ Worked reference adapters live in `examples/hello_*` — pick the one whose spec
 **v5 lower-level API** (still fully supported as the substrate the v6 path calls into):
 
 ```typescript
-import { CreateMediaBuyRequest, CreateMediaBuyResponse, CreateMediaBuyRequestSchema } from '@adcp/sdk';
+import type { CreateMediaBuyRequest, CreateMediaBuyResponse } from '@adcp/sdk';
+import { CreateMediaBuyRequestSchema } from '@adcp/sdk/schemas';
 
 function handleCreateMediaBuy(rawParams: unknown): CreateMediaBuyResponse {
   const request: CreateMediaBuyRequest = CreateMediaBuyRequestSchema.parse(rawParams);

--- a/docs/ZOD-SCHEMAS.md
+++ b/docs/ZOD-SCHEMAS.md
@@ -9,7 +9,7 @@ npm install @adcp/sdk zod
 ```
 
 ```typescript
-import { MediaBuySchema, GetProductsRequestSchema } from '@adcp/sdk';
+import { MediaBuySchema, GetProductsRequestSchema } from '@adcp/sdk/schemas';
 
 // Validate data
 const result = MediaBuySchema.safeParse(data);
@@ -44,7 +44,7 @@ if (result.success) {
 ### API Request Validation
 
 ```typescript
-import { GetProductsRequestSchema } from '@adcp/sdk';
+import { GetProductsRequestSchema } from '@adcp/sdk/schemas';
 
 function callGetProducts(request: unknown) {
   const validated = GetProductsRequestSchema.parse(request);
@@ -55,7 +55,7 @@ function callGetProducts(request: unknown) {
 ### API Response Validation
 
 ```typescript
-import { GetProductsResponseSchema } from '@adcp/sdk';
+import { GetProductsResponseSchema } from '@adcp/sdk/schemas';
 
 async function fetchProducts() {
   const response = await agent.getProducts(request);
@@ -69,7 +69,7 @@ async function fetchProducts() {
 ```typescript
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { CreateMediaBuyRequestSchema } from '@adcp/sdk';
+import { CreateMediaBuyRequestSchema } from '@adcp/sdk/schemas';
 
 function MediaBuyForm() {
   const { register, handleSubmit } = useForm({
@@ -155,7 +155,8 @@ if (!result.success) {
 ## TypeScript Integration
 
 ```typescript
-import { MediaBuy, MediaBuySchema } from '@adcp/sdk';
+import type { MediaBuy } from '@adcp/sdk';
+import { MediaBuySchema } from '@adcp/sdk/schemas';
 import { z } from 'zod';
 
 type MediaBuyInferred = z.infer<typeof MediaBuySchema>;
@@ -164,7 +165,7 @@ type MediaBuyInferred = z.infer<typeof MediaBuySchema>;
 
 ## Platform Implementation
 
-If you're building a platform that **receives** AdCP tool calls (a seller/publisher), you need request types for your handler signatures and schemas for runtime validation. Both are exported from `@adcp/sdk`.
+If you're building a platform that **receives** AdCP tool calls (a seller/publisher), import request types for handler signatures from `@adcp/sdk` and schemas for runtime validation from `@adcp/sdk/schemas`.
 
 ### Naming Convention
 
@@ -199,9 +200,8 @@ import {
   CreateMediaBuyResponse,
   PackageRequest,
   TargetingOverlay,
-  // Zod schema for runtime validation
-  CreateMediaBuyRequestSchema,
 } from '@adcp/sdk';
+import { CreateMediaBuyRequestSchema } from '@adcp/sdk/schemas';
 
 function handleCreateMediaBuy(rawParams: unknown): CreateMediaBuyResponse {
   // Validate and parse the incoming request
@@ -240,7 +240,7 @@ import {
   CreateMediaBuyRequestSchema,
   GetProductsRequestSchema,
   SyncCreativesRequestSchema,
-} from '@adcp/sdk';
+} from '@adcp/sdk/schemas';
 ```
 
 ## Example
@@ -258,7 +258,7 @@ When you `npm publish`, the package includes:
 @adcp/sdk/
   ├── dist/lib/types/schemas.generated.js  ← Zod schemas (compiled)
   ├── dist/lib/types/schemas.generated.d.ts ← Type definitions
-  └── dist/lib/index.js                    ← Re-exports schemas
+  └── dist/lib/schemas/index.js            ← Re-exports schemas
 ```
 
 ### What Downstream Users Get
@@ -267,7 +267,7 @@ When someone installs `@adcp/sdk`, they get:
 
 ```typescript
 // Works immediately after npm install
-import { MediaBuySchema } from '@adcp/sdk';
+import { MediaBuySchema } from '@adcp/sdk/schemas';
 
 const result = MediaBuySchema.safeParse(data);
 ```
@@ -302,7 +302,7 @@ npm install @adcp/sdk zod
 npm ls @adcp/sdk
 
 # Verify exports work
-node -e "console.log(require('@adcp/sdk').MediaBuySchema)"
+node -e "console.log(require('@adcp/sdk/schemas').MediaBuySchema)"
 ```
 
 ## Troubleshooting

--- a/docs/guides/BUILD-AN-AGENT.md
+++ b/docs/guides/BUILD-AN-AGENT.md
@@ -567,7 +567,8 @@ See [SIGNING-GUIDE.md](./SIGNING-GUIDE.md) for the full walkthrough: key generat
 For advanced cases where you need direct control over MCP tool registration, schema wiring, and response formatting. `createAdcpServerFromPlatform` calls into this internally.
 
 ```typescript
-import { createTaskCapableServer, taskToolResponse, GetSignalsRequestSchema } from '@adcp/sdk';
+import { createTaskCapableServer, taskToolResponse } from '@adcp/sdk';
+import { GetSignalsRequestSchema } from '@adcp/sdk/schemas';
 
 function createAgent({ taskStore }) {
   const server = createTaskCapableServer('Agent Name', '1.0.0', { taskStore });
@@ -640,6 +641,7 @@ For async tools that need background processing, use `registerAdcpTaskTool()`:
 
 ```typescript
 import { registerAdcpTaskTool, InMemoryTaskStore } from '@adcp/sdk';
+import { CreateMediaBuyRequestSchema } from '@adcp/sdk/schemas';
 
 const taskStore = new InMemoryTaskStore();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/sdk",
-  "version": "8.1.0-beta.20",
+  "version": "8.1.0-beta.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/sdk",
-      "version": "8.1.0-beta.20",
+      "version": "8.1.0-beta.21",
       "license": "Apache-2.0",
       "workspaces": [
         ".",
@@ -7356,7 +7356,7 @@
       "version": "6.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adcp/sdk": "^8.1.0-beta.20"
+        "@adcp/sdk": "^8.1.0-beta.21"
       },
       "bin": {
         "adcp": "bin/adcp.js"

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -527,9 +527,10 @@ export * from './types';
 //   PackageRequest  -- creation-shaped (required: buyer_ref, product_id, budget, pricing_option_id)
 //   Package         -- response-shaped from core.generated (has package_id, most fields optional)
 //
-// Platform implementors: use Request types to type/validate incoming tool calls,
+// Platform implementors: use Request types to type incoming tool calls,
 // Response types to shape your return values.
-// Zod schemas for runtime validation are exported below (e.g., CreateMediaBuyRequestSchema).
+// Runtime Zod schemas live at `@adcp/sdk/schemas` to keep ordinary root
+// imports from loading the generated schema declaration bundle.
 export type {
   // Media Buy Domain
   GetProductsRequest,
@@ -1027,14 +1028,6 @@ export {
   type GetProductsCacheScopeValidation,
 } from './utils/get-products-cache-scope';
 
-// ====== ZOD SCHEMAS (for runtime validation) ======
-/**
- * @deprecated Import Zod schemas from `@adcp/sdk/schemas` instead. The root
- * barrel re-export is kept for backwards compatibility, but it can force the
- * full generated schema declaration set into TypeScript programs.
- */
-export * from './types/schemas.generated';
-
 // ====== ENUM VALUE ARRAYS ======
 // `${TypeName}Values` const arrays for every named string-literal union in
 // the spec. Consumers can enumerate or validate against these without
@@ -1116,21 +1109,9 @@ export {
   type AgentOAuthClientCredentials,
 } from './auth/oauth';
 
-// ====== TOOL SCHEMA MAPS ======
-// Zod schemas keyed by tool name — use with server.registerTool(name, { inputSchema: schema.shape }, handler)
-export { TOOL_REQUEST_SCHEMAS } from './utils/tool-request-schemas';
-export { TOOL_RESPONSE_SCHEMAS } from './utils/response-schemas';
-
 // ====== VALIDATION ======
 // Schema validation for requests/responses
 export { validateAgentUrl, validateAdCPResponse, getExpectedSchema, handleAdCPResponse } from './validation';
-export {
-  SyncCreativesItemSchema,
-  SyncCreativesSuccessStrictSchema,
-  SyncCreativesResponseStrictSchema,
-  SyncCreativesActionSchema,
-} from './validation/sync-creatives';
-export type { SyncCreativesItem, SyncCreativesSuccessStrict } from './validation/sync-creatives';
 
 // ====== PROTOCOL CLIENTS ======
 // Low-level protocol clients for MCP and A2A (primarily for testing)

--- a/src/lib/schemas/index.ts
+++ b/src/lib/schemas/index.ts
@@ -16,6 +16,8 @@
  *   - {@link TOOL_INPUT_SCHEMAS}: `toolName → full Zod schema` map for
  *     custom tools whose request schema is a union/intersection and cannot
  *     be represented as a raw shape without weakening validation.
+ *   - {@link TOOL_RESPONSE_SCHEMAS}: `toolName → full Zod response schema`
+ *     map for response validation and compliance tooling.
  *   - {@link customToolFor}: sugar for registering a single custom tool
  *     with type-safe `handler` params derived from the schema's shape.
  *   - {@link customToolForSchema}: same sugar for full Zod schemas.
@@ -45,6 +47,14 @@ import type { KnownToolRequestSchemas } from '../utils/tool-request-schemas';
 
 export * from '../types/schemas.generated';
 export { TOOL_REQUEST_SCHEMAS } from '../utils/tool-request-schemas';
+export { TOOL_RESPONSE_SCHEMAS } from '../utils/response-schemas';
+export {
+  SyncCreativesItemSchema,
+  SyncCreativesSuccessStrictSchema,
+  SyncCreativesResponseStrictSchema,
+  SyncCreativesActionSchema,
+} from '../validation/sync-creatives';
+export type { SyncCreativesItem, SyncCreativesSuccessStrict } from '../validation/sync-creatives';
 
 type InputShape = Record<string, z.ZodType>;
 type InputSchema = z.ZodType;

--- a/src/lib/server/responses.ts
+++ b/src/lib/server/responses.ts
@@ -21,7 +21,7 @@
  * ```typescript
  * import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
  * import { capabilitiesResponse, productsResponse, adcpError } from '@adcp/sdk/server';
- * import { GetProductsRequestSchema } from '@adcp/sdk';
+ * import { GetProductsRequestSchema } from '@adcp/sdk/schemas';
  *
  * const server = new McpServer({ name: 'My Agent', version: '1.0.0' });
  *

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -319,13 +319,6 @@ export * from './asset-instances';
 // (e.g., SyncAccountsResponseRow.action) reachable to handler authors.
 export * from './sync-rows';
 
-/**
- * @deprecated Import Zod schemas from `@adcp/sdk/schemas` instead. This
- * compatibility re-export can force the full generated schema declaration set
- * into TypeScript programs that only need common SDK types.
- */
-export * from './schemas.generated';
-
 // Re-export const-array enum values (e.g., MediaChannelValues, PacingValues)
 // for consumers that need to enumerate or validate against the spec's
 // literal sets without re-deriving them from Zod schemas.

--- a/src/lib/utils/tool-request-schemas.ts
+++ b/src/lib/utils/tool-request-schemas.ts
@@ -3,7 +3,7 @@
  *
  * Use with MCP SDK's server.registerTool() for type-safe tool registration:
  *
- *   import { TOOL_REQUEST_SCHEMAS } from '@adcp/sdk';
+ *   import { TOOL_REQUEST_SCHEMAS } from '@adcp/sdk/schemas';
  *   server.registerTool(
  *     'get_products',
  *     { inputSchema: TOOL_REQUEST_SCHEMAS.get_products.shape },

--- a/test/lib/public-barrel-exports.test.js
+++ b/test/lib/public-barrel-exports.test.js
@@ -34,6 +34,7 @@ import {
   type CanonicalRef,
   type CanonicalReferenceResolutionResult,
 } from '@adcp/sdk/v2/format-schema';
+import { CreateMediaBuyRequestSchema } from '@adcp/sdk/schemas';
 import {
   AuthInvalidError,
   AuthMissingError,
@@ -57,6 +58,7 @@ const built = CanonicalFormat.nativeInFeed(
   { seller_preference: 'preferred', capability_id: 'native_feed' }
 );
 const builtKind: 'native_in_feed' = built.format_kind;
+const mediaBuyShape = CreateMediaBuyRequestSchema.shape;
 
 const syncError: SyncCreativesPayload = {
   errors: [{ code: 'INVALID_REQUEST', message: 'invalid creative batch' }],
@@ -108,6 +110,7 @@ const generatedInjectedScope: 'public' | 'account' = generatedMissingScope.cache
 
 void typedNative;
 void builtKind;
+void mediaBuyShape;
 void serverSyncError;
 void authErrors;
 void lazyBackend;
@@ -138,6 +141,7 @@ void generatedInjectedScope;
             '@adcp/sdk/server': ['dist/lib/server/index'],
             '@adcp/sdk/types': ['dist/lib/types/index'],
             '@adcp/sdk/v2/format-schema': ['dist/lib/v2/format-schema/index'],
+            '@adcp/sdk/schemas': ['dist/lib/schemas/index'],
           },
         },
         files: ['public-barrel-smoke.ts'],
@@ -154,4 +158,20 @@ void generatedInjectedScope;
   });
 
   assert.strictEqual(result.status, 0, `${result.stdout}\n${result.stderr}`);
+});
+
+test('schema exports stay behind @adcp/sdk/schemas', () => {
+  const root = require('../../dist/lib/index.js');
+  const types = require('../../dist/lib/types/index.js');
+  const schemas = require('../../dist/lib/schemas/index.js');
+
+  assert.strictEqual(root.CreateMediaBuyRequestSchema, undefined);
+  assert.strictEqual(root.TOOL_REQUEST_SCHEMAS, undefined);
+  assert.strictEqual(root.TOOL_RESPONSE_SCHEMAS, undefined);
+  assert.strictEqual(root.SyncCreativesItemSchema, undefined);
+  assert.strictEqual(types.CreateMediaBuyRequestSchema, undefined);
+  assert.ok(schemas.CreateMediaBuyRequestSchema);
+  assert.ok(schemas.TOOL_REQUEST_SCHEMAS.create_media_buy);
+  assert.ok(schemas.TOOL_RESPONSE_SCHEMAS.create_media_buy);
+  assert.ok(schemas.SyncCreativesItemSchema);
 });

--- a/test/lib/update-rights-creative-approval.test.js
+++ b/test/lib/update-rights-creative-approval.test.js
@@ -220,13 +220,18 @@ describe('creative_approval webhook builders', () => {
 });
 
 describe('public type re-exports', () => {
-  it('UpdateRights and CreativeApproval types reachable via @adcp/sdk/types', async () => {
-    // The runtime types entrypoint re-exports schema bindings; the static
-    // type-only exports are validated at typecheck time. Smoke check that
-    // the entrypoint loads and the runtime Zod schemas are reachable.
+  it('UpdateRights and CreativeApproval types stay on @adcp/sdk/types while schemas move to @adcp/sdk/schemas', async () => {
+    // Static type-only exports are validated by the public barrel typecheck
+    // smoke tests. Runtime Zod schemas now live behind the schemas subpath so
+    // importing @adcp/sdk/types does not pull schemas.generated into tsc.
     const types = await import('../../dist/lib/types/index.js');
-    assert.ok(types.UpdateRightsRequestSchema, 'UpdateRightsRequestSchema reachable via /types');
-    assert.ok(types.CreativeApprovalRequestSchema, 'CreativeApprovalRequestSchema reachable via /types');
-    assert.ok(types.CreativeApprovalResponseSchema, 'CreativeApprovalResponseSchema reachable via /types');
+    const publicSchemas = await import('../../dist/lib/schemas/index.js');
+
+    assert.equal(types.UpdateRightsRequestSchema, undefined, 'UpdateRightsRequestSchema absent from /types');
+    assert.equal(types.CreativeApprovalRequestSchema, undefined, 'CreativeApprovalRequestSchema absent from /types');
+    assert.equal(types.CreativeApprovalResponseSchema, undefined, 'CreativeApprovalResponseSchema absent from /types');
+    assert.ok(publicSchemas.UpdateRightsRequestSchema, 'UpdateRightsRequestSchema reachable via /schemas');
+    assert.ok(publicSchemas.CreativeApprovalRequestSchema, 'CreativeApprovalRequestSchema reachable via /schemas');
+    assert.ok(publicSchemas.CreativeApprovalResponseSchema, 'CreativeApprovalResponseSchema reachable via /schemas');
   });
 });


### PR DESCRIPTION
Moves generated Zod schemas, tool schema maps, and sync_creatives schema validators off the root package and @adcp/sdk/types so ordinary SDK imports avoid loading the large schema declaration bundle.

Keeps those runtime schema surfaces under @adcp/sdk/schemas and updates README/Zod/agent docs plus a major changeset for the breaking import-path change.

Adds barrel smoke coverage confirming root exports are absent while @adcp/sdk/schemas still exposes the schemas/maps.

Validated with npm run build:lib, targeted node tests for public barrels/Zod schemas/sync_creatives validators, commitlint, and the pre-push typecheck/build hook.