### PR TITLE
fix(storyboard): deep-match capability gate values

### DIFF
--- a/.changeset/deep-match-capability-gates.md
+++ b/.changeset/deep-match-capability-gates.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Structurally match JSON-valued entries in storyboard `contains` and `not_contains` capability gates, including object-valued governance task declarations.

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -391,12 +391,12 @@ function schemaDefaultShouldApply(raw: unknown, dottedPath: string): boolean {
  *   `resolveCapabilityPathForGate`).
  *
  * - `contains: V` — array-membership. `actual` must be an array that
- *   includes `V` (strict equality, no coercion). Empty arrays, non-arrays,
+ *   includes `V` (structural JSON equality, no coercion). Empty arrays, non-arrays,
  *   and absent fields all skip unless the capabilities schema declares a
  *   default that the gate materialized before predicate evaluation.
  *
  * - `not_contains: V` — negative array-membership. `actual` must be an array
- *   that does not include `V` (strict equality, no coercion). Missing and
+ *   that does not include `V` (structural JSON equality, no coercion). Missing and
  *   non-array values skip; an empty array satisfies the predicate.
  *
  * Exported for direct testing so the predicate semantics are pinned without
@@ -422,7 +422,7 @@ export function evaluateCapabilityPredicate(predicate: RequiresCapabilityPredica
         `agent declared ${actual === undefined ? 'no value' : JSON.stringify(actual)}.`
       );
     }
-    if (!actual.includes(predicate.contains)) {
+    if (!actual.some(value => capabilityValuesEqual(value, predicate.contains))) {
       return (
         `Capability predicate \`${predicate.path}\` must contain ${JSON.stringify(predicate.contains)}: ` +
         `agent declared ${JSON.stringify(actual)}.`
@@ -437,7 +437,7 @@ export function evaluateCapabilityPredicate(predicate: RequiresCapabilityPredica
         `agent declared ${actual === undefined ? 'no value' : JSON.stringify(actual)}.`
       );
     }
-    if (actual.includes(predicate.not_contains)) {
+    if (actual.some(value => capabilityValuesEqual(value, predicate.not_contains))) {
       return (
         `Capability predicate \`${predicate.path}\` must not contain ${JSON.stringify(predicate.not_contains)}: ` +
         `agent declared ${JSON.stringify(actual)}.`
@@ -460,6 +460,25 @@ export function evaluateCapabilityPredicate(predicate: RequiresCapabilityPredica
     );
   }
   return null;
+}
+
+/** Key-order-insensitive equality for JSON-valued capability declarations. */
+function capabilityValuesEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (typeof a !== typeof b || a === null || b === null || typeof a !== 'object') return false;
+  if (Array.isArray(a)) {
+    if (!Array.isArray(b) || a.length !== b.length) return false;
+    return a.every((value, index) => capabilityValuesEqual(value, b[index]));
+  }
+  if (Array.isArray(b)) return false;
+  const aRecord = a as Record<string, unknown>;
+  const bRecord = b as Record<string, unknown>;
+  const aKeys = Object.keys(aRecord).sort();
+  const bKeys = Object.keys(bRecord).sort();
+  return (
+    aKeys.length === bKeys.length &&
+    aKeys.every((key, index) => key === bKeys[index] && capabilityValuesEqual(aRecord[key], bRecord[key]))
+  );
 }
 
 function evaluateRequiresCapabilityGate(

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -14,11 +14,19 @@ import type { WebhookConformanceSigningOptions } from '../../conformance/types';
 // Parsed storyboard structure (mirrors YAML schema)
 // ────────────────────────────────────────────────────────────
 
+export type CapabilityPredicateValue =
+  | boolean
+  | string
+  | number
+  | null
+  | CapabilityPredicateValue[]
+  | { [key: string]: CapabilityPredicateValue };
+
 export type RequiresCapabilityPredicate =
   | { path: string; equals: boolean | string | number | null }
   | { path: string; present: boolean }
-  | { path: string; contains: boolean | string | number }
-  | { path: string; not_contains: boolean | string | number };
+  | { path: string; contains: CapabilityPredicateValue }
+  | { path: string; not_contains: CapabilityPredicateValue };
 
 export interface Storyboard {
   id: string;
@@ -167,7 +175,7 @@ export interface Storyboard {
    *   declaration shape is an array of allowed values (e.g.
    *   `media_buy.conversion_tracking.supported_targets: ["cost_per",
    *   "per_ad_spend"]`). The value at `path` MUST be an array and MUST include
-   *   `V` (strict equality, no coercion). Empty arrays fail; paths resolving
+   *   `V` (structural JSON equality, no coercion). Empty arrays fail; paths resolving
    *   to undefined or non-array values fail unless the `get_adcp_capabilities`
    *   response schema declares a default for that exact path and the parent
    *   capability object is present. Like `present:`, absence is otherwise the
@@ -175,7 +183,7 @@ export interface Storyboard {
    *   opted into the variant this storyboard tests.
    *
    * - `not_contains: V` — negative array-membership matcher. The value at
-   *   `path` MUST be an array and MUST NOT include `V` (strict equality, no
+   *   `path` MUST be an array and MUST NOT include `V` (structural JSON equality, no
    *   coercion). This is useful for rejection scenarios that apply only when
    *   an advertised allowlist omits a value. Missing and non-array values do
    *   not satisfy the predicate; a separate discovery validation should grade

--- a/test/lib/storyboard-capability-gate.test.js
+++ b/test/lib/storyboard-capability-gate.test.js
@@ -823,6 +823,55 @@ describe('requires_capability `contains:` matcher (#1817)', () => {
     assert.ok(evaluateCapabilityPredicate(containsNumber, ['42'])?.includes('must contain'));
     assert.ok(evaluateCapabilityPredicate(containsString, [42])?.includes('must contain'));
   });
+
+  test('contains: structurally matches object-valued capability entries', async () => {
+    const governanceTask = {
+      task: 'activate_signal',
+      modes: ['signed_context'],
+    };
+    const storyboard = {
+      ...supportedTargetsGatedStoryboard,
+      requires_capability: {
+        path: 'adcp.governance_enforcement.tasks',
+        contains: governanceTask,
+      },
+    };
+    const profile = {
+      name: 'Test Agent (signed signal governance)',
+      tools: ['get_adcp_capabilities', 'log_event'],
+      raw_capabilities: {
+        adcp: {
+          governance_enforcement: {
+            tasks: [{ modes: ['signed_context'], task: 'activate_signal' }],
+          },
+        },
+      },
+    };
+
+    const { client } = makeCapabilityGateClient();
+    const result = await runStoryboard('https://example.invalid/mcp', storyboard, {
+      protocol: 'mcp',
+      agentTools: profile.tools,
+      _profile: profile,
+      _client: client,
+    });
+
+    assert.equal(result.skipped_count, 0, 'matching object gate must not be skipped');
+    assert.equal(
+      evaluateCapabilityPredicate(
+        storyboard.requires_capability,
+        profile.raw_capabilities.adcp.governance_enforcement.tasks
+      ),
+      null,
+      'object key order must not affect membership'
+    );
+    assert.ok(
+      evaluateCapabilityPredicate(storyboard.requires_capability, [
+        { task: 'activate_signal', modes: ['unsigned_context'] },
+      ])?.includes('must contain'),
+      'nested array values remain significant'
+    );
+  });
 });
 
 describe('requires_capability `not_contains:` matcher', () => {
@@ -840,6 +889,16 @@ describe('requires_capability `not_contains:` matcher', () => {
 
     assert.equal(evaluateCapabilityPredicate(notContainsNumber, ['42']), null, 'membership is strict');
     assert.ok(evaluateCapabilityPredicate(notContainsNumber, [42])?.includes('must not contain'));
+
+    const notContainsObject = {
+      path: 'adcp.governance_enforcement.tasks',
+      not_contains: { task: 'activate_signal', modes: ['signed_context'] },
+    };
+    assert.ok(
+      evaluateCapabilityPredicate(notContainsObject, [
+        { modes: ['signed_context'], task: 'activate_signal' },
+      ])?.includes('must not contain')
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- support JSON-valued `contains` and `not_contains` capability predicates
- compare object entries structurally, independent of object key order
- cover the `adcp.governance_enforcement.tasks[]` signal-governance gate through the real storyboard runner

Unblocks adcontextprotocol/adcp#6590.

## Validation
- `npm run build`
- `node --test-timeout=60000 --test-force-exit --test test/lib/storyboard-capability-gate.test.js`
- `npm run typecheck`
- `npm run lint` (0 errors; existing warnings only)