### PR TITLE
fix(testing): grade controller payload failures

### DIFF
--- a/.changeset/fair-runners-grade.md
+++ b/.changeset/fair-runners-grade.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Grade explicit payload-level failures as expected errors in compliance storyboards, including live-account controller denials returned through successful MCP calls.

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -5261,8 +5261,13 @@ async function executeStep(
   // Determine pass/fail — inverted when expect_error is set
   let passed: boolean;
   if (step.expect_error) {
-    // Step passes when the task fails (returns an error)
-    passed = !taskResult?.success || !!stepResult.error;
+    // Raw protocol probes can succeed at the transport layer while carrying
+    // a controller-level rejection in their structured payload. Treat the
+    // payload's explicit failure signal as the expected error; authored
+    // validations below still verify that it is the *right* rejection.
+    const responsePayload = taskResult?.data as { success?: unknown } | undefined;
+    const payloadReportsFailure = responsePayload?.success === false;
+    passed = !taskResult?.success || !!stepResult.error || payloadReportsFailure;
   } else if (crossResponses) {
     // Parallel-dispatch step: pass/fail is driven by the cross-response
     // set, not the representative arm. The representative is pinned to

--- a/test/lib/storyboard-controller-mode-gate.test.js
+++ b/test/lib/storyboard-controller-mode-gate.test.js
@@ -1,0 +1,130 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('node:http');
+
+const { runStoryboard } = require('../../dist/lib/testing/storyboard/runner');
+
+const LIVE_KEY = 'demo-live-account-key';
+
+function modeGateStoryboard() {
+  return {
+    id: 'comply_controller_mode_gate',
+    version: '1.0.0',
+    title: 'Controller mode gate',
+    category: 'security',
+    summary: '',
+    narrative: '',
+    agent: { interaction_model: '*', capabilities: [] },
+    caller: { role: 'buyer_agent' },
+    phases: [
+      {
+        id: 'live_mode_denial',
+        title: 'Live-mode denial',
+        steps: [
+          {
+            id: 'deny_live_caller',
+            title: 'Controller rejects a live-mode account',
+            task: 'comply_test_controller',
+            auth: { type: 'api_key', from_test_kit: true },
+            expect_error: true,
+            sample_request: {
+              scenario: 'force_creative_status',
+              params: { creative_id: 'comply-live-mode-probe-000', status: 'approved' },
+              // The controller request schema requires sandbox:true. The
+              // seller determines live mode from this authenticated principal.
+              account: { sandbox: true },
+              context: { correlation_id: 'comply_controller_mode_gate--deny_live_caller' },
+            },
+            validations: [
+              { check: 'field_value', path: 'success', allowed_values: [false], description: 'request rejected' },
+              { check: 'field_value', path: 'error', allowed_values: ['FORBIDDEN'], description: 'live mode denied' },
+              { check: 'field_present', path: 'context', description: 'context echoed' },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+test('mode-gate payload rejection passes expect_error after a successful MCP call', async () => {
+  const calls = [];
+  const server = http.createServer(async (req, res) => {
+    const chunks = [];
+    for await (const chunk of req) chunks.push(chunk);
+    const rpc = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+
+    if (rpc.method === 'initialize') {
+      res.writeHead(200, { 'content-type': 'application/json', 'mcp-session-id': 'mode-gate-test' });
+      res.end(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: rpc.id,
+          result: {
+            protocolVersion: '2025-06-18',
+            capabilities: {},
+            serverInfo: { name: 'mode-gate-capture', version: '1.0.0' },
+          },
+        })
+      );
+      return;
+    }
+    if (rpc.method === 'notifications/initialized') {
+      res.writeHead(202);
+      res.end();
+      return;
+    }
+
+    calls.push({
+      authorization: req.headers.authorization,
+      name: rpc.params?.name,
+      args: rpc.params?.arguments,
+    });
+    const payload = { success: false, error: 'FORBIDDEN', context: rpc.params?.arguments?.context };
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: rpc.id,
+        result: {
+          structuredContent: payload,
+          content: [{ type: 'text', text: JSON.stringify(payload) }],
+        },
+      })
+    );
+  });
+
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  try {
+    const address = server.address();
+    const result = await runStoryboard(`http://127.0.0.1:${address.port}/mcp`, modeGateStoryboard(), {
+      protocol: 'mcp',
+      allow_http: true,
+      agentTools: ['comply_test_controller'],
+      _profile: { name: 'mode-gate-capture', tools: [{ name: 'comply_test_controller' }] },
+      _client: {
+        getAgentInfo: async () => ({ name: 'mode-gate-capture', tools: [{ name: 'comply_test_controller' }] }),
+      },
+      test_kit: {
+        sandbox: false,
+        auth: { api_key: LIVE_KEY, probe_task: 'list_creatives' },
+      },
+    });
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].authorization, `Bearer ${LIVE_KEY}`);
+    assert.equal(calls[0].name, 'comply_test_controller');
+    assert.equal(calls[0].args.account.sandbox, true);
+    assert.equal(calls[0].args.scenario, 'force_creative_status');
+
+    const step = result.phases[0].steps[0];
+    assert.equal(step.passed, true, JSON.stringify(step));
+    assert.equal(
+      step.validations.every(validation => validation.passed),
+      true
+    );
+    assert.equal(result.overall_passed, true);
+  } finally {
+    await new Promise(resolve => server.close(resolve));
+  }
+});

--- a/test/lib/storyboard-expect-error-failed-payload.test.js
+++ b/test/lib/storyboard-expect-error-failed-payload.test.js
@@ -212,4 +212,28 @@ describe('storyboard expect_error failed payload normalization (#2179)', () => {
     assert.equal(gateStep.passed, true);
     assert.equal(result.overall_passed, true);
   });
+
+  test('successful payloads do not pass expect_error merely because they contain an error field', async () => {
+    const client = {
+      getAgentInfo: async () => ({ name: 'stub', tools: [{ name: 'get_products' }] }),
+      getProducts: async () => ({
+        success: true,
+        data: {
+          success: true,
+          error_code: 'INVALID_REQUEST',
+          message: 'Advisory only',
+        },
+      }),
+    };
+
+    const result = await runStoryboard('https://stub.example/mcp', buildStoryboard(), {
+      protocol: 'mcp',
+      _client: client,
+      _profile: { name: 'stub', tools: [{ name: 'get_products' }] },
+    });
+
+    const rejectStep = result.phases[0].steps[0];
+    assert.equal(rejectStep.passed, false);
+    assert.equal(result.overall_passed, false);
+  });
 });


### PR DESCRIPTION
## Summary

- recognize explicit payload-level failures when grading `expect_error` storyboard steps
- preserve the mode-gate trust boundary: the request remains schema-valid with `account.sandbox: true`, while the live account is established by the test-kit credential
- cover the raw MCP controller path and guard against treating advisory error-shaped fields as failures

## Root cause

Raw MCP probes report a successful JSON-RPC `tools/call` as `TaskResult.success: true`, even when the controller's structured payload is its error arm (`{ success: false, error: 'FORBIDDEN' }`). The authored mode-gate validations all passed, but the runner's initial `expect_error` gate only inspected transport/task failure and therefore false-failed the step.

## Validation

- `npm run build`
- focused storyboard tests: 6 passed
- affected full-suite timeout files rerun serially: 28 passed
- `npm run lint`: 0 errors (existing warnings only)
- protocol, code, and DX expert reviews: no findings

The repository-wide parallel test run exhausted local subprocess timing budgets in unrelated A2A/CLI tests; every affected file passed when rerun serially.

Closes #2580
