### PR TITLE
fix: skip absent equals capability gates

### DIFF
--- a/.changeset/equals-gate-absence-7x.md
+++ b/.changeset/equals-gate-absence-7x.md
@@ -1,0 +1,5 @@
+---
+"@adcp/sdk": patch
+---
+
+Skip `requires_capability.equals` storyboards when the capability path is absent instead of running non-proposal gates against undeclared capability variants.

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -214,14 +214,14 @@ export function resolveCapabilityPath(raw: unknown, dottedPath: string): unknown
 /**
  * Evaluate a `requires_capability` predicate against the value already
  * resolved from the agent's raw capabilities. Returns `null` when the
- * predicate is satisfied (or unresolvable, per `equals` absence semantics)
- * and a human-readable detail string when the storyboard should be skipped.
+ * predicate is satisfied and a human-readable detail string when the
+ * storyboard should be skipped.
  *
  * Three matcher forms — see `Storyboard.requires_capability` for full semantics:
  *
- * - `equals: V` — skip only when `actual` is declared AND disagrees with `V`.
- *   Absent fields (`undefined`) RUN the storyboard so the failure surfaces
- *   an under-declared agent.
+ * - `equals: V` — scalar equality. `actual` must be declared and must equal
+ *   `V`. Absent fields (`undefined`) skip because the agent has not opted
+ *   into the capability or capability variant this storyboard tests.
  *
  * - `present: B` — presence is the load-bearing signal. `present: true`
  *   skips when the field is absent (treats `undefined` and `null` as absent).
@@ -275,19 +275,13 @@ export function evaluateCapabilityPredicate(
     }
     return null;
   }
-  // `equals` form — absence semantics are load-bearing. `actual === undefined`
-  // means the agent didn't declare the capability at all (field missing from
-  // `get_adcp_capabilities` response). We deliberately RUN the storyboard in
-  // that case rather than skip it: an agent that pre-dates the capability
-  // field hasn't explicitly opted out, so the storyboard's failures surface
-  // a real spec-coverage gap (under-declared agent) rather than a behavior
-  // the agent affirmatively refused. Skip ONLY when the agent declared a
-  // value AND that value disagrees with the predicate.
-  //
-  // Exception: optional proposal lifecycle storyboards require an explicit
-  // seller opt-in. Absent support is equivalent to unsupported.
-  if (actual === undefined && isProposalLifecycleGate(predicate)) {
-    return `Capability predicate \`${predicate.path} === true\` not satisfied: ` + `agent did not declare support.`;
+  // `equals` form: absence means the agent did not declare the capability or
+  // capability variant this storyboard tests, so skip as unsupported.
+  if (actual === undefined) {
+    return (
+      `Capability predicate \`${predicate.path} === ${JSON.stringify(predicate.equals)}\` not satisfied: ` +
+      `agent did not declare support.`
+    );
   }
   if (actual !== undefined && actual !== predicate.equals) {
     return (
@@ -296,13 +290,6 @@ export function evaluateCapabilityPredicate(
     );
   }
   return null;
-}
-
-function isProposalLifecycleGate(predicate: {
-  path: string;
-  equals?: boolean | string | number | null;
-}): predicate is { path: 'media_buy.supports_proposals'; equals: true } {
-  return predicate.path === 'media_buy.supports_proposals' && predicate.equals === true;
 }
 
 function buildSkip(reason: RunnerSkipReason, detail?: string): { reason: RunnerSkipReason; detail: string } {
@@ -1618,11 +1605,7 @@ async function executeStoryboardPass(
           notices: preflightNotices,
         };
       }
-    } else if (
-      isProposalLifecycleGate(cap) &&
-      profile !== undefined &&
-      !profile.tools.includes('get_adcp_capabilities')
-    ) {
+    } else if ('equals' in cap && profile !== undefined && !profile.tools.includes('get_adcp_capabilities')) {
       const unmetDetail = evaluateCapabilityPredicate(cap, undefined);
       if (unmetDetail !== null) {
         if (!options._client) await closeConnections(options.protocol);

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -100,13 +100,13 @@ export interface Storyboard {
    * `path` is a dotted key path into the raw `get_adcp_capabilities` response
    * (e.g. `"adcp.idempotency.supported"`).
    *
-   * Two matcher forms — mutually exclusive on a single gate:
+   * Three matcher forms — mutually exclusive on a single gate:
    *
-   * - `equals: V` — scalar equality. The path's resolved value must equal `V`
-   *   for the storyboard to run. When the path resolves to `undefined` (field
-   *   absent), the predicate is treated as unresolvable and the storyboard
-   *   runs — absence means the agent hasn't explicitly opted out, so failing
-   *   the storyboard surfaces the gap.
+   * - `equals: V` — scalar equality. The path's resolved value must be
+   *   declared and must equal `V` for the storyboard to run. When the path
+   *   resolves to `undefined` (field absent), the storyboard is skipped as
+   *   unsupported because the agent has not opted into the capability or
+   *   capability variant this storyboard tests.
    *
    * - `present: true|false` — presence-only matcher for spec capabilities whose
    *   contract is "presence of this object indicates support" (e.g.
@@ -114,10 +114,9 @@ export interface Storyboard {
    *   `path` to exist (non-null, non-undefined); empty object `{}` counts as
    *   present. `present: false` requires the value to be absent — useful for
    *   scenarios that only apply to agents that explicitly do NOT advertise a
-   *   capability. Unlike `equals`, absence is the load-bearing signal: when
-   *   `present: true` and the field is missing, the storyboard is skipped
-   *   (not_applicable) rather than run, because the seller's silence is the
-   *   spec-defined opt-out.
+   *   capability. Absence is the load-bearing signal: when `present: true` and
+   *   the field is missing, the storyboard is skipped (not_applicable) rather
+   *   than run, because the seller's silence is the spec-defined opt-out.
    *
    * - `contains: V` — array-membership matcher for capabilities whose
    *   declaration shape is an array of allowed values (e.g.
@@ -130,7 +129,8 @@ export interface Storyboard {
    *   the array hasn't opted into the variant this storyboard tests.
    *
    * When `raw_capabilities` is not available (e.g. the agent doesn't expose
-   * `get_adcp_capabilities`), the gate is a no-op and the storyboard runs.
+   * `get_adcp_capabilities`), `equals` gates skip as unsupported; other matcher
+   * forms are a no-op and the storyboard runs.
    */
   requires_capability?:
     | { path: string; equals: boolean | string | number | null }

--- a/test/lib/storyboard-capability-gate.test.js
+++ b/test/lib/storyboard-capability-gate.test.js
@@ -52,6 +52,32 @@ const disabledProfile = {
   raw_capabilities: { adcp: { idempotency: { supported: false } } },
 };
 
+const creativeApprovalModeGatedStoryboard = {
+  id: 'creative_approval_mode_equals_gate_test',
+  version: '1.0.0',
+  title: 'Creative approval mode (equals-gated)',
+  category: 'test',
+  summary: 'Runs only when media_buy.creative_approval_mode is auto_approve.',
+  narrative: '',
+  agent: { interaction_model: 'media_buy_seller', capabilities: [] },
+  caller: { role: 'buyer_agent' },
+  requires_capability: { path: 'media_buy.creative_approval_mode', equals: 'auto_approve' },
+  phases: [
+    {
+      id: 'creative_approval',
+      title: 'Creative approval phase',
+      steps: [
+        {
+          id: 'get_products',
+          title: 'Read products',
+          task: 'get_products',
+          sample_request: { brief: 'Find inventory for a test campaign.' },
+        },
+      ],
+    },
+  ],
+};
+
 const proposalLifecycleGatedStoryboard = {
   id: 'proposal_lifecycle_optional_feature_gate_test',
   version: '1.0.0',
@@ -118,14 +144,47 @@ describe('requires_capability storyboard skip gate (#933)', () => {
     assert.equal(step.extraction.path, 'none');
   });
 
-  // Negative-path coverage (gate-passes and absent-capabilities) is provided
-  // by the resolveCapabilityPath unit tests below and the "RUN-not-skip"
-  // condition in the runner (`actual !== undefined && actual !== equals`).
-  // Earlier drafts had two integration-style smoke tests for these cases
-  // that ended with `assert.ok(true, '...')` after a try/catch — they
-  // passed regardless of gate behavior. Dropped: false-confidence tests
-  // are worse than no test, and the unit coverage below pins the actual
-  // contract that the gate evaluates.
+  test('equals gate skips when the capability path is absent', async () => {
+    const result = await runStoryboard('http://fake-local-99988', creativeApprovalModeGatedStoryboard, {
+      _profile: {
+        name: 'Test Agent (no creative approval mode declared)',
+        tools: ['get_adcp_capabilities', 'get_products'],
+        raw_capabilities: { media_buy: {} },
+      },
+    });
+
+    assert.equal(result.overall_passed, true);
+    assert.equal(result.skipped_count, 1);
+    assert.equal(result.passed_count, 0);
+    assert.equal(result.failed_count, 0);
+
+    const step = result.phases[0].steps[0];
+    assert.equal(step.step_id, 'capability_unsupported');
+    assert.equal(step.skipped, true);
+    assert.equal(step.skip_reason, 'capability_unsupported');
+    assert.equal(step.skip.reason, 'unsatisfied_contract');
+    assert.ok(step.skip.detail.includes('media_buy.creative_approval_mode'));
+    assert.ok(step.skip.detail.includes('auto_approve'));
+    assert.ok(step.skip.detail.includes('did not declare'));
+  });
+
+  test('equals gate skips when raw capabilities are unavailable', async () => {
+    const result = await runStoryboard('http://fake-local-99986', creativeApprovalModeGatedStoryboard, {
+      _profile: {
+        name: 'Test Agent (no raw capabilities available)',
+        tools: ['get_products'],
+      },
+    });
+
+    assert.equal(result.overall_passed, true);
+    assert.equal(result.skipped_count, 1);
+    const step = result.phases[0].steps[0];
+    assert.equal(step.skipped, true);
+    assert.equal(step.skip_reason, 'capability_unsupported');
+    assert.equal(step.skip.reason, 'unsatisfied_contract');
+    assert.ok(step.skip.detail.includes('media_buy.creative_approval_mode'));
+    assert.ok(step.skip.detail.includes('did not declare'));
+  });
 
   test('resolveCapabilityPath: dotted path traversal (real exported helper)', () => {
     // Tests the actual function the gate uses — not an inline copy. If
@@ -350,8 +409,13 @@ describe('requires_capability `present:` matcher (#1811)', () => {
     assert.equal(evaluateCapabilityPredicate(presentFalse, null), null);
     assert.equal(evaluateCapabilityPredicate(presentFalse, {})?.includes('must be absent'), true);
 
-    // equals semantics unchanged: absence is unresolvable, run the storyboard.
-    assert.equal(evaluateCapabilityPredicate(equalsTrue, undefined), null, 'absent: equals runs the storyboard');
+    // equals semantics: absence skips because the agent has not opted into
+    // the capability or capability variant this storyboard tests.
+    assert.equal(
+      evaluateCapabilityPredicate(equalsTrue, undefined)?.includes('did not declare'),
+      true,
+      'absent: equals skips the storyboard'
+    );
     assert.equal(evaluateCapabilityPredicate(equalsTrue, true), null);
     assert.equal(
       evaluateCapabilityPredicate(equalsTrue, false)?.includes('not satisfied'),


### PR DESCRIPTION
## Summary

- generalize requires_capability.equals absence handling so absent capability paths skip as unsupported
- remove the proposal-only special case from the 7.x runner
- add regression coverage for media_buy.creative_approval_mode when the field or raw capabilities are absent

## Why

The published 7.x runner only skipped absent equals gates for media_buy.supports_proposals. Other selector gates, including media_buy.creative_approval_mode === auto_approve, could run against sellers that never declared the capability variant.

Addresses adcontextprotocol/adcp#5585.

## Validation

- npm ci
- npm run build:lib
- NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/lib/storyboard-capability-gate.test.js
- pre-push: format:check, typecheck, build:lib
