### PR TITLE
fix(compliance): emit stripped field notices

### DIFF
--- a/.changeset/input-schema-field-strip-notice.md
+++ b/.changeset/input-schema-field-strip-notice.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Surface input-schema field stripping as structured runner notices so compliance JSON output no longer hides stripped request fields in console warnings only.

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -1264,7 +1264,8 @@ export class SingleAgentClient {
 
     // Adapt request for v2 servers if needed
     const serverVersion = await this.detectServerVersion();
-    const adaptedParams = await this.adaptRequestForServerVersion(taskType, normalizedParams);
+    const inputSchemaStripLogs: any[] = [];
+    const adaptedParams = await this.adaptRequestForServerVersion(taskType, normalizedParams, inputSchemaStripLogs);
 
     // Symmetric to the pre-adapter v3 pass above: when the adapter
     // rewrote the request for a v2 server, warn-validate the adapted
@@ -1287,12 +1288,14 @@ export class SingleAgentClient {
     );
 
     // Merge collected drift into the executor's debug_logs so adopters
-    // reading result.debug_logs see post-adapter v2.5 warnings alongside
-    // the executor's own logs. On error paths the executor may not surface
-    // result.debug_logs at all — drift collected before the failure is
-    // dropped, matching the executor's own debug-log behavior.
-    if (v25DriftLogs.length > 0) {
-      result.debug_logs = [...(result.debug_logs ?? []), ...v25DriftLogs];
+    // reading result.debug_logs see input-schema stripping and post-adapter
+    // v2.5 warnings alongside the executor's own logs. On error paths the
+    // executor may not surface result.debug_logs at all — logs collected
+    // before the failure are dropped, matching the executor's own debug-log
+    // behavior.
+    const postAdapterLogs = [...inputSchemaStripLogs, ...v25DriftLogs];
+    if (postAdapterLogs.length > 0) {
+      result.debug_logs = [...(result.debug_logs ?? []), ...postAdapterLogs];
     }
 
     // Normalize response to v3 format
@@ -1326,7 +1329,7 @@ export class SingleAgentClient {
    *
    * Converts v3-style requests to v2 format when talking to v2 servers.
    */
-  private async adaptRequestForServerVersion(taskType: string, params: any): Promise<any> {
+  private async adaptRequestForServerVersion(taskType: string, params: any, debugLogs?: any[]): Promise<any> {
     // Get server version (cached after first call)
     const version = await this.detectServerVersion();
 
@@ -1413,6 +1416,17 @@ export class SingleAgentClient {
       console.warn(
         `[AdCP] Stripping fields not declared in agent "${this.agent.id}" schema for ${taskType}: ${stripped.join(', ')}`
       );
+      debugLogs?.push({
+        type: 'warning',
+        message: `Stripped fields not declared in agent tool input schema for ${taskType}: ${stripped.join(', ')}`,
+        timestamp: new Date().toISOString(),
+        details: {
+          code: 'input_schema_field_stripped',
+          task: taskType,
+          fields: stripped,
+          agent_id: this.agent.id,
+        },
+      });
     }
 
     return filtered;
@@ -2257,7 +2271,8 @@ export class SingleAgentClient {
       // Adapt request for the server's protocol version (e.g. strip v3-only
       // fields like buying_mode when talking to v2 agents).
       const serverVersion = await this.detectServerVersion();
-      const adaptedParams = await this.adaptRequestForServerVersion(taskName, normalizedParams);
+      const inputSchemaStripLogs: any[] = [];
+      const adaptedParams = await this.adaptRequestForServerVersion(taskName, normalizedParams, inputSchemaStripLogs);
 
       // Symmetric warn-only post-adapter pass against the v2.5 schema bundle.
       // Drift gets surfaced via result.metadata.debug_logs so adapter
@@ -2276,8 +2291,9 @@ export class SingleAgentClient {
         serverVersion
       );
 
-      if (v25DriftLogs.length > 0) {
-        result.debug_logs = [...(result.debug_logs ?? []), ...v25DriftLogs];
+      const postAdapterLogs = [...inputSchemaStripLogs, ...v25DriftLogs];
+      if (postAdapterLogs.length > 0) {
+        result.debug_logs = [...(result.debug_logs ?? []), ...postAdapterLogs];
       }
 
       // Normalize response to v3 format for consistent API surface

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -1441,6 +1441,56 @@ function collectCapabilityNotices(storyboard: Storyboard, rawCaps: unknown): Run
   return notices;
 }
 
+function collectInputSchemaFieldStripNotices(debugLogs: unknown, storyboardId: string): RunnerNotice[] {
+  if (!Array.isArray(debugLogs)) return [];
+  const notices: RunnerNotice[] = [];
+  const seen = new Set<string>();
+  for (const entry of debugLogs) {
+    if (!entry || typeof entry !== 'object') continue;
+    const details = (entry as { details?: unknown }).details;
+    if (!details || typeof details !== 'object') continue;
+    const record = details as Record<string, unknown>;
+    if (record.code !== 'input_schema_field_stripped') continue;
+    const task = typeof record.task === 'string' ? record.task : 'unknown_task';
+    const fields = Array.isArray(record.fields)
+      ? record.fields.filter((field): field is string => typeof field === 'string')
+      : [];
+    if (fields.length === 0) continue;
+    const key = `${task}\u0000${fields.join('\u0000')}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    notices.push({
+      severity: 'info',
+      code: 'input_schema_field_stripped',
+      message:
+        `Runner stripped fields not declared in the agent's tool input schema for ${task}: ` +
+        `${fields.join(', ')}. Fix the tool schema declaration or avoid sending unsupported fields.`,
+      docs_url: 'https://github.com/adcontextprotocol/adcp/issues/5495',
+      storyboard_ids: [storyboardId],
+    });
+  }
+  return notices;
+}
+
+function mergeRunnerNotices(notices: RunnerNotice[]): RunnerNotice[] {
+  const byCode = new Map<string, RunnerNotice>();
+  for (const notice of notices) {
+    const existing = byCode.get(notice.code);
+    if (existing) {
+      for (const sid of notice.storyboard_ids) {
+        if (!existing.storyboard_ids.includes(sid)) existing.storyboard_ids.push(sid);
+      }
+    } else {
+      byCode.set(notice.code, { ...notice, storyboard_ids: [...notice.storyboard_ids] });
+    }
+  }
+  return [...byCode.values()];
+}
+
+function collectStepNotices(phases: StoryboardPhaseResult[]): RunnerNotice[] {
+  return phases.flatMap(phase => phase.steps.flatMap(step => step.notices ?? []));
+}
+
 /**
  * Execute a single pass of the storyboard against the supplied replica URLs
  * using round-robin dispatch starting at `dispatchOffset`. Called directly
@@ -2164,7 +2214,7 @@ async function executeStoryboardPass(
         phasePassed = false;
         continue;
       }
-      const rawResult = await executeStep(assignment.client, step, phase.id, context, allSteps, options, {
+      const rawResult = await executeStep(assignment.client, step, storyboard.id, phase.id, context, allSteps, options, {
         contributions,
         priorStepResults,
         priorProbes,
@@ -2599,7 +2649,10 @@ async function executeStoryboardPass(
   // Use the fully-fetched profile for notice detection; fall back to pre-flight
   // notices (which used options._profile) when profile was not re-fetched in
   // this pass (standalone runner with options._profile pre-set skips the fetch).
-  const notices = collectCapabilityNotices(storyboard, profile?.raw_capabilities ?? options._profile?.raw_capabilities);
+  const notices = mergeRunnerNotices([
+    ...collectCapabilityNotices(storyboard, profile?.raw_capabilities ?? options._profile?.raw_capabilities),
+    ...collectStepNotices(phaseResults),
+  ]);
   const result: StoryboardResult = {
     storyboard_id: storyboard.id,
     storyboard_title: storyboard.title,
@@ -2957,7 +3010,7 @@ export async function runStoryboardStep(
   // previous step's result). Storyboard-level runs build this internally;
   // here the caller owns accumulation across stateless invocations.
   const contextProvenance = new Map<string, ContextProvenanceEntry>(Object.entries(options.context_provenance ?? {}));
-  const result = await executeStep(client, found.step, found.phaseId, context, allSteps, options, {
+  const result = await executeStep(client, found.step, storyboard.id, found.phaseId, context, allSteps, options, {
     contributions: new Set(),
     priorStepResults: new Map(),
     priorProbes: new Map(),
@@ -3035,6 +3088,7 @@ async function executeStep(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- client type varies (TestClient)
   client: any,
   step: StoryboardStep,
+  storyboardId: string,
   phaseId: string,
   context: StoryboardContext,
   allSteps: FlatStep[],
@@ -3547,6 +3601,10 @@ async function executeStep(
     payload: redactSecrets(request),
     ...(runState.agentUrl ? { url: runState.agentUrl } : {}),
   };
+  const inputSchemaStripNotices = collectInputSchemaFieldStripNotices(
+    (taskResult as { debug_logs?: unknown } | undefined)?.debug_logs,
+    storyboardId
+  );
 
   // AdCP 3.0.12 runner-output-contract `force_scenario_unsupported`: when a
   // comply_test_controller step calls a force_* scenario that the agent
@@ -3593,6 +3651,7 @@ async function executeStep(
         context,
         next,
         extraction: extractionFromTaskResult(taskResult),
+        ...(inputSchemaStripNotices.length > 0 && { notices: inputSchemaStripNotices }),
       };
     }
   }
@@ -3621,6 +3680,7 @@ async function executeStep(
       error: stepResult.error,
       next,
       extraction: { path: 'none' },
+      ...(inputSchemaStripNotices.length > 0 && { notices: inputSchemaStripNotices }),
     };
   }
 
@@ -4009,6 +4069,7 @@ async function executeStep(
     request: requestRecord,
     ...(responseRecord && { response_record: responseRecord }),
     extraction: extractionFromTaskResult(taskResult),
+    ...(inputSchemaStripNotices.length > 0 && { notices: inputSchemaStripNotices }),
     ...(hints.length > 0 && { hints }),
   };
 }

--- a/src/lib/testing/storyboard/task-map.ts
+++ b/src/lib/testing/storyboard/task-map.ts
@@ -132,23 +132,29 @@ export async function executeStoryboardTask(
   // submitted), use that data. Only poll when there's no data at all.
   const hasData = result.data !== undefined && result.data !== null;
   const isAsync = result.status === 'submitted' || result.status === 'working';
+  const prePollingDebugLogs = Array.isArray(result.debug_logs) ? [...result.debug_logs] : [];
+  let replacedByPolling = false;
   if (!hasData && isAsync && result.submitted?.waitForCompletion) {
     try {
       const timeout = new Promise<never>((_, reject) =>
         setTimeout(() => reject(new Error('Task polling timeout')), 30_000)
       );
       result = await Promise.race([result.submitted.waitForCompletion(2000), timeout]);
+      replacedByPolling = true;
     } catch {
       // Polling failed or timed out — return the intermediate result as-is
     }
   }
 
   const extractionPath = readExtractionPath(result.data);
+  const debugLogs = Array.isArray(result.debug_logs) ? result.debug_logs : [];
+  const mergedDebugLogs = replacedByPolling ? [...prePollingDebugLogs, ...debugLogs] : debugLogs;
   return {
     success: result.success ?? true,
     data: result.data,
     error: result.error,
     ...(result.adcpError && { adcp_error: result.adcpError }),
     ...(extractionPath !== undefined && { _extraction_path: extractionPath }),
+    ...(mergedDebugLogs.length > 0 && { debug_logs: mergedDebugLogs }),
   };
 }

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -1633,7 +1633,9 @@ export type NoticeCode =
   | 'request_signing.required'
   /** Agent advertises `webhook_signing.legacy_hmac_fallback: true`. Removed in
    *  AdCP 4.0 per `effective_version`. */
-  | 'webhook_signing.legacy_hmac_fallback.removed';
+  | 'webhook_signing.legacy_hmac_fallback.removed'
+  /** Runner stripped request fields missing from the agent's advertised tool input schema. */
+  | 'input_schema_field_stripped';
 
 /**
  * Severity of a runner notice. Deliberately separate from `ObservationSeverity`
@@ -1866,6 +1868,11 @@ export interface StoryboardStepResult {
   response_record?: RunnerResponseRecord;
   /** Which extraction path produced the parsed response (required per contract). */
   extraction: RunnerExtractionRecord;
+  /**
+   * Informational notices scoped to this step. These do not affect pass/fail.
+   * Storyboard-level `notices` aggregates step notices by code.
+   */
+  notices?: RunnerNotice[];
   /**
    * Non-fatal diagnostic hints the runner emitted alongside this step —
    * currently surfaces `context_value_rejected` when a request value came

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP SDK library version
  */
-export const LIBRARY_VERSION = '7.11.2';
+export const LIBRARY_VERSION = '7.11.5';
 
 /**
  * AdCP specification version this library is built for
@@ -68,10 +68,10 @@ export type AdcpVersion = (typeof COMPATIBLE_ADCP_VERSIONS)[number];
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '7.11.2',
+  library: '7.11.5',
   adcp: '3.0.18',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-06-16T07:26:36.307Z',
+  generatedAt: '2026-06-18T08:23:10.615Z',
 } as const;
 
 /**

--- a/test/lib/request-validation.test.js
+++ b/test/lib/request-validation.test.js
@@ -775,6 +775,7 @@ describe('v3 partial-schema field stripping', () => {
     ]);
 
     const capturedCalls = [];
+    let result;
     const originalCallTool = ProtocolClient.callTool;
     ProtocolClient.callTool = async (_agentConfig, toolName, args) => {
       capturedCalls.push({ toolName, args });
@@ -782,7 +783,7 @@ describe('v3 partial-schema field stripping', () => {
     };
 
     try {
-      await agent.getProducts({
+      result = await agent.getProducts({
         brand: { domain: 'fanta.com' },
         brief: 'love chocolate and have 20k to spend',
       });
@@ -803,6 +804,10 @@ describe('v3 partial-schema field stripping', () => {
       'brand should be stripped when not declared in agent schema'
     );
     assert.ok(getProductsCall.args.brief, 'brief should be preserved');
+    const stripLog = result.debug_logs.find(log => log.details?.code === 'input_schema_field_stripped');
+    assert.ok(stripLog, 'stripped fields should be surfaced in structured debug_logs');
+    assert.strictEqual(stripLog.details.task, 'get_products');
+    assert.deepStrictEqual(stripLog.details.fields, ['brand']);
   });
 
   test('should pass through all fields when v3 agent schema declares them', async () => {

--- a/test/lib/storyboard-notices.test.js
+++ b/test/lib/storyboard-notices.test.js
@@ -252,6 +252,135 @@ describe('RunnerNotice: webhook_signing.legacy_hmac_fallback.removed (#1704)', (
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Tests: input_schema_field_stripped
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('RunnerNotice: input_schema_field_stripped (#5495)', () => {
+  test('promotes structured field-strip debug logs to step and storyboard notices', async () => {
+    const sb = buildMinimalStoryboard({ id: 'input_schema_strip_notice' });
+    const client = {
+      executeTask: async taskName => ({
+        success: true,
+        status: 'completed',
+        data: { products: [] },
+        metadata: {
+          taskId: 'task-strip',
+          taskName,
+          agent: { id: 'partial-agent', name: 'Partial Agent', protocol: 'mcp' },
+          responseTimeMs: 1,
+          timestamp: new Date().toISOString(),
+          clarificationRounds: 0,
+          status: 'completed',
+        },
+        debug_logs: [
+          {
+            type: 'warning',
+            message: 'Stripped fields not declared in agent tool input schema for get_products: max_width, max_height',
+            timestamp: new Date().toISOString(),
+            details: {
+              code: 'input_schema_field_stripped',
+              task: 'get_products',
+              fields: ['max_width', 'max_height'],
+              agent_id: 'partial-agent',
+            },
+          },
+        ],
+      }),
+      resetContext: () => {},
+    };
+
+    const result = await runStoryboard('http://fake-local-99999', sb, {
+      _client: client,
+      _profile: profileClean,
+      agentTools: ['get_products'],
+    });
+
+    const step = result.phases[0].steps[0];
+    const stepNotice = step.notices?.find(n => n.code === 'input_schema_field_stripped');
+    assert.ok(stepNotice, 'step_result.notices should include the stripped-field notice');
+    assert.equal(stepNotice.severity, 'info');
+    assert.match(stepNotice.message, /get_products/);
+    assert.match(stepNotice.message, /max_width/);
+    assert.match(stepNotice.message, /max_height/);
+
+    const storyboardNotice = result.notices.find(n => n.code === 'input_schema_field_stripped');
+    assert.ok(storyboardNotice, 'StoryboardResult.notices should aggregate the step notice');
+    assert.deepEqual(storyboardNotice.storyboard_ids, ['input_schema_strip_notice']);
+    assert.equal(result.overall_passed, true, 'notice should not affect pass/fail');
+  });
+
+  test('preserves field-strip notices through async waitForCompletion polling path', async () => {
+    const sb = buildMinimalStoryboard({ id: 'input_schema_strip_async' });
+    let polled = false;
+    const client = {
+      executeTask: async taskName => ({
+        success: true,
+        status: 'submitted',
+        data: undefined,
+        metadata: {
+          taskId: 'task-async-strip',
+          taskName,
+          agent: { id: 'partial-agent', name: 'Partial Agent', protocol: 'mcp' },
+          responseTimeMs: 1,
+          timestamp: new Date().toISOString(),
+          clarificationRounds: 0,
+          status: 'submitted',
+        },
+        debug_logs: [
+          {
+            type: 'warning',
+            message: 'Stripped fields not declared in agent tool input schema for get_products: max_width',
+            timestamp: new Date().toISOString(),
+            details: {
+              code: 'input_schema_field_stripped',
+              task: 'get_products',
+              fields: ['max_width'],
+              agent_id: 'partial-agent',
+            },
+          },
+        ],
+        submitted: {
+          waitForCompletion: async () => {
+            polled = true;
+            return {
+              success: true,
+              status: 'completed',
+              data: { products: [] },
+              metadata: {
+                taskId: 'task-async-strip',
+                taskName,
+                agent: { id: 'partial-agent', name: 'Partial Agent', protocol: 'mcp' },
+                responseTimeMs: 2,
+                timestamp: new Date().toISOString(),
+                clarificationRounds: 0,
+                status: 'completed',
+              },
+            };
+          },
+        },
+      }),
+      resetContext: () => {},
+    };
+
+    const result = await runStoryboard('http://fake-local-99999', sb, {
+      _client: client,
+      _profile: profileClean,
+      agentTools: ['get_products'],
+    });
+
+    assert.ok(polled, 'waitForCompletion should have been called');
+    const step = result.phases[0].steps[0];
+    const stepNotice = step.notices?.find(n => n.code === 'input_schema_field_stripped');
+    assert.ok(stepNotice, 'step_result.notices must survive the async polling replacement');
+
+    const storyboardNotice = result.notices.find(n => n.code === 'input_schema_field_stripped');
+    assert.ok(storyboardNotice, 'StoryboardResult.notices must aggregate pre-polling strip notices');
+    assert.deepEqual(storyboardNotice.storyboard_ids, ['input_schema_strip_async']);
+    assert.equal(result.overall_passed, true, 'notice must not affect pass/fail');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Tests: multiple notices in one run
 // ─────────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Backports the structured `input_schema_field_stripped` compliance notice fix from main to the AdCP 3.0 / 7.11.x release branch.

## Why

adcontextprotocol/adcp#5495 remains open because `@adcp/sdk@7.11.5` only prints stripped input-schema fields as console warnings. CI JSON reports still miss the signal, so storyboard scenarios can appear to pass without exercising fields the runner sent.

## Changes

- Emits structured `debug_logs` entries when `SingleAgentClient` strips fields missing from an agent tool `inputSchema`.
- Preserves pre-polling strip logs when an async storyboard step is replaced by `waitForCompletion` output.
- Promotes strip logs to step-level `notices` and aggregates them into `StoryboardResult.notices`.
- Adds regression coverage for sync and async storyboard paths.
- Syncs generated `src/lib/version.ts` with the current 7.11.5 package version, matching the branch build output.

## Validation

- `npm run build`
- `NODE_ENV=test node --test-timeout=60000 --test-force-exit --test-name-pattern "input_schema_field_stripped|v3 partial-schema field stripping" --test test/lib/request-validation.test.js test/lib/storyboard-notices.test.js`
- `echo "fix(compliance): emit stripped field notices" | npx commitlint --config commitlint.config.js`
- `npx commitlint --from origin/backport-2114-adcp-3.0 --to HEAD --verbose`
- `npm pack --silent --pack-destination .tmp-pack`, then tarball grep confirmed `input_schema_field_stripped` appears in packed `dist/lib/core/SingleAgentClient.js` and `dist/lib/testing/storyboard/runner.js`.
