### PR TITLE
fix: preserve storyboard asap start time

### DIFF
--- a/.changeset/preserve-storyboard-asap-start.md
+++ b/.changeset/preserve-storyboard-asap-start.md
@@ -1,0 +1,5 @@
+---
+"@adcp/sdk": patch
+---
+
+Preserve storyboard `create_media_buy` sample requests that set `start_time: "asap"` instead of rewriting them to a generated future timestamp.

--- a/src/lib/testing/storyboard/request-builder.ts
+++ b/src/lib/testing/storyboard/request-builder.ts
@@ -121,16 +121,22 @@ function resolveMediaBuyWindow(
   const defaultEnd = new Date(now + 8 * DAY_MS).toISOString();
   const sampleStartMs = parseTime(sampleStart);
   const sampleEndMs = parseTime(sampleEnd);
+  const startIsAsap = sampleStart === 'asap';
 
-  const startTime = sampleStart && sampleStartMs !== undefined && sampleStartMs >= now ? sampleStart : defaultStart;
+  const startTime = startIsAsap
+    ? 'asap'
+    : sampleStart && sampleStartMs !== undefined && sampleStartMs >= now
+      ? sampleStart
+      : defaultStart;
   let endTime = sampleEnd && sampleEndMs !== undefined && sampleEndMs >= now ? sampleEnd : defaultEnd;
 
-  if (Date.parse(endTime) <= Date.parse(startTime)) {
+  const startTimeMs = startIsAsap ? now : Date.parse(startTime);
+  if (Date.parse(endTime) <= startTimeMs) {
     const sampleDurationMs =
       sampleStartMs !== undefined && sampleEndMs !== undefined && sampleEndMs > sampleStartMs
         ? sampleEndMs - sampleStartMs
         : DEFAULT_MEDIA_BUY_WINDOW_MS;
-    endTime = new Date(Date.parse(startTime) + sampleDurationMs).toISOString();
+    endTime = new Date(startTimeMs + sampleDurationMs).toISOString();
   }
 
   return { startTime, endTime };

--- a/test/lib/request-builder.test.js
+++ b/test/lib/request-builder.test.js
@@ -85,6 +85,23 @@ describe('Request Builder', () => {
       assert.strictEqual(result.end_time, FUTURE_END);
     });
 
+    test('preserves fixture start_time asap for active-buy storyboards', () => {
+      withDateNow('2026-06-06T12:00:00.000Z', () => {
+        const s = step('create_media_buy', {
+          sample_request: {
+            start_time: 'asap',
+            end_time: '2099-07-31T23:59:59Z',
+            packages: [{ product_id: 'p1', budget: 1000, pricing_option_id: 'opt' }],
+          },
+        });
+
+        const result = buildRequest(s, {}, DEFAULT_OPTIONS);
+
+        assert.strictEqual(result.start_time, 'asap');
+        assert.strictEqual(result.end_time, '2099-07-31T23:59:59Z');
+      });
+    });
+
     test('keeps create_media_buy window ordered when stale start meets same-day future end (#2143)', () => {
       withDateNow('2026-05-31T12:28:07.525Z', () => {
         const sampleStart = '2026-05-01T00:00:00Z';


### PR DESCRIPTION
## Summary

Preserves storyboard-authored `create_media_buy` requests that set `start_time: "asap"` instead of rewriting them to a generated future timestamp.

## Root Cause

The storyboard request builder only kept fixture `start_time` values when `Date.parse()` returned a future timestamp. The spec-defined sentinel `"asap"` does not parse as a date, so active-buy storyboards were silently sent with tomorrow's timestamp instead of driving the buy active immediately.

## Changes

- Treat `sample_request.start_time: "asap"` as an authoritative fixture value.
- Use the runner clock as the ordering baseline when checking `end_time` for an `asap` start.
- Add a regression test for active-buy storyboards.
- Add a patch changeset.

## Validation

- `npm run build:lib`
- `NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/lib/request-builder.test.js`
- `npx prettier --check src/lib/testing/storyboard/request-builder.ts test/lib/request-builder.test.js`
- `npm run lint` (passes with existing warnings)
- pre-push hook: formatting, typecheck, build passed
