### PR TITLE
fix(testing): canonicalize rate-limit exhaustion grading

### DIFF
--- a/.changeset/fix-rate-limit-exhaustion-detail.md
+++ b/.changeset/fix-rate-limit-exhaustion-detail.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Emit the canonical `rate_limit_not_triggered` detail when a rate-limit trip exhausts its attempts without observing a `RATE_LIMITED` response. Preserve the passing skipped-step contract while surfacing independent assertion failures through compliance reports.

--- a/src/lib/testing/compliance/comply.ts
+++ b/src/lib/testing/compliance/comply.ts
@@ -10,7 +10,7 @@
 
 import { createTestClient, discoverAgentProfile } from '../client';
 import type { TestOptions, TestResult, AgentProfile, TestStepResult } from '../types';
-import { mapStoryboardResultsToTrackResult, TRACK_LABELS } from './storyboard-tracks';
+import { collectDetachedAssertionFailures, mapStoryboardResultsToTrackResult, TRACK_LABELS } from './storyboard-tracks';
 import { applyAdcpVersionRunOptions, runStoryboard } from '../storyboard/runner';
 import { validateTestKit } from '../storyboard/test-kit';
 import { checkAccountDiscoveryGate } from './spec-conformance';
@@ -1021,17 +1021,7 @@ export function extractFailures(
       for (const step of phase.steps) {
         if (step.passed || step.skipped) continue;
 
-        // Find the step definition in the storyboard for expected text
-        let expected: string | undefined;
-        if (sb) {
-          for (const p of sb.phases) {
-            const stepDef = p.steps.find(s => s.id === step.step_id);
-            if (stepDef?.expected) {
-              expected = stepDef.expected.trim();
-              break;
-            }
-          }
-        }
+        const expected = findStoryboardStepExpected(sb, step.step_id);
 
         const firstFailedValidation = step.validations.find(validationFailsStep);
         const validationSummary = firstFailedValidation
@@ -1062,9 +1052,40 @@ export function extractFailures(
         });
       }
     }
+
+    // Assertion failures on skipped steps are not counted as failed steps and
+    // the loop above intentionally ignores skips. Preserve those gating
+    // failures from the storyboard assertion surface instead of dropping them.
+    for (const { assertion, owningStep } of collectDetachedAssertionFailures(result)) {
+      if (!owningStep) continue;
+
+      failures.push({
+        track,
+        storyboard_id: result.storyboard_id,
+        step_id: owningStep.step_id,
+        step_title: owningStep.title,
+        task: owningStep.task,
+        error: assertion.error ?? assertion.description,
+        expected: findStoryboardStepExpected(sb, owningStep.step_id),
+        fix_command: buildFixCommand(agentRef, result.storyboard_id, owningStep.step_id, fixOptions),
+        validation: {
+          check: 'assertion',
+          description: `${assertion.assertion_id}: ${assertion.description}`,
+        },
+      });
+    }
   }
 
   return failures;
+}
+
+function findStoryboardStepExpected(storyboard: Storyboard | undefined, stepId: string): string | undefined {
+  if (!storyboard) return undefined;
+  for (const phase of storyboard.phases) {
+    const expected = phase.steps.find(step => step.id === stepId)?.expected;
+    if (expected) return expected.trim();
+  }
+  return undefined;
 }
 
 function buildFixCommand(

--- a/src/lib/testing/compliance/storyboard-tracks.ts
+++ b/src/lib/testing/compliance/storyboard-tracks.ts
@@ -8,7 +8,33 @@
 
 import type { TestResult, TestStepResult, AgentProfile } from '../types';
 import type { ComplianceTrack, TrackResult, TrackStatus, AdvisoryObservation } from './types';
-import type { StoryboardResult, StoryboardStepResult } from '../storyboard/types';
+import type { AssertionResult, StoryboardResult, StoryboardStepResult } from '../storyboard/types';
+
+export interface DetachedAssertionFailure {
+  assertion: AssertionResult;
+  owningStep?: StoryboardStepResult;
+}
+
+/** Assertion failures that are not represented by a counted failed step. */
+export function collectDetachedAssertionFailures(result: StoryboardResult): DetachedAssertionFailure[] {
+  const failures: DetachedAssertionFailure[] = [];
+  for (const assertion of result.assertions ?? []) {
+    if (assertion.passed) continue;
+    if (assertion.scope === 'storyboard') {
+      failures.push({ assertion });
+      continue;
+    }
+    const assertionPhases =
+      assertion.pass_index === undefined
+        ? result.phases
+        : (result.passes?.find(pass => pass.pass_index === assertion.pass_index)?.phases ?? []);
+    const owningStep = assertionPhases.flatMap(phase => phase.steps).find(step => step.step_id === assertion.step_id);
+    if (owningStep?.skipped === true) {
+      failures.push({ assertion, owningStep });
+    }
+  }
+  return failures;
+}
 
 /** Labels for each compliance track. */
 export const TRACK_LABELS: Record<ComplianceTrack, string> = {
@@ -57,16 +83,14 @@ export function mapStoryboardResultsToTrackResult(
 
   for (const sbResult of storyboardResults) {
     totalDuration += sbResult.total_duration_ms;
-    const storyboardAssertionFailures = (sbResult.assertions ?? []).filter(
-      assertion => !assertion.passed && assertion.scope === 'storyboard'
-    );
+    const assertionFailures = collectDetachedAssertionFailures(sbResult);
 
-    for (const assertion of storyboardAssertionFailures) {
+    for (const { assertion, owningStep } of assertionFailures) {
       observations.push({
         category: 'error_compliance',
         severity: 'error',
         track,
-        message: 'A storyboard-scoped compliance assertion failed.',
+        message: `A ${assertion.scope}-scoped compliance assertion failed.`,
         evidence: {
           assertion_id: assertion.assertion_id,
           description: assertion.description,
@@ -75,12 +99,20 @@ export function mapStoryboardResultsToTrackResult(
           ...(assertion.hint !== undefined && { hint: assertion.hint }),
           ...(assertion.observation_count !== undefined && { observation_count: assertion.observation_count }),
           ...(assertion.status !== undefined && { status: assertion.status }),
+          ...(assertion.pass_index !== undefined && { pass_index: assertion.pass_index }),
         },
-        source: {
-          kind: 'storyboard',
-          code: 'storyboard-assertion-failed',
-          storyboard_id: sbResult.storyboard_id,
-        },
+        source: owningStep
+          ? {
+              kind: 'storyboard_step',
+              code: 'storyboard-assertion-failed',
+              storyboard_id: sbResult.storyboard_id,
+              step_id: owningStep.step_id,
+            }
+          : {
+              kind: 'storyboard',
+              code: 'storyboard-assertion-failed',
+              storyboard_id: sbResult.storyboard_id,
+            },
       });
     }
 
@@ -106,15 +138,19 @@ export function mapStoryboardResultsToTrackResult(
     // storyboard verdict fails despite every phase passing (for example, an
     // onEnd assertion failure), add one storyboard-level scenario instead of
     // falsely attributing the same failure to every phase.
-    if (!sbResult.overall_passed && sbResult.passed_count > 0 && sbResult.phases.every(phase => phase.passed)) {
+    if (
+      !sbResult.overall_passed &&
+      (sbResult.passed_count > 0 || assertionFailures.length > 0) &&
+      sbResult.phases.every(phase => phase.passed)
+    ) {
       scenarios.push({
         agent_url: sbResult.agent_url,
         scenario: `${sbResult.storyboard_id}/storyboard` as any,
         overall_passed: false,
         steps: [],
         summary:
-          storyboardAssertionFailures.length > 0
-            ? `${sbResult.storyboard_title}: ${storyboardAssertionFailures.length} storyboard assertion(s) failed`
+          assertionFailures.length > 0
+            ? `${sbResult.storyboard_title}: ${assertionFailures.length} assertion(s) failed`
             : `${sbResult.storyboard_title}: storyboard-level verdict failed`,
         total_duration_ms: 0,
         tested_at: sbResult.tested_at,
@@ -210,10 +246,12 @@ function computeTrackStatus(results: StoryboardResult[]): TrackStatus {
   const totalFailed = results.reduce((sum, r) => sum + r.failed_count, 0);
   const totalSkipped = results.reduce((sum, r) => sum + r.skipped_count, 0);
   const totalSteps = totalPassed + totalFailed + totalSkipped;
+  const hasAssertionFailure = results.some(result => collectDetachedAssertionFailures(result).length > 0);
 
   if (totalSteps === 0) return 'skip';
-  if (totalSteps === totalSkipped) return 'skip';
   if (totalFailed > 0) return totalPassed === 0 ? 'fail' : 'partial';
+  if (hasAssertionFailure) return totalPassed === 0 ? 'fail' : 'partial';
+  if (totalSteps === totalSkipped) return 'skip';
   // Storyboard-scoped assertions are not steps, so their failures correctly
   // leave failed_count at zero. The runner's overall verdict is authoritative:
   // some steps passed, but the cross-step invariant did not.

--- a/src/lib/testing/storyboard/junit.ts
+++ b/src/lib/testing/storyboard/junit.ts
@@ -7,6 +7,7 @@
 // break the emitted d.ts (adcp-client#900 reviewer finding).
 
 import type { StoryboardResult, StoryboardStepResult, StoryboardStepHint } from './types';
+import { collectDetachedAssertionFailures } from '../compliance/storyboard-tracks';
 import { randomBytes } from 'node:crypto';
 
 function xmlEscape(s: unknown): string {
@@ -70,6 +71,7 @@ export function formatStoryboardResultsAsJUnit(results: StoryboardResult[]): str
 
   for (const sb of results) {
     const suiteCases: string[] = [];
+    let suiteFailures = sb.failed_count;
     let representedSkipped = 0;
     const passPhases = sb.passes?.length
       ? sb.passes.map(pass => ({ label: `Pass ${pass.pass_index} › `, phases: pass.phases }))
@@ -144,10 +146,23 @@ export function formatStoryboardResultsAsJUnit(results: StoryboardResult[]): str
           `    </testcase>`
       );
     }
+    for (const { assertion } of collectDetachedAssertionFailures(sb)) {
+      totalTests += 1;
+      totalFailures += 1;
+      suiteFailures += 1;
+      const passLabel = assertion.pass_index === undefined ? '' : `Pass ${assertion.pass_index} › `;
+      const message = assertion.error ?? assertion.description;
+      const details = `${assertion.assertion_id}: ${assertion.description}${assertion.error ? `\n${assertion.error}` : ''}`;
+      suiteCases.push(
+        `    <testcase classname="${xmlEscape(sb.storyboard_id)}" name="${xmlEscape(`${passLabel}Assertion › ${assertion.assertion_id}`)}" time="0.000">\n` +
+          `      <failure message="${xmlEscape(message)}" type="StoryboardAssertionFailure">${xmlEscape(details)}</failure>\n` +
+          `    </testcase>`
+      );
+    }
     totalDuration += sb.total_duration_ms || 0;
     const suiteTests = suiteCases.length;
     suites.push(
-      `  <testsuite name="${xmlEscape(sb.storyboard_title)}" tests="${suiteTests}" failures="${sb.failed_count}" skipped="${sb.skipped_count}" time="${((sb.total_duration_ms || 0) / 1000).toFixed(3)}" timestamp="${sb.tested_at || new Date().toISOString()}">\n` +
+      `  <testsuite name="${xmlEscape(sb.storyboard_title)}" tests="${suiteTests}" failures="${suiteFailures}" skipped="${sb.skipped_count}" time="${((sb.total_duration_ms || 0) / 1000).toFixed(3)}" timestamp="${sb.tested_at || new Date().toISOString()}">\n` +
         suiteCases.join('\n') +
         `\n  </testsuite>`
     );

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -281,6 +281,14 @@ const DETAILED_SKIP_DETAILS: Partial<Record<RunnerDetailedSkipReason, string>> =
   rate_limit_not_triggered: 'No RATE_LIMITED response was observed within the configured max_attempts.',
 };
 
+/**
+ * Machine-readable detail values required by the AdCP report contract.
+ * The probe's human-readable error remains available on the legacy response.
+ */
+const CANONICAL_SKIP_DETAILS: Partial<Record<RunnerDetailedSkipReason, string>> = {
+  rate_limit_not_triggered: 'rate_limit_not_triggered',
+};
+
 const REPLAY_WEBHOOK_VECTOR_TASK = 'replay_webhook_vector';
 const REPLAY_TRUSTED_MATCH_CONTEXT_VECTOR_TASK = 'replay_trusted_match_context_vector';
 const WEBHOOK_REPLAY_DEFAULT_TIMEOUT_MS = 10_000;
@@ -3293,6 +3301,13 @@ async function executeStoryboardPass(
         v => v.check === 'response_schema' && validationFailsStep(v)
       );
 
+      // Rate-limit exhaustion is a contract-defined applicability result,
+      // not a response to grade. Preserve its empty validations array and
+      // passing skip status. Step assertions still run and remain visible on
+      // the storyboard-level assertions surface, but are not mirrored onto
+      // this skipped step or counted as a failed step.
+      const rateLimitTripNotApplicable = result.skipped === true && result.skip_reason === 'rate_limit_not_triggered';
+
       // Fire per-step assertions. Each result is appended to the step's
       // `validations[]` under `check: "assertion"` so existing UI renders
       // them alongside inline checks, and mirrored into `assertionResults`
@@ -3321,12 +3336,14 @@ async function executeStoryboardPass(
         for (const r of raw) {
           const full: AssertionResult = { ...r, assertion_id: spec.id, scope: 'step', step_id: step.id };
           assertionResults.push(full);
-          result.validations.push({
-            check: 'assertion',
-            passed: r.passed,
-            description: `${spec.id}: ${r.description}`,
-            ...(r.error !== undefined && { error: r.error }),
-          });
+          if (!rateLimitTripNotApplicable) {
+            result.validations.push({
+              check: 'assertion',
+              passed: r.passed,
+              description: `${spec.id}: ${r.description}`,
+              ...(r.error !== undefined && { error: r.error }),
+            });
+          }
           // Issue #935: assertions can attach a structured hint that the
           // runner mirrors into the owning step's `hints[]`. Producers today
           // include `status.monotonic` (monotonic_violation) and
@@ -3339,7 +3356,7 @@ async function executeStoryboardPass(
             result.hints = [...existing, r.hint];
           }
           if (!r.passed) {
-            result.passed = false;
+            if (!rateLimitTripNotApplicable) result.passed = false;
             assertionsFailed = true;
           }
         }
@@ -3966,7 +3983,9 @@ async function runMultiPass(
   // independently and reported `assertion_id` identically. Concatenate so
   // readers see a per-pass timeline; de-duplicating would hide a real
   // "passed on pass 1, failed on pass 2" divergence.
-  const assertionsAgg = passResults.flatMap(r => r.assertions ?? []);
+  const assertionsAgg = passResults.flatMap((r, index) =>
+    (r.assertions ?? []).map(assertion => ({ ...assertion, pass_index: index + 1 }))
+  );
   // Notices are identical across passes (same agent, same capabilities).
   // Schema-invalid capabilities notices retain one row per RFC 6901 pointer.
   const noticesDedup = [...new Map(passResults.flatMap(r => r.notices).map(n => [runnerNoticeKey(n), n])).values()];
@@ -6052,7 +6071,11 @@ async function executeProbeStep(
   if (httpResult?.skipped) {
     const detailedReason = (httpResult.skip_reason ?? 'probe_skipped') as RunnerDetailedSkipReason;
     const canonicalReason = DETAILED_SKIP_TO_CANONICAL[detailedReason] ?? 'not_applicable';
-    const detail = httpResult.error ?? DETAILED_SKIP_DETAILS[detailedReason] ?? SKIP_DETAILS[canonicalReason];
+    const detail =
+      CANONICAL_SKIP_DETAILS[detailedReason] ??
+      httpResult.error ??
+      DETAILED_SKIP_DETAILS[detailedReason] ??
+      SKIP_DETAILS[canonicalReason];
     const selectionResult = selectionForProbeSkip(detailedReason, detail);
     return {
       step_id: step.id,

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -2392,9 +2392,13 @@ export interface StoryboardStepResult {
    * by the RFC 9421 request-signing grader (#585, #617). The structured
    * `skip` field below always carries the canonical spec reason so consumers
    * of the runner-output contract don't need to know the grader vocabulary.
+   * In particular, `rate_limit_not_triggered` is a passing skipped result
+   * with `skip.reason === 'not_applicable'`,
+   * `skip.detail === 'rate_limit_not_triggered'`, and no validations. Its
+   * human-readable diagnostic remains on the legacy `response.error` field.
    */
   skip_reason?: RunnerSkipReason | RunnerDetailedSkipReason;
-  /** Structured skip result with canonical spec reason + human-readable detail. */
+  /** Structured skip result with canonical spec reason + contract-defined detail. */
   skip?: RunnerSkipResult;
   /**
    * Structured selection result for steps that were outside the caller's
@@ -3078,6 +3082,8 @@ export interface AssertionResult {
   scope: 'step' | 'storyboard';
   /** Step that produced the observation, when `scope === "step"`. */
   step_id?: string;
+  /** 1-based pass index when aggregated from a multi-pass run. */
+  pass_index?: number;
   /** Failure detail. Absent on pass. */
   error?: string;
   /**

--- a/test/lib/storyboard-rate-limit-trip.test.js
+++ b/test/lib/storyboard-rate-limit-trip.test.js
@@ -1,7 +1,11 @@
 const { describe, test } = require('node:test');
 const assert = require('node:assert/strict');
 
-const { runStoryboardStep } = require('../../dist/lib/testing/storyboard/runner');
+const { runStoryboard, runStoryboardStep } = require('../../dist/lib/testing/storyboard/runner');
+const { registerAssertion } = require('../../dist/lib/testing/storyboard/assertions');
+const { extractFailures } = require('../../dist/lib/testing/compliance/comply');
+const { mapStoryboardResultsToTrackResult } = require('../../dist/lib/testing/compliance/storyboard-tracks');
+const { formatStoryboardResultsAsJUnit } = require('../../dist/lib/testing/storyboard/junit');
 const { ResponseTooLargeError, ValidationError } = require('../../dist/lib/errors');
 const rootExports = require('../../dist/lib/index');
 const testingExports = require('../../dist/lib/testing/index');
@@ -418,7 +422,7 @@ describe('storyboard rate_limit_trip_runner wiring', () => {
     assert.equal(calls.length, 2);
   });
 
-  test('no RATE_LIMITED emits skip_reason rate_limit_not_triggered and skip.reason not_applicable', async () => {
+  test('no RATE_LIMITED emits the canonical not-applicable skip result without validations', async () => {
     const calls = [];
     const client = {
       executeTask: async (_taskName, params) => {
@@ -433,10 +437,105 @@ describe('storyboard rate_limit_trip_runner wiring', () => {
     assert.equal(result.skipped, true);
     assert.equal(result.skip_reason, 'rate_limit_not_triggered');
     assert.equal(result.skip.reason, 'not_applicable');
+    assert.equal(result.skip.detail, 'rate_limit_not_triggered');
+    assert.deepEqual(result.validations, []);
+    assert.match(result.response.error, /No RATE_LIMITED response observed/);
     assert.equal(calls.length, 50);
     assert.equal(new Set(calls.map(c => c.idempotency_key)).size, 50);
     assert.deepEqual(result.request.payload, calls[49]);
     assert.equal(result.response_record.payload.trip_request.context.correlation_id, 'trip#trip-50');
+  });
+
+  test('full storyboard run preserves the exhaustion skip and aggregate counters', async () => {
+    const calls = [];
+    const client = {
+      executeTask: async (_taskName, params) => {
+        calls.push(params);
+        return { success: true, data: { media_buy_id: `mb_${calls.length}` } };
+      },
+    };
+
+    const result = await runStoryboard('https://stub.example/mcp', makeStoryboard(), {
+      protocol: 'mcp',
+      _client: client,
+      _profile: { name: 'stub', tools: ['create_media_buy'] },
+      agentTools: ['create_media_buy'],
+      contracts: ['rate_limit_trip_runner'],
+      allowLiveSideEffects: true,
+    });
+    const step = result.phases[0].steps[0];
+
+    assert.equal(step.passed, true);
+    assert.equal(step.skipped, true);
+    assert.equal(step.skip.reason, 'not_applicable');
+    assert.equal(step.skip.detail, 'rate_limit_not_triggered');
+    assert.deepEqual(step.validations, []);
+    assert.equal(result.overall_passed, true);
+    assert.equal(result.passed_count, 0);
+    assert.equal(result.failed_count, 0);
+    assert.equal(result.skipped_count, 1);
+    assert.ok(result.assertions.length > 0, 'step assertions still execute for the skipped probe');
+    assert.ok(result.assertions.every(assertion => assertion.passed));
+    assert.equal(calls.length, 50);
+  });
+
+  test('full run surfaces a failing assertion without changing the exhaustion skip tuple', async () => {
+    const assertionId = 'test.rate_limit_exhaustion_failure';
+    registerAssertion({
+      id: assertionId,
+      description: 'test-only rate-limit exhaustion assertion',
+      onStep: async (_context, step) =>
+        step.skip_reason === 'rate_limit_not_triggered'
+          ? [{ passed: false, description: 'rate-limit policy assertion failed', error: 'policy failure' }]
+          : [],
+    });
+
+    const storyboard = makeStoryboard();
+    storyboard.track = 'error_handling';
+    storyboard.invariants = { enable: [assertionId] };
+    storyboard.phases[0].steps[0].expected = 'Rate-limit exhaustion is not a failed replay check.';
+    const client = {
+      executeTask: async () => ({ success: true, data: { media_buy_id: 'mb_no_limit' } }),
+    };
+    const result = await runStoryboard('https://stub.example/mcp', storyboard, {
+      protocol: 'mcp',
+      _client: client,
+      _profile: { name: 'stub', tools: ['create_media_buy'] },
+      agentTools: ['create_media_buy'],
+      contracts: ['rate_limit_trip_runner'],
+      allowLiveSideEffects: true,
+    });
+    const step = result.phases[0].steps[0];
+
+    assert.equal(step.passed, true);
+    assert.equal(step.skipped, true);
+    assert.equal(step.skip.detail, 'rate_limit_not_triggered');
+    assert.deepEqual(step.validations, []);
+    assert.equal(result.failed_count, 0);
+    assert.equal(result.skipped_count, 1);
+    assert.equal(result.overall_passed, false);
+    assert.ok(result.assertions.some(assertion => assertion.assertion_id === assertionId && !assertion.passed));
+
+    const track = mapStoryboardResultsToTrackResult('error_handling', [result], {
+      name: 'stub',
+      tools: [],
+    });
+    assert.equal(track.status, 'fail');
+    const observation = track.observations.find(observation => observation.evidence.assertion_id === assertionId);
+    assert.equal(observation.source.kind, 'storyboard_step');
+    assert.equal(observation.source.storyboard_id, storyboard.id);
+    assert.equal(observation.source.step_id, 'trip');
+
+    const failures = extractFailures([result], [storyboard], 'https://stub.example/mcp');
+    assert.equal(failures.length, 1);
+    assert.equal(failures[0].step_id, 'trip');
+    assert.equal(failures[0].expected, 'Rate-limit exhaustion is not a failed replay check.');
+    assert.equal(failures[0].validation.check, 'assertion');
+
+    const junit = formatStoryboardResultsAsJUnit([result]);
+    assert.match(junit, /<testsuites\b[^>]+failures="1"/);
+    assert.match(junit, /<testsuite\b[^>]+failures="1"/);
+    assert.match(junit, /type="StoryboardAssertionFailure"/);
   });
 
   test('uses normal request enrichment for sentinel product and pricing ids', async () => {

--- a/test/lib/storyboard-track-silent-rollup.test.js
+++ b/test/lib/storyboard-track-silent-rollup.test.js
@@ -205,6 +205,117 @@ describe('TrackStatus silent rollup', () => {
     assert.deepStrictEqual(result.observations, []);
   });
 
+  it('surfaces a failed assertion attached to a skipped step', () => {
+    const step = {
+      step_id: 'optional-step',
+      phase_id: 'optional',
+      title: 'Optional step',
+      task: 'get_optional_resource',
+      passed: false,
+      skipped: true,
+      skip_reason: 'not_applicable',
+      duration_ms: 1,
+      validations: [{ check: 'assertion', passed: false, description: 'policy failed' }],
+      context: {},
+    };
+    const result = mapStoryboardResultsToTrackResult(
+      'core',
+      [
+        sbResult({
+          passed: 0,
+          failed: 0,
+          skipped: 1,
+          overall_passed: false,
+          phases: [{ phase_id: 'optional', phase_title: 'Optional', passed: true, duration_ms: 1, steps: [step] }],
+          assertions: [
+            {
+              assertion_id: 'optional.policy',
+              passed: false,
+              description: 'policy failed',
+              scope: 'step',
+              step_id: 'optional-step',
+            },
+          ],
+        }),
+      ],
+      PROFILE
+    );
+
+    assert.strictEqual(result.status, 'fail');
+    assert.strictEqual(result.observations.length, 1);
+    assert.strictEqual(result.observations[0].source.step_id, 'optional-step');
+  });
+
+  it('attributes a detached assertion to its owning multi-pass step', () => {
+    const passedStep = {
+      step_id: 'trip',
+      phase_id: 'p1',
+      title: 'Trip',
+      task: 'expect_rate_limit_not_replayed',
+      passed: true,
+      duration_ms: 1,
+      validations: [],
+      context: {},
+    };
+    const skippedStep = {
+      ...passedStep,
+      skipped: true,
+      skip_reason: 'rate_limit_not_triggered',
+      skip: { reason: 'not_applicable', detail: 'rate_limit_not_triggered' },
+    };
+    const phase = step => ({ phase_id: 'p1', phase_title: 'Phase', passed: true, duration_ms: 1, steps: [step] });
+    const storyboardResult = sbResult({
+      passed: 1,
+      skipped: 1,
+      overall_passed: false,
+      phases: [phase(passedStep)],
+      assertions: [
+        {
+          assertion_id: 'rate-limit-policy',
+          passed: false,
+          description: 'Policy assertion failed',
+          scope: 'step',
+          step_id: 'trip',
+          pass_index: 2,
+        },
+      ],
+    });
+    storyboardResult.passes = [
+      {
+        pass_index: 1,
+        dispatch_offset: 0,
+        overall_passed: true,
+        phases: [phase(passedStep)],
+        passed_count: 1,
+        failed_count: 0,
+        skipped_count: 0,
+        duration_ms: 1,
+      },
+      {
+        pass_index: 2,
+        dispatch_offset: 1,
+        overall_passed: false,
+        phases: [phase(skippedStep)],
+        passed_count: 0,
+        failed_count: 0,
+        skipped_count: 1,
+        duration_ms: 1,
+      },
+    ];
+
+    const result = mapStoryboardResultsToTrackResult('error_handling', [storyboardResult], PROFILE);
+
+    assert.strictEqual(result.status, 'partial');
+    assert.strictEqual(result.observations.length, 1);
+    assert.deepStrictEqual(result.observations[0].source, {
+      kind: 'storyboard_step',
+      code: 'storyboard-assertion-failed',
+      storyboard_id: 'fixture',
+      step_id: 'trip',
+    });
+    assert.strictEqual(result.observations[0].evidence.pass_index, 2);
+  });
+
   it("emits 'silent' when every observation-bearing assertion record reports zero observations", () => {
     const result = mapStoryboardResultsToTrackResult(
       'governance',


### PR DESCRIPTION
## Summary

- emit the canonical `rate_limit_not_triggered` skip detail when the trip observer exhausts `max_attempts`
- preserve the required passing skipped-step tuple and empty validations in full storyboard runs
- keep independent assertion failures gating and visible in compliance results, multi-pass provenance, extracted failures, and JUnit

## Root cause

The observer already returned a skipped result before replay validation, but the generic runner replaced the machine detail with human prose. Full-run assertions could also mutate the skipped step, while downstream projections assumed every assertion failure belonged to a counted failed step.

## Validation

- `npm run build`
- `npm run typecheck`
- `npm run lint` (0 errors)
- 66 focused rate-limit, compliance rollup, parity, and JUnit tests
- required DX, protocol, code, security, and automated Codex reviews
- pre-push formatting, typecheck, and build hooks

Refs adcontextprotocol/adcp#6459
Aligns with adcontextprotocol/adcp#6533