### PR TITLE
perf: reuse modern MCP discovery results

### DIFF
--- a/.changeset/bright-cats-listen.md
+++ b/.changeset/bright-cats-listen.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Update the modular MCP client to 2.0.0-beta.5 and reuse authorization-scoped modern discovery results, including across OAuth endpoint discovery and read-only reconnects.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "packages/*"
       ],
       "dependencies": {
-        "@modelcontextprotocol/client": "2.0.0-beta.4",
+        "@modelcontextprotocol/client": "2.0.0-beta.5",
         "@modelcontextprotocol/node": "2.0.0-beta.4",
         "@modelcontextprotocol/server": "2.0.0-beta.4",
         "@types/ws": "^8.18.1",
@@ -1769,17 +1769,29 @@
       }
     },
     "node_modules/@modelcontextprotocol/client": {
-      "version": "2.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/client/-/client-2.0.0-beta.4.tgz",
-      "integrity": "sha512-VNHA/UXDk7mCpVl+jOg5B4WMRRD2OEl+it360Lhi6HiCbrIB2f6pZ0cqSDKXQVUtZvqnhdQHzZAM9h8EKWhq/A==",
+      "version": "2.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/client/-/client-2.0.0-beta.5.tgz",
+      "integrity": "sha512-YuuNm5f2TMoFQRje1UqVP8TJRjijCXMz4ckvoVpx1cUXuBEmykWQ2d8R536pek6UKcXT41T5nWc4qR1JFIbEmg==",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/core": "2.0.0-beta.4",
+        "@modelcontextprotocol/core": "2.0.0-beta.5",
         "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
         "eventsource-parser": "^3.0.0",
         "jose": "^6.1.3",
         "pkce-challenge": "^5.0.0",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/client/node_modules/@modelcontextprotocol/core": {
+      "version": "2.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0-beta.5.tgz",
+      "integrity": "sha512-HKbY9XTbsDy1Y6r2I55TGE3JEapM0vg96e1MUmBIF9LGjos5gjhcIrTz1yvBPLg2aFKHjwhUAQfRdrCEnPxNew==",
+      "license": "MIT",
+      "dependencies": {
         "zod": "^4.2.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -568,7 +568,7 @@
     "email": "bugs@adcontextprotocol.org"
   },
   "dependencies": {
-    "@modelcontextprotocol/client": "2.0.0-beta.4",
+    "@modelcontextprotocol/client": "2.0.0-beta.5",
     "@modelcontextprotocol/node": "2.0.0-beta.4",
     "@modelcontextprotocol/server": "2.0.0-beta.4",
     "@types/ws": "^8.18.1",

--- a/src/lib/auth/oauth/provider-cache.ts
+++ b/src/lib/auth/oauth/provider-cache.ts
@@ -1,0 +1,24 @@
+import { createNonInteractiveOAuthProvider } from './index';
+import type { MCPOAuthProvider } from './MCPOAuthProvider';
+import type { AgentConfig } from './types';
+
+const nonInteractiveOAuthProviderCache = new WeakMap<AgentConfig, MCPOAuthProvider>();
+
+/** Reuse one refresh-capable provider for repeated calls in the same agent authorization context. */
+export function getNonInteractiveOAuthProvider(
+  agent: AgentConfig,
+  options?: Parameters<typeof createNonInteractiveOAuthProvider>[1]
+): MCPOAuthProvider {
+  let provider = nonInteractiveOAuthProviderCache.get(agent);
+  if (!provider) {
+    provider = createNonInteractiveOAuthProvider(agent, options);
+    nonInteractiveOAuthProviderCache.set(agent, provider);
+  }
+  return provider;
+}
+
+/** Preserve provider identity when endpoint discovery creates a derived AgentConfig object. */
+export function shareNonInteractiveOAuthProvider(source: AgentConfig, target: AgentConfig): void {
+  const provider = nonInteractiveOAuthProviderCache.get(source);
+  if (provider) nonInteractiveOAuthProviderCache.set(target, provider);
+}

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -790,6 +790,10 @@ export class SingleAgentClient {
         ...this.normalizedAgent,
         agent_uri: this.discoveredEndpoint,
       };
+      if (this.normalizedAgent.oauth_tokens && !this.normalizedAgent.oauth_client_credentials) {
+        const { shareNonInteractiveOAuthProvider } = await import('../auth/oauth/provider-cache');
+        shareNonInteractiveOAuthProvider(this.normalizedAgent, this.discoveredAgent);
+      }
       return this.discoveredAgent;
     }
 
@@ -806,7 +810,12 @@ export class SingleAgentClient {
     const discoveredEndpoint = await this.discoverMCPEndpoint(this.normalizedAgent.agent_uri, options);
 
     if (usesScopedFetch) {
-      return { ...this.normalizedAgent, agent_uri: discoveredEndpoint };
+      const discoveredAgent = { ...this.normalizedAgent, agent_uri: discoveredEndpoint };
+      if (this.normalizedAgent.oauth_tokens && !this.normalizedAgent.oauth_client_credentials) {
+        const { shareNonInteractiveOAuthProvider } = await import('../auth/oauth/provider-cache');
+        shareNonInteractiveOAuthProvider(this.normalizedAgent, discoveredAgent);
+      }
+      return discoveredAgent;
     }
 
     this.discoveredEndpoint = discoveredEndpoint;
@@ -818,6 +827,10 @@ export class SingleAgentClient {
       ...this.normalizedAgent,
       agent_uri: this.discoveredEndpoint,
     };
+    if (this.normalizedAgent.oauth_tokens && !this.normalizedAgent.oauth_client_credentials) {
+      const { shareNonInteractiveOAuthProvider } = await import('../auth/oauth/provider-cache');
+      shareNonInteractiveOAuthProvider(this.normalizedAgent, this.discoveredAgent);
+    }
     return this.discoveredAgent;
   }
 
@@ -1015,13 +1028,17 @@ export class SingleAgentClient {
       : this.agent.auth_token;
     const agentHeaders = this.agent.headers;
     const authHeaders = { ...agentHeaders, ...createMCPAuthHeaders(authToken) };
-    const authProvider =
+    const oauth =
       this.normalizedAgent.oauth_tokens && !this.normalizedAgent.oauth_client_credentials
-        ? (await import('../auth/oauth')).createNonInteractiveOAuthProvider(this.normalizedAgent, {
-            agentHint: this.normalizedAgent.id,
-            allowHttp: isLikelyPrivateUrl(this.normalizedAgent.agent_uri),
-          })
+        ? await import('../auth/oauth')
         : undefined;
+    const authProvider = oauth
+      ? (await import('../auth/oauth/provider-cache')).getNonInteractiveOAuthProvider(this.normalizedAgent, {
+          agentHint: this.normalizedAgent.id,
+          storage: oauth.getAgentStorage(this.normalizedAgent),
+          allowHttp: isLikelyPrivateUrl(this.normalizedAgent.agent_uri),
+        })
+      : undefined;
 
     type EndpointTestResult = {
       success: boolean;
@@ -3869,9 +3886,11 @@ export class SingleAgentClient {
       }
       let authProvider: Parameters<typeof connectMCP>[0]['authProvider'];
       if (this.normalizedAgent.oauth_tokens && !this.normalizedAgent.oauth_client_credentials) {
-        const { createNonInteractiveOAuthProvider } = await import('../auth/oauth');
-        authProvider = createNonInteractiveOAuthProvider(this.normalizedAgent, {
+        const { getAgentStorage } = await import('../auth/oauth');
+        const { getNonInteractiveOAuthProvider } = await import('../auth/oauth/provider-cache');
+        authProvider = getNonInteractiveOAuthProvider(this.normalizedAgent, {
           agentHint: this.normalizedAgent.id,
+          storage: getAgentStorage(this.normalizedAgent),
           allowHttp: isLikelyPrivateUrl(this.normalizedAgent.agent_uri),
         });
         connectOptions.authProvider = authProvider;

--- a/src/lib/protocols/index.ts
+++ b/src/lib/protocols/index.ts
@@ -42,12 +42,12 @@ import type { AgentConfig, DebugLogEntry } from '../types';
 import type { PushNotificationConfig } from '../types/tools.generated';
 import { getAuthToken } from '../auth';
 import {
-  createNonInteractiveOAuthProvider,
   discoverAuthorizationRequirements,
   NeedsAuthorizationError,
   getAgentStorage,
   ensureClientCredentialsTokens,
 } from '../auth/oauth';
+import { getNonInteractiveOAuthProvider } from '../auth/oauth/provider-cache';
 import { is401Error } from '../errors';
 import { isLikelyPrivateUrl } from '../net';
 import { validateAgentUrl } from '../validation';
@@ -71,25 +71,6 @@ export {
 export type { TransportActivity, TransportActivityContext, TransportActivityHandler } from './transportDiagnostics';
 
 export type VersionEnvelopeMode = 'auto' | 'none' | 'major-only';
-
-const nonInteractiveOAuthProviderCache = new WeakMap<
-  AgentConfig,
-  ReturnType<typeof createNonInteractiveOAuthProvider>
->();
-
-function getNonInteractiveOAuthProvider(agent: AgentConfig): ReturnType<typeof createNonInteractiveOAuthProvider> {
-  let provider = nonInteractiveOAuthProviderCache.get(agent);
-  if (!provider) {
-    const storage = getAgentStorage(agent);
-    provider = createNonInteractiveOAuthProvider(agent, {
-      agentHint: agent.id,
-      storage,
-      allowHttp: isLikelyPrivateUrl(agent.agent_uri),
-    });
-    nonInteractiveOAuthProviderCache.set(agent, provider);
-  }
-  return provider;
-}
 
 /**
  * Derive the wire-level `adcp_major_version` integer from a caller-supplied
@@ -512,7 +493,11 @@ export class ProtocolClient {
                 // and their refresh path is a secret re-exchange (handled above),
                 // not the SDK's refresh_token grant.
                 if (agent.oauth_tokens && !agent.oauth_client_credentials) {
-                  const authProvider = getNonInteractiveOAuthProvider(agent);
+                  const authProvider = getNonInteractiveOAuthProvider(agent, {
+                    agentHint: agent.id,
+                    storage: getAgentStorage(agent),
+                    allowHttp: isLikelyPrivateUrl(agent.agent_uri),
+                  });
                   try {
                     return await callMCPToolWithOAuth({
                       agentUrl: agent.agent_uri,

--- a/src/lib/protocols/mcp-modern.ts
+++ b/src/lib/protocols/mcp-modern.ts
@@ -9,8 +9,12 @@
 
 import {
   Client,
+  SdkError,
+  SdkErrorCode,
   StreamableHTTPClientTransport,
+  type DiscoverResult,
   type OAuthClientProvider as ModernOAuthClientProvider,
+  type PriorDiscovery,
   type Tool,
 } from '@modelcontextprotocol/client';
 import { createHmac } from 'node:crypto';
@@ -65,8 +69,11 @@ const modernConnections = new Map<string, Client>();
 const legacyConnectionExpiresAt = new Map<string, number>();
 const pendingModernConnections = new Map<string, Promise<Client>>();
 const knownLegacyConnections = new Map<string, number>();
+const modernDiscoveries = new Map<string, { discover: DiscoverResult; expiresAt: number }>();
+const clientsUsingCachedDiscovery = new WeakSet<Client>();
 const MAX_CACHED_CONNECTIONS = 20;
 const LEGACY_CLASSIFICATION_TTL_MS = 5 * 60 * 1000;
+const MODERN_DISCOVERY_TTL_MS = 5 * 60 * 1000;
 const modernOAuthProviderIds = new WeakMap<object, string>();
 const modernFetchFnIds = new WeakMap<typeof fetch, string>();
 let nextModernOAuthProviderId = 0;
@@ -149,12 +156,38 @@ function isKnownLegacy(cacheKey: string): boolean {
 }
 
 function markKnownLegacy(cacheKey: string): void {
+  modernDiscoveries.delete(cacheKey);
   knownLegacyConnections.delete(cacheKey);
   knownLegacyConnections.set(cacheKey, Date.now());
   while (knownLegacyConnections.size > MAX_CACHED_CONNECTIONS) {
     const oldest = knownLegacyConnections.keys().next().value;
     if (!oldest) break;
     knownLegacyConnections.delete(oldest);
+  }
+}
+
+function getCachedModernDiscovery(cacheKey: string): PriorDiscovery | undefined {
+  const cached = modernDiscoveries.get(cacheKey);
+  if (!cached) return undefined;
+  if (cached.expiresAt <= Date.now()) {
+    modernDiscoveries.delete(cacheKey);
+    return undefined;
+  }
+  modernDiscoveries.delete(cacheKey);
+  modernDiscoveries.set(cacheKey, cached);
+  return { kind: 'modern', discover: cached.discover };
+}
+
+function cacheModernDiscovery(cacheKey: string, discover: DiscoverResult): void {
+  modernDiscoveries.delete(cacheKey);
+  modernDiscoveries.set(cacheKey, {
+    discover,
+    expiresAt: Date.now() + MODERN_DISCOVERY_TTL_MS,
+  });
+  while (modernDiscoveries.size > MAX_CACHED_CONNECTIONS) {
+    const oldest = modernDiscoveries.keys().next().value;
+    if (!oldest) break;
+    modernDiscoveries.delete(oldest);
   }
 }
 
@@ -203,9 +236,12 @@ function evictLeastRecentlyUsed(): void {
 }
 
 async function createNegotiatedClient(
+  cacheKey: string,
   options: ModernConnectionOptions,
-  authHeaders: Record<string, string>
+  authHeaders: Record<string, string>,
+  useCachedDiscovery = true
 ): Promise<Client> {
+  const generation = connectionGeneration;
   const requestTimeoutMs = resolveRequestTimeoutMs(options.requestTimeoutMs);
   const clientRequestTimeoutMs = resolveClientRequestTimeoutMs(options.requestTimeoutMs);
   const rawNetworkFetch: typeof fetch = options.fetchFn ?? ((input, init) => fetch(input, init));
@@ -238,17 +274,31 @@ async function createNegotiatedClient(
     }
   );
 
+  const prior = useCachedDiscovery ? getCachedModernDiscovery(cacheKey) : undefined;
   try {
     await client.connect(transport, {
       ...(options.signal && { signal: options.signal }),
       ...(clientRequestTimeoutMs !== undefined && { timeout: clientRequestTimeoutMs }),
+      ...(prior && { prior }),
     });
+    if (prior) clientsUsingCachedDiscovery.add(client);
+    if (!prior) {
+      const discover = client.getDiscoverResult();
+      if (generation === connectionGeneration) {
+        if (client.getProtocolEra() === 'modern' && discover) cacheModernDiscovery(cacheKey, discover);
+        else modernDiscoveries.delete(cacheKey);
+      }
+    }
     return client;
   } catch (error) {
+    if (prior) modernDiscoveries.delete(cacheKey);
     try {
       await client.close();
     } catch {
       /* ignore close errors */
+    }
+    if (prior && SdkError.isInstance(error) && error.code === SdkErrorCode.EraNegotiationFailed) {
+      return createNegotiatedClient(cacheKey, options, authHeaders, false);
     }
     throw error;
   }
@@ -266,7 +316,7 @@ async function getOrCreateModernConnection(
   if (pending) return pending;
 
   const generation = connectionGeneration;
-  const promise = createNegotiatedClient(options, authHeaders)
+  const promise = createNegotiatedClient(cacheKey, options, authHeaders)
     .then(client => {
       if (
         (client.getProtocolEra() === 'modern' || options.handleLegacy === true) &&
@@ -328,7 +378,7 @@ async function attemptModernCall(
   let client: Client;
   try {
     client = guardedConnection
-      ? await createNegotiatedClient(options, authHeaders)
+      ? await createNegotiatedClient(cacheKey, options, authHeaders)
       : await getOrCreateModernConnection(cacheKey, options, authHeaders);
   } catch (error) {
     const status = httpStatusOf(error);
@@ -382,6 +432,7 @@ async function attemptModernCall(
     // caller's explicit idempotency policy, not transport guesswork.
     modernConnections.delete(cacheKey);
     legacyConnectionExpiresAt.delete(cacheKey);
+    modernDiscoveries.delete(cacheKey);
     try {
       await client.close();
     } catch {
@@ -460,11 +511,19 @@ export async function probeModernMCPConnection(
     handleLegacy: options.handleLegacy,
   };
   const authHeaders = buildAuthHeaders(authToken, customHeaders, options.authProvider);
+  const cacheKey = connectionCacheKey(
+    agentUrl,
+    authHeaders,
+    options.signingContext?.cacheKey,
+    options.authProvider,
+    options.fetchFn
+  );
   let client: Client | undefined;
   try {
-    client = await createNegotiatedClient(connectionOptions, authHeaders);
+    client = await createNegotiatedClient(cacheKey, connectionOptions, authHeaders, false);
     return { connected: true, era: client.getProtocolEra() };
   } catch (error) {
+    modernDiscoveries.delete(cacheKey);
     if (is401Error(error) || isAbortOrTimeoutError(error)) throw error;
     const status = httpStatusOf(error);
     if (status === 404 || status === 405) return { connected: false };
@@ -493,21 +552,43 @@ export async function tryListModernMCPTools(
     fetchFn: options.fetchFn,
   };
   const authHeaders = buildAuthHeaders(authToken, customHeaders, options.authProvider);
+  const cacheKey = connectionCacheKey(
+    agentUrl,
+    authHeaders,
+    options.signingContext?.cacheKey,
+    options.authProvider,
+    options.fetchFn
+  );
   let client: Client | undefined;
-  try {
-    client = await createNegotiatedClient(connectionOptions, authHeaders);
-    if (client.getProtocolEra() !== 'modern') return { handled: false };
+  const listTools = async (connectedClient: Client): Promise<ModernMCPListAttempt> => {
+    if (connectedClient.getProtocolEra() !== 'modern') return { handled: false };
     const resolvedRequestTimeoutMs = resolveClientRequestTimeoutMs(options.requestTimeoutMs);
-    const result = await client.listTools(undefined, {
+    const result = await connectedClient.listTools(undefined, {
       ...(options.signal && { signal: options.signal }),
       ...(resolvedRequestTimeoutMs !== undefined && { timeout: resolvedRequestTimeoutMs }),
     });
     return { handled: true, tools: result.tools };
+  };
+  try {
+    client = await createNegotiatedClient(cacheKey, connectionOptions, authHeaders);
+    return await listTools(client);
   } catch (error) {
-    if (is401Error(error) || isAbortOrTimeoutError(error)) throw error;
-    const status = httpStatusOf(error);
+    let failure = error;
+    modernDiscoveries.delete(cacheKey);
+    if (!is401Error(failure) && !isAbortOrTimeoutError(failure) && client && clientsUsingCachedDiscovery.has(client)) {
+      await client.close().catch(() => {});
+      try {
+        client = await createNegotiatedClient(cacheKey, connectionOptions, authHeaders, false);
+        return await listTools(client);
+      } catch (retryError) {
+        failure = retryError;
+        modernDiscoveries.delete(cacheKey);
+      }
+    }
+    if (is401Error(failure) || isAbortOrTimeoutError(failure)) throw failure;
+    const status = httpStatusOf(failure);
     if (status === 404 || status === 405) return { handled: false };
-    throw error;
+    throw failure;
   } finally {
     await client?.close().catch(() => {});
   }
@@ -525,6 +606,7 @@ export async function closeModernMCPConnections(): Promise<void> {
   modernConnections.clear();
   legacyConnectionExpiresAt.clear();
   knownLegacyConnections.clear();
+  modernDiscoveries.clear();
   for (const client of clients) {
     try {
       await client.close();

--- a/test/lib/mcp-modern-negotiation.test.js
+++ b/test/lib/mcp-modern-negotiation.test.js
@@ -12,6 +12,11 @@ const { createServer } = require('node:http');
 const { callMCPTool, closeMCPConnections } = require('../../dist/lib/protocols/mcp.js');
 const { callMCPToolWithOAuth } = require('../../dist/lib/protocols/mcp.js');
 const { callMCPToolWithTasks } = require('../../dist/lib/protocols/mcp-tasks.js');
+const {
+  probeModernMCPConnection,
+  tryCallModernMCPTool,
+  tryListModernMCPTools,
+} = require('../../dist/lib/protocols/mcp-modern.js');
 
 function createStaticOAuthProvider(token) {
   return {
@@ -152,6 +157,168 @@ test('remote MCP client negotiates 2026-07-28 with a modern-only server', async 
     debugLogs.some(entry => entry.message === 'MCP: Tool echo response received (success)'),
     'modern calls should preserve the existing response debug log contract'
   );
+});
+
+test('modern discovery is reused within the same authorization context', async t => {
+  const { createMcpHandler, McpServer } = require('@modelcontextprotocol/server');
+  const { toNodeHandler } = require('@modelcontextprotocol/node');
+
+  const handler = createMcpHandler(
+    () => {
+      const server = new McpServer({ name: 'modern-discovery-cache-test', version: '1.0.0' });
+      server.registerTool('echo', { description: 'Echo a fixed modern result' }, async () => ({
+        content: [{ type: 'text', text: 'modern' }],
+      }));
+      return server;
+    },
+    { legacy: 'reject' }
+  );
+  const httpServer = createServer(toNodeHandler(handler));
+  const url = await listen(httpServer);
+  let discoverRequests = 0;
+  const countingFetch = async (input, init) => {
+    const request = input instanceof Request ? input.clone() : new Request(input, init);
+    if (request.method === 'POST') {
+      const body = await request
+        .clone()
+        .json()
+        .catch(() => undefined);
+      if (body?.method === 'server/discover') discoverRequests++;
+    }
+    return fetch(input, init);
+  };
+
+  t.after(async () => {
+    await closeMCPConnections();
+    await handler.close();
+    await closeServer(httpServer);
+  });
+
+  const probe = await probeModernMCPConnection(url, 'tenant-a-token', undefined, {
+    fetchFn: countingFetch,
+  });
+  assert.deepEqual(probe, { connected: true, era: 'modern' });
+  assert.equal(discoverRequests, 1);
+
+  const cachedAttempt = await tryCallModernMCPTool(url, 'echo', {}, 'tenant-a-token', [], undefined, {
+    fetchFn: countingFetch,
+  });
+  assert.equal(cachedAttempt.handled, true);
+  assert.equal(discoverRequests, 1, 'the first tool connection should adopt the cached discovery result');
+
+  const otherTenantAttempt = await tryCallModernMCPTool(url, 'echo', {}, 'tenant-b-token', [], undefined, {
+    fetchFn: countingFetch,
+  });
+  assert.equal(otherTenantAttempt.handled, true);
+  assert.equal(discoverRequests, 2, 'discovery results must not cross authorization contexts');
+
+  const { AgentClient } = require('../../dist/lib/core/AgentClient.js');
+  const oauthClient = new AgentClient(
+    {
+      id: 'oauth-discovery-cache-agent',
+      name: 'oauth-discovery-cache-agent',
+      protocol: 'mcp',
+      agent_uri: url.replace(/\/mcp$/, ''),
+      oauth_tokens: { access_token: 'oauth-discovery-token', token_type: 'Bearer' },
+    },
+    { transport: { fetchFn: countingFetch } }
+  );
+  const beforeOAuthDiscovery = discoverRequests;
+  const oauthInfo = await oauthClient.getAgentInfo();
+  assert.ok(oauthInfo.tools.some(tool => tool.name === 'echo'));
+  assert.equal(
+    discoverRequests,
+    beforeOAuthDiscovery + 1,
+    'OAuth endpoint probing and tool listing should share one provider-scoped discovery result'
+  );
+  const internalClient = oauthClient.client;
+  const {
+    getNonInteractiveOAuthProvider,
+    shareNonInteractiveOAuthProvider,
+  } = require('../../dist/lib/auth/oauth/provider-cache.js');
+  const derivedAgent = { ...internalClient.normalizedAgent, agent_uri: url };
+  shareNonInteractiveOAuthProvider(internalClient.normalizedAgent, derivedAgent);
+  assert.strictEqual(
+    getNonInteractiveOAuthProvider(internalClient.normalizedAgent),
+    getNonInteractiveOAuthProvider(derivedAgent),
+    'the derived agent config should retain the endpoint probe OAuth provider identity'
+  );
+});
+
+test('stale modern discovery is refreshed before read-only tool listing fails', async t => {
+  const { createMcpHandler, McpServer: ModernMcpServer } = require('@modelcontextprotocol/server');
+  const { toNodeHandler } = require('@modelcontextprotocol/node');
+  const { McpServer: LegacyMcpServer } = require('@modelcontextprotocol/sdk/server/mcp.js');
+  const { StreamableHTTPServerTransport } = require('@modelcontextprotocol/sdk/server/streamableHttp.js');
+
+  const modernHandler = createMcpHandler(
+    () => {
+      const server = new ModernMcpServer({ name: 'modern-before-downgrade', version: '1.0.0' });
+      server.registerTool('echo', { description: 'Modern echo' }, async () => ({
+        content: [{ type: 'text', text: 'modern' }],
+      }));
+      return server;
+    },
+    { legacy: 'reject' }
+  );
+  const modernNodeHandler = toNodeHandler(modernHandler);
+  let useLegacy = false;
+  let respondNotFound = false;
+  const httpServer = createServer(async (req, res) => {
+    if (respondNotFound) {
+      res.writeHead(404);
+      res.end();
+      return;
+    }
+    if (!useLegacy) {
+      await modernNodeHandler(req, res);
+      return;
+    }
+    const server = new LegacyMcpServer({ name: 'legacy-after-downgrade', version: '1.0.0' });
+    const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+    try {
+      await server.connect(transport);
+      await transport.handleRequest(req, res);
+    } finally {
+      await server.close();
+    }
+  });
+  const url = await listen(httpServer);
+  let discoverRequests = 0;
+  const countingFetch = async (input, init) => {
+    const request = input instanceof Request ? input.clone() : new Request(input, init);
+    if (request.method === 'POST') {
+      const body = await request
+        .clone()
+        .json()
+        .catch(() => undefined);
+      if (body?.method === 'server/discover') discoverRequests++;
+    }
+    return fetch(input, init);
+  };
+
+  t.after(async () => {
+    await closeMCPConnections();
+    await modernHandler.close();
+    await closeServer(httpServer);
+  });
+
+  const probe = await probeModernMCPConnection(url, undefined, undefined, { fetchFn: countingFetch });
+  assert.deepEqual(probe, { connected: true, era: 'modern' });
+  assert.equal(discoverRequests, 1);
+
+  useLegacy = true;
+  const listed = await tryListModernMCPTools(url, undefined, undefined, { fetchFn: countingFetch });
+  assert.deepEqual(listed, { handled: false });
+  assert.equal(discoverRequests, 2, 'read-only listing should re-probe after a stale modern verdict');
+
+  useLegacy = false;
+  const secondProbe = await probeModernMCPConnection(url, undefined, undefined, { fetchFn: countingFetch });
+  assert.deepEqual(secondProbe, { connected: true, era: 'modern' });
+  respondNotFound = true;
+  const unavailable = await tryListModernMCPTools(url, undefined, undefined, { fetchFn: countingFetch });
+  assert.deepEqual(unavailable, { handled: false });
+  assert.equal(discoverRequests, 4, 'a failed fresh retry should retain the 404 fallback contract');
 });
 
 test('remote MCP client preserves the v1 path for a legacy server', async t => {


### PR DESCRIPTION
## Summary

- update `@modelcontextprotocol/client` from `2.0.0-beta.4` to `2.0.0-beta.5`
- cache modern MCP discovery results for five minutes within the same endpoint and authorization context
- preserve OAuth provider identity only across trusted endpoint-derived agent configs
- retry stale discovery once for read-only tool listing while preserving the no-replay rule for tool calls

## Why

Beta.5 aligns discovery with the finalized MCP 2026-07-28 wire shape and adds `ConnectOptions.prior`. Reusing that validated discovery result removes a redundant `server/discover` round trip without changing legacy MCP Tasks routing or replaying mutating requests.

## Validation

- `npm run build:lib`
- `npm run typecheck`
- `NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/lib/mcp-modern-negotiation.test.js` (8 tests)
- protocol, security, and DX/code expert reviews
- pre-push validation
