### PR TITLE
feat(projection): add additive canonical product helpers

### DIFF
--- a/.changeset/add-additive-canonical-product.md
+++ b/.changeset/add-additive-canonical-product.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': minor
+---
+
+Expose `toAdditiveCanonicalProduct()` and `withAdditiveCanonicalFormatOptions()` for compatibility consumers that need URL-free canonical format declarations, preserved top-level `format_ids`, and serializable exact legacy-route sidecars.

--- a/docs/migration-12-to-13.md
+++ b/docs/migration-12-to-13.md
@@ -307,6 +307,34 @@ Each `CanonicalFormatLegacyRoute` contains `product_id`, the stable
 resolver to `AgentClient` or `createAdcpServerFromPlatform()` without changing
 the existing resolver callback contract.
 
+Compatibility consumers that must retain top-level `format_ids[]` while
+publishing URL-free canonical declarations can use the additive projection:
+
+```ts
+import {
+  canonicalFormatLegacyResolverFromRoutes,
+  toAdditiveCanonicalProduct,
+} from '@adcp/sdk/v2/projection';
+
+const { product, diagnostics, routes } =
+  toAdditiveCanonicalProduct(sourceProduct, { legacyFormatConverter });
+
+// product.format_ids is preserved, but product.format_options never exposes
+// v1_format_ref. Extract routes before any JSON round-trip — WeakMap metadata
+// is gone after deserialization. Persist the sidecar before crossing a process
+// boundary.
+await products.put(product.product_id, product);
+await creativeRoutes.put(product.product_id, routes);
+
+const resolver = canonicalFormatLegacyResolverFromRoutes(
+  await creativeRoutes.get(product.product_id)
+);
+```
+
+Source-authored canonical option ids, kinds, and params are preserved exactly;
+only the legacy compatibility hint moves to `routes`. Legacy-only input
+uses the same declaration and route contract after projection.
+
 For a fixed set of temporary seller adapters, prefer one declarative catalog over
 separate forward and reverse callbacks. `projectionAdaptersFromCatalogSnapshots`
 turns exact catalog-authored `v1_format_ref` pairs into client configuration for

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1565,6 +1565,8 @@ export {
 } from './v2/projection';
 
 export {
+  toAdditiveCanonicalProduct,
+  withAdditiveCanonicalFormatOptions,
   toCanonicalOnlyProduct,
   toCanonicalOnlyResponse,
   packageRefsForFormatOptions,
@@ -1584,6 +1586,7 @@ export {
   type CanonicalFormatLegacyResolver,
   type CanonicalFormatLegacyResolutionContext,
   type CanonicalFormatLegacyRoute,
+  type AdditiveCanonicalProduct,
   type CanonicalOnlyProduct,
   type CanonicalCreativeAsset,
   type CanonicalCreativeAsset as CreativeAsset,

--- a/src/lib/v2/projection/augment-response.ts
+++ b/src/lib/v2/projection/augment-response.ts
@@ -31,6 +31,7 @@ import { legacyRoutesForProduct } from './legacy-routes';
 import type { CanonicalFormatLegacyRoute } from './legacy-routes';
 
 const SDK_ID = `@adcp/sdk@${LIBRARY_VERSION}`;
+const DIRECT_LEGACY_FORMAT_IDENTITY_KEYS = new Set(['agenturl', 'formatid', 'formatids', 'v1formatref']);
 
 function canonicalDiagnostic(diagnostic: ProjectionDiagnostic): ProjectionDiagnostic {
   return {
@@ -306,8 +307,11 @@ export type AdditiveCanonicalProduct<P> = Omit<P, 'format_options'> & {
 function assertNoDirectLegacyFormatAliases(declarations: readonly V2ProductFormatDeclaration[]): void {
   for (let index = 0; index < declarations.length; index++) {
     const declaration = declarations[index] as unknown as Record<string, unknown>;
-    for (const field of ['agent_url', 'format_id', 'format_ids']) {
-      if (Object.prototype.hasOwnProperty.call(declaration, field)) {
+    for (const field of Object.keys(declaration)) {
+      if (
+        field !== 'v1_format_ref' &&
+        DIRECT_LEGACY_FORMAT_IDENTITY_KEYS.has(field.replaceAll('_', '').toLowerCase())
+      ) {
         throw new TypeError(
           `format_options[${index}] must not use legacy identity field ${field}; use v1_format_ref for migration routing`
         );
@@ -332,7 +336,7 @@ function assertNoDirectLegacyFormatAliases(declarations: readonly V2ProductForma
  * with `canonicalFormatLegacyResolverFromRoutes(restoredRoutes)`.
  *
  * @throws TypeError when a canonical declaration uses a direct legacy identity
- * alias such as `agent_url` instead of `v1_format_ref`.
+ * alias such as `agent_url` or `agentUrl` instead of `v1_format_ref`.
  */
 export function toAdditiveCanonicalProduct<P extends V1Product>(
   product: P,

--- a/src/lib/v2/projection/augment-response.ts
+++ b/src/lib/v2/projection/augment-response.ts
@@ -27,6 +27,8 @@ import { LIBRARY_VERSION } from '../../version';
 import { canonicalize as canonicalizeJson } from '../../utils/jcs';
 import { concealLegacyFormatRefs } from './legacy-metadata';
 import type { CanonicalFormatDeclaration } from './legacy-metadata';
+import { legacyRoutesForProduct } from './legacy-routes';
+import type { CanonicalFormatLegacyRoute } from './legacy-routes';
 
 const SDK_ID = `@adcp/sdk@${LIBRARY_VERSION}`;
 
@@ -289,6 +291,106 @@ export function withFormatOptions<R extends { products?: V1Product[] }>(
   return {
     response: { ...response, products: out } as R & { products: V2AugmentedProduct<V1Product>[] },
     diagnostics,
+  };
+}
+
+/**
+ * An additive canonical Product: canonical declarations contain no legacy
+ * routing identity, while the Product's top-level `format_ids[]` remains
+ * available to compatibility consumers.
+ */
+export type AdditiveCanonicalProduct<P> = Omit<P, 'format_options'> & {
+  format_options: CanonicalFormatDeclaration[];
+};
+
+function assertNoDirectLegacyFormatAliases(declarations: readonly V2ProductFormatDeclaration[]): void {
+  for (let index = 0; index < declarations.length; index++) {
+    const declaration = declarations[index] as unknown as Record<string, unknown>;
+    for (const field of ['agent_url', 'format_id', 'format_ids']) {
+      if (Object.prototype.hasOwnProperty.call(declaration, field)) {
+        throw new TypeError(
+          `format_options[${index}] must not use legacy identity field ${field}; use v1_format_ref for migration routing`
+        );
+      }
+    }
+  }
+}
+
+/**
+ * Project a Product to an additive, URL-free canonical surface.
+ *
+ * Unlike {@link augmentProductWithFormatOptions}, this always returns fresh
+ * `format_options[]` declarations with `v1_format_ref` concealed. Unlike
+ * {@link toCanonicalOnlyProduct}, it preserves the Product's top-level
+ * `format_ids[]`. Exact canonical-to-legacy downgrade identity is returned
+ * separately as JSON-safe {@link CanonicalFormatLegacyRoute} sidecars.
+ *
+ * Extract `routes` before any JSON round-trip — WeakMap metadata is gone after
+ * deserialization. This helper enforces that ordering internally; persist its
+ * returned `routes` whenever a canonical selection may cross a process boundary
+ * before being forwarded to a legacy seller. Rebuild the write-side resolver
+ * with `canonicalFormatLegacyResolverFromRoutes(restoredRoutes)`.
+ *
+ * @throws TypeError when a canonical declaration uses a direct legacy identity
+ * alias such as `agent_url` instead of `v1_format_ref`.
+ */
+export function toAdditiveCanonicalProduct<P extends V1Product>(
+  product: P,
+  options?: V1ToV2ProjectionOptions
+): {
+  product: AdditiveCanonicalProduct<P>;
+  diagnostics: ProjectionDiagnostic[];
+  routes: CanonicalFormatLegacyRoute[];
+} {
+  const { product: augmented, diagnostics } = augmentProductWithFormatOptions(product, options);
+  const routes = legacyRoutesForProduct(product.product_id, augmented.format_options);
+  assertNoDirectLegacyFormatAliases(augmented.format_options);
+  return {
+    product: {
+      ...augmented,
+      format_options: canonicalDeclarations(augmented.format_options),
+    } as AdditiveCanonicalProduct<P>,
+    diagnostics,
+    routes,
+  };
+}
+
+/**
+ * Response-level companion to {@link toAdditiveCanonicalProduct}. Projects
+ * every Product and accumulates its serializable legacy routes.
+ */
+export function withAdditiveCanonicalFormatOptions<R extends { products?: V1Product[] }>(
+  response: R,
+  options?: V1ToV2ProjectionOptions
+): {
+  response: Omit<R, 'products'> & { products: AdditiveCanonicalProduct<V1Product>[] };
+  diagnostics: ProjectionDiagnostic[];
+  routes: CanonicalFormatLegacyRoute[];
+} {
+  if (!Array.isArray(response?.products)) {
+    return {
+      response: { ...response, products: [] } as Omit<R, 'products'> & {
+        products: AdditiveCanonicalProduct<V1Product>[];
+      },
+      diagnostics: [],
+      routes: [],
+    };
+  }
+  const products: AdditiveCanonicalProduct<V1Product>[] = [];
+  const diagnostics: ProjectionDiagnostic[] = [];
+  const routes: CanonicalFormatLegacyRoute[] = [];
+  for (const sourceProduct of response.products) {
+    const projected = toAdditiveCanonicalProduct(sourceProduct, options);
+    products.push(projected.product);
+    diagnostics.push(...projected.diagnostics);
+    routes.push(...projected.routes);
+  }
+  return {
+    response: { ...response, products } as Omit<R, 'products'> & {
+      products: AdditiveCanonicalProduct<V1Product>[];
+    },
+    diagnostics,
+    routes,
   };
 }
 

--- a/src/lib/v2/projection/index.ts
+++ b/src/lib/v2/projection/index.ts
@@ -19,6 +19,11 @@
  *     can read the canonical model regardless of the seller's wire
  *     version. Additive — `format_ids[]` is preserved.
  *
+ *   - `toAdditiveCanonicalProduct` — additive projection with URL-free
+ *     `format_options[]`, preserved top-level `format_ids[]`, and explicit
+ *     serializable legacy-route sidecars for later forwarding.
+ *     `withAdditiveCanonicalFormatOptions` is the response-level companion.
+ *
  *   - `toCanonicalOnlyProduct` / `toCanonicalOnlyResponse` — the
  *     read-side narrowing for a fully-migrated consumer. Returns
  *     `format_options[]` with `format_ids[]` dropped, surfacing a
@@ -62,9 +67,12 @@ export {
 export {
   augmentProductWithFormatOptions,
   withFormatOptions,
+  toAdditiveCanonicalProduct,
+  withAdditiveCanonicalFormatOptions,
   toCanonicalOnlyProduct,
   toCanonicalOnlyResponse,
   type V2AugmentedProduct,
+  type AdditiveCanonicalProduct,
   type CanonicalOnlyProduct,
 } from './augment-response';
 

--- a/test/lib/v2-augment-response.test.js
+++ b/test/lib/v2-augment-response.test.js
@@ -7,7 +7,14 @@ const { existsSync, mkdtempSync, writeFileSync, rmSync } = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 
-const { withFormatOptions, augmentProductWithFormatOptions } = require('../../dist/lib/v2/projection/index.js');
+const {
+  withFormatOptions,
+  augmentProductWithFormatOptions,
+  toAdditiveCanonicalProduct,
+  withAdditiveCanonicalFormatOptions,
+  canonicalFormatLegacyResolverFromRoutes,
+  projectSyncCreativesForDelivery,
+} = require('../../dist/lib/v2/projection/index.js');
 
 const CATALOG_PATH = path.join(__dirname, 'v2-projection-fixtures', 'aao-reference-formats.json');
 const SKIP_REASON = existsSync(CATALOG_PATH)
@@ -230,6 +237,208 @@ describe('augmentProductWithFormatOptions', { skip: SKIP_REASON }, () => {
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+});
+
+describe('toAdditiveCanonicalProduct', () => {
+  test('conceals authored legacy refs, preserves additive identity, and forwards through persisted routes', () => {
+    const formatId = {
+      agent_url: 'https://formats.publisher.example/catalog',
+      id: 'homepage_takeover',
+      width: 1440,
+      height: 900,
+      duration_ms: 15000,
+    };
+    const source = {
+      product_id: 'homepage',
+      name: 'Homepage',
+      description: 'Authored additive canonical product',
+      format_ids: [formatId],
+      format_options: [
+        {
+          format_option_id: 'homepage-takeover',
+          format_kind: 'custom',
+          format_shape: 'multi_placement_takeover',
+          format_schema: {
+            uri: 'https://formats.publisher.example/schemas/homepage-takeover.json',
+            digest: `sha256:${'a'.repeat(64)}`,
+          },
+          params: { placements: 3 },
+          v1_format_ref: [formatId],
+        },
+      ],
+    };
+
+    const { product, diagnostics, routes } = toAdditiveCanonicalProduct(source);
+
+    assert.deepStrictEqual(diagnostics, []);
+    assert.deepStrictEqual(product.format_ids, source.format_ids, 'top-level compatibility surface remains');
+    assert.notStrictEqual(product, source, 'projection returns a fresh product');
+    assert.notStrictEqual(
+      product.format_options[0],
+      source.format_options[0],
+      'declarations are copied before concealment'
+    );
+    assert.deepStrictEqual(source.format_options[0].v1_format_ref, [formatId], 'source routing metadata is untouched');
+    assert.deepStrictEqual(product.format_options, [
+      {
+        format_option_id: 'homepage-takeover',
+        format_kind: 'custom',
+        format_shape: 'multi_placement_takeover',
+        format_schema: source.format_options[0].format_schema,
+        params: { placements: 3 },
+      },
+    ]);
+    assert.strictEqual(product.format_options[0].v1_format_ref, undefined);
+
+    const restoredRoutes = JSON.parse(JSON.stringify(routes));
+    assert.deepStrictEqual(restoredRoutes, [
+      {
+        product_id: 'homepage',
+        format_option_ref: { scope: 'product', format_option_id: 'homepage-takeover' },
+        format_ids: [formatId],
+      },
+    ]);
+
+    const resolver = canonicalFormatLegacyResolverFromRoutes(restoredRoutes);
+    const advertisedRef = {
+      scope: 'product',
+      format_option_id: product.format_options[0].format_option_id,
+    };
+    assert.deepStrictEqual(advertisedRef, restoredRoutes[0].format_option_ref);
+    const forwarded = projectSyncCreativesForDelivery(
+      {
+        creatives: [
+          {
+            creative_id: 'creative-1',
+            name: 'Homepage creative',
+            format_kind: 'custom',
+            format_option_ref: advertisedRef,
+            assets: {},
+          },
+        ],
+        assignments: [{ creative_id: 'creative-1', package_id: 'package-1' }],
+      },
+      [
+        {
+          package_id: 'package-1',
+          product_id: 'homepage',
+          format_option_refs: [advertisedRef],
+        },
+      ],
+      'legacy',
+      undefined,
+      resolver
+    );
+    assert.deepStrictEqual(forwarded.creatives[0].format_id, formatId);
+  });
+
+  test('legacy-only input uses the same URL-free declaration and route contract', () => {
+    const formatId = {
+      agent_url: 'https://formats.publisher.example/catalog',
+      id: 'legacy_takeover',
+      width: 1280,
+      height: 720,
+      duration_ms: 30000,
+    };
+    const source = {
+      product_id: 'legacy-homepage',
+      name: 'Legacy homepage',
+      description: 'Legacy-only source product',
+      format_ids: [formatId],
+    };
+
+    const { product, diagnostics, routes } = toAdditiveCanonicalProduct(source, {
+      legacyFormatConverter: () => ({
+        format_option_id: 'legacy-takeover',
+        format_kind: 'custom',
+        format_shape: 'multi_placement_takeover',
+        format_schema: {
+          uri: 'https://formats.publisher.example/schemas/legacy-takeover.json',
+          digest: `sha256:${'b'.repeat(64)}`,
+        },
+        params: { placements: 2 },
+      }),
+    });
+
+    assert.deepStrictEqual(diagnostics, []);
+    assert.deepStrictEqual(product.format_ids, source.format_ids);
+    assert.strictEqual(product.format_options[0].format_option_id, 'legacy-takeover');
+    assert.strictEqual(product.format_options[0].format_kind, 'custom');
+    assert.deepStrictEqual(product.format_options[0].params, { placements: 2 });
+    assert.strictEqual(product.format_options[0].v1_format_ref, undefined);
+    assert.deepStrictEqual(JSON.parse(JSON.stringify(routes)), [
+      {
+        product_id: 'legacy-homepage',
+        format_option_ref: { scope: 'product', format_option_id: 'legacy-takeover' },
+        format_ids: [formatId],
+      },
+    ]);
+  });
+
+  test('does not promote a direct agent_url alias into canonical route identity', () => {
+    assert.throws(
+      () =>
+        toAdditiveCanonicalProduct({
+          product_id: 'invalid-alias',
+          name: 'Invalid alias',
+          description: 'Non-schema identity must not become a canonical route',
+          format_options: [
+            {
+              format_option_id: 'alias-only',
+              format_kind: 'image',
+              params: { width: 300, height: 250 },
+              agent_url: 'https://formats.publisher.example/catalog',
+            },
+          ],
+        }),
+      /must not use legacy identity field agent_url/
+    );
+  });
+
+  test('response companion projects every product and accumulates routes', () => {
+    const formatIds = [
+      { agent_url: 'https://formats.publisher.example/catalog', id: 'first' },
+      { agent_url: 'https://formats.publisher.example/catalog', id: 'second' },
+    ];
+    const { response, diagnostics, routes } = withAdditiveCanonicalFormatOptions(
+      {
+        request_id: 'request-1',
+        products: formatIds.map((formatId, index) => ({
+          product_id: `product-${index + 1}`,
+          name: `Product ${index + 1}`,
+          description: 'Legacy source',
+          format_ids: [formatId],
+        })),
+      },
+      {
+        legacyFormatConverter: ({ productId }) => ({
+          format_option_id: `${productId}-option`,
+          format_kind: 'custom',
+          format_shape: 'publisher_defined',
+          format_schema: {
+            uri: `https://formats.publisher.example/schemas/${productId}.json`,
+            digest: `sha256:${'c'.repeat(64)}`,
+          },
+          params: {},
+        }),
+      }
+    );
+
+    assert.strictEqual(response.request_id, 'request-1');
+    assert.deepStrictEqual(diagnostics, []);
+    assert.deepStrictEqual(
+      response.products.map(product => product.format_options[0].format_option_id),
+      ['product-1-option', 'product-2-option']
+    );
+    assert.strictEqual(
+      response.products.some(product => 'v1_format_ref' in product.format_options[0]),
+      false
+    );
+    assert.deepStrictEqual(
+      routes.map(route => route.format_option_ref.format_option_id),
+      ['product-1-option', 'product-2-option']
+    );
   });
 });
 

--- a/test/lib/v2-augment-response.test.js
+++ b/test/lib/v2-augment-response.test.js
@@ -376,24 +376,35 @@ describe('toAdditiveCanonicalProduct', () => {
     ]);
   });
 
-  test('does not promote a direct agent_url alias into canonical route identity', () => {
-    assert.throws(
-      () =>
-        toAdditiveCanonicalProduct({
-          product_id: 'invalid-alias',
-          name: 'Invalid alias',
-          description: 'Non-schema identity must not become a canonical route',
-          format_options: [
-            {
-              format_option_id: 'alias-only',
-              format_kind: 'image',
-              params: { width: 300, height: 250 },
-              agent_url: 'https://formats.publisher.example/catalog',
-            },
-          ],
-        }),
-      /must not use legacy identity field agent_url/
-    );
+  test('rejects snake_case and camelCase legacy identity aliases', () => {
+    for (const [field, value] of [
+      ['agent_url', 'https://formats.publisher.example/catalog'],
+      ['agentUrl', 'https://formats.publisher.example/catalog'],
+      ['agentURL', 'https://formats.publisher.example/catalog'],
+      ['format_id', { agent_url: 'https://formats.publisher.example/catalog', id: 'legacy' }],
+      ['formatId', { agent_url: 'https://formats.publisher.example/catalog', id: 'legacy' }],
+      ['format_ids', [{ agent_url: 'https://formats.publisher.example/catalog', id: 'legacy' }]],
+      ['formatIds', [{ agent_url: 'https://formats.publisher.example/catalog', id: 'legacy' }]],
+      ['v1FormatRef', [{ agent_url: 'https://formats.publisher.example/catalog', id: 'legacy' }]],
+    ]) {
+      assert.throws(
+        () =>
+          toAdditiveCanonicalProduct({
+            product_id: `invalid-${field}`,
+            name: 'Invalid alias',
+            description: 'Non-schema identity must not become a canonical route',
+            format_options: [
+              {
+                format_option_id: 'alias-only',
+                format_kind: 'image',
+                params: { width: 300, height: 250 },
+                [field]: value,
+              },
+            ],
+          }),
+        new RegExp(`must not use legacy identity field ${field}`)
+      );
+    }
   });
 
   test('response companion projects every product and accumulates routes', () => {


### PR DESCRIPTION
Closes #2498.

## Summary

- add an additive canonical product projection that preserves top-level `format_ids` while concealing canonical legacy identity
- return JSON-safe legacy route sidecars before WeakMap metadata can be lost across serialization
- add a response-level companion, root/subpath exports, migration guidance, and a minor changeset

## Why

Compatibility consumers need to advertise URL-free canonical format declarations without losing the exact v1 route required when a later creative selection is forwarded to a legacy seller. The new helpers make that boundary explicit and reject direct legacy identity aliases on canonical declarations.

## Validation

- protocol, implementation, and test expert reviews: no blockers
- focused projection tests: 38 passed
- fast suite: 13,090 passed, 7 skipped, 0 failed
- formatting, typecheck, library build, publint, and package type-surface checks passed
- schema check: generated AdCP files current; external registry drift was unrelated and left out of this PR
