### PR TITLE
fix(webhooks): disable synchronous completion emission by default

### DIFF
--- a/.changeset/fix-sync-completion-webhook-default.md
+++ b/.changeset/fix-sync-completion-webhook-default.md
@@ -1,5 +1,5 @@
 ---
-'@adcp/sdk': patch
+'@adcp/sdk': minor
 ---
 
 Stop emitting completion webhooks for synchronous terminal responses by default, as required by AdCP. Existing adopters can temporarily restore the previous duplicate-delivery behavior with the explicit, non-conformant `autoEmitCompletionWebhooks: true` compatibility option.

--- a/.changeset/fix-sync-completion-webhook-default.md
+++ b/.changeset/fix-sync-completion-webhook-default.md
@@ -1,5 +1,5 @@
 ---
-'@adcp/sdk': minor
+'@adcp/sdk': major
 ---
 
 Stop emitting completion webhooks for synchronous terminal responses by default, as required by AdCP. Existing adopters can temporarily restore the previous duplicate-delivery behavior with the explicit, non-conformant `autoEmitCompletionWebhooks: true` compatibility option.

--- a/.changeset/fix-sync-completion-webhook-default.md
+++ b/.changeset/fix-sync-completion-webhook-default.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Stop emitting completion webhooks for synchronous terminal responses by default, as required by AdCP. Existing adopters can temporarily restore the previous duplicate-delivery behavior with the explicit, non-conformant `autoEmitCompletionWebhooks: true` compatibility option.

--- a/docs/guides/BUILD-AN-AGENT.md
+++ b/docs/guides/BUILD-AN-AGENT.md
@@ -21,7 +21,9 @@ interfaces: `SalesCorePlatform` + `SalesIngestionPlatform`,
 `CampaignGovernancePlatform`, `BrandRightsPlatform`, etc.) and the
 framework wires capability projection, idempotency, RFC 9421 signing,
 async tasks, status normalization, lifecycle state, multi-tenant
-routing, and webhook auto-emit on sync mutations. Compile-time
+routing, and async task completion webhooks. Synchronous terminal
+responses stay inline unless an adopter explicitly enables the
+non-conformant `autoEmitCompletionWebhooks` compatibility option. Compile-time
 enforcement via `RequiredPlatformsFor<S>` catches missing methods
 before runtime. The `definePlatform` / `defineSalesCorePlatform` /
 sibling helpers let you write inline platform literals without
@@ -161,7 +163,7 @@ serve(() => createAdcpServerFromPlatform(platform, { name: 'My Publisher', versi
 - **Auto-generates `get_adcp_capabilities`** from registered platform methods — no manual capability declaration.
 - **Auto-applies response builders** — return raw data, the framework wraps them in MCP `CallToolResult` with `structuredContent`.
 - **Resolves accounts** — `accounts.resolve(ref, ctx)` runs before your platform method, the resolved account lands at `ctx.account`. Returns `ACCOUNT_NOT_FOUND` envelope if resolution returns null. `accounts.resolution: 'implicit'` enforces inline-`{account_id}` refusal at the framework boundary (post-6.7 — pre-6.7 the docstring was aspirational).
-- **Idempotency, signing, async tasks, status normalization, lifecycle state** are framework-owned. Adopters write the business decisions.
+- **Idempotency, signing, async tasks, status normalization, lifecycle state** are framework-owned. Synchronous terminal responses do not emit completion webhooks by default; the inline result is authoritative. Adopters write the business decisions.
 - **Catches handler errors** — unhandled exceptions return `SERVICE_UNAVAILABLE` instead of crashing. Throw a typed error class (see § "Returning errors from handlers") to surface a structured envelope.
 
 ### Identity, multi-tenant, and lifecycle helpers (6.7)

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -44,7 +44,7 @@ serve(() => createAdcpServerFromPlatform(platform, {
 })); // http://localhost:3001/mcp
 ```
 
-Compile-time enforcement: `RequiredPlatformsFor<S>` catches missing specialism methods. Capability projection auto-derives `get_adcp_capabilities` blocks (`audience_targeting`, `conversion_tracking`, `compliance_testing.scenarios`, etc.). Idempotency, RFC 9421 signing, async tasks, status normalization, and sync-completion webhook auto-emit are framework-owned.
+Compile-time enforcement: `RequiredPlatformsFor<S>` catches missing specialism methods. Capability projection auto-derives `get_adcp_capabilities` blocks (`audience_targeting`, `conversion_tracking`, `compliance_testing.scenarios`, etc.). Idempotency, RFC 9421 signing, async tasks, and status normalization are framework-owned. Synchronous terminal responses do not emit completion webhooks by default; `autoEmitCompletionWebhooks: true` is available only as a non-conformant compatibility extension.
 
 Lower-level option: `createAdcpServer({ signals: { getSignals: ... } })` from `@adcp/sdk/server/legacy/v5` — handler-bag API. Still fully supported, the substrate the platform path calls into. Use when you need fine control over individual handlers, mid-migration from a v5 codebase, or custom-shaped tools the platform interface doesn't yet model. `wrapEnvelope(inner, { replayed, context, operationId })` from `@adcp/sdk/server` attaches protocol envelope fields with the per-error-code allowlist (IDEMPOTENCY_CONFLICT drops `replayed`).
 

--- a/docs/migration-12-to-13.md
+++ b/docs/migration-12-to-13.md
@@ -30,6 +30,22 @@ CI consumers that need a stable, compact artifact should continue using
 used `_view: 'reference'` on a `TrackResult` should use `TestedTrackEntry` instead;
 `TrackResult._view` now accepts only `'canonical'`.
 
+## Synchronous completion webhooks
+
+`createAdcpServerFromPlatform()` no longer emits a completion webhook by
+default when a request returns a terminal result inline. AdCP completion
+webhooks describe status changes after the initial response; buyers already
+have a synchronous result and should consume it directly.
+
+Existing integrations that temporarily depend on duplicate inline + webhook
+delivery can pass `autoEmitCompletionWebhooks: true`. This is a non-conformant
+compatibility extension covering synchronous discovery (`get_products`,
+`get_signals`) and mutation responses. Its synthesized `sync-*` task ID is not
+registered and cannot be polled with `get_task_status`. Delivery is detached
+and best-effort, so use durable request idempotency, ingress rate limits, and
+bounded emitter timeouts while migrating. Remove the option once buyers handle
+the inline terminal response.
+
 ## Root type imports are canonical
 
 The unqualified root exports `Product`, `Format`, `CreativeAsset`, `Package`, `PackageRequest`, `PackageUpdate`, `Placement`, `CreateMediaBuyRequest`, `UpdateMediaBuyRequest`, `SyncCreativesRequest`, and their creative-bearing response and server-payload types now mean their canonical shapes. Legacy wire shapes have `Legacy*` names. The old format-reference types are available only as `LegacyFormatID` / `LegacyFormatReferenceStructuredObject` from the root; the explicit `@adcp/sdk/types` protocol subpath remains raw for wire tooling.

--- a/docs/migration-5.x-to-6.x.md
+++ b/docs/migration-5.x-to-6.x.md
@@ -438,14 +438,20 @@ createAdcpServerFromPlatform(platform, {
   `{ tenantId, config, server } | null` without URL parsing. Use this
   instead of `resolveByRequest(canonicalHost, '/<id>/mcp')` tricks.
   Same `pending` / `disabled` health gate as the resolveByXxx helpers.
-- **`autoEmitCompletionWebhooks` is on by default (v6.0).** Sync-success
-  arms of `create_media_buy` / `update_media_buy` / `sync_creatives`
-  auto-fire a completion webhook when the buyer supplied
-  `push_notification_config.url`. Fire-and-forget — does not block the
-  sync response. Adopters who emit webhooks manually inside their
-  handlers (idempotency duplication concern) pass
-  `autoEmitCompletionWebhooks: false` on `createAdcpServerFromPlatform`
-  to suppress.
+- **`autoEmitCompletionWebhooks` now defaults to `false`.** AdCP sends
+  completion webhooks only for status changes after the initial response;
+  a request that returns a terminal result inline does not also emit a
+  completion webhook. This reverses the v6.0 default. Existing integrations
+  that temporarily require the old duplicate-delivery behavior can pass
+  `autoEmitCompletionWebhooks: true` to `createAdcpServerFromPlatform`.
+  That opt-in is a non-conformant compatibility extension: its synthesized
+  `sync-*` task ID is not registered and cannot be polled with
+  `get_task_status`, and it applies to synchronous discovery responses
+  (`get_products`, `get_signals`) as well as mutations. Delivery is detached
+  and best-effort. Use a durable request idempotency store, ingress rate
+  limits, and bounded emitter timeouts while the option is enabled to avoid
+  replayed duplicates or unbounded work from slow receivers. Migrate buyers
+  to consume the inline terminal result, then remove the option.
 - **`allowPrivateWebhookUrls` for sandbox testing.** The framework
   rejects loopback / RFC 1918 / link-local destinations on
   `push_notification_config.url` by default — accepting them in

--- a/scripts/generate-agent-docs.ts
+++ b/scripts/generate-agent-docs.ts
@@ -566,7 +566,7 @@ function generateLlmsTxt(
   ln('```');
   ln();
   ln(
-    `Compile-time enforcement: \`RequiredPlatformsFor<S>\` catches missing specialism methods. Capability projection auto-derives \`get_adcp_capabilities\` blocks (\`audience_targeting\`, \`conversion_tracking\`, \`compliance_testing.scenarios\`, etc.). Idempotency, RFC 9421 signing, async tasks, status normalization, and sync-completion webhook auto-emit are framework-owned.`
+    `Compile-time enforcement: \`RequiredPlatformsFor<S>\` catches missing specialism methods. Capability projection auto-derives \`get_adcp_capabilities\` blocks (\`audience_targeting\`, \`conversion_tracking\`, \`compliance_testing.scenarios\`, etc.). Idempotency, RFC 9421 signing, async tasks, and status normalization are framework-owned. Synchronous terminal responses do not emit completion webhooks by default; \`autoEmitCompletionWebhooks: true\` is available only as a non-conformant compatibility extension.`
   );
   ln();
   ln(

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -3659,8 +3659,9 @@ function selectServedAdcpRelease(
  * auto-hydration of `req.packages[i].product` on createMediaBuy,
  * default `resolveIdempotencyPrincipal` synthesis, capability projection,
  * async-task envelopes, status normalization via `StatusMappers`,
- * multi-tenant routing via `TenantRegistry`, and webhook auto-emit on
- * sync responses with `push_notification_config.url`.
+ * multi-tenant routing via `TenantRegistry`, and async task completion
+ * webhook delivery. Synchronous terminal responses remain inline unless
+ * an adopter explicitly enables the non-conformant compatibility option.
  *
  * Reach for `createAdcpServer` directly only when you need fine control
  * over individual handlers, are mid-migration from a v5 codebase, or

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -1402,19 +1402,23 @@ export interface CreateAdcpServerFromPlatformOptions extends Omit<
   strictSpecialismValidation?: boolean;
 
   /**
-   * Auto-fire a completion webhook on the sync-success arm of mutating
-   * tools when the request supplied `push_notification_config.url`.
-   * Default is `true` — buyers passing the URL expect notification
-   * regardless of whether the seller routed the call sync vs HITL, and
-   * v5 adopters routinely wired this manually inside every handler.
-   * The framework now does it for them.
+   * Auto-fire a completion webhook on the sync-success arm of task-capable
+   * tools when the request supplied `push_notification_config.url`. This
+   * includes discovery (`get_products`, `get_signals`) as well as mutations
+   * such as `create_media_buy`, `update_media_buy`, and `sync_creatives`.
+   * Default is `false`: AdCP completion webhooks describe status changes
+   * after the initial response, so a terminal response delivered inline
+   * must not also emit a webhook.
    *
-   * Webhook payload mirrors the HITL completion shape: top-level
+   * Setting this to `true` preserves the legacy compatibility behavior,
+   * but is a non-conformant extension. The webhook payload mirrors the
+   * HITL completion shape: top-level
    * `task_type` (the wire tool name), `status: 'completed'`, and
    * `result` carrying the projected sync response. `task_id` is
    * synthesized per call (sync responses don't allocate a registry
-   * task); buyers correlate via the resource IDs (`media_buy_id`,
-   * `creative_id`, etc.) on `result`.
+   * task), cannot be used with `get_task_status`, and exists only to
+   * satisfy the webhook payload shape. Buyers must correlate via the
+   * resource IDs (`media_buy_id`, `creative_id`, etc.) on `result`.
    *
    * Same `SPEC_WEBHOOK_TASK_TYPES` gate as the HITL path: tools outside
    * the closed wire enum don't emit (adopters use `publishStatusChange`
@@ -1422,10 +1426,12 @@ export interface CreateAdcpServerFromPlatformOptions extends Omit<
    * `emitWebhook` plumbing — host-wired signing, redelivery, and
    * observability hooks all apply uniformly.
    *
-   * Set `false` to suppress the auto-emit for adopters who emit
-   * webhooks manually inside their handlers (idempotency duplication
-   * concern) or for transitional deployments that don't yet have the
-   * webhook receiver path stood up.
+   * Use this opt-in only while migrating an existing integration that
+   * relies on duplicate inline + webhook delivery. New integrations
+   * should handle the terminal inline response instead. Compatibility
+   * delivery is detached and best-effort: use durable request idempotency,
+   * ingress rate limits, and bounded emitter timeouts to avoid duplicate
+   * deliveries or unbounded work from replayed or slow requests.
    */
   autoEmitCompletionWebhooks?: boolean;
 
@@ -2178,7 +2184,7 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
         fwLogger,
         {
           allowPrivateWebhookUrls: opts.allowPrivateWebhookUrls === true,
-          autoEmitCompletionWebhooks: opts.autoEmitCompletionWebhooks !== false,
+          autoEmitCompletionWebhooks: opts.autoEmitCompletionWebhooks === true,
         },
         ctxFor,
         effectiveCtxMetadata,
@@ -2201,7 +2207,7 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
         fwLogger,
         {
           allowPrivateWebhookUrls: opts.allowPrivateWebhookUrls === true,
-          autoEmitCompletionWebhooks: opts.autoEmitCompletionWebhooks !== false,
+          autoEmitCompletionWebhooks: opts.autoEmitCompletionWebhooks === true,
         },
         ctxFor,
         opts.legacyCreativeFormatConverter,
@@ -2227,7 +2233,7 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
         fwLogger,
         {
           allowPrivateWebhookUrls: opts.allowPrivateWebhookUrls === true,
-          autoEmitCompletionWebhooks: opts.autoEmitCompletionWebhooks !== false,
+          autoEmitCompletionWebhooks: opts.autoEmitCompletionWebhooks === true,
         },
         ctxFor,
         effectiveCtxMetadata

--- a/src/lib/server/index.ts
+++ b/src/lib/server/index.ts
@@ -505,10 +505,11 @@ export type {
 // `createAdcpServerFromPlatform` wraps `createAdcpServer` (the lower-level
 // handler-bag entry above) with compile-time specialism enforcement
 // (`RequiredPlatformsFor<S>`), capability projection, idempotency wiring,
-// async tasks, status normalization, multi-tenant routing, and webhook
-// auto-emit. Adopters declare a typed `DecisioningPlatform` per-specialism
-// and the framework wires the rest. See `docs/migration-5.x-to-6.x.md`
-// and `skills/build-decisioning-platform/` for the full walkthrough.
+// async tasks, status normalization, multi-tenant routing, and async task
+// completion webhooks. Synchronous terminal responses remain inline by
+// default. Adopters declare a typed `DecisioningPlatform` per-specialism
+// and the framework wires the rest. See `docs/migration-5.x-to-6.x.md` and
+// `skills/build-decisioning-platform/` for the full walkthrough.
 //
 // Both `createAdcpServer` and `createAdcpServerFromPlatform` live on the
 // same import path so adopters discover them as siblings; pick the

--- a/src/lib/server/legacy/v5/index.ts
+++ b/src/lib/server/legacy/v5/index.ts
@@ -7,7 +7,8 @@
  * which wraps this constructor with the typed specialism interfaces,
  * compile-time capability enforcement, ctx_metadata auto-hydration,
  * idempotency-principal synthesis, status mappers, multi-tenant routing,
- * and webhook auto-emit. See `docs/migration-5.x-to-6.x.md`.
+ * and async task completion webhooks. Synchronous terminal responses remain
+ * inline by default. See `docs/migration-5.x-to-6.x.md`.
  *
  * Reasons to import from `legacy/v5` rather than `@adcp/sdk/server`:
  *

--- a/test/server-decisioning-auto-emit-completion.test.js
+++ b/test/server-decisioning-auto-emit-completion.test.js
@@ -1,9 +1,6 @@
-// F12 — auto-emit completion webhook on sync responses with
-// push_notification_config.url. v6 framework previously fired only on
-// HITL task completion; sync mutating tools left buyers polling
-// (or adopters wired ctx.emitWebhook manually inside every handler).
-// Spec-listed mutating tools (create_media_buy, update_media_buy,
-// sync_creatives) now auto-fire when the buyer supplied a push URL.
+// Sync terminal responses do not emit completion webhooks by default.
+// `autoEmitCompletionWebhooks: true` preserves the legacy behavior as
+// an explicit, non-conformant compatibility extension.
 
 process.env.NODE_ENV = 'test';
 
@@ -49,7 +46,7 @@ function basePlatform() {
   };
 }
 
-function buildServer(opts = {}) {
+function buildServer(opts = {}, platform = basePlatform()) {
   const calls = [];
   const taskWebhookEmitter = {
     emit: async params => {
@@ -58,7 +55,7 @@ function buildServer(opts = {}) {
     },
     unsigned: true, // suppress signed-emitter warning in tests
   };
-  const server = createAdcpServerFromPlatform(basePlatform(), {
+  const server = createAdcpServerFromPlatform(platform, {
     name: 'auto-emit-host',
     version: '0.0.1',
     validation: { requests: 'off', responses: 'off' },
@@ -89,9 +86,73 @@ async function flushMicrotasks() {
   await new Promise(r => setImmediate(r));
 }
 
-describe('F12: auto-emit completion webhook on sync mutating responses', () => {
-  it('fires webhook on sync create_media_buy success when push_notification_config.url is set', async () => {
+describe('sync completion webhook compatibility opt-in', () => {
+  it('does not emit a webhook for a synchronous terminal response by default', async () => {
     const { server, calls } = buildServer();
+    const result = await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'create_media_buy',
+        arguments: {
+          ...ARGS_BASE,
+          push_notification_config: { url: 'https://buyer.example.com/webhook' },
+        },
+      },
+    });
+    assert.notStrictEqual(result.isError, true, JSON.stringify(result.structuredContent));
+    assert.strictEqual(result.structuredContent.media_buy_id, 'mb_42');
+    await flushMicrotasks();
+    assert.strictEqual(calls.length, 0, 'sync terminal response must not emit by default');
+  });
+
+  it('does not emit by default through the creative-owned sync_creatives path', async () => {
+    const platform = basePlatform();
+    delete platform.sales;
+    platform.capabilities.specialisms = [];
+    platform.creative = {
+      syncCreatives: async () => [{ creative_id: 'cr_1', action: 'created', status: 'approved' }],
+    };
+    const { server, calls } = buildServer({}, platform);
+    const result = await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'sync_creatives',
+        arguments: {
+          account: { account_id: 'acc_1' },
+          creatives: [{ creative_id: 'cr_1', name: 'Creative 1', format_kind: 'image', assets: {} }],
+          idempotency_key: 'dddddddd-dddd-dddd-dddd-dddddddddddd',
+          push_notification_config: { url: 'https://buyer.example.com/webhook' },
+        },
+      },
+    });
+    assert.notStrictEqual(result.isError, true, JSON.stringify(result.structuredContent));
+    await flushMicrotasks();
+    assert.strictEqual(calls.length, 0, 'creative sync terminal response must not emit by default');
+  });
+
+  it('does not emit by default through the synchronous get_signals path', async () => {
+    const platform = basePlatform();
+    platform.signals = { getSignals: async () => ({ signals: [] }) };
+    const { server, calls } = buildServer({}, platform);
+    const result = await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'get_signals',
+        arguments: {
+          account: { account_id: 'acc_1' },
+          discovery_mode: 'brief',
+          brief: 'sports fans',
+          push_notification_config: { url: 'https://buyer.example.com/webhook' },
+        },
+      },
+    });
+    assert.notStrictEqual(result.isError, true, JSON.stringify(result.structuredContent));
+    await flushMicrotasks();
+    assert.strictEqual(calls.length, 0, 'signals sync terminal response must not emit by default');
+  });
+
+  it('fires webhook when the non-conformant compatibility extension is explicitly enabled', async () => {
+    const { server, calls } = buildServer({ autoEmitCompletionWebhooks: true });
     const result = await server.dispatchTestRequest({
       method: 'tools/call',
       params: {
@@ -116,7 +177,7 @@ describe('F12: auto-emit completion webhook on sync mutating responses', () => {
   });
 
   it('does NOT fire when buyer omits push_notification_config.url', async () => {
-    const { server, calls } = buildServer();
+    const { server, calls } = buildServer({ autoEmitCompletionWebhooks: true });
     await server.dispatchTestRequest({
       method: 'tools/call',
       params: { name: 'create_media_buy', arguments: ARGS_BASE },
@@ -140,23 +201,8 @@ describe('F12: auto-emit completion webhook on sync mutating responses', () => {
     assert.strictEqual(calls.length, 0, 'auto-emit suppressed');
   });
 
-  it('default (option omitted) is true — webhook fires', async () => {
-    const { server, calls } = buildServer({});
-    await server.dispatchTestRequest({
-      method: 'tools/call',
-      params: {
-        name: 'create_media_buy',
-        arguments: {
-          ...ARGS_BASE,
-          push_notification_config: { url: 'https://buyer.example.com/webhook' },
-        },
-      },
-    });
-    assert.strictEqual(calls.length, 1, 'default-on');
-  });
-
   it('passes echoed token to the webhook payload', async () => {
-    const { server, calls } = buildServer();
+    const { server, calls } = buildServer({ autoEmitCompletionWebhooks: true });
     await server.dispatchTestRequest({
       method: 'tools/call',
       params: {
@@ -182,6 +228,7 @@ describe('F12: auto-emit completion webhook on sync mutating responses', () => {
       validation: { requests: 'off', responses: 'off' },
       taskWebhookEmitter: failingEmitter,
       allowPrivateWebhookUrls: true,
+      autoEmitCompletionWebhooks: true,
     });
     const result = await server.dispatchTestRequest({
       method: 'tools/call',
@@ -199,7 +246,7 @@ describe('F12: auto-emit completion webhook on sync mutating responses', () => {
   });
 
   it('sync_creatives auto-fires webhook on success', async () => {
-    const { server, calls } = buildServer();
+    const { server, calls } = buildServer({ autoEmitCompletionWebhooks: true });
     await server.dispatchTestRequest({
       method: 'tools/call',
       params: {
@@ -226,7 +273,7 @@ describe('F12: auto-emit completion webhook on sync mutating responses', () => {
     // straight through projectSync without extractPushConfig /
     // routeIfHandoff. Broadcast-tv storyboard's
     // expect_window_update_webhook step relies on this.
-    const { server, calls } = buildServer();
+    const { server, calls } = buildServer({ autoEmitCompletionWebhooks: true });
     await server.dispatchTestRequest({
       method: 'tools/call',
       params: {
@@ -268,6 +315,7 @@ describe('F12: auto-emit completion webhook on sync mutating responses', () => {
       validation: { requests: 'off', responses: 'off' },
       taskWebhookEmitter: slowEmitter,
       allowPrivateWebhookUrls: true,
+      autoEmitCompletionWebhooks: true,
     });
     const start = Date.now();
     const result = await server.dispatchTestRequest({


### PR DESCRIPTION
## Summary

- disable synchronous completion webhook emission by default across media-buy, creative, and signals handlers
- retain `autoEmitCompletionWebhooks: true` as an explicit non-conformant compatibility option
- document the v12-to-v13 migration path, synthetic task ID limitation, and operational safeguards
- add regression coverage for all three independently wired handler families

## Why

AdCP completion webhooks describe status changes after the initial response. A synchronous terminal response is already delivered inline and has no registered task ID, so emitting a second completion webhook by default is non-conformant and gives buyers an unpollable synthetic task ID.

## Validation

- `npm run build`
- `node --test --test-timeout=60000 test/server-decisioning-auto-emit-completion.test.js` (11/11 passing)
- `npm run ci:docs-check`
- Prettier and `git diff --check`
- protocol, code-quality, and security expert reviews: clean after findings were addressed

Closes #2462
