### PR TITLE
ci(release): mint App token so release PR triggers required checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,24 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
+      # Mint an AAO IPR Bot installation token so events created by this
+      # workflow (the release-PR branch push and the "chore: release package"
+      # PR itself) trigger downstream workflows. GitHub suppresses workflow
+      # triggers for events authored by the default GITHUB_TOKEN, which left
+      # the release PR permanently BLOCKED on the pull_request_target-based
+      # `IPR Policy / Signature` required check — it never fired, so only an
+      # admin bypass could merge. An App identity's events are not suppressed.
+      - name: Mint release bot token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.IPR_APP_ID }}
+          private-key: ${{ secrets.IPR_APP_PRIVATE_KEY }}
+
       - name: Checkout Repo
         uses: actions/checkout@v5
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v5
@@ -50,7 +66,7 @@ jobs:
           title: 'chore: release package'
           commit: 'chore: release package'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_CONFIG_PROVENANCE: true
 
       # `npm deprecate '@adcp/client@…'` is run manually post-release for now.


### PR DESCRIPTION
## Problem

`.github/workflows/release.yml` runs `changesets/action@v1` with `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}`. GitHub suppresses workflow triggers for events created by the default `GITHUB_TOKEN` (its recursion guard), so the bot-opened **"chore: release package"** PR never fires the `pull_request_target`-based **IPR Policy / Signature** check (`.github/workflows/ipr-agreement.yml`).

That check is a **required** status check on `main` (the "ipr policy" ruleset), so every release PR sits BLOCKED on *"Expected — Waiting for status to be reported"* and can only be merged by an admin bypass. PR #2348 is currently stuck this way.

## Fix

Mint an **AAO IPR Bot** installation token (`IPR_APP_ID` / `IPR_APP_PRIVATE_KEY`) and use it for both the checkout and the changesets step, instead of the default `GITHUB_TOKEN`. The release PR is then attributed to the App identity, whose events **do** trigger downstream workflows — so the IPR check fires and the PR is born mergeable.

Mirrors the two in-org reference implementations:
- `adcontextprotocol/adcp` → `.github/workflows/release.yml` (same changesets flow; uses `RELEASE_APP_ID`/`RELEASE_APP_PRIVATE_KEY`).
- `adcontextprotocol/adcp-client-python` → `.github/workflows/release-please.yml` (uses `IPR_APP_ID`/`IPR_APP_PRIVATE_KEY`).

## Which App / prerequisite verification

Verified before wiring (I only have `WRITE`, not admin, so this was the key check):
- The org secrets available to this repo are `IPR_APP_*` and `SECRETARIAT_APP_*` (no `RELEASE_APP_*` — that App is scoped to `adcp` only).
- `adcp/governance/ipr-bot-setup.md` documents the **AAO IPR Bot** App's repository permissions as **Contents: Read & write** + **Pull requests: Write**, and lists `adcontextprotocol/adcp-client` in its installation scope. GitHub App permissions are App-wide, so this is exactly what the changesets branch-push + PR-open need.
- Same secrets are already used on this repo by `ai-review.yml` and `ipr-agreement.yml`, and drive the sibling `adcp-client-python` release flow. **No admin handoff required.**

I used `create-github-app-token@v1` to match this repo's existing usage in `ai-review.yml` (rather than `@v3` from the task text) so the two workflows stay consistent.

## Scope / notes

- `.github/`-only change → no changeset needed (the changeset-check job passes).
- Because it modifies a workflow file, Argus won't auto-review it — a human merges.
- This fixes **future** release PRs. It does **not** unstick the current #2348 — that still needs an admin to merge or reopen it.

## Verification

- `npm run lint:workflows` → passed for 16 files.
- YAML parses; release steps: Mint release bot token | Checkout Repo | Setup Node.js | Install Dependencies | Build | Create Release Pull Request or Publish to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)