### PR TITLE
fix(runtime): project list_accounts CursorPage into pagination block

### DIFF
--- a/.changeset/fix-list-accounts-pagination-shape.md
+++ b/.changeset/fix-list-accounts-pagination-shape.md
@@ -1,0 +1,7 @@
+---
+'@adcp/sdk': patch
+---
+
+fix(runtime): `list_accounts` projects `CursorPage` into the `pagination` block instead of top-level `next_cursor`
+
+Both 3.0 and 3.1 `list-accounts-response` model pagination via `pagination: { has_more, cursor?, total_count? }` referencing `core/pagination-response.json`. The prior projector emitted `next_cursor` at the top level — schema-invisible under `additionalProperties: true`, but every adopter silently failed the `pagination_integrity_list_accounts` storyboard's `field_value pagination.has_more: true` + `field_present pagination.cursor` assertions regardless of `accounts.list` output. Fixes adcontextprotocol/adcp#5723.

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -5502,12 +5502,25 @@ function buildAccountHandlers<P extends DecisioningPlatform<any, any>>(
       // Wrap in projectSync so adopter `throw new AdcpError('PERMISSION_DENIED', ...)`
       // from the list impl projects to the structured wire envelope rather
       // than falling through to the framework's `SERVICE_UNAVAILABLE` mapping.
+      //
+      // Wire shape: 3.0 + 3.1 `list-accounts-response` model pagination via a
+      // `pagination` block referencing `core/pagination-response.json`
+      // (`has_more` required, `cursor` present only when `has_more=true`).
+      // Emitting top-level `next_cursor` — the shape shipped before this fix —
+      // was schema-invisible (`additionalProperties: true` on the response) but
+      // silently failed the `pagination_integrity_list_accounts` storyboard's
+      // `field_value pagination.has_more: true` + `field_present pagination.cursor`
+      // assertions for every adopter, regardless of `CursorPage` output.
+      // See adcontextprotocol/adcp#5723 for the reproduction from a 3.1 seller.
       return projectSync(
         () => accounts.list!(filter, resolveCtx),
         page => ({
           status: 'completed' as const,
           accounts: page.items.map(toWireAccount),
-          ...(page.nextCursor != null && { next_cursor: page.nextCursor }),
+          pagination: {
+            has_more: page.nextCursor != null,
+            ...(page.nextCursor != null && { cursor: page.nextCursor }),
+          },
         })
       );
     };

--- a/test/server-decisioning-from-platform.test.js
+++ b/test/server-decisioning-from-platform.test.js
@@ -2377,17 +2377,17 @@ describe('Custom-handler merge seam (incremental migration)', () => {
     assert.strictEqual(
       page1.structuredContent.pagination.has_more,
       true,
-      'pagination.has_more MUST be true when adopter returned nextCursor',
+      'pagination.has_more MUST be true when adopter returned nextCursor'
     );
     assert.strictEqual(
       page1.structuredContent.pagination.cursor,
       'cursor_page_2',
-      'pagination.cursor MUST echo adopter nextCursor',
+      'pagination.cursor MUST echo adopter nextCursor'
     );
     assert.strictEqual(
       page1.structuredContent.next_cursor,
       undefined,
-      'top-level next_cursor MUST NOT leak — schema models pagination via pagination block',
+      'top-level next_cursor MUST NOT leak — schema models pagination via pagination block'
     );
 
     const terminalPlatform = buildPlatform();
@@ -2405,12 +2405,12 @@ describe('Custom-handler merge seam (incremental migration)', () => {
     assert.strictEqual(
       terminal.structuredContent.pagination.has_more,
       false,
-      'pagination.has_more MUST be false when adopter returned no nextCursor',
+      'pagination.has_more MUST be false when adopter returned no nextCursor'
     );
     assert.strictEqual(
       terminal.structuredContent.pagination.cursor,
       undefined,
-      'pagination.cursor MUST be absent when has_more is false (per pagination-response schema)',
+      'pagination.cursor MUST be absent when has_more is false (per pagination-response schema)'
     );
   });
 

--- a/test/server-decisioning-from-platform.test.js
+++ b/test/server-decisioning-from-platform.test.js
@@ -2335,6 +2335,85 @@ describe('Custom-handler merge seam (incremental migration)', () => {
     assert.strictEqual(result.structuredContent.accounts[0].brand.domain, 'acme.com');
   });
 
+  it('list_accounts projects CursorPage into 3.1 pagination block (not top-level next_cursor)', async () => {
+    // Regression: adcontextprotocol/adcp#5723 — the pre-fix projector emitted a
+    // top-level `next_cursor` field. Both 3.0 and 3.1 `list-accounts-response`
+    // model pagination as `pagination: { has_more, cursor?, total_count? }`
+    // via `core/pagination-response.json`. The old shape passed schema
+    // (`additionalProperties: true`) but silently failed the
+    // `pagination_integrity_list_accounts` storyboard assertions for every
+    // adopter.
+    const page1Platform = buildPlatform({
+      accounts: {
+        resolve: async ref => ({
+          id: ref?.account_id ?? 'acc_1',
+          metadata: {},
+          authInfo: { kind: 'api_key' },
+        }),
+        upsert: async () => [],
+        list: async () => ({
+          items: [
+            {
+              id: 'acc_1',
+              metadata: { name: 'Acme', advertiser: 'Acme Corp' },
+              authInfo: { kind: 'api_key' },
+            },
+          ],
+          nextCursor: 'cursor_page_2',
+        }),
+      },
+    });
+    const server1 = createAdcpServerFromPlatform(page1Platform, {
+      name: 'pagination-fix',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+    const page1 = await server1.dispatchTestRequest({
+      method: 'tools/call',
+      params: { name: 'list_accounts', arguments: { pagination: { max_results: 1 } } },
+    });
+    assert.notStrictEqual(page1.isError, true, `page1 unexpected error: ${JSON.stringify(page1.structuredContent)}`);
+    assert.ok(page1.structuredContent.pagination, 'response MUST carry a pagination block');
+    assert.strictEqual(
+      page1.structuredContent.pagination.has_more,
+      true,
+      'pagination.has_more MUST be true when adopter returned nextCursor',
+    );
+    assert.strictEqual(
+      page1.structuredContent.pagination.cursor,
+      'cursor_page_2',
+      'pagination.cursor MUST echo adopter nextCursor',
+    );
+    assert.strictEqual(
+      page1.structuredContent.next_cursor,
+      undefined,
+      'top-level next_cursor MUST NOT leak — schema models pagination via pagination block',
+    );
+
+    const terminalPlatform = buildPlatform();
+    const server2 = createAdcpServerFromPlatform(terminalPlatform, {
+      name: 'pagination-terminal',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+    const terminal = await server2.dispatchTestRequest({
+      method: 'tools/call',
+      params: { name: 'list_accounts', arguments: {} },
+    });
+    assert.notStrictEqual(terminal.isError, true);
+    assert.ok(terminal.structuredContent.pagination, 'terminal-page response MUST also carry pagination');
+    assert.strictEqual(
+      terminal.structuredContent.pagination.has_more,
+      false,
+      'pagination.has_more MUST be false when adopter returned no nextCursor',
+    );
+    assert.strictEqual(
+      terminal.structuredContent.pagination.cursor,
+      undefined,
+      'pagination.cursor MUST be absent when has_more is false (per pagination-response schema)',
+    );
+  });
+
   it('opts.accounts.listAccounts runs when platform.accounts.list is undefined', async () => {
     let sawCall = false;
     const platform = buildPlatform({


### PR DESCRIPTION
## Summary

- `list_accounts` runtime projector at `src/lib/server/decisioning/runtime/from-platform.ts` L5507 was emitting `next_cursor` at the top level of the response. Both 3.0 and 3.1 `list-accounts-response.json` model pagination via `pagination: { has_more, cursor?, total_count? }` referencing `core/pagination-response.json`; the top-level shape was schema-invisible under `additionalProperties: true`, so no validator caught it, but every conformant adopter silently failed the `pagination_integrity_list_accounts` storyboard's `field_value pagination.has_more: true` + `field_present pagination.cursor` assertions.
- This PR translates `CursorPage<T>` → `pagination: { has_more, cursor? }` at the projector seam so an adopter's `accounts.list` output round-trips through the correct wire shape without any adopter changes. `total_count` is left off because `CursorPage<T>` (in `src/lib/server/decisioning/pagination.ts`) does not currently carry it — a follow-up widening could add it if desired.
- Non-breaking: the previously-emitted top-level `next_cursor` was never part of the response schema on either 3.0 or 3.1; no buyer client is documented to read it. Adopters returning `{ items, nextCursor }` unchanged now satisfy the pagination-integrity storyboard.

Fixes adcontextprotocol/adcp#5723.

Context: I filed #5723 as a reference implementer for `purrsonality-seller` (single-publisher first-party seller). @bokelley on 2026-07-02 confirmed this needs a fresh SDK-repo issue and pre-greenlit a "sweep PR covering all three projectors" (#5416, #5723, #5797). After tracing the code on `@adcp/sdk` 9.7.0 + main HEAD, only #5723 turned out to be a real projector shape bug on main — `#5797` is already covered by the documented `ctxFor(ctx, params)` → `RequestContext.input` threading (adopters can read `ctx.input.assignments` today, see the docblock at L3253-3256 of `from-platform.ts`), and #5416's alleged status overwrite is not present in the current `createMediaBuy` projector (identity `projectSync(..., r => r)`). Rather than bundle those into this PR, I'll close #5723's follow-up thread with a verification note and update #5797 / #5416 with the current state.

## Test plan

- [x] `npm run build:lib` — clean
- [x] `node --test test/server-decisioning-from-platform.test.js` — 136/136 pass, including the new regression case
  - Verifies `pagination.has_more: true` + `pagination.cursor: 'X'` when adopter returns `nextCursor: 'X'`
  - Verifies `pagination.has_more: false` + no `cursor` on the terminal page
  - Asserts `next_cursor` NEVER appears at top level
- [ ] Verified on `purrsonality-seller` prod against AAO `pagination_integrity_list_accounts/pagination_walk` — will re-evaluate after this lands in a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)