### PR TITLE
fix(unwrapper): treat flat error_code advisories as non-terminal

### DIFF
--- a/.changeset/advisory-flat-error-code-unwrapper.md
+++ b/.changeset/advisory-flat-error-code-unwrapper.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Treat flat `error_code` fields as advisory when the response also has a tool-specific success payload.

--- a/src/lib/utils/response-unwrapper.ts
+++ b/src/lib/utils/response-unwrapper.ts
@@ -191,7 +191,9 @@ export function isTerminalAdcpError(response: unknown, toolName?: string): boole
   const obj = response as Record<string, unknown> | null | undefined;
   if (obj?.status === 'failed' || obj?.status === 'rejected') return true;
   if (obj?.adcp_error && typeof (obj.adcp_error as { code?: unknown }).code === 'string') return true;
-  if (typeof obj?.error_code === 'string') return true;
+  if (typeof obj?.error_code === 'string') {
+    return !hasAdvisorySuccessPayload(obj, toolName);
+  }
   if (Array.isArray(obj?.errors) && obj.errors.length > 0) {
     return !hasAdvisorySuccessPayload(obj, toolName);
   }

--- a/test/lib/response-unwrapper.test.js
+++ b/test/lib/response-unwrapper.test.js
@@ -1227,6 +1227,24 @@ describe('Response Unwrapper', () => {
       assert.strictEqual(isAdcpSuccess(response, 'get_products'), false);
     });
 
+    test('task-aware terminal detection treats flat error_code as advisory on success payloads', () => {
+      const advisorySuccess = {
+        status: 'completed',
+        cache_scope: 'public',
+        products: [createTestProduct({ product_id: 'prod-advisory-flat-error-code' })],
+        error_code: 'FORMAT_DECLARATION_DIVERGENT',
+      };
+
+      assert.strictEqual(hasAdvisorySuccessPayload(advisorySuccess, 'get_products'), true);
+      assert.strictEqual(isTerminalAdcpError(advisorySuccess, 'get_products'), false);
+      assert.strictEqual(isTerminalAdcpError(advisorySuccess), true);
+
+      const mcpResponse = { structuredContent: advisorySuccess };
+      const result = unwrapProtocolResponse(mcpResponse, 'get_products', 'mcp');
+      assert.strictEqual(result.products[0].product_id, 'prod-advisory-flat-error-code');
+      assert.strictEqual(result.error_code, 'FORMAT_DECLARATION_DIVERGENT');
+    });
+
     test('should return false for adcp_error with non-string code', () => {
       assert.strictEqual(isAdcpError({ adcp_error: { code: 42 } }), false);
     });


### PR DESCRIPTION
## Summary
- gate flat `error_code` terminal detection with the same advisory success-payload check used for `errors[]`
- add a regression for get_products success payloads that echo a stray top-level `error_code`
- add a patch changeset

Closes #2230.

## Validation
- `npm run build:lib`
- `npm run format:check`
- `npm run typecheck`
- `NODE_ENV=test node --test test/lib/response-unwrapper.test.js`
- pre-push validation (typecheck + build)