### PR TITLE
fix(net): recognize Kubernetes service DNS names as private in isLikelyPrivateUrl

### DIFF
--- a/.changeset/fix-k8s-cluster-local-private-url.md
+++ b/.changeset/fix-k8s-cluster-local-private-url.md
@@ -1,0 +1,5 @@
+---
+"@adcp/sdk": patch
+---
+
+`isLikelyPrivateUrl` now recognizes Kubernetes service DNS names (`.cluster.local` suffix) as private. Callers connecting to a managed internal agent whose URI ends in `.svc.cluster.local` (with or without the trailing FQDN dot) are granted `allowPrivateIp` automatically, without needing `ADCP_ALLOW_PRIVATE_AGENT_URL=1`.

--- a/src/lib/net/address-guards.ts
+++ b/src/lib/net/address-guards.ts
@@ -114,9 +114,9 @@ export function isPrivateIp(address: string): boolean {
 
 /**
  * Best-effort check that a URL targets a development/private host, without
- * doing a DNS lookup. Matches loopback hostnames (`localhost`) and any IP
- * literal that {@link isPrivateIp} would reject. Public domain names always
- * return `false`.
+ * doing a DNS lookup. Matches loopback hostnames (`localhost`), Kubernetes
+ * service DNS names (`.cluster.local` suffix), and any IP literal that
+ * {@link isPrivateIp} would reject. Public domain names always return `false`.
  *
  * Used by higher layers that need to inherit the operator's "private is OK"
  * trust from a primary probe and propagate it to same-origin chain hops —
@@ -128,8 +128,15 @@ export function isPrivateIp(address: string): boolean {
 export function isLikelyPrivateUrl(url: string): boolean {
   try {
     const u = new URL(url);
-    const host = u.hostname.replace(/^\[|\]$/g, '').toLowerCase();
+    // Strip optional trailing DNS dot from FQDN form (e.g. "foo.svc.cluster.local.")
+    const host = u.hostname
+      .replace(/^\[|\]$/g, '')
+      .replace(/\.$/, '')
+      .toLowerCase();
     if (host === 'localhost') return true;
+    // Kubernetes service DNS names end in .cluster.local and always resolve to
+    // private ClusterIP addresses. Matching by suffix avoids a DNS round-trip.
+    if (host.endsWith('.cluster.local')) return true;
     return isPrivateIp(host);
   } catch {
     return false;

--- a/test/lib/net-public-export.test.js
+++ b/test/lib/net-public-export.test.js
@@ -18,6 +18,9 @@ describe('net SSRF helpers public exports', () => {
     assert.strictEqual(typeof sdk.isLikelyPrivateUrl, 'function');
     assert.ok(sdk.SSRF_TRANSIENT_CODES instanceof Set);
     assert.strictEqual(sdk.isPrivateIp('127.0.0.1'), true);
+    assert.strictEqual(sdk.isLikelyPrivateUrl('http://my-svc.default.svc.cluster.local.:4000/mcp'), true);
+    assert.strictEqual(sdk.isLikelyPrivateUrl('http://my-svc.default.svc.cluster.local/mcp'), true);
+    assert.strictEqual(sdk.isLikelyPrivateUrl('https://example.com/'), false);
 
     assert.strictEqual(typeof net.ssrfSafeFetch, 'function');
     assert.strictEqual(typeof net.decodeBodyAsJsonOrText, 'function');


### PR DESCRIPTION
## Why

`isLikelyPrivateUrl` matched `localhost` and IP literals but not Kubernetes DNS names. A managed internal agent deployed as a K8s service (e.g. `agentic-embedded-salesagent.scope3.svc.cluster.local.`) has a private ClusterIP address, but the hostname doesn't look like an IP to the classifier, so `allowPrivateIp` stayed `false` and the SSRF guard blocked the connection. Operators had to set `ADCP_ALLOW_PRIVATE_AGENT_URL=1` globally as a workaround.

## What Changed

- `isLikelyPrivateUrl` now strips the optional trailing FQDN dot and returns `true` for any hostname ending in `.cluster.local` — the Kubernetes cluster-internal DNS suffix
- Added three assertions to `net-public-export.test.js` covering the FQDN form (trailing dot), plain form, and a public URL that must still return `false`