### PR TITLE
fix: align modular MCP dependency versions

### DIFF
--- a/.changeset/fix-mcp-beta-pins.md
+++ b/.changeset/fix-mcp-beta-pins.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Align the modular MCP client, Node transport, and server dependencies on 2.0.0-beta.5.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,8 @@
       ],
       "dependencies": {
         "@modelcontextprotocol/client": "2.0.0-beta.5",
-        "@modelcontextprotocol/node": "2.0.0-beta.4",
-        "@modelcontextprotocol/server": "2.0.0-beta.4",
+        "@modelcontextprotocol/node": "2.0.0-beta.5",
+        "@modelcontextprotocol/server": "2.0.0-beta.5",
         "@types/ws": "^8.18.1",
         "ajv": "^8.18.0",
         "ajv-formats": "^3.0.1",
@@ -1786,7 +1786,7 @@
         "node": ">=20"
       }
     },
-    "node_modules/@modelcontextprotocol/client/node_modules/@modelcontextprotocol/core": {
+    "node_modules/@modelcontextprotocol/core": {
       "version": "2.0.0-beta.5",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0-beta.5.tgz",
       "integrity": "sha512-HKbY9XTbsDy1Y6r2I55TGE3JEapM0vg96e1MUmBIF9LGjos5gjhcIrTz1yvBPLg2aFKHjwhUAQfRdrCEnPxNew==",
@@ -1798,22 +1798,10 @@
         "node": ">=20"
       }
     },
-    "node_modules/@modelcontextprotocol/core": {
-      "version": "2.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0-beta.4.tgz",
-      "integrity": "sha512-nsMXd4wQBKzmph6r+WOhum+mXjDYljTAqwY/XUg3hLtvNOQ8+JVqBSJOVCMJvx9lXhTpTOPrGZ3BuNiaNPjSvg==",
-      "license": "MIT",
-      "dependencies": {
-        "zod": "^4.2.0"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
     "node_modules/@modelcontextprotocol/node": {
-      "version": "2.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/node/-/node-2.0.0-beta.4.tgz",
-      "integrity": "sha512-OqbrRVNYNfLxBB2BRkP5oIHKHa0IPHluMbaLgw7YCRKcj5be9ExzyWFJY3KVMb+1F2AVn+0SRoH0XKcNzh3HYQ==",
+      "version": "2.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/node/-/node-2.0.0-beta.5.tgz",
+      "integrity": "sha512-flrOzx5qFLBM9I8IYRGfYUY02erFmxOvYQ9sEE6iSj/ZZpRYKorXWscM/qrfW9rwlcGLyymHhnP2AaDbMB1lIA==",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9"
@@ -1822,7 +1810,7 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@modelcontextprotocol/server": "^2.0.0-beta.4",
+        "@modelcontextprotocol/server": "^2.0.0-beta.5",
         "hono": "^4.11.4"
       },
       "peerDependenciesMeta": {
@@ -1873,12 +1861,12 @@
       }
     },
     "node_modules/@modelcontextprotocol/server": {
-      "version": "2.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0-beta.4.tgz",
-      "integrity": "sha512-pjMZcNEt1dOq0aJCcY3b7w1Ayh+qmQN2xlfTELcGV9yiAjEGIczBPBLWWW0k0zzo5T8kiv15jtKPsWeHGxLvLg==",
+      "version": "2.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0-beta.5.tgz",
+      "integrity": "sha512-i1E5l75rQKsgY/AKAIspgMBH1vEL7dqiK7tHr0L+raYcb0SWOziqNGJXGIG6NY4AlXDWIKGJQGB7Nqfs3oUi5g==",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/core": "2.0.0-beta.4",
+        "@modelcontextprotocol/core": "2.0.0-beta.5",
         "zod": "^4.2.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -569,8 +569,8 @@
   },
   "dependencies": {
     "@modelcontextprotocol/client": "2.0.0-beta.5",
-    "@modelcontextprotocol/node": "2.0.0-beta.4",
-    "@modelcontextprotocol/server": "2.0.0-beta.4",
+    "@modelcontextprotocol/node": "2.0.0-beta.5",
+    "@modelcontextprotocol/server": "2.0.0-beta.5",
     "@types/ws": "^8.18.1",
     "ajv": "^8.18.0",
     "ajv-formats": "^3.0.1",


### PR DESCRIPTION
## Summary

Aligns `@modelcontextprotocol/client`, `@modelcontextprotocol/node`, and `@modelcontextprotocol/server` on `2.0.0-beta.5`.
The `13.0.0-rc.0` manifest mixed beta.5 client/core schemas with beta.4 server/core schemas, so the lockfile now resolves one coherent beta.5 dependency set.
Adds a patch changeset so prerelease mode advances the correction to `13.0.0-rc.1` on the `rc` dist-tag.

## Validation

Build, typecheck, protocol tests, 15 focused MCP negotiation/OAuth tests, and clean-room Node/Bun package verification pass.
