### PR TITLE
fix: bound long-lived client and server resources

### DIFF
--- a/.changeset/calm-foxes-bound.md
+++ b/.changeset/calm-foxes-bound.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': minor
+---
+
+Bound long-lived client and server caches and add a 60-second default deadline plus a 2 MiB response-body cap to `createUpstreamHttpClient`. Canonical-reference resolvers now use a count- and byte-bounded LRU by default, A2A client discovery and multi-host metadata caches evict least-recent entries, and upstream calls accept per-client/per-call `requestTimeoutMs`, `maxResponseBytes`, and caller cancellation. Set either numeric option to `0` to disable that bound.

--- a/docs/guides/CANONICAL-REFERENCE-RESOLVER.md
+++ b/docs/guides/CANONICAL-REFERENCE-RESOLVER.md
@@ -9,9 +9,20 @@ AdCP 3.1 `format_schema` and `platform_extensions` references use the same immut
 Use `@adcp/sdk/canonical-references` instead of hand-rolled fetch code. The resolver applies the SDK SSRF guard, pins DNS before connecting, disables redirects, enforces a 5 second default timeout, caps bodies at 1 MiB by default, verifies the SHA-256 digest, and caches successful fetched root documents by a policy-scoped `uri@digest` key.
 
 ```ts
-import { createCanonicalReferenceResolver } from '@adcp/sdk/canonical-references';
+import {
+  createCanonicalReferenceCache,
+  createCanonicalReferenceResolver,
+} from '@adcp/sdk/canonical-references';
 
 const resolver = createCanonicalReferenceResolver();
+
+// Optional: tune the bounded per-resolver LRU for your process budget.
+const largerResolver = createCanonicalReferenceResolver({
+  cache: createCanonicalReferenceCache({
+    maxEntries: 128,
+    maxBytes: 64 * 1024 * 1024,
+  }),
+});
 
 const formatSchemaRef = {
   uri: 'https://publisher.example-ad.com/schemas/slot.json',
@@ -59,7 +70,7 @@ External `$ref` bodies are mutable unless pinned. The canonical resolver therefo
 
 | Option | Default | Notes |
 |---|---:|---|
-| `cache` | fresh per resolver | Caller-owned cache. Entries are cloned on read/write and scoped by security policy. |
+| `cache` | fresh bounded LRU per resolver | The default keeps at most 64 entries and 32 MiB of estimated retained data. Pass `createCanonicalReferenceCache({ maxEntries, maxBytes })` to tune it, or inject a caller-owned cache. Entries are cloned on read/write and scoped by security policy. |
 | `timeoutMs` | `5000` | Per-fetch timeout. |
 | `maxBodyBytes` | `1048576` | Per-body cap for top-level and external ref fetches. |
 | `externalRefDigests` | none | Required for every external `$ref` in `format_schema`. |
@@ -73,3 +84,5 @@ External `$ref` bodies are mutable unless pinned. The canonical resolver therefo
 | `allowPrivateNetwork` | `false` | Test/dev-only private-network fixture escape hatch. Metadata/link-local remains blocked. |
 
 The legacy `@adcp/sdk/v2/format-schema` helpers still support the older `ADCP_ALLOW_INTERNAL_PROBES=1` test pattern. The canonical resolver uses explicit per-call/per-resolver options instead, so production code cannot inherit a relaxed environment flag accidentally.
+
+`maxBytes` is a conservative estimate covering the cached body, decoded string, and parsed document; exact JavaScript heap overhead varies by runtime. Content-addressed entries do not expire by time. LRU eviction can cause a later refetch, but the digest still guarantees the same immutable document. A custom injected cache remains entirely caller-owned and is not wrapped or capped by the resolver.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -102,7 +102,7 @@ const buy = await agent.createMediaBuy({
 
 ## Canonical Reference Resolver
 
-`format_schema` and `platform_extensions` references use immutable `{ uri, digest }` pointers. Use `createCanonicalReferenceResolver` from `@adcp/sdk/canonical-references` instead of raw fetches; it applies SSRF-safe DNS-pinned fetches, redirect blocking, timeout/body caps, SHA-256 verification, structured non-throwing statuses, and caller-owned policy-scoped caching.
+`format_schema` and `platform_extensions` references use immutable `{ uri, digest }` pointers. Use `createCanonicalReferenceResolver` from `@adcp/sdk/canonical-references` instead of raw fetches; it applies SSRF-safe DNS-pinned fetches, redirect blocking, timeout/body caps, SHA-256 verification, structured non-throwing statuses, and bounded policy-scoped LRU caching. The zero-argument cache holds at most 64 entries / 32 MiB estimated retained data; use `createCanonicalReferenceCache({ maxEntries, maxBytes })` to tune the per-resolver budget or inject a fully caller-owned cache.
 
 ```typescript
 import { createCanonicalReferenceResolver } from '@adcp/sdk/canonical-references';

--- a/scripts/generate-agent-docs.ts
+++ b/scripts/generate-agent-docs.ts
@@ -671,7 +671,7 @@ function generateLlmsTxt(
   ln(`## Canonical Reference Resolver`);
   ln();
   ln(
-    `\`format_schema\` and \`platform_extensions\` references use immutable \`{ uri, digest }\` pointers. Use \`createCanonicalReferenceResolver\` from \`@adcp/sdk/canonical-references\` instead of raw fetches; it applies SSRF-safe DNS-pinned fetches, redirect blocking, timeout/body caps, SHA-256 verification, structured non-throwing statuses, and caller-owned policy-scoped caching.`
+    `\`format_schema\` and \`platform_extensions\` references use immutable \`{ uri, digest }\` pointers. Use \`createCanonicalReferenceResolver\` from \`@adcp/sdk/canonical-references\` instead of raw fetches; it applies SSRF-safe DNS-pinned fetches, redirect blocking, timeout/body caps, SHA-256 verification, structured non-throwing statuses, and bounded policy-scoped LRU caching. The zero-argument cache holds at most 64 entries / 32 MiB estimated retained data; use \`createCanonicalReferenceCache({ maxEntries, maxBytes })\` to tune the per-resolver budget or inject a fully caller-owned cache.`
   );
   ln();
   ln('```typescript');

--- a/skills/build-seller-agent/deployment.md
+++ b/skills/build-seller-agent/deployment.md
@@ -16,12 +16,7 @@ Pass functions for `publicUrl` and `protectedResource`, branch on `ctx.host` in 
 
 ```typescript
 import { UnknownHostError, hostname } from '@adcp/sdk';
-import {
-  createAdcpServerFromPlatform,
-  serve,
-  verifyBearer,
-  type DecisioningPlatform,
-} from '@adcp/sdk/server';
+import { createAdcpServerFromPlatform, serve, verifyBearer, type DecisioningPlatform } from '@adcp/sdk/server';
 
 declare const snapPlatform: DecisioningPlatform;
 declare const metaPlatform: DecisioningPlatform;
@@ -36,17 +31,17 @@ const adapters = new Map<string, { name: string; platform: DecisioningPlatform }
   // ... one entry per hostname you front
 ]);
 
+function requireHostConfig(rawHost: string) {
+  if (!rawHost) throw new UnknownHostError('Host header required');
+  const host = hostname(rawHost); // strips a local/test port; works for IPv6
+  const config = adapters.get(host);
+  if (!config) throw new UnknownHostError(`No adapter configured for ${host}`);
+  return { host, ...config };
+}
+
 serve(
   ctx => {
-    // Fail closed on missing Host header. HTTP/1.1 requires it, but a
-    // misbehaving client can omit it — ctx.host is `''` in that case,
-    // and a blank-host adapter lookup would mint audience-mismatched
-    // tokens if we proceeded.
-    if (!ctx.host) throw new UnknownHostError('Host header required');
-    const cfg = adapters.get(ctx.host);
-    // UnknownHostError → 404 (generic body, routing table stays off the wire).
-    // Any other thrown error still surfaces as 500.
-    if (!cfg) throw new UnknownHostError(`No adapter configured for ${ctx.host}`);
+    const cfg = requireHostConfig(ctx.host);
     return createAdcpServerFromPlatform(cfg.platform, {
       name: cfg.name,
       version: '1.0.0',
@@ -54,11 +49,11 @@ serve(
   },
   {
     trustForwardedHost: true, // behind Fly/Cloud Run/ALB that sets X-Forwarded-Host
-    // hostname() strips the port — test/local runs include `:3001`, production
-    // doesn't. Works for IPv6 too.
-    publicUrl: host => `https://${hostname(host)}/mcp`,
-    protectedResource: host => ({
-      authorization_servers: [`https://${hostname(host)}/oauth`],
+    // The auth-free PRM route invokes these resolvers before the factory, so
+    // they MUST enforce the same allowlist instead of interpolating raw Host.
+    publicUrl: rawHost => `https://${requireHostConfig(rawHost).host}/mcp`,
+    protectedResource: rawHost => ({
+      authorization_servers: [`https://${requireHostConfig(rawHost).host}/oauth`],
       scopes_supported: ['read', 'write'],
     }),
     authenticate: verifyBearer({
@@ -74,13 +69,13 @@ serve(
 );
 ```
 
-Each unique host runs its resolver once and the result is cached. Every host advertises its own RFC 9728 `resource` URL, the 401 challenge carries the host's `resource_metadata` URL, and the factory sees the resolved host so it can return host-specific handlers. Auth, RFC 9421 signature verification, idempotency, and governance composition all stay inside `serve()` — nothing extra to re-own.
+Up to 128 accepted hosts are cached in a process-local LRU. `publicUrl` and `protectedResource` must be side-effect-free and idempotent because an evicted host is resolved again on its next request. Every host advertises its own RFC 9728 `resource` URL, the 401 challenge carries the host's `resource_metadata` URL, and the factory sees the resolved host so it can return host-specific handlers. Auth, RFC 9421 signature verification, idempotency, and governance composition all stay inside `serve()` — nothing extra to re-own.
 
 **Audience binding: use the ctx-form callback.** `audience: (req, { publicUrl }) => publicUrl` is the safest shape — the JWT audience check is guaranteed to match what RFC 9728 PRM advertises for this host, and `publicUrl` already follows `serve()`'s host resolution. `audience: (req) => ...` also works but you own the security: don't read `X-Forwarded-Host` there directly (it bypasses `trustForwardedHost`), and don't string-concat the mount path (it breaks silently if the mount path changes).
 
 **`trustForwardedHost: true` requires an overwriting proxy.** The framework trusts the first entry in an `X-Forwarded-Host` chain — safe when your proxy rewrites the header on ingress, UNSAFE when it appends (the attacker gets to pick the first entry). Fly, Cloud Run, and GCP HTTPS LBs overwrite. AWS ALB default and nginx default append — these need `proxy_set_header X-Forwarded-Host $host;` or equivalent before you enable the flag. Verify against a request that already has `X-Forwarded-Host: attacker.example` in it. RFC 7239 `Forwarded: host=...` is read the same way (same trust requirement).
 
-**Unknown hosts: throw `UnknownHostError` from the factory.** `serve()` catches it and responds 404 with a generic body (the routing table never crosses the wire). Throwing any other `Error` stays as a 500 so unrelated bugs remain loud.
+**Unknown hosts: throw `UnknownHostError` from every host callback.** Use one shared allowlist helper for the factory, `publicUrl`, and `protectedResource`; the auth-free PRM route can invoke the resolvers before the factory. `serve()` catches the error and responds 404 with a generic body (the routing table never crosses the wire). Throwing any other `Error` stays as a 500 so unrelated bugs remain loud.
 
 **Factory runs per request.** `serve()` calls the factory on every incoming request (to avoid cross-request state bleed). By default it closes the returned server at the end of each request — so caching the `AdcpServer` from one call to the next is unsafe without opt-in. Keep the default-path factory cheap: look up a pre-built platform from a module-scoped `Map`, and let `createAdcpServerFromPlatform(...)` build a fresh wrapper from that platform on every call.
 

--- a/src/lib/canonical-references/index.ts
+++ b/src/lib/canonical-references/index.ts
@@ -6,7 +6,7 @@
  * hex digest of the fetched body. This module gives callers one security
  * boundary for resolving those references: HTTPS-only by default, DNS-pinned
  * SSRF-safe fetches, redirects disabled, body and timeout caps, digest
- * verification, caller-owned caching, and structured non-throwing results.
+ * verification, bounded policy-scoped caching, and structured non-throwing results.
  */
 import { createHash } from 'crypto';
 import Ajv from 'ajv';
@@ -124,8 +124,15 @@ export interface CanonicalReferenceCache {
   set(key: string, value: CanonicalReferenceResolvedResult): void;
 }
 
+export interface CanonicalReferenceCacheOptions {
+  /** Maximum retained entries. Default 64. Set to 0 to disable caching. */
+  maxEntries?: number;
+  /** Maximum estimated retained bytes. Default 32 MiB. Set to 0 to disable caching. */
+  maxBytes?: number;
+}
+
 export interface CanonicalReferenceResolverOptions {
-  /** Caller-owned cache. Defaults to a fresh per-resolver Map. */
+  /** Caller-owned cache. Defaults to a fresh bounded per-resolver LRU. */
   cache?: CanonicalReferenceCache;
   /** Default 5_000 ms. */
   timeoutMs?: number;
@@ -179,6 +186,8 @@ export interface CanonicalReferenceResolver {
 const DEFAULT_TIMEOUT_MS = 5_000;
 const DEFAULT_MAX_BODY_BYTES = 1024 * 1024;
 const DEFAULT_MAX_TOTAL_REF_BYTES = 8 * 1024 * 1024;
+const DEFAULT_CACHE_MAX_ENTRIES = 64;
+const DEFAULT_CACHE_MAX_BYTES = 32 * 1024 * 1024;
 const DIGEST_RE = /^sha256:[0-9a-f]{64}$/;
 const DRAFT_07_URIS = new Set(['http://json-schema.org/draft-07/schema#', 'https://json-schema.org/draft-07/schema#']);
 const DRAFT_2020_12_URIS = new Set([
@@ -197,12 +206,75 @@ const SPECIAL_USE_HOSTS = new Set([
   'test',
 ]);
 
-export function createCanonicalReferenceCache(): CanonicalReferenceCache {
-  const store = new Map<string, CanonicalReferenceResolvedResult>();
+function resolveCacheLimit(
+  name: keyof CanonicalReferenceCacheOptions,
+  value: number | undefined,
+  fallback: number
+): number {
+  const resolved = value ?? fallback;
+  if (!Number.isSafeInteger(resolved) || resolved < 0) {
+    throw new RangeError(`${name} must be a non-negative safe integer`);
+  }
+  return resolved;
+}
+
+/**
+ * Estimate the heap retained by the three large, duplicated representations:
+ * raw bytes, the decoded JS string, and the parsed document. Object overhead is
+ * runtime-specific, so maxBytes is intentionally documented as an estimate.
+ */
+function estimateCanonicalReferenceCacheBytes(key: string, value: CanonicalReferenceResolvedResult): number {
+  let documentBytes = value.body.byteLength * 2;
+  try {
+    const serialized = JSON.stringify(value.document);
+    if (serialized !== undefined) documentBytes = serialized.length * 2;
+  } catch {
+    // Canonical JSON cannot be cyclic, but caller-supplied cache values may be.
+    // Retain the conservative body-derived fallback in that case.
+  }
+  const retainedStrings =
+    key.length * 2 +
+    (value.cacheKey?.length ?? 0) * 2 +
+    (value.ref?.uri?.length ?? 0) * 2 +
+    (value.ref?.digest?.length ?? 0) * 2 +
+    (value.contentType?.length ?? 0) * 2;
+  return value.body.byteLength + value.text.length * 2 + documentBytes + retainedStrings + 512;
+}
+
+export function createCanonicalReferenceCache(options: CanonicalReferenceCacheOptions = {}): CanonicalReferenceCache {
+  const maxEntries = resolveCacheLimit('maxEntries', options.maxEntries, DEFAULT_CACHE_MAX_ENTRIES);
+  const maxBytes = resolveCacheLimit('maxBytes', options.maxBytes, DEFAULT_CACHE_MAX_BYTES);
+  const store = new Map<string, { value: CanonicalReferenceResolvedResult; bytes: number }>();
+  let retainedBytes = 0;
+
   return {
-    get: key => store.get(key),
+    get: key => {
+      const entry = store.get(key);
+      if (!entry) return undefined;
+      // Map iteration order is the LRU order: refresh hits to most-recent.
+      store.delete(key);
+      store.set(key, entry);
+      return entry.value;
+    },
     set: (key, value) => {
-      store.set(key, value);
+      const previous = store.get(key);
+      if (previous) {
+        store.delete(key);
+        retainedBytes -= previous.bytes;
+      }
+
+      const bytes = estimateCanonicalReferenceCacheBytes(key, value);
+      if (maxEntries === 0 || maxBytes === 0 || bytes > maxBytes) return;
+
+      store.set(key, { value, bytes });
+      retainedBytes += bytes;
+      while (store.size > maxEntries || retainedBytes > maxBytes) {
+        const oldestKey = store.keys().next().value as string | undefined;
+        if (oldestKey === undefined) break;
+        const oldest = store.get(oldestKey);
+        store.delete(oldestKey);
+        if (oldest) retainedBytes -= oldest.bytes;
+      }
     },
   };
 }

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -442,6 +442,7 @@ export {
   resolvePlatformExtensionsReference,
   type CanonicalReference,
   type CanonicalReferenceCache,
+  type CanonicalReferenceCacheOptions,
   type CanonicalReferenceError,
   type CanonicalReferenceErrorCode,
   type CanonicalReferenceFailureResult,

--- a/src/lib/protocols/a2a.ts
+++ b/src/lib/protocols/a2a.ts
@@ -1,7 +1,6 @@
 // Official A2A client implementation - NO FALLBACKS
 import { A2AClient as A2AClientImpl } from '@a2a-js/sdk/client';
 import { AsyncLocalStorage } from 'node:async_hooks';
-import { createHmac } from 'node:crypto';
 import type { PushNotificationConfig } from '../types/tools.generated';
 import type { DebugLogEntry } from '../types/adcp';
 import { AuthenticationRequiredError, is401Error } from '../errors';
@@ -60,6 +59,24 @@ const callContextStorage = new AsyncLocalStorage<A2ACallContext>();
  */
 const a2aClientCache = new Map<string, InstanceType<typeof A2AClient>>();
 const pendingA2AClients = new Map<string, Promise<InstanceType<typeof A2AClient>>>();
+const MAX_CACHED_A2A_CLIENTS = 20;
+let a2aClientGeneration = 0;
+
+function getCachedA2AClient(cacheKey: string): InstanceType<typeof A2AClient> | undefined {
+  const client = a2aClientCache.get(cacheKey);
+  if (!client) return undefined;
+  a2aClientCache.delete(cacheKey);
+  a2aClientCache.set(cacheKey, client);
+  return client;
+}
+
+function evictLeastRecentlyUsedA2AClients(): void {
+  while (a2aClientCache.size > MAX_CACHED_A2A_CLIENTS) {
+    const oldestKey = a2aClientCache.keys().next().value as string | undefined;
+    if (oldestKey === undefined) return;
+    a2aClientCache.delete(oldestKey);
+  }
+}
 
 /**
  * Build the A2A connection-cache key. Mirrors the rationale in
@@ -79,31 +96,18 @@ function a2aCacheKey(
   agentUrl: string,
   authToken?: string,
   signingCacheKey?: string,
-  customHeaders?: Record<string, string>
+  customHeaders?: Record<string, string>,
+  allowPrivateIp = false
 ): string {
-  // 64-bit Map-key disambiguator — NOT a password hash. The cached client
-  // closes over the full credential, so a hypothetical hash collision still
-  // sends the original credential on the wire, just possibly cache-miss
-  // and reconnect. Routed via `cacheDisambiguator` (HMAC-SHA256 with empty
-  // key) instead of bare `createHash` so CodeQL's
-  // `js/insufficient-password-hash` heuristic doesn't misclassify the
-  // dataflow — see the helper docstring for the full rationale.
+  // Use the exact credential/header material in this private, in-memory key.
+  // The cached client already retains the same credential, so hashing would
+  // not reduce secret lifetime and would introduce a collision boundary.
+  // This key is never logged or persisted.
   const fingerprint = authToken ?? extractA2AAuthHeader(customHeaders);
-  const tokenSuffix = fingerprint ? `::${cacheDisambiguator(fingerprint)}` : '';
-  const headersKey = headersCacheDisambiguator(customHeaders);
-  const headersSuffix = headersKey ? `::headers:${headersKey}` : '';
-  const signingSuffix = signingCacheKey ? `::${signingCacheKey}` : '';
-  return `${agentUrl}${tokenSuffix}${headersSuffix}${signingSuffix}`;
-}
-
-/**
- * Produce a stable 64-bit Map-key disambiguator from credential material.
- * Mirrors the helper in `src/lib/protocols/mcp.ts` — the two protocol
- * modules intentionally don't share runtime imports, so each carries its
- * own copy. See the MCP-side docstring for the full rationale.
- */
-function cacheDisambiguator(value: string): string {
-  return createHmac('sha256', '').update(value).digest('hex').slice(0, 16);
+  const headersKey = headersCacheMaterial(customHeaders);
+  // A serialized tuple avoids delimiter ambiguity between attacker-controlled
+  // URLs and the policy/auth suffixes (for example, a URL ending in a suffix).
+  return JSON.stringify([agentUrl, fingerprint ?? null, headersKey ?? null, signingCacheKey ?? null, allowPrivateIp]);
 }
 
 /**
@@ -119,7 +123,7 @@ function extractA2AAuthHeader(headers: Record<string, string> | undefined): stri
   return undefined;
 }
 
-function headersCacheDisambiguator(headers?: Record<string, string>): string | undefined {
+function headersCacheMaterial(headers?: Record<string, string>): string | undefined {
   const entries = Object.entries(headers ?? {})
     .filter(([key]) => {
       const lower = key.toLowerCase();
@@ -127,7 +131,7 @@ function headersCacheDisambiguator(headers?: Record<string, string>): string | u
     })
     .map(([key, value]) => [key.toLowerCase(), value] as const)
     .sort(([a], [b]) => a.localeCompare(b));
-  return entries.length > 0 ? cacheDisambiguator(JSON.stringify(entries)) : undefined;
+  return entries.length > 0 ? JSON.stringify(entries) : undefined;
 }
 
 function redactHeadersForDebug(headers: Record<string, string>): Record<string, string> {
@@ -156,6 +160,7 @@ function redactPushNotificationConfigForDebug(
  * is just cache eviction.
  */
 export function closeA2AConnections(): void {
+  a2aClientGeneration++;
   a2aClientCache.clear();
   pendingA2AClients.clear();
 }
@@ -275,8 +280,15 @@ async function getOrCreateA2AClient(
   bypassCache = false
 ): Promise<InstanceType<typeof A2AClient>> {
   const signingContext = signingContextStorage.getStore();
-  const fetchFn = callContextStorage.getStore()?.fetchFn;
-  const cacheKey = a2aCacheKey(agentUrl, authToken, signingContext?.cacheKey, customHeaders);
+  const callContext = callContextStorage.getStore();
+  const fetchFn = callContext?.fetchFn;
+  const cacheKey = a2aCacheKey(
+    agentUrl,
+    authToken,
+    signingContext?.cacheKey,
+    customHeaders,
+    callContext?.allowPrivateIp === true
+  );
   // Scoped fetchers often carry request/tenant-specific egress policy. Keep
   // those calls one-shot so neither agent-card discovery nor a client created
   // under one policy can be reused by another caller, and so short-lived
@@ -284,19 +296,24 @@ async function getOrCreateA2AClient(
   if (bypassCache || fetchFn) {
     return createA2AClient(agentUrl, authToken);
   }
-  const cached = a2aClientCache.get(cacheKey);
+  const cached = getCachedA2AClient(cacheKey);
   if (cached) return cached;
 
   const pending = pendingA2AClients.get(cacheKey);
   if (pending) return pending;
 
+  const generation = a2aClientGeneration;
   const promise = createA2AClient(agentUrl, authToken)
     .then(client => {
+      if (generation !== a2aClientGeneration) {
+        throw new Error('A2A agent-card discovery completed after connection teardown');
+      }
       a2aClientCache.set(cacheKey, client);
+      evictLeastRecentlyUsedA2AClients();
       return client;
     })
     .finally(() => {
-      pendingA2AClients.delete(cacheKey);
+      if (pendingA2AClients.get(cacheKey) === promise) pendingA2AClients.delete(cacheKey);
     });
 
   pendingA2AClients.set(cacheKey, promise);
@@ -648,7 +665,15 @@ async function callA2AToolImpl(
       // case) rather than authToken, the cache key must reflect that or we
       // evict the wrong entry.
       const signingContext = signingContextStorage.getStore();
-      a2aClientCache.delete(a2aCacheKey(agentUrl, authToken, signingContext?.cacheKey, context.customHeaders));
+      a2aClientCache.delete(
+        a2aCacheKey(
+          agentUrl,
+          authToken,
+          signingContext?.cacheKey,
+          context.customHeaders,
+          context.allowPrivateIp === true
+        )
+      );
 
       debugLogs.push({
         type: 'error',

--- a/src/lib/server/serve.ts
+++ b/src/lib/server/serve.ts
@@ -167,12 +167,14 @@ export interface ServeOptions {
    *
    * **Multi-host.** Pass a function `(host) => string` when one process
    * fronts multiple hostnames (white-label publishers, multi-brand
-   * adapters). The resolver runs per unique host — the returned URL is
-   * cached and used as the RFC 9728 `resource`, the 401-challenge
+   * adapters). The resolver must be side-effect-free and idempotent. Its
+   * returned URL is cached in a 128-host process-local LRU and used as the RFC 9728 `resource`, the 401-challenge
    * `resource_metadata`, and the JWT audience for that host. Each
    * resolved URL's path must match the mount path, same as the static
-   * form. Setting {@link trustForwardedHost} is recommended when
-   * behind a proxy.
+   * form. The host argument is untrusted request input: allowlist it before
+   * deriving a URL and throw {@link UnknownHostError} for unknown hosts.
+   * Evicted hosts are resolved again on their next request.
+   * Setting {@link trustForwardedHost} is recommended when behind a proxy.
    */
   publicUrl?: string | ((host: string) => string);
 
@@ -192,8 +194,12 @@ export interface ServeOptions {
    * Pass a function `(host) => ProtectedResourceMetadata` for multi-host
    * deployments whose authorization servers or supported scopes vary per
    * hostname (e.g., each white-label seller has its own AS). The resolver
-   * runs once per unique host and the result is cached. The static form
-   * still works when every host uses the same PRM body.
+   * must be side-effect-free and idempotent. Results are cached in the same
+   * 128-host process-local LRU as {@link publicUrl}; evicted hosts are resolved
+   * again on their next request. The host argument is untrusted request input:
+   * use the same allowlist as {@link publicUrl} and throw
+   * {@link UnknownHostError} for unknown hosts. The static form still works
+   * when every host uses the same PRM body.
    */
   protectedResource?: ProtectedResourceMetadata | ((host: string) => ProtectedResourceMetadata);
 
@@ -349,40 +355,63 @@ export function serve(createAgent: (ctx: ServeContext) => AdcpServer | McpServer
     staticPublicOrigin = validatePublicUrl(publicUrlOption, mountPath);
   }
 
-  // Per-host caches. Function-form options are pure host → value lookups,
-  // so memoization is safe and avoids the per-request allocation of
-  // `new URL(...)` plus the caller's own host → config table work.
-  const publicUrlCache = new Map<string, string>();
-  const publicOriginCache = new Map<string, string>();
-  const prmCache = new Map<string, ProtectedResourceMetadata>();
+  // Function-form options are pure host → value lookups. Keep their values
+  // in one coordinated LRU so an unauthenticated Host-header spray cannot
+  // grow process-lifetime metadata Maps without bound.
+  const MAX_HOST_METADATA_CACHE_ENTRIES = 128;
+  type HostMetadataCacheEntry = {
+    publicUrl?: string;
+    publicOrigin?: string;
+    protectedResource?: ProtectedResourceMetadata;
+  };
+  const hostMetadataCache = new Map<string, HostMetadataCacheEntry>();
+
+  const getHostMetadata = (host: string): HostMetadataCacheEntry | undefined => {
+    const entry = hostMetadataCache.get(host);
+    if (!entry) return undefined;
+    hostMetadataCache.delete(host);
+    hostMetadataCache.set(host, entry);
+    return entry;
+  };
+
+  const updateHostMetadata = (host: string, update: HostMetadataCacheEntry): HostMetadataCacheEntry => {
+    const entry = { ...hostMetadataCache.get(host), ...update };
+    hostMetadataCache.delete(host);
+    hostMetadataCache.set(host, entry);
+    while (hostMetadataCache.size > MAX_HOST_METADATA_CACHE_ENTRIES) {
+      const oldestHost = hostMetadataCache.keys().next().value as string | undefined;
+      if (oldestHost === undefined) break;
+      hostMetadataCache.delete(oldestHost);
+    }
+    return entry;
+  };
 
   const resolvePublicUrl = (host: string): string | undefined => {
     if (typeof publicUrlOption === 'string') return publicUrlOption;
     if (!publicUrlIsFn) return undefined;
-    let cached = publicUrlCache.get(host);
-    if (cached !== undefined) return cached;
-    cached = (publicUrlOption as (h: string) => string)(host);
-    const origin = validatePublicUrl(cached, mountPath);
-    publicUrlCache.set(host, cached);
-    publicOriginCache.set(host, origin);
-    return cached;
+    const cached = getHostMetadata(host);
+    if (cached?.publicUrl !== undefined) return cached.publicUrl;
+    const publicUrl = (publicUrlOption as (h: string) => string)(host);
+    const publicOrigin = validatePublicUrl(publicUrl, mountPath);
+    updateHostMetadata(host, { publicUrl, publicOrigin });
+    return publicUrl;
   };
 
   const resolvePublicOrigin = (host: string): string | undefined => {
     if (typeof publicUrlOption === 'string') return staticPublicOrigin;
-    // Populate via resolvePublicUrl so both caches share a single validation pass.
+    // Populate via resolvePublicUrl so URL and origin share one validation pass.
     if (resolvePublicUrl(host) == null) return undefined;
-    return publicOriginCache.get(host);
+    return getHostMetadata(host)?.publicOrigin;
   };
 
   const resolveProtectedResource = (host: string): ProtectedResourceMetadata | undefined => {
     if (!protectedResourceOption) return undefined;
     if (!prmIsFn) return protectedResourceOption as ProtectedResourceMetadata;
-    let cached = prmCache.get(host);
-    if (cached !== undefined) return cached;
-    cached = (protectedResourceOption as (h: string) => ProtectedResourceMetadata)(host);
-    prmCache.set(host, cached);
-    return cached;
+    const cached = getHostMetadata(host);
+    if (cached?.protectedResource !== undefined) return cached.protectedResource;
+    const protectedResource = (protectedResourceOption as (h: string) => ProtectedResourceMetadata)(host);
+    updateHostMetadata(host, { protectedResource });
+    return protectedResource;
   };
 
   if (options?.authenticate == null && process.env.NODE_ENV === 'production') {
@@ -409,6 +438,9 @@ export function serve(createAgent: (ctx: ServeContext) => AdcpServer | McpServer
         resource = resolvePublicUrl(host);
         prm = resolveProtectedResource(host);
       } catch (err) {
+        // Resolve the pair transactionally: a permissive publicUrl resolver
+        // must not leave a partial entry when protectedResource rejects host.
+        hostMetadataCache.delete(host);
         if (err instanceof UnknownHostError) {
           // Operator signalled "this host isn't in my routing table." 404
           // lets the OAuth grader probe fall through cleanly and doesn't

--- a/src/lib/server/upstream-helpers.ts
+++ b/src/lib/server/upstream-helpers.ts
@@ -11,6 +11,13 @@
  * sales-guaranteed) without encoding any domain-specific logic.
  */
 
+import {
+  DEFAULT_REQUEST_TIMEOUT_MS,
+  resolveRequestTimeoutMs,
+  throwIfAborted,
+  withAbortSignal,
+} from '../protocols/abort';
+
 // ---------------------------------------------------------------------------
 // createTranslationMap
 // ---------------------------------------------------------------------------
@@ -148,6 +155,13 @@ export interface UpstreamHttpClientOptions {
    */
   defaultHeaders?: Record<string, string>;
   /**
+   * Overall deadline for auth resolution, fetch, and response-body parsing.
+   * Defaults to 60_000 ms. Set to 0 to disable the default deadline.
+   */
+  requestTimeoutMs?: number;
+  /** Maximum response-body bytes. Defaults to 2 MiB. Set to 0 to disable. */
+  maxResponseBytes?: number;
+  /**
    * Override the underlying fetch implementation. Defaults to
    * `globalThis.fetch`. Adopters wiring `@adcp/sdk/upstream-recorder` pass
    * `recorder.wrapFetch(globalThis.fetch)` so outbound calls flow through
@@ -176,6 +190,12 @@ export interface UpstreamCallOptions {
    * the right credential per call. Ignored by other auth kinds.
    */
   authContext?: AuthContext;
+  /** Abort this call. The signal is composed with the configured deadline. */
+  signal?: AbortSignal;
+  /** Override the client deadline for this call. Set to 0 to disable it. */
+  requestTimeoutMs?: number;
+  /** Override the client response-body cap for this call. Set to 0 to disable it. */
+  maxResponseBytes?: number;
 }
 
 export interface UpstreamHttpClient {
@@ -219,6 +239,67 @@ async function resolveAuthHeader(auth: UpstreamAuth, ctx?: AuthContext): Promise
   }
 }
 
+const DEFAULT_MAX_RESPONSE_BYTES = 2 * 1024 * 1024;
+
+function resolveMaxResponseBytes(value: number | undefined, fallback?: number): number | undefined {
+  const resolved = value ?? fallback;
+  if (resolved == null || resolved === 0) return undefined;
+  if (!Number.isSafeInteger(resolved) || resolved < 0) {
+    throw new RangeError('maxResponseBytes must be a non-negative safe integer');
+  }
+  return resolved;
+}
+
+function responseTooLarge(maxResponseBytes: number): Error {
+  const error = new Error(`Upstream response exceeded ${maxResponseBytes} bytes`);
+  error.name = 'ResponseTooLargeError';
+  return error;
+}
+
+async function cancelResponseBody(response: Response): Promise<void> {
+  try {
+    await response.body?.cancel();
+  } catch {
+    // Best effort: a locked/already-errored stream is already being reclaimed.
+  }
+}
+
+async function readResponseText(response: Response, maxResponseBytes: number | undefined): Promise<string> {
+  if (maxResponseBytes === undefined) return response.text();
+
+  const declared = response.headers?.get?.('content-length');
+  if (declared && /^\d+$/.test(declared.trim()) && Number(declared) > maxResponseBytes) {
+    await cancelResponseBody(response);
+    throw responseTooLarge(maxResponseBytes);
+  }
+
+  const reader = response.body?.getReader?.();
+  if (!reader) {
+    const text = await response.text();
+    if (new TextEncoder().encode(text).byteLength > maxResponseBytes) throw responseTooLarge(maxResponseBytes);
+    return text;
+  }
+
+  const decoder = new TextDecoder();
+  let bytes = 0;
+  let text = '';
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    bytes += value.byteLength;
+    if (bytes > maxResponseBytes) {
+      try {
+        await reader.cancel();
+      } catch {
+        // Preserve the stable size error if cancellation itself fails.
+      }
+      throw responseTooLarge(maxResponseBytes);
+    }
+    text += decoder.decode(value, { stream: true });
+  }
+  return text + decoder.decode();
+}
+
 async function doRequest<T>(
   baseUrl: string,
   auth: UpstreamAuth,
@@ -231,54 +312,69 @@ async function doRequest<T>(
     body?: unknown;
     headers?: Record<string, string>;
     authContext?: AuthContext;
+    signal?: AbortSignal;
+    requestTimeoutMs?: number;
+    maxResponseBytes?: number;
   }
 ): Promise<UpstreamHttpResult<T>> {
-  const authHeader = await resolveAuthHeader(auth, options.authContext);
-  const mergedHeaders: Record<string, string> = {
-    ...defaultHeaders,
-    ...authHeader,
-    ...options.headers,
-  };
+  const requestTimeoutMs = resolveRequestTimeoutMs(options.requestTimeoutMs);
+  return withAbortSignal([options.signal], requestTimeoutMs, async signal => {
+    const authHeader = await resolveAuthHeader(auth, options.authContext);
+    throwIfAborted(signal);
+    const mergedHeaders: Record<string, string> = {
+      ...defaultHeaders,
+      ...authHeader,
+      ...options.headers,
+    };
 
-  let url = `${baseUrl}${path}`;
-  if (options.params) {
-    const qs = Object.entries(options.params)
-      .filter(([, v]) => v !== undefined)
-      .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(String(v))}`)
-      .join('&');
-    if (qs) url = `${url}?${qs}`;
-  }
+    let url = `${baseUrl}${path}`;
+    if (options.params) {
+      const qs = Object.entries(options.params)
+        .filter(([, v]) => v !== undefined)
+        .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(String(v))}`)
+        .join('&');
+      if (qs) url = `${url}?${qs}`;
+    }
 
-  const init: RequestInit = { method, headers: mergedHeaders };
-  if (options.body !== undefined) {
-    init.body = JSON.stringify(options.body);
-    mergedHeaders['Content-Type'] = 'application/json';
-  }
+    const init: RequestInit = { method, headers: mergedHeaders, signal };
+    if (options.body !== undefined) {
+      init.body = JSON.stringify(options.body);
+      mergedHeaders['Content-Type'] = 'application/json';
+    }
 
-  const res = await fetchImpl(url, init);
+    const res = await fetchImpl(url, init);
+    throwIfAborted(signal);
 
-  // 404 → null body (not an error — resource absent is a common upstream signal)
-  if (res.status === 404) return { status: 404, body: null };
+    // 404 → null body (not an error — resource absent is a common upstream signal)
+    if (res.status === 404) {
+      await cancelResponseBody(res);
+      throwIfAborted(signal);
+      return { status: 404, body: null };
+    }
 
-  const text = await res.text();
+    const text = await readResponseText(res, options.maxResponseBytes);
+    throwIfAborted(signal);
 
-  // Non-2xx always throws — callers must not silently swallow errors
-  if (!res.ok) {
-    throw new Error(`Upstream ${method} ${path} failed: ${res.status} ${text.slice(0, 200)}`);
-  }
+    // Non-2xx always throws — callers must not silently swallow errors
+    if (!res.ok) {
+      throw new Error(`Upstream ${method} ${path} failed: ${res.status} ${text.slice(0, 200)}`);
+    }
 
-  // Empty body (204 No Content, etc.)
-  if (!text) return { status: res.status, body: null };
+    // Empty body (204 No Content, etc.)
+    if (!text) return { status: res.status, body: null };
 
-  const body = JSON.parse(text) as T;
-  return { status: res.status, body };
+    const body = JSON.parse(text) as T;
+    return { status: res.status, body };
+  });
 }
 
 /**
  * Create a thin typed HTTP client for upstream platform APIs.
  *
- * Handles auth injection, query-string serialization, and 404→null
- * translation so adapters can focus on domain logic.
+ * Handles auth injection, query-string serialization, a 60-second default
+ * request deadline, a 2 MiB response-body cap, and 404→null translation so
+ * adapters can focus on domain logic. Timeout failures have
+ * `error.name === 'TimeoutError'`.
  *
  * @example
  * ```ts
@@ -294,29 +390,43 @@ async function doRequest<T>(
  */
 export function createUpstreamHttpClient(options: UpstreamHttpClientOptions): UpstreamHttpClient {
   const { baseUrl, auth, defaultHeaders = {}, fetch: fetchImpl = globalThis.fetch } = options;
+  const defaultRequestTimeoutMs = resolveRequestTimeoutMs(options.requestTimeoutMs, DEFAULT_REQUEST_TIMEOUT_MS);
+  const defaultMaxResponseBytes = resolveMaxResponseBytes(options.maxResponseBytes, DEFAULT_MAX_RESPONSE_BYTES);
   return {
     get: (path, params, headers, opts) =>
       doRequest(baseUrl, auth, defaultHeaders, fetchImpl, 'GET', path, {
         params,
         headers,
         authContext: opts?.authContext,
+        signal: opts?.signal,
+        requestTimeoutMs: resolveRequestTimeoutMs(opts?.requestTimeoutMs, defaultRequestTimeoutMs),
+        maxResponseBytes: resolveMaxResponseBytes(opts?.maxResponseBytes, defaultMaxResponseBytes),
       }),
     post: (path, body, headers, opts) =>
       doRequest(baseUrl, auth, defaultHeaders, fetchImpl, 'POST', path, {
         body,
         headers,
         authContext: opts?.authContext,
+        signal: opts?.signal,
+        requestTimeoutMs: resolveRequestTimeoutMs(opts?.requestTimeoutMs, defaultRequestTimeoutMs),
+        maxResponseBytes: resolveMaxResponseBytes(opts?.maxResponseBytes, defaultMaxResponseBytes),
       }),
     put: (path, body, headers, opts) =>
       doRequest(baseUrl, auth, defaultHeaders, fetchImpl, 'PUT', path, {
         body,
         headers,
         authContext: opts?.authContext,
+        signal: opts?.signal,
+        requestTimeoutMs: resolveRequestTimeoutMs(opts?.requestTimeoutMs, defaultRequestTimeoutMs),
+        maxResponseBytes: resolveMaxResponseBytes(opts?.maxResponseBytes, defaultMaxResponseBytes),
       }),
     delete: (path, headers, opts) =>
       doRequest(baseUrl, auth, defaultHeaders, fetchImpl, 'DELETE', path, {
         headers,
         authContext: opts?.authContext,
+        signal: opts?.signal,
+        requestTimeoutMs: resolveRequestTimeoutMs(opts?.requestTimeoutMs, defaultRequestTimeoutMs),
+        maxResponseBytes: resolveMaxResponseBytes(opts?.maxResponseBytes, defaultMaxResponseBytes),
       }),
   };
 }

--- a/test/lib/a2a-client-cache.test.js
+++ b/test/lib/a2a-client-cache.test.js
@@ -1,0 +1,109 @@
+const { describe, test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+
+const sdkA2AClient = require('@a2a-js/sdk/client').A2AClient;
+const { callA2ATool, closeA2AConnections } = require('../../dist/lib/protocols/a2a.js');
+
+const originalFromCardUrl = sdkA2AClient.fromCardUrl;
+
+function stubClient() {
+  return {
+    sendMessage: async () => ({
+      result: {
+        kind: 'message',
+        messageId: 'response-message',
+        role: 'agent',
+        parts: [{ kind: 'data', data: { ok: true } }],
+      },
+    }),
+  };
+}
+
+describe('A2A client cache', () => {
+  beforeEach(() => closeA2AConnections());
+
+  afterEach(() => {
+    sdkA2AClient.fromCardUrl = originalFromCardUrl;
+    closeA2AConnections();
+  });
+
+  test('caps completed clients at 20 and refreshes LRU hits', async () => {
+    let discoveries = 0;
+    sdkA2AClient.fromCardUrl = async () => {
+      discoveries++;
+      return stubClient();
+    };
+
+    for (let index = 0; index < 20; index++) {
+      await callA2ATool(`https://agent-${index}.example`, 'get_products', {});
+    }
+    await callA2ATool('https://agent-0.example', 'get_products', {}); // touch oldest
+    await callA2ATool('https://agent-20.example', 'get_products', {}); // evicts agent-1
+    await callA2ATool('https://agent-0.example', 'get_products', {}); // still cached
+    await callA2ATool('https://agent-1.example', 'get_products', {}); // rediscover
+
+    assert.strictEqual(discoveries, 22);
+  });
+
+  test('teardown prevents a late discovery from repopulating the cache', async () => {
+    let finishDiscovery;
+    let discoveries = 0;
+    sdkA2AClient.fromCardUrl = () => {
+      discoveries++;
+      return new Promise(resolve => {
+        finishDiscovery = resolve;
+      });
+    };
+
+    const pending = callA2ATool('https://late.example', 'get_products', {});
+    await new Promise(resolve => setImmediate(resolve));
+    closeA2AConnections();
+    finishDiscovery(stubClient());
+    await assert.rejects(pending, /completed after connection teardown/);
+
+    sdkA2AClient.fromCardUrl = async () => {
+      discoveries++;
+      return stubClient();
+    };
+    await callA2ATool('https://late.example', 'get_products', {});
+    assert.strictEqual(discoveries, 2);
+  });
+
+  test('does not reuse a client across private-network policy boundaries', async () => {
+    let discoveries = 0;
+    sdkA2AClient.fromCardUrl = async () => {
+      discoveries++;
+      return stubClient();
+    };
+
+    const args = ['https://policy.example', 'get_products', {}, undefined, [], undefined, undefined, undefined];
+    await callA2ATool(...args, undefined, undefined, undefined, undefined, true);
+    await callA2ATool(...args, undefined, undefined, undefined, undefined, false);
+    await callA2ATool(...args, undefined, undefined, undefined, undefined, true);
+
+    assert.strictEqual(discoveries, 2);
+  });
+
+  test('policy tuple cannot collide with an attacker-controlled URL suffix', async () => {
+    let discoveries = 0;
+    sdkA2AClient.fromCardUrl = async () => {
+      discoveries++;
+      return stubClient();
+    };
+
+    const args = ['get_products', {}, undefined, [], undefined, undefined, undefined];
+    await callA2ATool('https://collision.example/agent', ...args, undefined, undefined, undefined, undefined, true);
+    await callA2ATool(
+      'https://collision.example/agent::private-ip:1',
+      ...args,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      false
+    );
+    await callA2ATool('https://collision.example/agent', ...args, undefined, undefined, undefined, undefined, true);
+
+    assert.strictEqual(discoveries, 2);
+  });
+});

--- a/test/lib/canonical-reference-resolver.test.js
+++ b/test/lib/canonical-reference-resolver.test.js
@@ -6,6 +6,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 const {
+  createCanonicalReferenceCache,
   createCanonicalReferenceResolver,
   resolveFormatSchemaReference,
   resolvePlatformExtensionsReference,
@@ -196,6 +197,102 @@ describe('canonical reference resolver', () => {
     assert.strictEqual(second.status, 'resolved');
     assert.deepStrictEqual(second.document, { vendor: 'example', feature: true });
     assert.strictEqual(Buffer.from(second.body).toString('utf8'), body.toString('utf8'));
+  });
+
+  test('bounded cache refreshes LRU hits and evicts the least-recent entry', async () => {
+    const fixtures = [
+      ['/cache-lru-a.json', { value: 'a' }],
+      ['/cache-lru-b.json', { value: 'b' }],
+      ['/cache-lru-c.json', { value: 'c' }],
+    ].map(([route, value]) => {
+      const body = jsonBody(value);
+      routes.set(route, (_req, res) => {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(body);
+      });
+      return { route, body };
+    });
+    const resolver = createCanonicalReferenceResolver({
+      ...unsafeLocal,
+      cache: createCanonicalReferenceCache({ maxEntries: 2, maxBytes: 1024 * 1024 }),
+    });
+
+    await resolver.resolvePlatformExtensions(ref(baseUrl, fixtures[0].route, fixtures[0].body));
+    await resolver.resolvePlatformExtensions(ref(baseUrl, fixtures[1].route, fixtures[1].body));
+    await resolver.resolvePlatformExtensions(ref(baseUrl, fixtures[0].route, fixtures[0].body)); // touch A
+    await resolver.resolvePlatformExtensions(ref(baseUrl, fixtures[2].route, fixtures[2].body)); // evict B
+    const recent = await resolver.resolvePlatformExtensions(ref(baseUrl, fixtures[0].route, fixtures[0].body));
+    const evicted = await resolver.resolvePlatformExtensions(ref(baseUrl, fixtures[1].route, fixtures[1].body));
+
+    assert.strictEqual(recent.fromCache, true);
+    assert.strictEqual(evicted.fromCache, false);
+    assert.strictEqual(requestCounts.get('/cache-lru-a.json'), 1);
+    assert.strictEqual(requestCounts.get('/cache-lru-b.json'), 2);
+    assert.strictEqual(requestCounts.get('/cache-lru-c.json'), 1);
+  });
+
+  test('oversize entries are returned without being retained', async () => {
+    const body = jsonBody({ value: 'too-large-for-cache' });
+    routes.set('/cache-oversize.json', (_req, res) => {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(body);
+    });
+    const resolver = createCanonicalReferenceResolver({
+      ...unsafeLocal,
+      cache: createCanonicalReferenceCache({ maxEntries: 10, maxBytes: 1 }),
+    });
+    const reference = ref(baseUrl, '/cache-oversize.json', body);
+
+    const first = await resolver.resolvePlatformExtensions(reference);
+    const second = await resolver.resolvePlatformExtensions(reference);
+
+    assert.strictEqual(first.status, 'resolved');
+    assert.strictEqual(second.fromCache, false);
+    assert.strictEqual(requestCounts.get('/cache-oversize.json'), 2);
+  });
+
+  test('zero-argument cache is bounded and validates explicit limits', () => {
+    const cache = createCanonicalReferenceCache();
+    for (let index = 0; index < 65; index++) {
+      cache.set(`key-${index}`, {
+        body: new Uint8Array(),
+        text: '',
+        document: {},
+      });
+    }
+
+    assert.strictEqual(cache.get('key-0'), undefined);
+    assert.ok(cache.get('key-64'));
+    assert.throws(() => createCanonicalReferenceCache({ maxEntries: -1 }), /maxEntries/);
+    assert.throws(() => createCanonicalReferenceCache({ maxBytes: Number.POSITIVE_INFINITY }), /maxBytes/);
+  });
+
+  test('byte accounting includes URI/key strings and subtracts replacements', () => {
+    const longUri = `https://cache.example/schema.json#${'x'.repeat(1_000)}`;
+    const longKey = `${longUri}@sha256:${'a'.repeat(64)}`;
+    const bounded = createCanonicalReferenceCache({ maxEntries: 10, maxBytes: 1_024 });
+    bounded.set(longKey, {
+      body: new Uint8Array(),
+      text: '',
+      document: {},
+      cacheKey: longKey,
+      ref: { uri: longUri, digest: `sha256:${'a'.repeat(64)}` },
+    });
+    assert.strictEqual(bounded.get(longKey), undefined);
+
+    const replacements = createCanonicalReferenceCache({ maxEntries: 10, maxBytes: 1_800 });
+    const result = (key, text) => ({
+      body: new TextEncoder().encode(text),
+      text,
+      document: {},
+      cacheKey: key,
+      ref: { uri: `https://cache.example/${key}`, digest: `sha256:${'b'.repeat(64)}` },
+    });
+    replacements.set('a', result('a', 'x'.repeat(300)));
+    replacements.set('a', result('a', ''));
+    replacements.set('b', result('b', ''));
+    assert.ok(replacements.get('a'));
+    assert.ok(replacements.get('b'));
   });
 
   test('cache scope includes body caps so permissive calls do not relax later strict calls', async () => {

--- a/test/server-auth.test.js
+++ b/test/server-auth.test.js
@@ -10,6 +10,7 @@ const {
   extractBearerToken,
   createAdcpServer,
   AuthError,
+  UnknownHostError,
   DEFAULT_JWT_ALGORITHMS,
 } = require('../dist/lib/server/legacy/v5/index.js');
 
@@ -478,6 +479,91 @@ describe('serve() + publicUrl + protectedResource', () => {
       // No Authorization header — must still succeed.
       const res = await fetchPath(ctx.port, '/.well-known/oauth-protected-resource/mcp');
       assert.strictEqual(res.status, 200);
+    } finally {
+      ctx.server.close();
+    }
+  });
+
+  it('bounds function-form host metadata with one coordinated LRU', async () => {
+    const publicCalls = new Map();
+    const prmCalls = new Map();
+    const ctx = await startServer({
+      trustForwardedHost: true,
+      publicUrl: host => {
+        publicCalls.set(host, (publicCalls.get(host) ?? 0) + 1);
+        return `https://${host}/mcp`;
+      },
+      protectedResource: host => {
+        prmCalls.set(host, (prmCalls.get(host) ?? 0) + 1);
+        return { authorization_servers: [`https://auth.${host}`] };
+      },
+    });
+    const metadataPath = '/.well-known/oauth-protected-resource/mcp';
+    const requestHost = host => fetchPath(ctx.port, metadataPath, { headers: { 'x-forwarded-host': host } });
+
+    try {
+      for (let index = 0; index < 128; index++) {
+        const res = await requestHost(`host-${index}.example`);
+        assert.strictEqual(res.status, 200);
+      }
+      await requestHost('host-0.example'); // refresh oldest
+      await requestHost('host-128.example'); // evict host-1
+      await requestHost('host-0.example');
+      await requestHost('host-1.example');
+
+      assert.strictEqual(publicCalls.get('host-0.example'), 1);
+      assert.strictEqual(prmCalls.get('host-0.example'), 1);
+      assert.strictEqual(publicCalls.get('host-1.example'), 2);
+      assert.strictEqual(prmCalls.get('host-1.example'), 2);
+    } finally {
+      ctx.server.close();
+    }
+  });
+
+  it('does not cache hosts rejected by a function-form resolver', async () => {
+    let calls = 0;
+    const ctx = await startServer({
+      publicUrl: host => {
+        calls++;
+        throw new UnknownHostError(`Unknown host ${host}`);
+      },
+      protectedResource: { authorization_servers: ['https://auth.example'] },
+    });
+    try {
+      const path = '/.well-known/oauth-protected-resource/mcp';
+      const first = await fetchPath(ctx.port, path, { headers: { host: 'unknown.example' } });
+      const second = await fetchPath(ctx.port, path, { headers: { host: 'unknown.example' } });
+      assert.strictEqual(first.status, 404);
+      assert.strictEqual(second.status, 404);
+      assert.strictEqual(calls, 2);
+    } finally {
+      ctx.server.close();
+    }
+  });
+
+  it('rolls back partial host metadata when the PRM resolver rejects', async () => {
+    let publicCalls = 0;
+    let prmCalls = 0;
+    const ctx = await startServer({
+      trustForwardedHost: true,
+      publicUrl: host => {
+        publicCalls++;
+        return `https://${host}/mcp`;
+      },
+      protectedResource: host => {
+        prmCalls++;
+        throw new UnknownHostError(`Unknown host ${host}`);
+      },
+    });
+    try {
+      const path = '/.well-known/oauth-protected-resource/mcp';
+      const headers = { 'x-forwarded-host': 'unknown-prm.example' };
+      const first = await fetchPath(ctx.port, path, { headers });
+      const second = await fetchPath(ctx.port, path, { headers });
+      assert.strictEqual(first.status, 404);
+      assert.strictEqual(second.status, 404);
+      assert.strictEqual(publicCalls, 2);
+      assert.strictEqual(prmCalls, 2);
     } finally {
       ctx.server.close();
     }

--- a/test/upstream-helpers.test.js
+++ b/test/upstream-helpers.test.js
@@ -295,4 +295,152 @@ describe('createUpstreamHttpClient', () => {
     await client.get('/items', undefined, undefined, { authContext: { principal: 'caller_token_xyz' } });
     assert.equal(capturedRequests[0].init.headers['Authorization'], 'Bearer caller_token_xyz');
   });
+
+  it('times out a fetch that never resolves and aborts the composed signal', async () => {
+    let seenSignal;
+    const client = createUpstreamHttpClient({
+      baseUrl: 'https://api.example.com',
+      auth: { kind: 'none' },
+      requestTimeoutMs: 10,
+      fetch: async (_url, init) => {
+        seenSignal = init.signal;
+        return new Promise(() => {});
+      },
+    });
+
+    await assert.rejects(client.get('/hang'), error => error.name === 'TimeoutError');
+    assert.strictEqual(seenSignal.aborted, true);
+  });
+
+  it('keeps the deadline active while consuming the response body', async () => {
+    const client = createUpstreamHttpClient({
+      baseUrl: 'https://api.example.com',
+      auth: { kind: 'none' },
+      requestTimeoutMs: 10,
+      fetch: async () => ({
+        status: 200,
+        ok: true,
+        text: async () => new Promise(() => {}),
+      }),
+    });
+
+    await assert.rejects(client.get('/slow-body'), error => error.name === 'TimeoutError');
+  });
+
+  it('bounds streamed response bodies and supports a per-call opt-out', async () => {
+    const client = createUpstreamHttpClient({
+      baseUrl: 'https://api.example.com',
+      auth: { kind: 'none' },
+      maxResponseBytes: 4,
+      fetch: async () => new Response('12345', { status: 200 }),
+    });
+
+    await assert.rejects(client.get('/large'), error => error.name === 'ResponseTooLargeError');
+    const unbounded = await client.get('/large', undefined, undefined, { maxResponseBytes: 0 });
+    assert.strictEqual(unbounded.body, 12345);
+  });
+
+  it('cancels a 404 response body before returning null', async () => {
+    let cancelled = 0;
+    const client = createUpstreamHttpClient({
+      baseUrl: 'https://api.example.com',
+      auth: { kind: 'none' },
+      fetch: async () => ({
+        status: 404,
+        ok: false,
+        body: { cancel: async () => cancelled++ },
+      }),
+    });
+
+    const result = await client.get('/missing');
+    assert.deepStrictEqual(result, { status: 404, body: null });
+    assert.strictEqual(cancelled, 1);
+  });
+
+  it('composes caller cancellation without misreporting it as a timeout', async () => {
+    const controller = new AbortController();
+    const client = createUpstreamHttpClient({
+      baseUrl: 'https://api.example.com',
+      auth: { kind: 'none' },
+      requestTimeoutMs: 1_000,
+      fetch: async () => new Promise(() => {}),
+    });
+
+    const pending = client.get('/cancel', undefined, undefined, { signal: controller.signal });
+    controller.abort();
+    await assert.rejects(pending, error => error.name === 'AbortError');
+  });
+
+  it('supports per-call timeout overrides and 0 disables the default deadline', async () => {
+    let disabledSignal = 'not-called';
+    const client = createUpstreamHttpClient({
+      baseUrl: 'https://api.example.com',
+      auth: { kind: 'none' },
+      requestTimeoutMs: 1_000,
+      fetch: async (_url, init) => {
+        disabledSignal = init.signal;
+        return { status: 204, ok: true, text: async () => '' };
+      },
+    });
+
+    await client.get('/no-deadline', undefined, undefined, { requestTimeoutMs: 0 });
+    assert.strictEqual(disabledSignal, undefined);
+
+    const hanging = createUpstreamHttpClient({
+      baseUrl: 'https://api.example.com',
+      auth: { kind: 'none' },
+      requestTimeoutMs: 1_000,
+      fetch: async () => new Promise(() => {}),
+    });
+    await assert.rejects(
+      hanging.get('/short-deadline', undefined, undefined, { requestTimeoutMs: 10 }),
+      error => error.name === 'TimeoutError'
+    );
+  });
+
+  it('does not start fetch after auth resolution completes past the deadline', async () => {
+    let resolveToken;
+    let fetchCalls = 0;
+    const client = createUpstreamHttpClient({
+      baseUrl: 'https://api.example.com',
+      auth: {
+        kind: 'dynamic_bearer',
+        getToken: () =>
+          new Promise(resolve => {
+            resolveToken = resolve;
+          }),
+      },
+      requestTimeoutMs: 10,
+      fetch: async () => {
+        fetchCalls++;
+        return new Response('{}', { status: 200 });
+      },
+    });
+
+    await assert.rejects(client.get('/late-auth'), error => error.name === 'TimeoutError');
+    resolveToken('late-token');
+    await new Promise(resolve => setImmediate(resolve));
+    assert.strictEqual(fetchCalls, 0);
+  });
+
+  it('rejects invalid request timeout configuration', () => {
+    assert.throws(
+      () =>
+        createUpstreamHttpClient({
+          baseUrl: 'https://api.example.com',
+          auth: { kind: 'none' },
+          requestTimeoutMs: -1,
+        }),
+      /requestTimeoutMs/
+    );
+    assert.throws(
+      () =>
+        createUpstreamHttpClient({
+          baseUrl: 'https://api.example.com',
+          auth: { kind: 'none' },
+          maxResponseBytes: -1,
+        }),
+      /maxResponseBytes/
+    );
+  });
 });


### PR DESCRIPTION
Closes #2429.

## Summary

- bound the default canonical-reference cache by LRU entry count and estimated retained bytes while leaving injected caches caller-owned
- cap A2A client discovery at 20 completed clients, prevent late teardown repopulation, and isolate cache keys by full auth/header/signing/private-network policy tuples
- add a 60-second upstream request deadline, caller cancellation, and a streaming 2 MiB response-body cap with per-client/per-call opt-outs
- cap function-form multi-host metadata at 128 coordinated LRU entries, roll back partial rejected-host entries, and document fail-closed allowlisting

## Review

- code, DX, and protocol/security expert reviews completed; all actionable findings resolved
- `npm run review:codex -- --all --base main` was attempted, but the organization has no OpenAI API credits, so it produced no review output
- webhook idempotency storage remains unchanged because count-based eviction would break retry-key stability; the issue's existing won't-fix reasoning still applies

## Validation

- `npm run build`
- `npm run typecheck`
- `npm run lint` (0 errors; existing warnings only)
- `npm run format:check`
- `npm run ci:docs-check`
- `NODE_ENV=test npm test` (15,145 passed, 0 failed, 7 skipped before the final focused hardening amendments)
- focused canonical-reference, A2A-cache, upstream-helper, and server-auth regressions
