### PR TITLE
fix: delete params alongside format_kind when downgrading package selectors

### DIFF
--- a/.changeset/orphaned-params-legacy-downgrade.md
+++ b/.changeset/orphaned-params-legacy-downgrade.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Fix `createMediaBuy`/`updateMediaBuy` leaving an orphaned `params` object on a package after downgrading a canonical `format_kind` + `params` selector to the legacy `format_ids` shape, which produced a wire payload matching neither the canonical nor legacy contract.

--- a/src/lib/v2/projection/creative-delivery.ts
+++ b/src/lib/v2/projection/creative-delivery.ts
@@ -917,6 +917,7 @@ function projectPackageSelectors(
         next.format_ids = resolved;
         delete next.format_option_refs;
         delete next.format_kind;
+        delete next.params;
         return next;
       }
       next.format_ids = dedupeLegacyRefs(selectedCandidates.map(candidate => candidate.ref));
@@ -960,6 +961,7 @@ function projectPackageSelectors(
       }
     }
     delete next.format_kind;
+    delete next.params;
   }
 
   return next;

--- a/test/lib/creative-format-projection.test.js
+++ b/test/lib/creative-format-projection.test.js
@@ -476,6 +476,31 @@ describe('creative format delivery projection', () => {
     );
   });
 
+  test('deletes params alongside format_kind when downgrading a package selector to legacy format_ids', () => {
+    const projected = projectMediaBuyCreativesForDelivery(
+      {
+        packages: [
+          {
+            product_id: 'product-123',
+            format_kind: 'video_hosted',
+            params: { width: 640, height: 480 },
+            creatives: [{ creative_id: 'creative-1', name: 'Creative', format_kind: 'video_hosted', assets: {} }],
+          },
+        ],
+      },
+      'legacy',
+      'create_media_buy',
+      undefined,
+      () => ({ agent_url: 'https://seller.example/formats', id: 'video_hosted_v1' })
+    );
+
+    assert.deepStrictEqual(projected.packages[0].format_ids, [
+      { agent_url: 'https://seller.example/formats', id: 'video_hosted_v1' },
+    ]);
+    assert.equal(Object.hasOwn(projected.packages[0], 'format_kind'), false);
+    assert.equal(Object.hasOwn(projected.packages[0], 'params'), false);
+  });
+
   const formats = [
     ['image', { agent_url: SELLER, id: 'display_300x250_image', width: 300, height: 250 }],
     ['html5', { agent_url: SELLER, id: 'display_728x90_html', width: 728, height: 90 }],

--- a/test/lib/creative-format-projection.test.js
+++ b/test/lib/creative-format-projection.test.js
@@ -446,6 +446,34 @@ describe('creative format delivery projection', () => {
     );
   });
 
+  test('deletes params alongside format_option_refs when the resolver fallback downgrades a package to legacy format_ids', () => {
+    const first = { agent_url: 'https://seller.example/formats', id: 'image_mrec' };
+    const second = { agent_url: 'https://seller.example/formats', id: 'image_leaderboard' };
+    const projected = projectMediaBuyCreativesForDelivery(
+      {
+        packages: [
+          {
+            product_id: 'multi-option-product',
+            format_option_refs: [
+              { scope: 'product', format_option_id: 'mrec' },
+              { scope: 'product', format_option_id: 'leaderboard' },
+            ],
+            params: { width: 300, height: 250 },
+          },
+        ],
+      },
+      'legacy',
+      'create_media_buy',
+      undefined,
+      context => (context.source === 'selector' ? [first, second] : undefined)
+    );
+
+    assert.deepStrictEqual(projected.packages[0].format_ids, [first, second]);
+    assert.equal(Object.hasOwn(projected.packages[0], 'format_option_refs'), false);
+    assert.equal(Object.hasOwn(projected.packages[0], 'format_kind'), false);
+    assert.equal(Object.hasOwn(projected.packages[0], 'params'), false);
+  });
+
   test('fails closed when a creative in a multi-option package has no unambiguous selection', () => {
     const refs = [
       { agent_url: 'https://seller.example/formats', id: 'image_mrec' },


### PR DESCRIPTION
## Why

Fixes #2541. When `createMediaBuy`/`updateMediaBuy` internally downgrades a canonical `format_kind` + `params` package selector to the legacy `format_ids` wire shape (e.g. because the negotiated seller doesn't support canonical formats), it deleted `format_kind` but left `params` behind. The resulting wire payload matched neither the canonical shape (`format_kind` + `params` together) nor the legacy shape (`format_ids` only), so sellers with strict schema validation requiring `format_kind` whenever `params` is present correctly rejected an otherwise fully valid request.

## What Changed

- `src/lib/v2/projection/creative-delivery.ts`: `projectPackageSelectors` now deletes `params` alongside `format_kind` in both legacy-downgrade branches — the `format_option_refs` resolver-fallback early return, and the `format_kind`-only canonicalKind branch.
- Added regression tests in `test/lib/creative-format-projection.test.js` covering both branches; verified each fails without its corresponding fix and passes with it (TDD).
- Audited the rest of the projection code for the same asymmetric-delete pattern (creative-level projection, other projection modules) — confirmed no other occurrences; `format_option_refs` deletion was already correctly paired, and creatives don't carry a `params` field at all.
- Added a changeset.

## Test plan

- [x] New regression tests fail before the fix, pass after (`node --test test/lib/creative-format-projection.test.js`)
- [x] Full related suite green (179 tests across creative-format-projection, v2-write-side, v2-to-v1/v1-to-v2 projection, roundtrip matrix, agent-client, adcp-client)
- [x] `tsc --project tsconfig.lib.json --noEmit` clean
- [x] Changeset added

🤖 Generated with [Claude Code](https://claude.com/claude-code)