### PR TITLE
fix: publish stable releases to latest

### DIFF
--- a/.changeset/latest-release-tag.md
+++ b/.changeset/latest-release-tag.md
@@ -1,0 +1,5 @@
+---
+"@adcp/sdk": patch
+---
+
+Publish stable SDK releases under the `latest` npm dist-tag by default.

--- a/docs/development/NPM-DIST-TAGS.md
+++ b/docs/development/NPM-DIST-TAGS.md
@@ -1,39 +1,41 @@
 # npm Dist-Tags
 
-`@adcp/sdk` publishes AdCP compatibility dist-tags:
+`@adcp/sdk` uses `latest` for the current stable SDK line. Users should be able
+to run `npm install @adcp/sdk` or `npx @adcp/sdk` and receive the supported
+stable release.
+
+Older supported protocol lines may also have explicit AdCP compatibility
+dist-tags:
 
 - `adcp-3.0` for the newest SDK runner/schema bundle in the AdCP 3.0 line.
-- `adcp-3.1` for the newest SDK runner/schema bundle in the AdCP 3.1 line.
-- `adcp-3.2` for the newest SDK runner/schema bundle once the AdCP 3.2 line opens.
+- `adcp-3.1` only if AdCP 3.1 becomes a maintenance line after a newer stable
+  protocol line opens.
 
-These are long-lived CI targets. They should move forward within a protocol
-minor line, but should not move across protocol minor lines. For example, Python
-SDK CI can pin `@adcp/sdk@adcp-3.0` and `@adcp/sdk@adcp-3.1` without being moved
-when another compatibility line opens.
+Compatibility tags are long-lived CI targets. They should move forward within a
+protocol minor line, but should not move across protocol minor lines. For
+example, Python SDK CI can pin `@adcp/sdk@adcp-3.0` without being moved when
+another compatibility line opens.
 
 Do not use bare `3.0`, `3.1`, or `3.2` as npm dist-tags. npm rejects those tag
 names because it parses them as semver ranges.
 
 ## Release Automation
 
-The release workflow publishes with `npm publish --tag adcp-<major.minor>` via
-`npm run release`. The tag is derived from `package.json#adcp_version`; for
-example:
+The release workflow publishes with `npm publish --tag latest` via
+`npm run release`. `latest` intentionally tracks the default stable SDK release,
+not a branch name.
 
-```text
-3.0.12 -> adcp-3.0
-3.1.0-beta.3 -> adcp-3.1
-3.2.0-beta.0 -> adcp-3.2
-```
+Set `ADCP_NPM_TAG` only when intentionally publishing a maintenance or alternate
+channel, for example `ADCP_NPM_TAG=adcp-3.0 npm run release`.
 
 This is intentionally a publish-time tag, not a post-publish `npm dist-tag add`.
 npm trusted publishing via GitHub OIDC authenticates `npm publish`, so the
-compatibility tag works without a long-lived npm token. Post-publish dist-tag
-mutation is a separate registry operation and is not covered by OIDC.
-Emergency retags can still be repaired manually with `npm dist-tag add`, but
-normal releases should not need a registry token.
+chosen tag works without a long-lived npm token. Post-publish dist-tag mutation
+is a separate registry operation and is not covered by OIDC. Emergency retags can
+still be repaired manually with `npm dist-tag add`, but normal releases should
+not need a registry token.
 
 Changesets pre-mode normally uses the pre-mode tag for both the npm dist-tag and
-the semver prerelease identifier. The release wrapper temporarily changes the
-checkout's pre-mode tag only while `changeset publish` runs. That keeps package
-versions like `8.1.0-beta.12`, while publishing them under `adcp-3.1`.
+the semver prerelease identifier. The release wrapper keeps that pre-mode tag
+unless `ADCP_NPM_TAG` is set. That prevents prereleases from moving `latest`
+accidentally.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/sdk",
-  "version": "9.0.0",
+  "version": "9.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/sdk",
-      "version": "9.0.0",
+      "version": "9.1.1",
       "license": "Apache-2.0",
       "workspaces": [
         ".",
@@ -7426,7 +7426,7 @@
       "version": "6.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adcp/sdk": "^9.0.0"
+        "@adcp/sdk": "^9.1.1"
       },
       "bin": {
         "adcp": "bin/adcp.js"

--- a/package.json
+++ b/package.json
@@ -303,7 +303,7 @@
     "test:e2e:local-app": "node test/e2e/adcp-e2e.test.js",
     "test:protocols": "node test/run-protocol-tests.js",
     "changeset": "changeset",
-    "version": "changeset version && npm run sync-version",
+    "version": "changeset version && npm install --package-lock-only --ignore-scripts && npm run sync-version",
     "release": "tsx scripts/publish-adcp-release.ts",
     "test:protocol-compliance": "node test/run-protocol-tests.js --only compliance",
     "test:protocol-schema": "node test/run-protocol-tests.js --only schema",

--- a/scripts/publish-adcp-release.ts
+++ b/scripts/publish-adcp-release.ts
@@ -3,44 +3,18 @@ import { spawnSync } from 'node:child_process';
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
-type PackageJson = {
-  adcp_version?: string;
-};
-
 type ChangesetPreState = {
   mode?: string;
   tag?: string;
   [key: string]: unknown;
 };
 
-const PACKAGE_JSON_PATH = resolve('package.json');
 const PRE_STATE_PATH = resolve('.changeset/pre.json');
+const DEFAULT_RELEASE_TAG = 'latest';
 const isDryRun = process.argv.includes('--dry-run');
-
-function readJson<T>(path: string): T {
-  return JSON.parse(readFileSync(path, 'utf8')) as T;
-}
 
 function writeJson(path: string, value: unknown): void {
   writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
-}
-
-function adcpMinorLine(adcpVersion: string): string {
-  const match = /^(\d+)\.(\d+)(?:\.\d+)?(?:-[0-9A-Za-z.-]+)?$/.exec(adcpVersion);
-  if (match == null) {
-    throw new Error(
-      `Cannot derive AdCP minor line from ${JSON.stringify(adcpVersion)}. ` +
-        'Expected MAJOR.MINOR[.PATCH][-PRERELEASE].'
-    );
-  }
-  return `${match[1]}.${match[2]}`;
-}
-
-function adcpPublishTag(): string {
-  const packageJson = readJson<PackageJson>(PACKAGE_JSON_PATH);
-  const adcpVersion = packageJson.adcp_version;
-  if (!adcpVersion) throw new Error('Missing package.json#adcp_version.');
-  return `adcp-${adcpMinorLine(adcpVersion)}`;
 }
 
 function runChangesetPublish(): number {
@@ -57,11 +31,16 @@ function runChangesetPublish(): number {
   return result.status ?? 1;
 }
 
-function main(): void {
-  const tag = process.env.ADCP_NPM_TAG || adcpPublishTag();
-  const publishArgs = ['publish', '--tag', tag];
+function resolvePublishTag(preState?: ChangesetPreState): string {
+  if (process.env.ADCP_NPM_TAG) return process.env.ADCP_NPM_TAG;
+  if (preState?.mode === 'pre' && preState.tag) return preState.tag;
+  return DEFAULT_RELEASE_TAG;
+}
 
+function main(): void {
   if (!existsSync(PRE_STATE_PATH)) {
+    const tag = resolvePublishTag();
+    const publishArgs = ['publish', '--tag', tag];
     console.log(`Publishing packages under npm dist-tag ${tag}.`);
     if (isDryRun) {
       console.log(`[dry-run] changeset ${publishArgs.join(' ')}`);
@@ -77,6 +56,8 @@ function main(): void {
 
   const originalPreStateText = readFileSync(PRE_STATE_PATH, 'utf8');
   const preState = JSON.parse(originalPreStateText) as ChangesetPreState;
+  const tag = resolvePublishTag(preState);
+  const publishArgs = ['publish', '--tag', tag];
 
   if (preState.mode !== 'pre') {
     console.log(`Publishing packages under npm dist-tag ${tag}.`);


### PR DESCRIPTION
## Summary

- Publish stable SDK releases under the `latest` npm dist-tag by default.
- Keep `ADCP_NPM_TAG` as the explicit override for maintenance channels like `adcp-3.0`.
- Refresh `package-lock.json` during the Changesets version step so release PRs keep lock metadata aligned with `package.json`.
- Document the npm dist-tag policy and add a patch changeset.

## Validation

- `npm run release -- --dry-run`
- `ADCP_NPM_TAG=adcp-3.0 npm run release -- --dry-run`
- `npx changeset status --since=origin/main`
- `npx tsc --noEmit --target es2022 --module nodenext --moduleResolution nodenext --types node scripts/publish-adcp-release.ts`
- `git diff --check`
- pre-push validation: typecheck + build
