### PR TITLE
fix: pin storyboard schemas to compliance version

### DIFF
--- a/.changeset/storyboard-compliance-schema-pin.md
+++ b/.changeset/storyboard-compliance-schema-pin.md
@@ -1,0 +1,7 @@
+---
+'@adcp/sdk': patch
+---
+
+Fail fast when `adcp storyboard run --compliance-version` selects a compliance bundle whose matching schema bundle is unavailable.
+
+The storyboard runner now refuses to proceed with installed default schemas in that case and points operators at `--schema-root` / `ADCP_SCHEMA_ROOT` or an SDK install that includes the requested schema bundle.

--- a/src/lib/testing/storyboard/compliance.ts
+++ b/src/lib/testing/storyboard/compliance.ts
@@ -250,9 +250,7 @@ function assertComplianceSchemaBundleAvailable(
   complianceDir: string | undefined
 ): void {
   if (hasSchemaBundle(adcpVersion)) return;
-  const selector = options.version
-    ? `--compliance-version ${options.version}`
-    : `compliance cache ${complianceDir}`;
+  const selector = options.version ? `--compliance-version ${options.version}` : `compliance cache ${complianceDir}`;
   const bundleKey = resolveBundleKey(adcpVersion);
   throw new Error(
     `${selector} selected AdCP compliance version "${adcpVersion}", but no matching schema bundle was found. ` +

--- a/src/lib/testing/storyboard/compliance.ts
+++ b/src/lib/testing/storyboard/compliance.ts
@@ -14,7 +14,7 @@ import { loadStoryboardFile } from './loader';
 import { ADCP_VERSION } from '../../version';
 import { ADCPError } from '../../errors';
 import { isAdcpVersionSupported } from '../../utils/adcp-version-config';
-import { resolveBundleKey } from '../../validation/schema-loader';
+import { hasSchemaBundle, resolveBundleKey } from '../../validation/schema-loader';
 import { synthesizeRequestSigningSteps } from './request-signing/synthesize';
 import type { RunnerSelectionResult, Storyboard } from './types';
 
@@ -200,9 +200,8 @@ function getRepoRoot(): string {
  *   3. `{package-root}/compliance/cache/{version}` (default, ships with the npm package)
  */
 export function getComplianceCacheDir(options: ResolveOptions = {}): string {
-  if (options.complianceDir) return options.complianceDir;
-  const envOverride = process.env.ADCP_COMPLIANCE_DIR;
-  if (envOverride) return envOverride;
+  const configured = getConfiguredComplianceDir(options);
+  if (configured) return configured;
   const version = options.version || readAdcpVersion();
   return join(getRepoRoot(), 'compliance', 'cache', version);
 }
@@ -236,8 +235,36 @@ export function loadComplianceIndex(options: ResolveOptions = {}): ComplianceInd
 export function getExternalSchemaRootForCompliance(options: ResolveOptions, adcpVersion: string): string | undefined {
   const configuredSchemaRoot = getConfiguredSchemaRoot(options);
   if (configuredSchemaRoot) return configuredSchemaRoot;
-  if (!options.complianceDir) return undefined;
-  return findExternalSchemaRoot(options.complianceDir, adcpVersion);
+  const complianceDir = getConfiguredComplianceDir(options);
+  const siblingSchemaRoot = complianceDir ? findExternalSchemaRoot(complianceDir, adcpVersion) : undefined;
+  if (siblingSchemaRoot) return siblingSchemaRoot;
+  if (options.version !== undefined || complianceDir !== undefined) {
+    assertComplianceSchemaBundleAvailable(options, adcpVersion, complianceDir);
+  }
+  return undefined;
+}
+
+function assertComplianceSchemaBundleAvailable(
+  options: ResolveOptions,
+  adcpVersion: string,
+  complianceDir: string | undefined
+): void {
+  if (hasSchemaBundle(adcpVersion)) return;
+  const selector = options.version
+    ? `--compliance-version ${options.version}`
+    : `compliance cache ${complianceDir}`;
+  const bundleKey = resolveBundleKey(adcpVersion);
+  throw new Error(
+    `${selector} selected AdCP compliance version "${adcpVersion}", but no matching schema bundle was found. ` +
+      `Refusing to validate storyboard responses with the installed default schemas. ` +
+      `Pass --schema-root PATH or set ADCP_SCHEMA_ROOT to a schema-data root for "${adcpVersion}" ` +
+      `(for example dist/lib/schemas-data/${bundleKey} or schemas/cache/${adcpVersion}), ` +
+      `or install/sync an @adcp/sdk package that includes that schema bundle.`
+  );
+}
+
+function getConfiguredComplianceDir(options: Pick<ResolveOptions, 'complianceDir'>): string | undefined {
+  return options.complianceDir ?? process.env.ADCP_COMPLIANCE_DIR;
 }
 
 function getConfiguredSchemaRoot(options: Pick<ResolveOptions, 'schemaRoot'>): string | undefined {

--- a/test/lib/cli-storyboard-file-flag.test.js
+++ b/test/lib/cli-storyboard-file-flag.test.js
@@ -1,7 +1,7 @@
 const { test, before, after } = require('node:test');
 const assert = require('node:assert');
 const { spawnSync } = require('node:child_process');
-const { writeFileSync, unlinkSync, mkdtempSync } = require('node:fs');
+const { writeFileSync, unlinkSync, mkdtempSync, mkdirSync, rmSync } = require('node:fs');
 const path = require('node:path');
 const os = require('node:os');
 
@@ -44,6 +44,14 @@ function runCli(args) {
   return spawnSync('node', [CLI, ...args], { encoding: 'utf8' });
 }
 
+function writeComplianceIndex(complianceDir, version) {
+  mkdirSync(complianceDir, { recursive: true });
+  writeFileSync(
+    path.join(complianceDir, 'index.json'),
+    JSON.stringify({ adcp_version: version, universal: [], protocols: [], specialisms: [] })
+  );
+}
+
 test('--file <path> (space form) loads the YAML', () => {
   const result = runCli(['storyboard', 'run', 'test-mcp', '--file', scenarioPath, '--dry-run']);
   assert.strictEqual(result.status, 0, `expected exit 0, got ${result.status}. stderr: ${result.stderr}`);
@@ -67,4 +75,38 @@ test('--file combined with a storyboard ID is rejected', () => {
   const result = runCli(['storyboard', 'run', 'test-mcp', 'some-id', '--file', scenarioPath, '--dry-run']);
   assert.strictEqual(result.status, 2);
   assert.match(result.stderr, /Cannot combine a storyboard ID with --file/);
+});
+
+test('--compliance-version fails before dry-run when matching schemas are unavailable', () => {
+  const tempRoot = mkdtempSync(path.join(os.tmpdir(), 'adcp-cli-compliance-missing-schema-'));
+  const complianceDir = path.join(tempRoot, 'compliance-cache', '9.9.0-beta.1');
+  const oldComplianceDir = process.env.ADCP_COMPLIANCE_DIR;
+  const oldSchemaRoot = process.env.ADCP_SCHEMA_ROOT;
+  try {
+    process.env.ADCP_COMPLIANCE_DIR = complianceDir;
+    delete process.env.ADCP_SCHEMA_ROOT;
+    writeComplianceIndex(complianceDir, '9.9.0-beta.1');
+
+    const result = runCli([
+      'storyboard',
+      'run',
+      'test-mcp',
+      '--file',
+      scenarioPath,
+      '--dry-run',
+      '--compliance-version',
+      '9.9.0-beta.1',
+    ]);
+
+    assert.strictEqual(result.status, 2);
+    assert.match(result.stderr, /--compliance-version 9\.9\.0-beta\.1 selected AdCP compliance version/);
+    assert.match(result.stderr, /installed default schemas/);
+    assert.match(result.stderr, /--schema-root/);
+  } finally {
+    if (oldComplianceDir === undefined) delete process.env.ADCP_COMPLIANCE_DIR;
+    else process.env.ADCP_COMPLIANCE_DIR = oldComplianceDir;
+    if (oldSchemaRoot === undefined) delete process.env.ADCP_SCHEMA_ROOT;
+    else process.env.ADCP_SCHEMA_ROOT = oldSchemaRoot;
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
 });

--- a/test/lib/storyboard-version-negotiation.test.js
+++ b/test/lib/storyboard-version-negotiation.test.js
@@ -563,6 +563,76 @@ describe('storyboard runner AdCP version negotiation', () => {
     }
   });
 
+  test('explicit compliance version fails fast when no matching schema bundle is available', () => {
+    const { getExternalSchemaRootForCompliance } = require('../../dist/lib/testing/storyboard/index.js');
+    const missingVersion = '9.9.0-beta.1';
+
+    assert.throws(
+      () => getExternalSchemaRootForCompliance({ version: missingVersion }, missingVersion),
+      /--compliance-version 9\.9\.0-beta\.1 selected AdCP compliance version "9\.9\.0-beta\.1".*installed default schemas.*--schema-root/
+    );
+  });
+
+  test('ADCP_COMPLIANCE_DIR resolves sibling schema bundle for scoped validation', () => {
+    const {
+      getExternalSchemaRootForCompliance,
+      loadComplianceIndex,
+    } = require('../../dist/lib/testing/storyboard/index.js');
+
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'adcp-env-compliance-schema-'));
+    const complianceDir = path.join(tempRoot, 'package', 'compliance', 'cache', '9.9.0-beta.1');
+    const schemaRoot = path.join(tempRoot, 'package', 'dist', 'lib', 'schemas-data', '9.9.0-beta.1');
+    const oldComplianceDir = process.env.ADCP_COMPLIANCE_DIR;
+    const oldSchemaRoot = process.env.ADCP_SCHEMA_ROOT;
+    try {
+      delete process.env.ADCP_SCHEMA_ROOT;
+      process.env.ADCP_COMPLIANCE_DIR = complianceDir;
+      writeComplianceIndex(complianceDir, '9.9.0-beta.1');
+      writeGetProductsRequestSchema(schemaRoot, '9.9.0-beta.1', 'env-sibling');
+
+      const index = loadComplianceIndex({});
+
+      assert.strictEqual(index.adcp_version, '9.9.0-beta.1');
+      assert.strictEqual(getExternalSchemaRootForCompliance({}, index.adcp_version), schemaRoot);
+    } finally {
+      if (oldComplianceDir === undefined) delete process.env.ADCP_COMPLIANCE_DIR;
+      else process.env.ADCP_COMPLIANCE_DIR = oldComplianceDir;
+      if (oldSchemaRoot === undefined) delete process.env.ADCP_SCHEMA_ROOT;
+      else process.env.ADCP_SCHEMA_ROOT = oldSchemaRoot;
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('ADCP_COMPLIANCE_DIR fails fast when matching schemas are unavailable', () => {
+    const {
+      getExternalSchemaRootForCompliance,
+      loadComplianceIndex,
+    } = require('../../dist/lib/testing/storyboard/index.js');
+
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'adcp-env-compliance-missing-schema-'));
+    const complianceDir = path.join(tempRoot, 'package', 'compliance', 'cache', '9.9.0-beta.1');
+    const oldComplianceDir = process.env.ADCP_COMPLIANCE_DIR;
+    const oldSchemaRoot = process.env.ADCP_SCHEMA_ROOT;
+    try {
+      delete process.env.ADCP_SCHEMA_ROOT;
+      process.env.ADCP_COMPLIANCE_DIR = complianceDir;
+      writeComplianceIndex(complianceDir, '9.9.0-beta.1');
+
+      const index = loadComplianceIndex({});
+
+      assert.throws(
+        () => getExternalSchemaRootForCompliance({}, index.adcp_version),
+        /compliance cache .* selected AdCP compliance version "9\.9\.0-beta\.1".*installed default schemas.*--schema-root/
+      );
+    } finally {
+      if (oldComplianceDir === undefined) delete process.env.ADCP_COMPLIANCE_DIR;
+      else process.env.ADCP_COMPLIANCE_DIR = oldComplianceDir;
+      if (oldSchemaRoot === undefined) delete process.env.ADCP_SCHEMA_ROOT;
+      else process.env.ADCP_SCHEMA_ROOT = oldSchemaRoot;
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   test('latest compliance metadata is repaired from schemaRoot index before storyboard annotation', () => {
     const {
       applyAdcpVersionRunOptions,


### PR DESCRIPTION
Fixes #2206.\n\nThis prevents storyboard compliance runs with an explicit compliance cache or version from silently validating responses against the installed default schema bundle when matching schemas are unavailable. It also resolves sibling schema bundles for ADCP_COMPLIANCE_DIR, adds helper-level and CLI smoke coverage, and includes a patch changeset.\n\nValidation: npm run build:lib; node --test-timeout=60000 --test test/lib/storyboard-version-negotiation.test.js; node --test-timeout=60000 --test test/lib/cli-storyboard-file-flag.test.js; npx commitlint --from HEAD~1 --to HEAD --verbose; pre-push typecheck/build.