### PR TITLE
fix: isolate storyboard controller seeding

### DIFF
--- a/.changeset/storyboard-seeding-context.md
+++ b/.changeset/storyboard-seeding-context.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Add storyboard-scoped correlation IDs and cache isolation to generated controller seeding calls, with unsupported seed scenarios graded as not applicable.

--- a/src/lib/server/test-controller.ts
+++ b/src/lib/server/test-controller.ts
@@ -776,9 +776,10 @@ function normalizeBuyerAgentSeedFixture(fixture: Record<string, unknown>): Recor
  * spec idempotency rules when a {@link SeedFixtureCache} is provided. */
 /**
  * Build the seed-cache key for a scenario. When `scope` is present (the
- * request's account / session scope), it's prefixed so two sandbox accounts
- * or sessions on one server can each seed the same fixture id with divergent
- * fixtures without colliding in the process-wide `SeedFixtureCache`.
+ * request's account / session / correlation scope), it's prefixed so two
+ * sandbox accounts, sessions, or storyboard runs on one server can each seed
+ * the same fixture id with divergent fixtures without colliding in the
+ * process-wide `SeedFixtureCache`.
  *
  * Without scope (legacy callers, or requests with no `account` envelope),
  * the unscoped key is used — preserving the pre-#1215 behavior. Adopters
@@ -796,6 +797,8 @@ function makeSeedCacheScope(input: Record<string, unknown>): string | undefined 
   if (context != null && typeof context === 'object') {
     const sessionId = (context as { session_id?: unknown }).session_id;
     if (typeof sessionId === 'string' && sessionId.length > 0) parts.push(`session:${sessionId}`);
+    const correlationId = (context as { correlation_id?: unknown }).correlation_id;
+    if (typeof correlationId === 'string' && correlationId.length > 0) parts.push(`correlation:${correlationId}`);
   }
 
   const account =
@@ -1280,11 +1283,11 @@ async function handleTestControllerRequestImpl(
       case SEED_SCENARIOS.SEED_CREATIVE_FORMAT:
       case SEED_SCENARIOS.SEED_MEASUREMENT_CATALOG:
       case SEED_SCENARIOS.SEED_BUYER_AGENT: {
-        // Seed-cache scope (issue #1215). Two sandbox accounts or sessions on
-        // one server can each seed the same fixture id with divergent fixtures;
-        // without a scope prefix the cache treats divergent replays as
-        // INVALID_PARAMS even when each scoped fixture is internally
-        // self-consistent. No resolver call here — test-controller is a
+        // Seed-cache scope (issues #1215/#2156). Two sandbox accounts,
+        // sessions, or storyboard correlation buckets on one server can each
+        // seed the same fixture id with divergent fixtures; without a scope
+        // prefix the cache treats divergent replays as INVALID_PARAMS even when
+        // each scoped fixture is internally self-consistent. No resolver call here — test-controller is a
         // generic helper that doesn't know about platform.accounts.resolve,
         // and read-time misalignment is fine because the cache only governs
         // idempotency, not user-visible state.

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -153,6 +153,9 @@ const SKIP_DETAILS: Record<RunnerSkipReason, string> = {
 const CONTROLLER_SEEDING_FAILED_DETAIL =
   'Skipped: pre-flight comply_test_controller seeding failed; the agent was not populated with the storyboard fixtures the remaining phases depend on.';
 
+const FIXTURE_SEED_UNSUPPORTED_DETAIL =
+  'Skipped: pre-flight comply_test_controller seeding requires a seed_* scenario this agent does not implement (`fixture_seed_unsupported`).';
+
 const OAUTH_NOT_ADVERTISED_DETAIL =
   'Skipped: agent does not advertise OAuth — /.well-known/oauth-protected-resource returned 404 (RFC 9728 §3). API-key path must carry auth_mechanism_verified for this storyboard to pass.';
 
@@ -2195,6 +2198,7 @@ async function executeStoryboardPass(
   let seedingPhaseResult: StoryboardPhaseResult | null = null;
   let seedingFailed = false;
   let seedingMissingController = false;
+  let seedingUnsupported = false;
   {
     const seeding =
       preSeeded !== undefined
@@ -2206,10 +2210,12 @@ async function executeStoryboardPass(
         seedingPhaseResult = seeding.phase;
         passedCount += seeding.passedCount;
         failedCount += seeding.failedCount;
-        if (seeding.missingController) skippedCount += seeding.phase.steps.length;
+        if (seeding.missingController || seeding.seedUnsupported) skippedCount += seeding.phase.steps.length;
       }
       if (seeding.missingController) {
         seedingMissingController = true;
+      } else if (seeding.seedUnsupported) {
+        seedingUnsupported = true;
       } else if (!seeding.allPassed) {
         seedingFailed = true;
       }
@@ -2339,25 +2345,26 @@ async function executeStoryboardPass(
     // (those ride as plain properties on the spread result).
     context = { ...context };
 
-    // Seeding-cascade skip: either the pre-flight seed phase failed (setup
-    // break) or the agent doesn't advertise `comply_test_controller`
-    // (coverage gap). Both paths emit skipped steps; the reasons differ so
-    // compliance reports distinguish "agent misconfigured" from "agent not
-    // graded against this storyboard". `controller_seeding_failed` is a
-    // detailed reason mapped to canonical `prerequisite_failed`;
-    // `missing_test_controller` is canonical on its own. Emits full step
-    // rows (not an empty phase) so implementors see exactly which
+    // Seeding-cascade skip: the pre-flight seed phase can fail as a setup
+    // break, or the agent can be out-of-scope for fixture seeding because it
+    // lacks either the controller tool or a required seed_* scenario. Emit
+    // full step rows (not an empty phase) so implementors see exactly which
     // buyer-side operations were elided.
-    if (seedingMissingController || seedingFailed) {
+    if (seedingMissingController || seedingUnsupported || seedingFailed) {
       const cascadeSkip: Pick<StoryboardStepResult, 'skip_reason' | 'skip'> = seedingMissingController
         ? {
             skip_reason: 'missing_test_controller',
             skip: { reason: 'missing_test_controller', detail: SKIP_DETAILS.missing_test_controller },
           }
-        : {
-            skip_reason: 'controller_seeding_failed',
-            skip: { reason: 'prerequisite_failed', detail: CONTROLLER_SEEDING_FAILED_DETAIL },
-          };
+        : seedingUnsupported
+          ? {
+              skip_reason: 'fixture_seed_unsupported',
+              skip: { reason: 'not_applicable', detail: FIXTURE_SEED_UNSUPPORTED_DETAIL },
+            }
+          : {
+              skip_reason: 'controller_seeding_failed',
+              skip: { reason: 'prerequisite_failed', detail: CONTROLLER_SEEDING_FAILED_DETAIL },
+            };
       const cascadeSteps: StoryboardStepResult[] = phase.steps.map(step => ({
         storyboard_id: storyboard.id,
         step_id: step.id,
@@ -2938,6 +2945,11 @@ async function executeStoryboardPass(
       if (!phaseDef || phaseDef.optional || !p.passed) return false;
       return p.steps.some(s => !s.skipped && s.passed);
     });
+  const storyboardWideFixtureSeedUnsupported =
+    seedingUnsupported &&
+    failedCount === 0 &&
+    phaseResults.some(p => p.steps.some(s => s.skipped && s.skip?.reason === 'not_applicable')) &&
+    phaseResults.every(p => p.steps.every(s => s.skipped && s.skip?.reason === 'not_applicable'));
   // Prepend the pre-flight seeding phase now that every consumer that
   // index-aligns `phaseResults` with `storyboard.phases` has run. Reader
   // order matches execution order.
@@ -2959,7 +2971,8 @@ async function executeStoryboardPass(
     // `multi-pass`.
     ...(isMultiInstance && { multi_instance_strategy: 'round-robin' as const }),
     ...(routingContext && { agent_map: { ...routingContext.agentMap } }),
-    overall_passed: failedCount === 0 && requiredPhasesPassed && !assertionsFailed,
+    overall_passed:
+      failedCount === 0 && (requiredPhasesPassed || storyboardWideFixtureSeedUnsupported) && !assertionsFailed,
     phases: phaseResults,
     context,
     total_duration_ms: Date.now() - start,

--- a/src/lib/testing/storyboard/seeding.ts
+++ b/src/lib/testing/storyboard/seeding.ts
@@ -38,7 +38,13 @@ export const CONTROLLER_SEEDING_PHASE_ID = '__controller_seeding__';
 /** Seed scenario names. Kept local — the server-side `SEED_SCENARIOS`
  * constant from `src/lib/server/test-controller.ts` is authoritative, but
  * importing it here would cross the testing ⇄ server module boundary. */
-type SeedScenario = 'seed_product' | 'seed_pricing_option' | 'seed_creative' | 'seed_plan' | 'seed_media_buy';
+type SeedScenario =
+  | 'seed_product'
+  | 'seed_pricing_option'
+  | 'seed_creative_format'
+  | 'seed_creative'
+  | 'seed_plan'
+  | 'seed_media_buy';
 type BuyerAgentSeedScenario = 'seed_buyer_agent';
 
 interface SeedCall {
@@ -139,6 +145,27 @@ export function buildSeedCalls(fixtures: StoryboardFixtures | undefined): SeedCa
     });
   });
 
+  (fixtures.creative_formats ?? []).forEach((entry, i) => {
+    const { format_id, ...fixtureFields } = entry;
+    const label = format_id ?? `#${i}`;
+    if (typeof format_id !== 'string' || format_id.length === 0) {
+      calls.push({
+        step_id: `seed_creative_format.${label}`,
+        title: `Seed creative format ${label}`,
+        scenario: 'seed_creative_format',
+        params: { fixture: seedFixtureFromFields(fixtureFields) },
+        authoring_error: `fixtures.creative_formats[${i}] requires a non-empty string 'format_id'`,
+      });
+      return;
+    }
+    calls.push({
+      step_id: `seed_creative_format.${format_id}`,
+      title: `Seed creative format ${format_id}`,
+      scenario: 'seed_creative_format',
+      params: { format_id, fixture: seedFixtureFromFields(fixtureFields) },
+    });
+  });
+
   (fixtures.creatives ?? []).forEach((entry, i) => {
     const { creative_id, ...fixture } = entry;
     const label = creative_id ?? `#${i}`;
@@ -205,6 +232,13 @@ export function buildSeedCalls(fixtures: StoryboardFixtures | undefined): SeedCa
   return calls;
 }
 
+function seedFixtureFromFields(fields: Record<string, unknown>): unknown {
+  if (Object.keys(fields).length === 1 && Object.hasOwn(fields, 'fixture')) {
+    return fields.fixture;
+  }
+  return fields;
+}
+
 export interface ControllerSeedingResult {
   /** Synthetic pre-flight phase to prepend to `StoryboardResult.phases[]`. */
   phase: StoryboardPhaseResult;
@@ -221,6 +255,12 @@ export interface ControllerSeedingResult {
    * grade (storyboard-schema.yaml `skip_reasons`).
    */
   missingController?: boolean;
+  /**
+   * Agent advertised `comply_test_controller`, but not one of the generated
+   * seed_* scenarios this storyboard requires. This is a coverage gap, not
+   * a failed agent behavior.
+   */
+  seedUnsupported?: boolean;
 }
 
 /**
@@ -255,6 +295,19 @@ export async function runControllerSeeding(
   let passedCount = 0;
   let failedCount = 0;
   let allPassed = true;
+  const seedContext = { correlation_id: `${storyboardCorrelationPrefix(storyboard)}--__seeding__` };
+  const authoringErrorResult = buildAuthoringErrorResult(storyboard, calls, context, start);
+  if (authoringErrorResult) return authoringErrorResult;
+  const unsupportedScenario = await findUnsupportedSeedScenario(client, calls, options, seedContext);
+  if (unsupportedScenario) {
+    return buildUnsupportedSeedResult(
+      storyboard,
+      calls,
+      context,
+      unsupportedScenario.scenario,
+      unsupportedScenario.detail
+    );
+  }
 
   for (const call of calls) {
     const stepStart = Date.now();
@@ -265,10 +318,16 @@ export async function runControllerSeeding(
       error = call.authoring_error;
     } else {
       try {
-        const raw = await callControllerRaw(client, { scenario: call.scenario, params: call.params }, options);
+        const raw = await callControllerRaw(
+          client,
+          { scenario: call.scenario, params: call.params, context: seedContext },
+          options
+        );
         const data = raw.data as { success?: boolean; error?: string; error_detail?: string } | undefined;
         if (raw.success && data?.success === true) {
           passed = true;
+        } else if (raw.success && data?.success === false && data.error === 'UNKNOWN_SCENARIO') {
+          return buildUnsupportedSeedResult(storyboard, calls, context, call.scenario, data.error_detail);
         } else {
           error = formatControllerError(call.scenario, raw, data);
         }
@@ -310,6 +369,153 @@ export async function runControllerSeeding(
     allPassed,
     passedCount,
     failedCount,
+  };
+}
+
+function storyboardCorrelationPrefix(storyboard: Storyboard): string {
+  for (const phase of storyboard.phases) {
+    for (const step of phase.steps) {
+      const requestContext = step.sample_request?.context;
+      if (!requestContext || typeof requestContext !== 'object' || Array.isArray(requestContext)) continue;
+      const correlationId = (requestContext as { correlation_id?: unknown }).correlation_id;
+      if (typeof correlationId !== 'string' || correlationId.length === 0) continue;
+      const suffixSeparator = correlationId.lastIndexOf('--');
+      return suffixSeparator > 0 ? correlationId.slice(0, suffixSeparator) : correlationId;
+    }
+  }
+  return storyboard.id;
+}
+
+function buildAuthoringErrorResult(
+  storyboard: Storyboard,
+  calls: SeedCall[],
+  context: StoryboardContext,
+  start: number
+): ControllerSeedingResult | null {
+  const authoringErrors = calls.filter((call): call is SeedCall & { authoring_error: string } =>
+    Boolean(call.authoring_error)
+  );
+  if (authoringErrors.length === 0) return null;
+  const steps: StoryboardStepResult[] = authoringErrors.map(call => ({
+    storyboard_id: storyboard.id,
+    step_id: call.step_id,
+    phase_id: CONTROLLER_SEEDING_PHASE_ID,
+    title: call.title,
+    task: 'comply_test_controller',
+    passed: false,
+    duration_ms: 0,
+    validations: [],
+    context,
+    extraction: { path: 'none' },
+    error: call.authoring_error,
+  }));
+  return {
+    phase: {
+      phase_id: CONTROLLER_SEEDING_PHASE_ID,
+      phase_title: 'Controller seeding (pre-flight) — invalid storyboard fixtures',
+      passed: false,
+      steps,
+      duration_ms: Date.now() - start,
+    },
+    allPassed: false,
+    passedCount: 0,
+    failedCount: steps.length,
+  };
+}
+
+async function findUnsupportedSeedScenario(
+  client: TestClient,
+  calls: SeedCall[],
+  options: StoryboardRunOptions,
+  seedContext: Record<string, unknown>
+): Promise<{ scenario: SeedScenario | BuyerAgentSeedScenario; detail: string } | null> {
+  const requiredScenarios = [...new Set(calls.filter(call => !call.authoring_error).map(call => call.scenario))];
+  if (requiredScenarios.length === 0) return null;
+
+  let advertisedScenarios = controllerScenarioSetFromOptions(options);
+  if (!advertisedScenarios) {
+    advertisedScenarios = await fetchControllerScenarioSet(client, options, seedContext);
+  }
+  if (!advertisedScenarios) return null;
+
+  for (const scenario of requiredScenarios) {
+    if (!advertisedScenarios.has(scenario)) {
+      return {
+        scenario,
+        detail: `list_scenarios did not advertise required seed scenario "${scenario}".`,
+      };
+    }
+  }
+  return null;
+}
+
+function controllerScenarioSetFromOptions(options: StoryboardRunOptions): Set<string> | null {
+  const capabilities = options._controllerCapabilities;
+  if (capabilities?.detected !== true) return null;
+  return new Set((capabilities.scenarios as readonly string[]).filter(scenario => typeof scenario === 'string'));
+}
+
+async function fetchControllerScenarioSet(
+  client: TestClient,
+  options: StoryboardRunOptions,
+  seedContext: Record<string, unknown>
+): Promise<Set<string> | null> {
+  try {
+    const raw = await callControllerRaw(client, { scenario: 'list_scenarios', context: seedContext }, options);
+    const data = raw.data as { success?: boolean; scenarios?: unknown } | undefined;
+    if (!raw.success || data?.success !== true) return null;
+    if (Array.isArray(data.scenarios)) {
+      return new Set(data.scenarios.filter((scenario): scenario is string => typeof scenario === 'string'));
+    }
+    if (data.scenarios && typeof data.scenarios === 'object') {
+      return new Set(Object.keys(data.scenarios));
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+const UNSUPPORTED_SEED_DETAIL =
+  'Skipped: agent advertised comply_test_controller, but does not implement a seed_* scenario required by this storyboard (`fixture_seed_unsupported`). Storyboard grades not_applicable — the buyer-side flow depends on pre-seeded state the agent has no way to accept.';
+
+function buildUnsupportedSeedResult(
+  storyboard: Storyboard,
+  calls: Array<{ step_id: string; title: string }>,
+  context: StoryboardContext,
+  scenario: SeedScenario | BuyerAgentSeedScenario,
+  detail?: string
+): ControllerSeedingResult {
+  const skipDetail = detail
+    ? `${UNSUPPORTED_SEED_DETAIL} Unsupported scenario ${scenario}: ${detail}`
+    : `${UNSUPPORTED_SEED_DETAIL} Unsupported scenario: ${scenario}.`;
+  const steps: StoryboardStepResult[] = calls.map(call => ({
+    storyboard_id: storyboard.id,
+    step_id: call.step_id,
+    phase_id: CONTROLLER_SEEDING_PHASE_ID,
+    title: call.title,
+    task: 'comply_test_controller',
+    passed: true,
+    skipped: true,
+    skip_reason: 'fixture_seed_unsupported',
+    skip: { reason: 'not_applicable', detail: skipDetail },
+    duration_ms: 0,
+    validations: [],
+    context,
+    extraction: { path: 'none' },
+  }));
+  return {
+    phase: {
+      phase_id: CONTROLLER_SEEDING_PHASE_ID,
+      phase_title: 'Controller seeding (pre-flight) — agent lacks required seed scenario',
+      passed: true,
+      steps,
+      duration_ms: 0,
+    },
+    allPassed: true,
+    passedCount: 0,
+    failedCount: 0,
+    seedUnsupported: true,
   };
 }
 

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -276,6 +276,7 @@ export interface StepInvariantsObject {
  *
  *   - `products[]`      → `seed_product`         — requires `product_id`
  *   - `pricing_options[]` → `seed_pricing_option` — requires `product_id` + `pricing_option_id`
+ *   - `creative_formats[]` → `seed_creative_format` — requires `format_id`
  *   - `creatives[]`     → `seed_creative`        — requires `creative_id`
  *   - `plans[]`         → `seed_plan`            — requires `plan_id`
  *   - `media_buys[]`    → `seed_media_buy`       — requires `media_buy_id`
@@ -291,6 +292,7 @@ export interface StepInvariantsObject {
 export interface StoryboardFixtures {
   products?: Array<Record<string, unknown> & { product_id?: string }>;
   pricing_options?: Array<Record<string, unknown> & { product_id?: string; pricing_option_id?: string }>;
+  creative_formats?: Array<Record<string, unknown> & { format_id?: string; fixture?: unknown }>;
   creatives?: Array<Record<string, unknown> & { creative_id?: string }>;
   plans?: Array<Record<string, unknown> & { plan_id?: string }>;
   media_buys?: Array<Record<string, unknown> & { media_buy_id?: string }>;
@@ -1727,6 +1729,13 @@ export type RunnerDetailedSkipReason =
    */
   | 'controller_seeding_failed'
   /**
+   * A generated pre-flight seed_* call targeted a scenario that the agent's
+   * comply_test_controller does not implement. Maps to canonical
+   * `not_applicable`: the seller cannot accept this storyboard's fixture
+   * setup, so the storyboard is out of scope rather than failed.
+   */
+  | 'fixture_seed_unsupported'
+  /**
    * A `requires_capability` predicate on the storyboard evaluated to false —
    * the agent explicitly declared it does not support the capability this
    * storyboard tests (e.g. `adcp.idempotency.supported: false`). The whole
@@ -1764,6 +1773,7 @@ export const DETAILED_SKIP_TO_CANONICAL: Record<RunnerDetailedSkipReason, Runner
   oauth_not_advertised: 'not_applicable',
   rate_limit_not_triggered: 'not_applicable',
   force_scenario_unsupported: 'not_applicable',
+  fixture_seed_unsupported: 'not_applicable',
   capability_unsupported: 'unsatisfied_contract',
   rate_abuse_opt_out: 'unsatisfied_contract',
   missing_test_kit_contract: 'unsatisfied_contract',

--- a/test/lib/storyboard-controller-seeding.test.js
+++ b/test/lib/storyboard-controller-seeding.test.js
@@ -81,6 +81,32 @@ describe('buildSeedCalls', () => {
     });
   });
 
+  test('creative_formats → seed_creative_format with format_id lifted and fixture body preserved', () => {
+    const calls = buildSeedCalls({
+      creative_formats: [
+        {
+          format_id: 'display_300x250',
+          fixture: { name: 'Display 300x250', type: 'display' },
+        },
+        {
+          format_id: 'video_30s',
+          name: 'Video 30s',
+          type: 'video',
+        },
+      ],
+    });
+    assert.strictEqual(calls.length, 2);
+    assert.strictEqual(calls[0].scenario, 'seed_creative_format');
+    assert.deepStrictEqual(calls[0].params, {
+      format_id: 'display_300x250',
+      fixture: { name: 'Display 300x250', type: 'display' },
+    });
+    assert.deepStrictEqual(calls[1].params, {
+      format_id: 'video_30s',
+      fixture: { name: 'Video 30s', type: 'video' },
+    });
+  });
+
   test('buyer_agents → seed_buyer_agent with agent_url lifted and commercial fields direct', () => {
     const calls = buildSeedCalls({
       buyer_agents: [
@@ -100,18 +126,27 @@ describe('buildSeedCalls', () => {
     });
   });
 
-  test('emits ordering: buyer_agents → products → pricing_options → creatives → plans → media_buys', () => {
+  test('emits ordering: buyer_agents → products → pricing_options → creative_formats → creatives → plans → media_buys', () => {
     const calls = buildSeedCalls({
       media_buys: [{ media_buy_id: 'mb-1' }],
       buyer_agents: [{ agent_url: 'https://buyer.example/agent' }],
       products: [{ product_id: 'p-1' }],
+      creative_formats: [{ format_id: 'fmt-1' }],
       creatives: [{ creative_id: 'c-1' }],
       plans: [{ plan_id: 'pl-1' }],
       pricing_options: [{ product_id: 'p-1', pricing_option_id: 'po-1' }],
     });
     assert.deepStrictEqual(
       calls.map(c => c.scenario),
-      ['seed_buyer_agent', 'seed_product', 'seed_pricing_option', 'seed_creative', 'seed_plan', 'seed_media_buy']
+      [
+        'seed_buyer_agent',
+        'seed_product',
+        'seed_pricing_option',
+        'seed_creative_format',
+        'seed_creative',
+        'seed_plan',
+        'seed_media_buy',
+      ]
     );
   });
 
@@ -120,13 +155,15 @@ describe('buildSeedCalls', () => {
       buyer_agents: [{ status: 'active' }],
       products: [{ delivery_type: 'non_guaranteed' }],
       pricing_options: [{ product_id: 'p-1' }],
+      creative_formats: [{ name: 'missing format_id' }],
       creatives: [{ format_id: 'x' }],
     });
-    assert.strictEqual(calls.length, 4);
+    assert.strictEqual(calls.length, 5);
     assert.match(calls[0].authoring_error, /agent_url/);
     assert.match(calls[1].authoring_error, /product_id/);
     assert.match(calls[2].authoring_error, /pricing_option_id/);
-    assert.match(calls[3].authoring_error, /creative_id/);
+    assert.match(calls[3].authoring_error, /format_id/);
+    assert.match(calls[4].authoring_error, /creative_id/);
   });
 });
 
@@ -206,10 +243,13 @@ describe('runControllerSeeding', () => {
     const { client, calls } = makeMockClient(successResponse);
     const result = await runControllerSeeding(client, storyboard, {}, {});
     assert.ok(result, 'seeding result should exist');
-    assert.strictEqual(calls.length, 3);
-    for (const call of calls) {
+    assert.strictEqual(calls[0].params.scenario, 'list_scenarios');
+    const seedCalls = calls.filter(call => String(call.params.scenario).startsWith('seed_'));
+    assert.strictEqual(seedCalls.length, 3);
+    for (const call of seedCalls) {
       assert.strictEqual(call.name, 'comply_test_controller');
       assert.match(String(call.params.scenario), /seed_/);
+      assert.deepStrictEqual(call.params.context, { correlation_id: 'test_sb--__seeding__' });
     }
     assert.strictEqual(result.allPassed, true);
     assert.strictEqual(result.passedCount, 3);
@@ -220,6 +260,144 @@ describe('runControllerSeeding', () => {
       assert.strictEqual(step.passed, true);
       assert.strictEqual(step.task, 'comply_test_controller');
     }
+  });
+
+  test('uses a stable seeding correlation id that differs by storyboard id', async () => {
+    const { client, calls } = makeMockClient(successResponse);
+    const first = { ...storyboardWithFixtures, id: 'first_sb' };
+    const second = { ...storyboardWithFixtures, id: 'second_sb' };
+
+    await runControllerSeeding(client, first, {}, { correlation_id: 'runner-context-ignored' });
+    await runControllerSeeding(client, second, {}, { correlation_id: 'runner-context-ignored' });
+
+    const seedCalls = calls.filter(call => String(call.params.scenario).startsWith('seed_'));
+    assert.strictEqual(seedCalls.length, 2);
+    assert.deepStrictEqual(seedCalls[0].params.context, { correlation_id: 'first_sb--__seeding__' });
+    assert.deepStrictEqual(seedCalls[1].params.context, { correlation_id: 'second_sb--__seeding__' });
+    assert.notStrictEqual(seedCalls[0].params.context.correlation_id, seedCalls[1].params.context.correlation_id);
+  });
+
+  test('derives seeding correlation prefix from authored storyboard step context when present', async () => {
+    const storyboard = {
+      ...storyboardWithFixtures,
+      id: 'media_buy_seller/provenance_enforcement',
+      phases: [
+        {
+          id: 'discovery',
+          title: 'discovery',
+          steps: [
+            {
+              id: 'get_products_with_disclosure_policy',
+              title: 'get products',
+              task: 'get_products',
+              sample_request: {
+                context: { correlation_id: 'provenance_enforcement--get_products' },
+              },
+              validations: [],
+            },
+          ],
+        },
+      ],
+    };
+    const runnerContext = { correlation_id: 'runner-context-ignored' };
+    const { client, calls } = makeMockClient(successResponse);
+
+    const result = await runControllerSeeding(client, storyboard, {}, runnerContext);
+
+    assert.ok(result);
+    const seedCalls = calls.filter(call => String(call.params.scenario).startsWith('seed_'));
+    assert.strictEqual(seedCalls.length, 1);
+    assert.deepStrictEqual(seedCalls[0].params.context, { correlation_id: 'provenance_enforcement--__seeding__' });
+    assert.strictEqual(result.phase.steps[0].context, runnerContext);
+  });
+
+  test('preserves authored correlation prefixes that contain internal double-dash separators', async () => {
+    const storyboard = {
+      ...storyboardWithFixtures,
+      id: 'creative_generative/seller',
+      phases: [
+        {
+          id: 'capabilities',
+          title: 'capabilities',
+          steps: [
+            {
+              id: 'get_capabilities',
+              title: 'get capabilities',
+              task: 'get_adcp_capabilities',
+              sample_request: {
+                context: { correlation_id: 'creative_generative--seller--get_capabilities' },
+              },
+              validations: [],
+            },
+          ],
+        },
+      ],
+    };
+    const { client, calls } = makeMockClient(successResponse);
+
+    await runControllerSeeding(client, storyboard, {}, {});
+
+    const seedCalls = calls.filter(call => String(call.params.scenario).startsWith('seed_'));
+    assert.strictEqual(seedCalls.length, 1);
+    assert.deepStrictEqual(seedCalls[0].params.context, { correlation_id: 'creative_generative--seller--__seeding__' });
+  });
+
+  test('preflights list_scenarios before mixed-fixture seeding to avoid partial writes', async () => {
+    const storyboard = {
+      ...storyboardWithFixtures,
+      fixtures: {
+        products: [{ product_id: 'p-1' }],
+        pricing_options: [{ product_id: 'p-1', pricing_option_id: 'po-1' }],
+      },
+    };
+    const { client, calls } = makeMockClient(({ params }) => {
+      if (params.scenario === 'list_scenarios') {
+        return {
+          success: true,
+          data: {
+            content: [{ type: 'text', text: JSON.stringify({ success: true, scenarios: ['seed_product'] }) }],
+          },
+        };
+      }
+      return successResponse();
+    });
+
+    const result = await runControllerSeeding(client, storyboard, {}, {});
+
+    assert.ok(result);
+    assert.strictEqual(result.seedUnsupported, true);
+    assert.deepStrictEqual(
+      calls.map(call => call.params.scenario),
+      ['list_scenarios'],
+      'no mutating seed call should be issued after preflight finds an unsupported seed scenario'
+    );
+    assert.strictEqual(result.phase.steps.length, 2);
+    for (const step of result.phase.steps) {
+      assert.strictEqual(step.skipped, true);
+      assert.strictEqual(step.skip_reason, 'fixture_seed_unsupported');
+      assert.strictEqual(step.skip.reason, 'not_applicable');
+    }
+  });
+
+  test('fixture authoring errors win over unsupported seed preflight without controller calls', async () => {
+    const storyboard = {
+      ...storyboardWithFixtures,
+      fixtures: {
+        products: [{ delivery_type: 'guaranteed' }],
+        creative_formats: [{ format_id: 'fmt-1' }],
+      },
+    };
+    const { client, calls } = makeMockClient(() => {
+      throw new Error('controller must not be called for malformed fixtures');
+    });
+
+    const result = await runControllerSeeding(client, storyboard, {}, {});
+
+    assert.ok(result);
+    assert.strictEqual(calls.length, 0);
+    assert.strictEqual(result.allPassed, false);
+    assert.strictEqual(result.failedCount, 1);
+    assert.match(result.phase.steps[0].error, /product_id/);
   });
 
   test('failure path: controller returns an error for one seed — phase fails, allPassed is false', async () => {
@@ -331,11 +509,14 @@ describe('runStoryboard: controller seeding integration', () => {
       _client: client,
     });
 
-    const seedCalls = calls.filter(c => c.name === 'comply_test_controller');
+    const controllerCalls = calls.filter(c => c.name === 'comply_test_controller');
+    const seedCalls = controllerCalls.filter(c => String(c.params.scenario).startsWith('seed_'));
     const productCalls = calls.filter(c => c.name === 'get_products');
+    assert.strictEqual(controllerCalls[0].params.scenario, 'list_scenarios');
     assert.strictEqual(seedCalls.length, 1, 'exactly one seed_product call');
     assert.strictEqual(seedCalls[0].params.scenario, 'seed_product');
     assert.strictEqual(seedCalls[0].params.params.product_id, 'sports_display');
+    assert.deepStrictEqual(seedCalls[0].params.context, { correlation_id: 'seed_runner_sb--__seeding__' });
     assert.ok(productCalls.length >= 1, 'real phase should run after seeding');
 
     const seedPhase = result.phases.find(p => p.phase_id === '__controller_seeding__');
@@ -352,7 +533,7 @@ describe('runStoryboard: controller seeding integration', () => {
             content: [
               {
                 type: 'text',
-                text: JSON.stringify({ success: false, error: 'UNKNOWN_SCENARIO', error_detail: 'no seedProduct' }),
+                text: JSON.stringify({ success: false, error: 'INVALID_PARAMS', error_detail: 'bad fixture' }),
               },
             ],
           },
@@ -383,6 +564,52 @@ describe('runStoryboard: controller seeding integration', () => {
       // controller_seeding_failed collapses to prerequisite_failed per
       // DETAILED_SKIP_TO_CANONICAL.
       assert.strictEqual(step.skip.reason, 'prerequisite_failed');
+    }
+  });
+
+  test('unsupported seed scenario grades not_applicable via fixture_seed_unsupported cascade', async () => {
+    const { client, calls } = makeRunnerClient(({ name }) => {
+      if (name === 'comply_test_controller') {
+        return {
+          success: true,
+          data: {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify({ success: false, error: 'UNKNOWN_SCENARIO', error_detail: 'no seedProduct' }),
+              },
+            ],
+          },
+        };
+      }
+      return successResponse();
+    });
+    const result = await runStoryboard('https://example.invalid/mcp', baseStoryboard, {
+      protocol: 'mcp',
+      agentTools: ['comply_test_controller', 'get_products'],
+      _profile: { name: 'Test', tools: ['comply_test_controller', 'get_products'] },
+      _client: client,
+    });
+
+    assert.strictEqual(result.failed_count, 0, 'unsupported seed scenarios must not count as failures');
+    assert.strictEqual(result.overall_passed, true, 'unsupported seed scenarios grade not_applicable, not failed');
+    const realPhaseCalls = calls.filter(c => c.name === 'get_products');
+    assert.strictEqual(realPhaseCalls.length, 0, 'real phases must not run without required fixture seeding');
+
+    const seedPhase = result.phases.find(p => p.phase_id === '__controller_seeding__');
+    assert.ok(seedPhase);
+    for (const step of seedPhase.steps) {
+      assert.strictEqual(step.skipped, true);
+      assert.strictEqual(step.skip_reason, 'fixture_seed_unsupported');
+      assert.strictEqual(step.skip.reason, 'not_applicable');
+    }
+
+    const realPhase = result.phases.find(p => p.phase_id === 'discovery');
+    assert.ok(realPhase);
+    for (const step of realPhase.steps) {
+      assert.strictEqual(step.skipped, true, `step ${step.step_id} should be skipped`);
+      assert.strictEqual(step.skip_reason, 'fixture_seed_unsupported');
+      assert.strictEqual(step.skip.reason, 'not_applicable');
     }
   });
 

--- a/test/server-test-controller.test.js
+++ b/test/server-test-controller.test.js
@@ -773,6 +773,46 @@ describe('handleTestControllerRequest', () => {
       );
     });
 
+    it('same account can seed the same product_id with divergent fixtures when correlation_id differs', async () => {
+      const writes = [];
+      const store = {
+        async seedProduct(productId, fixture) {
+          writes.push({ productId, fixture });
+        },
+      };
+      const seedCache = createSeedFixtureCache();
+
+      const first = await handleTestControllerRequest(
+        store,
+        {
+          scenario: 'seed_product',
+          account: { account_id: 'acc_1' },
+          context: { correlation_id: 'storyboard_a--__seeding__' },
+          params: { product_id: 'p1', fixture: { x: 1 } },
+        },
+        { seedCache }
+      );
+      assert.strictEqual(first.success, true);
+      assert.strictEqual(first.message, 'Fixture seeded');
+
+      const second = await handleTestControllerRequest(
+        store,
+        {
+          scenario: 'seed_product',
+          account: { account_id: 'acc_1' },
+          context: { correlation_id: 'storyboard_b--__seeding__' },
+          params: { product_id: 'p1', fixture: { x: 2 } },
+        },
+        { seedCache }
+      );
+      assert.strictEqual(second.success, true);
+      assert.strictEqual(second.message, 'Fixture seeded');
+      assert.deepStrictEqual(
+        writes.map(w => w.fixture.x),
+        [1, 2]
+      );
+    });
+
     it('same account replaying with divergent fixture still returns INVALID_PARAMS', async () => {
       const store = {
         async seedProduct() {},


### PR DESCRIPTION
This fixes #2156 by adding storyboard-scoped correlation IDs to generated controller seeding calls and using those IDs in the reference controller seed-cache scope. It also adds creative-format fixture seeding, preflights required seed scenarios to avoid partial writes, and grades unsupported seed scenarios as fixture_seed_unsupported/not_applicable. Invalid fixture authoring still fails before any controller calls, so malformed storyboards are not masked by missing seed support. Validated with npm run ci:quick plus the focused storyboard/controller test suite.