### PR TITLE
feat(testing): add expect_no_webhook storyboard assertion

### DIFF
--- a/.changeset/expect-no-webhook.md
+++ b/.changeset/expect-no-webhook.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Add an `expect_no_webhook` storyboard assertion that verifies zero matching webhook deliveries during a bounded observation window.

--- a/docs/guides/VALIDATE-YOUR-AGENT.md
+++ b/docs/guides/VALIDATE-YOUR-AGENT.md
@@ -92,6 +92,31 @@ npx @adcp/sdk@adcp-3.1 storyboard run http://localhost:3001/mcp --json > report.
 - `--auth <token>` — bearer token (also accepts `$ADCP_AUTH_TOKEN`)
 - `--oauth` — run the browser OAuth flow inline when the saved alias has no valid tokens (MCP only; equivalent to `adcp --save-auth <alias> <url> --oauth` then re-running)
 
+**Authoring webhook assertions.** Webhook storyboard pseudo-steps share the
+receiver URL and filter contract. Use `triggered_by` to scope the observation
+to the earlier step's `{{runner.webhook_url:<step_id>}}`; add `filter.body`
+entries for dotted-path payload matching.
+
+`expect_no_webhook` asserts silence: it passes only when zero matching
+deliveries arrive during the observation window (five seconds by default) and
+fails on the first match with `unexpected_webhook_received`. It deliberately
+does not validate a payload schema or require an `idempotency_key` on the
+passing path because no payload exists to inspect.
+
+```yaml
+- id: expect_sync_silence
+  task: expect_no_webhook
+  triggered_by: sync_get_products_with_webhook_config_success
+  filter:
+    body:
+      operation_id: op_sync_get_products_no_webhook
+  timeout_seconds: 5
+```
+
+All `expect_webhook*` steps require `webhook_receiver` runner support. If the
+`triggered_by` step is missing, skipped, or failed, the assertion skips with
+`prerequisite_failed` instead of treating the absence as a passing result.
+
 **Hosted compliance bundles.** Programmatic runners that mount compliance
 assets outside the installed SDK can pair the storyboard cache and schema cache
 explicitly:

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -2186,6 +2186,7 @@ function collectCapabilityNotices(storyboard: Storyboard, profile: AgentProfile 
   // unless it actually exercises the delivery path.
   const WEBHOOK_STEP_TASKS = new Set([
     'expect_webhook',
+    'expect_no_webhook',
     'expect_webhook_retry_keys_stable',
     'expect_webhook_signature_valid',
   ]);

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -776,7 +776,8 @@ export interface StoryboardStep {
   contributes_if?: string;
   // ──────────────────────────────────────────────────────────
   // Webhook-assertion step fields (only used when task is one
-  // of `expect_webhook`, `expect_webhook_retry_keys_stable`,
+  // of `expect_webhook`, `expect_no_webhook`,
+  // `expect_webhook_retry_keys_stable`, or
   // `expect_webhook_signature_valid`). The runner interprets
   // these pseudo-tasks as receiver observations, not agent calls.
   // ──────────────────────────────────────────────────────────
@@ -788,7 +789,7 @@ export interface StoryboardStep {
   triggered_by?: string;
   /** Match predicate scoped to the per-step URL and/or body fields. */
   filter?: WebhookFilterSpec;
-  /** Seconds to wait for the first matching delivery. Default 30. */
+  /** Seconds to observe for a matching delivery. Default 5 for `expect_no_webhook`, otherwise 30. */
   timeout_seconds?: number;
   /** When true (default) assert `idempotency_key` is present and pattern-valid. */
   expect_idempotency_key?: boolean;
@@ -1350,7 +1351,7 @@ export interface StoryboardValidation {
 // ────────────────────────────────────────────────────────────
 // Webhook-assertion step types
 //
-// The three `expect_webhook*` tasks are pseudo-tasks: they do not drive the
+// The four `expect_webhook*` tasks are pseudo-tasks: they do not drive the
 // agent over MCP. Instead the runner uses them to observe / assert on the
 // webhook deliveries a prior step triggered. Graded only when the storyboard
 // declares the `webhook_receiver_runner` contract and the runner hosts a
@@ -1390,6 +1391,8 @@ export type WebhookAssertionErrorCode =
   | 'missing_idempotency_key'
   | 'invalid_idempotency_key_format'
   | 'duplicate_webhook_on_replay'
+  // expect_no_webhook
+  | 'unexpected_webhook_received'
   // expect_webhook_retry_keys_stable
   | 'insufficient_retries'
   | 'idempotency_key_rotated'

--- a/src/lib/testing/storyboard/webhook-assertions.ts
+++ b/src/lib/testing/storyboard/webhook-assertions.ts
@@ -1,7 +1,7 @@
 /**
  * Webhook-assertion pseudo-tasks.
  *
- * Three step `task` values graded by observing the runner's webhook
+ * Four step `task` values graded by observing the runner's webhook
  * receiver rather than by calling the agent:
  *
  *   - `expect_webhook`
@@ -9,6 +9,10 @@
  *       well-formed `idempotency_key`. Optional: body-schema validation and
  *       max-deliveries-per-logical-event cap (catches duplicate-side-effect
  *       bugs on replay).
+ *
+ *   - `expect_no_webhook`
+ *       Assert that no matching webhook arrives during the observation
+ *       window. Resolves as soon as an unexpected delivery is observed.
  *
  *   - `expect_webhook_retry_keys_stable`
  *       Configure the receiver to reject the first N deliveries with 5xx so
@@ -82,11 +86,13 @@ function getSharedRevocationStore(runnerVars: RunnerVariables, override: Revocat
 
 export const WEBHOOK_ASSERTION_TASKS: Set<string> = new Set([
   'expect_webhook',
+  'expect_no_webhook',
   'expect_webhook_retry_keys_stable',
   'expect_webhook_signature_valid',
 ]);
 
 const DEFAULT_TIMEOUT_SECONDS = 30;
+const DEFAULT_NO_WEBHOOK_TIMEOUT_SECONDS = 5;
 const DEFAULT_RETRY_REPLAY_TIMEOUT_SECONDS = 90;
 const DEFAULT_RETRY_COUNT = 3;
 const DEFAULT_RETRY_HTTP_STATUS = 503;
@@ -172,7 +178,7 @@ export function armWebhookAssertions(
 }
 
 /**
- * Dispatch any of the three webhook-assertion pseudo-tasks.
+ * Dispatch any of the four webhook-assertion pseudo-tasks.
  *
  * Called by runner.executeStep when the step's `task` is in
  * `WEBHOOK_ASSERTION_TASKS`. Every path returns a `StoryboardStepResult`
@@ -229,10 +235,12 @@ export async function executeWebhookAssertionStep(
   // observe — surface as prerequisite_failed rather than timing out.
   if (step.triggered_by) {
     const prior = runState.priorStepResults.get(step.triggered_by);
-    if (prior && (prior.skipped || !prior.passed)) {
+    if (!prior || prior.skipped || !prior.passed) {
       return skippedResult(step, phaseId, context, start, {
         skip_reason: 'prerequisite_failed',
-        detail: `Triggering step "${step.triggered_by}" did not complete successfully.`,
+        detail: prior
+          ? `Triggering step "${step.triggered_by}" did not complete successfully.`
+          : `Triggering step "${step.triggered_by}" has no prior result.`,
         extraction,
         request: requestRecord,
         next,
@@ -250,6 +258,12 @@ export async function executeWebhookAssertionStep(
   switch (step.task) {
     case 'expect_webhook': {
       const outcome = await runExpectWebhook(step, filter, receiver);
+      validations = outcome.validations;
+      passed = outcome.passed;
+      break;
+    }
+    case 'expect_no_webhook': {
+      const outcome = await runExpectNoWebhook(step, filter, receiver);
       validations = outcome.validations;
       passed = outcome.passed;
       break;
@@ -329,6 +343,53 @@ function buildFilter(step: StoryboardStep, context: StoryboardContext, runnerVar
     }
   }
   return filter;
+}
+
+// ────────────────────────────────────────────────────────────
+// expect_no_webhook
+// ────────────────────────────────────────────────────────────
+
+async function runExpectNoWebhook(
+  step: StoryboardStep,
+  filter: WebhookFilter,
+  receiver: WebhookReceiver
+): Promise<{ validations: ValidationResult[]; passed: boolean }> {
+  const timeoutMs = clampTimeoutSeconds(step.timeout_seconds, DEFAULT_NO_WEBHOOK_TIMEOUT_SECONDS) * 1000;
+  const outcome = await receiver.wait(filter, timeoutMs);
+
+  if (!outcome.timed_out && outcome.webhook) {
+    const matches = receiver.matching(filter);
+    const webhook = outcome.webhook;
+    return singleFailure(
+      step,
+      'unexpected_webhook_received',
+      `Observed ${matches.length} webhook ${matches.length === 1 ? 'delivery' : 'deliveries'} matching the filter; expected none.`,
+      'zero webhook deliveries matching filter',
+      {
+        count: matches.length,
+        first_delivery: {
+          id: webhook.id,
+          step_id: webhook.step_id,
+          operation_id: webhook.operation_id,
+          delivery_index: webhook.delivery_index,
+          received_at: webhook.received_at,
+        },
+      },
+      null
+    );
+  }
+
+  return {
+    validations: [
+      {
+        check: 'expect_no_webhook',
+        passed: true,
+        description: `No webhook matching the filter arrived within ${timeoutMs}ms.`,
+        json_pointer: null,
+      },
+    ],
+    passed: true,
+  };
 }
 
 // ────────────────────────────────────────────────────────────
@@ -773,7 +834,8 @@ function singleFailure(
   code: WebhookAssertionErrorCode,
   message: string,
   expected: unknown,
-  actual: unknown
+  actual: unknown,
+  jsonPointer: string | null = '/idempotency_key'
 ): { validations: ValidationResult[]; passed: boolean } {
   return {
     validations: [
@@ -782,7 +844,7 @@ function singleFailure(
         passed: false,
         description: step.expected ?? step.title,
         error: message,
-        json_pointer: '/idempotency_key',
+        json_pointer: jsonPointer,
         expected,
         actual: { code, actual },
       },

--- a/test/lib/storyboard-completeness.test.js
+++ b/test/lib/storyboard-completeness.test.js
@@ -44,6 +44,7 @@ const HARNESS_TASKS = new Set([
   // observes the shared receiver rather than driving the agent, so these
   // steps have no request shape.
   'expect_webhook',
+  'expect_no_webhook',
   'expect_webhook_retry_keys_stable',
   'expect_webhook_signature_valid',
   // Inbound webhook receiver conformance replays a fixture into the local

--- a/test/lib/storyboard-webhook-receiver.test.js
+++ b/test/lib/storyboard-webhook-receiver.test.js
@@ -6,7 +6,7 @@
  *      retry-replay policy (5xx→2xx), filter matching.
  *   2. Runner variables — `{{runner.*}}` and `{{prior_step.*.operation_id}}`
  *      substitution against a `RunnerVariables` bag.
- *   3. runStoryboard integration — `expect_webhook`,
+ *   3. runStoryboard integration — `expect_webhook`, `expect_no_webhook`,
  *      `expect_webhook_retry_keys_stable`, and `expect_webhook_signature_valid`
  *      pseudo-tasks against a fake publisher.
  */
@@ -17,6 +17,8 @@ const http = require('http');
 const { setTimeout: delay } = require('node:timers/promises');
 
 const { createWebhookReceiver } = require('../../dist/lib/testing/storyboard/webhook-receiver.js');
+const webhookAssertions = require('../../dist/lib/testing/storyboard/webhook-assertions.js');
+const { executeWebhookAssertionStep } = webhookAssertions;
 const { injectContext, createRunnerVariables } = require('../../dist/lib/testing/storyboard/context.js');
 const { runStoryboard } = require('../../dist/lib/testing/storyboard/runner.js');
 const { ADCP_VERSION } = require('../../dist/lib/version.js');
@@ -777,6 +779,275 @@ describe('runStoryboard: expect_webhook step task', () => {
     const assertStep = result.phases[0].steps[0];
     assert.strictEqual(assertStep.skipped, true);
     assert.strictEqual(assertStep.skip.reason, 'unsatisfied_contract');
+  });
+});
+
+describe('runStoryboard: expect_no_webhook step task', () => {
+  let publisher;
+  afterEach(async () => {
+    if (publisher) await stopPublisher(publisher);
+    publisher = undefined;
+  });
+
+  test('passes after the observation window when no matching webhook arrives', async () => {
+    publisher = await startFakePublisher({ mode: 'quiet' });
+    const storyboard = storyboardWith([
+      {
+        id: 'trigger',
+        title: 'Complete synchronously without a webhook',
+        task: '__test_fire_webhook',
+        auth: 'none',
+        sample_request: { push_notification_config: { url: '{{runner.webhook_url:trigger}}' } },
+      },
+      {
+        id: 'assert_silence',
+        title: 'Assert no completion webhook',
+        task: 'expect_no_webhook',
+        triggered_by: 'trigger',
+        timeout_seconds: 0.05,
+      },
+    ]);
+
+    const result = await runStoryboard(publisher.url, storyboard, {
+      ...RUN_OPTIONS_BASE,
+      webhook_receiver: {},
+    });
+    const assertStep = result.phases[0].steps[1];
+    assert.strictEqual(assertStep.passed, true, JSON.stringify(assertStep.validations));
+    assert.strictEqual(assertStep.validations[0].check, 'expect_no_webhook');
+    assert.strictEqual(assertStep.validations[0].json_pointer, null);
+  });
+
+  test('fails immediately with safe correlation metadata when a matching webhook arrives', async () => {
+    publisher = await startFakePublisher({ mode: 'ok' });
+    const storyboard = storyboardWith([
+      {
+        id: 'trigger',
+        title: 'Emit an unexpected webhook',
+        task: '__test_fire_webhook',
+        auth: 'none',
+        sample_request: { push_notification_config: { url: '{{runner.webhook_url:trigger}}' } },
+      },
+      {
+        id: 'assert_silence',
+        title: 'Assert no completion webhook',
+        task: 'expect_no_webhook',
+        triggered_by: 'trigger',
+        timeout_seconds: 2,
+      },
+    ]);
+
+    const result = await runStoryboard(publisher.url, storyboard, {
+      ...RUN_OPTIONS_BASE,
+      webhook_receiver: {},
+    });
+    const assertStep = result.phases[0].steps[1];
+    const validation = assertStep.validations[0];
+    assert.strictEqual(assertStep.passed, false);
+    assert.strictEqual(validation.actual.code, 'unexpected_webhook_received');
+    assert.strictEqual(validation.json_pointer, null);
+    assert.strictEqual(validation.actual.actual.count, 1);
+    assert.strictEqual(validation.actual.actual.first_delivery.step_id, 'trigger');
+    assert.ok(validation.actual.actual.first_delivery.operation_id);
+    assert.ok(assertStep.duration_ms < 1000, `expected immediate failure, got ${assertStep.duration_ms}ms`);
+  });
+
+  test('fails when a matching webhook arrives while the observation waiter is active', async () => {
+    let signalWaitStarted;
+    const waitStarted = new Promise(resolve => {
+      signalWaitStarted = resolve;
+    });
+    let resolveWait;
+    const captured = [];
+    const receiver = {
+      base_url: 'http://127.0.0.1:1',
+      mode: 'loopback_mock',
+      all: () => [...captured],
+      matching: () => [...captured],
+      set_retry_replay: () => {},
+      wait: () => {
+        signalWaitStarted();
+        return new Promise(resolve => {
+          resolveWait = resolve;
+        });
+      },
+      wait_all: async () => [],
+      close: async () => {},
+    };
+    const runState = {
+      contributions: new Set(),
+      priorStepResults: new Map([['trigger', { passed: true }]]),
+      priorProbes: new Map(),
+      agentUrl: '',
+      webhookReceiver: receiver,
+      runnerVars: createRunnerVariables({ webhookBase: receiver.base_url }),
+    };
+    const step = {
+      id: 'assert_silence',
+      title: 'Assert no completion webhook',
+      task: 'expect_no_webhook',
+      triggered_by: 'trigger',
+      timeout_seconds: 1,
+    };
+
+    const resultPromise = executeWebhookAssertionStep(step, 'p', {}, [], {}, runState);
+    await waitStarted;
+    const webhook = {
+      id: 'delivery-1',
+      step_id: 'trigger',
+      operation_id: 'operation-1',
+      delivery_index: 1,
+      received_at: new Date().toISOString(),
+      body: { idempotency_key: 'evt_delayed_0123456789abcdef' },
+    };
+    captured.push(webhook);
+    resolveWait({ timed_out: false, webhook });
+
+    const assertStep = await resultPromise;
+    assert.strictEqual(assertStep.passed, false);
+    assert.strictEqual(assertStep.validations[0].actual.code, 'unexpected_webhook_received');
+    assert.strictEqual(assertStep.validations[0].actual.actual.first_delivery.id, 'delivery-1');
+  });
+
+  test('ignores deliveries that do not match the authored body filter', async () => {
+    publisher = await startFakePublisher({ mode: 'ok' });
+    const storyboard = storyboardWith([
+      {
+        id: 'trigger',
+        title: 'Emit an unrelated webhook',
+        task: '__test_fire_webhook',
+        auth: 'none',
+        sample_request: {
+          task_id: 'mb-1',
+          push_notification_config: { url: '{{runner.webhook_url:trigger}}' },
+        },
+      },
+      {
+        id: 'assert_silence',
+        title: 'Assert no matching webhook',
+        task: 'expect_no_webhook',
+        triggered_by: 'trigger',
+        filter: { body: { 'task.task_id': 'different-task' } },
+        timeout_seconds: 0.05,
+      },
+    ]);
+
+    const result = await runStoryboard(publisher.url, storyboard, {
+      ...RUN_OPTIONS_BASE,
+      webhook_receiver: {},
+    });
+    const assertStep = result.phases[0].steps[1];
+    assert.strictEqual(assertStep.passed, true, JSON.stringify(assertStep.validations));
+  });
+
+  test('skips when the triggering step was skipped', async () => {
+    publisher = await startFakePublisher({ mode: 'quiet' });
+    const storyboard = storyboardWith([
+      {
+        id: 'trigger',
+        title: 'Unavailable trigger',
+        task: '__test_fire_webhook',
+        requires_tool: '__missing_webhook_tool',
+        sample_request: {},
+      },
+      {
+        id: 'assert_silence',
+        title: 'Assert no completion webhook',
+        task: 'expect_no_webhook',
+        triggered_by: 'trigger',
+        timeout_seconds: 0.05,
+      },
+    ]);
+
+    const result = await runStoryboard(publisher.url, storyboard, {
+      ...RUN_OPTIONS_BASE,
+      webhook_receiver: {},
+    });
+    const [triggerStep, assertStep] = result.phases[0].steps;
+    assert.strictEqual(triggerStep.skipped, true);
+    assert.strictEqual(assertStep.skipped, true);
+    assert.strictEqual(assertStep.skip.reason, 'prerequisite_failed');
+  });
+
+  test('does not false-pass when triggered_by has no prior result', async () => {
+    publisher = await startFakePublisher({ mode: 'quiet' });
+    const storyboard = storyboardWith([
+      {
+        id: 'assert_silence',
+        title: 'Assert no completion webhook',
+        task: 'expect_no_webhook',
+        triggered_by: 'missing_trigger',
+        timeout_seconds: 0.05,
+      },
+    ]);
+
+    const result = await runStoryboard(publisher.url, storyboard, {
+      ...RUN_OPTIONS_BASE,
+      webhook_receiver: {},
+    });
+    const assertStep = result.phases[0].steps[0];
+    assert.strictEqual(assertStep.skipped, true);
+    assert.strictEqual(assertStep.skip.reason, 'prerequisite_failed');
+    assert.match(assertStep.skip.detail, /no prior result/);
+  });
+
+  test('grades not_applicable when webhook_receiver is not enabled', async () => {
+    publisher = await startFakePublisher({ mode: 'quiet' });
+    const storyboard = storyboardWith([
+      {
+        id: 'assert_silence',
+        title: 'No receiver',
+        task: 'expect_no_webhook',
+        timeout_seconds: 0.05,
+      },
+    ]);
+
+    const result = await runStoryboard(publisher.url, storyboard, RUN_OPTIONS_BASE);
+    const assertStep = result.phases[0].steps[0];
+    assert.strictEqual(assertStep.skipped, true);
+    assert.strictEqual(assertStep.skip.reason, 'unsatisfied_contract');
+  });
+
+  test('uses a five-second default and clamps authored timeouts to five minutes', async () => {
+    const observedTimeouts = [];
+    const receiver = {
+      base_url: 'http://127.0.0.1:1',
+      mode: 'loopback_mock',
+      all: () => [],
+      matching: () => [],
+      set_retry_replay: () => {},
+      wait: async (_filter, timeoutMs) => {
+        observedTimeouts.push(timeoutMs);
+        return { timed_out: true };
+      },
+      wait_all: async () => [],
+      close: async () => {},
+    };
+    const runState = {
+      contributions: new Set(),
+      priorStepResults: new Map([['trigger', { passed: true }]]),
+      priorProbes: new Map(),
+      agentUrl: publisher?.url ?? '',
+      webhookReceiver: receiver,
+      runnerVars: createRunnerVariables({ webhookBase: receiver.base_url }),
+    };
+    const baseStep = {
+      id: 'assert_silence',
+      title: 'Assert no completion webhook',
+      task: 'expect_no_webhook',
+      triggered_by: 'trigger',
+    };
+
+    await executeWebhookAssertionStep(baseStep, 'p', {}, [], {}, runState);
+    await executeWebhookAssertionStep({ ...baseStep, timeout_seconds: 999 }, 'p', {}, [], {}, runState);
+
+    assert.deepStrictEqual(observedTimeouts, [5000, 300000]);
+  });
+
+  test('is exported by both CJS and ESM builds', async () => {
+    const esmAssertions = await import('../../dist/lib/testing/storyboard/webhook-assertions.mjs');
+    assert.strictEqual(webhookAssertions.WEBHOOK_ASSERTION_TASKS.has('expect_no_webhook'), true);
+    assert.strictEqual(esmAssertions.WEBHOOK_ASSERTION_TASKS.has('expect_no_webhook'), true);
   });
 });
 


### PR DESCRIPTION
## Summary

- add the `expect_no_webhook` storyboard pseudo-task with receiver filtering and strict prerequisite gating
- fail on the first unexpected matching delivery with safe correlation diagnostics
- document the authoring contract and add focused CJS/ESM, filtering, timeout, active-waiter, and skip coverage

## Validation

- `npm run ci:quick`
- focused storyboard tests: 2,892 passed
- implementation, protocol, and Node.js testing expert reviews

Closes #2525
