### PR TITLE
fix: preserve comply timeout budget semantics

### DIFF
--- a/.changeset/fix-comply-timeout-budget.md
+++ b/.changeset/fix-comply-timeout-budget.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Restore `comply()` `timeout_ms` semantics so the budget stops new storyboards from starting instead of aborting the active assessment and reporting reachable agents as unreachable.

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -1751,7 +1751,9 @@ RUN OPTIONS (full assessment):
                       Hosted badge mode: allow a stable line (e.g. 3.1)
                       to resolve against a prerelease compliance cache.
   --file PATH         Run an ad-hoc storyboard YAML (spec evolution)
-  --timeout SECONDS   Timeout in seconds (default: 120)
+  --timeout SECONDS   Soft budget in seconds: stop starting new storyboards
+                      after this budget, without aborting an active storyboard
+                      (default: 120)
   --brief TEXT        Custom brief for product discovery
   --no-sandbox        Force production-path responses (#841). Sets
                       account.sandbox=false on every request AND stamps

--- a/src/lib/testing/client.ts
+++ b/src/lib/testing/client.ts
@@ -369,11 +369,9 @@ export async function runStep<T>(
  * `supported_protocols` + `specialisms` on the profile so the compliance
  * runner can select domain and specialism bundles.
  *
- * Pass `signal` (typically comply()'s combined timeout/external signal) to
- * bound discovery latency. Without it, an unhealthy agent whose well-known
- * card path returns 503-with-30s-tail or whose MCP transport silently
- * retries against a non-MCP root can stretch a single `getAgentInfo` call
- * past comply()'s timeout — the wall-clock symptom in adcp-client#1612.
+ * Pass `signal` for hard external cancellation. `comply()` deliberately does
+ * not pass its soft `timeout_ms` storyboard-start budget here; that budget
+ * stops new storyboards after discovery instead of aborting an active run.
  */
 export async function discoverAgentProfile(
   client: TestClient,

--- a/src/lib/testing/compliance/comply.ts
+++ b/src/lib/testing/compliance/comply.ts
@@ -1096,377 +1096,386 @@ async function complyImpl(agentUrl: string, options: ComplyOptions): Promise<Com
   // Fail fast on malformed test kits before we spin up any agent connection.
   validateTestKit(testOptions.test_kit);
 
-  // Build a combined AbortSignal from timeout_ms and/or external signal
-  const needsAbort = timeout_ms !== undefined || externalSignal !== undefined;
-  const abortController = needsAbort ? new AbortController() : undefined;
-  let timeoutId: ReturnType<typeof setTimeout> | undefined;
-  const onExternalAbort = externalSignal ? () => abortController!.abort(externalSignal.reason) : undefined;
+  // `signal` is hard external cancellation. `timeout_ms` is a soft comply()
+  // scheduling budget: once exceeded, stop starting new storyboards, but do
+  // not abort discovery or the storyboard currently in flight.
+  const signal = externalSignal;
 
-  if (timeout_ms !== undefined && abortController) {
-    timeoutId = setTimeout(
-      () => abortController.abort(new Error(`comply() timed out after ${timeout_ms}ms`)),
-      timeout_ms
-    );
-  }
+  return await withExternalSchemaRoot(complianceIndex.adcp_version, scopedSchemaRoot, async () => {
+    let effectiveOptions: TestOptions = applyAdcpVersionRunOptions(complianceIndex.adcp_version, {
+      ...testOptions,
+      sandbox: testOptions.sandbox !== false,
+      test_session_id: testOptions.test_session_id || `comply-${Date.now()}`,
+    });
 
-  if (externalSignal && abortController) {
-    if (externalSignal.aborted) {
-      abortController.abort(externalSignal.reason);
-    } else {
-      externalSignal.addEventListener('abort', onExternalAbort!, { once: true });
+    // Check for abort before starting
+    signal?.throwIfAborted();
+
+    // Collect observations across all tracks
+    const allObservations: AdvisoryObservation[] = [];
+
+    // Discover agent capabilities once and share across all storyboards.
+    // External cancellation still aborts discovery; timeout_ms is enforced
+    // later as a soft storyboard-start budget.
+    const discoveryOptions =
+      testOptions.versionEnvelope === undefined
+        ? { ...effectiveOptions, versionEnvelope: 'major-only' as const }
+        : effectiveOptions;
+    const discoveryClient = createTestClient(agentUrl, effectiveOptions.protocol ?? 'mcp', discoveryOptions);
+    const { profile, step: profileStep } = await discoverAgentProfile(discoveryClient, signal);
+    effectiveOptions = applyNegotiatedComplianceVersionOptions(profile, effectiveOptions, {
+      complianceVersion: complianceIndex.adcp_version,
+      ...(hostedStableLineAlias !== undefined && { hostedStableLineAlias }),
+      ...(testOptions.adcpVersion !== undefined && { callerAdcpVersion: testOptions.adcpVersion }),
+      ...(testOptions.versionEnvelope !== undefined && { callerVersionEnvelope: testOptions.versionEnvelope }),
+    });
+    const client =
+      discoveryOptions === effectiveOptions
+        ? discoveryClient
+        : createTestClient(agentUrl, effectiveOptions.protocol ?? 'mcp', effectiveOptions);
+    effectiveOptions._client = client;
+    effectiveOptions._profile = profile;
+
+    // Log discovered tools
+    if (profileStep.passed) {
+      allObservations.push({
+        category: 'tool_discovery',
+        severity: 'info',
+        message: `Discovered ${profile.tools.length} tools: [${profile.tools.join(', ')}]`,
+        evidence: { tools: profile.tools },
+        source: { kind: 'profile', code: 'tools-discovered' },
+      });
     }
-  }
 
-  const signal = abortController?.signal;
-
-  try {
-    return await withExternalSchemaRoot(complianceIndex.adcp_version, scopedSchemaRoot, async () => {
-      let effectiveOptions: TestOptions = applyAdcpVersionRunOptions(complianceIndex.adcp_version, {
-        ...testOptions,
-        sandbox: testOptions.sandbox !== false,
-        test_session_id: testOptions.test_session_id || `comply-${Date.now()}`,
-      });
-
-      // Check for abort before starting
-      signal?.throwIfAborted();
-
-      // Collect observations across all tracks
-      const allObservations: AdvisoryObservation[] = [];
-
-      // Discover agent capabilities once and share across all storyboards.
-      // Pass the combined signal so a slow/unresponsive agent can't hold the
-      // comply pipeline past its own timeout (adcp-client#1612).
-      const discoveryOptions =
-        testOptions.versionEnvelope === undefined
-          ? { ...effectiveOptions, versionEnvelope: 'major-only' as const }
-          : effectiveOptions;
-      const discoveryClient = createTestClient(agentUrl, effectiveOptions.protocol ?? 'mcp', discoveryOptions);
-      const { profile, step: profileStep } = await discoverAgentProfile(discoveryClient, signal);
-      effectiveOptions = applyNegotiatedComplianceVersionOptions(profile, effectiveOptions, {
-        complianceVersion: complianceIndex.adcp_version,
-        ...(hostedStableLineAlias !== undefined && { hostedStableLineAlias }),
-        ...(testOptions.adcpVersion !== undefined && { callerAdcpVersion: testOptions.adcpVersion }),
-        ...(testOptions.versionEnvelope !== undefined && { callerVersionEnvelope: testOptions.versionEnvelope }),
-      });
-      const client =
-        discoveryOptions === effectiveOptions
-          ? discoveryClient
-          : createTestClient(agentUrl, effectiveOptions.protocol ?? 'mcp', effectiveOptions);
-      effectiveOptions._client = client;
-      effectiveOptions._profile = profile;
-
-      // Log discovered tools
-      if (profileStep.passed) {
+    // Warn loudly when the runner can't make a capability-driven decision — either
+    // the agent doesn't advertise get_adcp_capabilities at all, or the call failed.
+    // Without this, an agent that just passes universal storyboards looks "compliant"
+    // when in fact none of its declared domains or specialisms were tested.
+    if (profileStep.passed && !explicitStoryboards?.length) {
+      if (profile.capabilities_probe_error) {
+        // The probe error text is agent-controlled. Fence it so downstream
+        // LLM summarizers of a shared ComplianceResult don't follow any
+        // instructions a hostile agent may have embedded. Raw text is kept
+        // in `evidence` for operator diagnosis — `evidence` is operator-only
+        // and MUST NOT be fed into an LLM summarizer.
         allObservations.push({
           category: 'tool_discovery',
-          severity: 'info',
-          message: `Discovered ${profile.tools.length} tools: [${profile.tools.join(', ')}]`,
-          evidence: { tools: profile.tools },
-          source: { kind: 'profile', code: 'tools-discovered' },
+          severity: 'error',
+          message:
+            `get_adcp_capabilities is advertised but the call failed. ` +
+            `Only universal storyboards ran — domain and specialism bundles were skipped. ` +
+            `Agent-reported error: ${fenceAgentText(profile.capabilities_probe_error)}`,
+          evidence: { agent_reported_error: profile.capabilities_probe_error },
+          source: { kind: 'profile', code: 'capabilities-probe-failed' },
+        });
+      } else if (!profile.tools.includes('get_adcp_capabilities')) {
+        allObservations.push({
+          category: 'tool_discovery',
+          severity: 'warning',
+          message:
+            'Agent does not implement get_adcp_capabilities — ran universal storyboards only. ' +
+            'Domain baselines and specialisms cannot be tested without a capabilities response.',
+          source: { kind: 'profile', code: 'capabilities-missing' },
+        });
+      } else if (!profile.supported_protocols?.length) {
+        allObservations.push({
+          category: 'tool_discovery',
+          severity: 'warning',
+          message:
+            'get_adcp_capabilities returned no supported_protocols — ran universal storyboards only. ' +
+            'Agent must declare at least one domain protocol to be fully tested.',
+          source: { kind: 'profile', code: 'no-supported-protocols' },
         });
       }
-
-      // Warn loudly when the runner can't make a capability-driven decision — either
-      // the agent doesn't advertise get_adcp_capabilities at all, or the call failed.
-      // Without this, an agent that just passes universal storyboards looks "compliant"
-      // when in fact none of its declared domains or specialisms were tested.
-      if (profileStep.passed && !explicitStoryboards?.length) {
-        if (profile.capabilities_probe_error) {
-          // The probe error text is agent-controlled. Fence it so downstream
-          // LLM summarizers of a shared ComplianceResult don't follow any
-          // instructions a hostile agent may have embedded. Raw text is kept
-          // in `evidence` for operator diagnosis — `evidence` is operator-only
-          // and MUST NOT be fed into an LLM summarizer.
-          allObservations.push({
-            category: 'tool_discovery',
-            severity: 'error',
-            message:
-              `get_adcp_capabilities is advertised but the call failed. ` +
-              `Only universal storyboards ran — domain and specialism bundles were skipped. ` +
-              `Agent-reported error: ${fenceAgentText(profile.capabilities_probe_error)}`,
-            evidence: { agent_reported_error: profile.capabilities_probe_error },
-            source: { kind: 'profile', code: 'capabilities-probe-failed' },
-          });
-        } else if (!profile.tools.includes('get_adcp_capabilities')) {
-          allObservations.push({
-            category: 'tool_discovery',
-            severity: 'warning',
-            message:
-              'Agent does not implement get_adcp_capabilities — ran universal storyboards only. ' +
-              'Domain baselines and specialisms cannot be tested without a capabilities response.',
-            source: { kind: 'profile', code: 'capabilities-missing' },
-          });
-        } else if (!profile.supported_protocols?.length) {
-          allObservations.push({
-            category: 'tool_discovery',
-            severity: 'warning',
-            message:
-              'get_adcp_capabilities returned no supported_protocols — ran universal storyboards only. ' +
-              'Agent must declare at least one domain protocol to be fully tested.',
-            source: { kind: 'profile', code: 'no-supported-protocols' },
-          });
-        }
-      }
-
-      // Detect test controller for deterministic mode
-      let controllerDetection: ControllerDetection = { detected: false };
-      if (profileStep.passed && hasTestController(profile)) {
-        controllerDetection = await detectController(client as any, profile, effectiveOptions);
-        if (controllerDetection.detected) {
-          effectiveOptions._controllerCapabilities = controllerDetection;
-        }
-      }
-
-      if (!profileStep.passed) {
-        // Capability discovery failed. If it's an auth rejection, we can still
-        // run storyboards that don't need tool discovery — crucially
-        // universal/security_baseline, which is designed precisely to diagnose
-        // agents that mishandle auth. Fall back to the unreachable result only
-        // when no such storyboards are available.
-        const authCheck = await detectAuthRejection(agentUrl, profileStep.error, signal);
-        if (authCheck.isAuth) {
-          const degraded: AgentProfile = { name: profile.name || 'Unknown (auth required)', tools: [] };
-          const candidate = explicitStoryboards?.length
-            ? resolveExplicitStoryboards(explicitStoryboards, resolveOptions)
-            : resolveFromCapabilities(degraded, resolveOptions).storyboards;
-          const runnable = candidate.filter(sb => (sb.required_tools?.length ?? 0) === 0 || sb.track === 'security');
-          if (runnable.length > 0) {
-            allObservations.push(...authCheck.observations);
-            effectiveOptions._profile = degraded;
-            // Skip the rest of the "reachable" setup — no test controller, no
-            // capability-warning observations — and jump straight to storyboard
-            // execution below with the filtered, runnable subset.
-            return await runWithDegradedProfile(
-              agentUrl,
-              degraded,
-              runnable,
-              options,
-              effectiveOptions,
-              allObservations,
-              start,
-              complianceIndex.adcp_version,
-              signal
-            );
-          }
-        }
-        return buildUnreachableResult(
-          agentUrl,
-          profile,
-          profileStep.error,
-          start,
-          effectiveOptions,
-          complianceIndex.adcp_version,
-          signal
-        );
-      }
-
-      // Resolve storyboards: explicit IDs override capability-driven selection.
-      let initialStoryboards: Storyboard[];
-      let notApplicable: NotApplicableStoryboard[] = [];
-      const missingToolStoryboards: NotApplicableStoryboard[] = [];
-      if (explicitStoryboards?.length) {
-        initialStoryboards = resolveExplicitStoryboards(explicitStoryboards, resolveOptions);
-      } else {
-        const resolved = resolveFromCapabilities(profile, resolveOptions);
-        initialStoryboards = resolved.storyboards;
-        notApplicable = resolved.not_applicable;
-      }
-      const applicableStoryboards = expandScenarios(initialStoryboards, resolveOptions);
-
-      // For capability-resolved runs, exclude storyboards and injected scenarios whose
-      // required_tools are absent from the agent's discovered toolset. These are
-      // not-applicable — the agent doesn't claim the specialism being tested. Running
-      // them produces cascading skips that pull the track to `partial`, which is a false
-      // signal for AAO badge grading (adcp-client#1680).
-      // Explicit storyboard IDs (options.storyboards) bypass this filter — they are an
-      // operator override and should run regardless of required_tools.
-      let runnableStoryboards: Storyboard[];
-      if (explicitStoryboards?.length) {
-        runnableStoryboards = applicableStoryboards;
-      } else {
-        const discoveredToolNames = new Set(profile.tools);
-        const filtered: Storyboard[] = [];
-        for (const sb of applicableStoryboards) {
-          const missing = (sb.required_tools ?? []).filter(t => !discoveredToolNames.has(t));
-          if (missing.length > 0) {
-            missingToolStoryboards.push({
-              storyboard_id: sb.id,
-              storyboard_title: sb.title,
-              track: sb.track,
-              reason: `missing required_tools: ${missing.join(', ')}`,
-            });
-          } else {
-            filtered.push(sb);
-          }
-        }
-        runnableStoryboards = filtered;
-      }
-
-      // Run storyboards
-      const storyboardResults: StoryboardResult[] = [];
-      const runOptions: StoryboardRunOptions = {
-        ...effectiveOptions,
-        agentTools: profile.tools,
-        ...(webhook_receiver !== undefined && { webhook_receiver }),
-        ...(webhook_replay_receiver !== undefined && { webhook_replay_receiver }),
-        ...(contracts !== undefined && { contracts }),
-        ...(signal !== undefined && { signal }),
-      };
-
-      for (const sb of runnableStoryboards) {
-        signal?.throwIfAborted();
-        const result = await runStoryboard(agentUrl, sb, runOptions);
-        storyboardResults.push(result);
-      }
-
-      // Surface storyboards the agent's declared major version predates as a
-      // distinct skip row. Not running them is correct (they didn't exist at
-      // the spec the agent certified against), but hiding them risks silent
-      // green builds against agents that haven't bumped their declared
-      // major_versions.
-      for (const na of [...notApplicable, ...missingToolStoryboards]) {
-        storyboardResults.push(buildNotApplicableStoryboardResult(agentUrl, na));
-      }
-
-      // Cross-storyboard spec-conformance gates. Push synthetic StoryboardResults
-      // for protocol-level invariants the AdCP spec mandates regardless of which
-      // specialism they're testing. The storyboard runner now honors 3.1
-      // `required_any_of_tools` tags when present; keep this universal
-      // account-discovery fallback until the upstream cache tags all relevant
-      // account-bearing storyboards.
-      const accountDiscoveryFailure = checkAccountDiscoveryGate(profile, agentUrl);
-      if (accountDiscoveryFailure) {
-        storyboardResults.push(accountDiscoveryFailure);
-      }
-
-      // Group results by track and build TrackResults
-      const grouped = groupByTrack(storyboardResults, runnableStoryboards, [
-        ...notApplicable,
-        ...missingToolStoryboards,
-      ]);
-      const trackResults: TrackResult[] = [];
-
-      // Tracks represented by the selected storyboards (used for deciding which rows to emit).
-      // Includes not-applicable entries so a version-gated track still gets a row.
-      const poolTrackSet = new Set<ComplianceTrack>();
-      for (const sb of runnableStoryboards) {
-        if (sb.track) poolTrackSet.add(sb.track as ComplianceTrack);
-      }
-      // Synthetic spec-conformance gates always land in `core`; ensure `core`
-      // is in the pool so its track row renders even when the run targeted a
-      // non-core specialism bundle that excluded universal storyboards.
-      if (accountDiscoveryFailure) poolTrackSet.add('core');
-      for (const na of [...notApplicable, ...missingToolStoryboards]) {
-        if (na.track) poolTrackSet.add(na.track as ComplianceTrack);
-      }
-
-      const trackFilterSet = trackFilter?.length ? new Set(trackFilter) : null;
-
-      for (const track of TRACK_ORDER) {
-        if (!poolTrackSet.has(track)) continue;
-        if (trackFilterSet && !trackFilterSet.has(track)) continue;
-
-        const results = grouped.get(track) ?? [];
-
-        if (results.length > 0) {
-          const trackResult = mapStoryboardResultsToTrackResult(track, results, profile);
-          const observations = collectObservations(track, trackResult.scenarios, profile);
-          trackResult.observations = observations;
-          allObservations.push(...observations);
-          trackResults.push(trackResult);
-        } else {
-          trackResults.push({
-            track,
-            status: 'skip',
-            label: TRACK_LABELS[track] || track,
-            scenarios: [],
-            skipped_scenarios: [],
-            observations: [],
-            duration_ms: 0,
-          });
-        }
-      }
-
-      const summary = buildSummary(trackResults, storyboardResults);
-      // Tag `_view` so grep-style triage can distinguish the canonical
-      // `tracks` entry from its appearance under the `tested_tracks` filter
-      // (adcp-client#1674). Shallow-copy on the `tested_tracks` side keeps
-      // the shared nested `scenarios` references intact while preventing
-      // the marker from colliding on the same object.
-      for (const t of trackResults) t._view = 'canonical';
-      const testedTracks: TrackResult[] = trackResults
-        .filter(t => t.status === 'pass' || t.status === 'fail' || t.status === 'partial' || t.status === 'silent')
-        .map(t => ({ ...t, _view: 'reference' as const }));
-      const skippedTracks = trackResults
-        .filter(t => t.status === 'skip')
-        .map(t => ({
-          track: t.track,
-          label: t.label,
-          reason: 'No storyboards produced results for this track',
-        }));
-
-      const overallStatus = computeOverallStatus(summary);
-
-      const agentRef = options.agent_alias || agentUrl;
-      const failures = extractFailures(storyboardResults, runnableStoryboards, agentRef, {
-        complianceVersion: complianceIndex.adcp_version,
-        ...(complianceDir !== undefined && { complianceDir }),
-        ...(schemaRoot !== undefined && { schemaRoot }),
-        ...(hostedStableLineAlias !== undefined && { hostedStableLineAlias }),
-      });
-
-      // Aggregate notices from all storyboard runs. Dedup is by `code` (each
-      // notice type appears once in the rollup), but the per-occurrence
-      // `storyboard_ids` arrays are merged so auditors can see how widespread
-      // a deprecation or future-required signal is without re-walking the
-      // per-storyboard arrays. Order is stable: first occurrence wins for
-      // the notice body; storyboard_ids preserves insertion order across the
-      // run's storyboard execution order.
-      const aggregatedNotices = new Map<string, RunnerNotice>();
-      for (const sbResult of storyboardResults) {
-        for (const notice of sbResult.notices) {
-          const existing = aggregatedNotices.get(notice.code);
-          if (existing) {
-            for (const sid of notice.storyboard_ids) {
-              if (!existing.storyboard_ids.includes(sid)) existing.storyboard_ids.push(sid);
-            }
-          } else {
-            // Clone so subsequent merges don't mutate the per-storyboard array.
-            aggregatedNotices.set(notice.code, { ...notice, storyboard_ids: [...notice.storyboard_ids] });
-          }
-        }
-      }
-      const noticesDedup = [...aggregatedNotices.values()];
-
-      return {
-        agent_url: agentUrl,
-        adcp_version: complianceIndex.adcp_version,
-        agent_profile: profile,
-        overall_status: overallStatus,
-        tracks: trackResults,
-        tested_tracks: testedTracks,
-        skipped_tracks: skippedTracks,
-        summary,
-        observations: allObservations,
-        failures: failures.length > 0 ? failures : undefined,
-        storyboards_executed: runnableStoryboards.map(sb => sb.id),
-        ...(notApplicable.length > 0 && { storyboards_not_applicable: notApplicable.map(na => na.storyboard_id) }),
-        ...(missingToolStoryboards.length > 0 && {
-          storyboards_missing_tools: missingToolStoryboards.map(na => na.storyboard_id),
-        }),
-        controller_detected: controllerDetection.detected,
-        controller_scenarios: controllerDetection.detected ? controllerDetection.scenarios : undefined,
-        tested_at: new Date().toISOString(),
-        total_duration_ms: Date.now() - start,
-        notices: noticesDedup,
-      };
-    });
-  } finally {
-    if (timeoutId !== undefined) clearTimeout(timeoutId);
-    if (onExternalAbort && externalSignal) {
-      externalSignal.removeEventListener('abort', onExternalAbort);
     }
-  }
+
+    // Detect test controller for deterministic mode
+    let controllerDetection: ControllerDetection = { detected: false };
+    if (profileStep.passed && hasTestController(profile)) {
+      controllerDetection = await detectController(client as any, profile, effectiveOptions);
+      if (controllerDetection.detected) {
+        effectiveOptions._controllerCapabilities = controllerDetection;
+      }
+    }
+
+    if (!profileStep.passed) {
+      // Capability discovery failed. If it's an auth rejection, we can still
+      // run storyboards that don't need tool discovery — crucially
+      // universal/security_baseline, which is designed precisely to diagnose
+      // agents that mishandle auth. Fall back to the unreachable result only
+      // when no such storyboards are available.
+      const authCheck = await detectAuthRejection(agentUrl, profileStep.error, signal);
+      if (authCheck.isAuth) {
+        const degraded: AgentProfile = { name: profile.name || 'Unknown (auth required)', tools: [] };
+        const candidate = explicitStoryboards?.length
+          ? resolveExplicitStoryboards(explicitStoryboards, resolveOptions)
+          : resolveFromCapabilities(degraded, resolveOptions).storyboards;
+        const runnable = candidate.filter(sb => (sb.required_tools?.length ?? 0) === 0 || sb.track === 'security');
+        if (runnable.length > 0) {
+          allObservations.push(...authCheck.observations);
+          effectiveOptions._profile = degraded;
+          // Skip the rest of the "reachable" setup — no test controller, no
+          // capability-warning observations — and jump straight to storyboard
+          // execution below with the filtered, runnable subset.
+          return await runWithDegradedProfile(
+            agentUrl,
+            degraded,
+            runnable,
+            options,
+            effectiveOptions,
+            allObservations,
+            start,
+            complianceIndex.adcp_version,
+            signal
+          );
+        }
+      }
+      return buildUnreachableResult(
+        agentUrl,
+        profile,
+        profileStep.error,
+        start,
+        effectiveOptions,
+        complianceIndex.adcp_version,
+        signal
+      );
+    }
+
+    // Resolve storyboards: explicit IDs override capability-driven selection.
+    let initialStoryboards: Storyboard[];
+    let notApplicable: NotApplicableStoryboard[] = [];
+    const missingToolStoryboards: NotApplicableStoryboard[] = [];
+    if (explicitStoryboards?.length) {
+      initialStoryboards = resolveExplicitStoryboards(explicitStoryboards, resolveOptions);
+    } else {
+      const resolved = resolveFromCapabilities(profile, resolveOptions);
+      initialStoryboards = resolved.storyboards;
+      notApplicable = resolved.not_applicable;
+    }
+    const applicableStoryboards = expandScenarios(initialStoryboards, resolveOptions);
+
+    // For capability-resolved runs, exclude storyboards and injected scenarios whose
+    // required_tools are absent from the agent's discovered toolset. These are
+    // not-applicable — the agent doesn't claim the specialism being tested. Running
+    // them produces cascading skips that pull the track to `partial`, which is a false
+    // signal for AAO badge grading (adcp-client#1680).
+    // Explicit storyboard IDs (options.storyboards) bypass this filter — they are an
+    // operator override and should run regardless of required_tools.
+    let runnableStoryboards: Storyboard[];
+    if (explicitStoryboards?.length) {
+      runnableStoryboards = applicableStoryboards;
+    } else {
+      const discoveredToolNames = new Set(profile.tools);
+      const filtered: Storyboard[] = [];
+      for (const sb of applicableStoryboards) {
+        const missing = (sb.required_tools ?? []).filter(t => !discoveredToolNames.has(t));
+        if (missing.length > 0) {
+          missingToolStoryboards.push({
+            storyboard_id: sb.id,
+            storyboard_title: sb.title,
+            track: sb.track,
+            reason: `missing required_tools: ${missing.join(', ')}`,
+          });
+        } else {
+          filtered.push(sb);
+        }
+      }
+      runnableStoryboards = filtered;
+    }
+
+    // Run storyboards
+    const storyboardResults: StoryboardResult[] = [];
+    const executedStoryboards: Storyboard[] = [];
+    const runOptions: StoryboardRunOptions = {
+      ...effectiveOptions,
+      agentTools: profile.tools,
+      ...(webhook_receiver !== undefined && { webhook_receiver }),
+      ...(webhook_replay_receiver !== undefined && { webhook_replay_receiver }),
+      ...(contracts !== undefined && { contracts }),
+      ...(signal !== undefined && { signal }),
+    };
+
+    let stoppedForTimeoutBudget = false;
+    for (const sb of runnableStoryboards) {
+      signal?.throwIfAborted();
+      if (hasComplyTimeoutBudgetExpired(start, timeout_ms)) {
+        stoppedForTimeoutBudget = true;
+        break;
+      }
+      const result = await runStoryboard(agentUrl, sb, runOptions);
+      storyboardResults.push(result);
+      executedStoryboards.push(sb);
+    }
+    if (stoppedForTimeoutBudget) {
+      allObservations.push(
+        buildComplyTimeoutBudgetObservation(timeout_ms!, storyboardResults.length, runnableStoryboards.length)
+      );
+    }
+
+    // Surface storyboards the agent's declared major version predates as a
+    // distinct skip row. Not running them is correct (they didn't exist at
+    // the spec the agent certified against), but hiding them risks silent
+    // green builds against agents that haven't bumped their declared
+    // major_versions.
+    for (const na of [...notApplicable, ...missingToolStoryboards]) {
+      storyboardResults.push(buildNotApplicableStoryboardResult(agentUrl, na));
+    }
+
+    // Cross-storyboard spec-conformance gates. Push synthetic StoryboardResults
+    // for protocol-level invariants the AdCP spec mandates regardless of which
+    // specialism they're testing. The storyboard runner now honors 3.1
+    // `required_any_of_tools` tags when present; keep this universal
+    // account-discovery fallback until the upstream cache tags all relevant
+    // account-bearing storyboards.
+    const accountDiscoveryFailure = checkAccountDiscoveryGate(profile, agentUrl);
+    if (accountDiscoveryFailure) {
+      storyboardResults.push(accountDiscoveryFailure);
+    }
+
+    // Group results by track and build TrackResults
+    const grouped = groupByTrack(storyboardResults, runnableStoryboards, [...notApplicable, ...missingToolStoryboards]);
+    const trackResults: TrackResult[] = [];
+
+    // Tracks represented by the selected storyboards (used for deciding which rows to emit).
+    // Includes not-applicable entries so a version-gated track still gets a row.
+    const poolTrackSet = new Set<ComplianceTrack>();
+    for (const sb of runnableStoryboards) {
+      if (sb.track) poolTrackSet.add(sb.track as ComplianceTrack);
+    }
+    // Synthetic spec-conformance gates always land in `core`; ensure `core`
+    // is in the pool so its track row renders even when the run targeted a
+    // non-core specialism bundle that excluded universal storyboards.
+    if (accountDiscoveryFailure) poolTrackSet.add('core');
+    for (const na of [...notApplicable, ...missingToolStoryboards]) {
+      if (na.track) poolTrackSet.add(na.track as ComplianceTrack);
+    }
+
+    const trackFilterSet = trackFilter?.length ? new Set(trackFilter) : null;
+
+    for (const track of TRACK_ORDER) {
+      if (!poolTrackSet.has(track)) continue;
+      if (trackFilterSet && !trackFilterSet.has(track)) continue;
+
+      const results = grouped.get(track) ?? [];
+
+      if (results.length > 0) {
+        const trackResult = mapStoryboardResultsToTrackResult(track, results, profile);
+        const observations = collectObservations(track, trackResult.scenarios, profile);
+        trackResult.observations = observations;
+        allObservations.push(...observations);
+        trackResults.push(trackResult);
+      } else {
+        trackResults.push({
+          track,
+          status: 'skip',
+          label: TRACK_LABELS[track] || track,
+          scenarios: [],
+          skipped_scenarios: [],
+          observations: [],
+          duration_ms: 0,
+        });
+      }
+    }
+
+    const summary = buildSummary(trackResults, storyboardResults);
+    // Tag `_view` so grep-style triage can distinguish the canonical
+    // `tracks` entry from its appearance under the `tested_tracks` filter
+    // (adcp-client#1674). Shallow-copy on the `tested_tracks` side keeps
+    // the shared nested `scenarios` references intact while preventing
+    // the marker from colliding on the same object.
+    for (const t of trackResults) t._view = 'canonical';
+    const testedTracks: TrackResult[] = trackResults
+      .filter(t => t.status === 'pass' || t.status === 'fail' || t.status === 'partial' || t.status === 'silent')
+      .map(t => ({ ...t, _view: 'reference' as const }));
+    const skippedTracks = trackResults
+      .filter(t => t.status === 'skip')
+      .map(t => ({
+        track: t.track,
+        label: t.label,
+        reason: 'No storyboards produced results for this track',
+      }));
+
+    const overallStatus: OverallStatus = stoppedForTimeoutBudget ? 'partial' : computeOverallStatus(summary);
+
+    const agentRef = options.agent_alias || agentUrl;
+    const failures = extractFailures(storyboardResults, runnableStoryboards, agentRef, {
+      complianceVersion: complianceIndex.adcp_version,
+      ...(complianceDir !== undefined && { complianceDir }),
+      ...(schemaRoot !== undefined && { schemaRoot }),
+      ...(hostedStableLineAlias !== undefined && { hostedStableLineAlias }),
+    });
+
+    // Aggregate notices from all storyboard runs. Dedup is by `code` (each
+    // notice type appears once in the rollup), but the per-occurrence
+    // `storyboard_ids` arrays are merged so auditors can see how widespread
+    // a deprecation or future-required signal is without re-walking the
+    // per-storyboard arrays. Order is stable: first occurrence wins for
+    // the notice body; storyboard_ids preserves insertion order across the
+    // run's storyboard execution order.
+    const aggregatedNotices = new Map<string, RunnerNotice>();
+    for (const sbResult of storyboardResults) {
+      for (const notice of sbResult.notices) {
+        const existing = aggregatedNotices.get(notice.code);
+        if (existing) {
+          for (const sid of notice.storyboard_ids) {
+            if (!existing.storyboard_ids.includes(sid)) existing.storyboard_ids.push(sid);
+          }
+        } else {
+          // Clone so subsequent merges don't mutate the per-storyboard array.
+          aggregatedNotices.set(notice.code, { ...notice, storyboard_ids: [...notice.storyboard_ids] });
+        }
+      }
+    }
+    const noticesDedup = [...aggregatedNotices.values()];
+
+    return {
+      agent_url: agentUrl,
+      adcp_version: complianceIndex.adcp_version,
+      agent_profile: profile,
+      overall_status: overallStatus,
+      tracks: trackResults,
+      tested_tracks: testedTracks,
+      skipped_tracks: skippedTracks,
+      summary,
+      observations: allObservations,
+      failures: failures.length > 0 ? failures : undefined,
+      storyboards_executed: executedStoryboards.map(sb => sb.id),
+      ...(notApplicable.length > 0 && { storyboards_not_applicable: notApplicable.map(na => na.storyboard_id) }),
+      ...(missingToolStoryboards.length > 0 && {
+        storyboards_missing_tools: missingToolStoryboards.map(na => na.storyboard_id),
+      }),
+      controller_detected: controllerDetection.detected,
+      controller_scenarios: controllerDetection.detected ? controllerDetection.scenarios : undefined,
+      tested_at: new Date().toISOString(),
+      total_duration_ms: Date.now() - start,
+      notices: noticesDedup,
+    };
+  });
+}
+
+function hasComplyTimeoutBudgetExpired(start: number, timeout_ms: number | undefined, now = Date.now()): boolean {
+  return timeout_ms !== undefined && now - start >= timeout_ms;
+}
+
+function buildComplyTimeoutBudgetObservation(
+  timeout_ms: number,
+  storyboardsExecuted: number,
+  storyboardsSelected: number
+): AdvisoryObservation {
+  return {
+    category: 'performance',
+    severity: 'warning',
+    message:
+      `Compliance timeout budget of ${timeout_ms}ms was reached. ` +
+      `Stopped starting new storyboards after ${storyboardsExecuted}/${storyboardsSelected} selected storyboard(s).`,
+    evidence: {
+      timeout_ms,
+      storyboards_executed: storyboardsExecuted,
+      storyboards_selected: storyboardsSelected,
+      storyboards_remaining: Math.max(0, storyboardsSelected - storyboardsExecuted),
+    },
+    source: { kind: 'profile', code: 'timeout-budget-exceeded' },
+  };
 }
 
 /**
@@ -1605,10 +1614,22 @@ async function runWithDegradedProfile(
     ...(signal !== undefined && { signal }),
   };
 
+  let stoppedForTimeoutBudget = false;
+  const executedStoryboards: Storyboard[] = [];
   for (const sb of storyboards) {
     signal?.throwIfAborted();
+    if (hasComplyTimeoutBudgetExpired(start, options.timeout_ms)) {
+      stoppedForTimeoutBudget = true;
+      break;
+    }
     const result = await runStoryboard(agentUrl, sb, runOptions);
     storyboardResults.push(result);
+    executedStoryboards.push(sb);
+  }
+  if (stoppedForTimeoutBudget && options.timeout_ms !== undefined) {
+    allObservations.push(
+      buildComplyTimeoutBudgetObservation(options.timeout_ms, storyboardResults.length, storyboards.length)
+    );
   }
 
   const grouped = groupByTrack(storyboardResults, storyboards);
@@ -1624,11 +1645,21 @@ async function runWithDegradedProfile(
       trackResult.observations = obs;
       allObservations.push(...obs);
       trackResults.push(trackResult);
+    } else {
+      trackResults.push({
+        track,
+        status: 'skip',
+        label: TRACK_LABELS[track] || track,
+        scenarios: [],
+        skipped_scenarios: [],
+        observations: [],
+        duration_ms: 0,
+      });
     }
   }
 
   const summary = buildSummary(trackResults, storyboardResults);
-  const overallStatus = computeOverallStatus(summary);
+  const overallStatus: OverallStatus = stoppedForTimeoutBudget ? 'partial' : computeOverallStatus(summary);
   const agentRef = options.agent_alias || agentUrl;
   const failures = extractFailures(storyboardResults, storyboards, agentRef, {
     complianceVersion: adcpVersion,
@@ -1641,6 +1672,14 @@ async function runWithDegradedProfile(
   // TrackResult appearing in both `tracks` and `tested_tracks`
   // (adcp-client#1674).
   for (const t of trackResults) t._view = 'canonical';
+  const skippedTracks = trackResults
+    .filter(t => t.status === 'skip')
+    .map(t => ({
+      track: t.track,
+      label: t.label,
+      reason: 'No storyboards produced results for this track',
+    }));
+
   return {
     agent_url: agentUrl,
     adcp_version: adcpVersion,
@@ -1650,11 +1689,11 @@ async function runWithDegradedProfile(
     tested_tracks: trackResults
       .filter(t => t.status === 'pass' || t.status === 'fail' || t.status === 'partial' || t.status === 'silent')
       .map(t => ({ ...t, _view: 'reference' as const })),
-    skipped_tracks: [],
+    skipped_tracks: skippedTracks,
     summary,
     observations: allObservations,
     failures: failures.length > 0 ? failures : undefined,
-    storyboards_executed: storyboards.map(sb => sb.id),
+    storyboards_executed: executedStoryboards.map(sb => sb.id),
     controller_detected: false,
     tested_at: new Date().toISOString(),
     total_duration_ms: Date.now() - start,

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -3975,6 +3975,7 @@ async function executeStep(
         executeStoryboardTask(client, effectiveStep.task, request, {
           skipIdempotencyAutoInject: testsMissingIdempotencyKey,
           skipAccountValidation: testsMissingAccount,
+          signal: options.signal,
         });
       const run = await runStep(step.title, effectiveStep.task, async () => {
         if (!captureA2a) return dispatch();
@@ -3996,6 +3997,9 @@ async function executeStep(
       taskResult = run.result;
       stepResult = run.step;
       caughtError = run.caughtError;
+      if (caughtError !== undefined && options.signal?.aborted) {
+        throw caughtError;
+      }
       if (captureA2a && a2aCaptures) {
         a2aEnvelope = parseLastA2aMessageSendCapture(a2aCaptures);
       }

--- a/src/lib/testing/storyboard/task-map.ts
+++ b/src/lib/testing/storyboard/task-map.ts
@@ -129,7 +129,7 @@ export async function executeStoryboardTask(
   client: any,
   taskName: string,
   params: Record<string, unknown>,
-  opts: { skipIdempotencyAutoInject?: boolean; skipAccountValidation?: boolean } = {}
+  opts: { skipIdempotencyAutoInject?: boolean; skipAccountValidation?: boolean; signal?: AbortSignal } = {}
 ): Promise<TaskResult> {
   const methodName = Object.hasOwn(TASK_TO_METHOD, taskName) ? TASK_TO_METHOD[taskName] : undefined;
 
@@ -158,7 +158,7 @@ export async function executeStoryboardTask(
   const BASE_DELAY_MS = 2000;
   for (let attempt = 0; ; attempt++) {
     try {
-      result = await invoke();
+      result = await raceWithSignal(invoke(), opts.signal);
       break;
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
@@ -167,7 +167,7 @@ export async function executeStoryboardTask(
       if (isRateLimit && attempt < MAX_RETRIES) {
         const jitter = Math.random() * 1000;
         const delay = BASE_DELAY_MS * 2 ** attempt + jitter;
-        await new Promise(resolve => setTimeout(resolve, delay));
+        await raceWithSignal(new Promise(resolve => setTimeout(resolve, delay)), opts.signal);
         continue;
       }
       throw err;
@@ -184,8 +184,12 @@ export async function executeStoryboardTask(
       const timeout = new Promise<never>((_, reject) =>
         setTimeout(() => reject(new Error('Task polling timeout')), 30_000)
       );
-      result = await Promise.race([result.submitted.waitForCompletion(2000), timeout]);
-    } catch {
+      result = await raceWithSignal(
+        Promise.race([result.submitted.waitForCompletion(2000, opts.signal), timeout]),
+        opts.signal
+      );
+    } catch (err) {
+      if (opts.signal?.aborted) throw err;
       // Polling failed or timed out — return the intermediate result as-is
     }
   }
@@ -207,4 +211,24 @@ export async function executeStoryboardTask(
     ...(adcpError && { adcp_error: adcpError }),
     ...(extractionPath !== undefined && { _extraction_path: extractionPath }),
   };
+}
+
+function raceWithSignal<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) return promise;
+  if (signal.aborted) return Promise.reject(signal.reason ?? new Error('aborted'));
+
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(signal.reason ?? new Error('aborted'));
+    signal.addEventListener('abort', onAbort, { once: true });
+    promise.then(
+      value => {
+        signal.removeEventListener('abort', onAbort);
+        resolve(value);
+      },
+      err => {
+        signal.removeEventListener('abort', onAbort);
+        reject(err);
+      }
+    );
+  });
 }

--- a/test/lib/comply-abort.test.js
+++ b/test/lib/comply-abort.test.js
@@ -1,15 +1,171 @@
 /**
  * Tests for comply() timeout_ms and signal options.
- *
- * These test the abort/timeout plumbing without hitting real agents —
- * we verify that comply() respects AbortSignal and timeout_ms by
- * passing pre-aborted signals and short timeouts.
  */
 
 const { describe, test } = require('node:test');
 const assert = require('node:assert');
+const fs = require('fs');
+const http = require('http');
+const os = require('os');
+const path = require('path');
 
 const { comply } = require('../../dist/lib/testing/compliance/index.js');
+const { ADCP_VERSION } = require('../../dist/lib/version.js');
+
+function writeTimeoutComplianceCache() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'adcp-comply-timeout-'));
+  fs.mkdirSync(path.join(dir, 'universal'), { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'index.json'),
+    JSON.stringify(
+      {
+        adcp_version: ADCP_VERSION,
+        generated_at: new Date().toISOString(),
+        universal: ['slow-timeout-one', 'slow-timeout-two'],
+        protocols: [],
+        specialisms: [],
+      },
+      null,
+      2
+    )
+  );
+  fs.writeFileSync(path.join(dir, 'universal', 'slow-timeout-one.yaml'), timeoutStoryboardYaml('slow_timeout_one', 50));
+  fs.writeFileSync(path.join(dir, 'universal', 'slow-timeout-two.yaml'), timeoutStoryboardYaml('slow_timeout_two', 0));
+  return dir;
+}
+
+function timeoutStoryboardYaml(id, delayMs) {
+  return `id: ${id}
+version: 1.0.0
+title: ${id}
+category: testing
+track: core
+summary: ''
+narrative: ''
+agent:
+  interaction_model: '*'
+  capabilities: []
+caller:
+  role: buyer_agent
+phases:
+  - id: probe
+    title: Probe
+    steps:
+      - id: probe
+        title: Probe
+        task: __test_probe
+        sample_request:
+          delay_ms: ${delayMs}
+`;
+}
+
+async function startTimeoutAgent(options = {}) {
+  const requests = [];
+  const tools = ['__test_probe', 'get_adcp_capabilities'];
+  const server = http.createServer(async (req, res) => {
+    const chunks = [];
+    for await (const chunk of req) chunks.push(chunk);
+    const raw = Buffer.concat(chunks).toString('utf8');
+    const rpc = raw ? JSON.parse(raw) : {};
+
+    if (rpc.method === 'initialize') {
+      res.writeHead(200, { 'content-type': 'application/json', 'mcp-session-id': 'test-session' });
+      res.end(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: rpc.id,
+          result: {
+            protocolVersion: '2025-11-25',
+            capabilities: {},
+            serverInfo: { name: 'timeout-test', version: '1.0.0' },
+          },
+        })
+      );
+      return;
+    }
+    if (rpc.method === 'notifications/initialized') {
+      res.writeHead(202);
+      res.end();
+      return;
+    }
+    if (rpc.method === 'tools/list') {
+      if (options.toolsListDelayMs) await new Promise(resolve => setTimeout(resolve, options.toolsListDelayMs));
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: rpc.id,
+          result: { tools: tools.map(name => ({ name, inputSchema: { type: 'object' } })) },
+        })
+      );
+      return;
+    }
+
+    const toolName = rpc.params?.name;
+    const args = rpc.params?.arguments ?? {};
+    requests.push({ tool: toolName, args });
+
+    if (toolName === '__test_probe') {
+      options.onProbeStart?.(args);
+      if (args.delay_ms) await new Promise(resolve => setTimeout(resolve, args.delay_ms));
+      options.onProbeFinish?.(args);
+      return okTool(res, rpc.id, { probed: true });
+    }
+    if (toolName === 'get_adcp_capabilities') {
+      return okTool(res, rpc.id, {
+        adcp: {
+          major_versions: [3],
+          supported_versions: ['3.1-rc.10'],
+          build_version: ADCP_VERSION,
+          idempotency: { supported: false },
+        },
+        supported_protocols: ['brand'],
+        specialisms: [],
+      });
+    }
+
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: rpc.id,
+        result: { isError: true, structuredContent: { error: `unknown tool ${toolName}` } },
+      })
+    );
+  });
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  return { server, requests, url: `http://127.0.0.1:${server.address().port}/mcp` };
+}
+
+async function startUnauthorizedAgent() {
+  const server = http.createServer((_req, res) => {
+    res.writeHead(401, {
+      'content-type': 'application/json',
+      'www-authenticate': 'Bearer realm="test"',
+    });
+    res.end(JSON.stringify({ error: 'unauthorized' }));
+  });
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  return { server, url: `http://127.0.0.1:${server.address().port}/mcp` };
+}
+
+function okTool(res, id, structuredContent) {
+  res.writeHead(200, { 'content-type': 'application/json' });
+  res.end(
+    JSON.stringify({
+      jsonrpc: '2.0',
+      id,
+      result: {
+        structuredContent,
+        content: [{ type: 'text', text: JSON.stringify(structuredContent) }],
+      },
+    })
+  );
+}
+
+function closeServer(server) {
+  return new Promise(resolve => server.close(resolve));
+}
 
 describe('comply() signal option', () => {
   test('rejects with AbortError when signal is already aborted', async () => {
@@ -43,20 +199,81 @@ describe('comply() signal option', () => {
 });
 
 describe('comply() timeout_ms option', () => {
-  test('timeout_ms creates an abort signal that fires', async () => {
-    // With an unreachable host and short timeout, the function will either:
-    // - abort due to timeout (throws)
-    // - return a discovery failure result (if discovery fails faster than timeout)
-    // Both outcomes are valid — the key property is that it doesn't hang.
-    const start = Date.now();
+  test('timeout_ms stops new storyboards without aborting the active storyboard', async () => {
+    const complianceDir = writeTimeoutComplianceCache();
+    const realDateNow = Date.now;
+    const fixedStart = realDateNow();
+    let budgetExpired = false;
+    Date.now = () => (budgetExpired ? fixedStart + 1000 : fixedStart);
+    const agent = await startTimeoutAgent({
+      onProbeStart: () => {
+        budgetExpired = true;
+      },
+    });
     try {
-      const result = await comply('https://unreachable.test/mcp', { timeout_ms: 100 });
-      assert.ok(result.summary, 'Should return a valid result');
-    } catch (err) {
-      assert.ok(err, 'Should have an error');
+      const result = await comply(agent.url, {
+        allow_http: true,
+        complianceDir,
+        storyboards: ['slow_timeout_one', 'slow_timeout_two'],
+        timeout_ms: 500,
+      });
+
+      assert.notStrictEqual(result.overall_status, 'unreachable');
+      assert.strictEqual(result.overall_status, 'partial');
+      assert.deepStrictEqual(result.storyboards_executed, ['slow_timeout_one']);
+      assert.strictEqual(agent.requests.filter(r => r.tool === '__test_probe').length, 1);
+      assert.ok(
+        result.observations.some(o => o.source?.code === 'timeout-budget-exceeded'),
+        `expected timeout-budget-exceeded observation, got ${JSON.stringify(result.observations)}`
+      );
+    } finally {
+      Date.now = realDateNow;
+      await closeServer(agent.server);
+      fs.rmSync(complianceDir, { recursive: true, force: true });
     }
-    const elapsed = Date.now() - start;
-    assert.ok(elapsed < 30000, `Should complete promptly, took ${elapsed}ms`);
+  });
+
+  test('timeout_ms waits for discovery, then stops before starting storyboards', async () => {
+    const complianceDir = writeTimeoutComplianceCache();
+    const agent = await startTimeoutAgent({ toolsListDelayMs: 50 });
+    try {
+      const result = await comply(agent.url, {
+        allow_http: true,
+        complianceDir,
+        storyboards: ['slow_timeout_one'],
+        timeout_ms: 1,
+      });
+
+      assert.strictEqual(result.overall_status, 'partial');
+      assert.deepStrictEqual(result.storyboards_executed, []);
+      assert.strictEqual(agent.requests.filter(r => r.tool === '__test_probe').length, 0);
+      assert.ok(result.observations.some(o => o.source?.code === 'timeout-budget-exceeded'));
+    } finally {
+      await closeServer(agent.server);
+      fs.rmSync(complianceDir, { recursive: true, force: true });
+    }
+  });
+
+  test('timeout_ms reports skipped tracks in degraded auth fallback before starting storyboards', async () => {
+    const complianceDir = writeTimeoutComplianceCache();
+    const agent = await startUnauthorizedAgent();
+    try {
+      const result = await comply(agent.url, {
+        allow_http: true,
+        complianceDir,
+        storyboards: ['slow_timeout_one'],
+        timeout_ms: 1,
+      });
+
+      assert.strictEqual(result.overall_status, 'partial');
+      assert.deepStrictEqual(result.storyboards_executed, []);
+      assert.ok(result.tracks.some(t => t.track === 'core' && t.status === 'skip'));
+      assert.ok(result.skipped_tracks.some(t => t.track === 'core'));
+      assert.ok(result.observations.some(o => o.source?.code === 'timeout-budget-exceeded'));
+    } finally {
+      await closeServer(agent.server);
+      fs.rmSync(complianceDir, { recursive: true, force: true });
+    }
   });
 
   test('rejects with TypeError for timeout_ms: 0', async () => {
@@ -117,5 +334,32 @@ describe('comply() combined timeout_ms + signal', () => {
         return true;
       }
     );
+  });
+
+  test('signal aborts an active storyboard step', async () => {
+    const complianceDir = writeTimeoutComplianceCache();
+    const controller = new AbortController();
+    const agent = await startTimeoutAgent({
+      onProbeStart: () => controller.abort(new Error('caller canceled mid-step')),
+    });
+
+    try {
+      await assert.rejects(
+        () =>
+          comply(agent.url, {
+            allow_http: true,
+            complianceDir,
+            storyboards: ['slow_timeout_one'],
+            signal: controller.signal,
+          }),
+        err => {
+          assert.ok(err.message?.includes('caller canceled mid-step'), `Expected caller reason, got: ${err.message}`);
+          return true;
+        }
+      );
+    } finally {
+      await closeServer(agent.server);
+      fs.rmSync(complianceDir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
This fixes comply() so timeout_ms is treated as a soft storyboard-start budget instead of an abort signal, keeping reachable agents from being reported as unreachable when a budget expires.

It preserves external AbortSignal as hard cancellation during active storyboard dispatch and async polling, and reports timeout-truncated runs as partial with executed storyboard and skipped-track visibility.

It updates CLI help, adds a patch changeset, and expands the comply abort tests with deterministic local MCP regressions.

Validation: npm run build:lib; NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/lib/comply-abort.test.js; NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/lib/storyboard-runner-signal-abort.test.js; NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/lib/storyboard-security.test.js; git diff --check.