### PR TITLE
fix(storyboard-runner): branch-set any_of peers must not cascade-skip each other

### DIFF
--- a/.changeset/branch-set-stateful-peer-cascade.md
+++ b/.changeset/branch-set-stateful-peer-cascade.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Storyboard runner: branch-set `any_of` peers no longer cascade-skip each other. When peer phases are `stateful: true`, an earlier peer's by-design failure was tripping the stateful cascade and skipping a later sibling peer with `prerequisite_failed` before it ran — so the only viable contribution never landed and the `any_of` gate returned `[]` (e.g. `media_buy_seller/refine_finalize_exclusivity` for a seller that rejects atomic multi-finalize). `cascadeForPhase` now excludes same-branch-set `any_of` peers from a phase's cascade dependencies; within-phase and cross-phase non-peer cascade behavior are unchanged.

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -2282,6 +2282,11 @@ async function executeStoryboardPass(
   // the storyboard. Phases push their own id at end-of-phase.
   const priorPhaseIds: string[] = [];
 
+  // Phase → branch-set membership, resolved once up front so the stateful
+  // cascade (and the post-loop branch-set re-grade) can consult it. Phases
+  // outside any branch set are absent from the map.
+  const branchSetsByPhaseId = resolveBranchSets(storyboard);
+
   // Helpers for per-phase cascade state.
   const effectiveDependsOn = (phase: { depends_on?: string[] }, prior: readonly string[]): readonly string[] =>
     phase.depends_on ?? prior;
@@ -2294,7 +2299,19 @@ async function executeStoryboardPass(
     if (phaseStatefulCascades.has(phase.id)) {
       return { tripped: true, trigger: phaseStatefulCascades.get(phase.id) ?? null };
     }
+    // Branch-set peers are mutually-exclusive `any_of` ALTERNATIVES, not a
+    // stateful dependency chain: a conformant seller satisfies exactly one
+    // peer, so the non-taken peer(s) fail by design (storyboard-schema.yaml,
+    // "Per-step grading in any_of branch patterns"). A peer's expected
+    // failure must NOT cascade-skip a sibling peer — doing so suppresses the
+    // only viable contribution and fails the any_of gate even though the
+    // seller behaved conformantly. Exclude same-branch-set peers from this
+    // phase's cascade dependencies. (adcontextprotocol/adcp-client#2305)
+    const ownBranchSet = branchSetsByPhaseId.get(phase.id)?.id;
     for (const depId of effectiveDependsOn(phase, prior)) {
+      if (ownBranchSet !== undefined && branchSetsByPhaseId.get(depId)?.id === ownBranchSet) {
+        continue;
+      }
       if (phaseStatefulCascades.has(depId)) {
         return { tripped: true, trigger: phaseStatefulCascades.get(depId) ?? null };
       }
@@ -3170,8 +3187,9 @@ async function executeStoryboardPass(
   // contribution status isn't knowable inside the per-phase loop. Runs
   // before storyboard-scoped assertions so `onEnd` hooks see the finalized
   // per-step grades (a moot peer's "failure" should not trip a cross-step
-  // invariant).
-  const branchSetsByPhaseId = resolveBranchSets(storyboard);
+  // invariant). `branchSetsByPhaseId` was resolved before the phase loop so
+  // the stateful cascade could consult it (branch-set peers don't cascade
+  // onto each other); reuse it here.
   const branchSetDelta = applyBranchSetGrading(
     storyboard.phases,
     phaseResults,

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -2299,17 +2299,24 @@ async function executeStoryboardPass(
     if (phaseStatefulCascades.has(phase.id)) {
       return { tripped: true, trigger: phaseStatefulCascades.get(phase.id) ?? null };
     }
-    // Branch-set peers are mutually-exclusive `any_of` ALTERNATIVES, not a
-    // stateful dependency chain: a conformant seller satisfies exactly one
+    // Branch-set peers under `any_of` are mutually-exclusive ALTERNATIVES, not
+    // a stateful dependency chain: a conformant seller satisfies exactly one
     // peer, so the non-taken peer(s) fail by design (storyboard-schema.yaml,
     // "Per-step grading in any_of branch patterns"). A peer's expected
     // failure must NOT cascade-skip a sibling peer — doing so suppresses the
     // only viable contribution and fails the any_of gate even though the
     // seller behaved conformantly. Exclude same-branch-set peers from this
     // phase's cascade dependencies. (adcontextprotocol/adcp-client#2305)
-    const ownBranchSet = branchSetsByPhaseId.get(phase.id)?.id;
+    //
+    // Scoped to `any_of` deliberately: `BranchSetSpec.semantics` is typed
+    // `string` to leave room for future semantics (e.g. `all_of`/`one_of`)
+    // where peers legitimately DO depend on each other and must keep
+    // cascading. `all_of` is rejected at load time today, so this is
+    // forward-compat hardening rather than live behavior.
+    const ownSpec = branchSetsByPhaseId.get(phase.id);
+    const ownAnyOfBranchSet = ownSpec?.semantics === 'any_of' ? ownSpec.id : undefined;
     for (const depId of effectiveDependsOn(phase, prior)) {
-      if (ownBranchSet !== undefined && branchSetsByPhaseId.get(depId)?.id === ownBranchSet) {
+      if (ownAnyOfBranchSet !== undefined && branchSetsByPhaseId.get(depId)?.id === ownAnyOfBranchSet) {
         continue;
       }
       if (phaseStatefulCascades.has(depId)) {

--- a/test/lib/storyboard-branch-set-grading.test.js
+++ b/test/lib/storyboard-branch-set-grading.test.js
@@ -697,4 +697,87 @@ phases:
       server.close();
     }
   });
+
+  it('stateful branch-set peers do not cascade-skip each other — the passing peer contributes even when a sibling peer failed first', async () => {
+    // Regression for the stateful-peer cascade bug
+    // (adcontextprotocol/adcp-client#2305). Mirrors
+    // media_buy_seller/refine_finalize_exclusivity for a seller that rejects
+    // atomic multi-finalize: the atomic-success peer (declared FIRST, stateful)
+    // fails by design, and the MULTI_FINALIZE_UNSUPPORTED peer (declared
+    // SECOND, stateful) passes and must contribute. Before the fix, the failing
+    // sibling's stateful-cascade trip skipped the passing peer with
+    // `prerequisite_failed`, so the any_of gate saw no contribution and failed —
+    // even though the seller behaved conformantly. Branch-set peers are
+    // mutually-exclusive `any_of` alternatives, not a stateful dependency chain.
+    const { server, url } = await startStub(500, {});
+    try {
+      const peer = (id, stepId, expectedStatus) => ({
+        id,
+        title: id,
+        optional: true,
+        branch_set: { id: 'handled', semantics: 'any_of' },
+        steps: [
+          {
+            id: stepId,
+            title: stepId,
+            task: 'list_creatives',
+            auth: 'none',
+            expect_error: true,
+            stateful: true, // the real branch peers are stateful — this is the gap
+            contributes_to: 'handled',
+            validations: [{ check: 'http_status', value: expectedStatus, description: '' }],
+          },
+        ],
+      });
+      const storyboard = {
+        id: 'stateful_branch_peers_sb',
+        version: '1.0.0',
+        title: 'Stateful branch-set peers',
+        category: 'test',
+        summary: '',
+        narrative: '',
+        agent: { interaction_model: '*', capabilities: [] },
+        caller: { role: 'buyer_agent' },
+        phases: [
+          peer('atomic_path', 'atomic', 200), // fails vs 500 stub — sibling not taken
+          peer('unsupported_path', 'unsupported', 500), // passes vs 500 stub — must contribute
+          {
+            id: 'gate',
+            title: 'gate',
+            steps: [
+              {
+                id: 'assert',
+                title: 'assert',
+                task: 'assert_contribution',
+                validations: [{ check: 'any_of', allowed_values: ['handled'], description: '' }],
+              },
+            ],
+          },
+        ],
+      };
+      const result = await runStoryboard(url, storyboard, runOpts);
+      const atomic = result.phases[0].steps[0];
+      const unsupported = result.phases[1].steps[0];
+      const gate = result.phases[2].steps[0];
+
+      // The passing peer must RUN (not be cascade-skipped by the failing
+      // sibling) and contribute the branch-set flag.
+      assert.notStrictEqual(
+        unsupported.skipped,
+        true,
+        'passing peer must not be cascade-skipped by its failing sibling peer'
+      );
+      assert.strictEqual(unsupported.passed, true, 'passing peer contributes the branch-set flag');
+
+      // The failing peer is forgiven as moot (a peer took the flag), NOT left
+      // as a raw prerequisite_failed/failure.
+      assert.strictEqual(atomic.skipped, true);
+      assert.strictEqual(atomic.skip_reason, 'peer_branch_taken');
+
+      assert.strictEqual(gate.passed, true, 'any_of gate passes — a peer contributed');
+      assert.strictEqual(result.overall_passed, true);
+    } finally {
+      server.close();
+    }
+  });
 });


### PR DESCRIPTION
## Problem

In a branch-set phase group (`branch_set: { semantics: any_of }`), the peers are
**mutually-exclusive alternatives** — a conformant agent satisfies exactly one,
and the schema tolerates the non-taken peer(s) failing. `applyBranchSetGrading`
already re-grades a failed peer as `peer_branch_taken` once a sibling contributes.

But when the peer steps are **`stateful: true`**, the stateful cascade defeats
this. A phase's default cascade dependency is "all prior phases"
(`effectiveDependsOn = phase.depends_on ?? prior`), so a peer implicitly depends
on its earlier-declared sibling peers. When the earlier peer fails (by design —
it's the branch the agent didn't take), it records a stateful-cascade trip, and
`cascadeForPhase` **cascade-skips the later peer with `prerequisite_failed`
before it runs**. A skipped step can't pass the contribution gate
(`!result.skipped && result.passed && step.contributes_to`), so the `any_of` flag
is never contributed and the `assert_contribution` gate returns `[]` — even
though the agent behaved conformantly.

### Concrete failure: `media_buy_seller/refine_finalize_exclusivity`

Its `multi_finalize_handled` branch set has two stateful peers, declared in this
order: `multi_finalize_atomic_path` (atomic-success) then
`multi_finalize_unsupported_path` (`MULTI_FINALIZE_UNSUPPORTED` / `INVALID_REQUEST`).
A seller that does **not** support atomic multi-finalize necessarily fails the
first peer and can only satisfy the second — but today the second is
cascade-skipped, so the gate fails:

```
get_products_multi_finalize_atomic        FAILED   (expected — branch not taken)
get_products_multi_finalize_unsupported   SKIPPED  prerequisite_failed
                                                    "Skipped: prior stateful step failed."
assert_multi_finalize                      FAILED   any_of -> []
```

## Fix

Branch-set peers are alternatives, not a stateful dependency chain. Exclude
same-branch-set peers from a phase's stateful-cascade dependencies in
`cascadeForPhase`. `branchSetsByPhaseId` (already computed via `resolveBranchSets`
for the post-loop re-grade) is hoisted above the phase loop so the cascade can
consult it; within-phase and cross-phase (non-peer) cascade behavior are
unchanged. After the fix the passing peer runs and contributes, the failing peer
is re-graded `peer_branch_taken` (moot), and the gate passes.

## Tests

- New regression test in `test/lib/storyboard-branch-set-grading.test.js`
  (two `stateful` `any_of` peers, failing one declared first). Every pre-existing
  branch-set test used non-stateful peers — which is why this slipped through.
- The full `test/lib/storyboard-*.test.js` suite stays green.

Fixes the `refine_finalize` contribution-drop half of #2305 (the
`stale_response_advisory` null-verdict half is separate). Full localization,
reproduction transcript, and diff in
https://github.com/adcontextprotocol/adcp-client/issues/2305#issuecomment-4833958217.
