### PR TITLE
fix: support hoisted structured-headers source builds

### DIFF
--- a/.changeset/fix-hoisted-structured-headers.md
+++ b/.changeset/fix-hoisted-structured-headers.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Fix source builds in hoisted dependency layouts by replacing the install-location-dependent `structured-headers` TypeScript path mapping with a version-pinned local declaration.

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "fast-check": "^3.23.2",
         "jose": "^6.2.2",
         "secure-json-parse": "^4.1.0",
-        "structured-headers": "^2.0.2",
+        "structured-headers": "2.0.2",
         "tldts": "^7.0.29",
         "undici": "^6.27.0",
         "ws": "^8.21.0",

--- a/package.json
+++ b/package.json
@@ -577,7 +577,7 @@
     "fast-check": "^3.23.2",
     "jose": "^6.2.2",
     "secure-json-parse": "^4.1.0",
-    "structured-headers": "^2.0.2",
+    "structured-headers": "2.0.2",
     "tldts": "^7.0.29",
     "undici": "^6.27.0",
     "ws": "^8.21.0",

--- a/src/lib/vendor-types/structured-headers.d.ts
+++ b/src/lib/vendor-types/structured-headers.d.ts
@@ -1,0 +1,29 @@
+// Keep this declaration aligned with the exact structured-headers version in
+// package.json. The package exposes types only through an exports map, which
+// legacy Node resolution cannot follow in hoisted source-build layouts.
+declare module 'structured-headers' {
+  class Token {
+    private readonly value;
+    constructor(value: string);
+    toString(): string;
+  }
+
+  class DisplayString {
+    private readonly value;
+    constructor(value: string);
+    toString(): string;
+  }
+
+  type BareItem = number | string | Token | ArrayBuffer | Date | boolean | DisplayString;
+  type Parameters = Map<string, BareItem>;
+  type Item = [BareItem, Parameters];
+  export type InnerList = [Item[], Parameters];
+  type Dictionary = Map<string, Item | InnerList>;
+
+  export class ParseError extends Error {
+    constructor(position: number, message: string);
+  }
+
+  export function parseDictionary(input: string): Dictionary;
+  export function serializeInnerList(input: InnerList): string;
+}

--- a/test/lib/typescript-config.test.js
+++ b/test/lib/typescript-config.test.js
@@ -1,0 +1,83 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } = require('node:fs');
+const { tmpdir } = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const REPO_ROOT = path.join(__dirname, '../..');
+
+function readJson(relativePath) {
+  return JSON.parse(readFileSync(path.join(REPO_ROOT, relativePath), 'utf8'));
+}
+
+test('TypeScript avoids install-location mappings and pins the local declaration dependency', () => {
+  const tsconfig = readJson('tsconfig.json');
+  const examplesConfig = readJson('tsconfig.examples.json');
+  const packageJson = readJson('package.json');
+
+  assert.equal(tsconfig.compilerOptions.module, 'commonjs');
+  assert.equal(tsconfig.compilerOptions.moduleResolution, 'node');
+  assert.equal(tsconfig.compilerOptions.paths?.['structured-headers'], undefined);
+  assert.equal(examplesConfig.compilerOptions.paths?.['structured-headers'], undefined);
+  assert.equal(packageJson.dependencies['structured-headers'], '2.0.2');
+});
+
+test('a nested CommonJS source package compiles with structured-headers hoisted to an ancestor', () => {
+  const fixtureRoot = mkdtempSync(path.join(tmpdir(), 'adcp-hoisted-types-'));
+  const nestedPackage = path.join(fixtureRoot, 'vendor', 'sdk');
+  const hoistedDependency = path.join(fixtureRoot, 'node_modules', 'structured-headers');
+  const installedDependency = path.dirname(path.dirname(require.resolve('structured-headers')));
+
+  try {
+    mkdirSync(path.join(nestedPackage, 'src'), { recursive: true });
+    mkdirSync(path.dirname(hoistedDependency), { recursive: true });
+    cpSync(installedDependency, hoistedDependency, { recursive: true });
+
+    writeFileSync(path.join(nestedPackage, 'package.json'), '{"name":"nested-sdk","type":"commonjs"}\n');
+    writeFileSync(
+      path.join(nestedPackage, 'tsconfig.json'),
+      JSON.stringify({
+        compilerOptions: {
+          target: 'ES2022',
+          module: 'commonjs',
+          moduleResolution: 'node',
+          strict: true,
+          declaration: true,
+          outDir: 'dist',
+        },
+        include: ['src/**/*'],
+      })
+    );
+    writeFileSync(
+      path.join(nestedPackage, 'src', 'structured-headers.d.ts'),
+      readFileSync(path.join(REPO_ROOT, 'src', 'lib', 'vendor-types', 'structured-headers.d.ts'), 'utf8')
+    );
+    writeFileSync(
+      path.join(nestedPackage, 'src', 'index.ts'),
+      [
+        "import { ParseError, parseDictionary, serializeInnerList, type InnerList } from 'structured-headers';",
+        '',
+        'export function roundTrip(value: string): string {',
+        '  const entry = parseDictionary(value).values().next().value;',
+        "  if (!entry || !Array.isArray(entry[0])) throw new ParseError(0, 'expected inner list');",
+        '  return serializeInnerList(entry as InnerList);',
+        '}',
+        '',
+      ].join('\n')
+    );
+
+    assert.equal(existsSync(path.join(nestedPackage, 'node_modules')), false);
+    const result = spawnSync(path.join(REPO_ROOT, 'node_modules', '.bin', 'tsc'), ['--project', nestedPackage], {
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+
+    const javascript = readFileSync(path.join(nestedPackage, 'dist', 'index.js'), 'utf8');
+    const declaration = readFileSync(path.join(nestedPackage, 'dist', 'index.d.ts'), 'utf8');
+    assert.match(javascript, /require\(["']structured-headers["']\)/);
+    assert.doesNotMatch(declaration, /structured-headers/);
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+});

--- a/tsconfig.examples.json
+++ b/tsconfig.examples.json
@@ -5,7 +5,6 @@
     "rootDir": ".",
     "baseUrl": ".",
     "paths": {
-      "structured-headers": ["./node_modules/structured-headers/cjs/index.d.cts"],
       "@adcp/sdk": ["./dist/lib/index.d.ts"],
       "@adcp/sdk/testing": ["./dist/lib/testing/index.d.ts"],
       "@adcp/sdk/server": ["./dist/lib/server/index.d.ts"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,9 +16,6 @@
     "declarationMap": true,
     "sourceMap": true,
     "moduleResolution": "node",
-    "paths": {
-      "structured-headers": ["./node_modules/structured-headers/cjs/index.d.cts"]
-    },
     "allowSyntheticDefaultImports": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -97,10 +97,9 @@ function fixDynamicImportExtensions() {
 //
 // `fixImportsPlugin` (see tsup#1240) supplies what `bundle: false` leaves out:
 // it appends the correct extension to relative imports, rewrites directory
-// imports to `/index`, and resolves tsconfig path aliases. Its alias step is
-// neutralised by pointing the build at a paths-free tsconfig (below), because
-// the only `paths` entry (`structured-headers`) is a typecheck-only pin to the
-// package's CJS type file and must stay a bare external import at runtime.
+// imports to `/index`, and resolves tsconfig path aliases. Pointing the build
+// at a paths-free tsconfig keeps its alias step neutral so external package
+// imports remain bare at runtime.
 // Declarations are emitted separately by `tsc --emitDeclarationOnly`.
 export default defineConfig({
   entry: ['src/lib/**/*.ts', '!src/lib/**/*.test.ts', '!src/lib/**/*.d.ts', '!src/lib/**/*.type-checks.ts'],
@@ -110,8 +109,6 @@ export default defineConfig({
   platform: 'node',
   bundle: false,
   // A paths-free tsconfig so the import-fixer's alias resolution is a no-op.
-  // The only `paths` entry (`structured-headers`) is a typecheck-only pin;
-  // at runtime it must stay a bare external import, not a rewritten path.
   tsconfig: 'tsconfig.build.json',
   sourcemap: true,
   clean: true,


### PR DESCRIPTION
## Summary

- Replace the install-layout-dependent `structured-headers` TypeScript path mapping with a local declaration.
- Pin `structured-headers` to the version represented by that declaration.
- Add a real hoisted-workspace compile regression test that verifies CommonJS output keeps a bare package import.

## Root cause

Legacy Node module resolution cannot follow the package's exports map, while the previous path shim assumed `structured-headers` lived in this package's own `node_modules`. That assumption fails in hoisted dependency layouts.

## Validation

- `npm run typecheck`
- `npm run typecheck:examples`
- `npm run build:lib`
- `node --test test/lib/typescript-config.test.js`
- Expert protocol, code, security, and DX reviews
- `npm run review:codex -- --all --base main`

Fixes #2362
