### PR TITLE
fix(webhooks): verify registered RFC 9421 callbacks

### DIFF
--- a/.changeset/calm-otters-verify.md
+++ b/.changeset/calm-otters-verify.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': minor
+---
+
+Verify inbound task-status webhooks with the authentication mode selected at registration time. The client now persists secretless callback provenance before seller dispatch, verifies those registrations with RFC 9421 using seller keys resolved through `brand.json`, rejects HMAC/RFC mode substitution, binds signatures to raw bytes and the trusted public callback URL, and provides injectable registration, replay, revocation, and JWKS stores for durable deployments. Legacy HMAC receivers remain compatible and never persist secret-derived material.

--- a/docs/guides/PUSH-NOTIFICATION-CONFIG.md
+++ b/docs/guides/PUSH-NOTIFICATION-CONFIG.md
@@ -4,20 +4,29 @@ Push notification config tells the AdCP agent where to send async task status up
 
 ## How It Works
 
-When you configure a `webhookUrlTemplate` and `webhookSecret` on the client, every outgoing tool call (`create_media_buy`, `update_media_buy`, `sync_creatives`, etc.) will include a `push_notification_config` in the wire payload. The URL is generated per-operation so each task has its own unique webhook endpoint.
+When you configure a `webhookUrlTemplate`, every outgoing tool call (`create_media_buy`, `update_media_buy`, `sync_creatives`, etc.) can include a `push_notification_config`. The URL is generated per operation. Omitting `webhookSecret` selects the current RFC 9421 signature profile; setting it explicitly selects legacy HMAC-SHA256.
 
 ## Client Setup
 
 ```typescript
 const client = new AdCPClient({
   webhookUrlTemplate: 'https://your-app.com/adcp/webhook/{task_type}/{agent_id}/{operation_id}',
-  webhookSecret: 'your-hmac-secret-min-32-characters-here',
 });
 ```
 
 ## Wire Payload
 
-All async operations produce the same `push_notification_config` shape on the wire:
+The default RFC 9421 registration has no `authentication` block:
+
+```json
+{
+  "push_notification_config": {
+    "url": "https://your-app.com/adcp/webhook/create_media_buy/agent_123/cd51e063-2b79-4a6d-afac-ed7789c3a443"
+  }
+}
+```
+
+Setting `webhookSecret` opts into the legacy shape:
 
 ```json
 {
@@ -96,10 +105,34 @@ All async operations produce the same `push_notification_config` shape on the wi
 
 ## Authentication
 
+### RFC 9421 (default)
+
+`SingleAgentClient` records the exact callback URL, seller, protocol, task, and selected authentication mode before dispatch. `verifyAndParseWebhook` then resolves the registered seller's keys through its capabilities → `brand.json` → `agents[].jwks_uri` chain and verifies the RFC 9421 signature, content digest, signature window, revocation, and nonce replay protection.
+
+The receiver must supply exact raw bytes, the trusted route operation ID, HTTP method, and the externally visible absolute URL. Do not derive the public URL from untrusted `Host` or `X-Forwarded-*` headers. Behind a trusted reverse proxy, construct it from server-owned configuration:
+
+```typescript
+app.post(
+  '/adcp/webhook/:task_type/:agent_id/:operation_id',
+  express.raw({ type: 'application/json' }),
+  client.createWebhookHandler({
+    getRequestUrl: req => `https://your-app.com${req.originalUrl}`,
+  }),
+);
+```
+
+The default registration and replay stores are process-local. Production receivers that can restart or run multiple replicas must inject a shared durable `webhookRegistrationStore` and `webhookVerification.replayStore`; registration writes must be atomic create-or-identical, and replay insertion must be atomic across replicas. Retain registrations for at least the seller retry horizon (seven days by default).
+
+For deterministic tests or infrastructure-managed keys, set `webhookVerification.jwks`. Otherwise seller key discovery is automatic and uses an unauthenticated official protocol client for the capabilities step, so credentials configured for one endpoint are never transplanted to the registered callback origin. Sellers whose capability discovery requires authentication should provide an origin-bound `webhookVerification.fetchCapabilities(agentUrl, protocol)` callback or inject `webhookVerification.jwks` directly.
+
+### Legacy HMAC-SHA256
+
 When `webhookSecret` is configured, the legacy webhook authentication path uses `HMAC-SHA256`. The agent signs `${timestamp}.${raw_body_bytes}` with the shared secret and sends:
 
 - `x-adcp-signature: sha256=<hex digest>`
 - `x-adcp-timestamp: <unix seconds>`
+
+HMAC registration provenance never stores the credential or a secret-derived fingerprint. The configured global `webhookSecret` remains the verification key, preserving the established behavior across process restarts and replicas. If the optional registration store is unavailable, HMAC dispatch and verification continue; RFC 9421 dispatch fails closed because seller-pinned provenance is required for safe verification.
 
 Capture the raw request body before JSON parsing and verify it with the SDK helper:
 
@@ -127,7 +160,9 @@ app.post('/adcp/webhook/:task_type/:agent_id/:operation_id', async (req, res) =>
 
 `verifyWebhookRequest` normalizes header casing, rejects missing or ambiguous signature headers, enforces a 300s timestamp freshness window by default, and compares signatures in constant time. It does not maintain a replay cache; use `webhookDedup` below to drop duplicate webhook events by `idempotency_key`.
 
-For spec-current RFC 9421 webhook signatures, use `createWebhookVerifier` / `verifyWebhookSignature` from `@adcp/sdk/signing/server` instead of the HMAC helper.
+The mode recorded at registration is authoritative. The receiver never tries RFC 9421 and falls back to HMAC (or vice versa), and mixed-mode headers fail with `webhook_mode_mismatch`.
+
+`reporting_webhook` and artifact callbacks are separate registrations. The automatic provenance described above covers task-status `push_notification_config`; existing reporting webhook HMAC verification remains recordless for compatibility.
 
 ## Deduplication
 

--- a/src/lib/core/ADCPMultiAgentClient.ts
+++ b/src/lib/core/ADCPMultiAgentClient.ts
@@ -12,6 +12,10 @@ import type {
   CreativeDeliveryTaskOptions,
   SingleAgentClientConfig,
   SyncCreativesTaskOptions,
+  VerifyAndParseWebhookOptions,
+  WebhookHandlerAdapter,
+  WebhookHandlerRequest,
+  WebhookParseResult,
 } from './SingleAgentClient';
 import { ADCP_VERSION } from '../version';
 import { resolveAdcpVersion } from '../utils/adcp-version-config';
@@ -53,6 +57,11 @@ import type {
   CanonicalSyncCreativesRequest,
   CanonicalUpdateMediaBuyRequest,
 } from '../v2/projection/creative-delivery';
+
+export interface MultiAgentWebhookHandlerAdapter extends WebhookHandlerAdapter {
+  /** Resolve agent identity from trusted routing state, never from the unverified payload. */
+  getAgentId?: (request: WebhookHandlerRequest) => string | undefined | Promise<string | undefined>;
+}
 
 /**
  * Collection of agent clients for parallel operations across multiple AdCP agents.
@@ -969,10 +978,46 @@ export class ADCPMultiAgentClient {
     return agent.getWebhookUrl(taskType, operationId);
   }
 
+  /** Verify without dispatching, using an agent id obtained from trusted routing context. */
+  async verifyAndParseWebhook(agentId: string, options: VerifyAndParseWebhookOptions): Promise<WebhookParseResult> {
+    return this.getAgent(agentId).verifyAndParseWebhook(options);
+  }
+
+  /**
+   * Create a multi-agent HTTP receiver. Agent selection comes only from the
+   * adapter or route `agent_id`/`agentId` parameter, never the webhook body.
+   */
+  createWebhookHandler(adapter: MultiAgentWebhookHandlerAdapter = {}) {
+    return async (
+      req: WebhookHandlerRequest,
+      res: {
+        status: (code: number) => { json: (body: unknown) => void };
+        json?: unknown;
+        writeHead: (code: number, headers: Record<string, string>) => void;
+        end: (body: string) => void;
+      }
+    ) => {
+      const agentId = (await adapter.getAgentId?.(req)) || req.params?.agent_id || req.params?.agentId;
+      if (!agentId || !this.hasAgent(agentId)) {
+        const body = { error: 'Trusted webhook route does not identify a configured agent.' };
+        if (res.json) res.status(400).json(body);
+        else {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify(body));
+        }
+        return;
+      }
+      return this.getAgent(agentId).createWebhookHandler(adapter)(req, res);
+    };
+  }
+
   /**
    * Handle webhook from any agent (async task completion or notifications)
    *
    * Automatically routes webhook to the correct agent based on agent_id in payload.
+   *
+   * @deprecated Legacy HMAC compatibility only. Use `createWebhookHandler()`
+   * so agent identity and complete RFC 9421 request context come from trusted routing.
    *
    * @param payload - Webhook payload from agent (must contain agent_id or operation_id)
    * @param taskType - Task type (e.g create_media_buy) from url param or url part of the webhook delivery

--- a/src/lib/core/AgentClient.ts
+++ b/src/lib/core/AgentClient.ts
@@ -24,6 +24,7 @@ import {
   type SingleAgentClientConfig,
   type SyncCreativesTaskOptions,
   type VerifyAndParseWebhookOptions,
+  type WebhookHandlerAdapter,
   type WebhookParseResult,
 } from './SingleAgentClient';
 import type { InputHandler, TaskOptions, TaskResult, TaskInfo, Message } from './ConversationTypes';
@@ -577,6 +578,11 @@ export class AgentClient {
    */
   async verifyAndParseWebhook(options: VerifyAndParseWebhookOptions): Promise<WebhookParseResult> {
     return this.client.verifyAndParseWebhook(options);
+  }
+
+  /** Create a trusted-route HTTP receiver for this specific agent. */
+  createWebhookHandler(adapter: WebhookHandlerAdapter = {}) {
+    return this.client.createWebhookHandler(adapter);
   }
 
   /**

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -1537,7 +1537,13 @@ export class SingleAgentClient {
             adcpVersion: this.resolvedAdcpVersion,
             ...(this.config.wireAdcpVersion !== undefined && { wireAdcpVersion: this.config.wireAdcpVersion }),
             ...(this.config.versionEnvelope !== undefined && { versionEnvelope: this.config.versionEnvelope }),
-            transport: this.config.transport,
+            transport: {
+              ...this.config.transport,
+              requestTimeoutMs:
+                this.config.transport?.requestTimeoutMs ??
+                this.config.webhookVerification?.resolverOptions?.timeoutMs ??
+                10_000,
+            },
           }
         );
       },

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -95,7 +95,7 @@ import { attachMatch } from './match';
 import { withTaskDeadline } from './task-deadline';
 import { createMCPRequestHeaders } from '../auth';
 import { isAbortOrTimeoutError } from '../protocols/abort';
-import { normalizeTransportOptions } from '../protocols';
+import { ProtocolClient, normalizeTransportOptions } from '../protocols';
 import {
   AuthenticationRequiredError,
   ConfigurationError,
@@ -126,6 +126,24 @@ import type { AdcpTaskName, TaskRequestFor, TaskResponseTypeMap } from './AgentC
 import type { Activity, AsyncHandlerConfig, WebhookMetadata } from './AsyncHandler';
 import { AsyncHandler } from './AsyncHandler';
 import { verifyWebhookRequest, type WebhookHeaderValue, type WebhookHeadersLike } from '../webhooks';
+import {
+  InMemoryWebhookRegistrationStore,
+  type WebhookRegistration,
+  type WebhookRegistrationStore,
+} from './webhook-registration';
+import {
+  InMemoryReplayStore,
+  type ReplayStore,
+  InMemoryRevocationStore,
+  type RevocationStore,
+  type JwksResolver,
+  WebhookSignatureError,
+  type WebhookSignatureErrorCode,
+  verifyWebhookSignature as verifyRfc9421WebhookSignature,
+  ResolvedAgentJwksResolver,
+  type ResolvedAgentJwksResolverOptions,
+  canonicalTargetUri,
+} from '../signing/server';
 import { unwrapProtocolResponse } from '../utils/response-unwrapper';
 import {
   isWellKnownAgentCardUrl as isWellKnownCardUrl,
@@ -858,20 +876,40 @@ export interface ClientProductPropertyPolicy extends BuyerPropertyPolicy {
 }
 
 export type WebhookParseErrorCode =
+  | WebhookSignatureErrorCode
   | 'webhook_signature_invalid'
   | 'webhook_timestamp_invalid'
   | 'webhook_unsupported_payload'
   | 'webhook_envelope_invalid'
   | 'webhook_result_invalid'
   /**
-   * The receiver has no way to authenticate this webhook: no `webhookSecret` is
-   * configured, so the legacy HMAC profile has nothing to verify against, and
-   * this client does not yet verify the RFC 9421 webhook profile that an
-   * omitted `authentication` block selects. Distinct from
-   * `webhook_signature_invalid` — nothing was checked and found wrong; there was
-   * no check to perform.
+   * The receiver has no trusted registration or legacy HMAC configuration, so
+   * no authentication check can be selected safely.
    */
-  | 'webhook_unverifiable';
+  | 'webhook_unverifiable'
+  | 'webhook_registration_not_found'
+  | 'webhook_registration_mismatch'
+  | 'webhook_verification_context_missing'
+  | 'webhook_registration_store_unavailable'
+  | 'webhook_verification_unavailable';
+
+export interface WebhookVerificationConfig {
+  /** Deterministic/custom key source. Defaults to resolveAgent brand.json discovery. */
+  jwks?: JwksResolver;
+  /** Shared nonce replay store. Defaults to one process-local store per client. */
+  replayStore?: ReplayStore;
+  /** Key revocation source. Defaults to one process-local store per client. */
+  revocationStore?: RevocationStore;
+  /** Clock in epoch seconds. */
+  now?: () => number;
+  /** Safe discovery/cache tuning for the default seller-pinned JWK resolver. */
+  resolverOptions?: Omit<ResolvedAgentJwksResolverOptions, 'fetchCapabilities'>;
+  /**
+   * Fetch capabilities for seller key discovery. The callback must authenticate
+   * only to the supplied, already-pinned seller URL and protocol.
+   */
+  fetchCapabilities?: (agentUrl: string, protocol: 'mcp' | 'a2a') => Promise<unknown>;
+}
 
 export interface VerifyAndParseWebhookOptions {
   /** Raw HTTP body bytes captured before JSON parsing. Required when `webhookSecret` is configured. */
@@ -886,10 +924,32 @@ export interface VerifyAndParseWebhookOptions {
   taskType?: string;
   /** Operation id from trusted routing context. Used as an A2A fallback. */
   operationId?: string;
+  /** Actual HTTP method from trusted server context. Required for RFC 9421. */
+  requestMethod?: string;
+  /** Externally visible absolute request URL from trusted server/proxy configuration. Required for RFC 9421. */
+  requestUrl?: string;
   /** Explicit legacy HMAC signature header value. */
   signature?: WebhookHeaderValue;
   /** Explicit legacy HMAC timestamp header value. */
   timestamp?: WebhookHeaderValue;
+}
+
+export interface WebhookHandlerRequest {
+  headers: Record<string, WebhookHeaderValue>;
+  body: unknown;
+  rawBody?: string | Buffer | Uint8Array;
+  params?: Record<string, string>;
+  method?: string;
+  /** Trusted externally visible absolute URL supplied by the application. */
+  publicUrl?: string;
+}
+
+export interface WebhookHandlerAdapter {
+  getOperationId?: (request: WebhookHandlerRequest) => string | undefined | Promise<string | undefined>;
+  getTaskType?: (request: WebhookHandlerRequest) => string | undefined | Promise<string | undefined>;
+  getRequestMethod?: (request: WebhookHandlerRequest) => string | undefined | Promise<string | undefined>;
+  /** Must return a trusted externally visible URL; never derive it from untrusted forwarding headers. */
+  getRequestUrl?: (request: WebhookHandlerRequest) => string | undefined | Promise<string | undefined>;
 }
 
 export type WebhookParseResult = WebhookParseSuccess | WebhookParseFailure;
@@ -1014,17 +1074,20 @@ export interface SingleAgentClientConfig extends ConversationConfig {
    * `docs/guides/PUSH-NOTIFICATION-CONFIG.md#deduplication`.
    */
   handlers?: AsyncHandlerConfig;
-  /** Webhook secret for signature verification (recommended for production) */
+  /** Select legacy HMAC-SHA256 push verification. Omit to use RFC 9421. */
   webhookSecret?: string;
+  /** Durable provenance for outbound push registrations. Defaults to process-local memory. */
+  webhookRegistrationStore?: WebhookRegistrationStore;
+  /** Registration retention in seconds. Defaults to seven days. */
+  webhookRegistrationTtlSeconds?: number;
+  /** RFC 9421 key, replay, revocation, and discovery configuration. */
+  webhookVerification?: WebhookVerificationConfig;
   /**
    * Accept inbound webhooks that carry no verifiable authenticity at all.
    *
-   * Without `webhookSecret` the legacy HMAC profile has nothing to verify
-   * against, and this client does not yet verify the RFC 9421 webhook profile
-   * that an omitted `authentication` block selects. `verifyAndParseWebhook`
-   * therefore refuses such webhooks with `webhook_unverifiable` by default:
-   * anyone who can reach the receiver route could otherwise forge task
-   * completions and status changes.
+   * This bypass applies only when no trusted push registration exists and no
+   * HMAC secret is configured. It never bypasses a failed RFC 9421 or HMAC
+   * verification for a known registration.
    *
    * Set this only when the receiver is genuinely unreachable from outside your
    * network (in-process test harnesses, a route bound to loopback). It is not a
@@ -1350,6 +1413,10 @@ export class SingleAgentClient {
   private readonly canonicalCreativeTaskAssociations = new Map<string, CanonicalCreativeTaskAssociation>();
   private readonly canonicalLegacyRoutes = new Map<string, CanonicalLegacyRoute>();
   private readonly resolvedAdcpVersion: string;
+  private readonly webhookRegistrationStore: WebhookRegistrationStore;
+  private readonly webhookReplayStore: ReplayStore;
+  private readonly webhookRevocationStore: RevocationStore;
+  private readonly webhookJwksResolvers = new Map<string, JwksResolver>();
 
   constructor(
     private agent: AgentConfig,
@@ -1361,6 +1428,13 @@ export class SingleAgentClient {
     // ConfigurationError if the pin's major differs from ADCP_MAJOR_VERSION
     // — cross-major support lands in Stage 3 of the multi-version refactor.
     this.resolvedAdcpVersion = resolveAdcpVersion(config.adcpVersion);
+    this.webhookRegistrationStore = config.webhookRegistrationStore ?? new InMemoryWebhookRegistrationStore();
+    this.webhookReplayStore = config.webhookVerification?.replayStore ?? new InMemoryReplayStore();
+    this.webhookRevocationStore = config.webhookVerification?.revocationStore ?? new InMemoryRevocationStore();
+    const registrationTtl = config.webhookRegistrationTtlSeconds ?? 7 * 24 * 60 * 60;
+    if (!Number.isSafeInteger(registrationTtl) || registrationTtl < 1) {
+      throw new ConfigurationError('webhookRegistrationTtlSeconds must be a positive safe integer.');
+    }
 
     // Inject userAgent into agent headers so it flows through both MCP and A2A transports
     if (config.userAgent) {
@@ -1381,6 +1455,7 @@ export class SingleAgentClient {
       webhookUrlTemplate: config.webhookUrlTemplate,
       agentId: agent.id,
       webhookSecret: config.webhookSecret,
+      onWebhookRegistration: registration => this.persistWebhookRegistration(registration),
       strictSchemaValidation: config.validation?.strictSchemaValidation !== false, // Default: true
       logSchemaViolations: config.validation?.logSchemaViolations !== false, // Default: true
       filterInvalidProducts: config.validation?.filterInvalidProducts === true, // Default: false
@@ -1403,6 +1478,72 @@ export class SingleAgentClient {
     if (config.handlers) {
       this.asyncHandler = new AsyncHandler(config.handlers);
     }
+  }
+
+  private async persistWebhookRegistration(args: {
+    agent: AgentConfig;
+    taskType: string;
+    operationId: string;
+    callbackUrl: string;
+    mode: WebhookRegistration['mode'];
+  }): Promise<void> {
+    const nowMs = this.config.webhookVerification?.now
+      ? Math.floor(this.config.webhookVerification.now() * 1000)
+      : Date.now();
+    const ttlSeconds = this.config.webhookRegistrationTtlSeconds ?? 7 * 24 * 60 * 60;
+    try {
+      await this.webhookRegistrationStore.putIfAbsent({
+        agentId: args.agent.id,
+        agentUrl: args.agent.agent_uri,
+        protocol: args.agent.protocol,
+        operationId: args.operationId,
+        taskType: args.taskType,
+        callbackUrl: args.callbackUrl,
+        method: 'POST',
+        mode: args.mode,
+        createdAt: nowMs,
+        expiresAt: nowMs + ttlSeconds * 1000,
+      });
+    } catch (cause) {
+      // RFC 9421 has no safe fallback without seller-pinned provenance. Legacy
+      // HMAC remains verifiable from the configured global secret, preserving
+      // pre-registration behavior across restarts and replicas.
+      if (args.mode === 'rfc9421') throw cause;
+    }
+  }
+
+  private webhookJwksFor(registration: Readonly<WebhookRegistration>): JwksResolver {
+    const configured = this.config.webhookVerification?.jwks;
+    if (configured) return configured;
+    const key = `${registration.protocol}\x00${registration.agentUrl}`;
+    const existing = this.webhookJwksResolvers.get(key);
+    if (existing) return existing;
+
+    const resolver = new ResolvedAgentJwksResolver(registration.agentUrl, registration.protocol, {
+      ...this.config.webhookVerification?.resolverOptions,
+      fetchCapabilities: agentUrl => {
+        const configuredFetch = this.config.webhookVerification?.fetchCapabilities;
+        if (configuredFetch) return configuredFetch(agentUrl, registration.protocol);
+        return ProtocolClient.callTool(
+          {
+            id: registration.agentId,
+            name: registration.agentId,
+            agent_uri: agentUrl,
+            protocol: registration.protocol,
+          },
+          'get_adcp_capabilities',
+          {},
+          {
+            adcpVersion: this.resolvedAdcpVersion,
+            ...(this.config.wireAdcpVersion !== undefined && { wireAdcpVersion: this.config.wireAdcpVersion }),
+            ...(this.config.versionEnvelope !== undefined && { versionEnvelope: this.config.versionEnvelope }),
+            transport: this.config.transport,
+          }
+        );
+      },
+    });
+    this.webhookJwksResolvers.set(key, resolver);
+    return resolver;
   }
 
   private resolveLegacyFormatConverter(
@@ -2292,16 +2433,159 @@ export class SingleAgentClient {
    * Verify and normalize an inbound webhook without dispatching handlers.
    *
    * This is the lower-level receiver primitive for integrations that need to
-   * map malformed webhooks to precise HTTP responses. It verifies the legacy
-   * HMAC profile when `webhookSecret` is configured, parses raw JSON bodies,
+   * map malformed webhooks to precise HTTP responses. It verifies the mode
+   * selected by the trusted outbound registration (RFC 9421 by default, or
+   * legacy HMAC when `webhookSecret` was used), parses raw JSON bodies,
    * validates the transport envelope shape, and returns the canonicalized
    * AdCP result plus routing metadata. Legacy wire inspection is intentionally
    * confined to the transport adapter and is not returned by this primary API.
    */
   async verifyAndParseWebhook(options: VerifyAndParseWebhookOptions): Promise<WebhookParseResult> {
     const rawBody = options.rawBody ?? rawBodyFromUnknown(options.body);
+    const authHeaders = inspectWebhookAuthenticationHeaders(options.headers, options.signature, options.timestamp);
+    const trustedOperationId =
+      options.operationId && options.operationId !== 'unknown' ? options.operationId : undefined;
+    let registration: Readonly<WebhookRegistration> | undefined;
+    if (trustedOperationId) {
+      try {
+        registration = await this.webhookRegistrationStore.get(this.agent.id, trustedOperationId);
+      } catch (cause) {
+        if (!this.config.webhookSecret) {
+          return {
+            ok: false,
+            code: 'webhook_registration_store_unavailable',
+            message: 'Webhook registration state is temporarily unavailable.',
+            cause,
+          };
+        }
+      }
+    }
+    if (registration && (registration.agentId !== this.agent.id || registration.operationId !== trustedOperationId)) {
+      return {
+        ok: false,
+        code: 'webhook_registration_store_unavailable',
+        message: 'Webhook registration state is inconsistent with the trusted route.',
+      };
+    }
+    if (registration) {
+      const nowMs = this.config.webhookVerification?.now
+        ? Math.floor(this.config.webhookVerification.now() * 1000)
+        : Date.now();
+      if (!Number.isFinite(registration.createdAt) || !Number.isFinite(registration.expiresAt)) {
+        return {
+          ok: false,
+          code: 'webhook_registration_store_unavailable',
+          message: 'Webhook registration state contains invalid timestamps.',
+        };
+      }
+      if (registration.expiresAt <= nowMs) registration = undefined;
+    }
 
-    if (this.config.webhookSecret) {
+    if (authHeaders.hasRfc9421 && !trustedOperationId) {
+      return {
+        ok: false,
+        code: 'webhook_verification_context_missing',
+        message: 'RFC 9421 verification requires a trusted route operation id.',
+      };
+    }
+    if (registration) {
+      const routedTaskType = options.taskType === 'unknown' ? undefined : options.taskType;
+      if (routedTaskType !== undefined && routedTaskType !== registration.taskType) {
+        return {
+          ok: false,
+          code: 'webhook_registration_mismatch',
+          message: 'Trusted webhook route does not match the registered task type.',
+        };
+      }
+      const oppositeMode =
+        (registration.mode === 'rfc9421' && authHeaders.hasLegacy) ||
+        (registration.mode === 'hmac-sha256' && authHeaders.hasRfc9421);
+      if (oppositeMode) {
+        const cause = new WebhookSignatureError(
+          'webhook_mode_mismatch',
+          1,
+          'Received webhook authentication mode does not match the registered callback mode.'
+        );
+        return { ok: false, code: cause.code, message: cause.message, cause };
+      }
+    }
+    if (!registration && this.config.webhookSecret && authHeaders.hasRfc9421) {
+      const cause = new WebhookSignatureError(
+        'webhook_mode_mismatch',
+        1,
+        'RFC 9421 signature headers do not match the configured legacy HMAC receiver mode.'
+      );
+      return { ok: false, code: cause.code, message: cause.message, cause };
+    }
+    if (registration?.mode === 'rfc9421') {
+      if (
+        rawBody === undefined ||
+        !options.headers ||
+        !trustedOperationId ||
+        !options.requestMethod ||
+        !options.requestUrl
+      ) {
+        return {
+          ok: false,
+          code: 'webhook_verification_context_missing',
+          message:
+            'RFC 9421 verification requires raw body bytes, all headers, POST method, an absolute trusted public URL, and a trusted route operation id.',
+        };
+      }
+      if (options.requestMethod.toUpperCase() !== 'POST') {
+        return {
+          ok: false,
+          code: 'webhook_verification_context_missing',
+          message: 'Webhook request method must be POST.',
+        };
+      }
+      try {
+        if (canonicalTargetUri(options.requestUrl) !== canonicalTargetUri(registration.callbackUrl)) {
+          const cause = new WebhookSignatureError(
+            'webhook_signature_invalid',
+            10,
+            'Trusted request URL does not match the registered callback URL.'
+          );
+          return { ok: false, code: cause.code, message: cause.message, cause };
+        }
+      } catch (cause) {
+        return {
+          ok: false,
+          code: 'webhook_verification_context_missing',
+          message: 'Webhook request URL must be a valid absolute public URL.',
+          cause,
+        };
+      }
+      const normalizedHeaders = normalizeRfc9421WebhookHeaders(options.headers);
+      if (!normalizedHeaders.ok) return normalizedHeaders.failure;
+      try {
+        await verifyRfc9421WebhookSignature(
+          {
+            method: options.requestMethod,
+            url: options.requestUrl,
+            headers: normalizedHeaders.headers,
+            body: rawBody,
+          },
+          {
+            jwks: this.webhookJwksFor(registration),
+            replayStore: this.webhookReplayStore,
+            revocationStore: this.webhookRevocationStore,
+            ...(this.config.webhookVerification?.now && { now: this.config.webhookVerification.now }),
+            agentUrlForKeyid: () => registration.agentUrl,
+          }
+        );
+      } catch (cause) {
+        if (cause instanceof WebhookSignatureError) {
+          return { ok: false, code: cause.code, message: cause.message, cause };
+        }
+        return {
+          ok: false,
+          code: 'webhook_verification_unavailable',
+          message: 'Seller signing keys could not be resolved for webhook verification.',
+          cause,
+        };
+      }
+    } else if (registration?.mode === 'hmac-sha256' || (!registration && this.config.webhookSecret)) {
       if (rawBody === undefined) {
         return {
           ok: false,
@@ -2309,9 +2593,27 @@ export class SingleAgentClient {
           message: 'Raw webhook body required for HMAC signature verification; capture bytes before JSON parsing.',
         };
       }
+      let hmacSecret: string | undefined;
+      try {
+        hmacSecret = this.config.webhookSecret;
+      } catch (cause) {
+        return {
+          ok: false,
+          code: 'webhook_verification_unavailable',
+          message: 'Legacy webhook key material is temporarily unavailable.',
+          cause,
+        };
+      }
+      if (!hmacSecret) {
+        return {
+          ok: false,
+          code: 'webhook_verification_unavailable',
+          message: 'Legacy webhook key material is unavailable for this registration.',
+        };
+      }
       const check = verifyWebhookRequest({
         rawBody,
-        secret: this.config.webhookSecret,
+        secret: hmacSecret,
         headers: options.headers,
         signature: options.signature,
         timestamp: options.timestamp,
@@ -2326,28 +2628,25 @@ export class SingleAgentClient {
           message: check.message,
         };
       }
-    } else if (this.config.allowUnauthenticatedWebhooks === true) {
+    } else if (
+      this.config.allowUnauthenticatedWebhooks === true &&
+      !registration &&
+      !authHeaders.hasRfc9421 &&
+      !authHeaders.hasLegacy
+    ) {
       warnUnverifiedWebhookReceive();
     } else {
-      // Fail closed. With no secret the legacy HMAC profile has nothing to
-      // verify against, and this client does not yet verify the RFC 9421 profile
-      // that an omitted `authentication` block selects (tracked separately), so
-      // accepting here would dispatch a caller-supplied payload to async and
-      // activity handlers and update external task status on nothing but its
-      // shape.
       return {
         ok: false,
-        code: 'webhook_unverifiable',
-        message:
-          'Refusing an unauthenticated webhook: no `webhookSecret` is configured, so there is no ' +
-          'signature to verify. Configure `webhookSecret` to enable HMAC verification, or set ' +
-          '`allowUnauthenticatedWebhooks: true` to accept unverified webhooks (only safe when the ' +
-          'receiver route is unreachable from outside your network).',
+        code: authHeaders.hasRfc9421 ? 'webhook_registration_not_found' : 'webhook_unverifiable',
+        message: 'Refusing a webhook without trusted registration provenance or a configured legacy HMAC secret.',
       };
     }
 
     const payloadSource =
-      this.config.webhookSecret && rawBody !== undefined ? rawBody : (options.payload ?? options.body ?? rawBody);
+      (registration || this.config.webhookSecret) && rawBody !== undefined
+        ? rawBody
+        : (options.payload ?? options.body ?? rawBody);
     const parsedPayload = parseWebhookBody(payloadSource);
     if (!parsedPayload.ok) {
       return parsedPayload;
@@ -2358,6 +2657,18 @@ export class SingleAgentClient {
         ? parsedPayload.payload.task_type
         : undefined;
     const payloadRecord = isObjectRecord(parsedPayload.payload) ? parsedPayload.payload : undefined;
+    if (
+      registration &&
+      ((typeof payloadRecord?.operation_id === 'string' && payloadRecord.operation_id !== registration.operationId) ||
+        (parsedTaskType !== undefined && parsedTaskType !== registration.taskType) ||
+        (typeof payloadRecord?.agent_id === 'string' && payloadRecord.agent_id !== registration.agentId))
+    ) {
+      return {
+        ok: false,
+        code: 'webhook_envelope_invalid',
+        message: 'Authenticated webhook routing fields do not match the trusted registration.',
+      };
+    }
     const associatedTaskTypes = new Set(
       [
         options.operationId,
@@ -2390,6 +2701,13 @@ export class SingleAgentClient {
         options.operationId ?? 'unknown'
       );
       normalizedTaskType = normalizedPayload.task_type;
+      if (registration && (normalizedPayload.protocol ?? 'mcp') !== registration.protocol) {
+        return {
+          ok: false,
+          code: 'webhook_envelope_invalid',
+          message: 'Authenticated webhook protocol does not match the trusted registration.',
+        };
+      }
       if (associatedTaskType !== undefined && normalizedPayload.task_type !== associatedTaskType) {
         return {
           ok: false,
@@ -2754,16 +3072,16 @@ export class SingleAgentClient {
    *
    * This helper creates a standard HTTP handler (Express/Next.js/etc.) that:
    * - Reads the full header bag so duplicate/conflicting signature headers are rejected
-   * - Verifies HMAC signature (if webhookSecret configured)
-   * - Validates timestamp freshness
+   * - Verifies the registered RFC 9421 or legacy HMAC signature mode
+   * - Validates signature freshness and RFC 9421 nonce replay
    * - Calls handleWebhook() with proper error handling
    *
-   * @returns HTTP handler function compatible with Express, Next.js, etc.
+   * @returns HTTP handler function compatible with Express-style adapters.
    *
    * @example Express
    * ```typescript
-   * const client = new ADCPClient(agent, {
-   *   webhookSecret: 'your-secret-key',
+   * const client = new SingleAgentClient(agent, {
+   *   webhookUrlTemplate: 'https://buyer.example/webhook/{task_type}/{operation_id}',
    *   handlers: {
    *     onSyncCreativesStatusChange: async (result) => {
    *       console.log('Creative synced:', result);
@@ -2771,22 +3089,18 @@ export class SingleAgentClient {
    *   }
    * });
    *
-   * app.post('/webhook', client.createWebhookHandler());
-   * ```
-   *
-   * @example Next.js API Route
-   * ```typescript
-   * export default client.createWebhookHandler();
+   * app.post(
+   *   '/webhook/:task_type/:operation_id',
+   *   express.raw({ type: 'application/json' }),
+   *   client.createWebhookHandler({
+   *     getRequestUrl: req => `https://buyer.example${req.originalUrl}`,
+   *   }),
+   * );
    * ```
    */
-  createWebhookHandler() {
+  createWebhookHandler(adapter: WebhookHandlerAdapter = {}) {
     return async (
-      req: {
-        headers: Record<string, WebhookHeaderValue>;
-        body: unknown;
-        rawBody?: string | Buffer | Uint8Array;
-        params?: Record<string, string>;
-      },
+      req: WebhookHandlerRequest,
       res: {
         status: (code: number) => { json: (body: unknown) => void };
         json?: unknown;
@@ -2813,8 +3127,12 @@ export class SingleAgentClient {
             : req.body;
 
         // Extract routing params if available (e.g., Express route params)
-        const taskType = req.params?.task_type || req.params?.taskType || 'unknown';
-        const operationId = req.params?.operation_id || req.params?.operationId || 'unknown';
+        const taskType =
+          (await adapter.getTaskType?.(req)) || req.params?.task_type || req.params?.taskType || 'unknown';
+        const operationId =
+          (await adapter.getOperationId?.(req)) || req.params?.operation_id || req.params?.operationId || 'unknown';
+        const requestMethod = (await adapter.getRequestMethod?.(req)) || req.method;
+        const requestUrl = (await adapter.getRequestUrl?.(req)) || req.publicUrl;
 
         const parsed = await this.verifyAndParseWebhook({
           payload,
@@ -2823,6 +3141,8 @@ export class SingleAgentClient {
           headers: req.headers,
           taskType,
           operationId,
+          requestMethod,
+          requestUrl,
         });
         if (!parsed.ok) {
           throw new WebhookDispatchError(parsed.code, parsed.message, parsed.cause);
@@ -6972,21 +7292,17 @@ let hasWarnedAboutUnverifiedWebhookReceive = false;
 /**
  * Warn once when a webhook is accepted with no authenticity check at all.
  *
- * Without `webhookSecret` the legacy HMAC profile has nothing to verify against,
- * so a structurally valid payload from any caller who can reach the receiver
- * route is dispatched to async/activity handlers and updates task status. The
- * spec's answer for a registration that omits `authentication` is the RFC 9421
- * webhook profile; until this receiver verifies that profile, an operator
- * running without a secret needs to know the check is absent rather than passing.
+ * This path is available only through the explicit
+ * `allowUnauthenticatedWebhooks` escape hatch and only when no trusted push
+ * registration or legacy HMAC secret is available.
  */
 function warnUnverifiedWebhookReceive(): void {
   if (hasWarnedAboutUnverifiedWebhookReceive) return;
   hasWarnedAboutUnverifiedWebhookReceive = true;
   console.warn(
-    '[adcp] Webhook accepted WITHOUT authenticity verification: no `webhookSecret` is configured, ' +
-      'so any caller able to reach this receiver can forge task completions and status changes. ' +
-      'Configure `webhookSecret` to enable HMAC verification, and restrict network access to the ' +
-      'receiver route.'
+    '[adcp] Webhook accepted WITHOUT authenticity verification because ' +
+      '`allowUnauthenticatedWebhooks` is enabled and no trusted registration was found. ' +
+      'Any caller able to reach this receiver can forge task completions and status changes.'
   );
 }
 
@@ -7041,6 +7357,67 @@ function isObjectRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
+function inspectWebhookAuthenticationHeaders(
+  headers: WebhookHeadersLike | undefined,
+  explicitSignature: WebhookHeaderValue,
+  explicitTimestamp: WebhookHeaderValue
+): { hasLegacy: boolean; hasRfc9421: boolean } {
+  const hasHeader = (name: string): boolean => {
+    if (!headers) return false;
+    if (typeof (headers as Headers).get === 'function') return (headers as Headers).get(name) !== null;
+    return Object.entries(headers).some(
+      ([key, value]) => key.toLowerCase() === name && value !== null && value !== undefined
+    );
+  };
+  return {
+    hasLegacy:
+      explicitSignature != null ||
+      explicitTimestamp != null ||
+      hasHeader('x-adcp-signature') ||
+      hasHeader('x-adcp-timestamp'),
+    hasRfc9421: hasHeader('signature') || hasHeader('signature-input'),
+  };
+}
+
+function normalizeRfc9421WebhookHeaders(
+  headers: WebhookHeadersLike
+): { ok: true; headers: Record<string, string | string[] | undefined> } | { ok: false; failure: WebhookParseFailure } {
+  const normalized: Record<string, string | string[] | undefined> = {};
+  if (typeof (headers as Headers).forEach === 'function') {
+    (headers as Headers).forEach((value, key) => {
+      normalized[key] = value;
+    });
+    return { ok: true, headers: normalized };
+  }
+
+  const singletonHeaders = new Set([
+    'signature',
+    'signature-input',
+    'content-digest',
+    'content-type',
+    'x-adcp-signature',
+    'x-adcp-timestamp',
+  ]);
+  const seen = new Set<string>();
+  for (const [key, value] of Object.entries(headers)) {
+    const lower = key.toLowerCase();
+    if (singletonHeaders.has(lower)) {
+      if (seen.has(lower) || Array.isArray(value)) {
+        const cause = new WebhookSignatureError(
+          'webhook_signature_header_malformed',
+          1,
+          `Webhook header ${lower} must have exactly one unambiguous value.`
+        );
+        return { ok: false, failure: { ok: false, code: cause.code, message: cause.message, cause } };
+      }
+      seen.add(lower);
+    }
+    if (value === null || value === undefined) continue;
+    normalized[key] = Array.isArray(value) ? value.map(String) : String(value);
+  }
+  return { ok: true, headers: normalized };
+}
+
 function isBareDeliveryReport(payload: Record<string, unknown>): boolean {
   return (
     typeof payload.notification_type === 'string' &&
@@ -7068,7 +7445,24 @@ function missingMcpWebhookFields(payload: Record<string, unknown>): string[] {
 
 function webhookErrorHttpStatus(error: unknown): number {
   if (error instanceof WebhookDispatchError) {
-    if (error.code === 'webhook_signature_invalid' || error.code === 'webhook_timestamp_invalid') {
+    if (error.code === 'webhook_signature_replayed') return 409;
+    if (error.code === 'webhook_signature_rate_abuse') return 429;
+    if (
+      error.code === 'webhook_registration_store_unavailable' ||
+      error.code === 'webhook_verification_unavailable' ||
+      error.code === 'webhook_signature_revocation_stale'
+    ) {
+      return 503;
+    }
+    if (error.code === 'webhook_verification_context_missing') return 500;
+    if (
+      error.code.startsWith('webhook_signature_') ||
+      error.code === 'webhook_timestamp_invalid' ||
+      error.code === 'webhook_mode_mismatch' ||
+      error.code === 'webhook_registration_not_found' ||
+      error.code === 'webhook_registration_mismatch' ||
+      error.code === 'webhook_unverifiable'
+    ) {
       return 401;
     }
     return 400;

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -3,8 +3,14 @@
 
 import { randomUUID } from 'crypto';
 import type { AgentConfig } from '../types';
-import { ProtocolClient, normalizeTransportOptions, prepareProtocolToolCall } from '../protocols';
+import {
+  ProtocolClient,
+  normalizeTransportOptions,
+  prepareProtocolToolCall,
+  type PreparedProtocolToolCall,
+} from '../protocols';
 import { listMCPTasks } from '../protocols/mcp-tasks';
+import { withPreparedProtocolToolCall } from '../protocols/prepared-call-context';
 import { getAuthToken } from '../auth';
 import { is401Error, adcpErrorToTypedError, ConfigurationError } from '../errors';
 import type { ADCPError } from '../errors';
@@ -91,6 +97,53 @@ const GOVERNED_CALLBACK_FIELDS = new Set(['push_notification_config', 'reporting
 type GovernedCredentialScanResult =
   | { kind: 'credential'; path: string; callbackField: string }
   | { kind: 'limit'; limit: 'nodes' | 'depth' };
+
+function webhookRegistrationFromPreparedCall(
+  agent: AgentConfig,
+  preparedCall: PreparedProtocolToolCall
+): { callbackUrl: string; mode: 'rfc9421' | 'hmac-sha256' } | undefined {
+  const candidate =
+    agent.protocol === 'a2a'
+      ? preparedCall.pushNotificationConfig
+      : preparedCall.args.push_notification_config &&
+          typeof preparedCall.args.push_notification_config === 'object' &&
+          !Array.isArray(preparedCall.args.push_notification_config)
+        ? (preparedCall.args.push_notification_config as Record<string, unknown>)
+        : undefined;
+  if (!candidate) return undefined;
+  if (typeof candidate.url !== 'string') {
+    throw new ConfigurationError('push_notification_config.url must be a string.', 'push_notification_config.url');
+  }
+
+  if (!Object.prototype.hasOwnProperty.call(candidate, 'authentication')) {
+    return { callbackUrl: candidate.url, mode: 'rfc9421' };
+  }
+  const authentication = candidate.authentication;
+  if (!authentication || typeof authentication !== 'object' || Array.isArray(authentication)) {
+    throw new ConfigurationError(
+      'push_notification_config.authentication selects legacy verification and must be a supported object.',
+      'push_notification_config.authentication'
+    );
+  }
+  const schemes = (authentication as Record<string, unknown>).schemes;
+  const credentials = (authentication as Record<string, unknown>).credentials;
+  if (
+    !Array.isArray(schemes) ||
+    schemes.length !== 1 ||
+    schemes[0] !== 'HMAC-SHA256' ||
+    typeof credentials !== 'string' ||
+    credentials.length === 0
+  ) {
+    throw new ConfigurationError(
+      'This receiver supports legacy HMAC-SHA256 or RFC 9421 push notifications; Bearer and mixed schemes are not supported.',
+      'push_notification_config.authentication.schemes'
+    );
+  }
+  return {
+    callbackUrl: candidate.url,
+    mode: 'hmac-sha256',
+  };
+}
 
 /**
  * Find callback authentication credentials before an exact downstream payload
@@ -419,8 +472,16 @@ export class TaskExecutor {
       webhookUrlTemplate?: WebhookUrlTemplate;
       /** Agent ID for webhook URL generation */
       agentId?: string;
-      /** Webhook secret for HMAC authentication (min 32 chars) */
+      /** Webhook secret for legacy HMAC authentication. */
       webhookSecret?: string;
+      /** Persist sanitized callback mode provenance before dispatch. */
+      onWebhookRegistration?: (registration: {
+        agent: AgentConfig;
+        taskType: string;
+        operationId: string;
+        callbackUrl: string;
+        mode: 'rfc9421' | 'hmac-sha256';
+      }) => void | Promise<void>;
       /** Fail tasks when response schema validation fails (default: true) */
       strictSchemaValidation?: boolean;
       /** Log all schema validation violations to debug logs (default: true) */
@@ -814,11 +875,35 @@ export class TaskExecutor {
         metadata: { toolName: taskName, type: 'request' },
       };
 
+      // Materialize once, persist callback provenance, and dispatch this same
+      // prepared object. A seller can post immediately after receiving the
+      // request, so the registration write must complete before the network
+      // boundary is crossed.
+      const preparedCall = prepareProtocolToolCall(agent, effectiveParams, {
+        webhookUrl,
+        webhookSecret: this.config.webhookSecret,
+        serverVersion,
+        adcpVersion: this.config.adcpVersion,
+        wireAdcpVersion: this.config.wireAdcpVersion,
+        versionEnvelope: this.config.versionEnvelope,
+      });
+      if (webhookUrl && this.config.onWebhookRegistration) {
+        const registration = webhookRegistrationFromPreparedCall(agent, preparedCall);
+        if (registration) {
+          await this.config.onWebhookRegistration({
+            agent,
+            taskType: taskName,
+            operationId: taskId,
+            ...registration,
+          });
+        }
+      }
+
       // Send initial request and get streaming response with webhook URL.
       // Pass the caller's A2A session ids (contextId for conversation binding,
       // taskId for resuming a non-terminal server-side task). The adapter
       // drops these on the wire for MCP (no session concept there).
-      const response = await ProtocolClient.callTool(agent, taskName, effectiveParams, {
+      const callOptions = {
         debugLogs,
         webhookUrl,
         webhookSecret: this.config.webhookSecret,
@@ -836,7 +921,11 @@ export class TaskExecutor {
           contextId: options.contextId,
           idempotencyKey,
         },
-      });
+      };
+      const response = await withPreparedProtocolToolCall(
+        { agent, toolName: taskName, args: effectiveParams, preparedCall },
+        () => ProtocolClient.callTool(agent, taskName, effectiveParams, callOptions)
+      );
       throwIfAborted(options.signal);
 
       // Emit protocol_response activity

--- a/src/lib/core/webhook-registration.ts
+++ b/src/lib/core/webhook-registration.ts
@@ -1,0 +1,143 @@
+import { ConfigurationError } from '../errors';
+import { isWebhookLoopbackHost } from '../signing/webhook-verifier';
+
+export type WebhookAuthenticationMode = 'hmac-sha256' | 'rfc9421';
+
+/**
+ * Trusted provenance for an outbound task-status webhook registration.
+ *
+ * Registrations contain routing and mode provenance only, never callback
+ * credentials. Stores should still treat seller and callback URLs as
+ * operationally sensitive and omit them from public diagnostics.
+ */
+export interface WebhookRegistration {
+  agentId: string;
+  agentUrl: string;
+  protocol: 'mcp' | 'a2a';
+  operationId: string;
+  taskType: string;
+  callbackUrl: string;
+  method: 'POST';
+  mode: WebhookAuthenticationMode;
+  /** Epoch milliseconds. */
+  createdAt: number;
+  /** Epoch milliseconds. */
+  expiresAt: number;
+}
+
+export interface WebhookRegistrationStore {
+  /** Return no record when `expiresAt` is at or before the current time. */
+  get(agentId: string, operationId: string): Promise<Readonly<WebhookRegistration> | undefined>;
+  /**
+   * Atomically create a registration. An identical retry is idempotent; a
+   * conflicting live registration for the same key MUST reject.
+   */
+  putIfAbsent(registration: WebhookRegistration): Promise<void>;
+  /** Remove provenance after a definitively synchronous terminal response. */
+  delete?(agentId: string, operationId: string): Promise<void>;
+}
+
+export interface InMemoryWebhookRegistrationStoreOptions {
+  /** Maximum number of live registrations. Defaults to 100,000. */
+  maxEntries?: number;
+  /** Current time in epoch milliseconds, for deterministic tests. */
+  now?: () => number;
+}
+
+/**
+ * Process-local registration store. Multi-process or restart-safe receivers
+ * must inject a shared durable implementation.
+ */
+export class InMemoryWebhookRegistrationStore implements WebhookRegistrationStore {
+  private readonly entries = new Map<string, Readonly<WebhookRegistration>>();
+  private readonly maxEntries: number;
+  private readonly now: () => number;
+
+  constructor(options: InMemoryWebhookRegistrationStoreOptions = {}) {
+    this.maxEntries = options.maxEntries ?? 100_000;
+    this.now = options.now ?? Date.now;
+    if (!Number.isSafeInteger(this.maxEntries) || this.maxEntries < 1) {
+      throw new TypeError('maxEntries must be a positive safe integer.');
+    }
+  }
+
+  async get(agentId: string, operationId: string): Promise<Readonly<WebhookRegistration> | undefined> {
+    const key = registrationKey(agentId, operationId);
+    const registration = this.entries.get(key);
+    if (!registration) return undefined;
+    if (registration.expiresAt <= this.now()) {
+      this.entries.delete(key);
+      return undefined;
+    }
+    return registration;
+  }
+
+  async putIfAbsent(registration: WebhookRegistration): Promise<void> {
+    validateRegistration(registration);
+    this.pruneExpired();
+    const key = registrationKey(registration.agentId, registration.operationId);
+    const existing = this.entries.get(key);
+    if (existing) {
+      if (sameRegistration(existing, registration)) return;
+      throw new ConfigurationError(
+        `Webhook operation id '${registration.operationId}' is already registered with different trusted provenance.`,
+        'operationId'
+      );
+    }
+    if (this.entries.size >= this.maxEntries) {
+      throw new Error('Webhook registration store capacity reached; refusing to dispatch an untracked callback.');
+    }
+    this.entries.set(key, Object.freeze({ ...registration }));
+  }
+
+  async delete(agentId: string, operationId: string): Promise<void> {
+    this.entries.delete(registrationKey(agentId, operationId));
+  }
+
+  private pruneExpired(): void {
+    const now = this.now();
+    for (const [key, registration] of this.entries) {
+      if (registration.expiresAt <= now) this.entries.delete(key);
+    }
+  }
+}
+
+function registrationKey(agentId: string, operationId: string): string {
+  return `${agentId}\x00${operationId}`;
+}
+
+function validateRegistration(registration: WebhookRegistration): void {
+  if (!registration.agentId || !registration.operationId || !registration.taskType) {
+    throw new TypeError('Webhook registration requires agentId, operationId, and taskType.');
+  }
+  if (
+    registration.agentId.includes('\0') ||
+    registration.operationId.includes('\0') ||
+    registration.taskType.includes('\0')
+  ) {
+    throw new TypeError('Webhook registration identifiers cannot contain NUL characters.');
+  }
+  const callback = new URL(registration.callbackUrl);
+  if (callback.username || callback.password || callback.hash) {
+    throw new TypeError('Webhook callbackUrl cannot contain userinfo or a fragment.');
+  }
+  if (callback.protocol !== 'https:' && !isWebhookLoopbackHost(callback.hostname)) {
+    throw new TypeError('Webhook callbackUrl must use HTTPS (except loopback development URLs).');
+  }
+  if (registration.expiresAt <= registration.createdAt) {
+    throw new TypeError('Webhook registration expiresAt must be later than createdAt.');
+  }
+}
+
+function sameRegistration(a: Readonly<WebhookRegistration>, b: WebhookRegistration): boolean {
+  return (
+    a.agentId === b.agentId &&
+    a.agentUrl === b.agentUrl &&
+    a.protocol === b.protocol &&
+    a.operationId === b.operationId &&
+    a.taskType === b.taskType &&
+    a.callbackUrl === b.callbackUrl &&
+    a.method === b.method &&
+    a.mode === b.mode
+  );
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -282,11 +282,21 @@ export type {
   SingleAgentClientConfig,
   SyncCreativesTaskOptions,
   VerifyAndParseWebhookOptions,
+  WebhookHandlerAdapter,
+  WebhookHandlerRequest,
   WebhookParseErrorCode,
   WebhookParseFailure,
   WebhookParseResult,
   WebhookParseSuccess,
+  WebhookVerificationConfig,
 } from './core/SingleAgentClient';
+export {
+  InMemoryWebhookRegistrationStore,
+  type InMemoryWebhookRegistrationStoreOptions,
+  type WebhookAuthenticationMode,
+  type WebhookRegistration,
+  type WebhookRegistrationStore,
+} from './core/webhook-registration';
 export {
   AgentClient,
   type CanonicalGetProductsResponse,
@@ -298,7 +308,11 @@ export {
   type AdcpTaskName,
   type InProcessAgentClientConfig,
 } from './core/AgentClient';
-export { ADCPMultiAgentClient, createADCPMultiAgentClient } from './core/ADCPMultiAgentClient';
+export {
+  ADCPMultiAgentClient,
+  createADCPMultiAgentClient,
+  type MultiAgentWebhookHandlerAdapter,
+} from './core/ADCPMultiAgentClient';
 export { ConfigurationManager } from './core/ConfigurationManager';
 export {
   CreativeAgentClient,

--- a/src/lib/protocols/index.ts
+++ b/src/lib/protocols/index.ts
@@ -69,6 +69,7 @@ import { ConfigurationError } from '../errors';
 import { resolveBundleKey, toReleasePrecisionWire, validateAdcpVersionWire } from '../validation/schema-loader';
 import { buildAgentSigningContext, CAPABILITY_OP, ensureCapabilityLoaded } from '../signing/client';
 import { withResponseSizeLimit } from './responseSizeLimit';
+import { preparedProtocolToolCallFor } from './prepared-call-context';
 import {
   withTransportDiagnostics,
   type TransportActivityHandler as TransportActivityHandlerFn,
@@ -495,15 +496,17 @@ export class ProtocolClient {
       transportActivityContext,
     } = options;
     const transport = normalizeTransportOptions(requestedTransport);
-    const preparedCall = prepareProtocolToolCall(agent, args, {
-      webhookUrl,
-      webhookSecret,
-      webhookToken,
-      serverVersion,
-      adcpVersion,
-      wireAdcpVersion,
-      versionEnvelope: versionEnvelopeMode,
-    });
+    const preparedCall =
+      preparedProtocolToolCallFor(agent, toolName, args) ??
+      prepareProtocolToolCall(agent, args, {
+        webhookUrl,
+        webhookSecret,
+        webhookToken,
+        serverVersion,
+        adcpVersion,
+        wireAdcpVersion,
+        versionEnvelope: versionEnvelopeMode,
+      });
     // Enter the response-size-limit ALS slot once for this call. The slot is
     // read by `wrapFetchWithSizeLimit` in both protocol transports, so the
     // cap applies regardless of which path (MCP / A2A / OAuth refresh) the

--- a/src/lib/protocols/prepared-call-context.ts
+++ b/src/lib/protocols/prepared-call-context.ts
@@ -1,0 +1,29 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import type { AgentConfig } from '../types';
+import type { PreparedProtocolToolCall } from './index';
+
+interface PreparedCallContext {
+  agent: AgentConfig;
+  toolName: string;
+  args: Record<string, unknown>;
+  preparedCall: PreparedProtocolToolCall;
+}
+
+const preparedCallStorage = new AsyncLocalStorage<PreparedCallContext>();
+
+/** Internal exact-wire handoff between TaskExecutor and ProtocolClient. */
+export function withPreparedProtocolToolCall<T>(context: PreparedCallContext, run: () => Promise<T>): Promise<T> {
+  return preparedCallStorage.run(context, run);
+}
+
+/** Consume only for the exact outer call; nested capability calls prepare normally. */
+export function preparedProtocolToolCallFor(
+  agent: AgentConfig,
+  toolName: string,
+  args: Record<string, unknown>
+): PreparedProtocolToolCall | undefined {
+  const context = preparedCallStorage.getStore();
+  return context?.agent === agent && context.toolName === toolName && context.args === args
+    ? context.preparedCall
+    : undefined;
+}

--- a/src/lib/signing/agent-resolver/index.ts
+++ b/src/lib/signing/agent-resolver/index.ts
@@ -17,6 +17,7 @@
  */
 
 export { resolveAgent } from './resolve-agent';
+export { ResolvedAgentJwksResolver } from './resolved-agent-jwks';
 export type {
   AgentResolution,
   AgentProtocol,
@@ -24,6 +25,7 @@ export type {
   ResolveAgentOptions,
   TraceStep,
 } from './resolve-agent';
+export type { ResolvedAgentJwksResolverOptions } from './resolved-agent-jwks';
 export { getAgentJwks, createAgentJwksSet } from './jwks-set';
 export type { AgentJwksResult, GetAgentJwksOptions, CreateAgentJwksSetOptions } from './jwks-set';
 export {

--- a/src/lib/signing/agent-resolver/resolved-agent-jwks.ts
+++ b/src/lib/signing/agent-resolver/resolved-agent-jwks.ts
@@ -1,0 +1,92 @@
+import type { AdcpJsonWebKey } from '../types';
+import type { JwksResolver } from '../jwks';
+import { resolveAgent, type AgentProtocol, type AgentResolution, type ResolveAgentOptions } from './resolve-agent';
+
+export interface ResolvedAgentJwksResolverOptions extends Pick<
+  ResolveAgentOptions,
+  'fetchCapabilities' | 'allowPrivateIp' | 'bodyCaps' | 'timeoutMs' | 'now'
+> {
+  /** Positive cache lifetime in seconds. Defaults to 300. */
+  cacheTtlSeconds?: number;
+  /** Cooldown before an unknown kid can force another discovery. Defaults to 30. */
+  unknownKidCooldownSeconds?: number;
+  /** Test/custom discovery override. Defaults to {@link resolveAgent}. */
+  resolve?: (agentUrl: string, options: ResolveAgentOptions) => Promise<AgentResolution>;
+}
+
+/** JWK resolver pinned to one exact seller URL and protocol. */
+export class ResolvedAgentJwksResolver implements JwksResolver {
+  private readonly now: () => number;
+  private readonly cacheTtlSeconds: number;
+  private readonly unknownKidCooldownSeconds: number;
+  private readonly resolveAgentFn: (agentUrl: string, options: ResolveAgentOptions) => Promise<AgentResolution>;
+  private keys = new Map<string, AdcpJsonWebKey>();
+  private expiresAt = 0;
+  private lastUnknownKidRefresh = Number.NEGATIVE_INFINITY;
+  private inFlight?: Promise<void>;
+
+  constructor(
+    private readonly agentUrl: string,
+    private readonly protocol: AgentProtocol,
+    private readonly options: ResolvedAgentJwksResolverOptions = {}
+  ) {
+    this.now = options.now ?? (() => Math.floor(Date.now() / 1000));
+    this.cacheTtlSeconds = options.cacheTtlSeconds ?? 300;
+    this.unknownKidCooldownSeconds = options.unknownKidCooldownSeconds ?? 30;
+    if (!Number.isFinite(this.cacheTtlSeconds) || this.cacheTtlSeconds <= 0) {
+      throw new TypeError('cacheTtlSeconds must be a finite positive number.');
+    }
+    if (!Number.isFinite(this.unknownKidCooldownSeconds) || this.unknownKidCooldownSeconds < 0) {
+      throw new TypeError('unknownKidCooldownSeconds must be a finite non-negative number.');
+    }
+    this.resolveAgentFn = options.resolve ?? resolveAgent;
+  }
+
+  async resolve(keyid: string): Promise<AdcpJsonWebKey | null> {
+    const now = this.now();
+    let refreshed = false;
+    if (now >= this.expiresAt) {
+      await this.refresh();
+      refreshed = true;
+    }
+    const cached = this.keys.get(keyid);
+    if (cached) return cached;
+
+    // A freshly fetched JWKS is already authoritative for this miss. The
+    // global cooldown (not per attacker-controlled kid) bounds discovery work
+    // when a stream of distinct bogus key ids arrives.
+    if (refreshed) {
+      this.lastUnknownKidRefresh = now;
+      return null;
+    }
+    if (now - this.lastUnknownKidRefresh < this.unknownKidCooldownSeconds) return null;
+    await this.refresh();
+    this.lastUnknownKidRefresh = now;
+    return this.keys.get(keyid) ?? null;
+  }
+
+  private async refresh(): Promise<void> {
+    if (this.inFlight) return this.inFlight;
+    this.inFlight = (async () => {
+      const resolution = await this.resolveAgentFn(this.agentUrl, {
+        protocol: this.protocol,
+        ...(this.options.fetchCapabilities && { fetchCapabilities: this.options.fetchCapabilities }),
+        ...(this.options.allowPrivateIp !== undefined && { allowPrivateIp: this.options.allowPrivateIp }),
+        ...(this.options.bodyCaps && { bodyCaps: this.options.bodyCaps }),
+        ...(this.options.timeoutMs !== undefined && { timeoutMs: this.options.timeoutMs }),
+        ...(this.options.now && { now: this.options.now }),
+      });
+      const next = new Map<string, AdcpJsonWebKey>();
+      for (const candidate of resolution.jwks.keys) {
+        if (candidate && typeof candidate === 'object' && typeof candidate.kid === 'string') {
+          next.set(candidate.kid, candidate as unknown as AdcpJsonWebKey);
+        }
+      }
+      this.keys = next;
+      this.expiresAt = this.now() + this.cacheTtlSeconds;
+    })().finally(() => {
+      this.inFlight = undefined;
+    });
+    return this.inFlight;
+  }
+}

--- a/src/lib/signing/server.ts
+++ b/src/lib/signing/server.ts
@@ -90,12 +90,14 @@ export {
 export { verifyRequestSignature, type VerifyRequestOptions } from './verifier';
 export {
   createWebhookVerifier,
+  isWebhookLoopbackHost,
   verifyWebhookSignature,
   WEBHOOK_MANDATORY_COMPONENTS,
   WEBHOOK_SIGNING_TAG,
   type CreateWebhookVerifierOptions,
   type VerifyWebhookOptions,
   type VerifyWebhookResult,
+  type WebhookRequestLike,
 } from './webhook-verifier';
 export { createExpressVerifier, type ExpressLike, type ExpressMiddlewareOptions } from './middleware';
 export {
@@ -109,6 +111,7 @@ export {
 export { signResponseAsync } from './signer-async';
 export {
   resolveAgent,
+  ResolvedAgentJwksResolver,
   getAgentJwks,
   createAgentJwksSet,
   AgentResolverError,
@@ -130,5 +133,6 @@ export {
   type IdentityKeyOrigins,
   type IdentityPosture,
   type ResolveAgentOptions,
+  type ResolvedAgentJwksResolverOptions,
   type TraceStep,
 } from './agent-resolver';

--- a/src/lib/signing/webhook-verifier.ts
+++ b/src/lib/signing/webhook-verifier.ts
@@ -23,7 +23,7 @@
  * match the security doc.
  */
 
-import { buildSignatureBase, canonicalTargetUri, getHeaderValue, type RequestLike } from './canonicalize';
+import { buildSignatureBase, canonicalTargetUri, getHeaderValue } from './canonicalize';
 import { contentDigestMatches } from './content-digest';
 import { RequestSignatureError, WebhookSignatureError } from './errors';
 import { parseSignature, parseSignatureInput, type ParsedSignatureInput } from './parser';
@@ -34,6 +34,14 @@ import { InMemoryRevocationStore, type RevocationStore } from './revocation';
 import { ALLOWED_ALGS, CLOCK_SKEW_TOLERANCE_SECONDS, MAX_SIGNATURE_WINDOW_SECONDS } from './types';
 
 export const WEBHOOK_SIGNING_TAG = 'adcp/webhook-signing/v1';
+
+/** Receiver-side request shape; body may be the exact undecoded wire bytes. */
+export interface WebhookRequestLike {
+  method: string;
+  url: string;
+  headers: Record<string, string | string[] | undefined>;
+  body?: string | Uint8Array;
+}
 
 /**
  * Covered-component minimum for webhooks. Unlike request-signing, every
@@ -88,7 +96,7 @@ export interface VerifyWebhookResult {
  * entry, so external traffic can't grow the per-keyid cache.
  */
 export async function verifyWebhookSignature(
-  request: RequestLike,
+  request: WebhookRequestLike,
   options: VerifyWebhookOptions
 ): Promise<VerifyWebhookResult> {
   const now = options.now ? options.now() : Math.floor(Date.now() / 1000);
@@ -246,7 +254,7 @@ export async function verifyWebhookSignature(
   // Step 10: cryptographic verify.
   const base = buildSignatureBase(
     parsedInput.components,
-    request,
+    { method: request.method, url: request.url, headers: request.headers },
     parsedInput.params,
     parsedInput.signatureParamsValue
   );
@@ -374,7 +382,7 @@ function validateTargetUri(rawUrl: string): void {
       `@target-uri "${rawUrl}" is not a parseable URL.`
     );
   }
-  if (url.protocol !== 'https:' && !isLoopbackHost(url.hostname)) {
+  if (url.protocol !== 'https:' && !isWebhookLoopbackHost(url.hostname)) {
     throw new WebhookSignatureError(
       'webhook_target_uri_malformed',
       6,
@@ -406,7 +414,7 @@ function validateTargetUri(rawUrl: string): void {
 // before this sees them. No octet-range check is needed (or reachable).
 const LOOPBACK_IPV4 = /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/;
 
-function isLoopbackHost(hostname: string): boolean {
+export function isWebhookLoopbackHost(hostname: string): boolean {
   if (!hostname) return false;
   // Node's `URL.hostname` keeps IPv6 literals bracketed; a FQDN keeps its dot.
   const normalized = hostname.toLowerCase().replace(/\.$/, '');
@@ -462,11 +470,11 @@ export interface CreateWebhookVerifierOptions extends Omit<VerifyWebhookOptions,
  */
 export function createWebhookVerifier(
   options: CreateWebhookVerifierOptions
-): (request: RequestLike) => Promise<VerifyWebhookResult> {
+): (request: WebhookRequestLike) => Promise<VerifyWebhookResult> {
   // Instantiate defaults once at creation time so every request handled by
   // this verifier shares the same replay / revocation state. Per-request
   // construction would defeat replay detection entirely.
   const replayStore = options.replayStore ?? new InMemoryReplayStore();
   const revocationStore = options.revocationStore ?? new InMemoryRevocationStore();
-  return (request: RequestLike) => verifyWebhookSignature(request, { ...options, replayStore, revocationStore });
+  return (request: WebhookRequestLike) => verifyWebhookSignature(request, { ...options, replayStore, revocationStore });
 }

--- a/test/webhook-rfc9421-client.test.js
+++ b/test/webhook-rfc9421-client.test.js
@@ -1,4 +1,4 @@
-const { describe, test, afterEach } = require('node:test');
+const { describe, test } = require('node:test');
 const assert = require('node:assert');
 const crypto = require('node:crypto');
 

--- a/test/webhook-rfc9421-client.test.js
+++ b/test/webhook-rfc9421-client.test.js
@@ -1,0 +1,583 @@
+const { describe, test, afterEach } = require('node:test');
+const assert = require('node:assert');
+const crypto = require('node:crypto');
+
+const {
+  ADCPMultiAgentClient,
+  InMemoryWebhookRegistrationStore,
+  SingleAgentClient,
+  TaskExecutor,
+} = require('../dist/lib/index.js');
+const { ProtocolClient, prepareProtocolToolCall } = require('../dist/lib/protocols/index.js');
+const {
+  preparedProtocolToolCallFor,
+  withPreparedProtocolToolCall,
+} = require('../dist/lib/protocols/prepared-call-context.js');
+const { signWebhook } = require('../dist/lib/signing/signer.js');
+const { StaticJwksResolver } = require('../dist/lib/signing/jwks.js');
+const { ResolvedAgentJwksResolver } = require('../dist/lib/signing/agent-resolver/index.js');
+
+const agent = {
+  id: 'seller-1',
+  name: 'Seller',
+  agent_uri: 'https://seller.example/mcp',
+  protocol: 'mcp',
+};
+
+function envelope(overrides = {}) {
+  return {
+    idempotency_key: 'whk_rfc9421_0000001',
+    operation_id: 'op-rfc-1',
+    task_id: 'task-rfc-1',
+    task_type: 'get_products',
+    status: 'completed',
+    timestamp: new Date().toISOString(),
+    result: { products: [] },
+    ...overrides,
+  };
+}
+
+function keypair(kid = 'seller-webhook-2026') {
+  const { privateKey, publicKey } = crypto.generateKeyPairSync('ed25519');
+  const privateJwk = privateKey.export({ format: 'jwk' });
+  const publicJwk = publicKey.export({ format: 'jwk' });
+  return {
+    signer: {
+      keyid: kid,
+      alg: 'ed25519',
+      privateKey: { ...privateJwk, kid, alg: 'ed25519', adcp_use: 'webhook-signing', key_ops: ['sign'] },
+    },
+    publicJwk: { ...publicJwk, kid, alg: 'ed25519', adcp_use: 'webhook-signing', key_ops: ['verify'] },
+  };
+}
+
+async function registeredRfcClient() {
+  const store = new InMemoryWebhookRegistrationStore();
+  const callbackUrl = 'https://buyer.example/webhooks/get_products/op-rfc-1';
+  await store.putIfAbsent({
+    agentId: agent.id,
+    agentUrl: agent.agent_uri,
+    protocol: agent.protocol,
+    operationId: 'op-rfc-1',
+    taskType: 'get_products',
+    callbackUrl,
+    method: 'POST',
+    mode: 'rfc9421',
+    createdAt: Date.now(),
+    expiresAt: Date.now() + 60_000,
+  });
+  const { signer, publicJwk } = keypair();
+  const client = new SingleAgentClient(agent, {
+    webhookRegistrationStore: store,
+    webhookVerification: { jwks: new StaticJwksResolver([publicJwk]) },
+  });
+  return { client, callbackUrl, signer };
+}
+
+function hmacHeaders(rawBody, secret) {
+  const timestamp = Math.floor(Date.now() / 1000);
+  const digest = crypto.createHmac('sha256', secret).update(`${timestamp}.${rawBody}`).digest('hex');
+  return {
+    'x-adcp-signature': `sha256=${digest}`,
+    'x-adcp-timestamp': String(timestamp),
+  };
+}
+
+function makeResponse() {
+  return {
+    statusCode: 0,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(body) {
+      this.body = body;
+    },
+    writeHead(code) {
+      this.statusCode = code;
+    },
+    end(body) {
+      this.body = JSON.parse(body);
+    },
+  };
+}
+
+describe('SingleAgentClient RFC 9421 webhook receiver', () => {
+  test('verifies the registered seller, public URL, and exact raw bytes', async () => {
+    const { client, callbackUrl, signer } = await registeredRfcClient();
+    const rawBody = JSON.stringify(envelope());
+    const signed = signWebhook(
+      { method: 'POST', url: callbackUrl, headers: { 'content-type': 'application/json' }, body: rawBody },
+      signer
+    );
+    const result = await client.verifyAndParseWebhook({
+      rawBody: Buffer.from(rawBody),
+      payload: envelope({ idempotency_key: 'attacker-controlled-parsed-copy' }),
+      headers: signed.headers,
+      taskType: 'get_products',
+      operationId: 'op-rfc-1',
+      requestMethod: 'POST',
+      requestUrl: callbackUrl,
+    });
+
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(result.metadata.idempotencyKey, 'whk_rfc9421_0000001');
+
+    const replay = await client.verifyAndParseWebhook({
+      rawBody,
+      headers: signed.headers,
+      taskType: 'get_products',
+      operationId: 'op-rfc-1',
+      requestMethod: 'POST',
+      requestUrl: callbackUrl,
+    });
+    assert.strictEqual(replay.ok, false);
+    assert.strictEqual(replay.code, 'webhook_signature_replayed');
+  });
+
+  test('rejects mode substitution and a different externally visible URL without fallback', async () => {
+    const { client, callbackUrl, signer } = await registeredRfcClient();
+    const rawBody = JSON.stringify(envelope());
+    const signed = signWebhook(
+      { method: 'POST', url: callbackUrl, headers: { 'content-type': 'application/json' }, body: rawBody },
+      signer
+    );
+
+    const legacyHeaders = await client.verifyAndParseWebhook({
+      rawBody,
+      headers: { ...signed.headers, 'x-adcp-timestamp': String(Math.floor(Date.now() / 1000)) },
+      operationId: 'op-rfc-1',
+      taskType: 'get_products',
+      requestMethod: 'POST',
+      requestUrl: callbackUrl,
+    });
+    assert.strictEqual(legacyHeaders.ok, false);
+    assert.strictEqual(legacyHeaders.code, 'webhook_mode_mismatch');
+
+    const wrongUrl = await client.verifyAndParseWebhook({
+      rawBody,
+      headers: signed.headers,
+      operationId: 'op-rfc-1',
+      taskType: 'get_products',
+      requestMethod: 'POST',
+      requestUrl: 'https://buyer.example/webhooks/get_products/other',
+    });
+    assert.strictEqual(wrongUrl.ok, false);
+    assert.strictEqual(wrongUrl.code, 'webhook_signature_invalid');
+  });
+
+  test('requires trusted route provenance for an RFC-signed request', async () => {
+    const { client, callbackUrl, signer } = await registeredRfcClient();
+    const rawBody = JSON.stringify(envelope());
+    const signed = signWebhook(
+      { method: 'POST', url: callbackUrl, headers: { 'content-type': 'application/json' }, body: rawBody },
+      signer
+    );
+    const result = await client.verifyAndParseWebhook({
+      rawBody,
+      headers: signed.headers,
+      requestMethod: 'POST',
+      requestUrl: callbackUrl,
+    });
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.code, 'webhook_verification_context_missing');
+  });
+
+  test('compares authenticated payload routing claims to the trusted registration', async () => {
+    const { client, callbackUrl, signer } = await registeredRfcClient();
+    const rawBody = JSON.stringify(envelope({ operation_id: 'different-operation' }));
+    const signed = signWebhook(
+      { method: 'POST', url: callbackUrl, headers: { 'content-type': 'application/json' }, body: rawBody },
+      signer
+    );
+    const result = await client.verifyAndParseWebhook({
+      rawBody,
+      headers: signed.headers,
+      taskType: 'get_products',
+      operationId: 'op-rfc-1',
+      requestMethod: 'POST',
+      requestUrl: callbackUrl,
+    });
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.code, 'webhook_envelope_invalid');
+  });
+
+  test('uses configured HMAC without persisting secret-derived material and rejects selector substitution', async () => {
+    const secret = 'legacy-secret';
+    const store = new InMemoryWebhookRegistrationStore();
+    const registration = {
+      agentId: agent.id,
+      agentUrl: agent.agent_uri,
+      protocol: agent.protocol,
+      operationId: 'op-rfc-1',
+      taskType: 'get_products',
+      callbackUrl: 'https://buyer.example/webhooks/get_products/op-rfc-1',
+      method: 'POST',
+      mode: 'hmac-sha256',
+      createdAt: Date.now(),
+      expiresAt: Date.now() + 60_000,
+    };
+    await store.putIfAbsent(registration);
+    assert.ok(!JSON.stringify(registration).includes(secret));
+
+    const client = new SingleAgentClient(agent, {
+      webhookSecret: secret,
+      webhookRegistrationStore: store,
+    });
+    const rawBody = JSON.stringify(envelope());
+    const headers = hmacHeaders(rawBody, secret);
+    const verified = await client.verifyAndParseWebhook({
+      rawBody,
+      headers,
+      taskType: 'get_products',
+      operationId: 'op-rfc-1',
+    });
+    assert.strictEqual(verified.ok, true);
+
+    const substituted = await client.verifyAndParseWebhook({
+      rawBody,
+      headers: { ...headers, signature: 'sig1=:AAAA:' },
+      taskType: 'get_products',
+      operationId: 'op-rfc-1',
+    });
+    assert.strictEqual(substituted.ok, false);
+    assert.strictEqual(substituted.code, 'webhook_mode_mismatch');
+  });
+
+  test('preserves recordless legacy HMAC compatibility after restart or replica changes', async () => {
+    const secret = 'legacy-secret';
+    const unavailableStore = {
+      async get() {
+        throw new Error('store unavailable');
+      },
+      async putIfAbsent() {
+        throw new Error('store unavailable');
+      },
+    };
+    const client = new SingleAgentClient(agent, {
+      webhookSecret: secret,
+      webhookRegistrationStore: unavailableStore,
+    });
+    const rawBody = JSON.stringify(envelope({ operation_id: 'unregistered-operation' }));
+    const headers = hmacHeaders(rawBody, secret);
+    const verified = await client.verifyAndParseWebhook({
+      rawBody,
+      headers,
+      taskType: 'get_products',
+      operationId: 'unregistered-operation',
+    });
+    assert.strictEqual(verified.ok, true);
+
+    const registrationBase = {
+      agent,
+      taskType: 'get_products',
+      operationId: 'op-persistence-outage',
+      callbackUrl: 'https://buyer.example/webhook/op-persistence-outage',
+    };
+    await client.persistWebhookRegistration({ ...registrationBase, mode: 'hmac-sha256' });
+    await assert.rejects(
+      client.persistWebhookRegistration({ ...registrationBase, mode: 'rfc9421' }),
+      /store unavailable/
+    );
+  });
+});
+
+describe('webhook registration provenance', () => {
+  test('putIfAbsent is idempotent for exact provenance and rejects substitution', async () => {
+    const store = new InMemoryWebhookRegistrationStore();
+    const registration = {
+      agentId: agent.id,
+      agentUrl: agent.agent_uri,
+      protocol: agent.protocol,
+      operationId: 'op-store-1',
+      taskType: 'get_products',
+      callbackUrl: 'https://buyer.example/webhook/op-store-1',
+      method: 'POST',
+      mode: 'rfc9421',
+      createdAt: Date.now(),
+      expiresAt: Date.now() + 60_000,
+    };
+    await store.putIfAbsent(registration);
+    await store.putIfAbsent({ ...registration, createdAt: registration.createdAt + 1 });
+    await assert.rejects(
+      store.putIfAbsent({ ...registration, callbackUrl: 'https://attacker.example/webhook' }),
+      /different trusted provenance/
+    );
+  });
+
+  test('TaskExecutor persists the single prepared call before dispatch', async () => {
+    const original = ProtocolClient.callTool;
+    let registration;
+    const store = new InMemoryWebhookRegistrationStore();
+    ProtocolClient.callTool = async () => {
+      assert.ok(registration, 'registration must be durable before dispatch begins');
+      return { status: 'completed', result: { products: [] } };
+    };
+    try {
+      const executor = new TaskExecutor({
+        webhookUrlTemplate: 'https://buyer.example/webhook/{operation_id}',
+        agentId: agent.id,
+        onWebhookRegistration: async value => {
+          registration = value;
+          const now = Date.now();
+          await store.putIfAbsent({
+            agentId: value.agent.id,
+            agentUrl: value.agent.agent_uri,
+            protocol: value.agent.protocol,
+            operationId: value.operationId,
+            taskType: value.taskType,
+            callbackUrl: value.callbackUrl,
+            method: 'POST',
+            mode: value.mode,
+            createdAt: now,
+            expiresAt: now + 60_000,
+          });
+        },
+        validation: { requests: 'off', responses: 'off' },
+      });
+      await executor.executeTask(agent, 'extension_task', {});
+      assert.strictEqual(registration.callbackUrl, `https://buyer.example/webhook/${registration.operationId}`);
+      assert.ok(!JSON.stringify(registration).includes('credentials'));
+      assert.ok(
+        await store.get(agent.id, registration.operationId),
+        'a late callback remains verifiable after a synchronous terminal response'
+      );
+    } finally {
+      ProtocolClient.callTool = original;
+    }
+  });
+
+  test('prepares MCP and A2A placement exactly and never treats reporting_webhook as task registration', async () => {
+    const reporting = { url: 'https://buyer.example/reporting' };
+    const callbackUrl = 'https://buyer.example/webhook/op-placement';
+    const mcp = prepareProtocolToolCall(agent, { reporting_webhook: reporting }, { webhookUrl: callbackUrl });
+    assert.strictEqual(mcp.args.reporting_webhook, reporting);
+    assert.deepStrictEqual(mcp.args.push_notification_config, { url: callbackUrl });
+
+    const a2aAgent = { ...agent, protocol: 'a2a' };
+    const a2a = prepareProtocolToolCall(a2aAgent, { reporting_webhook: reporting }, { webhookUrl: callbackUrl });
+    assert.strictEqual(a2a.args.reporting_webhook, reporting);
+    assert.strictEqual(a2a.args.push_notification_config, undefined);
+    assert.deepStrictEqual(a2a.pushNotificationConfig, { url: callbackUrl });
+
+    const args = { reporting_webhook: reporting };
+    const prepared = { args: { ...args, exact_marker: true } };
+    await withPreparedProtocolToolCall(
+      { agent, toolName: 'extension_task', args, preparedCall: prepared },
+      async () => {
+        assert.strictEqual(
+          preparedProtocolToolCallFor(agent, 'extension_task', args),
+          prepared,
+          'the internal transport handoff preserves prepared object identity'
+        );
+        assert.strictEqual(preparedProtocolToolCallFor(agent, 'extension_task', { ...args }), undefined);
+      }
+    );
+
+    const original = ProtocolClient.callTool;
+    let registrations = 0;
+    ProtocolClient.callTool = async () => ({ status: 'completed', result: {} });
+    try {
+      const executor = new TaskExecutor({
+        agentId: agent.id,
+        onWebhookRegistration: async () => {
+          registrations += 1;
+        },
+        validation: { requests: 'off', responses: 'off' },
+      });
+      await executor.executeTask(agent, 'extension_task', { reporting_webhook: reporting });
+      await executor.executeTask(agent, 'extension_task', {
+        push_notification_config: { url: 'http://caller-owned.example/callback' },
+      });
+      assert.strictEqual(registrations, 0);
+    } finally {
+      ProtocolClient.callTool = original;
+    }
+  });
+
+  test('HMAC registration contains no secret material and preserves existing short credentials', async () => {
+    const original = ProtocolClient.callTool;
+    const secret = 'legacy-secret';
+    let registration;
+    let dispatches = 0;
+    ProtocolClient.callTool = async () => {
+      dispatches += 1;
+      return { status: 'submitted' };
+    };
+    try {
+      const executor = new TaskExecutor({
+        webhookUrlTemplate: 'https://buyer.example/webhook/{operation_id}',
+        webhookSecret: secret,
+        agentId: agent.id,
+        onWebhookRegistration: async value => {
+          registration = value;
+        },
+        validation: { requests: 'off', responses: 'off' },
+      });
+      await executor.executeTask(agent, 'extension_task', {});
+      assert.strictEqual(dispatches, 1);
+      assert.strictEqual(registration.mode, 'hmac-sha256');
+      assert.ok(!JSON.stringify(registration).includes(secret));
+    } finally {
+      ProtocolClient.callTool = original;
+    }
+  });
+
+  test('A2A registration comes from transport configuration, and store failure prevents dispatch', async () => {
+    const original = ProtocolClient.callTool;
+    const a2aAgent = { ...agent, id: 'seller-a2a', protocol: 'a2a', agent_uri: 'https://seller.example/a2a' };
+    let dispatches = 0;
+    let registration;
+    ProtocolClient.callTool = async () => {
+      dispatches += 1;
+      return { status: 'completed', result: {} };
+    };
+    try {
+      const executor = new TaskExecutor({
+        webhookUrlTemplate: 'https://buyer.example/webhook/{operation_id}',
+        agentId: a2aAgent.id,
+        onWebhookRegistration: async value => {
+          registration = value;
+        },
+        validation: { requests: 'off', responses: 'off' },
+      });
+      await executor.executeTask(a2aAgent, 'extension_task', {});
+      assert.strictEqual(dispatches, 1);
+      assert.strictEqual(registration.callbackUrl, `https://buyer.example/webhook/${registration.operationId}`);
+
+      const failing = new TaskExecutor({
+        webhookUrlTemplate: 'https://buyer.example/webhook/{operation_id}',
+        agentId: a2aAgent.id,
+        onWebhookRegistration: async () => {
+          throw new Error('durable store unavailable');
+        },
+        validation: { requests: 'off', responses: 'off' },
+      });
+      const failed = await failing.executeTask(a2aAgent, 'extension_task', {});
+      assert.strictEqual(failed.success, false);
+      assert.strictEqual(dispatches, 1, 'seller dispatch must not happen after a registration write failure');
+    } finally {
+      ProtocolClient.callTool = original;
+    }
+  });
+});
+
+describe('seller-pinned webhook JWK discovery cache', () => {
+  test('coalesces positive lookups and rate-limits unknown-kid refreshes', async () => {
+    let now = 1_700_000_000;
+    let resolutions = 0;
+    const resolver = new ResolvedAgentJwksResolver('https://seller.example/mcp', 'mcp', {
+      now: () => now,
+      resolve: async (agentUrl, options) => {
+        resolutions += 1;
+        assert.strictEqual(agentUrl, 'https://seller.example/mcp');
+        assert.strictEqual(options.protocol, 'mcp');
+        return { jwks: { keys: [{ kid: 'known-key', kty: 'OKP' }] } };
+      },
+    });
+
+    assert.strictEqual((await resolver.resolve('known-key')).kid, 'known-key');
+    assert.strictEqual((await resolver.resolve('known-key')).kid, 'known-key');
+    assert.strictEqual(resolutions, 1);
+    assert.strictEqual(await resolver.resolve('unknown-key'), null);
+    assert.strictEqual(await resolver.resolve('unknown-key'), null);
+    assert.strictEqual(resolutions, 2);
+    assert.strictEqual(await resolver.resolve('different-attacker-key'), null);
+    assert.strictEqual(resolutions, 2, 'unknown-kid cooldown is global, not attacker-keyed');
+    now += 31;
+    assert.strictEqual(await resolver.resolve('unknown-key'), null);
+    assert.strictEqual(resolutions, 3);
+  });
+
+  test('binds A2A discovery protocol and retries immediately after a failed refresh', async () => {
+    let resolutions = 0;
+    const resolver = new ResolvedAgentJwksResolver('https://seller.example/a2a', 'a2a', {
+      resolve: async (_agentUrl, options) => {
+        resolutions += 1;
+        assert.strictEqual(options.protocol, 'a2a');
+        if (resolutions === 1) throw new Error('temporary discovery failure');
+        return { jwks: { keys: [{ kid: 'recovered-key', kty: 'OKP' }] } };
+      },
+    });
+    await assert.rejects(resolver.resolve('recovered-key'), /temporary discovery failure/);
+    assert.strictEqual((await resolver.resolve('recovered-key')).kid, 'recovered-key');
+    assert.strictEqual(resolutions, 2);
+  });
+
+  test('rejects invalid cache and cooldown limits', () => {
+    assert.throws(
+      () => new ResolvedAgentJwksResolver(agent.agent_uri, 'mcp', { cacheTtlSeconds: Number.NaN }),
+      /finite positive/
+    );
+    assert.throws(
+      () => new ResolvedAgentJwksResolver(agent.agent_uri, 'mcp', { unknownKidCooldownSeconds: -1 }),
+      /finite non-negative/
+    );
+  });
+});
+
+describe('multi-agent trusted webhook routing', () => {
+  test('selects the verifier from trusted route state and rejects a signed payload that spoofs another agent', async () => {
+    const secondAgent = { ...agent, id: 'seller-2', agent_uri: 'https://seller-2.example/mcp' };
+    const store = new InMemoryWebhookRegistrationStore();
+    const callbackUrl = 'https://buyer.example/webhooks/get_products/seller-1/op-rfc-1';
+    await store.putIfAbsent({
+      agentId: agent.id,
+      agentUrl: agent.agent_uri,
+      protocol: agent.protocol,
+      operationId: 'op-rfc-1',
+      taskType: 'get_products',
+      callbackUrl,
+      method: 'POST',
+      mode: 'rfc9421',
+      createdAt: Date.now(),
+      expiresAt: Date.now() + 60_000,
+    });
+    const { signer, publicJwk } = keypair('multi-agent-key');
+    const client = new ADCPMultiAgentClient([agent, secondAgent], {
+      webhookRegistrationStore: store,
+      webhookVerification: { jwks: new StaticJwksResolver([publicJwk]) },
+    });
+    const handler = client.createWebhookHandler({
+      getAgentId: req => req.params.agent_id,
+      getRequestUrl: () => callbackUrl,
+    });
+
+    const rawBody = JSON.stringify(envelope());
+    const signed = signWebhook(
+      { method: 'POST', url: callbackUrl, headers: { 'content-type': 'application/json' }, body: rawBody },
+      signer
+    );
+    const accepted = makeResponse();
+    await handler(
+      {
+        body: rawBody,
+        rawBody,
+        headers: signed.headers,
+        method: 'POST',
+        params: { agent_id: agent.id, task_type: 'get_products', operation_id: 'op-rfc-1' },
+      },
+      accepted
+    );
+    assert.strictEqual(accepted.statusCode, 202);
+
+    const spoofedBody = JSON.stringify(envelope({ agent_id: secondAgent.id }));
+    const spoofedSigned = signWebhook(
+      { method: 'POST', url: callbackUrl, headers: { 'content-type': 'application/json' }, body: spoofedBody },
+      signer
+    );
+    const rejected = makeResponse();
+    await handler(
+      {
+        body: spoofedBody,
+        rawBody: spoofedBody,
+        headers: spoofedSigned.headers,
+        method: 'POST',
+        params: { agent_id: agent.id, task_type: 'get_products', operation_id: 'op-rfc-1' },
+      },
+      rejected
+    );
+    assert.strictEqual(rejected.statusCode, 400);
+  });
+});


### PR DESCRIPTION
Closes #2423

## Summary
- persist SDK-generated callback mode and routing provenance before seller dispatch
- verify secretless callbacks with RFC 9421 using seller-pinned brand.json/JWKS discovery, replay protection, and trusted public URL binding
- reject authentication-mode substitution while preserving legacy global-HMAC behavior without storing secret-derived material
- add durable store hooks, trusted multi-agent routing, working receiver docs, and regression coverage for MCP/A2A placement

## Verification
- `npm run typecheck`
- `npm run build`
- 167 focused webhook, signing, governance, and transport tests
- conformance integration regression: 6/6
- code, protocol, and DX expert reviews: approved

The required `review:codex` command was attempted, but the configured reviewer service reported that its organization had no remaining credits.