### PR TITLE
fix: skip absent equals capability gates

### DIFF
--- a/.changeset/skip-absent-equals-capability-gates.md
+++ b/.changeset/skip-absent-equals-capability-gates.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Skip storyboard `requires_capability.equals` gates when the agent omits the capability field.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/sdk",
-  "version": "9.0.0-beta.29",
+  "version": "9.0.0-beta.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/sdk",
-      "version": "9.0.0-beta.29",
+      "version": "9.0.0-beta.30",
       "license": "Apache-2.0",
       "workspaces": [
         ".",
@@ -1727,7 +1727,6 @@
       "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2",
         "generic-pool": "3.9.0",
@@ -2013,7 +2012,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
       "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2149,7 +2147,6 @@
       "integrity": "sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.4",
         "@typescript-eslint/types": "8.59.4",
@@ -2360,7 +2357,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3369,7 +3365,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.0.tgz",
       "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -3673,7 +3668,6 @@
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -4200,7 +4194,6 @@
       "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -5646,7 +5639,6 @@
       "integrity": "sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.13.0",
         "pg-pool": "^3.14.0",
@@ -6840,7 +6832,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7050,7 +7041,6 @@
       "integrity": "sha512-wKh+lhdmMFivMlc6vRRcMGXeGEHGU2g8a2CkPTJjJlwRf1iXbimWIPcFolCqe4E0d/FRtGszpIrsp3WLpDB8Pw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@gerrit0/mini-shiki": "^3.23.0",
         "lunr": "^2.3.9",
@@ -7087,7 +7077,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7418,7 +7407,6 @@
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -7438,7 +7426,7 @@
       "version": "6.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adcp/sdk": "^9.0.0-beta.29"
+        "@adcp/sdk": "^9.0.0-beta.30"
       },
       "bin": {
         "adcp": "bin/adcp.js"

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -253,9 +253,7 @@ function selectionForProbeSkip(reason: RunnerDetailedSkipReason, detail: string)
 /**
  * Walk a dotted key path (e.g. `"adcp.idempotency.supported"`) through a
  * nested object. Returns `undefined` when any segment is missing or the
- * intermediate value is not an object — the caller treats `undefined` as
- * "path absent" and does NOT skip the storyboard (absence means the agent
- * hasn't explicitly opted out, so failing the storyboard surfaces the gap).
+ * intermediate value is not an object.
  *
  * Exported for direct testing. Inline copies of this logic in test code
  * silently drift from the runtime when edge cases (null prototypes,
@@ -275,14 +273,14 @@ export function resolveCapabilityPath(raw: unknown, dottedPath: string): unknown
 /**
  * Evaluate a `requires_capability` predicate against the value already
  * resolved from the agent's raw capabilities. Returns `null` when the
- * predicate is satisfied (or unresolvable, per `equals` absence semantics)
- * and a human-readable detail string when the storyboard should be skipped.
+ * predicate is satisfied and a human-readable detail string when the
+ * storyboard should be skipped.
  *
  * Three matcher forms — see `Storyboard.requires_capability` for full semantics:
  *
- * - `equals: V` — skip only when `actual` is declared AND disagrees with `V`.
- *   Absent fields (`undefined`) RUN the storyboard so the failure surfaces
- *   an under-declared agent.
+ * - `equals: V` — scalar equality. `actual` must be declared and must equal
+ *   `V`. Absent fields (`undefined`) skip because the agent has not opted
+ *   into the capability or capability variant this storyboard tests.
  *
  * - `present: B` — presence is the load-bearing signal. `present: true`
  *   skips when the field is absent (treats `undefined` and `null` as absent).
@@ -330,19 +328,13 @@ export function evaluateCapabilityPredicate(predicate: RequiresCapabilityPredica
     }
     return null;
   }
-  // `equals` form — absence semantics are load-bearing. `actual === undefined`
-  // means the agent didn't declare the capability at all (field missing from
-  // `get_adcp_capabilities` response). We deliberately RUN the storyboard in
-  // that case rather than skip it: an agent that pre-dates the capability
-  // field hasn't explicitly opted out, so the storyboard's failures surface
-  // a real spec-coverage gap (under-declared agent) rather than a behavior
-  // the agent affirmatively refused. Skip ONLY when the agent declared a
-  // value AND that value disagrees with the predicate.
-  //
-  // Exception: a small set of optional opt-in features treat absence as
-  // unsupported. These storyboards must skip when the seller stays silent.
-  if (actual === undefined && isAbsenceMeansUnsupportedGate(predicate)) {
-    return `Capability predicate \`${predicate.path} === true\` not satisfied: ` + `agent did not declare support.`;
+  // `equals` form: absence means the agent did not declare the capability or
+  // capability variant this storyboard tests, so skip as unsupported.
+  if (actual === undefined) {
+    return (
+      `Capability predicate \`${predicate.path} === ${JSON.stringify(predicate.equals)}\` not satisfied: ` +
+      `agent did not declare support.`
+    );
   }
   if (actual !== undefined && actual !== predicate.equals) {
     return (
@@ -353,35 +345,18 @@ export function evaluateCapabilityPredicate(predicate: RequiresCapabilityPredica
   return null;
 }
 
-const ABSENCE_MEANS_UNSUPPORTED_EQUALS_TRUE_PATHS = new Set([
-  'media_buy.features.inline_creative_management',
-  'media_buy.supports_proposals',
-]);
-
-function isAbsenceMeansUnsupportedGate(
-  predicate: RequiresCapabilityPredicate
-): predicate is { path: string; equals: true } {
-  return (
-    'equals' in predicate &&
-    ABSENCE_MEANS_UNSUPPORTED_EQUALS_TRUE_PATHS.has(predicate.path) &&
-    predicate.equals === true
-  );
-}
-
 function evaluateRequiresCapabilityGate(
   predicate: RequiresCapabilityPredicate,
-  profile: AgentProfile | undefined
+  profile: AgentProfile | undefined,
+  agentTools?: readonly string[]
 ): string | null {
   const rawCaps = profile?.raw_capabilities;
   if (rawCaps !== undefined) {
     const actual = resolveCapabilityPath(rawCaps, predicate.path);
     return evaluateCapabilityPredicate(predicate, actual);
   }
-  if (
-    isAbsenceMeansUnsupportedGate(predicate) &&
-    profile !== undefined &&
-    !profile.tools.includes('get_adcp_capabilities')
-  ) {
+  const tools = agentTools ?? profile?.tools;
+  if ('equals' in predicate && tools !== undefined && !tools.includes('get_adcp_capabilities')) {
     return evaluateCapabilityPredicate(predicate, undefined);
   }
   return null;
@@ -389,12 +364,13 @@ function evaluateRequiresCapabilityGate(
 
 function collectPhaseCapabilitySkipDetails(
   storyboard: Storyboard,
-  profile: AgentProfile | undefined
+  profile: AgentProfile | undefined,
+  agentTools?: readonly string[]
 ): Map<string, string> {
   const skipDetails = new Map<string, string>();
   for (const phase of storyboard.phases) {
     if (!phase.requires_capability) continue;
-    const unmetDetail = evaluateRequiresCapabilityGate(phase.requires_capability, profile);
+    const unmetDetail = evaluateRequiresCapabilityGate(phase.requires_capability, profile, agentTools);
     if (unmetDetail !== null) {
       skipDetails.set(phase.id, unmetDetail);
     }
@@ -2048,7 +2024,7 @@ async function executeStoryboardPass(
   // tests (e.g. `adcp.idempotency.supported: false`), skip the whole storyboard
   // rather than producing a cascade of misleading per-phase failures.
   if (storyboard.requires_capability) {
-    const unmetDetail = evaluateRequiresCapabilityGate(storyboard.requires_capability, profile);
+    const unmetDetail = evaluateRequiresCapabilityGate(storyboard.requires_capability, profile, options.agentTools);
     if (unmetDetail !== null) {
       if (!callerOwnsClients) await closeConnections(options.protocol);
       return {
@@ -2228,7 +2204,7 @@ async function executeStoryboardPass(
   // an implementor reading the report can't tell "nothing tested" from
   // "everything passed".
   const hasExecutableSteps = storyboard.phases.some(p => p.steps.length > 0);
-  const phaseCapabilitySkipDetails = collectPhaseCapabilitySkipDetails(storyboard, profile);
+  const phaseCapabilitySkipDetails = collectPhaseCapabilitySkipDetails(storyboard, profile, options.agentTools);
   const skipControllerSeedingForPhaseGates = allExecutablePhasesCapabilitySkipped(
     storyboard,
     phaseCapabilitySkipDetails
@@ -3192,7 +3168,7 @@ async function runMultiPass(
       ...(options.agentTools ? {} : { agentTools: normalizeAgentToolNames(preSeedProfile.tools) }),
     };
   }
-  const phaseCapabilitySkipDetails = collectPhaseCapabilitySkipDetails(storyboard, preSeedProfile);
+  const phaseCapabilitySkipDetails = collectPhaseCapabilitySkipDetails(storyboard, preSeedProfile, options.agentTools);
   const preSeededResult = allExecutablePhasesCapabilitySkipped(storyboard, phaseCapabilitySkipDetails)
     ? null
     : await runControllerSeeding(preSeedClients[0]!, storyboard, options, preSeedContext);

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -118,11 +118,11 @@ export interface Storyboard {
    *
    * Two matcher forms — mutually exclusive on a single gate:
    *
-   * - `equals: V` — scalar equality. The path's resolved value must equal `V`
-   *   for the storyboard to run. When the path resolves to `undefined` (field
-   *   absent), the predicate is treated as unresolvable and the storyboard
-   *   runs — absence means the agent hasn't explicitly opted out, so failing
-   *   the storyboard surfaces the gap.
+   * - `equals: V` — scalar equality. The path's resolved value must be
+   *   declared and must equal `V` for the storyboard to run. When the path
+   *   resolves to `undefined` (field absent), the storyboard is skipped as
+   *   `capability_unsupported`; omitting a capability means the agent has not
+   *   opted into that behavior or variant.
    *
    * - `present: true|false` — presence-only matcher for spec capabilities whose
    *   contract is "presence of this object indicates support" (e.g.
@@ -145,13 +145,11 @@ export interface Storyboard {
    *   absence is the load-bearing signal — a seller that doesn't advertise
    *   the array hasn't opted into the variant this storyboard tests.
    *
-   * When `raw_capabilities` is not available (e.g. the agent doesn't expose
-   * `get_adcp_capabilities`), the gate is a no-op and the storyboard runs.
-   * Exception: optional opt-in feature gates such as
-   * `media_buy.features.inline_creative_management === true` and
-   * `media_buy.supports_proposals === true` treat missing raw capabilities as
-   * unsupported when the discovered profile does not expose
-   * `get_adcp_capabilities`, because sellers must advertise those features.
+   * When `raw_capabilities` is not available and the discovered profile does
+   * not expose `get_adcp_capabilities`, `equals` gates are treated as
+   * unsupported because there is no declaration proving the agent opted into
+   * the behavior. Other matcher forms remain a no-op without raw
+   * capabilities because their authored paths cannot be inspected.
    */
   requires_capability?: RequiresCapabilityPredicate;
   /** Scenario IDs that must pass alongside this storyboard (loaded from storyboards/scenarios/) */

--- a/test/lib/storyboard-capability-gate.test.js
+++ b/test/lib/storyboard-capability-gate.test.js
@@ -104,6 +104,33 @@ const proposalLifecycleGatedStoryboard = {
   ],
 };
 
+const creativeApprovalModeGatedStoryboard = {
+  id: 'creative_approval_mode_equals_gate_test',
+  version: '1.0.0',
+  title: 'Creative approval auto-approve mode (equals-gated)',
+  category: 'test',
+  summary: 'Runs only when media_buy.creative_approval_mode is auto_approve.',
+  narrative: '',
+  agent: { interaction_model: 'media_buy_seller', capabilities: [] },
+  caller: { role: 'buyer_agent' },
+  requires_capability: { path: 'media_buy.creative_approval_mode', equals: 'auto_approve' },
+  phases: [
+    {
+      id: 'creative_approval',
+      title: 'Creative approval phase',
+      steps: [
+        {
+          id: 'discover_products',
+          title: 'Discover products',
+          task: 'get_products',
+          sample_request: { brief: 'coffee' },
+          validations: [],
+        },
+      ],
+    },
+  ],
+};
+
 describe('requires_capability storyboard skip gate (#933)', () => {
   test('emits capability_unsupported skip when agent declares supported: false', async () => {
     // _profile bypasses discoverAgentProfile; no network calls made because
@@ -144,14 +171,110 @@ describe('requires_capability storyboard skip gate (#933)', () => {
     assert.equal(step.extraction.path, 'none');
   });
 
-  // Negative-path coverage (gate-passes and absent-capabilities) is provided
-  // by the resolveCapabilityPath unit tests below and the "RUN-not-skip"
-  // condition in the runner (`actual !== undefined && actual !== equals`).
-  // Earlier drafts had two integration-style smoke tests for these cases
-  // that ended with `assert.ok(true, '...')` after a try/catch — they
-  // passed regardless of gate behavior. Dropped: false-confidence tests
-  // are worse than no test, and the unit coverage below pins the actual
-  // contract that the gate evaluates.
+  test('equals gate skips when the capability path is absent', async () => {
+    const result = await runStoryboard('http://fake-local-99988', creativeApprovalModeGatedStoryboard, {
+      _profile: {
+        name: 'Test Agent (no creative approval mode declared)',
+        tools: ['get_adcp_capabilities', 'get_products'],
+        raw_capabilities: { media_buy: {} },
+      },
+    });
+
+    assert.equal(result.overall_passed, true);
+    assert.equal(result.skipped_count, 1);
+    assert.equal(result.passed_count, 0);
+    assert.equal(result.failed_count, 0);
+
+    const step = result.phases[0].steps[0];
+    assert.equal(step.step_id, 'capability_unsupported');
+    assert.equal(step.skipped, true);
+    assert.equal(step.skip_reason, 'capability_unsupported');
+    assert.equal(step.skip.reason, 'unsatisfied_contract');
+    assert.ok(step.skip.detail.includes('media_buy.creative_approval_mode'));
+    assert.ok(step.skip.detail.includes('auto_approve'));
+    assert.ok(step.skip.detail.includes('did not declare'));
+  });
+
+  test('equals gate runs when the declared value exactly matches', async () => {
+    const { client, calls } = makeCapabilityGateClient();
+    const result = await runStoryboard('https://example.invalid/mcp', creativeApprovalModeGatedStoryboard, {
+      protocol: 'mcp',
+      allow_http: false,
+      agentTools: ['get_adcp_capabilities', 'get_products'],
+      _profile: {
+        name: 'Test Agent (auto-approve creative approval)',
+        tools: ['get_adcp_capabilities', 'get_products'],
+        raw_capabilities: { media_buy: { creative_approval_mode: 'auto_approve' } },
+      },
+      _client: client,
+    });
+
+    assert.equal(result.overall_passed, true);
+    assert.equal(result.skipped_count, 0);
+    assert.equal(result.passed_count, 1);
+    assert.equal(result.failed_count, 0);
+    assert.equal(result.phases[0].phase_id, 'creative_approval');
+    assert.equal(result.phases[0].steps[0].skipped, undefined);
+    assert.equal(result.phases[0].steps[0].passed, true);
+    assert.deepEqual(calls.map(c => c.name), ['get_products']);
+  });
+
+  test('equals gate skips when the declared value mismatches', async () => {
+    const result = await runStoryboard('http://fake-local-99987', creativeApprovalModeGatedStoryboard, {
+      _profile: {
+        name: 'Test Agent (human-review creative approval)',
+        tools: ['get_adcp_capabilities', 'get_products'],
+        raw_capabilities: { media_buy: { creative_approval_mode: 'require_human' } },
+      },
+    });
+
+    assert.equal(result.overall_passed, true);
+    assert.equal(result.skipped_count, 1);
+    const step = result.phases[0].steps[0];
+    assert.equal(step.skipped, true);
+    assert.equal(step.skip_reason, 'capability_unsupported');
+    assert.ok(step.skip.detail.includes('media_buy.creative_approval_mode'));
+    assert.ok(step.skip.detail.includes('auto_approve'));
+    assert.ok(step.skip.detail.includes('require_human'));
+  });
+
+  test('equals gate skips when raw capabilities are unavailable', async () => {
+    const result = await runStoryboard('http://fake-local-99986', creativeApprovalModeGatedStoryboard, {
+      _profile: {
+        name: 'Test Agent (no raw capabilities available)',
+        tools: ['get_products'],
+      },
+    });
+
+    assert.equal(result.overall_passed, true);
+    assert.equal(result.skipped_count, 1);
+    const step = result.phases[0].steps[0];
+    assert.equal(step.skipped, true);
+    assert.equal(step.skip_reason, 'capability_unsupported');
+    assert.equal(step.skip.reason, 'unsatisfied_contract');
+    assert.ok(step.skip.detail.includes('media_buy.creative_approval_mode'));
+    assert.ok(step.skip.detail.includes('did not declare'));
+  });
+
+  test('equals gate skips with caller-owned client and agentTools but no profile', async () => {
+    const { client, calls } = makeCapabilityGateClient();
+    const result = await runStoryboard('https://example.invalid/mcp', creativeApprovalModeGatedStoryboard, {
+      protocol: 'mcp',
+      allow_http: false,
+      agentTools: ['get_products'],
+      _client: client,
+    });
+
+    assert.equal(result.overall_passed, true);
+    assert.equal(result.skipped_count, 1);
+    const step = result.phases[0].steps[0];
+    assert.equal(step.skipped, true);
+    assert.equal(step.skip_reason, 'capability_unsupported');
+    assert.equal(step.skip.reason, 'unsatisfied_contract');
+    assert.ok(step.skip.detail.includes('media_buy.creative_approval_mode'));
+    assert.ok(step.skip.detail.includes('did not declare'));
+    assert.deepEqual(calls, [], 'top-level gate should skip before dispatching');
+  });
 
   test('resolveCapabilityPath: dotted path traversal (real exported helper)', () => {
     // Tests the actual function the gate uses — not an inline copy. If
@@ -191,7 +314,7 @@ describe('requires_capability storyboard skip gate (#933)', () => {
     assert.ok(typeof result === 'function' || result === undefined);
   });
 
-  test('optional inline creative feature skips when omitted', async () => {
+  test('inline creative equals gate skips when omitted', async () => {
     const result = await runStoryboard('http://fake-local-99994', inlineCreativeGatedStoryboard, {
       _profile: {
         name: 'Test Agent (no inline creative feature declared)',
@@ -210,7 +333,7 @@ describe('requires_capability storyboard skip gate (#933)', () => {
     assert.ok(step.skip.detail.includes('did not declare'));
   });
 
-  test('optional inline creative feature skips when raw capabilities are unavailable', async () => {
+  test('inline creative equals gate skips when raw capabilities are unavailable', async () => {
     const result = await runStoryboard('http://fake-local-99993', inlineCreativeGatedStoryboard, {
       _profile: {
         name: 'Test Agent (no raw capabilities available)',
@@ -228,7 +351,7 @@ describe('requires_capability storyboard skip gate (#933)', () => {
     assert.ok(step.skip.detail.includes('did not declare'));
   });
 
-  test('optional proposal lifecycle feature skips when omitted', async () => {
+  test('proposal lifecycle equals gate skips when omitted', async () => {
     const result = await runStoryboard('http://fake-local-99990', proposalLifecycleGatedStoryboard, {
       _profile: {
         name: 'Test Agent (no proposal support declared)',
@@ -247,7 +370,7 @@ describe('requires_capability storyboard skip gate (#933)', () => {
     assert.ok(step.skip.detail.includes('did not declare'));
   });
 
-  test('optional proposal lifecycle feature skips when raw capabilities are unavailable', async () => {
+  test('proposal lifecycle equals gate skips when raw capabilities are unavailable', async () => {
     const result = await runStoryboard('http://fake-local-99989', proposalLifecycleGatedStoryboard, {
       _profile: {
         name: 'Test Agent (proposal capability unavailable)',
@@ -395,14 +518,6 @@ describe('requires_capability `present:` matcher (#1811)', () => {
     const presentTrue = { path: 'x.y', present: true };
     const presentFalse = { path: 'x.y', present: false };
     const equalsTrue = { path: 'x.y', equals: true };
-    const inlineFeatureEqualsTrue = {
-      path: 'media_buy.features.inline_creative_management',
-      equals: true,
-    };
-    const proposalFeatureEqualsTrue = {
-      path: 'media_buy.supports_proposals',
-      equals: true,
-    };
 
     // present: true
     assert.equal(evaluateCapabilityPredicate(presentTrue, undefined)?.includes('must be present'), true);
@@ -417,30 +532,17 @@ describe('requires_capability `present:` matcher (#1811)', () => {
     assert.equal(evaluateCapabilityPredicate(presentFalse, null), null);
     assert.equal(evaluateCapabilityPredicate(presentFalse, {})?.includes('must be absent'), true);
 
-    // equals semantics unchanged: absence is unresolvable, run the storyboard.
-    assert.equal(evaluateCapabilityPredicate(equalsTrue, undefined), null, 'absent: equals runs the storyboard');
+    // equals
+    assert.equal(
+      evaluateCapabilityPredicate(equalsTrue, undefined)?.includes('did not declare'),
+      true,
+      'absent equals gate skips as unsupported'
+    );
     assert.equal(evaluateCapabilityPredicate(equalsTrue, true), null);
     assert.equal(
       evaluateCapabilityPredicate(equalsTrue, false)?.includes('not satisfied'),
       true,
       'declared mismatch skips with `not satisfied` detail'
-    );
-    assert.equal(
-      evaluateCapabilityPredicate(inlineFeatureEqualsTrue, undefined)?.includes('did not declare'),
-      true,
-      'inline_creative_management is an optional feature gate: absent skips'
-    );
-    assert.equal(evaluateCapabilityPredicate(inlineFeatureEqualsTrue, true), null);
-    assert.equal(
-      evaluateCapabilityPredicate(proposalFeatureEqualsTrue, undefined)?.includes('did not declare'),
-      true,
-      'supports_proposals is an optional feature gate: absent skips'
-    );
-    assert.equal(evaluateCapabilityPredicate(proposalFeatureEqualsTrue, true), null);
-    assert.equal(
-      evaluateCapabilityPredicate(proposalFeatureEqualsTrue, false)?.includes('not satisfied'),
-      true,
-      'supports_proposals: false skips proposal lifecycle storyboards'
     );
   });
 });
@@ -595,6 +697,49 @@ const deterministicSessionPhaseGatedStoryboard = {
   ],
 };
 
+const creativeApprovalPhaseGatedStoryboard = {
+  id: 'phase_capability_gate_creative_approval_test',
+  version: '1.0.0',
+  title: 'Creative approval with equals-gated phase',
+  category: 'test',
+  summary: 'Skips creative approval phase when the mode is absent.',
+  narrative: '',
+  agent: { interaction_model: 'sync', capabilities: [] },
+  caller: { role: 'buyer_agent' },
+  phases: [
+    {
+      id: 'creative_approval',
+      title: 'Creative approval phase',
+      requires_capability: {
+        path: 'media_buy.creative_approval_mode',
+        equals: 'auto_approve',
+      },
+      steps: [
+        {
+          id: 'approval_step',
+          title: 'Exercise auto-approve flow',
+          task: 'get_products',
+          sample_request: { brief: 'auto-approve gated phase' },
+          validations: [],
+        },
+      ],
+    },
+    {
+      id: 'ungated_discovery',
+      title: 'Ungated discovery',
+      steps: [
+        {
+          id: 'get_products',
+          title: 'Discover products',
+          task: 'get_products',
+          sample_request: { brief: 'ungated discovery phase' },
+          validations: [],
+        },
+      ],
+    },
+  ],
+};
+
 function makeCapabilityGateClient(responder = () => ({ success: true, data: {} })) {
   const calls = [];
   const client = {
@@ -699,6 +844,55 @@ describe('phase-level requires_capability gate (#2224)', () => {
       ['get_products'],
       'only the ungated later phase should dispatch'
     );
+  });
+
+  test('phase-level equals gate skips when the capability path is absent', async () => {
+    const { client, calls } = makeCapabilityGateClient();
+    const result = await runStoryboard('https://example.invalid/mcp', creativeApprovalPhaseGatedStoryboard, {
+      protocol: 'mcp',
+      allow_http: false,
+      agentTools: ['get_adcp_capabilities', 'get_products'],
+      _profile: {
+        name: 'Test Agent (no creative approval mode declared)',
+        tools: ['get_adcp_capabilities', 'get_products'],
+        raw_capabilities: { media_buy: {} },
+      },
+      _client: client,
+    });
+
+    assert.equal(result.overall_passed, true);
+    assert.equal(result.phases.length, 2);
+    assert.equal(result.phases[0].phase_id, 'creative_approval');
+    assert.equal(result.phases[0].steps[0].skipped, true);
+    assert.equal(result.phases[0].steps[0].skip_reason, 'not_applicable');
+    assert.equal(result.phases[0].steps[0].skip.reason, 'not_applicable');
+    assert.ok(result.phases[0].steps[0].skip.detail.includes('media_buy.creative_approval_mode'));
+    assert.ok(result.phases[0].steps[0].skip.detail.includes('did not declare'));
+    assert.equal(result.phases[1].phase_id, 'ungated_discovery');
+    assert.equal(result.phases[1].steps[0].passed, true);
+    assert.deepEqual(calls.map(c => c.name), ['get_products']);
+    assert.deepEqual(calls.map(c => c.params.brief), ['ungated discovery phase']);
+  });
+
+  test('phase-level equals gate skips with caller-owned client and agentTools but no profile', async () => {
+    const { client, calls } = makeCapabilityGateClient();
+    const result = await runStoryboard('https://example.invalid/mcp', creativeApprovalPhaseGatedStoryboard, {
+      protocol: 'mcp',
+      allow_http: false,
+      agentTools: ['get_products'],
+      _client: client,
+    });
+
+    assert.equal(result.overall_passed, true);
+    assert.equal(result.phases.length, 2);
+    assert.equal(result.phases[0].phase_id, 'creative_approval');
+    assert.equal(result.phases[0].steps[0].skipped, true);
+    assert.equal(result.phases[0].steps[0].skip_reason, 'not_applicable');
+    assert.ok(result.phases[0].steps[0].skip.detail.includes('media_buy.creative_approval_mode'));
+    assert.ok(result.phases[0].steps[0].skip.detail.includes('did not declare'));
+    assert.equal(result.phases[1].steps[0].passed, true);
+    assert.deepEqual(calls.map(c => c.name), ['get_products']);
+    assert.deepEqual(calls.map(c => c.params.brief), ['ungated discovery phase']);
   });
 
   test('optional-only gated phases do not create a vacuous overall pass', async () => {

--- a/test/lib/storyboard-capability-gate.test.js
+++ b/test/lib/storyboard-capability-gate.test.js
@@ -216,7 +216,10 @@ describe('requires_capability storyboard skip gate (#933)', () => {
     assert.equal(result.phases[0].phase_id, 'creative_approval');
     assert.equal(result.phases[0].steps[0].skipped, undefined);
     assert.equal(result.phases[0].steps[0].passed, true);
-    assert.deepEqual(calls.map(c => c.name), ['get_products']);
+    assert.deepEqual(
+      calls.map(c => c.name),
+      ['get_products']
+    );
   });
 
   test('equals gate skips when the declared value mismatches', async () => {
@@ -870,8 +873,14 @@ describe('phase-level requires_capability gate (#2224)', () => {
     assert.ok(result.phases[0].steps[0].skip.detail.includes('did not declare'));
     assert.equal(result.phases[1].phase_id, 'ungated_discovery');
     assert.equal(result.phases[1].steps[0].passed, true);
-    assert.deepEqual(calls.map(c => c.name), ['get_products']);
-    assert.deepEqual(calls.map(c => c.params.brief), ['ungated discovery phase']);
+    assert.deepEqual(
+      calls.map(c => c.name),
+      ['get_products']
+    );
+    assert.deepEqual(
+      calls.map(c => c.params.brief),
+      ['ungated discovery phase']
+    );
   });
 
   test('phase-level equals gate skips with caller-owned client and agentTools but no profile', async () => {
@@ -891,8 +900,14 @@ describe('phase-level requires_capability gate (#2224)', () => {
     assert.ok(result.phases[0].steps[0].skip.detail.includes('media_buy.creative_approval_mode'));
     assert.ok(result.phases[0].steps[0].skip.detail.includes('did not declare'));
     assert.equal(result.phases[1].steps[0].passed, true);
-    assert.deepEqual(calls.map(c => c.name), ['get_products']);
-    assert.deepEqual(calls.map(c => c.params.brief), ['ungated discovery phase']);
+    assert.deepEqual(
+      calls.map(c => c.name),
+      ['get_products']
+    );
+    assert.deepEqual(
+      calls.map(c => c.params.brief),
+      ['ungated discovery phase']
+    );
   });
 
   test('optional-only gated phases do not create a vacuous overall pass', async () => {


### PR DESCRIPTION
Fixes #2250. This updates storyboard capability gates so absent `requires_capability.equals` paths are treated as unsupported instead of running the storyboard, including caller-owned client runs that only provide `agentTools`. It removes the old optional-feature special case, updates type comments, adds top-level and phase-level regressions, includes a patch changeset, and carries the lockfile refresh already in the workspace. Validated with `npm run build:lib`, `NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/lib/storyboard-capability-gate.test.js`, `git diff --check`, and the pre-push typecheck/build hook.