### PR TITLE
fix: apply schema defaults to capability gates

### DIFF
--- a/.changeset/storyboard-capability-defaults.md
+++ b/.changeset/storyboard-capability-defaults.md
@@ -2,4 +2,4 @@
 "@adcp/sdk": patch
 ---
 
-Apply get_adcp_capabilities schema defaults when evaluating storyboard requires_capability gates.
+Apply get_adcp_capabilities schema defaults when evaluating storyboard `equals`/`contains` requires_capability gates. Presence matchers (`present:`) keep absence as the load-bearing signal and do not materialize defaults.

--- a/.changeset/storyboard-capability-defaults.md
+++ b/.changeset/storyboard-capability-defaults.md
@@ -1,0 +1,5 @@
+---
+"@adcp/sdk": patch
+---
+
+Apply get_adcp_capabilities schema defaults when evaluating storyboard requires_capability gates.

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -44,6 +44,7 @@ import { enrichRequest, hasRequestEnricher } from './request-builder';
 import { resolveAccount, resolveBrand } from '../client';
 import { isMutatingTask, generateIdempotencyKey } from '../../utils/idempotency';
 import {
+  getSchemaDefaultByPath,
   getSchemaValidatorByRef,
   resolveBundleKey,
   schemaAllowsTopLevelField,
@@ -265,9 +266,32 @@ export function resolveCapabilityPath(raw: unknown, dottedPath: string): unknown
   let current: unknown = raw;
   for (const key of keys) {
     if (current === null || typeof current !== 'object') return undefined;
+    if (!Object.prototype.hasOwnProperty.call(current, key)) return undefined;
     current = (current as Record<string, unknown>)[key];
   }
   return current;
+}
+
+const GET_ADCP_CAPABILITIES_RESPONSE_SCHEMA_REF = 'protocol/get-adcp-capabilities-response.json';
+
+function resolveCapabilityPathForGate(raw: unknown, dottedPath: string, adcpVersion?: string): unknown {
+  const actual = resolveCapabilityPath(raw, dottedPath);
+  if (actual !== undefined) return actual;
+  if (!schemaDefaultShouldApply(raw, dottedPath)) return undefined;
+  return getSchemaDefaultByPath(GET_ADCP_CAPABILITIES_RESPONSE_SCHEMA_REF, dottedPath, adcpVersion);
+}
+
+function schemaDefaultShouldApply(raw: unknown, dottedPath: string): boolean {
+  const keys = dottedPath.split('.');
+  if (keys.length <= 1) return raw !== null && typeof raw === 'object';
+
+  let current: unknown = raw;
+  for (const key of keys.slice(0, -1)) {
+    if (current === null || typeof current !== 'object') return false;
+    if (!Object.prototype.hasOwnProperty.call(current, key)) return false;
+    current = (current as Record<string, unknown>)[key];
+  }
+  return current !== null && typeof current === 'object';
 }
 
 /**
@@ -279,8 +303,8 @@ export function resolveCapabilityPath(raw: unknown, dottedPath: string): unknown
  * Three matcher forms — see `Storyboard.requires_capability` for full semantics:
  *
  * - `equals: V` — scalar equality. `actual` must be declared and must equal
- *   `V`. Absent fields (`undefined`) skip because the agent has not opted
- *   into the capability or capability variant this storyboard tests.
+ *   `V`. Absent fields (`undefined`) skip unless the capabilities schema
+ *   declares a default that the gate materialized before predicate evaluation.
  *
  * - `present: B` — presence is the load-bearing signal. `present: true`
  *   skips when the field is absent (treats `undefined` and `null` as absent).
@@ -294,8 +318,8 @@ export function resolveCapabilityPath(raw: unknown, dottedPath: string): unknown
  *
  * - `contains: V` — array-membership. `actual` must be an array that
  *   includes `V` (strict equality, no coercion). Empty arrays, non-arrays,
- *   and absent fields all skip — absence means the agent hasn't opted into
- *   the array variant this storyboard tests.
+ *   and absent fields all skip unless the capabilities schema declares a
+ *   default that the gate materialized before predicate evaluation.
  *
  * Exported for direct testing so the predicate semantics are pinned without
  * needing a full runStoryboard() roundtrip.
@@ -348,11 +372,12 @@ export function evaluateCapabilityPredicate(predicate: RequiresCapabilityPredica
 function evaluateRequiresCapabilityGate(
   predicate: RequiresCapabilityPredicate,
   profile: AgentProfile | undefined,
-  agentTools?: readonly string[]
+  agentTools?: readonly string[],
+  adcpVersion?: string
 ): string | null {
   const rawCaps = profile?.raw_capabilities;
   if (rawCaps !== undefined) {
-    const actual = resolveCapabilityPath(rawCaps, predicate.path);
+    const actual = resolveCapabilityPathForGate(rawCaps, predicate.path, adcpVersion);
     return evaluateCapabilityPredicate(predicate, actual);
   }
   const tools = agentTools ?? profile?.tools;
@@ -365,12 +390,13 @@ function evaluateRequiresCapabilityGate(
 function collectPhaseCapabilitySkipDetails(
   storyboard: Storyboard,
   profile: AgentProfile | undefined,
-  agentTools?: readonly string[]
+  agentTools?: readonly string[],
+  adcpVersion?: string
 ): Map<string, string> {
   const skipDetails = new Map<string, string>();
   for (const phase of storyboard.phases) {
     if (!phase.requires_capability) continue;
-    const unmetDetail = evaluateRequiresCapabilityGate(phase.requires_capability, profile, agentTools);
+    const unmetDetail = evaluateRequiresCapabilityGate(phase.requires_capability, profile, agentTools, adcpVersion);
     if (unmetDetail !== null) {
       skipDetails.set(phase.id, unmetDetail);
     }
@@ -2087,7 +2113,12 @@ async function executeStoryboardPass(
   // tests (e.g. `adcp.idempotency.supported: false`), skip the whole storyboard
   // rather than producing a cascade of misleading per-phase failures.
   if (storyboard.requires_capability) {
-    const unmetDetail = evaluateRequiresCapabilityGate(storyboard.requires_capability, profile, options.agentTools);
+    const unmetDetail = evaluateRequiresCapabilityGate(
+      storyboard.requires_capability,
+      profile,
+      options.agentTools,
+      options.adcpVersion
+    );
     if (unmetDetail !== null) {
       if (!callerOwnsClients) await closeConnections(options.protocol);
       return {
@@ -2267,7 +2298,12 @@ async function executeStoryboardPass(
   // an implementor reading the report can't tell "nothing tested" from
   // "everything passed".
   const hasExecutableSteps = storyboard.phases.some(p => p.steps.length > 0);
-  const phaseCapabilitySkipDetails = collectPhaseCapabilitySkipDetails(storyboard, profile, options.agentTools);
+  const phaseCapabilitySkipDetails = collectPhaseCapabilitySkipDetails(
+    storyboard,
+    profile,
+    options.agentTools,
+    options.adcpVersion
+  );
   const skipControllerSeedingForPhaseGates = allExecutablePhasesCapabilitySkipped(
     storyboard,
     phaseCapabilitySkipDetails
@@ -3243,7 +3279,12 @@ async function runMultiPass(
       ...(options.agentTools ? {} : { agentTools: normalizeAgentToolNames(preSeedProfile.tools) }),
     };
   }
-  const phaseCapabilitySkipDetails = collectPhaseCapabilitySkipDetails(storyboard, preSeedProfile, options.agentTools);
+  const phaseCapabilitySkipDetails = collectPhaseCapabilitySkipDetails(
+    storyboard,
+    preSeedProfile,
+    options.agentTools,
+    options.adcpVersion
+  );
   const preSeededResult = allExecutablePhasesCapabilitySkipped(storyboard, phaseCapabilitySkipDetails)
     ? null
     : await runControllerSeeding(preSeedClients[0]!, storyboard, options, preSeedContext);

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -274,11 +274,23 @@ export function resolveCapabilityPath(raw: unknown, dottedPath: string): unknown
 
 const GET_ADCP_CAPABILITIES_RESPONSE_SCHEMA_REF = 'protocol/get-adcp-capabilities-response.json';
 
-function resolveCapabilityPathForGate(raw: unknown, dottedPath: string, adcpVersion?: string): unknown {
-  const actual = resolveCapabilityPath(raw, dottedPath);
+function resolveCapabilityPathForGate(
+  raw: unknown,
+  predicate: RequiresCapabilityPredicate,
+  adcpVersion?: string
+): unknown {
+  const actual = resolveCapabilityPath(raw, predicate.path);
   if (actual !== undefined) return actual;
-  if (!schemaDefaultShouldApply(raw, dottedPath)) return undefined;
-  return getSchemaDefaultByPath(GET_ADCP_CAPABILITIES_RESPONSE_SCHEMA_REF, dottedPath, adcpVersion);
+  // `present:` is an absence-detection matcher — an absent field IS the
+  // load-bearing signal. Materializing a schema default would make a defaulted
+  // field never read as absent, silently flipping the gate (e.g. a signals
+  // seller that omits `signals.discovery_modes`, default `["brief"]`, would run
+  // a `present: true`-gated scenario that should skip). Defaults are resolved
+  // only for the value matchers (`equals` / `contains`), where the default's
+  // VALUE is what the gate tests.
+  if ('present' in predicate) return undefined;
+  if (!schemaDefaultShouldApply(raw, predicate.path)) return undefined;
+  return getSchemaDefaultByPath(GET_ADCP_CAPABILITIES_RESPONSE_SCHEMA_REF, predicate.path, adcpVersion);
 }
 
 function schemaDefaultShouldApply(raw: unknown, dottedPath: string): boolean {
@@ -314,7 +326,10 @@ function schemaDefaultShouldApply(raw: unknown, dottedPath: string): boolean {
  *   non-conformant for object-typed capabilities (`"type": "object"` rejects
  *   null in JSON Schema), but is coalesced with absent here in the spirit of
  *   Postel — agents that misdeclare a not-supported capability as `null`
- *   get the same not_applicable skip as agents that omit the field.
+ *   get the same not_applicable skip as agents that omit the field. Schema
+ *   defaults are deliberately NOT materialized for this matcher: presence is
+ *   the signal, so a default would defeat the gate (see
+ *   `resolveCapabilityPathForGate`).
  *
  * - `contains: V` — array-membership. `actual` must be an array that
  *   includes `V` (strict equality, no coercion). Empty arrays, non-arrays,
@@ -377,7 +392,7 @@ function evaluateRequiresCapabilityGate(
 ): string | null {
   const rawCaps = profile?.raw_capabilities;
   if (rawCaps !== undefined) {
-    const actual = resolveCapabilityPathForGate(rawCaps, predicate.path, adcpVersion);
+    const actual = resolveCapabilityPathForGate(rawCaps, predicate, adcpVersion);
     return evaluateCapabilityPredicate(predicate, actual);
   }
   const tools = agentTools ?? profile?.tools;

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -124,8 +124,9 @@ export interface Storyboard {
    * - `equals: V` — scalar equality. The path's resolved value must be
    *   declared and must equal `V` for the storyboard to run. When the path
    *   resolves to `undefined` (field absent), the storyboard is skipped as
-   *   `capability_unsupported`; omitting a capability means the agent has not
-   *   opted into that behavior or variant.
+   *   `capability_unsupported` unless the `get_adcp_capabilities` response
+   *   schema declares a default for that exact path and the parent capability
+   *   object is present.
    *
    * - `present: true|false` — presence-only matcher for spec capabilities whose
    *   contract is "presence of this object indicates support" (e.g.
@@ -143,10 +144,11 @@ export interface Storyboard {
    *   `media_buy.conversion_tracking.supported_targets: ["cost_per",
    *   "per_ad_spend"]`). The value at `path` MUST be an array and MUST include
    *   `V` (strict equality, no coercion). Empty arrays fail; paths resolving
-   *   to undefined or non-array values fail (treated as "capability not
-   *   declared", skip the storyboard as not_applicable). Like `present:`,
-   *   absence is the load-bearing signal — a seller that doesn't advertise
-   *   the array hasn't opted into the variant this storyboard tests.
+   *   to undefined or non-array values fail unless the `get_adcp_capabilities`
+   *   response schema declares a default for that exact path and the parent
+   *   capability object is present. Like `present:`, absence is otherwise the
+   *   load-bearing signal — a seller that doesn't advertise the array hasn't
+   *   opted into the variant this storyboard tests.
    *
    * When `raw_capabilities` is not available and the discovered profile does
    * not expose `get_adcp_capabilities`, `equals` gates are treated as

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -137,7 +137,9 @@ export interface Storyboard {
    *   capability. Unlike `equals`, absence is the load-bearing signal: when
    *   `present: true` and the field is missing, the storyboard is skipped
    *   (not_applicable) rather than run, because the seller's silence is the
-   *   spec-defined opt-out.
+   *   spec-defined opt-out. Schema defaults are NOT materialized for this
+   *   matcher (unlike `equals`/`contains`): a default would make a defaulted
+   *   field never read as absent, defeating the gate.
    *
    * - `contains: V` — array-membership matcher for capabilities whose
    *   declaration shape is an array of allowed values (e.g.

--- a/src/lib/validation/schema-loader.ts
+++ b/src/lib/validation/schema-loader.ts
@@ -973,3 +973,60 @@ export function schemaAllowsTopLevelField(toolName: string, field: string, versi
     return true;
   }
 }
+
+/**
+ * Resolve a JSON Schema `default` value by walking a dot-separated property
+ * path through a schema's nested `properties` maps.
+ *
+ * This intentionally does not instantiate AJV's `useDefaults` mutation mode.
+ * Callers decide when a schema default is semantically meaningful for their
+ * runtime object; this helper only reports what the bundled schema declares.
+ *
+ * Fails closed (`undefined`) when the schema is unavailable, the path is not a
+ * concrete properties path, or the target schema node has no `default`.
+ *
+ * @internal — not part of the public API surface; may change without a major bump.
+ */
+export function getSchemaDefaultByPath(schemaRef: string, dottedPath: string, version: string = ADCP_VERSION): unknown {
+  try {
+    const s = ensureInit(version);
+    const normalized = normalizeSchemaRef(schemaRef);
+    if (!normalized) return undefined;
+
+    const cacheKey = `schema-ref::${normalized}`;
+    const file = path.join(s.root, normalized);
+    if (!existsSync(file)) return undefined;
+
+    let schema = s.rawSchemas.get(cacheKey);
+    if (!schema) {
+      schema = loadJson(file) as Record<string, unknown>;
+      s.rawSchemas.set(cacheKey, schema);
+    }
+
+    const node = resolveSchemaPropertyPath(schema, dottedPath);
+    if (!node || !Object.prototype.hasOwnProperty.call(node, 'default')) return undefined;
+    return cloneJsonValue((node as { default: unknown }).default);
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveSchemaPropertyPath(
+  schema: Record<string, unknown>,
+  dottedPath: string
+): Record<string, unknown> | undefined {
+  let current: unknown = schema;
+  for (const key of dottedPath.split('.')) {
+    if (!current || typeof current !== 'object') return undefined;
+    const props = (current as Record<string, unknown>).properties;
+    if (!props || typeof props !== 'object') return undefined;
+    if (!Object.prototype.hasOwnProperty.call(props, key)) return undefined;
+    current = (props as Record<string, unknown>)[key];
+  }
+  return current && typeof current === 'object' ? (current as Record<string, unknown>) : undefined;
+}
+
+function cloneJsonValue(value: unknown): unknown {
+  if (value === null || typeof value !== 'object') return value;
+  return JSON.parse(JSON.stringify(value)) as unknown;
+}

--- a/test/lib/storyboard-capability-gate.test.js
+++ b/test/lib/storyboard-capability-gate.test.js
@@ -301,20 +301,11 @@ describe('requires_capability storyboard skip gate (#933)', () => {
   test('resolveCapabilityPath: prototype-chain keys are NOT walkable', () => {
     // Defensive: a malicious or malformed capabilities response shouldn't
     // be able to expose Object.prototype values via dotted-path lookup.
-    // `__proto__` is a real key on object literals, so it walks through
-    // — that's expected. But values inherited from Object.prototype
-    // (e.g., `constructor`) should NOT be reachable as if they were
-    // declared on the agent.
+    // Values inherited from Object.prototype must not be reachable as if
+    // they were declared on the agent.
     const obj = {};
-    // `toString` is on the prototype but not own-property
-    const result = resolveCapabilityPath(obj, 'toString');
-    // Either undefined (own-property check) or the function (no check).
-    // The current implementation does not enforce own-property — this
-    // test pins the current behavior so a future tightening is visible.
-    // If this assertion ever needs to flip, the call site (which only
-    // matches `actual === equals` against scalars) is unaffected: a
-    // function or any complex value will fail the equality predicate.
-    assert.ok(typeof result === 'function' || result === undefined);
+    assert.equal(resolveCapabilityPath(obj, 'toString'), undefined);
+    assert.equal(resolveCapabilityPath(obj, 'constructor'), undefined);
   });
 
   test('inline creative equals gate skips when omitted', async () => {
@@ -370,7 +361,7 @@ describe('requires_capability storyboard skip gate (#933)', () => {
     assert.equal(step.skip_reason, 'capability_unsupported');
     assert.equal(step.skip.reason, 'unsatisfied_contract');
     assert.ok(step.skip.detail.includes('media_buy.supports_proposals'));
-    assert.ok(step.skip.detail.includes('did not declare'));
+    assert.ok(step.skip.detail.includes('false'));
   });
 
   test('proposal lifecycle equals gate skips when raw capabilities are unavailable', async () => {
@@ -585,6 +576,36 @@ const supportedTargetsGatedStoryboard = {
   ],
 };
 
+const propagationSurfacesGatedStoryboard = {
+  id: 'dependency_impairment_snapshot_gate_test',
+  version: '1.0.0',
+  title: 'Dependency impairment snapshot surface (array-membership-gated)',
+  category: 'test',
+  summary: 'Runs only when seller surfaces dependency impairments on snapshots.',
+  narrative: '',
+  agent: { interaction_model: 'sync', capabilities: [] },
+  caller: { role: 'buyer_agent' },
+  requires_capability: {
+    path: 'media_buy.propagation_surfaces',
+    contains: 'snapshot',
+  },
+  phases: [
+    {
+      id: 'snapshot_impairment',
+      title: 'Snapshot impairment phase',
+      steps: [
+        {
+          id: 'get_products_step',
+          title: 'Discover products after snapshot gate',
+          task: 'get_products',
+          sample_request: { brief: 'snapshot impairment gated flow' },
+          validations: [],
+        },
+      ],
+    },
+  ],
+};
+
 describe('requires_capability `contains:` matcher (#1817)', () => {
   test('contains: skips when array is missing the required value', async () => {
     const profile = {
@@ -624,6 +645,85 @@ describe('requires_capability `contains:` matcher (#1817)', () => {
     });
     assert.equal(result.skipped_count, 1);
     assert.equal(result.phases[0].steps[0].skip_reason, 'capability_unsupported');
+  });
+
+  test('contains: materializes get_adcp_capabilities schema default when parent capability is present (#2278)', async () => {
+    const { client, calls } = makeCapabilityGateClient();
+    const result = await runStoryboard('https://example.invalid/mcp', propagationSurfacesGatedStoryboard, {
+      protocol: 'mcp',
+      allow_http: false,
+      agentTools: ['get_adcp_capabilities', 'get_products'],
+      _profile: {
+        name: 'Test Agent (implicit snapshot propagation surface)',
+        tools: ['get_adcp_capabilities', 'get_products'],
+        raw_capabilities: {
+          media_buy: { buying_modes: ['brief'] },
+        },
+      },
+      _client: client,
+    });
+
+    assert.equal(result.overall_passed, true);
+    assert.equal(result.skipped_count, 0);
+    assert.equal(result.passed_count, 1);
+    assert.equal(result.failed_count, 0);
+    assert.equal(result.phases[0].phase_id, 'snapshot_impairment');
+    assert.equal(result.phases[0].steps[0].skipped, undefined);
+    assert.equal(result.phases[0].steps[0].passed, true);
+    assert.deepEqual(
+      calls.map(c => c.name),
+      ['get_products']
+    );
+  });
+
+  test('contains: does not apply nested schema defaults when the parent capability is absent (#2278)', async () => {
+    const { client, calls } = makeCapabilityGateClient();
+    const result = await runStoryboard('https://example.invalid/mcp', propagationSurfacesGatedStoryboard, {
+      protocol: 'mcp',
+      allow_http: false,
+      agentTools: ['get_adcp_capabilities', 'get_products'],
+      _profile: {
+        name: 'Test Agent (no media-buy capability block)',
+        tools: ['get_adcp_capabilities', 'get_products'],
+        raw_capabilities: {
+          supported_protocols: ['media_buy'],
+        },
+      },
+      _client: client,
+    });
+
+    assert.equal(result.overall_passed, true);
+    assert.equal(result.skipped_count, 1);
+    assert.equal(result.passed_count, 0);
+    assert.equal(result.failed_count, 0);
+    assert.equal(result.phases[0].steps[0].skip_reason, 'capability_unsupported');
+    assert.deepEqual(calls, [], 'top-level gate should skip before dispatching');
+  });
+
+  test('contains: explicit propagation_surfaces declaration overrides the schema default (#2278)', async () => {
+    const { client, calls } = makeCapabilityGateClient();
+    const result = await runStoryboard('https://example.invalid/mcp', propagationSurfacesGatedStoryboard, {
+      protocol: 'mcp',
+      allow_http: false,
+      agentTools: ['get_adcp_capabilities', 'get_products'],
+      _profile: {
+        name: 'Test Agent (webhook-only propagation surface)',
+        tools: ['get_adcp_capabilities', 'get_products'],
+        raw_capabilities: {
+          media_buy: { propagation_surfaces: ['webhook'] },
+        },
+      },
+      _client: client,
+    });
+
+    assert.equal(result.overall_passed, true);
+    assert.equal(result.skipped_count, 1);
+    assert.equal(result.failed_count, 0);
+    assert.equal(result.phases[0].steps[0].skip_reason, 'capability_unsupported');
+    assert.ok(result.phases[0].steps[0].skip.detail.includes('media_buy.propagation_surfaces'));
+    assert.ok(result.phases[0].steps[0].skip.detail.includes('snapshot'));
+    assert.ok(result.phases[0].steps[0].skip.detail.includes('webhook'));
+    assert.deepEqual(calls, [], 'top-level gate should skip before dispatching');
   });
 
   test('evaluateCapabilityPredicate: pins contains semantics', () => {

--- a/test/lib/storyboard-capability-gate.test.js
+++ b/test/lib/storyboard-capability-gate.test.js
@@ -429,6 +429,36 @@ const presentAbsentGatedStoryboard = {
   requires_capability: { path: 'media_buy.conversion_tracking', present: false },
 };
 
+// `signals.discovery_modes` is a presence-gated field that ALSO carries a
+// schema default (`["brief"]`). It is the one capability where the #2278
+// default-materialization could collide with `present:` semantics, so it gets
+// dedicated coverage below.
+const discoveryModesPresentGatedStoryboard = {
+  id: 'signals_discovery_present_gate_test',
+  version: '1.0.0',
+  title: 'Signal discovery (presence-gated, schema-defaulted field)',
+  category: 'test',
+  summary: 'Runs only when the seller advertises signals.discovery_modes.',
+  narrative: '',
+  agent: { interaction_model: 'sync', capabilities: [] },
+  caller: { role: 'buyer_agent' },
+  requires_capability: { path: 'signals.discovery_modes', present: true },
+  phases: [
+    {
+      id: 'discovery',
+      title: 'Discovery phase',
+      steps: [
+        {
+          id: 'get_signals_step',
+          title: 'Discover signals',
+          task: 'get_signals',
+          sample_request: {},
+        },
+      ],
+    },
+  ],
+};
+
 describe('requires_capability `present:` matcher (#1811)', () => {
   test('present: true — skips when agent does not declare the capability at all', async () => {
     const profile = {
@@ -505,6 +535,35 @@ describe('requires_capability `present:` matcher (#1811)', () => {
     assert.ok(
       step.skip.detail.includes('must be absent'),
       `detail must explain absence requirement: ${step.skip.detail}`
+    );
+  });
+
+  test('present: true — schema defaults are NOT materialized; absent defaulted field still skips (#2278)', async () => {
+    // signals.discovery_modes has schema default ["brief"]. The #2278 default
+    // materialization must NOT apply to `present:` — absence is the gate's
+    // signal. A seller that declares a `signals` block but omits
+    // discovery_modes must still skip, not run. (Without the present-matcher
+    // exclusion, the default would materialize and flip this gate skip→run.)
+    const profile = {
+      name: 'Test Agent (signals declared, discovery_modes omitted)',
+      tools: ['get_adcp_capabilities', 'get_signals'],
+      raw_capabilities: { signals: { data_providers: ['example.com'] } },
+    };
+    const result = await runStoryboard('http://fake-local-99995', discoveryModesPresentGatedStoryboard, {
+      _profile: profile,
+    });
+    assert.equal(result.overall_passed, true);
+    assert.equal(result.skipped_count, 1);
+    const step = result.phases[0].steps[0];
+    assert.equal(step.skipped, true);
+    assert.equal(step.skip_reason, 'capability_unsupported');
+    assert.ok(
+      step.skip.detail.includes('signals.discovery_modes'),
+      `detail must mention the capability path: ${step.skip.detail}`
+    );
+    assert.ok(
+      step.skip.detail.includes('must be present'),
+      `detail must explain presence requirement: ${step.skip.detail}`
     );
   });
 


### PR DESCRIPTION
## Summary
- materialize JSON Schema defaults from get_adcp_capabilities before evaluating storyboard requires_capability gates
- keep nested defaults scoped to present parent capability objects so absent domains still skip
- harden capability path lookup to own properties and add #2278 regression coverage

Fixes #2278.

## Validation
- npm run build:lib
- NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/lib/storyboard-capability-gate.test.js
- npm run lint (passes with existing warnings)