### PR TITLE
fix(sync): stop schema syncs from clobbering the primary pin's shared surfaces

### DIFF
--- a/.changeset/sync-schemas-shared-surfaces.md
+++ b/.changeset/sync-schemas-shared-surfaces.md
@@ -1,0 +1,9 @@
+---
+'@adcp/sdk': patch
+---
+
+Stop schema syncs from clobbering checked-in protocol skills and the registry spec.
+
+`sync-schemas` wrote two non-version-scoped, checked-in files on every run: the protocol skills (`skills/adcp-*`) and `schemas/registry/registry.yaml`. A side-bundle sync (`sync-schemas -- 3.0.12`, `sync-schemas:3.1-beta`) therefore overwrote the primary pin's skills with an older version's content, and even the primary sync overwrote the registry spec — which is actually owned by `generate-registry-types --sync` from a different upstream. Both left a spurious diff in the working tree after any sync.
+
+The skill sync now runs only when syncing the primary pin, the `latest/` cache pointer is likewise only repointed for the primary pin (a side-bundle sync no longer silently makes the SDK validate against an older version by default), and the registry spec is no longer written by `sync-schemas` at all (its owner is `generate-registry-types --sync`). This removes the fragile `restoreFromHead`/`RESTORE_PATHS` workaround in the beta sync script.

--- a/scripts/sync-3-1-beta-schemas.ts
+++ b/scripts/sync-3-1-beta-schemas.ts
@@ -6,10 +6,11 @@
  * schemas.
  *
  * Wraps `syncSchemas()` so we inherit cosign verification, sha256 check,
- * and tarball extraction. The wrapper restores the `latest` symlink to
- * the SDK's primary pin afterwards — `syncSchemas()` always points
- * `latest/` at whatever it just synced, which is correct for a pin bump
- * but wrong for an opt-in side-bundle.
+ * and tarball extraction. For a side-bundle, `syncSchemas()` populates only the
+ * version-scoped caches — it leaves the shared surfaces (protocol skills, the
+ * `latest/` pointer) at the primary pin and never writes the registry spec — so
+ * the wrapper's only cleanup is a defensive re-affirmation of the `latest`
+ * symlink against the primary pin.
  */
 
 import { existsSync, lstatSync, readFileSync, rmSync, symlinkSync } from 'fs';
@@ -22,23 +23,6 @@ const SCHEMA_CACHE_DIR = path.join(REPO_ROOT, 'schemas/cache');
 const COMPLIANCE_CACHE_DIR = path.join(REPO_ROOT, 'compliance/cache');
 const BETA_VERSION = '3.1.0-beta.7';
 const GITHUB_DIST_BASE_URL = 'https://raw.githubusercontent.com/adcontextprotocol/adcp/main/dist';
-
-/**
- * Paths that `syncSchemas` overwrites as a side effect of any tarball
- * extraction — protocol-managed skills, the registry OpenAPI spec, and any
- * other check-in surfaces that piggyback on the primary sync. An opt-in
- * beta sync MUST NOT bump these against the SDK's primary pin, so we
- * restore them from `HEAD` after the sync runs.
- *
- * If you add a new check-in surface to `syncSchemas`, add the path here
- * (or refactor `syncSchemas` to expose a schemas-only mode).
- */
-const RESTORE_PATHS = [
-  'schemas/registry/registry.yaml',
-  'skills/adcp-brand/SKILL.md',
-  'skills/adcp-creative/SKILL.md',
-  'skills/adcp-media-buy/SKILL.md',
-];
 
 function getPrimaryAdcpVersion(): string {
   const versionFile = path.join(REPO_ROOT, 'ADCP_VERSION');
@@ -65,26 +49,6 @@ function restoreLatestSymlink(cacheRoot: string, primaryVersion: string): void {
   console.log(`🔗 ${cacheRoot}/latest → ${primaryVersion}`);
 }
 
-function restoreFromHead(paths: readonly string[]): void {
-  const tracked = paths.filter(p => existsSync(path.join(REPO_ROOT, p)));
-  if (tracked.length === 0) return;
-  // `git checkout HEAD --` is the narrowest restoration: it touches only the
-  // listed paths, never the working-tree state of anything else, and fails
-  // loudly if the paths aren't tracked. Run from REPO_ROOT so paths resolve
-  // relative to the git work tree.
-  const result = spawnSync('git', ['checkout', 'HEAD', '--', ...tracked], {
-    cwd: REPO_ROOT,
-    encoding: 'utf8',
-  });
-  if (result.status !== 0) {
-    throw new Error(
-      `Failed to restore side-effect paths from HEAD:\n  ${result.stderr || result.stdout}\n` +
-        `Run \`git status\` and restore manually before re-running.`
-    );
-  }
-  console.log(`♻️  Restored ${tracked.length} side-effect path(s) from HEAD (primary-pin state preserved).`);
-}
-
 function hasBetaCache(): boolean {
   return (
     existsSync(path.join(SCHEMA_CACHE_DIR, BETA_VERSION)) && existsSync(path.join(COMPLIANCE_CACHE_DIR, BETA_VERSION))
@@ -100,26 +64,24 @@ async function main(): Promise<void> {
     restoreLatestSymlink(COMPLIANCE_CACHE_DIR, primary);
     return;
   }
-  const delegatedToFallback = await syncBetaSchemasWithFallback();
+  const delegatedToFallback = await syncBetaSchemasWithFallback(primary);
   if (delegatedToFallback) return;
-  // `syncSchemas` repointed `latest/` at the beta. Move it back so the
-  // primary GA pin remains the default bundle for downstream consumers.
+  // As a side-bundle, `syncSchemas` no longer repoints `latest/` at the beta
+  // (it gates the pointer behind the primary pin). Re-affirm it defensively so
+  // the primary GA pin stays the default bundle regardless of prior cache state.
   restoreLatestSymlink(SCHEMA_CACHE_DIR, primary);
   restoreLatestSymlink(COMPLIANCE_CACHE_DIR, primary);
-  // When the beta is the primary pin, the synced tracked artifacts are the
-  // desired state; restoring from HEAD would undo the intended schema bump.
-  if (primary !== BETA_VERSION) {
-    // `syncSchemas` also overwrites tracked artifacts (registry.yaml, protocol
-    // skills) from the synced tarball. Those track the primary pin, not the
-    // opt-in beta — restore them from HEAD.
-    restoreFromHead(RESTORE_PATHS);
-  }
+  // No skill restore needed: unless the beta is itself the primary pin,
+  // `syncSchemas` runs schemas-only and never touches the shared skills, so
+  // they already hold the primary pin's committed content.
   console.log(`✅ ${BETA_VERSION} schemas at schemas/cache/${BETA_VERSION}/`);
 }
 
-async function syncBetaSchemasWithFallback(): Promise<boolean> {
+async function syncBetaSchemasWithFallback(primary: string): Promise<boolean> {
   try {
-    await syncSchemas(BETA_VERSION);
+    // Only write the shared surfaces (skills, `latest/` pointer) when the beta
+    // IS the primary pin. As a side-bundle they stay at the primary pin's state.
+    await syncSchemas(BETA_VERSION, { includeSharedSurfaces: primary === BETA_VERSION });
     return false;
   } catch (err) {
     if (process.env.ADCP_BASE_URL || process.env.ADCP_BETA_GITHUB_FALLBACK === '0') {

--- a/scripts/sync-schemas.ts
+++ b/scripts/sync-schemas.ts
@@ -27,7 +27,6 @@ const REPO_ROOT = path.join(__dirname, '..');
 const SCHEMA_CACHE_DIR = path.join(REPO_ROOT, 'schemas/cache');
 const COMPLIANCE_CACHE_DIR = path.join(REPO_ROOT, 'compliance/cache');
 const SKILLS_DIR = path.join(REPO_ROOT, 'skills');
-const REGISTRY_SPEC_PATH = path.join(REPO_ROOT, 'schemas/registry/registry.yaml');
 
 // Sigstore keyless identity used by the upstream release workflow (adcontextprotocol/adcp#2273).
 // Accepts any branch or tag ref — the trust gate is upstream `release.yml`'s
@@ -336,8 +335,19 @@ function syncSkillsFromBundle(extractRoot: string): void {
  *
  * Throws on sha256 mismatch or extraction failure. Returns false if the tarball
  * endpoint returns 404 (caller may fall back to per-file schema sync).
+ *
+ * `schemas/cache/<version>/` and `compliance/cache/<version>/` are version-scoped,
+ * so any version can populate them without disturbing another. The protocol
+ * skills (`skills/adcp-*`) and the `latest/` pointer are NOT version-scoped —
+ * they are shared surfaces that track the primary pin. `includeSharedSurfaces`
+ * gates both so a side-bundle sync (an older legacy version, an opt-in beta)
+ * never overwrites the primary pin's skills or repoints its default bundle.
  */
-async function syncFromTarball(version: string, baseUrl = ADCP_BASE_URL): Promise<boolean> {
+async function syncFromTarball(
+  version: string,
+  baseUrl = ADCP_BASE_URL,
+  includeSharedSurfaces = true
+): Promise<boolean> {
   const tgzUrl = `${baseUrl}/protocol/${version}.tgz`;
   const shaUrl = `${tgzUrl}.sha256`;
 
@@ -383,8 +393,11 @@ async function syncFromTarball(version: string, baseUrl = ADCP_BASE_URL): Promis
     // build-seller-agent/ stay untouched; protocol-canonical ones (the
     // call-adcp-agent buyer skill plus per-protocol skills) are kept aligned
     // with the pinned spec version. Older tarballs (no manifest.contents.skills
-    // array) are silently skipped — the SDK-local copies stay as-is.
-    syncSkillsFromBundle(extractRoot);
+    // array) are silently skipped — the SDK-local copies stay as-is. Skipped
+    // entirely for side-bundle syncs so they keep the primary pin's skills.
+    if (includeSharedSurfaces) {
+      syncSkillsFromBundle(extractRoot);
+    }
 
     // Refs inside the tarball point to /schemas/latest/; rewrite for pinned versions.
     const schemaDest = path.join(SCHEMA_CACHE_DIR, version);
@@ -392,17 +405,21 @@ async function syncFromTarball(version: string, baseUrl = ADCP_BASE_URL): Promis
     const semanticVersion: string = indexJson.adcp_version || version;
     normalizeRefsInTree(schemaDest, semanticVersion);
 
-    // Registry spec lives in the same bundle; keep writing to its legacy location
-    // for downstream generators that import from schemas/registry/registry.yaml.
-    const registryInBundle = path.join(extractRoot, 'openapi/registry.yaml');
-    if (existsSync(registryInBundle)) {
-      mkdirSync(path.dirname(REGISTRY_SPEC_PATH), { recursive: true });
-      copyFileSync(registryInBundle, REGISTRY_SPEC_PATH);
-      console.log(`✅ Registry spec extracted → ${REGISTRY_SPEC_PATH}`);
-    }
+    // schemas/registry/registry.yaml is intentionally NOT written here. Although
+    // the protocol tarball ships an openapi/registry.yaml, the registry spec has
+    // its own upstream (agenticadvertising.org) and its own owner,
+    // `generate-registry-types --sync`. That live spec runs ahead of the pinned
+    // protocol bundle, so copying the tarball's copy only downgraded the checked-in
+    // file and left a spurious diff in every working tree after a plain sync.
 
-    updateLatestSymlink(SCHEMA_CACHE_DIR, version);
-    updateLatestSymlink(COMPLIANCE_CACHE_DIR, version);
+    // `latest/` is a shared, non-version-scoped pointer that resolves to the
+    // default bundle — so it tracks the primary pin, not whichever side-bundle
+    // is being synced. Repointing it for a legacy/beta sync would silently make
+    // the SDK validate against an older version by default. Gate it like skills.
+    if (includeSharedSurfaces) {
+      updateLatestSymlink(SCHEMA_CACHE_DIR, version);
+      updateLatestSymlink(COMPLIANCE_CACHE_DIR, version);
+    }
 
     console.log(`📁 Schemas:    ${path.join(SCHEMA_CACHE_DIR, version)}`);
     console.log(`📁 Compliance: ${path.join(COMPLIANCE_CACHE_DIR, version)}`);
@@ -417,7 +434,11 @@ async function syncFromTarball(version: string, baseUrl = ADCP_BASE_URL): Promis
 
 // Per-file schema fallback. Used only if the tarball endpoint is unavailable.
 // Compliance is NOT synced by this path — requires the tarball.
-async function syncSchemasPerFile(version: string, baseUrl = ADCP_BASE_URL): Promise<void> {
+async function syncSchemasPerFile(
+  version: string,
+  baseUrl = ADCP_BASE_URL,
+  includeSharedSurfaces = true
+): Promise<void> {
   const indexUrl = `${baseUrl}/schemas/${version}/index.json`;
   console.log(`📥 Fetching schema index ${indexUrl}`);
   const schemaIndex: SchemaIndex = await fetchJson(indexUrl);
@@ -459,7 +480,10 @@ async function syncSchemasPerFile(version: string, baseUrl = ADCP_BASE_URL): Pro
     missing.forEach(r => attempted.add(r));
   }
 
-  updateLatestSymlink(SCHEMA_CACHE_DIR, version);
+  // Shared `latest/` pointer tracks the primary pin only (see syncFromTarball).
+  if (includeSharedSurfaces) {
+    updateLatestSymlink(SCHEMA_CACHE_DIR, version);
+  }
   console.warn(
     '⚠️  Compliance tree unavailable (per-file fallback only syncs schemas). ' +
       'Storyboard tooling will fail until the tarball endpoint is reachable.'
@@ -529,22 +553,42 @@ function findMissingRefs(cacheDir: string, alreadyAttempted: Set<string>): Set<s
   return missing;
 }
 
-async function sync(version?: string): Promise<void> {
+/**
+ * Sync a protocol bundle into the caches.
+ *
+ * `options.includeSharedSurfaces` controls the non-version-scoped surfaces this
+ * script owns: the protocol skills (`skills/adcp-*`) and the `latest/` pointer.
+ * It defaults to `true` only when syncing the primary pin (the `ADCP_VERSION`
+ * file), so `npm run sync-schemas` refreshes them but a side-bundle sync
+ * (`sync-schemas -- 3.0.12`, the opt-in beta) leaves the primary pin's skills
+ * and its default bundle untouched. This is what stops legacy/beta syncs from
+ * clobbering the checked-in skills or silently repointing `latest/` — callers
+ * no longer need to restore them afterward.
+ */
+async function sync(version?: string, options: { includeSharedSurfaces?: boolean } = {}): Promise<void> {
   const adcpVersion = version || getTargetAdCPVersion();
-  console.log(`🔄 Syncing AdCP @ ${adcpVersion}`);
+  const primaryPin = getTargetAdCPVersion();
+  const includeSharedSurfaces = options.includeSharedSurfaces ?? adcpVersion === primaryPin;
+  console.log(
+    `🔄 Syncing AdCP @ ${adcpVersion}` +
+      (includeSharedSurfaces ? '' : ' (schemas only — skills + latest pointer stay at the primary pin)')
+  );
 
-  async function syncWithBase(baseUrl: string, options: { preferGithubTarballFallback?: boolean } = {}): Promise<void> {
-    const viaTarball = await syncFromTarball(adcpVersion, baseUrl);
-    if (!viaTarball && options.preferGithubTarballFallback === true && process.env.ADCP_GITHUB_FALLBACK !== '0') {
+  async function syncWithBase(
+    baseUrl: string,
+    fallback: { preferGithubTarballFallback?: boolean } = {}
+  ): Promise<void> {
+    const viaTarball = await syncFromTarball(adcpVersion, baseUrl, includeSharedSurfaces);
+    if (!viaTarball && fallback.preferGithubTarballFallback === true && process.env.ADCP_GITHUB_FALLBACK !== '0') {
       console.warn(
         `⚠️  AdCP ${adcpVersion} tarball was not reachable from ${baseUrl}; ` +
           `retrying against GitHub dist before schema-only fallback.`
       );
-      const viaGithubTarball = await syncFromTarball(adcpVersion, GITHUB_DIST_BASE_URL);
+      const viaGithubTarball = await syncFromTarball(adcpVersion, GITHUB_DIST_BASE_URL, includeSharedSurfaces);
       if (viaGithubTarball) return;
     }
     if (!viaTarball) {
-      await syncSchemasPerFile(adcpVersion, baseUrl);
+      await syncSchemasPerFile(adcpVersion, baseUrl, includeSharedSurfaces);
     }
   }
 


### PR DESCRIPTION
Fixes #2352

## Problem

`scripts/sync-schemas.ts` wrote non-version-scoped, checked-in state on every run, so syncing a **side-bundle** version (`3.0.12`, `v2.5`, the opt-in `3.1.0-beta.7`) disturbed the primary pin (`ADCP_VERSION`, currently `3.1.2`). Because `npm run sync-schemas:all` syncs several versions in sequence, contributors kept seeing phantom diffs and reverting files they never touched.

Three shared surfaces were affected:

1. **Protocol skills (`skills/adcp-*`)** — stored in one shared folder (no per-version copy). A `3.0.12` sync overwrote the pinned `3.1.2` skills with older content. The beta script papered over this with a fragile `git checkout HEAD` restore (`RESTORE_PATHS`) that ran after a network fetch and needed a hand-maintained path list.
2. **The `latest/` cache pointer** — a standalone `sync-schemas -- 3.0.12` silently repointed `schemas/cache/latest` at the old version, making the SDK validate against it by default. (Surfaced in review.)
3. **`schemas/registry/registry.yaml`** — not really part of the versioned bundle. Its real owner is `scripts/generate-registry-types.ts --sync`, which downloads it from `https://agenticadvertising.org/openapi/registry.yaml` (a live spec ahead of the pinned tarball). `sync-schemas` copying the tarball's staler copy only downgraded the committed file.

## Fix

All three shared surfaces are now tied to the **primary pin**:

- `syncFromTarball` gains an `includeSharedSurfaces` flag (threaded into the per-file fallback too). It defaults on only when the synced version equals `ADCP_VERSION`. Skill writes and the `latest/` pointer are gated behind it, so side-bundle syncs leave them alone.
- The `registry.yaml` write is **removed from `sync-schemas` entirely** — `generate-registry-types --sync` is its sole owner.
- The `restoreFromHead`/`RESTORE_PATHS` workaround is deleted from `scripts/sync-3-1-beta-schemas.ts`; nothing gets clobbered anymore, so ordering in `sync-schemas:all` no longer matters.

## Not affected

- **Multi-version schema validation** — schemas remain per-version in `schemas/cache/<version>/`, untouched.
- **SDK-authored skills** (`build-*`, `call-adcp-agent`) — already never overwritten.
- **CI / publish** — `ci:schema-check` and `ci-validate.js` already run `generate-registry-types --sync` after `sync-schemas`, so the committed `registry.yaml` invariant is unchanged; `prepublishOnly` ships skills that deterministically track the primary pin.

## Verification

- Primary sync (`3.1.2`): still writes skills, `latest → 3.1.2`, registry untouched.
- Non-primary sync (`3.0.12`): skills unchanged, `latest` stays `3.1.2`, registry untouched.
- `generate-registry-types --sync` confirmed as registry's sole owner (zero diff vs committed).
- Typecheck clean; changeset added; two independent code-review passes (full + delta) came back clean.