### PR TITLE
fix(testing): honor canonical storyboard wire hints

### DIFF
--- a/.changeset/fix-storyboard-canonical-wire-selection.md
+++ b/.changeset/fix-storyboard-canonical-wire-selection.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Honor explicit canonical creative-wire requests in pre-3.2 storyboards and use canonical product catalogs for fixture discovery.

--- a/src/lib/testing/storyboard/seeding.ts
+++ b/src/lib/testing/storyboard/seeding.ts
@@ -853,6 +853,8 @@ async function discoverProductCatalog(
       brand,
       account,
       pagination: { max_results: 100, ...(cursor && { cursor }) },
+      // Fixture match declarations target the canonical product shape.
+      ext: { adcp: { creative_wire: 'canonical' } },
     };
     let result;
     try {

--- a/src/lib/testing/storyboard/task-map.test.ts
+++ b/src/lib/testing/storyboard/task-map.test.ts
@@ -87,6 +87,31 @@ describe('executeStoryboardTask — adcp_error forwarding', () => {
     expect(result.data).toEqual({ products: [], format: 'canonical' });
   });
 
+  it('honors an explicit canonical wire request when grading a pre-3.2 storyboard', async () => {
+    const calls: string[] = [];
+    let receivedParams: unknown;
+    const params = {
+      ext: { adcp: { creative_wire: 'canonical', storyboard_marker: true } },
+    };
+    const client = {
+      getAdcpVersion: () => '3.1.10',
+      getProducts: async (request: unknown) => {
+        calls.push('canonical');
+        receivedParams = request;
+        return { data: { products: [], format: 'canonical' } };
+      },
+      getProductsLegacy: async () => {
+        calls.push('legacy');
+        return { data: { products: [], format: 'legacy' } };
+      },
+    };
+
+    const result = await executeStoryboardTask(client, 'get_products', params);
+    expect(calls).toEqual(['canonical']);
+    expect(receivedParams).toBe(params);
+    expect(result.data).toEqual({ products: [], format: 'canonical' });
+  });
+
   it('forwards adcpError from a TaskResultFailure into adcp_error', async () => {
     const client = makeFailureClient(INVALID_REQUEST_ERROR);
     const result = await executeStoryboardTask(client, 'create_media_buy', {});

--- a/src/lib/testing/storyboard/task-map.ts
+++ b/src/lib/testing/storyboard/task-map.ts
@@ -102,10 +102,16 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
+function readCreativeWireHint(params: Record<string, unknown>): 'legacy' | 'canonical' | undefined {
+  if (!isRecord(params.ext) || !isRecord(params.ext.adcp)) return undefined;
+  const wire = params.ext.adcp.creative_wire;
+  return wire === 'legacy' || wire === 'canonical' ? wire : undefined;
+}
+
 function withLegacyCreativeWireHint(params: Record<string, unknown>): Record<string, unknown> {
+  if (readCreativeWireHint(params)) return params;
   const ext = isRecord(params.ext) ? params.ext : {};
   const adcp = isRecord(ext.adcp) ? ext.adcp : {};
-  if (adcp.creative_wire === 'legacy' || adcp.creative_wire === 'canonical') return params;
   return {
     ...params,
     ext: {
@@ -171,7 +177,10 @@ export async function executeStoryboardTask(
   params: Record<string, unknown>,
   opts: { skipIdempotencyAutoInject?: boolean; skipAccountValidation?: boolean; signal?: AbortSignal } = {}
 ): Promise<TaskResult> {
-  const legacyMethodName = gradesLegacyCreativeWire(client) ? LEGACY_CREATIVE_TASK_TO_METHOD[taskName] : undefined;
+  // AdCP 3.1 transition storyboards default to the legacy creative wire, but
+  // canonical-specific storyboards must be able to opt into the canonical API.
+  const useLegacyCreativeMethod = gradesLegacyCreativeWire(client) && readCreativeWireHint(params) !== 'canonical';
+  const legacyMethodName = useLegacyCreativeMethod ? LEGACY_CREATIVE_TASK_TO_METHOD[taskName] : undefined;
   const methodName =
     legacyMethodName ?? (Object.hasOwn(TASK_TO_METHOD, taskName) ? TASK_TO_METHOD[taskName] : undefined);
   const callParams = legacyMethodName ? withLegacyCreativeWireHint(params) : params;

--- a/test/lib/storyboard-fixture-resolution.test.js
+++ b/test/lib/storyboard-fixture-resolution.test.js
@@ -448,6 +448,7 @@ describe('discover strategy state machine', () => {
     const second = discoveryClient([product('a-product'), product('z-product')]);
     const a = await runControllerSeeding(first.client, sb, { agentTools: ['get_products'] }, {});
     const b = await runControllerSeeding(second.client, sb, { agentTools: ['get_products'] }, {});
+    assert.deepEqual(first.calls[0].params.ext, { adcp: { creative_wire: 'canonical' } });
     assert.equal(a.resolutionRecords[0].seller_ids.product_id, 'a-product');
     assert.deepEqual(a.resolutionRecords, b.resolutionRecords);
   });

--- a/test/lib/storyboard-task-map-error.test.js
+++ b/test/lib/storyboard-task-map-error.test.js
@@ -63,3 +63,52 @@ describe('executeStoryboardTask error normalization', () => {
     assert.deepEqual(result.data.errors, [{ code: 'GOVERNANCE_OBSERVATION', message: 'queued with advisory' }]);
   });
 });
+
+describe('executeStoryboardTask creative wire selection', () => {
+  test('uses the canonical method for an explicit canonical 3.1 request', async () => {
+    const calls = [];
+    const params = { ext: { adcp: { creative_wire: 'canonical' } } };
+    const result = await executeStoryboardTask(
+      {
+        getAdcpVersion: () => '3.1.10',
+        getProducts: async request => {
+          calls.push({ method: 'canonical', request });
+          return { data: { products: [], wire: 'canonical' } };
+        },
+        getProductsLegacy: async request => {
+          calls.push({ method: 'legacy', request });
+          return { data: { products: [], wire: 'legacy' } };
+        },
+      },
+      'get_products',
+      params
+    );
+
+    assert.deepEqual(calls, [{ method: 'canonical', request: params }]);
+    assert.equal(result.data.wire, 'canonical');
+  });
+
+  test('retains the legacy default for an unhinted 3.1 request', async () => {
+    const calls = [];
+    const result = await executeStoryboardTask(
+      {
+        getAdcpVersion: () => '3.1.10',
+        getProducts: async request => {
+          calls.push({ method: 'canonical', request });
+          return { data: { products: [], wire: 'canonical' } };
+        },
+        getProductsLegacy: async request => {
+          calls.push({ method: 'legacy', request });
+          return { data: { products: [], wire: 'legacy' } };
+        },
+      },
+      'get_products',
+      {}
+    );
+
+    assert.deepEqual(calls, [
+      { method: 'legacy', request: { ext: { adcp: { creative_wire: 'legacy' } } } },
+    ]);
+    assert.equal(result.data.wire, 'legacy');
+  });
+});

--- a/test/lib/storyboard-task-map-error.test.js
+++ b/test/lib/storyboard-task-map-error.test.js
@@ -106,9 +106,7 @@ describe('executeStoryboardTask creative wire selection', () => {
       {}
     );
 
-    assert.deepEqual(calls, [
-      { method: 'legacy', request: { ext: { adcp: { creative_wire: 'legacy' } } } },
-    ]);
+    assert.deepEqual(calls, [{ method: 'legacy', request: { ext: { adcp: { creative_wire: 'legacy' } } } }]);
     assert.equal(result.data.wire, 'legacy');
   });
 });


### PR DESCRIPTION
Honor explicit ext.adcp.creative_wire: canonical requests in pre-3.2 storyboard dispatch while retaining the legacy default for unhinted requests. Fixture discovery now requests canonical product catalogs so handle matchers do not fail on lossy legacy projection. Regression coverage exercises both selection modes and canonical fixture discovery, with a patch changeset included. Validation: npm run build:lib; npm run test:lib:fast (10,309 passed, 7 skipped); pre-push typecheck and build. Fixes #2456.