### PR TITLE
fix: accept AdCP 3.0 webhook envelopes that omit operation_id

### DIFF
--- a/.changeset/webhook-operation-id-backwards-compat.md
+++ b/.changeset/webhook-operation-id-backwards-compat.md
@@ -1,0 +1,5 @@
+---
+"@adcp/sdk": patch
+---
+
+Fix webhook receiver rejecting AdCP 3.0 envelopes that omit `operation_id`. `operation_id` became a required webhook field in AdCP 3.1, but `verifyAndParseWebhook` enforced it against all senders, breaking backwards compatibility with spec-compliant 3.0 servers. It is no longer part of the hard-required MCP webhook envelope set; when absent, the receiver falls back to the routing-context `operationId` as before.

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -302,9 +302,15 @@ const WEBHOOK_TASK_STATUSES = new Set<string>([
   'unknown',
 ]);
 
+// Top-level fields that every MCP webhook envelope must carry, regardless of
+// negotiated AdCP version. `operation_id` is intentionally NOT here: it became
+// a required webhook field in AdCP 3.1, but 3.0 senders are spec-compliant
+// without it. The receiver can't reliably know the sender's negotiated version
+// from the POST body alone, so requiring `operation_id` here broke 3.0
+// interop. When absent we fall back to the routing-context operationId (see
+// normalizeWebhookPayload), so its omission is non-fatal for dispatch.
 const MCP_WEBHOOK_REQUIRED_FIELDS = [
   'idempotency_key',
-  'operation_id',
   'task_id',
   'task_type',
   'status',

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -309,13 +309,7 @@ const WEBHOOK_TASK_STATUSES = new Set<string>([
 // from the POST body alone, so requiring `operation_id` here broke 3.0
 // interop. When absent we fall back to the routing-context operationId (see
 // normalizeWebhookPayload), so its omission is non-fatal for dispatch.
-const MCP_WEBHOOK_REQUIRED_FIELDS = [
-  'idempotency_key',
-  'task_id',
-  'task_type',
-  'status',
-  'timestamp',
-] as const;
+const MCP_WEBHOOK_REQUIRED_FIELDS = ['idempotency_key', 'task_id', 'task_type', 'status', 'timestamp'] as const;
 
 /**
  * Configuration for SingleAgentClient (and multi-agent client)

--- a/test/webhook-parse-verify.test.js
+++ b/test/webhook-parse-verify.test.js
@@ -48,6 +48,34 @@ describe('verifyAndParseWebhook', () => {
     assert.strictEqual(parsed.result.notification_type, 'scheduled');
   });
 
+  test('accepts AdCP 3.0 envelopes that omit operation_id (backwards compat)', async () => {
+    const client = new SingleAgentClient(agent, {});
+    const { operation_id, ...envelopeWithoutOperationId } = deliveryEnvelope();
+    const parsed = await client.verifyAndParseWebhook({
+      body: JSON.stringify(envelopeWithoutOperationId),
+      taskType: 'media_buy_delivery',
+    });
+
+    assert.strictEqual(parsed.ok, true);
+    assert.strictEqual(parsed.protocol, 'mcp');
+    assert.strictEqual(parsed.metadata.taskType, 'media_buy_delivery');
+    assert.strictEqual(parsed.metadata.idempotencyKey, 'whk_test_delivery_0000001');
+    assert.strictEqual(parsed.result.notification_type, 'scheduled');
+  });
+
+  test('falls back to routing-context operationId when the envelope omits operation_id', async () => {
+    const client = new SingleAgentClient(agent, {});
+    const { operation_id, ...envelopeWithoutOperationId } = deliveryEnvelope();
+    const parsed = await client.verifyAndParseWebhook({
+      body: JSON.stringify(envelopeWithoutOperationId),
+      taskType: 'media_buy_delivery',
+      operationId: 'ctx_op_123',
+    });
+
+    assert.strictEqual(parsed.ok, true);
+    assert.strictEqual(parsed.metadata.operationId, 'ctx_op_123');
+  });
+
   test('rejects bare delivery result payloads before dispatch', async () => {
     const client = new SingleAgentClient(agent, {});
     const parsed = await client.verifyAndParseWebhook({


### PR DESCRIPTION
## Summary

Fixes a backwards-compatibility break in the buyer-side webhook receiver. `operation_id` became a **required** top-level webhook envelope field in AdCP 3.1, but `verifyAndParseWebhook` (`SingleAgentClient`) enforced it against **all** senders regardless of negotiated version. Spec-compliant AdCP **3.0** servers omit `operation_id`, so their webhooks were rejected with `webhook_envelope_invalid` ("missing top-level field operation_id").

## Change

- Remove `operation_id` from the hard-required `MCP_WEBHOOK_REQUIRED_FIELDS` set. The receiver can't reliably infer a sender's negotiated AdCP version from the POST body alone, so requiring a 3.1-only field broke 3.0 interop.
- When `operation_id` is absent, the normalize path already falls back to the routing-context `operationId`, so its omission is non-fatal for dispatch.
- The five fields required in **both** 3.0 and 3.1 (`idempotency_key`, `task_id`, `task_type`, `status`, `timestamp`) remain enforced.

## Why this is correct per spec triage

AdCP 3.0 does not require `operation_id` on webhook envelopes; it was introduced as required in 3.1. A receiver that validates 3.0 traffic against the 3.1 contract is the bug. This restores the SDK to accepting any envelope valid under the version the sender actually speaks.

## Tests

Added two regression cases to `test/webhook-parse-verify.test.js`:
- A 3.0 envelope omitting `operation_id` now validates successfully.
- The routing-context `operationId` fallback is asserted when the envelope omits the field.

All 7 webhook parse/verify tests pass.

## Verification

- ✅ `npm run build`
- ✅ `node --test test/webhook-parse-verify.test.js` (7/7)
- ✅ `npm run lint` (0 errors)
- ✅ Changeset added (patch)
