### PR TITLE
feat(server): add response enhancer callback

### DIFF
--- a/.changeset/response-enhancer-config.md
+++ b/.changeset/response-enhancer-config.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': minor
+---
+
+Add an optional `responseEnhancer` callback to `createAdcpServer` and `createAdcpServerFromPlatform` for mutating MCP tool responses before they are returned.

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -1572,8 +1572,9 @@ export interface AdcpServerConfig<TAccount = unknown> {
    */
   webhooks?: WebhooksConfig;
   /**
-   * Optional callback to customize how the response is enhanced.
-   * If not provided, no response enhancement will be performed.
+   * Optional callback that can mutate MCP tool responses before they are
+   * returned. Runs for framework tools, custom tools, and generated discovery
+   * responses registered by `createAdcpServer`.
    */
   responseEnhancer?: (response: McpToolResponse) => void;
   /**
@@ -3512,6 +3513,11 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
 
   const registeredToolNames = new Set<string>();
 
+  const applyResponseEnhancer = (response: McpToolResponse): McpToolResponse => {
+    responseEnhancer?.(response);
+    return response;
+  };
+
   // Collect all domain handlers into a flat toolName → handler map
   const domainGroups: [Record<string, Function> | undefined, HandlerEntry[]][] = [
     [config.mediaBuy as Record<string, Function> | undefined, MEDIA_BUY_ENTRIES],
@@ -3605,10 +3611,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
           injectEnvelopeStatusIntoResponse(response);
           injectContextIntoResponse(response, params.context);
           injectVersionIntoResponse(response, servedAdcpVersion);
-          if (responseEnhancer) {
-            responseEnhancer(response);
-          }
-          return response;
+          return applyResponseEnhancer(response);
         };
 
         // --- Buyer-agent registry resolution (#1269 / #1292) ---
@@ -3829,12 +3832,14 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
               // path, which under-discloses when several vectors are
               // present together. Full list lives in
               // `details.credential_paths`.
-              return adcpError('PERMISSION_DENIED', {
-                message:
-                  'Request args carry credential-shaped keys. Credentials must arrive on authInfo, not in the request body.',
-                recovery: 'correctable',
-                details: { scope: 'credentials', credential_paths: blockedPaths },
-              });
+              return applyResponseEnhancer(
+                adcpError('PERMISSION_DENIED', {
+                  message:
+                    'Request args carry credential-shaped keys. Credentials must arrive on authInfo, not in the request body.',
+                  recovery: 'correctable',
+                  details: { scope: 'credentials', credential_paths: blockedPaths },
+                })
+              );
             }
           }
         }
@@ -3891,12 +3896,14 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
                 // signal; losing the diagnostic log is acceptable when
                 // the alternative is failing the request entirely.
               }
-              return adcpError('PERMISSION_DENIED', {
-                message:
-                  'Request authentication context carries credential-shaped keys. Configure your authenticator to keep credentials off authInfo.extra.',
-                recovery: 'terminal',
-                details: { scope: 'credentials' },
-              });
+              return applyResponseEnhancer(
+                adcpError('PERMISSION_DENIED', {
+                  message:
+                    'Request authentication context carries credential-shaped keys. Configure your authenticator to keep credentials off authInfo.extra.',
+                  recovery: 'terminal',
+                  details: { scope: 'credentials' },
+                })
+              );
             }
           }
         }
@@ -5117,10 +5124,10 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
       const rawHandler = handler as (...args: unknown[]) => Promise<McpToolResponse> | McpToolResponse;
       const wrappedHandler = (async (...args: unknown[]) => {
         try {
-          return await rawHandler(...args);
+          return applyResponseEnhancer(await rawHandler(...args));
         } catch (err) {
-          if (isThrownAdcpError(err)) return err;
-          if (err instanceof AdcpError) return projectThrownAdcpError(err);
+          if (isThrownAdcpError(err)) return applyResponseEnhancer(err);
+          if (err instanceof AdcpError) return applyResponseEnhancer(projectThrownAdcpError(err));
           throw err;
         }
       }) as Parameters<typeof server.registerTool>[2];
@@ -5316,7 +5323,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
       if (ctx !== null && typeof ctx === 'object' && !Array.isArray(ctx)) {
         (data as any).context = ctx;
       }
-      return capabilitiesResponse(data);
+      return applyResponseEnhancer(capabilitiesResponse(data));
     }) as Parameters<typeof server.registerTool>[2]
   );
   registeredToolNames.add('get_adcp_capabilities');

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -1572,6 +1572,11 @@ export interface AdcpServerConfig<TAccount = unknown> {
    */
   webhooks?: WebhooksConfig;
   /**
+   * Optional callback to customize how the response is enhanced.
+   * If not provided, no response enhancement will be performed.
+   */
+  responseEnhancer?: (response: McpToolResponse) => void;
+  /**
    * Auto-wire the RFC 9421 request-signature verifier onto the HTTP transport.
    * When set together with `capabilities.specialisms` containing
    * `signed-requests`, `serve()` mounts the verifier as `preTransport` so
@@ -3124,6 +3129,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
     validation: validationConfig,
     credentialPolicy,
     testController: testControllerBridge,
+    responseEnhancer,
   } = config;
 
   // One-shot construction-time warn when `testController` is wired without
@@ -3599,6 +3605,9 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
           injectEnvelopeStatusIntoResponse(response);
           injectContextIntoResponse(response, params.context);
           injectVersionIntoResponse(response, servedAdcpVersion);
+          if (responseEnhancer) {
+            responseEnhancer(response);
+          }
           return response;
         };
 

--- a/test/server-decisioning-from-platform.test.js
+++ b/test/server-decisioning-from-platform.test.js
@@ -133,6 +133,42 @@ describe('createAdcpServerFromPlatform — v6.0 alpha', () => {
     assert.strictEqual(typeof sawCtx.resolve.creativeFormat, 'function');
   });
 
+  it('applies responseEnhancer to platform and generated discovery responses', async () => {
+    const enhancedStatuses = [];
+    const server = createAdcpServerFromPlatform(buildPlatform(), {
+      name: 'spike',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+      responseEnhancer: response => {
+        enhancedStatuses.push(response.structuredContent?.status);
+        const first = Array.isArray(response.content) ? response.content[0] : undefined;
+        if (first && first.type === 'text' && typeof first.text === 'string') {
+          first.text = `${first.text}\n\nenhanced`;
+        }
+      },
+    });
+
+    const products = await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'get_products',
+        arguments: {
+          brief: 'premium',
+          promoted_offering: 'cars',
+          account: { account_id: 'acc_test' },
+        },
+      },
+    });
+    const capabilities = await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: { name: 'get_adcp_capabilities', arguments: {} },
+    });
+
+    assert.match(products.content[0].text, /enhanced/);
+    assert.match(capabilities.content[0].text, /enhanced/);
+    assert.strictEqual(enhancedStatuses.length, 2);
+  });
+
   it('fails closed for auth-derived get_products responses missing cache_scope', async () => {
     let sawCtx;
     const base = buildPlatform();
@@ -3158,6 +3194,32 @@ describe('tasks_get wire tool (B9)', () => {
     assert.strictEqual(payload.status, 'completed');
     assert.strictEqual(payload.protocol, 'media-buy');
     assert.deepStrictEqual(payload.result, { media_buy_id: 'mb_42', status: 'active' });
+  });
+
+  it('applies responseEnhancer to the framework-owned tasks_get custom tool', async () => {
+    const server = createAdcpServerFromPlatform(
+      buildHitlPlatform(async () => ({ media_buy_id: 'mb_42', status: 'active' })),
+      {
+        name: 'p',
+        version: '0.0.1',
+        validation: { requests: 'off', responses: 'off' },
+        responseEnhancer: response => {
+          const first = Array.isArray(response.content) ? response.content[0] : undefined;
+          if (first && first.type === 'text' && typeof first.text === 'string') {
+            first.text = `${first.text}\n\nenhanced`;
+          }
+        },
+      }
+    );
+    const taskId = await createTask(server, 'acc_owner');
+    const result = await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: { name: 'tasks_get', arguments: { task_id: taskId, account: { account_id: 'acc_owner' } } },
+    });
+
+    assert.notStrictEqual(result.isError, true, JSON.stringify(result.structuredContent));
+    assert.match(result.content[0].text, /enhanced/);
+    assert.strictEqual(result.structuredContent.task_id, taskId);
   });
 
   it('returns failed task with top-level error per spec tasks-get-response.json', async () => {


### PR DESCRIPTION
## Summary

Addresses the requested changes on #2155. I could not push directly to the contributor's org fork despite `maintainerCanModify: true` because GitHub returned 403, so this branch carries the same feature plus the follow-up fixes.

- Applies `responseEnhancer` consistently to framework tool responses, custom tool responses such as `tasks_get`, generated `get_adcp_capabilities` responses, and credential-policy error responses that intentionally bypass the normal finalizer.
- Adds a minor changeset for the new public server config option.
- Adds regression coverage for `createAdcpServerFromPlatform` normal platform responses, generated discovery responses, and the framework-owned `tasks_get` custom tool.

## Validation

- `npm run typecheck`
- `npx tsc --project tsconfig.lib.json`
- `NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/server-decisioning-from-platform.test.js`

Note: `npm run build:lib` could not complete locally on the contributor branch because `schemas:ensure` attempted to sync the old `3.0.12` schema cache and cosign verification failed for that tarball. The direct library `tsc` emit and focused tests passed.