### PR TITLE
feat: expose manager revalidation and body cap option

### DIFF
--- a/.changeset/registry-manager-revalidation.md
+++ b/.changeset/registry-manager-revalidation.md
@@ -1,0 +1,5 @@
+---
+"@adcp/sdk": minor
+---
+
+Expose `RegistryClient.requestManagerRevalidation()` and add `maxBodyBytes` to `validateAdAgents()` discovery options.

--- a/src/lib/discovery/validate-adagents.ts
+++ b/src/lib/discovery/validate-adagents.ts
@@ -85,6 +85,8 @@ export interface AdAgentsValidationResult {
 export interface ValidateAdAgentsOptions {
   /** Per-request timeout in ms (default 10_000). */
   timeoutMs?: number;
+  /** Maximum response body bytes for adagents.json and ads.txt fetches (default 256 KiB). */
+  maxBodyBytes?: number;
   /** Optional User-Agent suffix (validated via `validateUserAgent`). */
   userAgent?: string;
   /** Logger level (default `'warn'`). */
@@ -99,8 +101,8 @@ export interface ValidateAdAgentsOptions {
 }
 
 const DEFAULT_TIMEOUT_MS = 10_000;
-const MAX_ADAGENTS_BYTES = 256 * 1024;
-const MAX_ADS_TXT_BYTES = 256 * 1024;
+const DEFAULT_MAX_BODY_BYTES = 256 * 1024;
+const MAX_CONFIGURABLE_BODY_BYTES = 2 * 1024 * 1024;
 
 const FETCH_HEADERS = {
   Accept: 'application/json, text/plain, */*',
@@ -123,6 +125,7 @@ export async function validateAdAgents(
     validateUserAgent(options.userAgent);
   }
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const maxBodyBytes = resolveMaxBodyBytes(options.maxBodyBytes);
   const logger = createLogger({ level: options.logLevel ?? 'warn' }).child('validateAdAgents');
   const userAgentHeader = `adcp-validate-adagents/${LIBRARY_VERSION} (+https://adcontextprotocol.org)`;
   const fromHeader = options.userAgent
@@ -136,7 +139,7 @@ export async function validateAdAgents(
   // Step 1: try the publisher's canonical location.
   const direct = await fetchJsonOrStatus(publisherUrl, {
     timeoutMs,
-    maxBodyBytes: MAX_ADAGENTS_BYTES,
+    maxBodyBytes,
     userAgentHeader,
     fromHeader,
     redirectPolicy: { mode: 'same-registrable-domain', originUrl: publisherUrl },
@@ -189,7 +192,7 @@ export async function validateAdAgents(
       }
       const followed = await fetchJsonOrStatus(target, {
         timeoutMs,
-        maxBodyBytes: MAX_ADAGENTS_BYTES,
+        maxBodyBytes,
         userAgentHeader,
         fromHeader,
         redirectPolicy: { mode: 'none' },
@@ -249,7 +252,7 @@ export async function validateAdAgents(
   const adsTxtUrl = buildUrl(publisher, '/ads.txt');
   const adsTxt = await fetchTextOrStatus(adsTxtUrl, {
     timeoutMs,
-    maxBodyBytes: MAX_ADS_TXT_BYTES,
+    maxBodyBytes,
     userAgentHeader,
     fromHeader,
   });
@@ -286,7 +289,7 @@ export async function validateAdAgents(
   const managerUrl = buildUrl(managerDomain, '/.well-known/adagents.json');
   const manager = await fetchJsonOrStatus(managerUrl, {
     timeoutMs,
-    maxBodyBytes: MAX_ADAGENTS_BYTES,
+    maxBodyBytes,
     userAgentHeader,
     fromHeader,
     redirectPolicy: { mode: 'same-registrable-domain', originUrl: managerUrl },
@@ -333,6 +336,14 @@ export async function validateAdAgents(
 function coerceAdAgentsObject(value: unknown): AdAgentsJson | null {
   if (value === null || typeof value !== 'object' || Array.isArray(value)) return null;
   return value as AdAgentsJson;
+}
+
+function resolveMaxBodyBytes(maxBodyBytes: number | undefined): number {
+  const value = maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES;
+  if (!Number.isSafeInteger(value) || value <= 0 || value > MAX_CONFIGURABLE_BODY_BYTES) {
+    throw new Error(`maxBodyBytes must be an integer between 1 and ${MAX_CONFIGURABLE_BODY_BYTES}`);
+  }
+  return value;
 }
 
 /**

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -72,6 +72,8 @@ export type {
   PublisherPropertySelector,
   CompanySearchResult,
   FindCompanyResult,
+  ManagerRevalidationRequest,
+  ManagerRevalidationResponse,
   ListPoliciesQuery,
   ListPoliciesResponse,
   ResolvePolicyQuery,

--- a/src/lib/registry/index.ts
+++ b/src/lib/registry/index.ts
@@ -44,6 +44,8 @@ import type {
   AgentSearchResponse,
   CrawlRequest,
   CrawlRequestResponse,
+  ManagerRevalidationRequest,
+  ManagerRevalidationResponse,
   BrandActivity,
   PropertyActivity,
   PolicySummary,
@@ -132,6 +134,8 @@ export type {
   FeedQuery,
   AgentSearchQuery,
   CrawlRequest,
+  ManagerRevalidationRequest,
+  ManagerRevalidationResponse,
   ListPoliciesQuery,
   ListPoliciesResponse,
   ResolvePolicyQuery,
@@ -1044,6 +1048,20 @@ export class RegistryClient {
     if (!domain?.trim()) throw new Error('domain is required');
     if (!this.apiKey) throw new Error('apiKey is required for crawl requests');
     return this.post(`${this.baseUrl}/api/registry/crawl-request`, { domain });
+  }
+
+  /**
+   * Request fan-out re-validation for publishers delegating to a manager domain.
+   * Use after rotating a manager's adagents.json so MANAGERDOMAIN publishers
+   * are queued without waiting for the next routine crawl cycle.
+   *
+   * Requires authentication.
+   */
+  async requestManagerRevalidation(managerDomain: string): Promise<ManagerRevalidationResponse> {
+    if (!managerDomain?.trim()) throw new Error('managerDomain is required');
+    if (!this.apiKey) throw new Error('apiKey is required for manager revalidation requests');
+    const body: ManagerRevalidationRequest = { manager_domain: managerDomain };
+    return this.post(`${this.baseUrl}/api/registry/manager-revalidation-request`, body);
   }
 
   // ====== Policy Management ======

--- a/src/lib/registry/types.ts
+++ b/src/lib/registry/types.ts
@@ -290,6 +290,15 @@ export type AgentSearchQuery = NonNullable<operations['searchAgentProfiles']['pa
 /** Request body for POST /api/registry/crawl-request */
 export type CrawlRequest = NonNullable<operations['requestCrawl']['requestBody']>['content']['application/json'];
 
+/** Request body for POST /api/registry/manager-revalidation-request */
+export type ManagerRevalidationRequest = NonNullable<
+  operations['requestManagerRevalidation']['requestBody']
+>['content']['application/json'];
+
+/** Response from POST /api/registry/manager-revalidation-request (202) */
+export type ManagerRevalidationResponse =
+  operations['requestManagerRevalidation']['responses']['202']['content']['application/json'];
+
 /** Query parameters for GET /api/policies/registry */
 export type ListPoliciesQuery = NonNullable<operations['listPolicies']['parameters']['query']>;
 

--- a/test/lib/public-barrel-exports.test.js
+++ b/test/lib/public-barrel-exports.test.js
@@ -22,6 +22,8 @@ import {
   type CanonicalFormatParams,
   type EffectiveTaskState,
   type GetProductsResponse,
+  type ManagerRevalidationRequest,
+  type ManagerRevalidationResponse,
   type Placement,
   type ProductFormatDeclaration,
   type ResolvedTaskState,
@@ -129,6 +131,13 @@ const generatedMissingScope = ensureGetProductsCacheScope({
 } satisfies Omit<GetProductsResponse, 'cache_scope'>);
 const generatedInjectedScope: 'public' | 'account' = generatedMissingScope.cache_scope;
 
+const managerRevalidationRequest: ManagerRevalidationRequest = { manager_domain: 'cafemedia.com' };
+const managerRevalidationResponse: ManagerRevalidationResponse = {
+  message: 'Manager re-validation enqueued',
+  manager_domain: managerRevalidationRequest.manager_domain,
+  publishers_enqueued: 1,
+};
+
 const acceptsRootPlacement = (_placement: Placement) => {};
 const acceptsTypesPlacement = (_placement: TypesPlacement) => {};
 
@@ -146,6 +155,7 @@ void resolvedTaskState;
 void required;
 void generatedScope;
 void generatedInjectedScope;
+void managerRevalidationResponse;
 void acceptsRootPlacement;
 void acceptsTypesPlacement;
 `,

--- a/test/lib/registry.test.js
+++ b/test/lib/registry.test.js
@@ -3008,14 +3008,23 @@ describe('RegistryClient', () => {
     });
 
     test('throws without apiKey', async () => {
-      const client = new RegistryClient();
-      await assert.rejects(
-        () => client.requestCrawl('publisher.example.com'),
-        err => {
-          assert.ok(err.message.includes('apiKey is required'));
-          return true;
-        }
-      );
+      const savedApiKey = process.env.ADCP_REGISTRY_API_KEY;
+      delete process.env.ADCP_REGISTRY_API_KEY;
+      restore = mockFetch(async () => {
+        throw new Error('unexpected network call');
+      });
+      try {
+        const client = new RegistryClient();
+        await assert.rejects(
+          () => client.requestCrawl('publisher.example.com'),
+          err => {
+            assert.ok(err.message.includes('apiKey is required'));
+            return true;
+          }
+        );
+      } finally {
+        if (savedApiKey !== undefined) process.env.ADCP_REGISTRY_API_KEY = savedApiKey;
+      }
     });
 
     test('throws on empty domain', async () => {
@@ -3046,6 +3055,66 @@ describe('RegistryClient', () => {
         () => client.requestCrawl('publisher.example.com'),
         err => {
           assert.ok(err.message.includes('429'));
+          return true;
+        }
+      );
+    });
+  });
+
+  // ============ requestManagerRevalidation ============
+
+  describe('requestManagerRevalidation', () => {
+    test('requests manager fan-out revalidation', async () => {
+      restore = mockFetch(async (url, opts) => {
+        assert.ok(url.includes('/api/registry/manager-revalidation-request'));
+        assert.strictEqual(opts.method, 'POST');
+        const body = JSON.parse(opts.body);
+        assert.strictEqual(body.manager_domain, 'raptive.com');
+        assert.strictEqual(opts.headers.Authorization, 'Bearer test-key');
+        return new Response(
+          JSON.stringify({
+            message: 'Manager re-validation enqueued',
+            manager_domain: 'raptive.com',
+            publishers_enqueued: 42,
+          }),
+          { status: 202 }
+        );
+      });
+
+      const client = new RegistryClient({ apiKey: 'test-key' });
+      const result = await client.requestManagerRevalidation('raptive.com');
+
+      assert.strictEqual(result.message, 'Manager re-validation enqueued');
+      assert.strictEqual(result.manager_domain, 'raptive.com');
+      assert.strictEqual(result.publishers_enqueued, 42);
+    });
+
+    test('throws without apiKey', async () => {
+      const savedApiKey = process.env.ADCP_REGISTRY_API_KEY;
+      delete process.env.ADCP_REGISTRY_API_KEY;
+      restore = mockFetch(async () => {
+        throw new Error('unexpected network call');
+      });
+      try {
+        const client = new RegistryClient();
+        await assert.rejects(
+          () => client.requestManagerRevalidation('raptive.com'),
+          err => {
+            assert.ok(err.message.includes('apiKey is required'));
+            return true;
+          }
+        );
+      } finally {
+        if (savedApiKey !== undefined) process.env.ADCP_REGISTRY_API_KEY = savedApiKey;
+      }
+    });
+
+    test('throws on empty managerDomain', async () => {
+      const client = new RegistryClient({ apiKey: 'test-key' });
+      await assert.rejects(
+        () => client.requestManagerRevalidation(''),
+        err => {
+          assert.ok(err.message.includes('managerDomain is required'));
           return true;
         }
       );

--- a/test/lib/validate-adagents.test.js
+++ b/test/lib/validate-adagents.test.js
@@ -126,6 +126,17 @@ describe('parseManagerDomain', () => {
 });
 
 describe('validateAdAgents — discovery_method', () => {
+  test('rejects invalid maxBodyBytes values before fetching', async () => {
+    await assert.rejects(
+      () => validateAdAgents('example.com', { maxBodyBytes: Infinity }),
+      /maxBodyBytes must be an integer between 1 and 2097152/
+    );
+    await assert.rejects(
+      () => validateAdAgents('example.com', { maxBodyBytes: 2 * 1024 * 1024 + 1 }),
+      /maxBodyBytes must be an integer between 1 and 2097152/
+    );
+  });
+
   test("direct path: publisher hosts its own adagents.json → discovery_method 'direct'", async () => {
     const server = await startRoutedServer({
       '/.well-known/adagents.json': { body: adAgentsJson() },
@@ -187,6 +198,56 @@ describe('validateAdAgents — discovery_method', () => {
       assert.strictEqual(result.discovery_method, 'ads_txt_managerdomain');
       assert.strictEqual(result.manager_domain, manager.host);
       assert.ok(result.adagents?.authorized_agents?.length);
+    } finally {
+      await Promise.all([publisher.close(), manager.close()]);
+    }
+  });
+
+  test('managerdomain fallback honors custom maxBodyBytes for large adagents.json', async () => {
+    const largeAdagents = JSON.stringify({
+      $schema: 'https://adcontextprotocol.org/schemas/v1/adagents.json',
+      authorized_agents: [{ url: 'https://agent.example.com/mcp', authorized_for: 'Programmatic sales' }],
+      properties: [
+        {
+          property_type: 'website',
+          name: 'example.com',
+          identifiers: [{ type: 'domain', value: 'example.com' }],
+        },
+      ],
+      padding: 'x'.repeat(270 * 1024),
+    });
+    const manager = await startRoutedServer({
+      '/.well-known/adagents.json': { body: largeAdagents },
+    });
+    const publisher = await startRoutedServer({
+      '/ads.txt': {
+        body: `MANAGERDOMAIN=${manager.host}\n`,
+        contentType: 'text/plain',
+      },
+    });
+    try {
+      const defaultResult = await validateAdAgents(publisher.host, {
+        urlForDomain: (domain, path) => `http://${domain}${path}`,
+      });
+      assert.strictEqual(defaultResult.valid, false);
+      assert.strictEqual(defaultResult.discovery_method, 'ads_txt_managerdomain');
+      assert.ok(
+        defaultResult.errors.some(e => e.includes('Response body exceeded 262144 bytes')),
+        `expected default body cap failure, got: ${JSON.stringify(defaultResult.errors)}`
+      );
+
+      const raisedCapResult = await validateAdAgents(publisher.host, {
+        maxBodyBytes: largeAdagents.length + 1024,
+        urlForDomain: (domain, path) => `http://${domain}${path}`,
+      });
+      assert.strictEqual(
+        raisedCapResult.valid,
+        true,
+        `expected raised maxBodyBytes to pass, got errors=${JSON.stringify(raisedCapResult.errors)}`
+      );
+      assert.strictEqual(raisedCapResult.discovery_method, 'ads_txt_managerdomain');
+      assert.strictEqual(raisedCapResult.manager_domain, manager.host);
+      assert.ok(raisedCapResult.adagents?.authorized_agents?.length);
     } finally {
       await Promise.all([publisher.close(), manager.close()]);
     }


### PR DESCRIPTION
## Summary

- Add typed `RegistryClient.requestManagerRevalidation(managerDomain)` for the existing registry REST operation.
- Export `ManagerRevalidationRequest` and `ManagerRevalidationResponse` from both the registry module and package root.
- Add configurable `maxBodyBytes` support to `validateAdAgents`, with the existing 256 KiB default and a 2 MiB safety ceiling.
- Cover registry revalidation, root barrel exports, invalid body caps, and large MANAGERDOMAIN validation flows.

## Validation

- `npm run ci:quick`
- `npx commitlint --from HEAD~1 --to HEAD --verbose`
- pre-push hook: typecheck + build
- Docker focused tests: `node:22-bookworm` with registry and validate-adagents tests

## Live AAO Smoke

- Enqueued manager revalidation for `wonderstruck.org` with 0 publishers enqueued.
- Enqueued manager revalidation for `cafemedia.com` with 6798 publishers enqueued.
