### PR TITLE
fix(negotiation): accept 3.2 beta proposal responses

### DIFF
--- a/.changeset/warm-ravens-negotiate.md
+++ b/.changeset/warm-ravens-negotiate.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Accept AdCP 3.2 prerelease version envelopes when verifying `refine_proposals` responses from beta servers.

--- a/src/lib/negotiation/verification.ts
+++ b/src/lib/negotiation/verification.ts
@@ -139,8 +139,15 @@ function validateResponseShape(value: unknown, issues: ProposalVerificationIssue
     return false;
   }
   let valid = allowedKeys(value, RESPONSE_KEYS, 'response', issues);
-  if (value.adcp_version !== undefined && value.adcp_version !== '3.2') {
-    valid = shape(issues, 'adcp_version', 'refine_proposals response adcp_version must be 3.2');
+  if (
+    value.adcp_version !== undefined &&
+    (typeof value.adcp_version !== 'string' || !ADCP_3_2_RELEASE_PATTERN.test(value.adcp_version))
+  ) {
+    valid = shape(
+      issues,
+      'adcp_version',
+      `refine_proposals response adcp_version must be on the 3.2 release line; received ${formatReceivedValue(value.adcp_version)}`
+    );
   }
   if (value.message !== undefined && (typeof value.message !== 'string' || value.message.length > 2000)) {
     valid = shape(issues, 'message', 'message must be a string of at most 2000 characters');
@@ -854,6 +861,7 @@ const PRICING_KEYS = new Set([
 const MONEY_KEYS = new Set(['amount', 'currency']);
 const CANCELLATION_KEYS = new Set(['effective_at', 'fee', 'reason']);
 const OUTCOMES = new Set(['revised', 'partial', 'finalized', 'unable']);
+const ADCP_3_2_RELEASE_PATTERN = /^3\.2(?:-[A-Za-z0-9](?:[A-Za-z0-9.-]*[A-Za-z0-9])?)?$/;
 const REASONS = new Set<ProposalRefinementReason>([
   'commercially_declined',
   'constraint_unsatisfiable',
@@ -889,6 +897,16 @@ function nonempty(value: unknown): value is string {
 
 function boundedString(value: unknown, min: number, max: number): value is string {
   return typeof value === 'string' && value.length >= min && value.length <= max;
+}
+
+function formatReceivedValue(value: unknown): string {
+  try {
+    const serialized = JSON.stringify(value);
+    if (serialized === undefined) return typeof value;
+    return serialized.length <= 200 ? serialized : `${serialized.slice(0, 197)}...`;
+  } catch {
+    return typeof value;
+  }
 }
 
 function finite(value: unknown): value is number {

--- a/test/lib/proposal-negotiation-server.test.js
+++ b/test/lib/proposal-negotiation-server.test.js
@@ -13,6 +13,7 @@ const {
   proposalRefinementScopeFromContext,
   proposalTermsDigest,
 } = require('../../dist/lib/server/index.js');
+const { verifyRefineProposalsResponse } = require('../../dist/lib/index.js');
 
 const request = (key, proposalId = 'source-1') => ({
   adcp_version: '3.2',
@@ -121,8 +122,14 @@ describe('refine_proposals server integration', () => {
     assert.equal(capabilities.structuredContent.adcp_version, '3.2-beta.0');
     assert.ok(capabilities.structuredContent.media_buy.lifecycle_tools.includes('refine_proposals'));
 
-    const response = await call(server, 'refine_proposals', request('version-envelope-key-0001'), 'buyer-a');
+    const betaRequest = request('version-envelope-key-0001');
+    const response = await call(server, 'refine_proposals', betaRequest, 'buyer-a');
     assert.equal(response.structuredContent.adcp_version, '3.2-beta.0');
+    assert.equal(
+      verifyRefineProposalsResponse(betaRequest, response.structuredContent).ok,
+      true,
+      'the SDK buyer verifier must accept the default beta server response'
+    );
   });
 
   test('rejects an explicit pre-3.2 server pin', () => {

--- a/test/lib/proposal-negotiation-validation.test.js
+++ b/test/lib/proposal-negotiation-validation.test.js
@@ -252,6 +252,47 @@ test('compact submitted responses validate without completed-field access', () =
   }
 });
 
+test('response verifier accepts only release-precision values on the AdCP 3.2 line', () => {
+  const submitted = {
+    status: 'submitted',
+    task_id: 'proposal-task-version',
+  };
+
+  for (const adcp_version of ['3.2', '3.2-beta.0', '3.2-rc.1', '3.2-beta..1']) {
+    assert.equal(validateRefineProposalsResponseShape({ ...submitted, adcp_version }).ok, true, adcp_version);
+  }
+
+  for (const adcp_version of [
+    '3.1',
+    '4.0',
+    '3.2.0',
+    '3.2.0-beta.0',
+    '3.2-.',
+    '3.2-.beta',
+    '3.2-beta.',
+    '3.2--',
+    'garbage',
+    3.2,
+    null,
+    {},
+    true,
+  ]) {
+    const result = validateRefineProposalsResponseShape({ ...submitted, adcp_version });
+    assert.equal(result.ok, false, String(adcp_version));
+    assert.equal(result.issues[0]?.path, 'adcp_version');
+    assert.match(result.issues[0]?.message ?? '', /3\.2 release line; received/);
+  }
+
+  assert.match(
+    validateRefineProposalsResponseShape({ ...submitted, adcp_version: 3.2 }).issues[0]?.message ?? '',
+    /received 3\.2$/
+  );
+  assert.match(
+    validateRefineProposalsResponseShape({ ...submitted, adcp_version: null }).issues[0]?.message ?? '',
+    /received null$/
+  );
+});
+
 test('response verifier validates discriminated result shapes before semantic checks', () => {
   const req = request();
   const cases = [


### PR DESCRIPTION
## Summary

- accept stable and prerelease values on the AdCP 3.2 release line in `refine_proposals` response verification
- keep rejecting other release lines, full-semver bundle versions, malformed values, and non-string values with actionable diagnostics
- cover the default beta server response through the public SDK buyer verifier

## Validation

- `npm run ci:quick`
- `node --test test/lib/proposal-negotiation-validation.test.js test/lib/proposal-negotiation-server.test.js test/lib/proposal-negotiation.test.js`
- code, DX, and protocol expert reviews converged with no remaining findings

Closes #2571
