### PR TITLE
feat(negotiation): add proposal refinement APIs

### DIFF
--- a/.changeset/add-proposal-negotiation.md
+++ b/.changeset/add-proposal-negotiation.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': minor
+---
+
+Add first-class AdCP 3.2 proposal negotiation APIs for typed buyer requests/results, capability-aware preflight, normative response verification, retry/finalization orchestration, and seller-side atomic batch handling.

--- a/docs/migration-adcp-3.1-to-3.2-proposals.md
+++ b/docs/migration-adcp-3.1-to-3.2-proposals.md
@@ -1,0 +1,43 @@
+# AdCP 3.2 proposal negotiation
+
+AdCP 3.2 splits structured proposal negotiation into `refine_proposals`. Existing `get_products` refinement remains the 3.x fallback, but its `budget_range` is a soft discovery filter. Do not copy it directly into `constraints.total_budget`, which is a hard commercial requirement.
+
+## Buyer migration
+
+Discover support before sending a 3.2-only request, then pass the advertised dimensions into both the workflow helper and the client call:
+
+```ts
+const support = extractProposalRefinementSupport(await agent.getCapabilities());
+if (!support.supported) {
+  // Use the legacy get_products refinement adapter described below.
+}
+if (!support.capabilities) {
+  throw new Error('Seller omitted proposal_refinement capability details');
+}
+
+const negotiator = new ProposalNegotiator(
+  request =>
+    agent.refineProposals(request, undefined, {
+      proposalRefinementCapabilities: support.capabilities,
+    }),
+  { capabilities: support.capabilities }
+);
+```
+
+`extractProposalRefinementSupport()` accepts a raw `get_adcp_capabilities` response, the normalized value from `agent.getCapabilities()`, or a completed task/MCP wrapper. The SDK pins and requires the `adcp_version: '3.2'` and `adcp_major_version: 3` envelope, generates an idempotency key, rejects batches above 25, rejects alternatives above 10 or the seller's lower advertised ceiling, and rejects dimensions omitted from an explicit `supported_dimensions` declaration.
+
+Pass the result through `unwrapVerifiedRefineProposals(result, request)` or use `ProposalNegotiator`. Verification covers result ordering, source lineage, JCS terms digests, alternative distinctness/count, typed constraints, product changes, and partial-result subsets. Task-level failures and intermediate states throw before success fields are exposed.
+
+Exact transport retries reuse the same request and key. A changed refinement is a new intent and must use a fresh key; `ProposalNegotiator.changedRequest()` enforces that split. Check the committed proposal's `expires_at` immediately before `accept_proposal`/`buy_products`.
+
+If `lifecycle_tools` omits `refine_proposals`, translate supported requests to the legacy `get_products({ buying_mode: 'refine', refine: [...] })` flow. Free-text `ask` maps to the legacy proposal ask. Product include/omit actions map directly. Hard constraints require explicit adapter policy: legacy discovery cannot guarantee the 3.2 hard-constraint semantics, so verify the returned proposal locally or report the dimension as unsupported.
+
+## Seller migration
+
+Declare support with `defineProposalRefinementCapabilities()` and register the handler as `proposalNegotiation` in the options passed to `createAdcpServerFromPlatform(platform, options)`. Registering this group automatically pins that server instance to the bundled AdCP 3.2 schema when `adcpVersion` is omitted; an explicit version below 3.2 is rejected at construction. This is the transitional 3.2 handler-group seam until proposal negotiation is promoted into the generated schema pin and `DecisioningPlatform`. Existing v5 handler-bag adopters may instead import `createAdcpServer` from `@adcp/sdk/server/legacy/v5`; do not start an otherwise platform-shaped integration on that deprecated constructor.
+
+The server requires a trusted `resolveScope(ctx)` result and uses it for proposal lookup, persistence, and idempotency isolation; never derive tenant or principal scope from tool arguments. `createProposalRefinementHandler()` validates the complete 3.2/major-3 envelope, batch, and explicit dimensions before mutation, loads every source, calls the adopter's commercial evaluator, verifies the whole response, and only then opens a staging transaction. The evaluator owns pricing and concessions and must be side-effect-free; place inventory holds and other writes in the atomic transaction. The SDK does not choose business terms.
+
+Use `createProposalSuccessor()` for immutable lineage and the normative `sha256:` base64url digest of RFC 8785 JCS `commercial_terms`. Store reads return an opaque source version; `begin(scope, expectedSources)` must compare-and-swap those versions, advance every source version, and insert successor IDs without overwrite in the same atomic commit. The transaction must stage invisibly. Any stage/commit error invokes rollback. A finalize batch that cannot create every hold must return only `unable` results (`hold_unavailable` for the failing entry, `batch_aborted` for eligible siblings) and perform no write.
+
+See `examples/proposal-negotiation-buyer.ts` and `examples/proposal-negotiation-seller.ts`.

--- a/examples/README.md
+++ b/examples/README.md
@@ -58,6 +58,8 @@ The framework resolves buyer agents, status-gates them, and enforces `sync_accou
 - **`basic-a2a.ts`** - Simple A2A protocol client usage with multi-agent testing
 - **`env-config.ts`** - Loading agent configuration from environment variables
 - **`conversation-client.ts`** - Conversation-aware client with input handlers
+- **`proposal-negotiation-buyer.ts`** - AdCP 3.2 revision, counteroffer, hold, and acceptance flow
+- **`proposal-negotiation-seller.ts`** - Complete-batch validation and atomic proposal persistence
 
 ### Multi-specialism + multi-tenant (account-routed)
 
@@ -149,6 +151,7 @@ const client = ADCPMultiAgentClient.fromEnv();
 AdCP tools available on `AgentClient`:
 
 - `getProducts()` - Discover advertising products
+- `refineProposals()` - Revise or finalize compact proposals with capability-aware preflight
 - `listCreativeFormatsLegacy()` - Inspect the legacy named-format catalog during migration
 - `createMediaBuy()` - Create a media buy
 - `updateMediaBuy()` - Update a media buy

--- a/examples/proposal-negotiation-buyer.ts
+++ b/examples/proposal-negotiation-buyer.ts
@@ -1,0 +1,71 @@
+#!/usr/bin/env tsx
+/**
+ * Run against an AdCP 3.2 seller/training-agent profile:
+ *
+ * ADCP_AGENT_URL=https://seller.example/mcp/ ADCP_AUTH_TOKEN=... \
+ * ADCP_PROPOSAL_ID=proposal_123 npx tsx examples/proposal-negotiation-buyer.ts
+ */
+import {
+  ADCPMultiAgentClient,
+  ProposalNegotiator,
+  extractProposalRefinementSupport,
+  type CanonicalProposal,
+} from '../src/lib';
+
+const agentUrl = process.env['ADCP_AGENT_URL'];
+const sourceProposalId = process.env['ADCP_PROPOSAL_ID'];
+if (!agentUrl || !sourceProposalId) {
+  throw new Error('ADCP_AGENT_URL and ADCP_PROPOSAL_ID are required');
+}
+
+const client = ADCPMultiAgentClient.simple(agentUrl, {
+  authToken: process.env['ADCP_AUTH_TOKEN'],
+  protocol: 'mcp',
+});
+const agent = client.agent('default-agent');
+const proposalSupport = extractProposalRefinementSupport(await agent.getCapabilities());
+if (!proposalSupport.supported) {
+  throw new Error('Seller does not advertise refine_proposals; use the documented get_products fallback');
+}
+if (!proposalSupport.capabilities) {
+  throw new Error('Seller advertises refine_proposals without proposal_refinement capability details');
+}
+
+const negotiator = new ProposalNegotiator(
+  request =>
+    agent.refineProposals(request, undefined, {
+      disableWebhook: true,
+      proposalRefinementCapabilities: proposalSupport.capabilities,
+    }),
+  { capabilities: proposalSupport.capabilities, transportRetries: 1 }
+);
+
+const revised = await negotiator.execute({
+  refinements: [
+    {
+      proposal_id: sourceProposalId,
+      action: 'revise',
+      constraints: { total_budget: { currency: 'USD', max: 50_000 } },
+      alternatives: { count: 2 },
+      ask: 'Prefer the strongest forecast while preserving the hard budget ceiling.',
+    },
+  ],
+});
+
+const selected = negotiator.selectCounteroffer(revised.response, proposals =>
+  proposals.reduce((best, candidate) =>
+    (candidate.commercial_terms.total_budget?.amount ?? Infinity) <
+    (best.commercial_terms.total_budget?.amount ?? Infinity)
+      ? candidate
+      : best
+  )
+);
+const held = await negotiator.finalize(selected.proposal_id);
+
+const accepted = await negotiator.accept(held, async (proposal: CanonicalProposal) => {
+  // accept_proposal is a 3.2 split-lifecycle tool. The cast disappears when
+  // the generated SDK pin moves to the published 3.2 schema bundle.
+  return agent.executeTask('accept_proposal' as never, { proposal_id: proposal.proposal_id } as never);
+});
+
+console.log(JSON.stringify({ selected: selected.proposal_id, held_until: held.expires_at, accepted }, null, 2));

--- a/examples/proposal-negotiation-seller.ts
+++ b/examples/proposal-negotiation-seller.ts
@@ -1,0 +1,159 @@
+#!/usr/bin/env tsx
+/**
+ * Runnable authenticated MCP seller for `refine_proposals`.
+ *
+ * SOURCE_PROPOSAL_JSON='{"proposal_id":"...",...}' \
+ * DEMO_API_KEY='replace-me-with-a-long-random-key' \
+ * npx tsx examples/proposal-negotiation-seller.ts
+ */
+import { randomUUID } from 'node:crypto';
+import { createAdcpServer } from '@adcp/sdk/server/legacy/v5';
+import {
+  createIdempotencyStore,
+  createProposalRefinementHandler,
+  createProposalSuccessor,
+  memoryBackend,
+  proposalRefinementScopeFromContext,
+  serve,
+  verifyApiKey,
+  type CanonicalProposal,
+  type ProposalActiveHold,
+  type ProposalRefinementScope,
+  type ProposalRefinementTransaction,
+  type ProposalSourceExpectation,
+} from '@adcp/sdk/server';
+
+const sourceJson = process.env['SOURCE_PROPOSAL_JSON'];
+const apiKey = process.env['DEMO_API_KEY'];
+if (!sourceJson) throw new Error('SOURCE_PROPOSAL_JSON is required');
+if (!apiKey || apiKey.length < 16) throw new Error('DEMO_API_KEY must contain at least 16 characters');
+
+const source = JSON.parse(sourceJson) as CanonicalProposal;
+type VersionedProposal = { proposal: CanonicalProposal; version: number; active_hold?: ProposalActiveHold };
+const records = new Map<string, VersionedProposal>();
+const recordKey = (scope: Readonly<ProposalRefinementScope>, id: string) =>
+  `${scope.tenant_id}\0${scope.principal_id}\0${scope.account_id ?? ''}\0${id}`;
+const demoScope = { tenant_id: 'publisher-demo', principal_id: 'proposal-demo-buyer' };
+records.set(recordKey(demoScope, source.proposal_id), { proposal: source, version: 1 });
+
+const refinementHandler = createProposalRefinementHandler({
+  capabilities: { supported_dimensions: [] },
+  scope: proposalRefinementScopeFromContext,
+  store: {
+    get: (scope, id) => {
+      const record = records.get(recordKey(scope, id));
+      if (!record) return null;
+      const activeHoldExpiry = record.active_hold ? Date.parse(record.active_hold.expires_at) : undefined;
+      const activeHold =
+        record.active_hold &&
+        (activeHoldExpiry === undefined || !Number.isFinite(activeHoldExpiry) || activeHoldExpiry > Date.now())
+          ? structuredClone(record.active_hold)
+          : undefined;
+      return {
+        proposal: record.proposal,
+        version: String(record.version),
+        ...(activeHold && { active_hold: activeHold }),
+      };
+    },
+    begin: (scope, expectedSources): ProposalRefinementTransaction => {
+      const staged: CanonicalProposal[] = [];
+      const expectations = structuredClone(expectedSources) as ProposalSourceExpectation[];
+      return {
+        stage: proposals => staged.push(...structuredClone(proposals)),
+        commit: () => {
+          for (const expected of expectations) {
+            const current = records.get(recordKey(scope, expected.proposal_id));
+            if ((current ? String(current.version) : null) !== expected.version) {
+              throw new Error(`concurrent proposal update: ${expected.proposal_id}`);
+            }
+          }
+          for (const proposal of staged) {
+            const key = recordKey(scope, proposal.proposal_id);
+            if (records.has(key)) throw new Error(`successor already exists: ${proposal.proposal_id}`);
+          }
+          const holds = new Map<string, ProposalActiveHold>();
+          for (const expected of expectations) {
+            if (expected.action !== 'finalize') continue;
+            const current = records.get(recordKey(scope, expected.proposal_id));
+            if (current?.active_hold) {
+              const expiresAt = Date.parse(current.active_hold.expires_at);
+              if (!Number.isFinite(expiresAt) || expiresAt > Date.now()) {
+                throw new Error(`source already has an active or invalid hold: ${expected.proposal_id}`);
+              }
+            }
+            const committed = staged.find(
+              proposal =>
+                proposal.parent_proposal_id === expected.proposal_id && proposal.proposal_status === 'committed'
+            );
+            if (!committed?.expires_at || Date.parse(committed.expires_at) <= Date.now()) {
+              throw new Error(`finalize must stage a committed successor with a future hold: ${expected.proposal_id}`);
+            }
+            holds.set(expected.proposal_id, {
+              proposal_id: committed.proposal_id,
+              expires_at: committed.expires_at,
+            });
+          }
+          for (const expected of expectations) {
+            const key = recordKey(scope, expected.proposal_id);
+            const current = records.get(key);
+            if (current) {
+              records.set(key, {
+                ...current,
+                version: current.version + 1,
+                ...(holds.has(expected.proposal_id) && { active_hold: holds.get(expected.proposal_id)! }),
+              });
+            }
+          }
+          for (const proposal of staged) records.set(recordKey(scope, proposal.proposal_id), { proposal, version: 1 });
+        },
+        rollback: () => staged.splice(0),
+      };
+    },
+  },
+  // Commercial policy remains application-owned. This demo only reserves
+  // the exact terms of an available draft for fifteen minutes.
+  evaluate: ({ refinement, source: current }) => {
+    if (!current || refinement.action !== 'finalize') {
+      return {
+        source_proposal_id: refinement.proposal_id,
+        outcome: 'unable',
+        reason_code: 'source_unavailable',
+        reason: 'This demo only finalizes an available draft.',
+      };
+    }
+    return {
+      source_proposal_id: refinement.proposal_id,
+      outcome: 'finalized',
+      proposal: createProposalSuccessor(current, {
+        ...current,
+        proposal_id: `held:${randomUUID()}`,
+        proposal_status: 'committed',
+        expires_at: new Date(Date.now() + 15 * 60_000).toISOString(),
+      }),
+    };
+  },
+});
+
+const idempotency = createIdempotencyStore({ backend: memoryBackend(), ttlSeconds: 86_400 });
+
+serve(
+  ({ taskStore }) =>
+    createAdcpServer({
+      name: 'Proposal Negotiation Seller',
+      version: '1.0.0',
+      taskStore,
+      idempotency,
+      resolveIdempotencyPrincipal: ctx => ctx.proposalRefinementScope?.principal_id,
+      proposalNegotiation: {
+        capabilities: { supported_dimensions: [] },
+        resolveScope: ctx => ({
+          tenant_id: 'publisher-demo',
+          principal_id: ctx.authInfo?.clientId ?? 'unreachable-anonymous-principal',
+        }),
+        refineProposals: refinementHandler,
+      },
+    }),
+  {
+    authenticate: verifyApiKey({ keys: { [apiKey]: { principal: demoScope.principal_id } } }),
+  }
+);

--- a/package.json
+++ b/package.json
@@ -491,7 +491,7 @@
     "sync-schemas": "tsx scripts/sync-schemas.ts",
     "sync-schemas:v2.5": "tsx scripts/sync-v2-5-schemas.ts",
     "sync-schemas:3.1-beta": "tsx scripts/sync-3-1-beta-schemas.ts",
-    "sync-schemas:all": "npm run sync-schemas && npm run sync-schemas -- 3.0.12 && npm run sync-schemas:v2.5 && npm run sync-schemas:3.1-beta",
+    "sync-schemas:all": "npm run sync-schemas && npm run sync-schemas -- 3.2.0 && npm run sync-schemas -- 3.0.12 && npm run sync-schemas:v2.5 && npm run sync-schemas:3.1-beta",
     "sync-registry-schemas": "tsx scripts/generate-registry-types.ts --sync",
     "schemas:ensure": "tsx scripts/schemas-ensure.ts",
     "schema-diff": "tsx scripts/schema-diff.ts",

--- a/scripts/schemas-ensure.ts
+++ b/scripts/schemas-ensure.ts
@@ -77,14 +77,7 @@ const stableV30ComplianceOk = hasStableV30ComplianceCache();
 const v25Ok = hasV25Cache();
 
 const current = currentAdcpVersion();
-if (
-  currentV3Ok &&
-  stableV30Ok &&
-  proposalNegotiationOk &&
-  currentComplianceOk &&
-  stableV30ComplianceOk &&
-  v25Ok
-) {
+if (currentV3Ok && stableV30Ok && proposalNegotiationOk && currentComplianceOk && stableV30ComplianceOk && v25Ok) {
   pointLatestAtCurrent(CACHE_ROOT, current);
   pointLatestAtCurrent(COMPLIANCE_CACHE_ROOT, current);
   process.exit(0);

--- a/scripts/schemas-ensure.ts
+++ b/scripts/schemas-ensure.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env tsx
 /**
  * Idempotent guard for the schema cache. Tests load schemas from
- * `schemas/cache/{current,3.0.x,v2.5}/` (gitignored, populated by
+ * `schemas/cache/{current,3.2.0,3.0.x,v2.5}/` (gitignored, populated by
  * `npm run sync-schemas:all`). Fresh clones, branch switches that wipe
  * the cache, and `git clean -fdx` all leave a dev environment that
  * silently fails ~9 test suites with "AdCP schema data for version 'v2.5'
@@ -25,6 +25,11 @@ const REPO_ROOT = path.join(__dirname, '..');
 const CACHE_ROOT = path.join(REPO_ROOT, 'schemas/cache');
 const COMPLIANCE_CACHE_ROOT = path.join(REPO_ROOT, 'compliance/cache');
 const STABLE_3_0_SCHEMA_VERSION = '3.0.12';
+// `refine_proposals` is a first-class opt-in server surface while the SDK's
+// default client pin remains on 3.1. Keep its validator bundle available in
+// fresh clones and published builds so proposal-enabled servers can resolve
+// their automatic 3.2 pin without relying on a developer's pre-existing cache.
+const PROPOSAL_NEGOTIATION_SCHEMA_VERSION = '3.2.0';
 
 function currentAdcpVersion(): string {
   return readFileSync(path.join(REPO_ROOT, 'ADCP_VERSION'), 'utf8').trim();
@@ -37,6 +42,10 @@ function hasCurrentV3Cache(): boolean {
 
 function hasStableV30Cache(): boolean {
   return existsSync(path.join(CACHE_ROOT, STABLE_3_0_SCHEMA_VERSION));
+}
+
+function hasProposalNegotiationCache(): boolean {
+  return existsSync(path.join(CACHE_ROOT, PROPOSAL_NEGOTIATION_SCHEMA_VERSION));
 }
 
 function hasCurrentComplianceCache(): boolean {
@@ -62,12 +71,20 @@ function pointLatestAtCurrent(cacheRoot: string, current: string): void {
 
 const currentV3Ok = hasCurrentV3Cache();
 const stableV30Ok = hasStableV30Cache();
+const proposalNegotiationOk = hasProposalNegotiationCache();
 const currentComplianceOk = hasCurrentComplianceCache();
 const stableV30ComplianceOk = hasStableV30ComplianceCache();
 const v25Ok = hasV25Cache();
 
 const current = currentAdcpVersion();
-if (currentV3Ok && stableV30Ok && currentComplianceOk && stableV30ComplianceOk && v25Ok) {
+if (
+  currentV3Ok &&
+  stableV30Ok &&
+  proposalNegotiationOk &&
+  currentComplianceOk &&
+  stableV30ComplianceOk &&
+  v25Ok
+) {
   pointLatestAtCurrent(CACHE_ROOT, current);
   pointLatestAtCurrent(COMPLIANCE_CACHE_ROOT, current);
   process.exit(0);
@@ -78,6 +95,7 @@ if (currentV3Ok && stableV30Ok && currentComplianceOk && stableV30ComplianceOk &
 const scripts: string[] = [];
 if (!currentV3Ok || !currentComplianceOk) scripts.push('sync-schemas');
 if (!stableV30Ok || !stableV30ComplianceOk) scripts.push(`sync-schemas -- ${STABLE_3_0_SCHEMA_VERSION}`);
+if (!proposalNegotiationOk) scripts.push(`sync-schemas -- ${PROPOSAL_NEGOTIATION_SCHEMA_VERSION}`);
 if (!v25Ok) scripts.push('sync-schemas:v2.5');
 
 console.log(`[schemas:ensure] Missing schema cache; running: ${scripts.join(', ')}`);

--- a/src/lib/core/ADCPMultiAgentClient.ts
+++ b/src/lib/core/ADCPMultiAgentClient.ts
@@ -1,7 +1,13 @@
 // Multi-agent orchestrator providing simple, intuitive API
 
 import type { AgentConfig } from '../types';
-import { AgentClient, type CanonicalGetProductsResponse, type CanonicalProjectionTaskOptions } from './AgentClient';
+import {
+  AgentClient,
+  type CanonicalGetProductsResponse,
+  type CanonicalProjectionTaskOptions,
+  type ProposalRefinementTaskOptions,
+} from './AgentClient';
+import type { RefineProposalsInput, RefineProposalsResponse } from '../negotiation/types';
 import type {
   CreativeDeliveryTaskOptions,
   SingleAgentClientConfig,
@@ -124,6 +130,15 @@ export class AgentCollection {
     options?: CanonicalProjectionTaskOptions
   ): Promise<TaskResult<CanonicalGetProductsResponse>[]> {
     return this.executeAllSettled(client => client.getProducts(params, inputHandler, options));
+  }
+
+  /** Revise/finalize proposals across every selected agent. */
+  async refineProposals(
+    params: RefineProposalsInput,
+    inputHandler?: InputHandler,
+    options?: ProposalRefinementTaskOptions
+  ): Promise<TaskResult<RefineProposalsResponse>[]> {
+    return this.executeAllSettled(client => client.refineProposals(params, inputHandler, options));
   }
 
   /** @deprecated Explicit raw-wire fan-out for migration tooling. */

--- a/src/lib/core/AgentClient.ts
+++ b/src/lib/core/AgentClient.ts
@@ -106,6 +106,13 @@ import type {
   ListTransformersResponse,
 } from '../types/tools.generated';
 import type { MutatingRequestInput } from '../utils/idempotency';
+import { buildRefineProposalsRequest } from '../negotiation/buyer';
+import { assertRefineProposalsResponse } from '../negotiation/verification';
+import type {
+  ProposalRefinementCapabilities,
+  RefineProposalsInput,
+  RefineProposalsResponse,
+} from '../negotiation/types';
 import type { V1Product } from '../v2/projection/types';
 import type { LegacyFormatConverter } from '../v2/projection/v1-to-v2';
 import type { ProjectionCatalogSnapshot } from '../v2/projection/catalog-snapshot';
@@ -129,6 +136,18 @@ export type CanonicalProjectionTaskOptions = TaskOptions & {
   projectionCatalogs?: readonly ProjectionCatalogSnapshot[];
 };
 
+export type ProposalRefinementTaskOptions = TaskOptions & {
+  /** Explicit seller declaration from media_buy.proposal_refinement. */
+  proposalRefinementCapabilities?: ProposalRefinementCapabilities;
+};
+
+function stripRefineProposalsSdkAnnotations(data: RefineProposalsResponse): RefineProposalsResponse {
+  const canonical = { ...(data as RefineProposalsResponse & { success?: unknown; _message?: unknown }) };
+  delete canonical.success;
+  delete canonical._message;
+  return canonical;
+}
+
 /**
  * Projection metadata attached to canonical `get_products` responses.
  *
@@ -151,6 +170,7 @@ export type V2AugmentedGetProductsResponse = CanonicalGetProductsResponse;
  */
 export type TaskResponseTypeMap = {
   get_products: CanonicalGetProductsResponse;
+  refine_proposals: RefineProposalsResponse;
   create_media_buy: CanonicalCreativeResponse<CreateMediaBuyResponse>;
   update_media_buy: CanonicalCreativeResponse<UpdateMediaBuyResponse>;
   sync_creatives: CanonicalCreativeResponse<SyncCreativesResponse>;
@@ -191,6 +211,7 @@ export type AdcpTaskName = keyof TaskResponseTypeMap;
 /** Exact request mapping paired with {@link TaskResponseTypeMap}. */
 export type TaskRequestTypeMap = {
   get_products: CanonicalGetProductsRequest;
+  refine_proposals: RefineProposalsInput;
   create_media_buy: MutatingRequestInput<CanonicalCreateMediaBuyRequest>;
   update_media_buy: MutatingRequestInput<CanonicalUpdateMediaBuyRequest>;
   sync_creatives: MutatingRequestInput<CanonicalSyncCreativesRequest>;
@@ -575,6 +596,35 @@ export class AgentClient {
     });
 
     this.retainSession(result);
+    return result;
+  }
+
+  /**
+   * Revise or atomically finalize compact AdCP proposals.
+   *
+   * The SDK validates batch/cardinality rules and any explicit seller
+   * capability declaration before transport, and auto-generates the
+   * idempotency key when omitted.
+   */
+  async refineProposals(
+    params: RefineProposalsInput,
+    inputHandler?: InputHandler,
+    options?: ProposalRefinementTaskOptions
+  ): Promise<TaskResult<RefineProposalsResponse>> {
+    const { proposalRefinementCapabilities, ...taskOptions } = options ?? {};
+    const request = buildRefineProposalsRequest(params, proposalRefinementCapabilities);
+    const result = (await this.client.executeTask(
+      'refine_proposals' as never,
+      request as never,
+      inputHandler,
+      this.withSession('refine_proposals', taskOptions)
+    )) as TaskResult<RefineProposalsResponse>;
+    this.retainSession(result);
+    if (result.success && result.status === 'completed') {
+      const data = stripRefineProposalsSdkAnnotations(result.data);
+      assertRefineProposalsResponse(request, data);
+      return { ...result, data };
+    }
     return result;
   }
 
@@ -1498,6 +1548,12 @@ export class AgentClient {
     switch (taskName) {
       case 'get_products':
         return this.getProducts(params as CanonicalGetProductsRequest, inputHandler, options);
+      case 'refine_proposals':
+        return (await this.refineProposals(
+          params as RefineProposalsInput,
+          inputHandler,
+          options
+        )) as TaskResult<unknown>;
       case 'create_media_buy':
         return (await this.createMediaBuy(
           params as MutatingRequestInput<CanonicalCreateMediaBuyRequest>,

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -721,6 +721,7 @@ export type SyncCreativesTaskOptions = CreativeDeliveryTaskOptions & {
 
 const PRIMARY_ADCP_TASK_NAMES = {
   get_products: true,
+  refine_proposals: true,
   create_media_buy: true,
   update_media_buy: true,
   sync_creatives: true,

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -291,6 +291,7 @@ export {
   AgentClient,
   type CanonicalGetProductsResponse,
   type CanonicalProjectionTaskOptions,
+  type ProposalRefinementTaskOptions,
   type TaskResponseTypeMap,
   type TaskRequestTypeMap,
   type TaskRequestFor,
@@ -613,6 +614,9 @@ export type { IdempotencyCapabilities } from './utils/capabilities';
 export type { MutatingRequestInput } from './utils/idempotency';
 export { canonicalize, canonicalJsonSha256 } from './utils/jcs';
 export { rollupOptimizationMetricsFromProducts } from './utils/capability-rollups';
+
+// ====== PROPOSAL NEGOTIATION (AdCP 3.2) ======
+export * from './negotiation';
 
 // ====== CORE TYPES ======
 export * from './types';

--- a/src/lib/negotiation/buyer.ts
+++ b/src/lib/negotiation/buyer.ts
@@ -1,0 +1,523 @@
+import { generateIdempotencyKey, isValidIdempotencyKey } from '../utils/idempotency';
+import type { TaskResult } from '../core/ConversationTypes';
+import type {
+  ProposalRefinement,
+  ProposalRefinementCapabilities,
+  ProposalRefinementDimension,
+  ProposalRefinementSupport,
+  RefineProposalsInput,
+  RefineProposalsCompletedResponse,
+  RefineProposalsRequest,
+  RefineProposalsResponse,
+} from './types';
+import { PROPOSAL_REFINEMENT_DIMENSIONS } from './types';
+import { assertRefineProposalsResponse, isStrictDateTime } from './verification';
+
+export const MAX_PROPOSAL_REFINEMENTS = 25;
+export const MAX_PROPOSAL_ALTERNATIVES = 10;
+
+/**
+ * Read AdCP 3.2 proposal discovery from a raw get_adcp_capabilities response,
+ * a normalized `agent.getCapabilities()` value, or a completed TaskResult / MCP
+ * result wrapper. Malformed explicit declarations fail closed instead of being
+ * treated as absent support.
+ */
+export function extractProposalRefinementSupport(source: unknown): ProposalRefinementSupport {
+  const payload = unwrapCapabilityPayload(source);
+  if (!isRecord(payload)) fail('capabilities response must be an object', 'capabilities');
+
+  const mediaBuy = payload.media_buy;
+  if (mediaBuy === undefined) return Object.freeze({ supported: false });
+  if (!isRecord(mediaBuy)) fail('media_buy capabilities must be an object', 'capabilities.media_buy');
+
+  let supported = false;
+  if (mediaBuy.lifecycle_tools !== undefined) {
+    if (
+      !Array.isArray(mediaBuy.lifecycle_tools) ||
+      mediaBuy.lifecycle_tools.some(tool => typeof tool !== 'string' || tool.length === 0)
+    ) {
+      fail('media_buy.lifecycle_tools must contain non-empty strings', 'capabilities.media_buy.lifecycle_tools');
+    }
+    supported = mediaBuy.lifecycle_tools.includes('refine_proposals');
+  }
+
+  if (mediaBuy.proposal_refinement === undefined) return Object.freeze({ supported });
+  validateCapabilities(mediaBuy.proposal_refinement as ProposalRefinementCapabilities);
+  const raw = mediaBuy.proposal_refinement as ProposalRefinementCapabilities;
+  const capabilities = Object.freeze({
+    supported_dimensions: Object.freeze([...raw.supported_dimensions]),
+    ...(raw.max_alternatives !== undefined && { max_alternatives: raw.max_alternatives }),
+  });
+  return Object.freeze({ supported, capabilities });
+}
+
+export class ProposalRefinementValidationError extends Error {
+  constructor(
+    message: string,
+    readonly field?: string,
+    readonly code: 'VALIDATION_ERROR' | 'UNSUPPORTED_FEATURE' = 'VALIDATION_ERROR',
+    readonly details?: Record<string, unknown>
+  ) {
+    super(message);
+    this.name = 'ProposalRefinementValidationError';
+  }
+}
+
+export class RefineProposalsTaskError extends Error {
+  readonly result: TaskResult<RefineProposalsResponse>;
+
+  constructor(result: TaskResult<RefineProposalsResponse>) {
+    super(result.success ? `refine_proposals did not complete (status ${result.status})` : result.error);
+    this.name = 'RefineProposalsTaskError';
+    this.result = result;
+  }
+}
+
+export function refinementDimensions(refinement: ProposalRefinement): ProposalRefinementDimension[] {
+  if (refinement.action === 'finalize') return [];
+  const dimensions: ProposalRefinementDimension[] = [];
+  if (refinement.constraints) {
+    if (refinement.constraints.total_budget) dimensions.push('total_budget');
+    if (refinement.constraints.cpm) dimensions.push('cpm');
+    if (refinement.constraints.impressions) dimensions.push('impressions');
+    if (refinement.constraints.flight) dimensions.push('flight');
+  }
+  if (refinement.product_changes) dimensions.push('product_changes');
+  if (refinement.alternatives) dimensions.push('alternatives');
+  if (refinement.criteria) dimensions.push('criteria');
+  return dimensions;
+}
+
+export function validateRefineProposalsRequest(
+  request: unknown,
+  capabilities?: ProposalRefinementCapabilities
+): asserts request is RefineProposalsRequest {
+  if (!isRecord(request)) fail('request must be an object');
+  assertAllowedKeys(request, REQUEST_KEYS, 'request');
+  if (request.adcp_version !== '3.2') {
+    fail('refine_proposals requires adcp_version 3.2', 'adcp_version');
+  }
+  if (request.adcp_major_version !== 3) {
+    fail('refine_proposals requires adcp_major_version 3', 'adcp_major_version');
+  }
+  if (request.context_id !== undefined && !isNonemptyString(request.context_id)) {
+    fail('context_id must be a non-empty string', 'context_id');
+  }
+  if (
+    request.governance_context !== undefined &&
+    (!isNonemptyString(request.governance_context) || request.governance_context.length > 4096)
+  ) {
+    fail('governance_context must be a non-empty string of at most 4096 characters', 'governance_context');
+  }
+  if (request.context !== undefined && !isRecord(request.context)) fail('context must be an object', 'context');
+  if (request.push_notification_config !== undefined && !isRecord(request.push_notification_config)) {
+    fail('push_notification_config must be an object', 'push_notification_config');
+  }
+  if (!isValidIdempotencyKey(request.idempotency_key)) {
+    throw new ProposalRefinementValidationError(
+      'idempotency_key must be 16-255 characters from A-Z, a-z, 0-9, _, ., :, or -',
+      'idempotency_key'
+    );
+  }
+  if (!Array.isArray(request.refinements)) fail('refinements must be an array', 'refinements');
+  if (request.refinements.length < 1 || request.refinements.length > MAX_PROPOSAL_REFINEMENTS) {
+    throw new ProposalRefinementValidationError(
+      `refinements must contain 1-${MAX_PROPOSAL_REFINEMENTS} entries`,
+      'refinements'
+    );
+  }
+
+  validateCapabilities(capabilities);
+
+  const ids = new Set<string>();
+  const hasFinalize = request.refinements.some(entry => isRecord(entry) && entry.action === 'finalize');
+  for (const [index, refinement] of request.refinements.entries()) {
+    const base = `refinements[${index}]`;
+    if (!isRecord(refinement)) fail('refinement must be an object', base);
+    if (!isNonemptyString(refinement.proposal_id)) {
+      throw new ProposalRefinementValidationError('proposal_id must not be empty', `${base}.proposal_id`);
+    }
+    if (ids.has(refinement.proposal_id)) {
+      throw new ProposalRefinementValidationError('proposal_id values must be unique', `${base}.proposal_id`);
+    }
+    ids.add(refinement.proposal_id);
+
+    if (refinement.action !== 'revise' && refinement.action !== 'finalize') {
+      fail('action must be revise or finalize', `${base}.action`);
+    }
+    if (refinement.action === 'finalize') {
+      assertAllowedKeys(refinement, FINALIZE_KEYS, base);
+    } else {
+      assertAllowedKeys(refinement, REVISE_KEYS, base);
+    }
+    if (hasFinalize && refinement.action !== 'finalize') {
+      throw new ProposalRefinementValidationError(
+        'a batch containing finalize may contain only finalize entries',
+        `${base}.action`
+      );
+    }
+    if (refinement.action === 'revise') {
+      if (
+        refinement.change_kind !== undefined &&
+        refinement.change_kind !== 'amendment' &&
+        refinement.change_kind !== 'cancellation'
+      ) {
+        fail('change_kind must be amendment or cancellation', `${base}.change_kind`);
+      }
+      const hasRevision =
+        refinement.change_kind === 'cancellation' ||
+        refinement.constraints != null ||
+        refinement.product_changes != null ||
+        refinement.alternatives != null ||
+        refinement.ask != null ||
+        refinement.criteria != null;
+      if (!hasRevision) {
+        throw new ProposalRefinementValidationError(
+          'revise requires a constraint, product change, alternative request, ask, criteria, or cancellation',
+          base
+        );
+      }
+      validateConstraints(refinement as Extract<ProposalRefinement, { action: 'revise' }>, base);
+      const count = refinement.alternatives?.count;
+      if (count !== undefined) {
+        if (!Number.isInteger(count) || count < 2 || count > MAX_PROPOSAL_ALTERNATIVES) {
+          throw new ProposalRefinementValidationError(
+            `alternatives.count must be an integer from 2-${MAX_PROPOSAL_ALTERNATIVES}`,
+            `${base}.alternatives.count`
+          );
+        }
+        if (capabilities?.max_alternatives !== undefined && count > capabilities.max_alternatives) {
+          throw new ProposalRefinementValidationError(
+            `alternatives.count (${count}) exceeds seller max_alternatives (${capabilities.max_alternatives})`,
+            `${base}.alternatives.count`
+          );
+        }
+      }
+
+      if (capabilities !== undefined) {
+        const supported = new Set(capabilities.supported_dimensions);
+        const unsupported = refinementDimensions(refinement as ProposalRefinement).find(
+          dimension => !supported.has(dimension)
+        );
+        if (unsupported) {
+          throw new ProposalRefinementValidationError(
+            `seller does not advertise proposal refinement dimension ${unsupported}`,
+            base,
+            'UNSUPPORTED_FEATURE',
+            {
+              unsupported_dimension: unsupported,
+              supported_dimensions: [...capabilities.supported_dimensions],
+            }
+          );
+        }
+      }
+    }
+  }
+}
+
+function validateConstraints(refinement: Extract<ProposalRefinement, { action: 'revise' }>, base: string): void {
+  if (refinement.ask !== undefined && !isNonemptyString(refinement.ask)) {
+    throw new ProposalRefinementValidationError('ask must not be empty', `${base}.ask`);
+  }
+  if (refinement.criteria !== undefined && !isRecord(refinement.criteria)) {
+    fail('criteria must be an object', `${base}.criteria`);
+  }
+  if (refinement.criteria) {
+    assertAllowedKeys(refinement.criteria, CRITERIA_KEYS, `${base}.criteria`);
+    if (Object.keys(refinement.criteria).length === 0) fail('criteria must not be empty', `${base}.criteria`);
+    validateNonemptyUniqueStrings(refinement.criteria.product_ids, `${base}.criteria.product_ids`);
+    validateNonemptyUniqueStrings(refinement.criteria.policy_ids, `${base}.criteria.policy_ids`);
+    for (const key of ['offer_filters', 'targeting_overlay', 'required_overlay_support', 'ext'] as const) {
+      if (refinement.criteria[key] !== undefined && !isRecord(refinement.criteria[key])) {
+        fail(`${key} must be an object`, `${base}.criteria.${key}`);
+      }
+    }
+    if (refinement.criteria.catalog !== undefined) {
+      if (!isRecord(refinement.criteria.catalog)) fail('catalog must be an object', `${base}.criteria.catalog`);
+      assertAllowedKeys(refinement.criteria.catalog, CATALOG_KEYS, `${base}.criteria.catalog`);
+      if (!isNonemptyString(refinement.criteria.catalog.catalog_id)) {
+        fail('catalog.catalog_id must be a non-empty string', `${base}.criteria.catalog.catalog_id`);
+      }
+      if (refinement.criteria.catalog.type !== undefined && !CATALOG_TYPES.has(refinement.criteria.catalog.type)) {
+        fail('catalog.type must be a recognized catalog type', `${base}.criteria.catalog.type`);
+      }
+      validateNonemptyUniqueStrings(refinement.criteria.catalog.ids, `${base}.criteria.catalog.ids`);
+      validateNonemptyUniqueStrings(refinement.criteria.catalog.tags, `${base}.criteria.catalog.tags`);
+      validateNonemptyUniqueStrings(refinement.criteria.catalog.gtins, `${base}.criteria.catalog.gtins`);
+      if (
+        Array.isArray(refinement.criteria.catalog.gtins) &&
+        refinement.criteria.catalog.gtins.some(gtin => !/^[0-9]{8,14}$/.test(gtin))
+      ) {
+        fail('catalog.gtins must contain 8-14 digit identifiers', `${base}.criteria.catalog.gtins`);
+      }
+      for (const key of ['category', 'query'] as const) {
+        if (refinement.criteria.catalog[key] !== undefined && !isNonemptyString(refinement.criteria.catalog[key])) {
+          fail(`catalog.${key} must be a non-empty string`, `${base}.criteria.catalog.${key}`);
+        }
+      }
+    }
+  }
+  if (refinement.constraints !== undefined && !isRecord(refinement.constraints)) {
+    fail('constraints must be an object', `${base}.constraints`);
+  }
+  if (refinement.constraints) {
+    assertAllowedKeys(refinement.constraints, CONSTRAINT_KEYS, `${base}.constraints`);
+  }
+  if (refinement.constraints && Object.keys(refinement.constraints).length === 0) {
+    throw new ProposalRefinementValidationError('constraints must not be empty', `${base}.constraints`);
+  }
+  const budget = refinement.constraints?.total_budget;
+  if (budget) {
+    if (!isRecord(budget)) fail('total_budget must be an object', `${base}.constraints.total_budget`);
+    assertAllowedKeys(budget, BUDGET_KEYS, `${base}.constraints.total_budget`);
+    if (budget.min === undefined && budget.max === undefined) {
+      throw new ProposalRefinementValidationError(
+        'total_budget requires min or max',
+        `${base}.constraints.total_budget`
+      );
+    }
+    if (budget.min !== undefined && budget.max !== undefined && budget.min > budget.max) {
+      throw new ProposalRefinementValidationError(
+        'total_budget.min must be less than or equal to max',
+        `${base}.constraints.total_budget`
+      );
+    }
+    if (
+      typeof budget.currency !== 'string' ||
+      !/^[A-Z]{3}$/.test(budget.currency) ||
+      (budget.min !== undefined && (!isFiniteNumber(budget.min) || budget.min < 0)) ||
+      (budget.max !== undefined && (!isFiniteNumber(budget.max) || budget.max < 0))
+    ) {
+      throw new ProposalRefinementValidationError(
+        'total_budget requires an uppercase ISO currency and non-negative bounds',
+        `${base}.constraints.total_budget`
+      );
+    }
+  }
+  const cpm = refinement.constraints?.cpm;
+  if (cpm) {
+    if (!isRecord(cpm)) fail('cpm must be an object', `${base}.constraints.cpm`);
+    assertAllowedKeys(cpm, CPM_KEYS, `${base}.constraints.cpm`);
+  }
+  if (cpm && (!isFiniteNumber(cpm.max) || cpm.max <= 0 || !/^[A-Z]{3}$/.test(cpm.currency))) {
+    throw new ProposalRefinementValidationError(
+      'cpm requires max > 0 and an uppercase ISO currency',
+      `${base}.constraints.cpm`
+    );
+  }
+  const impressions = refinement.constraints?.impressions;
+  if (impressions) {
+    if (!isRecord(impressions)) fail('impressions must be an object', `${base}.constraints.impressions`);
+    assertAllowedKeys(impressions, IMPRESSIONS_KEYS, `${base}.constraints.impressions`);
+  }
+  if (impressions && (!isFiniteNumber(impressions.min) || impressions.min <= 0)) {
+    throw new ProposalRefinementValidationError(
+      'impressions.min must be greater than zero',
+      `${base}.constraints.impressions.min`
+    );
+  }
+  const flight = refinement.constraints?.flight;
+  if (flight) {
+    if (!isRecord(flight)) fail('flight must be an object', `${base}.constraints.flight`);
+    assertAllowedKeys(flight, FLIGHT_KEYS, `${base}.constraints.flight`);
+  }
+  if (flight && flight.start_no_later_than === undefined && flight.end_no_earlier_than === undefined) {
+    throw new ProposalRefinementValidationError(
+      'flight requires start_no_later_than or end_no_earlier_than',
+      `${base}.constraints.flight`
+    );
+  }
+  if (
+    flight &&
+    ((flight.start_no_later_than !== undefined && !isStrictDateTime(flight.start_no_later_than)) ||
+      (flight.end_no_earlier_than !== undefined && !isStrictDateTime(flight.end_no_earlier_than)))
+  ) {
+    throw new ProposalRefinementValidationError('flight bounds must be ISO date-times', `${base}.constraints.flight`);
+  }
+  if (refinement.product_changes !== undefined && !isRecord(refinement.product_changes)) {
+    fail('product_changes must be an object', `${base}.product_changes`);
+  }
+  if (refinement.product_changes) {
+    const changes = Object.entries(refinement.product_changes);
+    if (
+      changes.length === 0 ||
+      changes.some(([productId, action]) => !productId || !['include', 'omit'].includes(action))
+    ) {
+      throw new ProposalRefinementValidationError(
+        'product_changes requires non-empty product IDs mapped to include or omit',
+        `${base}.product_changes`
+      );
+    }
+  }
+  if (refinement.alternatives !== undefined) {
+    if (!isRecord(refinement.alternatives)) fail('alternatives must be an object', `${base}.alternatives`);
+    assertAllowedKeys(refinement.alternatives, ALTERNATIVES_KEYS, `${base}.alternatives`);
+    if (!Object.hasOwn(refinement.alternatives, 'count')) {
+      fail('alternatives.count is required', `${base}.alternatives.count`);
+    }
+  }
+}
+
+/** Build and preflight a request before any transport call. */
+export function buildRefineProposalsRequest(
+  input: RefineProposalsInput,
+  capabilities?: ProposalRefinementCapabilities
+): RefineProposalsRequest {
+  if (!isRecord(input)) fail('request input must be an object');
+  if (input.adcp_version !== undefined && input.adcp_version !== '3.2') {
+    fail('refine_proposals requires adcp_version 3.2', 'adcp_version');
+  }
+  if (input.adcp_major_version !== undefined && input.adcp_major_version !== 3) {
+    fail('refine_proposals requires adcp_major_version 3', 'adcp_major_version');
+  }
+  const snapshot = structuredClone(input) as RefineProposalsInput;
+  const request: RefineProposalsRequest = {
+    ...snapshot,
+    adcp_version: '3.2',
+    adcp_major_version: 3,
+    idempotency_key: snapshot.idempotency_key ?? generateIdempotencyKey(),
+  };
+  validateRefineProposalsRequest(request, capabilities);
+  return deepFreeze(request);
+}
+
+const REQUEST_KEYS = new Set([
+  'adcp_version',
+  'adcp_major_version',
+  'context_id',
+  'context',
+  'governance_context',
+  'push_notification_config',
+  'idempotency_key',
+  'refinements',
+]);
+const FINALIZE_KEYS = new Set(['proposal_id', 'action']);
+const REVISE_KEYS = new Set([
+  'proposal_id',
+  'action',
+  'change_kind',
+  'constraints',
+  'product_changes',
+  'alternatives',
+  'ask',
+  'criteria',
+]);
+const CONSTRAINT_KEYS = new Set(['total_budget', 'cpm', 'impressions', 'flight']);
+const BUDGET_KEYS = new Set(['min', 'max', 'currency']);
+const CPM_KEYS = new Set(['max', 'currency']);
+const IMPRESSIONS_KEYS = new Set(['min']);
+const FLIGHT_KEYS = new Set(['start_no_later_than', 'end_no_earlier_than']);
+const ALTERNATIVES_KEYS = new Set(['count']);
+const CRITERIA_KEYS = new Set([
+  'product_ids',
+  'offer_filters',
+  'targeting_overlay',
+  'required_overlay_support',
+  'catalog',
+  'policy_ids',
+  'ext',
+]);
+const CATALOG_KEYS = new Set(['catalog_id', 'type', 'ids', 'gtins', 'category', 'tags', 'query']);
+const CATALOG_TYPES = new Set([
+  'offering',
+  'product',
+  'inventory',
+  'store',
+  'promotion',
+  'hotel',
+  'flight',
+  'job',
+  'vehicle',
+  'real_estate',
+  'education',
+  'destination',
+  'app',
+]);
+
+function validateCapabilities(capabilities: ProposalRefinementCapabilities | undefined): void {
+  if (capabilities === undefined) return;
+  if (!isRecord(capabilities) || !Array.isArray(capabilities.supported_dimensions)) {
+    fail('proposal_refinement capabilities require supported_dimensions', 'capabilities.supported_dimensions');
+  }
+  const dimensions = capabilities.supported_dimensions;
+  if (
+    new Set(dimensions).size !== dimensions.length ||
+    dimensions.some(value => !(PROPOSAL_REFINEMENT_DIMENSIONS as readonly unknown[]).includes(value))
+  ) {
+    fail('supported_dimensions must contain unique recognized dimensions', 'capabilities.supported_dimensions');
+  }
+  if (
+    capabilities.max_alternatives !== undefined &&
+    (!Number.isInteger(capabilities.max_alternatives) ||
+      capabilities.max_alternatives < 2 ||
+      capabilities.max_alternatives > MAX_PROPOSAL_ALTERNATIVES)
+  ) {
+    fail('max_alternatives must be an integer from 2-10', 'capabilities.max_alternatives');
+  }
+  if (capabilities.max_alternatives !== undefined && !dimensions.includes('alternatives')) {
+    fail('max_alternatives requires alternatives in supported_dimensions', 'capabilities.max_alternatives');
+  }
+}
+
+function unwrapCapabilityPayload(source: unknown): unknown {
+  if (!isRecord(source)) return source;
+  if (source.success === false) fail('cannot extract capabilities from a failed task result', 'capabilities');
+  if (source._raw !== undefined) return source._raw;
+  if (source.structuredContent !== undefined) return source.structuredContent;
+  if (source.data !== undefined && (source.success === true || source.status !== undefined)) return source.data;
+  return source;
+}
+
+function validateNonemptyUniqueStrings(value: unknown, path: string): void {
+  if (value === undefined) return;
+  if (
+    !Array.isArray(value) ||
+    value.length === 0 ||
+    value.some(item => !isNonemptyString(item)) ||
+    new Set(value).size !== value.length
+  ) {
+    fail(`${path.split('.').at(-1)} must contain unique non-empty strings`, path);
+  }
+}
+
+function assertAllowedKeys(value: object, allowed: ReadonlySet<string>, path: string): void {
+  const unexpected = Object.keys(value).find(key => !allowed.has(key));
+  if (unexpected) fail(`${unexpected} is not allowed`, `${path}.${unexpected}`);
+}
+
+function isRecord(value: unknown): value is Record<string, any> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isNonemptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function fail(message: string, field?: string): never {
+  throw new ProposalRefinementValidationError(message, field);
+}
+
+function deepFreeze<T>(value: T): T {
+  if (value === null || typeof value !== 'object' || Object.isFrozen(value)) return value;
+  for (const child of Object.values(value as Record<string, unknown>)) deepFreeze(child);
+  return Object.freeze(value);
+}
+
+/**
+ * Narrow a task result only after surfacing task-level failures and verifying
+ * the completed payload against its source request.
+ */
+export function unwrapVerifiedRefineProposals(
+  result: TaskResult<RefineProposalsResponse>,
+  request: RefineProposalsRequest
+): RefineProposalsCompletedResponse {
+  if (!result.success || result.status !== 'completed') {
+    throw new RefineProposalsTaskError(result);
+  }
+  assertRefineProposalsResponse(request, result.data);
+  return result.data;
+}

--- a/src/lib/negotiation/index.ts
+++ b/src/lib/negotiation/index.ts
@@ -1,0 +1,5 @@
+export * from './types';
+export * from './buyer';
+export * from './verification';
+export * from './seller';
+export * from './orchestrator';

--- a/src/lib/negotiation/orchestrator.ts
+++ b/src/lib/negotiation/orchestrator.ts
@@ -1,0 +1,117 @@
+import type { TaskResult } from '../core/ConversationTypes';
+import { buildRefineProposalsRequest, unwrapVerifiedRefineProposals } from './buyer';
+import { isStrictDateTime } from './verification';
+import type {
+  CanonicalProposal,
+  ProposalRefinement,
+  ProposalRefinementCapabilities,
+  RefineProposalsCompletedResponse,
+  RefineProposalsInput,
+  RefineProposalsRequest,
+  RefineProposalsResponse,
+} from './types';
+
+export type RefineProposalsTransport = (
+  request: RefineProposalsRequest
+) => Promise<TaskResult<RefineProposalsResponse>>;
+
+export interface ProposalNegotiatorOptions {
+  capabilities?: ProposalRefinementCapabilities;
+  transportRetries?: number;
+  now?: () => Date;
+}
+
+/** Buyer orchestration for retry, counteroffer selection, hold, and acceptance. */
+export class ProposalNegotiator {
+  private readonly capabilities?: ProposalRefinementCapabilities;
+  private readonly transportRetries: number;
+  private readonly now: () => Date;
+
+  constructor(
+    private readonly transport: RefineProposalsTransport,
+    options: ProposalNegotiatorOptions = {}
+  ) {
+    this.capabilities = options.capabilities;
+    this.transportRetries = options.transportRetries ?? 1;
+    this.now = options.now ?? (() => new Date());
+  }
+
+  /** A transport retry reuses the exact request object and idempotency key. */
+  async execute(input: RefineProposalsInput): Promise<{
+    request: RefineProposalsRequest;
+    response: RefineProposalsCompletedResponse;
+    task: TaskResult<RefineProposalsResponse>;
+  }> {
+    const request = buildRefineProposalsRequest(input, this.capabilities);
+    let task: TaskResult<RefineProposalsResponse> | undefined;
+    let lastError: unknown;
+    for (let attempt = 0; attempt <= this.transportRetries; attempt++) {
+      try {
+        task = await this.transport(request);
+        break;
+      } catch (error) {
+        lastError = error;
+      }
+    }
+    if (!task) throw lastError;
+    return { request, response: unwrapVerifiedRefineProposals(task, request), task };
+  }
+
+  /** A changed commercial intent always receives a fresh idempotency key. */
+  changedRequest(previous: RefineProposalsRequest, refinements: ProposalRefinement[]): RefineProposalsRequest {
+    const { idempotency_key: _oldKey, refinements: _oldRefinements, ...envelope } = previous;
+    return buildRefineProposalsRequest({ ...envelope, refinements }, this.capabilities);
+  }
+
+  selectCounteroffer(
+    response: RefineProposalsCompletedResponse,
+    select: (proposals: readonly CanonicalProposal[]) => CanonicalProposal
+  ): CanonicalProposal {
+    const proposals = response.results.flatMap(result =>
+      result.outcome === 'revised' || result.outcome === 'partial' ? result.proposals : []
+    );
+    if (proposals.length === 0) throw new Error('refine_proposals returned no selectable counteroffer');
+    const selected = select(proposals);
+    const canonical = selected && proposals.find(proposal => proposal.proposal_id === selected.proposal_id);
+    if (!canonical) {
+      throw new Error('counteroffer selector returned a proposal outside the verified response');
+    }
+    // Return the verified object, never a selector-authored clone that merely
+    // copied a valid proposal_id and changed the commercial terms.
+    return canonical;
+  }
+
+  async finalize(proposalId: string): Promise<CanonicalProposal> {
+    const { response } = await this.execute({ refinements: [{ proposal_id: proposalId, action: 'finalize' }] });
+    const finalized = response.results[0];
+    if (!finalized || finalized.outcome !== 'finalized') {
+      const reason = finalized && finalized.outcome === 'unable' ? `: ${finalized.reason_code}` : '';
+      throw new Error(`seller could not finalize proposal${reason}`);
+    }
+    this.assertLiveHold(finalized.proposal);
+    return finalized.proposal;
+  }
+
+  async accept<T>(proposal: CanonicalProposal, accept: (proposal: CanonicalProposal) => Promise<T>): Promise<T> {
+    this.assertLiveHold(proposal);
+    return accept(proposal);
+  }
+
+  private assertLiveHold(proposal: CanonicalProposal): void {
+    if (proposal.proposal_status !== 'committed') throw new Error('only a committed proposal can be accepted');
+    const expiry = isStrictDateTime(proposal.expires_at) ? Date.parse(proposal.expires_at) : Number.NaN;
+    let nowMs = Number.NaN;
+    try {
+      const now = this.now();
+      nowMs = now instanceof Date ? now.getTime() : Number.NaN;
+    } catch {
+      // A broken clock dependency cannot authorize consumption of a hold.
+    }
+    if (!Number.isFinite(nowMs)) {
+      throw new Error('proposal inventory hold cannot be verified because the current time is invalid');
+    }
+    if (!Number.isFinite(expiry) || expiry <= nowMs) {
+      throw new Error('proposal inventory hold has expired; revise/finalize again before acceptance');
+    }
+  }
+}

--- a/src/lib/negotiation/seller.ts
+++ b/src/lib/negotiation/seller.ts
@@ -1,0 +1,404 @@
+import type { MaybePromise } from '../server/create-adcp-server';
+import { AdcpError } from '../server/decisioning/async-outcome';
+import type { HandlerContext } from '../server/create-adcp-server';
+import { ProposalRefinementValidationError, validateRefineProposalsRequest } from './buyer';
+import { assertRefineProposalsResponse, isStrictDateTime, proposalTermsDigest } from './verification';
+import type {
+  CanonicalProposal,
+  ProposalCommercialTerms,
+  ProposalRefinement,
+  ProposalRefinementCapabilities,
+  ProposalRefinementReason,
+  ProposalRefinementResult,
+  RefineProposalsCompletedResponse,
+  RefineProposalsRequest,
+} from './types';
+
+export interface ProposalFailureClassification {
+  unsatisfied_constraints?: readonly string[];
+  unsatisfied_product_changes?: Readonly<Record<string, 'include' | 'omit'>>;
+  batch_aborted?: boolean;
+  hold_unavailable?: boolean;
+  source_unavailable?: boolean;
+  alternatives_unavailable?: boolean;
+  unsupported_dimension?: boolean;
+  commercially_declined?: boolean;
+}
+
+/** Apply the protocol's deterministic reason-code precedence. */
+export function classifyProposalRefinementFailure(failure: ProposalFailureClassification): ProposalRefinementReason {
+  if (
+    (failure.unsatisfied_constraints?.length ?? 0) > 0 ||
+    Object.keys(failure.unsatisfied_product_changes ?? {}).length > 0
+  ) {
+    return 'constraint_unsatisfiable';
+  }
+  if (failure.batch_aborted) return 'batch_aborted';
+  if (failure.hold_unavailable) return 'hold_unavailable';
+  if (failure.source_unavailable) return 'source_unavailable';
+  if (failure.alternatives_unavailable) return 'alternatives_unavailable';
+  if (failure.unsupported_dimension) return 'unsupported_dimension';
+  if (failure.commercially_declined) return 'commercially_declined';
+  return 'uninterpreted';
+}
+
+export function defineProposalRefinementCapabilities(
+  capabilities: ProposalRefinementCapabilities
+): ProposalRefinementCapabilities {
+  const dimensions = capabilities.supported_dimensions;
+  if (dimensions && new Set(dimensions).size !== dimensions.length) {
+    throw new TypeError('proposal_refinement.supported_dimensions must be unique');
+  }
+  if (
+    capabilities.max_alternatives !== undefined &&
+    (!Number.isInteger(capabilities.max_alternatives) ||
+      capabilities.max_alternatives < 2 ||
+      capabilities.max_alternatives > 10)
+  ) {
+    throw new TypeError('proposal_refinement.max_alternatives must be an integer from 2-10');
+  }
+  if (capabilities.max_alternatives !== undefined && !dimensions?.includes('alternatives')) {
+    throw new TypeError('proposal_refinement.max_alternatives requires alternatives in supported_dimensions');
+  }
+  return Object.freeze({
+    ...capabilities,
+    ...(dimensions && { supported_dimensions: Object.freeze([...dimensions]) }),
+  });
+}
+
+export interface ProposalRefinementTransaction<TProposal extends CanonicalProposal = CanonicalProposal> {
+  /**
+   * Stage immutable successors; implementations MUST NOT expose them before
+   * commit and MUST insert them as new records (never upsert/overwrite).
+   */
+  stage(proposals: readonly TProposal[]): MaybePromise<void>;
+  /**
+   * Commit every staged successor atomically after comparing every source
+   * version supplied to `begin`. A mismatch MUST abort the whole batch.
+   *
+   * For `finalize`, the store MUST also reject an existing unexpired active
+   * hold and atomically record the staged committed successor as the source's
+   * new `active_hold`. Merely incrementing the source version is insufficient:
+   * a later request can read that new version and otherwise mint a second hold.
+   * Source proposal contents remain immutable.
+   */
+  commit(): MaybePromise<void>;
+  /** Restore the exact pre-batch state. Safe to call after any failed stage/commit. */
+  rollback(): MaybePromise<void>;
+}
+
+/** Authenticated, server-derived namespace for proposal persistence. */
+export interface ProposalRefinementScope {
+  tenant_id: string;
+  principal_id: string;
+  account_id?: string;
+}
+
+/** Current committed successor that reserves inventory for this source draft. */
+export interface ProposalActiveHold {
+  proposal_id: string;
+  expires_at: string;
+}
+
+/** Opaque store revision and active hold state used for compare-and-swap at commit. */
+export interface ProposalSourceSnapshot<TProposal extends CanonicalProposal = CanonicalProposal> {
+  proposal: TProposal;
+  version: string;
+  /**
+   * Present only while the committed successor's hold is unexpired. Stores
+   * MUST omit/clear expired holds and update this field atomically with the
+   * successor insert and source-version advance.
+   */
+  active_hold?: ProposalActiveHold;
+}
+
+export interface ProposalSourceExpectation {
+  proposal_id: string;
+  action: ProposalRefinement['action'];
+  /** `null` means the source was absent when the request was evaluated. */
+  version: string | null;
+}
+
+export interface ProposalRefinementStore<TProposal extends CanonicalProposal = CanonicalProposal> {
+  get(
+    scope: Readonly<ProposalRefinementScope>,
+    proposalId: string
+  ): MaybePromise<ProposalSourceSnapshot<TProposal> | null>;
+  begin(
+    scope: Readonly<ProposalRefinementScope>,
+    expectedSources: readonly ProposalSourceExpectation[]
+  ): MaybePromise<ProposalRefinementTransaction<TProposal>>;
+}
+
+export interface ProposalEvaluationContext<
+  TProposal extends CanonicalProposal = CanonicalProposal,
+  TContext = unknown,
+> {
+  refinement: ProposalRefinement;
+  source: TProposal | null;
+  index: number;
+  request: Readonly<RefineProposalsRequest>;
+  context: TContext;
+}
+
+export type ProposalCommercialEvaluator<TProposal extends CanonicalProposal = CanonicalProposal, TContext = unknown> = (
+  evaluation: ProposalEvaluationContext<TProposal, TContext>
+) => MaybePromise<ProposalRefinementResult<TProposal>>;
+
+export interface ProposalRefinementHandlerOptions<
+  TProposal extends CanonicalProposal = CanonicalProposal,
+  TProduct = Record<string, unknown>,
+  TContext = unknown,
+> {
+  capabilities: ProposalRefinementCapabilities;
+  store: ProposalRefinementStore<TProposal>;
+  /**
+   * Derive the persistence namespace from trusted handler context only. The
+   * request is deliberately not provided, so buyer arguments cannot choose a
+   * tenant or principal namespace.
+   */
+  scope: (context: TContext) => MaybePromise<ProposalRefinementScope>;
+  /** Application-owned commercial policy. The SDK never chooses business terms. */
+  evaluate: ProposalCommercialEvaluator<TProposal, TContext>;
+  products?: (results: readonly ProposalRefinementResult<TProposal>[], context: TContext) => MaybePromise<TProduct[]>;
+  now?: () => Date;
+}
+
+export type ProposalRefinementHandler<TProduct = Record<string, unknown>, TContext = unknown> = (
+  request: RefineProposalsRequest,
+  context: TContext
+) => Promise<RefineProposalsCompletedResponse<CanonicalProposal, TProduct>>;
+
+/**
+ * Build a seller handler that preflights the entire batch, evaluates without
+ * writes, verifies the complete response, and only then stages one atomic
+ * transaction. A preflight/evaluation/verification failure performs no write.
+ */
+export function createProposalRefinementHandler<
+  TProposal extends CanonicalProposal = CanonicalProposal,
+  TProduct = Record<string, unknown>,
+  TContext = unknown,
+>(options: ProposalRefinementHandlerOptions<TProposal, TProduct, TContext>) {
+  const capabilities = defineProposalRefinementCapabilities(options.capabilities);
+  return async (
+    request: RefineProposalsRequest,
+    context: TContext
+  ): Promise<RefineProposalsCompletedResponse<TProposal, TProduct>> => {
+    try {
+      validateRefineProposalsRequest(request, capabilities);
+    } catch (error) {
+      if (error instanceof ProposalRefinementValidationError) {
+        throw new ProposalSellerPreflightError(error.code, error.field ?? 'refinements', error.message, error.details);
+      }
+      throw error;
+    }
+
+    // Application callbacks never receive the caller-owned object graph.
+    // A deep immutable snapshot keeps concurrent evaluators and exact retry
+    // semantics stable even if the transport or caller retains references.
+    const requestSnapshot = deepFreeze(structuredClone(request));
+
+    const scope = freezeScope(await options.scope(context));
+    const loadedSnapshots = await Promise.all(
+      requestSnapshot.refinements.map(entry => options.store.get(scope, entry.proposal_id))
+    );
+    const snapshots = loadedSnapshots.map(snapshot => (snapshot ? deepFreeze(structuredClone(snapshot)) : null));
+    const sources = snapshots.map(snapshot => (snapshot ? deepFreeze(structuredClone(snapshot.proposal)) : null));
+    const now = options.now?.() ?? new Date();
+    preflightSourceStates(requestSnapshot.refinements, snapshots, safeDateTime(now));
+
+    const evaluatedResults = await Promise.all(
+      requestSnapshot.refinements.map((refinement, index) =>
+        options.evaluate({ refinement, source: sources[index]!, index, request: requestSnapshot, context })
+      )
+    );
+    const evaluatedProducts = options.products ? await options.products(evaluatedResults, context) : [];
+    // Snapshot and freeze the canonical response before verification. The
+    // transaction receives a separate frozen snapshot below, so a hostile or
+    // mutation-prone storage adapter cannot alter the verified return value.
+    const response = deepFreeze(
+      structuredClone({
+        status: 'completed' as const,
+        results: evaluatedResults,
+        products: evaluatedProducts,
+      })
+    ) as RefineProposalsCompletedResponse<TProposal, TProduct>;
+    assertRefineProposalsResponse(requestSnapshot, response, { now });
+    verifyFinalizePreservesSources(requestSnapshot.refinements, sources, response.results);
+
+    const successors = response.results.flatMap(result => {
+      if (result.outcome === 'revised' || result.outcome === 'partial') return result.proposals;
+      if (result.outcome === 'finalized') return [result.proposal];
+      return [];
+    });
+    if (successors.length === 0) return response;
+
+    const expectedSources = requestSnapshot.refinements.map((refinement, index) => ({
+      proposal_id: refinement.proposal_id,
+      action: refinement.action,
+      version: snapshots[index]?.version ?? null,
+    }));
+    const stagedSuccessors = deepFreeze(structuredClone(successors)) as readonly TProposal[];
+    const transaction = await options.store.begin(scope, expectedSources);
+    try {
+      await transaction.stage(stagedSuccessors);
+      await transaction.commit();
+    } catch (error) {
+      await transaction.rollback();
+      throw error;
+    }
+    return response;
+  };
+}
+
+/**
+ * Standard trusted-scope adapter for handlers registered with
+ * `createAdcpServer`. It refuses anonymous or unscoped calls instead of
+ * allowing buyer payload fields to select a persistence namespace.
+ */
+export function proposalRefinementScopeFromContext<TAccount>(
+  context: HandlerContext<TAccount>
+): ProposalRefinementScope {
+  const scope = context.proposalRefinementScope;
+  if (!scope) {
+    throw new AdcpError('SERVICE_UNAVAILABLE', {
+      message: 'Proposal refinement requires proposalNegotiation.resolveScope',
+    });
+  }
+  return freezeScope(scope);
+}
+
+function freezeScope(scope: ProposalRefinementScope): Readonly<ProposalRefinementScope> {
+  if (!scope?.tenant_id || !scope.principal_id) {
+    throw new AdcpError('SERVICE_UNAVAILABLE', {
+      message: 'Proposal refinement scope must include tenant_id and principal_id',
+    });
+  }
+  return Object.freeze({ ...scope });
+}
+
+function verifyFinalizePreservesSources<TProposal extends CanonicalProposal>(
+  refinements: readonly ProposalRefinement[],
+  sources: readonly (TProposal | null)[],
+  results: readonly ProposalRefinementResult<TProposal>[]
+): void {
+  for (const [index, refinement] of refinements.entries()) {
+    if (refinement.action !== 'finalize') continue;
+    const source = sources[index];
+    const result = results[index];
+    if (!source || result?.outcome !== 'finalized') continue;
+    const successor = result.proposal;
+    if (
+      source.terms_digest !== proposalTermsDigest(source.commercial_terms) ||
+      successor.terms_digest !== source.terms_digest ||
+      proposalTermsDigest(successor.commercial_terms) !== source.terms_digest
+    ) {
+      throw new ProposalSellerPreflightError(
+        'INVALID_STATE',
+        `results[${index}].proposal.commercial_terms`,
+        'finalize must preserve the source commercial terms and terms_digest'
+      );
+    }
+  }
+}
+
+function preflightSourceStates<TProposal extends CanonicalProposal>(
+  refinements: readonly ProposalRefinement[],
+  snapshots: readonly (Readonly<ProposalSourceSnapshot<TProposal>> | null)[],
+  nowMs: number
+): void {
+  for (const [index, refinement] of refinements.entries()) {
+    const snapshot = snapshots[index];
+    const source = snapshot?.proposal;
+    if (!source) continue; // evaluator classifies this as source_unavailable
+    if (refinement.action === 'finalize' && source.proposal_status !== 'draft') {
+      throw new ProposalSellerPreflightError(
+        'INVALID_STATE',
+        `refinements[${index}].proposal_id`,
+        'finalize must target a draft proposal'
+      );
+    }
+    if (refinement.action === 'finalize' && snapshot.active_hold !== undefined) {
+      const activeHold = snapshot.active_hold;
+      const expiresAt = isStrictDateTime(activeHold.expires_at) ? Date.parse(activeHold.expires_at) : Number.NaN;
+      if (!activeHold.proposal_id || !Number.isFinite(expiresAt)) {
+        throw new ProposalSellerPreflightError(
+          'INVALID_STATE',
+          `refinements[${index}].proposal_id`,
+          'source proposal has invalid active hold state'
+        );
+      }
+      if (!Number.isFinite(nowMs)) {
+        throw new ProposalSellerPreflightError(
+          'INVALID_STATE',
+          `refinements[${index}].proposal_id`,
+          'source proposal hold cannot be checked because the current time is invalid'
+        );
+      }
+      if (expiresAt > nowMs) {
+        throw new ProposalSellerPreflightError(
+          'INVALID_STATE',
+          `refinements[${index}].proposal_id`,
+          'source proposal already has an unexpired committed hold',
+          { active_proposal_id: activeHold.proposal_id, expires_at: activeHold.expires_at }
+        );
+      }
+    }
+    if (
+      refinement.action === 'revise' &&
+      refinement.change_kind === 'cancellation' &&
+      source.proposal_status !== 'accepted'
+    ) {
+      throw new ProposalSellerPreflightError(
+        'INVALID_STATE',
+        `refinements[${index}].change_kind`,
+        'cancellation must fork an accepted proposal'
+      );
+    }
+  }
+}
+
+function safeDateTime(value: unknown): number {
+  try {
+    return value instanceof Date ? value.getTime() : Number.NaN;
+  } catch {
+    return Number.NaN;
+  }
+}
+
+export class ProposalSellerPreflightError extends AdcpError {
+  constructor(
+    code: 'INVALID_STATE' | 'UNSUPPORTED_FEATURE' | 'VALIDATION_ERROR',
+    field: string,
+    message: string,
+    details?: Record<string, unknown>
+  ) {
+    super(code, { message, field, details });
+  }
+}
+
+export type ProposalSuccessorInput<TTerms extends ProposalCommercialTerms = ProposalCommercialTerms> = Omit<
+  CanonicalProposal<TTerms>,
+  'parent_proposal_id' | 'terms_digest'
+>;
+
+/** Create an immutable, correctly linked successor without choosing its terms. */
+export function createProposalSuccessor<TTerms extends ProposalCommercialTerms>(
+  source: CanonicalProposal,
+  successor: ProposalSuccessorInput<TTerms>
+): CanonicalProposal<TTerms> {
+  const result = structuredClone({
+    ...successor,
+    parent_proposal_id: source.proposal_id,
+    terms_digest: proposalTermsDigest(successor.commercial_terms),
+  }) as CanonicalProposal<TTerms>;
+  return deepFreeze(result);
+}
+
+function deepFreeze<T>(value: T): T {
+  if (value && typeof value === 'object' && !Object.isFrozen(value)) {
+    Object.freeze(value);
+    for (const nested of Object.values(value as Record<string, unknown>)) deepFreeze(nested);
+  }
+  return value;
+}

--- a/src/lib/negotiation/types.ts
+++ b/src/lib/negotiation/types.ts
@@ -141,7 +141,6 @@ export interface ProposalResolvedPricing {
   floor_price?: number;
   min_spend_per_package?: number;
   commission_rate?: number;
-  [key: string]: unknown;
 }
 
 export interface ProposalPurchase {
@@ -151,7 +150,6 @@ export interface ProposalPurchase {
   impressions?: number;
   start_time: string;
   end_time: string;
-  [key: string]: unknown;
 }
 
 export interface ProposalCommercialTerms<TPurchase extends ProposalPurchase = ProposalPurchase> {
@@ -160,7 +158,6 @@ export interface ProposalCommercialTerms<TPurchase extends ProposalPurchase = Pr
   start_time: string;
   end_time: string;
   total_budget?: { amount: number; currency: string };
-  [key: string]: unknown;
 }
 
 export interface CanonicalProposal<TTerms extends ProposalCommercialTerms = ProposalCommercialTerms> {

--- a/src/lib/negotiation/types.ts
+++ b/src/lib/negotiation/types.ts
@@ -1,0 +1,300 @@
+/** Public AdCP proposal-negotiation types (introduced by the 3.2 contract). */
+
+export const PROPOSAL_REFINEMENT_DIMENSIONS = [
+  'total_budget',
+  'cpm',
+  'impressions',
+  'flight',
+  'product_changes',
+  'alternatives',
+  'criteria',
+] as const;
+
+export type ProposalRefinementDimension = (typeof PROPOSAL_REFINEMENT_DIMENSIONS)[number];
+
+export interface ProposalRefinementCapabilities {
+  supported_dimensions: readonly ProposalRefinementDimension[];
+  max_alternatives?: number;
+}
+
+/** Typed view of the seller's compact proposal-lifecycle discovery fields. */
+export interface ProposalRefinementSupport {
+  /** Whether `media_buy.lifecycle_tools` explicitly includes `refine_proposals`. */
+  supported: boolean;
+  /** Present only when the seller advertises `media_buy.proposal_refinement`. */
+  capabilities?: ProposalRefinementCapabilities;
+}
+
+export interface ProposalBudgetConstraint {
+  currency: string;
+  min?: number;
+  max?: number;
+}
+
+export interface ProposalCpmConstraint {
+  max: number;
+  currency: string;
+}
+
+export interface ProposalImpressionsConstraint {
+  min: number;
+}
+
+export interface ProposalFlightConstraint {
+  start_no_later_than?: string;
+  end_no_earlier_than?: string;
+}
+
+export interface ProposalConstraints {
+  total_budget?: ProposalBudgetConstraint;
+  cpm?: ProposalCpmConstraint;
+  impressions?: ProposalImpressionsConstraint;
+  flight?: ProposalFlightConstraint;
+}
+
+export type ProposalProductChange = 'include' | 'omit';
+export type ProposalProductChanges = Record<string, ProposalProductChange>;
+
+/**
+ * AdCP 3.2 structured discovery criteria. Referenced offer/overlay objects
+ * retain forward-compatible value typing, while the closed top-level and
+ * catalog-selector vocabularies remain type-safe today.
+ */
+export interface ProposalDiscoveryCriteria {
+  product_ids?: string[];
+  offer_filters?: Record<string, unknown>;
+  targeting_overlay?: Record<string, unknown>;
+  required_overlay_support?: Record<string, unknown>;
+  catalog?: ProposalDiscoveryCatalogCriteria;
+  policy_ids?: string[];
+  ext?: Record<string, unknown>;
+}
+
+export type ProposalDiscoveryCatalogType =
+  | 'offering'
+  | 'product'
+  | 'inventory'
+  | 'store'
+  | 'promotion'
+  | 'hotel'
+  | 'flight'
+  | 'job'
+  | 'vehicle'
+  | 'real_estate'
+  | 'education'
+  | 'destination'
+  | 'app';
+
+export interface ProposalDiscoveryCatalogCriteria {
+  catalog_id: string;
+  type?: ProposalDiscoveryCatalogType;
+  ids?: string[];
+  gtins?: string[];
+  category?: string;
+  tags?: string[];
+  query?: string;
+}
+
+export interface ReviseProposalRefinement {
+  proposal_id: string;
+  action: 'revise';
+  change_kind?: 'amendment' | 'cancellation';
+  constraints?: ProposalConstraints;
+  product_changes?: ProposalProductChanges;
+  alternatives?: { count: number };
+  ask?: string;
+  criteria?: ProposalDiscoveryCriteria;
+}
+
+export interface FinalizeProposalRefinement {
+  proposal_id: string;
+  action: 'finalize';
+}
+
+export type ProposalRefinement = ReviseProposalRefinement | FinalizeProposalRefinement;
+
+export interface RefineProposalsRequest {
+  idempotency_key: string;
+  refinements: ProposalRefinement[];
+  context_id?: string;
+  context?: Record<string, unknown>;
+  governance_context?: string;
+  push_notification_config?: Record<string, unknown>;
+  adcp_version: '3.2';
+  adcp_major_version: 3;
+}
+
+export type RefineProposalsInput = Omit<
+  RefineProposalsRequest,
+  'idempotency_key' | 'adcp_version' | 'adcp_major_version'
+> & {
+  idempotency_key?: string;
+  adcp_version?: '3.2';
+  adcp_major_version?: 3;
+};
+
+export interface ProposalResolvedPricing {
+  pricing_option_id: string;
+  pricing_model: string;
+  currency: string;
+  fixed_price?: number;
+  floor_price?: number;
+  min_spend_per_package?: number;
+  commission_rate?: number;
+  [key: string]: unknown;
+}
+
+export interface ProposalPurchase {
+  product_id: string;
+  pricing_option_id: string;
+  pricing: ProposalResolvedPricing;
+  impressions?: number;
+  start_time: string;
+  end_time: string;
+  [key: string]: unknown;
+}
+
+export interface ProposalCommercialTerms<TPurchase extends ProposalPurchase = ProposalPurchase> {
+  brand: Record<string, unknown>;
+  purchases: TPurchase[];
+  start_time: string;
+  end_time: string;
+  total_budget?: { amount: number; currency: string };
+  [key: string]: unknown;
+}
+
+export interface CanonicalProposal<TTerms extends ProposalCommercialTerms = ProposalCommercialTerms> {
+  proposal_id: string;
+  proposal_kind: 'new_media_buy' | 'media_buy_update' | 'media_buy_cancellation';
+  parent_proposal_id?: string;
+  media_buy_id?: string;
+  base_media_buy_revision?: number;
+  opportunity_id?: string;
+  proposal_status: 'draft' | 'committed' | 'accepted';
+  accepted_at?: string;
+  expires_at?: string;
+  name: string;
+  description?: string;
+  brief_alignment?: string;
+  commercial_terms: TTerms;
+  terms_digest: string;
+  insertion_order?: Record<string, unknown>;
+}
+
+export type ProposalRefinementReason =
+  | 'commercially_declined'
+  | 'constraint_unsatisfiable'
+  | 'unsupported_dimension'
+  | 'uninterpreted'
+  | 'alternatives_unavailable'
+  | 'source_unavailable'
+  | 'hold_unavailable'
+  | 'batch_aborted';
+
+export interface RefinedProposalResult<TProposal extends CanonicalProposal = CanonicalProposal> {
+  source_proposal_id: string;
+  outcome: 'revised';
+  proposals: TProposal[];
+}
+
+export interface PartialProposalResult<TProposal extends CanonicalProposal = CanonicalProposal> {
+  source_proposal_id: string;
+  outcome: 'partial';
+  proposals: TProposal[];
+  reason_code: ProposalRefinementReason;
+  reason: string;
+  unsatisfied_constraints?: string[];
+  unsatisfied_product_changes?: ProposalProductChanges;
+  suggestions?: string[];
+  targeting_resolution?: Record<string, unknown>;
+}
+
+export interface UnableProposalResult {
+  source_proposal_id: string;
+  outcome: 'unable';
+  reason_code: ProposalRefinementReason;
+  reason: string;
+  unsatisfied_constraints?: string[];
+  unsatisfied_product_changes?: ProposalProductChanges;
+  suggestions?: string[];
+}
+
+export interface FinalizedProposalResult<TProposal extends CanonicalProposal = CanonicalProposal> {
+  source_proposal_id: string;
+  outcome: 'finalized';
+  proposal: TProposal;
+}
+
+export type ProposalRefinementResult<TProposal extends CanonicalProposal = CanonicalProposal> =
+  | RefinedProposalResult<TProposal>
+  | PartialProposalResult<TProposal>
+  | UnableProposalResult
+  | FinalizedProposalResult<TProposal>;
+
+export interface ProposalAdvisoryError {
+  code: string;
+  message: string;
+  [key: string]: unknown;
+}
+
+interface RefineProposalsResponseEnvelope {
+  adcp_version?: string;
+  replayed?: true;
+  context?: Record<string, unknown>;
+  ext?: Record<string, unknown>;
+  errors?: ProposalAdvisoryError[];
+}
+
+export interface RefineProposalsCompletedResponse<
+  TProposal extends CanonicalProposal = CanonicalProposal,
+  TProduct = Record<string, unknown>,
+> extends RefineProposalsResponseEnvelope {
+  status?: 'completed';
+  results: ProposalRefinementResult<TProposal>[];
+  products: TProduct[];
+  message?: string;
+}
+
+/** Compact async acknowledgement; terminal proposal fields arrive with task completion. */
+export interface RefineProposalsSubmittedResponse extends RefineProposalsResponseEnvelope {
+  status: 'submitted';
+  task_id: string;
+  message?: string;
+}
+
+export type RefineProposalsResponse<
+  TProposal extends CanonicalProposal = CanonicalProposal,
+  TProduct = Record<string, unknown>,
+> = RefineProposalsCompletedResponse<TProposal, TProduct> | RefineProposalsSubmittedResponse;
+
+export interface UnsupportedRefinementDimensionDetails {
+  unsupported_dimension: string;
+  supported_dimensions: string[];
+  [key: string]: unknown;
+}
+
+export interface ProposalVerificationIssue {
+  code:
+    | 'result_count'
+    | 'result_order'
+    | 'shape'
+    | 'outcome'
+    | 'lineage'
+    | 'proposal_identity'
+    | 'proposal_status'
+    | 'hold_expired'
+    | 'alternative_count'
+    | 'duplicate_terms'
+    | 'duplicate_digest'
+    | 'terms_digest'
+    | 'constraint'
+    | 'unsatisfied_subset'
+    | 'partial_invariant';
+  path: string;
+  message: string;
+}
+
+export interface ProposalVerificationResult {
+  ok: boolean;
+  issues: ProposalVerificationIssue[];
+}

--- a/src/lib/negotiation/verification.ts
+++ b/src/lib/negotiation/verification.ts
@@ -25,8 +25,7 @@ export class ProposalResponseVerificationError extends Error {
 
 /** Normative `sha256:` + base64url(SHA-256(RFC 8785 JCS(terms))). */
 export function proposalTermsDigest(commercialTerms: unknown): string {
-  const digest = createHash('sha256').update(canonicalize(commercialTerms)).digest('base64url');
-  return `sha256:${digest}`;
+  return digestCanonicalTerms(canonicalProposalTerms(commercialTerms));
 }
 
 export function verifyProposalTermsDigest(proposal: CanonicalProposal): boolean {
@@ -593,8 +592,8 @@ function verifyProposalSet(
     }
     let terms: string | undefined;
     try {
-      terms = canonicalize(proposal.commercial_terms);
-      if (proposal.terms_digest !== proposalTermsDigest(proposal.commercial_terms)) {
+      terms = canonicalProposalTerms(proposal.commercial_terms);
+      if (proposal.terms_digest !== digestCanonicalTerms(terms)) {
         push(issues, 'terms_digest', `${path}.terms_digest`, 'terms_digest does not match commercial_terms');
       }
     } catch (error) {
@@ -915,6 +914,34 @@ function allowedKeys(
     if (!allowed.has(key)) valid = shape(issues, `${path}.${key}`, `${key} is not allowed`);
   }
   return valid;
+}
+
+/** Canonicalize once so validation and hashing observe the exact same bytes, including accessor-backed input. */
+function canonicalProposalTerms(value: unknown): string {
+  const canonical = canonicalize(value);
+  assertIJsonString(canonical);
+  return canonical;
+}
+
+function digestCanonicalTerms(canonical: string): string {
+  return `sha256:${createHash('sha256').update(canonical).digest('base64url')}`;
+}
+
+function assertIJsonString(value: string): void {
+  for (let index = 0; index < value.length; index++) {
+    const code = value.charCodeAt(index);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const low = value.charCodeAt(index + 1);
+      if (low >= 0xdc00 && low <= 0xdfff) {
+        index++;
+        continue;
+      }
+      throw new TypeError('JCS: lone Unicode surrogate is not valid I-JSON');
+    }
+    if (code >= 0xdc00 && code <= 0xdfff) {
+      throw new TypeError('JCS: lone Unicode surrogate is not valid I-JSON');
+    }
+  }
 }
 
 function shape(issues: ProposalVerificationIssue[], path: string, message: string): false {

--- a/src/lib/negotiation/verification.ts
+++ b/src/lib/negotiation/verification.ts
@@ -1,0 +1,945 @@
+import { createHash } from 'node:crypto';
+import { canonicalize } from '../utils/jcs';
+import type {
+  CanonicalProposal,
+  ProposalConstraints,
+  ProposalProductChanges,
+  ProposalRefinement,
+  ProposalRefinementReason,
+  ProposalVerificationIssue,
+  ProposalVerificationResult,
+  RefineProposalsCompletedResponse,
+  RefineProposalsRequest,
+  RefineProposalsResponse,
+} from './types';
+
+export class ProposalResponseVerificationError extends Error {
+  readonly issues: ProposalVerificationIssue[];
+
+  constructor(issues: ProposalVerificationIssue[]) {
+    super(`refine_proposals response failed verification: ${issues.map(issue => issue.message).join('; ')}`);
+    this.name = 'ProposalResponseVerificationError';
+    this.issues = issues;
+  }
+}
+
+/** Normative `sha256:` + base64url(SHA-256(RFC 8785 JCS(terms))). */
+export function proposalTermsDigest(commercialTerms: unknown): string {
+  const digest = createHash('sha256').update(canonicalize(commercialTerms)).digest('base64url');
+  return `sha256:${digest}`;
+}
+
+export function verifyProposalTermsDigest(proposal: CanonicalProposal): boolean {
+  return proposal.terms_digest === proposalTermsDigest(proposal.commercial_terms);
+}
+
+/** Strict RFC 3339 date-time accepted by the AdCP `format: date-time` contract. */
+export function isStrictDateTime(value: unknown): value is string {
+  if (typeof value !== 'string') return false;
+  const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?(Z|([+-])(\d{2}):(\d{2}))$/.exec(value);
+  if (!match) return false;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const hour = Number(match[4]);
+  const minute = Number(match[5]);
+  const second = Number(match[6]);
+  const offsetHour = match[10] === undefined ? 0 : Number(match[10]);
+  const offsetMinute = match[11] === undefined ? 0 : Number(match[11]);
+  return (
+    month >= 1 &&
+    month <= 12 &&
+    day >= 1 &&
+    day <= daysInMonth(year, month) &&
+    hour <= 23 &&
+    minute <= 59 &&
+    second <= 59 &&
+    offsetHour <= 23 &&
+    offsetMinute <= 59 &&
+    Number.isFinite(Date.parse(value))
+  );
+}
+
+export function verifyRefineProposalsResponse(
+  request: RefineProposalsRequest,
+  response: unknown,
+  options: { now?: Date } = {}
+): ProposalVerificationResult {
+  const issues: ProposalVerificationIssue[] = [];
+
+  // Untrusted wire values are shape-checked completely before any semantic
+  // verification. This keeps discriminated-union access fail-closed.
+  if (!validateResponseShape(response, issues)) return { ok: false, issues };
+  if (response.status === 'submitted') {
+    push(issues, 'shape', 'status', 'semantic proposal verification requires a completed response');
+    return { ok: false, issues };
+  }
+
+  const now = options.now ?? new Date();
+  const nowMs = safeDateTime(now);
+  const results = response.results;
+  if (results.length !== request.refinements.length) {
+    push(issues, 'result_count', 'results', 'response must contain exactly one result per refinement');
+  }
+
+  const sourceIds = new Set(request.refinements.map(refinement => refinement.proposal_id));
+  const successorIds = new Set<string>();
+  const count = Math.min(results.length, request.refinements.length);
+  for (let index = 0; index < count; index++) {
+    const refinement = request.refinements[index]!;
+    const result = results[index]!;
+    const base = `results[${index}]`;
+    if (result.source_proposal_id !== refinement.proposal_id) {
+      push(issues, 'result_order', `${base}.source_proposal_id`, 'results must preserve source request order');
+    }
+    if (refinement.action === 'finalize' && result.outcome !== 'finalized' && result.outcome !== 'unable') {
+      push(issues, 'outcome', `${base}.outcome`, 'finalize may return only finalized or unable');
+    }
+    if (refinement.action === 'revise' && result.outcome === 'finalized') {
+      push(issues, 'outcome', `${base}.outcome`, 'revise must not return finalized');
+    }
+
+    verifyUnsatisfiedSubsets(refinement, result, base, issues);
+    if (result.outcome === 'unable') continue;
+    const proposals = result.outcome === 'finalized' ? [result.proposal] : result.proposals;
+    verifyProposalSet(refinement, result.outcome, proposals, base, nowMs, sourceIds, successorIds, issues);
+  }
+
+  const outcomes = new Set(results.map(result => result.outcome));
+  if (outcomes.has('finalized') && outcomes.size !== 1) {
+    push(issues, 'outcome', 'results', 'a successful finalize batch must finalize every entry atomically');
+  }
+  return { ok: issues.length === 0, issues };
+}
+
+export function assertRefineProposalsResponse(
+  request: RefineProposalsRequest,
+  response: unknown,
+  options: { now?: Date } = {}
+): asserts response is RefineProposalsCompletedResponse {
+  const result = verifyRefineProposalsResponse(request, response, options);
+  if (!result.ok) throw new ProposalResponseVerificationError(result.issues);
+}
+
+/** Validate the finalized 3.2 completed or compact-submitted wire shape, without source semantics. */
+export function validateRefineProposalsResponseShape(response: unknown): ProposalVerificationResult {
+  const issues: ProposalVerificationIssue[] = [];
+  validateResponseShape(response, issues);
+  return { ok: issues.length === 0, issues };
+}
+
+/** Assert the finalized 3.2 completed or compact-submitted wire shape, without requiring a source request. */
+export function assertRefineProposalsResponseShape(response: unknown): asserts response is RefineProposalsResponse {
+  const result = validateRefineProposalsResponseShape(response);
+  if (!result.ok) throw new ProposalResponseVerificationError(result.issues);
+}
+
+function validateResponseShape(value: unknown, issues: ProposalVerificationIssue[]): value is RefineProposalsResponse {
+  if (!isRecord(value)) {
+    push(issues, 'shape', 'response', 'response must be an object');
+    return false;
+  }
+  let valid = allowedKeys(value, RESPONSE_KEYS, 'response', issues);
+  if (value.adcp_version !== undefined && value.adcp_version !== '3.2') {
+    valid = shape(issues, 'adcp_version', 'refine_proposals response adcp_version must be 3.2');
+  }
+  if (value.message !== undefined && (typeof value.message !== 'string' || value.message.length > 2000)) {
+    valid = shape(issues, 'message', 'message must be a string of at most 2000 characters');
+  }
+  if (!validateAdvisoryErrors(value.errors, issues)) valid = false;
+  if (value.replayed !== undefined && value.replayed !== true) {
+    valid = shape(issues, 'replayed', 'replayed may only be true when present');
+  }
+  for (const key of ['context', 'ext'] as const) {
+    if (value[key] !== undefined && !isRecord(value[key])) {
+      valid = shape(issues, key, `${key} must be an object`);
+    }
+  }
+
+  if (value.status === 'submitted') {
+    if (!nonempty(value.task_id)) valid = shape(issues, 'task_id', 'submitted response requires a non-empty task_id');
+    for (const key of ['results', 'products'] as const) {
+      if (Object.hasOwn(value, key)) {
+        valid = shape(issues, key, `${key} is forbidden on a compact submitted response`);
+      }
+    }
+    return valid;
+  }
+
+  if (value.status !== undefined && value.status !== 'completed') {
+    valid = shape(issues, 'status', 'response status must be completed or submitted');
+  }
+  if (Object.hasOwn(value, 'task_id')) {
+    valid = shape(issues, 'task_id', 'task_id is forbidden on a completed response');
+  }
+  if (!Array.isArray(value.results) || value.results.length === 0) {
+    valid = shape(issues, 'results', 'results must be a non-empty array');
+  } else {
+    value.results.forEach((result, index) => {
+      if (!validateResultShape(result, `results[${index}]`, issues)) valid = false;
+    });
+  }
+  if (!Array.isArray(value.products)) {
+    valid = shape(issues, 'products', 'products must be an array');
+  } else {
+    value.products.forEach((product, index) => {
+      if (!isRecord(product)) {
+        valid = shape(issues, `products[${index}]`, 'product must be an object');
+      } else if (!nonempty(product.product_id) || !nonempty(product.name)) {
+        valid = shape(issues, `products[${index}]`, 'product requires non-empty product_id and name');
+      }
+    });
+  }
+  return valid;
+}
+
+function validateAdvisoryErrors(value: unknown, issues: ProposalVerificationIssue[]): boolean {
+  if (value === undefined) return true;
+  if (!Array.isArray(value)) return shape(issues, 'errors', 'errors must be an array');
+  let valid = true;
+  value.forEach((error, index) => {
+    if (!isRecord(error) || !nonempty(error.code) || !nonempty(error.message)) {
+      valid = shape(issues, `errors[${index}]`, 'error requires non-empty code and message');
+    }
+  });
+  return valid;
+}
+
+function validateResultShape(value: unknown, path: string, issues: ProposalVerificationIssue[]): boolean {
+  if (!isRecord(value)) return shape(issues, path, 'result must be an object');
+  let valid = allowedKeys(value, RESULT_KEYS, path, issues);
+  if (!nonempty(value.source_proposal_id))
+    valid = shape(issues, `${path}.source_proposal_id`, 'source_proposal_id is required');
+  if (!OUTCOMES.has(value.outcome as string)) {
+    shape(issues, `${path}.outcome`, 'outcome must be revised, partial, finalized, or unable');
+    return false;
+  }
+
+  const outcome = value.outcome as 'revised' | 'partial' | 'finalized' | 'unable';
+  const forbidden = (keys: string[]) => {
+    for (const key of keys) {
+      if (Object.hasOwn(value, key)) valid = shape(issues, `${path}.${key}`, `${key} is forbidden for ${outcome}`);
+    }
+  };
+  if (outcome === 'revised') {
+    forbidden(['proposal', 'reason_code', 'reason', 'unsatisfied_constraints', 'unsatisfied_product_changes']);
+    if (!validateProposalArray(value.proposals, `${path}.proposals`, issues)) valid = false;
+  } else if (outcome === 'partial') {
+    forbidden(['proposal']);
+    if (!validateProposalArray(value.proposals, `${path}.proposals`, issues)) valid = false;
+    if (!validateReason(value, path, issues)) valid = false;
+  } else if (outcome === 'finalized') {
+    forbidden(['proposals', 'reason_code', 'reason', 'unsatisfied_constraints', 'unsatisfied_product_changes']);
+    if (!validateCanonicalProposalShape(value.proposal, `${path}.proposal`, issues)) valid = false;
+  } else {
+    forbidden(['proposal', 'proposals']);
+    if (!validateReason(value, path, issues)) valid = false;
+  }
+
+  if (value.unsatisfied_constraints !== undefined) {
+    const constraints = value.unsatisfied_constraints;
+    if (
+      !Array.isArray(constraints) ||
+      constraints.length === 0 ||
+      constraints.some(item => !nonempty(item)) ||
+      new Set(constraints).size !== constraints.length
+    ) {
+      valid = shape(
+        issues,
+        `${path}.unsatisfied_constraints`,
+        'unsatisfied_constraints must contain unique non-empty strings'
+      );
+    }
+  }
+  if (value.unsatisfied_product_changes !== undefined) {
+    if (!validateProductChanges(value.unsatisfied_product_changes)) {
+      valid = shape(
+        issues,
+        `${path}.unsatisfied_product_changes`,
+        'unsatisfied_product_changes must be a non-empty include/omit map'
+      );
+    }
+  }
+  if (value.suggestions !== undefined) {
+    if (
+      !Array.isArray(value.suggestions) ||
+      value.suggestions.length === 0 ||
+      value.suggestions.some(item => !nonempty(item))
+    ) {
+      valid = shape(issues, `${path}.suggestions`, 'suggestions must contain non-empty strings');
+    }
+  }
+  if (value.targeting_resolution !== undefined && !isRecord(value.targeting_resolution)) {
+    valid = shape(issues, `${path}.targeting_resolution`, 'targeting_resolution must be an object');
+  }
+  return valid;
+}
+
+function validateReason(value: Record<string, unknown>, path: string, issues: ProposalVerificationIssue[]): boolean {
+  let valid = true;
+  if (!REASONS.has(value.reason_code as ProposalRefinementReason)) {
+    valid = shape(issues, `${path}.reason_code`, 'reason_code is not recognized');
+  }
+  if (!nonempty(value.reason)) valid = shape(issues, `${path}.reason`, 'reason must be a non-empty string');
+  return valid;
+}
+
+function validateProposalArray(
+  value: unknown,
+  path: string,
+  issues: ProposalVerificationIssue[]
+): value is CanonicalProposal[] {
+  if (!Array.isArray(value) || value.length === 0) return shape(issues, path, 'proposals must be a non-empty array');
+  let valid = true;
+  value.forEach((proposal, index) => {
+    if (!validateCanonicalProposalShape(proposal, `${path}[${index}]`, issues)) valid = false;
+  });
+  return valid;
+}
+
+function validateCanonicalProposalShape(
+  value: unknown,
+  path: string,
+  issues: ProposalVerificationIssue[]
+): value is CanonicalProposal {
+  if (!isRecord(value)) return shape(issues, path, 'proposal must be an object');
+  let valid = allowedKeys(value, PROPOSAL_KEYS, path, issues);
+  if (!boundedString(value.proposal_id, 1, 255))
+    valid = shape(issues, `${path}.proposal_id`, 'proposal_id must be non-empty');
+  if (!PROPOSAL_KINDS.has(value.proposal_kind as string))
+    valid = shape(issues, `${path}.proposal_kind`, 'proposal_kind is not recognized');
+  if (!nonempty(value.parent_proposal_id))
+    valid = shape(issues, `${path}.parent_proposal_id`, 'parent_proposal_id is required');
+  if (!PROPOSAL_STATUSES.has(value.proposal_status as string))
+    valid = shape(issues, `${path}.proposal_status`, 'proposal_status is not recognized');
+  if (!boundedString(value.name, 1, 500)) valid = shape(issues, `${path}.name`, 'name must be non-empty');
+  if (!/^sha256:[A-Za-z0-9_-]{43}$/.test(typeof value.terms_digest === 'string' ? value.terms_digest : '')) {
+    valid = shape(issues, `${path}.terms_digest`, 'terms_digest must be a sha256 base64url digest');
+  }
+  for (const key of ['description', 'brief_alignment'] as const) {
+    if (value[key] !== undefined && (typeof value[key] !== 'string' || value[key].length > 2000)) {
+      valid = shape(issues, `${path}.${key}`, `${key} must be a string of at most 2000 characters`);
+    }
+  }
+  for (const key of ['media_buy_id', 'opportunity_id'] as const) {
+    if (value[key] !== undefined && !nonempty(value[key]))
+      valid = shape(issues, `${path}.${key}`, `${key} must be non-empty`);
+  }
+  if (
+    value.base_media_buy_revision !== undefined &&
+    (!Number.isInteger(value.base_media_buy_revision) || value.base_media_buy_revision < 1)
+  ) {
+    valid = shape(issues, `${path}.base_media_buy_revision`, 'base_media_buy_revision must be a positive integer');
+  }
+  for (const key of ['accepted_at', 'expires_at'] as const) {
+    if (value[key] !== undefined && !isStrictDateTime(value[key]))
+      valid = shape(issues, `${path}.${key}`, `${key} must be an RFC 3339 date-time`);
+  }
+  if (value.insertion_order !== undefined && !isRecord(value.insertion_order))
+    valid = shape(issues, `${path}.insertion_order`, 'insertion_order must be an object');
+
+  if (
+    (value.proposal_kind === 'media_buy_update' || value.proposal_kind === 'media_buy_cancellation') &&
+    (!nonempty(value.media_buy_id) || !Number.isInteger(value.base_media_buy_revision))
+  ) {
+    valid = shape(issues, path, 'media-buy successor proposals require media_buy_id and base_media_buy_revision');
+  }
+  if (value.proposal_status === 'accepted' && (!nonempty(value.media_buy_id) || !isStrictDateTime(value.accepted_at))) {
+    valid = shape(issues, path, 'accepted proposals require media_buy_id and accepted_at');
+  }
+  if (value.proposal_status === 'committed' && !isStrictDateTime(value.expires_at)) {
+    valid = shape(issues, `${path}.expires_at`, 'committed proposals require expires_at');
+  }
+  if (!validateCommercialTerms(value.commercial_terms, `${path}.commercial_terms`, issues)) valid = false;
+  return valid;
+}
+
+function validateCommercialTerms(value: unknown, path: string, issues: ProposalVerificationIssue[]): boolean {
+  if (!isRecord(value)) return shape(issues, path, 'commercial_terms must be an object');
+  let valid = allowedKeys(value, COMMERCIAL_KEYS, path, issues);
+  if (!isRecord(value.brand)) valid = shape(issues, `${path}.brand`, 'brand must be an object');
+  if (!Array.isArray(value.purchases) || value.purchases.length === 0) {
+    valid = shape(issues, `${path}.purchases`, 'purchases must be a non-empty array');
+  } else {
+    value.purchases.forEach((purchase, index) => {
+      if (!validatePurchase(purchase, `${path}.purchases[${index}]`, issues)) valid = false;
+    });
+  }
+  if (value.start_time !== 'asap' && !isStrictDateTime(value.start_time))
+    valid = shape(issues, `${path}.start_time`, 'start_time must be asap or an RFC 3339 date-time');
+  if (!isStrictDateTime(value.end_time))
+    valid = shape(issues, `${path}.end_time`, 'end_time must be an RFC 3339 date-time');
+  for (const key of ['source_feed_version', 'source_pricing_version', 'purchase_order_ref'] as const) {
+    if (value[key] !== undefined && !nonempty(value[key]))
+      valid = shape(issues, `${path}.${key}`, `${key} must be non-empty`);
+  }
+  if (value.advertiser_industry !== undefined && typeof value.advertiser_industry !== 'string')
+    valid = shape(issues, `${path}.advertiser_industry`, 'advertiser_industry must be a string');
+  if (
+    value.agency_estimate_number !== undefined &&
+    (typeof value.agency_estimate_number !== 'string' || value.agency_estimate_number.length > 100)
+  )
+    valid = shape(
+      issues,
+      `${path}.agency_estimate_number`,
+      'agency_estimate_number must be a string of at most 100 characters'
+    );
+  if (value.total_budget !== undefined && !validateMoney(value.total_budget, `${path}.total_budget`, issues, true))
+    valid = false;
+  for (const key of ['budget_allocation', 'bidding', 'invoice_recipient'] as const) {
+    if (value[key] !== undefined && !isRecord(value[key]))
+      valid = shape(issues, `${path}.${key}`, `${key} must be an object`);
+  }
+  if (value.pacing !== undefined && typeof value.pacing !== 'string')
+    valid = shape(issues, `${path}.pacing`, 'pacing must be a string');
+  if (
+    value.reporting_commitments !== undefined &&
+    (!Array.isArray(value.reporting_commitments) || value.reporting_commitments.length === 0)
+  )
+    valid = shape(issues, `${path}.reporting_commitments`, 'reporting_commitments must be a non-empty array');
+  if (
+    value.cancellation_terms !== undefined &&
+    !validateCancellationTerms(value.cancellation_terms, `${path}.cancellation_terms`, issues)
+  )
+    valid = false;
+  return valid;
+}
+
+function validatePurchase(value: unknown, path: string, issues: ProposalVerificationIssue[]): boolean {
+  if (!isRecord(value)) return shape(issues, path, 'purchase must be an object');
+  let valid = allowedKeys(value, PURCHASE_KEYS, path, issues);
+  if (!nonempty(value.product_id)) valid = shape(issues, `${path}.product_id`, 'product_id is required');
+  if (!nonempty(value.pricing_option_id))
+    valid = shape(issues, `${path}.pricing_option_id`, 'pricing_option_id is required');
+  if (!isStrictDateTime(value.start_time))
+    valid = shape(issues, `${path}.start_time`, 'purchase start_time must be an RFC 3339 date-time');
+  if (!isStrictDateTime(value.end_time))
+    valid = shape(issues, `${path}.end_time`, 'purchase end_time must be an RFC 3339 date-time');
+  for (const key of ['budget', 'min_spend_target', 'impressions'] as const) {
+    if (value[key] !== undefined && (!finite(value[key]) || value[key] < 0))
+      valid = shape(issues, `${path}.${key}`, `${key} must be a finite non-negative number`);
+  }
+  for (const key of [
+    'format_option_refs',
+    'catalog_ids',
+    'optimization_goals',
+    'audience_evidence_pins',
+    'performance_standards',
+  ] as const) {
+    if (value[key] !== undefined && (!Array.isArray(value[key]) || value[key].length === 0))
+      valid = shape(issues, `${path}.${key}`, `${key} must be a non-empty array`);
+  }
+  for (const key of [
+    'bidding',
+    'targeting_overlay',
+    'audience_evidence_requirements',
+    'context',
+    'ext',
+    'measurement_terms',
+  ] as const) {
+    if (value[key] !== undefined && !isRecord(value[key]))
+      valid = shape(issues, `${path}.${key}`, `${key} must be an object`);
+  }
+  if (value.pacing !== undefined && typeof value.pacing !== 'string')
+    valid = shape(issues, `${path}.pacing`, 'pacing must be a string');
+  if (
+    value.agency_estimate_number !== undefined &&
+    (typeof value.agency_estimate_number !== 'string' || value.agency_estimate_number.length > 100)
+  )
+    valid = shape(
+      issues,
+      `${path}.agency_estimate_number`,
+      'agency_estimate_number must be a string of at most 100 characters'
+    );
+  if (!validatePricing(value.pricing, `${path}.pricing`, issues, value.pricing_option_id)) valid = false;
+  return valid;
+}
+
+function validatePricing(
+  value: unknown,
+  path: string,
+  issues: ProposalVerificationIssue[],
+  siblingId: unknown
+): boolean {
+  if (!isRecord(value)) return shape(issues, path, 'pricing must be an object');
+  let valid = allowedKeys(value, PRICING_KEYS, path, issues);
+  if (!nonempty(value.pricing_option_id))
+    valid = shape(issues, `${path}.pricing_option_id`, 'pricing_option_id is required');
+  if (value.pricing_option_id !== siblingId)
+    valid = shape(
+      issues,
+      `${path}.pricing_option_id`,
+      'pricing pricing_option_id must match the purchase pricing_option_id'
+    );
+  if (!PRICING_MODELS.has(value.pricing_model as string))
+    valid = shape(issues, `${path}.pricing_model`, 'pricing_model is not recognized');
+  if (typeof value.currency !== 'string' || !/^[A-Z]{3}$/.test(value.currency))
+    valid = shape(issues, `${path}.currency`, 'currency must be an uppercase ISO code');
+  for (const key of ['fixed_price', 'floor_price', 'min_spend_per_package'] as const) {
+    if (value[key] !== undefined && (!finite(value[key]) || value[key] < 0))
+      valid = shape(issues, `${path}.${key}`, `${key} must be a finite non-negative number`);
+  }
+  if (value.fixed_price !== undefined && value.floor_price !== undefined)
+    valid = shape(issues, path, 'fixed_price and floor_price are mutually exclusive');
+  if (
+    value.commission_rate !== undefined &&
+    (!finite(value.commission_rate) || value.commission_rate <= 0 || value.commission_rate > 1)
+  )
+    valid = shape(issues, `${path}.commission_rate`, 'commission_rate must be finite, greater than 0, and at most 1');
+  for (const key of ['price_guidance', 'price_breakdown', 'parameters'] as const) {
+    if (value[key] !== undefined && !isRecord(value[key]))
+      valid = shape(issues, `${path}.${key}`, `${key} must be an object`);
+  }
+  if (value.eligible_adjustments !== undefined && !Array.isArray(value.eligible_adjustments))
+    valid = shape(issues, `${path}.eligible_adjustments`, 'eligible_adjustments must be an array');
+  for (const key of ['event_type', 'custom_event_name', 'event_source_id', 'commission_basis_description'] as const) {
+    if (value[key] !== undefined && !nonempty(value[key]))
+      valid = shape(issues, `${path}.${key}`, `${key} must be non-empty`);
+  }
+  if (value.pricing_model === 'cpa' && (value.event_type === undefined || value.fixed_price === undefined))
+    valid = shape(issues, path, 'cpa pricing requires event_type and fixed_price');
+  if (
+    value.pricing_model === 'revenue_share' &&
+    (!nonempty(value.event_type) ||
+      !nonempty(value.event_source_id) ||
+      value.commission_rate === undefined ||
+      !nonempty(value.commission_basis_description))
+  )
+    valid = shape(issues, path, 'revenue_share pricing requires event and commission fields');
+  if (
+    (value.pricing_model === 'cpv' || value.pricing_model === 'cpp' || value.pricing_model === 'time') &&
+    !isRecord(value.parameters)
+  )
+    valid = shape(issues, `${path}.parameters`, `${value.pricing_model} pricing requires parameters`);
+  if (value.event_type === 'custom' && !nonempty(value.custom_event_name))
+    valid = shape(issues, `${path}.custom_event_name`, 'custom events require custom_event_name');
+  return valid;
+}
+
+function validateMoney(value: unknown, path: string, issues: ProposalVerificationIssue[], exact: boolean): boolean {
+  if (!isRecord(value)) return shape(issues, path, 'money value must be an object');
+  let valid = exact ? allowedKeys(value, MONEY_KEYS, path, issues) : true;
+  if (!finite(value.amount) || value.amount < 0)
+    valid = shape(issues, `${path}.amount`, 'amount must be a finite non-negative number');
+  if (typeof value.currency !== 'string' || !/^[A-Z]{3}$/.test(value.currency))
+    valid = shape(issues, `${path}.currency`, 'currency must be an uppercase ISO code');
+  return valid;
+}
+
+function validateCancellationTerms(value: unknown, path: string, issues: ProposalVerificationIssue[]): boolean {
+  if (!isRecord(value)) return shape(issues, path, 'cancellation_terms must be an object');
+  let valid = allowedKeys(value, CANCELLATION_KEYS, path, issues);
+  if (!isStrictDateTime(value.effective_at))
+    valid = shape(issues, `${path}.effective_at`, 'effective_at must be an RFC 3339 date-time');
+  if (value.fee !== undefined && !validateMoney(value.fee, `${path}.fee`, issues, true)) valid = false;
+  if (value.reason !== undefined && !boundedString(value.reason, 1, 500))
+    valid = shape(issues, `${path}.reason`, 'reason must be 1-500 characters');
+  return valid;
+}
+
+function verifyProposalSet(
+  refinement: ProposalRefinement,
+  outcome: 'revised' | 'partial' | 'finalized',
+  proposals: CanonicalProposal[],
+  base: string,
+  nowMs: number,
+  sourceIds: ReadonlySet<string>,
+  successorIds: Set<string>,
+  issues: ProposalVerificationIssue[]
+): void {
+  const expected = refinement.action === 'revise' ? (refinement.alternatives?.count ?? 1) : 1;
+  if (outcome === 'revised' && proposals.length !== expected) {
+    push(issues, 'alternative_count', `${base}.proposals`, `revised must return exactly ${expected} proposal(s)`);
+  }
+  if (outcome === 'partial' && (proposals.length < 1 || proposals.length > expected)) {
+    push(issues, 'alternative_count', `${base}.proposals`, `partial must return between 1 and ${expected} proposals`);
+  }
+
+  const canonicalTerms = new Set<string>();
+  const digests = new Set<string>();
+  for (const [proposalIndex, proposal] of proposals.entries()) {
+    const path = outcome === 'finalized' ? `${base}.proposal` : `${base}.proposals[${proposalIndex}]`;
+    if (sourceIds.has(proposal.proposal_id)) {
+      push(
+        issues,
+        'proposal_identity',
+        `${path}.proposal_id`,
+        'successor proposal_id must differ from every source proposal_id'
+      );
+    }
+    if (successorIds.has(proposal.proposal_id)) {
+      push(issues, 'proposal_identity', `${path}.proposal_id`, 'successor proposal_id values must be globally unique');
+    }
+    successorIds.add(proposal.proposal_id);
+    if (proposal.parent_proposal_id !== refinement.proposal_id) {
+      push(issues, 'lineage', `${path}.parent_proposal_id`, 'parent_proposal_id must equal source_proposal_id');
+    }
+    const expectedStatus = outcome === 'finalized' ? 'committed' : 'draft';
+    if (proposal.proposal_status !== expectedStatus) {
+      push(issues, 'proposal_status', `${path}.proposal_status`, `proposal_status must be ${expectedStatus}`);
+    }
+    if (outcome === 'finalized') {
+      const expiresAt = isStrictDateTime(proposal.expires_at) ? Date.parse(proposal.expires_at) : Number.NaN;
+      if (!Number.isFinite(nowMs)) {
+        push(
+          issues,
+          'hold_expired',
+          `${path}.expires_at`,
+          'finalized proposal hold cannot be verified because the current time is invalid'
+        );
+      } else if (!Number.isFinite(expiresAt) || expiresAt <= nowMs) {
+        push(issues, 'hold_expired', `${path}.expires_at`, 'finalized proposal must carry a future hold expiry');
+      }
+    }
+    let terms: string | undefined;
+    try {
+      terms = canonicalize(proposal.commercial_terms);
+      if (proposal.terms_digest !== proposalTermsDigest(proposal.commercial_terms)) {
+        push(issues, 'terms_digest', `${path}.terms_digest`, 'terms_digest does not match commercial_terms');
+      }
+    } catch (error) {
+      push(
+        issues,
+        'terms_digest',
+        `${path}.commercial_terms`,
+        `commercial_terms cannot be canonicalized: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+    if (terms !== undefined) {
+      if (canonicalTerms.has(terms))
+        push(issues, 'duplicate_terms', `${path}.commercial_terms`, 'alternatives must have distinct commercial terms');
+      canonicalTerms.add(terms);
+    }
+    if (digests.has(proposal.terms_digest))
+      push(issues, 'duplicate_digest', `${path}.terms_digest`, 'alternatives must have unique terms_digest values');
+    digests.add(proposal.terms_digest);
+
+    if (refinement.action === 'revise' && outcome === 'revised') {
+      verifyConstraints(refinement.constraints, proposal, path, issues, 'constraint');
+      verifyProductChanges(refinement.product_changes, proposal, path, issues, 'constraint');
+    }
+  }
+}
+
+function verifyUnsatisfiedSubsets(
+  refinement: ProposalRefinement,
+  result: RefineProposalsCompletedResponse['results'][number],
+  base: string,
+  issues: ProposalVerificationIssue[]
+): void {
+  if (result.outcome !== 'partial' && result.outcome !== 'unable') return;
+  const constraintKeys = new Set(Object.keys(refinement.action === 'revise' ? (refinement.constraints ?? {}) : {}));
+  for (const key of result.unsatisfied_constraints ?? []) {
+    if (!constraintKeys.has(key))
+      push(issues, 'unsatisfied_subset', `${base}.unsatisfied_constraints`, `${key} was not requested`);
+  }
+  const requestedChanges = refinement.action === 'revise' ? (refinement.product_changes ?? {}) : {};
+  for (const [productId, action] of Object.entries(result.unsatisfied_product_changes ?? {})) {
+    if (requestedChanges[productId] !== action)
+      push(
+        issues,
+        'unsatisfied_subset',
+        `${base}.unsatisfied_product_changes.${productId}`,
+        'change was not requested'
+      );
+  }
+  if (result.reason_code === 'constraint_unsatisfiable') {
+    if (!result.unsatisfied_constraints?.length && !Object.keys(result.unsatisfied_product_changes ?? {}).length) {
+      push(
+        issues,
+        'unsatisfied_subset',
+        base,
+        'constraint_unsatisfiable requires a machine-readable unsatisfied subset'
+      );
+    }
+  } else if (result.unsatisfied_constraints?.length || Object.keys(result.unsatisfied_product_changes ?? {}).length) {
+    push(issues, 'unsatisfied_subset', `${base}.reason_code`, 'typed failures must use constraint_unsatisfiable');
+  }
+
+  if (result.outcome === 'partial' && refinement.action === 'revise') {
+    const omittedConstraints = new Set(result.unsatisfied_constraints ?? []);
+    const omittedChanges = result.unsatisfied_product_changes ?? {};
+    for (const [proposalIndex, proposal] of result.proposals.entries()) {
+      const path = `${base}.proposals[${proposalIndex}]`;
+      const requiredConstraints = Object.fromEntries(
+        Object.entries(refinement.constraints ?? {}).filter(([key]) => !omittedConstraints.has(key))
+      ) as ProposalConstraints;
+      const requiredChanges = Object.fromEntries(
+        Object.entries(refinement.product_changes ?? {}).filter(
+          ([productId, action]) => omittedChanges[productId] !== action
+        )
+      ) as ProposalProductChanges;
+      verifyConstraints(requiredConstraints, proposal, path, issues, 'partial_invariant');
+      verifyProductChanges(requiredChanges, proposal, path, issues, 'partial_invariant');
+    }
+  }
+}
+
+function verifyConstraints(
+  constraints: ProposalConstraints | undefined,
+  proposal: CanonicalProposal,
+  path: string,
+  issues: ProposalVerificationIssue[],
+  code: 'constraint' | 'partial_invariant'
+): void {
+  if (!constraints) return;
+  const terms = proposal.commercial_terms;
+  const budget = constraints.total_budget;
+  if (budget) {
+    const actual = terms.total_budget;
+    if (
+      !actual ||
+      actual.currency !== budget.currency ||
+      (budget.min !== undefined && actual.amount < budget.min) ||
+      (budget.max !== undefined && actual.amount > budget.max)
+    ) {
+      push(issues, code, `${path}.commercial_terms.total_budget`, 'total_budget constraint is not satisfied');
+    }
+  }
+  const cpm = constraints.cpm;
+  if (
+    cpm &&
+    !terms.purchases.every(
+      purchase =>
+        (purchase.pricing.pricing_model === 'cpm' || purchase.pricing.pricing_model === 'vcpm') &&
+        purchase.pricing.currency === cpm.currency &&
+        typeof purchase.pricing.fixed_price === 'number' &&
+        purchase.pricing.fixed_price <= cpm.max
+    )
+  ) {
+    push(issues, code, `${path}.commercial_terms.purchases`, 'cpm constraint is not satisfied');
+  }
+  const impressions = constraints.impressions;
+  if (
+    impressions &&
+    (!terms.purchases.every(purchase => typeof purchase.impressions === 'number') ||
+      terms.purchases.reduce((sum, purchase) => sum + (purchase.impressions ?? 0), 0) < impressions.min)
+  ) {
+    push(issues, code, `${path}.commercial_terms.purchases`, 'impressions constraint is not satisfied');
+  }
+  const flight = constraints.flight;
+  if (flight) {
+    const start = terms.start_time === 'asap' ? Number.NaN : Date.parse(terms.start_time);
+    const end = Date.parse(terms.end_time);
+    if (
+      (flight.start_no_later_than !== undefined &&
+        (!Number.isFinite(start) || start > Date.parse(flight.start_no_later_than))) ||
+      (flight.end_no_earlier_than !== undefined &&
+        (!Number.isFinite(end) || end < Date.parse(flight.end_no_earlier_than)))
+    ) {
+      push(issues, code, `${path}.commercial_terms`, 'flight constraint is not satisfied');
+    }
+  }
+}
+
+function verifyProductChanges(
+  changes: ProposalProductChanges | undefined,
+  proposal: CanonicalProposal,
+  path: string,
+  issues: ProposalVerificationIssue[],
+  code: 'constraint' | 'partial_invariant'
+): void {
+  if (!changes) return;
+  const products = new Set(proposal.commercial_terms.purchases.map(purchase => purchase.product_id));
+  for (const [productId, action] of Object.entries(changes)) {
+    if ((action === 'include' && !products.has(productId)) || (action === 'omit' && products.has(productId))) {
+      push(
+        issues,
+        code,
+        `${path}.commercial_terms.purchases`,
+        `product change ${productId}:${action} is not satisfied`
+      );
+    }
+  }
+}
+
+const RESPONSE_KEYS = new Set([
+  'adcp_version',
+  'results',
+  'products',
+  'status',
+  'task_id',
+  'message',
+  'errors',
+  'context',
+  'ext',
+  'replayed',
+]);
+const RESULT_KEYS = new Set([
+  'source_proposal_id',
+  'outcome',
+  'proposal',
+  'proposals',
+  'reason_code',
+  'reason',
+  'unsatisfied_constraints',
+  'unsatisfied_product_changes',
+  'suggestions',
+  'targeting_resolution',
+]);
+const PROPOSAL_KEYS = new Set([
+  'proposal_id',
+  'proposal_kind',
+  'parent_proposal_id',
+  'media_buy_id',
+  'base_media_buy_revision',
+  'opportunity_id',
+  'proposal_status',
+  'accepted_at',
+  'expires_at',
+  'name',
+  'description',
+  'brief_alignment',
+  'commercial_terms',
+  'terms_digest',
+  'insertion_order',
+]);
+const COMMERCIAL_KEYS = new Set([
+  'source_feed_version',
+  'source_pricing_version',
+  'brand',
+  'advertiser_industry',
+  'purchases',
+  'start_time',
+  'end_time',
+  'total_budget',
+  'budget_allocation',
+  'pacing',
+  'bidding',
+  'invoice_recipient',
+  'purchase_order_ref',
+  'agency_estimate_number',
+  'reporting_commitments',
+  'cancellation_terms',
+]);
+const PURCHASE_KEYS = new Set([
+  'product_id',
+  'pricing_option_id',
+  'pricing',
+  'format_option_refs',
+  'catalog_ids',
+  'budget',
+  'min_spend_target',
+  'impressions',
+  'start_time',
+  'end_time',
+  'pacing',
+  'bidding',
+  'targeting_overlay',
+  'optimization_goals',
+  'audience_evidence_requirements',
+  'audience_evidence_pins',
+  'agency_estimate_number',
+  'context',
+  'ext',
+  'measurement_terms',
+  'performance_standards',
+]);
+const PRICING_KEYS = new Set([
+  'pricing_option_id',
+  'pricing_model',
+  'currency',
+  'fixed_price',
+  'floor_price',
+  'price_guidance',
+  'min_spend_per_package',
+  'price_breakdown',
+  'eligible_adjustments',
+  'parameters',
+  'event_type',
+  'custom_event_name',
+  'event_source_id',
+  'commission_rate',
+  'commission_basis_description',
+]);
+const MONEY_KEYS = new Set(['amount', 'currency']);
+const CANCELLATION_KEYS = new Set(['effective_at', 'fee', 'reason']);
+const OUTCOMES = new Set(['revised', 'partial', 'finalized', 'unable']);
+const REASONS = new Set<ProposalRefinementReason>([
+  'commercially_declined',
+  'constraint_unsatisfiable',
+  'unsupported_dimension',
+  'uninterpreted',
+  'alternatives_unavailable',
+  'source_unavailable',
+  'hold_unavailable',
+  'batch_aborted',
+]);
+const PROPOSAL_KINDS = new Set(['new_media_buy', 'media_buy_update', 'media_buy_cancellation']);
+const PROPOSAL_STATUSES = new Set(['draft', 'committed', 'accepted']);
+const PRICING_MODELS = new Set([
+  'cpm',
+  'vcpm',
+  'cpc',
+  'cpcv',
+  'cpv',
+  'cpp',
+  'cpa',
+  'revenue_share',
+  'flat_rate',
+  'time',
+]);
+
+function isRecord(value: unknown): value is Record<string, any> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function nonempty(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+function boundedString(value: unknown, min: number, max: number): value is string {
+  return typeof value === 'string' && value.length >= min && value.length <= max;
+}
+
+function finite(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function validateProductChanges(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    Object.keys(value).length > 0 &&
+    Object.entries(value).every(([key, action]) => key.length > 0 && (action === 'include' || action === 'omit'))
+  );
+}
+
+function allowedKeys(
+  value: Record<string, unknown>,
+  allowed: ReadonlySet<string>,
+  path: string,
+  issues: ProposalVerificationIssue[]
+): boolean {
+  let valid = true;
+  for (const key of Object.keys(value)) {
+    if (!allowed.has(key)) valid = shape(issues, `${path}.${key}`, `${key} is not allowed`);
+  }
+  return valid;
+}
+
+function shape(issues: ProposalVerificationIssue[], path: string, message: string): false {
+  push(issues, 'shape', path, message);
+  return false;
+}
+
+function daysInMonth(year: number, month: number): number {
+  if (month === 2) return year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0) ? 29 : 28;
+  return [4, 6, 9, 11].includes(month) ? 30 : 31;
+}
+
+function safeDateTime(value: unknown): number {
+  try {
+    return value instanceof Date ? value.getTime() : Number.NaN;
+  } catch {
+    return Number.NaN;
+  }
+}
+
+function push(
+  issues: ProposalVerificationIssue[],
+  code: ProposalVerificationIssue['code'],
+  path: string,
+  message: string
+): void {
+  issues.push({ code, path, message });
+}

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -112,6 +112,19 @@ import {
 } from './responses';
 
 import { TOOL_REQUEST_SCHEMAS } from '../utils/tool-request-schemas';
+import { defineProposalRefinementCapabilities } from '../negotiation/seller';
+import {
+  ProposalRefinementValidationError,
+  refinementDimensions,
+  validateRefineProposalsRequest,
+} from '../negotiation/buyer';
+import { validateRefineProposalsResponseShape } from '../negotiation/verification';
+import type {
+  ProposalRefinementCapabilities,
+  RefineProposalsRequest,
+  RefineProposalsResponse,
+} from '../negotiation/types';
+import type { ProposalRefinementScope } from '../negotiation/seller';
 
 // NOTE on `outputSchema`: the MCP SDK's client-side `callTool` validates
 // `result.structuredContent` against the registered `outputSchema`
@@ -447,6 +460,8 @@ export interface HandlerContext<TAccount = unknown> {
    * lookup result.
    */
   authInfo?: ResolvedAuthInfo;
+  /** Trusted proposal namespace resolved by `proposalNegotiation.resolveScope`. */
+  proposalRefinementScope?: Readonly<ProposalRefinementScope>;
   /**
    * Emit a signed webhook to a buyer's `push_notification_config.url`.
    * Populated when `AdcpServerConfig.webhooks` is configured. Handles
@@ -546,6 +561,11 @@ export function requireSessionKey<TAccount = unknown>(ctx: HandlerContext<TAccou
  * builder only fires on the Success arm.
  */
 export interface AdcpToolMap {
+  refine_proposals: {
+    params: RefineProposalsRequest;
+    result: RefineProposalsResponse;
+    response: RefineProposalsResponse;
+  };
   get_products: {
     params: z.input<typeof GetProductsRequestSchema>;
     result: RequireCacheScopeWhenProducts<ServerPayload<GetProductsResponse>>;
@@ -898,6 +918,15 @@ export interface MediaBuyHandlers<TAccount = unknown> {
   listCreativeFormats?: DomainHandler<'list_creative_formats', TAccount>;
   syncCreatives?: DomainHandler<'sync_creatives', TAccount>;
   listCreatives?: DomainHandler<'list_creatives', TAccount>;
+}
+
+/** First-class AdCP 3.2 proposal negotiation server seam. */
+export interface ProposalNegotiationHandlers<TAccount = unknown> {
+  /** Projected to `media_buy.proposal_refinement` during capability discovery. */
+  capabilities: ProposalRefinementCapabilities;
+  /** Resolve a stable tenant/account namespace from authenticated server context. */
+  resolveScope: (ctx: HandlerContext<TAccount>) => MaybePromise<ProposalRefinementScope>;
+  refineProposals: DomainHandler<'refine_proposals', TAccount>;
 }
 
 export interface EventTrackingHandlers<TAccount = unknown> {
@@ -1544,6 +1573,7 @@ export interface AdcpServerConfig<TAccount = unknown> {
 
   // Domain handler groups — register only what you support
   mediaBuy?: MediaBuyHandlers<TAccount>;
+  proposalNegotiation?: ProposalNegotiationHandlers<TAccount>;
   signals?: SignalsHandlers<TAccount>;
   creative?: CreativeHandlers<TAccount>;
   governance?: GovernanceHandlers<TAccount>;
@@ -2217,10 +2247,20 @@ function isThrownAdcpError(value: unknown): value is McpToolResponse {
  * (or false-conflict) across them. Other tools return `undefined` and
  * use the default `(principal, key)` scope.
  */
-function resolveExtraScope(toolName: string, params: Record<string, unknown>): string | undefined {
+function resolveExtraScope(
+  toolName: string,
+  params: Record<string, unknown>,
+  proposalScope?: Readonly<ProposalRefinementScope>
+): string | undefined {
   if (toolName === 'si_send_message') {
     const sessionId = params.session_id;
     return typeof sessionId === 'string' && sessionId.length > 0 ? sessionId : undefined;
+  }
+  if (toolName === 'refine_proposals' && proposalScope) {
+    // The proposal namespace is framework-owned trusted context. Keep the
+    // complete tuple in the replay scope so one authenticated principal
+    // cannot replay a response across tenant or account boundaries.
+    return JSON.stringify([proposalScope.tenant_id, proposalScope.principal_id, proposalScope.account_id ?? null]);
   }
   return undefined;
 }
@@ -2485,6 +2525,16 @@ type ToolInputShapeMap = Readonly<Record<string, ZodRawShapeCompat | undefined>>
 let cachedToolInputShapes: ToolInputShapeMap | undefined;
 const SHALLOW_HINT_FIELD_SCHEMA = z.unknown().optional();
 const SHALLOW_HINT_SCHEMAS = new Map<string, AnySchema>();
+const REFINE_PROPOSALS_INPUT_SHAPE = {
+  idempotency_key: SHALLOW_HINT_FIELD_SCHEMA,
+  refinements: SHALLOW_HINT_FIELD_SCHEMA,
+  context_id: SHALLOW_HINT_FIELD_SCHEMA,
+  context: SHALLOW_HINT_FIELD_SCHEMA,
+  governance_context: SHALLOW_HINT_FIELD_SCHEMA,
+  push_notification_config: SHALLOW_HINT_FIELD_SCHEMA,
+  adcp_version: SHALLOW_HINT_FIELD_SCHEMA,
+  adcp_major_version: SHALLOW_HINT_FIELD_SCHEMA,
+} as unknown as ZodRawShapeCompat;
 
 function getToolInputShapes(): ToolInputShapeMap {
   cachedToolInputShapes ??= TOOL_INPUT_SHAPES as unknown as ToolInputShapeMap;
@@ -2492,7 +2542,7 @@ function getToolInputShapes(): ToolInputShapeMap {
 }
 
 function shallowToolInputHintSchema(toolName: string): AnySchema | undefined {
-  const inputShape = getToolInputShapes()[toolName];
+  const inputShape = toolName === 'refine_proposals' ? REFINE_PROPOSALS_INPUT_SHAPE : getToolInputShapes()[toolName];
   if (inputShape === undefined) return undefined;
 
   const cached = SHALLOW_HINT_SCHEMAS.get(toolName);
@@ -2504,8 +2554,87 @@ function shallowToolInputHintSchema(toolName: string): AnySchema | undefined {
   return schema;
 }
 
+function validateFrameworkPayload(
+  toolName: string,
+  direction: 'request' | 'response',
+  payload: unknown,
+  version: Parameters<typeof validateRequest>[2],
+  proposalCapabilities?: ProposalRefinementCapabilities
+) {
+  if (toolName !== 'refine_proposals') {
+    return direction === 'request'
+      ? validateRequest(toolName, payload, version)
+      : validateResponse(toolName, payload, version);
+  }
+  if (direction === 'request') {
+    try {
+      validateRefineProposalsRequest(payload as RefineProposalsRequest, proposalCapabilities);
+      return {
+        valid: true as const,
+        issues: [] as ValidationIssue[],
+        schemaId: '/schemas/media-buy/refine-proposals-request.json',
+        variant: undefined,
+      };
+    } catch (error) {
+      const refinementError =
+        error instanceof ProposalRefinementValidationError
+          ? error
+          : new ProposalRefinementValidationError(
+              error instanceof Error ? error.message : 'invalid refine_proposals request'
+            );
+      return {
+        valid: false as const,
+        refinementError,
+        issues: [
+          {
+            pointer: fieldPathToPointer(refinementError.field),
+            message: refinementError.message,
+            keyword: 'validation',
+            schemaPath: '#/local/validation',
+            schemaId: '/schemas/media-buy/refine-proposals-request.json',
+          },
+        ],
+        schemaId: '/schemas/media-buy/refine-proposals-request.json',
+        variant: undefined,
+      };
+    }
+  }
+  const verification = validateRefineProposalsResponseShape(payload);
+  if (verification.ok) {
+    return {
+      valid: true as const,
+      issues: [] as ValidationIssue[],
+      schemaId: '/schemas/media-buy/refine-proposals-response.json',
+      variant: undefined,
+    };
+  }
+  const issues: ValidationIssue[] = verification.issues.map(issue => ({
+    pointer: fieldPathToPointer(issue.path),
+    message: issue.message,
+    keyword: issue.code,
+    schemaPath: `#/local/${issue.code}`,
+    schemaId: '/schemas/media-buy/refine-proposals-response.json',
+  }));
+  return {
+    valid: false as const,
+    issues,
+    schemaId: '/schemas/media-buy/refine-proposals-response.json',
+    variant: undefined,
+  };
+}
+
+function fieldPathToPointer(path: string | undefined): string {
+  if (!path) return '';
+  const segments = path
+    .replace(/\[(\d+)\]/g, '.$1')
+    .split('.')
+    .filter(Boolean);
+  return `/${segments.map(segment => segment.replaceAll('~', '~0').replaceAll('/', '~1')).join('/')}`;
+}
+
 const TOOL_META: Record<string, ToolMeta> = {
   // Media Buy
+  refine_proposals: { wrap: null, annotations: IDEMP },
   get_products: { wrap: productsResponse, annotations: RO },
   create_media_buy: { wrap: mediaBuyResponse, annotations: MUT },
   update_media_buy: { wrap: updateMediaBuyResponse, annotations: MUT },
@@ -2606,6 +2735,8 @@ const MEDIA_BUY_ENTRIES: HandlerEntry[] = [
   { handlerKey: 'listCreatives', toolName: 'list_creatives' },
 ];
 
+const PROPOSAL_NEGOTIATION_ENTRIES: HandlerEntry[] = [{ handlerKey: 'refineProposals', toolName: 'refine_proposals' }];
+
 const EVENT_TRACKING_ENTRIES: HandlerEntry[] = [
   { handlerKey: 'syncEventSources', toolName: 'sync_event_sources' },
   { handlerKey: 'logEvent', toolName: 'log_event' },
@@ -2680,7 +2811,7 @@ const BRAND_RIGHTS_ENTRIES: HandlerEntry[] = [
 // ---------------------------------------------------------------------------
 
 const TOOL_PROTOCOL_MAP: [readonly string[], AdcpProtocol][] = [
-  [MEDIA_BUY_TOOLS, 'media_buy'],
+  [[...MEDIA_BUY_TOOLS, 'refine_proposals'], 'media_buy'],
   [SIGNALS_TOOLS, 'signals'],
   [GOVERNANCE_TOOLS, 'governance'],
   [CREATIVE_TOOLS, 'creative'],
@@ -3544,6 +3675,13 @@ function bundledReleasesForMajors(majors: readonly number[], configured: ParsedA
     // stable semver patches otherwise collapse to release precision.
     if (!existing || parsed.value.startsWith('v')) releases.set(key, parsed);
   }
+  // A server may explicitly opt into a bundled forward release before the
+  // SDK-wide compatibility list advances (proposal negotiation does this for
+  // 3.2). Include that configured release in major-only negotiation.
+  if (acceptedMajors.has(configured.major)) {
+    const key = `${configured.major}.${configured.minor}${configured.prerelease ? `-${configured.prerelease}` : ''}`;
+    releases.set(key, configured);
+  }
   return [...releases.values()];
 }
 
@@ -3766,7 +3904,53 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
   // `wrapMcpServer` returns), but the ordering hides a sharp edge for
   // future refactors. Throws `ConfigurationError` on cross-major pins
   // whose schema bundle isn't shipped — see utils/adcp-version-config.ts.
-  const adcpVersion = resolveAdcpVersion(configuredAdcpVersion);
+  // Registering a 3.2-only proposal tool is an explicit opt-in to the
+  // bundled 3.2 server surface. Keep the SDK-wide client pin unchanged,
+  // but make this server instance negotiate and advertise the release it
+  // actually serves. An explicit older pin is rejected below.
+  const adcpVersion = resolveAdcpVersion(configuredAdcpVersion ?? (config.proposalNegotiation ? '3.2.0' : undefined));
+  const proposalRefinementCapabilities = config.proposalNegotiation
+    ? defineProposalRefinementCapabilities(config.proposalNegotiation.capabilities)
+    : undefined;
+  const proposalRelease = parseAdcpRelease(adcpVersion);
+  if (
+    proposalRefinementCapabilities &&
+    (!proposalRelease || proposalRelease.major !== 3 || proposalRelease.minor < 2)
+  ) {
+    throw new Error('createAdcpServer: proposalNegotiation requires adcpVersion 3.2 or newer');
+  }
+  if (proposalRefinementCapabilities && capConfig?.supported_versions?.length) {
+    const supportsProposalRelease = capConfig.supported_versions.some(value => {
+      const release = parseAdcpRelease(value);
+      return (
+        release !== undefined &&
+        release.major === 3 &&
+        release.minor >= 2 &&
+        proposalRelease !== undefined &&
+        compareAdcpRelease(release, proposalRelease) <= 0
+      );
+    });
+    if (!supportsProposalRelease) {
+      throw new Error(
+        'createAdcpServer: proposalNegotiation requires capabilities.supported_versions to include a served AdCP 3.2 release'
+      );
+    }
+  }
+  if (
+    proposalRefinementCapabilities &&
+    !capConfig?.supported_versions?.length &&
+    capConfig?.major_versions?.length &&
+    !capConfig.major_versions.includes(3)
+  ) {
+    throw new Error(
+      'createAdcpServer: proposalNegotiation requires capabilities.major_versions to include AdCP major 3'
+    );
+  }
+  if (proposalRefinementCapabilities && proposalRefinementCapabilities.supported_dimensions === undefined) {
+    throw new Error(
+      'createAdcpServer: proposalNegotiation.capabilities.supported_dimensions is required when refineProposals is registered'
+    );
+  }
 
   // Pre-resolved release-precision identifier the seller echoes on every
   // response per AdCP 3.1 spec PR `adcontextprotocol/adcp#3493`. `undefined`
@@ -4179,6 +4363,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
   };
 
   const releaseDefinesTool = (toolName: string, release: ServedAdcpRelease): boolean => {
+    if (toolName === 'refine_proposals') return true;
     try {
       return getValidator(toolName, 'request', release.validationVersion) !== undefined;
     } catch {
@@ -4545,6 +4730,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
   // Collect all domain handlers into a flat toolName → handler map
   const domainGroups: [Record<string, Function> | undefined, HandlerEntry[]][] = [
     [config.mediaBuy as Record<string, Function> | undefined, MEDIA_BUY_ENTRIES],
+    [config.proposalNegotiation as unknown as Record<string, Function> | undefined, PROPOSAL_NEGOTIATION_ENTRIES],
     [config.signals as Record<string, Function> | undefined, SIGNALS_ENTRIES],
     [config.creative as Record<string, Function> | undefined, CREATIVE_ENTRIES],
     [config.governance as Record<string, Function> | undefined, GOVERNANCE_ENTRIES],
@@ -4577,7 +4763,10 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
       }
 
       const meta = TOOL_META[toolName];
-      const schema = (TOOL_REQUEST_SCHEMAS as Readonly<Record<string, { shape: Record<string, unknown> }>>)[toolName];
+      const schema =
+        toolName === 'refine_proposals'
+          ? { shape: REFINE_PROPOSALS_INPUT_SHAPE }
+          : (TOOL_REQUEST_SCHEMAS as Readonly<Record<string, { shape: Record<string, unknown> }>>)[toolName];
       if (!schema?.shape) {
         logger.warn(`No schema found for tool "${toolName}" in TOOL_REQUEST_SCHEMAS, skipping`);
         continue;
@@ -4961,9 +5150,50 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
         // --- Request schema validation (opt-in) ---
         // Runs before idempotency so drifted payloads never touch the
         // replay cache. `off` short-circuits without calling AJV.
+        // Capability policy is not optional schema validation: an adopter
+        // that disables AJV must still never receive a dimension it did not
+        // advertise. Run that gate unconditionally for this forward tool.
+        if (toolName === 'refine_proposals' && proposalRefinementCapabilities && Array.isArray(params.refinements)) {
+          const supported = new Set(proposalRefinementCapabilities.supported_dimensions);
+          for (const [index, candidate] of params.refinements.entries()) {
+            if (!isPlainObject(candidate)) continue;
+            const unsupported = refinementDimensions(candidate as never).find(dimension => !supported.has(dimension));
+            if (unsupported) {
+              return finalize(
+                adcpError('UNSUPPORTED_FEATURE', {
+                  message: `seller does not advertise proposal refinement dimension ${unsupported}`,
+                  field: `refinements[${index}]`,
+                  details: {
+                    unsupported_dimension: unsupported,
+                    supported_dimensions: [...proposalRefinementCapabilities.supported_dimensions],
+                  },
+                })
+              );
+            }
+          }
+        }
         if (requestValidationMode !== 'off') {
-          const outcome = validateRequest(toolName, params, requestRelease.validationVersion);
+          const outcome = validateFrameworkPayload(
+            toolName,
+            'request',
+            params,
+            requestRelease.validationVersion,
+            proposalRefinementCapabilities
+          );
           if (!outcome.valid) {
+            if ('refinementError' in outcome && outcome.refinementError?.code === 'UNSUPPORTED_FEATURE') {
+              return finalize(
+                adcpError('UNSUPPORTED_FEATURE', {
+                  message: outcome.refinementError.message,
+                  ...(outcome.refinementError.field !== undefined && {
+                    field: outcome.refinementError.field,
+                  }),
+                  ...(outcome.refinementError.details !== undefined && {
+                    details: outcome.refinementError.details,
+                  }),
+                })
+              );
+            }
             // When `idempotency: 'disabled'` is set, drop the synthetic
             // "missing idempotency_key" failure on mutating tools — the
             // operator has explicitly opted out of enforcement and would
@@ -5138,6 +5368,33 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
           }
         }
 
+        if (toolName === 'refine_proposals') {
+          if (ctx.authInfo === undefined && ctx.agent === undefined) {
+            return finalize(
+              adcpError('AUTH_MISSING', {
+                message: 'refine_proposals requires an authenticated buyer principal',
+              })
+            );
+          }
+          try {
+            const scope = await config.proposalNegotiation!.resolveScope(ctx);
+            if (!scope?.tenant_id || !scope.principal_id) {
+              throw new Error('resolveScope must return non-empty tenant_id and principal_id');
+            }
+            ctx.proposalRefinementScope = Object.freeze({ ...scope });
+          } catch (err) {
+            if (err instanceof AdcpError) return finalize(projectThrownAdcpError(err));
+            const reason = err instanceof Error ? err.message : String(err);
+            logger.error('Proposal refinement scope resolution failed', { tool: toolName, error: reason });
+            return finalize(
+              adcpError('SERVICE_UNAVAILABLE', {
+                message: 'Proposal refinement scope resolution failed',
+                ...(exposeErrorDetails && { details: { reason: redactCredentialPatterns(reason) } }),
+              })
+            );
+          }
+        }
+
         // --- idempotency_key shape gate (runs even in disabled mode) ---
         // Defense-in-depth against buyers that bypass MCP schema
         // validation (different transport, bespoke client) AND against
@@ -5196,7 +5453,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
           // two different sessions must not replay into each other. The
           // caller's session_id enters the scope tuple so each session has
           // its own idempotency namespace.
-          const extraScope = resolveExtraScope(toolName, params);
+          const extraScope = resolveExtraScope(toolName, params, ctx.proposalRefinementScope);
 
           try {
             const checkResult = await idempotency.check({ principal, key, payload: params, extraScope });
@@ -5907,7 +6164,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
           // their shape is enforced by the adcpError() builder.
           if (responseValidationMode !== 'off' && !isErrorResponse(formatted)) {
             const payload = formatted.structuredContent;
-            const outcome = validateResponse(toolName, payload, requestRelease.validationVersion);
+            const outcome = validateFrameworkPayload(toolName, 'response', payload, requestRelease.validationVersion);
             if (!outcome.valid) {
               logger.warn(
                 `Schema validation warning (response) for ${toolName}: ${formatIssues(outcome.issues, 3, { rootSchemaId: outcome.schemaId })}`,
@@ -6528,6 +6785,24 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
     applyCapabilityOverrides(capabilitiesData, capConfig.overrides);
   }
 
+  if (proposalRefinementCapabilities) {
+    const mediaBuy = (capabilitiesData.media_buy ??= {
+      features: {
+        inline_creative_management: false,
+        property_list_filtering: false,
+        content_standards: false,
+        conversion_tracking: false,
+        audience_targeting: false,
+      },
+    });
+    const forwardMediaBuy = mediaBuy as typeof mediaBuy & {
+      lifecycle_tools?: string[];
+      proposal_refinement?: ProposalRefinementCapabilities;
+    };
+    forwardMediaBuy.proposal_refinement = proposalRefinementCapabilities;
+    forwardMediaBuy.lifecycle_tools = [...new Set([...(forwardMediaBuy.lifecycle_tools ?? []), 'refine_proposals'])];
+  }
+
   if (
     capabilitiesData.measurement !== undefined &&
     Array.isArray(capabilitiesData.experimental_features) &&
@@ -6651,6 +6926,23 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
         }),
       } as GetAdCPCapabilitiesResponse;
       const selected = parseAdcpRelease(release.validationVersion);
+      if (selected !== undefined && (selected.major < 3 || (selected.major === 3 && selected.minor < 2))) {
+        const forwardMediaBuy = data.media_buy as
+          | (NonNullable<typeof data.media_buy> & {
+              lifecycle_tools?: string[];
+              proposal_refinement?: ProposalRefinementCapabilities;
+            })
+          | undefined;
+        if (forwardMediaBuy) {
+          delete forwardMediaBuy.proposal_refinement;
+          if (forwardMediaBuy.lifecycle_tools) {
+            forwardMediaBuy.lifecycle_tools = forwardMediaBuy.lifecycle_tools.filter(
+              tool => tool !== 'refine_proposals'
+            );
+            if (forwardMediaBuy.lifecycle_tools.length === 0) delete forwardMediaBuy.lifecycle_tools;
+          }
+        }
+      }
       if (selected !== undefined && (selected.major < 3 || (selected.major === 3 && selected.minor < 1))) {
         delete (data.adcp as GetAdCPCapabilitiesResponse['adcp'] & { supported_versions?: string[] })
           .supported_versions;
@@ -6670,11 +6962,12 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
       // discovery callable without inventing one; once a protocol is
       // registered, the selected release schema is authoritative.
       if (responseValidationMode !== 'off' && data.supported_protocols.length > 0) {
-        const responseOutcome = validateResponse(
-          'get_adcp_capabilities',
-          response.structuredContent,
-          release.validationVersion
-        );
+        const validationPayload = structuredClone(response.structuredContent);
+        if (proposalRefinementCapabilities && isPlainObject(validationPayload?.media_buy)) {
+          delete validationPayload.media_buy.proposal_refinement;
+          delete validationPayload.media_buy.lifecycle_tools;
+        }
+        const responseOutcome = validateResponse('get_adcp_capabilities', validationPayload, release.validationVersion);
         if (!responseOutcome.valid) {
           logger.warn(
             `Schema validation warning (response) for get_adcp_capabilities: ${formatIssues(responseOutcome.issues, 3, { rootSchemaId: responseOutcome.schemaId })}`,

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -2193,7 +2193,7 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
   // never negotiate protocol behavior. Only the configured AdCP schema pin
   // determines whether this server may advertise the 3.1 feature bit (3.2+
   // makes canonical creatives part of the release contract itself).
-  const configuredAdcpVersion = opts.adcpVersion ?? ADCP_VERSION;
+  const configuredAdcpVersion = opts.adcpVersion ?? (opts.proposalNegotiation ? '3.2.0' : ADCP_VERSION);
   const configuredRelease = parseAdcpRelease(configuredAdcpVersion);
   if (!configuredRelease) {
     throw new PlatformConfigError(

--- a/src/lib/server/index.ts
+++ b/src/lib/server/index.ts
@@ -375,6 +375,7 @@ export type {
   HandlerContext as LegacyHandlerContext,
   SessionKeyContext,
   MediaBuyHandlers as LegacyMediaBuyHandlers,
+  ProposalNegotiationHandlers as LegacyProposalNegotiationHandlers,
   SignalsHandlers as LegacySignalsHandlers,
   CreativeHandlers as LegacyCreativeHandlers,
   GovernanceHandlers as LegacyGovernanceHandlers,
@@ -523,6 +524,36 @@ export type {
 // future major. New code should not pin against `legacy/v5` either —
 // reach for `createAdcpServerFromPlatform` first.
 export * from './decisioning';
+export {
+  createProposalRefinementHandler,
+  createProposalSuccessor,
+  proposalRefinementScopeFromContext,
+  classifyProposalRefinementFailure,
+  defineProposalRefinementCapabilities,
+  ProposalSellerPreflightError,
+} from '../negotiation/seller';
+export { proposalTermsDigest, verifyProposalTermsDigest } from '../negotiation/verification';
+export type {
+  ProposalCommercialEvaluator,
+  ProposalFailureClassification,
+  ProposalEvaluationContext,
+  ProposalRefinementHandler,
+  ProposalRefinementHandlerOptions,
+  ProposalRefinementStore,
+  ProposalRefinementTransaction,
+  ProposalRefinementScope,
+  ProposalSourceExpectation,
+  ProposalSourceSnapshot,
+  ProposalSuccessorInput,
+} from '../negotiation/seller';
+export type {
+  CanonicalProposal,
+  ProposalCommercialTerms,
+  ProposalRefinementCapabilities,
+  ProposalRefinementResult,
+  RefineProposalsRequest,
+  RefineProposalsResponse,
+} from '../negotiation/types';
 
 // ---------------------------------------------------------------------------
 // Ctx-metadata store — opaque-blob round-trip for adapter-internal state

--- a/src/lib/server/legacy/v5/index.ts
+++ b/src/lib/server/legacy/v5/index.ts
@@ -103,6 +103,7 @@ export type {
   HandlerContext,
   SessionKeyContext,
   MediaBuyHandlers,
+  ProposalNegotiationHandlers,
   SignalsHandlers,
   CreativeHandlers,
   GovernanceHandlers,

--- a/src/lib/utils/idempotency.ts
+++ b/src/lib/utils/idempotency.ts
@@ -37,6 +37,9 @@ function deriveMutatingTasks(): Set<string> {
       result.add(toolName);
     }
   }
+  // Forward surface: refine_proposals is normative in AdCP 3.2 but is
+  // available on protocol latest before the SDK's generated schema pin moves.
+  result.add('refine_proposals');
   return result;
 }
 

--- a/src/lib/utils/jcs.ts
+++ b/src/lib/utils/jcs.ts
@@ -132,24 +132,14 @@ function serializeNumber(n: number): string {
  * - Escape " \ and control chars U+0000..U+001F
  * - Use shortest escape form: \b \t \n \f \r for the common ones, \u00XX for others
  * - Do NOT escape forward slash, non-ASCII chars pass through verbatim
- * - Lone surrogates are rejected as required by RFC 8785
+ * - Lone surrogates are preserved for backwards compatibility with existing
+ *   shared idempotency/signing callers; protocol surfaces that require strict
+ *   I-JSON must validate the canonical output at their boundary
  */
 function serializeString(s: string): string {
   let out = '"';
   for (let i = 0; i < s.length; i++) {
     const code = s.charCodeAt(i);
-    if (code >= 0xd800 && code <= 0xdbff) {
-      const low = s.charCodeAt(i + 1);
-      if (!(low >= 0xdc00 && low <= 0xdfff)) {
-        throw new TypeError('JCS: lone Unicode surrogate is not valid I-JSON');
-      }
-      out += s.charAt(i) + s.charAt(i + 1);
-      i++;
-      continue;
-    }
-    if (code >= 0xdc00 && code <= 0xdfff) {
-      throw new TypeError('JCS: lone Unicode surrogate is not valid I-JSON');
-    }
     if (code === 0x22) {
       out += '\\"';
     } else if (code === 0x5c) {

--- a/src/lib/utils/jcs.ts
+++ b/src/lib/utils/jcs.ts
@@ -132,12 +132,24 @@ function serializeNumber(n: number): string {
  * - Escape " \ and control chars U+0000..U+001F
  * - Use shortest escape form: \b \t \n \f \r for the common ones, \u00XX for others
  * - Do NOT escape forward slash, non-ASCII chars pass through verbatim
- * - Lone surrogates are preserved (JSON allows them)
+ * - Lone surrogates are rejected as required by RFC 8785
  */
 function serializeString(s: string): string {
   let out = '"';
   for (let i = 0; i < s.length; i++) {
     const code = s.charCodeAt(i);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const low = s.charCodeAt(i + 1);
+      if (!(low >= 0xdc00 && low <= 0xdfff)) {
+        throw new TypeError('JCS: lone Unicode surrogate is not valid I-JSON');
+      }
+      out += s.charAt(i) + s.charAt(i + 1);
+      i++;
+      continue;
+    }
+    if (code >= 0xdc00 && code <= 0xdfff) {
+      throw new TypeError('JCS: lone Unicode surrogate is not valid I-JSON');
+    }
     if (code === 0x22) {
       out += '\\"';
     } else if (code === 0x5c) {

--- a/test/lib/proposal-negotiation-server.test.js
+++ b/test/lib/proposal-negotiation-server.test.js
@@ -1,0 +1,542 @@
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { createAdcpServer } = require('../../dist/lib/server/legacy/v5/index.js');
+const {
+  createIdempotencyStore,
+  createAdcpServerFromPlatform,
+  createInMemoryTaskRegistry,
+  createProposalRefinementHandler,
+  createProposalSuccessor,
+  InMemoryStateStore,
+  memoryBackend,
+  proposalRefinementScopeFromContext,
+  proposalTermsDigest,
+} = require('../../dist/lib/server/index.js');
+
+const request = (key, proposalId = 'source-1') => ({
+  adcp_version: '3.2',
+  adcp_major_version: 3,
+  idempotency_key: key,
+  refinements: [{ proposal_id: proposalId, action: 'finalize' }],
+});
+
+async function call(server, name, args, clientId) {
+  return server.dispatchTestRequest(
+    { method: 'tools/call', params: { name, arguments: args } },
+    clientId ? { authInfo: { token: 'redacted', clientId, scopes: [] } } : undefined
+  );
+}
+
+function negotiationServer(onCall, options = {}) {
+  return createAdcpServer({
+    name: 'proposal-test',
+    version: '1.0.0',
+    ...(options.adcpVersion && { adcpVersion: options.adcpVersion }),
+    ...(options.serverCapabilities && { capabilities: options.serverCapabilities }),
+    validation: options.validation ?? { requests: 'strict', responses: 'strict' },
+    stateStore: new InMemoryStateStore(),
+    idempotency: createIdempotencyStore({ backend: memoryBackend({ sweepIntervalMs: 0 }), ttlSeconds: 3600 }),
+    resolveIdempotencyPrincipal: ctx => ctx.proposalRefinementScope?.principal_id,
+    proposalNegotiation: {
+      capabilities: options.capabilities ?? {
+        supported_dimensions: ['total_budget', 'alternatives'],
+        max_alternatives: 4,
+      },
+      resolveScope:
+        options.resolveScope ?? (ctx => ({ tenant_id: 'seller-tenant', principal_id: ctx.authInfo.clientId })),
+      refineProposals:
+        options.refineProposals ??
+        (async (params, ctx) => {
+          onCall?.(params, ctx);
+          return {
+            status: 'completed',
+            results: params.refinements.map(entry => ({
+              source_proposal_id: entry.proposal_id,
+              outcome: 'unable',
+              reason_code: 'source_unavailable',
+              reason: 'not present',
+            })),
+            products: [],
+          };
+        }),
+    },
+  });
+}
+
+describe('refine_proposals server integration', () => {
+  test('modern platform seam auto-pins to an advertised 3.2 release', async () => {
+    const server = createAdcpServerFromPlatform(
+      {
+        capabilities: { specialisms: [], supported_versions: ['3.2'] },
+        accounts: {
+          resolution: 'derived',
+          resolve: async () => ({ id: 'account-1', metadata: {} }),
+        },
+      },
+      {
+        name: 'proposal-platform-test',
+        version: '1.0.0',
+        stateStore: new InMemoryStateStore(),
+        taskRegistry: createInMemoryTaskRegistry(),
+        resolveIdempotencyPrincipal: ctx => ctx.proposalRefinementScope?.principal_id,
+        validation: { requests: 'strict', responses: 'strict' },
+        proposalNegotiation: {
+          capabilities: { supported_dimensions: [] },
+          resolveScope: ctx => ({ tenant_id: 'seller-tenant', principal_id: ctx.authInfo.clientId }),
+          refineProposals: async params => ({
+            status: 'completed',
+            results: params.refinements.map(entry => ({
+              source_proposal_id: entry.proposal_id,
+              outcome: 'unable',
+              reason_code: 'source_unavailable',
+              reason: 'not present',
+            })),
+            products: [],
+          }),
+        },
+      }
+    );
+
+    const listed = await server.dispatchTestRequest({ method: 'tools/list' });
+    assert.ok(listed.tools.some(tool => tool.name === 'refine_proposals'));
+    const capabilities = await call(server, 'get_adcp_capabilities', {});
+    assert.equal(capabilities.structuredContent.adcp_version, '3.2');
+    assert.deepEqual(capabilities.structuredContent.adcp.supported_versions, ['3.2']);
+    assert.deepEqual(capabilities.structuredContent.media_buy.proposal_refinement, {
+      supported_dimensions: [],
+    });
+  });
+
+  test('registers as a framework tool and projects proposal capabilities', async () => {
+    const server = negotiationServer();
+    const listed = await server.dispatchTestRequest({ method: 'tools/list' });
+    assert.ok(listed.tools.some(tool => tool.name === 'refine_proposals'));
+
+    const capabilities = await call(server, 'get_adcp_capabilities', {});
+    assert.deepEqual(capabilities.structuredContent.media_buy.proposal_refinement, {
+      supported_dimensions: ['total_budget', 'alternatives'],
+      max_alternatives: 4,
+    });
+    assert.equal(capabilities.structuredContent.adcp_version, '3.2');
+    assert.ok(capabilities.structuredContent.media_buy.lifecycle_tools.includes('refine_proposals'));
+
+    const response = await call(server, 'refine_proposals', request('version-envelope-key-0001'), 'buyer-a');
+    assert.equal(response.structuredContent.adcp_version, '3.2');
+  });
+
+  test('rejects an explicit pre-3.2 server pin', () => {
+    assert.throws(() => negotiationServer(undefined, { adcpVersion: '3.1.13' }), /requires adcpVersion 3.2/);
+  });
+
+  test('rejects capability negotiation that advertises only pre-3.2 releases', () => {
+    assert.throws(
+      () => negotiationServer(undefined, { serverCapabilities: { supported_versions: ['3.1'] } }),
+      /supported_versions to include a served AdCP 3.2 release/
+    );
+  });
+
+  test('hides proposal refinement capabilities from a negotiated pre-3.2 response', async () => {
+    const server = negotiationServer(undefined, {
+      serverCapabilities: { supported_versions: ['3.1', '3.2'] },
+    });
+
+    const legacy = await call(server, 'get_adcp_capabilities', {
+      adcp_version: '3.1',
+      adcp_major_version: 3,
+    });
+    assert.equal(legacy.structuredContent.adcp_version, '3.1');
+    assert.equal(legacy.structuredContent.media_buy.proposal_refinement, undefined);
+    assert.equal(legacy.structuredContent.media_buy.lifecycle_tools, undefined);
+
+    const modern = await call(server, 'get_adcp_capabilities', {
+      adcp_version: '3.2',
+      adcp_major_version: 3,
+    });
+    assert.equal(modern.structuredContent.adcp_version, '3.2');
+    assert.deepEqual(modern.structuredContent.media_buy.proposal_refinement, {
+      supported_dimensions: ['total_budget', 'alternatives'],
+      max_alternatives: 4,
+    });
+    assert.ok(modern.structuredContent.media_buy.lifecycle_tools.includes('refine_proposals'));
+  });
+
+  test('requires authentication and validates before handler dispatch', async () => {
+    let calls = 0;
+    const server = negotiationServer(() => calls++);
+    const anonymous = await call(server, 'refine_proposals', request('anonymous-key-0001'));
+    assert.equal(anonymous.structuredContent.adcp_error.code, 'AUTH_MISSING');
+
+    const malformed = await call(
+      server,
+      'refine_proposals',
+      { idempotency_key: 'malformed-key-0001', refinements: [] },
+      'buyer-a'
+    );
+    assert.equal(malformed.structuredContent.adcp_error.code, 'VALIDATION_ERROR');
+    assert.equal(calls, 0);
+  });
+
+  test('scopes idempotency by trusted principal and replays exact retries', async () => {
+    const scopes = [];
+    const server = negotiationServer((_params, ctx) => scopes.push(ctx.proposalRefinementScope));
+    const payload = request('principal-scope-key-0001');
+
+    const first = await call(server, 'refine_proposals', payload, 'buyer-a');
+    const replay = await call(server, 'refine_proposals', payload, 'buyer-a');
+    const otherTenant = await call(server, 'refine_proposals', payload, 'buyer-b');
+
+    assert.equal(first.structuredContent.replayed, undefined);
+    assert.equal(replay.structuredContent.replayed, true);
+    assert.equal(otherTenant.structuredContent.replayed, undefined);
+    assert.deepEqual(scopes, [
+      { tenant_id: 'seller-tenant', principal_id: 'buyer-a' },
+      { tenant_id: 'seller-tenant', principal_id: 'buyer-b' },
+    ]);
+  });
+
+  test('isolates replay state across trusted tenant and account scope', async () => {
+    let activeScope = { tenant_id: 'tenant-a', principal_id: 'buyer-a', account_id: 'account-a' };
+    let calls = 0;
+    const server = negotiationServer(() => calls++, { resolveScope: () => activeScope });
+    const payload = request('tenant-account-scope-key-0001');
+
+    const tenantA = await call(server, 'refine_proposals', payload, 'buyer-a');
+    const tenantAReplay = await call(server, 'refine_proposals', payload, 'buyer-a');
+    activeScope = { tenant_id: 'tenant-b', principal_id: 'buyer-a', account_id: 'account-a' };
+    const tenantB = await call(server, 'refine_proposals', payload, 'buyer-a');
+    activeScope = { tenant_id: 'tenant-b', principal_id: 'buyer-a', account_id: 'account-b' };
+    const accountB = await call(server, 'refine_proposals', payload, 'buyer-a');
+
+    assert.equal(tenantA.structuredContent.replayed, undefined);
+    assert.equal(tenantAReplay.structuredContent.replayed, true);
+    assert.equal(tenantB.structuredContent.replayed, undefined);
+    assert.equal(accountB.structuredContent.replayed, undefined);
+    assert.equal(calls, 3);
+  });
+
+  test('enforces advertised dimensions before handler dispatch', async () => {
+    let calls = 0;
+    const server = negotiationServer(() => calls++, {
+      capabilities: { supported_dimensions: [] },
+    });
+    const payload = {
+      adcp_version: '3.2',
+      adcp_major_version: 3,
+      idempotency_key: 'unsupported-dimension-key-0001',
+      refinements: [
+        {
+          proposal_id: 'source-1',
+          action: 'revise',
+          constraints: { total_budget: { currency: 'USD', max: 1000 } },
+        },
+      ],
+    };
+
+    const response = await call(server, 'refine_proposals', payload, 'buyer-a');
+    assert.equal(response.structuredContent.adcp_error.code, 'UNSUPPORTED_FEATURE');
+    assert.deepEqual(response.structuredContent.adcp_error.details, {
+      unsupported_dimension: 'total_budget',
+      supported_dimensions: [],
+    });
+    assert.equal(calls, 0);
+  });
+
+  test('enforces advertised dimensions when optional schema validation is off', async () => {
+    let calls = 0;
+    const server = negotiationServer(() => calls++, {
+      capabilities: { supported_dimensions: [] },
+      validation: { requests: 'off', responses: 'off' },
+    });
+    const payload = {
+      idempotency_key: 'off-mode-dimension-key-0001',
+      refinements: [
+        {
+          proposal_id: 'source-1',
+          action: 'revise',
+          constraints: { total_budget: { currency: 'USD', max: 1000 } },
+        },
+      ],
+    };
+
+    const response = await call(server, 'refine_proposals', payload, 'buyer-a');
+    assert.equal(response.structuredContent.adcp_error.code, 'UNSUPPORTED_FEATURE');
+    assert.equal(calls, 0);
+  });
+
+  test('accepts the compact submitted response arm in strict mode', async () => {
+    const server = negotiationServer(undefined, {
+      capabilities: { supported_dimensions: [] },
+      refineProposals: async () => ({
+        status: 'submitted',
+        task_id: 'proposal-task-1',
+        message: 'Inventory underwriting is pending.',
+        errors: [{ code: 'UNDERWRITING_DELAY', message: 'Manual review requested.' }],
+      }),
+    });
+
+    const response = await call(server, 'refine_proposals', request('submitted-response-key-0001'), 'buyer-a');
+    assert.equal(response.isError, undefined);
+    assert.equal(response.structuredContent.status, 'submitted');
+    assert.equal(response.structuredContent.task_id, 'proposal-task-1');
+    assert.equal(response.structuredContent.adcp_version, '3.2');
+    assert.equal(response.structuredContent.results, undefined);
+    assert.equal(response.structuredContent.products, undefined);
+  });
+});
+
+function sourceProposal() {
+  const commercial_terms = {
+    brand: { domain: 'advertiser.test' },
+    purchases: [
+      {
+        product_id: 'product-1',
+        pricing_option_id: 'price-1',
+        pricing: {
+          pricing_option_id: 'price-1',
+          pricing_model: 'cpm',
+          currency: 'USD',
+          fixed_price: 10,
+        },
+        start_time: '2027-01-01T00:00:00Z',
+        end_time: '2027-02-01T00:00:00Z',
+      },
+    ],
+    start_time: '2027-01-01T00:00:00Z',
+    end_time: '2027-02-01T00:00:00Z',
+  };
+  return {
+    proposal_id: 'source-1',
+    proposal_kind: 'new_media_buy',
+    proposal_status: 'draft',
+    name: 'Source',
+    commercial_terms,
+    terms_digest: proposalTermsDigest(commercial_terms),
+  };
+}
+
+test('source snapshot CAS prevents concurrent different-key double holds', async () => {
+  const scope = { tenant_id: 'seller-tenant', principal_id: 'buyer-a' };
+  const records = new Map([['source-1', { proposal: sourceProposal(), version: 1 }]]);
+  let evaluations = 0;
+  let releaseEvaluations;
+  const bothEvaluating = new Promise(resolve => (releaseEvaluations = resolve));
+
+  const handler = createProposalRefinementHandler({
+    capabilities: { supported_dimensions: [] },
+    scope: proposalRefinementScopeFromContext,
+    store: {
+      get: (_scope, id) => {
+        const row = records.get(id);
+        return row ? { proposal: row.proposal, version: String(row.version) } : null;
+      },
+      begin: (_scope, expected) => {
+        const staged = [];
+        return {
+          stage: proposals => staged.push(...proposals),
+          commit: () => {
+            for (const source of expected) {
+              const row = records.get(source.proposal_id);
+              if ((row ? String(row.version) : null) !== source.version) throw new Error('CAS conflict');
+            }
+            for (const source of expected) {
+              const row = records.get(source.proposal_id);
+              if (row) records.set(source.proposal_id, { ...row, version: row.version + 1 });
+            }
+            for (const proposal of staged) {
+              if (records.has(proposal.proposal_id)) throw new Error('insert conflict');
+              records.set(proposal.proposal_id, { proposal, version: 1 });
+            }
+          },
+          rollback: () => staged.splice(0),
+        };
+      },
+    },
+    evaluate: async ({ request: incoming, refinement, source }) => {
+      evaluations++;
+      if (evaluations === 2) releaseEvaluations();
+      await bothEvaluating;
+      return {
+        source_proposal_id: refinement.proposal_id,
+        outcome: 'finalized',
+        proposal: createProposalSuccessor(source, {
+          ...source,
+          proposal_id: `held-${incoming.idempotency_key}`,
+          proposal_status: 'committed',
+          expires_at: '2028-01-01T00:00:00Z',
+        }),
+      };
+    },
+    now: () => new Date('2027-01-01T00:00:00Z'),
+  });
+  const context = { proposalRefinementScope: scope, store: {} };
+  const settled = await Promise.allSettled([
+    handler(request('concurrent-hold-key-0001'), context),
+    handler(request('concurrent-hold-key-0002'), context),
+  ]);
+
+  assert.equal(settled.filter(result => result.status === 'fulfilled').length, 1);
+  assert.equal(settled.filter(result => result.status === 'rejected').length, 1);
+  assert.equal([...records.keys()].filter(id => id.startsWith('held-')).length, 1);
+  assert.equal(records.get('source-1').version, 2);
+});
+
+test('active hold snapshot prevents sequential different-key double holds', async () => {
+  const source = sourceProposal();
+  const records = new Map([['source-1', { proposal: source, version: 1 }]]);
+  let evaluations = 0;
+  const handler = createProposalRefinementHandler({
+    capabilities: { supported_dimensions: [] },
+    scope: () => ({ tenant_id: 'seller-tenant', principal_id: 'buyer-a' }),
+    store: {
+      get: (_scope, id) => {
+        const row = records.get(id);
+        return row
+          ? {
+              proposal: row.proposal,
+              version: String(row.version),
+              ...(row.active_hold && { active_hold: structuredClone(row.active_hold) }),
+            }
+          : null;
+      },
+      begin: (_scope, expected) => {
+        const staged = [];
+        return {
+          stage: proposals => staged.push(...proposals),
+          commit: () => {
+            for (const expectation of expected) {
+              const row = records.get(expectation.proposal_id);
+              if ((row ? String(row.version) : null) !== expectation.version) throw new Error('CAS conflict');
+              if (row?.active_hold) throw new Error('active hold conflict');
+            }
+            for (const proposal of staged) {
+              if (records.has(proposal.proposal_id)) throw new Error('insert conflict');
+            }
+            for (const expectation of expected) {
+              const row = records.get(expectation.proposal_id);
+              const held = staged.find(proposal => proposal.parent_proposal_id === expectation.proposal_id);
+              if (row && held) {
+                records.set(expectation.proposal_id, {
+                  ...row,
+                  version: row.version + 1,
+                  active_hold: { proposal_id: held.proposal_id, expires_at: held.expires_at },
+                });
+              }
+            }
+            for (const proposal of staged) records.set(proposal.proposal_id, { proposal, version: 1 });
+          },
+          rollback: () => staged.splice(0),
+        };
+      },
+    },
+    evaluate: ({ request: incoming, refinement, source: immutableSource }) => {
+      evaluations++;
+      return {
+        source_proposal_id: refinement.proposal_id,
+        outcome: 'finalized',
+        proposal: createProposalSuccessor(immutableSource, {
+          ...immutableSource,
+          proposal_id: `held-${incoming.idempotency_key}`,
+          proposal_status: 'committed',
+          expires_at: '2028-01-01T00:00:00Z',
+        }),
+      };
+    },
+    now: () => new Date('2027-01-01T00:00:00Z'),
+  });
+
+  await handler(request('sequential-hold-key-0001'), {});
+  await assert.rejects(() => handler(request('sequential-hold-key-0002'), {}), /unexpired committed hold/);
+  assert.equal(evaluations, 1);
+  assert.equal([...records.keys()].filter(id => id.startsWith('held-')).length, 1);
+  assert.deepEqual(records.get('source-1').active_hold, {
+    proposal_id: 'held-sequential-hold-key-0001',
+    expires_at: '2028-01-01T00:00:00Z',
+  });
+});
+
+test('seller refuses a successor id that would overwrite its source', async () => {
+  const source = sourceProposal();
+  const handler = createProposalRefinementHandler({
+    capabilities: { supported_dimensions: [] },
+    scope: () => ({ tenant_id: 'seller-tenant', principal_id: 'buyer-a' }),
+    store: {
+      get: () => ({ proposal: source, version: '1' }),
+      begin: () => assert.fail('transaction must not start'),
+    },
+    evaluate: ({ refinement }) => ({
+      source_proposal_id: refinement.proposal_id,
+      outcome: 'finalized',
+      proposal: createProposalSuccessor(source, {
+        ...source,
+        proposal_id: source.proposal_id,
+        proposal_status: 'committed',
+        expires_at: '2028-01-01T00:00:00Z',
+      }),
+    }),
+    now: () => new Date('2027-01-01T00:00:00Z'),
+  });
+
+  await assert.rejects(() => handler(request('overwrite-source-key-0001'), {}), /must differ from every source/);
+});
+
+test('seller returns and stages independent immutable snapshots', async () => {
+  const source = sourceProposal();
+  let evaluatorProposal;
+  let staged;
+  let persisted;
+  const handler = createProposalRefinementHandler({
+    capabilities: { supported_dimensions: [] },
+    scope: () => ({ tenant_id: 'seller-tenant', principal_id: 'buyer-a' }),
+    store: {
+      get: () => ({ proposal: source, version: '1' }),
+      begin: () => ({
+        stage: proposals => {
+          staged = proposals;
+          assert.equal(Object.isFrozen(proposals), true);
+          assert.equal(Object.isFrozen(proposals[0]), true);
+          assert.equal(Object.isFrozen(proposals[0].commercial_terms), true);
+          assert.equal(Reflect.set(proposals[0], 'name', 'store mutation'), false);
+          assert.equal(Reflect.set(proposals[0].commercial_terms, 'start_time', '2099-01-01T00:00:00Z'), false);
+        },
+        commit: () => {
+          persisted = structuredClone(staged[0]);
+        },
+        rollback: () => assert.fail('valid response must commit'),
+      }),
+    },
+    evaluate: ({ request: incoming, refinement, source: immutableSource }) => {
+      assert.equal(Object.isFrozen(incoming), true);
+      assert.equal(Object.isFrozen(incoming.refinements[0]), true);
+      evaluatorProposal = structuredClone(
+        createProposalSuccessor(immutableSource, {
+          ...immutableSource,
+          proposal_id: 'held-independent-snapshot',
+          proposal_status: 'committed',
+          expires_at: '2028-01-01T00:00:00Z',
+        })
+      );
+      return {
+        source_proposal_id: refinement.proposal_id,
+        outcome: 'finalized',
+        proposal: evaluatorProposal,
+      };
+    },
+    now: () => new Date('2027-01-01T00:00:00Z'),
+  });
+
+  const response = await handler(request('immutable-snapshot-key-0001'), {});
+  const returned = response.results[0].proposal;
+  assert.notStrictEqual(returned, evaluatorProposal);
+  assert.notStrictEqual(returned, staged[0]);
+  assert.equal(Object.isFrozen(response), true);
+  assert.equal(Object.isFrozen(returned), true);
+  assert.equal(Object.isFrozen(returned.commercial_terms), true);
+
+  evaluatorProposal.name = 'evaluator mutation';
+  evaluatorProposal.commercial_terms.start_time = '2099-01-01T00:00:00Z';
+  assert.equal(returned.name, 'Source');
+  assert.equal(returned.commercial_terms.start_time, '2027-01-01T00:00:00Z');
+  assert.equal(persisted.name, 'Source');
+  assert.equal(persisted.commercial_terms.start_time, '2027-01-01T00:00:00Z');
+});

--- a/test/lib/proposal-negotiation-validation.test.js
+++ b/test/lib/proposal-negotiation-validation.test.js
@@ -1,0 +1,464 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  ProposalNegotiator,
+  ProposalRefinementValidationError,
+  buildRefineProposalsRequest,
+  canonicalize,
+  extractProposalRefinementSupport,
+  proposalTermsDigest,
+  validateRefineProposalsRequest,
+  validateRefineProposalsResponseShape,
+  verifyRefineProposalsResponse,
+} = require('../../dist/lib/index.js');
+
+const KEY = 'refine-validation-0001';
+
+function commercialTerms(overrides = {}) {
+  return {
+    brand: { domain: 'buyer.example' },
+    purchases: [
+      {
+        product_id: 'product-1',
+        pricing_option_id: 'price-1',
+        pricing: {
+          pricing_option_id: 'price-1',
+          pricing_model: 'cpm',
+          currency: 'USD',
+          fixed_price: 8,
+        },
+        impressions: 1_000_000,
+        start_time: '2027-01-01T00:00:00Z',
+        end_time: '2027-02-01T00:00:00Z',
+      },
+    ],
+    start_time: '2027-01-01T00:00:00Z',
+    end_time: '2027-02-01T00:00:00Z',
+    total_budget: { amount: 8_000, currency: 'USD' },
+    ...overrides,
+  };
+}
+
+function proposal(id = 'successor-1', parent = 'source-1', overrides = {}) {
+  const commercial_terms = overrides.commercial_terms ?? commercialTerms();
+  return {
+    proposal_id: id,
+    proposal_kind: 'new_media_buy',
+    parent_proposal_id: parent,
+    proposal_status: 'draft',
+    name: id,
+    ...overrides,
+    commercial_terms,
+    terms_digest: overrides.terms_digest ?? proposalTermsDigest(commercial_terms),
+  };
+}
+
+function request(refinements = [{ proposal_id: 'source-1', action: 'revise', ask: 'Improve the terms' }]) {
+  return { adcp_version: '3.2', adcp_major_version: 3, idempotency_key: KEY, refinements };
+}
+
+function response(proposals = [proposal()]) {
+  return {
+    results: [{ source_proposal_id: 'source-1', outcome: 'revised', proposals }],
+    products: [],
+  };
+}
+
+function shapeIssues(req, payload) {
+  return verifyRefineProposalsResponse(req, payload).issues.filter(issue => issue.code === 'shape');
+}
+
+test('buyer validation fails closed on malformed union arms, non-finite values, and non-RFC3339 dates', () => {
+  assert.throws(
+    () => buildRefineProposalsRequest({ refinements: [{ proposal_id: 'source-1', action: 'unknown' }] }),
+    /action must be revise or finalize/
+  );
+  assert.throws(
+    () =>
+      buildRefineProposalsRequest({
+        refinements: [{ proposal_id: 'source-1', action: 'finalize', ask: 'silently forbidden' }],
+      }),
+    /ask is not allowed/
+  );
+  assert.throws(
+    () =>
+      buildRefineProposalsRequest({
+        refinements: [
+          {
+            proposal_id: 'source-1',
+            action: 'revise',
+            constraints: { total_budget: { currency: 'USD', max: Number.NaN } },
+          },
+        ],
+      }),
+    /finite|non-negative/
+  );
+  assert.throws(
+    () =>
+      buildRefineProposalsRequest({
+        refinements: [
+          {
+            proposal_id: 'source-1',
+            action: 'revise',
+            constraints: { flight: { start_no_later_than: '2027-02-30T00:00:00Z' } },
+          },
+        ],
+      }),
+    /ISO date-times/
+  );
+  assert.throws(
+    () => buildRefineProposalsRequest({ refinements: request().refinements }, {}),
+    /require supported_dimensions/
+  );
+});
+
+test('builder pins the 3.2 wire envelope and returns an immutable deep snapshot for exact retry', () => {
+  const input = {
+    context: { planning: { attempt: 1 } },
+    refinements: request().refinements,
+  };
+  const built = buildRefineProposalsRequest(input);
+  input.context.planning.attempt = 2;
+  input.refinements[0].ask = 'Changed after construction';
+
+  assert.equal(built.adcp_version, '3.2');
+  assert.equal(built.adcp_major_version, 3);
+  assert.equal(built.context.planning.attempt, 1);
+  assert.equal(built.refinements[0].ask, 'Improve the terms');
+  assert.equal(Object.isFrozen(built), true);
+  assert.equal(Object.isFrozen(built.refinements), true);
+  assert.equal(Object.isFrozen(built.refinements[0]), true);
+  assert.throws(
+    () => buildRefineProposalsRequest({ adcp_version: '3.1.13', refinements: request().refinements }),
+    ProposalRefinementValidationError
+  );
+  assert.throws(
+    () => buildRefineProposalsRequest({ adcp_major_version: 4, refinements: request().refinements }),
+    ProposalRefinementValidationError
+  );
+});
+
+test('canonical request validation requires both 3.2 envelope fields', () => {
+  const canonical = request();
+  assert.doesNotThrow(() => validateRefineProposalsRequest(canonical));
+  assert.throws(() => validateRefineProposalsRequest({ ...canonical, adcp_version: undefined }), /adcp_version 3\.2/);
+  assert.throws(
+    () => validateRefineProposalsRequest({ ...canonical, adcp_major_version: undefined }),
+    /adcp_major_version 3/
+  );
+});
+
+test('proposal capability discovery accepts raw and normalized responses and fails closed on malformed declarations', () => {
+  const raw = {
+    media_buy: {
+      lifecycle_tools: ['get_products', 'refine_proposals'],
+      proposal_refinement: {
+        supported_dimensions: ['total_budget', 'alternatives'],
+        max_alternatives: 4,
+      },
+    },
+  };
+
+  for (const source of [raw, { _raw: raw }, { success: true, status: 'completed', data: raw }]) {
+    const support = extractProposalRefinementSupport(source);
+    assert.equal(support.supported, true);
+    assert.deepEqual(support.capabilities, raw.media_buy.proposal_refinement);
+    assert.equal(Object.isFrozen(support), true);
+    assert.equal(Object.isFrozen(support.capabilities.supported_dimensions), true);
+  }
+
+  assert.deepEqual(extractProposalRefinementSupport({ media_buy: { lifecycle_tools: ['get_products'] } }), {
+    supported: false,
+  });
+  assert.throws(
+    () =>
+      extractProposalRefinementSupport({
+        media_buy: { lifecycle_tools: ['refine_proposals'], proposal_refinement: {} },
+      }),
+    /supported_dimensions/
+  );
+  assert.throws(
+    () =>
+      extractProposalRefinementSupport({
+        media_buy: {
+          lifecycle_tools: ['refine_proposals'],
+          proposal_refinement: { supported_dimensions: ['total_budget'], max_alternatives: 4 },
+        },
+      }),
+    /requires alternatives/
+  );
+});
+
+test('criteria validation uses the closed 3.2 top-level vocabulary', () => {
+  assert.doesNotThrow(() =>
+    buildRefineProposalsRequest({
+      refinements: [
+        {
+          proposal_id: 'source-1',
+          action: 'revise',
+          criteria: {
+            product_ids: ['product-1'],
+            catalog: { catalog_id: 'catalog-1', type: 'product' },
+            targeting_overlay: { geo: ['US'] },
+          },
+        },
+      ],
+    })
+  );
+  for (const criteria of [
+    {},
+    { channels: ['ctv'] },
+    { product_ids: ['product-1', 'product-1'] },
+    { catalog: { type: 'publisher' } },
+    { catalog: { catalog_id: 'catalog-1', type: 'publisher' } },
+    { catalog: { catalog_id: 'catalog-1', gtins: ['not-a-gtin'] } },
+    { targeting_overlay: [] },
+  ]) {
+    assert.throws(() =>
+      buildRefineProposalsRequest({
+        refinements: [{ proposal_id: 'source-1', action: 'revise', criteria }],
+      })
+    );
+  }
+});
+
+test('compact submitted responses validate without completed-field access', () => {
+  const submitted = {
+    adcp_version: '3.2',
+    status: 'submitted',
+    task_id: 'proposal-task-1',
+    message: 'Inventory underwriting is pending.',
+    errors: [{ code: 'UNDERWRITING_DELAY', message: 'Manual review requested.' }],
+    context: { correlation_id: 'corr-1' },
+    ext: { seller: 'example' },
+  };
+  assert.equal(validateRefineProposalsResponseShape(submitted).ok, true);
+
+  const semantic = verifyRefineProposalsResponse(request(), submitted);
+  assert.equal(semantic.ok, false);
+  assert.equal(
+    semantic.issues.some(issue => issue.message.includes('requires a completed response')),
+    true
+  );
+
+  for (const invalid of [
+    { ...submitted, task_id: '' },
+    { ...submitted, errors: ['not-an-error'] },
+    { ...submitted, results: [] },
+    { ...submitted, message: 'x'.repeat(2001) },
+  ]) {
+    assert.equal(validateRefineProposalsResponseShape(invalid).ok, false);
+  }
+});
+
+test('response verifier validates discriminated result shapes before semantic checks', () => {
+  const req = request();
+  const cases = [
+    [{ results: [{ source_proposal_id: 'source-1', outcome: 'mystery' }], products: [] }, 'outcome'],
+    [
+      {
+        results: [
+          {
+            source_proposal_id: 'source-1',
+            outcome: 'revised',
+            proposals: [proposal()],
+            reason: 'forbidden',
+          },
+        ],
+        products: [],
+      },
+      'forbidden',
+    ],
+    [
+      {
+        results: [
+          {
+            source_proposal_id: 'source-1',
+            outcome: 'partial',
+            proposals: [proposal()],
+            reason_code: 'commercially_declined',
+          },
+        ],
+        products: [],
+      },
+      'reason',
+    ],
+    [
+      {
+        results: [
+          {
+            source_proposal_id: 'source-1',
+            outcome: 'unable',
+            reason_code: 'made_up',
+            reason: 'No',
+          },
+        ],
+        products: [],
+      },
+      'reason_code',
+    ],
+    [{ results: response().results, products: null }, 'products'],
+  ];
+  for (const [payload, expectedPath] of cases) {
+    assert.equal(
+      shapeIssues(req, payload).some(
+        issue => issue.path.includes(expectedPath) || issue.message.includes(expectedPath)
+      ),
+      true
+    );
+  }
+});
+
+test('canonical proposal validation requires nonempty purchases, finite values, strict dates, and pricing identity', () => {
+  const mutations = [
+    value => {
+      value.results[0].proposals[0].commercial_terms.purchases = [];
+    },
+    value => {
+      value.results[0].proposals[0].commercial_terms.total_budget.amount = Number.POSITIVE_INFINITY;
+    },
+    value => {
+      value.results[0].proposals[0].commercial_terms.purchases[0].start_time = 'next Tuesday';
+    },
+    value => {
+      value.results[0].proposals[0].commercial_terms.purchases[0].pricing.pricing_option_id = 'other-price';
+    },
+    value => {
+      delete value.results[0].proposals[0].proposal_kind;
+    },
+  ];
+  for (const mutate of mutations) {
+    const payload = structuredClone(response());
+    mutate(payload);
+    assert.equal(shapeIssues(request(), payload).length > 0, true);
+  }
+});
+
+test('successor IDs are globally unique and distinct from every source ID', () => {
+  const sourceReuse = response([proposal('source-1')]);
+  assert.equal(
+    verifyRefineProposalsResponse(request(), sourceReuse).issues.some(issue => issue.code === 'proposal_identity'),
+    true
+  );
+
+  const req = request([
+    { proposal_id: 'source-1', action: 'revise', ask: 'A' },
+    { proposal_id: 'source-2', action: 'revise', ask: 'B' },
+  ]);
+  const payload = {
+    results: [
+      { source_proposal_id: 'source-1', outcome: 'revised', proposals: [proposal('same-id', 'source-1')] },
+      {
+        source_proposal_id: 'source-2',
+        outcome: 'revised',
+        proposals: [
+          proposal('same-id', 'source-2', {
+            commercial_terms: commercialTerms({ total_budget: { amount: 7_000, currency: 'USD' } }),
+          }),
+        ],
+      },
+    ],
+    products: [],
+  };
+  assert.equal(
+    verifyRefineProposalsResponse(req, payload).issues.some(issue => issue.code === 'proposal_identity'),
+    true
+  );
+});
+
+test('alternatives require both unique terms and unique digests', () => {
+  const req = request([{ proposal_id: 'source-1', action: 'revise', alternatives: { count: 2 } }]);
+  const sameTerms = commercialTerms();
+  const duplicate = response([
+    proposal('successor-1', 'source-1', { commercial_terms: sameTerms }),
+    proposal('successor-2', 'source-1', { commercial_terms: structuredClone(sameTerms) }),
+  ]);
+  const issues = verifyRefineProposalsResponse(req, duplicate).issues;
+  assert.equal(
+    issues.some(issue => issue.code === 'duplicate_terms'),
+    true
+  );
+  assert.equal(
+    issues.some(issue => issue.code === 'duplicate_digest'),
+    true
+  );
+});
+
+test('JCS rejects lone Unicode surrogates before hashing but accepts valid pairs', () => {
+  assert.throws(() => canonicalize({ value: '\ud800' }), /lone Unicode surrogate/);
+  assert.throws(() => canonicalize({ ['\udc00']: 'value' }), /lone Unicode surrogate/);
+  assert.equal(canonicalize({ value: '\ud83d\ude80' }), '{"value":"🚀"}');
+  assert.throws(() => proposalTermsDigest({ value: '\ud800' }), /lone Unicode surrogate/);
+});
+
+test('counteroffer selection returns the verified canonical object and invalid hold expiries fail closed', async () => {
+  const negotiator = new ProposalNegotiator(async () => {
+    throw new Error('unused');
+  });
+  const canonical = proposal();
+  const payload = response([canonical]);
+  const selected = negotiator.selectCounteroffer(payload, ([candidate]) => ({
+    ...candidate,
+    name: 'selector-authored mutation',
+  }));
+  assert.strictEqual(selected, canonical);
+  assert.equal(selected.name, 'successor-1');
+
+  const invalidHold = proposal('held', 'source-1', {
+    proposal_status: 'committed',
+    expires_at: 'not-a-date',
+  });
+  let called = false;
+  await assert.rejects(
+    () =>
+      negotiator.accept(invalidHold, async () => {
+        called = true;
+      }),
+    /hold has expired/
+  );
+  assert.equal(called, false);
+});
+
+test('invalid injected clocks fail closed during verification, finalization, and acceptance', async () => {
+  const committed = proposal('held-valid', 'source-1', {
+    proposal_status: 'committed',
+    expires_at: '2100-01-01T00:00:00Z',
+  });
+  const finalizeRequest = request([{ proposal_id: 'source-1', action: 'finalize' }]);
+  const finalizeResponse = {
+    results: [{ source_proposal_id: 'source-1', outcome: 'finalized', proposal: committed }],
+    products: [],
+  };
+
+  const verification = verifyRefineProposalsResponse(finalizeRequest, finalizeResponse, {
+    now: new Date('invalid'),
+  });
+  assert.equal(verification.ok, false);
+  assert.equal(
+    verification.issues.some(issue => issue.code === 'hold_expired' && issue.message.includes('current time')),
+    true
+  );
+
+  const completedTask = {
+    success: true,
+    status: 'completed',
+    data: finalizeResponse,
+    metadata: {
+      taskId: 'task-invalid-clock',
+      taskName: 'refine_proposals',
+      agent: { id: 'seller', name: 'Seller', protocol: 'mcp' },
+      responseTimeMs: 1,
+      timestamp: new Date().toISOString(),
+      clarificationRounds: 0,
+      status: 'completed',
+    },
+  };
+  const negotiator = new ProposalNegotiator(async () => completedTask, {
+    now: () => new Date('invalid'),
+  });
+  let accepted = false;
+  await assert.rejects(() => negotiator.accept(committed, async () => (accepted = true)), /current time is invalid/);
+  assert.equal(accepted, false);
+  await assert.rejects(() => negotiator.finalize('source-1'), /current time is invalid/);
+});

--- a/test/lib/proposal-negotiation-validation.test.js
+++ b/test/lib/proposal-negotiation-validation.test.js
@@ -385,11 +385,26 @@ test('alternatives require both unique terms and unique digests', () => {
   );
 });
 
-test('JCS rejects lone Unicode surrogates before hashing but accepts valid pairs', () => {
-  assert.throws(() => canonicalize({ value: '\ud800' }), /lone Unicode surrogate/);
-  assert.throws(() => canonicalize({ ['\udc00']: 'value' }), /lone Unicode surrogate/);
+test('proposal JCS rejects lone Unicode surrogates without changing shared canonicalization', () => {
+  assert.equal(canonicalize({ value: '\ud800' }), '{"value":"\ud800"}');
   assert.equal(canonicalize({ value: '\ud83d\ude80' }), '{"value":"🚀"}');
   assert.throws(() => proposalTermsDigest({ value: '\ud800' }), /lone Unicode surrogate/);
+  assert.throws(() => proposalTermsDigest({ ['\udc00']: 'value' }), /lone Unicode surrogate/);
+  assert.doesNotThrow(() => proposalTermsDigest({ value: '\ud83d\ude80' }));
+});
+
+test('proposal digest validates the exact canonical bytes produced by accessors', () => {
+  let reads = 0;
+  const terms = {};
+  Object.defineProperty(terms, 'value', {
+    enumerable: true,
+    get() {
+      reads++;
+      return reads === 1 ? 'safe' : '\ud800';
+    },
+  });
+
+  assert.throws(() => proposalTermsDigest(terms), /lone Unicode surrogate/);
 });
 
 test('counteroffer selection returns the verified canonical object and invalid hold expiries fail closed', async () => {

--- a/test/lib/proposal-negotiation.test.js
+++ b/test/lib/proposal-negotiation.test.js
@@ -1,0 +1,507 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  ProposalNegotiator,
+  ProposalRefinementValidationError,
+  ProposalResponseVerificationError,
+  RefineProposalsTaskError,
+  buildRefineProposalsRequest,
+  classifyProposalRefinementFailure,
+  createProposalRefinementHandler,
+  createProposalSuccessor,
+  proposalTermsDigest,
+  unwrapVerifiedRefineProposals,
+  verifyRefineProposalsResponse,
+} = require('../../dist/lib/index.js');
+
+const KEY = 'refine-key-0000000001';
+
+function terms(overrides = {}) {
+  return {
+    brand: { domain: 'coffee.example' },
+    purchases: [
+      {
+        product_id: 'product-1',
+        pricing_option_id: 'price-1',
+        pricing: { pricing_option_id: 'price-1', pricing_model: 'cpm', currency: 'USD', fixed_price: 8 },
+        impressions: 1_000_000,
+        start_time: '2027-01-01T00:00:00.000Z',
+        end_time: '2027-02-01T00:00:00.000Z',
+      },
+    ],
+    start_time: '2027-01-01T00:00:00.000Z',
+    end_time: '2027-02-01T00:00:00.000Z',
+    total_budget: { amount: 8_000, currency: 'USD' },
+    ...overrides,
+  };
+}
+
+function proposal(id, parent, status = 'draft', termOverrides = {}) {
+  const commercial_terms = terms(termOverrides);
+  return {
+    proposal_id: id,
+    proposal_kind: 'new_media_buy',
+    parent_proposal_id: parent,
+    proposal_status: status,
+    ...(status === 'committed' && { expires_at: '2100-01-01T00:00:00.000Z' }),
+    name: id,
+    commercial_terms,
+    terms_digest: proposalTermsDigest(commercial_terms),
+  };
+}
+
+function revise(overrides = {}) {
+  return { proposal_id: 'source-1', action: 'revise', ask: 'A stronger offer', ...overrides };
+}
+
+function request(refinements = [revise()]) {
+  return { adcp_version: '3.2', adcp_major_version: 3, idempotency_key: KEY, refinements };
+}
+
+function completed(data) {
+  return {
+    success: true,
+    status: 'completed',
+    data,
+    metadata: {
+      taskId: 'task-1',
+      taskName: 'refine_proposals',
+      agent: { id: 'seller', name: 'Seller', protocol: 'mcp' },
+      responseTimeMs: 1,
+      timestamp: new Date().toISOString(),
+      clarificationRounds: 0,
+      status: 'completed',
+    },
+  };
+}
+
+test('buyer builder enforces explicit capability omissions for every typed dimension', () => {
+  const cases = [
+    revise({ constraints: { total_budget: { currency: 'USD', max: 10_000 } }, ask: undefined }),
+    revise({ constraints: { cpm: { currency: 'USD', max: 10 } }, ask: undefined }),
+    revise({ constraints: { impressions: { min: 10 } }, ask: undefined }),
+    revise({ constraints: { flight: { start_no_later_than: '2027-01-01T00:00:00Z' } }, ask: undefined }),
+    revise({ product_changes: { 'product-2': 'include' }, ask: undefined }),
+    revise({ alternatives: { count: 2 }, ask: undefined }),
+    revise({ criteria: { product_ids: ['product-1'] }, ask: undefined }),
+  ];
+  for (const refinement of cases) {
+    assert.throws(
+      () => buildRefineProposalsRequest({ refinements: [refinement] }, { supported_dimensions: [] }),
+      ProposalRefinementValidationError
+    );
+  }
+  assert.doesNotThrow(() =>
+    buildRefineProposalsRequest({
+      refinements: cases.map((entry, index) => ({ ...entry, proposal_id: `source-${index}` })),
+    })
+  );
+});
+
+test('buyer builder enforces protocol and seller alternative ceilings', () => {
+  assert.equal(
+    buildRefineProposalsRequest(
+      { refinements: [revise({ alternatives: { count: 10 } })] },
+      { supported_dimensions: ['alternatives'], max_alternatives: 10 }
+    ).refinements[0].alternatives.count,
+    10
+  );
+  assert.throws(() => buildRefineProposalsRequest({ refinements: [revise({ alternatives: { count: 11 } })] }), /2-10/);
+  assert.throws(
+    () =>
+      buildRefineProposalsRequest(
+        { refinements: [revise({ alternatives: { count: 5 } })] },
+        { supported_dimensions: ['alternatives'], max_alternatives: 4 }
+      ),
+    /exceeds seller/
+  );
+});
+
+test('buyer builder accepts 25 refinements, rejects 26, duplicates, and mixed finalize batches', () => {
+  const twentyFive = Array.from({ length: 25 }, (_, i) => revise({ proposal_id: `source-${i}` }));
+  assert.equal(buildRefineProposalsRequest({ refinements: twentyFive }).refinements.length, 25);
+  assert.throws(
+    () => buildRefineProposalsRequest({ refinements: [...twentyFive, revise({ proposal_id: 'source-26' })] }),
+    /1-25/
+  );
+  assert.throws(() => buildRefineProposalsRequest({ refinements: [revise(), revise()] }), /unique/);
+  assert.throws(
+    () =>
+      buildRefineProposalsRequest({
+        refinements: [revise(), { proposal_id: 'source-2', action: 'finalize' }],
+      }),
+    /only finalize/
+  );
+});
+
+test('response verifier accepts all eight reason codes with their required machine-readable shape', () => {
+  const reasons = [
+    'commercially_declined',
+    'constraint_unsatisfiable',
+    'unsupported_dimension',
+    'uninterpreted',
+    'alternatives_unavailable',
+    'source_unavailable',
+    'hold_unavailable',
+    'batch_aborted',
+  ];
+  for (const reason_code of reasons) {
+    const req = request([revise({ constraints: { total_budget: { currency: 'USD', max: 5_000 } }, ask: undefined })]);
+    const response = {
+      results: [
+        {
+          source_proposal_id: 'source-1',
+          outcome: 'unable',
+          reason_code,
+          reason: reason_code,
+          ...(reason_code === 'constraint_unsatisfiable' && { unsatisfied_constraints: ['total_budget'] }),
+        },
+      ],
+      products: [],
+    };
+    assert.equal(verifyRefineProposalsResponse(req, response).ok, true, reason_code);
+  }
+});
+
+test('seller failure classification gives typed constraints precedence over commercial refusal', () => {
+  assert.equal(
+    classifyProposalRefinementFailure({
+      unsatisfied_constraints: ['cpm'],
+      alternatives_unavailable: true,
+      commercially_declined: true,
+    }),
+    'constraint_unsatisfiable'
+  );
+  assert.equal(classifyProposalRefinementFailure({ hold_unavailable: true }), 'hold_unavailable');
+  assert.equal(classifyProposalRefinementFailure({}), 'uninterpreted');
+});
+
+test('response verifier checks ordering, lineage, JCS digest, and distinct alternatives', () => {
+  const req = request([revise({ alternatives: { count: 2 } })]);
+  const duplicate = proposal('draft-2', 'wrong-parent');
+  duplicate.terms_digest = 'sha256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+  const verified = verifyRefineProposalsResponse(req, {
+    results: [
+      {
+        source_proposal_id: 'wrong-source',
+        outcome: 'revised',
+        proposals: [proposal('draft-1', 'source-1'), duplicate],
+      },
+    ],
+    products: [],
+  });
+  assert.equal(verified.ok, false);
+  assert.deepEqual(
+    new Set(verified.issues.map(issue => issue.code)),
+    new Set(['result_order', 'lineage', 'terms_digest', 'duplicate_terms'])
+  );
+});
+
+test('partial proposals satisfy every constraint outside the advertised unsatisfied subset', () => {
+  const req = request([
+    revise({
+      ask: undefined,
+      alternatives: { count: 2 },
+      constraints: {
+        total_budget: { currency: 'USD', max: 5_000 },
+        impressions: { min: 900_000 },
+      },
+    }),
+  ]);
+  const valid = {
+    results: [
+      {
+        source_proposal_id: 'source-1',
+        outcome: 'partial',
+        proposals: [proposal('draft-1', 'source-1')],
+        reason_code: 'constraint_unsatisfiable',
+        reason: 'budget unavailable',
+        unsatisfied_constraints: ['total_budget'],
+      },
+    ],
+    products: [],
+  };
+  assert.equal(verifyRefineProposalsResponse(req, valid).ok, true);
+  valid.results[0].proposals[0] = proposal('draft-2', 'source-1', 'draft', {
+    purchases: [{ ...terms().purchases[0], impressions: 1 }],
+  });
+  assert.equal(
+    verifyRefineProposalsResponse(req, valid).issues.some(issue => issue.code === 'partial_invariant'),
+    true
+  );
+  valid.results[0].proposals = [
+    proposal('draft-1', 'source-1'),
+    proposal('draft-2', 'source-1', 'draft', { total_budget: { amount: 7_000, currency: 'USD' } }),
+    proposal('draft-3', 'source-1'),
+  ];
+  assert.equal(
+    verifyRefineProposalsResponse(req, valid).issues.some(issue => issue.code === 'alternative_count'),
+    true
+  );
+});
+
+test('ProposalNegotiator reuses exact keys on transport retry and mints keys for changed intent', async () => {
+  let calls = 0;
+  const seen = [];
+  const transport = async req => {
+    seen.push(req);
+    if (calls++ === 0) throw new Error('socket reset');
+    return completed({
+      results: [
+        {
+          source_proposal_id: 'source-1',
+          outcome: 'revised',
+          proposals: [proposal('draft-1', 'source-1')],
+        },
+      ],
+      products: [],
+    });
+  };
+  const negotiator = new ProposalNegotiator(transport, { transportRetries: 1 });
+  const executed = await negotiator.execute({ refinements: [revise()] });
+  assert.strictEqual(seen[0], seen[1]);
+  assert.equal(seen[0].idempotency_key, seen[1].idempotency_key);
+  const changed = negotiator.changedRequest(executed.request, [revise({ ask: 'Different intent' })]);
+  assert.notEqual(changed.idempotency_key, executed.request.idempotency_key);
+});
+
+test('task failures/intermediate states surface before response fields and expired holds cannot be accepted', async () => {
+  const failed = {
+    success: false,
+    status: 'failed',
+    error: 'INVALID_STATE: already finalized',
+    metadata: completed({}).metadata,
+  };
+  assert.throws(() => unwrapVerifiedRefineProposals(failed, request()), RefineProposalsTaskError);
+
+  let accepted = false;
+  const negotiator = new ProposalNegotiator(async () => failed, {
+    now: () => new Date('2100-01-02T00:00:00.000Z'),
+  });
+  await assert.rejects(
+    () =>
+      negotiator.accept(proposal('held', 'source-1', 'committed'), async () => {
+        accepted = true;
+      }),
+    /hold has expired/
+  );
+  assert.equal(accepted, false);
+});
+
+test('AgentClient.refineProposals dispatches through the official MCP client with an idempotency key', async () => {
+  const { McpServer } = require('@modelcontextprotocol/sdk/server/mcp.js');
+  const { Client } = require('@modelcontextprotocol/sdk/client/index.js');
+  const { InMemoryTransport } = require('@modelcontextprotocol/sdk/inMemory.js');
+  const { AgentClient } = require('../../dist/lib/index.js');
+  const z = require('zod');
+  let captured;
+  const server = new McpServer({ name: 'Negotiation seller', version: '1.0.0' });
+  server.registerTool('get_adcp_capabilities', { inputSchema: {} }, async () => ({
+    content: [{ type: 'text', text: '{}' }],
+    structuredContent: {
+      success: true,
+      adcp: { major_versions: [3], idempotency: { supported: true, replay_ttl_seconds: 86400 } },
+      supported_protocols: ['media_buy'],
+      specialisms: [],
+    },
+  }));
+  server.registerTool(
+    'refine_proposals',
+    { inputSchema: { idempotency_key: z.string(), refinements: z.array(z.any()) } },
+    async args => {
+      captured = args;
+      return {
+        content: [{ type: 'text', text: '{}' }],
+        structuredContent: {
+          success: true,
+          results: [
+            {
+              source_proposal_id: 'source-1',
+              outcome: 'revised',
+              proposals: [proposal('draft-1', 'source-1')],
+            },
+          ],
+          products: [],
+        },
+      };
+    }
+  );
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  const mcpClient = new Client({ name: 'Buyer', version: '1.0.0' });
+  await mcpClient.connect(clientTransport);
+  const agent = AgentClient.fromMCPClient(mcpClient);
+
+  const result = await agent.refineProposals({ refinements: [revise()] });
+  assert.equal(result.success, true);
+  assert.match(captured.idempotency_key, /^[A-Za-z0-9_.:-]{16,255}$/);
+  assert.equal(captured.refinements[0].proposal_id, 'source-1');
+
+  await mcpClient.close();
+  await server.close();
+});
+
+test('seller handler commits a complete finalize batch atomically', async () => {
+  const sources = new Map([
+    ['source-1', proposal('source-1', undefined)],
+    ['source-2', proposal('source-2', undefined)],
+  ]);
+  const staged = [];
+  let commits = 0;
+  const handler = createProposalRefinementHandler({
+    capabilities: { supported_dimensions: [] },
+    scope: () => ({ tenant_id: 'tenant-1', principal_id: 'buyer-1' }),
+    store: {
+      get: (_scope, id) => (sources.has(id) ? { proposal: sources.get(id), version: `v:${id}` } : null),
+      begin: () => ({
+        stage: proposals => staged.push(...proposals),
+        commit: () => commits++,
+        rollback: () => assert.fail('rollback not expected'),
+      }),
+    },
+    evaluate: ({ refinement, source }) => ({
+      source_proposal_id: refinement.proposal_id,
+      outcome: 'finalized',
+      proposal: createProposalSuccessor(source, {
+        ...proposal(`held-${refinement.proposal_id}`, undefined, 'committed'),
+      }),
+    }),
+  });
+  const response = await handler(
+    request([
+      { proposal_id: 'source-1', action: 'finalize' },
+      { proposal_id: 'source-2', action: 'finalize' },
+    ]),
+    {}
+  );
+  assert.equal(response.results.length, 2);
+  assert.equal(staged.length, 2);
+  assert.equal(commits, 1);
+});
+
+test('seller validates the full response before opening a transaction', async () => {
+  let begins = 0;
+  const source = proposal('source-1', undefined);
+  const handler = createProposalRefinementHandler({
+    capabilities: { supported_dimensions: [] },
+    scope: () => ({ tenant_id: 'tenant-1', principal_id: 'buyer-1' }),
+    store: {
+      get: () => ({ proposal: source, version: 'v:source-1' }),
+      begin: () => {
+        begins++;
+        throw new Error('must not begin');
+      },
+    },
+    evaluate: () => ({
+      source_proposal_id: 'source-1',
+      outcome: 'revised',
+      proposals: [proposal('bad', 'wrong-parent')],
+    }),
+  });
+  await assert.rejects(() => handler(request(), {}), ProposalResponseVerificationError);
+  assert.equal(begins, 0);
+});
+
+test('seller preflight failures retain structured protocol codes and perform no work', async () => {
+  let evaluations = 0;
+  let begins = 0;
+  const source = proposal('source-1', undefined, 'committed');
+  const handler = createProposalRefinementHandler({
+    capabilities: { supported_dimensions: [] },
+    scope: () => ({ tenant_id: 'tenant-1', principal_id: 'buyer-1' }),
+    store: {
+      get: () => ({ proposal: source, version: 'v:source-1' }),
+      begin: () => {
+        begins++;
+        throw new Error('must not begin');
+      },
+    },
+    evaluate: () => {
+      evaluations++;
+      throw new Error('must not evaluate');
+    },
+  });
+  await assert.rejects(
+    () => handler(request([{ proposal_id: 'source-1', action: 'finalize' }]), {}),
+    error =>
+      error.name === 'AdcpError' &&
+      error.code === 'INVALID_STATE' &&
+      error.recovery === 'correctable' &&
+      error.field === 'refinements[0].proposal_id'
+  );
+  assert.equal(evaluations, 0);
+  assert.equal(begins, 0);
+});
+
+test('seller rejects a partially successful finalize batch before persistence', async () => {
+  let begins = 0;
+  const sources = new Map([
+    ['source-1', proposal('source-1', undefined)],
+    ['source-2', proposal('source-2', undefined)],
+  ]);
+  const handler = createProposalRefinementHandler({
+    capabilities: { supported_dimensions: [] },
+    scope: () => ({ tenant_id: 'tenant-1', principal_id: 'buyer-1' }),
+    store: {
+      get: (_scope, id) => (sources.has(id) ? { proposal: sources.get(id), version: `v:${id}` } : null),
+      begin: () => {
+        begins++;
+        throw new Error('must not begin');
+      },
+    },
+    evaluate: ({ refinement, source, index }) =>
+      index === 0
+        ? {
+            source_proposal_id: refinement.proposal_id,
+            outcome: 'finalized',
+            proposal: createProposalSuccessor(source, {
+              ...proposal('held-1', undefined, 'committed'),
+            }),
+          }
+        : {
+            source_proposal_id: refinement.proposal_id,
+            outcome: 'unable',
+            reason_code: 'hold_unavailable',
+            reason: 'inventory changed',
+          },
+  });
+  await assert.rejects(
+    () =>
+      handler(
+        request([
+          { proposal_id: 'source-1', action: 'finalize' },
+          { proposal_id: 'source-2', action: 'finalize' },
+        ]),
+        {}
+      ),
+    ProposalResponseVerificationError
+  );
+  assert.equal(begins, 0);
+});
+
+test('seller rolls back the transaction when atomic commit fails', async () => {
+  let rollbacks = 0;
+  const source = proposal('source-1', undefined);
+  const handler = createProposalRefinementHandler({
+    capabilities: { supported_dimensions: [] },
+    scope: () => ({ tenant_id: 'tenant-1', principal_id: 'buyer-1' }),
+    store: {
+      get: () => ({ proposal: source, version: 'v:source-1' }),
+      begin: () => ({
+        stage: () => {},
+        commit: () => {
+          throw new Error('hold race');
+        },
+        rollback: () => rollbacks++,
+      }),
+    },
+    evaluate: () => ({
+      source_proposal_id: 'source-1',
+      outcome: 'revised',
+      proposals: [proposal('draft-2', 'source-1')],
+    }),
+  });
+  await assert.rejects(() => handler(request(), {}), /hold race/);
+  assert.equal(rollbacks, 1);
+});


### PR DESCRIPTION
## Summary

- add typed AdCP 3.2 `refine_proposals` buyer APIs with capability-aware preflight and verified results
- add first-class seller registration with scoped storage, replay-safe dispatch, and atomic CAS-backed finalization
- add orchestration helpers for retries, counteroffer selection, hold expiry, and acceptance
- document migration from legacy `get_products` refinement and provide runnable buyer/seller examples

## Why

AdCP 3.2 moves structured proposal negotiation into `refine_proposals`. The SDK needs a safe default path that preserves idempotency, tenant isolation, immutable proposal lineage, and all-or-nothing finalization for both buyer and seller agents.

Closes #2542.

## Validation

- [x] `npm run typecheck`
- [x] `npm run typecheck:examples`
- [x] `npm run build:lib`
- [x] proposal negotiation unit/integration tests (61 passing)
- [x] `npm run test:protocols`
- [x] `npm run test:node:fast` (13,177 passing, 7 skipped)

## Review

Protocol, code-quality, security, and adopter-DX expert passes were run before publication. Their convergent findings drove the first-class server pipeline, authenticated scope, CAS finalization, complete runtime validation, successor identity, and Unicode digest hardening in this revision.
