### PR TITLE
fix(storyboard): scope controller seeding correlation

### DIFF
--- a/.changeset/storyboard-seeding-correlation.md
+++ b/.changeset/storyboard-seeding-correlation.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Add storyboard-scoped correlation context to generated controller seeding calls so seeded fixtures can be isolated per storyboard run.

--- a/src/lib/testing/storyboard/seeding.ts
+++ b/src/lib/testing/storyboard/seeding.ts
@@ -265,7 +265,15 @@ export async function runControllerSeeding(
       error = call.authoring_error;
     } else {
       try {
-        const raw = await callControllerRaw(client, { scenario: call.scenario, params: call.params }, options);
+        const raw = await callControllerRaw(
+          client,
+          {
+            scenario: call.scenario,
+            params: call.params,
+            context: { correlation_id: `${storyboard.id}--__seeding__` },
+          },
+          options
+        );
         const data = raw.data as { success?: boolean; error?: string; error_detail?: string } | undefined;
         if (raw.success && data?.success === true) {
           passed = true;

--- a/test/lib/storyboard-controller-seeding.test.js
+++ b/test/lib/storyboard-controller-seeding.test.js
@@ -204,12 +204,13 @@ describe('runControllerSeeding', () => {
       },
     };
     const { client, calls } = makeMockClient(successResponse);
-    const result = await runControllerSeeding(client, storyboard, {}, {});
+    const result = await runControllerSeeding(client, storyboard, {}, { correlation_id: 'runner-context' });
     assert.ok(result, 'seeding result should exist');
     assert.strictEqual(calls.length, 3);
     for (const call of calls) {
       assert.strictEqual(call.name, 'comply_test_controller');
       assert.match(String(call.params.scenario), /seed_/);
+      assert.deepStrictEqual(call.params.context, { correlation_id: 'test_sb--__seeding__' });
     }
     assert.strictEqual(result.allPassed, true);
     assert.strictEqual(result.passedCount, 3);
@@ -220,6 +221,16 @@ describe('runControllerSeeding', () => {
       assert.strictEqual(step.passed, true);
       assert.strictEqual(step.task, 'comply_test_controller');
     }
+  });
+
+  test('uses a different seeding correlation id per storyboard', async () => {
+    const { client, calls } = makeMockClient(successResponse);
+    await runControllerSeeding(client, { ...storyboardWithFixtures, id: 'first_storyboard' }, {}, {});
+    await runControllerSeeding(client, { ...storyboardWithFixtures, id: 'second_storyboard' }, {}, {});
+    assert.deepStrictEqual(
+      calls.map(call => call.params.context?.correlation_id),
+      ['first_storyboard--__seeding__', 'second_storyboard--__seeding__']
+    );
   });
 
   test('failure path: controller returns an error for one seed — phase fails, allPassed is false', async () => {
@@ -336,6 +347,7 @@ describe('runStoryboard: controller seeding integration', () => {
     assert.strictEqual(seedCalls.length, 1, 'exactly one seed_product call');
     assert.strictEqual(seedCalls[0].params.scenario, 'seed_product');
     assert.strictEqual(seedCalls[0].params.params.product_id, 'sports_display');
+    assert.deepStrictEqual(seedCalls[0].params.context, { correlation_id: 'seed_runner_sb--__seeding__' });
     assert.ok(productCalls.length >= 1, 'real phase should run after seeding');
 
     const seedPhase = result.phases.find(p => p.phase_id === '__controller_seeding__');


### PR DESCRIPTION
## Summary

Refs #2156.

Generated `__controller_seeding__` calls now carry a storyboard-scoped `context.correlation_id`, using `<storyboard.id>--__seeding__`. This gives sellers a stable per-storyboard key for sandbox fixture isolation instead of sending correlation-blind seed calls.

This intentionally keeps the PR to correlation-id injection only. The later addendum on #2156 calls out `creative_formats[]` / `measurement_catalogs[]` fixture generation as a separable pre-existing gap, so this patch does not add new seed scenario generation behavior.

## What changed

- Added fresh seeding context to each generated controller seed call.
- Added regression coverage for the default seeding path, per-storyboard uniqueness, and the full `runStoryboard` integration path.
- Added a patch changeset.

## Testing

- `npx prettier --check src/lib/testing/storyboard/seeding.ts test/lib/storyboard-controller-seeding.test.js .changeset/storyboard-seeding-correlation.md`
- `git diff --check`
- `npm run sync-schemas`
- `npm run build:lib`
- `NODE_ENV=test node --test-timeout=60000 --test test/lib/storyboard-controller-seeding.test.js`
- `npm run typecheck`
- `npm run lint` (passes with existing warnings)
- `git push` pre-push hook passed: format, typecheck, build
- GitHub Actions: all visible checks passed on PR #2157

Local note: I also attempted `npm run ci:quick`. Format, typecheck, and build passed, then `test:node:fast` ran for over 16 minutes on local Node v23.6.1 with one `node --test` process consuming CPU and no further output, so I stopped that local broad run and relied on the GitHub Actions matrix.