### PR TITLE
feat(governance): enforce cross-role authorization

### DIFF
--- a/.changeset/smart-cats-govern.md
+++ b/.changeset/smart-cats-govern.md
@@ -1,0 +1,9 @@
+---
+'@adcp/sdk': minor
+---
+
+Add AdCP 3.2 cross-role governance authorization builders, capability-gated buyer middleware, compact-JWS service verification, and the published conformance vectors.
+
+Governance adapter transport or malformed-response failures now throw `GovernanceAdapterError` instead of returning a denial-shaped result, so sellers can distinguish unavailable governance infrastructure from an authoritative policy denial. Authoritative adapter denials now use the AdCP 3.2 `CheckGovernanceResponse` fields (`verdict`, `check_type`, and `findings`) and no longer expose the legacy `status`, `binding`, or `plan_id` response members.
+
+Governed calls now fail closed instead of forwarding receiver credentials from `push_notification_config`, `reporting_webhook`, or `artifact_webhook` to the governance agent. For an SDK-injected task-status webhook, retry with `{ disableWebhook: true }` and poll, or use A2A task-status notifications. Credential-bearing reporting and artifact callbacks must be omitted from governed requests. Legacy condition re-checks preserve and persist the response `governance_context` continuation token.

--- a/docs/migration-13-to-14.md
+++ b/docs/migration-13-to-14.md
@@ -110,6 +110,109 @@ to `required` after legacy callers are gone.
 
 Do not select a signing profile from a version value inside an unverified request body or header. On the server, bind the version to the endpoint, tenant, or authenticated agent configuration. Webhook signatures do not move to the 3.2 request profile.
 
+## Cross-role governance is capability-gated
+
+AdCP 3.2 governance authorizes one exact downstream action. A buyer-side
+`GovernanceMiddleware` now checks only tasks the target advertises under
+`adcp.governance_enforcement.tasks` with `signed_context` mode **and** the
+`governance.campaign` experimental feature marker. Intent checks
+carry `plan_id`, `target_agent`, `tool`, and the exact payload; they never reuse
+`governance_context`. An approved check adds the returned compact JWS to the
+downstream payload. A conditions verdict carries only `consultation_context`
+and must be adjusted and re-checked before it authorizes anything.
+
+Modern buyer configuration needs a stable caller URL. Conditional tasks use
+`resolveApplicability` when deciding whether a stateful change increases a
+commitment, and `resolveIntentDetails` supplies the authoritative ceiling for
+tasks whose amount is not derivable from the request:
+
+```ts
+const client = new AgentClient(seller, {
+  governance: {
+    campaign: {
+      agent: governanceAgent,
+      planId,
+      callerUrl: 'https://buyer.example/mcp',
+      resolveApplicability: async (tool, payload) => {
+        if (tool !== 'update_media_buy') return true;
+        const current = await mediaBuyStore.get(String(payload.media_buy_id));
+        return payload.total_budget != null &&
+          payload.total_budget.amount > current.total_budget;
+      },
+      resolveIntentDetails: async (tool, payload) => {
+        if (tool !== 'update_media_buy') return {};
+        const delta = await computePositiveBudgetDelta(payload);
+        return { proposedCommitment: { amount: delta.amount, currency: delta.currency } };
+      },
+    },
+  },
+});
+```
+
+The SDK handles stateless pause, cancel, deactivate, and creative-estimate
+exemptions itself. If a conditional request needs seller state and no resolver
+is installed, it is governed conservatively. Direct `TaskExecutor` callers
+must pass the target capability result; configured governance fails closed
+when it is absent.
+
+Services verify the token before starting a side effect:
+
+```ts
+import {
+  InMemoryGovernanceReplayStore,
+  createAdcpGovernanceEnforcementMiddleware,
+} from '@adcp/sdk/server';
+import { HttpsJwksResolver } from '@adcp/sdk/signing/server';
+
+const enforceGovernance = createAdcpGovernanceEnforcementMiddleware({
+  expectedIssuer: 'https://governance.example/mcp',
+  expectedAudience: 'https://seller.example/mcp',
+  jwks: new HttpsJwksResolver('https://governance.example/.well-known/jwks.json'),
+  replayStore: new InMemoryGovernanceReplayStore(),
+});
+
+await enforceGovernance(
+  {
+    token: params.governance_context,
+    authenticatedCaller: principal.agentUrl,
+    task: 'create_media_buy',
+    payload: params,
+    actualCommitment: { amount: params.total_budget.amount, currency: params.total_budget.currency },
+  },
+  () => commitMediaBuy(params),
+);
+```
+
+Use a shared atomic `GovernanceReplayStore` in multi-replica production
+services; the in-memory implementation is for a single process. The verifier
+checks critical markers, signature and key purpose, issuer, audience,
+authenticated caller, task, JCS payload hash, currency, amount ceiling, time
+window, revocation, and one-time `jti` consumption. Existing
+`media_buy.governance_aware` online-consultation integrations remain the 3.0/
+3.1 compatibility path; do not infer cross-role enforcement from that legacy
+boolean.
+
+The server-specific middleware returns a structured `PERMISSION_DENIED` AdCP
+response for missing, invalid, expired, or conflicting authorization. The
+framework-neutral `createGovernanceEnforcementMiddleware` throws
+`GovernanceAuthorizationError`; use it only when your framework explicitly
+maps that error to a permission denial. Resolve exact retries from the
+service's idempotency cache before invoking governance verification: a
+consumed authorization is always rejected, and the middleware never invokes
+the side effect twice. Without a fresh combined key-and-JTI revocation
+resolver, intent-token lifetime is capped at 15 minutes.
+
+Seller-side `GovernanceAdapter.checkCommitted()` accepts the legacy
+plan-addressed request shape during 3.x. The modern shape supplies
+`governanceContext`; purchase commitment is derived from
+`plannedDelivery.total_budget` and `currency`, while modification calls must
+supply the seller-computed positive `executionCommitment`. Governance-agent
+transport failure now throws `GovernanceAdapterError` with
+`governance_agent_unreachable` instead of being reported as a policy denial.
+Catch it at the server handler boundary and return
+`governanceUnavailableError()`, which emits the required transient
+`GOVERNANCE_UNAVAILABLE` wire error.
+
 ## Server handler additions
 
 `createAdcpServerFromPlatform()` routes the new compact lifecycle through

--- a/src/lib/adapters/governance-adapter.ts
+++ b/src/lib/adapters/governance-adapter.ts
@@ -17,6 +17,9 @@ import type {
 import { ProtocolClient } from '../protocols';
 import type { AgentConfig } from '../types';
 import { unwrapProtocolResponse } from '../utils/response-unwrapper';
+import type { GovernanceCommitment } from '../governance';
+import { buildGovernanceExecutionCommitment, buildGovernanceExecutionRequest } from '../governance';
+import { normalizeGovernanceVerdict } from '../core/GovernanceTypes';
 
 /**
  * Configuration for the seller-side governance adapter.
@@ -42,13 +45,9 @@ export interface GovernanceAdapterConfig {
 /**
  * Committed governance check request from the seller's perspective.
  */
-export interface CommittedCheckRequest {
-  /** Campaign governance plan ID */
-  planId: string;
-  /** @deprecated No longer sent to governance agent — use governanceContext instead */
+interface CommittedCheckRequestBase {
+  /** @deprecated Put the durable ID on plannedDelivery.media_buy_id. */
   mediaBuyId?: string;
-  /** Opaque governance context from the buyer's protocol envelope. Pass through verbatim. */
-  governanceContext?: string;
   /** What the seller will actually deliver */
   plannedDelivery: PlannedDelivery;
   /** Lifecycle phase of the check */
@@ -58,6 +57,23 @@ export interface CommittedCheckRequest {
   /** Summary of changes for modification-phase checks */
   modificationSummary?: string;
 }
+
+/** Deprecated plan-addressed request retained for existing seller adopters. */
+export interface LegacyCommittedCheckRequest extends CommittedCheckRequestBase {
+  planId: string;
+  governanceContext?: string;
+  executionCommitment?: GovernanceCommitment;
+}
+
+/** AdCP 3.2 context-addressed execution request. */
+export interface ModernCommittedCheckRequest extends CommittedCheckRequestBase {
+  /** Opaque governance context from the buyer's protocol envelope. */
+  governanceContext: string;
+  /** Required authoritative positive delta for modification checks. */
+  executionCommitment?: GovernanceCommitment;
+}
+
+export type CommittedCheckRequest = LegacyCommittedCheckRequest | ModernCommittedCheckRequest;
 
 /**
  * Interface for seller-side governance adapters.
@@ -81,12 +97,24 @@ export const GovernanceAdapterErrorCodes = {
 
 export type GovernanceAdapterErrorCode = (typeof GovernanceAdapterErrorCodes)[keyof typeof GovernanceAdapterErrorCodes];
 
+export class GovernanceAdapterError extends Error {
+  constructor(
+    readonly code: GovernanceAdapterErrorCode,
+    message: string,
+    options?: ErrorOptions
+  ) {
+    super(message, options);
+    this.name = 'GovernanceAdapterError';
+  }
+}
+
 /**
  * Type guard: check if a response is a governance adapter error.
  */
 export function isGovernanceAdapterError(
   response: unknown
-): response is { error: { code: GovernanceAdapterErrorCode; message?: string } } {
+): response is GovernanceAdapterError | { error: { code: GovernanceAdapterErrorCode; message?: string } } {
+  if (response instanceof GovernanceAdapterError) return true;
   if (!response || typeof response !== 'object') return false;
   const r = response as Record<string, any>;
   return r.error?.code && Object.values(GovernanceAdapterErrorCodes).includes(r.error.code);
@@ -113,27 +141,59 @@ export class GovernanceAdapter implements IGovernanceAdapter {
 
   async checkCommitted(request: CommittedCheckRequest): Promise<CheckGovernanceResponse> {
     if (!this.agentConfig) {
-      return {
-        status: 'failed',
-        check_id: '',
-        verdict: 'denied',
-        binding: 'committed',
-        plan_id: request.planId,
-        explanation: 'Governance not configured on this server',
-        error_code: GovernanceAdapterErrorCodes.NOT_SUPPORTED,
-      } as unknown as CheckGovernanceResponse;
+      return adapterDenial('Governance not configured on this server', GovernanceAdapterErrorCodes.NOT_SUPPORTED);
     }
 
-    const checkRequest: CheckGovernanceRequest = {
-      plan_id: request.planId,
-      caller: this.agentConfig.callerUrl,
-      governance_context: request.governanceContext,
-      planned_delivery: request.plannedDelivery,
-      phase: request.phase,
-      delivery_metrics: request.deliveryMetrics,
-      ...(request.mediaBuyId && { payload: { media_buy_id: request.mediaBuyId } }),
-      ...(request.modificationSummary && { payload: { modification_summary: request.modificationSummary } }),
-    };
+    const plannedDelivery =
+      request.mediaBuyId && !request.plannedDelivery.media_buy_id
+        ? { ...request.plannedDelivery, media_buy_id: request.mediaBuyId }
+        : request.plannedDelivery;
+    // `planId` identifies the published pre-3.2 request arm. Legacy callers
+    // commonly supplied both it and governanceContext, so plan addressing
+    // must take precedence; otherwise an SDK upgrade silently drops plan_id.
+    const planId = 'planId' in request ? request.planId : undefined;
+    const legacy = typeof planId === 'string' && planId.length > 0;
+    const modern = !legacy && typeof request.governanceContext === 'string' && request.governanceContext.length > 0;
+    const phase = request.phase ?? 'purchase';
+    let checkRequest: CheckGovernanceRequest;
+    if (modern) {
+      let executionCommitment = request.executionCommitment;
+      if (phase === 'modification' && !executionCommitment) {
+        throw new TypeError('Modern modification governance checks require an authoritative executionCommitment');
+      }
+      if (
+        phase === 'purchase' &&
+        !executionCommitment &&
+        typeof plannedDelivery.total_budget === 'number' &&
+        typeof plannedDelivery.currency === 'string'
+      ) {
+        executionCommitment = buildGovernanceExecutionCommitment(
+          plannedDelivery.total_budget,
+          plannedDelivery.currency
+        );
+      }
+      checkRequest = buildGovernanceExecutionRequest({
+        caller: this.agentConfig.callerUrl,
+        governanceContext: request.governanceContext!,
+        plannedDelivery,
+        phase,
+        executionCommitment,
+        deliveryMetrics: request.deliveryMetrics,
+        modificationSummary: request.modificationSummary,
+      });
+    } else {
+      // Preserve the published pre-3.2 plan-addressed request shape.
+      checkRequest = {
+        plan_id: planId,
+        caller: this.agentConfig.callerUrl,
+        governance_context: request.governanceContext,
+        planned_delivery: plannedDelivery,
+        phase: request.phase,
+        delivery_metrics: request.deliveryMetrics,
+        ...(request.mediaBuyId && { payload: { media_buy_id: request.mediaBuyId } }),
+        ...(request.modificationSummary && { payload: { modification_summary: request.modificationSummary } }),
+      } as CheckGovernanceRequest;
+    }
 
     try {
       const response = await ProtocolClient.callTool(
@@ -143,19 +203,43 @@ export class GovernanceAdapter implements IGovernanceAdapter {
         { adcpVersion: this.agentConfig.adcpVersion }
       );
 
-      return unwrapProtocolResponse(response) as unknown as CheckGovernanceResponse;
+      const unwrapped = unwrapProtocolResponse(response) as unknown as CheckGovernanceResponse;
+      if (!modern) return unwrapped;
+      const verdict = normalizeGovernanceVerdict(unwrapped);
+      if (!verdict || verdict.verdict === 'conditions' || verdict.checkType !== 'execution') {
+        throw new GovernanceAdapterError(
+          GovernanceAdapterErrorCodes.CHECK_FAILED,
+          'Governance execution check returned an invalid non-binary verdict'
+        );
+      }
+      return unwrapped;
     } catch (err) {
-      return {
-        status: 'failed',
-        check_id: '',
-        verdict: 'denied',
-        binding: 'committed',
-        plan_id: request.planId,
-        explanation: `Governance agent unreachable: ${(err as Error).message}`,
-        error_code: GovernanceAdapterErrorCodes.AGENT_UNREACHABLE,
-      } as unknown as CheckGovernanceResponse;
+      if (err instanceof GovernanceAdapterError) throw err;
+      throw new GovernanceAdapterError(
+        GovernanceAdapterErrorCodes.AGENT_UNREACHABLE,
+        `Governance agent unavailable: ${(err as Error).message}`,
+        { cause: err }
+      );
     }
   }
+}
+
+function adapterDenial(message: string, code: GovernanceAdapterErrorCode): CheckGovernanceResponse {
+  return {
+    check_id: '',
+    verdict: 'denied',
+    check_type: 'execution',
+    explanation: message,
+    findings: [
+      {
+        category_id: 'governance_execution',
+        severity: 'critical',
+        explanation: message,
+        details: { adapter_error_code: code },
+      },
+    ],
+    error_code: code,
+  } as unknown as CheckGovernanceResponse;
 }
 
 /**

--- a/src/lib/adapters/index.ts
+++ b/src/lib/adapters/index.ts
@@ -40,6 +40,9 @@ export {
   type GovernanceAdapterConfig,
   type GovernanceAdapterErrorCode,
   type CommittedCheckRequest,
+  type LegacyCommittedCheckRequest,
+  type ModernCommittedCheckRequest,
+  GovernanceAdapterError,
   GovernanceAdapterErrorCodes,
   isGovernanceAdapterError,
 } from './governance-adapter';

--- a/src/lib/core/GovernanceMiddleware.ts
+++ b/src/lib/core/GovernanceMiddleware.ts
@@ -34,6 +34,14 @@ import { toolRequiresGovernance, parseCheckResponse } from './GovernanceTypes';
 import { unwrapProtocolResponse } from '../utils/response-unwrapper';
 import { generateIdempotencyKey } from '../utils/idempotency';
 import { createAbortError } from '../protocols/abort';
+import type { AdcpCapabilities } from '../utils/capabilities';
+import { canonicalize } from '../utils/jcs';
+import {
+  buildGovernanceIntentRequest,
+  governancePurchaseTypeForTask,
+  targetDeclaresGovernanceEnforcement,
+  targetDeclaresLegacyGovernanceAwareness,
+} from '../governance';
 
 /**
  * Typed debug log entries for governance operations.
@@ -48,6 +56,8 @@ const SAFE_PATH_SEGMENT = /^[a-zA-Z_$][a-zA-Z0-9_$]*$|^\d+$/;
 
 /** Path segments that would cause prototype pollution even though they match the safe pattern. */
 const FORBIDDEN_PATH_SEGMENTS = new Set(['__proto__', 'constructor', 'prototype']);
+const MAX_CONDITION_PATH_DEPTH = 32;
+const MAX_CONDITION_ARRAY_INDEX = 10_000;
 
 /**
  * Set a value at a dot-path in an object. Creates intermediate objects as needed.
@@ -61,6 +71,9 @@ export function setAtPath(obj: Record<string, any>, path: string, value: unknown
     throw new Error('Empty path is not allowed');
   }
   const parts = path.split('.');
+  if (parts.length > MAX_CONDITION_PATH_DEPTH) {
+    throw new Error(`Condition path exceeds maximum depth of ${MAX_CONDITION_PATH_DEPTH}`);
+  }
   for (const part of parts) {
     // Explicit inline block for prototype-pollution vectors. The
     // FORBIDDEN_PATH_SEGMENTS set covers the same cases but CodeQL's
@@ -74,6 +87,9 @@ export function setAtPath(obj: Record<string, any>, path: string, value: unknown
     }
     if (!SAFE_PATH_SEGMENT.test(part)) {
       throw new Error(`Invalid path segment: ${part}`);
+    }
+    if (/^\d+$/.test(part) && Number(part) > MAX_CONDITION_ARRAY_INDEX) {
+      throw new Error(`Condition array index exceeds maximum of ${MAX_CONDITION_ARRAY_INDEX}`);
     }
   }
   let current = obj;
@@ -161,8 +177,38 @@ export class GovernanceMiddleware {
   /**
    * Check whether this tool requires a governance check.
    */
-  requiresCheck(tool: string): boolean {
-    return toolRequiresGovernance(tool, this.governanceConfig);
+  requiresCheck(tool: string, targetCapabilities?: AdcpCapabilities): boolean {
+    if (!toolRequiresGovernance(tool, this.governanceConfig)) return false;
+    // Preserve the published scope-only predicate for direct callers. The
+    // execution path uses shouldCheck(), which requires discovered target
+    // capabilities and fails closed when they are absent.
+    if (!targetCapabilities) return true;
+    return (
+      targetDeclaresGovernanceEnforcement(targetCapabilities, tool) ||
+      targetDeclaresLegacyGovernanceAwareness(targetCapabilities, tool)
+    );
+  }
+
+  /** Resolve request-level triggers and exemptions after the capability gate. */
+  async shouldCheck(
+    tool: string,
+    params: Readonly<Record<string, unknown>>,
+    targetCapabilities?: AdcpCapabilities
+  ): Promise<boolean> {
+    if (!toolRequiresGovernance(tool, this.governanceConfig)) return false;
+    if (!targetCapabilities) {
+      throw new Error(
+        `Target capabilities are required before applying configured governance to ${tool}; refusing to bypass governance`
+      );
+    }
+    if (!this.requiresCheck(tool, targetCapabilities)) return false;
+    // The legacy 3.0/3.1 declaration had no conditional-commitment contract.
+    if (!targetDeclaresGovernanceEnforcement(targetCapabilities, tool)) return true;
+
+    const stateless = statelessGovernanceApplicability(tool, params);
+    if (stateless !== undefined) return stateless;
+    const resolver = this.governanceConfig.campaign?.resolveApplicability;
+    return resolver ? resolver(tool, params) : true;
   }
 
   /**
@@ -185,6 +231,22 @@ export class GovernanceMiddleware {
   async checkProposed(
     tool: string,
     params: Record<string, unknown>,
+    debugLogs?: GovernanceDebugEntry[],
+    signal?: AbortSignal
+  ): Promise<{ result: GovernanceCheckResult; params: Record<string, unknown> }>;
+  async checkProposed(
+    targetAgent: AgentConfig,
+    targetCapabilities: AdcpCapabilities,
+    tool: string,
+    params: Record<string, unknown>,
+    debugLogs?: GovernanceDebugEntry[],
+    signal?: AbortSignal
+  ): Promise<{ result: GovernanceCheckResult; params: Record<string, unknown> }>;
+  async checkProposed(
+    targetAgentOrTool: AgentConfig | string,
+    targetCapabilitiesOrParams: AdcpCapabilities | Record<string, unknown>,
+    toolOrDebugLogs: string | GovernanceDebugEntry[] = [],
+    paramsOrSignal?: Record<string, unknown> | AbortSignal,
     debugLogs: GovernanceDebugEntry[] = [],
     signal?: AbortSignal
   ): Promise<{ result: GovernanceCheckResult; params: Record<string, unknown> }> {
@@ -193,20 +255,65 @@ export class GovernanceMiddleware {
       throw new Error('Campaign governance not configured');
     }
 
+    const legacyDirectCall = typeof targetAgentOrTool === 'string';
+    const targetAgent = typeof targetAgentOrTool === 'string' ? config.agent : targetAgentOrTool;
+    const targetCapabilities = legacyDirectCall ? undefined : (targetCapabilitiesOrParams as AdcpCapabilities);
+    const tool = typeof targetAgentOrTool === 'string' ? targetAgentOrTool : (toolOrDebugLogs as string);
+    const params = legacyDirectCall
+      ? (targetCapabilitiesOrParams as Record<string, unknown>)
+      : (paramsOrSignal as Record<string, unknown>);
+    if (legacyDirectCall) {
+      debugLogs = Array.isArray(toolOrDebugLogs) ? toolOrDebugLogs : [];
+      signal = paramsOrSignal instanceof AbortSignal ? paramsOrSignal : undefined;
+    }
+
     const maxReChecks = config.maxConditionsIterations ?? 0;
     let currentParams = structuredClone(params);
     let iteration = 0;
+    let consultationContext: string | undefined;
+    let legacyGovernanceContext = config.governanceContext;
+    let proposedCommitmentOverride: import('../governance').GovernanceCommitment | undefined;
+    let proposalOverride: CheckGovernanceRequest['proposal'] | undefined;
+    let purchaseTypeOverride: CheckGovernanceRequest['purchase_type'] | undefined;
+    let runtimeAttestationsOverride: CheckGovernanceRequest['runtime_attestations'] | undefined;
+    let invoiceRecipientOverride: CheckGovernanceRequest['invoice_recipient'] | undefined;
+    let conditionsApplied = false;
 
     // Always make the initial governance check. maxConditionsIterations only
     // controls how many times we re-apply conditions and re-check.
     do {
-      const request: CheckGovernanceRequest = {
-        plan_id: config.planId,
-        caller: config.callerUrl ?? '',
-        tool,
-        payload: currentParams,
-        governance_context: config.governanceContext,
-      };
+      const modernEnforcement = !legacyDirectCall && targetDeclaresGovernanceEnforcement(targetCapabilities, tool);
+      const legacyAwareness = legacyDirectCall || targetDeclaresLegacyGovernanceAwareness(targetCapabilities, tool);
+      if (!modernEnforcement && !legacyAwareness) {
+        throw new Error(`Target service does not declare governance enforcement for ${tool}`);
+      }
+      if (modernEnforcement && !config.callerUrl) {
+        throw new Error(
+          'CampaignGovernanceConfig.callerUrl is required when the target declares AdCP 3.2 governance enforcement'
+        );
+      }
+      const details = modernEnforcement ? ((await config.resolveIntentDetails?.(tool, currentParams)) ?? {}) : {};
+      const request: CheckGovernanceRequest = modernEnforcement
+        ? buildGovernanceIntentRequest({
+            planId: config.planId,
+            caller: config.callerUrl ?? '',
+            targetAgent,
+            tool,
+            payload: currentParams,
+            purchaseType: purchaseTypeOverride ?? details.purchaseType ?? governancePurchaseTypeForTask(tool),
+            proposedCommitment: proposedCommitmentOverride ?? details.proposedCommitment,
+            consultationContext,
+            proposal: proposalOverride ?? details.proposal,
+            runtimeAttestations: runtimeAttestationsOverride ?? details.runtimeAttestations,
+            invoiceRecipient: invoiceRecipientOverride ?? details.invoiceRecipient,
+          })
+        : ({
+            plan_id: config.planId,
+            caller: config.callerUrl ?? '',
+            tool,
+            payload: structuredClone(currentParams),
+            ...(legacyGovernanceContext !== undefined ? { governance_context: legacyGovernanceContext } : {}),
+          } as CheckGovernanceRequest);
 
       debugLogs.push({
         type: 'governance_check',
@@ -230,18 +337,31 @@ export class GovernanceMiddleware {
         tool,
         binding: 'proposed',
         iteration,
-        response: responseData,
+        response: redactGovernanceContexts(responseData),
       });
 
       const checkResult = parseCheckResponse(responseData as unknown as CheckGovernanceResponse);
 
-      // Thread governance_context from response to subsequent checks
-      if (checkResult.governanceContext) {
-        config.governanceContext = checkResult.governanceContext;
+      if (modernEnforcement && checkResult.checkType !== 'intent') {
+        throw new Error('Modern governance intent returned a legacy or execution verdict');
       }
 
       if (checkResult.status === 'approved') {
-        return { result: checkResult, params: currentParams };
+        if (conditionsApplied) {
+          checkResult.conditionsApplied = true;
+          checkResult.modifiedParams = structuredClone(currentParams);
+        }
+        if (modernEnforcement && !checkResult.governanceContext) {
+          throw new Error('Approved governance intent did not return a signed governance_context');
+        }
+        if (!modernEnforcement) {
+          if (checkResult.governanceContext) config.governanceContext = checkResult.governanceContext;
+          return { result: checkResult, params: currentParams };
+        }
+        return {
+          result: checkResult,
+          params: { ...currentParams, governance_context: checkResult.governanceContext },
+        };
       }
 
       if (checkResult.status === 'denied') {
@@ -266,13 +386,61 @@ export class GovernanceMiddleware {
         return { result: checkResult, params: currentParams };
       }
 
-      // Apply conditions and re-check
-      for (const condition of checkResult.conditions) {
-        setAtPath(currentParams, condition.field, condition.requiredValue);
+      if (modernEnforcement) {
+        // Conditions are rooted at the complete check_governance arguments,
+        // not just the downstream payload. They are a non-authorizing
+        // counterproposal and must be re-checked with consultation_context.
+        const adjustedRequest = structuredClone(request) as unknown as Record<string, any>;
+        const originalImmutableFields = snapshotImmutablePayloadFields(adjustedRequest.payload);
+        for (const condition of checkResult.conditions) {
+          const root = condition.field.split('.')[0];
+          if (!SUPPORTED_INTENT_CONDITION_ROOTS.has(root!)) {
+            throw new Error(`Governance condition cannot modify unsupported intent field: ${root}`);
+          }
+          setAtPath(adjustedRequest, condition.field, condition.requiredValue);
+        }
+
+        // A condition may replace the entire payload rather than naming the
+        // immutable routing, identity, and protocol-owned fields directly.
+        // Compare effective values after every condition so nested paths and
+        // whole-payload replacement cannot redirect the authorized request.
+        const adjustedImmutableFields = snapshotImmutablePayloadFields(adjustedRequest.payload);
+        for (const field of GOVERNANCE_IMMUTABLE_PAYLOAD_FIELDS) {
+          if (!jsonValuesEqual(originalImmutableFields[field], adjustedImmutableFields[field])) {
+            throw new Error(`Governance conditions cannot modify protected payload field ${field}`);
+          }
+        }
+
+        currentParams = structuredClone((adjustedRequest.payload ?? {}) as Record<string, unknown>);
+        proposedCommitmentOverride = adjustedRequest.proposed_commitment as
+          | import('../governance').GovernanceCommitment
+          | undefined;
+        proposalOverride = adjustedRequest.proposal as CheckGovernanceRequest['proposal'] | undefined;
+        purchaseTypeOverride = adjustedRequest.purchase_type as CheckGovernanceRequest['purchase_type'] | undefined;
+        runtimeAttestationsOverride = adjustedRequest.runtime_attestations as
+          | CheckGovernanceRequest['runtime_attestations']
+          | undefined;
+        invoiceRecipientOverride = adjustedRequest.invoice_recipient as
+          | CheckGovernanceRequest['invoice_recipient']
+          | undefined;
+        consultationContext = checkResult.consultationContext;
+        if (!consultationContext) {
+          throw new Error('Governance conditions response omitted consultation_context');
+        }
+      } else {
+        // Legacy conditions were rooted directly at the downstream payload.
+        for (const condition of checkResult.conditions) {
+          setAtPath(currentParams, condition.field, condition.requiredValue);
+        }
+        if (checkResult.governanceContext) {
+          legacyGovernanceContext = checkResult.governanceContext;
+          config.governanceContext = checkResult.governanceContext;
+        }
       }
 
       checkResult.conditionsApplied = true;
       checkResult.modifiedParams = currentParams;
+      conditionsApplied = true;
 
       debugLogs.push({
         type: 'governance_conditions_applied',
@@ -290,6 +458,7 @@ export class GovernanceMiddleware {
       result: {
         checkId: '',
         status: 'denied',
+        checkType: 'intent',
         explanation: `Governance conditions could not be resolved after ${maxReChecks} iterations`,
       },
       params: currentParams,
@@ -417,4 +586,99 @@ export class GovernanceMiddleware {
       timestamp: new Date().toISOString(),
     });
   }
+}
+
+const CONDITIONAL_OPERATIONAL_KEYS = new Set([
+  'account',
+  'adcp_major_version',
+  'adcp_version',
+  'context',
+  'governance_context',
+  'idempotency_key',
+  'media_buy_id',
+  'push_notification_config',
+  'revision',
+  'rights_id',
+]);
+
+const SUPPORTED_INTENT_CONDITION_ROOTS = new Set([
+  'payload',
+  'proposed_commitment',
+  'proposal',
+  'purchase_type',
+  'runtime_attestations',
+  'invoice_recipient',
+]);
+
+const GOVERNANCE_IMMUTABLE_PAYLOAD_FIELDS = [
+  'account',
+  'media_buy_id',
+  'rights_id',
+  'revision',
+  'idempotency_key',
+  'context',
+  'adcp_major_version',
+  'adcp_version',
+  'push_notification_config',
+] as const;
+
+function snapshotImmutablePayloadFields(
+  payload: unknown
+): Record<(typeof GOVERNANCE_IMMUTABLE_PAYLOAD_FIELDS)[number], unknown> {
+  const record = payload && typeof payload === 'object' ? (payload as Record<string, unknown>) : {};
+  const snapshot = {} as Record<(typeof GOVERNANCE_IMMUTABLE_PAYLOAD_FIELDS)[number], unknown>;
+  for (const field of GOVERNANCE_IMMUTABLE_PAYLOAD_FIELDS) {
+    snapshot[field] = record[field] === undefined ? undefined : structuredClone(record[field]);
+  }
+  return snapshot;
+}
+
+function jsonValuesEqual(left: unknown, right: unknown): boolean {
+  if (left === undefined || right === undefined) return left === right;
+  return canonicalize(left) === canonicalize(right);
+}
+
+/**
+ * Return a request-local applicability answer when the schema exemption is
+ * decidable without reading seller state. `undefined` delegates ambiguous
+ * delta/price/term comparisons to the adopter callback (or conservatively
+ * governs when no callback is installed).
+ */
+function statelessGovernanceApplicability(
+  tool: string,
+  params: Readonly<Record<string, unknown>>
+): boolean | undefined {
+  if (tool === 'activate_signal') return params.action !== 'deactivate';
+  if (tool === 'build_creative' && params.mode === 'estimate') return false;
+
+  if (tool === 'update_rights') {
+    if (params.paused === false) return true;
+    if (params.paused === true && hasOnlyOperationalAnd(params, ['paused'])) return false;
+    return undefined;
+  }
+
+  if (tool === 'update_media_buy' || tool === 'control_media_buy') {
+    if (params.paused === false) return true;
+    if (params.canceled === true && hasOnlyOperationalAnd(params, ['canceled', 'cancellation_reason'])) return false;
+    if (params.paused === true && hasOnlyOperationalAnd(params, ['paused'])) return false;
+    return undefined;
+  }
+
+  return undefined;
+}
+
+function hasOnlyOperationalAnd(params: Readonly<Record<string, unknown>>, allowed: string[]): boolean {
+  const allowedKeys = new Set(allowed);
+  return Object.keys(params).every(key => CONDITIONAL_OPERATIONAL_KEYS.has(key) || allowedKeys.has(key));
+}
+
+function redactGovernanceContexts(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(redactGovernanceContexts);
+  if (!value || typeof value !== 'object') return value;
+  return Object.fromEntries(
+    Object.entries(value).map(([key, child]) => [
+      key,
+      key === 'governance_context' || key === 'consultation_context' ? '[redacted]' : redactGovernanceContexts(child),
+    ])
+  );
 }

--- a/src/lib/core/GovernanceTypes.ts
+++ b/src/lib/core/GovernanceTypes.ts
@@ -7,7 +7,21 @@
  */
 
 import type { AgentConfig } from '../types';
-import type { CheckGovernanceResponse, EscalationSeverity } from '../types/tools.generated';
+import type { CheckGovernanceRequest, CheckGovernanceResponse, EscalationSeverity } from '../types/tools.generated';
+import type { GovernanceCommitment } from '../governance';
+
+export interface GovernanceIntentDetails {
+  /** Required for tasks whose commitment is not directly derivable from payload. */
+  proposedCommitment?: GovernanceCommitment;
+  /** Required for accept_proposal so governance can verify commercial terms. */
+  proposal?: CheckGovernanceRequest['proposal'];
+  /** Overrides the task-derived purchase type when a future task needs one. */
+  purchaseType?: CheckGovernanceRequest['purchase_type'];
+  /** Runtime evidence used by signal-activation intent checks. */
+  runtimeAttestations?: CheckGovernanceRequest['runtime_attestations'];
+  /** Billing override that governance must evaluate with the commitment. */
+  invoiceRecipient?: CheckGovernanceRequest['invoice_recipient'];
+}
 
 /**
  * Campaign governance agent configuration.
@@ -23,8 +37,24 @@ export interface CampaignGovernanceConfig {
   callerUrl?: string;
   /** Max re-check iterations after auto-applying conditions. Default: 0 (return conditions to caller without re-checking). The initial governance check always fires. */
   maxConditionsIterations?: number;
-  /** Opaque governance context string from a prior check_governance response. The middleware passes this through on subsequent checks and outcome reports. */
+  /** @deprecated Intent checks never reuse authorization; retained only as an outcome-report fallback. */
   governanceContext?: string;
+  /**
+   * Resolve intent-only fields that cannot be inferred safely from downstream
+   * task arguments (for example an update's positive commitment delta).
+   */
+  resolveIntentDetails?: (
+    tool: string,
+    payload: Readonly<Record<string, unknown>>
+  ) => GovernanceIntentDetails | Promise<GovernanceIntentDetails>;
+  /**
+   * Resolve conditional `x-governed-commitment` requests that require
+   * authoritative current state (for example, whether a budget change is
+   * decrease-only). Return `true` for a trigger and `false` for an exemption.
+   * Obvious stateless exemptions such as pause, cancel, deactivate, and
+   * creative estimates are handled by the SDK before this callback runs.
+   */
+  resolveApplicability?: (tool: string, payload: Readonly<Record<string, unknown>>) => boolean | Promise<boolean>;
 }
 
 /**
@@ -112,6 +142,8 @@ export interface GovernanceEscalation {
 export interface GovernanceCheckResult {
   checkId: string;
   status: 'approved' | 'denied' | 'conditions';
+  /** Modern 3.2 response shape, or `legacy` for the deprecated 3.x arm. */
+  checkType?: 'intent' | 'execution' | 'legacy';
   explanation: string;
   findings?: GovernanceFinding[];
   conditions?: GovernanceCondition[];
@@ -119,10 +151,147 @@ export interface GovernanceCheckResult {
   expiresAt?: string;
   /** Opaque governance context issued by the governance agent. Callers must thread this to subsequent checks and outcome reports. */
   governanceContext?: string;
+  /** Non-authorizing handle used only to re-check an adjusted intent. */
+  consultationContext?: string;
   /** Whether conditions were auto-applied by the middleware */
   conditionsApplied?: boolean;
   /** The modified params after conditions were applied */
   modifiedParams?: Record<string, unknown>;
+}
+
+interface NormalizedGovernanceVerdictBase {
+  checkId: string;
+  explanation: string;
+  raw: CheckGovernanceResponse;
+}
+
+export interface NormalizedGovernanceApproved extends NormalizedGovernanceVerdictBase {
+  verdict: 'approved';
+  checkType: 'intent' | 'execution' | 'legacy';
+  governanceContext?: string;
+  expiresAt?: string;
+}
+
+export interface NormalizedGovernanceDenied extends NormalizedGovernanceVerdictBase {
+  verdict: 'denied';
+  checkType: 'intent' | 'execution' | 'legacy';
+}
+
+/**
+ * Compatibility surface for callers that consumed the pre-3.2 normalized
+ * conditions type. Runtime normalization returns one of the stricter arms
+ * below, but this broad interface remains source-compatible.
+ */
+export interface NormalizedGovernanceConditions extends NormalizedGovernanceVerdictBase {
+  verdict: 'conditions';
+  checkType: 'intent' | 'execution' | 'legacy';
+  governanceContext?: string;
+  consultationContext?: string;
+}
+
+export interface NormalizedGovernanceLegacyConditions extends NormalizedGovernanceConditions {
+  checkType: 'legacy';
+  /** Deprecated legacy 3.x continuation token. Modern conditions use consultationContext instead. */
+  governanceContext?: string;
+  consultationContext?: never;
+}
+
+export interface NormalizedGovernanceIntentConditions extends NormalizedGovernanceConditions {
+  checkType: 'intent';
+  /** Non-authorizing handle that must be threaded only to the adjusted intent re-check. */
+  consultationContext: string;
+  governanceContext?: never;
+}
+
+export type NormalizedGovernanceStrictConditions =
+  | NormalizedGovernanceLegacyConditions
+  | NormalizedGovernanceIntentConditions;
+
+export type NormalizedGovernanceVerdict =
+  | NormalizedGovernanceApproved
+  | NormalizedGovernanceDenied
+  | NormalizedGovernanceConditions;
+
+type NormalizedGovernanceStrictVerdict =
+  | NormalizedGovernanceApproved
+  | NormalizedGovernanceDenied
+  | NormalizedGovernanceStrictConditions;
+
+/**
+ * Normalize modern `verdict` responses and the deprecated legacy `status`
+ * response arm into one discriminated shape. Invalid modern combinations
+ * fail closed instead of leaking an authorization token from conditions or
+ * denied responses.
+ */
+function normalizeGovernanceVerdictStrict(response: unknown): NormalizedGovernanceStrictVerdict | null {
+  if (!response || typeof response !== 'object' || Array.isArray(response)) return null;
+  const raw = response as Record<string, unknown>;
+  if ('check_type' in raw && raw.check_type !== 'intent' && raw.check_type !== 'execution') return null;
+  const checkType = raw.check_type === 'intent' || raw.check_type === 'execution' ? raw.check_type : 'legacy';
+  const verdict =
+    checkType !== 'legacy'
+      ? isGovernanceDecision(raw.verdict)
+        ? raw.verdict
+        : null
+      : isGovernanceDecision(raw.verdict)
+        ? raw.verdict
+        : isGovernanceDecision(raw.status)
+          ? raw.status
+          : null;
+  if (!verdict || typeof raw.check_id !== 'string' || typeof raw.explanation !== 'string') return null;
+
+  const isModern = checkType !== 'legacy';
+  const governanceContext = typeof raw.governance_context === 'string' ? raw.governance_context : undefined;
+  const consultationContext = typeof raw.consultation_context === 'string' ? raw.consultation_context : undefined;
+  const expiresAt = typeof raw.expires_at === 'string' ? raw.expires_at : undefined;
+
+  if (isModern) {
+    if (verdict === 'approved' && (!governanceContext || !expiresAt)) return null;
+    if (verdict === 'conditions') {
+      if (checkType !== 'intent' || !consultationContext || 'governance_context' in raw || 'expires_at' in raw)
+        return null;
+      if (!Array.isArray(raw.conditions) || raw.conditions.length === 0) return null;
+    }
+    if (verdict !== 'conditions' && (raw.conditions !== undefined || 'consultation_context' in raw)) return null;
+    if (verdict !== 'approved' && ('governance_context' in raw || 'expires_at' in raw)) return null;
+    if (verdict === 'denied' && (!Array.isArray(raw.findings) || raw.findings.length === 0)) return null;
+    if (checkType === 'execution' && verdict === 'conditions') return null;
+  }
+
+  const base: NormalizedGovernanceVerdictBase = {
+    checkId: raw.check_id,
+    explanation: raw.explanation,
+    raw: response as CheckGovernanceResponse,
+  };
+  if (verdict === 'approved') {
+    return { ...base, verdict, checkType, governanceContext, expiresAt };
+  }
+  if (verdict === 'conditions') {
+    if (checkType === 'legacy') return { ...base, verdict, checkType, governanceContext };
+    return { ...base, verdict, checkType: 'intent', consultationContext: consultationContext! };
+  }
+  return { ...base, verdict, checkType };
+}
+
+/** Normalize a wire response while retaining the pre-3.2 public union for source compatibility. */
+export function normalizeGovernanceVerdict(response: unknown): NormalizedGovernanceVerdict | null {
+  return normalizeGovernanceVerdictStrict(response);
+}
+
+export function isGovernanceApproved(response: unknown): response is CheckGovernanceResponse {
+  return normalizeGovernanceVerdictStrict(response)?.verdict === 'approved';
+}
+
+export function isGovernanceDenied(response: unknown): response is CheckGovernanceResponse {
+  return normalizeGovernanceVerdictStrict(response)?.verdict === 'denied';
+}
+
+export function isGovernanceConditions(response: unknown): response is CheckGovernanceResponse {
+  return normalizeGovernanceVerdictStrict(response)?.verdict === 'conditions';
+}
+
+function isGovernanceDecision(value: unknown): value is 'approved' | 'denied' | 'conditions' {
+  return value === 'approved' || value === 'denied' || value === 'conditions';
 }
 
 /**
@@ -143,10 +312,15 @@ export interface GovernanceOutcome {
  * Parse a CheckGovernanceResponse into GovernanceCheckResult.
  */
 export function parseCheckResponse(response: CheckGovernanceResponse): GovernanceCheckResult {
+  const normalized = normalizeGovernanceVerdictStrict(response);
+  if (!normalized) {
+    throw new TypeError('Invalid check_governance verdict response');
+  }
   return {
-    checkId: response.check_id,
-    status: response.verdict,
-    explanation: response.explanation,
+    checkId: normalized.checkId,
+    status: normalized.verdict,
+    checkType: normalized.checkType,
+    explanation: normalized.explanation,
     findings: response.findings?.map(f => ({
       categoryId: f.category_id,
       policyId: f.policy_id ?? undefined,
@@ -162,6 +336,10 @@ export function parseCheckResponse(response: CheckGovernanceResponse): Governanc
       reason: c.reason,
     })),
     expiresAt: response.expires_at ?? undefined,
-    governanceContext: response.governance_context ?? undefined,
+    governanceContext:
+      normalized.verdict === 'approved' || (normalized.verdict === 'conditions' && normalized.checkType === 'legacy')
+        ? normalized.governanceContext
+        : undefined,
+    consultationContext: normalized.verdict === 'conditions' ? normalized.consultationContext : undefined,
   };
 }

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -3048,7 +3048,8 @@ export class SingleAgentClient {
           adaptedParams,
           canonicalInputHandler,
           effectiveOptions,
-          serverVersion
+          serverVersion,
+          capabilityDiscoveryContext.capabilities
         )
     );
     throwIfAborted(effectiveOptions?.signal);
@@ -5498,7 +5499,8 @@ export class SingleAgentClient {
         adaptedParams,
         inputHandler,
         effectiveOptions,
-        serverVersion
+        serverVersion,
+        capabilityDiscoveryContext.capabilities
       );
 
       const postAdapterLogs = [...inputSchemaStripLogs, ...v25DriftLogs];

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -3,10 +3,10 @@
 
 import { randomUUID } from 'crypto';
 import type { AgentConfig } from '../types';
-import { ProtocolClient, normalizeTransportOptions } from '../protocols';
+import { ProtocolClient, normalizeTransportOptions, prepareProtocolToolCall } from '../protocols';
 import { listMCPTasks } from '../protocols/mcp-tasks';
 import { getAuthToken } from '../auth';
-import { is401Error, adcpErrorToTypedError } from '../errors';
+import { is401Error, adcpErrorToTypedError, ConfigurationError } from '../errors';
 import type { ADCPError } from '../errors';
 import type { Storage } from '../storage/interfaces';
 import {
@@ -23,6 +23,7 @@ import { generateIdempotencyKey, requestUsesIdempotency, redactIdempotencyKeyInA
 import { normalizeGetProductsResponse } from '../utils/pricing-adapter';
 import { normalizeLegacyMediaBuyStatusForReturn } from '../utils/envelope-status-compat';
 import { getLatestA2ADataPartFromResponse } from '../utils/a2a-artifacts';
+import type { AdcpCapabilities } from '../utils/capabilities';
 import { cancelA2ATask } from '../protocols/a2a';
 import { isAbortOrTimeoutError, throwIfAborted } from '../protocols/abort';
 import type {
@@ -45,6 +46,7 @@ import { ProtocolResponseParser, ADCP_STATUS, type ADCPStatus } from './Protocol
 import type { Activity } from './AsyncHandler';
 import { GovernanceMiddleware } from './GovernanceMiddleware';
 import type { GovernanceConfig, GovernanceCheckResult } from './GovernanceTypes';
+import { targetDeclaresGovernanceEnforcement } from '../governance';
 import { attachMatch } from './match';
 import { resolveWebhookUrl } from './webhook-url';
 import {
@@ -80,6 +82,102 @@ export class InputRequiredError extends Error {
     super(`Server requires input but no handler provided. Question: ${question}`);
     this.name = 'InputRequiredError';
   }
+}
+
+const GOVERNED_CREDENTIAL_SCAN_MAX_NODES = 10_000;
+const GOVERNED_CREDENTIAL_SCAN_MAX_DEPTH = 64;
+const GOVERNED_CALLBACK_FIELDS = new Set(['push_notification_config', 'reporting_webhook', 'artifact_webhook']);
+
+type GovernedCredentialScanResult =
+  | { kind: 'credential'; path: string; callbackField: string }
+  | { kind: 'limit'; limit: 'nodes' | 'depth' };
+
+/**
+ * Find callback authentication credentials before an exact downstream payload
+ * crosses the governance-agent boundary. AdCP 3.2 requires intent payloads to
+ * match the seller arguments byte-for-byte at the JSON-data-model level, so
+ * the SDK cannot safely redact a credential and reinsert it after approval:
+ * doing so would invalidate the seller's authorized_payload_hash check.
+ */
+function findGovernedAuthenticationCredential(value: unknown): GovernedCredentialScanResult | undefined {
+  const stack: Array<{ value: unknown; depth: number }> = [{ value, depth: 0 }];
+  const visited = new WeakSet<object>();
+  let visitedNodes = 0;
+
+  while (stack.length > 0) {
+    const current = stack.pop()!;
+    if (!current.value || typeof current.value !== 'object') continue;
+    if (current.depth > GOVERNED_CREDENTIAL_SCAN_MAX_DEPTH) return { kind: 'limit', limit: 'depth' };
+    if (visited.has(current.value)) continue;
+    visited.add(current.value);
+    if (++visitedNodes > GOVERNED_CREDENTIAL_SCAN_MAX_NODES) return { kind: 'limit', limit: 'nodes' };
+
+    if (!Array.isArray(current.value)) {
+      const record = current.value as Record<string, unknown>;
+      for (const callbackField of GOVERNED_CALLBACK_FIELDS) {
+        const callback = record[callbackField];
+        if (!callback || typeof callback !== 'object' || Array.isArray(callback)) continue;
+        const authentication = (callback as Record<string, unknown>).authentication;
+        if (
+          authentication &&
+          typeof authentication === 'object' &&
+          !Array.isArray(authentication) &&
+          (authentication as Record<string, unknown>).credentials !== undefined
+        ) {
+          return {
+            kind: 'credential',
+            path: `${callbackField}.authentication.credentials`,
+            callbackField,
+          };
+        }
+      }
+    }
+
+    for (const key in current.value) {
+      if (!Object.prototype.hasOwnProperty.call(current.value, key)) continue;
+      const child = (current.value as Record<string, unknown>)[key];
+      if (!child || typeof child !== 'object') continue;
+      if (visitedNodes + stack.length >= GOVERNED_CREDENTIAL_SCAN_MAX_NODES) {
+        return { kind: 'limit', limit: 'nodes' };
+      }
+      stack.push({ value: child, depth: current.depth + 1 });
+    }
+  }
+  return undefined;
+}
+
+function assertGovernedPayloadHasNoCallbackCredentials(
+  taskName: string,
+  payload: Record<string, unknown>,
+  options: { sdkInjectedPushConfig?: boolean } = {}
+): void {
+  const scanResult = findGovernedAuthenticationCredential(payload);
+  if (!scanResult) return;
+  if (scanResult.kind === 'limit') {
+    const limitDescription =
+      scanResult.limit === 'nodes'
+        ? `${GOVERNED_CREDENTIAL_SCAN_MAX_NODES.toLocaleString('en-US')} nested objects`
+        : `${GOVERNED_CREDENTIAL_SCAN_MAX_DEPTH} object levels`;
+    throw new ConfigurationError(
+      `The SDK could not safely inspect the governed ${taskName} payload for callback credentials because it ` +
+        `exceeds the ${limitDescription} safety limit. Simplify the payload or move deeply nested extension data ` +
+        `out of the governed request before retrying.`,
+      'governance.payload'
+    );
+  }
+  const remedy =
+    scanResult.callbackField === 'push_notification_config'
+      ? options.sdkInjectedPushConfig
+        ? 'Retry with task options `{ disableWebhook: true }` and poll for completion, or use A2A task-status notifications.'
+        : 'Remove the credential-bearing push notification config and poll for completion, or use A2A task-status notifications.'
+      : `Remove the credential-bearing ${scanResult.callbackField} from this governed request and use a ` +
+        `non-webhook delivery path.`;
+  throw new ConfigurationError(
+    `Governed ${taskName} cannot forward ${scanResult.path} to the governance agent. ` +
+      `The SDK will not disclose receiver authentication credentials, and redacting modern AdCP 3.2 payloads ` +
+      `would invalidate seller authorization. ${remedy}`,
+    scanResult.path
+  );
 }
 
 /**
@@ -517,10 +615,19 @@ export class TaskExecutor {
     params: any,
     inputHandler?: InputHandler,
     options: TaskOptions = {},
-    serverVersion?: 'v2' | 'v3'
+    serverVersion?: 'v2' | 'v3',
+    targetCapabilities?: AdcpCapabilities
   ): Promise<TaskResult<T>> {
     return withTaskDeadline(options, effectiveOptions =>
-      this.executeTaskWithinDeadline<T>(agent, taskName, params, inputHandler, effectiveOptions, serverVersion)
+      this.executeTaskWithinDeadline<T>(
+        agent,
+        taskName,
+        params,
+        inputHandler,
+        effectiveOptions,
+        serverVersion,
+        targetCapabilities
+      )
     );
   }
 
@@ -530,7 +637,8 @@ export class TaskExecutor {
     params: any,
     inputHandler?: InputHandler,
     options: TaskOptions = {},
-    serverVersion?: 'v2' | 'v3'
+    serverVersion?: 'v2' | 'v3',
+    targetCapabilities?: AdcpCapabilities
   ): Promise<TaskResult<T>> {
     if (serverVersion) this.lastKnownServerVersion = serverVersion;
     // The client-minted `taskId` is a local correlation id for tracking this
@@ -632,41 +740,69 @@ export class TaskExecutor {
       throwIfAborted(options.signal);
 
       // Run governance check if configured for this tool
-      if (this.governanceMiddleware?.requiresCheck(taskName)) {
-        const { result: govResult, params: adjustedParams } = await this.governanceMiddleware.checkProposed(
-          taskName,
-          params,
-          debugLogs,
-          options.signal
-        );
-        throwIfAborted(options.signal);
+      const governanceMiddleware = this.governanceMiddleware;
+      if (governanceMiddleware) {
+        const modernGovernance =
+          targetCapabilities !== undefined && targetDeclaresGovernanceEnforcement(targetCapabilities, taskName);
+        // Modern authorization binds the exact argument object the seller
+        // receives, including protocol-owned fields and MCP webhook
+        // registration. Legacy governance retains its historical application
+        // payload and must not receive SDK-injected callback credentials.
+        const governableParams = modernGovernance
+          ? prepareProtocolToolCall(agent, params, {
+              webhookUrl,
+              webhookSecret: this.config.webhookSecret,
+              serverVersion,
+              adcpVersion: this.config.adcpVersion,
+              wireAdcpVersion: this.config.wireAdcpVersion,
+              versionEnvelope: this.config.versionEnvelope,
+            }).args
+          : params;
+        if (await governanceMiddleware.shouldCheck(taskName, governableParams, targetCapabilities)) {
+          const sdkInjectedPushConfig =
+            modernGovernance &&
+            agent.protocol === 'mcp' &&
+            webhookUrl !== undefined &&
+            this.config.webhookSecret !== undefined;
+          assertGovernedPayloadHasNoCallbackCredentials(taskName, governableParams, { sdkInjectedPushConfig });
+          const { result: govResult, params: adjustedParams } = await governanceMiddleware.checkProposed(
+            agent,
+            targetCapabilities!,
+            taskName,
+            governableParams,
+            debugLogs,
+            options.signal
+          );
+          throwIfAborted(options.signal);
+          assertGovernedPayloadHasNoCallbackCredentials(taskName, adjustedParams, { sdkInjectedPushConfig });
 
-        // Governance always blocks on denial/unapplied conditions.
-        const isBlocking = true;
+          // Governance always blocks on denial/unapplied conditions.
+          const isBlocking = true;
 
-        if (govResult.status === 'denied' && isBlocking) {
-          const denied = this.buildGovernanceResult<T>(govResult, taskId, taskName, agent, startTime, debugLogs);
-          this.updateTaskStatus(taskId, 'governance-denied', undefined, denied.error);
-          return attachMatch(denied);
+          if (govResult.status === 'denied' && isBlocking) {
+            const denied = this.buildGovernanceResult<T>(govResult, taskId, taskName, agent, startTime, debugLogs);
+            this.updateTaskStatus(taskId, 'governance-denied', undefined, denied.error);
+            return attachMatch(denied);
+          }
+
+          if (govResult.status === 'conditions' && !govResult.conditionsApplied && isBlocking) {
+            const denied = this.buildGovernanceResult<T>(govResult, taskId, taskName, agent, startTime, debugLogs);
+            this.updateTaskStatus(taskId, 'governance-denied', undefined, denied.error);
+            return attachMatch(denied);
+          }
+
+          // Approved, or non-blocking mode (advisory/audit) allows execution to proceed
+          governanceCheckId = govResult.checkId;
+          governanceResult = govResult;
+          if (governanceCheckId) {
+            // Preserve the approved check identity as soon as the seller may be
+            // dispatched. If the deadline fires during response processing,
+            // callers can still reconcile the seller mutation against the
+            // original governance decision after restart.
+            attachTaskDeadlineGovernanceRecovery(options, { checkId: governanceCheckId });
+          }
+          effectiveParams = adjustedParams;
         }
-
-        if (govResult.status === 'conditions' && !govResult.conditionsApplied && isBlocking) {
-          const denied = this.buildGovernanceResult<T>(govResult, taskId, taskName, agent, startTime, debugLogs);
-          this.updateTaskStatus(taskId, 'governance-denied', undefined, denied.error);
-          return attachMatch(denied);
-        }
-
-        // Approved, or non-blocking mode (advisory/audit) allows execution to proceed
-        governanceCheckId = govResult.checkId;
-        governanceResult = govResult;
-        if (governanceCheckId) {
-          // Preserve the approved check identity as soon as the seller may be
-          // dispatched. If the deadline fires during response processing,
-          // callers can still reconcile the seller mutation against the
-          // original governance decision after restart.
-          attachTaskDeadlineGovernanceRecovery(options, { checkId: governanceCheckId });
-        }
-        effectiveParams = adjustedParams;
       }
 
       // Create initial message (uses effectiveParams which may have governance-applied conditions)

--- a/src/lib/governance/authorization.ts
+++ b/src/lib/governance/authorization.ts
@@ -1,0 +1,796 @@
+/**
+ * Cross-role governance authorization helpers (AdCP 3.2).
+ *
+ * Intent checks produce a compact JWS that authorizes one exact downstream
+ * request. Services verify that token before performing a governed side
+ * effect. This module deliberately keeps policy interpretation at the
+ * governance agent: service-side code checks only cryptographic and request
+ * bindings.
+ */
+
+import { createHash } from 'node:crypto';
+
+import { compactVerify, importJWK, type JWK } from 'jose';
+
+import type { AgentConfig } from '../types';
+import type { CheckGovernanceRequest, GovernancePhase, PlannedDelivery } from '../types/tools.generated';
+import type { AdcpCapabilities } from '../utils/capabilities';
+import { canonicalize } from '../utils/jcs';
+import type { JwksResolver } from '../signing/jwks';
+import type { ReplayStore } from '../signing/replay';
+import type { RevocationStore } from '../signing/revocation';
+import { parseStrictJson } from '../signing/agent-resolver/strict-json';
+
+export const GOVERNANCE_AUTHORIZATION_CRITICAL_CLAIMS = Object.freeze([
+  'authorized_commitment',
+  'authorized_task',
+  'authorized_payload_hash',
+] as const);
+
+export type GovernanceAuthorizationCriticalClaim = (typeof GOVERNANCE_AUTHORIZATION_CRITICAL_CLAIMS)[number];
+
+export type GovernanceEnforcementMode = 'signed_context' | 'online_execution_check';
+
+export interface GovernanceCommitment {
+  amount: number;
+  currency: string;
+}
+
+export interface GovernanceEnforcementTask {
+  task: string;
+  modes: GovernanceEnforcementMode[];
+}
+
+export interface GovernanceAuthorizationClaims extends Record<string, unknown> {
+  iss: string;
+  sub: string;
+  plan_hash: string;
+  aud: string;
+  iat: number;
+  nbf?: number;
+  exp: number;
+  jti: string;
+  phase: string;
+  caller: string;
+  check_id: string;
+  authorized_commitment?: GovernanceCommitment;
+  authorized_task?: string;
+  authorized_payload_hash?: string;
+}
+
+export type GovernanceAuthorizationErrorCode =
+  | 'governance_token_invalid'
+  | 'governance_key_unknown'
+  | 'governance_token_expired'
+  | 'governance_token_not_yet_valid'
+  | 'governance_token_not_applicable'
+  | 'governance_token_replayed'
+  | 'governance_token_revoked';
+
+export interface GovernanceAuthorizationSuccess {
+  ok: true;
+  claims: GovernanceAuthorizationClaims;
+  protectedHeader: Record<string, unknown>;
+  payloadHash: string;
+}
+
+export interface GovernanceAuthorizationFailure {
+  ok: false;
+  error: GovernanceAuthorizationErrorCode;
+  message: string;
+}
+
+export type GovernanceAuthorizationResult = GovernanceAuthorizationSuccess | GovernanceAuthorizationFailure;
+
+export interface GovernanceReplayStore {
+  /**
+   * Atomically consume one `(issuer, audience, jti)` tuple. Only one caller
+   * may receive `ok`; concurrent or later consumers receive `replayed`.
+   */
+  consume(
+    issuer: string,
+    audience: string,
+    jti: string,
+    expiresAt: number,
+    now: number,
+    binding?: GovernanceReplayBinding
+  ): Promise<'ok' | 'conflict' | 'replayed' | 'rate_abuse'>;
+}
+
+export interface GovernanceReplayBinding {
+  caller: string;
+  task: string;
+  payloadHash: string;
+  idempotencyKey?: string;
+}
+
+export interface InMemoryGovernanceReplayStoreOptions {
+  /** Maximum unexpired tuples per issuer/audience pair. Default: 100,000. */
+  maxEntries?: number;
+}
+
+/**
+ * Adapter for the SDK's signing replay stores. This lets governed services
+ * reuse the same atomic Redis/Postgres replay infrastructure as HTTP signing.
+ */
+export class GovernanceReplayStoreAdapter implements GovernanceReplayStore {
+  constructor(protected readonly replayStore: ReplayStore) {}
+
+  consume(
+    issuer: string,
+    audience: string,
+    jti: string,
+    expiresAt: number,
+    now: number,
+    _binding?: GovernanceReplayBinding
+  ): Promise<'ok' | 'replayed' | 'rate_abuse'> {
+    return this.replayStore.insert(issuer, audience, jti, Math.max(0, expiresAt - now), now);
+  }
+}
+
+/**
+ * Process-local replay store for development and single-process services.
+ * Multi-replica production services must supply an atomic shared store.
+ */
+export class InMemoryGovernanceReplayStore implements GovernanceReplayStore {
+  private readonly scopes = new Map<string, Map<string, { expiresAt: number; binding?: GovernanceReplayBinding }>>();
+  private readonly maxEntries: number;
+
+  constructor(options: InMemoryGovernanceReplayStoreOptions = {}) {
+    const maxEntries = options.maxEntries ?? 100_000;
+    if (!Number.isSafeInteger(maxEntries) || maxEntries <= 0) {
+      throw new TypeError('InMemoryGovernanceReplayStore.maxEntries must be a positive safe integer');
+    }
+    this.maxEntries = maxEntries;
+  }
+
+  /** Deterministic conformance-test preload. */
+  preload(issuer: string, audience: string, jti: string, expiresAt: number): void {
+    const scope = this.getScope(issuer, audience);
+    scope.set(jti, { expiresAt });
+  }
+
+  async consume(
+    issuer: string,
+    audience: string,
+    jti: string,
+    expiresAt: number,
+    now: number,
+    binding?: GovernanceReplayBinding
+  ): Promise<'ok' | 'conflict' | 'replayed' | 'rate_abuse'> {
+    const scope = this.getScope(issuer, audience);
+    const prior = scope.get(jti);
+    if (prior && prior.expiresAt > now) {
+      if (
+        binding?.idempotencyKey &&
+        prior.binding?.idempotencyKey === binding.idempotencyKey &&
+        prior.binding.caller === binding.caller &&
+        prior.binding.task === binding.task &&
+        prior.binding.payloadHash === binding.payloadHash
+      ) {
+        return 'replayed';
+      }
+      return prior.binding ? 'conflict' : 'replayed';
+    }
+    if (prior) scope.delete(jti);
+
+    if (scope.size >= this.maxEntries) {
+      for (const [entryJti, entry] of scope) {
+        if (entry.expiresAt <= now) scope.delete(entryJti);
+      }
+      if (scope.size >= this.maxEntries) return 'rate_abuse';
+    }
+    scope.set(jti, { expiresAt, ...(binding ? { binding: { ...binding } } : {}) });
+    return 'ok';
+  }
+
+  private getScope(issuer: string, audience: string) {
+    const key = `${issuer}\u001f${audience}`;
+    let scope = this.scopes.get(key);
+    if (!scope) {
+      scope = new Map();
+      this.scopes.set(key, scope);
+    }
+    return scope;
+  }
+}
+
+export interface GovernanceRevocationStatus {
+  issuer: string;
+  keyRevoked: boolean;
+  jtiRevoked: boolean;
+  /** Epoch seconds through which this combined status is authoritative. */
+  nextUpdate: number;
+}
+
+export interface GovernanceRevocationResolver {
+  resolve(issuer: string, kid: string, jti: string): GovernanceRevocationStatus | Promise<GovernanceRevocationStatus>;
+}
+
+export interface VerifyGovernanceAuthorizationOptions {
+  token: unknown;
+  expectedIssuer: string;
+  expectedAudience: string;
+  authenticatedCaller: string;
+  expectedTask: string;
+  payload: Record<string, unknown>;
+  actualCommitment: GovernanceCommitment;
+  /** Defaults to `intent`, the phase accepted by a downstream service. */
+  expectedPhase?: 'intent';
+  jwks: JwksResolver;
+  replayStore: GovernanceReplayStore;
+  /** Optional governance-key revocation source. */
+  revocationStore?: RevocationStore;
+  /** Optional token-level revocation check for the signed jti. */
+  isJtiRevoked?: (issuer: string, jti: string) => boolean | Promise<boolean>;
+  /**
+   * Combined, freshness-bearing key and token revocation source. Required to
+   * accept intent authorizations whose lifetime exceeds 15 minutes.
+   */
+  revocationResolver?: GovernanceRevocationResolver;
+  /** Epoch seconds; defaults to the current time. */
+  now?: () => number;
+  /** Defaults to 60 seconds. */
+  clockSkewSeconds?: number;
+}
+
+export interface BuildGovernanceIntentRequestInput {
+  planId: string;
+  caller: string;
+  targetAgent: string | Pick<AgentConfig, 'agent_uri'>;
+  tool: string;
+  payload: Record<string, unknown>;
+  purchaseType?: CheckGovernanceRequest['purchase_type'];
+  proposedCommitment?: GovernanceCommitment;
+  consultationContext?: string;
+  proposal?: CheckGovernanceRequest['proposal'];
+  runtimeAttestations?: CheckGovernanceRequest['runtime_attestations'];
+  invoiceRecipient?: CheckGovernanceRequest['invoice_recipient'];
+}
+
+export interface BuildGovernanceExecutionRequestInput {
+  caller: string;
+  governanceContext: string;
+  plannedDelivery: PlannedDelivery;
+  phase?: GovernancePhase;
+  executionCommitment?: GovernanceCommitment;
+  deliveryMetrics?: CheckGovernanceRequest['delivery_metrics'];
+  modificationSummary?: string;
+}
+
+export function buildGovernanceCommitment(amount: number, currency: string): GovernanceCommitment {
+  if (!Number.isFinite(amount) || amount < 0) {
+    throw new TypeError('Governance commitment amount must be finite and non-negative');
+  }
+  if (!/^[A-Z]{3}$/.test(currency)) {
+    throw new TypeError('Governance commitment currency must be an ISO 4217 three-letter uppercase code');
+  }
+  return { amount, currency };
+}
+
+/** Build the orchestrator ceiling supplied on an intent check. */
+export const buildGovernanceProposedCommitment = buildGovernanceCommitment;
+
+/** Build the service-computed positive delta supplied on an execution check. */
+export const buildGovernanceExecutionCommitment = buildGovernanceCommitment;
+
+/** Tasks whose intent request needs an explicit task-neutral commitment. */
+const EXPLICIT_PROPOSED_COMMITMENT_TASKS = new Set([
+  'update_media_buy',
+  'buy_products',
+  'accept_proposal',
+  'control_media_buy',
+  'acquire_rights',
+  'update_rights',
+  'activate_signal',
+  'build_creative',
+]);
+
+export function governanceTaskRequiresProposedCommitment(task: string): boolean {
+  return EXPLICIT_PROPOSED_COMMITMENT_TASKS.has(task);
+}
+
+export function governancePurchaseTypeForTask(task: string): CheckGovernanceRequest['purchase_type'] | undefined {
+  if (
+    task === 'create_media_buy' ||
+    task === 'update_media_buy' ||
+    task === 'buy_products' ||
+    task === 'accept_proposal' ||
+    task === 'control_media_buy'
+  ) {
+    return 'media_buy';
+  }
+  if (task === 'activate_signal') return 'signal_activation';
+  if (task === 'acquire_rights' || task === 'update_rights') return 'rights_license';
+  if (task === 'build_creative') return 'creative_services';
+  return undefined;
+}
+
+/** Build an intent-shaped check. Authorization context is intentionally absent. */
+export function buildGovernanceIntentRequest(input: BuildGovernanceIntentRequestInput): CheckGovernanceRequest {
+  const targetAgent = typeof input.targetAgent === 'string' ? input.targetAgent : input.targetAgent.agent_uri;
+  if (!input.planId || !input.caller || !targetAgent || !input.tool) {
+    throw new TypeError('Governance intent requires planId, caller, targetAgent, and tool');
+  }
+  if (governanceTaskRequiresProposedCommitment(input.tool) && !input.proposedCommitment) {
+    throw new TypeError(`${input.tool} governance intent requires proposedCommitment`);
+  }
+  if (input.tool === 'accept_proposal' && !input.proposal) {
+    throw new TypeError('accept_proposal governance intent requires proposal');
+  }
+
+  const request: CheckGovernanceRequest = {
+    plan_id: input.planId,
+    caller: input.caller,
+    target_agent: targetAgent,
+    tool: input.tool,
+    payload: structuredClone(input.payload),
+  };
+  if (input.purchaseType !== undefined) request.purchase_type = input.purchaseType;
+  if (input.proposedCommitment !== undefined) {
+    request.proposed_commitment = buildGovernanceCommitment(
+      input.proposedCommitment.amount,
+      input.proposedCommitment.currency
+    );
+  }
+  if (input.consultationContext !== undefined) request.consultation_context = input.consultationContext;
+  if (input.proposal !== undefined) request.proposal = structuredClone(input.proposal);
+  if (input.runtimeAttestations !== undefined)
+    request.runtime_attestations = structuredClone(input.runtimeAttestations);
+  if (input.invoiceRecipient !== undefined) request.invoice_recipient = structuredClone(input.invoiceRecipient);
+  return request;
+}
+
+/** Build an execution-shaped check. Plan and buyer payload stay private. */
+export function buildGovernanceExecutionRequest(input: BuildGovernanceExecutionRequestInput): CheckGovernanceRequest {
+  if (!input.caller || !input.governanceContext) {
+    throw new TypeError('Governance execution requires caller and governanceContext');
+  }
+  const phase = input.phase ?? 'purchase';
+  if (
+    (phase === 'modification' || phase === 'delivery') &&
+    !(input.plannedDelivery as { media_buy_id?: string }).media_buy_id
+  ) {
+    throw new TypeError(`Governance ${phase} execution requires plannedDelivery.media_buy_id`);
+  }
+  if (phase === 'modification' && !input.executionCommitment) {
+    throw new TypeError('Governance modification execution requires executionCommitment');
+  }
+  if (phase === 'delivery' && !input.deliveryMetrics) {
+    throw new TypeError('Governance delivery execution requires deliveryMetrics');
+  }
+
+  const request: CheckGovernanceRequest = {
+    caller: input.caller,
+    governance_context: input.governanceContext,
+    planned_delivery: structuredClone(input.plannedDelivery),
+    phase,
+  };
+  if (input.executionCommitment !== undefined) {
+    request.execution_commitment = buildGovernanceCommitment(
+      input.executionCommitment.amount,
+      input.executionCommitment.currency
+    );
+  }
+  if (input.deliveryMetrics !== undefined) request.delivery_metrics = structuredClone(input.deliveryMetrics);
+  if (input.modificationSummary !== undefined) request.modification_summary = input.modificationSummary;
+  return request;
+}
+
+/**
+ * SHA-256 over RFC 8785 JCS of the downstream request after removing exactly
+ * the two top-level transport/governance fields excluded by the protocol.
+ */
+export function computeGovernedPayloadHash(payload: Record<string, unknown>): string {
+  const businessPayload = Object.fromEntries(
+    Object.entries(payload).filter(([key]) => key !== 'governance_context' && key !== 'context')
+  );
+  return createHash('sha256').update(canonicalize(businessPayload)).digest('base64url');
+}
+
+function capabilitiesRoot(capabilities: unknown): Record<string, unknown> | undefined {
+  if (!isRecord(capabilities)) return undefined;
+  const normalizedRaw = (capabilities as Partial<AdcpCapabilities>)._raw;
+  return isRecord(normalizedRaw) ? normalizedRaw : capabilities;
+}
+
+/** Parse and validate the task-scoped governance-enforcement declaration. */
+export function getGovernanceEnforcementTasks(capabilities: unknown): GovernanceEnforcementTask[] {
+  const root = capabilitiesRoot(capabilities);
+  const adcp = isRecord(root?.adcp) ? root.adcp : undefined;
+  const enforcement = isRecord(adcp?.governance_enforcement) ? adcp.governance_enforcement : undefined;
+  const rawTasks = enforcement?.tasks;
+  if (!Array.isArray(rawTasks)) return [];
+
+  const seen = new Set<string>();
+  const tasks: GovernanceEnforcementTask[] = [];
+  for (const raw of rawTasks) {
+    if (!isRecord(raw) || typeof raw.task !== 'string' || !Array.isArray(raw.modes)) continue;
+    if (seen.has(raw.task)) {
+      throw new TypeError(`Duplicate governance_enforcement task declaration: ${raw.task}`);
+    }
+    seen.add(raw.task);
+    const modes = raw.modes.filter(
+      (mode): mode is GovernanceEnforcementMode => mode === 'signed_context' || mode === 'online_execution_check'
+    );
+    if (!modes.includes('signed_context')) continue;
+    tasks.push({ task: raw.task, modes: [...new Set(modes)] });
+  }
+  return tasks;
+}
+
+export function targetDeclaresGovernanceEnforcement(
+  capabilities: unknown,
+  task: string,
+  mode: GovernanceEnforcementMode = 'signed_context'
+): boolean {
+  const root = capabilitiesRoot(capabilities);
+  const normalizedFeatures = isRecord(capabilities)
+    ? (capabilities as { experimentalFeatures?: unknown }).experimentalFeatures
+    : undefined;
+  const rawFeatures = root?.experimental_features;
+  const features = Array.isArray(rawFeatures) ? rawFeatures : normalizedFeatures;
+  if (!Array.isArray(features) || !features.includes('governance.campaign')) return false;
+  return getGovernanceEnforcementTasks(capabilities).some(
+    declaration => declaration.task === task && declaration.modes.includes(mode)
+  );
+}
+
+/** Deprecated 3.0/3.1 online-consultation declaration for create_media_buy. */
+export function targetDeclaresLegacyGovernanceAwareness(capabilities: unknown, task: string): boolean {
+  if (task !== 'create_media_buy') return false;
+  const root = capabilitiesRoot(capabilities);
+  const mediaBuy = isRecord(root?.media_buy) ? root.media_buy : undefined;
+  return mediaBuy?.governance_aware === true;
+}
+
+/** Verify the published compact-JWS authorization profile and all service bindings. */
+export async function verifyGovernanceAuthorization(
+  options: VerifyGovernanceAuthorizationOptions
+): Promise<GovernanceAuthorizationResult> {
+  const reject = (error: GovernanceAuthorizationErrorCode, message: string): GovernanceAuthorizationFailure => ({
+    ok: false,
+    error,
+    message,
+  });
+
+  if (!options.authenticatedCaller) {
+    return reject('governance_token_invalid', 'Authenticated caller is required');
+  }
+  try {
+    buildGovernanceCommitment(options.actualCommitment.amount, options.actualCommitment.currency);
+  } catch (error) {
+    return reject('governance_token_invalid', (error as Error).message);
+  }
+
+  if (typeof options.token !== 'string' || options.token.length === 0) {
+    return reject('governance_token_invalid', 'governance_context is required');
+  }
+  if (options.token.length > 4096) {
+    return reject('governance_token_invalid', 'governance_context exceeds the protocol size limit');
+  }
+  const parts = options.token.split('.');
+  if (parts.length !== 3 || parts.some(part => !part || !/^[A-Za-z0-9_-]+$/.test(part))) {
+    return reject('governance_token_invalid', 'governance_context is not a compact JWS');
+  }
+
+  const protectedHeader = decodeJsonObject(parts[0]!);
+  const decodedClaims = decodeJsonObject(parts[1]!);
+  if (!protectedHeader || !decodedClaims) {
+    return reject('governance_token_invalid', 'governance_context contains invalid JSON');
+  }
+
+  const alg = protectedHeader.alg;
+  if (alg !== 'EdDSA' && alg !== 'ES256') {
+    return reject('governance_token_invalid', 'Unsupported governance JWS algorithm');
+  }
+  if (protectedHeader.typ !== 'adcp-gov+jws') {
+    return reject('governance_token_invalid', 'Invalid governance JWS typ');
+  }
+
+  const critical = protectedHeader.crit;
+  if (!Array.isArray(critical) || critical.some(name => typeof name !== 'string')) {
+    return reject('governance_token_invalid', 'Governance JWS crit must be a string array');
+  }
+  const criticalNames = critical as string[];
+  if (new Set(criticalNames).size !== criticalNames.length) {
+    return reject('governance_token_invalid', 'Governance JWS crit contains duplicates');
+  }
+  if (criticalNames.some(name => !(GOVERNANCE_AUTHORIZATION_CRITICAL_CLAIMS as readonly string[]).includes(name))) {
+    return reject('governance_token_invalid', 'Governance JWS has an unknown critical extension');
+  }
+  for (const name of GOVERNANCE_AUTHORIZATION_CRITICAL_CLAIMS) {
+    const hasClaim = decodedClaims[name] !== undefined;
+    const hasMarker = criticalNames.includes(name) && protectedHeader[name] === true;
+    if (hasClaim !== hasMarker) {
+      return reject('governance_token_invalid', `${name} claim and critical marker must appear together`);
+    }
+  }
+  if ((decodedClaims.authorized_task === undefined) !== (decodedClaims.authorized_payload_hash === undefined)) {
+    return reject('governance_token_invalid', 'authorized_task and authorized_payload_hash must appear together');
+  }
+
+  if (typeof decodedClaims.iss !== 'string' || decodedClaims.iss !== options.expectedIssuer) {
+    return reject('governance_token_invalid', 'Governance token issuer mismatch');
+  }
+  const kid = typeof protectedHeader.kid === 'string' ? protectedHeader.kid : '';
+  if (!kid) return reject('governance_key_unknown', 'Governance signing kid is missing');
+
+  let jwk;
+  try {
+    jwk = await options.jwks.resolve(kid);
+  } catch {
+    return reject('governance_key_unknown', 'Governance signing key could not be resolved');
+  }
+  if (
+    !jwk ||
+    jwk.adcp_use !== 'governance-signing' ||
+    jwk.use !== 'sig' ||
+    !jwk.key_ops?.includes('verify') ||
+    (jwk.alg !== undefined && jwk.alg !== alg)
+  ) {
+    return reject('governance_key_unknown', 'Governance signing key is unknown or not authorized');
+  }
+
+  try {
+    const key = await importJWK(jwk as JWK, alg);
+    await compactVerify(options.token, key, {
+      algorithms: [alg],
+      crit: {
+        authorized_commitment: true,
+        authorized_task: true,
+        authorized_payload_hash: true,
+      },
+    });
+  } catch {
+    return reject('governance_token_invalid', 'Governance token signature verification failed');
+  }
+
+  try {
+    if (options.revocationStore && (await options.revocationStore.isRevoked(kid))) {
+      return reject('governance_token_revoked', 'Governance signing key is revoked');
+    }
+    if (
+      options.isJtiRevoked &&
+      typeof decodedClaims.jti === 'string' &&
+      (await options.isJtiRevoked(decodedClaims.iss, decodedClaims.jti))
+    ) {
+      return reject('governance_token_revoked', 'Governance token is revoked');
+    }
+  } catch {
+    return reject('governance_token_revoked', 'Governance revocation status could not be established');
+  }
+
+  if (typeof decodedClaims.aud !== 'string') {
+    return reject('governance_token_invalid', 'Governance token audience is missing');
+  }
+  if (decodedClaims.aud !== options.expectedAudience) {
+    return reject('governance_token_not_applicable', 'Governance token audience mismatch');
+  }
+  if (typeof decodedClaims.caller !== 'string' || decodedClaims.caller.length === 0) {
+    return reject('governance_token_invalid', 'Governance token caller is missing');
+  }
+  if (decodedClaims.caller !== options.authenticatedCaller) {
+    return reject('governance_token_not_applicable', 'Governance token caller mismatch');
+  }
+  if (typeof decodedClaims.sub !== 'string' || !decodedClaims.sub) {
+    return reject('governance_token_invalid', 'Governance token action binding is missing');
+  }
+  if (typeof decodedClaims.plan_hash !== 'string' || !decodedClaims.plan_hash) {
+    return reject('governance_token_invalid', 'Governance token plan binding is missing');
+  }
+  if (typeof decodedClaims.check_id !== 'string' || !decodedClaims.check_id) {
+    return reject('governance_token_invalid', 'Governance token check binding is missing');
+  }
+  if (typeof decodedClaims.phase !== 'string') {
+    return reject('governance_token_invalid', 'Governance token phase is missing');
+  }
+  if (decodedClaims.phase !== (options.expectedPhase ?? 'intent')) {
+    return reject('governance_token_not_applicable', 'Governance token phase mismatch');
+  }
+  if (decodedClaims.media_buy_id !== undefined) {
+    return reject('governance_token_not_applicable', 'Intent governance token must not contain media_buy_id');
+  }
+
+  const now = options.now?.() ?? Math.floor(Date.now() / 1000);
+  const skew = options.clockSkewSeconds ?? 60;
+  if (!Number.isFinite(now) || !Number.isFinite(skew) || skew < 0) {
+    return reject('governance_token_invalid', 'Invalid governance verifier clock configuration');
+  }
+  if (typeof decodedClaims.iat !== 'number' || !Number.isFinite(decodedClaims.iat)) {
+    return reject('governance_token_invalid', 'Governance token iat is missing or invalid');
+  }
+  if (decodedClaims.iat > now + skew) {
+    return reject('governance_token_not_yet_valid', 'Governance token iat is in the future');
+  }
+  if (decodedClaims.nbf !== undefined) {
+    if (typeof decodedClaims.nbf !== 'number' || !Number.isFinite(decodedClaims.nbf)) {
+      return reject('governance_token_invalid', 'Governance token nbf is invalid');
+    }
+    if (decodedClaims.nbf > now + skew) {
+      return reject('governance_token_not_yet_valid', 'Governance token is not active yet');
+    }
+  }
+  if (typeof decodedClaims.exp !== 'number' || !Number.isFinite(decodedClaims.exp)) {
+    return reject('governance_token_invalid', 'Governance token exp is missing or invalid');
+  }
+  if (decodedClaims.exp < now - skew) {
+    return reject('governance_token_expired', 'Governance token is expired');
+  }
+  if (decodedClaims.exp <= decodedClaims.iat) {
+    return reject('governance_token_invalid', 'Governance token expiry must be after issuance');
+  }
+  if (typeof decodedClaims.jti !== 'string' || !decodedClaims.jti) {
+    return reject('governance_token_invalid', 'Governance token jti is missing');
+  }
+
+  let hasFreshCombinedRevocation = false;
+  if (options.revocationResolver) {
+    try {
+      const status = await options.revocationResolver.resolve(decodedClaims.iss, kid, decodedClaims.jti);
+      if (
+        status.issuer !== decodedClaims.iss ||
+        typeof status.keyRevoked !== 'boolean' ||
+        typeof status.jtiRevoked !== 'boolean' ||
+        !Number.isFinite(status.nextUpdate) ||
+        status.nextUpdate < now
+      ) {
+        return reject('governance_token_revoked', 'Governance revocation status is stale or mismatched');
+      }
+      if (status.keyRevoked || status.jtiRevoked) {
+        return reject('governance_token_revoked', 'Governance signing key or token is revoked');
+      }
+      hasFreshCombinedRevocation = true;
+    } catch {
+      return reject('governance_token_revoked', 'Governance revocation status could not be established');
+    }
+  }
+  if (!hasFreshCombinedRevocation && decodedClaims.exp - decodedClaims.iat > 15 * 60) {
+    return reject(
+      'governance_token_invalid',
+      'Governance token lifetime exceeds 15 minutes without fresh combined revocation status'
+    );
+  }
+
+  if (typeof decodedClaims.authorized_task !== 'string') {
+    return reject('governance_token_invalid', 'Governance token authorized_task is missing');
+  }
+  if (decodedClaims.authorized_task !== options.expectedTask) {
+    return reject('governance_token_not_applicable', 'Governance token task mismatch');
+  }
+
+  let payloadHash: string;
+  try {
+    payloadHash = computeGovernedPayloadHash(options.payload);
+  } catch {
+    return reject('governance_token_invalid', 'Governed payload is not canonical JSON');
+  }
+  if (typeof decodedClaims.authorized_payload_hash !== 'string') {
+    return reject('governance_token_invalid', 'Governance token payload hash is missing');
+  }
+  if (decodedClaims.authorized_payload_hash !== payloadHash) {
+    return reject('governance_token_not_applicable', 'Governance token payload hash mismatch');
+  }
+
+  if (!isRecord(decodedClaims.authorized_commitment)) {
+    return reject('governance_token_not_applicable', 'Governance token has no monetary authorization');
+  }
+  const authorizedAmount = decodedClaims.authorized_commitment.amount;
+  const authorizedCurrency = decodedClaims.authorized_commitment.currency;
+  if (typeof authorizedAmount !== 'number' || !Number.isFinite(authorizedAmount) || authorizedAmount < 0) {
+    return reject('governance_token_invalid', 'Governance token authorized amount is invalid');
+  }
+  if (typeof authorizedCurrency !== 'string' || !/^[A-Z]{3}$/.test(authorizedCurrency)) {
+    return reject('governance_token_invalid', 'Governance token authorized currency is invalid');
+  }
+  if (authorizedCurrency !== options.actualCommitment.currency || options.actualCommitment.amount > authorizedAmount) {
+    return reject('governance_token_not_applicable', 'Actual commitment exceeds or mismatches authorization');
+  }
+
+  let replayResult: Awaited<ReturnType<GovernanceReplayStore['consume']>>;
+  try {
+    const idempotencyKey =
+      typeof options.payload.idempotency_key === 'string' ? options.payload.idempotency_key : undefined;
+    replayResult = await options.replayStore.consume(
+      decodedClaims.iss,
+      decodedClaims.aud,
+      decodedClaims.jti,
+      decodedClaims.exp + skew,
+      now,
+      {
+        caller: options.authenticatedCaller,
+        task: options.expectedTask,
+        payloadHash,
+        ...(idempotencyKey ? { idempotencyKey } : {}),
+      }
+    );
+  } catch {
+    return reject('governance_token_replayed', 'Governance replay state could not be committed');
+  }
+  if (replayResult !== 'ok') {
+    return reject(
+      'governance_token_replayed',
+      replayResult === 'rate_abuse'
+        ? 'Governance replay store is full'
+        : replayResult === 'conflict'
+          ? 'Governance token was reused with conflicting request bindings'
+          : 'Governance token was already consumed'
+    );
+  }
+
+  return {
+    ok: true,
+    claims: decodedClaims as GovernanceAuthorizationClaims,
+    protectedHeader,
+    payloadHash,
+  };
+}
+
+export class GovernanceAuthorizationError extends Error {
+  readonly code: GovernanceAuthorizationErrorCode;
+
+  constructor(result: GovernanceAuthorizationFailure) {
+    super(result.message);
+    this.name = 'GovernanceAuthorizationError';
+    this.code = result.error;
+  }
+}
+
+export interface GovernanceEnforcementMiddlewareInput {
+  token: unknown;
+  authenticatedCaller: string;
+  task: string;
+  payload: Record<string, unknown>;
+  actualCommitment: GovernanceCommitment;
+  expectedPhase?: 'intent';
+}
+
+export type GovernanceEnforcementMiddlewareConfig = Omit<
+  VerifyGovernanceAuthorizationOptions,
+  'token' | 'authenticatedCaller' | 'expectedTask' | 'payload' | 'actualCommitment' | 'expectedPhase'
+>;
+
+export type GovernanceEnforcementMiddleware = <T>(
+  input: GovernanceEnforcementMiddlewareInput,
+  next: (authorization: GovernanceAuthorizationSuccess) => T | Promise<T>
+) => Promise<T>;
+
+/**
+ * Framework-neutral governed-service middleware. Verification completes and
+ * replay state is atomically consumed before `next` can perform side effects.
+ */
+export function createGovernanceEnforcementMiddleware(
+  config: GovernanceEnforcementMiddlewareConfig
+): GovernanceEnforcementMiddleware {
+  return async <T>(
+    input: GovernanceEnforcementMiddlewareInput,
+    next: (authorization: GovernanceAuthorizationSuccess) => T | Promise<T>
+  ): Promise<T> => {
+    const result = await verifyGovernanceAuthorization({
+      ...config,
+      token: input.token,
+      authenticatedCaller: input.authenticatedCaller,
+      expectedTask: input.task,
+      payload: input.payload,
+      actualCommitment: input.actualCommitment,
+      expectedPhase: input.expectedPhase,
+    });
+    if (!result.ok) throw new GovernanceAuthorizationError(result);
+    return next(result);
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, any> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function decodeJsonObject(segment: string): Record<string, unknown> | null {
+  try {
+    const bytes = Buffer.from(segment, 'base64url');
+    if (bytes.toString('base64url') !== segment) return null;
+    const parsed = parseStrictJson(new TextDecoder('utf-8', { fatal: true }).decode(bytes));
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/governance/index.ts
+++ b/src/lib/governance/index.ts
@@ -14,6 +14,48 @@
  * resolves category synonyms and custom policies server-side.
  */
 
+export {
+  GOVERNANCE_AUTHORIZATION_CRITICAL_CLAIMS,
+  GovernanceAuthorizationError,
+  GovernanceReplayStoreAdapter,
+  InMemoryGovernanceReplayStore,
+  buildGovernanceCommitment,
+  buildGovernanceExecutionCommitment,
+  buildGovernanceExecutionRequest,
+  buildGovernanceIntentRequest,
+  buildGovernanceProposedCommitment,
+  computeGovernedPayloadHash,
+  createGovernanceEnforcementMiddleware,
+  getGovernanceEnforcementTasks,
+  governancePurchaseTypeForTask,
+  governanceTaskRequiresProposedCommitment,
+  targetDeclaresGovernanceEnforcement,
+  targetDeclaresLegacyGovernanceAwareness,
+  verifyGovernanceAuthorization,
+} from './authorization';
+export type {
+  BuildGovernanceExecutionRequestInput,
+  BuildGovernanceIntentRequestInput,
+  GovernanceAuthorizationClaims,
+  GovernanceAuthorizationCriticalClaim,
+  GovernanceAuthorizationErrorCode,
+  GovernanceAuthorizationFailure,
+  GovernanceAuthorizationResult,
+  GovernanceAuthorizationSuccess,
+  GovernanceCommitment,
+  GovernanceEnforcementMiddleware,
+  GovernanceEnforcementMiddlewareConfig,
+  GovernanceEnforcementMiddlewareInput,
+  GovernanceEnforcementMode,
+  GovernanceEnforcementTask,
+  GovernanceReplayStore,
+  GovernanceReplayBinding,
+  GovernanceRevocationResolver,
+  GovernanceRevocationStatus,
+  InMemoryGovernanceReplayStoreOptions,
+  VerifyGovernanceAuthorizationOptions,
+} from './authorization';
+
 /**
  * `policy_categories` values that MUST set `human_review_required: true`
  * under GDPR Art 22 / EU AI Act Annex III. Matches the schema's `if/then`

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -352,10 +352,21 @@ export type {
   GovernanceCheckResult,
   GovernanceOutcome,
   GovernanceFinding,
+  GovernanceIntentDetails,
   GovernanceCondition,
   GovernanceEscalation,
+  NormalizedGovernanceApproved,
+  NormalizedGovernanceConditions,
+  NormalizedGovernanceDenied,
+  NormalizedGovernanceVerdict,
 } from './core/GovernanceTypes';
 export { GovernanceMiddleware } from './core/GovernanceMiddleware';
+export {
+  isGovernanceApproved,
+  isGovernanceConditions,
+  isGovernanceDenied,
+  normalizeGovernanceVerdict,
+} from './core/GovernanceTypes';
 export type { GovernanceDebugEntry } from './core/GovernanceMiddleware';
 
 // ====== GOVERNANCE PLAN HELPERS ======
@@ -363,9 +374,26 @@ export type { GovernanceDebugEntry } from './core/GovernanceMiddleware';
 // typically drop: budget reallocation autonomy and regulated-vertical
 // human review under GDPR Art 22 / EU AI Act Annex III.
 export {
+  GOVERNANCE_AUTHORIZATION_CRITICAL_CLAIMS,
+  GovernanceAuthorizationError,
+  GovernanceReplayStoreAdapter,
+  InMemoryGovernanceReplayStore,
+  buildGovernanceCommitment,
+  buildGovernanceExecutionCommitment,
+  buildGovernanceExecutionRequest,
+  buildGovernanceIntentRequest,
+  buildGovernanceProposedCommitment,
   buildHumanReviewPlan,
   buildHumanOverride,
+  computeGovernedPayloadHash,
+  createGovernanceEnforcementMiddleware,
+  getGovernanceEnforcementTasks,
+  governancePurchaseTypeForTask,
+  governanceTaskRequiresProposedCommitment,
+  targetDeclaresGovernanceEnforcement,
+  targetDeclaresLegacyGovernanceAwareness,
   validateGovernancePlan,
+  verifyGovernanceAuthorization,
   REGULATED_HUMAN_REVIEW_CATEGORIES,
   ANNEX_III_POLICY_IDS,
 } from './governance';
@@ -416,14 +444,34 @@ export {
   type PlatformExtensionsReferenceResult,
 } from './canonical-references';
 export type {
+  BuildGovernanceExecutionRequestInput,
+  BuildGovernanceIntentRequestInput,
   BuildHumanReviewPlanInput,
   BuildHumanOverrideInput,
   DataSubjectContestation,
+  GovernanceAuthorizationClaims,
+  GovernanceAuthorizationCriticalClaim,
+  GovernanceAuthorizationErrorCode,
+  GovernanceAuthorizationFailure,
+  GovernanceAuthorizationResult,
+  GovernanceAuthorizationSuccess,
+  GovernanceCommitment,
+  GovernanceEnforcementMiddleware,
+  GovernanceEnforcementMiddlewareConfig,
+  GovernanceEnforcementMiddlewareInput,
+  GovernanceEnforcementMode,
+  GovernanceEnforcementTask,
   GovernancePlan,
+  GovernanceReplayStore,
+  GovernanceReplayBinding,
+  GovernanceRevocationResolver,
+  GovernanceRevocationStatus,
   GovernanceValidationIssue,
   HumanOverride,
+  InMemoryGovernanceReplayStoreOptions,
   PlanBudget,
   ReallocationAutonomy,
+  VerifyGovernanceAuthorizationOptions,
 } from './governance';
 
 // ====== TASK EVENT TYPES ======
@@ -1912,6 +1960,9 @@ export {
   type GovernanceAdapterConfig,
   type GovernanceAdapterErrorCode,
   type CommittedCheckRequest,
+  type LegacyCommittedCheckRequest,
+  type ModernCommittedCheckRequest,
+  GovernanceAdapterError,
   GovernanceAdapterErrorCodes,
   isGovernanceAdapterError,
   // Implicit Account Store (resolution: 'implicit') — Shape A reference adapter

--- a/src/lib/protocols/index.ts
+++ b/src/lib/protocols/index.ts
@@ -388,6 +388,79 @@ export interface CallToolOptions {
   };
 }
 
+export interface PreparedProtocolToolCall {
+  /** Exact AdCP tool arguments that the target service will receive. */
+  args: Record<string, unknown>;
+  /** A2A carries task-status webhook registration outside tool arguments. */
+  pushNotificationConfig?: PushNotificationConfig;
+}
+
+/**
+ * Materialize protocol-owned request fields before a tool call is authorized.
+ *
+ * Governance binds the complete downstream AdCP argument object, including
+ * version fields and (for MCP) `push_notification_config`. Keeping this pure
+ * preparation step shared with {@link ProtocolClient.callTool} prevents the
+ * authorized payload from drifting from the payload that reaches the service.
+ */
+export function prepareProtocolToolCall(
+  agent: AgentConfig,
+  args: Record<string, unknown>,
+  options: Pick<
+    CallToolOptions,
+    | 'webhookUrl'
+    | 'webhookSecret'
+    | 'webhookToken'
+    | 'serverVersion'
+    | 'adcpVersion'
+    | 'wireAdcpVersion'
+    | 'versionEnvelope'
+  > = {}
+): PreparedProtocolToolCall {
+  const envelope = buildVersionEnvelopeForMode(
+    options.versionEnvelope ?? 'auto',
+    options.wireAdcpVersion ?? options.adcpVersion,
+    options.serverVersion
+  );
+  const argsWithVersion = applyVersionEnvelope(args, envelope);
+
+  // The in-process MCP client has historically had no protocol webhook
+  // registration path. Preserve that behavior and, crucially, describe the
+  // exact arguments that path will receive.
+  if (agent.protocol === 'mcp' && agent._inProcessMcpClient) {
+    return { args: argsWithVersion };
+  }
+
+  let pushNotificationConfig: PushNotificationConfig | undefined;
+  if (options.webhookUrl) {
+    if (options.webhookSecret) {
+      pushNotificationConfig = {
+        url: options.webhookUrl,
+        ...(options.webhookToken && { token: options.webhookToken }),
+        authentication: {
+          schemes: ['HMAC-SHA256' as const],
+          credentials: options.webhookSecret,
+        },
+      };
+    } else if (options.serverVersion === 'v2') {
+      warnV2PushNotificationNeedsSecret();
+    } else {
+      pushNotificationConfig = {
+        url: options.webhookUrl,
+        ...(options.webhookToken && { token: options.webhookToken }),
+      };
+    }
+  }
+
+  return {
+    args:
+      agent.protocol === 'mcp' && pushNotificationConfig
+        ? { ...argsWithVersion, push_notification_config: pushNotificationConfig }
+        : argsWithVersion,
+    ...(pushNotificationConfig ? { pushNotificationConfig } : {}),
+  };
+}
+
 /**
  * Universal protocol client - automatically routes to the correct protocol implementation
  */
@@ -422,17 +495,15 @@ export class ProtocolClient {
       transportActivityContext,
     } = options;
     const transport = normalizeTransportOptions(requestedTransport);
-    // Per-instance version envelope. Throws on unparseable pins via
-    // `resolveWireMajor`; construction-time `resolveAdcpVersion` is the
-    // primary gate but this is the failsafe for callers reaching
-    // `ProtocolClient.callTool` directly (test harnesses, the in-process
-    // MCP path). Returns `{ adcp_major_version }` for 3.0 pins and
-    // `{ adcp_major_version, adcp_version }` for 3.1+ pins.
-    const versionEnvelope = buildVersionEnvelopeForMode(
-      versionEnvelopeMode,
-      wireAdcpVersion ?? adcpVersion,
-      serverVersion
-    );
+    const preparedCall = prepareProtocolToolCall(agent, args, {
+      webhookUrl,
+      webhookSecret,
+      webhookToken,
+      serverVersion,
+      adcpVersion,
+      wireAdcpVersion,
+      versionEnvelope: versionEnvelopeMode,
+    });
     // Enter the response-size-limit ALS slot once for this call. The slot is
     // read by `wrapFetchWithSizeLimit` in both protocol transports, so the
     // cap applies regardless of which path (MCP / A2A / OAuth refresh) the
@@ -462,8 +533,7 @@ export class ProtocolClient {
               // still apply (they run in SingleAgentClient above this call). We skip
               // URL validation, OAuth refresh, and signing — none apply in-process.
               if (agent.protocol === 'mcp' && agent._inProcessMcpClient) {
-                const inProcArgs = applyVersionEnvelope(args, versionEnvelope);
-                return callMCPToolWithClient(agent._inProcessMcpClient, toolName, inProcArgs, debugLogs, {
+                return callMCPToolWithClient(agent._inProcessMcpClient, toolName, preparedCall.args, debugLogs, {
                   ...(signal && { signal }),
                   ...(transport?.requestTimeoutMs !== undefined && { requestTimeoutMs: transport.requestTimeoutMs }),
                 });
@@ -526,61 +596,7 @@ export class ProtocolClient {
                 );
               }
 
-              // Inject the version envelope on every request so sellers can validate
-              // compatibility. Skip for v2 servers — they don't recognise the
-              // version fields and strict-schema agents reject them. The envelope
-              // shape is per-pin: 3.0 pins get the integer `adcp_major_version`
-              // alone; 3.1+ pins get both that and the release-precision string
-              // `adcp_version` (`'3.1'` / `'3.1.0-beta.1'`) per spec PR
-              // `adcontextprotocol/adcp#3493`.
-              const argsWithVersion = applyVersionEnvelope(args, versionEnvelope);
-
-              // Build push_notification_config for ASYNC TASK STATUS notifications
-              // (NOT for reporting_webhook - that stays in args)
-              // Schema: https://adcontextprotocol.org/schemas/v1/core/push-notification-config.json
-              // `authentication` is a scheme SELECTOR, not a fallback: from AdCP
-              // 3.0 on, push-notification-config.json makes its presence opt the
-              // seller into legacy HMAC-SHA256 and its absence select the RFC
-              // 9421 webhook profile, with `required: ["url"]` only. Emitting it
-              // with a placeholder credential would therefore downgrade every
-              // webhook to legacy HMAC keyed by a constant that ships in this
-              // file, so the block is omitted unless a real secret backs it.
-              //
-              // v2.5 predates the selector: there `required` is
-              // `["url", "authentication"]` and there is no 9421 path, so an
-              // omitted block is schema-invalid rather than a mode selection.
-              // With no secret there is nothing honest to send a v2 seller, so
-              // suppress the registration instead of fabricating a credential.
-              const pushNotificationConfig: PushNotificationConfig | undefined = (():
-                | PushNotificationConfig
-                | undefined => {
-                if (!webhookUrl) return undefined;
-                if (webhookSecret) {
-                  return {
-                    url: webhookUrl,
-                    ...(webhookToken && { token: webhookToken }),
-                    authentication: {
-                      schemes: ['HMAC-SHA256' as const],
-                      credentials: webhookSecret,
-                    },
-                  };
-                }
-                if (serverVersion === 'v2') {
-                  warnV2PushNotificationNeedsSecret();
-                  return undefined;
-                }
-                return {
-                  url: webhookUrl,
-                  ...(webhookToken && { token: webhookToken }),
-                };
-              })();
-
               if (agent.protocol === 'mcp') {
-                // For MCP, include push_notification_config in tool arguments (MCP spec)
-                const argsWithWebhook = pushNotificationConfig
-                  ? { ...argsWithVersion, push_notification_config: pushNotificationConfig }
-                  : argsWithVersion;
-
                 // If the agent config carries authorization-code OAuth tokens,
                 // route through the OAuth provider path so the MCP SDK can refresh
                 // on 401 instead of hard-failing. Excludes client-credentials
@@ -597,7 +613,7 @@ export class ProtocolClient {
                     return await callMCPToolWithOAuth({
                       agentUrl: agent.agent_uri,
                       toolName,
-                      args: argsWithWebhook,
+                      args: preparedCall.args,
                       authProvider,
                       debugLogs,
                       customHeaders: agent.headers,
@@ -628,7 +644,7 @@ export class ProtocolClient {
                   return await callMCPToolWithTasks(
                     agent.agent_uri,
                     toolName,
-                    argsWithWebhook,
+                    preparedCall.args,
                     authToken,
                     debugLogs,
                     agent.headers,
@@ -662,7 +678,7 @@ export class ProtocolClient {
                       return await callMCPToolWithTasks(
                         agent.agent_uri,
                         toolName,
-                        argsWithWebhook,
+                        preparedCall.args,
                         retryAuthToken,
                         debugLogs,
                         agent.headers,
@@ -704,10 +720,10 @@ export class ProtocolClient {
                   return await callA2ATool(
                     agent.agent_uri,
                     toolName,
-                    argsWithVersion,
+                    preparedCall.args,
                     authToken,
                     debugLogs,
-                    pushNotificationConfig,
+                    preparedCall.pushNotificationConfig,
                     agent.headers,
                     signingContext,
                     session,
@@ -736,10 +752,10 @@ export class ProtocolClient {
                       return await callA2ATool(
                         agent.agent_uri,
                         toolName,
-                        argsWithVersion,
+                        preparedCall.args,
                         retryAuthToken,
                         debugLogs,
-                        pushNotificationConfig,
+                        preparedCall.pushNotificationConfig,
                         agent.headers,
                         signingContext,
                         session,

--- a/src/lib/protocols/transportDiagnostics.ts
+++ b/src/lib/protocols/transportDiagnostics.ts
@@ -77,10 +77,12 @@ const SENSITIVE_HEADER_NAMES = new Set([
   'mcp-session-id',
 ]);
 
+const SENSITIVE_EXACT_KEYS = new Set(['governance_context', 'consultation_context']);
+
 const SENSITIVE_KEY_RE =
-  /(^|[_-])(authorization|cookie|credentials?|secret|signature|token|api[_-]?key|private[_-]?key|idempotency[_-]?key|password)([_-]|$)/i;
+  /(^|[_-])(authorization|cookie|credentials?|secret|signature|token|api[_-]?key|private[_-]?key|idempotency[_-]?key|governance[_-]?context|consultation[_-]?context|password)([_-]|$)/i;
 const SENSITIVE_TEXT_FIELD_RE =
-  /((?:"[^"]*(?:authorization|cookie|credentials?|secret|signature|token|api[_-]?key|private[_-]?key|idempotency[_-]?key|password)[^"]*"\s*:\s*)|(?:^|[&\s])[^=&\s]*(?:authorization|cookie|credentials?|secret|signature|token|api[_-]?key|private[_-]?key|idempotency[_-]?key|password)[^=&\s]*=)("[^"]*"|[^&\s,}]+)/gi;
+  /((?:"[^"]*(?:authorization|cookie|credentials?|secret|signature|token|api[_-]?key|private[_-]?key|idempotency[_-]?key|governance[_-]?context|consultation[_-]?context|password)[^"]*"\s*:\s*)|(?:^|[&\s])[^=&\s]*(?:authorization|cookie|credentials?|secret|signature|token|api[_-]?key|private[_-]?key|idempotency[_-]?key|governance[_-]?context|consultation[_-]?context|password)[^=&\s]*=)("[^"]*"|[^&\s,}]+)/gi;
 const URL_LIKE_RE = /\bhttps?:\/\/[^\s"'<>]+/gi;
 
 export const transportDiagnosticsStorage = globalAsyncLocalStorage<TransportDiagnosticsSlot>('transportDiagnostics');
@@ -321,7 +323,8 @@ function normalizedKey(key: string): string {
 }
 
 function isSensitiveKey(key: string): boolean {
-  return SENSITIVE_KEY_RE.test(normalizedKey(key));
+  const normalized = normalizedKey(key);
+  return SENSITIVE_EXACT_KEYS.has(normalized) || SENSITIVE_KEY_RE.test(normalized);
 }
 
 function isDiagnosticTextContentType(contentType: string): boolean {

--- a/src/lib/server/governance.ts
+++ b/src/lib/server/governance.ts
@@ -57,6 +57,13 @@ import { callMCPTool } from '../protocols/mcp';
 import type { CheckGovernanceResponse } from '../types/tools.generated';
 import type { McpToolResponse } from './responses';
 import { adcpError } from './errors';
+import { normalizeGovernanceVerdict } from '../core/GovernanceTypes';
+import {
+  verifyGovernanceAuthorization,
+  type GovernanceEnforcementMiddlewareConfig,
+  type GovernanceEnforcementMiddlewareInput,
+  type GovernanceAuthorizationSuccess,
+} from '../governance';
 
 /**
  * Extract a tool's JSON payload from an MCP `CallToolResult` envelope.
@@ -93,8 +100,8 @@ function extractMcpPayload(raw: unknown): Record<string, unknown> | null {
     }
   }
 
-  // Legacy: caller spread the payload at top level.
-  if ('status' in envelope || 'check_id' in envelope) return envelope;
+  // Legacy and modern callers may spread the payload at top level.
+  if ('status' in envelope || 'verdict' in envelope || 'check_id' in envelope) return envelope;
 
   return null;
 }
@@ -181,27 +188,36 @@ export async function checkGovernance(options: CheckGovernanceOptions): Promise<
   const raw = await callMCPTool(agentUrl, 'check_governance', args, authToken);
   const extracted = extractMcpPayload(raw);
 
-  if (!extracted || !('status' in extracted) || !('check_id' in extracted) || !('explanation' in extracted)) {
+  if (
+    !extracted ||
+    (!('status' in extracted) && !('verdict' in extracted)) ||
+    !('check_id' in extracted) ||
+    !('explanation' in extracted)
+  ) {
     throw new Error(
       `Invalid check_governance response from ${agentUrl}: ` +
-        `missing required fields (status, check_id, explanation). Got: ${JSON.stringify(raw)?.slice(0, 200)}`
+        `missing required fields (verdict/status, check_id, explanation). Got: ${JSON.stringify(raw)?.slice(0, 200)}`
     );
   }
   const response = extracted as unknown as CheckGovernanceResponse;
+  const normalized = normalizeGovernanceVerdict(response);
+  if (!normalized) {
+    throw new Error(`Invalid check_governance verdict response from ${agentUrl}`);
+  }
 
-  if (response.verdict === 'approved') {
+  if (normalized.verdict === 'approved') {
     return {
       approved: true,
       checkId: response.check_id,
       explanation: response.explanation,
-      governanceContext: response.governance_context ?? undefined,
-      expiresAt: response.expires_at ?? undefined,
+      governanceContext: normalized.governanceContext,
+      expiresAt: normalized.expiresAt,
       nextCheck: response.next_check ?? undefined,
       findings: response.findings,
     };
   }
 
-  if (response.verdict === 'conditions') {
+  if (normalized.verdict === 'conditions') {
     return {
       approved: 'conditions',
       checkId: response.check_id,
@@ -245,4 +261,48 @@ export function governanceDeniedError(result: GovernanceDenied | GovernanceCondi
     message: result.explanation,
     details,
   });
+}
+
+/** Map an adapter transport failure to the protocol's transient wire error. */
+export function governanceUnavailableError(): McpToolResponse {
+  return adcpError('GOVERNANCE_UNAVAILABLE', {
+    message: 'The configured governance agent is unavailable; retry with backoff',
+  });
+}
+
+export type AdcpGovernanceEnforcementMiddleware = <T>(
+  input: GovernanceEnforcementMiddlewareInput,
+  next: (authorization: GovernanceAuthorizationSuccess) => T | Promise<T>
+) => Promise<T | McpToolResponse>;
+
+/**
+ * Server-handler variant of the governance verifier. Invalid, missing,
+ * expired, or replay-conflicting authorization is returned as the required
+ * structured `PERMISSION_DENIED` envelope instead of escaping as a generic
+ * exception that a dispatcher could misclassify as `INTERNAL_ERROR`.
+ */
+export function createAdcpGovernanceEnforcementMiddleware(
+  config: GovernanceEnforcementMiddlewareConfig
+): AdcpGovernanceEnforcementMiddleware {
+  return async <T>(
+    input: GovernanceEnforcementMiddlewareInput,
+    next: (authorization: GovernanceAuthorizationSuccess) => T | Promise<T>
+  ): Promise<T | McpToolResponse> => {
+    const result = await verifyGovernanceAuthorization({
+      ...config,
+      token: input.token,
+      authenticatedCaller: input.authenticatedCaller,
+      expectedTask: input.task,
+      payload: input.payload,
+      actualCommitment: input.actualCommitment,
+      expectedPhase: input.expectedPhase,
+    });
+    if (!result.ok) {
+      return adcpError('PERMISSION_DENIED', {
+        message: result.message,
+        details: { governance_error: result.error },
+      });
+    }
+    return next(result);
+  };
 }

--- a/src/lib/server/index.ts
+++ b/src/lib/server/index.ts
@@ -467,14 +467,47 @@ export type { SigningProvider } from '../signing/provider';
 export { createPinAndBindFetch, WEBHOOK_SSRF_POLICY, LOOPBACK_OK_WEBHOOK_SSRF_POLICY } from './pin-and-bind-fetch';
 export type { PinAndBindFetchOptions, DnsLookupAll } from './pin-and-bind-fetch';
 
-export { checkGovernance, governanceDeniedError } from './governance';
+export {
+  checkGovernance,
+  createAdcpGovernanceEnforcementMiddleware,
+  governanceDeniedError,
+  governanceUnavailableError,
+} from './governance';
 export type {
+  AdcpGovernanceEnforcementMiddleware,
   CheckGovernanceOptions,
   GovernanceCallResult,
   GovernanceApproved,
   GovernanceDenied,
   GovernanceConditions,
 } from './governance';
+
+export {
+  GovernanceAuthorizationError,
+  GovernanceReplayStoreAdapter,
+  InMemoryGovernanceReplayStore,
+  buildGovernanceExecutionCommitment,
+  buildGovernanceExecutionRequest,
+  computeGovernedPayloadHash,
+  createGovernanceEnforcementMiddleware,
+  verifyGovernanceAuthorization,
+} from '../governance';
+export type {
+  BuildGovernanceExecutionRequestInput,
+  GovernanceAuthorizationClaims,
+  GovernanceAuthorizationErrorCode,
+  GovernanceAuthorizationResult,
+  GovernanceAuthorizationSuccess,
+  GovernanceCommitment,
+  GovernanceEnforcementMiddleware,
+  GovernanceEnforcementMiddlewareConfig,
+  GovernanceEnforcementMiddlewareInput,
+  GovernanceReplayStore,
+  GovernanceReplayBinding,
+  GovernanceRevocationResolver,
+  GovernanceRevocationStatus,
+  VerifyGovernanceAuthorizationOptions,
+} from '../governance';
 
 export {
   clearDefaultResolvedListCache,

--- a/src/lib/testing/stubs/governance-agent-stub.ts
+++ b/src/lib/testing/stubs/governance-agent-stub.ts
@@ -5,7 +5,7 @@
  * Used by comply() to verify sellers correctly call governance agents with
  * governance_context during the media buy lifecycle.
  *
- * - Always returns "approved" with a deterministic governance_context
+ * - Always returns "approved" with a real compact-JWS governance_context
  * - Records every inbound call for assertion by test scenarios
  * - Starts on an ephemeral port (HTTP or HTTPS), shuts down cleanly
  */
@@ -19,7 +19,8 @@ import {
   type ServerResponse,
 } from 'http';
 import { createServer as createHttpsServer, type Server as HttpsServer } from 'https';
-import { randomUUID } from 'crypto';
+import { createHash, generateKeyPairSync, randomUUID, type KeyObject } from 'crypto';
+import { CompactSign } from 'jose';
 import { execFileSync } from 'child_process';
 import { tmpdir } from 'os';
 import { join } from 'path';
@@ -31,6 +32,9 @@ import {
   SyncPlansRequestSchema,
   GetPlanAuditLogsRequestSchema,
 } from '../../types/schemas.generated';
+import { canonicalize } from '../../utils/jcs';
+import { computeGovernedPayloadHash, type GovernanceCommitment } from '../../governance';
+import type { AdcpJsonWebKey } from '../../signing/types';
 
 export interface StubCallRecord {
   tool: string;
@@ -88,10 +92,28 @@ export class GovernanceAgentStub {
   private callLog: StubCallRecord[] = [];
   private governanceContextPrefix: string;
   private expectedToken: string;
+  private readonly signingKey: KeyObject;
+  private readonly signingJwk: AdcpJsonWebKey;
+  private issuer = 'https://governance-stub.invalid/governance';
 
   constructor() {
     this.governanceContextPrefix = `stub-gc-${randomUUID().slice(0, 8)}`;
     this.expectedToken = `stub-token-${randomUUID()}`;
+    const pair = generateKeyPairSync('ed25519');
+    this.signingKey = pair.privateKey;
+    const publicJwk = pair.publicKey.export({ format: 'jwk' }) as JsonWebKey;
+    const kid = `stub-gov-${createHash('sha256')
+      .update(publicJwk.x ?? '')
+      .digest('hex')
+      .slice(0, 12)}`;
+    this.signingJwk = {
+      ...publicJwk,
+      kid,
+      alg: 'EdDSA',
+      use: 'sig',
+      key_ops: ['verify'],
+      adcp_use: 'governance-signing',
+    } as AdcpJsonWebKey;
   }
 
   /**
@@ -100,6 +122,14 @@ export class GovernanceAgentStub {
    */
   get authToken(): string {
     return this.expectedToken;
+  }
+
+  get publicJwk(): AdcpJsonWebKey {
+    return structuredClone(this.signingJwk);
+  }
+
+  get issuerUrl(): string {
+    return this.issuer;
   }
 
   private handleRequest() {
@@ -162,7 +192,9 @@ export class GovernanceAgentStub {
           reject(new Error('Failed to get server address'));
           return;
         }
-        resolve({ url: `${protocol}://127.0.0.1:${addr.port}/mcp` });
+        const url = `${protocol}://127.0.0.1:${addr.port}/mcp`;
+        this.issuer = url;
+        resolve({ url });
       });
       this.httpServer!.on('error', reject);
     });
@@ -217,10 +249,53 @@ export class GovernanceAgentStub {
   }
 
   /**
-   * Generate the governance_context string this stub issues.
+   * Generate a signed governance_context string this stub issues.
    */
-  generateContext(planId: string): string {
-    return `${this.governanceContextPrefix}-${planId}`;
+  async generateContext(input: {
+    planId: string;
+    checkId: string;
+    audience: string;
+    caller: string;
+    task: string;
+    payload: Record<string, unknown>;
+    commitment: GovernanceCommitment;
+    phase?: string;
+  }): Promise<string> {
+    const now = Math.floor(Date.now() / 1000);
+    const claims = {
+      iss: this.issuer,
+      sub: `${this.governanceContextPrefix}-${createHash('sha256').update(input.planId).digest('hex').slice(0, 16)}`,
+      plan_hash: createHash('sha256')
+        .update(canonicalize({ plan_id: input.planId }))
+        .digest('base64url'),
+      aud: input.audience,
+      iat: now,
+      nbf: now - 5,
+      exp: now + 15 * 60,
+      jti: `stub-jti-${randomUUID()}`,
+      phase: input.phase ?? 'intent',
+      caller: input.caller,
+      check_id: input.checkId,
+      authorized_commitment: input.commitment,
+      authorized_task: input.task,
+      authorized_payload_hash: computeGovernedPayloadHash(input.payload),
+    };
+    const signer = new CompactSign(Buffer.from(JSON.stringify(claims), 'utf8')).setProtectedHeader({
+      alg: 'EdDSA',
+      kid: this.signingJwk.kid,
+      typ: 'adcp-gov+jws',
+      crit: ['authorized_commitment', 'authorized_task', 'authorized_payload_hash'],
+      authorized_commitment: true,
+      authorized_task: true,
+      authorized_payload_hash: true,
+    });
+    return signer.sign(this.signingKey, {
+      crit: {
+        authorized_commitment: true,
+        authorized_task: true,
+        authorized_payload_hash: true,
+      },
+    });
   }
 
   private recordCall(tool: string, params: Record<string, unknown>): void {
@@ -282,9 +357,45 @@ export class GovernanceAgentStub {
       (async (args: Record<string, unknown>) => {
         this.recordCall('check_governance', args);
 
-        const planId = args.plan_id as string;
+        const planId = (args.plan_id as string | undefined) ?? 'opaque-plan-binding';
         const checkId = `chk_stub_${randomUUID().slice(0, 8)}`;
-        const gc = this.generateContext(planId);
+        const payload = (args.payload as Record<string, unknown> | undefined) ?? {};
+        const totalBudget = payload.total_budget;
+        const totalBudgetObject =
+          totalBudget && typeof totalBudget === 'object'
+            ? (totalBudget as { amount?: unknown; currency?: unknown })
+            : undefined;
+        const proposed = args.proposed_commitment as { amount?: unknown; currency?: unknown } | undefined;
+        const execution = args.execution_commitment as { amount?: unknown; currency?: unknown } | undefined;
+        const planned = args.planned_delivery as { total_budget?: unknown; currency?: unknown } | undefined;
+        const amount =
+          proposed?.amount ??
+          totalBudgetObject?.amount ??
+          (typeof totalBudget === 'number' ? totalBudget : undefined) ??
+          execution?.amount ??
+          planned?.total_budget;
+        const currency =
+          proposed?.currency ??
+          totalBudgetObject?.currency ??
+          payload.currency ??
+          execution?.currency ??
+          planned?.currency;
+        if (typeof amount !== 'number' || typeof currency !== 'string') {
+          throw new TypeError('Stub governance intent requires a resolvable monetary commitment');
+        }
+        const caller = args.caller as string;
+        const audience = (args.target_agent as string | undefined) ?? caller;
+        const task = (args.tool as string | undefined) ?? 'execution';
+        const gc = await this.generateContext({
+          planId,
+          checkId,
+          audience,
+          caller,
+          task,
+          payload,
+          commitment: { amount, currency },
+          phase: args.tool ? 'intent' : 'execution',
+        });
 
         return {
           content: [
@@ -293,10 +404,11 @@ export class GovernanceAgentStub {
               text: JSON.stringify({
                 check_id: checkId,
                 verdict: 'approved',
-                plan_id: planId,
+                check_type: args.tool ? 'intent' : 'execution',
+                ...(args.tool ? { plan_id: planId } : {}),
                 explanation: 'Stub governance agent: approved for testing.',
                 governance_context: gc,
-                expires_at: new Date(Date.now() + 3600_000).toISOString(),
+                expires_at: new Date(Date.now() + 15 * 60_000).toISOString(),
               }),
             },
           ],

--- a/test/lib/governance-authorization.test.js
+++ b/test/lib/governance-authorization.test.js
@@ -1,0 +1,438 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const { CompactSign, importJWK } = require('jose');
+
+const {
+  buildGovernanceExecutionRequest,
+  buildGovernanceExecutionCommitment,
+  buildGovernanceIntentRequest,
+  buildGovernanceProposedCommitment,
+  computeGovernedPayloadHash,
+  createGovernanceEnforcementMiddleware,
+  getGovernanceEnforcementTasks,
+  InMemoryGovernanceReplayStore,
+  targetDeclaresGovernanceEnforcement,
+  verifyGovernanceAuthorization,
+} = require('../../dist/lib/index.js');
+const { StaticJwksResolver } = require('../../dist/lib/signing/jwks.js');
+const { createAdcpGovernanceEnforcementMiddleware } = require('../../dist/lib/server/governance.js');
+
+const vectors = require(
+  path.resolve(__dirname, '../../compliance/cache/latest/test-vectors/governance-authorization.json')
+);
+
+function verifierOptions(testCase) {
+  const signed = vectors.signed_jws;
+  const defaults = signed.verification_defaults;
+  const overrides = testCase.verification_overrides ?? {};
+  const testKey = { ...signed.test_key };
+  delete testKey.$comment;
+  delete testKey._private_d_for_test_only;
+
+  const replayStore = new InMemoryGovernanceReplayStore();
+  if (overrides.preconsumed_jti) {
+    replayStore.preload(testCase.claims.iss, testCase.claims.aud, testCase.claims.jti, testCase.claims.exp);
+  }
+
+  return {
+    token: testCase.compact_jws,
+    expectedIssuer: overrides.expected_issuer ?? defaults.expected_issuer,
+    expectedAudience: overrides.expected_audience ?? defaults.expected_audience,
+    authenticatedCaller: overrides.authenticated_caller ?? defaults.authenticated_caller,
+    expectedTask: overrides.expected_task ?? defaults.expected_task,
+    payload: overrides.payload ?? defaults.payload,
+    actualCommitment: overrides.actual_commitment ?? defaults.actual_commitment,
+    expectedPhase: overrides.expected_phase ?? defaults.expected_phase,
+    jwks: new StaticJwksResolver([testKey]),
+    replayStore,
+    now: () => overrides.now ?? defaults.now,
+    clockSkewSeconds: overrides.clock_skew_seconds ?? defaults.clock_skew_seconds,
+  };
+}
+
+async function signAuthorization(claims, headerOverrides = {}) {
+  const fixtureKey = vectors.signed_jws.test_key;
+  const privateKey = {
+    ...fixtureKey,
+    d: fixtureKey._private_d_for_test_only,
+    key_ops: ['sign'],
+  };
+  delete privateKey.$comment;
+  delete privateKey._private_d_for_test_only;
+  const key = await importJWK(privateKey, 'EdDSA');
+  const header = {
+    alg: 'EdDSA',
+    kid: fixtureKey.kid,
+    typ: 'adcp-gov+jws',
+    crit: ['authorized_commitment', 'authorized_task', 'authorized_payload_hash'],
+    authorized_commitment: true,
+    authorized_task: true,
+    authorized_payload_hash: true,
+    ...headerOverrides,
+  };
+  return new CompactSign(Buffer.from(JSON.stringify(claims))).setProtectedHeader(header).sign(key, {
+    crit: {
+      authorized_commitment: true,
+      authorized_task: true,
+      authorized_payload_hash: true,
+    },
+  });
+}
+
+describe('AdCP governance authorization profile', () => {
+  for (const testCase of vectors.payload_hash_cases) {
+    it(`computes published payload hash: ${testCase.id}`, () => {
+      assert.equal(computeGovernedPayloadHash(testCase.payload), testCase.expected_hash);
+    });
+  }
+
+  for (const testCase of vectors.signed_jws.cases) {
+    it(`verifies published compact JWS vector: ${testCase.id}`, async () => {
+      const result = await verifyGovernanceAuthorization(verifierOptions(testCase));
+      if (testCase.expected.result === 'accept') {
+        assert.equal(result.ok, true, result.message);
+      } else {
+        assert.equal(result.ok, false);
+        assert.equal(result.error, testCase.expected.error);
+      }
+    });
+  }
+
+  for (const authorizationCase of vectors.authorization_cases) {
+    it(`enforces published authorization case: ${authorizationCase.id}`, async () => {
+      const accepted = vectors.signed_jws.cases.find(testCase => testCase.id === 'valid-exact-authorization');
+      const payload = accepted.verification_overrides?.payload ?? vectors.signed_jws.verification_defaults.payload;
+      const claims = {
+        ...accepted.claims,
+        jti: `logical-${authorizationCase.id}`,
+        authorized_task: authorizationCase.task_match ? 'create_media_buy' : 'update_media_buy',
+        authorized_payload_hash: authorizationCase.payload_hash_match
+          ? computeGovernedPayloadHash(payload)
+          : computeGovernedPayloadHash({ ...payload, amount: 999 }),
+        authorized_commitment: {
+          amount: authorizationCase.authorized_amount,
+          currency: authorizationCase.currency_match ? 'USD' : 'EUR',
+        },
+      };
+      const headerOverrides = authorizationCase.critical_markers_complete
+        ? {}
+        : { crit: ['authorized_task', 'authorized_payload_hash'], authorized_commitment: undefined };
+      const token = await signAuthorization(claims, headerOverrides);
+      const options = verifierOptions(accepted);
+      const result = await verifyGovernanceAuthorization({
+        ...options,
+        token,
+        payload,
+        actualCommitment: { amount: authorizationCase.actual_amount, currency: 'USD' },
+      });
+      assert.equal(result.ok, authorizationCase.expected === 'accept');
+    });
+  }
+
+  it('fails closed for unknown-purpose keys and revoked authorizations', async () => {
+    const acceptedCase = vectors.signed_jws.cases.find(testCase => testCase.expected.result === 'accept');
+    const unknownKeyOptions = verifierOptions(acceptedCase);
+    unknownKeyOptions.jwks = new StaticJwksResolver([]);
+    const unknownKey = await verifyGovernanceAuthorization(unknownKeyOptions);
+    assert.equal(unknownKey.ok, false);
+    assert.equal(unknownKey.error, 'governance_key_unknown');
+
+    const missingUseOptions = verifierOptions(acceptedCase);
+    const missingUseKey = { ...vectors.signed_jws.test_key };
+    delete missingUseKey.$comment;
+    delete missingUseKey._private_d_for_test_only;
+    delete missingUseKey.use;
+    missingUseOptions.jwks = new StaticJwksResolver([missingUseKey]);
+    const missingUse = await verifyGovernanceAuthorization(missingUseOptions);
+    assert.equal(missingUse.ok, false);
+    assert.equal(missingUse.error, 'governance_key_unknown');
+
+    const revokedOptions = verifierOptions(acceptedCase);
+    const revoked = await verifyGovernanceAuthorization({
+      ...revokedOptions,
+      revocationStore: { isRevoked: async () => true },
+    });
+    assert.equal(revoked.ok, false);
+    assert.equal(revoked.error, 'governance_token_revoked');
+
+    const revokedJtiOptions = verifierOptions(acceptedCase);
+    const revokedJti = await verifyGovernanceAuthorization({
+      ...revokedJtiOptions,
+      isJtiRevoked: async () => true,
+    });
+    assert.equal(revokedJti.ok, false);
+    assert.equal(revokedJti.error, 'governance_token_revoked');
+  });
+
+  it('rejects a consumed authorization before a side effect can run twice', async () => {
+    const acceptedCase = vectors.signed_jws.cases.find(testCase => testCase.id === 'valid-exact-authorization');
+    const options = verifierOptions(acceptedCase);
+    assert.equal((await verifyGovernanceAuthorization(options)).ok, true);
+    const retry = await verifyGovernanceAuthorization(options);
+    assert.equal(retry.ok, false);
+    assert.equal(retry.error, 'governance_token_replayed');
+
+    const missingToken = await verifyGovernanceAuthorization({ ...options, token: undefined });
+    assert.equal(missingToken.ok, false);
+    assert.equal(missingToken.error, 'governance_token_invalid');
+  });
+
+  it('partitions in-memory replay capacity by issuer and audience', async () => {
+    const store = new InMemoryGovernanceReplayStore({ maxEntries: 1 });
+    assert.equal(await store.consume('issuer-a', 'audience-a', 'jti-1', 1000, 0), 'ok');
+    assert.equal(await store.consume('issuer-b', 'audience-b', 'jti-1', 1000, 0), 'ok');
+    assert.equal(await store.consume('issuer-a', 'audience-a', 'jti-2', 1000, 0), 'rate_abuse');
+  });
+
+  it('requires fresh combined revocation status for tokens over 15 minutes', async () => {
+    const acceptedCase = vectors.signed_jws.cases.find(testCase => testCase.id === 'valid-exact-authorization');
+    const claims = { ...acceptedCase.claims, jti: 'long-lived', exp: acceptedCase.claims.iat + 3600 };
+    const token = await signAuthorization(claims);
+    const options = verifierOptions(acceptedCase);
+    const withoutCombined = await verifyGovernanceAuthorization({
+      ...options,
+      token,
+      revocationStore: { isRevoked: async () => false },
+      isJtiRevoked: async () => false,
+    });
+    assert.equal(withoutCombined.ok, false);
+    assert.equal(withoutCombined.error, 'governance_token_invalid');
+
+    const withCombined = await verifyGovernanceAuthorization({
+      ...options,
+      token,
+      replayStore: new InMemoryGovernanceReplayStore(),
+      revocationResolver: {
+        resolve: async issuer => ({
+          issuer,
+          keyRevoked: false,
+          jtiRevoked: false,
+          nextUpdate: acceptedCase.claims.iat + 120,
+        }),
+      },
+    });
+    assert.equal(withCombined.ok, true);
+  });
+
+  it('fails closed when combined revocation status omits or mistypes either revocation flag', async () => {
+    const acceptedCase = vectors.signed_jws.cases.find(testCase => testCase.id === 'valid-exact-authorization');
+    const claims = { ...acceptedCase.claims, jti: 'malformed-revocation-status', exp: acceptedCase.claims.iat + 3600 };
+    const token = await signAuthorization(claims);
+    const malformedStatuses = [
+      { issuer: claims.iss, jtiRevoked: false, nextUpdate: claims.iat + 120 },
+      { issuer: claims.iss, keyRevoked: 'false', jtiRevoked: false, nextUpdate: claims.iat + 120 },
+      { issuer: claims.iss, keyRevoked: false, nextUpdate: claims.iat + 120 },
+      { issuer: claims.iss, keyRevoked: false, jtiRevoked: 0, nextUpdate: claims.iat + 120 },
+    ];
+
+    for (const status of malformedStatuses) {
+      const result = await verifyGovernanceAuthorization({
+        ...verifierOptions(acceptedCase),
+        token,
+        revocationResolver: { resolve: async () => status },
+      });
+      assert.equal(result.ok, false);
+      assert.equal(result.error, 'governance_token_revoked');
+    }
+  });
+
+  it('rejects intent authorizations that carry execution-only media_buy_id', async () => {
+    const acceptedCase = vectors.signed_jws.cases.find(testCase => testCase.id === 'valid-exact-authorization');
+    const claims = { ...acceptedCase.claims, jti: 'intent-with-media-buy-id', media_buy_id: 'buy-1' };
+    const token = await signAuthorization(claims);
+    const result = await verifyGovernanceAuthorization({ ...verifierOptions(acceptedCase), token });
+    assert.equal(result.ok, false);
+    assert.equal(result.error, 'governance_token_not_applicable');
+  });
+
+  it('builds distinct intent and execution request shapes', () => {
+    assert.deepEqual(buildGovernanceProposedCommitment(10, 'USD'), { amount: 10, currency: 'USD' });
+    assert.deepEqual(buildGovernanceExecutionCommitment(5, 'USD'), { amount: 5, currency: 'USD' });
+    const intent = buildGovernanceIntentRequest({
+      planId: 'plan-1',
+      caller: 'https://buyer.example',
+      targetAgent: 'https://seller.example/mcp',
+      tool: 'create_media_buy',
+      payload: { idempotency_key: 'key-1', total_budget: 10 },
+      purchaseType: 'media_buy',
+    });
+    assert.equal(intent.plan_id, 'plan-1');
+    assert.equal(intent.target_agent, 'https://seller.example/mcp');
+    assert.ok(!('governance_context' in intent));
+
+    const execution = buildGovernanceExecutionRequest({
+      caller: 'https://seller.example/mcp',
+      governanceContext: 'signed-token',
+      plannedDelivery: { total_budget: 10, currency: 'USD' },
+      executionCommitment: { amount: 10, currency: 'USD' },
+    });
+    assert.equal(execution.governance_context, 'signed-token');
+    assert.ok(!('plan_id' in execution));
+    assert.ok(!('tool' in execution));
+    assert.ok(!('payload' in execution));
+  });
+
+  it('enforces phase-specific execution request requirements', () => {
+    assert.throws(
+      () =>
+        buildGovernanceExecutionRequest({
+          caller: 'https://seller.example/mcp',
+          governanceContext: 'signed-token',
+          plannedDelivery: { media_buy_id: 'buy-1', total_budget: 10, currency: 'USD' },
+          phase: 'modification',
+        }),
+      /requires executionCommitment/
+    );
+    assert.throws(
+      () =>
+        buildGovernanceExecutionRequest({
+          caller: 'https://seller.example/mcp',
+          governanceContext: 'signed-token',
+          plannedDelivery: { media_buy_id: 'buy-1', total_budget: 10, currency: 'USD' },
+          phase: 'delivery',
+        }),
+      /requires deliveryMetrics/
+    );
+  });
+
+  it('requires one signed-context declaration per governed task', () => {
+    const capabilities = {
+      experimental_features: ['governance.campaign'],
+      adcp: {
+        governance_enforcement: {
+          tasks: [
+            { task: 'create_media_buy', modes: ['signed_context'] },
+            { task: 'update_media_buy', modes: ['online_execution_check'] },
+          ],
+        },
+      },
+    };
+    assert.deepEqual(getGovernanceEnforcementTasks(capabilities), [
+      { task: 'create_media_buy', modes: ['signed_context'] },
+    ]);
+    assert.equal(targetDeclaresGovernanceEnforcement(capabilities, 'create_media_buy'), true);
+    assert.equal(targetDeclaresGovernanceEnforcement(capabilities, 'update_media_buy'), false);
+    assert.equal(
+      targetDeclaresGovernanceEnforcement({ adcp: capabilities.adcp }, 'create_media_buy'),
+      false,
+      'the experimental feature marker is required'
+    );
+    assert.throws(
+      () =>
+        getGovernanceEnforcementTasks({
+          adcp: {
+            governance_enforcement: {
+              tasks: [
+                { task: 'create_media_buy', modes: [] },
+                { task: 'create_media_buy', modes: ['signed_context'] },
+              ],
+            },
+          },
+        }),
+      /Duplicate governance_enforcement task/
+    );
+  });
+
+  it('does not invoke a governed side effect before authorization succeeds', async () => {
+    const acceptedCase = vectors.signed_jws.cases.find(testCase => testCase.expected.result === 'accept');
+    const rejectedCase = vectors.signed_jws.cases.find(testCase => testCase.id === 'signature-tampered');
+    let sideEffects = 0;
+
+    const acceptedOptions = verifierOptions(acceptedCase);
+    const acceptedMiddleware = createGovernanceEnforcementMiddleware({
+      expectedIssuer: acceptedOptions.expectedIssuer,
+      expectedAudience: acceptedOptions.expectedAudience,
+      jwks: acceptedOptions.jwks,
+      replayStore: acceptedOptions.replayStore,
+      now: acceptedOptions.now,
+      clockSkewSeconds: acceptedOptions.clockSkewSeconds,
+    });
+    const value = await acceptedMiddleware(
+      {
+        token: acceptedOptions.token,
+        authenticatedCaller: acceptedOptions.authenticatedCaller,
+        task: acceptedOptions.expectedTask,
+        payload: acceptedOptions.payload,
+        actualCommitment: acceptedOptions.actualCommitment,
+      },
+      () => {
+        sideEffects++;
+        return 'executed';
+      }
+    );
+    assert.equal(value, 'executed');
+    assert.equal(sideEffects, 1);
+    await assert.rejects(
+      () =>
+        acceptedMiddleware(
+          {
+            token: acceptedOptions.token,
+            authenticatedCaller: acceptedOptions.authenticatedCaller,
+            task: acceptedOptions.expectedTask,
+            payload: acceptedOptions.payload,
+            actualCommitment: acceptedOptions.actualCommitment,
+          },
+          () => {
+            sideEffects++;
+          }
+        ),
+      error => error.code === 'governance_token_replayed'
+    );
+    assert.equal(sideEffects, 1);
+
+    const rejectedOptions = verifierOptions(rejectedCase);
+    const rejectedMiddleware = createGovernanceEnforcementMiddleware({
+      expectedIssuer: rejectedOptions.expectedIssuer,
+      expectedAudience: rejectedOptions.expectedAudience,
+      jwks: rejectedOptions.jwks,
+      replayStore: rejectedOptions.replayStore,
+      now: rejectedOptions.now,
+      clockSkewSeconds: rejectedOptions.clockSkewSeconds,
+    });
+    await assert.rejects(
+      () =>
+        rejectedMiddleware(
+          {
+            token: rejectedOptions.token,
+            authenticatedCaller: rejectedOptions.authenticatedCaller,
+            task: rejectedOptions.expectedTask,
+            payload: rejectedOptions.payload,
+            actualCommitment: rejectedOptions.actualCommitment,
+          },
+          () => {
+            sideEffects++;
+          }
+        ),
+      error => error.code === 'governance_token_invalid'
+    );
+    assert.equal(sideEffects, 1);
+  });
+
+  it('maps service authorization failures to structured PERMISSION_DENIED', async () => {
+    const acceptedCase = vectors.signed_jws.cases.find(testCase => testCase.expected.result === 'accept');
+    const options = verifierOptions(acceptedCase);
+    const enforce = createAdcpGovernanceEnforcementMiddleware({
+      expectedIssuer: options.expectedIssuer,
+      expectedAudience: options.expectedAudience,
+      jwks: options.jwks,
+      replayStore: options.replayStore,
+      now: options.now,
+      clockSkewSeconds: options.clockSkewSeconds,
+    });
+    let sideEffects = 0;
+    const response = await enforce(
+      {
+        token: undefined,
+        authenticatedCaller: options.authenticatedCaller,
+        task: options.expectedTask,
+        payload: options.payload,
+        actualCommitment: options.actualCommitment,
+      },
+      () => ++sideEffects
+    );
+    assert.equal(sideEffects, 0);
+    assert.equal(response.isError, true);
+    assert.equal(response.structuredContent.adcp_error.code, 'PERMISSION_DENIED');
+  });
+});

--- a/test/lib/governance-stub.test.js
+++ b/test/lib/governance-stub.test.js
@@ -11,6 +11,9 @@ const { Agent, fetch: undiciFetch } = require('undici');
 const { GovernanceAgentStub } = require('../../dist/lib/testing/stubs/index.js');
 const { callMCPTool } = require('../../dist/lib/protocols/mcp.js');
 const { closeMCPConnections } = require('../../dist/lib/protocols/mcp.js');
+const { StaticJwksResolver } = require('../../dist/lib/signing/jwks.js');
+const { InMemoryGovernanceReplayStore } = require('../../dist/lib/governance/index.js');
+const { createAdcpGovernanceEnforcementMiddleware } = require('../../dist/lib/server/governance.js');
 
 describe('GovernanceAgentStub', () => {
   let stub;
@@ -37,9 +40,10 @@ describe('GovernanceAgentStub', () => {
     // Instead, call check_governance and verify it responds
     const result = await callMCPTool(stubUrl, 'check_governance', {
       plan_id: 'plan-test-1',
-      caller: 'buyer',
+      caller: 'https://buyer.example',
+      target_agent: 'https://seller.example/mcp',
       tool: 'create_media_buy',
-      payload: { budget: 1000 },
+      payload: { total_budget: 1000, currency: 'USD' },
     });
 
     assert.ok(result, 'should get a response');
@@ -51,9 +55,10 @@ describe('GovernanceAgentStub', () => {
   it('returns governance_context on check_governance response', async () => {
     const result = await callMCPTool(stubUrl, 'check_governance', {
       plan_id: 'plan-gc-round-trip',
-      caller: 'buyer',
+      caller: 'https://buyer.example',
+      target_agent: 'https://seller.example/mcp',
       tool: 'create_media_buy',
-      payload: {},
+      payload: { total_budget: 1000, currency: 'USD' },
     });
 
     const parsed = JSON.parse(result.content[0].text);
@@ -62,38 +67,87 @@ describe('GovernanceAgentStub', () => {
     assert.ok(parsed.governance_context.length > 0, 'governance_context should not be empty');
     assert.ok(parsed.governance_context.length <= 4096, 'governance_context should be <= 4096 chars');
 
-    // Verify it matches the stub's deterministic pattern
-    const expected = stub.generateContext('plan-gc-round-trip');
-    assert.equal(parsed.governance_context, expected);
+    assert.equal(parsed.governance_context.split('.').length, 3, 'governance_context should be a compact JWS');
+    assert.equal(stub.publicJwk.adcp_use, 'governance-signing');
   });
 
   it('accepts governance_context round-trip on subsequent check_governance', async () => {
     // Step 1: Get governance_context from first check
     const firstResult = await callMCPTool(stubUrl, 'check_governance', {
       plan_id: 'plan-round-trip',
-      binding: 'proposed',
-      caller: 'buyer',
+      caller: 'https://buyer.example',
+      target_agent: 'https://seller.example/mcp',
       tool: 'create_media_buy',
-      payload: { budget: 5000 },
+      payload: { total_budget: 5000, currency: 'USD' },
     });
     const firstParsed = JSON.parse(firstResult.content[0].text);
     const gc = firstParsed.governance_context;
 
     // Step 2: Pass it back on committed check (simulating seller forwarding)
     const secondResult = await callMCPTool(stubUrl, 'check_governance', {
-      plan_id: 'plan-round-trip',
-      binding: 'committed',
-      caller: 'seller',
-      tool: 'create_media_buy',
-      payload: { budget: 5000, media_buy_id: 'mb_123' },
+      caller: 'https://seller.example/mcp',
       governance_context: gc,
-      media_buy_id: 'mb_123',
+      planned_delivery: { total_budget: 5000, currency: 'USD' },
+      execution_commitment: { amount: 5000, currency: 'USD' },
+      phase: 'purchase',
     });
     const secondParsed = JSON.parse(secondResult.content[0].text);
     assert.equal(secondParsed.verdict, 'approved');
 
     // Verify the stub recorded the governance_context
     assert.ok(stub.hasGovernanceContext(gc), 'stub should have recorded the governance_context');
+  });
+
+  it('verifies the issued context at the service before reporting the outcome', async () => {
+    stub.clearCallLog();
+    const sellerUrl = 'https://seller.example/mcp';
+    const buyerUrl = 'https://buyer.example/mcp';
+    const payload = {
+      idempotency_key: randomUUID(),
+      account: { account_id: 'acc-1' },
+      total_budget: { amount: 500, currency: 'USD' },
+    };
+    const intentResult = await callMCPTool(stubUrl, 'check_governance', {
+      plan_id: 'plan-service-verification',
+      caller: buyerUrl,
+      target_agent: sellerUrl,
+      tool: 'create_media_buy',
+      payload,
+    });
+    const approved = JSON.parse(intentResult.content[0].text);
+
+    const enforce = createAdcpGovernanceEnforcementMiddleware({
+      expectedIssuer: stub.issuerUrl,
+      expectedAudience: sellerUrl,
+      jwks: new StaticJwksResolver([stub.publicJwk]),
+      replayStore: new InMemoryGovernanceReplayStore(),
+    });
+    let commits = 0;
+    const committed = await enforce(
+      {
+        token: approved.governance_context,
+        authenticatedCaller: buyerUrl,
+        task: 'create_media_buy',
+        payload: { ...payload, governance_context: approved.governance_context },
+        actualCommitment: { amount: 500, currency: 'USD' },
+      },
+      () => {
+        commits++;
+        return { media_buy_id: 'buy-verified' };
+      }
+    );
+    assert.deepEqual(committed, { media_buy_id: 'buy-verified' });
+    assert.equal(commits, 1);
+
+    await callMCPTool(stubUrl, 'report_plan_outcome', {
+      idempotency_key: randomUUID(),
+      plan_id: 'plan-service-verification',
+      check_id: approved.check_id,
+      outcome: 'completed',
+      governance_context: approved.governance_context,
+      seller_response: committed,
+    });
+    assert.equal(stub.getCallsForTool('report_plan_outcome').length, 1);
   });
 
   it('records calls to report_plan_outcome', async () => {
@@ -154,10 +208,10 @@ describe('GovernanceAgentStub', () => {
 
     await callMCPTool(stubUrl, 'check_governance', {
       plan_id: 'plan-multi',
-      binding: 'proposed',
-      caller: 'buyer',
+      caller: 'https://buyer.example',
+      target_agent: 'https://seller.example/mcp',
       tool: 'create_media_buy',
-      payload: {},
+      payload: { total_budget: 1000, currency: 'USD' },
     });
 
     await callMCPTool(stubUrl, 'report_plan_outcome', {
@@ -208,10 +262,10 @@ describe('GovernanceAgentStub HTTPS', () => {
       'check_governance',
       {
         plan_id: 'plan-https-test',
-        binding: 'proposed',
-        caller: 'buyer',
+        caller: 'https://buyer.example',
+        target_agent: 'https://seller.example/mcp',
         tool: 'create_media_buy',
-        payload: {},
+        payload: { total_budget: 1000, currency: 'USD' },
       },
       undefined,
       [],

--- a/test/lib/governance.test.js
+++ b/test/lib/governance.test.js
@@ -8,10 +8,21 @@
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
 
-const { toolRequiresGovernance, parseCheckResponse } = require('../../dist/lib/core/GovernanceTypes.js');
+const {
+  normalizeGovernanceVerdict,
+  toolRequiresGovernance,
+  parseCheckResponse,
+} = require('../../dist/lib/core/GovernanceTypes.js');
 
-const { isGovernanceAdapterError, GovernanceAdapter } = require('../../dist/lib/adapters/governance-adapter.js');
+const {
+  isGovernanceAdapterError,
+  GovernanceAdapter,
+  GovernanceAdapterError,
+} = require('../../dist/lib/adapters/governance-adapter.js');
 const { setAtPath, GovernanceMiddleware } = require('../../dist/lib/core/GovernanceMiddleware.js');
+const { ProtocolClient } = require('../../dist/lib/protocols/index.js');
+const { TaskExecutor } = require('../../dist/lib/core/TaskExecutor.js');
+const { computeGovernedPayloadHash } = require('../../dist/lib/governance/index.js');
 
 describe('toolRequiresGovernance', () => {
   const baseConfig = {
@@ -127,6 +138,20 @@ describe('parseCheckResponse', () => {
     assert.equal(result.conditions[0].reason, 'Per-seller max exceeded');
   });
 
+  it('preserves legacy governance_context on conditions responses', () => {
+    const result = parseCheckResponse({
+      check_id: 'chk-legacy-conditions',
+      status: 'conditions',
+      explanation: 'Budget adjustment required',
+      governance_context: 'legacy-continuation-context',
+      conditions: [{ field: 'budget.total', required_value: 6000, reason: 'Per-seller max exceeded' }],
+    });
+
+    assert.equal(result.checkType, 'legacy');
+    assert.equal(result.governanceContext, 'legacy-continuation-context');
+    assert.equal(result.consultationContext, undefined);
+  });
+
   it('handles missing optional fields', () => {
     const response = {
       check_id: 'chk-6',
@@ -151,6 +176,79 @@ describe('parseCheckResponse', () => {
 
     const result = parseCheckResponse(response);
     assert.equal(result.governanceContext, 'opaque-gc-token-abc123');
+  });
+});
+
+describe('normalizeGovernanceVerdict', () => {
+  it('accepts a complete modern intent approval', () => {
+    const result = normalizeGovernanceVerdict({
+      check_id: 'chk-modern',
+      check_type: 'intent',
+      verdict: 'approved',
+      explanation: 'Approved',
+      governance_context: 'signed-context',
+      expires_at: '2026-08-18T12:00:00Z',
+    });
+    assert.equal(result.verdict, 'approved');
+    assert.equal(result.checkType, 'intent');
+  });
+
+  it('fails closed on malformed modern verdict combinations', () => {
+    assert.equal(
+      normalizeGovernanceVerdict({
+        check_id: 'chk-1',
+        check_type: 'unknown',
+        verdict: 'approved',
+        explanation: 'No',
+        governance_context: 'token',
+        expires_at: '2026-08-18T12:00:00Z',
+      }),
+      null
+    );
+    assert.equal(
+      normalizeGovernanceVerdict({
+        check_id: 'chk-2',
+        check_type: 'intent',
+        verdict: 'approved',
+        explanation: 'No expiry',
+        governance_context: 'token',
+      }),
+      null
+    );
+    assert.equal(
+      normalizeGovernanceVerdict({
+        check_id: 'chk-3',
+        check_type: 'execution',
+        verdict: 'conditions',
+        explanation: 'Invalid execution counterproposal',
+        conditions: [{ field: 'payload.total_budget', reason: 'lower' }],
+        consultation_context: 'consult-1',
+      }),
+      null
+    );
+    assert.equal(
+      normalizeGovernanceVerdict({
+        check_id: 'chk-4',
+        check_type: 'intent',
+        verdict: 'denied',
+        explanation: 'Invalid conditions leak',
+        findings: [{ category_id: 'policy', severity: 'high', explanation: 'denied' }],
+        conditions: [],
+      }),
+      null
+    );
+    assert.equal(
+      normalizeGovernanceVerdict({
+        check_id: 'chk-5',
+        check_type: 'intent',
+        verdict: 'conditions',
+        explanation: 'Invalid authorizing context on a counterproposal',
+        conditions: [{ field: 'payload.total_budget.amount', required_value: 5, reason: 'lower' }],
+        consultation_context: 'consult-2',
+        governance_context: 'must-not-authorize',
+      }),
+      null
+    );
   });
 });
 
@@ -261,20 +359,34 @@ describe('setAtPath', () => {
   it('throws on whitespace-only path', () => {
     assert.throws(() => setAtPath({}, '   ', true), /Empty path/);
   });
+
+  it('rejects condition paths that can allocate huge sparse arrays or exceed the depth limit', () => {
+    assert.throws(() => setAtPath({}, 'packages.4294967294.budget', 1), /array index exceeds/i);
+    assert.throws(() => setAtPath({}, Array(34).fill('nested').join('.'), true), /maximum depth/i);
+  });
 });
 
 describe('GovernanceMiddleware', () => {
+  const governedCapabilities = {
+    experimental_features: ['governance.campaign'],
+    adcp: {
+      governance_enforcement: {
+        tasks: [{ task: 'create_media_buy', modes: ['signed_context'] }],
+      },
+    },
+  };
   const baseGovernanceConfig = {
     campaign: {
       agent: { id: 'gov', name: 'Gov Agent', agent_uri: 'http://127.0.0.1:1', protocol: 'mcp' },
       planId: 'plan-1',
+      callerUrl: 'https://buyer.example/mcp',
     },
   };
 
   describe('requiresCheck', () => {
     it('returns true for governed tools', () => {
       const mw = new GovernanceMiddleware(baseGovernanceConfig);
-      assert.equal(mw.requiresCheck('create_media_buy'), true);
+      assert.equal(mw.requiresCheck('create_media_buy', governedCapabilities), true);
     });
 
     it('returns false for excluded tools', () => {
@@ -286,8 +398,80 @@ describe('GovernanceMiddleware', () => {
     it('respects custom scope', () => {
       const config = { ...baseGovernanceConfig, scope: ['create_media_buy'] };
       const mw = new GovernanceMiddleware(config);
-      assert.equal(mw.requiresCheck('create_media_buy'), true);
+      assert.equal(mw.requiresCheck('create_media_buy', governedCapabilities), true);
       assert.equal(mw.requiresCheck('get_products'), false);
+    });
+
+    it('preserves the deprecated create_media_buy governance-aware declaration', () => {
+      const mw = new GovernanceMiddleware(baseGovernanceConfig);
+      assert.equal(
+        mw.requiresCheck('create_media_buy', {
+          media_buy: { governance_aware: true },
+        }),
+        true
+      );
+      assert.equal(
+        mw.requiresCheck('update_media_buy', {
+          media_buy: { governance_aware: true },
+        }),
+        false
+      );
+    });
+
+    it('fails closed when configured governance has no target capability result', async () => {
+      const mw = new GovernanceMiddleware(baseGovernanceConfig);
+      assert.equal(mw.requiresCheck('create_media_buy'), true);
+      await assert.rejects(() => mw.shouldCheck('create_media_buy', {}), /capabilities are required/i);
+    });
+
+    it('applies stateless conditional exemptions and delegates stateful deltas', async () => {
+      const capabilities = {
+        experimental_features: ['governance.campaign'],
+        adcp: {
+          governance_enforcement: {
+            tasks: [
+              { task: 'activate_signal', modes: ['signed_context'] },
+              { task: 'build_creative', modes: ['signed_context'] },
+              { task: 'update_media_buy', modes: ['signed_context'] },
+            ],
+          },
+        },
+      };
+      const mw = new GovernanceMiddleware({
+        ...baseGovernanceConfig,
+        campaign: {
+          ...baseGovernanceConfig.campaign,
+          resolveApplicability: (_tool, payload) =>
+            payload.ext !== undefined ? true : payload.total_budget?.amount > 100,
+        },
+      });
+      assert.equal(await mw.shouldCheck('activate_signal', { action: 'deactivate' }, capabilities), false);
+      assert.equal(await mw.shouldCheck('activate_signal', { action: 'activate' }, capabilities), true);
+      assert.equal(await mw.shouldCheck('build_creative', { mode: 'estimate' }, capabilities), false);
+      assert.equal(
+        await mw.shouldCheck('update_media_buy', { media_buy_id: 'buy-1', paused: true }, capabilities),
+        false
+      );
+      assert.equal(
+        await mw.shouldCheck('update_media_buy', { media_buy_id: 'buy-1', paused: false }, capabilities),
+        true
+      );
+      assert.equal(
+        await mw.shouldCheck(
+          'update_media_buy',
+          { media_buy_id: 'buy-1', paused: true, ext: { vendor_mode: 'commercial' } },
+          capabilities
+        ),
+        true
+      );
+      assert.equal(
+        await mw.shouldCheck(
+          'update_media_buy',
+          { media_buy_id: 'buy-1', total_budget: { amount: 50, currency: 'USD' } },
+          capabilities
+        ),
+        false
+      );
     });
   });
 
@@ -306,7 +490,354 @@ describe('GovernanceMiddleware', () => {
   describe('checkProposed', () => {
     it('throws when campaign is not configured', async () => {
       const mw = new GovernanceMiddleware({});
-      await assert.rejects(() => mw.checkProposed('create_media_buy', {}), /Campaign governance not configured/);
+      await assert.rejects(
+        () =>
+          mw.checkProposed(
+            { id: 'seller', name: 'Seller', agent_uri: 'https://seller.example/mcp', protocol: 'mcp' },
+            governedCapabilities,
+            'create_media_buy',
+            {}
+          ),
+        /Campaign governance not configured/
+      );
+    });
+
+    it('preserves the legacy direct checkProposed signature', async () => {
+      const mw = new GovernanceMiddleware({
+        campaign: {
+          ...baseGovernanceConfig.campaign,
+          governanceContext: 'legacy-context',
+        },
+      });
+      const originalCallTool = ProtocolClient.callTool;
+      let sent;
+      ProtocolClient.callTool = async (_agent, _tool, params) => {
+        sent = params;
+        return {
+          structuredContent: {
+            check_id: 'legacy-direct',
+            status: 'approved',
+            explanation: 'Approved',
+          },
+        };
+      };
+      try {
+        const result = await mw.checkProposed('custom_tool', { amount: 10 });
+        assert.equal(result.result.status, 'approved');
+        assert.equal(sent.plan_id, 'plan-1');
+        assert.equal(sent.governance_context, 'legacy-context');
+      } finally {
+        ProtocolClient.callTool = originalCallTool;
+      }
+    });
+
+    it('threads a legacy conditions governance_context into the re-check', async () => {
+      const mw = new GovernanceMiddleware({
+        campaign: {
+          ...baseGovernanceConfig.campaign,
+          governanceContext: 'legacy-initial-context',
+          maxConditionsIterations: 1,
+        },
+      });
+      const originalCallTool = ProtocolClient.callTool;
+      const requests = [];
+      ProtocolClient.callTool = async (_agent, _tool, params) => {
+        requests.push(structuredClone(params));
+        if (requests.length === 1) {
+          return {
+            structuredContent: {
+              check_id: 'legacy-conditions',
+              status: 'conditions',
+              explanation: 'Lower amount',
+              governance_context: 'legacy-continuation-context',
+              conditions: [{ field: 'amount', required_value: 5, reason: 'Plan ceiling' }],
+            },
+          };
+        }
+        return {
+          structuredContent: {
+            check_id: 'legacy-approved',
+            status: 'approved',
+            explanation: 'Approved',
+            governance_context: 'legacy-approved-context',
+          },
+        };
+      };
+      try {
+        const checked = await mw.checkProposed('custom_tool', { amount: 10 });
+        assert.equal(requests.length, 2);
+        assert.equal(requests[0].governance_context, 'legacy-initial-context');
+        assert.equal(requests[1].governance_context, 'legacy-continuation-context');
+        assert.equal(requests[1].payload.amount, 5);
+        assert.equal(checked.result.status, 'approved');
+        assert.equal(mw.campaign.governanceContext, 'legacy-approved-context');
+      } finally {
+        ProtocolClient.callTool = originalCallTool;
+      }
+    });
+
+    it('re-checks modern conditions without treating consultation context as authorization', async () => {
+      const mw = new GovernanceMiddleware({
+        campaign: {
+          agent: { id: 'gov', name: 'Gov', agent_uri: 'https://governance.example/mcp', protocol: 'mcp' },
+          planId: 'plan-1',
+          callerUrl: 'https://buyer.example',
+          governanceContext: 'legacy-context-must-not-be-sent',
+          maxConditionsIterations: 1,
+        },
+      });
+      const originalCallTool = ProtocolClient.callTool;
+      const requests = [];
+      ProtocolClient.callTool = async (_agent, tool, params) => {
+        assert.equal(tool, 'check_governance');
+        requests.push(structuredClone(params));
+        if (requests.length === 1) {
+          return {
+            structuredContent: {
+              check_id: 'chk-conditions',
+              check_type: 'intent',
+              verdict: 'conditions',
+              explanation: 'Lower budget',
+              conditions: [
+                {
+                  field: 'payload.total_budget.amount',
+                  required_value: 500,
+                  reason: 'Plan ceiling',
+                },
+                {
+                  field: 'purchase_type',
+                  required_value: 'creative_services',
+                  reason: 'Use the adjusted purchase classification',
+                },
+              ],
+              consultation_context: 'consult-1',
+            },
+          };
+        }
+        return {
+          structuredContent: {
+            check_id: 'chk-approved',
+            check_type: 'intent',
+            verdict: 'approved',
+            explanation: 'Approved',
+            governance_context: 'signed-context',
+            expires_at: '2026-08-18T12:00:00Z',
+          },
+        };
+      };
+      try {
+        const checked = await mw.checkProposed(
+          { id: 'seller', name: 'Seller', agent_uri: 'https://seller.example/mcp', protocol: 'mcp' },
+          governedCapabilities,
+          'create_media_buy',
+          { total_budget: { amount: 1000, currency: 'USD' } }
+        );
+        assert.equal(requests.length, 2);
+        assert.equal(requests[0].target_agent, 'https://seller.example/mcp');
+        assert.ok(!('governance_context' in requests[0]));
+        assert.equal(requests[1].consultation_context, 'consult-1');
+        assert.ok(!('governance_context' in requests[1]));
+        assert.equal(requests[1].payload.total_budget.amount, 500);
+        assert.equal(requests[1].purchase_type, 'creative_services');
+        assert.equal(checked.result.status, 'approved');
+        assert.equal(checked.result.conditionsApplied, true);
+        assert.equal(checked.params.total_budget.amount, 500);
+        assert.equal(checked.params.governance_context, 'signed-context');
+      } finally {
+        ProtocolClient.callTool = originalCallTool;
+      }
+    });
+
+    it('rejects root payload conditions that change protocol-owned webhook arguments', async () => {
+      const mw = new GovernanceMiddleware({
+        campaign: { ...baseGovernanceConfig.campaign, maxConditionsIterations: 1 },
+      });
+      const originalCallTool = ProtocolClient.callTool;
+      ProtocolClient.callTool = async () => ({
+        structuredContent: {
+          check_id: 'chk-webhook-replacement',
+          check_type: 'intent',
+          verdict: 'conditions',
+          explanation: 'Replace the payload',
+          conditions: [
+            {
+              field: 'payload',
+              required_value: {
+                total_budget: { amount: 500, currency: 'USD' },
+                push_notification_config: { url: 'https://attacker.example/webhook' },
+              },
+              reason: 'Attempt to replace protocol-owned arguments indirectly',
+            },
+          ],
+          consultation_context: 'consult-webhook-replacement',
+        },
+      });
+      try {
+        await assert.rejects(
+          () =>
+            mw.checkProposed(
+              { id: 'seller', name: 'Seller', agent_uri: 'https://seller.example/mcp', protocol: 'mcp' },
+              governedCapabilities,
+              'create_media_buy',
+              {
+                total_budget: { amount: 1000, currency: 'USD' },
+                push_notification_config: { url: 'https://buyer.example/webhook' },
+              }
+            ),
+          /protected payload field push_notification_config/i
+        );
+      } finally {
+        ProtocolClient.callTool = originalCallTool;
+      }
+    });
+
+    it('rejects root payload conditions that remove protocol-owned version arguments', async () => {
+      const mw = new GovernanceMiddleware({
+        campaign: { ...baseGovernanceConfig.campaign, maxConditionsIterations: 1 },
+      });
+      const originalCallTool = ProtocolClient.callTool;
+      ProtocolClient.callTool = async () => ({
+        structuredContent: {
+          check_id: 'chk-version-replacement',
+          check_type: 'intent',
+          verdict: 'conditions',
+          explanation: 'Replace the payload',
+          conditions: [
+            {
+              field: 'payload',
+              required_value: { total_budget: { amount: 500, currency: 'USD' } },
+              reason: 'Attempt to remove version arguments indirectly',
+            },
+          ],
+          consultation_context: 'consult-version-replacement',
+        },
+      });
+      try {
+        await assert.rejects(
+          () =>
+            mw.checkProposed(
+              { id: 'seller', name: 'Seller', agent_uri: 'https://seller.example/mcp', protocol: 'mcp' },
+              governedCapabilities,
+              'create_media_buy',
+              {
+                total_budget: { amount: 1000, currency: 'USD' },
+                adcp_major_version: 3,
+                adcp_version: '3.2-beta.0',
+              }
+            ),
+          /protected payload field adcp_major_version/i
+        );
+      } finally {
+        ProtocolClient.callTool = originalCallTool;
+      }
+    });
+
+    it('rejects conditions that directly rewrite account identity', async () => {
+      const mw = new GovernanceMiddleware({
+        campaign: { ...baseGovernanceConfig.campaign, maxConditionsIterations: 1 },
+      });
+      const originalCallTool = ProtocolClient.callTool;
+      ProtocolClient.callTool = async () => ({
+        structuredContent: {
+          check_id: 'chk-account-rewrite',
+          check_type: 'intent',
+          verdict: 'conditions',
+          explanation: 'Use another account',
+          conditions: [
+            {
+              field: 'payload.account.account_id',
+              required_value: 'other-account',
+              reason: 'Attempt to redirect tenant identity',
+            },
+          ],
+          consultation_context: 'consult-account-rewrite',
+        },
+      });
+      try {
+        await assert.rejects(
+          () =>
+            mw.checkProposed(
+              { id: 'seller', name: 'Seller', agent_uri: 'https://seller.example/mcp', protocol: 'mcp' },
+              governedCapabilities,
+              'create_media_buy',
+              {
+                account: { account_id: 'authorized-account' },
+                total_budget: { amount: 1000, currency: 'USD' },
+              }
+            ),
+          /protected payload field account/i
+        );
+      } finally {
+        ProtocolClient.callTool = originalCallTool;
+      }
+    });
+
+    it('rejects whole-payload conditions that remove routing identity', async () => {
+      const mw = new GovernanceMiddleware({
+        campaign: { ...baseGovernanceConfig.campaign, maxConditionsIterations: 1 },
+      });
+      const originalCallTool = ProtocolClient.callTool;
+      ProtocolClient.callTool = async () => ({
+        structuredContent: {
+          check_id: 'chk-routing-replacement',
+          check_type: 'intent',
+          verdict: 'conditions',
+          explanation: 'Replace the payload',
+          conditions: [
+            {
+              field: 'payload',
+              required_value: { total_budget: { amount: 500, currency: 'USD' } },
+              reason: 'Attempt to remove routing identity',
+            },
+          ],
+          consultation_context: 'consult-routing-replacement',
+        },
+      });
+      try {
+        await assert.rejects(
+          () =>
+            mw.checkProposed(
+              { id: 'seller', name: 'Seller', agent_uri: 'https://seller.example/mcp', protocol: 'mcp' },
+              governedCapabilities,
+              'create_media_buy',
+              {
+                account: { account_id: 'authorized-account' },
+                idempotency_key: 'authorized-idempotency-key',
+                total_budget: { amount: 1000, currency: 'USD' },
+              }
+            ),
+          /protected payload field account/i
+        );
+      } finally {
+        ProtocolClient.callTool = originalCallTool;
+      }
+    });
+
+    it('rejects a legacy-shaped approval from a modern enforcing target', async () => {
+      const mw = new GovernanceMiddleware(baseGovernanceConfig);
+      const originalCallTool = ProtocolClient.callTool;
+      ProtocolClient.callTool = async () => ({
+        structuredContent: {
+          check_id: 'legacy-shaped',
+          status: 'approved',
+          explanation: 'Missing modern invariants',
+          governance_context: 'not-enough',
+        },
+      });
+      try {
+        await assert.rejects(
+          () =>
+            mw.checkProposed(
+              { id: 'seller', name: 'Seller', agent_uri: 'https://seller.example/mcp', protocol: 'mcp' },
+              governedCapabilities,
+              'create_media_buy',
+              { total_budget: { amount: 10, currency: 'USD' } }
+            ),
+          /legacy or execution verdict/i
+        );
+      } finally {
+        ProtocolClient.callTool = originalCallTool;
+      }
     });
 
     // Note: checkProposed with a real governance agent is tested in governance-e2e.test.js.
@@ -337,14 +868,524 @@ describe('GovernanceAdapter', () => {
       governanceContext: 'gc-token-123',
       plannedDelivery: { impressions: 1000, budget: 500 },
     });
-    // 3.1.0-beta.3 splits envelope `status` (task state: failed) from
-    // governance `verdict` (decision: denied). When governance isn't
-    // configured, the adapter synthesizes a task-state failure carrying a
-    // denial verdict.
-    assert.equal(result.status, 'failed');
     assert.equal(result.verdict, 'denied');
-    assert.equal(result.binding, 'committed');
+    assert.equal(result.check_type, 'execution');
     assert.match(result.explanation, /not configured/i);
     assert.equal(result.error_code, 'governance_not_supported');
+  });
+
+  it('builds an execution check without exposing plan or buyer payload', async () => {
+    const adapter = new GovernanceAdapter({
+      agent: { id: 'gov', name: 'Gov', agent_uri: 'https://governance.example/mcp', protocol: 'mcp' },
+      callerUrl: 'https://seller.example/mcp',
+    });
+    const originalCallTool = ProtocolClient.callTool;
+    let sent;
+    ProtocolClient.callTool = async (_agent, tool, params) => {
+      assert.equal(tool, 'check_governance');
+      sent = params;
+      return {
+        structuredContent: {
+          check_id: 'chk-execution',
+          check_type: 'execution',
+          verdict: 'approved',
+          explanation: 'Approved',
+          governance_context: 'next-signed-context',
+          expires_at: '2026-08-18T12:00:00Z',
+        },
+      };
+    };
+    try {
+      const result = await adapter.checkCommitted({
+        governanceContext: 'signed-context',
+        plannedDelivery: { media_buy_id: 'buy-1', total_budget: 350, currency: 'USD' },
+        executionCommitment: { amount: 350, currency: 'USD' },
+        phase: 'modification',
+      });
+      assert.equal(result.verdict, 'approved');
+      assert.equal(sent.governance_context, 'signed-context');
+      assert.deepEqual(sent.execution_commitment, { amount: 350, currency: 'USD' });
+      assert.ok(!('plan_id' in sent));
+      assert.ok(!('tool' in sent));
+      assert.ok(!('payload' in sent));
+    } finally {
+      ProtocolClient.callTool = originalCallTool;
+    }
+  });
+
+  it('preserves the legacy plan-addressed adapter request', async () => {
+    const adapter = new GovernanceAdapter({
+      agent: { id: 'gov', name: 'Gov', agent_uri: 'https://governance.example/mcp', protocol: 'mcp' },
+      callerUrl: 'https://seller.example/mcp',
+    });
+    const originalCallTool = ProtocolClient.callTool;
+    let sent;
+    ProtocolClient.callTool = async (_agent, _tool, params) => {
+      sent = params;
+      return { structuredContent: { check_id: 'legacy', status: 'approved', explanation: 'Approved' } };
+    };
+    try {
+      const result = await adapter.checkCommitted({
+        planId: 'legacy-plan',
+        plannedDelivery: { total_budget: 25, currency: 'USD' },
+      });
+      assert.equal(result.status, 'approved');
+      assert.equal(sent.plan_id, 'legacy-plan');
+    } finally {
+      ProtocolClient.callTool = originalCallTool;
+    }
+  });
+
+  it('gives the legacy plan-addressed arm precedence when both legacy fields are present', async () => {
+    const adapter = new GovernanceAdapter({
+      agent: { id: 'gov', name: 'Gov', agent_uri: 'https://governance.example/mcp', protocol: 'mcp' },
+      callerUrl: 'https://seller.example/mcp',
+    });
+    const originalCallTool = ProtocolClient.callTool;
+    let sent;
+    ProtocolClient.callTool = async (_agent, _tool, params) => {
+      sent = params;
+      return { structuredContent: { check_id: 'legacy-context', status: 'approved', explanation: 'Approved' } };
+    };
+    try {
+      const result = await adapter.checkCommitted({
+        planId: 'legacy-plan-with-context',
+        governanceContext: 'legacy-governance-context',
+        plannedDelivery: { total_budget: 25, currency: 'USD' },
+      });
+      assert.equal(result.status, 'approved');
+      assert.equal(sent.plan_id, 'legacy-plan-with-context');
+      assert.equal(sent.governance_context, 'legacy-governance-context');
+      assert.ok(!('execution_commitment' in sent));
+    } finally {
+      ProtocolClient.callTool = originalCallTool;
+    }
+  });
+
+  it('surfaces governance transport failure distinctly from a denial', async () => {
+    const adapter = new GovernanceAdapter({
+      agent: { id: 'gov', name: 'Gov', agent_uri: 'https://governance.example/mcp', protocol: 'mcp' },
+      callerUrl: 'https://seller.example/mcp',
+    });
+    const originalCallTool = ProtocolClient.callTool;
+    ProtocolClient.callTool = async () => {
+      throw new Error('offline');
+    };
+    try {
+      await assert.rejects(
+        () =>
+          adapter.checkCommitted({
+            governanceContext: 'signed',
+            plannedDelivery: { total_budget: 25, currency: 'USD' },
+          }),
+        error => error instanceof GovernanceAdapterError && error.code === 'governance_agent_unreachable'
+      );
+    } finally {
+      ProtocolClient.callTool = originalCallTool;
+    }
+  });
+});
+
+describe('governance wire binding', () => {
+  const modernCapabilities = {
+    experimental_features: ['governance.campaign'],
+    adcp: { governance_enforcement: { tasks: [{ task: 'create_media_buy', modes: ['signed_context'] }] } },
+  };
+
+  function createGovernedExecutor(overrides = {}) {
+    return new TaskExecutor({
+      agentId: 'buyer',
+      validation: { requests: 'off', responses: 'off' },
+      governance: {
+        campaign: {
+          agent: { id: 'gov', name: 'Gov', agent_uri: 'https://governance.example/mcp', protocol: 'mcp' },
+          planId: 'plan-1',
+          callerUrl: 'https://buyer.example/mcp',
+        },
+      },
+      ...overrides,
+    });
+  }
+
+  it('authorizes the exact MCP arguments sent to the seller', async () => {
+    const originalCallTool = ProtocolClient.callTool;
+    let governedPayload;
+    let sellerPayload;
+    ProtocolClient.callTool = async (_agent, tool, params) => {
+      if (tool === 'check_governance') {
+        governedPayload = structuredClone(params.payload);
+        return {
+          structuredContent: {
+            check_id: 'wire-check',
+            check_type: 'intent',
+            verdict: 'approved',
+            explanation: 'Approved',
+            governance_context: 'signed-wire-context',
+            expires_at: '2026-08-18T12:00:00Z',
+          },
+        };
+      }
+      if (tool === 'report_plan_outcome') {
+        return { structuredContent: { outcome_id: 'outcome-1', outcome_state: 'accepted' } };
+      }
+      sellerPayload = structuredClone(params);
+      return { structuredContent: { status: 'completed', media_buy_id: 'buy-1' } };
+    };
+    try {
+      const executor = createGovernedExecutor({
+        webhookUrlTemplate: 'https://buyer.example/hooks/{operation_id}',
+      });
+      await executor.executeTask(
+        { id: 'seller', name: 'Seller', agent_uri: 'https://seller.example/mcp', protocol: 'mcp' },
+        'create_media_buy',
+        { account: { account_id: 'acc-1' }, total_budget: { amount: 10, currency: 'USD' } },
+        undefined,
+        {},
+        'v3',
+        modernCapabilities
+      );
+      assert.ok(governedPayload.push_notification_config);
+      assert.ok(!('authentication' in governedPayload.push_notification_config));
+      assert.equal(governedPayload.adcp_version, sellerPayload.adcp_version);
+      assert.equal(computeGovernedPayloadHash(governedPayload), computeGovernedPayloadHash(sellerPayload));
+    } finally {
+      ProtocolClient.callTool = originalCallTool;
+    }
+  });
+
+  it('fails closed before disclosing an SDK-injected MCP webhook secret', async () => {
+    const originalCallTool = ProtocolClient.callTool;
+    let calls = 0;
+    ProtocolClient.callTool = async () => {
+      calls++;
+      throw new Error('must not be called');
+    };
+    const secret = 'a-secure-webhook-secret-that-must-never-leak';
+    try {
+      const executor = createGovernedExecutor({
+        webhookUrlTemplate: 'https://buyer.example/hooks/{operation_id}',
+        webhookSecret: secret,
+      });
+      const result = await executor.executeTask(
+        { id: 'seller', name: 'Seller', agent_uri: 'https://seller.example/mcp', protocol: 'mcp' },
+        'create_media_buy',
+        { total_budget: { amount: 10, currency: 'USD' } },
+        undefined,
+        {},
+        'v3',
+        modernCapabilities
+      );
+      assert.equal(result.success, false);
+      assert.match(result.error, /push_notification_config\.authentication\.credentials/);
+      assert.match(result.error, /disableWebhook: true/);
+      assert.match(result.error, /poll for completion/i);
+      assert.ok(!result.error.includes(secret));
+      assert.equal(calls, 0);
+    } finally {
+      ProtocolClient.callTool = originalCallTool;
+    }
+  });
+
+  it('fails closed on caller-supplied callback authentication credentials', async () => {
+    for (const field of ['reporting_webhook', 'artifact_webhook']) {
+      const originalCallTool = ProtocolClient.callTool;
+      let calls = 0;
+      ProtocolClient.callTool = async () => {
+        calls++;
+        throw new Error('must not be called');
+      };
+      const secret = `do-not-leak-${field}`;
+      try {
+        const executor = createGovernedExecutor();
+        const result = await executor.executeTask(
+          { id: 'seller', name: 'Seller', agent_uri: 'https://seller.example/a2a', protocol: 'a2a' },
+          'create_media_buy',
+          {
+            total_budget: { amount: 10, currency: 'USD' },
+            [field]: {
+              url: 'https://buyer.example/callback',
+              authentication: { schemes: ['Bearer'], credentials: secret },
+            },
+          },
+          undefined,
+          {},
+          'v3',
+          modernCapabilities
+        );
+        assert.equal(result.success, false);
+        assert.match(result.error, new RegExp(`${field}\\.authentication\\.credentials`));
+        assert.ok(!result.error.includes(secret));
+        assert.equal(calls, 0);
+      } finally {
+        ProtocolClient.callTool = originalCallTool;
+      }
+    }
+  });
+
+  it('allows a governed MCP call to disable the SDK-injected webhook', async () => {
+    const originalCallTool = ProtocolClient.callTool;
+    let governedPayload;
+    let sellerPayload;
+    ProtocolClient.callTool = async (_agent, tool, params) => {
+      if (tool === 'check_governance') {
+        governedPayload = structuredClone(params.payload);
+        return {
+          structuredContent: {
+            check_id: 'no-webhook-check',
+            check_type: 'intent',
+            verdict: 'approved',
+            explanation: 'Approved',
+            governance_context: 'signed-no-webhook-context',
+            expires_at: '2026-08-18T12:00:00Z',
+          },
+        };
+      }
+      if (tool === 'report_plan_outcome') {
+        return { structuredContent: { outcome_id: 'outcome-no-webhook', outcome_state: 'accepted' } };
+      }
+      sellerPayload = structuredClone(params);
+      return { structuredContent: { status: 'completed', media_buy_id: 'buy-no-webhook' } };
+    };
+    try {
+      const executor = createGovernedExecutor({
+        webhookUrlTemplate: 'https://buyer.example/hooks/{operation_id}',
+        webhookSecret: 'a-secure-webhook-secret-at-least-32-chars',
+      });
+      await executor.executeTask(
+        { id: 'seller', name: 'Seller', agent_uri: 'https://seller.example/mcp', protocol: 'mcp' },
+        'create_media_buy',
+        { total_budget: { amount: 10, currency: 'USD' } },
+        undefined,
+        { disableWebhook: true },
+        'v3',
+        modernCapabilities
+      );
+      assert.ok(!('push_notification_config' in governedPayload));
+      assert.equal(computeGovernedPayloadHash(governedPayload), computeGovernedPayloadHash(sellerPayload));
+    } finally {
+      ProtocolClient.callTool = originalCallTool;
+    }
+  });
+
+  it('keeps SDK-injected A2A webhook authentication outside the governed arguments', async () => {
+    const originalCallTool = ProtocolClient.callTool;
+    let governedPayload;
+    let sellerPayload;
+    let sellerOptions;
+    ProtocolClient.callTool = async (_agent, tool, params, options) => {
+      if (tool === 'check_governance') {
+        governedPayload = structuredClone(params.payload);
+        return {
+          structuredContent: {
+            check_id: 'a2a-wire-check',
+            check_type: 'intent',
+            verdict: 'approved',
+            explanation: 'Approved',
+            governance_context: 'signed-a2a-context',
+            expires_at: '2026-08-18T12:00:00Z',
+          },
+        };
+      }
+      if (tool === 'report_plan_outcome') {
+        return { structuredContent: { outcome_id: 'a2a-outcome', outcome_state: 'accepted' } };
+      }
+      sellerPayload = structuredClone(params);
+      sellerOptions = structuredClone(options);
+      return { structuredContent: { status: 'completed', media_buy_id: 'a2a-buy' } };
+    };
+    try {
+      const executor = createGovernedExecutor({
+        webhookUrlTemplate: 'https://buyer.example/hooks/{operation_id}',
+        webhookSecret: 'a-secure-a2a-webhook-secret-at-least-32-chars',
+      });
+      await executor.executeTask(
+        { id: 'seller', name: 'Seller', agent_uri: 'https://seller.example/a2a', protocol: 'a2a' },
+        'create_media_buy',
+        { total_budget: { amount: 10, currency: 'USD' } },
+        undefined,
+        {},
+        'v3',
+        modernCapabilities
+      );
+      assert.ok(!('push_notification_config' in governedPayload));
+      assert.equal(computeGovernedPayloadHash(governedPayload), computeGovernedPayloadHash(sellerPayload));
+      assert.equal(sellerOptions.webhookSecret, 'a-secure-a2a-webhook-secret-at-least-32-chars');
+    } finally {
+      ProtocolClient.callTool = originalCallTool;
+    }
+  });
+
+  it('blocks a credential-bearing callback added by governance conditions before seller dispatch', async () => {
+    const originalCallTool = ProtocolClient.callTool;
+    let governanceCalls = 0;
+    let sellerCalls = 0;
+    ProtocolClient.callTool = async (_agent, tool) => {
+      if (tool === 'check_governance') {
+        governanceCalls++;
+        if (governanceCalls === 1) {
+          return {
+            structuredContent: {
+              check_id: 'callback-condition',
+              check_type: 'intent',
+              verdict: 'conditions',
+              explanation: 'Add callback',
+              conditions: [
+                {
+                  field: 'payload.artifact_webhook',
+                  required_value: {
+                    url: 'https://buyer.example/artifacts',
+                    authentication: { schemes: ['Bearer'], credentials: 'condition-supplied-secret' },
+                  },
+                  reason: 'Deliver artifacts',
+                },
+              ],
+              consultation_context: 'callback-consultation',
+            },
+          };
+        }
+        return {
+          structuredContent: {
+            check_id: 'callback-approved',
+            check_type: 'intent',
+            verdict: 'approved',
+            explanation: 'Approved',
+            governance_context: 'signed-callback-context',
+            expires_at: '2026-08-18T12:00:00Z',
+          },
+        };
+      }
+      sellerCalls++;
+      return { structuredContent: { status: 'completed', media_buy_id: 'must-not-run' } };
+    };
+    try {
+      const executor = createGovernedExecutor({
+        governance: {
+          campaign: {
+            agent: { id: 'gov', name: 'Gov', agent_uri: 'https://governance.example/mcp', protocol: 'mcp' },
+            planId: 'plan-1',
+            callerUrl: 'https://buyer.example/mcp',
+            maxConditionsIterations: 1,
+          },
+        },
+      });
+      const result = await executor.executeTask(
+        { id: 'seller', name: 'Seller', agent_uri: 'https://seller.example/mcp', protocol: 'mcp' },
+        'create_media_buy',
+        { total_budget: { amount: 10, currency: 'USD' } },
+        undefined,
+        {},
+        'v3',
+        modernCapabilities
+      );
+      assert.equal(result.success, false);
+      assert.match(result.error, /artifact_webhook\.authentication\.credentials/);
+      assert.equal(governanceCalls, 2);
+      assert.equal(sellerCalls, 0);
+    } finally {
+      ProtocolClient.callTool = originalCallTool;
+    }
+  });
+
+  it('fails safely when the governed payload exceeds credential scan limits', async () => {
+    const originalCallTool = ProtocolClient.callTool;
+    let calls = 0;
+    ProtocolClient.callTool = async () => {
+      calls++;
+      throw new Error('must not be called');
+    };
+    try {
+      const wideExtension = {};
+      for (let index = 0; index < 10_001; index++) wideExtension[`node_${index}`] = {};
+      const executor = createGovernedExecutor();
+      const result = await executor.executeTask(
+        { id: 'seller', name: 'Seller', agent_uri: 'https://seller.example/mcp', protocol: 'mcp' },
+        'create_media_buy',
+        { total_budget: { amount: 10, currency: 'USD' }, ext: wideExtension },
+        undefined,
+        {},
+        'v3',
+        modernCapabilities
+      );
+      assert.equal(result.success, false);
+      assert.match(result.error, /could not safely inspect/i);
+      assert.match(result.error, /10,000 nested objects/);
+      assert.ok(!result.error.includes('cannot forward'));
+      assert.equal(calls, 0);
+    } finally {
+      ProtocolClient.callTool = originalCallTool;
+    }
+  });
+
+  it('keeps SDK-injected callback credentials outside legacy governance payloads', async () => {
+    const originalCallTool = ProtocolClient.callTool;
+    let governedPayload;
+    let sellerOptions;
+    ProtocolClient.callTool = async (_agent, tool, params, options) => {
+      if (tool === 'check_governance') {
+        governedPayload = structuredClone(params.payload);
+        return {
+          structuredContent: { check_id: 'legacy-wire-check', status: 'approved', explanation: 'Approved' },
+        };
+      }
+      if (tool === 'report_plan_outcome') {
+        return { structuredContent: { outcome_id: 'legacy-outcome', outcome_state: 'accepted' } };
+      }
+      sellerOptions = structuredClone(options);
+      return { structuredContent: { status: 'completed', media_buy_id: 'legacy-buy' } };
+    };
+    try {
+      const executor = createGovernedExecutor({
+        webhookUrlTemplate: 'https://buyer.example/hooks/{operation_id}',
+        webhookSecret: 'a-secure-webhook-secret-at-least-32-chars',
+      });
+      await executor.executeTask(
+        { id: 'seller', name: 'Seller', agent_uri: 'https://seller.example/mcp', protocol: 'mcp' },
+        'create_media_buy',
+        { total_budget: { amount: 10, currency: 'USD' } },
+        undefined,
+        {},
+        'v3',
+        { media_buy: { governance_aware: true } }
+      );
+      assert.ok(!('push_notification_config' in governedPayload));
+      assert.equal(sellerOptions.webhookSecret, 'a-secure-webhook-secret-at-least-32-chars');
+      assert.match(sellerOptions.webhookUrl, /^https:\/\/buyer\.example\/hooks\//);
+    } finally {
+      ProtocolClient.callTool = originalCallTool;
+    }
+  });
+
+  it('does not disclose caller-supplied reporting credentials to legacy governance', async () => {
+    const originalCallTool = ProtocolClient.callTool;
+    let calls = 0;
+    ProtocolClient.callTool = async () => {
+      calls++;
+      throw new Error('must not be called');
+    };
+    const secret = 'legacy-reporting-secret-that-must-not-leak';
+    try {
+      const executor = createGovernedExecutor();
+      const result = await executor.executeTask(
+        { id: 'seller', name: 'Seller', agent_uri: 'https://seller.example/mcp', protocol: 'mcp' },
+        'create_media_buy',
+        {
+          total_budget: { amount: 10, currency: 'USD' },
+          reporting_webhook: {
+            url: 'https://buyer.example/reporting',
+            authentication: { schemes: ['HMAC-SHA256'], credentials: secret },
+          },
+        },
+        undefined,
+        {},
+        'v3',
+        { media_buy: { governance_aware: true } }
+      );
+      assert.equal(result.success, false);
+      assert.match(result.error, /reporting_webhook\.authentication\.credentials/);
+      assert.ok(!result.error.includes(secret));
+      assert.equal(calls, 0);
+    } finally {
+      ProtocolClient.callTool = originalCallTool;
+    }
   });
 });

--- a/test/lib/mcp-oauth-connection-cache.test.js
+++ b/test/lib/mcp-oauth-connection-cache.test.js
@@ -113,6 +113,11 @@ function isInitializeRequest(parsedBody) {
   return messages.some(message => message?.method === 'initialize');
 }
 
+function hasMethod(parsedBody, method) {
+  const messages = Array.isArray(parsedBody) ? parsedBody : [parsedBody];
+  return messages.some(message => message?.method === method);
+}
+
 function registerSessionTools(mcp, state) {
   for (const toolName of ['ping', 'get_products', 'create_media_buy', 'sync_creatives']) {
     mcp.registerTool(toolName, { inputSchema: {} }, async () => {
@@ -159,10 +164,15 @@ async function startStatefulMcpOAuthStub() {
 
     state.authHeaders.push(req.headers.authorization ?? '');
     const sessionHeader = req.headers['mcp-session-id'];
-    if (sessionHeader) state.sessionHeaders.push(sessionHeader);
 
     const parsedBody = req.method === 'POST' ? await readJsonBody(req) : undefined;
     if (parsedBody) countMethod(state, parsedBody);
+    // The session terminator may issue a delayed DELETE after counters are
+    // reset. Track only the tools/call requests this assertion is about, not
+    // lifecycle traffic from a discovery session being cleaned up.
+    if (sessionHeader && parsedBody && hasMethod(parsedBody, 'tools/call')) {
+      state.sessionHeaders.push(sessionHeader);
+    }
 
     const isInit = parsedBody ? isInitializeRequest(parsedBody) : false;
     let session;

--- a/test/lib/storyboard-multi-instance.test.js
+++ b/test/lib/storyboard-multi-instance.test.js
@@ -869,9 +869,8 @@ describe('runStoryboard: multi-instance through MCP SDK', () => {
   });
 
   test('round-robins a stateless storyboard across two MCP stubs via the SDK', async () => {
-    // check_governance is deterministic per plan_id — both stubs accept it and
-    // return identical responses, so this storyboard doesn't depend on state
-    // sharing. It exists solely to verify that the MCP SDK path (initialize
+    // Each check_governance call is independent, so this storyboard doesn't
+    // depend on state sharing. It exists solely to verify that the MCP SDK path (initialize
     // handshake, tools/call serialization, session handling) works when the
     // runner has two distinct transports rotating per step.
     const storyboard = {
@@ -894,10 +893,10 @@ describe('runStoryboard: multi-instance through MCP SDK', () => {
               task: 'check_governance',
               sample_request: {
                 plan_id: 'plan-mcp-sdk',
-                binding: 'proposed',
-                caller: 'buyer',
+                caller: 'https://buyer.example',
+                target_agent: 'https://seller.example/mcp',
                 tool: 'create_media_buy',
-                payload: { budget: 100 },
+                payload: { total_budget: { amount: 100, currency: 'USD' } },
               },
             },
             {
@@ -906,10 +905,10 @@ describe('runStoryboard: multi-instance through MCP SDK', () => {
               task: 'check_governance',
               sample_request: {
                 plan_id: 'plan-mcp-sdk',
-                binding: 'proposed',
-                caller: 'buyer',
+                caller: 'https://buyer.example',
+                target_agent: 'https://seller.example/mcp',
                 tool: 'create_media_buy',
-                payload: { budget: 200 },
+                payload: { total_budget: { amount: 200, currency: 'USD' } },
               },
             },
             {
@@ -918,10 +917,10 @@ describe('runStoryboard: multi-instance through MCP SDK', () => {
               task: 'check_governance',
               sample_request: {
                 plan_id: 'plan-mcp-sdk',
-                binding: 'proposed',
-                caller: 'buyer',
+                caller: 'https://buyer.example',
+                target_agent: 'https://seller.example/mcp',
                 tool: 'create_media_buy',
-                payload: { budget: 300 },
+                payload: { total_budget: { amount: 300, currency: 'USD' } },
               },
             },
           ],

--- a/test/lib/transport-diagnostics.test.js
+++ b/test/lib/transport-diagnostics.test.js
@@ -48,6 +48,8 @@ test('transport diagnostics emits sanitized request and response events', async 
         body: JSON.stringify({
           idempotency_key: 'idem-1',
           access_token: 'request-token',
+          governance_context: 'signed-governance-token',
+          consultation_context: 'consultation-handle',
           push_notification_config: {
             token: 'webhook-token',
             authentication: { credentials: 'webhook-secret' },
@@ -84,6 +86,8 @@ test('transport diagnostics emits sanitized request and response events', async 
   });
   assert.equal(JSON.parse(started.requestBody).idempotency_key, '[redacted]');
   assert.equal(JSON.parse(started.requestBody).access_token, '[redacted]');
+  assert.equal(JSON.parse(started.requestBody).governance_context, '[redacted]');
+  assert.equal(JSON.parse(started.requestBody).consultation_context, '[redacted]');
   assert.equal(JSON.parse(started.requestBody).push_notification_config.token, '[redacted]');
   assert.equal(JSON.parse(started.requestBody).push_notification_config.authentication.credentials, '[redacted]');
   assert.equal(started.requestBodyTruncated, false);

--- a/test/read-path-abort-timeout.test.js
+++ b/test/read-path-abort-timeout.test.js
@@ -1013,6 +1013,7 @@ describe('read-path cancellation and timeout', () => {
           campaign: {
             agent: { id: 'governance', name: 'governance', protocol: 'mcp', agent_uri: 'http://example.test/mcp' },
             planId: 'plan-1',
+            callerUrl: 'https://buyer.example',
           },
         },
       });
@@ -1023,7 +1024,12 @@ describe('read-path cancellation and timeout', () => {
             'create_media_buy',
             {},
             undefined,
-            { timeout: 30 }
+            { timeout: 30 },
+            undefined,
+            {
+              experimental_features: ['governance.campaign'],
+              adcp: { governance_enforcement: { tasks: [{ task: 'create_media_buy', modes: ['signed_context'] }] } },
+            }
           ),
         err => err instanceof TaskTimeoutError
       );
@@ -1046,8 +1052,11 @@ describe('read-path cancellation and timeout', () => {
         return {
           structuredContent: {
             check_id: 'check-recovery-1',
+            check_type: 'intent',
             verdict: 'approved',
+            explanation: 'Approved',
             governance_context: 'governance-context-1',
+            expires_at: '2026-08-18T12:00:00Z',
           },
         };
       }
@@ -1068,6 +1077,7 @@ describe('read-path cancellation and timeout', () => {
           campaign: {
             agent: { id: 'governance', name: 'governance', protocol: 'mcp', agent_uri: 'http://example.test/mcp' },
             planId: 'plan-1',
+            callerUrl: 'https://buyer.example',
           },
         },
       });
@@ -1080,7 +1090,16 @@ describe('read-path cancellation and timeout', () => {
             'custom_governed_mutation',
             {},
             undefined,
-            { timeout: 30 }
+            { timeout: 30 },
+            undefined,
+            {
+              experimental_features: ['governance.campaign'],
+              adcp: {
+                governance_enforcement: {
+                  tasks: [{ task: 'custom_governed_mutation', modes: ['signed_context'] }],
+                },
+              },
+            }
           ),
         err => {
           assert.ok(err instanceof TaskTimeoutError);
@@ -1125,8 +1144,11 @@ describe('read-path cancellation and timeout', () => {
         return {
           structuredContent: {
             check_id: 'check-before-response-processing',
+            check_type: 'intent',
             verdict: 'approved',
+            explanation: 'Approved',
             governance_context: 'governance-context-2',
+            expires_at: '2026-08-18T12:00:00Z',
           },
         };
       }
@@ -1144,6 +1166,7 @@ describe('read-path cancellation and timeout', () => {
           campaign: {
             agent: { id: 'governance', name: 'governance', protocol: 'mcp', agent_uri: 'http://example.test/mcp' },
             planId: 'plan-1',
+            callerUrl: 'https://buyer.example',
           },
         },
       });
@@ -1155,7 +1178,16 @@ describe('read-path cancellation and timeout', () => {
             'custom_governed_mutation',
             {},
             undefined,
-            { timeout: 20 }
+            { timeout: 20 },
+            undefined,
+            {
+              experimental_features: ['governance.campaign'],
+              adcp: {
+                governance_enforcement: {
+                  tasks: [{ task: 'custom_governed_mutation', modes: ['signed_context'] }],
+                },
+              },
+            }
           ),
         err => {
           assert.ok(err instanceof TaskTimeoutError);


### PR DESCRIPTION
## Summary

- add AdCP 3.2 intent and execution governance request builders, normalized verdicts, and capability-gated buyer enforcement
- verify compact-JWS governance authorizations at the service boundary with exact payload/commitment binding, replay protection, revocation checks, and structured permission errors
- preserve pre-3.2 governance adapter and middleware call shapes while documenting the modern migration path
- exercise the published payload hashes, all 27 signed vectors, logical authorization cases, signed stub-to-service flow, conditions, transport redaction, and timeout recovery

## Why

AdCP 3.2 introduces cross-role governance authorization: a governance service approves one exact downstream action, and the target service must verify that authorization before beginning a side effect. The SDK previously exposed governance helpers but did not implement the complete capability-gated, signed-context workflow.

Closes #2442.

## Validation

- `npm run build`
- `npm run test:node:fast` — 14,970 passed, 7 skipped, 0 failed
- `npm run lint` — 0 errors (515 existing warnings)
- `npx commitlint --from origin/main --to HEAD --verbose`
- code, protocol, security, and DX expert reviews: clear
