### PR TITLE
feat(server)!: require an explicit refAccess on createTenantStore

### DIFF
--- a/.changeset/require-tenant-ref-access.md
+++ b/.changeset/require-tenant-ref-access.md
@@ -1,0 +1,18 @@
+---
+'@adcp/sdk': major
+---
+
+**Breaking:** `createTenantStore`'s `refAccess` is now required, with no default.
+
+It previously defaulted to `'ref-routed'`, under which `accounts.resolve` returns whatever tenant the buyer's ref names without consulting the authenticated principal. That is correct for an agency hub whose single credential legitimately spans tenants — and a cross-tenant **spend** hole for a hub whose tenants are unrelated clients, since `resolve` is the account path for `create_media_buy` and `update_media_buy`. Nothing in the code can distinguish those two deployments, so a default silently picked one.
+
+Both values remain available and neither behavior changed; only the choice is now explicit.
+
+- `'auth-scoped'` — a ref resolving to a tenant other than `resolveFromAuth(ctx)` returns `null` (framework emits `ACCOUNT_NOT_FOUND`). Correct for most multi-tenant deployments.
+- `'ref-routed'` — previous default. Keep it only if one credential is _supposed_ to span tenants, and layer a `resolve-presets` guard (`requireAccountMatch` / `requireAdvertiserMatch` / `requireOrgScope`) via `composeMethod`.
+
+Migration is one line per `createTenantStore` call. TypeScript reports it at the call site; the helper also throws at construction on a missing or unrecognized value, so JS adopters and `as any` casts can't fall through to the permissive branch silently.
+
+Note that `refAccess` governs `resolve` **only** — `upsert` / `syncGovernance` enforce the per-entry tenant gate either way. An adopter who had verified the sync-tool gate was never covered on `resolve`, which is what made the old default easy to miss.
+
+`skills/build-holdco-agent/SKILL.md` — the doc an adopter actually follows — never mentioned `refAccess` while its front-matter promised "per-tenant data isolation". It now documents the choice, adds a "What the helper does NOT guarantee" section, and `skills/cross-cutting.md` no longer describes the helper as an unqualified isolation gate.

--- a/examples/hello_seller_adapter_multi_tenant.ts
+++ b/examples/hello_seller_adapter_multi_tenant.ts
@@ -461,6 +461,13 @@ class MultiTenantAdapter implements DecisioningPlatform<Record<string, never>, T
    * disabled isolation for credentials lacking a home tenant.
    */
   accounts: AccountStore<TenantMeta> = createTenantStore<TenantState, TenantMeta>({
+    // Required, no default — the safe value depends on whether one credential
+    // is *supposed* to span tenants. Here it is not: each buyer agent_url maps
+    // to exactly one home tenant via BUYER_HOME_TENANT, so a ref naming another
+    // tenant must fail closed rather than resolve. An agency hub whose single
+    // credential legitimately spans tenants would pass 'ref-routed' instead and
+    // layer a `resolve-presets` guard on top.
+    refAccess: 'auth-scoped',
     resolveByRef: ref => {
       const r = narrowAccountRef(ref);
       if (!r.operator) return null;

--- a/skills/build-holdco-agent/SKILL.md
+++ b/skills/build-holdco-agent/SKILL.md
@@ -71,6 +71,7 @@ The framework calls `accounts.resolve(ref, ctx)` once per request, and hub adapt
 1. **Path 1** — operator-routed resolution for tools that carry `account` on the wire (`sync_accounts`, `sync_governance`, governance, property-lists)
 2. **Path 2** — auth-derived resolution for no-account tools (`get_brand_identity`, `get_rights`)
 3. **Per-entry tenant-isolation gate** on `sync_accounts` / `sync_governance` — verify each entry's `operator` maps to the buyer's authenticated home tenant before persisting, fail-closed when the auth principal isn't registered
+4. **A resolve posture** — decide whether a buyer-supplied ref naming *another* tenant resolves or fails closed. This is the `refAccess` field and it is **required with no default**, because both answers are correct for some hubs. It is a separate decision from (3): the gate in (3) covers the sync tools only, while `resolve` is the account path for `create_media_buy` and `update_media_buy`
 
 All three live in `createTenantStore<TTenant, TCtxMeta>` (`@adcp/sdk/server`). Callbacks the adopter provides; gating logic the SDK owns:
 
@@ -78,6 +79,9 @@ All three live in `createTenantStore<TTenant, TCtxMeta>` (`@adcp/sdk/server`). C
 import { createTenantStore, narrowAccountRef } from '@adcp/sdk/server';
 
 accounts: AccountStore<TenantMeta> = createTenantStore<TenantState, TenantMeta>({
+  // REQUIRED, no default. 'auth-scoped' = a ref naming another tenant fails
+  // closed. Use it unless one credential is *supposed* to span tenants.
+  refAccess: 'auth-scoped',
   resolveByRef: ref => {  // Path 1 — operator (or account_id) on the wire
     const r = narrowAccountRef(ref);
     const tenantId = OPERATOR_TO_TENANT.get(r.operator ?? '');
@@ -110,10 +114,25 @@ accounts: AccountStore<TenantMeta> = createTenantStore<TenantState, TenantMeta>(
 });
 ```
 
+**Pick your `refAccess` deliberately — it is the one field with no safe default:**
+
+| | `resolve` with a ref naming another tenant | Use when |
+| --- | --- | --- |
+| `'auth-scoped'` | returns `null` → `ACCOUNT_NOT_FOUND` | Tenants are unrelated clients / competing agencies. **Most hubs.** |
+| `'ref-routed'` | returns that tenant's `Account` | One credential is *supposed* to span tenants (a single agency operating all of them) |
+
+Getting this wrong in the `'ref-routed'` direction means any authenticated tenant can name another tenant's `account_id` or `operator` and have `create_media_buy` run scoped to that account — cross-tenant **spend**, not just cross-tenant reads. If you genuinely need `'ref-routed'`, layer a `resolve-presets` guard (`requireAccountMatch` / `requireAdvertiserMatch` / `requireOrgScope`) on top via `composeMethod`.
+
+**What the helper does NOT guarantee:**
+
+- **`refAccess` governs `resolve` only.** Verifying the sync-tool gate tells you nothing about `resolve`. Under `'ref-routed'` there is no isolation on `resolve` at all — that is the mode's purpose, not a bug.
+- **It does not scope your data layer.** `tenantToAccount` returns whatever your callbacks hand it; if `resolveByRef` reads a shared table without a tenant predicate, the helper cannot see that.
+
 **What the helper guarantees:**
 
 - **Cross-tenant entries never reach `upsertRow` / `syncGovernanceRow`.** The helper resolves `authTenant = resolveFromAuth(ctx)` once per request, then for each entry resolves `entryTenant = resolveByRef(ref)` and emits a `'failed'` row with `code: 'PERMISSION_DENIED'` when `tenantId(authTenant) !== tenantId(entryTenant)`. Adopter callbacks see only in-tenant entries.
 - **Fail-closed when `resolveFromAuth` returns null** (unknown principal, no `agentRegistry`, agent_url not in your home-tenant map): every entry fails `PERMISSION_DENIED`. Don't fork around this — the prior fail-OPEN shape (`if (homeTenantId && entryTenant !== homeTenantId)`) silently disabled isolation for credentials lacking a home-tenant binding.
+- **Construction refuses a missing or unrecognized `refAccess`.** TypeScript flags it, and the helper also throws at runtime so a JS adopter or an `as any` cast can't fall through to the permissive branch silently.
 - **`accounts.upsert` and `accounts.syncGovernance` are non-writable** on the returned store. An adopter who writes `accounts.upsert = customHandler` after construction gets a `TypeError` (in strict mode) instead of silently bypassing the gate. To extend with `list` / `reportUsage` / `getAccountFinancials`, use `Object.assign`:
 
   ```ts

--- a/skills/cross-cutting.md
+++ b/skills/cross-cutting.md
@@ -66,9 +66,11 @@ The hello adapters use simple in-memory `accounts.resolution: 'lookup'` against 
 - `createOAuthPassthroughResolver` — buyer-OAuth-passes-through (Shape B)
 - `createRosterAccountStore` — pre-loaded roster (Shape C)
 - `createDerivedAccountStore` — single-tenant `'derived'` mode (Shape D)
-- `createTenantStore` — multi-tenant with built-in isolation gate
+- `createTenantStore` — multi-tenant, with a built-in isolation gate on the account-sync tools and a **required** `refAccess` choice for `resolve`
 
 `createTenantStore` is the right default for any adopter handling more than one advertiser. It refuses inline `{account_id}` references unless your store explicitly lists them — that's a hard security gate, not a soft warning.
+
+Its `refAccess` field is required and has no default: `'auth-scoped'` makes a ref naming another tenant fail closed, `'ref-routed'` lets one credential span tenants on purpose. The sync-tool isolation gate is always on and is a *separate* decision — `refAccess` governs `accounts.resolve`, which is the account path for `create_media_buy` / `update_media_buy`. See `skills/build-holdco-agent/SKILL.md`.
 
 ## Webhooks: stable `operation_id` across retries
 

--- a/src/lib/server/decisioning/account.ts
+++ b/src/lib/server/decisioning/account.ts
@@ -5,10 +5,12 @@
  * shape. Generic `TCtxMeta` lets platforms type their metadata at the call site.
  *
  * Tenant scoping is expressed by what `accounts.resolve()` returns, not via
- * a multi-level type. Note that resolve is NOT an isolation gate by default:
- * `createTenantStore` resolves the ref the buyer supplies regardless of the
- * caller unless `refAccess: 'auth-scoped'` is set (or a `resolve-presets`
- * guard is composed). See `createTenantStore` and `resolve-presets.ts`.
+ * a multi-level type. Note that resolve is an isolation gate only when you make
+ * it one: `createTenantStore` requires an explicit `refAccess`, and under
+ * `'ref-routed'` it resolves the ref the buyer supplies regardless of the caller
+ * (isolation then has to come from a composed `resolve-presets` guard).
+ * `'auth-scoped'` fails closed instead. See `createTenantStore` and
+ * `resolve-presets.ts`.
  *
  * Status: Preview / 6.0.
  *

--- a/src/lib/server/decisioning/tenant-store.ts
+++ b/src/lib/server/decisioning/tenant-store.ts
@@ -6,12 +6,16 @@
  * account-sync tools (`sync_accounts` / `sync_governance`) that adopters
  * historically had to write — and silently fail to write — by hand.
  *
- * NOTE: `accounts.resolve` is NOT gated by default (`refAccess: 'ref-routed'`)
- * — it returns whatever tenant the buyer's ref points at, which is correct
- * for the agency-hub model where one credential spans tenants. Deployments
- * where a credential must NOT reach another tenant's account set
- * `refAccess: 'auth-scoped'` (gates `resolve` fail-closed) or compose a
- * `resolve-presets` guard. See {@link TenantStoreConfig.refAccess}.
+ * NOTE: `refAccess` is REQUIRED and has no default, because the safe value
+ * depends on a fact only the adopter knows. `'ref-routed'` returns whatever
+ * tenant the buyer's ref points at — correct for the agency-hub model where one
+ * credential legitimately spans tenants, and a cross-tenant spend hole where it
+ * doesn't. `'auth-scoped'` gates `resolve` fail-closed.
+ *
+ * `refAccess` governs `resolve` ONLY. `upsert` / `syncGovernance` enforce the
+ * tenant gate either way — so an adopter who has verified those is NOT covered
+ * on `resolve`, and `resolve` is the account path for `create_media_buy` and
+ * `update_media_buy`. See {@link TenantStoreConfig.refAccess}.
  *
  * Full walkthrough with same-tenant invariant + production caveats:
  * `skills/build-holdco-agent/SKILL.md`. Worked example:
@@ -53,7 +57,15 @@ export interface TenantStoreConfig<TTenant, TCtxMeta = Record<string, unknown>> 
    * Controls whether a buyer-supplied account ref on `accounts.resolve` is
    * gated against the authenticated principal's tenant.
    *
-   * - `'ref-routed'` (default) — `resolve` returns whatever tenant the ref
+   * REQUIRED, deliberately with no default. Both values are correct for some
+   * deployments and catastrophic for others, and nothing in the code can tell
+   * which one you are: `'ref-routed'` is right for an agency hub whose single
+   * credential legitimately spans tenants, and a cross-tenant spend hole for a
+   * hub whose tenants are unrelated clients. A default would silently pick one
+   * of those for you. Making it required turns that into a `tsc` error you
+   * resolve once, at construction, instead of a runtime surprise.
+   *
+   * - `'ref-routed'` — `resolve` returns whatever tenant the ref
    *   points at, WITHOUT checking the caller. This is correct for the
    *   agency-hub / account-routed model where one credential legitimately
    *   spans tenants (see `examples/hello_seller_adapter_multi_tenant.ts`).
@@ -71,16 +83,16 @@ export interface TenantStoreConfig<TTenant, TCtxMeta = Record<string, unknown>> 
    * This flag governs ONLY `resolve`. `upsert` / `syncGovernance` always
    * enforce the tenant gate regardless of this setting.
    */
-  refAccess?: 'ref-routed' | 'auth-scoped';
+  refAccess: 'ref-routed' | 'auth-scoped';
 
   /**
    * Path 1: account ref carries `account_id` OR `(brand, operator)`.
    * Resolve to the tenant the ref points at. Return null if the ref is
    * unknown (helper emits `ACCOUNT_NOT_FOUND` for that row).
    *
-   * By default (`refAccess: 'ref-routed'`) this resolves independent of who
-   * the caller is. Set `refAccess: 'auth-scoped'` to make `resolve` reject a
-   * ref that points at a tenant other than the caller's.
+   * Under `refAccess: 'ref-routed'` this resolves independent of who the caller
+   * is. Under `refAccess: 'auth-scoped'` a ref pointing at a tenant other than
+   * the caller's is rejected.
    *
    * Receives the full `AccountReference` so adopters can route on
    * `ref.sandbox` (Pattern 2: separate sandbox tenant) or read the
@@ -172,9 +184,9 @@ export interface TenantStoreConfig<TTenant, TCtxMeta = Record<string, unknown>> 
  *   set, otherwise `resolveFromAuth(ctx)`. Projects via `tenantToAccount`.
  *   Returns `null` if the resolver returned `null` (framework emits
  *   `ACCOUNT_NOT_FOUND` for tools that require an account, or treats
- *   absence as "no tenant" for tools that don't). By default this path does
- *   NOT check the caller against the ref's tenant — set
- *   `refAccess: 'auth-scoped'` to fail closed on a cross-tenant ref.
+ *   absence as "no tenant" for tools that don't). Under
+ *   `refAccess: 'ref-routed'` this path does NOT check the caller against the
+ *   ref's tenant; `refAccess: 'auth-scoped'` fails closed on a cross-tenant ref.
  *
  * - `accounts.upsert(refs, ctx)` — for each ref:
  *     1. Resolve the entry's tenant via `resolveByRef`.
@@ -213,6 +225,21 @@ export interface TenantStoreConfig<TTenant, TCtxMeta = Record<string, unknown>> 
 export function createTenantStore<TTenant, TCtxMeta = Record<string, unknown>>(
   config: TenantStoreConfig<TTenant, TCtxMeta>
 ): AccountStore<TCtxMeta> {
+  // `refAccess` is required in the type, but the type only protects TypeScript
+  // callers — a JS adopter or an `as any` cast would otherwise fall through to
+  // the permissive branch silently, which is the exact failure this field exists
+  // to prevent. Refuse at construction instead.
+  if (config.refAccess !== 'ref-routed' && config.refAccess !== 'auth-scoped') {
+    throw new Error(
+      'createTenantStore: `refAccess` is required and must be "ref-routed" or "auth-scoped". ' +
+        'There is deliberately no default — the safe value depends on whether one credential is ' +
+        'supposed to span tenants. Use "auth-scoped" when a credential must NOT reach another ' +
+        'tenant\'s account by naming its ref (most multi-tenant deployments), or "ref-routed" for ' +
+        'an agency hub whose single credential legitimately spans tenants. Note this governs ' +
+        '`resolve` only — which is the account path for create_media_buy and update_media_buy — ' +
+        'while `upsert` / `syncGovernance` are gated either way.'
+    );
+  }
   const store: AccountStore<TCtxMeta> = {
     resolve: async (ref, ctx) => {
       const resolveCtx = ctx ?? {};
@@ -223,7 +250,7 @@ export function createTenantStore<TTenant, TCtxMeta = Record<string, unknown>>(
       }
       const entryTenant = await config.resolveByRef(ref);
       if (entryTenant == null) return null;
-      if ((config.refAccess ?? 'ref-routed') === 'auth-scoped') {
+      if (config.refAccess === 'auth-scoped') {
         const authTenant = await config.resolveFromAuth(resolveCtx);
         // Fail-closed: an unresolvable principal OR a ref pointing at a
         // different tenant is treated as not found — a caller cannot reach

--- a/test/lib/create-tenant-store.test.js
+++ b/test/lib/create-tenant-store.test.js
@@ -51,6 +51,9 @@ function buildStore(opts = {}) {
       operator: ref?.operator ?? 'derived',
       sandbox: ref?.sandbox ?? false,
     }),
+    // Required with no default — stated explicitly here so every test below
+    // declares the resolve posture it is exercising rather than inheriting one.
+    refAccess: 'ref-routed',
     ...opts,
   };
   return createTenantStore(cfg);
@@ -106,8 +109,20 @@ describe('createTenantStore — resolve', () => {
 // ── resolve — refAccess isolation gate ──────────────────────────────────────
 
 describe('createTenantStore — resolve refAccess gate', () => {
-  test("default ('ref-routed') resolves a cross-tenant ref without checking the caller", async () => {
-    const store = buildStore();
+  // `refAccess` has no default: both values are correct for some deployments,
+  // so the helper refuses to pick one. These tests pass it explicitly.
+  test('refuses construction when refAccess is omitted', () => {
+    // Type-level requirement covers TS callers; this covers JS callers and
+    // `as any` casts, which would otherwise get the permissive branch silently.
+    assert.throws(() => buildStore({ refAccess: undefined }), /`refAccess` is required/);
+  });
+
+  test('refuses construction on an unrecognized refAccess value', () => {
+    assert.throws(() => buildStore({ refAccess: 'auth_scoped' }), /`refAccess` is required/);
+  });
+
+  test("'ref-routed' resolves a cross-tenant ref without checking the caller", async () => {
+    const store = buildStore({ refAccess: 'ref-routed' });
     // Meridian's credential names Pinnacle's operator — ref-routed returns it.
     const acc = await store.resolve(
       { brand: { domain: 'acme.example' }, operator: 'pinnacle.example' },


### PR DESCRIPTION
Addresses the third item in #2428 — the one that needed a product decision rather than a patch.

## Why

`refAccess` defaulted to `'ref-routed'`, under which `accounts.resolve` returns whatever tenant the buyer's ref names without consulting the authenticated principal (`tenant-store.ts:217-235`).

That default is **correct** for an agency hub whose single credential legitimately spans tenants — the model the helper was designed for, documented in its own header. It is a cross-tenant **spend** hole for a hub whose tenants are unrelated clients, because `resolve` is the account path for `create_media_buy` and `update_media_buy`, not just reads.

Nothing in the code can tell those two deployments apart. So any default silently picks one, and the wrong pick is invisible until someone notices another tenant's budget moving.

To be clear about what this is not: the previous behavior was **not a bug**. It was documented in three places, has a fail-closed alternative shipped, and has a characterization test named `"default ('ref-routed') resolves a cross-tenant ref without checking the caller"`. A `codex-security` scan flagged it as a vulnerability; on the code, that was **refuted**. The problem is the default, and the docs.

## What changed

`refAccess` is required. Neither behavior changed; only the choice is now explicit.

| | `resolve` with a ref naming another tenant | Use when |
| --- | --- | --- |
| `'auth-scoped'` | returns `null` → `ACCOUNT_NOT_FOUND` | Tenants are unrelated clients. **Most hubs.** |
| `'ref-routed'` | returns that tenant's `Account` | One credential is *supposed* to span tenants |

Migration is one line per call site. Considered and rejected: flipping the default to `'auth-scoped'`, which would break agency-hub adopters *quietly* — their calls start returning `null` and they debug it as a resolution bug. A required field breaks them at `tsc`, before they ship.

**The type alone isn't enough**, so the helper also throws at construction on a missing or unrecognized value. A JS adopter or an `as any` cast would otherwise fall through to the permissive branch silently — the exact failure the field exists to prevent.

## The docs were the larger half

`skills/build-holdco-agent/SKILL.md` is the file an adopter actually follows. Its front-matter promises *"per-tenant data isolation"*, its § "Account resolution + tenant-isolation gate" presents `createTenantStore` as the answer — and it mentioned `refAccess` **zero times**. Its "What the helper guarantees" list covers `upsertRow` / `syncGovernanceRow` / non-writability and omits `resolve` entirely.

So an adopter could follow the skill end to end, verify every guarantee it lists, and ship cross-tenant `resolve` believing they had isolation. Worse, the guarantee they *did* verify — the per-entry gate — covers `sync_accounts` / `sync_governance` only, which is a genuinely separate decision from `refAccess`.

That skill now documents the choice with a decision table, states the consequence of getting it wrong, and gains a **"What the helper does NOT guarantee"** section. `skills/cross-cutting.md` no longer describes the helper as an unqualified "built-in isolation gate", and `decisioning/account.ts`'s header no longer says resolve "is NOT an isolation gate by default" (there is no default now).

## Verification

- **12,690 pass, 0 fail** on the full suite. No other construction site broke.
- Two new tests cover the runtime refusal (omitted, and unrecognized value).
- The characterization test is renamed off "default" and passes `'ref-routed'` explicitly; the four `'auth-scoped'` tests are unchanged.
- `examples/hello_seller_adapter_multi_tenant.ts` takes `'auth-scoped'` — each buyer `agent_url` maps to exactly one home tenant there, so a ref naming another must fail closed. **Its storyboard tests pass unchanged**, which confirms the example never relied on cross-tenant resolution.

Changeset is `major`. Timed for the `13.0.0-rc` line, and `createTenantStore` is `Preview / 6.x` surface, so the bar for a required-field change is lower than it would be for stable API — but it's worth checking how many adopters are on this helper before merging.

## Not in scope

The other two items in #2428 are ordinary fixes, unaffected by this and still open: the test-controller bridge admitting on a buyer-supplied `sandbox` marker when only `resolveAccount` is wired, and the comply controller whose `ADCP_SANDBOX` / `ADCP_COMPLY_CONTROLLER_UNGATED` env flags suppress the warning rather than gating anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)