### PR TITLE
fix(security): SSRF-safe webhook default + tenant-store resolve isolation gate

### DIFF
--- a/.changeset/tidy-webhooks-tenant-isolation.md
+++ b/.changeset/tidy-webhooks-tenant-isolation.md
@@ -1,0 +1,19 @@
+---
+'@adcp/sdk': major
+---
+
+Security: webhook emitter is SSRF-safe by default, and `createTenantStore` gains an opt-in `resolve` isolation gate.
+
+**Breaking — webhook delivery default.** `createWebhookEmitter` / `createAdcpServer({ webhooks })` now default their HTTP client to `createPinAndBindFetch()` instead of `globalThis.fetch`. This defeats DNS-rebinding / SSRF against the buyer-supplied `push_notification_config.url` (https-only; loopback, private, and cloud-metadata ranges denied). In-process harnesses that deliver to a loopback `http://127.0.0.1` receiver must now opt in explicitly:
+
+```ts
+import { createPinAndBindFetch, LOOPBACK_OK_WEBHOOK_SSRF_POLICY } from '@adcp/sdk/server';
+
+createAdcpServer({
+  webhooks: { signerKey, fetch: createPinAndBindFetch({ policy: LOOPBACK_OK_WEBHOOK_SSRF_POLICY }) },
+});
+```
+
+Passing `fetch: globalThis.fetch` restores the previous unguarded behavior (only do so behind your own URL validation).
+
+**`createTenantStore` — `refAccess` gate on `resolve`.** Added `refAccess?: 'ref-routed' | 'auth-scoped'` (default `'ref-routed'`, non-breaking). `'ref-routed'` preserves the agency-hub model where one credential may resolve any tenant's account by ref. `'auth-scoped'` makes `accounts.resolve` fail closed when a buyer-supplied ref points at a tenant other than the authenticated principal's — closing a cross-tenant read/mutate path for non-trusted-buyer deployments. Corrected the `createTenantStore` / `account.ts` docs, which previously implied `resolve` was always an isolation gate; it is not unless `refAccess: 'auth-scoped'` is set or a `resolve-presets` guard is composed.

--- a/src/lib/server/decisioning/account.ts
+++ b/src/lib/server/decisioning/account.ts
@@ -4,8 +4,11 @@
  * Spotify Brand → Campaign) are encoded in `metadata`, not in the typed
  * shape. Generic `TCtxMeta` lets platforms type their metadata at the call site.
  *
- * Tenant isolation is enforced at `accounts.resolve()` returning null for
- * cross-scope references, not via a multi-level type.
+ * Tenant scoping is expressed by what `accounts.resolve()` returns, not via
+ * a multi-level type. Note that resolve is NOT an isolation gate by default:
+ * `createTenantStore` resolves the ref the buyer supplies regardless of the
+ * caller unless `refAccess: 'auth-scoped'` is set (or a `resolve-presets`
+ * guard is composed). See `createTenantStore` and `resolve-presets.ts`.
  *
  * Status: Preview / 6.0.
  *

--- a/src/lib/server/decisioning/tenant-store.ts
+++ b/src/lib/server/decisioning/tenant-store.ts
@@ -2,8 +2,16 @@
  * `createTenantStore` — opinionated `AccountStore` builder for multi-tenant
  * adapters. Canonicalizes the two-path resolution shape (operator-routed
  * for tools that carry `account` on the wire; auth-derived for tools that
- * don't) and bakes in the tenant-isolation gate that adopters historically
- * had to write — and silently fail to write — by hand.
+ * don't) and bakes in the per-entry tenant-isolation gate on the mutating
+ * account-sync tools (`sync_accounts` / `sync_governance`) that adopters
+ * historically had to write — and silently fail to write — by hand.
+ *
+ * NOTE: `accounts.resolve` is NOT gated by default (`refAccess: 'ref-routed'`)
+ * — it returns whatever tenant the buyer's ref points at, which is correct
+ * for the agency-hub model where one credential spans tenants. Deployments
+ * where a credential must NOT reach another tenant's account set
+ * `refAccess: 'auth-scoped'` (gates `resolve` fail-closed) or compose a
+ * `resolve-presets` guard. See {@link TenantStoreConfig.refAccess}.
  *
  * Full walkthrough with same-tenant invariant + production caveats:
  * `skills/build-holdco-agent/SKILL.md`. Worked example:
@@ -42,10 +50,37 @@ type SyncGovernanceRow = SyncGovernanceSuccess['accounts'][number];
  */
 export interface TenantStoreConfig<TTenant, TCtxMeta = Record<string, unknown>> {
   /**
+   * Controls whether a buyer-supplied account ref on `accounts.resolve` is
+   * gated against the authenticated principal's tenant.
+   *
+   * - `'ref-routed'` (default) — `resolve` returns whatever tenant the ref
+   *   points at, WITHOUT checking the caller. This is correct for the
+   *   agency-hub / account-routed model where one credential legitimately
+   *   spans tenants (see `examples/hello_seller_adapter_multi_tenant.ts`).
+   *   In this mode `resolve` performs NO isolation check — any authenticated
+   *   caller can resolve any tenant's account by naming its `account_id` /
+   *   `operator`. Isolation for such deployments must be layered on top with
+   *   a `resolve-presets` guard (`requireAccountMatch` /
+   *   `requireAdvertiserMatch` / `requireOrgScope`) via `composeMethod`.
+   * - `'auth-scoped'` — `resolve` fails closed: a ref that resolves to a
+   *   tenant other than `resolveFromAuth(ctx)` (or an unresolvable auth
+   *   principal) returns `null` (framework emits `ACCOUNT_NOT_FOUND`). Use
+   *   this when a credential must NOT be able to reach another tenant's
+   *   account by supplying its ref.
+   *
+   * This flag governs ONLY `resolve`. `upsert` / `syncGovernance` always
+   * enforce the tenant gate regardless of this setting.
+   */
+  refAccess?: 'ref-routed' | 'auth-scoped';
+
+  /**
    * Path 1: account ref carries `account_id` OR `(brand, operator)`.
-   * Resolve to the tenant the ref points at — independent of who the
-   * caller is. Return null if the ref is unknown (helper emits
-   * `ACCOUNT_NOT_FOUND` for that row).
+   * Resolve to the tenant the ref points at. Return null if the ref is
+   * unknown (helper emits `ACCOUNT_NOT_FOUND` for that row).
+   *
+   * By default (`refAccess: 'ref-routed'`) this resolves independent of who
+   * the caller is. Set `refAccess: 'auth-scoped'` to make `resolve` reject a
+   * ref that points at a tenant other than the caller's.
    *
    * Receives the full `AccountReference` so adopters can route on
    * `ref.sandbox` (Pattern 2: separate sandbox tenant) or read the
@@ -137,7 +172,9 @@ export interface TenantStoreConfig<TTenant, TCtxMeta = Record<string, unknown>> 
  *   set, otherwise `resolveFromAuth(ctx)`. Projects via `tenantToAccount`.
  *   Returns `null` if the resolver returned `null` (framework emits
  *   `ACCOUNT_NOT_FOUND` for tools that require an account, or treats
- *   absence as "no tenant" for tools that don't).
+ *   absence as "no tenant" for tools that don't). By default this path does
+ *   NOT check the caller against the ref's tenant — set
+ *   `refAccess: 'auth-scoped'` to fail closed on a cross-tenant ref.
  *
  * - `accounts.upsert(refs, ctx)` — for each ref:
  *     1. Resolve the entry's tenant via `resolveByRef`.
@@ -179,9 +216,23 @@ export function createTenantStore<TTenant, TCtxMeta = Record<string, unknown>>(
   const store: AccountStore<TCtxMeta> = {
     resolve: async (ref, ctx) => {
       const resolveCtx = ctx ?? {};
-      const tenant = ref ? await config.resolveByRef(ref) : await config.resolveFromAuth(resolveCtx);
-      if (tenant == null) return null;
-      return await config.tenantToAccount(tenant, ref, resolveCtx);
+      if (!ref) {
+        const authTenant = await config.resolveFromAuth(resolveCtx);
+        if (authTenant == null) return null;
+        return await config.tenantToAccount(authTenant, ref, resolveCtx);
+      }
+      const entryTenant = await config.resolveByRef(ref);
+      if (entryTenant == null) return null;
+      if ((config.refAccess ?? 'ref-routed') === 'auth-scoped') {
+        const authTenant = await config.resolveFromAuth(resolveCtx);
+        // Fail-closed: an unresolvable principal OR a ref pointing at a
+        // different tenant is treated as not found — a caller cannot reach
+        // another tenant's account by naming its ref.
+        if (authTenant == null || config.tenantId(authTenant) !== config.tenantId(entryTenant)) {
+          return null;
+        }
+      }
+      return await config.tenantToAccount(entryTenant, ref, resolveCtx);
     },
   };
 

--- a/src/lib/server/pin-and-bind-fetch.ts
+++ b/src/lib/server/pin-and-bind-fetch.ts
@@ -165,13 +165,12 @@ const DEFAULT_LOOKUP_ALL: DnsLookupAll = (hostname, options, callback) => {
  * Build a `fetch` that pins outbound connections to the IPs the SSRF policy
  * allows, defeating DNS-rebinding attacks against per-attempt DNS resolution.
  *
- * Pass as the `fetch` argument to `createWebhookEmitter` /
- * `createAdcpServer({ webhooks: { fetch } })` to enable rebinding protection
- * on outbound webhook delivery. Recommended for production. The default
- * `fetch` for `createWebhookEmitter` remains `globalThis.fetch` until v6 —
- * see `docs/guides/SIGNING-GUIDE.md` § Webhook SSRF defense for the
- * migration plan and {@link LOOPBACK_OK_WEBHOOK_SSRF_POLICY} for storyboard
- * tests that need loopback http delivery.
+ * This is the default `fetch` for `createWebhookEmitter` /
+ * `createAdcpServer({ webhooks })`, so production webhook delivery is
+ * rebinding-protected without extra wiring. Call it explicitly only to
+ * override the policy — e.g. {@link LOOPBACK_OK_WEBHOOK_SSRF_POLICY} for
+ * storyboard tests that deliver to a loopback http receiver. See
+ * `docs/guides/SIGNING-GUIDE.md` § Webhook SSRF defense.
  *
  * Construct once per emitter and reuse — each call instantiates a fresh
  * `undici.Agent` with its own connection pool.

--- a/src/lib/server/webhook-emitter.ts
+++ b/src/lib/server/webhook-emitter.ts
@@ -25,6 +25,7 @@ import { signWebhook, type SignerKey } from '../signing/signer';
 import { signWebhookAsync } from '../signing/signer-async';
 import type { SigningProvider } from '../signing/provider';
 import type { RequestLike } from '../signing/canonicalize';
+import { createPinAndBindFetch } from './pin-and-bind-fetch';
 import { createHmac, randomUUID } from 'node:crypto';
 
 /**
@@ -140,14 +141,18 @@ export interface WebhookEmitterOptions {
    */
   generateIdempotencyKey?: () => string;
   /**
-   * Override the HTTP client. Defaults to `globalThis.fetch`. Production
-   * deployments SHOULD pass `createPinAndBindFetch()` to defeat DNS-rebinding
-   * attacks against buyer-supplied `push_notification_config.url` values —
-   * see `docs/guides/SIGNING-GUIDE.md` § Webhook SSRF defense. The default
-   * will become `createPinAndBindFetch()` in v6 (major). Today's default is
-   * `globalThis.fetch` because pin-and-bind blocks loopback http URLs that
-   * the storyboard runner uses for testing webhook flows; flipping the
-   * default would break in-process storyboard runs without a migration.
+   * Override the HTTP client. Defaults to `createPinAndBindFetch()`, which
+   * defeats DNS-rebinding / SSRF attacks against the buyer-supplied
+   * `push_notification_config.url` (https-only; loopback, private, and cloud
+   * metadata ranges denied). See `docs/guides/SIGNING-GUIDE.md` § Webhook
+   * SSRF defense.
+   *
+   * In-process storyboard / test harnesses that deliver to a loopback
+   * `http://127.0.0.1:port` receiver must opt into the relaxed policy
+   * explicitly: `fetch: createPinAndBindFetch({ policy:
+   * LOOPBACK_OK_WEBHOOK_SSRF_POLICY })`. Passing `globalThis.fetch` here
+   * restores the unguarded pre-9.8 behavior — only do so behind your own
+   * URL validation.
    */
   fetch?: typeof fetch;
   /** Default `User-Agent` header. */
@@ -245,7 +250,7 @@ export function createWebhookEmitter(options: WebhookEmitterOptions): WebhookEmi
   }
   const store = options.idempotencyKeyStore ?? memoryWebhookKeyStore();
   const generateKey = options.generateIdempotencyKey ?? defaultGenerateIdempotencyKey;
-  const fetchImpl = options.fetch ?? globalThis.fetch;
+  const fetchImpl = options.fetch ?? createPinAndBindFetch();
   const sleep = options.sleep ?? defaultSleep;
 
   return {

--- a/test/lib/create-tenant-store.test.js
+++ b/test/lib/create-tenant-store.test.js
@@ -103,6 +103,53 @@ describe('createTenantStore — resolve', () => {
   });
 });
 
+// ── resolve — refAccess isolation gate ──────────────────────────────────────
+
+describe('createTenantStore — resolve refAccess gate', () => {
+  test("default ('ref-routed') resolves a cross-tenant ref without checking the caller", async () => {
+    const store = buildStore();
+    // Meridian's credential names Pinnacle's operator — ref-routed returns it.
+    const acc = await store.resolve(
+      { brand: { domain: 'acme.example' }, operator: 'pinnacle.example' },
+      ctxWith('buyer@meridian')
+    );
+    assert.equal(acc.id, 't_pinnacle');
+  });
+
+  test("'auth-scoped' blocks a cross-tenant ref (returns null)", async () => {
+    const store = buildStore({ refAccess: 'auth-scoped' });
+    const acc = await store.resolve(
+      { brand: { domain: 'acme.example' }, operator: 'pinnacle.example' },
+      ctxWith('buyer@meridian')
+    );
+    assert.equal(acc, null);
+  });
+
+  test("'auth-scoped' allows a same-tenant ref", async () => {
+    const store = buildStore({ refAccess: 'auth-scoped' });
+    const acc = await store.resolve(
+      { brand: { domain: 'acme.example' }, operator: 'pinnacle.example' },
+      ctxWith('buyer@pinnacle')
+    );
+    assert.equal(acc.id, 't_pinnacle');
+  });
+
+  test("'auth-scoped' fails closed when the auth principal is unresolvable", async () => {
+    const store = buildStore({ refAccess: 'auth-scoped' });
+    const acc = await store.resolve(
+      { brand: { domain: 'acme.example' }, operator: 'pinnacle.example' },
+      ctxWith('not-registered')
+    );
+    assert.equal(acc, null);
+  });
+
+  test("'auth-scoped' still serves Path 2 (no ref) from resolveFromAuth", async () => {
+    const store = buildStore({ refAccess: 'auth-scoped' });
+    const acc = await store.resolve(undefined, ctxWith('buyer@pinnacle'));
+    assert.equal(acc.id, 't_pinnacle');
+  });
+});
+
 // ── upsert (sync_accounts) — tenant-isolation gate ─────────────────────────
 
 describe('createTenantStore — upsert tenant-isolation gate', () => {

--- a/test/lib/pin-and-bind-fetch.test.js
+++ b/test/lib/pin-and-bind-fetch.test.js
@@ -271,24 +271,26 @@ describe('createWebhookEmitter: pin-and-bind opt-in via fetch override', () => {
     );
   });
 
-  test('emit() with default fetch (no opt-in) still works against loopback (back-compat)', async () => {
-    // Asserts that flipping pin-and-bind from default in v6 is the only
-    // behavior change — until then, omitting `fetch` keeps the legacy
-    // globalThis.fetch path that storyboard tests rely on.
+  test('emit() with the default fetch (no opt-in) is SSRF-guarded and blocks loopback', async () => {
+    // The emitter defaults to createPinAndBindFetch() — omitting `fetch`
+    // is secure-by-default. A loopback URL is refused (terminal), the same
+    // as the explicit opt-in above. Adopters delivering to a loopback
+    // receiver must opt into LOOPBACK_OK_WEBHOOK_SSRF_POLICY explicitly.
     const emitter = createWebhookEmitter({
       signerKey: makeSignerKey(),
       sleep: () => Promise.resolve(),
-      retries: { maxAttempts: 1 },
+      retries: { maxAttempts: 5 }, // SSRF should still cap at 1 — terminal.
     });
-    // We don't actually need a server listening; the assertion is that the
-    // call gets to the connect phase (i.e. wasn't blocked synchronously).
-    // ECONNREFUSED is the expected outcome on a free loopback port.
     const result = await emitter.emit({
       url: 'https://127.0.0.1:9999/webhook',
-      payload: { task: { task_id: 'compat', status: 'completed' } },
-      operation_id: 'op.compat',
+      payload: { task: { task_id: 'default-guarded', status: 'completed' } },
+      operation_id: 'op.default-guarded',
     });
-    assert.strictEqual(result.delivered, false);
-    assert.ok(!result.errors.some(e => /EADCP_SSRF_BLOCKED/.test(e)), 'default fetch must not raise SSRF block today');
+    assert.strictEqual(result.delivered, false, 'default fetch must not deliver to loopback');
+    assert.strictEqual(result.attempts, 1, 'SSRF block must be terminal — no retries');
+    assert.ok(
+      result.errors.some(e => /SSRF|EADCP_SSRF_BLOCKED|hosts_denied|host_literal/i.test(e)),
+      `expected SSRF-shaped error from the default fetch, got: ${JSON.stringify(result.errors)}`
+    );
   });
 });

--- a/test/lib/webhook-emitter-server-e2e.test.js
+++ b/test/lib/webhook-emitter-server-e2e.test.js
@@ -14,11 +14,21 @@ const assert = require('node:assert');
 const { generateKeyPairSync } = require('node:crypto');
 
 const { createAdcpServer } = require('../../dist/lib/server/create-adcp-server.js');
+const {
+  createPinAndBindFetch,
+  LOOPBACK_OK_WEBHOOK_SSRF_POLICY,
+} = require('../../dist/lib/server/pin-and-bind-fetch.js');
 const { createWebhookReceiver } = require('../../dist/lib/testing/storyboard/webhook-receiver.js');
 const { verifyWebhookSignature } = require('../../dist/lib/signing/webhook-verifier.js');
 const { StaticJwksResolver } = require('../../dist/lib/signing/jwks.js');
 const { InMemoryReplayStore } = require('../../dist/lib/signing/replay.js');
 const { InMemoryRevocationStore } = require('../../dist/lib/signing/revocation.js');
+
+// The emitter defaults to a strict pin-and-bind fetch that denies loopback
+// http. This E2E delivers to an in-process http://127.0.0.1 receiver, so it
+// opts into the loopback-relaxed policy — the same escape hatch the
+// storyboard runner uses. Cloud-metadata / private ranges stay denied.
+const loopbackFetch = createPinAndBindFetch({ policy: LOOPBACK_OK_WEBHOOK_SSRF_POLICY });
 
 function makeSignerKey(kid = 'e2e-webhook-key') {
   const { privateKey, publicKey } = generateKeyPairSync('ed25519');
@@ -58,7 +68,7 @@ describe('createAdcpServer + webhook emitter: full-stack publisher E2E', () => {
     const server = createAdcpServer({
       name: 'e2e-publisher',
       version: '1.0.0',
-      webhooks: { signerKey },
+      webhooks: { signerKey, fetch: loopbackFetch },
       mediaBuy: {
         createMediaBuy: async (params, ctx) => {
           // Business logic: create the media buy, then fire the webhook.
@@ -154,7 +164,7 @@ describe('createAdcpServer + webhook emitter: full-stack publisher E2E', () => {
     const server = createAdcpServer({
       name: 'stability-publisher',
       version: '1.0.0',
-      webhooks: { signerKey },
+      webhooks: { signerKey, fetch: loopbackFetch },
       mediaBuy: {
         createMediaBuy: async (params, ctx) => {
           // Emit twice for the same operation_id — simulates a handler


### PR DESCRIPTION
## What

Two high-confidence findings from the SDK security review, fixed and shipped together.

### 1. Webhook emitter SSRF (MEDIUM) — secure-by-default

`createWebhookEmitter` / `createAdcpServer({ webhooks })` defaulted their HTTP client to `globalThis.fetch`, which does no SSRF validation and re-resolves DNS per request. The destination is the buyer-controlled `push_notification_config.url`, so a counterparty could point it at loopback, an internal service, or `169.254.169.254` (incl. via DNS rebinding), and the framework would POST the signed payload there.

**Fix:** default to the in-tree `createPinAndBindFetch()` (https-only; loopback/private/metadata ranges denied; DNS pinned). This matches what `targeting-helpers.ts` already does for buyer-supplied list URLs.

**Breaking:** in-process harnesses delivering to a loopback `http://127.0.0.1` receiver must now opt in:
```ts
webhooks: { signerKey, fetch: createPinAndBindFetch({ policy: LOOPBACK_OK_WEBHOOK_SSRF_POLICY }) }
```
`fetch: globalThis.fetch` restores prior behavior (behind your own validation).

### 2. `createTenantStore.resolve` cross-tenant access (HIGH, conditional)

`resolve` returned whatever tenant a buyer-supplied `account_id`/`operator` ref named, with no check against the authenticated principal — while `upsert`/`syncGovernance` enforce the tenant gate. In a non-trusted-buyer multi-tenant deployment, buyer A could read/mutate tenant B's data by naming B's ref. The docstrings made this worse by claiming "isolation is enforced at `accounts.resolve()`".

**Fix:** added `refAccess?: 'ref-routed' | 'auth-scoped'` (default `'ref-routed'`, **non-breaking** — preserves the agency-hub model). `'auth-scoped'` fails `resolve` closed on a cross-tenant ref or unresolvable principal. Corrected the misleading `createTenantStore` / `account.ts` docs.

## Tests

- Updated the pin-and-bind back-compat test to assert the new secure default blocks loopback.
- Updated the full-stack webhook E2E to opt into the loopback policy.
- Added 5 `refAccess` gate cases (cross-tenant blocked, same-tenant allowed, fail-closed on unknown principal, Path-2 still works, ref-routed default documented).
- Affected suites green: 153/153 across tenant-store, webhook emitter/e2e, pin-and-bind, hmac-deprecation, auto-emit-completion, tenant-registry.

## Not included

Lower-confidence items from the review (signed-request `covers_content_digest: 'either'` — dropped: the SDK's own signer binds the body by default; test-controller seeding `sandbox` flag with no resolver — misconfiguration the framework already warns on; `exposeErrorDetails` when `NODE_ENV` unset) are left for separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)