### PR TITLE
fix(mcp): treat ERA_NEGOTIATION_FAILED as legacy-era signal

### DIFF
--- a/.changeset/fix-era-negotiation-legacy-fallback.md
+++ b/.changeset/fix-era-negotiation-legacy-fallback.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Treat ERA_NEGOTIATION_FAILED as a legacy-era signal in probeModernMCPConnection, attemptModernCall, and tryListModernMCPTools. Servers that respond to the server/discover probe with a malformed envelope (e.g. id: null) now fall back to the v1 transport path instead of surfacing "None responded to MCP protocol."

--- a/src/lib/protocols/mcp-modern.ts
+++ b/src/lib/protocols/mcp-modern.ts
@@ -391,6 +391,15 @@ async function attemptModernCall(
       });
       return { handled: false };
     }
+    if (SdkError.isInstance(error) && error.code === SdkErrorCode.EraNegotiationFailed) {
+      markKnownLegacy(cacheKey);
+      options.debugLogs.push({
+        type: 'info',
+        message: `MCP: Era negotiation failed for ${toolName}; preserving the v1 transport path`,
+        timestamp: new Date().toISOString(),
+      });
+      return { handled: false };
+    }
     throw error;
   }
 
@@ -527,6 +536,7 @@ export async function probeModernMCPConnection(
     if (is401Error(error) || isAbortOrTimeoutError(error)) throw error;
     const status = httpStatusOf(error);
     if (status === 404 || status === 405) return { connected: false };
+    if (SdkError.isInstance(error) && error.code === SdkErrorCode.EraNegotiationFailed) return { connected: false };
     throw error;
   } finally {
     await client?.close().catch(() => {});
@@ -588,6 +598,7 @@ export async function tryListModernMCPTools(
     if (is401Error(failure) || isAbortOrTimeoutError(failure)) throw failure;
     const status = httpStatusOf(failure);
     if (status === 404 || status === 405) return { handled: false };
+    if (SdkError.isInstance(failure) && failure.code === SdkErrorCode.EraNegotiationFailed) return { handled: false };
     throw failure;
   } finally {
     await client?.close().catch(() => {});

--- a/test/unit/mcp-era-negotiation-fallback.test.js
+++ b/test/unit/mcp-era-negotiation-fallback.test.js
@@ -1,0 +1,92 @@
+/**
+ * Regression tests for ERA_NEGOTIATION_FAILED handling in mcp-modern.ts.
+ *
+ * When a legacy MCP server responds to the server/discover probe with a
+ * malformed envelope (e.g. id: null), @modelcontextprotocol/client throws
+ * SdkError(EraNegotiationFailed). The three catch sites in mcp-modern.ts
+ * must treat this as a legacy-era signal rather than rethrowing, so the
+ * caller falls back to the v1 transport.
+ *
+ * Tests replicate the catch-block classifier logic in isolation — same
+ * approach as mcp-discovery-sse-fallback.test.js.
+ */
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const { SdkError, SdkErrorCode } = require('@modelcontextprotocol/client');
+
+function isEraNegotiationFailed(error) {
+  return SdkError.isInstance(error) && error.code === SdkErrorCode.EraNegotiationFailed;
+}
+
+// Replicates the probeModernMCPConnection catch classifier.
+function probeClassify(error) {
+  if (isEraNegotiationFailed(error)) return { connected: false };
+  throw error;
+}
+
+// Replicates the attemptModernCall catch classifier (after the 404/405 branch).
+function attemptClassify(error) {
+  const status = error?.status;
+  if (status === 404 || status === 405) return { handled: false };
+  if (isEraNegotiationFailed(error)) return { handled: false };
+  throw error;
+}
+
+// Replicates the tryListModernMCPTools catch classifier (after the 404/405 branch).
+function listClassify(error) {
+  const status = error?.status;
+  if (status === 404 || status === 405) return { handled: false };
+  if (isEraNegotiationFailed(error)) return { handled: false };
+  throw error;
+}
+
+describe('mcp-modern: ERA_NEGOTIATION_FAILED treated as legacy-era signal', () => {
+  const eraError = new SdkError(SdkErrorCode.EraNegotiationFailed, 'id: null in server/discover response');
+
+  describe('probeModernMCPConnection catch', () => {
+    test('ERA_NEGOTIATION_FAILED returns { connected: false }', () => {
+      const result = probeClassify(eraError);
+      assert.deepStrictEqual(result, { connected: false });
+    });
+
+    test('generic network error is rethrown', () => {
+      const networkErr = new Error('ECONNREFUSED');
+      assert.throws(() => probeClassify(networkErr), { message: 'ECONNREFUSED' });
+    });
+  });
+
+  describe('attemptModernCall catch', () => {
+    test('ERA_NEGOTIATION_FAILED returns { handled: false }', () => {
+      const result = attemptClassify(eraError);
+      assert.deepStrictEqual(result, { handled: false });
+    });
+
+    test('404 still returns { handled: false } (existing behavior preserved)', () => {
+      const result = attemptClassify(Object.assign(new Error('Not Found'), { status: 404 }));
+      assert.deepStrictEqual(result, { handled: false });
+    });
+
+    test('generic network error is rethrown', () => {
+      const networkErr = new Error('timeout');
+      assert.throws(() => attemptClassify(networkErr), { message: 'timeout' });
+    });
+  });
+
+  describe('tryListModernMCPTools catch', () => {
+    test('ERA_NEGOTIATION_FAILED returns { handled: false }', () => {
+      const result = listClassify(eraError);
+      assert.deepStrictEqual(result, { handled: false });
+    });
+
+    test('405 still returns { handled: false } (existing behavior preserved)', () => {
+      const result = listClassify(Object.assign(new Error('Method Not Allowed'), { status: 405 }));
+      assert.deepStrictEqual(result, { handled: false });
+    });
+
+    test('generic network error is rethrown', () => {
+      const networkErr = new Error('ETIMEDOUT');
+      assert.throws(() => listClassify(networkErr), { message: 'ETIMEDOUT' });
+    });
+  });
+});


### PR DESCRIPTION
## Why

Servers that respond to the \`server/discover\` probe with a malformed envelope (e.g. \`id: null\` instead of echoing the request id) cause \`@modelcontextprotocol/client\` to throw \`ERA_NEGOTIATION_FAILED\`. This error has no HTTP status, so the existing 404/405 check in the three discovery/call paths doesn't catch it — the error propagated as a fatal discovery failure, surfacing as "None responded to MCP protocol" on the buyer side.

Root cause confirmed for InMobi (adcp_agent 283, BASIC_AUTH): their server returns \`{"error":{"code":-32600,"message":"Missing ID field"},"id":null}\` for the \`server/discover\` probe. The \`id: null\` response fails the beta client's response-envelope parse, which throws \`ERA_NEGOTIATION_FAILED\`. Legacy mode connects successfully (all 9 tools listed).

## What Changed

In `probeModernMCPConnection`, `attemptModernCall`, and `tryListModernMCPTools`: treat `ERA_NEGOTIATION_FAILED` the same as 404/405 — fall back to the v1 transport path rather than rethrowing. Uses `SdkError.isInstance` (already imported) to identify the error.

This is the SDK-side fix for AI-5153. The partial fix already in `createNegotiatedClient` at line 300 handles stale cached discovery; this extends the same pattern to the initial discovery probe.