### PR TITLE
fix: make schema-sync directory renames EXDEV-safe for docker builds

### DIFF
--- a/scripts/sync-schemas.ts
+++ b/scripts/sync-schemas.ts
@@ -13,6 +13,7 @@ import {
   symlinkSync,
   renameSync,
   copyFileSync,
+  cpSync,
 } from 'fs';
 import { mkdtempSync } from 'fs';
 import { createHash } from 'crypto';
@@ -102,6 +103,22 @@ function normalizeRefsInTree(dir: string, semanticVersion: string): void {
   }
 }
 
+/**
+ * renameSync that survives EXDEV. Inside `docker build`, /app is overlayfs and
+ * a directory that came from a lower image layer (e.g. via `COPY . .`) cannot
+ * be renamed — the kernel returns EXDEV even though src and dest are on the
+ * same mount. Fall back to copy + delete, which overlayfs handles fine.
+ */
+function moveTreeSync(src: string, dest: string): void {
+  try {
+    renameSync(src, dest);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'EXDEV') throw err;
+    cpSync(src, dest, { recursive: true });
+    rmSync(src, { recursive: true, force: true });
+  }
+}
+
 function replaceTree(srcDir: string, destDir: string): void {
   if (!existsSync(srcDir)) {
     throw new Error(`Expected tarball entry ${srcDir} is missing.`);
@@ -119,11 +136,11 @@ function replaceTree(srcDir: string, destDir: string): void {
         rmSync(snapshotDir, { recursive: true, force: true });
       }
     }
-    renameSync(destDir, snapshotDir);
+    moveTreeSync(destDir, snapshotDir);
     console.log(`📸 Previous tree snapshotted → ${snapshotDir}`);
   }
   mkdirSync(path.dirname(destDir), { recursive: true });
-  renameSync(srcDir, destDir);
+  moveTreeSync(srcDir, destDir);
 }
 
 function updateLatestSymlink(cacheRoot: string, version: string): void {
@@ -251,7 +268,7 @@ function copySkillTree(srcDir: string, destDir: string): void {
     // schema-diff helper can pick up changes between syncs.
     const previous = `${destDir}.previous`;
     if (existsSync(previous)) rmSync(previous, { recursive: true, force: true });
-    renameSync(destDir, previous);
+    moveTreeSync(destDir, previous);
   }
   mkdirSync(destDir, { recursive: true });
   copyTreeFiltered(srcDir, destDir);
@@ -600,7 +617,10 @@ async function sync(version?: string, options: { includeSharedSurfaces?: boolean
     if (ADCP_BASE_URL !== DEFAULT_ADCP_BASE_URL || process.env.ADCP_GITHUB_FALLBACK === '0') {
       throw err;
     }
-    console.warn(`⚠️  AdCP ${adcpVersion} was not reachable from adcontextprotocol.org; retrying against GitHub dist.`);
+    console.warn(
+      `⚠️  Sync from adcontextprotocol.org failed for AdCP ${adcpVersion}; retrying against GitHub dist. ` +
+        `Original error: ${err instanceof Error ? err.message : err}`
+    );
     await syncWithBase(GITHUB_DIST_BASE_URL);
   }
 


### PR DESCRIPTION
## Problem

`npm run sync-schemas` (and therefore `schemas:ensure` / `build:lib`) fails inside any `docker build` where the schema cache is not pre-populated.

During an image build, the working tree is overlayfs. `renameSync` on a directory that came from a lower image layer (e.g. via `COPY . .`) fails with `EXDEV: cross-device link not permitted` even though src and dest are on the same mount — overlayfs cannot rename lower-layer directories. This hits `copySkillTree` when it snapshots an existing skill dir (`skills/adcp-brand` -> `skills/adcp-brand.previous`) and can equally hit `replaceTree`.

The failure is then misreported: the catch in `sync()` swallows the error and prints `AdCP <version> was not reachable from adcontextprotocol.org`, and the GitHub-dist fallback 404s (no `dist/` on `main`), so the build dies with a misleading network error. Bind mounts and normal checkouts are unaffected, which makes this look flaky/environment-specific.

## Fix

- Add `moveTreeSync`: try `renameSync`, and on `EXDEV` fall back to `cpSync(recursive)` + `rmSync` — overlayfs handles copy+delete fine. Used at all three directory-rename sites (`replaceTree` x2, `copySkillTree`).
- Include the original error message in the GitHub-dist fallback warning so extraction failures are no longer misreported as network failures.

## Notes

- `scripts/`-only change (dev tooling, not published in `files`), so no changeset per CONTRIBUTING policy — happy to add one if you want it anyway.
- Repro: `docker build` a context containing the repo, run `npm run sync-schemas` with an empty `schemas/cache/`. Verified fixed in node:22-alpine builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)