### PR TITLE
fix: allow empty-password Basic auth in storyboards

### DIFF
--- a/.changeset/storyboard-basic-empty-password.md
+++ b/.changeset/storyboard-basic-empty-password.md
@@ -1,0 +1,5 @@
+---
+"@adcp/sdk": patch
+---
+
+Allow storyboard Basic-auth probes to use RFC 7617-valid empty passwords.

--- a/src/lib/testing/storyboard/default-invariants.ts
+++ b/src/lib/testing/storyboard/default-invariants.ts
@@ -518,9 +518,10 @@ function extractAuthSecrets(auth: unknown): string[] {
   pushCredentialValue(out, a.token); // bearer
 
   // basic: the password is the secret; the base64 blob catches echoes of the
-  // full Authorization: Basic header. Username alone is not a secret.
-  if (typeof a.password === 'string' && a.password) {
-    out.push(a.password);
+  // full Authorization: Basic header, including RFC 7617-valid empty passwords.
+  // Username alone is not a secret.
+  if (typeof a.password === 'string') {
+    if (a.password) out.push(a.password);
     if (typeof a.username === 'string' && a.username) {
       out.push(Buffer.from(`${a.username}:${a.password}`, 'utf8').toString('base64'));
     }
@@ -552,14 +553,15 @@ function extractBasicSecrets(basic: unknown): string[] {
   const out: string[] = [];
   if (typeof b.credentials === 'string' && b.credentials) {
     const colonIndex = b.credentials.indexOf(':');
-    if (colonIndex > 0 && colonIndex < b.credentials.length - 1) {
-      out.push(b.credentials.slice(colonIndex + 1));
+    if (colonIndex > 0) {
+      const password = b.credentials.slice(colonIndex + 1);
+      if (password) out.push(password);
       out.push(Buffer.from(b.credentials, 'utf8').toString('base64'));
     }
     return out;
   }
-  if (typeof b.password === 'string' && b.password) {
-    out.push(b.password);
+  if (typeof b.password === 'string') {
+    if (b.password) out.push(b.password);
     if (typeof b.username === 'string' && b.username) {
       out.push(Buffer.from(`${b.username}:${b.password}`, 'utf8').toString('base64'));
     }

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -5733,7 +5733,7 @@ function normalizeBasicCredentials(input: BasicCredentialInput, fieldPrefix: str
     }
     assertSafeAuthHeaderPart(input.credentials, `${fieldPrefix}.credentials`);
     const colonIndex = input.credentials.indexOf(':');
-    if (colonIndex <= 0 || colonIndex >= input.credentials.length - 1) {
+    if (colonIndex <= 0) {
       throw new Error(`${fieldPrefix}.credentials must be in unencoded username:password form`);
     }
     return input.credentials;
@@ -5741,8 +5741,8 @@ function normalizeBasicCredentials(input: BasicCredentialInput, fieldPrefix: str
   if (typeof input.username !== 'string' || input.username.length === 0) {
     throw new Error(`${fieldPrefix}.username must be a non-empty string`);
   }
-  if (typeof input.password !== 'string' || input.password.length === 0) {
-    throw new Error(`${fieldPrefix}.password must be a non-empty string`);
+  if (typeof input.password !== 'string') {
+    throw new Error(`${fieldPrefix}.password must be a string`);
   }
   if (input.username.includes(':')) {
     throw new Error(`${fieldPrefix}.username must not contain colon (RFC 7617)`);

--- a/test/lib/storyboard-default-invariants.test.js
+++ b/test/lib/storyboard-default-invariants.test.js
@@ -635,6 +635,23 @@ describe('default-invariants: context.no_secret_echo', () => {
     assert.strictEqual(out[0].passed, false, 'must catch a leaked base64 Basic header');
   });
 
+  test('catches the base64-encoded Authorization: Basic header for options.auth empty-password Basic', () => {
+    const user = 'fixtureusername';
+    const basicHeader = Buffer.from(`${user}:`, 'utf8').toString('base64');
+    const out = runEcho({ auth: basicAuth(user, '') }, { leaked: `Authorization: Basic ${basicHeader}` });
+    assert.strictEqual(out[0].passed, false, 'must catch a leaked empty-password Basic header');
+  });
+
+  test('catches the base64-encoded Authorization: Basic header for test_kit.auth.basic empty-password credentials', () => {
+    const user = 'fixtureusername';
+    const basicHeader = Buffer.from(`${user}:`, 'utf8').toString('base64');
+    const out = runEcho(
+      { test_kit: { auth: { basic: { credentials: `${user}:` } } } },
+      { leaked: `Authorization: Basic ${basicHeader}` }
+    );
+    assert.strictEqual(out[0].passed, false, 'must catch a leaked test-kit empty-password Basic header');
+  });
+
   test('does NOT extract basic-auth username alone (RFC-like: username is a public identifier)', () => {
     // Username is a public identifier — welcome messages, audit logs, and
     // "last login by X" displays all legitimately echo it. Extracting it

--- a/test/lib/storyboard-idempotency-invariant.test.js
+++ b/test/lib/storyboard-idempotency-invariant.test.js
@@ -423,6 +423,16 @@ describe('defaultAuthHeadersForRawProbe', () => {
     assert.deepStrictEqual(h, { authorization: 'Basic ' + Buffer.from(`${u}:${p}`).toString('base64') });
   });
 
+  test('basic allows an empty password in username/password form', () => {
+    const h = defaultAuthHeadersForRawProbe({ auth: { type: 'basic', username: 'user', password: '' } });
+    assert.deepStrictEqual(h, { authorization: 'Basic dXNlcjo=' });
+  });
+
+  test('basic allows an empty password in credentials form', () => {
+    const h = defaultAuthHeadersForRawProbe({ auth: { type: 'basic', credentials: 'user:' } });
+    assert.deepStrictEqual(h, { authorization: 'Basic dXNlcjo=' });
+  });
+
   test('oauth → undefined (SDK fallback; refresh semantics unreplicable)', () => {
     const h = defaultAuthHeadersForRawProbe({
       auth: { type: 'oauth', tokens: { access_token: 'x', refresh_token: 'y', token_type: 'Bearer' } },
@@ -444,6 +454,20 @@ describe('defaultAuthHeadersForRawProbe', () => {
           auth: { type: 'basic', username: 'has:colon', password: 'test-fixture' },
         }),
       /must not contain colon/
+    );
+  });
+
+  test('basic credentials form rejects empty username', () => {
+    assert.throws(
+      () => defaultAuthHeadersForRawProbe({ auth: { type: 'basic', credentials: ':pass' } }),
+      /credentials must be in unencoded username:password form/
+    );
+  });
+
+  test('basic username/password form rejects empty username', () => {
+    assert.throws(
+      () => defaultAuthHeadersForRawProbe({ auth: { type: 'basic', username: '', password: 'pass' } }),
+      /username must be a non-empty string/
     );
   });
 

--- a/test/lib/storyboard-security.test.js
+++ b/test/lib/storyboard-security.test.js
@@ -923,14 +923,14 @@ describe('storyboard runner: auth-override dispatch', () => {
         test_kit: {
           auth: {
             probe_task: 'list_creatives',
-            basic: { credentials: 'demo-user:demo-password' },
+            basic: { credentials: 'demo-user:' },
           },
         },
         _profile: { name: 'T', tools: ['list_creatives'] },
         _client: { getAgentInfo: async () => ({ name: 'T', tools: [{ name: 'list_creatives' }] }) },
       });
       assert.strictEqual(result.overall_passed, true, JSON.stringify(result.phases[0].steps[0]));
-      assert.strictEqual(seenAuth, `Basic ${Buffer.from('demo-user:demo-password').toString('base64')}`);
+      assert.strictEqual(seenAuth, `Basic ${Buffer.from('demo-user:').toString('base64')}`);
       assert.doesNotMatch(seenAuth, /^Bearer /);
     } finally {
       server.close();


### PR DESCRIPTION
Fixes #2213.

Summary:
- Allow storyboard Basic auth normalization to accept RFC 7617-valid empty passwords while preserving empty-username and header-safety checks.
- Keep `context.no_secret_echo` catching leaked Basic `Authorization` blobs for `user:` credentials.
- Add regression tests and a patch changeset.

Validation:
- `npm run build:lib`
- `node --test-timeout=60000 --test --test-name-pattern='context.no_secret_echo' test/lib/storyboard-default-invariants.test.js`
- `node --test-timeout=60000 --test --test-name-pattern='defaultAuthHeadersForRawProbe' test/lib/storyboard-idempotency-invariant.test.js`
- `node --test-timeout=60000 --test --test-name-pattern='storyboard runner: auth-override dispatch' test/lib/storyboard-security.test.js`
- `git diff --check`
