### PR TITLE
fix: stop injecting deprecated top-level packages[].buyer_ref on v3 create/update_media_buy

### DIFF
--- a/.changeset/gate-buyer-ref-promotion-on-v2.md
+++ b/.changeset/gate-buyer-ref-promotion-on-v2.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Client: stop injecting a deprecated top-level `packages[].buyer_ref` on `create_media_buy` / `update_media_buy` requests to v3 sellers. The request normalizer previously copied `context.buyer_ref` up to a top-level `buyer_ref` on every call, unconditionally — before the version gate ran. Spec-compliant v3 receivers (which validate strictly against the 3.0 package schema that removed the top-level field) rejected the request with `INVALID_REQUEST: packages.0.buyer_ref: Extra inputs are not permitted`. The promotion has been moved into the v2.5 adapter (`adaptCreateMediaBuyRequestForV2`), which is already gated on `serverVersion !== 'v3'`, so legacy servers still receive the top-level field they expect while v3 sellers see the correct wire shape.

--- a/src/lib/utils/creative-adapter.ts
+++ b/src/lib/utils/creative-adapter.ts
@@ -75,9 +75,13 @@ export interface PackageAdapterContext {
  * Converts creative_assignments to creative_ids (dropping weight and placement_ids).
  * Strips v3-only package fields (optimization_goals, catalogs).
  *
- * When `ctx` is provided and the input has no `buyer_ref`, derives one as
- * `package.idempotency_key || ${ctx.parentBuyerRef}-${ctx.index}` so v2.5
- * package-request validation passes. Caller-supplied `buyer_ref` always wins.
+ * When `ctx` is provided and the input has no `buyer_ref`, derives one from —
+ * in order — `package.context.buyer_ref`, `package.idempotency_key`, or
+ * `${ctx.parentBuyerRef}-${ctx.index}` so v2.5 package-request validation
+ * passes. Caller-supplied top-level `buyer_ref` always wins. The `context.buyer_ref`
+ * fallback exists because v3 callers put their per-package correlation ref in
+ * `context.buyer_ref` (per the 3.0 package schema); this adapter is the only
+ * place that promotes it back to the top-level shape v2.5 sellers still expect.
  */
 export function adaptPackageRequestForV2(pkg: PackageRequestV3, ctx?: PackageAdapterContext): PackageRequestV2 {
   const {
@@ -93,20 +97,27 @@ export function adaptPackageRequestForV2(pkg: PackageRequestV3, ctx?: PackageAda
     buyer_ref?: unknown;
   };
 
-  // Derive per-package buyer_ref. Caller-supplied wins; then per-package
-  // idempotency_key; then a stable composition of the parent's buyer_ref
-  // and the package's array index. If none of those are available we
-  // pass through without a buyer_ref and let the v2.5 validator surface
-  // the missing field — better than synthesizing an unstable value that
-  // breaks dedupe on replay.
+  const contextBuyerRef =
+    rest.context && typeof rest.context === 'object' && !Array.isArray(rest.context)
+      ? (rest.context as Record<string, unknown>).buyer_ref
+      : undefined;
+
+  // Derive per-package buyer_ref. Caller-supplied top-level wins; then
+  // context.buyer_ref (the v3 per-package correlation slot); then per-package
+  // idempotency_key; then a stable composition of the parent's buyer_ref and
+  // the package's array index. If none of those are available we pass through
+  // without a buyer_ref and let the v2.5 validator surface the missing field
+  // — better than synthesizing an unstable value that breaks dedupe on replay.
   const derivedBuyerRef =
     typeof callerBuyerRef === 'string' && callerBuyerRef.length > 0
       ? callerBuyerRef
-      : typeof pkgIdempotencyKey === 'string' && pkgIdempotencyKey.length > 0
-        ? pkgIdempotencyKey
-        : ctx?.parentBuyerRef !== undefined && ctx?.index !== undefined
-          ? `${ctx.parentBuyerRef}-${ctx.index}`
-          : undefined;
+      : typeof contextBuyerRef === 'string' && contextBuyerRef.length > 0
+        ? contextBuyerRef
+        : typeof pkgIdempotencyKey === 'string' && pkgIdempotencyKey.length > 0
+          ? pkgIdempotencyKey
+          : ctx?.parentBuyerRef !== undefined && ctx?.index !== undefined
+            ? `${ctx.parentBuyerRef}-${ctx.index}`
+            : undefined;
 
   const baseOut: PackageRequestV2 = rest as PackageRequestV2;
   if (!rest.creative_assignments) {
@@ -125,15 +136,17 @@ export function adaptPackageRequestForV2(pkg: PackageRequestV3, ctx?: PackageAda
 /**
  * Adapt a create_media_buy request for a v2 server.
  * Strips v3-only top-level fields, converts brand → brand_manifest, derives
- * `buyer_ref` (top-level + per-package) from `idempotency_key`, and adapts
- * packages.
+ * `buyer_ref` (top-level + per-package) from `context.buyer_ref` or
+ * `idempotency_key`, and adapts packages.
  *
  * v2.5 requires `buyer_ref` as the buyer's reference for THIS media buy,
- * top-level + per-package. v3 doesn't model `buyer_ref` but `idempotency_key`
- * carries the same client-controlled-unique-identity semantics. Reusing it
- * preserves the idempotency contract sellers depend on for deduping replays:
- * the same v3 request always produces the same v2.5 `buyer_ref`. Caller-
- * supplied `buyer_ref` (if any) always wins.
+ * top-level + per-package. v3 removed the top-level field and moved buyer
+ * correlation into `context.buyer_ref`; `idempotency_key` carries the same
+ * client-controlled-unique-identity semantics. Preferring the caller's
+ * `context.buyer_ref` before falling back to `idempotency_key` preserves the
+ * buyer's stable reference on the wire when they provided one, and still
+ * satisfies v2.5 dedupe on replay when they did not. Caller-supplied
+ * top-level `buyer_ref` (if any) always wins.
  */
 export function adaptCreateMediaBuyRequestForV2(request: any): any {
   const {
@@ -148,6 +161,11 @@ export function adaptCreateMediaBuyRequestForV2(request: any): any {
     buyer_ref: callerBuyerRef,
     ...rest
   } = request;
+
+  const contextBuyerRef =
+    rest.context && typeof rest.context === 'object' && !Array.isArray(rest.context)
+      ? (rest.context as Record<string, unknown>).buyer_ref
+      : undefined;
 
   // Proposal mode is v3-only. If packages are also present we can still satisfy the request
   // by dropping proposal_id/total_budget and using the explicit packages.
@@ -173,9 +191,11 @@ export function adaptCreateMediaBuyRequestForV2(request: any): any {
   const buyer_ref =
     typeof callerBuyerRef === 'string' && callerBuyerRef.length > 0
       ? callerBuyerRef
-      : typeof idempotency_key === 'string' && idempotency_key.length > 0
-        ? idempotency_key
-        : undefined;
+      : typeof contextBuyerRef === 'string' && contextBuyerRef.length > 0
+        ? contextBuyerRef
+        : typeof idempotency_key === 'string' && idempotency_key.length > 0
+          ? idempotency_key
+          : undefined;
 
   return {
     ...rest,

--- a/src/lib/utils/request-normalizer.ts
+++ b/src/lib/utils/request-normalizer.ts
@@ -15,9 +15,16 @@ import { MUTATING_TASKS, generateIdempotencyKey } from './idempotency';
  * Normalize a single package's params for backward compatibility.
  *
  * Handles:
- * - context.buyer_ref → buyer_ref (pre-4.15 servers require top-level buyer_ref)
  * - optimization_goal (scalar) → optimization_goals (array)
  * - catalog (scalar object) → catalogs (array)
+ *
+ * Does NOT copy `context.buyer_ref` up to a top-level `buyer_ref`. The top-level
+ * field was removed from the package schema in AdCP 3.0 and strict v3 receivers
+ * reject it. When a request routes to a v2.5 seller, the v2 adapter in
+ * `creative-adapter.ts` derives `buyer_ref` (from a caller-supplied value,
+ * `context.buyer_ref`, `idempotency_key`, or parent/index) — that adapter is
+ * gated on `serverVersion !== 'v3'`, so the field only lands on the wire for
+ * sellers that still expect it.
  */
 export function normalizePackageParams(pkg: any): any {
   if (!pkg || typeof pkg !== 'object') return pkg;
@@ -50,13 +57,6 @@ export function normalizePackageParams(pkg: any): any {
       normalized.budget,
       'pre-3.0 shape not supported in AdCP 3.0. Use budget as a number instead.'
     );
-  }
-
-  // context.buyer_ref → buyer_ref (backward compat for pre-4.15 AdCP servers)
-  // AdCP 4.15 moved buyer_ref into context, but older servers still require it
-  // at the top level. Copy it back so requests validate on both old and new servers.
-  if (normalized.context?.buyer_ref && !normalized.buyer_ref) {
-    normalized.buyer_ref = normalized.context.buyer_ref;
   }
 
   // optimization_goal (scalar) → optimization_goals (array)
@@ -94,7 +94,7 @@ export function normalizeRequestParams(
     return params;
   }
 
-  let normalized = { ...params };
+  const normalized = { ...params };
 
   // ── idempotency_key auto-generation ──
   // Tasks that mutate state require a caller-supplied idempotency_key per
@@ -164,16 +164,11 @@ export function normalizeRequestParams(
     );
   }
 
-  // ── context.buyer_ref → buyer_ref (create_media_buy, update_media_buy) ──
-  // AdCP 4.15 moved buyer_ref into context, but pre-4.15 servers still require
-  // it at the top level. Copy it back so requests validate on both old and new servers.
-  if (
-    (taskType === 'create_media_buy' || taskType === 'update_media_buy') &&
-    normalized.context?.buyer_ref &&
-    !normalized.buyer_ref
-  ) {
-    normalized.buyer_ref = normalized.context.buyer_ref;
-  }
+  // Top-level `buyer_ref` on create_media_buy / update_media_buy was removed
+  // from the AdCP request schema in 3.0. It is NOT derived from `context.buyer_ref`
+  // here — strict v3 receivers reject it as an unknown field. The v2.5 adapter in
+  // `creative-adapter.ts` performs the derivation for legacy servers only, gated
+  // on `serverVersion !== 'v3'`.
 
   // ── Package normalization (create_media_buy, update_media_buy) ──
   if ((taskType === 'create_media_buy' || taskType === 'update_media_buy') && Array.isArray(normalized.packages)) {

--- a/test/lib/request-validation.test.js
+++ b/test/lib/request-validation.test.js
@@ -210,8 +210,10 @@ describe('SingleAgentClient Request Validation', () => {
       const client = new AdCPClient([mockAgent]);
       const agent = client.agent(mockAgent.id);
 
-      // buyer_ref is copied from context.buyer_ref by the normalizer for pre-4.15 servers.
-      // Non-strict parse accepts it without special-case handling.
+      // Callers may still pass a top-level buyer_ref explicitly for legacy servers
+      // that require it — the v2 adapter treats a caller-supplied top-level value
+      // as the highest-priority derivation source. Non-strict parse accepts it
+      // without special-case handling.
       await assert.doesNotReject(async () => {
         try {
           await agent.createMediaBuy({

--- a/test/lib/v3-compatibility.test.js
+++ b/test/lib/v3-compatibility.test.js
@@ -589,6 +589,59 @@ describe('Creative Assignment Adapter', () => {
         assert.strictEqual(result.buyer_ref, 'caller-buyer-1');
       });
 
+      test('derives top-level buyer_ref from context.buyer_ref when no top-level buyer_ref is supplied', () => {
+        // v3 callers put their per-request buyer correlation in context.buyer_ref
+        // (the 3.0 request schema removed the top-level field). The v2 adapter
+        // is the only place that promotes it back to the top-level shape v2.5
+        // sellers still expect.
+        const result = adaptCreateMediaBuyRequestForV2({
+          account: { account_id: 'acc-1' },
+          brand: { domain: 'example.com' },
+          context: { buyer_ref: 'ctx-buyer-1' },
+          packages: [{ product_id: 'prod-1', budget: 1000, pricing_option_id: 'po-1' }],
+          start_time: 'asap',
+          end_time: '2027-12-31T23:59:59Z',
+          idempotency_key: 'idemp-aaa',
+        });
+        assert.strictEqual(result.buyer_ref, 'ctx-buyer-1');
+      });
+
+      test('caller-supplied top-level buyer_ref wins over context.buyer_ref', () => {
+        const result = adaptCreateMediaBuyRequestForV2({
+          buyer_ref: 'caller-buyer-1',
+          account: { account_id: 'acc-1' },
+          brand: { domain: 'example.com' },
+          context: { buyer_ref: 'ctx-buyer-1' },
+          packages: [{ product_id: 'prod-1', budget: 1000, pricing_option_id: 'po-1' }],
+          start_time: 'asap',
+          end_time: '2027-12-31T23:59:59Z',
+        });
+        assert.strictEqual(result.buyer_ref, 'caller-buyer-1');
+      });
+
+      test('per-package context.buyer_ref becomes top-level buyer_ref on the adapted package', () => {
+        // Symmetric to the request-level case above — each package's own
+        // context.buyer_ref promotes to a top-level buyer_ref for v2.5
+        // sellers, without polluting v3 wire payloads (that path is gated
+        // on serverVersion !== 'v3' at the caller).
+        const result = adaptCreateMediaBuyRequestForV2({
+          account: { account_id: 'acc-1' },
+          brand: { domain: 'example.com' },
+          packages: [
+            {
+              product_id: 'prod-1',
+              budget: 1000,
+              pricing_option_id: 'po-1',
+              context: { buyer_ref: 'pkg-ctx-1' },
+            },
+          ],
+          start_time: 'asap',
+          end_time: '2027-12-31T23:59:59Z',
+          idempotency_key: 'idemp-aaa',
+        });
+        assert.strictEqual(result.packages[0].buyer_ref, 'pkg-ctx-1');
+      });
+
       test('no buyer_ref emitted when neither caller buyer_ref nor idempotency_key is present', () => {
         // v3 pre-send validation should already have rejected this; defensive
         // path for warn-mode where the request still reaches the adapter.
@@ -1919,18 +1972,24 @@ describe('Package Parameter Normalization', () => {
     assert.strictEqual(normalizePackageParams(42), 42);
   });
 
-  test('should copy context.buyer_ref to top-level buyer_ref for pre-4.15 compat', () => {
+  test('should NOT copy context.buyer_ref to top-level buyer_ref (v3 field removed)', () => {
+    // The AdCP 3.0 package schema removed top-level buyer_ref; strict v3
+    // receivers reject it as an unknown field. The v2.5 adapter in
+    // creative-adapter.ts derives it for legacy servers only.
     const result = normalizePackageParams({
       product_id: 'prod-1',
       budget: 5000,
       pricing_option_id: 'po-1',
       context: { buyer_ref: 'br-123' },
     });
-    assert.strictEqual(result.buyer_ref, 'br-123');
+    assert.strictEqual(result.buyer_ref, undefined);
     assert.strictEqual(result.context.buyer_ref, 'br-123');
   });
 
-  test('should not overwrite existing top-level buyer_ref with context.buyer_ref', () => {
+  test('should preserve a caller-supplied top-level buyer_ref (still legal on v2)', () => {
+    // The normalizer must not strip a top-level buyer_ref the caller set
+    // themselves — the field is v2.5-legal and the v2 adapter reads it as
+    // the highest-priority derivation source.
     const result = normalizePackageParams({
       product_id: 'prod-1',
       buyer_ref: 'existing-ref',
@@ -1949,18 +2008,18 @@ describe('Package Parameter Normalization', () => {
 });
 
 describe('Request-level context.buyer_ref → buyer_ref (create_media_buy)', () => {
-  test('should copy context.buyer_ref to top-level buyer_ref for pre-4.15 compat', () => {
+  test('should NOT copy request-level context.buyer_ref to top-level buyer_ref (v3 field removed)', () => {
     resetWarnings();
     const result = normalizeRequestParams('create_media_buy', {
       account: { account_id: 'acc-1' },
       brand: { domain: 'example.com' },
       context: { buyer_ref: 'br-request-123' },
     });
-    assert.strictEqual(result.buyer_ref, 'br-request-123');
+    assert.strictEqual(result.buyer_ref, undefined);
     assert.strictEqual(result.context.buyer_ref, 'br-request-123');
   });
 
-  test('should not overwrite existing top-level buyer_ref with context.buyer_ref', () => {
+  test('should preserve a caller-supplied top-level buyer_ref (legal on v2)', () => {
     resetWarnings();
     const result = normalizeRequestParams('create_media_buy', {
       buyer_ref: 'existing-ref',
@@ -1971,7 +2030,7 @@ describe('Request-level context.buyer_ref → buyer_ref (create_media_buy)', () 
     assert.strictEqual(result.buyer_ref, 'existing-ref');
   });
 
-  test('should not set buyer_ref when context has no buyer_ref', () => {
+  test('should not set buyer_ref when neither top-level nor context supplies one', () => {
     resetWarnings();
     const result = normalizeRequestParams('create_media_buy', {
       account: { account_id: 'acc-1' },
@@ -1981,20 +2040,11 @@ describe('Request-level context.buyer_ref → buyer_ref (create_media_buy)', () 
     assert.strictEqual(result.buyer_ref, undefined);
   });
 
-  test('should copy context.buyer_ref to top-level buyer_ref for update_media_buy', () => {
+  test('should NOT copy context.buyer_ref to top-level buyer_ref for update_media_buy', () => {
     resetWarnings();
     const result = normalizeRequestParams('update_media_buy', {
       media_buy_id: 'mb-1',
       context: { buyer_ref: 'br-update-123' },
-    });
-    assert.strictEqual(result.buyer_ref, 'br-update-123');
-  });
-
-  test('should not apply request-level buyer_ref shim to other task types', () => {
-    resetWarnings();
-    const result = normalizeRequestParams('get_products', {
-      brand: { domain: 'example.com' },
-      context: { buyer_ref: 'br-123' },
     });
     assert.strictEqual(result.buyer_ref, undefined);
   });


### PR DESCRIPTION
## Why

The request normalizer copied `context.buyer_ref` up to a top-level `packages[].buyer_ref` on every `create_media_buy` / `update_media_buy` — unconditionally, and before any server-version detection ran. Spec-compliant v3 receivers validate strictly against the 3.0 package schema (which removed the top-level field) and reject the request with:

```
INVALID_REQUEST: packages.0.buyer_ref: Extra inputs are not permitted
category: invalid_request
```

The client's own comment on the promotion asserted that new servers would still accept the extra field, but the 3.0 spec removed it and any strict v3 receiver (Pydantic `extra="forbid"`, Zod strict, etc.) correctly rejects it. The bug was invisible against permissive receivers that ignore unknown fields and only surfaced when calling a strict v3 seller.

Repro: build a v3 `create_media_buy` request with per-package `context: { buyer_ref: '...' }` (the AdCP 3.x correlation slot), send it to a v3 seller running strict Pydantic. Client-side normalization injects the deprecated top-level `buyer_ref`, receiver rejects. Both sides on `@adcp/sdk@10.0.1`.

## What Changed

- `src/lib/utils/request-normalizer.ts` — removed the `context.buyer_ref → packages[].buyer_ref` copy from `normalizePackageParams` (was unconditional) and the parallel request-level copy from `normalizeRequestParams`. Both now leave `context.buyer_ref` where the caller put it. Comments explain that the promotion moved into the v2.5 adapter, which is version-gated.
- `src/lib/utils/creative-adapter.ts` — `adaptPackageRequestForV2` and `adaptCreateMediaBuyRequestForV2` (both already gated on `serverVersion !== 'v3'` at the caller in `SingleAgentClient.adaptRequest`) now consider `context.buyer_ref` as a derivation source for the v2.5 top-level `buyer_ref`, sitting between caller-supplied top-level and `idempotency_key` in the priority chain. Legacy v2.5 sellers keep receiving the top-level field they expect.
- Tests updated in `test/lib/v3-compatibility.test.js` — the assertions that expected the normalizer to promote `context.buyer_ref` now assert that it does NOT (v3 wire shape is preserved), and new v2-adapter tests pin the moved derivation behavior (request-level and per-package).
- Small comment update in `test/lib/request-validation.test.js` — the existing test at line 209 keeps working because a caller-supplied top-level `buyer_ref` is still legal; comment now reflects why.

Derivation priority in the v2 adapter (unchanged for callers who explicitly set a top-level `buyer_ref`):

1. Caller-supplied top-level `buyer_ref`
2. `context.buyer_ref` (new here — was previously done unconditionally by the normalizer)
3. `idempotency_key`
4. Per-package: `${parentBuyerRef}-${index}`

The replay-dedupe contract (same v3 input → same v2.5 `buyer_ref`) is preserved.

## Test plan

- [x] `npm run build` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — full suite green (0 failures)
- [x] `npx eslint src/lib/utils/{request-normalizer,creative-adapter}.ts` — no new errors (pre-existing `no-explicit-any` warnings only)
- [x] Updated the 5 tests that asserted the removed behavior; added 3 tests that pin the moved behavior in the v2 adapter (request-level context, priority vs caller-supplied top-level, per-package context)
- [x] Changeset added (`patch`)

Supersedes #2339 (fork-based; closed).