### PR TITLE
feat(registry): add community mirror upsert helper

### DIFF
--- a/.changeset/community-mirror-create-upsert.md
+++ b/.changeset/community-mirror-create-upsert.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': minor
+---
+
+Add RegistryClient.upsertCommunityMirrorAdagents for keyed community-mirror publishes, while keeping createCommunityMirrorAdagents as the generator-only helper.

--- a/README.md
+++ b/README.md
@@ -691,7 +691,18 @@ const catalog = buildCommunityMirrorAdagents({
 await new RegistryClient().createAdagents(catalog);
 ```
 
-`RegistryClient.createAdagents()` and `createCommunityMirrorAdagents()` are intended for build-time generation, cache fills, or write-through publishing. Public `/.well-known/adagents.json` routes should serve generated JSON from static storage or an application cache rather than calling the registry on every request.
+`RegistryClient.createAdagents()` and `createCommunityMirrorAdagents()` are intended for build-time generation and cache fills. Public `/.well-known/adagents.json` routes should serve generated JSON from static storage or an application cache rather than calling the registry on every request.
+
+To persist an AAO/community mirror in the registry, use the keyed upsert path:
+
+```typescript
+await new RegistryClient({ apiKey: process.env.ADCP_REGISTRY_API_KEY }).upsertCommunityMirrorAdagents('meta', {
+  catalog_etag: 'meta-creative-formats-2026-05',
+  formats: catalog.formats,
+});
+```
+
+`upsertCommunityMirrorAdagents()` writes to the hosted mirror lifecycle endpoint, while `createCommunityMirrorAdagents()` remains a side-effect-free generator helper.
 
 ## Database Schema
 

--- a/README.md
+++ b/README.md
@@ -700,6 +700,12 @@ await new RegistryClient({ apiKey: process.env.ADCP_REGISTRY_API_KEY }).upsertCo
   catalog_etag: 'meta-creative-formats-2026-05',
   formats: catalog.formats,
 });
+
+await new RegistryClient({ apiKey: process.env.ADCP_REGISTRY_API_KEY }).upsertCommunityMirrorAdagents({
+  platform: 'meta',
+  catalog_etag: 'meta-creative-formats-2026-05',
+  formats: catalog.formats,
+});
 ```
 
 `upsertCommunityMirrorAdagents()` writes to the hosted mirror lifecycle endpoint, while `createCommunityMirrorAdagents()` remains a side-effect-free generator helper.

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -49,6 +49,7 @@ export type {
   AdagentsPlacementTag,
   CreatedAdagentsJson,
   CommunityMirrorAdagentsConfig,
+  CreateCommunityMirrorAdagentsConfig,
   CommunityMirrorAdagentsCatalog,
   PublishCommunityMirrorAdagentsResponse,
   CommunityMirrorAdagentsSummary,

--- a/src/lib/registry/create-adagents.type-checks.ts
+++ b/src/lib/registry/create-adagents.type-checks.ts
@@ -8,6 +8,7 @@ import type {
   AdagentsPlacementDefinition,
   CreateAdagentsRequest,
   CommunityMirrorAdagentsConfig,
+  CreateCommunityMirrorAdagentsConfig,
 } from './types';
 
 const metaFeedImageFormat: AdagentsCatalogFormat = {
@@ -50,6 +51,11 @@ const communityMirrorConfig: CommunityMirrorAdagentsConfig = {
   },
 };
 
+const communityMirrorPublishConfig: CreateCommunityMirrorAdagentsConfig = {
+  ...communityMirrorConfig,
+  platform: 'meta',
+};
+
 const communityMirrorManifest: CreateAdagentsRequest = buildCommunityMirrorAdagents(communityMirrorConfig);
 void communityMirrorManifest;
 
@@ -70,7 +76,10 @@ void directCreateRequest;
 
 async function registryListCompatibility(client: RegistryClient): Promise<void> {
   await client.listAgents({ type: 'si' });
+  await client.previewCommunityMirrorAdagents(communityMirrorConfig);
   await client.createCommunityMirrorAdagents(communityMirrorConfig);
+  await client.upsertCommunityMirrorAdagents(communityMirrorPublishConfig);
+  await client.upsertCommunityMirrorAdagents('meta', communityMirrorConfig);
   await client.publishCommunityMirrorAdagents('meta', communityMirrorConfig);
 
   const mirror = await client.getCommunityMirrorAdagents('meta');

--- a/src/lib/registry/index.ts
+++ b/src/lib/registry/index.ts
@@ -782,7 +782,9 @@ export class RegistryClient {
    *
    * This persists the mirror under `/api/registry/mirrors/:platform`. Use
    * `previewCommunityMirrorAdagents()` when you only need to validate or
-   * preview the generated document without saving it.
+   * preview the generated document without saving it. Use
+   * `upsertCommunityMirrorAdagents(...)` when you want the client to infer the
+   * platform key from config.
    *
    * @remarks
    * Catalog content may include registry-supplied strings. Treat them as
@@ -1079,8 +1081,9 @@ export class RegistryClient {
   }
 
   private communityMirrorPlatformFromConfig(config: CreateCommunityMirrorAdagentsConfig): string {
-    if (typeof config.platform === 'string' && config.platform.trim()) {
-      return config.platform;
+    if (typeof config.platform === 'string') {
+      const platform = config.platform.trim();
+      if (platform) return platform;
     }
 
     const properties = (config as { properties?: unknown }).properties;

--- a/src/lib/registry/index.ts
+++ b/src/lib/registry/index.ts
@@ -22,6 +22,7 @@ import type {
   CreateAdagentsRequest,
   CreateAdagentsResponse,
   CommunityMirrorAdagentsConfig,
+  CreateCommunityMirrorAdagentsConfig,
   CommunityMirrorAdagentsCatalog,
   PublishCommunityMirrorAdagentsResponse,
   ListCommunityMirrorAdagentsResponse,
@@ -96,6 +97,7 @@ export type {
   AdagentsPlacementTag,
   CreatedAdagentsJson,
   CommunityMirrorAdagentsConfig,
+  CreateCommunityMirrorAdagentsConfig,
   CommunityMirrorAdagentsCatalog,
   PublishCommunityMirrorAdagentsResponse,
   CommunityMirrorAdagentsSummary,
@@ -193,6 +195,7 @@ export function buildCommunityMirrorAdagents(config: CommunityMirrorAdagentsConf
     authorized_agents?: unknown;
     include_schema?: unknown;
     include_timestamp?: unknown;
+    platform?: unknown;
   };
   if ('authorized_agents' in maybeConfig) {
     throw new Error('authorized_agents is not accepted for community mirror adagents catalogs');
@@ -207,8 +210,10 @@ export function buildCommunityMirrorAdagents(config: CommunityMirrorAdagentsConf
     throw new Error('formats must contain at least one catalog format');
   }
 
+  const { platform: _platform, ...catalogConfig } = maybeConfig;
+
   return {
-    ...config,
+    ...catalogConfig,
     authorized_agents: [],
   };
 }
@@ -734,21 +739,54 @@ export class RegistryClient {
   /**
    * Build and submit a catalog-only community mirror adagents.json descriptor.
    *
-   * This is the high-level helper for AAO/community mirror catalog publication.
+   * This uses the registry generator endpoint and does not persist a mirror.
    * It emits `authorized_agents: []` and refuses caller-supplied authorization
-   * entries; use `createAdagents()` directly only for seller-authorized hosted
-   * publisher files.
+   * entries; use `publishCommunityMirrorAdagents(platform, config)` or
+   * `upsertCommunityMirrorAdagents(...)` to publish or update a hosted
+   * community mirror catalog.
    */
   async createCommunityMirrorAdagents(config: CommunityMirrorAdagentsConfig): Promise<CreateAdagentsResponse> {
     return this.createAdagents(buildCommunityMirrorAdagents(config));
   }
 
   /**
+   * Alias for `createCommunityMirrorAdagents()` that makes the generator-only
+   * behavior explicit at call sites.
+   */
+  async previewCommunityMirrorAdagents(config: CommunityMirrorAdagentsConfig): Promise<CreateAdagentsResponse> {
+    return this.createCommunityMirrorAdagents(config);
+  }
+
+  /**
+   * Publish or update a catalog-only community mirror adagents.json descriptor
+   * using a stable platform key from the first argument, `config.platform`, or a
+   * single consistent `properties[].platform` value.
+   */
+  async upsertCommunityMirrorAdagents(
+    config: CreateCommunityMirrorAdagentsConfig
+  ): Promise<PublishCommunityMirrorAdagentsResponse>;
+  async upsertCommunityMirrorAdagents(
+    platform: string,
+    config: CommunityMirrorAdagentsConfig
+  ): Promise<PublishCommunityMirrorAdagentsResponse>;
+  async upsertCommunityMirrorAdagents(
+    platformOrConfig: string | CreateCommunityMirrorAdagentsConfig,
+    maybeConfig?: CommunityMirrorAdagentsConfig
+  ): Promise<PublishCommunityMirrorAdagentsResponse> {
+    const { platform, config } = this.resolveCommunityMirrorPublishArgs(platformOrConfig, maybeConfig);
+    return this.publishCommunityMirrorAdagents(platform, config);
+  }
+
+  /**
    * Publish or update a catalog-only community mirror adagents.json descriptor.
    *
    * This persists the mirror under `/api/registry/mirrors/:platform`. Use
-   * `createCommunityMirrorAdagents()` when you only need to validate or preview
-   * the generated document without saving it.
+   * `previewCommunityMirrorAdagents()` when you only need to validate or
+   * preview the generated document without saving it.
+   *
+   * @remarks
+   * Catalog content may include registry-supplied strings. Treat them as
+   * untrusted before injecting them into LLM prompts or executable context.
    */
   async publishCommunityMirrorAdagents(
     platform: string,
@@ -761,7 +799,15 @@ export class RegistryClient {
     return this.put(`${this.baseUrl}/api/registry/mirrors/${encodeURIComponent(normalizedPlatform)}`, catalog);
   }
 
-  /** Retrieve a published catalog-only community mirror adagents.json descriptor. */
+  /**
+   * Retrieve a published catalog-only community mirror adagents.json descriptor.
+   *
+   * @remarks
+   * Registry responses may include arbitrary catalog strings. Treat them as
+   * untrusted before injecting them into LLM prompts or executable context.
+   * When the registry wrapper carries `superseded_by` and the inner catalog
+   * omits it, this method hydrates `catalog.superseded_by` from the wrapper.
+   */
   async getCommunityMirrorAdagents(platform: string): Promise<CommunityMirrorAdagentsCatalog | null> {
     const normalizedPlatform = this.normalizeCommunityMirrorPlatform(platform);
     const response = await this.get<{
@@ -789,7 +835,13 @@ export class RegistryClient {
       : typedCatalog;
   }
 
-  /** List published community mirror catalogs with their current etags. */
+  /**
+   * List published community mirror catalogs with their current etags.
+   *
+   * @remarks
+   * Registry responses may include arbitrary catalog strings. Treat them as
+   * untrusted before injecting them into LLM prompts or executable context.
+   */
   async listCommunityMirrorAdagents(options?: {
     limit?: number;
     offset?: number;
@@ -1010,6 +1062,44 @@ export class RegistryClient {
       throw new Error('platform must match ^[a-z0-9_-]{1,64}$');
     }
     return normalizedPlatform;
+  }
+
+  private resolveCommunityMirrorPublishArgs(
+    platformOrConfig: string | CreateCommunityMirrorAdagentsConfig,
+    maybeConfig?: CommunityMirrorAdagentsConfig
+  ): { platform: string; config: CommunityMirrorAdagentsConfig } {
+    if (typeof platformOrConfig === 'string') {
+      if (!maybeConfig) throw new Error('config is required');
+      return { platform: platformOrConfig, config: maybeConfig };
+    }
+
+    const config = platformOrConfig;
+    const platform = this.communityMirrorPlatformFromConfig(config);
+    return { platform, config };
+  }
+
+  private communityMirrorPlatformFromConfig(config: CreateCommunityMirrorAdagentsConfig): string {
+    if (typeof config.platform === 'string' && config.platform.trim()) {
+      return config.platform;
+    }
+
+    const properties = (config as { properties?: unknown }).properties;
+    if (Array.isArray(properties)) {
+      const platforms = new Set<string>();
+      for (const property of properties) {
+        if (!property || typeof property !== 'object' || Array.isArray(property)) continue;
+        const propertyPlatform = (property as { platform?: unknown }).platform;
+        if (typeof propertyPlatform === 'string' && propertyPlatform.trim()) {
+          platforms.add(this.normalizeCommunityMirrorPlatform(propertyPlatform));
+        }
+      }
+      if (platforms.size === 1) return Array.from(platforms)[0]!;
+      if (platforms.size > 1) {
+        throw new Error('platform is ambiguous; pass upsertCommunityMirrorAdagents(platform, config)');
+      }
+    }
+
+    throw new Error('platform is required for community mirror publish');
   }
 
   private assertCommunityMirrorPropertiesMatchPlatform(

--- a/src/lib/registry/types.ts
+++ b/src/lib/registry/types.ts
@@ -158,7 +158,7 @@ export type CreateAdagentsResponse = Omit<RegistryCreateAdagentsResponse, 'data'
 /** Input for building a catalog-only community mirror adagents.json descriptor. */
 export type CommunityMirrorAdagentsConfig = Omit<
   CreateAdagentsRequest,
-  'authorized_agents' | 'catalog_etag' | 'formats' | 'include_schema' | 'include_timestamp'
+  'authorized_agents' | 'catalog_etag' | 'formats' | 'include_schema' | 'include_timestamp' | 'platform'
 > & {
   /** Community mirror catalogs should be cacheable static artifacts with stable content identity. */
   catalog_etag: string;
@@ -174,10 +174,19 @@ export type CommunityMirrorAdagentsConfig = Omit<
   include_timestamp?: never;
 };
 
+/** Input for publishing/upserting a catalog-only community mirror descriptor. */
+export type CreateCommunityMirrorAdagentsConfig = CommunityMirrorAdagentsConfig & {
+  /**
+   * Stable platform key for the hosted mirror. If omitted, RegistryClient can
+   * infer it only when every `properties[].platform` value is the same.
+   */
+  platform?: string;
+};
+
 /** Catalog-only community mirror adagents.json descriptor. */
 export type CommunityMirrorAdagentsCatalog = Omit<
   CreateAdagentsRequest,
-  'authorized_agents' | 'catalog_etag' | 'formats' | 'include_schema' | 'include_timestamp'
+  'authorized_agents' | 'catalog_etag' | 'formats' | 'include_schema' | 'include_timestamp' | 'platform'
 > & {
   authorized_agents: [];
   catalog_etag: string;

--- a/test/lib/registry.test.js
+++ b/test/lib/registry.test.js
@@ -1699,8 +1699,10 @@ describe('RegistryClient', () => {
 
     test('passes catalog-only community mirror fields through to the registry', async () => {
       const created = { success: true, data: { success: true, adagents_json: {} } };
+      let capturedUrl;
       let capturedOpts;
       restore = mockFetch(async (url, opts) => {
+        capturedUrl = url;
         capturedOpts = opts;
         return new Response(JSON.stringify(created), { status: 200 });
       });
@@ -1722,6 +1724,7 @@ describe('RegistryClient', () => {
       const client = new RegistryClient();
       await client.createAdagents(config);
 
+      assert.ok(capturedUrl.endsWith('/api/adagents/create'));
       const body = JSON.parse(capturedOpts.body);
       assert.deepStrictEqual(body.authorized_agents, []);
       assert.strictEqual(body.catalog_etag, 'meta-creative-formats-2026-05');
@@ -1732,6 +1735,7 @@ describe('RegistryClient', () => {
 
     test('builds community mirror catalogs without authorization claims', () => {
       const catalog = buildCommunityMirrorAdagents({
+        platform: 'meta',
         catalog_etag: 'meta-creative-formats-2026-05',
         formats: [
           {
@@ -1753,6 +1757,7 @@ describe('RegistryClient', () => {
       });
 
       assert.deepStrictEqual(catalog.authorized_agents, []);
+      assert.strictEqual(catalog.platform, undefined);
       assert.strictEqual(catalog.catalog_etag, 'meta-creative-formats-2026-05');
       assert.strictEqual(catalog.formats[0].format_kind, 'image');
       assert.strictEqual(catalog.placements[0].format_options[0].format_option_id, 'meta-feed-image');
@@ -1786,10 +1791,12 @@ describe('RegistryClient', () => {
       );
     });
 
-    test('creates community mirror catalogs via the high-level helper', async () => {
+    test('creates community mirror catalogs via the generator endpoint', async () => {
       const created = { success: true, data: { success: true, adagents_json: {} } };
+      let capturedUrl;
       let capturedOpts;
       restore = mockFetch(async (url, opts) => {
+        capturedUrl = url;
         capturedOpts = opts;
         return new Response(JSON.stringify(created), { status: 200 });
       });
@@ -1800,6 +1807,152 @@ describe('RegistryClient', () => {
         formats: [{ format_option_id: 'meta-feed-image', format_kind: 'image', params: { width: 1080, height: 1080 } }],
       });
 
+      assert.ok(capturedUrl.endsWith('/api/adagents/create'));
+      assert.strictEqual(capturedOpts.method, 'POST');
+      const body = JSON.parse(capturedOpts.body);
+      assert.deepStrictEqual(body.authorized_agents, []);
+      assert.strictEqual(body.catalog_etag, 'meta-creative-formats-2026-05');
+    });
+
+    test('upserts community mirror catalogs via keyed helper', async () => {
+      const published = {
+        success: true,
+        platform: 'meta',
+        catalog_etag: 'meta-creative-formats-2026-05',
+        superseded_by: null,
+        updated_at: '2026-06-05T12:00:00.000Z',
+      };
+      let capturedUrl;
+      let capturedOpts;
+      restore = mockFetch(async (url, opts) => {
+        capturedUrl = url;
+        capturedOpts = opts;
+        return new Response(JSON.stringify(published), { status: 200 });
+      });
+
+      const client = new RegistryClient({ apiKey: 'sk_test' });
+      const result = await client.upsertCommunityMirrorAdagents({
+        platform: 'Meta',
+        catalog_etag: 'meta-creative-formats-2026-05',
+        formats: [{ format_option_id: 'meta-feed-image', format_kind: 'image', params: { width: 1080, height: 1080 } }],
+      });
+
+      assert.strictEqual(result.platform, 'meta');
+      assert.ok(capturedUrl.endsWith('/api/registry/mirrors/meta'));
+      assert.strictEqual(capturedOpts.method, 'PUT');
+      assert.strictEqual(capturedOpts.headers.Authorization, 'Bearer sk_test');
+      const body = JSON.parse(capturedOpts.body);
+      assert.deepStrictEqual(body.authorized_agents, []);
+      assert.strictEqual(body.catalog_etag, 'meta-creative-formats-2026-05');
+      assert.strictEqual(body.platform, undefined);
+    });
+
+    test('upsertCommunityMirrorAdagents accepts platform as first argument', async () => {
+      let capturedUrl;
+      restore = mockFetch(async url => {
+        capturedUrl = url;
+        return new Response(
+          JSON.stringify({
+            success: true,
+            platform: 'meta',
+            catalog_etag: 'meta-creative-formats-2026-05',
+            superseded_by: null,
+            updated_at: '2026-06-05T12:00:00.000Z',
+          }),
+          { status: 200 }
+        );
+      });
+
+      const client = new RegistryClient({ apiKey: 'sk_test' });
+      await client.upsertCommunityMirrorAdagents('Meta', {
+        catalog_etag: 'meta-creative-formats-2026-05',
+        formats: [{ format_option_id: 'meta-feed-image', format_kind: 'image', params: { width: 1080, height: 1080 } }],
+      });
+
+      assert.ok(capturedUrl.endsWith('/api/registry/mirrors/meta'));
+    });
+
+    test('upsertCommunityMirrorAdagents infers platform from a single property platform', async () => {
+      let capturedUrl;
+      restore = mockFetch(async url => {
+        capturedUrl = url;
+        return new Response(
+          JSON.stringify({
+            success: true,
+            platform: 'meta',
+            catalog_etag: 'meta-creative-formats-2026-05',
+            superseded_by: null,
+            updated_at: '2026-06-05T12:00:00.000Z',
+          }),
+          { status: 200 }
+        );
+      });
+
+      const client = new RegistryClient({ apiKey: 'sk_test' });
+      await client.upsertCommunityMirrorAdagents({
+        catalog_etag: 'meta-creative-formats-2026-05',
+        properties: [{ domain: 'creative.adcontextprotocol.org', platform: 'Meta' }],
+        formats: [{ format_option_id: 'meta-feed-image', format_kind: 'image', params: { width: 1080, height: 1080 } }],
+      });
+
+      assert.ok(capturedUrl.endsWith('/api/registry/mirrors/meta'));
+    });
+
+    test('upsertCommunityMirrorAdagents requires a platform identity', async () => {
+      const client = new RegistryClient({ apiKey: 'sk_test' });
+      await assert.rejects(
+        () =>
+          client.upsertCommunityMirrorAdagents({
+            catalog_etag: 'meta-creative-formats-2026-05',
+            formats: [
+              { format_option_id: 'meta-feed-image', format_kind: 'image', params: { width: 1080, height: 1080 } },
+            ],
+          }),
+        /platform is required for community mirror publish/
+      );
+    });
+
+    test('upsertCommunityMirrorAdagents rejects ambiguous property platforms', async () => {
+      const client = new RegistryClient({ apiKey: 'sk_test' });
+      await assert.rejects(
+        () =>
+          client.upsertCommunityMirrorAdagents({
+            catalog_etag: 'meta-creative-formats-2026-05',
+            properties: [
+              { domain: 'creative.adcontextprotocol.org', platform: 'meta' },
+              { domain: 'creative.adcontextprotocol.org', platform: 'tiktok' },
+            ],
+            formats: [
+              { format_option_id: 'meta-feed-image', format_kind: 'image', params: { width: 1080, height: 1080 } },
+            ],
+          }),
+        /platform is ambiguous; pass upsertCommunityMirrorAdagents\(platform, config\)/
+      );
+    });
+
+    test('upsertCommunityMirrorAdagents requires config with first-argument platform', async () => {
+      const client = new RegistryClient({ apiKey: 'sk_test' });
+      await assert.rejects(() => client.upsertCommunityMirrorAdagents('meta'), /config is required/);
+    });
+
+    test('previews community mirror catalogs via the generator endpoint', async () => {
+      const created = { success: true, data: { success: true, adagents_json: {} } };
+      let capturedUrl;
+      let capturedOpts;
+      restore = mockFetch(async (url, opts) => {
+        capturedUrl = url;
+        capturedOpts = opts;
+        return new Response(JSON.stringify(created), { status: 200 });
+      });
+
+      const client = new RegistryClient();
+      await client.previewCommunityMirrorAdagents({
+        catalog_etag: 'meta-creative-formats-2026-05',
+        formats: [{ format_option_id: 'meta-feed-image', format_kind: 'image', params: { width: 1080, height: 1080 } }],
+      });
+
+      assert.ok(capturedUrl.endsWith('/api/adagents/create'));
+      assert.strictEqual(capturedOpts.method, 'POST');
       const body = JSON.parse(capturedOpts.body);
       assert.deepStrictEqual(body.authorized_agents, []);
       assert.strictEqual(body.catalog_etag, 'meta-creative-formats-2026-05');


### PR DESCRIPTION
## Summary

Fixes #2175 and addresses #2176.

- keeps `createCommunityMirrorAdagents()` as the backward-compatible generator-only helper that POSTs to `/api/adagents/create`
- adds explicit `previewCommunityMirrorAdagents()` alias for generator/validation call sites
- adds `upsertCommunityMirrorAdagents()` for persisted community mirror writes via `/api/registry/mirrors/:platform`, with platform inference for single-platform configs
- documents the generator vs persisted-write split and exports the new config type
- adds registry tests for route/body shape, explicit and inferred platform keys, ambiguous/missing platform errors, and the read/list lifecycle helpers

## Expert Review

- code-reviewer: approved after `createCommunityMirrorAdagents()` was restored to generator-only behavior and the new upsert helper was added.
- protocol_reviewer: approved after the changeset was changed from patch to minor for the additive public API.
- nodejs-testing-expert: approved the registry coverage and noted no remaining test blockers.

## Validation

- `npm run ci:quick`
- `npm run build:lib`
- `npm run typecheck`
- `npm run format:check`
- `NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/lib/registry.test.js`
- `npx commitlint --from origin/main --to HEAD --verbose`
- `node .github/scripts/check-pr-title.cjs "feat(registry): add community mirror upsert helper"`
