### PR TITLE
fix(compliance): avoid valid_actions advisory false positives

### DIFF
--- a/.changeset/valid-actions-advisory-scan.md
+++ b/.changeset/valid-actions-advisory-scan.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Avoid false-positive `missing-valid-actions` advisories when a later `get_media_buys` observation in the same compliance run includes `valid_actions`.

--- a/src/lib/testing/compliance/comply.ts
+++ b/src/lib/testing/compliance/comply.ts
@@ -9,7 +9,7 @@
  */
 
 import { createTestClient, discoverAgentProfile } from '../client';
-import type { TestOptions, TestResult, AgentProfile } from '../types';
+import type { TestOptions, TestResult, AgentProfile, TestStepResult } from '../types';
 import { mapStoryboardResultsToTrackResult, TRACK_LABELS } from './storyboard-tracks';
 import { applyAdcpVersionRunOptions, runStoryboard } from '../storyboard/runner';
 import { validateTestKit } from '../storyboard/test-kit';
@@ -174,90 +174,107 @@ export function collectObservations(
 
   // Media buy track observations
   if (track === 'media_buy') {
-    // Check for valid_actions support (first match only)
-    let checkedValidActions = false;
+    const getMediaBuyObservations: Array<{
+      result: TestResult;
+      step: TestStepResult;
+      obs: {
+        valid_actions?: unknown;
+        history_entries?: number;
+        history_valid?: boolean;
+        has_creative_deadline?: boolean;
+        sandbox?: unknown;
+      };
+    }> = [];
     for (const result of results) {
-      if (checkedValidActions) break;
       for (const step of result.steps ?? []) {
         if (step.task === 'get_media_buys' && step.observation_data) {
-          const obs = step.observation_data as {
-            valid_actions?: unknown;
-            history_entries?: number;
-            history_valid?: boolean;
-            has_creative_deadline?: boolean;
-            sandbox?: unknown;
-          };
-          if (obs.valid_actions === undefined || obs.valid_actions === null) {
-            observations.push({
-              category: 'best_practice',
-              severity: 'warning',
-              track,
-              message:
-                'Agent does not return valid_actions in get_media_buys response. ' +
-                'Without valid_actions, buyer agents must hardcode the state machine to know what operations are permitted.',
-              source: {
-                kind: 'storyboard_step',
-                code: 'missing-valid-actions',
-                storyboard_id: result.scenario,
-                step_id: step.step,
-              },
-            });
-          }
-
-          if (obs.has_creative_deadline === false) {
-            observations.push({
-              category: 'best_practice',
-              severity: 'suggestion',
-              track,
-              message:
-                'Agent does not return creative_deadline on media buys or packages. ' +
-                'Buyers need to know when creative uploads must be finalized to avoid rejected submissions.',
-              source: {
-                kind: 'storyboard_step',
-                code: 'missing-creative-deadline',
-                storyboard_id: result.scenario,
-                step_id: step.step,
-              },
-            });
-          }
-
-          if (obs.history_entries && obs.history_entries > 0 && obs.history_valid === false) {
-            observations.push({
-              category: 'best_practice',
-              severity: 'warning',
-              track,
-              message:
-                'Agent returns history entries but some lack required fields (timestamp, action). ' +
-                'History entries must include at least timestamp and action to be useful for audit.',
-              source: {
-                kind: 'storyboard_step',
-                code: 'invalid-history-entries',
-                storyboard_id: result.scenario,
-                step_id: step.step,
-              },
-            });
-          }
-
-          if (obs.sandbox === undefined || obs.sandbox === null) {
-            observations.push({
-              category: 'best_practice',
-              severity: 'suggestion',
-              track,
-              message:
-                'Agent does not confirm sandbox mode in get_media_buys response. ' +
-                'Include sandbox: true so buyers can verify the agent honored sandbox mode.',
-              source: {
-                kind: 'storyboard_step',
-                code: 'missing-sandbox-echo',
-                storyboard_id: result.scenario,
-                step_id: step.step,
-              },
-            });
-          }
-
-          checkedValidActions = true;
-          break;
+          getMediaBuyObservations.push({
+            result,
+            step,
+            obs: step.observation_data as {
+              valid_actions?: unknown;
+              history_entries?: number;
+              history_valid?: boolean;
+              has_creative_deadline?: boolean;
+              sandbox?: unknown;
+            },
+          });
         }
+      }
+    }
+
+    const firstGetMediaBuysObservation = getMediaBuyObservations[0];
+    if (firstGetMediaBuysObservation) {
+      const hasAnyValidActions = getMediaBuyObservations.some(
+        ({ obs }) => obs.valid_actions !== undefined && obs.valid_actions !== null
+      );
+      if (!hasAnyValidActions) {
+        observations.push({
+          category: 'best_practice',
+          severity: 'warning',
+          track,
+          message:
+            'Agent does not return valid_actions in get_media_buys response. ' +
+            'Without valid_actions, buyer agents must hardcode the state machine to know what operations are permitted.',
+          source: {
+            kind: 'storyboard_step',
+            code: 'missing-valid-actions',
+            storyboard_id: firstGetMediaBuysObservation.result.scenario,
+            step_id: firstGetMediaBuysObservation.step.step,
+          },
+        });
+      }
+
+      const { result, step, obs } = firstGetMediaBuysObservation;
+      if (obs.has_creative_deadline === false) {
+        observations.push({
+          category: 'best_practice',
+          severity: 'suggestion',
+          track,
+          message:
+            'Agent does not return creative_deadline on media buys or packages. ' +
+            'Buyers need to know when creative uploads must be finalized to avoid rejected submissions.',
+          source: {
+            kind: 'storyboard_step',
+            code: 'missing-creative-deadline',
+            storyboard_id: result.scenario,
+            step_id: step.step,
+          },
+        });
+      }
+
+      if (obs.history_entries && obs.history_entries > 0 && obs.history_valid === false) {
+        observations.push({
+          category: 'best_practice',
+          severity: 'warning',
+          track,
+          message:
+            'Agent returns history entries but some lack required fields (timestamp, action). ' +
+            'History entries must include at least timestamp and action to be useful for audit.',
+          source: {
+            kind: 'storyboard_step',
+            code: 'invalid-history-entries',
+            storyboard_id: result.scenario,
+            step_id: step.step,
+          },
+        });
+      }
+
+      if (obs.sandbox === undefined || obs.sandbox === null) {
+        observations.push({
+          category: 'best_practice',
+          severity: 'suggestion',
+          track,
+          message:
+            'Agent does not confirm sandbox mode in get_media_buys response. ' +
+            'Include sandbox: true so buyers can verify the agent honored sandbox mode.',
+          source: {
+            kind: 'storyboard_step',
+            code: 'missing-sandbox-echo',
+            storyboard_id: result.scenario,
+            step_id: step.step,
+          },
+        });
       }
     }
 

--- a/src/lib/testing/compliance/comply.ts
+++ b/src/lib/testing/compliance/comply.ts
@@ -174,11 +174,30 @@ export function collectObservations(
 
   // Media buy track observations
   if (track === 'media_buy') {
+    const hasValidActions = (obs: { valid_actions?: unknown; media_buys?: unknown }): boolean => {
+      if (obs.valid_actions !== undefined && obs.valid_actions !== null) {
+        return true;
+      }
+
+      if (!Array.isArray(obs.media_buys)) {
+        return false;
+      }
+
+      return obs.media_buys.some(
+        buy =>
+          buy !== null &&
+          typeof buy === 'object' &&
+          (buy as { valid_actions?: unknown }).valid_actions !== undefined &&
+          (buy as { valid_actions?: unknown }).valid_actions !== null
+      );
+    };
+
     const getMediaBuyObservations: Array<{
       result: TestResult;
       step: TestStepResult;
       obs: {
         valid_actions?: unknown;
+        media_buys?: unknown;
         history_entries?: number;
         history_valid?: boolean;
         has_creative_deadline?: boolean;
@@ -193,6 +212,7 @@ export function collectObservations(
             step,
             obs: step.observation_data as {
               valid_actions?: unknown;
+              media_buys?: unknown;
               history_entries?: number;
               history_valid?: boolean;
               has_creative_deadline?: boolean;
@@ -205,9 +225,7 @@ export function collectObservations(
 
     const firstGetMediaBuysObservation = getMediaBuyObservations[0];
     if (firstGetMediaBuysObservation) {
-      const hasAnyValidActions = getMediaBuyObservations.some(
-        ({ obs }) => obs.valid_actions !== undefined && obs.valid_actions !== null
-      );
+      const hasAnyValidActions = getMediaBuyObservations.some(({ obs }) => hasValidActions(obs));
       if (!hasAnyValidActions) {
         observations.push({
           category: 'best_practice',

--- a/test/lib/comply-advisory-rule-source.test.js
+++ b/test/lib/comply-advisory-rule-source.test.js
@@ -122,6 +122,53 @@ describe('collectObservations — create_media_buy advisories (#1736)', () => {
   });
 });
 
+describe('collectObservations — valid_actions advisory (#5319)', () => {
+  function mediaBuyResultWithGetMediaBuysObservations(observations) {
+    return {
+      agent_url: 'https://example.com/mcp',
+      scenario: 'media_buy_seller/pending_creatives_to_start',
+      overall_passed: true,
+      summary: '',
+      total_duration_ms: 100,
+      tested_at: '2026-01-01T00:00:00.000Z',
+      steps: observations.map((observation_data, index) => ({
+        step: `Get media buys ${index + 1}`,
+        task: 'get_media_buys',
+        passed: true,
+        duration_ms: 100,
+        observation_data,
+      })),
+    };
+  }
+
+  test('does not emit missing-valid-actions when a later get_media_buys observation has valid_actions', () => {
+    const result = mediaBuyResultWithGetMediaBuysObservations([
+      { valid_actions: undefined },
+      { valid_actions: ['cancel', 'update_budget'], sandbox: true },
+    ]);
+
+    const observations = collectObservations('media_buy', [result], dummyProfile);
+    const missingValidActions = observations.filter(o => o.source?.code === 'missing-valid-actions');
+
+    assert.equal(
+      missingValidActions.length,
+      0,
+      `Expected no missing-valid-actions advisory when any get_media_buys observation includes valid_actions, got ${JSON.stringify(missingValidActions)}`
+    );
+  });
+
+  test('still emits missing-valid-actions when no get_media_buys observation has valid_actions', () => {
+    const result = mediaBuyResultWithGetMediaBuysObservations([{ sandbox: true }, { valid_actions: null }]);
+
+    const observations = collectObservations('media_buy', [result], dummyProfile);
+    const missingValidActions = observations.filter(o => o.source?.code === 'missing-valid-actions');
+
+    assert.equal(missingValidActions.length, 1);
+    assert.equal(missingValidActions[0].source.storyboard_id, 'media_buy_seller/pending_creatives_to_start');
+    assert.equal(missingValidActions[0].source.step_id, 'Get media buys 1');
+  });
+});
+
 // ────────────────────────────────────────────────────────────────────────────
 // #1746 — Every advisory carries traceable source coordinates.
 //

--- a/test/lib/comply-advisory-rule-source.test.js
+++ b/test/lib/comply-advisory-rule-source.test.js
@@ -157,6 +157,29 @@ describe('collectObservations — valid_actions advisory (#5319)', () => {
     );
   });
 
+  test('does not emit missing-valid-actions when returned media buys include valid_actions', () => {
+    const result = mediaBuyResultWithGetMediaBuysObservations([
+      {
+        media_buys: [
+          {
+            media_buy_id: 'mb1',
+            status: 'pending_start',
+            valid_actions: ['cancel'],
+          },
+        ],
+      },
+    ]);
+
+    const observations = collectObservations('media_buy', [result], dummyProfile);
+    const missingValidActions = observations.filter(o => o.source?.code === 'missing-valid-actions');
+
+    assert.equal(
+      missingValidActions.length,
+      0,
+      `Expected no missing-valid-actions advisory when returned media buys include valid_actions, got ${JSON.stringify(missingValidActions)}`
+    );
+  });
+
   test('still emits missing-valid-actions when no get_media_buys observation has valid_actions', () => {
     const result = mediaBuyResultWithGetMediaBuysObservations([{ sandbox: true }, { valid_actions: null }]);
 


### PR DESCRIPTION
## Summary
- Scans all `get_media_buys` observations in a compliance run before emitting `missing-valid-actions`.
- Preserves the existing first-observation behavior for the other media-buy advisories.
- Adds regression coverage for adcontextprotocol/adcp#5319.

## Tests
- `npm run build:lib`
- `NODE_ENV=test node --test-timeout=60000 --test test/lib/comply-advisory-rule-source.test.js`
- `npm run typecheck`
- `npm run test:lib:fast`
- `npx prettier --check src/lib/testing/compliance/comply.ts test/lib/comply-advisory-rule-source.test.js .changeset/valid-actions-advisory-scan.md`
- `git diff --check -- src/lib/testing/compliance/comply.ts test/lib/comply-advisory-rule-source.test.js .changeset/valid-actions-advisory-scan.md`

Follow-up for adcontextprotocol/adcp#5319.