### PR TITLE
fix: reset compliance task registry

### DIFF
--- a/.changeset/compliance-reset-task-registry.md
+++ b/.changeset/compliance-reset-task-registry.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Flush in-memory task registries from compliance.reset() so repeated storyboard runs can reuse hardcoded task IDs.

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -59,6 +59,7 @@ import type { TaskStore, TaskMessageQueue } from './tasks';
 import { adcpError, applyAdcpErrorAllowlist } from './errors';
 import type { BuyerAgent, BuyerAgentRegistry } from './decisioning/buyer-agent';
 import type { ResolvedAuthInfo } from './decisioning/account';
+import type { TaskRegistry } from './decisioning/runtime/task-registry';
 import { AdcpError } from './decisioning/async-outcome';
 import { redactCredentialPatterns } from './redact';
 import {
@@ -1430,6 +1431,15 @@ export interface AdcpServerConfig<TAccount = unknown> {
    * Defaults to InMemoryStateStore. Use PostgresStateStore for production.
    */
   stateStore?: AdcpStateStore;
+
+  /**
+   * Task registry for async task lifecycle records.
+   *
+   * Usually supplied by `createAdcpServerFromPlatform`; low-level callers
+   * only need this when they want `compliance.reset()` to flush in-memory
+   * task records between repeated test runs.
+   */
+  taskRegistry?: TaskRegistry;
 
   // Domain handler groups — register only what you support
   mediaBuy?: MediaBuyHandlers<TAccount>;
@@ -3100,6 +3110,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
     agentRegistry,
     exposeErrorDetails = process.env.NODE_ENV !== 'production',
     stateStore = DEFAULT_STATE_STORE,
+    taskRegistry,
     logger = noopLogger,
     capabilities: capConfig,
     idempotency: idempotencyConfig,
@@ -5362,6 +5373,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
       const storeWithClear = stateStore as unknown as { clear?: () => void };
       if (typeof storeWithClear.clear === 'function') storeWithClear.clear();
       if (idempotency && idempotency.clearAll) await idempotency.clearAll();
+      if (taskRegistry?.clear) await taskRegistry.clear();
     },
   };
   const wrapped: AdcpServerInternal = wrapMcpServer(server, compliance, adcpVersion);

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -1220,6 +1220,7 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
 
   const config: AdcpServerConfig<Account> = {
     ...opts,
+    taskRegistry,
     ...(autoSeedStore != null && { testController: makeAutoSeedBridge(autoSeedStore) }),
     ...(projectedCapabilitiesConfig != null && { capabilities: projectedCapabilitiesConfig }),
     // Buyer-agent registry (Phase 1 of #1269). Threaded through from the

--- a/src/lib/server/decisioning/runtime/task-registry.ts
+++ b/src/lib/server/decisioning/runtime/task-registry.ts
@@ -135,6 +135,14 @@ export interface TaskRegistry {
    * Used by test harnesses + `tasks/get` integration.
    */
   awaitTask(taskId: string): Promise<void>;
+
+  /**
+   * Optional test-harness flush. In-memory registries expose this so
+   * `AdcpServer.compliance.reset()` can clear hardcoded overrideTaskId
+   * records between repeated storyboard runs. Persistent registries should
+   * omit it unless they can safely flush their configured backend.
+   */
+  clear?(): void | Promise<void>;
 }
 
 export function createInMemoryTaskRegistry(): TaskRegistry {
@@ -213,6 +221,11 @@ export function createInMemoryTaskRegistry(): TaskRegistry {
     async awaitTask(taskId: string): Promise<void> {
       const pending = backgrounds.get(taskId);
       if (pending) await pending;
+    },
+
+    clear(): void {
+      tasks.clear();
+      backgrounds.clear();
     },
   };
 }

--- a/test/server-decisioning-handoff-task-id.test.js
+++ b/test/server-decisioning-handoff-task-id.test.js
@@ -161,4 +161,46 @@ describe('createInMemoryTaskRegistry overrideTaskId collision guard (#1554)', ()
     const { taskId } = await registry.create({ tool: 't', accountId: 'a1' });
     assert.ok(taskId.startsWith('task_'));
   });
+
+  it('clear() removes existing tasks and preserves the registry instance', async () => {
+    const registry = createInMemoryTaskRegistry();
+    const registerBackground = registry._registerBackground;
+    await registry.create({ tool: 't', accountId: 'a1', overrideTaskId: 'task_clear' });
+    registry._registerBackground('task_clear', new Promise(() => {}));
+
+    registry.clear();
+
+    assert.strictEqual(registry._registerBackground, registerBackground);
+    assert.strictEqual(await registry.getTask('task_clear'), null);
+    await assert.doesNotReject(() => registry.create({ tool: 't', accountId: 'a1', overrideTaskId: 'task_clear' }));
+  });
+});
+
+describe('compliance.reset taskRegistry flush (#2154)', () => {
+  it('allows a forced task_id to be reused after compliance.reset()', async () => {
+    const FORCED_ID = 'task_reset-reusable-abc123';
+    const taskRegistry = createInMemoryTaskRegistry();
+    const platform = buildPlatform({
+      createMediaBuy: async (_req, ctx) =>
+        ctx.handoffToTask(async () => ({ media_buy_id: 'mb_reset', status: 'active' }), { task_id: FORCED_ID }),
+    });
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'test',
+      version: '0.0.1',
+      taskRegistry,
+      validation: { requests: 'off', responses: 'off' },
+    });
+
+    const first = await dispatchCreate(server);
+    assert.strictEqual(first.structuredContent.task_id, FORCED_ID);
+    await server.awaitTask(FORCED_ID);
+    assert.ok(await taskRegistry.getTask(FORCED_ID), 'pre-reset task is present');
+
+    await server.compliance.reset();
+
+    assert.strictEqual(await taskRegistry.getTask(FORCED_ID), null, 'reset cleared task registry');
+    const second = await dispatchCreate(server);
+    assert.strictEqual(second.structuredContent.task_id, FORCED_ID);
+    assert.notStrictEqual(second.isError, true, JSON.stringify(second.structuredContent));
+  });
 });


### PR DESCRIPTION
## Summary

- add an optional task registry clear hook and implement it for the in-memory registry
- thread the resolved task registry through createAdcpServerFromPlatform into createAdcpServer
- make compliance.reset() flush task records so forced task_id values can be reused across repeated storyboard runs
- add regression coverage and a patch changeset

Closes #2154.

## Validation

- node --test test/server-decisioning-handoff-task-id.test.js
- npm run ci:quick
- node --test test/lib/request-builder.test.js
- git diff --check
