### PR TITLE
docs(sdk): fix getProducts JSDoc examples to use schema-valid requests

### DIFF
--- a/.changeset/fix-getproducts-jsdoc-example.md
+++ b/.changeset/fix-getproducts-jsdoc-example.md
@@ -1,0 +1,7 @@
+---
+"@adcp/sdk": patch
+---
+
+docs(sdk): fix getProducts JSDoc examples to use schema-valid requests
+
+All `getProducts` JSDoc examples now include the required `buying_mode` field and omit `promoted_offering`, which is not a defined field on `GetProductsRequest`. Affected files: `SingleAgentClient`, `AgentClient`, and `testing/test-helpers`.

--- a/src/lib/core/AgentClient.ts
+++ b/src/lib/core/AgentClient.ts
@@ -627,7 +627,7 @@ export class AgentClient {
    * Compatibility translation for an older seller happens below this method.
    *
    * ```ts
-   * const { data: { products } } = await agent.getProducts({ brief: '...' });
+   * const { data: { products } } = await agent.getProducts({ buying_mode: 'brief', brief: '...' });
    * const product = products[0];
    * const format = product.format_options[0];
    *
@@ -1260,7 +1260,7 @@ export class AgentClient {
    * @example
    * ```typescript
    * const agent = multiClient.agent('my-agent');
-   * await agent.getProducts({ brief: 'Tech products' });
+   * await agent.getProducts({ buying_mode: 'brief', brief: 'Tech products' });
    *
    * // Continue the conversation
    * const refined = await agent.continueConversation(

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -4208,8 +4208,8 @@ export class SingleAgentClient {
    * ```typescript
    * const products = await client.getProducts(
    *   {
+   *     buying_mode: 'brief',
    *     brief: 'Premium coffee brands for millennials',
-   *     promoted_offering: 'Artisan coffee blends'
    *   },
    *   (context) => {
    *     if (context.inputRequest.field === 'budget') return 50000;
@@ -5577,7 +5577,7 @@ export class SingleAgentClient {
    * @example
    * ```typescript
    * const agent = new ADCPClient(config);
-   * const initial = await agent.getProducts({ brief: 'Tech products' });
+   * const initial = await agent.getProducts({ buying_mode: 'brief', brief: 'Tech products' });
    *
    * // Continue the conversation — use the server-returned contextId, not
    * // the client-minted correlation taskId.

--- a/src/lib/testing/test-helpers.ts
+++ b/src/lib/testing/test-helpers.ts
@@ -68,8 +68,8 @@ export const TEST_AGENT_NO_AUTH_A2A_CONFIG: AgentConfig = {
  *
  * // Simple getProducts call
  * const result = await testAgent.getProducts({
+ *   buying_mode: 'brief',
  *   brief: 'Coffee subscription service for busy professionals',
- *   promoted_offering: 'Premium monthly coffee deliveries'
  * });
  *
  * if (result.success) {
@@ -104,8 +104,8 @@ export const testAgent: AgentClient = new ADCPMultiAgentClient([TEST_AGENT_MCP_C
  * import { testAgentA2A } from '@adcp/sdk/testing';
  *
  * const result = await testAgentA2A.getProducts({
+ *   buying_mode: 'brief',
  *   brief: 'Sustainable fashion brands',
- *   promoted_offering: 'Eco-friendly clothing'
  * });
  * ```
  *
@@ -128,8 +128,8 @@ export const testAgentA2A: AgentClient = new ADCPMultiAgentClient([TEST_AGENT_A2
  * // This will fail with authentication error
  * try {
  *   const result = await testAgentNoAuth.getProducts({
+ *     buying_mode: 'brief',
  *     brief: 'Coffee subscription',
- *     promoted_offering: 'Premium coffee'
  *   });
  * } catch (error) {
  *   console.log('Expected auth error:', error.message);
@@ -157,10 +157,10 @@ export const testAgentNoAuth: AgentClient = new ADCPMultiAgentClient([TEST_AGENT
  * import { testAgentA2A } from '@adcp/sdk/testing';
  *
  * // This works (has auth)
- * const authResult = await testAgentA2A.getProducts({ brief: 'Test' });
+ * const authResult = await testAgentA2A.getProducts({ buying_mode: 'brief', brief: 'Test' });
  *
  * // This fails (no auth)
- * const noAuthResult = await testAgentNoAuthA2A.getProducts({ brief: 'Test' });
+ * const noAuthResult = await testAgentNoAuthA2A.getProducts({ buying_mode: 'brief', brief: 'Test' });
  * ```
  *
  * @remarks
@@ -185,8 +185,8 @@ export const testAgentNoAuthA2A: AgentClient = new ADCPMultiAgentClient([TEST_AG
  *
  * // Or use agent collection for parallel operations
  * const results = await testAgentClient.allAgents().getProducts({
+ *   buying_mode: 'brief',
  *   brief: 'Premium coffee brands',
- *   promoted_offering: 'Artisan coffee'
  * });
  * ```
  *


### PR DESCRIPTION
Closes #2532

All `getProducts` JSDoc `@example` blocks that called the method without the required `buying_mode` field, or with the invalid `promoted_offering` field, are corrected. Nine call sites across three files are fixed; a patch changeset is included.

**Root cause:** `GetProductsRequest.buying_mode` is a required field (`'brief' | 'wholesale' | 'refine'`, no `?`) per `src/lib/types/tools.generated.ts:41`. `promoted_offering` is not defined on `GetProductsRequest` and was only silently tolerated due to the `[k: string]: unknown | undefined` index signature. `brand` (the issue's other concern) was already optional; the fix simply omits it from examples rather than implying it is required.

**What changed:**
- `src/lib/core/SingleAgentClient.ts` — primary `@example` on `getProducts` (removed `promoted_offering`, added `buying_mode: 'brief'`); secondary example in `continueConversation` `@example`
- `src/lib/core/AgentClient.ts` — inline snippet in `createMediaBuy` JSDoc; `continueConversation` `@example`
- `src/lib/testing/test-helpers.ts` — five `@example` blocks across `testAgent`, `testAgentA2A`, `testAgentNoAuth`, `testAgentNoAuthA2A`, and `testAgentClient` exports

**What was tested:**
- `npm run format:check` — passed
- `npm run typecheck` / `npm run ci:quick` — pre-existing environment issues (`tsx` not installed, stale `@types/node`) prevent full CI locally; these failures exist on `main` and are unrelated to JSDoc changes
- All nine fixed call sites grep-verified to include `buying_mode` after the change

**Pre-PR review:**
- code-reviewer: approved — `buying_mode: 'brief'` confirmed schema-valid; `promoted_offering` confirmed absent from `GetProductsRequest` GA schema; patch changeset level correct
- docs-expert: approved — all nine sites in the three targeted files verified correct; non-breaking

**Known follow-up (out of scope for this PR):**
`ADCPMultiAgentClient.ts` (~lines 65, 587, 616, 662), `advanced.ts` (~line 24), and `errors/index.ts` (~line 241) also have `getProducts` JSDoc snippets missing `buying_mode`. These were not part of the original issue scope and are not touched here. A follow-up issue should capture them.

**Triage-managed PR.** This bot does not currently iterate on review comments or PR conversation threads (only on the source issue). To unblock:

- **Push fixup commits directly:** `gh pr checkout <num>` → fix → push.
- **Or request a new first draft PR:** comment `/triage execute` on the source issue only when no triage-managed PR is already open. Triage does not update existing PRs.

See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121) for context.

Session: https://claude.ai/code/session_01Sbg2qCWnhzbHfFtYJRRkPg

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sbg2qCWnhzbHfFtYJRRkPg)_