### PR TITLE
fix(storyboard): enforce phase capability gates

### DIFF
--- a/.changeset/phase-capability-gates.md
+++ b/.changeset/phase-capability-gates.md
@@ -1,0 +1,5 @@
+---
+"@adcp/sdk": patch
+---
+
+Enforce phase-level `requires_capability` gates in the storyboard runner so protocol-specific phases skip as `not_applicable` before dispatch when seller capabilities do not match.

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -97,6 +97,7 @@ import type {
   RequirementName,
   RunnerSkipReason,
   RunnerNotice,
+  RequiresCapabilityPredicate,
   ResponseNotApplicableGate,
   StepAuthDirective,
   Storyboard,
@@ -302,10 +303,7 @@ export function resolveCapabilityPath(raw: unknown, dottedPath: string): unknown
  * needing a full runStoryboard() roundtrip.
  */
 export function evaluateCapabilityPredicate(
-  predicate:
-    | { path: string; equals: boolean | string | number | null }
-    | { path: string; present: boolean }
-    | { path: string; contains: boolean | string | number },
+  predicate: RequiresCapabilityPredicate,
   actual: unknown
 ): string | null {
   if ('present' in predicate) {
@@ -360,16 +358,55 @@ export function evaluateCapabilityPredicate(
 }
 
 function isInlineCreativeManagementGate(
-  predicate:
-    | { path: string; equals: boolean | string | number | null }
-    | { path: string; present: boolean }
-    | { path: string; contains: boolean | string | number }
+  predicate: RequiresCapabilityPredicate
 ): predicate is { path: 'media_buy.features.inline_creative_management'; equals: true } {
   return (
     'equals' in predicate &&
     predicate.path === 'media_buy.features.inline_creative_management' &&
     predicate.equals === true
   );
+}
+
+function evaluateRequiresCapabilityGate(
+  predicate: RequiresCapabilityPredicate,
+  profile: AgentProfile | undefined
+): string | null {
+  const rawCaps = profile?.raw_capabilities;
+  if (rawCaps !== undefined) {
+    const actual = resolveCapabilityPath(rawCaps, predicate.path);
+    return evaluateCapabilityPredicate(predicate, actual);
+  }
+  if (
+    isInlineCreativeManagementGate(predicate) &&
+    profile !== undefined &&
+    !profile.tools.includes('get_adcp_capabilities')
+  ) {
+    return evaluateCapabilityPredicate(predicate, undefined);
+  }
+  return null;
+}
+
+function collectPhaseCapabilitySkipDetails(
+  storyboard: Storyboard,
+  profile: AgentProfile | undefined
+): Map<string, string> {
+  const skipDetails = new Map<string, string>();
+  for (const phase of storyboard.phases) {
+    if (!phase.requires_capability) continue;
+    const unmetDetail = evaluateRequiresCapabilityGate(phase.requires_capability, profile);
+    if (unmetDetail !== null) {
+      skipDetails.set(phase.id, unmetDetail);
+    }
+  }
+  return skipDetails;
+}
+
+function allExecutablePhasesCapabilitySkipped(
+  storyboard: Storyboard,
+  phaseCapabilitySkipDetails: ReadonlyMap<string, string>
+): boolean {
+  const executablePhases = storyboard.phases.filter(phase => phase.steps.length > 0);
+  return executablePhases.length > 0 && executablePhases.every(phase => phaseCapabilitySkipDetails.has(phase.id));
 }
 
 function buildSkip(reason: RunnerSkipReason, detail?: string): { reason: RunnerSkipReason; detail: string } {
@@ -1220,6 +1257,30 @@ function buildCapabilityUnsupportedResult(
   };
 }
 
+function buildPhaseCapabilitySkippedSteps(
+  storyboard: Storyboard,
+  phase: StoryboardPhase,
+  detail: string,
+  context: StoryboardContext
+): StoryboardStepResult[] {
+  return phase.steps.map(step => ({
+    storyboard_id: storyboard.id,
+    step_id: step.id,
+    phase_id: phase.id,
+    title: step.title,
+    task: step.task,
+    passed: true,
+    skipped: true,
+    skip_reason: 'not_applicable',
+    skip: { reason: 'not_applicable', detail },
+    duration_ms: 0,
+    validations: [],
+    context,
+    error: detail,
+    extraction: { path: 'none' },
+  }));
+}
+
 /**
  * Map a `requires:` requirement onto the canonical `RunnerSkipReason` to
  * emit when that requirement is unmet. `controller` reuses the existing
@@ -1973,31 +2034,13 @@ async function executeStoryboardPass(
   // tests (e.g. `adcp.idempotency.supported: false`), skip the whole storyboard
   // rather than producing a cascade of misleading per-phase failures.
   if (storyboard.requires_capability) {
-    const rawCaps = profile?.raw_capabilities;
-    if (rawCaps !== undefined) {
-      const cap = storyboard.requires_capability;
-      const actual = resolveCapabilityPath(rawCaps, cap.path);
-      const unmetDetail = evaluateCapabilityPredicate(cap, actual);
-      if (unmetDetail !== null) {
-        if (!callerOwnsClients) await closeConnections(options.protocol);
-        return {
-          ...buildCapabilityUnsupportedResult(agentUrls, storyboard, unmetDetail),
-          notices: preflightNotices,
-        };
-      }
-    } else if (
-      isInlineCreativeManagementGate(storyboard.requires_capability) &&
-      profile !== undefined &&
-      !profile.tools.includes('get_adcp_capabilities')
-    ) {
-      const unmetDetail = evaluateCapabilityPredicate(storyboard.requires_capability, undefined);
-      if (unmetDetail !== null) {
-        if (!callerOwnsClients) await closeConnections(options.protocol);
-        return {
-          ...buildCapabilityUnsupportedResult(agentUrls, storyboard, unmetDetail),
-          notices: preflightNotices,
-        };
-      }
+    const unmetDetail = evaluateRequiresCapabilityGate(storyboard.requires_capability, profile);
+    if (unmetDetail !== null) {
+      if (!callerOwnsClients) await closeConnections(options.protocol);
+      return {
+        ...buildCapabilityUnsupportedResult(agentUrls, storyboard, unmetDetail),
+        notices: preflightNotices,
+      };
     }
   }
 
@@ -2046,6 +2089,7 @@ async function executeStoryboardPass(
   let passedCount = 0;
   let failedCount = 0;
   let skippedCount = 0;
+  const phaseCapabilitySkippedIds = new Set<string>();
   // Per-phase stateful-cascade tracking (#1161).
   //
   // Map entry exists iff the phase tripped its stateful cascade — i.e.,
@@ -2170,6 +2214,11 @@ async function executeStoryboardPass(
   // an implementor reading the report can't tell "nothing tested" from
   // "everything passed".
   const hasExecutableSteps = storyboard.phases.some(p => p.steps.length > 0);
+  const phaseCapabilitySkipDetails = collectPhaseCapabilitySkipDetails(storyboard, profile);
+  const skipControllerSeedingForPhaseGates = allExecutablePhasesCapabilitySkipped(
+    storyboard,
+    phaseCapabilitySkipDetails
+  );
   if (!hasExecutableSteps) {
     const isScenarioComposed = (storyboard.requires_scenarios?.length ?? 0) > 0;
     const detail = isScenarioComposed
@@ -2235,7 +2284,9 @@ async function executeStoryboardPass(
   let seedingUnsupported = false;
   {
     const seeding =
-      preSeeded !== undefined
+      skipControllerSeedingForPhaseGates
+        ? null
+        : preSeeded !== undefined
         ? preSeeded.result
         : await runControllerSeeding(clients[0]!, storyboard, options, context);
     if (seeding) {
@@ -2262,6 +2313,21 @@ async function executeStoryboardPass(
     // to completion regardless of the outer budget.
     options.signal?.throwIfAborted();
     const phaseStart = Date.now();
+    const phaseCapabilitySkipDetail = phaseCapabilitySkipDetails.get(phase.id);
+    if (phaseCapabilitySkipDetail !== undefined) {
+      const skippedSteps = buildPhaseCapabilitySkippedSteps(storyboard, phase, phaseCapabilitySkipDetail, context);
+      phaseResults.push({
+        phase_id: phase.id,
+        phase_title: phase.title,
+        passed: true,
+        steps: skippedSteps,
+        duration_ms: Date.now() - phaseStart,
+      });
+      skippedCount += skippedSteps.length;
+      phaseCapabilitySkippedIds.add(phase.id);
+      priorPhaseIds.push(phase.id);
+      continue;
+    }
     const stepResults: StoryboardStepResult[] = [];
     let phasePassed = true;
     // `statefulFailed` and `statefulSkipTrigger` live at storyboard
@@ -2972,13 +3038,24 @@ async function executeStoryboardPass(
   // false, flipping overall_passed to false. Short-circuit to true so the
   // no-phases sentinel produces overall_passed: true (consistent with how
   // buildNotApplicableStoryboardResult shapes its result in comply.ts).
+  const requiredPhaseHasExecutedPass = phaseResults.some((p, idx) => {
+    const phaseDef = storyboard.phases[idx];
+    if (!phaseDef || phaseDef.optional || !p.passed) return false;
+    return p.steps.some(s => !s.skipped && s.passed);
+  });
+  const requiredPhaseDefs = storyboard.phases.filter(phaseDef => !phaseDef.optional);
+  const requiredPhasesCoveredByCapabilityGates =
+    phaseCapabilitySkippedIds.size > 0 &&
+    requiredPhaseDefs.length > 0 &&
+    requiredPhaseDefs.every(phaseDef => {
+      if (phaseCapabilitySkippedIds.has(phaseDef.id)) return true;
+      const phaseResult = phaseResults.find(p => p.phase_id === phaseDef.id);
+      return !!phaseResult && phaseResult.passed && phaseResult.steps.some(s => !s.skipped && s.passed);
+    });
   const requiredPhasesPassed =
     !hasExecutableSteps ||
-    phaseResults.some((p, idx) => {
-      const phaseDef = storyboard.phases[idx];
-      if (!phaseDef || phaseDef.optional || !p.passed) return false;
-      return p.steps.some(s => !s.skipped && s.passed);
-    });
+    requiredPhaseHasExecutedPass ||
+    (failedCount === 0 && requiredPhasesCoveredByCapabilityGates);
   const storyboardWideFixtureSeedUnsupported =
     seedingUnsupported &&
     failedCount === 0 &&
@@ -3086,7 +3163,26 @@ async function runMultiPass(
   const preSeedContext: StoryboardContext = { ...storyboard.context, ...options.context };
   if (storyboard.context) forwardAliasCache(storyboard.context, preSeedContext);
   if (options.context) forwardAliasCache(options.context, preSeedContext);
-  const preSeededResult = await runControllerSeeding(preSeedClients[0]!, storyboard, options, preSeedContext);
+  let preSeedProfile = options._profile;
+  if (!preSeedProfile) {
+    const discovered = await getOrDiscoverProfile(preSeedClients[0]!, options);
+    if (discovered.step.passed === false) {
+      await closeConnections(options.protocol);
+      return buildDiscoveryFailedResult(agentUrls, storyboard, discovered.step);
+    }
+    preSeedProfile = discovered.profile;
+  }
+  if (preSeedProfile && (!options._profile || !options.agentTools)) {
+    options = {
+      ...options,
+      _profile: preSeedProfile,
+      ...(options.agentTools ? {} : { agentTools: normalizeAgentToolNames(preSeedProfile.tools) }),
+    };
+  }
+  const phaseCapabilitySkipDetails = collectPhaseCapabilitySkipDetails(storyboard, preSeedProfile);
+  const preSeededResult = allExecutablePhasesCapabilitySkipped(storyboard, phaseCapabilitySkipDetails)
+    ? null
+    : await runControllerSeeding(preSeedClients[0]!, storyboard, options, preSeedContext);
 
   const passes: StoryboardPassResult[] = [];
   const passResults: StoryboardResult[] = [];

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -302,10 +302,7 @@ export function resolveCapabilityPath(raw: unknown, dottedPath: string): unknown
  * Exported for direct testing so the predicate semantics are pinned without
  * needing a full runStoryboard() roundtrip.
  */
-export function evaluateCapabilityPredicate(
-  predicate: RequiresCapabilityPredicate,
-  actual: unknown
-): string | null {
+export function evaluateCapabilityPredicate(predicate: RequiresCapabilityPredicate, actual: unknown): string | null {
   if ('present' in predicate) {
     const isPresent = actual !== undefined && actual !== null;
     if (predicate.present && !isPresent) {
@@ -2283,10 +2280,9 @@ async function executeStoryboardPass(
   let seedingMissingController = false;
   let seedingUnsupported = false;
   {
-    const seeding =
-      skipControllerSeedingForPhaseGates
-        ? null
-        : preSeeded !== undefined
+    const seeding = skipControllerSeedingForPhaseGates
+      ? null
+      : preSeeded !== undefined
         ? preSeeded.result
         : await runControllerSeeding(clients[0]!, storyboard, options, context);
     if (seeding) {

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -14,6 +14,11 @@ import type { WebhookConformanceSigningOptions } from '../../conformance/types';
 // Parsed storyboard structure (mirrors YAML schema)
 // ────────────────────────────────────────────────────────────
 
+export type RequiresCapabilityPredicate =
+  | { path: string; equals: boolean | string | number | null }
+  | { path: string; present: boolean }
+  | { path: string; contains: boolean | string | number };
+
 export interface Storyboard {
   id: string;
   version: string;
@@ -147,10 +152,7 @@ export interface Storyboard {
    * does not expose `get_adcp_capabilities`, because inline package creative
    * upload is an optional rc.9 feature that sellers must advertise.
    */
-  requires_capability?:
-    | { path: string; equals: boolean | string | number | null }
-    | { path: string; present: boolean }
-    | { path: string; contains: boolean | string | number };
+  requires_capability?: RequiresCapabilityPredicate;
   /** Scenario IDs that must pass alongside this storyboard (loaded from storyboards/scenarios/) */
   requires_scenarios?: string[];
   agent: {
@@ -327,6 +329,14 @@ export interface StoryboardPhase {
   steps: StoryboardStep[];
   /** When true, the phase is allowed to be skipped without failing the storyboard. */
   optional?: boolean;
+  /**
+   * Predicate evaluated against the agent's declared capabilities before this
+   * phase is set up or any of its steps are dispatched. Uses the same matcher
+   * dialect as `Storyboard.requires_capability` (`equals`, `present`,
+   * `contains`). When false, every step in the phase is emitted as a
+   * `not_applicable` skip and the runner continues with later phases.
+   */
+  requires_capability?: RequiresCapabilityPredicate;
   /**
    * Phases this phase depends on for stateful cascade purposes (#1161).
    *

--- a/test/lib/storyboard-capability-gate.test.js
+++ b/test/lib/storyboard-capability-gate.test.js
@@ -482,3 +482,191 @@ describe('requires_capability `contains:` matcher (#1817)', () => {
     assert.ok(evaluateCapabilityPredicate(containsString, [42])?.includes('must contain'));
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Phase-level `requires_capability` gates (adcp-client#2224) — same matcher
+// dialect as storyboard-level gates, but scoped to one phase.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const deterministicSessionPhaseGatedStoryboard = {
+  id: 'phase_capability_gate_deterministic_session_test',
+  version: '1.0.0',
+  title: 'Deterministic testing with SI-gated phase',
+  category: 'test',
+  summary: 'Skips deterministic_session for non-SI sellers.',
+  narrative: '',
+  agent: { interaction_model: 'sync', capabilities: [] },
+  caller: { role: 'buyer_agent' },
+  phases: [
+    {
+      id: 'deterministic_session',
+      title: 'Deterministic SI session',
+      requires_capability: {
+        path: 'supported_protocols',
+        contains: 'sponsored_intelligence',
+      },
+      steps: [
+        {
+          id: 'si_initiate_session',
+          title: 'Start deterministic SI session',
+          task: 'si_initiate_session',
+          sample_request: {},
+        },
+      ],
+    },
+  ],
+};
+
+function makeCapabilityGateClient(responder = () => ({ success: true, data: {} })) {
+  const calls = [];
+  const client = {
+    async executeTask(name, params) {
+      calls.push({ name, params });
+      return responder({ name, params });
+    },
+  };
+  return { client, calls };
+}
+
+describe('phase-level requires_capability gate (#2224)', () => {
+  test('skips deterministic_session as not_applicable when sponsored_intelligence is not advertised', async () => {
+    const result = await runStoryboard('http://fake-local-99992', deterministicSessionPhaseGatedStoryboard, {
+      _profile: {
+        name: 'Test Agent (media-buy only)',
+        tools: ['get_adcp_capabilities', 'comply_test_controller'],
+        raw_capabilities: { supported_protocols: ['media_buy'] },
+      },
+    });
+
+    assert.equal(result.overall_passed, true, 'phase gate is not a failure');
+    assert.equal(result.skipped_count, 1);
+    assert.equal(result.failed_count, 0);
+    assert.equal(result.passed_count, 0);
+    assert.equal(result.phases.length, 1);
+
+    const phase = result.phases[0];
+    assert.equal(phase.phase_id, 'deterministic_session');
+    assert.equal(phase.passed, true);
+    assert.equal(phase.steps.length, 1);
+
+    const step = phase.steps[0];
+    assert.equal(step.step_id, 'si_initiate_session');
+    assert.equal(step.skipped, true);
+    assert.equal(step.skip_reason, 'not_applicable');
+    assert.equal(step.skip.reason, 'not_applicable');
+    assert.ok(step.skip.detail.includes('supported_protocols'));
+    assert.ok(step.skip.detail.includes('sponsored_intelligence'));
+    assert.ok(step.skip.detail.includes('media_buy'));
+  });
+
+  test('runs the phase gate when sponsored_intelligence is advertised, preserving missing_tool', async () => {
+    const result = await runStoryboard('http://fake-local-99991', deterministicSessionPhaseGatedStoryboard, {
+      _profile: {
+        name: 'Test Agent (SI declared, tool omitted)',
+        tools: ['get_adcp_capabilities', 'comply_test_controller'],
+        raw_capabilities: { supported_protocols: ['media_buy', 'sponsored_intelligence'] },
+      },
+    });
+
+    const step = result.phases[0].steps[0];
+    assert.equal(step.skipped, true);
+    assert.equal(step.skip_reason, 'missing_tool');
+    assert.equal(step.skip.reason, 'missing_tool');
+    assert.ok(step.skip.detail.includes('si_initiate_session'));
+  });
+
+  test('skips only the gated phase and continues later phases', async () => {
+    const { client, calls } = makeCapabilityGateClient();
+    const storyboard = {
+      ...deterministicSessionPhaseGatedStoryboard,
+      phases: [
+        deterministicSessionPhaseGatedStoryboard.phases[0],
+        {
+          id: 'media_buy_discovery',
+          title: 'Media buy discovery',
+          steps: [
+            {
+              id: 'get_products',
+              title: 'Discover products',
+              task: 'get_products',
+              sample_request: { brief: 'coffee' },
+              validations: [],
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = await runStoryboard('https://example.invalid/mcp', storyboard, {
+      protocol: 'mcp',
+      allow_http: false,
+      agentTools: ['get_adcp_capabilities', 'get_products'],
+      _profile: {
+        name: 'Test Agent (media-buy only)',
+        tools: ['get_adcp_capabilities', 'get_products'],
+        raw_capabilities: { supported_protocols: ['media_buy'] },
+      },
+      _client: client,
+    });
+
+    assert.equal(result.overall_passed, true);
+    assert.equal(result.phases.length, 2);
+    assert.equal(result.phases[0].phase_id, 'deterministic_session');
+    assert.equal(result.phases[0].steps[0].skip_reason, 'not_applicable');
+    assert.equal(result.phases[1].phase_id, 'media_buy_discovery');
+    assert.equal(result.phases[1].steps[0].skipped, undefined);
+    assert.equal(result.phases[1].steps[0].passed, true);
+    assert.deepEqual(
+      calls.map(c => c.name),
+      ['get_products'],
+      'only the ungated later phase should dispatch'
+    );
+  });
+
+  test('optional-only gated phases do not create a vacuous overall pass', async () => {
+    const result = await runStoryboard('http://fake-local-99990', {
+      ...deterministicSessionPhaseGatedStoryboard,
+      phases: [{ ...deterministicSessionPhaseGatedStoryboard.phases[0], optional: true }],
+    }, {
+      _profile: {
+        name: 'Test Agent (media-buy only)',
+        tools: ['get_adcp_capabilities'],
+        raw_capabilities: { supported_protocols: ['media_buy'] },
+      },
+    });
+
+    assert.equal(result.failed_count, 0);
+    assert.equal(result.passed_count, 0);
+    assert.equal(result.skipped_count, 1);
+    assert.equal(result.overall_passed, false, 'optional-only skip remains no executed required coverage');
+  });
+
+  test('does not run controller seeding when every executable phase is gated not_applicable', async () => {
+    const { client, calls } = makeCapabilityGateClient(({ name }) => {
+      throw new Error(`unexpected call: ${name}`);
+    });
+    const storyboard = {
+      ...deterministicSessionPhaseGatedStoryboard,
+      prerequisites: { description: 'needs seeds', controller_seeding: true },
+      fixtures: { products: [{ product_id: 'p-1' }] },
+    };
+
+    const result = await runStoryboard('https://example.invalid/mcp', storyboard, {
+      protocol: 'mcp',
+      allow_http: false,
+      agentTools: ['get_adcp_capabilities', 'comply_test_controller'],
+      _profile: {
+        name: 'Test Agent (media-buy only)',
+        tools: ['get_adcp_capabilities', 'comply_test_controller'],
+        raw_capabilities: { supported_protocols: ['media_buy'] },
+      },
+      _client: client,
+    });
+
+    assert.equal(result.overall_passed, true);
+    assert.equal(result.phases.length, 1);
+    assert.equal(result.phases[0].phase_id, 'deterministic_session');
+    assert.equal(result.phases[0].steps[0].skip_reason, 'not_applicable');
+    assert.deepEqual(calls, [], 'phase gate should skip before controller seeding or step dispatch');
+  });
+});

--- a/test/lib/storyboard-capability-gate.test.js
+++ b/test/lib/storyboard-capability-gate.test.js
@@ -624,16 +624,20 @@ describe('phase-level requires_capability gate (#2224)', () => {
   });
 
   test('optional-only gated phases do not create a vacuous overall pass', async () => {
-    const result = await runStoryboard('http://fake-local-99990', {
-      ...deterministicSessionPhaseGatedStoryboard,
-      phases: [{ ...deterministicSessionPhaseGatedStoryboard.phases[0], optional: true }],
-    }, {
-      _profile: {
-        name: 'Test Agent (media-buy only)',
-        tools: ['get_adcp_capabilities'],
-        raw_capabilities: { supported_protocols: ['media_buy'] },
+    const result = await runStoryboard(
+      'http://fake-local-99990',
+      {
+        ...deterministicSessionPhaseGatedStoryboard,
+        phases: [{ ...deterministicSessionPhaseGatedStoryboard.phases[0], optional: true }],
       },
-    });
+      {
+        _profile: {
+          name: 'Test Agent (media-buy only)',
+          tools: ['get_adcp_capabilities'],
+          raw_capabilities: { supported_protocols: ['media_buy'] },
+        },
+      }
+    );
 
     assert.equal(result.failed_count, 0);
     assert.equal(result.passed_count, 0);

--- a/test/lib/storyboard-multi-instance.test.js
+++ b/test/lib/storyboard-multi-instance.test.js
@@ -62,13 +62,30 @@ function handleMcpHandshake(rpc, res, tools) {
  * one shared Map across two agents to simulate a correctly shared backing
  * store, or separate Maps to simulate the per-process bug.
  */
-async function startFakeAgent({ state, label }) {
+async function startFakeAgent({
+  state,
+  label,
+  tools = ['__test_write', '__test_read', '__test_probe', 'get_adcp_capabilities'],
+  capabilities = { version: '1.0', protocols: [], specialisms: [] },
+  failToolsList = false,
+}) {
   const requests = [];
   const server = http.createServer(async (req, res) => {
     const chunks = [];
     for await (const c of req) chunks.push(c);
-    const rpc = JSON.parse(Buffer.concat(chunks).toString('utf8'));
-    if (handleMcpHandshake(rpc, res, ['__test_write', '__test_read', '__test_probe', 'get_adcp_capabilities'])) {
+    const body = Buffer.concat(chunks).toString('utf8');
+    if (!body) {
+      res.writeHead(404);
+      res.end();
+      return;
+    }
+    const rpc = JSON.parse(body);
+    if (failToolsList && rpc.method === 'tools/list') {
+      res.writeHead(500, { 'content-type': 'text/plain' });
+      res.end('tools list unavailable');
+      return;
+    }
+    if (handleMcpHandshake(rpc, res, tools)) {
       return;
     }
     const toolName = rpc.params?.name;
@@ -106,7 +123,7 @@ async function startFakeAgent({ state, label }) {
       return ok({ instance: label });
     }
     if (toolName === 'get_adcp_capabilities') {
-      return ok({ version: '1.0', protocols: [], specialisms: [] });
+      return ok(capabilities);
     }
     return notFound(`unknown tool ${toolName} on instance ${label}`);
   });
@@ -364,6 +381,90 @@ describe('runStoryboard: multi-instance multi-pass', () => {
     // Top-level `phases` exposes the first pass's phases for single-pass consumers.
     assert.strictEqual(result.phases[0].steps[0].agent_index, 1);
     assert.strictEqual(result.phases[0].steps[1].agent_index, 2);
+  });
+
+  test('does not pre-seed when discovery shows every executable phase is capability-gated out', async () => {
+    const shared = new Map();
+    const tools = ['get_adcp_capabilities', 'comply_test_controller'];
+    const capabilities = { adcp: { major_versions: [3] }, supported_protocols: ['media_buy'] };
+    agentA = await startFakeAgent({ state: shared, label: 'A', tools, capabilities });
+    agentB = await startFakeAgent({ state: shared, label: 'B', tools, capabilities });
+
+    const storyboard = {
+      id: 'multi_pass_phase_gate_seed_suppression',
+      version: '1.0.0',
+      title: 'Multi-pass phase gate seed suppression',
+      category: 'testing',
+      summary: '',
+      narrative: '',
+      agent: { interaction_model: '*', capabilities: [] },
+      caller: { role: 'buyer_agent' },
+      prerequisites: { description: 'needs seeds', controller_seeding: true },
+      fixtures: { products: [{ product_id: 'p-1' }] },
+      phases: [
+        {
+          id: 'deterministic_session',
+          title: 'Deterministic SI session',
+          requires_capability: { path: 'supported_protocols', contains: 'sponsored_intelligence' },
+          steps: [
+            {
+              id: 'si_initiate_session',
+              title: 'Start deterministic SI session',
+              task: 'si_initiate_session',
+              sample_request: {},
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = await runStoryboard([agentA.url, agentB.url], storyboard, {
+      protocol: 'mcp',
+      allow_http: true,
+      multi_instance_strategy: 'multi-pass',
+    });
+
+    assert.strictEqual(result.overall_passed, true);
+    assert.strictEqual(result.passes.length, 2);
+    assert.strictEqual(result.passes[0].phases[0].steps[0].skip_reason, 'not_applicable');
+    assert.strictEqual(result.passes[1].phases[0].steps[0].skip_reason, 'not_applicable');
+
+    const allRequests = [...agentA.requests, ...agentB.requests];
+    assert.ok(
+      allRequests.some(r => r.tool === 'get_adcp_capabilities'),
+      'first replica should be discovered before the pre-seed decision'
+    );
+    assert.deepStrictEqual(
+      allRequests.filter(r => r.tool === 'comply_test_controller'),
+      [],
+      'all executable phases are gated out, so controller seeding must not run'
+    );
+  });
+
+  test('surfaces discovery_failed when pre-seed discovery fails before multi-pass execution', async () => {
+    const shared = new Map();
+    agentA = await startFakeAgent({ state: shared, label: 'A', failToolsList: true });
+    agentB = await startFakeAgent({ state: shared, label: 'B' });
+
+    const result = await runStoryboard(
+      [agentA.url, agentB.url],
+      storyboardWith([{ id: 's1', title: 's1', task: '__test_probe', auth: 'none', sample_request: {} }]),
+      {
+        protocol: 'mcp',
+        allow_http: true,
+        multi_instance_strategy: 'multi-pass',
+      }
+    );
+
+    assert.strictEqual(result.overall_passed, false);
+    assert.strictEqual(result.phases[0].phase_id, 'discovery_failed');
+    assert.strictEqual(result.phases[0].steps[0].step_id, 'discovery_failed');
+    assert.strictEqual(result.passes, undefined, 'pre-execution discovery failure should not fabricate pass results');
+    assert.deepStrictEqual(
+      [...agentA.requests, ...agentB.requests],
+      [],
+      'no storyboard tool calls should dispatch after failed discovery'
+    );
   });
 
   test('aggregates failures from a per-replica bug across both passes', async () => {


### PR DESCRIPTION
## Summary

Enforces phase-level `requires_capability` gates in the storyboard runner using the existing `equals`, `present`, and `contains` matcher semantics.
Skipped phases now emit `not_applicable` step rows before dispatch, and fully gated storyboards avoid controller seeding side effects.
The fix preserves `missing_tool` when a capability gate passes but a required tool is not advertised, including multi-pass runs.

Fixes #2224.

## Validation

- `npm run build:lib`
- `node --test-timeout=60000 --test test/lib/storyboard-capability-gate.test.js test/lib/storyboard-controller-seeding.test.js test/lib/storyboard-multi-instance.test.js`
- `git diff --check`
