### PR TITLE
fix(testing): correct runner sessions and capability notices

### DIFF
--- a/.changeset/fix-runner-session-capability-notices.md
+++ b/.changeset/fix-runner-session-capability-notices.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Fix storyboard account selection for default implicit-account capabilities and agency-operated brands; reuse and gracefully close caller-owned MCP workflow sessions while treating session 404s as terminal and never implicitly replaying ambiguous tool-call failures; and surface schema-invalid `get_adcp_capabilities` responses as structured preflight notices.

--- a/src/lib/protocols/index.ts
+++ b/src/lib/protocols/index.ts
@@ -9,6 +9,7 @@ export {
 } from './mcp';
 
 import { closeMCPConnections } from './mcp';
+import { closeCurrentMCPConnectionScope, withMCPConnectionScope } from './mcp-scope';
 import { closeA2AConnections } from './a2a';
 
 /**
@@ -22,6 +23,17 @@ export async function closeConnections(protocol: 'mcp' | 'a2a' = 'mcp'): Promise
     closeA2AConnections();
   }
 }
+
+/** Close only the current runner's MCP scope; fall back to legacy global cleanup. */
+export async function closeScopedConnections(protocol: 'mcp' | 'a2a' = 'mcp'): Promise<void> {
+  if (protocol === 'mcp') {
+    if (!(await closeCurrentMCPConnectionScope())) await closeMCPConnections();
+  } else {
+    closeA2AConnections();
+  }
+}
+
+export { withMCPConnectionScope };
 export type { MCPCallOptions, MCPConnectionResult } from './mcp';
 export { callA2ATool } from './a2a';
 export { DEFAULT_REQUEST_TIMEOUT_MS } from './abort';

--- a/src/lib/protocols/mcp-modern.ts
+++ b/src/lib/protocols/mcp-modern.ts
@@ -21,6 +21,13 @@ import { createHmac } from 'node:crypto';
 import { createMCPAuthHeaders } from '../auth';
 import { is401Error } from '../errors';
 import { withSpan, injectTraceHeaders } from '../observability/tracing';
+import {
+  currentMCPConnectionScopeKey,
+  isMCPConnectionScopeCacheKeyActive,
+  registerMCPConnectionScopeCleanup,
+  registerMCPConnectionScopePending,
+} from './mcp-scope';
+import { terminateSessionBestEffort } from './session-termination';
 import { buildAgentSigningFetch, signingContextStorage, type AgentSigningContext } from '../signing/client';
 import type { DebugLogEntry } from '../types/adcp';
 import {
@@ -68,6 +75,7 @@ interface ModernConnectionOptions {
 const modernConnections = new Map<string, Client>();
 const legacyConnectionExpiresAt = new Map<string, number>();
 const pendingModernConnections = new Map<string, Promise<Client>>();
+const modernTransports = new WeakMap<Client, StreamableHTTPClientTransport>();
 const knownLegacyConnections = new Map<string, number>();
 const modernDiscoveries = new Map<string, { discover: DiscoverResult; expiresAt: number }>();
 const clientsUsingCachedDiscovery = new WeakSet<Client>();
@@ -76,9 +84,20 @@ const LEGACY_CLASSIFICATION_TTL_MS = 5 * 60 * 1000;
 const MODERN_DISCOVERY_TTL_MS = 5 * 60 * 1000;
 const modernOAuthProviderIds = new WeakMap<object, string>();
 const modernFetchFnIds = new WeakMap<typeof fetch, string>();
+const modernSignalIds = new WeakMap<AbortSignal, string>();
 let nextModernOAuthProviderId = 0;
 let nextModernFetchFnId = 0;
+let nextModernSignalId = 0;
 let connectionGeneration = 0;
+
+async function closeModernClient(client: Client, terminateSession = true): Promise<void> {
+  const transport = modernTransports.get(client);
+  modernTransports.delete(client);
+  if (terminateSession && transport?.sessionId) {
+    await terminateSessionBestEffort(transport);
+  }
+  await client.close();
+}
 
 function cacheDisambiguator(value: string): string {
   return createHmac('sha256', '').update(value).digest('hex');
@@ -124,12 +143,25 @@ function fetchFnCacheKey(fetchFn: typeof fetch | undefined): string | undefined 
   return key;
 }
 
+function signalCacheKey(signal: AbortSignal | undefined): string | undefined {
+  if (!signal) return undefined;
+  let key = modernSignalIds.get(signal);
+  if (!key) {
+    key = `signal:${++nextModernSignalId}`;
+    modernSignalIds.set(signal, key);
+  }
+  return key;
+}
+
 function connectionCacheKey(
   agentUrl: string,
   headers: Record<string, string>,
   signingCacheKey?: string,
   authProvider?: object,
-  fetchFn?: typeof fetch
+  fetchFn?: typeof fetch,
+  signal?: AbortSignal,
+  requestTimeoutMs?: number,
+  handleLegacy?: boolean
 ): string {
   const normalizedHeaders = Object.entries(headers)
     .map(([key, value]) => [key.toLowerCase(), value] as const)
@@ -140,6 +172,12 @@ function connectionCacheKey(
   if (providerKey) parts.push(providerKey);
   const fetchKey = fetchFnCacheKey(fetchFn);
   if (fetchKey) parts.push(fetchKey);
+  const signalKey = signalCacheKey(signal);
+  if (signalKey) parts.push(signalKey);
+  if (requestTimeoutMs !== undefined) parts.push(`timeout:${requestTimeoutMs}`);
+  if (handleLegacy !== undefined) parts.push(`handle-legacy:${handleLegacy}`);
+  const scopeKey = currentMCPConnectionScopeKey();
+  if (scopeKey) parts.push(scopeKey);
   return parts.join('::');
 }
 
@@ -224,7 +262,7 @@ function getCachedConnection(cacheKey: string): Client | undefined {
     if (legacyExpiry !== undefined && legacyExpiry <= Date.now()) {
       modernConnections.delete(cacheKey);
       legacyConnectionExpiresAt.delete(cacheKey);
-      void client.close().catch(() => {});
+      void closeModernClient(client).catch(() => {});
       return undefined;
     }
     modernConnections.delete(cacheKey);
@@ -235,12 +273,12 @@ function getCachedConnection(cacheKey: string): Client | undefined {
 
 function evictLeastRecentlyUsed(): void {
   if (modernConnections.size <= MAX_CACHED_CONNECTIONS) return;
-  const oldestKey = modernConnections.keys().next().value;
+  const oldestKey = [...modernConnections.keys()].find(key => !isMCPConnectionScopeCacheKeyActive(key));
   if (!oldestKey) return;
   const client = modernConnections.get(oldestKey);
   modernConnections.delete(oldestKey);
   legacyConnectionExpiresAt.delete(oldestKey);
-  void client?.close().catch(() => {});
+  if (client) void closeModernClient(client).catch(() => {});
 }
 
 /**
@@ -289,9 +327,7 @@ async function createNegotiatedClient(
   const clientRequestTimeoutMs = resolveClientRequestTimeoutMs(options.requestTimeoutMs);
   const rawNetworkFetch: typeof fetch = options.fetchFn ?? ((input, init) => fetch(input, init));
   const networkFetch: typeof fetch = (input, init) =>
-    withAbortSignal<Response>([options.signal, init?.signal], requestTimeoutMs, signal =>
-      rawNetworkFetch(input, { ...init, signal })
-    );
+    withAbortSignal<Response>([init?.signal], requestTimeoutMs, signal => rawNetworkFetch(input, { ...init, signal }));
   const diagnosticFetch = wrapFetchWithTransportDiagnostics(wrapFetchWithSizeLimit(networkFetch));
   const signedFetch: typeof fetch = options.signingContext
     ? (buildAgentSigningFetch({
@@ -328,6 +364,7 @@ async function createNegotiatedClient(
       ...(clientRequestTimeoutMs !== undefined && { timeout: clientRequestTimeoutMs }),
       ...(prior && { prior }),
     });
+    modernTransports.set(client, transport);
     if (prior && !skipProbe) clientsUsingCachedDiscovery.add(client);
     if (!prior) {
       const discover = client.getDiscoverResult();
@@ -340,7 +377,7 @@ async function createNegotiatedClient(
   } catch (error) {
     if (prior && !skipProbe) modernDiscoveries.delete(cacheKey);
     try {
-      await client.close();
+      await closeModernClient(client, false);
     } catch {
       /* ignore close errors */
     }
@@ -396,12 +433,19 @@ async function getOrCreateModernConnection(
 
   const generation = connectionGeneration;
   const promise = createNegotiatedClient(cacheKey, options, authHeaders)
-    .then(client => {
+    .then(async client => {
       if (
         (client.getProtocolEra() === 'modern' || options.handleLegacy === true) &&
         generation === connectionGeneration
       ) {
         modernConnections.set(cacheKey, client);
+        registerMCPConnectionScopeCleanup('modern', cacheKey, async () => {
+          if (modernConnections.get(cacheKey) !== client) return;
+          modernConnections.delete(cacheKey);
+          legacyConnectionExpiresAt.delete(cacheKey);
+          modernDiscoveries.delete(cacheKey);
+          await closeModernClient(client);
+        });
         if (client.getProtocolEra() === 'legacy') {
           legacyConnectionExpiresAt.set(cacheKey, Date.now() + LEGACY_CLASSIFICATION_TTL_MS);
         } else {
@@ -409,7 +453,8 @@ async function getOrCreateModernConnection(
         }
         evictLeastRecentlyUsed();
       } else if (generation !== connectionGeneration) {
-        void client.close().catch(() => {});
+        await closeModernClient(client).catch(() => {});
+        throw new Error('MCP connection completed after connection teardown');
       }
       return client;
     })
@@ -417,6 +462,7 @@ async function getOrCreateModernConnection(
       if (pendingModernConnections.get(cacheKey) === promise) pendingModernConnections.delete(cacheKey);
     });
   pendingModernConnections.set(cacheKey, promise);
+  registerMCPConnectionScopePending(promise);
   return promise;
 }
 
@@ -448,15 +494,20 @@ async function attemptModernCall(
     authHeaders,
     options.signingContext?.cacheKey,
     options.authProvider,
-    options.fetchFn
+    options.fetchFn,
+    options.signal,
+    options.requestTimeoutMs,
+    options.handleLegacy
   );
   if (isKnownLegacy(cacheKey)) return { handled: false };
 
   const guardedConnection =
     options.signal !== undefined || options.requestTimeoutMs !== undefined || options.fetchFn !== undefined;
+  const oneShot = guardedConnection && currentMCPConnectionScopeKey() === undefined;
   let client: Client;
+  let callSucceeded = false;
   try {
-    client = guardedConnection
+    client = oneShot
       ? await createNegotiatedClient(cacheKey, options, authHeaders)
       : await getOrCreateModernConnection(cacheKey, options, authHeaders);
   } catch (error) {
@@ -492,7 +543,7 @@ async function attemptModernCall(
     } else {
       markKnownLegacy(cacheKey);
       try {
-        await client.close();
+        await closeModernClient(client);
       } catch {
         /* ignore close errors */
       }
@@ -513,6 +564,7 @@ async function attemptModernCall(
 
   try {
     const response = await callOnModernClient(client, toolName, args, options.signal, options.requestTimeoutMs);
+    callSucceeded = true;
     return { handled: true, response };
   } catch (error) {
     // A tool request may have reached the server even when its response was
@@ -522,19 +574,13 @@ async function attemptModernCall(
     legacyConnectionExpiresAt.delete(cacheKey);
     modernDiscoveries.delete(cacheKey);
     try {
-      await client.close();
+      await closeModernClient(client, !isAbortOrTimeoutError(error));
     } catch {
       /* ignore close errors */
     }
     throw error;
   } finally {
-    if (guardedConnection) {
-      try {
-        await client.close();
-      } catch {
-        /* ignore close errors */
-      }
-    }
+    if (oneShot && client && callSucceeded) await closeModernClient(client).catch(() => {});
   }
 }
 
@@ -604,7 +650,10 @@ export async function probeModernMCPConnection(
     authHeaders,
     options.signingContext?.cacheKey,
     options.authProvider,
-    options.fetchFn
+    options.fetchFn,
+    options.signal,
+    options.requestTimeoutMs,
+    options.handleLegacy
   );
   let client: Client | undefined;
   try {
@@ -618,7 +667,7 @@ export async function probeModernMCPConnection(
     if (isLegacyEraNegotiationFailure(error, status)) return { connected: false };
     throw error;
   } finally {
-    await client?.close().catch(() => {});
+    if (client) await closeModernClient(client).catch(() => {});
   }
 }
 
@@ -646,7 +695,10 @@ export async function tryListModernMCPTools(
     authHeaders,
     options.signingContext?.cacheKey,
     options.authProvider,
-    options.fetchFn
+    options.fetchFn,
+    options.signal,
+    options.requestTimeoutMs,
+    options.handleLegacy
   );
   let client: Client | undefined;
   const listTools = async (connectedClient: Client): Promise<ModernMCPListAttempt> => {
@@ -665,7 +717,7 @@ export async function tryListModernMCPTools(
     let failure = error;
     modernDiscoveries.delete(cacheKey);
     if (!is401Error(failure) && !isAbortOrTimeoutError(failure) && client && clientsUsingCachedDiscovery.has(client)) {
-      await client.close().catch(() => {});
+      await closeModernClient(client, false).catch(() => {});
       try {
         client = await createNegotiatedClient(cacheKey, connectionOptions, authHeaders, false);
         return await listTools(client);
@@ -680,7 +732,7 @@ export async function tryListModernMCPTools(
     if (isLegacyEraNegotiationFailure(failure, status)) return { handled: false };
     throw failure;
   } finally {
-    await client?.close().catch(() => {});
+    if (client) await closeModernClient(client).catch(() => {});
   }
 }
 
@@ -699,7 +751,7 @@ export async function closeModernMCPConnections(): Promise<void> {
   modernDiscoveries.clear();
   for (const client of clients) {
     try {
-      await client.close();
+      await closeModernClient(client);
     } catch {
       /* ignore close errors */
     }

--- a/src/lib/protocols/mcp-scope.ts
+++ b/src/lib/protocols/mcp-scope.ts
@@ -1,0 +1,87 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+type ScopeCleanup = () => Promise<void>;
+
+interface MCPConnectionScope {
+  id: number;
+  cacheKey: string;
+  pending: Set<Promise<unknown>>;
+  cleanups: Map<string, ScopeCleanup>;
+}
+
+const scopeStorage = new AsyncLocalStorage<MCPConnectionScope>();
+const activeScopeKeys = new Set<string>();
+let nextScopeId = 0;
+
+/** Cache-key suffix for the current caller-owned MCP workflow. */
+export function currentMCPConnectionScopeKey(): string | undefined {
+  return scopeStorage.getStore()?.cacheKey;
+}
+
+/** Whether an LRU entry belongs to a workflow that has not finished yet. */
+export function isMCPConnectionScopeCacheKeyActive(cacheKey: string): boolean {
+  const marker = cacheKey.lastIndexOf('::scope:');
+  return marker >= 0 && activeScopeKeys.has(cacheKey.slice(marker + 2));
+}
+
+/** Register one idempotent cache-entry cleanup with the current workflow. */
+export function registerMCPConnectionScopeCleanup(
+  namespace: 'legacy' | 'oauth' | 'modern',
+  cacheKey: string,
+  cleanup: ScopeCleanup
+): void {
+  scopeStorage.getStore()?.cleanups.set(`${namespace}\u0000${cacheKey}`, cleanup);
+}
+
+/** Track initialization that may outlive the task which started it. */
+export function registerMCPConnectionScopePending(pending: Promise<unknown>): void {
+  const scope = scopeStorage.getStore();
+  if (!scope) return;
+  scope.pending.add(pending);
+  const remove = () => scope.pending.delete(pending);
+  void pending.then(remove, remove);
+}
+
+/** Close only connections owned by the current workflow, if one exists. */
+export async function closeCurrentMCPConnectionScope(): Promise<boolean> {
+  const scope = scopeStorage.getStore();
+  if (!scope) return false;
+
+  // A timed-out parallel branch may still be initializing after the runner's
+  // result path starts to unwind. Wait for those connects to either register
+  // their cleanup or reject before taking the cleanup snapshot.
+  while (scope.pending.size > 0) {
+    await Promise.allSettled([...scope.pending]);
+  }
+
+  // Clear before awaiting so an early close followed by another tool call in
+  // the same workflow can register a fresh connection for the outer finally.
+  const cleanups = [...scope.cleanups.values()];
+  scope.cleanups.clear();
+  await Promise.allSettled(cleanups.map(cleanup => cleanup()));
+  return true;
+}
+
+/**
+ * Isolate connection reuse to one runner/workflow and close it on every exit.
+ * Nested callers join the existing scope so a storyboard still gets exactly
+ * one reusable session rather than one session per helper layer.
+ */
+export async function withMCPConnectionScope<T>(fn: () => Promise<T>, options: { isolate?: boolean } = {}): Promise<T> {
+  if (scopeStorage.getStore() && options.isolate !== true) return fn();
+
+  const id = ++nextScopeId;
+  const scope: MCPConnectionScope = { id, cacheKey: `scope:${id}`, pending: new Set(), cleanups: new Map() };
+  activeScopeKeys.add(scope.cacheKey);
+  return scopeStorage.run(scope, async () => {
+    try {
+      return await fn();
+    } finally {
+      try {
+        await closeCurrentMCPConnectionScope();
+      } finally {
+        activeScopeKeys.delete(scope.cacheKey);
+      }
+    }
+  });
+}

--- a/src/lib/protocols/mcp-tasks.ts
+++ b/src/lib/protocols/mcp-tasks.ts
@@ -14,7 +14,7 @@ import type { DebugLogEntry } from '../types/adcp';
 import type { TaskInfo } from '../core/ConversationTypes';
 import { withCachedConnection } from './mcp';
 import { createMCPAuthHeaders } from '../auth';
-import { withSpan, injectTraceHeaders } from '../observability/tracing';
+import { withSpan } from '../observability/tracing';
 import { signingContextStorage, type AgentSigningContext } from '../signing/client';
 import { redactArgsForLog as sharedRedactArgsForLog } from '../utils/redact-args';
 import { withResponseSizeLimit } from './responseSizeLimit';
@@ -130,10 +130,8 @@ function mapMCPTaskToTaskInfo(
  * Build auth headers for MCP connections.
  */
 function buildAuthHeaders(authToken?: string, customHeaders?: Record<string, string>): Record<string, string> {
-  const traceHeaders = injectTraceHeaders();
   return {
     ...customHeaders,
-    ...traceHeaders,
     ...(authToken ? createMCPAuthHeaders(authToken) : {}),
   };
 }

--- a/src/lib/protocols/mcp.ts
+++ b/src/lib/protocols/mcp.ts
@@ -25,6 +25,13 @@ import {
   withAbortSignal,
 } from './abort';
 import { closeModernMCPConnections, tryCallModernMCPTool } from './mcp-modern';
+import {
+  currentMCPConnectionScopeKey,
+  isMCPConnectionScopeCacheKeyActive,
+  registerMCPConnectionScopeCleanup,
+  registerMCPConnectionScopePending,
+} from './mcp-scope';
+import { terminateSessionBestEffort } from './session-termination';
 
 // Re-export for convenience
 export { UnauthorizedError };
@@ -37,17 +44,17 @@ type CallToolResponse = {
 };
 
 /**
- * Module-level connection cache keyed by agent URL + auth token hash.
+ * Module-level connection cache keyed by endpoint, credentials, transport
+ * policy, cancellation scope, and timeout configuration.
  * Reuses MCP connections across tool calls to avoid TCP connection exhaustion
  * during comply/test runs that make dozens of sequential calls.
  *
  * Uses LRU eviction: cache hits delete-and-re-insert the entry so that
  * Map iteration order reflects most-recent access.
  *
- * The cache key includes only URL + auth token hash. Custom headers and trace
- * headers are set at connection-creation time and fixed for the connection's
- * lifetime — callers with different custom headers will share a connection
- * created with the first caller's headers.
+ * Caller-defined trace headers are refreshed per request and excluded from the
+ * key. Other headers, scoped fetchers, and AbortSignals remain isolated by
+ * value or identity.
  *
  * Note: This is a process-global singleton. Not suitable for multi-tenant
  * server use where different tenants share a process.
@@ -56,11 +63,25 @@ const connectionCache = new Map<string, MCPClient>();
 const pendingConnections = new Map<string, Promise<MCPClient>>();
 const oauthConnectionCache = new Map<string, MCPClient>();
 const pendingOAuthConnections = new Map<string, Promise<MCPClient>>();
+const streamableTransports = new WeakMap<MCPClient, StreamableHTTPClientTransport>();
 const oauthProviderIds = new WeakMap<OAuthClientProvider, string>();
-const oauthFetchFnIds = new WeakMap<typeof fetch, string>();
+const transportFetchFnIds = new WeakMap<typeof fetch, string>();
+const transportSignalIds = new WeakMap<AbortSignal, string>();
 const MAX_CACHED_CONNECTIONS = 20;
 let nextOAuthProviderId = 0;
-let nextOAuthFetchFnId = 0;
+let nextTransportFetchFnId = 0;
+let nextTransportSignalId = 0;
+let connectionGeneration = 0;
+let oauthConnectionGeneration = 0;
+
+async function closeMCPClient(client: MCPClient, terminateSession = true): Promise<void> {
+  const transport = streamableTransports.get(client);
+  streamableTransports.delete(client);
+  if (terminateSession && transport?.sessionId) {
+    await terminateSessionBestEffort(transport);
+  }
+  await client.close();
+}
 
 /**
  * Track URLs where StreamableHTTP has previously connected successfully.
@@ -107,7 +128,10 @@ function connectionCacheKey(
   agentUrl: string,
   authToken?: string,
   signingCacheKey?: string,
-  authHeaders?: Record<string, string>
+  authHeaders?: Record<string, string>,
+  transportFetch?: typeof fetch,
+  signal?: AbortSignal,
+  requestTimeoutMs?: number
 ): string {
   const parts = [agentUrl];
   const fingerprint = authToken ?? extractAuthHeader(authHeaders);
@@ -115,6 +139,11 @@ function connectionCacheKey(
   const headersKey = headersCacheDisambiguator(authHeaders);
   if (headersKey) parts.push(`headers:${headersKey}`);
   if (signingCacheKey) parts.push(signingCacheKey);
+  if (transportFetch) parts.push(`fetch:${getTransportFetchFnDisambiguator(transportFetch)}`);
+  if (signal) parts.push(`signal:${getTransportSignalDisambiguator(signal)}`);
+  if (requestTimeoutMs !== undefined) parts.push(`timeout:${requestTimeoutMs}`);
+  const scopeKey = currentMCPConnectionScopeKey();
+  if (scopeKey) parts.push(scopeKey);
   return parts.join('::');
 }
 
@@ -165,6 +194,15 @@ function headersCacheDisambiguator(headers?: Record<string, string>): string | u
   return entries.length > 0 ? cacheDisambiguator(JSON.stringify(entries)) : undefined;
 }
 
+function withPerRequestTraceHeaders(fetchImpl: typeof fetch): typeof fetch {
+  return (input, init) => {
+    const headers = new Headers(input instanceof Request ? input.headers : undefined);
+    new Headers(init?.headers).forEach((value, key) => headers.set(key, value));
+    for (const [key, value] of Object.entries(injectTraceHeaders())) headers.set(key, value);
+    return fetchImpl(input, { ...init, headers });
+  };
+}
+
 /** Get a cached connection, refreshing its LRU position. */
 function getCachedConnection(key: string): MCPClient | undefined {
   const client = connectionCache.get(key);
@@ -178,22 +216,23 @@ function getCachedConnection(key: string): MCPClient | undefined {
 
 function evictLeastRecentlyUsed(): void {
   if (connectionCache.size <= MAX_CACHED_CONNECTIONS) return;
-  // Map iteration order is insertion-order; first key = least-recently-used
-  const lruKey = connectionCache.keys().next().value;
+  // Never terminate a session owned by an in-progress workflow. Temporary
+  // overflow is reclaimed by that workflow's scoped finally.
+  const lruKey = [...connectionCache.keys()].find(key => !isMCPConnectionScopeCacheKeyActive(key));
   if (!lruKey) return;
   const oldClient = connectionCache.get(lruKey);
   connectionCache.delete(lruKey);
   // Fire-and-forget: eviction is on the hot path; close is best-effort
-  oldClient?.close().catch(() => {});
+  if (oldClient) void closeMCPClient(oldClient).catch(() => {});
 }
 
 function evictLeastRecentlyUsedOAuth(): void {
   if (oauthConnectionCache.size <= MAX_CACHED_CONNECTIONS) return;
-  const lruKey = oauthConnectionCache.keys().next().value;
+  const lruKey = [...oauthConnectionCache.keys()].find(key => !isMCPConnectionScopeCacheKeyActive(key));
   if (!lruKey) return;
   const oldClient = oauthConnectionCache.get(lruKey);
   oauthConnectionCache.delete(lruKey);
-  oldClient?.close().catch(() => {});
+  if (oldClient) void closeMCPClient(oldClient).catch(() => {});
 }
 
 /**
@@ -202,11 +241,18 @@ function evictLeastRecentlyUsedOAuth(): void {
  * used authorization-code OAuth sessions.
  */
 export async function closeOAuthConnections(): Promise<void> {
-  const entries = [...oauthConnectionCache.entries()];
+  oauthConnectionGeneration++;
+  const pending = [...pendingOAuthConnections.values()];
+  pendingOAuthConnections.clear();
+  const settled = await Promise.allSettled(pending);
+  const clients = new Set(oauthConnectionCache.values());
+  for (const result of settled) {
+    if (result.status === 'fulfilled') clients.add(result.value);
+  }
   oauthConnectionCache.clear();
-  for (const [, client] of entries) {
+  for (const client of clients) {
     try {
-      await client.close();
+      await closeMCPClient(client);
     } catch {
       /* ignore close errors */
     }
@@ -218,12 +264,19 @@ export async function closeOAuthConnections(): Promise<void> {
  * Call this at the end of comply/test runs or before process exit.
  */
 export async function closeMCPConnections(): Promise<void> {
-  const entries = [...connectionCache.entries()];
+  connectionGeneration++;
+  const pending = [...pendingConnections.values()];
+  pendingConnections.clear();
+  const settled = await Promise.allSettled(pending);
+  const clients = new Set(connectionCache.values());
+  for (const result of settled) {
+    if (result.status === 'fulfilled') clients.add(result.value);
+  }
   connectionCache.clear();
   knownStreamableHTTPUrls.clear();
-  for (const [, client] of entries) {
+  for (const client of clients) {
     try {
-      await client.close();
+      await closeMCPClient(client);
     } catch {
       /* ignore close errors */
     }
@@ -243,6 +296,7 @@ async function getOrCreateConnection(
   authHeaders: Record<string, string>,
   debugLogs: DebugLogEntry[],
   label: string,
+  transportFetch?: typeof fetch,
   requestOptions: { signal?: AbortSignal; requestTimeoutMs?: number } = {}
 ): Promise<MCPClient> {
   const cached = getCachedConnection(cacheKey);
@@ -251,17 +305,28 @@ async function getOrCreateConnection(
   const pending = pendingConnections.get(cacheKey);
   if (pending) return pending;
 
-  const promise = connectMCPWithFallback(baseUrl, authHeaders, debugLogs, label, undefined, requestOptions)
-    .then(client => {
+  const generation = connectionGeneration;
+  const promise = connectMCPWithFallback(baseUrl, authHeaders, debugLogs, label, transportFetch, requestOptions)
+    .then(async client => {
+      if (generation !== connectionGeneration) {
+        await closeMCPClient(client).catch(() => {});
+        throw new Error(`MCP ${label} completed after connection teardown`);
+      }
       connectionCache.set(cacheKey, client);
+      registerMCPConnectionScopeCleanup('legacy', cacheKey, async () => {
+        if (connectionCache.get(cacheKey) !== client) return;
+        connectionCache.delete(cacheKey);
+        await closeMCPClient(client);
+      });
       evictLeastRecentlyUsed();
       return client;
     })
     .finally(() => {
-      pendingConnections.delete(cacheKey);
+      if (pendingConnections.get(cacheKey) === promise) pendingConnections.delete(cacheKey);
     });
 
   pendingConnections.set(cacheKey, promise);
+  registerMCPConnectionScopePending(promise);
   return promise;
 }
 
@@ -274,11 +339,20 @@ function getOAuthProviderDisambiguator(authProvider: OAuthClientProvider): strin
   return id;
 }
 
-function getOAuthFetchFnDisambiguator(fetchFn: typeof fetch): string {
-  let id = oauthFetchFnIds.get(fetchFn);
+function getTransportFetchFnDisambiguator(fetchFn: typeof fetch): string {
+  let id = transportFetchFnIds.get(fetchFn);
   if (!id) {
-    id = cacheDisambiguator(`oauth-fetch:${++nextOAuthFetchFnId}`);
-    oauthFetchFnIds.set(fetchFn, id);
+    id = cacheDisambiguator(`transport-fetch:${++nextTransportFetchFnId}`);
+    transportFetchFnIds.set(fetchFn, id);
+  }
+  return id;
+}
+
+function getTransportSignalDisambiguator(signal: AbortSignal): string {
+  let id = transportSignalIds.get(signal);
+  if (!id) {
+    id = cacheDisambiguator(`transport-signal:${++nextTransportSignalId}`);
+    transportSignalIds.set(signal, id);
   }
   return id;
 }
@@ -292,13 +366,19 @@ function oauthConnectionCacheKey(
   authProvider: OAuthClientProvider,
   signingCacheKey?: string,
   customHeaders?: Record<string, string>,
-  fetchFn?: typeof fetch
+  fetchFn?: typeof fetch,
+  signal?: AbortSignal,
+  requestTimeoutMs?: number
 ): string {
   const parts = [`${agentUrl}::oauth:${getOAuthProviderDisambiguator(authProvider)}`];
   if (signingCacheKey) parts.push(signingCacheKey);
   const headersKey = customHeadersDisambiguator(customHeaders);
   if (headersKey) parts.push(`headers:${headersKey}`);
-  if (fetchFn) parts.push(`fetch:${getOAuthFetchFnDisambiguator(fetchFn)}`);
+  if (fetchFn) parts.push(`fetch:${getTransportFetchFnDisambiguator(fetchFn)}`);
+  if (signal) parts.push(`signal:${getTransportSignalDisambiguator(signal)}`);
+  if (requestTimeoutMs !== undefined) parts.push(`timeout:${requestTimeoutMs}`);
+  const scopeKey = currentMCPConnectionScopeKey();
+  if (scopeKey) parts.push(scopeKey);
   return parts.join('::');
 }
 
@@ -331,17 +411,28 @@ async function getOrCreateOAuthConnection(
   const pending = pendingOAuthConnections.get(cacheKey);
   if (pending) return pending;
 
+  const generation = oauthConnectionGeneration;
   const promise = connectMCP(options)
-    .then(({ client }) => {
+    .then(async ({ client }) => {
+      if (generation !== oauthConnectionGeneration) {
+        await closeMCPClient(client).catch(() => {});
+        throw new Error('OAuth MCP connection completed after connection teardown');
+      }
       oauthConnectionCache.set(cacheKey, client);
+      registerMCPConnectionScopeCleanup('oauth', cacheKey, async () => {
+        if (oauthConnectionCache.get(cacheKey) !== client) return;
+        oauthConnectionCache.delete(cacheKey);
+        await closeMCPClient(client);
+      });
       evictLeastRecentlyUsedOAuth();
       return client;
     })
     .finally(() => {
-      pendingOAuthConnections.delete(cacheKey);
+      if (pendingOAuthConnections.get(cacheKey) === promise) pendingOAuthConnections.delete(cacheKey);
     });
 
   pendingOAuthConnections.set(cacheKey, promise);
+  registerMCPConnectionScopePending(promise);
   return promise;
 }
 
@@ -359,25 +450,29 @@ async function withCachedOAuthConnection<T>(
   label: string,
   fn: (client: MCPClient) => Promise<T>
 ): Promise<T> {
+  const guardedConnection =
+    options.signal !== undefined || options.requestTimeoutMs !== undefined || options.fetchFn !== undefined;
+  if (guardedConnection && currentMCPConnectionScopeKey() === undefined) {
+    const { client } = await connectMCP(options);
+    let succeeded = false;
+    try {
+      const result = await fn(client);
+      succeeded = true;
+      return result;
+    } finally {
+      await closeMCPClient(client, succeeded).catch(() => {});
+    }
+  }
+
   const cacheKey = oauthConnectionCacheKey(
     options.agentUrl,
     options.authProvider,
     options.signingContext?.cacheKey,
     options.customHeaders,
-    options.fetchFn
+    options.fetchFn,
+    options.signal,
+    options.requestTimeoutMs
   );
-  if (options.signal || options.requestTimeoutMs !== undefined || options.fetchFn) {
-    const { client } = await connectMCP(options);
-    try {
-      return await fn(client);
-    } finally {
-      try {
-        await client.close();
-      } catch {
-        /* ignore */
-      }
-    }
-  }
 
   const mcpClient = await getOrCreateOAuthConnection(cacheKey, options);
 
@@ -395,7 +490,7 @@ async function withCachedOAuthConnection<T>(
     if (is401Error(error)) {
       oauthConnectionCache.delete(cacheKey);
       try {
-        await mcpClient.close();
+        await closeMCPClient(mcpClient, false);
       } catch {
         /* ignore */
       }
@@ -408,36 +503,47 @@ async function withCachedOAuthConnection<T>(
     }
 
     if (isAbortOrTimeoutError(error)) {
+      oauthConnectionCache.delete(cacheKey);
+      try {
+        // Abort the transport immediately. A graceful DELETE here can hang
+        // behind the same failed server and defeat the caller's deadline.
+        await closeMCPClient(mcpClient, false);
+      } catch {
+        /* ignore */
+      }
+      throw error;
+    }
+
+    // A 404 after a successful initialize means this known session no longer
+    // exists. Reconnecting/replaying the call can create a request storm and
+    // is unsafe for mutations, so evict and surface it as terminal.
+    if (httpStatusOf(error) === 404) {
+      oauthConnectionCache.delete(cacheKey);
+      try {
+        await closeMCPClient(mcpClient, false);
+      } catch {
+        /* ignore */
+      }
       throw error;
     }
 
     oauthConnectionCache.delete(cacheKey);
     try {
-      await mcpClient.close();
+      await closeMCPClient(mcpClient, false);
     } catch {
       /* ignore */
     }
 
-    const retryClient = await getOrCreateOAuthConnection(cacheKey, {
-      ...options,
-      debugLogs: options.debugLogs,
-    });
-
-    try {
-      return await fn(retryClient);
-    } catch (retryError) {
-      if (retryError instanceof Error && error instanceof Error) {
-        retryError.cause = error;
-      }
-      throw retryError;
-    }
+    // The request may have reached the seller even when its response was lost.
+    // Never replay a tool call implicitly; callers own idempotent retry policy.
+    throw error;
   }
 }
 
 /**
  * Get or create a cached MCP connection, then call `fn` with it.
- * On transport errors, evicts the stale connection and retries once.
- * Auth errors (401) evict and close the connection, then throw immediately.
+ * Call failures evict the stale connection and surface without replaying: the
+ * request may already have committed before its response was lost.
  *
  * @internal Used by mcp-tasks.ts for protocol-level task operations.
  * Not part of the public API — do not import from outside the protocols directory.
@@ -455,28 +561,40 @@ export async function withCachedConnection<T>(
   const signingContext = signingContextStorage.getStore();
   const baseUrl = new URL(agentUrl);
 
-  if (transportFetch || requestOptions.signal || requestOptions.requestTimeoutMs !== undefined) {
-    const guardedClient = await connectMCPWithFallback(
-      baseUrl,
-      authHeaders,
-      debugLogs,
-      label,
-      transportFetch,
-      requestOptions
-    );
+  const guardedConnection =
+    transportFetch !== undefined ||
+    requestOptions.signal !== undefined ||
+    requestOptions.requestTimeoutMs !== undefined;
+  if (guardedConnection && currentMCPConnectionScopeKey() === undefined) {
+    const client = await connectMCPWithFallback(baseUrl, authHeaders, debugLogs, label, transportFetch, requestOptions);
+    let succeeded = false;
     try {
-      return await withAbortSignal([requestOptions.signal], undefined, () => fn(guardedClient));
+      const result = await withAbortSignal([requestOptions.signal], undefined, () => fn(client));
+      succeeded = true;
+      return result;
     } finally {
-      try {
-        await guardedClient.close();
-      } catch {
-        /* ignore */
-      }
+      await closeMCPClient(client, succeeded).catch(() => {});
     }
   }
 
-  const cacheKey = connectionCacheKey(agentUrl, authToken, signingContext?.cacheKey, authHeaders);
-  const mcpClient = await getOrCreateConnection(cacheKey, baseUrl, authHeaders, debugLogs, label, requestOptions);
+  const cacheKey = connectionCacheKey(
+    agentUrl,
+    authToken,
+    signingContext?.cacheKey,
+    authHeaders,
+    transportFetch,
+    requestOptions.signal,
+    requestOptions.requestTimeoutMs
+  );
+  const mcpClient = await getOrCreateConnection(
+    cacheKey,
+    baseUrl,
+    authHeaders,
+    debugLogs,
+    label,
+    transportFetch,
+    requestOptions
+  );
 
   try {
     return await fn(mcpClient);
@@ -493,7 +611,7 @@ export async function withCachedConnection<T>(
     if (is401Error(error)) {
       connectionCache.delete(cacheKey);
       try {
-        await mcpClient.close();
+        await closeMCPClient(mcpClient, false);
       } catch {
         /* ignore */
       }
@@ -506,36 +624,52 @@ export async function withCachedConnection<T>(
     }
 
     if (isAbortOrTimeoutError(error)) {
+      connectionCache.delete(cacheKey);
+      try {
+        // client.close() aborts the v1 transport's in-flight POST. Do not wait
+        // for a best-effort DELETE on the caller's abort/timeout path.
+        await closeMCPClient(mcpClient, false);
+      } catch {
+        /* ignore */
+      }
       throw error;
     }
 
-    // Evict stale connection and retry once with a fresh connection
+    if (httpStatusOf(error) === 404) {
+      connectionCache.delete(cacheKey);
+      try {
+        await closeMCPClient(mcpClient, false);
+      } catch {
+        /* ignore */
+      }
+      debugLogs.push({
+        type: 'warning',
+        message: `MCP: Session not found for ${label}; evicted cached connection without retry`,
+        timestamp: new Date().toISOString(),
+      });
+      throw error;
+    }
+
+    // A tool request may have reached the seller even when its response was
+    // lost. Evict the unusable session, but never replay the call implicitly.
     connectionCache.delete(cacheKey);
     try {
-      await mcpClient.close();
+      await closeMCPClient(mcpClient, false);
     } catch {
       /* ignore */
     }
 
-    const retryClient = await getOrCreateConnection(
-      cacheKey,
-      baseUrl,
-      authHeaders,
-      debugLogs,
-      `${label} (retry)`,
-      requestOptions
-    );
-
-    try {
-      return await fn(retryClient);
-    } catch (retryError) {
-      // Attach original error for diagnostics
-      if (retryError instanceof Error && error instanceof Error) {
-        retryError.cause = error;
-      }
-      throw retryError;
-    }
+    throw error;
   }
+}
+
+function httpStatusOf(error: unknown, depth = 0): number | undefined {
+  if (!error || typeof error !== 'object' || depth > 4) return undefined;
+  const candidate = error as { status?: unknown; code?: unknown; cause?: unknown; response?: { status?: unknown } };
+  if (typeof candidate.status === 'number') return candidate.status;
+  if (typeof candidate.response?.status === 'number') return candidate.response.status;
+  if (typeof candidate.code === 'number' && candidate.code >= 100 && candidate.code <= 599) return candidate.code;
+  return httpStatusOf(candidate.cause, depth + 1);
 }
 
 /**
@@ -564,8 +698,9 @@ export interface MCPCallOptions {
   requestTimeoutMs?: number;
   /**
    * Scoped fetch implementation used for MCP requests, OAuth discovery, and token exchange.
-   * Calls with a scoped fetcher use an isolated one-shot connection rather than the shared
-   * OAuth connection cache, so callers must not rely on cross-call MCP session state.
+   * Direct SDK calls retain isolated one-shot connections. Runner workflows opt into
+   * scoped reuse, where the exact fetch function, cancellation signal, timeout,
+   * credential, and headers all participate in connection identity.
    */
   fetchFn?: typeof fetch;
 }
@@ -635,9 +770,7 @@ async function connectMCPWithFallbackImpl(
     // Keep cancellation linked for the entire response-body lifetime. A
     // Promise race around fetch only covers receipt of response headers; MCP
     // Streamable HTTP can then hold the body open while a tool runs.
-    const signals = [requestOptions.signal, init?.signal ?? undefined].filter(
-      (signal): signal is AbortSignal => signal !== undefined
-    );
+    const signals = [init?.signal ?? undefined].filter((signal): signal is AbortSignal => signal !== undefined);
     const signal = signals.length === 0 ? undefined : signals.length === 1 ? signals[0] : AbortSignal.any(signals);
     return rawNetworkFetch(input, { ...init, signal });
   };
@@ -652,7 +785,7 @@ async function connectMCPWithFallbackImpl(
     : diagnosticFetch;
   const transportOptions: StreamableHTTPClientTransportOptions = {
     requestInit: { headers: authHeaders, redirect: 'manual' },
-    fetch: wrapFetchWithCapture(baseFetch),
+    fetch: wrapFetchWithCapture(withPerRequestTraceHeaders(baseFetch)),
   };
   let failedClient: MCPClient | undefined;
 
@@ -664,7 +797,9 @@ async function connectMCPWithFallbackImpl(
       message: `MCP: Attempting StreamableHTTP ${label} to ${url}`,
       timestamp: new Date().toISOString(),
     });
-    await client.connect(new StreamableHTTPClientTransport(url, transportOptions), mcpRequestOptions);
+    const transport = new StreamableHTTPClientTransport(url, transportOptions);
+    await client.connect(transport, mcpRequestOptions);
+    streamableTransports.set(client, transport);
     failedClient = undefined;
     trackStreamableHTTPUrl(url.toString());
     debugLogs.push({
@@ -709,7 +844,9 @@ async function connectMCPWithFallbackImpl(
       });
       const retryClient = new MCPClient({ name: 'AdCP-Client', version: '1.0.0' });
       try {
-        await retryClient.connect(new StreamableHTTPClientTransport(url, transportOptions), mcpRequestOptions);
+        const retryTransport = new StreamableHTTPClientTransport(url, transportOptions);
+        await retryClient.connect(retryTransport, mcpRequestOptions);
+        streamableTransports.set(retryClient, retryTransport);
         trackStreamableHTTPUrl(url.toString());
         debugLogs.push({
           type: 'success',
@@ -764,7 +901,7 @@ async function connectMCPWithFallbackImpl(
       await client.connect(
         new SSEClientTransport(url, {
           requestInit: { headers: authHeaders, redirect: 'manual' },
-          fetch: wrapFetchWithCapture(baseFetch),
+          fetch: wrapFetchWithCapture(withPerRequestTraceHeaders(baseFetch)),
         }),
         mcpRequestOptions
       );
@@ -882,13 +1019,9 @@ async function callMCPToolImpl(
   transportFetch?: typeof fetch,
   requestOptions?: { signal?: AbortSignal; requestTimeoutMs?: number }
 ): Promise<unknown> {
-  // Inject trace context headers for distributed tracing
-  const traceHeaders = injectTraceHeaders();
-
-  // Merge: custom < trace < auth (auth always wins)
+  // Trace context is injected dynamically by the cached transport fetch.
   const authHeaders = {
     ...customHeaders,
-    ...traceHeaders,
     ...(authToken ? createMCPAuthHeaders(authToken) : {}),
   };
 
@@ -930,10 +1063,8 @@ async function callMCPToolRawImpl(
   customHeaders?: Record<string, string>,
   transportFetch?: typeof fetch
 ): Promise<unknown> {
-  const traceHeaders = injectTraceHeaders();
   const authHeaders = {
     ...customHeaders,
-    ...traceHeaders,
     ...(authToken ? createMCPAuthHeaders(authToken) : {}),
   };
 
@@ -1080,7 +1211,7 @@ export async function connectMCP(options: {
   };
   const rawNetworkFetch: typeof fetch = fetchFn ?? ((input, init) => fetch(input, init));
   const sizeLimited = wrapFetchWithSizeLimit((input, init) =>
-    withAbortSignal<Response>([signal, init?.signal], requestTimeoutMs, linkedSignal =>
+    withAbortSignal<Response>([init?.signal], requestTimeoutMs, linkedSignal =>
       rawNetworkFetch(input, { ...init, signal: linkedSignal })
     )
   );
@@ -1092,12 +1223,13 @@ export async function connectMCP(options: {
         getCapability: signingContext.getCapability,
       }) as typeof fetch)
     : diagnosticFetch;
-  transportOptions.fetch = wrapFetchWithCapture(signedFetch);
+  transportOptions.fetch = wrapFetchWithCapture(withPerRequestTraceHeaders(signedFetch));
 
   const transport = new StreamableHTTPClientTransport(baseUrl, transportOptions);
 
   try {
     await mcpClient.connect(transport, requestOptions);
+    streamableTransports.set(mcpClient, transport);
     debugLogs.push({
       type: 'success',
       message: 'MCP: Connected successfully',
@@ -1165,9 +1297,9 @@ export async function connectMCP(options: {
  * session/source/principal; the provider owns token refresh state for the
  * cached transport.
  *
- * Supplying `fetchFn` opts out of connection reuse. Scoped fetchers commonly
- * carry request- or tenant-specific network policy, so each call gets an
- * isolated connection that is closed after the tool response.
+ * Scoped fetchers, cancellation signals, and timeout policies retain one-shot
+ * behavior for direct SDK callers. Runner workflows explicitly opt into a
+ * caller-owned cache scope that reuses and then gracefully closes the session.
  *
  * Signing: this path consumes `options.signingContext` via the transport —
  * `connectMCP` attaches a signing-fetch wrapper at transport-creation time —

--- a/src/lib/protocols/session-termination.ts
+++ b/src/lib/protocols/session-termination.ts
@@ -1,0 +1,22 @@
+const SESSION_TERMINATION_TIMEOUT_MS = 1_000;
+
+interface SessionTerminatingTransport {
+  terminateSession(): Promise<void>;
+}
+
+/**
+ * Attempt the official MCP DELETE handshake without letting an unresponsive
+ * seller block local transport cleanup indefinitely.
+ */
+export async function terminateSessionBestEffort(transport: SessionTerminatingTransport): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const termination = transport.terminateSession().catch(() => {});
+  const deadline = new Promise<void>(resolve => {
+    timer = setTimeout(resolve, SESSION_TERMINATION_TIMEOUT_MS);
+  });
+  try {
+    await Promise.race([termination, deadline]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}

--- a/src/lib/testing/client.ts
+++ b/src/lib/testing/client.ts
@@ -23,6 +23,7 @@ import { classifyProbeUrl } from '../utils/probe-policy';
 import { SsrfRefusedError } from '../net/ssrf-fetch';
 import { ADCP_VERSION } from '../version';
 import type { VersionEnvelopeMode } from '../protocols';
+import { validateIncomingResponse } from '../validation/client-hooks';
 
 const TEST_CLIENT_VERSION_OPTIONS = Symbol('adcp.testClientVersionOptions');
 
@@ -473,8 +474,26 @@ export async function discoverAgentProfile(
   if (profile.tools.includes('get_adcp_capabilities')) {
     try {
       const caps = (await raceWithSignal(client.getAdcpCapabilities({}, undefined, { signal }), signal)) as TaskResult;
-      if (caps?.success && caps?.data) {
+      if (caps?.data) {
         profile.raw_capabilities = caps.data;
+        const validation = validateIncomingResponse(
+          'get_adcp_capabilities',
+          caps.data,
+          'strict',
+          undefined,
+          client.getAdcpVersion()
+        );
+        if (!validation.valid) {
+          profile.capabilities_schema_issues = validation.issues.map(issue => ({
+            pointer: issue.pointer,
+            message: issue.message,
+          }));
+        }
+
+        // Even a schema-invalid response can contain enough trustworthy
+        // discriminators to select the storyboards the seller claimed. Keep
+        // parsing best-effort so the preflight notice augments downstream
+        // failures instead of suppressing them.
         const parsed = parseCapabilitiesResponse(caps.data);
         profile.adcp_version = parsed.version;
         profile.adcp_major_versions = parsed.majorVersions;
@@ -489,7 +508,8 @@ export async function discoverAgentProfile(
         }
         const libVersion = (caps.data as Record<string, unknown>).library_version;
         if (typeof libVersion === 'string') profile.library_version = libVersion;
-      } else {
+      }
+      if (!caps?.success && !profile.capabilities_schema_issues?.length) {
         profile.capabilities_probe_error = caps?.error || 'get_adcp_capabilities returned no data';
       }
     } catch (err) {

--- a/src/lib/testing/client.ts
+++ b/src/lib/testing/client.ts
@@ -509,7 +509,7 @@ export async function discoverAgentProfile(
         const libVersion = (caps.data as Record<string, unknown>).library_version;
         if (typeof libVersion === 'string') profile.library_version = libVersion;
       }
-      if (!caps?.success && !profile.capabilities_schema_issues?.length) {
+      if ((!caps?.success || !caps?.data) && !profile.capabilities_schema_issues?.length) {
         profile.capabilities_probe_error = caps?.error || 'get_adcp_capabilities returned no data';
       }
     } catch (err) {

--- a/src/lib/testing/compliance/comply.ts
+++ b/src/lib/testing/compliance/comply.ts
@@ -53,7 +53,7 @@ import type {
   AdvisoryObservation,
   OverallStatus,
 } from './types';
-import { closeConnections } from '../../protocols';
+import { closeScopedConnections, withMCPConnectionScope } from '../../protocols';
 import type { VersionEnvelopeMode } from '../../protocols';
 import { detectController, hasTestController } from '../test-controller';
 import type { ControllerDetection } from '../test-controller';
@@ -609,11 +609,13 @@ export async function comply(agentUrl: string, options: ComplyOptions = {}): Pro
         `Production agents MUST terminate TLS. Pass { allow_http: true } (or --allow-http) for local development.`
     );
   }
-  try {
-    return await complyImpl(agentUrl, options);
-  } finally {
-    await closeConnections(options.protocol);
-  }
+  return withMCPConnectionScope(async () => {
+    try {
+      return await complyImpl(agentUrl, options);
+    } finally {
+      await closeScopedConnections(options.protocol);
+    }
+  });
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -1435,8 +1437,8 @@ async function complyImpl(agentUrl: string, options: ComplyOptions): Promise<Com
       ...(hostedStableLineAlias !== undefined && { hostedStableLineAlias }),
     });
 
-    // Aggregate notices from all storyboard runs. Dedup is by `code` (each
-    // notice type appears once in the rollup), but the per-occurrence
+    // Aggregate notices from all storyboard runs. Dedup is by `code`, or by
+    // (`code`, `capability_pointer`) for schema-validation notices, while the per-occurrence
     // `storyboard_ids` arrays are merged so auditors can see how widespread
     // a deprecation or future-required signal is without re-walking the
     // per-storyboard arrays. Order is stable: first occurrence wins for
@@ -1445,14 +1447,16 @@ async function complyImpl(agentUrl: string, options: ComplyOptions): Promise<Com
     const aggregatedNotices = new Map<string, RunnerNotice>();
     for (const sbResult of storyboardResults) {
       for (const notice of sbResult.notices) {
-        const existing = aggregatedNotices.get(notice.code);
+        const noticeKey =
+          notice.capability_pointer === undefined ? notice.code : `${notice.code}\u0000${notice.capability_pointer}`;
+        const existing = aggregatedNotices.get(noticeKey);
         if (existing) {
           for (const sid of notice.storyboard_ids) {
             if (!existing.storyboard_ids.includes(sid)) existing.storyboard_ids.push(sid);
           }
         } else {
           // Clone so subsequent merges don't mutate the per-storyboard array.
-          aggregatedNotices.set(notice.code, { ...notice, storyboard_ids: [...notice.storyboard_ids] });
+          aggregatedNotices.set(noticeKey, { ...notice, storyboard_ids: [...notice.storyboard_ids] });
         }
       }
     }

--- a/src/lib/testing/compliance/types.ts
+++ b/src/lib/testing/compliance/types.ts
@@ -173,7 +173,8 @@ export interface ComplianceResult {
   total_duration_ms: number;
   /**
    * Protocol-compliance advisories aggregated across all storyboard runs,
-   * deduplicated by `code`. Always present (default `[]`) — mirrors the
+   * deduplicated by `code`, or (`code`, `capability_pointer`) when present.
+   * Always present (default `[]`) — mirrors the
    * always-present invariant on `StoryboardResult.notices` so adopters
    * can iterate `for (const n of result.notices)` at either level without
    * a defensive `?.`. For per-storyboard notices see `StoryboardResult.notices`.

--- a/src/lib/testing/scenarios/media-buy.ts
+++ b/src/lib/testing/scenarios/media-buy.ts
@@ -1363,14 +1363,18 @@ export async function resolveAccountForMediaBuy(
   return { accountRef: resolveAccount(options), steps };
 }
 
-function getMediaBuyAccountResolutionHints(profile: AgentProfile): MediaBuyAccountResolutionHints {
+export function getMediaBuyAccountResolutionHints(profile: AgentProfile): MediaBuyAccountResolutionHints {
   const capabilities = profile.raw_capabilities;
   if (!isRecord(capabilities) || !isRecord(capabilities.account)) {
     return {};
   }
 
   const requireOperatorAuth = capabilities.account.require_operator_auth;
-  return typeof requireOperatorAuth === 'boolean' ? { requireOperatorAuth } : {};
+  // `false` is the schema default. Once the account capability block exists,
+  // omission must not silently switch the runner into explicit discovery
+  // mode merely because list_accounts is also advertised. Preserve the
+  // legacy list_accounts heuristic only when no account block was available.
+  return { requireOperatorAuth: typeof requireOperatorAuth === 'boolean' ? requireOperatorAuth : false };
 }
 
 function selectMediaBuyAccount(
@@ -1420,7 +1424,11 @@ function accountMatchesBrand(
     return false;
   }
 
-  return typeof account.operator !== 'string' || account.operator === brand.domain;
+  // The operator is a separate natural-key dimension, not an alias for the
+  // brand domain. Agency-operated accounts routinely have
+  // `operator !== brand.domain`; the requested test brand is the only brand
+  // signal available to this selector.
+  return true;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -10,7 +10,7 @@ import { createHash, createHmac } from 'node:crypto';
 import { existsSync, readFileSync } from 'node:fs';
 import { basename, join } from 'node:path';
 import { getOrCreateClientResolution, getOrDiscoverProfile, runStep, type TestClient } from '../client';
-import { closeConnections, type VersionEnvelopeMode } from '../../protocols';
+import { closeScopedConnections, withMCPConnectionScope, type VersionEnvelopeMode } from '../../protocols';
 import { getCapturesFromError, withRawResponseCapture, type RawHttpCapture } from '../../protocols/rawResponseCapture';
 import { executeStoryboardTask } from './task-map';
 import {
@@ -1094,14 +1094,19 @@ export async function runStoryboard(
   storyboard: Storyboard,
   options: StoryboardRunOptions = {}
 ): Promise<StoryboardResult> {
-  options = applyStoryboardVersionOptions(storyboard, options);
-  const schemaRoot = getRunSchemaRoot(options);
-  if (schemaRoot) {
-    return await withExternalSchemaRoot(schemaRoot.adcpVersion, schemaRoot.schemaRoot, () =>
-      runStoryboardBody(agentUrlOrUrls, storyboard, options)
-    );
-  }
-  return await runStoryboardBody(agentUrlOrUrls, storyboard, options);
+  return withMCPConnectionScope(
+    async () => {
+      options = applyStoryboardVersionOptions(storyboard, options);
+      const schemaRoot = getRunSchemaRoot(options);
+      if (schemaRoot) {
+        return await withExternalSchemaRoot(schemaRoot.adcpVersion, schemaRoot.schemaRoot, () =>
+          runStoryboardBody(agentUrlOrUrls, storyboard, options)
+        );
+      }
+      return await runStoryboardBody(agentUrlOrUrls, storyboard, options);
+    },
+    { isolate: true }
+  );
 }
 
 async function runStoryboardBody(
@@ -1149,7 +1154,7 @@ async function runStoryboardBody(
       const resultAgentUrls = options.agents ? Object.values(options.agents).map(e => e.url) : agentUrls;
       return {
         ...buildRequirementUnmetResult(resultAgentUrls, storyboard, unmet.requirement, unmet.detail),
-        notices: collectCapabilityNotices(storyboard, options._profile?.raw_capabilities),
+        notices: collectCapabilityNotices(storyboard, options._profile),
       };
     }
   }
@@ -1968,7 +1973,10 @@ function buildRequiredToolsMissingResult(
  * agent's declared capabilities. Returns an empty array when rawCaps is
  * absent (standalone runner without pre-fetched profile).
  *
- * Currently emits three spec-grounded notices (adcp-client#1704, #2082):
+ * Currently emits four spec-grounded notices (adcp-client#1704, #2082, #2461):
+ *
+ * - `capabilities_response_schema_invalid`: one informational notice per
+ *   schema issue, identified by its RFC 6901 `capability_pointer`.
  *
  * - `signed_requests_specialism_deprecated`: agent claims deprecated
  *   `specialisms: ['signed-requests']` alongside `request_signing.supported:
@@ -1983,8 +1991,18 @@ function buildRequiredToolsMissingResult(
  *   `webhook_signing.legacy_hmac_fallback: true`, which is removed in
  *   `effective_version: '4.0'`.
  */
-function collectCapabilityNotices(storyboard: Storyboard, rawCaps: unknown): RunnerNotice[] {
-  const notices: RunnerNotice[] = [];
+function collectCapabilityNotices(storyboard: Storyboard, profile: AgentProfile | undefined): RunnerNotice[] {
+  const notices: RunnerNotice[] = (profile?.capabilities_schema_issues ?? []).map(issue => ({
+    severity: 'info',
+    code: 'capabilities_response_schema_invalid',
+    message:
+      `The agent's get_adcp_capabilities response failed schema validation at ${issue.pointer || '/'}: ` +
+      `${issue.message}. Track results may share this root cause; fix it first, then re-read the failures.`,
+    capability_pointer: issue.pointer,
+    docs_url: 'https://github.com/adcontextprotocol/adcp/issues/6254',
+    storyboard_ids: [storyboard.id],
+  }));
+  const rawCaps = profile?.raw_capabilities;
   if (!rawCaps || typeof rawCaps !== 'object') return notices;
   const caps = rawCaps as Record<string, unknown>;
 
@@ -2102,16 +2120,21 @@ function collectInputSchemaFieldStripNotices(debugLogs: unknown, storyboardId: s
 function mergeRunnerNotices(notices: RunnerNotice[]): RunnerNotice[] {
   const byCode = new Map<string, RunnerNotice>();
   for (const notice of notices) {
-    const existing = byCode.get(notice.code);
+    const key = runnerNoticeKey(notice);
+    const existing = byCode.get(key);
     if (existing) {
       for (const sid of notice.storyboard_ids) {
         if (!existing.storyboard_ids.includes(sid)) existing.storyboard_ids.push(sid);
       }
     } else {
-      byCode.set(notice.code, { ...notice, storyboard_ids: [...notice.storyboard_ids] });
+      byCode.set(key, { ...notice, storyboard_ids: [...notice.storyboard_ids] });
     }
   }
   return [...byCode.values()];
+}
+
+function runnerNoticeKey(notice: RunnerNotice): string {
+  return notice.capability_pointer === undefined ? notice.code : `${notice.code}\u0000${notice.capability_pointer}`;
 }
 
 function collectStepNotices(phases: StoryboardPhaseResult[]): RunnerNotice[] {
@@ -2157,7 +2180,7 @@ async function executeStoryboardPass(
         duration_ms: 0,
         error: detail,
       };
-      await closeConnections(options.protocol);
+      await closeScopedConnections(options.protocol);
       return buildDiscoveryFailedResult(agentUrls, storyboard, failedStep);
     }
     clients = [...routingContext.clients.values()];
@@ -2214,7 +2237,7 @@ async function executeStoryboardPass(
       // (auth misconfig, MCP transport-fallback bugs, network policy, etc.).
       // See: https://github.com/adcontextprotocol/adcp-client/issues/...
       if (discovered.step.passed === false) {
-        await closeConnections(options.protocol);
+        await closeScopedConnections(options.protocol);
         return buildDiscoveryFailedResult(agentUrls, storyboard, discovered.step);
       }
       profile = discovered.profile;
@@ -2272,13 +2295,13 @@ async function executeStoryboardPass(
   // early-return results (requirement-unmet, capability-unsupported). In the
   // standalone runner path options._profile may be undefined; notices will be
   // collected again from the fully-fetched profile at result-build time.
-  const preflightNotices = collectCapabilityNotices(storyboard, options._profile?.raw_capabilities);
+  const preflightNotices = collectCapabilityNotices(storyboard, options._profile);
 
   const allRequires = resolveStoryboardRequires(storyboard, options);
   if (allRequires.length) {
     const unmet = checkRequires(allRequires, storyboard, options, profile);
     if (unmet) {
-      if (!callerOwnsClients) await closeConnections(options.protocol);
+      if (!callerOwnsClients) await closeScopedConnections(options.protocol);
       return {
         ...buildRequirementUnmetResult(agentUrls, storyboard, unmet.requirement, unmet.detail),
         notices: preflightNotices,
@@ -2293,7 +2316,7 @@ async function executeStoryboardPass(
       const detail =
         `missing_required_tool_family: needs ${missing.tools.join(' or ')}` +
         (missing.rationale ? ` (${missing.rationale})` : '');
-      if (!callerOwnsClients) await closeConnections(options.protocol);
+      if (!callerOwnsClients) await closeScopedConnections(options.protocol);
       return {
         ...buildRequiredAnyOfToolsMissingResult(agentUrls, storyboard, detail),
         notices: preflightNotices,
@@ -2313,7 +2336,7 @@ async function executeStoryboardPass(
       options.adcpVersion
     );
     if (unmetDetail !== null) {
-      if (!callerOwnsClients) await closeConnections(options.protocol);
+      if (!callerOwnsClients) await closeScopedConnections(options.protocol);
       return {
         ...buildCapabilityUnsupportedResult(agentUrls, storyboard, unmetDetail),
         notices: preflightNotices,
@@ -2334,7 +2357,7 @@ async function executeStoryboardPass(
   if (storyboard.required_tools?.length && options.agentTools) {
     const hasAnyRequired = storyboard.required_tools.some(t => options.agentTools!.includes(t));
     if (!hasAnyRequired) {
-      if (!callerOwnsClients) await closeConnections(options.protocol);
+      if (!callerOwnsClients) await closeScopedConnections(options.protocol);
       return {
         ...buildRequiredToolsMissingResult(
           agentUrls,
@@ -3598,7 +3621,7 @@ async function executeStoryboardPass(
   // notices (which used options._profile) when profile was not re-fetched in
   // this pass (standalone runner with options._profile pre-set skips the fetch).
   const notices = mergeRunnerNotices([
-    ...collectCapabilityNotices(storyboard, profile?.raw_capabilities ?? options._profile?.raw_capabilities),
+    ...collectCapabilityNotices(storyboard, profile ?? options._profile),
     ...collectStepNotices(phaseResults),
   ]);
   const result: StoryboardResult = {
@@ -3643,10 +3666,10 @@ async function executeStoryboardPass(
   };
 
   // Close protocol connections when the runner created its own client. The
-  // connection pool is keyed by URL+auth, so a single closeConnections() call
-  // evicts every instance's transport regardless of how many URLs we used.
+  // The runner scope tracks every URL used by this storyboard, so one scoped
+  // close releases all of its transports without disrupting concurrent runs.
   if (!callerOwnsClients) {
-    await closeConnections(options.protocol);
+    await closeScopedConnections(options.protocol);
   }
 
   if (webhookReceiver) await webhookReceiver.close();
@@ -3698,7 +3721,7 @@ async function runMultiPass(
   if (!preSeedProfile) {
     const discovered = await getOrDiscoverProfile(preSeedClients[0]!, options);
     if (discovered.step.passed === false) {
-      await closeConnections(options.protocol);
+      await closeScopedConnections(options.protocol);
       return buildDiscoveryFailedResult(agentUrls, storyboard, discovered.step);
     }
     preSeedProfile = discovered.profile;
@@ -3770,8 +3793,9 @@ async function runMultiPass(
   // readers see a per-pass timeline; de-duplicating would hide a real
   // "passed on pass 1, failed on pass 2" divergence.
   const assertionsAgg = passResults.flatMap(r => r.assertions ?? []);
-  // Notices are identical across passes (same agent, same capabilities); deduplicate by code.
-  const noticesDedup = [...new Map(passResults.flatMap(r => r.notices).map(n => [n.code, n])).values()];
+  // Notices are identical across passes (same agent, same capabilities).
+  // Schema-invalid capabilities notices retain one row per RFC 6901 pointer.
+  const noticesDedup = [...new Map(passResults.flatMap(r => r.notices).map(n => [runnerNoticeKey(n), n])).values()];
 
   return {
     storyboard_id: storyboard.id,
@@ -3948,15 +3972,20 @@ export async function runStoryboardStep(
   stepId: string,
   options: StoryboardRunOptions = {}
 ): Promise<StoryboardStepResult> {
-  validateStoryboardShape(storyboard);
-  options = applyStoryboardVersionOptions(storyboard, options);
-  const schemaRoot = getRunSchemaRoot(options);
-  if (schemaRoot) {
-    return await withExternalSchemaRoot(schemaRoot.adcpVersion, schemaRoot.schemaRoot, () =>
-      runStoryboardStepBody(agentUrl, storyboard, stepId, options)
-    );
-  }
-  return await runStoryboardStepBody(agentUrl, storyboard, stepId, options);
+  return withMCPConnectionScope(
+    async () => {
+      validateStoryboardShape(storyboard);
+      options = applyStoryboardVersionOptions(storyboard, options);
+      const schemaRoot = getRunSchemaRoot(options);
+      if (schemaRoot) {
+        return await withExternalSchemaRoot(schemaRoot.adcpVersion, schemaRoot.schemaRoot, () =>
+          runStoryboardStepBody(agentUrl, storyboard, stepId, options)
+        );
+      }
+      return await runStoryboardStepBody(agentUrl, storyboard, stepId, options);
+    },
+    { isolate: true }
+  );
 }
 
 async function runStoryboardStepBody(
@@ -4052,7 +4081,7 @@ async function runStoryboardStepBody(
   }
 
   if (!clientResolution.reusedShared) {
-    await closeConnections(options.protocol);
+    await closeScopedConnections(options.protocol);
   }
 
   if (ownsWebhookReceiver && webhookReceiver) await webhookReceiver.close();

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -2111,7 +2111,9 @@ export type NoticeCode =
    *  AdCP 4.0 per `effective_version`. */
   | 'webhook_signing.legacy_hmac_fallback.removed'
   /** Runner stripped request fields missing from the agent's advertised tool input schema. */
-  | 'input_schema_field_stripped';
+  | 'input_schema_field_stripped'
+  /** The preflight get_adcp_capabilities response failed schema validation. */
+  | 'capabilities_response_schema_invalid';
 
 /**
  * Severity of a runner notice. Deliberately separate from `ObservationSeverity`
@@ -2119,7 +2121,7 @@ export type NoticeCode =
  * compliance trajectory_ — a different axis: something is fine today but the
  * spec already signals a future state change.
  *
- * - `info` — purely informational; no action required now.
+ * - `info` — non-grading context; it may still identify an actionable defect.
  * - `deprecation` — SHOULD migrate; the field/claim is deprecated in the current
  *   spec version.
  * - `future_required` — behavior is optional today but will be mandatory in a
@@ -2135,7 +2137,8 @@ export type NoticeSeverity = 'info' | 'deprecation' | 'future_required';
  * like "DEPRECATION" or "FUTURE-REQUIRED" without parsing prose strings.
  *
  * `ComplianceResult.notices` aggregates these across all storyboard runs,
- * deduplicated by `code`.
+ * deduplicated by `code`, or by (`code`, `capability_pointer`) when a pointer
+ * is present. This preserves one schema-invalid notice per response location.
  *
  * Spec: adcp-client#1704.
  */
@@ -2159,6 +2162,12 @@ export interface RunnerNotice {
    */
   capability_path?: string;
   /**
+   * RFC 6901 pointer into the agent's `get_adcp_capabilities` response.
+   * Distinct from `capability_path`, which is a human-readable dotted flag
+   * path. Notices may carry both when they identify the same location.
+   */
+  capability_pointer?: string;
+  /**
    * Click-through URL for adopters to read the underlying spec section,
    * migration guide, or AdCP issue. Optional; consumers that surface
    * notices in dashboards or CI output use this to deep-link the
@@ -2169,10 +2178,10 @@ export interface RunnerNotice {
    * Storyboard ids that triggered this notice. On `StoryboardResult.notices`
    * this is always a single-element array (the storyboard the notice came
    * from). On `ComplianceResult.notices` (the deduplicated cross-storyboard
-   * rollup) this aggregates every storyboard that emitted the same `code`,
-   * so auditors can see "how widespread" a deprecation or future-required
-   * signal is without re-walking the per-storyboard arrays. Order is stable
-   * across runs (insertion order across the storyboard execution order).
+   * rollup) this aggregates every storyboard that emitted the same dedupe key
+   * (`code`, or `code` + `capability_pointer` when present), so auditors can
+   * see "how widespread" a signal is without re-walking the per-storyboard
+   * arrays. Order is stable across runs (storyboard execution order).
    */
   storyboard_ids: string[];
 }
@@ -2896,11 +2905,13 @@ export interface StoryboardResult {
   /**
    * Structured protocol-compliance advisories produced for this storyboard
    * run. Each notice carries a stable `code` (machine-readable, suitable for
-   * CI badge routing) and a `severity` (`deprecation` | `future_required`).
+   * CI badge routing) and a non-grading `severity` (`info` | `deprecation` |
+   * `future_required`).
    * Always present; empty array when no notices were triggered.
    *
    * `ComplianceResult.notices` aggregates across all storyboard runs,
-   * deduplicated by `code`. Spec: adcp-client#1704.
+   * deduplicated by `code`, or by (`code`, `capability_pointer`) when a
+   * capability pointer is present. Spec: adcp-client#1704 and adcp#6256.
    */
   notices: RunnerNotice[];
   /**

--- a/src/lib/testing/types.ts
+++ b/src/lib/testing/types.ts
@@ -367,6 +367,18 @@ export interface AgentProfile {
    */
   capabilities_probe_error?: string;
   /**
+   * Schema violations found during the preflight `get_adcp_capabilities`
+   * call. Kept separately from `capabilities_probe_error`: an invalid
+   * response is still available for best-effort storyboard selection, while
+   * the runner surfaces each violation as a structured notice.
+   */
+  capabilities_schema_issues?: Array<{
+    /** RFC 6901 pointer into the capabilities response. */
+    pointer: string;
+    /** Validator-authored explanation of the violation. */
+    message: string;
+  }>;
+  /**
    * Raw `get_adcp_capabilities` response body. Used by the storyboard runner to
    * evaluate `requires_capability` predicates (e.g. `adcp.idempotency.supported`)
    * that reference fields not extracted into the normalised profile shape above.

--- a/test/lib/discover-agent-profile-signal.test.js
+++ b/test/lib/discover-agent-profile-signal.test.js
@@ -116,6 +116,20 @@ describe('discoverAgentProfile: AbortSignal honored (#1612)', () => {
     );
   });
 
+  test('records a probe diagnostic when capabilities succeeds without data', async () => {
+    const client = {
+      getAgentInfo: async () => ({
+        name: 'Empty capabilities seller',
+        tools: [{ name: 'get_adcp_capabilities' }],
+      }),
+      getAdcpCapabilities: async () => ({ success: true }),
+    };
+
+    const { profile } = await discoverAgentProfile(client);
+    assert.strictEqual(profile.raw_capabilities, undefined);
+    assert.strictEqual(profile.capabilities_probe_error, 'get_adcp_capabilities returned no data');
+  });
+
   // code-reviewer follow-up on #1612: the wrapper covers the second
   // `getAdcpCapabilities()` call, not just the first `getAgentInfo()`.
   // Cover that path explicitly so a future refactor that bypasses

--- a/test/lib/discover-agent-profile-signal.test.js
+++ b/test/lib/discover-agent-profile-signal.test.js
@@ -89,6 +89,33 @@ describe('discoverAgentProfile: AbortSignal honored (#1612)', () => {
     client.cleanup();
   });
 
+  test('captures schema-invalid capabilities pointers without suppressing best-effort profile parsing', async () => {
+    const client = {
+      getAgentInfo: async () => ({
+        name: 'Invalid capabilities seller',
+        tools: [{ name: 'get_adcp_capabilities' }],
+      }),
+      getAdcpVersion: () => '3.1.11',
+      getAdcpCapabilities: async () => ({
+        success: true,
+        data: {
+          adcp: { major_versions: [3], idempotency: { supported: true, replay_ttl_seconds: 86400 } },
+          supported_protocols: ['media_buy'],
+          account: { sandbox: { supported: true } },
+        },
+      }),
+    };
+
+    const { profile } = await discoverAgentProfile(client);
+    assert.deepStrictEqual(profile.supported_protocols, ['media_buy']);
+    assert.ok(profile.raw_capabilities, 'invalid response remains available for downstream selection');
+    assert.ok(profile.capabilities_schema_issues?.length >= 1);
+    assert.ok(
+      profile.capabilities_schema_issues.some(issue => issue.pointer === '/account/supported_billing'),
+      JSON.stringify(profile.capabilities_schema_issues)
+    );
+  });
+
   // code-reviewer follow-up on #1612: the wrapper covers the second
   // `getAdcpCapabilities()` call, not just the first `getAgentInfo()`.
   // Cover that path explicitly so a future refactor that bypasses

--- a/test/lib/mcp-modern-negotiation.test.js
+++ b/test/lib/mcp-modern-negotiation.test.js
@@ -12,6 +12,7 @@ const { createServer } = require('node:http');
 const { callMCPTool, closeMCPConnections } = require('../../dist/lib/protocols/mcp.js');
 const { callMCPToolWithOAuth } = require('../../dist/lib/protocols/mcp.js');
 const { callMCPToolWithTasks } = require('../../dist/lib/protocols/mcp-tasks.js');
+const { withMCPConnectionScope } = require('../../dist/lib/protocols/index.js');
 const {
   probeModernMCPConnection,
   tryCallModernMCPTool,
@@ -176,6 +177,7 @@ test('modern discovery is reused within the same authorization context', async t
   const httpServer = createServer(toNodeHandler(handler));
   const url = await listen(httpServer);
   let discoverRequests = 0;
+  let initializeRequests = 0;
   const countingFetch = async (input, init) => {
     const request = input instanceof Request ? input.clone() : new Request(input, init);
     if (request.method === 'POST') {
@@ -184,9 +186,12 @@ test('modern discovery is reused within the same authorization context', async t
         .json()
         .catch(() => undefined);
       if (body?.method === 'server/discover') discoverRequests++;
+      if (body?.method === 'initialize') initializeRequests++;
     }
     return fetch(input, init);
   };
+  const controller = new AbortController();
+  const scopedOptions = { fetchFn: countingFetch, signal: controller.signal, requestTimeoutMs: 2_000 };
 
   t.after(async () => {
     await closeMCPConnections();
@@ -194,23 +199,32 @@ test('modern discovery is reused within the same authorization context', async t
     await closeServer(httpServer);
   });
 
-  const probe = await probeModernMCPConnection(url, 'tenant-a-token', undefined, {
-    fetchFn: countingFetch,
-  });
+  const probe = await probeModernMCPConnection(url, 'tenant-a-token', undefined, scopedOptions);
   assert.deepEqual(probe, { connected: true, era: 'modern' });
   assert.equal(discoverRequests, 1);
 
-  const cachedAttempt = await tryCallModernMCPTool(url, 'echo', {}, 'tenant-a-token', [], undefined, {
-    fetchFn: countingFetch,
-  });
-  assert.equal(cachedAttempt.handled, true);
-  assert.equal(discoverRequests, 1, 'the first tool connection should adopt the cached discovery result');
+  await withMCPConnectionScope(async () => {
+    const cachedAttempt = await tryCallModernMCPTool(url, 'echo', {}, 'tenant-a-token', [], undefined, scopedOptions);
+    assert.equal(cachedAttempt.handled, true);
+    assert.equal(discoverRequests, 2, 'the workflow should establish its own caller-owned discovery scope');
+    const initializesAfterFirstToolCall = initializeRequests;
 
-  const otherTenantAttempt = await tryCallModernMCPTool(url, 'echo', {}, 'tenant-b-token', [], undefined, {
-    fetchFn: countingFetch,
+    const reusedAttempt = await tryCallModernMCPTool(url, 'echo', {}, 'tenant-a-token', [], undefined, scopedOptions);
+    assert.equal(reusedAttempt.handled, true);
+    assert.equal(initializeRequests, initializesAfterFirstToolCall, 'scoped modern calls should reuse one session');
   });
+
+  const otherTenantAttempt = await tryCallModernMCPTool(
+    url,
+    'echo',
+    {},
+    'tenant-b-token',
+    [],
+    undefined,
+    scopedOptions
+  );
   assert.equal(otherTenantAttempt.handled, true);
-  assert.equal(discoverRequests, 2, 'discovery results must not cross authorization contexts');
+  assert.equal(discoverRequests, 3, 'discovery results must not cross authorization contexts');
 
   const { AgentClient } = require('../../dist/lib/core/AgentClient.js');
   const oauthClient = new AgentClient(
@@ -353,6 +367,50 @@ test('remote MCP client preserves the v1 path for a legacy server', async t => {
     debugLogs.some(entry => entry.message.includes('preserving the v1 Tasks path')),
     'legacy servers should retain the v1 client and Tasks compatibility path'
   );
+});
+
+test('handleLegacy policy is isolated from the cached legacy classification', async t => {
+  const { McpServer } = require('@modelcontextprotocol/sdk/server/mcp.js');
+  const { StreamableHTTPServerTransport } = require('@modelcontextprotocol/sdk/server/streamableHttp.js');
+
+  const httpServer = createServer(async (req, res) => {
+    const server = new McpServer({ name: 'legacy-policy-test', version: '1.0.0' });
+    server.registerTool('echo', { description: 'Echo through the negotiated legacy era' }, async () => ({
+      content: [{ type: 'text', text: 'legacy-policy' }],
+    }));
+    const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+    try {
+      await server.connect(transport);
+      await transport.handleRequest(req, res);
+    } finally {
+      await server.close();
+    }
+  });
+  const url = await listen(httpServer);
+  const scopedFetch = (input, init) => fetch(input, init);
+  const controller = new AbortController();
+
+  t.after(async () => {
+    await closeMCPConnections();
+    httpServer.closeAllConnections?.();
+    await closeServer(httpServer);
+  });
+
+  const fallbackAttempt = await tryCallModernMCPTool(url, 'echo', {}, undefined, [], undefined, {
+    fetchFn: scopedFetch,
+    signal: controller.signal,
+    requestTimeoutMs: 2_000,
+  });
+  assert.deepEqual(fallbackAttempt, { handled: false });
+
+  const handledAttempt = await tryCallModernMCPTool(url, 'echo', {}, undefined, [], undefined, {
+    fetchFn: scopedFetch,
+    signal: controller.signal,
+    requestTimeoutMs: 2_000,
+    handleLegacy: true,
+  });
+  assert.equal(handledAttempt.handled, true);
+  assert.equal(handledAttempt.response.content[0].text, 'legacy-policy');
 });
 
 test('modern discovery 5xx fails closed without dispatching through the v1 client', async t => {

--- a/test/lib/mcp-scoped-session-reuse.test.js
+++ b/test/lib/mcp-scoped-session-reuse.test.js
@@ -1,0 +1,349 @@
+/**
+ * Regression coverage for adcontextprotocol/adcp#6204.
+ *
+ * A hosted conformance run supplies a scoped fetch function, an AbortSignal,
+ * and a request timeout. Those safeguards used to force a brand-new MCP
+ * transport for every tool call. The connection cache now includes their
+ * identities/configuration so calls in the same scope reuse one initialized
+ * session without crossing policy or cancellation boundaries.
+ */
+
+const { after, before, describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const { propagation } = require('@opentelemetry/api');
+
+const { callMCPToolWithTasks } = require('../../dist/lib/protocols/mcp-tasks.js');
+const { callMCPTool, closeMCPConnections } = require('../../dist/lib/protocols/mcp.js');
+const { withMCPConnectionScope } = require('../../dist/lib/protocols/index.js');
+
+let server;
+let origin;
+const counts = new Map();
+let blockedCall;
+
+function counter(path) {
+  let value = counts.get(path);
+  if (!value) {
+    value = { initialize: 0, calls: 0, deletes: 0, traceparents: [] };
+    counts.set(path, value);
+  }
+  return value;
+}
+
+before(async () => {
+  server = http.createServer(async (req, res) => {
+    const path = new URL(req.url, origin).pathname;
+    const state = counter(path);
+    if (req.method === 'DELETE') {
+      state.deletes++;
+      if (path === '/hung-delete' || path === '/hung-success-delete') return;
+      res.writeHead(200).end();
+      return;
+    }
+
+    let raw = '';
+    for await (const chunk of req) raw += chunk;
+    const message = raw ? JSON.parse(raw) : {};
+
+    if (message.method === 'initialize') state.initialize++;
+    if (message.method === 'tools/call') {
+      state.calls++;
+      state.traceparents.push(req.headers.traceparent);
+    }
+
+    if ((path === '/delayed' || path === '/scoped-delayed') && message.method === 'initialize') {
+      await new Promise(resolve => setTimeout(resolve, 75));
+    }
+
+    if (path === '/drop' && message.method === 'tools/call') {
+      req.socket.destroy();
+      return;
+    }
+
+    if (path === '/scope-b' && message.method === 'tools/call' && blockedCall) {
+      await blockedCall.promise;
+    }
+
+    if (path === '/hung-delete' && message.method === 'tools/call') {
+      await new Promise(() => {});
+    }
+
+    if (path === '/not-found' && message.method === 'tools/call') {
+      res.writeHead(404, { 'content-type': 'text/plain' });
+      res.end('Session not found');
+      return;
+    }
+
+    if (message.method === 'notifications/initialized') {
+      res.writeHead(202).end();
+      return;
+    }
+
+    const result =
+      message.method === 'initialize'
+        ? {
+            protocolVersion: '2025-03-26',
+            serverInfo: { name: 'session-reuse-test', version: '1.0.0' },
+            capabilities: { tools: {} },
+          }
+        : message.method === 'tools/list'
+          ? { tools: [] }
+          : { content: [{ type: 'text', text: '{}' }], isError: false };
+    res.writeHead(200, {
+      'content-type': 'application/json',
+      'mcp-session-id': `session-${path.slice(1)}`,
+    });
+    res.end(JSON.stringify({ jsonrpc: '2.0', id: message.id ?? null, result }));
+  });
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  origin = `http://127.0.0.1:${server.address().port}`;
+});
+
+after(async () => {
+  await closeMCPConnections();
+  server.closeAllConnections?.();
+  await new Promise(resolve => server.close(resolve));
+});
+
+describe('scoped MCP session reuse', () => {
+  test('reuses and gracefully closes one session per caller-owned workflow', async () => {
+    const scopedFetch = (input, init) => fetch(input, init);
+    const controller = new AbortController();
+    const options = { fetchFn: scopedFetch, signal: controller.signal, requestTimeoutMs: 2_000 };
+    let deletesBeforeWorkflowClose = 0;
+
+    await withMCPConnectionScope(async () => {
+      await callMCPToolWithTasks(`${origin}/workflow`, 'ping', {}, undefined, [], undefined, options);
+      const initializedAfterFirstCall = counter('/workflow').initialize;
+      const deletesAfterNegotiation = counter('/workflow').deletes;
+      deletesBeforeWorkflowClose = deletesAfterNegotiation;
+      await callMCPToolWithTasks(`${origin}/workflow`, 'ping', {}, undefined, [], undefined, options);
+      assert.equal(counter('/workflow').initialize, initializedAfterFirstCall);
+      assert.equal(counter('/workflow').calls, 2);
+      assert.equal(
+        counter('/workflow').deletes,
+        deletesAfterNegotiation,
+        'the shared session stays live until workflow completion'
+      );
+    });
+
+    const initializedAfterFirstWorkflow = counter('/workflow').initialize;
+    const deletesAfterFirstWorkflow = counter('/workflow').deletes;
+    assert.ok(
+      deletesAfterFirstWorkflow > deletesBeforeWorkflowClose,
+      'workflow completion should terminate only its session'
+    );
+    await withMCPConnectionScope(() =>
+      callMCPToolWithTasks(`${origin}/workflow`, 'ping', {}, undefined, [], undefined, options)
+    );
+    assert.ok(
+      counter('/workflow').initialize > initializedAfterFirstWorkflow,
+      'the next workflow must get a fresh session'
+    );
+  });
+
+  test('one completed workflow cannot close another workflow active in the same process', async () => {
+    let releaseBlockedCall;
+    blockedCall = {
+      promise: new Promise(resolve => {
+        releaseBlockedCall = resolve;
+      }),
+    };
+    const optionsFor = () => ({
+      fetchFn: (input, init) => fetch(input, init),
+      signal: new AbortController().signal,
+      requestTimeoutMs: 2_000,
+    });
+
+    const workflowB = withMCPConnectionScope(() =>
+      callMCPToolWithTasks(`${origin}/scope-b`, 'ping', {}, undefined, [], undefined, optionsFor())
+    );
+    try {
+      while (counter('/scope-b').calls === 0) await new Promise(resolve => setTimeout(resolve, 5));
+      const bDeletesWhileActive = counter('/scope-b').deletes;
+
+      await withMCPConnectionScope(() =>
+        callMCPToolWithTasks(`${origin}/scope-a`, 'ping', {}, undefined, [], undefined, optionsFor())
+      );
+      assert.equal(
+        counter('/scope-b').deletes,
+        bDeletesWhileActive,
+        'workflow A teardown must not terminate workflow B'
+      );
+    } finally {
+      releaseBlockedCall();
+      blockedCall = undefined;
+    }
+
+    await workflowB;
+  });
+
+  test('reuses a session across calls with the same fetch, signal, and timeout', async () => {
+    const controller = new AbortController();
+    const scopedFetch = (input, init) => fetch(input, init);
+    const options = { fetchFn: scopedFetch, signal: controller.signal, requestTimeoutMs: 2_000 };
+
+    const deletesBeforeScope = counter('/reuse').deletes;
+    await withMCPConnectionScope(async () => {
+      await callMCPToolWithTasks(`${origin}/reuse`, 'ping', {}, undefined, [], undefined, options);
+      const initializedAfterFirstCall = counter('/reuse').initialize;
+      await callMCPToolWithTasks(`${origin}/reuse`, 'ping', {}, undefined, [], undefined, options);
+
+      assert.equal(counter('/reuse').initialize, initializedAfterFirstCall, 'second call must reuse the session');
+      assert.equal(counter('/reuse').calls, 2);
+    });
+    assert.ok(counter('/reuse').deletes > deletesBeforeScope, 'session should close at scope teardown');
+  });
+
+  test('treats session-not-found 404 as terminal instead of reconnecting and replaying', async () => {
+    const scopedFetch = (input, init) => fetch(input, init);
+    const controller = new AbortController();
+
+    await assert.rejects(
+      callMCPToolWithTasks(`${origin}/not-found`, 'mutate', {}, undefined, [], undefined, {
+        fetchFn: scopedFetch,
+        signal: controller.signal,
+        requestTimeoutMs: 2_000,
+      }),
+      /404|Session not found/i
+    );
+
+    assert.equal(counter('/not-found').calls, 1, 'failed tool call must not be replayed');
+  });
+
+  test('does not replay a tool call after an ambiguous connection failure', async () => {
+    const controller = new AbortController();
+    const scopedFetch = (input, init) => fetch(input, init);
+
+    await assert.rejects(
+      callMCPToolWithTasks(`${origin}/drop`, 'mutate', {}, undefined, [], undefined, {
+        fetchFn: scopedFetch,
+        signal: controller.signal,
+        requestTimeoutMs: 2_000,
+      })
+    );
+
+    assert.equal(counter('/drop').calls, 1, 'ambiguous tool call must not be replayed');
+  });
+
+  test('a direct one-shot abort does not wait for a server that hangs DELETE', async () => {
+    const controller = new AbortController();
+    const abortTimer = setTimeout(() => controller.abort(), 50);
+    const startedAt = Date.now();
+    try {
+      await assert.rejects(
+        Promise.race([
+          callMCPTool(
+            `${origin}/hung-delete`,
+            'ping',
+            {},
+            undefined,
+            [],
+            undefined,
+            undefined,
+            (input, init) => fetch(input, init),
+            { signal: controller.signal, requestTimeoutMs: 1_000 }
+          ),
+          new Promise((_, reject) => setTimeout(() => reject(new Error('abort path hung')), 500)),
+        ]),
+        error => error?.name === 'AbortError'
+      );
+    } finally {
+      clearTimeout(abortTimer);
+    }
+
+    assert.ok(Date.now() - startedAt < 500, 'abort must not be extended by graceful session termination');
+    assert.equal(counter('/hung-delete').deletes, 0, 'failed one-shot calls should close locally without DELETE');
+  });
+
+  test('successful graceful teardown is bounded when a server hangs DELETE', async () => {
+    const startedAt = Date.now();
+    const response = await callMCPTool(
+      `${origin}/hung-success-delete`,
+      'ping',
+      {},
+      undefined,
+      [],
+      undefined,
+      undefined,
+      (input, init) => fetch(input, init),
+      { requestTimeoutMs: 2_000 }
+    );
+
+    assert.equal(response.content[0].text, '{}');
+    assert.ok(Date.now() - startedAt < 1_500, 'best-effort DELETE must have a bounded deadline');
+    assert.equal(counter('/hung-success-delete').deletes, 1);
+  });
+
+  test('drains a connection whose initialize is still pending during teardown', async () => {
+    const firstCall = callMCPToolWithTasks(`${origin}/delayed`, 'ping', {}, undefined, [], undefined);
+
+    while (counter('/delayed').initialize === 0) await new Promise(resolve => setTimeout(resolve, 5));
+    await Promise.allSettled([firstCall, closeMCPConnections()]);
+    assert.ok(counter('/delayed').deletes >= 1, 'teardown should terminate the late connection');
+
+    const initializedBeforeSecondCall = counter('/delayed').initialize;
+    await callMCPToolWithTasks(`${origin}/delayed`, 'ping', {}, undefined, [], undefined);
+    assert.ok(
+      counter('/delayed').initialize > initializedBeforeSecondCall,
+      'a connection completed after teardown must not repopulate the cache'
+    );
+  });
+
+  test('scoped teardown drains initialize work that outlives the workflow body', async () => {
+    const controller = new AbortController();
+    const scopedFetch = (input, init) => fetch(input, init);
+    const options = { fetchFn: scopedFetch, signal: controller.signal, requestTimeoutMs: 2_000 };
+    let pendingCall;
+
+    const deletesBefore = counter('/scoped-delayed').deletes;
+    await withMCPConnectionScope(async () => {
+      pendingCall = callMCPToolWithTasks(`${origin}/scoped-delayed`, 'ping', {}, undefined, [], undefined, options);
+      void pendingCall.catch(() => {});
+      while (counter('/scoped-delayed').initialize === 0) await new Promise(resolve => setTimeout(resolve, 5));
+      // Deliberately return without awaiting the branch, matching a runner
+      // barrier that has stopped waiting for a slow parallel dispatch.
+    });
+    await Promise.allSettled([pendingCall]);
+
+    assert.ok(
+      counter('/scoped-delayed').deletes > deletesBefore,
+      'late initialization must be terminated before scoped teardown completes'
+    );
+  });
+
+  test('refreshes trace context on each request over a reused session', async () => {
+    let traceparent = '00-11111111111111111111111111111111-1111111111111111-01';
+    const installed = propagation.setGlobalPropagator({
+      inject(_context, carrier, setter) {
+        setter.set(carrier, 'traceparent', traceparent);
+      },
+      extract(context) {
+        return context;
+      },
+      fields() {
+        return ['traceparent'];
+      },
+    });
+    assert.equal(installed, true);
+
+    const controller = new AbortController();
+    const scopedFetch = (input, init) => fetch(input, init);
+    const options = { fetchFn: scopedFetch, signal: controller.signal, requestTimeoutMs: 2_000 };
+    try {
+      await withMCPConnectionScope(async () => {
+        await callMCPToolWithTasks(`${origin}/tracing`, 'ping', {}, undefined, [], undefined, options);
+        traceparent = '00-22222222222222222222222222222222-2222222222222222-01';
+        await callMCPToolWithTasks(`${origin}/tracing`, 'ping', {}, undefined, [], undefined, options);
+      });
+    } finally {
+      propagation.disable();
+    }
+
+    assert.deepStrictEqual(counter('/tracing').traceparents, [
+      '00-11111111111111111111111111111111-1111111111111111-01',
+      '00-22222222222222222222222222222222-2222222222222222-01',
+    ]);
+  });
+});

--- a/test/lib/sandbox-account-resolution.test.js
+++ b/test/lib/sandbox-account-resolution.test.js
@@ -3,7 +3,10 @@ const { describe, test } = require('node:test');
 const assert = require('node:assert');
 
 const { resolveAccountForAudiences, resolveAccountForMediaBuy } = require('../../dist/lib/testing/index.js');
-const { buildCreateMediaBuyRequest } = require('../../dist/lib/testing/scenarios/media-buy.js');
+const {
+  buildCreateMediaBuyRequest,
+  getMediaBuyAccountResolutionHints,
+} = require('../../dist/lib/testing/scenarios/media-buy.js');
 
 describe('resolveAccountForAudiences', () => {
   const defaultOptions = { brand: { domain: 'test.example' } };
@@ -320,6 +323,17 @@ describe('resolveAccountForMediaBuy', () => {
     assert.strictEqual(steps.length, 0);
   });
 
+  test('omitted require_operator_auth defaults to implicit when the account capability block exists', () => {
+    assert.deepStrictEqual(
+      getMediaBuyAccountResolutionHints({
+        name: 'seller',
+        tools: ['list_accounts'],
+        raw_capabilities: { account: { supported_billing: ['agent'] } },
+      }),
+      { requireOperatorAuth: false }
+    );
+  });
+
   test('declared explicit sandbox seller fails instead of falling back when no account is returned', async () => {
     const { accountRef, steps } = await resolveAccountForMediaBuy(
       { ...defaultOptions, sandbox: true },
@@ -362,6 +376,36 @@ describe('resolveAccountForMediaBuy', () => {
 
     assert.deepStrictEqual(accountRef, { account_id: 'acct-match' });
     assert.match(steps[0].details, /brand-matched account: acct-match/);
+  });
+
+  test('brand matching accepts an agency-operated account', async () => {
+    const { accountRef, steps } = await resolveAccountForMediaBuy(
+      defaultOptions,
+      ['list_accounts', 'create_media_buy'],
+      async () => ({
+        success: true,
+        data: {
+          accounts: [
+            {
+              account_id: 'acct-other',
+              brand: { domain: 'other.example' },
+              operator: 'other-agency.example',
+              status: 'active',
+            },
+            {
+              account_id: 'acct-agency',
+              brand: { domain: 'test.example' },
+              operator: 'pinnacle-agency.example',
+              status: 'active',
+            },
+          ],
+        },
+      }),
+      { requireOperatorAuth: true }
+    );
+
+    assert.deepStrictEqual(accountRef, { account_id: 'acct-agency' });
+    assert.match(steps[0].details, /brand-matched account: acct-agency/);
   });
 
   test('multiple matching accounts require explicit media_buy_account_id', async () => {

--- a/test/lib/storyboard-notices.test.js
+++ b/test/lib/storyboard-notices.test.js
@@ -153,6 +153,16 @@ const profileNoRawCaps = {
   // raw_capabilities absent — standalone runner before profile fetch
 };
 
+const profileWithInvalidCapabilities = {
+  name: 'Test Agent (invalid capabilities)',
+  tools: ['get_adcp_capabilities', 'get_products'],
+  raw_capabilities: { account: {} },
+  capabilities_schema_issues: [
+    { pointer: '/account/supported_billing', message: "must have required property 'supported_billing'" },
+    { pointer: '/account/sandbox', message: 'must be boolean' },
+  ],
+};
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Helpers
 // ─────────────────────────────────────────────────────────────────────────────
@@ -188,6 +198,20 @@ describe('RunnerNotice — notices field always present (#1704)', () => {
     assert.ok(result.overall_passed, 'capability-unsupported is a skip, not a failure');
     assert.ok(Array.isArray(result.notices), 'notices must be an array on early-return paths');
     assert.equal(result.notices.length, 0, 'no notices on a non-webhook, non-signing storyboard');
+  });
+});
+
+describe('RunnerNotice: capabilities_response_schema_invalid (#2461)', () => {
+  test('emits one notice per validation pointer and preserves both through deduplication', async () => {
+    const result = await runWith(buildMinimalStoryboard(), profileWithInvalidCapabilities);
+    const notices = result.notices.filter(n => n.code === 'capabilities_response_schema_invalid');
+
+    assert.equal(notices.length, 2);
+    assert.deepStrictEqual(notices.map(n => n.capability_pointer).sort(), [
+      '/account/sandbox',
+      '/account/supported_billing',
+    ]);
+    assert.ok(notices.every(n => n.severity === 'info'));
   });
 });
 


### PR DESCRIPTION
## Summary

- fix runner account resolution for implicit account defaults and agency-operated brands (#6242 counterpart)
- reuse one MCP session per caller-owned runner workflow, isolate concurrent runs, close sessions gracefully with bounded teardown, and never replay ambiguous tool failures (#6204 counterpart)
- validate `get_adcp_capabilities` preflight responses and emit one structured informational notice per RFC 6901 validation pointer (part B of #2461 / adcontextprotocol/adcp#6254)

## Validation

- `npm run test:node:fast` — 13,032 passed, 0 failed, 7 skipped
- focused MCP/OAuth/modern/timeout regressions
- TypeScript build and typecheck
- ESLint, Prettier, commitlint, and diff whitespace checks
- protocol, security, and DX expert reviews converged with no actionable findings

The repository Codex review command was also attempted, but the configured OpenAI account had no API credits available.

Closes #2461
Refs adcontextprotocol/adcp#6204
Refs adcontextprotocol/adcp#6242
Refs adcontextprotocol/adcp#6254
