### PR TITLE
fix: repair latest compliance metadata version

### DIFF
--- a/.changeset/fix-latest-compliance-version.md
+++ b/.changeset/fix-latest-compliance-version.md
@@ -1,0 +1,6 @@
+---
+'@adcp/sdk': patch
+---
+
+Repair local compliance bundles whose `latest` selector leaked into `ComplianceIndex.adcp_version` by deriving the
+real AdCP version from the matching schema bundle before storyboard execution.

--- a/src/lib/testing/storyboard/compliance.ts
+++ b/src/lib/testing/storyboard/compliance.ts
@@ -9,7 +9,7 @@
  */
 
 import { readFileSync, readdirSync, existsSync, statSync } from 'fs';
-import { dirname, join, resolve } from 'path';
+import { basename, dirname, join, resolve } from 'path';
 import { loadStoryboardFile } from './loader';
 import { ADCP_VERSION } from '../../version';
 import { ADCPError } from '../../errors';
@@ -94,6 +94,7 @@ export interface ComplianceIndexSpecialism {
 }
 
 export interface ComplianceIndex {
+  published_version?: string;
   adcp_version: string;
   generated_at: string;
   universal: string[];
@@ -229,31 +230,208 @@ export function loadComplianceIndex(options: ResolveOptions = {}): ComplianceInd
     throw new Error(complianceMissingMessage('Compliance cache', dir));
   }
   const index = JSON.parse(readFileSync(indexPath, 'utf-8')) as ComplianceIndex;
-  return index;
+  return normalizeComplianceIndex(index, options, indexPath);
 }
 
 export function getExternalSchemaRootForCompliance(options: ResolveOptions, adcpVersion: string): string | undefined {
-  if (options.schemaRoot) {
-    return options.schemaRoot;
-  }
+  const configuredSchemaRoot = getConfiguredSchemaRoot(options);
+  if (configuredSchemaRoot) return configuredSchemaRoot;
   if (!options.complianceDir) return undefined;
   return findExternalSchemaRoot(options.complianceDir, adcpVersion);
 }
 
+function getConfiguredSchemaRoot(options: Pick<ResolveOptions, 'schemaRoot'>): string | undefined {
+  return options.schemaRoot ?? process.env.ADCP_SCHEMA_ROOT;
+}
+
+function normalizeComplianceIndex(index: ComplianceIndex, options: ResolveOptions, indexPath: string): ComplianceIndex {
+  if (index.adcp_version === 'latest') {
+    const repairedVersion = findReplacementForLatestComplianceVersion(index, options);
+    if (repairedVersion) {
+      return { ...index, adcp_version: repairedVersion };
+    }
+  }
+
+  assertValidComplianceIndexVersion(index.adcp_version, indexPath);
+  return index;
+}
+
+function findReplacementForLatestComplianceVersion(
+  index: ComplianceIndex,
+  options: ResolveOptions
+): string | undefined {
+  if (isValidComplianceIndexVersion(index.published_version)) return index.published_version;
+
+  const schemaRoot = getConfiguredSchemaRoot(options);
+  const configuredVersion = schemaRoot ? readSchemaRootAdcpVersion(schemaRoot) : undefined;
+  if (configuredVersion) return configuredVersion;
+
+  if (!options.complianceDir) return undefined;
+  return readSiblingSchemaAdcpVersion(options.complianceDir);
+}
+
+function readSchemaRootAdcpVersion(schemaRoot: string): string | undefined {
+  const roots = [schemaRoot];
+  if (basename(schemaRoot) === 'bundled') roots.push(dirname(schemaRoot));
+
+  for (const root of roots) {
+    const indexPath = join(root, 'index.json');
+    if (!existsSync(indexPath)) continue;
+    try {
+      const parsed = JSON.parse(readFileSync(indexPath, 'utf-8')) as { adcp_version?: unknown };
+      if (isValidComplianceIndexVersion(parsed.adcp_version)) return parsed.adcp_version;
+    } catch {
+      // Schema-root discovery is best-effort; the final compliance-index
+      // validation below owns the actionable error when no replacement exists.
+    }
+  }
+  for (const root of roots) {
+    const version = readSchemaIdVersion(root);
+    if (version) return version;
+  }
+  return undefined;
+}
+
+function readSchemaIdVersion(root: string): string | undefined {
+  const versions = new Set<string>();
+  const scanRoot = existsSync(join(root, 'bundled')) ? join(root, 'bundled') : root;
+  for (const file of walkJsonFiles(scanRoot)) {
+    try {
+      const parsed = JSON.parse(readFileSync(file, 'utf-8')) as { $id?: unknown };
+      if (typeof parsed.$id !== 'string') continue;
+      const version = parsed.$id.match(/\/schemas\/([^/]+)\//)?.[1];
+      if (isValidComplianceIndexVersion(version)) versions.add(version);
+    } catch {
+      // Best-effort discovery; malformed schemas are handled by validation.
+    }
+  }
+  return versions.size === 1 ? [...versions][0] : undefined;
+}
+
+function readSiblingSchemaAdcpVersion(complianceDir: string): string | undefined {
+  for (const schemaRoot of schemaRootCandidatesForComplianceDir(complianceDir)) {
+    const version = readSchemaRootAdcpVersion(schemaRoot);
+    if (version) return version;
+  }
+  return undefined;
+}
+
+function isValidComplianceIndexVersion(version: unknown): version is string {
+  if (typeof version !== 'string') return false;
+  try {
+    resolveBundleKey(version);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function assertValidComplianceIndexVersion(version: string, indexPath: string): void {
+  try {
+    resolveBundleKey(version);
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `Compliance cache ${indexPath} declares invalid adcp_version ${JSON.stringify(version)}. ` +
+        `adcp_version must be a real AdCP bundle version, not a selector alias such as "latest". ` +
+        `If this is a local development bundle, pass ADCP_SCHEMA_ROOT or --schema-root pointing at the matching schema bundle. ` +
+        reason
+    );
+  }
+}
+
 function findExternalSchemaRoot(complianceDir: string, adcpVersion: string): string | undefined {
-  const key = resolveBundleKey(adcpVersion);
-  const packageRoot = dirname(dirname(dirname(resolve(complianceDir))));
-  const candidates = [
-    complianceDir,
-    join(packageRoot, 'dist', 'lib', 'schemas-data', key),
-    join(packageRoot, 'schemas', 'cache', adcpVersion),
-    join(packageRoot, 'schemas', 'cache', key),
-  ];
+  const candidates = [complianceDir, ...schemaRootCandidatesForComplianceDir(complianceDir, adcpVersion)];
   return candidates.find(hasSchemaRootShape);
 }
 
+function schemaRootCandidatesForComplianceDir(complianceDir: string, adcpVersion?: string): string[] {
+  const candidates = new Set<string>();
+  const packageRoots = packageRootCandidatesForComplianceDir(complianceDir);
+  const add = (candidate: string) => candidates.add(candidate);
+
+  for (const packageRoot of packageRoots) {
+    addVersionedSchemaRoots(packageRoot, adcpVersion ?? ADCP_VERSION, add);
+  }
+  for (const packageRoot of packageRoots) {
+    add(join(packageRoot, 'dist', 'schemas', 'latest'));
+    add(join(packageRoot, 'schemas', 'cache', 'latest'));
+    add(join(packageRoot, 'dist', 'lib', 'schemas-data', 'latest'));
+  }
+  if (adcpVersion === undefined) {
+    for (const packageRoot of packageRoots) {
+      addSchemaContainerChildren(join(packageRoot, 'dist', 'lib', 'schemas-data'), add);
+      addSchemaContainerChildren(join(packageRoot, 'dist', 'schemas'), add);
+      addSchemaContainerChildren(join(packageRoot, 'schemas', 'cache'), add);
+    }
+  }
+
+  return [...candidates];
+}
+
+function addVersionedSchemaRoots(packageRoot: string, adcpVersion: string, add: (candidate: string) => void): void {
+  const key = resolveBundleKey(adcpVersion);
+  add(join(packageRoot, 'dist', 'lib', 'schemas-data', key));
+  add(join(packageRoot, 'dist', 'schemas', adcpVersion));
+  add(join(packageRoot, 'dist', 'schemas', key));
+  add(join(packageRoot, 'schemas', 'cache', adcpVersion));
+  add(join(packageRoot, 'schemas', 'cache', key));
+}
+
+function addSchemaContainerChildren(container: string, add: (candidate: string) => void): void {
+  if (!existsSync(container)) return;
+  for (const entry of readdirSync(container).sort().reverse()) {
+    const full = join(container, entry);
+    try {
+      if (statSync(full).isDirectory()) add(full);
+    } catch {
+      // Best-effort sibling discovery; ignore entries that disappear mid-scan.
+    }
+  }
+}
+
+function packageRootCandidatesForComplianceDir(complianceDir: string): string[] {
+  const roots = new Set<string>();
+  const resolved = resolve(complianceDir);
+  let current = resolved;
+
+  while (true) {
+    if (basename(current) === 'compliance') {
+      const parent = dirname(current);
+      if (basename(parent) === 'dist') roots.add(dirname(parent));
+      roots.add(parent);
+    }
+    const next = dirname(current);
+    if (next === current) break;
+    current = next;
+  }
+
+  roots.add(dirname(dirname(dirname(resolved))));
+  return [...roots];
+}
+
 function hasSchemaRootShape(root: string): boolean {
-  return existsSync(join(root, 'bundled')) || existsSync(join(root, 'core'));
+  if (!existsSync(root)) return false;
+  const scanRoot = existsSync(join(root, 'bundled')) ? join(root, 'bundled') : root;
+  return walkJsonFiles(scanRoot).some(file => {
+    try {
+      const parsed = JSON.parse(readFileSync(file, 'utf-8')) as { $id?: unknown; $schema?: unknown };
+      return typeof parsed.$id === 'string' || typeof parsed.$schema === 'string';
+    } catch {
+      return false;
+    }
+  });
+}
+
+function walkJsonFiles(dir: string): string[] {
+  if (!existsSync(dir)) return [];
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...walkJsonFiles(full));
+    else if (entry.isFile() && entry.name.endsWith('.json')) out.push(full);
+  }
+  return out;
 }
 
 /**

--- a/test/lib/storyboard-version-negotiation.test.js
+++ b/test/lib/storyboard-version-negotiation.test.js
@@ -21,6 +21,16 @@ function writeComplianceIndex(complianceDir, version = '3.0.12') {
   );
 }
 
+function writeComplianceIndexJson(complianceDir, index) {
+  fs.mkdirSync(complianceDir, { recursive: true });
+  fs.writeFileSync(path.join(complianceDir, 'index.json'), JSON.stringify(index));
+}
+
+function writeSchemaIndex(schemaRoot, version) {
+  fs.mkdirSync(schemaRoot, { recursive: true });
+  fs.writeFileSync(path.join(schemaRoot, 'index.json'), JSON.stringify({ adcp_version: version }));
+}
+
 function writeGetProductsRequestSchema(schemaRoot, idVersion, sentinel = 'external') {
   fs.mkdirSync(path.join(schemaRoot, 'bundled', 'media-buy'), { recursive: true });
   fs.writeFileSync(
@@ -549,6 +559,172 @@ describe('storyboard runner AdCP version negotiation', () => {
       });
     } finally {
       _resetValidationLoader('3.0.12');
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('latest compliance metadata is repaired from schemaRoot index before storyboard annotation', () => {
+    const {
+      applyAdcpVersionRunOptions,
+      listBundles,
+      loadComplianceIndex,
+    } = require('../../dist/lib/testing/storyboard/index.js');
+
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'adcp-latest-compliance-version-'));
+    const complianceDir = path.join(tempRoot, 'dist', 'compliance', 'latest');
+    const schemaRoot = path.join(tempRoot, 'dist', 'schemas', 'latest');
+    try {
+      writeComplianceIndexJson(complianceDir, {
+        published_version: 'latest',
+        adcp_version: 'latest',
+        generated_at: '2026-06-05T00:00:00.000Z',
+        universal: ['capability-discovery'],
+        protocols: [],
+        specialisms: [],
+      });
+      writeSchemaIndex(schemaRoot, CURRENT_PRERELEASE_VERSION);
+
+      const index = loadComplianceIndex({ complianceDir, schemaRoot });
+      assert.strictEqual(index.published_version, 'latest');
+      assert.strictEqual(index.adcp_version, CURRENT_PRERELEASE_VERSION);
+
+      const bundles = listBundles({ complianceDir, schemaRoot });
+      assert.strictEqual(bundles[0].adcp_version, CURRENT_PRERELEASE_VERSION);
+
+      const options = applyAdcpVersionRunOptions(index.adcp_version, { schemaRoot });
+      assert.strictEqual(options.adcpVersion, CURRENT_PRERELEASE_VERSION);
+      assert.strictEqual(options.versionEnvelope, 'auto');
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('latest compliance metadata can be repaired from published_version', () => {
+    const { loadComplianceIndex } = require('../../dist/lib/testing/storyboard/index.js');
+
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'adcp-latest-compliance-published-version-'));
+    const complianceDir = path.join(tempRoot, 'dist', 'compliance', 'latest');
+    try {
+      writeComplianceIndexJson(complianceDir, {
+        published_version: CURRENT_PRERELEASE_VERSION,
+        adcp_version: 'latest',
+        generated_at: '2026-06-05T00:00:00.000Z',
+        universal: [],
+        protocols: [],
+        specialisms: [],
+      });
+
+      const index = loadComplianceIndex({ complianceDir });
+      assert.strictEqual(index.adcp_version, CURRENT_PRERELEASE_VERSION);
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('latest compliance metadata is repaired from index-less schemaRoot ids', () => {
+    const { loadComplianceIndex } = require('../../dist/lib/testing/storyboard/index.js');
+
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'adcp-latest-compliance-schema-ids-'));
+    const complianceDir = path.join(tempRoot, 'dist', 'compliance', 'latest');
+    const schemaRoot = path.join(tempRoot, 'schema-bundles', CURRENT_PRERELEASE_VERSION);
+    try {
+      writeComplianceIndexJson(complianceDir, {
+        published_version: 'latest',
+        adcp_version: 'latest',
+        generated_at: '2026-06-05T00:00:00.000Z',
+        universal: [],
+        protocols: [],
+        specialisms: [],
+      });
+      writeGetProductsRequestSchema(schemaRoot, CURRENT_PRERELEASE_VERSION, 'schema-id-version');
+
+      const index = loadComplianceIndex({ complianceDir, schemaRoot });
+      assert.strictEqual(index.adcp_version, CURRENT_PRERELEASE_VERSION);
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('latest compliance metadata is repaired from sibling schema bundle without schemaRoot', () => {
+    const {
+      getExternalSchemaRootForCompliance,
+      loadComplianceIndex,
+    } = require('../../dist/lib/testing/storyboard/index.js');
+
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'adcp-latest-compliance-sibling-'));
+    const complianceDir = path.join(tempRoot, 'package', 'dist', 'compliance', 'latest');
+    const schemaRoot = path.join(tempRoot, 'package', 'dist', 'lib', 'schemas-data', CURRENT_PRERELEASE_VERSION);
+    try {
+      writeComplianceIndexJson(complianceDir, {
+        published_version: 'latest',
+        adcp_version: 'latest',
+        generated_at: '2026-06-05T00:00:00.000Z',
+        universal: [],
+        protocols: [],
+        specialisms: [],
+      });
+      writeGetProductsRequestSchema(schemaRoot, CURRENT_PRERELEASE_VERSION, 'sibling-schema-id-version');
+
+      const index = loadComplianceIndex({ complianceDir });
+      assert.strictEqual(index.adcp_version, CURRENT_PRERELEASE_VERSION);
+      assert.strictEqual(getExternalSchemaRootForCompliance({ complianceDir }, index.adcp_version), schemaRoot);
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('ADCP_SCHEMA_ROOT repairs latest compliance metadata from the matching schema index', () => {
+    const { loadComplianceIndex } = require('../../dist/lib/testing/storyboard/index.js');
+
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'adcp-latest-compliance-env-'));
+    const complianceDir = path.join(tempRoot, 'dist', 'compliance', 'latest');
+    const schemaRoot = path.join(tempRoot, 'dist', 'schemas', 'latest');
+    const oldSchemaRoot = process.env.ADCP_SCHEMA_ROOT;
+    try {
+      writeComplianceIndexJson(complianceDir, {
+        published_version: 'latest',
+        adcp_version: 'latest',
+        generated_at: '2026-06-05T00:00:00.000Z',
+        universal: [],
+        protocols: [],
+        specialisms: [],
+      });
+      writeSchemaIndex(schemaRoot, CURRENT_PRERELEASE_VERSION);
+
+      process.env.ADCP_SCHEMA_ROOT = schemaRoot;
+      const index = loadComplianceIndex({ complianceDir });
+      assert.strictEqual(index.adcp_version, CURRENT_PRERELEASE_VERSION);
+    } finally {
+      if (oldSchemaRoot === undefined) delete process.env.ADCP_SCHEMA_ROOT;
+      else process.env.ADCP_SCHEMA_ROOT = oldSchemaRoot;
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('unrepairable latest compliance metadata fails before it can reach the wire', () => {
+    const { loadComplianceIndex } = require('../../dist/lib/testing/storyboard/index.js');
+
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'adcp-latest-compliance-invalid-'));
+    const complianceDir = path.join(tempRoot, 'dist', 'compliance', 'latest');
+    const oldSchemaRoot = process.env.ADCP_SCHEMA_ROOT;
+    try {
+      delete process.env.ADCP_SCHEMA_ROOT;
+      writeComplianceIndexJson(complianceDir, {
+        published_version: 'latest',
+        adcp_version: 'latest',
+        generated_at: '2026-06-05T00:00:00.000Z',
+        universal: [],
+        protocols: [],
+        specialisms: [],
+      });
+
+      assert.throws(
+        () => loadComplianceIndex({ complianceDir }),
+        /declares invalid adcp_version "latest".*ADCP_SCHEMA_ROOT/
+      );
+    } finally {
+      if (oldSchemaRoot === undefined) delete process.env.ADCP_SCHEMA_ROOT;
+      else process.env.ADCP_SCHEMA_ROOT = oldSchemaRoot;
       fs.rmSync(tempRoot, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
Fixes adcontextprotocol/adcp#5373.

This repairs local compliance bundles whose index declares `adcp_version: "latest"` by deriving a valid AdCP version from `published_version` or the matching schema bundle before storyboards are annotated, while leaving `resolveBundleKey()` strict so unrepairable metadata fails before reaching the wire.

It adds regression coverage for explicit `schemaRoot`, `ADCP_SCHEMA_ROOT`, fail-closed behavior, and includes a patch changeset.

Expert review follow-up added coverage for `published_version`, index-less schema roots that declare version via schema `$id`, and `complianceDir`-only sibling schema discovery.

Validated with `npm run build:lib`, `node --test --test-timeout=60000 test/lib/storyboard-version-negotiation.test.js`, and the pre-push typecheck/build hook.
