### PR TITLE
fix(storyboard): grade unsigned signing-required steps not applicable

### DIFF
--- a/.changeset/tidy-signatures-skip.md
+++ b/.changeset/tidy-signatures-skip.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Grade unsigned functional storyboard steps as not applicable when an agent capability requires a request signature and returns the corresponding rejection.

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -2045,11 +2045,11 @@ async function executeStoryboardPass(
     // prevents a stale `pendingTaskId` from a prior storyboard's non-terminal
     // step from auto-threading into this storyboard's first call. (#1585)
     resetClientSessions(clients);
-    // Pick the first agent's profile as the "primary" for downstream code
-    // that reads single-profile fields (library_version on per-step result
-    // records, raw_capabilities for `requires_capability`). Per-step
-    // accuracy across N agents is a follow-up; today's storyboards that
-    // use `requires_capability` are single-tenant authored.
+    // Pick the first agent's profile as the run-level "primary" for gates
+    // that are evaluated before a step is routed (`requires_capability`,
+    // notices). The dispatcher separately attaches the selected agent's
+    // profile to each step assignment for capability-derived execution
+    // behavior and per-step library-version hints.
     profile = [...routingContext.profiles.values()][0];
     // For `required_tools` gating, union every agent's advertised tools so
     // a storyboard that needs ≥1 of [sync_governance, activate_signal]
@@ -2363,7 +2363,7 @@ async function executeStoryboardPass(
   const dispatch =
     routingContext && options.agents
       ? createRoutingDispatcher(routingContext, options, options.agents)
-      : createDispatcher(agentUrls, clients, 'round-robin', dispatchOffset);
+      : createDispatcher(agentUrls, clients, 'round-robin', dispatchOffset, profile);
 
   // Resolve cross-step assertions declared on `storyboard.invariants`.
   // `resolveAssertions` throws on unknown ids — fail fast here rather than
@@ -2823,7 +2823,8 @@ async function executeStoryboardPass(
           priorA2aEnvelopes,
           stepRequestStarts,
           responseDerivedNotApplicableContextKeys,
-          agentLibraryVersion: profile?.library_version,
+          agentProfile: assignment.profile,
+          agentLibraryVersion: assignment.profile?.library_version,
           storyboardRequiresRequestSigner: allRequires.includes('request_signer'),
         }
       );
@@ -3688,6 +3689,7 @@ async function runStoryboardStepBody(
     priorA2aEnvelopes: new Map(),
     stepRequestStarts: new Map(),
     responseDerivedNotApplicableContextKeys,
+    agentProfile: profile,
     agentLibraryVersion: profile?.library_version,
     storyboardRequiresRequestSigner: resolveStoryboardRequires(storyboard, options).includes('request_signer'),
   });
@@ -3755,6 +3757,11 @@ interface ExecutionState {
    * up from the per-step `ExecutionState` literal.
    */
   priorA2aEnvelopes?: Map<string, A2ATaskEnvelope>;
+  /**
+   * Profile for the agent selected to execute this step. In routed runs this
+   * must be the selected agent's profile, not the run-level primary profile.
+   */
+  agentProfile?: AgentProfile;
   /**
    * Agent's reported `@adcp/client@X.Y.Z` library version, captured from
    * the `get_adcp_capabilities` discovery probe. Threaded into shape-drift
@@ -4353,7 +4360,10 @@ async function executeStep(
   // false-negative grade. Convert only the capability-declared rejection:
   // the response code, dispatched task, and unsigned-storyboard state must
   // all agree before authored validations are bypassed.
-  const requiredForSigning = resolveCapabilityPath(options._profile?.raw_capabilities, 'request_signing.required_for');
+  const requiredForSigning = resolveCapabilityPath(
+    runState.agentProfile?.raw_capabilities,
+    'request_signing.required_for'
+  );
   if (
     taskResult?.adcp_error?.code === 'request_signature_required' &&
     Array.isArray(requiredForSigning) &&
@@ -6684,6 +6694,8 @@ interface StepAssignment {
   agentUrl: string;
   /** 0-based index into the agent URL list */
   instanceIndex: number;
+  /** Profile discovered for the agent selected to execute this step. */
+  profile?: AgentProfile;
 }
 
 interface Dispatcher {
@@ -6706,7 +6718,8 @@ function createDispatcher(
   agentUrls: string[],
   clients: TestClient[],
   _strategy: 'round-robin',
-  startOffset = 0
+  startOffset = 0,
+  profile?: AgentProfile
 ): Dispatcher {
   let counter = startOffset;
   return {
@@ -6717,6 +6730,7 @@ function createDispatcher(
         client: clients[idx]!,
         agentUrl: agentUrls[idx]!,
         instanceIndex: idx,
+        profile,
       };
     },
   };
@@ -6743,6 +6757,7 @@ function createRoutingDispatcher(
     nextFor(step: StoryboardStep): StepAssignment {
       const key = resolveAgentForStep(step, options, ctx);
       const client = ctx.clients.get(key);
+      const profile = ctx.profiles.get(key);
       const url = agents[key]?.url;
       if (!client || !url) {
         throw new RoutingError(
@@ -6756,6 +6771,7 @@ function createRoutingDispatcher(
         client,
         agentUrl: url,
         instanceIndex: keyToIndex.get(key) ?? 0,
+        profile,
       };
     },
   };

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -2824,6 +2824,7 @@ async function executeStoryboardPass(
           stepRequestStarts,
           responseDerivedNotApplicableContextKeys,
           agentLibraryVersion: profile?.library_version,
+          storyboardRequiresRequestSigner: allRequires.includes('request_signer'),
         }
       );
       const result: StoryboardStepResult = { ...rawResult, storyboard_id: storyboard.id };
@@ -3688,6 +3689,7 @@ async function runStoryboardStepBody(
     stepRequestStarts: new Map(),
     responseDerivedNotApplicableContextKeys,
     agentLibraryVersion: profile?.library_version,
+    storyboardRequiresRequestSigner: resolveStoryboardRequires(storyboard, options).includes('request_signer'),
   });
 
   if (!result.skipped && result.passed && found.step.contributes_to) {
@@ -3761,6 +3763,12 @@ interface ExecutionState {
    * #850. Undefined when the agent did not advertise `library_version`.
    */
   agentLibraryVersion?: string;
+  /**
+   * Whether the storyboard declares or implicitly requires a request signer.
+   * Unsigned functional storyboards use this to distinguish an expected
+   * signature-required rejection from a failure in a signing test.
+   */
+  storyboardRequiresRequestSigner?: boolean;
 }
 
 async function executeStep(
@@ -4339,6 +4347,43 @@ async function executeStep(
     (taskResult as { debug_logs?: unknown } | undefined)?.debug_logs,
     storyboardId
   );
+
+  // Until functional storyboards can sign individual mutating requests,
+  // a seller that correctly requires signatures would otherwise receive a
+  // false-negative grade. Convert only the capability-declared rejection:
+  // the response code, dispatched task, and unsigned-storyboard state must
+  // all agree before authored validations are bypassed.
+  const requiredForSigning = resolveCapabilityPath(options._profile?.raw_capabilities, 'request_signing.required_for');
+  if (
+    taskResult?.adcp_error?.code === 'request_signature_required' &&
+    Array.isArray(requiredForSigning) &&
+    requiredForSigning.includes(effectiveStep.task) &&
+    runState.storyboardRequiresRequestSigner !== true
+  ) {
+    const next = getNextStepPreview(step.id, allSteps, context, runState.runnerVars);
+    const detail =
+      `Agent declared request_signing.required_for includes "${effectiveStep.task}" and rejected the unsigned ` +
+      `request with request_signature_required; storyboard "${storyboardId}" does not require request_signer.`;
+    return {
+      step_id: step.id,
+      phase_id: phaseId,
+      title: step.title,
+      task: step.task,
+      passed: true,
+      skipped: true,
+      skip_reason: 'not_applicable',
+      skip: buildSkip('not_applicable', detail),
+      duration_ms: stepResult.duration_ms,
+      validations: [],
+      context,
+      response: redactSecrets(taskResult.data),
+      next,
+      request: requestRecord,
+      ...(responseRecord && { response_record: responseRecord }),
+      extraction: extractionFromTaskResult(taskResult),
+      ...(inputSchemaStripNotices.length > 0 && { notices: inputSchemaStripNotices }),
+    };
+  }
 
   // AdCP 3.0.12 runner-output-contract `force_scenario_unsupported`: when a
   // comply_test_controller step calls a force_* scenario that the agent

--- a/test/lib/storyboard-request-signature-required.test.js
+++ b/test/lib/storyboard-request-signature-required.test.js
@@ -1,7 +1,9 @@
 const { describe, test } = require('node:test');
 const assert = require('node:assert/strict');
+const http = require('node:http');
 
 const { runStoryboard } = require('../../dist/lib/testing/storyboard/runner');
+const { closeMCPConnections } = require('../../dist/lib/protocols/mcp');
 
 function buildClient(errorCode = 'request_signature_required') {
   return {
@@ -30,7 +32,7 @@ function buildProfile(requiredFor = ['create_media_buy']) {
   };
 }
 
-function buildStoryboard(requires) {
+function buildStoryboard(requires, agent) {
   return {
     id: 'unsigned_functional_media_buy',
     version: '1.0.0',
@@ -50,6 +52,7 @@ function buildStoryboard(requires) {
             id: 'create_buy',
             title: 'Create media buy',
             task: 'create_media_buy',
+            ...(agent && { agent }),
             stateful: true,
             sample_request: {
               account: { brand: { domain: 'example.com' }, operator: 'agency.example' },
@@ -77,6 +80,125 @@ function buildStoryboard(requires) {
       },
     ],
   };
+}
+
+function handleMcpHandshake(rpc, res, tools) {
+  if (rpc.method === 'initialize') {
+    res.writeHead(200, { 'content-type': 'application/json', 'mcp-session-id': 'test-session' });
+    res.end(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: rpc.id,
+        result: { protocolVersion: '2025-11-25', capabilities: {}, serverInfo: { name: 'test', version: '1.0.0' } },
+      })
+    );
+    return true;
+  }
+  if (rpc.method === 'notifications/initialized') {
+    res.writeHead(202);
+    res.end();
+    return true;
+  }
+  if (rpc.method === 'tools/list') {
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: rpc.id,
+        result: { tools: tools.map(name => ({ name, inputSchema: { type: 'object' } })) },
+      })
+    );
+    return true;
+  }
+  return false;
+}
+
+async function startRoutedAgent(requiredFor) {
+  const tools = ['get_adcp_capabilities', 'create_media_buy'];
+  const requests = [];
+  const server = http.createServer(async (req, res) => {
+    const chunks = [];
+    for await (const chunk of req) chunks.push(chunk);
+    const body = Buffer.concat(chunks).toString('utf8');
+    if (!body) {
+      res.writeHead(200);
+      res.end();
+      return;
+    }
+    const rpc = JSON.parse(body);
+    if (handleMcpHandshake(rpc, res, tools)) return;
+
+    if (rpc.method !== 'tools/call') {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ jsonrpc: '2.0', id: rpc.id, error: { code: -32601, message: 'Method not found' } }));
+      return;
+    }
+
+    const toolName = rpc.params?.name;
+    requests.push(toolName);
+    const structuredContent =
+      toolName === 'get_adcp_capabilities'
+        ? {
+            adcp: {
+              major_versions: [3],
+              supported_versions: ['3.1'],
+              idempotency: { supported: true, replay_ttl_seconds: 86400 },
+            },
+            supported_protocols: ['media_buy'],
+            specialisms: ['sales-non-guaranteed'],
+            request_signing: { supported: true, required_for: requiredFor },
+          }
+        : {
+            adcp_error: {
+              code: 'request_signature_required',
+              message: 'Request signature required',
+            },
+          };
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: rpc.id,
+        result: {
+          ...(toolName === 'create_media_buy' && { isError: true }),
+          structuredContent,
+        },
+      })
+    );
+  });
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  return {
+    requests,
+    server,
+    url: `http://127.0.0.1:${server.address().port}/mcp`,
+  };
+}
+
+async function runRoutedCase({ primaryRequiredFor, secondaryRequiredFor }) {
+  const primary = await startRoutedAgent(primaryRequiredFor);
+  const secondary = await startRoutedAgent(secondaryRequiredFor);
+  try {
+    const result = await runStoryboard('', buildStoryboard(undefined, 'secondary'), {
+      protocol: 'mcp',
+      allow_http: true,
+      agents: {
+        primary: { url: primary.url },
+        secondary: { url: secondary.url },
+      },
+    });
+    return {
+      step: result.phases[0].steps[0],
+      primaryRequests: [...primary.requests],
+      secondaryRequests: [...secondary.requests],
+      secondaryUrl: secondary.url,
+    };
+  } finally {
+    await closeMCPConnections();
+    await Promise.all([
+      new Promise(resolve => primary.server.close(resolve)),
+      new Promise(resolve => secondary.server.close(resolve)),
+    ]);
+  }
 }
 
 async function runCase({ errorCode, requiredFor, requires } = {}) {
@@ -122,5 +244,31 @@ describe('unsigned functional request-signing guard (adcp-client#2373)', () => {
 
     assert.notEqual(result.skipped, true);
     assert.equal(result.passed, false);
+  });
+
+  test('uses the routed agent profile when only the secondary requires the task signature', async () => {
+    const result = await runRoutedCase({
+      primaryRequiredFor: [],
+      secondaryRequiredFor: ['create_media_buy'],
+    });
+
+    assert.equal(result.step.agent_url, result.secondaryUrl);
+    assert.equal(result.step.skipped, true);
+    assert.equal(result.step.skip_reason, 'not_applicable');
+    assert.equal(result.primaryRequests.includes('create_media_buy'), false);
+    assert.equal(result.secondaryRequests.includes('create_media_buy'), true);
+  });
+
+  test('does not skip from the primary profile when the routed secondary does not require the task signature', async () => {
+    const result = await runRoutedCase({
+      primaryRequiredFor: ['create_media_buy'],
+      secondaryRequiredFor: [],
+    });
+
+    assert.equal(result.step.agent_url, result.secondaryUrl);
+    assert.notEqual(result.step.skipped, true);
+    assert.equal(result.step.passed, false);
+    assert.equal(result.primaryRequests.includes('create_media_buy'), false);
+    assert.equal(result.secondaryRequests.includes('create_media_buy'), true);
   });
 });

--- a/test/lib/storyboard-request-signature-required.test.js
+++ b/test/lib/storyboard-request-signature-required.test.js
@@ -1,0 +1,126 @@
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { runStoryboard } = require('../../dist/lib/testing/storyboard/runner');
+
+function buildClient(errorCode = 'request_signature_required') {
+  return {
+    executeTask: async task => {
+      assert.equal(task, 'create_media_buy');
+      return {
+        adcp_error: {
+          code: errorCode,
+          message: errorCode === 'request_signature_required' ? 'Request signature required' : 'Invalid request',
+        },
+      };
+    },
+  };
+}
+
+function buildProfile(requiredFor = ['create_media_buy']) {
+  return {
+    name: 'stub',
+    tools: [{ name: 'create_media_buy' }],
+    raw_capabilities: {
+      request_signing: {
+        supported: true,
+        required_for: requiredFor,
+      },
+    },
+  };
+}
+
+function buildStoryboard(requires) {
+  return {
+    id: 'unsigned_functional_media_buy',
+    version: '1.0.0',
+    title: 'Unsigned functional media buy',
+    category: 'test',
+    summary: '',
+    narrative: '',
+    ...(requires && { requires }),
+    agent: { interaction_model: '*', capabilities: [] },
+    caller: { role: 'buyer_agent' },
+    phases: [
+      {
+        id: 'create',
+        title: 'Create media buy',
+        steps: [
+          {
+            id: 'create_buy',
+            title: 'Create media buy',
+            task: 'create_media_buy',
+            stateful: true,
+            sample_request: {
+              account: { brand: { domain: 'example.com' }, operator: 'agency.example' },
+              brand: { domain: 'example.com' },
+              start_time: '2026-08-01T00:00:00Z',
+              end_time: '2026-08-08T00:00:00Z',
+              packages: [
+                {
+                  buyer_ref: 'pkg-1',
+                  product_id: 'prod-1',
+                  pricing_option_id: 'cpm-1',
+                  budget: 1000,
+                },
+              ],
+            },
+            validations: [
+              {
+                check: 'field_present',
+                path: 'media_buy_id',
+                description: 'A successful response includes a media buy id',
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+async function runCase({ errorCode, requiredFor, requires } = {}) {
+  const profile = buildProfile(requiredFor);
+  const result = await runStoryboard('https://stub.example/mcp', buildStoryboard(requires), {
+    protocol: 'mcp',
+    allow_http: true,
+    agentTools: ['create_media_buy'],
+    _client: buildClient(errorCode),
+    _profile: profile,
+  });
+  return result.phases[0].steps[0];
+}
+
+describe('unsigned functional request-signing guard (adcp-client#2373)', () => {
+  test('grades a capability-declared signature-required rejection not_applicable', async () => {
+    const result = await runCase();
+
+    assert.equal(result.skipped, true);
+    assert.equal(result.skip_reason, 'not_applicable');
+    assert.equal(result.skip.reason, 'not_applicable');
+    assert.match(result.skip.detail, /request_signing\.required_for/);
+    assert.match(result.skip.detail, /create_media_buy/);
+    assert.deepEqual(result.validations, [], 'authored validations must not run for the expected rejection');
+  });
+
+  test('does not skip a different error code', async () => {
+    const result = await runCase({ errorCode: 'INVALID_REQUEST' });
+
+    assert.notEqual(result.skipped, true);
+    assert.equal(result.passed, false);
+  });
+
+  test('does not skip when the task is absent from request_signing.required_for', async () => {
+    const result = await runCase({ requiredFor: ['update_media_buy'] });
+
+    assert.notEqual(result.skipped, true);
+    assert.equal(result.passed, false);
+  });
+
+  test('does not skip a storyboard that requires a request signer', async () => {
+    const result = await runCase({ requires: ['request_signer'] });
+
+    assert.notEqual(result.skipped, true);
+    assert.equal(result.passed, false);
+  });
+});


### PR DESCRIPTION
## Summary

- grade an unsigned functional step `not_applicable` only when the agent returns `request_signature_required`, the dispatched task appears in `request_signing.required_for`, and the storyboard does not require `request_signer`
- preserve normal failure behavior for other error codes, tasks, and signing storyboards
- add a runnable Node regression and patch changeset

## Why

Functional storyboards currently dispatch mutating requests without signing support. Sellers that correctly require signatures for those tasks therefore receive false-negative conformance failures even when their signed-request vectors pass.

The guard is capability-derived and runs after dispatch but before authored validations, so it does not bypass seller verification or affect agents that do not declare the task as signing-required.

Fixes #2373.

## Validation

- `npm run build:lib`
- `NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/lib/storyboard-request-signature-required.test.js`
- related runner suite: 101 tests passed across the new regression, requires gating, cascade behavior, and existing post-dispatch skip behavior
- `npm run typecheck`
- `npm run lint` (0 errors)
- targeted Prettier check
- `git diff --check`
- repository pre-push validation
