### PR TITLE
feat(conformance): add multi-agent storyboard requirement

### DIFF
--- a/.changeset/sun-valley-multi-agent-requires.md
+++ b/.changeset/sun-valley-multi-agent-requires.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': minor
+---
+
+Add a known storyboard `multi_agent` runtime requirement. Storyboards that already authored this previously unknown requirement now run when `default_agent` plus step-level `agent:` overrides resolve to at least two distinct entries in `options.agents`; otherwise they continue to skip with `requirement_unmet`.

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -1031,6 +1031,7 @@ async function runStoryboardBody(
   if (!options.agents && agentUrls.length === 0) {
     throw new Error('runStoryboard: at least one agent URL required');
   }
+
   const isMultiInstance = agentUrls.length > 1;
   if (isMultiInstance && options._client) {
     throw new Error(
@@ -1056,6 +1057,19 @@ async function runStoryboardBody(
     }
     return runMultiPass(agentUrls, storyboard, options);
   }
+
+  const allRequires = resolveStoryboardRequires(storyboard, options);
+  if (allRequires.length) {
+    const unmet = checkRequires(allRequires, storyboard, options, options._profile);
+    if (unmet) {
+      const resultAgentUrls = options.agents ? Object.values(options.agents).map(e => e.url) : agentUrls;
+      return {
+        ...buildRequirementUnmetResult(resultAgentUrls, storyboard, unmet.requirement, unmet.detail),
+        notices: collectCapabilityNotices(storyboard, options._profile?.raw_capabilities),
+      };
+    }
+  }
+
   if (options.agents) {
     // Project the agents map's URLs into the legacy `agentUrls` array so
     // downstream signatures (per-step `agent_url:` records, etc.) keep
@@ -1277,6 +1291,7 @@ const REQUIREMENT_TO_SKIP_REASON: Record<RequirementName, RunnerSkipReason> = {
   real_wire: 'requirement_unmet',
   webhook_receiver: 'requirement_unmet',
   request_signer: 'not_applicable',
+  multi_agent: 'requirement_unmet',
 };
 
 function isKnownRequirement(requirement: string): requirement is RequirementName {
@@ -1447,9 +1462,16 @@ function normalizeAgentToolNames(tools: unknown): string[] | undefined {
  *     threaded through), the gate is a no-op — the caller accepted
  *     responsibility for capability compatibility by reusing an external
  *     client. Spec: adcp-client#1702.
+ *   - `multi_agent` — `options.agents` is set and the storyboard's
+ *     declared route keys (`default_agent` and step-level `agent:` overrides)
+ *     resolve to at least two distinct entries in that map. Raw
+ *     `options.agents` cardinality is not enough; the requirement describes
+ *     the topology this storyboard actually routes through.
+ *     Spec: adcp-client#2281.
  */
 function checkRequires(
   requires: readonly string[],
+  storyboard: Storyboard,
   options: StoryboardRunOptions,
   profile?: AgentProfile
 ): { requirement: string; detail: string } | null {
@@ -1529,9 +1551,47 @@ function checkRequires(
             'register the test keypair before the 4.0 cut to avoid a hard compliance failure then.',
         };
       }
+      case 'multi_agent': {
+        const routeKeys = collectMultiAgentRequirementRouteKeys(storyboard, options);
+        if (routeKeys.length >= 2) break;
+        const availableKeys = options.agents ? Object.keys(options.agents) : [];
+        const routed = routeKeys.length ? routeKeys.join(', ') : '(none)';
+        const available = availableKeys.length ? availableKeys.join(', ') : '(none)';
+        return {
+          requirement,
+          detail:
+            "Storyboard requires 'multi_agent'; configure `agents` and route this storyboard " +
+            'to at least two distinct agent keys via `default_agent` and/or step-level `agent:` overrides. ' +
+            `Resolved route keys: [${routed}]. Available agents: [${available}].`,
+        };
+      }
     }
   }
   return null;
+}
+
+function collectMultiAgentRequirementRouteKeys(storyboard: Storyboard, options: StoryboardRunOptions): string[] {
+  const agents = options.agents;
+  if (!agents) return [];
+
+  const routeKeys = new Set<string>();
+  if (options.default_agent !== undefined && options.default_agent in agents) {
+    routeKeys.add(options.default_agent);
+  }
+  for (const phase of storyboard.phases ?? []) {
+    for (const step of phase.steps ?? []) {
+      if (step.agent !== undefined && step.agent in agents) {
+        routeKeys.add(step.agent);
+      }
+    }
+  }
+  return [...routeKeys];
+}
+
+function resolveStoryboardRequires(storyboard: Storyboard, options: StoryboardRunOptions): string[] {
+  const declared = storyboard.requires ?? [];
+  const implicit = detectImplicitRequires(storyboard, options);
+  return [...declared, ...implicit.filter(r => !declared.includes(r))];
 }
 
 /**
@@ -2053,11 +2113,9 @@ async function executeStoryboardPass(
   // collected again from the fully-fetched profile at result-build time.
   const preflightNotices = collectCapabilityNotices(storyboard, options._profile?.raw_capabilities);
 
-  const declared = storyboard.requires ?? [];
-  const implicit = detectImplicitRequires(storyboard, options);
-  const allRequires = [...declared, ...implicit.filter(r => !declared.includes(r))];
+  const allRequires = resolveStoryboardRequires(storyboard, options);
   if (allRequires.length) {
-    const unmet = checkRequires(allRequires, options, profile);
+    const unmet = checkRequires(allRequires, storyboard, options, profile);
     if (unmet) {
       if (!callerOwnsClients) await closeConnections(options.protocol);
       return {

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -95,6 +95,12 @@ export interface Storyboard {
    *     ("Agents that do not advertise support are not tested against
    *     this storyboard — absence of advertisement is not a failure").
    *     Spec: adcp-client#1702.
+   *   - `multi_agent` — the run must be configured with
+   *     `StoryboardRunOptions.agents`, and the storyboard's authored
+   *     route keys (`default_agent` plus any step-level `agent:` overrides)
+   *     must resolve to at least two distinct entries in that agents map.
+   *     This checks the routed topology the storyboard actually declares,
+   *     not the raw number of available agents. Spec: adcp-client#2281.
    *
    * Default when the field is absent: `[real_wire]` (storyboard runs
    * everywhere — matches existing pre-tagging behavior). Tagging is
@@ -104,7 +110,7 @@ export interface Storyboard {
    * at runtime with `skip_reason: 'requirement_unmet'` and the authored name
    * on `RunnerSkipResult.requirement`.
    *
-   * Spec: adcp-client#1626. The schema may be proposed upstream to
+   * Spec: adcp-client#1626, adcp-client#2281. The schema may be proposed upstream to
    * `adcontextprotocol/adcp` once it has bedded in across SDK
    * storyboards.
    */
@@ -1848,9 +1854,15 @@ export interface RunnerSelectionResult {
  * surface change; coordinate with the upstream spec proposal before
  * extending.
  *
- * Spec: adcp-client#1626.
+ * Spec: adcp-client#1626, adcp-client#2281.
  */
-export type RequirementName = 'controller' | 'seeded_state' | 'real_wire' | 'webhook_receiver' | 'request_signer';
+export type RequirementName =
+  | 'controller'
+  | 'seeded_state'
+  | 'real_wire'
+  | 'webhook_receiver'
+  | 'request_signer'
+  | 'multi_agent';
 
 /**
  * Enumeration of every requirement this SDK knows how to satisfy. The loader
@@ -1865,6 +1877,7 @@ export const KNOWN_REQUIREMENTS: ReadonlySet<RequirementName> = new Set([
   'real_wire',
   'webhook_receiver',
   'request_signer',
+  'multi_agent',
 ] as const satisfies readonly RequirementName[]);
 
 /**

--- a/test/lib/storyboard-requires-gate.test.js
+++ b/test/lib/storyboard-requires-gate.test.js
@@ -136,6 +136,74 @@ describe('Storyboard.requires gate (#1626)', () => {
     assert.ok(!phaseIds.includes('requirement_unmet'), 'real_wire never blocks');
   });
 
+  test('requires: [multi_agent] skips without options.agents', async () => {
+    const sb = buildStoryboard({ requires: ['multi_agent'] });
+    const result = await runStoryboard('http://fake-local-99999', sb, {
+      _profile: profileWithoutController,
+      agentTools: profileWithoutController.tools,
+    });
+
+    const step = result.phases[0].steps[0];
+    assert.equal(step.skipped, true);
+    assert.equal(step.skip_reason, 'requirement_unmet');
+    assert.equal(step.skip.reason, 'requirement_unmet');
+    assert.equal(step.skip.requirement, 'multi_agent');
+    assert.match(step.skip.detail, /at least two distinct agent keys/);
+    assert.match(step.skip.detail, /Available agents: \[\(none\)\]/);
+  });
+
+  test('requires: [multi_agent] passes with two distinct declared route keys', async () => {
+    const sb = buildStoryboard({
+      requires: ['multi_agent'],
+      phases: [
+        {
+          id: 'p1',
+          title: 'Phase 1',
+          steps: [{ id: 'step1', title: 'A routed read', task: 'get_products', agent: 'signals' }],
+        },
+      ],
+    });
+    const result = await runStoryboard('', sb, {
+      allow_http: true,
+      agents: {
+        sales: { url: 'http://127.0.0.1:1/sales/mcp' },
+        signals: { url: 'http://127.0.0.1:1/signals/mcp' },
+      },
+      default_agent: 'sales',
+    });
+
+    const phaseIds = result.phases.map(p => p.phase_id);
+    assert.ok(!phaseIds.includes('requirement_unmet'), 'two distinct route keys satisfy multi_agent');
+  });
+
+  test('requires: [multi_agent] stays unmet when routes resolve to one distinct key', async () => {
+    const sb = buildStoryboard({
+      requires: ['multi_agent'],
+      phases: [
+        {
+          id: 'p1',
+          title: 'Phase 1',
+          steps: [{ id: 'step1', title: 'A routed read', task: 'get_products', agent: 'sales' }],
+        },
+      ],
+    });
+    const result = await runStoryboard('', sb, {
+      allow_http: true,
+      agents: {
+        sales: { url: 'http://127.0.0.1:1/sales/mcp' },
+        signals: { url: 'http://127.0.0.1:1/signals/mcp' },
+      },
+      default_agent: 'sales',
+    });
+
+    const step = result.phases[0].steps[0];
+    assert.equal(step.skipped, true);
+    assert.equal(step.skip_reason, 'requirement_unmet');
+    assert.equal(step.skip.requirement, 'multi_agent');
+    assert.match(step.skip.detail, /Resolved route keys: \[sales\]/);
+    assert.match(step.skip.detail, /Available agents: \[sales, signals\]/);
+  });
+
   test('multiple requires: first unmet wins', async () => {
     // Both controller and seeded_state are unmet; the gate reports the
     // first one in the array order, not a synthesized aggregate.
@@ -149,8 +217,34 @@ describe('Storyboard.requires gate (#1626)', () => {
     assert.equal(step.skip.requirement, 'controller', 'first unmet requirement is reported');
   });
 
+  test('mixed requires: multi_agent passes through to controller gate', async () => {
+    const sb = buildStoryboard({
+      requires: ['multi_agent', 'controller'],
+      phases: [
+        {
+          id: 'p1',
+          title: 'Phase 1',
+          steps: [{ id: 'step1', title: 'A routed read', task: 'get_products', agent: 'signals' }],
+        },
+      ],
+    });
+    const result = await runStoryboard('', sb, {
+      allow_http: true,
+      agentTools: profileWithoutController.tools,
+      agents: {
+        sales: { url: 'http://127.0.0.1:1/sales/mcp' },
+        signals: { url: 'http://127.0.0.1:1/signals/mcp' },
+      },
+      default_agent: 'sales',
+    });
+
+    const step = result.phases[0].steps[0];
+    assert.equal(step.skip_reason, 'missing_test_controller');
+    assert.equal(step.skip.requirement, 'controller');
+  });
+
   test('unknown requires values load and skip with requirement_unmet at runtime', async () => {
-    const sb = buildStoryboard({ requires: ['multi_agent'] });
+    const sb = buildStoryboard({ requires: ['future_runtime'] });
     const result = await runStoryboard('http://fake-local-99999', sb, {
       _profile: profileWithoutController,
       agentTools: profileWithoutController.tools,
@@ -164,8 +258,8 @@ describe('Storyboard.requires gate (#1626)', () => {
     assert.equal(step.skipped, true);
     assert.equal(step.skip_reason, 'requirement_unmet');
     assert.equal(step.skip.reason, 'requirement_unmet');
-    assert.equal(step.skip.requirement, 'multi_agent');
-    assert.match(step.skip.detail, /unknown runtime requirement 'multi_agent'/);
+    assert.equal(step.skip.requirement, 'future_runtime');
+    assert.match(step.skip.detail, /unknown runtime requirement 'future_runtime'/);
   });
 });
 


### PR DESCRIPTION
## Summary

- Add `multi_agent` as a known storyboard `requires` runtime requirement.
- Gate `multi_agent` on distinct authored route keys from `default_agent` and step-level `agent:` overrides, not raw `options.agents` cardinality.
- Add regression coverage for missing agents, two routed agents, one-distinct-route boundary, mixed requirements, and unknown future requirements.

## Validation

- `npm run build`
- `NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/lib/storyboard-requires-gate.test.js`
- `NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/lib/storyboard-requires-gate.test.js test/lib/agent-routing.test.js`
- `npm run lint` (exits 0; existing warnings remain)
- `git diff --check`
- pre-push hook: `npm run typecheck` and `npm run build`

Fixes #2281.
