### PR TITLE
fix: enforce get products property policies

### DIFF
--- a/.changeset/product-property-policy.md
+++ b/.changeset/product-property-policy.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': minor
+---
+
+Add a buyer-side product property policy validator for auditing, filtering, or rejecting get_products responses against excluded publisher domains and property IDs.

--- a/src/lib/core/AsyncHandler.ts
+++ b/src/lib/core/AsyncHandler.ts
@@ -53,6 +53,7 @@ import type {
   UpdateMediaBuyAsyncWorking,
   UpdateMediaBuyResponse,
 } from '../types/core.generated';
+import type { TaskResultMetadata } from './ConversationTypes';
 import {
   CreateMediaBuyAsyncResponseData,
   GetProductsAsyncResponseData,
@@ -94,6 +95,12 @@ export interface WebhookMetadata {
    * as the canonical dedup key; see `AsyncHandlerConfig.webhookDedup`.
    */
   idempotency_key?: string;
+  /**
+   * Buyer-side product property policy evaluation for completed get_products
+   * webhooks. Present when the client filters, audits, or rejects a webhook
+   * result before dispatching it to handlers.
+   */
+  productPropertyPolicy?: TaskResultMetadata['productPropertyPolicy'];
 }
 
 /**
@@ -365,7 +372,7 @@ export class AsyncHandler {
       task_id: metadata.task_id,
       task_type: metadata.task_type,
       status: metadata.status,
-      payload: result,
+      payload: metadata.rawHTTPPayload?.result ?? result,
       timestamp: metadata.timestamp,
     });
 

--- a/src/lib/core/ConversationTypes.ts
+++ b/src/lib/core/ConversationTypes.ts
@@ -1,6 +1,11 @@
 // Core conversation types for ADCP client library
 // These types support the conversation and clarification pattern
 
+import type {
+  ProductPropertyPolicyDiagnostic,
+  ProductPropertyPolicyMode,
+} from '../media-buy/property-policy';
+
 /**
  * Represents a single message in a conversation with an agent
  */
@@ -411,6 +416,27 @@ export interface TaskResultMetadata {
    * configuration pin, when detecting same-major downshift.
    */
   adcpVersion?: string;
+  /**
+   * Buyer-side product property policy enforcement summary for `get_products`.
+   * Present when the client evaluates a configured product property policy or
+   * enforces the request's `property_list` reference against the response.
+   */
+  productPropertyPolicy?: {
+    mode: ProductPropertyPolicyMode;
+    ok: boolean;
+    accepted_count: number;
+    rejected_count: number;
+    flagged_count: number;
+    message?: string;
+    request_property_list?: {
+      list_id: string;
+      agent_url: string;
+      identifier_count?: number;
+      cache_valid_until?: string;
+      resolution_error?: string;
+    };
+    diagnostics: ProductPropertyPolicyDiagnostic[];
+  };
 }
 
 /** Fields shared across all TaskResult variants. */

--- a/src/lib/core/ConversationTypes.ts
+++ b/src/lib/core/ConversationTypes.ts
@@ -1,10 +1,7 @@
 // Core conversation types for ADCP client library
 // These types support the conversation and clarification pattern
 
-import type {
-  ProductPropertyPolicyDiagnostic,
-  ProductPropertyPolicyMode,
-} from '../media-buy/property-policy';
+import type { ProductPropertyPolicyDiagnostic, ProductPropertyPolicyMode } from '../media-buy/property-policy';
 
 /**
  * Represents a single message in a conversation with an agent

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -9,6 +9,7 @@ import { isAdcpVersionSupported, resolveAdcpVersion } from '../utils/adcp-versio
 import type {
   GetProductsRequest,
   GetProductsResponse,
+  PropertyListReference,
   ListCreativeFormatsRequest,
   ListCreativeFormatsResponse,
   CreateMediaBuyRequest,
@@ -129,6 +130,16 @@ import {
 import { normalizeRequestParams } from '../utils/request-normalizer';
 import { validateUserAgent } from '../utils/validate-user-agent';
 import { getV25Adapter } from '../adapters/legacy/v2-5';
+import {
+  ProductPropertyPolicyError,
+  validateProductsAgainstPropertyPolicy,
+  type BuyerPropertyPolicy,
+  type ProductPolicyProductLike,
+  type ProductPropertyPolicyDiagnostic,
+  type ProductPropertyPolicyMode,
+  type ProductPropertyPolicyValidationResult,
+} from '../media-buy/property-policy';
+import { resolvePropertyList, type ResolveListOptions } from '../server/targeting-helpers';
 
 /**
  * Error class for v3 feature compatibility issues
@@ -176,6 +187,34 @@ type NormalizedWebhookPayload = {
   idempotency_key?: string;
   protocol?: 'mcp' | 'a2a';
 };
+
+export interface ClientProductPropertyPolicy extends BuyerPropertyPolicy {
+  /**
+   * Enforcement mode for completed `get_products` responses.
+   *
+   * - `filter` (default): remove rejected products before handlers/callers see them
+   * - `reject_response`: fail the task when any product violates the policy
+   * - `audit`: keep products but attach diagnostics
+   */
+  mode?: ProductPropertyPolicyMode;
+  /**
+   * When true, a `get_products` request carrying `property_list` is resolved
+   * and used as an allow-list for the returned products. Defaults to true.
+   */
+  enforceRequestPropertyList?: boolean;
+  /**
+   * Resolver options for request-derived property-list validation. The default
+   * uses the SDK's process-local resolved-list cache.
+   */
+  propertyListResolveOptions?: ResolveListOptions;
+  /**
+   * Message surfaced in debug logs and failed results when the policy rejects
+   * products.
+   *
+   * @default 'Property list not adhered to'
+   */
+  message?: string;
+}
 
 export type WebhookParseErrorCode =
   | 'webhook_signature_invalid'
@@ -425,6 +464,18 @@ export interface SingleAgentClientConfig extends ConversationConfig {
      * @default false
      */
     filterInvalidProducts?: boolean;
+    /**
+     * Buyer-side property policy applied to completed `get_products`
+     * responses before completion handlers and callers receive the product
+     * list. A request-level `property_list` is enforced automatically by
+     * default; set this to `false` only when the caller deliberately wants to
+     * trust seller-side filtering without SDK verification.
+     *
+     * Use this for brand/block-list rules such as excluding `ladbible.com`;
+     * domain matching normalizes `www.` aliases, so `www.ladbible.com`
+     * violates an exclusion for `ladbible.com`.
+     */
+    productPropertyPolicy?: ClientProductPropertyPolicy | false;
   };
   /** Governance configuration for buyer-side campaign governance */
   governance?: import('./GovernanceTypes').GovernanceConfig;
@@ -497,6 +548,65 @@ function valueMatchesSchemaType(value: unknown, propSchema: unknown): boolean {
   return false;
 }
 
+function propertyListReferenceFromRequest(params: Record<string, unknown>): PropertyListReference | undefined {
+  const value = params.property_list;
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  const ref = value as Partial<PropertyListReference>;
+  if (typeof ref.agent_url !== 'string' || typeof ref.list_id !== 'string') return undefined;
+  return {
+    agent_url: ref.agent_url,
+    list_id: ref.list_id,
+    ...(typeof ref.auth_token === 'string' ? { auth_token: ref.auth_token } : {}),
+  };
+}
+
+function hasProductPropertyPolicyRules(policy: BuyerPropertyPolicy): boolean {
+  return Boolean(
+    policy.allowedDomains?.length ||
+      policy.allowedPropertyIdentifiers?.length ||
+      policy.requireAllowedPropertyMatch ||
+      policy.excludedDomains?.length ||
+      policy.excludedPropertyIds?.length ||
+      policy.strict ||
+      policy.unknownSelectorBehavior ||
+      policy.missingPublisherPropertiesBehavior
+  );
+}
+
+function comparablePropertyIdentifiers(
+  identifiers: readonly { type: string; value: string }[]
+): Array<{ type: string; value: string }> {
+  return identifiers
+    .filter(identifier => identifier.type === 'domain' || identifier.type === 'subdomain')
+    .map(identifier => ({ type: identifier.type, value: identifier.value }));
+}
+
+function unsupportedPropertyIdentifiers(identifiers: readonly { type: string; value: string }[]): Array<{ type: string }> {
+  return identifiers
+    .filter(identifier => identifier.type !== 'domain' && identifier.type !== 'subdomain')
+    .map(identifier => ({ type: identifier.type }));
+}
+
+function sanitizeDiagnosticUrl(value: string): string {
+  try {
+    const url = new URL(value);
+    url.username = '';
+    url.password = '';
+    url.search = '';
+    url.hash = '';
+    return url.toString();
+  } catch {
+    return 'invalid_url';
+  }
+}
+
+function propertyListResolutionErrorCode(err: unknown): string {
+  const message = err instanceof Error ? err.message : '';
+  if (/^property_list_[a-z_]+$/.test(message)) return message;
+  if (/^list_agent_url_[a-z_]+$/.test(message)) return message;
+  return 'property_list_resolution_failed';
+}
+
 export class SingleAgentClient {
   private executor: TaskExecutor;
   private asyncHandler?: AsyncHandler;
@@ -509,6 +619,7 @@ export class SingleAgentClient {
   private _v2WarningFired = false; // Gate: emit the v2-sunset warning once per client instance
   private _syntheticV3WarningFired = false; // Gate: emit the synthetic-v3 warning once per client instance
   private _syntheticV2WarningFired = false; // Gate: emit the synthetic-v2 warning once per client instance
+  private readonly productPolicyRequestParamsByTask = new Map<string, Record<string, unknown>>();
   private readonly resolvedAdcpVersion: string;
 
   constructor(
@@ -1082,7 +1193,7 @@ export class SingleAgentClient {
   }
 
   private async dispatchParsedWebhook(parsed: WebhookParseSuccess): Promise<boolean> {
-    const metadata: WebhookMetadata = {
+    let metadata: WebhookMetadata = {
       operation_id: parsed.metadata.operationId,
       context_id: parsed.metadata.contextId,
       task_id: parsed.metadata.taskId,
@@ -1093,7 +1204,14 @@ export class SingleAgentClient {
       timestamp: parsed.metadata.timestamp || new Date().toISOString(),
       idempotency_key: parsed.metadata.idempotencyKey,
       protocol: parsed.protocol,
+      rawHTTPPayload: parsed.envelope,
     };
+    const policyDispatch = await this.applyProductPropertyPolicyToWebhookResult(
+      parsed.result as AdCPAsyncResponseData | undefined,
+      metadata
+    );
+    const webhookResult = policyDispatch.result;
+    metadata = policyDispatch.metadata;
 
     // Emit activity
     await this.config.onActivity?.({
@@ -1108,12 +1226,19 @@ export class SingleAgentClient {
       timestamp: metadata.timestamp,
     });
 
-    // Handle through async handler if configured
-    if (this.asyncHandler) {
-      await this.asyncHandler.handleWebhook({ result: parsed.result as AdCPAsyncResponseData | undefined, metadata });
+    if (policyDispatch.suppressHandler) {
+      this.forgetProductPolicyRequestParams(metadata);
       return true;
     }
 
+    // Handle through async handler if configured
+    if (this.asyncHandler) {
+      await this.asyncHandler.handleWebhook({ result: webhookResult, metadata });
+      this.forgetProductPolicyRequestParams(metadata);
+      return true;
+    }
+
+    this.forgetProductPolicyRequestParams(metadata);
     return false;
   }
 
@@ -1513,7 +1638,7 @@ export class SingleAgentClient {
       this.executor.validateAdaptedRequestAgainstV2(taskType, adaptedParams, v25DriftLogs);
     }
 
-    const result = await this.executor.executeTask<T>(
+    let result = await this.executor.executeTask<T>(
       agent,
       taskType,
       adaptedParams,
@@ -1536,6 +1661,10 @@ export class SingleAgentClient {
       result.data = this.normalizeResponseToV3(taskType, result.data) as T;
     }
 
+    result = this.wrapProductPolicySubmittedContinuation(result, taskType, normalizedParams);
+    this.rememberProductPolicyRequestParams(taskType, normalizedParams, result, options);
+    result = await this.applyProductPropertyPolicy(result, taskType, normalizedParams);
+
     // Call handler if task completed successfully and handler is configured
     if (result.status === 'completed' && result.success && this.asyncHandler) {
       const handler = this.config.handlers?.[handlerName] as
@@ -1555,6 +1684,350 @@ export class SingleAgentClient {
     }
 
     return result;
+  }
+
+  private async applyProductPropertyPolicy<T>(
+    result: TaskResult<T>,
+    taskType: string,
+    requestParams: Record<string, unknown>
+  ): Promise<TaskResult<T>> {
+    const policyConfig = this.config.validation?.productPropertyPolicy;
+    if (policyConfig === false || taskType !== 'get_products') return result;
+    if (!result.success || result.status !== 'completed' || !result.data) return result;
+
+    const response = result.data as unknown as GetProductsResponse;
+    if (!Array.isArray(response.products)) return result;
+
+    const requestPropertyList = propertyListReferenceFromRequest(requestParams);
+    const {
+      mode = 'filter',
+      message = 'Property list not adhered to',
+      enforceRequestPropertyList = true,
+      propertyListResolveOptions,
+      ...explicitPolicy
+    } = policyConfig || {};
+    const policy: BuyerPropertyPolicy = {
+      ...explicitPolicy,
+    };
+
+    let resolvedRequestPropertyList:
+      | {
+          listId: string;
+          agentUrl: string;
+          identifierCount: number;
+          cacheValidUntil?: string;
+        }
+      | undefined;
+
+    if (requestPropertyList && enforceRequestPropertyList) {
+      try {
+        const resolved = await resolvePropertyList(requestPropertyList, propertyListResolveOptions);
+        const comparableIdentifiers = comparablePropertyIdentifiers(resolved.identifiers);
+        const unsupportedIdentifiers = unsupportedPropertyIdentifiers(resolved.identifiers);
+        if (unsupportedIdentifiers.length > 0) {
+          throw new Error('property_list_unsupported_identifier_types');
+        }
+        if (comparableIdentifiers.length > 0 || resolved.identifiers.length === 0) {
+          policy.allowedPropertyIdentifiers = [...(policy.allowedPropertyIdentifiers ?? []), ...comparableIdentifiers];
+          policy.requireAllowedPropertyMatch = true;
+        }
+        policy.strict = policy.strict ?? true;
+        resolvedRequestPropertyList = {
+          listId: resolved.listId,
+          agentUrl: resolved.agentUrl,
+          identifierCount: resolved.identifiers.length,
+          ...(resolved.cacheValidUntil ? { cacheValidUntil: resolved.cacheValidUntil } : {}),
+        };
+      } catch (err) {
+        const errorCode = propertyListResolutionErrorCode(err);
+        const diagnosticAgentUrl = sanitizeDiagnosticUrl(requestPropertyList.agent_url);
+        return attachMatch({
+          success: false as const,
+          status: 'failed' as const,
+          data: response as unknown as T,
+          error: `${message}: could not resolve property_list ${requestPropertyList.list_id}`,
+          metadata: {
+            ...result.metadata,
+            status: 'failed',
+            productPropertyPolicy: {
+              mode,
+              ok: false,
+              accepted_count: 0,
+              rejected_count: response.products.length,
+              flagged_count: 0,
+              message,
+              diagnostics: [],
+              request_property_list: {
+                list_id: requestPropertyList.list_id,
+                agent_url: diagnosticAgentUrl,
+                resolution_error: errorCode,
+              },
+            },
+          },
+          conversation: result.conversation,
+          debug_logs: [
+            ...(result.debug_logs ?? []),
+            {
+              type: 'product_property_policy',
+              message,
+              mode,
+              ok: false,
+              request_property_list: {
+                list_id: requestPropertyList.list_id,
+                agent_url: diagnosticAgentUrl,
+                resolution_error: errorCode,
+              },
+            },
+          ],
+        });
+      }
+    }
+
+    if (!hasProductPropertyPolicyRules(policy)) return result;
+
+    let validation: ProductPropertyPolicyValidationResult<ProductPolicyProductLike>;
+    try {
+      validation = validateProductsAgainstPropertyPolicy({
+        products: response.products,
+        policy,
+        mode,
+      });
+    } catch (err) {
+      if (!(err instanceof ProductPropertyPolicyError)) throw err;
+      validation = err.result;
+    }
+
+    const summary = {
+      mode,
+      ok: validation.ok,
+      accepted_count: validation.acceptedProducts.length,
+      rejected_count: validation.rejectedProducts.length,
+      flagged_count: validation.flaggedProducts.length,
+      ...(validation.ok ? {} : { message }),
+      ...(resolvedRequestPropertyList
+        ? {
+            request_property_list: {
+              list_id: resolvedRequestPropertyList.listId,
+              agent_url: sanitizeDiagnosticUrl(resolvedRequestPropertyList.agentUrl),
+              identifier_count: resolvedRequestPropertyList.identifierCount,
+              ...(resolvedRequestPropertyList.cacheValidUntil
+                ? { cache_valid_until: resolvedRequestPropertyList.cacheValidUntil }
+                : {}),
+            },
+          }
+        : {}),
+      diagnostics: validation.diagnostics as ProductPropertyPolicyDiagnostic[],
+    };
+    result.metadata.productPropertyPolicy = summary;
+
+    if (validation.diagnostics.length > 0) {
+      result.debug_logs = [
+        ...(result.debug_logs ?? []),
+        {
+          type: 'product_property_policy',
+          message: validation.ok ? 'Product property policy evaluated' : message,
+          mode,
+          ok: validation.ok,
+          accepted_count: validation.acceptedProducts.length,
+          rejected_count: validation.rejectedProducts.length,
+          flagged_count: validation.flaggedProducts.length,
+          ...(summary.request_property_list ? { request_property_list: summary.request_property_list } : {}),
+          diagnostics: validation.diagnostics,
+        },
+      ];
+    }
+
+    if (mode === 'filter') {
+      result.data = {
+        ...(response as unknown as Record<string, unknown>),
+        products: validation.products,
+      } as T;
+      return result;
+    }
+
+    if (mode === 'reject_response' && !validation.ok) {
+      return attachMatch({
+        success: false as const,
+        status: 'failed' as const,
+        data: response as unknown as T,
+        error: message,
+        metadata: {
+          ...result.metadata,
+          status: 'failed',
+          productPropertyPolicy: summary,
+        },
+        conversation: result.conversation,
+        debug_logs: result.debug_logs,
+      });
+    }
+
+    return result;
+  }
+
+  private rememberProductPolicyRequestParams<T>(
+    taskType: string,
+    requestParams: Record<string, unknown>,
+    result: TaskResult<T>,
+    options?: TaskOptions
+  ): void {
+    if (taskType !== 'get_products') return;
+    if (result.status !== 'submitted' && result.status !== 'working') return;
+
+    const keys = new Set<string>();
+    if (result.metadata.taskId) keys.add(result.metadata.taskId);
+    if (result.metadata.contextId) keys.add(result.metadata.contextId);
+    if (result.metadata.serverTaskId) keys.add(result.metadata.serverTaskId);
+    if (options?.taskId) keys.add(options.taskId);
+    if (options?.contextId) keys.add(options.contextId);
+
+    for (const key of keys) {
+      this.productPolicyRequestParamsByTask.set(key, requestParams);
+    }
+  }
+
+  private forgetProductPolicyRequestParams(metadata: WebhookMetadata): void {
+    this.forgetProductPolicyRequestParamKeys([metadata.operation_id, metadata.task_id, metadata.context_id]);
+  }
+
+  private forgetProductPolicyRequestParamKeys(keys: Array<string | undefined>): void {
+    for (const key of keys) {
+      if (!key) continue;
+      this.productPolicyRequestParamsByTask.delete(key);
+    }
+  }
+
+  private wrapProductPolicySubmittedContinuation<T>(
+    result: TaskResult<T>,
+    taskType: string,
+    requestParams: Record<string, unknown>
+  ): TaskResult<T> {
+    if (taskType !== 'get_products' || result.status !== 'submitted' || !result.submitted) return result;
+
+    const submitted = result.submitted;
+    result.submitted = {
+      ...submitted,
+      track: async transport => {
+        const taskInfo = await submitted.track(transport);
+        const processed = await this.applyProductPropertyPolicyToTaskInfo(taskInfo, taskType, requestParams);
+        if (['completed', 'failed', 'rejected', 'canceled'].includes(processed.status)) {
+          this.forgetProductPolicyRequestParamKeys([result.metadata.taskId, result.metadata.serverTaskId, processed.taskId]);
+        }
+        return processed;
+      },
+      waitForCompletion: async (pollInterval, signal) => {
+        let completed = await submitted.waitForCompletion(pollInterval, signal);
+        if (completed.success && completed.data) {
+          completed.data = this.normalizeResponseToV3(taskType, completed.data) as T;
+        }
+        const processed = await this.applyProductPropertyPolicy(completed, taskType, requestParams);
+        if (processed.status === 'completed' || processed.status === 'failed') {
+          this.forgetProductPolicyRequestParamKeys([
+            result.metadata.taskId,
+            result.metadata.serverTaskId,
+            processed.metadata.taskId,
+            processed.metadata.serverTaskId,
+          ]);
+        }
+        return processed;
+      },
+    };
+
+    return result;
+  }
+
+  private async applyProductPropertyPolicyToTaskInfo(
+    taskInfo: TaskInfo,
+    taskType: string,
+    requestParams: Record<string, unknown>
+  ): Promise<TaskInfo> {
+    if (taskType !== 'get_products' || taskInfo.status !== 'completed' || !taskInfo.result) return taskInfo;
+
+    const policyResult = await this.applyProductPropertyPolicy(
+      attachMatch({
+        success: true as const,
+        status: 'completed' as const,
+        data: this.normalizeResponseToV3(taskType, taskInfo.result),
+        metadata: {
+          taskId: taskInfo.taskId,
+          taskName: taskInfo.taskType,
+          agent: { id: this.agent.id, name: this.agent.name, protocol: this.agent.protocol },
+          responseTimeMs: Math.max(0, Date.now() - taskInfo.createdAt),
+          timestamp: new Date().toISOString(),
+          clarificationRounds: 0,
+          status: 'completed',
+        },
+        debug_logs: [],
+      }),
+      taskType,
+      requestParams
+    );
+
+    if (policyResult.success) {
+      return { ...taskInfo, result: policyResult.data };
+    }
+
+    return {
+      ...taskInfo,
+      status: 'failed',
+      result: policyResult.data,
+      error: policyResult.error,
+      message: policyResult.error,
+    };
+  }
+
+  private productPolicyRequestParamsForWebhook(metadata: WebhookMetadata): Record<string, unknown> {
+    return (
+      this.executor.getRequestParams(metadata.operation_id) ??
+      this.executor.getRequestParams(metadata.task_id) ??
+      this.productPolicyRequestParamsByTask.get(metadata.operation_id) ??
+      this.productPolicyRequestParamsByTask.get(metadata.task_id) ??
+      (metadata.context_id ? this.productPolicyRequestParamsByTask.get(metadata.context_id) : undefined) ??
+      {}
+    );
+  }
+
+  private async applyProductPropertyPolicyToWebhookResult(
+    result: AdCPAsyncResponseData | undefined,
+    metadata: WebhookMetadata
+  ): Promise<{ result: AdCPAsyncResponseData | undefined; metadata: WebhookMetadata; suppressHandler: boolean }> {
+    if (metadata.task_type !== 'get_products' || metadata.status !== 'completed' || !result) {
+      return { result, metadata, suppressHandler: false };
+    }
+
+    const policyResult = await this.applyProductPropertyPolicy<AdCPAsyncResponseData>(
+      attachMatch({
+        success: true as const,
+        status: 'completed' as const,
+        data: result,
+        metadata: {
+          taskId: metadata.operation_id,
+          taskName: metadata.task_type,
+          agent: { id: this.agent.id, name: this.agent.name, protocol: this.agent.protocol },
+          responseTimeMs: 0,
+          timestamp: metadata.timestamp,
+          clarificationRounds: 0,
+          status: 'completed',
+        },
+        debug_logs: [],
+      }),
+      metadata.task_type,
+      this.productPolicyRequestParamsForWebhook(metadata)
+    );
+
+    const nextMetadata: WebhookMetadata = {
+      ...metadata,
+      status: policyResult.success ? metadata.status : 'failed',
+      ...(policyResult.error ? { message: policyResult.error } : {}),
+      ...(policyResult.metadata.productPropertyPolicy
+        ? { productPropertyPolicy: policyResult.metadata.productPropertyPolicy }
+        : {}),
+    };
+
+    return {
+      result: policyResult.data as AdCPAsyncResponseData | undefined,
+      metadata: nextMetadata,
+      suppressHandler: !policyResult.success,
+    };
   }
 
   /**
@@ -2503,7 +2976,7 @@ export class SingleAgentClient {
         this.executor.validateAdaptedRequestAgainstV2(taskName, adaptedParams, v25DriftLogs);
       }
 
-      const result = await this.executor.executeTask<T>(
+      let result = await this.executor.executeTask<T>(
         agent,
         taskName,
         adaptedParams,
@@ -2520,6 +2993,10 @@ export class SingleAgentClient {
       if (result.success && result.data) {
         result.data = this.normalizeResponseToV3(taskName, result.data) as T;
       }
+
+      result = this.wrapProductPolicySubmittedContinuation(result, taskName, normalizedParams);
+      this.rememberProductPolicyRequestParams(taskName, normalizedParams, result, options);
+      result = await this.applyProductPropertyPolicy(result, taskName, normalizedParams);
 
       return result;
     } catch (error) {

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -563,13 +563,13 @@ function propertyListReferenceFromRequest(params: Record<string, unknown>): Prop
 function hasProductPropertyPolicyRules(policy: BuyerPropertyPolicy): boolean {
   return Boolean(
     policy.allowedDomains?.length ||
-      policy.allowedPropertyIdentifiers?.length ||
-      policy.requireAllowedPropertyMatch ||
-      policy.excludedDomains?.length ||
-      policy.excludedPropertyIds?.length ||
-      policy.strict ||
-      policy.unknownSelectorBehavior ||
-      policy.missingPublisherPropertiesBehavior
+    policy.allowedPropertyIdentifiers?.length ||
+    policy.requireAllowedPropertyMatch ||
+    policy.excludedDomains?.length ||
+    policy.excludedPropertyIds?.length ||
+    policy.strict ||
+    policy.unknownSelectorBehavior ||
+    policy.missingPublisherPropertiesBehavior
   );
 }
 
@@ -581,7 +581,9 @@ function comparablePropertyIdentifiers(
     .map(identifier => ({ type: identifier.type, value: identifier.value }));
 }
 
-function unsupportedPropertyIdentifiers(identifiers: readonly { type: string; value: string }[]): Array<{ type: string }> {
+function unsupportedPropertyIdentifiers(
+  identifiers: readonly { type: string; value: string }[]
+): Array<{ type: string }> {
   return identifiers
     .filter(identifier => identifier.type !== 'domain' && identifier.type !== 'subdomain')
     .map(identifier => ({ type: identifier.type }));
@@ -1910,7 +1912,11 @@ export class SingleAgentClient {
         const taskInfo = await submitted.track(transport);
         const processed = await this.applyProductPropertyPolicyToTaskInfo(taskInfo, taskType, requestParams);
         if (['completed', 'failed', 'rejected', 'canceled'].includes(processed.status)) {
-          this.forgetProductPolicyRequestParamKeys([result.metadata.taskId, result.metadata.serverTaskId, processed.taskId]);
+          this.forgetProductPolicyRequestParamKeys([
+            result.metadata.taskId,
+            result.metadata.serverTaskId,
+            processed.taskId,
+          ]);
         }
         return processed;
       },

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -364,6 +364,13 @@ export class TaskExecutor {
     return this.governanceMiddleware;
   }
 
+  getRequestParams(taskId: string): Record<string, unknown> | undefined {
+    const params = this.activeTasks.get(taskId)?.params;
+    return params && typeof params === 'object' && !Array.isArray(params)
+      ? (params as Record<string, unknown>)
+      : undefined;
+  }
+
   /**
    * Run the configured pre-send schema check against the user-facing request
    * shape. Callers invoke this on the unadapted (v3) params before any wire

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -206,6 +206,7 @@ export {
   UnsupportedFeatureError,
 } from './core/SingleAgentClient';
 export type {
+  ClientProductPropertyPolicy,
   SingleAgentClientConfig,
   VerifyAndParseWebhookOptions,
   WebhookParseErrorCode,

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -459,10 +459,20 @@ export type {
   PreflightAllowed,
   PreflightDenial,
   PreflightDenied,
+  BuyerPropertyPolicy,
+  NormalizedPolicyDomain,
+  ProductPolicyProductLike,
+  ProductPropertyPolicyDiagnostic,
+  ProductPropertyPolicyDiagnosticCode,
+  ProductPropertyPolicyDiagnosticSeverity,
+  ProductPropertyPolicyMode,
+  ProductPropertyPolicySelectorBehavior,
+  ProductPropertyPolicyValidationResult,
   PreflightResult,
   ResolvedAction,
   SLAWindow,
   SlaWindow,
+  ValidateProductsAgainstPropertyPolicyOptions,
   UpdateFieldEntry,
   UpdateMediaBuyRequestLike,
 } from './media-buy';
@@ -492,8 +502,11 @@ export {
   getActionForMutation,
   getAvailableActions,
   getRollupParent,
+  ProductPropertyPolicyError,
+  normalizeDomainForPropertyPolicy,
   preflightUpdateMediaBuy,
   recoveryForModeMismatch,
+  validateProductsAgainstPropertyPolicy,
 } from './media-buy';
 export { InputRequiredError } from './core/TaskExecutor';
 

--- a/src/lib/media-buy/index.ts
+++ b/src/lib/media-buy/index.ts
@@ -23,6 +23,24 @@ export {
 } from './available-actions';
 
 export type {
+  BuyerPropertyPolicy,
+  NormalizedPolicyDomain,
+  ProductPolicyProductLike,
+  ProductPropertyPolicyDiagnostic,
+  ProductPropertyPolicyDiagnosticCode,
+  ProductPropertyPolicyDiagnosticSeverity,
+  ProductPropertyPolicyMode,
+  ProductPropertyPolicySelectorBehavior,
+  ProductPropertyPolicyValidationResult,
+  ValidateProductsAgainstPropertyPolicyOptions,
+} from './property-policy';
+export {
+  ProductPropertyPolicyError,
+  normalizeDomainForPropertyPolicy,
+  validateProductsAgainstPropertyPolicy,
+} from './property-policy';
+
+export type {
   DecomposedUpdateMediaBuy,
   DecomposedUpdateMediaBuyMutation,
   MediaBuyMutationDirection,

--- a/src/lib/media-buy/property-policy.ts
+++ b/src/lib/media-buy/property-policy.ts
@@ -476,7 +476,9 @@ function matchedAllowedDomainForCandidate(
   candidate: NormalizedPolicyDomain,
   policy: CompiledPropertyPolicy
 ): string | undefined {
-  const explicitDomain = policy.allowedDomains.find(allowed => propertyListDomainMatches(candidate.host, allowed.input));
+  const explicitDomain = policy.allowedDomains.find(allowed =>
+    propertyListDomainMatches(candidate.host, allowed.input)
+  );
   if (explicitDomain) return explicitDomain.host;
 
   for (const identifier of policy.allowedPropertyIdentifiers) {

--- a/src/lib/media-buy/property-policy.ts
+++ b/src/lib/media-buy/property-policy.ts
@@ -3,6 +3,22 @@ export type ProductPropertyPolicyMode = 'audit' | 'filter' | 'reject_response';
 export type ProductPropertyPolicySelectorBehavior = 'allow' | 'flag' | 'reject';
 
 export interface BuyerPropertyPolicy {
+  /** Domains the buyer will accept in returned products. */
+  allowedDomains?: readonly string[];
+  /**
+   * Resolved property-list identifiers the buyer will accept in returned
+   * products. Domain identifiers are matched with AdCP property-list domain
+   * semantics (`example.com` matches `www.example.com` and `m.example.com`;
+   * `*.example.com` matches subdomains only).
+   */
+  allowedPropertyIdentifiers?: readonly ProductPropertyPolicyIdentifier[];
+  /**
+   * Require products to match the allowed domain/identifier set even when that
+   * set is empty. Used when a request property_list resolves successfully to
+   * zero identifiers; the safe interpretation is that no properties are
+   * eligible.
+   */
+  requireAllowedPropertyMatch?: boolean;
   /** Domains the buyer will not accept in returned products. */
   excludedDomains?: readonly string[];
   /** Publisher-scoped property IDs the buyer will not accept in returned products. */
@@ -38,10 +54,17 @@ export interface ProductPolicyProductLike {
   product_id?: unknown;
   id?: unknown;
   publisher_properties?: unknown;
+  property_targeting_allowed?: unknown;
   [key: string]: unknown;
 }
 
+export interface ProductPropertyPolicyIdentifier {
+  type: string;
+  value: string;
+}
+
 export type ProductPropertyPolicyDiagnosticCode =
+  | 'outside_property_list'
   | 'excluded_domain'
   | 'excluded_property_id'
   | 'missing_publisher_properties'
@@ -61,7 +84,10 @@ export interface ProductPropertyPolicyDiagnostic {
   publisher_property_index?: number;
   selection_type?: string;
   publisher_domain?: string;
+  publisher_domains?: string[];
   normalized_domain?: string;
+  normalized_domains?: string[];
+  matched_allowed_domain?: string;
   matched_excluded_domain?: string;
   property_ids?: string[];
   matched_property_ids?: string[];
@@ -101,6 +127,9 @@ export class ProductPropertyPolicyError<TProduct extends ProductPolicyProductLik
 }
 
 interface CompiledPropertyPolicy {
+  allowedDomains: NormalizedPolicyDomain[];
+  allowedPropertyIdentifiers: ProductPropertyPolicyIdentifier[];
+  requireAllowedPropertyMatch: boolean;
   excludedDomainsByComparable: Map<string, NormalizedPolicyDomain>;
   excludedPropertyIds: Set<string>;
   unknownSelectorBehavior: ProductPropertyPolicySelectorBehavior;
@@ -110,7 +139,13 @@ interface CompiledPropertyPolicy {
 interface ProductPublisherPropertySelectorLike {
   selection_type?: unknown;
   publisher_domain?: unknown;
+  publisher_domains?: unknown;
   property_ids?: unknown;
+}
+
+interface PublisherDomainCandidate {
+  raw: string;
+  path: string;
 }
 
 export function validateProductsAgainstPropertyPolicy<TProduct extends ProductPolicyProductLike>(
@@ -160,6 +195,12 @@ export function normalizeDomainForPropertyPolicy(value: string): NormalizedPolic
 }
 
 function compilePolicy(policy: BuyerPropertyPolicy): CompiledPropertyPolicy {
+  const allowedDomains: NormalizedPolicyDomain[] = [];
+  for (const domain of policy.allowedDomains ?? []) {
+    const normalized = normalizeDomainForPropertyPolicy(domain);
+    if (normalized) allowedDomains.push(normalized);
+  }
+
   const excludedDomainsByComparable = new Map<string, NormalizedPolicyDomain>();
   for (const domain of policy.excludedDomains ?? []) {
     const normalized = normalizeDomainForPropertyPolicy(domain);
@@ -167,6 +208,11 @@ function compilePolicy(policy: BuyerPropertyPolicy): CompiledPropertyPolicy {
   }
 
   return {
+    allowedDomains,
+    allowedPropertyIdentifiers: [...(policy.allowedPropertyIdentifiers ?? [])],
+    requireAllowedPropertyMatch:
+      policy.requireAllowedPropertyMatch ??
+      Boolean(policy.allowedDomains?.length || policy.allowedPropertyIdentifiers?.length),
     excludedDomainsByComparable,
     excludedPropertyIds: new Set(policy.excludedPropertyIds ?? []),
     unknownSelectorBehavior: policy.unknownSelectorBehavior ?? (policy.strict ? 'reject' : 'flag'),
@@ -194,9 +240,29 @@ function diagnosticsForProduct(
   }
 
   const diagnostics: ProductPropertyPolicyDiagnostic[] = [];
+  let hasEligibleSubsetSelector = false;
+  const requiresSubsetMatch = hasAllowedPropertyScope(policy) && product.property_targeting_allowed === true;
   publisherProperties.forEach((rawSelector, selectorIndex) => {
-    diagnostics.push(...diagnosticsForSelector(rawSelector, productIndex, selectorIndex, productId, policy));
+    diagnostics.push(
+      ...diagnosticsForSelector(rawSelector, productIndex, selectorIndex, productId, policy, {
+        enforceEveryDomainInAllowedScope: !requiresSubsetMatch,
+        enforceExclusions: !requiresSubsetMatch,
+      })
+    );
+    if (requiresSubsetMatch && selectorIsEligibleForSubsetTargeting(rawSelector, productIndex, selectorIndex, policy)) {
+      hasEligibleSubsetSelector = true;
+    }
   });
+  if (requiresSubsetMatch && !hasEligibleSubsetSelector) {
+    diagnostics.push({
+      code: 'outside_property_list',
+      severity: 'rejected',
+      message: 'Product has no buyer-eligible publisher properties inside the requested property list.',
+      product_index: productIndex,
+      product_id: productId,
+      path: `products[${productIndex}].publisher_properties`,
+    });
+  }
   return diagnostics;
 }
 
@@ -205,7 +271,8 @@ function diagnosticsForSelector(
   productIndex: number,
   selectorIndex: number,
   productId: string | undefined,
-  policy: CompiledPropertyPolicy
+  policy: CompiledPropertyPolicy,
+  options: { enforceEveryDomainInAllowedScope: boolean; enforceExclusions: boolean }
 ): ProductPropertyPolicyDiagnostic[] {
   const path = `products[${productIndex}].publisher_properties[${selectorIndex}]`;
   if (!rawSelector || typeof rawSelector !== 'object' || Array.isArray(rawSelector)) {
@@ -221,15 +288,36 @@ function diagnosticsForSelector(
 
   const selector = rawSelector as ProductPublisherPropertySelectorLike;
   const selectionType = typeof selector.selection_type === 'string' ? selector.selection_type : undefined;
-  const rawDomain = typeof selector.publisher_domain === 'string' ? selector.publisher_domain : undefined;
-  const normalizedDomain = rawDomain ? normalizeDomainForPropertyPolicy(rawDomain) : undefined;
+  const domainCandidates = publisherDomainCandidates(selector, path);
+  const normalizedDomains = domainCandidates
+    .map(candidate => ({ candidate, normalized: normalizeDomainForPropertyPolicy(candidate.raw) }))
+    .filter((entry): entry is { candidate: PublisherDomainCandidate; normalized: NormalizedPolicyDomain } =>
+      Boolean(entry.normalized)
+    );
   const diagnostics: ProductPropertyPolicyDiagnostic[] = [];
 
-  if (!rawDomain) {
+  if (selector.publisher_domains !== undefined) {
+    diagnostics.push({
+      code: 'unknown_selector',
+      severity: 'rejected',
+      message:
+        'Product publisher property selector uses publisher_domains, which is not valid on product publisher_properties.',
+      product_index: productIndex,
+      product_id: productId,
+      path,
+      publisher_property_index: selectorIndex,
+      selection_type: selectionType,
+      ...(typeof selector.publisher_domain === 'string' ? { publisher_domain: selector.publisher_domain } : {}),
+      publisher_domains: stringArray(selector.publisher_domains),
+    });
+  }
+
+  if (domainCandidates.length === 0) {
     diagnostics.push(
       ...diagnosticForBehavior(policy.unknownSelectorBehavior, {
         code: 'unknown_selector',
-        message: 'Product publisher property selector is missing publisher_domain and cannot be evaluated confidently.',
+        message:
+          'Product publisher property selector is missing publisher_domain/publisher_domains and cannot be evaluated confidently.',
         product_index: productIndex,
         product_id: productId,
         path: `${path}.publisher_domain`,
@@ -239,35 +327,57 @@ function diagnosticsForSelector(
     );
   }
 
-  if (rawDomain && !normalizedDomain) {
+  for (const candidate of domainCandidates) {
+    const normalizedDomain = normalizeDomainForPropertyPolicy(candidate.raw);
+    if (normalizedDomain) continue;
     diagnostics.push(
       ...diagnosticForBehavior(policy.unknownSelectorBehavior, {
         code: 'malformed_publisher_domain',
-        message: 'Publisher property selector has a malformed publisher_domain and cannot be evaluated.',
+        message: 'Publisher property selector has a malformed publisher domain and cannot be evaluated.',
         product_index: productIndex,
         product_id: productId,
-        path: `${path}.publisher_domain`,
+        path: candidate.path,
         publisher_property_index: selectorIndex,
         selection_type: selectionType,
-        publisher_domain: rawDomain,
+        publisher_domain: candidate.raw,
       })
     );
   }
 
-  if (normalizedDomain) {
+  for (const { candidate, normalized: normalizedDomain } of normalizedDomains) {
+    const matchedAllowedDomain = matchedAllowedDomainForCandidate(normalizedDomain, policy);
+    if (options.enforceEveryDomainInAllowedScope && hasAllowedPropertyScope(policy) && !matchedAllowedDomain) {
+      diagnostics.push({
+        code: 'outside_property_list',
+        severity: 'rejected',
+        message: `Product includes publisher domain ${normalizedDomain.host} outside the requested property list.`,
+        product_index: productIndex,
+        product_id: productId,
+        path: candidate.path,
+        publisher_property_index: selectorIndex,
+        selection_type: selectionType,
+        publisher_domain: candidate.raw,
+        publisher_domains: domainCandidates.map(candidate => candidate.raw),
+        normalized_domain: normalizedDomain.host,
+        normalized_domains: normalizedDomains.map(entry => entry.normalized.host),
+      });
+    }
+
     const excludedDomain = policy.excludedDomainsByComparable.get(normalizedDomain.comparable);
-    if (excludedDomain) {
+    if (options.enforceExclusions && excludedDomain) {
       diagnostics.push({
         code: 'excluded_domain',
         severity: 'rejected',
         message: `Product includes excluded publisher domain ${normalizedDomain.host}.`,
         product_index: productIndex,
         product_id: productId,
-        path: `${path}.publisher_domain`,
+        path: candidate.path,
         publisher_property_index: selectorIndex,
         selection_type: selectionType,
-        publisher_domain: rawDomain,
+        publisher_domain: candidate.raw,
+        publisher_domains: domainCandidates.map(candidate => candidate.raw),
         normalized_domain: normalizedDomain.host,
+        normalized_domains: normalizedDomains.map(entry => entry.normalized.host),
         matched_excluded_domain: excludedDomain.host,
       });
     }
@@ -276,7 +386,7 @@ function diagnosticsForSelector(
   if (selectionType === 'by_id') {
     const propertyIds = stringArray(selector.property_ids);
     const matchedPropertyIds = propertyIds.filter(id => policy.excludedPropertyIds.has(id));
-    if (matchedPropertyIds.length > 0) {
+    if (options.enforceExclusions && matchedPropertyIds.length > 0) {
       diagnostics.push({
         code: 'excluded_property_id',
         severity: 'rejected',
@@ -286,8 +396,10 @@ function diagnosticsForSelector(
         path: `${path}.property_ids`,
         publisher_property_index: selectorIndex,
         selection_type: selectionType,
-        publisher_domain: rawDomain,
-        normalized_domain: normalizedDomain?.host,
+        publisher_domain: domainCandidates[0]?.raw,
+        publisher_domains: domainCandidates.map(candidate => candidate.raw),
+        normalized_domain: normalizedDomains[0]?.normalized.host,
+        normalized_domains: normalizedDomains.map(entry => entry.normalized.host),
         property_ids: propertyIds,
         matched_property_ids: matchedPropertyIds,
       });
@@ -303,8 +415,10 @@ function diagnosticsForSelector(
         path,
         publisher_property_index: selectorIndex,
         selection_type: selectionType,
-        publisher_domain: rawDomain,
-        normalized_domain: normalizedDomain?.host,
+        publisher_domain: domainCandidates[0]?.raw,
+        publisher_domains: domainCandidates.map(candidate => candidate.raw),
+        normalized_domain: normalizedDomains[0]?.normalized.host,
+        normalized_domains: normalizedDomains.map(entry => entry.normalized.host),
       })
     );
   } else if (selectionType !== 'all') {
@@ -317,13 +431,72 @@ function diagnosticsForSelector(
         path: `${path}.selection_type`,
         publisher_property_index: selectorIndex,
         selection_type: selectionType,
-        publisher_domain: rawDomain,
-        normalized_domain: normalizedDomain?.host,
+        publisher_domain: domainCandidates[0]?.raw,
+        publisher_domains: domainCandidates.map(candidate => candidate.raw),
+        normalized_domain: normalizedDomains[0]?.normalized.host,
+        normalized_domains: normalizedDomains.map(entry => entry.normalized.host),
       })
     );
   }
 
   return diagnostics;
+}
+
+function hasAllowedPropertyScope(policy: CompiledPropertyPolicy): boolean {
+  return policy.requireAllowedPropertyMatch;
+}
+
+function selectorIsEligibleForSubsetTargeting(
+  rawSelector: unknown,
+  productIndex: number,
+  selectorIndex: number,
+  policy: CompiledPropertyPolicy
+): boolean {
+  const path = `products[${productIndex}].publisher_properties[${selectorIndex}]`;
+  if (!rawSelector || typeof rawSelector !== 'object' || Array.isArray(rawSelector)) return false;
+  const selector = rawSelector as ProductPublisherPropertySelectorLike;
+  if (selector.publisher_domains !== undefined) return false;
+  if (selector.selection_type === 'by_tag') return false;
+  if (selector.selection_type !== 'all' && selector.selection_type !== 'by_id') return false;
+
+  const hasEligibleDomain = publisherDomainCandidates(selector, path).some(candidate => {
+    const normalized = normalizeDomainForPropertyPolicy(candidate.raw);
+    if (!normalized) return false;
+    if (hasAllowedPropertyScope(policy) && !matchedAllowedDomainForCandidate(normalized, policy)) return false;
+    return !policy.excludedDomainsByComparable.has(normalized.comparable);
+  });
+  if (!hasEligibleDomain) return false;
+
+  if (selector.selection_type !== 'by_id') return true;
+  const propertyIds = stringArray(selector.property_ids);
+  return propertyIds.length === 0 || propertyIds.some(id => !policy.excludedPropertyIds.has(id));
+}
+
+function matchedAllowedDomainForCandidate(
+  candidate: NormalizedPolicyDomain,
+  policy: CompiledPropertyPolicy
+): string | undefined {
+  const explicitDomain = policy.allowedDomains.find(allowed => propertyListDomainMatches(candidate.host, allowed.input));
+  if (explicitDomain) return explicitDomain.host;
+
+  for (const identifier of policy.allowedPropertyIdentifiers) {
+    if (identifier.type !== 'domain' && identifier.type !== 'subdomain') continue;
+    if (propertyListDomainMatches(candidate.host, identifier.value, identifier.type)) {
+      return identifier.value;
+    }
+  }
+  return undefined;
+}
+
+function publisherDomainCandidates(
+  selector: ProductPublisherPropertySelectorLike,
+  path: string
+): PublisherDomainCandidate[] {
+  const candidates: PublisherDomainCandidate[] = [];
+  if (typeof selector.publisher_domain === 'string') {
+    candidates.push({ raw: selector.publisher_domain, path: `${path}.publisher_domain` });
+  }
+  return candidates;
 }
 
 function diagnosticForBehavior(
@@ -373,6 +546,19 @@ function hasScheme(value: string): boolean {
 
 function comparableDomain(host: string): string {
   return host.startsWith('www.') ? host.slice(4) : host;
+}
+
+function propertyListDomainMatches(candidateValue: string, patternValue: string, type: string = 'domain'): boolean {
+  const candidate = normalizeDomainForPropertyPolicy(candidateValue)?.host;
+  const pattern = normalizeDomainForPropertyPolicy(patternValue)?.host;
+  if (!candidate || !pattern) return false;
+  if (candidate === pattern) return true;
+  if (type === 'subdomain') return false;
+  if (pattern.startsWith('*.')) {
+    const base = pattern.slice(2);
+    return candidate.endsWith(`.${base}`) && candidate !== base;
+  }
+  return candidate === `www.${pattern}` || candidate === `m.${pattern}`;
 }
 
 function isUsableHostname(host: string): boolean {

--- a/src/lib/media-buy/property-policy.ts
+++ b/src/lib/media-buy/property-policy.ts
@@ -1,0 +1,382 @@
+export type ProductPropertyPolicyMode = 'audit' | 'filter' | 'reject_response';
+
+export type ProductPropertyPolicySelectorBehavior = 'allow' | 'flag' | 'reject';
+
+export interface BuyerPropertyPolicy {
+  /** Domains the buyer will not accept in returned products. */
+  excludedDomains?: readonly string[];
+  /** Publisher-scoped property IDs the buyer will not accept in returned products. */
+  excludedPropertyIds?: readonly string[];
+  /**
+   * Shorthand for strict brand-safety evaluation. Defaults unresolved tag
+   * selectors and missing `publisher_properties` to rejection unless the more
+   * specific behavior fields override it.
+   */
+  strict?: boolean;
+  /**
+   * How to handle selectors the SDK cannot confidently evaluate, such as
+   * `selection_type: "by_tag"` without resolved property metadata.
+   *
+   * Default: `reject` when `strict` is true, otherwise `flag`.
+   */
+  unknownSelectorBehavior?: ProductPropertyPolicySelectorBehavior;
+  /**
+   * How to handle products that omit `publisher_properties`.
+   *
+   * Default: `reject` when `strict` is true, otherwise `allow`.
+   */
+  missingPublisherPropertiesBehavior?: ProductPropertyPolicySelectorBehavior;
+}
+
+export interface ValidateProductsAgainstPropertyPolicyOptions<TProduct extends ProductPolicyProductLike> {
+  products: readonly TProduct[];
+  policy: BuyerPropertyPolicy;
+  mode?: ProductPropertyPolicyMode;
+}
+
+export interface ProductPolicyProductLike {
+  product_id?: unknown;
+  id?: unknown;
+  publisher_properties?: unknown;
+  [key: string]: unknown;
+}
+
+export type ProductPropertyPolicyDiagnosticCode =
+  | 'excluded_domain'
+  | 'excluded_property_id'
+  | 'missing_publisher_properties'
+  | 'unresolved_tag_selector'
+  | 'unknown_selector'
+  | 'malformed_publisher_domain';
+
+export type ProductPropertyPolicyDiagnosticSeverity = 'rejected' | 'flagged';
+
+export interface ProductPropertyPolicyDiagnostic {
+  code: ProductPropertyPolicyDiagnosticCode;
+  severity: ProductPropertyPolicyDiagnosticSeverity;
+  message: string;
+  product_index: number;
+  product_id?: string;
+  path: string;
+  publisher_property_index?: number;
+  selection_type?: string;
+  publisher_domain?: string;
+  normalized_domain?: string;
+  matched_excluded_domain?: string;
+  property_ids?: string[];
+  matched_property_ids?: string[];
+}
+
+export interface ProductPropertyPolicyValidationResult<TProduct extends ProductPolicyProductLike> {
+  mode: ProductPropertyPolicyMode;
+  ok: boolean;
+  /**
+   * Mode-adjusted output. `audit` returns the original product list, `filter`
+   * returns only policy-eligible products, and `reject_response` returns the
+   * original list when no rejection occurs.
+   */
+  products: TProduct[];
+  acceptedProducts: TProduct[];
+  rejectedProducts: TProduct[];
+  flaggedProducts: TProduct[];
+  diagnostics: ProductPropertyPolicyDiagnostic[];
+}
+
+export interface NormalizedPolicyDomain {
+  input: string;
+  host: string;
+  comparable: string;
+}
+
+export class ProductPropertyPolicyError<TProduct extends ProductPolicyProductLike> extends Error {
+  readonly name = 'ProductPropertyPolicyError';
+
+  constructor(public readonly result: ProductPropertyPolicyValidationResult<TProduct>) {
+    super(
+      `Product property policy rejected ${result.rejectedProducts.length} product${
+        result.rejectedProducts.length === 1 ? '' : 's'
+      }`
+    );
+  }
+}
+
+interface CompiledPropertyPolicy {
+  excludedDomainsByComparable: Map<string, NormalizedPolicyDomain>;
+  excludedPropertyIds: Set<string>;
+  unknownSelectorBehavior: ProductPropertyPolicySelectorBehavior;
+  missingPublisherPropertiesBehavior: ProductPropertyPolicySelectorBehavior;
+}
+
+interface ProductPublisherPropertySelectorLike {
+  selection_type?: unknown;
+  publisher_domain?: unknown;
+  property_ids?: unknown;
+}
+
+export function validateProductsAgainstPropertyPolicy<TProduct extends ProductPolicyProductLike>(
+  options: ValidateProductsAgainstPropertyPolicyOptions<TProduct>
+): ProductPropertyPolicyValidationResult<TProduct> {
+  const mode = options.mode ?? 'audit';
+  const compiled = compilePolicy(options.policy);
+  const diagnostics: ProductPropertyPolicyDiagnostic[] = [];
+
+  options.products.forEach((product, productIndex) => {
+    diagnostics.push(...diagnosticsForProduct(product, productIndex, compiled));
+  });
+
+  const rejectedIndexes = new Set(diagnostics.filter(d => d.severity === 'rejected').map(d => d.product_index));
+  const flaggedIndexes = new Set(diagnostics.filter(d => d.severity === 'flagged').map(d => d.product_index));
+
+  const acceptedProducts = options.products.filter((_, index) => !rejectedIndexes.has(index));
+  const rejectedProducts = options.products.filter((_, index) => rejectedIndexes.has(index));
+  const flaggedProducts = options.products.filter(
+    (_, index) => flaggedIndexes.has(index) && !rejectedIndexes.has(index)
+  );
+
+  const result: ProductPropertyPolicyValidationResult<TProduct> = {
+    mode,
+    ok: rejectedProducts.length === 0,
+    products: mode === 'filter' ? acceptedProducts : [...options.products],
+    acceptedProducts,
+    rejectedProducts,
+    flaggedProducts,
+    diagnostics,
+  };
+
+  if (mode === 'reject_response' && !result.ok) {
+    throw new ProductPropertyPolicyError(result);
+  }
+
+  return result;
+}
+
+export function normalizeDomainForPropertyPolicy(value: string): NormalizedPolicyDomain | undefined {
+  const input = value;
+  let host = extractHostname(value);
+  if (!host) return undefined;
+  host = host.toLowerCase().replace(/\.$/, '');
+  if (!isUsableHostname(host)) return undefined;
+  return { input, host, comparable: comparableDomain(host) };
+}
+
+function compilePolicy(policy: BuyerPropertyPolicy): CompiledPropertyPolicy {
+  const excludedDomainsByComparable = new Map<string, NormalizedPolicyDomain>();
+  for (const domain of policy.excludedDomains ?? []) {
+    const normalized = normalizeDomainForPropertyPolicy(domain);
+    if (normalized) excludedDomainsByComparable.set(normalized.comparable, normalized);
+  }
+
+  return {
+    excludedDomainsByComparable,
+    excludedPropertyIds: new Set(policy.excludedPropertyIds ?? []),
+    unknownSelectorBehavior: policy.unknownSelectorBehavior ?? (policy.strict ? 'reject' : 'flag'),
+    missingPublisherPropertiesBehavior:
+      policy.missingPublisherPropertiesBehavior ?? (policy.strict ? 'reject' : 'allow'),
+  };
+}
+
+function diagnosticsForProduct(
+  product: ProductPolicyProductLike,
+  productIndex: number,
+  policy: CompiledPropertyPolicy
+): ProductPropertyPolicyDiagnostic[] {
+  const publisherProperties = product.publisher_properties;
+  const productId = productIdForDiagnostics(product);
+
+  if (!Array.isArray(publisherProperties) || publisherProperties.length === 0) {
+    return diagnosticForBehavior(policy.missingPublisherPropertiesBehavior, {
+      code: 'missing_publisher_properties',
+      message: 'Product is missing publisher_properties, so buyer property exclusions cannot be evaluated.',
+      product_index: productIndex,
+      product_id: productId,
+      path: `products[${productIndex}].publisher_properties`,
+    });
+  }
+
+  const diagnostics: ProductPropertyPolicyDiagnostic[] = [];
+  publisherProperties.forEach((rawSelector, selectorIndex) => {
+    diagnostics.push(...diagnosticsForSelector(rawSelector, productIndex, selectorIndex, productId, policy));
+  });
+  return diagnostics;
+}
+
+function diagnosticsForSelector(
+  rawSelector: unknown,
+  productIndex: number,
+  selectorIndex: number,
+  productId: string | undefined,
+  policy: CompiledPropertyPolicy
+): ProductPropertyPolicyDiagnostic[] {
+  const path = `products[${productIndex}].publisher_properties[${selectorIndex}]`;
+  if (!rawSelector || typeof rawSelector !== 'object' || Array.isArray(rawSelector)) {
+    return diagnosticForBehavior(policy.unknownSelectorBehavior, {
+      code: 'unknown_selector',
+      message: 'Publisher property selector is not an object and cannot be evaluated.',
+      product_index: productIndex,
+      product_id: productId,
+      path,
+      publisher_property_index: selectorIndex,
+    });
+  }
+
+  const selector = rawSelector as ProductPublisherPropertySelectorLike;
+  const selectionType = typeof selector.selection_type === 'string' ? selector.selection_type : undefined;
+  const rawDomain = typeof selector.publisher_domain === 'string' ? selector.publisher_domain : undefined;
+  const normalizedDomain = rawDomain ? normalizeDomainForPropertyPolicy(rawDomain) : undefined;
+  const diagnostics: ProductPropertyPolicyDiagnostic[] = [];
+
+  if (!rawDomain) {
+    diagnostics.push(
+      ...diagnosticForBehavior(policy.unknownSelectorBehavior, {
+        code: 'unknown_selector',
+        message: 'Product publisher property selector is missing publisher_domain and cannot be evaluated confidently.',
+        product_index: productIndex,
+        product_id: productId,
+        path: `${path}.publisher_domain`,
+        publisher_property_index: selectorIndex,
+        selection_type: selectionType,
+      })
+    );
+  }
+
+  if (rawDomain && !normalizedDomain) {
+    diagnostics.push(
+      ...diagnosticForBehavior(policy.unknownSelectorBehavior, {
+        code: 'malformed_publisher_domain',
+        message: 'Publisher property selector has a malformed publisher_domain and cannot be evaluated.',
+        product_index: productIndex,
+        product_id: productId,
+        path: `${path}.publisher_domain`,
+        publisher_property_index: selectorIndex,
+        selection_type: selectionType,
+        publisher_domain: rawDomain,
+      })
+    );
+  }
+
+  if (normalizedDomain) {
+    const excludedDomain = policy.excludedDomainsByComparable.get(normalizedDomain.comparable);
+    if (excludedDomain) {
+      diagnostics.push({
+        code: 'excluded_domain',
+        severity: 'rejected',
+        message: `Product includes excluded publisher domain ${normalizedDomain.host}.`,
+        product_index: productIndex,
+        product_id: productId,
+        path: `${path}.publisher_domain`,
+        publisher_property_index: selectorIndex,
+        selection_type: selectionType,
+        publisher_domain: rawDomain,
+        normalized_domain: normalizedDomain.host,
+        matched_excluded_domain: excludedDomain.host,
+      });
+    }
+  }
+
+  if (selectionType === 'by_id') {
+    const propertyIds = stringArray(selector.property_ids);
+    const matchedPropertyIds = propertyIds.filter(id => policy.excludedPropertyIds.has(id));
+    if (matchedPropertyIds.length > 0) {
+      diagnostics.push({
+        code: 'excluded_property_id',
+        severity: 'rejected',
+        message: `Product includes excluded publisher property ID${matchedPropertyIds.length === 1 ? '' : 's'}.`,
+        product_index: productIndex,
+        product_id: productId,
+        path: `${path}.property_ids`,
+        publisher_property_index: selectorIndex,
+        selection_type: selectionType,
+        publisher_domain: rawDomain,
+        normalized_domain: normalizedDomain?.host,
+        property_ids: propertyIds,
+        matched_property_ids: matchedPropertyIds,
+      });
+    }
+  } else if (selectionType === 'by_tag') {
+    diagnostics.push(
+      ...diagnosticForBehavior(policy.unknownSelectorBehavior, {
+        code: 'unresolved_tag_selector',
+        message:
+          'Product uses selection_type by_tag; without resolved property metadata it cannot be evaluated confidently.',
+        product_index: productIndex,
+        product_id: productId,
+        path,
+        publisher_property_index: selectorIndex,
+        selection_type: selectionType,
+        publisher_domain: rawDomain,
+        normalized_domain: normalizedDomain?.host,
+      })
+    );
+  } else if (selectionType !== 'all') {
+    diagnostics.push(
+      ...diagnosticForBehavior(policy.unknownSelectorBehavior, {
+        code: 'unknown_selector',
+        message: 'Product uses an unknown publisher_properties selection_type and cannot be evaluated.',
+        product_index: productIndex,
+        product_id: productId,
+        path: `${path}.selection_type`,
+        publisher_property_index: selectorIndex,
+        selection_type: selectionType,
+        publisher_domain: rawDomain,
+        normalized_domain: normalizedDomain?.host,
+      })
+    );
+  }
+
+  return diagnostics;
+}
+
+function diagnosticForBehavior(
+  behavior: ProductPropertyPolicySelectorBehavior,
+  diagnostic: Omit<ProductPropertyPolicyDiagnostic, 'severity'>
+): ProductPropertyPolicyDiagnostic[] {
+  if (behavior === 'allow') return [];
+  return [{ ...diagnostic, severity: behavior === 'reject' ? 'rejected' : 'flagged' }];
+}
+
+function productIdForDiagnostics(product: ProductPolicyProductLike): string | undefined {
+  if (typeof product.product_id === 'string') return product.product_id;
+  if (typeof product.id === 'string') return product.id;
+  return undefined;
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((v): v is string => typeof v === 'string') : [];
+}
+
+function extractHostname(value: string): string | undefined {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return undefined;
+
+  try {
+    const url = new URL(hasScheme(trimmed) || trimmed.startsWith('//') ? trimmed : `https://${trimmed}`);
+    return url.hostname;
+  } catch {
+    let host = trimmed.replace(/^[a-z][a-z0-9+.-]*:\/\//i, '').replace(/^\/\//, '');
+    const firstPathChar = host.search(/[/?#]/);
+    if (firstPathChar >= 0) host = host.slice(0, firstPathChar);
+    const at = host.lastIndexOf('@');
+    if (at >= 0) host = host.slice(at + 1);
+    if (host.startsWith('[')) {
+      const close = host.indexOf(']');
+      if (close >= 0) host = host.slice(1, close);
+    } else {
+      host = host.replace(/:\d+$/, '');
+    }
+    return host;
+  }
+}
+
+function hasScheme(value: string): boolean {
+  return /^[a-z][a-z0-9+.-]*:\/\//i.test(value);
+}
+
+function comparableDomain(host: string): string {
+  return host.startsWith('www.') ? host.slice(4) : host;
+}
+
+function isUsableHostname(host: string): boolean {
+  if (host.length === 0 || host.length > 253) return false;
+  // eslint-disable-next-line no-control-regex
+  return !/[\x00-\x1f\x7f\s/\\]/.test(host);
+}

--- a/src/lib/protocols/mcp.ts
+++ b/src/lib/protocols/mcp.ts
@@ -392,12 +392,26 @@ export async function withCachedConnection<T>(
   authHeaders: Record<string, string>,
   debugLogs: DebugLogEntry[],
   label: string,
-  fn: (client: MCPClient) => Promise<T>
+  fn: (client: MCPClient) => Promise<T>,
+  transportFetch?: typeof fetch
 ): Promise<T> {
   const signingContext = signingContextStorage.getStore();
-  const cacheKey = connectionCacheKey(agentUrl, authToken, signingContext?.cacheKey, authHeaders);
   const baseUrl = new URL(agentUrl);
 
+  if (transportFetch) {
+    const guardedClient = await connectMCPWithFallback(baseUrl, authHeaders, debugLogs, label, transportFetch);
+    try {
+      return await fn(guardedClient);
+    } finally {
+      try {
+        await guardedClient.close();
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+
+  const cacheKey = connectionCacheKey(agentUrl, authToken, signingContext?.cacheKey, authHeaders);
   const mcpClient = await getOrCreateConnection(cacheKey, baseUrl, authHeaders, debugLogs, label);
 
   try {
@@ -497,7 +511,8 @@ export async function connectMCPWithFallback(
   url: URL,
   authHeaders: Record<string, string>,
   debugLogs: DebugLogEntry[] = [],
-  label = 'connection'
+  label = 'connection',
+  transportFetch?: typeof fetch
 ): Promise<MCPClient> {
   return withSpan(
     'adcp.mcp.connect',
@@ -506,7 +521,7 @@ export async function connectMCPWithFallback(
       'adcp.connection_label': label,
     },
     async () => {
-      return connectMCPWithFallbackImpl(url, authHeaders, debugLogs, label);
+      return connectMCPWithFallbackImpl(url, authHeaders, debugLogs, label, transportFetch);
     }
   );
 }
@@ -515,14 +530,16 @@ async function connectMCPWithFallbackImpl(
   url: URL,
   authHeaders: Record<string, string>,
   debugLogs: DebugLogEntry[] = [],
-  label = 'connection'
+  label = 'connection',
+  transportFetch?: typeof fetch
 ): Promise<MCPClient> {
   const signingContext = signingContextStorage.getStore();
   // Wrap order (innermost → outermost): network → size-limit → signing → capture.
   // Size-limit applies to the raw network response so signing/capture see a
   // bounded body (capture clones via `response.clone()`, which would otherwise
   // buffer a hostile reply in memory).
-  const sizeLimited = wrapFetchWithSizeLimit((input, init) => fetch(input as any, init));
+  const networkFetch = transportFetch ?? ((input, init) => fetch(input as any, init));
+  const sizeLimited = wrapFetchWithSizeLimit(networkFetch);
   const baseFetch: typeof fetch = signingContext
     ? (buildAgentSigningFetch({
         upstream: sizeLimited,
@@ -531,7 +548,7 @@ async function connectMCPWithFallbackImpl(
       }) as typeof fetch)
     : sizeLimited;
   const transportOptions: StreamableHTTPClientTransportOptions = {
-    requestInit: { headers: authHeaders },
+    requestInit: { headers: authHeaders, ...(transportFetch ? { redirect: 'manual' as const } : {}) },
     fetch: wrapFetchWithCapture(baseFetch),
   };
   let failedClient: MCPClient | undefined;
@@ -635,7 +652,7 @@ async function connectMCPWithFallbackImpl(
     const client = new MCPClient({ name: 'AdCP-Client', version: '1.0.0' });
     await client.connect(
       new SSEClientTransport(url, {
-        requestInit: { headers: authHeaders },
+        requestInit: { headers: authHeaders, ...(transportFetch ? { redirect: 'manual' as const } : {}) },
         fetch: wrapFetchWithCapture(baseFetch),
       })
     );
@@ -655,7 +672,8 @@ export async function callMCPTool(
   authToken?: string,
   debugLogs: DebugLogEntry[] = [],
   customHeaders?: Record<string, string>,
-  signingContext?: AgentSigningContext
+  signingContext?: AgentSigningContext,
+  transportFetch?: typeof fetch
 ): Promise<unknown> {
   return withSpan(
     'adcp.mcp.call_tool',
@@ -665,7 +683,7 @@ export async function callMCPTool(
     },
     async () => {
       return signingContextStorage.run(signingContext, () =>
-        callMCPToolImpl(agentUrl, toolName, args, authToken, debugLogs, customHeaders)
+        callMCPToolImpl(agentUrl, toolName, args, authToken, debugLogs, customHeaders, transportFetch)
       );
     }
   );
@@ -682,10 +700,11 @@ export async function callMCPToolRaw(
   authToken?: string,
   debugLogs: DebugLogEntry[] = [],
   customHeaders?: Record<string, string>,
-  signingContext?: AgentSigningContext
+  signingContext?: AgentSigningContext,
+  transportFetch?: typeof fetch
 ): Promise<unknown> {
   return signingContextStorage.run(signingContext, () =>
-    callMCPToolRawImpl(agentUrl, toolName, args, authToken, debugLogs, customHeaders)
+    callMCPToolRawImpl(agentUrl, toolName, args, authToken, debugLogs, customHeaders, transportFetch)
   );
 }
 
@@ -695,7 +714,8 @@ async function callMCPToolImpl(
   args: Record<string, unknown>,
   authToken?: string,
   debugLogs: DebugLogEntry[] = [],
-  customHeaders?: Record<string, string>
+  customHeaders?: Record<string, string>,
+  transportFetch?: typeof fetch
 ): Promise<unknown> {
   // Inject trace context headers for distributed tracing
   const traceHeaders = injectTraceHeaders();
@@ -737,7 +757,8 @@ async function callMCPToolImpl(
     authHeaders,
     debugLogs,
     toolName,
-    client => client.callTool({ name: toolName, arguments: args }) as Promise<CallToolResponse>
+    client => client.callTool({ name: toolName, arguments: args }) as Promise<CallToolResponse>,
+    transportFetch
   );
 
   debugLogs.push({
@@ -759,7 +780,8 @@ async function callMCPToolRawImpl(
   args: Record<string, unknown>,
   authToken?: string,
   debugLogs: DebugLogEntry[] = [],
-  customHeaders?: Record<string, string>
+  customHeaders?: Record<string, string>,
+  transportFetch?: typeof fetch
 ): Promise<unknown> {
   const traceHeaders = injectTraceHeaders();
   const authHeaders = {
@@ -769,7 +791,8 @@ async function callMCPToolRawImpl(
   };
 
   return withCachedConnection(agentUrl, authToken, authHeaders, debugLogs, toolName, client =>
-    client.callTool({ name: toolName, arguments: args })
+    client.callTool({ name: toolName, arguments: args }),
+    transportFetch
   );
 }
 

--- a/src/lib/protocols/mcp.ts
+++ b/src/lib/protocols/mcp.ts
@@ -790,8 +790,13 @@ async function callMCPToolRawImpl(
     ...(authToken ? createMCPAuthHeaders(authToken) : {}),
   };
 
-  return withCachedConnection(agentUrl, authToken, authHeaders, debugLogs, toolName, client =>
-    client.callTool({ name: toolName, arguments: args }),
+  return withCachedConnection(
+    agentUrl,
+    authToken,
+    authHeaders,
+    debugLogs,
+    toolName,
+    client => client.callTool({ name: toolName, arguments: args }),
     transportFetch
   );
 }

--- a/src/lib/server/index.ts
+++ b/src/lib/server/index.ts
@@ -458,15 +458,25 @@ export type {
 } from './governance';
 
 export {
+  clearDefaultResolvedListCache,
+  createResolvedListCache,
+  DEFAULT_RESOLVE_LIST_PAGE_SIZE,
+  defaultResolvedListCache,
   resolvePropertyList,
   resolveCollectionList,
+  resolvedListCacheKey,
   matchesPropertyList,
   matchesCollectionList,
 } from './targeting-helpers';
 export type {
+  ResolvedListCache,
+  ResolvedListCacheEntry,
+  ResolvedListCacheValue,
+  ResolvedListKind,
   ResolvedPropertyList,
   ResolvedCollectionList,
   ResolvedCollection,
+  ResolveListCallTool,
   ResolveListOptions,
 } from './targeting-helpers';
 

--- a/src/lib/server/targeting-helpers.test.ts
+++ b/src/lib/server/targeting-helpers.test.ts
@@ -148,16 +148,22 @@ describe('resolvePropertyList cache', () => {
       };
     };
 
-    await resolvePropertyList({ agent_url: 'https://lists.example/mcp', list_id: 'pl-1', auth_token: 'token-a' }, {
-      cache,
-      now,
-      callTool,
-    });
-    await resolvePropertyList({ agent_url: 'https://lists.example/mcp', list_id: 'pl-1', auth_token: 'token-b' }, {
-      cache,
-      now,
-      callTool,
-    });
+    await resolvePropertyList(
+      { agent_url: 'https://lists.example/mcp', list_id: 'pl-1', auth_token: 'token-a' },
+      {
+        cache,
+        now,
+        callTool,
+      }
+    );
+    await resolvePropertyList(
+      { agent_url: 'https://lists.example/mcp', list_id: 'pl-1', auth_token: 'token-b' },
+      {
+        cache,
+        now,
+        callTool,
+      }
+    );
 
     expect(calls).toHaveLength(2);
   });
@@ -256,7 +262,10 @@ describe('resolvePropertyList cache', () => {
       /list_agent_url_insecure/
     );
     await expect(
-      resolvePropertyList({ agent_url: 'https://user:pass@lists.example/mcp?token=secret', list_id: 'pl-1' }, { callTool })
+      resolvePropertyList(
+        { agent_url: 'https://user:pass@lists.example/mcp?token=secret', list_id: 'pl-1' },
+        { callTool }
+      )
     ).rejects.toThrow(/list_agent_url_malformed/);
     expect(calls).toHaveLength(0);
   });

--- a/src/lib/server/targeting-helpers.test.ts
+++ b/src/lib/server/targeting-helpers.test.ts
@@ -1,9 +1,13 @@
 import { describe, it, expect } from 'vitest';
 import {
+  createResolvedListCache,
   matchesPropertyList,
   matchesCollectionList,
+  resolveCollectionList,
+  resolvePropertyList,
   type ResolvedPropertyList,
   type ResolvedCollectionList,
+  type ResolveListCallTool,
 } from './targeting-helpers';
 
 describe('matchesPropertyList', () => {
@@ -104,5 +108,316 @@ describe('matchesCollectionList', () => {
   it('does not match when list entry lacks distribution_ids and rids differ', () => {
     const candidate = { collection_rid: 'rid:other' };
     expect(matchesCollectionList(candidate, list)).toBe(false);
+  });
+});
+
+describe('resolvePropertyList cache', () => {
+  const now = () => new Date('2026-06-02T12:00:00.000Z');
+  const future = '2026-06-02T12:05:00.000Z';
+
+  it('caches resolved identifiers until cache_valid_until and returns cloned values', async () => {
+    const cache = createResolvedListCache();
+    const calls: unknown[][] = [];
+    const callTool: ResolveListCallTool = async (...args) => {
+      calls.push(args);
+      return {
+        list: { list_id: 'pl-1', name: 'Allow list' },
+        identifiers: [{ type: 'domain', value: `site-${calls.length}.example` }],
+        cache_valid_until: future,
+      };
+    };
+
+    const ref = { agent_url: 'https://lists.example/mcp', list_id: 'pl-1', auth_token: 'token-a' };
+    const first = await resolvePropertyList(ref, { cache, now, callTool });
+    first.identifiers[0]!.value = 'mutated.example';
+    const second = await resolvePropertyList(ref, { cache, now, callTool });
+
+    expect(calls).toHaveLength(1);
+    expect(second.identifiers).toEqual([{ type: 'domain', value: 'site-1.example' }]);
+  });
+
+  it('scopes cache entries by auth token fingerprint', async () => {
+    const cache = createResolvedListCache();
+    const calls: unknown[][] = [];
+    const callTool: ResolveListCallTool = async (...args) => {
+      calls.push(args);
+      return {
+        list: { list_id: 'pl-1', name: 'Allow list' },
+        identifiers: [{ type: 'domain', value: `site-${calls.length}.example` }],
+        cache_valid_until: future,
+      };
+    };
+
+    await resolvePropertyList({ agent_url: 'https://lists.example/mcp', list_id: 'pl-1', auth_token: 'token-a' }, {
+      cache,
+      now,
+      callTool,
+    });
+    await resolvePropertyList({ agent_url: 'https://lists.example/mcp', list_id: 'pl-1', auth_token: 'token-b' }, {
+      cache,
+      now,
+      callTool,
+    });
+
+    expect(calls).toHaveLength(2);
+  });
+
+  it('does not cache shared entries without auth token or cache scope', async () => {
+    const cache = createResolvedListCache();
+    const calls: unknown[][] = [];
+    const callTool: ResolveListCallTool = async (...args) => {
+      calls.push(args);
+      return {
+        list: { list_id: 'pl-1', name: 'Allow list' },
+        identifiers: [{ type: 'domain', value: `site-${calls.length}.example` }],
+        cache_valid_until: future,
+      };
+    };
+
+    const ref = { agent_url: 'https://lists.example/mcp', list_id: 'pl-1' };
+    await resolvePropertyList(ref, { cache, now, callTool });
+    const second = await resolvePropertyList(ref, { cache, now, callTool });
+
+    expect(calls).toHaveLength(2);
+    expect(second.identifiers).toEqual([{ type: 'domain', value: 'site-2.example' }]);
+  });
+
+  it('uses cacheScopeKey to scope anonymous cache entries', async () => {
+    const cache = createResolvedListCache();
+    const calls: unknown[][] = [];
+    const callTool: ResolveListCallTool = async (...args) => {
+      calls.push(args);
+      return {
+        list: { list_id: 'pl-1', name: 'Allow list' },
+        identifiers: [{ type: 'domain', value: `site-${calls.length}.example` }],
+        cache_valid_until: future,
+      };
+    };
+
+    const ref = { agent_url: 'https://lists.example/mcp', list_id: 'pl-1' };
+    const first = await resolvePropertyList(ref, { cache, now, callTool, cacheScopeKey: 'tenant-a' });
+    const second = await resolvePropertyList(ref, { cache, now, callTool, cacheScopeKey: 'tenant-a' });
+    const third = await resolvePropertyList(ref, { cache, now, callTool, cacheScopeKey: 'tenant-b' });
+
+    expect(calls).toHaveLength(2);
+    expect(second.identifiers).toEqual(first.identifiers);
+    expect(third.identifiers).toEqual([{ type: 'domain', value: 'site-2.example' }]);
+  });
+
+  it('returns cached property lists before default network DNS validation', async () => {
+    const cache = createResolvedListCache();
+    const ref = { agent_url: 'https://lists.example.invalid/mcp', list_id: 'pl-1', auth_token: 'token-a' };
+    await resolvePropertyList(ref, {
+      cache,
+      now,
+      callTool: async () => ({
+        list: { list_id: 'pl-1', name: 'Allow list' },
+        identifiers: [{ type: 'domain', value: 'cached.example' }],
+        cache_valid_until: future,
+      }),
+    });
+
+    const cached = await resolvePropertyList(ref, { cache, now });
+
+    expect(cached.identifiers).toEqual([{ type: 'domain', value: 'cached.example' }]);
+  });
+
+  it('bypasses the process-global cache when a custom callTool is supplied without an explicit cache', async () => {
+    const ref = { agent_url: 'https://lists.example/mcp', list_id: 'pl-1', auth_token: 'token-a' };
+    const first = await resolvePropertyList(ref, {
+      now,
+      callTool: async () => ({
+        list: { list_id: 'pl-1', name: 'Allow list' },
+        identifiers: [{ type: 'domain', value: 'a.example' }],
+        cache_valid_until: future,
+      }),
+    });
+    const second = await resolvePropertyList(ref, {
+      now,
+      callTool: async () => ({
+        list: { list_id: 'pl-1', name: 'Allow list' },
+        identifiers: [{ type: 'domain', value: 'b.example' }],
+        cache_valid_until: future,
+      }),
+    });
+
+    expect(first.identifiers).toEqual([{ type: 'domain', value: 'a.example' }]);
+    expect(second.identifiers).toEqual([{ type: 'domain', value: 'b.example' }]);
+  });
+
+  it('validates property list agent URLs before calling the resolver target', async () => {
+    const calls: unknown[][] = [];
+    const callTool: ResolveListCallTool = async (...args) => {
+      calls.push(args);
+      return { list: { list_id: 'pl-1', name: 'Allow list' }, identifiers: [] };
+    };
+
+    await expect(resolvePropertyList({ agent_url: 'file:///tmp/list', list_id: 'pl-1' }, { callTool })).rejects.toThrow(
+      /list_agent_url_insecure/
+    );
+    await expect(
+      resolvePropertyList({ agent_url: 'https://user:pass@lists.example/mcp?token=secret', list_id: 'pl-1' }, { callTool })
+    ).rejects.toThrow(/list_agent_url_malformed/);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('refreshes expired cache entries', async () => {
+    const cache = createResolvedListCache();
+    const calls: unknown[][] = [];
+    const callTool: ResolveListCallTool = async (...args) => {
+      calls.push(args);
+      return {
+        list: { list_id: 'pl-1', name: 'Allow list' },
+        identifiers: [{ type: 'domain', value: `site-${calls.length}.example` }],
+        cache_valid_until: '2026-06-02T12:01:00.000Z',
+      };
+    };
+
+    const ref = { agent_url: 'https://lists.example/mcp', list_id: 'pl-1', auth_token: 'token-a' };
+    await resolvePropertyList(ref, { cache, now, callTool });
+    const refreshed = await resolvePropertyList(ref, {
+      cache,
+      now: () => new Date('2026-06-02T12:02:00.000Z'),
+      callTool,
+    });
+
+    expect(calls).toHaveLength(2);
+    expect(refreshed.identifiers).toEqual([{ type: 'domain', value: 'site-2.example' }]);
+  });
+
+  it('walks pagination before caching a resolved property list', async () => {
+    const cache = createResolvedListCache();
+    const calls: Array<{ args: Record<string, unknown> }> = [];
+    const callTool: ResolveListCallTool = async (_agentUrl, _toolName, args) => {
+      calls.push({ args });
+      const pagination = args.pagination as { cursor?: string } | undefined;
+      if (!pagination?.cursor) {
+        return {
+          list: { list_id: 'pl-1', name: 'Allow list' },
+          identifiers: [{ type: 'domain', value: 'first.example' }],
+          pagination: { has_more: true, cursor: 'page-2' },
+          cache_valid_until: future,
+        };
+      }
+      return {
+        list: { list_id: 'pl-1', name: 'Allow list' },
+        identifiers: [{ type: 'domain', value: 'second.example' }],
+        pagination: { has_more: false },
+        cache_valid_until: future,
+      };
+    };
+
+    const ref = { agent_url: 'https://lists.example/mcp', list_id: 'pl-1', auth_token: 'token-a' };
+    const resolved = await resolvePropertyList(ref, { cache, now, callTool, pageSize: 1 });
+    const cached = await resolvePropertyList(ref, { cache, now, callTool, pageSize: 1 });
+
+    expect(calls).toHaveLength(2);
+    expect(calls[0]!.args).toEqual({ list_id: 'pl-1', resolve: true, pagination: { max_results: 1 } });
+    expect(calls[1]!.args).toEqual({
+      list_id: 'pl-1',
+      resolve: true,
+      pagination: { max_results: 1, cursor: 'page-2' },
+    });
+    expect(resolved.identifiers).toEqual([
+      { type: 'domain', value: 'first.example' },
+      { type: 'domain', value: 'second.example' },
+    ]);
+    expect(cached.identifiers).toEqual(resolved.identifiers);
+  });
+
+  it('rejects property-list pagination cursors without has_more true', async () => {
+    const callTool: ResolveListCallTool = async () => ({
+      list: { list_id: 'pl-1', name: 'Allow list' },
+      identifiers: [{ type: 'domain', value: 'first.example' }],
+      pagination: { cursor: 'page-2' },
+      cache_valid_until: future,
+    });
+
+    await expect(
+      resolvePropertyList(
+        { agent_url: 'https://lists.example/mcp', list_id: 'pl-1', auth_token: 'token-a' },
+        { cache: createResolvedListCache(), now, callTool }
+      )
+    ).rejects.toThrow(/property_list_invalid_pagination/);
+  });
+});
+
+describe('resolveCollectionList cache', () => {
+  it('validates collection list agent URLs before calling the resolver target', async () => {
+    const calls: unknown[][] = [];
+    const callTool: ResolveListCallTool = async (...args) => {
+      calls.push(args);
+      return { list: { list_id: 'cl-1', name: 'Shows' }, collections: [] };
+    };
+
+    await expect(
+      resolveCollectionList({ agent_url: 'file:///tmp/list', list_id: 'cl-1' }, { callTool })
+    ).rejects.toThrow(/list_agent_url_insecure/);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('caches resolved collections until cache_valid_until', async () => {
+    const cache = createResolvedListCache();
+    const calls: unknown[][] = [];
+    const callTool: ResolveListCallTool = async (...args) => {
+      calls.push(args);
+      return {
+        list: { list_id: 'cl-1', name: 'Shows' },
+        collections: [{ collection_rid: `rid:${calls.length}`, name: 'Trail Life' }],
+        cache_valid_until: '2026-06-02T12:05:00.000Z',
+      };
+    };
+
+    const ref = { agent_url: 'https://lists.example/mcp', list_id: 'cl-1', auth_token: 'token-a' };
+    const first = await resolveCollectionList(ref, {
+      cache,
+      now: () => new Date('2026-06-02T12:00:00.000Z'),
+      callTool,
+    });
+    const second = await resolveCollectionList(ref, {
+      cache,
+      now: () => new Date('2026-06-02T12:00:30.000Z'),
+      callTool,
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(second.collections).toEqual(first.collections);
+  });
+
+  it('returns cached collection lists before default network DNS validation', async () => {
+    const cache = createResolvedListCache();
+    const ref = { agent_url: 'https://lists.example.invalid/mcp', list_id: 'cl-1', auth_token: 'token-a' };
+    await resolveCollectionList(ref, {
+      cache,
+      now: () => new Date('2026-06-02T12:00:00.000Z'),
+      callTool: async () => ({
+        list: { list_id: 'cl-1', name: 'Shows' },
+        collections: [{ collection_rid: 'rid:cached', name: 'Cached Show' }],
+        cache_valid_until: '2026-06-02T12:05:00.000Z',
+      }),
+    });
+
+    const cached = await resolveCollectionList(ref, {
+      cache,
+      now: () => new Date('2026-06-02T12:00:30.000Z'),
+    });
+
+    expect(cached.collections).toEqual([{ collection_rid: 'rid:cached', name: 'Cached Show' }]);
+  });
+
+  it('rejects collection-list pagination cursors without has_more true', async () => {
+    const callTool: ResolveListCallTool = async () => ({
+      list: { list_id: 'cl-1', name: 'Shows' },
+      collections: [{ collection_rid: 'rid:1', name: 'Trail Life' }],
+      pagination: { cursor: 'page-2' },
+      cache_valid_until: '2026-06-02T12:05:00.000Z',
+    });
+
+    await expect(
+      resolveCollectionList(
+        { agent_url: 'https://lists.example/mcp', list_id: 'cl-1', auth_token: 'token-a' },
+        { cache: createResolvedListCache(), now: () => new Date('2026-06-02T12:00:00.000Z'), callTool }
+      )
+    ).rejects.toThrow(/collection_list_invalid_pagination/);
   });
 });

--- a/src/lib/server/targeting-helpers.ts
+++ b/src/lib/server/targeting-helpers.ts
@@ -24,7 +24,12 @@
  * AdCP property and collection specs.
  */
 
+import { createHash } from 'node:crypto';
+import { lookup as dnsLookup } from 'node:dns/promises';
 import { callMCPTool } from '../protocols/mcp';
+import { isAlwaysBlocked, isPrivateIp } from '../net';
+import { isInternalProbesAllowed } from '../utils/probe-policy';
+import { createPinAndBindFetch } from './pin-and-bind-fetch';
 import type {
   PropertyListReference,
   CollectionListReference,
@@ -55,12 +60,99 @@ export interface ResolvedCollectionList {
 }
 
 // ---------------------------------------------------------------------------
+// Resolved list cache
+// ---------------------------------------------------------------------------
+
+export type ResolvedListKind = 'property' | 'collection';
+export type ResolvedListCacheValue = ResolvedPropertyList | ResolvedCollectionList;
+export const DEFAULT_RESOLVE_LIST_PAGE_SIZE = 1000;
+
+export interface ResolvedListCacheEntry<TValue extends ResolvedListCacheValue = ResolvedListCacheValue> {
+  value: TValue;
+  expiresAtMs: number;
+}
+
+export interface ResolvedListCache {
+  get<TValue extends ResolvedListCacheValue>(key: string, nowMs?: number): TValue | undefined;
+  set<TValue extends ResolvedListCacheValue>(key: string, entry: ResolvedListCacheEntry<TValue>): void;
+  delete(key: string): boolean;
+  clear(): void;
+}
+
+class MemoryResolvedListCache implements ResolvedListCache {
+  private readonly entries = new Map<string, ResolvedListCacheEntry>();
+
+  get<TValue extends ResolvedListCacheValue>(key: string, nowMs = Date.now()): TValue | undefined {
+    const entry = this.entries.get(key);
+    if (!entry) return undefined;
+    if (entry.expiresAtMs <= nowMs) {
+      this.entries.delete(key);
+      return undefined;
+    }
+    return cloneResolvedList(entry.value) as TValue;
+  }
+
+  set<TValue extends ResolvedListCacheValue>(key: string, entry: ResolvedListCacheEntry<TValue>): void {
+    this.entries.set(key, {
+      expiresAtMs: entry.expiresAtMs,
+      value: cloneResolvedList(entry.value),
+    });
+  }
+
+  delete(key: string): boolean {
+    return this.entries.delete(key);
+  }
+
+  clear(): void {
+    this.entries.clear();
+  }
+}
+
+export function createResolvedListCache(): ResolvedListCache {
+  return new MemoryResolvedListCache();
+}
+
+export const defaultResolvedListCache = createResolvedListCache();
+
+export function clearDefaultResolvedListCache(): void {
+  defaultResolvedListCache.clear();
+}
+
+// ---------------------------------------------------------------------------
 // resolvePropertyList / resolveCollectionList
 // ---------------------------------------------------------------------------
+
+export type ResolveListCallTool = (
+  agentUrl: string,
+  toolName: 'get_property_list' | 'get_collection_list',
+  args: Record<string, unknown>,
+  authToken?: string
+) => Promise<unknown>;
+
+const defaultResolveListFetchBase = createPinAndBindFetch();
+const defaultResolveListFetch: typeof fetch = (input, init) =>
+  defaultResolveListFetchBase(input, { ...init, redirect: 'manual' });
+
+const defaultResolveListCallTool: ResolveListCallTool = (agentUrl, toolName, args, authToken) =>
+  callMCPTool(agentUrl, toolName, args, authToken, [], undefined, undefined, defaultResolveListFetch);
 
 export interface ResolveListOptions {
   /** Maximum page size when calling get_property_list / get_collection_list. Defaults to 1000. */
   pageSize?: number;
+  /** Maximum number of pages to walk before treating pagination as unsafe. Defaults to 100. */
+  maxPages?: number;
+  /** Cache for resolved list contents. Defaults to the process-local SDK cache. Pass false to disable caching. */
+  cache?: ResolvedListCache | false;
+  /**
+   * Tenant/principal/auth-context fingerprint for cache scoping when the list
+   * reference does not carry an auth_token. Shared caching is disabled without
+   * either auth_token or this explicit scope.
+   */
+  cacheScopeKey?: string;
+  /** Clock hook for testing cache expiry. */
+  now?: () => Date | number;
+  /** MCP call hook for testing/custom transports. */
+  callTool?: ResolveListCallTool;
 }
 
 /**
@@ -73,28 +165,68 @@ export async function resolvePropertyList(
   ref: PropertyListReference,
   options: ResolveListOptions = {}
 ): Promise<ResolvedPropertyList> {
-  const args: Record<string, unknown> = {
-    list_id: ref.list_id,
-    resolve: true,
-  };
-  if (options.pageSize != null) args.page_size = options.pageSize;
+  const structurallyNormalizedRef = await normalizePropertyListReference(ref, { resolveDns: false });
+  const cache = cacheForOptions(options);
+  const nowMs = nowMsForOptions(options);
+  const cacheKey = resolvedListCacheKey('property', structurallyNormalizedRef, options);
+  const cached = cacheKey ? cache?.get<ResolvedPropertyList>(cacheKey, nowMs) : undefined;
+  if (cached) return cached;
 
-  const raw = (await callMCPTool(ref.agent_url, 'get_property_list', args, ref.auth_token)) as Record<string, unknown>;
+  const normalizedRef = options.callTool
+    ? structurallyNormalizedRef
+    : await normalizePropertyListReference(structurallyNormalizedRef, { resolveDns: false });
+  const result = await fetchResolvedPropertyList(normalizedRef, options);
+  cacheResolvedList(cache, cacheKey, result, nowMs);
+  return result;
+}
 
-  if (!raw || typeof raw !== 'object' || !('list' in raw)) {
-    throw new Error(
-      `Invalid get_property_list response from ${ref.agent_url}: missing 'list'. ` +
-        `Got: ${JSON.stringify(raw)?.slice(0, 200)}`
-    );
+async function fetchResolvedPropertyList(
+  ref: PropertyListReference,
+  options: ResolveListOptions
+): Promise<ResolvedPropertyList> {
+  const callTool = options.callTool ?? defaultResolveListCallTool;
+  const identifiers: Identifier[] = [];
+  let listId = ref.list_id;
+  let cacheValidUntil: string | undefined;
+  let missingCacheValidUntil = false;
+  let cursor: string | undefined;
+
+  for (let pageIndex = 0; pageIndex < maxPagesForOptions(options); pageIndex += 1) {
+    const args = buildResolveListArgs(ref.list_id, pageSizeForOptions(options), cursor);
+
+    const raw = (await callTool(ref.agent_url, 'get_property_list', args, ref.auth_token)) as Record<string, unknown>;
+
+    if (!raw || typeof raw !== 'object' || !('list' in raw)) {
+      throw new Error('property_list_invalid_response');
+    }
+    const response = raw as unknown as GetPropertyListResponse;
+    listId = response.list.list_id;
+    identifiers.push(...(response.identifiers ?? []));
+    if (typeof response.cache_valid_until === 'string') {
+      cacheValidUntil = earliestIsoTimestamp(cacheValidUntil, response.cache_valid_until);
+    } else {
+      missingCacheValidUntil = true;
+    }
+
+    const pagination = readPagination(response.pagination);
+    if (pagination.invalid) {
+      throw new Error('property_list_invalid_pagination');
+    }
+    if (!pagination.hasMore) {
+      return {
+        listId,
+        agentUrl: ref.agent_url,
+        identifiers,
+        cacheValidUntil: missingCacheValidUntil ? undefined : cacheValidUntil,
+      };
+    }
+    if (!pagination.cursor) {
+      throw new Error('property_list_invalid_pagination');
+    }
+    cursor = pagination.cursor;
   }
-  const response = raw as unknown as GetPropertyListResponse;
 
-  return {
-    listId: response.list.list_id,
-    agentUrl: ref.agent_url,
-    identifiers: response.identifiers ?? [],
-    cacheValidUntil: response.cache_valid_until ?? undefined,
-  };
+  throw new Error('property_list_pagination_limit_exceeded');
 }
 
 /**
@@ -107,31 +239,229 @@ export async function resolveCollectionList(
   ref: CollectionListReference,
   options: ResolveListOptions = {}
 ): Promise<ResolvedCollectionList> {
-  const args: Record<string, unknown> = {
+  const structurallyNormalizedRef = await normalizeCollectionListReference(ref, { resolveDns: false });
+  const cache = cacheForOptions(options);
+  const nowMs = nowMsForOptions(options);
+  const cacheKey = resolvedListCacheKey('collection', structurallyNormalizedRef, options);
+  const cached = cacheKey ? cache?.get<ResolvedCollectionList>(cacheKey, nowMs) : undefined;
+  if (cached) return cached;
+
+  const normalizedRef = options.callTool
+    ? structurallyNormalizedRef
+    : await normalizeCollectionListReference(structurallyNormalizedRef, { resolveDns: false });
+  const result = await fetchResolvedCollectionList(normalizedRef, options);
+  cacheResolvedList(cache, cacheKey, result, nowMs);
+  return result;
+}
+
+async function fetchResolvedCollectionList(
+  ref: CollectionListReference,
+  options: ResolveListOptions
+): Promise<ResolvedCollectionList> {
+  const callTool = options.callTool ?? defaultResolveListCallTool;
+  const collections: ResolvedCollection[] = [];
+  let listId = ref.list_id;
+  let cacheValidUntil: string | undefined;
+  let missingCacheValidUntil = false;
+  let cursor: string | undefined;
+
+  for (let pageIndex = 0; pageIndex < maxPagesForOptions(options); pageIndex += 1) {
+    const args = buildResolveListArgs(ref.list_id, pageSizeForOptions(options), cursor);
+
+    const raw = (await callTool(ref.agent_url, 'get_collection_list', args, ref.auth_token)) as Record<string, unknown>;
+
+    if (!raw || typeof raw !== 'object' || !('list' in raw)) {
+      throw new Error('collection_list_invalid_response');
+    }
+    const response = raw as unknown as GetCollectionListResponse;
+    listId = response.list.list_id;
+    collections.push(...(response.collections ?? []));
+    if (typeof response.cache_valid_until === 'string') {
+      cacheValidUntil = earliestIsoTimestamp(cacheValidUntil, response.cache_valid_until);
+    } else {
+      missingCacheValidUntil = true;
+    }
+
+    const pagination = readPagination(response.pagination);
+    if (pagination.invalid) {
+      throw new Error('collection_list_invalid_pagination');
+    }
+    if (!pagination.hasMore) {
+      return {
+        listId,
+        agentUrl: ref.agent_url,
+        collections,
+        cacheValidUntil: missingCacheValidUntil ? undefined : cacheValidUntil,
+      };
+    }
+    if (!pagination.cursor) {
+      throw new Error('collection_list_invalid_pagination');
+    }
+    cursor = pagination.cursor;
+  }
+
+  throw new Error('collection_list_pagination_limit_exceeded');
+}
+
+export function resolvedListCacheKey(
+  kind: ResolvedListKind,
+  ref: Pick<PropertyListReference | CollectionListReference, 'agent_url' | 'list_id' | 'auth_token'>,
+  options: Pick<ResolveListOptions, 'pageSize' | 'cacheScopeKey'> = {}
+): string | undefined {
+  const scope = ref.auth_token ?? options.cacheScopeKey;
+  if (!scope) return undefined;
+  const material = JSON.stringify({
+    kind,
+    agent_url: ref.agent_url,
     list_id: ref.list_id,
+    scope_sha256: sha256(scope),
+    page_size: options.pageSize ?? DEFAULT_RESOLVE_LIST_PAGE_SIZE,
+    resolve: true,
+  });
+  return `adcp-resolved-list:${sha256(material)}`;
+}
+
+async function normalizePropertyListReference(
+  ref: PropertyListReference,
+  options: { resolveDns: boolean }
+): Promise<PropertyListReference> {
+  return {
+    ...ref,
+    agent_url: await normalizeListAgentUrl(ref.agent_url, options),
+  };
+}
+
+async function normalizeCollectionListReference(
+  ref: CollectionListReference,
+  options: { resolveDns: boolean }
+): Promise<CollectionListReference> {
+  return {
+    ...ref,
+    agent_url: await normalizeListAgentUrl(ref.agent_url, options),
+  };
+}
+
+async function normalizeListAgentUrl(raw: string, options: { resolveDns: boolean }): Promise<string> {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new Error('list_agent_url_invalid');
+  }
+
+  if (url.username || url.password || url.search || url.hash) {
+    throw new Error('list_agent_url_malformed');
+  }
+
+  const allowInternal = isInternalProbesAllowed();
+  if (url.protocol !== 'https:' && !(allowInternal && url.protocol === 'http:')) {
+    throw new Error('list_agent_url_insecure');
+  }
+
+  const hostname = url.hostname.replace(/^\[|\]$/g, '');
+  if (isAlwaysBlocked(hostname)) {
+    throw new Error('list_agent_url_always_blocked');
+  }
+  if (!allowInternal && isPrivateIp(hostname)) {
+    throw new Error('list_agent_url_private_address');
+  }
+
+  if (options.resolveDns) {
+    let addresses: { address: string }[];
+    try {
+      addresses = await dnsLookup(hostname, { all: true });
+    } catch {
+      throw new Error('list_agent_url_dns_failed');
+    }
+    if (addresses.length === 0) {
+      throw new Error('list_agent_url_dns_empty');
+    }
+    for (const { address } of addresses) {
+      if (isAlwaysBlocked(address)) {
+        throw new Error('list_agent_url_always_blocked');
+      }
+      if (!allowInternal && isPrivateIp(address)) {
+        throw new Error('list_agent_url_private_address');
+      }
+    }
+  }
+
+  return url.toString();
+}
+
+function buildResolveListArgs(listId: string, pageSize: number, cursor: string | undefined) {
+  const args: Record<string, unknown> = {
+    list_id: listId,
     resolve: true,
   };
-  if (options.pageSize != null) args.page_size = options.pageSize;
+  const pagination: Record<string, unknown> = {};
+  pagination.max_results = pageSize;
+  if (cursor) pagination.cursor = cursor;
+  if (Object.keys(pagination).length > 0) args.pagination = pagination;
+  return args;
+}
 
-  const raw = (await callMCPTool(ref.agent_url, 'get_collection_list', args, ref.auth_token)) as Record<
-    string,
-    unknown
-  >;
+function cacheForOptions(options: ResolveListOptions): ResolvedListCache | undefined {
+  if (options.callTool && options.cache === undefined) return undefined;
+  return options.cache === false ? undefined : (options.cache ?? defaultResolvedListCache);
+}
 
-  if (!raw || typeof raw !== 'object' || !('list' in raw)) {
-    throw new Error(
-      `Invalid get_collection_list response from ${ref.agent_url}: missing 'list'. ` +
-        `Got: ${JSON.stringify(raw)?.slice(0, 200)}`
-    );
-  }
-  const response = raw as unknown as GetCollectionListResponse;
+function cacheResolvedList(
+  cache: ResolvedListCache | undefined,
+  cacheKey: string | undefined,
+  value: ResolvedListCacheValue,
+  nowMs: number
+): void {
+  if (!cache || !cacheKey || !value.cacheValidUntil) return;
+  const expiresAtMs = Date.parse(value.cacheValidUntil);
+  if (!Number.isFinite(expiresAtMs) || expiresAtMs <= nowMs) return;
+  cache.set(cacheKey, { value, expiresAtMs });
+}
 
+function nowMsForOptions(options: ResolveListOptions): number {
+  const now = options.now?.();
+  if (now instanceof Date) return now.getTime();
+  if (typeof now === 'number') return now;
+  return Date.now();
+}
+
+function maxPagesForOptions(options: ResolveListOptions): number {
+  return options.maxPages ?? 100;
+}
+
+function pageSizeForOptions(options: Pick<ResolveListOptions, 'pageSize'>): number {
+  return options.pageSize ?? DEFAULT_RESOLVE_LIST_PAGE_SIZE;
+}
+
+function readPagination(value: unknown): { hasMore: boolean; cursor?: string; invalid: boolean } {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return { hasMore: false, invalid: false };
+  const pagination = value as { has_more?: unknown; cursor?: unknown };
+  const cursor = typeof pagination.cursor === 'string' && pagination.cursor.length > 0 ? pagination.cursor : undefined;
+  const invalid =
+    (pagination.has_more !== undefined && typeof pagination.has_more !== 'boolean') ||
+    (cursor !== undefined && pagination.has_more !== true);
   return {
-    listId: response.list.list_id,
-    agentUrl: ref.agent_url,
-    collections: response.collections ?? [],
-    cacheValidUntil: response.cache_valid_until ?? undefined,
+    hasMore: pagination.has_more === true,
+    cursor,
+    invalid,
   };
+}
+
+function earliestIsoTimestamp(current: string | undefined, next: string): string {
+  if (!current) return next;
+  const currentMs = Date.parse(current);
+  const nextMs = Date.parse(next);
+  if (!Number.isFinite(currentMs)) return next;
+  if (!Number.isFinite(nextMs)) return current;
+  return nextMs < currentMs ? next : current;
+}
+
+function cloneResolvedList<TValue extends ResolvedListCacheValue>(value: TValue): TValue {
+  return structuredClone(value);
+}
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value, 'utf8').digest('hex');
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/server/targeting-helpers.ts
+++ b/src/lib/server/targeting-helpers.ts
@@ -186,7 +186,7 @@ async function fetchResolvedPropertyList(
 ): Promise<ResolvedPropertyList> {
   const callTool = options.callTool ?? defaultResolveListCallTool;
   const identifiers: Identifier[] = [];
-  let listId = ref.list_id;
+  let listId: string;
   let cacheValidUntil: string | undefined;
   let missingCacheValidUntil = false;
   let cursor: string | undefined;
@@ -260,7 +260,7 @@ async function fetchResolvedCollectionList(
 ): Promise<ResolvedCollectionList> {
   const callTool = options.callTool ?? defaultResolveListCallTool;
   const collections: ResolvedCollection[] = [];
-  let listId = ref.list_id;
+  let listId: string;
   let cacheValidUntil: string | undefined;
   let missingCacheValidUntil = false;
   let cursor: string | undefined;

--- a/test/lib/product-property-policy-client.test.js
+++ b/test/lib/product-property-policy-client.test.js
@@ -94,10 +94,7 @@ describe('client product property policy enforcement', () => {
       ['safe']
     );
     assert.strictEqual(result.metadata.productPropertyPolicy.rejected_count, 1);
-    assert.strictEqual(
-      result.metadata.productPropertyPolicy.diagnostics[0].matched_excluded_domain,
-      'ladbible.com'
-    );
+    assert.strictEqual(result.metadata.productPropertyPolicy.diagnostics[0].matched_excluded_domain, 'ladbible.com');
     assert.strictEqual(result.data.filter_diagnostics, undefined);
     assert.ok(result.debug_logs.some(entry => entry.type === 'product_property_policy'));
   });
@@ -123,7 +120,10 @@ describe('client product property policy enforcement', () => {
     assert.strictEqual(result.success, false);
     assert.strictEqual(result.status, 'failed');
     assert.strictEqual(result.error, 'Property list not adhered to');
-    assert.deepStrictEqual(result.data.products.map(p => p.product_id), ['safe', 'blocked']);
+    assert.deepStrictEqual(
+      result.data.products.map(p => p.product_id),
+      ['safe', 'blocked']
+    );
     assert.strictEqual(result.metadata.productPropertyPolicy.rejected_count, 1);
     assert.deepStrictEqual(handlerCalls, []);
   });
@@ -191,7 +191,10 @@ describe('client product property policy enforcement', () => {
     assert.strictEqual(result.success, false);
     assert.strictEqual(result.status, 'failed');
     assert.strictEqual(result.error, 'Property list not adhered to');
-    assert.deepStrictEqual(result.data.products.map(p => p.product_id), ['safe', 'blocked']);
+    assert.deepStrictEqual(
+      result.data.products.map(p => p.product_id),
+      ['safe', 'blocked']
+    );
     assert.strictEqual(result.metadata.productPropertyPolicy.request_property_list.list_id, 'cope_allowed_properties');
     assert.strictEqual(result.metadata.productPropertyPolicy.request_property_list.identifier_count, 1);
     assert.strictEqual(result.metadata.productPropertyPolicy.diagnostics[0].code, 'outside_property_list');
@@ -243,7 +246,10 @@ describe('client product property policy enforcement', () => {
 
     assert.strictEqual(result.success, false);
     assert.strictEqual(result.status, 'failed');
-    assert.deepStrictEqual(result.data.products.map(p => p.product_id), ['app_product']);
+    assert.deepStrictEqual(
+      result.data.products.map(p => p.product_id),
+      ['app_product']
+    );
     assert.strictEqual(
       result.metadata.productPropertyPolicy.request_property_list.resolution_error,
       'property_list_unsupported_identifier_types'
@@ -324,7 +330,10 @@ describe('client product property policy enforcement', () => {
       handlerCalls[0].metadata.rawHTTPPayload.result.products.map(p => p.product_id),
       ['safe', 'blocked']
     );
-    assert.strictEqual(handlerCalls[0].metadata.productPropertyPolicy.request_property_list.list_id, 'cope_allowed_properties');
+    assert.strictEqual(
+      handlerCalls[0].metadata.productPropertyPolicy.request_property_list.list_id,
+      'cope_allowed_properties'
+    );
     assert.deepStrictEqual(listCalls, [
       {
         agentUrl: 'https://lists.example/mcp',
@@ -515,7 +524,10 @@ describe('client product property policy enforcement', () => {
       handlerCalls[0].response.products.map(p => p.product_id),
       ['safe']
     );
-    assert.strictEqual(handlerCalls[0].metadata.productPropertyPolicy.request_property_list.list_id, 'cope_allowed_properties');
+    assert.strictEqual(
+      handlerCalls[0].metadata.productPropertyPolicy.request_property_list.list_id,
+      'cope_allowed_properties'
+    );
 
     releaseInitialResponse();
     const submitted = await submittedPromise;
@@ -555,7 +567,10 @@ describe('client product property policy enforcement', () => {
       result.metadata.productPropertyPolicy.request_property_list.resolution_error,
       'list_agent_url_malformed'
     );
-    assert.strictEqual(result.metadata.productPropertyPolicy.request_property_list.agent_url, 'https://lists.example/mcp');
+    assert.strictEqual(
+      result.metadata.productPropertyPolicy.request_property_list.agent_url,
+      'https://lists.example/mcp'
+    );
     const policyLog = result.debug_logs.find(entry => entry.type === 'product_property_policy');
     assert.strictEqual(policyLog.request_property_list.resolution_error, 'list_agent_url_malformed');
   });

--- a/test/lib/product-property-policy-client.test.js
+++ b/test/lib/product-property-policy-client.test.js
@@ -1,0 +1,562 @@
+const { describe, test, mock, afterEach } = require('node:test');
+const assert = require('node:assert');
+
+const { AdCPClient } = require('../../dist/lib/index.js');
+const { ProtocolClient } = require('../../dist/lib/protocols');
+
+const originalCallTool = ProtocolClient.callTool;
+
+afterEach(() => {
+  ProtocolClient.callTool = originalCallTool;
+});
+
+function makeProduct(product_id, publisher_domain, overrides = {}) {
+  return {
+    product_id,
+    name: product_id,
+    publisher_properties: [{ selection_type: 'all', publisher_domain }],
+    ...overrides,
+  };
+}
+
+function makeClient(config = {}) {
+  const agent = {
+    id: 'seller',
+    name: 'Seller',
+    agent_uri: 'https://seller.example/mcp',
+    protocol: 'mcp',
+  };
+  const client = new AdCPClient([agent], {
+    validateFeatures: false,
+    validation: {
+      responses: 'off',
+      ...config.validation,
+    },
+    ...(config.handlers ? { handlers: config.handlers } : {}),
+    ...(config.onActivity ? { onActivity: config.onActivity } : {}),
+  });
+  const agentClient = client.agent('seller');
+  const inner = agentClient.client;
+  inner.discoveredEndpoint = agent.agent_uri;
+  inner.cachedCapabilities = {
+    version: 'v3',
+    majorVersions: [3],
+    protocols: ['media_buy'],
+    features: {
+      inlineCreativeManagement: false,
+      conversionTracking: false,
+      audienceTargeting: false,
+      propertyListFiltering: false,
+      contentStandards: false,
+    },
+    extensions: [],
+    _synthetic: false,
+  };
+  return agentClient;
+}
+
+function stubGetProducts(products) {
+  ProtocolClient.callTool = mock.fn(async (_agent, taskName) => {
+    assert.strictEqual(taskName, 'get_products');
+    return {
+      status: 'completed',
+      products,
+      cache_scope: 'public',
+    };
+  });
+}
+
+describe('client product property policy enforcement', () => {
+  test('filters excluded domains before caller and handler receive get_products', async () => {
+    const handlerCalls = [];
+    stubGetProducts([makeProduct('safe', 'example.com'), makeProduct('blocked', 'www.ladbible.com')]);
+
+    const agent = makeClient({
+      validation: {
+        productPropertyPolicy: {
+          excludedDomains: ['ladbible.com'],
+        },
+      },
+      handlers: {
+        onGetProductsStatusChange: response => handlerCalls.push(response),
+      },
+    });
+
+    const result = await agent.getProducts({ brief: 'sports' }, undefined, { project: false });
+
+    assert.strictEqual(result.success, true);
+    assert.deepStrictEqual(
+      result.data.products.map(p => p.product_id),
+      ['safe']
+    );
+    assert.deepStrictEqual(
+      handlerCalls[0].products.map(p => p.product_id),
+      ['safe']
+    );
+    assert.strictEqual(result.metadata.productPropertyPolicy.rejected_count, 1);
+    assert.strictEqual(
+      result.metadata.productPropertyPolicy.diagnostics[0].matched_excluded_domain,
+      'ladbible.com'
+    );
+    assert.strictEqual(result.data.filter_diagnostics, undefined);
+    assert.ok(result.debug_logs.some(entry => entry.type === 'product_property_policy'));
+  });
+
+  test('reject_response mode fails get_products and suppresses completion handler', async () => {
+    const handlerCalls = [];
+    stubGetProducts([makeProduct('safe', 'example.com'), makeProduct('blocked', 'www.ladbible.com')]);
+
+    const agent = makeClient({
+      validation: {
+        productPropertyPolicy: {
+          excludedDomains: ['ladbible.com'],
+          mode: 'reject_response',
+        },
+      },
+      handlers: {
+        onGetProductsStatusChange: response => handlerCalls.push(response),
+      },
+    });
+
+    const result = await agent.getProducts({ brief: 'sports' }, undefined, { project: false });
+
+    assert.strictEqual(result.success, false);
+    assert.strictEqual(result.status, 'failed');
+    assert.strictEqual(result.error, 'Property list not adhered to');
+    assert.deepStrictEqual(result.data.products.map(p => p.product_id), ['safe', 'blocked']);
+    assert.strictEqual(result.metadata.productPropertyPolicy.rejected_count, 1);
+    assert.deepStrictEqual(handlerCalls, []);
+  });
+
+  test('filters generic executeTask get_products results before caller receives them', async () => {
+    stubGetProducts([makeProduct('safe', 'example.com'), makeProduct('blocked', 'www.ladbible.com')]);
+
+    const agent = makeClient({
+      validation: {
+        productPropertyPolicy: {
+          excludedDomains: ['ladbible.com'],
+        },
+      },
+    });
+
+    const result = await agent.executeTask('get_products', { brief: 'sports' }, undefined, { project: false });
+
+    assert.strictEqual(result.success, true);
+    assert.deepStrictEqual(
+      result.data.products.map(p => p.product_id),
+      ['safe']
+    );
+    assert.strictEqual(result.metadata.productPropertyPolicy.rejected_count, 1);
+  });
+
+  test('uses get_products property_list ref to reject products outside the resolved list', async () => {
+    const handlerCalls = [];
+    const listCalls = [];
+    stubGetProducts([makeProduct('safe', 'www.example.com'), makeProduct('blocked', 'www.ladbible.com')]);
+
+    const agent = makeClient({
+      validation: {
+        productPropertyPolicy: {
+          mode: 'reject_response',
+          propertyListResolveOptions: {
+            callTool: async (agentUrl, toolName, args, authToken) => {
+              listCalls.push({ agentUrl, toolName, args, authToken });
+              return {
+                list: { list_id: 'cope_allowed_properties', name: 'Cope allowed properties' },
+                identifiers: [{ type: 'domain', value: 'example.com' }],
+                cache_valid_until: '2026-06-02T12:05:00.000Z',
+              };
+            },
+          },
+        },
+      },
+      handlers: {
+        onGetProductsStatusChange: response => handlerCalls.push(response),
+      },
+    });
+
+    const result = await agent.getProducts(
+      {
+        brief: 'sports',
+        property_list: {
+          agent_url: 'https://lists.example/mcp',
+          list_id: 'cope_allowed_properties',
+          auth_token: 'list-token',
+        },
+      },
+      undefined,
+      { project: false }
+    );
+
+    assert.strictEqual(result.success, false);
+    assert.strictEqual(result.status, 'failed');
+    assert.strictEqual(result.error, 'Property list not adhered to');
+    assert.deepStrictEqual(result.data.products.map(p => p.product_id), ['safe', 'blocked']);
+    assert.strictEqual(result.metadata.productPropertyPolicy.request_property_list.list_id, 'cope_allowed_properties');
+    assert.strictEqual(result.metadata.productPropertyPolicy.request_property_list.identifier_count, 1);
+    assert.strictEqual(result.metadata.productPropertyPolicy.diagnostics[0].code, 'outside_property_list');
+    assert.strictEqual(result.metadata.productPropertyPolicy.diagnostics[0].normalized_domain, 'www.ladbible.com');
+    assert.deepStrictEqual(handlerCalls, []);
+    assert.deepStrictEqual(listCalls, [
+      {
+        agentUrl: 'https://lists.example/mcp',
+        toolName: 'get_property_list',
+        args: {
+          list_id: 'cope_allowed_properties',
+          resolve: true,
+          pagination: { max_results: 1000 },
+        },
+        authToken: 'list-token',
+      },
+    ]);
+  });
+
+  test('fails closed when request property_list uses unsupported non-domain identifiers', async () => {
+    stubGetProducts([makeProduct('app_product', 'www.example.com')]);
+
+    const agent = makeClient({
+      validation: {
+        productPropertyPolicy: {
+          mode: 'reject_response',
+          propertyListResolveOptions: {
+            callTool: async () => ({
+              list: { list_id: 'app_allowlist', name: 'App allowlist' },
+              identifiers: [{ type: 'ios_bundle', value: 'com.example.app' }],
+              cache_valid_until: '2026-06-02T12:05:00.000Z',
+            }),
+          },
+        },
+      },
+    });
+
+    const result = await agent.getProducts(
+      {
+        brief: 'apps',
+        property_list: {
+          agent_url: 'https://lists.example/mcp',
+          list_id: 'app_allowlist',
+        },
+      },
+      undefined,
+      { project: false }
+    );
+
+    assert.strictEqual(result.success, false);
+    assert.strictEqual(result.status, 'failed');
+    assert.deepStrictEqual(result.data.products.map(p => p.product_id), ['app_product']);
+    assert.strictEqual(
+      result.metadata.productPropertyPolicy.request_property_list.resolution_error,
+      'property_list_unsupported_identifier_types'
+    );
+  });
+
+  test('filters completed get_products webhooks using the original request property_list', async () => {
+    const handlerCalls = [];
+    const listCalls = [];
+
+    ProtocolClient.callTool = mock.fn(async (_agent, taskName) => {
+      assert.strictEqual(taskName, 'get_products');
+      return {
+        status: 'submitted',
+        task_id: 'seller-task-1',
+      };
+    });
+
+    const agent = makeClient({
+      validation: {
+        productPropertyPolicy: {
+          propertyListResolveOptions: {
+            callTool: async (agentUrl, toolName, args, authToken) => {
+              listCalls.push({ agentUrl, toolName, args, authToken });
+              return {
+                list: { list_id: 'cope_allowed_properties', name: 'Cope allowed properties' },
+                identifiers: [{ type: 'domain', value: 'example.com' }],
+                cache_valid_until: '2026-06-02T12:05:00.000Z',
+              };
+            },
+          },
+        },
+      },
+      handlers: {
+        onGetProductsStatusChange: (response, metadata) => handlerCalls.push({ response, metadata }),
+      },
+    });
+
+    const submitted = await agent.getProducts(
+      {
+        brief: 'sports',
+        property_list: {
+          agent_url: 'https://lists.example/mcp',
+          list_id: 'cope_allowed_properties',
+          auth_token: 'list-token',
+        },
+      },
+      undefined,
+      { project: false }
+    );
+
+    assert.strictEqual(submitted.status, 'submitted');
+    const handled = await agent.handleWebhook(
+      {
+        idempotency_key: 'webhook-event-1',
+        operation_id: submitted.metadata.taskId,
+        task_id: 'seller-task-1',
+        task_type: 'get_products',
+        status: 'completed',
+        timestamp: '2026-06-02T12:00:00.000Z',
+        result: {
+          products: [makeProduct('safe', 'www.example.com'), makeProduct('blocked', 'www.ladbible.com')],
+          cache_scope: 'public',
+        },
+      },
+      'get_products',
+      submitted.metadata.taskId
+    );
+
+    assert.strictEqual(handled, true);
+    assert.strictEqual(handlerCalls.length, 1);
+    assert.deepStrictEqual(
+      handlerCalls[0].response.products.map(p => p.product_id),
+      ['safe']
+    );
+    assert.strictEqual(handlerCalls[0].metadata.productPropertyPolicy.rejected_count, 1);
+    assert.deepStrictEqual(
+      handlerCalls[0].metadata.rawHTTPPayload.result.products.map(p => p.product_id),
+      ['safe', 'blocked']
+    );
+    assert.strictEqual(handlerCalls[0].metadata.productPropertyPolicy.request_property_list.list_id, 'cope_allowed_properties');
+    assert.deepStrictEqual(listCalls, [
+      {
+        agentUrl: 'https://lists.example/mcp',
+        toolName: 'get_property_list',
+        args: {
+          list_id: 'cope_allowed_properties',
+          resolve: true,
+          pagination: { max_results: 1000 },
+        },
+        authToken: 'list-token',
+      },
+    ]);
+  });
+
+  test('filters submitted get_products polling continuations before caller receives products', async () => {
+    let pollCalls = 0;
+
+    ProtocolClient.callTool = mock.fn(async (_agent, taskName) => {
+      if (taskName === 'tasks_get' || taskName === 'tasks/get') {
+        pollCalls += 1;
+        return {
+          task_id: 'seller-task-1',
+          task_type: 'get_products',
+          protocol: 'media-buy',
+          status: 'completed',
+          created_at: '2026-06-02T12:00:00.000Z',
+          updated_at: '2026-06-02T12:00:01.000Z',
+          result: {
+            products: [makeProduct('safe', 'www.example.com'), makeProduct('blocked', 'www.ladbible.com')],
+            cache_scope: 'public',
+          },
+        };
+      }
+      assert.strictEqual(taskName, 'get_products');
+      return {
+        status: 'submitted',
+        task_id: 'seller-task-1',
+      };
+    });
+
+    const agent = makeClient({
+      validation: {
+        productPropertyPolicy: {
+          excludedDomains: ['ladbible.com'],
+        },
+      },
+    });
+
+    const submitted = await agent.getProducts({ brief: 'sports' }, undefined, { project: false });
+    assert.strictEqual(submitted.status, 'submitted');
+
+    const tracked = await submitted.submitted.track();
+    assert.strictEqual(tracked.status, 'completed');
+    assert.deepStrictEqual(
+      tracked.result.products.map(p => p.product_id),
+      ['safe']
+    );
+
+    const completed = await submitted.submitted.waitForCompletion(1);
+    assert.strictEqual(completed.success, true);
+    assert.deepStrictEqual(
+      completed.data.products.map(p => p.product_id),
+      ['safe']
+    );
+    assert.strictEqual(completed.metadata.productPropertyPolicy.rejected_count, 1);
+    assert.strictEqual(pollCalls, 2);
+  });
+
+  test('rejects submitted get_products polling completions in reject_response mode', async () => {
+    ProtocolClient.callTool = mock.fn(async (_agent, taskName) => {
+      if (taskName === 'tasks_get' || taskName === 'tasks/get') {
+        return {
+          task_id: 'seller-task-1',
+          task_type: 'get_products',
+          protocol: 'media-buy',
+          status: 'completed',
+          created_at: '2026-06-02T12:00:00.000Z',
+          updated_at: '2026-06-02T12:00:01.000Z',
+          result: {
+            products: [makeProduct('safe', 'www.example.com'), makeProduct('blocked', 'www.ladbible.com')],
+            cache_scope: 'public',
+          },
+        };
+      }
+      assert.strictEqual(taskName, 'get_products');
+      return {
+        status: 'submitted',
+        task_id: 'seller-task-1',
+      };
+    });
+
+    const agent = makeClient({
+      validation: {
+        productPropertyPolicy: {
+          excludedDomains: ['ladbible.com'],
+          mode: 'reject_response',
+        },
+      },
+    });
+
+    const submitted = await agent.getProducts({ brief: 'sports' }, undefined, { project: false });
+    const tracked = await submitted.submitted.track();
+    assert.strictEqual(tracked.status, 'failed');
+    assert.deepStrictEqual(
+      tracked.result.products.map(p => p.product_id),
+      ['safe', 'blocked']
+    );
+
+    const completed = await submitted.submitted.waitForCompletion(1);
+    assert.strictEqual(completed.success, false);
+    assert.strictEqual(completed.status, 'failed');
+    assert.strictEqual(completed.error, 'Property list not adhered to');
+    assert.deepStrictEqual(
+      completed.data.products.map(p => p.product_id),
+      ['safe', 'blocked']
+    );
+  });
+
+  test('filters fast get_products webhooks using executor request params before initial response returns', async () => {
+    const handlerCalls = [];
+    let capturedOperationId;
+    let releaseInitialResponse;
+    const callToolStarted = new Promise(resolve => {
+      ProtocolClient.callTool = mock.fn(async (_agent, taskName) => {
+        assert.strictEqual(taskName, 'get_products');
+        resolve();
+        return new Promise(resolveInitial => {
+          releaseInitialResponse = () => resolveInitial({ status: 'submitted', task_id: 'seller-task-1' });
+        });
+      });
+    });
+
+    const agent = makeClient({
+      onActivity: activity => {
+        if (activity.type === 'protocol_request' && activity.task_type === 'get_products') {
+          capturedOperationId = activity.operation_id;
+        }
+      },
+      validation: {
+        productPropertyPolicy: {
+          propertyListResolveOptions: {
+            callTool: async () => ({
+              list: { list_id: 'cope_allowed_properties', name: 'Cope allowed properties' },
+              identifiers: [{ type: 'domain', value: 'example.com' }],
+              cache_valid_until: '2026-06-02T12:05:00.000Z',
+            }),
+          },
+        },
+      },
+      handlers: {
+        onGetProductsStatusChange: (response, metadata) => handlerCalls.push({ response, metadata }),
+      },
+    });
+
+    const submittedPromise = agent.getProducts(
+      {
+        brief: 'sports',
+        property_list: {
+          agent_url: 'https://lists.example/mcp',
+          list_id: 'cope_allowed_properties',
+        },
+      },
+      undefined,
+      { project: false }
+    );
+    await callToolStarted;
+    assert.ok(capturedOperationId, 'protocol_request activity should expose the webhook operation id');
+
+    const handled = await agent.handleWebhook(
+      {
+        idempotency_key: 'webhook-event-fast',
+        operation_id: capturedOperationId,
+        task_id: 'seller-task-1',
+        task_type: 'get_products',
+        status: 'completed',
+        timestamp: '2026-06-02T12:00:00.000Z',
+        result: {
+          products: [makeProduct('safe', 'www.example.com'), makeProduct('blocked', 'www.ladbible.com')],
+          cache_scope: 'public',
+        },
+      },
+      'get_products',
+      capturedOperationId
+    );
+
+    assert.strictEqual(handled, true);
+    assert.deepStrictEqual(
+      handlerCalls[0].response.products.map(p => p.product_id),
+      ['safe']
+    );
+    assert.strictEqual(handlerCalls[0].metadata.productPropertyPolicy.request_property_list.list_id, 'cope_allowed_properties');
+
+    releaseInitialResponse();
+    const submitted = await submittedPromise;
+    assert.strictEqual(submitted.status, 'submitted');
+  });
+
+  test('sanitizes property_list resolution failures in metadata and debug logs', async () => {
+    stubGetProducts([makeProduct('safe', 'www.example.com')]);
+
+    const agent = makeClient({
+      validation: {
+        productPropertyPolicy: {
+          mode: 'reject_response',
+          propertyListResolveOptions: {
+            callTool: async () => {
+              throw new Error('remote payload with secret token');
+            },
+          },
+        },
+      },
+    });
+
+    const result = await agent.getProducts(
+      {
+        brief: 'sports',
+        property_list: {
+          agent_url: 'https://user:pass@lists.example/mcp?token=secret',
+          list_id: 'cope_allowed_properties',
+        },
+      },
+      undefined,
+      { project: false }
+    );
+
+    assert.strictEqual(result.success, false);
+    assert.strictEqual(
+      result.metadata.productPropertyPolicy.request_property_list.resolution_error,
+      'list_agent_url_malformed'
+    );
+    assert.strictEqual(result.metadata.productPropertyPolicy.request_property_list.agent_url, 'https://lists.example/mcp');
+    const policyLog = result.debug_logs.find(entry => entry.type === 'product_property_policy');
+    assert.strictEqual(policyLog.request_property_list.resolution_error, 'list_agent_url_malformed');
+  });
+});

--- a/test/lib/product-property-policy.test.js
+++ b/test/lib/product-property-policy.test.js
@@ -86,6 +86,115 @@ describe('validateProductsAgainstPropertyPolicy', () => {
     assert.strictEqual(result.diagnostics[0].normalized_domain, 'ladbible.com');
   });
 
+  test('filters products outside resolved property-list identifiers', () => {
+    const result = validateProductsAgainstPropertyPolicy({
+      products: [
+        product({ product_id: 'prod_safe', publisher_properties: [{ selection_type: 'all', publisher_domain: 'www.example.com' }] }),
+        product({
+          product_id: 'prod_ladbible',
+          publisher_properties: [{ selection_type: 'all', publisher_domain: 'www.ladbible.com' }],
+        }),
+      ],
+      policy: {
+        allowedPropertyIdentifiers: [{ type: 'domain', value: 'example.com' }],
+        strict: true,
+      },
+      mode: 'filter',
+    });
+
+    assert.deepStrictEqual(
+      result.products.map(p => p.product_id),
+      ['prod_safe']
+    );
+    assert.strictEqual(result.diagnostics[0].code, 'outside_property_list');
+    assert.strictEqual(result.diagnostics[0].normalized_domain, 'www.ladbible.com');
+  });
+
+  test('allows subset-targetable products with a property-list intersection', () => {
+    const result = validateProductsAgainstPropertyPolicy({
+      products: [
+        product({
+          product_id: 'prod_subset_ok',
+          property_targeting_allowed: true,
+          publisher_properties: [
+            { selection_type: 'all', publisher_domain: 'www.example.com' },
+            { selection_type: 'all', publisher_domain: 'www.ladbible.com' },
+          ],
+        }),
+        product({
+          product_id: 'prod_all_or_nothing_rejected',
+          publisher_properties: [
+            { selection_type: 'all', publisher_domain: 'www.example.com' },
+            { selection_type: 'all', publisher_domain: 'www.ladbible.com' },
+          ],
+        }),
+      ],
+      policy: {
+        allowedPropertyIdentifiers: [{ type: 'domain', value: 'example.com' }],
+        strict: true,
+      },
+      mode: 'filter',
+    });
+
+    assert.deepStrictEqual(
+      result.products.map(p => p.product_id),
+      ['prod_subset_ok']
+    );
+    assert.strictEqual(result.diagnostics[0].product_id, 'prod_all_or_nothing_rejected');
+    assert.strictEqual(result.diagnostics[0].code, 'outside_property_list');
+  });
+
+  test('allows subset-targetable products with an eligible selector despite explicit exclusions', () => {
+    const result = validateProductsAgainstPropertyPolicy({
+      products: [
+        product({
+          product_id: 'prod_subset_ok',
+          property_targeting_allowed: true,
+          publisher_properties: [
+            { selection_type: 'all', publisher_domain: 'www.example.com' },
+            { selection_type: 'all', publisher_domain: 'www.ladbible.com' },
+          ],
+        }),
+        product({
+          product_id: 'prod_subset_rejected',
+          property_targeting_allowed: true,
+          publisher_properties: [{ selection_type: 'all', publisher_domain: 'www.ladbible.com' }],
+        }),
+      ],
+      policy: {
+        allowedPropertyIdentifiers: [
+          { type: 'domain', value: 'example.com' },
+          { type: 'domain', value: 'ladbible.com' },
+        ],
+        excludedDomains: ['ladbible.com'],
+        strict: true,
+      },
+      mode: 'filter',
+    });
+
+    assert.deepStrictEqual(
+      result.products.map(p => p.product_id),
+      ['prod_subset_ok']
+    );
+    assert.strictEqual(result.diagnostics[0].product_id, 'prod_subset_rejected');
+    assert.strictEqual(result.diagnostics[0].code, 'outside_property_list');
+  });
+
+  test('rejects products when an enforced allowed property list is empty', () => {
+    const result = validateProductsAgainstPropertyPolicy({
+      products: [product({ product_id: 'prod_safe' })],
+      policy: {
+        allowedPropertyIdentifiers: [],
+        requireAllowedPropertyMatch: true,
+        strict: true,
+      },
+      mode: 'filter',
+    });
+
+    assert.deepStrictEqual(result.products, []);
+    assert.strictEqual(result.diagnostics[0].code, 'outside_property_list');
+  });
+
   test('rejects by_id selectors that include excluded property IDs', () => {
     const result = validateProductsAgainstPropertyPolicy({
       products: [
@@ -174,25 +283,56 @@ describe('validateProductsAgainstPropertyPolicy', () => {
     assert.strictEqual(rejected.diagnostics[0].severity, 'rejected');
   });
 
-  test('missing publisher_domain in a product selector is flagged by default and rejected in strict mode', () => {
+  test('compact publisher_domains selectors are malformed for product publisher_properties', () => {
     const products = [
       product({
         product_id: 'prod_compact_shape',
-        publisher_properties: [{ selection_type: 'all', publisher_domains: ['ladbible.com'] }],
+        publisher_properties: [{ selection_type: 'all', publisher_domains: ['example.com', 'ladbible.com'] }],
       }),
     ];
 
-    const flagged = validateProductsAgainstPropertyPolicy({
+    const result = validateProductsAgainstPropertyPolicy({
       products,
       policy: { excludedDomains: ['ladbible.com'] },
       mode: 'filter',
     });
     assert.deepStrictEqual(
-      flagged.products.map(p => p.product_id),
-      ['prod_compact_shape']
+      result.products.map(p => p.product_id),
+      []
     );
-    assert.strictEqual(flagged.diagnostics[0].code, 'unknown_selector');
-    assert.strictEqual(flagged.diagnostics[0].severity, 'flagged');
+    assert.strictEqual(result.diagnostics[0].code, 'unknown_selector');
+    assert.strictEqual(result.diagnostics[0].path, 'products[0].publisher_properties[0]');
+    assert.deepStrictEqual(result.diagnostics[0].publisher_domains, ['example.com', 'ladbible.com']);
+    assert.strictEqual(result.diagnostics[0].severity, 'rejected');
+
+    const rejected = validateProductsAgainstPropertyPolicy({
+      products,
+      policy: { strict: true },
+      mode: 'filter',
+    });
+    assert.deepStrictEqual(rejected.products, []);
+    assert.strictEqual(rejected.diagnostics[0].severity, 'rejected');
+  });
+
+  test('malformed compact publisher_domains selectors are rejected before forwarding', () => {
+    const products = [
+      product({
+        product_id: 'prod_compact_shape',
+        publisher_properties: [{ selection_type: 'all', publisher_domains: 'ladbible.com' }],
+      }),
+    ];
+
+    const rejectedByShape = validateProductsAgainstPropertyPolicy({
+      products,
+      policy: { excludedDomains: ['ladbible.com'] },
+      mode: 'filter',
+    });
+    assert.deepStrictEqual(
+      rejectedByShape.products.map(p => p.product_id),
+      []
+    );
+    assert.strictEqual(rejectedByShape.diagnostics[0].code, 'unknown_selector');
+    assert.strictEqual(rejectedByShape.diagnostics[0].severity, 'rejected');
 
     const rejected = validateProductsAgainstPropertyPolicy({
       products,

--- a/test/lib/product-property-policy.test.js
+++ b/test/lib/product-property-policy.test.js
@@ -89,7 +89,10 @@ describe('validateProductsAgainstPropertyPolicy', () => {
   test('filters products outside resolved property-list identifiers', () => {
     const result = validateProductsAgainstPropertyPolicy({
       products: [
-        product({ product_id: 'prod_safe', publisher_properties: [{ selection_type: 'all', publisher_domain: 'www.example.com' }] }),
+        product({
+          product_id: 'prod_safe',
+          publisher_properties: [{ selection_type: 'all', publisher_domain: 'www.example.com' }],
+        }),
         product({
           product_id: 'prod_ladbible',
           publisher_properties: [{ selection_type: 'all', publisher_domain: 'www.ladbible.com' }],

--- a/test/lib/product-property-policy.test.js
+++ b/test/lib/product-property-policy.test.js
@@ -1,0 +1,205 @@
+const { describe, test } = require('node:test');
+const assert = require('node:assert');
+
+const {
+  ProductPropertyPolicyError,
+  normalizeDomainForPropertyPolicy,
+  validateProductsAgainstPropertyPolicy,
+} = require('../../dist/lib/media-buy');
+
+function product(overrides) {
+  return {
+    product_id: 'prod_ok',
+    name: 'Test product',
+    publisher_properties: [{ selection_type: 'all', publisher_domain: 'example.com' }],
+    ...overrides,
+  };
+}
+
+describe('normalizeDomainForPropertyPolicy', () => {
+  test('normalizes schemes, paths, casing, ports, and www equivalence', () => {
+    assert.deepStrictEqual(normalizeDomainForPropertyPolicy('https://WWW.LADBible.com/news?id=1'), {
+      input: 'https://WWW.LADBible.com/news?id=1',
+      host: 'www.ladbible.com',
+      comparable: 'ladbible.com',
+    });
+
+    assert.deepStrictEqual(normalizeDomainForPropertyPolicy('ladbible.com:443/sports'), {
+      input: 'ladbible.com:443/sports',
+      host: 'ladbible.com',
+      comparable: 'ladbible.com',
+    });
+  });
+});
+
+describe('validateProductsAgainstPropertyPolicy', () => {
+  test('audits products without changing the returned products array', () => {
+    const products = [
+      product({ product_id: 'prod_safe' }),
+      product({
+        product_id: 'prod_excluded',
+        publisher_properties: [{ selection_type: 'all', publisher_domain: 'www.ladbible.com' }],
+      }),
+    ];
+
+    const result = validateProductsAgainstPropertyPolicy({
+      products,
+      policy: { excludedDomains: ['ladbible.com'] },
+      mode: 'audit',
+    });
+
+    assert.strictEqual(result.ok, false);
+    assert.deepStrictEqual(
+      result.products.map(p => p.product_id),
+      ['prod_safe', 'prod_excluded']
+    );
+    assert.deepStrictEqual(
+      result.acceptedProducts.map(p => p.product_id),
+      ['prod_safe']
+    );
+    assert.deepStrictEqual(
+      result.rejectedProducts.map(p => p.product_id),
+      ['prod_excluded']
+    );
+    assert.strictEqual(result.diagnostics[0].code, 'excluded_domain');
+    assert.strictEqual(result.diagnostics[0].matched_excluded_domain, 'ladbible.com');
+  });
+
+  test('filters products with all-selector excluded domains', () => {
+    const result = validateProductsAgainstPropertyPolicy({
+      products: [
+        product({ product_id: 'prod_safe' }),
+        product({
+          product_id: 'prod_ladbible',
+          publisher_properties: [{ selection_type: 'all', publisher_domain: 'https://ladbible.com/news' }],
+        }),
+      ],
+      policy: { excludedDomains: ['www.ladbible.com'] },
+      mode: 'filter',
+    });
+
+    assert.strictEqual(result.ok, false);
+    assert.deepStrictEqual(
+      result.products.map(p => p.product_id),
+      ['prod_safe']
+    );
+    assert.strictEqual(result.diagnostics[0].normalized_domain, 'ladbible.com');
+  });
+
+  test('rejects by_id selectors that include excluded property IDs', () => {
+    const result = validateProductsAgainstPropertyPolicy({
+      products: [
+        product({
+          product_id: 'prod_by_id',
+          publisher_properties: [
+            {
+              selection_type: 'by_id',
+              publisher_domain: 'news.example',
+              property_ids: ['homepage', 'www_ladbible_com'],
+            },
+          ],
+        }),
+      ],
+      policy: { excludedPropertyIds: ['www_ladbible_com'] },
+      mode: 'filter',
+    });
+
+    assert.deepStrictEqual(result.products, []);
+    assert.strictEqual(result.diagnostics[0].code, 'excluded_property_id');
+    assert.deepStrictEqual(result.diagnostics[0].matched_property_ids, ['www_ladbible_com']);
+  });
+
+  test('reject_response throws a structured error with diagnostics', () => {
+    assert.throws(
+      () =>
+        validateProductsAgainstPropertyPolicy({
+          products: [
+            product({
+              product_id: 'prod_ladbible',
+              publisher_properties: [{ selection_type: 'all', publisher_domain: 'ladbible.com' }],
+            }),
+          ],
+          policy: { excludedDomains: ['ladbible.com'] },
+          mode: 'reject_response',
+        }),
+      err => {
+        assert.ok(err instanceof ProductPropertyPolicyError);
+        assert.strictEqual(err.result.rejectedProducts[0].product_id, 'prod_ladbible');
+        assert.strictEqual(err.result.diagnostics[0].code, 'excluded_domain');
+        return true;
+      }
+    );
+  });
+
+  test('strict mode rejects products missing publisher_properties', () => {
+    const result = validateProductsAgainstPropertyPolicy({
+      products: [product({ product_id: 'prod_unknown', publisher_properties: undefined })],
+      policy: { strict: true },
+      mode: 'filter',
+    });
+
+    assert.deepStrictEqual(result.products, []);
+    assert.strictEqual(result.diagnostics[0].code, 'missing_publisher_properties');
+    assert.strictEqual(result.diagnostics[0].severity, 'rejected');
+  });
+
+  test('unresolved by_tag selectors are flagged by default and rejected when configured', () => {
+    const products = [
+      product({
+        product_id: 'prod_by_tag',
+        publisher_properties: [
+          { selection_type: 'by_tag', publisher_domain: 'news.example', property_tags: ['sports'] },
+        ],
+      }),
+    ];
+
+    const flagged = validateProductsAgainstPropertyPolicy({
+      products,
+      policy: {},
+      mode: 'filter',
+    });
+    assert.deepStrictEqual(
+      flagged.products.map(p => p.product_id),
+      ['prod_by_tag']
+    );
+    assert.strictEqual(flagged.diagnostics[0].code, 'unresolved_tag_selector');
+    assert.strictEqual(flagged.diagnostics[0].severity, 'flagged');
+
+    const rejected = validateProductsAgainstPropertyPolicy({
+      products,
+      policy: { unknownSelectorBehavior: 'reject' },
+      mode: 'filter',
+    });
+    assert.deepStrictEqual(rejected.products, []);
+    assert.strictEqual(rejected.diagnostics[0].severity, 'rejected');
+  });
+
+  test('missing publisher_domain in a product selector is flagged by default and rejected in strict mode', () => {
+    const products = [
+      product({
+        product_id: 'prod_compact_shape',
+        publisher_properties: [{ selection_type: 'all', publisher_domains: ['ladbible.com'] }],
+      }),
+    ];
+
+    const flagged = validateProductsAgainstPropertyPolicy({
+      products,
+      policy: { excludedDomains: ['ladbible.com'] },
+      mode: 'filter',
+    });
+    assert.deepStrictEqual(
+      flagged.products.map(p => p.product_id),
+      ['prod_compact_shape']
+    );
+    assert.strictEqual(flagged.diagnostics[0].code, 'unknown_selector');
+    assert.strictEqual(flagged.diagnostics[0].severity, 'flagged');
+
+    const rejected = validateProductsAgainstPropertyPolicy({
+      products,
+      policy: { excludedDomains: ['ladbible.com'], strict: true },
+      mode: 'filter',
+    });
+    assert.deepStrictEqual(rejected.products, []);
+    assert.strictEqual(rejected.diagnostics[0].severity, 'rejected');
+  });
+});


### PR DESCRIPTION
## Summary
- Enforce buyer-side product property policies for `get_products` across typed calls, generic `executeTask`, submitted polling, and webhooks.
- Resolve request `property_list` refs into cached allow-lists, fail closed on unsupported identifier types, preserve raw seller payloads on rejection, and keep raw webhook payloads available for observability.
- Harden resolved list fetching with cache-before-DNS behavior, malformed pagination rejection, sanitized diagnostics, and pinned/no-redirect MCP transport for default list resolution.

## Validation
- `npm run build:lib`
- `node --test-timeout=60000 --test-force-exit --test test/lib/product-property-policy-client.test.js test/lib/product-property-policy.test.js`
- `npx vitest run src/lib/server/targeting-helpers.test.ts`
- `node --test-timeout=180000 --test-force-exit --test test/examples/hello-seller-adapter-guaranteed.test.js`
- `node --test-timeout=180000 --test-force-exit --test test/examples/hello-seller-adapter-non-guaranteed.test.js`
- Docker clean Node 20: `npm ci`, `npm run build:lib`, focused policy tests, targeting-helper tests
- `npx commitlint --from origin/main --to HEAD --verbose`
