### PR TITLE
feat!: ship tree-shakeable dual ESM + CJS build (#2344)

### DIFF
--- a/.changeset/package-artifact-verification.md
+++ b/.changeset/package-artifact-verification.md
@@ -15,6 +15,10 @@ Harden the publish artifact and correct a peer-dependency floor.
   `import` condition now points at `enums.mjs`, and `enums`, `testing/personas`,
   and `server/legacy/v5` gained the `typesVersions` entries they were missing.
 
+Raising the `@modelcontextprotocol/sdk` peer floor is a breaking-shaped change; it
+is safe here only because it is co-released with the major bump from the
+tree-shakeable dual-build changeset.
+
 Verification tooling only (devDependencies, no new runtime deps): `npm run
 check:package` (publint + attw) and `npm run verify:package` (clean-room
 dual-format smoke against the packed tarball with peers at their range floors),

--- a/.changeset/package-artifact-verification.md
+++ b/.changeset/package-artifact-verification.md
@@ -1,0 +1,21 @@
+---
+'@adcp/sdk': patch
+---
+
+Harden the publish artifact and correct a peer-dependency floor.
+
+- Raise the `@modelcontextprotocol/sdk` peer floor from `^1.17.5` to `^1.24.0`.
+  The main entry eagerly loads `server/tasks`, which imports
+  `@modelcontextprotocol/sdk/experimental/tasks/*`; those subpaths first ship in
+  1.24.0, so any consumer importing `@adcp/sdk` on an older MCP SDK hit
+  `ERR_MODULE_NOT_FOUND`. Same class of too-low pin as the `@a2a-js/sdk` fix.
+- Emit ESM-format type declarations (`.d.mts`) alongside `.d.ts` and give every
+  subpath export per-condition types, so the ESM `import` condition no longer
+  resolves to a CJS declaration ("masquerading as CJS"). `@adcp/sdk/enums`'s
+  `import` condition now points at `enums.mjs`, and `enums`, `testing/personas`,
+  and `server/legacy/v5` gained the `typesVersions` entries they were missing.
+
+Verification tooling only (devDependencies, no new runtime deps): `npm run
+check:package` (publint + attw) and `npm run verify:package` (clean-room
+dual-format smoke against the packed tarball with peers at their range floors),
+both wired into CI. See `docs/development/PACKAGE-VERIFICATION.md`.

--- a/.changeset/tree-shakeable-esm-cjs.md
+++ b/.changeset/tree-shakeable-esm-cjs.md
@@ -1,0 +1,29 @@
+---
+'@adcp/sdk': major
+---
+
+Ship a tree-shakeable dual ESM + CJS build.
+
+The library now builds with tsup (`bundle: false`, one output file per source
+module), emitting ESM (`.mjs`, reached via the `import` condition) alongside the
+existing CommonJS (`.js`, reached via `require`), and declares `sideEffects` so
+bundlers can drop unused code. Importing a single symbol no longer pulls the
+whole barrel: `import { EventTypeValues } from '@adcp/sdk/types'` bundles to
+under 1 KB with zod absent, down from ~1.9 MB.
+
+`require('@adcp/sdk')` and the CLI keep working. This is a major version because
+every consumer's module resolution goes through the reworked `exports` map
+(each subpath now resolves `import` → `.mjs`, `require` → `.js`, `types` →
+`.d.ts`).
+
+The `@a2a-js/sdk` peer floor is raised from `^0.3.4` to `^0.3.13`: `@adcp/sdk/server`
+imports `agentCardHandler` from `@a2a-js/sdk/server/express`, which only exists
+from 0.3.13. CJS named-import interop masked a too-low pin; ESM surfaces it as a
+load-time error, so the floor now matches what the code actually needs.
+
+Dual-package safety: the request-signing and response-capture
+`AsyncLocalStorage` stores are anchored on the global symbol registry so a
+process that loads both builds shares one instance (no silently unsigned
+requests), and the verified-signature brand uses `Symbol.for`. Consumers that
+`instanceof`-check SDK errors across a mixed ESM/CJS boundary should use the
+exported `isADCPError` / `isErrorOfType` guards instead.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,58 @@ jobs:
             console.log('✅ Package exports are valid');
           "
 
+      - name: Static export-map checks (publint + attw)
+        run: npm run check:package
+
+  # Clean-room dual-format smoke: install the packed tarball with peers at their
+  # range floors and load it via real ESM + CJS. This does a live registry
+  # install, so the expensive steps run only when a packaging-relevant file
+  # changed. The job itself always completes (skipped steps = success), so it is
+  # safe to require via the `test` aggregator and never hangs pending.
+  package-smoke:
+    name: Package Artifact Smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Detect packaging-relevant changes
+        id: detect
+        run: |
+          base="${{ github.event.pull_request.base.sha || github.event.before }}"
+          if [ -z "$base" ] || ! git cat-file -e "${base}^{commit}" 2>/dev/null; then
+            # No usable base (first push, force-push, scheduled run) — run to be safe.
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          elif git diff --name-only "$base" HEAD | grep -qE '^(package\.json|package-lock\.json|tsup\.config\.ts|tsconfig\.json|tsconfig\.lib\.json|tsconfig\.build\.json|scripts/(generate-dmts-declarations|generate-per-tool-types|copy-schemas-to-dist|copy-v2-projection-catalog|generate-wire-spec-fields)\.ts|scripts/verify-package\.mjs|\.github/workflows/ci\.yml)$'; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No packaging-relevant changes; skipping the clean-room smoke."
+          fi
+
+      - name: Setup Node.js
+        if: steps.detect.outputs.changed == 'true'
+        uses: actions/setup-node@v5
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+
+      - name: Install dependencies
+        if: steps.detect.outputs.changed == 'true'
+        run: npm ci
+
+      - name: Build library
+        if: steps.detect.outputs.changed == 'true'
+        run: npm run build:lib
+
+      - name: Clean-room dual-format smoke (packed artifact + peer floors)
+        if: steps.detect.outputs.changed == 'true'
+        run: npm run verify:package
+
   adopter-typechecks:
     name: Adopter Typechecks
     runs-on: ubuntu-latest
@@ -397,6 +449,7 @@ jobs:
       - unit-tests
       - example-integration-tests
       - security-audit
+      - package-smoke
     if: ${{ always() }}
     timeout-minutes: 2
 

--- a/docs/development/PACKAGE-VERIFICATION.md
+++ b/docs/development/PACKAGE-VERIFICATION.md
@@ -1,0 +1,99 @@
+# Package artifact verification
+
+The SDK ships a tree-shakeable dual ESM + CJS build with ~30 subpath exports.
+Two mechanical guards keep the publish artifact honest so packaging regressions
+fail CI instead of reaching consumers.
+
+**How they run in CI** (both live in `.github/workflows/ci.yml`):
+
+- `check:package` is cheap and offline, so it runs on **every PR** as a step in
+  the `library-build` job.
+- `verify:package` does a live registry install, so it runs in the
+  `package-smoke` job, whose expensive steps fire **only when a
+  packaging-relevant file changed** (exports map, build config, declaration/emit
+  scripts, dependency pins, or the smoke script itself). The job always
+  completes — when nothing packaging-relevant changed, its steps are skipped and
+  it passes — so it is safe to include in the required `test` aggregator and
+  never hangs pending.
+
+**Coverage tradeoff:** because `package-smoke` is gated on packaging paths (not
+`src/lib/**`), a source-only change that drifts a peer floor — e.g. a new import
+that needs a higher `@modelcontextprotocol/sdk` — won't run the smoke on that
+PR. Bumping a dependency floor goes through `package.json` (which *is* gated),
+so the common case is covered; a floor requirement introduced purely in source
+without a manifest change is the residual gap.
+
+## `npm run check:package` — static export-map checks
+
+Runs [`publint --strict`](https://publint.dev) and
+[`attw --pack .`](https://arethetypeswrong.github.io) against the built package.
+
+- **publint** validates the `exports` map: condition ordering (`types` first),
+  file existence, and format correctness.
+- **attw** resolves every subpath through the four module-resolution modes
+  (`node10`, `node16` from CJS, `node16` from ESM, `bundler`) and flags
+  mismatches — the classic one being an ESM `.mjs` file typed by a CJS `.d.ts`
+  ("masquerading as CJS").
+
+Requires a prior `npm run build:lib` (it inspects `dist/`).
+
+### Why the build emits `.d.mts`
+
+The package is `type: commonjs`, so a `.d.ts` is a CJS-format declaration. The
+`import` condition resolves to `.mjs` (real ESM), so it needs an ESM-format
+declaration or attw reports "masquerading as CJS". `scripts/generate-dmts-declarations.ts`
+runs at the end of `build:lib`: it copies each `.d.ts` to `.d.mts` and appends
+explicit `.mjs` / `/index.mjs` extensions to relative specifiers (ESM
+declaration resolution requires them) — the declaration-layer companion to the
+runtime import-fixers in `tsup.config.ts`. Each subpath's `exports` entry then
+carries per-condition types:
+
+```jsonc
+"./auth": {
+  "import":  { "types": "./dist/lib/auth/index.d.mts", "default": "./dist/lib/auth/index.mjs" },
+  "require": { "types": "./dist/lib/auth/index.d.ts",  "default": "./dist/lib/auth/index.js" }
+}
+```
+
+The `./types/*` wildcard export stays a single `types`-only condition: the
+per-tool slices under `dist/lib/types/` are self-contained type-only artifacts
+(no runtime), so they have no `import`/`require` to split, and attw resolves the
+wildcard cleanly. Because those slices are never reached through an `import`
+condition, the generator **skips** emitting `.d.mts` for them (keyed off
+`per-tool-index.json`), trimming ~5.5 MB of otherwise-unreachable declarations.
+
+## `npm run verify:package` — clean-room dual-format smoke
+
+`scripts/verify-package.mjs` packs a tarball, installs it plus its **required**
+peers pinned to their **range floors** into a throwaway dir under `os.tmpdir()`
+(outside the workspace, so npm resolution is honest and not monorepo-deduped),
+then loads `@adcp/sdk`, `@adcp/sdk/enums`, and `@adcp/sdk/server` through both a
+real ESM `import` and a real CJS `require`, asserting each loads and exposes a
+known runtime symbol. `server` is included so the `@a2a-js/sdk` peer gets real
+ESM/CJS load coverage through a dedicated entrypoint. Optional peers
+(`peerDependenciesMeta`) are **not** installed — no tested subpath loads them,
+so pinning them would add only install weight and registry-flake surface. It
+uses `npm install` in the temp dir (never workspace pnpm/catalog) and cleans up
+on exit. Requires a prior `npm run build:lib`.
+
+This is what catches a peer floor that is declared lower than the code needs:
+CJS named-import interop can mask a too-low pin, but a real ESM import surfaces
+it as a load-time `ERR_MODULE_NOT_FOUND`.
+
+## Peer-dependency floor rationale
+
+`verify:package` installs the required peers at their floors on every run;
+their floors are pinned to what the code actually imports. (Optional peers are
+listed for completeness but the smoke does not install them.)
+
+| Peer | Floor | How the SDK uses it | Why the floor |
+| --- | --- | --- | --- |
+| `@a2a-js/sdk` | `^0.3.13` | `@adcp/sdk/server` imports `agentCardHandler` from `@a2a-js/sdk/server/express` | That subpath first exists in 0.3.13 (see the #2344 changeset). |
+| `@modelcontextprotocol/sdk` | `^1.24.0` | `src/lib/server/{serve,tasks,postgres-task-store}.ts` import `@modelcontextprotocol/sdk/experimental/tasks/*` | `experimental/tasks/stores/in-memory.js` first ships in **1.24.0** (absent in 1.23.1). The main entry eagerly loads `server/tasks`, so any consumer importing `@adcp/sdk` on `< 1.24.0` hits `ERR_MODULE_NOT_FOUND`. Corrected from an earlier `^1.17.5`. |
+| `zod` | `^4.1.5` | Bare `import … from 'zod'` only (no `zod/v4` subpaths); top-level v4 API | v4 top-level surface; loads at floor. Dev pin `^4.1.12` is a patch-level gap. |
+| `@opentelemetry/api` | `^1.0.0` (optional) | Metrics/tracing | Stable 1.x API. Not installed by the smoke. |
+| `pg` | `^8.0.0` (optional) | `postgres-task-store` | Stable 8.x `Pool`/`Client` API. Not installed by the smoke. |
+| `redis` | `^4.6.0 \|\| ^5.0.0` (optional) | Redis-backed stores | Both major lines supported. Not installed by the smoke. |
+
+When a floor changes, update both `package.json#peerDependencies` and this
+table, then rerun `verify:package` to confirm the new floor loads.

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "adcp": "bin/adcp.js"
       },
       "devDependencies": {
-        "@a2a-js/sdk": "^0.3.4",
+        "@a2a-js/sdk": "^0.3.13",
         "@changesets/cli": "^2.29.7",
         "@commitlint/cli": "^19.6.0",
         "@commitlint/config-conventional": "^19.6.0",
@@ -40,6 +40,7 @@
         "@types/pg": "^8.20.0",
         "@types/tar": "^6.1.13",
         "actionlint": "^2.0.6",
+        "esbuild-fix-imports-plugin": "^1.0.23",
         "eslint": "^10.0.3",
         "json-schema-to-typescript": "^15.0.4",
         "json-schema-to-zod": "^2.6.1",
@@ -49,6 +50,7 @@
         "redis": "^4.7.0",
         "tar": "^7.5.13",
         "ts-to-zod": "^5.0.1",
+        "tsup": "^8.5.1",
         "tsx": "^4.6.0",
         "typedoc": "^0.28.13",
         "typedoc-plugin-markdown": "^4.9.0",
@@ -60,7 +62,7 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@a2a-js/sdk": "^0.3.4",
+        "@a2a-js/sdk": "^0.3.13",
         "@modelcontextprotocol/sdk": "^1.17.5",
         "@opentelemetry/api": "^1.0.0",
         "pg": "^8.0.0",
@@ -1431,6 +1433,45 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
     "node_modules/@jsdevtools/ono": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
@@ -1727,6 +1768,7 @@
       "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2",
         "generic-pool": "3.9.0",
@@ -1851,6 +1893,356 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@shikijs/engine-oniguruma": {
       "version": "3.23.0",
@@ -2012,6 +2404,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
       "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2147,6 +2540,7 @@
       "integrity": "sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.4",
         "@typescript-eslint/types": "8.59.4",
@@ -2357,6 +2751,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2482,6 +2877,13 @@
         "node": ">=14"
       }
     },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -2588,6 +2990,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/bundle-require": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
+      "integrity": "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "load-tsconfig": "^0.2.3"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "esbuild": ">=0.18"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -2596,6 +3014,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -2852,6 +3280,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/compare-func": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
@@ -2861,6 +3299,23 @@
       "dependencies": {
         "array-ify": "^1.0.0",
         "dot-prop": "^5.1.0"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
       }
     },
     "node_modules/content-disposition": {
@@ -3296,6 +3751,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -3331,6 +3787,13 @@
         "@esbuild/win32-x64": "0.28.1"
       }
     },
+    "node_modules/esbuild-fix-imports-plugin": {
+      "version": "1.0.23",
+      "resolved": "https://registry.npmjs.org/esbuild-fix-imports-plugin/-/esbuild-fix-imports-plugin-1.0.23.tgz",
+      "integrity": "sha512-zDn2Mq3OnW9qNm9FrHDeE0FePgIRIaH9EWpHOGsJZFPfyPSNqzvCK/x9EZJ5eHEEyXe8ZGdb5CjDpzqkyAqcCg==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -3365,6 +3828,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.0.tgz",
       "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -3668,6 +4132,7 @@
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -3901,6 +4366,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fix-dts-default-cjs-exports": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
+      "integrity": "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.17",
+        "mlly": "^1.7.4",
+        "rollup": "^4.34.8"
       }
     },
     "node_modules/flat-cache": {
@@ -4194,6 +4671,7 @@
       "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -4555,6 +5033,16 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/js-levenshtein": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
@@ -4878,6 +5366,16 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/load-tsconfig": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
+      "integrity": "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
     "node_modules/locate-path": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
@@ -5096,6 +5594,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/markdown-it": {
       "version": "14.2.0",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
@@ -5306,6 +5814,19 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
     "node_modules/mri": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
@@ -5321,6 +5842,18 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -5633,12 +6166,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pg": {
       "version": "8.21.0",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.21.0.tgz",
       "integrity": "sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.13.0",
         "pg-pool": "^3.14.0",
@@ -5760,6 +6301,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/pkce-challenge": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
@@ -5770,6 +6321,18 @@
         "node": ">=16.20.0"
       }
     },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
     "node_modules/pluralize": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
@@ -5778,6 +6341,49 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
       }
     },
     "node_modules/postgres-array": {
@@ -6119,6 +6725,51 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -6393,6 +7044,16 @@
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/spawndamnit": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/spawndamnit/-/spawndamnit-3.0.1.tgz",
@@ -6487,6 +7148,29 @@
       "engines": {
         "node": ">=18",
         "npm": ">=6"
+      }
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/supports-color": {
@@ -6777,6 +7461,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -6832,6 +7539,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6880,6 +7588,16 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -6891,6 +7609,13 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/ts-to-zod": {
       "version": "5.1.0",
@@ -6934,6 +7659,550 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/tsup": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.1.tgz",
+      "integrity": "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-require": "^5.1.0",
+        "cac": "^6.7.14",
+        "chokidar": "^4.0.3",
+        "consola": "^3.4.0",
+        "debug": "^4.4.0",
+        "esbuild": "^0.27.0",
+        "fix-dts-default-cjs-exports": "^1.0.0",
+        "joycon": "^3.1.1",
+        "picocolors": "^1.1.1",
+        "postcss-load-config": "^6.0.1",
+        "resolve-from": "^5.0.0",
+        "rollup": "^4.34.8",
+        "source-map": "^0.7.6",
+        "sucrase": "^3.35.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.11",
+        "tree-kill": "^1.2.2"
+      },
+      "bin": {
+        "tsup": "dist/cli-default.js",
+        "tsup-node": "dist/cli-node.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@microsoft/api-extractor": "^7.36.0",
+        "@swc/core": "^1",
+        "postcss": "^8.4.12",
+        "typescript": ">=4.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@microsoft/api-extractor": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/tsup/node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -7041,6 +8310,7 @@
       "integrity": "sha512-wKh+lhdmMFivMlc6vRRcMGXeGEHGU2g8a2CkPTJjJlwRf1iXbimWIPcFolCqe4E0d/FRtGszpIrsp3WLpDB8Pw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@gerrit0/mini-shiki": "^3.23.0",
         "lunr": "^2.3.9",
@@ -7077,6 +8347,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7113,6 +8384,13 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
       "dev": true,
       "license": "MIT"
     },
@@ -7407,6 +8685,7 @@
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
       },
       "devDependencies": {
         "@a2a-js/sdk": "^0.3.13",
+        "@arethetypeswrong/cli": "^0.18.5",
         "@changesets/cli": "^2.29.7",
         "@commitlint/cli": "^19.6.0",
         "@commitlint/config-conventional": "^19.6.0",
@@ -47,6 +48,7 @@
         "openapi-typescript": "^7.13.0",
         "pg": "^8.20.0",
         "prettier": "^3.6.2",
+        "publint": "^0.3.21",
         "redis": "^4.7.0",
         "tar": "^7.5.13",
         "ts-to-zod": "^5.0.1",
@@ -63,7 +65,7 @@
       },
       "peerDependencies": {
         "@a2a-js/sdk": "^0.3.13",
-        "@modelcontextprotocol/sdk": "^1.17.5",
+        "@modelcontextprotocol/sdk": "^1.24.0",
         "@opentelemetry/api": "^1.0.0",
         "pg": "^8.0.0",
         "redis": "^4.6.0 || ^5.0.0",
@@ -122,6 +124,12 @@
       "resolved": "",
       "link": true
     },
+    "node_modules/@andrewbranch/untar.js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@andrewbranch/untar.js/-/untar.js-1.0.3.tgz",
+      "integrity": "sha512-Jh15/qVmrLGhkKJBdXlK1+9tY4lZruYjsgkDFj08ZmDiWVBLJcqkok7Z0/R0In+i1rScBpJlSvrTS2Lm41Pbnw==",
+      "dev": true
+    },
     "node_modules/@apidevtools/json-schema-ref-parser": {
       "version": "11.9.3",
       "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.9.3.tgz",
@@ -170,6 +178,118 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/@arethetypeswrong/cli": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/@arethetypeswrong/cli/-/cli-0.18.5.tgz",
+      "integrity": "sha512-gM+8vRsQOD/Uc7EnBedUhkG5OCsDWE4uoak5QvomGpMpaky0Eh41p04nIMgrWb8EOmqZUJGc6zz9hsP6E56R7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@arethetypeswrong/core": "0.18.5",
+        "chalk": "^4.1.2",
+        "cli-table3": "^0.6.3",
+        "commander": "^10.0.1",
+        "marked": "^9.1.2",
+        "marked-terminal": "^7.1.0",
+        "semver": "^7.5.4"
+      },
+      "bin": {
+        "attw": "dist/index.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@arethetypeswrong/cli/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@arethetypeswrong/cli/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@arethetypeswrong/cli/node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@arethetypeswrong/cli/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@arethetypeswrong/core": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/@arethetypeswrong/core/-/core-0.18.5.tgz",
+      "integrity": "sha512-9ytjzGwxjm9Uz7I9avfbt5vlQt6uk9uRRESzJjqrznl6WKvI6dwYTo+vJ3U02Wrq/mR3iql/PzhvHhKdJIAjDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@andrewbranch/untar.js": "^1.0.3",
+        "@loaderkit/resolve": "^1.0.2",
+        "cjs-module-lexer": "^1.2.3",
+        "fflate": "^0.8.3",
+        "lru-cache": "^11.0.1",
+        "semver": "^7.5.4",
+        "typescript": "5.6.1-rc",
+        "validate-npm-package-name": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@arethetypeswrong/core/node_modules/typescript": {
+      "version": "5.6.1-rc",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.1-rc.tgz",
+      "integrity": "sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
@@ -204,6 +324,13 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@braidai/lang": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@braidai/lang/-/lang-1.1.2.tgz",
+      "integrity": "sha512-qBcknbBufNHlui137Hft8xauQMTZDKdophmLFv05r2eNmdIv/MlPuP4TdUknHG68UdWLgVZwgxVe735HzJNIwA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@changesets/apply-release-plan": {
       "version": "7.1.1",
@@ -500,6 +627,17 @@
         "@clack/core": "1.0.0-alpha.4",
         "picocolors": "^1.0.0",
         "sisteransi": "^1.0.5"
+      }
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
       }
     },
     "node_modules/@commitlint/cli": {
@@ -1479,6 +1617,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@loaderkit/resolve": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@loaderkit/resolve/-/resolve-1.0.6.tgz",
+      "integrity": "sha512-G8FdIoF5CypfwmD9rl8BXod5HDn8JqB0CCNBXDTaRZ+yRYhARrrSToX1zg1zy9jX3zLqigsELwhT4gNtkdQAUg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@braidai/lang": "^1.0.0"
+      }
+    },
     "node_modules/@manypkg/find-root": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@manypkg/find-root/-/find-root-1.1.0.tgz",
@@ -1750,6 +1898,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@publint/pack": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@publint/pack/-/pack-0.1.5.tgz",
+      "integrity": "sha512-edgyN2pP07uXiP4tJs0s8KVmU8M8i60YPbbI0/WDeok1mIJHRXz+CgD8I0nelwDkoCh3EWL/G5kGfbuHjsdbvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyexec": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://bjornlu.com/sponsor"
       }
     },
     "node_modules/@redis/bloom": {
@@ -2292,6 +2456,19 @@
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
@@ -3087,6 +3264,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/chardet": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
@@ -3120,6 +3307,13 @@
         "node": ">=18"
       }
     },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/clean-stack": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-3.0.1.tgz",
@@ -3152,6 +3346,115 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cli-highlight": {
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/cli-highlight/-/cli-highlight-2.1.11.tgz",
+      "integrity": "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "highlight.js": "^10.7.1",
+        "mz": "^2.4.0",
+        "parse5": "^5.1.1",
+        "parse5-htmlparser2-tree-adapter": "^6.0.0",
+        "yargs": "^16.0.0"
+      },
+      "bin": {
+        "highlight": "bin/highlight"
+      },
+      "engines": {
+        "node": ">=8.0.0",
+        "npm": ">=5.0.0"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/yargs": {
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.2.tgz",
+      "integrity": "sha512-Nt9ZJjXTv5R8MHbqby/wXQ6Gi0Bb3TcYZkR1bzuL4yB2OxWPkXknz513gEF0GoA6tn00UpbPvERW8rzCuWCA6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/cli-spinners": {
       "version": "2.9.2",
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
@@ -3163,6 +3466,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-table3": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+      "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      },
+      "optionalDependencies": {
+        "@colors/colors": "1.5.0"
       }
     },
     "node_modules/cli-truncate": {
@@ -3638,6 +3957,13 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emojilib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz",
+      "integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==",
       "dev": true,
       "license": "MIT"
     },
@@ -4293,6 +4619,13 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -4663,6 +4996,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/hono": {
@@ -5587,6 +5930,16 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/lunr": {
       "version": "2.3.9",
       "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
@@ -5638,6 +5991,71 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/marked": {
+      "version": "9.1.6",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-9.1.6.tgz",
+      "integrity": "sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/marked-terminal": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-7.3.0.tgz",
+      "integrity": "sha512-t4rBvPsHc57uE/2nJOLmMbZCQ4tgAccAED3ngXQqW6g+TxA488JzJ+FK3lQkzBQOI1mRV/r/Kq+1ZlJ4D0owQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "ansi-regex": "^6.1.0",
+        "chalk": "^5.4.1",
+        "cli-highlight": "^2.1.11",
+        "cli-table3": "^0.6.5",
+        "node-emoji": "^2.2.0",
+        "supports-hyperlinks": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "marked": ">=1 <16"
+      }
+    },
+    "node_modules/marked-terminal/node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/marked-terminal/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -5869,6 +6287,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-emoji": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.2.0.tgz",
+      "integrity": "sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^4.6.0",
+        "char-regex": "^1.0.2",
+        "emojilib": "^2.4.0",
+        "skin-tone": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/object-assign": {
@@ -6115,6 +6549,30 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/parse5": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+      "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
+      "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^6.0.1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
@@ -6468,6 +6926,35 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/publint": {
+      "version": "0.3.21",
+      "resolved": "https://registry.npmjs.org/publint/-/publint-0.3.21.tgz",
+      "integrity": "sha512-OqejcnMV6E9zel2oCrUOJEiiFkGiAAni0A6ibfQNh1k9Gu5z4F+Yso8lllam7AzmV6Do0vp7u3UpZNRBwuXaHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@publint/pack": "^0.1.4",
+        "package-manager-detector": "^1.6.0",
+        "picocolors": "^1.1.1",
+        "sade": "^1.8.1"
+      },
+      "bin": {
+        "publint": "src/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://bjornlu.com/sponsor"
+      }
+    },
+    "node_modules/publint/node_modules/package-manager-detector": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.7.0.tgz",
+      "integrity": "sha512-xg1eHpwYL/D/HEdWw2goFZP6vV0FH7W+PZ5rFkGjdIDLtxq7EkzBUeT3m+lndYCt8wKbmofUu1MUdMCXkCk9ZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -6811,6 +7298,19 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/sade": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mri": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -7017,6 +7517,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/skin-tone": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/skin-tone/-/skin-tone-2.0.0.tgz",
+      "integrity": "sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "unicode-emoji-modifier-base": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -7184,6 +7697,36 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/supports-hyperlinks": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
+      "integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
+      }
+    },
+    "node_modules/supports-hyperlinks/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/tar": {
@@ -7492,9 +8035,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
-      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8409,6 +8952,16 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
+    "node_modules/unicode-emoji-modifier-base": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-emoji-modifier-base/-/unicode-emoji-modifier-base-1.0.0.tgz",
+      "integrity": "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/unicorn-magic": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
@@ -8470,6 +9023,16 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/validate-npm-package-name": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz",
+      "integrity": "sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -7,31 +7,32 @@
     "packages/*"
   ],
   "main": "dist/lib/index.js",
+  "module": "./dist/lib/index.mjs",
   "types": "dist/lib/index.d.ts",
   "type": "commonjs",
   "exports": {
     ".": {
-      "import": "./dist/lib/index.js",
+      "import": "./dist/lib/index.mjs",
       "require": "./dist/lib/index.js",
       "types": "./dist/lib/index.d.ts"
     },
     "./client": {
-      "import": "./dist/lib/client/index.js",
+      "import": "./dist/lib/client/index.mjs",
       "require": "./dist/lib/client/index.js",
       "types": "./dist/lib/client/index.d.ts"
     },
     "./compliance": {
-      "import": "./dist/lib/compliance/index.js",
+      "import": "./dist/lib/compliance/index.mjs",
       "require": "./dist/lib/compliance/index.js",
       "types": "./dist/lib/compliance/index.d.ts"
     },
     "./advanced": {
-      "import": "./dist/lib/advanced.js",
+      "import": "./dist/lib/advanced.mjs",
       "require": "./dist/lib/advanced.js",
       "types": "./dist/lib/advanced.d.ts"
     },
     "./types": {
-      "import": "./dist/lib/types/index.js",
+      "import": "./dist/lib/types/index.mjs",
       "require": "./dist/lib/types/index.js",
       "types": "./dist/lib/types/index.d.ts"
     },
@@ -41,12 +42,12 @@
       "types": "./dist/lib/enums.d.ts"
     },
     "./types/v2-5": {
-      "import": "./dist/lib/types/v2-5/index.js",
+      "import": "./dist/lib/types/v2-5/index.mjs",
       "require": "./dist/lib/types/v2-5/index.js",
       "types": "./dist/lib/types/v2-5/index.d.ts"
     },
     "./types/v3-1-beta": {
-      "import": "./dist/lib/types/v3-1-beta/index.js",
+      "import": "./dist/lib/types/v3-1-beta/index.mjs",
       "require": "./dist/lib/types/v3-1-beta/index.js",
       "types": "./dist/lib/types/v3-1-beta/index.d.ts"
     },
@@ -54,122 +55,122 @@
       "types": "./dist/lib/types/*.d.ts"
     },
     "./wholesale-feed-sync": {
-      "import": "./dist/lib/wholesale-feed-sync/index.js",
+      "import": "./dist/lib/wholesale-feed-sync/index.mjs",
       "require": "./dist/lib/wholesale-feed-sync/index.js",
       "types": "./dist/lib/wholesale-feed-sync/index.d.ts"
     },
     "./v2/projection": {
-      "import": "./dist/lib/v2/projection/index.js",
+      "import": "./dist/lib/v2/projection/index.mjs",
       "require": "./dist/lib/v2/projection/index.js",
       "types": "./dist/lib/v2/projection/index.d.ts"
     },
     "./v2/format-schema": {
-      "import": "./dist/lib/v2/format-schema/index.js",
+      "import": "./dist/lib/v2/format-schema/index.mjs",
       "require": "./dist/lib/v2/format-schema/index.js",
       "types": "./dist/lib/v2/format-schema/index.d.ts"
     },
     "./v2/publisher-catalog": {
-      "import": "./dist/lib/v2/publisher-catalog/index.js",
+      "import": "./dist/lib/v2/publisher-catalog/index.mjs",
       "require": "./dist/lib/v2/publisher-catalog/index.js",
       "types": "./dist/lib/v2/publisher-catalog/index.d.ts"
     },
     "./testing": {
-      "import": "./dist/lib/testing/index.js",
+      "import": "./dist/lib/testing/index.mjs",
       "require": "./dist/lib/testing/index.js",
       "types": "./dist/lib/testing/index.d.ts"
     },
     "./testing/personas": {
-      "import": "./dist/lib/testing/personas/index.js",
+      "import": "./dist/lib/testing/personas/index.mjs",
       "require": "./dist/lib/testing/personas/index.js",
       "types": "./dist/lib/testing/personas/index.d.ts"
     },
     "./auth": {
-      "import": "./dist/lib/auth/index.js",
+      "import": "./dist/lib/auth/index.mjs",
       "require": "./dist/lib/auth/index.js",
       "types": "./dist/lib/auth/index.d.ts"
     },
     "./webhooks": {
-      "import": "./dist/lib/webhooks/index.js",
+      "import": "./dist/lib/webhooks/index.mjs",
       "require": "./dist/lib/webhooks/index.js",
       "types": "./dist/lib/webhooks/index.d.ts"
     },
     "./brand": {
-      "import": "./dist/lib/brand/index.js",
+      "import": "./dist/lib/brand/index.mjs",
       "require": "./dist/lib/brand/index.js",
       "types": "./dist/lib/brand/index.d.ts"
     },
     "./net": {
-      "import": "./dist/lib/net/index.js",
+      "import": "./dist/lib/net/index.mjs",
       "require": "./dist/lib/net/index.js",
       "types": "./dist/lib/net/index.d.ts"
     },
     "./canonical-references": {
-      "import": "./dist/lib/canonical-references/index.js",
+      "import": "./dist/lib/canonical-references/index.mjs",
       "require": "./dist/lib/canonical-references/index.js",
       "types": "./dist/lib/canonical-references/index.d.ts"
     },
     "./server": {
-      "import": "./dist/lib/server/index.js",
+      "import": "./dist/lib/server/index.mjs",
       "require": "./dist/lib/server/index.js",
       "types": "./dist/lib/server/index.d.ts"
     },
     "./server/legacy/v5": {
-      "import": "./dist/lib/server/legacy/v5/index.js",
+      "import": "./dist/lib/server/legacy/v5/index.mjs",
       "require": "./dist/lib/server/legacy/v5/index.js",
       "types": "./dist/lib/server/legacy/v5/index.d.ts"
     },
     "./signing": {
-      "import": "./dist/lib/signing/index.js",
+      "import": "./dist/lib/signing/index.mjs",
       "require": "./dist/lib/signing/index.js",
       "types": "./dist/lib/signing/index.d.ts"
     },
     "./signing/client": {
-      "import": "./dist/lib/signing/client.js",
+      "import": "./dist/lib/signing/client.mjs",
       "require": "./dist/lib/signing/client.js",
       "types": "./dist/lib/signing/client.d.ts"
     },
     "./signing/server": {
-      "import": "./dist/lib/signing/server.js",
+      "import": "./dist/lib/signing/server.mjs",
       "require": "./dist/lib/signing/server.js",
       "types": "./dist/lib/signing/server.d.ts"
     },
     "./signing/testing": {
-      "import": "./dist/lib/signing/testing.js",
+      "import": "./dist/lib/signing/testing.mjs",
       "require": "./dist/lib/signing/testing.js",
       "types": "./dist/lib/signing/testing.d.ts"
     },
     "./schemas": {
-      "import": "./dist/lib/schemas/index.js",
+      "import": "./dist/lib/schemas/index.mjs",
       "require": "./dist/lib/schemas/index.js",
       "types": "./dist/lib/schemas/index.d.ts"
     },
     "./compliance-fixtures": {
-      "import": "./dist/lib/compliance-fixtures/index.js",
+      "import": "./dist/lib/compliance-fixtures/index.mjs",
       "require": "./dist/lib/compliance-fixtures/index.js",
       "types": "./dist/lib/compliance-fixtures/index.d.ts"
     },
     "./conformance": {
-      "import": "./dist/lib/conformance/index.js",
+      "import": "./dist/lib/conformance/index.mjs",
       "require": "./dist/lib/conformance/index.js",
       "types": "./dist/lib/conformance/index.d.ts"
     },
     "./substitution": {
-      "import": "./dist/lib/substitution/index.js",
+      "import": "./dist/lib/substitution/index.mjs",
       "require": "./dist/lib/substitution/index.js",
       "types": "./dist/lib/substitution/index.d.ts"
     },
     "./express-mcp": {
-      "import": "./dist/lib/express-mcp/index.js",
+      "import": "./dist/lib/express-mcp/index.mjs",
       "require": "./dist/lib/express-mcp/index.js",
       "types": "./dist/lib/express-mcp/index.d.ts"
     },
     "./mock-server": {
-      "import": "./dist/lib/mock-server/index.js",
+      "import": "./dist/lib/mock-server/index.mjs",
       "require": "./dist/lib/mock-server/index.js",
       "types": "./dist/lib/mock-server/index.d.ts"
     },
     "./upstream-recorder": {
-      "import": "./dist/lib/upstream-recorder/index.js",
+      "import": "./dist/lib/upstream-recorder/index.mjs",
       "require": "./dist/lib/upstream-recorder/index.js",
       "types": "./dist/lib/upstream-recorder/index.d.ts"
     },
@@ -290,7 +291,7 @@
     "sync:agents": "node scripts/import-claude-agents.mjs",
     "prepublishOnly": "npm run clean && npm run sync-schemas:all && (test -f src/lib/types/tools.generated.ts || npm run generate-types) && npm run build:lib && node --test-timeout=60000 --test-force-exit --test test/lib/adcp-client.test.js test/lib/validation.test.js test/lib/zod-schemas.test.js",
     "build": "npm run build:lib",
-    "build:lib": "npm run sync-version && npm run schemas:ensure && tsx scripts/generate-wire-spec-fields.ts && tsc --project tsconfig.lib.json && tsx scripts/copy-schemas-to-dist.ts && tsx scripts/copy-v2-projection-catalog.ts && tsx scripts/generate-per-tool-types.ts",
+    "build:lib": "npm run sync-version && npm run schemas:ensure && tsx scripts/generate-wire-spec-fields.ts && tsup && tsc --project tsconfig.lib.json --emitDeclarationOnly && tsx scripts/copy-schemas-to-dist.ts && tsx scripts/copy-v2-projection-catalog.ts && tsx scripts/generate-per-tool-types.ts",
     "build:test-agents": "npm run build:lib && tsc -p test-agents/tsconfig.json --rootDir test-agents",
     "pretest": "npm run schemas:ensure",
     "test": "npm run test:node && npm test --workspace=packages/eslint-plugin --if-present",
@@ -409,7 +410,7 @@
     "yaml": "^2.7.1"
   },
   "peerDependencies": {
-    "@a2a-js/sdk": "^0.3.4",
+    "@a2a-js/sdk": "^0.3.13",
     "@modelcontextprotocol/sdk": "^1.17.5",
     "@opentelemetry/api": "^1.0.0",
     "pg": "^8.0.0",
@@ -428,7 +429,7 @@
     }
   },
   "devDependencies": {
-    "@a2a-js/sdk": "^0.3.4",
+    "@a2a-js/sdk": "^0.3.13",
     "@changesets/cli": "^2.29.7",
     "@commitlint/cli": "^19.6.0",
     "@commitlint/config-conventional": "^19.6.0",
@@ -439,6 +440,7 @@
     "@types/pg": "^8.20.0",
     "@types/tar": "^6.1.13",
     "actionlint": "^2.0.6",
+    "esbuild-fix-imports-plugin": "^1.0.23",
     "eslint": "^10.0.3",
     "json-schema-to-typescript": "^15.0.4",
     "json-schema-to-zod": "^2.6.1",
@@ -448,6 +450,7 @@
     "redis": "^4.7.0",
     "tar": "^7.5.13",
     "ts-to-zod": "^5.0.1",
+    "tsup": "^8.5.1",
     "tsx": "^4.6.0",
     "typedoc": "^0.28.13",
     "typedoc-plugin-markdown": "^4.9.0",
@@ -467,5 +470,8 @@
     },
     "minimatch": "^10.2.1"
   },
-  "adcp_version": "3.1.2"
+  "adcp_version": "3.1.2",
+  "sideEffects": [
+    "**/default-invariants.*"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -12,167 +12,327 @@
   "type": "commonjs",
   "exports": {
     ".": {
-      "import": "./dist/lib/index.mjs",
-      "require": "./dist/lib/index.js",
-      "types": "./dist/lib/index.d.ts"
+      "import": {
+        "types": "./dist/lib/index.d.mts",
+        "default": "./dist/lib/index.mjs"
+      },
+      "require": {
+        "types": "./dist/lib/index.d.ts",
+        "default": "./dist/lib/index.js"
+      }
     },
     "./client": {
-      "import": "./dist/lib/client/index.mjs",
-      "require": "./dist/lib/client/index.js",
-      "types": "./dist/lib/client/index.d.ts"
+      "import": {
+        "types": "./dist/lib/client/index.d.mts",
+        "default": "./dist/lib/client/index.mjs"
+      },
+      "require": {
+        "types": "./dist/lib/client/index.d.ts",
+        "default": "./dist/lib/client/index.js"
+      }
     },
     "./compliance": {
-      "import": "./dist/lib/compliance/index.mjs",
-      "require": "./dist/lib/compliance/index.js",
-      "types": "./dist/lib/compliance/index.d.ts"
+      "import": {
+        "types": "./dist/lib/compliance/index.d.mts",
+        "default": "./dist/lib/compliance/index.mjs"
+      },
+      "require": {
+        "types": "./dist/lib/compliance/index.d.ts",
+        "default": "./dist/lib/compliance/index.js"
+      }
     },
     "./advanced": {
-      "import": "./dist/lib/advanced.mjs",
-      "require": "./dist/lib/advanced.js",
-      "types": "./dist/lib/advanced.d.ts"
+      "import": {
+        "types": "./dist/lib/advanced.d.mts",
+        "default": "./dist/lib/advanced.mjs"
+      },
+      "require": {
+        "types": "./dist/lib/advanced.d.ts",
+        "default": "./dist/lib/advanced.js"
+      }
     },
     "./types": {
-      "import": "./dist/lib/types/index.mjs",
-      "require": "./dist/lib/types/index.js",
-      "types": "./dist/lib/types/index.d.ts"
+      "import": {
+        "types": "./dist/lib/types/index.d.mts",
+        "default": "./dist/lib/types/index.mjs"
+      },
+      "require": {
+        "types": "./dist/lib/types/index.d.ts",
+        "default": "./dist/lib/types/index.js"
+      }
     },
     "./enums": {
-      "import": "./dist/lib/enums.js",
-      "require": "./dist/lib/enums.js",
-      "types": "./dist/lib/enums.d.ts"
+      "import": {
+        "types": "./dist/lib/enums.d.mts",
+        "default": "./dist/lib/enums.mjs"
+      },
+      "require": {
+        "types": "./dist/lib/enums.d.ts",
+        "default": "./dist/lib/enums.js"
+      }
     },
     "./types/v2-5": {
-      "import": "./dist/lib/types/v2-5/index.mjs",
-      "require": "./dist/lib/types/v2-5/index.js",
-      "types": "./dist/lib/types/v2-5/index.d.ts"
+      "import": {
+        "types": "./dist/lib/types/v2-5/index.d.mts",
+        "default": "./dist/lib/types/v2-5/index.mjs"
+      },
+      "require": {
+        "types": "./dist/lib/types/v2-5/index.d.ts",
+        "default": "./dist/lib/types/v2-5/index.js"
+      }
     },
     "./types/v3-1-beta": {
-      "import": "./dist/lib/types/v3-1-beta/index.mjs",
-      "require": "./dist/lib/types/v3-1-beta/index.js",
-      "types": "./dist/lib/types/v3-1-beta/index.d.ts"
+      "import": {
+        "types": "./dist/lib/types/v3-1-beta/index.d.mts",
+        "default": "./dist/lib/types/v3-1-beta/index.mjs"
+      },
+      "require": {
+        "types": "./dist/lib/types/v3-1-beta/index.d.ts",
+        "default": "./dist/lib/types/v3-1-beta/index.js"
+      }
     },
     "./types/*": {
       "types": "./dist/lib/types/*.d.ts"
     },
     "./wholesale-feed-sync": {
-      "import": "./dist/lib/wholesale-feed-sync/index.mjs",
-      "require": "./dist/lib/wholesale-feed-sync/index.js",
-      "types": "./dist/lib/wholesale-feed-sync/index.d.ts"
+      "import": {
+        "types": "./dist/lib/wholesale-feed-sync/index.d.mts",
+        "default": "./dist/lib/wholesale-feed-sync/index.mjs"
+      },
+      "require": {
+        "types": "./dist/lib/wholesale-feed-sync/index.d.ts",
+        "default": "./dist/lib/wholesale-feed-sync/index.js"
+      }
     },
     "./v2/projection": {
-      "import": "./dist/lib/v2/projection/index.mjs",
-      "require": "./dist/lib/v2/projection/index.js",
-      "types": "./dist/lib/v2/projection/index.d.ts"
+      "import": {
+        "types": "./dist/lib/v2/projection/index.d.mts",
+        "default": "./dist/lib/v2/projection/index.mjs"
+      },
+      "require": {
+        "types": "./dist/lib/v2/projection/index.d.ts",
+        "default": "./dist/lib/v2/projection/index.js"
+      }
     },
     "./v2/format-schema": {
-      "import": "./dist/lib/v2/format-schema/index.mjs",
-      "require": "./dist/lib/v2/format-schema/index.js",
-      "types": "./dist/lib/v2/format-schema/index.d.ts"
+      "import": {
+        "types": "./dist/lib/v2/format-schema/index.d.mts",
+        "default": "./dist/lib/v2/format-schema/index.mjs"
+      },
+      "require": {
+        "types": "./dist/lib/v2/format-schema/index.d.ts",
+        "default": "./dist/lib/v2/format-schema/index.js"
+      }
     },
     "./v2/publisher-catalog": {
-      "import": "./dist/lib/v2/publisher-catalog/index.mjs",
-      "require": "./dist/lib/v2/publisher-catalog/index.js",
-      "types": "./dist/lib/v2/publisher-catalog/index.d.ts"
+      "import": {
+        "types": "./dist/lib/v2/publisher-catalog/index.d.mts",
+        "default": "./dist/lib/v2/publisher-catalog/index.mjs"
+      },
+      "require": {
+        "types": "./dist/lib/v2/publisher-catalog/index.d.ts",
+        "default": "./dist/lib/v2/publisher-catalog/index.js"
+      }
     },
     "./testing": {
-      "import": "./dist/lib/testing/index.mjs",
-      "require": "./dist/lib/testing/index.js",
-      "types": "./dist/lib/testing/index.d.ts"
+      "import": {
+        "types": "./dist/lib/testing/index.d.mts",
+        "default": "./dist/lib/testing/index.mjs"
+      },
+      "require": {
+        "types": "./dist/lib/testing/index.d.ts",
+        "default": "./dist/lib/testing/index.js"
+      }
     },
     "./testing/personas": {
-      "import": "./dist/lib/testing/personas/index.mjs",
-      "require": "./dist/lib/testing/personas/index.js",
-      "types": "./dist/lib/testing/personas/index.d.ts"
+      "import": {
+        "types": "./dist/lib/testing/personas/index.d.mts",
+        "default": "./dist/lib/testing/personas/index.mjs"
+      },
+      "require": {
+        "types": "./dist/lib/testing/personas/index.d.ts",
+        "default": "./dist/lib/testing/personas/index.js"
+      }
     },
     "./auth": {
-      "import": "./dist/lib/auth/index.mjs",
-      "require": "./dist/lib/auth/index.js",
-      "types": "./dist/lib/auth/index.d.ts"
+      "import": {
+        "types": "./dist/lib/auth/index.d.mts",
+        "default": "./dist/lib/auth/index.mjs"
+      },
+      "require": {
+        "types": "./dist/lib/auth/index.d.ts",
+        "default": "./dist/lib/auth/index.js"
+      }
     },
     "./webhooks": {
-      "import": "./dist/lib/webhooks/index.mjs",
-      "require": "./dist/lib/webhooks/index.js",
-      "types": "./dist/lib/webhooks/index.d.ts"
+      "import": {
+        "types": "./dist/lib/webhooks/index.d.mts",
+        "default": "./dist/lib/webhooks/index.mjs"
+      },
+      "require": {
+        "types": "./dist/lib/webhooks/index.d.ts",
+        "default": "./dist/lib/webhooks/index.js"
+      }
     },
     "./brand": {
-      "import": "./dist/lib/brand/index.mjs",
-      "require": "./dist/lib/brand/index.js",
-      "types": "./dist/lib/brand/index.d.ts"
+      "import": {
+        "types": "./dist/lib/brand/index.d.mts",
+        "default": "./dist/lib/brand/index.mjs"
+      },
+      "require": {
+        "types": "./dist/lib/brand/index.d.ts",
+        "default": "./dist/lib/brand/index.js"
+      }
     },
     "./net": {
-      "import": "./dist/lib/net/index.mjs",
-      "require": "./dist/lib/net/index.js",
-      "types": "./dist/lib/net/index.d.ts"
+      "import": {
+        "types": "./dist/lib/net/index.d.mts",
+        "default": "./dist/lib/net/index.mjs"
+      },
+      "require": {
+        "types": "./dist/lib/net/index.d.ts",
+        "default": "./dist/lib/net/index.js"
+      }
     },
     "./canonical-references": {
-      "import": "./dist/lib/canonical-references/index.mjs",
-      "require": "./dist/lib/canonical-references/index.js",
-      "types": "./dist/lib/canonical-references/index.d.ts"
+      "import": {
+        "types": "./dist/lib/canonical-references/index.d.mts",
+        "default": "./dist/lib/canonical-references/index.mjs"
+      },
+      "require": {
+        "types": "./dist/lib/canonical-references/index.d.ts",
+        "default": "./dist/lib/canonical-references/index.js"
+      }
     },
     "./server": {
-      "import": "./dist/lib/server/index.mjs",
-      "require": "./dist/lib/server/index.js",
-      "types": "./dist/lib/server/index.d.ts"
+      "import": {
+        "types": "./dist/lib/server/index.d.mts",
+        "default": "./dist/lib/server/index.mjs"
+      },
+      "require": {
+        "types": "./dist/lib/server/index.d.ts",
+        "default": "./dist/lib/server/index.js"
+      }
     },
     "./server/legacy/v5": {
-      "import": "./dist/lib/server/legacy/v5/index.mjs",
-      "require": "./dist/lib/server/legacy/v5/index.js",
-      "types": "./dist/lib/server/legacy/v5/index.d.ts"
+      "import": {
+        "types": "./dist/lib/server/legacy/v5/index.d.mts",
+        "default": "./dist/lib/server/legacy/v5/index.mjs"
+      },
+      "require": {
+        "types": "./dist/lib/server/legacy/v5/index.d.ts",
+        "default": "./dist/lib/server/legacy/v5/index.js"
+      }
     },
     "./signing": {
-      "import": "./dist/lib/signing/index.mjs",
-      "require": "./dist/lib/signing/index.js",
-      "types": "./dist/lib/signing/index.d.ts"
+      "import": {
+        "types": "./dist/lib/signing/index.d.mts",
+        "default": "./dist/lib/signing/index.mjs"
+      },
+      "require": {
+        "types": "./dist/lib/signing/index.d.ts",
+        "default": "./dist/lib/signing/index.js"
+      }
     },
     "./signing/client": {
-      "import": "./dist/lib/signing/client.mjs",
-      "require": "./dist/lib/signing/client.js",
-      "types": "./dist/lib/signing/client.d.ts"
+      "import": {
+        "types": "./dist/lib/signing/client.d.mts",
+        "default": "./dist/lib/signing/client.mjs"
+      },
+      "require": {
+        "types": "./dist/lib/signing/client.d.ts",
+        "default": "./dist/lib/signing/client.js"
+      }
     },
     "./signing/server": {
-      "import": "./dist/lib/signing/server.mjs",
-      "require": "./dist/lib/signing/server.js",
-      "types": "./dist/lib/signing/server.d.ts"
+      "import": {
+        "types": "./dist/lib/signing/server.d.mts",
+        "default": "./dist/lib/signing/server.mjs"
+      },
+      "require": {
+        "types": "./dist/lib/signing/server.d.ts",
+        "default": "./dist/lib/signing/server.js"
+      }
     },
     "./signing/testing": {
-      "import": "./dist/lib/signing/testing.mjs",
-      "require": "./dist/lib/signing/testing.js",
-      "types": "./dist/lib/signing/testing.d.ts"
+      "import": {
+        "types": "./dist/lib/signing/testing.d.mts",
+        "default": "./dist/lib/signing/testing.mjs"
+      },
+      "require": {
+        "types": "./dist/lib/signing/testing.d.ts",
+        "default": "./dist/lib/signing/testing.js"
+      }
     },
     "./schemas": {
-      "import": "./dist/lib/schemas/index.mjs",
-      "require": "./dist/lib/schemas/index.js",
-      "types": "./dist/lib/schemas/index.d.ts"
+      "import": {
+        "types": "./dist/lib/schemas/index.d.mts",
+        "default": "./dist/lib/schemas/index.mjs"
+      },
+      "require": {
+        "types": "./dist/lib/schemas/index.d.ts",
+        "default": "./dist/lib/schemas/index.js"
+      }
     },
     "./compliance-fixtures": {
-      "import": "./dist/lib/compliance-fixtures/index.mjs",
-      "require": "./dist/lib/compliance-fixtures/index.js",
-      "types": "./dist/lib/compliance-fixtures/index.d.ts"
+      "import": {
+        "types": "./dist/lib/compliance-fixtures/index.d.mts",
+        "default": "./dist/lib/compliance-fixtures/index.mjs"
+      },
+      "require": {
+        "types": "./dist/lib/compliance-fixtures/index.d.ts",
+        "default": "./dist/lib/compliance-fixtures/index.js"
+      }
     },
     "./conformance": {
-      "import": "./dist/lib/conformance/index.mjs",
-      "require": "./dist/lib/conformance/index.js",
-      "types": "./dist/lib/conformance/index.d.ts"
+      "import": {
+        "types": "./dist/lib/conformance/index.d.mts",
+        "default": "./dist/lib/conformance/index.mjs"
+      },
+      "require": {
+        "types": "./dist/lib/conformance/index.d.ts",
+        "default": "./dist/lib/conformance/index.js"
+      }
     },
     "./substitution": {
-      "import": "./dist/lib/substitution/index.mjs",
-      "require": "./dist/lib/substitution/index.js",
-      "types": "./dist/lib/substitution/index.d.ts"
+      "import": {
+        "types": "./dist/lib/substitution/index.d.mts",
+        "default": "./dist/lib/substitution/index.mjs"
+      },
+      "require": {
+        "types": "./dist/lib/substitution/index.d.ts",
+        "default": "./dist/lib/substitution/index.js"
+      }
     },
     "./express-mcp": {
-      "import": "./dist/lib/express-mcp/index.mjs",
-      "require": "./dist/lib/express-mcp/index.js",
-      "types": "./dist/lib/express-mcp/index.d.ts"
+      "import": {
+        "types": "./dist/lib/express-mcp/index.d.mts",
+        "default": "./dist/lib/express-mcp/index.mjs"
+      },
+      "require": {
+        "types": "./dist/lib/express-mcp/index.d.ts",
+        "default": "./dist/lib/express-mcp/index.js"
+      }
     },
     "./mock-server": {
-      "import": "./dist/lib/mock-server/index.mjs",
-      "require": "./dist/lib/mock-server/index.js",
-      "types": "./dist/lib/mock-server/index.d.ts"
+      "import": {
+        "types": "./dist/lib/mock-server/index.d.mts",
+        "default": "./dist/lib/mock-server/index.mjs"
+      },
+      "require": {
+        "types": "./dist/lib/mock-server/index.d.ts",
+        "default": "./dist/lib/mock-server/index.js"
+      }
     },
     "./upstream-recorder": {
-      "import": "./dist/lib/upstream-recorder/index.mjs",
-      "require": "./dist/lib/upstream-recorder/index.js",
-      "types": "./dist/lib/upstream-recorder/index.d.ts"
+      "import": {
+        "types": "./dist/lib/upstream-recorder/index.d.mts",
+        "default": "./dist/lib/upstream-recorder/index.mjs"
+      },
+      "require": {
+        "types": "./dist/lib/upstream-recorder/index.d.ts",
+        "default": "./dist/lib/upstream-recorder/index.js"
+      }
     },
     "./package.json": "./package.json"
   },
@@ -262,6 +422,15 @@
       "upstream-recorder": [
         "dist/lib/upstream-recorder/index.d.ts"
       ],
+      "enums": [
+        "dist/lib/enums.d.ts"
+      ],
+      "testing/personas": [
+        "dist/lib/testing/personas/index.d.ts"
+      ],
+      "server/legacy/v5": [
+        "dist/lib/server/legacy/v5/index.d.ts"
+      ],
       "types/*": [
         "dist/lib/types/*.d.ts"
       ]
@@ -291,7 +460,7 @@
     "sync:agents": "node scripts/import-claude-agents.mjs",
     "prepublishOnly": "npm run clean && npm run sync-schemas:all && (test -f src/lib/types/tools.generated.ts || npm run generate-types) && npm run build:lib && node --test-timeout=60000 --test-force-exit --test test/lib/adcp-client.test.js test/lib/validation.test.js test/lib/zod-schemas.test.js",
     "build": "npm run build:lib",
-    "build:lib": "npm run sync-version && npm run schemas:ensure && tsx scripts/generate-wire-spec-fields.ts && tsup && tsc --project tsconfig.lib.json --emitDeclarationOnly && tsx scripts/copy-schemas-to-dist.ts && tsx scripts/copy-v2-projection-catalog.ts && tsx scripts/generate-per-tool-types.ts",
+    "build:lib": "npm run sync-version && npm run schemas:ensure && tsx scripts/generate-wire-spec-fields.ts && tsup && tsc --project tsconfig.lib.json --emitDeclarationOnly && tsx scripts/copy-schemas-to-dist.ts && tsx scripts/copy-v2-projection-catalog.ts && tsx scripts/generate-per-tool-types.ts && tsx scripts/generate-dmts-declarations.ts",
     "build:test-agents": "npm run build:lib && tsc -p test-agents/tsconfig.json --rootDir test-agents",
     "pretest": "npm run schemas:ensure",
     "test": "npm run test:node && npm test --workspace=packages/eslint-plugin --if-present",
@@ -339,6 +508,8 @@
     "compliance:fork-matrix": "node --test --test-timeout=300000 'test/examples/hello-*.test.js' test/examples/proxy-seller-snap.test.js",
     "typecheck:skill-examples": "tsx scripts/typecheck-skill-examples.ts",
     "check:skill-sync": "tsx scripts/check-skill-sync.ts",
+    "check:package": "publint --strict && attw --pack .",
+    "verify:package": "node scripts/verify-package.mjs",
     "check:adopter-types": "tsx scripts/check-adopter-types.ts",
     "check:adopter-types-narrow": "tsx scripts/check-adopter-types-narrow.ts",
     "sync-version": "tsx scripts/sync-version.ts",
@@ -411,7 +582,7 @@
   },
   "peerDependencies": {
     "@a2a-js/sdk": "^0.3.13",
-    "@modelcontextprotocol/sdk": "^1.17.5",
+    "@modelcontextprotocol/sdk": "^1.24.0",
     "@opentelemetry/api": "^1.0.0",
     "pg": "^8.0.0",
     "redis": "^4.6.0 || ^5.0.0",
@@ -430,6 +601,7 @@
   },
   "devDependencies": {
     "@a2a-js/sdk": "^0.3.13",
+    "@arethetypeswrong/cli": "^0.18.5",
     "@changesets/cli": "^2.29.7",
     "@commitlint/cli": "^19.6.0",
     "@commitlint/config-conventional": "^19.6.0",
@@ -447,6 +619,7 @@
     "openapi-typescript": "^7.13.0",
     "pg": "^8.20.0",
     "prettier": "^3.6.2",
+    "publint": "^0.3.21",
     "redis": "^4.7.0",
     "tar": "^7.5.13",
     "ts-to-zod": "^5.0.1",

--- a/scripts/generate-dmts-declarations.ts
+++ b/scripts/generate-dmts-declarations.ts
@@ -1,0 +1,107 @@
+#!/usr/bin/env tsx
+/**
+ * TL;DR: we ship the library in two module formats (.mjs / .js), and each
+ * format needs its own matching set of type files. Our build tools only produce
+ * the type files for one format; the tool that would produce the other set
+ * can't handle a project this large. So this script produces the missing set.
+ * Delete it once the build can generate both natively.
+ *
+ * Emit ESM-format type declarations (`.d.mts`) alongside the `.d.ts` files
+ * produced by `tsc --emitDeclarationOnly`.
+ *
+ * The package is `type: commonjs`, so a `.d.ts` is interpreted as a CJS-format
+ * declaration. When a consumer resolves the package through the `import`
+ * condition (real ESM, `moduleResolution: node16`/`bundler`), TypeScript then
+ * types the `.mjs` runtime file with that CJS `.d.ts` — attw flags this as
+ * "masquerading as CJS" (FalseCJS). Shipping a parallel `.d.mts` for the
+ * `import` condition gives ESM consumers an ESM-format declaration, so the
+ * runtime format and the declaration format agree.
+ *
+ * ESM declaration resolution requires explicit relative specifiers, so this is
+ * the declaration-layer companion to the runtime import-fixers in
+ * `tsup.config.ts`: it copies each `.d.ts` to `.d.mts` and appends the module
+ * extension to every relative `from`/`import(...)` specifier — `.mjs` for a
+ * file, `/index.mjs` for a directory — resolving each against the built dist
+ * tree (the bytes that actually ship).
+ */
+import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import * as path from 'node:path';
+
+const DIST_LIB = path.resolve(process.cwd(), 'dist/lib');
+
+function collectDeclarationFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...collectDeclarationFiles(full));
+    } else if (entry.name.endsWith('.d.ts')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+// The per-tool type slices under `dist/lib/types/` are reached only through the
+// types-only `./types/*` wildcard export (no `import`/`require` condition), so
+// they never resolve as ESM and a `.d.mts` for them is dead weight (~5.5 MB).
+// Skip them, keyed off the authoritative per-tool manifest.
+function wildcardOnlySlices(): Set<string> {
+  const indexPath = path.join(DIST_LIB, 'types', 'per-tool-index.json');
+  if (!existsSync(indexPath)) return new Set();
+  const index = JSON.parse(readFileSync(indexPath, 'utf8')) as {
+    tools: Record<string, { subpath: string }>;
+  };
+  return new Set(Object.values(index.tools).map(t => path.join(DIST_LIB, 'types', `${path.basename(t.subpath)}.d.ts`)));
+}
+
+// Resolve a relative specifier against the dist tree and return the ESM form.
+// A specifier that already carries a JS/JSON extension is normalised (`.js` →
+// `.mjs`); an extensionless one becomes `<spec>.mjs` for a file or
+// `<spec>/index.mjs` for a directory. Anything that resolves to neither is
+// left untouched (bare packages, or specifiers we can't classify).
+function toEsmSpecifier(spec: string, fromDir: string): string {
+  const extMatch = spec.match(/\.(mjs|cjs|js|json|node|wasm)$/);
+  if (extMatch) {
+    return extMatch[1] === 'js' ? spec.replace(/\.js$/, '.mjs') : spec;
+  }
+  const abs = path.resolve(fromDir, spec);
+  if (existsSync(`${abs}.d.ts`)) return `${spec}.mjs`;
+  if (existsSync(path.join(abs, 'index.d.ts'))) return `${spec}/index.mjs`;
+  return spec;
+}
+
+// Rewrite the specifier in every real `from '...'` / `import('...')` clause.
+// The leading alternative consumes block and line comments whole and returns
+// them untouched, so relative paths inside JSDoc `@example` blocks are left
+// alone (rewriting them would corrupt the shipped documentation examples).
+function rewriteSpecifiers(code: string, fromDir: string): string {
+  const pattern = /(\/\*[\s\S]*?\*\/|\/\/[^\n]*)|(\bfrom\s*|\bimport\s*\(\s*)(['"])(\.[^'"]+)\3/g;
+  return code.replace(pattern, (match, comment, pre, quote, spec) => {
+    if (comment !== undefined) return comment;
+    return `${pre}${quote}${toEsmSpecifier(spec, fromDir)}${quote}`;
+  });
+}
+
+function main(): void {
+  if (!existsSync(DIST_LIB) || !statSync(DIST_LIB).isDirectory()) {
+    throw new Error(`dist/lib not found at ${DIST_LIB}; run the declaration emit (tsc) first`);
+  }
+
+  const skip = wildcardOnlySlices();
+  const declarations = collectDeclarationFiles(DIST_LIB).filter(f => !skip.has(f));
+  let written = 0;
+  for (const file of declarations) {
+    const source = readFileSync(file, 'utf8');
+    // The declaration map points at the `.d.ts`; drop the reference rather than
+    // ship a `.d.mts` whose sourceMappingURL resolves to the wrong file.
+    const withoutMap = source.replace(/\n?\/\/# sourceMappingURL=.*\.d\.ts\.map\s*$/, '\n');
+    const rewritten = rewriteSpecifiers(withoutMap, path.dirname(file));
+    const target = file.replace(/\.d\.ts$/, '.d.mts');
+    writeFileSync(target, rewritten);
+    written++;
+  }
+  console.log(`✅ Emitted ${written} .d.mts declaration(s) alongside .d.ts`);
+}
+
+main();

--- a/scripts/verify-package.mjs
+++ b/scripts/verify-package.mjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+/**
+ * Clean-room dual-format smoke test for the publish artifact.
+ *
+ * `check:package` (publint + attw) reads the export map statically; this
+ * script proves the packed tarball actually loads. It packs the package,
+ * installs the tarball plus its required peerDependencies pinned to their
+ * range floors into a throwaway directory in the OS temp dir, then loads
+ * `@adcp/sdk`, `@adcp/sdk/enums`, and `@adcp/sdk/server` through both a real
+ * ESM `import` and a real CJS `require`, asserting each exposes a known runtime
+ * symbol.
+ *
+ * Why a temp dir outside the repo: installing inside the workspace would let
+ * the monorepo dedupe peers against the repo's own node_modules, so a missing
+ * or too-low peer floor would be masked. A fresh dir under os.tmpdir() with
+ * its own package.json gives an honest npm resolution — the same one a
+ * downstream consumer gets. This is what would have caught the @a2a-js/sdk
+ * peer-floor bug (^0.3.4 declared while the code needs >=0.3.13).
+ *
+ * Requires a prior `npm run build:lib` — it packs whatever is in dist/.
+ * Exits non-zero on any failure.
+ */
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+/** Lowest version a semver range accepts (first `||` clause, operators stripped). */
+function rangeFloor(range) {
+  const firstClause = range.split('||')[0].trim();
+  const match = firstClause.match(/\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?/);
+  if (!match) {
+    throw new Error(`Cannot determine version floor for range: "${range}"`);
+  }
+  return match[0];
+}
+
+function run(cmd, args, options = {}) {
+  return execFileSync(cmd, args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'inherit'], ...options });
+}
+
+const pkg = JSON.parse(readFileSync(path.join(REPO_ROOT, 'package.json'), 'utf8'));
+
+// Pin every REQUIRED peer to its floor, so the smoke test resolves the exact
+// minimums the export map promises — not whatever higher version npm would
+// otherwise pick. Optional peers (peerDependenciesMeta) are skipped: no tested
+// subpath loads them, so installing them adds only weight and registry-flake
+// surface without adding load coverage.
+const optionalPeers = pkg.peerDependenciesMeta ?? {};
+const peerFloors = Object.entries(pkg.peerDependencies ?? {})
+  .filter(([name]) => !optionalPeers[name]?.optional)
+  .map(([name, range]) => `${name}@${rangeFloor(range)}`);
+
+let tmpDir;
+let tarballPath;
+try {
+  console.log('📦 Packing tarball...');
+  // --ignore-scripts: dist/ is already built, so skip the prepare hook whose
+  // stdout would otherwise corrupt the --json payload.
+  const packJson = run('npm', ['pack', '--json', '--ignore-scripts'], { cwd: REPO_ROOT });
+  const filename = JSON.parse(packJson.slice(packJson.indexOf('[')))[0].filename;
+  tarballPath = path.join(REPO_ROOT, filename);
+  console.log(`   → ${filename}`);
+
+  tmpDir = mkdtempSync(path.join(tmpdir(), 'adcp-verify-'));
+  console.log(`🧪 Clean-room dir: ${tmpDir}`);
+
+  // A private package.json makes npm treat tmpDir as the project root, so it
+  // never walks up into the repo's workspace.
+  writeFileSync(
+    path.join(tmpDir, 'package.json'),
+    JSON.stringify({ name: 'adcp-verify-consumer', version: '1.0.0', private: true }, null, 2)
+  );
+
+  console.log(`📥 Installing tarball + peer floors:\n   ${peerFloors.join('\n   ')}`);
+  run('npm', ['install', '--no-audit', '--no-fund', '--loglevel=error', tarballPath, ...peerFloors], {
+    cwd: tmpDir,
+    stdio: 'inherit',
+  });
+
+  // Cover the barrel, a zod-free enum entry, and the server subpath — the last
+  // adds real ESM/CJS load coverage of the @a2a-js/sdk peer through a dedicated
+  // entrypoint rather than relying on whatever the barrel happens to re-export.
+  const cases = [
+    { specifier: '@adcp/sdk', symbol: 'EventTypeValues' },
+    { specifier: '@adcp/sdk/enums', symbol: 'EventTypeValues' },
+    { specifier: '@adcp/sdk/server', symbol: 'A2AInvocationError' },
+  ];
+
+  // Shared by both generated smoke modules. A function declaration (not an
+  // arrow) so it hoists above the ESM import statements that call it.
+  const assertSource = [
+    'function assertion(m, symbol) {',
+    '  if (Object.keys(m).length === 0) {',
+    '    throw new Error("module exposed no exports");',
+    '  }',
+    '  if (m[symbol] === undefined) {',
+    '    throw new Error(symbol + " export is missing");',
+    '  }',
+    '}',
+    '',
+  ].join('\n');
+
+  // ESM: real `import` of every case in one module.
+  const esmBody = cases
+    .map(
+      (c, i) =>
+        `import * as m${i} from '${c.specifier}';\nassertion(m${i}, '${c.symbol}');\nconsole.log('  ESM ${c.specifier} → ${c.symbol} ok');`
+    )
+    .join('\n');
+  writeFileSync(path.join(tmpDir, 'smoke.mjs'), `${assertSource}${esmBody}\n`);
+
+  // CJS: real `require` of every case in one module.
+  const cjsBody = cases
+    .map(
+      (c, i) =>
+        `const m${i} = require('${c.specifier}');\nassertion(m${i}, '${c.symbol}');\nconsole.log('  CJS ${c.specifier} → ${c.symbol} ok');`
+    )
+    .join('\n');
+  writeFileSync(path.join(tmpDir, 'smoke.cjs'), `${assertSource}${cjsBody}\n`);
+
+  console.log('🔍 ESM import:');
+  run('node', ['smoke.mjs'], { cwd: tmpDir, stdio: 'inherit' });
+  console.log('🔍 CJS require:');
+  run('node', ['smoke.cjs'], { cwd: tmpDir, stdio: 'inherit' });
+
+  console.log('\n✅ Package loads in both ESM and CJS with peer floors satisfied.');
+} catch (err) {
+  console.error('\n❌ Package verification failed:');
+  console.error(err.message ?? err);
+  process.exitCode = 1;
+} finally {
+  if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
+  if (tarballPath) rmSync(tarballPath, { force: true });
+}

--- a/scripts/verify-package.mjs
+++ b/scripts/verify-package.mjs
@@ -21,7 +21,7 @@
  * Exits non-zero on any failure.
  */
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -55,16 +55,7 @@ const peerFloors = Object.entries(pkg.peerDependencies ?? {})
   .map(([name, range]) => `${name}@${rangeFloor(range)}`);
 
 let tmpDir;
-let tarballPath;
 try {
-  console.log('📦 Packing tarball...');
-  // --ignore-scripts: dist/ is already built, so skip the prepare hook whose
-  // stdout would otherwise corrupt the --json payload.
-  const packJson = run('npm', ['pack', '--json', '--ignore-scripts'], { cwd: REPO_ROOT });
-  const filename = JSON.parse(packJson.slice(packJson.indexOf('[')))[0].filename;
-  tarballPath = path.join(REPO_ROOT, filename);
-  console.log(`   → ${filename}`);
-
   tmpDir = mkdtempSync(path.join(tmpdir(), 'adcp-verify-'));
   console.log(`🧪 Clean-room dir: ${tmpDir}`);
 
@@ -74,6 +65,20 @@ try {
     path.join(tmpDir, 'package.json'),
     JSON.stringify({ name: 'adcp-verify-consumer', version: '1.0.0', private: true }, null, 2)
   );
+
+  // Pack into the temp dir and locate the .tgz on disk. We deliberately do NOT
+  // parse `npm pack --json` stdout: npm runs the `prepare` lifecycle during
+  // pack and its banner pollutes stdout (even with --ignore-scripts on some npm
+  // versions), which breaks JSON parsing. Reading the emitted file sidesteps it.
+  console.log('📦 Packing tarball...');
+  run('npm', ['pack', '--pack-destination', tmpDir, '--ignore-scripts', '--loglevel=error'], {
+    cwd: REPO_ROOT,
+    stdio: 'inherit',
+  });
+  const tgz = readdirSync(tmpDir).find(f => f.endsWith('.tgz'));
+  if (!tgz) throw new Error(`npm pack produced no .tgz in ${tmpDir}`);
+  const tarballPath = path.join(tmpDir, tgz);
+  console.log(`   → ${tgz}`);
 
   console.log(`📥 Installing tarball + peer floors:\n   ${peerFloors.join('\n   ')}`);
   run('npm', ['install', '--no-audit', '--no-fund', '--loglevel=error', tarballPath, ...peerFloors], {
@@ -133,6 +138,6 @@ try {
   console.error(err.message ?? err);
   process.exitCode = 1;
 } finally {
+  // The tarball lives inside tmpDir, so removing the dir removes it too.
   if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
-  if (tarballPath) rmSync(tarballPath, { force: true });
 }

--- a/src/lib/auth/oauth/index.ts
+++ b/src/lib/auth/oauth/index.ts
@@ -94,6 +94,7 @@ export { MCPOAuthProvider } from './MCPOAuthProvider';
 
 import { MCPOAuthProvider } from './MCPOAuthProvider';
 import { CLIFlowHandler, type CLIFlowHandlerConfig } from './CLIFlowHandler';
+import { NonInteractiveFlowHandler } from './NonInteractiveFlowHandler';
 import type { OAuthClientMetadata, OAuthConfigStorage, AgentConfig } from './types';
 import { DEFAULT_CLIENT_METADATA } from './types';
 
@@ -202,7 +203,6 @@ export function createNonInteractiveOAuthProvider(
     allowHttp?: boolean;
   }
 ): MCPOAuthProvider {
-  const { NonInteractiveFlowHandler } = require('./NonInteractiveFlowHandler');
   const flowHandler = new NonInteractiveFlowHandler({ agentHint: options?.agentHint });
 
   const clientMetadata: OAuthClientMetadata = {

--- a/src/lib/canonical-references/index.ts
+++ b/src/lib/canonical-references/index.ts
@@ -10,7 +10,11 @@
  */
 import { createHash } from 'crypto';
 import Ajv from 'ajv';
-import Ajv2020 from 'ajv/dist/2020';
+// Loaded via `require` (extension-lenient CJS resolution) rather than a
+// bare-specifier `import` — ajv ships no `exports` map, so Node's ESM resolver
+// would demand an explicit `ajv/dist/2020.js`. The ESM build gets a
+// `createRequire` shim, so `require` is available in both formats.
+const Ajv2020 = require('ajv/dist/2020') as typeof import('ajv/dist/2020').default;
 import addFormats from 'ajv-formats';
 import { ssrfSafeFetch, SSRF_TRANSIENT_CODES, SsrfRefusedError } from '../net/ssrf-fetch';
 import {
@@ -752,7 +756,7 @@ function getDraft07Ajv(): Ajv {
   return ajv;
 }
 
-function getDraft2020Ajv(): Ajv2020 {
+function getDraft2020Ajv(): InstanceType<typeof Ajv2020> {
   const ajv = new Ajv2020({
     strict: false,
     allErrors: true,

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -85,6 +85,10 @@ import type {
   CreateMediaBuyResponse,
 } from '../types/core.generated';
 import type { Task as A2ATask, TaskStatusUpdateEvent } from '@a2a-js/sdk';
+import { A2AClient as A2AClientImpl } from '@a2a-js/sdk/client';
+// A2A SDK client used untyped — wire shapes are validated at runtime, matching
+// the prior CommonJS `require('@a2a-js/sdk/client')` behaviour.
+const A2AClient: any = A2AClientImpl;
 
 import { TaskExecutor, DeferredTaskError } from './TaskExecutor';
 import { attachMatch } from './match';
@@ -832,9 +836,6 @@ export class SingleAgentClient {
    * - Check for OAuth metadata to provide helpful guidance
    */
   private async fetchA2ACanonicalUrl(agentUri: string, readOptions?: ReadRequestOptions): Promise<string> {
-    const clientModule = require('@a2a-js/sdk/client');
-    const A2AClient = clientModule.A2AClient;
-
     // adcp-client#1804 — wrap A2A card discovery in withResponseSizeLimit so
     // `transport.maxResponseBytes` applies to every agent-card fetch. The
     // auth-stamping fetchImpl composes through wrapFetchWithSizeLimit so the
@@ -3788,8 +3789,6 @@ export class SingleAgentClient {
       }
     } else if (this.normalizedAgent.protocol === 'a2a') {
       // Use A2A SDK to get agent card
-      const clientModule = require('@a2a-js/sdk/client');
-      const A2AClient = clientModule.A2AClient;
 
       // adcp-client#1799 — route the custom fetchImpl through
       // `wrapFetchWithSizeLimit` so the active ALS slot enforces the cap on

--- a/src/lib/protocols/a2a.ts
+++ b/src/lib/protocols/a2a.ts
@@ -1,7 +1,5 @@
 // Official A2A client implementation - NO FALLBACKS
-const clientModule = require('@a2a-js/sdk/client');
-const A2AClient = clientModule.A2AClient;
-
+import { A2AClient as A2AClientImpl } from '@a2a-js/sdk/client';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { createHmac, randomUUID } from 'node:crypto';
 import type { PushNotificationConfig } from '../types/tools.generated';
@@ -22,6 +20,11 @@ import { wrapFetchWithSizeLimit } from './responseSizeLimit';
 import { wrapFetchWithTransportDiagnostics } from './transportDiagnostics';
 import { DEFAULT_REQUEST_TIMEOUT_MS, resolveRequestTimeoutMs, withAbortSignal } from './abort';
 import { getLatestA2ADataPartFromResponse } from '../utils/a2a-artifacts';
+
+// The A2A SDK client is used untyped: request/response shapes are validated at
+// runtime against the AdCP wire contract, not against the SDK's exported
+// types. Preserves the prior behaviour of the CommonJS `require` form.
+const A2AClient: any = A2AClientImpl;
 
 if (!A2AClient) {
   throw new Error('A2A SDK client is required. Please install @a2a-js/sdk');

--- a/src/lib/protocols/rawResponseCapture.ts
+++ b/src/lib/protocols/rawResponseCapture.ts
@@ -9,7 +9,7 @@
 // every HTTP request that happened inside `fn`. The uniform-error invariant
 // uses the captures to compare two probes byte-for-byte.
 
-import { AsyncLocalStorage } from 'node:async_hooks';
+import { globalAsyncLocalStorage } from '../utils/global-async-local-storage';
 
 export interface RawHttpCapture {
   url: string;
@@ -33,7 +33,7 @@ interface CaptureSlot {
 // against accidentally retaining huge responses.
 const DEFAULT_MAX_BODY_BYTES = 1_048_576;
 
-export const rawResponseCaptureStorage = new AsyncLocalStorage<CaptureSlot>();
+export const rawResponseCaptureStorage = globalAsyncLocalStorage<CaptureSlot>('rawResponseCapture');
 
 /**
  * Run `fn` with a raw-response capture slot active. Every HTTP request made

--- a/src/lib/protocols/responseSizeLimit.ts
+++ b/src/lib/protocols/responseSizeLimit.ts
@@ -10,14 +10,14 @@
 // reads the size-limited body via `response.clone()`, so a hostile reply
 // can't blow memory through the capture path either.
 
-import { AsyncLocalStorage } from 'node:async_hooks';
+import { globalAsyncLocalStorage } from '../utils/global-async-local-storage';
 import { ResponseTooLargeError } from '../errors';
 
 interface SizeLimitSlot {
   maxResponseBytes: number;
 }
 
-export const responseSizeLimitStorage = new AsyncLocalStorage<SizeLimitSlot>();
+export const responseSizeLimitStorage = globalAsyncLocalStorage<SizeLimitSlot>('responseSizeLimit');
 
 /**
  * Run `fn` with a response body byte cap active. Every fetch made through

--- a/src/lib/protocols/transportDiagnostics.ts
+++ b/src/lib/protocols/transportDiagnostics.ts
@@ -1,4 +1,4 @@
-import { AsyncLocalStorage } from 'node:async_hooks';
+import { globalAsyncLocalStorage } from '../utils/global-async-local-storage';
 import { createHmac } from 'node:crypto';
 
 export type TransportActivityType = 'request_started' | 'response_received' | 'request_failed';
@@ -83,7 +83,7 @@ const SENSITIVE_TEXT_FIELD_RE =
   /((?:"[^"]*(?:authorization|cookie|credentials?|secret|signature|token|api[_-]?key|private[_-]?key|idempotency[_-]?key|password)[^"]*"\s*:\s*)|(?:^|[&\s])[^=&\s]*(?:authorization|cookie|credentials?|secret|signature|token|api[_-]?key|private[_-]?key|idempotency[_-]?key|password)[^=&\s]*=)("[^"]*"|[^&\s,}]+)/gi;
 const URL_LIKE_RE = /\bhttps?:\/\/[^\s"'<>]+/gi;
 
-export const transportDiagnosticsStorage = new AsyncLocalStorage<TransportDiagnosticsSlot>();
+export const transportDiagnosticsStorage = globalAsyncLocalStorage<TransportDiagnosticsSlot>('transportDiagnostics');
 
 export function withTransportDiagnostics<T>(
   context: TransportActivityContext & { onTransportActivity?: TransportActivityHandler },

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -40,6 +40,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { parseAdcpMajorVersion, toReleasePrecisionVersion, type AdcpVersion } from '../version';
 import { resolveAdcpVersion } from '../utils/adcp-version-config';
 import { resolveBundleKey } from '../validation/schema-loader';
+import { TOOL_INPUT_SHAPES } from '../schemas';
 import { bundleSupportsAdcpVersionField } from '../protocols';
 import { getToolsWithErrorArm, type ErrorArmDescriptor } from './error-arm-tools';
 import type { ToolCallback } from '@modelcontextprotocol/sdk/server/mcp.js';
@@ -2433,7 +2434,7 @@ const SHALLOW_HINT_FIELD_SCHEMA = z.unknown().optional();
 const SHALLOW_HINT_SCHEMAS = new Map<string, AnySchema>();
 
 function getToolInputShapes(): ToolInputShapeMap {
-  cachedToolInputShapes ??= require('../schemas').TOOL_INPUT_SHAPES as ToolInputShapeMap;
+  cachedToolInputShapes ??= TOOL_INPUT_SHAPES as unknown as ToolInputShapeMap;
   return cachedToolInputShapes;
 }
 

--- a/src/lib/server/decisioning/buyer-agent.ts
+++ b/src/lib/server/decisioning/buyer-agent.ts
@@ -396,11 +396,7 @@ function isVerifiedHttpSigPayload(credential: { agent_url?: string }): credentia
  * `{ kind: 'http_sig', ... }` credential will NOT carry the brand —
  * `signingOnly` and `mixed` registry factories reject those.
  */
-// `Symbol.for` (global registry) rather than a fresh `Symbol()` so this
-// fail-closed brand still matches when a consumer loads both the ESM and CJS
-// builds: a plain `Symbol()` would differ between the two copies and silently
-// reject a legitimately verified credential.
-const VERIFIED_HTTP_SIG_BRAND: unique symbol = Symbol.for('@adcp/sdk.verifiedHttpSig');
+const VERIFIED_HTTP_SIG_BRAND: unique symbol = Symbol('@adcp/sdk.verifiedHttpSig');
 
 type VerifiedHttpSig = Extract<AdcpCredential, { kind: 'http_sig' }> & {
   readonly [VERIFIED_HTTP_SIG_BRAND]: true;

--- a/src/lib/server/decisioning/buyer-agent.ts
+++ b/src/lib/server/decisioning/buyer-agent.ts
@@ -396,7 +396,11 @@ function isVerifiedHttpSigPayload(credential: { agent_url?: string }): credentia
  * `{ kind: 'http_sig', ... }` credential will NOT carry the brand —
  * `signingOnly` and `mixed` registry factories reject those.
  */
-const VERIFIED_HTTP_SIG_BRAND: unique symbol = Symbol('@adcp/sdk.verifiedHttpSig');
+// `Symbol.for` (global registry) rather than a fresh `Symbol()` so this
+// fail-closed brand still matches when a consumer loads both the ESM and CJS
+// builds: a plain `Symbol()` would differ between the two copies and silently
+// reject a legitimately verified credential.
+const VERIFIED_HTTP_SIG_BRAND: unique symbol = Symbol.for('@adcp/sdk.verifiedHttpSig');
 
 type VerifiedHttpSig = Extract<AdcpCredential, { kind: 'http_sig' }> & {
   readonly [VERIFIED_HTTP_SIG_BRAND]: true;

--- a/src/lib/signing/agent-context.ts
+++ b/src/lib/signing/agent-context.ts
@@ -1,5 +1,5 @@
-import { AsyncLocalStorage } from 'node:async_hooks';
 import { createHash } from 'node:crypto';
+import { globalAsyncLocalStorage } from '../utils/global-async-local-storage';
 import type { AgentConfig, AgentRequestSigningConfig } from '../types/adcp';
 import {
   buildCapabilityCacheKey,
@@ -70,7 +70,7 @@ export interface AgentSigningContext {
  * so a non-signing call cannot inherit a stale context from an enclosing
  * scope.
  */
-export const signingContextStorage = new AsyncLocalStorage<AgentSigningContext | undefined>();
+export const signingContextStorage = globalAsyncLocalStorage<AgentSigningContext | undefined>('signingContext');
 
 /**
  * Build an `AgentSigningContext` from an `AgentConfig` when signing is

--- a/src/lib/testing/compliance/comply.ts
+++ b/src/lib/testing/compliance/comply.ts
@@ -20,7 +20,9 @@ import { checkAccountDiscoveryGate } from './spec-conformance';
 // reference without shipping the matching implementation module. Without this,
 // `resolveAssertions` throws and every comply() call against an up-to-date
 // compliance cache fails at startup.
-import '../storyboard/default-invariants';
+import { registerDefaultInvariants } from '../storyboard/default-invariants';
+
+registerDefaultInvariants();
 import {
   resolveStoryboardsForCapabilities,
   resolveBundleOrStoryboard,

--- a/src/lib/testing/storyboard/default-invariants.ts
+++ b/src/lib/testing/storyboard/default-invariants.ts
@@ -59,1299 +59,1262 @@ function registerOnce(id: string, spec: Parameters<typeof registerAssertion>[0])
   registerAssertion(spec);
 }
 
-registerOnce('idempotency.conflict_no_payload_leak', {
-  id: 'idempotency.conflict_no_payload_leak',
-  default: true,
-  description:
-    'IDEMPOTENCY_CONFLICT errors MUST NOT echo the prior request payload or response (stolen-key read oracle).',
-  onStep: (_ctx, stepResult) => {
-    const err = extractAdcpError(stepResult);
-    if (!err) return [];
-    if (err.code !== 'IDEMPOTENCY_CONFLICT') return [];
+/**
+ * Register the default invariant assertions into the shared registry.
+ *
+ * Idempotent (guarded by `REGISTERED`), so the storyboard runner and the
+ * compliance harness can both call it. Invoked explicitly by those entry
+ * points rather than through a bare `import './default-invariants'` for side
+ * effect: a side-effect-only import is fragile — ESM extension rewriting and
+ * bundler tree-shaking can silently drop it, leaving the assertion registry
+ * empty and `resolveAssertions` throwing.
+ */
+export function registerDefaultInvariants(): void {
+  registerOnce('idempotency.conflict_no_payload_leak', {
+    id: 'idempotency.conflict_no_payload_leak',
+    default: true,
+    description:
+      'IDEMPOTENCY_CONFLICT errors MUST NOT echo the prior request payload or response (stolen-key read oracle).',
+    onStep: (_ctx, stepResult) => {
+      const err = extractAdcpError(stepResult);
+      if (!err) return [];
+      if (err.code !== 'IDEMPOTENCY_CONFLICT') return [];
 
-    const description = 'IDEMPOTENCY_CONFLICT error redacts prior payload';
-    const leaked: string[] = [];
-    for (const key of Object.keys(err.details)) {
-      if (!CONFLICT_ADCP_ERROR_ALLOWLIST.has(key)) leaked.push(key);
-    }
-    const expectedRecovery = STANDARD_ERROR_CODES.IDEMPOTENCY_CONFLICT.recovery;
-    if ('recovery' in err.details && err.details.recovery !== expectedRecovery) {
+      const description = 'IDEMPOTENCY_CONFLICT error redacts prior payload';
+      const leaked: string[] = [];
+      for (const key of Object.keys(err.details)) {
+        if (!CONFLICT_ADCP_ERROR_ALLOWLIST.has(key)) leaked.push(key);
+      }
+      const expectedRecovery = STANDARD_ERROR_CODES.IDEMPOTENCY_CONFLICT.recovery;
+      if ('recovery' in err.details && err.details.recovery !== expectedRecovery) {
+        return [
+          {
+            passed: false,
+            description,
+            step_id: stepResult.step_id,
+            error:
+              `IDEMPOTENCY_CONFLICT error envelope carried non-standard recovery metadata: ` +
+              `expected ${JSON.stringify(expectedRecovery)}.`,
+          },
+        ];
+      }
+      if (leaked.length === 0) {
+        return [{ passed: true, description, step_id: stepResult.step_id }];
+      }
       return [
         {
           passed: false,
           description,
           step_id: stepResult.step_id,
           error:
-            `IDEMPOTENCY_CONFLICT error envelope carried non-standard recovery metadata: ` +
-            `expected ${JSON.stringify(expectedRecovery)}.`,
+            `IDEMPOTENCY_CONFLICT error envelope leaked non-allowlisted field(s): ${leaked.sort().join(', ')}. ` +
+            `Allowed envelope keys (ADCP_ERROR_FIELD_ALLOWLIST.IDEMPOTENCY_CONFLICT): ` +
+            `${[...CONFLICT_ADCP_ERROR_ALLOWLIST].join(', ')}.`,
         },
       ];
-    }
-    if (leaked.length === 0) {
-      return [{ passed: true, description, step_id: stepResult.step_id }];
-    }
-    return [
-      {
-        passed: false,
-        description,
-        step_id: stepResult.step_id,
-        error:
-          `IDEMPOTENCY_CONFLICT error envelope leaked non-allowlisted field(s): ${leaked.sort().join(', ')}. ` +
-          `Allowed envelope keys (ADCP_ERROR_FIELD_ALLOWLIST.IDEMPOTENCY_CONFLICT): ` +
-          `${[...CONFLICT_ADCP_ERROR_ALLOWLIST].join(', ')}.`,
-      },
-    ];
-  },
-});
+    },
+  });
 
-/**
- * Bearer-token literal pattern. Matches the wire form a seller might echo
- * from `Authorization: Bearer <token>` — case-insensitive `bearer` keyword
- * followed by a token body of at least 10 characters of base64url / JWT
- * vocabulary. Kept strict on length to avoid false positives on prose like
- * "bearer of bad news".
- */
-const BEARER_TOKEN_PATTERN = /\bbearer\s+[A-Za-z0-9._~+/=-]{10,}/i;
-
-/**
- * Property names that MUST NOT appear on a response body — a seller that
- * serializes `Authorization` / `api_key` / `x-api-key` headers or fields
- * into the response is almost certainly leaking credentials, regardless of
- * whether the scanner picks up the value verbatim (header normalization,
- * whitespace differences, etc. can mask verbatim matches). Case-insensitive.
- */
-const SUSPECT_PROPERTY_NAMES = new Set(['authorization', 'api_key', 'apikey', 'bearer', 'x-api-key']);
-
-/**
- * Minimum length for a caller-supplied secret to be hunted for verbatim.
- * Set to 16 because real OAuth access tokens, refresh tokens, and signing
- * secrets are ≥20 chars by convention (opaque UUIDs, JWTs, HMAC hex). A
- * shorter floor would false-positive on benign identifiers (short
- * usernames, environment names, 8-char hex prefixes, ISO timestamps).
- * Hand-coded fixture keys like `"test-key"` below this bar are not caught
- * — that's the right tradeoff: a real agent echoing such a value is an
- * obvious leak a human reviewer would spot, and the collision cost of
- * matching short strings against every response body is too high to
- * justify the coverage.
- */
-const SECRET_MIN_LENGTH = 16;
-
-registerOnce('context.no_secret_echo', {
-  id: 'context.no_secret_echo',
-  default: true,
-  description: 'Response bodies MUST NOT echo bearer tokens, API keys, or auth header values back to the caller.',
-  onStart: ctx => {
-    // Stash caller-supplied secrets worth hunting verbatim. `auth` is the
-    // structured discriminated union from TestOptions — we walk it and
-    // extract leaf strings so `String.includes(obj)` can't silently no-op.
-    // test_kit api_key pickup matches what storyboards typically stage;
-    // options.secrets is a consumer hook for custom credentials.
-    const secrets = new Set<string>();
-    const optAny = ctx.options as unknown as {
-      auth_token?: string;
-      auth?: unknown;
-      secrets?: string[];
-      test_kit?: { auth?: { api_key?: string; basic?: unknown } };
-    };
-    addIfSecret(secrets, optAny.auth_token);
-    for (const s of extractAuthSecrets(optAny.auth)) addIfSecret(secrets, s);
-    for (const s of optAny.secrets ?? []) addIfSecret(secrets, s);
-    addIfSecret(secrets, optAny.test_kit?.auth?.api_key);
-    for (const s of extractBasicSecrets(optAny.test_kit?.auth?.basic)) addIfSecret(secrets, s);
-    ctx.state.secrets = secrets;
-  },
-  onStep: (ctx, stepResult) => {
-    const body = (stepResult as unknown as { response?: unknown }).response;
-    if (body === undefined || body === null) return [];
-
-    const secrets = (ctx.state.secrets as Set<string> | undefined) ?? new Set<string>();
-    const description = 'Response omits caller-supplied secrets and credential-shaped fields';
-
-    const hit = findSecretEcho(body, secrets);
-    if (hit) {
-      return [
-        {
-          passed: false,
-          description,
-          step_id: stepResult.step_id,
-          error: `step "${stepResult.step_id}" response ${hit}`,
-        },
-      ];
-    }
-    return [{ passed: true, description, step_id: stepResult.step_id }];
-  },
-});
-
-/**
- * Recursively walk `value` hunting for (a) suspect property names at any
- * depth, (b) bearer-token literals in any string value, and (c) verbatim
- * copies of caller-supplied secrets. First hit wins; the caller turns the
- * reason into a human-readable error message.
- */
-function findSecretEcho(value: unknown, secrets: Set<string>): string | null {
-  const stack: unknown[] = [value];
-  while (stack.length > 0) {
-    const v = stack.pop();
-    if (typeof v === 'string') {
-      if (BEARER_TOKEN_PATTERN.test(v)) return 'contains a bearer-token literal';
-      for (const s of secrets) {
-        if (v.includes(s)) return 'contains a caller-supplied secret value verbatim';
-      }
-      continue;
-    }
-    if (Array.isArray(v)) {
-      for (const item of v) stack.push(item);
-      continue;
-    }
-    if (v !== null && typeof v === 'object') {
-      for (const [key, inner] of Object.entries(v as Record<string, unknown>)) {
-        // Name-based dragnet. The SUSPECT_PROPERTY_NAMES set catches the
-        // "bare token on a credential-named field" leak shape that the
-        // BEARER_TOKEN_PATTERN value-scan misses (a JWT without `Bearer `
-        // prefix won't match the regex). But the dragnet over-rejects
-        // when the field's VALUE is a structured object or array — those
-        // are spec-legitimate config payloads, not credential echoes.
-        // `compliance/cache/{version}/property/validation-result.json`
-        // declares an `authorization` object field carrying authorization-
-        // validation metadata, not a token; sellers extending
-        // `sync_accounts` via the schema's `additionalProperties: true`
-        // may carry their own structured `authorization` posture. Both
-        // are spec-conformant.
-        //
-        // Gate the name-based fail on `typeof inner === 'string'` and
-        // non-empty so structured values pass through to the recursive
-        // walk below. The recursion still scans nested string values, so
-        // a `Bearer xyz...` literal embedded in a structured object is
-        // still caught by the regex at the top of this loop.
-        // Spec: adcp-client#1713 / adcp#4419.
-        if (SUSPECT_PROPERTY_NAMES.has(key.toLowerCase()) && typeof inner === 'string' && inner.length > 0) {
-          return `contains suspect property name "${key}" with string value`;
-        }
-        stack.push(inner);
-      }
-    }
-  }
-  return null;
-}
-
-// ────────────────────────────────────────────────────────────
-// governance.denial_blocks_mutation
-// ────────────────────────────────────────────────────────────
-
-/**
- * Error codes that signal a seller-side refusal with plan scope. Grounded
- * in `ErrorCodeSchema` in `src/lib/types/schemas.generated.ts`. Excludes
- * transient (`GOVERNANCE_UNAVAILABLE` — no decision rendered) and
- * account-state (`ACCOUNT_SUSPENDED`) codes — those aren't plan denials.
- */
-const GOVERNANCE_DENIAL_CODES = new Set([
-  'GOVERNANCE_DENIED',
-  'CAMPAIGN_SUSPENDED',
-  'PERMISSION_DENIED',
-  'POLICY_VIOLATION',
-  'TERMS_REJECTED',
-  'COMPLIANCE_UNSATISFIED',
-]);
-
-/**
- * Write-class tasks whose successful response carries a server-minted
- * resource id at the top level. Read tasks (`get_*`, `list_*`,
- * `check_governance`) can echo ids without having created anything; they
- * are excluded so the assertion doesn't false-positive on lookups after
- * a denial. Sync-batch tasks (`sync_*`) are excluded until per-item
- * acquisition detection lands — see follow-up in the spec repo.
- */
-const GOVERNANCE_WRITE_TASKS = new Set([
-  'create_media_buy',
-  'update_media_buy',
-  'activate_signal',
-  'create_property_list',
-  'update_property_list',
-  'delete_property_list',
-  'create_collection_list',
-  'update_collection_list',
-  'delete_collection_list',
-  'acquire_rights',
-]);
-
-const GOVERNANCE_ACQUIRED_STATUSES = new Set(['pending_creatives', 'pending_start', 'active', 'paused', 'completed']);
-
-const GOVERNANCE_RESOURCE_ID_FIELDS = [
-  'media_buy_id',
-  'plan_id',
-  'creative_id',
-  'audience_id',
-  'catalog_id',
-  'activation_id',
-  'property_list_id',
-  'collection_list_id',
-  'acquisition_id',
-  'operation_id',
-];
-
-interface GovernanceDenialAnchor {
-  stepId: string;
-  signal: string;
-}
-
-registerOnce('governance.denial_blocks_mutation', {
-  id: 'governance.denial_blocks_mutation',
-  default: true,
-  description:
-    'Once a governance signal denies a plan, no subsequent step in the run may acquire a resource for that plan.',
-  onStart: ctx => {
-    ctx.state.deniedPlans = new Map<string, GovernanceDenialAnchor>();
-    ctx.state.runDenial = undefined;
-  },
-  onStep: (ctx, stepResult) => {
-    const state = ctx.state as {
-      deniedPlans: Map<string, GovernanceDenialAnchor>;
-      runDenial?: GovernanceDenialAnchor;
-    };
-    const planId = extractGovernancePlanId(stepResult);
-
-    // Denial observation is never itself a failure — record and return.
-    const denial = detectGovernanceDenial(stepResult);
-    if (denial) {
-      // A step marked `expect_error: true` is the storyboard author explicitly
-      // acknowledging the denial. Subsequent mutations in the same run are a
-      // recovery path, not a silent bypass — don't anchor. The invariant still
-      // catches silent denials (check_governance 200 `status: denied`, or
-      // adcp_error responses the author did not expect).
-      if (stepResult.expect_error) return [];
-      const anchor: GovernanceDenialAnchor = { stepId: stepResult.step_id, signal: denial };
-      if (planId) {
-        if (!state.deniedPlans.has(planId)) state.deniedPlans.set(planId, anchor);
-      } else if (!state.runDenial) {
-        state.runDenial = anchor;
-      }
-      return [];
-    }
-
-    const acquired = detectGovernanceAcquisition(stepResult);
-    if (!acquired) return [];
-
-    const anchor = (planId && state.deniedPlans.get(planId)) ?? state.runDenial;
-    if (!anchor) return [];
-
-    // Always surface the step-level escape hatch — it's the one hint that
-    // works for both wire-error denials and `check_governance` 200
-    // `status: denied`. Names the step, names the field, shows the YAML so
-    // the author doesn't have to re-derive the escape from source.
-    const escapeHint =
-      `. If the denial at step "${anchor.stepId}" is an intentional recovery-path setup, add to that step:\n` +
-      `  invariants:\n` +
-      `    disable: [governance.denial_blocks_mutation]`;
-
-    return [
-      {
-        passed: false,
-        description: 'Mutation acquired a resource after a governance denial',
-        step_id: stepResult.step_id,
-        error:
-          `step "${anchor.stepId}" returned ${anchor.signal}` +
-          (planId ? ` for plan_id=${planId}` : ' (run-wide)') +
-          `; subsequent step "${stepResult.step_id}" (task=${stepResult.task}) ` +
-          `acquired ${acquired.field}=${acquired.id}` +
-          (planId ? ' for the same plan' : '') +
-          escapeHint,
-      },
-    ];
-  },
-});
-
-function detectGovernanceDenial(step: import('./types').StoryboardStepResult): string | undefined {
-  const err = extractAdcpError(step);
-  if (err && GOVERNANCE_DENIAL_CODES.has(err.code)) return err.code;
-  // `check_governance` decides-no via a 200 response with `status: "denied"`
-  // (see static/schemas/source/governance/check-governance-response.json in
-  // the spec repo). The body isn't wrapped in `adcp_error`.
-  if (step.task === 'check_governance') {
-    const body = (step as unknown as { response?: unknown }).response;
-    if (body && typeof body === 'object') {
-      const status = (body as Record<string, unknown>).status;
-      if (status === 'denied') return 'CHECK_GOVERNANCE_DENIED';
-    }
-  }
-  return undefined;
-}
-
-function extractGovernancePlanId(step: import('./types').StoryboardStepResult): string | undefined {
-  const body = (step as unknown as { response?: unknown }).response;
-  if (body && typeof body === 'object') {
-    const rec = body as Record<string, unknown>;
-    if (typeof rec.plan_id === 'string' && rec.plan_id) return rec.plan_id;
-  }
-  // The runner records the outgoing payload on `stepResult.request` — read
-  // from there rather than accumulated step context to avoid stale plan_id
-  // bleed from earlier unrelated steps.
-  const req = (step as unknown as { request?: { payload?: unknown } }).request;
-  if (req && typeof req.payload === 'object' && req.payload !== null) {
-    const payload = req.payload as Record<string, unknown>;
-    if (typeof payload.plan_id === 'string' && payload.plan_id) return payload.plan_id;
-  }
-  return undefined;
-}
-
-function detectGovernanceAcquisition(
-  step: import('./types').StoryboardStepResult
-): { field: string; id: string } | undefined {
-  if (step.expect_error) return undefined;
-  if (!step.passed) return undefined;
-  if (!GOVERNANCE_WRITE_TASKS.has(step.task)) return undefined;
-
-  const body = (step as unknown as { response?: unknown }).response;
-  if (!body || typeof body !== 'object') return undefined;
-  const record = body as Record<string, unknown>;
-
-  if (step.task === 'create_media_buy' || step.task === 'update_media_buy') {
-    const status = record.status;
-    if (typeof status === 'string' && !GOVERNANCE_ACQUIRED_STATUSES.has(status)) return undefined;
-  }
-
-  for (const field of GOVERNANCE_RESOURCE_ID_FIELDS) {
-    const val = record[field];
-    if (typeof val === 'string' && val.length > 0) return { field, id: val };
-  }
-  return undefined;
-}
-
-// ────────────────────────────────────────────────────────────
-// Helpers
-// ────────────────────────────────────────────────────────────
-
-interface AdcpErrorShape {
-  code: string;
-  details: Record<string, unknown>;
-}
-
-function extractAdcpError(step: import('./types').StoryboardStepResult): AdcpErrorShape | null {
-  const resp = (step as unknown as { response?: unknown }).response;
-  if (!resp || typeof resp !== 'object') return null;
-  const envelope = (resp as { adcp_error?: unknown }).adcp_error;
-  if (!envelope || typeof envelope !== 'object') return null;
-  const code = (envelope as { code?: unknown }).code;
-  if (typeof code !== 'string') return null;
-  return { code, details: envelope as Record<string, unknown> };
-}
-
-/**
- * Add a value to the secrets set if it is a non-empty string of at least
- * `SECRET_MIN_LENGTH` chars. Centralises the length guard so every source
- * (structured auth, `auth_token`, `secrets[]`, `test_kit.auth.api_key`)
- * gets the same floor.
- */
-function addIfSecret(out: Set<string>, value: unknown): void {
-  if (typeof value !== 'string') return;
-  if (value.length < SECRET_MIN_LENGTH) return;
-  out.add(value);
-}
-
-const ENV_REFERENCE_PREFIX = '$ENV:';
-
-/**
- * Resolve a possibly `$ENV:VAR`-prefixed credential value to the literal it
- * references at runtime. Mirrors the auth-layer `resolveSecret` in
- * `src/lib/auth/oauth/secret-resolver.ts`, but swallows missing / empty
- * variables instead of throwing — the assertion must never break a
- * storyboard run just because it can't resolve a ref.
- *
- * Returns `undefined` if the value is not an env reference, or if the
- * referenced variable is unset / empty. Callers should skip `undefined`
- * results. The literal `$ENV:FOO` string itself is never returned because
- * it is a reference, not a secret, and cannot appear in an agent response.
- */
-function resolveEnvReference(value: string): string | undefined {
-  if (!value.startsWith(ENV_REFERENCE_PREFIX)) return undefined;
-  const envVar = value.slice(ENV_REFERENCE_PREFIX.length).trim();
-  if (!envVar) return undefined;
-  const resolved = process.env[envVar];
-  if (!resolved) return undefined;
-  return resolved;
-}
-
-/**
- * Push a credential-field string onto `out`, resolving `$ENV:VAR` references
- * to their literal runtime value. Literal values pass through unchanged.
- * `$ENV:` references only contribute the resolved value — the reference
- * string itself is not a secret.
- */
-function pushCredentialValue(out: string[], value: unknown): void {
-  if (typeof value !== 'string' || !value) return;
-  if (value.startsWith(ENV_REFERENCE_PREFIX)) {
-    const resolved = resolveEnvReference(value);
-    if (resolved) out.push(resolved);
-    return;
-  }
-  out.push(value);
-}
-
-/**
- * Extract every leaf string secret from a structured `TestOptions.auth` value.
- * Mirrors the four variants in `src/lib/testing/types.ts`:
- *   - bearer                    → `token`
- *   - basic                     → `password` and, when both credentials are
- *                                 present, the `base64(user:pass)` blob an
- *                                 `Authorization: Basic` header carries.
- *                                 Username alone is NOT extracted — it's a
- *                                 public identifier (welcome messages, audit
- *                                 logs, "last login by X" echoes legitimately).
- *   - oauth                     → `tokens.access_token`, `tokens.refresh_token`,
- *                                 `client.client_secret` (if confidential)
- *   - oauth_client_credentials  → `credentials.client_secret` (may be a
- *                                 `$ENV:VAR` reference, resolved at runtime),
- *                                 `tokens.access_token`, `tokens.refresh_token`.
- *                                 `client_id` is NOT extracted — RFC 6749 §2.2
- *                                 is explicit that the client identifier is
- *                                 public and legitimately echoed in token
- *                                 responses, introspection payloads, audit
- *                                 logs, and error bodies.
- *
- * Returns an empty list for anything we can't recognise — the goal is a best-
- * effort extraction, not schema validation. The SECRET_MIN_LENGTH guard is
- * applied by the caller via `addIfSecret`.
- */
-function extractAuthSecrets(auth: unknown): string[] {
-  if (!auth || typeof auth !== 'object') return [];
-  const a = auth as Record<string, unknown>;
-  const out: string[] = [];
-  pushCredentialValue(out, a.token); // bearer
-
-  // basic: the password is the secret; the base64 blob catches echoes of the
-  // full Authorization: Basic header, including RFC 7617-valid empty passwords.
-  // Username alone is not a secret.
-  if (typeof a.password === 'string') {
-    if (a.password) out.push(a.password);
-    if (typeof a.username === 'string' && a.username) {
-      out.push(Buffer.from(`${a.username}:${a.password}`, 'utf8').toString('base64'));
-    }
-  }
-
-  if (a.tokens && typeof a.tokens === 'object') {
-    const t = a.tokens as Record<string, unknown>;
-    if (typeof t.access_token === 'string' && t.access_token) out.push(t.access_token);
-    if (typeof t.refresh_token === 'string' && t.refresh_token) out.push(t.refresh_token);
-  }
-  if (a.client && typeof a.client === 'object') {
-    const c = a.client as Record<string, unknown>;
-    if (typeof c.client_secret === 'string' && c.client_secret) out.push(c.client_secret);
-  }
-  if (a.credentials && typeof a.credentials === 'object') {
-    const c = a.credentials as Record<string, unknown>;
-    // client_secret on AgentOAuthClientCredentials may be a `$ENV:VAR`
-    // reference — resolve so the assertion compares the real runtime value
-    // the AS sees, not the reference string. client_id is NOT extracted
-    // (RFC 6749 §2.2 — public identifier).
-    pushCredentialValue(out, c.client_secret);
-  }
-  return out;
-}
-
-function extractBasicSecrets(basic: unknown): string[] {
-  if (!basic || typeof basic !== 'object') return [];
-  const b = basic as Record<string, unknown>;
-  const out: string[] = [];
-  if (typeof b.credentials === 'string' && b.credentials) {
-    const colonIndex = b.credentials.indexOf(':');
-    if (colonIndex > 0) {
-      const password = b.credentials.slice(colonIndex + 1);
-      if (password) out.push(password);
-      out.push(Buffer.from(b.credentials, 'utf8').toString('base64'));
-    }
-    return out;
-  }
-  if (typeof b.password === 'string') {
-    if (b.password) out.push(b.password);
-    if (typeof b.username === 'string' && b.username) {
-      out.push(Buffer.from(`${b.username}:${b.password}`, 'utf8').toString('base64'));
-    }
-  }
-  return out;
-}
-
-// ────────────────────────────────────────────────────────────
-// status.monotonic
-// ────────────────────────────────────────────────────────────
-
-/**
- * Per-resource-type lifecycle transition graphs. Each inner map is
- * `from → Set<to>`. An observed transition `prev → curr` is legal iff
- * `TRANSITIONS[type].get(prev)?.has(curr)` (self-edges `prev === curr`
- * are always legal and skipped). The tables are hand-written from the
- * spec enum schemas in `static/schemas/source/enums/*-status.json` and
- * the narrative transitions documented there. When an enum gains a
- * value this module needs an update alongside the schema change — that's
- * the right coupling, visible in PR review.
- *
- * Bidirectional edges are listed in both directions explicitly (no
- * auto-mirroring) so one-way edges like `rejected → processing` for
- * creative assets don't accidentally become reversible.
- */
-interface TransitionGraph {
-  readonly transitions: ReadonlyMap<string, ReadonlySet<string>>;
   /**
-   * Filename of the canonical enum schema this graph mirrors, relative to
-   * `/schemas/<adcp-version>/enums/`. Used to render a deep-link in the
-   * assertion failure message so implementors can jump straight to the
-   * spec's lifecycle doc instead of grep-searching for it.
+   * Bearer-token literal pattern. Matches the wire form a seller might echo
+   * from `Authorization: Bearer <token>` — case-insensitive `bearer` keyword
+   * followed by a token body of at least 10 characters of base64url / JWT
+   * vocabulary. Kept strict on length to avoid false positives on prose like
+   * "bearer of bad news".
    */
-  readonly enumFile: string;
-}
+  const BEARER_TOKEN_PATTERN = /\bbearer\s+[A-Za-z0-9._~+/=-]{10,}/i;
 
-const SCHEMA_URL_BASE = 'https://adcontextprotocol.org';
+  /**
+   * Property names that MUST NOT appear on a response body — a seller that
+   * serializes `Authorization` / `api_key` / `x-api-key` headers or fields
+   * into the response is almost certainly leaking credentials, regardless of
+   * whether the scanner picks up the value verbatim (header normalization,
+   * whitespace differences, etc. can mask verbatim matches). Case-insensitive.
+   */
+  const SUSPECT_PROPERTY_NAMES = new Set(['authorization', 'api_key', 'apikey', 'bearer', 'x-api-key']);
 
-function buildEnumSchemaUrl(enumFile: string): string {
-  return `${SCHEMA_URL_BASE}/schemas/${ADCP_VERSION}/enums/${enumFile}`;
-}
+  /**
+   * Minimum length for a caller-supplied secret to be hunted for verbatim.
+   * Set to 16 because real OAuth access tokens, refresh tokens, and signing
+   * secrets are ≥20 chars by convention (opaque UUIDs, JWTs, HMAC hex). A
+   * shorter floor would false-positive on benign identifiers (short
+   * usernames, environment names, 8-char hex prefixes, ISO timestamps).
+   * Hand-coded fixture keys like `"test-key"` below this bar are not caught
+   * — that's the right tradeoff: a real agent echoing such a value is an
+   * obvious leak a human reviewer would spot, and the collision cost of
+   * matching short strings against every response body is too high to
+   * justify the coverage.
+   */
+  const SECRET_MIN_LENGTH = 16;
 
-// Source of truth for both graphs lives in `server/state-machine.ts` so
-// production sellers and the runner enforce identical edges. Wrap the typed
-// maps in `TransitionGraph` for the runner's string-keyed extractors.
-const MEDIA_BUY_TRANSITIONS: TransitionGraph = {
-  transitions: MEDIA_BUY_TRANSITIONS_TYPED as ReadonlyMap<string, ReadonlySet<string>>,
-  enumFile: 'media-buy-status.json',
-};
+  registerOnce('context.no_secret_echo', {
+    id: 'context.no_secret_echo',
+    default: true,
+    description: 'Response bodies MUST NOT echo bearer tokens, API keys, or auth header values back to the caller.',
+    onStart: ctx => {
+      // Stash caller-supplied secrets worth hunting verbatim. `auth` is the
+      // structured discriminated union from TestOptions — we walk it and
+      // extract leaf strings so `String.includes(obj)` can't silently no-op.
+      // test_kit api_key pickup matches what storyboards typically stage;
+      // options.secrets is a consumer hook for custom credentials.
+      const secrets = new Set<string>();
+      const optAny = ctx.options as unknown as {
+        auth_token?: string;
+        auth?: unknown;
+        secrets?: string[];
+        test_kit?: { auth?: { api_key?: string; basic?: unknown } };
+      };
+      addIfSecret(secrets, optAny.auth_token);
+      for (const s of extractAuthSecrets(optAny.auth)) addIfSecret(secrets, s);
+      for (const s of optAny.secrets ?? []) addIfSecret(secrets, s);
+      addIfSecret(secrets, optAny.test_kit?.auth?.api_key);
+      for (const s of extractBasicSecrets(optAny.test_kit?.auth?.basic)) addIfSecret(secrets, s);
+      ctx.state.secrets = secrets;
+    },
+    onStep: (ctx, stepResult) => {
+      const body = (stepResult as unknown as { response?: unknown }).response;
+      if (body === undefined || body === null) return [];
 
-const CREATIVE_ASSET_TRANSITIONS: TransitionGraph = {
-  transitions: CREATIVE_ASSET_TRANSITIONS_TYPED as ReadonlyMap<string, ReadonlySet<string>>,
-  enumFile: 'creative-status.json',
-};
+      const secrets = (ctx.state.secrets as Set<string> | undefined) ?? new Set<string>();
+      const description = 'Response omits caller-supplied secrets and credential-shaped fields';
 
-const CREATIVE_APPROVAL_TRANSITIONS: TransitionGraph = {
-  // See `static/schemas/source/enums/creative-approval-status.json`.
-  // Per-assignment approval state on a package. `rejected → pending_review`
-  // is allowed on re-sync.
-  transitions: new Map<string, ReadonlySet<string>>([
-    ['pending_review', new Set(['approved', 'rejected'])],
-    ['approved', new Set(['rejected'])],
-    ['rejected', new Set(['pending_review'])],
-  ]),
-  enumFile: 'creative-approval-status.json',
-};
-
-const ACCOUNT_TRANSITIONS: TransitionGraph = {
-  // See `static/schemas/source/enums/account-status.json`. `active ↔
-  // suspended` and `active ↔ payment_required` are both reversible.
-  // `suspended → payment_required` covers the legitimate case where a
-  // suspended account's credit lapses during the suspension window.
-  // `rejected | closed` are terminal.
-  transitions: new Map<string, ReadonlySet<string>>([
-    ['pending_approval', new Set(['active', 'rejected'])],
-    ['active', new Set(['suspended', 'payment_required', 'closed'])],
-    ['suspended', new Set(['active', 'payment_required', 'closed'])],
-    ['payment_required', new Set(['active', 'suspended', 'closed'])],
-    ['rejected', new Set()],
-    ['closed', new Set()],
-  ]),
-  enumFile: 'account-status.json',
-};
-
-const SI_SESSION_TRANSITIONS: TransitionGraph = {
-  // See `static/schemas/source/enums/si-session-status.json`.
-  // `complete | terminated` are terminal.
-  transitions: new Map<string, ReadonlySet<string>>([
-    ['active', new Set(['pending_handoff', 'complete', 'terminated'])],
-    ['pending_handoff', new Set(['complete', 'terminated'])],
-    ['complete', new Set()],
-    ['terminated', new Set()],
-  ]),
-  enumFile: 'si-session-status.json',
-};
-
-const CATALOG_ITEM_TRANSITIONS: TransitionGraph = {
-  // See `static/schemas/source/enums/catalog-item-status.json`. `approved ↔
-  // warning` is reversible (seller flags a warning, then clears it).
-  // `rejected → pending` is allowed on re-sync. No terminals.
-  transitions: new Map<string, ReadonlySet<string>>([
-    ['pending', new Set(['approved', 'rejected', 'warning'])],
-    ['approved', new Set(['warning', 'rejected'])],
-    ['warning', new Set(['approved', 'rejected'])],
-    ['rejected', new Set(['pending'])],
-  ]),
-  enumFile: 'catalog-item-status.json',
-};
-
-const PROPOSAL_TRANSITIONS: TransitionGraph = {
-  // See `static/schemas/source/enums/proposal-status.json`. One-way.
-  transitions: new Map<string, ReadonlySet<string>>([
-    ['draft', new Set(['committed'])],
-    ['committed', new Set()],
-  ]),
-  enumFile: 'proposal-status.json',
-};
-
-const AUDIENCE_TRANSITIONS: TransitionGraph = {
-  // See `static/schemas/source/enums/audience-status.json`. Fully bidirectional
-  // across the three states — sellers MAY re-enter `processing` on re-sync
-  // from `ready` or `too_small`, and `ready ↔ too_small` can happen as
-  // member counts cross `minimum_size` (spec hedges this as MAY, not MUST).
-  // No terminals: delete / fail omit `status` entirely via the envelope's
-  // `action` field, so there's nothing to record for them.
-  transitions: new Map<string, ReadonlySet<string>>([
-    ['processing', new Set(['ready', 'too_small'])],
-    ['ready', new Set(['processing', 'too_small'])],
-    ['too_small', new Set(['processing', 'ready'])],
-  ]),
-  enumFile: 'audience-status.json',
-};
-
-/**
- * Extractor record per resource type. For each response shape we recognize,
- * describe how to walk the body and emit `(resource_id, status)` pairs.
- * The runner hands us `stepResult.response` — we look at the shape and
- * the task name to disambiguate (e.g. `get_media_buys` vs `sync_creatives`).
- */
-interface StatusObservation {
-  resource_type: string;
-  resource_id: string;
-  status: string;
-  graph: TransitionGraph;
-}
-
-/**
- * Task-aware extractors. Each knows the response shape for its task family
- * and walks arrays where present. Unknown tasks produce no observations —
- * the assertion is silent on tasks it doesn't recognize.
- */
-function extractStatusObservations(task: string, body: Record<string, unknown>): StatusObservation[] {
-  const obs: StatusObservation[] = [];
-
-  // Media-buy: create/update_media_buy return top-level status + packages
-  // with per-creative approval_status. get_media_buys returns media_buys[].
-  if (task === 'create_media_buy' || task === 'update_media_buy') {
-    pushMediaBuy(obs, body);
-  } else if (task === 'get_media_buys') {
-    for (const mb of asArray(body.media_buys)) {
-      if (isObject(mb)) pushMediaBuy(obs, mb);
-    }
-  }
-
-  // Creative asset lifecycle: sync_creatives and list_creatives.
-  if (task === 'sync_creatives' || task === 'list_creatives') {
-    for (const c of asArray(body.creatives)) {
-      if (isObject(c)) pushCreative(obs, c);
-    }
-  }
-
-  // Account: sync_accounts and list_accounts. Embedded `account` objects on
-  // media-buy responses do not carry a lifecycle status — they're just
-  // references (brand, operator) — so we don't read them here.
-  if (task === 'sync_accounts' || task === 'list_accounts') {
-    for (const a of asArray(body.accounts)) {
-      if (isObject(a)) pushAccount(obs, a);
-    }
-  }
-
-  // SI session: si_initiate_session / si_send_message return top-level
-  // `session_id` + `status`.
-  if (task === 'si_initiate_session' || task === 'si_send_message' || task === 'si_terminate_session') {
-    pushSiSession(obs, body);
-  }
-
-  // Catalog items: sync_catalogs / list_catalogs return `items[]` per catalog.
-  if (task === 'sync_catalogs' || task === 'list_catalogs') {
-    for (const cat of asArray(body.catalogs)) {
-      if (!isObject(cat)) continue;
-      for (const item of asArray(cat.items)) {
-        if (isObject(item)) pushCatalogItem(obs, item);
-      }
-    }
-    for (const item of asArray(body.items)) {
-      if (isObject(item)) pushCatalogItem(obs, item);
-    }
-  }
-
-  // Proposal: get_products may return a `proposal` object when the
-  // caller is refining toward commitment.
-  if (task === 'get_products' && isObject(body.proposal)) {
-    pushProposal(obs, body.proposal);
-  }
-
-  // Audience lifecycle: sync_audiences is both the write and discovery path
-  // (discovery-only calls omit the request `audiences` array but still return
-  // `audiences[]`). No separate list_audiences task exists.
-  if (task === 'sync_audiences') {
-    for (const a of asArray(body.audiences)) {
-      if (isObject(a)) pushAudience(obs, a);
-    }
-  }
-
-  return obs;
-}
-
-function pushMediaBuy(obs: StatusObservation[], record: Record<string, unknown>): void {
-  const id = asString(record.media_buy_id);
-  // 3.1+: `media_buy_status` (body) carries MediaBuyStatus; top-level
-  // `status` (envelope) carries TaskStatus. Pre-3.1 + nested fields on
-  // `get_media_buys` / `get_media_buy_delivery`: `status` still carries
-  // MediaBuyStatus. Read the canonical 3.1 field first, fall back to
-  // legacy. Refs adcontextprotocol/adcp#4895 (3.1 additive-deprecate),
-  // #4906 (3.2 legacy removal), #4905 (4.0 nested cascade).
-  const status = asString(record.media_buy_status) ?? asString(record.status);
-  if (id && status) {
-    obs.push({
-      resource_type: 'media_buy',
-      resource_id: id,
-      status,
-      graph: MEDIA_BUY_TRANSITIONS,
-    });
-  }
-  // Each media_buy carries packages; each package can list creative_approvals
-  // with per-creative approval_status. Track those against the approval graph.
-  for (const pkg of asArray(record.packages)) {
-    if (!isObject(pkg)) continue;
-    for (const ca of asArray(pkg.creative_approvals)) {
-      if (!isObject(ca)) continue;
-      const cid = asString(ca.creative_id);
-      const astatus = asString(ca.approval_status);
-      if (cid && astatus) {
-        obs.push({
-          resource_type: 'creative_approval',
-          resource_id: cid,
-          status: astatus,
-          graph: CREATIVE_APPROVAL_TRANSITIONS,
-        });
-      }
-    }
-  }
-}
-
-function pushCreative(obs: StatusObservation[], record: Record<string, unknown>): void {
-  const id = asString(record.creative_id);
-  const status = asString(record.status);
-  if (id && status) {
-    obs.push({
-      resource_type: 'creative',
-      resource_id: id,
-      status,
-      graph: CREATIVE_ASSET_TRANSITIONS,
-    });
-  }
-}
-
-function pushAccount(obs: StatusObservation[], record: Record<string, unknown>): void {
-  const id = asString(record.account_id);
-  const status = asString(record.status);
-  if (id && status) {
-    obs.push({
-      resource_type: 'account',
-      resource_id: id,
-      status,
-      graph: ACCOUNT_TRANSITIONS,
-    });
-  }
-}
-
-function pushSiSession(obs: StatusObservation[], record: Record<string, unknown>): void {
-  const id = asString(record.session_id);
-  const status = asString(record.status);
-  if (id && status) {
-    obs.push({
-      resource_type: 'si_session',
-      resource_id: id,
-      status,
-      graph: SI_SESSION_TRANSITIONS,
-    });
-  }
-}
-
-function pushCatalogItem(obs: StatusObservation[], record: Record<string, unknown>): void {
-  // Catalog items are heterogeneous across catalog types. Prefer `item_id`
-  // (spec-canonical on sync/list responses), then domain-specific
-  // `offering_id` (SI) and `sku` (retail), then a generic `id` as last
-  // resort. The fallback chain silently mis-identifies if a seller echoes
-  // a non-canonical id — the resulting history splits per id shape rather
-  // than emitting an error. Acceptable tradeoff given schema churn; enum
-  // drift stays under `response_schema`'s purview.
-  const id = asString(record.item_id) ?? asString(record.offering_id) ?? asString(record.sku) ?? asString(record.id);
-  const status = asString(record.status);
-  if (id && status) {
-    obs.push({
-      resource_type: 'catalog_item',
-      resource_id: id,
-      status,
-      graph: CATALOG_ITEM_TRANSITIONS,
-    });
-  }
-}
-
-function pushProposal(obs: StatusObservation[], record: Record<string, unknown>): void {
-  const id = asString(record.proposal_id);
-  const status = asString(record.status);
-  if (id && status) {
-    obs.push({
-      resource_type: 'proposal',
-      resource_id: id,
-      status,
-      graph: PROPOSAL_TRANSITIONS,
-    });
-  }
-}
-
-function pushAudience(obs: StatusObservation[], record: Record<string, unknown>): void {
-  // `status` is absent when `action` is `deleted` or `failed` — spec
-  // envelope intentionally omits the field rather than emitting a terminal
-  // value. The `&& status` guard below makes those observations silent.
-  const id = asString(record.audience_id);
-  const status = asString(record.status);
-  if (id && status) {
-    obs.push({
-      resource_type: 'audience',
-      resource_id: id,
-      status,
-      graph: AUDIENCE_TRANSITIONS,
-    });
-  }
-}
-
-interface MonotonicState {
-  stepId: string;
-  status: string;
-}
-
-registerOnce('status.monotonic', {
-  id: 'status.monotonic',
-  default: true,
-  description:
-    'Observed resource statuses (media_buy, creative, account, si_session, catalog_item, proposal, creative_approval, audience) MUST only transition along edges in the spec lifecycle graph.',
-  onStart: ctx => {
-    // `${resource_type}:${resource_id}` → last-observed state. Tuple key
-    // disambiguates the unlikely `media_buy_id` / `creative_id` collision.
-    ctx.state.history = new Map<string, MonotonicState>();
-  },
-  onStep: (ctx, stepResult) => {
-    // Skip error / skipped / negative-path steps. An errored read doesn't
-    // observe a new state; `expect_error: true` runs are probing error
-    // codes, not transitions.
-    if (stepResult.skipped) return [];
-    if (stepResult.expect_error) return [];
-    if (!stepResult.passed) return [];
-    const body = (stepResult as unknown as { response?: unknown }).response;
-    if (!body || typeof body !== 'object') return [];
-    if (extractAdcpError(stepResult)) return [];
-
-    const history = ctx.state.history as Map<string, MonotonicState>;
-    const observations = extractStatusObservations(stepResult.task, body as Record<string, unknown>);
-    const description = 'Resource statuses transition only along spec lifecycle edges';
-
-    for (const ob of observations) {
-      const key = `${ob.resource_type}:${ob.resource_id}`;
-      const prev = history.get(key);
-      if (!prev) {
-        history.set(key, { stepId: stepResult.step_id, status: ob.status });
-        continue;
-      }
-      if (prev.status === ob.status) {
-        // No-op observation (replay, re-read of unchanged state). Don't emit,
-        // don't advance the anchor step — the earlier stepId stays useful for
-        // diagnostics if a later backward edge appears.
-        continue;
-      }
-      const allowedTargets = ob.graph.transitions.get(prev.status);
-      if (!allowedTargets) {
-        // Unknown previous status (enum drift or we missed a state in the
-        // table). Don't fail — `response_schema` catches enum violations;
-        // reset the anchor so downstream transitions still get checked.
-        history.set(key, { stepId: stepResult.step_id, status: ob.status });
-        continue;
-      }
-      if (!allowedTargets.has(ob.status)) {
-        // Surface the legal next states + a canonical enum URL so implementors
-        // can self-diagnose without grepping the SDK source for the
-        // lifecycle table. `allowedTargets` is empty for terminal states
-        // (completed / rejected / canceled / etc.) — call that out explicitly
-        // rather than rendering an empty list that reads as "any target is
-        // fine, just not this one".
-        const legalTargets = [...allowedTargets].sort();
-        const legalDescription =
-          legalTargets.length > 0 ? legalTargets.map(t => `"${t}"`).join(', ') : '(none — terminal state)';
-        const enumUrl = buildEnumSchemaUrl(ob.graph.enumFile);
-        const errorMessage =
-          `${ob.resource_type} ${ob.resource_id}: ${prev.status} → ${ob.status} ` +
-          `(step "${prev.stepId}" → step "${stepResult.step_id}") is not in the lifecycle graph. ` +
-          `Legal next states from "${prev.status}": ${legalDescription}. ` +
-          `See ${enumUrl} for the canonical lifecycle.`;
+      const hit = findSecretEcho(body, secrets);
+      if (hit) {
         return [
           {
             passed: false,
             description,
             step_id: stepResult.step_id,
-            error: errorMessage,
-            // Issue #935: structured `MonotonicViolationHint` mirrored into
-            // the owning step's `hints[]` so renderers can branch on the
-            // discriminator and render the legal-target set in a per-kind
-            // template instead of regex-parsing the prose error string.
-            hint: {
-              kind: 'monotonic_violation',
-              message: errorMessage,
-              resource_type: ob.resource_type,
-              resource_id: ob.resource_id,
-              from_status: prev.status,
-              to_status: ob.status,
-              from_step_id: prev.stepId,
-              legal_next_states: legalTargets,
-              enum_url: enumUrl,
-            },
+            error: `step "${stepResult.step_id}" response ${hit}`,
           },
         ];
       }
-      history.set(key, { stepId: stepResult.step_id, status: ob.status });
-    }
+      return [{ passed: true, description, step_id: stepResult.step_id }];
+    },
+  });
 
-    if (observations.length === 0) return [];
-    return [{ passed: true, description, step_id: stepResult.step_id }];
-  },
-  // Emit a run-level summary so the track rollup can distinguish
-  // "wired and exercised" (history.size > 0) from "wired but never
-  // observed a lifecycle resource" (history.size === 0). The latter
-  // demotes the track to TrackStatus: 'silent' even though every step
-  // and every per-step assertion record passed. Companion to
-  // adcontextprotocol/adcp#2834.
-  onEnd: ctx => {
-    const history = ctx.state.history as Map<string, MonotonicState> | undefined;
-    const observation_count = history?.size ?? 0;
-    return [
-      {
-        passed: true,
-        description: 'Resource statuses transition only along spec lifecycle edges',
-        observation_count,
-        status: observation_count === 0 ? ('silent' as const) : ('pass' as const),
-      },
-    ];
-  },
-});
-
-// Tiny type-safety helpers for the extractors above.
-function isObject(v: unknown): v is Record<string, unknown> {
-  return v !== null && typeof v === 'object' && !Array.isArray(v);
-}
-
-function asArray(v: unknown): unknown[] {
-  return Array.isArray(v) ? v : [];
-}
-
-function asString(v: unknown): string | undefined {
-  return typeof v === 'string' && v.length > 0 ? v : undefined;
-}
-
-// ────────────────────────────────────────────────────────────
-// impairment.coherence
-// ────────────────────────────────────────────────────────────
-
-/**
- * Per-resource-type offline status sets. An impairment entry referencing
- * `(resource_type, resource_id)` is coherent when the runner's last
- * observation for that resource matches one of these values.
- *
- * Sourced from spec issue #2859 plus the resource-status enum schemas:
- *   - audience:     `suspended`    (audience-status.json)
- *   - creative:     `rejected`     (creative-status.json — terminal)
- *   - catalog_item: `withdrawn`    (catalog-item-status.json)
- *   - event_source: `insufficient` (assessment-status.json, on
- *                                   event-source-health.status)
- *
- * `property` is intentionally absent — offline state is sourced from
- * `brand.json` / `adagents.json` depublishing, not from a status enum on
- * the wire. The runner has no observation hook for that transition today,
- * so property-typed impairments grade silent rather than emitting a forward
- * pass / fail. The spec issue calls this out explicitly.
- */
-const IMPAIRMENT_OFFLINE_STATUS: ReadonlyMap<string, ReadonlySet<string>> = new Map([
-  ['audience', new Set(['suspended'])],
-  ['creative', new Set(['rejected'])],
-  ['catalog_item', new Set(['withdrawn'])],
-  ['event_source', new Set(['insufficient'])],
-]);
-
-/**
- * Media-buy statuses that are non-terminal — the inverse rule only applies
- * while the buy is still serving (or about to). The spec issue carves out
- * `completed`, `canceled`, `rejected` as the terminal set that MAY remain
- * unreported because the buy is no longer accruing impressions.
- */
-const NON_TERMINAL_MEDIA_BUY_STATUSES: ReadonlySet<string> = new Set([
-  'pending_creatives',
-  'pending_start',
-  'active',
-  'paused',
-]);
-
-interface ImpairmentEntry {
-  resource_type: string;
-  resource_id: string;
-}
-
-interface BuySnapshot {
-  media_buy_id: string;
-  status: string | undefined;
-  health: string | undefined;
-  impairments: ImpairmentEntry[];
-  referencedCreativeIds: Set<string>;
-  referencedAudienceIds: Set<string>;
-  stepId: string;
-}
-
-interface ResourceObservation {
-  status: string;
-  stepId: string;
-}
-
-/**
- * Resource families the inverse rule does NOT yet grade — the buy-side
- * reference shape for these in `media_buy.packages` isn't stable in the
- * cached schema, so we can't reliably tell which buys reference which
- * resources. Listed here so the onEnd summary can emit a runtime
- * "partial inverse coverage" signal when the run actually observed
- * offline resources in one of these families — making the deferral
- * visible to storyboard authors and reviewers rather than burying it in
- * PR prose and JSDoc.
- *
- * `audience` is graded — the buy-side reference lives at
- * `packages[*].targeting_overlay.audience_include[]` and is extracted in
- * `readBuySnapshot`. `catalog_item` and `event_source` are deferred: a
- * buy doesn't reference catalog_items or event_sources by stable id in
- * the cached schema, so the runner can't traverse buy → resource.
- */
-const INVERSE_DEFERRED_FAMILIES: ReadonlySet<string> = new Set(['catalog_item', 'event_source']);
-
-/**
- * Private per-run scratch state. Namespaced under
- * `ctx.state.impairmentCoherence` so generic field names (`offlineResources`,
- * `observedTransition`) can't collide with another assertion that lands
- * later and pokes the same shared `ctx.state` bag.
- */
-interface ImpairmentCoherenceState {
-  /** `${resource_type}:${resource_id}` → last observation, offline or not. */
-  resourceStatus: Map<string, ResourceObservation>;
-  /** `${resource_type}:${resource_id}` for entries currently in an offline status. */
-  offlineResources: Map<string, ResourceObservation>;
-  /** Run actually observed at least one resource status transition. */
-  observedTransition: boolean;
-  /** Run actually observed at least one media-buy snapshot read. */
-  observedBuySnapshot: boolean;
   /**
-   * Per-family count of offline observations the run saw, used by the
-   * onEnd summary to flag deferred inverse-rule coverage. A non-zero
-   * count for any family in `INVERSE_DEFERRED_FAMILIES` means the run
-   * exercised the cross-resource path for a family the runner can't yet
-   * grade — surfaced so reviewers see the gap at run-time.
+   * Recursively walk `value` hunting for (a) suspect property names at any
+   * depth, (b) bearer-token literals in any string value, and (c) verbatim
+   * copies of caller-supplied secrets. First hit wins; the caller turns the
+   * reason into a human-readable error message.
    */
-  offlineObservationsByFamily: Map<string, number>;
-}
-
-const IMPAIRMENT_STATE_KEY = 'impairmentCoherence';
-
-function getImpairmentState(ctx: import('./assertions').AssertionContext): ImpairmentCoherenceState {
-  // onStart populates the namespaced slot; the cast is safe because no other
-  // assertion writes there.
-  return ctx.state[IMPAIRMENT_STATE_KEY] as ImpairmentCoherenceState;
-}
-
-registerOnce('impairment.coherence', {
-  id: 'impairment.coherence',
-  default: true,
-  description:
-    'media_buy.impairments[] MUST reference currently-offline resources (forward); any offline resource referenced by a non-terminal buy MUST appear in impairments[] (inverse); health == "impaired" iff impairments[] is non-empty.',
-  onStart: ctx => {
-    const state: ImpairmentCoherenceState = {
-      resourceStatus: new Map(),
-      offlineResources: new Map(),
-      observedTransition: false,
-      observedBuySnapshot: false,
-      offlineObservationsByFamily: new Map(),
-    };
-    ctx.state[IMPAIRMENT_STATE_KEY] = state;
-  },
-  onStep: (ctx, stepResult) => {
-    if (stepResult.skipped) return [];
-    if (stepResult.expect_error) return [];
-    if (!stepResult.passed) return [];
-    const body = (stepResult as unknown as { response?: unknown }).response;
-    if (!body || typeof body !== 'object') return [];
-    if (extractAdcpError(stepResult)) return [];
-
-    const state = getImpairmentState(ctx);
-
-    type CoherenceResult = {
-      passed: boolean;
-      description: string;
-      step_id: string;
-      error?: string;
-      status?: 'not_applicable';
-      hint?: import('./types').ImpairmentCoherenceHint | import('./types').ImpairmentCoherenceNotApplicableHint;
-    };
-    const deferredCoverageResults: CoherenceResult[] = [];
-
-    // Direct, dedicated extractor for the four families this invariant cares
-    // about. NOT routed through `extractStatusObservations` (which is bound
-    // to the `status.monotonic` transition graphs and therefore excludes
-    // the new offline values `suspended` / `withdrawn` / `insufficient`):
-    // monotonic's graphs intentionally enumerate only spec-stable enum
-    // values, but those new offline states are exactly what this invariant
-    // needs to observe.
-    for (const ob of extractImpairmentObservations(stepResult.task, body as Record<string, unknown>)) {
-      const key = `${ob.resource_type}:${ob.resource_id}`;
-      state.resourceStatus.set(key, { status: ob.status, stepId: stepResult.step_id });
-      const offline = IMPAIRMENT_OFFLINE_STATUS.get(ob.resource_type);
-      if (offline?.has(ob.status)) {
-        const wasOffline = state.offlineResources.has(key);
-        state.offlineResources.set(key, { status: ob.status, stepId: stepResult.step_id });
-        state.observedTransition = true;
-        state.offlineObservationsByFamily.set(
-          ob.resource_type,
-          (state.offlineObservationsByFamily.get(ob.resource_type) ?? 0) + 1
-        );
-
-        // Issue #1806: surface deferred inverse-rule coverage at the
-        // transition step. When a resource family the runner can't yet
-        // reverse-traverse (`catalog_item` / `event_source`) enters an
-        // offline state for the first time in this run, emit a
-        // `not_applicable` step-level result so reviewers see the gap in
-        // run output instead of having to read PR prose. One emission per
-        // (resource_type, resource_id) per run — re-syncs of an already
-        // offline resource don't re-fire. Only catalog_item and event_source
-        // surface here; audience is graded via the inverse rule using refs
-        // from packages[*].targeting_overlay.audience_include[].
-        if (!wasOffline && (ob.resource_type === 'catalog_item' || ob.resource_type === 'event_source')) {
-          const message =
-            `inverse-rule coverage for ${ob.resource_type} ${ob.resource_id} ` +
-            `(status="${ob.status}", step "${stepResult.step_id}") is deferred — ` +
-            `buy → resource traversal not yet implemented for this family.`;
-          deferredCoverageResults.push({
-            passed: true,
-            status: 'not_applicable',
-            description:
-              'inverse-rule coverage deferred for non-creative offline resource (resource_traversal_deferred)',
-            step_id: stepResult.step_id,
-            hint: {
-              kind: 'impairment_coherence_not_applicable',
-              violation: 'inverse',
-              reason: 'resource_traversal_deferred',
-              message,
-              resource_type: ob.resource_type,
-              resource_id: ob.resource_id,
-              resource_status: ob.status,
-              resource_step_id: stepResult.step_id,
-            },
-          });
+  function findSecretEcho(value: unknown, secrets: Set<string>): string | null {
+    const stack: unknown[] = [value];
+    while (stack.length > 0) {
+      const v = stack.pop();
+      if (typeof v === 'string') {
+        if (BEARER_TOKEN_PATTERN.test(v)) return 'contains a bearer-token literal';
+        for (const s of secrets) {
+          if (v.includes(s)) return 'contains a caller-supplied secret value verbatim';
         }
-      } else {
-        // Resource recovered from offline → drop the entry so the inverse
-        // rule no longer expects it in impairments[].
-        state.offlineResources.delete(key);
+        continue;
+      }
+      if (Array.isArray(v)) {
+        for (const item of v) stack.push(item);
+        continue;
+      }
+      if (v !== null && typeof v === 'object') {
+        for (const [key, inner] of Object.entries(v as Record<string, unknown>)) {
+          // Name-based dragnet. The SUSPECT_PROPERTY_NAMES set catches the
+          // "bare token on a credential-named field" leak shape that the
+          // BEARER_TOKEN_PATTERN value-scan misses (a JWT without `Bearer `
+          // prefix won't match the regex). But the dragnet over-rejects
+          // when the field's VALUE is a structured object or array — those
+          // are spec-legitimate config payloads, not credential echoes.
+          // `compliance/cache/{version}/property/validation-result.json`
+          // declares an `authorization` object field carrying authorization-
+          // validation metadata, not a token; sellers extending
+          // `sync_accounts` via the schema's `additionalProperties: true`
+          // may carry their own structured `authorization` posture. Both
+          // are spec-conformant.
+          //
+          // Gate the name-based fail on `typeof inner === 'string'` and
+          // non-empty so structured values pass through to the recursive
+          // walk below. The recursion still scans nested string values, so
+          // a `Bearer xyz...` literal embedded in a structured object is
+          // still caught by the regex at the top of this loop.
+          // Spec: adcp-client#1713 / adcp#4419.
+          if (SUSPECT_PROPERTY_NAMES.has(key.toLowerCase()) && typeof inner === 'string' && inner.length > 0) {
+            return `contains suspect property name "${key}" with string value`;
+          }
+          stack.push(inner);
+        }
       }
     }
+    return null;
+  }
 
-    // Extract media-buy snapshots and run the three coherence checks.
-    const snapshots = extractBuySnapshots(stepResult.task, body as Record<string, unknown>, stepResult.step_id);
-    if (snapshots.length === 0) return deferredCoverageResults;
-    state.observedBuySnapshot = true;
+  // ────────────────────────────────────────────────────────────
+  // governance.denial_blocks_mutation
+  // ────────────────────────────────────────────────────────────
 
-    const description = 'media_buy.impairments[] coheres with resource state and buy health';
-    const results: CoherenceResult[] = [];
+  /**
+   * Error codes that signal a seller-side refusal with plan scope. Grounded
+   * in `ErrorCodeSchema` in `src/lib/types/schemas.generated.ts`. Excludes
+   * transient (`GOVERNANCE_UNAVAILABLE` — no decision rendered) and
+   * account-state (`ACCOUNT_SUSPENDED`) codes — those aren't plan denials.
+   */
+  const GOVERNANCE_DENIAL_CODES = new Set([
+    'GOVERNANCE_DENIED',
+    'CAMPAIGN_SUSPENDED',
+    'PERMISSION_DENIED',
+    'POLICY_VIOLATION',
+    'TERMS_REJECTED',
+    'COMPLIANCE_UNSATISFIED',
+  ]);
 
-    for (const snap of snapshots) {
-      const isTerminal = Boolean(snap.status && !NON_TERMINAL_MEDIA_BUY_STATUSES.has(snap.status));
+  /**
+   * Write-class tasks whose successful response carries a server-minted
+   * resource id at the top level. Read tasks (`get_*`, `list_*`,
+   * `check_governance`) can echo ids without having created anything; they
+   * are excluded so the assertion doesn't false-positive on lookups after
+   * a denial. Sync-batch tasks (`sync_*`) are excluded until per-item
+   * acquisition detection lands — see follow-up in the spec repo.
+   */
+  const GOVERNANCE_WRITE_TASKS = new Set([
+    'create_media_buy',
+    'update_media_buy',
+    'activate_signal',
+    'create_property_list',
+    'update_property_list',
+    'delete_property_list',
+    'create_collection_list',
+    'update_collection_list',
+    'delete_collection_list',
+    'acquire_rights',
+  ]);
 
-      // Health-iff-impairments check. The spec ties the two together — a
-      // buy with non-empty impairments[] MUST report `health: "impaired"`,
-      // and an `impaired` health MUST have at least one impairment entry.
-      // Skip on terminal buys (the spec's terminal carve-out lets the
-      // seller stop tracking impairments, which makes the biconditional
-      // moot) and on snapshots that omit `health` entirely (sellers
-      // without health scoring grade silent).
-      if (!isTerminal && snap.health !== undefined) {
-        const hasImpairments = snap.impairments.length > 0;
-        const isImpaired = snap.health === 'impaired';
-        if (hasImpairments !== isImpaired) {
-          const message =
-            `media_buy ${snap.media_buy_id} health="${snap.health}" but impairments[] has ` +
-            `${snap.impairments.length} entries. ` +
-            `Spec: health MUST be "impaired" iff impairments[] is non-empty (adcp#2859).`;
-          results.push({
-            passed: false,
-            description,
-            step_id: stepResult.step_id,
-            error: message,
-            hint: {
-              kind: 'impairment_coherence_violation',
-              violation: 'health',
-              message,
-              media_buy_id: snap.media_buy_id,
-              buy_step_id: snap.stepId,
-              buy_health: snap.health,
-              impairments_count: snap.impairments.length,
-            },
-          });
+  const GOVERNANCE_ACQUIRED_STATUSES = new Set(['pending_creatives', 'pending_start', 'active', 'paused', 'completed']);
+
+  const GOVERNANCE_RESOURCE_ID_FIELDS = [
+    'media_buy_id',
+    'plan_id',
+    'creative_id',
+    'audience_id',
+    'catalog_id',
+    'activation_id',
+    'property_list_id',
+    'collection_list_id',
+    'acquisition_id',
+    'operation_id',
+  ];
+
+  interface GovernanceDenialAnchor {
+    stepId: string;
+    signal: string;
+  }
+
+  registerOnce('governance.denial_blocks_mutation', {
+    id: 'governance.denial_blocks_mutation',
+    default: true,
+    description:
+      'Once a governance signal denies a plan, no subsequent step in the run may acquire a resource for that plan.',
+    onStart: ctx => {
+      ctx.state.deniedPlans = new Map<string, GovernanceDenialAnchor>();
+      ctx.state.runDenial = undefined;
+    },
+    onStep: (ctx, stepResult) => {
+      const state = ctx.state as {
+        deniedPlans: Map<string, GovernanceDenialAnchor>;
+        runDenial?: GovernanceDenialAnchor;
+      };
+      const planId = extractGovernancePlanId(stepResult);
+
+      // Denial observation is never itself a failure — record and return.
+      const denial = detectGovernanceDenial(stepResult);
+      if (denial) {
+        // A step marked `expect_error: true` is the storyboard author explicitly
+        // acknowledging the denial. Subsequent mutations in the same run are a
+        // recovery path, not a silent bypass — don't anchor. The invariant still
+        // catches silent denials (check_governance 200 `status: denied`, or
+        // adcp_error responses the author did not expect).
+        if (stepResult.expect_error) return [];
+        const anchor: GovernanceDenialAnchor = { stepId: stepResult.step_id, signal: denial };
+        if (planId) {
+          if (!state.deniedPlans.has(planId)) state.deniedPlans.set(planId, anchor);
+        } else if (!state.runDenial) {
+          state.runDenial = anchor;
         }
+        return [];
       }
 
-      // Forward check. Every impairment entry must reference a resource the
-      // runner has observed in an offline state. If we have an observation
-      // and it's NOT offline, the seller is reporting a phantom impairment;
-      // if we have no observation at all, grade silent (can't disprove).
-      for (const entry of snap.impairments) {
-        const key = `${entry.resource_type}:${entry.resource_id}`;
-        const offline = IMPAIRMENT_OFFLINE_STATUS.get(entry.resource_type);
-        if (!offline) continue; // property or unknown family — skip silently
-        if (state.offlineResources.has(key)) continue; // ok, we agree it's offline
+      const acquired = detectGovernanceAcquisition(stepResult);
+      if (!acquired) return [];
 
-        const lastStatus = state.resourceStatus.get(key);
-        if (!lastStatus) continue; // never observed — can't grade
+      const anchor = (planId && state.deniedPlans.get(planId)) ?? state.runDenial;
+      if (!anchor) return [];
 
-        const offlineList = [...offline].sort().join(', ');
-        const message =
-          `media_buy ${snap.media_buy_id} impairments[] references ${entry.resource_type} ` +
-          `${entry.resource_id}, but its last observed status is "${lastStatus.status}" (step "${lastStatus.stepId}"). ` +
-          `Offline statuses for ${entry.resource_type}: ${offlineList}.`;
-        results.push({
+      // Always surface the step-level escape hatch — it's the one hint that
+      // works for both wire-error denials and `check_governance` 200
+      // `status: denied`. Names the step, names the field, shows the YAML so
+      // the author doesn't have to re-derive the escape from source.
+      const escapeHint =
+        `. If the denial at step "${anchor.stepId}" is an intentional recovery-path setup, add to that step:\n` +
+        `  invariants:\n` +
+        `    disable: [governance.denial_blocks_mutation]`;
+
+      return [
+        {
           passed: false,
-          description,
+          description: 'Mutation acquired a resource after a governance denial',
           step_id: stepResult.step_id,
-          error: message,
-          hint: {
-            kind: 'impairment_coherence_violation',
-            violation: 'forward',
-            message,
-            media_buy_id: snap.media_buy_id,
-            buy_step_id: snap.stepId,
-            resource_type: entry.resource_type,
-            resource_id: entry.resource_id,
-            resource_status: lastStatus.status,
-            resource_step_id: lastStatus.stepId,
-            impairments_count: snap.impairments.length,
-          },
-        });
+          error:
+            `step "${anchor.stepId}" returned ${anchor.signal}` +
+            (planId ? ` for plan_id=${planId}` : ' (run-wide)') +
+            `; subsequent step "${stepResult.step_id}" (task=${stepResult.task}) ` +
+            `acquired ${acquired.field}=${acquired.id}` +
+            (planId ? ' for the same plan' : '') +
+            escapeHint,
+        },
+      ];
+    },
+  });
+
+  function detectGovernanceDenial(step: import('./types').StoryboardStepResult): string | undefined {
+    const err = extractAdcpError(step);
+    if (err && GOVERNANCE_DENIAL_CODES.has(err.code)) return err.code;
+    // `check_governance` decides-no via a 200 response with `status: "denied"`
+    // (see static/schemas/source/governance/check-governance-response.json in
+    // the spec repo). The body isn't wrapped in `adcp_error`.
+    if (step.task === 'check_governance') {
+      const body = (step as unknown as { response?: unknown }).response;
+      if (body && typeof body === 'object') {
+        const status = (body as Record<string, unknown>).status;
+        if (status === 'denied') return 'CHECK_GOVERNANCE_DENIED';
+      }
+    }
+    return undefined;
+  }
+
+  function extractGovernancePlanId(step: import('./types').StoryboardStepResult): string | undefined {
+    const body = (step as unknown as { response?: unknown }).response;
+    if (body && typeof body === 'object') {
+      const rec = body as Record<string, unknown>;
+      if (typeof rec.plan_id === 'string' && rec.plan_id) return rec.plan_id;
+    }
+    // The runner records the outgoing payload on `stepResult.request` — read
+    // from there rather than accumulated step context to avoid stale plan_id
+    // bleed from earlier unrelated steps.
+    const req = (step as unknown as { request?: { payload?: unknown } }).request;
+    if (req && typeof req.payload === 'object' && req.payload !== null) {
+      const payload = req.payload as Record<string, unknown>;
+      if (typeof payload.plan_id === 'string' && payload.plan_id) return payload.plan_id;
+    }
+    return undefined;
+  }
+
+  function detectGovernanceAcquisition(
+    step: import('./types').StoryboardStepResult
+  ): { field: string; id: string } | undefined {
+    if (step.expect_error) return undefined;
+    if (!step.passed) return undefined;
+    if (!GOVERNANCE_WRITE_TASKS.has(step.task)) return undefined;
+
+    const body = (step as unknown as { response?: unknown }).response;
+    if (!body || typeof body !== 'object') return undefined;
+    const record = body as Record<string, unknown>;
+
+    if (step.task === 'create_media_buy' || step.task === 'update_media_buy') {
+      const status = record.status;
+      if (typeof status === 'string' && !GOVERNANCE_ACQUIRED_STATUSES.has(status)) return undefined;
+    }
+
+    for (const field of GOVERNANCE_RESOURCE_ID_FIELDS) {
+      const val = record[field];
+      if (typeof val === 'string' && val.length > 0) return { field, id: val };
+    }
+    return undefined;
+  }
+
+  // ────────────────────────────────────────────────────────────
+  // Helpers
+  // ────────────────────────────────────────────────────────────
+
+  interface AdcpErrorShape {
+    code: string;
+    details: Record<string, unknown>;
+  }
+
+  function extractAdcpError(step: import('./types').StoryboardStepResult): AdcpErrorShape | null {
+    const resp = (step as unknown as { response?: unknown }).response;
+    if (!resp || typeof resp !== 'object') return null;
+    const envelope = (resp as { adcp_error?: unknown }).adcp_error;
+    if (!envelope || typeof envelope !== 'object') return null;
+    const code = (envelope as { code?: unknown }).code;
+    if (typeof code !== 'string') return null;
+    return { code, details: envelope as Record<string, unknown> };
+  }
+
+  /**
+   * Add a value to the secrets set if it is a non-empty string of at least
+   * `SECRET_MIN_LENGTH` chars. Centralises the length guard so every source
+   * (structured auth, `auth_token`, `secrets[]`, `test_kit.auth.api_key`)
+   * gets the same floor.
+   */
+  function addIfSecret(out: Set<string>, value: unknown): void {
+    if (typeof value !== 'string') return;
+    if (value.length < SECRET_MIN_LENGTH) return;
+    out.add(value);
+  }
+
+  const ENV_REFERENCE_PREFIX = '$ENV:';
+
+  /**
+   * Resolve a possibly `$ENV:VAR`-prefixed credential value to the literal it
+   * references at runtime. Mirrors the auth-layer `resolveSecret` in
+   * `src/lib/auth/oauth/secret-resolver.ts`, but swallows missing / empty
+   * variables instead of throwing — the assertion must never break a
+   * storyboard run just because it can't resolve a ref.
+   *
+   * Returns `undefined` if the value is not an env reference, or if the
+   * referenced variable is unset / empty. Callers should skip `undefined`
+   * results. The literal `$ENV:FOO` string itself is never returned because
+   * it is a reference, not a secret, and cannot appear in an agent response.
+   */
+  function resolveEnvReference(value: string): string | undefined {
+    if (!value.startsWith(ENV_REFERENCE_PREFIX)) return undefined;
+    const envVar = value.slice(ENV_REFERENCE_PREFIX.length).trim();
+    if (!envVar) return undefined;
+    const resolved = process.env[envVar];
+    if (!resolved) return undefined;
+    return resolved;
+  }
+
+  /**
+   * Push a credential-field string onto `out`, resolving `$ENV:VAR` references
+   * to their literal runtime value. Literal values pass through unchanged.
+   * `$ENV:` references only contribute the resolved value — the reference
+   * string itself is not a secret.
+   */
+  function pushCredentialValue(out: string[], value: unknown): void {
+    if (typeof value !== 'string' || !value) return;
+    if (value.startsWith(ENV_REFERENCE_PREFIX)) {
+      const resolved = resolveEnvReference(value);
+      if (resolved) out.push(resolved);
+      return;
+    }
+    out.push(value);
+  }
+
+  /**
+   * Extract every leaf string secret from a structured `TestOptions.auth` value.
+   * Mirrors the four variants in `src/lib/testing/types.ts`:
+   *   - bearer                    → `token`
+   *   - basic                     → `password` and, when both credentials are
+   *                                 present, the `base64(user:pass)` blob an
+   *                                 `Authorization: Basic` header carries.
+   *                                 Username alone is NOT extracted — it's a
+   *                                 public identifier (welcome messages, audit
+   *                                 logs, "last login by X" echoes legitimately).
+   *   - oauth                     → `tokens.access_token`, `tokens.refresh_token`,
+   *                                 `client.client_secret` (if confidential)
+   *   - oauth_client_credentials  → `credentials.client_secret` (may be a
+   *                                 `$ENV:VAR` reference, resolved at runtime),
+   *                                 `tokens.access_token`, `tokens.refresh_token`.
+   *                                 `client_id` is NOT extracted — RFC 6749 §2.2
+   *                                 is explicit that the client identifier is
+   *                                 public and legitimately echoed in token
+   *                                 responses, introspection payloads, audit
+   *                                 logs, and error bodies.
+   *
+   * Returns an empty list for anything we can't recognise — the goal is a best-
+   * effort extraction, not schema validation. The SECRET_MIN_LENGTH guard is
+   * applied by the caller via `addIfSecret`.
+   */
+  function extractAuthSecrets(auth: unknown): string[] {
+    if (!auth || typeof auth !== 'object') return [];
+    const a = auth as Record<string, unknown>;
+    const out: string[] = [];
+    pushCredentialValue(out, a.token); // bearer
+
+    // basic: the password is the secret; the base64 blob catches echoes of the
+    // full Authorization: Basic header, including RFC 7617-valid empty passwords.
+    // Username alone is not a secret.
+    if (typeof a.password === 'string') {
+      if (a.password) out.push(a.password);
+      if (typeof a.username === 'string' && a.username) {
+        out.push(Buffer.from(`${a.username}:${a.password}`, 'utf8').toString('base64'));
+      }
+    }
+
+    if (a.tokens && typeof a.tokens === 'object') {
+      const t = a.tokens as Record<string, unknown>;
+      if (typeof t.access_token === 'string' && t.access_token) out.push(t.access_token);
+      if (typeof t.refresh_token === 'string' && t.refresh_token) out.push(t.refresh_token);
+    }
+    if (a.client && typeof a.client === 'object') {
+      const c = a.client as Record<string, unknown>;
+      if (typeof c.client_secret === 'string' && c.client_secret) out.push(c.client_secret);
+    }
+    if (a.credentials && typeof a.credentials === 'object') {
+      const c = a.credentials as Record<string, unknown>;
+      // client_secret on AgentOAuthClientCredentials may be a `$ENV:VAR`
+      // reference — resolve so the assertion compares the real runtime value
+      // the AS sees, not the reference string. client_id is NOT extracted
+      // (RFC 6749 §2.2 — public identifier).
+      pushCredentialValue(out, c.client_secret);
+    }
+    return out;
+  }
+
+  function extractBasicSecrets(basic: unknown): string[] {
+    if (!basic || typeof basic !== 'object') return [];
+    const b = basic as Record<string, unknown>;
+    const out: string[] = [];
+    if (typeof b.credentials === 'string' && b.credentials) {
+      const colonIndex = b.credentials.indexOf(':');
+      if (colonIndex > 0) {
+        const password = b.credentials.slice(colonIndex + 1);
+        if (password) out.push(password);
+        out.push(Buffer.from(b.credentials, 'utf8').toString('base64'));
+      }
+      return out;
+    }
+    if (typeof b.password === 'string') {
+      if (b.password) out.push(b.password);
+      if (typeof b.username === 'string' && b.username) {
+        out.push(Buffer.from(`${b.username}:${b.password}`, 'utf8').toString('base64'));
+      }
+    }
+    return out;
+  }
+
+  // ────────────────────────────────────────────────────────────
+  // status.monotonic
+  // ────────────────────────────────────────────────────────────
+
+  /**
+   * Per-resource-type lifecycle transition graphs. Each inner map is
+   * `from → Set<to>`. An observed transition `prev → curr` is legal iff
+   * `TRANSITIONS[type].get(prev)?.has(curr)` (self-edges `prev === curr`
+   * are always legal and skipped). The tables are hand-written from the
+   * spec enum schemas in `static/schemas/source/enums/*-status.json` and
+   * the narrative transitions documented there. When an enum gains a
+   * value this module needs an update alongside the schema change — that's
+   * the right coupling, visible in PR review.
+   *
+   * Bidirectional edges are listed in both directions explicitly (no
+   * auto-mirroring) so one-way edges like `rejected → processing` for
+   * creative assets don't accidentally become reversible.
+   */
+  interface TransitionGraph {
+    readonly transitions: ReadonlyMap<string, ReadonlySet<string>>;
+    /**
+     * Filename of the canonical enum schema this graph mirrors, relative to
+     * `/schemas/<adcp-version>/enums/`. Used to render a deep-link in the
+     * assertion failure message so implementors can jump straight to the
+     * spec's lifecycle doc instead of grep-searching for it.
+     */
+    readonly enumFile: string;
+  }
+
+  const SCHEMA_URL_BASE = 'https://adcontextprotocol.org';
+
+  function buildEnumSchemaUrl(enumFile: string): string {
+    return `${SCHEMA_URL_BASE}/schemas/${ADCP_VERSION}/enums/${enumFile}`;
+  }
+
+  // Source of truth for both graphs lives in `server/state-machine.ts` so
+  // production sellers and the runner enforce identical edges. Wrap the typed
+  // maps in `TransitionGraph` for the runner's string-keyed extractors.
+  const MEDIA_BUY_TRANSITIONS: TransitionGraph = {
+    transitions: MEDIA_BUY_TRANSITIONS_TYPED as ReadonlyMap<string, ReadonlySet<string>>,
+    enumFile: 'media-buy-status.json',
+  };
+
+  const CREATIVE_ASSET_TRANSITIONS: TransitionGraph = {
+    transitions: CREATIVE_ASSET_TRANSITIONS_TYPED as ReadonlyMap<string, ReadonlySet<string>>,
+    enumFile: 'creative-status.json',
+  };
+
+  const CREATIVE_APPROVAL_TRANSITIONS: TransitionGraph = {
+    // See `static/schemas/source/enums/creative-approval-status.json`.
+    // Per-assignment approval state on a package. `rejected → pending_review`
+    // is allowed on re-sync.
+    transitions: new Map<string, ReadonlySet<string>>([
+      ['pending_review', new Set(['approved', 'rejected'])],
+      ['approved', new Set(['rejected'])],
+      ['rejected', new Set(['pending_review'])],
+    ]),
+    enumFile: 'creative-approval-status.json',
+  };
+
+  const ACCOUNT_TRANSITIONS: TransitionGraph = {
+    // See `static/schemas/source/enums/account-status.json`. `active ↔
+    // suspended` and `active ↔ payment_required` are both reversible.
+    // `suspended → payment_required` covers the legitimate case where a
+    // suspended account's credit lapses during the suspension window.
+    // `rejected | closed` are terminal.
+    transitions: new Map<string, ReadonlySet<string>>([
+      ['pending_approval', new Set(['active', 'rejected'])],
+      ['active', new Set(['suspended', 'payment_required', 'closed'])],
+      ['suspended', new Set(['active', 'payment_required', 'closed'])],
+      ['payment_required', new Set(['active', 'suspended', 'closed'])],
+      ['rejected', new Set()],
+      ['closed', new Set()],
+    ]),
+    enumFile: 'account-status.json',
+  };
+
+  const SI_SESSION_TRANSITIONS: TransitionGraph = {
+    // See `static/schemas/source/enums/si-session-status.json`.
+    // `complete | terminated` are terminal.
+    transitions: new Map<string, ReadonlySet<string>>([
+      ['active', new Set(['pending_handoff', 'complete', 'terminated'])],
+      ['pending_handoff', new Set(['complete', 'terminated'])],
+      ['complete', new Set()],
+      ['terminated', new Set()],
+    ]),
+    enumFile: 'si-session-status.json',
+  };
+
+  const CATALOG_ITEM_TRANSITIONS: TransitionGraph = {
+    // See `static/schemas/source/enums/catalog-item-status.json`. `approved ↔
+    // warning` is reversible (seller flags a warning, then clears it).
+    // `rejected → pending` is allowed on re-sync. No terminals.
+    transitions: new Map<string, ReadonlySet<string>>([
+      ['pending', new Set(['approved', 'rejected', 'warning'])],
+      ['approved', new Set(['warning', 'rejected'])],
+      ['warning', new Set(['approved', 'rejected'])],
+      ['rejected', new Set(['pending'])],
+    ]),
+    enumFile: 'catalog-item-status.json',
+  };
+
+  const PROPOSAL_TRANSITIONS: TransitionGraph = {
+    // See `static/schemas/source/enums/proposal-status.json`. One-way.
+    transitions: new Map<string, ReadonlySet<string>>([
+      ['draft', new Set(['committed'])],
+      ['committed', new Set()],
+    ]),
+    enumFile: 'proposal-status.json',
+  };
+
+  const AUDIENCE_TRANSITIONS: TransitionGraph = {
+    // See `static/schemas/source/enums/audience-status.json`. Fully bidirectional
+    // across the three states — sellers MAY re-enter `processing` on re-sync
+    // from `ready` or `too_small`, and `ready ↔ too_small` can happen as
+    // member counts cross `minimum_size` (spec hedges this as MAY, not MUST).
+    // No terminals: delete / fail omit `status` entirely via the envelope's
+    // `action` field, so there's nothing to record for them.
+    transitions: new Map<string, ReadonlySet<string>>([
+      ['processing', new Set(['ready', 'too_small'])],
+      ['ready', new Set(['processing', 'too_small'])],
+      ['too_small', new Set(['processing', 'ready'])],
+    ]),
+    enumFile: 'audience-status.json',
+  };
+
+  /**
+   * Extractor record per resource type. For each response shape we recognize,
+   * describe how to walk the body and emit `(resource_id, status)` pairs.
+   * The runner hands us `stepResult.response` — we look at the shape and
+   * the task name to disambiguate (e.g. `get_media_buys` vs `sync_creatives`).
+   */
+  interface StatusObservation {
+    resource_type: string;
+    resource_id: string;
+    status: string;
+    graph: TransitionGraph;
+  }
+
+  /**
+   * Task-aware extractors. Each knows the response shape for its task family
+   * and walks arrays where present. Unknown tasks produce no observations —
+   * the assertion is silent on tasks it doesn't recognize.
+   */
+  function extractStatusObservations(task: string, body: Record<string, unknown>): StatusObservation[] {
+    const obs: StatusObservation[] = [];
+
+    // Media-buy: create/update_media_buy return top-level status + packages
+    // with per-creative approval_status. get_media_buys returns media_buys[].
+    if (task === 'create_media_buy' || task === 'update_media_buy') {
+      pushMediaBuy(obs, body);
+    } else if (task === 'get_media_buys') {
+      for (const mb of asArray(body.media_buys)) {
+        if (isObject(mb)) pushMediaBuy(obs, mb);
+      }
+    }
+
+    // Creative asset lifecycle: sync_creatives and list_creatives.
+    if (task === 'sync_creatives' || task === 'list_creatives') {
+      for (const c of asArray(body.creatives)) {
+        if (isObject(c)) pushCreative(obs, c);
+      }
+    }
+
+    // Account: sync_accounts and list_accounts. Embedded `account` objects on
+    // media-buy responses do not carry a lifecycle status — they're just
+    // references (brand, operator) — so we don't read them here.
+    if (task === 'sync_accounts' || task === 'list_accounts') {
+      for (const a of asArray(body.accounts)) {
+        if (isObject(a)) pushAccount(obs, a);
+      }
+    }
+
+    // SI session: si_initiate_session / si_send_message return top-level
+    // `session_id` + `status`.
+    if (task === 'si_initiate_session' || task === 'si_send_message' || task === 'si_terminate_session') {
+      pushSiSession(obs, body);
+    }
+
+    // Catalog items: sync_catalogs / list_catalogs return `items[]` per catalog.
+    if (task === 'sync_catalogs' || task === 'list_catalogs') {
+      for (const cat of asArray(body.catalogs)) {
+        if (!isObject(cat)) continue;
+        for (const item of asArray(cat.items)) {
+          if (isObject(item)) pushCatalogItem(obs, item);
+        }
+      }
+      for (const item of asArray(body.items)) {
+        if (isObject(item)) pushCatalogItem(obs, item);
+      }
+    }
+
+    // Proposal: get_products may return a `proposal` object when the
+    // caller is refining toward commitment.
+    if (task === 'get_products' && isObject(body.proposal)) {
+      pushProposal(obs, body.proposal);
+    }
+
+    // Audience lifecycle: sync_audiences is both the write and discovery path
+    // (discovery-only calls omit the request `audiences` array but still return
+    // `audiences[]`). No separate list_audiences task exists.
+    if (task === 'sync_audiences') {
+      for (const a of asArray(body.audiences)) {
+        if (isObject(a)) pushAudience(obs, a);
+      }
+    }
+
+    return obs;
+  }
+
+  function pushMediaBuy(obs: StatusObservation[], record: Record<string, unknown>): void {
+    const id = asString(record.media_buy_id);
+    // 3.1+: `media_buy_status` (body) carries MediaBuyStatus; top-level
+    // `status` (envelope) carries TaskStatus. Pre-3.1 + nested fields on
+    // `get_media_buys` / `get_media_buy_delivery`: `status` still carries
+    // MediaBuyStatus. Read the canonical 3.1 field first, fall back to
+    // legacy. Refs adcontextprotocol/adcp#4895 (3.1 additive-deprecate),
+    // #4906 (3.2 legacy removal), #4905 (4.0 nested cascade).
+    const status = asString(record.media_buy_status) ?? asString(record.status);
+    if (id && status) {
+      obs.push({
+        resource_type: 'media_buy',
+        resource_id: id,
+        status,
+        graph: MEDIA_BUY_TRANSITIONS,
+      });
+    }
+    // Each media_buy carries packages; each package can list creative_approvals
+    // with per-creative approval_status. Track those against the approval graph.
+    for (const pkg of asArray(record.packages)) {
+      if (!isObject(pkg)) continue;
+      for (const ca of asArray(pkg.creative_approvals)) {
+        if (!isObject(ca)) continue;
+        const cid = asString(ca.creative_id);
+        const astatus = asString(ca.approval_status);
+        if (cid && astatus) {
+          obs.push({
+            resource_type: 'creative_approval',
+            resource_id: cid,
+            status: astatus,
+            graph: CREATIVE_APPROVAL_TRANSITIONS,
+          });
+        }
+      }
+    }
+  }
+
+  function pushCreative(obs: StatusObservation[], record: Record<string, unknown>): void {
+    const id = asString(record.creative_id);
+    const status = asString(record.status);
+    if (id && status) {
+      obs.push({
+        resource_type: 'creative',
+        resource_id: id,
+        status,
+        graph: CREATIVE_ASSET_TRANSITIONS,
+      });
+    }
+  }
+
+  function pushAccount(obs: StatusObservation[], record: Record<string, unknown>): void {
+    const id = asString(record.account_id);
+    const status = asString(record.status);
+    if (id && status) {
+      obs.push({
+        resource_type: 'account',
+        resource_id: id,
+        status,
+        graph: ACCOUNT_TRANSITIONS,
+      });
+    }
+  }
+
+  function pushSiSession(obs: StatusObservation[], record: Record<string, unknown>): void {
+    const id = asString(record.session_id);
+    const status = asString(record.status);
+    if (id && status) {
+      obs.push({
+        resource_type: 'si_session',
+        resource_id: id,
+        status,
+        graph: SI_SESSION_TRANSITIONS,
+      });
+    }
+  }
+
+  function pushCatalogItem(obs: StatusObservation[], record: Record<string, unknown>): void {
+    // Catalog items are heterogeneous across catalog types. Prefer `item_id`
+    // (spec-canonical on sync/list responses), then domain-specific
+    // `offering_id` (SI) and `sku` (retail), then a generic `id` as last
+    // resort. The fallback chain silently mis-identifies if a seller echoes
+    // a non-canonical id — the resulting history splits per id shape rather
+    // than emitting an error. Acceptable tradeoff given schema churn; enum
+    // drift stays under `response_schema`'s purview.
+    const id = asString(record.item_id) ?? asString(record.offering_id) ?? asString(record.sku) ?? asString(record.id);
+    const status = asString(record.status);
+    if (id && status) {
+      obs.push({
+        resource_type: 'catalog_item',
+        resource_id: id,
+        status,
+        graph: CATALOG_ITEM_TRANSITIONS,
+      });
+    }
+  }
+
+  function pushProposal(obs: StatusObservation[], record: Record<string, unknown>): void {
+    const id = asString(record.proposal_id);
+    const status = asString(record.status);
+    if (id && status) {
+      obs.push({
+        resource_type: 'proposal',
+        resource_id: id,
+        status,
+        graph: PROPOSAL_TRANSITIONS,
+      });
+    }
+  }
+
+  function pushAudience(obs: StatusObservation[], record: Record<string, unknown>): void {
+    // `status` is absent when `action` is `deleted` or `failed` — spec
+    // envelope intentionally omits the field rather than emitting a terminal
+    // value. The `&& status` guard below makes those observations silent.
+    const id = asString(record.audience_id);
+    const status = asString(record.status);
+    if (id && status) {
+      obs.push({
+        resource_type: 'audience',
+        resource_id: id,
+        status,
+        graph: AUDIENCE_TRANSITIONS,
+      });
+    }
+  }
+
+  interface MonotonicState {
+    stepId: string;
+    status: string;
+  }
+
+  registerOnce('status.monotonic', {
+    id: 'status.monotonic',
+    default: true,
+    description:
+      'Observed resource statuses (media_buy, creative, account, si_session, catalog_item, proposal, creative_approval, audience) MUST only transition along edges in the spec lifecycle graph.',
+    onStart: ctx => {
+      // `${resource_type}:${resource_id}` → last-observed state. Tuple key
+      // disambiguates the unlikely `media_buy_id` / `creative_id` collision.
+      ctx.state.history = new Map<string, MonotonicState>();
+    },
+    onStep: (ctx, stepResult) => {
+      // Skip error / skipped / negative-path steps. An errored read doesn't
+      // observe a new state; `expect_error: true` runs are probing error
+      // codes, not transitions.
+      if (stepResult.skipped) return [];
+      if (stepResult.expect_error) return [];
+      if (!stepResult.passed) return [];
+      const body = (stepResult as unknown as { response?: unknown }).response;
+      if (!body || typeof body !== 'object') return [];
+      if (extractAdcpError(stepResult)) return [];
+
+      const history = ctx.state.history as Map<string, MonotonicState>;
+      const observations = extractStatusObservations(stepResult.task, body as Record<string, unknown>);
+      const description = 'Resource statuses transition only along spec lifecycle edges';
+
+      for (const ob of observations) {
+        const key = `${ob.resource_type}:${ob.resource_id}`;
+        const prev = history.get(key);
+        if (!prev) {
+          history.set(key, { stepId: stepResult.step_id, status: ob.status });
+          continue;
+        }
+        if (prev.status === ob.status) {
+          // No-op observation (replay, re-read of unchanged state). Don't emit,
+          // don't advance the anchor step — the earlier stepId stays useful for
+          // diagnostics if a later backward edge appears.
+          continue;
+        }
+        const allowedTargets = ob.graph.transitions.get(prev.status);
+        if (!allowedTargets) {
+          // Unknown previous status (enum drift or we missed a state in the
+          // table). Don't fail — `response_schema` catches enum violations;
+          // reset the anchor so downstream transitions still get checked.
+          history.set(key, { stepId: stepResult.step_id, status: ob.status });
+          continue;
+        }
+        if (!allowedTargets.has(ob.status)) {
+          // Surface the legal next states + a canonical enum URL so implementors
+          // can self-diagnose without grepping the SDK source for the
+          // lifecycle table. `allowedTargets` is empty for terminal states
+          // (completed / rejected / canceled / etc.) — call that out explicitly
+          // rather than rendering an empty list that reads as "any target is
+          // fine, just not this one".
+          const legalTargets = [...allowedTargets].sort();
+          const legalDescription =
+            legalTargets.length > 0 ? legalTargets.map(t => `"${t}"`).join(', ') : '(none — terminal state)';
+          const enumUrl = buildEnumSchemaUrl(ob.graph.enumFile);
+          const errorMessage =
+            `${ob.resource_type} ${ob.resource_id}: ${prev.status} → ${ob.status} ` +
+            `(step "${prev.stepId}" → step "${stepResult.step_id}") is not in the lifecycle graph. ` +
+            `Legal next states from "${prev.status}": ${legalDescription}. ` +
+            `See ${enumUrl} for the canonical lifecycle.`;
+          return [
+            {
+              passed: false,
+              description,
+              step_id: stepResult.step_id,
+              error: errorMessage,
+              // Issue #935: structured `MonotonicViolationHint` mirrored into
+              // the owning step's `hints[]` so renderers can branch on the
+              // discriminator and render the legal-target set in a per-kind
+              // template instead of regex-parsing the prose error string.
+              hint: {
+                kind: 'monotonic_violation',
+                message: errorMessage,
+                resource_type: ob.resource_type,
+                resource_id: ob.resource_id,
+                from_status: prev.status,
+                to_status: ob.status,
+                from_step_id: prev.stepId,
+                legal_next_states: legalTargets,
+                enum_url: enumUrl,
+              },
+            },
+          ];
+        }
+        history.set(key, { stepId: stepResult.step_id, status: ob.status });
       }
 
-      // Inverse check. For each resource the buy references — creatives
-      // via `packages[].creative_assignments[].creative_id`, audiences via
-      // `packages[].targeting_overlay.audience_include[]` — if the runner
-      // has it in the offline set AND the buy is non-terminal AND the
-      // impairments[] list doesn't mention it, the seller failed to
-      // propagate the resource state into the buy. `catalog_item` and
-      // `event_source` inverse coverage is still deferred: their buy-side
-      // reference shape isn't yet stable enough in the cached schema to
-      // extract without ambiguity.
-      if (isTerminal) continue;
+      if (observations.length === 0) return [];
+      return [{ passed: true, description, step_id: stepResult.step_id }];
+    },
+    // Emit a run-level summary so the track rollup can distinguish
+    // "wired and exercised" (history.size > 0) from "wired but never
+    // observed a lifecycle resource" (history.size === 0). The latter
+    // demotes the track to TrackStatus: 'silent' even though every step
+    // and every per-step assertion record passed. Companion to
+    // adcontextprotocol/adcp#2834.
+    onEnd: ctx => {
+      const history = ctx.state.history as Map<string, MonotonicState> | undefined;
+      const observation_count = history?.size ?? 0;
+      return [
+        {
+          passed: true,
+          description: 'Resource statuses transition only along spec lifecycle edges',
+          observation_count,
+          status: observation_count === 0 ? ('silent' as const) : ('pass' as const),
+        },
+      ];
+    },
+  });
 
-      for (const [resourceType, referencedIds] of [
-        ['creative', snap.referencedCreativeIds] as const,
-        ['audience', snap.referencedAudienceIds] as const,
-      ]) {
-        const impairedIds = new Set(
-          snap.impairments.filter(e => e.resource_type === resourceType).map(e => e.resource_id)
-        );
-        for (const resourceId of referencedIds) {
-          const key = `${resourceType}:${resourceId}`;
-          const offline = state.offlineResources.get(key);
-          if (!offline) continue;
-          if (impairedIds.has(resourceId)) continue;
+  // Tiny type-safety helpers for the extractors above.
+  function isObject(v: unknown): v is Record<string, unknown> {
+    return v !== null && typeof v === 'object' && !Array.isArray(v);
+  }
+
+  function asArray(v: unknown): unknown[] {
+    return Array.isArray(v) ? v : [];
+  }
+
+  function asString(v: unknown): string | undefined {
+    return typeof v === 'string' && v.length > 0 ? v : undefined;
+  }
+
+  // ────────────────────────────────────────────────────────────
+  // impairment.coherence
+  // ────────────────────────────────────────────────────────────
+
+  /**
+   * Per-resource-type offline status sets. An impairment entry referencing
+   * `(resource_type, resource_id)` is coherent when the runner's last
+   * observation for that resource matches one of these values.
+   *
+   * Sourced from spec issue #2859 plus the resource-status enum schemas:
+   *   - audience:     `suspended`    (audience-status.json)
+   *   - creative:     `rejected`     (creative-status.json — terminal)
+   *   - catalog_item: `withdrawn`    (catalog-item-status.json)
+   *   - event_source: `insufficient` (assessment-status.json, on
+   *                                   event-source-health.status)
+   *
+   * `property` is intentionally absent — offline state is sourced from
+   * `brand.json` / `adagents.json` depublishing, not from a status enum on
+   * the wire. The runner has no observation hook for that transition today,
+   * so property-typed impairments grade silent rather than emitting a forward
+   * pass / fail. The spec issue calls this out explicitly.
+   */
+  const IMPAIRMENT_OFFLINE_STATUS: ReadonlyMap<string, ReadonlySet<string>> = new Map([
+    ['audience', new Set(['suspended'])],
+    ['creative', new Set(['rejected'])],
+    ['catalog_item', new Set(['withdrawn'])],
+    ['event_source', new Set(['insufficient'])],
+  ]);
+
+  /**
+   * Media-buy statuses that are non-terminal — the inverse rule only applies
+   * while the buy is still serving (or about to). The spec issue carves out
+   * `completed`, `canceled`, `rejected` as the terminal set that MAY remain
+   * unreported because the buy is no longer accruing impressions.
+   */
+  const NON_TERMINAL_MEDIA_BUY_STATUSES: ReadonlySet<string> = new Set([
+    'pending_creatives',
+    'pending_start',
+    'active',
+    'paused',
+  ]);
+
+  interface ImpairmentEntry {
+    resource_type: string;
+    resource_id: string;
+  }
+
+  interface BuySnapshot {
+    media_buy_id: string;
+    status: string | undefined;
+    health: string | undefined;
+    impairments: ImpairmentEntry[];
+    referencedCreativeIds: Set<string>;
+    referencedAudienceIds: Set<string>;
+    stepId: string;
+  }
+
+  interface ResourceObservation {
+    status: string;
+    stepId: string;
+  }
+
+  /**
+   * Resource families the inverse rule does NOT yet grade — the buy-side
+   * reference shape for these in `media_buy.packages` isn't stable in the
+   * cached schema, so we can't reliably tell which buys reference which
+   * resources. Listed here so the onEnd summary can emit a runtime
+   * "partial inverse coverage" signal when the run actually observed
+   * offline resources in one of these families — making the deferral
+   * visible to storyboard authors and reviewers rather than burying it in
+   * PR prose and JSDoc.
+   *
+   * `audience` is graded — the buy-side reference lives at
+   * `packages[*].targeting_overlay.audience_include[]` and is extracted in
+   * `readBuySnapshot`. `catalog_item` and `event_source` are deferred: a
+   * buy doesn't reference catalog_items or event_sources by stable id in
+   * the cached schema, so the runner can't traverse buy → resource.
+   */
+  const INVERSE_DEFERRED_FAMILIES: ReadonlySet<string> = new Set(['catalog_item', 'event_source']);
+
+  /**
+   * Private per-run scratch state. Namespaced under
+   * `ctx.state.impairmentCoherence` so generic field names (`offlineResources`,
+   * `observedTransition`) can't collide with another assertion that lands
+   * later and pokes the same shared `ctx.state` bag.
+   */
+  interface ImpairmentCoherenceState {
+    /** `${resource_type}:${resource_id}` → last observation, offline or not. */
+    resourceStatus: Map<string, ResourceObservation>;
+    /** `${resource_type}:${resource_id}` for entries currently in an offline status. */
+    offlineResources: Map<string, ResourceObservation>;
+    /** Run actually observed at least one resource status transition. */
+    observedTransition: boolean;
+    /** Run actually observed at least one media-buy snapshot read. */
+    observedBuySnapshot: boolean;
+    /**
+     * Per-family count of offline observations the run saw, used by the
+     * onEnd summary to flag deferred inverse-rule coverage. A non-zero
+     * count for any family in `INVERSE_DEFERRED_FAMILIES` means the run
+     * exercised the cross-resource path for a family the runner can't yet
+     * grade — surfaced so reviewers see the gap at run-time.
+     */
+    offlineObservationsByFamily: Map<string, number>;
+  }
+
+  const IMPAIRMENT_STATE_KEY = 'impairmentCoherence';
+
+  function getImpairmentState(ctx: import('./assertions').AssertionContext): ImpairmentCoherenceState {
+    // onStart populates the namespaced slot; the cast is safe because no other
+    // assertion writes there.
+    return ctx.state[IMPAIRMENT_STATE_KEY] as ImpairmentCoherenceState;
+  }
+
+  registerOnce('impairment.coherence', {
+    id: 'impairment.coherence',
+    default: true,
+    description:
+      'media_buy.impairments[] MUST reference currently-offline resources (forward); any offline resource referenced by a non-terminal buy MUST appear in impairments[] (inverse); health == "impaired" iff impairments[] is non-empty.',
+    onStart: ctx => {
+      const state: ImpairmentCoherenceState = {
+        resourceStatus: new Map(),
+        offlineResources: new Map(),
+        observedTransition: false,
+        observedBuySnapshot: false,
+        offlineObservationsByFamily: new Map(),
+      };
+      ctx.state[IMPAIRMENT_STATE_KEY] = state;
+    },
+    onStep: (ctx, stepResult) => {
+      if (stepResult.skipped) return [];
+      if (stepResult.expect_error) return [];
+      if (!stepResult.passed) return [];
+      const body = (stepResult as unknown as { response?: unknown }).response;
+      if (!body || typeof body !== 'object') return [];
+      if (extractAdcpError(stepResult)) return [];
+
+      const state = getImpairmentState(ctx);
+
+      type CoherenceResult = {
+        passed: boolean;
+        description: string;
+        step_id: string;
+        error?: string;
+        status?: 'not_applicable';
+        hint?: import('./types').ImpairmentCoherenceHint | import('./types').ImpairmentCoherenceNotApplicableHint;
+      };
+      const deferredCoverageResults: CoherenceResult[] = [];
+
+      // Direct, dedicated extractor for the four families this invariant cares
+      // about. NOT routed through `extractStatusObservations` (which is bound
+      // to the `status.monotonic` transition graphs and therefore excludes
+      // the new offline values `suspended` / `withdrawn` / `insufficient`):
+      // monotonic's graphs intentionally enumerate only spec-stable enum
+      // values, but those new offline states are exactly what this invariant
+      // needs to observe.
+      for (const ob of extractImpairmentObservations(stepResult.task, body as Record<string, unknown>)) {
+        const key = `${ob.resource_type}:${ob.resource_id}`;
+        state.resourceStatus.set(key, { status: ob.status, stepId: stepResult.step_id });
+        const offline = IMPAIRMENT_OFFLINE_STATUS.get(ob.resource_type);
+        if (offline?.has(ob.status)) {
+          const wasOffline = state.offlineResources.has(key);
+          state.offlineResources.set(key, { status: ob.status, stepId: stepResult.step_id });
+          state.observedTransition = true;
+          state.offlineObservationsByFamily.set(
+            ob.resource_type,
+            (state.offlineObservationsByFamily.get(ob.resource_type) ?? 0) + 1
+          );
+
+          // Issue #1806: surface deferred inverse-rule coverage at the
+          // transition step. When a resource family the runner can't yet
+          // reverse-traverse (`catalog_item` / `event_source`) enters an
+          // offline state for the first time in this run, emit a
+          // `not_applicable` step-level result so reviewers see the gap in
+          // run output instead of having to read PR prose. One emission per
+          // (resource_type, resource_id) per run — re-syncs of an already
+          // offline resource don't re-fire. Only catalog_item and event_source
+          // surface here; audience is graded via the inverse rule using refs
+          // from packages[*].targeting_overlay.audience_include[].
+          if (!wasOffline && (ob.resource_type === 'catalog_item' || ob.resource_type === 'event_source')) {
+            const message =
+              `inverse-rule coverage for ${ob.resource_type} ${ob.resource_id} ` +
+              `(status="${ob.status}", step "${stepResult.step_id}") is deferred — ` +
+              `buy → resource traversal not yet implemented for this family.`;
+            deferredCoverageResults.push({
+              passed: true,
+              status: 'not_applicable',
+              description:
+                'inverse-rule coverage deferred for non-creative offline resource (resource_traversal_deferred)',
+              step_id: stepResult.step_id,
+              hint: {
+                kind: 'impairment_coherence_not_applicable',
+                violation: 'inverse',
+                reason: 'resource_traversal_deferred',
+                message,
+                resource_type: ob.resource_type,
+                resource_id: ob.resource_id,
+                resource_status: ob.status,
+                resource_step_id: stepResult.step_id,
+              },
+            });
+          }
+        } else {
+          // Resource recovered from offline → drop the entry so the inverse
+          // rule no longer expects it in impairments[].
+          state.offlineResources.delete(key);
+        }
+      }
+
+      // Extract media-buy snapshots and run the three coherence checks.
+      const snapshots = extractBuySnapshots(stepResult.task, body as Record<string, unknown>, stepResult.step_id);
+      if (snapshots.length === 0) return deferredCoverageResults;
+      state.observedBuySnapshot = true;
+
+      const description = 'media_buy.impairments[] coheres with resource state and buy health';
+      const results: CoherenceResult[] = [];
+
+      for (const snap of snapshots) {
+        const isTerminal = Boolean(snap.status && !NON_TERMINAL_MEDIA_BUY_STATUSES.has(snap.status));
+
+        // Health-iff-impairments check. The spec ties the two together — a
+        // buy with non-empty impairments[] MUST report `health: "impaired"`,
+        // and an `impaired` health MUST have at least one impairment entry.
+        // Skip on terminal buys (the spec's terminal carve-out lets the
+        // seller stop tracking impairments, which makes the biconditional
+        // moot) and on snapshots that omit `health` entirely (sellers
+        // without health scoring grade silent).
+        if (!isTerminal && snap.health !== undefined) {
+          const hasImpairments = snap.impairments.length > 0;
+          const isImpaired = snap.health === 'impaired';
+          if (hasImpairments !== isImpaired) {
+            const message =
+              `media_buy ${snap.media_buy_id} health="${snap.health}" but impairments[] has ` +
+              `${snap.impairments.length} entries. ` +
+              `Spec: health MUST be "impaired" iff impairments[] is non-empty (adcp#2859).`;
+            results.push({
+              passed: false,
+              description,
+              step_id: stepResult.step_id,
+              error: message,
+              hint: {
+                kind: 'impairment_coherence_violation',
+                violation: 'health',
+                message,
+                media_buy_id: snap.media_buy_id,
+                buy_step_id: snap.stepId,
+                buy_health: snap.health,
+                impairments_count: snap.impairments.length,
+              },
+            });
+          }
+        }
+
+        // Forward check. Every impairment entry must reference a resource the
+        // runner has observed in an offline state. If we have an observation
+        // and it's NOT offline, the seller is reporting a phantom impairment;
+        // if we have no observation at all, grade silent (can't disprove).
+        for (const entry of snap.impairments) {
+          const key = `${entry.resource_type}:${entry.resource_id}`;
+          const offline = IMPAIRMENT_OFFLINE_STATUS.get(entry.resource_type);
+          if (!offline) continue; // property or unknown family — skip silently
+          if (state.offlineResources.has(key)) continue; // ok, we agree it's offline
+
+          const lastStatus = state.resourceStatus.get(key);
+          if (!lastStatus) continue; // never observed — can't grade
+
+          const offlineList = [...offline].sort().join(', ');
           const message =
-            `media_buy ${snap.media_buy_id} (status="${snap.status ?? 'unknown'}") references ${resourceType} ` +
-            `${resourceId} which is offline (status="${offline.status}", step "${offline.stepId}"), ` +
-            `but impairments[] does not list it. Spec: any offline resource referenced by a ` +
-            `non-terminal buy MUST appear in impairments[] (adcp#2859).`;
+            `media_buy ${snap.media_buy_id} impairments[] references ${entry.resource_type} ` +
+            `${entry.resource_id}, but its last observed status is "${lastStatus.status}" (step "${lastStatus.stepId}"). ` +
+            `Offline statuses for ${entry.resource_type}: ${offlineList}.`;
           results.push({
             passed: false,
             description,
@@ -1359,211 +1322,267 @@ registerOnce('impairment.coherence', {
             error: message,
             hint: {
               kind: 'impairment_coherence_violation',
-              violation: 'inverse',
+              violation: 'forward',
               message,
               media_buy_id: snap.media_buy_id,
               buy_step_id: snap.stepId,
-              resource_type: resourceType,
-              resource_id: resourceId,
-              resource_status: offline.status,
-              resource_step_id: offline.stepId,
+              resource_type: entry.resource_type,
+              resource_id: entry.resource_id,
+              resource_status: lastStatus.status,
+              resource_step_id: lastStatus.stepId,
               impairments_count: snap.impairments.length,
             },
           });
         }
-      }
-    }
 
-    if (results.length === 0) {
-      return [...deferredCoverageResults, { passed: true, description, step_id: stepResult.step_id }];
-    }
-    return [...deferredCoverageResults, ...results];
-  },
-  // Emit a run-level summary so the track rollup can distinguish
-  // "wired and exercised" from "wired but neither side observed". When
-  // either side is missing the assertion is functionally NA — the spec
-  // issue explicitly carves out that case rather than treating it as a
-  // silent pass with false confidence.
-  onEnd: ctx => {
-    const state = ctx.state[IMPAIRMENT_STATE_KEY] as ImpairmentCoherenceState | undefined;
-    const exercised = Boolean(state?.observedTransition && state?.observedBuySnapshot);
-    const results: Omit<import('./types').AssertionResult, 'assertion_id' | 'scope'>[] = [
-      {
-        passed: true,
-        description: 'media_buy.impairments[] coheres with resource state and buy health',
-        observation_count: exercised ? 1 : 0,
-        status: exercised ? ('pass' as const) : ('silent' as const),
-      },
-    ];
+        // Inverse check. For each resource the buy references — creatives
+        // via `packages[].creative_assignments[].creative_id`, audiences via
+        // `packages[].targeting_overlay.audience_include[]` — if the runner
+        // has it in the offline set AND the buy is non-terminal AND the
+        // impairments[] list doesn't mention it, the seller failed to
+        // propagate the resource state into the buy. `catalog_item` and
+        // `event_source` inverse coverage is still deferred: their buy-side
+        // reference shape isn't yet stable enough in the cached schema to
+        // extract without ambiguity.
+        if (isTerminal) continue;
 
-    // Surface partial inverse-rule coverage. If the run observed at least
-    // one offline resource in a deferred family (audience, catalog_item,
-    // event_source), the inverse rule's silence on those families is
-    // material to this run — naming the gap loudly at the end of the run
-    // beats burying it in PR prose and JSDoc.
-    if (state) {
-      const deferredCounts: { family: string; count: number }[] = [];
-      for (const family of INVERSE_DEFERRED_FAMILIES) {
-        const count = state.offlineObservationsByFamily.get(family) ?? 0;
-        if (count > 0) deferredCounts.push({ family, count });
+        for (const [resourceType, referencedIds] of [
+          ['creative', snap.referencedCreativeIds] as const,
+          ['audience', snap.referencedAudienceIds] as const,
+        ]) {
+          const impairedIds = new Set(
+            snap.impairments.filter(e => e.resource_type === resourceType).map(e => e.resource_id)
+          );
+          for (const resourceId of referencedIds) {
+            const key = `${resourceType}:${resourceId}`;
+            const offline = state.offlineResources.get(key);
+            if (!offline) continue;
+            if (impairedIds.has(resourceId)) continue;
+            const message =
+              `media_buy ${snap.media_buy_id} (status="${snap.status ?? 'unknown'}") references ${resourceType} ` +
+              `${resourceId} which is offline (status="${offline.status}", step "${offline.stepId}"), ` +
+              `but impairments[] does not list it. Spec: any offline resource referenced by a ` +
+              `non-terminal buy MUST appear in impairments[] (adcp#2859).`;
+            results.push({
+              passed: false,
+              description,
+              step_id: stepResult.step_id,
+              error: message,
+              hint: {
+                kind: 'impairment_coherence_violation',
+                violation: 'inverse',
+                message,
+                media_buy_id: snap.media_buy_id,
+                buy_step_id: snap.stepId,
+                resource_type: resourceType,
+                resource_id: resourceId,
+                resource_status: offline.status,
+                resource_step_id: offline.stepId,
+                impairments_count: snap.impairments.length,
+              },
+            });
+          }
+        }
       }
-      if (deferredCounts.length > 0) {
-        const summary = deferredCounts.map(d => `${d.family} (${d.count})`).join(', ');
-        results.push({
+
+      if (results.length === 0) {
+        return [...deferredCoverageResults, { passed: true, description, step_id: stepResult.step_id }];
+      }
+      return [...deferredCoverageResults, ...results];
+    },
+    // Emit a run-level summary so the track rollup can distinguish
+    // "wired and exercised" from "wired but neither side observed". When
+    // either side is missing the assertion is functionally NA — the spec
+    // issue explicitly carves out that case rather than treating it as a
+    // silent pass with false confidence.
+    onEnd: ctx => {
+      const state = ctx.state[IMPAIRMENT_STATE_KEY] as ImpairmentCoherenceState | undefined;
+      const exercised = Boolean(state?.observedTransition && state?.observedBuySnapshot);
+      const results: Omit<import('./types').AssertionResult, 'assertion_id' | 'scope'>[] = [
+        {
           passed: true,
-          description:
-            'inverse coverage gap: offline resources observed for families the runner does not yet grade ' +
-            'on the inverse rule (creative and audience are graded; catalog_item and event_source are forward-only). ' +
-            `Observed: ${summary}.`,
-          observation_count: 0,
-        });
+          description: 'media_buy.impairments[] coheres with resource state and buy health',
+          observation_count: exercised ? 1 : 0,
+          status: exercised ? ('pass' as const) : ('silent' as const),
+        },
+      ];
+
+      // Surface partial inverse-rule coverage. If the run observed at least
+      // one offline resource in a deferred family (audience, catalog_item,
+      // event_source), the inverse rule's silence on those families is
+      // material to this run — naming the gap loudly at the end of the run
+      // beats burying it in PR prose and JSDoc.
+      if (state) {
+        const deferredCounts: { family: string; count: number }[] = [];
+        for (const family of INVERSE_DEFERRED_FAMILIES) {
+          const count = state.offlineObservationsByFamily.get(family) ?? 0;
+          if (count > 0) deferredCounts.push({ family, count });
+        }
+        if (deferredCounts.length > 0) {
+          const summary = deferredCounts.map(d => `${d.family} (${d.count})`).join(', ');
+          results.push({
+            passed: true,
+            description:
+              'inverse coverage gap: offline resources observed for families the runner does not yet grade ' +
+              'on the inverse rule (creative and audience are graded; catalog_item and event_source are forward-only). ' +
+              `Observed: ${summary}.`,
+            observation_count: 0,
+          });
+        }
+      }
+
+      return results;
+    },
+  });
+
+  /**
+   * Dedicated status extractor for the resource families this invariant
+   * grades. Returns `(resource_type, resource_id, status)` triples for every
+   * shape the spec carries an offline value on. Independent of
+   * `status.monotonic`'s `extractStatusObservations` so the new offline
+   * statuses (`suspended`, `withdrawn`, `insufficient`) — which monotonic's
+   * graphs intentionally don't enumerate — are still observable here.
+   */
+  function extractImpairmentObservations(
+    task: string,
+    body: Record<string, unknown>
+  ): { resource_type: string; resource_id: string; status: string }[] {
+    const out: { resource_type: string; resource_id: string; status: string }[] = [];
+    if (task === 'sync_creatives' || task === 'list_creatives') {
+      for (const c of asArray(body.creatives)) {
+        if (!isObject(c)) continue;
+        const id = asString(c.creative_id);
+        const status = asString(c.status);
+        if (id && status) out.push({ resource_type: 'creative', resource_id: id, status });
+      }
+    } else if (task === 'sync_audiences') {
+      for (const a of asArray(body.audiences)) {
+        if (!isObject(a)) continue;
+        const id = asString(a.audience_id);
+        const status = asString(a.status);
+        if (id && status) out.push({ resource_type: 'audience', resource_id: id, status });
+      }
+    } else if (task === 'sync_catalogs' || task === 'list_catalogs') {
+      // Two response shapes: catalogs[].items[] (nested) or items[] (flat).
+      // Heterogeneous item ids — prefer `item_id` (spec-canonical), then
+      // `offering_id` (SI), `sku` (retail), else `id`. Matches the fallback
+      // chain in `pushCatalogItem`.
+      const collect = (item: Record<string, unknown>) => {
+        const id = asString(item.item_id) ?? asString(item.offering_id) ?? asString(item.sku) ?? asString(item.id);
+        const status = asString(item.status);
+        if (id && status) out.push({ resource_type: 'catalog_item', resource_id: id, status });
+      };
+      for (const cat of asArray(body.catalogs)) {
+        if (!isObject(cat)) continue;
+        for (const item of asArray(cat.items)) if (isObject(item)) collect(item);
+      }
+      for (const item of asArray(body.items)) if (isObject(item)) collect(item);
+    } else if (task === 'sync_event_sources') {
+      for (const es of asArray(body.event_sources)) {
+        if (!isObject(es)) continue;
+        const id = asString(es.event_source_id);
+        // event_source health lives under `health.status` per
+        // `core/event-source-health.json`; the top-level enum is
+        // `assessment-status.json` (`insufficient | minimum | good | excellent`).
+        const health = isObject(es.health) ? es.health : undefined;
+        const status = health ? asString(health.status) : undefined;
+        if (id && status) out.push({ resource_type: 'event_source', resource_id: id, status });
       }
     }
-
-    return results;
-  },
-});
-
-/**
- * Dedicated status extractor for the resource families this invariant
- * grades. Returns `(resource_type, resource_id, status)` triples for every
- * shape the spec carries an offline value on. Independent of
- * `status.monotonic`'s `extractStatusObservations` so the new offline
- * statuses (`suspended`, `withdrawn`, `insufficient`) — which monotonic's
- * graphs intentionally don't enumerate — are still observable here.
- */
-function extractImpairmentObservations(
-  task: string,
-  body: Record<string, unknown>
-): { resource_type: string; resource_id: string; status: string }[] {
-  const out: { resource_type: string; resource_id: string; status: string }[] = [];
-  if (task === 'sync_creatives' || task === 'list_creatives') {
-    for (const c of asArray(body.creatives)) {
-      if (!isObject(c)) continue;
-      const id = asString(c.creative_id);
-      const status = asString(c.status);
-      if (id && status) out.push({ resource_type: 'creative', resource_id: id, status });
-    }
-  } else if (task === 'sync_audiences') {
-    for (const a of asArray(body.audiences)) {
-      if (!isObject(a)) continue;
-      const id = asString(a.audience_id);
-      const status = asString(a.status);
-      if (id && status) out.push({ resource_type: 'audience', resource_id: id, status });
-    }
-  } else if (task === 'sync_catalogs' || task === 'list_catalogs') {
-    // Two response shapes: catalogs[].items[] (nested) or items[] (flat).
-    // Heterogeneous item ids — prefer `item_id` (spec-canonical), then
-    // `offering_id` (SI), `sku` (retail), else `id`. Matches the fallback
-    // chain in `pushCatalogItem`.
-    const collect = (item: Record<string, unknown>) => {
-      const id = asString(item.item_id) ?? asString(item.offering_id) ?? asString(item.sku) ?? asString(item.id);
-      const status = asString(item.status);
-      if (id && status) out.push({ resource_type: 'catalog_item', resource_id: id, status });
-    };
-    for (const cat of asArray(body.catalogs)) {
-      if (!isObject(cat)) continue;
-      for (const item of asArray(cat.items)) if (isObject(item)) collect(item);
-    }
-    for (const item of asArray(body.items)) if (isObject(item)) collect(item);
-  } else if (task === 'sync_event_sources') {
-    for (const es of asArray(body.event_sources)) {
-      if (!isObject(es)) continue;
-      const id = asString(es.event_source_id);
-      // event_source health lives under `health.status` per
-      // `core/event-source-health.json`; the top-level enum is
-      // `assessment-status.json` (`insufficient | minimum | good | excellent`).
-      const health = isObject(es.health) ? es.health : undefined;
-      const status = health ? asString(health.status) : undefined;
-      if (id && status) out.push({ resource_type: 'event_source', resource_id: id, status });
-    }
+    return out;
   }
-  return out;
-}
 
-/**
- * Extract every media-buy snapshot present on a step response. Walks
- * `create_media_buy` / `update_media_buy` (top-level buy object) and
- * `get_media_buys` (`media_buys[]` array). Returns each snapshot's
- * impairments[], health, status, the set of `creative_id`s the buy
- * references through `packages[].creative_assignments[]`, and the set of
- * `audience_id`s referenced through `packages[].targeting_overlay.audience_include[]`.
- * Both reference sets feed the inverse rule. `audience_exclude` is not
- * collected as a hard dependency for the inverse rule: an offline exclude
- * does not prevent the buy from serving, so it isn't a "buy can't function"
- * signal. Note this is a serviceability framing, not a safety framing —
- * an offline exclude can still silently break the suppression promise,
- * which is a separate (forward-looking) signal class.
- */
-function extractBuySnapshots(task: string, body: Record<string, unknown>, stepId: string): BuySnapshot[] {
-  const out: BuySnapshot[] = [];
-  if (task === 'create_media_buy' || task === 'update_media_buy') {
-    const snap = readBuySnapshot(body, stepId);
-    if (snap) out.push(snap);
-  } else if (task === 'get_media_buys') {
-    for (const mb of asArray(body.media_buys)) {
-      if (!isObject(mb)) continue;
-      const snap = readBuySnapshot(mb, stepId);
+  /**
+   * Extract every media-buy snapshot present on a step response. Walks
+   * `create_media_buy` / `update_media_buy` (top-level buy object) and
+   * `get_media_buys` (`media_buys[]` array). Returns each snapshot's
+   * impairments[], health, status, the set of `creative_id`s the buy
+   * references through `packages[].creative_assignments[]`, and the set of
+   * `audience_id`s referenced through `packages[].targeting_overlay.audience_include[]`.
+   * Both reference sets feed the inverse rule. `audience_exclude` is not
+   * collected as a hard dependency for the inverse rule: an offline exclude
+   * does not prevent the buy from serving, so it isn't a "buy can't function"
+   * signal. Note this is a serviceability framing, not a safety framing —
+   * an offline exclude can still silently break the suppression promise,
+   * which is a separate (forward-looking) signal class.
+   */
+  function extractBuySnapshots(task: string, body: Record<string, unknown>, stepId: string): BuySnapshot[] {
+    const out: BuySnapshot[] = [];
+    if (task === 'create_media_buy' || task === 'update_media_buy') {
+      const snap = readBuySnapshot(body, stepId);
       if (snap) out.push(snap);
-    }
-  }
-  return out;
-}
-
-function readBuySnapshot(record: Record<string, unknown>, stepId: string): BuySnapshot | undefined {
-  const media_buy_id = asString(record.media_buy_id);
-  if (!media_buy_id) return undefined;
-  const status = asString(record.status);
-  const health = asString(record.health);
-  const impairments: ImpairmentEntry[] = [];
-  for (const entry of asArray(record.impairments)) {
-    if (!isObject(entry)) continue;
-    const resource_type = asString(entry.resource_type);
-    const resource_id = asString(entry.resource_id);
-    if (!resource_type || !resource_id) continue;
-    impairments.push({ resource_type, resource_id });
-  }
-  const referencedCreativeIds = new Set<string>();
-  const referencedAudienceIds = new Set<string>();
-  for (const pkg of asArray(record.packages)) {
-    if (!isObject(pkg)) continue;
-    // Creative refs appear in two shapes on the wire:
-    //   - `core/package.json` → `creative_assignments[].creative_id` (used on
-    //     create_media_buy request/response, update_media_buy)
-    //   - `get-media-buys-response.json` → `creative_approvals[].creative_id`
-    //     (the snapshot shape — `creative_approvals` carries per-assignment
-    //     approval_status alongside the id)
-    // Walk both — sellers conformant to either schema surface the references
-    // we need for the inverse rule.
-    for (const ca of asArray(pkg.creative_assignments)) {
-      if (!isObject(ca)) continue;
-      const cid = asString(ca.creative_id);
-      if (cid) referencedCreativeIds.add(cid);
-    }
-    for (const ca of asArray(pkg.creative_approvals)) {
-      if (!isObject(ca)) continue;
-      const cid = asString(ca.creative_id);
-      if (cid) referencedCreativeIds.add(cid);
-    }
-    // Audience refs: only `audience_include` counts as a hard dependency
-    // for the inverse rule. `audience_exclude` is omitted on serviceability
-    // grounds — a suspended exclude doesn't keep the buy from serving — not
-    // on safety grounds. An offline exclude can still silently break the
-    // suppression promise; that's a separate signal class (see extractBuySnapshots).
-    const overlay = isObject(pkg.targeting_overlay) ? pkg.targeting_overlay : undefined;
-    if (overlay) {
-      for (const aid of asArray(overlay.audience_include)) {
-        if (typeof aid === 'string' && aid.length > 0) referencedAudienceIds.add(aid);
+    } else if (task === 'get_media_buys') {
+      for (const mb of asArray(body.media_buys)) {
+        if (!isObject(mb)) continue;
+        const snap = readBuySnapshot(mb, stepId);
+        if (snap) out.push(snap);
       }
     }
+    return out;
   }
-  return {
-    media_buy_id,
-    status,
-    health,
-    impairments,
-    referencedCreativeIds,
-    referencedAudienceIds,
-    stepId,
-  };
+
+  function readBuySnapshot(record: Record<string, unknown>, stepId: string): BuySnapshot | undefined {
+    const media_buy_id = asString(record.media_buy_id);
+    if (!media_buy_id) return undefined;
+    const status = asString(record.status);
+    const health = asString(record.health);
+    const impairments: ImpairmentEntry[] = [];
+    for (const entry of asArray(record.impairments)) {
+      if (!isObject(entry)) continue;
+      const resource_type = asString(entry.resource_type);
+      const resource_id = asString(entry.resource_id);
+      if (!resource_type || !resource_id) continue;
+      impairments.push({ resource_type, resource_id });
+    }
+    const referencedCreativeIds = new Set<string>();
+    const referencedAudienceIds = new Set<string>();
+    for (const pkg of asArray(record.packages)) {
+      if (!isObject(pkg)) continue;
+      // Creative refs appear in two shapes on the wire:
+      //   - `core/package.json` → `creative_assignments[].creative_id` (used on
+      //     create_media_buy request/response, update_media_buy)
+      //   - `get-media-buys-response.json` → `creative_approvals[].creative_id`
+      //     (the snapshot shape — `creative_approvals` carries per-assignment
+      //     approval_status alongside the id)
+      // Walk both — sellers conformant to either schema surface the references
+      // we need for the inverse rule.
+      for (const ca of asArray(pkg.creative_assignments)) {
+        if (!isObject(ca)) continue;
+        const cid = asString(ca.creative_id);
+        if (cid) referencedCreativeIds.add(cid);
+      }
+      for (const ca of asArray(pkg.creative_approvals)) {
+        if (!isObject(ca)) continue;
+        const cid = asString(ca.creative_id);
+        if (cid) referencedCreativeIds.add(cid);
+      }
+      // Audience refs: only `audience_include` counts as a hard dependency
+      // for the inverse rule. `audience_exclude` is omitted on serviceability
+      // grounds — a suspended exclude doesn't keep the buy from serving — not
+      // on safety grounds. An offline exclude can still silently break the
+      // suppression promise; that's a separate signal class (see extractBuySnapshots).
+      const overlay = isObject(pkg.targeting_overlay) ? pkg.targeting_overlay : undefined;
+      if (overlay) {
+        for (const aid of asArray(overlay.audience_include)) {
+          if (typeof aid === 'string' && aid.length > 0) referencedAudienceIds.add(aid);
+        }
+      }
+    }
+    return {
+      media_buy_id,
+      status,
+      health,
+      impairments,
+      referencedCreativeIds,
+      referencedAudienceIds,
+      stepId,
+    };
+  }
 }
+
+// Register on module load too, so merely importing this module (or a direct
+// `require('.../default-invariants')`) still registers the defaults —
+// preserving the historical side-effect-on-import behaviour. Idempotent via
+// the `REGISTERED` guard, so the explicit calls from the storyboard and
+// compliance entry points are harmless repeats.
+registerDefaultInvariants();

--- a/src/lib/testing/storyboard/index.ts
+++ b/src/lib/testing/storyboard/index.ts
@@ -10,10 +10,12 @@
 // Side-effect import: registers the default cross-step assertions that
 // upstream storyboards reference by id (idempotency.conflict_no_payload_leak,
 // context.no_secret_echo, governance.denial_blocks_mutation). Without this
-// import here, any `runStoryboard` call against a storyboard declaring
+// registration here, any `runStoryboard` call against a storyboard declaring
 // `invariants: [...]` would throw at start on unresolved ids. Consumers who
 // want to replace the defaults can `clearAssertionRegistry()` first.
-import './default-invariants';
+import { registerDefaultInvariants } from './default-invariants';
+
+registerDefaultInvariants();
 
 // Types
 export type {

--- a/src/lib/utils/global-async-local-storage.ts
+++ b/src/lib/utils/global-async-local-storage.ts
@@ -1,0 +1,23 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+/**
+ * Returns a process-global {@link AsyncLocalStorage} identified by `key`.
+ *
+ * The package ships both an ESM and a CommonJS build. If a single process
+ * loads both (some dependencies `import` @adcp/sdk while others `require` it),
+ * each build would otherwise construct its own `AsyncLocalStorage`. A
+ * `.run(...)` established on one copy is then invisible to a `.getStore()` on
+ * the other, so request-signing and response-capture context would silently
+ * disappear — requests could go out unsigned with no error. Anchoring the
+ * instance on the global symbol registry guarantees a single shared store no
+ * matter how many copies of this module exist.
+ */
+export function globalAsyncLocalStorage<T>(key: string): AsyncLocalStorage<T> {
+  const registryKey = Symbol.for(`@adcp/sdk.als.${key}`);
+  const registry = globalThis as unknown as Record<symbol, AsyncLocalStorage<T> | undefined>;
+  const existing = registry[registryKey];
+  if (existing) return existing;
+  const created = new AsyncLocalStorage<T>();
+  registry[registryKey] = created;
+  return created;
+}

--- a/src/lib/v2/format-schema/resolver.ts
+++ b/src/lib/v2/format-schema/resolver.ts
@@ -1,6 +1,13 @@
-import Ajv2019 from 'ajv/dist/2019';
+// Loaded via `require` (extension-lenient CJS resolution) rather than a
+// bare-specifier `import` — ajv ships no `exports` map, so Node's ESM resolver
+// would demand an explicit `ajv/dist/2019.js`. The ESM build gets a
+// `createRequire` shim, so `require` is available in both formats.
+const Ajv2019 = require('ajv/dist/2019') as typeof import('ajv/dist/2019').default;
 import addFormats from 'ajv-formats';
-import draft7MetaSchema from 'ajv/dist/refs/json-schema-draft-07.json';
+// Loaded via `require` (not a JSON `import`) so it resolves in both CJS and
+// ESM without a Node import attribute; the ESM build gets a `createRequire`
+// shim for this module.
+const draft7MetaSchema = require('ajv/dist/refs/json-schema-draft-07.json');
 import {
   fetchFormatSchema,
   FormatSchemaFetchError,

--- a/test/lib/brand-public-export.test.js
+++ b/test/lib/brand-public-export.test.js
@@ -44,9 +44,8 @@ describe('brand helpers public exports', () => {
 
   it('publishes runtime and declaration paths for @adcp/sdk/brand', () => {
     assert.deepStrictEqual(pkg.exports['./brand'], {
-      import: './dist/lib/brand/index.mjs',
-      require: './dist/lib/brand/index.js',
-      types: './dist/lib/brand/index.d.ts',
+      import: { types: './dist/lib/brand/index.d.mts', default: './dist/lib/brand/index.mjs' },
+      require: { types: './dist/lib/brand/index.d.ts', default: './dist/lib/brand/index.js' },
     });
     assert.deepStrictEqual(pkg.typesVersions['*'].brand, ['dist/lib/brand/index.d.ts']);
 

--- a/test/lib/brand-public-export.test.js
+++ b/test/lib/brand-public-export.test.js
@@ -44,7 +44,7 @@ describe('brand helpers public exports', () => {
 
   it('publishes runtime and declaration paths for @adcp/sdk/brand', () => {
     assert.deepStrictEqual(pkg.exports['./brand'], {
-      import: './dist/lib/brand/index.js',
+      import: './dist/lib/brand/index.mjs',
       require: './dist/lib/brand/index.js',
       types: './dist/lib/brand/index.d.ts',
     });

--- a/test/lib/canonical-reference-resolver.test.js
+++ b/test/lib/canonical-reference-resolver.test.js
@@ -553,7 +553,7 @@ describe('canonical reference resolver', () => {
     assert.strictEqual(typeof canonical.createCanonicalReferenceResolver, 'function');
     assert.strictEqual(sdk.createCanonicalReferenceResolver, canonical.createCanonicalReferenceResolver);
     assert.deepStrictEqual(pkg.exports['./canonical-references'], {
-      import: './dist/lib/canonical-references/index.js',
+      import: './dist/lib/canonical-references/index.mjs',
       require: './dist/lib/canonical-references/index.js',
       types: './dist/lib/canonical-references/index.d.ts',
     });

--- a/test/lib/canonical-reference-resolver.test.js
+++ b/test/lib/canonical-reference-resolver.test.js
@@ -553,9 +553,14 @@ describe('canonical reference resolver', () => {
     assert.strictEqual(typeof canonical.createCanonicalReferenceResolver, 'function');
     assert.strictEqual(sdk.createCanonicalReferenceResolver, canonical.createCanonicalReferenceResolver);
     assert.deepStrictEqual(pkg.exports['./canonical-references'], {
-      import: './dist/lib/canonical-references/index.mjs',
-      require: './dist/lib/canonical-references/index.js',
-      types: './dist/lib/canonical-references/index.d.ts',
+      import: {
+        types: './dist/lib/canonical-references/index.d.mts',
+        default: './dist/lib/canonical-references/index.mjs',
+      },
+      require: {
+        types: './dist/lib/canonical-references/index.d.ts',
+        default: './dist/lib/canonical-references/index.js',
+      },
     });
     assert.deepStrictEqual(pkg.typesVersions['*']['canonical-references'], [
       'dist/lib/canonical-references/index.d.ts',

--- a/test/lib/net-public-export.test.js
+++ b/test/lib/net-public-export.test.js
@@ -35,7 +35,7 @@ describe('net SSRF helpers public exports', () => {
 
   it('publishes runtime and declaration paths for @adcp/sdk/net', () => {
     assert.deepStrictEqual(pkg.exports['./net'], {
-      import: './dist/lib/net/index.js',
+      import: './dist/lib/net/index.mjs',
       require: './dist/lib/net/index.js',
       types: './dist/lib/net/index.d.ts',
     });

--- a/test/lib/net-public-export.test.js
+++ b/test/lib/net-public-export.test.js
@@ -35,9 +35,8 @@ describe('net SSRF helpers public exports', () => {
 
   it('publishes runtime and declaration paths for @adcp/sdk/net', () => {
     assert.deepStrictEqual(pkg.exports['./net'], {
-      import: './dist/lib/net/index.mjs',
-      require: './dist/lib/net/index.js',
-      types: './dist/lib/net/index.d.ts',
+      import: { types: './dist/lib/net/index.d.mts', default: './dist/lib/net/index.mjs' },
+      require: { types: './dist/lib/net/index.d.ts', default: './dist/lib/net/index.js' },
     });
     assert.deepStrictEqual(pkg.typesVersions['*'].net, ['dist/lib/net/index.d.ts']);
 

--- a/test/lib/state-machine-scenarios.test.js
+++ b/test/lib/state-machine-scenarios.test.js
@@ -66,7 +66,7 @@ describe('State machine scenario routing in agent-tester', () => {
     const fs = require('node:fs');
     const path = require('node:path');
     const src = fs.readFileSync(path.join(__dirname, '../../dist/lib/testing/agent-tester.js'), 'utf8');
-    assert.ok(src.includes("'media_buy_lifecycle'"), 'should route media_buy_lifecycle');
+    assert.ok(src.includes('media_buy_lifecycle'), 'should route media_buy_lifecycle');
     assert.ok(src.includes('testMediaBuyLifecycle'), 'should call testMediaBuyLifecycle');
   });
 
@@ -74,7 +74,7 @@ describe('State machine scenario routing in agent-tester', () => {
     const fs = require('node:fs');
     const path = require('node:path');
     const src = fs.readFileSync(path.join(__dirname, '../../dist/lib/testing/agent-tester.js'), 'utf8');
-    assert.ok(src.includes("'terminal_state_enforcement'"), 'should route terminal_state_enforcement');
+    assert.ok(src.includes('terminal_state_enforcement'), 'should route terminal_state_enforcement');
     assert.ok(src.includes('testTerminalStateEnforcement'), 'should call testTerminalStateEnforcement');
   });
 
@@ -82,7 +82,7 @@ describe('State machine scenario routing in agent-tester', () => {
     const fs = require('node:fs');
     const path = require('node:path');
     const src = fs.readFileSync(path.join(__dirname, '../../dist/lib/testing/agent-tester.js'), 'utf8');
-    assert.ok(src.includes("'package_lifecycle'"), 'should route package_lifecycle');
+    assert.ok(src.includes('package_lifecycle'), 'should route package_lifecycle');
     assert.ok(src.includes('testPackageLifecycle'), 'should call testPackageLifecycle');
   });
 });

--- a/test/lib/v2-5-types-import.test.js
+++ b/test/lib/v2-5-types-import.test.js
@@ -60,6 +60,7 @@ describe('v2.5 type bundle', () => {
     const pkg = require('../../package.json');
     const exp = pkg.exports?.['./types/v2-5'];
     assert.ok(exp, 'package.json must export `./types/v2-5`');
-    assert.match(exp.types, /v2-5\/index\.d\.ts$/);
+    assert.match(exp.require.types, /v2-5\/index\.d\.ts$/);
+    assert.match(exp.import.types, /v2-5\/index\.d\.mts$/);
   });
 });

--- a/test/lib/v3-scenarios.test.js
+++ b/test/lib/v3-scenarios.test.js
@@ -124,7 +124,7 @@ describe('testAgent routes new scenarios', () => {
     const fs = require('node:fs');
     const path = require('node:path');
     const src = fs.readFileSync(path.join(__dirname, '../../dist/lib/testing/agent-tester.js'), 'utf8');
-    assert.ok(src.includes("'property_list_filters'"), 'agent-tester should route property_list_filters');
+    assert.ok(src.includes('property_list_filters'), 'agent-tester should route property_list_filters');
     assert.ok(src.includes('testPropertyListFilters'), 'agent-tester should call testPropertyListFilters');
   });
 
@@ -132,7 +132,7 @@ describe('testAgent routes new scenarios', () => {
     const fs = require('node:fs');
     const path = require('node:path');
     const src = fs.readFileSync(path.join(__dirname, '../../dist/lib/testing/agent-tester.js'), 'utf8');
-    assert.ok(src.includes("'si_handoff'"), 'agent-tester should route si_handoff');
+    assert.ok(src.includes('si_handoff'), 'agent-tester should route si_handoff');
     assert.ok(src.includes('testSIHandoff'), 'agent-tester should call testSIHandoff');
   });
 
@@ -140,7 +140,7 @@ describe('testAgent routes new scenarios', () => {
     const fs = require('node:fs');
     const path = require('node:path');
     const src = fs.readFileSync(path.join(__dirname, '../../dist/lib/testing/agent-tester.js'), 'utf8');
-    assert.ok(src.includes("'schema_compliance'"), 'agent-tester should route schema_compliance');
+    assert.ok(src.includes('schema_compliance'), 'agent-tester should route schema_compliance');
     assert.ok(src.includes('testSchemaCompliance'), 'agent-tester should call testSchemaCompliance');
   });
 });

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "paths": {}
+  }
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,0 +1,102 @@
+import { existsSync } from 'node:fs';
+import * as nodePath from 'node:path';
+import { defineConfig } from 'tsup';
+import { fixImportsPlugin } from 'esbuild-fix-imports-plugin';
+
+// Companion to `fixImportsPlugin`: that plugin rewrites static `from '...'` and
+// `require('...')` specifiers, but not dynamic `import('...')`. Under
+// `bundle: false` those stay extensionless, so a lazy `await import('../x')`
+// throws ERR_MODULE_NOT_FOUND at runtime. Mirror the same fix for dynamic
+// imports — append the format extension, or `/index` for a directory target.
+// (Kept as dynamic imports rather than converted to static, so the heavy
+// modules they load stay out of the eager graph and remain tree-shakeable.)
+function fixDynamicImportExtensions() {
+  return {
+    name: 'fix-dynamic-import-extensions',
+    setup(build: import('esbuild').PluginBuild) {
+      const ext = build.initialOptions.format === 'esm' ? '.mjs' : '.js';
+      build.onEnd(result => {
+        for (const file of result.outputFiles ?? []) {
+          if (!file.path.endsWith(ext)) continue;
+          // bundle:false preserves the tree, so the output file maps 1:1 to a
+          // source file; resolve specifiers against the source dir.
+          const srcDir = nodePath.dirname(
+            file.path.replace(
+              `${nodePath.sep}dist${nodePath.sep}lib${nodePath.sep}`,
+              `${nodePath.sep}src${nodePath.sep}lib${nodePath.sep}`
+            )
+          );
+          const code = Buffer.from(file.contents).toString('utf8');
+          const next = code.replace(/import\(\s*(["'])(\.[^"']+)\1\s*\)/g, (match, quote, spec) => {
+            if (/\.(mjs|cjs|js|json|node|wasm)$/.test(spec)) return match;
+            const abs = nodePath.resolve(srcDir, spec);
+            if (existsSync(`${abs}.ts`)) return `import(${quote}${spec}${ext}${quote})`;
+            if (existsSync(nodePath.join(abs, 'index.ts'))) return `import(${quote}${spec}/index${ext}${quote})`;
+            return match;
+          });
+          if (next !== code) file.contents = Buffer.from(next);
+        }
+      });
+    },
+  };
+}
+
+// Build the library as a tree-shakeable dual package.
+//
+// `bundle: false` transpiles each source module 1:1 (no bundling, no chunks),
+// so the output mirrors the source tree exactly. That keeps three things
+// correct with zero extra work:
+//   1. a consumer's bundler tree-shakes across the preserved module graph when
+//      it imports from a public entry (importing one symbol stays lean),
+//   2. the CLI and internal tooling that deep-`require` dist paths still
+//      resolve, and
+//   3. the `__dirname`-based schema-data lookups keep their original directory
+//      depth (each module stays at its own path).
+//
+// `fixImportsPlugin` (see tsup#1240) supplies what `bundle: false` leaves out:
+// it appends the correct extension to relative imports, rewrites directory
+// imports to `/index`, and resolves tsconfig path aliases. Its alias step is
+// neutralised by pointing the build at a paths-free tsconfig (below), because
+// the only `paths` entry (`structured-headers`) is a typecheck-only pin to the
+// package's CJS type file and must stay a bare external import at runtime.
+// Declarations are emitted separately by `tsc --emitDeclarationOnly`.
+export default defineConfig({
+  entry: ['src/lib/**/*.ts', '!src/lib/**/*.test.ts', '!src/lib/**/*.d.ts', '!src/lib/**/*.type-checks.ts'],
+  outDir: 'dist/lib',
+  format: ['esm', 'cjs'],
+  target: 'es2022',
+  platform: 'node',
+  bundle: false,
+  // A paths-free tsconfig so the import-fixer's alias resolution is a no-op.
+  // The only `paths` entry (`structured-headers`) is a typecheck-only pin;
+  // at runtime it must stay a bare external import, not a rewritten path.
+  tsconfig: 'tsconfig.build.json',
+  sourcemap: true,
+  clean: true,
+  dts: false,
+  // Not tsup's `shims: true`: with many entries it emits `__dirname` once in a
+  // shared chunk (resolving to the chunk's dir, not each module's). The banner
+  // below is inlined into every ESM file, so `import.meta.url` — and therefore
+  // `__dirname` — is correct per file. CJS keeps the native globals.
+  shims: false,
+  esbuildOptions(options, context) {
+    if (context.format === 'esm') {
+      options.banner = {
+        js: [
+          "import { fileURLToPath as __adcpFileURLToPath } from 'node:url';",
+          "import { dirname as __adcpDirname } from 'node:path';",
+          "import { createRequire as __adcpCreateRequire } from 'node:module';",
+          'const __filename = __adcpFileURLToPath(import.meta.url);',
+          'const __dirname = __adcpDirname(__filename);',
+          'const require = __adcpCreateRequire(import.meta.url);',
+        ].join('\n'),
+      };
+    }
+  },
+  // ESM → .mjs (the `import` condition), CJS → .js (the `require` condition and
+  // the CLI's `require('../dist/lib/...')`). The package stays `type: commonjs`.
+  outExtension({ format }) {
+    return { js: format === 'esm' ? '.mjs' : '.js' };
+  },
+  esbuildPlugins: [fixImportsPlugin(), fixDynamicImportExtensions()],
+});


### PR DESCRIPTION
## What this does (#2344)

Makes `@adcp/sdk` tree-shakeable: ships a **dual ESM + CJS** build and marks the package `sideEffects`-aware, so importing one symbol no longer drags in the whole library. `require('@adcp/sdk')` and the CLI keep working. Major version (the `exports` map changes for every consumer).

**The win (measured):** `import { EventTypeValues } from '@adcp/sdk/types'` → **~0.6 KB, zod absent** (was **~1.9 MB with zod**).

## Status — all green ✅

| check | result |
|---|---|
| Fast test gate | 12,519 pass / 0 fail |
| Slow / CLI tests | 50 pass / 0 fail |
| typecheck, build, ESM+CJS runtime, CLI | pass |

## How it works

- **tsup** with `bundle: false` → one output file per source module (mirrors the old `tsc` layout, so tree-shaking works across the preserved graph and the CLI/tests that deep-import build internals still resolve).
- `esbuild-fix-imports-plugin` adds ESM import extensions + directory `/index` resolution; a small companion plugin does the same for **dynamic `import()`** (the standard plugin misses those, which is what caused lazy `await import()` to fail — now fixed).
- An ESM banner supplies per-file `__dirname` / `require` from `import.meta.url` (per-file, not a shared shim chunk).
- `exports`: `import` → `.mjs`, `require` → `.js`, `types` → `.d.ts`. `type` stays `commonjs`. Declarations via `tsc --emitDeclarationOnly`.
- **Dual-package safety:** the request-signing and response-capture `AsyncLocalStorage` stores are anchored on the global symbol registry (a process that loads both builds shares one instance — no silently-unsigned requests); the verified-signature brand uses `Symbol.for`.
- Default invariants register via an explicit `registerDefaultInvariants()` (plus a load-time self-call) instead of a bare side-effect import, so bundlers can't drop them.

## Notes for review

- Build tool is **tsup** (the standard choice). rollup `preserveModules` was evaluated as an alternative and also works; tsup wins on config simplicity.
- `default-invariants.ts` shows a large diff — it's a mechanical wrap of the existing registrations into `registerDefaultInvariants()` (review with `git diff -w`).
