### PR TITLE
fix(testing): skip webhook replay storyboards without receiver

### DIFF
--- a/.changeset/fix-webhook-replay-receiver-gate.md
+++ b/.changeset/fix-webhook-replay-receiver-gate.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Grade webhook replay storyboards as not applicable when no inbound receiver URL is configured.

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -1089,6 +1089,21 @@ async function runStoryboardBody(
     );
   }
 
+  // Applicability gates must run before either multi-instance strategy.
+  // In particular, multi-pass performs discovery and aggregates per-replica
+  // counts, while a missing runtime requirement is one whole-storyboard skip.
+  const allRequires = resolveStoryboardRequires(storyboard, options);
+  if (allRequires.length) {
+    const unmet = checkRequires(allRequires, storyboard, options, options._profile);
+    if (unmet) {
+      const resultAgentUrls = options.agents ? Object.values(options.agents).map(e => e.url) : agentUrls;
+      return {
+        ...buildRequirementUnmetResult(resultAgentUrls, storyboard, unmet.requirement, unmet.detail),
+        notices: collectCapabilityNotices(storyboard, options._profile?.raw_capabilities),
+      };
+    }
+  }
+
   const requestedStrategy = options.multi_instance_strategy ?? 'round-robin';
   if (requestedStrategy === 'multi-pass' && isMultiInstance) {
     // Webhook receivers bind a fresh ephemeral port per pass. Each pass would
@@ -1105,18 +1120,6 @@ async function runStoryboardBody(
       );
     }
     return runMultiPass(agentUrls, storyboard, options);
-  }
-
-  const allRequires = resolveStoryboardRequires(storyboard, options);
-  if (allRequires.length) {
-    const unmet = checkRequires(allRequires, storyboard, options, options._profile);
-    if (unmet) {
-      const resultAgentUrls = options.agents ? Object.values(options.agents).map(e => e.url) : agentUrls;
-      return {
-        ...buildRequirementUnmetResult(resultAgentUrls, storyboard, unmet.requirement, unmet.detail),
-        notices: collectCapabilityNotices(storyboard, options._profile?.raw_capabilities),
-      };
-    }
   }
 
   if (options.agents) {
@@ -1339,6 +1342,7 @@ const REQUIREMENT_TO_SKIP_REASON: Record<RequirementName, RunnerSkipReason> = {
   seeded_state: 'requirement_unmet',
   real_wire: 'requirement_unmet',
   webhook_receiver: 'requirement_unmet',
+  webhook_replay_receiver: 'not_applicable',
   request_signer: 'not_applicable',
   multi_agent: 'requirement_unmet',
 };
@@ -1498,6 +1502,10 @@ function normalizeAgentToolNames(tools: unknown): string[] | undefined {
  *     Autodetected from step `sample_request` token presence (see
  *     `detectImplicitRequires`); authors don't write this tag manually.
  *     Spec: adcp-client#1678.
+ *   - `webhook_replay_receiver` — operator supplied a non-empty
+ *     `options.webhook_replay_receiver.url`. Autodetected from any
+ *     `replay_webhook_vector` step (see `detectImplicitRequires`); authors
+ *     don't write this tag manually. Spec: adcp-client#2356.
  *   - `request_signer` — agent advertises `request_signing.supported: true`
  *     in `get_adcp_capabilities`. Autodetected for any storyboard whose
  *     id is `'signed_requests'` or that contains a `request_signing_probe`
@@ -1572,6 +1580,19 @@ function checkRequires(
               'Required by the webhook-emission universal: ' +
               'compliance/{version}/universal/webhook-emission.yaml grades not_applicable when ' +
               'no receiver is configured (prerequisites section).',
+          };
+        }
+        break;
+      }
+      case 'webhook_replay_receiver': {
+        if (!options.webhook_replay_receiver?.url) {
+          return {
+            requirement,
+            detail:
+              'Storyboard contains a `replay_webhook_vector` step but no webhook replay receiver URL ' +
+              'is configured. Pass `webhook_replay_receiver.url` in StoryboardRunOptions to run ' +
+              'inbound buyer/orchestrator receiver conformance. Seller agents without an inbound ' +
+              'receiver grade not_applicable for this storyboard.',
           };
         }
         break;
@@ -1684,6 +1705,12 @@ function valueContainsWebhookToken(value: unknown): boolean {
  *     don't need to remember to add `requires: [webhook_receiver]`
  *     separately. Contract-gated synthetic steps only count when their
  *     `requires_contract` is configured for this run. Spec: adcp-client#1678.
+ *   - `'webhook_replay_receiver'`, autodetected from any
+ *     `replay_webhook_vector` step. These vectors target an inbound
+ *     buyer/orchestrator receiver, so without `webhook_replay_receiver.url`
+ *     the whole storyboard grades not_applicable instead of executing an
+ *     all-skipped phase that fails the required-phase rollup. Spec:
+ *     adcp-client#2356.
  *   - `'request_signer'`, autodetected from `storyboard.id ===
  *     'signed_requests'` or any step using the synthesized
  *     `request_signing_probe` task. The signed-requests universal
@@ -1699,16 +1726,17 @@ function detectImplicitRequires(
 ): RequirementName[] {
   const requires: RequirementName[] = [];
   let needsWebhook = false;
+  let needsWebhookReplayReceiver = false;
   let needsSigner = storyboard.id === 'signed_requests';
   const contractsInScope = new Set(options.contracts ?? []);
   for (const phase of storyboard.phases) {
     for (const step of phase.steps) {
-      const rateLimitTripInScope = !step.requires_contract || contractsInScope.has(step.requires_contract);
+      const stepContractInScope = !step.requires_contract || contractsInScope.has(step.requires_contract);
       if (
         !needsWebhook &&
         ((step.sample_request && valueContainsWebhookToken(step.sample_request)) ||
           (step.rate_limit_trip?.trip_target_sample_request &&
-            rateLimitTripInScope &&
+            stepContractInScope &&
             valueContainsWebhookToken(step.rate_limit_trip.trip_target_sample_request)))
       ) {
         needsWebhook = true;
@@ -1716,11 +1744,15 @@ function detectImplicitRequires(
       if (!needsSigner && step.task === 'request_signing_probe') {
         needsSigner = true;
       }
-      if (needsWebhook && needsSigner) break;
+      if (!needsWebhookReplayReceiver && stepContractInScope && step.task === REPLAY_WEBHOOK_VECTOR_TASK) {
+        needsWebhookReplayReceiver = true;
+      }
+      if (needsWebhook && needsWebhookReplayReceiver && needsSigner) break;
     }
-    if (needsWebhook && needsSigner) break;
+    if (needsWebhook && needsWebhookReplayReceiver && needsSigner) break;
   }
   if (needsWebhook) requires.push('webhook_receiver');
+  if (needsWebhookReplayReceiver) requires.push('webhook_replay_receiver');
   if (needsSigner) requires.push('request_signer');
   return requires;
 }
@@ -5452,6 +5484,26 @@ async function executeReplayWebhookVectorStep(
   runState: ExecutionState
 ): Promise<StoryboardStepResult> {
   const start = Date.now();
+  if (step.requires_contract && !new Set(options.contracts ?? []).has(step.requires_contract)) {
+    const detail = `Test-kit contract "${step.requires_contract}" is not configured on this runner.`;
+    const reason: RunnerDetailedSkipReason = 'missing_test_kit_contract';
+    return {
+      step_id: step.id,
+      phase_id: phaseId,
+      title: step.title,
+      task: step.task,
+      passed: true,
+      skipped: true,
+      skip_reason: reason,
+      skip: buildSkip(DETAILED_SKIP_TO_CANONICAL[reason], detail),
+      duration_ms: Date.now() - start,
+      validations: [],
+      context,
+      next: getNextStepPreview(step.id, allSteps, context, runState.runnerVars),
+      extraction: { path: 'none', note: 'test-kit contract not configured' },
+    };
+  }
+
   const receiver = options.webhook_replay_receiver;
   if (!receiver?.url) {
     const detail =

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -84,6 +84,11 @@ export interface Storyboard {
    *     declares this requirement implicitly. Authors do not need to
    *     write `requires: [webhook_receiver]` — the tokens are
    *     self-describing.
+   *   - `webhook_replay_receiver` — the runner must be configured with an
+   *     inbound buyer/orchestrator receiver URL
+   *     (`StoryboardRunOptions.webhook_replay_receiver.url`). Autodetected
+   *     from any `replay_webhook_vector` step and graded not applicable when
+   *     absent. Spec: adcp-client#2356.
    *   - `request_signer` — the agent under test MUST advertise
    *     `request_signing.supported: true` in `get_adcp_capabilities`.
    *     Autodetected: any storyboard whose `id === 'signed_requests'`
@@ -1956,13 +1961,14 @@ export interface RunnerSelectionResult {
  * surface change; coordinate with the upstream spec proposal before
  * extending.
  *
- * Spec: adcp-client#1626, adcp-client#2281.
+ * Spec: adcp-client#1626, adcp-client#2281, adcp-client#2356.
  */
 export type RequirementName =
   | 'controller'
   | 'seeded_state'
   | 'real_wire'
   | 'webhook_receiver'
+  | 'webhook_replay_receiver'
   | 'request_signer'
   | 'multi_agent';
 
@@ -1978,6 +1984,7 @@ export const KNOWN_REQUIREMENTS: ReadonlySet<RequirementName> = new Set([
   'seeded_state',
   'real_wire',
   'webhook_receiver',
+  'webhook_replay_receiver',
   'request_signer',
   'multi_agent',
 ] as const satisfies readonly RequirementName[]);

--- a/test/lib/storyboard-multi-instance.test.js
+++ b/test/lib/storyboard-multi-instance.test.js
@@ -669,6 +669,29 @@ describe('runStoryboard: multi-instance multi-pass', () => {
     );
   });
 
+  test('gates replay_webhook_vector before multi-pass discovery when no receiver is configured', async () => {
+    const storyboard = storyboardWith([
+      {
+        id: 'replay_envelope',
+        title: 'Replay a canonical webhook envelope',
+        task: 'replay_webhook_vector',
+        vector_ref: 'static/test-vectors/webhook-receiver-envelope.json#positive/mcp-delivery-report-envelope',
+      },
+    ]);
+
+    const result = await runStoryboard(['http://127.0.0.1:1/mcp', 'http://127.0.0.1:2/mcp'], storyboard, {
+      ...RUN_OPTIONS_BASE,
+      multi_instance_strategy: 'multi-pass',
+    });
+
+    assert.strictEqual(result.overall_passed, true);
+    assert.strictEqual(result.failed_count, 0);
+    assert.strictEqual(result.skipped_count, 1, 'whole-storyboard applicability skip is not multiplied per replica');
+    assert.strictEqual(result.passes, undefined, 'gate returns before multi-pass discovery and aggregation');
+    assert.strictEqual(result.phases[0].steps[0].skip.reason, 'not_applicable');
+    assert.strictEqual(result.phases[0].steps[0].skip.requirement, 'webhook_replay_receiver');
+  });
+
   test('rotates dispatch across 3 replicas with 3 passes', async () => {
     const shared = new Map();
     const agents = await Promise.all([

--- a/test/lib/storyboard-requires-gate.test.js
+++ b/test/lib/storyboard-requires-gate.test.js
@@ -15,7 +15,11 @@ const { describe, test } = require('node:test');
 const assert = require('node:assert/strict');
 
 const { runStoryboard, runStoryboardStep } = require('../../dist/lib/testing/storyboard/index.js');
-const { parseStoryboard, validateStoryboardShape } = require('../../dist/lib/testing/storyboard/loader.js');
+const {
+  loadStoryboardFile,
+  parseStoryboard,
+  validateStoryboardShape,
+} = require('../../dist/lib/testing/storyboard/loader.js');
 
 function buildStoryboard(overrides = {}) {
   return {
@@ -777,6 +781,113 @@ phases:
 `;
     const parsed = parseStoryboard(yaml);
     assert.deepEqual(parsed.requires, ['webhook_receiver']);
+  });
+});
+
+// ────────────────────────────────────────────────────────────
+// adcp-client#2356: implicit webhook_replay_receiver requirement
+// ────────────────────────────────────────────────────────────
+
+describe('Storyboard.requires gate (#2356): implicit webhook_replay_receiver', () => {
+  test('replay_webhook_vector storyboards grade not_applicable when no receiver URL is configured', async () => {
+    const sb = buildStoryboard({
+      phases: [
+        {
+          id: 'receiver_conformance',
+          title: 'Inbound receiver conformance',
+          steps: [
+            {
+              id: 'replay_envelope',
+              title: 'Replay a canonical webhook envelope',
+              task: 'replay_webhook_vector',
+              vector_ref: 'static/test-vectors/webhook-receiver-envelope.json#positive/mcp-delivery-report-envelope',
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = await runStoryboard('http://fake-local-99999', sb, {
+      _profile: profileWithoutController,
+      agentTools: profileWithoutController.tools,
+    });
+
+    assert.equal(result.overall_passed, true, 'missing receiver URL is an applicability skip, not a failure');
+    assert.equal(result.skipped_count, 1);
+    assert.equal(result.failed_count, 0);
+
+    const step = result.phases[0].steps[0];
+    assert.equal(step.skipped, true);
+    assert.equal(step.skip.reason, 'not_applicable');
+    assert.equal(step.skip.requirement, 'webhook_replay_receiver');
+    assert.match(step.skip.detail, /webhook_replay_receiver\.url/);
+  });
+
+  test('published webhook receiver storyboard skips as one whole scenario before discovery', async () => {
+    const sb = loadStoryboardFile('compliance/cache/latest/universal/webhook-receiver-envelope.yaml');
+
+    const result = await runStoryboard('http://127.0.0.1:1/mcp', sb);
+
+    assert.equal(result.overall_passed, true);
+    assert.equal(result.passed_count, 0);
+    assert.equal(result.failed_count, 0);
+    assert.equal(result.skipped_count, 1, 'five replay steps collapse to one storyboard applicability skip');
+    assert.equal(result.phases.length, 1);
+    assert.equal(result.phases[0].phase_id, 'requirement_unmet');
+    assert.equal(result.phases[0].steps[0].skip.reason, 'not_applicable');
+    assert.equal(result.phases[0].steps[0].skip.requirement, 'webhook_replay_receiver');
+  });
+
+  test('out-of-scope contract-gated replay steps do not skip unrelated phases', async () => {
+    const sb = buildStoryboard({
+      phases: [
+        {
+          id: 'normal',
+          title: 'Normal phase',
+          steps: [
+            {
+              id: 'normal_read',
+              title: 'Normal read still runs',
+              task: 'get_products',
+              sample_request: { buying_mode: 'brief', brief: 'show products' },
+            },
+          ],
+        },
+        {
+          id: 'receiver_contract',
+          title: 'Out-of-scope receiver contract',
+          steps: [
+            {
+              id: 'replay_envelope',
+              title: 'Replay a canonical webhook envelope',
+              task: 'replay_webhook_vector',
+              requires_contract: 'webhook_replay_runner',
+              vector_ref: 'static/test-vectors/webhook-receiver-envelope.json#positive/mcp-delivery-report-envelope',
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = await runStoryboard('http://fake-local-99999', sb, {
+      _profile: profileWithoutController,
+      agentTools: profileWithoutController.tools,
+    });
+
+    assert.ok(
+      !result.phases.some(phase => phase.phase_id === 'requirement_unmet'),
+      'out-of-scope replay step must not trigger the storyboard-level receiver requirement'
+    );
+    assert.ok(
+      result.phases.some(phase => phase.phase_id === 'normal'),
+      'unrelated phase still runs'
+    );
+    const replay = result.phases
+      .find(phase => phase.phase_id === 'receiver_contract')
+      ?.steps.find(step => step.step_id === 'replay_envelope');
+    assert.equal(replay?.skipped, true);
+    assert.equal(replay?.skip_reason, 'missing_test_kit_contract');
+    assert.equal(replay?.skip.reason, 'unsatisfied_contract');
   });
 });
 

--- a/test/lib/storyboard-webhook-receiver.test.js
+++ b/test/lib/storyboard-webhook-receiver.test.js
@@ -1047,16 +1047,17 @@ describe('runStoryboard: replay_webhook_vector', () => {
 
     assert.strictEqual(result.overall_passed, true);
     assert.strictEqual(result.failed_count, 0);
-    assert.strictEqual(result.skipped_count, 5);
-    assert.strictEqual(result.phases.length, 2);
-    for (const step of result.phases.flatMap(phase => phase.steps)) {
-      assert.strictEqual(step.skipped, true);
-      assert.strictEqual(step.skip.reason, 'not_applicable');
-      assert.match(step.skip.detail, /webhook_replay_receiver\.url/);
-    }
+    assert.strictEqual(result.skipped_count, 1);
+    assert.strictEqual(result.phases.length, 1);
+    assert.strictEqual(result.phases[0].phase_id, 'requirement_unmet');
+    const step = result.phases[0].steps[0];
+    assert.strictEqual(step.skipped, true);
+    assert.strictEqual(step.skip.reason, 'not_applicable');
+    assert.strictEqual(step.skip.requirement, 'webhook_replay_receiver');
+    assert.match(step.skip.detail, /webhook_replay_receiver\.url/);
   });
 
-  test('does not pass vacuously when another required step has a non-applicable skip reason', async () => {
+  test('applies the receiver requirement before evaluating unrelated step-level skips', async () => {
     const storyboard = storyboardWith([
       {
         id: 'post_delivery_report_envelope',
@@ -1076,12 +1077,11 @@ describe('runStoryboard: replay_webhook_vector', () => {
       agentTools: [],
     });
 
-    assert.strictEqual(result.overall_passed, false);
+    assert.strictEqual(result.overall_passed, true);
     assert.strictEqual(result.failed_count, 0);
-    assert.strictEqual(result.skipped_count, 2);
-    assert.deepStrictEqual(
-      result.phases[0].steps.map(step => step.skip.reason),
-      ['not_applicable', 'missing_tool']
-    );
+    assert.strictEqual(result.skipped_count, 1);
+    assert.strictEqual(result.phases[0].phase_id, 'requirement_unmet');
+    assert.strictEqual(result.phases[0].steps[0].skip.reason, 'not_applicable');
+    assert.strictEqual(result.phases[0].steps[0].skip.requirement, 'webhook_replay_receiver');
   });
 });


### PR DESCRIPTION
## Summary

- detect `replay_webhook_vector` storyboards as requiring an inbound replay receiver
- skip the whole storyboard as `not_applicable` before discovery or multi-pass aggregation when no receiver URL is configured
- honor test-kit contract scoping before replay dispatch

## Root cause

Missing `webhook_replay_receiver.url` was handled only at the individual step level. When every required step skipped, the required-phase rollup still evaluated false, producing `overall_passed: false` with zero failed steps.

## Impact

Seller and signals agents no longer show a spurious failing webhook-receiver storyboard when the runner is not configured to test a buyer/orchestrator receiver. Configured receiver runs are unchanged.

## Validation

- expert protocol, code-quality, and Node test reviews: ship, no remaining findings
- focused storyboard requirement, multi-instance, and webhook receiver tests
- repository pre-push typecheck and library build

Closes #2356
