### PR TITLE
fix(server): align account list types and pagination totals

### DIFF
--- a/.changeset/fix-account-list-types.md
+++ b/.changeset/fix-account-list-types.md
@@ -1,5 +1,5 @@
 ---
-'@adcp/sdk': patch
+'@adcp/sdk': major
 ---
 
 fix(server): align `list_accounts` handlers with the wire request, type resolved account modes, and project optional pagination totals

--- a/.changeset/fix-account-list-types.md
+++ b/.changeset/fix-account-list-types.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+fix(server): align `list_accounts` handlers with the wire request, type resolved account modes, and project optional pagination totals

--- a/src/lib/adapters/roster-account-store.ts
+++ b/src/lib/adapters/roster-account-store.ts
@@ -41,10 +41,10 @@
  * @public
  */
 
-import type { AccountReference } from '../types/tools.generated';
-import type { Account, AccountFilter, AccountStore, ResolveContext } from '../server/decisioning/account';
+import type { AccountReference, ListAccountsRequest } from '../types/tools.generated';
+import type { Account, AccountStore, ResolveContext } from '../server/decisioning/account';
 import { refAccountId } from '../server/decisioning/account';
-import type { CursorPage, CursorRequest } from '../server/decisioning/pagination';
+import type { CursorPage } from '../server/decisioning/pagination';
 
 /**
  * Options for {@link createRosterAccountStore}.
@@ -98,17 +98,17 @@ export interface RosterAccountStoreOptions<TRosterEntry, TCtxMeta = Record<strin
    * **Push filter + pagination down.** The naive shape — fetch the full
    * roster, filter+slice in memory — works for tens of accounts per tenant
    * but does not scale. Adopters with a Postgres-backed roster should map
-   * `filter.brand_domain` / `filter.operator` / `filter.status[]` /
-   * `cursor` / `limit` to a SQL query. The helper does NOT post-filter;
-   * the adopter is the source of truth.
+   * `request.account` / `request.status` / `request.sandbox` and
+   * `request.pagination.{cursor,max_results}` to a SQL query. The helper
+   * does NOT post-filter; the adopter is the source of truth.
    *
-   * **No default status filter.** `filter.status` is `undefined` unless the
+   * **No default status filter.** `request.status` is `undefined` unless the
    * buyer passed it. If you want production callers to see only `active` +
    * `pending_approval` by default, apply that fallback inside your query —
-   * the helper passes `filter` through verbatim.
+   * the helper passes `request` through verbatim.
    */
   list?: (
-    filter: AccountFilter & CursorRequest,
+    request: ListAccountsRequest,
     ctx: ResolveContext | undefined
   ) => CursorPage<TRosterEntry> | Promise<CursorPage<TRosterEntry>>;
 
@@ -330,6 +330,7 @@ export function createRosterAccountStore<TRosterEntry, TCtxMeta = Record<string,
       return {
         items: page.items.map(entry => options.toAccount(entry, ctx)),
         ...(page.nextCursor !== undefined && { nextCursor: page.nextCursor }),
+        ...(page.totalCount !== undefined && { totalCount: page.totalCount }),
       };
     };
   }

--- a/src/lib/server/account-mode.ts
+++ b/src/lib/server/account-mode.ts
@@ -16,6 +16,7 @@
  */
 
 import { AdcpError } from './decisioning/async-outcome';
+import type { Account } from './decisioning/account';
 
 /**
  * Three operationally distinct account modes:
@@ -54,7 +55,7 @@ export type AccountMode = 'live' | 'sandbox' | 'mock';
  * downgrade every account's gate to a no-op. The own-property check makes
  * the gate immune to that class of attack regardless of upstream hardening.
  */
-export function getAccountMode(account: unknown): AccountMode {
+export function getAccountMode(account: Account<unknown>): AccountMode {
   if (account == null || typeof account !== 'object') return 'live';
   if (Object.hasOwn(account, 'mode')) {
     const mode = (account as { mode?: unknown }).mode;
@@ -76,7 +77,8 @@ export function getAccountMode(account: unknown): AccountMode {
  * shape that doesn't carry the field.
  */
 export function isSandboxOrMockAccount(account: unknown): boolean {
-  const mode = getAccountMode(account);
+  if (account == null || typeof account !== 'object') return false;
+  const mode = getAccountMode(account as Account<unknown>);
   return mode === 'sandbox' || mode === 'mock';
 }
 

--- a/src/lib/server/decisioning/account.ts
+++ b/src/lib/server/decisioning/account.ts
@@ -26,6 +26,7 @@ import type {
   AccountReference,
   BusinessEntity,
   ExtensionObject,
+  ListAccountsRequest,
   PaymentTerms,
   ListAccountsResponse,
   ReportUsageRequest,
@@ -41,7 +42,8 @@ import type {
 } from '../../types/tools.generated';
 import type { ServerPayload } from '../../types/server-payload';
 import type { NotificationConfig } from '../../types/v3-1-beta';
-import type { CursorPage, CursorRequest } from './pagination';
+import type { CursorPage } from './pagination';
+import type { AccountMode } from '../account-mode';
 import type { AdcpStructuredError } from './async-outcome';
 import type { AdcpCredential, BuyerAgent } from './buyer-agent';
 
@@ -218,6 +220,14 @@ export interface Account<TCtxMeta = Record<string, unknown>> {
    * introspectable account authorization for this caller/account tuple.
    */
   authorization?: AccountAuthorization;
+
+  /**
+   * Operational mode used by framework gates for test-only surfaces.
+   * Defaults to `'live'` when omitted. Unlike the wire-side
+   * `AccountReference.sandbox` selector, this value comes from the trusted
+   * resolved account and is not emitted on account response payloads.
+   */
+  mode?: AccountMode;
 
   /**
    * Sandbox account marker. For implicit accounts the wire schema treats
@@ -634,7 +644,7 @@ export interface AccountStore<TCtxMeta = Record<string, unknown>> {
    * scope the listing per-principal (e.g., return only accounts visible to
    * the calling buyer agent) without re-deriving identity from the request.
    */
-  list?(filter: AccountFilter & CursorRequest, ctx?: ResolveContext): Promise<ListAccountsHandlerResult<TCtxMeta>>;
+  list?(request: ListAccountsRequest, ctx?: ResolveContext): Promise<ListAccountsHandlerResult<TCtxMeta>>;
 
   /**
    * report_usage API surface. Operator-billed platforms accept usage rows
@@ -762,14 +772,11 @@ export class AccountNotFoundError extends Error {
   }
 }
 
-export interface AccountFilter {
-  /** Filter by brand domain across all operators. */
-  brand_domain?: string;
-  /** Filter by operator across all brands. */
-  operator?: string;
-  /** Filter by status. */
-  status?: AdcpAccountStatus[];
-}
+/**
+ * @deprecated Use the wire-accurate `ListAccountsRequest` type. Retained as
+ * an alias so existing imports keep compiling.
+ */
+export type AccountFilter = ListAccountsRequest;
 
 /**
  * Per-account result row returned by an adopter's `accounts.upsert`

--- a/src/lib/server/decisioning/decisioning.type-checks.ts
+++ b/src/lib/server/decisioning/decisioning.type-checks.ts
@@ -72,6 +72,7 @@ import {
 } from './index';
 import type { ComplyControllerConfig } from '../../testing/comply-controller';
 import type { CanonicalListCreativesResponse } from '../../v2/projection/creative-delivery';
+import { getAccountMode } from '../account-mode';
 
 // ── AdcpError construction ────────────────────────────────────────────
 
@@ -556,9 +557,42 @@ function _account_handler_result_aliases_are_exported() {
     SyncGovernanceHandlerResult,
     _Result<ReportUsageHandlerResult, Error>,
     _Result<GetAccountFinancialsHandlerResult, Error>,
-  ] = [{ items: [] }, [], [], _ok({ accepted: 0 }), _ok({} as GetAccountFinancialsHandlerResult)];
+  ] = [{ items: [], totalCount: 0 }, [], [], _ok({ accepted: 0 }), _ok({} as GetAccountFinancialsHandlerResult)];
   return results;
 }
+
+const _list_accounts_handler_receives_wire_request: NonNullable<AccountStore['list']> = async request => {
+  const status: string | undefined = request.status;
+  const account = request.account;
+  const sandbox: boolean | undefined = request.sandbox;
+  const maxResults: number | undefined = request.pagination?.max_results;
+  const cursor: string | undefined = request.pagination?.cursor;
+  // @ts-expect-error — list_accounts has nested pagination, not legacy top-level `limit`.
+  const limit = request.limit;
+  // @ts-expect-error — the wire request carries one status, not a status array.
+  const invalidStatusArray: typeof request.status = ['active'];
+  void status;
+  void account;
+  void sandbox;
+  void maxResults;
+  void cursor;
+  void limit;
+  void invalidStatusArray;
+  return { items: [], totalCount: 0 };
+};
+
+const _account_mode_is_typed: Account = {
+  id: 'acct_1',
+  name: 'Acme',
+  status: 'active',
+  mode: 'sandbox',
+  ctx_metadata: {},
+};
+getAccountMode(_account_mode_is_typed);
+const _unknown_account_mode_input: unknown = _account_mode_is_typed;
+// @ts-expect-error — callers must narrow unknown values to a resolved Account first.
+getAccountMode(_unknown_account_mode_input);
+void _account_mode_is_typed;
 
 function _server_payload_preserves_domain_status_fields(): void {
   type CreateMediaBuySuccess = import('../../types/tools.generated').CreateMediaBuySuccess;

--- a/src/lib/server/decisioning/pagination.ts
+++ b/src/lib/server/decisioning/pagination.ts
@@ -12,6 +12,8 @@ export interface CursorPage<T> {
   items: T[];
   /** Opaque continuation token; absent on the last page. */
   nextCursor?: string;
+  /** Total items matching the request across all pages, when known. */
+  totalCount?: number;
 }
 
 export interface CursorRequest {

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -6452,6 +6452,7 @@ function buildAccountHandlers<P extends DecisioningPlatform<any, any>>(
           pagination: {
             has_more: page.nextCursor != null,
             ...(page.nextCursor != null && { cursor: page.nextCursor }),
+            ...(page.totalCount !== undefined && { total_count: page.totalCount }),
           },
         })
       );

--- a/test/roster-account-store.test.js
+++ b/test/roster-account-store.test.js
@@ -244,15 +244,17 @@ describe('createRosterAccountStore', () => {
             { id: 'a2', name: 'A2' },
           ],
           nextCursor: 'cur-2',
+          totalCount: 12,
         }),
       });
 
-      const page = await store.list({ limit: 2 });
+      const page = await store.list({ pagination: { max_results: 2 } });
       assert.equal(page.items.length, 2);
       assert.equal(page.items[0].id, 'a1');
       assert.equal(page.items[0].name, 'A1');
       assert.deepEqual(page.items[0].ctx_metadata, { upstream: 'a1' });
       assert.equal(page.nextCursor, 'cur-2');
+      assert.equal(page.totalCount, 12);
     });
 
     it('omits nextCursor when adopter does not return one (last page)', async () => {
@@ -268,23 +270,28 @@ describe('createRosterAccountStore', () => {
       assert.equal('nextCursor' in page, false, 'nextCursor key must not be present');
     });
 
-    it('passes filter and ctx through to adopter list', async () => {
-      let seenFilter;
+    it('passes the wire request and ctx through to adopter list', async () => {
+      let seenRequest;
       let seenCtx;
       const ctx = { authInfo: { kind: 'public' } };
       const store = createRosterAccountStore({
         lookup: () => undefined,
         toAccount: row => ({ id: row.id, name: row.id, status: 'active', ctx_metadata: {} }),
-        list: (filter, c) => {
-          seenFilter = filter;
+        list: (request, c) => {
+          seenRequest = request;
           seenCtx = c;
           return { items: [] };
         },
       });
 
-      const filter = { brand_domain: 'acme.com', limit: 50, cursor: 'c1' };
-      await store.list(filter, ctx);
-      assert.deepEqual(seenFilter, filter);
+      const request = {
+        account: { account_id: 'acct_1' },
+        status: 'active',
+        sandbox: true,
+        pagination: { max_results: 50, cursor: 'c1' },
+      };
+      await store.list(request, ctx);
+      assert.deepEqual(seenRequest, request);
       assert.equal(seenCtx, ctx);
     });
 

--- a/test/server-decisioning-from-platform.test.js
+++ b/test/server-decisioning-from-platform.test.js
@@ -4030,6 +4030,7 @@ describe('Custom-handler merge seam (incremental migration)', () => {
             },
           ],
           nextCursor: 'cursor_page_2',
+          totalCount: 37,
         }),
       },
     });
@@ -4053,6 +4054,11 @@ describe('Custom-handler merge seam (incremental migration)', () => {
       page1.structuredContent.pagination.cursor,
       'cursor_page_2',
       'pagination.cursor MUST echo adopter nextCursor'
+    );
+    assert.strictEqual(
+      page1.structuredContent.pagination.total_count,
+      37,
+      'pagination.total_count MUST project adopter totalCount when present'
     );
     assert.strictEqual(
       page1.structuredContent.next_cursor,
@@ -4081,6 +4087,11 @@ describe('Custom-handler merge seam (incremental migration)', () => {
       terminal.structuredContent.pagination.cursor,
       undefined,
       'pagination.cursor MUST be absent when has_more is false (per pagination-response schema)'
+    );
+    assert.strictEqual(
+      terminal.structuredContent.pagination.total_count,
+      undefined,
+      'pagination.total_count MUST remain optional when the adopter cannot compute it'
     );
   });
 


### PR DESCRIPTION
## Summary

- type `AccountStore.list` and roster callbacks with the wire-accurate `ListAccountsRequest`
- add the documented `Account.mode` field and narrow `getAccountMode` to resolved accounts
- expose `CursorPage.totalCount` and project it to `pagination.total_count`
- preserve pagination totals through `createRosterAccountStore`

Closes #2449.
Closes #2450.
Closes #2451.

## Root cause

The adopter-facing account-list types had drifted from the request actually passed by the framework, the documented account mode was absent from `Account`, and the cursor abstraction dropped an optional wire pagination total.

## Validation

- three independent expert reviews: protocol, code quality, and Node.js testing
- `npm run format:check`
- `npm run typecheck`
- `npm run build:lib`
- focused account-mode and roster tests (39 passing)
- focused `list_accounts` pagination projection regression
