### PR TITLE
fix(storyboard): grade missing webhook receiver as not applicable

### DIFF
--- a/.changeset/fix-webhook-receiver-rollup.md
+++ b/.changeset/fix-webhook-receiver-rollup.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Grade webhook receiver storyboards as not applicable when no replay receiver URL is configured, instead of reporting an all-skipped run as failing.

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -3309,11 +3309,11 @@ async function executeStoryboardPass(
     }
   }
 
-  // Overall pass requires (a) no required-phase failures AND (b) at least one
-  // required phase actually passed with at least one non-skipped step AND
-  // (c) no assertion failures. Without (b) a storyboard where every phase is
-  // marked optional and every required phase's steps are individually skipped
-  // (e.g. all steps have requires_tool and none matched) would pass vacuously.
+  // Overall pass requires (a) no required-phase failures, (b) either an
+  // executed pass or every required phase grading canonically not_applicable,
+  // and (c) no assertion failures. Without (b), a storyboard where every phase
+  // is optional or every required step is skipped for another reason (for
+  // example, missing_tool) would pass vacuously.
   // (c) makes assertions gating — a run with all validations green but a
   // cross-step invariant broken is not conformant.
   // When no phases had executable steps the storyboard result is a skip, not a
@@ -3328,6 +3328,17 @@ async function executeStoryboardPass(
     return p.steps.some(s => !s.skipped && s.passed);
   });
   const requiredPhaseDefs = storyboard.phases.filter(phaseDef => !phaseDef.optional);
+  const requiredPhasesNotApplicable =
+    requiredPhaseDefs.length > 0 &&
+    requiredPhaseDefs.every(phaseDef => {
+      const phaseResult = phaseResults.find(p => p.phase_id === phaseDef.id);
+      return (
+        !!phaseResult &&
+        phaseResult.passed &&
+        phaseResult.steps.length > 0 &&
+        phaseResult.steps.every(step => step.skipped && step.skip?.reason === 'not_applicable')
+      );
+    });
   const requiredPhasesCoveredByCapabilityGates =
     phaseCapabilitySkippedIds.size > 0 &&
     requiredPhaseDefs.length > 0 &&
@@ -3339,6 +3350,7 @@ async function executeStoryboardPass(
   const requiredPhasesPassed =
     !hasExecutableSteps ||
     requiredPhaseHasExecutedPass ||
+    requiredPhasesNotApplicable ||
     (failedCount === 0 && requiredPhasesCoveredByCapabilityGates);
   const storyboardWideFixtureUnavailable = (seedingUnsupported || fixtureUnsatisfied) && failedCount === 0;
   // Prepend the pre-flight seeding phase now that every consumer that

--- a/test/lib/storyboard-webhook-receiver.test.js
+++ b/test/lib/storyboard-webhook-receiver.test.js
@@ -1000,13 +1000,74 @@ describe('runStoryboard: replay_webhook_vector', () => {
     assert.ok(step.validations.some(v => v.check === 'webhook_replay_payload_schema' && v.passed === true));
   });
 
-  test('grades not_applicable when no replay receiver URL is configured', async () => {
+  test('grades the storyboard not applicable when no replay receiver URL is configured', async () => {
+    const steps = [
+      {
+        id: 'post_delivery_report_envelope',
+        title: 'POST delivery report inside MCP webhook envelope',
+        task: 'replay_webhook_vector',
+        vector_ref: 'static/test-vectors/webhook-receiver-envelope.json#positive/mcp-delivery-report-envelope',
+      },
+      {
+        id: 'post_same_event_retry',
+        title: 'POST retry with same idempotency_key',
+        task: 'replay_webhook_vector',
+        vector_ref:
+          'static/test-vectors/webhook-receiver-envelope.json#positive/mcp-delivery-report-retry-same-idempotency-key',
+      },
+      {
+        id: 'reject_bare_delivery_result',
+        title: 'Reject top-level notification_type result',
+        task: 'replay_webhook_vector',
+        vector_ref: 'static/test-vectors/webhook-receiver-envelope.json#negative/bare-delivery-result',
+      },
+      {
+        id: 'reject_missing_idempotency_key',
+        title: 'Reject envelope without idempotency_key',
+        task: 'replay_webhook_vector',
+        vector_ref: 'static/test-vectors/webhook-receiver-envelope.json#negative/missing-idempotency-key',
+      },
+      {
+        id: 'reject_unsupported_status',
+        title: 'Reject media buy status used as webhook status',
+        task: 'replay_webhook_vector',
+        vector_ref: 'static/test-vectors/webhook-receiver-envelope.json#negative/unsupported-top-level-status',
+      },
+    ];
+    const storyboard = storyboardWith(steps);
+    storyboard.phases = [
+      { id: 'positive_envelope_replay', title: 'Accept canonical webhook envelopes', steps: steps.slice(0, 2) },
+      { id: 'negative_envelope_rejections', title: 'Reject invalid webhook envelopes', steps: steps.slice(2) },
+    ];
+
+    const result = await runStoryboard('http://127.0.0.1:9/mcp', storyboard, {
+      ...RUN_OPTIONS_BASE,
+      agentTools: [],
+    });
+
+    assert.strictEqual(result.overall_passed, true);
+    assert.strictEqual(result.failed_count, 0);
+    assert.strictEqual(result.skipped_count, 5);
+    assert.strictEqual(result.phases.length, 2);
+    for (const step of result.phases.flatMap(phase => phase.steps)) {
+      assert.strictEqual(step.skipped, true);
+      assert.strictEqual(step.skip.reason, 'not_applicable');
+      assert.match(step.skip.detail, /webhook_replay_receiver\.url/);
+    }
+  });
+
+  test('does not pass vacuously when another required step has a non-applicable skip reason', async () => {
     const storyboard = storyboardWith([
       {
         id: 'post_delivery_report_envelope',
         title: 'POST delivery report inside MCP webhook envelope',
         task: 'replay_webhook_vector',
         vector_ref: 'static/test-vectors/webhook-receiver-envelope.json#positive/mcp-delivery-report-envelope',
+      },
+      {
+        id: 'missing_agent_tool',
+        title: 'Missing agent tool',
+        task: 'missing_agent_tool',
       },
     ]);
 
@@ -1015,9 +1076,12 @@ describe('runStoryboard: replay_webhook_vector', () => {
       agentTools: [],
     });
 
-    const step = result.phases[0].steps[0];
-    assert.strictEqual(step.skipped, true);
-    assert.strictEqual(step.skip.reason, 'not_applicable');
-    assert.match(step.skip.detail, /webhook_replay_receiver\.url/);
+    assert.strictEqual(result.overall_passed, false);
+    assert.strictEqual(result.failed_count, 0);
+    assert.strictEqual(result.skipped_count, 2);
+    assert.deepStrictEqual(
+      result.phases[0].steps.map(step => step.skip.reason),
+      ['not_applicable', 'missing_tool']
+    );
   });
 });


### PR DESCRIPTION
## Summary

- treat required storyboard phases whose steps are all canonically `not_applicable` as covered
- preserve the vacuous-pass guard for `missing_tool` and other skip reasons
- add a patch changeset and regression coverage matching the two-phase, five-step webhook receiver storyboard

## Root cause

`replay_webhook_vector` correctly skipped each step as `not_applicable` when no receiver URL was configured, but the storyboard rollup required a non-skipped passing step. That converted the intentionally all-skipped storyboard into `overall_passed: false`.

## Impact

Agents that are not configured as buyer/orchestrator webhook receivers no longer show a spurious failing storyboard. Actual failures and non-applicability skip mixtures remain non-passing.

Closes #2356.

## Validation

- protocol, code, and Node.js testing expert reviews
- 67 targeted storyboard tests passed
- Prettier and `git diff --check` passed
- PR title validated with `.github/scripts/check-pr-title.cjs`
