### PR TITLE
fix: preserve scoped storyboard routing

### DIFF
--- a/.changeset/fix-scoped-storyboard-routing.md
+++ b/.changeset/fix-scoped-storyboard-routing.md
@@ -2,4 +2,4 @@
 '@adcp/sdk': patch
 ---
 
-Use request-scoped seller capabilities for protocol-version adaptation instead of stale capabilities cached from another request context.
+Use request-scoped seller capabilities for protocol-version adaptation instead of stale capabilities cached from another request context. Keep canonical product-discovery storyboards on the raw response projection so they can grade dual legacy and canonical format declarations without changing the requested wire.

--- a/.changeset/fix-scoped-storyboard-routing.md
+++ b/.changeset/fix-scoped-storyboard-routing.md
@@ -2,4 +2,4 @@
 '@adcp/sdk': patch
 ---
 
-Use request-scoped seller capabilities for protocol-version adaptation instead of stale capabilities cached from another request context. Keep canonical product-discovery storyboards on the raw response projection so they can grade dual legacy and canonical format declarations without changing the requested wire.
+Use request-scoped seller capabilities for protocol-version adaptation instead of stale capabilities cached from another request context. Add an explicit raw storyboard response projection so compatibility scenarios can grade dual legacy and canonical format declarations without changing the seller request.

--- a/.changeset/fix-scoped-storyboard-routing.md
+++ b/.changeset/fix-scoped-storyboard-routing.md
@@ -2,4 +2,4 @@
 '@adcp/sdk': patch
 ---
 
-Preserve canonical product discovery in AdCP 3.1 storyboards and use request-scoped seller capabilities for protocol-version adaptation instead of stale capabilities cached from another request context.
+Use request-scoped seller capabilities for protocol-version adaptation instead of stale capabilities cached from another request context.

--- a/.changeset/fix-scoped-storyboard-routing.md
+++ b/.changeset/fix-scoped-storyboard-routing.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Preserve canonical product discovery in AdCP 3.1 storyboards and use request-scoped seller capabilities for protocol-version adaptation instead of stale capabilities cached from another request context.

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -207,7 +207,10 @@ import { canonicalize as canonicalizeJson } from '../utils/jcs';
 
 type ReadRequestOptions = Pick<TaskOptions, 'signal' | 'transport'>;
 type ToolSchemaMap = Map<string, Record<string, unknown>>;
-type CapabilityDiscoveryContext = { toolSchemas?: ToolSchemaMap };
+type CapabilityDiscoveryContext = {
+  toolSchemas?: ToolSchemaMap;
+  capabilities?: AdcpCapabilities;
+};
 const CAPABILITY_DISCOVERY_CONTEXT = Symbol('capabilityDiscoveryContext');
 type InternalReadRequestOptions = ReadRequestOptions & {
   [CAPABILITY_DISCOVERY_CONTEXT]?: CapabilityDiscoveryContext;
@@ -3003,7 +3006,8 @@ export class SingleAgentClient {
       normalizedParams,
       serverVersion,
       inputSchemaStripLogs,
-      capabilityDiscoveryContext.toolSchemas
+      capabilityDiscoveryContext.toolSchemas,
+      capabilityDiscoveryContext.capabilities
     );
 
     // Symmetric to the pre-adapter v3 pass above: when the adapter
@@ -3946,7 +3950,8 @@ export class SingleAgentClient {
     params: any,
     serverVersion: string,
     debugLogs?: any[],
-    perCallToolSchemas?: ToolSchemaMap
+    perCallToolSchemas?: ToolSchemaMap,
+    perCallCapabilities?: AdcpCapabilities
   ): { params: any; driftLogs: Record<string, unknown>[] } {
     const driftLogs: Record<string, unknown>[] = [];
     let adapted = params;
@@ -4082,7 +4087,7 @@ export class SingleAgentClient {
     // AdCP version. `resolveAdapterKey` returns the effective target version
     // based on the client pin and the seller's advertised caps; adapters live
     // in `src/lib/adapters/version/<target>/`.
-    const adapterKey = resolveAdapterKey(this.resolvedAdcpVersion, this.cachedCapabilities);
+    const adapterKey = resolveAdapterKey(this.resolvedAdcpVersion, perCallCapabilities ?? this.cachedCapabilities);
     if (adapterKey) {
       const versionAdapter = getVersionAdapter(adapterKey, taskType);
       if (versionAdapter) {
@@ -5458,7 +5463,8 @@ export class SingleAgentClient {
         normalizedParams,
         serverVersion,
         inputSchemaStripLogs,
-        capabilityDiscoveryContext.toolSchemas
+        capabilityDiscoveryContext.toolSchemas,
+        capabilityDiscoveryContext.capabilities
       );
 
       // Symmetric warn-only post-adapter pass against the v2.5 schema bundle.
@@ -6534,6 +6540,8 @@ export class SingleAgentClient {
    */
   async detectServerVersion(options?: ReadRequestOptions): Promise<'v2' | 'v3'> {
     const capabilities = await this.getCapabilities(options);
+    const discoveryContext = (options as InternalReadRequestOptions | undefined)?.[CAPABILITY_DISCOVERY_CONTEXT];
+    if (discoveryContext) discoveryContext.capabilities = capabilities;
     return capabilities.version;
   }
 

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -5036,6 +5036,7 @@ async function executeStep(
         executeStoryboardTask(client, effectiveStep.task, request, {
           skipIdempotencyAutoInject: testsMissingIdempotencyKey,
           skipAccountValidation: testsMissingAccount,
+          responseProjection: effectiveStep.response_projection,
           signal: options.signal,
         });
       const run = await runStep(step.title, effectiveStep.task, async () => {

--- a/src/lib/testing/storyboard/task-map.test.ts
+++ b/src/lib/testing/storyboard/task-map.test.ts
@@ -112,6 +112,29 @@ describe('executeStoryboardTask — adcp_error forwarding', () => {
     expect(result.data).toEqual({ products: [], format: 'canonical' });
   });
 
+  it('uses the raw product projection without changing an unhinted request', async () => {
+    const calls: string[] = [];
+    let receivedParams: unknown;
+    const params = { context: { correlation_id: 'dual-format-grading' } };
+    const client = {
+      getAdcpVersion: () => '3.1.10',
+      getProducts: async () => {
+        calls.push('canonical');
+        return { data: { products: [] } };
+      },
+      getProductsLegacy: async (request: unknown) => {
+        calls.push('raw');
+        receivedParams = request;
+        return { data: { products: [], format: 'dual' } };
+      },
+    };
+
+    const result = await executeStoryboardTask(client, 'get_products', params, { responseProjection: 'raw' });
+    expect(calls).toEqual(['raw']);
+    expect(receivedParams).toBe(params);
+    expect(result.data).toEqual({ products: [], format: 'dual' });
+  });
+
   it('forwards adcpError from a TaskResultFailure into adcp_error', async () => {
     const client = makeFailureClient(INVALID_REQUEST_ERROR);
     const result = await executeStoryboardTask(client, 'create_media_buy', {});

--- a/src/lib/testing/storyboard/task-map.ts
+++ b/src/lib/testing/storyboard/task-map.ts
@@ -195,10 +195,7 @@ export async function executeStoryboardTask(
   const legacyMethodName = useLegacyCreativeMethod ? LEGACY_CREATIVE_TASK_TO_METHOD[taskName] : undefined;
   const methodName =
     legacyMethodName ?? (Object.hasOwn(TASK_TO_METHOD, taskName) ? TASK_TO_METHOD[taskName] : undefined);
-  // getProductsLegacy selects the raw response projection, not a legacy-only
-  // request contract. Leave its wire hint unset so the seller can return the
-  // canonical format_options required by canonical discovery storyboards.
-  const callParams = legacyMethodName && taskName !== 'get_products' ? withLegacyCreativeWireHint(params) : params;
+  const callParams = legacyMethodName ? withLegacyCreativeWireHint(params) : params;
 
   // Only pass TaskOptions when a flag is actually set — avoids changing
   // behavior for the common path that relies on method defaults.

--- a/src/lib/testing/storyboard/task-map.ts
+++ b/src/lib/testing/storyboard/task-map.ts
@@ -195,7 +195,10 @@ export async function executeStoryboardTask(
   const legacyMethodName = useLegacyCreativeMethod ? LEGACY_CREATIVE_TASK_TO_METHOD[taskName] : undefined;
   const methodName =
     legacyMethodName ?? (Object.hasOwn(TASK_TO_METHOD, taskName) ? TASK_TO_METHOD[taskName] : undefined);
-  const callParams = legacyMethodName ? withLegacyCreativeWireHint(params) : params;
+  // getProductsLegacy selects the raw response projection, not a legacy-only
+  // request contract. Leave its wire hint unset so the seller can return the
+  // canonical format_options required by canonical discovery storyboards.
+  const callParams = legacyMethodName && taskName !== 'get_products' ? withLegacyCreativeWireHint(params) : params;
 
   // Only pass TaskOptions when a flag is actually set — avoids changing
   // behavior for the common path that relies on method defaults.

--- a/src/lib/testing/storyboard/task-map.ts
+++ b/src/lib/testing/storyboard/task-map.ts
@@ -191,7 +191,13 @@ export async function executeStoryboardTask(
 
   // AdCP 3.1 transition storyboards default to the legacy creative wire, but
   // canonical-specific storyboards must be able to opt into the canonical API.
-  const useLegacyCreativeMethod = gradesLegacyCreativeWire(client) && readCreativeWireHint(params) !== 'canonical';
+  const creativeWireHint = readCreativeWireHint(params);
+  // getProductsLegacy is the raw-response projection needed to grade both
+  // format_ids and format_options during the migration window. Its request
+  // wire is negotiated independently below: unhinted calls default to legacy,
+  // while an explicit canonical hint is preserved.
+  const useLegacyCreativeMethod =
+    gradesLegacyCreativeWire(client) && (taskName === 'get_products' || creativeWireHint !== 'canonical');
   const legacyMethodName = useLegacyCreativeMethod ? LEGACY_CREATIVE_TASK_TO_METHOD[taskName] : undefined;
   const methodName =
     legacyMethodName ?? (Object.hasOwn(TASK_TO_METHOD, taskName) ? TASK_TO_METHOD[taskName] : undefined);

--- a/src/lib/testing/storyboard/task-map.ts
+++ b/src/lib/testing/storyboard/task-map.ts
@@ -176,7 +176,12 @@ export async function executeStoryboardTask(
   client: any,
   taskName: string,
   params: Record<string, unknown>,
-  opts: { skipIdempotencyAutoInject?: boolean; skipAccountValidation?: boolean; signal?: AbortSignal } = {}
+  opts: {
+    skipIdempotencyAutoInject?: boolean;
+    skipAccountValidation?: boolean;
+    responseProjection?: 'raw';
+    signal?: AbortSignal;
+  } = {}
 ): Promise<TaskResult> {
   const unresolvedAssetDirectives = findUnresolvedCreativeAssetDirectives(params);
   if (unresolvedAssetDirectives.length > 0) {
@@ -191,17 +196,17 @@ export async function executeStoryboardTask(
 
   // AdCP 3.1 transition storyboards default to the legacy creative wire, but
   // canonical-specific storyboards must be able to opt into the canonical API.
-  const creativeWireHint = readCreativeWireHint(params);
-  // getProductsLegacy is the raw-response projection needed to grade both
-  // format_ids and format_options during the migration window. Its request
-  // wire is negotiated independently below: unhinted calls default to legacy,
-  // while an explicit canonical hint is preserved.
+  const forceRawProjection = opts.responseProjection === 'raw';
   const useLegacyCreativeMethod =
-    gradesLegacyCreativeWire(client) && (taskName === 'get_products' || creativeWireHint !== 'canonical');
+    forceRawProjection || (gradesLegacyCreativeWire(client) && readCreativeWireHint(params) !== 'canonical');
   const legacyMethodName = useLegacyCreativeMethod ? LEGACY_CREATIVE_TASK_TO_METHOD[taskName] : undefined;
   const methodName =
     legacyMethodName ?? (Object.hasOwn(TASK_TO_METHOD, taskName) ? TASK_TO_METHOD[taskName] : undefined);
-  const callParams = legacyMethodName ? withLegacyCreativeWireHint(params) : params;
+  // A forced raw projection is a runner concern, not wire negotiation. Leave
+  // the authored request untouched so dual-declaration storyboards can grade
+  // the seller's default response. Normal pre-3.2 grading still requests the
+  // legacy creative wire explicitly.
+  const callParams = legacyMethodName && !forceRawProjection ? withLegacyCreativeWireHint(params) : params;
 
   // Only pass TaskOptions when a flag is actually set — avoids changing
   // behavior for the common path that relies on method defaults.

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -659,6 +659,12 @@ export interface StoryboardStep {
   doc_ref?: string;
   /** Maps to existing @adcp/sdk test scenario (legacy, partial coverage) */
   comply_scenario?: string;
+  /**
+   * Select the SDK response projection used for this step. `raw` is reserved
+   * for compatibility storyboards that must grade both legacy and canonical
+   * fields from the same seller response without changing the request wire.
+   */
+  response_projection?: 'raw';
   /** Whether this step depends on state from a previous step */
   stateful?: boolean;
   /**

--- a/test/lib/request-validation.test.js
+++ b/test/lib/request-validation.test.js
@@ -1439,4 +1439,61 @@ describe('strict request validation against v2 servers', () => {
     assert.strictEqual(call.args.buying_mode, 'brief', 'buying_mode is preserved for v3');
     assert.deepStrictEqual(call.args.brand, { domain: 'example.com' }, 'brand is preserved for v3');
   });
+
+  test('request-scoped capabilities override a stale cache during version adaptation', async () => {
+    const mockMCPAgent = {
+      id: 'scoped-v31-agent',
+      name: 'Scoped AdCP 3.1 Agent',
+      agent_uri: 'https://agents.example.com/mcp',
+      protocol: 'mcp',
+    };
+    const client = new AdCPClient([mockMCPAgent]);
+    const agent = client.agent(mockMCPAgent.id);
+    const inner = agent.client;
+
+    inner.discoveredEndpoint = mockMCPAgent.agent_uri;
+    inner.cachedCapabilities = {
+      version: 'v3',
+      majorVersions: [3],
+      supportedVersions: ['3.0'],
+      protocols: ['media_buy'],
+      features: {},
+      extensions: [],
+      _synthetic: false,
+    };
+    inner.getCapabilities = async () => ({
+      version: 'v3',
+      majorVersions: [3],
+      supportedVersions: ['3.1'],
+      protocols: ['media_buy'],
+      features: {},
+      extensions: [],
+      _synthetic: false,
+    });
+
+    const capturedCalls = [];
+    const originalCallTool = ProtocolClient.callTool;
+    ProtocolClient.callTool = async (_agentConfig, toolName, args) => {
+      capturedCalls.push({ toolName, args });
+      return { status: 'completed', products: [] };
+    };
+
+    try {
+      await agent.getProductsLegacy({
+        buying_mode: 'brief',
+        brief: 'Premium ad placements',
+        filters: { pricing_currencies: ['USD'] },
+      });
+    } finally {
+      ProtocolClient.callTool = originalCallTool;
+    }
+
+    const call = capturedCalls.find(c => c.toolName === 'get_products');
+    assert.ok(call, 'get_products should have reached the protocol layer');
+    assert.deepStrictEqual(
+      call.args.filters?.pricing_currencies,
+      ['USD'],
+      'the stale 3.0 cache must not strip fields supported by the request-scoped 3.1 seller'
+    );
+  });
 });

--- a/test/lib/storyboard-task-map-error.test.js
+++ b/test/lib/storyboard-task-map-error.test.js
@@ -88,7 +88,7 @@ describe('executeStoryboardTask creative wire selection', () => {
     assert.equal(result.data.wire, 'canonical');
   });
 
-  test('uses the raw projection without forcing a legacy wire for unhinted 3.1 product discovery', async () => {
+  test('retains the legacy default for an unhinted 3.1 request', async () => {
     const calls = [];
     const result = await executeStoryboardTask(
       {
@@ -106,25 +106,8 @@ describe('executeStoryboardTask creative wire selection', () => {
       {}
     );
 
-    assert.deepEqual(calls, [{ method: 'legacy', request: {} }]);
+    assert.deepEqual(calls, [{ method: 'legacy', request: { ext: { adcp: { creative_wire: 'legacy' } } } }]);
     assert.equal(result.data.wire, 'legacy');
-  });
-
-  test('still forces the legacy wire for creative tasks on 3.1', async () => {
-    const calls = [];
-    await executeStoryboardTask(
-      {
-        getAdcpVersion: () => '3.1.10',
-        syncCreativesLegacy: async request => {
-          calls.push(request);
-          return { data: { creatives: [] } };
-        },
-      },
-      'sync_creatives',
-      {}
-    );
-
-    assert.deepEqual(calls, [{ ext: { adcp: { creative_wire: 'legacy' } } }]);
   });
 });
 

--- a/test/lib/storyboard-task-map-error.test.js
+++ b/test/lib/storyboard-task-map-error.test.js
@@ -88,7 +88,7 @@ describe('executeStoryboardTask creative wire selection', () => {
     assert.equal(result.data.wire, 'canonical');
   });
 
-  test('retains the legacy default for an unhinted 3.1 request', async () => {
+  test('uses the raw projection without forcing a legacy wire for unhinted 3.1 product discovery', async () => {
     const calls = [];
     const result = await executeStoryboardTask(
       {
@@ -106,8 +106,25 @@ describe('executeStoryboardTask creative wire selection', () => {
       {}
     );
 
-    assert.deepEqual(calls, [{ method: 'legacy', request: { ext: { adcp: { creative_wire: 'legacy' } } } }]);
+    assert.deepEqual(calls, [{ method: 'legacy', request: {} }]);
     assert.equal(result.data.wire, 'legacy');
+  });
+
+  test('still forces the legacy wire for creative tasks on 3.1', async () => {
+    const calls = [];
+    await executeStoryboardTask(
+      {
+        getAdcpVersion: () => '3.1.10',
+        syncCreativesLegacy: async request => {
+          calls.push(request);
+          return { data: { creatives: [] } };
+        },
+      },
+      'sync_creatives',
+      {}
+    );
+
+    assert.deepEqual(calls, [{ ext: { adcp: { creative_wire: 'legacy' } } }]);
   });
 });
 

--- a/test/lib/storyboard-task-map-error.test.js
+++ b/test/lib/storyboard-task-map-error.test.js
@@ -65,7 +65,7 @@ describe('executeStoryboardTask error normalization', () => {
 });
 
 describe('executeStoryboardTask creative wire selection', () => {
-  test('uses the raw product projection with an explicit canonical 3.1 wire', async () => {
+  test('uses the canonical method for an explicit canonical 3.1 request', async () => {
     const calls = [];
     const params = { ext: { adcp: { creative_wire: 'canonical' } } };
     const result = await executeStoryboardTask(
@@ -84,8 +84,8 @@ describe('executeStoryboardTask creative wire selection', () => {
       params
     );
 
-    assert.deepEqual(calls, [{ method: 'legacy', request: params }]);
-    assert.equal(result.data.wire, 'legacy');
+    assert.deepEqual(calls, [{ method: 'canonical', request: params }]);
+    assert.equal(result.data.wire, 'canonical');
   });
 
   test('retains the legacy default for an unhinted 3.1 request', async () => {
@@ -108,6 +108,30 @@ describe('executeStoryboardTask creative wire selection', () => {
 
     assert.deepEqual(calls, [{ method: 'legacy', request: { ext: { adcp: { creative_wire: 'legacy' } } } }]);
     assert.equal(result.data.wire, 'legacy');
+  });
+
+  test('uses a raw product projection without changing the authored wire', async () => {
+    const calls = [];
+    const params = { context: { correlation_id: 'dual-format-grading' } };
+    const result = await executeStoryboardTask(
+      {
+        getAdcpVersion: () => '3.1.10',
+        getProducts: async request => {
+          calls.push({ method: 'canonical', request });
+          return { data: { products: [], wire: 'canonical' } };
+        },
+        getProductsLegacy: async request => {
+          calls.push({ method: 'raw', request });
+          return { data: { products: [], wire: 'dual' } };
+        },
+      },
+      'get_products',
+      params,
+      { responseProjection: 'raw' }
+    );
+
+    assert.deepEqual(calls, [{ method: 'raw', request: params }]);
+    assert.equal(result.data.wire, 'dual');
   });
 });
 

--- a/test/lib/storyboard-task-map-error.test.js
+++ b/test/lib/storyboard-task-map-error.test.js
@@ -65,7 +65,7 @@ describe('executeStoryboardTask error normalization', () => {
 });
 
 describe('executeStoryboardTask creative wire selection', () => {
-  test('uses the canonical method for an explicit canonical 3.1 request', async () => {
+  test('uses the raw product projection with an explicit canonical 3.1 wire', async () => {
     const calls = [];
     const params = { ext: { adcp: { creative_wire: 'canonical' } } };
     const result = await executeStoryboardTask(
@@ -84,8 +84,8 @@ describe('executeStoryboardTask creative wire selection', () => {
       params
     );
 
-    assert.deepEqual(calls, [{ method: 'canonical', request: params }]);
-    assert.equal(result.data.wire, 'canonical');
+    assert.deepEqual(calls, [{ method: 'legacy', request: params }]);
+    assert.equal(result.data.wire, 'legacy');
   });
 
   test('retains the legacy default for an unhinted 3.1 request', async () => {


### PR DESCRIPTION
## Summary
- keep `get_products` storyboard discovery on the raw projection without forcing a legacy creative wire
- propagate request-scoped capabilities into version-adapter selection
- add regressions for canonical product discovery and stale cross-request capability caches

## Validation
- `npm run build`
- `node --test --test-timeout=60000 test/lib/storyboard-task-map-error.test.js test/lib/request-validation.test.js`
- `npm run lint`
- `npm run typecheck`
- pre-push validation