### PR TITLE
fix: emit version from capabilities handler

### DIFF
--- a/.changeset/capabilities-version-envelope.md
+++ b/.changeset/capabilities-version-envelope.md
@@ -1,0 +1,5 @@
+---
+"@adcp/sdk": patch
+---
+
+Emit `adcp_version` from the auto-registered `get_adcp_capabilities` server handler.

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -6289,7 +6289,9 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
       if (ctx !== null && typeof ctx === 'object' && !Array.isArray(ctx)) {
         (data as any).context = ctx;
       }
-      return applyResponseEnhancer(capabilitiesResponse(data));
+      const response = capabilitiesResponse(data);
+      injectVersionIntoResponse(response, servedAdcpVersion);
+      return applyResponseEnhancer(response);
     }) as Parameters<typeof server.registerTool>[2]
   );
   registeredToolNames.add('get_adcp_capabilities');

--- a/test/lib/adcp-version-string-emit.test.js
+++ b/test/lib/adcp-version-string-emit.test.js
@@ -9,6 +9,14 @@ const { test, describe } = require('node:test');
 const assert = require('node:assert');
 
 const { bundleSupportsAdcpVersionField, extractVersionUnsupportedDetails } = require('../../dist/lib/index.js');
+const { createAdcpServer } = require('../../dist/lib/server/create-adcp-server.js');
+
+async function callToolRaw(server, toolName, params) {
+  return server.dispatchTestRequest({
+    method: 'tools/call',
+    params: { name: toolName, arguments: params ?? {} },
+  });
+}
 
 describe('bundleSupportsAdcpVersionField gate', () => {
   test('3.0 stable bundle does not have the field', () => {
@@ -138,5 +146,22 @@ describe('extractVersionUnsupportedDetails', () => {
   test('partial population — supported_versions only', () => {
     const out = extractVersionUnsupportedDetails({ supported_versions: ['3.0'] });
     assert.deepStrictEqual(out, { supported_versions: ['3.0'] });
+  });
+});
+
+describe('createAdcpServer version emission', () => {
+  test('auto-registered get_adcp_capabilities emits adcp_version when pinned to 3.1', async () => {
+    const server = createAdcpServer({
+      name: 'Versioned Seller',
+      version: '1.0.0',
+      adcpVersion: '3.1',
+    });
+
+    const result = await callToolRaw(server, 'get_adcp_capabilities', {});
+    assert.strictEqual(result.structuredContent.adcp_version, '3.1');
+
+    const text = result.content?.find(part => part.type === 'text')?.text;
+    assert.ok(text, 'capabilities response should include a text fallback');
+    assert.match(text, /Agent capabilities/);
   });
 });


### PR DESCRIPTION
## Summary

- Stamp `adcp_version` on the auto-registered `get_adcp_capabilities` handler before response enhancement.
- Add targeted coverage for a 3.1-pinned server so the discovery response envelope includes `adcp_version`.
- Add a patch changeset.

Fixes #2300.

## Validation

- `npm run build:lib`
- `NODE_ENV=test node --test-timeout=60000 --test test/lib/adcp-version-string-emit.test.js`
- `git diff --check`
- pre-push validation: format check, typecheck, build:lib
