### PR TITLE
chore(ci): move Argus to the AAO Secretariat App identity

### DIFF
--- a/.github/ai-review/expert-adcp-reviewer.md
+++ b/.github/ai-review/expert-adcp-reviewer.md
@@ -1,6 +1,6 @@
 # Argus — Expert PR Reviewer
 
-You are **Argus**, the expert PR reviewer for `adcontextprotocol/adcp-client` (the official TypeScript SDK + CLI for AdCP, published as `@adcp/sdk`). You review pull requests **in the voice of Brian O'Kelley** (`bokelley` — primary maintainer). Apply his standing engineering bar.
+You are **Argus**, the review desk of the **AAO Secretariat**, serving the AdCP Working Group as the expert PR reviewer for `adcontextprotocol/adcp-client` (the official TypeScript SDK + CLI for AdCP, published as `@adcp/sdk`). Apply the WG constitution appended to this prompt. When a question is settled precedent, cite the decision record (`DR-NNNN` in the spec repo's `governance/decisions/`).
 
 This is a real review on a real PR. You do **not** post the review yourself — a deterministic workflow step (the arbiter) posts it for you. Your job is to produce the review and record your decision by writing two files with the `Write` tool:
 

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -12,15 +12,14 @@ name: AI PR Review (Argus)
 # cannot swallow the verdict: the arbiter posts what the reviewer recorded,
 # and degrades to a COMMENT (never a fabricated approval) when no verdict was written.
 #
-# Reviews are posted as the AAO IPR Bot GitHub App (reused — same App that
-# powers ipr-agreement.yml), so they count toward the "1 review required"
-# branch-protection check the same way a human approval does. If Argus
-# graduates to its own App, swap these secret names accordingly.
+# Reviews are posted as the AAO Secretariat GitHub App, so they count
+# toward the "1 review required" branch-protection check the same way a
+# human approval does.
 #
 # Required secrets:
-#   IPR_APP_ID           — already configured (org-level)
-#   IPR_APP_PRIVATE_KEY  — already configured (org-level)
-#   ANTHROPIC_API_KEY    — already configured
+#   SECRETARIAT_APP_ID          — AAO Secretariat GitHub App ID (org-level)
+#   SECRETARIAT_APP_PRIVATE_KEY — AAO Secretariat App private key PEM (org-level)
+#   ANTHROPIC_API_KEY           — already configured
 #
 # Adapted from adcontextprotocol/adcp's Argus workflow (PR #4816).
 
@@ -38,7 +37,7 @@ on:
 # Bot login that posts Argus reviews. Verifier pins on this so reviews
 # from other bots do not satisfy the "Argus posted" check.
 env:
-  ARGUS_BOT_LOGIN: aao-ipr-bot[bot]
+  ARGUS_BOT_LOGIN: aao-secretariat[bot]
 
 jobs:
   code_review:
@@ -60,7 +59,7 @@ jobs:
           fetch-depth: 0
 
       # ─────────────────────────────────────────────────────────────────────
-      # Mint an installation token from the AAO IPR Bot GitHub App. Reviews
+      # Mint an installation token from the AAO Secretariat GitHub App. Reviews
       # posted with this token appear as the App's bot user and count
       # toward branch-protection's required-approvals check.
       # ─────────────────────────────────────────────────────────────────────
@@ -68,8 +67,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ secrets.IPR_APP_ID }}
-          private-key: ${{ secrets.IPR_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.SECRETARIAT_APP_ID }}
+          private-key: ${{ secrets.SECRETARIAT_APP_PRIVATE_KEY }}
 
       # ─────────────────────────────────────────────────────────────────────
       # Workflow-modification gate.
@@ -218,10 +217,22 @@ jobs:
             exit 1
           fi
           PROMPT_BODY="$(git show "${BASE_SHA}:.github/ai-review/expert-adcp-reviewer.md")"
+          # The WG constitution lives in the spec repo, not here. Fetch it from
+          # adcp@main at review time — the PR cannot mutate the rules it is
+          # reviewed under. If the fetch fails, the review runs without it.
+          CONSTITUTION="$(curl -sf https://raw.githubusercontent.com/adcontextprotocol/adcp/main/.agents/wg/constitution.md || true)"
           SENTINEL="ARGUS_$(openssl rand -hex 8)_EOF"
           {
             echo "ARGUS_PROMPT<<${SENTINEL}"
             echo "$PROMPT_BODY"
+            if [ -n "$CONSTITUTION" ]; then
+              echo ''
+              echo '---'
+              echo ''
+              echo '## WG constitution (from adcontextprotocol/adcp@main)'
+              echo ''
+              echo "$CONSTITUTION"
+            fi
             echo ''
             echo '---'
             echo ''


### PR DESCRIPTION
## What changed

Migrates the Argus AI-review workflow from the IPR App identity to the org's new **AAO Secretariat** GitHub App, matching the spec repo's migration (adcontextprotocol/adcp#5832).

- `.github/workflows/ai-review.yml`
  - App-token minting now uses `secrets.SECRETARIAT_APP_ID` / `secrets.SECRETARIAT_APP_PRIVATE_KEY` (was `IPR_APP_ID` / `IPR_APP_PRIVATE_KEY`).
  - `ARGUS_BOT_LOGIN` pinned to `aao-secretariat[bot]` (was `aao-ipr-bot[bot]`) — the skip-check and post-review verifier both key off this.
  - Header comments now describe Argus as the AAO Secretariat's review desk applying the WG constitution, not a reviewer in a maintainer's voice.
  - The prompt-building step appends the WG constitution after the prompt body under a `## WG constitution (from adcontextprotocol/adcp@main)` heading, fetched at review time via `curl -sf` from the spec repo's `main`. Emitted only when the fetch returns content; the randomized heredoc sentinel discipline is unchanged.
  - The reviewer prompt was already loaded fail-closed from the PR's **base SHA** (`git show "${BASE_SHA}:..."`) — unchanged.
- `.github/ai-review/expert-adcp-reviewer.md`
  - Identity clause only: Argus is the review desk of the AAO Secretariat serving the AdCP Working Group; applies the appended WG constitution and cites decision records (`DR-NNNN` in the spec repo's `governance/decisions/`) when a question is settled precedent. Review logic (MUST FIX list, coverage rules, expert delegation) untouched.

Nothing else in the repo is modified — no other workflows, no changesets, no version files.

## After merge

Argus reviews will post as **`aao-secretariat[bot]`** instead of `aao-ipr-bot[bot]`.

## ⚠️ DO NOT MERGE yet

**Do not merge until the org-level `SECRETARIAT_APP_ID` / `SECRETARIAT_APP_PRIVATE_KEY` secrets are visible to this repo.** They are still being provisioned. If this merges before the secrets land, the Mint App token step fails and Argus reviews stop on every PR.

## Security note

The WG constitution is fetched from `adcontextprotocol/adcp@main` at review time — it is **not** read from this repo's checkout or from the PR, so a PR cannot alter the rules it is reviewed under. If the fetch fails, the review runs without the constitution rather than failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)