### PR TITLE
fix(conformance): handle webhook placeholders and flat errors

### DIFF
--- a/.changeset/export-placement-type.md
+++ b/.changeset/export-placement-type.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Re-export the generated `Placement` type from the package root and `@adcp/sdk/types` barrel for callers that need to name placement entries from product response shapes.

--- a/.changeset/storyboard-flat-error-code.md
+++ b/.changeset/storyboard-flat-error-code.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Treat flat `{ error_code: "..." }` responses as terminal AdCP errors in storyboard expected-error handling so permissive non-standard INVALID_REQUEST envelopes do not fail negative-path steps.

--- a/.changeset/storyboard-webhook-rate-limit-requires.md
+++ b/.changeset/storyboard-webhook-rate-limit-requires.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Detect implicit `webhook_receiver` requirements inside `rate_limit_trip.trip_target_sample_request` so storyboards with runner webhook placeholders skip before dispatch when no receiver is configured.

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -737,6 +737,7 @@ export type {
   SyncCatalogsError,
   // Format Assets
   Overlay,
+  Placement,
   // Creative Agent Domain
   CreativeManifest,
   CreativeVariable,

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -1576,10 +1576,12 @@ function valueContainsWebhookToken(value: unknown): boolean {
  * structure (not its declared `requires:` list). Today:
  *   - `'webhook_receiver'`, autodetected from `{{runner.webhook_url:…}}`
  *     / `{{runner.webhook_base}}` token presence inside any step's
- *     `sample_request`. Token presence is the authoring contract — a
- *     storyboard that names the runner's webhook receiver cannot run
- *     without one — so authors don't need to remember to add
- *     `requires: [webhook_receiver]` separately. Spec: adcp-client#1678.
+ *     `sample_request` or in-scope `rate_limit_trip.trip_target_sample_request`.
+ *     Token presence is the authoring contract — a storyboard that names
+ *     the runner's webhook receiver cannot run without one — so authors
+ *     don't need to remember to add `requires: [webhook_receiver]`
+ *     separately. Contract-gated synthetic steps only count when their
+ *     `requires_contract` is configured for this run. Spec: adcp-client#1678.
  *   - `'request_signer'`, autodetected from `storyboard.id ===
  *     'signed_requests'` or any step using the synthesized
  *     `request_signing_probe` task. The signed-requests universal
@@ -1589,13 +1591,24 @@ function valueContainsWebhookToken(value: unknown): boolean {
  *     failures on bearer-only agents that never claimed signing.
  *     Spec: adcp-client#1702.
  */
-function detectImplicitRequires(storyboard: Storyboard): RequirementName[] {
+function detectImplicitRequires(
+  storyboard: Storyboard,
+  options: Pick<StoryboardRunOptions, 'contracts'> = {}
+): RequirementName[] {
   const requires: RequirementName[] = [];
   let needsWebhook = false;
   let needsSigner = storyboard.id === 'signed_requests';
+  const contractsInScope = new Set(options.contracts ?? []);
   for (const phase of storyboard.phases) {
     for (const step of phase.steps) {
-      if (!needsWebhook && step.sample_request && valueContainsWebhookToken(step.sample_request)) {
+      const rateLimitTripInScope = !step.requires_contract || contractsInScope.has(step.requires_contract);
+      if (
+        !needsWebhook &&
+        ((step.sample_request && valueContainsWebhookToken(step.sample_request)) ||
+          (step.rate_limit_trip?.trip_target_sample_request &&
+            rateLimitTripInScope &&
+            valueContainsWebhookToken(step.rate_limit_trip.trip_target_sample_request)))
+      ) {
         needsWebhook = true;
       }
       if (!needsSigner && step.task === 'request_signing_probe') {
@@ -1998,7 +2011,7 @@ async function executeStoryboardPass(
   const preflightNotices = collectCapabilityNotices(storyboard, options._profile?.raw_capabilities);
 
   const declared = storyboard.requires ?? [];
-  const implicit = detectImplicitRequires(storyboard);
+  const implicit = detectImplicitRequires(storyboard, options);
   const allRequires = [...declared, ...implicit.filter(r => !declared.includes(r))];
   if (allRequires.length) {
     const unmet = checkRequires(allRequires, options, profile);

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -118,6 +118,7 @@ export type {
   AudienceStatus,
   MediaBuyStatus,
   CreativeStatus,
+  Placement,
   PublisherPropertySelector,
   ReportingCapabilities,
 } from './tools.generated';

--- a/src/lib/utils/response-unwrapper.ts
+++ b/src/lib/utils/response-unwrapper.ts
@@ -191,6 +191,7 @@ export function isTerminalAdcpError(response: unknown, toolName?: string): boole
   const obj = response as Record<string, unknown> | null | undefined;
   if (obj?.status === 'failed' || obj?.status === 'rejected') return true;
   if (obj?.adcp_error && typeof (obj.adcp_error as { code?: unknown }).code === 'string') return true;
+  if (typeof obj?.error_code === 'string') return true;
   if (Array.isArray(obj?.errors) && obj.errors.length > 0) {
     return !hasAdvisorySuccessPayload(obj, toolName);
   }

--- a/test/lib/public-barrel-exports.test.js
+++ b/test/lib/public-barrel-exports.test.js
@@ -20,6 +20,7 @@ import {
   ensureGetProductsCacheScope,
   type CanonicalFormatParams,
   type GetProductsResponse,
+  type Placement,
   type ProductFormatDeclaration,
   type SyncCreativesPayload,
 } from '@adcp/sdk';
@@ -43,6 +44,7 @@ import {
 } from '@adcp/sdk/server';
 import type {
   ProductFormatDeclaration as TypesProductFormatDeclaration,
+  Placement as TypesPlacement,
   RequireCacheScopeWhenProducts,
 } from '@adcp/sdk/types';
 
@@ -108,6 +110,9 @@ const generatedMissingScope = ensureGetProductsCacheScope({
 } satisfies Omit<GetProductsResponse, 'cache_scope'>);
 const generatedInjectedScope: 'public' | 'account' = generatedMissingScope.cache_scope;
 
+const acceptsRootPlacement = (_placement: Placement) => {};
+const acceptsTypesPlacement = (_placement: TypesPlacement) => {};
+
 void typedNative;
 void builtKind;
 void mediaBuyShape;
@@ -120,6 +125,8 @@ void scope;
 void required;
 void generatedScope;
 void generatedInjectedScope;
+void acceptsRootPlacement;
+void acceptsTypesPlacement;
 `,
     'utf8'
   );

--- a/test/lib/response-unwrapper.test.js
+++ b/test/lib/response-unwrapper.test.js
@@ -1216,6 +1216,17 @@ describe('Response Unwrapper', () => {
       assert.strictEqual(isAdcpError({ adcp_error: { code: 'RATE_LIMITED', message: 'slow' } }), true);
     });
 
+    test('flat error_code responses are terminal for permissive expected-error handling', () => {
+      const response = {
+        error_code: 'INVALID_REQUEST',
+        message: 'Invalid request',
+      };
+
+      assert.strictEqual(isAdcpError(response), false);
+      assert.strictEqual(isTerminalAdcpError(response, 'get_products'), true);
+      assert.strictEqual(isAdcpSuccess(response, 'get_products'), false);
+    });
+
     test('should return false for adcp_error with non-string code', () => {
       assert.strictEqual(isAdcpError({ adcp_error: { code: 42 } }), false);
     });

--- a/test/lib/storyboard-expect-error-failed-payload.test.js
+++ b/test/lib/storyboard-expect-error-failed-payload.test.js
@@ -182,4 +182,34 @@ describe('storyboard expect_error failed payload normalization (#2179)', () => {
     assert.equal(result.failed_count, 0);
     assert.equal(result.overall_passed, true);
   });
+
+  test('flat data.error_code INVALID_REQUEST passes expect_error validation', async () => {
+    const client = {
+      getAgentInfo: async () => ({ name: 'stub', tools: [{ name: 'get_products' }] }),
+      getProducts: async () => ({
+        data: {
+          error_code: 'INVALID_REQUEST',
+          message: 'Invalid request',
+        },
+      }),
+    };
+
+    const result = await runStoryboard('https://stub.example/mcp', buildStoryboard(), {
+      protocol: 'mcp',
+      _client: client,
+      _profile: { name: 'stub', tools: [{ name: 'get_products' }] },
+    });
+
+    const rejectStep = result.phases[0].steps[0];
+    const gateStep = result.phases[1].steps[0];
+
+    assert.equal(rejectStep.passed, true);
+    assert.equal(rejectStep.validations[0].passed, true);
+    assert.deepEqual(rejectStep.response_record.payload, {
+      error_code: 'INVALID_REQUEST',
+      message: 'Invalid request',
+    });
+    assert.equal(gateStep.passed, true);
+    assert.equal(result.overall_passed, true);
+  });
 });

--- a/test/lib/storyboard-requires-gate.test.js
+++ b/test/lib/storyboard-requires-gate.test.js
@@ -527,6 +527,110 @@ describe('Storyboard.requires gate (#1678): implicit webhook_receiver', () => {
     assert.equal(step.skip.requirement, 'webhook_receiver', 'recursive scan finds nested tokens');
   });
 
+  test('webhook tokens in rate_limit_trip target requests also trigger the gate', async () => {
+    const sb = buildStoryboard({
+      phases: [
+        {
+          id: 'p1',
+          title: 'Rate-limit target with webhook callback',
+          steps: [
+            {
+              id: 'trip',
+              title: 'Rate-limit trip target request needs a receiver',
+              task: 'expect_rate_limit_not_replayed',
+              rate_limit_trip: {
+                trip_target_task: 'create_media_buy',
+                trip_target_sample_request: {
+                  buyer_ref: 'buyer-rate-limit-test',
+                  packages: [{ product_id: 'prod_1', budget: 1000 }],
+                  push_notification_config: {
+                    url: '{{runner.webhook_url:trip}}',
+                  },
+                },
+                max_attempts: 50,
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = await runStoryboard('http://fake-local-99999', sb, {
+      _profile: profileWithoutController,
+      agentTools: profileWithoutController.tools,
+      contracts: ['rate_limit_trip_runner'],
+    });
+
+    const step = result.phases[0].steps[0];
+    assert.equal(step.skipped, true);
+    assert.equal(step.skip_reason, 'requirement_unmet');
+    assert.equal(step.skip.requirement, 'webhook_receiver');
+  });
+
+  test('out-of-scope rate_limit_trip webhook tokens do not skip unrelated phases', async () => {
+    const sb = buildStoryboard({
+      phases: [
+        {
+          id: 'normal',
+          title: 'Normal phase',
+          steps: [
+            {
+              id: 'normal_read',
+              title: 'Normal read still runs',
+              task: 'get_products',
+              sample_request: { buying_mode: 'brief', brief: 'show products' },
+            },
+          ],
+        },
+        {
+          id: 'rate_limit',
+          title: 'Out-of-scope rate-limit phase',
+          steps: [
+            {
+              id: 'trip',
+              title: 'Rate-limit trip target request needs a receiver only when the contract is in scope',
+              task: 'expect_rate_limit_not_replayed',
+              requires_contract: 'rate_limit_trip_runner',
+              rate_limit_trip: {
+                trip_target_task: 'create_media_buy',
+                trip_target_sample_request: {
+                  buyer_ref: 'buyer-rate-limit-test',
+                  packages: [{ product_id: 'prod_1', budget: 1000 }],
+                  push_notification_config: {
+                    url: '{{runner.webhook_url:trip}}',
+                  },
+                },
+                max_attempts: 50,
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = await runStoryboard('http://fake-local-99999', sb, {
+      _profile: {
+        ...profileWithoutController,
+        tools: [...profileWithoutController.tools, 'create_media_buy'],
+      },
+      agentTools: [...profileWithoutController.tools, 'create_media_buy'],
+    });
+
+    assert.ok(
+      !result.phases.some(phase => phase.phase_id === 'requirement_unmet'),
+      'out-of-scope contract-gated webhook token must not trigger storyboard-level requirement_unmet'
+    );
+    assert.ok(
+      result.phases.some(phase => phase.phase_id === 'normal'),
+      'unrelated phase still runs'
+    );
+    const trip = result.phases
+      .find(phase => phase.phase_id === 'rate_limit')
+      ?.steps.find(step => step.step_id === 'trip');
+    assert.equal(trip?.skipped, true);
+    assert.equal(trip?.skip_reason, 'missing_test_kit_contract');
+  });
+
   test('declared requires: [webhook_receiver] resolves the same way (loader allows the name)', () => {
     const yaml = `
 id: ok_webhook_declared


### PR DESCRIPTION
## Summary

- Detect implicit `webhook_receiver` requirements inside `rate_limit_trip.trip_target_sample_request` so unresolved `{{runner.webhook_url:*}}` placeholders skip before dispatch when no receiver is configured.
- Treat flat `{ error_code: "..." }` payloads as terminal AdCP errors for storyboard `expect_error` handling.
- Re-export the generated `Placement` type from the root package and `@adcp/sdk/types`.

Fixes #2210.
Fixes #2211.
Fixes #2208.
Fixes #2195.

## Validation

- `npm run build:lib`
- `NODE_ENV=test node --test --test-timeout=60000 --test-force-exit test/lib/storyboard-requires-gate.test.js`
- `NODE_ENV=test node --test --test-timeout=60000 test/lib/response-unwrapper.test.js`
- `NODE_ENV=test node --test --test-timeout=60000 test/lib/storyboard-rate-limit-trip.test.js`
- `NODE_ENV=test node --test --test-timeout=60000 test/lib/storyboard-expect-error-failed-payload.test.js`
- `NODE_ENV=test node --test --test-timeout=60000 test/lib/public-barrel-exports.test.js`
- `NODE_ENV=test node --test --test-timeout=60000 --test-name-pattern "initializes the MCP session before dispatching" test/lib/storyboard-security.test.js`
- `npx prettier --check src/lib/testing/storyboard/runner.ts src/lib/utils/response-unwrapper.ts src/lib/index.ts src/lib/types/index.ts test/lib/storyboard-requires-gate.test.js test/lib/storyboard-expect-error-failed-payload.test.js test/lib/public-barrel-exports.test.js .changeset/storyboard-webhook-rate-limit-requires.md .changeset/storyboard-flat-error-code.md .changeset/export-placement-type.md`

## Notes

- `PublisherProperty` is not a generated type in the current schema surface; `PublisherPropertySelector` was already exported.
- The MCP security initialization regression for #2209 is already fixed on current `main`; this PR includes the targeted verification command above but does not change that code path.
