### PR TITLE
feat(v2): add assetType bare format resolver hint

### DIFF
--- a/.changeset/bare-format-asset-type-option.md
+++ b/.changeset/bare-format-asset-type-option.md
@@ -1,0 +1,5 @@
+---
+"@adcp/sdk": patch
+---
+
+Add `assetType` to `resolveCanonicalFormatKind` and `canonicalDeclarationFromBareId` so under-specified bare format ids can be disambiguated with the asset type adopters already store. `assetTypeHint` remains accepted as a backwards-compatible alias.

--- a/docs/migration-8.0-to-8.1.md
+++ b/docs/migration-8.0-to-8.1.md
@@ -405,13 +405,14 @@ Both fail closed — they return `null`, never a guess, for an unknown id, an
 under-specified id (`display_300x250`, which the catalog only carries as
 `_image` / `_html` / `_generative` variants), or an id from a non-AAO catalog.
 
-If you hold the asset type (e.g. a `format_type` field), pass `assetTypeHint`
+If you hold the asset type (e.g. a `format_type` field), pass `assetType`
 to disambiguate an under-specified id — the resolver retries the catalog
 variant `<id>_<suffix>` instead of you re-deriving the suffix:
 
 ```ts
-resolveCanonicalFormatKind('display_300x250', { assetTypeHint: 'image' }); // 'image'
-resolveCanonicalFormatKind('display_300x250', { assetTypeHint: 'html' }); // 'html5'
+resolveCanonicalFormatKind('display_300x250', { assetType: 'image' }); // 'image'
+resolveCanonicalFormatKind('display_300x250', { assetType: 'html' }); // 'html5'
+resolveCanonicalFormatKind('display', { assetType: 'javascript' }); // 'display_tag'
 // canonical-kind aliases work too: 'html5' → '_html', 'display_tag' → '_js'.
 // Still fails closed if <id>_<suffix> isn't a catalog entry.
 ```

--- a/src/lib/v2/projection/v1-to-v2.ts
+++ b/src/lib/v2/projection/v1-to-v2.ts
@@ -257,16 +257,22 @@ export interface BareFormatIdResolveOptions {
    * (an adopter's `format_type`) and the resolver retries the disambiguated
    * catalog variant `<id>_<suffix>`.
    *
-   * The vocabulary is the catalog **suffix**, not the canonical
-   * `format_kind` — `_image` and `_generative` both resolve to kind
-   * `image`, so a kind hint couldn't tell them apart. Accepts the suffixes
-   * `image` / `html` / `generative` / `js` directly, plus the canonical-kind
-   * aliases `html5` → `html` and `display_tag` → `js`.
+   * The vocabulary is the catalog asset type where it differs from the
+   * variant suffix (`javascript` → `_js`), otherwise the suffix itself
+   * (`image`, `html`, `generative`, `js`). Canonical-kind aliases are also
+   * accepted (`html5` → `html`, `display_tag` → `js`) for callers already
+   * holding a kind-like local value.
    *
    * Only consulted when the bare id does NOT resolve on its own (a real
    * catalog id is authoritative). Still fails closed: if `<id>_<suffix>`
    * is not a catalog entry, returns `null` — the hint narrows, it never
    * fabricates.
+   */
+  assetType?: string;
+
+  /**
+   * @deprecated Use `assetType`. Kept as a backwards-compatible alias for
+   * callers who adopted the initial helper surface before issue #2289.
    */
   assetTypeHint?: string;
 }
@@ -298,8 +304,9 @@ export interface BareFormatIdResolveOptions {
  * shape to match on, and a catalog entry lacking a `canonical:` fails
  * closed before the structural step is reached.
  *
- * For an under-specified bare id, pass `assetTypeHint` (the asset type you
- * already hold) and the resolver retries the disambiguated catalog variant
+ * For an under-specified bare id, pass `assetType` (the asset type you
+ * already hold, such as an adopter's `format_type`) and the resolver retries
+ * the disambiguated catalog variant
  * `<id>_<suffix>` — so the SDK owns the `_image` / `_html` suffix
  * convention instead of every adopter re-deriving it. The hint is
  * consulted only when the bare id doesn't resolve on its own, and still
@@ -333,7 +340,8 @@ export function canonicalDeclarationFromBareId(
   // Under-specified bare id + an asset-type hint: retry the disambiguated
   // catalog variant `<id>_<suffix>`. Fails closed if that isn't a catalog
   // entry either — the hint narrows, it never fabricates.
-  const suffix = options?.assetTypeHint ? normalizeAssetTypeSuffix(options.assetTypeHint) : '';
+  const assetType = options?.assetType ?? options?.assetTypeHint;
+  const suffix = assetType ? normalizeAssetTypeSuffix(assetType) : '';
   if (suffix) {
     const disambiguated = `${id}_${suffix}`;
     const hinted = projectFormatId(
@@ -348,16 +356,17 @@ export function canonicalDeclarationFromBareId(
 }
 
 /**
- * Map an `assetTypeHint` to the AAO catalog's `<base>_<suffix>` suffix.
- * The catalog suffixes are `image` / `html` / `generative` / `js`; the two
- * canonical-kind names that differ from their suffix (`html5`, `display_tag`)
- * are aliased. Any other value is passed through lowercased so a future
- * suffix resolves without a code change — an unknown suffix simply misses
- * the catalog and the caller fails closed.
+ * Map an `assetType` to the AAO catalog's `<base>_<suffix>` suffix.
+ * Catalog asset type `javascript` and canonical-kind names that differ from
+ * their suffix (`html5`, `display_tag`) are aliased. Any other value is passed
+ * through lowercased so a future asset type or suffix resolves without a code
+ * change — an unknown value simply misses the catalog and the caller fails
+ * closed.
  */
 function normalizeAssetTypeSuffix(hint: string): string {
   const h = hint.trim().toLowerCase();
   if (h === 'html5') return 'html';
+  if (h === 'javascript') return 'js';
   if (h === 'display_tag') return 'js';
   return h;
 }
@@ -370,7 +379,7 @@ function normalizeAssetTypeSuffix(hint: string): string {
  *
  * Thin projection of {@link canonicalDeclarationFromBareId} down to the
  * `format_kind`; see it for the resolution order, fail-closed semantics,
- * the `agentUrl` default, and the `assetTypeHint` disambiguator.
+ * the `agentUrl` default, and the `assetType` disambiguator.
  */
 export function resolveCanonicalFormatKind(
   id: string,

--- a/test/lib/bare-format-id-resolver.test.js
+++ b/test/lib/bare-format-id-resolver.test.js
@@ -85,28 +85,33 @@ describe('resolveCanonicalFormatKind', { skip: SKIP_REASON }, () => {
     assert.strictEqual(resolveCanonicalFormatKind('display_300x250_image', { agentUrl: 'https://example.com/' }), null);
   });
 
-  test('assetTypeHint disambiguates an under-specified bare id to its catalog variant', () => {
-    assert.strictEqual(resolveCanonicalFormatKind('display_300x250', { assetTypeHint: 'image' }), 'image');
-    assert.strictEqual(resolveCanonicalFormatKind('display_300x250', { assetTypeHint: 'html' }), 'html5');
-    assert.strictEqual(resolveCanonicalFormatKind('display_300x250', { assetTypeHint: 'generative' }), 'image');
+  test('assetType disambiguates an under-specified bare id to its catalog variant', () => {
+    assert.strictEqual(resolveCanonicalFormatKind('display_300x250', { assetType: 'image' }), 'image');
+    assert.strictEqual(resolveCanonicalFormatKind('display_300x250', { assetType: 'html' }), 'html5');
+    assert.strictEqual(resolveCanonicalFormatKind('display_300x250', { assetType: 'generative' }), 'image');
     // Size-less base id disambiguates too.
-    assert.strictEqual(resolveCanonicalFormatKind('display', { assetTypeHint: 'js' }), 'display_tag');
+    assert.strictEqual(resolveCanonicalFormatKind('display', { assetType: 'js' }), 'display_tag');
   });
 
-  test('assetTypeHint accepts canonical-kind aliases (html5 → html, display_tag → js)', () => {
-    assert.strictEqual(resolveCanonicalFormatKind('display_300x250', { assetTypeHint: 'html5' }), 'html5');
-    assert.strictEqual(resolveCanonicalFormatKind('display', { assetTypeHint: 'display_tag' }), 'display_tag');
+  test('assetType accepts catalog and canonical-kind aliases (javascript → js, html5 → html, display_tag → js)', () => {
+    assert.strictEqual(resolveCanonicalFormatKind('display', { assetType: 'javascript' }), 'display_tag');
+    assert.strictEqual(resolveCanonicalFormatKind('display_300x250', { assetType: 'html5' }), 'html5');
+    assert.strictEqual(resolveCanonicalFormatKind('display', { assetType: 'display_tag' }), 'display_tag');
   });
 
-  test('assetTypeHint still fails closed when the disambiguated id is not a catalog entry', () => {
-    assert.strictEqual(resolveCanonicalFormatKind('display_300x250', { assetTypeHint: 'nope' }), null);
-    assert.strictEqual(resolveCanonicalFormatKind('totally_made_up', { assetTypeHint: 'image' }), null);
+  test('assetType still fails closed when the disambiguated id is not a catalog entry', () => {
+    assert.strictEqual(resolveCanonicalFormatKind('display_300x250', { assetType: 'nope' }), null);
+    assert.strictEqual(resolveCanonicalFormatKind('totally_made_up', { assetType: 'image' }), null);
   });
 
-  test('a directly-resolvable id wins over a contradicting assetTypeHint', () => {
+  test('a directly-resolvable id wins over a contradicting assetType', () => {
     // display_300x250_image is a real catalog id (image); a stray html hint
     // must not override the authoritative direct match.
-    assert.strictEqual(resolveCanonicalFormatKind('display_300x250_image', { assetTypeHint: 'html' }), 'image');
+    assert.strictEqual(resolveCanonicalFormatKind('display_300x250_image', { assetType: 'html' }), 'image');
+  });
+
+  test('assetTypeHint remains a backwards-compatible alias', () => {
+    assert.strictEqual(resolveCanonicalFormatKind('display_300x250', { assetTypeHint: 'image' }), 'image');
   });
 });
 
@@ -140,8 +145,8 @@ describe('canonicalDeclarationFromBareId', { skip: SKIP_REASON }, () => {
     assert.ok(Array.isArray(decl.params.slots));
   });
 
-  test('assetTypeHint resolves an under-specified id and the v1_format_ref carries the DISAMBIGUATED id', () => {
-    const decl = canonicalDeclarationFromBareId('display_300x250', { assetTypeHint: 'generative' });
+  test('assetType resolves an under-specified id and the v1_format_ref carries the DISAMBIGUATED id', () => {
+    const decl = canonicalDeclarationFromBareId('display_300x250', { assetType: 'generative' });
     assert.ok(decl);
     assert.strictEqual(decl.format_kind, 'image');
     assert.strictEqual(decl.params.asset_source, 'agent_synthesized');


### PR DESCRIPTION
## Summary

- add `assetType` to `resolveCanonicalFormatKind` and `canonicalDeclarationFromBareId` for disambiguating under-specified bare format ids
- keep `assetTypeHint` as a backwards-compatible deprecated alias
- map catalog asset type `javascript` to the `_js` variant and document the preferred API

Closes #2289.

## Validation

- `npm run build:lib`
- `NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/lib/bare-format-id-resolver.test.js`
- expert review: `git diff --check`, `npx tsc --noEmit --project tsconfig.lib.json`, focused resolver test
- pre-push hook: `npm run typecheck`, `npm run build:lib`