### PR TITLE
fix(server): allow create media buy error payloads

### DIFF
--- a/.changeset/fuzzy-pandas-return.md
+++ b/.changeset/fuzzy-pandas-return.md
@@ -1,5 +1,5 @@
 ---
-'@adcp/sdk': minor
+'@adcp/sdk': major
 ---
 
 Allow `create_media_buy` server handlers to return the protocol's structured multi-error payload arm without unsafe casts.

--- a/.changeset/fuzzy-pandas-return.md
+++ b/.changeset/fuzzy-pandas-return.md
@@ -1,0 +1,7 @@
+---
+'@adcp/sdk': minor
+---
+
+Allow `create_media_buy` server handlers to return the protocol's structured multi-error payload arm without unsafe casts.
+
+BREAKING NOTE: Code that reads success-only fields from `CreateMediaBuyPayload` must first narrow out the `errors` arm.

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -260,7 +260,6 @@ import type {
 } from '../types/core.generated';
 import type {
   GetProductsResponse,
-  CreateMediaBuySuccess,
   CreateMediaBuyResponse,
   UpdateMediaBuySuccess,
   UpdateMediaBuyResponse,
@@ -338,6 +337,7 @@ import type {
 import type { AdcpProtocol, MediaBuyFeatures, AccountCapabilities, CreativeCapabilities } from '../utils/capabilities';
 import type { MediaChannel } from '../types/tools.generated';
 import type { RequireCacheScopeWhenProducts, ServerPayload } from '../types/server-payload';
+import type { CreateMediaBuyPayload as CreateMediaBuyServerPayload } from '../types/server-payload-aliases';
 import { STANDARD_ERROR_CODES, isStandardErrorCode } from '../types/error-codes';
 import {
   MEDIA_BUY_TOOLS,
@@ -535,8 +535,10 @@ export function requireSessionKey<TAccount = unknown>(ctx: HandlerContext<TAccou
 /**
  * Per-tool param / result / response types.
  *
- * `result` is the narrow success arm — what the framework's response
- * builders (`mediaBuyResponse`, `syncCreativesResponse`, ...) expect.
+ * `result` is the server-handler payload — normally the narrow success arm
+ * consumed by the framework's response builders (`mediaBuyResponse`,
+ * `syncCreativesResponse`, ...), plus a structured Error arm when the tool
+ * supports returning one directly.
  * `response` is the full AdCP response union (Success | Error | Submitted).
  * Handlers can return either shape: adapter patterns that produce
  * `Result<FooResponse, ...>` now type-check without `as any`, and the
@@ -551,7 +553,7 @@ export interface AdcpToolMap {
   };
   create_media_buy: {
     params: z.input<typeof CreateMediaBuyRequestSchema>;
-    result: ServerPayload<CreateMediaBuySuccess>;
+    result: CreateMediaBuyServerPayload;
     response: CreateMediaBuyResponse;
   };
   update_media_buy: {

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -3595,6 +3595,16 @@ function rejectHandRolledSubmitted(result: unknown): void {
   }
 }
 
+const RETURNED_ERROR_ARM_KEYS = new Set(['errors', 'context', 'ext', 'success', 'conflicting_standards_id']);
+
+/** Match only a pure generated Error arm, never a success payload carrying advisory errors. */
+function isReturnedErrorArm(value: unknown): value is { errors: unknown[]; context?: unknown; ext?: unknown } {
+  if (value == null || typeof value !== 'object') return false;
+  const record = value as Record<string, unknown>;
+  if (!Array.isArray(record.errors) || 'status' in record) return false;
+  return Object.keys(record).every(key => RETURNED_ERROR_ARM_KEYS.has(key));
+}
+
 /**
  * Route a unified-shape return value: if it's a `TaskHandoff` marker,
  * dispatch through `dispatchHitl`; otherwise pass through the sync
@@ -5041,6 +5051,25 @@ function buildMediaBuyHandlers<P extends DecisioningPlatform<any, any>>(
                 });
               }
               throw err;
+            }
+            if (isReturnedErrorArm(result)) {
+              // A returned domain Error arm is a failed create, not a
+              // successful proposal consumption or sync-completion webhook.
+              // Restore the proposal so the corrected request can retry.
+              if (reservation && proposalStore) {
+                await releaseProposalReservation({
+                  store: proposalStore,
+                  record: reservation,
+                  logger,
+                });
+              }
+              return asSemanticServerResponseForWire(
+                result,
+                'create_media_buy',
+                legacyFormatConverter,
+                canonicalFormatLegacyResolver,
+                responseWireMode
+              );
             }
             // Inline-success path: promote CONSUMING → CONSUMED with the
             // adapter's media_buy_id. HITL handoff: the proposal stays

--- a/src/lib/server/decisioning/specialisms/sales.ts
+++ b/src/lib/server/decisioning/specialisms/sales.ts
@@ -67,6 +67,7 @@ import type { RequireCacheScopeWhenProducts, ServerPayload } from '../../../type
 import type {
   GetProductsRequest,
   GetProductsResponse,
+  CreateMediaBuyError,
   CreateMediaBuySuccess,
   UpdateMediaBuySuccess,
   GetMediaBuysRequest,
@@ -101,12 +102,17 @@ import type {
 
 type Creative = CanonicalCreativeAsset;
 type Ctx<TCtxMeta> = RequestContext<Account<TCtxMeta>>;
+type ExclusivePayload<TLeft, TRight> =
+  | (TLeft & { [K in Exclude<keyof TRight, keyof TLeft>]?: never })
+  | (TRight & { [K in Exclude<keyof TLeft, keyof TRight>]?: never });
 
 type CanonicalGetProductsPayload = Omit<ServerPayload<CanonicalCreativeResponse<GetProductsResponse>>, 'products'> & {
   products?: CanonicalProduct[];
 };
 export type GetProductsPayload = RequireCacheScopeWhenProducts<CanonicalGetProductsPayload>;
-export type CreateMediaBuyPayload = ServerPayload<CanonicalCreativeResponse<CreateMediaBuySuccess>>;
+type CreateMediaBuySuccessPayload = ServerPayload<CanonicalCreativeResponse<CreateMediaBuySuccess>>;
+type CreateMediaBuyErrorPayload = ServerPayload<CanonicalCreativeResponse<CreateMediaBuyError>>;
+export type CreateMediaBuyPayload = ExclusivePayload<CreateMediaBuySuccessPayload, CreateMediaBuyErrorPayload>;
 export type UpdateMediaBuyPayload = ServerPayload<CanonicalCreativeResponse<UpdateMediaBuySuccess>>;
 export type GetMediaBuyDeliveryPayload = ServerPayload<CanonicalCreativeResponse<GetMediaBuyDeliveryResponse>>;
 export type GetMediaBuysPayload = ServerPayload<CanonicalCreativeResponse<GetMediaBuysResponse>>;
@@ -114,7 +120,10 @@ export type ProvidePerformanceFeedbackPayload = ServerPayload<ProvidePerformance
 export type LegacyListCreativeFormatsPayload = ServerPayload<ListCreativeFormatsResponse>;
 export type ListCreativesPayload = ServerPayload<CanonicalListCreativesResponse>;
 export type LegacyGetProductsPayload = RequireCacheScopeWhenProducts<ServerPayload<GetProductsResponse>>;
-export type LegacyCreateMediaBuyPayload = ServerPayload<CreateMediaBuySuccess>;
+export type LegacyCreateMediaBuyPayload = ExclusivePayload<
+  ServerPayload<CreateMediaBuySuccess>,
+  ServerPayload<CreateMediaBuyError>
+>;
 export type LegacyUpdateMediaBuyPayload = ServerPayload<UpdateMediaBuySuccess>;
 export type LegacyGetMediaBuyDeliveryPayload = ServerPayload<GetMediaBuyDeliveryResponse>;
 export type LegacyGetMediaBuysPayload = ServerPayload<GetMediaBuysResponse>;
@@ -133,7 +142,7 @@ export type SyncEventSourcesPayload = ServerPayload<SyncEventSourcesSuccess>;
  */
 export type SyncCreativesRow = SyncCreativesSuccess['creatives'][number];
 export type GetProductsHandlerResult = GetProductsPayload | TaskHandoff<GetProductsPayload>;
-export type CreateMediaBuyHandlerResult = CreateMediaBuyPayload | TaskHandoff<CreateMediaBuyPayload>;
+export type CreateMediaBuyHandlerResult = CreateMediaBuyPayload | TaskHandoff<CreateMediaBuySuccessPayload>;
 export type UpdateMediaBuyHandlerResult = UpdateMediaBuyPayload | TaskHandoff<UpdateMediaBuyPayload>;
 export type SyncCreativesHandlerResult = SyncCreativesRow[] | TaskHandoff<SyncCreativesRow[]>;
 
@@ -186,6 +195,11 @@ export interface SalesPlatform<TCtxMeta = Record<string, unknown>> {
    *
    * Status changes flow via `publishStatusChange(...)` regardless of
    * which path was taken.
+   *
+   * For synchronous domain validation that produces multiple failures,
+   * return the pure Error arm (`{ errors: [...] }`) with no success-only
+   * fields. Handoff callbacks remain success-only; throw `AdcpError` inside
+   * a handoff to transition the task to `failed`.
    *
    * The handoff function's return value is persisted as JSONB in the
    * task registry. Postgres-backed registries cap row size at 4MB —

--- a/src/lib/types/server-payload-aliases.ts
+++ b/src/lib/types/server-payload-aliases.ts
@@ -15,6 +15,7 @@ import type {
   CheckGovernanceResponse,
   CreateCollectionListResponse,
   CreateContentStandardsResponse,
+  CreateMediaBuyError,
   CreateMediaBuySuccess,
   CreatePropertyListResponse,
   DeleteCollectionListResponse,
@@ -78,6 +79,10 @@ import type {
 } from './core.generated';
 import type { RequireCacheScopeWhenProducts, ServerPayload } from './server-payload';
 
+type ExclusivePayload<TLeft, TRight> =
+  | (TLeft & { [K in Exclude<keyof TRight, keyof TLeft>]?: never })
+  | (TRight & { [K in Exclude<keyof TLeft, keyof TRight>]?: never });
+
 export type GetAdCPCapabilitiesPayload = ServerPayload<GetAdCPCapabilitiesResponse>;
 
 export type ListAccountsPayload = ServerPayload<ListAccountsResponse>;
@@ -90,7 +95,10 @@ export type GetAccountFinancialsPayload = ServerPayload<GetAccountFinancialsResp
 export type GetAccountFinancialsSuccessPayload = ServerPayload<GetAccountFinancialsSuccess>;
 
 export type GetProductsPayload = RequireCacheScopeWhenProducts<ServerPayload<GetProductsResponse>>;
-export type CreateMediaBuyPayload = ServerPayload<CreateMediaBuySuccess>;
+export type CreateMediaBuyPayload = ExclusivePayload<
+  ServerPayload<CreateMediaBuySuccess>,
+  ServerPayload<CreateMediaBuyError>
+>;
 export type UpdateMediaBuyPayload = ServerPayload<UpdateMediaBuySuccess>;
 export type GetMediaBuysPayload = ServerPayload<GetMediaBuysResponse>;
 export type GetMediaBuyDeliveryPayload = ServerPayload<GetMediaBuyDeliveryResponse>;

--- a/src/type-tests/server-payload-aliases.type-test.ts
+++ b/src/type-tests/server-payload-aliases.type-test.ts
@@ -14,24 +14,66 @@ import type {
   GetProductsPayload as TypesGetProductsPayload,
   PreviewCreativePayload as TypesPreviewCreativePayload,
 } from '../lib/types';
-import type { CreateMediaBuySuccess } from '../lib/types';
-import type { GetProductsPayload as DecisioningGetProductsPayload } from '../lib/server/decisioning/specialisms/sales';
+import type { CreateMediaBuyError, CreateMediaBuySuccess } from '../lib/types';
+import type { AdcpToolMap } from '../lib/server/create-adcp-server';
+import type { TaskHandoff } from '../lib/server/decisioning/async-outcome';
+import type {
+  CreateMediaBuyHandlerResult,
+  GetProductsPayload as DecisioningGetProductsPayload,
+} from '../lib/server/decisioning/specialisms/sales';
 import { legacyProductsResponse } from '../lib/server';
 
-const rootCreateMediaBuyPayload: RootCreateMediaBuyPayload = {
+const rootCreateMediaBuyPayload = {
   media_buy_id: 'mb_1',
   confirmed_at: '2026-01-01T00:00:00Z',
   revision: 1,
   packages: [],
   status: 'active',
-};
+} satisfies RootCreateMediaBuyPayload;
 const serverCreateMediaBuyPayload: ServerCreateMediaBuyPayload = rootCreateMediaBuyPayload;
 const typesCreateMediaBuyPayload: TypesCreateMediaBuyPayload = serverCreateMediaBuyPayload;
 const genericPayload: ServerPayload<CreateMediaBuySuccess> = typesCreateMediaBuyPayload;
 void genericPayload;
+
+const rootCreateMediaBuyErrorPayload: RootCreateMediaBuyPayload = {
+  errors: [
+    { code: 'INVALID_REQUEST', message: 'packages array is required' },
+    { code: 'VALIDATION_ERROR', message: 'package budget is invalid', field: 'packages[0].budget' },
+  ],
+};
+const serverCreateMediaBuyErrorPayload: ServerCreateMediaBuyPayload = rootCreateMediaBuyErrorPayload;
+const typesCreateMediaBuyErrorPayload: TypesCreateMediaBuyPayload = serverCreateMediaBuyErrorPayload;
+const genericErrorPayload: ServerPayload<CreateMediaBuyError> = typesCreateMediaBuyErrorPayload;
+const handlerErrorPayload: CreateMediaBuyHandlerResult = rootCreateMediaBuyErrorPayload;
+const toolMapErrorPayload: AdcpToolMap['create_media_buy']['result'] = typesCreateMediaBuyErrorPayload;
+const legacyCreateMediaBuyErrorPayload: ServerLegacyCreateMediaBuyPayload = typesCreateMediaBuyErrorPayload;
+void genericErrorPayload;
+void handlerErrorPayload;
+void toolMapErrorPayload;
+void legacyCreateMediaBuyErrorPayload;
+
+// @ts-expect-error Error arms must not carry success-only media-buy fields.
+const hybridCreateMediaBuyPayload: TypesCreateMediaBuyPayload = {
+  media_buy_id: 'mb_invalid',
+  confirmed_at: null,
+  revision: 1,
+  packages: [],
+  errors: [{ code: 'INVALID_REQUEST', message: 'hybrid payload' }],
+};
+void hybridCreateMediaBuyPayload;
+
+declare const createMediaBuyErrorHandoff: TaskHandoff<ServerPayload<CreateMediaBuyError>>;
+// @ts-expect-error Handoff callbacks must return success; throw AdcpError to fail an async task.
+const handlerErrorHandoff: CreateMediaBuyHandlerResult = createMediaBuyErrorHandoff;
+void handlerErrorHandoff;
+
+declare const createMediaBuyPayload: TypesCreateMediaBuyPayload;
+// @ts-expect-error Error-arm payloads are not assignable to the success-only subtype.
+const successOnlyPayload: ServerPayload<CreateMediaBuySuccess> = createMediaBuyPayload;
+void successOnlyPayload;
 // @ts-expect-error Primary server payload packages never expose legacy format_ids.
 void rootCreateMediaBuyPayload.packages[0]?.format_ids;
-declare const legacyCreateMediaBuyPayload: ServerLegacyCreateMediaBuyPayload;
+declare const legacyCreateMediaBuyPayload: Extract<ServerLegacyCreateMediaBuyPayload, { packages: unknown }>;
 void legacyCreateMediaBuyPayload.packages[0]?.format_ids;
 
 const rootGetProductsPayload: RootGetProductsPayload = {

--- a/test/lib/proposal-manager-e2e.test.js
+++ b/test/lib/proposal-manager-e2e.test.js
@@ -255,6 +255,54 @@ test('e2e: createMediaBuy adapter throw → reservation rolled back to COMMITTED
   assert.strictEqual(store.get('p1', { expectedAccountId: 'acct_1' }).state, 'committed');
 });
 
+test('e2e: createMediaBuy Error arm → errors preserved and reservation rolled back to COMMITTED', async () => {
+  const store = new InMemoryProposalStore();
+  store.putDraft({
+    proposalId: 'p1',
+    accountId: 'acct_1',
+    recipes: new Map(),
+    proposalPayload: { proposal_id: 'p1' },
+  });
+  store.commit('p1', { expiresAt: new Date(Date.now() + 60_000), proposalPayload: { proposal_id: 'p1' } });
+
+  const errors = [
+    { code: 'INVALID_REQUEST', message: 'package targeting is required', field: 'packages[0].targeting' },
+    { code: 'BUDGET_TOO_LOW', message: 'package budget is below the product minimum', field: 'packages[0].budget' },
+  ];
+  const sales = {
+    getProducts: async () => ({ products: [] }),
+    createMediaBuy: async () => ({ errors }),
+    updateMediaBuy: async () => ({ media_buy_id: 'mb', buyer_ref: 'br', packages: [], status: 'active' }),
+    getMediaBuyDelivery: async () => ({
+      media_buy_deliveries: [],
+      reporting_period: { start_date: '2026-01-01', end_date: '2026-01-02' },
+    }),
+  };
+  const server = createAdcpServerFromPlatform(buildPlatform({ proposalManager: undefined, sales }), {
+    name: 'e2e',
+    version: '1.0',
+    proposalStore: store,
+    validation: { requests: 'off', responses: 'off' },
+  });
+  const response = await server.dispatchTestRequest(
+    {
+      method: 'tools/call',
+      params: {
+        name: 'create_media_buy',
+        arguments: { proposal_id: 'p1', idempotency_key: 'idem-key-error-arm-0001' },
+      },
+    },
+    { authInfo }
+  );
+
+  assert.strictEqual(response.isError, true);
+  assert.deepStrictEqual(
+    response.structuredContent.errors,
+    errors.map(error => ({ ...error, recovery: 'correctable' }))
+  );
+  assert.strictEqual(store.get('p1', { expectedAccountId: 'acct_1' }).state, 'committed');
+});
+
 test('e2e: v1 path unchanged when no proposalStore wired', async () => {
   const calls = [];
   const sales = {


### PR DESCRIPTION
## Summary

- include the structured `CreateMediaBuyError` arm in public server payload and tool-map types
- reject hybrid success/error payloads and keep async handoff callbacks success-only
- roll back proposal reservations when a synchronous create returns domain errors
- add public type regressions, proposal lifecycle coverage, and a major changeset

## Root cause

`CreateMediaBuyPayload` exposed only the success arm even though the protocol response union also permits a structured multi-error arm. Widening the type also required handling direct domain errors before success-only proposal and completion-webhook logic.

## Impact

Server adopters can return pure `{ errors: [...] }` payloads from synchronous `createMediaBuy` handlers without unsafe casts. Code reading success-only fields from `CreateMediaBuyPayload` must narrow out the error arm first. Async handoffs still fail by throwing `AdcpError`.

## Validation

- independent code, protocol, and Node.js testing expert reviews
- `npm run typecheck`
- `npm run build:lib`
- `NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/lib/proposal-manager-e2e.test.js`
- repository pre-push validation
- `git diff --check`

Closes #2259
