### PR TITLE
feat(server): register portable MCP App resources

### DIFF
--- a/.changeset/fresh-app-resources.md
+++ b/.changeset/fresh-app-resources.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Add typed, portable MCP App resource registration across legacy and modern server transports.

--- a/docs/guides/BUILD-AN-AGENT.md
+++ b/docs/guides/BUILD-AN-AGENT.md
@@ -562,6 +562,76 @@ createAdcpServerFromPlatform(platform, {
 
 See [SIGNING-GUIDE.md](./SIGNING-GUIDE.md) for the full walkthrough: key generation, JWKS publication, brand.json, conformance testing, and KMS-backed production deployment.
 
+### Portable MCP Apps for custom tools
+
+Use `resources` with custom-tool `_meta.ui` to attach one host-neutral MCP
+App to a tool. The framework registers the `ui://` resource on both legacy
+MCP connections and every modern per-request server reconstruction; the same
+configuration therefore works in compliant Claude, ChatGPT, and future hosts.
+
+```typescript
+import {
+  createAdcpServerFromPlatform,
+  MCP_APP_RESOURCE_MIME_TYPE,
+} from '@adcp/sdk/server';
+
+const server = createAdcpServerFromPlatform(platform, {
+  name: 'My Publisher',
+  version: '1.0.0',
+  resources: [
+    {
+      name: 'creative_upload',
+      uri: 'ui://creative/upload',
+      mimeType: MCP_APP_RESOURCE_MIME_TYPE,
+      _meta: {
+        ui: {
+          csp: {
+            connectDomains: ['https://uploads.example.com'],
+            resourceDomains: ['https://assets.example.com'],
+          },
+          prefersBorder: true,
+        },
+      },
+      handler: async () => renderUploadApp(),
+    },
+  ],
+  customTools: {
+    upload_creative_asset: {
+      description: 'Open the creative upload flow.',
+      _meta: { ui: { resourceUri: 'ui://creative/upload' } },
+      handler: async () => ({
+        // Required text-only fallback for hosts without MCP Apps support.
+        content: [{ type: 'text', text: 'Upload a creative asset.' }],
+      }),
+    },
+    prepare_creative_upload: {
+      _meta: { ui: { visibility: ['app'] } },
+      handler: prepareCreativeUpload,
+    },
+    finalize_creative_upload: {
+      _meta: { ui: { visibility: ['app'] } },
+      handler: finalizeCreativeUpload,
+    },
+  },
+});
+```
+
+MCP App resources always use a `ui://` URI and
+`text/html;profile=mcp-app`; the public types and construction-time checks
+reject other shapes. The resource `_meta.ui` object carries CSP domains,
+permissions, a dedicated host domain, and border preference, and is emitted
+consistently by both `resources/list` and `resources/read`.
+
+`ui.visibility` is host routing metadata, not an authorization boundary.
+App-only handlers must still authenticate and authorize every request, and
+tools should always return meaningful text content so clients that do not
+negotiate `io.modelcontextprotocol/ui` degrade gracefully. A startup warning
+identifies any tool `resourceUri` that does not match a configured resource.
+Resource handlers intentionally receive no authentication material: the HTML
+bundle must be principal-independent and cache-safe. Fetch tenant data or mint
+short-lived upload URLs through authenticated app-only tools after the app has
+loaded.
+
 ### createTaskCapableServer (Low-Level)
 
 For advanced cases where you need direct control over MCP tool registration, schema wiring, and response formatting. `createAdcpServerFromPlatform` calls into this internally.

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -987,6 +987,7 @@ export {
   ADCP_SERVE_REQUEST_CONTEXT,
   createA2AAdapter,
   A2AInvocationError,
+  MCP_APP_RESOURCE_MIME_TYPE,
 } from './server';
 export type {
   AdcpErrorOptions,
@@ -1024,6 +1025,12 @@ export type {
   AdcpCustomToolConfig,
   McpAppUiMeta,
   McpAppMeta,
+  AdcpMcpResourceDefinition,
+  McpAppResourceCsp,
+  McpAppResourcePermissions,
+  McpAppResourceUiMeta,
+  McpAppResourceMeta,
+  McpAppResourceReadContext,
   AdcpLogger,
   HandlerContext,
   MediaBuyHandlers,

--- a/src/lib/server/adcp-server.ts
+++ b/src/lib/server/adcp-server.ts
@@ -30,6 +30,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import type { McpToolResponse } from './responses';
+import type { AdcpMcpResourceDefinition } from './mcp-app';
 import { ADCP_VERSION } from '../version';
 
 /**
@@ -340,6 +341,9 @@ export const ADCP_CAPABILITIES: unique symbol = Symbol.for('@adcp/client.capabil
 /** Per-request tool visibility policy consumed by transport adapters. @internal */
 export const ADCP_TOOL_VISIBILITY: unique symbol = Symbol.for('@adcp/client.toolVisibility');
 
+/** Configured MCP App resources mirrored into modern per-request servers. @internal */
+export const ADCP_MCP_APP_RESOURCES: unique symbol = Symbol.for('@adcp/client.mcpAppResources');
+
 /** @internal */
 export type AdcpToolVisibilityResolver = (options: {
   toolName: string;
@@ -351,6 +355,7 @@ export type AdcpToolVisibilityResolver = (options: {
 export interface AdcpServerInternal extends AdcpServer {
   readonly [ADCP_SDK_SERVER]: McpServer;
   [ADCP_TOOL_VISIBILITY]?: AdcpToolVisibilityResolver;
+  [ADCP_MCP_APP_RESOURCES]?: readonly AdcpMcpResourceDefinition[];
 }
 
 /**
@@ -368,6 +373,21 @@ export function getSdkServer(server: AdcpServer | McpServer): McpServer | undefi
 /** Attach a transport-independent per-request tool visibility policy. @internal */
 export function setToolVisibilityResolver(server: AdcpServer, resolver: AdcpToolVisibilityResolver): void {
   (server as AdcpServerInternal)[ADCP_TOOL_VISIBILITY] = resolver;
+}
+
+/** Attach validated resource definitions for transport adapters. @internal */
+export function setMcpAppResources(server: AdcpServer, resources: readonly AdcpMcpResourceDefinition[]): void {
+  Object.defineProperty(server, ADCP_MCP_APP_RESOURCES, {
+    value: resources,
+    enumerable: false,
+    configurable: false,
+    writable: false,
+  });
+}
+
+/** Read validated resource definitions for transport adapters. @internal */
+export function listMcpAppResources(server: AdcpServer): readonly AdcpMcpResourceDefinition[] {
+  return (server as AdcpServerInternal)[ADCP_MCP_APP_RESOURCES] ?? [];
 }
 
 /** Resolve whether a registered tool may be exposed to this request. @internal */

--- a/src/lib/server/adcp-server.type-checks.ts
+++ b/src/lib/server/adcp-server.type-checks.ts
@@ -7,6 +7,7 @@
 
 import type { AdcpServer } from './adcp-server';
 import type { AdcpCustomToolConfig, McpAppMeta, MediaBuyHandlers } from './create-adcp-server';
+import type { AdcpMcpResourceDefinition, McpAppResourceMeta } from './mcp-app';
 
 // ── Plain object with same structural shape isn't an AdcpServer ──────────
 
@@ -79,6 +80,42 @@ const _flatMcpAppMeta: McpAppMeta = {
   'ui.resourceUri': 'ui://creative/upload',
 };
 
+const _validMcpAppResourceMeta: McpAppResourceMeta = {
+  ui: {
+    csp: {
+      connectDomains: ['https://api.example.com'],
+      resourceDomains: ['https://cdn.example.com'],
+      frameDomains: ['https://player.example.com'],
+      baseUriDomains: ['https://cdn.example.com'],
+    },
+    domain: 'upload.example.com',
+    prefersBorder: true,
+  },
+};
+
+const _validMcpAppResource: AdcpMcpResourceDefinition = {
+  name: 'creative_upload',
+  uri: 'ui://creative/upload',
+  mimeType: 'text/html;profile=mcp-app',
+  _meta: _validMcpAppResourceMeta,
+  handler: async (_uri, { signal }) => (signal.aborted ? '' : '<!doctype html><html></html>'),
+};
+
+const _invalidMcpAppResourceUri: AdcpMcpResourceDefinition = {
+  name: 'wrong_scheme',
+  // @ts-expect-error — MCP App resources require the ui:// scheme.
+  uri: 'https://example.com/app',
+  handler: async () => '<!doctype html><html></html>',
+};
+
+const _invalidMcpAppResourceMime: AdcpMcpResourceDefinition = {
+  name: 'wrong_mime',
+  uri: 'ui://creative/wrong-mime',
+  // @ts-expect-error — arbitrary HTML MIME types are not MCP App resources.
+  mimeType: 'text/html',
+  handler: async () => '<!doctype html><html></html>',
+};
+
 export const _references = [
   _imitationCannotBeAdcpServer,
   _registerToolNotOnAdcpServer,
@@ -88,4 +125,8 @@ export const _references = [
   _customToolWithMcpAppMeta,
   _invalidMcpAppMeta,
   _flatMcpAppMeta,
+  _validMcpAppResourceMeta,
+  _validMcpAppResource,
+  _invalidMcpAppResourceUri,
+  _invalidMcpAppResourceMime,
 ] as const;

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -51,10 +51,17 @@ import {
   ADCP_STATE_STORE,
   wrapMcpServer,
   setSdkServerInstructions,
+  setMcpAppResources,
   wrapInitializeHandler,
   type AdcpServer,
   type AdcpServerInternal,
 } from './adcp-server';
+import {
+  mcpAppResourceMetadata,
+  normalizeMcpAppResources,
+  readMcpAppResource,
+  type AdcpMcpResourceDefinition,
+} from './mcp-app';
 import { createTaskCapableServer, InMemoryTaskStore } from './tasks';
 import type { TaskStore, TaskMessageQueue } from './tasks';
 import { adcpError, applyAdcpErrorAllowlist, sanitizeStructuredAdcpError } from './errors';
@@ -1776,6 +1783,17 @@ export interface AdcpServerConfig<TAccount = unknown> {
    * construction time — the spec handler wins by convention.
    */
   customTools?: Record<string, AdcpCustomToolConfig<any, any>>;
+
+  /**
+   * Portable HTML MCP Apps served through standard MCP resources.
+   *
+   * Each definition is registered on both the legacy MCP server and every
+   * modern per-request server reconstruction. A custom tool links to a
+   * resource with `_meta.ui.resourceUri`; a startup warning identifies any
+   * link whose URI is absent here. Hosts without MCP Apps support can ignore
+   * the metadata and consume the tool's normal text result.
+   */
+  resources?: readonly AdcpMcpResourceDefinition[];
 
   /**
    * Opt-in bridge between the `comply_test_controller` seed store and the
@@ -3509,6 +3527,17 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
     config.exposeToolSchemas === true
       ? (shallowToolInputHintSchema(toolName) ?? PASSTHROUGH_INPUT_SCHEMA)
       : PASSTHROUGH_INPUT_SCHEMA;
+  const mcpAppResources = normalizeMcpAppResources(config.resources);
+  const mcpAppResourceUris = new Set<string>(mcpAppResources.map(resource => resource.uri));
+  for (const [toolName, tool] of Object.entries(config.customTools ?? {})) {
+    const resourceUri = tool?._meta?.ui?.resourceUri;
+    if (resourceUri === undefined || mcpAppResourceUris.has(resourceUri)) continue;
+    const message =
+      `[adcp/createAdcpServer] customTools["${toolName}"]._meta.ui.resourceUri references ` +
+      `"${resourceUri}", but no matching MCP App resource is configured in resources[].`;
+    process.emitWarning(message, { type: 'AdcpServerConfigWarning', code: 'ADCP_MCP_APP_RESOURCE_MISSING' });
+    logger.warn(message);
+  }
 
   // One-shot construction-time warn when `testController` is wired without
   // any account resolver. The dispatch-time sandbox gate admits requests
@@ -3898,6 +3927,21 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
     taskMessageQueue,
     instructions: resolvedInstructions,
   });
+
+  // The v1 SDK server remains the canonical legacy path. The modern adapter
+  // separately mirrors these validated definitions onto every per-request
+  // MCP v2 server reconstruction.
+  for (const resource of mcpAppResources) {
+    server.registerResource(
+      resource.name,
+      resource.uri,
+      mcpAppResourceMetadata(resource) as Parameters<typeof server.registerResource>[2],
+      async (uri, extra) =>
+        readMcpAppResource(resource, uri, {
+          signal: extra.signal,
+        })
+    );
+  }
 
   // Wire async instructions resolution into the MCP `initialize` handler.
   // The function returned a Promise at construction time; await it here
@@ -6407,6 +6451,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
     },
   };
   const wrapped: AdcpServerInternal = wrapMcpServer(server, compliance, adcpVersion);
+  setMcpAppResources(wrapped, mcpAppResources);
 
   // Attach the auto-wired preTransport so `serve()` mounts the verifier
   // on the HTTP transport. Stashed under a non-enumerable symbol property

--- a/src/lib/server/index.ts
+++ b/src/lib/server/index.ts
@@ -320,6 +320,16 @@ export type { PostgresStateStoreOptions } from './postgres-state-store';
 
 export { structuredSerialize, structuredDeserialize } from './structured-serialize';
 
+export { MCP_APP_RESOURCE_MIME_TYPE } from './mcp-app';
+export type {
+  AdcpMcpResourceDefinition,
+  McpAppResourceCsp,
+  McpAppResourcePermissions,
+  McpAppResourceUiMeta,
+  McpAppResourceMeta,
+  McpAppResourceReadContext,
+} from './mcp-app';
+
 // `createAdcpServer` is NOT re-exported from `@adcp/sdk/server` anymore —
 // LLMs scaffolding from skills consistently latched onto it as the canonical
 // entry point despite the @deprecated JSDoc. Removing the top-level export

--- a/src/lib/server/mcp-app.ts
+++ b/src/lib/server/mcp-app.ts
@@ -1,0 +1,165 @@
+/** MIME type required by the stable MCP Apps HTML resource contract. */
+export const MCP_APP_RESOURCE_MIME_TYPE = 'text/html;profile=mcp-app' as const;
+
+/** Content Security Policy sources requested by an MCP App resource. */
+export interface McpAppResourceCsp {
+  /** Origins allowed for fetch, XHR, and WebSocket connections. */
+  connectDomains?: string[];
+  /** Origins allowed for scripts, styles, images, fonts, and media. */
+  resourceDomains?: string[];
+  /** Origins allowed for nested iframes. */
+  frameDomains?: string[];
+  /** Origins allowed in the document's base URI. */
+  baseUriDomains?: string[];
+}
+
+/** Browser permissions an MCP App may ask its host to grant. */
+export interface McpAppResourcePermissions {
+  camera?: Record<string, never>;
+  microphone?: Record<string, never>;
+  geolocation?: Record<string, never>;
+  clipboardWrite?: Record<string, never>;
+}
+
+/** Security and presentation hints for an MCP App resource. */
+export interface McpAppResourceUiMeta {
+  csp?: McpAppResourceCsp;
+  permissions?: McpAppResourcePermissions;
+  /** Host-specific dedicated sandbox domain. */
+  domain?: string;
+  /** Whether the host should render a visible boundary around the app. */
+  prefersBorder?: boolean;
+}
+
+/** Typed metadata emitted on both resource discovery and resource content. */
+export interface McpAppResourceMeta {
+  ui?: McpAppResourceUiMeta;
+}
+
+/** Transport-neutral context passed to an MCP App resource handler. */
+export interface McpAppResourceReadContext {
+  signal: AbortSignal;
+}
+
+/**
+ * Declarative registration for one static HTML MCP App resource.
+ *
+ * The framework registers the resource on both the legacy MCP SDK server and
+ * every modern per-request server reconstruction. The handler returns the
+ * complete HTML document; the framework owns the URI, MIME type, and metadata
+ * in the `resources/read` response so discovery and readback cannot drift.
+ */
+export interface AdcpMcpResourceDefinition {
+  /** Stable programmatic name surfaced by `resources/list`. */
+  name: string;
+  /** MCP Apps require the `ui://` URI scheme. */
+  uri: `ui://${string}`;
+  title?: string;
+  description?: string;
+  /** Defaults to the only MIME type currently supported by MCP Apps. */
+  mimeType?: typeof MCP_APP_RESOURCE_MIME_TYPE;
+  _meta?: McpAppResourceMeta;
+  handler: (uri: URL, ctx: McpAppResourceReadContext) => string | Promise<string>;
+}
+
+/** @internal */
+export function normalizeMcpAppResources(
+  resources: readonly AdcpMcpResourceDefinition[] | undefined
+): readonly AdcpMcpResourceDefinition[] {
+  if (resources === undefined) return [];
+
+  const names = new Set<string>();
+  const uris = new Set<string>();
+  return resources.map((resource, index) => {
+    const path = `resources[${index}]`;
+    if (!resource || typeof resource !== 'object') {
+      throw new Error(`createAdcpServer: ${path} must be an MCP App resource definition`);
+    }
+    if (typeof resource.name !== 'string' || resource.name.trim() === '') {
+      throw new Error(`createAdcpServer: ${path}.name must be a non-empty string`);
+    }
+    if (names.has(resource.name)) {
+      throw new Error(`createAdcpServer: duplicate MCP App resource name "${resource.name}"`);
+    }
+    names.add(resource.name);
+
+    if (typeof resource.uri !== 'string' || !resource.uri.startsWith('ui://')) {
+      throw new Error(`createAdcpServer: ${path}.uri must use the ui:// scheme`);
+    }
+    try {
+      const parsed = new URL(resource.uri);
+      if (parsed.protocol !== 'ui:' || (parsed.hostname === '' && parsed.pathname === '')) throw new Error('empty URI');
+      if (parsed.href !== resource.uri) {
+        throw new Error(`non-canonical URI; use "${parsed.href}"`);
+      }
+    } catch (error) {
+      const detail =
+        error instanceof Error && error.message.startsWith('non-canonical URI') ? ` (${error.message})` : '';
+      throw new Error(`createAdcpServer: ${path}.uri must be a valid canonical ui:// URI${detail}`);
+    }
+    if (uris.has(resource.uri)) {
+      throw new Error(`createAdcpServer: duplicate MCP App resource URI "${resource.uri}"`);
+    }
+    uris.add(resource.uri);
+
+    if (resource.mimeType !== undefined && resource.mimeType !== MCP_APP_RESOURCE_MIME_TYPE) {
+      throw new Error(
+        `createAdcpServer: ${path}.mimeType must be "${MCP_APP_RESOURCE_MIME_TYPE}" for an MCP App resource`
+      );
+    }
+    if (typeof resource.handler !== 'function') {
+      throw new Error(`createAdcpServer: ${path}.handler must be a function`);
+    }
+
+    return { ...resource, mimeType: MCP_APP_RESOURCE_MIME_TYPE };
+  });
+}
+
+/** @internal */
+export function mcpAppResourceMetadata(resource: AdcpMcpResourceDefinition): Record<string, unknown> {
+  return {
+    ...(resource.title !== undefined && { title: resource.title }),
+    ...(resource.description !== undefined && { description: resource.description }),
+    mimeType: MCP_APP_RESOURCE_MIME_TYPE,
+    ...(resource._meta !== undefined && { _meta: resource._meta }),
+  };
+}
+
+/** @internal */
+export async function readMcpAppResource(
+  resource: AdcpMcpResourceDefinition,
+  uri: URL,
+  ctx: McpAppResourceReadContext
+): Promise<{
+  contents: Array<{
+    uri: string;
+    mimeType: typeof MCP_APP_RESOURCE_MIME_TYPE;
+    text: string;
+    _meta?: Record<string, unknown>;
+  }>;
+}> {
+  let text: string;
+  try {
+    const result = await resource.handler(uri, ctx);
+    if (typeof result !== 'string') {
+      throw new TypeError(`handler returned ${result === null ? 'null' : typeof result}, not a string`);
+    }
+    text = result;
+  } catch (error) {
+    // Resource callbacks sit outside the AdCP tool-error envelope. Log the
+    // private cause here, then expose a fixed message so provider errors,
+    // file paths, and credentials never become JSON-RPC error text.
+    console.error(`[adcp/mcp-app] resource handler "${resource.name}" failed`, error);
+    throw new Error('MCP App resource is temporarily unavailable');
+  }
+  return {
+    contents: [
+      {
+        uri: uri.href,
+        mimeType: MCP_APP_RESOURCE_MIME_TYPE,
+        text,
+        ...(resource._meta !== undefined && { _meta: resource._meta as Record<string, unknown> }),
+      },
+    ],
+  };
+}

--- a/src/lib/server/mcp-modern-server.ts
+++ b/src/lib/server/mcp-modern-server.ts
@@ -12,6 +12,7 @@ import {
   createMcpHandler,
   isLegacyRequest,
   type AuthInfo as ModernAuthInfo,
+  type ResourceMetadata,
   type StandardSchemaWithJSON,
   type ServerContext,
   type ToolAnnotations,
@@ -23,11 +24,13 @@ import {
   getSdkServerInfo,
   getSdkServerInstructions,
   isRegisteredToolVisible,
+  listMcpAppResources,
   listRegisteredToolDefinitions,
   type AdcpAuthInfo,
   type AdcpServer,
 } from './adcp-server';
 import { ADCP_INSTRUCTIONS_RESOLVER } from './create-adcp-server';
+import { mcpAppResourceMetadata, readMcpAppResource } from './mcp-app';
 
 export interface ModernMcpServerAdapter {
   handle: NodeMcpRequestHandler;
@@ -44,6 +47,13 @@ function toAdcpAuthInfo(authInfo: ModernAuthInfo | undefined): AdcpAuthInfo | un
     ...(authInfo.expiresAt !== undefined && { expiresAt: authInfo.expiresAt }),
     ...(authInfo.extra !== undefined && { extra: authInfo.extra }),
   };
+}
+
+function linkedMcpAppResourceUri(tool: { _meta?: Record<string, unknown> }): string | undefined {
+  const ui = tool._meta?.['ui'];
+  if (ui === null || typeof ui !== 'object') return undefined;
+  const resourceUri = (ui as Record<string, unknown>)['resourceUri'];
+  return typeof resourceUri === 'string' ? resourceUri : undefined;
 }
 
 /** Build a strict 2026-07-28 handler around one configured AdCP server. @internal */
@@ -69,8 +79,11 @@ export function createModernMcpServerAdapter(agentServer: AdcpServer): ModernMcp
       );
 
       const authInfo = toAdcpAuthInfo(requestContext.authInfo);
+      const toolVisibility = new Map<string, boolean>();
       for (const tool of toolDefinitions) {
-        if (!(await isRegisteredToolVisible(agentServer, { toolName: tool.name, authInfo }))) continue;
+        const visible = await isRegisteredToolVisible(agentServer, { toolName: tool.name, authInfo });
+        toolVisibility.set(tool.name, visible);
+        if (!visible) continue;
         const config = {
           ...(tool.title !== undefined && { title: tool.title }),
           ...(tool.description !== undefined && { description: tool.description }),
@@ -97,6 +110,23 @@ export function createModernMcpServerAdapter(agentServer: AdcpServer): ModernMcp
         } else {
           modern.registerTool(tool.name, config, async ctx => invoke({}, ctx));
         }
+      }
+
+      // `createMcpHandler` reconstructs the MCP v2 server for every request,
+      // so resources must be registered inside the factory rather than once
+      // when the opaque AdCP server is created.
+      for (const resource of listMcpAppResources(agentServer)) {
+        const linkedTools = toolDefinitions.filter(tool => linkedMcpAppResourceUri(tool) === resource.uri);
+        if (linkedTools.length > 0 && !linkedTools.some(tool => toolVisibility.get(tool.name) === true)) continue;
+        modern.registerResource(
+          resource.name,
+          resource.uri,
+          mcpAppResourceMetadata(resource) as ResourceMetadata,
+          async (uri, ctx) =>
+            readMcpAppResource(resource, uri, {
+              signal: ctx.mcpReq.signal,
+            })
+        );
       }
 
       return modern;

--- a/test/lib/mcp-modern-negotiation.test.js
+++ b/test/lib/mcp-modern-negotiation.test.js
@@ -310,6 +310,16 @@ test('modern serving forwards portable MCP App metadata for custom tools', async
   const { Client, StreamableHTTPClientTransport } = require('@modelcontextprotocol/client');
 
   const appOnlyMeta = { ui: { visibility: ['app'] } };
+  const resourceMeta = {
+    ui: {
+      csp: {
+        connectDomains: ['https://api.example.com'],
+        resourceDomains: ['https://cdn.example.com'],
+      },
+      domain: 'creative-upload.example.com',
+      prefersBorder: true,
+    },
+  };
   const result = text => async () => ({ content: [{ type: 'text', text }] });
   const httpServer = serve(
     () =>
@@ -317,6 +327,15 @@ test('modern serving forwards portable MCP App metadata for custom tools', async
         name: 'modern-mcp-app-test',
         version: '1.0.0',
         stateStore: new InMemoryStateStore(),
+        resources: [
+          {
+            name: 'creative_upload',
+            uri: 'ui://creative/upload',
+            title: 'Creative upload',
+            _meta: resourceMeta,
+            handler: async () => '<!doctype html><html><body>upload</body></html>',
+          },
+        ],
         customTools: {
           upload_creative_asset: {
             description: 'Open the portable creative upload app',
@@ -345,7 +364,14 @@ test('modern serving forwards portable MCP App metadata for custom tools', async
 
   const client = new Client(
     { name: 'portable-mcp-app-client', version: '1.0.0' },
-    { versionNegotiation: { mode: { pin: '2026-07-28' } } }
+    {
+      capabilities: {
+        extensions: {
+          'io.modelcontextprotocol/ui': { mimeTypes: ['text/html;profile=mcp-app'] },
+        },
+      },
+      versionNegotiation: { mode: { pin: '2026-07-28' } },
+    }
   );
   const transport = new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${address.port}/mcp`));
   t.after(async () => {
@@ -362,12 +388,45 @@ test('modern serving forwards portable MCP App metadata for custom tools', async
   assert.deepEqual(tools.prepare_creative_upload._meta, appOnlyMeta);
   assert.deepEqual(tools.finalize_creative_upload._meta, appOnlyMeta);
 
+  const listedResources = await client.listResources();
+  assert.deepEqual(listedResources.resources, [
+    {
+      name: 'creative_upload',
+      uri: 'ui://creative/upload',
+      title: 'Creative upload',
+      mimeType: 'text/html;profile=mcp-app',
+      _meta: resourceMeta,
+    },
+  ]);
+  const resource = await client.readResource({ uri: 'ui://creative/upload' });
+  assert.deepEqual(resource.contents, [
+    {
+      uri: 'ui://creative/upload',
+      mimeType: 'text/html;profile=mcp-app',
+      text: '<!doctype html><html><body>upload</body></html>',
+      _meta: resourceMeta,
+    },
+  ]);
+
   const prepared = await client.callTool({ name: 'prepare_creative_upload', arguments: {} });
   assert.equal(
     prepared.content[0].text,
     'prepared',
     'visibility metadata must not become a server-side authorization boundary'
   );
+
+  // Capability negotiation belongs to the host. A client that does not
+  // advertise MCP Apps must still receive and call the ordinary text tool;
+  // the optional resource registration cannot make the server UI-only.
+  const fallbackClient = new Client(
+    { name: 'text-only-client', version: '1.0.0' },
+    { versionNegotiation: { mode: { pin: '2026-07-28' } } }
+  );
+  const fallbackTransport = new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${address.port}/mcp`));
+  t.after(async () => fallbackClient.close().catch(() => {}));
+  await fallbackClient.connect(fallbackTransport);
+  const fallback = await fallbackClient.callTool({ name: 'upload_creative_asset', arguments: {} });
+  assert.equal(fallback.content[0].text, 'opened');
 });
 
 test('modern serving honors per-request tool visibility', async t => {
@@ -382,8 +441,24 @@ test('modern serving honors per-request tool visibility', async t => {
         name: 'modern-visibility-test',
         version: '1.0.0',
         stateStore: new InMemoryStateStore(),
+        resources: [
+          {
+            name: 'private_app',
+            uri: 'ui://private/app',
+            handler: async () => '<!doctype html><html><body>private</body></html>',
+          },
+        ],
+        customTools: {
+          open_private_app: {
+            _meta: { ui: { resourceUri: 'ui://private/app' } },
+            handler: async () => ({ content: [{ type: 'text', text: 'private' }] }),
+          },
+        },
       });
-      setToolVisibilityResolver(server, ({ toolName }) => toolName !== 'get_adcp_capabilities');
+      setToolVisibilityResolver(
+        server,
+        ({ toolName }) => toolName !== 'get_adcp_capabilities' && toolName !== 'open_private_app'
+      );
       return server;
     },
     { port: 0, onListening: () => {} }
@@ -409,5 +484,9 @@ test('modern serving honors per-request tool visibility', async t => {
   await client.connect(transport);
   const listed = await client.listTools();
   assert.ok(!listed.tools.some(tool => tool.name === 'get_adcp_capabilities'));
+  assert.ok(!listed.tools.some(tool => tool.name === 'open_private_app'));
+  const resources = await client.listResources();
+  assert.deepEqual(resources.resources, [], 'resources linked only from hidden tools must also be hidden');
   await assert.rejects(() => client.callTool({ name: 'get_adcp_capabilities', arguments: {} }));
+  await assert.rejects(() => client.readResource({ uri: 'ui://private/app' }));
 });

--- a/test/server-create-adcp-server.test.js
+++ b/test/server-create-adcp-server.test.js
@@ -382,6 +382,147 @@ describe('createAdcpServer', () => {
     });
   });
 
+  describe('MCP App resources', () => {
+    it('lists and reads a typed ui:// HTML resource on the legacy MCP path', async () => {
+      let seen;
+      const resourceMeta = {
+        ui: {
+          csp: {
+            connectDomains: ['https://api.example.com'],
+            resourceDomains: ['https://cdn.example.com'],
+          },
+          domain: 'creative-upload.example.com',
+          prefersBorder: true,
+        },
+      };
+      const server = createAdcpServer({
+        name: 'Test',
+        version: '1.0.0',
+        resources: [
+          {
+            name: 'creative_upload',
+            uri: 'ui://creative/upload',
+            title: 'Creative upload',
+            description: 'Upload creative assets without leaving the host.',
+            _meta: resourceMeta,
+            handler: async (uri, ctx) => {
+              seen = {
+                uri: uri.href,
+                hasAuthInfo: Object.hasOwn(ctx, 'authInfo'),
+                aborted: ctx.signal.aborted,
+              };
+              return '<!doctype html><html><body>upload</body></html>';
+            },
+          },
+        ],
+      });
+
+      const listed = await server.dispatchTestRequest({ method: 'resources/list' });
+      assert.deepStrictEqual(listed.resources, [
+        {
+          name: 'creative_upload',
+          uri: 'ui://creative/upload',
+          title: 'Creative upload',
+          description: 'Upload creative assets without leaving the host.',
+          mimeType: 'text/html;profile=mcp-app',
+          _meta: resourceMeta,
+        },
+      ]);
+
+      const read = await server.dispatchTestRequest(
+        { method: 'resources/read', params: { uri: 'ui://creative/upload' } },
+        { authInfo: { token: 'secret', clientId: 'buyer_1', scopes: [] } }
+      );
+      assert.deepStrictEqual(seen, { uri: 'ui://creative/upload', hasAuthInfo: false, aborted: false });
+      assert.deepStrictEqual(read.contents, [
+        {
+          uri: 'ui://creative/upload',
+          mimeType: 'text/html;profile=mcp-app',
+          text: '<!doctype html><html><body>upload</body></html>',
+          _meta: resourceMeta,
+        },
+      ]);
+    });
+
+    it('fails construction for invalid or duplicate resource definitions', () => {
+      const html = async () => '<!doctype html><html></html>';
+      assert.throws(
+        () =>
+          createAdcpServer({
+            name: 'Test',
+            version: '1.0.0',
+            resources: [{ name: 'bad', uri: 'https://example.com/app', handler: html }],
+          }),
+        /resources\[0\]\.uri must use the ui:\/\/ scheme/
+      );
+      assert.throws(
+        () =>
+          createAdcpServer({
+            name: 'Test',
+            version: '1.0.0',
+            resources: [
+              { name: 'one', uri: 'ui://creative/upload', handler: html },
+              { name: 'two', uri: 'ui://creative/upload', handler: html },
+            ],
+          }),
+        /duplicate MCP App resource URI/
+      );
+      assert.throws(
+        () =>
+          createAdcpServer({
+            name: 'Test',
+            version: '1.0.0',
+            resources: [{ name: 'noncanonical', uri: 'ui://creative/upload/../other', handler: html }],
+          }),
+        /must be a valid canonical ui:\/\/ URI \(non-canonical URI; use "ui:\/\/creative\/other"\)/
+      );
+    });
+
+    it('logs private resource-handler failures but returns a fixed public error', async t => {
+      const errorLog = t.mock.method(console, 'error', () => {});
+      const server = createAdcpServer({
+        name: 'Test',
+        version: '1.0.0',
+        resources: [
+          {
+            name: 'creative_upload',
+            uri: 'ui://creative/upload',
+            handler: async () => {
+              throw new Error('provider password: top-secret');
+            },
+          },
+        ],
+      });
+
+      await assert.rejects(
+        () => server.dispatchTestRequest({ method: 'resources/read', params: { uri: 'ui://creative/upload' } }),
+        error => {
+          assert.doesNotMatch(error.message, /top-secret/);
+          assert.match(error.message, /MCP App resource is temporarily unavailable/);
+          return true;
+        }
+      );
+      assert.strictEqual(errorLog.mock.callCount(), 1, 'private cause should remain observable server-side');
+    });
+
+    it('warns when a tool links to an unregistered resource URI', () => {
+      const warn = mock.fn();
+      createAdcpServer({
+        name: 'Test',
+        version: '1.0.0',
+        logger: { debug() {}, info() {}, warn, error() {} },
+        customTools: {
+          upload_creative_asset: {
+            _meta: { ui: { resourceUri: 'ui://creative/missing' } },
+            handler: async () => ({ content: [{ type: 'text', text: 'Text-only fallback' }] }),
+          },
+        },
+      });
+      assert.strictEqual(warn.mock.callCount(), 1);
+      assert.match(warn.mock.calls[0].arguments[0], /ui:\/\/creative\/missing/);
+    });
+  });
+
   describe('auto-generated capabilities', () => {
     it('detects media_buy protocol from mediaBuy handlers', async () => {
       const server = createAdcpServer({


### PR DESCRIPTION
## Why

Custom tools can now advertise portable MCP App metadata, but adopters still cannot register the referenced `ui://` HTML resource through the public AdCP server API. That leaves compliant hosts unable to complete `resources/read` without reaching through private MCP SDK internals, and the modern server adapter reconstructs its MCP server per request so one-time registration is insufficient.

## What Changed

- add a typed `resources` option for static MCP App HTML, including the stable MIME type, CSP, permissions, dedicated domain, border preference, and a cancellation-aware reader
- register the same resource definitions on the legacy MCP SDK server and every modern per-request server reconstruction
- emit identical metadata through `resources/list` and `resources/read`, reject invalid/non-canonical `ui://` URIs and duplicate names/URIs, and warn when a tool links to a missing resource
- preserve ordinary text tool results for clients that do not negotiate MCP Apps
- hide a modern resource when every tool linking to it is hidden by the request's tool-visibility policy
- keep resource HTML principal-independent and cache-safe by withholding authentication material from resource handlers; authenticated app-only tools own tenant data and signed URL minting
- sanitize resource-handler failures on the wire while retaining the private cause in server logs
- document the model-visible origin tool + app-only prepare/finalize pattern and add a patch changeset

## Validation

- `npm run ci:quick`
- `npm run typecheck`
- `npm run build:lib`
- `NODE_ENV=test node --test test/server-create-adcp-server.test.js test/lib/mcp-modern-negotiation.test.js` (138/138)
- repository pre-push validation
- `npm run review:codex -- --all --base main` (protocol, code, security; all actionable findings addressed)

Closes #2368
