### PR TITLE
docs(sdk): fix getProducts request example

### DIFF
--- a/.changeset/fix-get-products-jsdoc-example.md
+++ b/.changeset/fix-get-products-jsdoc-example.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Correct the `getProducts` API example to use a schema-valid brief request and clarify that brand context is optional.

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -4200,6 +4200,10 @@ export class SingleAgentClient {
   /**
    * Discover available advertising products
    *
+   * `brand` is optional when `catalog` is absent, including for the brief-only
+   * request below. Requests with `catalog` must include `brand`; otherwise,
+   * include it whenever discovery should account for a specific advertiser.
+   *
    * @param params - Product discovery parameters
    * @param inputHandler - Handler for clarification requests
    * @param options - Task execution options
@@ -4208,8 +4212,8 @@ export class SingleAgentClient {
    * ```typescript
    * const products = await client.getProducts(
    *   {
-   *     brief: 'Premium coffee brands for millennials',
-   *     promoted_offering: 'Artisan coffee blends'
+   *     buying_mode: 'brief',
+   *     brief: 'Find podcast and streaming audio placements for an eco-friendly bike subscription launch'
    *   },
    *   (context) => {
    *     if (context.inputRequest.field === 'budget') return 50000;

--- a/src/type-tests/canonical-creative-client.type-test.ts
+++ b/src/type-tests/canonical-creative-client.type-test.ts
@@ -186,6 +186,18 @@ const canonicalGetProductsRequest: CanonicalGetProductsRequest = {
 };
 agent.getProducts(canonicalGetProductsRequest);
 single.getProducts(canonicalGetProductsRequest);
+
+// Keep the SingleAgentClient.getProducts JSDoc example schema-valid and show
+// that advertiser brand context is optional for brief-based discovery.
+const getProductsJSDocExample = {
+  buying_mode: 'brief',
+  brief: 'Find podcast and streaming audio placements for an eco-friendly bike subscription launch',
+} satisfies CanonicalGetProductsRequest;
+single.getProducts(getProductsJSDocExample);
+single.getProducts({
+  ...getProductsJSDocExample,
+  brand: { domain: 'pedal-forward.example' },
+});
 // @ts-expect-error Primary product discovery cannot request legacy format_ids.
 agent.getProducts({ buying_mode: 'wholesale', fields: ['format_ids'] });
 // @ts-expect-error Generic primary execution enforces the same request boundary.


### PR DESCRIPTION
## Summary

- replace the invalid promoted_offering getProducts example with a schema-valid brief request
- include required buying_mode
- document that brand is optional only when catalog is absent
- add typechecked unbranded and branded example coverage
- add an @adcp/sdk patch changeset

## Verification

- pinned Prettier check
- npm run typecheck
- npm run build:lib
- git diff --check
- independent code review: no remaining findings

Closes #2532