### PR TITLE
fix(mcp): restore Bun version negotiation

### DIFF
--- a/.changeset/slow-spoons-connect.md
+++ b/.changeset/slow-spoons-connect.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Restore MCP version negotiation for Bun consumers of the ESM package artifact.

--- a/scripts/verify-package.mjs
+++ b/scripts/verify-package.mjs
@@ -8,7 +8,8 @@
  * range floors into a throwaway directory in the OS temp dir, then loads
  * `@adcp/sdk`, `@adcp/sdk/enums`, and `@adcp/sdk/server` through both a real
  * ESM `import` and a real CJS `require`, asserting each exposes a known runtime
- * symbol.
+ * symbol. It also runs a modern MCP negotiation under Bun, whose ESM/CJS
+ * interoperability differs from Node's.
  *
  * Why a temp dir outside the repo: installing inside the workspace would let
  * the monorepo dedupe peers against the repo's own node_modules, so a missing
@@ -132,6 +133,47 @@ try {
   console.log('🔍 CJS require:');
   run('node', ['smoke.cjs'], { cwd: tmpDir, stdio: 'inherit' });
 
+  // Bun selects a different conditional-export path for dual ESM/CJS
+  // dependencies than Node. Exercise the packed artifact through a real MCP
+  // initialize + tool call so protocol modules retain the createRequire shim
+  // needed by Bun's MCP dependency loading.
+  writeFileSync(
+    path.join(tmpDir, 'smoke.mcp.mjs'),
+    [
+      "import { createServer } from 'node:http';",
+      "import { createMcpHandler, McpServer } from '@modelcontextprotocol/server';",
+      "import { toNodeHandler } from '@modelcontextprotocol/node';",
+      "import { callMCPTool, closeMCPConnections } from '@adcp/sdk';",
+      '',
+      'const handler = createMcpHandler(() => {',
+      "  const server = new McpServer({ name: 'package-smoke', version: '1.0.0' });",
+      "  server.registerTool('echo', { description: 'Echo a fixed result' }, async () => ({",
+      "    content: [{ type: 'text', text: 'ok' }],",
+      '  }));',
+      '  return server;',
+      "}, { legacy: 'reject' });",
+      'const nodeHandler = toNodeHandler(handler);',
+      'const httpServer = createServer((req, res) => void nodeHandler(req, res));',
+      "await new Promise((resolve, reject) => { httpServer.once('error', reject); httpServer.listen(0, '127.0.0.1', resolve); });",
+      'try {',
+      '  const address = httpServer.address();',
+      "  if (!address || typeof address === 'string') throw new Error('server did not bind');",
+      '  const result = await callMCPTool(',
+      '    `http://127.0.0.1:${address.port}/mcp`,',
+      "    'echo', {}, undefined, [], {}, undefined, undefined, { requestTimeoutMs: 5_000 }",
+      '  );',
+      "  if (result.content?.[0]?.text !== 'ok') throw new Error(`unexpected MCP result: ${JSON.stringify(result)}`);",
+      '} finally {',
+      '  await closeMCPConnections();',
+      '  await handler.close();',
+      '  await new Promise((resolve, reject) => httpServer.close(error => error ? reject(error) : resolve()));',
+      '}',
+    ].join('\n')
+  );
+  console.log('🔥 Bun MCP negotiation:');
+  run('npx', ['--yes', 'bun@1.3.8', 'smoke.mcp.mjs'], { cwd: tmpDir, stdio: 'inherit' });
+  console.log('  Bun ESM negotiation through @adcp/sdk ok');
+
   // `@adcp/sdk/enums` is documented as a lean, zod-free entry point safe for
   // browser bundlers. Bundling it with `--platform=browser` catches
   // Node-only imports (`node:url`/`node:path`/`node:module`, etc.) that
@@ -153,7 +195,9 @@ try {
   );
   console.log('  browser bundle of @adcp/sdk/enums ok');
 
-  console.log('\n✅ Package loads in both ESM and CJS with peer floors satisfied, and browser-bundles cleanly.');
+  console.log(
+    '\n✅ Package loads in Node and Bun with peer floors satisfied, negotiates MCP, and browser-bundles cleanly.'
+  );
 } catch (err) {
   console.error('\n❌ Package verification failed:');
   console.error(err.message ?? err);

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -4,13 +4,11 @@ import { transformSync } from 'esbuild';
 import { defineConfig } from 'tsup';
 import { fixImportsPlugin } from 'esbuild-fix-imports-plugin';
 
-// Only files that actually reference `__dirname` or `require` in their body
-// need the ESM shim below (no source file reads bare `__filename`, so it's
-// only an intermediate in computing `__dirname` from `import.meta.url`, not
-// its own shim target); injecting it into every ESM output (as a global
-// esbuild `banner`) drags `node:url`/`node:path`/`node:module` imports into
-// pure-data/pure-logic modules that never touch them, which a browser
-// bundler can't resolve (adcp#2364).
+// Files that reference `__dirname` or `require` in their body need the ESM
+// shim below. Protocol transport modules also receive it: Bun uses the
+// createRequire binding to load dual ESM/CJS MCP dependencies consistently.
+// Applying the shim to every ESM output would still drag Node built-ins into
+// pure-data modules that browser bundlers consume (adcp#2364).
 //
 // Runs pre-transform via `onLoad` — prepending to the TS source rather than
 // the emitted JS — so esbuild's own sourcemap generation accounts for the
@@ -37,7 +35,10 @@ function conditionalNodeShimPlugin() {
       build.onLoad({ filter: /\.ts$/ }, args => {
         const source = readFileSync(args.path, 'utf8');
         const { code } = transformSync(source, { loader: 'ts', legalComments: 'none' });
-        if (!needsShim.test(code)) return null;
+        const isProtocolTransport = args.path.includes(
+          `${nodePath.sep}src${nodePath.sep}lib${nodePath.sep}protocols${nodePath.sep}`
+        );
+        if (!isProtocolTransport && !needsShim.test(code)) return null;
         return { contents: `${banner}\n${source}`, loader: 'ts' };
       });
     },


### PR DESCRIPTION
## Summary

- apply the per-file ESM Node shim to protocol transport modules as an explicit allowlist
- add a clean-room Bun 1.3.8 smoke test that installs the packed artifact and completes modern MCP negotiation plus a tool call
- preserve the browser-safe `@adcp/sdk/enums` bundle check

## Root cause

The 12.0.1 conditional shim only covered source files that directly referenced `__dirname` or `require`. The MCP protocol modules do not contain those references themselves, but Bun needs the `createRequire` binding when loading their dual ESM/CJS dependency graph. Removing the former blanket banner therefore made the packed ESM artifact fail while loading MCP dependencies before negotiation could complete.

This keeps the conditional build introduced for browser consumers and adds a narrow protocol-directory allowlist instead of restoring the global banner.

## Validation

- `npm run build:lib`
- `NODE_ENV=test npx --yes node@20 --test-timeout=60000 --test-force-exit --test test/lib/mcp-modern-negotiation.test.js`
- `NODE_ENV=test npx --yes node@20 --test-timeout=60000 --test-force-exit --test test/read-path-abort-timeout.test.js`
- `npm run verify:package`
- `npm run check:package`
- `npm run typecheck`
- targeted Prettier check
- `git diff --check`
- repository pre-push validation

Fixes #2369.