### PR TITLE
fix(signing): restore legacy storyboard interoperability

### DIFF
--- a/.changeset/smart-cats-verify-legacy.md
+++ b/.changeset/smart-cats-verify-legacy.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Restore RFC 9421 verifier and storyboard interoperability with frozen AdCP 3.0 and 3.1 signing vectors while preserving explicitly pinned 3.2 digest requirements.

--- a/docs/migration-12-to-14.md
+++ b/docs/migration-12-to-14.md
@@ -129,7 +129,7 @@ For `refine_proposals`, respect the advertised batch, alternative, and dimension
 
 ## Adopt version-aware request signing
 
-SDK 14 retains the AdCP 3.0/3.1 unpadded Base64URL request profile and adds the AdCP 3.2 padded standard-Base64 profile with mandatory `Content-Digest`. High-level clients propagate their configured agent version. Low-level callers and server verifiers must bind a trusted negotiated/configured version to signing options.
+SDK 14 retains the AdCP 3.0/3.1 unpadded Base64URL `Signature` profile and adds the AdCP 3.2 padded standard-Base64 signature profile with mandatory `Content-Digest`. `Content-Digest` itself remains an RFC 9530 structured field using padded standard Base64 across versions. High-level clients propagate their configured agent version. Low-level callers and server verifiers should bind a trusted negotiated/configured version to signing options; an unpinned verifier remains tolerant of both signature encodings for SDK 13 source compatibility.
 
 Never select the profile from an unverified request field. Webhook signing remains on the existing legacy profile.
 

--- a/docs/migration-13-to-14.md
+++ b/docs/migration-13-to-14.md
@@ -94,12 +94,12 @@ For proposal refinement, validate the advertised limits and supported dimensions
 
 SDK 13 used the legacy AdCP 3.0/3.1 representation. SDK 14 selects between two profiles:
 
-| Agent version | Binary encoding | Signed request `Content-Digest` |
-|---|---|---|
-| AdCP 3.0 or 3.1 | unpadded Base64URL | governed by the legacy coverage policy |
-| AdCP 3.2 | padded standard Base64 | mandatory |
+| Agent version | `Signature` encoding | `Content-Digest` encoding | Digest coverage |
+|---|---|---|---|
+| AdCP 3.0 or 3.1 | unpadded Base64URL | padded standard Base64 | governed by the legacy coverage policy |
+| AdCP 3.2 | padded standard Base64 | padded standard Base64 | mandatory |
 
-High-level A2A/MCP clients carry the configured agent version automatically. Low-level signing integrations should pass their trusted version context and can inspect the encoding with `requestSigningEncodingForVersion()`.
+High-level A2A/MCP clients carry the configured agent version automatically. Low-level signing integrations should pass their trusted version context and can inspect the signature encoding with `requestSigningEncodingForVersion()`. For SDK 13 source compatibility, a low-level verifier with no `adcpVersion` accepts either signature encoding and applies its configured digest-coverage policy; an explicit trusted 3.2 pin keeps mandatory digest coverage.
 
 For a staged server rollout, set the internal verifier option
 `signedRequests.covers_content_digest: 'either'` to accept SDK 13 Base64URL

--- a/src/lib/server/auth-signature.ts
+++ b/src/lib/server/auth-signature.ts
@@ -80,7 +80,11 @@ export interface VerifySignatureAsAuthenticatorOptions {
   revocationStore?: RevocationStore;
   /** Override clock for tests. */
   now?: () => number;
-  /** Trusted endpoint release pin used to select the 3.0/3.1 or 3.2 binary profile. */
+  /**
+   * Trusted endpoint release pin used to select the 3.0/3.1 or 3.2 signature
+   * profile. When omitted, verification accepts both encodings for SDK 13
+   * compatibility while digest coverage follows `capability`.
+   */
   adcpVersion?: string;
   /**
    * Extract the AdCP operation name from the incoming request. Called with

--- a/src/lib/signing/signer.ts
+++ b/src/lib/signing/signer.ts
@@ -228,7 +228,10 @@ export function prepareRequestSignature(
   const coverDigest = hasBody && (binaryEncoding === 'rfc8941-base64' || options.coverContentDigest === true);
   const headers: Record<string, string> = { ...flattenHeaders(request.headers) };
   if (coverDigest) {
-    headers['Content-Digest'] = computeContentDigest(request.body ?? '', binaryEncoding);
+    // Content-Digest is an RFC 9530 Structured Field and uses RFC 8941
+    // standard Base64 independently of the request Signature's versioned
+    // serialization. Frozen AdCP 3.0/3.1 vectors already use this form.
+    headers['Content-Digest'] = computeContentDigest(request.body ?? '', 'rfc8941-base64');
   }
 
   const components = [...MANDATORY_COMPONENTS];

--- a/src/lib/signing/verifier.ts
+++ b/src/lib/signing/verifier.ts
@@ -6,7 +6,12 @@ import {
   rejectNonAsciiHost,
   type RequestLike,
 } from './canonicalize';
-import { contentDigestMatches, contentDigestUsesEncoding, requestSigningEncodingForVersion } from './content-digest';
+import {
+  contentDigestMatches,
+  contentDigestUsesEncoding,
+  requestSigningEncodingForVersion,
+  type SfBinaryEncoding,
+} from './content-digest';
 import { RequestSignatureError } from './errors';
 import { parseSignature, parseSignatureInput, type ParsedSignatureInput } from './parser';
 import { jwkToPublicKey, verifySignature } from './crypto';
@@ -23,7 +28,6 @@ import {
   type VerifierCapability,
   type VerifyResult,
 } from './types';
-import { ADCP_VERSION } from '../version';
 
 export interface VerifyRequestOptions {
   capability: VerifierCapability;
@@ -39,7 +43,12 @@ export interface VerifyRequestOptions {
    * always-verify mode (where every request is signed) can leave this blank.
    */
   operation?: string;
-  /** Trusted endpoint release pin; never inferred from request payload data. */
+  /**
+   * Trusted endpoint release pin; never inferred from request payload data.
+   * When omitted, the verifier accepts both the legacy 3.0/3.1 Base64URL
+   * representation and the 3.2+ RFC 8941 Base64 representation. Digest
+   * coverage still follows `capability.covers_content_digest`.
+   */
   adcpVersion?: string;
   agentUrlForKeyid?: (keyid: string) => string | undefined;
 }
@@ -49,7 +58,8 @@ export async function verifyRequestSignature(
   options: VerifyRequestOptions
 ): Promise<VerifyResult> {
   const now = options.now ? options.now() : Math.floor(Date.now() / 1000);
-  const binaryEncoding = requestSigningEncodingForVersion(options.adcpVersion ?? ADCP_VERSION);
+  const pinnedBinaryEncoding =
+    options.adcpVersion !== undefined ? requestSigningEncodingForVersion(options.adcpVersion) : undefined;
   const sigInputHeader = getHeaderValue(request.headers, 'Signature-Input');
   const sigHeader = getHeaderValue(request.headers, 'Signature');
 
@@ -110,22 +120,21 @@ export async function verifyRequestSignature(
 
   // Step 1: parse.
   const parsedInput = parseSignatureInput(sigInputHeader);
-  let parsedSig;
-  try {
-    parsedSig = parseSignature(sigHeader, parsedInput.label, binaryEncoding);
-  } catch (error) {
-    // `either` is the explicit rolling-upgrade profile: SDK 14 servers may
-    // receive SDK 12/13 Base64URL signatures while the endpoint itself is
-    // pinned to 3.2. The signature bytes are identical; only their structured
-    // field serialization differs. Strict `required`/`forbidden` profiles do
-    // not take this fallback.
-    if (options.capability.covers_content_digest !== 'either') throw error;
-    parsedSig = parseSignature(
-      sigHeader,
-      parsedInput.label,
-      binaryEncoding === 'rfc8941-base64' ? 'legacy-base64url' : 'rfc8941-base64'
-    );
+  const binaryEncodingCandidates = signatureEncodingCandidates(
+    pinnedBinaryEncoding,
+    options.capability?.covers_content_digest
+  );
+  let parsedSig: ReturnType<typeof parseSignature> | undefined;
+  let parseError: unknown;
+  for (const candidate of binaryEncodingCandidates) {
+    try {
+      parsedSig = parseSignature(sigHeader, parsedInput.label, candidate);
+      break;
+    } catch (error) {
+      parseError ??= error;
+    }
   }
+  if (!parsedSig) throw parseError;
   rejectNonAsciiHost(request.url);
   validateSingleValuedCoveredHeaders(parsedInput.components, request);
 
@@ -154,8 +163,10 @@ export async function verifyRequestSignature(
   validateWindow(parsedInput.params.created, parsedInput.params.expires, now);
 
   // Step 6: covered components.
+  // The 3.2 digest floor comes only from the trusted endpoint pin. Never
+  // derive it from the request's attacker-controlled serialization.
   const effectiveCapability =
-    binaryEncoding === 'rfc8941-base64'
+    pinnedBinaryEncoding === 'rfc8941-base64'
       ? { ...options.capability, covers_content_digest: 'required' as const }
       : options.capability;
   validateCoveredComponents(parsedInput.components, effectiveCapability, request);
@@ -240,12 +251,9 @@ export async function verifyRequestSignature(
     const digestHeader = getHeaderValue(request.headers, 'Content-Digest');
     const encodingMatches =
       !!digestHeader &&
-      (contentDigestUsesEncoding(digestHeader, binaryEncoding) ||
-        (options.capability.covers_content_digest === 'either' &&
-          contentDigestUsesEncoding(
-            digestHeader,
-            binaryEncoding === 'rfc8941-base64' ? 'legacy-base64url' : 'rfc8941-base64'
-          )));
+      contentDigestEncodingCandidates(pinnedBinaryEncoding, options.capability.covers_content_digest).some(candidate =>
+        contentDigestUsesEncoding(digestHeader, candidate)
+      );
     if (!digestHeader || !encodingMatches || !contentDigestMatches(digestHeader, request.body ?? '')) {
       throw new RequestSignatureError(
         'request_signature_digest_mismatch',
@@ -279,6 +287,30 @@ export async function verifyRequestSignature(
 
   const agent_url = options.agentUrlForKeyid?.(jwk.kid);
   return { status: 'verified', keyid: jwk.kid, agent_url, verified_at: now };
+}
+
+function signatureEncodingCandidates(
+  pinned: SfBinaryEncoding | undefined,
+  digestPolicy: VerifierCapability['covers_content_digest'] | undefined
+): readonly SfBinaryEncoding[] {
+  if (!pinned) return ['rfc8941-base64', 'legacy-base64url'];
+  if (digestPolicy !== 'either') return [pinned];
+  return [pinned, alternateBinaryEncoding(pinned)];
+}
+
+function contentDigestEncodingCandidates(
+  pinned: SfBinaryEncoding | undefined,
+  digestPolicy: VerifierCapability['covers_content_digest']
+): readonly SfBinaryEncoding[] {
+  // Legacy bundles contain both historical Base64URL digests and standards-
+  // compliant RFC 8941 Base64 digests. A strict 3.2 endpoint narrows to the
+  // latter; rolling-upgrade and unpinned verifiers accept both serializations.
+  if (pinned === 'rfc8941-base64' && digestPolicy !== 'either') return [pinned];
+  return ['rfc8941-base64', 'legacy-base64url'];
+}
+
+function alternateBinaryEncoding(encoding: SfBinaryEncoding): SfBinaryEncoding {
+  return encoding === 'rfc8941-base64' ? 'legacy-base64url' : 'rfc8941-base64';
 }
 
 function jsonRpcProtocolMethods(body: string | undefined): string[] {

--- a/src/lib/testing/compliance/comply.ts
+++ b/src/lib/testing/compliance/comply.ts
@@ -1355,6 +1355,7 @@ async function complyImpl(agentUrl: string, options: ComplyOptions): Promise<Com
     const executedStoryboards: Storyboard[] = [];
     const runOptions: StoryboardRunOptions = {
       ...effectiveOptions,
+      ...(complianceDir !== undefined && { complianceDir }),
       agentTools: profile.tools,
       ...(webhook_receiver !== undefined && { webhook_receiver }),
       ...(webhook_replay_receiver !== undefined && { webhook_replay_receiver }),

--- a/src/lib/testing/storyboard/compliance.ts
+++ b/src/lib/testing/storyboard/compliance.ts
@@ -533,11 +533,26 @@ function loadStoryboardsFromDir(dir: string): Storyboard[] {
 /** Load storyboards for a single bundle (universal YAML file, domain dir, or specialism dir). */
 export function loadBundleStoryboards(ref: BundleRef): Storyboard[] {
   const raw = ref.kind === 'universal' ? safeLoadUniversal(ref.path) : loadStoryboardsFromDir(ref.path);
-  return raw.map(sb => annotateStoryboardVersion(postProcessStoryboard(sb), ref.adcp_version));
+  const complianceDir = dirname(dirname(ref.path));
+  return raw.map(sb =>
+    annotateStoryboardVersion(
+      postProcessStoryboard(sb, ref.adcp_version, complianceDir),
+      ref.adcp_version,
+      complianceDir
+    )
+  );
 }
 
-function annotateStoryboardVersion(storyboard: Storyboard, adcpVersion: string | undefined): Storyboard {
-  return adcpVersion === undefined ? storyboard : { ...storyboard, adcp_version: adcpVersion };
+function annotateStoryboardVersion(
+  storyboard: Storyboard,
+  adcpVersion: string | undefined,
+  complianceDir: string
+): Storyboard {
+  return {
+    ...storyboard,
+    ...(adcpVersion !== undefined && { adcp_version: adcpVersion }),
+    compliance_dir: complianceDir,
+  };
 }
 
 function safeLoadUniversal(path: string): Storyboard[] {
@@ -554,10 +569,10 @@ function safeLoadUniversal(path: string): Storyboard[] {
  * request-signing test vectors; synthesize them here so downstream callers
  * (the runner, CLI tooling, reporting) see a fully-populated storyboard.
  */
-function postProcessStoryboard(storyboard: Storyboard): Storyboard {
+function postProcessStoryboard(storyboard: Storyboard, adcpVersion?: string, complianceDir?: string): Storyboard {
   if (storyboard.id === 'signed_requests') {
     try {
-      return synthesizeRequestSigningSteps(storyboard);
+      return synthesizeRequestSigningSteps(storyboard, { version: adcpVersion, complianceDir });
     } catch (err) {
       // Synthesis failure = infrastructural problem (cache missing vectors,
       // schema drift, etc.). Emit a synthetic failing phase so the runner's

--- a/src/lib/testing/storyboard/request-signing/probe-dispatch.ts
+++ b/src/lib/testing/storyboard/request-signing/probe-dispatch.ts
@@ -44,7 +44,10 @@ export async function probeRequestSigningVector(
   // hardcoded vector id. Keeps the dispatch resilient to upstream renames.
   if (parsed.kind === 'negative' && rsOpts.skipRateAbuse) {
     try {
-      const loaded = loadRequestSigningVectors();
+      const loaded = loadRequestSigningVectors({
+        version: options.adcpVersion,
+        complianceDir: options.complianceDir,
+      });
       const vector = loaded.negative.find(v => v.id === parsed.vector_id);
       if (vector?.requires_contract === 'rate_abuse') {
         return skipProbe(agentUrl, 'rate_abuse_opt_out');
@@ -58,6 +61,8 @@ export async function probeRequestSigningVector(
   }
   try {
     const result = await gradeOneVector(parsed.vector_id, parsed.kind, agentUrl, {
+      ...(options.adcpVersion && { version: options.adcpVersion }),
+      ...(options.complianceDir && { complianceDir: options.complianceDir }),
       allowPrivateIp: options.allow_http === true,
       rateAbuseCap: rsOpts.rateAbuseCap,
       allowLiveSideEffects: rsOpts.allowLiveSideEffects,

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -220,7 +220,10 @@ export function applyStoryboardVersionOptions(
   storyboard: Storyboard,
   options: StoryboardRunOptions
 ): StoryboardRunOptions {
-  return applyAdcpVersionRunOptions(storyboard.adcp_version, options);
+  const versioned = applyAdcpVersionRunOptions(storyboard.adcp_version, options);
+  const mayInheritStoryboardDir = options.adcpVersion === undefined || options.adcpVersion === storyboard.adcp_version;
+  const complianceDir = versioned.complianceDir ?? (mayInheritStoryboardDir ? storyboard.compliance_dir : undefined);
+  return complianceDir && versioned.complianceDir !== complianceDir ? { ...versioned, complianceDir } : versioned;
 }
 
 export function applyAdcpVersionRunOptions(
@@ -6670,7 +6673,7 @@ function webhookVectorFileCandidates(refPath: string, options: StoryboardRunOpti
     candidates.push(join(options.webhook_replay_receiver.vectorsRoot, withoutStatic));
     candidates.push(join(options.webhook_replay_receiver.vectorsRoot, baseName));
   }
-  const complianceDir = getComplianceCacheDir({ version: options.adcpVersion });
+  const complianceDir = getComplianceCacheDir({ version: options.adcpVersion, complianceDir: options.complianceDir });
   candidates.push(join(complianceDir, withoutStatic));
   candidates.push(join(complianceDir, refPath));
   candidates.push(join(process.cwd(), refPath));

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -37,6 +37,12 @@ export interface Storyboard {
    * authored in storyboard YAML.
    */
   adcp_version?: string;
+  /**
+   * Compliance cache root this storyboard was loaded from. Injected by the
+   * cache loader so synthesized vectors and runtime probes use the same
+   * bundle even when process-level cache environment variables differ.
+   */
+  compliance_dir?: string;
   title: string;
   category: string;
   summary: string;
@@ -1600,6 +1606,8 @@ export interface TrustedMatchPublisherAuthRunner {
 }
 
 export interface StoryboardRunOptions extends TestOptions {
+  /** Compliance cache root for bundle-scoped fixtures and test vectors. */
+  complianceDir?: string;
   /** Initial context (e.g., from a previous step invocation) */
   context?: StoryboardContext;
   /**

--- a/test/lib/storyboard-version-negotiation.test.js
+++ b/test/lib/storyboard-version-negotiation.test.js
@@ -122,6 +122,18 @@ describe('storyboard runner AdCP version negotiation', () => {
     assert.strictEqual(options.versionEnvelope, 'auto');
   });
 
+  test('explicit version override does not inherit a mismatched storyboard cache root', () => {
+    const { applyStoryboardVersionOptions } = require('../../dist/lib/testing/storyboard/index.js');
+
+    const options = applyStoryboardVersionOptions(
+      { adcp_version: CURRENT_PRERELEASE_VERSION, compliance_dir: '/cache/3.2' },
+      { adcpVersion: '3.1.15' }
+    );
+
+    assert.strictEqual(options.adcpVersion, '3.1.15');
+    assert.strictEqual(options.complianceDir, undefined);
+  });
+
   test('version_negotiation evaluates envelope_field_pattern instead of forward-compatible not_applicable', async () => {
     const { runStoryboard } = require('../../dist/lib/testing/storyboard/runner.js');
     const { createTestClient } = require('../../dist/lib/testing/client.js');

--- a/test/request-signing-review-fixes.test.js
+++ b/test/request-signing-review-fixes.test.js
@@ -173,6 +173,23 @@ describe('content-digest SF dictionary support (protocol finding)', () => {
     const header = `sha-512=:AAAA==:, sha-256=:${sha256}:`;
     assert.strictEqual(contentDigestMatches(header, body), true);
   });
+
+  test('legacy request signatures still emit RFC 9530 standard-Base64 Content-Digest', () => {
+    const body = '{"plan_id":"legacy_digest"}';
+    const signed = signRequest(
+      {
+        method: 'POST',
+        url: 'https://seller.example.com/adcp/create_media_buy',
+        headers: { 'Content-Type': 'application/json' },
+        body,
+      },
+      { keyid: 'test-ed25519-2026', alg: 'ed25519', privateKey: privateJwk },
+      { coverContentDigest: true, binaryEncoding: 'legacy-base64url' }
+    );
+
+    assert.strictEqual(contentDigestUsesEncoding(signed.headers['Content-Digest'], 'rfc8941-base64'), true);
+    assert.strictEqual(contentDigestUsesEncoding(signed.headers['Content-Digest'], 'legacy-base64url'), false);
+  });
 });
 
 describe('AdCP 3.2 RFC 8941 binary profile', () => {
@@ -183,7 +200,7 @@ describe('AdCP 3.2 RFC 8941 binary profile', () => {
     assert.strictEqual(requestSigningEncodingForVersion('3.2.0-beta.0'), 'rfc8941-base64');
   });
 
-  test('SDK 14 defaults verification to 3.2 padded Base64 and mandatory Content-Digest', async () => {
+  test('an explicitly pinned 3.2 verifier uses padded Base64 and mandatory Content-Digest', async () => {
     const now = 1776520800;
     const url = 'https://seller.example.com/adcp/create_media_buy';
     const body = '{"plan_id":"plan_3_2"}';
@@ -205,18 +222,19 @@ describe('AdCP 3.2 RFC 8941 binary profile', () => {
     const result = await verifyRequestSignature(
       { method: 'POST', url, headers: signed.headers, body },
       {
-        capability: { supported: true, covers_content_digest: 'forbidden', required_for: [] },
+        capability: { supported: true, covers_content_digest: 'required', required_for: [] },
         jwks: new StaticJwksResolver([publicJwk]),
         replayStore: new InMemoryReplayStore(),
         revocationStore: new InMemoryRevocationStore(),
         now: () => now,
         operation: 'create_media_buy',
+        adcpVersion: '3.2-beta.0',
       }
     );
     assert.strictEqual(result.keyid, 'test-ed25519-2026');
   });
 
-  test('SDK 14 default rejects legacy body signatures that omit Content-Digest', async () => {
+  test('an explicit 3.2 pin rejects legacy body signatures that omit Content-Digest', async () => {
     const now = 1776520800;
     const url = 'https://seller.example.com/adcp/create_media_buy';
     const body = '{"amount":1}';
@@ -225,20 +243,23 @@ describe('AdCP 3.2 RFC 8941 binary profile', () => {
       { keyid: 'test-ed25519-2026', alg: 'ed25519', privateKey: privateJwk },
       { now: () => now, nonce: 'legacy-no-digest-nonce', binaryEncoding: 'legacy-base64url' }
     );
-    await assert.rejects(
-      () =>
-        verifyRequestSignature(
-          { method: 'POST', url, headers: signed.headers, body: '{"amount":999999}' },
-          {
-            capability: { supported: true, covers_content_digest: 'either', required_for: [] },
-            jwks: new StaticJwksResolver([publicJwk]),
-            replayStore: new InMemoryReplayStore(),
-            revocationStore: new InMemoryRevocationStore(),
-            now: () => now,
-          }
-        ),
-      err => err instanceof RequestSignatureError && err.code === 'request_signature_components_incomplete'
-    );
+    for (const adcpVersion of ['3.2-beta.0', '']) {
+      await assert.rejects(
+        () =>
+          verifyRequestSignature(
+            { method: 'POST', url, headers: signed.headers, body: '{"amount":999999}' },
+            {
+              capability: { supported: true, covers_content_digest: 'either', required_for: [] },
+              jwks: new StaticJwksResolver([publicJwk]),
+              replayStore: new InMemoryReplayStore(),
+              revocationStore: new InMemoryRevocationStore(),
+              now: () => now,
+              adcpVersion,
+            }
+          ),
+        err => err instanceof RequestSignatureError && err.code === 'request_signature_components_incomplete'
+      );
+    }
   });
 
   test('strict verification rejects duplicate Content-Digest dictionary members', async () => {

--- a/test/request-signing-runner-integration.test.js
+++ b/test/request-signing-runner-integration.test.js
@@ -124,6 +124,33 @@ function startReferenceVerifier({ replayCap = 1000 } = {}) {
 }
 
 describe('request-signing: synthesize step expansion', () => {
+  test('compliance loader synthesizes vectors from the selected frozen bundle', () => {
+    const previousComplianceDir = process.env.ADCP_COMPLIANCE_DIR;
+    process.env.ADCP_COMPLIANCE_DIR = path.join('compliance', 'cache', '3.2.0-beta.0');
+    let storyboards;
+    try {
+      storyboards = loadBundleStoryboards({
+        kind: 'universal',
+        id: 'signed-requests',
+        path: path.join('compliance', 'cache', '3.0.24', 'universal', 'signed-requests.yaml'),
+        adcp_version: '3.0.24',
+      });
+    } finally {
+      if (previousComplianceDir === undefined) delete process.env.ADCP_COMPLIANCE_DIR;
+      else process.env.ADCP_COMPLIANCE_DIR = previousComplianceDir;
+    }
+    const sb = storyboards.find(storyboard => storyboard.id === 'signed_requests');
+    assert.ok(sb, '3.0.24 signed_requests storyboard loaded');
+    assert.strictEqual(sb.adcp_version, '3.0.24');
+    assert.strictEqual(sb.compliance_dir, path.join('compliance', 'cache', '3.0.24'));
+    assert.strictEqual(sb.phases.find(phase => phase.id === 'positive_vectors').steps.length, 12);
+    assert.strictEqual(
+      sb.phases.find(phase => phase.id === 'negative_vectors').steps.length,
+      27,
+      '3.0.24 must not synthesize the 28 vectors from the ambient 3.2 cache'
+    );
+  });
+
   test('compliance loader synthesizes per-vector steps for the signed-requests universal storyboard', () => {
     // AdCP 3.0.1 promoted `signed-requests` from a specialism to a universal
     // capability-gated storyboard (lives at `universal/signed-requests.yaml`,

--- a/test/request-signing-version-compat.test.js
+++ b/test/request-signing-version-compat.test.js
@@ -1,0 +1,60 @@
+const { describe, test } = require('node:test');
+const assert = require('node:assert');
+
+const {
+  InMemoryReplayStore,
+  InMemoryRevocationStore,
+  RequestSignatureError,
+  StaticJwksResolver,
+  verifyRequestSignature,
+} = require('../dist/lib/signing/index.js');
+const { loadRequestSigningVectors } = require('../dist/lib/testing/storyboard/request-signing/index.js');
+
+function publicKeys(loaded) {
+  return loaded.keys.keys.map(({ private_d: _private, ...key }) => key);
+}
+
+function verificationOptions(vector, loaded, adcpVersion) {
+  return {
+    capability: vector.verifier_capability,
+    jwks: new StaticJwksResolver(publicKeys(loaded)),
+    replayStore: new InMemoryReplayStore(),
+    revocationStore: new InMemoryRevocationStore(),
+    now: () => vector.reference_now,
+    operation: new URL(vector.request.url).pathname.split('/').filter(Boolean).at(-1),
+    ...(adcpVersion && { adcpVersion }),
+  };
+}
+
+describe('request-signing compatibility across frozen AdCP bundles', () => {
+  for (const version of ['3.0.24', '3.1.15']) {
+    test(`${version} positive vectors work with both omitted and explicit endpoint pins`, async () => {
+      const loaded = loadRequestSigningVectors({ version });
+      const vectors = ['001-basic-post', '002-post-with-content-digest'].map(id =>
+        loaded.positive.find(vector => vector.id === id)
+      );
+
+      for (const vector of vectors) {
+        assert.ok(vector, `${version} vector should exist`);
+        for (const adcpVersion of [undefined, version]) {
+          const result = await verifyRequestSignature(vector.request, verificationOptions(vector, loaded, adcpVersion));
+          assert.strictEqual(result.status, 'verified', `${vector.id} with pin ${adcpVersion ?? 'omitted'}`);
+        }
+      }
+    });
+
+    test(`${version} omitted endpoint pin preserves negative-vector error precedence`, async () => {
+      const loaded = loadRequestSigningVectors({ version });
+      for (const id of ['002-wrong-tag', '007-missing-content-digest', '018-digest-covered-when-forbidden']) {
+        const vector = loaded.negative.find(candidate => candidate.id === id);
+        assert.ok(vector, `${version} negative vector ${id} should exist`);
+
+        await assert.rejects(
+          () => verifyRequestSignature(vector.request, verificationOptions(vector, loaded)),
+          error => error instanceof RequestSignatureError && error.code === vector.expected_error_code,
+          `${id} should fail with ${vector.expected_error_code}`
+        );
+      }
+    });
+  }
+});


### PR DESCRIPTION
Closes #2576

## Summary
- restore omitted-version verifier compatibility for AdCP 3.0/3.1 signatures without weakening explicitly pinned 3.2 digest requirements
- decouple Signature and Content-Digest encodings and restore RFC 9530 digest emission
- pin storyboard synthesis and probes to the selected compliance cache root and version
- add frozen 3.0.24/3.1.15 positive and negative regression coverage

## Verification
- npm run build:lib
- npm run lint (0 errors; existing warnings)
- 91 request-signing/vector tests
- 33 signed-server integration tests
- code, DX, protocol, and security expert reviews clean
- npm run review:codex -- --all --base main attempted; unavailable because the configured API account has no remaining credits