### PR TITLE
fix: align adagents redirect discovery

### DIFF
--- a/.changeset/adagents-discovery-redirect-policy.md
+++ b/.changeset/adagents-discovery-redirect-policy.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Align adagents.json discovery HTTP redirect handling with the shared policy: follow same-registrable-domain redirects on the initial .well-known fetch, and refuse redirects from authoritative_location targets.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/sdk",
-  "version": "9.0.0-beta.27",
+  "version": "9.0.0-beta.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/sdk",
-      "version": "9.0.0-beta.27",
+      "version": "9.0.0-beta.28",
       "license": "Apache-2.0",
       "workspaces": [
         ".",
@@ -7356,7 +7356,7 @@
       "version": "6.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adcp/sdk": "^9.0.0-beta.27"
+        "@adcp/sdk": "^9.0.0-beta.28"
       },
       "bin": {
         "adcp": "bin/adcp.js"

--- a/src/lib/discovery/adagents-redirects.ts
+++ b/src/lib/discovery/adagents-redirects.ts
@@ -97,11 +97,10 @@ export async function ssrfSafeFetchAdAgents(
 
 export function validateSameRegistrableDomainRedirect(originUrl: string, currentUrl: string, nextUrl: string): void {
   let origin: URL;
-  let current: URL;
   let next: URL;
   try {
     origin = new URL(originUrl);
-    current = new URL(currentUrl);
+    new URL(currentUrl);
     next = new URL(nextUrl);
   } catch {
     throw new AdAgentsRedirectRefusedError('redirect_refused', 'Invalid adagents.json redirect URL', {

--- a/src/lib/discovery/adagents-redirects.ts
+++ b/src/lib/discovery/adagents-redirects.ts
@@ -11,6 +11,7 @@ export type AdAgentsRedirectRefusalCode =
   | 'redirect_missing_location'
   | 'redirect_scheme_changed'
   | 'redirect_cross_registrable_domain'
+  | 'redirect_userinfo_not_allowed'
   | 'redirect_too_many';
 
 export class AdAgentsRedirectRefusedError extends Error {
@@ -55,13 +56,28 @@ export async function ssrfSafeFetchAdAgents(
       );
     }
 
-    const nextUrl = new URL(location, currentUrl).toString();
+    let next: URL;
+    try {
+      next = new URL(location, currentUrl);
+    } catch {
+      throw new AdAgentsRedirectRefusedError('redirect_refused', 'Invalid adagents.json redirect URL', {
+        url: currentUrl,
+      });
+    }
+    const nextUrl = next.toString();
+    if (next.username || next.password) {
+      throw new AdAgentsRedirectRefusedError(
+        'redirect_userinfo_not_allowed',
+        'adagents.json redirect must not include userinfo',
+        { url: currentUrl, location: scrubUrl(next) }
+      );
+    }
 
     if (policy.mode === 'none') {
       throw new AdAgentsRedirectRefusedError(
         'redirect_refused',
-        `Redirect refused while fetching authoritative adagents.json: ${nextUrl}`,
-        { url: currentUrl, location: nextUrl }
+        'Redirect refused while fetching authoritative adagents.json',
+        { url: currentUrl, location: scrubUrl(next) }
       );
     }
 
@@ -69,7 +85,7 @@ export async function ssrfSafeFetchAdAgents(
       throw new AdAgentsRedirectRefusedError(
         'redirect_too_many',
         `Too many adagents.json redirects; maximum is ${maxRedirects}`,
-        { url: currentUrl, location: nextUrl }
+        { url: currentUrl, location: scrubUrl(next) }
       );
     }
 
@@ -88,25 +104,23 @@ export function validateSameRegistrableDomainRedirect(originUrl: string, current
     current = new URL(currentUrl);
     next = new URL(nextUrl);
   } catch {
-    throw new AdAgentsRedirectRefusedError('redirect_refused', `Invalid adagents.json redirect URL: ${nextUrl}`, {
+    throw new AdAgentsRedirectRefusedError('redirect_refused', 'Invalid adagents.json redirect URL', {
       url: currentUrl,
-      location: nextUrl,
     });
   }
 
   if (next.protocol !== origin.protocol) {
-    throw new AdAgentsRedirectRefusedError(
-      'redirect_scheme_changed',
-      `adagents.json redirect changed scheme: ${current.protocol} -> ${next.protocol}`,
-      { url: currentUrl, location: nextUrl }
-    );
+    throw new AdAgentsRedirectRefusedError('redirect_scheme_changed', 'adagents.json redirect changed scheme', {
+      url: currentUrl,
+      location: scrubUrl(next),
+    });
   }
 
   if (!sameRegistrableDomain(origin, next)) {
     throw new AdAgentsRedirectRefusedError(
       'redirect_cross_registrable_domain',
-      `adagents.json redirect crosses registrable domain: ${origin.hostname} -> ${next.hostname}`,
-      { url: currentUrl, location: nextUrl }
+      'adagents.json redirect crosses registrable domain',
+      { url: currentUrl, location: scrubUrl(next) }
     );
   }
 }
@@ -126,4 +140,13 @@ function registrableDomain(hostname: string): string | null {
   const parsed = parseTld(hostname, { allowPrivateDomains: true });
   if (parsed.isIp || !parsed.domain) return null;
   return parsed.domain.toLowerCase();
+}
+
+function scrubUrl(url: URL): string {
+  const scrubbed = new URL(url.toString());
+  scrubbed.username = '';
+  scrubbed.password = '';
+  scrubbed.search = '';
+  scrubbed.hash = '';
+  return scrubbed.toString();
 }

--- a/src/lib/discovery/adagents-redirects.ts
+++ b/src/lib/discovery/adagents-redirects.ts
@@ -1,0 +1,129 @@
+import { parse as parseTld } from 'tldts';
+
+import { ssrfSafeFetch, type SsrfFetchOptions, type SsrfFetchResult } from '../net/ssrf-fetch';
+import { isInternalProbesAllowed } from '../utils/probe-policy';
+
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+const DEFAULT_WELL_KNOWN_REDIRECT_HOPS = 3;
+
+export type AdAgentsRedirectRefusalCode =
+  | 'redirect_refused'
+  | 'redirect_missing_location'
+  | 'redirect_scheme_changed'
+  | 'redirect_cross_registrable_domain'
+  | 'redirect_too_many';
+
+export class AdAgentsRedirectRefusedError extends Error {
+  readonly code: AdAgentsRedirectRefusalCode;
+  readonly url: string;
+  readonly location?: string;
+
+  constructor(code: AdAgentsRedirectRefusalCode, message: string, meta: { url: string; location?: string }) {
+    super(message);
+    this.name = 'AdAgentsRedirectRefusedError';
+    this.code = code;
+    this.url = meta.url;
+    this.location = meta.location;
+  }
+}
+
+export type AdAgentsRedirectPolicy =
+  | { mode: 'none' }
+  | { mode: 'same-registrable-domain'; originUrl: string; maxRedirects?: number };
+
+export async function ssrfSafeFetchAdAgents(
+  url: string,
+  options: SsrfFetchOptions,
+  policy: AdAgentsRedirectPolicy
+): Promise<SsrfFetchResult> {
+  let currentUrl = url;
+  let redirects = 0;
+  const originUrl = policy.mode === 'same-registrable-domain' ? policy.originUrl : url;
+  const maxRedirects =
+    policy.mode === 'same-registrable-domain' ? (policy.maxRedirects ?? DEFAULT_WELL_KNOWN_REDIRECT_HOPS) : 0;
+
+  while (true) {
+    const result = await ssrfSafeFetch(currentUrl, options);
+    if (!REDIRECT_STATUSES.has(result.status)) return result;
+
+    const location = result.headers['location'];
+    if (!location) {
+      throw new AdAgentsRedirectRefusedError(
+        'redirect_missing_location',
+        `HTTP ${result.status} redirect with no Location header`,
+        { url: currentUrl }
+      );
+    }
+
+    const nextUrl = new URL(location, currentUrl).toString();
+
+    if (policy.mode === 'none') {
+      throw new AdAgentsRedirectRefusedError(
+        'redirect_refused',
+        `Redirect refused while fetching authoritative adagents.json: ${nextUrl}`,
+        { url: currentUrl, location: nextUrl }
+      );
+    }
+
+    if (redirects >= maxRedirects) {
+      throw new AdAgentsRedirectRefusedError(
+        'redirect_too_many',
+        `Too many adagents.json redirects; maximum is ${maxRedirects}`,
+        { url: currentUrl, location: nextUrl }
+      );
+    }
+
+    validateSameRegistrableDomainRedirect(originUrl, currentUrl, nextUrl);
+    redirects++;
+    currentUrl = nextUrl;
+  }
+}
+
+export function validateSameRegistrableDomainRedirect(originUrl: string, currentUrl: string, nextUrl: string): void {
+  let origin: URL;
+  let current: URL;
+  let next: URL;
+  try {
+    origin = new URL(originUrl);
+    current = new URL(currentUrl);
+    next = new URL(nextUrl);
+  } catch {
+    throw new AdAgentsRedirectRefusedError('redirect_refused', `Invalid adagents.json redirect URL: ${nextUrl}`, {
+      url: currentUrl,
+      location: nextUrl,
+    });
+  }
+
+  if (next.protocol !== origin.protocol) {
+    throw new AdAgentsRedirectRefusedError(
+      'redirect_scheme_changed',
+      `adagents.json redirect changed scheme: ${current.protocol} -> ${next.protocol}`,
+      { url: currentUrl, location: nextUrl }
+    );
+  }
+
+  if (!sameRegistrableDomain(origin, next)) {
+    throw new AdAgentsRedirectRefusedError(
+      'redirect_cross_registrable_domain',
+      `adagents.json redirect crosses registrable domain: ${origin.hostname} -> ${next.hostname}`,
+      { url: currentUrl, location: nextUrl }
+    );
+  }
+}
+
+export function sameRegistrableDomain(a: URL, b: URL): boolean {
+  const aDomain = registrableDomain(a.hostname);
+  const bDomain = registrableDomain(b.hostname);
+  if (aDomain && bDomain) return aDomain === bDomain;
+
+  // Loopback tests run through http://127.0.0.1 under the explicit internal
+  // probe opt-in. Production publisher discovery should not treat IP literals
+  // as registrable domains.
+  return isInternalProbesAllowed() && a.hostname === b.hostname;
+}
+
+function registrableDomain(hostname: string): string | null {
+  const parsed = parseTld(hostname, { allowPrivateDomains: true });
+  if (parsed.isIp || !parsed.domain) return null;
+  return parsed.domain.toLowerCase();
+}

--- a/src/lib/discovery/network-consistency-checker.ts
+++ b/src/lib/discovery/network-consistency-checker.ts
@@ -240,14 +240,15 @@ export class NetworkConsistencyChecker {
       const firstDomain = this.domains[0];
       try {
         const pointerUrl = `https://${firstDomain}/.well-known/adagents.json`;
-        const pointerData = await this.fetchJson<AdAgentsJson>(pointerUrl, {
+        const pointer = await this.fetchJsonWithUrl<AdAgentsJson>(pointerUrl, {
           mode: 'same-registrable-domain',
           originUrl: pointerUrl,
         });
+        const pointerData = pointer.data;
         if (pointerData.authoritative_location) {
           url = pointerData.authoritative_location;
         } else {
-          return { url: `https://${firstDomain}/.well-known/adagents.json`, data: pointerData };
+          return { url: pointer.url, data: pointerData };
         }
       } catch (error) {
         report.schemaErrors.push({
@@ -259,7 +260,12 @@ export class NetworkConsistencyChecker {
     }
 
     try {
-      const data = await this.fetchJson<AdAgentsJson>(url, { mode: 'none' });
+      const authoritative = await this.fetchJsonWithUrl<AdAgentsJson>(url, {
+        mode: 'same-registrable-domain',
+        originUrl: url,
+      });
+      const data = authoritative.data;
+      const resolvedUrl = authoritative.url;
 
       // Follow at most one authoritative_location redirect
       if (data.authoritative_location && !data.authorized_agents) {
@@ -271,19 +277,20 @@ export class NetworkConsistencyChecker {
           });
           return { url, data: null };
         }
-        if (redirectUrl === url) {
+        if (redirectUrl === resolvedUrl) {
           report.schemaErrors.push({
             field: 'authoritative_location',
             message: 'authoritative_location points to itself',
           });
-          return { url, data: null };
+          return { url: resolvedUrl, data: null };
         }
-        const redirectData = await this.fetchJson<AdAgentsJson>(redirectUrl, { mode: 'none' });
+        const redirect = await this.fetchJsonWithUrl<AdAgentsJson>(redirectUrl, { mode: 'none' });
+        const redirectData = redirect.data;
         // Do not follow further redirects from the redirect target
-        return { url: redirectUrl, data: redirectData };
+        return { url: redirect.url, data: redirectData };
       }
 
-      return { url, data };
+      return { url: resolvedUrl, data };
     } catch (error) {
       report.schemaErrors.push({
         field: '$root',
@@ -475,10 +482,11 @@ export class NetworkConsistencyChecker {
     const url = `https://${domain}/.well-known/adagents.json`;
 
     try {
-      const data = await this.fetchJson<AdAgentsJson>(url, {
+      const pointer = await this.fetchJsonWithUrl<AdAgentsJson>(url, {
         mode: 'same-registrable-domain',
         originUrl: url,
       });
+      const data = pointer.data;
 
       if (data.authoritative_location) {
         if (data.authoritative_location === authoritativeUrl) {
@@ -508,7 +516,7 @@ export class NetworkConsistencyChecker {
       }
 
       // No authoritative_location — the domain hosts its own file
-      if (url === authoritativeUrl) {
+      if (pointer.url === authoritativeUrl) {
         return {
           detail: { domain, status: 'ok', errors: [] },
         };
@@ -522,7 +530,7 @@ export class NetworkConsistencyChecker {
         },
         stale: {
           domain,
-          pointerUrl: url,
+          pointerUrl: pointer.url,
           expectedUrl: authoritativeUrl,
         },
       };
@@ -553,14 +561,17 @@ export class NetworkConsistencyChecker {
       } | null> => {
         try {
           const pointerUrl = `https://${domain}/.well-known/adagents.json`;
-          const data = await this.fetchJson<AdAgentsJson>(pointerUrl, {
+          const pointer = await this.fetchJsonWithUrl<AdAgentsJson>(pointerUrl, {
             mode: 'same-registrable-domain',
             originUrl: pointerUrl,
           });
+          const data = pointer.data;
           const result =
             data.authoritative_location === authoritativeUrl
               ? { domain, orphaned: true, pointerUrl: data.authoritative_location }
-              : null;
+              : !data.authoritative_location && pointer.url === authoritativeUrl
+                ? { domain, orphaned: true, pointerUrl: pointer.url }
+                : null;
           return result;
         } catch {
           return null;
@@ -591,6 +602,13 @@ export class NetworkConsistencyChecker {
     url: string,
     redirectPolicy: AdAgentsRedirectPolicy = { mode: 'same-registrable-domain', originUrl: url }
   ): Promise<T> {
+    return (await this.fetchJsonWithUrl<T>(url, redirectPolicy)).data;
+  }
+
+  private async fetchJsonWithUrl<T>(
+    url: string,
+    redirectPolicy: AdAgentsRedirectPolicy = { mode: 'same-registrable-domain', originUrl: url }
+  ): Promise<{ data: T; url: string }> {
     validateAgentUrl(url);
     // Shared AbortController: total wall-clock bounded by `this.timeoutMs`
     // across the initial fetch + any 1-redirect follow. See `probeAgent`
@@ -626,18 +644,15 @@ export class NetworkConsistencyChecker {
         // The callers here (adagents.json) require JSON, so re-attempt parse
         // and surface a clear error if it's not.
         try {
-          return JSON.parse(parsed) as T;
+          return { data: JSON.parse(parsed) as T, url: result.url };
         } catch {
           throw new Error('Response was not valid JSON');
         }
       }
-      return parsed as T;
+      return { data: parsed as T, url: result.url };
     } catch (error) {
       if (error instanceof SsrfRefusedError && error.code === 'body_exceeds_limit') {
         throw new Error('Response too large');
-      }
-      if (error instanceof AdAgentsRedirectRefusedError) {
-        throw new Error(error.message);
       }
       throw error;
     }
@@ -660,6 +675,9 @@ export class NetworkConsistencyChecker {
       }
       // Policy refusal: prefix so the report makes the distinction visible.
       return `[SSRF refused] ${error.message}`;
+    }
+    if (error instanceof AdAgentsRedirectRefusedError) {
+      return error.message;
     }
     if (error instanceof Error) {
       if (error.name === 'AbortError') return 'Request timed out';

--- a/src/lib/discovery/network-consistency-checker.ts
+++ b/src/lib/discovery/network-consistency-checker.ts
@@ -15,6 +15,7 @@ import { validateAgentUrl } from '../validation';
 import { ssrfSafeFetch, SsrfRefusedError, SSRF_TRANSIENT_CODES, decodeBodyAsJsonOrText } from '../net/ssrf-fetch';
 import { isInternalProbesAllowed } from '../utils/probe-policy';
 import type { AdAgentsJson, AuthorizedAgent, Property } from './types';
+import { AdAgentsRedirectRefusedError, ssrfSafeFetchAdAgents, type AdAgentsRedirectPolicy } from './adagents-redirects';
 
 // ====== Configuration ======
 
@@ -238,7 +239,11 @@ export class NetworkConsistencyChecker {
     if (!url) {
       const firstDomain = this.domains[0];
       try {
-        const pointerData = await this.fetchJson<AdAgentsJson>(`https://${firstDomain}/.well-known/adagents.json`);
+        const pointerUrl = `https://${firstDomain}/.well-known/adagents.json`;
+        const pointerData = await this.fetchJson<AdAgentsJson>(pointerUrl, {
+          mode: 'same-registrable-domain',
+          originUrl: pointerUrl,
+        });
         if (pointerData.authoritative_location) {
           url = pointerData.authoritative_location;
         } else {
@@ -254,7 +259,7 @@ export class NetworkConsistencyChecker {
     }
 
     try {
-      const data = await this.fetchJson<AdAgentsJson>(url);
+      const data = await this.fetchJson<AdAgentsJson>(url, { mode: 'none' });
 
       // Follow at most one authoritative_location redirect
       if (data.authoritative_location && !data.authorized_agents) {
@@ -273,7 +278,7 @@ export class NetworkConsistencyChecker {
           });
           return { url, data: null };
         }
-        const redirectData = await this.fetchJson<AdAgentsJson>(redirectUrl);
+        const redirectData = await this.fetchJson<AdAgentsJson>(redirectUrl, { mode: 'none' });
         // Do not follow further redirects from the redirect target
         return { url: redirectUrl, data: redirectData };
       }
@@ -470,7 +475,10 @@ export class NetworkConsistencyChecker {
     const url = `https://${domain}/.well-known/adagents.json`;
 
     try {
-      const data = await this.fetchJson<AdAgentsJson>(url);
+      const data = await this.fetchJson<AdAgentsJson>(url, {
+        mode: 'same-registrable-domain',
+        originUrl: url,
+      });
 
       if (data.authoritative_location) {
         if (data.authoritative_location === authoritativeUrl) {
@@ -544,7 +552,11 @@ export class NetworkConsistencyChecker {
         pointerUrl: string;
       } | null> => {
         try {
-          const data = await this.fetchJson<AdAgentsJson>(`https://${domain}/.well-known/adagents.json`);
+          const pointerUrl = `https://${domain}/.well-known/adagents.json`;
+          const data = await this.fetchJson<AdAgentsJson>(pointerUrl, {
+            mode: 'same-registrable-domain',
+            originUrl: pointerUrl,
+          });
           const result =
             data.authoritative_location === authoritativeUrl
               ? { domain, orphaned: true, pointerUrl: data.authoritative_location }
@@ -575,7 +587,10 @@ export class NetworkConsistencyChecker {
     }
   }
 
-  private async fetchJson<T>(url: string): Promise<T> {
+  private async fetchJson<T>(
+    url: string,
+    redirectPolicy: AdAgentsRedirectPolicy = { mode: 'same-registrable-domain', originUrl: url }
+  ): Promise<T> {
     validateAgentUrl(url);
     // Shared AbortController: total wall-clock bounded by `this.timeoutMs`
     // across the initial fetch + any 1-redirect follow. See `probeAgent`
@@ -586,30 +601,9 @@ export class NetworkConsistencyChecker {
       // / scheme guard / redirect: 'manual' in one wrapper. Each ssrfSafeFetch
       // call DNS-pins independently — the redirect-follow path below
       // re-validates against the address guards via the second invocation.
-      let result = await ssrfSafeFetch(url, {
-        timeoutMs: this.timeoutMs,
-        allowPrivateIp: isInternalProbesAllowed(),
-        signal: sharedSignal,
-        maxBodyBytes: MAX_RESPONSE_BYTES,
-        headers: {
-          ...FETCH_HEADERS,
-          'User-Agent': this.userAgentHeader,
-          From: this.fromHeader,
-        },
-      });
-
-      // Follow one HTTP redirect with SSRF validation.
-      if (result.status >= 300 && result.status < 400) {
-        const location = result.headers['location'];
-        if (!location) {
-          throw new Error(`HTTP ${result.status} redirect with no Location header`);
-        }
-        const redirectUrl = new URL(location, url).toString();
-        if (!redirectUrl.startsWith('https://')) {
-          throw new Error('Redirect to non-HTTPS URL not allowed');
-        }
-        validateAgentUrl(redirectUrl);
-        result = await ssrfSafeFetch(redirectUrl, {
+      const result = await ssrfSafeFetchAdAgents(
+        url,
+        {
           timeoutMs: this.timeoutMs,
           allowPrivateIp: isInternalProbesAllowed(),
           signal: sharedSignal,
@@ -619,8 +613,9 @@ export class NetworkConsistencyChecker {
             'User-Agent': this.userAgentHeader,
             From: this.fromHeader,
           },
-        });
-      }
+        },
+        redirectPolicy
+      );
 
       if (result.status < 200 || result.status >= 300) {
         throw new Error(`HTTP ${result.status}`);
@@ -640,6 +635,9 @@ export class NetworkConsistencyChecker {
     } catch (error) {
       if (error instanceof SsrfRefusedError && error.code === 'body_exceeds_limit') {
         throw new Error('Response too large');
+      }
+      if (error instanceof AdAgentsRedirectRefusedError) {
+        throw new Error(error.message);
       }
       throw error;
     }

--- a/src/lib/discovery/property-crawler.ts
+++ b/src/lib/discovery/property-crawler.ts
@@ -13,10 +13,11 @@ import { getPropertyIndex } from './property-index';
 import { createLogger, type LogLevel } from '../utils/logger';
 import { LIBRARY_VERSION } from '../version';
 import { validateUserAgent } from '../utils/validate-user-agent';
-import { ssrfSafeFetch, SsrfRefusedError, SSRF_TRANSIENT_CODES, decodeBodyAsJsonOrText } from '../net/ssrf-fetch';
+import { SsrfRefusedError, SSRF_TRANSIENT_CODES, decodeBodyAsJsonOrText } from '../net/ssrf-fetch';
 import { isInternalProbesAllowed } from '../utils/probe-policy';
 import type { Property, AdAgentsJson } from './types';
 import { resolveAgentProperties } from './resolve-agent-properties';
+import { AdAgentsRedirectRefusedError, ssrfSafeFetchAdAgents } from './adagents-redirects';
 
 /**
  * Cap on a single adagents.json response body. The published advertising
@@ -314,23 +315,27 @@ export class PropertyCrawler {
       // ssrfSafeFetch's address guards; the recursive `authoritative_location`
       // follow path below re-validates each redirect target by re-entering
       // this same function (so DNS-pin defense applies at each hop).
-      const result = await ssrfSafeFetch(url, {
-        maxBodyBytes: MAX_ADAGENTS_BODY_BYTES,
-        allowPrivateIp: isInternalProbesAllowed(),
-        headers: {
-          // Use standard browser headers to pass CDN bot detection (e.g., Akamai)
-          // Some CDNs reject modified User-Agents, so we use a standard Chrome string
-          // Note: PropertyCrawler identifies itself via From header (RFC 9110)
-          'User-Agent':
-            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
-          Accept: 'application/json, text/plain, */*',
-          'Accept-Language': 'en-US,en;q=0.9',
-          'Accept-Encoding': 'gzip, deflate, br',
-          From: this.userAgent
-            ? `adcp-property-crawler@adcontextprotocol.org (${this.userAgent}; v${LIBRARY_VERSION})`
-            : `adcp-property-crawler@adcontextprotocol.org (v${LIBRARY_VERSION})`,
+      const result = await ssrfSafeFetchAdAgents(
+        url,
+        {
+          maxBodyBytes: MAX_ADAGENTS_BODY_BYTES,
+          allowPrivateIp: isInternalProbesAllowed(),
+          headers: {
+            // Use standard browser headers to pass CDN bot detection (e.g., Akamai)
+            // Some CDNs reject modified User-Agents, so we use a standard Chrome string
+            // Note: PropertyCrawler identifies itself via From header (RFC 9110)
+            'User-Agent':
+              'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+            Accept: 'application/json, text/plain, */*',
+            'Accept-Language': 'en-US,en;q=0.9',
+            'Accept-Encoding': 'gzip, deflate, br',
+            From: this.userAgent
+              ? `adcp-property-crawler@adcontextprotocol.org (${this.userAgent}; v${LIBRARY_VERSION})`
+              : `adcp-property-crawler@adcontextprotocol.org (v${LIBRARY_VERSION})`,
+          },
         },
-      });
+        depth === 0 ? { mode: 'same-registrable-domain', originUrl: url } : { mode: 'none' }
+      );
       if (result.status < 200 || result.status >= 300) {
         throw new Error(`HTTP ${result.status}`);
       }
@@ -431,6 +436,9 @@ export class PropertyCrawler {
       // continues to suppress them at debug level.
       if (error instanceof SsrfRefusedError && !SSRF_TRANSIENT_CODES.has(error.code)) {
         throw new Error(`Failed to fetch adagents.json: [SSRF refused] ${error.message}`);
+      }
+      if (error instanceof AdAgentsRedirectRefusedError) {
+        throw new Error(`Failed to fetch adagents.json: ${error.message}`);
       }
       throw new Error(`Failed to fetch adagents.json: ${error instanceof Error ? error.message : String(error)}`);
     }

--- a/src/lib/discovery/validate-adagents.ts
+++ b/src/lib/discovery/validate-adagents.ts
@@ -33,6 +33,7 @@ import { validateUserAgent } from '../utils/validate-user-agent';
 import { ssrfSafeFetch, SsrfRefusedError, decodeBodyAsJsonOrText } from '../net/ssrf-fetch';
 import { isInternalProbesAllowed } from '../utils/probe-policy';
 import type { AdAgentsJson } from './types';
+import { AdAgentsRedirectRefusedError, ssrfSafeFetchAdAgents, type AdAgentsRedirectPolicy } from './adagents-redirects';
 
 /** How the validator located the authoritative `adagents.json` for a publisher. */
 export type DiscoveryMethod = 'direct' | 'authoritative_location' | 'ads_txt_managerdomain';
@@ -138,6 +139,7 @@ export async function validateAdAgents(
     maxBodyBytes: MAX_ADAGENTS_BYTES,
     userAgentHeader,
     fromHeader,
+    redirectPolicy: { mode: 'same-registrable-domain', originUrl: publisherUrl },
   });
 
   if (direct.kind === 'ok') {
@@ -147,7 +149,7 @@ export async function validateAdAgents(
         valid: false,
         publisher_domain: publisher,
         discovery_method: 'direct',
-        resolved_url: publisherUrl,
+        resolved_url: direct.url,
         errors: ['adagents.json fetch failed: invalid JSON: response is not a JSON object'],
       };
     }
@@ -166,7 +168,7 @@ export async function validateAdAgents(
           valid: false,
           publisher_domain: publisher,
           discovery_method: 'authoritative_location',
-          resolved_url: publisherUrl,
+          resolved_url: direct.url,
           errors: [`authoritative_location must use https://, got: ${target}`],
         };
       }
@@ -176,12 +178,12 @@ export async function validateAdAgents(
       // wasted RTT against the publisher's own server, not SSRF
       // (still routed through `ssrfSafeFetch`), but the right check
       // is on origin+pathname.
-      if (sameOriginAndPath(target, publisherUrl)) {
+      if (sameOriginAndPath(target, direct.url)) {
         return {
           valid: false,
           publisher_domain: publisher,
           discovery_method: 'authoritative_location',
-          resolved_url: publisherUrl,
+          resolved_url: direct.url,
           errors: ['authoritative_location points back to the publisher (cycle)'],
         };
       }
@@ -190,6 +192,7 @@ export async function validateAdAgents(
         maxBodyBytes: MAX_ADAGENTS_BYTES,
         userAgentHeader,
         fromHeader,
+        redirectPolicy: { mode: 'none' },
       });
       if (followed.kind !== 'ok') {
         return {
@@ -214,7 +217,7 @@ export async function validateAdAgents(
         valid: true,
         publisher_domain: publisher,
         discovery_method: 'authoritative_location',
-        resolved_url: target,
+        resolved_url: followed.url,
         adagents: followedAdAgents,
         errors: [],
       };
@@ -224,7 +227,7 @@ export async function validateAdAgents(
       valid: true,
       publisher_domain: publisher,
       discovery_method: 'direct',
-      resolved_url: publisherUrl,
+      resolved_url: direct.url,
       adagents: data,
       errors: [],
     };
@@ -286,6 +289,7 @@ export async function validateAdAgents(
     maxBodyBytes: MAX_ADAGENTS_BYTES,
     userAgentHeader,
     fromHeader,
+    redirectPolicy: { mode: 'same-registrable-domain', originUrl: managerUrl },
   });
   if (manager.kind !== 'ok') {
     logger.debug(`Manager domain ${managerDomain} adagents.json fetch failed: ${describeOutcome(manager)}`);
@@ -314,7 +318,7 @@ export async function validateAdAgents(
     publisher_domain: publisher,
     discovery_method: 'ads_txt_managerdomain',
     manager_domain: managerDomain,
-    resolved_url: managerUrl,
+    resolved_url: manager.url,
     adagents: managerAdAgents,
     errors: [],
   };
@@ -421,26 +425,28 @@ type FetchFailure =
   | { kind: 'http_error'; status: number }
   | { kind: 'transport_error'; message: string }
   | { kind: 'parse_error'; message: string }
-  | { kind: 'ssrf_refused'; message: string };
+  | { kind: 'ssrf_refused'; message: string }
+  | { kind: 'redirect_refused'; message: string };
 
-type RawFetchOutcome = { kind: 'ok-text'; text: string } | FetchFailure;
+type RawFetchOutcome = { kind: 'ok-text'; text: string; url: string } | FetchFailure;
 
-type JsonFetchOutcome = { kind: 'ok'; data: unknown } | FetchFailure;
+type JsonFetchOutcome = { kind: 'ok'; data: unknown; url: string } | FetchFailure;
 
-type TextFetchOutcome = { kind: 'ok'; text: string } | FetchFailure;
+type TextFetchOutcome = { kind: 'ok'; text: string; url: string } | FetchFailure;
 
 interface InternalFetchOptions {
   timeoutMs: number;
   maxBodyBytes: number;
   userAgentHeader: string;
   fromHeader: string;
+  redirectPolicy?: AdAgentsRedirectPolicy;
 }
 
 async function fetchJsonOrStatus(url: string, opts: InternalFetchOptions): Promise<JsonFetchOutcome> {
   const raw = await rawFetch(url, opts);
   if (raw.kind !== 'ok-text') return raw;
   try {
-    return { kind: 'ok', data: JSON.parse(raw.text) };
+    return { kind: 'ok', data: JSON.parse(raw.text), url: raw.url };
   } catch (err) {
     return { kind: 'parse_error', message: err instanceof Error ? err.message : 'invalid JSON' };
   }
@@ -448,22 +454,26 @@ async function fetchJsonOrStatus(url: string, opts: InternalFetchOptions): Promi
 
 async function fetchTextOrStatus(url: string, opts: InternalFetchOptions): Promise<TextFetchOutcome> {
   const raw = await rawFetch(url, opts);
-  if (raw.kind === 'ok-text') return { kind: 'ok', text: raw.text };
+  if (raw.kind === 'ok-text') return { kind: 'ok', text: raw.text, url: raw.url };
   return raw;
 }
 
 async function rawFetch(url: string, opts: InternalFetchOptions): Promise<RawFetchOutcome> {
   try {
-    const result = await ssrfSafeFetch(url, {
-      timeoutMs: opts.timeoutMs,
-      allowPrivateIp: isInternalProbesAllowed(),
-      maxBodyBytes: opts.maxBodyBytes,
-      headers: {
-        ...FETCH_HEADERS,
-        'User-Agent': opts.userAgentHeader,
-        From: opts.fromHeader,
+    const result = await ssrfSafeFetchAdAgents(
+      url,
+      {
+        timeoutMs: opts.timeoutMs,
+        allowPrivateIp: isInternalProbesAllowed(),
+        maxBodyBytes: opts.maxBodyBytes,
+        headers: {
+          ...FETCH_HEADERS,
+          'User-Agent': opts.userAgentHeader,
+          From: opts.fromHeader,
+        },
       },
-    });
+      opts.redirectPolicy ?? { mode: 'none' }
+    );
     if (result.status === 404) return { kind: 'not_found' };
     if (result.status < 200 || result.status >= 300) {
       return { kind: 'http_error', status: result.status };
@@ -472,8 +482,11 @@ async function rawFetch(url: string, opts: InternalFetchOptions): Promise<RawFet
     // lets ads.txt and adagents.json share the same fetch primitive.
     const decoded = decodeBodyAsJsonOrText(result.body, 'text/plain');
     const text = typeof decoded === 'string' ? decoded : JSON.stringify(decoded);
-    return { kind: 'ok-text', text };
+    return { kind: 'ok-text', text, url: result.url };
   } catch (err) {
+    if (err instanceof AdAgentsRedirectRefusedError) {
+      return { kind: 'redirect_refused', message: err.message };
+    }
     if (err instanceof SsrfRefusedError) {
       return { kind: 'ssrf_refused', message: err.message };
     }
@@ -498,5 +511,7 @@ function describeOutcome(outcome: FetchFailure): string {
       return `invalid JSON: ${outcome.message}`;
     case 'ssrf_refused':
       return `[SSRF refused] ${outcome.message}`;
+    case 'redirect_refused':
+      return outcome.message;
   }
 }

--- a/src/lib/discovery/validate-adagents.ts
+++ b/src/lib/discovery/validate-adagents.ts
@@ -460,20 +460,19 @@ async function fetchTextOrStatus(url: string, opts: InternalFetchOptions): Promi
 
 async function rawFetch(url: string, opts: InternalFetchOptions): Promise<RawFetchOutcome> {
   try {
-    const result = await ssrfSafeFetchAdAgents(
-      url,
-      {
-        timeoutMs: opts.timeoutMs,
-        allowPrivateIp: isInternalProbesAllowed(),
-        maxBodyBytes: opts.maxBodyBytes,
-        headers: {
-          ...FETCH_HEADERS,
-          'User-Agent': opts.userAgentHeader,
-          From: opts.fromHeader,
-        },
+    const fetchOptions = {
+      timeoutMs: opts.timeoutMs,
+      allowPrivateIp: isInternalProbesAllowed(),
+      maxBodyBytes: opts.maxBodyBytes,
+      headers: {
+        ...FETCH_HEADERS,
+        'User-Agent': opts.userAgentHeader,
+        From: opts.fromHeader,
       },
-      opts.redirectPolicy ?? { mode: 'none' }
-    );
+    };
+    const result = opts.redirectPolicy
+      ? await ssrfSafeFetchAdAgents(url, fetchOptions, opts.redirectPolicy)
+      : await ssrfSafeFetch(url, fetchOptions);
     if (result.status === 404) return { kind: 'not_found' };
     if (result.status < 200 || result.status >= 300) {
       return { kind: 'http_error', status: result.status };

--- a/test/lib/network-consistency-checker.test.js
+++ b/test/lib/network-consistency-checker.test.js
@@ -385,6 +385,45 @@ describe('NetworkConsistencyChecker', () => {
       }
     });
 
+    test('explicit authoritativeUrl follows same-site redirect and records final URL', async () => {
+      const authFile = makeAuthoritativeFile(
+        [
+          {
+            property_type: 'mobile_app',
+            name: 'redirected-app',
+            identifiers: [{ type: 'bundle_id', value: 'com.redirected.app' }],
+          },
+        ],
+        [{ url: 'https://seller.example.com/mcp', authorized_for: 'Sales' }]
+      );
+      const server = await startServer((req, res) => {
+        if (req.url === '/adagents.json') {
+          res.writeHead(301, { Location: '/canonical/adagents.json' });
+          res.end();
+          return;
+        }
+        if (req.url === '/canonical/adagents.json') {
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify(authFile));
+          return;
+        }
+        res.writeHead(404);
+        res.end();
+      });
+      try {
+        const checker = new NetworkConsistencyChecker({
+          authoritativeUrl: `${server.url}/adagents.json`,
+          logLevel: 'silent',
+          timeoutMs: 1000,
+        });
+        const report = await checker.check();
+        assert.strictEqual(report.authoritativeUrl, `${server.url}/canonical/adagents.json`);
+        assert.strictEqual(report.schemaErrors.length, 0);
+      } finally {
+        await server.close();
+      }
+    });
+
     test('authoritative URL fetch failure returns early with schema error', async () => {
       // ECONNREFUSED on the authoritative URL. Bind + close to free the
       // port, then point `check()` at the dead URL.
@@ -404,6 +443,32 @@ describe('NetworkConsistencyChecker', () => {
       assert.ok(report.schemaErrors.length >= 1);
       assert.ok(report.schemaErrors.some(e => e.field === '$root'));
       assert.strictEqual(report.domains.length, 0);
+    });
+
+    test('redirect policy refusals surface diagnostic messages in reports', async () => {
+      const server = await startServer((req, res) => {
+        if (req.url === '/adagents.json') {
+          res.writeHead(301, { Location: 'http://cross.example.com/adagents.json' });
+          res.end();
+          return;
+        }
+        res.writeHead(404);
+        res.end();
+      });
+      try {
+        const checker = new NetworkConsistencyChecker({
+          authoritativeUrl: `${server.url}/adagents.json`,
+          logLevel: 'silent',
+          timeoutMs: 1000,
+        });
+        const report = await checker.check();
+        assert.ok(
+          report.schemaErrors.some(e => e.message.includes('adagents.json redirect crosses registrable domain')),
+          `expected redirect diagnostic, got: ${JSON.stringify(report.schemaErrors)}`
+        );
+      } finally {
+        await server.close();
+      }
     });
 
     test('self-referential authoritative_location is reported as schema error', async () => {

--- a/test/lib/network-consistency-checker.test.js
+++ b/test/lib/network-consistency-checker.test.js
@@ -557,19 +557,10 @@ describe('NetworkConsistencyChecker', () => {
 
   describe('HTTP redirect following', () => {
     test('follows one redirect on pointer fetch (CDN www redirect)', async () => {
-      // `fetchJson` follows a single 301/302 with a Location header.
+      // `fetchJson` follows same-site 3xx responses with a Location header.
       // Serve a 301 → /v2/adagents.json, then 200 with the pointer body.
       const server = await startServer((req, res) => {
         if (req.url === '/.well-known/adagents.json') {
-          // ssrfSafeFetch sets redirect: 'manual', so fetchJson sees the
-          // 3xx + Location header and re-validates the target URL. The
-          // target must pass `validateAgentUrl` (allows http) and
-          // start with `https://` per the production guard. The
-          // production guard is strict: `redirectUrl.startsWith('https://')`.
-          // A loopback redirect target can't pass that guard, so the
-          // redirect-follow path is exercised but rejects. Use a same-
-          // origin target and assert the redirect is REJECTED with the
-          // non-HTTPS error.
           res.writeHead(301, { Location: '/v2/adagents.json' });
           res.end();
         } else if (req.url === '/v2/adagents.json') {
@@ -585,14 +576,8 @@ describe('NetworkConsistencyChecker', () => {
           authoritativeUrl: 'https://network.example.com/adagents.json',
           logLevel: 'silent',
         });
-        // Production rejects loopback redirect targets because they
-        // resolve to http://. The observable behavior: the redirect
-        // surfaces as a "Redirect to non-HTTPS URL not allowed" error.
-        await assert.rejects(
-          () => checker['fetchJson'](`${server.url}/.well-known/adagents.json`),
-          /not allowed|HTTP 301/,
-          'redirect-follow logic engages and re-validates the target'
-        );
+        const data = await checker['fetchJson'](`${server.url}/.well-known/adagents.json`);
+        assert.strictEqual(data.authoritative_location, 'https://network.example.com/adagents.json');
       } finally {
         await server.close();
       }
@@ -637,7 +622,7 @@ describe('NetworkConsistencyChecker', () => {
     });
 
     test('rejects redirect to non-HTTPS URL on pointer fetch', async () => {
-      // 301 → http://insecure-target/. The production guard rejects.
+      // 301 → a different registrable domain. The same-site policy rejects.
       const server = await startServer((req, res) => {
         if (req.url === '/.well-known/adagents.json') {
           res.writeHead(301, { Location: 'http://insecure.example.com/.well-known/adagents.json' });
@@ -654,8 +639,8 @@ describe('NetworkConsistencyChecker', () => {
         });
         await assert.rejects(
           () => checker['fetchJson'](`${server.url}/.well-known/adagents.json`),
-          /not allowed|HTTP 301/,
-          'non-HTTPS redirect target must be rejected'
+          /crosses registrable domain|HTTP 301/,
+          'cross-domain redirect target must be rejected'
         );
       } finally {
         await server.close();

--- a/test/lib/validate-adagents.test.js
+++ b/test/lib/validate-adagents.test.js
@@ -241,6 +241,36 @@ describe('validateAdAgents — discovery_method', () => {
     }
   });
 
+  test('redirected ads.txt reports an HTTP status, not an adagents redirect refusal', async () => {
+    const publisher = await startRoutedServer({
+      '/ads.txt': {
+        status: 301,
+        headers: { Location: '/ads2.txt' },
+        contentType: 'text/plain',
+      },
+      '/ads2.txt': {
+        body: 'MANAGERDOMAIN=manager.example\n',
+        contentType: 'text/plain',
+      },
+    });
+    try {
+      const result = await validateAdAgents(publisher.host, {
+        urlForDomain: (domain, path) => `http://${domain}${path}`,
+      });
+      assert.strictEqual(result.valid, false);
+      assert.ok(
+        result.errors.some(e => e.includes('ads.txt unavailable: HTTP 301')),
+        `expected ads.txt HTTP 301 error, got: ${JSON.stringify(result.errors)}`
+      );
+      assert.ok(
+        result.errors.every(e => !e.includes('authoritative adagents.json')),
+        `ads.txt error should not use adagents redirect wording: ${JSON.stringify(result.errors)}`
+      );
+    } finally {
+      await publisher.close();
+    }
+  });
+
   test('duplicate MANAGERDOMAIN lines → last entry wins', async () => {
     const skip = await startRoutedServer({});
     const keep = await startRoutedServer({
@@ -559,6 +589,32 @@ describe('validateAdAgents — adagents.json HTTP redirect policy', () => {
       );
     } finally {
       await Promise.all([publisher.close(), authoritative.close()]);
+    }
+  });
+
+  test('redirect errors reject userinfo and do not echo credentials or query strings', async () => {
+    const publisher = await startRoutedServer({
+      '/.well-known/adagents.json': {
+        status: 301,
+        headers: { Location: `http://user:pass@placeholder.invalid/v2/adagents.json?sig=secret123#frag` },
+      },
+    });
+    try {
+      const target = `http://user:pass@${publisher.host}/v2/adagents.json?sig=secret123#frag`;
+      const result = await validateAdAgents(publisher.host, {
+        urlForDomain: (domain, path) => `http://${domain}${path}`,
+      });
+      assert.strictEqual(result.valid, false);
+      assert.ok(
+        result.errors.some(e => e.includes('adagents.json redirect must not include userinfo')),
+        `expected userinfo refusal, got: ${JSON.stringify(result.errors)}`
+      );
+      assert.ok(
+        result.errors.every(e => !e.includes('user:pass') && !e.includes('sig=secret123')),
+        `redirect error leaked sensitive URL parts from ${target}: ${JSON.stringify(result.errors)}`
+      );
+    } finally {
+      await publisher.close();
     }
   });
 });

--- a/test/lib/validate-adagents.test.js
+++ b/test/lib/validate-adagents.test.js
@@ -18,11 +18,15 @@ const assert = require('node:assert');
 const http = require('node:http');
 
 const { validateAdAgents, parseManagerDomain } = require('../../dist/lib/discovery/validate-adagents.js');
+const {
+  validateSameRegistrableDomainRedirect,
+  AdAgentsRedirectRefusedError,
+} = require('../../dist/lib/discovery/adagents-redirects.js');
 
 /**
  * Start a loopback HTTP server with a per-path response map.
  *
- * @param {Record<string, { status?: number, body?: string, contentType?: string }>} routes
+ * @param {Record<string, { status?: number, body?: string, contentType?: string, headers?: Record<string, string> }>} routes
  *   Map from request path to response config. Unmapped paths → 404.
  */
 function startRoutedServer(routes) {
@@ -36,6 +40,7 @@ function startRoutedServer(routes) {
       }
       res.writeHead(route.status ?? 200, {
         'Content-Type': route.contentType ?? 'application/json',
+        ...(route.headers ?? {}),
       });
       res.end(route.body ?? '');
     });
@@ -48,6 +53,17 @@ function startRoutedServer(routes) {
       });
     });
   });
+}
+
+function assertRedirectAllowed(originUrl, currentUrl, nextUrl) {
+  assert.doesNotThrow(() => validateSameRegistrableDomainRedirect(originUrl, currentUrl, nextUrl));
+}
+
+function assertRedirectRefused(originUrl, currentUrl, nextUrl, code) {
+  assert.throws(
+    () => validateSameRegistrableDomainRedirect(originUrl, currentUrl, nextUrl),
+    err => err instanceof AdAgentsRedirectRefusedError && err.code === code
+  );
 }
 
 function adAgentsJson(agentUrl = 'https://agent.example.com/mcp') {
@@ -409,6 +425,140 @@ describe('validateAdAgents — discovery_method', () => {
       assert.strictEqual(result.publisher_domain, publisher.host);
     } finally {
       await publisher.close();
+    }
+  });
+});
+
+describe('validateAdAgents — adagents.json HTTP redirect policy', () => {
+  test('well-known redirect policy matches cross-SDK registrable-domain vectors', () => {
+    assertRedirectAllowed(
+      'https://ladepeche.fr/.well-known/adagents.json',
+      'https://ladepeche.fr/.well-known/adagents.json',
+      'https://www.ladepeche.fr/.well-known/adagents.json'
+    );
+    assertRedirectAllowed(
+      'https://www.example.com/.well-known/adagents.json',
+      'https://www.example.com/.well-known/adagents.json',
+      'https://example.com/.well-known/adagents.json'
+    );
+    assertRedirectAllowed(
+      'https://pub.example/.well-known/adagents.json',
+      'https://pub.example/.well-known/adagents.json',
+      'https://cdn.pub.example/.well-known/adagents.json'
+    );
+    assertRedirectAllowed(
+      'https://example.co.uk/.well-known/adagents.json',
+      'https://example.co.uk/.well-known/adagents.json',
+      'https://www.example.co.uk/.well-known/adagents.json'
+    );
+    assertRedirectAllowed(
+      'https://victim.github.io/.well-known/adagents.json',
+      'https://victim.github.io/.well-known/adagents.json',
+      'https://www.victim.github.io/.well-known/adagents.json'
+    );
+
+    assertRedirectRefused(
+      'https://ladepeche.fr/.well-known/adagents.json',
+      'https://ladepeche.fr/.well-known/adagents.json',
+      'https://claire.pub/.well-known/adagents.json',
+      'redirect_cross_registrable_domain'
+    );
+    assertRedirectRefused(
+      'https://example.co.uk/.well-known/adagents.json',
+      'https://example.co.uk/.well-known/adagents.json',
+      'https://example.com/.well-known/adagents.json',
+      'redirect_cross_registrable_domain'
+    );
+    assertRedirectRefused(
+      'https://victim.github.io/.well-known/adagents.json',
+      'https://victim.github.io/.well-known/adagents.json',
+      'https://attacker.github.io/.well-known/adagents.json',
+      'redirect_cross_registrable_domain'
+    );
+    assertRedirectRefused(
+      'https://pub.example/.well-known/adagents.json',
+      'https://www.pub.example/.well-known/adagents.json',
+      'https://attacker.example/.well-known/adagents.json',
+      'redirect_cross_registrable_domain'
+    );
+    assertRedirectRefused(
+      'https://pub.example/.well-known/adagents.json',
+      'https://pub.example/.well-known/adagents.json',
+      'http://pub.example/.well-known/adagents.json',
+      'redirect_scheme_changed'
+    );
+  });
+
+  test('initial .well-known fetch follows same-site HTTP redirects', async () => {
+    const publisher = await startRoutedServer({
+      '/.well-known/adagents.json': {
+        status: 301,
+        headers: { Location: '/v2/adagents.json' },
+      },
+      '/v2/adagents.json': { body: adAgentsJson('https://redirected.example/mcp') },
+    });
+    try {
+      const result = await validateAdAgents(publisher.host, {
+        urlForDomain: (domain, path) => `http://${domain}${path}`,
+      });
+      assert.strictEqual(result.valid, true, `expected valid, got errors=${JSON.stringify(result.errors)}`);
+      assert.strictEqual(result.discovery_method, 'direct');
+      assert.ok(result.resolved_url.endsWith('/v2/adagents.json'), `unexpected resolved_url=${result.resolved_url}`);
+      assert.strictEqual(result.adagents?.authorized_agents?.[0]?.url, 'https://redirected.example/mcp');
+    } finally {
+      await publisher.close();
+    }
+  });
+
+  test('initial .well-known fetch enforces three redirect hop cap', async () => {
+    const publisher = await startRoutedServer({
+      '/.well-known/adagents.json': { status: 301, headers: { Location: '/r1' } },
+      '/r1': { status: 301, headers: { Location: '/r2' } },
+      '/r2': { status: 301, headers: { Location: '/r3' } },
+      '/r3': { status: 301, headers: { Location: '/r4' } },
+      '/r4': { body: adAgentsJson('https://too-late.example/mcp') },
+    });
+    try {
+      const result = await validateAdAgents(publisher.host, {
+        urlForDomain: (domain, path) => `http://${domain}${path}`,
+      });
+      assert.strictEqual(result.valid, false);
+      assert.ok(
+        result.errors.some(e => e.includes('Too many adagents.json redirects')),
+        `expected hop-cap error, got: ${JSON.stringify(result.errors)}`
+      );
+    } finally {
+      await publisher.close();
+    }
+  });
+
+  test('authoritative_location dereference refuses any HTTP redirect', async () => {
+    const authoritative = await startRoutedServer({
+      '/authoritative/adagents.json': {
+        status: 301,
+        headers: { Location: '/canonical/adagents.json' },
+      },
+      '/canonical/adagents.json': { body: adAgentsJson('https://must-not-fetch.example/mcp') },
+    });
+    const publisher = await startRoutedServer({
+      '/.well-known/adagents.json': {
+        body: JSON.stringify({
+          authoritative_location: `${authoritative.url}/authoritative/adagents.json`,
+        }),
+      },
+    });
+    try {
+      const result = await validateAdAgents(publisher.host, {
+        urlForDomain: (domain, path) => `http://${domain}${path}`,
+      });
+      assert.strictEqual(result.valid, false);
+      assert.strictEqual(result.discovery_method, 'authoritative_location');
+      assert.ok(
+        result.errors.some(e => e.includes('Redirect refused while fetching authoritative adagents.json')),
+        `expected authoritative redirect refusal, got: ${JSON.stringify(result.errors)}`
+      );
+    } finally {
+      await Promise.all([publisher.close(), authoritative.close()]);
     }
   });
 });


### PR DESCRIPTION
## Summary
- Follow same-registrable-domain HTTP redirects on the initial `.well-known/adagents.json` discovery fetch, including PSL private-domain handling and a 3-hop cap.
- Refuse HTTP redirects from `authoritative_location` dereferences across the validator, property crawler, and network checker.
- Add redirect-policy tests, a patch changeset, and keep the lockfile version aligned at `9.0.0-beta.28`.

## Validation
- `npm run build:lib`
- `npx tsc --project tsconfig.lib.json --noEmit`
- `NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/lib/validate-adagents.test.js test/lib/property-crawler.test.js test/lib/network-consistency-checker.test.js`
- pre-push validation passed during `git push`