### PR TITLE
fix(testing): align creative fixture coverage contract

### DIFF
--- a/.changeset/grade-unavailable-creative-fixtures.md
+++ b/.changeset/grade-unavailable-creative-fixtures.md
@@ -1,5 +1,5 @@
 ---
-'@adcp/sdk': patch
+'@adcp/sdk': minor
 ---
 
-Grade storyboard steps as not applicable when the selected test kit cannot synthesize a seller-required creative asset slot, while preserving slot-level diagnostics and prerequisite failures for missing format context.
+Grade storyboards with the canonical `fixture_unavailable` reason when the selected test kit cannot synthesize a seller-required creative asset slot. Preflight future directives before intervening side effects, preserve slot-level diagnostics, and use exact text-slot mappings.

--- a/src/lib/testing/compliance/storyboard-tracks.ts
+++ b/src/lib/testing/compliance/storyboard-tracks.ts
@@ -170,7 +170,9 @@ function computeTrackStatus(results: StoryboardResult[]): TrackStatus {
   if (totalSteps === totalSkipped) return 'skip';
   if (totalFailed > 0) return totalPassed === 0 ? 'fail' : 'partial';
   const hasFixtureUnavailable = results.some(result =>
-    result.phases.some(phase => phase.steps.some(step => step.skip?.reason === 'fixture_unavailable'))
+    (result.passes?.flatMap(pass => pass.phases) ?? result.phases).some(phase =>
+      phase.steps.some(step => step.skip?.reason === 'fixture_unavailable')
+    )
   );
   if (hasFixtureUnavailable) return 'partial';
 

--- a/src/lib/testing/compliance/storyboard-tracks.ts
+++ b/src/lib/testing/compliance/storyboard-tracks.ts
@@ -144,6 +144,7 @@ function skipReasonLabel(reason: string | undefined): string | undefined {
     prerequisite_failed: 'Skipped: a prerequisite did not pass',
     missing_tool: 'Skipped: agent did not advertise the required tool',
     missing_test_controller: 'Not testable: requires comply_test_controller',
+    fixture_unavailable: 'Not testable: the runner fixture cannot satisfy the seller-declared contract',
     unsatisfied_contract: 'Skipped: test-kit contract is out of scope',
     peer_branch_taken: 'Skipped: a peer branch in the same any_of branch set already contributed the aggregation flag',
   };
@@ -168,6 +169,10 @@ function computeTrackStatus(results: StoryboardResult[]): TrackStatus {
   if (totalSteps === 0) return 'skip';
   if (totalSteps === totalSkipped) return 'skip';
   if (totalFailed > 0) return totalPassed === 0 ? 'fail' : 'partial';
+  const hasFixtureUnavailable = results.some(result =>
+    result.phases.some(phase => phase.steps.some(step => step.skip?.reason === 'fixture_unavailable'))
+  );
+  if (hasFixtureUnavailable) return 'partial';
 
   // No failures. Demote to `silent` when every observation-bearing
   // invariant record reports zero observations. Step-level passes alone

--- a/src/lib/testing/storyboard/creative-assets.ts
+++ b/src/lib/testing/storyboard/creative-assets.ts
@@ -12,6 +12,7 @@ interface Dimensions {
 interface RequiredSlot extends Dimensions {
   id: string;
   assetType: string;
+  requirements: JsonObject;
 }
 
 type AssetsBuildFailure =
@@ -137,7 +138,8 @@ function requiredSlots(format: JsonObject): RequiredSlot[] {
     if (!isObject(slotValue) || slotValue.required !== true) return [];
     const id = canonicalSlots ? slotValue.asset_group_id : slotValue.asset_id;
     if (typeof id !== 'string' || typeof slotValue.asset_type !== 'string') return [];
-    return [{ id, assetType: slotValue.asset_type, ...slotDimensions(slotValue, fallback) }];
+    const requirements = isObject(slotValue.requirements) ? slotValue.requirements : {};
+    return [{ id, assetType: slotValue.asset_type, requirements, ...slotDimensions(slotValue, fallback) }];
   });
 }
 
@@ -150,14 +152,88 @@ function imageConstraint(slot: RequiredSlot): string {
   return 'requires an image fixture with a URL';
 }
 
+function imageFixtureMismatch(candidate: JsonObject, slot: RequiredSlot): string | undefined {
+  const requirements = slot.requirements;
+  const supported = new Set([
+    'width',
+    'height',
+    'dimensions',
+    'min_width',
+    'max_width',
+    'min_height',
+    'max_height',
+    'aspect_ratio',
+    'formats',
+    'pixel_ratios',
+    'parameters_from_format_id',
+    'unit',
+  ]);
+  const unsupported = Object.keys(requirements).find(key => !supported.has(key));
+  if (unsupported) return `cannot verify image requirement "${unsupported}" from fixture metadata`;
+
+  const unit = typeof requirements.unit === 'string' ? requirements.unit : 'px';
+  if (unit !== 'px' && unit !== 'pixel' && unit !== 'pixels') {
+    return `requires image dimensions in unsupported unit "${unit}"`;
+  }
+
+  const width = asNumber(candidate.width);
+  const height = asNumber(candidate.height);
+  const minWidth = asNumber(requirements.min_width);
+  const maxWidth = asNumber(requirements.max_width);
+  const minHeight = asNumber(requirements.min_height);
+  const maxHeight = asNumber(requirements.max_height);
+  if (minWidth !== undefined && (width === undefined || width < minWidth)) return `requires minimum width ${minWidth}`;
+  if (maxWidth !== undefined && (width === undefined || width > maxWidth)) return `requires maximum width ${maxWidth}`;
+  if (minHeight !== undefined && (height === undefined || height < minHeight)) {
+    return `requires minimum height ${minHeight}`;
+  }
+  if (maxHeight !== undefined && (height === undefined || height > maxHeight)) {
+    return `requires maximum height ${maxHeight}`;
+  }
+
+  if (typeof requirements.aspect_ratio === 'string') {
+    const match = /^(\d+(?:\.\d+)?):(\d+(?:\.\d+)?)$/.exec(requirements.aspect_ratio);
+    if (!match || width === undefined || height === undefined) {
+      return `cannot verify aspect ratio "${requirements.aspect_ratio}"`;
+    }
+    const expected = Number(match[1]) / Number(match[2]);
+    if (Math.abs(width / height - expected) > 0.001) return `requires aspect ratio ${requirements.aspect_ratio}`;
+  }
+
+  if (Array.isArray(requirements.formats)) {
+    const mimeType = typeof candidate.mime_type === 'string' ? candidate.mime_type.toLowerCase() : '';
+    const extension = mimeType.split('/')[1]?.replace('jpeg', 'jpg');
+    const allowed = requirements.formats
+      .filter((item): item is string => typeof item === 'string')
+      .map(item => item.toLowerCase().replace('jpeg', 'jpg'));
+    if (!extension || !allowed.includes(extension)) return `requires image format in [${allowed.join(', ')}]`;
+  }
+
+  if (Array.isArray(requirements.pixel_ratios)) {
+    const ratio = asNumber(candidate.pixel_ratio) ?? 1;
+    const allowed = requirements.pixel_ratios.filter((item): item is number => asNumber(item) !== undefined);
+    if (!allowed.includes(ratio)) return `requires pixel ratio in [${allowed.join(', ')}]`;
+  }
+  return undefined;
+}
+
 function buildImage(slot: RequiredSlot, assets: JsonObject): AssetBuildResult {
   const images = Array.isArray(assets.images) ? assets.images.filter(isObject) : [];
+  let mismatch: string | undefined;
   const image = images.find(candidate => {
     const widthMatches = slot.width === undefined || candidate.width === slot.width;
     const heightMatches = slot.height === undefined || candidate.height === slot.height;
-    return widthMatches && heightMatches;
+    if (!widthMatches || !heightMatches) return false;
+    const candidateMismatch = imageFixtureMismatch(candidate, slot);
+    if (candidateMismatch) {
+      mismatch ??= candidateMismatch;
+      return false;
+    }
+    return true;
   });
-  if (!image) return { ok: false, constraint: imageConstraint(slot) };
+  if (!image) {
+    return { ok: false, constraint: mismatch ? `${imageConstraint(slot)}; ${mismatch}` : imageConstraint(slot) };
+  }
   if (typeof image.url !== 'string') {
     return { ok: false, constraint: `${imageConstraint(slot)}, but the matching fixture has no URL` };
   }
@@ -173,8 +249,52 @@ function buildImage(slot: RequiredSlot, assets: JsonObject): AssetBuildResult {
   };
 }
 
-function firstString(value: unknown): string | undefined {
-  return Array.isArray(value) ? value.find((item): item is string => typeof item === 'string') : undefined;
+function textFixtureMismatch(content: string, requirements: JsonObject): string | undefined {
+  const supported = new Set([
+    'min_length',
+    'max_length',
+    'min_lines',
+    'max_lines',
+    'character_pattern',
+    'prohibited_terms',
+    'allowed_values',
+  ]);
+  const unsupported = Object.keys(requirements).find(key => !supported.has(key));
+  if (unsupported) return `cannot verify text requirement "${unsupported}"`;
+
+  const minLength = asNumber(requirements.min_length);
+  const maxLength = asNumber(requirements.max_length);
+  if (minLength !== undefined && content.length < minLength) return `requires minimum length ${minLength}`;
+  if (maxLength !== undefined && content.length > maxLength) return `requires maximum length ${maxLength}`;
+
+  const lines = content.split(/\r?\n/).length;
+  const minLines = asNumber(requirements.min_lines);
+  const maxLines = asNumber(requirements.max_lines);
+  if (minLines !== undefined && lines < minLines) return `requires minimum line count ${minLines}`;
+  if (maxLines !== undefined && lines > maxLines) return `requires maximum line count ${maxLines}`;
+
+  if (typeof requirements.character_pattern === 'string') {
+    try {
+      if (!new RegExp(requirements.character_pattern).test(content)) {
+        return `requires character pattern ${requirements.character_pattern}`;
+      }
+    } catch {
+      return `declares invalid character pattern ${requirements.character_pattern}`;
+    }
+  }
+  if (Array.isArray(requirements.prohibited_terms)) {
+    const prohibited = requirements.prohibited_terms.find(
+      (term): term is string => typeof term === 'string' && content.toLowerCase().includes(term.toLowerCase())
+    );
+    if (prohibited) return `prohibits term "${prohibited}"`;
+  }
+  if (
+    Array.isArray(requirements.allowed_values) &&
+    !requirements.allowed_values.some(value => typeof value === 'string' && value === content)
+  ) {
+    return 'requires one of the declared allowed_values';
+  }
+  return undefined;
 }
 
 function buildText(slot: RequiredSlot, assets: JsonObject): AssetBuildResult {
@@ -197,10 +317,58 @@ function buildText(slot: RequiredSlot, assets: JsonObject): AssetBuildResult {
       constraint: 'slot id has no exact runner mapping to a headlines, descriptions, or CTA fixture category',
     };
   }
-  const content = firstString(text[fixtureCategory]);
+  const candidates = Array.isArray(text[fixtureCategory])
+    ? text[fixtureCategory].filter((item): item is string => typeof item === 'string')
+    : [];
+  let mismatch: string | undefined;
+  const content = candidates.find(candidate => {
+    const candidateMismatch = textFixtureMismatch(candidate, slot.requirements);
+    if (candidateMismatch) {
+      mismatch ??= candidateMismatch;
+      return false;
+    }
+    return true;
+  });
   return content === undefined
-    ? { ok: false, constraint: `requires a ${fixtureCategory} text fixture` }
+    ? {
+        ok: false,
+        constraint: mismatch ?? `requires a ${fixtureCategory} text fixture`,
+      }
     : { ok: true, asset: { asset_type: 'text', content } };
+}
+
+function buildUrl(slot: RequiredSlot, assets: JsonObject): AssetBuildResult {
+  if (typeof assets.click_url !== 'string') return { ok: false, constraint: 'requires a click_url fixture' };
+  const url = assets.click_url;
+  const supported = new Set(['role', 'protocols', 'allowed_domains', 'max_length', 'macro_support']);
+  const unsupported = Object.keys(slot.requirements).find(key => !supported.has(key));
+  if (unsupported) return { ok: false, constraint: `cannot verify URL requirement "${unsupported}"` };
+  const maxLength = asNumber(slot.requirements.max_length);
+  if (maxLength !== undefined && url.length > maxLength) {
+    return { ok: false, constraint: `requires URL maximum length ${maxLength}` };
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return { ok: false, constraint: 'click_url fixture is not an absolute URL' };
+  }
+  if (
+    Array.isArray(slot.requirements.protocols) &&
+    !slot.requirements.protocols.some(protocol => protocol === parsed.protocol.replace(/:$/, ''))
+  ) {
+    return { ok: false, constraint: 'click_url fixture uses a disallowed protocol' };
+  }
+  if (
+    Array.isArray(slot.requirements.allowed_domains) &&
+    !slot.requirements.allowed_domains.some(domain => domain === parsed.hostname)
+  ) {
+    return { ok: false, constraint: 'click_url fixture uses a disallowed domain' };
+  }
+  if (slot.requirements.macro_support === true && !/\$\{[^}]+\}/.test(url)) {
+    return { ok: false, constraint: 'requires a URL fixture with macro support' };
+  }
+  return { ok: true, asset: { asset_type: 'url', url } };
 }
 
 function buildAsset(slot: RequiredSlot, testKit: unknown): AssetBuildResult {
@@ -209,10 +377,7 @@ function buildAsset(slot: RequiredSlot, testKit: unknown): AssetBuildResult {
   }
   const assets = testKit.assets;
   if (slot.assetType === 'image') return buildImage(slot, assets);
-  if (slot.assetType === 'url' && typeof assets.click_url === 'string') {
-    return { ok: true, asset: { asset_type: 'url', url: assets.click_url } };
-  }
-  if (slot.assetType === 'url') return { ok: false, constraint: 'requires a click_url fixture' };
+  if (slot.assetType === 'url') return buildUrl(slot, assets);
   if (slot.assetType === 'text') return buildText(slot, assets);
   return { ok: false, constraint: `asset type "${slot.assetType}" is not supported by the selected test kit` };
 }

--- a/src/lib/testing/storyboard/creative-assets.ts
+++ b/src/lib/testing/storyboard/creative-assets.ts
@@ -37,6 +37,8 @@ type AssetBuildResult = { ok: true; asset: JsonObject } | { ok: false; constrain
 
 type AssetsBuildResult = { ok: true; assets: JsonObject } | { ok: false; failure: AssetsBuildFailure };
 
+type RequiredSlotsResult = { ok: true; slots: RequiredSlot[] } | { ok: false; constraint: string };
+
 function isObject(value: unknown): value is JsonObject {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
@@ -137,31 +139,42 @@ function slotDimensions(slot: JsonObject, fallback: Dimensions): Dimensions {
   };
 }
 
-function requiredSlots(format: JsonObject): RequiredSlot[] {
+function requiredSlots(format: JsonObject): RequiredSlotsResult {
   const canonicalSlots = Array.isArray(format.slots) ? format.slots : undefined;
   const legacySlots = Array.isArray(format.assets)
     ? format.assets
     : Array.isArray(format.assets_required)
       ? format.assets_required
       : undefined;
+  const usesAssetsRequired = canonicalSlots === undefined && !Array.isArray(format.assets) && legacySlots !== undefined;
   const slots = canonicalSlots ?? legacySlots ?? [];
   const fallback = formatDimensions(format);
+  const container = canonicalSlots !== undefined ? 'slots' : usesAssetsRequired ? 'assets_required' : 'assets';
 
-  return slots.flatMap(slotValue => {
-    if (!isObject(slotValue) || slotValue.required !== true) return [];
+  const required: RequiredSlot[] = [];
+  for (let index = 0; index < slots.length; index += 1) {
+    const slotValue = slots[index];
+    if (!isObject(slotValue) || (!usesAssetsRequired && slotValue.required !== true)) continue;
     const isRepeatableGroup = slotValue.item_type === 'repeatable_group';
-    const id = canonicalSlots || isRepeatableGroup ? slotValue.asset_group_id : slotValue.asset_id;
+    const id = canonicalSlots !== undefined || isRepeatableGroup ? slotValue.asset_group_id : slotValue.asset_id;
     const assetType =
       typeof slotValue.asset_type === 'string'
         ? slotValue.asset_type
         : isRepeatableGroup
           ? 'repeatable_group'
           : undefined;
-    if (typeof id !== 'string' || assetType === undefined) return [];
+    const idField = canonicalSlots !== undefined || isRepeatableGroup ? 'asset_group_id' : 'asset_id';
+    if (typeof id !== 'string') {
+      return { ok: false, constraint: `required ${container}[${index}].${idField} must be a string` };
+    }
+    if (assetType === undefined) {
+      return { ok: false, constraint: `required ${container}[${index}].asset_type must be a string` };
+    }
     const requirements = isObject(slotValue.requirements) ? slotValue.requirements : {};
     const dimensions = slotDimensions(slotValue, fallback);
-    return [{ id, assetType, requirements, ...dimensions }];
-  });
+    required.push({ id, assetType, requirements, ...dimensions });
+  }
+  return { ok: true, slots: required };
 }
 
 function imageConstraint(slot: RequiredSlot): string {
@@ -420,10 +433,13 @@ function buildAssets(value: unknown, context: StoryboardContext, testKit: unknow
   if (!resolved.ok) {
     return { ok: false, failure: { reason: resolved.reason, constraint: resolved.constraint } };
   }
-  const slots = requiredSlots(resolved.format);
+  const required = requiredSlots(resolved.format);
+  if (!required.ok) {
+    return { ok: false, failure: { reason: 'malformed_directive', constraint: required.constraint } };
+  }
 
   const built: JsonObject = {};
-  for (const slot of slots) {
+  for (const slot of required.slots) {
     const result = buildAsset(slot, testKit);
     if (!result.ok) {
       return {

--- a/src/lib/testing/storyboard/creative-assets.ts
+++ b/src/lib/testing/storyboard/creative-assets.ts
@@ -90,7 +90,16 @@ function resolveFormat(
       constraint: `format "${value.id}"${agent} is absent from storyboard context.formats`,
     };
   }
-  return { ok: true, format };
+  const catalogFormatId = isObject(format.format_id) ? format.format_id : {};
+  return {
+    ok: true,
+    format: {
+      ...format,
+      ...(asNumber(value.width) !== undefined ? { width: value.width } : {}),
+      ...(asNumber(value.height) !== undefined ? { height: value.height } : {}),
+      format_id: { ...catalogFormatId, ...value },
+    },
+  };
 }
 
 function dimensionsFromId(format: JsonObject): Dimensions {
@@ -100,7 +109,11 @@ function dimensionsFromId(format: JsonObject): Dimensions {
 }
 
 function formatDimensions(format: JsonObject): Dimensions {
-  const direct = { width: asNumber(format.width), height: asNumber(format.height) };
+  const nestedFormatId = isObject(format.format_id) ? format.format_id : {};
+  const direct = {
+    width: asNumber(format.width) ?? asNumber(nestedFormatId.width),
+    height: asNumber(format.height) ?? asNumber(nestedFormatId.height),
+  };
   if (direct.width !== undefined || direct.height !== undefined) return direct;
 
   const renders = Array.isArray(format.renders) ? format.renders : [];
@@ -145,7 +158,8 @@ function requiredSlots(format: JsonObject): RequiredSlot[] {
           : undefined;
     if (typeof id !== 'string' || assetType === undefined) return [];
     const requirements = isObject(slotValue.requirements) ? slotValue.requirements : {};
-    return [{ id, assetType, requirements, ...slotDimensions(slotValue, fallback) }];
+    const dimensions = slotDimensions(slotValue, fallback);
+    return [{ id, assetType, requirements, ...dimensions }];
   });
 }
 

--- a/src/lib/testing/storyboard/creative-assets.ts
+++ b/src/lib/testing/storyboard/creative-assets.ts
@@ -149,11 +149,12 @@ function requiredSlots(format: JsonObject): RequiredSlot[] {
 
   return slots.flatMap(slotValue => {
     if (!isObject(slotValue) || slotValue.required !== true) return [];
-    const id = canonicalSlots ? slotValue.asset_group_id : slotValue.asset_id;
+    const isRepeatableGroup = slotValue.item_type === 'repeatable_group';
+    const id = canonicalSlots || isRepeatableGroup ? slotValue.asset_group_id : slotValue.asset_id;
     const assetType =
       typeof slotValue.asset_type === 'string'
         ? slotValue.asset_type
-        : slotValue.item_type === 'repeatable_group'
+        : isRepeatableGroup
           ? 'repeatable_group'
           : undefined;
     if (typeof id !== 'string' || assetType === undefined) return [];

--- a/src/lib/testing/storyboard/creative-assets.ts
+++ b/src/lib/testing/storyboard/creative-assets.ts
@@ -137,9 +137,15 @@ function requiredSlots(format: JsonObject): RequiredSlot[] {
   return slots.flatMap(slotValue => {
     if (!isObject(slotValue) || slotValue.required !== true) return [];
     const id = canonicalSlots ? slotValue.asset_group_id : slotValue.asset_id;
-    if (typeof id !== 'string' || typeof slotValue.asset_type !== 'string') return [];
+    const assetType =
+      typeof slotValue.asset_type === 'string'
+        ? slotValue.asset_type
+        : slotValue.item_type === 'repeatable_group'
+          ? 'repeatable_group'
+          : undefined;
+    if (typeof id !== 'string' || assetType === undefined) return [];
     const requirements = isObject(slotValue.requirements) ? slotValue.requirements : {};
-    return [{ id, assetType: slotValue.asset_type, requirements, ...slotDimensions(slotValue, fallback) }];
+    return [{ id, assetType, requirements, ...slotDimensions(slotValue, fallback) }];
   });
 }
 

--- a/src/lib/testing/storyboard/creative-assets.ts
+++ b/src/lib/testing/storyboard/creative-assets.ts
@@ -20,7 +20,7 @@ type AssetsBuildFailure =
       constraint: string;
     }
   | {
-      reason: 'creative_asset_fixture_unavailable';
+      reason: 'fixture_unavailable';
       slotId: string;
       assetType: string;
       constraint: string;
@@ -180,25 +180,26 @@ function firstString(value: unknown): string | undefined {
 function buildText(slot: RequiredSlot, assets: JsonObject): AssetBuildResult {
   const text = isObject(assets.text) ? assets.text : {};
   const id = slot.id.toLowerCase();
-  let content: string | undefined;
-  let semantic: string;
-  if (id.includes('headline')) {
-    content = firstString(text.headlines);
-    semantic = 'headline';
-  } else if (id.includes('description') || id.includes('body')) {
-    content = firstString(text.descriptions);
-    semantic = 'description/body';
-  } else if (id.includes('cta') || id.includes('call_to_action')) {
-    content = firstString(text.cta);
-    semantic = 'CTA/call_to_action';
-  } else {
+  const fixtureCategory = {
+    headline: 'headlines',
+    title: 'headlines',
+    description: 'descriptions',
+    body: 'descriptions',
+    body_text: 'descriptions',
+    primary_text: 'descriptions',
+    cta: 'cta',
+    cta_text: 'cta',
+    call_to_action: 'cta',
+  }[id];
+  if (fixtureCategory === undefined) {
     return {
       ok: false,
-      constraint: 'slot id does not identify a supported headline, description/body, or CTA/call_to_action semantic',
+      constraint: 'slot id has no exact runner mapping to a headlines, descriptions, or CTA fixture category',
     };
   }
+  const content = firstString(text[fixtureCategory]);
   return content === undefined
-    ? { ok: false, constraint: `requires a ${semantic} text fixture` }
+    ? { ok: false, constraint: `requires a ${fixtureCategory} text fixture` }
     : { ok: true, asset: { asset_type: 'text', content } };
 }
 
@@ -222,15 +223,6 @@ function buildAssets(value: unknown, context: StoryboardContext, testKit: unknow
     return { ok: false, failure: { reason: resolved.reason, constraint: resolved.constraint } };
   }
   const slots = requiredSlots(resolved.format);
-  if (slots.length === 0) {
-    return {
-      ok: false,
-      failure: {
-        reason: 'malformed_directive',
-        constraint: 'format does not declare any recognizable required asset slots',
-      },
-    };
-  }
 
   const built: JsonObject = {};
   for (const slot of slots) {
@@ -239,7 +231,7 @@ function buildAssets(value: unknown, context: StoryboardContext, testKit: unknow
       return {
         ok: false,
         failure: {
-          reason: 'creative_asset_fixture_unavailable',
+          reason: 'fixture_unavailable',
           slotId: slot.id,
           assetType: slot.assetType,
           constraint: result.constraint,

--- a/src/lib/testing/storyboard/creative-assets.ts
+++ b/src/lib/testing/storyboard/creative-assets.ts
@@ -276,7 +276,6 @@ function textFixtureMismatch(content: string, requirements: JsonObject): string 
     'max_length',
     'min_lines',
     'max_lines',
-    'character_pattern',
     'prohibited_terms',
     'allowed_values',
   ]);
@@ -294,15 +293,6 @@ function textFixtureMismatch(content: string, requirements: JsonObject): string 
   if (minLines !== undefined && lines < minLines) return `requires minimum line count ${minLines}`;
   if (maxLines !== undefined && lines > maxLines) return `requires maximum line count ${maxLines}`;
 
-  if (typeof requirements.character_pattern === 'string') {
-    try {
-      if (!new RegExp(requirements.character_pattern).test(content)) {
-        return `requires character pattern ${requirements.character_pattern}`;
-      }
-    } catch {
-      return `declares invalid character pattern ${requirements.character_pattern}`;
-    }
-  }
   if (Array.isArray(requirements.prohibited_terms)) {
     const prohibited = requirements.prohibited_terms.find(
       (term): term is string => typeof term === 'string' && content.toLowerCase().includes(term.toLowerCase())
@@ -358,6 +348,28 @@ function buildText(slot: RequiredSlot, assets: JsonObject): AssetBuildResult {
     : { ok: true, asset: { asset_type: 'text', content } };
 }
 
+function containsUrlMacro(value: string): boolean {
+  let inMacro = false;
+  let hasContent = false;
+  for (let index = 0; index < value.length; index += 1) {
+    if (!inMacro) {
+      if (value[index] === '$' && value[index + 1] === '{') {
+        inMacro = true;
+        hasContent = false;
+        index += 1;
+      }
+      continue;
+    }
+    if (value[index] === '}') {
+      if (hasContent) return true;
+      inMacro = false;
+      continue;
+    }
+    hasContent = true;
+  }
+  return false;
+}
+
 function buildUrl(slot: RequiredSlot, assets: JsonObject): AssetBuildResult {
   if (typeof assets.click_url !== 'string') return { ok: false, constraint: 'requires a click_url fixture' };
   const url = assets.click_url;
@@ -386,7 +398,7 @@ function buildUrl(slot: RequiredSlot, assets: JsonObject): AssetBuildResult {
   ) {
     return { ok: false, constraint: 'click_url fixture uses a disallowed domain' };
   }
-  if (slot.requirements.macro_support === true && !/\$\{[^}]+\}/.test(url)) {
+  if (slot.requirements.macro_support === true && !containsUrlMacro(url)) {
     return { ok: false, constraint: 'requires a URL fixture with macro support' };
   }
   return { ok: true, asset: { asset_type: 'url', url } };

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -2493,7 +2493,10 @@ async function executeStoryboardPass(
     storyboard,
     phaseCapabilitySkipDetails
   );
-  const capabilitySkippedPhaseIds = new Set(phaseCapabilitySkipDetails.keys());
+  const capabilitySkippedPhaseIds = new Set([
+    ...phaseCapabilitySkipDetails.keys(),
+    ...storyboard.phases.filter(phase => shouldSkipPhase(phase, options)).map(phase => phase.id),
+  ]);
   let creativeAssetFixtureGap = preflightRemainingCreativeAssetDirectives(
     allSteps,
     -1,
@@ -3681,9 +3684,27 @@ async function runMultiPass(
     options.agentTools,
     options.adcpVersion
   );
-  const preSeededResult = allExecutablePhasesCapabilitySkipped(storyboard, phaseCapabilitySkipDetails)
-    ? null
-    : await runControllerSeeding(preSeedClients[0]!, storyboard, options, preSeedContext);
+  const preSeedExcludedPhaseIds = new Set([
+    ...phaseCapabilitySkipDetails.keys(),
+    ...storyboard.phases.filter(phase => shouldSkipPhase(phase, options)).map(phase => phase.id),
+  ]);
+  const preSeedFixtureGap = preflightRemainingCreativeAssetDirectives(
+    flattenSteps(storyboard),
+    -1,
+    preSeedContext,
+    options,
+    {
+      contributions: new Set(),
+      priorStepResults: new Map(),
+      priorProbes: new Map(),
+      agentUrl: agentUrls[0]!,
+    },
+    preSeedExcludedPhaseIds
+  );
+  const preSeededResult =
+    preSeedFixtureGap || allExecutablePhasesCapabilitySkipped(storyboard, phaseCapabilitySkipDetails)
+      ? null
+      : await runControllerSeeding(preSeedClients[0]!, storyboard, options, preSeedContext);
 
   const passes: StoryboardPassResult[] = [];
   const passResults: StoryboardResult[] = [];
@@ -5703,6 +5724,12 @@ function preflightRemainingCreativeAssetDirectives(
 
     const resolvedTask = resolveTaskName(target.step, options);
     if (!resolvedTask) continue;
+    if (target.step.requires_tool && options.agentTools && !options.agentTools.includes(target.step.requires_tool)) {
+      continue;
+    }
+    if (target.step.requires_contract && !new Set(options.contracts ?? []).has(target.step.requires_contract)) {
+      continue;
+    }
     if (!PROBE_TASKS.has(target.step.task) && options.agentTools && !options.agentTools.includes(resolvedTask)) {
       continue;
     }

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -160,6 +160,7 @@ const SKIP_DETAILS: Record<RunnerSkipReason, string> = {
   missing_tool: 'Skipped: agent did not advertise the required tool.',
   missing_test_controller:
     'Skipped: deterministic_testing phase requires comply_test_controller, which the agent did not advertise.',
+  fixture_unavailable: 'Skipped: the runner test kit cannot synthesize a valid input for the seller-declared contract.',
   unsatisfied_contract: 'Skipped: test-kit contract is out of scope for this grading run.',
   requirement_unmet:
     'Skipped: a requires: tag named a runtime requirement that is not available on this run (see RunnerSkipResult.requirement).',
@@ -452,10 +453,7 @@ function buildSkip(reason: RunnerSkipReason, detail?: string): { reason: RunnerS
   return { reason, detail: detail ?? SKIP_DETAILS[reason] };
 }
 
-type CreativeAssetFixtureUnavailableFailure = Extract<
-  CreativeAssetExpansionFailure,
-  { reason: 'creative_asset_fixture_unavailable' }
->;
+type CreativeAssetFixtureUnavailableFailure = Extract<CreativeAssetExpansionFailure, { reason: 'fixture_unavailable' }>;
 
 function buildCreativeAssetFixtureUnavailableStep(
   step: StoryboardStep,
@@ -476,8 +474,8 @@ function buildCreativeAssetFixtureUnavailableStep(
     task,
     passed: true,
     skipped: true,
-    skip_reason: 'creative_asset_fixture_unavailable',
-    skip: buildSkip('not_applicable', detail),
+    skip_reason: 'fixture_unavailable',
+    skip: buildSkip('fixture_unavailable', detail),
     duration_ms: 0,
     validations: [],
     context,
@@ -2495,6 +2493,30 @@ async function executeStoryboardPass(
     storyboard,
     phaseCapabilitySkipDetails
   );
+  const capabilitySkippedPhaseIds = new Set(phaseCapabilitySkipDetails.keys());
+  let creativeAssetFixtureGap = preflightRemainingCreativeAssetDirectives(
+    allSteps,
+    -1,
+    context,
+    options,
+    {
+      contributions,
+      priorStepResults,
+      priorProbes,
+      agentUrl: agentUrls[0]!,
+      webhookReceiver,
+      runnerVars,
+      contextProvenance,
+      priorA2aEnvelopes,
+      stepRequestStarts,
+      responseDerivedNotApplicableContextKeys,
+      agentProfile: profile,
+      agentLibraryVersion: profile?.library_version,
+      storyboardRequiresRequestSigner: allRequires.includes('request_signer'),
+    },
+    capabilitySkippedPhaseIds
+  );
+  let creativeAssetFixtureGapRecorded = false;
   if (!hasExecutableSteps) {
     const isScenarioComposed = (storyboard.requires_scenarios?.length ?? 0) > 0;
     const detail = isScenarioComposed
@@ -2578,11 +2600,13 @@ async function executeStoryboardPass(
         fixtureDiscoveryClient = dispatch.nextFor(fixtureStep('get_products')).client;
       }
     }
-    const seeding = skipControllerSeedingForPhaseGates
+    const seeding = creativeAssetFixtureGap
       ? null
-      : preSeeded !== undefined
-        ? preSeeded.result
-        : await runControllerSeeding(fixtureSeedClient, storyboard, options, context, fixtureDiscoveryClient);
+      : skipControllerSeedingForPhaseGates
+        ? null
+        : preSeeded !== undefined
+          ? preSeeded.result
+          : await runControllerSeeding(fixtureSeedClient, storyboard, options, context, fixtureDiscoveryClient);
     if (seeding) {
       const attach = preSeeded === undefined || preSeeded.attach;
       if (attach) {
@@ -2640,6 +2664,42 @@ async function executeStoryboardPass(
     }
   }
 
+  const buildExecutionState = (
+    agentUrl = agentUrls[0]!,
+    agentProfile: AgentProfile | undefined = profile
+  ): ExecutionState => ({
+    contributions,
+    priorStepResults,
+    priorProbes,
+    agentUrl,
+    webhookReceiver,
+    runnerVars,
+    contextProvenance,
+    priorA2aEnvelopes,
+    stepRequestStarts,
+    responseDerivedNotApplicableContextKeys,
+    agentProfile,
+    agentLibraryVersion: agentProfile?.library_version,
+    storyboardRequiresRequestSigner: allRequires.includes('request_signer'),
+    fixtureBindings,
+  });
+  if (
+    !creativeAssetFixtureGap &&
+    !seedingMissingController &&
+    !seedingUnsupported &&
+    !seedingFailed &&
+    !fixtureUnsatisfied
+  ) {
+    creativeAssetFixtureGap = preflightRemainingCreativeAssetDirectives(
+      allSteps,
+      -1,
+      context,
+      options,
+      buildExecutionState(),
+      capabilitySkippedPhaseIds
+    );
+  }
+
   for (const phase of storyboard.phases) {
     // adcp-client#1612: bail at phase boundaries when comply()'s combined
     // timeout/external signal has aborted. Without this the phase loop runs
@@ -2658,6 +2718,38 @@ async function executeStoryboardPass(
         steps: [],
         duration_ms: 0,
       });
+      continue;
+    }
+
+    // A captured seller format proved that a future creative directive cannot
+    // be synthesized. Preserve earlier observations, record the directive
+    // step once, and leave every other remaining phase empty: no side effect
+    // or prerequisite cascade may occur after this runner-owned coverage gap.
+    if (creativeAssetFixtureGap) {
+      const gapSteps: StoryboardStepResult[] = [];
+      if (!creativeAssetFixtureGapRecorded && creativeAssetFixtureGap.target.phaseId === phase.id) {
+        const gapStep = buildCreativeAssetFixtureUnavailableStep(
+          creativeAssetFixtureGap.target.step,
+          phase.id,
+          context,
+          allSteps,
+          buildExecutionState(),
+          creativeAssetFixtureGap.failure
+        );
+        gapStep.storyboard_id = storyboard.id;
+        gapSteps.push(gapStep);
+        priorStepResults.set(gapStep.step_id, gapStep);
+        skippedCount++;
+        creativeAssetFixtureGapRecorded = true;
+      }
+      phaseResults.push({
+        phase_id: phase.id,
+        phase_title: phase.title,
+        passed: true,
+        steps: gapSteps,
+        duration_ms: 0,
+      });
+      priorPhaseIds.push(phase.id);
       continue;
     }
 
@@ -2972,6 +3064,7 @@ async function executeStoryboardPass(
         phasePassed = false;
         continue;
       }
+      const stepExecutionState = buildExecutionState(assignment.agentUrl, assignment.profile);
       const rawResult = await executeStep(
         assignment.client,
         step,
@@ -2980,22 +3073,7 @@ async function executeStoryboardPass(
         context,
         allSteps,
         options,
-        {
-          contributions,
-          priorStepResults,
-          priorProbes,
-          agentUrl: assignment.agentUrl,
-          webhookReceiver,
-          runnerVars,
-          contextProvenance,
-          priorA2aEnvelopes,
-          stepRequestStarts,
-          responseDerivedNotApplicableContextKeys,
-          agentProfile: assignment.profile,
-          agentLibraryVersion: assignment.profile?.library_version,
-          storyboardRequiresRequestSigner: allRequires.includes('request_signer'),
-          fixtureBindings,
-        }
+        stepExecutionState
       );
       const result: StoryboardStepResult = { ...rawResult, storyboard_id: storyboard.id };
       if (isMultiInstance || useRouting) {
@@ -3256,6 +3334,40 @@ async function executeStoryboardPass(
           annotateMultiInstanceFailure(result, storyboard, stepResults);
         }
       }
+
+      if (!result.skipped && result.passed) {
+        const currentGlobalIndex = allSteps.find(
+          flat => flat.phaseId === phase.id && flat.step.id === step.id
+        )?.globalIndex;
+        if (currentGlobalIndex !== undefined) {
+          creativeAssetFixtureGap = preflightRemainingCreativeAssetDirectives(
+            allSteps,
+            currentGlobalIndex,
+            context,
+            options,
+            stepExecutionState,
+            capabilitySkippedPhaseIds
+          );
+        }
+        if (creativeAssetFixtureGap) {
+          if (creativeAssetFixtureGap.target.phaseId === phase.id) {
+            const gapStep = buildCreativeAssetFixtureUnavailableStep(
+              creativeAssetFixtureGap.target.step,
+              phase.id,
+              context,
+              allSteps,
+              stepExecutionState,
+              creativeAssetFixtureGap.failure
+            );
+            gapStep.storyboard_id = storyboard.id;
+            stepResults.push(gapStep);
+            priorStepResults.set(gapStep.step_id, gapStep);
+            skippedCount++;
+            creativeAssetFixtureGapRecorded = true;
+          }
+          break;
+        }
+      }
     }
 
     // Phase-end cascade resolution for deferred `not_applicable` triggers.
@@ -3368,26 +3480,30 @@ async function executeStoryboardPass(
   // invariant). `branchSetsByPhaseId` was resolved before the phase loop so
   // the stateful cascade could consult it (branch-set peers don't cascade
   // onto each other); reuse it here.
-  const branchSetDelta = applyBranchSetGrading(
-    storyboard.phases,
-    phaseResults,
-    branchSetsByPhaseId,
-    contributions,
-    contributionSources,
-    countedAsFailed
-  );
+  const branchSetDelta = creativeAssetFixtureGap
+    ? { skippedDelta: 0 }
+    : applyBranchSetGrading(
+        storyboard.phases,
+        phaseResults,
+        branchSetsByPhaseId,
+        contributions,
+        contributionSources,
+        countedAsFailed
+      );
   skippedCount += branchSetDelta.skippedDelta;
 
   // Fire storyboard-scoped assertions. These observe the full run and can
   // emit `scope: "storyboard"` findings that flip `overall_passed` without
   // being attributable to a single step (e.g. "saw >1 acquire for the same
   // replayed idempotency_key across the run").
-  for (const spec of assertions) {
-    if (!spec.onEnd) continue;
-    const raw = await spec.onEnd(assertionContexts.get(spec.id)!);
-    for (const r of raw) {
-      assertionResults.push({ ...r, assertion_id: spec.id, scope: 'storyboard' });
-      if (!r.passed) assertionsFailed = true;
+  if (!creativeAssetFixtureGap) {
+    for (const spec of assertions) {
+      if (!spec.onEnd) continue;
+      const raw = await spec.onEnd(assertionContexts.get(spec.id)!);
+      for (const r of raw) {
+        assertionResults.push({ ...r, assertion_id: spec.id, scope: 'storyboard' });
+        if (!r.passed) assertionsFailed = true;
+      }
     }
   }
 
@@ -3434,7 +3550,8 @@ async function executeStoryboardPass(
     requiredPhaseHasExecutedPass ||
     requiredPhasesNotApplicable ||
     (failedCount === 0 && requiredPhasesCoveredByCapabilityGates);
-  const storyboardWideFixtureUnavailable = (seedingUnsupported || fixtureUnsatisfied) && failedCount === 0;
+  const storyboardWideFixtureUnavailable =
+    (seedingUnsupported || fixtureUnsatisfied || creativeAssetFixtureGap !== undefined) && failedCount === 0;
   // Prepend the pre-flight seeding phase now that every consumer that
   // index-aligns `phaseResults` with `storyboard.phases` has run. Reader
   // order matches execution order.
@@ -4202,7 +4319,7 @@ async function executeStep(
   // active test kit after all other nested request construction is complete.
   const creativeAssetExpansion = expandCreativeAssetDirectivesWithDiagnostics(request, context, options.test_kit);
   request = creativeAssetExpansion.value as Record<string, unknown>;
-  if (!creativeAssetExpansion.ok && creativeAssetExpansion.failure.reason === 'creative_asset_fixture_unavailable') {
+  if (!creativeAssetExpansion.ok && creativeAssetExpansion.failure.reason === 'fixture_unavailable') {
     return buildCreativeAssetFixtureUnavailableStep(
       step,
       phaseId,
@@ -5553,13 +5670,61 @@ function buildEffectiveStepRequest(
     context,
     options.test_kit
   );
-  if (!creativeAssetExpansion.ok && creativeAssetExpansion.failure.reason === 'creative_asset_fixture_unavailable') {
+  if (!creativeAssetExpansion.ok && creativeAssetExpansion.failure.reason === 'fixture_unavailable') {
     return { ok: false, creativeAssetFailure: creativeAssetExpansion.failure };
   }
   return {
     ok: true,
     request: creativeAssetExpansion.value as Record<string, unknown>,
   };
+}
+
+interface CreativeAssetPreflightGap {
+  target: FlatStep;
+  failure: CreativeAssetFixtureUnavailableFailure;
+}
+
+/**
+ * Preflight future creative directives as soon as their seller format enters
+ * context. Missing context and malformed directives stay on their ordinary
+ * execution paths; only a proven test-kit coverage gap terminates the run.
+ */
+function preflightRemainingCreativeAssetDirectives(
+  allSteps: FlatStep[],
+  afterGlobalIndex: number,
+  context: StoryboardContext,
+  options: StoryboardRunOptions,
+  runState: ExecutionState,
+  excludedPhaseIds: ReadonlySet<string> = new Set()
+): CreativeAssetPreflightGap | undefined {
+  for (const target of allSteps) {
+    if (target.globalIndex <= afterGlobalIndex) continue;
+    if (excludedPhaseIds.has(target.phaseId)) continue;
+
+    const resolvedTask = resolveTaskName(target.step, options);
+    if (!resolvedTask) continue;
+    if (!PROBE_TASKS.has(target.step.task) && options.agentTools && !options.agentTools.includes(resolvedTask)) {
+      continue;
+    }
+    let requestStep = resolvedTask === target.step.task ? target.step : { ...target.step, task: resolvedTask };
+
+    if (target.step.task === 'expect_rate_limit_not_replayed') {
+      const rateLimitTrip = target.step.rate_limit_trip;
+      if (validateRateLimitTripSpec(rateLimitTrip) || !rateLimitTrip) continue;
+      requestStep = {
+        ...target.step,
+        task: rateLimitTrip.trip_target_task,
+        sample_request: rateLimitTrip.trip_target_sample_request,
+        omit_idempotency_key: true,
+      };
+    }
+
+    const request = buildEffectiveStepRequest(requestStep, context, options, runState);
+    if (!request.ok && 'creativeAssetFailure' in request) {
+      return { target, failure: request.creativeAssetFailure };
+    }
+  }
+  return undefined;
 }
 
 interface ResolvedWebhookReplayVector {

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -1808,6 +1808,9 @@ export type RunnerSkipReason =
    * The runner selected the pathway but its test kit cannot synthesize a
    * valid input for the seller-declared contract. This is a runner-owned
    * coverage gap: it never fails validations or cascades prerequisites.
+   * Spec: AdCP runner-output-contract v2.8.0,
+   * `skip_result.reasons.fixture_unavailable` (adcp#6276). Early preflight
+   * and whole-storyboard termination semantics: adcp#6278.
    */
   | 'fixture_unavailable'
   | 'unsatisfied_contract'

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -1804,6 +1804,12 @@ export type RunnerSkipReason =
   | 'prerequisite_failed'
   | 'missing_tool'
   | 'missing_test_controller'
+  /**
+   * The runner selected the pathway but its test kit cannot synthesize a
+   * valid input for the seller-declared contract. This is a runner-owned
+   * coverage gap: it never fails validations or cascades prerequisites.
+   */
+  | 'fixture_unavailable'
   | 'unsatisfied_contract'
   /**
    * A storyboard-level `requires:` tag named a requirement that is not
@@ -1837,7 +1843,7 @@ export type RunnerSkipReason =
   | 'peer_substituted';
 
 /**
- * Grader-specific skip reasons. These are narrower than the six canonical
+ * Grader-specific skip reasons. These are narrower than the canonical
  * `RunnerSkipReason` values — they carry runner-local context (which probe,
  * which operator opt-out) that the contract neither requires nor forbids.
  * The runner records them on `skip_reason` for legacy consumers, and also
@@ -1881,8 +1887,6 @@ export type RunnerDetailedSkipReason =
   | 'fixture_seed_unsupported'
   /** A valid fixture strategy ladder exhausted without finding a binding. */
   | 'fixture_unsatisfied'
-  /** A valid seller format requires an asset slot the selected test kit cannot synthesize. */
-  | 'creative_asset_fixture_unavailable'
   /**
    * A `requires_capability` predicate on the storyboard evaluated to false —
    * the agent explicitly declared it does not support the capability this
@@ -1907,7 +1911,7 @@ export type RunnerDetailedSkipReason =
   | 'force_scenario_unsupported';
 
 /**
- * Map detailed grader skip reasons onto the six canonical spec values so
+ * Map detailed grader skip reasons onto the canonical spec values so
  * consumers reading `skip.reason` get a stable enum regardless of which
  * subsystem produced the skip.
  */
@@ -1923,7 +1927,6 @@ export const DETAILED_SKIP_TO_CANONICAL: Record<RunnerDetailedSkipReason, Runner
   force_scenario_unsupported: 'not_applicable',
   fixture_seed_unsupported: 'not_applicable',
   fixture_unsatisfied: 'not_applicable',
-  creative_asset_fixture_unavailable: 'not_applicable',
   capability_unsupported: 'unsatisfied_contract',
   rate_abuse_opt_out: 'unsatisfied_contract',
   missing_test_kit_contract: 'unsatisfied_contract',
@@ -2227,8 +2230,8 @@ export interface StoryboardStepResult {
   /** True when the step was not executed */
   skipped?: boolean;
   /**
-   * Skip reason. Accepts either a canonical `RunnerSkipReason` (the six
-   * spec-required values) or one of the grader-specific variants introduced
+   * Skip reason. Accepts either a canonical `RunnerSkipReason` or one of the
+   * grader-specific variants introduced
    * by the RFC 9421 request-signing grader (#585, #617). The structured
    * `skip` field below always carries the canonical spec reason so consumers
    * of the runner-output contract don't need to know the grader vocabulary.

--- a/test/lib/storyboard-creative-assets.test.js
+++ b/test/lib/storyboard-creative-assets.test.js
@@ -236,6 +236,39 @@ describe('$build_assets_from_format', () => {
     }
   });
 
+  test('reports a required repeatable group instead of silently dropping it', () => {
+    const result = expandCreativeAssetDirectivesWithDiagnostics(
+      {
+        assets: {
+          [BUILD_ASSETS_FROM_FORMAT_DIRECTIVE]: {
+            slots: [
+              {
+                asset_group_id: 'carousel',
+                item_type: 'repeatable_group',
+                required: true,
+                min_count: 2,
+                assets: [
+                  {
+                    asset_id: 'card_image',
+                    asset_type: 'image',
+                    required: true,
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      },
+      {},
+      TEST_KIT
+    );
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.failure.reason, 'fixture_unavailable');
+    assert.strictEqual(result.failure.slotId, 'carousel');
+    assert.strictEqual(result.failure.assetType, 'repeatable_group');
+  });
+
   test('reports an unavailable exact image dimension', () => {
     const result = expandCreativeAssetDirectivesWithDiagnostics(
       {

--- a/test/lib/storyboard-creative-assets.test.js
+++ b/test/lib/storyboard-creative-assets.test.js
@@ -8,7 +8,6 @@ const {
 const { expandCreativeAssetDirectives, findUnresolvedCreativeAssetDirectives } = require('../../dist/lib/testing');
 const { injectContext } = require('../../dist/lib/testing/storyboard/context');
 const { runStoryboard } = require('../../dist/lib/testing/storyboard/runner');
-const { DETAILED_SKIP_TO_CANONICAL } = require('../../dist/lib/testing/storyboard/types');
 
 const TEST_KIT = {
   assets: {
@@ -85,10 +84,6 @@ function runnerOptions(calls) {
 }
 
 describe('$build_assets_from_format', () => {
-  test('maps fixture-unavailable diagnostics to canonical not_applicable', () => {
-    assert.strictEqual(DETAILED_SKIP_TO_CANONICAL.creative_asset_fixture_unavailable, 'not_applicable');
-  });
-
   test('uses canonical required slots and selects the exact declared dimensions', () => {
     const request = {
       creatives: [
@@ -180,9 +175,15 @@ describe('$build_assets_from_format', () => {
             slots: [
               { asset_group_id: 'image_main', asset_type: 'image', required: true },
               { asset_group_id: 'landing_url', asset_type: 'url', required: true },
-              { asset_group_id: 'marketing_headline', asset_type: 'text', required: true },
-              { asset_group_id: 'body_copy', asset_type: 'text', required: true },
-              { asset_group_id: 'primary_cta', asset_type: 'text', required: true },
+              { asset_group_id: 'headline', asset_type: 'text', required: true },
+              { asset_group_id: 'title', asset_type: 'text', required: true },
+              { asset_group_id: 'description', asset_type: 'text', required: true },
+              { asset_group_id: 'body', asset_type: 'text', required: true },
+              { asset_group_id: 'body_text', asset_type: 'text', required: true },
+              { asset_group_id: 'primary_text', asset_type: 'text', required: true },
+              { asset_group_id: 'cta', asset_type: 'text', required: true },
+              { asset_group_id: 'cta_text', asset_type: 'text', required: true },
+              { asset_group_id: 'call_to_action', asset_type: 'text', required: true },
             ],
           },
         },
@@ -196,15 +197,21 @@ describe('$build_assets_from_format', () => {
       asset_type: 'url',
       url: 'https://acmeoutdoor.example/summer-sale',
     });
-    assert.deepStrictEqual(expanded.assets.marketing_headline, {
-      asset_type: 'text',
-      content: 'Built for the Trail',
-    });
-    assert.deepStrictEqual(expanded.assets.body_copy, {
-      asset_type: 'text',
-      content: 'Adventure starts here',
-    });
-    assert.deepStrictEqual(expanded.assets.primary_cta, { asset_type: 'text', content: 'Shop Now' });
+    for (const slotId of ['headline', 'title']) {
+      assert.deepStrictEqual(expanded.assets[slotId], {
+        asset_type: 'text',
+        content: 'Built for the Trail',
+      });
+    }
+    for (const slotId of ['description', 'body', 'body_text', 'primary_text']) {
+      assert.deepStrictEqual(expanded.assets[slotId], {
+        asset_type: 'text',
+        content: 'Adventure starts here',
+      });
+    }
+    for (const slotId of ['cta', 'cta_text', 'call_to_action']) {
+      assert.deepStrictEqual(expanded.assets[slotId], { asset_type: 'text', content: 'Shop Now' });
+    }
   });
 
   test('reports unsupported asset types with a slot-level fixture diagnostic', () => {
@@ -222,7 +229,7 @@ describe('$build_assets_from_format', () => {
       );
 
       assert.strictEqual(result.ok, false);
-      assert.strictEqual(result.failure.reason, 'creative_asset_fixture_unavailable');
+      assert.strictEqual(result.failure.reason, 'fixture_unavailable');
       assert.strictEqual(result.failure.slotId, `${assetType}_main`);
       assert.strictEqual(result.failure.assetType, assetType);
       assert.match(result.failure.constraint, new RegExp(`asset type "${assetType}"`));
@@ -245,18 +252,40 @@ describe('$build_assets_from_format', () => {
     );
 
     assert.strictEqual(result.ok, false);
-    assert.strictEqual(result.failure.reason, 'creative_asset_fixture_unavailable');
+    assert.strictEqual(result.failure.reason, 'fixture_unavailable');
     assert.strictEqual(result.failure.slotId, 'billboard');
     assert.strictEqual(result.failure.assetType, 'image');
     assert.match(result.failure.constraint, /exact 970x250/);
   });
 
-  test('does not substitute marketing copy for an unknown text semantic', () => {
+  test('does not infer text semantics from unknown or substring-lookalike slot ids', () => {
+    for (const slotId of ['legal_disclaimer', 'marketing_headline']) {
+      const result = expandCreativeAssetDirectivesWithDiagnostics(
+        {
+          assets: {
+            [BUILD_ASSETS_FROM_FORMAT_DIRECTIVE]: {
+              slots: [{ asset_group_id: slotId, asset_type: 'text', required: true }],
+            },
+          },
+        },
+        {},
+        TEST_KIT
+      );
+
+      assert.strictEqual(result.ok, false);
+      assert.strictEqual(result.failure.reason, 'fixture_unavailable');
+      assert.strictEqual(result.failure.slotId, slotId);
+      assert.strictEqual(result.failure.assetType, 'text');
+      assert.match(result.failure.constraint, /no exact runner mapping/);
+    }
+  });
+
+  test('expands a valid format with no required slots to an empty asset map', () => {
     const result = expandCreativeAssetDirectivesWithDiagnostics(
       {
         assets: {
           [BUILD_ASSETS_FROM_FORMAT_DIRECTIVE]: {
-            slots: [{ asset_group_id: 'legal_disclaimer', asset_type: 'text', required: true }],
+            slots: [{ asset_group_id: 'optional_image', asset_type: 'image', required: false }],
           },
         },
       },
@@ -264,11 +293,8 @@ describe('$build_assets_from_format', () => {
       TEST_KIT
     );
 
-    assert.strictEqual(result.ok, false);
-    assert.strictEqual(result.failure.reason, 'creative_asset_fixture_unavailable');
-    assert.strictEqual(result.failure.slotId, 'legal_disclaimer');
-    assert.strictEqual(result.failure.assetType, 'text');
-    assert.match(result.failure.constraint, /does not identify a supported headline/);
+    assert.strictEqual(result.ok, true);
+    assert.deepStrictEqual(result.value.assets, {});
   });
 
   test('distinguishes missing format context and malformed directives from fixture gaps', () => {
@@ -462,8 +488,8 @@ describe('$build_assets_from_format', () => {
     const step = result.phases[0].steps[0];
     assert.strictEqual(step.skipped, true);
     assert.strictEqual(step.passed, true);
-    assert.strictEqual(step.skip_reason, 'creative_asset_fixture_unavailable');
-    assert.strictEqual(step.skip.reason, 'not_applicable');
+    assert.strictEqual(step.skip_reason, 'fixture_unavailable');
+    assert.strictEqual(step.skip.reason, 'fixture_unavailable');
     assert.match(step.skip.detail, /^creative_asset_fixture_unavailable:/);
     assert.match(step.skip.detail, /slot "video_main"/);
     assert.match(step.skip.detail, /asset type "video"/);
@@ -562,6 +588,120 @@ describe('$build_assets_from_format', () => {
     assert.strictEqual(consumer.skip.reason, 'prerequisite_failed');
   });
 
+  test('preflights a captured format before intervening side effects and terminates without cascades', async () => {
+    const calls = [];
+    const storyboard = {
+      id: 'creative_asset_early_preflight',
+      version: '1.0.0',
+      title: 'Creative asset early preflight',
+      category: 'compliance',
+      summary: '',
+      narrative: '',
+      agent: { interaction_model: '*', capabilities: [] },
+      caller: { role: 'buyer_agent' },
+      phases: [
+        {
+          id: 'setup',
+          title: 'Setup',
+          steps: [
+            {
+              id: 'formats',
+              title: 'Discover a format',
+              task: 'get_products',
+              sample_request: {},
+              context_outputs: [{ key: 'format_params', path: 'products[0].format_options[0].params' }],
+              validations: [],
+            },
+            {
+              id: 'create_buy',
+              title: 'Create buy',
+              task: 'create_media_buy',
+              stateful: true,
+              sample_request: {},
+              validations: [],
+            },
+            {
+              id: 'sync',
+              title: 'Sync creative',
+              task: 'sync_creatives',
+              stateful: true,
+              sample_request: {
+                creatives: [
+                  {
+                    creative_id: 'creative-1',
+                    format_kind: 'video',
+                    assets: { [BUILD_ASSETS_FROM_FORMAT_DIRECTIVE]: '$context.format_params' },
+                  },
+                ],
+              },
+              validations: [],
+            },
+          ],
+        },
+        {
+          id: 'cleanup',
+          title: 'Cleanup',
+          steps: [
+            {
+              id: 'cancel_buy',
+              title: 'Cancel buy',
+              task: 'update_media_buy',
+              stateful: true,
+              sample_request: {},
+              validations: [],
+            },
+          ],
+        },
+      ],
+    };
+    const options = runnerOptions(calls);
+    options.agentTools = ['get_products', 'create_media_buy', 'sync_creatives', 'update_media_buy'];
+    options._profile.tools = options.agentTools;
+    options._client.executeTask = async (name, params) => {
+      calls.push({ name, params });
+      if (name === 'get_products') {
+        return {
+          success: true,
+          data: {
+            products: [
+              {
+                format_options: [
+                  {
+                    params: {
+                      slots: [{ asset_group_id: 'video_main', asset_type: 'video', required: true }],
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        };
+      }
+      return { success: true, data: {} };
+    };
+
+    const result = await runStoryboard('https://seller.example/mcp', storyboard, options);
+
+    assert.deepStrictEqual(
+      calls.map(call => call.name),
+      ['get_products']
+    );
+    assert.deepStrictEqual(
+      result.phases[0].steps.map(step => step.step_id),
+      ['formats', 'sync']
+    );
+    assert.strictEqual(result.phases[0].steps[1].skip.reason, 'fixture_unavailable');
+    assert.deepStrictEqual(result.phases[1].steps, []);
+    assert.strictEqual(
+      result.phases.flatMap(phase => phase.steps).some(step => step.skip_reason === 'prerequisite_failed'),
+      false
+    );
+    assert.strictEqual(result.passed_count, 1);
+    assert.strictEqual(result.failed_count, 0);
+    assert.strictEqual(result.skipped_count, 1);
+    assert.strictEqual(result.overall_passed, true);
+  });
+
   test('rate-limit trip target also grades an unavailable fixture pre-wire', async () => {
     const calls = [];
     const storyboard = {
@@ -615,8 +755,8 @@ describe('$build_assets_from_format', () => {
     const step = result.phases[0].steps[0];
     assert.strictEqual(step.passed, true);
     assert.strictEqual(step.skipped, true);
-    assert.strictEqual(step.skip_reason, 'creative_asset_fixture_unavailable');
-    assert.strictEqual(step.skip.reason, 'not_applicable');
+    assert.strictEqual(step.skip_reason, 'fixture_unavailable');
+    assert.strictEqual(step.skip.reason, 'fixture_unavailable');
     assert.match(step.skip.detail, /slot "vast_main"/);
     assert.match(step.skip.detail, /asset type "vast_tag"/);
     assert.strictEqual(result.failed_count, 0);

--- a/test/lib/storyboard-creative-assets.test.js
+++ b/test/lib/storyboard-creative-assets.test.js
@@ -258,6 +258,58 @@ describe('$build_assets_from_format', () => {
     assert.match(result.failure.constraint, /exact 970x250/);
   });
 
+  test('reports text fixtures that violate declared slot constraints', () => {
+    const result = expandCreativeAssetDirectivesWithDiagnostics(
+      {
+        assets: {
+          [BUILD_ASSETS_FROM_FORMAT_DIRECTIVE]: {
+            slots: [
+              {
+                asset_group_id: 'headline',
+                asset_type: 'text',
+                required: true,
+                requirements: { max_length: 5 },
+              },
+            ],
+          },
+        },
+      },
+      {},
+      TEST_KIT
+    );
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.failure.reason, 'fixture_unavailable');
+    assert.match(result.failure.constraint, /maximum length 5/);
+  });
+
+  test('reports image requirements the fixture metadata cannot prove', () => {
+    const result = expandCreativeAssetDirectivesWithDiagnostics(
+      {
+        assets: {
+          [BUILD_ASSETS_FROM_FORMAT_DIRECTIVE]: {
+            width: 300,
+            height: 250,
+            slots: [
+              {
+                asset_group_id: 'image_main',
+                asset_type: 'image',
+                required: true,
+                requirements: { max_file_size_kb: 25 },
+              },
+            ],
+          },
+        },
+      },
+      {},
+      TEST_KIT
+    );
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.failure.reason, 'fixture_unavailable');
+    assert.match(result.failure.constraint, /max_file_size_kb/);
+  });
+
   test('does not infer text semantics from unknown or substring-lookalike slot ids', () => {
     for (const slotId of ['legal_disclaimer', 'marketing_headline']) {
       const result = expandCreativeAssetDirectivesWithDiagnostics(
@@ -700,6 +752,144 @@ describe('$build_assets_from_format', () => {
     assert.strictEqual(result.failed_count, 0);
     assert.strictEqual(result.skipped_count, 1);
     assert.strictEqual(result.overall_passed, true);
+  });
+
+  test('does not preflight directives in skip_if phases or steps gated by requires_tool', async () => {
+    const calls = [];
+    const unavailableRequest = {
+      creatives: [
+        {
+          creative_id: 'creative-1',
+          assets: {
+            [BUILD_ASSETS_FROM_FORMAT_DIRECTIVE]: {
+              slots: [{ asset_group_id: 'video_main', asset_type: 'video', required: true }],
+            },
+          },
+        },
+      ],
+    };
+    const storyboard = {
+      id: 'creative_asset_ineligible_preflight',
+      version: '1.0.0',
+      title: 'Creative asset ineligible preflight',
+      category: 'compliance',
+      summary: '',
+      narrative: '',
+      agent: { interaction_model: '*', capabilities: [] },
+      caller: { role: 'buyer_agent' },
+      phases: [
+        {
+          id: 'test_kit_skipped',
+          title: 'Test-kit skipped',
+          skip_if: 'test_kit.skip_creative',
+          steps: [
+            {
+              id: 'skipped_sync',
+              title: 'Skipped sync',
+              task: 'sync_creatives',
+              sample_request: unavailableRequest,
+              validations: [],
+            },
+          ],
+        },
+        {
+          id: 'tool_gated',
+          title: 'Tool gated',
+          steps: [
+            {
+              id: 'gated_sync',
+              title: 'Gated sync',
+              task: 'sync_creatives',
+              requires_tool: 'creative_video_transformer',
+              sample_request: unavailableRequest,
+              validations: [],
+            },
+          ],
+        },
+        {
+          id: 'runnable',
+          title: 'Runnable',
+          steps: [
+            {
+              id: 'list',
+              title: 'List creatives',
+              task: 'list_creatives',
+              sample_request: {},
+              validations: [],
+            },
+          ],
+        },
+      ],
+    };
+    const options = runnerOptions(calls);
+    options.test_kit = { ...TEST_KIT, skip_creative: true };
+    options.agentTools = ['sync_creatives', 'list_creatives'];
+    options._profile.tools = options.agentTools;
+
+    const result = await runStoryboard('https://seller.example/mcp', storyboard, options);
+
+    assert.deepStrictEqual(
+      calls.map(call => call.name),
+      ['list_creatives']
+    );
+    assert.deepStrictEqual(result.phases[0].steps, []);
+    assert.strictEqual(result.phases[1].steps[0].skip_reason, 'missing_tool');
+    assert.strictEqual(
+      result.phases.flatMap(phase => phase.steps).some(step => step.skip_reason === 'fixture_unavailable'),
+      false
+    );
+  });
+
+  test('does not let a missing requires_contract probe become fixture_unavailable', async () => {
+    const calls = [];
+    const storyboard = {
+      id: 'creative_asset_contract_gate',
+      version: '1.0.0',
+      title: 'Creative asset contract gate',
+      category: 'compliance',
+      summary: '',
+      narrative: '',
+      agent: { interaction_model: '*', capabilities: [] },
+      caller: { role: 'buyer_agent' },
+      phases: [
+        {
+          id: 'rate_limit',
+          title: 'Rate limit',
+          steps: [
+            {
+              id: 'trip',
+              title: 'Trip rate limit',
+              task: 'expect_rate_limit_not_replayed',
+              requires_contract: 'rate-abuse',
+              rate_limit_trip: {
+                trip_target_task: 'sync_creatives',
+                trip_target_sample_request: {
+                  creatives: [
+                    {
+                      creative_id: 'creative-1',
+                      assets: {
+                        [BUILD_ASSETS_FROM_FORMAT_DIRECTIVE]: {
+                          slots: [{ asset_group_id: 'video_main', asset_type: 'video', required: true }],
+                        },
+                      },
+                    },
+                  ],
+                },
+                max_attempts: 2,
+                replay_max_wait_seconds: 1,
+              },
+              validations: [],
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = await runStoryboard('https://seller.example/mcp', storyboard, runnerOptions(calls));
+
+    assert.strictEqual(calls.length, 0);
+    assert.strictEqual(result.phases[0].steps[0].skip_reason, 'missing_test_kit_contract');
+    assert.strictEqual(result.phases[0].steps[0].skip.reason, 'unsatisfied_contract');
   });
 
   test('rate-limit trip target also grades an unavailable fixture pre-wire', async () => {

--- a/test/lib/storyboard-creative-assets.test.js
+++ b/test/lib/storyboard-creative-assets.test.js
@@ -300,36 +300,38 @@ describe('$build_assets_from_format', () => {
   });
 
   test('reports a required repeatable group instead of silently dropping it', () => {
-    const result = expandCreativeAssetDirectivesWithDiagnostics(
-      {
-        assets: {
-          [BUILD_ASSETS_FROM_FORMAT_DIRECTIVE]: {
-            slots: [
-              {
-                asset_group_id: 'carousel',
-                item_type: 'repeatable_group',
-                required: true,
-                min_count: 2,
-                assets: [
-                  {
-                    asset_id: 'card_image',
-                    asset_type: 'image',
-                    required: true,
-                  },
-                ],
-              },
-            ],
+    for (const container of ['slots', 'assets']) {
+      const result = expandCreativeAssetDirectivesWithDiagnostics(
+        {
+          assets: {
+            [BUILD_ASSETS_FROM_FORMAT_DIRECTIVE]: {
+              [container]: [
+                {
+                  asset_group_id: 'carousel',
+                  item_type: 'repeatable_group',
+                  required: true,
+                  min_count: 2,
+                  assets: [
+                    {
+                      asset_id: 'card_image',
+                      asset_type: 'image',
+                      required: true,
+                    },
+                  ],
+                },
+              ],
+            },
           },
         },
-      },
-      {},
-      TEST_KIT
-    );
+        {},
+        TEST_KIT
+      );
 
-    assert.strictEqual(result.ok, false);
-    assert.strictEqual(result.failure.reason, 'fixture_unavailable');
-    assert.strictEqual(result.failure.slotId, 'carousel');
-    assert.strictEqual(result.failure.assetType, 'repeatable_group');
+      assert.strictEqual(result.ok, false, container);
+      assert.strictEqual(result.failure.reason, 'fixture_unavailable', container);
+      assert.strictEqual(result.failure.slotId, 'carousel', container);
+      assert.strictEqual(result.failure.assetType, 'repeatable_group', container);
+    }
   });
 
   test('reports an unavailable exact image dimension', () => {

--- a/test/lib/storyboard-creative-assets.test.js
+++ b/test/lib/storyboard-creative-assets.test.js
@@ -143,6 +143,69 @@ describe('$build_assets_from_format', () => {
     });
   });
 
+  test('preserves parameterized FormatId dimensions when resolving a template format', () => {
+    const formatRef = {
+      agent_url: 'https://creative.example',
+      id: 'display_template',
+      width: 970,
+      height: 250,
+    };
+    const result = expandCreativeAssetDirectivesWithDiagnostics(
+      { assets: { [BUILD_ASSETS_FROM_FORMAT_DIRECTIVE]: formatRef } },
+      {
+        formats: [
+          {
+            format_id: { agent_url: 'https://creative.example', id: 'display_template' },
+            assets: [
+              {
+                asset_id: 'banner_image',
+                asset_type: 'image',
+                required: true,
+                requirements: { parameters_from_format_id: true },
+              },
+            ],
+          },
+        ],
+      },
+      TEST_KIT
+    );
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.failure.reason, 'fixture_unavailable');
+    assert.match(result.failure.constraint, /exact 970x250/);
+  });
+
+  test('reads parameterized dimensions from an inline format_id', () => {
+    const result = expandCreativeAssetDirectivesWithDiagnostics(
+      {
+        assets: {
+          [BUILD_ASSETS_FROM_FORMAT_DIRECTIVE]: {
+            format_id: {
+              agent_url: 'https://creative.example',
+              id: 'display_template',
+              width: 970,
+              height: 250,
+            },
+            assets: [
+              {
+                asset_id: 'banner_image',
+                asset_type: 'image',
+                required: true,
+                requirements: { parameters_from_format_id: true },
+              },
+            ],
+          },
+        },
+      },
+      {},
+      TEST_KIT
+    );
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.failure.reason, 'fixture_unavailable');
+    assert.match(result.failure.constraint, /exact 970x250/);
+  });
+
   test('preserves sibling assets when expanding the directive', () => {
     const trackingPixel = { asset_type: 'url', url: 'https://metrics.example/pixel' };
     const expanded = expandCreativeAssetDirectives(

--- a/test/lib/storyboard-creative-assets.test.js
+++ b/test/lib/storyboard-creative-assets.test.js
@@ -501,6 +501,97 @@ describe('$build_assets_from_format', () => {
     assert.deepStrictEqual(result.value.assets, {});
   });
 
+  test('rejects malformed required slots instead of silently dropping them', () => {
+    const malformedSlots = [
+      {
+        slot: { asset_group_id: 'image_main', required: true },
+        expectedField: 'slots[0].asset_type',
+      },
+      {
+        slot: { asset_group_id: 123, asset_type: 'image', required: true },
+        expectedField: 'slots[0].asset_group_id',
+      },
+    ];
+
+    for (const { slot, expectedField } of malformedSlots) {
+      const result = expandCreativeAssetDirectivesWithDiagnostics(
+        {
+          assets: {
+            [BUILD_ASSETS_FROM_FORMAT_DIRECTIVE]: {
+              slots: [slot],
+            },
+          },
+        },
+        {},
+        TEST_KIT
+      );
+
+      assert.strictEqual(result.ok, false);
+      assert.strictEqual(result.failure.reason, 'malformed_directive');
+      assert.ok(result.failure.constraint.includes(expectedField));
+    }
+  });
+
+  test('rejects a malformed required slot even when another required slot is valid', () => {
+    const result = expandCreativeAssetDirectivesWithDiagnostics(
+      {
+        assets: {
+          [BUILD_ASSETS_FROM_FORMAT_DIRECTIVE]: {
+            width: 300,
+            height: 250,
+            slots: [
+              { asset_group_id: 'image_main', asset_type: 'image', required: true },
+              { asset_group_id: 'headline', required: true },
+            ],
+          },
+        },
+      },
+      {},
+      TEST_KIT
+    );
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.failure.reason, 'malformed_directive');
+    assert.match(result.failure.constraint, /slots\[1\]\.asset_type/);
+  });
+
+  test('treats every legacy assets_required entry as required', () => {
+    const result = expandCreativeAssetDirectivesWithDiagnostics(
+      {
+        assets: {
+          [BUILD_ASSETS_FROM_FORMAT_DIRECTIVE]: {
+            width: 300,
+            height: 250,
+            assets_required: [{ asset_id: 'image_main', asset_type: 'image' }],
+          },
+        },
+      },
+      {},
+      TEST_KIT
+    );
+
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(result.value.assets.image_main.url, 'https://assets.example/300x250.jpg');
+  });
+
+  test('rejects a malformed legacy assets_required entry', () => {
+    const result = expandCreativeAssetDirectivesWithDiagnostics(
+      {
+        assets: {
+          [BUILD_ASSETS_FROM_FORMAT_DIRECTIVE]: {
+            assets_required: [{ asset_id: 'image_main' }],
+          },
+        },
+      },
+      {},
+      TEST_KIT
+    );
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.failure.reason, 'malformed_directive');
+    assert.match(result.failure.constraint, /assets_required\[0\]\.asset_type/);
+  });
+
   test('distinguishes missing format context and malformed directives from fixture gaps', () => {
     const missingFormat = expandCreativeAssetDirectivesWithDiagnostics(
       { assets: { [BUILD_ASSETS_FROM_FORMAT_DIRECTIVE]: { id: 'missing_format' } } },

--- a/test/lib/storyboard-creative-assets.test.js
+++ b/test/lib/storyboard-creative-assets.test.js
@@ -381,6 +381,60 @@ describe('$build_assets_from_format', () => {
     assert.match(result.failure.constraint, /maximum length 5/);
   });
 
+  test('does not execute seller-supplied character patterns', () => {
+    for (const characterPattern of ['^[A-Z ]+$', '(a|a?)+$', '(\\w*\\s*)*$']) {
+      const result = expandCreativeAssetDirectivesWithDiagnostics(
+        {
+          assets: {
+            [BUILD_ASSETS_FROM_FORMAT_DIRECTIVE]: {
+              slots: [
+                {
+                  asset_group_id: 'headline',
+                  asset_type: 'text',
+                  required: true,
+                  requirements: { character_pattern: characterPattern },
+                },
+              ],
+            },
+          },
+        },
+        {},
+        TEST_KIT
+      );
+
+      assert.strictEqual(result.ok, false);
+      assert.strictEqual(result.failure.reason, 'fixture_unavailable');
+      assert.match(result.failure.constraint, /character_pattern/);
+    }
+  });
+
+  test('requires a complete URL macro without regex backtracking', () => {
+    const format = {
+      slots: [
+        {
+          asset_group_id: 'landing_url',
+          asset_type: 'url',
+          required: true,
+          requirements: { macro_support: true },
+        },
+      ],
+    };
+    const incomplete = expandCreativeAssetDirectivesWithDiagnostics(
+      { assets: { [BUILD_ASSETS_FROM_FORMAT_DIRECTIVE]: format } },
+      {},
+      { assets: { ...TEST_KIT.assets, click_url: `https://example.com/${'${{'.repeat(2_000)}` } }
+    );
+    const complete = expandCreativeAssetDirectivesWithDiagnostics(
+      { assets: { [BUILD_ASSETS_FROM_FORMAT_DIRECTIVE]: format } },
+      {},
+      { assets: { ...TEST_KIT.assets, click_url: 'https://example.com/${campaign_id}' } }
+    );
+
+    assert.strictEqual(incomplete.ok, false);
+    assert.match(incomplete.failure.constraint, /macro support/);
+    assert.strictEqual(complete.ok, true);
+  });
+
   test('reports image requirements the fixture metadata cannot prove', () => {
     const result = expandCreativeAssetDirectivesWithDiagnostics(
       {

--- a/test/lib/storyboard-multi-instance.test.js
+++ b/test/lib/storyboard-multi-instance.test.js
@@ -528,6 +528,71 @@ describe('runStoryboard: multi-instance multi-pass', () => {
     );
   });
 
+  test('preflights an initial creative fixture gap before multi-pass controller seeding', async () => {
+    const shared = new Map();
+    const tools = ['get_adcp_capabilities', 'comply_test_controller', 'sync_creatives'];
+    agentA = await startFakeAgent({ state: shared, label: 'A', tools });
+    agentB = await startFakeAgent({ state: shared, label: 'B', tools });
+    const storyboard = {
+      id: 'multi_pass_creative_fixture_gap',
+      version: '1.0.0',
+      title: 'Multi-pass creative fixture gap',
+      category: 'testing',
+      summary: '',
+      narrative: '',
+      agent: { interaction_model: '*', capabilities: [] },
+      caller: { role: 'buyer_agent' },
+      prerequisites: { description: 'needs seeds', controller_seeding: true },
+      fixtures: { products: [{ product_id: 'p-1' }] },
+      context: {
+        format_params: {
+          slots: [{ asset_group_id: 'video_main', asset_type: 'video', required: true }],
+        },
+      },
+      phases: [
+        {
+          id: 'creative',
+          title: 'Creative',
+          steps: [
+            {
+              id: 'sync',
+              title: 'Sync',
+              task: 'sync_creatives',
+              sample_request: {
+                creatives: [
+                  {
+                    creative_id: 'creative-1',
+                    assets: { $build_assets_from_format: '$context.format_params' },
+                  },
+                ],
+              },
+              validations: [],
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = await runStoryboard([agentA.url, agentB.url], storyboard, {
+      protocol: 'mcp',
+      allow_http: true,
+      agentTools: tools,
+      _profile: { name: 'fake', tools: tools.map(name => ({ name })) },
+      multi_instance_strategy: 'multi-pass',
+      test_kit: { assets: {} },
+    });
+
+    assert.strictEqual(result.overall_passed, true);
+    assert.strictEqual(result.passes.length, 2);
+    assert.ok(result.passes.every(pass => pass.phases[0].steps[0].skip_reason === 'fixture_unavailable'));
+    const allRequests = [...agentA.requests, ...agentB.requests];
+    assert.deepStrictEqual(
+      allRequests.filter(request => request.tool === 'comply_test_controller' || request.tool === 'sync_creatives'),
+      [],
+      'fixture preflight must run before seeding or creative transport'
+    );
+  });
+
   test('surfaces discovery_failed when pre-seed discovery fails before multi-pass execution', async () => {
     const shared = new Map();
     agentA = await startFakeAgent({ state: shared, label: 'A', failToolsList: true });

--- a/test/lib/storyboard-skip-counting.test.js
+++ b/test/lib/storyboard-skip-counting.test.js
@@ -96,6 +96,39 @@ describe('storyboard skip counting', () => {
       assert.strictEqual(trackResult.status, 'pass', 'track with some passed steps should have pass status');
     });
 
+    test('fixture_unavailable keeps a mixed track coverage-incomplete', () => {
+      const result = storyboardResult({
+        passed_count: 1,
+        failed_count: 0,
+        skipped_count: 1,
+        phases: [
+          {
+            phase_id: 'flow',
+            phase_title: 'Flow',
+            passed: true,
+            steps: [
+              stepResult({ duration_ms: 50 }),
+              stepResult({
+                step_id: 'creative',
+                skipped: true,
+                skip_reason: 'fixture_unavailable',
+                skip: {
+                  reason: 'fixture_unavailable',
+                  detail:
+                    'creative_asset_fixture_unavailable: slot "video", asset type "video", constraint: fixture missing',
+                },
+                duration_ms: 0,
+              }),
+            ],
+            duration_ms: 50,
+          },
+        ],
+      });
+
+      const trackResult = mapStoryboardResultsToTrackResult('creative', [result], dummyProfile);
+      assert.strictEqual(trackResult.status, 'partial');
+    });
+
     test('track with no storyboards reports skip status', () => {
       const trackResult = mapStoryboardResultsToTrackResult('signals', [], dummyProfile);
       assert.strictEqual(trackResult.status, 'skip');

--- a/test/lib/storyboard-skip-counting.test.js
+++ b/test/lib/storyboard-skip-counting.test.js
@@ -129,6 +129,66 @@ describe('storyboard skip counting', () => {
       assert.strictEqual(trackResult.status, 'partial');
     });
 
+    test('fixture_unavailable in a later multi-pass result keeps the track coverage-incomplete', () => {
+      const passingPhase = {
+        phase_id: 'flow',
+        phase_title: 'Flow',
+        passed: true,
+        steps: [stepResult({ duration_ms: 50 })],
+        duration_ms: 50,
+      };
+      const fixturePhase = {
+        phase_id: 'flow',
+        phase_title: 'Flow',
+        passed: true,
+        steps: [
+          stepResult({
+            step_id: 'creative',
+            skipped: true,
+            skip_reason: 'fixture_unavailable',
+            skip: {
+              reason: 'fixture_unavailable',
+              detail:
+                'creative_asset_fixture_unavailable: slot "video", asset type "video", constraint: fixture missing',
+            },
+            duration_ms: 0,
+          }),
+        ],
+        duration_ms: 0,
+      };
+      const result = storyboardResult({
+        passed_count: 1,
+        failed_count: 0,
+        skipped_count: 1,
+        phases: [passingPhase],
+        passes: [
+          {
+            pass_index: 1,
+            dispatch_offset: 0,
+            overall_passed: true,
+            phases: [passingPhase],
+            passed_count: 1,
+            failed_count: 0,
+            skipped_count: 0,
+            duration_ms: 50,
+          },
+          {
+            pass_index: 2,
+            dispatch_offset: 1,
+            overall_passed: true,
+            phases: [fixturePhase],
+            passed_count: 0,
+            failed_count: 0,
+            skipped_count: 1,
+            duration_ms: 0,
+          },
+        ],
+      });
+
+      const trackResult = mapStoryboardResultsToTrackResult('creative', [result], dummyProfile);
+      assert.strictEqual(trackResult.status, 'partial');
+    });
+
     test('track with no storyboards reports skip status', () => {
       const trackResult = mapStoryboardResultsToTrackResult('signals', [], dummyProfile);
       assert.strictEqual(trackResult.status, 'skip');


### PR DESCRIPTION
## Summary

- use canonical `fixture_unavailable` for runner-owned creative fixture gaps
- preflight future creative directives as soon as their format is captured, before intervening mutations or multi-pass seeding
- use exact text-slot mappings and validate declared text, image, and URL constraints
- keep ineligible phases and steps on their normal skip paths
- keep fixture-gapped compliance tracks coverage-incomplete instead of passing

## Why

Follow-up to #2475 and #2465 after the protocol contract landed in adcontextprotocol/adcp#6276 and #6278. The original client change used a detailed reason that canonicalized to `not_applicable`, inferred text semantics by substring, and waited until the consumer step to detect a gap. That could leave side effects behind and could report incomplete coverage as passing.

## Validation

- `npm run typecheck`
- `npm run lint -- --quiet`
- `npm run build`
- `node --test test/lib/storyboard-creative-assets.test.js test/lib/storyboard-skip-counting.test.js test/lib/storyboard-multi-instance.test.js` (49 passing)
- protocol and code expert review
