### PR TITLE
fix: omit media buy capabilities for creative-only platforms

### DIFF
--- a/.changeset/fix-creative-only-capabilities.md
+++ b/.changeset/fix-creative-only-capabilities.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Omit the media-buy capability block from creative-only platforms unless they explicitly declare media-buy features.

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -6470,7 +6470,8 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
     supported_protocols: protocols as GetAdCPCapabilitiesResponse['supported_protocols'],
   };
 
-  if (protocols.includes('media_buy') || capConfig?.features) {
+  const hasExplicitMediaBuyFeatures = Object.keys(capConfig?.features ?? {}).length > 0;
+  if (protocols.includes('media_buy') || hasExplicitMediaBuyFeatures) {
     capabilitiesData.media_buy = {
       features: {
         ...(capConfig?.features?.canonicalCreatives !== undefined && {

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -1975,7 +1975,9 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
       specialisms: [...platformSpecialisms] as NonNullable<GetAdCPCapabilitiesResponse['specialisms']>,
     }),
     ...(claimsSignedSpecialism && { request_signing: { supported: true as const } }),
-    features: adopterFeatures,
+    ...((hasMediaBuyProjection || Object.keys(adopterFeatureBase).length > 0) && {
+      features: adopterFeatures,
+    }),
     ...(adopterCreative !== undefined && { creative: adopterCreative }),
     ...(adopterAccount !== undefined && { account: adopterAccount }),
     ...(adopterSupportedVersions !== undefined && {
@@ -1984,7 +1986,9 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
     ...(hasOverridesObject && {
       overrides: {
         ...(adopterOverrides ?? {}),
-        media_buy: mergeCapabilityOverride(adopterOverrides?.media_buy, mediaBuyOverrides),
+        ...(hasMediaBuyProjection
+          ? { media_buy: mergeCapabilityOverride(adopterOverrides?.media_buy, mediaBuyOverrides) }
+          : adopterOverrides?.media_buy !== undefined && { media_buy: adopterOverrides.media_buy }),
         ...(hasBrandProjection && {
           brand: mergeCapabilityOverride(adopterOverrides?.brand, brandOverrides),
         }),

--- a/test/server-create-adcp-server.test.js
+++ b/test/server-create-adcp-server.test.js
@@ -588,6 +588,21 @@ describe('createAdcpServer', () => {
       const caps = await callTool(server, 'get_adcp_capabilities', {});
       assert.strictEqual(caps.media_buy.features.inline_creative_management, true);
     });
+
+    it('does not emit media_buy capabilities for an empty features object (#2438)', async () => {
+      const server = createAdcpServer({
+        name: 'Test',
+        version: '1.0.0',
+        creative: {
+          buildCreative: async () => ({ creative_manifest: { manifest_id: 'mf_1', assets: [] } }),
+        },
+        capabilities: { features: {} },
+      });
+      const caps = await callTool(server, 'get_adcp_capabilities', {});
+
+      assert.deepStrictEqual(caps.supported_protocols, ['creative']);
+      assert.strictEqual(caps.media_buy, undefined);
+    });
   });
 
   describe('response builder wiring', () => {

--- a/test/server-decisioning-from-platform.test.js
+++ b/test/server-decisioning-from-platform.test.js
@@ -1806,6 +1806,64 @@ describe('SalesPlatform — full surface dispatch', () => {
 });
 
 describe('CreativeBuilderPlatform + AudiencePlatform wiring', () => {
+  function buildCreativeOnlyPlatform(capabilityOverrides = {}) {
+    return {
+      capabilities: {
+        specialisms: [],
+        config: {},
+        ...capabilityOverrides,
+      },
+      accounts: {
+        resolve: async () => ({ id: 'acc_1', metadata: {}, authInfo: { kind: 'api_key' } }),
+      },
+    };
+  }
+
+  async function getCapabilities(platform) {
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'creative-only',
+      version: '1.0.0',
+      validation: { requests: 'off', responses: 'off' },
+      legacyHandlers: {
+        creative: {
+          buildCreative: async () => ({ creative_manifest: { manifest_id: 'mf_1', assets: [] } }),
+        },
+      },
+    });
+    const result = await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: { name: 'get_adcp_capabilities', arguments: {} },
+    });
+    assert.notStrictEqual(result.isError, true, JSON.stringify(result.structuredContent));
+    return result.structuredContent;
+  }
+
+  it('omits media_buy capabilities for a creative-only platform (#2438)', async () => {
+    const caps = await getCapabilities(buildCreativeOnlyPlatform());
+
+    assert.deepStrictEqual(caps.supported_protocols, ['creative']);
+    assert.strictEqual(caps.media_buy, undefined);
+  });
+
+  it('preserves a media_buy null override for a creative-only platform (#2438)', async () => {
+    const caps = await getCapabilities(
+      buildCreativeOnlyPlatform({
+        features: { inlineCreativeManagement: true },
+        overrides: { media_buy: null },
+      })
+    );
+
+    assert.deepStrictEqual(caps.supported_protocols, ['creative']);
+    assert.strictEqual(caps.media_buy, undefined);
+  });
+
+  it('emits media_buy capabilities when a creative-only platform explicitly declares features (#2438)', async () => {
+    const caps = await getCapabilities(buildCreativeOnlyPlatform({ features: { inlineCreativeManagement: false } }));
+
+    assert.deepStrictEqual(caps.supported_protocols, ['creative']);
+    assert.strictEqual(caps.media_buy.features.inline_creative_management, false);
+  });
+
   it('build_creative dispatches through platform.creative.buildCreative', async () => {
     let sawReq;
     const platform = {


### PR DESCRIPTION
## Summary

- omit `media_buy` capabilities for creative-only platforms when no media-buy implementation or features are declared
- preserve explicit `media_buy: null` overrides when the framework has no media-buy projection
- keep explicitly declared media-buy features available on creative-only platforms

## Root cause

The platform projection always forwarded a truthy features object, including an empty object or an object containing only the framework-derived canonical creative flag. The lower-level capability generator treated any truthy features value as a reason to emit `media_buy`, and the framework merge replaced an adopter's `media_buy: null` override.

## Validation

- `npm run build:lib`
- `npm run typecheck`
- `NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/server-decisioning-from-platform.test.js` (166 passing before expert-requested test-only strengthening)
- issue-specific regression tests (4 passing)
- `test/capabilities-overrides.test.js` and `test/server-create-adcp-server.test.js` (150 passing before focused test addition)
- Prettier and `git diff --check`

Fixes #2438
