### PR TITLE
feat: add per-PR npm beta releases via beta-release label

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,9 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@adcp/client"]
+  "ignore": ["@adcp/client"],
+  "snapshot": {
+    "useCalculatedVersion": true,
+    "prereleaseTemplate": "{tag}-{commit}"
+  }
 }

--- a/.changeset/tiny-deserts-build.md
+++ b/.changeset/tiny-deserts-build.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add a `beta-release` PR label that publishes a one-off npm snapshot prerelease of the labeled PR under a `pr-<N>` dist-tag for end-to-end testing before merge. No library behavior change — CI/tooling only.

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -2,7 +2,7 @@ name: Beta Release
 
 on:
   pull_request:
-    types: [labeled, synchronize, closed]
+    types: [labeled, unlabeled, synchronize, closed]
 
 concurrency:
   group: beta-release-${{ github.event.pull_request.number }}
@@ -11,34 +11,55 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  BETA_TAG: pr-${{ github.event.pull_request.number }}
+
 jobs:
   publish:
     name: Publish PR snapshot
-    if: ${{ github.event.action != 'closed' && contains(github.event.pull_request.labels.*.name, 'beta-release') && github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.event.action != 'closed' && github.event.action != 'unlabeled' && contains(github.event.pull_request.labels.*.name, 'beta-release') && github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
       id-token: write
-    env:
-      BETA_TAG: pr-${{ github.event.pull_request.number }}
     steps:
       - name: Checkout PR head
         uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
+      - name: Reject incompatible Changesets pre-release mode
+        run: |
+          if [ -f .changeset/pre.json ] && [ "$(jq -r '.mode' .changeset/pre.json)" = "pre" ]; then
+            echo "::error::main is currently in Changesets pre-release mode (a long-lived beta channel is active — see docs/development/v8.0-beta-plan.md). Per-PR snapshot releases are not supported while pre-release mode is active."
+            exit 1
+          fi
+
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
 
       - name: Install Dependencies
         run: npm ci
 
+      - name: Capture pre-snapshot version
+        id: pre_version
+        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
       - name: Version snapshot
         run: npx changeset version --snapshot "$BETA_TAG"
+
+      - name: Verify snapshot bumped the version
+        run: |
+          NEW_VERSION="$(node -p "require('./package.json').version")"
+          if [ "$NEW_VERSION" = "${{ steps.pre_version.outputs.version }}" ]; then
+            echo "::error::No changeset (or only empty changesets) found on this PR, so the snapshot version was not bumped and there is nothing to publish. Add a real changeset with 'npm run changeset' and push again."
+            exit 1
+          fi
 
       - name: Build
         run: npm run build:lib
@@ -68,12 +89,13 @@ jobs:
               'Promotion to an official release happens by merging this PR normally — ' +
               'the real version is cut fresh by the standard release flow, not by retagging this build.';
 
-            const { data: comments } = await github.rest.issues.listComments({
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
+              per_page: 100,
             });
-            const existing = comments.find(c => c.body.includes(marker));
+            const existing = comments.find(c => (c.body || '').includes(marker));
 
             if (existing) {
               await github.rest.issues.updateComment({
@@ -93,7 +115,7 @@ jobs:
 
   cleanup:
     name: Remove PR dist-tag
-    if: ${{ github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'beta-release') }}
+    if: ${{ (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'beta-release')) || (github.event.action == 'unlabeled' && github.event.label.name == 'beta-release') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -109,6 +131,6 @@ jobs:
 
       - name: Remove pr-<N> dist-tag
         if: ${{ env.HAS_DIST_TAG_TOKEN == 'true' }}
-        run: npm dist-tag rm @adcp/sdk "pr-${{ github.event.pull_request.number }}" || true
+        run: npm dist-tag rm @adcp/sdk "$BETA_TAG" || true
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_DIST_TAG_TOKEN }}

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -1,0 +1,114 @@
+name: Beta Release
+
+on:
+  pull_request:
+    types: [labeled, synchronize, closed]
+
+concurrency:
+  group: beta-release-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish PR snapshot
+    if: ${{ github.event.action != 'closed' && contains(github.event.pull_request.labels.*.name, 'beta-release') && github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    env:
+      BETA_TAG: pr-${{ github.event.pull_request.number }}
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Version snapshot
+        run: npx changeset version --snapshot "$BETA_TAG"
+
+      - name: Build
+        run: npm run build:lib
+
+      - name: Publish snapshot to npm
+        id: publish
+        run: |
+          ADCP_NPM_TAG="$BETA_TAG" npm run release
+          echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+        env:
+          NPM_CONFIG_PROVENANCE: true
+
+      - name: Comment install instructions
+        uses: actions/github-script@v7
+        env:
+          BETA_VERSION: ${{ steps.publish.outputs.version }}
+        with:
+          script: |
+            const marker = '<!-- beta-release-bot -->';
+            const { BETA_TAG, BETA_VERSION } = process.env;
+            const body = `${marker}\n### Beta release published\n\n` +
+              `\`@adcp/sdk@${BETA_VERSION}\` was published under the \`${BETA_TAG}\` npm dist-tag.\n\n` +
+              '```sh\n' +
+              `npm install @adcp/sdk@${BETA_TAG}\n` +
+              '```\n\n' +
+              'This snapshot is republished on every push while the `beta-release` label is attached. ' +
+              'Promotion to an official release happens by merging this PR normally — ' +
+              'the real version is cut fresh by the standard release flow, not by retagging this build.';
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+  cleanup:
+    name: Remove PR dist-tag
+    if: ${{ github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'beta-release') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      HAS_DIST_TAG_TOKEN: ${{ secrets.NPM_DIST_TAG_TOKEN != '' }}
+    steps:
+      - name: Setup Node.js
+        if: ${{ env.HAS_DIST_TAG_TOKEN == 'true' }}
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Remove pr-<N> dist-tag
+        if: ${{ env.HAS_DIST_TAG_TOKEN == 'true' }}
+        run: npm dist-tag rm @adcp/sdk "pr-${{ github.event.pull_request.number }}" || true
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_DIST_TAG_TOKEN }}

--- a/docs/development/NPM-DIST-TAGS.md
+++ b/docs/development/NPM-DIST-TAGS.md
@@ -53,7 +53,10 @@ The `beta-release.yml` workflow publishes this automatically under the
 `pr-<N>` dist-tag using a Changesets snapshot release (`changeset version
 --snapshot` + `changeset publish --tag`), reusing `scripts/publish-adcp-release.ts`
 via `ADCP_NPM_TAG`. It republishes on every push while the label stays
-attached, and comments the resolved version and install command on the PR.
+attached, and comments the resolved version and install command on the PR. A
+PR without a real changeset (or with only an empty one) fails this step
+loudly instead of silently publishing nothing — add one with `npm run
+changeset` first.
 
 **Promotion is just merging the PR normally.** There is no separate promote
 step: the real `latest` version is cut fresh by the existing `release.yml` +
@@ -61,11 +64,18 @@ Changesets flow from whatever lands on `main`, which is not guaranteed to be
 byte-identical to the last snapshot build if other PRs merge into the same
 release batch first.
 
-Cleanup of the `pr-<N>` dist-tag on PR close is best-effort — it requires an
-`NPM_DIST_TAG_TOKEN` secret (dist-tag removal isn't covered by OIDC trusted
-publishing, same limitation as above) and silently no-ops if that secret isn't
-configured. Stale `pr-<N>` tags left behind are harmless registry clutter, not
-a functional problem.
+The `pr-<N>` dist-tag is removed when the PR closes with the `beta-release`
+label still attached, or immediately if the label is removed before that.
+Cleanup is best-effort — it requires an `NPM_DIST_TAG_TOKEN` secret (dist-tag
+removal isn't covered by OIDC trusted publishing, same limitation as above)
+and silently no-ops if that secret isn't configured. Stale `pr-<N>` tags left
+behind are harmless registry clutter, not a functional problem.
+
+Per-PR snapshots are incompatible with Changesets pre-release mode
+(`.changeset/pre.json` with `mode: "pre"`) — the workflow detects this and
+fails with an explicit error rather than letting `changeset version
+--snapshot` throw an opaque one. This mechanism is unavailable for the
+duration of any long-lived beta channel cut with the pattern below.
 
 This is a different mechanism from the long-lived beta-channel pattern
 described in [`v8.0-beta-plan.md`](./v8.0-beta-plan.md) (a dedicated

--- a/docs/development/NPM-DIST-TAGS.md
+++ b/docs/development/NPM-DIST-TAGS.md
@@ -39,3 +39,38 @@ Changesets pre-mode normally uses the pre-mode tag for both the npm dist-tag and
 the semver prerelease identifier. The release wrapper keeps that pre-mode tag
 unless `ADCP_NPM_TAG` is set. That prevents prereleases from moving `latest`
 accidentally.
+
+## Per-PR Beta Releases
+
+Add the `beta-release` label to a PR to get an installable npm build of that
+PR's exact code, for end-to-end testing before merge:
+
+```sh
+npm install @adcp/sdk@pr-<N>   # N is the PR number
+```
+
+The `beta-release.yml` workflow publishes this automatically under the
+`pr-<N>` dist-tag using a Changesets snapshot release (`changeset version
+--snapshot` + `changeset publish --tag`), reusing `scripts/publish-adcp-release.ts`
+via `ADCP_NPM_TAG`. It republishes on every push while the label stays
+attached, and comments the resolved version and install command on the PR.
+
+**Promotion is just merging the PR normally.** There is no separate promote
+step: the real `latest` version is cut fresh by the existing `release.yml` +
+Changesets flow from whatever lands on `main`, which is not guaranteed to be
+byte-identical to the last snapshot build if other PRs merge into the same
+release batch first.
+
+Cleanup of the `pr-<N>` dist-tag on PR close is best-effort — it requires an
+`NPM_DIST_TAG_TOKEN` secret (dist-tag removal isn't covered by OIDC trusted
+publishing, same limitation as above) and silently no-ops if that secret isn't
+configured. Stale `pr-<N>` tags left behind are harmless registry clutter, not
+a functional problem.
+
+This is a different mechanism from the long-lived beta-channel pattern
+described in [`v8.0-beta-plan.md`](./v8.0-beta-plan.md) (a dedicated
+`release/*-beta` branch in Changesets pre-release mode, publishing
+`X.Y.Z-beta.N` under a shared `beta` tag across many PRs, promoted via
+`changeset pre exit`). Use per-PR snapshots to validate one change in
+isolation; use the pre-release-mode pattern for a sustained beta line ahead of
+a major/minor GA.


### PR DESCRIPTION
## Why
There was no way to publish a testable npm build of a specific PR before merging it, so changes could only be validated after they'd already landed on `main` and shipped to `latest`.

## What Changed
Adds a `beta-release.yml` workflow: labeling a PR `beta-release` publishes a Changesets snapshot prerelease of that PR's exact code under a `pr-<N>` npm dist-tag (reusing the existing `scripts/publish-adcp-release.ts` release script via `ADCP_NPM_TAG`), republishing on every push and commenting install instructions on the PR. Promotion is just merging the PR normally — the real `latest` version is cut fresh by the existing changesets + `release.yml` flow. Includes a best-effort dist-tag cleanup job (gated on an `NPM_DIST_TAG_TOKEN` secret still to be provisioned), guards against no-op publishes when a PR is missing a real changeset, and rejects running during Changesets pre-release mode. Docs added to `docs/development/NPM-DIST-TAGS.md` distinguishing this from the existing long-lived beta-channel pattern in `v8.0-beta-plan.md`.

## Note
`NPM_DIST_TAG_TOKEN` (for dist-tag cleanup) and npm trusted-publisher registration for `beta-release.yml` (alongside the existing `release.yml` entry) still need to be provisioned on npmjs.com before this fully works end-to-end.