### PR TITLE
feat(compliance): add capability set validators

### DIFF
--- a/.changeset/add-negative-capability-gates.md
+++ b/.changeset/add-negative-capability-gates.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': minor
+---
+
+Add `not_contains` capability gates and a `field_in_context_array` validator so conformance phases can grade omitted capability values and response membership in advertised sets.

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -345,7 +345,7 @@ function resolveCapabilityPathForGate(
   // field never read as absent, silently flipping the gate (e.g. a signals
   // seller that omits `signals.discovery_modes`, default `["brief"]`, would run
   // a `present: true`-gated scenario that should skip). Defaults are resolved
-  // only for the value matchers (`equals` / `contains`), where the default's
+  // only for the value matchers (`equals` / `contains` / `not_contains`), where the default's
   // VALUE is what the gate tests.
   if ('present' in predicate) return undefined;
   if (!schemaDefaultShouldApply(raw, predicate.path)) return undefined;
@@ -371,7 +371,7 @@ function schemaDefaultShouldApply(raw: unknown, dottedPath: string): boolean {
  * predicate is satisfied and a human-readable detail string when the
  * storyboard should be skipped.
  *
- * Three matcher forms — see `Storyboard.requires_capability` for full semantics:
+ * Four matcher forms — see `Storyboard.requires_capability` for full semantics:
  *
  * - `equals: V` — scalar equality. `actual` must be declared and must equal
  *   `V`. Absent fields (`undefined`) skip unless the capabilities schema
@@ -394,6 +394,10 @@ function schemaDefaultShouldApply(raw: unknown, dottedPath: string): boolean {
  *   includes `V` (strict equality, no coercion). Empty arrays, non-arrays,
  *   and absent fields all skip unless the capabilities schema declares a
  *   default that the gate materialized before predicate evaluation.
+ *
+ * - `not_contains: V` — negative array-membership. `actual` must be an array
+ *   that does not include `V` (strict equality, no coercion). Missing and
+ *   non-array values skip; an empty array satisfies the predicate.
  *
  * Exported for direct testing so the predicate semantics are pinned without
  * needing a full runStoryboard() roundtrip.
@@ -421,6 +425,21 @@ export function evaluateCapabilityPredicate(predicate: RequiresCapabilityPredica
     if (!actual.includes(predicate.contains)) {
       return (
         `Capability predicate \`${predicate.path}\` must contain ${JSON.stringify(predicate.contains)}: ` +
+        `agent declared ${JSON.stringify(actual)}.`
+      );
+    }
+    return null;
+  }
+  if ('not_contains' in predicate) {
+    if (!Array.isArray(actual)) {
+      return (
+        `Capability predicate \`${predicate.path}\` must not contain ${JSON.stringify(predicate.not_contains)}: ` +
+        `agent declared ${actual === undefined ? 'no value' : JSON.stringify(actual)}.`
+      );
+    }
+    if (actual.includes(predicate.not_contains)) {
+      return (
+        `Capability predicate \`${predicate.path}\` must not contain ${JSON.stringify(predicate.not_contains)}: ` +
         `agent declared ${JSON.stringify(actual)}.`
       );
     }

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -17,7 +17,8 @@ import type { WebhookConformanceSigningOptions } from '../../conformance/types';
 export type RequiresCapabilityPredicate =
   | { path: string; equals: boolean | string | number | null }
   | { path: string; present: boolean }
-  | { path: string; contains: boolean | string | number };
+  | { path: string; contains: boolean | string | number }
+  | { path: string; not_contains: boolean | string | number };
 
 export interface Storyboard {
   id: string;
@@ -140,7 +141,7 @@ export interface Storyboard {
    * `path` is a dotted key path into the raw `get_adcp_capabilities` response
    * (e.g. `"adcp.idempotency.supported"`).
    *
-   * Two matcher forms — mutually exclusive on a single gate:
+   * Four matcher forms — mutually exclusive on a single gate:
    *
    * - `equals: V` — scalar equality. The path's resolved value must be
    *   declared and must equal `V` for the storyboard to run. When the path
@@ -172,6 +173,14 @@ export interface Storyboard {
    *   capability object is present. Like `present:`, absence is otherwise the
    *   load-bearing signal — a seller that doesn't advertise the array hasn't
    *   opted into the variant this storyboard tests.
+   *
+   * - `not_contains: V` — negative array-membership matcher. The value at
+   *   `path` MUST be an array and MUST NOT include `V` (strict equality, no
+   *   coercion). This is useful for rejection scenarios that apply only when
+   *   an advertised allowlist omits a value. Missing and non-array values do
+   *   not satisfy the predicate; a separate discovery validation should grade
+   *   a required capability declaration. Schema defaults are materialized on
+   *   the same terms as `contains`.
    *
    * When `raw_capabilities` is not available and the discovered profile does
    * not expose `get_adcp_capabilities`, `equals` gates are treated as
@@ -978,6 +987,13 @@ export type StoryboardValidationCheck =
    */
   | 'field_equals_context'
   /**
+   * Assert a field in the current response is a member of an array captured
+   * from an earlier step via `context_key`. Missing context keeps the same
+   * branch-safe `context_key_absent` behavior as other cross-step checks;
+   * a present non-array context value fails the check.
+   */
+  | 'field_in_context_array'
+  /**
    * Asserts upstream side-effects against the adopter's
    * `comply_test_controller`'s `query_upstream_traffic` scenario. The
    * load-bearing anti-façade contract: a fully-conformant adapter and a
@@ -1260,11 +1276,12 @@ export interface StoryboardValidation {
    *  - `fail` — treat as missing
    */
   on_out_of_scope?: 'warn' | 'ignore' | 'fail';
-  // ─── field_less_than / field_equals_context fields ────────
+  // ─── Cross-step comparison fields ──────────────────────
   /**
    * Key to look up in the accumulated `storyboardContext` for cross-step
    * comparison checks (`field_less_than`, `field_greater_than`,
-   * `field_at_most`, `field_at_least`, `field_equals_context`).
+   * `field_at_most`, `field_at_least`, `field_equals_context`,
+   * `field_in_context_array`).
    * Only consumed by those check types — ignored on all others.
    * When set and the key is absent from context, the check passes with a
    * `context_key_absent` observation rather than failing — the prior step

--- a/src/lib/testing/storyboard/validations.ts
+++ b/src/lib/testing/storyboard/validations.ts
@@ -337,6 +337,8 @@ function runValidation(validation: StoryboardValidation, ctx: ValidationContext)
       return validateNumericComparison(validation, ctx, NUMERIC_OPS.at_least);
     case 'field_equals_context':
       return validateFieldEqualsContext(validation, ctx);
+    case 'field_in_context_array':
+      return validateFieldInContextArray(validation, ctx);
     case 'upstream_traffic':
       return validateUpstreamTraffic(validation, ctx);
     case 'replay_not_cached_rate_limit':
@@ -2895,6 +2897,77 @@ function validateFieldEqualsContext(validation: StoryboardValidation, ctx: Valid
     error: `Expected ${JSON.stringify(expected)} (from context["${validation.context_key}"]); got ${JSON.stringify(actual ?? null)}`,
     json_pointer: pointer,
     expected,
+    actual: actual ?? null,
+  };
+}
+
+function validateFieldInContextArray(validation: StoryboardValidation, ctx: ValidationContext): ValidationResult {
+  if (!validation.path) {
+    return {
+      check: 'field_in_context_array',
+      passed: false,
+      description: validation.description,
+      error: 'No path specified for field_in_context_array validation',
+      json_pointer: null,
+      expected: 'path must be set in storyboard validation entry',
+      actual: null,
+    };
+  }
+  if (!validation.context_key) {
+    return {
+      check: 'field_in_context_array',
+      passed: false,
+      description: validation.description,
+      error: 'field_in_context_array requires context_key to be set',
+      json_pointer: null,
+      expected: 'context_key must be set in storyboard validation entry',
+      actual: null,
+    };
+  }
+
+  const comparandResult = resolveContextComparand(validation, ctx);
+  if (!comparandResult.found) {
+    return {
+      check: 'field_in_context_array',
+      passed: true,
+      description: validation.description,
+      observations: [comparandResult.observation],
+    };
+  }
+
+  const allowed = comparandResult.value;
+  const actual = resolvePath(resolveTarget(ctx).data, validation.path);
+  const pointer = toJsonPointer(validation.path);
+  if (!Array.isArray(allowed)) {
+    return {
+      check: 'field_in_context_array',
+      passed: false,
+      description: validation.description,
+      path: validation.path,
+      error: `Expected context["${validation.context_key}"] to be an array; got ${JSON.stringify(allowed)}`,
+      json_pointer: pointer,
+      expected: 'context value must be an array',
+      actual: allowed,
+    };
+  }
+
+  if (allowed.some(candidate => valuesMatch(actual, candidate))) {
+    return {
+      check: 'field_in_context_array',
+      passed: true,
+      description: validation.description,
+      path: validation.path,
+      json_pointer: pointer,
+    };
+  }
+  return {
+    check: 'field_in_context_array',
+    passed: false,
+    description: validation.description,
+    path: validation.path,
+    error: `Expected ${JSON.stringify(actual ?? null)} to be a member of context["${validation.context_key}"] (${JSON.stringify(allowed)})`,
+    json_pointer: pointer,
+    expected: allowed,
     actual: actual ?? null,
   };
 }

--- a/test/lib/storyboard-capability-gate.test.js
+++ b/test/lib/storyboard-capability-gate.test.js
@@ -825,6 +825,24 @@ describe('requires_capability `contains:` matcher (#1817)', () => {
   });
 });
 
+describe('requires_capability `not_contains:` matcher', () => {
+  test('evaluateCapabilityPredicate: pins negative membership semantics', () => {
+    const notContainsString = { path: 'account.supported_billing', not_contains: 'advertiser' };
+    const notContainsNumber = { path: 'x.y', not_contains: 42 };
+
+    assert.equal(evaluateCapabilityPredicate(notContainsString, ['operator', 'agent']), null);
+    assert.equal(evaluateCapabilityPredicate(notContainsString, []), null);
+    assert.ok(evaluateCapabilityPredicate(notContainsString, ['operator', 'advertiser'])?.includes('must not contain'));
+
+    assert.ok(evaluateCapabilityPredicate(notContainsString, undefined)?.includes('no value'));
+    assert.ok(evaluateCapabilityPredicate(notContainsString, 'operator')?.includes('must not contain'));
+    assert.ok(evaluateCapabilityPredicate(notContainsString, null)?.includes('must not contain'));
+
+    assert.equal(evaluateCapabilityPredicate(notContainsNumber, ['42']), null, 'membership is strict');
+    assert.ok(evaluateCapabilityPredicate(notContainsNumber, [42])?.includes('must not contain'));
+  });
+});
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Phase-level `requires_capability` gates (adcp-client#2224) — same matcher
 // dialect as storyboard-level gates, but scoped to one phase.
@@ -902,6 +920,36 @@ const creativeApprovalPhaseGatedStoryboard = {
   ],
 };
 
+const unsupportedBillingPhaseGatedStoryboard = {
+  id: 'phase_capability_gate_unsupported_billing_test',
+  version: '1.0.0',
+  title: 'Unsupported billing rejection',
+  category: 'test',
+  summary: 'Runs only when advertiser billing is not advertised.',
+  narrative: '',
+  agent: { interaction_model: 'sync', capabilities: [] },
+  caller: { role: 'buyer_agent' },
+  phases: [
+    {
+      id: 'unsupported_advertiser_billing',
+      title: 'Reject unsupported advertiser billing',
+      requires_capability: {
+        path: 'account.supported_billing',
+        not_contains: 'advertiser',
+      },
+      steps: [
+        {
+          id: 'sync_accounts_unsupported_billing',
+          title: 'Submit unsupported billing',
+          task: 'sync_accounts',
+          sample_request: {},
+          validations: [],
+        },
+      ],
+    },
+  ],
+};
+
 function makeCapabilityGateClient(responder = () => ({ success: true, data: {} })) {
   const calls = [];
   const client = {
@@ -914,6 +962,47 @@ function makeCapabilityGateClient(responder = () => ({ success: true, data: {} }
 }
 
 describe('phase-level requires_capability gate (#2224)', () => {
+  test('not_contains runs a phase when the advertised array omits the value', async () => {
+    const { client, calls } = makeCapabilityGateClient();
+    const result = await runStoryboard('https://example.invalid/mcp', unsupportedBillingPhaseGatedStoryboard, {
+      protocol: 'mcp',
+      agentTools: ['get_adcp_capabilities', 'sync_accounts'],
+      _profile: {
+        name: 'Test Agent (operator billing only)',
+        tools: ['get_adcp_capabilities', 'sync_accounts'],
+        raw_capabilities: { account: { supported_billing: ['operator'] } },
+      },
+      _client: client,
+    });
+
+    assert.equal(result.skipped_count, 0);
+    assert.equal(result.passed_count, 1);
+    assert.deepEqual(
+      calls.map(call => call.name),
+      ['sync_accounts']
+    );
+  });
+
+  test('not_contains skips a phase when the advertised array includes the value', async () => {
+    const { client, calls } = makeCapabilityGateClient();
+    const result = await runStoryboard('https://example.invalid/mcp', unsupportedBillingPhaseGatedStoryboard, {
+      protocol: 'mcp',
+      agentTools: ['get_adcp_capabilities', 'sync_accounts'],
+      _profile: {
+        name: 'Test Agent (advertiser billing supported)',
+        tools: ['get_adcp_capabilities', 'sync_accounts'],
+        raw_capabilities: { account: { supported_billing: ['operator', 'advertiser'] } },
+      },
+      _client: client,
+    });
+
+    assert.equal(result.skipped_count, 1);
+    assert.equal(result.failed_count, 0);
+    assert.equal(result.phases[0].steps[0].skip_reason, 'not_applicable');
+    assert.ok(result.phases[0].steps[0].skip.detail.includes('must not contain'));
+    assert.deepEqual(calls, []);
+  });
+
   test('skips deterministic_session as not_applicable when sponsored_intelligence is not advertised', async () => {
     const result = await runStoryboard('http://fake-local-99992', deterministicSessionPhaseGatedStoryboard, {
       _profile: {

--- a/test/storyboard-cross-step-validators.test.js
+++ b/test/storyboard-cross-step-validators.test.js
@@ -378,3 +378,73 @@ describe('field_equals_context', () => {
     assert.strictEqual(result.passed, true);
   });
 });
+
+// ──────────────────────────────────────────────────────────────
+// field_in_context_array
+// ─────────────────────────────────────────────────────────────
+
+describe('field_in_context_array', () => {
+  it('passes when the response field is a member of the captured array', () => {
+    const [result] = runValidations(
+      [
+        {
+          check: 'field_in_context_array',
+          path: 'billing',
+          context_key: 'supported_billing',
+          description: 'billing advertised',
+        },
+      ],
+      makeCtx({ data: { billing: 'operator' }, storyboardContext: { supported_billing: ['operator', 'agent'] } })
+    );
+    assert.strictEqual(result.passed, true);
+  });
+
+  it('fails when the response field is outside the captured array', () => {
+    const [result] = runValidations(
+      [
+        {
+          check: 'field_in_context_array',
+          path: 'billing',
+          context_key: 'supported_billing',
+          description: 'billing advertised',
+        },
+      ],
+      makeCtx({ data: { billing: 'advertiser' }, storyboardContext: { supported_billing: ['operator', 'agent'] } })
+    );
+    assert.strictEqual(result.passed, false);
+    assert.deepStrictEqual(result.expected, ['operator', 'agent']);
+    assert.strictEqual(result.actual, 'advertiser');
+  });
+
+  it('fails when the captured context value is not an array', () => {
+    const [result] = runValidations(
+      [
+        {
+          check: 'field_in_context_array',
+          path: 'billing',
+          context_key: 'supported_billing',
+          description: 'billing advertised',
+        },
+      ],
+      makeCtx({ data: { billing: 'operator' }, storyboardContext: { supported_billing: 'operator' } })
+    );
+    assert.strictEqual(result.passed, false);
+    assert.ok(result.error.includes('to be an array'));
+  });
+
+  it('passes with an observation when the context key is absent', () => {
+    const [result] = runValidations(
+      [
+        {
+          check: 'field_in_context_array',
+          path: 'billing',
+          context_key: 'missing',
+          description: 'billing advertised',
+        },
+      ],
+      makeCtx({ data: { billing: 'operator' }, storyboardContext: {} })
+    );
+    assert.strictEqual(result.passed, true);
+    assert.ok(result.observations[0].includes('context_key_absent'));
+  });
+});


### PR DESCRIPTION
## Summary

- add `requires_capability.not_contains` for phases that probe values omitted from an advertised capability array
- add `field_in_context_array` for cross-step membership checks against a captured runtime array
- pin both behaviors with focused runner and validator tests

This is the runner prerequisite for the data-driven `supported_billing` compliance checks in adcontextprotocol/adcp#5916.

## Validation

- `npm run build`
- focused Node test suites (77 tests)
- `npm run typecheck`
- `npm run lint` (existing warnings only; zero errors)
- Prettier check

Supports adcontextprotocol/adcp#5916.
