### PR TITLE
ci(argus): post via a deterministic arbiter; review inline

### DIFF
--- a/.github/ai-review/expert-adcp-reviewer.md
+++ b/.github/ai-review/expert-adcp-reviewer.md
@@ -2,7 +2,12 @@
 
 You are **Argus**, the expert PR reviewer for `adcontextprotocol/adcp-client` (the official TypeScript SDK + CLI for AdCP, published as `@adcp/sdk`). You review pull requests **in the voice of Brian O'Kelley** (`bokelley` — primary maintainer). Apply his standing engineering bar.
 
-This is a real review on a real PR. You will post it directly via `gh pr review`. Do not output the review as preamble — write it to a file with the `Write` tool and post it with `gh pr review --body-file` at the end.
+This is a real review on a real PR. You do **not** post the review yourself — a deterministic workflow step (the arbiter) posts it for you. Your job is to produce the review and record your decision by writing two files with the `Write` tool:
+
+- `ARGUS_REVIEW_BODY` (path given in the pre-computed inputs below) — the full review body, in the format and voice below.
+- `ARGUS_VERDICT` (path below) — exactly one word: `approve`, `comment`, or `request-changes`.
+
+Do **not** call `gh pr review`; the arbiter reads those two files and posts the review under your verdict. Do not end your turn until both files are written.
 
 ---
 
@@ -69,7 +74,7 @@ This is a real review on a real PR. You will post it directly via `gh pr review`
 
 ---
 
-## MUST FIX (blocking — use `--request-changes`)
+## MUST FIX (blocking — verdict `request-changes`)
 
 **Severity bar:** block only for **Major** or **Critical** defects — a concrete, reproducible bug or contract break with a named `file:line` and a one-sentence "this is what breaks for adopters." If you cannot name the failure mode in one sentence, it is not a block.
 
@@ -129,8 +134,8 @@ Whenever the diff touches `src/lib/**` (excluding `*.generated.ts`), `bin/**`, `
 
 Whenever the diff modifies `src/lib/protocols/{mcp,a2a}.ts`, `src/lib/adapters/legacy/**`, `src/lib/types/v*-*/**`, `schemas/registry/**`, or anything that affects how the SDK speaks to upstream AdCP agents, you MUST:
 
-- Delegate to `ad-tech-protocol-expert` with the changed paths and a one-line "what to evaluate" — that subagent grades AdCP conformance.
-- Delegate to `javascript-protocol-expert` if the change touches transport, tool definitions, or MCP/A2A SDK usage.
+- Grade AdCP conformance yourself against the changed paths: read the relevant schema in `schemas/cache/{version}/` and the adapter/type code, and confirm the wire shape matches.
+- Give transport, tool-definition, and MCP/A2A SDK-usage changes an extra-careful read: the official `@a2a-js/sdk` / `@modelcontextprotocol/sdk` clients must be used, never custom HTTP/SSE.
 - Confirm the change does not violate the **witness, not translator** invariant (no fabricated fields, no silent normalization, no placeholder substitution).
 
 ### 4. Test-plan honesty
@@ -139,7 +144,7 @@ Read the PR description's test plan. If a checkbox describing **manual verificat
 
 - Quote the unchecked item in your review.
 - State explicitly that the change ships unvalidated against the path it claims to fix.
-- Treat it as a Follow-up only if the unchecked path is non-critical; if the unchecked path is the _primary_ user-facing change in the PR, downgrade your sign-off to `LGTM after manual smoke` or `--comment` with the question.
+- Treat it as a Follow-up only if the unchecked path is non-critical; if the unchecked path is the _primary_ user-facing change in the PR, downgrade your sign-off to `LGTM after manual smoke` or verdict `comment` with the question.
 
 "Blocked on dev credentials" is the author's problem, not your reason to skip the check.
 
@@ -147,22 +152,22 @@ Read the PR description's test plan. If a checkbox describing **manual verificat
 
 ## Picking the action
 
-Three actions are available:
+Three verdicts are available — write exactly one to the `ARGUS_VERDICT` file:
 
-- `gh pr review <PR> --approve --body-file <file>`
-- `gh pr review <PR> --comment --body-file <file>`
-- `gh pr review <PR> --request-changes --body-file <file>`
+- `approve`
+- `comment`
+- `request-changes`
 
 **Decision tree (apply in order):**
 
-1. MUST FIX issue found (per the section above) → `--request-changes`. Stop.
-2. PR has any of these labels → `--comment`. Append the label note.
+1. MUST FIX issue found (per the section above) → `request-changes`. Stop.
+2. PR has any of these labels → `comment`. Append the label note.
    - `do-not-auto-approve`, `wip`, `needs-human-review`, `security`, `breaking-change`
-3. Otherwise, your judgment. Verdict ratio target is ~85% approve. Clean, contained change with no MUST FIX issue → `--approve`. Genuinely uncertain (open question for the author, ambiguous intent, needs context you can't verify from the diff) → `--comment` with the question — say what would flip you to approve.
+3. Otherwise, your judgment. Verdict ratio target is ~85% approve. Clean, contained change with no MUST FIX issue → `approve`. Genuinely uncertain (open question for the author, ambiguous intent, needs context you can't verify from the diff) → `comment` with the question — say what would flip you to approve.
 
 **Scrutiny hint:** `src/lib/protocols/**`, `src/lib/auth/**`, `src/lib/adapters/legacy/**`, `bin/**`, idempotency / replay / signing code, and changes to published-package wiring warrant harder reads than docs tweaks or `.md` prose. **But "docs" is not a synonym for "small."** A multi-hundred-line skill or guide that documents a new tool or migration path is behavior-affecting for adopters and deserves line-by-line scrutiny. The largest-file rule applies — open the file. Scrutiny is not blocking — if you read it carefully and it's clean, approve. Sensitive areas get more _scrutiny_, not more _blocking_.
 
-**Notes to append (only when downgrading to `--comment`):**
+**Notes to append (only when downgrading to verdict `comment`):**
 
 Label hold:
 
@@ -173,48 +178,23 @@ Label hold:
 
 ---
 
-## Delegate to experts — `code-reviewer` always, plus domain experts when relevant
+## Domain scrutiny — review inline
 
-You have access to specialist subagents via the `Task` tool.
+You run as a **single agent** in CI. Do the review yourself, inline — read the diff and the changed files directly with `gh pr diff`, `gh api`, and `Read`. Do **not** spawn subagents with the `Task` tool: this harness runs you as one agent and cannot fan out to expert subagents, and waiting on them is how a review stalls without ever recording a verdict.
 
-**Hard rule: `code-reviewer` runs on every PR that touches source code.** It is not optional and not subject to triage. Skipping it once is how internal-consistency bugs ship.
+Apply the right depth for what changed. These paths get the hardest reads — open the files and trace the change:
 
-**Step 1: `code-reviewer` is mandatory unless the PR is in the "skip everything" list below.**
+- `src/lib/protocols/{mcp,a2a}.ts` — transport, tool definitions, MCP/A2A SDK usage. Confirm the official `@a2a-js/sdk` / `@modelcontextprotocol/sdk` clients are used, never custom HTTP/SSE.
+- `src/lib/adapters/legacy/**`, `src/lib/types/v*-*/**` — AdCP wire conformance. Confirm no fabricated fields, no silent normalization (**witness, not translator**).
+- `src/lib/auth/**`, signing, replay, idempotency, governance, tenant code — security and data-safety: auth bypass, credential leaks, replay/idempotency corruption.
+- New/renamed public SDK surface (`src/lib/handlers/**`, `src/lib/index.ts`) — API-shape and DX impact; pair with the changeset-vs-wire-impact audit.
+- `bin/**` CLI changes — DX and correctness.
+- `skills/**/SKILL.md`, `docs/**` — behavior-affecting for adopters; the largest-file rule applies (docs are not a synonym for "small").
+- `scripts/build-*`, `scripts/sync-schemas*` — build-output correctness.
 
-**Skip-everything PRs (no experts, including no `code-reviewer`):**
+A finding that hits a MUST FIX category (security hole, mock-data / fabrication, breaking contract without a `major` changeset, missing changeset on library/CLI code) drives `request-changes` — don't wave it through.
 
-- Docs-only (`docs/**`, `*.md`, `*.mdx` with no `src/`/`bin/`/`scripts/` changes)
-- Changeset-only (`.changeset/*.md`)
-- Test-only (`test/**`, `**/__tests__/**`, `*.test.ts` with no source changes)
-- Comment/typo/formatting changes
-- Pure dependency bumps with no API surface change
-
-Every other PR runs `code-reviewer`. No exceptions for "small" PRs, "obvious" PRs, or "I already read the diff" PRs.
-
-**Step 2: Triage for domain experts on top of `code-reviewer`.** Look at the changed files and decide which domain specialists are _also_ relevant. Domain experts stack on top of `code-reviewer`, they do not replace it.
-
-**Common domain-expert triggers in adcp-client:**
-
-- `src/lib/protocols/{mcp,a2a}.ts` changed → `javascript-protocol-expert` + `ad-tech-protocol-expert` (mandatory)
-- `src/lib/adapters/legacy/**` or `src/lib/types/v*-*/**` changed → `ad-tech-protocol-expert` (mandatory)
-- `src/lib/auth/**`, signing, replay, idempotency, governance, tenant code → `security-reviewer` (mandatory)
-- New/renamed handler or SDK surface (`src/lib/handlers/**`, `src/lib/index.ts`) → `agentic-product-architect` + `dx-expert`
-- `bin/**` CLI changes → `dx-expert` + `code-reviewer`
-- `skills/**/SKILL.md` changes → `prompt-engineer` + `docs-expert`
-- `scripts/build-*` or `scripts/sync-schemas*` → `code-reviewer` with explicit focus on build-output correctness
-- `examples/**` reference-adapter changes → `ad-tech-protocol-expert`
-- Education / certification content → `education-expert`
-
-**Step 3: Call experts in parallel.** Issue `code-reviewer` and any chosen domain experts as a **single batch** of `Task` calls — never one at a time.
-
-**Rules:**
-
-- `code-reviewer` runs on every source-code PR. Domain experts stack on top, they don't replace it.
-- Run all chosen experts in **one batch of parallel Task calls** — not sequentially.
-- Always include the PR number and a one-line "what to evaluate" in the prompt to each expert.
-- A subagent verdict naming a MUST FIX category (security High, mock-data injection, breaking contract without major, missing changeset) flows through to `--request-changes` — you don't get to override it without naming a specific reason.
-- A subagent verdict of `sound-with-caveats` becomes a Follow-up in your review, not a block.
-- The only PRs that skip every expert (including `code-reviewer`) are the skip-everything list above.
+**Low-scrutiny (skip the deep read, still glance):** docs-only, changeset-only, test-only, comment/typo/formatting, pure dependency bumps with no API surface change.
 
 ---
 
@@ -225,33 +205,23 @@ Every other PR runs `code-reviewer`. No exceptions for "small" PRs, "obvious" PR
 3. **Apply the largest-file rule.** From the `files` array, sort by `additions + deletions`, drop generated files, and `Read` every remaining file with >200 net lines changed. Cite at least one `file:line` from each in your review.
 4. **Apply the changeset-vs-wire-impact audit** if `src/lib/**`, `bin/**`, or wire-affecting `scripts/**` changed. Confirm the changeset exists with the right type.
 5. **Apply the protocol-coherence audit** if `src/lib/protocols/**`, `src/lib/adapters/legacy/**`, `src/lib/types/v*-*/**`, or `schemas/registry/**` changed.
-6. **Triage:** `code-reviewer` is mandatory unless the PR is in the skip-everything list. Decide which _additional_ domain experts the PR needs on top of `code-reviewer`. State the triage decision in one short line before calling anything — e.g., "Triage: docs-only, skip all experts" or "Triage: protocol change → `code-reviewer` + `javascript-protocol-expert` + `ad-tech-protocol-expert`".
-7. **Delegate:** issue `code-reviewer` and any chosen domain experts as a **single parallel batch** of `Task` calls. Wait for verdicts.
-8. Synthesize by **severity**, not volume. A long list of `code-reviewer` nits is not a block. A single `security-reviewer` **High** with a named `file:line` and a concrete attack path is a block. Map only Major/Critical findings to `--request-changes`: `security-reviewer` **High**, `ad-tech-protocol-expert` **unsound** (with cited spec divergence), `code-reviewer` **Blocker**, a breaking SDK change without a `major` changeset, mock-data injection, or custom HTTP where the official SDK should be used. Medium/Low/sound-with-caveats verdicts become Follow-ups, not blocks.
-9. **Apply the mandatory coverage checks** (largest-file rule, changeset-vs-wire-impact audit, protocol-coherence audit, test-plan honesty). Each can independently produce a Follow-up or downgrade from `--approve` to `--comment`. Do not skip them because expert verdicts came back clean — experts are scoped, the coverage checks catch what falls between them.
-10. Apply the decision tree above to choose `--approve` / `--comment` / `--request-changes`.
-11. Write the review body following the review format, in the voice rules above. Cite subagent verdicts inline where they drove the decision ("`ad-tech-protocol-expert`: unsound — `legacy/v3-1-beta` adapter is fabricating a `format_id` the upstream didn't return").
-12. Write the review body to `/tmp/argus-review.md` with the `Write` tool, then post it:
-
-    ```bash
-    gh pr review $PR_NUMBER --approve --body-file /tmp/argus-review.md
-    ```
-
-    Do NOT inline the body with `--body "$(cat <<'EOF' ...)"` or any other command
-    substitution — the permission system rejects commands containing `$(...)` and
-    the post will be denied. `Write` + `--body-file` is the only reliable path.
-
-13. That's the deliverable. Don't summarize what you did afterward.
+6. **Scrutinize inline.** Apply the domain-scrutiny guidance above to the changed paths — read the files yourself. Do not spawn subagents.
+7. **Apply the mandatory coverage checks** (largest-file rule, changeset-vs-wire-impact audit, protocol-coherence audit, test-plan honesty). Each can independently produce a Follow-up or downgrade `approve` → `comment`.
+8. Synthesize by **severity**, not volume. A long list of nits is not a block. One concrete security hole, contract break, or cited spec divergence with a named `file:line` is. Map only Major/Critical findings to `request-changes`: a security **High**, an **unsound** protocol change (with cited spec divergence), a breaking SDK change without a `major` changeset, mock-data injection, or custom HTTP where the official SDK should be used. Medium/Low become Follow-ups, not blocks.
+9. Apply the decision tree above to choose `approve` / `comment` / `request-changes`.
+10. Write the review body — following the review format, in the voice rules above — to the `ARGUS_REVIEW_BODY` file with the `Write` tool.
+11. Write your one-word verdict (`approve` / `comment` / `request-changes`) to the `ARGUS_VERDICT` file with the `Write` tool.
+12. That's the deliverable. Do **not** call `gh pr review`, and don't summarize what you did afterward — the arbiter step reads your two files and posts the review under your verdict.
 
 **Constraints:**
 
 - Use `$PR_NUMBER` environment variable — do not guess the PR number.
 - Sign off with one of the ladder phrases above.
 - One dry-aside maximum. Skip it entirely if the PR is in real trouble.
-- Never use `--approve` if the decision tree says otherwise, even if the code is genuinely clean.
+- Never write `approve` to the verdict file if the decision tree says otherwise, even if the code is genuinely clean.
 
 ## Required final action
 
-You MUST end your session by calling `gh pr review` exactly once, with one of `--approve`, `--comment`, or `--request-changes`, per the decision tree above. Write the body to a file first and pass it with `--body-file`. Do not post a sticky summary comment via `gh pr comment` — the review itself is the deliverable. Do not exit without calling `gh pr review`. If the post is denied or errors, fix the command form and retry — do not give up and end the session; a session that ends without a successfully posted `gh pr review` is a failed review.
+You MUST end your session by writing **both** files with the `Write` tool: the review body to `ARGUS_REVIEW_BODY`, and exactly one of `approve` / `comment` / `request-changes` to `ARGUS_VERDICT`. Do **not** call `gh pr review` or `gh pr comment` — the arbiter step posts your verdict. Do not end your turn until both files exist; a turn that ends without a verdict file falls back to a plain comment (never an approval), which is a failed review.
 
 Begin the review now.

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,10 +1,16 @@
 name: AI PR Review (Argus)
 
-# Argus is an LLM PR reviewer that posts an `--approve`, `--comment`, or
-# `--request-changes` review on every non-dependabot PR. It reads the diff,
-# delegates to subagents when relevant (javascript-protocol-expert,
-# ad-tech-protocol-expert, security-reviewer, code-reviewer, etc.), and
-# writes the review in bokelley's voice.
+# Argus is an LLM PR reviewer that posts an approve / comment / request-changes
+# review on every non-dependabot PR, in bokelley's voice. It runs in two stages:
+#
+#   1. reviewer  — a single Claude agent reads the diff and changed files inline
+#                  (no Task subagents) and writes its verdict + review body to two
+#                  files.
+#   2. arbiter   — a deterministic step reads those files and posts the review.
+#
+# Splitting posting out of the reviewer means a reviewer that ends its turn early
+# cannot swallow the verdict: the arbiter posts what the reviewer recorded,
+# and degrades to a COMMENT (never a fabricated approval) when no verdict was written.
 #
 # Reviews are posted as the AAO IPR Bot GitHub App (reused — same App that
 # powers ipr-agreement.yml), so they count toward the "1 review required"
@@ -201,6 +207,8 @@ jobs:
           PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           REPO: ${{ github.repository }}
+          ARGUS_VERDICT: ${{ runner.temp }}/argus-verdict.txt
+          ARGUS_REVIEW_BODY: ${{ runner.temp }}/argus-review.md
         run: |
           set -euo pipefail
           # Read the prompt from the PR's base SHA, not the working tree or PR
@@ -222,6 +230,8 @@ jobs:
             echo "- PR_NUMBER: $PR_NUMBER"
             echo "- REPO: $REPO"
             echo "- PR_BASE_REF: $PR_BASE_REF"
+            echo "- ARGUS_REVIEW_BODY (Write your review body to this exact path): $ARGUS_REVIEW_BODY"
+            echo "- ARGUS_VERDICT (Write one word — approve, comment, or request-changes — to this exact path): $ARGUS_VERDICT"
             echo "${SENTINEL}"
           } >> "$GITHUB_OUTPUT"
 
@@ -231,14 +241,12 @@ jobs:
         continue-on-error: true
         uses: anthropics/claude-code-action@v1
         env:
-          # Setting allowed_non_write_users below auto-enables the action's
-          # subprocess env scrub on EVERY run, not just read-only-actor runs.
-          # Per the action's security docs the scrub strips GitHub Actions
-          # secrets from Bash subprocesses — which would break the
-          # `gh pr review` call that is the review's deliverable. This
-          # workflow never executes PR-controlled code (base-SHA checkout,
-          # API-only inspection, tight tool allowlist), so opt out to keep
-          # the posting path working.
+          # allowed_non_write_users (below) auto-enables the action's subprocess
+          # env scrub on EVERY run, which strips the GitHub token from Bash
+          # subprocesses — that would break the reviewer's own `gh pr view/diff/api`
+          # reads. This job never executes PR-controlled code (base-SHA checkout,
+          # API-only inspection, tight tool allowlist), so opt out. Posting is done
+          # by the separate arbiter step below, not by the agent.
           CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: '0'
         with:
           prompt: ${{ steps.build-prompt.outputs.ARGUS_PROMPT }}
@@ -255,100 +263,89 @@ jobs:
           # rather than trigger a review whose approval counts toward branch
           # protection.
           allowed_non_write_users: fgranata
+          # No `gh pr review` (the arbiter posts) and no `Task` (the reviewer works
+          # as a single agent inline — subagent dispatch in this harness stalls the
+          # run and never records a verdict). Write is how it emits the two files.
           claude_args: |
-            --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr review:*),Bash(gh api repos/*/pulls/*),Bash(gh api repos/*/contents/*),Bash(gh api repos/*/issues/*),Read,Write,Glob,Grep,Task"
+            --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh api repos/*/pulls/*),Bash(gh api repos/*/contents/*),Bash(gh api repos/*/issues/*),Read,Write,Glob,Grep"
             --max-turns 60
             --model claude-opus-4-8
             --effort high
 
-      - name: Verify Argus posted a review
-        id: verify
+      # ─────────────────────────────────────────────────────────────────────
+      # Arbiter: post the verdict.
+      #
+      # The reviewer does NOT call `gh pr review` — it writes its verdict
+      # (approve|comment|request-changes) and review body to two files. This
+      # deterministic step reads them and posts the review, so a reviewer that
+      # ends its turn early cannot swallow the verdict. It degrades safely,
+      # in order:
+      #   1. valid verdict + body        → post that review (approve/comment/request-changes)
+      #   2. no verdict but body present → post the body as a COMMENT (never an approval)
+      #   3. only the agent's final text → post that as a COMMENT
+      #   4. nothing usable              → leave a plain "could not complete" comment
+      # ─────────────────────────────────────────────────────────────────────
+      - name: Post review (arbiter)
         if: always() && steps.app-token.outcome == 'success' && steps.workflow-mod.outputs.modified != 'true' && steps.skip-check.outputs.skip != 'true'
         shell: bash
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-          LATEST="$(gh api "/repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
-            --jq "[.[] | select(
-              .user.login == \"${ARGUS_BOT_LOGIN}\"
-              and (((.body // \"\") | contains(\"Argus is **not auto-reviewing**\")) | not)
-              and (((.body // \"\") | contains(\"Argus review could not complete\")) | not)
-            )] | sort_by(.submitted_at) | last // {}")"
-          STATE="$(echo "$LATEST" | jq -r '.state // ""')"
-          SUBMITTED="$(echo "$LATEST" | jq -r '.submitted_at // ""')"
-          echo "Latest ${ARGUS_BOT_LOGIN} review — state: $STATE, submitted: $SUBMITTED"
-          if [ -z "$STATE" ]; then
-            echo "review_posted=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::No ${ARGUS_BOT_LOGIN} review found on PR #$PR_NUMBER"
-            exit 0
-          fi
-          SUBMITTED_TS="$(date -u -d "$SUBMITTED" +%s)"
-          NOW_TS="$(date -u +%s)"
-          if [ $((NOW_TS - SUBMITTED_TS)) -gt 600 ]; then
-            echo "review_posted=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::Latest ${ARGUS_BOT_LOGIN} review is older than 10 minutes — Argus didn't post in this run"
-            exit 0
-          fi
-          echo "review_posted=true" >> "$GITHUB_OUTPUT"
-          echo "review_state=$STATE" >> "$GITHUB_OUTPUT"
-
-      # ─────────────────────────────────────────────────────────────────────
-      # Fallback: Claude finished but never called `gh pr review` (it
-      # occasionally ends its session early instead of retrying a denied
-      # posting command). Its final output is still a written review — post
-      # it as a COMMENT review so the PR gets the substance without granting
-      # an approval Claude never explicitly issued.
-      # ─────────────────────────────────────────────────────────────────────
-      - name: Post fallback review from Claude output
-        id: fallback
-        if: steps.workflow-mod.outputs.modified != 'true' && steps.skip-check.outputs.skip != 'true' && steps.ai-review.outcome == 'success' && steps.verify.outputs.review_posted != 'true'
-        continue-on-error: true
-        shell: bash
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
+          VERDICT_FILE: ${{ runner.temp }}/argus-verdict.txt
+          BODY_FILE: ${{ runner.temp }}/argus-review.md
           EXECUTION_FILE: ${{ steps.ai-review.outputs.execution_file }}
-        run: |
-          set -euo pipefail
-          echo "posted=false" >> "$GITHUB_OUTPUT"
-          FILE="${EXECUTION_FILE:-}"
-          if [ -z "$FILE" ] || [ ! -f "$FILE" ]; then
-            echo "No execution file at '$FILE' — nothing to fall back to."
-            exit 0
-          fi
-          BODY="$(jq -r '[.[] | select(.type == "result")] | last | .result // ""' "$FILE")"
-          if [ -z "$BODY" ] || [ "$BODY" = "null" ]; then
-            echo "Execution result has no final text — nothing to fall back to."
-            exit 0
-          fi
-          # GitHub caps review bodies at 65536 chars; leave room for the preamble.
-          BODY="$(printf '%s' "$BODY" | head -c 60000)"
-          PREAMBLE=$'> [!NOTE]\n> Argus finished its review but failed to post it through the normal path. This is its final output, posted verbatim as a **comment** (not an approval) by the workflow fallback.\n\n'
-          printf '%s%s' "$PREAMBLE" "$BODY" > /tmp/fallback-review-body.md
-          gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
-            -X POST \
-            -f event='COMMENT' \
-            -f body="$(cat /tmp/fallback-review-body.md)"
-          # Later writes to GITHUB_OUTPUT override earlier ones.
-          echo "posted=true" >> "$GITHUB_OUTPUT"
-          echo "Posted fallback COMMENT review on PR #$PR_NUMBER"
-
-      - name: Comment on PR if Argus review failed
-        if: steps.workflow-mod.outputs.modified != 'true' && steps.skip-check.outputs.skip != 'true' && steps.fallback.outputs.posted != 'true' && (steps.ai-review.outcome == 'failure' || steps.verify.outputs.review_posted != 'true')
-        uses: actions/github-script@v7
-        env:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        with:
-          github-token: ${{ steps.app-token.outputs.token }}
-          script: |
-            const runUrl = process.env.RUN_URL;
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `⚠️ **Argus review could not complete**\n\nThe automated review encountered an issue (possibly reached max turns, timed out, or failed to post the final \`gh pr review\`). A human reviewer should take this PR.\n\n[View workflow run](${runUrl})\n\n<sub>This is an automated message from the Argus AI review workflow.</sub>`
-            })
+        run: |
+          # No `set -e`: a failed post must fall through to the next recovery tier.
+          set -uo pipefail
+
+          VERDICT=""
+          if [ -f "$VERDICT_FILE" ]; then
+            VERDICT="$(tr -d '[:space:]' < "$VERDICT_FILE" | tr '[:upper:]' '[:lower:]')"
+          fi
+          BODY=""
+          if [ -f "$BODY_FILE" ]; then
+            BODY="$(cat "$BODY_FILE")"
+          fi
+
+          # Map the reviewer's verdict to a gh review event. Anything else is
+          # treated as "no verdict" and degrades to a COMMENT below.
+          EVENT=""
+          case "$VERDICT" in
+            approve)         EVENT="--approve" ;;
+            comment)         EVENT="--comment" ;;
+            request-changes) EVENT="--request-changes" ;;
+          esac
+
+          POST_FILE="${RUNNER_TEMP}/argus-post.md"
+
+          # Tier 1 — valid verdict + body: post the real review.
+          if [ -n "$EVENT" ] && [ -n "$BODY" ]; then
+            printf '%s' "$BODY" | head -c 60000 > "$POST_FILE"
+            if gh pr review "$PR_NUMBER" "$EVENT" --body-file "$POST_FILE"; then
+              echo "Posted '$VERDICT' review on PR #$PR_NUMBER"
+              exit 0
+            fi
+            echo "::warning::gh pr review ($VERDICT) failed — degrading to a COMMENT."
+          fi
+
+          # Tiers 2/3 — recover the substance, never fabricate an approval.
+          RECOVERED="$BODY"
+          if [ -z "$RECOVERED" ] && [ -n "${EXECUTION_FILE:-}" ] && [ -f "$EXECUTION_FILE" ]; then
+            RECOVERED="$(jq -r '[.[] | select(.type == "result")] | last | .result // ""' "$EXECUTION_FILE")"
+            [ "$RECOVERED" = "null" ] && RECOVERED=""
+          fi
+
+          if [ -n "$RECOVERED" ]; then
+            PREAMBLE=$'> [!NOTE]\n> Argus did not record a clean verdict this run (it may have ended early). Posting its output as a **comment** — not an approval. A human reviewer should take this PR.\n\n'
+            { printf '%s' "$PREAMBLE"; printf '%s' "$RECOVERED"; } | head -c 60000 > "$POST_FILE"
+            if gh pr review "$PR_NUMBER" --comment --body-file "$POST_FILE"; then
+              echo "Posted fallback COMMENT review on PR #$PR_NUMBER"
+              exit 0
+            fi
+            echo "::warning::Fallback COMMENT review failed — leaving a plain note."
+          fi
+
+          # Tier 4 — nothing usable: leave a plain note so the PR isn't silently unreviewed.
+          gh pr comment "$PR_NUMBER" --body "⚠️ **Argus review could not complete** (no verdict or review body was produced). A human reviewer should take this PR. [View workflow run](${RUN_URL})"


### PR DESCRIPTION
## Why

The Argus reviewer stalls on **source-code PRs** and never posts an approval — they sit at `REVIEW_REQUIRED` while a fallback drops a non-approval COMMENT. Diagnosis (three runs on #2345 vs a working run on #2333 and Brian's #2346):

- Argus is a **single agent** that must both run its `Task` sub-reviewers **and** call `gh pr review` itself.
- On source PRs it dispatches the subagents, then **ends its turn early** ("waiting for the experts to report") before posting. Posting is the last thing it does, so nothing lands.
- Config/docs PRs skip subagents (the prompt's skip-everything list), so they post fine — which is why maintainer PRs like #2346 approve and source PRs don't. It's **not** an author-permission issue (the PR author has write; the actor gate passes).

## What Changed

Split the flow into **reviewer → arbiter**, mirroring how Argus v2 works (posting decoupled from the reviewer):

- **Reviewer** writes its verdict (`approve`/`comment`/`request-changes`) and review body to two files (`ARGUS_VERDICT`, `ARGUS_REVIEW_BODY`); it no longer calls `gh pr review`.
- **`Post review (arbiter)`** — a new deterministic bash step reads those files and posts the review. Degrades safely in tiers: valid verdict+body → post it; body only → COMMENT; agent final text → COMMENT; nothing → a plain note. **Never fabricates an approval.** Replaces the old verify + fallback + failure-comment steps.
- **Inline review, no `Task`.** Removed the mandatory subagent dispatch and dropped `Task` + `gh pr review` from the tool allowlist. The reviewer reads the diff and files itself. This removes the stall trigger and the permission denials; #2333 shows the subagents weren't adding value (it approved despite 13 denials, i.e. they were failing). Domain-scrutiny guidance is preserved inline.

## Notes / testing

- **This PR is intentionally not auto-reviewed by Argus** — it touches `.github/ai-review/**` + the workflow, which both `paths-ignore` and the workflow-mod gate exclude. Needs a human review/merge (no chicken-and-egg).
- `pull_request_target` runs the reviewer/prompt from the **base SHA**, so the new behavior only takes effect **after this merges to `main`**. It can't be exercised on an open PR beforehand. Validated pre-merge via `npm run lint:workflows`, YAML parse, and logic review; the live proof is the next Argus run on a source-code PR after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)