### PR TITLE
fix(types): export all creative asset variants

### DIFF
--- a/.changeset/fix-asset-instance-registry-drift.md
+++ b/.changeset/fix-asset-instance-registry-drift.md
@@ -1,0 +1,7 @@
+---
+'@adcp/sdk': minor
+---
+
+Expose `PublishedPostAsset`, `ZipAsset`, `CardAsset`, `PixelTrackerAsset`, `VASTTrackerAsset`, and `DAASTTrackerAsset` from the package root and `@adcp/sdk/types`, and include every generated registry-backed variant in `AssetInstance`.
+
+BREAKING NOTE: exhaustive `AssetInstance` switches must add cases for `zip`, `published_post`, `card`, `pixel_tracker`, `vast_tracker`, and `daast_tracker`. These are additive protocol variants that the SDK previously omitted from its public union.

--- a/src/lib/server/decisioning/manifest-helpers.ts
+++ b/src/lib/server/decisioning/manifest-helpers.ts
@@ -1,11 +1,12 @@
 /**
  * Helpers for reading typed assets out of `creative_manifest.assets`.
  *
- * `creative_manifest.assets` is a keyed map (`{ [asset_id]: AssetInstance }`)
- * where each value is a discriminated union by `asset_type`. Adopters
- * narrowing per-call write the same null-check + discriminator-check
- * boilerplate over and over. These helpers replace that boilerplate
- * without compromising the discriminator-narrowing story.
+ * `creative_manifest.assets` is a keyed map
+ * (`{ [asset_id]: AssetInstance | AssetInstance[] }`) where each individual
+ * value is a discriminated union by `asset_type`. Adopters narrowing per-call
+ * write the same null-check + discriminator-check boilerplate over and over.
+ * These helpers replace that boilerplate without compromising the
+ * discriminator-narrowing story.
  *
  * Status: Preview / 6.0.
  *

--- a/src/lib/types/asset-instances.ts
+++ b/src/lib/types/asset-instances.ts
@@ -21,6 +21,7 @@
 // (registry) and schemas/cache/{version}/core/assets/*-asset.json (per-type).
 
 import type {
+  AssetVariant,
   ImageAsset,
   VideoAsset,
   AudioAsset,
@@ -35,6 +36,12 @@ import type {
   BriefAsset,
   CatalogAsset,
   WebhookAsset,
+  ZipAsset,
+  PublishedPostAsset,
+  CardAsset,
+  PixelTrackerAsset,
+  VASTTrackerAsset,
+  DAASTTrackerAsset,
 } from './tools.generated';
 
 /**
@@ -56,25 +63,13 @@ import type {
  * }
  * ```
  *
- * This is the type to use for `creative_manifest.assets[<key>]` values.
- * The `assets` map itself is `Record<string, AssetInstance>` — keys come
- * from the format's declared asset slot ids; values are these instances.
+ * This is the type to use for individual values in
+ * `creative_manifest.assets[<key>]`. The `assets` map itself is
+ * `Record<string, AssetInstance | AssetInstance[]>` — keys come from the
+ * format's declared asset slot ids; values are single instances or arrays
+ * for slots whose format declaration accepts multiple assets.
  */
-export type AssetInstance =
-  | ImageAsset
-  | VideoAsset
-  | AudioAsset
-  | TextAsset
-  | HTMLAsset
-  | URLAsset
-  | CSSAsset
-  | JavaScriptAsset
-  | MarkdownAsset
-  | VASTAsset
-  | DAASTAsset
-  | BriefAsset
-  | CatalogAsset
-  | WebhookAsset;
+export type AssetInstance = AssetVariant;
 
 /**
  * The discriminator value (`asset_type`) of every variant in
@@ -102,4 +97,10 @@ export type {
   BriefAsset,
   CatalogAsset,
   WebhookAsset,
+  ZipAsset,
+  PublishedPostAsset,
+  CardAsset,
+  PixelTrackerAsset,
+  VASTTrackerAsset,
+  DAASTTrackerAsset,
 };

--- a/src/lib/types/asset-instances.type-checks.ts
+++ b/src/lib/types/asset-instances.type-checks.ts
@@ -17,7 +17,14 @@
 //
 // Run with `npm run typecheck`.
 
-import type { AssetInstance, AssetInstanceType, SyncAccountsResponseRow, SyncGovernanceResponseRow } from './index';
+import type {
+  AssetInstance,
+  AssetInstanceType,
+  PublishedPostAsset,
+  SyncAccountsResponseRow,
+  SyncGovernanceResponseRow,
+} from './index';
+import type { AssetVariant } from './tools.generated';
 
 // ── AssetInstance: discriminator narrowing + exhaustiveness ──────────────
 
@@ -43,6 +50,12 @@ function describeAsset(asset: AssetInstance): string {
     case 'brief':
     case 'catalog':
     case 'webhook':
+    case 'zip':
+    case 'published_post':
+    case 'card':
+    case 'pixel_tracker':
+    case 'vast_tracker':
+    case 'daast_tracker':
       return asset.asset_type;
     default: {
       // Exhaustiveness rail: if a new asset_type lands in AssetInstance
@@ -93,7 +106,31 @@ const _all_types: AssetInstanceType[] = [
   'brief',
   'catalog',
   'webhook',
+  'zip',
+  'published_post',
+  'card',
+  'pixel_tracker',
+  'vast_tracker',
+  'daast_tracker',
 ];
+
+// AssetInstance intentionally aliases the generated protocol union. The
+// runtime schema test separately compares that union's refs with every entry
+// in the creative asset-type registry.
+declare const _registry_variant: AssetVariant;
+const _registry_drift_guard: AssetInstance = _registry_variant;
+
+const _published_post: PublishedPostAsset = {
+  asset_type: 'published_post',
+  platform: 'meta',
+  platform_post_id: 'page_post',
+};
+const _published_post_as_asset: AssetInstance = _published_post;
+
+function _publishedPost_narrows(asset: AssetInstance): string | undefined {
+  if (asset.asset_type === 'published_post') return asset.platform_post_id;
+  return undefined;
+}
 
 function _assetType_bogusValue(): AssetInstanceType {
   // @ts-expect-error — 'banner' is not a valid asset_type.
@@ -152,6 +189,10 @@ export const _references = [
   _imageAsset_missingWidth,
   _htmlAsset_wrongFieldName,
   _all_types,
+  _registry_drift_guard,
+  _published_post,
+  _published_post_as_asset,
+  _publishedPost_narrows,
   _assetType_bogusValue,
   _row_ok,
   _row_missingAction,

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -317,11 +317,10 @@ export * from './format-asset-slots';
 // Discriminated union of creative asset INSTANCES (what a buyer delivers
 // inside `creative_manifest.assets`). Companion to format-asset-slots.ts
 // (which describes what a publisher SELLS in `Format.assets[]`). The
-// individual ImageAsset / VideoAsset / etc. interfaces are generated; this
-// file is the missing canonical union over them.
-// Note: tools.generated.ts also has `AssetVariant`, a narrower generated union
-// that omits AudioAsset. `AssetInstance` (this file) is the curated, complete
-// union — prefer it. `AssetVariant` is intentionally not re-exported.
+// individual ImageAsset / VideoAsset / etc. interfaces and their canonical
+// `AssetVariant` union are generated. `AssetInstance` aliases that union so
+// every registry-backed asset branch remains available without curated drift.
+// `AssetVariant` itself is intentionally not re-exported.
 export * from './asset-instances';
 
 // Strict per-row types for sync_* response success arms. The codegen

--- a/test/lib/asset-instances-public-exports.test.js
+++ b/test/lib/asset-instances-public-exports.test.js
@@ -1,0 +1,135 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const schemaRoot = path.resolve(__dirname, '../../schemas/cache/latest');
+const registryPath = path.join(schemaRoot, 'creative/asset-types/index.json');
+const unionPath = path.join(schemaRoot, 'core/assets/asset-union.json');
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function normalizeAssetSchemaRef(ref) {
+  return ref.replace(/^\/schemas\/(?:[^/]+\/)?core\/assets\//, '/schemas/core/assets/');
+}
+
+test('generated asset union stays aligned with the creative asset-type registry', () => {
+  const registry = readJson(registryPath);
+  const union = readJson(unionPath);
+  const registryRefs = [];
+
+  for (const [assetType, entry] of Object.entries(registry.asset_types)) {
+    const normalizedRef = normalizeAssetSchemaRef(entry.schema);
+    registryRefs.push(normalizedRef);
+
+    const assetSchema = readJson(path.join(schemaRoot, 'core/assets', path.basename(normalizedRef)));
+    assert.strictEqual(
+      assetSchema.properties?.asset_type?.const,
+      assetType,
+      `${entry.schema} must declare asset_type=${assetType}`
+    );
+  }
+
+  const unionRefs = union.oneOf.map(branch => normalizeAssetSchemaRef(branch.$ref));
+  assert.deepStrictEqual(
+    [...unionRefs].sort(),
+    [...registryRefs].sort(),
+    'asset-union.json must contain exactly the schemas declared by the creative asset-type registry'
+  );
+});
+
+test('asset instance types resolve from ESM and CJS public entrypoints', () => {
+  const contextDir = path.resolve(__dirname, '../../.context');
+  fs.mkdirSync(contextDir, { recursive: true });
+
+  const registry = readJson(registryPath);
+  const assetTypeNames = Object.values(registry.asset_types).map(entry => {
+    const assetSchema = readJson(path.join(schemaRoot, 'core/assets', path.basename(entry.schema)));
+    return assetSchema.title.replace(/\s+/g, '');
+  });
+  const rootTypeImports = assetTypeNames.map(name => `${name} as Root${name}`).join(',\n  ');
+  const rootTypeUnion = assetTypeNames.map(name => `Root${name}`).join('\n  | ');
+  const typesTypeImports = assetTypeNames.join(',\n  ');
+  const typesTypeUnion = assetTypeNames.join('\n  | ');
+
+  const source = `
+import type {
+  AssetInstance as RootAssetInstance,
+  ${rootTypeImports},
+} from '@adcp/sdk';
+import type {
+  AssetInstance,
+  ${typesTypeImports},
+} from '@adcp/sdk/types';
+
+const post: PublishedPostAsset = {
+  asset_type: 'published_post',
+  platform: 'meta',
+  platform_post_id: 'page_post',
+};
+const asset: AssetInstance = post;
+const rootPost: RootPublishedPostAsset = post;
+const rootAsset: RootAssetInstance = rootPost;
+
+function narrow(candidate: AssetInstance): string | undefined {
+  if (candidate.asset_type === 'published_post') return candidate.platform_post_id;
+  return undefined;
+}
+
+type RootPublicVariants =
+  | ${rootTypeUnion};
+type TypesPublicVariants =
+  | ${typesTypeUnion};
+declare const rootAssetCandidate: RootAssetInstance;
+declare const typesAssetCandidate: AssetInstance;
+declare const rootVariant: RootPublicVariants;
+declare const typesVariant: TypesPublicVariants;
+const rootUnionCoversAsset: RootPublicVariants = rootAssetCandidate;
+const rootAssetCoversUnion: RootAssetInstance = rootVariant;
+const typesUnionCoversAsset: TypesPublicVariants = typesAssetCandidate;
+const typesAssetCoversUnion: AssetInstance = typesVariant;
+
+void asset;
+void rootAsset;
+void narrow;
+void rootUnionCoversAsset;
+void rootAssetCoversUnion;
+void typesUnionCoversAsset;
+void typesAssetCoversUnion;
+`;
+
+  const cjsPath = path.join(contextDir, 'asset-instance-entrypoints.cts');
+  const esmPath = path.join(contextDir, 'asset-instance-entrypoints.mts');
+  const tsconfigPath = path.join(contextDir, 'asset-instance-entrypoints-tsconfig.json');
+  fs.writeFileSync(cjsPath, source, 'utf8');
+  fs.writeFileSync(esmPath, source, 'utf8');
+  fs.writeFileSync(
+    tsconfigPath,
+    JSON.stringify(
+      {
+        compilerOptions: {
+          target: 'ES2022',
+          module: 'NodeNext',
+          moduleResolution: 'NodeNext',
+          strict: true,
+          skipLibCheck: true,
+          noEmit: true,
+        },
+        files: ['asset-instance-entrypoints.cts', 'asset-instance-entrypoints.mts'],
+      },
+      null,
+      2
+    ),
+    'utf8'
+  );
+
+  const result = spawnSync('npx', ['tsc', '-p', tsconfigPath], {
+    cwd: path.resolve(__dirname, '../..'),
+    encoding: 'utf8',
+  });
+
+  assert.strictEqual(result.status, 0, `${result.stdout}\n${result.stderr}`);
+});

--- a/test/lib/signer-grader.test.js
+++ b/test/lib/signer-grader.test.js
@@ -207,17 +207,20 @@ describe('gradeSigner', () => {
     );
   });
 
-  test('signer signs with wrong key (different `d`) → verifier rejects request_signature_invalid', async () => {
-    // Advertise ed25519 + correct kid, but sign with ES256 private material.
+  test('signer signs with wrong keypair → verifier rejects request_signature_invalid', async () => {
+    // Advertise ed25519 + correct kid, but sign with a different Ed25519
+    // keypair.
     // This simulates a KMS adapter pointed at the wrong key version.
     const dir = mkdtempSync(path.join(os.tmpdir(), 'adcp-grader-'));
     const keyFilePath = path.join(dir, 'key.jwk');
-    // Create a frankenstein JWK: kid + alg of ed25519, but `d` from a different
-    // ed25519 key that's not in the JWKS. Reuses the gov-signing key from the
-    // test vectors.
+    // Keep the advertised identity metadata, but sign with a complete,
+    // different Ed25519 keypair that's not in the JWKS. Reuses the
+    // governance-signing key material from the test vectors. Both `x` and
+    // `d` must come from that pair; Node rejects an incoherent OKP JWK before
+    // signing, which would test signer setup rather than verifier rejection.
     const govEd = keysData.keys.find(k => k.adcp_use === 'governance-signing' && k.crv === 'Ed25519');
     assert.ok(govEd, 'test fixture: governance-signing Ed25519 key required for wrong-key assertion');
-    const wrongKey = { ...privateJwkFor(ed), d: govEd._private_d_for_test_only };
+    const wrongKey = { ...privateJwkFor(ed), x: govEd.x, d: govEd._private_d_for_test_only };
     writeFileSync(keyFilePath, JSON.stringify(wrongKey));
 
     const report = await gradeSigner({
@@ -229,7 +232,8 @@ describe('gradeSigner', () => {
       allowPrivateIp: true,
     });
     assert.strictEqual(report.passed, false);
-    assert.match(report.step.error_code, /request_signature_invalid|request_signature_key_unknown/);
+    assert.strictEqual(report.step.error_code, 'request_signature_invalid');
+    assert.match(report.step.diagnostic, /step 10/);
   });
 
   test('passing both --key-file and --signer-url throws a clear setup error', async () => {

--- a/test/request-signing-provider.test.js
+++ b/test/request-signing-provider.test.js
@@ -665,10 +665,11 @@ describe('end-to-end: provider-signed request verifies under the SDK verifier', 
     // Sign with the wrong key but advertise the right `kid`. Verifier must
     // reject — the signature won't validate against the JWKS public key.
     const wrongKey = privateJwkFor('test-ed25519-2026');
-    // Mutate `d` to a different valid Ed25519 scalar (also from the test
-    // vectors): use the gov-signing key's scalar but keep `kid` advertising
-    // the request-signing identity.
-    const wrongJwk = { ...wrongKey, d: privateJwkFor('test-gov-2026').d };
+    // Replace the complete keypair with the governance-signing fixture while
+    // retaining the request-signing identity metadata. Swapping only `d`
+    // leaves an incoherent OKP JWK that Node rejects before signing.
+    const alternateKey = privateJwkFor('test-gov-2026');
+    const wrongJwk = { ...wrongKey, x: alternateKey.x, d: alternateKey.d };
     const provider = new InMemorySigningProvider({
       keyid: kid,
       algorithm: 'ed25519',
@@ -688,7 +689,7 @@ describe('end-to-end: provider-signed request verifies under the SDK verifier', 
             now: SAMPLE_OPTIONS.now,
           }
         ),
-      err => err instanceof RequestSignatureError && /signature_invalid|key_purpose|key_unknown/.test(err.code)
+      err => err instanceof RequestSignatureError && err.code === 'request_signature_invalid' && err.failedStep === 10
     );
   });
 });


### PR DESCRIPTION
## Summary

- expose every registry-backed creative asset type from the package root and `@adcp/sdk/types`
- define `AssetInstance` from the generated `AssetVariant` source of truth
- add registry, discriminator, narrowing, and CJS/ESM public-entrypoint drift coverage
- repair wrong-key signing fixtures so they reach exact step-10 cryptographic rejection on current Node versions

## Root cause

The hand-curated `AssetInstance` union and named export list drifted behind the generated protocol asset union. Separately, two negative signing tests replaced only an Ed25519 private scalar while retaining a mismatched public coordinate; stricter Node runtimes rejected that incoherent JWK before the verifier path was exercised.

## Impact

Consumers can import all protocol-valid asset interfaces, including `PublishedPostAsset`, and assign every registry-backed branch to `AssetInstance`. Exhaustive `AssetInstance` switches will now surface the six branches that the SDK previously omitted.

## Validation

- `npm run typecheck`
- `npm run build:lib`
- asset registry/public entrypoint tests (CJS and ESM)
- signing grader/provider suites: exact `request_signature_invalid` at verifier step 10
- protocol, security, code, and DX expert reviews
- protocol, code, and security Codex review personas

Fixes #2417
