### PR TITLE
fix: support keyed storyboard array matching

### DIFF
--- a/.changeset/finalize-array-wildcards.md
+++ b/.changeset/finalize-array-wildcards.md
@@ -1,0 +1,5 @@
+---
+"@adcp/sdk": patch
+---
+
+Support keyed subset matching for storyboard array wildcard checks.

--- a/src/lib/testing/storyboard/path.ts
+++ b/src/lib/testing/storyboard/path.ts
@@ -6,7 +6,8 @@
  */
 
 /**
- * Wildcard marker produced by `parsePathWithWildcards` for `[*]` segments.
+ * Wildcard marker produced by `parsePathWithWildcards` for `[*]` / `[]`
+ * segments.
  * The plain `parsePath` tokenizer does not emit it — callers that need
  * wildcard semantics (`resolvePathAll`) use the wildcard-aware parser.
  */
@@ -54,17 +55,19 @@ export function parsePath(path: string): Array<string | number> {
 }
 
 /**
- * Parse a path string into segments, preserving `[*]` wildcards.
+ * Parse a path string into segments, preserving `[*]` wildcards. Empty
+ * brackets (`[]`) are accepted as a shorthand wildcard for storyboard
+ * assertions written in the same style as schema prose (`allowed_actions[]`).
  * "products[*].format_ids[*]" → ["products", WILDCARD, "format_ids", WILDCARD]
  */
 export function parsePathWithWildcards(path: string): Array<string | number | typeof WILDCARD> {
   if (path.length > MAX_PATH_LENGTH) return [];
   const segments: Array<string | number | typeof WILDCARD> = [];
-  const re = /([^.\[\]]+)|\[(\d+)\]|\[(\*)\]/g;
+  const re = /([^.\[\]]+)|\[(\d+)\]|\[(\*)?\]/g;
   let match: RegExpExecArray | null;
 
   while ((match = re.exec(path)) !== null) {
-    if (match[3] !== undefined) {
+    if (match[3] !== undefined || match[0] === '[]') {
       segments.push(WILDCARD);
     } else if (match[2] !== undefined) {
       segments.push(parseInt(match[2], 10));
@@ -255,12 +258,18 @@ function walk(current: unknown, segments: Array<string | number | typeof WILDCAR
  * as `~1`.
  */
 export function toJsonPointer(path: string): string {
-  const segments = parsePath(path);
+  const segments = parsePathWithWildcards(path);
   if (segments.length === 0) return '';
   return (
     '/' +
     segments
-      .map(seg => (typeof seg === 'number' ? String(seg) : String(seg).replace(/~/g, '~0').replace(/\//g, '~1')))
+      .map(seg =>
+        seg === WILDCARD
+          ? '*'
+          : typeof seg === 'number'
+            ? String(seg)
+            : String(seg).replace(/~/g, '~0').replace(/\//g, '~1')
+      )
       .join('/')
   );
 }

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -762,15 +762,17 @@ export type StoryboardValidationCheck =
    * `envelope_field_value`.
    */
   | 'envelope_field_pattern'
-  // Wildcard-aware membership check. `path` may include `[*]` segments that
-  // expand to every array element via `resolvePathAll`. Passes when ANY
-  // resolved value matches `value` (or any of `allowed_values`). Lets
-  // storyboards assert presence of an expected entry inside an unordered
-  // array without hardcoding a positional index — e.g.,
-  // `creatives[0].errors[*].code = PROVENANCE_DISCLOSURE_MISSING` passes
-  // regardless of cascade ordering or co-emitted errors. When the path has
-  // no wildcard segments this reduces to scalar equality / array membership
-  // depending on what the path resolves to.
+  // Wildcard-aware membership check. `path` may include `[*]` or `[]`
+  // segments that expand to every array element via `resolvePathAll`.
+  // Passes when ANY resolved value matches `value` (or any of
+  // `allowed_values`). Object and array expectations are matched as deep
+  // subsets, so storyboards can assert keyed entries inside unordered arrays
+  // without hardcoding positions — e.g.,
+  // `creatives[0].errors[*].code = PROVENANCE_DISCLOSURE_MISSING` or
+  // `products[0].allowed_actions[]` with
+  // `{ action: "increase_budget", modes: ["self_serve"] }`.
+  // When the path has no wildcard segments this reduces to scalar equality
+  // / array membership depending on what the path resolves to.
   | 'field_contains'
   | 'status_code'
   | 'error_code'

--- a/src/lib/testing/storyboard/validations.ts
+++ b/src/lib/testing/storyboard/validations.ts
@@ -872,9 +872,9 @@ function containsValueMatches(actual: unknown, expected: unknown): boolean {
 
   if (isRecord(expected)) {
     if (!isRecord(actual)) return false;
-    return Object.entries(expected).every(([key, expectedValue]) =>
-      Object.prototype.hasOwnProperty.call(actual, key) &&
-      containsValueMatches(actual[key], expectedValue)
+    return Object.entries(expected).every(
+      ([key, expectedValue]) =>
+        Object.prototype.hasOwnProperty.call(actual, key) && containsValueMatches(actual[key], expectedValue)
     );
   }
 

--- a/src/lib/testing/storyboard/validations.ts
+++ b/src/lib/testing/storyboard/validations.ts
@@ -745,6 +745,8 @@ function validateFieldPresent(validation: StoryboardValidation, taskResult: Task
       actual: null,
     };
   }
+  const wildcardError = rejectWildcardScalarPath(validation, checkName);
+  if (wildcardError) return wildcardError;
 
   const value = resolvePath(taskResult.data, validation.path);
   const present = value !== undefined && value !== null;
@@ -796,6 +798,8 @@ function validateFieldAbsent(validation: StoryboardValidation, taskResult: TaskR
       actual: null,
     };
   }
+  const wildcardError = rejectWildcardScalarPath(validation, checkName);
+  if (wildcardError) return wildcardError;
 
   const value = resolvePath(taskResult.data, validation.path);
   const absent = value === undefined || value === null;
@@ -834,6 +838,67 @@ function valuesMatch(actual: unknown, expected: unknown): boolean {
   return actual === expected;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+/**
+ * Matching used by `field_contains`.
+ *
+ * Scalar expectations keep exact equality, while object/array expectations are
+ * treated as deep subsets. This lets a storyboard assert the keyed parts of an
+ * unordered response entry such as:
+ *
+ *   path: products[0].allowed_actions[]
+ *   value: { action: "extend_flight", modes: ["requires_approval"] }
+ *
+ * without requiring the seller to omit additional optional fields or keep a
+ * fixed array order.
+ */
+function containsValueMatches(actual: unknown, expected: unknown): boolean {
+  if (Array.isArray(expected)) {
+    if (!Array.isArray(actual)) return false;
+    if (expected.length === 0) return actual.length === 0;
+    const used = new Set<number>();
+    return expected.every(expectedItem => {
+      const matchIndex = actual.findIndex(
+        (actualItem, index) => !used.has(index) && containsValueMatches(actualItem, expectedItem)
+      );
+      if (matchIndex === -1) return false;
+      used.add(matchIndex);
+      return true;
+    });
+  }
+
+  if (isRecord(expected)) {
+    if (!isRecord(actual)) return false;
+    return Object.entries(expected).every(([key, expectedValue]) =>
+      Object.prototype.hasOwnProperty.call(actual, key) &&
+      containsValueMatches(actual[key], expectedValue)
+    );
+  }
+
+  return valuesMatch(actual, expected);
+}
+
+function pathUsesWildcardSyntax(path: string): boolean {
+  return /\[(?:\*|)\]/.test(path);
+}
+
+function rejectWildcardScalarPath(validation: StoryboardValidation, checkName: string): ValidationResult | undefined {
+  if (!validation.path || !pathUsesWildcardSyntax(validation.path)) return undefined;
+  return {
+    check: checkName,
+    passed: false,
+    description: validation.description,
+    path: validation.path,
+    error: `${checkName} does not support wildcard path syntax (${validation.path}); use field_contains for array wildcard membership checks`,
+    json_pointer: toJsonPointer(validation.path),
+    expected: 'path without [] or [*] wildcard syntax',
+    actual: validation.path,
+  };
+}
+
 function validateFieldValue(validation: StoryboardValidation, taskResult: TaskResult): ValidationResult {
   // `check` is either `field_value` or `envelope_field_value` (adcp#3429);
   // result echoes the storyboard's choice so reporters can distinguish.
@@ -850,6 +915,8 @@ function validateFieldValue(validation: StoryboardValidation, taskResult: TaskRe
       actual: null,
     };
   }
+  const wildcardError = rejectWildcardScalarPath(validation, checkName);
+  if (wildcardError) return wildcardError;
 
   const actual = resolvePath(taskResult.data, validation.path);
   const pointer = toJsonPointer(validation.path);
@@ -927,6 +994,8 @@ function validateFieldValueOrAbsent(validation: StoryboardValidation, taskResult
       actual: null,
     };
   }
+  const wildcardError = rejectWildcardScalarPath(validation, checkName);
+  if (wildcardError) return wildcardError;
 
   const rawActual = resolvePath(taskResult.data, validation.path);
   const pointer = toJsonPointer(validation.path);
@@ -1031,6 +1100,8 @@ function validateFieldPattern(validation: StoryboardValidation, taskResult: Task
       actual: null,
     };
   }
+  const wildcardError = rejectWildcardScalarPath(validation, checkName);
+  if (wildcardError) return wildcardError;
 
   const pointer = toJsonPointer(validation.path);
   const expected = { pattern: validation.pattern };
@@ -1108,11 +1179,11 @@ function validateFieldPattern(validation: StoryboardValidation, taskResult: Task
 // ────────────────────────────────────────────────────────────
 // field_contains: wildcard-aware membership check
 //
-// Resolves `path` via `resolvePathAll` (which understands `[*]` segments)
-// and passes when ANY resolved value matches `value` or any of
-// `allowed_values`. Lets storyboards assert "this code appears somewhere
-// in errors[]" without pinning a positional index that breaks if the
-// seller's emit order shifts or co-emits additional errors.
+// Resolves `path` via `resolvePathAll` (which understands `[*]` and `[]`
+// segments) and passes when ANY resolved value matches `value` or any of
+// `allowed_values`. Object/array expectations are deep subset matches, so
+// keyed entries like `allowed_actions[]` can be asserted without pinning a
+// positional index or requiring exact object shape.
 // ────────────────────────────────────────────────────────────
 
 function validateFieldContains(validation: StoryboardValidation, taskResult: TaskResult): ValidationResult {
@@ -1147,7 +1218,7 @@ function validateFieldContains(validation: StoryboardValidation, taskResult: Tas
   const pointer = toJsonPointer(validation.path);
 
   const candidates = validation.allowed_values?.length ? validation.allowed_values : [validation.value];
-  const matched = resolved.some(actual => candidates.some(c => valuesMatch(actual, c)));
+  const matched = resolved.some(actual => candidates.some(c => containsValueMatches(actual, c)));
 
   if (matched) {
     return {

--- a/test/lib/storyboard-validations.test.js
+++ b/test/lib/storyboard-validations.test.js
@@ -1,6 +1,7 @@
 const { describe, it } = require('node:test');
 const assert = require('node:assert');
 const { runValidations } = require('../../dist/lib/testing/storyboard/validations');
+const { toJsonPointer } = require('../../dist/lib/testing/storyboard/path');
 
 function errorCodeValidation(value) {
   return { check: 'error_code', value, description: `Expected ${value}` };
@@ -642,6 +643,164 @@ describe('field_contains (adcp#3803 item 2)', () => {
     assert.strictEqual(result.passed, true, result.error);
   });
 
+  it('passes when any allowed_values object candidate matches as a subset', () => {
+    const taskResult = {
+      success: true,
+      data: {
+        available_actions: [
+          { action: 'cancel', mode: 'requires_approval' },
+          { action: 'increase_budget', mode: 'self_serve', sla: { response_max: 'PT5M' } },
+        ],
+      },
+    };
+    const [result] = runOne(
+      [
+        {
+          check: 'field_contains',
+          path: 'available_actions[]',
+          allowed_values: [
+            { action: 'extend_flight', mode: 'requires_approval' },
+            { action: 'increase_budget', sla: { response_max: 'PT5M' } },
+          ],
+          description: 'one keyed action candidate is acceptable',
+        },
+      ],
+      'create_media_buy',
+      taskResult
+    );
+    assert.strictEqual(result.passed, true, result.error);
+  });
+
+  it('treats [] as an array wildcard for keyed allowed_actions subset matches', () => {
+    const taskResult = {
+      success: true,
+      data: {
+        products: [
+          {
+            product_id: 'available_actions_display',
+            allowed_actions: [
+              {
+                action: 'cancel',
+                modes: ['requires_approval'],
+                allowed_statuses: ['active'],
+                terms_ref: 'terms://available-actions/cancel',
+              },
+              {
+                action: 'increase_budget',
+                modes: ['self_serve', 'automatic'],
+                sla: { response_max: 'PT5M', completion_max: 'PT1H' },
+              },
+              {
+                action: 'extend_flight',
+                modes: ['requires_approval'],
+                sla: { response_max: 'PT1H' },
+                terms_ref: 'terms://available-actions/extension',
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    const [result] = runOne(
+      [
+        {
+          check: 'field_contains',
+          path: 'products[0].allowed_actions[]',
+          value: {
+            action: 'increase_budget',
+            modes: ['self_serve'],
+            sla: { response_max: 'PT5M' },
+          },
+          description: 'increase_budget allowed action is present regardless of ordering or optional fields',
+        },
+      ],
+      'get_products',
+      taskResult
+    );
+
+    assert.strictEqual(result.passed, true, result.error);
+    assert.strictEqual(result.json_pointer, '/products/0/allowed_actions/*');
+  });
+
+  it('fails when an explicit empty nested array expectation is not actually empty', () => {
+    const taskResult = {
+      success: true,
+      data: {
+        available_actions: [{ action: 'increase_budget', modes: ['self_serve'] }],
+      },
+    };
+
+    const [result] = runOne(
+      [
+        {
+          check: 'field_contains',
+          path: 'available_actions[]',
+          value: { action: 'increase_budget', modes: [] },
+          description: 'empty expected modes means modes must be empty',
+        },
+      ],
+      'create_media_buy',
+      taskResult
+    );
+
+    assert.strictEqual(result.passed, false);
+    assert.match(result.error, /increase_budget/);
+  });
+
+  it('fails when duplicate expected array items would reuse one actual item', () => {
+    const taskResult = {
+      success: true,
+      data: {
+        available_actions: [{ action: 'increase_budget', modes: ['self_serve'] }],
+      },
+    };
+
+    const [result] = runOne(
+      [
+        {
+          check: 'field_contains',
+          path: 'available_actions[]',
+          value: { action: 'increase_budget', modes: ['self_serve', 'self_serve'] },
+          description: 'duplicate expected modes require duplicate actual modes',
+        },
+      ],
+      'create_media_buy',
+      taskResult
+    );
+
+    assert.strictEqual(result.passed, false);
+  });
+
+  it('fails keyed subset matching when the matching array entry has the wrong nested value', () => {
+    const taskResult = {
+      success: true,
+      data: {
+        available_actions: [
+          { action: 'cancel', mode: 'requires_approval' },
+          { action: 'increase_budget', mode: 'self_serve' },
+        ],
+      },
+    };
+
+    const [result] = runOne(
+      [
+        {
+          check: 'field_contains',
+          path: 'available_actions[]',
+          value: { action: 'increase_budget', mode: 'requires_approval' },
+          description: 'same keyed action must also match the requested mode',
+        },
+      ],
+      'create_media_buy',
+      taskResult
+    );
+
+    assert.strictEqual(result.passed, false);
+    assert.match(result.error, /increase_budget/);
+    assert.deepStrictEqual(result.actual, taskResult.data.available_actions);
+  });
+
   it('fails when no resolved value matches', () => {
     const taskResult = {
       success: true,
@@ -738,7 +897,33 @@ describe('field_contains (adcp#3803 item 2)', () => {
     // toJsonPointer renders [*] as /* (literal asterisk) — `*` isn't a
     // forbidden character in RFC 6901, so it round-trips unescaped.
     assert.strictEqual(result.json_pointer, '/creatives/0/errors/*/code');
+    assert.strictEqual(toJsonPointer('allowed_actions[]'), '/allowed_actions/*');
   });
+});
+
+describe('scalar field checks reject wildcard path syntax', () => {
+  for (const validation of [
+    { check: 'field_present', path: 'available_actions[]', description: 'present wildcard rejected' },
+    { check: 'field_absent', path: 'available_actions[]', description: 'absent wildcard rejected' },
+    { check: 'field_value', path: 'available_actions[]', value: [], description: 'value wildcard rejected' },
+    {
+      check: 'field_value_or_absent',
+      path: 'available_actions[]',
+      value: [],
+      description: 'value_or_absent wildcard rejected',
+    },
+    { check: 'field_pattern', path: 'available_actions[]', pattern: 'x', description: 'pattern wildcard rejected' },
+  ]) {
+    it(`${validation.check} rejects [] wildcard shorthand`, () => {
+      const [result] = runOne([validation], 'create_media_buy', {
+        success: true,
+        data: { available_actions: [] },
+      });
+      assert.strictEqual(result.passed, false);
+      assert.match(result.error, /does not support wildcard path syntax/);
+      assert.strictEqual(result.expected, 'path without [] or [*] wildcard syntax');
+    });
+  }
 });
 
 describe('array_length (adcp#4685 / adcp-client#1830)', () => {


### PR DESCRIPTION
Adds [] wildcard shorthand for storyboard array paths and deep subset matching for field_contains, so unordered keyed arrays like allowed_actions[] can be validated without positional assumptions. Scalar field checks now reject wildcard path syntax instead of silently resolving the parent array. This also preserves the existing multi-finalize expect_error contribution path for #2179 while covering the array matcher regression for #2182. Validated with npm run build:lib and focused storyboard validation tests.