### PR TITLE
feat(registry): add brand logo save helper

### DIFF
--- a/.changeset/registry-logo-save-and-creative-error-code.md
+++ b/.changeset/registry-logo-save-and-creative-error-code.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': minor
+---
+
+Add `RegistryClient.saveBrandLogo()` as the canonical AAO brand-logo helper, normalize list responses to `assets` while preserving the legacy `logos` alias, and bridge creative asset errors to canonical `code` with deprecated `error_code` compatibility.

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -32,6 +32,8 @@ export type {
   BrandLogoAsset,
   ListBrandLogosOptions,
   ListBrandLogosResponse,
+  SaveBrandLogoInput,
+  SaveBrandLogoResponse,
   UploadBrandLogoInput,
   UploadBrandLogoResponse,
   SavePropertyRequest,

--- a/src/lib/registry/index.ts
+++ b/src/lib/registry/index.ts
@@ -7,6 +7,8 @@ import type {
   SaveBrandResponse,
   ListBrandLogosOptions,
   ListBrandLogosResponse,
+  SaveBrandLogoInput,
+  SaveBrandLogoResponse,
   UploadBrandLogoInput,
   UploadBrandLogoResponse,
   SavePropertyRequest,
@@ -85,6 +87,8 @@ export type {
   BrandLogoAsset,
   ListBrandLogosOptions,
   ListBrandLogosResponse,
+  SaveBrandLogoInput,
+  SaveBrandLogoResponse,
   UploadBrandLogoInput,
   UploadBrandLogoResponse,
   SavePropertyRequest,
@@ -341,18 +345,27 @@ export class RegistryClient {
     return this.get(`${this.baseUrl}/api/brands/enrich?domain=${encodeURIComponent(domain)}`);
   }
 
-  /** List AAO brand logo assets for a domain, optionally filtered by tags. */
+  /**
+   * List AAO brand logo assets for a domain, optionally filtered by tags.
+   *
+   * @remarks
+   * Passing a raw `string[]` as the second argument is deprecated; pass
+   * `{ tags }` instead.
+   */
   async listBrandLogos(domain: string, options?: ListBrandLogosOptions | string[]): Promise<ListBrandLogosResponse> {
     if (!domain?.trim()) throw new Error('domain is required');
     const params = new URLSearchParams();
     const tags = Array.isArray(options) ? options : options?.tags;
     if (tags?.length) params.set('tags', tags.join(','));
     const qs = params.toString();
-    return this.get(`${this.baseUrl}/api/brands/${encodeURIComponent(domain)}/logos${qs ? `?${qs}` : ''}`);
+    const response = await this.get<Record<string, unknown>>(
+      `${this.baseUrl}/api/brands/${encodeURIComponent(domain)}/logos${qs ? `?${qs}` : ''}`
+    );
+    return this.normalizeBrandLogoList(response);
   }
 
-  /** Upload an AAO brand logo asset for review. Requires authentication. */
-  async uploadBrandLogo(input: UploadBrandLogoInput): Promise<UploadBrandLogoResponse> {
+  /** Save an AAO brand logo asset for review. Requires authentication. */
+  async saveBrandLogo(input: SaveBrandLogoInput): Promise<SaveBrandLogoResponse> {
     if (!input?.domain?.trim()) throw new Error('domain is required');
     if (!input?.filename?.trim()) throw new Error('filename is required');
     if (!input?.mimeType?.trim()) throw new Error('mimeType is required');
@@ -366,6 +379,11 @@ export class RegistryClient {
     form.append('tags', input.tags.join(','));
 
     return this.postFormData(`${this.baseUrl}/api/brands/${encodeURIComponent(input.domain)}/logos`, form);
+  }
+
+  /** @deprecated Use `saveBrandLogo()`. */
+  async uploadBrandLogo(input: UploadBrandLogoInput): Promise<UploadBrandLogoResponse> {
+    return this.saveBrandLogo(input);
   }
 
   /** Save or update a community brand. Requires authentication. */
@@ -1156,7 +1174,26 @@ export class RegistryClient {
     return this.parseJson(text);
   }
 
-  private toBrandLogoBlob(data: UploadBrandLogoInput['data'], mimeType: string): Blob {
+  private normalizeBrandLogoList(response: Record<string, unknown>): ListBrandLogosResponse {
+    const assets = Array.isArray(response.assets)
+      ? (response.assets as ListBrandLogosResponse['assets'])
+      : Array.isArray(response.logos)
+        ? (response.logos as ListBrandLogosResponse['assets'])
+        : [];
+    const logos = Array.isArray(response.logos) ? (response.logos as ListBrandLogosResponse['assets']) : assets;
+
+    const normalized: ListBrandLogosResponse = {
+      assets,
+      logos,
+    };
+    if (typeof response.domain === 'string') normalized.domain = response.domain;
+    if (response.stats != null && typeof response.stats === 'object' && !Array.isArray(response.stats)) {
+      normalized.stats = response.stats as Record<string, unknown>;
+    }
+    return normalized;
+  }
+
+  private toBrandLogoBlob(data: SaveBrandLogoInput['data'], mimeType: string): Blob {
     if (data instanceof Blob) return new Blob([data], { type: mimeType });
     if (data instanceof ArrayBuffer) return new Blob([data], { type: mimeType });
     if (ArrayBuffer.isView(data)) {

--- a/src/lib/registry/types.ts
+++ b/src/lib/registry/types.ts
@@ -408,8 +408,11 @@ export type BrandLogoAsset = ApprovedBrandLogoAsset | PendingBrandLogoAsset | Re
 
 /** Response from GET /api/brands/:domain/logos. */
 export interface ListBrandLogosResponse {
-  domain: string;
-  logos: BrandLogoAsset[];
+  domain?: string;
+  assets: BrandLogoAsset[];
+  stats?: Record<string, unknown>;
+  /** @deprecated Use `assets`. Preserved for older AAO responses and callers. */
+  logos?: BrandLogoAsset[];
 }
 
 /** Options for listing brand logo assets. */
@@ -419,7 +422,7 @@ export interface ListBrandLogosOptions {
 }
 
 /** Input for POST /api/brands/:domain/logos. */
-export interface UploadBrandLogoInput {
+export interface SaveBrandLogoInput {
   domain: string;
   data: Blob | Buffer | ArrayBuffer | ArrayBufferView;
   filename: string;
@@ -428,6 +431,9 @@ export interface UploadBrandLogoInput {
   note?: string;
 }
 
+/** @deprecated Use `SaveBrandLogoInput`. */
+export type UploadBrandLogoInput = SaveBrandLogoInput;
+
 /**
  * Response from POST /api/brands/:domain/logos.
  *
@@ -435,7 +441,7 @@ export interface UploadBrandLogoInput {
  * These endpoints are not yet present in the generated registry OpenAPI
  * types, so this hand-rolled shape mirrors the current AAO response contract.
  */
-export type UploadBrandLogoResponse = {
+export type SaveBrandLogoResponse = {
   success?: boolean;
   domain: string;
   logo_id: string;
@@ -445,6 +451,9 @@ export type UploadBrandLogoResponse = {
   message?: string;
   review_sla_hours?: number;
 };
+
+/** @deprecated Use `SaveBrandLogoResponse`. */
+export type UploadBrandLogoResponse = SaveBrandLogoResponse;
 
 // ====== Backward compatibility ======
 

--- a/src/lib/types/adcp.ts
+++ b/src/lib/types/adcp.ts
@@ -654,6 +654,22 @@ export interface PaginationOptions {
   cursor?: string;
 }
 
+export type ManageCreativeAssetsError = {
+  creative_id?: string;
+  message: string;
+} & (
+  | {
+      code: string;
+      /** @deprecated Use `code`. Preserved for older creative-library integrations. */
+      error_code?: string;
+    }
+  | {
+      code?: string;
+      /** @deprecated Use `code`. Preserved for older creative-library integrations. */
+      error_code: string;
+    }
+);
+
 // Response Types
 export interface ManageCreativeAssetsResponse {
   success: boolean;
@@ -684,11 +700,7 @@ export interface ManageCreativeAssetsResponse {
       archived: boolean;
     }[];
   };
-  errors?: {
-    creative_id?: string;
-    error_code: string;
-    message: string;
-  }[];
+  errors?: ManageCreativeAssetsError[];
 }
 
 export interface ListCreativesResponse {

--- a/src/lib/types/adcp.type-checks.ts
+++ b/src/lib/types/adcp.type-checks.ts
@@ -1,0 +1,46 @@
+// Type-only regressions for public AdCP compatibility shapes.
+//
+// Run with `npm run typecheck`. The library build excludes `*.type-checks.ts`.
+
+import type { ManageCreativeAssetsResponse } from './adcp';
+
+const creativeAssetErrorsWithCanonicalCode: ManageCreativeAssetsResponse = {
+  success: false,
+  action: 'upload',
+  errors: [
+    {
+      creative_id: 'creative_1',
+      code: 'INVALID_CREATIVE',
+      message: 'Creative failed validation',
+    },
+  ],
+};
+
+const creativeAssetErrorsWithLegacyCode: ManageCreativeAssetsResponse = {
+  success: false,
+  action: 'upload',
+  errors: [
+    {
+      creative_id: 'creative_1',
+      code: 'INVALID_CREATIVE',
+      error_code: 'INVALID_CREATIVE',
+      message: 'Creative failed validation',
+    },
+  ],
+};
+
+const creativeAssetErrorsWithLegacyOnlyCode: ManageCreativeAssetsResponse = {
+  success: false,
+  action: 'upload',
+  errors: [
+    {
+      creative_id: 'creative_1',
+      error_code: 'INVALID_CREATIVE',
+      message: 'Creative failed validation',
+    },
+  ],
+};
+
+void creativeAssetErrorsWithCanonicalCode;
+void creativeAssetErrorsWithLegacyCode;
+void creativeAssetErrorsWithLegacyOnlyCode;

--- a/test/e2e/registry-live.test.js
+++ b/test/e2e/registry-live.test.js
@@ -16,11 +16,11 @@ describe('RegistryClient live AAO brand logo endpoints', () => {
     const result = await client.listBrandLogos(READ_DOMAIN);
 
     assert.equal(result.domain, READ_DOMAIN);
-    assert.ok(Array.isArray(result.logos), 'logos must be an array');
-    if (ALLOW_EMPTY_READ_DOMAIN && result.logos.length === 0) return;
-    assert.ok(result.logos.length > 0, `expected live logos for ${READ_DOMAIN}`);
+    assert.ok(Array.isArray(result.assets), 'assets must be an array');
+    if (ALLOW_EMPTY_READ_DOMAIN && result.assets.length === 0) return;
+    assert.ok(result.assets.length > 0, `expected live logos for ${READ_DOMAIN}`);
 
-    for (const logo of result.logos) {
+    for (const logo of result.assets) {
       assert.equal(typeof logo.id, 'string');
       assert.ok(logo.id.length > 0, 'logo.id must be non-empty');
       assert.equal(typeof logo.content_type, 'string');
@@ -40,11 +40,11 @@ describe('RegistryClient live AAO brand logo endpoints', () => {
     const result = await client.listBrandLogos(READ_DOMAIN, { tags: ['primary'] });
 
     assert.equal(result.domain, READ_DOMAIN);
-    if (ALLOW_EMPTY_READ_DOMAIN && result.logos.length === 0) return;
-    assert.ok(result.logos.length > 0, `expected primary logos for ${READ_DOMAIN}`);
+    if (ALLOW_EMPTY_READ_DOMAIN && result.assets.length === 0) return;
+    assert.ok(result.assets.length > 0, `expected primary logos for ${READ_DOMAIN}`);
     assert.ok(
-      result.logos.every(logo => logo.tags.includes('primary')),
-      `expected every returned logo to include primary tag: ${JSON.stringify(result.logos)}`
+      result.assets.every(logo => logo.tags.includes('primary')),
+      `expected every returned logo to include primary tag: ${JSON.stringify(result.assets)}`
     );
   });
 
@@ -59,7 +59,7 @@ describe('RegistryClient live AAO brand logo endpoints', () => {
       const client = new RegistryClient({ baseUrl: BASE_URL, apiKey: process.env.ADCP_REGISTRY_API_KEY });
       const svg = '<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"><rect width="1" height="1"/></svg>';
 
-      const result = await client.uploadBrandLogo({
+      const result = await client.saveBrandLogo({
         domain: UPLOAD_DOMAIN,
         data: Buffer.from(svg, 'utf8'),
         filename: `adcp-sdk-e2e-${Date.now()}.svg`,
@@ -76,7 +76,7 @@ describe('RegistryClient live AAO brand logo endpoints', () => {
 
       const listed = await client.listBrandLogos(UPLOAD_DOMAIN, { tags: ['primary'] });
       assert.ok(
-        listed.logos.some(logo => logo.id === result.logo_id),
+        listed.assets.some(logo => logo.id === result.logo_id),
         `expected uploaded logo ${result.logo_id} in list response: ${JSON.stringify(listed)}`
       );
     }

--- a/test/lib/registry.test.js
+++ b/test/lib/registry.test.js
@@ -344,7 +344,7 @@ describe('RegistryClient', () => {
       let capturedUrl;
       restore = mockFetch(async url => {
         capturedUrl = url;
-        return new Response(JSON.stringify({ domain: 'acme.com', logos: [LOGO_ASSET] }), { status: 200 });
+        return new Response(JSON.stringify({ domain: 'acme.com', assets: [LOGO_ASSET] }), { status: 200 });
       });
 
       const client = new RegistryClient();
@@ -354,14 +354,15 @@ describe('RegistryClient', () => {
       assert.strictEqual(parsed.pathname, '/api/brands/acme.com/logos');
       assert.strictEqual(parsed.searchParams.get('tags'), 'primary,light-bg');
       assert.strictEqual(result.domain, 'acme.com');
-      assert.strictEqual(result.logos[0].id, 'logo_123');
+      assert.strictEqual(result.assets[0].id, 'logo_123');
+      assert.strictEqual(result.logos, result.assets);
     });
 
-    test('accepts options object for logo tag filters', async () => {
+    test('accepts options object for logo tag filters and preserves legacy logos responses', async () => {
       let capturedUrl;
       restore = mockFetch(async url => {
         capturedUrl = url;
-        return new Response(JSON.stringify({ domain: 'acme.com', logos: [] }), { status: 200 });
+        return new Response(JSON.stringify({ domain: 'acme.com', logos: [LOGO_ASSET] }), { status: 200 });
       });
 
       const client = new RegistryClient();
@@ -369,10 +370,11 @@ describe('RegistryClient', () => {
 
       const parsed = new URL(capturedUrl);
       assert.strictEqual(parsed.searchParams.get('tags'), 'dark-bg');
-      assert.deepStrictEqual(result.logos, []);
+      assert.strictEqual(result.assets[0].id, 'logo_123');
+      assert.strictEqual(result.logos[0].id, 'logo_123');
     });
 
-    test('uploads logo assets as multipart form data', async () => {
+    test('saves logo assets as multipart form data', async () => {
       restore = mockFetch(async (url, opts) => {
         assert.ok(url.includes('/api/brands/acme.com/logos'));
         assert.strictEqual(opts.method, 'POST');
@@ -401,7 +403,7 @@ describe('RegistryClient', () => {
       });
 
       const client = new RegistryClient({ apiKey: 'sk_test' });
-      const result = await client.uploadBrandLogo({
+      const result = await client.saveBrandLogo({
         domain: 'acme.com',
         data: Buffer.from('logo-bytes'),
         filename: 'logo.png',
@@ -413,6 +415,31 @@ describe('RegistryClient', () => {
       assert.strictEqual(result.logo_id, 'logo_pending');
       assert.strictEqual(result.review_status, 'pending');
       assert.strictEqual(result.review_sla_hours, 24);
+    });
+
+    test('keeps uploadBrandLogo as a deprecated alias', async () => {
+      restore = mockFetch(async () => {
+        return new Response(
+          JSON.stringify({
+            success: true,
+            domain: 'acme.com',
+            logo_id: 'logo_alias',
+            review_status: 'pending',
+          }),
+          { status: 200 }
+        );
+      });
+
+      const client = new RegistryClient({ apiKey: 'sk_test' });
+      const result = await client.uploadBrandLogo({
+        domain: 'acme.com',
+        data: Buffer.from('logo-bytes'),
+        filename: 'logo.png',
+        mimeType: 'image/png',
+        tags: ['primary'],
+      });
+
+      assert.strictEqual(result.logo_id, 'logo_alias');
     });
 
     test('accepts Blob and ArrayBuffer logo data', async () => {
@@ -432,14 +459,14 @@ describe('RegistryClient', () => {
       });
 
       const client = new RegistryClient({ apiKey: 'sk_test' });
-      await client.uploadBrandLogo({
+      await client.saveBrandLogo({
         domain: 'acme.com',
         data: new Blob(['blob-logo'], { type: 'text/plain' }),
         filename: 'blob.txt',
         mimeType: 'image/svg+xml',
         tags: ['primary'],
       });
-      await client.uploadBrandLogo({
+      await client.saveBrandLogo({
         domain: 'acme.com',
         data: new TextEncoder().encode('array-buffer-logo').buffer,
         filename: 'array-buffer.svg',
@@ -457,7 +484,7 @@ describe('RegistryClient', () => {
       const client = new RegistryClient();
       await assert.rejects(
         () =>
-          client.uploadBrandLogo({
+          client.saveBrandLogo({
             domain: 'acme.com',
             data: Buffer.from('logo'),
             filename: 'logo.png',
@@ -476,7 +503,7 @@ describe('RegistryClient', () => {
       await assert.rejects(() => client.listBrandLogos(''), { message: /domain is required/ });
       await assert.rejects(
         () =>
-          client.uploadBrandLogo({
+          client.saveBrandLogo({
             domain: 'acme.com',
             data: Buffer.from('logo'),
             filename: '',
@@ -487,7 +514,7 @@ describe('RegistryClient', () => {
       );
       await assert.rejects(
         () =>
-          client.uploadBrandLogo({
+          client.saveBrandLogo({
             domain: 'acme.com',
             data: Buffer.from('logo'),
             filename: 'logo.png',


### PR DESCRIPTION
## Summary
- add `RegistryClient.saveBrandLogo()` as the canonical AAO logo save helper while keeping `uploadBrandLogo()` as a deprecated alias
- normalize `listBrandLogos()` responses to `assets` and preserve the legacy `logos` alias for existing AAO responses/callers
- bridge `ManageCreativeAssetsResponse.errors[]` to canonical `code` while preserving legacy `error_code`-only compatibility

Closes #2235
Closes #2231

## Validation
- `npm run typecheck`
- `npm run format:check`
- `npm run build:lib`
- `NODE_ENV=test node --test test/lib/registry.test.js`
- pre-push validation hook
