### PR TITLE
fix(projection): lint package selector dimensions

### DIFF
--- a/.changeset/tidy-banners-lint.md
+++ b/.changeset/tidy-banners-lint.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Add a write-side diagnostic helper for incomplete or conflicting fixed-size image dimensions across canonical package selectors and deprecated legacy format IDs.

--- a/.changeset/tidy-banners-lint.md
+++ b/.changeset/tidy-banners-lint.md
@@ -2,4 +2,4 @@
 '@adcp/sdk': patch
 ---
 
-Add a write-side diagnostic helper for incomplete or conflicting fixed-size image dimensions across canonical package selectors and deprecated legacy format IDs.
+Add `lintPackageFormatSelectorDimensions` to `@adcp/sdk/v2/projection` for incomplete or conflicting fixed-size image dimensions across canonical package selectors and deprecated legacy format IDs.

--- a/.changeset/tidy-banners-lint.md
+++ b/.changeset/tidy-banners-lint.md
@@ -1,5 +1,5 @@
 ---
-'@adcp/sdk': patch
+'@adcp/sdk': minor
 ---
 
 Add `lintPackageFormatSelectorDimensions` to `@adcp/sdk/v2/projection` for incomplete or conflicting fixed-size image dimensions across canonical package selectors and deprecated legacy format IDs.

--- a/src/lib/v2/projection/index.ts
+++ b/src/lib/v2/projection/index.ts
@@ -115,6 +115,7 @@ export {
   tryLegacyFormatIdsFromOptions,
   legacyFormatIdsForFormatOption,
   legacyFormatIdsForCapability,
+  lintPackageFormatSelectorDimensions,
   FormatOptionRefsLookupError,
   CapabilityIdsLookupError,
   type PackageFormatRefs,
@@ -123,6 +124,11 @@ export {
   type FormatOptionSelector,
   type FormatOptionRefsLookupErrorCode,
   type CapabilityIdsLookupErrorCode,
+  type PackageFormatSelectorInput,
+  type PackageFormatSelectorDimensionOptions,
+  type FixedSizeDimensions,
+  type PackageFormatSelectorDimensionDiagnosticCode,
+  type PackageFormatSelectorDimensionDiagnostic,
 } from './write-side';
 
 export type { V1FormatId, V2ProductFormatDeclaration, V2Product, V1Product, ProjectionDiagnostic } from './types';

--- a/src/lib/v2/projection/write-side.ts
+++ b/src/lib/v2/projection/write-side.ts
@@ -73,10 +73,19 @@ export interface PackageFormatSelectorInput {
   format_ids?: readonly V1FormatId[];
 }
 
-/** Optional seller-specific catalogs used to resolve legacy format IDs. */
+/** Optional seller-specific catalogs and context used to resolve legacy format IDs. */
 export interface PackageFormatSelectorDimensionOptions {
   legacyFormatConverter?: LegacyFormatConverter;
   projectionCatalogs?: readonly ProjectionCatalogSnapshot[];
+  /**
+   * Preserve the caller's real product/path identity for product-aware legacy
+   * converters. Omit only when the converter is context-independent.
+   */
+  projectionContext?: {
+    productId: string;
+    /** Field path of the package selector; defaults to the selector root. */
+    field?: string;
+  };
 }
 
 export interface FixedSizeDimensions {
@@ -167,6 +176,34 @@ function addInspectionDiagnostic(
   return true;
 }
 
+function inspectSelectorDimensions(
+  params: Readonly<Record<string, unknown>> | undefined,
+  diagnostics: PackageFormatSelectorDimensionDiagnostic[],
+  selector: 'canonical' | 'legacy',
+  field: string,
+  formatIdIndex?: number
+): { inspection: DimensionInspection; diagnosed: boolean } {
+  const inspection = inspectFixedDimensions(params);
+  if (!Array.isArray(params?.sizes)) {
+    return {
+      inspection,
+      diagnosed: addInspectionDiagnostic(diagnostics, inspection, selector, field, formatIdIndex),
+    };
+  }
+
+  let diagnosed = false;
+  for (const [index, size] of params.sizes.entries()) {
+    const sizeInspection =
+      size !== null && typeof size === 'object' && !Array.isArray(size)
+        ? inspectFixedDimensions(size as Readonly<Record<string, unknown>>)
+        : ({ kind: 'invalid' } as const);
+    diagnosed =
+      addInspectionDiagnostic(diagnostics, sizeInspection, selector, `${field}.sizes[${index}]`, formatIdIndex) ||
+      diagnosed;
+  }
+  return { inspection, diagnosed };
+}
+
 /**
  * Diagnose fixed-size image dimension loss across direct canonical and
  * deprecated legacy package selectors.
@@ -175,49 +212,109 @@ function addInspectionDiagnostic(
  * precedence, mutate the package, or reject valid canonical-only,
  * legacy-only, multi-size, responsive, or inherently canonical-only shapes.
  * Legacy IDs are normalized through the same catalog/converter path as the
- * rest of the projection layer.
+ * rest of the projection layer. An empty result means no dimensional issue
+ * was found among selectors the configured catalogs/converter could resolve;
+ * it is not proof that every seller-owned legacy ID was resolvable.
+ *
+ * @example
+ * ```ts
+ * import { lintPackageFormatSelectorDimensions } from '@adcp/sdk/v2/projection';
+ *
+ * const diagnostics = lintPackageFormatSelectorDimensions(packageSelector, {
+ *   projectionCatalogs: sellerCatalogs,
+ *   legacyFormatConverter: convertSellerFormat,
+ *   projectionContext: { productId: product.product_id, field: 'packages[0]' },
+ * });
+ * if (diagnostics.length > 0) report(diagnostics);
+ * ```
  */
 export function lintPackageFormatSelectorDimensions(
   selector: PackageFormatSelectorInput,
   options?: PackageFormatSelectorDimensionOptions
 ): PackageFormatSelectorDimensionDiagnostic[] {
   const diagnostics: PackageFormatSelectorDimensionDiagnostic[] = [];
+  const paramsField = options?.projectionContext?.field ? `${options.projectionContext.field}.params` : 'params';
+  const formatIdField = (index: number): string =>
+    `${options?.projectionContext?.field ? `${options.projectionContext.field}.` : ''}format_ids[${index}]`;
   const canonicalImage = selector.format_kind === 'image';
-  const canonicalInspection = canonicalImage ? inspectFixedDimensions(selector.params) : { kind: 'non_fixed' as const };
-  const canonicalAlreadyDiagnosed = canonicalImage
-    ? addInspectionDiagnostic(diagnostics, canonicalInspection, 'canonical', 'params')
-    : false;
+  const canonicalResult = canonicalImage
+    ? inspectSelectorDimensions(selector.params, diagnostics, 'canonical', paramsField)
+    : { inspection: { kind: 'non_fixed' as const }, diagnosed: false };
+  const canonicalInspection = canonicalResult.inspection;
 
   const legacyImages: Array<{ index: number; inspection: DimensionInspection }> = [];
   for (const [index, ref] of (selector.format_ids ?? []).entries()) {
-    const inlineInspection = inspectFixedDimensions(ref as unknown as Readonly<Record<string, unknown>>);
-    if (addInspectionDiagnostic(diagnostics, inlineInspection, 'legacy', `format_ids[${index}]`, index)) continue;
-    if (!canonicalImage || canonicalInspection.kind === 'non_fixed') continue;
+    const field = formatIdField(index);
+    const inlineResult = inspectSelectorDimensions(
+      ref as unknown as Readonly<Record<string, unknown>>,
+      diagnostics,
+      'legacy',
+      field,
+      index
+    );
+    if (inlineResult.diagnosed) continue;
 
-    const projected = projectV1ProductToV2(
+    const productId = options?.projectionContext?.productId ?? '<package-selector>';
+    let converterDiagnosed = false;
+    const legacyFormatConverter = options?.legacyFormatConverter
+      ? (context: Parameters<LegacyFormatConverter>[0]) => {
+          const converted = options.legacyFormatConverter?.({ ...context, productId, field });
+          if (converted?.format_kind === 'image') {
+            converterDiagnosed =
+              inspectSelectorDimensions(converted.params, diagnostics, 'legacy', field, index).diagnosed ||
+              converterDiagnosed;
+          }
+          return converted;
+        }
+      : undefined;
+
+    const projection = projectV1ProductToV2(
       {
-        product_id: `<package-selector:${index}>`,
+        product_id: productId,
         name: 'Package selector',
         description: 'Package selector dimensional lint',
         format_ids: [{ ...ref }],
       },
-      options
-    ).v2.format_options[0];
+      { legacyFormatConverter, projectionCatalogs: options?.projectionCatalogs }
+    );
+    if (converterDiagnosed) continue;
+    const dimensionalFailure = projection.diagnostics.find(
+      diagnostic =>
+        diagnostic.code === 'FORMAT_PROJECTION_FAILED' &&
+        (diagnostic.error.details.resolution_failure === 'invalid_format_id_parameters' ||
+          diagnostic.error.details.resolution_failure === 'catalog_requirement_conflict')
+    );
+    if (dimensionalFailure?.code === 'FORMAT_PROJECTION_FAILED') {
+      const catalogConflict = dimensionalFailure.error.details.resolution_failure === 'catalog_requirement_conflict';
+      diagnostics.push({
+        code: catalogConflict ? 'FORMAT_SELECTOR_DIMENSIONS_MISMATCH' : 'FORMAT_SELECTOR_DIMENSIONS_INVALID',
+        field,
+        selector: 'legacy',
+        message: catalogConflict
+          ? `${field} dimensions conflict with the resolved legacy format catalog`
+          : `${field} contains invalid fixed-size image dimensions`,
+        format_id_index: index,
+      });
+      continue;
+    }
+
+    const projected = projection.v2.format_options[0];
     if (projected?.format_kind !== 'image') continue;
-    legacyImages.push({ index, inspection: inspectFixedDimensions(projected.params) });
+    const projectedResult = inspectSelectorDimensions(projected.params, diagnostics, 'legacy', field, index);
+    if (!projectedResult.diagnosed) legacyImages.push({ index, inspection: projectedResult.inspection });
   }
 
   if (!canonicalImage || canonicalInspection.kind === 'non_fixed' || legacyImages.length === 0) {
     return diagnostics;
   }
 
-  if (canonicalInspection.kind === 'absent' && !canonicalAlreadyDiagnosed) {
+  if (canonicalInspection.kind === 'absent' && !canonicalResult.diagnosed) {
     diagnostics.push({
       code: 'FORMAT_SELECTOR_DIMENSIONS_INCOMPLETE',
-      field: 'params',
+      field: paramsField,
       selector: 'canonical',
       message:
-        'params must provide width and height when a direct image selector is combined with legacy image selectors',
+        `${paramsField} must provide width and height when a direct image selector is combined with legacy image selectors`,
     });
   }
 
@@ -225,9 +322,9 @@ export function lintPackageFormatSelectorDimensions(
     if (legacy.inspection.kind === 'absent') {
       diagnostics.push({
         code: 'FORMAT_SELECTOR_DIMENSIONS_INCOMPLETE',
-        field: `format_ids[${legacy.index}]`,
+        field: formatIdField(legacy.index),
         selector: 'legacy',
-        message: `format_ids[${legacy.index}] does not resolve to width and height for comparison with the direct image selector`,
+        message: `${formatIdField(legacy.index)} does not resolve to width and height for comparison with the direct image selector`,
         format_id_index: legacy.index,
       });
       continue;
@@ -240,10 +337,10 @@ export function lintPackageFormatSelectorDimensions(
     ) {
       diagnostics.push({
         code: 'FORMAT_SELECTOR_DIMENSIONS_MISMATCH',
-        field: `format_ids[${legacy.index}]`,
+        field: formatIdField(legacy.index),
         selector: 'cross_projection',
         message:
-          `format_ids[${legacy.index}] resolves to ${legacy.inspection.dimensions.width}x${legacy.inspection.dimensions.height}, ` +
+          `${formatIdField(legacy.index)} resolves to ${legacy.inspection.dimensions.width}x${legacy.inspection.dimensions.height}, ` +
           `but the direct image selector declares ${canonicalInspection.dimensions.width}x${canonicalInspection.dimensions.height}`,
         format_id_index: legacy.index,
         canonical_dimensions: canonicalInspection.dimensions,

--- a/src/lib/v2/projection/write-side.ts
+++ b/src/lib/v2/projection/write-side.ts
@@ -192,9 +192,19 @@ function inspectSelectorDimensions(
   }
 
   const hasDirectDimensions = params.width !== undefined || params.height !== undefined;
-  let diagnosed = hasDirectDimensions
-    ? addInspectionDiagnostic(diagnostics, inspection, selector, field, formatIdIndex)
-    : false;
+  let diagnosed = false;
+  if (hasDirectDimensions && inspection.kind === 'complete') {
+    diagnostics.push({
+      code: 'FORMAT_SELECTOR_DIMENSIONS_INVALID',
+      field,
+      selector,
+      message: `${field} cannot combine fixed width and height with a multi-size sizes array`,
+      ...(formatIdIndex !== undefined ? { format_id_index: formatIdIndex } : {}),
+    });
+    diagnosed = true;
+  } else if (hasDirectDimensions) {
+    diagnosed = addInspectionDiagnostic(diagnostics, inspection, selector, field, formatIdIndex);
+  }
   if (params.sizes.length === 0) {
     addInspectionDiagnostic(diagnostics, { kind: 'invalid' }, selector, `${field}.sizes`, formatIdIndex);
     return { inspection, diagnosed: true };

--- a/src/lib/v2/projection/write-side.ts
+++ b/src/lib/v2/projection/write-side.ts
@@ -300,23 +300,40 @@ export function lintPackageFormatSelectorDimensions(
       { legacyFormatConverter, projectionCatalogs: options?.projectionCatalogs }
     );
     if (converterDiagnosed) continue;
-    const dimensionalCatalogConflict =
-      inlineResult.inspection.kind === 'complete' &&
-      ref.duration_ms === undefined &&
-      projection.diagnostics.some(
-        diagnostic =>
-          diagnostic.code === 'FORMAT_PROJECTION_FAILED' &&
-          diagnostic.error.details.resolution_failure === 'catalog_requirement_conflict'
+    const catalogConflict = projection.diagnostics.some(
+      diagnostic =>
+        diagnostic.code === 'FORMAT_PROJECTION_FAILED' &&
+        diagnostic.error.details.resolution_failure === 'catalog_requirement_conflict'
+    );
+    if (catalogConflict && inlineResult.inspection.kind === 'complete') {
+      const baseProjection = projectV1ProductToV2(
+        {
+          product_id: productId,
+          name: 'Package selector',
+          description: 'Package selector dimensional lint',
+          format_ids: [{ agent_url: ref.agent_url, id: ref.id }],
+        },
+        { projectionCatalogs: options?.projectionCatalogs }
       );
-    if (dimensionalCatalogConflict) {
-      diagnostics.push({
-        code: 'FORMAT_SELECTOR_DIMENSIONS_MISMATCH',
-        field,
-        selector: 'legacy',
-        message: `${field} dimensions conflict with the resolved legacy format catalog`,
-        format_id_index: index,
-      });
-      continue;
+      const baseDeclaration = baseProjection.v2.format_options[0];
+      const baseInspection =
+        baseDeclaration?.format_kind === 'image'
+          ? inspectFixedDimensions(baseDeclaration.params)
+          : ({ kind: 'non_fixed' } as const);
+      if (
+        baseInspection.kind === 'complete' &&
+        (baseInspection.dimensions.width !== inlineResult.inspection.dimensions.width ||
+          baseInspection.dimensions.height !== inlineResult.inspection.dimensions.height)
+      ) {
+        diagnostics.push({
+          code: 'FORMAT_SELECTOR_DIMENSIONS_MISMATCH',
+          field,
+          selector: 'legacy',
+          message: `${field} dimensions conflict with the resolved legacy format catalog`,
+          format_id_index: index,
+        });
+        continue;
+      }
     }
 
     const projected = projection.v2.format_options[0];

--- a/src/lib/v2/projection/write-side.ts
+++ b/src/lib/v2/projection/write-side.ts
@@ -191,12 +191,23 @@ function inspectSelectorDimensions(
     };
   }
 
-  let diagnosed = false;
+  const hasDirectDimensions = params.width !== undefined || params.height !== undefined;
+  let diagnosed = hasDirectDimensions
+    ? addInspectionDiagnostic(diagnostics, inspection, selector, field, formatIdIndex)
+    : false;
+  if (params.sizes.length === 0) {
+    addInspectionDiagnostic(diagnostics, { kind: 'invalid' }, selector, `${field}.sizes`, formatIdIndex);
+    return { inspection, diagnosed: true };
+  }
   for (const [index, size] of params.sizes.entries()) {
-    const sizeInspection =
+    const inspectedSize =
       size !== null && typeof size === 'object' && !Array.isArray(size)
         ? inspectFixedDimensions(size as Readonly<Record<string, unknown>>)
         : ({ kind: 'invalid' } as const);
+    const sizeInspection =
+      inspectedSize.kind === 'absent' || inspectedSize.kind === 'non_fixed'
+        ? ({ kind: 'invalid' } as const)
+        : inspectedSize;
     diagnosed =
       addInspectionDiagnostic(diagnostics, sizeInspection, selector, `${field}.sizes[${index}]`, formatIdIndex) ||
       diagnosed;
@@ -213,8 +224,9 @@ function inspectSelectorDimensions(
  * legacy-only, multi-size, responsive, or inherently canonical-only shapes.
  * Legacy IDs are normalized through the same catalog/converter path as the
  * rest of the projection layer. An empty result means no dimensional issue
- * was found among selectors the configured catalogs/converter could resolve;
- * it is not proof that every seller-owned legacy ID was resolvable.
+ * was found among selectors the SDK's built-in mappings and any configured
+ * catalogs/converter could resolve; it is not proof that every seller-owned
+ * legacy ID was resolvable.
  *
  * @example
  * ```ts
@@ -278,21 +290,20 @@ export function lintPackageFormatSelectorDimensions(
       { legacyFormatConverter, projectionCatalogs: options?.projectionCatalogs }
     );
     if (converterDiagnosed) continue;
-    const dimensionalFailure = projection.diagnostics.find(
-      diagnostic =>
-        diagnostic.code === 'FORMAT_PROJECTION_FAILED' &&
-        (diagnostic.error.details.resolution_failure === 'invalid_format_id_parameters' ||
-          diagnostic.error.details.resolution_failure === 'catalog_requirement_conflict')
-    );
-    if (dimensionalFailure?.code === 'FORMAT_PROJECTION_FAILED') {
-      const catalogConflict = dimensionalFailure.error.details.resolution_failure === 'catalog_requirement_conflict';
+    const dimensionalCatalogConflict =
+      inlineResult.inspection.kind === 'complete' &&
+      ref.duration_ms === undefined &&
+      projection.diagnostics.some(
+        diagnostic =>
+          diagnostic.code === 'FORMAT_PROJECTION_FAILED' &&
+          diagnostic.error.details.resolution_failure === 'catalog_requirement_conflict'
+      );
+    if (dimensionalCatalogConflict) {
       diagnostics.push({
-        code: catalogConflict ? 'FORMAT_SELECTOR_DIMENSIONS_MISMATCH' : 'FORMAT_SELECTOR_DIMENSIONS_INVALID',
+        code: 'FORMAT_SELECTOR_DIMENSIONS_MISMATCH',
         field,
         selector: 'legacy',
-        message: catalogConflict
-          ? `${field} dimensions conflict with the resolved legacy format catalog`
-          : `${field} contains invalid fixed-size image dimensions`,
+        message: `${field} dimensions conflict with the resolved legacy format catalog`,
         format_id_index: index,
       });
       continue;
@@ -313,8 +324,7 @@ export function lintPackageFormatSelectorDimensions(
       code: 'FORMAT_SELECTOR_DIMENSIONS_INCOMPLETE',
       field: paramsField,
       selector: 'canonical',
-      message:
-        `${paramsField} must provide width and height when a direct image selector is combined with legacy image selectors`,
+      message: `${paramsField} must provide width and height when a direct image selector is combined with legacy image selectors`,
     });
   }
 

--- a/src/lib/v2/projection/write-side.ts
+++ b/src/lib/v2/projection/write-side.ts
@@ -8,10 +8,12 @@
  * protocol version.
  */
 
-import type { V1FormatId, V2ProductFormatDeclaration } from './types';
+import type { CanonicalFormatKind, V1FormatId, V2ProductFormatDeclaration } from './types';
 import { warnOnce } from '../../utils/deprecation';
 import { concealLegacyFormatRefs, concealSelectedFormatOptions } from './legacy-metadata';
 import type { CanonicalFormatDeclaration } from './legacy-metadata';
+import { projectV1ProductToV2, type LegacyFormatConverter } from './v1-to-v2';
+import type { ProjectionCatalogSnapshot } from './catalog-snapshot';
 
 export type FormatOptionRef =
   | {
@@ -63,6 +65,194 @@ export type CapabilityIdsLookupErrorCode =
   | 'capability_ids_not_published'
   | 'empty_input'
   | 'invalid_product';
+
+/** Package selector fields inspected by {@link lintPackageFormatSelectorDimensions}. */
+export interface PackageFormatSelectorInput {
+  format_kind?: CanonicalFormatKind;
+  params?: Readonly<Record<string, unknown>>;
+  format_ids?: readonly V1FormatId[];
+}
+
+/** Optional seller-specific catalogs used to resolve legacy format IDs. */
+export interface PackageFormatSelectorDimensionOptions {
+  legacyFormatConverter?: LegacyFormatConverter;
+  projectionCatalogs?: readonly ProjectionCatalogSnapshot[];
+}
+
+export interface FixedSizeDimensions {
+  width: number;
+  height: number;
+}
+
+export type PackageFormatSelectorDimensionDiagnosticCode =
+  | 'FORMAT_SELECTOR_DIMENSIONS_INCOMPLETE'
+  | 'FORMAT_SELECTOR_DIMENSIONS_INVALID'
+  | 'FORMAT_SELECTOR_DIMENSIONS_MISMATCH';
+
+/**
+ * SDK-local, non-wire diagnostic returned by
+ * {@link lintPackageFormatSelectorDimensions}.
+ */
+export interface PackageFormatSelectorDimensionDiagnostic {
+  code: PackageFormatSelectorDimensionDiagnosticCode;
+  field: string;
+  selector: 'canonical' | 'legacy' | 'cross_projection';
+  message: string;
+  format_id_index?: number;
+  canonical_dimensions?: FixedSizeDimensions;
+  legacy_dimensions?: FixedSizeDimensions;
+}
+
+type DimensionInspection =
+  | { kind: 'absent' }
+  | { kind: 'non_fixed' }
+  | { kind: 'incomplete' }
+  | { kind: 'invalid' }
+  | { kind: 'complete'; dimensions: FixedSizeDimensions };
+
+function inspectFixedDimensions(params: Readonly<Record<string, unknown>> | undefined): DimensionInspection {
+  if (!params) return { kind: 'absent' };
+  const widthPresent = params.width !== undefined;
+  const heightPresent = params.height !== undefined;
+  if (widthPresent || heightPresent) {
+    if (widthPresent !== heightPresent) return { kind: 'incomplete' };
+    if (
+      !Number.isInteger(params.width) ||
+      (params.width as number) <= 0 ||
+      !Number.isInteger(params.height) ||
+      (params.height as number) <= 0
+    ) {
+      return { kind: 'invalid' };
+    }
+    return { kind: 'complete', dimensions: { width: params.width as number, height: params.height as number } };
+  }
+
+  if (Array.isArray(params.sizes)) {
+    if (params.sizes.length !== 1) return { kind: 'non_fixed' };
+    const only = params.sizes[0];
+    if (only === null || typeof only !== 'object' || Array.isArray(only)) return { kind: 'invalid' };
+    return inspectFixedDimensions(only as Readonly<Record<string, unknown>>);
+  }
+
+  if (
+    params.min_width !== undefined ||
+    params.max_width !== undefined ||
+    params.min_height !== undefined ||
+    params.max_height !== undefined
+  ) {
+    return { kind: 'non_fixed' };
+  }
+  return { kind: 'absent' };
+}
+
+function addInspectionDiagnostic(
+  diagnostics: PackageFormatSelectorDimensionDiagnostic[],
+  inspection: DimensionInspection,
+  selector: 'canonical' | 'legacy',
+  field: string,
+  formatIdIndex?: number
+): boolean {
+  if (inspection.kind !== 'incomplete' && inspection.kind !== 'invalid') return false;
+  diagnostics.push({
+    code:
+      inspection.kind === 'incomplete' ? 'FORMAT_SELECTOR_DIMENSIONS_INCOMPLETE' : 'FORMAT_SELECTOR_DIMENSIONS_INVALID',
+    field,
+    selector,
+    message:
+      inspection.kind === 'incomplete'
+        ? `${field} must provide width and height together for a fixed-size image selector`
+        : `${field} width and height must be positive integers for a fixed-size image selector`,
+    ...(formatIdIndex !== undefined ? { format_id_index: formatIdIndex } : {}),
+  });
+  return true;
+}
+
+/**
+ * Diagnose fixed-size image dimension loss across direct canonical and
+ * deprecated legacy package selectors.
+ *
+ * This helper is deliberately advisory: it does not choose selector
+ * precedence, mutate the package, or reject valid canonical-only,
+ * legacy-only, multi-size, responsive, or inherently canonical-only shapes.
+ * Legacy IDs are normalized through the same catalog/converter path as the
+ * rest of the projection layer.
+ */
+export function lintPackageFormatSelectorDimensions(
+  selector: PackageFormatSelectorInput,
+  options?: PackageFormatSelectorDimensionOptions
+): PackageFormatSelectorDimensionDiagnostic[] {
+  const diagnostics: PackageFormatSelectorDimensionDiagnostic[] = [];
+  const canonicalImage = selector.format_kind === 'image';
+  const canonicalInspection = canonicalImage ? inspectFixedDimensions(selector.params) : { kind: 'non_fixed' as const };
+  const canonicalAlreadyDiagnosed = canonicalImage
+    ? addInspectionDiagnostic(diagnostics, canonicalInspection, 'canonical', 'params')
+    : false;
+
+  const legacyImages: Array<{ index: number; inspection: DimensionInspection }> = [];
+  for (const [index, ref] of (selector.format_ids ?? []).entries()) {
+    const inlineInspection = inspectFixedDimensions(ref as unknown as Readonly<Record<string, unknown>>);
+    if (addInspectionDiagnostic(diagnostics, inlineInspection, 'legacy', `format_ids[${index}]`, index)) continue;
+    if (!canonicalImage || canonicalInspection.kind === 'non_fixed') continue;
+
+    const projected = projectV1ProductToV2(
+      {
+        product_id: `<package-selector:${index}>`,
+        name: 'Package selector',
+        description: 'Package selector dimensional lint',
+        format_ids: [{ ...ref }],
+      },
+      options
+    ).v2.format_options[0];
+    if (projected?.format_kind !== 'image') continue;
+    legacyImages.push({ index, inspection: inspectFixedDimensions(projected.params) });
+  }
+
+  if (!canonicalImage || canonicalInspection.kind === 'non_fixed' || legacyImages.length === 0) {
+    return diagnostics;
+  }
+
+  if (canonicalInspection.kind === 'absent' && !canonicalAlreadyDiagnosed) {
+    diagnostics.push({
+      code: 'FORMAT_SELECTOR_DIMENSIONS_INCOMPLETE',
+      field: 'params',
+      selector: 'canonical',
+      message:
+        'params must provide width and height when a direct image selector is combined with legacy image selectors',
+    });
+  }
+
+  for (const legacy of legacyImages) {
+    if (legacy.inspection.kind === 'absent') {
+      diagnostics.push({
+        code: 'FORMAT_SELECTOR_DIMENSIONS_INCOMPLETE',
+        field: `format_ids[${legacy.index}]`,
+        selector: 'legacy',
+        message: `format_ids[${legacy.index}] does not resolve to width and height for comparison with the direct image selector`,
+        format_id_index: legacy.index,
+      });
+      continue;
+    }
+    if (
+      canonicalInspection.kind === 'complete' &&
+      legacy.inspection.kind === 'complete' &&
+      (canonicalInspection.dimensions.width !== legacy.inspection.dimensions.width ||
+        canonicalInspection.dimensions.height !== legacy.inspection.dimensions.height)
+    ) {
+      diagnostics.push({
+        code: 'FORMAT_SELECTOR_DIMENSIONS_MISMATCH',
+        field: `format_ids[${legacy.index}]`,
+        selector: 'cross_projection',
+        message:
+          `format_ids[${legacy.index}] resolves to ${legacy.inspection.dimensions.width}x${legacy.inspection.dimensions.height}, ` +
+          `but the direct image selector declares ${canonicalInspection.dimensions.width}x${canonicalInspection.dimensions.height}`,
+        format_id_index: legacy.index,
+        canonical_dimensions: canonicalInspection.dimensions,
+        legacy_dimensions: legacy.inspection.dimensions,
+      });
+    }
+  }
+  return diagnostics;
+}
 
 /**
  * Structured error from {@link packageRefsForFormatOptions}. Carries a

--- a/test/lib/v2-write-side.test.js
+++ b/test/lib/v2-write-side.test.js
@@ -18,9 +18,108 @@ const {
   tryLegacyFormatIdsFromOptions,
   legacyFormatIdsForFormatOption,
   legacyFormatIdsForCapability,
+  lintPackageFormatSelectorDimensions,
   projectCreativeForDelivery,
   projectMediaBuyCreativesForDelivery,
 } = require('../../dist/lib/v2/projection/index.js');
+
+const AAO_AGENT_URL = 'https://creative.adcontextprotocol.org/';
+
+describe('lintPackageFormatSelectorDimensions', () => {
+  test('accepts equivalent fixed-size canonical and legacy selectors', () => {
+    assert.deepStrictEqual(
+      lintPackageFormatSelectorDimensions({
+        format_kind: 'image',
+        params: { width: 300, height: 250 },
+        format_ids: [{ agent_url: AAO_AGENT_URL, id: 'display_300x250_image' }],
+      }),
+      []
+    );
+  });
+
+  test('reports width/height atomicity failures on either selector', () => {
+    const diagnostics = lintPackageFormatSelectorDimensions({
+      format_kind: 'image',
+      params: { width: 300 },
+      format_ids: [{ agent_url: AAO_AGENT_URL, id: 'display_300x250_image', height: 250 }],
+    });
+
+    assert.deepStrictEqual(
+      diagnostics.map(diagnostic => [diagnostic.code, diagnostic.selector, diagnostic.field]),
+      [
+        ['FORMAT_SELECTOR_DIMENSIONS_INCOMPLETE', 'canonical', 'params'],
+        ['FORMAT_SELECTOR_DIMENSIONS_INCOMPLETE', 'legacy', 'format_ids[0]'],
+      ]
+    );
+  });
+
+  test('reports conflicting canonical and resolved legacy dimensions', () => {
+    const diagnostics = lintPackageFormatSelectorDimensions({
+      format_kind: 'image',
+      params: { width: 300, height: 250 },
+      format_ids: [{ agent_url: AAO_AGENT_URL, id: 'display_728x90_image' }],
+    });
+
+    assert.strictEqual(diagnostics.length, 1);
+    assert.strictEqual(diagnostics[0].code, 'FORMAT_SELECTOR_DIMENSIONS_MISMATCH');
+    assert.deepStrictEqual(diagnostics[0].canonical_dimensions, { width: 300, height: 250 });
+    assert.deepStrictEqual(diagnostics[0].legacy_dimensions, { width: 728, height: 90 });
+  });
+
+  test('reports dimensionless dual image selectors without guessing dimensions', () => {
+    const diagnostics = lintPackageFormatSelectorDimensions(
+      {
+        format_kind: 'image',
+        params: {},
+        format_ids: [{ agent_url: 'https://formats.example/', id: 'display_image' }],
+      },
+      {
+        legacyFormatConverter: () => ({
+          format_kind: 'image',
+          format_option_id: 'generic_image',
+          params: {},
+        }),
+      }
+    );
+
+    assert.deepStrictEqual(
+      diagnostics.map(diagnostic => [diagnostic.code, diagnostic.selector, diagnostic.field]),
+      [
+        ['FORMAT_SELECTOR_DIMENSIONS_INCOMPLETE', 'canonical', 'params'],
+        ['FORMAT_SELECTOR_DIMENSIONS_INCOMPLETE', 'legacy', 'format_ids[0]'],
+      ]
+    );
+  });
+
+  test('accepts valid single-path and inherently canonical-only selectors', () => {
+    for (const selector of [
+      { format_kind: 'image', params: { width: 300, height: 250 } },
+      { format_ids: [{ agent_url: AAO_AGENT_URL, id: 'display_300x250_image' }] },
+      { format_kind: 'sponsored_placement', params: { source_catalog: 'retail' } },
+    ]) {
+      assert.deepStrictEqual(lintPackageFormatSelectorDimensions(selector), []);
+    }
+  });
+
+  test('does not treat multi-size image selectors as one fixed-size projection', () => {
+    assert.deepStrictEqual(
+      lintPackageFormatSelectorDimensions({
+        format_kind: 'image',
+        params: {
+          sizes: [
+            { width: 300, height: 250 },
+            { width: 728, height: 90 },
+          ],
+        },
+        format_ids: [
+          { agent_url: AAO_AGENT_URL, id: 'display_300x250_image' },
+          { agent_url: AAO_AGENT_URL, id: 'display_728x90_image' },
+        ],
+      }),
+      []
+    );
+  });
+});
 
 function legacyWireFormatIds(refs) {
   return projectMediaBuyCreativesForDelivery({ packages: [{ ...refs }] }, 'legacy').packages[0].format_ids;

--- a/test/lib/v2-write-side.test.js
+++ b/test/lib/v2-write-side.test.js
@@ -235,6 +235,7 @@ describe('lintPackageFormatSelectorDimensions', () => {
     const cases = [
       [{ width: 300, sizes }, 'FORMAT_SELECTOR_DIMENSIONS_INCOMPLETE'],
       [{ width: 0, height: 250, sizes }, 'FORMAT_SELECTOR_DIMENSIONS_INVALID'],
+      [{ width: 300, height: 250, sizes }, 'FORMAT_SELECTOR_DIMENSIONS_INVALID'],
     ];
 
     for (const [params, code] of cases) {

--- a/test/lib/v2-write-side.test.js
+++ b/test/lib/v2-write-side.test.js
@@ -84,6 +84,17 @@ describe('lintPackageFormatSelectorDimensions', () => {
     );
   });
 
+  test('does not relabel video duration projection failures as image dimension diagnostics', () => {
+    for (const duration_ms of [15000, 0]) {
+      assert.deepStrictEqual(
+        lintPackageFormatSelectorDimensions({
+          format_ids: [{ agent_url: AAO_AGENT_URL, id: 'video_standard_30s', duration_ms }],
+        }),
+        []
+      );
+    }
+  });
+
   test('reports dimensionless dual image selectors without guessing dimensions', () => {
     const diagnostics = lintPackageFormatSelectorDimensions(
       {
@@ -202,6 +213,37 @@ describe('lintPackageFormatSelectorDimensions', () => {
       diagnostics.map(diagnostic => [diagnostic.code, diagnostic.selector, diagnostic.field]),
       [['FORMAT_SELECTOR_DIMENSIONS_INCOMPLETE', 'canonical', 'params.sizes[1]']]
     );
+  });
+
+  test('rejects empty multi-size declarations and dimensionless size entries', () => {
+    const cases = [
+      [{ sizes: [] }, 'params.sizes'],
+      [{ sizes: [{}] }, 'params.sizes[0]'],
+    ];
+
+    for (const [params, field] of cases) {
+      const diagnostics = lintPackageFormatSelectorDimensions({ format_kind: 'image', params });
+      assert.deepStrictEqual(
+        diagnostics.map(diagnostic => [diagnostic.code, diagnostic.field]),
+        [['FORMAT_SELECTOR_DIMENSIONS_INVALID', field]]
+      );
+    }
+  });
+
+  test('validates direct dimensions even when sizes are also present', () => {
+    const sizes = [{ width: 300, height: 250 }];
+    const cases = [
+      [{ width: 300, sizes }, 'FORMAT_SELECTOR_DIMENSIONS_INCOMPLETE'],
+      [{ width: 0, height: 250, sizes }, 'FORMAT_SELECTOR_DIMENSIONS_INVALID'],
+    ];
+
+    for (const [params, code] of cases) {
+      const diagnostics = lintPackageFormatSelectorDimensions({ format_kind: 'image', params });
+      assert.deepStrictEqual(
+        diagnostics.map(diagnostic => [diagnostic.code, diagnostic.field]),
+        [[code, 'params']]
+      );
+    }
   });
 });
 

--- a/test/lib/v2-write-side.test.js
+++ b/test/lib/v2-write-side.test.js
@@ -66,6 +66,24 @@ describe('lintPackageFormatSelectorDimensions', () => {
     assert.deepStrictEqual(diagnostics[0].legacy_dimensions, { width: 728, height: 90 });
   });
 
+  test('reports dimensions that conflict with the resolved legacy catalog', () => {
+    const diagnostics = lintPackageFormatSelectorDimensions({
+      format_ids: [
+        {
+          agent_url: AAO_AGENT_URL,
+          id: 'display_728x90_image',
+          width: 300,
+          height: 250,
+        },
+      ],
+    });
+
+    assert.deepStrictEqual(
+      diagnostics.map(diagnostic => [diagnostic.code, diagnostic.selector, diagnostic.field]),
+      [['FORMAT_SELECTOR_DIMENSIONS_MISMATCH', 'legacy', 'format_ids[0]']]
+    );
+  });
+
   test('reports dimensionless dual image selectors without guessing dimensions', () => {
     const diagnostics = lintPackageFormatSelectorDimensions(
       {
@@ -101,6 +119,58 @@ describe('lintPackageFormatSelectorDimensions', () => {
     }
   });
 
+  test('reports incomplete and invalid dimensions from resolved legacy-only projections', () => {
+    const diagnostics = lintPackageFormatSelectorDimensions(
+      {
+        format_ids: [
+          { agent_url: 'https://formats.example/', id: 'partial_image' },
+          { agent_url: 'https://formats.example/', id: 'invalid_image' },
+        ],
+      },
+      {
+        legacyFormatConverter: ({ formatId }) => ({
+          format_kind: 'image',
+          format_option_id: formatId.id,
+          params: formatId.id === 'partial_image' ? { width: 300 } : { width: 0, height: 250 },
+        }),
+      }
+    );
+
+    assert.deepStrictEqual(
+      diagnostics.map(diagnostic => [diagnostic.code, diagnostic.selector, diagnostic.field]),
+      [
+        ['FORMAT_SELECTOR_DIMENSIONS_INCOMPLETE', 'legacy', 'format_ids[0]'],
+        ['FORMAT_SELECTOR_DIMENSIONS_INVALID', 'legacy', 'format_ids[1]'],
+      ]
+    );
+  });
+
+  test('preserves product-aware converter context', () => {
+    const seen = [];
+    const diagnostics = lintPackageFormatSelectorDimensions(
+      {
+        format_kind: 'image',
+        params: { width: 300, height: 250 },
+        format_ids: [{ agent_url: 'https://formats.example/', id: 'contextual_image' }],
+      },
+      {
+        projectionContext: { productId: 'product-42', field: 'packages[3]' },
+        legacyFormatConverter: context => {
+          seen.push({ productId: context.productId, field: context.field });
+          return context.productId === 'product-42'
+            ? { format_kind: 'image', format_option_id: 'contextual', params: { width: 728, height: 90 } }
+            : null;
+        },
+      }
+    );
+
+    assert.deepStrictEqual(
+      diagnostics.map(diagnostic => [diagnostic.code, diagnostic.field]),
+      [['FORMAT_SELECTOR_DIMENSIONS_MISMATCH', 'packages[3].format_ids[0]']]
+    );
+    assert.deepStrictEqual(seen, [{ productId: 'product-42', field: 'packages[3].format_ids[0]' }]);
+  });
+
   test('does not treat multi-size image selectors as one fixed-size projection', () => {
     assert.deepStrictEqual(
       lintPackageFormatSelectorDimensions({
@@ -117,6 +187,20 @@ describe('lintPackageFormatSelectorDimensions', () => {
         ],
       }),
       []
+    );
+  });
+
+  test('still enforces width/height atomicity within multi-size selectors', () => {
+    const diagnostics = lintPackageFormatSelectorDimensions({
+      format_kind: 'image',
+      params: {
+        sizes: [{ width: 300, height: 250 }, { width: 728 }],
+      },
+    });
+
+    assert.deepStrictEqual(
+      diagnostics.map(diagnostic => [diagnostic.code, diagnostic.selector, diagnostic.field]),
+      [['FORMAT_SELECTOR_DIMENSIONS_INCOMPLETE', 'canonical', 'params.sizes[1]']]
     );
   });
 });

--- a/test/lib/v2-write-side.test.js
+++ b/test/lib/v2-write-side.test.js
@@ -67,21 +67,24 @@ describe('lintPackageFormatSelectorDimensions', () => {
   });
 
   test('reports dimensions that conflict with the resolved legacy catalog', () => {
-    const diagnostics = lintPackageFormatSelectorDimensions({
-      format_ids: [
-        {
-          agent_url: AAO_AGENT_URL,
-          id: 'display_728x90_image',
-          width: 300,
-          height: 250,
-        },
-      ],
-    });
+    for (const duration_ms of [undefined, 30000]) {
+      const diagnostics = lintPackageFormatSelectorDimensions({
+        format_ids: [
+          {
+            agent_url: AAO_AGENT_URL,
+            id: 'display_728x90_image',
+            width: 300,
+            height: 250,
+            ...(duration_ms === undefined ? {} : { duration_ms }),
+          },
+        ],
+      });
 
-    assert.deepStrictEqual(
-      diagnostics.map(diagnostic => [diagnostic.code, diagnostic.selector, diagnostic.field]),
-      [['FORMAT_SELECTOR_DIMENSIONS_MISMATCH', 'legacy', 'format_ids[0]']]
-    );
+      assert.deepStrictEqual(
+        diagnostics.map(diagnostic => [diagnostic.code, diagnostic.selector, diagnostic.field]),
+        [['FORMAT_SELECTOR_DIMENSIONS_MISMATCH', 'legacy', 'format_ids[0]']]
+      );
+    }
   });
 
   test('does not relabel video duration projection failures as image dimension diagnostics', () => {
@@ -93,6 +96,22 @@ describe('lintPackageFormatSelectorDimensions', () => {
         []
       );
     }
+  });
+
+  test('does not relabel non-image catalog conflicts as image dimension diagnostics', () => {
+    assert.deepStrictEqual(
+      lintPackageFormatSelectorDimensions({
+        format_ids: [
+          {
+            agent_url: AAO_AGENT_URL,
+            id: 'display_728x90_html',
+            width: 300,
+            height: 250,
+          },
+        ],
+      }),
+      []
+    );
   });
 
   test('reports dimensionless dual image selectors without guessing dimensions', () => {


### PR DESCRIPTION
## Summary

- add a pure write-side diagnostic helper for fixed-size image package selectors
- reuse the existing legacy projection catalog/converter to compare canonical and deprecated selector dimensions
- report incomplete, invalid, and conflicting dimensions without choosing selector precedence or mutating requests
- keep canonical-only, legacy-only, multi-size, responsive, and inherently canonical-only selectors valid

## Why

Legacy 3.x callers can still send both canonical `format_kind`/`params` and deprecated `format_ids`. Missing or conflicting fixed-size image dimensions could survive shape validation and fail later inside an adapter. This adds an advisory SDK seam while leaving the protocol-level precedence decision to adcontextprotocol/adcp#6648.

## Validation

- `npm run build`
- `NODE_ENV=test npm test` (15,020 fast; 64 slow; 30 eslint-plugin tests; 0 failures)
- `npm run typecheck`
- targeted ESLint and Prettier checks
- `npm run ci:docs-check`

Closes #2584
