### PR TITLE
feat: add lean, zod-free `./enums` export

### DIFF
--- a/.changeset/lean-enums-export.md
+++ b/.changeset/lean-enums-export.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': minor
+---
+
+Add a lean, zero-dependency `./enums` export. `import { EventTypeValues } from '@adcp/sdk/enums'` (and the other AdCP enum value arrays) now resolves to a zod-free entry point, so bundlers no longer pull the full `./types` barrel and zod (~1.84 MB) just to read an enum. Useful for zod-free consumers such as browser bundles. Re-exports the existing `types/enums.generated` (named unions) and `types/inline-enums.generated` (per-field unions) modules; no change to `./types`.

--- a/package.json
+++ b/package.json
@@ -35,6 +35,11 @@
       "require": "./dist/lib/types/index.js",
       "types": "./dist/lib/types/index.d.ts"
     },
+    "./enums": {
+      "import": "./dist/lib/enums.js",
+      "require": "./dist/lib/enums.js",
+      "types": "./dist/lib/enums.d.ts"
+    },
     "./types/v2-5": {
       "import": "./dist/lib/types/v2-5/index.js",
       "require": "./dist/lib/types/v2-5/index.js",

--- a/src/lib/enums.ts
+++ b/src/lib/enums.ts
@@ -1,0 +1,15 @@
+// Lean, zero-dependency entry point for AdCP enum value arrays.
+//
+// Both re-exported modules are pure `as const` string-literal arrays with no
+// imports (codegen output), so importing from `@adcp/sdk/enums` pulls in only
+// the arrays a consumer names: no `./types` barrel, no zod. This is the safe
+// entry for zod-free consumers (e.g. browser bundles) that want an AdCP enum
+// as their single source of truth.
+//
+//   import { EventTypeValues } from '@adcp/sdk/enums';
+//
+// enums.generated exposes `NameValues` arrays for named string-literal unions;
+// inline-enums.generated exposes `Parent_PropertyValues` arrays for anonymous
+// per-field unions.
+export * from './types/enums.generated';
+export * from './types/inline-enums.generated';


### PR DESCRIPTION
## Why

Consumers that want a single AdCP enum value array (e.g. `EventTypeValues`) as their source of truth have no lean way to get one. The only runtime entry exposing those arrays is `@adcp/sdk/types`, a CommonJS `__exportStar(require(...))` barrel. Because the package is CJS with no `sideEffects`, bundlers cannot tree-shake across the `require` re-exports, so importing one enum drags in the whole barrel and zod.

Measured (esbuild, `--bundle --minify`):
- `import { EventTypeValues } from '@adcp/sdk/types'` → **1,881,376 B, includes zod**
- via the new `@adcp/sdk/enums` → **61,548 B, zero zod** (~30× smaller)

This is a hard blocker for zod-free consumers (e.g. browser widgets), which keep hand-maintained enum copies instead of sourcing from the SDK.

## What Changed

- New `src/lib/enums.ts` — a barrel re-exporting the two **zero-dependency** generated modules `types/enums.generated` (named string-literal unions → `NameValues`) and `types/inline-enums.generated` (per-field unions → `Parent_PropertyValues`). Both are pure `as const` arrays with no imports, so the require graph stays small (no zod).
- New `./enums` entry in `package.json` `exports` (import/require/types).
- Changeset (`minor`).

No change to `./types`. Deliberately did **not** add a `./types/*` runtime wildcard (would leak internal generated filenames as public API and re-expose the zod-heavy modules).

## Verification

- `npm run build:lib` emits `dist/lib/enums.{js,d.ts}`
- `npm run typecheck` clean; `npm run test:node:fast` → 12,526 pass / 0 fail
- Runtime: `EventTypeValues.length === 31` (incl. `follow` / `content_view` / `watch_milestone`); `require('@adcp/sdk/enums')` resolves via the exports map
- Zod-free proof: bundling a consumer of `@adcp/sdk/enums` contains neither zod nor `wellknown-schemas.generated`

Closes #2343. The durable/general fix (ESM + tree-shakeable packaging) is tracked in #2344.

🤖 Generated with [Claude Code](https://claude.com/claude-code)