### PR TITLE
fix: add read-path cancellation and discovery timeouts

### DIFF
--- a/.changeset/read-path-cancel-timeout.md
+++ b/.changeset/read-path-cancel-timeout.md
@@ -1,0 +1,5 @@
+---
+"@adcp/sdk": minor
+---
+
+Add read-path cancellation and bounded A2A agent-card discovery. `getAgentInfo()`, `getCapabilities()`, and task calls such as `getProducts()` now accept `AbortSignal` through their options, and `transport.requestTimeoutMs` controls the read-path request timeout with a default 60s cap for A2A agent-card fetches.

--- a/src/lib/core/AgentClient.ts
+++ b/src/lib/core/AgentClient.ts
@@ -837,8 +837,8 @@ export class AgentClient {
    * For v3 servers: calls get_adcp_capabilities tool
    * For v2 servers: builds synthetic capabilities from tool list
    */
-  async getCapabilities(): Promise<AdcpCapabilities> {
-    return this.client.getCapabilities();
+  async getCapabilities(options?: Pick<TaskOptions, 'signal' | 'transport'>): Promise<AdcpCapabilities> {
+    return this.client.getCapabilities(options);
   }
 
   /**
@@ -1344,8 +1344,8 @@ export class AgentClient {
   /**
    * Get agent information including capabilities
    */
-  async getAgentInfo() {
-    return this.client.getAgentInfo();
+  async getAgentInfo(options?: Pick<TaskOptions, 'signal' | 'transport'>) {
+    return this.client.getAgentInfo(options);
   }
 
   /**

--- a/src/lib/core/ConversationTypes.ts
+++ b/src/lib/core/ConversationTypes.ts
@@ -146,6 +146,13 @@ export type WebhookUrlTemplate =
 export interface TaskOptions {
   /** Timeout for entire task (ms) */
   timeout?: number;
+  /**
+   * Caller-owned cancellation signal for the read path and in-flight protocol
+   * call. Aborting this signal cancels discovery probes (`getAgentInfo`,
+   * `getCapabilities`, feature/version preflight) and the tool request where
+   * the underlying official protocol client supports it.
+   */
+  signal?: AbortSignal;
   /** Maximum clarification rounds before failing */
   maxClarifications?: number;
   /**

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -3895,8 +3895,7 @@ export class SingleAgentClient {
             `threw — treating as v3 (synthetic) since the agent has the v3-only discovery tool. ` +
             `This client routes to v3 adapters, but calls reading capability details ` +
             `(idempotency TTL, supported_versions, feature flags) will fail until the agent ` +
-            `operator fixes the capabilities endpoint.`,
-          { errorType: error instanceof Error ? error.name : typeof error }
+            `operator fixes the capabilities endpoint.`
         );
       }
 

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -3663,22 +3663,38 @@ export class SingleAgentClient {
       // calls native `fetch` directly and ignores `transport.maxResponseBytes`.
       const { wrapFetchWithSizeLimit } = await import('../protocols/responseSizeLimit');
       const authToken = this.normalizedAgent.auth_token;
+      const agentHeaders = this.normalizedAgent.headers ?? {};
       const sizeLimitedFetch = wrapFetchWithSizeLimit((input, init) => fetch(input as RequestInfo | URL, init));
-      const fetchImpl = authToken
-        ? async (url: string | URL | Request, requestInit?: RequestInit) => {
-            const headers = {
-              ...(requestInit?.headers as Record<string, string>),
-              Authorization: `Bearer ${authToken}`,
-              'x-adcp-auth': authToken,
-            };
-            return withAbortSignal<Response>([options?.signal, requestInit?.signal], requestTimeoutMs, signal =>
-              sizeLimitedFetch(url as RequestInfo | URL, { ...requestInit, headers, signal })
-            );
+      const normalizeHeaders = (headers?: HeadersInit): Record<string, string> => {
+        const normalized: Record<string, string> = {};
+        if (!headers) return normalized;
+        if (headers instanceof Headers) {
+          headers.forEach((value, key) => {
+            normalized[key] = value;
+          });
+        } else if (Array.isArray(headers)) {
+          for (const [key, value] of headers) {
+            normalized[key] = value;
           }
-        : (url: string | URL | Request, requestInit?: RequestInit) =>
-            withAbortSignal<Response>([options?.signal, requestInit?.signal], requestTimeoutMs, signal =>
-              sizeLimitedFetch(url as RequestInfo | URL, { ...requestInit, signal })
-            );
+        } else {
+          Object.assign(normalized, headers);
+        }
+        return normalized;
+      };
+      const buildHeaders = (requestInit?: RequestInit): Record<string, string> => ({
+        ...normalizeHeaders(requestInit?.headers),
+        ...agentHeaders,
+        ...(authToken && {
+          Authorization: `Bearer ${authToken}`,
+          'x-adcp-auth': authToken,
+        }),
+      });
+      const fetchImpl = async (url: string | URL | Request, requestInit?: RequestInit) => {
+        const headers = buildHeaders(requestInit);
+        return withAbortSignal<Response>([options?.signal, requestInit?.signal], requestTimeoutMs, signal =>
+          sizeLimitedFetch(url as RequestInfo | URL, { ...requestInit, headers, signal })
+        );
+      };
 
       const cardUrls = buildCardUrls(this.normalizedAgent.agent_uri);
 

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -3801,13 +3801,7 @@ export class SingleAgentClient {
         // executor then hits ProtocolClient.callTool which reads _inProcessMcpClient directly,
         // so the sentinel adcp-in-process:// URI never reaches validateAgentUrl.
         const agent = await this.ensureEndpointDiscovered(options);
-        const result = await this.executor.executeTask<any>(
-          agent,
-          'get_adcp_capabilities',
-          {},
-          undefined,
-          options
-        );
+        const result = await this.executor.executeTask<any>(agent, 'get_adcp_capabilities', {}, undefined, options);
         throwIfAborted(options?.signal);
         const requestTimeoutMs = resolveRequestTimeoutMs(
           options?.transport?.requestTimeoutMs ?? this.config.transport?.requestTimeoutMs

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -88,6 +88,7 @@ import type { Task as A2ATask, TaskStatusUpdateEvent } from '@a2a-js/sdk';
 import { TaskExecutor, DeferredTaskError } from './TaskExecutor';
 import { attachMatch } from './match';
 import { createMCPAuthHeaders } from '../auth';
+import { isAbortOrTimeoutError } from '../protocols/abort';
 import {
   AuthenticationRequiredError,
   ConfigurationError,
@@ -123,6 +124,14 @@ import {
   stripTransportSuffix,
 } from '../utils/a2a-discovery';
 import * as crypto from 'crypto';
+import {
+  DEFAULT_REQUEST_TIMEOUT_MS,
+  createTimeoutError,
+  resolveClientRequestTimeoutMs,
+  resolveRequestTimeoutMs,
+  throwIfAborted,
+  withAbortSignal,
+} from '../protocols/abort';
 
 // v3.0 compatibility utilities
 import type { AdcpCapabilities, AdcpMajorVersion, ToolInfo, FeatureName } from '../utils/capabilities';
@@ -136,6 +145,7 @@ import {
   listDeclaredFeatures,
   TASK_FEATURE_MAP,
 } from '../utils/capabilities';
+
 import { normalizeRequestParams } from '../utils/request-normalizer';
 import { validateUserAgent } from '../utils/validate-user-agent';
 import { resolveWebhookUrl, selectWebhookTemplate } from './webhook-url';
@@ -150,6 +160,8 @@ import {
   type ProductPropertyPolicyValidationResult,
 } from '../media-buy/property-policy';
 import { resolvePropertyList, type ResolveListOptions } from '../server/targeting-helpers';
+
+type ReadRequestOptions = Pick<TaskOptions, 'signal' | 'transport'>;
 
 /**
  * Error class for v3 feature compatibility issues
@@ -503,7 +515,9 @@ export interface SingleAgentClientConfig extends ConversationConfig {
    *
    * Set `maxResponseBytes` when crawling untrusted agents (registries,
    * federated discovery layers) to prevent a hostile vendor from buffering
-   * a large reply before any application-layer schema validation runs.
+   * a large reply before any application-layer schema validation runs. Set
+   * `requestTimeoutMs` to override the default 60s cap on A2A agent-card
+   * discovery; use `0` to disable the SDK-imposed discovery timeout.
    */
   transport?: import('../protocols').TransportOptions;
 }
@@ -713,7 +727,8 @@ export class SingleAgentClient {
    * Returns the agent config with the discovered endpoint.
    * Also computes the canonical base URL by stripping /mcp suffix.
    */
-  private async ensureEndpointDiscovered(): Promise<AgentConfig> {
+  private async ensureEndpointDiscovered(options?: ReadRequestOptions): Promise<AgentConfig> {
+    throwIfAborted(options?.signal);
     const needsDiscovery = this.normalizedAgent._needsDiscovery;
 
     if (!needsDiscovery) {
@@ -733,7 +748,7 @@ export class SingleAgentClient {
     }
 
     // Perform discovery
-    this.discoveredEndpoint = await this.discoverMCPEndpoint(this.normalizedAgent.agent_uri);
+    this.discoveredEndpoint = await this.discoverMCPEndpoint(this.normalizedAgent.agent_uri, options);
 
     // Compute canonical base URL by stripping /mcp suffix
     this.canonicalBaseUrl = this.computeBaseUrl(this.discoveredEndpoint);
@@ -751,7 +766,8 @@ export class SingleAgentClient {
    * Fetches the agent card and extracts the canonical URL.
    * Returns the agent config with the canonical URL.
    */
-  private async ensureCanonicalUrlResolved(): Promise<AgentConfig> {
+  private async ensureCanonicalUrlResolved(options?: ReadRequestOptions): Promise<AgentConfig> {
+    throwIfAborted(options?.signal);
     const needsCanonicalUrl = this.normalizedAgent._needsCanonicalUrl;
 
     if (!needsCanonicalUrl) {
@@ -767,7 +783,7 @@ export class SingleAgentClient {
     }
 
     // Fetch agent card to get canonical URL
-    const canonicalUrl = await this.fetchA2ACanonicalUrl(this.normalizedAgent.agent_uri);
+    const canonicalUrl = await this.fetchA2ACanonicalUrl(this.normalizedAgent.agent_uri, options);
     this.canonicalBaseUrl = canonicalUrl;
 
     return {
@@ -783,7 +799,7 @@ export class SingleAgentClient {
    * - If the agent card fetch returns 401, throw AuthenticationRequiredError
    * - Check for OAuth metadata to provide helpful guidance
    */
-  private async fetchA2ACanonicalUrl(agentUri: string): Promise<string> {
+  private async fetchA2ACanonicalUrl(agentUri: string, readOptions?: ReadRequestOptions): Promise<string> {
     const clientModule = require('@a2a-js/sdk/client');
     const A2AClient = clientModule.A2AClient;
 
@@ -793,15 +809,17 @@ export class SingleAgentClient {
     // active ALS slot enforces the cap on the wire call. Matches the same
     // pattern in `getAgentInfo` (closed #1799 via PR #1802).
     const { withResponseSizeLimit, wrapFetchWithSizeLimit } = await import('../protocols/responseSizeLimit');
-    const maxResponseBytes = this.config.transport?.maxResponseBytes;
+    const transport = readOptions?.transport ?? this.config.transport;
+    const maxResponseBytes = transport?.maxResponseBytes;
+    const requestTimeoutMs = resolveRequestTimeoutMs(transport?.requestTimeoutMs, DEFAULT_REQUEST_TIMEOUT_MS);
     const sizeLimitedFetch = wrapFetchWithSizeLimit((input, init) => fetch(input as RequestInfo | URL, init));
 
     const authToken = this.normalizedAgent.auth_token;
     let got401 = false;
 
-    const fetchImpl = async (url: string | URL | Request, options?: RequestInit) => {
+    const fetchImpl = async (url: string | URL | Request, requestInit?: RequestInit) => {
       const headers: Record<string, string> = {
-        ...(options?.headers as Record<string, string>),
+        ...(requestInit?.headers as Record<string, string>),
         ...this.normalizedAgent.headers,
         ...(authToken && {
           Authorization: `Bearer ${authToken}`,
@@ -809,7 +827,11 @@ export class SingleAgentClient {
         }),
       };
 
-      const response = await sizeLimitedFetch(url as RequestInfo | URL, { ...options, headers });
+      const response = await withAbortSignal<Response>(
+        [readOptions?.signal, requestInit?.signal],
+        requestTimeoutMs,
+        signal => sizeLimitedFetch(url as RequestInfo | URL, { ...requestInit, headers, signal })
+      );
 
       // Track 401 errors for later handling
       if (response.status === 401) {
@@ -905,7 +927,8 @@ export class SingleAgentClient {
    *
    * Note: This is async and called lazily on first agent interaction
    */
-  private async discoverMCPEndpoint(providedUri: string): Promise<string> {
+  private async discoverMCPEndpoint(providedUri: string, options?: ReadRequestOptions): Promise<string> {
+    throwIfAborted(options?.signal);
     const { connectMCPWithFallback } = await import('../protocols/mcp');
 
     const authToken = this.agent.auth_token;
@@ -920,10 +943,16 @@ export class SingleAgentClient {
 
     const testEndpoint = async (url: string): Promise<EndpointTestResult> => {
       try {
-        const client = await connectMCPWithFallback(new URL(url), authHeaders);
+        const client = await connectMCPWithFallback(new URL(url), authHeaders, [], 'endpoint discovery', undefined, {
+          signal: options?.signal,
+          requestTimeoutMs: options?.transport?.requestTimeoutMs ?? this.config.transport?.requestTimeoutMs,
+        });
         await client.close();
         return { success: true };
       } catch (error: unknown) {
+        if (isAbortOrTimeoutError(error)) {
+          throw error;
+        }
         if (is401Error(error)) {
           return { success: false, status: 401, error };
         }
@@ -1586,6 +1615,7 @@ export class SingleAgentClient {
     inputHandler?: InputHandler,
     options?: TaskOptions
   ): Promise<TaskResult<T>> {
+    throwIfAborted(options?.signal);
     // Normalize params for backwards compatibility before validation
     let normalizedParams = normalizeRequestParams(taskType, params, {
       skipIdempotencyAutoInject: options?.skipIdempotencyAutoInject,
@@ -1629,20 +1659,20 @@ export class SingleAgentClient {
     }
 
     // Validate required features before sending request
-    await this.validateTaskFeatures(taskType);
+    await this.validateTaskFeatures(taskType, options);
 
     // Guard mutating calls against pre-v3 sellers when opted in.
     if (this.config.requireV3ForMutations && isMutatingTask(taskType)) {
-      await this.requireSupportedMajor(taskType);
+      await this.requireSupportedMajor(taskType, options);
     }
 
     // Check for v3 features used against v2 servers - return empty result if unsupported
-    const earlyResult = await this.getEarlyResultForUnsupportedFeatures<T>(taskType, normalizedParams);
+    const earlyResult = await this.getEarlyResultForUnsupportedFeatures<T>(taskType, normalizedParams, options);
     if (earlyResult) {
       return attachMatch(earlyResult);
     }
 
-    const agent = await this.ensureEndpointDiscovered();
+    const agent = await this.ensureEndpointDiscovered(options);
 
     // Schema-driven pre-send validation runs on the unadapted v3 shape so
     // wire-format adapters (e.g. adaptGetProductsRequestForV2) don't strip
@@ -1654,7 +1684,7 @@ export class SingleAgentClient {
     }
 
     // Adapt request for the detected server and AdCP protocol versions.
-    const serverVersion = await this.detectServerVersion();
+    const serverVersion = await this.detectServerVersion(options);
     const inputSchemaStripLogs: any[] = [];
     const { params: adaptedParams, driftLogs: adaptDriftLogs } = this.adaptRequest(
       taskType,
@@ -2236,14 +2266,18 @@ export class SingleAgentClient {
    *
    * @returns TaskResult with empty data if v3 features are unsupported, null to proceed normally
    */
-  private async getEarlyResultForUnsupportedFeatures<T>(taskType: string, params: any): Promise<TaskResult<T> | null> {
+  private async getEarlyResultForUnsupportedFeatures<T>(
+    taskType: string,
+    params: any,
+    options?: ReadRequestOptions
+  ): Promise<TaskResult<T> | null> {
     // Only check for tasks that have v3-specific features
     if (taskType !== 'get_products') {
       return null;
     }
 
     // Get capabilities to check what the server supports
-    const capabilities = await this.getCapabilities();
+    const capabilities = await this.getCapabilities(options);
 
     // If server is v3, all features are supported - proceed normally
     if (capabilities.version === 'v3') {
@@ -2703,7 +2737,7 @@ export class SingleAgentClient {
     inputHandler?: InputHandler,
     options?: TaskOptions
   ): Promise<TaskResult<GetAdCPCapabilitiesResponse>> {
-    const agent = await this.ensureEndpointDiscovered();
+    const agent = await this.ensureEndpointDiscovered(options);
     this.executor.validateRequest('get_adcp_capabilities', params);
     return this.executor.executeTask<GetAdCPCapabilitiesResponse>(
       agent,
@@ -3036,6 +3070,7 @@ export class SingleAgentClient {
     inputHandler?: InputHandler,
     options?: TaskOptions
   ): Promise<TaskResult<T>> {
+    throwIfAborted(options?.signal);
     const startTime = Date.now();
     try {
       const normalizedParams = normalizeRequestParams(taskName, params, {
@@ -3052,11 +3087,11 @@ export class SingleAgentClient {
         options
       );
 
-      await this.validateTaskFeatures(taskName);
+      await this.validateTaskFeatures(taskName, options);
       if (this.config.requireV3ForMutations && isMutatingTask(taskName)) {
-        await this.requireSupportedMajor(taskName);
+        await this.requireSupportedMajor(taskName, options);
       }
-      const agent = await this.ensureEndpointDiscovered();
+      const agent = await this.ensureEndpointDiscovered(options);
 
       // Schema-driven pre-send validation runs on the unadapted v3 shape so
       // wire-format adapters (e.g. adaptGetProductsRequestForV2) don't strip
@@ -3068,7 +3103,7 @@ export class SingleAgentClient {
       }
 
       // Adapt request for the detected server and AdCP protocol versions.
-      const serverVersion = await this.detectServerVersion();
+      const serverVersion = await this.detectServerVersion(options);
       const inputSchemaStripLogs: any[] = [];
       const { params: adaptedParams, driftLogs: adaptDriftLogs } = this.adaptRequest(
         taskName,
@@ -3119,7 +3154,8 @@ export class SingleAgentClient {
         error instanceof AuthenticationRequiredError ||
         error instanceof TaskTimeoutError ||
         error instanceof VersionUnsupportedError ||
-        error instanceof FeatureUnsupportedError
+        error instanceof FeatureUnsupportedError ||
+        isAbortOrTimeoutError(error)
       ) {
         throw error;
       }
@@ -3513,7 +3549,7 @@ export class SingleAgentClient {
    * });
    * ```
    */
-  async getAgentInfo(): Promise<{
+  async getAgentInfo(options?: ReadRequestOptions): Promise<{
     name: string;
     description?: string;
     protocol: 'mcp' | 'a2a';
@@ -3529,12 +3565,22 @@ export class SingleAgentClient {
     // `transport.maxResponseBytes` extends to discovery / tools-list bodies.
     // `withResponseSizeLimit` is a no-op when no cap is configured.
     const { withResponseSizeLimit } = await import('../protocols/responseSizeLimit');
-    const maxResponseBytes = this.config.transport?.maxResponseBytes;
+    throwIfAborted(options?.signal);
+    const transport = options?.transport ?? this.config.transport;
+    const maxResponseBytes = transport?.maxResponseBytes;
+    const requestTimeoutMs = resolveRequestTimeoutMs(transport?.requestTimeoutMs, DEFAULT_REQUEST_TIMEOUT_MS);
+    const clientRequestTimeoutMs = resolveClientRequestTimeoutMs(transport?.requestTimeoutMs);
+    const mcpRequestOptions = {
+      ...(options?.signal && { signal: options.signal }),
+      ...(clientRequestTimeoutMs !== undefined && { timeout: clientRequestTimeoutMs }),
+    };
     if (this.normalizedAgent.protocol === 'mcp') {
       // In-process: use the pre-connected client instead of opening a new HTTP connection
       if (this.normalizedAgent._inProcessMcpClient) {
         const mcpClient = this.normalizedAgent._inProcessMcpClient;
-        const toolsList = await withResponseSizeLimit(maxResponseBytes, () => mcpClient.listTools());
+        const toolsList = await withResponseSizeLimit(maxResponseBytes, () =>
+          mcpClient.listTools(undefined, mcpRequestOptions)
+        );
         const tools = toolsList.tools.map(tool => ({
           name: tool.name,
           description: tool.description,
@@ -3551,7 +3597,7 @@ export class SingleAgentClient {
       }
 
       // Discover endpoint if needed
-      const agent = await this.ensureEndpointDiscovered();
+      const agent = await this.ensureEndpointDiscovered(options);
 
       // Use the shared connectMCP path so both static bearer AND saved OAuth
       // tokens work. OAuth takes the refresh-capable authProvider branch.
@@ -3561,6 +3607,12 @@ export class SingleAgentClient {
       // SDK doesn't emit a competing `Authorization: Bearer …`.
       const { connectMCP } = await import('../protocols/mcp');
       const connectOptions: Parameters<typeof connectMCP>[0] = { agentUrl: agent.agent_uri };
+      if (options?.signal) {
+        connectOptions.signal = options.signal;
+      }
+      if (transport?.requestTimeoutMs !== undefined) {
+        connectOptions.requestTimeoutMs = transport.requestTimeoutMs;
+      }
       if (this.normalizedAgent.headers && Object.keys(this.normalizedAgent.headers).length > 0) {
         connectOptions.customHeaders = this.normalizedAgent.headers;
       }
@@ -3575,7 +3627,9 @@ export class SingleAgentClient {
 
       const { client: mcpClient } = await connectMCP(connectOptions);
       try {
-        const toolsList = await withResponseSizeLimit(maxResponseBytes, () => mcpClient.listTools());
+        const toolsList = await withResponseSizeLimit(maxResponseBytes, () =>
+          mcpClient.listTools(undefined, mcpRequestOptions)
+        );
 
         const tools = toolsList.tools.map(tool => ({
           name: tool.name,
@@ -3611,15 +3665,20 @@ export class SingleAgentClient {
       const authToken = this.normalizedAgent.auth_token;
       const sizeLimitedFetch = wrapFetchWithSizeLimit((input, init) => fetch(input as RequestInfo | URL, init));
       const fetchImpl = authToken
-        ? async (url: string | URL | Request, options?: RequestInit) => {
+        ? async (url: string | URL | Request, requestInit?: RequestInit) => {
             const headers = {
-              ...(options?.headers as Record<string, string>),
+              ...(requestInit?.headers as Record<string, string>),
               Authorization: `Bearer ${authToken}`,
               'x-adcp-auth': authToken,
             };
-            return sizeLimitedFetch(url as RequestInfo | URL, { ...options, headers });
+            return withAbortSignal<Response>([options?.signal, requestInit?.signal], requestTimeoutMs, signal =>
+              sizeLimitedFetch(url as RequestInfo | URL, { ...requestInit, headers, signal })
+            );
           }
-        : (url: string | URL | Request, options?: RequestInit) => sizeLimitedFetch(url as RequestInfo | URL, options);
+        : (url: string | URL | Request, requestInit?: RequestInit) =>
+            withAbortSignal<Response>([options?.signal, requestInit?.signal], requestTimeoutMs, signal =>
+              sizeLimitedFetch(url as RequestInfo | URL, { ...requestInit, signal })
+            );
 
       const cardUrls = buildCardUrls(this.normalizedAgent.agent_uri);
 
@@ -3692,7 +3751,8 @@ export class SingleAgentClient {
    * }
    * ```
    */
-  async getCapabilities(): Promise<AdcpCapabilities> {
+  async getCapabilities(options?: ReadRequestOptions): Promise<AdcpCapabilities> {
+    throwIfAborted(options?.signal);
     // Return cached if available
     if (this.cachedCapabilities) {
       this.maybeWarnV2Sunset(this.cachedCapabilities);
@@ -3700,7 +3760,7 @@ export class SingleAgentClient {
     }
 
     // First get tool list to support both detection methods
-    const agentInfo = await this.getAgentInfo();
+    const agentInfo = await this.getAgentInfo(options);
     const tools: ToolInfo[] = agentInfo.tools.map(t => ({
       name: t.name,
       description: t.description,
@@ -3724,8 +3784,25 @@ export class SingleAgentClient {
         // because normalizeAgentConfig returns early when _inProcessMcpClient is set). The
         // executor then hits ProtocolClient.callTool which reads _inProcessMcpClient directly,
         // so the sentinel adcp-in-process:// URI never reaches validateAgentUrl.
-        const agent = await this.ensureEndpointDiscovered();
-        const result = await this.executor.executeTask<any>(agent, 'get_adcp_capabilities', {}, undefined);
+        const agent = await this.ensureEndpointDiscovered(options);
+        const result = await this.executor.executeTask<any>(
+          agent,
+          'get_adcp_capabilities',
+          {},
+          undefined,
+          options
+        );
+        throwIfAborted(options?.signal);
+        const requestTimeoutMs = resolveRequestTimeoutMs(
+          options?.transport?.requestTimeoutMs ?? this.config.transport?.requestTimeoutMs
+        );
+        if (
+          !result.success &&
+          requestTimeoutMs !== undefined &&
+          /\b(requesttimeout|timeout|timed out)\b/i.test(result.error ?? '')
+        ) {
+          throw createTimeoutError(requestTimeoutMs);
+        }
 
         if (result.success && result.data) {
           this.cachedCapabilities = augmentCapabilitiesFromTools(parseCapabilitiesResponse(result.data), tools);
@@ -3785,7 +3862,7 @@ export class SingleAgentClient {
             `since the agent has the v3-only discovery tool. ` +
             `This client routes to v3 adapters, but calls reading capability details ` +
             `(idempotency TTL, supported_versions, feature flags) will fail until the agent ` +
-            `operator fixes the capabilities endpoint at ${this.agent.agent_uri}.`,
+            `operator fixes the capabilities endpoint.`,
           {
             success: result.success,
             hasError: !!result.error,
@@ -3796,7 +3873,11 @@ export class SingleAgentClient {
         // Re-throw errors that indicate real infrastructure problems —
         // only fall through for tool-execution failures (the agent
         // advertises get_adcp_capabilities but can't actually serve it).
-        if (error instanceof AuthenticationRequiredError || error instanceof TaskTimeoutError) {
+        if (
+          error instanceof AuthenticationRequiredError ||
+          error instanceof TaskTimeoutError ||
+          isAbortOrTimeoutError(error)
+        ) {
           throw error;
         }
         console.warn(
@@ -3804,8 +3885,8 @@ export class SingleAgentClient {
             `threw — treating as v3 (synthetic) since the agent has the v3-only discovery tool. ` +
             `This client routes to v3 adapters, but calls reading capability details ` +
             `(idempotency TTL, supported_versions, feature flags) will fail until the agent ` +
-            `operator fixes the capabilities endpoint at ${this.agent.agent_uri}. ` +
-            `Error: ${error instanceof Error ? error.message : String(error)}`
+            `operator fixes the capabilities endpoint.`,
+          { errorType: error instanceof Error ? error.name : typeof error }
         );
       }
 
@@ -3906,8 +3987,8 @@ export class SingleAgentClient {
    *
    * @returns 'v2' or 'v3' based on server capabilities
    */
-  async detectServerVersion(): Promise<'v2' | 'v3'> {
-    const capabilities = await this.getCapabilities();
+  async detectServerVersion(options?: ReadRequestOptions): Promise<'v2' | 'v3'> {
+    const capabilities = await this.getCapabilities(options);
     return capabilities.version;
   }
 
@@ -4012,13 +4093,17 @@ export class SingleAgentClient {
    *
    * Skipped when validateFeatures is false or the task has no feature requirements.
    */
-  private async validateTaskFeatures(taskName: string): Promise<void> {
+  private async validateTaskFeatures(taskName: string, options?: ReadRequestOptions): Promise<void> {
     if (this.config.validateFeatures === false) return;
 
     const requiredFeatures = TASK_FEATURE_MAP[taskName];
     if (!requiredFeatures || requiredFeatures.length === 0) return;
 
-    await this.require(...requiredFeatures);
+    const capabilities = await this.getCapabilities(options);
+    const missing = requiredFeatures.filter(f => !resolveFeature(capabilities, f));
+    if (missing.length > 0) {
+      throw new FeatureUnsupportedError(missing, listDeclaredFeatures(capabilities), this.agent.agent_uri);
+    }
   }
 
   /**
@@ -4146,9 +4231,9 @@ export class SingleAgentClient {
    *
    * Throws `VersionUnsupportedError` with the specific reason on failure.
    */
-  async requireSupportedMajor(taskType: string = 'request'): Promise<void> {
+  async requireSupportedMajor(taskType: string = 'request', options?: ReadRequestOptions): Promise<void> {
     if (this.isV2Allowed()) return;
-    const capabilities = await this.getCapabilities();
+    const capabilities = await this.getCapabilities(options);
 
     // Synthetic capabilities — no authoritative `get_adcp_capabilities`
     // response, so the version + idempotency-TTL fields couldn't be read.

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -698,6 +698,14 @@ export class TaskExecutor {
 
       return attachMatch(result);
     } catch (error) {
+      if (isAbortOrTimeoutError(error)) {
+        if (idempotencyKey && error && typeof error === 'object') {
+          (error as Error & { idempotency_key?: string; idempotencyKey?: string }).idempotency_key = idempotencyKey;
+          (error as Error & { idempotency_key?: string; idempotencyKey?: string }).idempotencyKey = idempotencyKey;
+        }
+        throw error;
+      }
+
       // Report failed outcome on error
       if (governanceCheckId && this.governanceMiddleware && governanceResult?.governanceContext) {
         await this.governanceMiddleware.reportOutcome(
@@ -708,13 +716,6 @@ export class TaskExecutor {
           debugLogs,
           governanceResult.governanceContext
         );
-      }
-      if (isAbortOrTimeoutError(error)) {
-        if (idempotencyKey && error && typeof error === 'object') {
-          (error as Error & { idempotency_key?: string; idempotencyKey?: string }).idempotency_key = idempotencyKey;
-          (error as Error & { idempotency_key?: string; idempotencyKey?: string }).idempotencyKey = idempotencyKey;
-        }
-        throw error;
       }
       return attachMatch(this.createErrorResult<T>(taskId, agent, error, debugLogs, startTime));
     }

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -24,6 +24,7 @@ import { normalizeGetProductsResponse } from '../utils/pricing-adapter';
 import { normalizeLegacyMediaBuyStatusForReturn } from '../utils/envelope-status-compat';
 import { getLatestA2ADataPartFromResponse } from '../utils/a2a-artifacts';
 import { cancelA2ATask } from '../protocols/a2a';
+import { isAbortOrTimeoutError } from '../protocols/abort';
 import type {
   Message,
   InputRequest,
@@ -605,6 +606,7 @@ export class TaskExecutor {
         ...(this.config.wireAdcpVersion !== undefined && { wireAdcpVersion: this.config.wireAdcpVersion }),
         ...(this.config.versionEnvelope !== undefined && { versionEnvelope: this.config.versionEnvelope }),
         transport: options.transport ?? this.config.transport,
+        signal: options.signal,
         onTransportActivity: this.config.onTransportActivity,
         transportActivityContext: {
           operationId: taskId,
@@ -706,6 +708,13 @@ export class TaskExecutor {
           debugLogs,
           governanceResult.governanceContext
         );
+      }
+      if (isAbortOrTimeoutError(error)) {
+        if (idempotencyKey && error && typeof error === 'object') {
+          (error as Error & { idempotency_key?: string; idempotencyKey?: string }).idempotency_key = idempotencyKey;
+          (error as Error & { idempotency_key?: string; idempotencyKey?: string }).idempotencyKey = idempotencyKey;
+        }
+        throw error;
       }
       return attachMatch(this.createErrorResult<T>(taskId, agent, error, debugLogs, startTime));
     }
@@ -1397,7 +1406,8 @@ export class TaskExecutor {
   private async getTaskStatusWithRawResponse(
     agent: AgentConfig,
     taskId: string,
-    transport?: import('../protocols').TransportOptions
+    transport?: import('../protocols').TransportOptions,
+    signal?: AbortSignal
   ): Promise<TaskStatusPollResult> {
     // AdCP `tasks/get` is the cross-protocol work-status interface
     // (`schemas/cache/<v>/bundled/core/tasks-get-{request,response}.json`).
@@ -1436,6 +1446,7 @@ export class TaskExecutor {
         ...(this.config.wireAdcpVersion !== undefined && { wireAdcpVersion: this.config.wireAdcpVersion }),
         ...(this.config.versionEnvelope !== undefined && { versionEnvelope: this.config.versionEnvelope }),
         transport: transport ?? this.config.transport,
+        signal,
         onTransportActivity: this.config.onTransportActivity,
         transportActivityContext: {
           taskId,
@@ -1460,9 +1471,10 @@ export class TaskExecutor {
   async getTaskStatus(
     agent: AgentConfig,
     taskId: string,
-    transport?: import('../protocols').TransportOptions
+    transport?: import('../protocols').TransportOptions,
+    signal?: AbortSignal
   ): Promise<TaskInfo> {
-    return (await this.getTaskStatusWithRawResponse(agent, taskId, transport)).task;
+    return (await this.getTaskStatusWithRawResponse(agent, taskId, transport, signal)).task;
   }
 
   async pollTaskCompletion<T>(
@@ -1532,7 +1544,7 @@ export class TaskExecutor {
       let status: TaskInfo;
       let rawResponse: Record<string, unknown> | undefined;
       try {
-        const pollResult = await this.getTaskStatusWithRawResponse(agent, taskId, transport);
+        const pollResult = await this.getTaskStatusWithRawResponse(agent, taskId, transport, signal);
         status = pollResult.task;
         rawResponse = pollResult.rawResponse;
       } catch (err) {
@@ -1746,6 +1758,7 @@ export class TaskExecutor {
         ...(this.config.wireAdcpVersion !== undefined && { wireAdcpVersion: this.config.wireAdcpVersion }),
         ...(this.config.versionEnvelope !== undefined && { versionEnvelope: this.config.versionEnvelope }),
         transport: options.transport ?? this.config.transport,
+        signal: options.signal,
         onTransportActivity: this.config.onTransportActivity,
         transportActivityContext: {
           operationId: taskId,

--- a/src/lib/protocols/a2a.ts
+++ b/src/lib/protocols/a2a.ts
@@ -20,6 +20,7 @@ import { redactIdempotencyKeyInArgs } from '../utils/idempotency';
 import { wrapFetchWithCapture } from './rawResponseCapture';
 import { wrapFetchWithSizeLimit } from './responseSizeLimit';
 import { wrapFetchWithTransportDiagnostics } from './transportDiagnostics';
+import { DEFAULT_REQUEST_TIMEOUT_MS, resolveRequestTimeoutMs, withAbortSignal } from './abort';
 import { getLatestA2ADataPartFromResponse } from '../utils/a2a-artifacts';
 
 if (!A2AClient) {
@@ -35,6 +36,8 @@ interface A2ACallContext {
   customHeaders?: Record<string, string>;
   debugLogs: DebugLogEntry[];
   got401Ref: { value: boolean };
+  signal?: AbortSignal;
+  requestTimeoutMs?: number;
 }
 
 const callContextStorage = new AsyncLocalStorage<A2ACallContext>();
@@ -238,10 +241,14 @@ export async function cancelA2ATask(agent: AgentConfig, taskId: string): Promise
 async function getOrCreateA2AClient(
   agentUrl: string,
   authToken: string | undefined,
-  customAuthHeader?: string
+  customAuthHeader?: string,
+  bypassCache = false
 ): Promise<InstanceType<typeof A2AClient>> {
   const signingContext = signingContextStorage.getStore();
   const cacheKey = a2aCacheKey(agentUrl, authToken, signingContext?.cacheKey, customAuthHeader);
+  if (bypassCache) {
+    return createA2AClient(agentUrl, authToken);
+  }
   const cached = a2aClientCache.get(cacheKey);
   if (cached) return cached;
 
@@ -309,7 +316,7 @@ function buildFetchImpl(authToken: string | undefined) {
   // agent has request-signing configured, we wrap it with the AdCP signing
   // fetch so the signature covers the exact bytes we're about to send (auth
   // headers included, since the signer re-reads the final header record).
-  const baseFetch = async (url: string | URL | Request, options?: RequestInit) => {
+  const baseFetch = async (url: string | URL | Request, options?: RequestInit): Promise<Response> => {
     const context = callContextStorage.getStore();
 
     const existingHeaders: Record<string, string> = {};
@@ -332,6 +339,9 @@ function buildFetchImpl(authToken: string | undefined) {
     const urlString = typeof url === 'string' ? url : url.toString();
     const isDiscoveryRequest = isAgentCardPath(urlString);
     const traceHeaders = isDiscoveryRequest ? {} : injectTraceHeaders();
+    const requestTimeoutMs = isDiscoveryRequest
+      ? resolveRequestTimeoutMs(context?.requestTimeoutMs, DEFAULT_REQUEST_TIMEOUT_MS)
+      : undefined;
 
     // Merge: existing < trace < custom < auth (auth always wins)
     const headers: Record<string, string> = {
@@ -357,7 +367,9 @@ function buildFetchImpl(authToken: string | undefined) {
       ),
     });
 
-    const response = await networkFetch(url as any, { ...options, headers });
+    const response = await withAbortSignal<Response>([context?.signal, options?.signal], requestTimeoutMs, signal =>
+      networkFetch(url as any, { ...options, headers, signal })
+    );
 
     if (response.status === 401 && context) {
       context.got401Ref.value = true;
@@ -437,7 +449,9 @@ export async function callA2ATool(
   pushNotificationConfig?: PushNotificationConfig,
   customHeaders?: Record<string, string>,
   signingContext?: AgentSigningContext,
-  session?: A2ASessionIds
+  session?: A2ASessionIds,
+  signal?: AbortSignal,
+  requestTimeoutMs?: number
 ): Promise<unknown> {
   return withSpan(
     'adcp.a2a.call_tool',
@@ -450,6 +464,8 @@ export async function callA2ATool(
         customHeaders,
         debugLogs,
         got401Ref: { value: false },
+        signal,
+        requestTimeoutMs,
       };
       return signingContextStorage.run(signingContext, () =>
         callContextStorage.run(context, () =>
@@ -485,7 +501,12 @@ async function callA2AToolImpl(
     // the cache key disambiguates by the actual outgoing credential, not
     // just the absent `authToken`.
     const customAuthHeader = extractA2AAuthHeader(context.customHeaders);
-    const client = await getOrCreateA2AClient(agentUrl, authToken, customAuthHeader);
+    const client = await getOrCreateA2AClient(
+      agentUrl,
+      authToken,
+      customAuthHeader,
+      !!context.signal || context.requestTimeoutMs !== undefined
+    );
 
     const requestPayload: {
       message: {

--- a/src/lib/protocols/a2a.ts
+++ b/src/lib/protocols/a2a.ts
@@ -64,15 +64,14 @@ const pendingA2AClients = new Map<string, Promise<InstanceType<typeof A2AClient>
  * credentials share a single cached A2AClient — single-CLI-process safe,
  * multi-tenant SDK consumer not safe.
  *
- * `customAuthHeader` is the case-insensitive `Authorization` value from the
- * per-call `customHeaders`. Extracted by the call site so this helper stays
- * a pure key-builder.
+ * `customHeaders` also feed the key so tenant/routing headers cannot reuse
+ * a card/client discovered for another caller.
  */
 function a2aCacheKey(
   agentUrl: string,
   authToken?: string,
   signingCacheKey?: string,
-  customAuthHeader?: string
+  customHeaders?: Record<string, string>
 ): string {
   // 64-bit Map-key disambiguator — NOT a password hash. The cached client
   // closes over the full credential, so a hypothetical hash collision still
@@ -81,10 +80,12 @@ function a2aCacheKey(
   // key) instead of bare `createHash` so CodeQL's
   // `js/insufficient-password-hash` heuristic doesn't misclassify the
   // dataflow — see the helper docstring for the full rationale.
-  const fingerprint = authToken ?? customAuthHeader;
+  const fingerprint = authToken ?? extractA2AAuthHeader(customHeaders);
   const tokenSuffix = fingerprint ? `::${cacheDisambiguator(fingerprint)}` : '';
+  const headersKey = headersCacheDisambiguator(customHeaders);
+  const headersSuffix = headersKey ? `::headers:${headersKey}` : '';
   const signingSuffix = signingCacheKey ? `::${signingCacheKey}` : '';
-  return `${agentUrl}${tokenSuffix}${signingSuffix}`;
+  return `${agentUrl}${tokenSuffix}${headersSuffix}${signingSuffix}`;
 }
 
 /**
@@ -108,6 +109,37 @@ function extractA2AAuthHeader(headers: Record<string, string> | undefined): stri
     if (key.toLowerCase() === 'authorization' && value) return value;
   }
   return undefined;
+}
+
+function headersCacheDisambiguator(headers?: Record<string, string>): string | undefined {
+  const entries = Object.entries(headers ?? {})
+    .filter(([key]) => {
+      const lower = key.toLowerCase();
+      return lower !== 'traceparent' && lower !== 'tracestate' && lower !== 'baggage';
+    })
+    .map(([key, value]) => [key.toLowerCase(), value] as const)
+    .sort(([a], [b]) => a.localeCompare(b));
+  return entries.length > 0 ? cacheDisambiguator(JSON.stringify(entries)) : undefined;
+}
+
+function redactHeadersForDebug(headers: Record<string, string>): Record<string, string> {
+  return Object.fromEntries(Object.keys(headers).map(key => [key, '***']));
+}
+
+function redactPushNotificationConfigForDebug(
+  config: PushNotificationConfig | undefined
+): PushNotificationConfig | undefined {
+  if (!config) return undefined;
+  return {
+    ...config,
+    ...(config.token && { token: '***' }),
+    ...(config.authentication && {
+      authentication: {
+        ...config.authentication,
+        ...(config.authentication.credentials && { credentials: '***' }),
+      },
+    }),
+  };
 }
 
 /**
@@ -241,11 +273,11 @@ export async function cancelA2ATask(agent: AgentConfig, taskId: string): Promise
 async function getOrCreateA2AClient(
   agentUrl: string,
   authToken: string | undefined,
-  customAuthHeader?: string,
+  customHeaders?: Record<string, string>,
   bypassCache = false
 ): Promise<InstanceType<typeof A2AClient>> {
   const signingContext = signingContextStorage.getStore();
-  const cacheKey = a2aCacheKey(agentUrl, authToken, signingContext?.cacheKey, customAuthHeader);
+  const cacheKey = a2aCacheKey(agentUrl, authToken, signingContext?.cacheKey, customHeaders);
   if (bypassCache) {
     return createA2AClient(agentUrl, authToken);
   }
@@ -341,7 +373,7 @@ function buildFetchImpl(authToken: string | undefined) {
     const traceHeaders = isDiscoveryRequest ? {} : injectTraceHeaders();
     const requestTimeoutMs = isDiscoveryRequest
       ? resolveRequestTimeoutMs(context?.requestTimeoutMs, DEFAULT_REQUEST_TIMEOUT_MS)
-      : undefined;
+      : resolveRequestTimeoutMs(context?.requestTimeoutMs);
 
     // Merge: existing < trace < custom < auth (auth always wins)
     const headers: Record<string, string> = {
@@ -359,12 +391,7 @@ function buildFetchImpl(authToken: string | undefined) {
       message: `A2A: Fetch to ${urlString}`,
       timestamp: new Date().toISOString(),
       hasAuth: !!authToken,
-      headers: Object.fromEntries(
-        Object.entries(headers).map(([k, v]) => {
-          const lower = k.toLowerCase();
-          return lower === 'authorization' || lower === 'x-adcp-auth' ? [k, '***'] : [k, v];
-        })
-      ),
+      headers: redactHeadersForDebug(headers),
     });
 
     const response = await withAbortSignal<Response>([context?.signal, options?.signal], requestTimeoutMs, signal =>
@@ -496,15 +523,10 @@ async function callA2AToolImpl(
   session: A2ASessionIds | undefined
 ): Promise<unknown> {
   try {
-    // Pull a non-Bearer `Authorization` value out of the per-call custom
-    // headers if present. The CLI's `--auth-scheme basic` path sets this so
-    // the cache key disambiguates by the actual outgoing credential, not
-    // just the absent `authToken`.
-    const customAuthHeader = extractA2AAuthHeader(context.customHeaders);
     const client = await getOrCreateA2AClient(
       agentUrl,
       authToken,
-      customAuthHeader,
+      context.customHeaders,
       !!context.signal || context.requestTimeoutMs !== undefined
     );
 
@@ -545,21 +567,25 @@ async function callA2AToolImpl(
 
     const payloadSize = JSON.stringify(requestPayload).length;
     const redactedParameters = redactIdempotencyKeyInArgs(parameters);
-    const redactedPayload =
-      redactedParameters === parameters
-        ? requestPayload
-        : {
-            ...requestPayload,
-            message: {
-              ...requestPayload.message,
-              parts: [
-                {
-                  kind: 'data',
-                  data: { skill: toolName, parameters: redactedParameters },
-                },
-              ],
-            },
-          };
+    const redactedPayload = {
+      ...requestPayload,
+      message: {
+        ...requestPayload.message,
+        parts: [
+          {
+            kind: 'data',
+            data: { skill: toolName, parameters: redactedParameters },
+          },
+        ],
+      },
+      ...(requestPayload.configuration && {
+        configuration: {
+          pushNotificationConfig: redactPushNotificationConfigForDebug(
+            requestPayload.configuration.pushNotificationConfig
+          )!,
+        },
+      }),
+    };
     debugLogs.push({
       type: 'info',
       message: `A2A: Calling skill ${toolName} with parameters: ${JSON.stringify(
@@ -610,8 +636,7 @@ async function callA2AToolImpl(
       // case) rather than authToken, the cache key must reflect that or we
       // evict the wrong entry.
       const signingContext = signingContextStorage.getStore();
-      const customAuthHeader = extractA2AAuthHeader(context.customHeaders);
-      a2aClientCache.delete(a2aCacheKey(agentUrl, authToken, signingContext?.cacheKey, customAuthHeader));
+      a2aClientCache.delete(a2aCacheKey(agentUrl, authToken, signingContext?.cacheKey, context.customHeaders));
 
       debugLogs.push({
         type: 'error',

--- a/src/lib/protocols/abort.ts
+++ b/src/lib/protocols/abort.ts
@@ -1,0 +1,104 @@
+export const DEFAULT_REQUEST_TIMEOUT_MS = 60_000;
+export const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+export function resolveRequestTimeoutMs(timeoutMs: number | undefined, defaultTimeoutMs?: number): number | undefined {
+  const resolved = timeoutMs ?? defaultTimeoutMs;
+  if (resolved == null) return undefined;
+  if (resolved === 0) return undefined;
+  if (!Number.isFinite(resolved) || resolved < 0 || resolved > MAX_TIMER_DELAY_MS) {
+    throw new RangeError(`requestTimeoutMs must be a finite non-negative number <= ${MAX_TIMER_DELAY_MS}`);
+  }
+  return resolved;
+}
+
+export function resolveClientRequestTimeoutMs(timeoutMs: number | undefined): number | undefined {
+  if (timeoutMs === 0) return MAX_TIMER_DELAY_MS;
+  return resolveRequestTimeoutMs(timeoutMs);
+}
+
+export function createAbortError(reason?: unknown): Error {
+  if (reason instanceof Error && (reason.name === 'AbortError' || reason.name === 'TimeoutError')) return reason;
+  const error = new Error(reason == null ? 'The operation was aborted' : String(reason));
+  error.name = 'AbortError';
+  if (reason instanceof Error) {
+    (error as Error & { cause?: unknown }).cause = reason;
+    error.message = reason.message;
+  }
+  return error;
+}
+
+export function createTimeoutError(timeoutMs: number): Error {
+  const error = new Error(`Request timed out after ${timeoutMs} ms`);
+  error.name = 'TimeoutError';
+  return error;
+}
+
+export function isAbortOrTimeoutError(error: unknown): boolean {
+  if (error == null || typeof error !== 'object') return false;
+  const value = error as { name?: unknown; code?: unknown };
+  if (value.name === 'AbortError' || value.name === 'TimeoutError') return true;
+  // @modelcontextprotocol/sdk raises JSON-RPC RequestTimeout (-32001) for
+  // both SDK timeouts and AbortSignal-triggered request cancellation.
+  return value.code === -32001;
+}
+
+export function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    throw createAbortError(signal.reason);
+  }
+}
+
+export async function withAbortSignal<T>(
+  signals: Array<AbortSignal | null | undefined>,
+  timeoutMs: number | undefined,
+  fn: (signal?: AbortSignal) => Promise<T>
+): Promise<T> {
+  const activeSignals = signals.filter((signal): signal is AbortSignal => signal != null);
+  for (const signal of activeSignals) {
+    throwIfAborted(signal);
+  }
+
+  if (timeoutMs == null && activeSignals.length === 0) {
+    return fn(undefined);
+  }
+
+  if (timeoutMs == null && activeSignals.length === 1) {
+    const signal = activeSignals[0]!;
+    try {
+      return await fn(signal);
+    } catch (error) {
+      if (signal.aborted) {
+        throw createAbortError(signal.reason);
+      }
+      throw error;
+    }
+  }
+
+  const controller = new AbortController();
+  const abort = (reason?: unknown) => {
+    if (!controller.signal.aborted) {
+      controller.abort(reason);
+    }
+  };
+
+  const listeners = activeSignals.map(signal => {
+    const listener = () => abort(createAbortError(signal.reason));
+    signal.addEventListener('abort', listener, { once: true });
+    return { signal, listener };
+  });
+  const timer =
+    timeoutMs == null
+      ? undefined
+      : setTimeout(() => {
+          abort(createTimeoutError(timeoutMs));
+        }, timeoutMs);
+
+  try {
+    return await fn(controller.signal);
+  } finally {
+    if (timer) clearTimeout(timer);
+    for (const { signal, listener } of listeners) {
+      signal.removeEventListener('abort', listener);
+    }
+  }
+}

--- a/src/lib/protocols/index.ts
+++ b/src/lib/protocols/index.ts
@@ -525,7 +525,9 @@ export class ProtocolClient {
                     {
                       ...(signingContext && { signingContext }),
                       ...(signal && { signal }),
-                      ...(transport?.requestTimeoutMs !== undefined && { requestTimeoutMs: transport.requestTimeoutMs }),
+                      ...(transport?.requestTimeoutMs !== undefined && {
+                        requestTimeoutMs: transport.requestTimeoutMs,
+                      }),
                     }
                   );
                 } catch (err) {

--- a/src/lib/protocols/index.ts
+++ b/src/lib/protocols/index.ts
@@ -24,6 +24,7 @@ export async function closeConnections(protocol: 'mcp' | 'a2a' = 'mcp'): Promise
 }
 export type { MCPCallOptions, MCPConnectionResult } from './mcp';
 export { callA2ATool } from './a2a';
+export { DEFAULT_REQUEST_TIMEOUT_MS } from './abort';
 export {
   callMCPToolWithTasks,
   getMCPTaskStatus,
@@ -248,6 +249,13 @@ export interface TransportOptions {
    * existing signing / capture wrappers is non-obvious and a footgun.
    */
   maxResponseBytes?: number;
+  /**
+   * Timeout in milliseconds for bounded one-shot transport requests such as
+   * A2A agent-card discovery and MCP read-path probes. Defaults to 60 seconds
+   * for A2A discovery so an unresponsive card endpoint cannot hang forever.
+   * Set to `0` to disable the SDK-imposed discovery timeout.
+   */
+  requestTimeoutMs?: number;
 }
 
 /**
@@ -301,6 +309,8 @@ export interface CallToolOptions {
    * matching field on the client constructor's `transport` option.
    */
   transport?: TransportOptions;
+  /** Caller-owned cancellation signal for the in-flight protocol call. */
+  signal?: AbortSignal;
   /** Transport-level diagnostics callback for outbound HTTP requests. */
   onTransportActivity?: TransportActivityHandlerFn;
   /**
@@ -344,6 +354,7 @@ export class ProtocolClient {
       wireAdcpVersion,
       versionEnvelope: versionEnvelopeMode = 'auto',
       transport,
+      signal,
       onTransportActivity,
       transportActivityContext,
     } = options;
@@ -388,7 +399,10 @@ export class ProtocolClient {
               // URL validation, OAuth refresh, and signing — none apply in-process.
               if (agent.protocol === 'mcp' && agent._inProcessMcpClient) {
                 const inProcArgs = applyVersionEnvelope(args, versionEnvelope);
-                return callMCPToolWithClient(agent._inProcessMcpClient, toolName, inProcArgs, debugLogs);
+                return callMCPToolWithClient(agent._inProcessMcpClient, toolName, inProcArgs, debugLogs, {
+                  ...(signal && { signal }),
+                  ...(transport?.requestTimeoutMs !== undefined && { requestTimeoutMs: transport.requestTimeoutMs }),
+                });
               }
 
               validateAgentUrl(agent.agent_uri);
@@ -431,6 +445,8 @@ export class ProtocolClient {
                     serverVersion,
                     adcpVersion,
                     ...(versionEnvelopeMode !== 'auto' && { versionEnvelope: versionEnvelopeMode }),
+                    transport,
+                    signal,
                     onTransportActivity,
                     transportActivityContext,
                   })
@@ -483,6 +499,8 @@ export class ProtocolClient {
                       debugLogs,
                       customHeaders: agent.headers,
                       signingContext,
+                      signal,
+                      requestTimeoutMs: transport?.requestTimeoutMs,
                     });
                   } catch (err) {
                     // Refresh failed or server rejected the refreshed token — walk the
@@ -503,7 +521,11 @@ export class ProtocolClient {
                     authToken,
                     debugLogs,
                     agent.headers,
-                    signingContext ? { signingContext } : undefined
+                    {
+                      ...(signingContext && { signingContext }),
+                      ...(signal && { signal }),
+                      ...(transport?.requestTimeoutMs !== undefined && { requestTimeoutMs: transport.requestTimeoutMs }),
+                    }
                   );
                 } catch (err) {
                   // Client-credentials agents: on 401, the AS may have rotated
@@ -523,7 +545,13 @@ export class ProtocolClient {
                         retryAuthToken,
                         debugLogs,
                         agent.headers,
-                        signingContext ? { signingContext } : undefined
+                        {
+                          ...(signingContext && { signingContext }),
+                          ...(signal && { signal }),
+                          ...(transport?.requestTimeoutMs !== undefined && {
+                            requestTimeoutMs: transport.requestTimeoutMs,
+                          }),
+                        }
                       );
                     } catch (retryErr) {
                       await rethrowAsNeedsAuthorization(retryErr, agent.agent_uri);
@@ -545,7 +573,9 @@ export class ProtocolClient {
                     pushNotificationConfig,
                     agent.headers,
                     signingContext,
-                    session
+                    session,
+                    signal,
+                    transport?.requestTimeoutMs
                   );
                 } catch (err) {
                   // Same single-retry-on-401 for client-credentials agents as the
@@ -567,7 +597,9 @@ export class ProtocolClient {
                         pushNotificationConfig,
                         agent.headers,
                         signingContext,
-                        session
+                        session,
+                        signal,
+                        transport?.requestTimeoutMs
                       );
                     } catch (retryErr) {
                       await rethrowAsNeedsAuthorization(retryErr, agent.agent_uri);
@@ -646,7 +678,10 @@ export const createMCPClient = (
           applyVersionEnvelope(args, versionEnvelope),
           authToken,
           debugLogs,
-          headers
+          headers,
+          {
+            ...(transport?.requestTimeoutMs !== undefined && { requestTimeoutMs: transport.requestTimeoutMs }),
+          }
         )
       ),
   };
@@ -672,7 +707,11 @@ export const createA2AClient = (
           authToken,
           debugLogs,
           undefined,
-          headers
+          headers,
+          undefined,
+          undefined,
+          undefined,
+          transport?.requestTimeoutMs
         )
       ),
   };

--- a/src/lib/protocols/index.ts
+++ b/src/lib/protocols/index.ts
@@ -447,6 +447,7 @@ export class ProtocolClient {
                     ...(versionEnvelopeMode !== 'auto' && { versionEnvelope: versionEnvelopeMode }),
                     transport,
                     signal,
+                    ...(transport?.requestTimeoutMs !== undefined && { requestTimeoutMs: transport.requestTimeoutMs }),
                     onTransportActivity,
                     transportActivityContext,
                   })

--- a/src/lib/protocols/mcp-tasks.ts
+++ b/src/lib/protocols/mcp-tasks.ts
@@ -336,7 +336,6 @@ async function callToolOnClient(
   // Use callToolStream which handles the full task lifecycle
   const stream = client.experimental.tasks.callToolStream({ name: toolName, arguments: args }, undefined, {
     timeout: resolvedRequestTimeoutMs ?? workingTimeout,
-    maxTotalTimeout: workingTimeout,
     resetTimeoutOnProgress: true,
     ...(signal && { signal }),
   });

--- a/src/lib/protocols/mcp-tasks.ts
+++ b/src/lib/protocols/mcp-tasks.ts
@@ -19,6 +19,7 @@ import { signingContextStorage, type AgentSigningContext } from '../signing/clie
 import { redactIdempotencyKeyInArgs } from '../utils/idempotency';
 import { withResponseSizeLimit } from './responseSizeLimit';
 import { withTransportDiagnostics, type TransportActivityHandler } from './transportDiagnostics';
+import { isAbortOrTimeoutError, resolveClientRequestTimeoutMs } from './abort';
 
 /** Response shape returned by MCPClient.callTool(). */
 type CallToolResponse = {
@@ -51,9 +52,12 @@ const toolsListedClients = new WeakSet<MCPClient>();
  * Ensure tool metadata is cached in the SDK so isToolTask() works.
  * Called once per client connection when tasks are supported.
  */
-async function ensureToolsListed(client: MCPClient): Promise<void> {
+async function ensureToolsListed(client: MCPClient, signal?: AbortSignal, requestTimeoutMs?: number): Promise<void> {
   if (toolsListedClients.has(client)) return;
-  await client.listTools();
+  await client.listTools(undefined, {
+    ...(signal && { signal }),
+    ...(requestTimeoutMs !== undefined && { timeout: requestTimeoutMs }),
+  });
   toolsListedClients.add(client);
 }
 
@@ -182,7 +186,12 @@ export async function callMCPToolWithTasks(
   authToken?: string,
   debugLogs: DebugLogEntry[] = [],
   customHeaders?: Record<string, string>,
-  options?: { workingTimeout?: number; signingContext?: AgentSigningContext }
+  options?: {
+    workingTimeout?: number;
+    signingContext?: AgentSigningContext;
+    signal?: AbortSignal;
+    requestTimeoutMs?: number;
+  }
 ): Promise<unknown> {
   return withSpan(
     'adcp.mcp.call_tool',
@@ -219,8 +228,24 @@ export async function callMCPToolWithTasks(
           });
         }
 
-        return withCachedConnection(agentUrl, authToken, authHeaders, debugLogs, toolName, client =>
-          callToolOnClient(client, toolName, args, debugLogs, workingTimeout)
+        return withCachedConnection(
+          agentUrl,
+          authToken,
+          authHeaders,
+          debugLogs,
+          toolName,
+          client =>
+            callToolOnClient(
+              client,
+              toolName,
+              args,
+              debugLogs,
+              workingTimeout,
+              options?.signal,
+              options?.requestTimeoutMs
+            ),
+          undefined,
+          { signal: options?.signal, requestTimeoutMs: options?.requestTimeoutMs }
         );
       })
   );
@@ -242,14 +267,22 @@ export async function callMCPToolWithClient(
   toolName: string,
   args: Record<string, unknown>,
   debugLogs: DebugLogEntry[] = [],
-  options?: { workingTimeout?: number }
+  options?: { workingTimeout?: number; signal?: AbortSignal; requestTimeoutMs?: number }
 ): Promise<unknown> {
   debugLogs.push({
     type: 'info',
     message: `MCP: Calling tool ${toolName} (in-process) with args: ${JSON.stringify(redactArgsForLog(args))}`,
     timestamp: new Date().toISOString(),
   });
-  return callToolOnClient(mcpClient, toolName, args, debugLogs, options?.workingTimeout ?? 120_000);
+  return callToolOnClient(
+    mcpClient,
+    toolName,
+    args,
+    debugLogs,
+    options?.workingTimeout ?? 120_000,
+    options?.signal,
+    options?.requestTimeoutMs
+  );
 }
 
 /**
@@ -262,15 +295,22 @@ async function callToolOnClient(
   toolName: string,
   args: Record<string, unknown>,
   debugLogs: DebugLogEntry[],
-  workingTimeout: number
+  workingTimeout: number,
+  signal?: AbortSignal,
+  requestTimeoutMs?: number
 ): Promise<unknown> {
+  const resolvedRequestTimeoutMs = resolveClientRequestTimeoutMs(requestTimeoutMs);
+  const requestOptions = {
+    ...(signal && { signal }),
+    ...(resolvedRequestTimeoutMs !== undefined && { timeout: resolvedRequestTimeoutMs }),
+  };
   if (!serverSupportsTasks(client)) {
     debugLogs.push({
       type: 'info',
       message: `MCP Tasks: Server does not support tasks, using standard callTool for ${toolName}`,
       timestamp: new Date().toISOString(),
     });
-    const response = (await client.callTool({ name: toolName, arguments: args })) as CallToolResponse;
+    const response = (await client.callTool({ name: toolName, arguments: args }, undefined, requestOptions)) as CallToolResponse;
 
     debugLogs.push({
       type: response?.isError ? 'error' : 'success',
@@ -285,7 +325,7 @@ async function callToolOnClient(
   // Ensure tool metadata is cached so the SDK's isToolTask() works correctly.
   // Without this, callToolStream silently skips task creation for tools that
   // declare taskSupport: 'optional' | 'required'.
-  await ensureToolsListed(client);
+  await ensureToolsListed(client, signal, resolvedRequestTimeoutMs);
 
   debugLogs.push({
     type: 'info',
@@ -295,8 +335,10 @@ async function callToolOnClient(
 
   // Use callToolStream which handles the full task lifecycle
   const stream = client.experimental.tasks.callToolStream({ name: toolName, arguments: args }, undefined, {
-    timeout: workingTimeout,
+    timeout: resolvedRequestTimeoutMs ?? workingTimeout,
+    maxTotalTimeout: workingTimeout,
     resetTimeoutOnProgress: true,
+    ...(signal && { signal }),
   });
 
   let capturedTaskId: string | undefined;
@@ -345,7 +387,7 @@ async function callToolOnClient(
           // and return it as a proper isError response for downstream unwrapping.
           if (capturedTaskId) {
             try {
-              const taskResult = await client.experimental.tasks.getTaskResult(capturedTaskId);
+              const taskResult = await client.experimental.tasks.getTaskResult(capturedTaskId, undefined, requestOptions);
               const content = taskResult?.content as Array<{ type: string; text?: string }> | undefined;
               if (content) {
                 return {
@@ -363,9 +405,12 @@ async function callToolOnClient(
       }
     }
   } catch (error) {
+    if (signal?.aborted && isAbortOrTimeoutError(error)) {
+      throw error;
+    }
     // If we timed out but have a taskId, return a working status
     // so the caller can poll via getMCPTaskStatus/getMCPTaskResult
-    if (capturedTaskId && error instanceof Error && error.message.includes('Timeout')) {
+    if (capturedTaskId && error instanceof Error && /timeout|timed out/i.test(error.message)) {
       debugLogs.push({
         type: 'info',
         message: `MCP Tasks: Timeout for ${toolName}, returning working status with taskId ${capturedTaskId}`,
@@ -380,6 +425,9 @@ async function callToolOnClient(
         },
       };
     }
+    if (isAbortOrTimeoutError(error)) {
+      throw error;
+    }
     // Servers may return a synchronous tool error (e.g. VERSION_UNSUPPORTED)
     // rather than creating a task. The Tasks SDK rejects these with a Zod
     // validation error about a missing `task` field. When no task was
@@ -392,7 +440,7 @@ async function callToolOnClient(
         message: `MCP Tasks: Server returned synchronous response for ${toolName}, falling back to callTool`,
         timestamp: new Date().toISOString(),
       });
-      return (await client.callTool({ name: toolName, arguments: args })) as CallToolResponse;
+      return (await client.callTool({ name: toolName, arguments: args }, undefined, requestOptions)) as CallToolResponse;
     }
     throw error;
   }

--- a/src/lib/protocols/mcp-tasks.ts
+++ b/src/lib/protocols/mcp-tasks.ts
@@ -310,7 +310,11 @@ async function callToolOnClient(
       message: `MCP Tasks: Server does not support tasks, using standard callTool for ${toolName}`,
       timestamp: new Date().toISOString(),
     });
-    const response = (await client.callTool({ name: toolName, arguments: args }, undefined, requestOptions)) as CallToolResponse;
+    const response = (await client.callTool(
+      { name: toolName, arguments: args },
+      undefined,
+      requestOptions
+    )) as CallToolResponse;
 
     debugLogs.push({
       type: response?.isError ? 'error' : 'success',
@@ -386,7 +390,11 @@ async function callToolOnClient(
           // and return it as a proper isError response for downstream unwrapping.
           if (capturedTaskId) {
             try {
-              const taskResult = await client.experimental.tasks.getTaskResult(capturedTaskId, undefined, requestOptions);
+              const taskResult = await client.experimental.tasks.getTaskResult(
+                capturedTaskId,
+                undefined,
+                requestOptions
+              );
               const content = taskResult?.content as Array<{ type: string; text?: string }> | undefined;
               if (content) {
                 return {
@@ -439,7 +447,11 @@ async function callToolOnClient(
         message: `MCP Tasks: Server returned synchronous response for ${toolName}, falling back to callTool`,
         timestamp: new Date().toISOString(),
       });
-      return (await client.callTool({ name: toolName, arguments: args }, undefined, requestOptions)) as CallToolResponse;
+      return (await client.callTool(
+        { name: toolName, arguments: args },
+        undefined,
+        requestOptions
+      )) as CallToolResponse;
     }
     throw error;
   }

--- a/src/lib/protocols/mcp.ts
+++ b/src/lib/protocols/mcp.ts
@@ -18,6 +18,7 @@ import { redactIdempotencyKeyInArgs } from '../utils/idempotency';
 import { wrapFetchWithCapture } from './rawResponseCapture';
 import { wrapFetchWithSizeLimit } from './responseSizeLimit';
 import { wrapFetchWithTransportDiagnostics } from './transportDiagnostics';
+import { isAbortOrTimeoutError, resolveClientRequestTimeoutMs, resolveRequestTimeoutMs, withAbortSignal } from './abort';
 
 // Re-export for convenience
 export { UnauthorizedError };
@@ -219,7 +220,8 @@ async function getOrCreateConnection(
   baseUrl: URL,
   authHeaders: Record<string, string>,
   debugLogs: DebugLogEntry[],
-  label: string
+  label: string,
+  requestOptions: { signal?: AbortSignal; requestTimeoutMs?: number } = {}
 ): Promise<MCPClient> {
   const cached = getCachedConnection(cacheKey);
   if (cached) return cached;
@@ -227,7 +229,7 @@ async function getOrCreateConnection(
   const pending = pendingConnections.get(cacheKey);
   if (pending) return pending;
 
-  const promise = connectMCPWithFallback(baseUrl, authHeaders, debugLogs, label)
+  const promise = connectMCPWithFallback(baseUrl, authHeaders, debugLogs, label, undefined, requestOptions)
     .then(client => {
       connectionCache.set(cacheKey, client);
       evictLeastRecentlyUsed();
@@ -289,6 +291,8 @@ async function getOrCreateOAuthConnection(
     debugLogs: DebugLogEntry[];
     customHeaders?: Record<string, string>;
     signingContext?: AgentSigningContext;
+    signal?: AbortSignal;
+    requestTimeoutMs?: number;
   }
 ): Promise<MCPClient> {
   const cached = getCachedOAuthConnection(cacheKey);
@@ -318,6 +322,8 @@ async function withCachedOAuthConnection<T>(
     debugLogs: DebugLogEntry[];
     customHeaders?: Record<string, string>;
     signingContext?: AgentSigningContext;
+    signal?: AbortSignal;
+    requestTimeoutMs?: number;
   },
   label: string,
   fn: (client: MCPClient) => Promise<T>
@@ -328,6 +334,19 @@ async function withCachedOAuthConnection<T>(
     options.signingContext?.cacheKey,
     options.customHeaders
   );
+  if (options.signal || options.requestTimeoutMs !== undefined) {
+    const { client } = await connectMCP(options);
+    try {
+      return await fn(client);
+    } finally {
+      try {
+        await client.close();
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+
   const mcpClient = await getOrCreateOAuthConnection(cacheKey, options);
 
   try {
@@ -394,13 +413,21 @@ export async function withCachedConnection<T>(
   debugLogs: DebugLogEntry[],
   label: string,
   fn: (client: MCPClient) => Promise<T>,
-  transportFetch?: typeof fetch
+  transportFetch?: typeof fetch,
+  requestOptions: { signal?: AbortSignal; requestTimeoutMs?: number } = {}
 ): Promise<T> {
   const signingContext = signingContextStorage.getStore();
   const baseUrl = new URL(agentUrl);
 
-  if (transportFetch) {
-    const guardedClient = await connectMCPWithFallback(baseUrl, authHeaders, debugLogs, label, transportFetch);
+  if (transportFetch || requestOptions.signal || requestOptions.requestTimeoutMs !== undefined) {
+    const guardedClient = await connectMCPWithFallback(
+      baseUrl,
+      authHeaders,
+      debugLogs,
+      label,
+      transportFetch,
+      requestOptions
+    );
     try {
       return await fn(guardedClient);
     } finally {
@@ -413,7 +440,7 @@ export async function withCachedConnection<T>(
   }
 
   const cacheKey = connectionCacheKey(agentUrl, authToken, signingContext?.cacheKey, authHeaders);
-  const mcpClient = await getOrCreateConnection(cacheKey, baseUrl, authHeaders, debugLogs, label);
+  const mcpClient = await getOrCreateConnection(cacheKey, baseUrl, authHeaders, debugLogs, label, requestOptions);
 
   try {
     return await fn(mcpClient);
@@ -450,7 +477,14 @@ export async function withCachedConnection<T>(
       /* ignore */
     }
 
-    const retryClient = await getOrCreateConnection(cacheKey, baseUrl, authHeaders, debugLogs, `${label} (retry)`);
+    const retryClient = await getOrCreateConnection(
+      cacheKey,
+      baseUrl,
+      authHeaders,
+      debugLogs,
+      `${label} (retry)`,
+      requestOptions
+    );
 
     try {
       return await fn(retryClient);
@@ -484,6 +518,10 @@ export interface MCPCallOptions {
   customHeaders?: Record<string, string>;
   /** RFC 9421 signing context — when set, the transport signs outbound ops per seller capability. */
   signingContext?: AgentSigningContext;
+  /** Caller-owned cancellation signal for connect and callTool. */
+  signal?: AbortSignal;
+  /** Optional per-request timeout for connect and callTool. */
+  requestTimeoutMs?: number;
 }
 
 /**
@@ -513,7 +551,8 @@ export async function connectMCPWithFallback(
   authHeaders: Record<string, string>,
   debugLogs: DebugLogEntry[] = [],
   label = 'connection',
-  transportFetch?: typeof fetch
+  transportFetch?: typeof fetch,
+  requestOptions: { signal?: AbortSignal; requestTimeoutMs?: number } = {}
 ): Promise<MCPClient> {
   return withSpan(
     'adcp.mcp.connect',
@@ -522,7 +561,7 @@ export async function connectMCPWithFallback(
       'adcp.connection_label': label,
     },
     async () => {
-      return connectMCPWithFallbackImpl(url, authHeaders, debugLogs, label, transportFetch);
+      return connectMCPWithFallbackImpl(url, authHeaders, debugLogs, label, transportFetch, requestOptions);
     }
   );
 }
@@ -532,14 +571,25 @@ async function connectMCPWithFallbackImpl(
   authHeaders: Record<string, string>,
   debugLogs: DebugLogEntry[] = [],
   label = 'connection',
-  transportFetch?: typeof fetch
+  transportFetch?: typeof fetch,
+  requestOptions: { signal?: AbortSignal; requestTimeoutMs?: number } = {}
 ): Promise<MCPClient> {
   const signingContext = signingContextStorage.getStore();
   // Wrap order (innermost → outermost): network → size-limit → signing → capture.
   // Size-limit applies to the raw network response so signing/capture see a
   // bounded body (capture clones via `response.clone()`, which would otherwise
   // buffer a hostile reply in memory).
-  const networkFetch = transportFetch ?? ((input, init) => fetch(input as any, init));
+  const requestTimeoutMs = resolveRequestTimeoutMs(requestOptions.requestTimeoutMs);
+  const clientRequestTimeoutMs = resolveClientRequestTimeoutMs(requestOptions.requestTimeoutMs);
+  const mcpRequestOptions = {
+    ...(requestOptions.signal && { signal: requestOptions.signal }),
+    ...(clientRequestTimeoutMs !== undefined && { timeout: clientRequestTimeoutMs }),
+  };
+  const rawNetworkFetch: typeof fetch = transportFetch ?? ((input, init) => fetch(input as any, init));
+  const networkFetch = (input: Parameters<typeof fetch>[0], init?: RequestInit) =>
+    withAbortSignal<Response>([requestOptions.signal, init?.signal], requestTimeoutMs, signal =>
+      rawNetworkFetch(input, { ...init, signal })
+    );
   const sizeLimited = wrapFetchWithSizeLimit(networkFetch);
   const diagnosticFetch = wrapFetchWithTransportDiagnostics(sizeLimited);
   const baseFetch: typeof fetch = signingContext
@@ -563,7 +613,7 @@ async function connectMCPWithFallbackImpl(
       message: `MCP: Attempting StreamableHTTP ${label} to ${url}`,
       timestamp: new Date().toISOString(),
     });
-    await client.connect(new StreamableHTTPClientTransport(url, transportOptions));
+    await client.connect(new StreamableHTTPClientTransport(url, transportOptions), mcpRequestOptions);
     failedClient = undefined;
     trackStreamableHTTPUrl(url.toString());
     debugLogs.push({
@@ -592,6 +642,10 @@ async function connectMCPWithFallbackImpl(
       error,
     });
 
+    if (isAbortOrTimeoutError(error)) {
+      throw error;
+    }
+
     // Retry StreamableHTTP once on any transient connect failure — network blips,
     // JSON parse errors on half-buffered responses, and mid-handshake proxy
     // disconnects all surface as generic Error or McpError, not StreamableHTTPError.
@@ -604,7 +658,7 @@ async function connectMCPWithFallbackImpl(
       });
       const retryClient = new MCPClient({ name: 'AdCP-Client', version: '1.0.0' });
       try {
-        await retryClient.connect(new StreamableHTTPClientTransport(url, transportOptions));
+        await retryClient.connect(new StreamableHTTPClientTransport(url, transportOptions), mcpRequestOptions);
         trackStreamableHTTPUrl(url.toString());
         debugLogs.push({
           type: 'success',
@@ -623,6 +677,9 @@ async function connectMCPWithFallbackImpl(
           message: `MCP: StreamableHTTP retry also failed for ${label}: ${retryError instanceof Error ? retryError.message : String(retryError)}`,
           timestamp: new Date().toISOString(),
         });
+        if (isAbortOrTimeoutError(retryError)) {
+          throw retryError;
+        }
         // Fall through to SSE fallback below
       }
     }
@@ -652,12 +709,22 @@ async function connectMCPWithFallbackImpl(
       timestamp: new Date().toISOString(),
     });
     const client = new MCPClient({ name: 'AdCP-Client', version: '1.0.0' });
-    await client.connect(
-      new SSEClientTransport(url, {
-        requestInit: { headers: authHeaders, ...(transportFetch ? { redirect: 'manual' as const } : {}) },
-        fetch: wrapFetchWithCapture(baseFetch),
-      })
-    );
+    try {
+      await client.connect(
+        new SSEClientTransport(url, {
+          requestInit: { headers: authHeaders, ...(transportFetch ? { redirect: 'manual' as const } : {}) },
+          fetch: wrapFetchWithCapture(baseFetch),
+        }),
+        mcpRequestOptions
+      );
+    } catch (sseError) {
+      try {
+        await client.close();
+      } catch {
+        /* ignore */
+      }
+      throw sseError;
+    }
     debugLogs.push({
       type: 'success',
       message: `MCP: Connected via SSE transport for ${label}`,
@@ -675,7 +742,8 @@ export async function callMCPTool(
   debugLogs: DebugLogEntry[] = [],
   customHeaders?: Record<string, string>,
   signingContext?: AgentSigningContext,
-  transportFetch?: typeof fetch
+  transportFetch?: typeof fetch,
+  requestOptions?: { signal?: AbortSignal; requestTimeoutMs?: number }
 ): Promise<unknown> {
   return withSpan(
     'adcp.mcp.call_tool',
@@ -685,7 +753,7 @@ export async function callMCPTool(
     },
     async () => {
       return signingContextStorage.run(signingContext, () =>
-        callMCPToolImpl(agentUrl, toolName, args, authToken, debugLogs, customHeaders, transportFetch)
+        callMCPToolImpl(agentUrl, toolName, args, authToken, debugLogs, customHeaders, transportFetch, requestOptions)
       );
     }
   );
@@ -717,7 +785,8 @@ async function callMCPToolImpl(
   authToken?: string,
   debugLogs: DebugLogEntry[] = [],
   customHeaders?: Record<string, string>,
-  transportFetch?: typeof fetch
+  transportFetch?: typeof fetch,
+  requestOptions?: { signal?: AbortSignal; requestTimeoutMs?: number }
 ): Promise<unknown> {
   // Inject trace context headers for distributed tracing
   const traceHeaders = injectTraceHeaders();
@@ -753,14 +822,24 @@ async function callMCPToolImpl(
     });
   }
 
+  const resolvedRequestTimeoutMs = resolveClientRequestTimeoutMs(requestOptions?.requestTimeoutMs);
   const response = await withCachedConnection(
     agentUrl,
     authToken,
     authHeaders,
     debugLogs,
     toolName,
-    client => client.callTool({ name: toolName, arguments: args }) as Promise<CallToolResponse>,
-    transportFetch
+    client =>
+      client.callTool(
+        { name: toolName, arguments: args },
+        undefined,
+        {
+          ...(requestOptions?.signal && { signal: requestOptions.signal }),
+          ...(resolvedRequestTimeoutMs !== undefined && { timeout: resolvedRequestTimeoutMs }),
+        }
+      ) as Promise<CallToolResponse>,
+    transportFetch,
+    requestOptions
   );
 
   debugLogs.push({
@@ -844,8 +923,19 @@ export async function connectMCP(options: {
   debugLogs?: DebugLogEntry[];
   customHeaders?: Record<string, string>;
   signingContext?: AgentSigningContext;
+  signal?: AbortSignal;
+  requestTimeoutMs?: number;
 }): Promise<MCPConnectionResult> {
-  const { agentUrl, authToken, authProvider, debugLogs = [], customHeaders, signingContext } = options;
+  const {
+    agentUrl,
+    authToken,
+    authProvider,
+    debugLogs = [],
+    customHeaders,
+    signingContext,
+    signal,
+    requestTimeoutMs: configuredRequestTimeoutMs,
+  } = options;
   const baseUrl = new URL(agentUrl);
 
   debugLogs.push({
@@ -911,7 +1001,17 @@ export async function connectMCP(options: {
   // headers the SDK assembled (including any OAuth-issued Authorization) and
   // decides per outbound request whether to sign. Size-limit sits innermost so
   // the response body is bounded before signing/capture observe it.
-  const sizeLimited = wrapFetchWithSizeLimit((input, init) => fetch(input as string | URL, init));
+  const requestTimeoutMs = resolveRequestTimeoutMs(configuredRequestTimeoutMs);
+  const clientRequestTimeoutMs = resolveClientRequestTimeoutMs(configuredRequestTimeoutMs);
+  const requestOptions = {
+    ...(signal && { signal }),
+    ...(clientRequestTimeoutMs !== undefined && { timeout: clientRequestTimeoutMs }),
+  };
+  const sizeLimited = wrapFetchWithSizeLimit((input, init) =>
+    withAbortSignal<Response>([signal, init?.signal], requestTimeoutMs, linkedSignal =>
+      fetch(input as string | URL, { ...init, signal: linkedSignal })
+    )
+  );
   const diagnosticFetch = wrapFetchWithTransportDiagnostics(sizeLimited);
   const signedFetch: typeof fetch = signingContext
     ? (buildAgentSigningFetch({
@@ -925,7 +1025,7 @@ export async function connectMCP(options: {
   const transport = new StreamableHTTPClientTransport(baseUrl, transportOptions);
 
   try {
-    await mcpClient.connect(transport);
+    await mcpClient.connect(transport, requestOptions);
     debugLogs.push({
       type: 'success',
       message: 'MCP: Connected successfully',
@@ -1004,11 +1104,30 @@ export async function connectMCP(options: {
  * @throws UnauthorizedError if OAuth is required (with transport attached)
  */
 export async function callMCPToolWithOAuth(options: MCPCallOptions): Promise<unknown> {
-  const { agentUrl, toolName, args, authToken, authProvider, debugLogs = [], customHeaders, signingContext } = options;
+  const {
+    agentUrl,
+    toolName,
+    args,
+    authToken,
+    authProvider,
+    debugLogs = [],
+    customHeaders,
+    signingContext,
+    signal,
+    requestTimeoutMs,
+  } = options;
+  const resolvedRequestTimeoutMs = resolveClientRequestTimeoutMs(requestTimeoutMs);
+  const requestOptions = {
+    ...(signal && { signal }),
+    ...(resolvedRequestTimeoutMs !== undefined && { timeout: resolvedRequestTimeoutMs }),
+  };
 
   // If no OAuth provider, use the legacy function
   if (!authProvider) {
-    return callMCPTool(agentUrl, toolName, args, authToken, debugLogs, customHeaders, signingContext);
+    return callMCPTool(agentUrl, toolName, args, authToken, debugLogs, customHeaders, signingContext, undefined, {
+      signal,
+      requestTimeoutMs,
+    });
   }
 
   const response = await withCachedOAuthConnection(
@@ -1018,6 +1137,8 @@ export async function callMCPToolWithOAuth(options: MCPCallOptions): Promise<unk
       debugLogs,
       customHeaders,
       signingContext,
+      signal,
+      requestTimeoutMs,
     },
     toolName,
     async client => {
@@ -1027,10 +1148,7 @@ export async function callMCPToolWithOAuth(options: MCPCallOptions): Promise<unk
         timestamp: new Date().toISOString(),
       });
 
-      const response = await client.callTool({
-        name: toolName,
-        arguments: args,
-      });
+      const response = await client.callTool({ name: toolName, arguments: args }, undefined, requestOptions);
 
       debugLogs.push({
         type: response?.isError ? 'error' : 'success',

--- a/src/lib/protocols/mcp.ts
+++ b/src/lib/protocols/mcp.ts
@@ -77,7 +77,7 @@ function trackStreamableHTTPUrl(url: string): void {
 }
 
 /**
- * Build the connection-cache key for a (URL, credential, signing-context)
+ * Build the connection-cache key for a (URL, credential/header, signing-context)
  * triple.
  *
  * Two credential paths feed this cache. The bearer path supplies `authToken`
@@ -91,11 +91,9 @@ function trackStreamableHTTPUrl(url: string): void {
  * behalf of N principals would silently leak credentials across the
  * connection boundary.
  *
- * Fix: when `authToken` is unset, derive the fingerprint from the
- * `Authorization` header on `authHeaders` (case-insensitive lookup, since
- * header keys vary by call site). The shared `createSha256Prefix` helper
- * keeps both paths byte-equivalent for compatibility with existing cache
- * entries.
+ * Also include non-trace custom headers in the key. Tenant/routing headers can
+ * select a different upstream seller or credential context even when the bearer
+ * token is identical.
  */
 function connectionCacheKey(
   agentUrl: string,
@@ -103,9 +101,13 @@ function connectionCacheKey(
   signingCacheKey?: string,
   authHeaders?: Record<string, string>
 ): string {
+  const parts = [agentUrl];
   const fingerprint = authToken ?? extractAuthHeader(authHeaders);
-  const base = fingerprint ? `${agentUrl}::${cacheDisambiguator(fingerprint)}` : agentUrl;
-  return signingCacheKey ? `${base}::${signingCacheKey}` : base;
+  if (fingerprint) parts.push(cacheDisambiguator(fingerprint));
+  const headersKey = headersCacheDisambiguator(authHeaders);
+  if (headersKey) parts.push(`headers:${headersKey}`);
+  if (signingCacheKey) parts.push(signingCacheKey);
+  return parts.join('::');
 }
 
 /**
@@ -142,6 +144,17 @@ function extractAuthHeader(headers?: Record<string, string>): string | undefined
     if (key.toLowerCase() === 'authorization' && value) return value;
   }
   return undefined;
+}
+
+function headersCacheDisambiguator(headers?: Record<string, string>): string | undefined {
+  const entries = Object.entries(headers ?? {})
+    .filter(([key]) => {
+      const lower = key.toLowerCase();
+      return lower !== 'traceparent' && lower !== 'tracestate' && lower !== 'baggage';
+    })
+    .map(([key, value]) => [key.toLowerCase(), value] as const)
+    .sort(([a], [b]) => a.localeCompare(b));
+  return entries.length > 0 ? cacheDisambiguator(JSON.stringify(entries)) : undefined;
 }
 
 /** Get a cached connection, refreshing its LRU position. */
@@ -253,11 +266,7 @@ function getOAuthProviderDisambiguator(authProvider: OAuthClientProvider): strin
 }
 
 function customHeadersDisambiguator(customHeaders?: Record<string, string>): string | undefined {
-  const entries = Object.entries(customHeaders ?? {})
-    .filter(([key]) => key.toLowerCase() !== 'authorization')
-    .map(([key, value]) => [key.toLowerCase(), value] as const)
-    .sort(([a], [b]) => a.localeCompare(b));
-  return entries.length > 0 ? cacheDisambiguator(JSON.stringify(entries)) : undefined;
+  return headersCacheDisambiguator(customHeaders);
 }
 
 function oauthConnectionCacheKey(
@@ -375,6 +384,10 @@ async function withCachedOAuthConnection<T>(
       throw error;
     }
 
+    if (isAbortOrTimeoutError(error)) {
+      throw error;
+    }
+
     oauthConnectionCache.delete(cacheKey);
     try {
       await mcpClient.close();
@@ -466,6 +479,10 @@ export async function withCachedConnection<T>(
         message: `MCP: Authentication issue detected for ${label} - headers may not be reaching server`,
         timestamp: new Date().toISOString(),
       });
+      throw error;
+    }
+
+    if (isAbortOrTimeoutError(error)) {
       throw error;
     }
 

--- a/src/lib/protocols/mcp.ts
+++ b/src/lib/protocols/mcp.ts
@@ -18,7 +18,12 @@ import { redactIdempotencyKeyInArgs } from '../utils/idempotency';
 import { wrapFetchWithCapture } from './rawResponseCapture';
 import { wrapFetchWithSizeLimit } from './responseSizeLimit';
 import { wrapFetchWithTransportDiagnostics } from './transportDiagnostics';
-import { isAbortOrTimeoutError, resolveClientRequestTimeoutMs, resolveRequestTimeoutMs, withAbortSignal } from './abort';
+import {
+  isAbortOrTimeoutError,
+  resolveClientRequestTimeoutMs,
+  resolveRequestTimeoutMs,
+  withAbortSignal,
+} from './abort';
 
 // Re-export for convenience
 export { UnauthorizedError };
@@ -847,14 +852,10 @@ async function callMCPToolImpl(
     debugLogs,
     toolName,
     client =>
-      client.callTool(
-        { name: toolName, arguments: args },
-        undefined,
-        {
-          ...(requestOptions?.signal && { signal: requestOptions.signal }),
-          ...(resolvedRequestTimeoutMs !== undefined && { timeout: resolvedRequestTimeoutMs }),
-        }
-      ) as Promise<CallToolResponse>,
+      client.callTool({ name: toolName, arguments: args }, undefined, {
+        ...(requestOptions?.signal && { signal: requestOptions.signal }),
+        ...(resolvedRequestTimeoutMs !== undefined && { timeout: resolvedRequestTimeoutMs }),
+      }) as Promise<CallToolResponse>,
     transportFetch,
     requestOptions
   );

--- a/src/lib/signing/capability-priming.ts
+++ b/src/lib/signing/capability-priming.ts
@@ -3,6 +3,7 @@ import type { AgentSigningContext } from './agent-context';
 import type { CachedCapability } from './capability-cache';
 import { unwrapProtocolResponse } from './protocol-response';
 import type { VerifierCapability } from './types';
+import { isAbortOrTimeoutError } from '../protocols/abort';
 
 /**
  * Op name used to fetch the seller's capability advertisement. The signing
@@ -87,7 +88,10 @@ export async function ensureCapabilityLoaded(
       cache.set(key, entry);
       return entry;
     })
-    .catch(() => {
+    .catch(error => {
+      if (isAbortOrTimeoutError(error)) {
+        throw error;
+      }
       const now = Math.floor(Date.now() / 1000);
       const entry: CachedCapability = {
         requestSigning: undefined,

--- a/src/lib/testing/client.ts
+++ b/src/lib/testing/client.ts
@@ -310,7 +310,7 @@ export async function getOrDiscoverProfile(
       step: { step: 'Discover agent capabilities', passed: true, duration_ms: 0 },
     };
   }
-  return discoverAgentProfile(client);
+  return discoverAgentProfile(client, options.signal);
 }
 
 /**
@@ -432,7 +432,7 @@ export async function discoverAgentProfile(
   signal?: AbortSignal
 ): Promise<{ profile: AgentProfile; step: TestStepResult }> {
   const { result: agentInfo, step } = await runStep('Discover agent capabilities', 'getAgentInfo', () =>
-    raceWithSignal(client.getAgentInfo(), signal)
+    raceWithSignal(client.getAgentInfo({ signal }), signal)
   );
 
   const profile: AgentProfile = {
@@ -454,7 +454,7 @@ export async function discoverAgentProfile(
 
   if (profile.tools.includes('get_adcp_capabilities')) {
     try {
-      const caps = (await raceWithSignal(client.getAdcpCapabilities({}), signal)) as TaskResult;
+      const caps = (await raceWithSignal(client.getAdcpCapabilities({}, undefined, { signal }), signal)) as TaskResult;
       if (caps?.success && caps?.data) {
         profile.raw_capabilities = caps.data;
         const parsed = parseCapabilitiesResponse(caps.data);

--- a/src/lib/testing/types.ts
+++ b/src/lib/testing/types.ts
@@ -75,6 +75,8 @@ export type TestScenario =
 export interface TestOptions {
   // Protocol to use for testing (default: 'mcp')
   protocol?: 'mcp' | 'a2a';
+  /** Optional cancellation signal for discovery and storyboard helper calls. */
+  signal?: AbortSignal;
   /**
    * AdCP protocol version the test client should speak. Storyboard runners
    * set this from the compliance cache version instead of relying on the

--- a/test/read-path-abort-timeout.test.js
+++ b/test/read-path-abort-timeout.test.js
@@ -242,6 +242,7 @@ describe('read-path cancellation and timeout', () => {
 
   it('passes requestTimeoutMs to MCP Tasks before a task id is captured', async () => {
     let seenTimeout;
+    let seenMaxTotalTimeout;
     const timeoutError = new Error('Request timed out');
     timeoutError.code = -32001;
     const client = {
@@ -251,6 +252,7 @@ describe('read-path cancellation and timeout', () => {
         tasks: {
           callToolStream: (_request, _unused, options) => {
             seenTimeout = options.timeout;
+            seenMaxTotalTimeout = options.maxTotalTimeout;
             return (async function* () {
               throw timeoutError;
             })();
@@ -263,6 +265,7 @@ describe('read-path cancellation and timeout', () => {
       callMCPToolWithClient(client, 'get_products', {}, [], { workingTimeout: 120000, requestTimeoutMs: 25 })
     );
     assert.strictEqual(seenTimeout, 25);
+    assert.strictEqual(seenMaxTotalTimeout, undefined);
   });
 
   it('attaches generated idempotency keys to mutating timeout errors', async () => {

--- a/test/read-path-abort-timeout.test.js
+++ b/test/read-path-abort-timeout.test.js
@@ -9,6 +9,7 @@ const { connectMCPWithFallback } = require('../dist/lib/protocols/mcp');
 const { MAX_TIMER_DELAY_MS, resolveClientRequestTimeoutMs } = require('../dist/lib/protocols/abort');
 const { callMCPToolWithClient } = require('../dist/lib/protocols/mcp-tasks');
 const { getOrDiscoverProfile } = require('../dist/lib/testing/client');
+const { CapabilityCache, ensureCapabilityLoaded } = require('../dist/lib/signing/client');
 
 describe('read-path cancellation and timeout', () => {
   let server;
@@ -60,6 +61,56 @@ describe('read-path cancellation and timeout', () => {
         return true;
       }
     );
+  });
+
+  it('forwards custom headers during A2A getAgentInfo agent-card discovery', async () => {
+    const headerServer = http.createServer((req, res) => {
+      if (req.url === '/.well-known/agent.json' || req.url === '/.well-known/agent-card.json') {
+        if (req.headers['x-adcp-tenant'] !== 'tenant-1') {
+          res.writeHead(403);
+          res.end('missing tenant header');
+          return;
+        }
+        const { port } = headerServer.address();
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(
+          JSON.stringify({
+            protocolVersion: '0.3.0',
+            name: 'tenant-card',
+            description: 'tenant scoped card',
+            url: `http://127.0.0.1:${port}/rpc`,
+            preferredTransport: 'JSONRPC',
+            version: '1.0.0',
+            defaultInputModes: ['application/json'],
+            defaultOutputModes: ['application/json'],
+            capabilities: { streaming: false, pushNotifications: false },
+            skills: [{ id: 'get_products', name: 'get_products', description: 'discover', tags: ['adcp'] }],
+          })
+        );
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+
+    await new Promise(resolve => headerServer.listen(0, '127.0.0.1', resolve));
+    const { port } = headerServer.address();
+
+    try {
+      const client = new AgentClient({
+        id: 'tenant-a2a',
+        agent_uri: `http://127.0.0.1:${port}`,
+        protocol: 'a2a',
+        name: 'test',
+        headers: { 'x-adcp-tenant': 'tenant-1' },
+      });
+
+      const info = await client.getAgentInfo();
+      assert.strictEqual(info.name, 'tenant-card');
+      assert.ok(info.tools.some(tool => tool.name === 'get_products'));
+    } finally {
+      await new Promise(resolve => headerServer.close(resolve));
+    }
   });
 
   it('lets callers abort getProducts while it is still in read-path discovery', async () => {
@@ -295,6 +346,33 @@ describe('read-path cancellation and timeout', () => {
     } finally {
       ProtocolClient.callTool = originalCallTool;
     }
+  });
+
+  it('does not negative-cache request-signing capability after timeout', async () => {
+    const cache = new CapabilityCache();
+    const capabilityCacheKey = 'agent::sig=test';
+    const signingContext = {
+      cache,
+      capabilityCacheKey,
+      getCapability: () => cache.get(capabilityCacheKey),
+      invalidate: () => cache.invalidate(capabilityCacheKey),
+    };
+    const timeoutError = new Error('Request timed out');
+    timeoutError.name = 'TimeoutError';
+
+    await assert.rejects(
+      () => ensureCapabilityLoaded({}, signingContext, async () => Promise.reject(timeoutError)),
+      err => err === timeoutError
+    );
+    assert.strictEqual(cache.get(capabilityCacheKey), undefined);
+
+    const recovered = await ensureCapabilityLoaded({}, signingContext, async () => ({
+      request_signing: { required_for: ['create_media_buy'] },
+      adcp: { major_versions: [3] },
+    }));
+
+    assert.deepStrictEqual(recovered.requestSigning, { required_for: ['create_media_buy'] });
+    assert.strictEqual(cache.get(capabilityCacheKey), recovered);
   });
 
   it('forwards getOrDiscoverProfile signal into profile discovery', async () => {

--- a/test/read-path-abort-timeout.test.js
+++ b/test/read-path-abort-timeout.test.js
@@ -250,14 +250,9 @@ describe('read-path cancellation and timeout', () => {
 
     await assert.rejects(
       () =>
-        connectMCPWithFallback(
-          new URL('http://example.test/mcp'),
-          {},
-          debugLogs,
-          'timeout-test',
-          transportFetch,
-          { requestTimeoutMs: 25 }
-        ),
+        connectMCPWithFallback(new URL('http://example.test/mcp'), {}, debugLogs, 'timeout-test', transportFetch, {
+          requestTimeoutMs: 25,
+        }),
       err => {
         assert.ok(err?.name === 'TimeoutError' || err?.code === -32001);
         return true;

--- a/test/read-path-abort-timeout.test.js
+++ b/test/read-path-abort-timeout.test.js
@@ -1,0 +1,316 @@
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert');
+const http = require('node:http');
+
+const { AgentClient } = require('../dist/lib/core/AgentClient');
+const { TaskExecutor } = require('../dist/lib/core/TaskExecutor');
+const { ProtocolClient } = require('../dist/lib/protocols');
+const { connectMCPWithFallback } = require('../dist/lib/protocols/mcp');
+const { MAX_TIMER_DELAY_MS, resolveClientRequestTimeoutMs } = require('../dist/lib/protocols/abort');
+const { callMCPToolWithClient } = require('../dist/lib/protocols/mcp-tasks');
+const { getOrDiscoverProfile } = require('../dist/lib/testing/client');
+
+describe('read-path cancellation and timeout', () => {
+  let server;
+  let baseUrl;
+  const sockets = new Set();
+
+  before(async () => {
+    server = http.createServer((req, res) => {
+      if (
+        req.url === '/.well-known/agent.json' ||
+        req.url === '/.well-known/agent-card.json' ||
+        req.url?.startsWith('/mcp')
+      ) {
+        // Deliberately hold the connection open. The client-side signal or
+        // timeout must reclaim the fetch rather than waiting for the server.
+        req.on('close', () => {
+          res.destroy();
+        });
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+    server.on('connection', socket => {
+      sockets.add(socket);
+      socket.on('close', () => sockets.delete(socket));
+    });
+    await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+    const { port } = server.address();
+    baseUrl = `http://127.0.0.1:${port}`;
+  });
+
+  after(async () => {
+    for (const socket of sockets) socket.destroy();
+    await new Promise(resolve => server.close(resolve));
+  });
+
+  it('bounds A2A getAgentInfo agent-card discovery with requestTimeoutMs', async () => {
+    const client = new AgentClient(
+      { id: 'hanging-a2a', agent_uri: baseUrl, protocol: 'a2a', name: 'test' },
+      { transport: { requestTimeoutMs: 25 } }
+    );
+
+    await assert.rejects(
+      () => client.getAgentInfo(),
+      err => {
+        assert.strictEqual(err?.name, 'TimeoutError');
+        assert.match(err.message, /25 ms/);
+        return true;
+      }
+    );
+  });
+
+  it('lets callers abort getProducts while it is still in read-path discovery', async () => {
+    const client = new AgentClient({ id: 'abort-a2a', agent_uri: baseUrl, protocol: 'a2a', name: 'test' });
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), 25);
+
+    await assert.rejects(
+      () =>
+        client.getProducts({ buying_mode: 'brief', brief: 'coffee' }, undefined, {
+          signal: controller.signal,
+          transport: { requestTimeoutMs: 0 },
+        }),
+      err => {
+        assert.strictEqual(err?.name, 'AbortError');
+        return true;
+      }
+    );
+  });
+
+  it('normalizes primitive abort reasons to AbortError', async () => {
+    const client = new AgentClient({ id: 'primitive-abort-a2a', agent_uri: baseUrl, protocol: 'a2a', name: 'test' });
+    const controller = new AbortController();
+    setTimeout(() => controller.abort('cancelled'), 25);
+
+    await assert.rejects(
+      () =>
+        client.getProducts({ buying_mode: 'brief', brief: 'coffee' }, undefined, {
+          signal: controller.signal,
+          transport: { requestTimeoutMs: 0 },
+        }),
+      err => {
+        assert.strictEqual(err?.name, 'AbortError');
+        assert.match(err.message, /cancelled/);
+        return true;
+      }
+    );
+  });
+
+  it('normalizes Error abort reasons to AbortError', async () => {
+    const client = new AgentClient({ id: 'error-abort-a2a', agent_uri: baseUrl, protocol: 'a2a', name: 'test' });
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(new Error('cancelled by caller')), 25);
+
+    await assert.rejects(
+      () =>
+        client.getProducts({ buying_mode: 'brief', brief: 'coffee' }, undefined, {
+          signal: controller.signal,
+          transport: { requestTimeoutMs: 0 },
+        }),
+      err => {
+        assert.strictEqual(err?.name, 'AbortError');
+        assert.match(err.message, /cancelled by caller/);
+        return true;
+      }
+    );
+  });
+
+  it('preserves MCP discovery timeout errors instead of generic endpoint failure', async () => {
+    const client = new AgentClient(
+      { id: 'hanging-mcp', agent_uri: `${baseUrl}/mcp`, protocol: 'mcp', name: 'test' },
+      { transport: { requestTimeoutMs: 25 } }
+    );
+
+    await assert.rejects(
+      () => client.getAgentInfo(),
+      err => {
+        assert.ok(err?.name === 'TimeoutError' || err?.code === -32001);
+        assert.doesNotMatch(err.message, /Failed to discover MCP endpoint/);
+        return true;
+      }
+    );
+  });
+
+  it('lets generic executeTask callers abort during read-path preflight', async () => {
+    const client = new AgentClient({ id: 'generic-abort-a2a', agent_uri: baseUrl, protocol: 'a2a', name: 'test' });
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), 25);
+
+    await assert.rejects(
+      () =>
+        client.executeTask('get_products', { buying_mode: 'brief', brief: 'coffee' }, undefined, {
+          signal: controller.signal,
+          transport: { requestTimeoutMs: 0 },
+        }),
+      err => {
+        assert.strictEqual(err?.name, 'AbortError');
+        return true;
+      }
+    );
+  });
+
+  it('rejects invalid requestTimeoutMs values instead of treating them as disabled', async () => {
+    const client = new AgentClient(
+      { id: 'invalid-timeout-a2a', agent_uri: baseUrl, protocol: 'a2a', name: 'test' },
+      { transport: { requestTimeoutMs: -1 } }
+    );
+
+    await assert.rejects(
+      () => client.getAgentInfo(),
+      err => {
+        assert.ok(err instanceof RangeError);
+        assert.match(err.message, /requestTimeoutMs/);
+        return true;
+      }
+    );
+  });
+
+  it('rejects requestTimeoutMs values above the platform timer cap', async () => {
+    const client = new AgentClient(
+      { id: 'too-large-timeout-a2a', agent_uri: baseUrl, protocol: 'a2a', name: 'test' },
+      { transport: { requestTimeoutMs: MAX_TIMER_DELAY_MS + 1 } }
+    );
+
+    await assert.rejects(
+      () => client.getAgentInfo(),
+      err => {
+        assert.ok(err instanceof RangeError);
+        assert.match(err.message, /requestTimeoutMs/);
+        return true;
+      }
+    );
+  });
+
+  it('does not retry or fall back to SSE after an MCP connect timeout', async () => {
+    const debugLogs = [];
+    const transportFetch = async (_input, init = {}) => {
+      return new Promise((_resolve, reject) => {
+        const signal = init.signal;
+        if (signal?.aborted) {
+          reject(signal.reason);
+          return;
+        }
+        signal?.addEventListener('abort', () => reject(signal.reason), { once: true });
+      });
+    };
+
+    await assert.rejects(
+      () =>
+        connectMCPWithFallback(
+          new URL('http://example.test/mcp'),
+          {},
+          debugLogs,
+          'timeout-test',
+          transportFetch,
+          { requestTimeoutMs: 25 }
+        ),
+      err => {
+        assert.ok(err?.name === 'TimeoutError' || err?.code === -32001);
+        return true;
+      }
+    );
+    assert.ok(!debugLogs.some(log => /retry|Falling back to SSE/i.test(log.message)));
+  });
+
+  it('keeps MCP Tasks stream timeout pollable after a task id is captured', async () => {
+    const timeoutError = new Error('Request timed out');
+    timeoutError.code = -32001;
+    const client = {
+      getServerCapabilities: () => ({ tasks: { requests: { tools: { call: true } } } }),
+      listTools: async () => ({ tools: [] }),
+      experimental: {
+        tasks: {
+          callToolStream: async function* () {
+            yield { type: 'taskCreated', task: { taskId: 'task-1', status: 'working', pollInterval: 123 } };
+            throw timeoutError;
+          },
+        },
+      },
+    };
+
+    const response = await callMCPToolWithClient(client, 'get_products', {}, [], { workingTimeout: 1 });
+
+    assert.deepStrictEqual(response.structuredContent, {
+      status: 'working',
+      task_id: 'task-1',
+      poll_interval: 123,
+    });
+  });
+
+  it('passes requestTimeoutMs to MCP Tasks before a task id is captured', async () => {
+    let seenTimeout;
+    const timeoutError = new Error('Request timed out');
+    timeoutError.code = -32001;
+    const client = {
+      getServerCapabilities: () => ({ tasks: { requests: { tools: { call: true } } } }),
+      listTools: async () => ({ tools: [] }),
+      experimental: {
+        tasks: {
+          callToolStream: (_request, _unused, options) => {
+            seenTimeout = options.timeout;
+            return (async function* () {
+              throw timeoutError;
+            })();
+          },
+        },
+      },
+    };
+
+    await assert.rejects(() =>
+      callMCPToolWithClient(client, 'get_products', {}, [], { workingTimeout: 120000, requestTimeoutMs: 25 })
+    );
+    assert.strictEqual(seenTimeout, 25);
+  });
+
+  it('attaches generated idempotency keys to mutating timeout errors', async () => {
+    const originalCallTool = ProtocolClient.callTool;
+    const timeoutError = new Error('Request timed out');
+    timeoutError.name = 'TimeoutError';
+    ProtocolClient.callTool = async () => {
+      throw timeoutError;
+    };
+
+    try {
+      const executor = new TaskExecutor();
+      await assert.rejects(
+        () =>
+          executor.executeTask(
+            { id: 'timeout-mutating', name: 'test', protocol: 'mcp', agent_uri: 'http://example.test/mcp' },
+            'create_media_buy',
+            { buyer_ref: 'buyer-1', packages: [] }
+          ),
+        err => {
+          assert.strictEqual(err.name, 'TimeoutError');
+          assert.ok(err.idempotency_key);
+          assert.strictEqual(err.idempotencyKey, err.idempotency_key);
+          return true;
+        }
+      );
+    } finally {
+      ProtocolClient.callTool = originalCallTool;
+    }
+  });
+
+  it('forwards getOrDiscoverProfile signal into profile discovery', async () => {
+    const controller = new AbortController();
+    let receivedSignal;
+    const client = {
+      getAgentInfo: async options => {
+        receivedSignal = options?.signal;
+        return { name: 'stub-agent', tools: [] };
+      },
+    };
+
+    const { profile } = await getOrDiscoverProfile(client, { signal: controller.signal });
+
+    assert.strictEqual(receivedSignal, controller.signal);
+    assert.strictEqual(profile.name, 'stub-agent');
+  });
+
+  it('maps requestTimeoutMs 0 to the MCP client timeout disable sentinel', () => {
+    assert.strictEqual(resolveClientRequestTimeoutMs(0), MAX_TIMER_DELAY_MS);
+  });
+});


### PR DESCRIPTION
Fixes #2308

## Summary

- Add caller-owned `AbortSignal` support across read-path calls, typed task calls, generic `executeTask`, MCP/A2A discovery, and compliance discovery helpers.
- Add bounded request timeout handling for A2A agent-card discovery and MCP read-path/client requests, including explicit validation and `requestTimeoutMs: 0` handling.
- Preserve cancellation/timeout semantics instead of converting them into synthetic capability fallbacks or failed task results, while attaching generated idempotency keys to mutating timeout errors for safe retry.
- Add focused regression coverage for A2A/MCP discovery timeout, abort propagation, MCP Tasks timeout precedence, helper signal forwarding, and timeout validation.

## Expert review

- Ran Conductor expert review agents: code review, protocol, ad-tech protocol, and security.
- Ran `npm run review:codex -- --all --base origin/main` repeatedly during the patch. Findings around MCP retry/fallback, capability timeout fallback, MCP Tasks precedence, polling signal threading, timeout bounds, primitive abort reasons, and mutating idempotency keys were addressed with code changes and regression tests.

## Testing

- `npm run build:lib`
- Pre-push validation: `npm run typecheck` and `npm run build:lib`
- `NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/read-path-abort-timeout.test.js test/unit/get-agent-info-size-limit.test.js test/unit/a2a-card-size-limit.test.js test/unit/mcp-tool-size-limit.test.js test/unit/mcp-discovery-sse-fallback.test.js test/unit/mcp-custom-fetch.test.js test/lib/mcp-auth-headers.test.js`  
  Result: 49 passed, 0 failed.
- `git diff --check`

## Notes

- I also attempted `npm run test:node:fast`; the new read-path regression suite passed inside that run, but the broad command failed due unrelated existing file-level 60s timeouts in CLI/schema/server test files.
