### PR TITLE
feat: expose task state resolver

### DIFF
--- a/.changeset/resolve-task-state-helper.md
+++ b/.changeset/resolve-task-state-helper.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': minor
+---
+
+Expose `resolveTaskState()` to reconcile `TaskResult.status` with task-envelope status values in response payloads.

--- a/src/lib/core/ProtocolResponseParser.ts
+++ b/src/lib/core/ProtocolResponseParser.ts
@@ -5,67 +5,18 @@
 
 import type { InputRequest } from './ConversationTypes';
 import { getLatestA2ADataPartFromTask } from '../utils/a2a-artifacts';
+import {
+  ADCP_STATUS,
+  type ADCPStatus,
+  TASK_ENVELOPE_FIELDS,
+  extractAdcpStatusFromA2aTaskResult,
+  extractAdcpTaskStatusFromPayload,
+  isAdcpStatus,
+} from './task-status';
 
-/**
- * ADCP standardized status values as per spec PR #78
- * Clear semantics for async task management:
- * - submitted: Long-running tasks (hours to days) - webhook required
- * - working: Processing tasks (<120 seconds) - keep connection open
- * - input-required: Tasks needing user interaction via handler
- * - completed: Successful task completion
- */
-export const ADCP_STATUS = {
-  SUBMITTED: 'submitted', // Long-running (hours/days) - webhook required
-  WORKING: 'working', // Processing (<120s) - keep connection open
-  INPUT_REQUIRED: 'input-required', // Needs user input via handler
-  COMPLETED: 'completed', // Task completed successfully
-  FAILED: 'failed', // Task failed
-  CANCELED: 'canceled', // Task was canceled
-  REJECTED: 'rejected', // Task was rejected
-  AUTH_REQUIRED: 'auth-required', // Authentication required
-  UNKNOWN: 'unknown', // Unknown status
-} as const;
+export { ADCP_STATUS, type ADCPStatus } from './task-status';
 
-export type ADCPStatus = (typeof ADCP_STATUS)[keyof typeof ADCP_STATUS];
-
-/**
- * Fields that belong to the task envelope, not to a domain payload. Derived
- * from `ProtocolEnvelope` (core/protocol-envelope.json) plus the optional
- * `errors` / `context` / `ext` fields that AdCP task-response schemas place at
- * envelope level. Used to disambiguate `structuredContent.status` from AdCP v3
- * domain status enums (MediaBuyStatus, CreativeStatus, etc.) that share
- * literals like `completed` / `canceled` / `failed` / `rejected` — see #646
- * and #2009.
- */
-const TASK_ENVELOPE_FIELDS: ReadonlySet<string> = new Set([
-  'status',
-  'message',
-  'timestamp',
-  'context_id',
-  'task_id',
-  'replayed',
-  'push_notification_config',
-  'governance_context',
-  'adcp_version',
-  'errors',
-  'context',
-  'ext',
-]);
 const NESTED_TASK_ENVELOPE_FIELDS: ReadonlySet<string> = new Set([...TASK_ENVELOPE_FIELDS, 'taskId', 'adcp_error']);
-
-/**
- * ADCP task-lifecycle statuses that never overlap with AdCP domain status
- * enums and can be trusted from `structuredContent.status` or A2A DataPart
- * `status` unconditionally.
- * The other literals (`completed` / `canceled` / `failed` / `rejected`) share
- * values with `MediaBuyStatus` et al and require envelope-shape disambiguation.
- */
-const EXCLUSIVE_TASK_STATUSES: ReadonlySet<string> = new Set([
-  ADCP_STATUS.SUBMITTED,
-  ADCP_STATUS.WORKING,
-  ADCP_STATUS.INPUT_REQUIRED,
-  ADCP_STATUS.AUTH_REQUIRED,
-]);
 
 /**
  * Max length for a server-issued session id (`contextId` / `taskId`) we
@@ -89,45 +40,6 @@ function isSafeSessionId(v: unknown): v is string {
   if (typeof v !== 'string') return false;
   if (v.length === 0 || v.length > SESSION_ID_MAX_LENGTH) return false;
   return SESSION_ID_PATTERN.test(v);
-}
-
-/**
- * Extract the AdCP work-layer status from an A2A wrapped Task result,
- * if present. Exclusive AdCP task statuses (`submitted` / `working` /
- * `input-required` / `auth-required`) live on the latest structured DataPart
- * `status` (per adcp-client#899's two-lifecycle contract); the transport-layer
- * `result.status.state` tracks the HTTP-call lifecycle and is `'completed'`
- * for AdCP submitted arms.
- *
- * Shared literals (`completed` / `canceled` / `failed` / `rejected`) are
- * ambiguous in A2A artifact data because domain payloads also have a
- * `status` field. A completed `update_media_buy` task can return
- * `{ media_buy_id, status: "canceled" }`; that means the media buy was
- * canceled, not the A2A task. Use the same envelope-shape guard as MCP
- * structuredContent. See issue #2009.
- *
- * Returns `undefined` for non-AdCP A2A responses (no artifact, no
- * DataPart, or `data.status` not in the AdCP enum) so callers can
- * fall back to the transport-layer status.
- */
-function extractAdcpStatusFromA2aTaskResult(result: any): ADCPStatus | undefined {
-  if (result == null || typeof result !== 'object' || Array.isArray(result)) return undefined;
-  if (result.kind !== 'task') return undefined;
-  const extracted = getLatestA2ADataPartFromTask(result);
-  if (!extracted) return undefined;
-  const data = extracted.data;
-  const status = data.status;
-  if (typeof status === 'string' && (Object.values(ADCP_STATUS) as string[]).includes(status)) {
-    if (EXCLUSIVE_TASK_STATUSES.has(status)) {
-      return status as ADCPStatus;
-    }
-    const hasDomainPayload = Object.keys(data).some(k => !TASK_ENVELOPE_FIELDS.has(k));
-    if (hasDomainPayload) {
-      return undefined;
-    }
-    return status as ADCPStatus;
-  }
-  return undefined;
 }
 
 /**
@@ -297,12 +209,12 @@ export class ProtocolResponseParser {
     // when the artifact didn't surface an AdCP status (non-AdCP A2A
     // responses, or sync-completed responses where transport state is
     // authoritative).
-    if (response?.result?.status?.state && Object.values(ADCP_STATUS).includes(response.result.status.state)) {
+    if (isAdcpStatus(response?.result?.status?.state)) {
       return response.result.status.state as ADCPStatus;
     }
 
     // Check top-level status first (A2A and direct responses)
-    if (response?.status && Object.values(ADCP_STATUS).includes(response.status)) {
+    if (isAdcpStatus(response?.status)) {
       return response.status as ADCPStatus;
     }
 
@@ -315,14 +227,9 @@ export class ProtocolResponseParser {
     // Otherwise we fall through to the structuredContent fallback below, so Zod
     // validators parse the domain payload. See issue #646.
     const sc = response?.structuredContent;
-    if (sc?.status && Object.values(ADCP_STATUS).includes(sc.status)) {
-      if (EXCLUSIVE_TASK_STATUSES.has(sc.status)) {
-        return sc.status as ADCPStatus;
-      }
-      const hasDomainPayload = Object.keys(sc).some(k => !TASK_ENVELOPE_FIELDS.has(k));
-      if (!hasDomainPayload) {
-        return sc.status as ADCPStatus;
-      }
+    if (sc?.status && isAdcpStatus(sc.status)) {
+      const taskStatus = extractAdcpTaskStatusFromPayload(sc);
+      if (taskStatus) return taskStatus;
       // Domain payload present alongside a shared-literal status — fall through.
     }
 

--- a/src/lib/core/task-status.ts
+++ b/src/lib/core/task-status.ts
@@ -1,0 +1,88 @@
+import { getLatestA2ADataPartFromTask } from '../utils/a2a-artifacts';
+
+/**
+ * ADCP standardized status values as per spec PR #78.
+ */
+export const ADCP_STATUS = {
+  SUBMITTED: 'submitted',
+  WORKING: 'working',
+  INPUT_REQUIRED: 'input-required',
+  COMPLETED: 'completed',
+  FAILED: 'failed',
+  CANCELED: 'canceled',
+  REJECTED: 'rejected',
+  AUTH_REQUIRED: 'auth-required',
+  UNKNOWN: 'unknown',
+} as const;
+
+export type ADCPStatus = (typeof ADCP_STATUS)[keyof typeof ADCP_STATUS];
+
+/**
+ * Fields that belong to the task envelope, not to a domain payload. Derived
+ * from `ProtocolEnvelope` (core/protocol-envelope.json) plus optional fields
+ * that AdCP task-response schemas place at envelope level.
+ */
+export const TASK_ENVELOPE_FIELDS: ReadonlySet<string> = new Set([
+  'status',
+  'message',
+  'timestamp',
+  'context_id',
+  'task_id',
+  'replayed',
+  'push_notification_config',
+  'governance_context',
+  'adcp_version',
+  'errors',
+  'context',
+  'ext',
+]);
+
+/**
+ * ADCP task-lifecycle statuses that never overlap with AdCP domain status
+ * enums and can be trusted from response payload `status` unconditionally.
+ */
+const EXCLUSIVE_TASK_STATUSES: ReadonlySet<string> = new Set([
+  ADCP_STATUS.SUBMITTED,
+  ADCP_STATUS.WORKING,
+  ADCP_STATUS.INPUT_REQUIRED,
+  ADCP_STATUS.AUTH_REQUIRED,
+]);
+
+export function isAdcpStatus(status: unknown): status is ADCPStatus {
+  return typeof status === 'string' && (Object.values(ADCP_STATUS) as string[]).includes(status);
+}
+
+/**
+ * Extract a task-lifecycle status from an AdCP payload while ignoring
+ * domain-level `status` fields that collide with task status literals.
+ */
+export function extractAdcpTaskStatusFromPayload(payload: unknown): ADCPStatus | undefined {
+  if (payload == null || typeof payload !== 'object' || Array.isArray(payload)) return undefined;
+
+  const record = payload as Record<string, unknown>;
+  const status = record.status;
+  if (!isAdcpStatus(status)) return undefined;
+
+  if (EXCLUSIVE_TASK_STATUSES.has(status)) {
+    return status;
+  }
+
+  const hasDomainPayload = Object.keys(record).some(k => !TASK_ENVELOPE_FIELDS.has(k));
+  if (hasDomainPayload) {
+    return undefined;
+  }
+
+  return status;
+}
+
+/**
+ * Extract the AdCP work-layer status from an A2A wrapped Task result, if
+ * present. Returns `undefined` for non-AdCP A2A responses so callers can fall
+ * back to the transport-layer status.
+ */
+export function extractAdcpStatusFromA2aTaskResult(result: unknown): ADCPStatus | undefined {
+  if (result == null || typeof result !== 'object' || Array.isArray(result)) return undefined;
+  if ((result as { kind?: unknown }).kind !== 'task') return undefined;
+  const extracted = getLatestA2ADataPartFromTask(result);
+  return extractAdcpTaskStatusFromPayload(extracted?.data);
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1187,7 +1187,9 @@ export {
   hasAdvisorySuccessPayload,
   getAuthoritativeMediaBuyStatus,
   isMediaBuyStatus,
+  resolveTaskState,
 } from './utils';
+export type { EffectiveTaskState, ResolvedTaskState, ResolveTaskStateOptions } from './utils';
 export { injectLegacyEnvelopeStatus } from './utils/envelope-status-compat';
 export { extractResult, type ToolCallResultLike } from './utils';
 export { REQUEST_TIMEOUT, MAX_CONCURRENT, STANDARD_FORMATS } from './utils';

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -154,6 +154,12 @@ export {
   type GetProductsCacheScopeValidation,
 } from './get-products-cache-scope';
 export { getAuthoritativeMediaBuyStatus, isMediaBuyStatus } from './media-buy-status';
+export {
+  resolveTaskState,
+  type EffectiveTaskState,
+  type ResolvedTaskState,
+  type ResolveTaskStateOptions,
+} from './task-state';
 
 // Lightweight MCP CallToolResult extractor (prefers structuredContent, falls back to JSON text).
 export { extractResult, type ToolCallResultLike } from './extract-result';

--- a/src/lib/utils/task-state.ts
+++ b/src/lib/utils/task-state.ts
@@ -1,0 +1,158 @@
+import type { TaskResult, TaskStatus } from '../core/ConversationTypes';
+import { ADCP_STATUS, type ADCPStatus, extractAdcpTaskStatusFromPayload, isAdcpStatus } from '../core/task-status';
+
+export type EffectiveTaskState =
+  | Extract<
+      TaskStatus,
+      | 'submitted'
+      | 'working'
+      | 'input-required'
+      | 'auth-required'
+      | 'completed'
+      | 'failed'
+      | 'rejected'
+      | 'canceled'
+      | 'deferred'
+      | 'governance-denied'
+    >
+  | 'unknown';
+
+export interface ResolveTaskStateOptions {
+  /**
+   * AdCP tool name that produced the result. Supplying this lets future SDK
+   * versions apply tool-specific reconciliation without changing the API shape.
+   */
+  toolName?: string;
+}
+
+export interface ResolvedTaskState<T> {
+  /** Client/wrapper-level TaskResult status. */
+  wrapperStatus: TaskResult<T>['status'];
+  /** Raw payload `status` value when one is present. May be a domain status. */
+  payloadStatus?: string;
+  /** The task state callers should branch on. */
+  effectiveState: EffectiveTaskState;
+  /** Original result data, preserved as-is. */
+  data: T | undefined;
+  /** Advisory note when the helper had less context than it can accept. */
+  hint?: string;
+}
+
+const REDUCED_PRECISION_HINT =
+  'Pass options.toolName for maximum precision when reconciling payload status fields that can collide with domain statuses.';
+
+/**
+ * Reconcile a TaskResult wrapper status with an unwrapped AdCP response payload
+ * status. This follows the same task-envelope guard as ProtocolResponseParser:
+ * shared literals such as `canceled` and `failed` only count as task lifecycle
+ * statuses when the payload shape looks like a task envelope, not a domain
+ * object such as a media buy or creative.
+ */
+export function resolveTaskState<T>(
+  result: TaskResult<T>,
+  options: ResolveTaskStateOptions = {}
+): ResolvedTaskState<T> {
+  const wrapperStatus = result.status;
+  const data = result.data;
+  const payloadStatus = extractRawPayloadStatus(data);
+
+  if (wrapperStatus === 'failed' || wrapperStatus === 'governance-denied') {
+    return buildResolved(result, {
+      data,
+      payloadStatus,
+      effectiveState: wrapperStatus,
+      includeHint: !options.toolName,
+    });
+  }
+
+  const payloadTaskStatus = extractPayloadTaskStatus(data);
+  const effectiveState = payloadTaskStatus ?? normalizeWrapperStatus(wrapperStatus);
+
+  return buildResolved(result, {
+    data,
+    payloadStatus,
+    effectiveState,
+    includeHint: !options.toolName,
+  });
+}
+
+function buildResolved<T>(
+  result: TaskResult<T>,
+  fields: {
+    data: T | undefined;
+    payloadStatus: string | undefined;
+    effectiveState: EffectiveTaskState;
+    includeHint: boolean;
+  }
+): ResolvedTaskState<T> {
+  return {
+    wrapperStatus: result.status,
+    ...(fields.payloadStatus !== undefined ? { payloadStatus: fields.payloadStatus } : {}),
+    effectiveState: fields.effectiveState,
+    data: fields.data,
+    ...(fields.includeHint ? { hint: REDUCED_PRECISION_HINT } : {}),
+  };
+}
+
+function normalizeWrapperStatus(status: TaskResult<unknown>['status']): EffectiveTaskState {
+  if (status === 'completed') return ADCP_STATUS.COMPLETED;
+  if (status === 'working') return ADCP_STATUS.WORKING;
+  if (status === 'submitted') return ADCP_STATUS.SUBMITTED;
+  if (status === 'input-required') return ADCP_STATUS.INPUT_REQUIRED;
+  if (status === 'auth-required') return ADCP_STATUS.AUTH_REQUIRED;
+  if (status === 'deferred') return 'deferred';
+  if (status === 'failed') return ADCP_STATUS.FAILED;
+  if (status === 'governance-denied') return 'governance-denied';
+  return ADCP_STATUS.UNKNOWN;
+}
+
+function extractRawPayloadStatus(payload: unknown): string | undefined {
+  const direct = getObjectRecord(payload);
+  if (!direct) return undefined;
+  if (typeof direct.status === 'string') return direct.status;
+
+  const nested = getObjectRecord(direct.response);
+  if (typeof nested?.status === 'string') return nested.status;
+
+  const task = getObjectRecord(direct.task);
+  if (typeof task?.status === 'string') return task.status;
+
+  return undefined;
+}
+
+function extractPayloadTaskStatus(payload: unknown): EffectiveTaskState | undefined {
+  const direct = extractTaskStatusFromRecord(payload);
+  if (direct) return direct;
+
+  const record = getObjectRecord(payload);
+  if (!record) return undefined;
+
+  const nested = extractTaskStatusFromRecord(record.response);
+  if (nested) return nested;
+
+  return extractTaskStatusFromRecord(record.task);
+}
+
+function extractTaskStatusFromRecord(payload: unknown): ADCPStatus | undefined {
+  const envelopeStatus = extractAdcpTaskStatusFromPayload(payload);
+  if (envelopeStatus) return envelopeStatus;
+
+  const record = getObjectRecord(payload);
+  if (!record || !isTaskStatusPayload(record) || !isAdcpStatus(record.status)) return undefined;
+  return record.status;
+}
+
+function isTaskStatusPayload(record: Record<string, unknown>): boolean {
+  return (
+    typeof record.task_id === 'string' &&
+    (typeof record.task_type === 'string' ||
+      typeof record.protocol === 'string' ||
+      typeof record.created_at === 'string' ||
+      typeof record.updated_at === 'string')
+  );
+}
+
+function getObjectRecord(value: unknown): Record<string, unknown> | undefined {
+  if (value == null || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  return value as Record<string, unknown>;
+}

--- a/test/lib/public-barrel-exports.test.js
+++ b/test/lib/public-barrel-exports.test.js
@@ -18,10 +18,13 @@ import {
   CanonicalFormat,
   createLazyBackend,
   ensureGetProductsCacheScope,
+  resolveTaskState,
   type CanonicalFormatParams,
+  type EffectiveTaskState,
   type GetProductsResponse,
   type Placement,
   type ProductFormatDeclaration,
+  type ResolvedTaskState,
   type SyncCreativesPayload,
 } from '@adcp/sdk';
 import type {
@@ -94,6 +97,22 @@ void acceptsCanonicalResult;
 
 const scoped = ensureGetProductsCacheScope({ products: [], cache_scope: 'legacy' as string });
 const scope: 'public' | 'account' = scoped.cache_scope;
+const taskState = resolveTaskState({
+  success: true,
+  status: 'completed',
+  data: { status: 'submitted', task_id: 'task_1' },
+  metadata: {
+    taskId: 'client-task-1',
+    taskName: 'create_media_buy',
+    agent: { id: 'agent-1', name: 'Agent', protocol: 'mcp' },
+    responseTimeMs: 1,
+    timestamp: '2026-06-13T00:00:00Z',
+    clarificationRounds: 0,
+    status: 'completed',
+  },
+}, { toolName: 'create_media_buy' });
+const effectiveState: EffectiveTaskState = taskState.effectiveState;
+const resolvedTaskState: ResolvedTaskState<{ status: string; task_id: string }> = taskState;
 
 const required: RequireCacheScopeWhenProducts<{ products: unknown[]; cache_scope?: 'public' | 'account' }> = scoped;
 
@@ -122,6 +141,8 @@ void lazyBackend;
 void lazyBackendOptions;
 void serverLazyBackend;
 void scope;
+void effectiveState;
+void resolvedTaskState;
 void required;
 void generatedScope;
 void generatedInjectedScope;

--- a/test/lib/task-state.test.js
+++ b/test/lib/task-state.test.js
@@ -1,0 +1,101 @@
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+
+const { resolveTaskState } = require('../../dist/lib/index.js');
+
+function stubResult(status, overrides = {}) {
+  return {
+    success: status !== 'failed' && status !== 'governance-denied',
+    status,
+    metadata: {
+      taskId: 'client-task-1',
+      taskName: 'create_media_buy',
+      agent: { id: 'agent-1', name: 'Test Agent', protocol: 'mcp' },
+      responseTimeMs: 10,
+      timestamp: '2026-06-13T00:00:00Z',
+      clarificationRounds: 0,
+      status,
+    },
+    ...overrides,
+  };
+}
+
+describe('resolveTaskState()', () => {
+  test('wrapper completed with no payload status stays completed', () => {
+    const result = stubResult('completed', {
+      data: { media_buy_id: 'mb_1', packages: [] },
+    });
+
+    assert.deepStrictEqual(resolveTaskState(result, { toolName: 'create_media_buy' }), {
+      wrapperStatus: 'completed',
+      effectiveState: 'completed',
+      data: { media_buy_id: 'mb_1', packages: [] },
+    });
+  });
+
+  test('wrapper completed with task-envelope submitted status resolves to submitted', () => {
+    const result = stubResult('completed', {
+      data: { status: 'submitted', task_id: 'task_1', message: 'Queued' },
+    });
+
+    assert.deepStrictEqual(resolveTaskState(result, { toolName: 'create_media_buy' }), {
+      wrapperStatus: 'completed',
+      payloadStatus: 'submitted',
+      effectiveState: 'submitted',
+      data: { status: 'submitted', task_id: 'task_1', message: 'Queued' },
+    });
+  });
+
+  test('wrapper completed with domain-level canceled status stays completed', () => {
+    const result = stubResult('completed', {
+      data: {
+        media_buy_id: 'mb_canceled',
+        status: 'canceled',
+        affected_packages: [],
+      },
+    });
+
+    assert.deepStrictEqual(resolveTaskState(result, { toolName: 'update_media_buy' }), {
+      wrapperStatus: 'completed',
+      payloadStatus: 'canceled',
+      effectiveState: 'completed',
+      data: {
+        media_buy_id: 'mb_canceled',
+        status: 'canceled',
+        affected_packages: [],
+      },
+    });
+  });
+
+  test('wrapper working with absent data does not throw', () => {
+    const result = stubResult('working');
+
+    assert.deepStrictEqual(resolveTaskState(result, { toolName: 'create_media_buy' }), {
+      wrapperStatus: 'working',
+      effectiveState: 'working',
+      data: undefined,
+    });
+  });
+
+  test('wrapper failed wins over payload task status', () => {
+    const result = stubResult('failed', {
+      success: false,
+      error: 'Transport failed',
+      data: { status: 'completed', task_id: 'task_1' },
+    });
+
+    assert.deepStrictEqual(resolveTaskState(result, { toolName: 'create_media_buy' }), {
+      wrapperStatus: 'failed',
+      payloadStatus: 'completed',
+      effectiveState: 'failed',
+      data: { status: 'completed', task_id: 'task_1' },
+    });
+  });
+
+  test('surfaces hint when toolName is absent', () => {
+    const resolved = resolveTaskState(stubResult('completed', { data: { status: 'submitted', task_id: 'task_1' } }));
+
+    assert.strictEqual(resolved.effectiveState, 'submitted');
+    assert.match(resolved.hint, /toolName/);
+  });
+});


### PR DESCRIPTION
## Summary
- add public `resolveTaskState()` helper for reconciling `TaskResult.status` with AdCP payload task status
- share task-envelope/domain-status disambiguation with `ProtocolResponseParser`
- export helper/types from the root SDK barrel and add focused regression coverage

Closes #2232

## Expert review
- code review: no blocking findings; `tsc --project tsconfig.lib.json --noEmit --pretty false` and `git diff --check` passed
- protocol review: no blocking findings on envelope/domain status disambiguation or wrapper-failure precedence
- test review: no coverage blockers after staging new files

## Validation
- `npm run build:lib`
- `NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/lib/task-state.test.js test/lib/protocol-response-parser-status.test.js test/lib/protocol-response-parser-a2a-submitted.test.js test/lib/public-barrel-exports.test.js`
- pre-push hook: `npm run typecheck` and library build validation
- `npx commitlint --from origin/main --to HEAD --verbose`

## Notes
- left the pre-existing local `package-lock.json` modification out of this PR
