### PR TITLE
feat(upstream-recorder)!: require payload digest options object

### DIFF
--- a/.changeset/remove-legacy-payload-digest-options.md
+++ b/.changeset/remove-legacy-payload-digest-options.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': major
+---
+
+Remove the legacy bare `RegExp` and `false` third-argument forms from `computePayloadDigestSha256()`. Pass custom redaction as `{ redactPattern }` and identify already-normalized payloads with `{ prenormalized: true }`.

--- a/docs/migration-12-to-13.md
+++ b/docs/migration-12-to-13.md
@@ -91,6 +91,27 @@ The same rule applies to raw `creative`, `governance`, and `brandRights` groups.
 
 ## Legacy utility and low-level server names
 
+### Upstream recorder payload digests
+
+`computePayloadDigestSha256()` now has one third-argument shape:
+`PayloadDigestOptions`. Replace the removed bare `RegExp` and `false` forms
+with their named equivalents:
+
+```ts
+computePayloadDigestSha256(payload, contentType, {
+  redactPattern: /^(authorization|vendor_secret)$/i,
+});
+
+computePayloadDigestSha256(redactedPayload, contentType, {
+  prenormalized: true,
+});
+```
+
+TypeScript rejects the old forms, and untyped JavaScript calls fail with
+`PayloadDigestError`. When using `redactPattern: false`, also set
+`prenormalized: true`; disabling redaction for an unverified payload remains
+an error.
+
 Named-format fixtures and preview helpers are no longer easy to mistake for
 canonical discovery APIs:
 

--- a/src/lib/upstream-recorder/recorder.ts
+++ b/src/lib/upstream-recorder/recorder.ts
@@ -5,6 +5,7 @@
 
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { createHash } from 'node:crypto';
+import { isRegExp } from 'node:util/types';
 import {
   normalizeSecretKeyPattern,
   redactSecrets,
@@ -551,14 +552,13 @@ function sha256Hex(value: string): string {
  * - `createUpstreamRecorder({ redactPattern })` → `computePayloadDigestSha256(..., { redactPattern })`
  * - `createUpstreamRecorder({ maxPayloadBytes })` → `computePayloadDigestSha256(..., { maxPayloadBytes })`
  *
- * Prefer `{ prenormalized: true }` only when the payload has already been
- * normalized/redacted exactly as the recorder would store it; legacy `false`
- * remains accepted as the same prenormalized sentinel. The prenormalized path
- * skips redaction, so the helper rejects secret-shaped keys whose values are
- * not already the literal `"[redacted]"` marker or an explicit null
- * placeholder. For form-encoded bodies, duplicate secret-shaped keys are also
- * rejected because last-wins maps cannot prove that every original value was
- * inspected before hashing.
+ * Use `{ prenormalized: true }` only when the payload has already been
+ * normalized/redacted exactly as the recorder would store it. The
+ * prenormalized path skips redaction, so the helper rejects secret-shaped keys
+ * whose values are not already the literal `"[redacted]"` marker or an
+ * explicit null placeholder. For form-encoded bodies, duplicate secret-shaped
+ * keys are also rejected because last-wins maps cannot prove that every
+ * original value was inspected before hashing.
  *
  * JSON content is serialized with RFC 8785 JCS before hashing. When
  * `contentType` is JSON-shaped and `payload` is a string, the helper parses
@@ -575,53 +575,21 @@ function sha256Hex(value: string): string {
  */
 export function computePayloadDigestSha256(
   payload: unknown,
-  contentType?: string,
-  options?: PayloadDigestOptions
-): string;
-/**
- * @deprecated Pass `{ redactPattern: /.../ }` instead of the bare `RegExp`
- * form. The legacy form remains accepted for this major.
- */
-export function computePayloadDigestSha256(payload: unknown, contentType: string | undefined, options: RegExp): string;
-/**
- * @deprecated Pass `{ prenormalized: true }` instead of `false`. The legacy
- * form remains accepted for this major.
- */
-export function computePayloadDigestSha256(payload: unknown, contentType: string | undefined, options: false): string;
-export function computePayloadDigestSha256(
-  payload: unknown,
   contentType = 'application/json',
-  options: RegExp | false | PayloadDigestOptions = SECRET_KEY_PATTERN
+  options: PayloadDigestOptions = {}
 ): string {
-  const redactPattern =
-    options instanceof RegExp || options === false
-      ? options === false
+  try {
+    assertPayloadDigestOptions(options);
+    const redactPattern = options.prenormalized
+      ? false
+      : options.redactPattern === false
         ? false
-        : normalizeSecretKeyPattern(options)
-      : options?.prenormalized
-        ? false
-        : options?.redactPattern === false
-          ? false
-          : normalizeSecretKeyPattern(options?.redactPattern ?? SECRET_KEY_PATTERN);
-  const prenormalizedSafetyPattern =
-    typeof options === 'object' &&
-    options !== null &&
-    !(options instanceof RegExp) &&
-    options.redactPattern instanceof RegExp
+        : normalizeSecretKeyPattern(options.redactPattern ?? SECRET_KEY_PATTERN);
+    const prenormalizedSafetyPattern = isRegExp(options.redactPattern)
       ? normalizeSecretKeyPattern(options.redactPattern)
       : SECRET_KEY_PATTERN;
-  const maxPayloadBytes =
-    typeof options === 'object' && options !== null && !(options instanceof RegExp)
-      ? clamp(options.maxPayloadBytes, 0, 16 * 1024 * 1024, DEFAULT_MAX_PAYLOAD_BYTES)
-      : DEFAULT_MAX_PAYLOAD_BYTES;
-  try {
-    if (
-      typeof options === 'object' &&
-      options !== null &&
-      !(options instanceof RegExp) &&
-      options.redactPattern === false &&
-      options.prenormalized !== true
-    ) {
+    const maxPayloadBytes = clamp(options.maxPayloadBytes, 0, 16 * 1024 * 1024, DEFAULT_MAX_PAYLOAD_BYTES);
+    if (options.redactPattern === false && options.prenormalized !== true) {
       throw new PayloadDigestError('PayloadDigestOptions.redactPattern=false requires prenormalized=true');
     }
     const payloadForDigest =
@@ -637,6 +605,12 @@ export function computePayloadDigestSha256(
   } catch (err) {
     if (err instanceof PayloadDigestError) throw err;
     throw new PayloadDigestError(err instanceof Error ? err.message : 'Payload digest canonicalization failed', err);
+  }
+}
+
+function assertPayloadDigestOptions(options: unknown): asserts options is PayloadDigestOptions {
+  if (typeof options !== 'object' || options === null || isRegExp(options) || Array.isArray(options)) {
+    throw new PayloadDigestError('computePayloadDigestSha256 options must be a PayloadDigestOptions object');
   }
 }
 

--- a/src/lib/upstream-recorder/recorder.type-checks.ts
+++ b/src/lib/upstream-recorder/recorder.type-checks.ts
@@ -1,0 +1,14 @@
+import { computePayloadDigestSha256 } from './recorder';
+
+computePayloadDigestSha256({ authorization: 'secret' }, 'application/json', {
+  redactPattern: /authorization/i,
+});
+computePayloadDigestSha256({ authorization: '[redacted]' }, 'application/json', {
+  prenormalized: true,
+});
+
+// @ts-expect-error Bare RegExp options were removed in v13; use { redactPattern }.
+computePayloadDigestSha256({ authorization: 'secret' }, 'application/json', /authorization/i);
+
+// @ts-expect-error The false sentinel was removed in v13; use { prenormalized: true }.
+computePayloadDigestSha256({ authorization: '[redacted]' }, 'application/json', false);

--- a/test/lib/upstream-recorder-spec-shape.test.js
+++ b/test/lib/upstream-recorder-spec-shape.test.js
@@ -13,6 +13,7 @@ const path = require('node:path');
 const { describe, test } = require('node:test');
 const assert = require('node:assert/strict');
 const { createHash } = require('node:crypto');
+const { runInNewContext } = require('node:vm');
 const Ajv = require('ajv').default;
 const addFormats = require('ajv-formats').default;
 
@@ -334,7 +335,10 @@ describe('RecordedCall spec-shape conformance (UpstreamTrafficSuccess)', () => {
     );
 
     assert.throws(
-      () => computePayloadDigestSha256('access_token=fake_test_fixture', 'application/x-www-form-urlencoded', false),
+      () =>
+        computePayloadDigestSha256('access_token=fake_test_fixture', 'application/x-www-form-urlencoded', {
+          prenormalized: true,
+        }),
       {
         name: 'PayloadDigestError',
         message: /access_token/,
@@ -346,7 +350,7 @@ describe('RecordedCall spec-shape conformance (UpstreamTrafficSuccess)', () => {
         computePayloadDigestSha256(
           'authorization=fake_test_fixture&authorization=%5Bredacted%5D',
           'application/x-www-form-urlencoded',
-          false
+          { prenormalized: true }
         ),
       {
         name: 'PayloadDigestError',
@@ -378,7 +382,10 @@ describe('RecordedCall spec-shape conformance (UpstreamTrafficSuccess)', () => {
     );
 
     assert.throws(
-      () => computePayloadDigestSha256({ authorization: { nested: 'fake_test_fixture' } }, 'application/json', false),
+      () =>
+        computePayloadDigestSha256({ authorization: { nested: 'fake_test_fixture' } }, 'application/json', {
+          prenormalized: true,
+        }),
       {
         name: 'PayloadDigestError',
         message: /authorization/,
@@ -389,7 +396,7 @@ describe('RecordedCall spec-shape conformance (UpstreamTrafficSuccess)', () => {
       computePayloadDigestSha256(
         { authorization: null, token: '[redacted]', password: '[redacted]' },
         'application/json',
-        false
+        { prenormalized: true }
       )
     );
   });
@@ -397,7 +404,7 @@ describe('RecordedCall spec-shape conformance (UpstreamTrafficSuccess)', () => {
   test('computePayloadDigestSha256 scans deep prenormalized payloads without recursive stack overflow', () => {
     let payload = { authorization: '[redacted]' };
     for (let i = 0; i < 10_000; i++) payload = { wrapper: payload };
-    assert.throws(() => computePayloadDigestSha256(payload, 'application/json', false), {
+    assert.throws(() => computePayloadDigestSha256(payload, 'application/json', { prenormalized: true }), {
       name: 'PayloadDigestError',
       message: /JSON payload exceeds max canonicalization depth/,
     });
@@ -441,13 +448,33 @@ describe('RecordedCall spec-shape conformance (UpstreamTrafficSuccess)', () => {
     };
     assert.equal(computePayloadDigestSha256(raw), sha256Hex(canonicalize(defaultRedacted)));
     assert.equal(
-      computePayloadDigestSha256(raw, 'application/json', /^(authorization|vendor_secret)$/i),
+      computePayloadDigestSha256(raw, 'application/json', {
+        redactPattern: /^(authorization|vendor_secret)$/i,
+      }),
       sha256Hex(canonicalize(customRedacted))
     );
     assert.equal(
       computePayloadDigestSha256(defaultRedacted, 'application/json', { prenormalized: true }),
-      computePayloadDigestSha256(defaultRedacted, 'application/json', false)
+      sha256Hex(canonicalize(defaultRedacted))
     );
+  });
+
+  test('computePayloadDigestSha256 rejects legacy third-argument forms', () => {
+    assert.throws(() => computePayloadDigestSha256({ ok: true }, 'application/json', /authorization/i), {
+      name: 'PayloadDigestError',
+      message: /options must be a PayloadDigestOptions object/,
+    });
+    assert.throws(
+      () => computePayloadDigestSha256({ ok: true }, 'application/json', runInNewContext('/authorization/i')),
+      {
+        name: 'PayloadDigestError',
+        message: /options must be a PayloadDigestOptions object/,
+      }
+    );
+    assert.throws(() => computePayloadDigestSha256({ ok: true }, 'application/json', false), {
+      name: 'PayloadDigestError',
+      message: /options must be a PayloadDigestOptions object/,
+    });
   });
 
   test('custom global redaction patterns do not skip repeated secret keys', async () => {


### PR DESCRIPTION
## Summary

- remove the legacy bare `RegExp` and `false` overloads from `computePayloadDigestSha256()`
- reject removed call forms at runtime, including cross-realm regular expressions
- migrate tests and documentation to `PayloadDigestOptions`, add compile-time negative coverage, and include a major changeset

Closes #2054

## Expert review

- code-quality review found one cross-realm `RegExp` edge case; fixed with `node:util/types.isRegExp` and independently re-reviewed clean
- protocol/API review found no remaining compatibility or release-hygiene issues
- Node.js testing review found no remaining coverage or CI blockers

## Validation

- repository pre-push validation (full typecheck and library build)
- `npx tsup`
- `node --test-timeout=60000 --test-force-exit --test test/lib/upstream-recorder-spec-shape.test.js` (32/32 passing)
- focused TypeScript compile assertions
- Prettier, diff checks, PR-title validation, and commitlint
