### PR TITLE
feat(creative): add pluggable preview cache backend

### DIFF
--- a/.changeset/durable-preview-assets.md
+++ b/.changeset/durable-preview-assets.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Document durable MCPUI preview asset patterns and add a pluggable cache backend for batch preview helpers.

--- a/docs/guides/PREVIEW-ASSET-DURABILITY.md
+++ b/docs/guides/PREVIEW-ASSET-DURABILITY.md
@@ -85,17 +85,27 @@ Production services that cache preview results should pass a shared
 `PreviewCacheBackend`:
 
 ```ts
-import type { PreviewCacheBackend } from '@adcp/sdk';
+import { batchPreviewFormats, type PreviewCacheBackend } from '@adcp/sdk';
+import type { RedisClientType } from 'redis';
 
-const previewCache: PreviewCacheBackend = {
-  get: key => redis.get(key).then(raw => (raw ? JSON.parse(raw) : null)),
-  set: async (key, entry) => {
-    await redis.set(key, JSON.stringify(entry), { EX: 3600 });
-  },
-  delete: async key => {
-    await redis.del(key);
-  },
-};
+function redisPreviewCache(redis: RedisClientType): PreviewCacheBackend {
+  return {
+    get: key => redis.get(key).then(raw => (raw ? JSON.parse(raw) : null)),
+    set: async (key, entry) => {
+      const ttlSeconds = entry.expiresAt
+        ? Math.max(1, Math.floor((Date.parse(entry.expiresAt) - Date.now()) / 1000))
+        : 3600;
+      await redis.set(key, JSON.stringify(entry), { EX: ttlSeconds });
+    },
+    delete: async key => {
+      await redis.del(key);
+    },
+  };
+}
+
+const previews = await batchPreviewFormats(formats, creativeAgentClient, {
+  cacheBackend: redisPreviewCache(redis),
+});
 ```
 
 Only cache references that already resolve durably. If the cached `previewUrl`
@@ -112,9 +122,9 @@ For `urlRender` and `bothRender`, make sure `preview_url` is backed by a durable
 route:
 
 ```ts
-import { urlRender } from '@adcp/sdk';
+import { previewCreative, urlRender } from '@adcp/sdk';
 
-return {
+return previewCreative.single({
   previews: [
     {
       preview_id: variant.id,
@@ -127,7 +137,7 @@ return {
       ],
     },
   ],
-};
+});
 ```
 
 The route should be able to resolve `variant.assetId` from shared storage from

--- a/docs/guides/PREVIEW-ASSET-DURABILITY.md
+++ b/docs/guides/PREVIEW-ASSET-DURABILITY.md
@@ -1,0 +1,147 @@
+# Preview asset durability
+
+Creative workflows often return `preview_creative` renders as MCPUI preview
+URLs while the buyer is still iterating. Those URLs are part of the workflow
+contract: a browser, MCPUI host, later refinement call, or reviewer may fetch
+them after the tool call has returned and after a load balancer has routed the
+request to another process.
+
+If a preview URL depends on process-local state, it will fail in multi-pod
+deployments. A common failure mode is:
+
+1. Pod A generates a draft creative and returns
+   `/creative-sessions/{sessionId}/variants/{variantId}/assets/{assetId}`.
+2. The browser or MCPUI host fetches that URL through the load balancer.
+3. Pod B receives the request but does not have Pod A's in-memory session map.
+4. The preview 404s even though the original tool call succeeded.
+
+## TL;DR
+
+- `preview_url` values should resolve through durable storage in production.
+- In-memory maps are fine for local development and single-process demos, but
+  not for multi-pod services.
+- Treat draft bytes, hosted preview artifacts, and final campaign manifests as
+  separate lifecycle stages.
+- A cache of preview metadata is not an asset store. Cache entries may point at
+  durable URLs; they must not be the only place the asset exists.
+
+## Three lifecycle stages
+
+### 1. Inline draft bytes
+
+Use inline bytes only for small, immediate draft work: model output that has not
+yet been accepted, transformed, or reviewed. Inline bytes are convenient inside
+one request, but they should not be the only representation behind a URL that
+will be fetched later.
+
+Good uses:
+
+- passing a just-generated image to a renderer in the same process
+- holding a short-lived thumbnail while deciding whether to persist it
+- returning `preview_html` with `bothRender` when the host also receives a
+  durable `preview_url`
+
+Avoid:
+
+- returning a URL that can only be resolved from an in-memory `Map`
+- assuming sticky sessions will always route follow-up fetches to the creator
+  process
+
+### 2. Hosted preview artifact
+
+A hosted preview artifact is the durable resource behind `preview_url`. Store
+the bytes in object storage, a database blob table, or another shared backing
+service. Store the session and variant metadata in a durable index such as
+Postgres so follow-up calls can resolve lineage, selection state, evaluator
+notes, and current/final flags.
+
+Recommended shape:
+
+- object storage holds large asset bytes
+- Postgres or another durable database holds session, variant, asset, and
+  review metadata
+- preview routes resolve by opaque IDs and stream bytes from shared storage
+- URLs remain valid long enough for review, refinement, and finalization
+
+The URL can still be short-lived if it is re-mintable from durable metadata. For
+example, a route may authenticate the caller and redirect to a signed object
+storage URL. The critical property is that any pod can perform that lookup.
+
+### 3. Final campaign creative manifest
+
+The final creative manifest is the serving artifact that moves into the campaign
+or ad server workflow. It should reference approved assets and serving tags, not
+an arbitrary draft cache entry. Keep the draft/session lifecycle separate so a
+buyer can iterate without accidentally promoting every preview asset into a
+campaign creative.
+
+## Preview cache vs asset store
+
+`src/lib/utils/preview-utils.ts` includes a default process-local cache for
+batch preview helpers. That cache stores the result of `preview_creative`; it is
+not a durable asset store and is not shared across pods.
+
+Production services that cache preview results should pass a shared
+`PreviewCacheBackend`:
+
+```ts
+import type { PreviewCacheBackend } from '@adcp/sdk';
+
+const previewCache: PreviewCacheBackend = {
+  get: key => redis.get(key).then(raw => (raw ? JSON.parse(raw) : null)),
+  set: async (key, entry) => {
+    await redis.set(key, JSON.stringify(entry), { EX: 3600 });
+  },
+  delete: async key => {
+    await redis.del(key);
+  },
+};
+```
+
+Only cache references that already resolve durably. If the cached `previewUrl`
+points at process-local bytes, a shared cache only makes the broken reference
+available to more callers.
+
+## `preview_creative` response guidance
+
+Return `urlRender` or `bothRender` when the preview needs to be opened by a
+browser or MCPUI host. `htmlRender` alone is only appropriate when the caller can
+use inline HTML directly and no later fetch is required.
+
+For `urlRender` and `bothRender`, make sure `preview_url` is backed by a durable
+route:
+
+```ts
+import { urlRender } from '@adcp/sdk';
+
+return {
+  previews: [
+    {
+      preview_id: variant.id,
+      renders: [
+        urlRender({
+          render_id: variant.primaryRenderId,
+          role: 'primary',
+          preview_url: `https://creative.example/previews/${variant.assetId}`,
+        }),
+      ],
+    },
+  ],
+};
+```
+
+The route should be able to resolve `variant.assetId` from shared storage from
+any pod. Do not require the serving process to have created the variant in the
+same process lifetime.
+
+## Checklist
+
+- Store creative session metadata durably before returning a preview URL.
+- Store large preview bytes in shared storage, or make them re-mintable from a
+  durable source of truth.
+- Make preview asset IDs opaque; do not expose filesystem paths or internal
+  storage keys directly.
+- Treat memory caches as accelerators only. A cache miss should rehydrate from
+  durable storage or return a real not-found/error state.
+- Test with at least two app instances and route the fetch to a different
+  instance than the one that generated the preview.

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,7 @@ Welcome to the official documentation for `@adcp/sdk`, the TypeScript/JavaScript
 - [Validate Your Agent](./guides/VALIDATE-YOUR-AGENT.md) — five-command checklist + storyboard runner
 - [Account Resolution](./guides/account-resolution.md) — `'explicit'` vs `'implicit'` vs `'derived'` mode selection
 - [ctx_metadata Safety](./guides/CTX-METADATA-SAFETY.md) — don't store secrets there
+- [Preview Asset Durability](./guides/PREVIEW-ASSET-DURABILITY.md) — durable MCPUI preview URLs for generated creative assets
 - [Signing Guide](./guides/SIGNING-GUIDE.md) — RFC 9421 request signing + JWKS
 - [Conformance](./guides/CONFORMANCE.md) — property-based fuzzing against bundled JSON schemas
 - Worked reference adapters: `examples/hello_*` family (pick by specialism)

--- a/package.json
+++ b/package.json
@@ -274,6 +274,7 @@
     "docs/llms.txt",
     "docs/guides/BUILD-AN-AGENT.md",
     "docs/guides/CANONICAL-REFERENCE-RESOLVER.md",
+    "docs/guides/PREVIEW-ASSET-DURABILITY.md",
     "examples/**/*",
     "AGENTS.md",
     "README.md",

--- a/skills/build-creative-agent/SKILL.md
+++ b/skills/build-creative-agent/SKILL.md
@@ -53,6 +53,8 @@ Both run with `NoAccountCtx<TCtxMeta>` — they don't carry an authenticated acc
 
 `preview_creative` should return `urlRender` or `bothRender`, **not `htmlRender` alone**. The creative-template storyboard asserts `previews[0].renders[0].preview_url` is renderable. If your platform can host a preview URL, use `urlRender`. If you only have inline HTML, use `bothRender` (emit both `preview_url` and `preview_html`).
 
+Preview URLs must resolve from durable storage in production; do not back MCPUI preview links with pod-local in-memory maps except in local demos. See [`docs/guides/PREVIEW-ASSET-DURABILITY.md`](../../docs/guides/PREVIEW-ASSET-DURABILITY.md).
+
 ## Specialism deltas at a glance
 
 The fork targets cover the baseline + specialism deltas. Quick reference for what each archetype needs that the others don't:

--- a/skills/build-creative-agent/SKILL.md
+++ b/skills/build-creative-agent/SKILL.md
@@ -53,7 +53,7 @@ Both run with `NoAccountCtx<TCtxMeta>` — they don't carry an authenticated acc
 
 `preview_creative` should return `urlRender` or `bothRender`, **not `htmlRender` alone**. The creative-template storyboard asserts `previews[0].renders[0].preview_url` is renderable. If your platform can host a preview URL, use `urlRender`. If you only have inline HTML, use `bothRender` (emit both `preview_url` and `preview_html`).
 
-Preview URLs must resolve from durable storage in production; do not back MCPUI preview links with pod-local in-memory maps except in local demos. See [`docs/guides/PREVIEW-ASSET-DURABILITY.md`](../../docs/guides/PREVIEW-ASSET-DURABILITY.md).
+Preview URLs must resolve from durable storage in production; do not back MCPUI preview links with pod-local in-memory maps except in local demos. If you fork `hello_creative_adapter_template.ts`, replace the mock upstream `preview_url` plumbing with a route that reads preview bytes and session metadata from shared storage before shipping. See [`docs/guides/PREVIEW-ASSET-DURABILITY.md`](../../docs/guides/PREVIEW-ASSET-DURABILITY.md).
 
 ## Specialism deltas at a glance
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1182,6 +1182,15 @@ export {
 export { injectLegacyEnvelopeStatus } from './utils/envelope-status-compat';
 export { extractResult, type ToolCallResultLike } from './utils';
 export { REQUEST_TIMEOUT, MAX_CONCURRENT, STANDARD_FORMATS } from './utils';
+export {
+  batchPreviewProducts,
+  batchPreviewFormats,
+  clearPreviewCache,
+  type PreviewResult,
+  type BatchPreviewOptions,
+  type PreviewCacheBackend,
+  type PreviewCacheEntry,
+} from './utils';
 export { detectProtocol, detectProtocolWithTimeout } from './utils';
 export { A2A_CARD_PATHS, isAgentCardPath, isWellKnownAgentCardUrl, buildCardUrls, stripAgentCardPath } from './utils';
 

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -11,6 +11,8 @@ export {
   clearPreviewCache,
   type PreviewResult,
   type BatchPreviewOptions,
+  type PreviewCacheBackend,
+  type PreviewCacheEntry,
 } from './preview-utils';
 
 // Configuration constants

--- a/src/lib/utils/preview-utils.ts
+++ b/src/lib/utils/preview-utils.ts
@@ -26,22 +26,68 @@ export interface BatchPreviewOptions {
   cacheTtl?: number;
   /** Whether to skip cache and force fresh previews (defaults to false) */
   skipCache?: boolean;
+  /**
+   * Cache backend for preview results.
+   *
+   * The default backend is process-local memory. It is safe for tests,
+   * local development, and single-process CLIs, but it is not shared
+   * across pods and does not survive restarts. Production services that
+   * cache preview URLs should provide a shared backend such as Redis or
+   * Postgres, and the cached URL itself must still resolve to durable
+   * storage rather than process-local assets.
+   */
+  cacheBackend?: PreviewCacheBackend;
 }
 
 /**
  * Cache entry for preview results
  */
-interface CacheEntry {
+export interface PreviewCacheEntry {
   previewUrl: string;
   previewId: string;
   timestamp: number;
 }
 
 /**
- * Simple in-memory cache for preview results
- * Key format: `${itemType}:${formatId.agent_url}:${formatId.id}:${manifestHash}`
+ * Pluggable cache backend for preview results.
+ *
+ * This cache stores references returned by `preview_creative`; it is not
+ * an asset store. Preview URLs placed in any cache must already be
+ * durable across load-balancer hops, pod restarts, and later refinement
+ * calls.
  */
-const previewCache = new Map<string, CacheEntry>();
+export interface PreviewCacheBackend {
+  get(cacheKey: string): PreviewCacheEntry | null | undefined | Promise<PreviewCacheEntry | null | undefined>;
+  set(cacheKey: string, entry: PreviewCacheEntry): void | Promise<void>;
+  delete?(cacheKey: string): void | Promise<void>;
+  clear?(): void | Promise<void>;
+}
+
+/**
+ * Process-local in-memory cache for preview results.
+ *
+ * Development-only default: this map is not multi-pod-safe and does not
+ * survive process restarts. It must not be used as the backing store for
+ * MCPUI preview assets in production.
+ *
+ * Key format: `${formatId.agent_url}:${formatId.id}:${manifestHash}`
+ */
+const previewCache = new Map<string, PreviewCacheEntry>();
+
+const defaultPreviewCacheBackend: PreviewCacheBackend = {
+  get(cacheKey) {
+    return previewCache.get(cacheKey);
+  },
+  set(cacheKey, entry) {
+    previewCache.set(cacheKey, entry);
+  },
+  delete(cacheKey) {
+    previewCache.delete(cacheKey);
+  },
+  clear() {
+    previewCache.clear();
+  },
+};
 
 /**
  * Generate a cache key for a preview request
@@ -59,13 +105,17 @@ function getCacheKey(formatId: FormatID, manifest: any): string {
 /**
  * Get cached preview if available and not expired
  */
-function getCachedPreview(cacheKey: string, ttl: number): CacheEntry | null {
-  const entry = previewCache.get(cacheKey);
+async function getCachedPreview(
+  cacheBackend: PreviewCacheBackend,
+  cacheKey: string,
+  ttl: number
+): Promise<PreviewCacheEntry | null> {
+  const entry = await cacheBackend.get(cacheKey);
   if (!entry) return null;
 
   const now = Date.now();
   if (now - entry.timestamp > ttl) {
-    previewCache.delete(cacheKey);
+    await cacheBackend.delete?.(cacheKey);
     return null;
   }
 
@@ -75,8 +125,13 @@ function getCachedPreview(cacheKey: string, ttl: number): CacheEntry | null {
 /**
  * Set cached preview
  */
-function setCachedPreview(cacheKey: string, previewUrl: string, previewId: string): void {
-  previewCache.set(cacheKey, {
+async function setCachedPreview(
+  cacheBackend: PreviewCacheBackend,
+  cacheKey: string,
+  previewUrl: string,
+  previewId: string
+): Promise<void> {
+  await cacheBackend.set(cacheKey, {
     previewUrl,
     previewId,
     timestamp: Date.now(),
@@ -84,10 +139,10 @@ function setCachedPreview(cacheKey: string, previewUrl: string, previewId: strin
 }
 
 /**
- * Clear all cached previews
+ * Clear all previews from the default process-local cache.
  */
 export function clearPreviewCache(): void {
-  previewCache.clear();
+  defaultPreviewCacheBackend.clear?.();
 }
 
 /**
@@ -177,6 +232,7 @@ export async function batchPreviewFormats(
 ): Promise<PreviewResult[]> {
   const cacheTtl = options.cacheTtl ?? 3600000; // 1 hour default
   const skipCache = options.skipCache ?? false;
+  const cacheBackend = options.cacheBackend ?? defaultPreviewCacheBackend;
 
   // Collect all formats that have format_card manifests
   const previewRequests: {
@@ -189,20 +245,20 @@ export async function batchPreviewFormats(
 
   const results: PreviewResult[] = [];
 
-  formats.forEach(format => {
+  for (const format of formats) {
     if (format.format_card) {
       const cacheKey = getCacheKey(format.format_card.format_id, format.format_card.manifest);
 
       // Check cache first
       if (!skipCache) {
-        const cached = getCachedPreview(cacheKey, cacheTtl);
+        const cached = await getCachedPreview(cacheBackend, cacheKey, cacheTtl);
         if (cached) {
           results.push({
             item: format,
             previewUrl: cached.previewUrl,
             previewId: cached.previewId,
           });
-          return;
+          continue;
         }
       }
 
@@ -219,7 +275,7 @@ export async function batchPreviewFormats(
         item: format,
       });
     }
-  });
+  }
 
   // If all were cached or none have format_card, return early
   if (previewRequests.length === 0) {
@@ -270,7 +326,7 @@ export async function batchPreviewFormats(
 
           if (previewUrl) {
             // Cache the result
-            setCachedPreview(req.cacheKey, previewUrl, previewId);
+            await setCachedPreview(cacheBackend, req.cacheKey, previewUrl, previewId);
 
             results.push({
               item: req.format,

--- a/src/lib/utils/preview-utils.ts
+++ b/src/lib/utils/preview-utils.ts
@@ -46,6 +46,8 @@ export interface PreviewCacheEntry {
   previewUrl: string;
   previewId: string;
   timestamp: number;
+  /** ISO 8601 timestamp from `preview_creative.expires_at`, when provided. */
+  expiresAt?: string;
 }
 
 /**
@@ -102,6 +104,12 @@ function getCacheKey(formatId: FormatID, manifest: any): string {
   return `${formatId.agent_url}:${formatId.id}:${manifestHash}`;
 }
 
+function hasExpiredAt(expiresAt: string | undefined, now: number): boolean {
+  if (!expiresAt) return false;
+  const expiresAtMs = Date.parse(expiresAt);
+  return Number.isNaN(expiresAtMs) ? false : expiresAtMs <= now;
+}
+
 /**
  * Get cached preview if available and not expired
  */
@@ -114,7 +122,7 @@ async function getCachedPreview(
   if (!entry) return null;
 
   const now = Date.now();
-  if (now - entry.timestamp > ttl) {
+  if (now - entry.timestamp > ttl || hasExpiredAt(entry.expiresAt, now)) {
     await cacheBackend.delete?.(cacheKey);
     return null;
   }
@@ -129,11 +137,13 @@ async function setCachedPreview(
   cacheBackend: PreviewCacheBackend,
   cacheKey: string,
   previewUrl: string,
-  previewId: string
+  previewId: string,
+  expiresAt?: string
 ): Promise<void> {
   await cacheBackend.set(cacheKey, {
     previewUrl,
     previewId,
+    expiresAt,
     timestamp: Date.now(),
   });
 }
@@ -251,7 +261,12 @@ export async function batchPreviewFormats(
 
       // Check cache first
       if (!skipCache) {
-        const cached = await getCachedPreview(cacheBackend, cacheKey, cacheTtl);
+        let cached: PreviewCacheEntry | null = null;
+        try {
+          cached = await getCachedPreview(cacheBackend, cacheKey, cacheTtl);
+        } catch {
+          cached = null;
+        }
         if (cached) {
           results.push({
             item: format,
@@ -325,14 +340,16 @@ export async function batchPreviewFormats(
           const previewId = preview.preview_id;
 
           if (previewUrl) {
-            // Cache the result
-            await setCachedPreview(cacheBackend, req.cacheKey, previewUrl, previewId);
-
             results.push({
               item: req.format,
               previewUrl,
               previewId,
             });
+            try {
+              await setCachedPreview(cacheBackend, req.cacheKey, previewUrl, previewId, responseData.expires_at);
+            } catch {
+              // Preview cache is an accelerator; successful previews should still return on cache write failures.
+            }
           } else {
             results.push({
               item: req.format,

--- a/test/lib/preview-utils.test.js
+++ b/test/lib/preview-utils.test.js
@@ -1,0 +1,122 @@
+const { describe, test, beforeEach } = require('node:test');
+const assert = require('node:assert');
+
+const { batchPreviewFormats, clearPreviewCache } = require('../../dist/lib/index.js');
+
+describe('preview utilities', () => {
+  beforeEach(() => {
+    clearPreviewCache();
+  });
+
+  test('batchPreviewFormats can use a shared cache backend', async () => {
+    const format = {
+      name: 'Leaderboard',
+      format_card: {
+        format_id: {
+          agent_url: 'https://creative.example/mcp',
+          id: 'leaderboard',
+        },
+        manifest: {
+          headline: 'Sale',
+        },
+      },
+    };
+
+    const cache = new Map();
+    const backend = {
+      get: key => cache.get(key),
+      set: (key, entry) => cache.set(key, entry),
+      delete: key => cache.delete(key),
+      clear: () => cache.clear(),
+    };
+
+    let calls = 0;
+    const creativeAgentClient = {
+      previewCreative: async () => {
+        calls += 1;
+        return {
+          data: {
+            previews: [
+              {
+                preview_id: 'preview_1',
+                renders: [
+                  {
+                    output_format: 'url',
+                    preview_url: 'https://assets.example/previews/preview_1.png',
+                  },
+                ],
+              },
+            ],
+          },
+        };
+      },
+    };
+
+    const first = await batchPreviewFormats([format], creativeAgentClient, { cacheBackend: backend });
+    const second = await batchPreviewFormats([format], creativeAgentClient, { cacheBackend: backend });
+
+    assert.strictEqual(calls, 1);
+    assert.strictEqual(first[0].previewUrl, 'https://assets.example/previews/preview_1.png');
+    assert.strictEqual(second[0].previewUrl, 'https://assets.example/previews/preview_1.png');
+    assert.strictEqual(second[0].previewId, 'preview_1');
+  });
+
+  test('batchPreviewFormats expires cached entries through the backend', async () => {
+    const format = {
+      name: 'Medium Rectangle',
+      format_card: {
+        format_id: {
+          agent_url: 'https://creative.example/mcp',
+          id: 'medium_rectangle',
+        },
+        manifest: {
+          headline: 'Fresh',
+        },
+      },
+    };
+
+    const expiredEntry = {
+      previewUrl: 'https://assets.example/previews/old.png',
+      previewId: 'old_preview',
+      timestamp: Date.now() - 10000,
+    };
+    let cacheKey;
+    let deletedKey;
+    const backend = {
+      get: key => {
+        cacheKey = key;
+        return expiredEntry;
+      },
+      set: () => {},
+      delete: key => {
+        deletedKey = key;
+      },
+    };
+
+    const creativeAgentClient = {
+      previewCreative: async () => ({
+        data: {
+          previews: [
+            {
+              preview_id: 'fresh_preview',
+              renders: [
+                {
+                  output_format: 'url',
+                  preview_url: 'https://assets.example/previews/fresh.png',
+                },
+              ],
+            },
+          ],
+        },
+      }),
+    };
+
+    const result = await batchPreviewFormats([format], creativeAgentClient, {
+      cacheBackend: backend,
+      cacheTtl: 1,
+    });
+
+    assert.strictEqual(deletedKey, cacheKey);
+    assert.strictEqual(result[0].previewUrl, 'https://assets.example/previews/fresh.png');
+  });
+});

--- a/test/lib/preview-utils.test.js
+++ b/test/lib/preview-utils.test.js
@@ -8,19 +8,52 @@ describe('preview utilities', () => {
     clearPreviewCache();
   });
 
-  test('batchPreviewFormats can use a shared cache backend', async () => {
-    const format = {
+  function previewFormat(id = 'leaderboard') {
+    return {
       name: 'Leaderboard',
       format_card: {
         format_id: {
           agent_url: 'https://creative.example/mcp',
-          id: 'leaderboard',
+          id,
         },
         manifest: {
           headline: 'Sale',
         },
       },
     };
+  }
+
+  function creativeAgentClient({ previewUrl = 'https://assets.example/previews/preview_1.png', expiresAt } = {}) {
+    let calls = 0;
+    return {
+      get calls() {
+        return calls;
+      },
+      previewCreative: async () => {
+        calls += 1;
+        return {
+          data: {
+            response_type: 'single',
+            expires_at: expiresAt,
+            previews: [
+              {
+                preview_id: `preview_${calls}`,
+                renders: [
+                  {
+                    output_format: 'url',
+                    preview_url: previewUrl,
+                  },
+                ],
+              },
+            ],
+          },
+        };
+      },
+    };
+  }
+
+  test('batchPreviewFormats can use a shared cache backend', async () => {
+    const format = previewFormat();
 
     const cache = new Map();
     const backend = {
@@ -30,50 +63,19 @@ describe('preview utilities', () => {
       clear: () => cache.clear(),
     };
 
-    let calls = 0;
-    const creativeAgentClient = {
-      previewCreative: async () => {
-        calls += 1;
-        return {
-          data: {
-            previews: [
-              {
-                preview_id: 'preview_1',
-                renders: [
-                  {
-                    output_format: 'url',
-                    preview_url: 'https://assets.example/previews/preview_1.png',
-                  },
-                ],
-              },
-            ],
-          },
-        };
-      },
-    };
+    const client = creativeAgentClient();
 
-    const first = await batchPreviewFormats([format], creativeAgentClient, { cacheBackend: backend });
-    const second = await batchPreviewFormats([format], creativeAgentClient, { cacheBackend: backend });
+    const first = await batchPreviewFormats([format], client, { cacheBackend: backend });
+    const second = await batchPreviewFormats([format], client, { cacheBackend: backend });
 
-    assert.strictEqual(calls, 1);
+    assert.strictEqual(client.calls, 1);
     assert.strictEqual(first[0].previewUrl, 'https://assets.example/previews/preview_1.png');
     assert.strictEqual(second[0].previewUrl, 'https://assets.example/previews/preview_1.png');
     assert.strictEqual(second[0].previewId, 'preview_1');
   });
 
   test('batchPreviewFormats expires cached entries through the backend', async () => {
-    const format = {
-      name: 'Medium Rectangle',
-      format_card: {
-        format_id: {
-          agent_url: 'https://creative.example/mcp',
-          id: 'medium_rectangle',
-        },
-        manifest: {
-          headline: 'Fresh',
-        },
-      },
-    };
+    const format = previewFormat('medium_rectangle');
 
     const expiredEntry = {
       previewUrl: 'https://assets.example/previews/old.png',
@@ -93,30 +95,101 @@ describe('preview utilities', () => {
       },
     };
 
-    const creativeAgentClient = {
-      previewCreative: async () => ({
-        data: {
-          previews: [
-            {
-              preview_id: 'fresh_preview',
-              renders: [
-                {
-                  output_format: 'url',
-                  preview_url: 'https://assets.example/previews/fresh.png',
-                },
-              ],
-            },
-          ],
-        },
-      }),
-    };
+    const client = creativeAgentClient({ previewUrl: 'https://assets.example/previews/fresh.png' });
 
-    const result = await batchPreviewFormats([format], creativeAgentClient, {
+    const result = await batchPreviewFormats([format], client, {
       cacheBackend: backend,
       cacheTtl: 1,
     });
 
     assert.strictEqual(deletedKey, cacheKey);
     assert.strictEqual(result[0].previewUrl, 'https://assets.example/previews/fresh.png');
+  });
+
+  test('batchPreviewFormats expires cached entries by preview response expires_at', async () => {
+    const format = previewFormat('expiring_preview');
+    const expiredEntry = {
+      previewUrl: 'https://assets.example/previews/old.png',
+      previewId: 'old_preview',
+      expiresAt: new Date(Date.now() - 1000).toISOString(),
+      timestamp: Date.now(),
+    };
+    let deletedKey;
+    const backend = {
+      get: () => expiredEntry,
+      set: () => {},
+      delete: key => {
+        deletedKey = key;
+      },
+    };
+
+    const client = creativeAgentClient({ previewUrl: 'https://assets.example/previews/fresh.png' });
+
+    const result = await batchPreviewFormats([format], client, {
+      cacheBackend: backend,
+      cacheTtl: 3600000,
+    });
+
+    assert.strictEqual(client.calls, 1);
+    assert.ok(deletedKey);
+    assert.strictEqual(result[0].previewUrl, 'https://assets.example/previews/fresh.png');
+  });
+
+  test('batchPreviewFormats stores preview response expires_at in cache entries', async () => {
+    const format = previewFormat('store_expiry');
+    const expiresAt = new Date(Date.now() + 60000).toISOString();
+    let cachedEntry;
+    const backend = {
+      get: () => null,
+      set: (_key, entry) => {
+        cachedEntry = entry;
+      },
+    };
+
+    const client = creativeAgentClient({ expiresAt });
+
+    await batchPreviewFormats([format], client, {
+      cacheBackend: backend,
+    });
+
+    assert.strictEqual(cachedEntry.expiresAt, expiresAt);
+  });
+
+  test('batchPreviewFormats treats cache read failures as misses', async () => {
+    const format = previewFormat('read_failure');
+    const backend = {
+      get: async () => {
+        throw new Error('cache unavailable');
+      },
+      set: () => {},
+    };
+
+    const client = creativeAgentClient({ previewUrl: 'https://assets.example/previews/from-agent.png' });
+
+    const result = await batchPreviewFormats([format], client, {
+      cacheBackend: backend,
+    });
+
+    assert.strictEqual(client.calls, 1);
+    assert.strictEqual(result[0].previewUrl, 'https://assets.example/previews/from-agent.png');
+  });
+
+  test('batchPreviewFormats returns successful previews when cache writes fail', async () => {
+    const format = previewFormat('write_failure');
+    const backend = {
+      get: () => null,
+      set: async () => {
+        throw new Error('cache write failed');
+      },
+    };
+
+    const client = creativeAgentClient({ previewUrl: 'https://assets.example/previews/uncached.png' });
+
+    const result = await batchPreviewFormats([format], client, {
+      cacheBackend: backend,
+    });
+
+    assert.strictEqual(result[0].previewUrl, 'https://assets.example/previews/uncached.png');
+    assert.strictEqual(result[0].error, undefined);
   });
 });


### PR DESCRIPTION
## Summary

- add a pluggable `PreviewCacheBackend` for batch preview helpers while keeping the existing process-local cache as the default
- document durable MCPUI preview URL patterns for generated creative assets
- add a creative-agent skill callout and regression tests for shared cache backend behavior

## Why

Generated creative previews can 404 in multi-pod deployments when returned MCPUI URLs depend on process-local state. This keeps the SDK wire-compatible while making the SDK-side cache footgun explicit and giving production adopters a shared-cache hook.

Protocol-level questions like `asset_ref` on `PreviewRender` remain out of scope and are tracked upstream in adcontextprotocol/adcp#5434.

## Validation

- `npm run build:lib`
- `NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/lib/preview-utils.test.js`
- `npm run ci:docs-check`
- `npm run ci:quick`
- `git diff --check`
- `node .github/scripts/check-pr-title.cjs "feat(creative): add pluggable preview cache backend"`
- `echo "feat(creative): add pluggable preview cache backend" | npx commitlint --config commitlint.config.js`
- `npx commitlint --from HEAD~1 --to HEAD --verbose`
