### PR TITLE
fix(testing): finish creative scenario fixture validation

### DIFF
--- a/.changeset/fix-creative-scenario-residuals.md
+++ b/.changeset/fix-creative-scenario-residuals.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Keep testing-scenario creative fixtures schema-valid by adding the inline image discriminator and filling missing format owners from the seller without overwriting explicit creative-agent ownership.

--- a/src/lib/testing/scenarios/media-buy.ts
+++ b/src/lib/testing/scenarios/media-buy.ts
@@ -132,6 +132,20 @@ function getDefaultFormatId(): FormatID {
   return { agent_url: 'https://creative.adcontextprotocol.org', id: 'display_300x250' };
 }
 
+function resolveSellerFormatId(value: unknown, agentUrl: string): FormatID | undefined {
+  const candidate = isRecord(value) && value.format_id !== undefined ? value.format_id : value;
+
+  if (typeof candidate === 'string') {
+    return { agent_url: agentUrl, id: candidate };
+  }
+
+  if (isRecord(candidate) && typeof candidate.id === 'string') {
+    return { agent_url: agentUrl, ...candidate, id: candidate.id } as FormatID;
+  }
+
+  return undefined;
+}
+
 function formatIdToString(formatId: FormatID): string {
   return formatId.id;
 }
@@ -167,6 +181,7 @@ function buildStaticInlineCreative(formatId: FormatID) {
     format_id: formatId,
     assets: {
       primary: {
+        asset_type: 'image' as const,
         url: 'https://via.placeholder.com/300x250?text=Inline+Creative',
         width: 300,
         height: 250,
@@ -768,10 +783,7 @@ export async function testCreativeSync(
   }
 
   // Get format info first
-  let formatId: Record<string, unknown> = {
-    agent_url: 'https://creative.adcontextprotocol.org',
-    id: 'display_300x250',
-  };
+  let formatId: FormatID = getDefaultFormatId();
   if (profile.tools.includes('list_creative_formats')) {
     const { result: formatsResult } = await runStep<TaskResult>(
       'Get formats for creative',
@@ -785,12 +797,7 @@ export async function testCreativeSync(
       const formats = data.formats as Record<string, unknown>[] | undefined;
       const firstFormat = formatIds?.[0] || formats?.[0];
       if (firstFormat) {
-        if (typeof firstFormat === 'string') {
-          formatId = { agent_url: agentUrl, id: firstFormat };
-        } else {
-          const formatObj = firstFormat as Record<string, unknown>;
-          formatId = (formatObj.format_id as Record<string, unknown>) || formatObj;
-        }
+        formatId = resolveSellerFormatId(firstFormat, agentUrl) ?? formatId;
       }
     }
   }

--- a/test/lib/creative-scenario-fixture-validation.test.js
+++ b/test/lib/creative-scenario-fixture-validation.test.js
@@ -10,7 +10,7 @@ const { test, describe } = require('node:test');
 const assert = require('node:assert');
 
 const { validateRequest } = require('../../dist/lib/validation');
-const { testCreativeSync } = require('../../dist/lib/testing');
+const { testCreativeInline, testCreativeSync } = require('../../dist/lib/testing');
 
 const SELLER_URL = 'https://seller.example/mcp';
 
@@ -129,5 +129,100 @@ describe('creative scenario fixture schema validity (issue #2460)', () => {
     };
     const outcome = validateRequest('sync_creatives', { ...BASE_ENVELOPE, creatives: [brokenCreative] });
     assert.strictEqual(outcome.valid, false, 'Expected schema validation to fail without agent_url in format_id');
+  });
+});
+
+describe('creative scenario residual paths (issue #2443)', () => {
+  test('testCreativeSync keeps the AAO default when format discovery is unavailable', async () => {
+    let syncRequest;
+    const client = {
+      syncCreatives: async request => {
+        syncRequest = request;
+        return { success: true, data: { creatives: [] } };
+      },
+    };
+
+    await testCreativeSync(SELLER_URL, {
+      sandbox: true,
+      _client: client,
+      _profile: { tools: ['sync_creatives'] },
+    });
+
+    assert.deepStrictEqual(syncRequest.creatives[0].format_id, DEFAULT_FORMAT_ID);
+  });
+
+  for (const [label, formatsData, expectedFormatId] of [
+    ['direct format object', { formats: [{ id: 'display_direct' }] }, { agent_url: SELLER_URL, id: 'display_direct' }],
+    [
+      'nested format object',
+      { formats: [{ format_id: { id: 'display_nested' } }] },
+      { agent_url: SELLER_URL, id: 'display_nested' },
+    ],
+    [
+      'nested format object with an explicit owner',
+      { formats: [{ format_id: { agent_url: 'https://creative.example/mcp', id: 'display_owned' } }] },
+      { agent_url: 'https://creative.example/mcp', id: 'display_owned' },
+    ],
+  ]) {
+    test(`testCreativeSync binds ${label} to the seller agent`, async () => {
+      let syncRequest;
+      const client = {
+        listCreativeFormatsLegacy: async () => ({ success: true, data: formatsData }),
+        syncCreatives: async request => {
+          syncRequest = request;
+          return { success: true, data: { creatives: [] } };
+        },
+      };
+
+      await testCreativeSync(SELLER_URL, {
+        sandbox: true,
+        _client: client,
+        _profile: { tools: ['list_creative_formats', 'sync_creatives'] },
+      });
+
+      assert.deepStrictEqual(syncRequest.creatives[0].format_id, expectedFormatId);
+    });
+  }
+
+  test('testCreativeInline includes the image asset discriminator', async () => {
+    let createRequest;
+    const product = {
+      product_id: 'display-product',
+      name: 'Display product',
+      description: 'Regression fixture',
+      channels: ['display'],
+      format_ids: [{ agent_url: SELLER_URL, id: 'display_300x250' }],
+      pricing_options: [
+        {
+          pricing_option_id: 'display-cpm',
+          pricing_model: 'cpm',
+          currency: 'USD',
+          fixed_price: 10,
+        },
+      ],
+    };
+    const client = {
+      getProducts: async () => ({ success: true, data: { products: [product] } }),
+      createMediaBuy: async request => {
+        createRequest = request;
+        return { success: false, error: 'Captured request' };
+      },
+    };
+
+    await testCreativeInline(SELLER_URL, {
+      sandbox: true,
+      _client: client,
+      _profile: { tools: ['create_media_buy'] },
+    });
+
+    const creative = createRequest.packages[0].creatives[0];
+    assert.strictEqual(creative.assets.primary.asset_type, 'image');
+    assert.strictEqual(
+      validateRequest('create_media_buy', {
+        ...createRequest,
+        idempotency_key: 'test-inline-creative-regression-001',
+      }).valid,
+      true
+    );
   });
 });


### PR DESCRIPTION
## Summary

- add the required `asset_type: "image"` discriminator to the static inline creative fixture
- normalize legacy format discovery results, using the seller only when an owner is missing
- preserve explicit creative-agent ownership and the standard AAO fallback reference
- add behavior-level regressions through `testCreativeSync` and `testCreativeInline`

## Root cause

The scenario helpers had two remaining fixture paths that diverged from the schema-valid builders: the inline image omitted its union discriminator, and format discovery passed through legacy response shapes without guaranteeing the required seller `agent_url`.

## Validation

- `npm run build`
- `npm run format:check`
- `NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/lib/creative-scenario-fixture-validation.test.js` (12/12)
- `git diff --check`

Closes #2443
