### PR TITLE
fix(cli): reject replayed request-signing vectors

### DIFF
--- a/.changeset/fix-signing-cli-replay-preload.md
+++ b/.changeset/fix-signing-cli-replay-preload.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Reject replay test vectors in `adcp signing verify-vector` by preloading nonce fixtures with the request's canonical target scope.

--- a/bin/adcp-signing.js
+++ b/bin/adcp-signing.js
@@ -5,6 +5,7 @@ const { readFileSync, writeFileSync, existsSync } = require('node:fs');
 const path = require('node:path');
 
 const {
+  canonicalTargetUri,
   InMemoryReplayStore,
   InMemoryRevocationStore,
   RequestSignatureError,
@@ -136,23 +137,24 @@ async function verifyVector(argv) {
   const replayStore = new InMemoryReplayStore();
   const revocationStore = new InMemoryRevocationStore();
   const state = vector.test_harness_state ?? {};
-  if (state.replay_cache_entries) {
-    for (const entry of state.replay_cache_entries) {
-      replayStore.preload(entry.keyid, entry.nonce, entry.ttl_seconds, now);
-    }
-  }
-  if (state.revocation_list) revocationStore.load(state.revocation_list);
-  if (state.replay_cache_per_keyid_cap_hit) {
-    replayStore.setCapHitForTesting(state.replay_cache_per_keyid_cap_hit.keyid);
-  }
-
-  const jwksEntries = vector.jwks_override
-    ? vector.jwks_override.keys
-    : (vector.jwks_ref ?? []).map(kid => keysByKid.get(kid)).filter(Boolean);
-  const jwks = new StaticJwksResolver(jwksEntries);
-  const operation = new URL(vector.request.url).pathname.split('/').filter(Boolean).pop();
-
   try {
+    if (state.replay_cache_entries) {
+      const scope = canonicalTargetUri(vector.request.url);
+      for (const entry of state.replay_cache_entries) {
+        replayStore.preload(entry.keyid, scope, entry.nonce, entry.ttl_seconds, now);
+      }
+    }
+    if (state.revocation_list) revocationStore.load(state.revocation_list);
+    if (state.replay_cache_per_keyid_cap_hit) {
+      replayStore.setCapHitForTesting(state.replay_cache_per_keyid_cap_hit.keyid);
+    }
+
+    const jwksEntries = vector.jwks_override
+      ? vector.jwks_override.keys
+      : (vector.jwks_ref ?? []).map(kid => keysByKid.get(kid)).filter(Boolean);
+    const jwks = new StaticJwksResolver(jwksEntries);
+    const operation = new URL(vector.request.url).pathname.split('/').filter(Boolean).pop();
+
     const verified = await verifyRequestSignature(vector.request, {
       capability: vector.verifier_capability,
       jwks,

--- a/test/lib/cli-signing-verify-vector.test.js
+++ b/test/lib/cli-signing-verify-vector.test.js
@@ -1,0 +1,72 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { spawnSync } = require('node:child_process');
+const { mkdtempSync, readFileSync, rmSync, writeFileSync } = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const CLI = path.resolve(__dirname, '../../bin/adcp.js');
+const VECTOR_ROOT = path.resolve(__dirname, '../../compliance/cache/latest/test-vectors/request-signing');
+const KEYS = path.join(VECTOR_ROOT, 'keys.json');
+
+function verifyVectorPath(vectorPath) {
+  return spawnSync(process.execPath, [CLI, 'signing', 'verify-vector', '--vector', vectorPath, '--keys', KEYS], {
+    encoding: 'utf8',
+    timeout: 45_000,
+  });
+}
+
+function verifyVector(vector) {
+  return verifyVectorPath(path.join(VECTOR_ROOT, vector));
+}
+
+function verifyReplayVectorWithUrl(url) {
+  const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'adcp-signing-vector-'));
+  try {
+    const source = path.join(VECTOR_ROOT, 'negative/016-replayed-nonce.json');
+    const vector = JSON.parse(readFileSync(source, 'utf8'));
+    vector.request.url = url;
+    const vectorPath = path.join(tmpDir, 'vector.json');
+    writeFileSync(vectorPath, JSON.stringify(vector));
+    return verifyVectorPath(vectorPath);
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+function parseOutput(result) {
+  assert.ok(result.stdout, `expected JSON on stdout. stderr: ${result.stderr}`);
+  return JSON.parse(result.stdout);
+}
+
+test('signing verify-vector accepts a positive request-signing vector', () => {
+  const result = verifyVector('positive/001-basic-post.json');
+
+  assert.strictEqual(result.status, 0, `expected exit 0, got ${result.status}. stderr: ${result.stderr}`);
+  assert.strictEqual(parseOutput(result).outcome, 'accepted');
+});
+
+test('signing verify-vector rejects a preloaded replay nonce', () => {
+  const result = verifyVector('negative/016-replayed-nonce.json');
+
+  assert.strictEqual(result.status, 1, `expected exit 1, got ${result.status}. stderr: ${result.stderr}`);
+  const output = parseOutput(result);
+  assert.strictEqual(output.outcome, 'rejected');
+  assert.strictEqual(output.error_code, 'request_signature_replayed');
+});
+
+test('signing verify-vector canonicalizes replay scope before preloading', () => {
+  const result = verifyReplayVectorWithUrl('https://seller.example.com:443/adcp/create_media_buy');
+
+  assert.strictEqual(result.status, 1, `expected exit 1, got ${result.status}. stderr: ${result.stderr}`);
+  assert.strictEqual(parseOutput(result).error_code, 'request_signature_replayed');
+});
+
+test('signing verify-vector formats replay-state URL errors as JSON', () => {
+  const result = verifyReplayVectorWithUrl('https://user:pass@seller.example.com/adcp/create_media_buy');
+
+  assert.strictEqual(result.status, 1, `expected exit 1, got ${result.status}. stderr: ${result.stderr}`);
+  const output = parseOutput(result);
+  assert.strictEqual(output.outcome, 'rejected');
+  assert.strictEqual(output.error_code, 'request_signature_header_malformed');
+});


### PR DESCRIPTION
## Summary

- preload request-signing replay fixtures under the canonical target URI scope used by the verifier
- keep replay-state canonicalization failures on the CLI structured JSON rejection path
- cover positive, replayed, canonical-equivalent, and malformed replay-state vectors through the real CLI subprocess
- include a patch changeset for the published CLI fix

## Root cause

`InMemoryReplayStore.preload` gained a `scope` argument, but the untyped signing CLI retained the old four-argument call. The shifted values populated the wrong composite replay key, allowing vector 016 to be accepted.

## Validation

- `npm run ci:quick`
- `node --test-timeout=60000 --test test/lib/cli-signing-verify-vector.test.js`
- DX, protocol, code, and security expert reviews: no remaining actionable findings

Closes #2517
