### PR TITLE
feat: add transport diagnostics hook

### DIFF
--- a/.changeset/clean-taxis-observe.md
+++ b/.changeset/clean-taxis-observe.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': minor
+---
+
+Add `onTransportActivity` diagnostics for sanitized outbound MCP/A2A transport request, response, and failure events.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/sdk",
-  "version": "9.0.0-beta.31",
+  "version": "9.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/sdk",
-      "version": "9.0.0-beta.31",
+      "version": "9.0.0",
       "license": "Apache-2.0",
       "workspaces": [
         ".",
@@ -21,7 +21,7 @@
         "secure-json-parse": "^4.1.0",
         "structured-headers": "^2.0.2",
         "tldts": "^7.0.29",
-        "undici": "^6.25.0",
+        "undici": "^6.27.0",
         "ws": "^8.21.0",
         "yaml": "^2.7.1"
       },
@@ -7117,9 +7117,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
-      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"
@@ -7426,7 +7426,7 @@
       "version": "6.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adcp/sdk": "^9.0.0-beta.31"
+        "@adcp/sdk": "^9.0.0"
       },
       "bin": {
         "adcp": "bin/adcp.js"
@@ -7434,10 +7434,10 @@
     },
     "packages/eslint-plugin": {
       "name": "@adcp/eslint-plugin",
-      "version": "0.1.3-beta.1",
+      "version": "0.1.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adcp/sdk": "^9.0.0-beta.22",
+        "@adcp/sdk": "^9.0.0",
         "@typescript-eslint/utils": "^8.0.0"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -399,7 +399,7 @@
     "secure-json-parse": "^4.1.0",
     "structured-headers": "^2.0.2",
     "tldts": "^7.0.29",
-    "undici": "^6.25.0",
+    "undici": "^6.27.0",
     "ws": "^8.21.0",
     "yaml": "^2.7.1"
   },

--- a/src/lib/core/GovernanceMiddleware.ts
+++ b/src/lib/core/GovernanceMiddleware.ts
@@ -130,7 +130,8 @@ export class GovernanceMiddleware {
      * to the SDK constant — same shape as a no-pin call.
      */
     private adcpVersion?: string,
-    private versionEnvelope?: import('../protocols').VersionEnvelopeMode
+    private versionEnvelope?: import('../protocols').VersionEnvelopeMode,
+    private onTransportActivity?: import('../protocols').TransportActivityHandler
   ) {}
 
   /**
@@ -216,6 +217,7 @@ export class GovernanceMiddleware {
         debugLogs,
         adcpVersion: this.adcpVersion,
         ...(this.versionEnvelope !== undefined && { versionEnvelope: this.versionEnvelope }),
+        onTransportActivity: this.onTransportActivity,
       });
 
       // Unwrap protocol response (MCP text content, structuredContent, A2A artifacts)
@@ -338,6 +340,12 @@ export class GovernanceMiddleware {
           debugLogs,
           adcpVersion: this.adcpVersion,
           ...(this.versionEnvelope !== undefined && { versionEnvelope: this.versionEnvelope }),
+          onTransportActivity: this.onTransportActivity,
+          transportActivityContext: {
+            operationId: checkId,
+            taskId: checkId,
+            idempotencyKey,
+          },
         }
       );
 

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -352,6 +352,14 @@ export interface SingleAgentClientConfig extends ConversationConfig {
   /** Activity callback for observability (logging, UI updates, etc) */
   onActivity?: (activity: Activity) => void | Promise<void>;
   /**
+   * Transport-level diagnostics callback for outbound HTTP requests.
+   *
+   * Receives sanitized request/response/failure events from the SDK's
+   * protocol fetch layer. Header maps are allowlisted/redacted and URLs have
+   * credentials, query strings, and fragments stripped before emission.
+   */
+  onTransportActivity?: import('../protocols').TransportActivityHandler;
+  /**
    * Task completion handlers — called for both sync responses and webhook
    * completions.
    *
@@ -670,6 +678,7 @@ export class SingleAgentClient {
         ...(config.validation?.responses != null && { responses: config.validation.responses }),
       },
       onActivity: config.onActivity,
+      onTransportActivity: config.onTransportActivity,
       governance: config.governance,
       adcpVersion: this.resolvedAdcpVersion,
       ...(config.wireAdcpVersion !== undefined && { wireAdcpVersion: config.wireAdcpVersion }),

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -311,6 +311,8 @@ export class TaskExecutor {
       filterInvalidProducts?: boolean;
       /** Global activity callback for observability */
       onActivity?: (activity: Activity) => void | Promise<void>;
+      /** Transport-level diagnostics callback for outbound HTTP requests. */
+      onTransportActivity?: import('../protocols').TransportActivityHandler;
       /** Governance configuration for buyer-side campaign governance */
       governance?: GovernanceConfig;
       /**
@@ -342,7 +344,8 @@ export class TaskExecutor {
         config.governance,
         config.onActivity,
         config.adcpVersion,
-        config.versionEnvelope
+        config.versionEnvelope,
+        config.onTransportActivity
       );
     }
     const modes = resolveValidationModes(config.validation);
@@ -602,6 +605,13 @@ export class TaskExecutor {
         ...(this.config.wireAdcpVersion !== undefined && { wireAdcpVersion: this.config.wireAdcpVersion }),
         ...(this.config.versionEnvelope !== undefined && { versionEnvelope: this.config.versionEnvelope }),
         transport: options.transport ?? this.config.transport,
+        onTransportActivity: this.config.onTransportActivity,
+        transportActivityContext: {
+          operationId: taskId,
+          taskId: options.taskId ?? taskId,
+          contextId: options.contextId,
+          idempotencyKey,
+        },
       });
 
       // Emit protocol_response activity
@@ -1340,7 +1350,13 @@ export class TaskExecutor {
     if (agent.protocol === 'mcp') {
       const authToken = getAuthToken(agent);
       try {
-        return await listMCPTasks(agent.agent_uri, authToken);
+        return await listMCPTasks(agent.agent_uri, authToken, undefined, {
+          transport: transport ?? this.config.transport,
+          onTransportActivity: this.config.onTransportActivity,
+          transportActivityContext: {
+            agentId: agent.id,
+          },
+        });
       } catch (err) {
         if (is401Error(err)) throw err;
         // Fall through to tool call if protocol method is not supported
@@ -1356,6 +1372,7 @@ export class TaskExecutor {
         ...(this.config.wireAdcpVersion !== undefined && { wireAdcpVersion: this.config.wireAdcpVersion }),
         ...(this.config.versionEnvelope !== undefined && { versionEnvelope: this.config.versionEnvelope }),
         transport: transport ?? this.config.transport,
+        onTransportActivity: this.config.onTransportActivity,
       }
     )) as Record<string, unknown>;
     return (response.tasks as TaskInfo[]) || [];
@@ -1419,6 +1436,10 @@ export class TaskExecutor {
         ...(this.config.wireAdcpVersion !== undefined && { wireAdcpVersion: this.config.wireAdcpVersion }),
         ...(this.config.versionEnvelope !== undefined && { versionEnvelope: this.config.versionEnvelope }),
         transport: transport ?? this.config.transport,
+        onTransportActivity: this.config.onTransportActivity,
+        transportActivityContext: {
+          taskId,
+        },
       }
     )) as Record<string, unknown>;
     // We don't run `extractResponseData` here: that helper's
@@ -1725,6 +1746,12 @@ export class TaskExecutor {
         ...(this.config.wireAdcpVersion !== undefined && { wireAdcpVersion: this.config.wireAdcpVersion }),
         ...(this.config.versionEnvelope !== undefined && { versionEnvelope: this.config.versionEnvelope }),
         transport: options.transport ?? this.config.transport,
+        onTransportActivity: this.config.onTransportActivity,
+        transportActivityContext: {
+          operationId: taskId,
+          taskId,
+          contextId,
+        },
       }
     );
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1169,9 +1169,17 @@ export {
   closeMCPConnections,
   closeOAuthConnections,
   bundleSupportsAdcpVersionField,
+  sanitizeTransportHeaders,
+  sanitizeTransportUrl,
 } from './protocols';
 export { toReleasePrecisionWire, validateAdcpVersionWire } from './validation/schema-loader';
-export type { CallToolOptions, TransportOptions } from './protocols';
+export type {
+  CallToolOptions,
+  TransportActivity,
+  TransportActivityContext,
+  TransportActivityHandler,
+  TransportOptions,
+} from './protocols';
 
 // ====== WIRE VERSION HELPERS (NAMESPACE) ======
 // Grouped re-exports of the three AdCP `adcp_version` envelope helpers

--- a/src/lib/protocols/a2a.ts
+++ b/src/lib/protocols/a2a.ts
@@ -19,6 +19,7 @@ import type { AgentConfig } from '../types/adcp';
 import { redactIdempotencyKeyInArgs } from '../utils/idempotency';
 import { wrapFetchWithCapture } from './rawResponseCapture';
 import { wrapFetchWithSizeLimit } from './responseSizeLimit';
+import { wrapFetchWithTransportDiagnostics } from './transportDiagnostics';
 import { getLatestA2ADataPartFromResponse } from '../utils/a2a-artifacts';
 
 if (!A2AClient) {
@@ -300,7 +301,9 @@ function buildFetchImpl(authToken: string | undefined) {
 
   // Innermost wrapper: enforce response body size cap from the active
   // `responseSizeLimitStorage` slot. Pass-through when no slot is set.
-  const networkFetch = wrapFetchWithSizeLimit((input, init) => fetch(input as any, init));
+  const networkFetch = wrapFetchWithTransportDiagnostics(
+    wrapFetchWithSizeLimit((input, init) => fetch(input as any, init))
+  );
 
   // Inner fetch handles auth/header injection and 401 detection. If the
   // agent has request-signing configured, we wrap it with the AdCP signing

--- a/src/lib/protocols/index.ts
+++ b/src/lib/protocols/index.ts
@@ -56,6 +56,18 @@ import { ConfigurationError } from '../errors';
 import { resolveBundleKey, toReleasePrecisionWire, validateAdcpVersionWire } from '../validation/schema-loader';
 import { buildAgentSigningContext, CAPABILITY_OP, ensureCapabilityLoaded } from '../signing/client';
 import { withResponseSizeLimit } from './responseSizeLimit';
+import {
+  withTransportDiagnostics,
+  type TransportActivityHandler as TransportActivityHandlerFn,
+} from './transportDiagnostics';
+
+export {
+  sanitizeTransportHeaders,
+  sanitizeTransportUrl,
+  withTransportDiagnostics,
+  wrapFetchWithTransportDiagnostics,
+} from './transportDiagnostics';
+export type { TransportActivity, TransportActivityContext, TransportActivityHandler } from './transportDiagnostics';
 
 export type VersionEnvelopeMode = 'auto' | 'none' | 'major-only';
 
@@ -289,6 +301,18 @@ export interface CallToolOptions {
    * matching field on the client constructor's `transport` option.
    */
   transport?: TransportOptions;
+  /** Transport-level diagnostics callback for outbound HTTP requests. */
+  onTransportActivity?: TransportActivityHandlerFn;
+  /**
+   * Correlation metadata attached to transport diagnostics events emitted
+   * while this protocol call is active.
+   */
+  transportActivityContext?: {
+    operationId?: string;
+    taskId?: string;
+    contextId?: string;
+    idempotencyKey?: string;
+  };
 }
 
 /**
@@ -320,6 +344,8 @@ export class ProtocolClient {
       wireAdcpVersion,
       versionEnvelope: versionEnvelopeMode = 'auto',
       transport,
+      onTransportActivity,
+      transportActivityContext,
     } = options;
     // Per-instance version envelope. Throws on unparseable pins via
     // `resolveWireMajor`; construction-time `resolveAdcpVersion` is the
@@ -337,212 +363,225 @@ export class ProtocolClient {
     // cap applies regardless of which path (MCP / A2A / OAuth refresh) the
     // call ends up taking. No-op when the cap is unset or non-positive.
     return withResponseSizeLimit(transport?.maxResponseBytes, () =>
-      withSpan(
-        `adcp.${agent.protocol}.call_tool`,
+      withTransportDiagnostics(
         {
-          'adcp.agent_id': agent.id,
-          'adcp.protocol': agent.protocol,
-          'adcp.tool': toolName,
-          'http.url': agent.agent_uri,
+          agentId: agent.id,
+          protocol: agent.protocol,
+          tool: toolName,
+          taskType: toolName,
+          ...transportActivityContext,
+          onTransportActivity,
         },
-        async () => {
-          // In-process MCP path: pre-connected client, no HTTP transport.
-          // Idempotency injection, schema validation, and governance middleware all
-          // still apply (they run in SingleAgentClient above this call). We skip
-          // URL validation, OAuth refresh, and signing — none apply in-process.
-          if (agent.protocol === 'mcp' && agent._inProcessMcpClient) {
-            const inProcArgs = applyVersionEnvelope(args, versionEnvelope);
-            return callMCPToolWithClient(agent._inProcessMcpClient, toolName, inProcArgs, debugLogs);
-          }
-
-          validateAgentUrl(agent.agent_uri);
-
-          // OAuth 2.0 client credentials (RFC 6749 §4.4): re-exchange the
-          // secret for a fresh access token whenever the cached one is within
-          // its expiration skew. Runs before every call so mid-session expiry
-          // can't leave the caller with a stale bearer. No-op if the agent
-          // doesn't declare client credentials. Cheap on warm cache (single
-          // `Date.now()` compare); a single POST to the token endpoint on miss.
-          //
-          // `allowPrivateIp` inherits the trust the caller already placed in
-          // `agent.agent_uri` — if they're making a call to a private-IP agent,
-          // they've authorized this process to talk to private-IP hosts, so
-          // the token endpoint on the same network is reachable too. Public
-          // agent URLs with private-IP token endpoints still require an
-          // explicit opt-in via the library API.
-          if (agent.oauth_client_credentials) {
-            const ccStorage = getAgentStorage(agent);
-            const allowPrivateIp = isLikelyPrivateUrl(agent.agent_uri);
-            await ensureClientCredentialsTokens(agent, { storage: ccStorage, allowPrivateIp });
-          }
-
-          const authToken = getAuthToken(agent);
-
-          // RFC 9421 signing context. Built once per call and passed through
-          // to each protocol-layer entry (`callMCPToolWithTasks`, `callA2ATool`,
-          // `callMCPToolWithOAuth`) — those entries seed `signingContextStorage`
-          // (AsyncLocalStorage) so the internal transport helpers read it
-          // without an explicit parameter. Keep the explicit arg here: it's the
-          // ALS seed, not incidental plumbing. `get_adcp_capabilities` is
-          // exempt from signing (it's the discovery call itself) and also
-          // triggers cache priming for any other op on agents with
-          // `request_signing` configured.
-          const signingContext = buildAgentSigningContext(agent);
-          if (signingContext && toolName !== CAPABILITY_OP) {
-            await ensureCapabilityLoaded(agent, signingContext, primeArgs =>
-              ProtocolClient.callTool(agent, CAPABILITY_OP, primeArgs, {
-                debugLogs,
-                serverVersion,
-                adcpVersion,
-                ...(versionEnvelopeMode !== 'auto' && { versionEnvelope: versionEnvelopeMode }),
-              })
-            );
-          }
-
-          // Inject the version envelope on every request so sellers can validate
-          // compatibility. Skip for v2 servers — they don't recognise the
-          // version fields and strict-schema agents reject them. The envelope
-          // shape is per-pin: 3.0 pins get the integer `adcp_major_version`
-          // alone; 3.1+ pins get both that and the release-precision string
-          // `adcp_version` (`'3.1'` / `'3.1.0-beta.1'`) per spec PR
-          // `adcontextprotocol/adcp#3493`.
-          const argsWithVersion = applyVersionEnvelope(args, versionEnvelope);
-
-          // Build push_notification_config for ASYNC TASK STATUS notifications
-          // (NOT for reporting_webhook - that stays in args)
-          // Schema: https://adcontextprotocol.org/schemas/v1/core/push-notification-config.json
-          const pushNotificationConfig: PushNotificationConfig | undefined = webhookUrl
-            ? {
-                url: webhookUrl,
-                ...(webhookToken && { token: webhookToken }),
-                authentication: {
-                  schemes: ['HMAC-SHA256'],
-                  credentials: webhookSecret || 'placeholder_secret_min_32_characters_required',
-                },
+        () =>
+          withSpan(
+            `adcp.${agent.protocol}.call_tool`,
+            {
+              'adcp.agent_id': agent.id,
+              'adcp.protocol': agent.protocol,
+              'adcp.tool': toolName,
+              'http.url': agent.agent_uri,
+            },
+            async () => {
+              // In-process MCP path: pre-connected client, no HTTP transport.
+              // Idempotency injection, schema validation, and governance middleware all
+              // still apply (they run in SingleAgentClient above this call). We skip
+              // URL validation, OAuth refresh, and signing — none apply in-process.
+              if (agent.protocol === 'mcp' && agent._inProcessMcpClient) {
+                const inProcArgs = applyVersionEnvelope(args, versionEnvelope);
+                return callMCPToolWithClient(agent._inProcessMcpClient, toolName, inProcArgs, debugLogs);
               }
-            : undefined;
 
-          if (agent.protocol === 'mcp') {
-            // For MCP, include push_notification_config in tool arguments (MCP spec)
-            const argsWithWebhook = pushNotificationConfig
-              ? { ...argsWithVersion, push_notification_config: pushNotificationConfig }
-              : argsWithVersion;
+              validateAgentUrl(agent.agent_uri);
 
-            // If the agent config carries authorization-code OAuth tokens,
-            // route through the OAuth provider path so the MCP SDK can refresh
-            // on 401 instead of hard-failing. Excludes client-credentials
-            // agents: they have a cached access token but no refresh_token,
-            // and their refresh path is a secret re-exchange (handled above),
-            // not the SDK's refresh_token grant.
-            if (agent.oauth_tokens && !agent.oauth_client_credentials) {
-              const authProvider = getNonInteractiveOAuthProvider(agent);
-              try {
-                return await callMCPToolWithOAuth({
-                  agentUrl: agent.agent_uri,
-                  toolName,
-                  args: argsWithWebhook,
-                  authProvider,
-                  debugLogs,
-                  customHeaders: agent.headers,
-                  signingContext,
-                });
-              } catch (err) {
-                // Refresh failed or server rejected the refreshed token — walk the
-                // discovery chain so the caller can distinguish "re-auth needed"
-                // from other failure modes.
-                await rethrowAsNeedsAuthorization(err, agent.agent_uri);
-                throw err;
-              }
-            }
-
-            // Use callMCPToolWithTasks which auto-detects server tasks capability
-            // and falls back to standard callTool when tasks are not supported
-            try {
-              return await callMCPToolWithTasks(
-                agent.agent_uri,
-                toolName,
-                argsWithWebhook,
-                authToken,
-                debugLogs,
-                agent.headers,
-                signingContext ? { signingContext } : undefined
-              );
-            } catch (err) {
-              // Client-credentials agents: on 401, the AS may have rotated
-              // something out-of-band. Force a fresh exchange and retry once
-              // before surfacing the error. Bounded (single retry) so we don't
-              // loop if the credentials are genuinely wrong.
-              if (agent.oauth_client_credentials && is401Error(err)) {
+              // OAuth 2.0 client credentials (RFC 6749 §4.4): re-exchange the
+              // secret for a fresh access token whenever the cached one is within
+              // its expiration skew. Runs before every call so mid-session expiry
+              // can't leave the caller with a stale bearer. No-op if the agent
+              // doesn't declare client credentials. Cheap on warm cache (single
+              // `Date.now()` compare); a single POST to the token endpoint on miss.
+              //
+              // `allowPrivateIp` inherits the trust the caller already placed in
+              // `agent.agent_uri` — if they're making a call to a private-IP agent,
+              // they've authorized this process to talk to private-IP hosts, so
+              // the token endpoint on the same network is reachable too. Public
+              // agent URLs with private-IP token endpoints still require an
+              // explicit opt-in via the library API.
+              if (agent.oauth_client_credentials) {
                 const ccStorage = getAgentStorage(agent);
                 const allowPrivateIp = isLikelyPrivateUrl(agent.agent_uri);
-                await ensureClientCredentialsTokens(agent, { storage: ccStorage, force: true, allowPrivateIp });
-                const retryAuthToken = agent.oauth_tokens?.access_token ?? authToken;
+                await ensureClientCredentialsTokens(agent, { storage: ccStorage, allowPrivateIp });
+              }
+
+              const authToken = getAuthToken(agent);
+
+              // RFC 9421 signing context. Built once per call and passed through
+              // to each protocol-layer entry (`callMCPToolWithTasks`, `callA2ATool`,
+              // `callMCPToolWithOAuth`) — those entries seed `signingContextStorage`
+              // (AsyncLocalStorage) so the internal transport helpers read it
+              // without an explicit parameter. Keep the explicit arg here: it's the
+              // ALS seed, not incidental plumbing. `get_adcp_capabilities` is
+              // exempt from signing (it's the discovery call itself) and also
+              // triggers cache priming for any other op on agents with
+              // `request_signing` configured.
+              const signingContext = buildAgentSigningContext(agent);
+              if (signingContext && toolName !== CAPABILITY_OP) {
+                await ensureCapabilityLoaded(agent, signingContext, primeArgs =>
+                  ProtocolClient.callTool(agent, CAPABILITY_OP, primeArgs, {
+                    debugLogs,
+                    serverVersion,
+                    adcpVersion,
+                    ...(versionEnvelopeMode !== 'auto' && { versionEnvelope: versionEnvelopeMode }),
+                    onTransportActivity,
+                    transportActivityContext,
+                  })
+                );
+              }
+
+              // Inject the version envelope on every request so sellers can validate
+              // compatibility. Skip for v2 servers — they don't recognise the
+              // version fields and strict-schema agents reject them. The envelope
+              // shape is per-pin: 3.0 pins get the integer `adcp_major_version`
+              // alone; 3.1+ pins get both that and the release-precision string
+              // `adcp_version` (`'3.1'` / `'3.1.0-beta.1'`) per spec PR
+              // `adcontextprotocol/adcp#3493`.
+              const argsWithVersion = applyVersionEnvelope(args, versionEnvelope);
+
+              // Build push_notification_config for ASYNC TASK STATUS notifications
+              // (NOT for reporting_webhook - that stays in args)
+              // Schema: https://adcontextprotocol.org/schemas/v1/core/push-notification-config.json
+              const pushNotificationConfig: PushNotificationConfig | undefined = webhookUrl
+                ? {
+                    url: webhookUrl,
+                    ...(webhookToken && { token: webhookToken }),
+                    authentication: {
+                      schemes: ['HMAC-SHA256'],
+                      credentials: webhookSecret || 'placeholder_secret_min_32_characters_required',
+                    },
+                  }
+                : undefined;
+
+              if (agent.protocol === 'mcp') {
+                // For MCP, include push_notification_config in tool arguments (MCP spec)
+                const argsWithWebhook = pushNotificationConfig
+                  ? { ...argsWithVersion, push_notification_config: pushNotificationConfig }
+                  : argsWithVersion;
+
+                // If the agent config carries authorization-code OAuth tokens,
+                // route through the OAuth provider path so the MCP SDK can refresh
+                // on 401 instead of hard-failing. Excludes client-credentials
+                // agents: they have a cached access token but no refresh_token,
+                // and their refresh path is a secret re-exchange (handled above),
+                // not the SDK's refresh_token grant.
+                if (agent.oauth_tokens && !agent.oauth_client_credentials) {
+                  const authProvider = getNonInteractiveOAuthProvider(agent);
+                  try {
+                    return await callMCPToolWithOAuth({
+                      agentUrl: agent.agent_uri,
+                      toolName,
+                      args: argsWithWebhook,
+                      authProvider,
+                      debugLogs,
+                      customHeaders: agent.headers,
+                      signingContext,
+                    });
+                  } catch (err) {
+                    // Refresh failed or server rejected the refreshed token — walk the
+                    // discovery chain so the caller can distinguish "re-auth needed"
+                    // from other failure modes.
+                    await rethrowAsNeedsAuthorization(err, agent.agent_uri);
+                    throw err;
+                  }
+                }
+
+                // Use callMCPToolWithTasks which auto-detects server tasks capability
+                // and falls back to standard callTool when tasks are not supported
                 try {
                   return await callMCPToolWithTasks(
                     agent.agent_uri,
                     toolName,
                     argsWithWebhook,
-                    retryAuthToken,
+                    authToken,
                     debugLogs,
                     agent.headers,
                     signingContext ? { signingContext } : undefined
                   );
-                } catch (retryErr) {
-                  await rethrowAsNeedsAuthorization(retryErr, agent.agent_uri);
-                  throw retryErr;
+                } catch (err) {
+                  // Client-credentials agents: on 401, the AS may have rotated
+                  // something out-of-band. Force a fresh exchange and retry once
+                  // before surfacing the error. Bounded (single retry) so we don't
+                  // loop if the credentials are genuinely wrong.
+                  if (agent.oauth_client_credentials && is401Error(err)) {
+                    const ccStorage = getAgentStorage(agent);
+                    const allowPrivateIp = isLikelyPrivateUrl(agent.agent_uri);
+                    await ensureClientCredentialsTokens(agent, { storage: ccStorage, force: true, allowPrivateIp });
+                    const retryAuthToken = agent.oauth_tokens?.access_token ?? authToken;
+                    try {
+                      return await callMCPToolWithTasks(
+                        agent.agent_uri,
+                        toolName,
+                        argsWithWebhook,
+                        retryAuthToken,
+                        debugLogs,
+                        agent.headers,
+                        signingContext ? { signingContext } : undefined
+                      );
+                    } catch (retryErr) {
+                      await rethrowAsNeedsAuthorization(retryErr, agent.agent_uri);
+                      throw retryErr;
+                    }
+                  }
+                  await rethrowAsNeedsAuthorization(err, agent.agent_uri);
+                  throw err;
                 }
-              }
-              await rethrowAsNeedsAuthorization(err, agent.agent_uri);
-              throw err;
-            }
-          } else if (agent.protocol === 'a2a') {
-            // For A2A, pass pushNotificationConfig separately (not in skill parameters)
-            try {
-              return await callA2ATool(
-                agent.agent_uri,
-                toolName,
-                argsWithVersion,
-                authToken,
-                debugLogs,
-                pushNotificationConfig,
-                agent.headers,
-                signingContext,
-                session
-              );
-            } catch (err) {
-              // Same single-retry-on-401 for client-credentials agents as the
-              // MCP path above. Kept symmetric so A2A CC agents aren't a
-              // second-class experience — including the NeedsAuthorizationError
-              // rewrap on a retry that still 401s.
-              if (agent.oauth_client_credentials && is401Error(err)) {
-                const ccStorage = getAgentStorage(agent);
-                const allowPrivateIp = isLikelyPrivateUrl(agent.agent_uri);
-                await ensureClientCredentialsTokens(agent, { storage: ccStorage, force: true, allowPrivateIp });
-                const retryAuthToken = agent.oauth_tokens?.access_token ?? authToken;
+              } else if (agent.protocol === 'a2a') {
+                // For A2A, pass pushNotificationConfig separately (not in skill parameters)
                 try {
                   return await callA2ATool(
                     agent.agent_uri,
                     toolName,
                     argsWithVersion,
-                    retryAuthToken,
+                    authToken,
                     debugLogs,
                     pushNotificationConfig,
                     agent.headers,
                     signingContext,
                     session
                   );
-                } catch (retryErr) {
-                  await rethrowAsNeedsAuthorization(retryErr, agent.agent_uri);
-                  throw retryErr;
+                } catch (err) {
+                  // Same single-retry-on-401 for client-credentials agents as the
+                  // MCP path above. Kept symmetric so A2A CC agents aren't a
+                  // second-class experience — including the NeedsAuthorizationError
+                  // rewrap on a retry that still 401s.
+                  if (agent.oauth_client_credentials && is401Error(err)) {
+                    const ccStorage = getAgentStorage(agent);
+                    const allowPrivateIp = isLikelyPrivateUrl(agent.agent_uri);
+                    await ensureClientCredentialsTokens(agent, { storage: ccStorage, force: true, allowPrivateIp });
+                    const retryAuthToken = agent.oauth_tokens?.access_token ?? authToken;
+                    try {
+                      return await callA2ATool(
+                        agent.agent_uri,
+                        toolName,
+                        argsWithVersion,
+                        retryAuthToken,
+                        debugLogs,
+                        pushNotificationConfig,
+                        agent.headers,
+                        signingContext,
+                        session
+                      );
+                    } catch (retryErr) {
+                      await rethrowAsNeedsAuthorization(retryErr, agent.agent_uri);
+                      throw retryErr;
+                    }
+                  }
+                  await rethrowAsNeedsAuthorization(err, agent.agent_uri);
+                  throw err;
                 }
+              } else {
+                throw new Error(`Unsupported protocol: ${agent.protocol}`);
               }
-              await rethrowAsNeedsAuthorization(err, agent.agent_uri);
-              throw err;
             }
-          } else {
-            throw new Error(`Unsupported protocol: ${agent.protocol}`);
-          }
-        }
+          )
       )
     );
   }

--- a/src/lib/protocols/mcp-tasks.ts
+++ b/src/lib/protocols/mcp-tasks.ts
@@ -17,6 +17,8 @@ import { createMCPAuthHeaders } from '../auth';
 import { withSpan, injectTraceHeaders } from '../observability/tracing';
 import { signingContextStorage, type AgentSigningContext } from '../signing/client';
 import { redactIdempotencyKeyInArgs } from '../utils/idempotency';
+import { withResponseSizeLimit } from './responseSizeLimit';
+import { withTransportDiagnostics, type TransportActivityHandler } from './transportDiagnostics';
 
 /** Response shape returned by MCPClient.callTool(). */
 type CallToolResponse = {
@@ -24,6 +26,18 @@ type CallToolResponse = {
   content?: Array<{ type: string; text?: string }>;
   [key: string]: unknown;
 };
+
+interface MCPTaskProtocolOptions {
+  transport?: { maxResponseBytes?: number };
+  onTransportActivity?: TransportActivityHandler;
+  transportActivityContext?: {
+    agentId: string;
+    operationId?: string;
+    taskId?: string;
+    contextId?: string;
+    idempotencyKey?: string;
+  };
+}
 
 /**
  * Track which MCP clients have had listTools() called.
@@ -469,19 +483,33 @@ export async function getMCPTaskResult(
 export async function listMCPTasks(
   agentUrl: string,
   authToken?: string,
-  debugLogs: DebugLogEntry[] = []
+  debugLogs: DebugLogEntry[] = [],
+  options: MCPTaskProtocolOptions = {}
 ): Promise<TaskInfo[]> {
   const authHeaders = buildAuthHeaders(authToken);
 
-  return withCachedConnection(agentUrl, authToken, authHeaders, debugLogs, 'tasks/list', async client => {
-    const result = await client.experimental.tasks.listTasks();
-    debugLogs.push({
-      type: 'info',
-      message: `MCP Tasks: listTasks returned ${result.tasks.length} tasks`,
-      timestamp: new Date().toISOString(),
-    });
-    return result.tasks.map((task: any) => mapMCPTaskToTaskInfo(task));
-  });
+  return withResponseSizeLimit(options.transport?.maxResponseBytes, () =>
+    withTransportDiagnostics(
+      {
+        agentId: options.transportActivityContext?.agentId ?? 'unknown-agent',
+        protocol: 'mcp',
+        tool: 'tasks/list',
+        taskType: 'tasks/list',
+        ...options.transportActivityContext,
+        onTransportActivity: options.onTransportActivity,
+      },
+      () =>
+        withCachedConnection(agentUrl, authToken, authHeaders, debugLogs, 'tasks/list', async client => {
+          const result = await client.experimental.tasks.listTasks();
+          debugLogs.push({
+            type: 'info',
+            message: `MCP Tasks: listTasks returned ${result.tasks.length} tasks`,
+            timestamp: new Date().toISOString(),
+          });
+          return result.tasks.map((task: any) => mapMCPTaskToTaskInfo(task));
+        })
+    )
+  );
 }
 
 /**

--- a/src/lib/protocols/mcp.ts
+++ b/src/lib/protocols/mcp.ts
@@ -17,6 +17,7 @@ import { buildAgentSigningFetch, signingContextStorage, type AgentSigningContext
 import { redactIdempotencyKeyInArgs } from '../utils/idempotency';
 import { wrapFetchWithCapture } from './rawResponseCapture';
 import { wrapFetchWithSizeLimit } from './responseSizeLimit';
+import { wrapFetchWithTransportDiagnostics } from './transportDiagnostics';
 
 // Re-export for convenience
 export { UnauthorizedError };
@@ -540,13 +541,14 @@ async function connectMCPWithFallbackImpl(
   // buffer a hostile reply in memory).
   const networkFetch = transportFetch ?? ((input, init) => fetch(input as any, init));
   const sizeLimited = wrapFetchWithSizeLimit(networkFetch);
+  const diagnosticFetch = wrapFetchWithTransportDiagnostics(sizeLimited);
   const baseFetch: typeof fetch = signingContext
     ? (buildAgentSigningFetch({
-        upstream: sizeLimited,
+        upstream: diagnosticFetch,
         signing: signingContext.signing,
         getCapability: signingContext.getCapability,
       }) as typeof fetch)
-    : sizeLimited;
+    : diagnosticFetch;
   const transportOptions: StreamableHTTPClientTransportOptions = {
     requestInit: { headers: authHeaders, ...(transportFetch ? { redirect: 'manual' as const } : {}) },
     fetch: wrapFetchWithCapture(baseFetch),
@@ -910,13 +912,14 @@ export async function connectMCP(options: {
   // decides per outbound request whether to sign. Size-limit sits innermost so
   // the response body is bounded before signing/capture observe it.
   const sizeLimited = wrapFetchWithSizeLimit((input, init) => fetch(input as string | URL, init));
+  const diagnosticFetch = wrapFetchWithTransportDiagnostics(sizeLimited);
   const signedFetch: typeof fetch = signingContext
     ? (buildAgentSigningFetch({
-        upstream: sizeLimited,
+        upstream: diagnosticFetch,
         signing: signingContext.signing,
         getCapability: signingContext.getCapability,
       }) as typeof fetch)
-    : sizeLimited;
+    : diagnosticFetch;
   transportOptions.fetch = wrapFetchWithCapture(signedFetch);
 
   const transport = new StreamableHTTPClientTransport(baseUrl, transportOptions);

--- a/src/lib/protocols/transportDiagnostics.ts
+++ b/src/lib/protocols/transportDiagnostics.ts
@@ -1,0 +1,376 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { createHmac } from 'node:crypto';
+
+export type TransportActivityType = 'request_started' | 'response_received' | 'request_failed';
+
+export interface TransportActivityContext {
+  agentId: string;
+  protocol: 'mcp' | 'a2a';
+  tool?: string;
+  taskType?: string;
+  operationId?: string;
+  taskId?: string;
+  contextId?: string;
+  idempotencyKey?: string;
+}
+
+export interface TransportActivity {
+  type: TransportActivityType;
+  agentId: string;
+  protocol: 'mcp' | 'a2a';
+  tool?: string;
+  taskType?: string;
+  operationId?: string;
+  taskId?: string;
+  contextId?: string;
+  idempotencyKeyHash?: string;
+  method: string;
+  url: string;
+  requestHeaders: Record<string, string>;
+  requestBody?: string;
+  requestBodyTruncated?: boolean;
+  startedAt: string;
+  timestamp: string;
+  durationMs?: number;
+  httpStatus?: number;
+  statusText?: string;
+  responseHeaders?: Record<string, string>;
+  responseBody?: string;
+  responseBodyTruncated?: boolean;
+  errorName?: string;
+  errorMessage?: string;
+}
+
+export type TransportActivityHandler = (event: TransportActivity) => void | Promise<void>;
+
+interface TransportDiagnosticsSlot extends TransportActivityContext {
+  onTransportActivity?: TransportActivityHandler;
+  pending: Promise<void>[];
+}
+
+const BODY_SNIPPET_LIMIT = 64 * 1024;
+const REDACTED = '[redacted]';
+
+const SAFE_HEADER_NAMES = new Set([
+  'accept',
+  'accept-encoding',
+  'content-type',
+  'last-event-id',
+  'mcp-protocol-version',
+  'traceparent',
+  'tracestate',
+  'user-agent',
+  'x-adcp-agent-id',
+  'x-adcp-request-id',
+  'x-correlation-id',
+  'x-request-id',
+  'x-scope3-debug-id',
+]);
+
+const SENSITIVE_HEADER_NAMES = new Set([
+  'authorization',
+  'cookie',
+  'proxy-authorization',
+  'set-cookie',
+  'x-adcp-auth',
+  'x-api-key',
+  'mcp-session-id',
+]);
+
+const SENSITIVE_KEY_RE =
+  /(^|[_-])(authorization|cookie|credentials?|secret|signature|token|api[_-]?key|private[_-]?key|idempotency[_-]?key|password)([_-]|$)/i;
+const SENSITIVE_TEXT_FIELD_RE =
+  /((?:"[^"]*(?:authorization|cookie|credentials?|secret|signature|token|api[_-]?key|private[_-]?key|idempotency[_-]?key|password)[^"]*"\s*:\s*)|(?:^|[&\s])[^=&\s]*(?:authorization|cookie|credentials?|secret|signature|token|api[_-]?key|private[_-]?key|idempotency[_-]?key|password)[^=&\s]*=)("[^"]*"|[^&\s,}]+)/gi;
+const URL_LIKE_RE = /\bhttps?:\/\/[^\s"'<>]+/gi;
+
+export const transportDiagnosticsStorage = new AsyncLocalStorage<TransportDiagnosticsSlot>();
+
+export function withTransportDiagnostics<T>(
+  context: TransportActivityContext & { onTransportActivity?: TransportActivityHandler },
+  fn: () => Promise<T>
+): Promise<T> {
+  if (!context.onTransportActivity) return fn();
+  const slot: TransportDiagnosticsSlot = { ...context, pending: [] };
+  return transportDiagnosticsStorage.run(slot, async () => {
+    try {
+      return await fn();
+    } finally {
+      await Promise.allSettled(slot.pending);
+    }
+  });
+}
+
+export function sanitizeTransportUrl(value: string): string {
+  try {
+    const url = new URL(value);
+    url.username = '';
+    url.password = '';
+    url.search = '';
+    url.hash = '';
+    return url.toString();
+  } catch {
+    return 'invalid_url';
+  }
+}
+
+export function sanitizeTransportHeaders(headers: HeadersInit | undefined): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of headerEntries(headers)) {
+    const lower = key.toLowerCase();
+    if (SENSITIVE_HEADER_NAMES.has(lower) || SENSITIVE_KEY_RE.test(lower)) {
+      out[lower] = REDACTED;
+    } else if (SAFE_HEADER_NAMES.has(lower) || isSafeCorrelationHeader(lower)) {
+      out[lower] = value;
+    }
+  }
+  return out;
+}
+
+export function wrapFetchWithTransportDiagnostics(upstream: typeof fetch): typeof fetch {
+  const wrapped: typeof fetch = async (input, init) => {
+    const slot = transportDiagnosticsStorage.getStore();
+    if (!slot?.onTransportActivity) return upstream(input, init);
+
+    const startedAtMs = Date.now();
+    const startedAt = new Date(startedAtMs).toISOString();
+    const method = getMethod(input, init);
+    const url = sanitizeTransportUrl(getUrl(input));
+    const requestHeaders = sanitizeTransportHeaders(mergeRequestHeaders(input, init));
+    const requestBody = bodySnippet(init?.body);
+    const baseEvent = {
+      agentId: slot.agentId,
+      protocol: slot.protocol,
+      ...(slot.tool && { tool: slot.tool, taskType: slot.taskType ?? slot.tool }),
+      ...(slot.operationId && { operationId: slot.operationId }),
+      ...(slot.taskId && { taskId: slot.taskId }),
+      ...(slot.contextId && { contextId: slot.contextId }),
+      ...(slot.idempotencyKey && { idempotencyKeyHash: fingerprintDiagnosticValue(slot.idempotencyKey) }),
+      method,
+      url,
+      requestHeaders,
+      ...(requestBody && {
+        requestBody: requestBody.body,
+        requestBodyTruncated: requestBody.truncated,
+      }),
+      startedAt,
+    };
+
+    emitTransportActivity(slot.onTransportActivity, {
+      type: 'request_started',
+      ...baseEvent,
+      timestamp: startedAt,
+    });
+
+    try {
+      const response = await upstream(input, init);
+      const durationMs = Date.now() - startedAtMs;
+      const responseHeaders = sanitizeResponseHeaders(response.headers);
+      const responseBody = await responseBodySnippet(response);
+      emitTransportActivity(slot.onTransportActivity, {
+        type: 'response_received',
+        ...baseEvent,
+        timestamp: new Date().toISOString(),
+        durationMs,
+        httpStatus: response.status,
+        statusText: response.statusText,
+        responseHeaders,
+        ...(responseBody && {
+          responseBody: responseBody.body,
+          responseBodyTruncated: responseBody.truncated,
+        }),
+      });
+      return response;
+    } catch (error) {
+      emitTransportActivity(slot.onTransportActivity, {
+        type: 'request_failed',
+        ...baseEvent,
+        timestamp: new Date().toISOString(),
+        durationMs: Date.now() - startedAtMs,
+        errorName: error instanceof Error ? error.name : typeof error,
+        errorMessage: sanitizeDiagnosticText(error instanceof Error ? error.message : String(error)),
+      });
+      throw error;
+    }
+  };
+  return wrapped;
+}
+
+function emitTransportActivity(handler: TransportActivityHandler, event: TransportActivity): void {
+  try {
+    const slot = transportDiagnosticsStorage.getStore();
+    const frozen = Object.freeze(structuredClone(event));
+    const pending = Promise.resolve()
+      .then(() => handler(frozen))
+      .then(
+        () => {},
+        () => {}
+      );
+    slot?.pending.push(pending);
+  } catch {
+    // Observability hooks must not change protocol behavior.
+  }
+}
+
+function getUrl(input: RequestInfo | URL): string {
+  return typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+}
+
+function getMethod(input: RequestInfo | URL, init?: RequestInit): string {
+  return (init?.method ?? (input instanceof Request ? input.method : 'GET')).toUpperCase();
+}
+
+function mergeRequestHeaders(input: RequestInfo | URL, init?: RequestInit): Headers {
+  const headers = new Headers(input instanceof Request ? input.headers : undefined);
+  if (init?.headers) {
+    for (const [key, value] of headerEntries(init.headers)) {
+      headers.set(key, value);
+    }
+  }
+  return headers;
+}
+
+function sanitizeResponseHeaders(headers: Headers): Record<string, string> {
+  return sanitizeTransportHeaders(headers);
+}
+
+function headerEntries(headers: HeadersInit | undefined): Array<[string, string]> {
+  if (!headers) return [];
+  if (headers instanceof Headers) {
+    const entries: Array<[string, string]> = [];
+    headers.forEach((value, key) => entries.push([key, value]));
+    return entries;
+  }
+  if (Array.isArray(headers)) return headers.map(([key, value]) => [key, value]);
+  return Object.entries(headers).map(([key, value]) => [key, String(value)]);
+}
+
+function isSafeCorrelationHeader(lower: string): boolean {
+  if (!lower.startsWith('x-')) return false;
+  return (
+    lower.includes('correlation') || lower.includes('debug') || lower.includes('request-id') || lower.includes('trace')
+  );
+}
+
+function bodySnippet(body: BodyInit | null | undefined): { body: string; truncated: boolean } | undefined {
+  if (body == null) return undefined;
+  if (typeof body === 'string') return sanitizeBodyText(body, BODY_SNIPPET_LIMIT);
+  if (body instanceof URLSearchParams) return sanitizeBodyText(body.toString(), BODY_SNIPPET_LIMIT);
+  if (body instanceof Blob) return { body: `[blob ${body.size} bytes]`, truncated: false };
+  if (body instanceof ArrayBuffer) {
+    return sanitizeBodyText(Buffer.from(body).toString('utf8'), BODY_SNIPPET_LIMIT);
+  }
+  if (ArrayBuffer.isView(body)) {
+    return sanitizeBodyText(
+      Buffer.from(body.buffer, body.byteOffset, body.byteLength).toString('utf8'),
+      BODY_SNIPPET_LIMIT
+    );
+  }
+  return undefined;
+}
+
+async function responseBodySnippet(response: Response): Promise<{ body: string; truncated: boolean } | undefined> {
+  const contentType = response.headers.get('content-type') ?? '';
+  if (!isDiagnosticTextContentType(contentType)) return undefined;
+  try {
+    const { text, truncated } = await readResponseTextBounded(response.clone(), BODY_SNIPPET_LIMIT);
+    return { body: redactSensitiveJsonOrText(text), truncated };
+  } catch {
+    return undefined;
+  }
+}
+
+function sanitizeBodyText(text: string, limit: number): { body: string; truncated: boolean } {
+  const truncated = text.length > limit;
+  const bounded = truncated ? text.slice(0, limit) : text;
+  return { body: redactSensitiveJsonOrText(bounded), truncated };
+}
+
+function redactSensitiveJsonOrText(text: string): string {
+  try {
+    return JSON.stringify(redactSensitiveValue(JSON.parse(text)));
+  } catch {
+    return sanitizeDiagnosticText(text);
+  }
+}
+
+function redactSensitiveValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(redactSensitiveValue);
+  if (typeof value === 'string') return sanitizeStringValue(value);
+  if (!value || typeof value !== 'object') return value;
+  const out: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(value)) {
+    out[key] = isSensitiveKey(key) ? REDACTED : redactSensitiveValue(child);
+  }
+  return out;
+}
+
+function sanitizeDiagnosticText(text: string): string {
+  return text
+    .replace(URL_LIKE_RE, value => sanitizeTransportUrl(value))
+    .replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, 'Bearer [redacted]')
+    .replace(/Basic\s+[A-Za-z0-9+/=-]+/gi, 'Basic [redacted]')
+    .replace(SENSITIVE_TEXT_FIELD_RE, (_match, prefix) => `${prefix}${REDACTED}`);
+}
+
+function sanitizeStringValue(value: string): string {
+  return sanitizeDiagnosticText(value);
+}
+
+function normalizedKey(key: string): string {
+  return key.replace(/([a-z0-9])([A-Z])/g, '$1_$2').toLowerCase();
+}
+
+function isSensitiveKey(key: string): boolean {
+  return SENSITIVE_KEY_RE.test(normalizedKey(key));
+}
+
+function isDiagnosticTextContentType(contentType: string): boolean {
+  const lower = contentType.toLowerCase();
+  if (!lower) return true;
+  if (lower.includes('text/event-stream')) return false;
+  return (
+    lower.startsWith('text/') ||
+    lower.includes('json') ||
+    lower.includes('xml') ||
+    lower.includes('javascript') ||
+    lower.includes('x-www-form-urlencoded')
+  );
+}
+
+async function readResponseTextBounded(
+  response: Response,
+  limit: number
+): Promise<{ text: string; truncated: boolean }> {
+  if (!response.body) {
+    const text = await response.text();
+    return { text: text.slice(0, limit), truncated: text.length > limit };
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let text = '';
+  let truncated = false;
+
+  try {
+    while (text.length <= limit) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      text += decoder.decode(value, { stream: true });
+      if (text.length > limit) {
+        truncated = true;
+        text = text.slice(0, limit);
+        await reader.cancel();
+        break;
+      }
+    }
+    if (!truncated) text += decoder.decode();
+  } finally {
+    reader.releaseLock();
+  }
+
+  return { text, truncated };
+}
+
+function fingerprintDiagnosticValue(value: string): string {
+  return createHmac('sha256', 'adcp-transport-diagnostics').update(value).digest('hex').slice(0, 16);
+}

--- a/test/lib/transport-diagnostics.test.js
+++ b/test/lib/transport-diagnostics.test.js
@@ -1,0 +1,250 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+  sanitizeTransportHeaders,
+  sanitizeTransportUrl,
+  withTransportDiagnostics,
+  wrapFetchWithTransportDiagnostics,
+} = require('../../dist/lib/protocols/index.js');
+
+test('transport diagnostics emits sanitized request and response events', async () => {
+  const events = [];
+  const upstream = async () =>
+    new Response(JSON.stringify({ ok: true, access_token: 'response-token', id: 'resp-1' }), {
+      status: 202,
+      statusText: 'Accepted',
+      headers: {
+        'content-type': 'application/json',
+        'set-cookie': 'sid=secret',
+        'x-request-id': 'srv-req-1',
+      },
+    });
+  const instrumentedFetch = wrapFetchWithTransportDiagnostics(upstream);
+
+  const response = await withTransportDiagnostics(
+    {
+      agentId: 'agent-1',
+      protocol: 'mcp',
+      tool: 'get_products',
+      operationId: 'op-1',
+      taskId: 'task-1',
+      contextId: 'ctx-1',
+      idempotencyKey: 'idem-1',
+      onTransportActivity: event => events.push(event),
+    },
+    () =>
+      instrumentedFetch('https://user:pass@example.com/mcp?signature=signed#fragment', {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer request-token',
+          'Content-Type': 'application/json',
+          Cookie: 'sid=secret',
+          'x-adcp-auth': 'adcp-token',
+          'x-api-key': 'api-key',
+          'x-private-tenant': 'tenant-a',
+          'x-scope3-debug-id': 'debug-1',
+        },
+        body: JSON.stringify({
+          idempotency_key: 'idem-1',
+          access_token: 'request-token',
+          push_notification_config: {
+            token: 'webhook-token',
+            authentication: { credentials: 'webhook-secret' },
+          },
+        }),
+      })
+  );
+
+  assert.equal(response.status, 202);
+  assert.equal(await response.text(), JSON.stringify({ ok: true, access_token: 'response-token', id: 'resp-1' }));
+
+  assert.equal(events.length, 2);
+  const [started, received] = events;
+
+  assert.equal(started.type, 'request_started');
+  assert.equal(started.agentId, 'agent-1');
+  assert.equal(started.protocol, 'mcp');
+  assert.equal(started.tool, 'get_products');
+  assert.equal(started.taskType, 'get_products');
+  assert.equal(started.operationId, 'op-1');
+  assert.equal(started.taskId, 'task-1');
+  assert.equal(started.contextId, 'ctx-1');
+  assert.equal(typeof started.idempotencyKeyHash, 'string');
+  assert.notEqual(started.idempotencyKeyHash, 'idem-1');
+  assert.equal(started.method, 'POST');
+  assert.equal(started.url, 'https://example.com/mcp');
+  assert.deepEqual(started.requestHeaders, {
+    authorization: '[redacted]',
+    'content-type': 'application/json',
+    cookie: '[redacted]',
+    'x-adcp-auth': '[redacted]',
+    'x-api-key': '[redacted]',
+    'x-scope3-debug-id': 'debug-1',
+  });
+  assert.equal(JSON.parse(started.requestBody).idempotency_key, '[redacted]');
+  assert.equal(JSON.parse(started.requestBody).access_token, '[redacted]');
+  assert.equal(JSON.parse(started.requestBody).push_notification_config.token, '[redacted]');
+  assert.equal(JSON.parse(started.requestBody).push_notification_config.authentication.credentials, '[redacted]');
+  assert.equal(started.requestBodyTruncated, false);
+
+  assert.equal(received.type, 'response_received');
+  assert.equal(received.httpStatus, 202);
+  assert.equal(received.statusText, 'Accepted');
+  assert.equal(received.url, 'https://example.com/mcp');
+  assert.equal(received.durationMs >= 0, true);
+  assert.deepEqual(received.responseHeaders, {
+    'content-type': 'application/json',
+    'set-cookie': '[redacted]',
+    'x-request-id': 'srv-req-1',
+  });
+  assert.deepEqual(JSON.parse(received.responseBody), {
+    ok: true,
+    access_token: '[redacted]',
+    id: 'resp-1',
+  });
+  assert.equal(received.responseBodyTruncated, false);
+});
+
+test('transport diagnostics emits request_failed without swallowing the error', async () => {
+  const events = [];
+  const instrumentedFetch = wrapFetchWithTransportDiagnostics(async () => {
+    throw new TypeError(
+      'socket hang up for https://user:pass@seller.example/a2a?access_token=query-token with Bearer header-token'
+    );
+  });
+
+  await assert.rejects(
+    withTransportDiagnostics(
+      {
+        agentId: 'agent-2',
+        protocol: 'a2a',
+        tool: 'create_media_buy',
+        onTransportActivity: event => events.push(event),
+      },
+      () => instrumentedFetch('https://seller.example/a2a', { method: 'POST' })
+    ),
+    /socket hang up/
+  );
+
+  assert.equal(events.length, 2);
+  assert.equal(events[0].type, 'request_started');
+  assert.equal(events[1].type, 'request_failed');
+  assert.equal(events[1].errorName, 'TypeError');
+  assert.equal(events[1].errorMessage.includes('https://seller.example/a2a'), true);
+  assert.equal(events[1].errorMessage.includes('user:pass'), false);
+  assert.equal(events[1].errorMessage.includes('query-token'), false);
+  assert.equal(events[1].errorMessage.includes('header-token'), false);
+  assert.equal(events[1].durationMs >= 0, true);
+});
+
+test('transport diagnostics waits for async handlers after the request completes', async () => {
+  const events = [];
+  const instrumentedFetch = wrapFetchWithTransportDiagnostics(async () => new Response('{}'));
+
+  await withTransportDiagnostics(
+    {
+      agentId: 'agent-async',
+      protocol: 'mcp',
+      tool: 'get_products',
+      onTransportActivity: async event => {
+        await new Promise(resolve => setTimeout(resolve, 5));
+        events.push(event);
+      },
+    },
+    () => instrumentedFetch('https://seller.example/mcp', { method: 'POST' })
+  );
+
+  assert.deepEqual(
+    events.map(event => event.type),
+    ['request_started', 'response_received']
+  );
+});
+
+test('transport diagnostics redacts camelCase secrets and strips URL-bearing body fields', async () => {
+  const events = [];
+  const instrumentedFetch = wrapFetchWithTransportDiagnostics(
+    async () =>
+      new Response(
+        JSON.stringify({
+          refreshToken: 'response-refresh',
+          nested: [{ privateKey: 'pem-secret' }],
+          callbackUrl: 'https://callback.example/path?token=response-token#frag',
+        }),
+        { headers: { 'content-type': 'application/json' } }
+      )
+  );
+
+  await withTransportDiagnostics(
+    {
+      agentId: 'agent-3',
+      protocol: 'mcp',
+      tool: 'sync_creatives',
+      onTransportActivity: event => events.push(event),
+    },
+    () =>
+      instrumentedFetch('https://seller.example/mcp', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          accessToken: 'request-token',
+          nested: [{ privateKey: 'pem-secret' }],
+          webhookUrl: 'https://hooks.example/path?token=request-token#frag',
+        }),
+      })
+  );
+
+  assert.deepEqual(JSON.parse(events[0].requestBody), {
+    accessToken: '[redacted]',
+    nested: [{ privateKey: '[redacted]' }],
+    webhookUrl: 'https://hooks.example/path',
+  });
+  assert.deepEqual(JSON.parse(events[1].responseBody), {
+    refreshToken: '[redacted]',
+    nested: [{ privateKey: '[redacted]' }],
+    callbackUrl: 'https://callback.example/path',
+  });
+});
+
+test('transport diagnostics redacts sensitive form-style body fields', async () => {
+  const events = [];
+  const instrumentedFetch = wrapFetchWithTransportDiagnostics(async () => new Response('{}'));
+
+  await withTransportDiagnostics(
+    {
+      agentId: 'agent-3',
+      protocol: 'mcp',
+      tool: 'sync_creatives',
+      onTransportActivity: event => events.push(event),
+    },
+    () =>
+      instrumentedFetch('https://seller.example/mcp', {
+        method: 'POST',
+        body: 'access_token=secret-token&safe=value',
+      })
+  );
+
+  assert.equal(events[0].requestBody, 'access_token=[redacted]&safe=value');
+});
+
+test('transport diagnostics helpers sanitize URLs and headers', () => {
+  assert.equal(
+    sanitizeTransportUrl('https://user:pass@example.com/path?token=signed#frag'),
+    'https://example.com/path'
+  );
+  assert.deepEqual(
+    sanitizeTransportHeaders({
+      Authorization: 'Bearer secret',
+      'mcp-session-id': 'session-secret',
+      Traceparent: '00-abc',
+      'x-custom-routing': 'tenant',
+      'x-scope3-debug-id': 'debug',
+    }),
+    {
+      authorization: '[redacted]',
+      'mcp-session-id': '[redacted]',
+      traceparent: '00-abc',
+      'x-scope3-debug-id': 'debug',
+    }
+  );
+});

--- a/test/transport-diagnostics-e2e.test.js
+++ b/test/transport-diagnostics-e2e.test.js
@@ -1,0 +1,266 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const express = require('express');
+
+const { ADCPMultiAgentClient, closeMCPConnections, serve } = require('../dist/lib/index.js');
+const { closeConnections } = require('../dist/lib/protocols/index.js');
+const { createAdcpServer: _createAdcpServer } = require('../dist/lib/server/create-adcp-server');
+const { createA2AAdapter } = require('../dist/lib/server/a2a-adapter');
+const { InMemoryStateStore } = require('../dist/lib/server/state-store');
+
+function createAdcpServer(config) {
+  return _createAdcpServer({
+    ...config,
+    stateStore: config?.stateStore ?? new InMemoryStateStore(),
+    validation: { requests: 'off', responses: 'off', ...(config?.validation ?? {}) },
+  });
+}
+
+function waitForListening(server) {
+  return new Promise(resolve => {
+    if (server.listening) return resolve();
+    server.once('listening', resolve);
+  });
+}
+
+function closeServer(server) {
+  return new Promise(resolve => server.close(resolve));
+}
+
+async function startMcpFixture(handlers) {
+  const httpServer = serve(
+    () =>
+      createAdcpServer({
+        name: 'Transport Diagnostics MCP Seller',
+        version: '1.0.0',
+        ...handlers,
+      }),
+    { port: 0, onListening: () => {} }
+  );
+  await waitForListening(httpServer);
+  const { port } = httpServer.address();
+  return {
+    url: `http://127.0.0.1:${port}/mcp`,
+    close: () => closeServer(httpServer),
+  };
+}
+
+async function startA2aFixture(handlers) {
+  const adcp = createAdcpServer({
+    name: 'Transport Diagnostics A2A Seller',
+    version: '1.0.0',
+    ...handlers,
+  });
+  const app = express();
+  app.use(express.json());
+  const server = app.listen(0);
+  await new Promise(resolve => server.once('listening', resolve));
+  const { port } = server.address();
+  const url = `http://127.0.0.1:${port}/a2a`;
+  const a2a = createA2AAdapter({
+    server: adcp,
+    agentCard: {
+      name: 'Transport Diagnostics A2A Seller',
+      description: 'A2A fixture for transport diagnostics E2E tests',
+      url,
+      version: '1.0.0',
+      provider: { organization: 'Test', url: 'https://test.example' },
+      securitySchemes: { bearer: { type: 'http', scheme: 'bearer' } },
+    },
+  });
+  a2a.mount(app);
+  return {
+    url,
+    close: () => closeServer(server),
+  };
+}
+
+function createClient(agent, events) {
+  return new ADCPMultiAgentClient([agent], {
+    allowV2: true,
+    validateFeatures: false,
+    validation: { requests: 'off', responses: 'off' },
+    webhookUrlTemplate: 'https://buyer.example/webhook?token=webhook-url-secret#fragment',
+    webhookSecret: 'webhook-secret-minimum-32-characters',
+    onTransportActivity: event => events.push(event),
+  });
+}
+
+const createMediaBuyParams = {
+  account: { account_id: 'acct_transport_e2e' },
+  brand: { domain: 'brand.example' },
+  start_time: '2026-05-01T00:00:00Z',
+  end_time: '2026-05-31T23:59:59Z',
+  packages: [{ product_id: 'prod_transport_e2e', pricing_option_id: 'po_transport_e2e', budget: 5000 }],
+};
+
+function assertNoSecretLeak(events, secrets) {
+  const serialized = JSON.stringify(events);
+  for (const secret of secrets) {
+    assert.equal(serialized.includes(secret), false, `transport events leaked ${secret}`);
+  }
+}
+
+function findToolEvent(events, type, protocol) {
+  return events.find(
+    event =>
+      event.type === type &&
+      event.protocol === protocol &&
+      event.tool === 'create_media_buy' &&
+      event.method === 'POST' &&
+      event.requestBody?.includes('create_media_buy')
+  );
+}
+
+function toolEvents(events, type, protocol) {
+  return events.filter(
+    event =>
+      event.type === type &&
+      event.protocol === protocol &&
+      event.tool === 'create_media_buy' &&
+      event.method === 'POST' &&
+      event.requestBody?.includes('create_media_buy')
+  );
+}
+
+describe('transport diagnostics public-client E2E', () => {
+  it('emits sanitized MCP transport events through ADCPMultiAgentClient', async () => {
+    const calls = [];
+    const events = [];
+    const fixture = await startMcpFixture({
+      mediaBuy: {
+        createMediaBuy: async params => {
+          calls.push(params);
+          return { media_buy_id: `mb_transport_mcp_${calls.length}`, packages: [] };
+        },
+      },
+    });
+
+    try {
+      const client = createClient(
+        {
+          id: 'mcp-agent',
+          name: 'MCP Agent',
+          agent_uri: fixture.url,
+          protocol: 'mcp',
+          auth_token: 'mcp-auth-token-secret',
+          headers: {
+            'x-api-key': 'mcp-api-key-secret',
+            'x-scope3-debug-id': 'debug-mcp-e2e',
+          },
+        },
+        events
+      );
+
+      const result = await client.agent('mcp-agent').createMediaBuy(createMediaBuyParams);
+      assert.equal(result.success, true, result.error);
+      assert.equal(result.status, 'completed');
+      const secondResult = await client.agent('mcp-agent').createMediaBuy(createMediaBuyParams);
+      assert.equal(secondResult.success, true, secondResult.error);
+      assert.equal(result.data.media_buy_id, 'mb_transport_mcp_1');
+      assert.equal(secondResult.data.media_buy_id, 'mb_transport_mcp_2');
+      assert.equal(calls.length, 2);
+
+      const started = findToolEvent(events, 'request_started', 'mcp');
+      const received = findToolEvent(events, 'response_received', 'mcp');
+      assert.ok(started, `missing MCP request_started event: ${JSON.stringify(events, null, 2)}`);
+      assert.ok(received, `missing MCP response_received event: ${JSON.stringify(events, null, 2)}`);
+      assert.equal(started.agentId, 'mcp-agent');
+      assert.equal(typeof started.operationId, 'string');
+      assert.equal(typeof started.taskId, 'string');
+      assert.equal(typeof started.idempotencyKeyHash, 'string');
+      assert.notEqual(started.idempotencyKeyHash, result.metadata.idempotency_key);
+      assert.equal(started.requestHeaders.authorization, '[redacted]');
+      assert.equal(started.requestHeaders['x-adcp-auth'], '[redacted]');
+      assert.equal(started.requestHeaders['x-api-key'], '[redacted]');
+      assert.equal(started.requestHeaders['x-scope3-debug-id'], 'debug-mcp-e2e');
+      assert.equal(received.httpStatus, 200);
+      const toolStarts = toolEvents(events, 'request_started', 'mcp');
+      assert.equal(toolStarts.length, 2, `expected two MCP create_media_buy request events`);
+      assert.notEqual(toolStarts[0].operationId, toolStarts[1].operationId);
+      assert.notEqual(toolStarts[0].taskId, toolStarts[1].taskId);
+      assert.notEqual(toolStarts[0].idempotencyKeyHash, toolStarts[1].idempotencyKeyHash);
+      assertNoSecretLeak(events, [
+        'mcp-auth-token-secret',
+        'mcp-api-key-secret',
+        'webhook-secret-minimum-32-characters',
+        'webhook-url-secret',
+        result.metadata.idempotency_key,
+        secondResult.metadata.idempotency_key,
+      ]);
+    } finally {
+      await closeMCPConnections();
+      await fixture.close();
+    }
+  });
+
+  it('emits sanitized A2A transport events through ADCPMultiAgentClient', async () => {
+    const calls = [];
+    const events = [];
+    const fixture = await startA2aFixture({
+      mediaBuy: {
+        createMediaBuy: async params => {
+          calls.push(params);
+          return { media_buy_id: `mb_transport_a2a_${calls.length}`, packages: [] };
+        },
+      },
+    });
+
+    try {
+      const client = createClient(
+        {
+          id: 'a2a-agent',
+          name: 'A2A Agent',
+          agent_uri: fixture.url,
+          protocol: 'a2a',
+          auth_token: 'a2a-auth-token-secret',
+          headers: {
+            'x-api-key': 'a2a-api-key-secret',
+            'x-scope3-debug-id': 'debug-a2a-e2e',
+          },
+        },
+        events
+      );
+
+      const result = await client.agent('a2a-agent').createMediaBuy(createMediaBuyParams);
+      assert.equal(result.success, true, result.error);
+      assert.equal(result.status, 'completed');
+      const secondResult = await client.agent('a2a-agent').createMediaBuy(createMediaBuyParams);
+      assert.equal(secondResult.success, true, secondResult.error);
+      assert.equal(result.data.media_buy_id, 'mb_transport_a2a_1');
+      assert.equal(secondResult.data.media_buy_id, 'mb_transport_a2a_2');
+      assert.equal(calls.length, 2);
+
+      const started = findToolEvent(events, 'request_started', 'a2a');
+      const received = findToolEvent(events, 'response_received', 'a2a');
+      assert.ok(started, `missing A2A request_started event: ${JSON.stringify(events, null, 2)}`);
+      assert.ok(received, `missing A2A response_received event: ${JSON.stringify(events, null, 2)}`);
+      assert.equal(started.agentId, 'a2a-agent');
+      assert.equal(typeof started.operationId, 'string');
+      assert.equal(typeof started.taskId, 'string');
+      assert.equal(typeof started.idempotencyKeyHash, 'string');
+      assert.notEqual(started.idempotencyKeyHash, result.metadata.idempotency_key);
+      assert.equal(started.requestHeaders.authorization, '[redacted]');
+      assert.equal(started.requestHeaders['x-adcp-auth'], '[redacted]');
+      assert.equal(started.requestHeaders['x-api-key'], '[redacted]');
+      assert.equal(started.requestHeaders['x-scope3-debug-id'], 'debug-a2a-e2e');
+      assert.equal(received.httpStatus, 200);
+      const toolStarts = toolEvents(events, 'request_started', 'a2a');
+      assert.equal(toolStarts.length, 2, `expected two A2A create_media_buy request events`);
+      assert.notEqual(toolStarts[0].operationId, toolStarts[1].operationId);
+      assert.notEqual(toolStarts[0].taskId, toolStarts[1].taskId);
+      assert.notEqual(toolStarts[0].idempotencyKeyHash, toolStarts[1].idempotencyKeyHash);
+      assertNoSecretLeak(events, [
+        'a2a-auth-token-secret',
+        'a2a-api-key-secret',
+        'webhook-secret-minimum-32-characters',
+        'webhook-url-secret',
+        result.metadata.idempotency_key,
+        secondResult.metadata.idempotency_key,
+      ]);
+    } finally {
+      await closeConnections('a2a');
+      await fixture.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #2272.

Adds a public `onTransportActivity` diagnostics hook for outbound MCP and A2A transport requests. Events include request/response/failure phases, HTTP status, duration, method, sanitized URL, safe headers, bounded redacted body snippets, and operation/task/context correlation fields.

The hook is wired through `ADCPMultiAgentClient`, task execution, governance checks, cached MCP calls, native `tasks/list`, and A2A calls while preserving the official protocol SDK clients.

Also updates `undici` from `6.25.0` to `6.27.0` so the PR passes the repo high-severity npm audit gate.

## Safety

- Redacts sensitive headers including auth, cookies, API keys, signatures, and MCP session IDs.
- Redacts body secrets, idempotency keys, private keys, and URL query/userinfo data.
- Avoids reading binary/SSE bodies and bounds response snippets.
- Async handlers are awaited by the diagnostics scope without blocking network start or surfacing handler failures to protocol calls.

## Validation

- `npm run build:lib`
- `NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/transport-diagnostics-e2e.test.js test/lib/transport-diagnostics.test.js test/server-a2a-submitted-end-to-end.test.js test/lib/mcp-oauth-connection-cache.test.js`
- `npm run test:all`
- `npm audit --audit-level=high`
- `npx commitlint --from origin/main --to HEAD --verbose`
