### PR TITLE
fix: recognize content standards specialism

### DIFF
--- a/.changeset/fix-content-standards-specialism.md
+++ b/.changeset/fix-content-standards-specialism.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Recognize the `content-standards` specialism as support for governance content standards feature gates and include declared specialisms in capability diagnostics.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/sdk",
-  "version": "9.0.0-beta.26",
+  "version": "9.0.0-beta.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/sdk",
-      "version": "9.0.0-beta.26",
+      "version": "9.0.0-beta.27",
       "license": "Apache-2.0",
       "workspaces": [
         ".",
@@ -7356,7 +7356,7 @@
       "version": "6.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adcp/sdk": "^9.0.0-beta.26"
+        "@adcp/sdk": "^9.0.0-beta.27"
       },
       "bin": {
         "adcp": "bin/adcp.js"

--- a/src/lib/utils/capabilities.ts
+++ b/src/lib/utils/capabilities.ts
@@ -515,7 +515,9 @@ function declaresSpecialism(specialisms: readonly string[] | undefined, speciali
 }
 
 function hasContentStandardsSupport(capabilities: Pick<AdcpCapabilities, 'features' | 'specialisms'>): boolean {
-  return capabilities.features.contentStandards === true || declaresSpecialism(capabilities.specialisms, 'content-standards');
+  return (
+    capabilities.features.contentStandards === true || declaresSpecialism(capabilities.specialisms, 'content-standards')
+  );
 }
 
 /**

--- a/src/lib/utils/capabilities.ts
+++ b/src/lib/utils/capabilities.ts
@@ -156,6 +156,9 @@ export interface AdcpCapabilities {
   /** Supported protocols */
   protocols: AdcpProtocol[];
 
+  /** Public specialism ids declared by this agent */
+  specialisms?: string[];
+
   /** Media buy specific features */
   features: MediaBuyFeatures;
 
@@ -507,12 +510,24 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
+function declaresSpecialism(specialisms: readonly string[] | undefined, specialism: string): boolean {
+  return specialisms?.includes(specialism) === true;
+}
+
+function hasContentStandardsSupport(capabilities: Pick<AdcpCapabilities, 'features' | 'specialisms'>): boolean {
+  return capabilities.features.contentStandards === true || declaresSpecialism(capabilities.specialisms, 'content-standards');
+}
+
 /**
  * Parse a get_adcp_capabilities response into normalized form
  */
 export function parseCapabilitiesResponse(response: any): AdcpCapabilities {
   const majorVersions = (response.adcp?.major_versions ?? [2]) as AdcpMajorVersion[];
   const highestVersion = Math.max(...majorVersions) as AdcpMajorVersion;
+  const specialisms = Array.isArray(response.specialisms)
+    ? response.specialisms.filter((s: unknown): s is string => typeof s === 'string')
+    : undefined;
+  const declaresContentStandardsSpecialism = declaresSpecialism(specialisms, 'content-standards');
 
   // AdCP 3.1+ release-precision capability fields per spec PR
   // `adcontextprotocol/adcp#3493`. Both fields are optional during the 3.x
@@ -541,7 +556,7 @@ export function parseCapabilitiesResponse(response: any): AdcpCapabilities {
   const features: MediaBuyFeatures = {
     inlineCreativeManagement: response.media_buy?.features?.inline_creative_management ?? false,
     propertyListFiltering: response.media_buy?.features?.property_list_filtering ?? false,
-    contentStandards: response.media_buy?.features?.content_standards ?? false,
+    contentStandards: response.media_buy?.features?.content_standards === true || declaresContentStandardsSpecialism,
     conversionTracking: response.media_buy?.features?.conversion_tracking ?? false,
     audienceTargeting: response.media_buy?.features?.audience_targeting ?? false,
   };
@@ -583,6 +598,7 @@ export function parseCapabilitiesResponse(response: any): AdcpCapabilities {
     supportedVersions,
     buildVersion,
     protocols,
+    specialisms,
     features,
     account,
     creative,
@@ -624,7 +640,7 @@ export function supportsPropertyListFiltering(capabilities: AdcpCapabilities): b
  * Check if content standards are supported (v3 feature)
  */
 export function supportsContentStandards(capabilities: AdcpCapabilities): boolean {
-  return capabilities.features.contentStandards ?? false;
+  return hasContentStandardsSupport(capabilities);
 }
 
 /**
@@ -820,6 +836,9 @@ export function resolveFeature(capabilities: AdcpCapabilities, feature: FeatureN
   // Media buy features (e.g., 'audience_targeting', 'conversion_tracking')
   const featureKey = FEATURE_KEY_MAP[feature];
   if (featureKey) {
+    if (featureKey === 'contentStandards') {
+      return supportsContentStandards(capabilities);
+    }
     return capabilities.features[featureKey] ?? false;
   }
 
@@ -846,9 +865,18 @@ export function listDeclaredFeatures(capabilities: AdcpCapabilities): string[] {
 
   // Media buy features
   for (const [snakeKey, camelKey] of Object.entries(FEATURE_KEY_MAP)) {
-    if (capabilities.features[camelKey]) {
+    const declared =
+      camelKey === 'contentStandards'
+        ? supportsContentStandards(capabilities)
+        : (capabilities.features[camelKey] ?? false);
+    if (declared) {
       features.push(snakeKey);
     }
+  }
+
+  // Public specialism declarations
+  for (const specialism of capabilities.specialisms ?? []) {
+    features.push(`specialism:${specialism}`);
   }
 
   // Extensions

--- a/test/lib/feature-capability-validation.test.js
+++ b/test/lib/feature-capability-validation.test.js
@@ -4,7 +4,9 @@ const { test, describe } = require('node:test');
 const assert = require('node:assert');
 
 const {
+  parseCapabilitiesResponse,
   resolveFeature,
+  supportsContentStandards,
   listDeclaredFeatures,
   FeatureUnsupportedError,
   SingleAgentClient,
@@ -51,6 +53,17 @@ function makeCapabilities(overrides = {}) {
   };
 }
 
+function makeClientWithCapabilities(capabilities) {
+  const client = new SingleAgentClient({
+    id: 'test',
+    name: 'Test',
+    agent_uri: 'https://seller.example.com/mcp',
+    protocol: 'mcp',
+  });
+  client.getCapabilities = async () => capabilities;
+  return client;
+}
+
 describe('resolveFeature', () => {
   test('checks supported_protocols for protocol names', () => {
     const caps = makeCapabilities();
@@ -78,6 +91,38 @@ describe('resolveFeature', () => {
     assert.strictEqual(resolveFeature(caps, 'conversion_tracking'), true);
     assert.strictEqual(resolveFeature(caps, 'property_list_filtering'), false);
     assert.strictEqual(resolveFeature(caps, 'content_standards'), false);
+  });
+
+  test('treats content-standards specialism as content_standards support', () => {
+    const caps = parseCapabilitiesResponse({
+      adcp: { major_versions: [3] },
+      supported_protocols: ['governance'],
+      specialisms: ['content-standards'],
+      media_buy: { features: { content_standards: false } },
+      extensions_supported: [],
+    });
+
+    assert.strictEqual(caps.features.contentStandards, true);
+    assert.strictEqual(resolveFeature(caps, 'governance'), true);
+    assert.strictEqual(resolveFeature(caps, 'content_standards'), true);
+  });
+
+  test('treats hand-built content-standards specialism as content_standards support', () => {
+    const caps = makeCapabilities({
+      protocols: ['governance'],
+      specialisms: ['content-standards'],
+      features: {
+        inlineCreativeManagement: false,
+        propertyListFiltering: false,
+        contentStandards: false,
+        conversionTracking: false,
+        audienceTargeting: false,
+      },
+    });
+
+    assert.strictEqual(supportsContentStandards(caps), true);
+    assert.strictEqual(resolveFeature(caps, 'content_standards'), true);
+    assert.ok(listDeclaredFeatures(caps).includes('content_standards'));
   });
 
   test('returns false for unknown features', () => {
@@ -116,6 +161,21 @@ describe('listDeclaredFeatures', () => {
     assert.ok(features.includes('targeting.device_type'), 'should list targeting.device_type');
     // false features should not be listed
     assert.ok(!features.includes('targeting.geo_regions'), 'should not list false targeting feature');
+  });
+
+  test('lists declared specialisms for feature-gate diagnostics', () => {
+    const caps = parseCapabilitiesResponse({
+      adcp: { major_versions: [3] },
+      supported_protocols: ['governance'],
+      specialisms: ['content-standards', 'property-lists'],
+      extensions_supported: [],
+    });
+    const features = listDeclaredFeatures(caps);
+
+    assert.ok(features.includes('governance'), 'should list protocol');
+    assert.ok(features.includes('content_standards'), 'should list resolved internal content standards feature');
+    assert.ok(features.includes('specialism:content-standards'), 'should list public content standards specialism');
+    assert.ok(features.includes('specialism:property-lists'), 'should list other public specialisms');
   });
 
   test('returns empty-ish list for minimal capabilities', () => {
@@ -186,6 +246,41 @@ describe('SingleAgentClient feature API exists', () => {
       protocol: 'mcp',
     });
     assert.strictEqual(typeof client.refreshCapabilities, 'function');
+  });
+});
+
+describe('SingleAgentClient feature gate', () => {
+  test('allows content standards tasks for governance + content-standards specialism', async () => {
+    const capabilities = parseCapabilitiesResponse({
+      adcp: { major_versions: [3] },
+      supported_protocols: ['governance'],
+      specialisms: ['content-standards'],
+      extensions_supported: [],
+    });
+    const client = makeClientWithCapabilities(capabilities);
+
+    await assert.doesNotReject(() => client.require('governance', 'content_standards'));
+  });
+
+  test('content-standards specialism does not bypass missing governance protocol', async () => {
+    const capabilities = parseCapabilitiesResponse({
+      adcp: { major_versions: [3] },
+      supported_protocols: [],
+      specialisms: ['content-standards'],
+      extensions_supported: [],
+    });
+    const client = makeClientWithCapabilities(capabilities);
+
+    await assert.rejects(
+      () => client.require('governance', 'content_standards'),
+      err => {
+        assert.ok(err instanceof FeatureUnsupportedError);
+        assert.ok(err.message.includes('governance'));
+        assert.ok(err.message.includes('content_standards'));
+        assert.ok(err.message.includes('specialism:content-standards'));
+        return true;
+      }
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes content standards capability gating so the public `content-standards` specialism satisfies the internal `content_standards` feature requirement while still requiring the `governance` protocol.
Preserves declared specialisms in normalized capabilities and includes them in feature diagnostics.
Adds focused helper and `SingleAgentClient.require()` regression coverage plus a patch changeset.
Includes the workspace lockfile version bump from 9.0.0-beta.26 to 9.0.0-beta.27.

## Validation

- `npm run build:lib`
- `NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/lib/feature-capability-validation.test.js`
- `NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/lib/v3-compatibility.test.js`
- pre-push validation: typecheck + build