### PR TITLE
fix: normalize storyboard failed AdCP payloads

### DIFF
--- a/.changeset/storyboard-expect-error-failed-payload.md
+++ b/.changeset/storyboard-expect-error-failed-payload.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Fix storyboard `expect_error` grading for failed AdCP payloads when the SDK task result omits `success: false`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/sdk",
-  "version": "9.0.0-beta.22",
+  "version": "9.0.0-beta.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/sdk",
-      "version": "9.0.0-beta.22",
+      "version": "9.0.0-beta.24",
       "license": "Apache-2.0",
       "workspaces": [
         ".",
@@ -7356,7 +7356,7 @@
       "version": "6.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adcp/sdk": "^9.0.0-beta.22"
+        "@adcp/sdk": "^9.0.0-beta.24"
       },
       "bin": {
         "adcp": "bin/adcp.js"

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -3896,7 +3896,11 @@ async function executeStep(
       if (taskResult) {
         responseRecord = {
           transport: options.protocol === 'a2a' ? 'a2a' : 'mcp',
-          payload: redactSecrets(taskResult.data ?? taskResult.error ?? null),
+          payload: redactSecrets(
+            taskResult.data ??
+              taskResult.error ??
+              (taskResult.adcp_error ? { adcp_error: taskResult.adcp_error } : null)
+          ),
           duration_ms: durationMs,
         };
       }
@@ -3932,7 +3936,11 @@ async function executeStep(
       if (taskResult) {
         responseRecord = {
           transport: options.protocol === 'a2a' ? 'a2a' : 'mcp',
-          payload: redactSecrets(taskResult.data ?? taskResult.error ?? null),
+          payload: redactSecrets(
+            taskResult.data ??
+              taskResult.error ??
+              (taskResult.adcp_error ? { adcp_error: taskResult.adcp_error } : null)
+          ),
           duration_ms: stepResult.duration_ms,
         };
       }

--- a/src/lib/testing/storyboard/task-map.test.ts
+++ b/src/lib/testing/storyboard/task-map.test.ts
@@ -9,6 +9,27 @@ const INVALID_REQUEST_ERROR = {
   details: { validation_errors: [{ field: 'packages.0.product_id', message: 'Field required' }] },
 };
 
+const MULTI_FINALIZE_FAILED_PAYLOAD = {
+  products: [],
+  proposals: [],
+  errors: [
+    {
+      code: 'MULTI_FINALIZE_UNSUPPORTED',
+      message:
+        'Atomic multi-proposal finalize is not supported; sequence individual create_media_buy(proposal_id=...) calls instead.',
+      field: 'refine',
+      recovery: 'correctable',
+    },
+  ],
+  adcp_version: '3.1',
+  status: 'failed',
+};
+
+const ADVISORY_ERROR = {
+  code: 'NON_BLOCKING_DIAGNOSTIC',
+  message: 'Advisory warning',
+};
+
 function makeFailureClient(adcpError?: object) {
   return {
     createMediaBuy: async () => ({
@@ -74,5 +95,61 @@ describe('executeStoryboardTask — adcp_error forwarding', () => {
     };
     const result = await executeStoryboardTask(client, 'unknown_task', {});
     expect(result.adcp_error?.code).toBe('UNKNOWN_ERROR');
+  });
+
+  it('infers failure from a failed AdCP payload when TaskResult.success is omitted', async () => {
+    const client = {
+      getProducts: async () => ({
+        data: MULTI_FINALIZE_FAILED_PAYLOAD,
+      }),
+    };
+
+    const result = await executeStoryboardTask(client, 'get_products', {});
+
+    expect(result.success).toBe(false);
+    expect(result.data).toEqual(MULTI_FINALIZE_FAILED_PAYLOAD);
+  });
+
+  it('uses canonical terminal AdCP error detection when TaskResult.success is omitted', async () => {
+    const cases = [
+      { name: 'rejected status', data: { status: 'rejected' } },
+      { name: 'failed status', data: { status: 'failed' } },
+      { name: 'errors without success payload', data: { status: 'completed', errors: [ADVISORY_ERROR] } },
+    ];
+
+    for (const testCase of cases) {
+      const client = {
+        getProducts: async () => ({ data: testCase.data }),
+      };
+
+      const result = await executeStoryboardTask(client, 'get_products', {});
+
+      expect(result.success, testCase.name).toBe(false);
+    }
+  });
+
+  it('does not treat advisory errors on a success payload as failure', async () => {
+    const client = {
+      getProducts: async () => ({
+        data: { status: 'completed', products: [], errors: [ADVISORY_ERROR] },
+      }),
+    };
+
+    const result = await executeStoryboardTask(client, 'get_products', {});
+
+    expect(result.success).toBe(true);
+  });
+
+  it('forwards top-level adcp_error from a TaskResult when adcpError is absent', async () => {
+    const client = {
+      getProducts: async () => ({
+        adcp_error: INVALID_REQUEST_ERROR,
+      }),
+    };
+
+    const result = await executeStoryboardTask(client, 'get_products', {});
+
+    expect(result.success).toBe(false);
+    expect(result.adcp_error).toEqual(INVALID_REQUEST_ERROR);
   });
 });

--- a/src/lib/testing/storyboard/task-map.ts
+++ b/src/lib/testing/storyboard/task-map.ts
@@ -8,7 +8,7 @@
  */
 
 import type { TaskResult } from '../types';
-import { readExtractionPath } from '../../utils/response-unwrapper';
+import { isTerminalAdcpError, readExtractionPath } from '../../utils/response-unwrapper';
 
 /**
  * Map of AdCP task names to SingleAgentClient method names.
@@ -69,6 +69,19 @@ export const TASK_TO_METHOD: Record<string, string> = {
   si_send_message: 'siSendMessage',
   si_terminate_session: 'siTerminateSession',
 };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function normalizeStoryboardTaskSuccess(result: unknown, taskName: string): boolean {
+  if (!isRecord(result)) return true;
+  if (typeof result.success === 'boolean') return result.success;
+  if (result.status === 'failed' || result.status === 'rejected') return false;
+  if (result.adcpError || result.adcp_error) return false;
+  if (isTerminalAdcpError(result.data, taskName)) return false;
+  return true;
+}
 
 /**
  * Execute a storyboard task against a SingleAgentClient.
@@ -144,11 +157,12 @@ export async function executeStoryboardTask(
   }
 
   const extractionPath = readExtractionPath(result.data);
+  const adcpError = result.adcpError ?? (isRecord(result.adcp_error) ? result.adcp_error : undefined);
   return {
-    success: result.success ?? true,
+    success: normalizeStoryboardTaskSuccess(result, taskName),
     data: result.data,
     error: result.error,
-    ...(result.adcpError && { adcp_error: result.adcpError }),
+    ...(adcpError && { adcp_error: adcpError }),
     ...(extractionPath !== undefined && { _extraction_path: extractionPath }),
   };
 }

--- a/src/lib/testing/storyboard/validations.ts
+++ b/src/lib/testing/storyboard/validations.ts
@@ -1423,7 +1423,9 @@ function validateErrorCode(validation: StoryboardValidation, taskResult: TaskRes
     firstError && typeof firstError === 'object' && typeof (firstError as Record<string, unknown>).code === 'string'
       ? ((firstError as Record<string, unknown>).code as string)
       : undefined;
-  const adcpError = data?.adcp_error as Record<string, unknown> | undefined;
+  const adcpError =
+    (data?.adcp_error as Record<string, unknown> | undefined) ??
+    (taskResult.adcp_error as Record<string, unknown> | undefined);
   const errorCode =
     firstErrorCode ??
     adcpError?.code ??
@@ -1436,7 +1438,9 @@ function validateErrorCode(validation: StoryboardValidation, taskResult: TaskRes
     firstErrorCode !== undefined
       ? '/errors/0/code'
       : adcpError?.code !== undefined
-        ? '/adcp_error/code'
+        ? data?.adcp_error !== undefined
+          ? '/adcp_error/code'
+          : null
         : data?.error_code !== undefined
           ? '/error_code'
           : null;

--- a/test/lib/storyboard-expect-error-failed-payload.test.js
+++ b/test/lib/storyboard-expect-error-failed-payload.test.js
@@ -1,0 +1,127 @@
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { runStoryboard } = require('../../dist/lib/testing/storyboard/runner');
+
+const failedAdcpPayload = {
+  products: [],
+  proposals: [],
+  errors: [
+    {
+      code: 'MULTI_FINALIZE_UNSUPPORTED',
+      message:
+        'Atomic multi-proposal finalize is not supported; sequence individual create_media_buy(proposal_id=...) calls instead.',
+      field: 'refine',
+      recovery: 'correctable',
+    },
+  ],
+  adcp_version: '3.1',
+  status: 'failed',
+};
+
+const topLevelAdcpError = {
+  code: 'INVALID_REQUEST',
+  message: 'Invalid multi-finalize request',
+  field: 'refine',
+  recovery: 'correctable',
+};
+
+function buildStoryboard() {
+  return {
+    id: 'failed_payload_expect_error',
+    version: '1.0.0',
+    title: 'Failed payload expect_error',
+    category: 'test',
+    summary: '',
+    narrative: '',
+    agent: { interaction_model: '*', capabilities: [] },
+    caller: { role: 'buyer_agent' },
+    phases: [
+      {
+        id: 'reject',
+        title: 'reject',
+        steps: [
+          {
+            id: 'multi_finalize',
+            title: 'multi finalize unsupported',
+            task: 'get_products',
+            expect_error: true,
+            contributes_to: 'multi_finalize_handled',
+            sample_request: { buying_mode: 'brief', brief: 'finalize multiple proposals' },
+            validations: [
+              {
+                check: 'error_code',
+                allowed_values: ['MULTI_FINALIZE_UNSUPPORTED', 'INVALID_REQUEST'],
+                description: 'seller rejects atomic multi-proposal finalize',
+              },
+            ],
+          },
+        ],
+      },
+      {
+        id: 'gate',
+        title: 'gate',
+        steps: [
+          {
+            id: 'assert_multi_finalize_handled',
+            title: 'assert multi finalize branch',
+            task: 'assert_contribution',
+            validations: [
+              {
+                check: 'any_of',
+                allowed_values: ['multi_finalize_handled'],
+                description: 'one multi-finalize handling path was credited',
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+describe('storyboard expect_error failed payload normalization (#2179)', () => {
+  test('failed AdCP payloads without TaskResult.success pass expect_error and credit contributions', async () => {
+    const client = {
+      getAgentInfo: async () => ({ name: 'stub', tools: [{ name: 'get_products' }] }),
+      getProducts: async () => ({ data: failedAdcpPayload }),
+    };
+
+    const result = await runStoryboard('https://stub.example/mcp', buildStoryboard(), {
+      protocol: 'mcp',
+      _client: client,
+      _profile: { name: 'stub', tools: [{ name: 'get_products' }] },
+    });
+
+    const rejectStep = result.phases[0].steps[0];
+    const gateStep = result.phases[1].steps[0];
+
+    assert.equal(rejectStep.passed, true);
+    assert.equal(rejectStep.validations[0].passed, true);
+    assert.equal(gateStep.passed, true);
+    assert.equal(gateStep.validations[0].passed, true);
+    assert.equal(result.overall_passed, true);
+  });
+
+  test('top-level adcp_error without data supports expect_error error_code validation', async () => {
+    const client = {
+      getAgentInfo: async () => ({ name: 'stub', tools: [{ name: 'get_products' }] }),
+      getProducts: async () => ({ adcp_error: topLevelAdcpError }),
+    };
+
+    const result = await runStoryboard('https://stub.example/mcp', buildStoryboard(), {
+      protocol: 'mcp',
+      _client: client,
+      _profile: { name: 'stub', tools: [{ name: 'get_products' }] },
+    });
+
+    const rejectStep = result.phases[0].steps[0];
+    const gateStep = result.phases[1].steps[0];
+
+    assert.equal(rejectStep.passed, true);
+    assert.equal(rejectStep.validations[0].passed, true);
+    assert.deepEqual(rejectStep.response_record.payload, { adcp_error: topLevelAdcpError });
+    assert.equal(gateStep.passed, true);
+    assert.equal(result.overall_passed, true);
+  });
+});


### PR DESCRIPTION
Fixes #2179 by normalizing storyboard task success from canonical terminal AdCP error envelopes when SDK adapters omit success: false. The runner now preserves top-level adcp_error for error_code validation and response diagnostics, while advisory success payloads remain successful. Adds adapter and full-run storyboard regression coverage, a patch changeset, and keeps package-lock aligned with the current beta version. Validated with npm run build:lib, targeted Vitest/node tests, and ESLint on the touched storyboard files.