### PR TITLE
Migrate conductor.json to .conductor/settings.toml

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,4 @@
+"$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
+
+[scripts]
+setup = "# Fetch latest changes from remote\ngit fetch origin\n\n# Rebase onto latest origin/main\ngit rebase origin/main\n\n# Copy configuration files\ncp $CONDUCTOR_ROOT_PATH/.env .\n\n# Install dependencies\nnpm install\n\n# Sync ADCP schemas\necho '📥 Syncing ADCP schemas...'\nnpm run sync-schemas\n\n# Generate types from schemas\necho '🔧 Generating TypeScript types...'\nnpm run generate-types"

--- a/conductor.json
+++ b/conductor.json
@@ -1,5 +1,0 @@
-{
-  "scripts": {
-    "setup": "# Fetch latest changes from remote\ngit fetch origin\n\n# Rebase onto latest origin/main\ngit rebase origin/main\n\n# Copy configuration files\ncp $CONDUCTOR_ROOT_PATH/.env .\n\n# Install dependencies\nnpm install\n\n# Sync ADCP schemas\necho '📥 Syncing ADCP schemas...'\nnpm run sync-schemas\n\n# Generate types from schemas\necho '🔧 Generating TypeScript types...'\nnpm run generate-types"
-  }
-}


### PR DESCRIPTION
This PR migrates the legacy `conductor.json` configuration to the new `.conductor/settings.toml` format.

Generated by Conductor.