### PR TITLE
fix(testing): resolve media-buy accounts via list_accounts

### DIFF
--- a/.changeset/explicit-media-buy-account-resolution.md
+++ b/.changeset/explicit-media-buy-account-resolution.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Fix media-buy test scenarios to discover explicit seller accounts via `list_accounts` and reuse the resolved account for product discovery, media-buy creation, and creative sync.

--- a/src/lib/testing/agent-tester.ts
+++ b/src/lib/testing/agent-tester.ts
@@ -513,6 +513,7 @@ export {
   testSIHandoff,
   testCapabilityDiscovery,
   testSyncAudiences,
+  resolveAccountForMediaBuy,
   resolveAccountForAudiences,
   testSchemaCompliance,
   testErrorCodes,

--- a/src/lib/testing/index.ts
+++ b/src/lib/testing/index.ts
@@ -54,6 +54,7 @@ export {
   testSIHandoff,
   testCapabilityDiscovery,
   testSyncAudiences,
+  resolveAccountForMediaBuy,
   resolveAccountForAudiences,
   testSchemaCompliance,
   // State machine compliance

--- a/src/lib/testing/scenarios/index.ts
+++ b/src/lib/testing/scenarios/index.ts
@@ -19,6 +19,7 @@ export {
   testCreativeInline,
   testCreativeReference,
   testSyncAudiences,
+  resolveAccountForMediaBuy,
   resolveAccountForAudiences,
   selectProduct,
   selectPricingOption,

--- a/src/lib/testing/scenarios/media-buy.ts
+++ b/src/lib/testing/scenarios/media-buy.ts
@@ -74,6 +74,7 @@ export function buildCreateMediaBuyRequest(
   extras: {
     inline_creatives?: Record<string, unknown>[];
     creative_ids?: string[];
+    accountRef?: AccountReference;
   } = {}
 ): Record<string, unknown> {
   const minSpend = pricingOption.min_spend_per_package || 0;
@@ -107,8 +108,16 @@ export function buildCreateMediaBuyRequest(
     packageRequest.creative_ids = extras.creative_ids;
   }
 
+  const hasAccountRef = Object.prototype.hasOwnProperty.call(extras, 'accountRef');
+  const account = hasAccountRef ? extras.accountRef : resolveAccount(options);
+  if (!account) {
+    throw new Error(
+      'buildCreateMediaBuyRequest received accountRef: undefined. Resolve an account before building the request.'
+    );
+  }
+
   return {
-    account: resolveAccount(options),
+    account,
     brand: resolveBrand(options),
     start_time: startTime.toISOString(),
     end_time: endTime.toISOString(),
@@ -204,6 +213,27 @@ export async function testCreateMediaBuy(
     return { steps, profile };
   }
 
+  const { accountRef, steps: accountSteps } = await resolveAccountForMediaBuy(
+    options,
+    profile.tools,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- intentional: test request bypasses strict typing
+    async params => client.listAccounts(params as any) as Promise<TaskResult>,
+    getMediaBuyAccountResolutionHints(profile)
+  );
+  steps.push(...accountSteps);
+
+  if (!accountRef) {
+    steps.push({
+      step: 'Resolve account for media buy',
+      task: 'list_accounts',
+      passed: false,
+      duration_ms: 0,
+      error:
+        'No account available. Provide media_buy_account_id/account_id, use sandbox: true, or ensure list_accounts returns an account.',
+    });
+    return { steps, profile };
+  }
+
   // Get products
   const { result: productsResult } = await runStep<TaskResult>(
     'Fetch products for media buy',
@@ -213,6 +243,7 @@ export async function testCreateMediaBuy(
         buying_mode: 'brief',
         brief: options.brief || 'Looking for display advertising products',
         brand: resolveBrand(options),
+        account: accountRef,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any -- intentional: test request bypasses strict typing
       } as any) as Promise<TaskResult>
   );
@@ -254,7 +285,7 @@ export async function testCreateMediaBuy(
     return { steps, profile };
   }
 
-  const createRequest = buildCreateMediaBuyRequest(product, pricingOption, options);
+  const createRequest = buildCreateMediaBuyRequest(product, pricingOption, options, { accountRef });
 
   // Create the media buy
   const { result: createResult, step: createStep } = await runStep<TaskResult>(
@@ -712,6 +743,27 @@ export async function testCreativeSync(
     return { steps, profile };
   }
 
+  const { accountRef, steps: accountSteps } = await resolveAccountForMediaBuy(
+    options,
+    profile.tools,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- intentional: test request bypasses strict typing
+    async params => client.listAccounts(params as any) as Promise<TaskResult>,
+    getMediaBuyAccountResolutionHints(profile)
+  );
+  steps.push(...accountSteps);
+
+  if (!accountRef) {
+    steps.push({
+      step: 'Resolve account for creative sync',
+      task: 'list_accounts',
+      passed: false,
+      duration_ms: 0,
+      error:
+        'No account available. Provide media_buy_account_id/account_id, use sandbox: true, or ensure list_accounts returns an account.',
+    });
+    return { steps, profile };
+  }
+
   // Get format info first
   let formatId: Record<string, unknown> = {
     agent_url: 'https://creative.adcontextprotocol.org',
@@ -761,7 +813,7 @@ export async function testCreativeSync(
     'sync_creatives',
     async () =>
       client.syncCreatives({
-        account: resolveAccount(options),
+        account: accountRef,
         creatives: [testCreative],
         // eslint-disable-next-line @typescript-eslint/no-explicit-any -- intentional: test request bypasses strict typing
       } as any) as Promise<TaskResult>
@@ -1201,10 +1253,171 @@ export async function testCreativeReference(
 const TEST_HASHED_EMAIL = 'a' + '0'.repeat(63);
 const TEST_HASHED_PHONE = 'b' + '0'.repeat(63);
 
+interface MediaBuyAccountResolutionHints {
+  requireOperatorAuth?: boolean;
+}
+
+/**
+ * Resolve which account reference to use for media-buy and creative-library
+ * test calls.
+ *
+ * Priority: media_buy_account_id > account_id > explicit-account discovery >
+ * implicit/sandbox natural key. When account capabilities are unavailable,
+ * list_accounts support is treated as an explicit-account hint for backwards
+ * compatibility with older agents.
+ *
+ * Extracted for testability — the listAccounts callback abstracts the client call.
+ */
+export async function resolveAccountForMediaBuy(
+  options: TestOptions,
+  tools: string[],
+  listAccounts: (params: Record<string, unknown>) => Promise<TaskResult>,
+  hints: MediaBuyAccountResolutionHints = {}
+): Promise<{ accountRef: AccountReference | undefined; steps: TestStepResult[] }> {
+  const steps: TestStepResult[] = [];
+
+  const explicitAccountId = options.media_buy_account_id ?? options.account_id;
+  if (explicitAccountId) {
+    return { accountRef: { account_id: explicitAccountId }, steps };
+  }
+
+  const hasListAccounts = tools.includes('list_accounts');
+  const shouldDiscoverExplicitAccount = hasListAccounts && hints.requireOperatorAuth !== false;
+
+  if (options.sandbox && shouldDiscoverExplicitAccount) {
+    const { result: sandboxResult, step: sandboxStep } = await runStep<TaskResult>(
+      'Discover sandbox accounts for media buy',
+      'list_accounts',
+      async () => listAccounts({ sandbox: true, status: 'active' })
+    );
+
+    const sandboxData = sandboxResult?.success
+      ? (sandboxResult.data as unknown as ListAccountsResponse | undefined)
+      : undefined;
+    const selection = selectMediaBuyAccount(sandboxData?.accounts ?? [], options);
+    if (selection.accountRef) {
+      sandboxStep.details = selection.details;
+      steps.push(sandboxStep);
+      return { accountRef: selection.accountRef, steps };
+    }
+
+    sandboxStep.details = sandboxResult?.success
+      ? selection.details
+      : 'list_accounts failed; falling back to natural key';
+    if (hints.requireOperatorAuth === true || selection.ambiguous) {
+      sandboxStep.passed = false;
+    } else {
+      sandboxStep.passed = true;
+      sandboxStep.error = undefined;
+    }
+    steps.push(sandboxStep);
+    if (hints.requireOperatorAuth === true || selection.ambiguous) {
+      return { accountRef: undefined, steps };
+    }
+
+    const brand = resolveBrand(options);
+    return { accountRef: { brand, operator: brand.domain, sandbox: true }, steps };
+  }
+
+  if (options.sandbox) {
+    const brand = resolveBrand(options);
+    return { accountRef: { brand, operator: brand.domain, sandbox: true }, steps };
+  }
+
+  if (shouldDiscoverExplicitAccount) {
+    const { result: accountsResult, step: accountsStep } = await runStep<TaskResult>(
+      'Discover accounts for media buy',
+      'list_accounts',
+      async () => listAccounts({ status: 'active' })
+    );
+
+    if (accountsResult?.success && accountsResult?.data) {
+      const accountsData = accountsResult.data as unknown as ListAccountsResponse;
+      const selection = selectMediaBuyAccount(accountsData.accounts ?? [], options);
+      if (selection.accountRef) {
+        accountsStep.details = selection.details;
+        steps.push(accountsStep);
+        return { accountRef: selection.accountRef, steps };
+      }
+      accountsStep.details = selection.details;
+    } else {
+      accountsStep.details = 'list_accounts call failed';
+    }
+    steps.push(accountsStep);
+    return { accountRef: undefined, steps };
+  }
+
+  return { accountRef: resolveAccount(options), steps };
+}
+
+function getMediaBuyAccountResolutionHints(profile: AgentProfile): MediaBuyAccountResolutionHints {
+  const capabilities = profile.raw_capabilities;
+  if (!isRecord(capabilities) || !isRecord(capabilities.account)) {
+    return {};
+  }
+
+  const requireOperatorAuth = capabilities.account.require_operator_auth;
+  return typeof requireOperatorAuth === 'boolean' ? { requireOperatorAuth } : {};
+}
+
+function selectMediaBuyAccount(
+  accounts: ListAccountsResponse['accounts'],
+  options: TestOptions
+): { accountRef?: AccountReference; details: string; ambiguous?: boolean } {
+  const candidates = accounts.filter(
+    account =>
+      typeof account.account_id === 'string' &&
+      account.account_id.length > 0 &&
+      (account.status === undefined || account.status === 'active')
+  );
+  if (candidates.length === 0) {
+    return { details: 'list_accounts returned no active accounts with account_id' };
+  }
+
+  const brand = resolveBrand(options);
+  const brandMatches = candidates.filter(account => accountMatchesBrand(account, brand));
+  const selectable = brandMatches.length > 0 ? brandMatches : candidates;
+
+  if (selectable.length === 1) {
+    const accountId = selectable[0]!.account_id as string;
+    const matchSource = brandMatches.length === 1 ? 'brand-matched ' : '';
+    return {
+      accountRef: { account_id: accountId },
+      details: `Using ${matchSource}account: ${accountId}`,
+    };
+  }
+
+  const accountIds = selectable.map(account => account.account_id).join(', ');
+  return {
+    details: `list_accounts returned multiple matching accounts (${accountIds}); provide media_buy_account_id/account_id to disambiguate`,
+    ambiguous: true,
+  };
+}
+
+function accountMatchesBrand(
+  account: ListAccountsResponse['accounts'][number],
+  brand: ReturnType<typeof resolveBrand>
+) {
+  const accountBrand = account.brand;
+  if (!isRecord(accountBrand) || accountBrand.domain !== brand.domain) {
+    return false;
+  }
+
+  if (brand.brand_id && accountBrand.brand_id !== brand.brand_id) {
+    return false;
+  }
+
+  return typeof account.operator !== 'string' || account.operator === brand.domain;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
 /**
  * Resolve which account reference to use for audience sync.
  *
- * Priority: explicit account_id > sandbox discovery > sandbox natural key > list_accounts discovery.
+ * Priority: audience_account_id > account_id > sandbox discovery > sandbox natural key > list_accounts discovery.
  *
  * Extracted for testability — the listAccounts callback abstracts the client call.
  */
@@ -1215,8 +1428,9 @@ export async function resolveAccountForAudiences(
 ): Promise<{ accountRef: AccountReference | undefined; steps: TestStepResult[] }> {
   const steps: TestStepResult[] = [];
 
-  if (options.audience_account_id) {
-    return { accountRef: { account_id: options.audience_account_id }, steps };
+  const explicitAccountId = options.audience_account_id ?? options.account_id;
+  if (explicitAccountId) {
+    return { accountRef: { account_id: explicitAccountId }, steps };
   }
 
   if (options.sandbox && tools.includes('list_accounts')) {

--- a/src/lib/testing/types.ts
+++ b/src/lib/testing/types.ts
@@ -198,6 +198,16 @@ export interface TestOptions {
   si_offering_id?: string;
   // For SI testing: initial conversation context
   si_context?: string;
+  /**
+   * Shared explicit account id for test scenarios that need an account-scoped
+   * request. Domain-specific account ids below take precedence when provided.
+   */
+  account_id?: string;
+  /**
+   * For media-buy testing: account ID to use with get_products,
+   * create_media_buy, sync_creatives, and related media-buy flows.
+   */
+  media_buy_account_id?: string;
   // For audience testing: account ID to use with sync_audiences
   audience_account_id?: string;
   // When true, use sandbox mode. For implicit accounts, uses the natural key with

--- a/test/lib/sandbox-account-resolution.test.js
+++ b/test/lib/sandbox-account-resolution.test.js
@@ -2,7 +2,8 @@
 const { describe, test } = require('node:test');
 const assert = require('node:assert');
 
-const { resolveAccountForAudiences } = require('../../dist/lib/testing/index.js');
+const { resolveAccountForAudiences, resolveAccountForMediaBuy } = require('../../dist/lib/testing/index.js');
+const { buildCreateMediaBuyRequest } = require('../../dist/lib/testing/scenarios/media-buy.js');
 
 describe('resolveAccountForAudiences', () => {
   const defaultOptions = { brand: { domain: 'test.example' } };
@@ -17,6 +18,19 @@ describe('resolveAccountForAudiences', () => {
     );
 
     assert.deepStrictEqual(accountRef, { account_id: 'acct-123' });
+    assert.strictEqual(steps.length, 0, 'no steps needed for explicit account_id');
+  });
+
+  test('shared account_id is used when audience_account_id is absent', async () => {
+    const { accountRef, steps } = await resolveAccountForAudiences(
+      { ...defaultOptions, account_id: 'acct-shared', sandbox: true },
+      ['list_accounts', 'sync_audiences'],
+      async () => {
+        throw new Error('should not be called');
+      }
+    );
+
+    assert.deepStrictEqual(accountRef, { account_id: 'acct-shared' });
     assert.strictEqual(steps.length, 0, 'no steps needed for explicit account_id');
   });
 
@@ -179,5 +193,258 @@ describe('resolveAccountForAudiences', () => {
     assert.strictEqual(steps[0].passed, true);
     assert.strictEqual(steps[0].error, undefined, 'error should be cleared when fallback succeeds');
     assert.match(steps[0].details, /list_accounts failed/);
+  });
+});
+
+describe('resolveAccountForMediaBuy', () => {
+  const defaultOptions = { brand: { domain: 'test.example' } };
+
+  test('media_buy_account_id takes precedence over shared account_id and sandbox', async () => {
+    const { accountRef, steps } = await resolveAccountForMediaBuy(
+      {
+        ...defaultOptions,
+        media_buy_account_id: 'media-acct',
+        account_id: 'shared-acct',
+        sandbox: true,
+      },
+      ['list_accounts', 'get_products', 'create_media_buy'],
+      async () => {
+        throw new Error('should not be called');
+      }
+    );
+
+    assert.deepStrictEqual(accountRef, { account_id: 'media-acct' });
+    assert.strictEqual(steps.length, 0);
+  });
+
+  test('shared account_id is used when media_buy_account_id is absent', async () => {
+    const { accountRef, steps } = await resolveAccountForMediaBuy(
+      { ...defaultOptions, account_id: 'shared-acct', sandbox: true },
+      ['list_accounts', 'get_products', 'create_media_buy'],
+      async () => {
+        throw new Error('should not be called');
+      }
+    );
+
+    assert.deepStrictEqual(accountRef, { account_id: 'shared-acct' });
+    assert.strictEqual(steps.length, 0);
+  });
+
+  test('sandbox with list_accounts returning accounts uses discovered account_id', async () => {
+    const { accountRef, steps } = await resolveAccountForMediaBuy(
+      { ...defaultOptions, sandbox: true },
+      ['list_accounts', 'get_products', 'create_media_buy'],
+      async params => {
+        assert.deepStrictEqual(params, { sandbox: true, status: 'active' });
+        return { success: true, data: { accounts: [{ account_id: 'sandbox-media-acct', status: 'active' }] } };
+      }
+    );
+
+    assert.deepStrictEqual(accountRef, { account_id: 'sandbox-media-acct' });
+    assert.strictEqual(steps.length, 1);
+    assert.strictEqual(steps[0].step, 'Discover sandbox accounts for media buy');
+    assert.match(steps[0].details, /sandbox-media-acct/);
+  });
+
+  test('sandbox with empty list_accounts falls back to natural key', async () => {
+    const { accountRef, steps } = await resolveAccountForMediaBuy(
+      { ...defaultOptions, sandbox: true },
+      ['list_accounts', 'get_products', 'create_media_buy'],
+      async () => ({ success: true, data: { accounts: [] } })
+    );
+
+    assert.strictEqual(accountRef.sandbox, true);
+    assert.strictEqual(accountRef.operator, 'test.example');
+    assert.deepStrictEqual(accountRef.brand, { domain: 'test.example' });
+    assert.strictEqual(steps.length, 1);
+    assert.strictEqual(steps[0].passed, true);
+    assert.match(steps[0].details, /no active accounts/);
+  });
+
+  test('non-sandbox with list_accounts discovers account', async () => {
+    const { accountRef, steps } = await resolveAccountForMediaBuy(
+      defaultOptions,
+      ['list_accounts', 'get_products', 'create_media_buy'],
+      async params => {
+        assert.deepStrictEqual(params, { status: 'active' });
+        return { success: true, data: { accounts: [{ account_id: 'prod-media-acct', status: 'active' }] } };
+      }
+    );
+
+    assert.deepStrictEqual(accountRef, { account_id: 'prod-media-acct' });
+    assert.strictEqual(steps.length, 1);
+    assert.strictEqual(steps[0].step, 'Discover accounts for media buy');
+    assert.match(steps[0].details, /prod-media-acct/);
+  });
+
+  test('non-sandbox with list_accounts returning empty yields undefined', async () => {
+    const { accountRef, steps } = await resolveAccountForMediaBuy(
+      defaultOptions,
+      ['list_accounts', 'get_products', 'create_media_buy'],
+      async () => ({ success: true, data: { accounts: [] } })
+    );
+
+    assert.strictEqual(accountRef, undefined);
+    assert.strictEqual(steps.length, 1);
+    assert.strictEqual(steps[0].details, 'list_accounts returned no active accounts with account_id');
+  });
+
+  test('non-active discovered accounts are not selected for media-buy creation', async () => {
+    const { accountRef, steps } = await resolveAccountForMediaBuy(
+      defaultOptions,
+      ['list_accounts', 'get_products', 'create_media_buy'],
+      async () => ({
+        success: true,
+        data: { accounts: [{ account_id: 'pending-acct', status: 'pending_approval' }] },
+      }),
+      { requireOperatorAuth: true }
+    );
+
+    assert.strictEqual(accountRef, undefined);
+    assert.strictEqual(steps.length, 1);
+    assert.strictEqual(steps[0].details, 'list_accounts returned no active accounts with account_id');
+  });
+
+  test('declared implicit seller uses natural key even when list_accounts exists', async () => {
+    const { accountRef, steps } = await resolveAccountForMediaBuy(
+      defaultOptions,
+      ['list_accounts', 'get_products', 'create_media_buy'],
+      async () => {
+        throw new Error('should not be called');
+      },
+      { requireOperatorAuth: false }
+    );
+
+    assert.strictEqual(accountRef.operator, 'test.example');
+    assert.deepStrictEqual(accountRef.brand, { domain: 'test.example' });
+    assert.strictEqual(steps.length, 0);
+  });
+
+  test('declared explicit sandbox seller fails instead of falling back when no account is returned', async () => {
+    const { accountRef, steps } = await resolveAccountForMediaBuy(
+      { ...defaultOptions, sandbox: true },
+      ['list_accounts', 'get_products', 'create_media_buy'],
+      async () => ({ success: true, data: { accounts: [] } }),
+      { requireOperatorAuth: true }
+    );
+
+    assert.strictEqual(accountRef, undefined);
+    assert.strictEqual(steps.length, 1);
+    assert.strictEqual(steps[0].passed, false);
+    assert.strictEqual(steps[0].details, 'list_accounts returned no active accounts with account_id');
+  });
+
+  test('multiple accounts are ambiguous unless one matches the requested brand/operator', async () => {
+    const { accountRef, steps } = await resolveAccountForMediaBuy(
+      defaultOptions,
+      ['list_accounts', 'get_products', 'create_media_buy'],
+      async () => ({
+        success: true,
+        data: {
+          accounts: [
+            {
+              account_id: 'acct-other',
+              brand: { domain: 'other.example' },
+              operator: 'other.example',
+              status: 'active',
+            },
+            {
+              account_id: 'acct-match',
+              brand: { domain: 'test.example' },
+              operator: 'test.example',
+              status: 'active',
+            },
+          ],
+        },
+      }),
+      { requireOperatorAuth: true }
+    );
+
+    assert.deepStrictEqual(accountRef, { account_id: 'acct-match' });
+    assert.match(steps[0].details, /brand-matched account: acct-match/);
+  });
+
+  test('multiple matching accounts require explicit media_buy_account_id', async () => {
+    const { accountRef, steps } = await resolveAccountForMediaBuy(
+      defaultOptions,
+      ['list_accounts', 'get_products', 'create_media_buy'],
+      async () => ({
+        success: true,
+        data: {
+          accounts: [
+            {
+              account_id: 'acct-1',
+              brand: { domain: 'test.example' },
+              operator: 'test.example',
+              status: 'active',
+            },
+            {
+              account_id: 'acct-2',
+              brand: { domain: 'test.example' },
+              operator: 'test.example',
+              status: 'active',
+            },
+          ],
+        },
+      }),
+      { requireOperatorAuth: true }
+    );
+
+    assert.strictEqual(accountRef, undefined);
+    assert.strictEqual(steps.length, 1);
+    assert.match(steps[0].details, /multiple matching accounts/);
+    assert.match(steps[0].details, /media_buy_account_id/);
+  });
+
+  test('without list_accounts uses natural key for implicit-account sellers', async () => {
+    const { accountRef, steps } = await resolveAccountForMediaBuy(
+      defaultOptions,
+      ['get_products', 'create_media_buy'],
+      async () => {
+        throw new Error('should not be called');
+      }
+    );
+
+    assert.strictEqual(accountRef.sandbox, undefined);
+    assert.strictEqual(accountRef.operator, 'test.example');
+    assert.deepStrictEqual(accountRef.brand, { domain: 'test.example' });
+    assert.strictEqual(steps.length, 0);
+  });
+});
+
+describe('buildCreateMediaBuyRequest accountRef override', () => {
+  const product = {
+    product_id: 'prod-1',
+    name: 'Product 1',
+    pricing_options: [{ pricing_option_id: 'po-1', pricing_model: 'cpm' }],
+  };
+  const pricingOption = product.pricing_options[0];
+
+  test('uses provided accountRef instead of natural key', () => {
+    const request = buildCreateMediaBuyRequest(
+      product,
+      pricingOption,
+      { brand: { domain: 'test.example' } },
+      {
+        accountRef: { account_id: 'acct-override' },
+      }
+    );
+
+    assert.deepStrictEqual(request.account, { account_id: 'acct-override' });
+  });
+
+  test('throws when accountRef is explicitly undefined', () => {
+    assert.throws(
+      () =>
+        buildCreateMediaBuyRequest(
+          product,
+          pricingOption,
+          { brand: { domain: 'test.example' } },
+          {
+            accountRef: undefined,
+          }
+        ),
+      /Resolve an account before building the request/
+    );
   });
 });


### PR DESCRIPTION
Closes #2112.

## Summary
- add media-buy account resolution that prefers `media_buy_account_id`, then shared `account_id`, then explicit-account `list_accounts` discovery
- use `get_adcp_capabilities.account.require_operator_auth` when available so declared implicit sellers keep the natural-key path
- query only active accounts, select a singleton or exact brand/operator match, and fail with an explicit-account-id hint when discovery is ambiguous
- thread the resolved account through `get_products`, `create_media_buy`, and `sync_creatives` in the testing scenarios
- add regression coverage for explicit, implicit, sandbox, discovered, ambiguous, inactive, and missing-account paths
- add a patch changeset

## Validation
- `npm run ci:quick`
- `git diff --check`
- `npx prettier --check src/lib/testing/scenarios/media-buy.ts test/lib/sandbox-account-resolution.test.js`
- `NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/lib/sandbox-account-resolution.test.js`
- `npx commitlint --from origin/main --to HEAD --verbose`