### PR TITLE
feat(storyboard): echo authored validation ids

### DIFF
--- a/.changeset/storyboard-validation-result-ids.md
+++ b/.changeset/storyboard-validation-result-ids.md
@@ -1,0 +1,7 @@
+---
+'@adcp/sdk': minor
+---
+
+feat(storyboard): echo authored validation ids in runner results
+
+Storyboard validation entries may now declare stable `id` values, and the runner echoes those IDs unchanged on authored `ValidationResult` output across passing, failing, advisory, not-applicable, and cross-response checks. Compliance failure summaries preserve the first failed validation's ID, while runner-synthesized validations continue to omit IDs.

--- a/src/lib/testing/compliance/comply.ts
+++ b/src/lib/testing/compliance/comply.ts
@@ -1003,6 +1003,7 @@ export function extractFailures(
         const firstFailedValidation = step.validations.find(v => !v.passed);
         const validationSummary = firstFailedValidation
           ? {
+              ...(firstFailedValidation.id !== undefined && { id: firstFailedValidation.id }),
               check: firstFailedValidation.check,
               description: firstFailedValidation.description,
               ...(firstFailedValidation.json_pointer !== undefined && {

--- a/src/lib/testing/compliance/types.ts
+++ b/src/lib/testing/compliance/types.ts
@@ -115,6 +115,7 @@ export interface ComplianceFailure {
    * any validation ran.
    */
   validation?: {
+    id?: string;
     check: string;
     description: string;
     json_pointer?: string | null;

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -1087,6 +1087,8 @@ export interface RefsResolveScope {
 }
 
 export interface StoryboardValidation {
+  /** Stable authored validation identifier echoed into runner results when present. */
+  id?: string;
   check: StoryboardValidationCheck;
   /** JSON path for field checks, e.g. "accounts[0].account_id" */
   path?: string;
@@ -1959,6 +1961,8 @@ export interface RunnerNotice {
 // ────────────────────────────────────────────────────────────
 
 export interface ValidationResult {
+  /** Stable authored validation identifier, echoed unchanged when provided by the storyboard. */
+  id?: string;
   check: string;
   passed: boolean;
   description: string;

--- a/src/lib/testing/storyboard/validations.ts
+++ b/src/lib/testing/storyboard/validations.ts
@@ -222,7 +222,7 @@ export interface UpstreamTrafficQueryResult {
  * Run all validations for a storyboard step.
  */
 export function runValidations(validations: StoryboardValidation[], context: ValidationContext): ValidationResult[] {
-  return validations.map(v => attachOnFailure(runValidation(v, context), context));
+  return validations.map(v => attachOnFailure(runValidation(v, context), context, v));
 }
 
 /**
@@ -231,9 +231,20 @@ export function runValidations(validations: StoryboardValidation[], context: Val
  * minimal — carrying the full payload on every passing check bloats the
  * JSON surface without diagnostic value.
  */
-function attachOnFailure(result: ValidationResult, context: ValidationContext): ValidationResult {
-  if (result.passed) return result;
-  const augmented: ValidationResult = { ...result };
+function attachOnFailure(
+  result: ValidationResult,
+  context: ValidationContext,
+  validation: StoryboardValidation
+): ValidationResult {
+  const withId: ValidationResult =
+    validation.id === undefined
+      ? result
+      : {
+          ...result,
+          id: validation.id,
+        };
+  if (withId.passed) return withId;
+  const augmented: ValidationResult = { ...withId };
   if (context.request && augmented.request === undefined) augmented.request = context.request;
   if (context.response && augmented.response === undefined) augmented.response = context.response;
   return augmented;

--- a/test/lib/comply-vs-storyboard-parity.test.js
+++ b/test/lib/comply-vs-storyboard-parity.test.js
@@ -148,6 +148,28 @@ describe('extractFailures parity guard (#1708): assertion-only failure surface',
     assert.equal(failures[0].validation.check, 'assertion');
     assert.match(failures[0].validation.description, /context\.no_secret_echo/);
   });
+
+  test('authored validation id survives the compliance failure summary', () => {
+    const sb = buildStoryboardDef('parity_validation_id');
+    const result = buildStoryboardResult('parity_validation_id', {
+      stepPassed: false,
+      validations: [
+        {
+          id: 'check_health_impaired',
+          check: 'field_value',
+          passed: false,
+          description: 'Health is impaired',
+          json_pointer: '/health',
+          expected: 'impaired',
+          actual: 'healthy',
+        },
+      ],
+    });
+    const failures = extractFailures([result], [sb], 'parity_test_agent');
+    assert.equal(failures.length, 1);
+    assert.equal(failures[0].validation.id, 'check_health_impaired');
+    assert.equal(failures[0].validation.check, 'field_value');
+  });
 });
 
 // ────────────────────────────────────────────────────────────

--- a/test/lib/storyboard-runner-contract.test.js
+++ b/test/lib/storyboard-runner-contract.test.js
@@ -28,6 +28,7 @@ function runOne(validation, overrides = {}) {
     agentUrl: overrides.agentUrl ?? 'https://example.com/mcp',
     contributions: overrides.contributions ?? new Set(),
     responseSchemaRef: overrides.responseSchemaRef,
+    crossResponses: overrides.crossResponses,
     request: overrides.request,
     response: overrides.response,
   })[0];
@@ -384,6 +385,77 @@ describe('runner-output contract: validation_result', () => {
     assert.strictEqual(result.passed, true);
     assert.strictEqual(result.request, undefined);
     assert.strictEqual(result.response, undefined);
+  });
+
+  test('authored validation id echoes on pass, fail, and not_applicable results', () => {
+    const results = runValidations(
+      [
+        {
+          id: 'check_health_impaired',
+          check: 'field_value',
+          path: 'health',
+          value: 'impaired',
+          description: 'Health is impaired',
+        },
+        {
+          id: 'check_status_active',
+          check: 'field_value',
+          path: 'status',
+          value: 'active',
+          description: 'Status is active',
+        },
+        {
+          id: 'check_future_rule',
+          check: 'future_check_kind',
+          description: 'Future check grades not_applicable',
+        },
+      ],
+      {
+        taskName: 'get_products',
+        taskResult: { success: true, data: { health: 'impaired', status: 'paused' } },
+        agentUrl: 'https://example.com/mcp',
+        contributions: new Set(),
+      }
+    );
+
+    assert.strictEqual(results[0].passed, true);
+    assert.strictEqual(results[0].id, 'check_health_impaired');
+    assert.strictEqual(results[1].passed, false);
+    assert.strictEqual(results[1].id, 'check_status_active');
+    assert.strictEqual(results[2].passed, true);
+    assert.strictEqual(results[2].not_applicable, true);
+    assert.strictEqual(results[2].id, 'check_future_rule');
+  });
+
+  test('authored cross-response validation id is preserved', () => {
+    const dispatchA = { success: true, data: { media_buy_id: 'mb-1' } };
+    const dispatchB = { success: true, data: { media_buy_id: 'mb-1' } };
+    const result = runOne(
+      {
+        id: 'check_parallel_same_media_buy',
+        check: 'cross_response_field_equal',
+        path: 'media_buy_id',
+        description: 'Parallel dispatches resolve to the same media buy',
+      },
+      {
+        crossResponses: {
+          dispatches: [{ taskResult: dispatchA }, { taskResult: dispatchB }],
+          resolved: [dispatchA, dispatchB],
+        },
+      }
+    );
+
+    assert.strictEqual(result.passed, true);
+    assert.strictEqual(result.id, 'check_parallel_same_media_buy');
+  });
+
+  test('runner does not invent validation id when authored validation omits one', () => {
+    const result = runOne(
+      { check: 'field_present', path: 'status', description: 'status present' },
+      { taskResult: { success: true, data: { status: 'active' } } }
+    );
+
+    assert.strictEqual(result.id, undefined);
   });
 });
 

--- a/test/lib/storyboard-schema-validation-attribution.test.js
+++ b/test/lib/storyboard-schema-validation-attribution.test.js
@@ -113,6 +113,7 @@ describe('adcp-client#1709 — Zod-reject error attribution', () => {
     const schemaValidation = result.validations.find(v => v.check === 'response_schema');
     assert.ok(schemaValidation, 'response_schema validation must be present in step.validations');
     assert.equal(schemaValidation.passed, false);
+    assert.equal(schemaValidation.id, undefined, 'synthesized response_schema validation must not invent an id');
     assert.match(schemaValidation.description, /get_products/);
     assert.match(schemaValidation.error, /authorization/, 'error message names the rejected field');
   });

--- a/test/lib/storyboard-strict-validation.test.js
+++ b/test/lib/storyboard-strict-validation.test.js
@@ -123,6 +123,27 @@ describe('storyboard validations: strict/lenient response_schema delta', () => {
     assert.match(v.warning, /format/);
   });
 
+  test('strictness warning preserves authored validation id', () => {
+    const response = {
+      formats: [
+        {
+          format_id: { agent_url: 'not-a-uri', id: 'display_static' },
+          name: 'Display Static',
+          description: 'Static display format',
+          assets: [],
+        },
+      ],
+    };
+    const results = runValidations(
+      [{ id: 'check_format_agent_url_uri', check: 'response_schema', description: 'response conforms' }],
+      ctx('list_creative_formats', response, 'creative/list-creative-formats-response.json')
+    );
+    const v = results[0];
+    assert.strictEqual(v.passed, true);
+    assert.ok(typeof v.warning === 'string', 'warning surfaced on strict-only failure');
+    assert.strictEqual(v.id, 'check_format_agent_url_uri');
+  });
+
   test('warning absent when both Zod and AJV pass cleanly', () => {
     const results = runValidations(
       [{ check: 'response_schema', description: 'response conforms' }],


### PR DESCRIPTION
## Summary

Closes #2196.

- add optional authored validation IDs to storyboard validation inputs and runner validation results
- echo authored IDs through the shared validation result path, including pass, fail, not_applicable, advisory, and cross-response checks
- preserve validation IDs in compliance failure summaries
- keep runner-synthesized validations ID-less and avoid advertising runner output contract 2.6.0 prematurely

## Validation

- expert review: protocol reviewer, code reviewer, follow-up code review
- npm run build
- NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/lib/storyboard-runner-contract.test.js test/lib/storyboard-schema-validation-attribution.test.js test/lib/storyboard-strict-validation.test.js test/lib/comply-vs-storyboard-parity.test.js
- npx commitlint --from HEAD~1 --to HEAD --verbose
- pre-push hook: npm run typecheck, npm run build
