### PR TITLE
fix(storyboard): classify capability skips as not applicable

### DIFF
--- a/.changeset/honest-capability-gate-skips.md
+++ b/.changeset/honest-capability-gate-skips.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Classify a failed storyboard-level `requires_capability` predicate as canonical `not_applicable` while preserving the legacy `capability_unsupported` detailed reason.

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -1320,7 +1320,7 @@ function buildCapabilityUnsupportedResult(
     passed: true,
     skipped: true,
     skip_reason: 'capability_unsupported',
-    skip: { reason: 'unsatisfied_contract', detail },
+    skip: { reason: DETAILED_SKIP_TO_CANONICAL.capability_unsupported, detail },
     duration_ms: 0,
     validations: [],
     context: {},

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -1903,7 +1903,8 @@ export type RunnerSkipReason =
    * advertise `comply_test_controller`, or `seeded_state` when the operator
    * didn't pass `--asserts-seeded-state`). Distinct from `missing_tool` /
    * `missing_test_controller` (per-step tool gates) and `unsatisfied_contract`
-   * (capability predicate). The `RunnerSkipResult.requirement` field carries
+   * (a declared runner contract is unavailable). The
+   * `RunnerSkipResult.requirement` field carries
    * the unmet requirement name, including unknown forward-compatible strings.
    * Spec: adcp-client#1626.
    */
@@ -1978,9 +1979,8 @@ export type RunnerDetailedSkipReason =
    * the agent explicitly declared it does not support the capability this
    * storyboard tests (e.g. `adcp.idempotency.supported: false`). The whole
    * storyboard is skipped before any phase runs. Maps to canonical
-   * `unsatisfied_contract`: the agent's self-declared capability profile
-   * does not satisfy the storyboard's preconditions — consistent with peer
-   * skip reasons `rate_abuse_opt_out` and `missing_test_kit_contract`.
+   * `not_applicable`: this storyboard does not target the agent's
+   * self-declared capability profile.
    */
   | 'capability_unsupported'
   /**
@@ -2013,7 +2013,7 @@ export const DETAILED_SKIP_TO_CANONICAL: Record<RunnerDetailedSkipReason, Runner
   force_scenario_unsupported: 'not_applicable',
   fixture_seed_unsupported: 'not_applicable',
   fixture_unsatisfied: 'not_applicable',
-  capability_unsupported: 'unsatisfied_contract',
+  capability_unsupported: 'not_applicable',
   rate_abuse_opt_out: 'unsatisfied_contract',
   missing_test_kit_contract: 'unsatisfied_contract',
   live_side_effect_opt_in_required: 'unsatisfied_contract',

--- a/test/lib/storyboard-capability-gate.test.js
+++ b/test/lib/storyboard-capability-gate.test.js
@@ -159,7 +159,7 @@ describe('requires_capability storyboard skip gate (#933)', () => {
 
     // Structured skip block: canonical spec reason + human-readable detail
     assert.ok(step.skip, 'step.skip block present');
-    assert.equal(step.skip.reason, 'unsatisfied_contract', 'canonical spec reason');
+    assert.equal(step.skip.reason, 'not_applicable', 'canonical spec reason');
     assert.ok(
       step.skip.detail.includes('adcp.idempotency.supported'),
       `detail must mention the capability path: ${step.skip.detail}`
@@ -189,7 +189,7 @@ describe('requires_capability storyboard skip gate (#933)', () => {
     assert.equal(step.step_id, 'capability_unsupported');
     assert.equal(step.skipped, true);
     assert.equal(step.skip_reason, 'capability_unsupported');
-    assert.equal(step.skip.reason, 'unsatisfied_contract');
+    assert.equal(step.skip.reason, 'not_applicable');
     assert.ok(step.skip.detail.includes('media_buy.creative_approval_mode'));
     assert.ok(step.skip.detail.includes('auto_approve'));
     assert.ok(step.skip.detail.includes('did not declare'));
@@ -254,7 +254,7 @@ describe('requires_capability storyboard skip gate (#933)', () => {
     const step = result.phases[0].steps[0];
     assert.equal(step.skipped, true);
     assert.equal(step.skip_reason, 'capability_unsupported');
-    assert.equal(step.skip.reason, 'unsatisfied_contract');
+    assert.equal(step.skip.reason, 'not_applicable');
     assert.ok(step.skip.detail.includes('media_buy.creative_approval_mode'));
     assert.ok(step.skip.detail.includes('did not declare'));
   });
@@ -273,7 +273,7 @@ describe('requires_capability storyboard skip gate (#933)', () => {
     const step = result.phases[0].steps[0];
     assert.equal(step.skipped, true);
     assert.equal(step.skip_reason, 'capability_unsupported');
-    assert.equal(step.skip.reason, 'unsatisfied_contract');
+    assert.equal(step.skip.reason, 'not_applicable');
     assert.ok(step.skip.detail.includes('media_buy.creative_approval_mode'));
     assert.ok(step.skip.detail.includes('did not declare'));
     assert.deepEqual(calls, [], 'top-level gate should skip before dispatching');
@@ -322,7 +322,7 @@ describe('requires_capability storyboard skip gate (#933)', () => {
     const step = result.phases[0].steps[0];
     assert.equal(step.skipped, true);
     assert.equal(step.skip_reason, 'capability_unsupported');
-    assert.equal(step.skip.reason, 'unsatisfied_contract');
+    assert.equal(step.skip.reason, 'not_applicable');
     assert.ok(step.skip.detail.includes('media_buy.features.inline_creative_management'));
     assert.ok(step.skip.detail.includes('did not declare'));
   });
@@ -340,7 +340,7 @@ describe('requires_capability storyboard skip gate (#933)', () => {
     const step = result.phases[0].steps[0];
     assert.equal(step.skipped, true);
     assert.equal(step.skip_reason, 'capability_unsupported');
-    assert.equal(step.skip.reason, 'unsatisfied_contract');
+    assert.equal(step.skip.reason, 'not_applicable');
     assert.ok(step.skip.detail.includes('media_buy.features.inline_creative_management'));
     assert.ok(step.skip.detail.includes('did not declare'));
   });
@@ -359,7 +359,7 @@ describe('requires_capability storyboard skip gate (#933)', () => {
     const step = result.phases[0].steps[0];
     assert.equal(step.skipped, true);
     assert.equal(step.skip_reason, 'capability_unsupported');
-    assert.equal(step.skip.reason, 'unsatisfied_contract');
+    assert.equal(step.skip.reason, 'not_applicable');
     assert.ok(step.skip.detail.includes('media_buy.supports_proposals'));
     assert.ok(step.skip.detail.includes('false'));
   });
@@ -377,15 +377,15 @@ describe('requires_capability storyboard skip gate (#933)', () => {
     const step = result.phases[0].steps[0];
     assert.equal(step.skipped, true);
     assert.equal(step.skip_reason, 'capability_unsupported');
-    assert.equal(step.skip.reason, 'unsatisfied_contract');
+    assert.equal(step.skip.reason, 'not_applicable');
     assert.ok(step.skip.detail.includes('media_buy.supports_proposals'));
     assert.ok(step.skip.detail.includes('did not declare'));
   });
 
-  test('DETAILED_SKIP_TO_CANONICAL maps capability_unsupported to unsatisfied_contract', () => {
+  test('DETAILED_SKIP_TO_CANONICAL maps capability_unsupported to not_applicable', () => {
     assert.equal(
       DETAILED_SKIP_TO_CANONICAL['capability_unsupported'],
-      'unsatisfied_contract',
+      'not_applicable',
       'canonical spec reason for capability_unsupported'
     );
   });
@@ -474,7 +474,7 @@ describe('requires_capability `present:` matcher (#1811)', () => {
     const step = result.phases[0].steps[0];
     assert.equal(step.skipped, true);
     assert.equal(step.skip_reason, 'capability_unsupported');
-    assert.equal(step.skip.reason, 'unsatisfied_contract');
+    assert.equal(step.skip.reason, 'not_applicable');
     assert.ok(
       step.skip.detail.includes('media_buy.conversion_tracking'),
       `detail must mention the capability path: ${step.skip.detail}`
@@ -682,7 +682,7 @@ describe('requires_capability `contains:` matcher (#1817)', () => {
     const step = result.phases[0].steps[0];
     assert.equal(step.skipped, true);
     assert.equal(step.skip_reason, 'capability_unsupported');
-    assert.equal(step.skip.reason, 'unsatisfied_contract');
+    assert.equal(step.skip.reason, 'not_applicable');
     assert.ok(
       step.skip.detail.includes('media_buy.conversion_tracking.supported_targets'),
       `detail must mention capability path: ${step.skip.detail}`


### PR DESCRIPTION
Closes #2511.

## Summary

- map storyboard-level `capability_unsupported` skips to canonical `not_applicable`
- preserve the legacy detailed `skip_reason: capability_unsupported` field
- update equals, present, and contains capability-gate regression coverage
- add a patch changeset for `@adcp/sdk`

## Validation

- `npm run build:lib`
- `node --test-timeout=60000 --test test/lib/storyboard-capability-gate.test.js` — 32/32
- `npm run typecheck`
- `npm run lint` — no errors; existing warnings only
- Node 20 rerun of the two timing-sensitive MCP tests from the monolithic local run — 45/45
- pre-push formatting, typecheck, and build gate
- `npx changeset status --since=origin/main`
- `npx commitlint --from origin/main --to HEAD --verbose`
- `git diff --check origin/main...HEAD`

Three independent expert passes completed. Protocol review confirmed the mapping is required by the pinned AdCP 3.1.11 runner contract; code and test reviews found no actionable issues.
