### PR TITLE
fix: allow larger adagents validation bodies

### DIFF
--- a/.changeset/large-adagents-body-cap.md
+++ b/.changeset/large-adagents-body-cap.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Allow validateAdAgents callers to opt into larger adagents.json response bodies.

--- a/src/lib/discovery/validate-adagents.ts
+++ b/src/lib/discovery/validate-adagents.ts
@@ -102,7 +102,7 @@ export interface ValidateAdAgentsOptions {
 
 const DEFAULT_TIMEOUT_MS = 10_000;
 const DEFAULT_MAX_BODY_BYTES = 256 * 1024;
-const MAX_CONFIGURABLE_BODY_BYTES = 2 * 1024 * 1024;
+const MAX_CONFIGURABLE_BODY_BYTES = 10 * 1024 * 1024;
 
 const FETCH_HEADERS = {
   Accept: 'application/json, text/plain, */*',

--- a/test/lib/validate-adagents.test.js
+++ b/test/lib/validate-adagents.test.js
@@ -129,11 +129,11 @@ describe('validateAdAgents — discovery_method', () => {
   test('rejects invalid maxBodyBytes values before fetching', async () => {
     await assert.rejects(
       () => validateAdAgents('example.com', { maxBodyBytes: Infinity }),
-      /maxBodyBytes must be an integer between 1 and 2097152/
+      /maxBodyBytes must be an integer between 1 and 10485760/
     );
     await assert.rejects(
-      () => validateAdAgents('example.com', { maxBodyBytes: 2 * 1024 * 1024 + 1 }),
-      /maxBodyBytes must be an integer between 1 and 2097152/
+      () => validateAdAgents('example.com', { maxBodyBytes: 10 * 1024 * 1024 + 1 }),
+      /maxBodyBytes must be an integer between 1 and 10485760/
     );
   });
 
@@ -203,7 +203,7 @@ describe('validateAdAgents — discovery_method', () => {
     }
   });
 
-  test('managerdomain fallback honors custom maxBodyBytes for large adagents.json', async () => {
+  test('managerdomain fallback honors custom maxBodyBytes for network-scale adagents.json', async () => {
     const largeAdagents = JSON.stringify({
       $schema: 'https://adcontextprotocol.org/schemas/v1/adagents.json',
       authorized_agents: [{ url: 'https://agent.example.com/mcp', authorized_for: 'Programmatic sales' }],
@@ -214,7 +214,7 @@ describe('validateAdAgents — discovery_method', () => {
           identifiers: [{ type: 'domain', value: 'example.com' }],
         },
       ],
-      padding: 'x'.repeat(270 * 1024),
+      padding: 'x'.repeat(3_500_000),
     });
     const manager = await startRoutedServer({
       '/.well-known/adagents.json': { body: largeAdagents },


### PR DESCRIPTION
## Why

Large manager/network `adagents.json` files exist in production. Raptive's
`cafemedia.com` file is currently about 3.37 MB, but `validateAdAgents()` capped
explicit opt-in body sizes at 2 MiB. That forced downstream callers that need
authoritative network membership to bypass the validator for large files.

Fixes #2331.

## What Changed

- Raised the `validateAdAgents()` maximum configurable `maxBodyBytes` value from
  2 MiB to 10 MiB.
- Kept the default response body cap unchanged at 256 KiB.
- Expanded the managerdomain fallback custom-cap test to use a network-scale
  3.5 MB response.
- Updated invalid option validation expectations for the new explicit maximum.

## Context

This unblocks replacing a scoped workaround in
scope3data/agentic-api#5764 with the SDK validator once a release containing
this change is available.

## Validation

- `npm run build:lib`
- `env NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/lib/validate-adagents.test.js`
- pre-push hook passed: format check, typecheck, build
