### PR TITLE
fix(mcp): treat ERA_NEGOTIATION_FAILED as legacy-era signal [backport 12.x]

### DIFF
--- a/.changeset/fix-era-negotiation-legacy-fallback.md
+++ b/.changeset/fix-era-negotiation-legacy-fallback.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Treat ERA_NEGOTIATION_FAILED as a legacy-era signal in probeModernMCPConnection, attemptModernCall, and tryListModernMCPTools. Servers that respond to the server/discover probe with a malformed envelope (e.g. id: null) now fall back to the v1 transport path instead of surfacing "None responded to MCP protocol."

--- a/src/lib/protocols/mcp-modern.ts
+++ b/src/lib/protocols/mcp-modern.ts
@@ -9,6 +9,8 @@
 
 import {
   Client,
+  SdkError,
+  SdkErrorCode,
   StreamableHTTPClientTransport,
   type OAuthClientProvider as ModernOAuthClientProvider,
   type Tool,
@@ -341,6 +343,15 @@ async function attemptModernCall(
       });
       return { handled: false };
     }
+    if (SdkError.isInstance(error) && error.code === SdkErrorCode.EraNegotiationFailed) {
+      markKnownLegacy(cacheKey);
+      options.debugLogs.push({
+        type: 'info',
+        message: `MCP: Era negotiation failed for ${toolName}; preserving the v1 transport path`,
+        timestamp: new Date().toISOString(),
+      });
+      return { handled: false };
+    }
     throw error;
   }
 
@@ -468,6 +479,7 @@ export async function probeModernMCPConnection(
     if (is401Error(error) || isAbortOrTimeoutError(error)) throw error;
     const status = httpStatusOf(error);
     if (status === 404 || status === 405) return { connected: false };
+    if (SdkError.isInstance(error) && error.code === SdkErrorCode.EraNegotiationFailed) return { connected: false };
     throw error;
   } finally {
     await client?.close().catch(() => {});
@@ -507,6 +519,7 @@ export async function tryListModernMCPTools(
     if (is401Error(error) || isAbortOrTimeoutError(error)) throw error;
     const status = httpStatusOf(error);
     if (status === 404 || status === 405) return { handled: false };
+    if (SdkError.isInstance(error) && error.code === SdkErrorCode.EraNegotiationFailed) return { handled: false };
     throw error;
   } finally {
     await client?.close().catch(() => {});


### PR DESCRIPTION
## Why

Backport of AI-5153 fix to 12.x (current version used in agentic-api is 12.0.3).

Servers that respond to the \`server/discover\` probe with a malformed envelope (e.g. \`id: null\` instead of echoing the request id) cause \`@modelcontextprotocol/client\` to throw \`ERA_NEGOTIATION_FAILED\`. This error has no HTTP status, so the existing 404/405 check doesn't catch it — the error propagates as "None responded to MCP protocol."

Root cause confirmed for InMobi (adcp_agent 283, BASIC_AUTH): their server returns \`{"error":{"code":-32600,"message":"Missing ID field"},"id":null}\` for \`server/discover\`. The \`id: null\` response fails the beta client's envelope parse.

See companion PR targeting main: #2408

## What Changed

- Added `SdkError, SdkErrorCode` to imports from `@modelcontextprotocol/client`
- In `probeModernMCPConnection`, `attemptModernCall`, `tryListModernMCPTools`: treat `ERA_NEGOTIATION_FAILED` the same as 404/405 — fall back to the v1 transport path

Branch is based on \`@adcp/sdk@12.1.1\`. After this merges, agentic-api can bump \`@adcp/sdk\` to 12.1.2.