### PR TITLE
fix(testing): grade unavailable creative fixtures not applicable

### DIFF
--- a/.changeset/grade-unavailable-creative-fixtures.md
+++ b/.changeset/grade-unavailable-creative-fixtures.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Grade storyboard steps as not applicable when the selected test kit cannot synthesize a seller-required creative asset slot, while preserving slot-level diagnostics and prerequisite failures for missing format context.

--- a/src/lib/testing/storyboard/creative-assets.ts
+++ b/src/lib/testing/storyboard/creative-assets.ts
@@ -14,6 +14,28 @@ interface RequiredSlot extends Dimensions {
   assetType: string;
 }
 
+type AssetsBuildFailure =
+  | {
+      reason: 'format_not_found' | 'malformed_directive';
+      constraint: string;
+    }
+  | {
+      reason: 'creative_asset_fixture_unavailable';
+      slotId: string;
+      assetType: string;
+      constraint: string;
+    };
+
+export type CreativeAssetExpansionFailure = AssetsBuildFailure & { path: string };
+
+export type CreativeAssetExpansionResult =
+  | { ok: true; value: unknown }
+  | { ok: false; value: unknown; failure: CreativeAssetExpansionFailure };
+
+type AssetBuildResult = { ok: true; asset: JsonObject } | { ok: false; constraint: string };
+
+type AssetsBuildResult = { ok: true; assets: JsonObject } | { ok: false; failure: AssetsBuildFailure };
+
 function isObject(value: unknown): value is JsonObject {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
@@ -35,17 +57,39 @@ function formatIdMatches(candidate: unknown, requested: JsonObject): boolean {
   return requestedAgent === undefined || candidateAgent === requestedAgent;
 }
 
-function resolveFormat(value: unknown, context: StoryboardContext): JsonObject | undefined {
-  if (!isObject(value)) return undefined;
+function resolveFormat(
+  value: unknown,
+  context: StoryboardContext
+):
+  | { ok: true; format: JsonObject }
+  | { ok: false; reason: 'format_not_found' | 'malformed_directive'; constraint: string } {
+  if (!isObject(value)) {
+    return {
+      ok: false,
+      reason: 'malformed_directive',
+      constraint: 'directive value must be a format object or FormatId',
+    };
+  }
   if (Array.isArray(value.slots) || Array.isArray(value.assets) || Array.isArray(value.assets_required)) {
-    return value;
+    return { ok: true, format: value };
   }
 
-  if (typeof value.id !== 'string') return undefined;
+  if (typeof value.id !== 'string') {
+    return { ok: false, reason: 'malformed_directive', constraint: 'format reference must contain a string id' };
+  }
   const formats = Array.isArray(context.formats) ? context.formats : [];
-  return formats.find(
+  const format = formats.find(
     (candidate): candidate is JsonObject => isObject(candidate) && formatIdMatches(candidate.format_id, value)
   );
+  if (!format) {
+    const agent = typeof value.agent_url === 'string' ? ` from ${value.agent_url}` : '';
+    return {
+      ok: false,
+      reason: 'format_not_found',
+      constraint: `format "${value.id}"${agent} is absent from storyboard context.formats`,
+    };
+  }
+  return { ok: true, format };
 }
 
 function dimensionsFromId(format: JsonObject): Dimensions {
@@ -97,20 +141,35 @@ function requiredSlots(format: JsonObject): RequiredSlot[] {
   });
 }
 
-function buildImage(slot: RequiredSlot, assets: JsonObject): JsonObject | undefined {
+function imageConstraint(slot: RequiredSlot): string {
+  if (slot.width !== undefined && slot.height !== undefined) {
+    return `requires an exact ${slot.width}x${slot.height} image fixture`;
+  }
+  if (slot.width !== undefined) return `requires an image fixture with exact width ${slot.width}`;
+  if (slot.height !== undefined) return `requires an image fixture with exact height ${slot.height}`;
+  return 'requires an image fixture with a URL';
+}
+
+function buildImage(slot: RequiredSlot, assets: JsonObject): AssetBuildResult {
   const images = Array.isArray(assets.images) ? assets.images.filter(isObject) : [];
   const image = images.find(candidate => {
     const widthMatches = slot.width === undefined || candidate.width === slot.width;
     const heightMatches = slot.height === undefined || candidate.height === slot.height;
     return widthMatches && heightMatches;
   });
-  if (!image || typeof image.url !== 'string') return undefined;
+  if (!image) return { ok: false, constraint: imageConstraint(slot) };
+  if (typeof image.url !== 'string') {
+    return { ok: false, constraint: `${imageConstraint(slot)}, but the matching fixture has no URL` };
+  }
   return {
-    asset_type: 'image',
-    url: image.url,
-    ...(asNumber(image.width) !== undefined ? { width: image.width } : {}),
-    ...(asNumber(image.height) !== undefined ? { height: image.height } : {}),
-    ...(typeof image.mime_type === 'string' ? { mime_type: image.mime_type } : {}),
+    ok: true,
+    asset: {
+      asset_type: 'image',
+      url: image.url,
+      ...(asNumber(image.width) !== undefined ? { width: image.width } : {}),
+      ...(asNumber(image.height) !== undefined ? { height: image.height } : {}),
+      ...(typeof image.mime_type === 'string' ? { mime_type: image.mime_type } : {}),
+    },
   };
 }
 
@@ -118,66 +177,142 @@ function firstString(value: unknown): string | undefined {
   return Array.isArray(value) ? value.find((item): item is string => typeof item === 'string') : undefined;
 }
 
-function buildText(slot: RequiredSlot, assets: JsonObject): JsonObject | undefined {
+function buildText(slot: RequiredSlot, assets: JsonObject): AssetBuildResult {
   const text = isObject(assets.text) ? assets.text : {};
   const id = slot.id.toLowerCase();
-  const content = id.includes('headline')
-    ? firstString(text.headlines)
-    : id.includes('description') || id.includes('body')
-      ? firstString(text.descriptions)
-      : id.includes('cta') || id.includes('call_to_action')
-        ? firstString(text.cta)
-        : (firstString(text.headlines) ?? firstString(text.descriptions) ?? firstString(text.cta));
-  return content === undefined ? undefined : { asset_type: 'text', content };
+  let content: string | undefined;
+  let semantic: string;
+  if (id.includes('headline')) {
+    content = firstString(text.headlines);
+    semantic = 'headline';
+  } else if (id.includes('description') || id.includes('body')) {
+    content = firstString(text.descriptions);
+    semantic = 'description/body';
+  } else if (id.includes('cta') || id.includes('call_to_action')) {
+    content = firstString(text.cta);
+    semantic = 'CTA/call_to_action';
+  } else {
+    return {
+      ok: false,
+      constraint: 'slot id does not identify a supported headline, description/body, or CTA/call_to_action semantic',
+    };
+  }
+  return content === undefined
+    ? { ok: false, constraint: `requires a ${semantic} text fixture` }
+    : { ok: true, asset: { asset_type: 'text', content } };
 }
 
-function buildAsset(slot: RequiredSlot, testKit: unknown): JsonObject | undefined {
-  if (!isObject(testKit) || !isObject(testKit.assets)) return undefined;
+function buildAsset(slot: RequiredSlot, testKit: unknown): AssetBuildResult {
+  if (!isObject(testKit) || !isObject(testKit.assets)) {
+    return { ok: false, constraint: 'selected test kit does not declare asset fixtures' };
+  }
   const assets = testKit.assets;
   if (slot.assetType === 'image') return buildImage(slot, assets);
   if (slot.assetType === 'url' && typeof assets.click_url === 'string') {
-    return { asset_type: 'url', url: assets.click_url };
+    return { ok: true, asset: { asset_type: 'url', url: assets.click_url } };
   }
+  if (slot.assetType === 'url') return { ok: false, constraint: 'requires a click_url fixture' };
   if (slot.assetType === 'text') return buildText(slot, assets);
-  return undefined;
+  return { ok: false, constraint: `asset type "${slot.assetType}" is not supported by the selected test kit` };
 }
 
-function buildAssets(value: unknown, context: StoryboardContext, testKit: unknown): JsonObject | undefined {
-  const format = resolveFormat(value, context);
-  if (!format) return undefined;
-  const slots = requiredSlots(format);
-  if (slots.length === 0) return undefined;
+function buildAssets(value: unknown, context: StoryboardContext, testKit: unknown): AssetsBuildResult {
+  const resolved = resolveFormat(value, context);
+  if (!resolved.ok) {
+    return { ok: false, failure: { reason: resolved.reason, constraint: resolved.constraint } };
+  }
+  const slots = requiredSlots(resolved.format);
+  if (slots.length === 0) {
+    return {
+      ok: false,
+      failure: {
+        reason: 'malformed_directive',
+        constraint: 'format does not declare any recognizable required asset slots',
+      },
+    };
+  }
 
   const built: JsonObject = {};
   for (const slot of slots) {
-    const asset = buildAsset(slot, testKit);
-    if (!asset) return undefined;
-    built[slot.id] = asset;
+    const result = buildAsset(slot, testKit);
+    if (!result.ok) {
+      return {
+        ok: false,
+        failure: {
+          reason: 'creative_asset_fixture_unavailable',
+          slotId: slot.id,
+          assetType: slot.assetType,
+          constraint: result.constraint,
+        },
+      };
+    }
+    built[slot.id] = result.asset;
   }
-  return built;
+  return { ok: true, assets: built };
+}
+
+function expandWithDiagnostics(
+  value: unknown,
+  context: StoryboardContext,
+  testKit: unknown,
+  path: string
+): CreativeAssetExpansionResult {
+  if (Array.isArray(value)) {
+    const expanded = Array.from(value as unknown[]);
+    for (let index = 0; index < value.length; index += 1) {
+      const result = expandWithDiagnostics(value[index], context, testKit, `${path}[${index}]`);
+      expanded[index] = result.value;
+      if (!result.ok) return { ...result, value: expanded };
+    }
+    return { ok: true, value: expanded };
+  }
+  if (!isObject(value)) return { ok: true, value };
+
+  if (Object.prototype.hasOwnProperty.call(value, BUILD_ASSETS_FROM_FORMAT_DIRECTIVE)) {
+    const built = buildAssets(value[BUILD_ASSETS_FROM_FORMAT_DIRECTIVE], context, testKit);
+    if (!built.ok) {
+      return {
+        ok: false,
+        value,
+        failure: {
+          ...built.failure,
+          path: `${path}.${BUILD_ASSETS_FROM_FORMAT_DIRECTIVE}`,
+        },
+      };
+    }
+    const siblings: JsonObject = Object.fromEntries(
+      Object.entries(value).filter(([key]) => key !== BUILD_ASSETS_FROM_FORMAT_DIRECTIVE)
+    );
+    for (const [key, item] of Object.entries(value)) {
+      if (key === BUILD_ASSETS_FROM_FORMAT_DIRECTIVE) continue;
+      const result = expandWithDiagnostics(item, context, testKit, `${path}.${key}`);
+      siblings[key] = result.value;
+      if (!result.ok) return { ...result, value: { ...siblings, ...built.assets } };
+    }
+    return { ok: true, value: { ...siblings, ...built.assets } };
+  }
+
+  const expanded: JsonObject = { ...value };
+  for (const [key, item] of Object.entries(value)) {
+    const result = expandWithDiagnostics(item, context, testKit, `${path}.${key}`);
+    expanded[key] = result.value;
+    if (!result.ok) return { ...result, value: expanded };
+  }
+  return { ok: true, value: expanded };
+}
+
+/** Expand reserved storyboard creative-asset directives and preserve the first failure diagnostic. */
+export function expandCreativeAssetDirectivesWithDiagnostics(
+  value: unknown,
+  context: StoryboardContext,
+  testKit: unknown
+): CreativeAssetExpansionResult {
+  return expandWithDiagnostics(value, context, testKit, '$');
 }
 
 /** Expand reserved storyboard creative-asset directives without mutating the fixture. */
 export function expandCreativeAssetDirectives(value: unknown, context: StoryboardContext, testKit: unknown): unknown {
-  if (Array.isArray(value)) {
-    return value.map(item => expandCreativeAssetDirectives(item, context, testKit));
-  }
-  if (!isObject(value)) return value;
-
-  if (Object.prototype.hasOwnProperty.call(value, BUILD_ASSETS_FROM_FORMAT_DIRECTIVE)) {
-    const built = buildAssets(value[BUILD_ASSETS_FROM_FORMAT_DIRECTIVE], context, testKit);
-    if (!built) return value;
-    const siblings = Object.fromEntries(
-      Object.entries(value)
-        .filter(([key]) => key !== BUILD_ASSETS_FROM_FORMAT_DIRECTIVE)
-        .map(([key, item]) => [key, expandCreativeAssetDirectives(item, context, testKit)])
-    );
-    return { ...siblings, ...built };
-  }
-
-  return Object.fromEntries(
-    Object.entries(value).map(([key, item]) => [key, expandCreativeAssetDirectives(item, context, testKit)])
-  );
+  return expandCreativeAssetDirectivesWithDiagnostics(value, context, testKit).value;
 }
 
 export function findUnresolvedCreativeAssetDirectives(value: unknown): string[] {

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -43,8 +43,9 @@ import { IDENTIFIER_DIGEST_LIMIT } from '../../upstream-recorder/constants';
 import { enrichRequest, hasRequestEnricher } from './request-builder';
 import {
   BUILD_ASSETS_FROM_FORMAT_DIRECTIVE,
-  expandCreativeAssetDirectives,
+  expandCreativeAssetDirectivesWithDiagnostics,
   findUnresolvedCreativeAssetDirectives,
+  type CreativeAssetExpansionFailure,
 } from './creative-assets';
 import { resolveAccount, resolveBrand } from '../client';
 import { isMutatingTask, generateIdempotencyKey } from '../../utils/idempotency';
@@ -437,6 +438,40 @@ function allExecutablePhasesCapabilitySkipped(
 
 function buildSkip(reason: RunnerSkipReason, detail?: string): { reason: RunnerSkipReason; detail: string } {
   return { reason, detail: detail ?? SKIP_DETAILS[reason] };
+}
+
+type CreativeAssetFixtureUnavailableFailure = Extract<
+  CreativeAssetExpansionFailure,
+  { reason: 'creative_asset_fixture_unavailable' }
+>;
+
+function buildCreativeAssetFixtureUnavailableStep(
+  step: StoryboardStep,
+  phaseId: string,
+  context: StoryboardContext,
+  allSteps: FlatStep[],
+  runState: ExecutionState,
+  failure: CreativeAssetFixtureUnavailableFailure,
+  task = step.task
+): StoryboardStepResult {
+  const detail =
+    `creative_asset_fixture_unavailable: slot "${failure.slotId}", asset type "${failure.assetType}", ` +
+    `constraint: ${failure.constraint} (${failure.path})`;
+  return {
+    step_id: step.id,
+    phase_id: phaseId,
+    title: step.title,
+    task,
+    passed: true,
+    skipped: true,
+    skip_reason: 'creative_asset_fixture_unavailable',
+    skip: buildSkip('not_applicable', detail),
+    duration_ms: 0,
+    validations: [],
+    context,
+    next: getNextStepPreview(step.id, allSteps, context, runState.runnerVars),
+    extraction: { path: 'none' },
+  };
 }
 
 interface ResponseDerivedSkip {
@@ -4150,7 +4185,19 @@ async function executeStep(
 
   // Assemble seller-required creative slots from the selected format and
   // active test kit after all other nested request construction is complete.
-  request = expandCreativeAssetDirectives(request, context, options.test_kit) as Record<string, unknown>;
+  const creativeAssetExpansion = expandCreativeAssetDirectivesWithDiagnostics(request, context, options.test_kit);
+  request = creativeAssetExpansion.value as Record<string, unknown>;
+  if (!creativeAssetExpansion.ok && creativeAssetExpansion.failure.reason === 'creative_asset_fixture_unavailable') {
+    return buildCreativeAssetFixtureUnavailableStep(
+      step,
+      phaseId,
+      context,
+      allSteps,
+      runState,
+      creativeAssetExpansion.failure,
+      effectiveStep.task
+    );
+  }
 
   // Detect unresolved $context placeholders — a prior step likely failed
   // and didn't produce the expected output. Skip rather than sending garbage.
@@ -5180,6 +5227,16 @@ async function executeProbeStep(
       };
       const targetRequestResult = buildEffectiveStepRequest(targetStep, context, options, runState);
       if (!targetRequestResult.ok) {
+        if ('creativeAssetFailure' in targetRequestResult) {
+          return buildCreativeAssetFixtureUnavailableStep(
+            step,
+            phaseId,
+            context,
+            allSteps,
+            runState,
+            targetRequestResult.creativeAssetFailure
+          );
+        }
         const next = getNextStepPreview(step.id, allSteps, context, runState.runnerVars);
         return {
           step_id: step.id,
@@ -5407,6 +5464,10 @@ async function executeProbeStep(
 
 type FixtureBindingApplicationResult = { ok: true; request: Record<string, unknown> } | { ok: false; error: string };
 
+type EffectiveStepRequestResult =
+  | FixtureBindingApplicationResult
+  | { ok: false; creativeAssetFailure: CreativeAssetFixtureUnavailableFailure };
+
 function applyFixtureBindingsSafely(
   request: Record<string, unknown>,
   task: string,
@@ -5433,7 +5494,7 @@ function buildEffectiveStepRequest(
   context: StoryboardContext,
   options: StoryboardRunOptions,
   runState: ExecutionState
-): FixtureBindingApplicationResult {
+): EffectiveStepRequestResult {
   let request: Record<string, unknown>;
   if (options.request) {
     request = injectContext({ ...options.request }, context, runState.runnerVars);
@@ -5456,12 +5517,17 @@ function buildEffectiveStepRequest(
   request = applyIdempotencyInvariant(request, step.task, step);
   const fixtureBinding = applyFixtureBindingsSafely(request, step.task, options, runState);
   if (!fixtureBinding.ok) return fixtureBinding;
+  const creativeAssetExpansion = expandCreativeAssetDirectivesWithDiagnostics(
+    fixtureBinding.request,
+    context,
+    options.test_kit
+  );
+  if (!creativeAssetExpansion.ok && creativeAssetExpansion.failure.reason === 'creative_asset_fixture_unavailable') {
+    return { ok: false, creativeAssetFailure: creativeAssetExpansion.failure };
+  }
   return {
     ok: true,
-    request: expandCreativeAssetDirectives(fixtureBinding.request, context, options.test_kit) as Record<
-      string,
-      unknown
-    >,
+    request: creativeAssetExpansion.value as Record<string, unknown>,
   };
 }
 

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -1880,6 +1880,8 @@ export type RunnerDetailedSkipReason =
   | 'fixture_seed_unsupported'
   /** A valid fixture strategy ladder exhausted without finding a binding. */
   | 'fixture_unsatisfied'
+  /** A valid seller format requires an asset slot the selected test kit cannot synthesize. */
+  | 'creative_asset_fixture_unavailable'
   /**
    * A `requires_capability` predicate on the storyboard evaluated to false —
    * the agent explicitly declared it does not support the capability this
@@ -1920,6 +1922,7 @@ export const DETAILED_SKIP_TO_CANONICAL: Record<RunnerDetailedSkipReason, Runner
   force_scenario_unsupported: 'not_applicable',
   fixture_seed_unsupported: 'not_applicable',
   fixture_unsatisfied: 'not_applicable',
+  creative_asset_fixture_unavailable: 'not_applicable',
   capability_unsupported: 'unsatisfied_contract',
   rate_abuse_opt_out: 'unsatisfied_contract',
   missing_test_kit_contract: 'unsatisfied_contract',

--- a/test/lib/storyboard-creative-assets.test.js
+++ b/test/lib/storyboard-creative-assets.test.js
@@ -1,10 +1,14 @@
 const { describe, test } = require('node:test');
 const assert = require('node:assert');
 
-const { BUILD_ASSETS_FROM_FORMAT_DIRECTIVE } = require('../../dist/lib/testing/storyboard/creative-assets');
+const {
+  BUILD_ASSETS_FROM_FORMAT_DIRECTIVE,
+  expandCreativeAssetDirectivesWithDiagnostics,
+} = require('../../dist/lib/testing/storyboard/creative-assets');
 const { expandCreativeAssetDirectives, findUnresolvedCreativeAssetDirectives } = require('../../dist/lib/testing');
 const { injectContext } = require('../../dist/lib/testing/storyboard/context');
 const { runStoryboard } = require('../../dist/lib/testing/storyboard/runner');
+const { DETAILED_SKIP_TO_CANONICAL } = require('../../dist/lib/testing/storyboard/types');
 
 const TEST_KIT = {
   assets: {
@@ -23,7 +27,68 @@ const TEST_KIT = {
   },
 };
 
+function buildCreativeSyncStoryboard({ context, directive, formatKind = 'image' }) {
+  return {
+    id: 'creative_asset_preflight',
+    version: '1.0.0',
+    title: 'Creative asset preflight',
+    category: 'compliance',
+    summary: '',
+    narrative: '',
+    agent: { interaction_model: '*', capabilities: [] },
+    caller: { role: 'buyer_agent' },
+    context,
+    phases: [
+      {
+        id: 'creative',
+        title: 'Creative',
+        steps: [
+          {
+            id: 'sync',
+            title: 'Sync creative',
+            task: 'sync_creatives',
+            expect_error: true,
+            sample_request: {
+              account: { operator: 'seller.example' },
+              creatives: [
+                {
+                  creative_id: 'creative-1',
+                  format_kind: formatKind,
+                  assets: { [BUILD_ASSETS_FROM_FORMAT_DIRECTIVE]: directive },
+                },
+              ],
+            },
+            validations: [],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function runnerOptions(calls) {
+  return {
+    protocol: 'mcp',
+    agentTools: ['sync_creatives'],
+    _profile: { name: 'Test', tools: ['sync_creatives'] },
+    _client: {
+      async executeTask(name, params) {
+        calls.push({ name, params });
+        return { success: true, data: {} };
+      },
+      async getAgentInfo() {
+        return { name: 'Test', tools: [{ name: 'sync_creatives' }] };
+      },
+    },
+    test_kit: TEST_KIT,
+  };
+}
+
 describe('$build_assets_from_format', () => {
+  test('maps fixture-unavailable diagnostics to canonical not_applicable', () => {
+    assert.strictEqual(DETAILED_SKIP_TO_CANONICAL.creative_asset_fixture_unavailable, 'not_applicable');
+  });
+
   test('uses canonical required slots and selects the exact declared dimensions', () => {
     const request = {
       creatives: [
@@ -103,6 +168,151 @@ describe('$build_assets_from_format', () => {
     assert.deepStrictEqual(expanded.assets.tracking_pixel, trackingPixel);
     assert.strictEqual(expanded.assets.image_main.url, 'https://assets.example/320x50.jpg');
     assert.strictEqual(BUILD_ASSETS_FROM_FORMAT_DIRECTIVE in expanded.assets, false);
+  });
+
+  test('builds recognized image, URL, headline, description, and CTA slots', () => {
+    const expanded = expandCreativeAssetDirectives(
+      {
+        assets: {
+          [BUILD_ASSETS_FROM_FORMAT_DIRECTIVE]: {
+            width: 300,
+            height: 250,
+            slots: [
+              { asset_group_id: 'image_main', asset_type: 'image', required: true },
+              { asset_group_id: 'landing_url', asset_type: 'url', required: true },
+              { asset_group_id: 'marketing_headline', asset_type: 'text', required: true },
+              { asset_group_id: 'body_copy', asset_type: 'text', required: true },
+              { asset_group_id: 'primary_cta', asset_type: 'text', required: true },
+            ],
+          },
+        },
+      },
+      {},
+      TEST_KIT
+    );
+
+    assert.strictEqual(expanded.assets.image_main.url, 'https://assets.example/300x250.jpg');
+    assert.deepStrictEqual(expanded.assets.landing_url, {
+      asset_type: 'url',
+      url: 'https://acmeoutdoor.example/summer-sale',
+    });
+    assert.deepStrictEqual(expanded.assets.marketing_headline, {
+      asset_type: 'text',
+      content: 'Built for the Trail',
+    });
+    assert.deepStrictEqual(expanded.assets.body_copy, {
+      asset_type: 'text',
+      content: 'Adventure starts here',
+    });
+    assert.deepStrictEqual(expanded.assets.primary_cta, { asset_type: 'text', content: 'Shop Now' });
+  });
+
+  test('reports unsupported asset types with a slot-level fixture diagnostic', () => {
+    for (const assetType of ['video', 'audio', 'html', 'javascript', 'vast_tag']) {
+      const result = expandCreativeAssetDirectivesWithDiagnostics(
+        {
+          assets: {
+            [BUILD_ASSETS_FROM_FORMAT_DIRECTIVE]: {
+              slots: [{ asset_group_id: `${assetType}_main`, asset_type: assetType, required: true }],
+            },
+          },
+        },
+        {},
+        TEST_KIT
+      );
+
+      assert.strictEqual(result.ok, false);
+      assert.strictEqual(result.failure.reason, 'creative_asset_fixture_unavailable');
+      assert.strictEqual(result.failure.slotId, `${assetType}_main`);
+      assert.strictEqual(result.failure.assetType, assetType);
+      assert.match(result.failure.constraint, new RegExp(`asset type "${assetType}"`));
+    }
+  });
+
+  test('reports an unavailable exact image dimension', () => {
+    const result = expandCreativeAssetDirectivesWithDiagnostics(
+      {
+        assets: {
+          [BUILD_ASSETS_FROM_FORMAT_DIRECTIVE]: {
+            width: 970,
+            height: 250,
+            slots: [{ asset_group_id: 'billboard', asset_type: 'image', required: true }],
+          },
+        },
+      },
+      {},
+      TEST_KIT
+    );
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.failure.reason, 'creative_asset_fixture_unavailable');
+    assert.strictEqual(result.failure.slotId, 'billboard');
+    assert.strictEqual(result.failure.assetType, 'image');
+    assert.match(result.failure.constraint, /exact 970x250/);
+  });
+
+  test('does not substitute marketing copy for an unknown text semantic', () => {
+    const result = expandCreativeAssetDirectivesWithDiagnostics(
+      {
+        assets: {
+          [BUILD_ASSETS_FROM_FORMAT_DIRECTIVE]: {
+            slots: [{ asset_group_id: 'legal_disclaimer', asset_type: 'text', required: true }],
+          },
+        },
+      },
+      {},
+      TEST_KIT
+    );
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.failure.reason, 'creative_asset_fixture_unavailable');
+    assert.strictEqual(result.failure.slotId, 'legal_disclaimer');
+    assert.strictEqual(result.failure.assetType, 'text');
+    assert.match(result.failure.constraint, /does not identify a supported headline/);
+  });
+
+  test('distinguishes missing format context and malformed directives from fixture gaps', () => {
+    const missingFormat = expandCreativeAssetDirectivesWithDiagnostics(
+      { assets: { [BUILD_ASSETS_FROM_FORMAT_DIRECTIVE]: { id: 'missing_format' } } },
+      {},
+      TEST_KIT
+    );
+    assert.strictEqual(missingFormat.ok, false);
+    assert.strictEqual(missingFormat.failure.reason, 'format_not_found');
+
+    const malformed = expandCreativeAssetDirectivesWithDiagnostics(
+      { assets: { [BUILD_ASSETS_FROM_FORMAT_DIRECTIVE]: 'not-a-format' } },
+      {},
+      TEST_KIT
+    );
+    assert.strictEqual(malformed.ok, false);
+    assert.strictEqual(malformed.failure.reason, 'malformed_directive');
+  });
+
+  test('preserves unvisited sibling data when a nested directive cannot expand', () => {
+    const result = expandCreativeAssetDirectivesWithDiagnostics(
+      {
+        assets: {
+          [BUILD_ASSETS_FROM_FORMAT_DIRECTIVE]: {
+            width: 300,
+            height: 250,
+            slots: [{ asset_group_id: 'image_main', asset_type: 'image', required: true }],
+          },
+          nested: {
+            [BUILD_ASSETS_FROM_FORMAT_DIRECTIVE]: {
+              slots: [{ asset_group_id: 'video_main', asset_type: 'video', required: true }],
+            },
+          },
+          metadata: { authored: true },
+        },
+      },
+      {},
+      TEST_KIT
+    );
+
+    assert.strictEqual(result.ok, false);
+    assert.deepStrictEqual(result.value.assets.metadata, { authored: true });
+    assert.strictEqual(result.value.assets.image_main.url, 'https://assets.example/300x250.jpg');
   });
 
   test('leaves an unfulfillable directive detectable so it cannot reach transport', () => {
@@ -190,7 +400,7 @@ describe('$build_assets_from_format', () => {
     assert.strictEqual(BUILD_ASSETS_FROM_FORMAT_DIRECTIVE in calls[0].params.creatives[0].assets, false);
   });
 
-  test('runner fails pre-wire when a required seller asset cannot be populated', async () => {
+  test('runner grades an unavailable seller asset not_applicable before transport', async () => {
     const calls = [];
     const storyboard = {
       id: 'creative_asset_preflight_failure',
@@ -251,8 +461,167 @@ describe('$build_assets_from_format', () => {
     assert.strictEqual(calls.length, 0);
     const step = result.phases[0].steps[0];
     assert.strictEqual(step.skipped, true);
+    assert.strictEqual(step.passed, true);
+    assert.strictEqual(step.skip_reason, 'creative_asset_fixture_unavailable');
+    assert.strictEqual(step.skip.reason, 'not_applicable');
+    assert.match(step.skip.detail, /^creative_asset_fixture_unavailable:/);
+    assert.match(step.skip.detail, /slot "video_main"/);
+    assert.match(step.skip.detail, /asset type "video"/);
+    assert.match(step.skip.detail, /constraint:/);
+    assert.deepStrictEqual(step.validations, []);
+    assert.strictEqual(result.failed_count, 0);
+    assert.strictEqual(result.skipped_count, 1);
+    assert.strictEqual(result.overall_passed, true);
+  });
+
+  test('missing format context remains a prerequisite failure', async () => {
+    const calls = [];
+    const storyboard = buildCreativeSyncStoryboard({
+      context: {},
+      directive: { agent_url: 'https://seller.example', id: 'missing_format' },
+    });
+
+    const result = await runStoryboard('https://seller.example/mcp', storyboard, runnerOptions(calls));
+
+    assert.strictEqual(calls.length, 0);
+    const step = result.phases[0].steps[0];
+    assert.strictEqual(step.skipped, true);
+    assert.strictEqual(step.passed, false);
+    assert.strictEqual(step.skip_reason, 'prerequisite_failed');
+    assert.strictEqual(step.skip.reason, 'prerequisite_failed');
     assert.strictEqual(step.validations[0].check, 'unresolved_substitution');
-    assert.strictEqual(step.validations[0].expected, BUILD_ASSETS_FROM_FORMAT_DIRECTIVE);
+  });
+
+  test('failed format producer leaves its consumer on the prerequisite-failure cascade', async () => {
+    const calls = [];
+    const storyboard = {
+      id: 'creative_asset_failed_producer',
+      version: '1.0.0',
+      title: 'Creative asset failed producer',
+      category: 'compliance',
+      summary: '',
+      narrative: '',
+      agent: { interaction_model: '*', capabilities: [] },
+      caller: { role: 'buyer_agent' },
+      phases: [
+        {
+          id: 'discovery',
+          title: 'Discovery',
+          steps: [
+            {
+              id: 'formats',
+              title: 'Discover formats',
+              task: 'list_creative_formats',
+              sample_request: {},
+              context_outputs: [{ key: 'format_params', path: '$.formats[0]' }],
+              validations: [],
+            },
+          ],
+        },
+        {
+          id: 'creative',
+          title: 'Creative',
+          steps: [
+            {
+              id: 'sync',
+              title: 'Sync creative',
+              task: 'sync_creatives',
+              sample_request: {
+                account: { operator: 'seller.example' },
+                creatives: [
+                  {
+                    creative_id: 'creative-1',
+                    format_kind: 'image',
+                    assets: { [BUILD_ASSETS_FROM_FORMAT_DIRECTIVE]: '$context.format_params' },
+                  },
+                ],
+              },
+              validations: [],
+            },
+          ],
+        },
+      ],
+    };
+    const options = runnerOptions(calls);
+    options.agentTools = ['list_creative_formats', 'sync_creatives'];
+    options._profile.tools = options.agentTools;
+    options._client.executeTask = async name => {
+      calls.push({ name });
+      return { success: false, error: 'producer failed', data: {} };
+    };
+
+    const result = await runStoryboard('https://seller.example/mcp', storyboard, options);
+
+    assert.deepStrictEqual(
+      calls.map(call => call.name),
+      ['list_creative_formats']
+    );
+    const consumer = result.phases[1].steps[0];
+    assert.strictEqual(consumer.skipped, true);
+    assert.strictEqual(consumer.skip_reason, 'prerequisite_failed');
+    assert.strictEqual(consumer.skip.reason, 'prerequisite_failed');
+  });
+
+  test('rate-limit trip target also grades an unavailable fixture pre-wire', async () => {
+    const calls = [];
+    const storyboard = {
+      id: 'creative_asset_rate_limit_preflight',
+      version: '1.0.0',
+      title: 'Creative asset rate-limit preflight',
+      category: 'compliance',
+      summary: '',
+      narrative: '',
+      agent: { interaction_model: '*', capabilities: [] },
+      caller: { role: 'buyer_agent' },
+      context: {
+        format_params: {
+          slots: [{ asset_group_id: 'vast_main', asset_type: 'vast_tag', required: true }],
+        },
+      },
+      phases: [
+        {
+          id: 'creative',
+          title: 'Creative',
+          steps: [
+            {
+              id: 'trip',
+              title: 'Trip sync creatives rate limit',
+              task: 'expect_rate_limit_not_replayed',
+              rate_limit_trip: {
+                trip_target_task: 'sync_creatives',
+                trip_target_sample_request: {
+                  account: { operator: 'seller.example' },
+                  creatives: [
+                    {
+                      creative_id: 'creative-1',
+                      format_kind: 'video',
+                      assets: { [BUILD_ASSETS_FROM_FORMAT_DIRECTIVE]: '$context.format_params' },
+                    },
+                  ],
+                },
+                max_attempts: 50,
+                replay_max_wait_seconds: 1,
+              },
+              validations: [],
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = await runStoryboard('https://seller.example/mcp', storyboard, runnerOptions(calls));
+
+    assert.strictEqual(calls.length, 0);
+    const step = result.phases[0].steps[0];
+    assert.strictEqual(step.passed, true);
+    assert.strictEqual(step.skipped, true);
+    assert.strictEqual(step.skip_reason, 'creative_asset_fixture_unavailable');
+    assert.strictEqual(step.skip.reason, 'not_applicable');
+    assert.match(step.skip.detail, /slot "vast_main"/);
+    assert.match(step.skip.detail, /asset type "vast_tag"/);
+    assert.strictEqual(result.failed_count, 0);
+    assert.strictEqual(result.skipped_count, 1);
+    assert.strictEqual(result.overall_passed, true);
   });
 });
 


### PR DESCRIPTION
## Summary

- distinguish unavailable creative fixtures from malformed directives and missing format context
- grade unsynthesizable required slots as canonical `not_applicable` before schema validation or transport
- preserve slot/type/constraint diagnostics and remove fallback marketing copy for unknown text semantics
- keep ordinary dispatch and rate-limit-trip request construction aligned

## Root cause

`$build_assets_from_format` previously returned only an unresolved directive when any required slot could not be populated. The runner could not distinguish its own finite fixture coverage from a seller or prerequisite failure, and unknown text semantics could silently receive unrelated marketing copy.

## Validation

- `node --test --test-timeout=60000 test/lib/storyboard-creative-assets.test.js` (17/17 passing)
- repository pre-push typecheck and build
- commitlint and PR-title validation
- independent protocol, code-review, and Node testing expert reviews (all approved)

Fixes #2465
