### PR TITLE
fix: resolve storyboard webhook and MCP probe regressions

### DIFF
--- a/.changeset/storyboard-webhook-mcp-probe.md
+++ b/.changeset/storyboard-webhook-mcp-probe.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Fix storyboard webhook placeholder resolution for runner-provided requests and make raw MCP security probes complete the Streamable HTTP initialization boundary before dispatching tool calls.

--- a/src/lib/testing/storyboard/probes.ts
+++ b/src/lib/testing/storyboard/probes.ts
@@ -355,7 +355,9 @@ function failedTaskResult(message: string): TaskResult {
 
 function taskResultFromPostFailure(posted: RawJsonRpcPostResult): TaskResult {
   if (posted.parseError) {
-    return failedTaskResult(`Non-JSON response body (content-type: ${posted.httpResult.headers['content-type'] ?? 'unknown'}).`);
+    return failedTaskResult(
+      `Non-JSON response body (content-type: ${posted.httpResult.headers['content-type'] ?? 'unknown'}).`
+    );
   }
   if (posted.parsed) return taskResultFromRpc(posted.httpResult, posted.parsed);
   return failedTaskResult(posted.httpResult.error ?? `HTTP ${posted.httpResult.status}`);
@@ -402,7 +404,12 @@ export async function rawMcpProbe(options: {
     allowPrivateIp,
     responseId: initializeId,
   });
-  if (initialize.httpResult.error || initialize.httpResult.status >= 400 || !initialize.parsed || initialize.parsed.error) {
+  if (
+    initialize.httpResult.error ||
+    initialize.httpResult.status >= 400 ||
+    !initialize.parsed ||
+    initialize.parsed.error
+  ) {
     return {
       httpResult: initialize.httpResult,
       taskResult: taskResultFromPostFailure(initialize),
@@ -437,7 +444,12 @@ export async function rawMcpProbe(options: {
     protocolVersion: negotiatedProtocolVersion,
     allowEmptyBody: true,
   });
-  if (initialized.httpResult.error || initialized.httpResult.status >= 400 || initialized.parseError || initialized.parsed?.error) {
+  if (
+    initialized.httpResult.error ||
+    initialized.httpResult.status >= 400 ||
+    initialized.parseError ||
+    initialized.parsed?.error
+  ) {
     return {
       httpResult: initialized.httpResult,
       taskResult: taskResultFromPostFailure(initialized),

--- a/src/lib/testing/storyboard/probes.ts
+++ b/src/lib/testing/storyboard/probes.ts
@@ -12,6 +12,7 @@
  *   prior steps that carried `contributes_to`.
  */
 import { randomBytes } from 'crypto';
+import { LATEST_PROTOCOL_VERSION, SUPPORTED_PROTOCOL_VERSIONS } from '@modelcontextprotocol/sdk/types.js';
 import {
   ssrfSafeFetch,
   decodeBodyAsJsonOrText,
@@ -188,21 +189,184 @@ function base64url(buf: Buffer): string {
 // ---------------------------------------------------------------------------
 
 let probeRequestId = 0;
+const MCP_SESSION_ID_HEADER = 'mcp-session-id';
+const MCP_PROTOCOL_VERSION_HEADER = 'mcp-protocol-version';
+
+type JsonRpcEnvelope = {
+  jsonrpc: '2.0';
+  id?: number;
+  method?: string;
+  params?: Record<string, unknown>;
+  result?: { structuredContent?: unknown; content?: unknown; isError?: boolean; protocolVersion?: string };
+  error?: { message?: string; code?: number };
+};
+
+interface RawJsonRpcPostResult {
+  httpResult: HttpProbeResult;
+  parsed?: JsonRpcEnvelope;
+  parseError?: boolean;
+}
+
+async function postRawMcpJsonRpc(options: {
+  agentUrl: string;
+  envelope: Record<string, unknown>;
+  headers: Record<string, string>;
+  allowPrivateIp: boolean;
+  sessionId?: string;
+  protocolVersion?: string;
+  responseId?: number;
+  parseBody?: boolean;
+  allowEmptyBody?: boolean;
+}): Promise<RawJsonRpcPostResult> {
+  const {
+    agentUrl,
+    envelope,
+    headers,
+    allowPrivateIp,
+    sessionId,
+    protocolVersion,
+    responseId,
+    parseBody = true,
+    allowEmptyBody = false,
+  } = options;
+  const httpResult: HttpProbeResult = { url: agentUrl, status: 0, headers: {}, body: null };
+  try {
+    const res = await ssrfSafeFetch(agentUrl, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+        ...withoutMcpSessionHeaders(headers),
+        ...(sessionId ? { [MCP_SESSION_ID_HEADER]: sessionId } : {}),
+        ...(protocolVersion ? { [MCP_PROTOCOL_VERSION_HEADER]: protocolVersion } : {}),
+      },
+      body: JSON.stringify(envelope),
+      allowPrivateIp,
+    });
+    httpResult.status = res.status;
+    httpResult.headers = res.headers;
+
+    const text = Buffer.from(res.body.buffer, res.body.byteOffset, res.body.byteLength).toString('utf8');
+    if (!parseBody) {
+      httpResult.body = text || null;
+      return { httpResult };
+    }
+    if (allowEmptyBody && text.trim() === '') {
+      httpResult.body = null;
+      return { httpResult };
+    }
+    try {
+      const parsed = parseMcpJsonRpcResponse(text, httpResult.headers['content-type'], responseId);
+      httpResult.body = parsed;
+      return { httpResult, parsed };
+    } catch {
+      httpResult.body = text;
+      return { httpResult, parseError: true };
+    }
+  } catch (err) {
+    httpResult.error = err instanceof Error ? err.message : String(err);
+    return { httpResult };
+  }
+}
+
+function withoutMcpSessionHeaders(headers: Record<string, string>): Record<string, string> {
+  const cleaned: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    const normalized = key.toLowerCase();
+    if (normalized === MCP_SESSION_ID_HEADER || normalized === MCP_PROTOCOL_VERSION_HEADER) continue;
+    cleaned[key] = value;
+  }
+  return cleaned;
+}
+
+function parseMcpJsonRpcResponse(text: string, contentType: string | undefined, responseId?: number): JsonRpcEnvelope {
+  if (contentType?.toLowerCase().includes('text/event-stream')) {
+    // Streamable-HTTP MCP: the response is one or more SSE events whose
+    // `data:` payloads are JSON-RPC envelopes. The spec lets a server emit
+    // notifications before the final response, so choose the matching id.
+    const dataLines = text.split(/\r?\n/).filter(l => l.startsWith('data:'));
+    if (dataLines.length === 0) throw new Error('SSE response with no data event');
+    let matched: JsonRpcEnvelope | undefined;
+    let lastParsed: JsonRpcEnvelope | undefined;
+    for (const line of dataLines) {
+      const payload = line.slice('data:'.length).trim();
+      if (!payload) continue;
+      try {
+        const envelope = JSON.parse(payload) as JsonRpcEnvelope;
+        lastParsed = envelope;
+        if (responseId !== undefined && envelope?.id === responseId) {
+          matched = envelope;
+          break;
+        }
+      } catch {
+        // Skip non-JSON data lines (heartbeats, etc.); keep walking.
+      }
+    }
+    const parsed = matched ?? lastParsed;
+    if (parsed === undefined) throw new Error('SSE response had data events but none were parseable JSON');
+    return parsed;
+  }
+  return JSON.parse(text) as JsonRpcEnvelope;
+}
+
+function taskResultFromRpc(httpResult: HttpProbeResult, rpc: JsonRpcEnvelope): TaskResult {
+  if (httpResult.status >= 400) {
+    return {
+      success: false,
+      data: undefined,
+      error: rpc.error?.message ?? `HTTP ${httpResult.status}`,
+      _extraction_path: 'error',
+    };
+  }
+  if (rpc.error) {
+    const code = rpc.error.code;
+    return {
+      success: false,
+      data: undefined,
+      error:
+        code !== undefined
+          ? `JSON-RPC error ${code}: ${rpc.error.message ?? 'no message'}`
+          : (rpc.error.message ?? 'JSON-RPC error (no code)'),
+      _extraction_path: 'error',
+    };
+  }
+  const structured = rpc.result?.structuredContent;
+  const hasStructured = structured !== undefined && structured !== null;
+  const data = hasStructured ? structured : rpc.result?.content;
+  const isError = !!rpc.result?.isError;
+  const extractionPath: 'structured_content' | 'text_fallback' | 'error' | 'none' = isError
+    ? 'error'
+    : hasStructured
+      ? 'structured_content'
+      : data !== undefined && data !== null
+        ? 'text_fallback'
+        : 'none';
+  return { success: !isError, data, _extraction_path: extractionPath };
+}
+
+function failedTaskResult(message: string): TaskResult {
+  return {
+    success: false,
+    data: undefined,
+    error: message,
+    _extraction_path: 'error',
+  };
+}
+
+function taskResultFromPostFailure(posted: RawJsonRpcPostResult): TaskResult {
+  if (posted.parseError) {
+    return failedTaskResult(`Non-JSON response body (content-type: ${posted.httpResult.headers['content-type'] ?? 'unknown'}).`);
+  }
+  if (posted.parsed) return taskResultFromRpc(posted.httpResult, posted.parsed);
+  return failedTaskResult(posted.httpResult.error ?? `HTTP ${posted.httpResult.status}`);
+}
 
 /**
  * POST a JSON-RPC `tools/call` request to the MCP endpoint with caller-provided
- * headers. Bypasses the MCP SDK so auth overrides (none / literal / strategy)
- * can be exercised and the raw HTTP status + `WWW-Authenticate` header can be
- * captured.
- *
- * **Known limitation**: this probe skips MCP Streamable HTTP session
- * initialization (`initialize` + `tools/list`). Agents that enforce
- * session-init before `tools/call` will return `-32002 Session not initialized`
- * (or similar). The probe detects that response and reports
- * `error: 'session_not_initialized'` on the synthetic TaskResult so callers
- * don't mistake it for a valid auth rejection. For agents that gate auth at
- * the HTTP/transport layer (the common pattern) the 401 + WWW-Authenticate
- * fires before the session check, which is what this probe is designed to see.
+ * headers. The probe first performs the Streamable HTTP initialize handshake,
+ * including `notifications/initialized`, so auth probes hit the same session
+ * boundary as normal MCP clients while still exposing raw HTTP status and
+ * `WWW-Authenticate` headers for security storyboards.
  *
  * **Args are not secret** — must not contain credentials or PII. The server's
  * response body lands in `httpResult.body` and is written to compliance
@@ -221,157 +385,90 @@ export async function rawMcpProbe(options: {
   allowPrivateIp?: boolean;
 }): Promise<{ httpResult: HttpProbeResult; taskResult?: TaskResult }> {
   const { agentUrl, toolName, args, headers = {}, allowPrivateIp = false } = options;
+  const initializeId = ++probeRequestId;
+  const initialize = await postRawMcpJsonRpc({
+    agentUrl,
+    envelope: {
+      jsonrpc: '2.0',
+      id: initializeId,
+      method: 'initialize',
+      params: {
+        protocolVersion: LATEST_PROTOCOL_VERSION,
+        capabilities: {},
+        clientInfo: { name: 'AdCP Storyboard Raw MCP Probe', version: '1.0.0' },
+      },
+    },
+    headers,
+    allowPrivateIp,
+    responseId: initializeId,
+  });
+  if (initialize.httpResult.error || initialize.httpResult.status >= 400 || !initialize.parsed || initialize.parsed.error) {
+    return {
+      httpResult: initialize.httpResult,
+      taskResult: taskResultFromPostFailure(initialize),
+    };
+  }
+  const negotiatedProtocolVersion = initialize.parsed.result?.protocolVersion;
+  if (
+    typeof negotiatedProtocolVersion !== 'string' ||
+    !SUPPORTED_PROTOCOL_VERSIONS.includes(negotiatedProtocolVersion)
+  ) {
+    return {
+      httpResult: initialize.httpResult,
+      taskResult: failedTaskResult(
+        negotiatedProtocolVersion
+          ? `Server's protocol version is not supported: ${negotiatedProtocolVersion}`
+          : 'Server sent invalid initialize result: missing protocolVersion'
+      ),
+    };
+  }
+
+  const sessionId = initialize.httpResult.headers[MCP_SESSION_ID_HEADER];
+  const initialized = await postRawMcpJsonRpc({
+    agentUrl,
+    envelope: {
+      jsonrpc: '2.0',
+      method: 'notifications/initialized',
+      params: {},
+    },
+    headers,
+    allowPrivateIp,
+    ...(sessionId && { sessionId }),
+    protocolVersion: negotiatedProtocolVersion,
+    allowEmptyBody: true,
+  });
+  if (initialized.httpResult.error || initialized.httpResult.status >= 400 || initialized.parseError || initialized.parsed?.error) {
+    return {
+      httpResult: initialized.httpResult,
+      taskResult: taskResultFromPostFailure(initialized),
+    };
+  }
+
   const requestId = ++probeRequestId;
-  const body = JSON.stringify({
+  const toolEnvelope = {
     jsonrpc: '2.0',
     id: requestId,
     method: 'tools/call',
     params: { name: toolName, arguments: args },
+  };
+  const posted = await postRawMcpJsonRpc({
+    agentUrl,
+    envelope: toolEnvelope,
+    headers,
+    allowPrivateIp,
+    ...(sessionId && { sessionId }),
+    protocolVersion: negotiatedProtocolVersion,
+    responseId: requestId,
   });
-
-  const httpResult: HttpProbeResult = { url: agentUrl, status: 0, headers: {}, body: null };
-  try {
-    // Advertise both JSON and SSE so Streamable-HTTP MCP servers don't 406.
-    // Strict MCP servers (e.g. those built on the official SDK) require the
-    // client to accept both — they return SSE-framed responses for tools/call
-    // even though the payload is a single JSON-RPC envelope. The probe parses
-    // the SSE wire form below; the existing JSON branch is preserved for
-    // servers that downgrade to plain JSON when offered both.
-    const res = await ssrfSafeFetch(agentUrl, {
-      method: 'POST',
-      headers: {
-        'content-type': 'application/json',
-        accept: 'application/json, text/event-stream',
-        ...headers,
-      },
-      body,
-      allowPrivateIp,
-    });
-    httpResult.status = res.status;
-    httpResult.headers = res.headers;
-
-    const text = Buffer.from(res.body.buffer, res.body.byteOffset, res.body.byteLength).toString('utf8');
-    let parsed: unknown;
-    try {
-      const contentType = httpResult.headers['content-type'] ?? '';
-      if (contentType.toLowerCase().includes('text/event-stream')) {
-        // Streamable-HTTP MCP: the response is one or more SSE events whose
-        // `data:` payloads are JSON-RPC envelopes. The spec lets a server
-        // emit zero-or-more server-initiated frames (e.g.
-        // `notifications/progress`) before the final tools/call response —
-        // so picking the first `data:` line would parse the wrong envelope.
-        // Walk every `data:` line, JSON-parse each, and pick the envelope
-        // whose `id` matches the request. Fall back to the last parseable
-        // envelope when no id matches (defensive — servers SHOULD include
-        // `id` on the response per JSON-RPC 2.0).
-        const dataLines = text.split(/\r?\n/).filter(l => l.startsWith('data:'));
-        if (dataLines.length === 0) throw new Error('SSE response with no data event');
-        let matched: unknown;
-        let lastParsed: unknown;
-        for (const line of dataLines) {
-          const payload = line.slice('data:'.length).trim();
-          if (!payload) continue;
-          try {
-            const envelope = JSON.parse(payload) as { id?: unknown };
-            lastParsed = envelope;
-            if (envelope?.id === requestId) {
-              matched = envelope;
-              break;
-            }
-          } catch {
-            // Skip non-JSON data lines (heartbeats, etc.); keep walking.
-          }
-        }
-        parsed = matched ?? lastParsed;
-        if (parsed === undefined) throw new Error('SSE response had data events but none were parseable JSON');
-      } else {
-        parsed = JSON.parse(text);
-      }
-    } catch {
-      httpResult.body = text;
-      // HTTP 400 with a plain-text body that signals a missing MCP session — e.g.
-      // "Bad Request: Missing session ID" from strict Python-based servers.  Detect
-      // before falling back to the generic non-JSON message so compliance reports
-      // show the session-init diagnostic rather than a bare HTTP 400.
-      if (httpResult.status >= 400 && /missing session/i.test(text)) {
-        return {
-          httpResult,
-          taskResult: {
-            success: false,
-            data: undefined,
-            error: `MCP session not initialized (HTTP ${httpResult.status}: ${text.trim()}). rawMcpProbe skips the initialize handshake; strict servers will reject here before auth is evaluated.`,
-            _extraction_path: 'error',
-          },
-        };
-      }
-      return {
-        httpResult,
-        taskResult: {
-          success: false,
-          data: undefined,
-          error: `Non-JSON response body (content-type: ${httpResult.headers['content-type'] ?? 'unknown'}).`,
-          _extraction_path: 'error',
-        },
-      };
-    }
-    httpResult.body = parsed;
-
-    const rpc = parsed as {
-      result?: { structuredContent?: unknown; content?: unknown; isError?: boolean };
-      error?: { message?: string; code?: number };
+  const { httpResult, parsed } = posted;
+  if (httpResult.error) return { httpResult, taskResult: taskResultFromPostFailure(posted) };
+  if (!parsed) {
+    return {
+      httpResult,
+      taskResult: taskResultFromPostFailure(posted),
     };
-    // HTTP-level failure trumps the JSON-RPC envelope — a 401/500 with any body
-    // shape is still a failure.
-    if (httpResult.status >= 400) {
-      return {
-        httpResult,
-        taskResult: {
-          success: false,
-          data: undefined,
-          error: rpc.error?.message ?? `HTTP ${httpResult.status}`,
-          _extraction_path: 'error',
-        },
-      };
-    }
-    if (rpc.error) {
-      // MCP Streamable HTTP session-init errors — agents that require
-      // `initialize` before `tools/call`. Distinct from auth failures so
-      // downstream compliance reporting doesn't misdiagnose.
-      const code = rpc.error.code;
-      const isSessionInit =
-        code === -32002 ||
-        (typeof rpc.error.message === 'string' && /session.*(?:not.*)?initialized/i.test(rpc.error.message));
-      return {
-        httpResult,
-        taskResult: {
-          success: false,
-          data: undefined,
-          error: isSessionInit
-            ? `MCP session not initialized (${code}: ${rpc.error.message ?? 'no message'}). rawMcpProbe skips the initialize handshake; strict servers will reject here before auth is evaluated.`
-            : (rpc.error.message ?? `JSON-RPC error ${code}`),
-          _extraction_path: 'error',
-        },
-      };
-    }
-    // Record which branch produced the data — rawMcpProbe reads the JSON-RPC
-    // envelope directly, so the provenance is knowable here (unlike the SDK
-    // path where we have to plumb it through the unwrapper).
-    const structured = rpc.result?.structuredContent;
-    const hasStructured = structured !== undefined && structured !== null;
-    const data = hasStructured ? structured : rpc.result?.content;
-    const isError = !!rpc.result?.isError;
-    const extractionPath: 'structured_content' | 'text_fallback' | 'error' | 'none' = isError
-      ? 'error'
-      : hasStructured
-        ? 'structured_content'
-        : data !== undefined && data !== null
-          ? 'text_fallback'
-          : 'none';
-    return { httpResult, taskResult: { success: !isError, data, _extraction_path: extractionPath } };
-  } catch (err) {
-    httpResult.error = err instanceof Error ? err.message : String(err);
-    return { httpResult };
   }
+  return { httpResult, taskResult: taskResultFromRpc(httpResult, parsed) };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -3610,7 +3610,7 @@ async function executeStep(
   // 5. Empty object (only reachable for non-mutating tasks with neither fixture nor enricher)
   let request: Record<string, unknown>;
   if (options.request) {
-    request = { ...options.request };
+    request = injectContext({ ...options.request }, context, runState.runnerVars);
   } else if (step.expect_error && step.sample_request) {
     request = injectContext({ ...step.sample_request }, context, runState.runnerVars);
   } else if (hasRequestEnricher(effectiveStep.task)) {
@@ -3707,6 +3707,38 @@ async function executeStep(
       ...responseDerivedContextResult(runState),
       ...(!allResponseDerived && { error: detail }),
       next,
+      extraction: { path: 'none' },
+    };
+  }
+
+  const unresolvedRunnerTokens = findUnresolvedRunnerTokens(request);
+  if (unresolvedRunnerTokens.length > 0) {
+    const isPrerequisiteFailure = hasUnresolvedPriorStepToken(unresolvedRunnerTokens);
+    const skipReason = isPrerequisiteFailure ? 'prerequisite_failed' : 'not_applicable';
+    const next = getNextStepPreview(step.id, allSteps, context, runState.runnerVars);
+    const detail =
+      'Skipped: storyboard request references unresolved runner placeholders. ' +
+      `Unresolved token(s): ${unresolvedRunnerTokens.join(', ')}.`;
+    return {
+      step_id: step.id,
+      phase_id: phaseId,
+      title: step.title,
+      task: effectiveStep.task,
+      passed: !isPrerequisiteFailure,
+      skipped: true,
+      skip_reason: skipReason,
+      skip: buildSkip(skipReason, detail),
+      duration_ms: 0,
+      validations: [],
+      context,
+      next,
+      ...(isPrerequisiteFailure ? { error: detail } : {}),
+      request: {
+        transport: options.protocol === 'a2a' ? 'a2a' : 'mcp',
+        operation: effectiveStep.task,
+        payload: redactSecrets(request),
+        ...(runState.agentUrl ? { url: runState.agentUrl } : {}),
+      },
       extraction: { path: 'none' },
     };
   }
@@ -4604,6 +4636,31 @@ async function executeProbeStep(
           error: detail,
         };
       }
+      const unresolvedRunnerTokens = findUnresolvedRunnerTokens(resolvedTargetRequest);
+      if (unresolvedRunnerTokens.length > 0) {
+        const isPrerequisiteFailure = hasUnresolvedPriorStepToken(unresolvedRunnerTokens);
+        const skipReason = isPrerequisiteFailure ? 'prerequisite_failed' : 'not_applicable';
+        const next = getNextStepPreview(step.id, allSteps, context, runState.runnerVars);
+        const detail =
+          'Skipped: rate_limit_trip target request references unresolved runner placeholders. ' +
+          `Unresolved token(s): ${unresolvedRunnerTokens.join(', ')}.`;
+        return {
+          step_id: step.id,
+          phase_id: phaseId,
+          title: step.title,
+          task: step.task,
+          passed: !isPrerequisiteFailure,
+          skipped: true,
+          skip_reason: skipReason,
+          skip: buildSkip(skipReason, detail),
+          duration_ms: Date.now() - start,
+          validations: [],
+          context,
+          next,
+          extraction: { path: 'none' },
+          ...(isPrerequisiteFailure ? { error: detail } : {}),
+        };
+      }
       const advertisedTools = resolveAdvertisedTools(options);
       if (advertisedTools && !advertisedTools.includes(rateLimitTrip.trip_target_task)) {
         const next = getNextStepPreview(step.id, allSteps, context, runState.runnerVars);
@@ -4757,7 +4814,7 @@ function buildEffectiveStepRequest(
 ): Record<string, unknown> {
   let request: Record<string, unknown>;
   if (options.request) {
-    request = { ...options.request };
+    request = injectContext({ ...options.request }, context, runState.runnerVars);
   } else if (step.expect_error && step.sample_request) {
     request = injectContext({ ...step.sample_request }, context, runState.runnerVars);
   } else if (hasRequestEnricher(step.task)) {
@@ -6171,6 +6228,29 @@ function findUnresolvedContextVars(obj: unknown): Array<{ key: string; token: st
   };
   walk(obj);
   return vars;
+}
+
+const UNRESOLVED_RUNNER_TOKEN_RE =
+  /\{\{(?:runner\.(?:webhook_url:[A-Za-z0-9_]+|webhook_base)|prior_step\.[A-Za-z0-9_]+\.operation_id)\}\}/g;
+
+function findUnresolvedRunnerTokens(obj: unknown): string[] {
+  const vars: string[] = [];
+  const walk = (val: unknown) => {
+    if (typeof val === 'string') {
+      const matches = val.match(UNRESOLVED_RUNNER_TOKEN_RE);
+      if (matches) vars.push(...matches);
+    } else if (Array.isArray(val)) {
+      val.forEach(walk);
+    } else if (val !== null && typeof val === 'object') {
+      Object.values(val as Record<string, unknown>).forEach(walk);
+    }
+  };
+  walk(obj);
+  return [...new Set(vars)];
+}
+
+function hasUnresolvedPriorStepToken(tokens: string[]): boolean {
+  return tokens.some(token => token.startsWith('{{prior_step.'));
 }
 
 function flattenSteps(storyboard: Storyboard): FlatStep[] {

--- a/test/lib/storyboard-account-invariant.test.js
+++ b/test/lib/storyboard-account-invariant.test.js
@@ -21,6 +21,37 @@ const http = require('http');
 
 const { applyBrandInvariant, runStoryboard } = require('../../dist/lib/testing/storyboard/runner.js');
 
+function handleMcpHandshake(rpc, res, tools) {
+  if (rpc.method === 'initialize') {
+    res.writeHead(200, { 'content-type': 'application/json', 'mcp-session-id': 'test-session' });
+    res.end(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: rpc.id,
+        result: { protocolVersion: '2025-11-25', capabilities: {}, serverInfo: { name: 'test', version: '1.0.0' } },
+      })
+    );
+    return true;
+  }
+  if (rpc.method === 'notifications/initialized') {
+    res.writeHead(202);
+    res.end();
+    return true;
+  }
+  if (rpc.method === 'tools/list') {
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: rpc.id,
+        result: { tools: tools.map(name => ({ name, inputSchema: { type: 'object' } })) },
+      })
+    );
+    return true;
+  }
+  return false;
+}
+
 // ────────────────────────────────────────────────────────────
 // Unit: applyBrandInvariant omit_account flag
 // ────────────────────────────────────────────────────────────
@@ -87,6 +118,7 @@ describe('runStoryboard: omit_account wire-level behavior', () => {
       const chunks = [];
       for await (const c of req) chunks.push(c);
       const rpc = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+      if (handleMcpHandshake(rpc, res, ['create_media_buy'])) return;
       seen.push({ name: rpc.params.name, args: rpc.params.arguments });
       res.writeHead(400, { 'content-type': 'application/json' });
       res.end(
@@ -159,6 +191,7 @@ describe('runStoryboard: omit_account wire-level behavior', () => {
       const chunks = [];
       for await (const c of req) chunks.push(c);
       const rpc = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+      if (handleMcpHandshake(rpc, res, ['create_media_buy'])) return;
       seen.push({ name: rpc.params.name, args: rpc.params.arguments });
       res.writeHead(401, { 'content-type': 'application/json', 'www-authenticate': 'Bearer realm="x"' });
       res.end('{}');

--- a/test/lib/storyboard-brand-invariant.test.js
+++ b/test/lib/storyboard-brand-invariant.test.js
@@ -17,6 +17,37 @@ const { applyBrandInvariant, runStoryboard } = require('../../dist/lib/testing/s
 
 const BRAND = { domain: 'acmeoutdoor.example' };
 
+function handleMcpHandshake(rpc, res, tools) {
+  if (rpc.method === 'initialize') {
+    res.writeHead(200, { 'content-type': 'application/json', 'mcp-session-id': 'test-session' });
+    res.end(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: rpc.id,
+        result: { protocolVersion: '2025-11-25', capabilities: {}, serverInfo: { name: 'test', version: '1.0.0' } },
+      })
+    );
+    return true;
+  }
+  if (rpc.method === 'notifications/initialized') {
+    res.writeHead(202);
+    res.end();
+    return true;
+  }
+  if (rpc.method === 'tools/list') {
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: rpc.id,
+        result: { tools: tools.map(name => ({ name, inputSchema: { type: 'object' } })) },
+      })
+    );
+    return true;
+  }
+  return false;
+}
+
 describe('applyBrandInvariant', () => {
   test('injects brand when the request omits it', () => {
     const result = applyBrandInvariant({ list_id: 'pl-1' }, { brand: BRAND });
@@ -257,6 +288,7 @@ describe('runStoryboard: brand invariant on the wire', () => {
       const chunks = [];
       for await (const c of req) chunks.push(c);
       const rpc = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+      if (handleMcpHandshake(rpc, res, ['list_creatives'])) return;
       seen.push({ name: rpc.params.name, args: rpc.params.arguments });
       res.writeHead(401, { 'content-type': 'application/json', 'www-authenticate': 'Bearer realm="x"' });
       res.end('{}');
@@ -354,6 +386,7 @@ describe('runStoryboard: brand invariant on the wire', () => {
       const chunks = [];
       for await (const c of req) chunks.push(c);
       const rpc = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+      if (handleMcpHandshake(rpc, res, ['create_media_buy', 'sync_creatives'])) return;
       seen.push({ name: rpc.params.name, args: rpc.params.arguments });
       res.writeHead(401, { 'content-type': 'application/json', 'www-authenticate': 'Bearer realm="x"' });
       res.end('{}');

--- a/test/lib/storyboard-cascade-skip-on-skip.test.js
+++ b/test/lib/storyboard-cascade-skip-on-skip.test.js
@@ -59,6 +59,37 @@ async function startFakeAgent() {
     const chunks = [];
     for await (const c of req) chunks.push(c);
     const rpc = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+    if (rpc.method === 'initialize') {
+      res.writeHead(200, { 'content-type': 'application/json', 'mcp-session-id': 'test-session' });
+      res.end(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: rpc.id,
+          result: { protocolVersion: '2025-11-25', capabilities: {}, serverInfo: { name: 'test', version: '1.0.0' } },
+        })
+      );
+      return;
+    }
+    if (rpc.method === 'notifications/initialized') {
+      res.writeHead(202);
+      res.end();
+      return;
+    }
+    if (rpc.method === 'tools/list') {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: rpc.id,
+          result: {
+            tools: ['__test_setup', '__test_assert', 'sync_accounts', '__test_fail', 'get_adcp_capabilities'].map(
+              name => ({ name, inputSchema: { type: 'object' } })
+            ),
+          },
+        })
+      );
+      return;
+    }
     const ok = (structured, isError = false) =>
       res.writeHead(200, { 'content-type': 'application/json' }).end(
         JSON.stringify({

--- a/test/lib/storyboard-envelope-passthrough.test.js
+++ b/test/lib/storyboard-envelope-passthrough.test.js
@@ -20,17 +20,37 @@ const { runStoryboard } = require('../../dist/lib/testing/storyboard/runner.js')
 
 const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
+function createRecordingMcpServer(seen) {
+  return http.createServer(async (req, res) => {
+    const chunks = [];
+    for await (const c of req) chunks.push(c);
+    const rpc = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+    if (rpc.method === 'initialize') {
+      res.writeHead(200, { 'content-type': 'application/json', 'mcp-session-id': 'test-session' });
+      res.end(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: rpc.id,
+          result: { protocolVersion: '2025-11-25', capabilities: {}, serverInfo: { name: 'test', version: '1.0.0' } },
+        })
+      );
+      return;
+    }
+    if (rpc.method === 'notifications/initialized') {
+      res.writeHead(202);
+      res.end();
+      return;
+    }
+    seen.push({ name: rpc.params.name, args: rpc.params.arguments });
+    res.writeHead(401, { 'content-type': 'application/json', 'www-authenticate': 'Bearer realm="x"' });
+    res.end(JSON.stringify({ jsonrpc: '2.0', id: rpc.id, error: { code: -32001, message: 'unauthorized' } }));
+  });
+}
+
 describe('runStoryboard: sample_request envelope pass-through with a request builder', () => {
   it('forwards push_notification_config from sample_request into the outbound create_media_buy args', async () => {
     const seen = [];
-    const server = http.createServer(async (req, res) => {
-      const chunks = [];
-      for await (const c of req) chunks.push(c);
-      const rpc = JSON.parse(Buffer.concat(chunks).toString('utf8'));
-      seen.push({ name: rpc.params.name, args: rpc.params.arguments });
-      res.writeHead(401, { 'content-type': 'application/json', 'www-authenticate': 'Bearer realm="x"' });
-      res.end('{}');
-    });
+    const server = createRecordingMcpServer(seen);
     await new Promise(r => server.listen(0, r));
     const agentUrl = `http://127.0.0.1:${server.address().port}/mcp`;
     try {
@@ -101,14 +121,7 @@ describe('runStoryboard: sample_request envelope pass-through with a request bui
 
   it('preserves the signal_owned activate_on_agent sample_request through runner dispatch (ADCP-4009)', async () => {
     const seen = [];
-    const server = http.createServer(async (req, res) => {
-      const chunks = [];
-      for await (const c of req) chunks.push(c);
-      const rpc = JSON.parse(Buffer.concat(chunks).toString('utf8'));
-      seen.push({ name: rpc.params.name, args: rpc.params.arguments });
-      res.writeHead(401, { 'content-type': 'application/json', 'www-authenticate': 'Bearer realm="x"' });
-      res.end('{}');
-    });
+    const server = createRecordingMcpServer(seen);
     await new Promise(r => server.listen(0, r));
     const agentUrl = `http://127.0.0.1:${server.address().port}/mcp`;
     try {
@@ -188,14 +201,7 @@ describe('runStoryboard: sample_request envelope pass-through with a request bui
 
   it('resolves {{runner.webhook_url:<step_id>}} inside push_notification_config.url against the runner webhook receiver', async () => {
     const seen = [];
-    const server = http.createServer(async (req, res) => {
-      const chunks = [];
-      for await (const c of req) chunks.push(c);
-      const rpc = JSON.parse(Buffer.concat(chunks).toString('utf8'));
-      seen.push({ name: rpc.params.name, args: rpc.params.arguments });
-      res.writeHead(401, { 'content-type': 'application/json', 'www-authenticate': 'Bearer realm="x"' });
-      res.end('{}');
-    });
+    const server = createRecordingMcpServer(seen);
     await new Promise(r => server.listen(0, r));
     const agentUrl = `http://127.0.0.1:${server.address().port}/mcp`;
     try {
@@ -259,14 +265,7 @@ describe('runStoryboard: sample_request envelope pass-through with a request bui
 
   it('still forwards push_notification_config on the non-builder path (acquire_rights) so no future "simplification" of the merge block breaks one path undetected', async () => {
     const seen = [];
-    const server = http.createServer(async (req, res) => {
-      const chunks = [];
-      for await (const c of req) chunks.push(c);
-      const rpc = JSON.parse(Buffer.concat(chunks).toString('utf8'));
-      seen.push({ name: rpc.params.name, args: rpc.params.arguments });
-      res.writeHead(401, { 'content-type': 'application/json', 'www-authenticate': 'Bearer realm="x"' });
-      res.end('{}');
-    });
+    const server = createRecordingMcpServer(seen);
     await new Promise(r => server.listen(0, r));
     const agentUrl = `http://127.0.0.1:${server.address().port}/mcp`;
     try {
@@ -326,14 +325,7 @@ describe('runStoryboard: sample_request envelope pass-through with a request bui
 
   it('does not let sample_request overwrite a push_notification_config already on the request (e.g. supplied via options.request) — the `=== undefined` guard is load-bearing', async () => {
     const seen = [];
-    const server = http.createServer(async (req, res) => {
-      const chunks = [];
-      for await (const c of req) chunks.push(c);
-      const rpc = JSON.parse(Buffer.concat(chunks).toString('utf8'));
-      seen.push({ name: rpc.params.name, args: rpc.params.arguments });
-      res.writeHead(401, { 'content-type': 'application/json', 'www-authenticate': 'Bearer realm="x"' });
-      res.end('{}');
-    });
+    const server = createRecordingMcpServer(seen);
     await new Promise(r => server.listen(0, r));
     const agentUrl = `http://127.0.0.1:${server.address().port}/mcp`;
     try {
@@ -394,6 +386,191 @@ describe('runStoryboard: sample_request envelope pass-through with a request bui
         'https://buyer.example/FROM_CALLER',
         'caller-provided push_notification_config must win — sample_request only fills missing fields'
       );
+    } finally {
+      server.close();
+    }
+  });
+
+  it('resolves runner webhook placeholders supplied through options.request before dispatch', async () => {
+    const seen = [];
+    const server = createRecordingMcpServer(seen);
+    await new Promise(r => server.listen(0, r));
+    const agentUrl = `http://127.0.0.1:${server.address().port}/mcp`;
+    try {
+      const storyboard = {
+        id: 'options_request_webhook_url_sb',
+        version: '1.0.0',
+        title: 'Options request webhook substitution',
+        category: 'compliance',
+        summary: '',
+        narrative: '',
+        agent: { interaction_model: '*', capabilities: [] },
+        caller: { role: 'buyer_agent' },
+        phases: [
+          {
+            id: 'p',
+            title: 'create',
+            steps: [
+              {
+                id: 'create_buy',
+                title: 'caller-provided request still gets runner substitutions',
+                task: 'create_media_buy',
+                auth: 'none',
+                sample_request: {
+                  start_time: '2099-10-01T00:00:00Z',
+                  end_time: '2099-12-31T23:59:59Z',
+                  packages: [{ buyer_ref: 'pkg-1', product_id: 'prod-1', pricing_option_id: 'cpm-1', budget: 100 }],
+                },
+                validations: [{ check: 'http_status_in', allowed_values: [401], description: '' }],
+              },
+            ],
+          },
+        ],
+      };
+      await runStoryboard(agentUrl, storyboard, {
+        protocol: 'mcp',
+        allow_http: true,
+        agentTools: ['create_media_buy'],
+        webhook_receiver: { mode: 'ephemeral' },
+        request: {
+          start_time: '2099-10-01T00:00:00Z',
+          end_time: '2099-12-31T23:59:59Z',
+          push_notification_config: { url: '{{runner.webhook_url:create_buy}}' },
+        },
+        _profile: { name: 'Test', tools: ['create_media_buy'] },
+        _client: {
+          getAgentInfo: async () => ({ name: 'Test', tools: [{ name: 'create_media_buy' }] }),
+        },
+      });
+
+      assert.strictEqual(seen.length, 1);
+      const url = seen[0].args.push_notification_config?.url;
+      assert.ok(typeof url === 'string', 'push_notification_config.url must be forwarded');
+      assert.ok(/\/step\/create_buy\/[0-9a-f-]{36}$/i.test(url), `expected expanded runner webhook URL; got ${url}`);
+      assert.ok(!url.includes('{{runner.'), 'options.request webhook token must not reach the agent');
+    } finally {
+      server.close();
+    }
+  });
+
+  it('skips instead of dispatching when options.request contains an unresolved runner webhook placeholder', async () => {
+    const seen = [];
+    const server = createRecordingMcpServer(seen);
+    await new Promise(r => server.listen(0, r));
+    const agentUrl = `http://127.0.0.1:${server.address().port}/mcp`;
+    try {
+      const storyboard = {
+        id: 'options_request_webhook_url_no_receiver_sb',
+        version: '1.0.0',
+        title: 'Options request webhook substitution without receiver',
+        category: 'compliance',
+        summary: '',
+        narrative: '',
+        agent: { interaction_model: '*', capabilities: [] },
+        caller: { role: 'buyer_agent' },
+        phases: [
+          {
+            id: 'p',
+            title: 'create',
+            steps: [
+              {
+                id: 'create_buy',
+                title: 'unresolved runner webhook token must not be sent',
+                task: 'create_media_buy',
+                auth: 'none',
+                sample_request: {
+                  start_time: '2099-10-01T00:00:00Z',
+                  end_time: '2099-12-31T23:59:59Z',
+                  packages: [{ buyer_ref: 'pkg-1', product_id: 'prod-1', pricing_option_id: 'cpm-1', budget: 100 }],
+                },
+                validations: [{ check: 'http_status_in', allowed_values: [401], description: '' }],
+              },
+            ],
+          },
+        ],
+      };
+      const result = await runStoryboard(agentUrl, storyboard, {
+        protocol: 'mcp',
+        allow_http: true,
+        agentTools: ['create_media_buy'],
+        request: {
+          start_time: '2099-10-01T00:00:00Z',
+          end_time: '2099-12-31T23:59:59Z',
+          push_notification_config: { url: '{{runner.webhook_url:create_buy}}' },
+        },
+        _profile: { name: 'Test', tools: ['create_media_buy'] },
+        _client: {
+          getAgentInfo: async () => ({ name: 'Test', tools: [{ name: 'create_media_buy' }] }),
+        },
+      });
+
+      assert.strictEqual(seen.length, 0, 'unresolved runner webhook token must not be dispatched');
+      const step = result.phases[0].steps[0];
+      assert.strictEqual(step.skipped, true);
+      assert.strictEqual(step.skip_reason, 'not_applicable');
+      assert.match(step.skip.detail, /unresolved runner placeholders/);
+    } finally {
+      server.close();
+    }
+  });
+
+  it('skips instead of dispatching when options.request contains an unresolved prior_step operation placeholder', async () => {
+    const seen = [];
+    const server = createRecordingMcpServer(seen);
+    await new Promise(r => server.listen(0, r));
+    const agentUrl = `http://127.0.0.1:${server.address().port}/mcp`;
+    try {
+      const storyboard = {
+        id: 'options_request_prior_step_unresolved_sb',
+        version: '1.0.0',
+        title: 'Options request prior step substitution without operation id',
+        category: 'compliance',
+        summary: '',
+        narrative: '',
+        agent: { interaction_model: '*', capabilities: [] },
+        caller: { role: 'buyer_agent' },
+        phases: [
+          {
+            id: 'p',
+            title: 'create',
+            steps: [
+              {
+                id: 'create_buy',
+                title: 'unresolved prior step token must not be sent',
+                task: 'create_media_buy',
+                auth: 'none',
+                sample_request: {
+                  start_time: '2099-10-01T00:00:00Z',
+                  end_time: '2099-12-31T23:59:59Z',
+                  packages: [{ buyer_ref: 'pkg-1', product_id: 'prod-1', pricing_option_id: 'cpm-1', budget: 100 }],
+                },
+                validations: [{ check: 'http_status_in', allowed_values: [401], description: '' }],
+              },
+            ],
+          },
+        ],
+      };
+      const result = await runStoryboard(agentUrl, storyboard, {
+        protocol: 'mcp',
+        allow_http: true,
+        agentTools: ['create_media_buy'],
+        request: {
+          start_time: '2099-10-01T00:00:00Z',
+          end_time: '2099-12-31T23:59:59Z',
+          push_notification_config: { url: 'https://hooks.example/{{prior_step.missing.operation_id}}' },
+        },
+        _profile: { name: 'Test', tools: ['create_media_buy'] },
+        _client: {
+          getAgentInfo: async () => ({ name: 'Test', tools: [{ name: 'create_media_buy' }] }),
+        },
+      });
+
+      assert.strictEqual(seen.length, 0, 'unresolved prior_step token must not be dispatched');
+      const step = result.phases[0].steps[0];
+      assert.strictEqual(step.skipped, true);
+      assert.strictEqual(step.passed, false);
+      assert.strictEqual(step.skip_reason, 'prerequisite_failed');
+      assert.match(step.skip.detail, /prior_step\.missing\.operation_id/);
     } finally {
       server.close();
     }

--- a/test/lib/storyboard-expect-error-failed-payload.test.js
+++ b/test/lib/storyboard-expect-error-failed-payload.test.js
@@ -26,6 +26,13 @@ const topLevelAdcpError = {
   recovery: 'correctable',
 };
 
+const pastStartAdcpError = {
+  code: 'INVALID_REQUEST',
+  message: 'start_time must not be in the past',
+  field: 'start_time',
+  recovery: 'correctable',
+};
+
 function buildStoryboard() {
   return {
     id: 'failed_payload_expect_error',
@@ -122,6 +129,57 @@ describe('storyboard expect_error failed payload normalization (#2179)', () => {
     assert.equal(rejectStep.validations[0].passed, true);
     assert.deepEqual(rejectStep.response_record.payload, { adcp_error: topLevelAdcpError });
     assert.equal(gateStep.passed, true);
+    assert.equal(result.overall_passed, true);
+  });
+
+  test('past-start create_media_buy INVALID_REQUEST passes the step and storyboard aggregate', async () => {
+    const storyboard = {
+      id: 'schema_validation_past_start_rejection',
+      version: '1.0.0',
+      title: 'Past start rejection',
+      category: 'test',
+      summary: '',
+      narrative: '',
+      agent: { interaction_model: '*', capabilities: [] },
+      caller: { role: 'buyer_agent' },
+      phases: [
+        {
+          id: 'past_start_rejection',
+          title: 'past start rejection',
+          steps: [
+            {
+              id: 'create_buy_past_start_reject',
+              title: 'reject past start date',
+              task: 'create_media_buy',
+              expect_error: true,
+              negative_path: 'payload_well_formed',
+              sample_request: {
+                start_time: '2020-01-01T00:00:00Z',
+                end_time: '2020-01-02T00:00:00Z',
+                packages: [{ buyer_ref: 'pkg-1', product_id: 'prod-1', pricing_option_id: 'cpm-1', budget: 100 }],
+              },
+              validations: [{ check: 'error_code', value: 'INVALID_REQUEST', description: 'past start rejected' }],
+            },
+          ],
+        },
+      ],
+    };
+    const client = {
+      getAgentInfo: async () => ({ name: 'stub', tools: [{ name: 'create_media_buy' }] }),
+      createMediaBuy: async () => ({ adcp_error: pastStartAdcpError }),
+    };
+
+    const result = await runStoryboard('https://stub.example/mcp', storyboard, {
+      protocol: 'mcp',
+      _client: client,
+      _profile: { name: 'stub', tools: [{ name: 'create_media_buy' }] },
+    });
+
+    const step = result.phases[0].steps[0];
+    assert.equal(step.passed, true);
+    assert.equal(step.validations[0].passed, true);
+    assert.deepEqual(step.response_record.payload, { adcp_error: pastStartAdcpError });
+    assert.equal(result.failed_count, 0);
     assert.equal(result.overall_passed, true);
   });
 });

--- a/test/lib/storyboard-idempotency-invariant.test.js
+++ b/test/lib/storyboard-idempotency-invariant.test.js
@@ -28,6 +28,32 @@ function closeServer(server) {
   });
 }
 
+function createRecordingMcpServer(seen, handleTool) {
+  return http.createServer(async (req, res) => {
+    const chunks = [];
+    for await (const c of req) chunks.push(c);
+    const rpc = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+    if (rpc.method === 'initialize') {
+      res.writeHead(200, { 'content-type': 'application/json', 'mcp-session-id': 'test-session' });
+      res.end(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: rpc.id,
+          result: { protocolVersion: '2025-11-25', capabilities: {}, serverInfo: { name: 'test', version: '1.0.0' } },
+        })
+      );
+      return;
+    }
+    if (rpc.method === 'notifications/initialized') {
+      res.writeHead(202);
+      res.end();
+      return;
+    }
+    seen.push({ name: rpc.params.name, args: rpc.params.arguments });
+    handleTool(rpc, res);
+  });
+}
+
 describe('applyIdempotencyInvariant', () => {
   test('injects a UUID v4 on mutating tasks when the request omits one', () => {
     const result = applyIdempotencyInvariant({ name: 'p1' }, 'create_property_list', {});
@@ -98,11 +124,7 @@ describe('applyIdempotencyInvariant', () => {
 describe('runStoryboard: idempotency_key invariant on the wire', { concurrency: false }, () => {
   it('auto-injects idempotency_key on mutating steps whose sample_request omits it, including untyped tasks (acquire_rights) that fall through to executeTask', async () => {
     const seen = [];
-    const server = http.createServer(async (req, res) => {
-      const chunks = [];
-      for await (const c of req) chunks.push(c);
-      const rpc = JSON.parse(Buffer.concat(chunks).toString('utf8'));
-      seen.push({ name: rpc.params.name, args: rpc.params.arguments });
+    const server = createRecordingMcpServer(seen, (_rpc, res) => {
       res.writeHead(401, { 'content-type': 'application/json', 'www-authenticate': 'Bearer realm="x"' });
       res.end('{}');
     });
@@ -185,13 +207,75 @@ describe('runStoryboard: idempotency_key invariant on the wire', { concurrency: 
     }
   });
 
+  it('resolves runner webhook placeholders on a mutating options.request before idempotency dispatch', async () => {
+    const seen = [];
+    const server = createRecordingMcpServer(seen, (_rpc, res) => {
+      res.writeHead(401, { 'content-type': 'application/json', 'www-authenticate': 'Bearer realm="x"' });
+      res.end('{}');
+    });
+    await new Promise(r => server.listen(0, r));
+    const agentUrl = `http://127.0.0.1:${server.address().port}/mcp`;
+    try {
+      const storyboard = {
+        id: 'idempotency_webhook_options_request_sb',
+        version: '1.0.0',
+        title: 'Idempotency webhook invariant',
+        category: 'compliance',
+        summary: '',
+        narrative: '',
+        agent: { interaction_model: '*', capabilities: [] },
+        caller: { role: 'buyer_agent' },
+        phases: [
+          {
+            id: 'p',
+            title: 'mutating',
+            steps: [
+              {
+                id: 'create_buy',
+                title: 'mutating options request resolves webhook before idempotency dispatch',
+                task: 'create_media_buy',
+                auth: 'none',
+                sample_request: {
+                  start_time: '2099-10-01T00:00:00Z',
+                  end_time: '2099-12-31T23:59:59Z',
+                  packages: [{ buyer_ref: 'pkg-1', product_id: 'prod-1', pricing_option_id: 'cpm-1', budget: 100 }],
+                },
+                validations: [{ check: 'http_status_in', allowed_values: [401], description: '' }],
+              },
+            ],
+          },
+        ],
+      };
+      await runStoryboard(agentUrl, storyboard, {
+        protocol: 'mcp',
+        allow_http: true,
+        agentTools: ['create_media_buy'],
+        webhook_receiver: { mode: 'ephemeral' },
+        request: {
+          start_time: '2099-10-01T00:00:00Z',
+          end_time: '2099-12-31T23:59:59Z',
+          push_notification_config: { url: '{{runner.webhook_url:create_buy}}' },
+        },
+        _profile: { name: 'Test', tools: ['create_media_buy'] },
+        _client: {
+          getAgentInfo: async () => ({ name: 'Test', tools: [{ name: 'create_media_buy' }] }),
+        },
+      });
+
+      assert.strictEqual(seen.length, 1);
+      assert.match(String(seen[0].args.idempotency_key), UUID_V4);
+      const url = seen[0].args.push_notification_config?.url;
+      assert.ok(typeof url === 'string', 'push_notification_config.url must be forwarded');
+      assert.ok(/\/step\/create_buy\/[0-9a-f-]{36}$/i.test(url), `expected expanded runner webhook URL; got ${url}`);
+      assert.ok(!url.includes('{{runner.'), 'runner webhook token must not reach the agent');
+    } finally {
+      await closeServer(server);
+    }
+  });
+
   it('injects on expect_error mutating steps so storyboards testing GOVERNANCE_DENIED / UNAUTHORIZED / brand_mismatch reach the error path they named', async () => {
     const seen = [];
-    const server = http.createServer(async (req, res) => {
-      const chunks = [];
-      for await (const c of req) chunks.push(c);
-      const rpc = JSON.parse(Buffer.concat(chunks).toString('utf8'));
-      seen.push({ name: rpc.params.name, args: rpc.params.arguments });
+    const server = createRecordingMcpServer(seen, (rpc, res) => {
       res.writeHead(403, { 'content-type': 'application/json' });
       res.end(
         JSON.stringify({
@@ -254,11 +338,7 @@ describe('runStoryboard: idempotency_key invariant on the wire', { concurrency: 
 
   it('leaves idempotency_key absent when step.omit_idempotency_key=true so the server sees a missing-key request', async () => {
     const seen = [];
-    const server = http.createServer(async (req, res) => {
-      const chunks = [];
-      for await (const c of req) chunks.push(c);
-      const rpc = JSON.parse(Buffer.concat(chunks).toString('utf8'));
-      seen.push({ name: rpc.params.name, args: rpc.params.arguments });
+    const server = createRecordingMcpServer(seen, (rpc, res) => {
       res.writeHead(400, { 'content-type': 'application/json' });
       res.end(
         JSON.stringify({

--- a/test/lib/storyboard-multi-instance.test.js
+++ b/test/lib/storyboard-multi-instance.test.js
@@ -8,9 +8,9 @@
  * is exercised in CI.
  *
  * These tests stand up two local HTTP servers as fake MCP agents. Steps use
- * `auth: 'none'` so dispatch goes through `rawMcpProbe` (no MCP SDK session
- * handshake) — sufficient for the round-robin and attribution assertions,
- * and keeps the tests free of MCP initialization concerns.
+ * `auth: 'none'`, but the runner still initializes MCP transports before
+ * dispatch. The fake agents below implement that handshake and only record
+ * actual tool calls for round-robin attribution assertions.
  */
 
 const { describe, test, beforeEach, afterEach } = require('node:test');
@@ -25,6 +25,37 @@ const { closeMCPConnections } = require('../../dist/lib/protocols/mcp.js');
 // Fake agent harness
 // ────────────────────────────────────────────────────────────
 
+function handleMcpHandshake(rpc, res, tools) {
+  if (rpc.method === 'initialize') {
+    res.writeHead(200, { 'content-type': 'application/json', 'mcp-session-id': 'test-session' });
+    res.end(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: rpc.id,
+        result: { protocolVersion: '2025-11-25', capabilities: {}, serverInfo: { name: 'test', version: '1.0.0' } },
+      })
+    );
+    return true;
+  }
+  if (rpc.method === 'notifications/initialized') {
+    res.writeHead(202);
+    res.end();
+    return true;
+  }
+  if (rpc.method === 'tools/list') {
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: rpc.id,
+        result: { tools: tools.map(name => ({ name, inputSchema: { type: 'object' } })) },
+      })
+    );
+    return true;
+  }
+  return false;
+}
+
 /**
  * Start a fake MCP agent on an ephemeral port. `state` is a Map the handler
  * writes to for `create_*` tasks and reads from for `get_*` tasks — inject
@@ -37,6 +68,9 @@ async function startFakeAgent({ state, label }) {
     const chunks = [];
     for await (const c of req) chunks.push(c);
     const rpc = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+    if (handleMcpHandshake(rpc, res, ['__test_write', '__test_read', '__test_probe', 'get_adcp_capabilities'])) {
+      return;
+    }
     const toolName = rpc.params?.name;
     const args = rpc.params?.arguments ?? {};
     requests.push({ tool: toolName, args, label });
@@ -382,6 +416,7 @@ describe('runStoryboard: multi-instance multi-pass', () => {
         const chunks = [];
         for await (const c of req) chunks.push(c);
         const rpc = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+        if (handleMcpHandshake(rpc, res, ['__test_probe', 'get_adcp_capabilities'])) return;
         const tool = rpc.params?.name;
         if (tool === 'get_adcp_capabilities') {
           res.writeHead(200, { 'content-type': 'application/json' }).end(

--- a/test/lib/storyboard-rate-limit-trip.test.js
+++ b/test/lib/storyboard-rate-limit-trip.test.js
@@ -464,6 +464,30 @@ describe('storyboard rate_limit_trip_runner wiring', () => {
     assert.equal(result.response_record.payload.trip_request.buyer_ref, 'override-ref');
   });
 
+  test('unresolved runner tokens in the rate-limit target request skip before dispatch', async () => {
+    const client = {
+      executeTask: async () => {
+        throw new Error('should not dispatch unresolved runner tokens');
+      },
+    };
+
+    const result = await runTripStep(client, makeStoryboard(), {
+      request: {
+        buyer_ref: 'override-ref',
+        packages: [{ product_id: 'override-prod', budget: 1234 }],
+        push_notification_config: {
+          url: 'https://hooks.example/{{runner.webhook_url:trip}}/{{prior_step.missing.operation_id}}',
+        },
+      },
+    });
+
+    assert.equal(result.passed, false);
+    assert.equal(result.skipped, true);
+    assert.equal(result.skip_reason, 'prerequisite_failed');
+    assert.match(result.skip.detail, /runner\.webhook_url:trip/);
+    assert.match(result.skip.detail, /prior_step\.missing\.operation_id/);
+  });
+
   test('expect_error trip target preserves authored sample request without enrichment', async () => {
     const calls = [];
     const client = {

--- a/test/lib/storyboard-root-context.test.js
+++ b/test/lib/storyboard-root-context.test.js
@@ -48,6 +48,33 @@ async function startCaptureAgent() {
     const chunks = [];
     for await (const c of req) chunks.push(c);
     const rpc = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+    if (rpc.method === 'initialize') {
+      res.writeHead(200, { 'content-type': 'application/json', 'mcp-session-id': 'test-session' });
+      res.end(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: rpc.id,
+          result: { protocolVersion: '2025-11-25', capabilities: {}, serverInfo: { name: 'test', version: '1.0.0' } },
+        })
+      );
+      return;
+    }
+    if (rpc.method === 'notifications/initialized') {
+      res.writeHead(202);
+      res.end();
+      return;
+    }
+    if (rpc.method === 'tools/list') {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: rpc.id,
+          result: { tools: [{ name: 'get_products', inputSchema: { type: 'object' } }] },
+        })
+      );
+      return;
+    }
     if (rpc.params?.name) {
       seen.push({ name: rpc.params.name, args: rpc.params.arguments });
     }

--- a/test/lib/storyboard-security.test.js
+++ b/test/lib/storyboard-security.test.js
@@ -547,7 +547,11 @@ describe('rawMcpProbe', () => {
           JSON.stringify({
             jsonrpc: '2.0',
             id: rpc.id,
-            result: { protocolVersion: '2025-11-25', capabilities: {}, serverInfo: { name: 'strict', version: '1.0.0' } },
+            result: {
+              protocolVersion: '2025-11-25',
+              capabilities: {},
+              serverInfo: { name: 'strict', version: '1.0.0' },
+            },
           })
         );
         return;
@@ -1362,6 +1366,22 @@ describe('security_baseline: unconditional PRM enforcement (#677)', () => {
           );
         }
         if (auth === `Bearer ${validApiKey}`) {
+          if (body.method === 'initialize') {
+            return reply(200, {
+              jsonrpc: '2.0',
+              id: body.id,
+              result: {
+                protocolVersion: '2025-11-25',
+                capabilities: {},
+                serverInfo: { name: 'auth-test-agent', version: '1.0.0' },
+              },
+            });
+          }
+          if (body.method === 'notifications/initialized') {
+            res.writeHead(202);
+            res.end();
+            return;
+          }
           return reply(200, {
             jsonrpc: '2.0',
             id: body.id,

--- a/test/lib/storyboard-security.test.js
+++ b/test/lib/storyboard-security.test.js
@@ -30,6 +30,26 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 
+function maybeHandleMcpHandshake(rpc, res) {
+  if (rpc.method === 'initialize') {
+    res.writeHead(200, { 'content-type': 'application/json', 'mcp-session-id': 'test-session' });
+    res.end(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: rpc.id,
+        result: { protocolVersion: '2025-11-25', capabilities: {}, serverInfo: { name: 'test', version: '1.0.0' } },
+      })
+    );
+    return true;
+  }
+  if (rpc.method === 'notifications/initialized') {
+    res.writeHead(202);
+    res.end();
+    return true;
+  }
+  return false;
+}
+
 // ────────────────────────────────────────────────────────────
 // isPrivateIp
 // ────────────────────────────────────────────────────────────
@@ -383,10 +403,12 @@ describe('rawMcpProbe', () => {
   it('sends JSON-RPC tools/call and surfaces HTTP status + body', async () => {
     let seenBody, seenAuth;
     const server = http.createServer(async (req, res) => {
-      seenAuth = req.headers.authorization ?? null;
       const chunks = [];
       for await (const c of req) chunks.push(c);
-      seenBody = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+      const rpc = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+      if (maybeHandleMcpHandshake(rpc, res)) return;
+      seenAuth = req.headers.authorization ?? null;
+      seenBody = rpc;
       res.writeHead(200, { 'content-type': 'application/json' });
       res.end(
         JSON.stringify({
@@ -415,6 +437,140 @@ describe('rawMcpProbe', () => {
     }
   });
 
+  it('initializes the MCP session before dispatching the auth probe tool call', async () => {
+    const seen = [];
+    const server = http.createServer(async (req, res) => {
+      const chunks = [];
+      for await (const c of req) chunks.push(c);
+      const rpc = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+      seen.push({
+        method: rpc.method,
+        session: req.headers['mcp-session-id'] ?? null,
+        protocol: req.headers['mcp-protocol-version'] ?? null,
+      });
+      if (rpc.method === 'initialize') {
+        res.writeHead(200, { 'content-type': 'application/json', 'mcp-session-id': 'sess-raw-probe' });
+        res.end(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            id: rpc.id,
+            result: {
+              protocolVersion: '2025-06-18',
+              capabilities: {},
+              serverInfo: { name: 'strict', version: '1.0.0' },
+            },
+          })
+        );
+        return;
+      }
+      if (rpc.method === 'notifications/initialized') {
+        res.writeHead(
+          req.headers['mcp-session-id'] === 'sess-raw-probe' && req.headers['mcp-protocol-version'] === '2025-06-18'
+            ? 202
+            : 400
+        );
+        res.end();
+        return;
+      }
+      if (req.headers['mcp-session-id'] !== 'sess-raw-probe' || req.headers['mcp-protocol-version'] !== '2025-06-18') {
+        res.writeHead(400, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ jsonrpc: '2.0', id: rpc.id, error: { code: -32002, message: 'not initialized' } }));
+        return;
+      }
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: rpc.id,
+          result: { structuredContent: { ok: true } },
+        })
+      );
+    });
+    await new Promise(r => server.listen(0, r));
+    try {
+      const { httpResult, taskResult } = await rawMcpProbe({
+        agentUrl: `http://127.0.0.1:${server.address().port}/mcp`,
+        toolName: 'list_creatives',
+        args: {},
+        allowPrivateIp: true,
+      });
+      assert.strictEqual(httpResult.status, 200);
+      assert.deepStrictEqual(taskResult.data, { ok: true });
+      assert.deepStrictEqual(
+        seen.map(s => s.method),
+        ['initialize', 'notifications/initialized', 'tools/call']
+      );
+      assert.strictEqual(seen[2].session, 'sess-raw-probe');
+      assert.strictEqual(seen[1].protocol, '2025-06-18');
+      assert.strictEqual(seen[2].protocol, '2025-06-18');
+    } finally {
+      server.close();
+    }
+  });
+
+  it('stops before notifications/initialized when initialize returns a JSON-RPC error', async () => {
+    const seen = [];
+    const server = http.createServer(async (req, res) => {
+      const chunks = [];
+      for await (const c of req) chunks.push(c);
+      const rpc = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+      seen.push(rpc.method);
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ jsonrpc: '2.0', id: rpc.id, error: { code: -32600, message: 'bad initialize' } }));
+    });
+    await new Promise(r => server.listen(0, r));
+    try {
+      const { httpResult, taskResult } = await rawMcpProbe({
+        agentUrl: `http://127.0.0.1:${server.address().port}/mcp`,
+        toolName: 'list_creatives',
+        args: {},
+        allowPrivateIp: true,
+      });
+      assert.strictEqual(httpResult.status, 200);
+      assert.match(taskResult.error, /bad initialize/);
+      assert.deepStrictEqual(seen, ['initialize']);
+    } finally {
+      server.close();
+    }
+  });
+
+  it('stops before tools/call when notifications/initialized is rejected', async () => {
+    const seen = [];
+    const server = http.createServer(async (req, res) => {
+      const chunks = [];
+      for await (const c of req) chunks.push(c);
+      const rpc = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+      seen.push(rpc.method);
+      if (rpc.method === 'initialize') {
+        res.writeHead(200, { 'content-type': 'application/json', 'mcp-session-id': 'sess-raw-probe' });
+        res.end(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            id: rpc.id,
+            result: { protocolVersion: '2025-11-25', capabilities: {}, serverInfo: { name: 'strict', version: '1.0.0' } },
+          })
+        );
+        return;
+      }
+      res.writeHead(400, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ jsonrpc: '2.0', id: rpc.id, error: { code: -32002, message: 'initialized rejected' } }));
+    });
+    await new Promise(r => server.listen(0, r));
+    try {
+      const { httpResult, taskResult } = await rawMcpProbe({
+        agentUrl: `http://127.0.0.1:${server.address().port}/mcp`,
+        toolName: 'list_creatives',
+        args: {},
+        allowPrivateIp: true,
+      });
+      assert.strictEqual(httpResult.status, 400);
+      assert.match(taskResult.error, /initialized rejected/);
+      assert.deepStrictEqual(seen, ['initialize', 'notifications/initialized']);
+    } finally {
+      server.close();
+    }
+  });
+
   it('surfaces 401 + WWW-Authenticate from the agent', async () => {
     const server = http.createServer((req, res) => {
       res.writeHead(401, {
@@ -433,6 +589,35 @@ describe('rawMcpProbe', () => {
       });
       assert.strictEqual(httpResult.status, 401);
       assert.match(httpResult.headers['www-authenticate'], /Bearer realm/);
+    } finally {
+      server.close();
+    }
+  });
+
+  it('preserves non-JSON MCP auth responses with a stable synthetic task error', async () => {
+    const server = http.createServer(async (req, res) => {
+      const chunks = [];
+      for await (const c of req) chunks.push(c);
+      const rpc = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+      if (maybeHandleMcpHandshake(rpc, res)) return;
+      res.writeHead(401, {
+        'content-type': 'text/plain',
+        'www-authenticate': 'Bearer realm="adcp"',
+      });
+      res.end('plain unauthorized');
+    });
+    await new Promise(r => server.listen(0, r));
+    try {
+      const { httpResult, taskResult } = await rawMcpProbe({
+        agentUrl: `http://127.0.0.1:${server.address().port}/mcp`,
+        toolName: 'list_creatives',
+        args: {},
+        allowPrivateIp: true,
+      });
+      assert.strictEqual(httpResult.status, 401);
+      assert.strictEqual(httpResult.body, 'plain unauthorized');
+      assert.match(httpResult.headers['www-authenticate'], /Bearer/);
+      assert.match(taskResult.error, /Non-JSON response body/);
     } finally {
       server.close();
     }
@@ -485,10 +670,11 @@ describe('rawMcpProbe', () => {
     // MCP server).
     let seenAccept;
     const server = http.createServer(async (req, res) => {
-      seenAccept = req.headers.accept ?? '';
       const chunks = [];
       for await (const c of req) chunks.push(c);
       const seenBody = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+      if (maybeHandleMcpHandshake(seenBody, res)) return;
+      seenAccept = req.headers.accept ?? '';
       res.writeHead(200, { 'content-type': 'text/event-stream' });
       res.end(
         `event: message\ndata: ${JSON.stringify({
@@ -526,6 +712,7 @@ describe('rawMcpProbe', () => {
       const chunks = [];
       for await (const c of req) chunks.push(c);
       const seenBody = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+      if (maybeHandleMcpHandshake(seenBody, res)) return;
       res.writeHead(200, { 'content-type': 'text/event-stream' });
       // First frame: a server-initiated progress notification (no `id` field,
       // so it can never match a request id).
@@ -783,6 +970,7 @@ describe('storyboard runner: auth-override dispatch', () => {
       const chunks = [];
       for await (const c of req) chunks.push(c);
       const rpc = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+      if (maybeHandleMcpHandshake(rpc, res)) return;
       seenTool = rpc.params.name;
       res.writeHead(401, { 'content-type': 'application/json', 'www-authenticate': 'Bearer realm="x"' });
       res.end('{}');
@@ -865,10 +1053,11 @@ describe('storyboard runner: auth-override dispatch', () => {
   it('step auth.type=basic sends Basic from test_kit.auth.basic credentials', async () => {
     let seenAuth = null;
     const server = http.createServer(async (req, res) => {
-      seenAuth = req.headers.authorization ?? null;
       const chunks = [];
       for await (const c of req) chunks.push(c);
       const rpc = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+      if (maybeHandleMcpHandshake(rpc, res)) return;
+      seenAuth = req.headers.authorization ?? null;
       res.writeHead(200, { 'content-type': 'application/json' });
       res.end(
         JSON.stringify({
@@ -940,10 +1129,11 @@ describe('storyboard runner: auth-override dispatch', () => {
   it('step auth.type=basic supports explicit username/password and random-invalid credentials', async () => {
     const observed = [];
     const server = http.createServer(async (req, res) => {
-      observed.push(req.headers.authorization ?? null);
       const chunks = [];
       for await (const c of req) chunks.push(c);
       const rpc = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+      if (maybeHandleMcpHandshake(rpc, res)) return;
+      observed.push(req.headers.authorization ?? null);
       const isFirst = observed.length === 1;
       res.writeHead(isFirst ? 200 : 401, {
         'content-type': 'application/json',

--- a/test/lib/storyboard-webhook-receiver.test.js
+++ b/test/lib/storyboard-webhook-receiver.test.js
@@ -257,6 +257,33 @@ async function startFakePublisher(config = {}) {
       res.writeHead(400).end();
       return;
     }
+    if (rpc.method === 'initialize') {
+      res.writeHead(200, { 'content-type': 'application/json', 'mcp-session-id': 'test-session' });
+      res.end(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: rpc.id,
+          result: { protocolVersion: '2025-11-25', capabilities: {}, serverInfo: { name: 'test', version: '1.0.0' } },
+        })
+      );
+      return;
+    }
+    if (rpc.method === 'notifications/initialized') {
+      res.writeHead(202);
+      res.end();
+      return;
+    }
+    if (rpc.method === 'tools/list') {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: rpc.id,
+          result: { tools: [{ name: '__test_fire_webhook', inputSchema: { type: 'object' } }] },
+        })
+      );
+      return;
+    }
     const toolName = rpc.params?.name;
     const args = rpc.params?.arguments ?? {};
 

--- a/test/lib/storyboard-webhook-signature.test.js
+++ b/test/lib/storyboard-webhook-signature.test.js
@@ -56,6 +56,39 @@ async function startSignedPublisher({ signerKey, tag } = {}) {
     const toolName = rpc.params?.name;
     const args = rpc.params?.arguments ?? {};
 
+    if (rpc.method === 'initialize') {
+      res.writeHead(200, { 'content-type': 'application/json' }).end(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: rpc.id,
+          result: {
+            protocolVersion: '2025-11-25',
+            capabilities: {},
+            serverInfo: { name: 'signed-webhook-test-agent', version: '1.0.0' },
+          },
+        })
+      );
+      return;
+    }
+
+    if (rpc.method === 'notifications/initialized') {
+      res.writeHead(202).end();
+      return;
+    }
+
+    if (rpc.method === 'tools/list') {
+      res.writeHead(200, { 'content-type': 'application/json' }).end(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: rpc.id,
+          result: {
+            tools: [{ name: '__test_fire_webhook', inputSchema: { type: 'object' } }],
+          },
+        })
+      );
+      return;
+    }
+
     if (toolName === '__test_fire_webhook') {
       const url = args.push_notification_config?.url;
       const body = JSON.stringify({


### PR DESCRIPTION
Fixes storyboard regressions where runner-provided webhook placeholders were not expanded before dispatch, unresolved runner tokens could leak to sellers, strict MCP security probes skipped the Streamable HTTP initialization boundary, and expected AdCP error payloads could fail aggregate grading.

The runner now expands options.request, blocks unresolved runner tokens across normal and rate-limit replay paths, and treats missing prior-step operation IDs as prerequisite failures.

Raw MCP probes now initialize sessions, validate negotiated protocol versions, echo post-init MCP headers, fail closed on initialization errors, and preserve non-JSON auth diagnostics.

Validation: npm run build; npx tsc --project tsconfig.lib.json --noEmit; focused storyboard security, envelope, idempotency, rate-limit, and expect-error tests.