### PR TITLE
fix: allow unknown storyboard requires gates

### DIFF
--- a/.changeset/quiet-storyboards-skip.md
+++ b/.changeset/quiet-storyboards-skip.md
@@ -1,0 +1,5 @@
+---
+"@adcp/sdk": patch
+---
+
+Allow unknown storyboard `requires` values to load and skip at runtime with `requirement_unmet`.

--- a/src/lib/testing/storyboard/loader.ts
+++ b/src/lib/testing/storyboard/loader.ts
@@ -8,8 +8,7 @@
 
 import { readFileSync } from 'fs';
 import { parse } from 'yaml';
-import type { RequirementName, Storyboard } from './types';
-import { KNOWN_REQUIREMENTS } from './types';
+import type { Storyboard } from './types';
 import { MUTATING_TASKS } from '../../utils/idempotency';
 
 /**
@@ -221,19 +220,17 @@ function validatePhaseDependsOn(storyboard: Storyboard): void {
 
 /**
  * Authoring-time validation for `Storyboard.requires` (#1626). The field is
- * a closed enumeration over `RequirementName` so typos and stale tags fail
- * loud rather than silently dropping coverage:
+ * an array of non-empty requirement names:
  *
  *   - `requires: []` is rejected — an empty array reads as "no
  *     requirements," which is the same as omitting the field; failing
  *     load forces the author to omit it explicitly.
- *   - Each entry must be a known `RequirementName` (see
- *     `KNOWN_REQUIREMENTS`). Unknown values fail load with the offending
- *     name and the full set of recognised values.
+ *   - Each entry must be a non-empty string.
  *
- * Future SDK versions may grow `KNOWN_REQUIREMENTS`; storyboards built
- * against an older SDK that name a requirement the runner doesn't know
- * about would silently skip every run, so we fail-load instead.
+ * Unknown string values are allowed for forward compatibility. Runners that
+ * don't know how to satisfy a future requirement skip at runtime with
+ * `skip_reason: 'requirement_unmet'` and the authored value in
+ * `skip.requirement`.
  */
 function validateRequires(storyboard: Storyboard): void {
   if (storyboard.requires === undefined) return;
@@ -245,12 +242,10 @@ function validateRequires(storyboard: Storyboard): void {
   if (storyboard.requires.length === 0) {
     throw new Error(`[${storyboard.id}] requires: [] is not allowed — omit the field to use the default ([real_wire])`);
   }
-  for (const name of storyboard.requires) {
-    if (typeof name !== 'string' || !KNOWN_REQUIREMENTS.has(name as RequirementName)) {
-      const known = [...KNOWN_REQUIREMENTS].sort().join(', ');
-      throw new Error(
-        `[${storyboard.id}] requires: unknown requirement '${String(name)}' — recognised values are [${known}]`
-      );
+  for (let i = 0; i < storyboard.requires.length; i++) {
+    const name = storyboard.requires[i];
+    if (typeof name !== 'string' || name.length === 0) {
+      throw new Error(`[${storyboard.id}] requires[${i}]: entries must be non-empty strings`);
     }
   }
 }

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -123,7 +123,7 @@ import {
   RoutingError,
   type AgentRoutingContext,
 } from './agent-routing';
-import { DETAILED_SKIP_TO_CANONICAL } from './types';
+import { DETAILED_SKIP_TO_CANONICAL, KNOWN_REQUIREMENTS } from './types';
 import type { AgentProfile, TaskResult, TestStepResult } from '../types';
 import {
   type AssertionContext,
@@ -1279,6 +1279,10 @@ const REQUIREMENT_TO_SKIP_REASON: Record<RequirementName, RunnerSkipReason> = {
   request_signer: 'not_applicable',
 };
 
+function isKnownRequirement(requirement: string): requirement is RequirementName {
+  return KNOWN_REQUIREMENTS.has(requirement as RequirementName);
+}
+
 /**
  * Build a minimal StoryboardResult for a storyboard skipped because a
  * `requires:` tag named a requirement that isn't available on this run
@@ -1291,10 +1295,10 @@ const REQUIREMENT_TO_SKIP_REASON: Record<RequirementName, RunnerSkipReason> = {
 function buildRequirementUnmetResult(
   agentUrls: string[],
   storyboard: Storyboard,
-  requirement: RequirementName,
+  requirement: string,
   detail: string
 ): StoryboardResult {
-  const reason = REQUIREMENT_TO_SKIP_REASON[requirement];
+  const reason = isKnownRequirement(requirement) ? REQUIREMENT_TO_SKIP_REASON[requirement] : 'requirement_unmet';
   const syntheticStep: StoryboardStepResult = {
     storyboard_id: storyboard.id,
     step_id: `requirement_unmet:${requirement}`,
@@ -1445,11 +1449,20 @@ function normalizeAgentToolNames(tools: unknown): string[] | undefined {
  *     client. Spec: adcp-client#1702.
  */
 function checkRequires(
-  requires: readonly RequirementName[],
+  requires: readonly string[],
   options: StoryboardRunOptions,
   profile?: AgentProfile
-): { requirement: RequirementName; detail: string } | null {
+): { requirement: string; detail: string } | null {
   for (const requirement of requires) {
+    if (!isKnownRequirement(requirement)) {
+      return {
+        requirement,
+        detail:
+          `Storyboard requires unknown runtime requirement '${requirement}'. ` +
+          `This SDK does not know how to satisfy it, so the requirement is treated as unmet ` +
+          `for forward compatibility.`,
+      };
+    }
     switch (requirement) {
       case 'controller': {
         if (!options.agentTools) continue;

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -98,14 +98,17 @@ export interface Storyboard {
    *
    * Default when the field is absent: `[real_wire]` (storyboard runs
    * everywhere — matches existing pre-tagging behavior). Tagging is
-   * additive opt-in; loader rejects unknown requirement names and an
-   * empty array (`requires: []`) so authoring mistakes fail loud.
+   * additive opt-in; loader rejects malformed values and an empty array
+   * (`requires: []`) so authoring mistakes fail loud. Unknown string
+   * requirements are forward-compatible: they load successfully, then skip
+   * at runtime with `skip_reason: 'requirement_unmet'` and the authored name
+   * on `RunnerSkipResult.requirement`.
    *
    * Spec: adcp-client#1626. The schema may be proposed upstream to
    * `adcontextprotocol/adcp` once it has bedded in across SDK
    * storyboards.
    */
-  requires?: RequirementName[];
+  requires?: string[];
   /**
    * Predicate evaluated against the agent's declared capabilities before any
    * phase runs. When the predicate is false, the runner emits a single
@@ -1698,7 +1701,8 @@ export type RunnerSkipReason =
    * didn't pass `--asserts-seeded-state`). Distinct from `missing_tool` /
    * `missing_test_controller` (per-step tool gates) and `unsatisfied_contract`
    * (capability predicate). The `RunnerSkipResult.requirement` field carries
-   * the unmet requirement name. Spec: adcp-client#1626.
+   * the unmet requirement name, including unknown forward-compatible strings.
+   * Spec: adcp-client#1626.
    */
   | 'requirement_unmet'
   /**
@@ -1815,13 +1819,16 @@ export interface RunnerSkipResult {
   reason: RunnerSkipReason;
   detail: string;
   /**
-   * Set when `reason === 'requirement_unmet'` to name the storyboard-level
-   * requirement that was not available on this run. Carries the same value
-   * authored in `Storyboard.requires`. Consumers (skip-cause aggregation,
-   * dashboards) key on this field to group not-applicable scenarios by
-   * cause. Absent for every other skip reason. Spec: adcp-client#1626.
+   * Set on storyboard-level `requires:` skips to name the requirement that was
+   * not available on this run. Most such skips use
+   * `reason === 'requirement_unmet'`; legacy-preserving mappings such as
+   * `controller -> missing_test_controller` also carry this field. Carries the
+   * same value authored in `Storyboard.requires`, including unknown
+   * forward-compatible strings. Consumers (skip-cause aggregation, dashboards)
+   * key on this field to group not-applicable scenarios by cause. Spec:
+   * adcp-client#1626.
    */
-  requirement?: RequirementName;
+  requirement?: string;
 }
 
 export type RunnerSelectionReason =
@@ -1846,10 +1853,10 @@ export interface RunnerSelectionResult {
 export type RequirementName = 'controller' | 'seeded_state' | 'real_wire' | 'webhook_receiver' | 'request_signer';
 
 /**
- * Closed enumeration of every known requirement. Used by the loader to
- * reject typos in `Storyboard.requires` (`requires: [contoller]` fails
- * load rather than silently dropping coverage) and by the runner to
- * compute available requirements for the gate. Keep in sync with
+ * Enumeration of every requirement this SDK knows how to satisfy. The loader
+ * accepts other non-empty strings for forward compatibility; the runner treats
+ * those as unmet runtime requirements so future source-authored gates degrade
+ * to `requirement_unmet` instead of failing load. Keep in sync with
  * `RequirementName`.
  */
 export const KNOWN_REQUIREMENTS: ReadonlySet<RequirementName> = new Set([

--- a/test/lib/storyboard-requires-gate.test.js
+++ b/test/lib/storyboard-requires-gate.test.js
@@ -148,6 +148,25 @@ describe('Storyboard.requires gate (#1626)', () => {
     const step = result.phases[0].steps[0];
     assert.equal(step.skip.requirement, 'controller', 'first unmet requirement is reported');
   });
+
+  test('unknown requires values load and skip with requirement_unmet at runtime', async () => {
+    const sb = buildStoryboard({ requires: ['multi_agent'] });
+    const result = await runStoryboard('http://fake-local-99999', sb, {
+      _profile: profileWithoutController,
+      agentTools: profileWithoutController.tools,
+    });
+
+    assert.equal(result.overall_passed, true, 'unknown requires-unmet is not a failure');
+    assert.equal(result.skipped_count, 1);
+    assert.equal(result.failed_count, 0);
+
+    const step = result.phases[0].steps[0];
+    assert.equal(step.skipped, true);
+    assert.equal(step.skip_reason, 'requirement_unmet');
+    assert.equal(step.skip.reason, 'requirement_unmet');
+    assert.equal(step.skip.requirement, 'multi_agent');
+    assert.match(step.skip.detail, /unknown runtime requirement 'multi_agent'/);
+  });
 });
 
 describe('Storyboard upstream_traffic authoring checks', () => {
@@ -312,15 +331,15 @@ phases:
     assert.throws(() => parseStoryboard(yaml), /requires: \[\] is not allowed/);
   });
 
-  test('rejects unknown requirement names', () => {
+  test('accepts unknown requirement names for forward-compatible runtime gating', () => {
     const yaml = `
-id: bad_unknown
+id: ok_unknown
 version: "1.0.0"
-title: bad name
+title: future gate
 category: test
 summary: ""
 narrative: ""
-requires: [contoller]
+requires: [multi_agent]
 agent:
   interaction_model: sync
   capabilities: []
@@ -331,7 +350,8 @@ phases:
     title: P
     steps: []
 `;
-    assert.throws(() => parseStoryboard(yaml), /unknown requirement 'contoller'/);
+    const parsed = parseStoryboard(yaml);
+    assert.deepEqual(parsed.requires, ['multi_agent']);
   });
 
   test('rejects non-array requires', () => {
@@ -348,6 +368,17 @@ phases:
       phases: [{ id: 'p1', title: 'P', steps: [] }],
     };
     assert.throws(() => validateStoryboardShape(sb), /requires: must be an array/);
+  });
+
+  test('rejects malformed requires entries', () => {
+    assert.throws(
+      () => validateStoryboardShape(buildStoryboard({ requires: [''] })),
+      /requires\[0\]: entries must be non-empty strings/
+    );
+    assert.throws(
+      () => validateStoryboardShape(buildStoryboard({ requires: ['controller', 42] })),
+      /requires\[1\]: entries must be non-empty strings/
+    );
   });
 
   test('accepts known requirement names', () => {


### PR DESCRIPTION
## Summary
- allow unknown storyboard `requires` strings to pass loader validation
- treat unknown runtime requirements as unmet and emit `requirement_unmet` with `skip.requirement` set to the authored value
- keep known requirement behavior intact, including the legacy `controller -> missing_test_controller` mapping
- add regression coverage and a patch changeset

## Why
Fixes #2273. Source-authored future gates such as `requires: [multi_agent]` should degrade to a structured runtime skip instead of failing storyboard load.

## Expert Review
- Node.js testing expert found missing malformed-entry coverage; added `rejects malformed requires entries`.
- Protocol reviewer found a `RunnerSkipResult.requirement` doc mismatch for legacy mapped skips; updated the comment.
- A third code-review agent did not complete before PR creation and was closed.

## Validation
- `npx tsc --project tsconfig.lib.json --noEmit`
- `NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/lib/storyboard-requires-gate.test.js`
- `git diff --check -- src/lib/testing/storyboard/loader.ts src/lib/testing/storyboard/runner.ts src/lib/testing/storyboard/types.ts test/lib/storyboard-requires-gate.test.js .changeset/quiet-storyboards-skip.md`
- `npx commitlint --from HEAD~1 --to HEAD --verbose`
- pre-push validation hook passed

## Notes
`package-lock.json` has a pre-existing local modification in this workspace and is intentionally not included in this PR.