### PR TITLE
fix(testing): guard unexpanded creative asset directives

### DIFF
--- a/.changeset/guard-unexpanded-creative-assets.md
+++ b/.changeset/guard-unexpanded-creative-assets.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Reject unexpanded storyboard creative-asset directives before client dispatch and expose the expansion helpers through `@adcp/sdk/testing`.

--- a/src/lib/testing/index.ts
+++ b/src/lib/testing/index.ts
@@ -267,6 +267,9 @@ export {
   // Task mapping
   TASK_TO_METHOD,
   executeStoryboardTask,
+  // Storyboard-only creative asset directives
+  expandCreativeAssetDirectives,
+  findUnresolvedCreativeAssetDirectives,
   // Context
   extractContext,
   injectContext,

--- a/src/lib/testing/storyboard/index.ts
+++ b/src/lib/testing/storyboard/index.ts
@@ -167,6 +167,9 @@ export type {
 // Task mapping
 export { TASK_TO_METHOD, executeStoryboardTask } from './task-map';
 
+// Storyboard-only creative asset directives
+export { expandCreativeAssetDirectives, findUnresolvedCreativeAssetDirectives } from './creative-assets';
+
 // Path utilities
 export { parsePath, resolvePath, setPath } from './path';
 

--- a/src/lib/testing/storyboard/task-map.ts
+++ b/src/lib/testing/storyboard/task-map.ts
@@ -10,6 +10,7 @@
 import type { TaskResult } from '../types';
 import type { AdcpErrorInfo } from '../../core/ConversationTypes';
 import { isTerminalAdcpError, readExtractionPath } from '../../utils/response-unwrapper';
+import { BUILD_ASSETS_FROM_FORMAT_DIRECTIVE, findUnresolvedCreativeAssetDirectives } from './creative-assets';
 
 /**
  * Map of AdCP task names to SingleAgentClient method names.
@@ -177,6 +178,17 @@ export async function executeStoryboardTask(
   params: Record<string, unknown>,
   opts: { skipIdempotencyAutoInject?: boolean; skipAccountValidation?: boolean; signal?: AbortSignal } = {}
 ): Promise<TaskResult> {
+  const unresolvedAssetDirectives = findUnresolvedCreativeAssetDirectives(params);
+  if (unresolvedAssetDirectives.length > 0) {
+    return {
+      success: false,
+      error:
+        `Request contains unexpanded storyboard directive '${BUILD_ASSETS_FROM_FORMAT_DIRECTIVE}' at ` +
+        `${unresolvedAssetDirectives.join(', ')}. ` +
+        'Call expandCreativeAssetDirectives(params, context, testKit) before passing params to executeStoryboardTask.',
+    };
+  }
+
   // AdCP 3.1 transition storyboards default to the legacy creative wire, but
   // canonical-specific storyboards must be able to opt into the canonical API.
   const useLegacyCreativeMethod = gradesLegacyCreativeWire(client) && readCreativeWireHint(params) !== 'canonical';

--- a/test/lib/storyboard-creative-assets.test.js
+++ b/test/lib/storyboard-creative-assets.test.js
@@ -1,11 +1,8 @@
 const { describe, test } = require('node:test');
 const assert = require('node:assert');
 
-const {
-  BUILD_ASSETS_FROM_FORMAT_DIRECTIVE,
-  expandCreativeAssetDirectives,
-  findUnresolvedCreativeAssetDirectives,
-} = require('../../dist/lib/testing/storyboard/creative-assets');
+const { BUILD_ASSETS_FROM_FORMAT_DIRECTIVE } = require('../../dist/lib/testing/storyboard/creative-assets');
+const { expandCreativeAssetDirectives, findUnresolvedCreativeAssetDirectives } = require('../../dist/lib/testing');
 const { injectContext } = require('../../dist/lib/testing/storyboard/context');
 const { runStoryboard } = require('../../dist/lib/testing/storyboard/runner');
 

--- a/test/lib/storyboard-task-map-error.test.js
+++ b/test/lib/storyboard-task-map-error.test.js
@@ -110,3 +110,36 @@ describe('executeStoryboardTask creative wire selection', () => {
     assert.equal(result.data.wire, 'legacy');
   });
 });
+
+describe('executeStoryboardTask creative asset directives', () => {
+  test('rejects unexpanded directives before client validation or dispatch', async () => {
+    let callCount = 0;
+    const result = await executeStoryboardTask(
+      {
+        syncCreatives: async () => {
+          callCount += 1;
+          return { data: { creatives: [] } };
+        },
+      },
+      'sync_creatives',
+      {
+        creatives: [
+          {
+            assets: {
+              $build_assets_from_format: { agent_url: 'https://creative.example', id: 'display_300x250' },
+            },
+          },
+        ],
+      }
+    );
+
+    assert.equal(callCount, 0);
+    assert.deepEqual(result, {
+      success: false,
+      error:
+        "Request contains unexpanded storyboard directive '$build_assets_from_format' at " +
+        '$.creatives[0].assets.$build_assets_from_format. ' +
+        'Call expandCreativeAssetDirectives(params, context, testKit) before passing params to executeStoryboardTask.',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- reject unresolved `$build_assets_from_format` directives before `executeStoryboardTask` dispatches to client validation or transport
- expose `expandCreativeAssetDirectives` and `findUnresolvedCreativeAssetDirectives` from `@adcp/sdk/testing`
- add regression coverage proving external graders can expand directives and unexpanded requests never reach the client

## Root cause

The main storyboard runner expanded and checked the directive before dispatch, but callers using `executeStoryboardTask` directly bypassed that sequence. The client then validated a runner-only annotation against the wire schema and failed locally, grading sellers for requests they never received.

## Validation

- `npm run build`
- `NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/lib/storyboard-creative-assets.test.js test/lib/storyboard-task-map-error.test.js`
- `git diff --check`

Closes #2459
