### PR TITLE
fix: grade raw product responses in storyboards

### DIFF
--- a/.changeset/grade-raw-product-responses.md
+++ b/.changeset/grade-raw-product-responses.md
@@ -2,4 +2,4 @@
 '@adcp/sdk': patch
 ---
 
-Make executable storyboard steps grade raw `get_products` protocol responses by default so SDK convenience projections cannot rewrite conformance evidence. Fixture seeding keeps canonical SDK projection, while product-discovery request wire selection remains authored or negotiated independently.
+Make schema-compliance `get_products` storyboard steps grade raw protocol responses by default so SDK convenience projections cannot rewrite conformance evidence. Flow storyboards and fixture seeding keep canonical SDK projection, while product-discovery request wire selection remains authored or negotiated independently.

--- a/.changeset/grade-raw-product-responses.md
+++ b/.changeset/grade-raw-product-responses.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Make the storyboard runner grade raw `get_products` protocol responses by default so SDK convenience projections cannot rewrite conformance evidence. Creative-wire version negotiation remains independent from response projection.

--- a/.changeset/grade-raw-product-responses.md
+++ b/.changeset/grade-raw-product-responses.md
@@ -2,4 +2,4 @@
 '@adcp/sdk': patch
 ---
 
-Make the storyboard runner grade raw `get_products` protocol responses by default so SDK convenience projections cannot rewrite conformance evidence. Creative-wire version negotiation remains independent from response projection.
+Make the storyboard runner grade raw `get_products` protocol responses by default so SDK convenience projections cannot rewrite conformance evidence. Product-discovery request wire selection remains authored or negotiated independently from response projection.

--- a/.changeset/grade-raw-product-responses.md
+++ b/.changeset/grade-raw-product-responses.md
@@ -2,4 +2,4 @@
 '@adcp/sdk': patch
 ---
 
-Make the storyboard runner grade raw `get_products` protocol responses by default so SDK convenience projections cannot rewrite conformance evidence. Product-discovery request wire selection remains authored or negotiated independently from response projection.
+Make executable storyboard steps grade raw `get_products` protocol responses by default so SDK convenience projections cannot rewrite conformance evidence. Fixture seeding keeps canonical SDK projection, while product-discovery request wire selection remains authored or negotiated independently.

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -5037,7 +5037,8 @@ async function executeStep(
           skipIdempotencyAutoInject: testsMissingIdempotencyKey,
           skipAccountValidation: testsMissingAccount,
           responseProjection:
-            effectiveStep.response_projection ?? defaultStoryboardResponseProjection(effectiveStep.task),
+            effectiveStep.response_projection ??
+            defaultStoryboardResponseProjection(effectiveStep.task, effectiveStep.comply_scenario),
           signal: options.signal,
         });
       const run = await runStep(step.title, effectiveStep.task, async () => {

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -12,7 +12,7 @@ import { basename, join } from 'node:path';
 import { getOrCreateClientResolution, getOrDiscoverProfile, runStep, type TestClient } from '../client';
 import { closeScopedConnections, withMCPConnectionScope, type VersionEnvelopeMode } from '../../protocols';
 import { getCapturesFromError, withRawResponseCapture, type RawHttpCapture } from '../../protocols/rawResponseCapture';
-import { executeStoryboardTask } from './task-map';
+import { defaultStoryboardResponseProjection, executeStoryboardTask } from './task-map';
 import {
   extractContextWithProvenance,
   injectContext,
@@ -5036,7 +5036,8 @@ async function executeStep(
         executeStoryboardTask(client, effectiveStep.task, request, {
           skipIdempotencyAutoInject: testsMissingIdempotencyKey,
           skipAccountValidation: testsMissingAccount,
-          responseProjection: effectiveStep.response_projection,
+          responseProjection:
+            effectiveStep.response_projection ?? defaultStoryboardResponseProjection(effectiveStep.task),
           signal: options.signal,
         });
       const run = await runStep(step.title, effectiveStep.task, async () => {

--- a/src/lib/testing/storyboard/task-map.test.ts
+++ b/src/lib/testing/storyboard/task-map.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { executeStoryboardTask } from './task-map';
+import { defaultStoryboardResponseProjection, executeStoryboardTask } from './task-map';
 
 const INVALID_REQUEST_ERROR = {
   code: 'INVALID_REQUEST',
@@ -61,11 +61,11 @@ describe('executeStoryboardTask — adcp_error forwarding', () => {
 
     const result = await executeStoryboardTask(client, 'get_products', {});
     expect(calls).toEqual(['legacy']);
-    expect(receivedParams).toEqual({});
+    expect(receivedParams).toEqual({ ext: { adcp: { creative_wire: 'legacy' } } });
     expect(result.data).toEqual({ products: [], format: 'legacy' });
   });
 
-  it('preserves the raw seller response when grading a 3.2+ wire', async () => {
+  it('uses canonical creative methods when called without runner projection policy on a 3.2+ wire', async () => {
     const calls: string[] = [];
     let receivedParams: unknown;
     const client = {
@@ -75,20 +75,19 @@ describe('executeStoryboardTask — adcp_error forwarding', () => {
         receivedParams = params;
         return { data: { products: [], format: 'canonical' } };
       },
-      getProductsLegacy: async (params: unknown) => {
+      getProductsLegacy: async () => {
         calls.push('raw');
-        receivedParams = params;
-        return { data: { products: [], format: 'canonical' } };
+        return { data: { products: [] } };
       },
     };
 
     const result = await executeStoryboardTask(client, 'get_products', {});
-    expect(calls).toEqual(['raw']);
+    expect(calls).toEqual(['canonical']);
     expect(receivedParams).toEqual({});
     expect(result.data).toEqual({ products: [], format: 'canonical' });
   });
 
-  it('honors an explicit canonical wire request without projecting its response', async () => {
+  it('honors an explicit canonical wire request when called without runner projection policy', async () => {
     const calls: string[] = [];
     let receivedParams: unknown;
     const params = {
@@ -101,15 +100,14 @@ describe('executeStoryboardTask — adcp_error forwarding', () => {
         receivedParams = request;
         return { data: { products: [], format: 'canonical' } };
       },
-      getProductsLegacy: async (request: unknown) => {
+      getProductsLegacy: async () => {
         calls.push('raw');
-        receivedParams = request;
-        return { data: { products: [], format: 'canonical' } };
+        return { data: { products: [], format: 'legacy' } };
       },
     };
 
     const result = await executeStoryboardTask(client, 'get_products', params);
-    expect(calls).toEqual(['raw']);
+    expect(calls).toEqual(['canonical']);
     expect(receivedParams).toBe(params);
     expect(result.data).toEqual({ products: [], format: 'canonical' });
   });
@@ -193,7 +191,7 @@ describe('executeStoryboardTask — adcp_error forwarding', () => {
 
   it('infers failure from a failed AdCP payload when TaskResult.success is omitted', async () => {
     const client = {
-      getProductsLegacy: async () => ({
+      getProducts: async () => ({
         data: MULTI_FINALIZE_FAILED_PAYLOAD,
       }),
     };
@@ -213,7 +211,7 @@ describe('executeStoryboardTask — adcp_error forwarding', () => {
 
     for (const testCase of cases) {
       const client = {
-        getProductsLegacy: async () => ({ data: testCase.data }),
+        getProducts: async () => ({ data: testCase.data }),
       };
 
       const result = await executeStoryboardTask(client, 'get_products', {});
@@ -224,7 +222,7 @@ describe('executeStoryboardTask — adcp_error forwarding', () => {
 
   it('does not treat advisory errors on a success payload as failure', async () => {
     const client = {
-      getProductsLegacy: async () => ({
+      getProducts: async () => ({
         data: { status: 'completed', products: [], errors: [ADVISORY_ERROR] },
       }),
     };
@@ -236,7 +234,7 @@ describe('executeStoryboardTask — adcp_error forwarding', () => {
 
   it('forwards top-level adcp_error from a TaskResult when adcpError is absent', async () => {
     const client = {
-      getProductsLegacy: async () => ({
+      getProducts: async () => ({
         adcp_error: INVALID_REQUEST_ERROR,
       }),
     };
@@ -245,5 +243,11 @@ describe('executeStoryboardTask — adcp_error forwarding', () => {
 
     expect(result.success).toBe(false);
     expect(result.adcp_error).toEqual(INVALID_REQUEST_ERROR);
+  });
+
+  it('defaults executable get_products storyboard steps to raw evidence only', () => {
+    expect(defaultStoryboardResponseProjection('get_products')).toBe('raw');
+    expect(defaultStoryboardResponseProjection('create_media_buy')).toBeUndefined();
+    expect(defaultStoryboardResponseProjection('comply_test_controller')).toBeUndefined();
   });
 });

--- a/src/lib/testing/storyboard/task-map.test.ts
+++ b/src/lib/testing/storyboard/task-map.test.ts
@@ -245,9 +245,10 @@ describe('executeStoryboardTask — adcp_error forwarding', () => {
     expect(result.adcp_error).toEqual(INVALID_REQUEST_ERROR);
   });
 
-  it('defaults executable get_products storyboard steps to raw evidence only', () => {
-    expect(defaultStoryboardResponseProjection('get_products')).toBe('raw');
-    expect(defaultStoryboardResponseProjection('create_media_buy')).toBeUndefined();
-    expect(defaultStoryboardResponseProjection('comply_test_controller')).toBeUndefined();
+  it('defaults schema-compliance get_products steps to raw evidence only', () => {
+    expect(defaultStoryboardResponseProjection('get_products', 'schema_compliance')).toBe('raw');
+    expect(defaultStoryboardResponseProjection('get_products', 'full_sales_flow')).toBeUndefined();
+    expect(defaultStoryboardResponseProjection('get_products', undefined)).toBeUndefined();
+    expect(defaultStoryboardResponseProjection('create_media_buy', 'schema_compliance')).toBeUndefined();
   });
 });

--- a/src/lib/testing/storyboard/task-map.test.ts
+++ b/src/lib/testing/storyboard/task-map.test.ts
@@ -65,7 +65,7 @@ describe('executeStoryboardTask — adcp_error forwarding', () => {
     expect(result.data).toEqual({ products: [], format: 'legacy' });
   });
 
-  it('uses canonical creative methods when grading a 3.2+ wire', async () => {
+  it('preserves the raw seller response when grading a 3.2+ wire', async () => {
     const calls: string[] = [];
     let receivedParams: unknown;
     const client = {
@@ -75,19 +75,20 @@ describe('executeStoryboardTask — adcp_error forwarding', () => {
         receivedParams = params;
         return { data: { products: [], format: 'canonical' } };
       },
-      getProductsLegacy: async () => {
-        calls.push('legacy');
-        return { data: { products: [] } };
+      getProductsLegacy: async (params: unknown) => {
+        calls.push('raw');
+        receivedParams = params;
+        return { data: { products: [], format: 'canonical' } };
       },
     };
 
     const result = await executeStoryboardTask(client, 'get_products', {});
-    expect(calls).toEqual(['canonical']);
+    expect(calls).toEqual(['raw']);
     expect(receivedParams).toEqual({});
     expect(result.data).toEqual({ products: [], format: 'canonical' });
   });
 
-  it('honors an explicit canonical wire request when grading a pre-3.2 storyboard', async () => {
+  it('honors an explicit canonical wire request without projecting its response', async () => {
     const calls: string[] = [];
     let receivedParams: unknown;
     const params = {
@@ -100,14 +101,15 @@ describe('executeStoryboardTask — adcp_error forwarding', () => {
         receivedParams = request;
         return { data: { products: [], format: 'canonical' } };
       },
-      getProductsLegacy: async () => {
-        calls.push('legacy');
-        return { data: { products: [], format: 'legacy' } };
+      getProductsLegacy: async (request: unknown) => {
+        calls.push('raw');
+        receivedParams = request;
+        return { data: { products: [], format: 'canonical' } };
       },
     };
 
     const result = await executeStoryboardTask(client, 'get_products', params);
-    expect(calls).toEqual(['canonical']);
+    expect(calls).toEqual(['raw']);
     expect(receivedParams).toBe(params);
     expect(result.data).toEqual({ products: [], format: 'canonical' });
   });
@@ -191,7 +193,7 @@ describe('executeStoryboardTask — adcp_error forwarding', () => {
 
   it('infers failure from a failed AdCP payload when TaskResult.success is omitted', async () => {
     const client = {
-      getProducts: async () => ({
+      getProductsLegacy: async () => ({
         data: MULTI_FINALIZE_FAILED_PAYLOAD,
       }),
     };
@@ -211,7 +213,7 @@ describe('executeStoryboardTask — adcp_error forwarding', () => {
 
     for (const testCase of cases) {
       const client = {
-        getProducts: async () => ({ data: testCase.data }),
+        getProductsLegacy: async () => ({ data: testCase.data }),
       };
 
       const result = await executeStoryboardTask(client, 'get_products', {});
@@ -222,7 +224,7 @@ describe('executeStoryboardTask — adcp_error forwarding', () => {
 
   it('does not treat advisory errors on a success payload as failure', async () => {
     const client = {
-      getProducts: async () => ({
+      getProductsLegacy: async () => ({
         data: { status: 'completed', products: [], errors: [ADVISORY_ERROR] },
       }),
     };
@@ -234,7 +236,7 @@ describe('executeStoryboardTask — adcp_error forwarding', () => {
 
   it('forwards top-level adcp_error from a TaskResult when adcpError is absent', async () => {
     const client = {
-      getProducts: async () => ({
+      getProductsLegacy: async () => ({
         adcp_error: INVALID_REQUEST_ERROR,
       }),
     };

--- a/src/lib/testing/storyboard/task-map.test.ts
+++ b/src/lib/testing/storyboard/task-map.test.ts
@@ -61,7 +61,7 @@ describe('executeStoryboardTask — adcp_error forwarding', () => {
 
     const result = await executeStoryboardTask(client, 'get_products', {});
     expect(calls).toEqual(['legacy']);
-    expect(receivedParams).toEqual({ ext: { adcp: { creative_wire: 'legacy' } } });
+    expect(receivedParams).toEqual({});
     expect(result.data).toEqual({ products: [], format: 'legacy' });
   });
 

--- a/src/lib/testing/storyboard/task-map.ts
+++ b/src/lib/testing/storyboard/task-map.ts
@@ -23,7 +23,9 @@ export const TASK_TO_METHOD: Record<string, string> = {
   sync_audiences: 'syncAudiences',
 
   // Product discovery & media buy
-  get_products: 'getProducts',
+  // Conformance must grade the seller's protocol response before the SDK's
+  // canonical convenience projection adds, removes, or rewrites fields.
+  get_products: 'getProductsLegacy',
   create_media_buy: 'createMediaBuy',
   update_media_buy: 'updateMediaBuy',
   get_media_buys: 'getMediaBuys',
@@ -195,7 +197,10 @@ export async function executeStoryboardTask(
   }
 
   // AdCP 3.1 transition storyboards default to the legacy creative wire, but
-  // canonical-specific storyboards must be able to opt into the canonical API.
+  // canonical-specific storyboards can opt into the canonical wire. Product
+  // discovery still uses getProductsLegacy in either case because that method
+  // preserves the seller response; wire selection and response projection are
+  // independent concerns.
   const forceRawProjection = opts.responseProjection === 'raw';
   const useLegacyCreativeMethod =
     forceRawProjection || (gradesLegacyCreativeWire(client) && readCreativeWireHint(params) !== 'canonical');

--- a/src/lib/testing/storyboard/task-map.ts
+++ b/src/lib/testing/storyboard/task-map.ts
@@ -23,9 +23,7 @@ export const TASK_TO_METHOD: Record<string, string> = {
   sync_audiences: 'syncAudiences',
 
   // Product discovery & media buy
-  // Conformance must grade the seller's protocol response before the SDK's
-  // canonical convenience projection adds, removes, or rewrites fields.
-  get_products: 'getProductsLegacy',
+  get_products: 'getProducts',
   create_media_buy: 'createMediaBuy',
   update_media_buy: 'updateMediaBuy',
   get_media_buys: 'getMediaBuys',
@@ -82,6 +80,15 @@ const LEGACY_CREATIVE_TASK_TO_METHOD: Readonly<Record<string, string>> = {
   sync_creatives: 'syncCreativesLegacy',
   list_creatives: 'listCreativesLegacy',
 };
+
+/**
+ * Conformance steps grade seller evidence before SDK convenience projection.
+ * Fixture seeding calls executeStoryboardTask directly and intentionally does
+ * not use this runner-only default.
+ */
+export function defaultStoryboardResponseProjection(taskName: string): 'raw' | undefined {
+  return taskName === 'get_products' ? 'raw' : undefined;
+}
 
 function gradesLegacyCreativeWire(client: unknown): boolean {
   if (client === null || typeof client !== 'object') return false;
@@ -207,14 +214,11 @@ export async function executeStoryboardTask(
   const legacyMethodName = useLegacyCreativeMethod ? LEGACY_CREATIVE_TASK_TO_METHOD[taskName] : undefined;
   const methodName =
     legacyMethodName ?? (Object.hasOwn(TASK_TO_METHOD, taskName) ? TASK_TO_METHOD[taskName] : undefined);
-  // Response projection is a runner concern, not wire negotiation. Product
-  // discovery keeps the authored request unchanged in every version so the
-  // seller and negotiated protocol select the wire. Other pre-3.2 creative
-  // tasks retain their explicit legacy-wire compatibility hint.
-  const callParams =
-    legacyMethodName && !forceRawProjection && taskName !== 'get_products'
-      ? withLegacyCreativeWireHint(params)
-      : params;
+  // A forced raw projection is a runner concern, not wire negotiation. Leave
+  // the authored request untouched so the seller and negotiated protocol
+  // select the wire. Ordinary pre-3.2 SDK calls retain their explicit legacy
+  // compatibility hint, including fixture-seeding discovery calls.
+  const callParams = legacyMethodName && !forceRawProjection ? withLegacyCreativeWireHint(params) : params;
 
   // Only pass TaskOptions when a flag is actually set — avoids changing
   // behavior for the common path that relies on method defaults.

--- a/src/lib/testing/storyboard/task-map.ts
+++ b/src/lib/testing/storyboard/task-map.ts
@@ -207,11 +207,14 @@ export async function executeStoryboardTask(
   const legacyMethodName = useLegacyCreativeMethod ? LEGACY_CREATIVE_TASK_TO_METHOD[taskName] : undefined;
   const methodName =
     legacyMethodName ?? (Object.hasOwn(TASK_TO_METHOD, taskName) ? TASK_TO_METHOD[taskName] : undefined);
-  // A forced raw projection is a runner concern, not wire negotiation. Leave
-  // the authored request untouched so dual-declaration storyboards can grade
-  // the seller's default response. Normal pre-3.2 grading still requests the
-  // legacy creative wire explicitly.
-  const callParams = legacyMethodName && !forceRawProjection ? withLegacyCreativeWireHint(params) : params;
+  // Response projection is a runner concern, not wire negotiation. Product
+  // discovery keeps the authored request unchanged in every version so the
+  // seller and negotiated protocol select the wire. Other pre-3.2 creative
+  // tasks retain their explicit legacy-wire compatibility hint.
+  const callParams =
+    legacyMethodName && !forceRawProjection && taskName !== 'get_products'
+      ? withLegacyCreativeWireHint(params)
+      : params;
 
   // Only pass TaskOptions when a flag is actually set — avoids changing
   // behavior for the common path that relies on method defaults.

--- a/src/lib/testing/storyboard/task-map.ts
+++ b/src/lib/testing/storyboard/task-map.ts
@@ -82,12 +82,15 @@ const LEGACY_CREATIVE_TASK_TO_METHOD: Readonly<Record<string, string>> = {
 };
 
 /**
- * Conformance steps grade seller evidence before SDK convenience projection.
- * Fixture seeding calls executeStoryboardTask directly and intentionally does
- * not use this runner-only default.
+ * Schema-compliance steps grade seller evidence before SDK convenience
+ * projection. Flow storyboards and fixture seeding intentionally keep the
+ * canonical SDK projection because they consume normalized product shapes.
  */
-export function defaultStoryboardResponseProjection(taskName: string): 'raw' | undefined {
-  return taskName === 'get_products' ? 'raw' : undefined;
+export function defaultStoryboardResponseProjection(
+  taskName: string,
+  complyScenario: string | undefined
+): 'raw' | undefined {
+  return taskName === 'get_products' && complyScenario === 'schema_compliance' ? 'raw' : undefined;
 }
 
 function gradesLegacyCreativeWire(client: unknown): boolean {

--- a/test/lib/storyboard-task-map-error.test.js
+++ b/test/lib/storyboard-task-map-error.test.js
@@ -65,7 +65,7 @@ describe('executeStoryboardTask error normalization', () => {
 });
 
 describe('executeStoryboardTask creative wire selection', () => {
-  test('uses the canonical method for an explicit canonical 3.1 request', async () => {
+  test('uses the raw response projection for an explicit canonical 3.1 request', async () => {
     const calls = [];
     const params = { ext: { adcp: { creative_wire: 'canonical' } } };
     const result = await executeStoryboardTask(
@@ -77,14 +77,36 @@ describe('executeStoryboardTask creative wire selection', () => {
         },
         getProductsLegacy: async request => {
           calls.push({ method: 'legacy', request });
-          return { data: { products: [], wire: 'legacy' } };
+          return { data: { products: [], wire: 'canonical' } };
         },
       },
       'get_products',
       params
     );
 
-    assert.deepEqual(calls, [{ method: 'canonical', request: params }]);
+    assert.deepEqual(calls, [{ method: 'legacy', request: params }]);
+    assert.equal(result.data.wire, 'canonical');
+  });
+
+  test('uses the raw response projection for an unhinted 3.2 request', async () => {
+    const calls = [];
+    const result = await executeStoryboardTask(
+      {
+        getAdcpVersion: () => '3.2',
+        getProducts: async request => {
+          calls.push({ method: 'canonical', request });
+          return { data: { products: [], wire: 'projected' } };
+        },
+        getProductsLegacy: async request => {
+          calls.push({ method: 'raw', request });
+          return { data: { products: [], wire: 'canonical' } };
+        },
+      },
+      'get_products',
+      {}
+    );
+
+    assert.deepEqual(calls, [{ method: 'raw', request: {} }]);
     assert.equal(result.data.wire, 'canonical');
   });
 

--- a/test/lib/storyboard-task-map-error.test.js
+++ b/test/lib/storyboard-task-map-error.test.js
@@ -65,7 +65,7 @@ describe('executeStoryboardTask error normalization', () => {
 });
 
 describe('executeStoryboardTask creative wire selection', () => {
-  test('uses the raw response projection for an explicit canonical 3.1 request', async () => {
+  test('uses the canonical method for an explicit canonical 3.1 request without runner projection policy', async () => {
     const calls = [];
     const params = { ext: { adcp: { creative_wire: 'canonical' } } };
     const result = await executeStoryboardTask(
@@ -84,29 +84,7 @@ describe('executeStoryboardTask creative wire selection', () => {
       params
     );
 
-    assert.deepEqual(calls, [{ method: 'legacy', request: params }]);
-    assert.equal(result.data.wire, 'canonical');
-  });
-
-  test('uses the raw response projection for an unhinted 3.2 request', async () => {
-    const calls = [];
-    const result = await executeStoryboardTask(
-      {
-        getAdcpVersion: () => '3.2',
-        getProducts: async request => {
-          calls.push({ method: 'canonical', request });
-          return { data: { products: [], wire: 'projected' } };
-        },
-        getProductsLegacy: async request => {
-          calls.push({ method: 'raw', request });
-          return { data: { products: [], wire: 'canonical' } };
-        },
-      },
-      'get_products',
-      {}
-    );
-
-    assert.deepEqual(calls, [{ method: 'raw', request: {} }]);
+    assert.deepEqual(calls, [{ method: 'canonical', request: params }]);
     assert.equal(result.data.wire, 'canonical');
   });
 
@@ -128,7 +106,7 @@ describe('executeStoryboardTask creative wire selection', () => {
       {}
     );
 
-    assert.deepEqual(calls, [{ method: 'legacy', request: {} }]);
+    assert.deepEqual(calls, [{ method: 'legacy', request: { ext: { adcp: { creative_wire: 'legacy' } } } }]);
     assert.equal(result.data.wire, 'legacy');
   });
 

--- a/test/lib/storyboard-task-map-error.test.js
+++ b/test/lib/storyboard-task-map-error.test.js
@@ -128,7 +128,7 @@ describe('executeStoryboardTask creative wire selection', () => {
       {}
     );
 
-    assert.deepEqual(calls, [{ method: 'legacy', request: { ext: { adcp: { creative_wire: 'legacy' } } } }]);
+    assert.deepEqual(calls, [{ method: 'legacy', request: {} }]);
     assert.equal(result.data.wire, 'legacy');
   });
 


### PR DESCRIPTION
## Summary

- route storyboard `get_products` calls through the SDK unprojected response path by default
- keep creative-wire version negotiation independent from response projection
- cover legacy 3.1, explicit canonical 3.1, and canonical 3.2 requests in both source and built-output tests

## Why

Conformance storyboards must grade the seller response, not the SDK convenience projection. Requiring each storyboard step to opt into `response_projection: raw` is error-prone and allows SDK-added or removed fields to alter compliance evidence.

## Validation

- `npm run build`
- `npx vitest run src/lib/testing/storyboard/task-map.test.ts`
- `node --test --test-timeout=60000 test/lib/storyboard-task-map-error.test.js`
- `npm run lint`
- `npm run typecheck`
- full pre-push validation