### PR TITLE
fix(discovery): align adagents property resolution

### DIFF
--- a/.changeset/adagents-resolution-parity.md
+++ b/.changeset/adagents-resolution-parity.md
@@ -1,5 +1,5 @@
 ---
-'@adcp/sdk': patch
+'@adcp/sdk': minor
 ---
 
-Align TypeScript adagents property resolution with Python-compatible legacy inline entries, schema-valid revocation filtering, ambiguous URL fail-closed behavior, and add `getAllProperties`.
+Refine TypeScript adagents property resolution for legacy inline entries, schema-valid revocation filtering, ambiguous URL fail-closed behavior, and add `getAllProperties`.

--- a/.changeset/adagents-resolution-parity.md
+++ b/.changeset/adagents-resolution-parity.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Align TypeScript adagents property resolution with Python-compatible legacy inline entries, schema-valid revocation filtering, ambiguous URL fail-closed behavior, and add `getAllProperties`.

--- a/src/lib/discovery/inline-publisher-properties.ts
+++ b/src/lib/discovery/inline-publisher-properties.ts
@@ -248,8 +248,16 @@ function shallowEqual(a: unknown, b: unknown): boolean {
 function revokedDomainSet(input: unknown): Set<string> {
   if (!Array.isArray(input)) return new Set();
   const out = new Set<string>();
-  for (const d of input) {
-    if (typeof d === 'string' && d.length > 0) out.add(d.toLowerCase());
+  for (const item of input) {
+    const domain =
+      typeof item === 'string'
+        ? item
+        : item &&
+            typeof item === 'object' &&
+            typeof (item as { publisher_domain?: unknown }).publisher_domain === 'string'
+          ? (item as { publisher_domain: string }).publisher_domain
+          : undefined;
+    if (domain && domain.length > 0) out.add(domain.toLowerCase());
   }
   return out;
 }

--- a/src/lib/discovery/resolve-agent-properties.ts
+++ b/src/lib/discovery/resolve-agent-properties.ts
@@ -18,11 +18,11 @@
  *     for the caller to resolve against other publishers' adagents.json
  *   - `signal_ids` / `signal_tags` → signals agents; no property output
  *
- * Mirrors the Python SDK's `_resolve_agent_properties` (adcp-client-python).
- * Fails closed: entries without `authorization_type` or with a missing
- * selector return zero properties, except the Python-compatible legacy
- * bare-inline shape above. The pre-fix TS behavior of attributing every
- * property to every listed agent is gone.
+ * Mirrors the Python SDK's `_resolve_agent_properties` for schema-less
+ * legacy bare-inline entries while keeping schema-declared files strict.
+ * Missing selectors and bare entries without their own inline `properties[]`
+ * return zero properties. The pre-fix TS behavior of attributing every
+ * top-level property to every listed agent is gone.
  */
 import type {
   AdAgentsJson,
@@ -428,6 +428,8 @@ function revokedDomainSet(input: unknown): Set<string> {
   if (!Array.isArray(input)) return new Set();
   const out = new Set<string>();
   for (const item of input) {
+    // `revoked_at` and `reason` are metadata; presence in this list is the
+    // revocation signal.
     const domain =
       typeof item === 'string'
         ? item

--- a/src/lib/discovery/resolve-agent-properties.ts
+++ b/src/lib/discovery/resolve-agent-properties.ts
@@ -129,7 +129,8 @@ function parseAgentUrl(raw: string): URL | null {
  * Resolve `agentUrl`'s authorization scope against an `adagents.json`
  * file. The lookup uses canonicalized URL comparison — two URLs
  * differing only in host case, default port, percent-encoding of
- * unreserved chars, or fragment are the same agent.
+ * unreserved chars, or fragment are the same agent. Scheme and trailing
+ * slash differences remain distinct.
  *
  * Returns `{ properties: [], cross_publisher: [], cross_publisher_expanded: [], unresolvable: '...' }`
  * (never throws) when the agent isn't listed, when its entry is
@@ -307,6 +308,11 @@ function resolveMatchedAgentProperties(adAgents: AdAgentsJson, entry: Authorized
  * absent from the result. Legacy bare-inline entries with `properties[]`
  * are included. `publisher_properties` cross-references are reported
  * separately so the caller can resolve them against other publishers' files.
+ *
+ * The returned map is keyed by public canonical URL; if a file contains
+ * canonical-equivalent entries, the later entry wins in this non-authoritative
+ * inventory view. Use `resolveAgentProperties` for an authorization decision
+ * for a specific agent URL because it fails closed on ambiguous matches.
  */
 export function listAgentPropertyMap(adAgents: AdAgentsJson): {
   byAgent: Map<string, Property[]>;
@@ -356,18 +362,21 @@ export function listAgentPropertyMap(adAgents: AdAgentsJson): {
 }
 
 /**
- * Python-compatible total local property helper for `adagents.json`.
+ * Non-authoritative total local property helper for `adagents.json`.
  *
  * This concatenates each authorized agent's locally resolved property scope
  * (`property_ids`, `property_tags`, `inline_properties`, legacy bare inline,
  * and inline-resolved `publisher_properties`). It intentionally preserves
- * duplicate property objects across multiple agents because the Python helper
- * is a sum of per-agent scopes, not a unique publisher catalog.
+ * duplicate property objects across multiple agents because it is a sum of
+ * per-agent scopes, not a unique publisher catalog.
  *
  * If no agent scope resolves to local properties, it falls back to the file's
  * top-level `properties[]`. In both paths, properties whose
  * `publisher_domain` is listed in `revoked_publisher_domains[]` are filtered
  * out.
+ *
+ * Do not use this helper for authorization. It resolves each entry independently
+ * for inventory aggregation and does not fail closed on canonical URL ambiguity.
  */
 export function getAllProperties(adAgents: AdAgentsJson): Property[] {
   const out: Property[] = [];
@@ -410,7 +419,7 @@ function filterRevokedProperties(properties: unknown, revokedDomainsInput: unkno
   if (revokedDomains.size === 0) return properties as Property[];
   return (properties as Property[]).filter(p => {
     const domains = propertyPublisherDomains(p);
-    if (domains.length === 0) return false;
+    if (domains.length === 0) return true;
     return domains.every(domain => !revokedDomains.has(domain.toLowerCase()));
   });
 }

--- a/src/lib/discovery/resolve-agent-properties.ts
+++ b/src/lib/discovery/resolve-agent-properties.ts
@@ -12,15 +12,17 @@
  *   - `property_ids`   → filter top-level `properties[]` by `property_id`
  *   - `property_tags`  → filter top-level `properties[]` by tag intersection
  *   - `inline_properties` → return the agent entry's own `properties[]`
+ *   - legacy bare inline (`properties[]` without `authorization_type`) →
+ *     return the agent entry's own `properties[]`
  *   - `publisher_properties` → cross-publisher; returned as `cross_publisher`
  *     for the caller to resolve against other publishers' adagents.json
  *   - `signal_ids` / `signal_tags` → signals agents; no property output
  *
  * Mirrors the Python SDK's `_resolve_agent_properties` (adcp-client-python).
  * Fails closed: entries without `authorization_type` or with a missing
- * selector return zero properties — matching the Python SDK and the
- * schema's strict-conformance position. The pre-fix TS behavior of
- * attributing every property to every listed agent is gone.
+ * selector return zero properties, except the Python-compatible legacy
+ * bare-inline shape above. The pre-fix TS behavior of attributing every
+ * property to every listed agent is gone.
  */
 import type {
   AdAgentsJson,
@@ -68,6 +70,8 @@ export interface ResolvedAgentScope {
 export type ResolveUnresolvableReason =
   /** The agent URL is not listed in `authorized_agents[]` at all. */
   | 'agent_not_listed'
+  /** More than one entry matches the same canonical agent URL. */
+  | 'ambiguous_agent_url'
   /** Entry exists but has no `authorization_type` discriminator. */
   | 'missing_authorization_type'
   /** Entry has an `authorization_type` we do not recognize. */
@@ -95,6 +99,17 @@ export type ResolveUnresolvableReason =
  * resolver — e.g., TMP `seller_agent_url` validation.
  */
 export function canonicalizeAgentUrl(raw: string): string | null {
+  const parsed = parseAgentUrl(raw);
+  if (!parsed) return null;
+  // `URL.host` already strips default ports and lowercases the hostname.
+  // Use `protocol + host` (NOT `origin`) so the assembled string keeps
+  // the IDN-A-label form Node produces.
+  const path = decodeUnreservedPercentEncoding(parsed.pathname);
+  const query = parsed.search ? decodeUnreservedPercentEncoding(parsed.search) : '';
+  return `${parsed.protocol}//${parsed.host}${path}${query}`;
+}
+
+function parseAgentUrl(raw: string): URL | null {
   if (typeof raw !== 'string' || raw.length === 0) return null;
   let parsed: URL;
   try {
@@ -107,19 +122,14 @@ export function canonicalizeAgentUrl(raw: string): string | null {
   // Reject non-http(s) schemes — `adagents.json` agent URLs are HTTPS-only
   // in production, but we accept `http://` here so loopback fixtures parse.
   if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') return null;
-  // `URL.host` already strips default ports and lowercases the hostname.
-  // Use `protocol + host` (NOT `origin`) so the assembled string keeps
-  // the IDN-A-label form Node produces.
-  const path = decodeUnreservedPercentEncoding(parsed.pathname);
-  const query = parsed.search ? decodeUnreservedPercentEncoding(parsed.search) : '';
-  return `${parsed.protocol}//${parsed.host}${path}${query}`;
+  return parsed;
 }
 
 /**
  * Resolve `agentUrl`'s authorization scope against an `adagents.json`
  * file. The lookup uses canonicalized URL comparison — two URLs
- * differing only in case, default port, percent-encoding of unreserved
- * chars, or fragment are the same agent.
+ * differing only in host case, default port, percent-encoding of
+ * unreserved chars, or fragment are the same agent.
  *
  * Returns `{ properties: [], cross_publisher: [], cross_publisher_expanded: [], unresolvable: '...' }`
  * (never throws) when the agent isn't listed, when its entry is
@@ -132,18 +142,39 @@ export function resolveAgentProperties(adAgents: AdAgentsJson, agentUrl: string)
   }
 
   const entries = Array.isArray(adAgents.authorized_agents) ? adAgents.authorized_agents : [];
-  const entry = entries.find(e => {
+  const matches = entries.filter(e => {
     if (!e || typeof e.url !== 'string') return false;
     const canon = canonicalizeAgentUrl(e.url);
     return canon !== null && canon === wanted;
   });
+  if (matches.length > 1) {
+    return { properties: [], cross_publisher: [], cross_publisher_expanded: [], unresolvable: 'ambiguous_agent_url' };
+  }
 
+  const entry = matches[0];
   if (!entry) {
     return { properties: [], cross_publisher: [], cross_publisher_expanded: [], unresolvable: 'agent_not_listed' };
   }
 
+  return resolveMatchedAgentProperties(adAgents, entry);
+}
+
+function resolveMatchedAgentProperties(adAgents: AdAgentsJson, entry: AuthorizedAgent): ResolvedAgentScope {
+  const allProperties = filterRevokedProperties(adAgents.properties, adAgents.revoked_publisher_domains);
   const authType = entry.authorization_type as AuthorizationType | undefined;
   if (!authType) {
+    // Python SDK compatibility: legacy files sometimes omit the discriminator
+    // while carrying inline `properties[]` on the agent entry.
+    if (allowsLegacyBareInline(adAgents) && Array.isArray(entry.properties) && entry.properties.length > 0) {
+      const inline = filterRevokedProperties(entry.properties, adAgents.revoked_publisher_domains);
+      return {
+        properties: inline,
+        cross_publisher: [],
+        cross_publisher_expanded: [],
+        matched_entry: entry,
+        ...(inline.length === 0 ? { unresolvable: 'no_match' as const } : {}),
+      };
+    }
     return {
       properties: [],
       cross_publisher: [],
@@ -152,8 +183,6 @@ export function resolveAgentProperties(adAgents: AdAgentsJson, agentUrl: string)
       unresolvable: 'missing_authorization_type',
     };
   }
-
-  const allProperties = Array.isArray(adAgents.properties) ? adAgents.properties : [];
 
   switch (authType) {
     case 'property_ids': {
@@ -211,7 +240,14 @@ export function resolveAgentProperties(adAgents: AdAgentsJson, agentUrl: string)
           unresolvable: 'missing_selector',
         };
       }
-      return { properties: inline, cross_publisher: [], cross_publisher_expanded: [], matched_entry: entry };
+      const matched = filterRevokedProperties(inline, adAgents.revoked_publisher_domains);
+      return {
+        properties: matched,
+        cross_publisher: [],
+        cross_publisher_expanded: [],
+        matched_entry: entry,
+        ...(matched.length === 0 ? { unresolvable: 'no_match' as const } : {}),
+      };
     }
 
     case 'publisher_properties': {
@@ -267,10 +303,10 @@ export function resolveAgentProperties(adAgents: AdAgentsJson, agentUrl: string)
 /**
  * Convenience: list every locally-resolvable (`agent_url` →
  * `Property[]`) pair from an `adagents.json` file. Agents listed with
- * `signal_ids` / `signal_tags` or with no `authorization_type` are
- * absent from the result. `publisher_properties` cross-references are
- * reported separately so the caller can resolve them against other
- * publishers' files.
+ * `signal_ids` / `signal_tags` or with no resolvable property selector are
+ * absent from the result. Legacy bare-inline entries with `properties[]`
+ * are included. `publisher_properties` cross-references are reported
+ * separately so the caller can resolve them against other publishers' files.
  */
 export function listAgentPropertyMap(adAgents: AdAgentsJson): {
   byAgent: Map<string, Property[]>;
@@ -298,7 +334,7 @@ export function listAgentPropertyMap(adAgents: AdAgentsJson): {
   const entries = Array.isArray(adAgents.authorized_agents) ? adAgents.authorized_agents : [];
   for (const entry of entries) {
     if (!entry || typeof entry.url !== 'string') continue;
-    const scope = resolveAgentProperties(adAgents, entry.url);
+    const scope = resolveMatchedAgentProperties(adAgents, entry);
     const canon = canonicalizeAgentUrl(entry.url);
     const key = canon ?? entry.url;
     if (scope.properties.length > 0) {
@@ -317,6 +353,31 @@ export function listAgentPropertyMap(adAgents: AdAgentsJson): {
   }
 
   return { byAgent, unresolved, cross_publisher };
+}
+
+/**
+ * Python-compatible total local property helper for `adagents.json`.
+ *
+ * This concatenates each authorized agent's locally resolved property scope
+ * (`property_ids`, `property_tags`, `inline_properties`, legacy bare inline,
+ * and inline-resolved `publisher_properties`). It intentionally preserves
+ * duplicate property objects across multiple agents because the Python helper
+ * is a sum of per-agent scopes, not a unique publisher catalog.
+ *
+ * If no agent scope resolves to local properties, it falls back to the file's
+ * top-level `properties[]`. In both paths, properties whose
+ * `publisher_domain` is listed in `revoked_publisher_domains[]` are filtered
+ * out.
+ */
+export function getAllProperties(adAgents: AdAgentsJson): Property[] {
+  const out: Property[] = [];
+  const entries = Array.isArray(adAgents.authorized_agents) ? adAgents.authorized_agents : [];
+  for (const entry of entries) {
+    if (!entry || typeof entry.url !== 'string') continue;
+    const scope = resolveMatchedAgentProperties(adAgents, entry);
+    if (scope.properties.length > 0) out.push(...scope.properties);
+  }
+  return out.length > 0 ? out : filterRevokedProperties(adAgents.properties, adAgents.revoked_publisher_domains);
 }
 
 /**
@@ -341,4 +402,56 @@ function decodeUnreservedPercentEncoding(input: string): string {
       code === 0x7e; // '~'
     return isUnreserved ? String.fromCharCode(code) : match.toUpperCase();
   });
+}
+
+function filterRevokedProperties(properties: unknown, revokedDomainsInput: unknown): Property[] {
+  if (!Array.isArray(properties)) return [];
+  const revokedDomains = revokedDomainSet(revokedDomainsInput);
+  if (revokedDomains.size === 0) return properties as Property[];
+  return (properties as Property[]).filter(p => {
+    const domains = propertyPublisherDomains(p);
+    if (domains.length === 0) return false;
+    return domains.every(domain => !revokedDomains.has(domain.toLowerCase()));
+  });
+}
+
+function revokedDomainSet(input: unknown): Set<string> {
+  if (!Array.isArray(input)) return new Set();
+  const out = new Set<string>();
+  for (const item of input) {
+    const domain =
+      typeof item === 'string'
+        ? item
+        : item &&
+            typeof item === 'object' &&
+            typeof (item as { publisher_domain?: unknown }).publisher_domain === 'string'
+          ? (item as { publisher_domain: string }).publisher_domain
+          : undefined;
+    if (domain && domain.length > 0) out.add(domain.toLowerCase());
+  }
+  return out;
+}
+
+function propertyPublisherDomains(property: Property): string[] {
+  const out: string[] = [];
+  if (typeof property.publisher_domain === 'string' && property.publisher_domain.length > 0) {
+    out.push(property.publisher_domain);
+  }
+  if (Array.isArray(property.identifiers)) {
+    for (const id of property.identifiers) {
+      if (
+        id &&
+        (id.type === 'domain' || id.type === 'subdomain') &&
+        typeof id.value === 'string' &&
+        id.value.length > 0
+      ) {
+        out.push(id.value);
+      }
+    }
+  }
+  return out;
+}
+
+function allowsLegacyBareInline(adAgents: AdAgentsJson): boolean {
+  return typeof adAgents.$schema !== 'string' || adAgents.$schema.length === 0;
 }

--- a/src/lib/discovery/types.ts
+++ b/src/lib/discovery/types.ts
@@ -44,6 +44,14 @@ export interface Property {
   publisher_domain?: string;
 }
 
+export type RevokedPublisherDomain =
+  | string
+  | {
+      publisher_domain: string;
+      revoked_at?: string;
+      reason?: string;
+    };
+
 /**
  * Discriminator for the per-agent authorization scope on each
  * `authorized_agents[]` entry. Drives `resolveAgentProperties()` —
@@ -102,7 +110,9 @@ export type CompactPublisherPropertySelector =
  * field — see the spec at `schemas/cache/3.0.11/adagents.json`. Files
  * in the wild sometimes omit them, so both fields are typed as optional
  * here. `resolveAgentProperties()` fails closed (returns no properties)
- * when the discriminator or its selector is missing.
+ * when the discriminator or its selector is missing, except for the legacy
+ * Python-compatible bare-inline shape where an entry omits
+ * `authorization_type` but carries inline `properties[]`.
  */
 export interface AuthorizedAgent {
   url: string;
@@ -210,6 +220,6 @@ export interface AdAgentsJson {
    * part 2) and the SDK's `property-crawler` for the consumer-side
    * cross-check.
    */
-  revoked_publisher_domains?: string[];
+  revoked_publisher_domains?: RevokedPublisherDomain[];
   last_updated?: string;
 }

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -211,6 +211,7 @@ export {
 export {
   resolveAgentProperties,
   listAgentPropertyMap,
+  getAllProperties,
   canonicalizeAgentUrl,
   type ResolvedAgentScope,
   type ResolveUnresolvableReason,

--- a/test/lib/inline-publisher-properties.test.js
+++ b/test/lib/inline-publisher-properties.test.js
@@ -157,6 +157,17 @@ describe('resolveInlinePublisherProperties — revocation', () => {
     const result = resolveInlinePublisherProperties(file, [{ selection_type: 'all', publisher_domain: 'a.example' }]);
     assert.strictEqual(result.revoked_selectors.length, 1);
   });
+
+  test('schema-valid revocation objects are honored', () => {
+    const file = {
+      ...adAgents,
+      revoked_publisher_domains: [{ publisher_domain: 'a.example', revoked_at: '2026-01-01T00:00:00Z' }],
+    };
+    const result = resolveInlinePublisherProperties(file, [{ selection_type: 'all', publisher_domain: 'a.example' }]);
+    assert.strictEqual(result.inline_properties.length, 0);
+    assert.strictEqual(result.unresolved_selectors.length, 0);
+    assert.strictEqual(result.revoked_selectors.length, 1);
+  });
 });
 
 describe('resolveInlinePublisherProperties — input defensiveness', () => {

--- a/test/lib/property-crawler.test.js
+++ b/test/lib/property-crawler.test.js
@@ -23,6 +23,7 @@ const assert = require('node:assert');
 const http = require('node:http');
 
 const { PropertyCrawler } = require('../../dist/lib/discovery/property-crawler.js');
+const { getPropertyIndex, resetPropertyIndex } = require('../../dist/lib/discovery/property-index.js');
 const { LIBRARY_VERSION } = require('../../dist/lib/version.js');
 
 /**
@@ -580,6 +581,64 @@ describe('PropertyCrawler', () => {
         );
       } finally {
         await server.close();
+      }
+    });
+
+    test('crawlAgents honors revocations when raw adagents properties omit publisher_domain', async () => {
+      resetPropertyIndex();
+      class TestCrawler extends PropertyCrawler {
+        async crawlAgent() {
+          return ['publisher.example'];
+        }
+
+        async fetchPublisherProperties() {
+          const rawAdAgents = {
+            revoked_publisher_domains: [{ publisher_domain: 'revoked.example', revoked_at: '2026-01-01T00:00:00Z' }],
+            properties: [
+              {
+                property_id: 'revoked',
+                property_type: 'website',
+                name: 'Revoked Site',
+                identifiers: [{ type: 'domain', value: 'revoked.example' }],
+              },
+              {
+                property_id: 'kept',
+                property_type: 'website',
+                name: 'Kept Site',
+                identifiers: [{ type: 'domain', value: 'kept.example' }],
+              },
+            ],
+            authorized_agents: [
+              {
+                url: 'https://agent.example/mcp',
+                authorized_for: 'test',
+                authorization_type: 'property_ids',
+                property_ids: ['revoked', 'kept'],
+              },
+            ],
+          };
+          return {
+            properties: {
+              'publisher.example': rawAdAgents.properties.map(p => ({ ...p, publisher_domain: 'publisher.example' })),
+            },
+            adAgents: { 'publisher.example': rawAdAgents },
+            warnings: [],
+          };
+        }
+      }
+
+      try {
+        const crawler = new TestCrawler({ logLevel: 'silent' });
+        const result = await crawler.crawlAgents([{ agent_url: 'https://agent.example/mcp' }]);
+        const auth = getPropertyIndex().getAgentAuthorizations('https://agent.example/mcp');
+
+        assert.strictEqual(result.totalProperties, 1);
+        assert.deepStrictEqual(
+          auth.properties.map(p => p.property_id),
+          ['kept']
+        );
+      } finally {
+        resetPropertyIndex();
       }
     });
   });

--- a/test/lib/resolve-agent-properties.test.js
+++ b/test/lib/resolve-agent-properties.test.js
@@ -27,6 +27,17 @@ function makeProperty(id, name, tags) {
   return out;
 }
 
+function makeAppProperty(id, bundle, tags) {
+  const out = {
+    property_id: id,
+    property_type: 'mobile_app',
+    name: bundle,
+    identifiers: [{ type: 'ios_bundle', value: bundle }],
+  };
+  if (tags) out.tags = tags;
+  return out;
+}
+
 describe('canonicalizeAgentUrl', () => {
   test('lowercases scheme and host', () => {
     assert.strictEqual(canonicalizeAgentUrl('HTTPS://Example.COM/mcp'), 'https://example.com/mcp');
@@ -465,7 +476,7 @@ describe('resolveAgentProperties — authorization_type: signal_ids / signal_tag
   });
 });
 
-describe('resolveAgentProperties — fail-closed behavior (#1721 spec parity with Python SDK)', () => {
+describe('resolveAgentProperties — fail-closed and revocation behavior (#1721)', () => {
   test('agent not in authorized_agents → unresolvable: agent_not_listed', () => {
     const file = {
       properties: [makeProperty('main', 'main.example')],
@@ -485,8 +496,8 @@ describe('resolveAgentProperties — fail-closed behavior (#1721 spec parity wit
 
   test('missing authorization_type → unresolvable: missing_authorization_type (issue example)', () => {
     // The Wonderstruck/Interchange production case from #1721:
-    // both agents listed, neither has authorization_type. Python SDK
-    // resolves to 0 properties. TS SDK (post-fix) must agree.
+    // both agents listed, neither has authorization_type. Schema-declared
+    // agent scopes must not inherit every top-level property.
     const file = {
       properties: [
         {
@@ -559,6 +570,45 @@ describe('resolveAgentProperties — fail-closed behavior (#1721 spec parity wit
     assert.deepStrictEqual(
       scope.properties.map(p => p.property_id),
       ['kept']
+    );
+  });
+
+  test('domainless app properties survive unrelated revoked publisher domains', () => {
+    const file = {
+      revoked_publisher_domains: [{ publisher_domain: 'a.example', revoked_at: '2026-01-01T00:00:00Z' }],
+      properties: [makeAppProperty('app', 'com.example.publisher', ['apps'])],
+      authorized_agents: [
+        {
+          url: 'https://ids.example/mcp',
+          authorized_for: 'ids',
+          authorization_type: 'property_ids',
+          property_ids: ['app'],
+        },
+        {
+          url: 'https://tags.example/mcp',
+          authorized_for: 'tags',
+          authorization_type: 'property_tags',
+          property_tags: ['apps'],
+        },
+        {
+          url: 'https://inline.example/mcp',
+          authorized_for: 'inline',
+          authorization_type: 'inline_properties',
+          properties: [makeAppProperty('inline_app', 'com.example.inline')],
+        },
+      ],
+    };
+    assert.deepStrictEqual(
+      resolveAgentProperties(file, 'https://ids.example/mcp').properties.map(p => p.property_id),
+      ['app']
+    );
+    assert.deepStrictEqual(
+      resolveAgentProperties(file, 'https://tags.example/mcp').properties.map(p => p.property_id),
+      ['app']
+    );
+    assert.deepStrictEqual(
+      resolveAgentProperties(file, 'https://inline.example/mcp').properties.map(p => p.property_id),
+      ['inline_app']
     );
   });
 
@@ -706,6 +756,25 @@ describe('getAllProperties', () => {
     assert.deepStrictEqual(
       getAllProperties(file).map(p => p.property_id),
       ['kept']
+    );
+  });
+
+  test('fallback keeps domainless app properties when unrelated domains are revoked', () => {
+    const file = {
+      revoked_publisher_domains: [{ publisher_domain: 'revoked.example', revoked_at: '2026-01-01T00:00:00Z' }],
+      properties: [makeAppProperty('app', 'com.example.publisher')],
+      authorized_agents: [
+        {
+          url: 'https://signals.example/mcp',
+          authorized_for: 'signals',
+          authorization_type: 'signal_ids',
+          signal_ids: ['s1'],
+        },
+      ],
+    };
+    assert.deepStrictEqual(
+      getAllProperties(file).map(p => p.property_id),
+      ['app']
     );
   });
 

--- a/test/lib/resolve-agent-properties.test.js
+++ b/test/lib/resolve-agent-properties.test.js
@@ -12,6 +12,7 @@ const assert = require('node:assert');
 const {
   resolveAgentProperties,
   listAgentPropertyMap,
+  getAllProperties,
   canonicalizeAgentUrl,
 } = require('../../dist/lib/discovery/resolve-agent-properties.js');
 
@@ -29,6 +30,7 @@ function makeProperty(id, name, tags) {
 describe('canonicalizeAgentUrl', () => {
   test('lowercases scheme and host', () => {
     assert.strictEqual(canonicalizeAgentUrl('HTTPS://Example.COM/mcp'), 'https://example.com/mcp');
+    assert.strictEqual(canonicalizeAgentUrl('http://Example.COM/mcp'), 'http://example.com/mcp');
   });
 
   test('strips default port (443 for https, 80 for http)', () => {
@@ -48,6 +50,11 @@ describe('canonicalizeAgentUrl', () => {
 
   test('strips fragment', () => {
     assert.strictEqual(canonicalizeAgentUrl('https://example.com/mcp#foo'), 'https://example.com/mcp');
+  });
+
+  test('preserves trailing slash in the public canonical URL', () => {
+    assert.strictEqual(canonicalizeAgentUrl('https://example.com/mcp/'), 'https://example.com/mcp/');
+    assert.strictEqual(canonicalizeAgentUrl('https://example.com/'), 'https://example.com/');
   });
 
   test('rejects userinfo', () => {
@@ -89,6 +96,54 @@ describe('resolveAgentProperties — authorization_type: property_ids', () => {
   test('canonical-URL match: trailing port-443 still matches', () => {
     const scope = resolveAgentProperties(adAgents, 'https://agent-news.example:443/mcp');
     assert.strictEqual(scope.properties.length, 1);
+  });
+
+  test('canonical-URL match: scheme differences do not match', () => {
+    const file = {
+      ...adAgents,
+      authorized_agents: [{ ...adAgents.authorized_agents[0], url: 'http://agent-news.example/mcp' }],
+    };
+    const scope = resolveAgentProperties(file, 'https://agent-news.example/mcp');
+    assert.strictEqual(scope.properties.length, 0);
+    assert.strictEqual(scope.unresolvable, 'agent_not_listed');
+  });
+
+  test('canonical-URL match: trailing slash differences do not match', () => {
+    const file = {
+      ...adAgents,
+      authorized_agents: [{ ...adAgents.authorized_agents[0], url: 'https://agent-news.example/mcp/' }],
+    };
+    const scope = resolveAgentProperties(file, 'https://agent-news.example/mcp');
+    assert.strictEqual(scope.properties.length, 0);
+    assert.strictEqual(scope.unresolvable, 'agent_not_listed');
+  });
+
+  test('listAgentPropertyMap keeps public canonical URL keys', () => {
+    const result = listAgentPropertyMap(adAgents);
+    assert.ok(result.byAgent.has('https://agent-news.example/mcp'));
+  });
+
+  test('external URL lookup fails closed when canonical-equivalent entries are ambiguous', () => {
+    const file = {
+      properties: [makeProperty('home', 'home.example'), makeProperty('news', 'news.example')],
+      authorized_agents: [
+        {
+          url: 'https://agent-news.example/mcp',
+          authorized_for: 'home',
+          authorization_type: 'property_ids',
+          property_ids: ['home'],
+        },
+        {
+          url: 'https://agent-news.example:443/mcp',
+          authorized_for: 'news',
+          authorization_type: 'property_ids',
+          property_ids: ['news'],
+        },
+      ],
+    };
+    const scope = resolveAgentProperties(file, 'https://agent-news.example/mcp');
+    assert.strictEqual(scope.properties.length, 0);
+    assert.strictEqual(scope.unresolvable, 'ambiguous_agent_url');
   });
 
   test('returns no_match when none of the property_ids resolve', () => {
@@ -156,6 +211,83 @@ describe('resolveAgentProperties — authorization_type: inline_properties', () 
     assert.deepStrictEqual(scope.properties.map(p => p.property_id).sort(), ['inline_a', 'inline_b']);
     // Top-level `main` is NOT included — inline overrides top-level.
     assert.ok(!scope.properties.some(p => p.property_id === 'main'));
+  });
+
+  test('filters revoked inline properties', () => {
+    const file = {
+      revoked_publisher_domains: ['a.example'],
+      authorized_agents: [
+        {
+          url: 'https://agent.example/mcp',
+          authorized_for: 'inline test',
+          authorization_type: 'inline_properties',
+          properties: [
+            { ...makeProperty('inline_a', 'a.example'), publisher_domain: 'a.example' },
+            { ...makeProperty('inline_b', 'b.example'), publisher_domain: 'b.example' },
+          ],
+        },
+      ],
+    };
+    const scope = resolveAgentProperties(file, 'https://agent.example/mcp');
+    assert.deepStrictEqual(
+      scope.properties.map(p => p.property_id),
+      ['inline_b']
+    );
+  });
+});
+
+describe('resolveAgentProperties — legacy bare inline properties[]', () => {
+  test('treats an entry without authorization_type but with properties[] as inline_properties', () => {
+    const file = {
+      properties: [makeProperty('top', 'top.example')],
+      authorized_agents: [
+        {
+          url: 'https://legacy.example/mcp',
+          authorized_for: 'legacy inline',
+          properties: [makeProperty('inline_a', 'a.example'), makeProperty('inline_b', 'b.example')],
+        },
+      ],
+    };
+    const scope = resolveAgentProperties(file, 'https://legacy.example/mcp');
+    assert.deepStrictEqual(scope.properties.map(p => p.property_id).sort(), ['inline_a', 'inline_b']);
+    assert.strictEqual(scope.unresolvable, undefined);
+  });
+
+  test('applies revoked_publisher_domains to legacy bare inline properties', () => {
+    const file = {
+      revoked_publisher_domains: ['a.example'],
+      authorized_agents: [
+        {
+          url: 'https://legacy.example/mcp',
+          authorized_for: 'legacy inline',
+          properties: [
+            { ...makeProperty('inline_a', 'a.example'), publisher_domain: 'a.example' },
+            { ...makeProperty('inline_b', 'b.example'), publisher_domain: 'b.example' },
+          ],
+        },
+      ],
+    };
+    const scope = resolveAgentProperties(file, 'https://legacy.example/mcp');
+    assert.deepStrictEqual(
+      scope.properties.map(p => p.property_id),
+      ['inline_b']
+    );
+  });
+
+  test('schema-declared files do not enable legacy bare inline compatibility', () => {
+    const file = {
+      $schema: 'https://adcontextprotocol.org/schemas/v1/adagents.json',
+      authorized_agents: [
+        {
+          url: 'https://legacy.example/mcp',
+          authorized_for: 'legacy inline',
+          properties: [makeProperty('inline_a', 'a.example')],
+        },
+      ],
+    };
+    const scope = resolveAgentProperties(file, 'https://legacy.example/mcp');
+    assert.strictEqual(scope.properties.length, 0);
+    assert.strictEqual(scope.unresolvable, 'missing_authorization_type');
   });
 });
 
@@ -376,6 +508,60 @@ describe('resolveAgentProperties — fail-closed behavior (#1721 spec parity wit
     }
   });
 
+  test('revoked top-level publisher domains are filtered from property_ids and property_tags scopes', () => {
+    const file = {
+      revoked_publisher_domains: [{ publisher_domain: 'a.example', revoked_at: '2026-01-01T00:00:00Z' }],
+      properties: [
+        { ...makeProperty('revoked', 'a.example', ['news']), publisher_domain: 'a.example' },
+        { ...makeProperty('kept', 'b.example', ['news']), publisher_domain: 'b.example' },
+      ],
+      authorized_agents: [
+        {
+          url: 'https://ids.example/mcp',
+          authorized_for: 'ids',
+          authorization_type: 'property_ids',
+          property_ids: ['revoked', 'kept'],
+        },
+        {
+          url: 'https://tags.example/mcp',
+          authorized_for: 'tags',
+          authorization_type: 'property_tags',
+          property_tags: ['news'],
+        },
+      ],
+    };
+    const idsScope = resolveAgentProperties(file, 'https://ids.example/mcp');
+    const tagsScope = resolveAgentProperties(file, 'https://tags.example/mcp');
+    assert.deepStrictEqual(
+      idsScope.properties.map(p => p.property_id),
+      ['kept']
+    );
+    assert.deepStrictEqual(
+      tagsScope.properties.map(p => p.property_id),
+      ['kept']
+    );
+  });
+
+  test('revoked publisher domains also match domain identifiers when publisher_domain is absent', () => {
+    const file = {
+      revoked_publisher_domains: [{ publisher_domain: 'a.example', revoked_at: '2026-01-01T00:00:00Z' }],
+      properties: [makeProperty('revoked', 'a.example'), makeProperty('kept', 'b.example')],
+      authorized_agents: [
+        {
+          url: 'https://ids.example/mcp',
+          authorized_for: 'ids',
+          authorization_type: 'property_ids',
+          property_ids: ['revoked', 'kept'],
+        },
+      ],
+    };
+    const scope = resolveAgentProperties(file, 'https://ids.example/mcp');
+    assert.deepStrictEqual(
+      scope.properties.map(p => p.property_id),
+      ['kept']
+    );
+  });
+
   test('unknown authorization_type → unresolvable: unknown_authorization_type', () => {
     const file = {
       properties: [makeProperty('main', 'main.example')],
@@ -442,5 +628,108 @@ describe('listAgentPropertyMap', () => {
     assert.strictEqual(result.unresolved.length, 2);
     assert.ok(result.unresolved.some(u => u.reason === 'missing_authorization_type'));
     assert.ok(result.unresolved.some(u => u.reason === 'signals_only'));
+  });
+});
+
+describe('getAllProperties', () => {
+  test(
+    'is exported from the root SDK entry point',
+    { skip: Number(process.versions.node.split('.')[0]) < 20 ? 'root CJS entry requires Node 20+ dev stack' : false },
+    () => {
+      const { getAllProperties: rootGetAllProperties } = require('../../dist/lib/index.js');
+      assert.strictEqual(rootGetAllProperties, getAllProperties);
+    }
+  );
+
+  test('sums per-agent resolved properties instead of returning the top-level catalog length', () => {
+    const file = {
+      properties: [
+        makeProperty('p1', 'one.example'),
+        makeProperty('p2', 'two.example'),
+        makeProperty('p3', 'three.example'),
+      ],
+      authorized_agents: [
+        {
+          url: 'https://agent.example/mcp',
+          authorized_for: 'subset',
+          authorization_type: 'property_ids',
+          property_ids: ['p1', 'p2'],
+        },
+      ],
+    };
+    assert.deepStrictEqual(
+      getAllProperties(file).map(p => p.property_id),
+      ['p1', 'p2']
+    );
+  });
+
+  test('preserves duplicate properties across multiple agent scopes', () => {
+    const file = {
+      properties: [makeProperty('p1', 'one.example')],
+      authorized_agents: [
+        {
+          url: 'https://agent-a.example/mcp',
+          authorized_for: 'one',
+          authorization_type: 'property_ids',
+          property_ids: ['p1'],
+        },
+        {
+          url: 'https://agent-b.example/mcp',
+          authorized_for: 'one',
+          authorization_type: 'property_ids',
+          property_ids: ['p1'],
+        },
+      ],
+    };
+    assert.deepStrictEqual(
+      getAllProperties(file).map(p => p.property_id),
+      ['p1', 'p1']
+    );
+  });
+
+  test('falls back to top-level properties when no agent resolves locally, filtering revoked domains', () => {
+    const file = {
+      revoked_publisher_domains: [{ publisher_domain: 'revoked.example', revoked_at: '2026-01-01T00:00:00Z' }],
+      properties: [
+        { ...makeProperty('revoked', 'revoked.example'), publisher_domain: 'revoked.example' },
+        { ...makeProperty('kept', 'kept.example'), publisher_domain: 'kept.example' },
+      ],
+      authorized_agents: [
+        {
+          url: 'https://signals.example/mcp',
+          authorized_for: 'signals',
+          authorization_type: 'signal_ids',
+          signal_ids: ['s1'],
+        },
+      ],
+    };
+    assert.deepStrictEqual(
+      getAllProperties(file).map(p => p.property_id),
+      ['kept']
+    );
+  });
+
+  test('resolves canonical-equivalent duplicate entries independently', () => {
+    const file = {
+      properties: [makeProperty('p1', 'one.example'), makeProperty('p2', 'two.example')],
+      authorized_agents: [
+        {
+          url: 'https://agent.example/mcp',
+          authorized_for: 'first',
+          authorization_type: 'property_ids',
+          property_ids: ['p1'],
+        },
+        {
+          url: 'https://agent.example:443/mcp',
+          authorized_for: 'second',
+          authorization_type: 'property_ids',
+          property_ids: ['p2'],
+        },
+      ],
+    };
+    assert.deepStrictEqual(
+      getAllProperties(file).map(p => p.property_id),
+      ['p1', 'p2']
+    );
   });
 });


### PR DESCRIPTION
Aligns adagents property resolution with Python-compatible legacy inline behavior, schema-valid revocation objects, identifier-domain revocation matching, and fail-closed ambiguous URL handling. Adds the exported getAllProperties aggregate helper while keeping per-agent resolution duplicate-safe. Expands resolver, inline publisher property, and crawler regression coverage, plus a patch changeset for @adcp/sdk. Validated with build:lib, targeted Node test suites locally, Docker coverage on Node 18/20/22, pre-push typecheck/build, and expert review; Codex review could not run because the local Codex CLI reported quota exceeded.