### PR TITLE
fix(package): reduce published schema declaration size

### DIFF
--- a/.changeset/tiny-schema-facades.md
+++ b/.changeset/tiny-schema-facades.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Reduce the published package size by sharing the exact generated schema declarations between ESM and CommonJS consumers.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,9 @@ jobs:
       - name: Build library
         run: npm run build:lib
 
+      - name: Enforce publish-size budgets
+        run: npm run check:package-size
+
       - name: Validate package exports
         run: |
           node -e "
@@ -165,7 +168,7 @@ jobs:
           if [ -z "$base" ] || ! git cat-file -e "${base}^{commit}" 2>/dev/null; then
             # No usable base (first push, force-push, scheduled run) — run to be safe.
             echo "changed=true" >> "$GITHUB_OUTPUT"
-          elif git diff --name-only "$base" HEAD | grep -qE '^(package\.json|package-lock\.json|tsup\.config\.ts|tsconfig\.json|tsconfig\.lib\.json|tsconfig\.build\.json|scripts/(generate-dmts-declarations|generate-per-tool-types|copy-schemas-to-dist|copy-v2-projection-catalog|generate-wire-spec-fields)\.ts|scripts/verify-package\.mjs|\.github/workflows/ci\.yml)$'; then
+          elif git diff --name-only "$base" HEAD | grep -qE '^(package\.json|package-lock\.json|tsup\.config\.ts|tsconfig\.json|tsconfig\.lib\.json|tsconfig\.build\.json|scripts/(generate-dmts-declarations|generate-per-tool-types|copy-schemas-to-dist|copy-v2-projection-catalog|generate-wire-spec-fields)\.ts|scripts/(verify-package|check-package-size)\.mjs|\.github/workflows/ci\.yml)$'; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"

--- a/docs/development/PACKAGE-VERIFICATION.md
+++ b/docs/development/PACKAGE-VERIFICATION.md
@@ -1,11 +1,14 @@
 # Package artifact verification
 
 The SDK ships a tree-shakeable dual ESM + CJS build with ~30 subpath exports.
-Two mechanical guards keep the publish artifact honest so packaging regressions
+Three mechanical guards keep the publish artifact honest so packaging regressions
 fail CI instead of reaching consumers.
 
-**How they run in CI** (both live in `.github/workflows/ci.yml`):
+**How they run in CI** (all three live in `.github/workflows/ci.yml`):
 
+- `check:package-size` is a fast, offline `npm pack --dry-run` audit, so it runs
+  after every `library-build`. It caps packed bytes, unpacked bytes, file count,
+  and the generated declaration sizes, and requires the exact schema façade.
 - `check:package` is cheap and offline, so it runs on **every PR** as a step in
   the `library-build` job.
 - `verify:package` does a live registry install, so it runs in the
@@ -37,13 +40,23 @@ Runs [`publint --strict`](https://publint.dev) and
 
 Requires a prior `npm run build:lib` (it inspects `dist/`).
 
+## `npm run check:package-size` — publish-size budgets
+
+`scripts/check-package-size.mjs` asks npm for the exact dry-run pack manifest
+and fails closed if its size metadata is missing. It enforces budgets for
+compressed bytes, installed bytes, and entry count, plus separate limits for
+the canonical generated schema declaration and its ESM façade. Because it runs
+unconditionally after `build:lib`, growth from any packaged source, generated
+schema, or copied cache is covered even when the live package smoke is skipped.
+The full `verify:package` smoke imports and runs the same checker.
+
 ### Why the build emits `.d.mts`
 
 The package is `type: commonjs`, so a `.d.ts` is a CJS-format declaration. The
 `import` condition resolves to `.mjs` (real ESM), so it needs an ESM-format
 declaration or attw reports "masquerading as CJS". `scripts/generate-dmts-declarations.ts`
-runs at the end of `build:lib`: it copies each `.d.ts` to `.d.mts` and appends
-explicit `.mjs` / `/index.mjs` extensions to relative specifiers (ESM
+runs at the end of `build:lib`: it normally copies each `.d.ts` to `.d.mts` and
+appends explicit `.mjs` / `/index.mjs` extensions to relative specifiers (ESM
 declaration resolution requires them) — the declaration-layer companion to the
 runtime import-fixers in `tsup.config.ts`. Each subpath's `exports` entry then
 carries per-condition types:
@@ -62,15 +75,32 @@ wildcard cleanly. Because those slices are never reached through an `import`
 condition, the generator **skips** emitting `.d.mts` for them (keyed off
 `per-tool-index.json`), trimming ~5.5 MB of otherwise-unreachable declarations.
 
+The generated Zod schema declaration is the other exception. Its fully
+inferred type graph is tens of MiB, so duplicating it byte-for-byte would make
+the installed package tens of MiB larger. The ESM declaration is instead an
+exact façade:
+
+```ts
+export * from './schemas.generated.js';
+```
+
+TypeScript's declaration extension substitution resolves that `.js` specifier
+to the canonical `schemas.generated.d.ts`, preserving the complete `.shape`,
+`.pick`, `z.input`, and `z.output` surface without re-annotating or weakening
+the public types. The generator and package-size audit both fail closed if the
+façade contract becomes unsafe.
+
 ## `npm run verify:package` — clean-room dual-format smoke
 
 `scripts/verify-package.mjs` packs a tarball, installs it plus its **required**
 peers pinned to their **range floors** into a throwaway dir under `os.tmpdir()`
 (outside the workspace, so npm resolution is honest and not monorepo-deduped),
-then loads `@adcp/sdk`, `@adcp/sdk/enums`, and `@adcp/sdk/server` through both a
-real ESM `import` and a real CJS `require`, asserting each loads and exposes a
-known runtime symbol. `server` is included so the `@a2a-js/sdk` peer gets real
-ESM/CJS load coverage through a dedicated entrypoint. Optional peers
+then loads the main, enums, server, testing, and schemas entry points through
+both a real ESM `import` and a real CJS `require`, asserting each loads and
+exposes a known runtime symbol. It also type-checks the exact generated schema
+surface from `.mts` and `.cts` consumers. `server` is included so the
+`@a2a-js/sdk` peer gets real ESM/CJS load coverage through a dedicated
+entrypoint. Optional peers
 (`peerDependenciesMeta`) are **not** installed — no tested subpath loads them,
 so pinning them would add only install weight and registry-flake surface. It
 uses `npm install` in the temp dir (never workspace pnpm/catalog) and cleans up

--- a/package.json
+++ b/package.json
@@ -513,6 +513,7 @@
     "typecheck:skill-examples": "tsx scripts/typecheck-skill-examples.ts",
     "check:skill-sync": "tsx scripts/check-skill-sync.ts",
     "check:package": "publint --strict && node --max-old-space-size=8192 ./node_modules/@arethetypeswrong/cli/dist/index.js --pack .",
+    "check:package-size": "node scripts/check-package-size.mjs",
     "verify:package": "node scripts/verify-package.mjs",
     "check:adopter-types": "tsx scripts/check-adopter-types.ts",
     "check:adopter-types-narrow": "tsx scripts/check-adopter-types-narrow.ts",

--- a/scripts/check-package-size.mjs
+++ b/scripts/check-package-size.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+/**
+ * Fast, offline publish-size audit.
+ *
+ * Requires a prior `npm run build:lib`. Unlike the full clean-room package
+ * smoke, this runs on every library build so any packaged source or generated
+ * artifact can trip the budgets.
+ */
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const MAX_PACKED_TARBALL_BYTES = 45 * 1024 * 1024;
+const MAX_UNPACKED_PACKAGE_BYTES = 305 * 1024 * 1024;
+const MAX_PACKED_FILE_COUNT = 7_400;
+const MAX_CJS_SCHEMA_DECLARATION_BYTES = 45 * 1024 * 1024;
+const MAX_ESM_SCHEMA_FACADE_BYTES = 1024;
+const EXPECTED_ESM_SCHEMA_FACADE = "export * from './schemas.generated.js';\n";
+
+function mib(bytes) {
+  return (bytes / 1024 / 1024).toFixed(1);
+}
+
+function assertAtMost(label, actual, limit, unit = 'bytes') {
+  if (!Number.isFinite(actual)) {
+    throw new Error(`${label} is missing or is not a finite number`);
+  }
+  if (actual > limit) {
+    throw new Error(`${label} is ${actual} ${unit}; budget is ${limit} ${unit}`);
+  }
+}
+
+export function checkPackageSize(repoRoot) {
+  const output = execFileSync('npm', ['pack', '--dry-run', '--json', '--ignore-scripts', '--loglevel=error'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'inherit'],
+  });
+  let packageInfo;
+  try {
+    [packageInfo] = JSON.parse(output);
+  } catch (error) {
+    throw new Error(`npm pack did not return valid JSON: ${error.message}`);
+  }
+  if (!packageInfo || !Array.isArray(packageInfo.files)) {
+    throw new Error('npm pack did not return package file metadata');
+  }
+  for (const field of ['size', 'unpackedSize', 'entryCount']) {
+    if (!Number.isFinite(packageInfo[field])) {
+      throw new Error(`npm pack returned an invalid ${field}`);
+    }
+  }
+
+  if (packageInfo.size > MAX_PACKED_TARBALL_BYTES) {
+    throw new Error(`packed tarball is ${mib(packageInfo.size)} MiB; budget is ${mib(MAX_PACKED_TARBALL_BYTES)} MiB`);
+  }
+  if (packageInfo.unpackedSize > MAX_UNPACKED_PACKAGE_BYTES) {
+    throw new Error(
+      `unpacked package is ${mib(packageInfo.unpackedSize)} MiB; budget is ${mib(MAX_UNPACKED_PACKAGE_BYTES)} MiB`
+    );
+  }
+  assertAtMost('packed file count', packageInfo.entryCount, MAX_PACKED_FILE_COUNT, 'files');
+
+  const cjsSchema = packageInfo.files.find(file => file.path === 'dist/lib/types/schemas.generated.d.ts');
+  const esmSchema = packageInfo.files.find(file => file.path === 'dist/lib/types/schemas.generated.d.mts');
+  if (!cjsSchema) throw new Error('packed package is missing schemas.generated.d.ts');
+  if (!esmSchema) throw new Error('packed package is missing schemas.generated.d.mts');
+  if (!Number.isFinite(cjsSchema.size)) {
+    throw new Error('npm pack returned an invalid size for schemas.generated.d.ts');
+  }
+  if (cjsSchema.size > MAX_CJS_SCHEMA_DECLARATION_BYTES) {
+    throw new Error(
+      `schemas.generated.d.ts is ${mib(cjsSchema.size)} MiB; ` +
+        `budget is ${mib(MAX_CJS_SCHEMA_DECLARATION_BYTES)} MiB`
+    );
+  }
+  assertAtMost('schemas.generated.d.mts', esmSchema.size, MAX_ESM_SCHEMA_FACADE_BYTES);
+
+  const facadePath = path.join(repoRoot, 'dist', 'lib', 'types', 'schemas.generated.d.mts');
+  if (readFileSync(facadePath, 'utf8') !== EXPECTED_ESM_SCHEMA_FACADE) {
+    throw new Error('schemas.generated.d.mts is not the expected exact ESM facade');
+  }
+
+  console.log(
+    `✅ Package size: ${mib(packageInfo.size)} MiB packed, ${mib(packageInfo.unpackedSize)} MiB unpacked, ` +
+      `${packageInfo.entryCount} files; schema declarations ${mib(cjsSchema.size)} MiB CJS + ${esmSchema.size} B ESM`
+  );
+  return packageInfo;
+}
+
+const scriptPath = process.argv[1] ? path.resolve(process.argv[1]) : undefined;
+if (scriptPath === fileURLToPath(import.meta.url)) {
+  const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+  try {
+    checkPackageSize(repoRoot);
+  } catch (error) {
+    console.error(`❌ Package size check failed: ${error.message ?? error}`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/check-package-size.mjs
+++ b/scripts/check-package-size.mjs
@@ -31,18 +31,28 @@ function assertAtMost(label, actual, limit, unit = 'bytes') {
   }
 }
 
+export function parseNpmPackOutput(output) {
+  // npm 10 can print prepare-hook output (including ANSI color sequences)
+  // before --json output even with --ignore-scripts. Try each array opener in
+  // order and accept only a complete top-level JSON array.
+  for (let start = output.indexOf('['); start !== -1; start = output.indexOf('[', start + 1)) {
+    try {
+      const parsed = JSON.parse(output.slice(start).trim());
+      if (Array.isArray(parsed)) return parsed;
+    } catch {
+      // Keep scanning past banners such as ESC[32m or non-JSON hook output.
+    }
+  }
+  throw new Error('npm pack did not return a valid JSON array');
+}
+
 export function checkPackageSize(repoRoot) {
   const output = execFileSync('npm', ['pack', '--dry-run', '--json', '--ignore-scripts', '--loglevel=error'], {
     cwd: repoRoot,
     encoding: 'utf8',
     stdio: ['ignore', 'pipe', 'inherit'],
   });
-  let packageInfo;
-  try {
-    [packageInfo] = JSON.parse(output);
-  } catch (error) {
-    throw new Error(`npm pack did not return valid JSON: ${error.message}`);
-  }
+  const [packageInfo] = parseNpmPackOutput(output);
   if (!packageInfo || !Array.isArray(packageInfo.files)) {
     throw new Error('npm pack did not return package file metadata');
   }

--- a/scripts/generate-dmts-declarations.ts
+++ b/scripts/generate-dmts-declarations.ts
@@ -19,10 +19,13 @@
  *
  * ESM declaration resolution requires explicit relative specifiers, so this is
  * the declaration-layer companion to the runtime import-fixers in
- * `tsup.config.ts`: it copies each `.d.ts` to `.d.mts` and appends the module
- * extension to every relative `from`/`import(...)` specifier — `.mjs` for a
- * file, `/index.mjs` for a directory — resolving each against the built dist
- * tree (the bytes that actually ship).
+ * `tsup.config.ts`: it normally copies each `.d.ts` to `.d.mts` and appends the
+ * module extension to every relative `from`/`import(...)` specifier — `.mjs`
+ * for a file, `/index.mjs` for a directory — resolving each against the built
+ * dist tree (the bytes that actually ship). The generated Zod declaration is
+ * the exception: its exact inferred type graph is tens of MiB, so its ESM file
+ * is a facade over the canonical CJS declaration instead of a byte-for-byte
+ * duplicate.
  */
 import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import * as path from 'node:path';
@@ -90,9 +93,29 @@ function main(): void {
 
   const skip = wildcardOnlySlices();
   const declarations = collectDeclarationFiles(DIST_LIB).filter(f => !skip.has(f));
+  const generatedSchemasDeclaration = path.join(DIST_LIB, 'types', 'schemas.generated.d.ts');
   let written = 0;
   for (const file of declarations) {
     const source = readFileSync(file, 'utf8');
+    if (file === generatedSchemasDeclaration) {
+      // This declaration is tens of MiB because TypeScript expands the full
+      // inferred Zod shapes. Keep the exact CJS declaration as the source of
+      // truth and expose it through a tiny ESM declaration facade instead of
+      // copying the same type graph byte-for-byte.
+      const hasDefaultExport =
+        /^\s*export\s+default\b/m.test(source) ||
+        /^\s*export\s*=\s*/m.test(source) ||
+        /\bexport\s*\{[^}]*\bdefault\b[^}]*\}/m.test(source);
+      if (hasDefaultExport) {
+        throw new Error('schemas.generated.d.ts has an export that the ESM facade would omit');
+      }
+      if (!existsSync(file.replace(/\.d\.ts$/, '.js'))) {
+        throw new Error('schemas.generated.js is missing; build runtime files before declarations');
+      }
+      writeFileSync(file.replace(/\.d\.ts$/, '.d.mts'), `export * from './schemas.generated.js';\n`);
+      written++;
+      continue;
+    }
     // The declaration map points at the `.d.ts`; drop the reference rather than
     // ship a `.d.mts` whose sourceMappingURL resolves to the wrong file.
     const withoutMap = source.replace(/\n?\/\/# sourceMappingURL=.*\.d\.ts\.map\s*$/, '\n');

--- a/scripts/verify-package.mjs
+++ b/scripts/verify-package.mjs
@@ -6,10 +6,10 @@
  * script proves the packed tarball actually loads. It packs the package,
  * installs the tarball plus its required peerDependencies pinned to their
  * range floors into a throwaway directory in the OS temp dir, then loads
- * `@adcp/sdk`, `@adcp/sdk/enums`, and `@adcp/sdk/server` through both a real
- * ESM `import` and a real CJS `require`, asserting each exposes a known runtime
- * symbol. It also runs a modern MCP negotiation under Bun, whose ESM/CJS
- * interoperability differs from Node's.
+ * package entry points through both a real ESM `import` and a real CJS
+ * `require`, asserting each exposes a known runtime symbol. It also compiles
+ * the exact schema surface through both declaration formats and runs a modern
+ * MCP negotiation under Bun, whose ESM/CJS interoperability differs from Node's.
  *
  * Why a temp dir outside the repo: installing inside the workspace would let
  * the monorepo dedupe peers against the repo's own node_modules, so a missing
@@ -26,9 +26,9 @@ import { mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { checkPackageSize } from './check-package-size.mjs';
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-const MAX_PACKED_TARBALL_BYTES = 50 * 1024 * 1024;
 
 /** Lowest version a semver range accepts (first `||` clause, operators stripped). */
 function rangeFloor(range) {
@@ -68,6 +68,9 @@ try {
     JSON.stringify({ name: 'adcp-verify-consumer', version: '1.0.0', private: true }, null, 2)
   );
 
+  console.log('📏 Auditing publish size...');
+  checkPackageSize(REPO_ROOT);
+
   // Pack into the temp dir and locate the .tgz on disk. We deliberately do NOT
   // parse `npm pack --json` stdout: npm runs the `prepare` lifecycle during
   // pack and its banner pollutes stdout (even with --ignore-scripts on some npm
@@ -81,14 +84,8 @@ try {
   if (!tgz) throw new Error(`npm pack produced no .tgz in ${tmpDir}`);
   const tarballPath = path.join(tmpDir, tgz);
   const tarballBytes = statSync(tarballPath).size;
-  if (tarballBytes > MAX_PACKED_TARBALL_BYTES) {
-    throw new Error(
-      `packed tarball is ${(tarballBytes / 1024 / 1024).toFixed(1)} MiB; ` +
-        `budget is ${MAX_PACKED_TARBALL_BYTES / 1024 / 1024} MiB`
-    );
-  }
   console.log(`   → ${tgz}`);
-  console.log(`   ${(tarballBytes / 1024 / 1024).toFixed(1)} MiB (50 MiB budget)`);
+  console.log(`   ${(tarballBytes / 1024 / 1024).toFixed(1)} MiB`);
 
   const packedPaths = new Set(run('tar', ['-tf', tarballPath]).trim().split('\n'));
   const requiredGuides = [
@@ -123,6 +120,7 @@ try {
     { specifier: '@adcp/sdk/enums', symbol: 'EventTypeValues' },
     { specifier: '@adcp/sdk/server', symbol: 'A2AInvocationError' },
     { specifier: '@adcp/sdk/testing', symbol: 'mergeSeedProductLegacy' },
+    { specifier: '@adcp/sdk/schemas', symbol: 'CreativeAssetSchema' },
   ];
 
   // Shared by both generated smoke modules. A function declaration (not an
@@ -161,6 +159,50 @@ try {
   run('node', ['smoke.mjs'], { cwd: tmpDir, stdio: 'inherit' });
   console.log('🔍 CJS require:');
   run('node', ['smoke.cjs'], { cwd: tmpDir, stdio: 'inherit' });
+
+  const schemaTypeSmoke = [
+    "import { CreativeAssetSchema } from '@adcp/sdk/schemas';",
+    "import type { z } from 'zod';",
+    '',
+    'type IsAny<T> = 0 extends 1 & T ? true : false;',
+    'type Input = z.input<typeof CreativeAssetSchema>;',
+    'type Output = z.output<typeof CreativeAssetSchema>;',
+    'const schemaIsNotAny: IsAny<typeof CreativeAssetSchema> = false;',
+    'const shapeIsNotAny: IsAny<typeof CreativeAssetSchema.shape> = false;',
+    'const inputIsNotAny: IsAny<Input> = false;',
+    'const outputIsNotAny: IsAny<Output> = false;',
+    'const creativeId = CreativeAssetSchema.shape.creative_id;',
+    'const idOnly = CreativeAssetSchema.pick({ creative_id: true });',
+    'const parse = (input: Input): Output => CreativeAssetSchema.parse(input);',
+    'void [schemaIsNotAny, shapeIsNotAny, inputIsNotAny, outputIsNotAny, creativeId, idOnly, parse];',
+    '',
+  ].join('\n');
+  writeFileSync(path.join(tmpDir, 'smoke-types.mts'), schemaTypeSmoke);
+  writeFileSync(path.join(tmpDir, 'smoke-types.cts'), schemaTypeSmoke);
+  console.log('🔬 TypeScript Node16 declarations (ESM + CJS):');
+  // The generated declaration is 43 MiB and full dependency re-checking
+  // exceeds an 8 GiB heap. build:lib already checks its source graph; this
+  // consumer check resolves the packed bridge and instantiates its public
+  // schema types while skipping diagnostics internal to dependency .d.ts files.
+  const typecheckArgs = [
+    '--max-old-space-size=8192',
+    path.join(REPO_ROOT, 'node_modules', 'typescript', 'bin', 'tsc'),
+    '--noEmit',
+    '--strict',
+    '--skipLibCheck',
+    '--target',
+    'ES2022',
+    '--module',
+    'Node16',
+    '--moduleResolution',
+    'Node16',
+  ];
+  // Compile each format in its own process. Loading both copies of this exact
+  // 43 MiB inferred type graph at once can exceed an 8 GiB heap.
+  for (const fixture of ['smoke-types.mts', 'smoke-types.cts']) {
+    run(process.execPath, [...typecheckArgs, fixture], { cwd: tmpDir, stdio: 'inherit' });
+  }
+  console.log('  exact schema types resolve through both declaration formats');
 
   // Bun selects a different conditional-export path for dual ESM/CJS
   // dependencies than Node. Exercise the packed artifact through a real MCP

--- a/test/check-package-size.test.js
+++ b/test/check-package-size.test.js
@@ -1,0 +1,22 @@
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+const { test } = require('node:test');
+
+const modulePromise = import(pathToFileURL(path.resolve(__dirname, '..', 'scripts', 'check-package-size.mjs')).href);
+
+test('parses clean npm pack JSON output', async () => {
+  const { parseNpmPackOutput } = await modulePromise;
+  assert.deepEqual(parseNpmPackOutput('[{"size": 42}]\n'), [{ size: 42 }]);
+});
+
+test('ignores ANSI-colored prepare output before npm pack JSON', async () => {
+  const { parseNpmPackOutput } = await modulePromise;
+  const output = '\x1b[32m✅ Git hooks are already configured\x1b[0m\n[prepare] done\n[{"size": 42}]\n';
+  assert.deepEqual(parseNpmPackOutput(output), [{ size: 42 }]);
+});
+
+test('fails closed when npm pack returns no JSON array', async () => {
+  const { parseNpmPackOutput } = await modulePromise;
+  assert.throws(() => parseNpmPackOutput('\x1b[31mpack failed\x1b[0m\n'), /valid JSON array/);
+});

--- a/test/generate-dmts-declarations.test.js
+++ b/test/generate-dmts-declarations.test.js
@@ -1,0 +1,69 @@
+const assert = require('node:assert/strict');
+const { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } = require('node:fs');
+const { tmpdir } = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const { test } = require('node:test');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const SCRIPT = path.join(REPO_ROOT, 'scripts', 'generate-dmts-declarations.ts');
+const TSX = path.join(REPO_ROOT, 'node_modules', '.bin', 'tsx');
+
+function createFixture(schemaDeclaration) {
+  const root = mkdtempSync(path.join(tmpdir(), 'generate-dmts-'));
+  const typesDir = path.join(root, 'dist', 'lib', 'types');
+  const featureDir = path.join(root, 'dist', 'lib', 'feature');
+  mkdirSync(typesDir, { recursive: true });
+  mkdirSync(featureDir, { recursive: true });
+
+  writeFileSync(path.join(typesDir, 'schemas.generated.d.ts'), schemaDeclaration);
+  writeFileSync(path.join(typesDir, 'schemas.generated.js'), 'exports.ExampleSchema = {};\n');
+  writeFileSync(path.join(typesDir, 'dependency.d.ts'), 'export declare const dependency: string;\n');
+  writeFileSync(path.join(typesDir, 'dependency.js'), 'exports.dependency = "ok";\n');
+  writeFileSync(
+    path.join(featureDir, 'index.d.ts'),
+    "export { dependency } from '../types/dependency';\n//# sourceMappingURL=index.d.ts.map\n"
+  );
+
+  return root;
+}
+
+function runGenerator(cwd) {
+  return spawnSync(TSX, [SCRIPT], { cwd, encoding: 'utf8' });
+}
+
+test('uses an exact ESM facade for the generated schema declaration', () => {
+  const root = createFixture('export declare const ExampleSchema: { readonly exact: true };\n');
+  try {
+    const result = runGenerator(root);
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(
+      readFileSync(path.join(root, 'dist', 'lib', 'types', 'schemas.generated.d.mts'), 'utf8'),
+      "export * from './schemas.generated.js';\n"
+    );
+    assert.equal(
+      readFileSync(path.join(root, 'dist', 'lib', 'feature', 'index.d.mts'), 'utf8'),
+      "export { dependency } from '../types/dependency.mjs';\n"
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('rejects schema exports that export-star would omit', () => {
+  for (const declaration of [
+    'export default function schema() {}\n',
+    'declare const schema: unknown;\nexport { schema as default };\n',
+    "export { default } from './dependency';\n",
+    'declare const schema: unknown;\nexport = schema;\n',
+  ]) {
+    const root = createFixture(declaration);
+    try {
+      const result = runGenerator(root);
+      assert.notEqual(result.status, 0);
+      assert.match(result.stderr, /export that the ESM facade would omit/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }
+});


### PR DESCRIPTION
## Summary

- replace the duplicated 43.7 MB ESM generated-schema declaration with a 40-byte façade over the exact CJS declaration
- add regression coverage for façade generation and incompatible exports
- enforce packed, unpacked, file-count, and declaration-size budgets on every library build
- extend clean-room package verification across schema runtime and TypeScript ESM/CJS consumers

## Impact

The beta package reported in #2579 was 49.8 MB packed and 411.8 MB unpacked. The rebuilt beta.2 artifact is 42.5 MB packed and 309.5 MB unpacked (40.5 MiB / 295.1 MiB), while preserving the exact inferred Zod type surface.

## Validation

- `npm run ci:quick`
- `npm run check:package-size`
- `npm run check:package`
- `npm run verify:package`
- code and package-DX expert reviews

Closes #2579
