### PR TITLE
feat(server): expose MCP App metadata for custom tools

### DIFF
--- a/.changeset/quiet-tools-render.md
+++ b/.changeset/quiet-tools-render.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Add typed MCP App metadata to custom tools and forward it through modern MCP tool discovery.

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1022,6 +1022,8 @@ export type {
   AdcpServerToolName,
   AdcpCapabilitiesConfig,
   AdcpCustomToolConfig,
+  McpAppUiMeta,
+  McpAppMeta,
   AdcpLogger,
   HandlerContext,
   MediaBuyHandlers,

--- a/src/lib/server/adcp-server.type-checks.ts
+++ b/src/lib/server/adcp-server.type-checks.ts
@@ -6,7 +6,7 @@
 // Run with `npm run typecheck`.
 
 import type { AdcpServer } from './adcp-server';
-import type { MediaBuyHandlers } from './create-adcp-server';
+import type { AdcpCustomToolConfig, McpAppMeta, MediaBuyHandlers } from './create-adcp-server';
 
 // ── Plain object with same structural shape isn't an AdcpServer ──────────
 
@@ -56,9 +56,36 @@ function _legacy_media_buy_handlers_accept_payload_returns(): MediaBuyHandlers {
   };
 }
 
+// ── MCP App metadata is strict and portable ─────────────────────────────
+
+const _validMcpAppMeta: McpAppMeta = {
+  ui: { resourceUri: 'ui://creative/upload', visibility: ['model', 'app'] },
+};
+
+const _customToolWithMcpAppMeta: AdcpCustomToolConfig = {
+  _meta: _validMcpAppMeta,
+  handler: async () => ({ content: [] }),
+};
+
+const _invalidMcpAppMeta: McpAppMeta = {
+  ui: {
+    // @ts-expect-error — only model and app are supported visibility values.
+    visibility: ['server'],
+  },
+};
+
+const _flatMcpAppMeta: McpAppMeta = {
+  // @ts-expect-error — MCP App metadata uses the nested ui.resourceUri shape.
+  'ui.resourceUri': 'ui://creative/upload',
+};
+
 export const _references = [
   _imitationCannotBeAdcpServer,
   _registerToolNotOnAdcpServer,
   _adcpServerCallSitesStillWork,
   _legacy_media_buy_handlers_accept_payload_returns,
+  _validMcpAppMeta,
+  _customToolWithMcpAppMeta,
+  _invalidMcpAppMeta,
+  _flatMcpAppMeta,
 ] as const;

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -1272,6 +1272,19 @@ export type AdcpPreTransport = (
 // Custom tool config
 // ---------------------------------------------------------------------------
 
+/** UI hints for a custom tool backed by an MCP App. */
+export interface McpAppUiMeta {
+  /** URI of the MCP App resource rendered when the tool is invoked. */
+  resourceUri?: string;
+  /** Audiences a compliant host exposes the tool to. Routing metadata, not authorization. */
+  visibility?: Array<'model' | 'app'>;
+}
+
+/** Typed MCP App metadata forwarded unchanged in `tools/list`. */
+export interface McpAppMeta {
+  ui?: McpAppUiMeta;
+}
+
 /**
  * Declarative registration for a tool outside {@link AdcpToolMap} — seller
  * extensions (e.g. collection-list helpers), test-harness endpoints
@@ -1318,6 +1331,8 @@ export interface AdcpCustomToolConfig<
   outputSchema?: OutputArgs;
   /** Tool annotations (readOnlyHint / destructiveHint / idempotentHint / openWorldHint). */
   annotations?: ToolAnnotations;
+  /** Portable MCP App metadata surfaced unchanged in `tools/list`. */
+  _meta?: McpAppMeta;
   /**
    * Tool handler. Gets SDK-validated `args` based on `inputSchema` and
    * must return a `CallToolResult`. Use `capabilitiesResponse`,
@@ -6097,7 +6112,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
       }
       const custom = config.customTools[customName];
       if (!custom) continue;
-      const { description, title, inputSchema, outputSchema, annotations, handler } = custom;
+      const { description, title, inputSchema, outputSchema, annotations, _meta, handler } = custom;
       // Wrap the adopter-supplied handler so `throw new AdcpError(...)` and
       // `throw adcpError(...)` from inside it project to the typed envelope —
       // matching the behavior framework-registered tools get from the catch
@@ -6122,6 +6137,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
           ...(inputSchema != null && { inputSchema }),
           ...(outputSchema != null && { outputSchema }),
           ...(annotations != null && { annotations }),
+          ...(_meta != null && { _meta }),
         } as Parameters<typeof server.registerTool>[1],
         wrappedHandler
       );

--- a/src/lib/server/index.ts
+++ b/src/lib/server/index.ts
@@ -351,6 +351,8 @@ export type {
   AdcpCapabilitiesConfig,
   AdcpCapabilitiesOverrides,
   AdcpCustomToolConfig,
+  McpAppUiMeta,
+  McpAppMeta,
   AdcpLogger,
   SignedRequestsConfig,
   AdcpPreTransport,

--- a/src/lib/server/legacy/v5/index.ts
+++ b/src/lib/server/legacy/v5/index.ts
@@ -50,6 +50,8 @@ export type {
   AdcpCapabilitiesConfig,
   AdcpCapabilitiesOverrides,
   AdcpCustomToolConfig,
+  McpAppUiMeta,
+  McpAppMeta,
   AdcpLogger,
   SignedRequestsConfig,
   AdcpPreTransport,

--- a/test/lib/mcp-modern-negotiation.test.js
+++ b/test/lib/mcp-modern-negotiation.test.js
@@ -304,6 +304,72 @@ test('serve exposes AdCP tools to a client pinned to MCP 2026-07-28', async t =>
   await hostileClient.close().catch(() => {});
 });
 
+test('modern serving forwards portable MCP App metadata for custom tools', async t => {
+  const { serve, InMemoryStateStore } = require('../../dist/lib/index.js');
+  const { createAdcpServer } = require('../../dist/lib/server/legacy/v5/index.js');
+  const { Client, StreamableHTTPClientTransport } = require('@modelcontextprotocol/client');
+
+  const appOnlyMeta = { ui: { visibility: ['app'] } };
+  const result = text => async () => ({ content: [{ type: 'text', text }] });
+  const httpServer = serve(
+    () =>
+      createAdcpServer({
+        name: 'modern-mcp-app-test',
+        version: '1.0.0',
+        stateStore: new InMemoryStateStore(),
+        customTools: {
+          upload_creative_asset: {
+            description: 'Open the portable creative upload app',
+            _meta: { ui: { resourceUri: 'ui://creative/upload' } },
+            handler: result('opened'),
+          },
+          prepare_creative_upload: {
+            _meta: appOnlyMeta,
+            handler: result('prepared'),
+          },
+          finalize_creative_upload: {
+            _meta: appOnlyMeta,
+            handler: result('finalized'),
+          },
+        },
+      }),
+    { port: 0, onListening: () => {} }
+  );
+  await new Promise((resolve, reject) => {
+    httpServer.once('error', reject);
+    if (httpServer.listening) resolve();
+    else httpServer.once('listening', resolve);
+  });
+  const address = httpServer.address();
+  assert.ok(address && typeof address === 'object');
+
+  const client = new Client(
+    { name: 'portable-mcp-app-client', version: '1.0.0' },
+    { versionNegotiation: { mode: { pin: '2026-07-28' } } }
+  );
+  const transport = new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${address.port}/mcp`));
+  t.after(async () => {
+    await client.close().catch(() => {});
+    await closeServer(httpServer);
+  });
+
+  await client.connect(transport);
+  const listed = await client.listTools();
+  const tools = Object.fromEntries(listed.tools.map(tool => [tool.name, tool]));
+  assert.deepEqual(tools.upload_creative_asset._meta, {
+    ui: { resourceUri: 'ui://creative/upload' },
+  });
+  assert.deepEqual(tools.prepare_creative_upload._meta, appOnlyMeta);
+  assert.deepEqual(tools.finalize_creative_upload._meta, appOnlyMeta);
+
+  const prepared = await client.callTool({ name: 'prepare_creative_upload', arguments: {} });
+  assert.equal(
+    prepared.content[0].text,
+    'prepared',
+    'visibility metadata must not become a server-side authorization boundary'
+  );
+});
+
 test('modern serving honors per-request tool visibility', async t => {
   const { serve, InMemoryStateStore } = require('../../dist/lib/index.js');
   const { createAdcpServer } = require('../../dist/lib/server/legacy/v5/index.js');


### PR DESCRIPTION
## Summary

- add public `McpAppMeta` and `McpAppUiMeta` types for custom tools
- forward custom-tool `_meta.ui` unchanged through legacy registration and modern MCP server reconstruction
- cover a model-visible origin tool plus app-only prepare/finalize tools with type and integration tests
- add a patch changeset for `@adcp/sdk`

## Why

Custom tools could not declare portable MCP App metadata through the public server API. This prevented adopters from associating a tool with a `ui://` resource or marking supporting tools as app-only without reaching through private MCP server internals.

`ui.visibility` is host routing metadata rather than a server-side authorization boundary; the public type supports both `model` and `app` audiences.

Resource registration remains separate follow-up work because the modern adapter reconstructs its MCP server per request. The ext-apps v2 migration is tracked in #2371.

## Validation

- `npm run ci:quick`
- repository pre-push validation
- conventional commit and PR-title checks
- independent API/DX, MCP Apps protocol, and code/test expert reviews

Refs #2368
