### PR TITLE
feat: scope webhook templates by operation

### DIFF
--- a/.changeset/webhook-scope-creative-context.md
+++ b/.changeset/webhook-scope-creative-context.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': minor
+---
+
+Add operation-scoped webhook URL template filters and per-call webhook suppression, and capture build_creative variant context from storyboard responses.

--- a/src/lib/core/ConversationTypes.ts
+++ b/src/lib/core/ConversationTypes.ts
@@ -123,6 +123,24 @@ export type TaskStatus =
   | 'governance-denied';
 
 /**
+ * Predicate used by scoped webhook URL templates to decide which operations
+ * receive protocol-level webhook URLs.
+ */
+export type WebhookToolPredicate = (toolName: string) => boolean;
+
+/**
+ * Webhook URL template with macro substitution. A bare string preserves the
+ * legacy behavior: every operation receives a generated webhook URL. The
+ * object form scopes webhook URL generation to a tool allowlist or predicate.
+ */
+export type WebhookUrlTemplate =
+  | string
+  | {
+      template: string;
+      tools?: string[] | WebhookToolPredicate;
+    };
+
+/**
  * Options for task execution
  */
 export interface TaskOptions {
@@ -145,6 +163,8 @@ export interface TaskOptions {
   taskId?: string;
   /** Enable debug logging for this task */
   debug?: boolean;
+  /** Suppress automatic webhook URL generation for this call. */
+  disableWebhook?: boolean;
   /** Additional metadata to include */
   metadata?: Record<string, any>;
   /**

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -102,7 +102,14 @@ import {
   probeAuthChallenge,
 } from '../auth/oauth/authorization-required';
 import { discoverOAuthMetadata } from '../auth/oauth/discovery';
-import type { InputHandler, TaskOptions, TaskResult, ConversationConfig, TaskInfo } from './ConversationTypes';
+import type {
+  InputHandler,
+  TaskOptions,
+  TaskResult,
+  ConversationConfig,
+  TaskInfo,
+  WebhookUrlTemplate,
+} from './ConversationTypes';
 import type { Activity, AsyncHandlerConfig, WebhookMetadata } from './AsyncHandler';
 import { AsyncHandler } from './AsyncHandler';
 import { verifyWebhookRequest, type WebhookHeaderValue, type WebhookHeadersLike } from '../webhooks';
@@ -129,6 +136,7 @@ import {
 } from '../utils/capabilities';
 import { normalizeRequestParams } from '../utils/request-normalizer';
 import { validateUserAgent } from '../utils/validate-user-agent';
+import { resolveWebhookUrl } from './webhook-url';
 import { getV25Adapter } from '../adapters/legacy/v2-5';
 import {
   ProductPropertyPolicyError,
@@ -365,7 +373,7 @@ export interface SingleAgentClientConfig extends ConversationConfig {
    * Query string: "https://myapp.com/webhook?agent={agent_id}&op={operation_id}&type={task_type}"
    * Custom: "https://myapp.com/api/v1/adcp/{agent_id}?operation={operation_id}"
    */
-  webhookUrlTemplate?: string;
+  webhookUrlTemplate?: WebhookUrlTemplate;
   /**
    * Reporting webhook frequency
    *
@@ -1400,11 +1408,11 @@ export class SingleAgentClient {
       throw new Error('webhookUrlTemplate not configured - cannot generate webhook URL');
     }
 
-    // Macro substitution
-    return this.config.webhookUrlTemplate
-      .replace(/{agent_id}/g, this.agent.id)
-      .replace(/{task_type}/g, taskType)
-      .replace(/{operation_id}/g, operationId);
+    const webhookUrl = resolveWebhookUrl(this.config.webhookUrlTemplate, this.agent.id, taskType, operationId);
+    if (!webhookUrl) {
+      throw new Error(`webhookUrlTemplate not configured for task type '${taskType}'`);
+    }
+    return webhookUrl;
   }
 
   /**
@@ -2294,35 +2302,43 @@ export class SingleAgentClient {
     // Merge library defaults with consumer-provided reporting_webhook config
     // Library provides url/auth/frequency defaults, consumer can override any field
     // Generates a media_buy_delivery webhook URL using operation_id pattern: delivery_report_{agent_id}_{YYYY-MM}
-    if (this.config.webhookUrlTemplate) {
+    if (this.config.webhookUrlTemplate && !options?.disableWebhook) {
       const now = new Date();
       const year = now.getUTCFullYear();
       const month = String(now.getUTCMonth() + 1).padStart(2, '0');
       const operationId = `delivery_report_${this.agent.id}_${year}-${month}`;
-      const deliveryWebhookUrl = this.getWebhookUrl('media_buy_delivery', operationId);
+      const deliveryWebhookUrl = resolveWebhookUrl(
+        this.config.webhookUrlTemplate,
+        this.agent.id,
+        'media_buy_delivery',
+        operationId,
+        options
+      );
 
-      // Library defaults
-      const libraryDefaults = {
-        url: deliveryWebhookUrl,
-        authentication: {
-          schemes: ['HMAC-SHA256'] as const,
-          credentials: this.config.webhookSecret || 'placeholder_secret_min_32_characters_required',
-        },
-        reporting_frequency: (this.config.reportingWebhookFrequency || 'daily') as 'hourly' | 'daily' | 'monthly',
-      };
-
-      // Deep merge: consumer overrides library defaults
-      params = {
-        ...params,
-        reporting_webhook: {
-          ...libraryDefaults,
-          ...params.reporting_webhook,
+      if (deliveryWebhookUrl) {
+        // Library defaults
+        const libraryDefaults = {
+          url: deliveryWebhookUrl,
           authentication: {
-            ...libraryDefaults.authentication,
-            ...params.reporting_webhook?.authentication,
+            schemes: ['HMAC-SHA256'] as const,
+            credentials: this.config.webhookSecret || 'placeholder_secret_min_32_characters_required',
           },
-        },
-      } as CreateMediaBuyRequest;
+          reporting_frequency: (this.config.reportingWebhookFrequency || 'daily') as 'hourly' | 'daily' | 'monthly',
+        };
+
+        // Deep merge: consumer overrides library defaults
+        params = {
+          ...params,
+          reporting_webhook: {
+            ...libraryDefaults,
+            ...params.reporting_webhook,
+            authentication: {
+              ...libraryDefaults.authentication,
+              ...params.reporting_webhook?.authentication,
+            },
+          },
+        } as CreateMediaBuyRequest;
+      }
     }
 
     return this.executeAndHandle<CreateMediaBuyResponse>(

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -37,6 +37,7 @@ import type {
   TaskInfo,
   DeferredContinuation,
   SubmittedContinuation,
+  WebhookUrlTemplate,
 } from './ConversationTypes';
 import { normalizeHandlerResponse, isDeferResponse, isAbortResponse } from '../handlers/types';
 import { ProtocolResponseParser, ADCP_STATUS, type ADCPStatus } from './ProtocolResponseParser';
@@ -44,6 +45,7 @@ import type { Activity } from './AsyncHandler';
 import { GovernanceMiddleware } from './GovernanceMiddleware';
 import type { GovernanceConfig, GovernanceCheckResult } from './GovernanceTypes';
 import { attachMatch } from './match';
+import { resolveWebhookUrl } from './webhook-url';
 /**
  * Custom errors for task execution
  */
@@ -289,7 +291,7 @@ export class TaskExecutor {
       /** Storage for deferred task state */
       deferredStorage?: Storage<DeferredTaskState>;
       /** Webhook URL template for protocol-level webhook support */
-      webhookUrlTemplate?: string;
+      webhookUrlTemplate?: WebhookUrlTemplate;
       /** Agent ID for webhook URL generation */
       agentId?: string;
       /** Webhook secret for HMAC authentication (min 32 chars) */
@@ -459,15 +461,8 @@ export class TaskExecutor {
     return adcpErrorToTypedError(adcpError, key);
   }
 
-  private generateWebhookUrl(taskName: string, operationId: string): string | undefined {
-    if (!this.config.webhookUrlTemplate || !this.config.agentId) {
-      return undefined;
-    }
-
-    return this.config.webhookUrlTemplate
-      .replace(/{agent_id}/g, this.config.agentId)
-      .replace(/{task_type}/g, taskName)
-      .replace(/{operation_id}/g, operationId);
+  private generateWebhookUrl(taskName: string, operationId: string, options?: TaskOptions): string | undefined {
+    return resolveWebhookUrl(this.config.webhookUrlTemplate, this.config.agentId, taskName, operationId, options);
   }
 
   /**
@@ -535,7 +530,7 @@ export class TaskExecutor {
     const debugLogs: any[] = [];
 
     // Generate webhook URL if template is configured
-    const webhookUrl = this.generateWebhookUrl(taskName, taskId);
+    const webhookUrl = this.generateWebhookUrl(taskName, taskId, options);
 
     // Governance state (scoped outside try so catch can access)
     let governanceCheckId: string | undefined;

--- a/src/lib/core/webhook-url.ts
+++ b/src/lib/core/webhook-url.ts
@@ -1,0 +1,32 @@
+import type { TaskOptions, WebhookUrlTemplate } from './ConversationTypes';
+
+export function selectWebhookTemplate(config: WebhookUrlTemplate | undefined, taskName: string): string | undefined {
+  if (!config) return undefined;
+  if (typeof config === 'string') return config;
+
+  if (!config.template) return undefined;
+  if (config.tools === undefined) return config.template;
+  if (Array.isArray(config.tools)) {
+    return config.tools.includes(taskName) ? config.template : undefined;
+  }
+
+  return config.tools(taskName) ? config.template : undefined;
+}
+
+export function resolveWebhookUrl(
+  config: WebhookUrlTemplate | undefined,
+  agentId: string | undefined,
+  taskName: string,
+  operationId: string,
+  options?: Pick<TaskOptions, 'disableWebhook'>
+): string | undefined {
+  if (options?.disableWebhook || !agentId) return undefined;
+
+  const template = selectWebhookTemplate(config, taskName);
+  if (!template) return undefined;
+
+  return template
+    .replace(/{agent_id}/g, agentId)
+    .replace(/{task_type}/g, taskName)
+    .replace(/{operation_id}/g, operationId);
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -251,6 +251,8 @@ export type {
   InputHandlerResponse,
   ConversationContext,
   TaskOptions,
+  WebhookToolPredicate,
+  WebhookUrlTemplate,
   TaskResult,
   TaskResultCompleted,
   TaskResultIntermediate,

--- a/src/lib/testing/storyboard/context.ts
+++ b/src/lib/testing/storyboard/context.ts
@@ -137,6 +137,26 @@ export const CONTEXT_EXTRACTORS: Record<string, ContextExtractor> = {
       extracted.creative_manifests = manifests;
       if (manifests[0].format_id) extracted.format_id = manifests[0].format_id;
     }
+    // Variant response: creatives[].variants[] (BuildCreativeVariantSuccess).
+    const creatives = d?.creatives as Array<Record<string, unknown>> | undefined;
+    if (creatives?.[0]) {
+      extracted.creatives = creatives;
+
+      const variants = creatives.flatMap(creative => {
+        const creativeVariants = creative.variants as Array<Record<string, unknown>> | undefined;
+        return Array.isArray(creativeVariants) ? creativeVariants : [];
+      });
+      if (variants[0]) {
+        extracted.variants = variants;
+        if (variants[0].build_variant_id) extracted.build_variant_id = variants[0].build_variant_id;
+
+        const variantManifest = variants[0].creative_manifest as Record<string, unknown> | undefined;
+        if (variantManifest) {
+          extracted.creative_manifest ??= variantManifest;
+          if (!extracted.format_id && variantManifest.format_id) extracted.format_id = variantManifest.format_id;
+        }
+      }
+    }
     return extracted;
   },
 

--- a/test/lib/context-extractors.test.js
+++ b/test/lib/context-extractors.test.js
@@ -4,6 +4,60 @@ const assert = require('node:assert/strict');
 const { extractContext } = require('../../dist/lib/testing/storyboard/context.js');
 
 describe('context extractors', () => {
+  describe('build_creative', () => {
+    it('preserves single creative_manifest extraction', () => {
+      const data = {
+        creative_manifest: {
+          format_id: { agent_url: 'https://creative.example', id: 'display_300x250' },
+          assets: [],
+        },
+      };
+
+      const result = extractContext('build_creative', data);
+      assert.deepStrictEqual(result.creative_manifest, data.creative_manifest);
+      assert.deepStrictEqual(result.format_id, data.creative_manifest.format_id);
+    });
+
+    it('extracts variant groups and first variant context', () => {
+      const firstManifest = {
+        format_id: { agent_url: 'https://creative.example', id: 'display_300x250' },
+        assets: [{ slot: 'image', url: 'https://cdn.example/one.png' }],
+      };
+      const secondManifest = {
+        format_id: { agent_url: 'https://creative.example', id: 'display_728x90' },
+        assets: [{ slot: 'image', url: 'https://cdn.example/two.png' }],
+      };
+      const data = {
+        creatives: [
+          {
+            creative_ref: 'summer',
+            variants: [{ build_variant_id: 'bv_1', creative_manifest: firstManifest }],
+          },
+          {
+            creative_ref: 'winter',
+            variants: [{ build_variant_id: 'bv_2', creative_manifest: secondManifest }],
+          },
+        ],
+      };
+
+      const result = extractContext('build_creative', data);
+      assert.deepStrictEqual(result.creatives, data.creatives);
+      assert.deepStrictEqual(result.variants, [data.creatives[0].variants[0], data.creatives[1].variants[0]]);
+      assert.equal(result.build_variant_id, 'bv_1');
+      assert.deepStrictEqual(result.creative_manifest, firstManifest);
+      assert.deepStrictEqual(result.format_id, firstManifest.format_id);
+    });
+
+    it('retains creatives even when no variants are present', () => {
+      const data = { creatives: [{ creative_ref: 'summer', status: 'failed' }] };
+
+      const result = extractContext('build_creative', data);
+      assert.deepStrictEqual(result.creatives, data.creatives);
+      assert.equal(result.variants, undefined);
+      assert.equal(result.build_variant_id, undefined);
+    });
+  });
+
   describe('list_creatives', () => {
     it('extracts creative_id and creatives array', () => {
       const data = {

--- a/test/lib/webhook-template-scope.test.js
+++ b/test/lib/webhook-template-scope.test.js
@@ -1,0 +1,148 @@
+const { describe, it, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { ProtocolClient, SingleAgentClient, TaskExecutor } = require('../../dist/lib/index.js');
+
+const originalCallTool = ProtocolClient.callTool;
+
+const agent = {
+  id: 'agent_1',
+  name: 'Agent 1',
+  agent_uri: 'https://agent.example/mcp/',
+  protocol: 'mcp',
+};
+
+describe('webhook template scoping', () => {
+  afterEach(() => {
+    ProtocolClient.callTool = originalCallTool;
+  });
+
+  it('does not send webhookUrl for tools outside the scoped template', async () => {
+    const calls = [];
+    ProtocolClient.callTool = async (_agent, _taskName, _params, options) => {
+      calls.push(options);
+      return { status: 'completed', products: [] };
+    };
+
+    const executor = new TaskExecutor({
+      agentId: agent.id,
+      webhookUrlTemplate: {
+        template: 'https://buyer.example/webhook/{task_type}/{agent_id}/{operation_id}',
+        tools: ['sync_creatives'],
+      },
+      validation: { requests: 'off', responses: 'off' },
+    });
+
+    await executor.executeTask(agent, 'get_products', {});
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].webhookUrl, undefined);
+  });
+
+  it('sends webhookUrl for tools inside the scoped template', async () => {
+    const calls = [];
+    ProtocolClient.callTool = async (_agent, _taskName, _params, options) => {
+      calls.push(options);
+      return { status: 'completed', creatives: [] };
+    };
+
+    const executor = new TaskExecutor({
+      agentId: agent.id,
+      webhookUrlTemplate: {
+        template: 'https://buyer.example/webhook/{task_type}/{agent_id}/{operation_id}',
+        tools: ['sync_creatives'],
+      },
+      validation: { requests: 'off', responses: 'off' },
+    });
+
+    await executor.executeTask(agent, 'sync_creatives', {});
+
+    assert.equal(calls.length, 1);
+    assert.match(calls[0].webhookUrl, /^https:\/\/buyer\.example\/webhook\/sync_creatives\/agent_1\//);
+  });
+
+  it('disableWebhook suppresses a globally configured template for one call', async () => {
+    const calls = [];
+    ProtocolClient.callTool = async (_agent, _taskName, _params, options) => {
+      calls.push(options);
+      return { status: 'completed', creatives: [] };
+    };
+
+    const executor = new TaskExecutor({
+      agentId: agent.id,
+      webhookUrlTemplate: 'https://buyer.example/webhook/{task_type}/{agent_id}/{operation_id}',
+      validation: { requests: 'off', responses: 'off' },
+    });
+
+    await executor.executeTask(agent, 'sync_creatives', {}, undefined, { disableWebhook: true });
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].webhookUrl, undefined);
+  });
+
+  it('injects reporting_webhook when media_buy_delivery is in scope', async () => {
+    const calls = [];
+    ProtocolClient.callTool = async (_agent, taskName, params, options) => {
+      calls.push({ taskName, params, options });
+      return { status: 'completed', media_buy_id: 'mb_1' };
+    };
+
+    const client = new SingleAgentClient(agent, {
+      webhookUrlTemplate: {
+        template: 'https://buyer.example/webhook/{task_type}/{agent_id}/{operation_id}',
+        tools: ['media_buy_delivery'],
+      },
+      validateFeatures: false,
+      validation: { requests: 'off', responses: 'off' },
+    });
+    client.ensureEndpointDiscovered = async () => agent;
+    client.detectServerVersion = async () => 'v3';
+
+    await client.createMediaBuy({
+      account: { account_id: 'acc_1' },
+      brand: { domain: 'brand.example' },
+      start_time: 'asap',
+      end_time: '2026-12-31T00:00:00Z',
+      packages: [{ product_id: 'prod_1', budget: 1000, pricing_option_id: 'po_1' }],
+    });
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].taskName, 'create_media_buy');
+    assert.match(
+      calls[0].params.reporting_webhook.url,
+      /^https:\/\/buyer\.example\/webhook\/media_buy_delivery\/agent_1\/delivery_report_agent_1_/
+    );
+    assert.equal(calls[0].options.webhookUrl, undefined);
+  });
+
+  it('does not inject reporting_webhook when media_buy_delivery is out of scope', async () => {
+    const calls = [];
+    ProtocolClient.callTool = async (_agent, taskName, params, options) => {
+      calls.push({ taskName, params, options });
+      return { status: 'completed', media_buy_id: 'mb_1' };
+    };
+
+    const client = new SingleAgentClient(agent, {
+      webhookUrlTemplate: {
+        template: 'https://buyer.example/webhook/{task_type}/{agent_id}/{operation_id}',
+        tools: ['sync_creatives'],
+      },
+      validateFeatures: false,
+      validation: { requests: 'off', responses: 'off' },
+    });
+    client.ensureEndpointDiscovered = async () => agent;
+    client.detectServerVersion = async () => 'v3';
+
+    await client.createMediaBuy({
+      account: { account_id: 'acc_1' },
+      brand: { domain: 'brand.example' },
+      start_time: 'asap',
+      end_time: '2026-12-31T00:00:00Z',
+      packages: [{ product_id: 'prod_1', budget: 1000, pricing_option_id: 'po_1' }],
+    });
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].params.reporting_webhook, undefined);
+    assert.equal(calls[0].options.webhookUrl, undefined);
+  });
+});

--- a/test/webhook-url-macros.test.js
+++ b/test/webhook-url-macros.test.js
@@ -47,6 +47,48 @@ test('notification webhook URL', () => {
   assert.strictEqual(url, 'https://myapp.com/webhook/media_buy_delivery/test_agent/delivery_report_test_agent_2025-10');
 });
 
+test('scoped template allows configured tools', () => {
+  const client = new AdCPClient([agentConfig], {
+    webhookUrlTemplate: {
+      template: 'https://myapp.com/webhook/{task_type}/{agent_id}/{operation_id}',
+      tools: ['sync_creatives'],
+    },
+  });
+
+  const url = client.agent('test_agent').getWebhookUrl('sync_creatives', 'op_123');
+  assert.strictEqual(url, 'https://myapp.com/webhook/sync_creatives/test_agent/op_123');
+});
+
+test('scoped template rejects unconfigured tools', () => {
+  const client = new AdCPClient([agentConfig], {
+    webhookUrlTemplate: {
+      template: 'https://myapp.com/webhook/{task_type}/{agent_id}/{operation_id}',
+      tools: ['sync_creatives'],
+    },
+  });
+
+  assert.throws(
+    () => client.agent('test_agent').getWebhookUrl('get_products', 'op_123'),
+    /webhookUrlTemplate not configured for task type 'get_products'/
+  );
+});
+
+test('scoped template supports predicate filters', () => {
+  const client = new AdCPClient([agentConfig], {
+    webhookUrlTemplate: {
+      template: 'https://myapp.com/webhook/{task_type}/{agent_id}/{operation_id}',
+      tools: taskName => taskName.startsWith('sync_'),
+    },
+  });
+
+  const url = client.agent('test_agent').getWebhookUrl('sync_creatives', 'op_123');
+  assert.strictEqual(url, 'https://myapp.com/webhook/sync_creatives/test_agent/op_123');
+  assert.throws(
+    () => client.agent('test_agent').getWebhookUrl('create_media_buy', 'op_123'),
+    /webhookUrlTemplate not configured for task type 'create_media_buy'/
+  );
+});
+
 test('throws error if webhookUrlTemplate not configured', () => {
   const client = new AdCPClient([agentConfig], {});
 


### PR DESCRIPTION
## Summary

- add scoped webhook URL templates with string-compatible legacy behavior, tool allowlists/predicates, and per-call `disableWebhook`
- apply the same resolver to protocol-level webhook injection and `createMediaBuy` reporting webhook defaults
- extract `build_creative` variant-group output into storyboard context (`creatives`, flattened `variants`, first `build_variant_id`, and first variant manifest/format)

Closes #2168.
Closes #2165.

## Validation

- `npm run build:lib`
- `node --test --test-timeout=60000 --test-force-exit test/webhook-url-macros.test.js test/lib/webhook-template-scope.test.js test/lib/context-extractors.test.js`
- `npx prettier --check src/lib/core/ConversationTypes.ts src/lib/core/SingleAgentClient.ts src/lib/core/TaskExecutor.ts src/lib/core/webhook-url.ts src/lib/index.ts src/lib/testing/storyboard/context.ts test/webhook-url-macros.test.js test/lib/webhook-template-scope.test.js test/lib/context-extractors.test.js .changeset/webhook-scope-creative-context.md`
- `npm run typecheck`
- `npm run lint` (warnings only, no errors)
- `npx commitlint --from origin/main --to HEAD --verbose`
- pre-push hook: typecheck + library build
