### PR TITLE
fix: enforce absolute task lifecycle deadlines

### DIFF
--- a/.changeset/fix-task-timeout-deadline.md
+++ b/.changeset/fix-task-timeout-deadline.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Enforce `TaskOptions.timeout` as an absolute wall-clock deadline across discovery, capability preflight, and MCP/A2A tool execution. The SDK now composes the deadline with caller cancellation, aborts in-flight protocol work, surfaces `TaskTimeoutError`, and keeps `workingTimeout` as a separate resettable progress timeout.

--- a/docs/guides/ASYNC-API-REFERENCE.md
+++ b/docs/guides/ASYNC-API-REFERENCE.md
@@ -166,7 +166,7 @@ Core task execution engine that handles the conversation loop with agents.
 ```typescript
 class TaskExecutor {
   constructor(config?: {
-    /** Default timeout for 'working' status (max 120s per PR #78) */
+    /** Resettable idle/progress timeout for protocol work in 'working' status */
     workingTimeout?: number;
     /** Default max clarification attempts */
     defaultMaxClarifications?: number;
@@ -236,8 +236,10 @@ Configuration options for task execution.
 
 ```typescript
 interface TaskOptions {
-  /** Timeout for entire task (ms) */
+  /** Absolute deadline for the full call; does not reset on progress (ms) */
   timeout?: number;
+  /** Caller cancellation, composed with the absolute deadline */
+  signal?: AbortSignal;
   /** Maximum clarification rounds before failing */
   maxClarifications?: number;
   /** Context ID to continue existing conversation */
@@ -663,11 +665,20 @@ try {
 
 ### TaskTimeoutError
 
-Thrown when a task exceeds the working timeout (120 seconds).
+Thrown when `TaskOptions.timeout` reaches its absolute wall-clock deadline.
+`workingTimeout` remains a separate resettable idle/progress timeout.
 
 ```typescript
 class TaskTimeoutError extends Error {
   constructor(taskId: string, timeout: number);
+  /** Present for a mutating request once its retry identity is known */
+  idempotency_key?: string;
+  /** Present when the deadline expired during governance outcome reporting */
+  governanceRecovery?: {
+    checkId: string;
+    outcome?: 'completed' | 'failed';
+    outcomeIdempotencyKey?: string;
+  };
 }
 ```
 
@@ -677,6 +688,9 @@ try {
   const result = await agent.complexAnalysis(params, handler);
 } catch (error) {
   if (error instanceof TaskTimeoutError) {
+    // Reuse error.idempotency_key when reconciling the seller mutation.
+    // If governanceRecovery is present, pass its outcomeIdempotencyKey to
+    // reportGovernanceOutcome after recovering the seller result.
     console.log('Task timed out - consider using submitted pattern');
   }
 }
@@ -795,7 +809,7 @@ interface ConversationConfig {
   maxHistorySize?: number;
   /** Whether to persist conversations */
   persistConversations?: boolean;
-  /** Timeout for 'working' status (max 120s per PR #78) */
+  /** Resettable idle/progress timeout for protocol work in 'working' status */
   workingTimeout?: number;
   /** Default max clarifications */
   defaultMaxClarifications?: number;

--- a/src/lib/auth/oauth/ClientCredentialsFlow.ts
+++ b/src/lib/auth/oauth/ClientCredentialsFlow.ts
@@ -34,6 +34,7 @@ import type { OAuthConfigStorage } from './types';
 import { resolveSecret } from './secret-resolver';
 import { isLikelyPrivateUrl } from '../../net';
 import { wrapFetchWithSizeLimit } from '../../protocols/responseSizeLimit';
+import { createAbortError, throwIfAborted, withAbortSignal } from '../../protocols/abort';
 
 /** Max length we'll echo from an AS-supplied error description into errors. */
 const MAX_AS_ERROR_LENGTH = 200;
@@ -88,6 +89,8 @@ export interface ExchangeClientCredentialsOptions {
    * user-supplied configs should leave this off.
    */
   allowPrivateIp?: boolean;
+  /** Caller-owned cancellation signal, composed with `timeoutMs`. */
+  signal?: AbortSignal;
 }
 
 /**
@@ -193,6 +196,8 @@ export async function exchangeClientCredentials(
   credentials: AgentOAuthClientCredentials,
   options: ExchangeClientCredentialsOptions = {}
 ): Promise<AgentOAuthTokens> {
+  throwIfAborted(options.signal);
+
   // Wrap with the response-size-limit guard so a hostile token endpoint
   // can't buffer-bomb on every refresh. Pass-through when no
   // `withResponseSizeLimit` slot is active. (#1175)
@@ -240,19 +245,30 @@ export async function exchangeClientCredentials(
     body.set('client_secret', clientSecret);
   }
 
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
-
   let response: Response;
+  let bodyText: string;
+  const timeoutError = new Error(`Client credentials exchange timed out after ${timeoutMs}ms`);
+  timeoutError.name = 'TimeoutError';
   try {
-    response = await fetchImpl(credentials.token_endpoint, {
-      method: 'POST',
-      headers,
-      body: body.toString(),
-      signal: controller.signal,
-    });
+    ({ response, bodyText } = await withAbortSignal(
+      [options.signal],
+      timeoutMs,
+      async signal => {
+        const tokenResponse = await fetchImpl(credentials.token_endpoint, {
+          method: 'POST',
+          headers,
+          body: body.toString(),
+          signal,
+        });
+        return { response: tokenResponse, bodyText: await tokenResponse.text() };
+      },
+      { timeoutError }
+    ));
   } catch (err) {
-    if ((err as { name?: string }).name === 'AbortError') {
+    if (options.signal?.aborted) {
+      throw createAbortError(options.signal.reason);
+    }
+    if (err === timeoutError) {
       throw new ClientCredentialsExchangeError(
         `Token endpoint ${credentials.token_endpoint} did not respond within ${timeoutMs}ms.`,
         'network'
@@ -262,11 +278,8 @@ export async function exchangeClientCredentials(
       `Failed to reach token endpoint ${credentials.token_endpoint}: ${(err as Error).message}`,
       'network'
     );
-  } finally {
-    clearTimeout(timeout);
   }
 
-  const bodyText = await response.text();
   let parsed: Record<string, unknown> | undefined;
   try {
     parsed = bodyText ? (JSON.parse(bodyText) as Record<string, unknown>) : undefined;
@@ -326,15 +339,11 @@ export interface EnsureClientCredentialsOptions extends ExchangeClientCredential
 }
 
 /**
- * In-flight refresh coalescing map. Keyed by the tuple
- * `(agent.id, token_endpoint, client_id)` — concurrent
- * `ensureClientCredentialsTokens` calls for the same credentials share a
- * single token POST instead of each racing to exchange the same secret.
- *
- * Two different `AgentConfig` objects that accidentally reuse the same
- * `id` (e.g. two tenants both creating `cli-agent`) but hold different
- * credentials won't cross-contaminate — the endpoint + client_id in the
- * key keeps them distinct.
+ * In-flight refresh coalescing map. Scoped by `AgentConfig` object identity
+ * so only callers deliberately sharing one configuration can share a bearer.
+ * A string key built from public OAuth fields is insufficient here: two
+ * tenants can reuse an agent id, endpoint, and client id while differing in
+ * secret, scope, audience, or resource.
  *
  * Cleared on completion regardless of success/failure.
  *
@@ -344,17 +353,35 @@ export interface EnsureClientCredentialsOptions extends ExchangeClientCredential
  * For the CLI this is fine; for high-throughput server deployments,
  * coalesce upstream at the storage layer.
  */
-const inFlightRefresh = new Map<string, Promise<AgentOAuthTokens>>();
+interface InFlightRefresh {
+  promise: Promise<AgentOAuthTokens>;
+  controller: AbortController;
+  waiters: number;
+  settled: boolean;
+}
 
-/**
- * Compute the coalesce key for `ensureClientCredentialsTokens`. `force: true`
- * uses a distinct bucket so a 401-triggered forced refresh never piggybacks
- * on a still-pending non-forced exchange — the whole point of forcing is
- * that the in-flight token is *known* stale, so awaiting it would defeat
- * the retry.
- */
-function coalesceKeyFor(agent: AgentConfig, credentials: AgentOAuthClientCredentials, force: boolean): string {
-  return `${force ? 'force' : 'normal'}\u0000${agent.id}\u0000${credentials.token_endpoint}\u0000${credentials.client_id}`;
+type RefreshMode = 'normal' | 'force';
+
+const inFlightRefresh = new WeakMap<AgentConfig, Map<RefreshMode, InFlightRefresh>>();
+
+async function waitForRefresh(entry: InFlightRefresh, signal?: AbortSignal): Promise<AgentOAuthTokens> {
+  if (signal?.aborted) throw createAbortError(signal.reason);
+  entry.waiters += 1;
+  let abortListener: (() => void) | undefined;
+  try {
+    if (!signal) return await entry.promise;
+    const aborted = new Promise<never>((_resolve, reject) => {
+      abortListener = () => reject(createAbortError(signal.reason));
+      signal.addEventListener('abort', abortListener, { once: true });
+    });
+    return await Promise.race([entry.promise, aborted]);
+  } finally {
+    if (abortListener && signal) signal.removeEventListener('abort', abortListener);
+    entry.waiters -= 1;
+    if (entry.waiters === 0 && !entry.settled && !entry.controller.signal.aborted) {
+      entry.controller.abort(createAbortError(signal?.reason ?? 'No callers remain for token refresh'));
+    }
+  }
 }
 
 /**
@@ -380,6 +407,8 @@ export async function ensureClientCredentialsTokens(
   agent: AgentConfig,
   options: EnsureClientCredentialsOptions = {}
 ): Promise<AgentOAuthTokens> {
+  throwIfAborted(options.signal);
+
   if (!agent.oauth_client_credentials) {
     throw new Error(
       `ensureClientCredentialsTokens called for agent '${agent.id}' with no oauth_client_credentials configured.`
@@ -397,20 +426,33 @@ export async function ensureClientCredentialsTokens(
     return cached!;
   }
 
-  const coalesceKey = coalesceKeyFor(agent, agent.oauth_client_credentials, options.force === true);
-  const existing = inFlightRefresh.get(coalesceKey);
-  if (existing) {
-    const tokens = await existing;
+  const refreshMode: RefreshMode = options.force ? 'force' : 'normal';
+  let agentRefreshes = inFlightRefresh.get(agent);
+  const existing = agentRefreshes?.get(refreshMode);
+  if (existing && !existing.controller.signal.aborted) {
+    const tokens = await waitForRefresh(existing, options.signal);
     agent.oauth_tokens = tokens;
     return tokens;
   }
 
-  const exchange = (async () => {
+  const controller = new AbortController();
+  const entry: InFlightRefresh = {
+    promise: undefined as unknown as Promise<AgentOAuthTokens>,
+    controller,
+    waiters: 0,
+    settled: false,
+  };
+  if (!agentRefreshes) {
+    agentRefreshes = new Map();
+    inFlightRefresh.set(agent, agentRefreshes);
+  }
+  entry.promise = (async () => {
     try {
       const tokens = await exchangeClientCredentials(agent.oauth_client_credentials!, {
         fetch: options.fetch,
         timeoutMs: options.timeoutMs,
         allowPrivateIp: options.allowPrivateIp,
+        signal: controller.signal,
       });
       agent.oauth_tokens = tokens;
       if (options.storage) {
@@ -418,10 +460,14 @@ export async function ensureClientCredentialsTokens(
       }
       return tokens;
     } finally {
-      inFlightRefresh.delete(coalesceKey);
+      entry.settled = true;
+      if (agentRefreshes?.get(refreshMode) === entry) {
+        agentRefreshes.delete(refreshMode);
+        if (agentRefreshes.size === 0) inFlightRefresh.delete(agent);
+      }
     }
   })();
 
-  inFlightRefresh.set(coalesceKey, exchange);
-  return exchange;
+  agentRefreshes.set(refreshMode, entry);
+  return waitForRefresh(entry, options.signal);
 }

--- a/src/lib/auth/oauth/authorization-required.ts
+++ b/src/lib/auth/oauth/authorization-required.ts
@@ -12,6 +12,7 @@
  */
 import { ssrfSafeFetch, decodeBodyAsJsonOrText } from '../../net';
 import { AuthenticationRequiredError, type OAuthMetadataInfo } from '../../errors';
+import { throwIfAborted } from '../../protocols/abort';
 import { parseWWWAuthenticate, type WWWAuthenticateChallenge } from './diagnostics';
 
 /**
@@ -199,6 +200,8 @@ export interface DiscoverAuthorizationOptions {
   timeoutMs?: number;
   /** Scoped fetch implementation for the agent, PRM, and AS metadata probes. */
   fetchFn?: typeof fetch;
+  /** Caller cancellation, including the absolute task deadline. */
+  signal?: AbortSignal;
   /**
    * If provided, use this `WWW-Authenticate` header verbatim instead of
    * re-probing the agent. Use this when you already have a 401 response in
@@ -241,7 +244,13 @@ export async function discoverAuthorizationRequirements(
 
   let challengeHeader = options.wwwAuthenticate;
   if (!challengeHeader) {
-    const probe = await probeAgent401(agentUrl, allowPrivateIpOnAgent, options.timeoutMs, options.fetchFn);
+    const probe = await probeAgent401(
+      agentUrl,
+      allowPrivateIpOnAgent,
+      options.timeoutMs,
+      options.fetchFn,
+      options.signal
+    );
     if (probe.status !== 401) {
       // 200, 403, 5xx, or network error — not an OAuth 401 we can act on.
       return null;
@@ -269,7 +278,8 @@ export async function discoverAuthorizationRequirements(
       challenge.resource_metadata,
       allowPrivateIpForHop(challenge.resource_metadata),
       options.timeoutMs,
-      options.fetchFn
+      options.fetchFn,
+      options.signal
     );
     if (prm && typeof prm === 'object') {
       const resource = (prm as { resource?: unknown }).resource;
@@ -296,7 +306,13 @@ export async function discoverAuthorizationRequirements(
     let md: Record<string, unknown> | undefined;
     let source: 'rfc-8414' | 'openid-configuration' | undefined;
     if (asUrl) {
-      const res = await fetchJson(asUrl, allowPrivateIpForHop(asUrl), options.timeoutMs, options.fetchFn);
+      const res = await fetchJson(
+        asUrl,
+        allowPrivateIpForHop(asUrl),
+        options.timeoutMs,
+        options.fetchFn,
+        options.signal
+      );
       if (res && typeof res === 'object') {
         md = res as Record<string, unknown>;
         source = 'rfc-8414';
@@ -305,7 +321,13 @@ export async function discoverAuthorizationRequirements(
     if (!md) {
       const oidcUrl = buildOidcDiscoveryUrl(requirements.authorizationServer);
       if (oidcUrl) {
-        const res = await fetchJson(oidcUrl, allowPrivateIpForHop(oidcUrl), options.timeoutMs, options.fetchFn);
+        const res = await fetchJson(
+          oidcUrl,
+          allowPrivateIpForHop(oidcUrl),
+          options.timeoutMs,
+          options.fetchFn,
+          options.signal
+        );
         if (res && typeof res === 'object') {
           md = res as Record<string, unknown>;
           source = 'openid-configuration';
@@ -358,9 +380,15 @@ export async function discoverAuthorizationRequirements(
  */
 export async function probeAuthChallenge(
   agentUrl: string,
-  options: { allowPrivateIp?: boolean; timeoutMs?: number; fetchFn?: typeof fetch } = {}
+  options: { allowPrivateIp?: boolean; timeoutMs?: number; fetchFn?: typeof fetch; signal?: AbortSignal } = {}
 ): Promise<WWWAuthenticateChallenge | null> {
-  const probe = await probeAgent401(agentUrl, options.allowPrivateIp ?? false, options.timeoutMs, options.fetchFn);
+  const probe = await probeAgent401(
+    agentUrl,
+    options.allowPrivateIp ?? false,
+    options.timeoutMs,
+    options.fetchFn,
+    options.signal
+  );
   if (probe.status !== 401) return null;
   return parseWWWAuthenticate(probe.wwwAuthenticate ?? null);
 }
@@ -374,7 +402,8 @@ async function probeAgent401(
   agentUrl: string,
   allowPrivateIp: boolean,
   timeoutMs?: number,
-  fetchFn?: typeof fetch
+  fetchFn?: typeof fetch,
+  signal?: AbortSignal
 ): Promise<{ status: number; wwwAuthenticate?: string }> {
   const body = JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' });
   try {
@@ -386,11 +415,13 @@ async function probeAgent401(
       },
       body,
       allowPrivateIp,
+      signal,
       ...(timeoutMs !== undefined ? { timeoutMs } : {}),
       ...(fetchFn ? { trustedFetchFn: fetchFn } : {}),
     });
     return { status: res.status, wwwAuthenticate: res.headers['www-authenticate'] };
   } catch {
+    throwIfAborted(signal);
     return { status: 0 };
   }
 }
@@ -454,19 +485,22 @@ async function fetchJson(
   url: string,
   allowPrivateIp: boolean,
   timeoutMs?: number,
-  fetchFn?: typeof fetch
+  fetchFn?: typeof fetch,
+  signal?: AbortSignal
 ): Promise<unknown> {
   try {
     const res = await ssrfSafeFetch(url, {
       method: 'GET',
       headers: { accept: 'application/json' },
       allowPrivateIp,
+      signal,
       ...(timeoutMs !== undefined ? { timeoutMs } : {}),
       ...(fetchFn ? { trustedFetchFn: fetchFn } : {}),
     });
     if (res.status !== 200) return undefined;
     return decodeBodyAsJsonOrText(res.body, res.headers['content-type']);
   } catch {
+    throwIfAborted(signal);
     return undefined;
   }
 }

--- a/src/lib/auth/oauth/discovery.ts
+++ b/src/lib/auth/oauth/discovery.ts
@@ -6,6 +6,7 @@
  */
 
 import { wrapFetchWithSizeLimit } from '../../protocols/responseSizeLimit';
+import { throwIfAborted } from '../../protocols/abort';
 
 /**
  * OAuth Authorization Server Metadata
@@ -40,6 +41,8 @@ export interface DiscoveryOptions {
   timeout?: number;
   /** Custom fetch function (for testing or custom HTTP handling) */
   fetch?: typeof fetch;
+  /** Caller cancellation, including the absolute task deadline. */
+  signal?: AbortSignal;
 }
 
 /**
@@ -70,6 +73,7 @@ export async function discoverOAuthMetadata(
   // `withResponseSizeLimit` slot is active. (#1175)
   const { timeout = 5000, fetch: providedFetch = fetch } = options;
   const customFetch = wrapFetchWithSizeLimit(providedFetch);
+  throwIfAborted(options.signal);
 
   try {
     const baseUrl = new URL(agentUrl);
@@ -87,13 +91,13 @@ export async function discoverOAuthMetadata(
     const urlsToTry = pathAwareUrl ? [pathAwareUrl, rootUrl] : [rootUrl];
 
     for (const metadataUrl of urlsToTry) {
-      const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), timeout);
+      const timeoutSignal = AbortSignal.timeout(timeout);
+      const signal = options.signal ? AbortSignal.any([options.signal, timeoutSignal]) : timeoutSignal;
 
       try {
         const response = await customFetch(metadataUrl.toString(), {
           headers: { Accept: 'application/json' },
-          signal: controller.signal,
+          signal,
         });
 
         if (!response.ok) {
@@ -109,15 +113,15 @@ export async function discoverOAuthMetadata(
 
         return metadata;
       } catch {
+        throwIfAborted(options.signal);
         // Parse error, timeout, or network error on this URL -- try next
         continue;
-      } finally {
-        clearTimeout(timeoutId);
       }
     }
 
     return null;
   } catch {
+    throwIfAborted(options.signal);
     // Network error, timeout, or invalid URL - agent doesn't support OAuth
     return null;
   }

--- a/src/lib/core/ConversationTypes.ts
+++ b/src/lib/core/ConversationTypes.ts
@@ -144,7 +144,11 @@ export type WebhookUrlTemplate =
  * Options for task execution
  */
 export interface TaskOptions {
-  /** Timeout for entire task (ms) */
+  /**
+   * Absolute wall-clock deadline for the entire SDK task call (ms), including
+   * discovery and capability/version preflight. Unlike `workingTimeout`, this
+   * deadline never resets on progress and aborts in-flight protocol work.
+   */
   timeout?: number;
   /**
    * Caller-owned cancellation signal for the read path and in-flight protocol
@@ -585,7 +589,7 @@ export interface ConversationConfig {
   maxHistorySize?: number;
   /** Whether to persist conversations */
   persistConversations?: boolean;
-  /** Timeout for 'working' status (max 120s per PR #78) */
+  /** Resettable idle/progress timeout for protocol work in 'working' status. */
   workingTimeout?: number;
   /** Default max clarifications */
   defaultMaxClarifications?: number;

--- a/src/lib/core/GovernanceMiddleware.ts
+++ b/src/lib/core/GovernanceMiddleware.ts
@@ -33,6 +33,7 @@ import type {
 import { toolRequiresGovernance, parseCheckResponse } from './GovernanceTypes';
 import { unwrapProtocolResponse } from '../utils/response-unwrapper';
 import { generateIdempotencyKey } from '../utils/idempotency';
+import { createAbortError } from '../protocols/abort';
 
 /**
  * Typed debug log entries for governance operations.
@@ -138,7 +139,7 @@ export class GovernanceMiddleware {
    * Get or mint the idempotency key for a `(checkId, outcome)` tuple.
    * Uses the Map's insertion-order semantics for LRU eviction.
    */
-  private getOrMintOutcomeKey(checkId: string, outcome: OutcomeType): string {
+  getOutcomeIdempotencyKey(checkId: string, outcome: OutcomeType): string {
     const tupleKey = `${checkId}\u001f${outcome}`;
     const cached = this.outcomeKeys.get(tupleKey);
     if (cached !== undefined) {
@@ -184,7 +185,8 @@ export class GovernanceMiddleware {
   async checkProposed(
     tool: string,
     params: Record<string, unknown>,
-    debugLogs: GovernanceDebugEntry[] = []
+    debugLogs: GovernanceDebugEntry[] = [],
+    signal?: AbortSignal
   ): Promise<{ result: GovernanceCheckResult; params: Record<string, unknown> }> {
     const config = this.governanceConfig.campaign;
     if (!config) {
@@ -217,6 +219,7 @@ export class GovernanceMiddleware {
         debugLogs,
         adcpVersion: this.adcpVersion,
         ...(this.versionEnvelope !== undefined && { versionEnvelope: this.versionEnvelope }),
+        signal,
         onTransportActivity: this.onTransportActivity,
       });
 
@@ -303,7 +306,9 @@ export class GovernanceMiddleware {
     sellerResponse?: Record<string, unknown>,
     error?: { code?: string; message: string },
     debugLogs: GovernanceDebugEntry[] = [],
-    governanceContext?: string
+    governanceContext?: string,
+    signal?: AbortSignal,
+    outcomeIdempotencyKey?: string
   ): Promise<GovernanceOutcome | undefined> {
     const config = this.governanceConfig.campaign;
     if (!config) return undefined;
@@ -313,7 +318,7 @@ export class GovernanceMiddleware {
     // Reuse the same idempotency_key for retries of the same
     // (checkId, outcome) intent so the governance agent treats them as
     // one logical outcome report rather than distinct submissions.
-    const idempotencyKey = this.getOrMintOutcomeKey(checkId, outcome);
+    const idempotencyKey = outcomeIdempotencyKey || this.getOutcomeIdempotencyKey(checkId, outcome);
 
     const request: ReportPlanOutcomeRequest = {
       idempotency_key: idempotencyKey,
@@ -340,6 +345,7 @@ export class GovernanceMiddleware {
           debugLogs,
           adcpVersion: this.adcpVersion,
           ...(this.versionEnvelope !== undefined && { versionEnvelope: this.versionEnvelope }),
+          signal,
           onTransportActivity: this.onTransportActivity,
           transportActivityContext: {
             operationId: checkId,
@@ -375,6 +381,7 @@ export class GovernanceMiddleware {
             : undefined,
       };
     } catch (err) {
+      if (signal?.aborted) throw createAbortError(signal.reason);
       // Outcome reporting failure shouldn't fail the task
       debugLogs.push({
         type: 'governance_outcome_error',

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -96,6 +96,7 @@ const A2AClient: any = A2AClientImpl;
 
 import { TaskExecutor, DeferredTaskError } from './TaskExecutor';
 import { attachMatch } from './match';
+import { withTaskDeadline } from './task-deadline';
 import { createMCPAuthHeaders } from '../auth';
 import { isAbortOrTimeoutError } from '../protocols/abort';
 import {
@@ -1762,6 +1763,7 @@ export class SingleAgentClient {
         storage: getAgentStorage(this.normalizedAgent),
         allowPrivateIp: isLikelyPrivateUrl(this.normalizedAgent.agent_uri),
         fetch: transport?.fetchFn,
+        signal: options?.signal,
       });
     }
 
@@ -1823,6 +1825,7 @@ export class SingleAgentClient {
         storage: getAgentStorage(this.normalizedAgent),
         allowPrivateIp: isLikelyPrivateUrl(this.normalizedAgent.agent_uri),
         fetch: transport?.fetchFn,
+        signal: options?.signal,
       });
     }
 
@@ -1921,6 +1924,7 @@ export class SingleAgentClient {
         const requirements = await discoverAuthorizationRequirements(agentUri, {
           allowPrivateIp: isLikelyPrivateUrl(agentUri),
           fetchFn: transport?.fetchFn,
+          signal: readOptions?.signal,
         });
         if (requirements) {
           throw new NeedsAuthorizationError(requirements);
@@ -1933,8 +1937,12 @@ export class SingleAgentClient {
         const challenge = await probeAuthChallenge(agentUri, {
           allowPrivateIp: isLikelyPrivateUrl(agentUri),
           fetchFn: transport?.fetchFn,
+          signal: readOptions?.signal,
         });
-        const oauthMetadata = await discoverOAuthMetadata(agentUri, { fetch: transport?.fetchFn });
+        const oauthMetadata = await discoverOAuthMetadata(agentUri, {
+          fetch: transport?.fetchFn,
+          signal: readOptions?.signal,
+        });
         throw new AuthenticationRequiredError(agentUri, oauthMetadata || undefined, undefined, challenge ?? undefined);
       }
 
@@ -2109,6 +2117,7 @@ export class SingleAgentClient {
       const requirements = await discoverAuthorizationRequirements(providedUri, {
         allowPrivateIp: isLikelyPrivateUrl(providedUri),
         fetchFn: options?.transport?.fetchFn ?? this.config.transport?.fetchFn,
+        signal: options?.signal,
       });
       if (requirements) {
         throw new NeedsAuthorizationError(requirements);
@@ -2120,9 +2129,11 @@ export class SingleAgentClient {
       const challenge = await probeAuthChallenge(providedUri, {
         allowPrivateIp: isLikelyPrivateUrl(providedUri),
         fetchFn: options?.transport?.fetchFn ?? this.config.transport?.fetchFn,
+        signal: options?.signal,
       });
       const oauthMetadata = await discoverOAuthMetadata(providedUri, {
         fetch: options?.transport?.fetchFn ?? this.config.transport?.fetchFn,
+        signal: options?.signal,
       });
       throw new AuthenticationRequiredError(providedUri, oauthMetadata || undefined, undefined, challenge ?? undefined);
     }
@@ -2882,6 +2893,30 @@ export class SingleAgentClient {
     legacyFormatConverter?: LegacyFormatConverter,
     canonicalRequest?: unknown
   ): Promise<TaskResult<T>> {
+    return withTaskDeadline(options, effectiveOptions =>
+      this.executeAndHandleWithinDeadline(
+        taskType,
+        handlerName,
+        params,
+        inputHandler,
+        effectiveOptions,
+        transformCompletedResponse,
+        legacyFormatConverter,
+        canonicalRequest
+      )
+    );
+  }
+
+  private async executeAndHandleWithinDeadline<T>(
+    taskType: string,
+    handlerName: keyof AsyncHandlerConfig,
+    params: any,
+    inputHandler?: InputHandler,
+    options?: TaskOptions,
+    transformCompletedResponse?: (data: T) => T,
+    legacyFormatConverter?: LegacyFormatConverter,
+    canonicalRequest?: unknown
+  ): Promise<TaskResult<T>> {
     throwIfAborted(options?.signal);
     // Normalize params for backwards compatibility before validation
     let normalizedParams = normalizeRequestParams(taskType, params, {
@@ -2927,19 +2962,23 @@ export class SingleAgentClient {
 
     // Validate required features before sending request
     await this.validateTaskFeatures(taskType, options);
+    throwIfAborted(options?.signal);
 
     // Guard mutating calls against pre-v3 sellers when opted in.
     if (this.config.requireV3ForMutations && isMutatingTask(taskType)) {
       await this.requireSupportedMajor(taskType, options);
+      throwIfAborted(options?.signal);
     }
 
     // Check for v3 features used against v2 servers - return empty result if unsupported
     const earlyResult = await this.getEarlyResultForUnsupportedFeatures<T>(taskType, normalizedParams, options);
+    throwIfAborted(options?.signal);
     if (earlyResult) {
       return attachMatch(earlyResult);
     }
 
     const agent = await this.ensureEndpointDiscovered(options);
+    throwIfAborted(options?.signal);
 
     // Schema-driven pre-send validation runs on the unadapted v3 shape so
     // wire-format adapters (e.g. adaptGetProductsRequestForV2) don't strip
@@ -2957,6 +2996,7 @@ export class SingleAgentClient {
       [CAPABILITY_DISCOVERY_CONTEXT]: capabilityDiscoveryContext,
     };
     const serverVersion = await this.detectServerVersion(detectionOptions);
+    throwIfAborted(options?.signal);
     const inputSchemaStripLogs: any[] = [];
     const { params: adaptedParams, driftLogs: adaptDriftLogs } = this.adaptRequest(
       taskType,
@@ -2991,6 +3031,7 @@ export class SingleAgentClient {
           serverVersion
         )
     );
+    throwIfAborted(effectiveOptions?.signal);
 
     // Merge collected drift into the executor's debug_logs so adopters
     // reading result.debug_logs see input-schema stripping, post-adapter
@@ -3014,6 +3055,7 @@ export class SingleAgentClient {
     }
     this.rememberLegacyFormatConverter(taskType, legacyFormatConverter, result, options);
     result = await this.applyProductPropertyPolicy(result, taskType, normalizedParams);
+    throwIfAborted(effectiveOptions?.signal);
 
     if (CANONICAL_CREATIVE_ACTIVITY_TASKS.has(taskType)) {
       // The full canonical request is needed only while the protocol activity
@@ -3039,6 +3081,7 @@ export class SingleAgentClient {
         | ((data: unknown, metadata: Record<string, unknown>) => Promise<void>)
         | undefined;
       if (handler) {
+        throwIfAborted(effectiveOptions?.signal);
         const metadata = {
           operation_id: options?.contextId || 'sync',
           context_id: options?.contextId,
@@ -3049,6 +3092,7 @@ export class SingleAgentClient {
           timestamp: new Date().toISOString(),
         };
         await handler(result.data, metadata);
+        throwIfAborted(effectiveOptions?.signal);
       }
     }
 
@@ -4252,6 +4296,16 @@ export class SingleAgentClient {
     inputHandler?: InputHandler,
     options?: CreativeDeliveryTaskOptions
   ): Promise<TaskResult<CanonicalCreativeResponse<CreateMediaBuyResponse>>> {
+    return withTaskDeadline(options, effectiveOptions =>
+      this.createMediaBuyWithinDeadline(params, inputHandler, effectiveOptions)
+    );
+  }
+
+  private async createMediaBuyWithinDeadline(
+    params: MutatingRequestInput<CanonicalCreateMediaBuyRequest>,
+    inputHandler: InputHandler | undefined,
+    options: CreativeDeliveryTaskOptions
+  ): Promise<TaskResult<CanonicalCreativeResponse<CreateMediaBuyResponse>>> {
     const { legacyFormatConverter, projectionCatalogs, canonicalFormatLegacyResolver, ...taskOptions } = options ?? {};
     const effectiveLegacyFormatConverter = this.resolveLegacyFormatConverter(
       legacyFormatConverter,
@@ -4386,6 +4440,16 @@ export class SingleAgentClient {
     inputHandler?: InputHandler,
     options?: CreativeDeliveryTaskOptions
   ): Promise<TaskResult<CanonicalCreativeResponse<UpdateMediaBuyResponse>>> {
+    return withTaskDeadline(options, effectiveOptions =>
+      this.updateMediaBuyWithinDeadline(params, inputHandler, effectiveOptions)
+    );
+  }
+
+  private async updateMediaBuyWithinDeadline(
+    params: MutatingRequestInput<CanonicalUpdateMediaBuyRequest>,
+    inputHandler: InputHandler | undefined,
+    options: CreativeDeliveryTaskOptions
+  ): Promise<TaskResult<CanonicalCreativeResponse<UpdateMediaBuyResponse>>> {
     const { legacyFormatConverter, projectionCatalogs, canonicalFormatLegacyResolver, ...taskOptions } = options ?? {};
     const effectiveLegacyFormatConverter = this.resolveLegacyFormatConverter(
       legacyFormatConverter,
@@ -4449,6 +4513,16 @@ export class SingleAgentClient {
     params: MutatingRequestInput<CanonicalSyncCreativesRequest>,
     inputHandler?: InputHandler,
     options?: SyncCreativesTaskOptions
+  ): Promise<TaskResult<CanonicalCreativeResponse<SyncCreativesResponse>>> {
+    return withTaskDeadline(options, effectiveOptions =>
+      this.syncCreativesWithinDeadline(params, inputHandler, effectiveOptions)
+    );
+  }
+
+  private async syncCreativesWithinDeadline(
+    params: MutatingRequestInput<CanonicalSyncCreativesRequest>,
+    inputHandler: InputHandler | undefined,
+    options: SyncCreativesTaskOptions
   ): Promise<TaskResult<CanonicalCreativeResponse<SyncCreativesResponse>>> {
     const {
       creativeFormatProjection,
@@ -4817,20 +4891,32 @@ export class SingleAgentClient {
    *
    * Use this when a task returned status 'submitted' or 'working' and
    * later resolves via polling or webhooks. The checkId is available
-   * on the original TaskResult at result.governance.checkId.
+   * on the original TaskResult at result.governance.checkId. After a
+   * TaskTimeoutError during governance postflight, pass the error's
+   * governanceRecovery.outcomeIdempotencyKey in `options` to safely retry.
    */
   async reportGovernanceOutcome(
     checkId: string,
     outcome: OutcomeType,
     governanceContext?: string,
     sellerResponse?: Record<string, unknown>,
-    error?: { code?: string; message: string }
+    error?: { code?: string; message: string },
+    options?: { outcomeIdempotencyKey?: string; signal?: AbortSignal }
   ): Promise<import('./GovernanceTypes').GovernanceOutcome | undefined> {
     const middleware = this.executor.getGovernanceMiddleware();
     if (!middleware) {
       throw new Error('No governance middleware configured. Set config.governance.campaign to enable governance.');
     }
-    return middleware.reportOutcome(checkId, outcome, sellerResponse, error, [], governanceContext);
+    return middleware.reportOutcome(
+      checkId,
+      outcome,
+      sellerResponse,
+      error,
+      [],
+      governanceContext,
+      options?.signal,
+      options?.outcomeIdempotencyKey
+    );
   }
 
   private getGovernanceAgent(): AgentConfig {
@@ -4856,6 +4942,16 @@ export class SingleAgentClient {
     params: GetAdCPCapabilitiesRequest,
     inputHandler?: InputHandler,
     options?: TaskOptions
+  ): Promise<TaskResult<GetAdCPCapabilitiesResponse>> {
+    return withTaskDeadline(options, effectiveOptions =>
+      this.getAdcpCapabilitiesWithinDeadline(params, inputHandler, effectiveOptions)
+    );
+  }
+
+  private async getAdcpCapabilitiesWithinDeadline(
+    params: GetAdCPCapabilitiesRequest,
+    inputHandler: InputHandler | undefined,
+    options: TaskOptions
   ): Promise<TaskResult<GetAdCPCapabilitiesResponse>> {
     const agent = await this.ensureEndpointDiscovered(options);
     this.executor.validateRequest('get_adcp_capabilities', params);
@@ -5266,6 +5362,17 @@ export class SingleAgentClient {
   }
 
   private async executeTaskUnprojected<T = any>(
+    taskName: string,
+    params: any,
+    inputHandler?: InputHandler,
+    options?: TaskOptions
+  ): Promise<TaskResult<T>> {
+    return withTaskDeadline(options, effectiveOptions =>
+      this.executeTaskUnprojectedWithinDeadline<T>(taskName, params, inputHandler, effectiveOptions)
+    );
+  }
+
+  private async executeTaskUnprojectedWithinDeadline<T = any>(
     taskName: string,
     params: any,
     inputHandler?: InputHandler,
@@ -5900,6 +6007,7 @@ export class SingleAgentClient {
         storage: getAgentStorage(this.normalizedAgent),
         allowPrivateIp: isLikelyPrivateUrl(this.normalizedAgent.agent_uri),
         fetch: transport?.fetchFn,
+        signal: options?.signal,
       });
       return this.normalizedAgent.oauth_tokens?.access_token;
     };

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -24,7 +24,7 @@ import { normalizeGetProductsResponse } from '../utils/pricing-adapter';
 import { normalizeLegacyMediaBuyStatusForReturn } from '../utils/envelope-status-compat';
 import { getLatestA2ADataPartFromResponse } from '../utils/a2a-artifacts';
 import { cancelA2ATask } from '../protocols/a2a';
-import { isAbortOrTimeoutError } from '../protocols/abort';
+import { isAbortOrTimeoutError, throwIfAborted } from '../protocols/abort';
 import type {
   Message,
   InputRequest,
@@ -47,16 +47,20 @@ import { GovernanceMiddleware } from './GovernanceMiddleware';
 import type { GovernanceConfig, GovernanceCheckResult } from './GovernanceTypes';
 import { attachMatch } from './match';
 import { resolveWebhookUrl } from './webhook-url';
+import {
+  attachTaskDeadlineGovernanceRecovery,
+  attachTaskDeadlineIdempotencyKey,
+  getTaskOperationId,
+  withTaskDeadline,
+} from './task-deadline';
+
+// Keep the direct `core/TaskExecutor` export identical to the package-level
+// typed timeout error thrown by the deadline wrapper.
+export { TaskTimeoutError } from '../errors';
+
 /**
  * Custom errors for task execution
  */
-export class TaskTimeoutError extends Error {
-  constructor(taskId: string, timeout: number) {
-    super(`Task ${taskId} timed out after ${timeout}ms`);
-    this.name = 'TaskTimeoutError';
-  }
-}
-
 export class MaxClarificationError extends Error {
   constructor(taskId: string, maxAttempts: number) {
     super(`Task ${taskId} exceeded maximum clarification attempts: ${maxAttempts}`);
@@ -277,6 +281,14 @@ interface TaskStatusPollResult {
 }
 
 const COMPACTED_TASK_STATE_LIMIT = 10_000;
+const TERMINAL_TASK_STATUSES = new Set<TaskStatus>([
+  'completed',
+  'failed',
+  'rejected',
+  'canceled',
+  'governance-denied',
+  'aborted',
+]);
 
 /**
  * Core task execution engine that handles the conversation loop with agents
@@ -507,6 +519,19 @@ export class TaskExecutor {
     options: TaskOptions = {},
     serverVersion?: 'v2' | 'v3'
   ): Promise<TaskResult<T>> {
+    return withTaskDeadline(options, effectiveOptions =>
+      this.executeTaskWithinDeadline<T>(agent, taskName, params, inputHandler, effectiveOptions, serverVersion)
+    );
+  }
+
+  private async executeTaskWithinDeadline<T = any>(
+    agent: AgentConfig,
+    taskName: string,
+    params: any,
+    inputHandler?: InputHandler,
+    options: TaskOptions = {},
+    serverVersion?: 'v2' | 'v3'
+  ): Promise<TaskResult<T>> {
     if (serverVersion) this.lastKnownServerVersion = serverVersion;
     // The client-minted `taskId` is a local correlation id for tracking this
     // call's lifecycle (activeTasks map, metadata, webhook URL macros). It is
@@ -514,7 +539,7 @@ export class TaskExecutor {
     // flows in on the response and is surfaced via metadata.serverTaskId.
     // `options.contextId` / `options.taskId` ride on the A2A message envelope
     // and are threaded straight to the protocol adapter below.
-    const taskId = randomUUID();
+    const taskId = getTaskOperationId(options) ?? randomUUID();
     const startTime = Date.now();
     const workingTimeout = this.config.workingTimeout || 120000; // 120s max per PR #78
 
@@ -524,6 +549,7 @@ export class TaskExecutor {
     // `options.skipIdempotencyAutoInject` disables this for compliance testing
     // that needs to exercise server-side missing-key behavior.
     const idempotencyKey = options.skipIdempotencyAutoInject ? undefined : resolveIdempotencyKey(taskName, params);
+    if (idempotencyKey) attachTaskDeadlineIdempotencyKey(options, idempotencyKey);
     if (idempotencyKey && params && typeof params === 'object' && !params.idempotency_key) {
       params = { ...params, idempotency_key: idempotencyKey };
     }
@@ -543,6 +569,26 @@ export class TaskExecutor {
       idempotencyKey,
     };
     this.activeTasks.set(taskId, taskState);
+
+    // Compact task state as soon as cancellation fires, even if a protocol
+    // adapter or caller callback never settles after receiving the signal.
+    // The outer deadline race guarantees prompt rejection; this listener is
+    // the matching resource-retention boundary for activeTasks.
+    const taskAbortListener = options.signal
+      ? () => {
+          const currentStatus = this.activeTasks.get(taskId)?.status;
+          if (currentStatus && !TERMINAL_TASK_STATUSES.has(currentStatus)) {
+            const reason = options.signal?.reason;
+            this.updateTaskStatus(
+              taskId,
+              'aborted',
+              undefined,
+              reason instanceof Error ? reason.message : reason == null ? 'The operation was aborted' : String(reason)
+            );
+          }
+        }
+      : undefined;
+    if (taskAbortListener) options.signal!.addEventListener('abort', taskAbortListener, { once: true });
 
     // Emit task creation event
     this.emitTaskEvent(
@@ -583,14 +629,17 @@ export class TaskExecutor {
         payload: { params: redactIdempotencyKeyInArgs(params) },
         timestamp: new Date().toISOString(),
       });
+      throwIfAborted(options.signal);
 
       // Run governance check if configured for this tool
       if (this.governanceMiddleware?.requiresCheck(taskName)) {
         const { result: govResult, params: adjustedParams } = await this.governanceMiddleware.checkProposed(
           taskName,
           params,
-          debugLogs
+          debugLogs,
+          options.signal
         );
+        throwIfAborted(options.signal);
 
         // Governance always blocks on denial/unapplied conditions.
         const isBlocking = true;
@@ -610,6 +659,13 @@ export class TaskExecutor {
         // Approved, or non-blocking mode (advisory/audit) allows execution to proceed
         governanceCheckId = govResult.checkId;
         governanceResult = govResult;
+        if (governanceCheckId) {
+          // Preserve the approved check identity as soon as the seller may be
+          // dispatched. If the deadline fires during response processing,
+          // callers can still reconcile the seller mutation against the
+          // original governance decision after restart.
+          attachTaskDeadlineGovernanceRecovery(options, { checkId: governanceCheckId });
+        }
         effectiveParams = adjustedParams;
       }
 
@@ -645,6 +701,7 @@ export class TaskExecutor {
           idempotencyKey,
         },
       });
+      throwIfAborted(options.signal);
 
       // Emit protocol_response activity
       const respStatus = this.responseParser.getStatus(response) as string | undefined;
@@ -659,6 +716,7 @@ export class TaskExecutor {
         payload: response,
         timestamp: new Date().toISOString(),
       });
+      throwIfAborted(options.signal);
 
       // Add initial response message
       const responseMessage: Message = {
@@ -684,6 +742,7 @@ export class TaskExecutor {
         debugLogs,
         startTime
       );
+      throwIfAborted(options.signal);
 
       // Attach governance check result to the task result
       if (governanceResult) {
@@ -697,26 +756,47 @@ export class TaskExecutor {
       if (governanceCheckId && this.governanceMiddleware) {
         const govCtx = governanceResult?.governanceContext;
         if (result.status === 'completed' && govCtx) {
+          const outcomeIdempotencyKey = this.governanceMiddleware.getOutcomeIdempotencyKey(
+            governanceCheckId,
+            'completed'
+          );
+          attachTaskDeadlineGovernanceRecovery(options, {
+            checkId: governanceCheckId,
+            outcome: 'completed',
+            outcomeIdempotencyKey,
+          });
           result.governanceOutcome = await this.governanceMiddleware.reportOutcome(
             governanceCheckId,
             'completed',
             result.data as Record<string, unknown> | undefined,
             undefined,
             debugLogs,
-            govCtx
+            govCtx,
+            options.signal,
+            outcomeIdempotencyKey
           );
+          throwIfAborted(options.signal);
           if (!result.governanceOutcome) {
             result.governanceOutcomeError = 'Outcome reporting to governance agent failed';
           }
         } else if (result.error && govCtx) {
+          const outcomeIdempotencyKey = this.governanceMiddleware.getOutcomeIdempotencyKey(governanceCheckId, 'failed');
+          attachTaskDeadlineGovernanceRecovery(options, {
+            checkId: governanceCheckId,
+            outcome: 'failed',
+            outcomeIdempotencyKey,
+          });
           result.governanceOutcome = await this.governanceMiddleware.reportOutcome(
             governanceCheckId,
             'failed',
             undefined,
             { message: result.error },
             debugLogs,
-            govCtx
+            govCtx,
+            options.signal,
+            outcomeIdempotencyKey
           );
+          throwIfAborted(options.signal);
           if (!result.governanceOutcome) {
             result.governanceOutcomeError = 'Outcome reporting to governance agent failed';
           }
@@ -739,24 +819,37 @@ export class TaskExecutor {
           (error as Error & { idempotency_key?: string; idempotencyKey?: string }).idempotency_key = idempotencyKey;
           (error as Error & { idempotency_key?: string; idempotencyKey?: string }).idempotencyKey = idempotencyKey;
         }
-        this.updateTaskStatus(taskId, 'aborted', undefined, error instanceof Error ? error.message : String(error));
+        const currentStatus = this.activeTasks.get(taskId)?.status;
+        if (currentStatus && !TERMINAL_TASK_STATUSES.has(currentStatus)) {
+          this.updateTaskStatus(taskId, 'aborted', undefined, error instanceof Error ? error.message : String(error));
+        }
         throw error;
       }
 
       // Report failed outcome on error
       if (governanceCheckId && this.governanceMiddleware && governanceResult?.governanceContext) {
+        const outcomeIdempotencyKey = this.governanceMiddleware.getOutcomeIdempotencyKey(governanceCheckId, 'failed');
+        attachTaskDeadlineGovernanceRecovery(options, {
+          checkId: governanceCheckId,
+          outcome: 'failed',
+          outcomeIdempotencyKey,
+        });
         await this.governanceMiddleware.reportOutcome(
           governanceCheckId,
           'failed',
           undefined,
           { message: (error as Error).message },
           debugLogs,
-          governanceResult.governanceContext
+          governanceResult.governanceContext,
+          options.signal,
+          outcomeIdempotencyKey
         );
       }
       const failed = this.createErrorResult<T>(taskId, agent, error, debugLogs, startTime);
       this.updateTaskStatus(taskId, 'failed', undefined, failed.error);
       return attachMatch(failed);
+    } finally {
+      if (taskAbortListener) options.signal!.removeEventListener('abort', taskAbortListener);
     }
   }
 
@@ -1384,6 +1477,7 @@ export class TaskExecutor {
 
     // Call handler
     const handlerResponse = await inputHandler(context);
+    throwIfAborted(options.signal);
 
     // Check if handler wants to defer
     if (isDeferResponse(handlerResponse)) {
@@ -1400,6 +1494,14 @@ export class TaskExecutor {
           messages,
           createdAt: Date.now(),
         });
+        try {
+          throwIfAborted(options.signal);
+        } catch (error) {
+          // Cancellation may race a storage adapter that ignores the signal.
+          // Remove the just-written resume record before propagating it.
+          await this.config.deferredStorage.delete(token);
+          throw error;
+        }
       }
       // Deferred storage is the resume source of truth. Avoid retaining a
       // duplicate full request (including assets/credentials) in activeTasks.
@@ -1430,6 +1532,7 @@ export class TaskExecutor {
     }
 
     // Handler provided input - continue with the task
+    throwIfAborted(options.signal);
     return this.continueTaskWithInput<T>(
       agent,
       taskId,
@@ -2237,6 +2340,9 @@ export class TaskExecutor {
   private updateTaskStatus(taskId: string, status: TaskStatus, result?: any, error?: string): void {
     const task = this.activeTasks.get(taskId);
     if (task) {
+      // Once cancellation has released request state, late work must not
+      // resurrect the task or emit completion after the caller has retried.
+      if (task.status === 'aborted' && status !== 'aborted') return;
       const previousStatus = task.status;
       task.status = status;
 
@@ -2270,7 +2376,7 @@ export class TaskExecutor {
 
       // If task is finished, remove from active tasks after a delay.
       // unref() ensures this timer doesn't prevent the process from exiting.
-      if (['completed', 'failed', 'rejected', 'canceled', 'governance-denied', 'aborted'].includes(status)) {
+      if (TERMINAL_TASK_STATUSES.has(status)) {
         // Keep lifecycle metadata briefly for status inspection, but release
         // request/conversation/options immediately. These may contain inline
         // creative assets and webhook or transport credentials.

--- a/src/lib/core/task-deadline.ts
+++ b/src/lib/core/task-deadline.ts
@@ -1,0 +1,65 @@
+import { randomUUID } from 'node:crypto';
+
+import { TaskTimeoutError, type GovernanceOutcomeRecovery } from '../errors';
+import { MAX_TIMER_DELAY_MS, throwIfAborted, withAbortSignal } from '../protocols/abort';
+import type { TaskOptions } from './ConversationTypes';
+
+const TASK_OPERATION_ID = Symbol('adcp.taskOperationId');
+const TASK_DEADLINE_ERROR = Symbol('adcp.taskDeadlineError');
+
+type DeadlineTaskOptions<TOptions extends TaskOptions = TaskOptions> = TOptions & {
+  [TASK_OPERATION_ID]: string;
+  [TASK_DEADLINE_ERROR]?: TaskTimeoutError;
+};
+
+export function getTaskOperationId(options: TaskOptions | undefined): string | undefined {
+  return (options as DeadlineTaskOptions | undefined)?.[TASK_OPERATION_ID];
+}
+
+export function attachTaskDeadlineIdempotencyKey(options: TaskOptions, idempotencyKey: string): void {
+  const error = (options as DeadlineTaskOptions)[TASK_DEADLINE_ERROR];
+  if (!error) return;
+  error.idempotency_key = idempotencyKey;
+  error.idempotencyKey = idempotencyKey;
+}
+
+export function attachTaskDeadlineGovernanceRecovery(options: TaskOptions, recovery: GovernanceOutcomeRecovery): void {
+  const error = (options as DeadlineTaskOptions)[TASK_DEADLINE_ERROR];
+  if (error) error.governanceRecovery = recovery;
+}
+
+/**
+ * Run one complete SDK task under the caller's absolute wall-clock deadline.
+ *
+ * The consumed timeout is removed from the nested options so lower layers do
+ * not start a second deadline. They still receive the composed signal, while
+ * `workingTimeout` remains the transport's separate resettable idle timeout.
+ */
+export async function withTaskDeadline<T, TOptions extends TaskOptions = TaskOptions>(
+  options: TOptions | undefined,
+  run: (effectiveOptions: DeadlineTaskOptions<TOptions>) => Promise<T>
+): Promise<T> {
+  const existing = options as DeadlineTaskOptions<TOptions> | undefined;
+  const taskId = existing?.[TASK_OPERATION_ID] ?? randomUUID();
+  const timeout = options?.timeout;
+  const baseOptions = { ...options, timeout: undefined, [TASK_OPERATION_ID]: taskId } as DeadlineTaskOptions<TOptions>;
+  throwIfAborted(options?.signal);
+  if (timeout === undefined || timeout === 0) return run(baseOptions);
+
+  if (!Number.isFinite(timeout) || timeout < 0 || timeout > MAX_TIMER_DELAY_MS) {
+    throw new RangeError(`timeout must be a finite non-negative number <= ${MAX_TIMER_DELAY_MS}`);
+  }
+
+  const timeoutError = new TaskTimeoutError(taskId, timeout);
+  return withAbortSignal(
+    [options?.signal],
+    timeout,
+    signal =>
+      run({
+        ...baseOptions,
+        signal,
+        [TASK_DEADLINE_ERROR]: timeoutError,
+      }),
+    { timeoutError }
+  );
+}

--- a/src/lib/errors/index.ts
+++ b/src/lib/errors/index.ts
@@ -18,8 +18,20 @@ export abstract class ADCPError extends Error {
 /**
  * Error thrown when a task times out
  */
+export interface GovernanceOutcomeRecovery {
+  checkId: string;
+  outcome?: 'completed' | 'failed';
+  outcomeIdempotencyKey?: string;
+}
+
 export class TaskTimeoutError extends ADCPError {
   readonly code = 'TASK_TIMEOUT';
+  /** Retry-safety key for mutating requests that reached dispatch. */
+  idempotency_key?: string;
+  /** Camel-case compatibility alias for `idempotency_key`. */
+  idempotencyKey?: string;
+  /** Retry identity when the deadline expires during governance postflight. */
+  governanceRecovery?: GovernanceOutcomeRecovery;
 
   constructor(
     public readonly taskId: string,

--- a/src/lib/net/ssrf-fetch.ts
+++ b/src/lib/net/ssrf-fetch.ts
@@ -152,6 +152,7 @@ export interface SsrfFetchResult {
  * timeouts, remote resets) propagate as the native fetch error.
  */
 export async function ssrfSafeFetch(url: string, options: SsrfFetchOptions = {}): Promise<SsrfFetchResult> {
+  throwIfSignalAborted(options.signal);
   const allowPrivateIp = options.allowPrivateIp === true;
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const maxBodyBytes = options.maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES;
@@ -188,12 +189,14 @@ export async function ssrfSafeFetch(url: string, options: SsrfFetchOptions = {})
   try {
     addresses = await dnsLookupAsync(hostname, { all: true });
   } catch (err) {
+    throwIfSignalAborted(options.signal);
     throw new SsrfRefusedError(
       'dns_lookup_failed',
       `DNS lookup failed for ${hostname}: ${err instanceof Error ? err.message : String(err)}`,
       { url, hostname }
     );
   }
+  throwIfSignalAborted(options.signal);
   if (addresses.length === 0) {
     throw new SsrfRefusedError('dns_empty', `DNS returned no addresses for ${hostname}`, {
       url,
@@ -251,6 +254,7 @@ export async function ssrfSafeFetch(url: string, options: SsrfFetchOptions = {})
   const ac = new AbortController();
   const onExternalAbort = () => ac.abort(options.signal?.reason);
   options.signal?.addEventListener('abort', onExternalAbort, { once: true });
+  if (options.signal?.aborted) onExternalAbort();
   const timer = setTimeout(() => ac.abort(new Error('ssrf-fetch: timeout')), timeoutMs);
 
   try {
@@ -327,6 +331,14 @@ export async function ssrfSafeFetch(url: string, options: SsrfFetchOptions = {})
     options.signal?.removeEventListener('abort', onExternalAbort);
     await dispatcher.close().catch(() => {});
   }
+}
+
+function throwIfSignalAborted(signal?: AbortSignal): void {
+  if (!signal?.aborted) return;
+  if (signal.reason instanceof Error) throw signal.reason;
+  const error = new Error(signal.reason == null ? 'The operation was aborted' : String(signal.reason));
+  error.name = 'AbortError';
+  throw error;
 }
 
 /**

--- a/src/lib/protocols/abort.ts
+++ b/src/lib/protocols/abort.ts
@@ -17,7 +17,12 @@ export function resolveClientRequestTimeoutMs(timeoutMs: number | undefined): nu
 }
 
 export function createAbortError(reason?: unknown): Error {
-  if (reason instanceof Error && (reason.name === 'AbortError' || reason.name === 'TimeoutError')) return reason;
+  if (
+    reason instanceof Error &&
+    (reason.name === 'AbortError' || reason.name === 'TimeoutError' || reason.name === 'TaskTimeoutError')
+  ) {
+    return reason;
+  }
   const error = new Error(reason == null ? 'The operation was aborted' : String(reason));
   error.name = 'AbortError';
   if (reason instanceof Error) {
@@ -36,11 +41,11 @@ export function createTimeoutError(timeoutMs: number): Error {
 export function isAbortOrTimeoutError(error: unknown): boolean {
   if (error == null || typeof error !== 'object') return false;
   const value = error as { name?: unknown; code?: unknown };
-  if (value.name === 'AbortError' || value.name === 'TimeoutError') return true;
+  if (value.name === 'AbortError' || value.name === 'TimeoutError' || value.name === 'TaskTimeoutError') return true;
   // MCP SDK v1 raises JSON-RPC RequestTimeout (-32001); the v2 packages use
   // the typed SDK error code REQUEST_TIMEOUT. Both represent the same
   // timeout/cancellation boundary and must bypass endpoint fallback.
-  return value.code === -32001 || value.code === 'REQUEST_TIMEOUT';
+  return value.code === -32001 || value.code === 'REQUEST_TIMEOUT' || value.code === 'TASK_TIMEOUT';
 }
 
 export function throwIfAborted(signal?: AbortSignal): void {
@@ -52,7 +57,8 @@ export function throwIfAborted(signal?: AbortSignal): void {
 export async function withAbortSignal<T>(
   signals: Array<AbortSignal | null | undefined>,
   timeoutMs: number | undefined,
-  fn: (signal?: AbortSignal) => Promise<T>
+  fn: (signal?: AbortSignal) => Promise<T>,
+  options: { timeoutError?: Error } = {}
 ): Promise<T> {
   const activeSignals = signals.filter((signal): signal is AbortSignal => signal != null);
   for (const signal of activeSignals) {
@@ -61,18 +67,6 @@ export async function withAbortSignal<T>(
 
   if (timeoutMs == null && activeSignals.length === 0) {
     return fn(undefined);
-  }
-
-  if (timeoutMs == null && activeSignals.length === 1) {
-    const signal = activeSignals[0]!;
-    try {
-      return await fn(signal);
-    } catch (error) {
-      if (signal.aborted) {
-        throw createAbortError(signal.reason);
-      }
-      throw error;
-    }
   }
 
   const controller = new AbortController();
@@ -91,13 +85,28 @@ export async function withAbortSignal<T>(
     timeoutMs == null
       ? undefined
       : setTimeout(() => {
-          abort(createTimeoutError(timeoutMs));
+          abort(options.timeoutError ?? createTimeoutError(timeoutMs));
         }, timeoutMs);
 
+  let rejectOnAbort: ((reason: unknown) => void) | undefined;
+  const aborted = new Promise<never>((_resolve, reject) => {
+    rejectOnAbort = () => reject(controller.signal.reason ?? createAbortError());
+    controller.signal.addEventListener('abort', rejectOnAbort, { once: true });
+  });
+
   try {
-    return await fn(controller.signal);
+    // The signal reclaims transports that honor cancellation. The race also
+    // guarantees the caller-facing deadline when an intermediate callback or
+    // protocol implementation is slow to observe that signal.
+    return await Promise.race([fn(controller.signal), aborted]);
+  } catch (error) {
+    if (controller.signal.aborted) {
+      throw controller.signal.reason ?? createAbortError();
+    }
+    throw error;
   } finally {
     if (timer) clearTimeout(timer);
+    if (rejectOnAbort) controller.signal.removeEventListener('abort', rejectOnAbort);
     for (const { signal, listener } of listeners) {
       signal.removeEventListener('abort', listener);
     }

--- a/src/lib/protocols/index.ts
+++ b/src/lib/protocols/index.ts
@@ -449,6 +449,7 @@ export class ProtocolClient {
                   storage: ccStorage,
                   allowPrivateIp,
                   fetch: transport?.fetchFn,
+                  signal,
                 });
               }
 
@@ -564,7 +565,7 @@ export class ProtocolClient {
                     // Refresh failed or server rejected the refreshed token — walk the
                     // discovery chain so the caller can distinguish "re-auth needed"
                     // from other failure modes.
-                    await rethrowAsNeedsAuthorization(err, agent.agent_uri, transport?.fetchFn);
+                    await rethrowAsNeedsAuthorization(err, agent.agent_uri, transport?.fetchFn, signal);
                     throw err;
                   }
                 }
@@ -601,6 +602,7 @@ export class ProtocolClient {
                       force: true,
                       allowPrivateIp,
                       fetch: transport?.fetchFn,
+                      signal,
                     });
                     const retryAuthToken = agent.oauth_tokens?.access_token ?? authToken;
                     try {
@@ -621,11 +623,11 @@ export class ProtocolClient {
                         }
                       );
                     } catch (retryErr) {
-                      await rethrowAsNeedsAuthorization(retryErr, agent.agent_uri, transport?.fetchFn);
+                      await rethrowAsNeedsAuthorization(retryErr, agent.agent_uri, transport?.fetchFn, signal);
                       throw retryErr;
                     }
                   }
-                  await rethrowAsNeedsAuthorization(err, agent.agent_uri, transport?.fetchFn);
+                  await rethrowAsNeedsAuthorization(err, agent.agent_uri, transport?.fetchFn, signal);
                   throw err;
                 }
               } else if (agent.protocol === 'a2a') {
@@ -658,6 +660,7 @@ export class ProtocolClient {
                       force: true,
                       allowPrivateIp,
                       fetch: transport?.fetchFn,
+                      signal,
                     });
                     const retryAuthToken = agent.oauth_tokens?.access_token ?? authToken;
                     try {
@@ -676,11 +679,11 @@ export class ProtocolClient {
                         transport?.fetchFn
                       );
                     } catch (retryErr) {
-                      await rethrowAsNeedsAuthorization(retryErr, agent.agent_uri, transport?.fetchFn);
+                      await rethrowAsNeedsAuthorization(retryErr, agent.agent_uri, transport?.fetchFn, signal);
                       throw retryErr;
                     }
                   }
-                  await rethrowAsNeedsAuthorization(err, agent.agent_uri, transport?.fetchFn);
+                  await rethrowAsNeedsAuthorization(err, agent.agent_uri, transport?.fetchFn, signal);
                   throw err;
                 }
               } else {
@@ -702,7 +705,12 @@ export class ProtocolClient {
  * Keeping this off the hot path: we only probe on error, and the probe is
  * a single unauthenticated `tools/list` POST — no retries, no DNS rebind.
  */
-async function rethrowAsNeedsAuthorization(err: unknown, agentUrl: string, fetchFn?: typeof fetch): Promise<void> {
+async function rethrowAsNeedsAuthorization(
+  err: unknown,
+  agentUrl: string,
+  fetchFn?: typeof fetch,
+  signal?: AbortSignal
+): Promise<void> {
   if (err instanceof NeedsAuthorizationError) throw err;
   if (!is401Error(err)) return;
 
@@ -714,7 +722,7 @@ async function rethrowAsNeedsAuthorization(err: unknown, agentUrl: string, fetch
   // discoverAuthorizationRequirements internally catches network failures and
   // returns null rather than throwing — anything that escapes is a genuine
   // bug we want to surface rather than mask the 401 with.
-  const requirements = await discoverAuthorizationRequirements(agentUrl, { allowPrivateIp, fetchFn });
+  const requirements = await discoverAuthorizationRequirements(agentUrl, { allowPrivateIp, fetchFn, signal });
   if (requirements) {
     throw new NeedsAuthorizationError(requirements);
   }

--- a/src/lib/protocols/mcp.ts
+++ b/src/lib/protocols/mcp.ts
@@ -465,7 +465,7 @@ export async function withCachedConnection<T>(
       requestOptions
     );
     try {
-      return await fn(guardedClient);
+      return await withAbortSignal([requestOptions.signal], undefined, () => fn(guardedClient));
     } finally {
       try {
         await guardedClient.close();
@@ -625,17 +625,22 @@ async function connectMCPWithFallbackImpl(
   // Size-limit applies to the raw network response so signing/capture see a
   // bounded body (capture clones via `response.clone()`, which would otherwise
   // buffer a hostile reply in memory).
-  const requestTimeoutMs = resolveRequestTimeoutMs(requestOptions.requestTimeoutMs);
   const clientRequestTimeoutMs = resolveClientRequestTimeoutMs(requestOptions.requestTimeoutMs);
   const mcpRequestOptions = {
     ...(requestOptions.signal && { signal: requestOptions.signal }),
     ...(clientRequestTimeoutMs !== undefined && { timeout: clientRequestTimeoutMs }),
   };
   const rawNetworkFetch: typeof fetch = transportFetch ?? ((input, init) => fetch(input as any, init));
-  const networkFetch = (input: Parameters<typeof fetch>[0], init?: RequestInit) =>
-    withAbortSignal<Response>([requestOptions.signal, init?.signal], requestTimeoutMs, signal =>
-      rawNetworkFetch(input, { ...init, signal })
+  const networkFetch = (input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+    // Keep cancellation linked for the entire response-body lifetime. A
+    // Promise race around fetch only covers receipt of response headers; MCP
+    // Streamable HTTP can then hold the body open while a tool runs.
+    const signals = [requestOptions.signal, init?.signal ?? undefined].filter(
+      (signal): signal is AbortSignal => signal !== undefined
     );
+    const signal = signals.length === 0 ? undefined : signals.length === 1 ? signals[0] : AbortSignal.any(signals);
+    return rawNetworkFetch(input, { ...init, signal });
+  };
   const sizeLimited = wrapFetchWithSizeLimit(networkFetch);
   const diagnosticFetch = wrapFetchWithTransportDiagnostics(sizeLimited);
   const baseFetch: typeof fetch = signingContext

--- a/test/oauth-client-credentials.test.js
+++ b/test/oauth-client-credentials.test.js
@@ -563,6 +563,186 @@ describe('ensureClientCredentialsTokens', () => {
     assert.strictEqual(hits, 1, 'expected a single upstream POST across all 10 concurrent callers');
     for (const t of results) assert.strictEqual(t.access_token, 'coalesced_at');
   });
+
+  it('does not coalesce different agent configs that share public OAuth fields', async () => {
+    const credentials = {
+      token_endpoint: 'https://auth.example.com/token',
+      client_id: 'shared-client',
+    };
+    const tenantA = {
+      id: 'shared-agent-id',
+      name: 'tenant-a',
+      agent_uri: 'https://agent.example.com/mcp',
+      protocol: 'mcp',
+      oauth_client_credentials: { ...credentials, client_secret: 'tenant-a-secret', scope: 'tenant-a' },
+    };
+    const tenantB = {
+      id: 'shared-agent-id',
+      name: 'tenant-b',
+      agent_uri: 'https://agent.example.com/mcp',
+      protocol: 'mcp',
+      oauth_client_credentials: { ...credentials, client_secret: 'tenant-b-secret', scope: 'tenant-b' },
+    };
+    let tenantAHits = 0;
+    let tenantBHits = 0;
+    let releaseTenantA;
+    const tenantAFetch = makeFetchStub(
+      async () =>
+        new Promise(resolve => {
+          tenantAHits += 1;
+          releaseTenantA = () =>
+            resolve(new Response(JSON.stringify({ access_token: 'tenant-a-token' }), { status: 200 }));
+        })
+    );
+    const tenantBFetch = makeFetchStub(async () => {
+      tenantBHits += 1;
+      return new Response(JSON.stringify({ access_token: 'tenant-b-token' }), { status: 200 });
+    });
+
+    const tenantAPending = ensureClientCredentialsTokens(tenantA, { fetch: tenantAFetch });
+    const tenantBResult = await ensureClientCredentialsTokens(tenantB, { fetch: tenantBFetch });
+    releaseTenantA();
+    const tenantAResult = await tenantAPending;
+
+    assert.strictEqual(tenantAResult.access_token, 'tenant-a-token');
+    assert.strictEqual(tenantBResult.access_token, 'tenant-b-token');
+    assert.strictEqual(tenantAHits, 1);
+    assert.strictEqual(tenantBHits, 1);
+  });
+
+  it('aborts a client-credentials token request when its caller cancels', async () => {
+    let fetchObservedAbort = false;
+    const fetchStub = makeFetchStub(
+      async (_url, init) =>
+        new Promise((_resolve, reject) => {
+          init.signal.addEventListener(
+            'abort',
+            () => {
+              fetchObservedAbort = true;
+              reject(init.signal.reason);
+            },
+            { once: true }
+          );
+        })
+    );
+    const agent = {
+      id: 'cancelled-cc-agent',
+      name: 'a',
+      agent_uri: 'https://agent.example.com/mcp',
+      protocol: 'mcp',
+      oauth_client_credentials: {
+        token_endpoint: 'https://auth.example.com/token',
+        client_id: 'id',
+        client_secret: 'secret',
+      },
+    };
+    const controller = new AbortController();
+    const pending = ensureClientCredentialsTokens(agent, { fetch: fetchStub, signal: controller.signal });
+    controller.abort('task deadline');
+
+    await assert.rejects(pending, err => err?.name === 'AbortError' && /task deadline/.test(err.message));
+    assert.strictEqual(fetchObservedAbort, true);
+  });
+
+  it('does not start a token request for a pre-aborted caller', async () => {
+    let hits = 0;
+    const agent = {
+      id: 'pre-cancelled-cc-agent',
+      name: 'a',
+      agent_uri: 'https://agent.example.com/mcp',
+      protocol: 'mcp',
+      oauth_client_credentials: {
+        token_endpoint: 'https://auth.example.com/token',
+        client_id: 'id',
+        client_secret: 'secret',
+      },
+    };
+    const controller = new AbortController();
+    controller.abort('already cancelled');
+
+    await assert.rejects(
+      ensureClientCredentialsTokens(agent, {
+        signal: controller.signal,
+        fetch: async () => {
+          hits += 1;
+          return new Response(JSON.stringify({ access_token: 'must-not-run' }), { status: 200 });
+        },
+      }),
+      err => err?.name === 'AbortError' && /already cancelled/.test(err.message)
+    );
+    assert.strictEqual(hits, 0);
+  });
+
+  it('starts a fresh refresh after the last waiter cancels an older exchange', async () => {
+    let hits = 0;
+    const fetchStub = makeFetchStub(async (_url, init) => {
+      hits += 1;
+      if (hits === 1) {
+        return new Promise((_resolve, reject) => {
+          init.signal.addEventListener('abort', () => setTimeout(() => reject(init.signal.reason), 25), { once: true });
+        });
+      }
+      return new Response(JSON.stringify({ access_token: 'replacement_at', expires_in: 3600 }), { status: 200 });
+    });
+    const agent = {
+      id: 'replacement-refresh-agent',
+      name: 'a',
+      agent_uri: 'https://agent.example.com/mcp',
+      protocol: 'mcp',
+      oauth_client_credentials: {
+        token_endpoint: 'https://auth.example.com/token',
+        client_id: 'id',
+        client_secret: 'secret',
+      },
+    };
+    const first = new AbortController();
+    const firstPending = ensureClientCredentialsTokens(agent, { fetch: fetchStub, signal: first.signal });
+    first.abort('first caller stopped');
+    await assert.rejects(firstPending, err => err?.name === 'AbortError');
+
+    const tokens = await ensureClientCredentialsTokens(agent, { fetch: fetchStub });
+    assert.strictEqual(tokens.access_token, 'replacement_at');
+    assert.strictEqual(hits, 2);
+  });
+
+  it('keeps a coalesced token request alive while another caller still waits', async () => {
+    let resolveFetch;
+    let sharedSignal;
+    let hits = 0;
+    const fetchStub = makeFetchStub(
+      async (_url, init) =>
+        new Promise(resolve => {
+          hits += 1;
+          sharedSignal = init.signal;
+          resolveFetch = resolve;
+        })
+    );
+    const agent = {
+      id: 'coalesced-cancellation-agent',
+      name: 'a',
+      agent_uri: 'https://agent.example.com/mcp',
+      protocol: 'mcp',
+      oauth_client_credentials: {
+        token_endpoint: 'https://auth.example.com/token',
+        client_id: 'id',
+        client_secret: 'secret',
+      },
+    };
+    const first = new AbortController();
+    const second = new AbortController();
+    const firstPending = ensureClientCredentialsTokens(agent, { fetch: fetchStub, signal: first.signal });
+    const firstRejected = assert.rejects(firstPending, err => err?.name === 'AbortError');
+    const secondPending = ensureClientCredentialsTokens(agent, { fetch: fetchStub, signal: second.signal });
+
+    first.abort('first caller stopped');
+    await firstRejected;
+    assert.strictEqual(sharedSignal.aborted, false, 'remaining waiter must retain the shared request');
+    resolveFetch(new Response(JSON.stringify({ access_token: 'shared_at', expires_in: 3600 }), { status: 200 }));
+
+    const tokens = await secondPending;
+    assert.strictEqual(tokens.access_token, 'shared_at');
+    assert.strictEqual(hits, 1);
+  });
 });
 
 describe('getAuthToken integration with client credentials', () => {

--- a/test/read-path-abort-timeout.test.js
+++ b/test/read-path-abort-timeout.test.js
@@ -3,11 +3,12 @@ const assert = require('node:assert');
 const http = require('node:http');
 
 const { AgentClient } = require('../dist/lib/core/AgentClient');
-const { TaskExecutor } = require('../dist/lib/core/TaskExecutor');
+const { TaskExecutor, TaskTimeoutError: ExecutorTaskTimeoutError } = require('../dist/lib/core/TaskExecutor');
+const { TaskTimeoutError } = require('../dist/lib/errors');
 const { ProtocolClient } = require('../dist/lib/protocols');
 const { connectMCPWithFallback } = require('../dist/lib/protocols/mcp');
 const { MAX_TIMER_DELAY_MS, resolveClientRequestTimeoutMs } = require('../dist/lib/protocols/abort');
-const { callMCPToolWithClient } = require('../dist/lib/protocols/mcp-tasks');
+const { callMCPToolWithClient, callMCPToolWithTasks } = require('../dist/lib/protocols/mcp-tasks');
 const { getOrDiscoverProfile } = require('../dist/lib/testing/client');
 const { CapabilityCache, ensureCapabilityLoaded } = require('../dist/lib/signing/client');
 
@@ -15,6 +16,10 @@ describe('read-path cancellation and timeout', () => {
   let server;
   let baseUrl;
   const sockets = new Set();
+
+  it('uses one typed TaskTimeoutError across package and TaskExecutor exports', () => {
+    assert.strictEqual(ExecutorTaskTimeoutError, TaskTimeoutError);
+  });
 
   before(async () => {
     server = http.createServer((req, res) => {
@@ -203,6 +208,419 @@ describe('read-path cancellation and timeout', () => {
     );
   });
 
+  it('enforces TaskOptions.timeout across A2A endpoint discovery', async () => {
+    const client = new AgentClient({ id: 'deadline-a2a', agent_uri: baseUrl, protocol: 'a2a', name: 'test' });
+
+    await assert.rejects(
+      () =>
+        client.getProducts({ buying_mode: 'brief', brief: 'coffee' }, undefined, {
+          timeout: 25,
+          transport: { requestTimeoutMs: 0 },
+        }),
+      err => {
+        assert.ok(err instanceof TaskTimeoutError);
+        assert.strictEqual(err.timeout, 25);
+        assert.strictEqual(err.code, 'TASK_TIMEOUT');
+        return true;
+      }
+    );
+  });
+
+  it('aborts a hanging OAuth diagnostic probe after an MCP 401', async () => {
+    let resolveProbeStarted;
+    let resolveProbeClosed;
+    const probeStarted = new Promise(resolve => {
+      resolveProbeStarted = resolve;
+    });
+    const probeClosed = new Promise(resolve => {
+      resolveProbeClosed = resolve;
+    });
+    const liveSockets = new Set();
+    const authServer = http.createServer((req, res) => {
+      if (req.method !== 'POST') {
+        res.writeHead(401, { 'www-authenticate': 'Bearer realm="deadline-test"' });
+        res.end();
+        return;
+      }
+      const chunks = [];
+      req.on('data', chunk => chunks.push(chunk));
+      req.on('end', () => {
+        let method;
+        try {
+          method = JSON.parse(Buffer.concat(chunks).toString('utf8')).method;
+        } catch {}
+        if (method === 'tools/list') {
+          resolveProbeStarted();
+          res.on('close', () => {
+            if (!res.writableEnded) resolveProbeClosed();
+          });
+          return;
+        }
+        res.writeHead(401, { 'www-authenticate': 'Bearer realm="deadline-test"' });
+        res.end();
+      });
+    });
+    authServer.on('connection', socket => {
+      liveSockets.add(socket);
+      socket.on('close', () => liveSockets.delete(socket));
+    });
+    await new Promise(resolve => authServer.listen(0, '127.0.0.1', resolve));
+    const { port } = authServer.address();
+
+    try {
+      const executor = new TaskExecutor();
+      await assert.rejects(
+        () =>
+          executor.executeTask(
+            {
+              id: 'deadline-mcp-auth-probe',
+              agent_uri: `http://127.0.0.1:${port}`,
+              protocol: 'mcp',
+              name: 'test',
+            },
+            'custom_unauthorized',
+            {},
+            undefined,
+            { timeout: 150, transport: { requestTimeoutMs: 0 } }
+          ),
+        err => err instanceof TaskTimeoutError
+      );
+      await Promise.race([
+        probeStarted,
+        new Promise((_, reject) => setTimeout(() => reject(new Error('OAuth diagnostic probe did not start')), 1_000)),
+      ]);
+      await Promise.race([
+        probeClosed,
+        new Promise((_, reject) => setTimeout(() => reject(new Error('OAuth diagnostic probe did not close')), 500)),
+      ]);
+    } finally {
+      for (const socket of liveSockets) socket.destroy();
+      await new Promise(resolve => authServer.close(resolve));
+    }
+  });
+
+  it('enforces TaskOptions.timeout across getAdcpCapabilities MCP discovery', async () => {
+    const client = new AgentClient({ id: 'deadline-mcp-caps', agent_uri: baseUrl, protocol: 'mcp', name: 'test' });
+
+    await assert.rejects(
+      () =>
+        client.getAdcpCapabilities({}, undefined, {
+          timeout: 25,
+          transport: { requestTimeoutMs: 0 },
+        }),
+      err => {
+        assert.ok(err instanceof TaskTimeoutError);
+        assert.strictEqual(err.timeout, 25);
+        return true;
+      }
+    );
+  });
+
+  it('preserves caller-abort semantics when cancellation beats the task deadline', async () => {
+    const client = new AgentClient({ id: 'abort-before-deadline', agent_uri: baseUrl, protocol: 'a2a', name: 'test' });
+    const controller = new AbortController();
+    setTimeout(() => controller.abort('caller stopped'), 20);
+
+    await assert.rejects(
+      () =>
+        client.getProducts({ buying_mode: 'brief', brief: 'coffee' }, undefined, {
+          timeout: 200,
+          signal: controller.signal,
+          transport: { requestTimeoutMs: 0 },
+        }),
+      err => {
+        assert.strictEqual(err?.name, 'AbortError');
+        assert.match(err.message, /caller stopped/);
+        assert.ok(!(err instanceof TaskTimeoutError));
+        return true;
+      }
+    );
+  });
+
+  it('aborts and closes an actual A2A sendMessage request at the task deadline', async () => {
+    let resolveToolStarted;
+    let resolveResponseClosed;
+    const toolStarted = new Promise(resolve => {
+      resolveToolStarted = resolve;
+    });
+    const responseClosed = new Promise(resolve => {
+      resolveResponseClosed = resolve;
+    });
+    const liveSockets = new Set();
+    const a2aServer = http.createServer((req, res) => {
+      if (
+        req.method === 'GET' &&
+        (req.url === '/.well-known/agent.json' || req.url === '/.well-known/agent-card.json')
+      ) {
+        const { port } = a2aServer.address();
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(
+          JSON.stringify({
+            protocolVersion: '0.3.0',
+            name: 'deadline-a2a',
+            description: 'deadline fixture',
+            url: `http://127.0.0.1:${port}/rpc`,
+            preferredTransport: 'JSONRPC',
+            version: '1.0.0',
+            defaultInputModes: ['application/json'],
+            defaultOutputModes: ['application/json'],
+            capabilities: { streaming: false, pushNotifications: false },
+            skills: [{ id: 'custom_hanging', name: 'custom_hanging', description: 'hang', tags: ['test'] }],
+          })
+        );
+        return;
+      }
+      if (req.method === 'POST' && req.url === '/rpc') {
+        resolveToolStarted();
+        res.on('close', () => {
+          if (!res.writableEnded) resolveResponseClosed();
+        });
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+    a2aServer.on('connection', socket => {
+      liveSockets.add(socket);
+      socket.on('close', () => liveSockets.delete(socket));
+    });
+    await new Promise(resolve => a2aServer.listen(0, '127.0.0.1', resolve));
+    const { port } = a2aServer.address();
+
+    try {
+      const executor = new TaskExecutor();
+      await assert.rejects(
+        () =>
+          executor.executeTask(
+            { id: 'a2a-send-deadline', name: 'test', protocol: 'a2a', agent_uri: `http://127.0.0.1:${port}` },
+            'custom_hanging',
+            {},
+            undefined,
+            { timeout: 100 }
+          ),
+        err => err instanceof TaskTimeoutError
+      );
+      await Promise.race([
+        toolStarted,
+        new Promise((_, reject) => setTimeout(() => reject(new Error('A2A tool did not start')), 1_000)),
+      ]);
+      await Promise.race([
+        responseClosed,
+        new Promise((_, reject) => setTimeout(() => reject(new Error('A2A response did not close')), 500)),
+      ]);
+    } finally {
+      for (const socket of liveSockets) socket.destroy();
+      await new Promise(resolve => a2aServer.close(resolve));
+    }
+  });
+
+  it('aborts and closes an actual modern MCP tool request at the task deadline', async () => {
+    const { createMcpHandler, McpServer } = require('@modelcontextprotocol/server');
+    const { toNodeHandler } = require('@modelcontextprotocol/node');
+    const { closeMCPConnections } = require('../dist/lib/protocols/mcp');
+    let resolveToolStarted;
+    let resolveResponseClosed;
+    const toolStarted = new Promise(resolve => {
+      resolveToolStarted = resolve;
+    });
+    const responseClosed = new Promise(resolve => {
+      resolveResponseClosed = resolve;
+    });
+    const handler = createMcpHandler(
+      () => {
+        const mcp = new McpServer({ name: 'deadline-modern', version: '1.0.0' });
+        mcp.registerTool('custom_hanging', { description: 'hang' }, async () => {
+          resolveToolStarted();
+          return new Promise(() => {});
+        });
+        return mcp;
+      },
+      { legacy: 'reject' }
+    );
+    const nodeHandler = toNodeHandler(handler);
+    const liveSockets = new Set();
+    const mcpServer = http.createServer(async (req, res) => {
+      res.on('close', () => {
+        if (!res.writableEnded) resolveResponseClosed();
+      });
+      await nodeHandler(req, res);
+    });
+    mcpServer.on('connection', socket => {
+      liveSockets.add(socket);
+      socket.on('close', () => liveSockets.delete(socket));
+    });
+    await new Promise(resolve => mcpServer.listen(0, '127.0.0.1', resolve));
+    const { port } = mcpServer.address();
+
+    try {
+      const executor = new TaskExecutor();
+      await assert.rejects(
+        () =>
+          executor.executeTask(
+            { id: 'modern-mcp-deadline', name: 'test', protocol: 'mcp', agent_uri: `http://127.0.0.1:${port}` },
+            'custom_hanging',
+            {},
+            undefined,
+            { timeout: 2_000 }
+          ),
+        err => err instanceof TaskTimeoutError
+      );
+      await Promise.race([
+        toolStarted,
+        new Promise((_, reject) => setTimeout(() => reject(new Error('modern MCP tool did not start')), 5_000)),
+      ]);
+      await Promise.race([
+        responseClosed,
+        new Promise((_, reject) => setTimeout(() => reject(new Error('modern MCP response did not close')), 500)),
+      ]);
+    } finally {
+      for (const socket of liveSockets) socket.destroy();
+      await Promise.race([closeMCPConnections(), new Promise(resolve => setTimeout(resolve, 1_000))]);
+      await Promise.race([handler.close(), new Promise(resolve => setTimeout(resolve, 1_000))]);
+      await new Promise(resolve => mcpServer.close(resolve));
+    }
+  });
+
+  it('aborts and closes an actual legacy MCP fallback tool request at the task deadline', async () => {
+    const { McpServer } = require('@modelcontextprotocol/sdk/server/mcp.js');
+    const { StreamableHTTPServerTransport } = require('@modelcontextprotocol/sdk/server/streamableHttp.js');
+    const { closeMCPConnections } = require('../dist/lib/protocols/mcp');
+    let resolveToolStarted;
+    let resolveResponseClosed;
+    const toolStarted = new Promise(resolve => {
+      resolveToolStarted = resolve;
+    });
+    const responseClosed = new Promise(resolve => {
+      resolveResponseClosed = resolve;
+    });
+    const liveSockets = new Set();
+    const legacyServer = http.createServer(async (req, res) => {
+      let isToolRequest = false;
+      res.on('close', () => {
+        if (isToolRequest) resolveResponseClosed();
+      });
+      const mcp = new McpServer({ name: 'deadline-legacy', version: '1.0.0' });
+      mcp.registerTool('custom_hanging', { description: 'hang' }, async () => {
+        isToolRequest = true;
+        resolveToolStarted();
+        return new Promise(() => {});
+      });
+      const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+      try {
+        await mcp.connect(transport);
+        await transport.handleRequest(req, res);
+      } finally {
+        await mcp.close();
+      }
+    });
+    legacyServer.on('connection', socket => {
+      liveSockets.add(socket);
+      socket.on('close', () => liveSockets.delete(socket));
+    });
+    await new Promise(resolve => legacyServer.listen(0, '127.0.0.1', resolve));
+    const { port } = legacyServer.address();
+
+    try {
+      const executor = new TaskExecutor();
+      await assert.rejects(
+        () =>
+          executor.executeTask(
+            { id: 'legacy-mcp-deadline', name: 'test', protocol: 'mcp', agent_uri: `http://127.0.0.1:${port}` },
+            'custom_hanging',
+            {},
+            undefined,
+            { timeout: 2_000 }
+          ),
+        err => err instanceof TaskTimeoutError
+      );
+      await Promise.race([
+        toolStarted,
+        new Promise((_, reject) => setTimeout(() => reject(new Error('legacy MCP tool did not start')), 5_000)),
+      ]);
+      await Promise.race([
+        responseClosed,
+        new Promise((_, reject) => setTimeout(() => reject(new Error('legacy MCP response did not close')), 500)),
+      ]);
+    } finally {
+      for (const socket of liveSockets) socket.destroy();
+      await Promise.race([closeMCPConnections(), new Promise(resolve => setTimeout(resolve, 1_000))]);
+      await new Promise(resolve => legacyServer.close(resolve));
+    }
+  });
+
+  it('keeps legacy MCP Tasks progress alive beyond requestTimeoutMs', async () => {
+    const { McpServer } = require('@modelcontextprotocol/sdk/server/mcp.js');
+    const { StreamableHTTPServerTransport } = require('@modelcontextprotocol/sdk/server/streamableHttp.js');
+    const { InMemoryTaskStore } = require('../dist/lib/server/tasks.js');
+    const { closeMCPConnections } = require('../dist/lib/protocols/mcp');
+    const taskStore = new InMemoryTaskStore();
+    const liveSockets = new Set();
+    const progressServer = http.createServer(async (req, res) => {
+      const mcp = new McpServer(
+        { name: 'progress-legacy', version: '1.0.0' },
+        {
+          capabilities: { tasks: { list: {}, cancel: {}, requests: { tools: { call: {} } } } },
+          taskStore,
+        }
+      );
+      mcp.experimental.tasks.registerToolTask(
+        'custom_progress_task',
+        {
+          description: 'complete after several progress polls',
+          inputSchema: {},
+          execution: { taskSupport: 'required' },
+        },
+        {
+          createTask: async (_args, extra) => {
+            const task = await extra.taskStore.createTask({ ttl: 60_000, pollInterval: 20 });
+            setTimeout(() => {
+              taskStore.storeTaskResult(task.taskId, 'completed', {
+                content: [{ type: 'text', text: 'done' }],
+                structuredContent: { status: 'completed', ok: true },
+              });
+            }, 250);
+            return { task };
+          },
+          getTask: async (_args, extra) => extra.taskStore.getTask(extra.taskId),
+          getTaskResult: async (_args, extra) => extra.taskStore.getTaskResult(extra.taskId),
+        }
+      );
+      const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+      try {
+        await mcp.connect(transport);
+        await transport.handleRequest(req, res);
+      } finally {
+        await mcp.close();
+      }
+    });
+    progressServer.on('connection', socket => {
+      liveSockets.add(socket);
+      socket.on('close', () => liveSockets.delete(socket));
+    });
+    await new Promise(resolve => progressServer.listen(0, '127.0.0.1', resolve));
+    const { port } = progressServer.address();
+
+    try {
+      const startedAt = Date.now();
+      const result = await callMCPToolWithTasks(
+        `http://127.0.0.1:${port}`,
+        'custom_progress_task',
+        {},
+        undefined,
+        [],
+        undefined,
+        { requestTimeoutMs: 75, workingTimeout: 1_000 }
+      );
+      assert.ok(Date.now() - startedAt > 150, 'task should outlive the one-shot request timeout');
+      assert.strictEqual(result.structuredContent.status, 'completed');
+      assert.strictEqual(result.structuredContent.ok, true);
+    } finally {
+      for (const socket of liveSockets) socket.destroy();
+      await Promise.race([closeMCPConnections(), new Promise(resolve => setTimeout(resolve, 1_000))]);
+      await new Promise(resolve => progressServer.close(resolve));
+    }
+  });
+
   it('rejects invalid requestTimeoutMs values instead of treating them as disabled', async () => {
     const client = new AgentClient(
       { id: 'invalid-timeout-a2a', agent_uri: baseUrl, protocol: 'a2a', name: 'test' },
@@ -312,6 +730,473 @@ describe('read-path cancellation and timeout', () => {
     );
     assert.strictEqual(seenTimeout, 25);
     assert.strictEqual(seenMaxTotalTimeout, undefined);
+  });
+
+  it('keeps TaskOptions.timeout absolute while MCP Tasks emits continuous progress', async () => {
+    const originalCallTool = ProtocolClient.callTool;
+    let progressCount = 0;
+    let transportObservedAbort = false;
+    let resolveAbortObserved;
+    const abortObserved = new Promise(resolve => {
+      resolveAbortObserved = resolve;
+    });
+    const client = {
+      getServerCapabilities: () => ({ tasks: { requests: { tools: { call: true } } } }),
+      listTools: async () => ({ tools: [] }),
+      experimental: {
+        tasks: {
+          callToolStream: (_request, _unused, options) =>
+            (async function* () {
+              yield { type: 'taskCreated', task: { taskId: 'chatty-task', status: 'working' } };
+              while (true) {
+                await new Promise(resolve => setImmediate(resolve));
+                if (options.signal?.aborted) {
+                  transportObservedAbort = true;
+                  resolveAbortObserved();
+                  throw options.signal.reason;
+                }
+                progressCount += 1;
+                yield { type: 'taskStatus', task: { taskId: 'chatty-task', status: 'working' } };
+              }
+            })(),
+        },
+      },
+    };
+
+    ProtocolClient.callTool = (_agent, toolName, params, options) =>
+      callMCPToolWithClient(client, toolName, params, [], {
+        workingTimeout: 1_000,
+        signal: options.signal,
+      });
+
+    try {
+      const executor = new TaskExecutor({ workingTimeout: 1_000 });
+      const startedAt = Date.now();
+      await assert.rejects(
+        () =>
+          executor.executeTask(
+            { id: 'chatty-mcp', name: 'test', protocol: 'mcp', agent_uri: 'http://example.test/mcp' },
+            'custom_chatty_task',
+            {},
+            undefined,
+            { timeout: 100 }
+          ),
+        err => {
+          assert.ok(err instanceof TaskTimeoutError);
+          assert.strictEqual(err.timeout, 100);
+          return true;
+        }
+      );
+      assert.ok(Date.now() - startedAt < 2_000, 'deadline should not reset on progress');
+      assert.ok(progressCount > 1, 'test stream should emit repeated progress');
+      await Promise.race([
+        abortObserved,
+        new Promise((_, reject) => setTimeout(() => reject(new Error('transport did not observe abort')), 500)),
+      ]);
+      assert.strictEqual(transportObservedAbort, true);
+    } finally {
+      ProtocolClient.callTool = originalCallTool;
+    }
+  });
+
+  it('compacts active task state when underlying work ignores cancellation', async () => {
+    const originalCallTool = ProtocolClient.callTool;
+    ProtocolClient.callTool = async () => new Promise(() => {});
+
+    try {
+      const executor = new TaskExecutor();
+      let timeoutError;
+      await assert.rejects(
+        () =>
+          executor.executeTask(
+            { id: 'ignored-cancel', name: 'test', protocol: 'mcp', agent_uri: 'http://example.test/mcp' },
+            'custom_never_settles',
+            { private_payload: 'must-be-released' },
+            undefined,
+            { timeout: 25 }
+          ),
+        err => {
+          timeoutError = err;
+          return err instanceof TaskTimeoutError;
+        }
+      );
+
+      const retained = executor.getActiveTasks().find(task => task.taskId === timeoutError.taskId);
+      assert.ok(retained, 'terminal metadata remains briefly inspectable');
+      assert.strictEqual(retained.status, 'aborted');
+      assert.strictEqual(retained.params, undefined);
+      assert.deepStrictEqual(retained.messages, []);
+      assert.deepStrictEqual(retained.options, {});
+    } finally {
+      ProtocolClient.callTool = originalCallTool;
+    }
+  });
+
+  it('does not resurrect an aborted task when cancellation-ignoring work resolves late', async () => {
+    const originalCallTool = ProtocolClient.callTool;
+    ProtocolClient.callTool = async () => {
+      await new Promise(resolve => setTimeout(resolve, 60));
+      return { structuredContent: { status: 'completed', ok: true } };
+    };
+    const statuses = [];
+
+    try {
+      const executor = new TaskExecutor({
+        onActivity: activity => {
+          if (activity.type === 'status_change') statuses.push(activity.status);
+        },
+      });
+      let timeoutError;
+      await assert.rejects(
+        () =>
+          executor.executeTask(
+            { id: 'late-result', name: 'test', protocol: 'mcp', agent_uri: 'http://example.test/mcp' },
+            'custom_late_result',
+            {},
+            undefined,
+            { timeout: 20 }
+          ),
+        err => {
+          timeoutError = err;
+          return err instanceof TaskTimeoutError;
+        }
+      );
+      await new Promise(resolve => setTimeout(resolve, 80));
+
+      const retained = executor.getActiveTasks().find(task => task.taskId === timeoutError.taskId);
+      assert.strictEqual(retained?.status, 'aborted');
+      assert.strictEqual(statuses.includes('completed'), false);
+    } finally {
+      ProtocolClient.callTool = originalCallTool;
+    }
+  });
+
+  it('does not persist a late deferral after the absolute deadline', async () => {
+    const originalCallTool = ProtocolClient.callTool;
+    const stored = new Map();
+    ProtocolClient.callTool = async () => ({
+      status: 'input-required',
+      question: 'Defer this?',
+      field: 'approval',
+      contextId: 'late-deferral-context',
+    });
+
+    try {
+      const executor = new TaskExecutor({
+        deferredStorage: {
+          set: async (token, value) => stored.set(token, value),
+          get: async token => stored.get(token),
+          delete: async token => stored.delete(token),
+          has: async token => stored.has(token),
+        },
+      });
+      const slowHandler = async () => {
+        await new Promise(resolve => setTimeout(resolve, 60));
+        return { defer: true, token: 'late-token' };
+      };
+
+      await assert.rejects(
+        () =>
+          executor.executeTask(
+            { id: 'late-deferral', name: 'test', protocol: 'mcp', agent_uri: 'http://example.test/mcp' },
+            'custom_input_task',
+            { secret_payload: 'must-not-be-retained' },
+            slowHandler,
+            { timeout: 20 }
+          ),
+        err => err instanceof TaskTimeoutError
+      );
+      await new Promise(resolve => setTimeout(resolve, 80));
+      assert.strictEqual(stored.size, 0);
+    } finally {
+      ProtocolClient.callTool = originalCallTool;
+    }
+  });
+
+  it('clears the task deadline after a fast successful call', async () => {
+    const originalCallTool = ProtocolClient.callTool;
+    let receivedSignal;
+    let receivedLateAbort = false;
+    const caller = new AbortController();
+    const callerSignal = caller.signal;
+    const originalAddEventListener = callerSignal.addEventListener.bind(callerSignal);
+    const originalRemoveEventListener = callerSignal.removeEventListener.bind(callerSignal);
+    let callerAbortListenersAdded = 0;
+    let callerAbortListenersRemoved = 0;
+    callerSignal.addEventListener = (type, listener, options) => {
+      if (type === 'abort') callerAbortListenersAdded += 1;
+      return originalAddEventListener(type, listener, options);
+    };
+    callerSignal.removeEventListener = (type, listener, options) => {
+      if (type === 'abort') callerAbortListenersRemoved += 1;
+      return originalRemoveEventListener(type, listener, options);
+    };
+    ProtocolClient.callTool = async (_agent, _toolName, _params, options) => {
+      receivedSignal = options.signal;
+      options.signal?.addEventListener('abort', () => {
+        receivedLateAbort = true;
+      });
+      return { structuredContent: { status: 'completed', ok: true } };
+    };
+
+    try {
+      const executor = new TaskExecutor();
+      const result = await executor.executeTask(
+        { id: 'fast-mcp', name: 'test', protocol: 'mcp', agent_uri: 'http://example.test/mcp' },
+        'custom_fast_task',
+        {},
+        undefined,
+        { timeout: 20, signal: callerSignal }
+      );
+      assert.strictEqual(result.status, 'completed');
+      assert.ok(receivedSignal);
+      await new Promise(resolve => setTimeout(resolve, 40));
+      assert.strictEqual(receivedLateAbort, false);
+      assert.strictEqual(receivedSignal.aborted, false);
+      assert.strictEqual(callerAbortListenersAdded, callerAbortListenersRemoved);
+    } finally {
+      ProtocolClient.callTool = originalCallTool;
+    }
+  });
+
+  it('treats TaskOptions.timeout 0 as disabled while preserving cancellation', async () => {
+    const originalCallTool = ProtocolClient.callTool;
+    let calls = 0;
+    ProtocolClient.callTool = async () => {
+      calls += 1;
+      return { structuredContent: { status: 'completed', ok: true } };
+    };
+
+    try {
+      const executor = new TaskExecutor();
+      const agent = { id: 'zero-timeout', name: 'test', protocol: 'mcp', agent_uri: 'http://example.test/mcp' };
+      const result = await executor.executeTask(agent, 'custom_fast_task', {}, undefined, { timeout: 0 });
+      assert.strictEqual(result.status, 'completed');
+
+      const controller = new AbortController();
+      controller.abort('already cancelled');
+      await assert.rejects(
+        () => executor.executeTask(agent, 'custom_fast_task', {}, undefined, { timeout: 0, signal: controller.signal }),
+        err => err?.name === 'AbortError' && /already cancelled/.test(err.message)
+      );
+      assert.strictEqual(calls, 1, 'pre-aborted zero-timeout call must not dispatch');
+    } finally {
+      ProtocolClient.callTool = originalCallTool;
+    }
+  });
+
+  it('aborts governance preflight at the absolute deadline', async () => {
+    const originalCallTool = ProtocolClient.callTool;
+    let governanceSignal;
+    let resolveGovernanceAbort;
+    const governanceAbort = new Promise(resolve => {
+      resolveGovernanceAbort = resolve;
+    });
+    ProtocolClient.callTool = async (_agent, toolName, _params, options) => {
+      assert.strictEqual(toolName, 'check_governance');
+      governanceSignal = options.signal;
+      return new Promise((_resolve, reject) => {
+        options.signal.addEventListener(
+          'abort',
+          () => {
+            resolveGovernanceAbort();
+            reject(options.signal.reason);
+          },
+          { once: true }
+        );
+      });
+    };
+
+    try {
+      const executor = new TaskExecutor({
+        governance: {
+          campaign: {
+            agent: { id: 'governance', name: 'governance', protocol: 'mcp', agent_uri: 'http://example.test/mcp' },
+            planId: 'plan-1',
+          },
+        },
+      });
+      await assert.rejects(
+        () =>
+          executor.executeTask(
+            { id: 'seller', name: 'seller', protocol: 'mcp', agent_uri: 'http://example.test/mcp' },
+            'create_media_buy',
+            {},
+            undefined,
+            { timeout: 30 }
+          ),
+        err => err instanceof TaskTimeoutError
+      );
+      await Promise.race([
+        governanceAbort,
+        new Promise((_, reject) => setTimeout(() => reject(new Error('governance did not observe abort')), 500)),
+      ]);
+      assert.strictEqual(governanceSignal.aborted, true);
+    } finally {
+      ProtocolClient.callTool = originalCallTool;
+    }
+  });
+
+  it('exposes governance postflight retry identity on deadline errors', async () => {
+    const originalCallTool = ProtocolClient.callTool;
+    const outcomeRequests = [];
+    const statuses = [];
+    ProtocolClient.callTool = async (_agent, toolName, params) => {
+      if (toolName === 'check_governance') {
+        return {
+          structuredContent: {
+            check_id: 'check-recovery-1',
+            verdict: 'approved',
+            governance_context: 'governance-context-1',
+          },
+        };
+      }
+      if (toolName === 'report_plan_outcome') {
+        outcomeRequests.push(params);
+        if (outcomeRequests.length === 1) return new Promise(() => {});
+        return { structuredContent: { outcome_id: 'outcome-1', outcome_state: 'accepted' } };
+      }
+      return { structuredContent: { status: 'completed', ok: true } };
+    };
+
+    try {
+      const executor = new TaskExecutor({
+        onActivity: activity => {
+          if (activity.type === 'status_change') statuses.push(activity.status);
+        },
+        governance: {
+          campaign: {
+            agent: { id: 'governance', name: 'governance', protocol: 'mcp', agent_uri: 'http://example.test/mcp' },
+            planId: 'plan-1',
+          },
+        },
+      });
+      let recovery;
+      let timeoutError;
+      await assert.rejects(
+        () =>
+          executor.executeTask(
+            { id: 'seller', name: 'seller', protocol: 'mcp', agent_uri: 'http://example.test/mcp' },
+            'custom_governed_mutation',
+            {},
+            undefined,
+            { timeout: 30 }
+          ),
+        err => {
+          assert.ok(err instanceof TaskTimeoutError);
+          timeoutError = err;
+          recovery = err.governanceRecovery;
+          return true;
+        }
+      );
+
+      assert.deepStrictEqual(recovery, {
+        checkId: 'check-recovery-1',
+        outcome: 'completed',
+        outcomeIdempotencyKey: outcomeRequests[0].idempotency_key,
+      });
+      assert.strictEqual(statuses.includes('aborted'), false);
+      assert.strictEqual(
+        executor.getActiveTasks().find(task => task.taskId === timeoutError?.taskId)?.status,
+        'completed'
+      );
+      const middleware = executor.getGovernanceMiddleware();
+      const retried = await middleware.reportOutcome(
+        recovery.checkId,
+        recovery.outcome,
+        { status: 'completed', ok: true },
+        undefined,
+        [],
+        'governance-context-1',
+        undefined,
+        recovery.outcomeIdempotencyKey
+      );
+      assert.strictEqual(retried.status, 'accepted');
+      assert.strictEqual(outcomeRequests[1].idempotency_key, recovery.outcomeIdempotencyKey);
+    } finally {
+      ProtocolClient.callTool = originalCallTool;
+    }
+  });
+
+  it('preserves the governance check id when response processing exceeds the deadline', async () => {
+    const originalCallTool = ProtocolClient.callTool;
+    ProtocolClient.callTool = async (_agent, toolName) => {
+      if (toolName === 'check_governance') {
+        return {
+          structuredContent: {
+            check_id: 'check-before-response-processing',
+            verdict: 'approved',
+            governance_context: 'governance-context-2',
+          },
+        };
+      }
+      return { structuredContent: { status: 'completed', ok: true } };
+    };
+
+    try {
+      const executor = new TaskExecutor({
+        onActivity: async activity => {
+          if (activity.type === 'protocol_response') {
+            await new Promise(resolve => setTimeout(resolve, 60));
+          }
+        },
+        governance: {
+          campaign: {
+            agent: { id: 'governance', name: 'governance', protocol: 'mcp', agent_uri: 'http://example.test/mcp' },
+            planId: 'plan-1',
+          },
+        },
+      });
+
+      await assert.rejects(
+        () =>
+          executor.executeTask(
+            { id: 'seller', name: 'seller', protocol: 'mcp', agent_uri: 'http://example.test/mcp' },
+            'custom_governed_mutation',
+            {},
+            undefined,
+            { timeout: 20 }
+          ),
+        err => {
+          assert.ok(err instanceof TaskTimeoutError);
+          assert.deepStrictEqual(err.governanceRecovery, { checkId: 'check-before-response-processing' });
+          return true;
+        }
+      );
+    } finally {
+      ProtocolClient.callTool = originalCallTool;
+    }
+  });
+
+  it('attaches idempotency keys to TaskOptions deadline errors', async () => {
+    const originalCallTool = ProtocolClient.callTool;
+    ProtocolClient.callTool = async (_agent, _toolName, _params, options) =>
+      new Promise((_resolve, reject) => {
+        options.signal.addEventListener('abort', () => reject(options.signal.reason), { once: true });
+      });
+
+    try {
+      const executor = new TaskExecutor();
+      await assert.rejects(
+        () =>
+          executor.executeTask(
+            { id: 'deadline-mutating', name: 'test', protocol: 'mcp', agent_uri: 'http://example.test/mcp' },
+            'create_media_buy',
+            { buyer_ref: 'buyer-1', packages: [] },
+            undefined,
+            { timeout: 25 }
+          ),
+        err => {
+          assert.ok(err instanceof TaskTimeoutError);
+          assert.match(err.taskId, /^[0-9a-f-]{36}$/);
+          assert.ok(err.idempotency_key);
+          assert.strictEqual(err.idempotencyKey, err.idempotency_key);
+          return true;
+        }
+      );
+    } finally {
+      ProtocolClient.callTool = originalCallTool;
+    }
   });
 
   it('attaches generated idempotency keys to mutating timeout errors', async () => {


### PR DESCRIPTION
Closes #2453.

Previously, `TaskOptions.timeout` began too low in the execution stack, so discovery, capability checks, handlers, and 401 diagnostics could outlive the advertised task deadline.

This adds one absolute lifecycle deadline with cancellation propagation and cleanup across A2A, MCP, OAuth, governance, and client-credentials refresh, while preserving progress-resettable `workingTimeout` semantics and exposing typed retry/recovery metadata.

Validated by 261 focused tests, TypeScript checks, the full library build, formatting checks, and independent code, protocol, and security expert reviews.
