### PR TITLE
fix(testing): buildAccount preserves the test kit's explicit sandbox flag

### DIFF
--- a/.changeset/build-account-preserve-kit-sandbox.md
+++ b/.changeset/build-account-preserve-kit-sandbox.md
@@ -1,0 +1,5 @@
+---
+"@adcp/sdk": patch
+---
+
+`buildAccount` no longer clobbers an explicit `sandbox: false` from the resolved test kit: `sandbox` now defaults to `true` only when the kit leaves it unset. Fixes the `comply_controller_mode_gate` storyboard, whose live-mode kit (`acme-outdoor-live`, `sandbox: false`) could never reach sellers as a live-mode principal — the storyboard failed every seller regardless of their gate (#2580).

--- a/src/lib/testing/test-controller.ts
+++ b/src/lib/testing/test-controller.ts
@@ -65,8 +65,16 @@ const DEFAULT_SANDBOX_ACCOUNT = { brand: { domain: 'test.example' }, operator: '
 function buildAccount(options?: TestOptions): Record<string, unknown> {
   if (options) {
     const account = resolveAccount(options);
-    // Ensure sandbox is set — controller requires it
-    return { ...account, sandbox: true };
+    // Default sandbox to true (the controller requires the field) but let an
+    // explicit kit value win: the comply_controller_mode_gate storyboard's
+    // live-mode kit (acme-outdoor-live) sets `sandbox: false`, and the old
+    // `{ ...account, sandbox: true }` spread clobbered it — no seller could
+    // ever see the live-mode principal the storyboard exists to test (#2580).
+    // A bare spread-flip would regress the other way (resolveAccount always
+    // emits the key, so an unset kit flag would spread `undefined` over the
+    // default), hence the explicit coalesce.
+    const sandbox = 'sandbox' in account ? (account.sandbox ?? true) : true;
+    return { ...account, sandbox };
   }
   return DEFAULT_SANDBOX_ACCOUNT;
 }

--- a/test/lib/test-controller-build-account-sandbox.test.js
+++ b/test/lib/test-controller-build-account-sandbox.test.js
@@ -1,0 +1,68 @@
+/**
+ * buildAccount must preserve an explicit `sandbox: false` from the resolved
+ * test kit (adcp-client#2580): the comply_controller_mode_gate storyboard's
+ * live-mode kit (acme-outdoor-live) sets `sandbox: false`, but the old
+ * `{ ...account, sandbox: true }` spread clobbered it — every controller
+ * call reached sellers as a sandbox principal, making the storyboard
+ * ungradeable by construction. Exercised through the exported
+ * callControllerRaw with a capture client (buildAccount is module-private).
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { callControllerRaw } = require('../../dist/lib/testing/test-controller.js');
+
+function captureClient() {
+  const captured = {};
+  return {
+    captured,
+    executeTask(name, params) {
+      captured.name = name;
+      captured.params = params;
+      return Promise.resolve({ success: true, data: { content: [{ type: 'text', text: '{}' }] } });
+    },
+  };
+}
+
+const BRAND_OPTIONS = { brand: { domain: 'acme-outdoor.example' } };
+
+describe('buildAccount sandbox handling (via callControllerRaw)', () => {
+  it("preserves the live-mode kit's explicit sandbox: false", async () => {
+    const client = captureClient();
+    await callControllerRaw(
+      client,
+      { scenario: 'force_creative_status' },
+      {
+        ...BRAND_OPTIONS,
+        sandbox: false,
+      }
+    );
+    assert.equal(client.captured.params.account.sandbox, false);
+  });
+
+  it('defaults sandbox to true when the kit sets nothing', async () => {
+    const client = captureClient();
+    await callControllerRaw(client, { scenario: 'seed_product' }, BRAND_OPTIONS);
+    assert.equal(client.captured.params.account.sandbox, true);
+  });
+
+  it('keeps an explicit sandbox: true untouched', async () => {
+    const client = captureClient();
+    await callControllerRaw(
+      client,
+      { scenario: 'seed_product' },
+      {
+        ...BRAND_OPTIONS,
+        sandbox: true,
+      }
+    );
+    assert.equal(client.captured.params.account.sandbox, true);
+  });
+
+  it('no options still yields the default sandbox account', async () => {
+    const client = captureClient();
+    await callControllerRaw(client, { scenario: 'list_scenarios' });
+    assert.equal(client.captured.params.account.sandbox, true);
+  });
+});


### PR DESCRIPTION
Fixes #2580.

`buildAccount` unconditionally stamped `sandbox: true` after spreading the resolved account, so the `comply_controller_mode_gate` storyboard's live-mode kit (`acme-outdoor-live`, `sandbox: false`) could never reach any seller as a live-mode principal — the storyboard failed every seller regardless of their gate (wire evidence in the issue: a graded probe arrived at a production seller as `account: {"sandbox": true}`).

## Fix

`sandbox` now defaults to `true` only when the resolved kit leaves it unset:

```ts
const sandbox = 'sandbox' in account ? (account.sandbox ?? true) : true;
return { ...account, sandbox };
```

A bare spread-flip (`{ sandbox: true, ...account }`) would regress the other way — `resolveAccount` always emits the key, so an unset kit flag would spread `undefined` over the default; and the `account_id` arm of the `AccountReference` union has no `sandbox` member, hence the `in`-narrowing.

## Tests

New `test/lib/test-controller-build-account-sandbox.test.js` (4 cases, exercised through the exported `callControllerRaw` with a capture client since `buildAccount` is module-private): explicit `false` preserved, unset defaults `true`, explicit `true` untouched, no-options default account. Adjacent controller suites (seeding, bridge, discovery-arm) pass unchanged. Changeset included (patch).

Validation offer stands: our seller's FORBIDDEN gate is deployed at adcp.bidmachine.io — a mode-gate run on a build with this fix should flip that storyboard to green immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)