### PR TITLE
feat(decisioning): expose AdcpCapabilitiesConfig passthrough slots on DecisioningCapabilities (#2199)

### DIFF
--- a/.changeset/2199-decisioning-capabilities-passthrough.md
+++ b/.changeset/2199-decisioning-capabilities-passthrough.md
@@ -1,0 +1,25 @@
+---
+'@adcp/sdk': minor
+---
+
+feat(decisioning): expose `features`, `creative`, `account`, `overrides`, and `supported_versions` passthrough slots on `DecisioningCapabilities`
+
+Closes #2199.
+
+Adopters going through `definePlatform` / `createAdcpServerFromPlatform` (the documented v6 path) could not declare the per-feature capability granularity that the lower-level `createAdcpServer` exposes through `AdcpCapabilitiesConfig`. `CreateAdcpServerFromPlatformOptions extends Omit<AdcpServerConfig, 'capabilities' | ...>` cuts off the entire `AdcpCapabilitiesConfig` surface; `DecisioningCapabilities` covered a useful slice but had no path to `features`, `creative`, `account`, `overrides`, or `supported_versions`.
+
+This adds five optional passthrough fields to `DecisioningCapabilities<TConfig>`:
+
+- **`features?: Partial<MediaBuyFeatures>`** — adopter values form the base for `media_buy.features`. Auto-derived `audience_targeting` / `conversion_tracking` / `content_standards` booleans take precedence for those three keys (the framework's per-domain `media_buy` override is applied AFTER `capConfig.features` lays down the base inside `createAdcpServer`).
+- **`creative?: Partial<CreativeCapabilities>`** — forwarded into `get_adcp_capabilities.creative`.
+- **`account?: Partial<AccountCapabilities>`** — adopter base for the account block; existing `requireOperatorAuth` / `supportedBillings` projections overlay through the per-domain `account` override.
+- **`overrides?: AdcpCapabilitiesOverrides`** — direct deep-merge passthrough. Adopter-declared overrides are merged BEFORE the framework's per-domain blocks (media_buy / brand / account / compliance_testing), so framework-derived blocks remain authoritative on keys the projection engine handles.
+- **`supported_versions?: string[]`** — release-precision AdCP versions; forwarded into `get_adcp_capabilities.adcp.supported_versions`.
+
+Non-breaking: all five fields optional. Adopters who declare none see identical wire output.
+
+**Why this matters for adopters**
+
+Conformance storyboards in 3.1.0-rc.10+ grade capability-absent scenarios as `fail` rather than `not_applicable` when the adopter can't declare not-supported feature blocks. A single-publisher / single-slot seller (no measurement vendor partnership, no wholesale catalog, no provenance verification pipeline) previously had 23 storyboards failing in our reference adopter because there was no path to declare those capabilities as unsupported through `definePlatform`. With this passthrough, adopters can honestly say "we don't support X" and the runner grades accordingly.
+
+Migration: v5 adopters passing `supported_versions` via `opts.capabilities` on `AdcpServerConfig` should move it to `capabilities.supported_versions` on the platform declaration.

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -6141,6 +6141,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
     status: 'completed',
     adcp: {
       major_versions: capConfig?.major_versions ?? [3],
+      ...(capConfig?.supported_versions?.length && { supported_versions: [...capConfig.supported_versions] }),
       idempotency: idempotencyCapability,
     },
     supported_protocols: protocols as GetAdCPCapabilitiesResponse['supported_protocols'],

--- a/src/lib/server/decisioning/capabilities.ts
+++ b/src/lib/server/decisioning/capabilities.ts
@@ -22,6 +22,8 @@ import type {
   PostalAreaSupport,
 } from '../../types/tools.generated';
 import type { ProductMetricOptimizationLike } from '../../utils/capability-rollups';
+import type { MediaBuyFeatures, AccountCapabilities, CreativeCapabilities } from '../../utils/capabilities';
+import type { AdcpCapabilitiesOverrides } from '../create-adcp-server';
 
 /**
  * Pre-resolved alias for the wire `media_buy` block. Used as the projection
@@ -253,6 +255,74 @@ export interface DecisioningCapabilities<TConfig = unknown> {
    * `AUTH_REQUIRED` envelope before dispatching to the platform.
    */
   requireOperatorAuth?: boolean;
+
+  /**
+   * Media-buy feature flags forwarded into `get_adcp_capabilities.media_buy.features`.
+   * Adopter values serve as the base; auto-derived `audience_targeting`,
+   * `conversion_tracking`, and `content_standards` booleans take precedence
+   * for those three keys (overlaid by the framework via the per-domain
+   * `media_buy` override on the inner createAdcpServer call). Use this to
+   * declare `inlineCreativeManagement` and `propertyListFiltering` directly
+   * from `definePlatform`; declare not-supported feature blocks (e.g.
+   * `inlineCreativeManagement: false`) so the conformance runner grades
+   * them `not_applicable` instead of `fail`.
+   *
+   * Resolves the `definePlatform` passthrough gap noted in adcp-client#2199.
+   */
+  features?: Partial<MediaBuyFeatures>;
+
+  /**
+   * Creative-protocol capabilities forwarded into `get_adcp_capabilities.creative`.
+   * Use to declare `supportsCompliance`, `hasCreativeLibrary`,
+   * `supportsGeneration`, and `supportsTransformation` from `definePlatform`.
+   * Adopters that don't run a provenance-verification pipeline should
+   * declare the relevant fields as `false` so creative storyboards gate
+   * cleanly.
+   *
+   * Resolves the `definePlatform` passthrough gap noted in adcp-client#2199.
+   */
+  creative?: Partial<CreativeCapabilities>;
+
+  /**
+   * Account capabilities forwarded into `get_adcp_capabilities.account` as a
+   * base layer. The framework's existing `requireOperatorAuth` and
+   * `supportedBillings` projections overlay on top via the per-domain
+   * `account` override, so explicit projections win on those keys.
+   * `authorizationEndpoint`, `defaultBilling`, `requiredForProducts`, and
+   * `sandbox` are pure adopter-driven additions exposed through this slot.
+   *
+   * Resolves the `definePlatform` passthrough gap noted in adcp-client#2199.
+   */
+  account?: Partial<AccountCapabilities>;
+
+  /**
+   * Deep-merge overrides applied to the wire `get_adcp_capabilities`
+   * response. Use this for fields that the top-level `DecisioningCapabilities`
+   * shape doesn't model — `media_buy.propagation_surfaces`,
+   * `media_buy.measurement_terms`, `signals.discovery_modes`, etc. The
+   * framework's per-domain projections (auto-derived `media_buy`, `brand`,
+   * `account`, `compliance_testing` blocks) are merged AFTER adopter
+   * overrides, so framework-derived values remain authoritative on the keys
+   * the projection engine handles.
+   *
+   * Mirrors `AdcpCapabilitiesConfig.overrides` on the lower-level
+   * `createAdcpServer` API. Resolves the `definePlatform` passthrough gap
+   * noted in adcp-client#2199.
+   */
+  overrides?: AdcpCapabilitiesOverrides;
+
+  /**
+   * Release-precision AdCP versions this platform supports (e.g. `["3.0", "3.1"]`).
+   * Forwarded into `get_adcp_capabilities.adcp.supported_versions`. 3.1+
+   * sellers should declare here the same release-precision strings they
+   * emit in `adcp_version` on responses; 3.0-pinned sellers can omit.
+   *
+   * Resolves the same gap previously noted for `supported_versions` —
+   * was unreachable through `definePlatform` because
+   * `CreateAdcpServerFromPlatformOptions` omits `'capabilities'` from
+   * `AdcpServerConfig`. See adcp-client#2199.
+   */
+  supported_versions?: string[];
 
   /**
    * Platform-specific config. Strongly typed when the adopter uses the generic.

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -166,6 +166,34 @@ import type { Product } from '../../../types/tools.generated';
 import { normalizeErrors } from '../../normalize-errors';
 import { redactCredentialPatterns } from '../../redact';
 
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  if (v === null || typeof v !== 'object') return false;
+  if (Array.isArray(v)) return false;
+  const proto = Object.getPrototypeOf(v);
+  return proto === Object.prototype || proto === null;
+}
+
+function deepMergePlainObjects(target: unknown, source: unknown): unknown {
+  if (source === undefined) return target;
+  if (source === null) return null;
+  if (!isPlainObject(source)) return source;
+  if (!isPlainObject(target)) return { ...source };
+  const out: Record<string, unknown> = { ...target };
+  for (const [key, value] of Object.entries(source)) {
+    if (value === undefined) continue;
+    if (value === null) {
+      delete out[key];
+      continue;
+    }
+    out[key] = deepMergePlainObjects(out[key], value);
+  }
+  return out;
+}
+
+function mergeCapabilityOverride<T extends object>(adopter: T | null | undefined, framework: Partial<T>): T {
+  return deepMergePlainObjects(adopter ?? {}, framework) as T;
+}
+
 /**
  * Apply `normalizeErrors` to a sync_creatives row's optional `errors`
  * field. Adopters often return errors as bare strings, native Error
@@ -1163,18 +1191,64 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
   const hasOverridesProjection =
     hasMediaBuyProjection || hasBrandProjection || hasAccountProjection || hasComplianceTestingProjection;
 
+  // Adopter-declared passthrough fields (issue #2199). DecisioningCapabilities
+  // exposes a subset of AdcpCapabilitiesConfig that wasn't previously reachable
+  // through definePlatform; forward them so adopters can declare not-supported
+  // feature blocks, creative-capability flags, account-shape additions,
+  // deep-merge overrides, and release-precision supported_versions without
+  // dropping to the lower-level createAdcpServer API.
+  //
+  // Precedence per the brief on #2199:
+  //  - features:  adopter base; auto-derived audience_targeting /
+  //               conversion_tracking / content_standards booleans take
+  //               precedence (handled downstream by applyCapabilityOverrides
+  //               on the inner createAdcpServer call — the framework's
+  //               media_buy override is applied AFTER capConfig.features
+  //               lays down the base).
+  //  - account:   adopter base; existing requireOperatorAuth /
+  //               supportedBilling projections overlay through the
+  //               per-domain account override below.
+  //  - overrides: adopter-declared overrides merged before framework's
+  //               per-domain blocks so framework-derived blocks remain
+  //               authoritative on the keys the projection engine handles.
+  const adopterFeatures = platform.capabilities.features;
+  const adopterCreative = platform.capabilities.creative;
+  const adopterAccount = platform.capabilities.account;
+  const adopterOverrides = platform.capabilities.overrides;
+  const adopterSupportedVersions = platform.capabilities.supported_versions;
+  const hasAdopterPassthroughs =
+    adopterFeatures !== undefined ||
+    adopterCreative !== undefined ||
+    adopterAccount !== undefined ||
+    adopterOverrides !== undefined ||
+    adopterSupportedVersions !== undefined;
+  const hasOverridesObject = hasOverridesProjection || adopterOverrides !== undefined;
+
   const projectedCapabilitiesConfig =
-    hasOverridesProjection || hasSpecialisms
+    hasOverridesObject || hasSpecialisms || hasAdopterPassthroughs
       ? {
           ...(hasSpecialisms && {
             specialisms: [...platformSpecialisms] as NonNullable<GetAdCPCapabilitiesResponse['specialisms']>,
           }),
           ...(claimsSignedSpecialism && { request_signing: { supported: true as const } }),
-          ...(hasOverridesProjection && {
+          ...(adopterFeatures !== undefined && { features: adopterFeatures }),
+          ...(adopterCreative !== undefined && { creative: adopterCreative }),
+          ...(adopterAccount !== undefined && { account: adopterAccount }),
+          ...(adopterSupportedVersions !== undefined && {
+            supported_versions: [...adopterSupportedVersions],
+          }),
+          ...(hasOverridesObject && {
             overrides: {
-              ...(hasMediaBuyProjection && { media_buy: mediaBuyOverrides }),
-              ...(hasBrandProjection && { brand: brandOverrides }),
-              ...(hasAccountProjection && { account: accountOverrides }),
+              ...(adopterOverrides ?? {}),
+              ...(hasMediaBuyProjection && {
+                media_buy: mergeCapabilityOverride(adopterOverrides?.media_buy, mediaBuyOverrides),
+              }),
+              ...(hasBrandProjection && {
+                brand: mergeCapabilityOverride(adopterOverrides?.brand, brandOverrides),
+              }),
+              ...(hasAccountProjection && {
+                account: mergeCapabilityOverride(adopterOverrides?.account, accountOverrides),
+              }),
               ...(hasComplianceTestingProjection &&
                 complianceTestingOverrides != null && { compliance_testing: complianceTestingOverrides }),
             },

--- a/test/server-decisioning-capability-projections.test.js
+++ b/test/server-decisioning-capability-projections.test.js
@@ -229,6 +229,68 @@ describe('Capability projections — declarative capability blocks on Decisionin
     assert.notStrictEqual(features.content_standards, true);
   });
 
+  it('forwards AdcpCapabilitiesConfig passthroughs declared on DecisioningCapabilities', async () => {
+    const server = createAdcpServerFromPlatform(
+      basePlatform({
+        features: {
+          inlineCreativeManagement: true,
+          propertyListFiltering: true,
+          audienceTargeting: false,
+        },
+        audience_targeting: {
+          supported_identifier_types: ['hashed_email'],
+          minimum_audience_size: 50,
+        },
+        targeting: {
+          geo_countries: true,
+        },
+        creative: {
+          supportsCompliance: false,
+          hasCreativeLibrary: false,
+          supportsGeneration: true,
+          supportsTransformation: false,
+        },
+        account: {
+          requireOperatorAuth: false,
+          supportedBilling: ['agent'],
+          defaultBilling: 'agent',
+          requiredForProducts: true,
+          sandbox: true,
+        },
+        requireOperatorAuth: true,
+        supportedBillings: ['operator'],
+        supported_versions: ['3.1'],
+        overrides: {
+          media_buy: {
+            execution: {
+              targeting: {
+                keyword_targets: {
+                  supported_match_types: ['exact'],
+                },
+              },
+            },
+          },
+        },
+      }),
+      { name: 'h', version: '0.0.1', validation: { requests: 'off', responses: 'off' } }
+    );
+
+    const result = await dispatchCapabilities(server);
+    const caps = result.structuredContent;
+
+    assert.deepStrictEqual(caps?.adcp?.supported_versions, ['3.1']);
+    assert.strictEqual(caps?.media_buy?.features?.inline_creative_management, true);
+    assert.strictEqual(caps?.media_buy?.features?.property_list_filtering, true);
+    assert.strictEqual(caps?.media_buy?.features?.audience_targeting, true);
+    assert.strictEqual(caps?.media_buy?.execution?.targeting?.geo_countries, true);
+    assert.deepStrictEqual(caps?.media_buy?.execution?.targeting?.keyword_targets?.supported_match_types, ['exact']);
+    assert.strictEqual(caps?.creative?.supports_generation, true);
+    assert.strictEqual(caps?.account?.required_for_products, true);
+    assert.strictEqual(caps?.account?.sandbox, true);
+    assert.strictEqual(caps?.account?.require_operator_auth, true);
+    assert.deepStrictEqual(caps?.account?.supported_billing, ['operator']);
+  });
+
   it('brand-protocol capability block projects via overrides.brand', async () => {
     // Brand-rights adopters declare capabilities.brand; the framework
     // projects via the overrides.brand deep-merge seam. When


### PR DESCRIPTION
Closes #2199.

## Summary

Adds optional passthrough fields to `DecisioningCapabilities<TConfig>` so adopters using `definePlatform` / `createAdcpServerFromPlatform` can declare capability details that were already modeled by the lower-level `AdcpCapabilitiesConfig` surface:

- `features?: Partial<MediaBuyFeatures>`
- `creative?: Partial<CreativeCapabilities>`
- `account?: Partial<AccountCapabilities>`
- `overrides?: AdcpCapabilitiesOverrides`
- `supported_versions?: string[]`

This is the Option A shape from the #2199 triage: one declaration point on the platform, with framework-derived projections still authoritative for fields the framework owns.

## Notes

- `features` is forwarded as the base `media_buy.features` config; rich framework projections such as `audience_targeting`, `conversion_tracking`, and `content_standards` still force their matching feature booleans to `true`.
- `account` is forwarded as the base account block; existing `requireOperatorAuth` and `supportedBillings` projections still overlay that base.
- `overrides` are merged before framework-derived per-domain blocks, preserving existing framework precedence.
- `supported_versions` is now emitted on `get_adcp_capabilities.adcp.supported_versions`; previously it was only used for version-error details.

## Validation

- `npm run build:lib`
- `npm run typecheck`
- `npm audit --audit-level=high`
- `npx prettier --check src/lib/server/create-adcp-server.ts test/server-decisioning-capability-projections.test.js src/lib/server/decisioning/capabilities.ts src/lib/server/decisioning/runtime/from-platform.ts .changeset/2199-decisioning-capabilities-passthrough.md`
- `NODE_ENV=test node --test --test-timeout=60000 test/server-decisioning-capability-projections.test.js`
