### PR TITLE
fix(testing): make local creative scenario fixture schema-valid

### DIFF
--- a/.changeset/fix-creative-scenario-fixture-schema-valid.md
+++ b/.changeset/fix-creative-scenario-fixture-schema-valid.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Fix `testCreativeSync()` fixture to be schema-valid: add `asset_type: 'image'` discriminator on `assets.primary`, preserve `agent_url` in the string-format fallback path via object spread, and add `idempotency_key` to the `sync_creatives` call envelope.

--- a/src/lib/testing/scenarios/media-buy.ts
+++ b/src/lib/testing/scenarios/media-buy.ts
@@ -8,6 +8,8 @@
  * - sync_creatives
  */
 
+import { randomUUID } from 'crypto';
+
 import type {
   AccountReference,
   SyncCreativesSuccess,
@@ -784,7 +786,7 @@ export async function testCreativeSync(
       const firstFormat = formatIds?.[0] || formats?.[0];
       if (firstFormat) {
         if (typeof firstFormat === 'string') {
-          formatId = { ...formatId, id: firstFormat };
+          formatId = { agent_url: agentUrl, id: firstFormat };
         } else {
           const formatObj = firstFormat as Record<string, unknown>;
           formatId = (formatObj.format_id as Record<string, unknown>) || formatObj;
@@ -797,7 +799,7 @@ export async function testCreativeSync(
   // Assets must be an object keyed by asset_role, not an array
   const syncKey = generateIdempotencyKey();
   const testCreative = {
-    creative_id: `test-creative-${syncKey}`,
+    creative_id: `test-creative-${randomUUID()}`,
     name: 'E2E Test Creative',
     format_id: formatId,
     assets: {

--- a/src/lib/testing/scenarios/media-buy.ts
+++ b/src/lib/testing/scenarios/media-buy.ts
@@ -27,6 +27,7 @@ import {
 } from '../client';
 import { testDiscovery } from './discovery';
 import { getAuthoritativeMediaBuyStatus } from '../../utils/media-buy-status';
+import { generateIdempotencyKey } from '../../utils/idempotency';
 
 /**
  * Find a suitable product for testing based on options
@@ -783,7 +784,7 @@ export async function testCreativeSync(
       const firstFormat = formatIds?.[0] || formats?.[0];
       if (firstFormat) {
         if (typeof firstFormat === 'string') {
-          formatId = { id: firstFormat };
+          formatId = { ...formatId, id: firstFormat };
         } else {
           const formatObj = firstFormat as Record<string, unknown>;
           formatId = (formatObj.format_id as Record<string, unknown>) || formatObj;
@@ -794,12 +795,14 @@ export async function testCreativeSync(
 
   // Test sync_creatives with a simple creative
   // Assets must be an object keyed by asset_role, not an array
+  const syncKey = generateIdempotencyKey();
   const testCreative = {
-    creative_id: `test-creative-${Date.now()}`,
+    creative_id: `test-creative-${syncKey}`,
     name: 'E2E Test Creative',
     format_id: formatId,
     assets: {
       primary: {
+        asset_type: 'image' as const,
         url: 'https://via.placeholder.com/300x250',
         width: 300,
         height: 250,
@@ -815,6 +818,7 @@ export async function testCreativeSync(
       client.syncCreatives({
         account: accountRef,
         creatives: [testCreative],
+        idempotency_key: syncKey,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any -- intentional: test request bypasses strict typing
       } as any) as Promise<TaskResult>
   );

--- a/test/lib/creative-scenario-fixture-validation.test.js
+++ b/test/lib/creative-scenario-fixture-validation.test.js
@@ -10,6 +10,9 @@ const { test, describe } = require('node:test');
 const assert = require('node:assert');
 
 const { validateRequest } = require('../../dist/lib/validation');
+const { testCreativeSync } = require('../../dist/lib/testing');
+
+const SELLER_URL = 'https://seller.example/mcp';
 
 // Mirrors the default formatId initialised in testCreativeSync()
 const DEFAULT_FORMAT_ID = {
@@ -50,13 +53,41 @@ describe('creative scenario fixture schema validity (issue #2460)', () => {
     assert.strictEqual(BASE_CREATIVE.assets.primary.asset_type, 'image');
   });
 
-  test('string-format fallback preserves agent_url', () => {
-    const initialFormatId = { ...DEFAULT_FORMAT_ID };
+  test('testCreativeSync sends its schema-valid fixture with a seller-owned string format ID', async () => {
     const stringFormatFromAgent = 'video_1920x1080';
-    // Simulates: formatId = { ...formatId, id: firstFormat }
-    const result = { ...initialFormatId, id: stringFormatFromAgent };
-    assert.strictEqual(result.agent_url, DEFAULT_FORMAT_ID.agent_url, 'agent_url must be preserved');
-    assert.strictEqual(result.id, stringFormatFromAgent, 'id must be updated');
+    let syncRequest;
+    const client = {
+      listCreativeFormatsLegacy: async () => ({
+        success: true,
+        data: { format_ids: [stringFormatFromAgent], formats: [] },
+      }),
+      syncCreatives: async request => {
+        syncRequest = request;
+        return { success: true, data: { creatives: [] } };
+      },
+    };
+
+    await testCreativeSync(SELLER_URL, {
+      sandbox: true,
+      _client: client,
+      _profile: { tools: ['list_creative_formats', 'sync_creatives'] },
+    });
+
+    assert.ok(syncRequest, 'testCreativeSync must dispatch sync_creatives');
+    assert.deepStrictEqual(syncRequest.creatives[0].format_id, {
+      agent_url: SELLER_URL,
+      id: stringFormatFromAgent,
+    });
+    assert.strictEqual(syncRequest.creatives[0].assets.primary.asset_type, 'image');
+    assert.match(syncRequest.creatives[0].creative_id, /^test-creative-[0-9a-f-]{36}$/);
+    assert.notStrictEqual(syncRequest.creatives[0].creative_id, `test-creative-${syncRequest.idempotency_key}`);
+
+    const outcome = validateRequest('sync_creatives', syncRequest);
+    assert.strictEqual(
+      outcome.valid,
+      true,
+      `Expected actual scenario request to be schema-valid, got: ${JSON.stringify(outcome.issues, null, 2)}`
+    );
   });
 
   test('sync_creatives envelope with fixture validates against published schema', () => {

--- a/test/lib/creative-scenario-fixture-validation.test.js
+++ b/test/lib/creative-scenario-fixture-validation.test.js
@@ -1,0 +1,102 @@
+// Regression test for issue #2460: local creative scenario fixture must be schema-valid.
+//
+// The testCreativeSync() fixture in src/lib/testing/scenarios/media-buy.ts was
+// missing asset_type: "image" on assets.primary, agent_url in the string-format
+// fallback path, and idempotency_key on the sync_creatives call envelope.
+// This file validates the canonical fixture shape against the published schema
+// so future regressions are caught at build time.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+
+const { validateRequest } = require('../../dist/lib/validation');
+
+// Mirrors the default formatId initialised in testCreativeSync()
+const DEFAULT_FORMAT_ID = {
+  agent_url: 'https://creative.adcontextprotocol.org',
+  id: 'display_300x250',
+};
+
+// Mirrors the testCreative const built inside testCreativeSync() after the fix.
+const BASE_CREATIVE = {
+  creative_id: 'test-creative-fixture-regression',
+  name: 'E2E Test Creative',
+  format_id: DEFAULT_FORMAT_ID,
+  assets: {
+    primary: {
+      asset_type: 'image',
+      url: 'https://via.placeholder.com/300x250',
+      width: 300,
+      height: 250,
+      format: 'png',
+    },
+  },
+};
+
+// Minimal valid sync_creatives envelope that wraps the fixture.
+const BASE_ENVELOPE = {
+  account: { account_id: 'test-account' },
+  creatives: [BASE_CREATIVE],
+  idempotency_key: 'test-sync-creative-regression-001',
+};
+
+describe('creative scenario fixture schema validity (issue #2460)', () => {
+  test('default format_id has agent_url', () => {
+    assert.ok(typeof DEFAULT_FORMAT_ID.agent_url === 'string', 'agent_url must be a string');
+    assert.ok(DEFAULT_FORMAT_ID.agent_url.startsWith('https://'), 'agent_url must be https');
+  });
+
+  test('fixture asset has asset_type discriminator', () => {
+    assert.strictEqual(BASE_CREATIVE.assets.primary.asset_type, 'image');
+  });
+
+  test('string-format fallback preserves agent_url', () => {
+    const initialFormatId = { ...DEFAULT_FORMAT_ID };
+    const stringFormatFromAgent = 'video_1920x1080';
+    // Simulates: formatId = { ...formatId, id: firstFormat }
+    const result = { ...initialFormatId, id: stringFormatFromAgent };
+    assert.strictEqual(result.agent_url, DEFAULT_FORMAT_ID.agent_url, 'agent_url must be preserved');
+    assert.strictEqual(result.id, stringFormatFromAgent, 'id must be updated');
+  });
+
+  test('sync_creatives envelope with fixture validates against published schema', () => {
+    const outcome = validateRequest('sync_creatives', BASE_ENVELOPE);
+    assert.strictEqual(
+      outcome.valid,
+      true,
+      `Expected no schema issues, got: ${JSON.stringify(outcome.issues, null, 2)}`
+    );
+  });
+
+  test('fixture without asset_type fails schema validation', () => {
+    const brokenCreative = {
+      ...BASE_CREATIVE,
+      assets: {
+        primary: {
+          // asset_type intentionally omitted — reproduces the pre-fix bug
+          url: 'https://via.placeholder.com/300x250',
+          width: 300,
+          height: 250,
+          format: 'png',
+        },
+      },
+    };
+    const outcome = validateRequest('sync_creatives', { ...BASE_ENVELOPE, creatives: [brokenCreative] });
+    assert.strictEqual(outcome.valid, false, 'Expected schema validation to fail without asset_type');
+  });
+
+  test('envelope without idempotency_key fails schema validation', () => {
+    const { idempotency_key, ...envelopeWithoutKey } = BASE_ENVELOPE;
+    const outcome = validateRequest('sync_creatives', envelopeWithoutKey);
+    assert.strictEqual(outcome.valid, false, 'Expected schema validation to fail without idempotency_key');
+  });
+
+  test('format_id without agent_url fails schema validation', () => {
+    const brokenCreative = {
+      ...BASE_CREATIVE,
+      format_id: { id: 'display_300x250' }, // agent_url intentionally omitted
+    };
+    const outcome = validateRequest('sync_creatives', { ...BASE_ENVELOPE, creatives: [brokenCreative] });
+    assert.strictEqual(outcome.valid, false, 'Expected schema validation to fail without agent_url in format_id');
+  });
+});


### PR DESCRIPTION
## Summary

- add the required `asset_type: "image"` discriminator to the `testCreativeSync` image fixture
- reconstruct bare format IDs with the seller agent URL that advertised them
- add the required `idempotency_key` while keeping it independent from the rendered creative ID
- exercise the actual scenario through an injected test client and validate its captured request against the published schema

## Root cause

The local scenario assembled a request that omitted required schema fields before seller dispatch. Its string-format fallback also assigned seller-advertised IDs to the hardcoded AAO namespace.

## Validation

- `npm run build`
- `NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/lib/creative-scenario-fixture-validation.test.js` (7/7)
- `git diff --check`

The remaining inline-creative and non-string format-object paths are handled by follow-up #2473.

Closes #2460
