### PR TITLE
fix(storyboard-runner): field_value object equality must not be key-order-sensitive

### DIFF
--- a/.changeset/field-value-key-order.md
+++ b/.changeset/field-value-key-order.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Storyboard runner: `field_value` (and its `allowed_values` / envelope variants) now compares object values with JSON deep equality instead of `JSON.stringify` string equality. The stringify comparison was key-order-sensitive, so a content-equal object whose members serialize in a different order false-negatived the check (observed live: `list_formats_integrity` failed "format_id round-trips verbatim" on `{id, agent_url}` echoed as `{agent_url, id}`). Object member order is not significant per RFC 8259; array element order remains strict, matching the sibling `deepEqual` helpers in `webhook-receiver.ts` and `canonical-format-satisfaction.ts`. Fixes #2327.

--- a/src/lib/testing/storyboard/validations.ts
+++ b/src/lib/testing/storyboard/validations.ts
@@ -844,9 +844,42 @@ function validateFieldAbsent(validation: StoryboardValidation, taskResult: TaskR
 
 function valuesMatch(actual: unknown, expected: unknown): boolean {
   if (typeof actual === 'object' && actual !== null) {
-    return JSON.stringify(actual) === JSON.stringify(expected);
+    return deepEqualJsonValue(actual, expected);
   }
   return actual === expected;
+}
+
+/**
+ * JSON deep equality for `field_value`-family checks: object member order is
+ * NOT significant (RFC 8259 section 4), array element order IS, scalars are
+ * strict. Mirrors the sibling implementations in `webhook-receiver.ts` and
+ * `canonical-format-satisfaction.ts`. Previously this was a
+ * `JSON.stringify(a) === JSON.stringify(b)` comparison, which false-negatived
+ * content-equal objects whose members serialize in a different order (e.g. a
+ * format_id `{id, agent_url}` echoed by the agent as `{agent_url, id}`) —
+ * adcp-client#2327.
+ */
+function deepEqualJsonValue(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (typeof a !== typeof b) return false;
+  if (a === null || b === null) return a === b;
+  if (typeof a !== 'object') return false;
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b)) return false;
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) {
+      if (!deepEqualJsonValue(a[i], b[i])) return false;
+    }
+    return true;
+  }
+  const keysA = Object.keys(a as Record<string, unknown>);
+  const keysB = Object.keys(b as Record<string, unknown>);
+  if (keysA.length !== keysB.length) return false;
+  for (const k of keysA) {
+    if (!Object.prototype.hasOwnProperty.call(b, k)) return false;
+    if (!deepEqualJsonValue((a as Record<string, unknown>)[k], (b as Record<string, unknown>)[k])) return false;
+  }
+  return true;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/test/storyboard-field-value-key-order.test.js
+++ b/test/storyboard-field-value-key-order.test.js
@@ -1,0 +1,107 @@
+'use strict';
+
+// Regression for adcp-client#2327: `field_value` object equality was a
+// JSON.stringify comparison, which is key-order-sensitive — a content-equal
+// object whose members serialize in a different order false-negatived the
+// check (observed live: a format_id {id, agent_url} echoed as {agent_url, id}
+// failed "round-trips verbatim"). JSON object member order is not significant
+// (RFC 8259 section 4); array element order is, and stays strict.
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+
+const { runValidations } = require('../dist/lib/testing/storyboard/validations.js');
+
+function makeCtx({ data, storyboardContext } = {}) {
+  return {
+    taskName: 'list_creative_formats',
+    agentUrl: 'https://example.com/mcp',
+    contributions: new Set(),
+    taskResult: { success: true, data: data ?? {} },
+    storyboardContext: storyboardContext,
+  };
+}
+
+describe('field_value object equality is key-order-insensitive (#2327)', () => {
+  it('passes when actual object has the same members in a different order', () => {
+    const [result] = runValidations(
+      [
+        {
+          check: 'field_value',
+          path: 'formats[0].format_id',
+          value: { id: 'video_1920x1080', agent_url: 'https://example.com/mcp' },
+          description: 'format_id round-trips verbatim',
+        },
+      ],
+      // Insertion order deliberately reversed vs the expectation.
+      makeCtx({ data: { formats: [{ format_id: { agent_url: 'https://example.com/mcp', id: 'video_1920x1080' } }] } })
+    );
+    assert.strictEqual(result.passed, true, JSON.stringify(result));
+  });
+
+  it('passes on nested objects with reordered members', () => {
+    const [result] = runValidations(
+      [
+        {
+          check: 'field_value',
+          path: 'pkg',
+          value: { a: 1, inner: { x: 'y', n: [1, 2] } },
+          description: 'nested reorder',
+        },
+      ],
+      makeCtx({ data: { pkg: { inner: { n: [1, 2], x: 'y' }, a: 1 } } })
+    );
+    assert.strictEqual(result.passed, true, JSON.stringify(result));
+  });
+
+  it('still fails when a member value differs', () => {
+    const [result] = runValidations(
+      [
+        {
+          check: 'field_value',
+          path: 'formats[0].format_id',
+          value: { id: 'video_1920x1080', agent_url: 'https://example.com/mcp' },
+          description: 'format_id round-trips verbatim',
+        },
+      ],
+      makeCtx({ data: { formats: [{ format_id: { agent_url: 'https://example.com/mcp', id: 'display_300x250' } }] } })
+    );
+    assert.strictEqual(result.passed, false);
+  });
+
+  it('still fails when a member is missing or extra', () => {
+    const [missing] = runValidations(
+      [{ check: 'field_value', path: 'o', value: { a: 1, b: 2 }, description: 'missing member' }],
+      makeCtx({ data: { o: { a: 1 } } })
+    );
+    assert.strictEqual(missing.passed, false);
+    const [extra] = runValidations(
+      [{ check: 'field_value', path: 'o', value: { a: 1 }, description: 'extra member' }],
+      makeCtx({ data: { o: { a: 1, b: 2 } } })
+    );
+    assert.strictEqual(extra.passed, false);
+  });
+
+  it('array element order remains significant', () => {
+    const [result] = runValidations(
+      [{ check: 'field_value', path: 'arr', value: [1, 2, 3], description: 'array order strict' }],
+      makeCtx({ data: { arr: [3, 2, 1] } })
+    );
+    assert.strictEqual(result.passed, false);
+  });
+
+  it('allowed_values honors key-order-insensitive object match', () => {
+    const [result] = runValidations(
+      [
+        {
+          check: 'field_value',
+          path: 'o',
+          allowed_values: [{ a: 1, b: 2 }, { c: 3 }],
+          description: 'allowed_values object member',
+        },
+      ],
+      makeCtx({ data: { o: { b: 2, a: 1 } } })
+    );
+    assert.strictEqual(result.passed, true, JSON.stringify(result));
+  });
+});


### PR DESCRIPTION
Fixes #2327.

## Problem

`valuesMatch` in `src/lib/testing/storyboard/validations.ts` compares object values with `JSON.stringify(actual) === JSON.stringify(expected)`. Stringify preserves member insertion order, so a content-equal object whose members serialize in a different order false-negatives every `field_value` / `allowed_values` / `field_equals_context` check on object values. Observed on a live conformance run: `media_buy_seller/list_formats_integrity` failed "format_id round-trips verbatim" with

```json
"expected": { "id": "video_1920x1080", "agent_url": "https://…/adcp/mcp" },
"actual":   { "agent_url": "https://…/adcp/mcp", "id": "video_1920x1080" }
```

— identical members, different order. Per RFC 8259 §4, object member order is not significant in JSON.

## Change

Replace the stringify comparison with JSON deep equality: objects order-insensitive, arrays order-sensitive, scalars strict — the same semantics as the two sibling helpers already in the tree (`deepEqual` in `webhook-receiver.ts`, `deepEqualJson` in `canonical-format-satisfaction.ts`); `field_value` was the odd one out. Behavior otherwise unchanged: differing values, missing/extra members, and reordered arrays still fail.

## Tests

`test/storyboard-field-value-key-order.test.js` (6): reordered flat + nested objects pass; differing member value fails; missing/extra member fails; array order stays strict; `allowed_values` honors the order-insensitive match. Neighboring suites (`storyboard-cross-step-validators`, `lib/storyboard-branch-set-grading`) still green. `patch` changeset included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)