### PR TITLE
fix: preserve storyboard assertion failures in compliance rollups

### DIFF
--- a/.changeset/fuzzy-pandas-report.md
+++ b/.changeset/fuzzy-pandas-report.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Honor storyboard-level assertion failures in compliance track and scenario verdicts, and preserve their diagnostics as structured error observations without incrementing failed-step counters.

--- a/src/lib/testing/compliance/comply.ts
+++ b/src/lib/testing/compliance/comply.ts
@@ -1405,7 +1405,10 @@ async function complyImpl(agentUrl: string, options: ComplyOptions): Promise<Com
 
       if (results.length > 0) {
         const trackResult = mapStoryboardResultsToTrackResult(track, results, profile);
-        const observations = collectObservations(track, trackResult.scenarios, profile);
+        const observations = [
+          ...trackResult.observations,
+          ...collectObservations(track, trackResult.scenarios, profile),
+        ];
         trackResult.observations = observations;
         allObservations.push(...observations);
         trackResults.push(trackResult);
@@ -1695,7 +1698,7 @@ async function runWithDegradedProfile(
     const results = grouped.get(track) ?? [];
     if (results.length > 0) {
       const trackResult = mapStoryboardResultsToTrackResult(track, results, profile);
-      const obs = collectObservations(track, trackResult.scenarios, profile);
+      const obs = [...trackResult.observations, ...collectObservations(track, trackResult.scenarios, profile)];
       trackResult.observations = obs;
       allObservations.push(...obs);
       trackResults.push(trackResult);

--- a/src/lib/testing/compliance/storyboard-tracks.ts
+++ b/src/lib/testing/compliance/storyboard-tracks.ts
@@ -57,6 +57,32 @@ export function mapStoryboardResultsToTrackResult(
 
   for (const sbResult of storyboardResults) {
     totalDuration += sbResult.total_duration_ms;
+    const storyboardAssertionFailures = (sbResult.assertions ?? []).filter(
+      assertion => !assertion.passed && assertion.scope === 'storyboard'
+    );
+
+    for (const assertion of storyboardAssertionFailures) {
+      observations.push({
+        category: 'error_compliance',
+        severity: 'error',
+        track,
+        message: 'A storyboard-scoped compliance assertion failed.',
+        evidence: {
+          assertion_id: assertion.assertion_id,
+          description: assertion.description,
+          scope: assertion.scope,
+          ...(assertion.error !== undefined && { error: assertion.error }),
+          ...(assertion.hint !== undefined && { hint: assertion.hint }),
+          ...(assertion.observation_count !== undefined && { observation_count: assertion.observation_count }),
+          ...(assertion.status !== undefined && { status: assertion.status }),
+        },
+        source: {
+          kind: 'storyboard',
+          code: 'storyboard-assertion-failed',
+          storyboard_id: sbResult.storyboard_id,
+        },
+      });
+    }
 
     for (const phase of sbResult.phases) {
       const steps: TestStepResult[] = phase.steps.map(stepResult => mapStepToTestStep(stepResult));
@@ -74,6 +100,25 @@ export function mapStoryboardResultsToTrackResult(
       };
 
       scenarios.push(testResult);
+    }
+
+    // Phase scenarios retain their own verdicts. When the authoritative
+    // storyboard verdict fails despite every phase passing (for example, an
+    // onEnd assertion failure), add one storyboard-level scenario instead of
+    // falsely attributing the same failure to every phase.
+    if (!sbResult.overall_passed && sbResult.passed_count > 0 && sbResult.phases.every(phase => phase.passed)) {
+      scenarios.push({
+        agent_url: sbResult.agent_url,
+        scenario: `${sbResult.storyboard_id}/storyboard` as any,
+        overall_passed: false,
+        steps: [],
+        summary:
+          storyboardAssertionFailures.length > 0
+            ? `${sbResult.storyboard_title}: ${storyboardAssertionFailures.length} storyboard assertion(s) failed`
+            : `${sbResult.storyboard_title}: storyboard-level verdict failed`,
+        total_duration_ms: 0,
+        tested_at: sbResult.tested_at,
+      });
     }
   }
 
@@ -169,6 +214,10 @@ function computeTrackStatus(results: StoryboardResult[]): TrackStatus {
   if (totalSteps === 0) return 'skip';
   if (totalSteps === totalSkipped) return 'skip';
   if (totalFailed > 0) return totalPassed === 0 ? 'fail' : 'partial';
+  // Storyboard-scoped assertions are not steps, so their failures correctly
+  // leave failed_count at zero. The runner's overall verdict is authoritative:
+  // some steps passed, but the cross-step invariant did not.
+  if (results.some(result => !result.overall_passed)) return 'partial';
   const hasFixtureUnavailable = results.some(result =>
     (result.passes?.flatMap(pass => pass.phases) ?? result.phases).some(phase =>
       phase.steps.some(step => step.skip?.reason === 'fixture_unavailable')

--- a/src/lib/testing/compliance/types.ts
+++ b/src/lib/testing/compliance/types.ts
@@ -279,13 +279,11 @@ export type ObservationSeverity = 'info' | 'suggestion' | 'warning' | 'error';
  *   storyboard pipeline (e.g. auth-failure detection on a 401
  *   discovery response). No storyboard coordinates apply.
  *
- * **`storyboard_id` shape note.** This field is sourced from
- * `TestResult.scenario`, which the storyboard runner constructs as
- * `${storyboard_id}/${phase_id}` (see `storyboard-tracks.ts`). So
- * `source.storyboard_id` is a composite "storyboard/phase" identifier,
- * not the bare storyboard ID. Greppable against the storyboard YAML
- * either way; the composite form gives extra phase-level specificity
- * even when `step_id` is also present.
+ * **`storyboard_id` shape note.** For `storyboard_step` sources this field
+ * is sourced from `TestResult.scenario`, which the storyboard runner
+ * constructs as `${storyboard_id}/${phase_id}` (see
+ * `storyboard-tracks.ts`). For storyboard-wide sources it is the bare
+ * storyboard ID because no single phase owns the finding.
  *
  * **`code` casing note.** `code` is intentionally kebab-case
  * (e.g. `slow-response`, `missing-valid-actions`) to match storyboard

--- a/test/lib/comply-abort.test.js
+++ b/test/lib/comply-abort.test.js
@@ -9,7 +9,8 @@ const http = require('http');
 const os = require('os');
 const path = require('path');
 
-const { comply } = require('../../dist/lib/testing/compliance/index.js');
+const { comply, formatComplianceResultsJSON } = require('../../dist/lib/testing/compliance/index.js');
+const { registerAssertion } = require('../../dist/lib/testing/storyboard/assertions.js');
 const { ADCP_VERSION } = require('../../dist/lib/version.js');
 
 function writeTimeoutComplianceCache() {
@@ -57,6 +58,49 @@ phases:
         sample_request:
           delay_ms: ${delayMs}
 `;
+}
+
+function writeAssertionFailureComplianceCache() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'adcp-comply-assertion-'));
+  fs.mkdirSync(path.join(dir, 'universal'), { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'index.json'),
+    JSON.stringify({
+      adcp_version: ADCP_VERSION,
+      generated_at: new Date().toISOString(),
+      universal: ['assertion-only-failure'],
+      protocols: [],
+      specialisms: [],
+    })
+  );
+  fs.writeFileSync(
+    path.join(dir, 'universal', 'assertion-only-failure.yaml'),
+    `id: assertion_only_failure
+version: 1.0.0
+title: Assertion-only failure
+category: testing
+track: core
+summary: ''
+narrative: ''
+agent:
+  interaction_model: '*'
+  capabilities: []
+caller:
+  role: buyer_agent
+invariants:
+  enable:
+    - test.aggregate-assertion-failure
+phases:
+  - id: flow
+    title: Flow
+    steps:
+      - id: passing-step
+        title: Passing step
+        task: __test_probe
+        sample_request: {}
+`
+  );
+  return dir;
 }
 
 async function startTimeoutAgent(options = {}) {
@@ -195,6 +239,59 @@ describe('comply() signal option', () => {
         return true;
       }
     );
+  });
+});
+
+describe('comply() storyboard assertion aggregation', () => {
+  test('preserves assertion-only failures in the public ComplianceResult JSON', async () => {
+    registerAssertion({
+      id: 'test.aggregate-assertion-failure',
+      onEnd: () => [
+        {
+          passed: false,
+          description: 'Cross-step invariant',
+          error: 'Observed a forbidden cross-step transition',
+          status: 'fail',
+        },
+      ],
+    });
+    const complianceDir = writeAssertionFailureComplianceCache();
+    const agent = await startTimeoutAgent();
+
+    try {
+      const result = await comply(agent.url, {
+        allow_http: true,
+        complianceDir,
+        storyboards: ['assertion_only_failure'],
+      });
+      const json = JSON.parse(formatComplianceResultsJSON(result));
+      const track = json.tracks.find(candidate => candidate.track === 'core');
+      const trackObservation = track.observations.find(
+        observation => observation.source?.code === 'storyboard-assertion-failed'
+      );
+      const rootObservation = json.observations.find(
+        observation => observation.source?.code === 'storyboard-assertion-failed'
+      );
+      const testedTrackObservation = json.tested_tracks[0].observations.find(
+        observation => observation.source?.code === 'storyboard-assertion-failed'
+      );
+
+      assert.strictEqual(json.overall_status, 'partial');
+      assert.strictEqual(track.status, 'partial');
+      assert.ok(track.scenarios.some(scenario => !scenario.overall_passed));
+      assert.strictEqual(json.summary.steps_passed, 1);
+      assert.strictEqual(json.summary.steps_failed, 0);
+      assert.strictEqual(json.failures, undefined);
+      for (const observation of [trackObservation, rootObservation, testedTrackObservation]) {
+        assert.ok(observation, 'expected assertion failure observation at every aggregate projection');
+        assert.strictEqual(observation.severity, 'error');
+        assert.strictEqual(observation.evidence.assertion_id, 'test.aggregate-assertion-failure');
+        assert.strictEqual(observation.evidence.error, 'Observed a forbidden cross-step transition');
+      }
+    } finally {
+      await closeServer(agent.server);
+      fs.rmSync(complianceDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/test/lib/storyboard-track-silent-rollup.test.js
+++ b/test/lib/storyboard-track-silent-rollup.test.js
@@ -19,13 +19,20 @@ const assert = require('node:assert');
 const { mapStoryboardResultsToTrackResult } = require('../../dist/lib/testing/compliance/storyboard-tracks.js');
 
 /** Minimal StoryboardResult factory — only the fields the rollup reads. */
-function sbResult({ passed = 1, failed = 0, skipped = 0, assertions = [] } = {}) {
+function sbResult({
+  passed = 1,
+  failed = 0,
+  skipped = 0,
+  overall_passed = failed === 0,
+  phases = [],
+  assertions = [],
+} = {}) {
   return {
     storyboard_id: 'fixture',
     storyboard_title: 'fixture',
     agent_url: 'https://example.test',
-    overall_passed: failed === 0,
-    phases: [],
+    overall_passed,
+    phases,
     passed_count: passed,
     failed_count: failed,
     skipped_count: skipped,
@@ -38,6 +45,166 @@ function sbResult({ passed = 1, failed = 0, skipped = 0, assertions = [] } = {})
 const PROFILE = { name: 'fixture', tools: [] };
 
 describe('TrackStatus silent rollup', () => {
+  it('preserves a storyboard-scoped assertion failure when every executed step passed', () => {
+    const result = mapStoryboardResultsToTrackResult(
+      'governance',
+      [
+        sbResult({
+          passed: 1,
+          failed: 0,
+          overall_passed: false,
+          phases: [
+            {
+              phase_id: 'lifecycle',
+              phase_title: 'Lifecycle',
+              passed: true,
+              duration_ms: 5,
+              steps: [
+                {
+                  step_id: 'read-state',
+                  phase_id: 'lifecycle',
+                  title: 'Read state',
+                  task: 'get_media_buys',
+                  passed: true,
+                  duration_ms: 5,
+                  validations: [],
+                  context: {},
+                },
+              ],
+            },
+          ],
+          assertions: [
+            {
+              assertion_id: 'status.monotonic',
+              passed: false,
+              description: 'Resource statuses transition only along spec lifecycle edges',
+              scope: 'storyboard',
+              error: 'Observed an illegal active -> pending transition',
+              status: 'fail',
+            },
+          ],
+        }),
+      ],
+      PROFILE
+    );
+
+    assert.strictEqual(result.status, 'partial');
+    assert.strictEqual(result.scenarios[0].overall_passed, true);
+    assert.strictEqual(result.scenarios[0].steps.filter(step => !step.passed).length, 0);
+    assert.strictEqual(result.scenarios[1].scenario, 'fixture/storyboard');
+    assert.strictEqual(result.scenarios[1].overall_passed, false);
+    assert.deepStrictEqual(result.scenarios[1].steps, []);
+    assert.deepStrictEqual(result.observations, [
+      {
+        category: 'error_compliance',
+        severity: 'error',
+        track: 'governance',
+        message: 'A storyboard-scoped compliance assertion failed.',
+        evidence: {
+          assertion_id: 'status.monotonic',
+          description: 'Resource statuses transition only along spec lifecycle edges',
+          scope: 'storyboard',
+          error: 'Observed an illegal active -> pending transition',
+          status: 'fail',
+        },
+        source: {
+          kind: 'storyboard',
+          code: 'storyboard-assertion-failed',
+          storyboard_id: 'fixture',
+        },
+      },
+    ]);
+  });
+
+  it('surfaces an authoritative failed storyboard verdict even without assertion diagnostics', () => {
+    const result = mapStoryboardResultsToTrackResult(
+      'core',
+      [
+        sbResult({
+          passed: 1,
+          overall_passed: false,
+          phases: [
+            {
+              phase_id: 'optional-only',
+              phase_title: 'Optional only',
+              passed: true,
+              duration_ms: 0,
+              steps: [],
+            },
+          ],
+        }),
+      ],
+      PROFILE
+    );
+
+    assert.strictEqual(result.status, 'partial');
+    assert.deepStrictEqual(
+      result.scenarios.map(scenario => [scenario.scenario, scenario.overall_passed]),
+      [
+        ['fixture/optional-only', true],
+        ['fixture/storyboard', false],
+      ]
+    );
+    assert.deepStrictEqual(result.observations, []);
+  });
+
+  it('keeps an all-skipped failed storyboard neutral without a synthetic failure', () => {
+    const result = mapStoryboardResultsToTrackResult(
+      'core',
+      [
+        sbResult({
+          passed: 0,
+          skipped: 1,
+          overall_passed: false,
+          phases: [
+            {
+              phase_id: 'optional-only',
+              phase_title: 'Optional only',
+              passed: true,
+              duration_ms: 0,
+              steps: [],
+            },
+          ],
+        }),
+      ],
+      PROFILE
+    );
+
+    assert.strictEqual(result.status, 'skip');
+    assert.deepStrictEqual(
+      result.scenarios.map(scenario => [scenario.scenario, scenario.overall_passed]),
+      [['fixture/optional-only', true]]
+    );
+    assert.deepStrictEqual(result.observations, []);
+  });
+
+  it('does not duplicate step-scoped assertion failures as storyboard observations', () => {
+    const result = mapStoryboardResultsToTrackResult(
+      'core',
+      [
+        sbResult({
+          passed: 0,
+          failed: 1,
+          overall_passed: false,
+          assertions: [
+            {
+              assertion_id: 'context.no_secret_echo',
+              passed: false,
+              description: 'Response must not echo a secret',
+              scope: 'step',
+              step_id: 'read-state',
+              error: 'Secret echoed',
+            },
+          ],
+        }),
+      ],
+      PROFILE
+    );
+
+    assert.strictEqual(result.status, 'fail');
+    assert.deepStrictEqual(result.observations, []);
+  });
+
   it("emits 'silent' when every observation-bearing assertion record reports zero observations", () => {
     const result = mapStoryboardResultsToTrackResult(
       'governance',


### PR DESCRIPTION
Fixes #2520

## Summary

- honor authoritative storyboard verdicts when storyboard-scoped assertions fail without failed steps
- represent the failure once as a storyboard-level scenario while preserving truthful phase and all-skipped results
- preserve structured assertion observations through canonical track, tested-track, degraded, and top-level aggregation
- document storyboard-wide observation provenance and add a patch changeset

## Validation

- three expert reviews: protocol, code/security, and Node.js testing (all approved)
- formatting and TypeScript typecheck
- library build
- 13,145 fast tests (13,138 passed, 7 skipped)
- 64 slow tests
- 30 ESLint-plugin tests
- focused serialized ComplianceResult and mapper regressions