### PR TITLE
fix: support seed_account comply controller

### DIFF
--- a/.changeset/seed-account-controller.md
+++ b/.changeset/seed-account-controller.md
@@ -1,0 +1,5 @@
+---
+"@adcp/sdk": patch
+---
+
+Support `seed_account` in `comply_test_controller` helpers and storyboard fixture seeding.

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -2441,6 +2441,7 @@ function deriveScenariosFromAdapters(
   if (cfg.force?.creative_purge) out.push('force_creative_purge');
   if (cfg.simulate?.delivery) out.push('simulate_delivery');
   if (cfg.simulate?.budget_spend) out.push('simulate_budget_spend');
+  if (cfg.seed?.account) out.push('seed_account');
   if (cfg.seed?.product) out.push('seed_product');
   if (cfg.seed?.pricing_option) out.push('seed_pricing_option');
   if (cfg.seed?.creative) out.push('seed_creative');

--- a/src/lib/server/test-controller.ts
+++ b/src/lib/server/test-controller.ts
@@ -139,6 +139,7 @@ export type ControllerScenario = ListScenariosSuccess['scenarios'][number];
 /** Scenario names accepted in `scenario` requests but not advertised via
  * `list_scenarios`. Sellers opt in by implementing the matching store method. */
 export type SeedScenario =
+  | 'seed_account'
   | 'seed_product'
   | 'seed_pricing_option'
   | 'seed_creative'
@@ -178,6 +179,7 @@ export const CONTROLLER_SCENARIOS = {
  * advertised via `list_scenarios`.
  */
 export const SEED_SCENARIOS = {
+  SEED_ACCOUNT: 'seed_account',
   SEED_PRODUCT: 'seed_product',
   SEED_PRICING_OPTION: 'seed_pricing_option',
   SEED_CREATIVE: 'seed_creative',
@@ -383,6 +385,9 @@ export interface TestControllerStore {
     spend_percentage: number;
     [key: string]: unknown;
   }): Promise<SimulationSuccess>;
+
+  /** Seed an account fixture. Returns when the fixture is persisted. */
+  seedAccount?(accountId: string, fixture: Record<string, unknown> | undefined): Promise<void>;
 
   /** Seed a product fixture. Returns when the fixture is persisted. */
   seedProduct?(productId: string, fixture: Record<string, unknown> | undefined): Promise<void>;
@@ -648,6 +653,7 @@ const SCENARIO_MAP: Array<[keyof TestControllerStore, ControllerScenario]> = [
   ['forceCreativePurge', CONTROLLER_SCENARIOS.FORCE_CREATIVE_PURGE],
   ['simulateDelivery', CONTROLLER_SCENARIOS.SIMULATE_DELIVERY],
   ['simulateBudgetSpend', CONTROLLER_SCENARIOS.SIMULATE_BUDGET_SPEND],
+  ['seedAccount', SEED_SCENARIOS.SEED_ACCOUNT],
   ['seedProduct', SEED_SCENARIOS.SEED_PRODUCT],
   ['seedPricingOption', SEED_SCENARIOS.SEED_PRICING_OPTION],
   ['seedCreative', SEED_SCENARIOS.SEED_CREATIVE],
@@ -897,6 +903,20 @@ async function dispatchSeed(
   let missingParam: string | null = null;
 
   switch (scenario) {
+    case SEED_SCENARIOS.SEED_ACCOUNT: {
+      if (!params?.account_id) {
+        missingParam = 'seed_account requires params.account_id';
+        break;
+      }
+      if (!store.seedAccount) return controllerError('UNKNOWN_SCENARIO', `Scenario not supported: ${scenario}`);
+      const accountId = params.account_id as string;
+      dispatch = {
+        key: makeSeedCacheKey(`seed_account:${accountId}`, scope),
+        fixture,
+        invoke: () => store.seedAccount!(accountId, fixture),
+      };
+      break;
+    }
     case SEED_SCENARIOS.SEED_PRODUCT: {
       if (!params?.product_id) {
         missingParam = 'seed_product requires params.product_id';
@@ -1354,6 +1374,7 @@ async function handleTestControllerRequestImpl(
         return wrapStoreSuccess(await store.forceCreativePurge(creativeId as string, purgeParams));
       }
 
+      case SEED_SCENARIOS.SEED_ACCOUNT:
       case SEED_SCENARIOS.SEED_PRODUCT:
       case SEED_SCENARIOS.SEED_PRICING_OPTION:
       case SEED_SCENARIOS.SEED_CREATIVE:

--- a/src/lib/testing/comply-controller.ts
+++ b/src/lib/testing/comply-controller.ts
@@ -95,6 +95,14 @@ export interface SeedProductParams {
   fixture: Record<string, unknown>;
 }
 
+/** Params for `seed_account`. `fixture` mirrors the persisted account shape
+ * (name, status, billing/rate-card metadata, authorization, …). Kept
+ * permissive because storyboards declare only the account fields they need. */
+export interface SeedAccountParams {
+  account_id: string;
+  fixture: Record<string, unknown>;
+}
+
 export interface SeedPricingOptionParams {
   product_id: string;
   pricing_option_id: string;
@@ -349,6 +357,7 @@ export interface ComplyControllerConfig {
   /** Seed adapters. Each registered method advertises its scenario as
    * implemented; omitted methods return `UNKNOWN_SCENARIO` when called. */
   seed?: {
+    account?: SeedAdapter<SeedAccountParams>;
     product?: SeedAdapter<SeedProductParams>;
     pricing_option?: SeedAdapter<SeedPricingOptionParams>;
     creative?: SeedAdapter<SeedCreativeParams>;
@@ -506,6 +515,11 @@ function buildStore(config: ComplyControllerConfig, ctx: ComplyControllerContext
   const store: TestControllerStore = {};
   const { seed, force, simulate, queryUpstreamTraffic, queryProvenanceAuditObservations } = config;
 
+  if (seed?.account) {
+    store.seedAccount = async (accountId, fixture) => {
+      await seed.account!({ account_id: accountId, fixture: fixture ?? {} }, ctx);
+    };
+  }
   if (seed?.product) {
     store.seedProduct = async (productId, fixture) => {
       await seed.product!({ product_id: productId, fixture: fixture ?? {} }, ctx);
@@ -638,6 +652,7 @@ function advertisedScenarios(config: ComplyControllerConfig): ControllerScenario
   if (config.force?.creative_purge) out.push(CONTROLLER_SCENARIOS.FORCE_CREATIVE_PURGE);
   if (config.simulate?.delivery) out.push(CONTROLLER_SCENARIOS.SIMULATE_DELIVERY);
   if (config.simulate?.budget_spend) out.push(CONTROLLER_SCENARIOS.SIMULATE_BUDGET_SPEND);
+  if (config.seed?.account) out.push('seed_account' as unknown as ControllerScenario);
   if (config.seed?.product) out.push('seed_product');
   if (config.seed?.pricing_option) out.push('seed_pricing_option');
   if (config.seed?.creative) out.push('seed_creative');

--- a/src/lib/testing/index.ts
+++ b/src/lib/testing/index.ts
@@ -144,6 +144,7 @@ export type {
   ForceMediaBuyStatusParams,
   ForceSessionStatusParams,
   ForceTaskCompletionParams,
+  SeedAccountParams,
   SeedAdapter,
   SeedBuyerAgentParams,
   SeedCreativeFormatParams,

--- a/src/lib/testing/storyboard/seeding.ts
+++ b/src/lib/testing/storyboard/seeding.ts
@@ -39,6 +39,7 @@ export const CONTROLLER_SEEDING_PHASE_ID = '__controller_seeding__';
  * constant from `src/lib/server/test-controller.ts` is authoritative, but
  * importing it here would cross the testing ⇄ server module boundary. */
 type SeedScenario =
+  | 'seed_account'
   | 'seed_product'
   | 'seed_pricing_option'
   | 'seed_creative_format'
@@ -75,6 +76,27 @@ interface SeedCall {
 export function buildSeedCalls(fixtures: StoryboardFixtures | undefined): SeedCall[] {
   if (!fixtures) return [];
   const calls: SeedCall[] = [];
+
+  (fixtures.accounts ?? []).forEach((entry, i) => {
+    const { account_id, ...fixtureFields } = entry;
+    const label = account_id ?? `#${i}`;
+    if (typeof account_id !== 'string' || account_id.length === 0) {
+      calls.push({
+        step_id: `seed_account.${label}`,
+        title: `Seed account ${label}`,
+        scenario: 'seed_account',
+        params: { fixture: seedFixtureFromFields(fixtureFields) },
+        authoring_error: `fixtures.accounts[${i}] requires a non-empty string 'account_id'`,
+      });
+      return;
+    }
+    calls.push({
+      step_id: `seed_account.${account_id}`,
+      title: `Seed account ${account_id}`,
+      scenario: 'seed_account',
+      params: { account_id, fixture: seedFixtureFromFields(fixtureFields) },
+    });
+  });
 
   (fixtures.buyer_agents ?? []).forEach((entry, i) => {
     const { agent_url, ...params } = entry;

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -297,6 +297,7 @@ export interface StepInvariantsObject {
  * alongside the body the runner forwards into `params.fixture` for the
  * corresponding `seed_*` scenario.
  *
+ *   - `accounts[]`      → `seed_account`         — requires `account_id`
  *   - `products[]`      → `seed_product`         — requires `product_id`
  *   - `pricing_options[]` → `seed_pricing_option` — requires `product_id` + `pricing_option_id`
  *   - `creative_formats[]` → `seed_creative_format` — requires `format_id`
@@ -313,6 +314,7 @@ export interface StepInvariantsObject {
  * authoring mistake is surfaced before any real step runs.
  */
 export interface StoryboardFixtures {
+  accounts?: Array<Record<string, unknown> & { account_id?: string }>;
   products?: Array<Record<string, unknown> & { product_id?: string }>;
   pricing_options?: Array<Record<string, unknown> & { product_id?: string; pricing_option_id?: string }>;
   creative_formats?: Array<Record<string, unknown> & { format_id?: string; fixture?: unknown }>;

--- a/test/comply-controller.test.js
+++ b/test/comply-controller.test.js
@@ -25,13 +25,14 @@ describe('createComplyController — list_scenarios', () => {
   it('advertises seed scenarios when seed adapters are configured', async () => {
     const controller = createComplyController({
       seed: {
+        account: () => {},
         buyer_agent: () => {},
         product: () => {},
       },
     });
     const result = await controller.handleRaw({ scenario: 'list_scenarios' });
     assert.strictEqual(result.success, true);
-    assert.deepStrictEqual([...result.scenarios].sort(), ['seed_buyer_agent', 'seed_product']);
+    assert.deepStrictEqual([...result.scenarios].sort(), ['seed_account', 'seed_buyer_agent', 'seed_product']);
   });
 
   it('advertises force_create_media_buy_arm and force_task_completion when registered', async () => {
@@ -373,6 +374,30 @@ describe('createComplyController — seed idempotency', () => {
     assert.ok(persisted.has('p1'));
   });
 
+  it('routes seed.account to the adapter with typed params', async () => {
+    let captured;
+    const controller = createComplyController({
+      seed: {
+        account: params => {
+          captured = params;
+        },
+      },
+    });
+    const result = await controller.handleRaw({
+      scenario: 'seed_account',
+      params: {
+        account_id: 'acct-1',
+        fixture: { name: 'Sandbox account', status: 'active' },
+      },
+    });
+    assert.strictEqual(result.success, true);
+    assert.strictEqual(result.message, 'Fixture seeded');
+    assert.deepStrictEqual(captured, {
+      account_id: 'acct-1',
+      fixture: { name: 'Sandbox account', status: 'active' },
+    });
+  });
+
   it('does not let nested fixture.agent_url override seed.buyer_agent params', async () => {
     const seen = [];
     const controller = createComplyController({
@@ -512,13 +537,21 @@ describe('createComplyController — seed idempotency', () => {
   });
 
   it('returns INVALID_PARAMS when a seed is missing its required id', async () => {
-    const controller = createComplyController({ seed: { product: () => {} } });
-    const result = await controller.handleRaw({
+    const productController = createComplyController({ seed: { product: () => {} } });
+    const result = await productController.handleRaw({
       scenario: 'seed_product',
       params: { fixture: { delivery_type: 'guaranteed' } },
     });
     assert.strictEqual(result.error, 'INVALID_PARAMS');
     assert.match(result.error_detail, /product_id/);
+
+    const accountController = createComplyController({ seed: { account: () => {} } });
+    const accountResult = await accountController.handleRaw({
+      scenario: 'seed_account',
+      params: { fixture: { status: 'active' } },
+    });
+    assert.strictEqual(accountResult.error, 'INVALID_PARAMS');
+    assert.match(accountResult.error_detail, /account_id/);
   });
 
   it('returns UNKNOWN_SCENARIO when a seed adapter is not registered', async () => {

--- a/test/lib/storyboard-controller-seeding.test.js
+++ b/test/lib/storyboard-controller-seeding.test.js
@@ -39,6 +39,37 @@ describe('buildSeedCalls', () => {
     assert.strictEqual(calls[1].params.product_id, 'outdoor_video_auction');
   });
 
+  test('accounts → seed_account with account_id lifted into params and rest in fixture', () => {
+    const calls = buildSeedCalls({
+      accounts: [
+        {
+          account_id: 'acct-sandbox-1',
+          fixture: {
+            name: 'Sandbox Advertiser',
+            status: 'active',
+            sandbox: true,
+          },
+        },
+      ],
+    });
+    assert.strictEqual(calls.length, 1);
+    assert.strictEqual(calls[0].scenario, 'seed_account');
+    assert.deepStrictEqual(calls[0].params, {
+      account_id: 'acct-sandbox-1',
+      fixture: { name: 'Sandbox Advertiser', status: 'active', sandbox: true },
+    });
+  });
+
+  test('accounts → seed_account supports direct fixture fields for older storyboard snapshots', () => {
+    const calls = buildSeedCalls({
+      accounts: [{ account_id: 'acct-sandbox-1', status: 'active', sandbox: true }],
+    });
+    assert.deepStrictEqual(calls[0].params, {
+      account_id: 'acct-sandbox-1',
+      fixture: { status: 'active', sandbox: true },
+    });
+  });
+
   test('pricing_options → seed_pricing_option with product_id + pricing_option_id lifted', () => {
     const calls = buildSeedCalls({
       pricing_options: [
@@ -126,8 +157,9 @@ describe('buildSeedCalls', () => {
     });
   });
 
-  test('emits ordering: buyer_agents → products → pricing_options → creative_formats → creatives → plans → media_buys', () => {
+  test('emits ordering: accounts → buyer_agents → products → pricing_options → creative_formats → creatives → plans → media_buys', () => {
     const calls = buildSeedCalls({
+      accounts: [{ account_id: 'acct-1' }],
       media_buys: [{ media_buy_id: 'mb-1' }],
       buyer_agents: [{ agent_url: 'https://buyer.example/agent' }],
       products: [{ product_id: 'p-1' }],
@@ -139,6 +171,7 @@ describe('buildSeedCalls', () => {
     assert.deepStrictEqual(
       calls.map(c => c.scenario),
       [
+        'seed_account',
         'seed_buyer_agent',
         'seed_product',
         'seed_pricing_option',
@@ -152,18 +185,20 @@ describe('buildSeedCalls', () => {
 
   test('flags authoring error when a required id field is missing — seed is not issued', () => {
     const calls = buildSeedCalls({
+      accounts: [{ name: 'missing account_id' }],
       buyer_agents: [{ status: 'active' }],
       products: [{ delivery_type: 'non_guaranteed' }],
       pricing_options: [{ product_id: 'p-1' }],
       creative_formats: [{ name: 'missing format_id' }],
       creatives: [{ format_id: 'x' }],
     });
-    assert.strictEqual(calls.length, 5);
-    assert.match(calls[0].authoring_error, /agent_url/);
-    assert.match(calls[1].authoring_error, /product_id/);
-    assert.match(calls[2].authoring_error, /pricing_option_id/);
-    assert.match(calls[3].authoring_error, /format_id/);
-    assert.match(calls[4].authoring_error, /creative_id/);
+    assert.strictEqual(calls.length, 6);
+    assert.match(calls[0].authoring_error, /account_id/);
+    assert.match(calls[1].authoring_error, /agent_url/);
+    assert.match(calls[2].authoring_error, /product_id/);
+    assert.match(calls[3].authoring_error, /pricing_option_id/);
+    assert.match(calls[4].authoring_error, /format_id/);
+    assert.match(calls[5].authoring_error, /creative_id/);
   });
 });
 

--- a/test/server-decisioning-comply-test.test.js
+++ b/test/server-decisioning-comply-test.test.js
@@ -128,6 +128,9 @@ describe('createAdcpServerFromPlatform — comply_test_controller wiring', () =>
             resource_id: 'mb_1',
           }),
         },
+        seed: {
+          account: async () => {},
+        },
       },
     });
 
@@ -145,6 +148,7 @@ describe('createAdcpServerFromPlatform — comply_test_controller wiring', () =>
     assert.ok(scenarios.includes('force_creative_status'));
     assert.ok(scenarios.includes('force_media_buy_status'));
     assert.ok(scenarios.includes('simulate_delivery'));
+    assert.ok(scenarios.includes('seed_account'), 'seed.account adapter should be advertised');
     assert.ok(scenarios.includes('seed_product'), 'auto-seed product adapter should be advertised');
     assert.ok(scenarios.includes('seed_pricing_option'), 'auto-seed pricing adapter should be advertised');
     assert.ok(!scenarios.includes('force_account_status'), 'force_account_status was not declared');
@@ -250,6 +254,9 @@ describe('createAdcpServerFromPlatform — comply_test_controller wiring', () =>
             resource_id: 'mb_1',
           }),
         },
+        seed: {
+          account: async () => {},
+        },
       },
     });
 
@@ -265,6 +272,7 @@ describe('createAdcpServerFromPlatform — comply_test_controller wiring', () =>
     assert.ok(ct.scenarios.includes('force_creative_status'));
     assert.ok(ct.scenarios.includes('force_media_buy_status'));
     assert.ok(ct.scenarios.includes('simulate_delivery'));
+    assert.ok(ct.scenarios.includes('seed_account'), 'seed.account adapter should be projected');
     assert.ok(ct.scenarios.includes('seed_product'), 'auto-seed product adapter should be projected');
     assert.ok(ct.scenarios.includes('seed_pricing_option'), 'auto-seed pricing adapter should be projected');
     assert.ok(!ct.scenarios.includes('force_account_status'), 'unwired scenario must not appear');

--- a/test/server-test-controller.test.js
+++ b/test/server-test-controller.test.js
@@ -589,9 +589,7 @@ describe('handleTestControllerRequest', () => {
       assert.strictEqual(result.success, true);
       assert.strictEqual(result.message, 'Fixture seeded');
       assert.strictEqual(result.previous_state, undefined);
-      assert.deepStrictEqual(calls, [
-        { accountId: 'acct-1', fixture: { name: 'Sandbox account', status: 'active' } },
-      ]);
+      assert.deepStrictEqual(calls, [{ accountId: 'acct-1', fixture: { name: 'Sandbox account', status: 'active' } }]);
     });
 
     it('returns INVALID_PARAMS without account_id', async () => {

--- a/test/server-test-controller.test.js
+++ b/test/server-test-controller.test.js
@@ -40,6 +40,7 @@ describe('handleTestControllerRequest', () => {
         async forceUpstreamUnavailable() {},
         async simulateDelivery() {},
         async simulateBudgetSpend() {},
+        async seedAccount() {},
         async seedProduct() {},
         async seedPricingOption() {},
         async seedCreative() {},
@@ -570,6 +571,48 @@ describe('handleTestControllerRequest', () => {
       assert.strictEqual(result.success, false);
       assert.strictEqual(result.error, 'INVALID_PARAMS');
       assert.match(result.error_detail, /reason_code/);
+    });
+  });
+
+  describe('seed_account', () => {
+    it('forwards accountId + fixture to store', async () => {
+      const calls = [];
+      const store = {
+        async seedAccount(accountId, fixture) {
+          calls.push({ accountId, fixture });
+        },
+      };
+      const result = await handleTestControllerRequest(store, {
+        scenario: 'seed_account',
+        params: { account_id: 'acct-1', fixture: { name: 'Sandbox account', status: 'active' } },
+      });
+      assert.strictEqual(result.success, true);
+      assert.strictEqual(result.message, 'Fixture seeded');
+      assert.strictEqual(result.previous_state, undefined);
+      assert.deepStrictEqual(calls, [
+        { accountId: 'acct-1', fixture: { name: 'Sandbox account', status: 'active' } },
+      ]);
+    });
+
+    it('returns INVALID_PARAMS without account_id', async () => {
+      const store = { async seedAccount() {} };
+      const result = await handleTestControllerRequest(store, {
+        scenario: 'seed_account',
+        params: { fixture: {} },
+      });
+      assert.strictEqual(result.error, 'INVALID_PARAMS');
+      assert.match(result.error_detail, /requires params\.account_id/);
+    });
+
+    it('returns UNKNOWN_SCENARIO when store lacks method', async () => {
+      const result = await handleTestControllerRequest(
+        {},
+        {
+          scenario: 'seed_account',
+          params: { account_id: 'acct-1', fixture: {} },
+        }
+      );
+      assert.strictEqual(result.error, 'UNKNOWN_SCENARIO');
     });
   });
 


### PR DESCRIPTION
## Summary

- Adds `seed_account` support to the lower-level `comply_test_controller` store/dispatcher and `createComplyController` typed facade.
- Teaches storyboard fixture seeding to emit `seed_account` calls from `fixtures.accounts[]`, including the current `{ account_id, fixture }` storyboard shape.
- Includes `seed.account` in platform capability projection so `get_adcp_capabilities.compliance_testing.scenarios` matches `list_scenarios`.
- Adds a patch changeset.

## Root Cause

`seed_account` was present in the protocol schema, but the SDK helper surfaces did not enumerate or dispatch it. Storyboard seeding also ignored `fixtures.accounts[]`, so pagination-integrity account fixtures were never seeded.

## Validation

- `npm run build:lib`
- `NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/comply-controller.test.js`
- `NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/server-test-controller.test.js`
- `NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/lib/storyboard-controller-seeding.test.js`
- `NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/server-decisioning-comply-test.test.js`
- `git diff --check`
- Pre-push validation: typecheck + build passed

## Review

Ran parallel expert review (protocol, code review, Node.js testing). Initial findings on account fixture unwrapping and capability projection were fixed; re-checks reported no remaining actionable issues.

## Local Repro

Against `origin/main`, `createComplyController({ seed: { account } })` returns `UNKNOWN_SCENARIO` for `seed_account` and advertises no seed scenario. This branch advertises `seed_account`, dispatches to the adapter, and emits the three `seed_account` calls from the cached `pagination-integrity-list-accounts` storyboard.
