### PR TITLE
fix: sign webhook auth payloads

### DIFF
--- a/.changeset/sign-webhook-auth-payloads.md
+++ b/.changeset/sign-webhook-auth-payloads.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Sign outbound requests that carry `push_notification_config.authentication` even when seller request-signing capabilities are cold or do not list the operation.

--- a/.changeset/sign-webhook-auth-payloads.md
+++ b/.changeset/sign-webhook-auth-payloads.md
@@ -2,4 +2,4 @@
 '@adcp/sdk': patch
 ---
 
-Sign outbound requests that carry `push_notification_config.authentication` even when seller request-signing capabilities are cold or do not list the operation.
+Sign outbound requests that carry webhook receiver authentication even when seller request-signing capabilities are cold or do not list the operation. The verifier now also rejects unsigned requests with non-empty `authentication` objects in the payload, including task, reporting, artifact, revocation, and account notification webhook configs.

--- a/src/lib/signing/agent-fetch.ts
+++ b/src/lib/signing/agent-fetch.ts
@@ -105,6 +105,49 @@ export function extractAdcpOperation(body: unknown): string | undefined {
   return undefined;
 }
 
+const MAX_WEBHOOK_AUTH_TRAVERSAL_DEPTH = 64;
+
+/**
+ * Detect webhook receiver credentials in the outbound JSON-RPC payload. The
+ * verifier rejects unsigned requests carrying these credentials regardless of
+ * the seller's operation-level capability advertisement, so the client must
+ * sign them even while the capability cache is cold or silent for that op.
+ */
+function carriesWebhookAuthentication(body: unknown): boolean {
+  const text = bodyToUtf8(body);
+  if (!text) return false;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return false;
+  }
+  return containsWebhookAuthentication(parsed, MAX_WEBHOOK_AUTH_TRAVERSAL_DEPTH);
+}
+
+function containsWebhookAuthentication(value: unknown, depthRemaining: number): boolean {
+  if (depthRemaining <= 0) return false;
+  if (!value || typeof value !== 'object') return false;
+  if (Array.isArray(value)) {
+    return value.some(item => containsWebhookAuthentication(item, depthRemaining - 1));
+  }
+
+  const obj = value as Record<string, unknown>;
+  if (hasNonEmptyAuthentication(obj.push_notification_config)) return true;
+
+  for (const [key, nested] of Object.entries(obj)) {
+    if (key === 'push_notification_config') continue;
+    if (containsWebhookAuthentication(nested, depthRemaining - 1)) return true;
+  }
+  return false;
+}
+
+function hasNonEmptyAuthentication(value: unknown): boolean {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const auth = (value as { authentication?: unknown }).authentication;
+  return !!auth && typeof auth === 'object' && !Array.isArray(auth) && Object.keys(auth).length > 0;
+}
+
 /**
  * Decide whether an outbound AdCP call should be signed given the seller's
  * advertised capability block and the buyer's override list.
@@ -193,12 +236,13 @@ export interface BuildAgentSigningFetchOptions {
 /**
  * Build a fetch wrapper suitable for injection into MCP/A2A transports. On
  * every outbound request:
- *   1. Extract the AdCP operation name from the JSON-RPC body (MCP tool-call
+ *   1. Sign immediately when the payload carries webhook authentication.
+ *   2. Extract the AdCP operation name from the JSON-RPC body (MCP tool-call
  *      or A2A message/send). Non-AdCP JSON-RPC methods (e.g., `initialize`)
  *      pass through unsigned.
- *   2. Consult the cached seller capability to decide whether to sign.
- *   3. Resolve the seller's content-digest policy into a per-request toggle.
- *   4. Delegate to `createSigningFetch` with the decision baked in.
+ *   3. Consult the cached seller capability to decide whether to sign.
+ *   4. Resolve the seller's content-digest policy into a per-request toggle.
+ *   5. Delegate to `createSigningFetch` with the decision baked in.
  */
 export function buildAgentSigningFetch(options: BuildAgentSigningFetchOptions): FetchLike {
   const { signing, getCapability } = options;
@@ -210,6 +254,7 @@ export function buildAgentSigningFetch(options: BuildAgentSigningFetchOptions): 
   const upstream: FetchLike = explicitUpstream ?? ((input, init) => defaultUpstream()(input, init));
 
   const shouldSign = (_url: string, init: RequestInit | undefined): boolean => {
+    if (carriesWebhookAuthentication(init?.body)) return true;
     const operation = extractAdcpOperation(init?.body);
     const entry = getCapability();
     return shouldSignOperation(operation, entry?.requestSigning, signing);

--- a/src/lib/signing/agent-fetch.ts
+++ b/src/lib/signing/agent-fetch.ts
@@ -13,8 +13,10 @@ import {
 } from './capability-cache';
 import type { ContentDigestPolicy, VerifierCapability } from './types';
 import type { SignerKey } from './signer';
+import { containsWebhookAuthentication } from './webhook-auth-detection';
 
 type FetchLike = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+const MAX_WEBHOOK_AUTH_INSPECTION_BYTES = 1_048_576;
 
 /**
  * Resolve `globalThis.fetch` at the moment of each outbound request — not at
@@ -105,47 +107,24 @@ export function extractAdcpOperation(body: unknown): string | undefined {
   return undefined;
 }
 
-const MAX_WEBHOOK_AUTH_TRAVERSAL_DEPTH = 64;
-
 /**
  * Detect webhook receiver credentials in the outbound JSON-RPC payload. The
  * verifier rejects unsigned requests carrying these credentials regardless of
  * the seller's operation-level capability advertisement, so the client must
  * sign them even while the capability cache is cold or silent for that op.
+ * The scan is bounded; if the body exceeds the inspection budget, sign it.
  */
 function carriesWebhookAuthentication(body: unknown): boolean {
   const text = bodyToUtf8(body);
   if (!text) return false;
+  if (text.length > MAX_WEBHOOK_AUTH_INSPECTION_BYTES) return true;
   let parsed: unknown;
   try {
     parsed = JSON.parse(text);
   } catch {
     return false;
   }
-  return containsWebhookAuthentication(parsed, MAX_WEBHOOK_AUTH_TRAVERSAL_DEPTH);
-}
-
-function containsWebhookAuthentication(value: unknown, depthRemaining: number): boolean {
-  if (depthRemaining <= 0) return false;
-  if (!value || typeof value !== 'object') return false;
-  if (Array.isArray(value)) {
-    return value.some(item => containsWebhookAuthentication(item, depthRemaining - 1));
-  }
-
-  const obj = value as Record<string, unknown>;
-  if (hasNonEmptyAuthentication(obj.push_notification_config)) return true;
-
-  for (const [key, nested] of Object.entries(obj)) {
-    if (key === 'push_notification_config') continue;
-    if (containsWebhookAuthentication(nested, depthRemaining - 1)) return true;
-  }
-  return false;
-}
-
-function hasNonEmptyAuthentication(value: unknown): boolean {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
-  const auth = (value as { authentication?: unknown }).authentication;
-  return !!auth && typeof auth === 'object' && !Array.isArray(auth) && Object.keys(auth).length > 0;
+  return containsWebhookAuthentication(parsed);
 }
 
 /**

--- a/src/lib/signing/verifier.ts
+++ b/src/lib/signing/verifier.ts
@@ -13,6 +13,7 @@ import { jwkToPublicKey, verifySignature } from './crypto';
 import type { JwksResolver } from './jwks';
 import type { ReplayStore } from './replay';
 import type { RevocationStore } from './revocation';
+import { containsWebhookAuthentication, WEBHOOK_AUTH_TRAVERSAL_DEPTH } from './webhook-auth-detection';
 import {
   ALLOWED_ALGS,
   CLOCK_SKEW_TOLERANCE_SECONDS,
@@ -79,9 +80,10 @@ export async function verifyRequestSignature(
         `Protocol method "${requiredProtocolMethod}" requires a signed request`
       );
     }
-    // Payload-driven elevation: any request carrying
-    // `push_notification_config.authentication` MUST be RFC 9421 signed,
-    // regardless of whether the operation appears in `required_for`
+    // Payload-driven elevation: any request carrying webhook receiver
+    // credentials (task, reporting, artifact, or revocation callbacks) MUST
+    // be RFC 9421 signed, regardless of whether the operation appears in
+    // `required_for`
     // (#webhook-security downgrade-resistance). A bearer-only channel
     // would otherwise let an attacker who captured a token register or
     // update webhook credentials and redirect callbacks to a hostile URL.
@@ -89,7 +91,7 @@ export async function verifyRequestSignature(
       throw new RequestSignatureError(
         'request_signature_required',
         0,
-        'Requests carrying push_notification_config.authentication must be RFC 9421 signed'
+        'Requests carrying webhook authentication must be RFC 9421 signed'
       );
     }
     return { status: 'unsigned', verified_at: now };
@@ -497,16 +499,15 @@ const MAX_UNSIGNED_BODY_INSPECTION_BYTES = 1_048_576;
  * AdCP payloads reach depth ~5-8; 64 is generous without leaving room for
  * a pathological `{"a":{"a":{...}}}` to burn the stack.
  */
-const MAX_BODY_TRAVERSAL_DEPTH = 64;
-
 function exceedsUnsignedBodyInspectionCap(body: string | undefined): boolean {
   return typeof body === 'string' && body.length > MAX_UNSIGNED_BODY_INSPECTION_BYTES;
 }
 
 /**
  * Scan a JSON request body for a non-empty
- * `push_notification_config.authentication` object — anywhere in the tree,
- * including inside arrays of pending config updates. Runs only on the
+ * webhook authentication object — anywhere in the tree, including inside
+ * arrays of pending config updates. MCP uses `push_notification_config`;
+ * A2A uses `pushNotificationConfig`. Runs only on the
  * unsigned branch; returning `true` triggers the webhook-security downgrade
  * rejection in {@link verifyRequestSignature}.
  *
@@ -528,32 +529,7 @@ function carriesWebhookAuthentication(request: RequestLike): boolean {
   } catch {
     return false;
   }
-  return containsWebhookAuthentication(parsed, MAX_BODY_TRAVERSAL_DEPTH);
-}
-
-function containsWebhookAuthentication(value: unknown, depthRemaining: number): boolean {
-  if (depthRemaining <= 0) return false;
-  if (value === null || typeof value !== 'object') return false;
-  if (Array.isArray(value)) {
-    for (const item of value) {
-      if (containsWebhookAuthentication(item, depthRemaining - 1)) return true;
-    }
-    return false;
-  }
-  const obj = value as Record<string, unknown>;
-  const pnc = obj.push_notification_config;
-  if (pnc && typeof pnc === 'object' && !Array.isArray(pnc)) {
-    const auth = (pnc as Record<string, unknown>).authentication;
-    if (auth && typeof auth === 'object' && !Array.isArray(auth) && Object.keys(auth).length > 0) {
-      return true;
-    }
-  }
-  for (const [key, v] of Object.entries(obj)) {
-    // Already inspected push_notification_config above; don't re-walk it.
-    if (key === 'push_notification_config') continue;
-    if (containsWebhookAuthentication(v, depthRemaining - 1)) return true;
-  }
-  return false;
+  return containsWebhookAuthentication(parsed, WEBHOOK_AUTH_TRAVERSAL_DEPTH);
 }
 
 function validateCoveredComponents(components: string[], capability: VerifierCapability, request: RequestLike): void {

--- a/src/lib/signing/webhook-auth-detection.ts
+++ b/src/lib/signing/webhook-auth-detection.ts
@@ -1,18 +1,10 @@
 export const WEBHOOK_AUTH_TRAVERSAL_DEPTH = 64;
 
-const WEBHOOK_AUTH_CONFIG_KEYS = new Set([
-  'push_notification_config',
-  'pushNotificationConfig',
-  'reporting_webhook',
-  'reportingWebhook',
-  'artifact_webhook',
-  'artifactWebhook',
-  'revocation_webhook',
-  'revocationWebhook',
-]);
-
 /**
- * Scan a parsed JSON value for a non-empty webhook authentication object.
+ * Scan a parsed JSON value for a non-empty authentication object. The false
+ * positive cost is over-signing; the false negative cost is an unsigned
+ * webhook-credential registration.
+ *
  * Inspection-budget exhaustion fails closed by returning true.
  */
 export function containsWebhookAuthentication(value: unknown, depthRemaining = WEBHOOK_AUTH_TRAVERSAL_DEPTH): boolean {
@@ -23,19 +15,16 @@ export function containsWebhookAuthentication(value: unknown, depthRemaining = W
   }
 
   const obj = value as Record<string, unknown>;
-  for (const key of WEBHOOK_AUTH_CONFIG_KEYS) {
-    if (hasNonEmptyWebhookAuthentication(obj[key])) return true;
-  }
+  if (hasNonEmptyAuthenticationObject(obj.authentication)) return true;
 
   for (const [key, nested] of Object.entries(obj)) {
-    if (WEBHOOK_AUTH_CONFIG_KEYS.has(key)) continue;
+    if (key === 'authentication') continue;
     if (containsWebhookAuthentication(nested, depthRemaining - 1)) return true;
   }
   return false;
 }
 
-function hasNonEmptyWebhookAuthentication(value: unknown): boolean {
+function hasNonEmptyAuthenticationObject(value: unknown): boolean {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
-  const auth = (value as Record<string, unknown>).authentication;
-  return !!auth && typeof auth === 'object' && !Array.isArray(auth) && Object.keys(auth).length > 0;
+  return Object.keys(value).length > 0;
 }

--- a/src/lib/signing/webhook-auth-detection.ts
+++ b/src/lib/signing/webhook-auth-detection.ts
@@ -1,0 +1,41 @@
+export const WEBHOOK_AUTH_TRAVERSAL_DEPTH = 64;
+
+const WEBHOOK_AUTH_CONFIG_KEYS = new Set([
+  'push_notification_config',
+  'pushNotificationConfig',
+  'reporting_webhook',
+  'reportingWebhook',
+  'artifact_webhook',
+  'artifactWebhook',
+  'revocation_webhook',
+  'revocationWebhook',
+]);
+
+/**
+ * Scan a parsed JSON value for a non-empty webhook authentication object.
+ * Inspection-budget exhaustion fails closed by returning true.
+ */
+export function containsWebhookAuthentication(value: unknown, depthRemaining = WEBHOOK_AUTH_TRAVERSAL_DEPTH): boolean {
+  if (depthRemaining <= 0) return true;
+  if (!value || typeof value !== 'object') return false;
+  if (Array.isArray(value)) {
+    return value.some(item => containsWebhookAuthentication(item, depthRemaining - 1));
+  }
+
+  const obj = value as Record<string, unknown>;
+  for (const key of WEBHOOK_AUTH_CONFIG_KEYS) {
+    if (hasNonEmptyWebhookAuthentication(obj[key])) return true;
+  }
+
+  for (const [key, nested] of Object.entries(obj)) {
+    if (WEBHOOK_AUTH_CONFIG_KEYS.has(key)) continue;
+    if (containsWebhookAuthentication(nested, depthRemaining - 1)) return true;
+  }
+  return false;
+}
+
+function hasNonEmptyWebhookAuthentication(value: unknown): boolean {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const auth = (value as Record<string, unknown>).authentication;
+  return !!auth && typeof auth === 'object' && !Array.isArray(auth) && Object.keys(auth).length > 0;
+}

--- a/test/lib/signing-defaults-and-preset.test.js
+++ b/test/lib/signing-defaults-and-preset.test.js
@@ -451,6 +451,42 @@ describe('createAgentSignedFetch preset', () => {
     assert.ok(headers.get('signature-input'), 'artifact webhook auth payload should be signed');
   });
 
+  it('signs account notification config authentication payloads even when the capability cache is cold', async () => {
+    const cache = new CapabilityCache();
+    const { captured, upstream } = makeCapturingUpstream();
+    const signedFetch = createAgentSignedFetch({ signing, sellerAgentUri, cache, upstream });
+    await signedFetch('https://seller.example.com/mcp', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: {
+          name: 'sync_accounts',
+          arguments: {
+            accounts: [
+              {
+                account_id: 'acct_001',
+                notification_configs: [
+                  {
+                    url: 'https://buyer.example.com/adcp/account-notifications',
+                    authentication: {
+                      schemes: ['HMAC-SHA256'],
+                      credentials: 'placeholder_secret_min_32_characters_required',
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      }),
+    });
+    const headers = new Headers(captured.init?.headers);
+    assert.ok(headers.get('signature-input'), 'account notification config auth payload should be signed');
+  });
+
   it('signs when webhook authentication is beyond the traversal budget', async () => {
     const cache = new CapabilityCache();
     const { captured, upstream } = makeCapturingUpstream();

--- a/test/lib/signing-defaults-and-preset.test.js
+++ b/test/lib/signing-defaults-and-preset.test.js
@@ -278,6 +278,61 @@ describe('createAgentSignedFetch preset', () => {
     assert.strictEqual(headers.get('signature-input'), null, 'cold cache should not sign');
   });
 
+  it('signs webhook authentication payloads even when the capability cache is cold', async () => {
+    const cache = new CapabilityCache();
+    const { captured, upstream } = makeCapturingUpstream();
+    const signedFetch = createAgentSignedFetch({ signing, sellerAgentUri, cache, upstream });
+    await signedFetch('https://seller.example.com/mcp', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: {
+          name: 'create_media_buy',
+          arguments: {
+            push_notification_config: {
+              url: 'https://buyer.example.com/adcp/webhook/create_media_buy/op-1',
+              authentication: {
+                schemes: ['HMAC-SHA256'],
+                credentials: 'placeholder_secret_min_32_characters_required',
+              },
+            },
+          },
+        },
+      }),
+    });
+    const headers = new Headers(captured.init?.headers);
+    assert.ok(headers.get('signature-input'), 'webhook auth payload should be signed');
+    assert.ok(headers.get('signature'), 'Signature header should be present');
+  });
+
+  it('does not sign webhook payloads without authentication when the capability cache is cold', async () => {
+    const cache = new CapabilityCache();
+    const { captured, upstream } = makeCapturingUpstream();
+    const signedFetch = createAgentSignedFetch({ signing, sellerAgentUri, cache, upstream });
+    await signedFetch('https://seller.example.com/mcp', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: {
+          name: 'create_media_buy',
+          arguments: {
+            push_notification_config: {
+              url: 'https://buyer.example.com/adcp/webhook/create_media_buy/op-1',
+            },
+          },
+        },
+      }),
+    });
+    const headers = new Headers(captured.init?.headers);
+    assert.strictEqual(headers.get('signature-input'), null, 'webhook URL alone should not force signing');
+  });
+
   it('signs when the capability cache lists the operation as required_for', async () => {
     const cache = new CapabilityCache();
     const { buildCapabilityCacheKey } = require('../../dist/lib/signing/index.js');

--- a/test/lib/signing-defaults-and-preset.test.js
+++ b/test/lib/signing-defaults-and-preset.test.js
@@ -25,6 +25,7 @@ const {
   createAgentSignedFetch,
   createExpressVerifier,
 } = require('../../dist/lib/signing/index.js');
+const { InMemorySigningProvider } = require('../../dist/lib/signing/testing.js');
 
 // ---------------------------------------------------------------------------
 // Key + request helpers
@@ -260,6 +261,30 @@ describe('createAgentSignedFetch preset', () => {
     return { captured, upstream };
   }
 
+  function a2aWebhookBody(pushNotificationConfig) {
+    return JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'message/send',
+      params: {
+        message: {
+          parts: [{ kind: 'data', data: { skill: 'create_media_buy', parameters: {} } }],
+        },
+        configuration: {
+          pushNotificationConfig,
+        },
+      },
+    });
+  }
+
+  function deeplyNested(value, depth) {
+    let out = value;
+    for (let i = 0; i < depth; i += 1) {
+      out = { nested: out };
+    }
+    return out;
+  }
+
   it('returns a FetchLike function', () => {
     const signedFetch = createAgentSignedFetch({ signing, sellerAgentUri, cache: new CapabilityCache() });
     assert.strictEqual(typeof signedFetch, 'function');
@@ -308,6 +333,26 @@ describe('createAgentSignedFetch preset', () => {
     assert.ok(headers.get('signature'), 'Signature header should be present');
   });
 
+  it('signs A2A push notification authentication payloads even when the capability cache is cold', async () => {
+    const cache = new CapabilityCache();
+    const { captured, upstream } = makeCapturingUpstream();
+    const signedFetch = createAgentSignedFetch({ signing, sellerAgentUri, cache, upstream });
+    await signedFetch('https://seller.example.com/a2a', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: a2aWebhookBody({
+        url: 'https://buyer.example.com/adcp/webhook/create_media_buy/op-1',
+        authentication: {
+          schemes: ['HMAC-SHA256'],
+          credentials: 'placeholder_secret_min_32_characters_required',
+        },
+      }),
+    });
+    const headers = new Headers(captured.init?.headers);
+    assert.ok(headers.get('signature-input'), 'A2A webhook auth payload should be signed');
+    assert.ok(headers.get('signature'), 'Signature header should be present');
+  });
+
   it('does not sign webhook payloads without authentication when the capability cache is cold', async () => {
     const cache = new CapabilityCache();
     const { captured, upstream } = makeCapturingUpstream();
@@ -331,6 +376,167 @@ describe('createAgentSignedFetch preset', () => {
     });
     const headers = new Headers(captured.init?.headers);
     assert.strictEqual(headers.get('signature-input'), null, 'webhook URL alone should not force signing');
+  });
+
+  it('does not sign A2A push notification payloads without authentication when the capability cache is cold', async () => {
+    const cache = new CapabilityCache();
+    const { captured, upstream } = makeCapturingUpstream();
+    const signedFetch = createAgentSignedFetch({ signing, sellerAgentUri, cache, upstream });
+    await signedFetch('https://seller.example.com/a2a', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: a2aWebhookBody({
+        url: 'https://buyer.example.com/adcp/webhook/create_media_buy/op-1',
+      }),
+    });
+    const headers = new Headers(captured.init?.headers);
+    assert.strictEqual(headers.get('signature-input'), null, 'A2A webhook URL alone should not force signing');
+  });
+
+  it('signs reporting webhook authentication payloads even when the capability cache is cold', async () => {
+    const cache = new CapabilityCache();
+    const { captured, upstream } = makeCapturingUpstream();
+    const signedFetch = createAgentSignedFetch({ signing, sellerAgentUri, cache, upstream });
+    await signedFetch('https://seller.example.com/mcp', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: {
+          name: 'create_media_buy',
+          arguments: {
+            reporting_webhook: {
+              url: 'https://buyer.example.com/adcp/reporting',
+              authentication: {
+                schemes: ['HMAC-SHA256'],
+                credentials: 'placeholder_secret_min_32_characters_required',
+              },
+            },
+          },
+        },
+      }),
+    });
+    const headers = new Headers(captured.init?.headers);
+    assert.ok(headers.get('signature-input'), 'reporting webhook auth payload should be signed');
+  });
+
+  it('signs artifact webhook authentication payloads even when the capability cache is cold', async () => {
+    const cache = new CapabilityCache();
+    const { captured, upstream } = makeCapturingUpstream();
+    const signedFetch = createAgentSignedFetch({ signing, sellerAgentUri, cache, upstream });
+    await signedFetch('https://seller.example.com/mcp', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: {
+          name: 'create_media_buy',
+          arguments: {
+            artifact_webhook: {
+              url: 'https://buyer.example.com/adcp/artifacts',
+              authentication: {
+                schemes: ['HMAC-SHA256'],
+                credentials: 'placeholder_secret_min_32_characters_required',
+              },
+            },
+          },
+        },
+      }),
+    });
+    const headers = new Headers(captured.init?.headers);
+    assert.ok(headers.get('signature-input'), 'artifact webhook auth payload should be signed');
+  });
+
+  it('signs when webhook authentication is beyond the traversal budget', async () => {
+    const cache = new CapabilityCache();
+    const { captured, upstream } = makeCapturingUpstream();
+    const signedFetch = createAgentSignedFetch({ signing, sellerAgentUri, cache, upstream });
+    await signedFetch('https://seller.example.com/mcp', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(
+        deeplyNested(
+          {
+            push_notification_config: {
+              authentication: { schemes: ['HMAC-SHA256'], credentials: 'secret' },
+            },
+          },
+          70
+        )
+      ),
+    });
+    const headers = new Headers(captured.init?.headers);
+    assert.ok(headers.get('signature-input'), 'inspection-depth exhaustion should fail closed by signing');
+  });
+
+  it('signs oversized bodies instead of parsing beyond the inspection budget', async () => {
+    const cache = new CapabilityCache();
+    const { captured, upstream } = makeCapturingUpstream();
+    const signedFetch = createAgentSignedFetch({ signing, sellerAgentUri, cache, upstream });
+    await signedFetch('https://seller.example.com/mcp', {
+      method: 'POST',
+      headers: { 'Content-Type': 'text/plain' },
+      body: 'x'.repeat(1_048_577),
+    });
+    const headers = new Headers(captured.init?.headers);
+    assert.ok(headers.get('signature-input'), 'oversized body should fail closed by signing');
+  });
+
+  it('routes webhook authentication signing through provider-backed request signing', async () => {
+    const provider = new InMemorySigningProvider({
+      keyid: 'test-ed25519-2026',
+      algorithm: 'ed25519',
+      privateKey: primaryPrivate,
+    });
+    let signCalls = 0;
+    const countingProvider = {
+      keyid: provider.keyid,
+      algorithm: provider.algorithm,
+      fingerprint: provider.fingerprint,
+      sign: async payload => {
+        signCalls += 1;
+        return provider.sign(payload);
+      },
+    };
+    const { captured, upstream } = makeCapturingUpstream();
+    const signedFetch = buildAgentSigningFetch({
+      signing: {
+        kind: 'provider',
+        provider: countingProvider,
+        agent_url: 'https://buyer.example.com',
+      },
+      getCapability: () => undefined,
+      upstream,
+    });
+    await signedFetch('https://seller.example.com/mcp', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: {
+          name: 'create_media_buy',
+          arguments: {
+            push_notification_config: {
+              url: 'https://buyer.example.com/adcp/webhook/create_media_buy/op-1',
+              authentication: {
+                schemes: ['HMAC-SHA256'],
+                credentials: 'placeholder_secret_min_32_characters_required',
+              },
+            },
+          },
+        },
+      }),
+    });
+    const headers = new Headers(captured.init?.headers);
+    assert.strictEqual(signCalls, 1, 'provider should sign webhook auth payload once');
+    assert.ok(headers.get('signature-input'), 'webhook auth payload should be provider-signed');
+    assert.ok(headers.get('signature'), 'Signature header should be present');
   });
 
   it('signs when the capability cache lists the operation as required_for', async () => {

--- a/test/request-signing-agent-a2a.test.js
+++ b/test/request-signing-agent-a2a.test.js
@@ -98,7 +98,7 @@ async function startA2aStub(initialCapability) {
       parsed?.params?.message?.parts?.find(p => p?.kind === 'data' && typeof p?.data?.skill === 'string')?.data
         ?.skill ?? '<unknown>';
 
-    state.rpcCalls.push({ headers: { ...req.headers }, skill, method: parsed.method });
+    state.rpcCalls.push({ headers: { ...req.headers }, skill, method: parsed.method, body: parsed });
 
     const resultPayload =
       skill === 'get_adcp_capabilities'
@@ -231,6 +231,66 @@ test('A2A: ops outside the seller advertisement pass through unsigned', async ()
     const call = stub.state.rpcCalls.filter(r => r.skill === 'another_op')[0];
     assert.ok(call, 'another_op reached the stub');
     assert.strictEqual(call.headers['signature-input'], undefined, 'another_op unsigned on A2A');
+  } finally {
+    await cleanup(stub);
+  }
+});
+
+test('A2A: webhook authentication payload is signed even when the operation is outside required_for', async () => {
+  await resetGlobalState();
+  const stub = await startA2aStub({
+    supported: true,
+    covers_content_digest: 'either',
+    required_for: [],
+  });
+  try {
+    await ProtocolClient.callTool(
+      agentFor(stub.url),
+      'create_media_buy',
+      { plan_id: 'plan_a2a_webhook_001' },
+      {
+        webhookUrl: 'https://buyer.example.com/adcp/webhook/create_media_buy/op-1',
+        webhookSecret: 'placeholder_secret_min_32_characters_required',
+      }
+    );
+    const call = stub.state.rpcCalls.filter(r => r.skill === 'create_media_buy')[0];
+    assert.ok(call, 'create_media_buy reached the stub');
+    assert.match(call.headers['signature-input'] || '', /^sig1=/, 'A2A webhook auth payload forced signing');
+    assert.match(call.headers['signature'] || '', /^sig1=:/, 'Signature header is present');
+    assert.deepStrictEqual(call.body.params.configuration?.pushNotificationConfig?.authentication, {
+      schemes: ['HMAC-SHA256'],
+      credentials: 'placeholder_secret_min_32_characters_required',
+    });
+  } finally {
+    await cleanup(stub);
+  }
+});
+
+test('A2A: reporting webhook authentication payload is signed even when the operation is outside required_for', async () => {
+  await resetGlobalState();
+  const stub = await startA2aStub({
+    supported: true,
+    covers_content_digest: 'either',
+    required_for: [],
+  });
+  try {
+    await ProtocolClient.callTool(agentFor(stub.url), 'create_media_buy', {
+      plan_id: 'plan_a2a_reporting_001',
+      reporting_webhook: {
+        url: 'https://buyer.example.com/adcp/reporting',
+        authentication: {
+          schemes: ['HMAC-SHA256'],
+          credentials: 'placeholder_secret_min_32_characters_required',
+        },
+      },
+    });
+    const call = stub.state.rpcCalls.filter(r => r.skill === 'create_media_buy')[0];
+    assert.ok(call, 'create_media_buy reached the stub');
+    assert.match(call.headers['signature-input'] || '', /^sig1=/, 'A2A reporting webhook auth forced signing');
+    assert.deepStrictEqual(call.body.params.message.parts[0].data.parameters.reporting_webhook?.authentication, {
+      schemes: ['HMAC-SHA256'],
+      credentials: 'placeholder_secret_min_32_characters_required',
+    });
   } finally {
     await cleanup(stub);
   }

--- a/test/request-signing-agent-integration.test.js
+++ b/test/request-signing-agent-integration.test.js
@@ -3,6 +3,7 @@ const assert = require('node:assert');
 const http = require('node:http');
 const { readFileSync } = require('node:fs');
 const path = require('node:path');
+const { z } = require('zod');
 
 const { McpServer } = require('@modelcontextprotocol/sdk/server/mcp.js');
 const { StreamableHTTPServerTransport } = require('@modelcontextprotocol/sdk/server/streamableHttp.js');
@@ -73,13 +74,22 @@ async function startMcpStub(initialCapability) {
       };
     });
 
-    const echoAs = name => async () => {
+    const echoAs = name => async args => {
       entry.toolName = name;
+      entry.args = args;
       return { content: [{ type: 'text', text: JSON.stringify({ ok: true }) }] };
     };
 
-    mcp.registerTool('create_media_buy', { inputSchema: {} }, echoAs('create_media_buy'));
-    mcp.registerTool('another_op', { inputSchema: {} }, echoAs('another_op'));
+    const passthroughSchema = {
+      plan_id: z.string().optional(),
+      push_notification_config: z.any().optional(),
+      reporting_webhook: z.any().optional(),
+      adcp_major_version: z.number().optional(),
+      adcp_version: z.string().optional(),
+    };
+
+    mcp.registerTool('create_media_buy', { inputSchema: passthroughSchema }, echoAs('create_media_buy'));
+    mcp.registerTool('another_op', { inputSchema: passthroughSchema }, echoAs('another_op'));
     mcp.registerTool('unsigned_op', { inputSchema: {} }, echoAs('unsigned_op'));
 
     return mcp;
@@ -204,6 +214,66 @@ test('ops outside required_for / supported_for / always_sign pass through unsign
     const calls = stub.state.toolCallHeaders.filter(r => r.toolName === 'unsigned_op');
     assert.strictEqual(calls.length, 1);
     assert.strictEqual(calls[0].headers['signature-input'], undefined);
+  } finally {
+    await cleanup(stub);
+  }
+});
+
+test('webhook authentication payload is signed even when the operation is outside required_for', async () => {
+  await resetGlobalState();
+  const stub = await startMcpStub({
+    supported: true,
+    covers_content_digest: 'either',
+    required_for: [],
+  });
+  try {
+    await ProtocolClient.callTool(
+      agentFor(stub.url),
+      'create_media_buy',
+      { plan_id: 'plan_webhook_001' },
+      {
+        webhookUrl: 'https://buyer.example.com/adcp/webhook/create_media_buy/op-1',
+        webhookSecret: 'placeholder_secret_min_32_characters_required',
+      }
+    );
+    const call = stub.state.toolCallHeaders.filter(r => r.toolName === 'create_media_buy')[0];
+    assert.ok(call, 'create_media_buy reached the stub');
+    assert.match(call.headers['signature-input'] || '', /^sig1=/, 'webhook auth payload forced signing');
+    assert.match(call.headers['signature'] || '', /^sig1=:/, 'Signature header is present');
+    assert.deepStrictEqual(call.args.push_notification_config?.authentication, {
+      schemes: ['HMAC-SHA256'],
+      credentials: 'placeholder_secret_min_32_characters_required',
+    });
+  } finally {
+    await cleanup(stub);
+  }
+});
+
+test('reporting webhook authentication payload is signed even when the operation is outside required_for', async () => {
+  await resetGlobalState();
+  const stub = await startMcpStub({
+    supported: true,
+    covers_content_digest: 'either',
+    required_for: [],
+  });
+  try {
+    await ProtocolClient.callTool(agentFor(stub.url), 'create_media_buy', {
+      plan_id: 'plan_reporting_001',
+      reporting_webhook: {
+        url: 'https://buyer.example.com/adcp/reporting',
+        authentication: {
+          schemes: ['HMAC-SHA256'],
+          credentials: 'placeholder_secret_min_32_characters_required',
+        },
+      },
+    });
+    const call = stub.state.toolCallHeaders.filter(r => r.toolName === 'create_media_buy')[0];
+    assert.ok(call, 'create_media_buy reached the stub');
+    assert.match(call.headers['signature-input'] || '', /^sig1=/, 'reporting webhook auth payload forced signing');
+    assert.deepStrictEqual(call.args.reporting_webhook?.authentication, {
+      schemes: ['HMAC-SHA256'],
+      credentials: 'placeholder_secret_min_32_characters_required',
+    });
   } finally {
     await cleanup(stub);
   }

--- a/test/request-signing-agent-integration.test.js
+++ b/test/request-signing-agent-integration.test.js
@@ -84,12 +84,14 @@ async function startMcpStub(initialCapability) {
       plan_id: z.string().optional(),
       push_notification_config: z.any().optional(),
       reporting_webhook: z.any().optional(),
+      accounts: z.any().optional(),
       adcp_major_version: z.number().optional(),
       adcp_version: z.string().optional(),
     };
 
     mcp.registerTool('create_media_buy', { inputSchema: passthroughSchema }, echoAs('create_media_buy'));
     mcp.registerTool('another_op', { inputSchema: passthroughSchema }, echoAs('another_op'));
+    mcp.registerTool('sync_accounts', { inputSchema: passthroughSchema }, echoAs('sync_accounts'));
     mcp.registerTool('unsigned_op', { inputSchema: {} }, echoAs('unsigned_op'));
 
     return mcp;
@@ -271,6 +273,46 @@ test('reporting webhook authentication payload is signed even when the operation
     assert.ok(call, 'create_media_buy reached the stub');
     assert.match(call.headers['signature-input'] || '', /^sig1=/, 'reporting webhook auth payload forced signing');
     assert.deepStrictEqual(call.args.reporting_webhook?.authentication, {
+      schemes: ['HMAC-SHA256'],
+      credentials: 'placeholder_secret_min_32_characters_required',
+    });
+  } finally {
+    await cleanup(stub);
+  }
+});
+
+test('account notification config authentication payload is signed even when the operation is outside required_for', async () => {
+  await resetGlobalState();
+  const stub = await startMcpStub({
+    supported: true,
+    covers_content_digest: 'either',
+    required_for: [],
+  });
+  try {
+    await ProtocolClient.callTool(agentFor(stub.url), 'sync_accounts', {
+      accounts: [
+        {
+          account_id: 'acct_001',
+          notification_configs: [
+            {
+              url: 'https://buyer.example.com/adcp/account-notifications',
+              authentication: {
+                schemes: ['HMAC-SHA256'],
+                credentials: 'placeholder_secret_min_32_characters_required',
+              },
+            },
+          ],
+        },
+      ],
+    });
+    const call = stub.state.toolCallHeaders.filter(r => r.toolName === 'sync_accounts')[0];
+    assert.ok(call, 'sync_accounts reached the stub');
+    assert.match(
+      call.headers['signature-input'] || '',
+      /^sig1=/,
+      'account notification config auth payload forced signing'
+    );
+    assert.deepStrictEqual(call.args.accounts?.[0]?.notification_configs?.[0]?.authentication, {
       schemes: ['HMAC-SHA256'],
       credentials: 'placeholder_secret_min_32_characters_required',
     });

--- a/test/request-signing-verifier-api.test.js
+++ b/test/request-signing-verifier-api.test.js
@@ -228,8 +228,10 @@ describe('verifier API v3: operation optional + VerifyResult discriminated union
   // ── Vector 027: webhook-authentication downgrade resistance ─────────
   //
   // The verifier rejects unsigned requests whose JSON body carries a
-  // non-empty `push_notification_config.authentication` anywhere in the
-  // tree, regardless of whether the operation is in `required_for`.
+  // non-empty webhook authentication object anywhere in the tree, regardless
+  // of whether the operation is in `required_for`. MCP carries this as
+  // `push_notification_config.authentication`; A2A carries it as
+  // `pushNotificationConfig.authentication`.
   // These tests lock the surface around the happy-path conformance
   // vector (which only proves the top-level-object case).
 
@@ -248,6 +250,14 @@ describe('verifier API v3: operation optional + VerifyResult discriminated union
       { method: 'POST', url: webhookUrl, headers: { 'Content-Type': 'application/json' }, body },
       { ...baseStores(), capability: webhookCapability, now: () => 1_776_520_800, operation: webhookOperation }
     );
+  }
+
+  function deeplyNested(value, depth) {
+    let out = value;
+    for (let i = 0; i < depth; i += 1) {
+      out = { nested: out };
+    }
+    return out;
   }
 
   it('unsigned request with push_notification_config but no authentication returns unsigned', async () => {
@@ -280,6 +290,21 @@ describe('verifier API v3: operation optional + VerifyResult discriminated union
     assert.strictEqual(result.status, 'unsigned');
   });
 
+  it('unsigned A2A request with pushNotificationConfig but no authentication returns unsigned', async () => {
+    const result = await verifyUnsigned(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'message/send',
+        params: {
+          configuration: {
+            pushNotificationConfig: { url: 'https://buyer.example/webhook' },
+          },
+        },
+      })
+    );
+    assert.strictEqual(result.status, 'unsigned');
+  });
+
   it('unsigned request with authentication nested inside an array rejects', async () => {
     await assert.rejects(
       () =>
@@ -296,6 +321,76 @@ describe('verifier API v3: operation optional + VerifyResult discriminated union
               },
             ],
           })
+        ),
+      err => err instanceof RequestSignatureError && err.code === 'request_signature_required'
+    );
+  });
+
+  it('unsigned A2A request with pushNotificationConfig authentication rejects', async () => {
+    await assert.rejects(
+      () =>
+        verifyUnsigned(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            method: 'message/send',
+            params: {
+              configuration: {
+                pushNotificationConfig: {
+                  url: 'https://buyer.example/webhook',
+                  authentication: { scheme: 'HMAC-SHA256', credentials: 'secret' },
+                },
+              },
+            },
+          })
+        ),
+      err => err instanceof RequestSignatureError && err.code === 'request_signature_required'
+    );
+  });
+
+  it('unsigned request with reporting_webhook authentication rejects', async () => {
+    await assert.rejects(
+      () =>
+        verifyUnsigned(
+          JSON.stringify({
+            reporting_webhook: {
+              url: 'https://buyer.example/reporting',
+              authentication: { scheme: 'HMAC-SHA256', credentials: 'secret' },
+            },
+          })
+        ),
+      err => err instanceof RequestSignatureError && err.code === 'request_signature_required'
+    );
+  });
+
+  it('unsigned request with artifact_webhook authentication rejects', async () => {
+    await assert.rejects(
+      () =>
+        verifyUnsigned(
+          JSON.stringify({
+            artifact_webhook: {
+              url: 'https://buyer.example/artifacts',
+              authentication: { scheme: 'HMAC-SHA256', credentials: 'secret' },
+            },
+          })
+        ),
+      err => err instanceof RequestSignatureError && err.code === 'request_signature_required'
+    );
+  });
+
+  it('unsigned request beyond the traversal budget rejects', async () => {
+    await assert.rejects(
+      () =>
+        verifyUnsigned(
+          JSON.stringify(
+            deeplyNested(
+              {
+                push_notification_config: {
+                  authentication: { scheme: 'HMAC-SHA256', credentials: 'secret' },
+                },
+              },
+              70
+            )
+          )
         ),
       err => err instanceof RequestSignatureError && err.code === 'request_signature_required'
     );

--- a/test/request-signing-verifier-api.test.js
+++ b/test/request-signing-verifier-api.test.js
@@ -377,6 +377,28 @@ describe('verifier API v3: operation optional + VerifyResult discriminated union
     );
   });
 
+  it('unsigned sync_accounts request with notification_configs authentication rejects', async () => {
+    await assert.rejects(
+      () =>
+        verifyUnsigned(
+          JSON.stringify({
+            accounts: [
+              {
+                account_id: 'acct_001',
+                notification_configs: [
+                  {
+                    url: 'https://buyer.example/account-notifications',
+                    authentication: { scheme: 'HMAC-SHA256', credentials: 'secret' },
+                  },
+                ],
+              },
+            ],
+          })
+        ),
+      err => err instanceof RequestSignatureError && err.code === 'request_signature_required'
+    );
+  });
+
   it('unsigned request beyond the traversal budget rejects', async () => {
     await assert.rejects(
       () =>


### PR DESCRIPTION
## Why

The request verifier rejects unsigned requests that carry webhook receiver authentication, but the outbound signing fetch previously only used operation-level capability metadata and `always_sign` to decide whether to sign. If a seller enforces the payload-level webhook-auth rule while its request-signing capability cache is cold or silent for that operation, the SDK can send webhook registration requests unsigned.

## What Changed

- Detect non-empty authenticated webhook receiver configs in outbound JSON-RPC bodies.
  - Task status webhooks: `push_notification_config` / A2A `pushNotificationConfig`.
  - Reporting, artifact, and revocation webhooks: snake_case and camelCase variants.
- Force RFC 9421 signing for those payloads before falling back to capability-based operation signing.
- Keep buyer and seller scanning logic shared through one internal detector.
- Fail closed on webhook-auth inspection budget exhaustion:
  - buyer side signs oversized bodies before parsing;
  - verifier rejects unsigned oversized/deep bodies when it cannot prove absence.
- Add regression coverage for MCP, A2A, provider-backed signing, reporting/artifact webhooks, depth exhaustion, and oversized payloads.
- Add a patch changeset.

## Validation

- `npm run build:lib`
- `NODE_ENV=test node --test-timeout=60000 --test test/lib/signing-defaults-and-preset.test.js test/request-signing-verifier-api.test.js test/request-signing-agent-integration.test.js test/request-signing-agent-a2a.test.js`
- `npm run typecheck`
- `npx prettier --check src/lib/signing/agent-fetch.ts src/lib/signing/verifier.ts src/lib/signing/webhook-auth-detection.ts test/lib/signing-defaults-and-preset.test.js test/request-signing-verifier-api.test.js test/request-signing-agent-integration.test.js test/request-signing-agent-a2a.test.js .changeset/sign-webhook-auth-payloads.md`
- `npx commitlint --from origin/main --to HEAD --verbose`
- Expert review stack: protocol, security, code review, and testing experts; final re-checks clean.

`npm run review:codex -- --all --base main` was attempted twice but the local Codex CLI returned `ERROR: Quota exceeded`, so no Codex model findings were produced.
