### PR TITLE
fix(oauth): support scoped fetch during MCP refresh

### DIFF
--- a/.changeset/tidy-mice-fetch.md
+++ b/.changeset/tidy-mice-fetch.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Allow MCP OAuth callers to supply a scoped `fetchFn` for transport requests, discovery, and token refresh.

--- a/src/lib/advanced.ts
+++ b/src/lib/advanced.ts
@@ -38,4 +38,13 @@
  * - Type-safe tool methods
  * - Error handling and validation
  */
-export { ProtocolClient, callMCPTool, callA2ATool, createMCPClient, createA2AClient } from './protocols';
+export {
+  ProtocolClient,
+  callMCPTool,
+  callMCPToolWithOAuth,
+  connectMCP,
+  callA2ATool,
+  createMCPClient,
+  createA2AClient,
+} from './protocols';
+export type { MCPCallOptions, MCPConnectionResult } from './protocols';

--- a/src/lib/protocols/mcp-modern.ts
+++ b/src/lib/protocols/mcp-modern.ts
@@ -43,6 +43,7 @@ export interface ModernMCPConnectionOptions {
   authProvider?: object;
   signal?: AbortSignal;
   requestTimeoutMs?: number;
+  fetchFn?: typeof fetch;
   /** Use the v2 SDK's negotiated legacy client instead of handing off to v1. */
   handleLegacy?: boolean;
 }
@@ -56,6 +57,7 @@ interface ModernConnectionOptions {
   authProvider?: object;
   signal?: AbortSignal;
   requestTimeoutMs?: number;
+  fetchFn?: typeof fetch;
   handleLegacy?: boolean;
 }
 
@@ -66,7 +68,9 @@ const knownLegacyConnections = new Map<string, number>();
 const MAX_CACHED_CONNECTIONS = 20;
 const LEGACY_CLASSIFICATION_TTL_MS = 5 * 60 * 1000;
 const modernOAuthProviderIds = new WeakMap<object, string>();
+const modernFetchFnIds = new WeakMap<typeof fetch, string>();
 let nextModernOAuthProviderId = 0;
+let nextModernFetchFnId = 0;
 let connectionGeneration = 0;
 
 function cacheDisambiguator(value: string): string {
@@ -103,11 +107,22 @@ function oauthProviderCacheKey(provider: object | undefined): string | undefined
   return key;
 }
 
+function fetchFnCacheKey(fetchFn: typeof fetch | undefined): string | undefined {
+  if (!fetchFn) return undefined;
+  let key = modernFetchFnIds.get(fetchFn);
+  if (!key) {
+    key = `fetch:${++nextModernFetchFnId}`;
+    modernFetchFnIds.set(fetchFn, key);
+  }
+  return key;
+}
+
 function connectionCacheKey(
   agentUrl: string,
   headers: Record<string, string>,
   signingCacheKey?: string,
-  authProvider?: object
+  authProvider?: object,
+  fetchFn?: typeof fetch
 ): string {
   const normalizedHeaders = Object.entries(headers)
     .map(([key, value]) => [key.toLowerCase(), value] as const)
@@ -116,6 +131,8 @@ function connectionCacheKey(
   if (signingCacheKey) parts.push(signingCacheKey);
   const providerKey = oauthProviderCacheKey(authProvider);
   if (providerKey) parts.push(providerKey);
+  const fetchKey = fetchFnCacheKey(fetchFn);
+  if (fetchKey) parts.push(fetchKey);
   return parts.join('::');
 }
 
@@ -191,7 +208,7 @@ async function createNegotiatedClient(
 ): Promise<Client> {
   const requestTimeoutMs = resolveRequestTimeoutMs(options.requestTimeoutMs);
   const clientRequestTimeoutMs = resolveClientRequestTimeoutMs(options.requestTimeoutMs);
-  const rawNetworkFetch: typeof fetch = (input, init) => fetch(input, init);
+  const rawNetworkFetch: typeof fetch = options.fetchFn ?? ((input, init) => fetch(input, init));
   const networkFetch: typeof fetch = (input, init) =>
     withAbortSignal<Response>([options.signal, init?.signal], requestTimeoutMs, signal =>
       rawNetworkFetch(input, { ...init, signal })
@@ -301,11 +318,13 @@ async function attemptModernCall(
     options.agentUrl,
     authHeaders,
     options.signingContext?.cacheKey,
-    options.authProvider
+    options.authProvider,
+    options.fetchFn
   );
   if (isKnownLegacy(cacheKey)) return { handled: false };
 
-  const guardedConnection = options.signal !== undefined || options.requestTimeoutMs !== undefined;
+  const guardedConnection =
+    options.signal !== undefined || options.requestTimeoutMs !== undefined || options.fetchFn !== undefined;
   let client: Client;
   try {
     client = guardedConnection
@@ -408,6 +427,7 @@ export async function tryCallModernMCPTool(
           authProvider: options.authProvider,
           signal: options.signal,
           requestTimeoutMs: options.requestTimeoutMs,
+          fetchFn: options.fetchFn,
           handleLegacy: options.handleLegacy,
         },
         toolName,
@@ -436,6 +456,7 @@ export async function probeModernMCPConnection(
     authProvider: options.authProvider,
     signal: options.signal,
     requestTimeoutMs: options.requestTimeoutMs,
+    fetchFn: options.fetchFn,
     handleLegacy: options.handleLegacy,
   };
   const authHeaders = buildAuthHeaders(authToken, customHeaders, options.authProvider);
@@ -469,6 +490,7 @@ export async function tryListModernMCPTools(
     authProvider: options.authProvider,
     signal: options.signal,
     requestTimeoutMs: options.requestTimeoutMs,
+    fetchFn: options.fetchFn,
   };
   const authHeaders = buildAuthHeaders(authToken, customHeaders, options.authProvider);
   let client: Client | undefined;

--- a/src/lib/protocols/mcp.ts
+++ b/src/lib/protocols/mcp.ts
@@ -57,8 +57,10 @@ const pendingConnections = new Map<string, Promise<MCPClient>>();
 const oauthConnectionCache = new Map<string, MCPClient>();
 const pendingOAuthConnections = new Map<string, Promise<MCPClient>>();
 const oauthProviderIds = new WeakMap<OAuthClientProvider, string>();
+const oauthFetchFnIds = new WeakMap<typeof fetch, string>();
 const MAX_CACHED_CONNECTIONS = 20;
 let nextOAuthProviderId = 0;
+let nextOAuthFetchFnId = 0;
 
 /**
  * Track URLs where StreamableHTTP has previously connected successfully.
@@ -272,6 +274,15 @@ function getOAuthProviderDisambiguator(authProvider: OAuthClientProvider): strin
   return id;
 }
 
+function getOAuthFetchFnDisambiguator(fetchFn: typeof fetch): string {
+  let id = oauthFetchFnIds.get(fetchFn);
+  if (!id) {
+    id = cacheDisambiguator(`oauth-fetch:${++nextOAuthFetchFnId}`);
+    oauthFetchFnIds.set(fetchFn, id);
+  }
+  return id;
+}
+
 function customHeadersDisambiguator(customHeaders?: Record<string, string>): string | undefined {
   return headersCacheDisambiguator(customHeaders);
 }
@@ -280,12 +291,14 @@ function oauthConnectionCacheKey(
   agentUrl: string,
   authProvider: OAuthClientProvider,
   signingCacheKey?: string,
-  customHeaders?: Record<string, string>
+  customHeaders?: Record<string, string>,
+  fetchFn?: typeof fetch
 ): string {
   const parts = [`${agentUrl}::oauth:${getOAuthProviderDisambiguator(authProvider)}`];
   if (signingCacheKey) parts.push(signingCacheKey);
   const headersKey = customHeadersDisambiguator(customHeaders);
   if (headersKey) parts.push(`headers:${headersKey}`);
+  if (fetchFn) parts.push(`fetch:${getOAuthFetchFnDisambiguator(fetchFn)}`);
   return parts.join('::');
 }
 
@@ -309,6 +322,7 @@ async function getOrCreateOAuthConnection(
     signingContext?: AgentSigningContext;
     signal?: AbortSignal;
     requestTimeoutMs?: number;
+    fetchFn?: typeof fetch;
   }
 ): Promise<MCPClient> {
   const cached = getCachedOAuthConnection(cacheKey);
@@ -340,6 +354,7 @@ async function withCachedOAuthConnection<T>(
     signingContext?: AgentSigningContext;
     signal?: AbortSignal;
     requestTimeoutMs?: number;
+    fetchFn?: typeof fetch;
   },
   label: string,
   fn: (client: MCPClient) => Promise<T>
@@ -348,9 +363,10 @@ async function withCachedOAuthConnection<T>(
     options.agentUrl,
     options.authProvider,
     options.signingContext?.cacheKey,
-    options.customHeaders
+    options.customHeaders,
+    options.fetchFn
   );
-  if (options.signal || options.requestTimeoutMs !== undefined) {
+  if (options.signal || options.requestTimeoutMs !== undefined || options.fetchFn) {
     const { client } = await connectMCP(options);
     try {
       return await fn(client);
@@ -546,6 +562,12 @@ export interface MCPCallOptions {
   signal?: AbortSignal;
   /** Optional per-request timeout for connect and callTool. */
   requestTimeoutMs?: number;
+  /**
+   * Scoped fetch implementation used for MCP requests, OAuth discovery, and token exchange.
+   * Calls with a scoped fetcher use an isolated one-shot connection rather than the shared
+   * OAuth connection cache, so callers must not rely on cross-call MCP session state.
+   */
+  fetchFn?: typeof fetch;
 }
 
 /**
@@ -969,6 +991,7 @@ export async function connectMCP(options: {
   signingContext?: AgentSigningContext;
   signal?: AbortSignal;
   requestTimeoutMs?: number;
+  fetchFn?: typeof fetch;
 }): Promise<MCPConnectionResult> {
   const {
     agentUrl,
@@ -979,6 +1002,7 @@ export async function connectMCP(options: {
     signingContext,
     signal,
     requestTimeoutMs: configuredRequestTimeoutMs,
+    fetchFn,
   } = options;
   const baseUrl = new URL(agentUrl);
 
@@ -1049,9 +1073,10 @@ export async function connectMCP(options: {
     ...(signal && { signal }),
     ...(clientRequestTimeoutMs !== undefined && { timeout: clientRequestTimeoutMs }),
   };
+  const rawNetworkFetch: typeof fetch = fetchFn ?? ((input, init) => fetch(input, init));
   const sizeLimited = wrapFetchWithSizeLimit((input, init) =>
     withAbortSignal<Response>([signal, init?.signal], requestTimeoutMs, linkedSignal =>
-      fetch(input as string | URL, { ...init, signal: linkedSignal })
+      rawNetworkFetch(input, { ...init, signal: linkedSignal })
     )
   );
   const diagnosticFetch = wrapFetchWithTransportDiagnostics(sizeLimited);
@@ -1135,6 +1160,10 @@ export async function connectMCP(options: {
  * session/source/principal; the provider owns token refresh state for the
  * cached transport.
  *
+ * Supplying `fetchFn` opts out of connection reuse. Scoped fetchers commonly
+ * carry request- or tenant-specific network policy, so each call gets an
+ * isolated connection that is closed after the tool response.
+ *
  * Signing: this path consumes `options.signingContext` via the transport —
  * `connectMCP` attaches a signing-fetch wrapper at transport-creation time —
  * rather than via `signingContextStorage`. The OAuth cache key includes the
@@ -1157,6 +1186,7 @@ export async function callMCPToolWithOAuth(options: MCPCallOptions): Promise<unk
     signingContext,
     signal,
     requestTimeoutMs,
+    fetchFn,
   } = options;
   const resolvedRequestTimeoutMs = resolveClientRequestTimeoutMs(requestTimeoutMs);
   const requestOptions = {
@@ -1166,7 +1196,7 @@ export async function callMCPToolWithOAuth(options: MCPCallOptions): Promise<unk
 
   // If no OAuth provider, use the legacy function
   if (!authProvider) {
-    return callMCPTool(agentUrl, toolName, args, authToken, debugLogs, customHeaders, signingContext, undefined, {
+    return callMCPTool(agentUrl, toolName, args, authToken, debugLogs, customHeaders, signingContext, fetchFn, {
       signal,
       requestTimeoutMs,
     });
@@ -1177,6 +1207,7 @@ export async function callMCPToolWithOAuth(options: MCPCallOptions): Promise<unk
     signingContext,
     signal,
     requestTimeoutMs,
+    fetchFn,
     handleLegacy: true,
   });
   if (modernAttempt.handled) {
@@ -1197,6 +1228,7 @@ export async function callMCPToolWithOAuth(options: MCPCallOptions): Promise<unk
       signingContext,
       signal,
       requestTimeoutMs,
+      fetchFn,
     },
     toolName,
     async client => {

--- a/test/lib/mcp-oauth-scoped-fetch.test.js
+++ b/test/lib/mcp-oauth-scoped-fetch.test.js
@@ -1,0 +1,239 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { createServer } = require('node:http');
+
+const { callMCPToolWithOAuth, connectMCP } = require('../../dist/lib/advanced.js');
+const { closeMCPConnections } = require('../../dist/lib/protocols/mcp.js');
+
+function createRefreshProvider(issuer) {
+  let tokens = {
+    access_token: 'expired-token',
+    refresh_token: 'refresh-token',
+    token_type: 'Bearer',
+    issuer,
+  };
+  return {
+    get redirectUrl() {
+      return 'http://127.0.0.1/oauth/callback';
+    },
+    get clientMetadata() {
+      return {
+        client_name: 'scoped-fetch-test',
+        redirect_uris: [this.redirectUrl],
+        grant_types: ['authorization_code', 'refresh_token'],
+        response_types: ['code'],
+        token_endpoint_auth_method: 'none',
+      };
+    },
+    async clientInformation() {
+      return { client_id: 'scoped-fetch-client' };
+    },
+    async tokens() {
+      return tokens;
+    },
+    async saveTokens(nextTokens) {
+      tokens = nextTokens;
+    },
+    async redirectToAuthorization() {
+      throw new Error('refresh should not start an interactive authorization flow');
+    },
+    async saveCodeVerifier() {},
+    async codeVerifier() {
+      return 'verifier';
+    },
+    async invalidateCredentials() {},
+  };
+}
+
+function json(res, status, body) {
+  res.writeHead(status, { 'content-type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+async function readBody(req) {
+  let body = '';
+  for await (const chunk of req) body += chunk;
+  return body;
+}
+
+async function listen(server) {
+  await new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const address = server.address();
+  assert.ok(address && typeof address === 'object');
+  return `http://127.0.0.1:${address.port}`;
+}
+
+async function closeServer(server) {
+  if (typeof server.closeAllConnections === 'function') server.closeAllConnections();
+  await new Promise(resolve => server.close(resolve));
+}
+
+async function startOAuthServer(era) {
+  const state = { origin: '', refreshCalls: 0 };
+  let modernHandler;
+  let closeModernHandler = async () => {};
+
+  if (era === 'modern') {
+    const { createMcpHandler, McpServer } = require('@modelcontextprotocol/server');
+    const { toNodeHandler } = require('@modelcontextprotocol/node');
+    const handler = createMcpHandler(
+      () => {
+        const mcp = new McpServer({ name: 'scoped-fetch-modern', version: '1.0.0' });
+        mcp.registerTool('ping', {}, async () => ({ content: [{ type: 'text', text: 'pong' }] }));
+        return mcp;
+      },
+      { legacy: 'reject' }
+    );
+    modernHandler = toNodeHandler(handler);
+    closeModernHandler = () => handler.close();
+  }
+
+  const server = createServer(async (req, res) => {
+    const path = new URL(req.url, state.origin).pathname;
+
+    if (path.startsWith('/.well-known/oauth-protected-resource')) {
+      json(res, 200, {
+        resource: `${state.origin}/mcp`,
+        authorization_servers: [state.origin],
+      });
+      return;
+    }
+    if (path.startsWith('/.well-known/oauth-authorization-server')) {
+      json(res, 200, {
+        issuer: state.origin,
+        authorization_endpoint: `${state.origin}/authorize`,
+        token_endpoint: `${state.origin}/token`,
+        grant_types_supported: ['authorization_code', 'refresh_token'],
+        response_types_supported: ['code'],
+        token_endpoint_auth_methods_supported: ['none'],
+      });
+      return;
+    }
+    if (path === '/token' && req.method === 'POST') {
+      const body = new URLSearchParams(await readBody(req));
+      assert.equal(body.get('grant_type'), 'refresh_token');
+      assert.equal(body.get('refresh_token'), 'refresh-token');
+      state.refreshCalls++;
+      json(res, 200, {
+        access_token: 'fresh-token',
+        refresh_token: 'refresh-token',
+        token_type: 'Bearer',
+        expires_in: 3600,
+      });
+      return;
+    }
+    if (path !== '/mcp' && path !== '/mcp/') {
+      res.writeHead(404);
+      res.end('not found');
+      return;
+    }
+    if (req.headers.authorization !== 'Bearer fresh-token') {
+      res.writeHead(401, {
+        'www-authenticate': `Bearer resource_metadata="${state.origin}/.well-known/oauth-protected-resource/mcp"`,
+      });
+      res.end('unauthorized');
+      return;
+    }
+
+    if (era === 'modern') {
+      await modernHandler(req, res);
+      return;
+    }
+
+    const { McpServer } = require('@modelcontextprotocol/sdk/server/mcp.js');
+    const { StreamableHTTPServerTransport } = require('@modelcontextprotocol/sdk/server/streamableHttp.js');
+    const parsedBody = req.method === 'POST' ? JSON.parse(await readBody(req)) : undefined;
+    const mcp = new McpServer({ name: 'scoped-fetch-legacy', version: '1.0.0' });
+    mcp.registerTool('ping', { inputSchema: {} }, async () => ({ content: [{ type: 'text', text: 'pong' }] }));
+    const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+    try {
+      await mcp.connect(transport);
+      await transport.handleRequest(req, res, parsedBody);
+    } finally {
+      await mcp.close();
+    }
+  });
+
+  state.origin = await listen(server);
+  return {
+    url: `${state.origin}/mcp`,
+    state,
+    stop: async () => {
+      await closeModernHandler();
+      await closeServer(server);
+    },
+  };
+}
+
+async function withGlobalFetchGuard(run) {
+  const originalFetch = global.fetch;
+  const fetchedUrls = [];
+  const fetchFn = async (input, init) => {
+    fetchedUrls.push(String(input instanceof Request ? input.url : input));
+    return originalFetch(input, init);
+  };
+  global.fetch = async () => {
+    throw new Error('global fetch must not be used when fetchFn is supplied');
+  };
+  try {
+    await run(fetchFn, fetchedUrls);
+  } finally {
+    global.fetch = originalFetch;
+  }
+}
+
+test('modern OAuth refresh uses the scoped fetcher instead of global fetch', async () => {
+  await closeMCPConnections();
+  const server = await startOAuthServer('modern');
+  try {
+    await withGlobalFetchGuard(async (fetchFn, fetchedUrls) => {
+      const result = await callMCPToolWithOAuth({
+        agentUrl: server.url,
+        toolName: 'ping',
+        args: {},
+        authProvider: createRefreshProvider(server.state.origin),
+        fetchFn,
+      });
+      assert.equal(result.content[0].text, 'pong');
+      assert.ok(
+        fetchedUrls.some(url => url.endsWith('/token')),
+        'scoped fetcher should perform the token exchange'
+      );
+    });
+    assert.equal(server.state.refreshCalls, 1);
+  } finally {
+    await closeMCPConnections();
+    await server.stop();
+  }
+});
+
+test('legacy OAuth refresh uses the scoped fetcher instead of global fetch', async () => {
+  await closeMCPConnections();
+  const server = await startOAuthServer('legacy');
+  try {
+    await withGlobalFetchGuard(async (fetchFn, fetchedUrls) => {
+      const { client } = await connectMCP({
+        agentUrl: server.url,
+        authProvider: createRefreshProvider(server.state.origin),
+        fetchFn,
+      });
+      try {
+        const result = await client.callTool({ name: 'ping', arguments: {} });
+        assert.equal(result.content[0].text, 'pong');
+      } finally {
+        await client.close();
+      }
+      assert.ok(
+        fetchedUrls.some(url => url.endsWith('/token')),
+        'scoped fetcher should perform the token exchange'
+      );
+    });
+    assert.equal(server.state.refreshCalls, 1);
+  } finally {
+    await closeMCPConnections();
+    await server.stop();
+  }
+});

--- a/test/lib/new-client.test.js
+++ b/test/lib/new-client.test.js
@@ -210,9 +210,17 @@ describe('Integration with existing codebase', () => {
   });
 
   test('should work with protocol clients from /advanced', () => {
-    const { callMCPTool, callA2ATool, ProtocolClient } = require('../../dist/lib/advanced.js');
+    const {
+      callMCPTool,
+      callMCPToolWithOAuth,
+      connectMCP,
+      callA2ATool,
+      ProtocolClient,
+    } = require('../../dist/lib/advanced.js');
 
     assert(typeof callMCPTool === 'function', 'MCP client should be available in /advanced');
+    assert(typeof callMCPToolWithOAuth === 'function', 'OAuth MCP client should be available in /advanced');
+    assert(typeof connectMCP === 'function', 'low-level MCP connection should be available in /advanced');
     assert(typeof callA2ATool === 'function', 'A2A client should be available in /advanced');
     assert(typeof ProtocolClient === 'function', 'ProtocolClient should be available in /advanced');
   });


### PR DESCRIPTION
## Summary

- add a scoped `fetchFn` to MCP OAuth calls and low-level connections
- use the supplied fetcher for modern and legacy MCP transport, OAuth discovery, and refresh token exchange
- isolate scoped fetchers from shared OAuth connection caches and expose the API through `@adcp/sdk/advanced`
- add modern and legacy refresh integration coverage that fails if global `fetch` is used

## Root cause

The MCP transports used global `fetch` during SDK-managed OAuth discovery and refresh. Hosted consumers therefore could not carry their DNS-rebinding, redirect, and private-address protections into refresh-time requests.

## Impact

Hosted consumers can now supply one SSRF-safe fetch implementation for the complete MCP OAuth request chain. Existing CLI and SDK callers retain global `fetch` by default. Scoped fetch calls intentionally use isolated one-shot connections, so they do not preserve cross-call MCP session state.

## Validation

- `npm run build`
- `npm run typecheck`
- `npm run check:package`
- `node --test --test-timeout=60000 test/lib/new-client.test.js test/lib/mcp-modern-negotiation.test.js test/lib/mcp-oauth-connection-cache.test.js test/lib/mcp-oauth-scoped-fetch.test.js`
- protocol expert: no findings
- security expert: no findings
- DX expert: public export finding fixed; one-shot cache behavior documented as the accepted security tradeoff

Closes #2380
