### PR TITLE
fix(server): route update media buy handoffs through task registry

### DIFF
--- a/.changeset/fix-update-media-buy-task-handoff.md
+++ b/.changeset/fix-update-media-buy-task-handoff.md
@@ -1,0 +1,13 @@
+---
+'@adcp/sdk': patch
+---
+
+Route `update_media_buy` task handoffs through the framework task registry so
+background updates receive the same caller scope, polling support, and webhook
+lifecycle as `create_media_buy`.
+
+**Upgrade warning:** adopters that worked around this bug by calling
+`taskRegistry.create(...)` manually must remove that workaround before
+upgrading. Leaving both paths active can register the update twice and emit
+duplicate async completion webhooks; the framework does not deduplicate a
+manually registered task against `ctx.handoffToTask(...)`.

--- a/src/lib/server/decisioning/decisioning.type-checks.ts
+++ b/src/lib/server/decisioning/decisioning.type-checks.ts
@@ -33,6 +33,7 @@ import type {
   CreateMediaBuyHandlerResult,
   CreateMediaBuyPayload,
   UpdateMediaBuyPayload,
+  UpdateMediaBuyHandlerResult,
   GetMediaBuyDeliveryPayload,
   GetMediaBuysPayload,
   GetAccountFinancialsHandlerResult,
@@ -442,7 +443,7 @@ function _sales_platform_handler_results_accept_task_handoff() {
   const sales: SalesCorePlatform<_SocialMeta> & SalesIngestionPlatform<_SocialMeta> = {
     getProducts: async (_req, ctx) => ctx.handoffToTask(async () => ({ products: [], cache_scope: 'account' })),
     createMediaBuy: async (_req, ctx) => ctx.handoffToTask(async () => _createBuyPayload()),
-    updateMediaBuy: async () => _updateBuyPayload(),
+    updateMediaBuy: async (_buyId, _patch, ctx) => ctx.handoffToTask(async () => _updateBuyPayload()),
     getMediaBuyDelivery: async () => ({
       reporting_period: { start: '2026-01-01', end: '2026-01-31' },
       media_buy_deliveries: [],
@@ -453,9 +454,11 @@ function _sales_platform_handler_results_accept_task_handoff() {
 
   const getProductsResult: GetProductsHandlerResult = { products: [], cache_scope: 'account' };
   const createResult: CreateMediaBuyHandlerResult = _createBuyPayload();
+  const updateResult: UpdateMediaBuyHandlerResult = _updateBuyPayload();
   const syncResult: SyncCreativesHandlerResult = [];
   void getProductsResult;
   void createResult;
+  void updateResult;
   void syncResult;
   return sales;
 }

--- a/src/lib/server/decisioning/index.ts
+++ b/src/lib/server/decisioning/index.ts
@@ -242,6 +242,7 @@ export type {
   CreateMediaBuyPayload,
   CreateMediaBuyHandlerResult,
   UpdateMediaBuyPayload,
+  UpdateMediaBuyHandlerResult,
   GetMediaBuyDeliveryPayload,
   GetMediaBuysPayload,
   ProvidePerformanceFeedbackPayload,

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -2850,10 +2850,11 @@ function rejectHandRolledSubmitted(result: unknown): void {
  * projection.
  *
  * Adopter return type is `Success | TaskHandoff<Success>`. Each
- * specialism dispatcher uses this helper so all three call sites
- * (`createMediaBuy`, `sales.syncCreatives`, `creative.syncCreatives`)
+ * specialism dispatcher uses this helper so all four call sites
+ * (`createMediaBuy`, `updateMediaBuy`, `sales.syncCreatives`,
+ * `creative.syncCreatives`)
  * route through a single seam — closes round-6 CR-1 (drift across
- * three near-identical `isTaskHandoff` branches).
+ * near-identical `isTaskHandoff` branches).
  *
  * `project` shapes both arms identically — for `syncCreatives`,
  * `rows → { creatives: rows }`; for `createMediaBuy`, identity.
@@ -4321,38 +4322,35 @@ function buildMediaBuyHandlers<P extends DecisioningPlatform<any, any>>(
               allowPrivateWebhookUrls: pushOpts.allowPrivateWebhookUrls,
             });
             const result = await sales!.updateMediaBuy!(media_buy_id, params, reqCtx);
-            // Persist optimistically: the platform method returned without
-            // throwing, so the patch was accepted at the seam. If the
-            // publisher returned an error envelope on the success path
-            // (rare but possible — `update_media_buy` can return a Failed
-            // status arm in the wire schema), the persisted overlay
-            // diverges from the seller's view of the buy. Adopters who
-            // need stricter coupling should not return error-shaped
-            // success arms; the spec's preferred shape is to throw an
-            // `AdcpError` for genuine failures.
-            await persistTargetingOverlayFromUpdate(mediaBuyStore, reqCtx.account?.id, media_buy_id, params, logger);
-            // F12 sync auto-emit. updateMediaBuy is sync-only on the
-            // platform interface (no TaskHandoff arm — spec response
-            // doesn't include Submitted), so we don't route through
-            // routeIfHandoff. Fire-and-forget to keep slowloris webhook
-            // receivers from blocking the sync response.
-            if (pushOpts.autoEmitCompletionWebhooks && push.url) {
-              const emitOpts = {
-                tool: 'update_media_buy' as const,
+            return routeIfHandoff(
+              taskRegistry,
+              {
+                tool: 'update_media_buy',
                 accountId: reqCtx.account.id,
+                ownerScope: taskOwnerScopeFor(ctx, reqCtx.account.id),
                 pushNotificationUrl: push.url,
-                ...(push.token !== undefined && { pushNotificationToken: push.token }),
-                ...(push.operationId !== undefined && { pushNotificationOperationId: push.operationId }),
+                pushNotificationToken: push.token,
+                pushNotificationOperationId: push.operationId,
                 emitWebhook: taskWebhookEmit ?? ctx.emitWebhook,
-                ...(observability && { observability }),
+                autoEmitCompletion: pushOpts.autoEmitCompletionWebhooks,
+                observability,
                 logger,
-              };
-              void emitSyncCompletionWebhook(emitOpts, result).catch((err: unknown) => {
-                const msg = err instanceof Error ? err.message : String(err);
-                logger.warn(`[adcp/decisioning] sync completion webhook background-error: ${msg}`);
-              });
-            }
-            return result;
+              },
+              result,
+              async r => {
+                // A TaskHandoff marker is not acceptance of the patch. Apply
+                // the local overlay only when the sync call or background
+                // task completes and the result is projected to the wire.
+                await persistTargetingOverlayFromUpdate(
+                  mediaBuyStore,
+                  reqCtx.account?.id,
+                  media_buy_id,
+                  params,
+                  logger
+                );
+                return r;
+              }
+            );
           },
           r => r
         );

--- a/src/lib/server/decisioning/specialisms/sales.ts
+++ b/src/lib/server/decisioning/specialisms/sales.ts
@@ -118,6 +118,7 @@ export type SyncEventSourcesPayload = ServerPayload<SyncEventSourcesSuccess>;
 export type SyncCreativesRow = SyncCreativesSuccess['creatives'][number];
 export type GetProductsHandlerResult = GetProductsPayload | TaskHandoff<GetProductsPayload>;
 export type CreateMediaBuyHandlerResult = CreateMediaBuyPayload | TaskHandoff<CreateMediaBuyPayload>;
+export type UpdateMediaBuyHandlerResult = UpdateMediaBuyPayload | TaskHandoff<UpdateMediaBuyPayload>;
 export type SyncCreativesHandlerResult = SyncCreativesRow[] | TaskHandoff<SyncCreativesRow[]>;
 
 export interface SalesPlatform<TCtxMeta = Record<string, unknown>> {
@@ -203,17 +204,18 @@ export interface SalesPlatform<TCtxMeta = Record<string, unknown>> {
    */
   createMediaBuy?(req: CreateMediaBuyRequest, ctx: Ctx<TCtxMeta>): Promise<CreateMediaBuyHandlerResult>;
 
-  // ── update_media_buy: sync only (today) ─────────────────────────────
-  // Spec inconsistency — same root cause as get_products above. The
-  // `UpdateMediaBuyAsyncSubmitted` schema exists, but the per-tool
-  // `update-media-buy-response.json` `oneOf` doesn't reference it, so
-  // codegen produces `Success | Error` (no Submitted). Tracked as
-  // adcontextprotocol/adcp#3392. Until that lands, operator
-  // re-approval flows surface eventual transitions via
-  // `publishStatusChange` on `resource_type: 'media_buy'` rather than
-  // HITL on this tool.
-  /** Sync update. Returns the patched buy. */
-  updateMediaBuy?(buyId: string, patch: UpdateMediaBuyRequest, ctx: Ctx<TCtxMeta>): Promise<UpdateMediaBuyPayload>;
+  // ── update_media_buy: unified hybrid shape
+  /**
+   * Update a media buy. Return the patched buy immediately (sync fast path)
+   * OR `ctx.handoffToTask(fn)` when the upstream activation or approval flow
+   * must continue in the background. The framework owns task registration,
+   * caller scoping, polling, and completion webhooks on the handoff path.
+   */
+  updateMediaBuy?(
+    buyId: string,
+    patch: UpdateMediaBuyRequest,
+    ctx: Ctx<TCtxMeta>
+  ): Promise<UpdateMediaBuyHandlerResult>;
 
   // ── sync_creatives: unified hybrid shape ────────────────────────────
 

--- a/test/server-decisioning-from-platform.test.js
+++ b/test/server-decisioning-from-platform.test.js
@@ -698,6 +698,21 @@ describe('HITL dual-method dispatch — *Task variants', () => {
     });
   }
 
+  function dispatchUpdate(server, overrides = {}) {
+    return server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'update_media_buy',
+        arguments: {
+          media_buy_id: 'mb_1',
+          idempotency_key: '33333333-3333-3333-3333-333333333333',
+          account: { account_id: 'acc_1' },
+          ...overrides,
+        },
+      },
+    });
+  }
+
   function dispatchGetProducts(server, overrides = {}) {
     return server.dispatchTestRequest({
       method: 'tools/call',
@@ -1188,6 +1203,81 @@ describe('HITL dual-method dispatch — *Task variants', () => {
     const finalRecord = await server.getTaskState(taskId);
     assert.strictEqual(finalRecord.status, 'completed');
     assert.deepStrictEqual(finalRecord.result, { media_buy_id: 'mb_final', status: 'active' });
+  });
+
+  it('updateMediaBuy returning ctx.handoffToTask is caller-scoped and pollable through task status', async () => {
+    let capturedTaskId;
+    const platform = buildHitlPlatform({
+      updateMediaBuy: async (_buyId, _patch, ctx) =>
+        ctx.handoffToTask(async taskCtx => {
+          capturedTaskId = taskCtx.id;
+          await new Promise(r => setTimeout(r, 20));
+          return { media_buy_id: 'mb_1', status: 'paused' };
+        }),
+    });
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'update-hitl',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+      resolveSessionKey: () => 'buyer-session-1',
+    });
+
+    const submitted = await dispatchUpdate(server);
+    assert.strictEqual(submitted.structuredContent.status, 'submitted');
+    assert.ok(submitted.structuredContent.task_id.startsWith('task_'));
+    assert.strictEqual(submitted.structuredContent.task_id, capturedTaskId);
+    assert.strictEqual(submitted.structuredContent.media_buy_id, undefined);
+
+    const taskId = submitted.structuredContent.task_id;
+    await server.awaitTask(taskId);
+
+    const polled = await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'get_task_status',
+        arguments: { task_id: taskId, include_result: true, account: { account_id: 'acc_1' } },
+      },
+    });
+    assert.notStrictEqual(polled.isError, true, JSON.stringify(polled.structuredContent));
+    assert.strictEqual(polled.structuredContent.task_type, 'update_media_buy');
+    assert.strictEqual(polled.structuredContent.status, 'completed');
+    assert.deepStrictEqual(polled.structuredContent.result, { media_buy_id: 'mb_1', status: 'paused' });
+  });
+
+  it('updateMediaBuy keeps synchronous success on the non-handoff path', async () => {
+    const platform = buildHitlPlatform({
+      updateMediaBuy: async () => ({ media_buy_id: 'mb_sync', status: 'active' }),
+    });
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'update-sync',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+
+    const result = await dispatchUpdate(server, { media_buy_id: 'mb_sync' });
+    assert.notStrictEqual(result.isError, true, JSON.stringify(result.structuredContent));
+    assert.strictEqual(result.structuredContent.media_buy_id, 'mb_sync');
+    assert.strictEqual(result.structuredContent.status, 'completed');
+    assert.strictEqual(result.structuredContent.media_buy_status, 'active');
+    assert.strictEqual(result.structuredContent.task_id, undefined);
+  });
+
+  it('updateMediaBuy keeps typed error bodies on the non-handoff path', async () => {
+    const platform = buildHitlPlatform({
+      updateMediaBuy: async () => ({
+        errors: [{ code: 'INVALID_STATE', message: 'media buy cannot be updated from its current state' }],
+      }),
+    });
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'update-error',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+
+    const result = await dispatchUpdate(server);
+    assert.strictEqual(result.isError, true);
+    assert.strictEqual(result.structuredContent.task_id, undefined);
+    assert.strictEqual(result.structuredContent.errors[0].code, 'INVALID_STATE');
   });
 
   it('hybrid createMediaBuy: returns Success directly OR ctx.handoffToTask per call', async () => {


### PR DESCRIPTION
## Summary

- route `updateMediaBuy` task handoffs through the same framework registry path as `createMediaBuy`
- expose `TaskHandoff<UpdateMediaBuyPayload>` on the public `SalesPlatform` handler type
- preserve synchronous success and typed error-body behavior
- add caller-scoped polling coverage and a patch changeset

## Root cause

`createAdcpServerFromPlatform` projected `updateMediaBuy` with `projectSync`
only. A handler could construct `ctx.handoffToTask(...)`, but the runtime never
recognized the marker, registered its task, or assigned the framework-computed
owner scope. Polling then failed even though async `update_media_buy` is a legal
protocol path.

## Upgrade warning

Adopters that manually called `taskRegistry.create(...)` as a workaround must
remove that code before upgrading. Running the workaround alongside the new
framework-owned handoff path can double-register work and emit duplicate
completion webhooks; there is no automatic deduplication between those paths.

## Validation

- `npm run build:lib`
- `npm run typecheck`
- `node --test-timeout=60000 --test-force-exit --test test/server-decisioning-from-platform.test.js` (139 passed)
- `npx prettier --check` on all changed source/test/changeset files
- `npx changeset status --since=origin/main`
- pre-push validation hook

Fixes adcontextprotocol/adcp#5974.
