### PR TITLE
feat(creative): add validated reference preview utilities

### DIFF
--- a/.changeset/clear-previews-resolve.md
+++ b/.changeset/clear-previews-resolve.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': minor
+---
+
+Preserve preview-renderer provenance while normalizing preview responses, and add a pure helper for resolving seller, publisher-placement, community-reference, and manifest preview authority without fetching or executing renderer code.

--- a/.changeset/gentle-carousels-render.md
+++ b/.changeset/gentle-carousels-render.md
@@ -1,0 +1,5 @@
+---
+'@adcp/reference-renderers': minor
+---
+
+Add canonical image-carousel rendering, structured image and carousel validation results, declared preview-macro substitution, explicit network plans, and a capability-minimal iframe mounting helper.

--- a/packages/reference-renderers/README.md
+++ b/packages/reference-renderers/README.md
@@ -17,6 +17,49 @@ const html = renderImage({
 
 The named exports `renderImage`, `renderNativeInFeed`, and `renderVast` return complete HTML documents. They are non-authoritative reference presentations: they demonstrate the canonical asset contract but do not reproduce publisher chrome or a serving platform's output.
 
-The renderers do not fetch resources while rendering, use ambient credentials, fire trackers, resolve remote VAST tags or wrappers, expand macros, or execute creative-provided code. Returned documents may reference HTTPS creative media and landing pages declared by the manifest. Consumers should still run the package and returned presentation in an isolated, credential-free sandbox.
+`renderImageCarousel` adds the canonical `image_carousel` family. For clients
+that must fail closed instead of receiving a placeholder, the structured APIs
+validate raw manifests and format declarations before producing HTML:
+
+```js
+import { mountReferencePreview, renderImageCarouselResult } from '@adcp/reference-renderers';
+
+const result = renderImageCarouselResult({
+  manifest,
+  declaration: {
+    format_kind: 'image_carousel',
+    supported_macros: ['CLICK_ID'],
+    params: {
+      min_cards: 2,
+      max_cards: 6,
+      card_aspect_ratio: '1:1',
+      allowed_card_media_asset_types: ['image'],
+    },
+  },
+  macros: { CLICK_ID: 'preview-click' },
+});
+
+if (result.ok) {
+  const mounted = mountReferencePreview(container, result.html);
+  // mounted.destroy() when the host unmounts
+} else {
+  console.error(result.issues);
+}
+```
+
+`prepareImageReference` and `prepareImageCarouselReference` return the validated
+presentation and its explicit network plan without generating HTML.
+
+The renderers do not fetch resources while rendering, use ambient credentials,
+fire trackers, resolve remote VAST tags or wrappers, or execute
+creative-provided code. Structured rendering expands only macros declared by
+the format and supplied explicitly for that preview; undeclared or unresolved
+macros fail closed. Returned documents may reference only HTTPS creative media
+and landing pages declared by the manifest.
+
+Consumers should still run the package and returned presentation in an
+isolated, credential-free sandbox. `mountReferencePreview` creates an iframe
+with an empty `sandbox` capability set and `referrerpolicy="no-referrer"`; it
+never injects the returned HTML into the host document.
 
 `renderVast` only extracts an HTTPS `<MediaFile>` from inline VAST XML. For a remote VAST URL it returns a placeholder; use an authorized `preview_creative` provider for platform behavior.

--- a/packages/reference-renderers/index.d.ts
+++ b/packages/reference-renderers/index.d.ts
@@ -2,6 +2,17 @@ export interface AssetValue {
   asset_type?: string;
   url?: string;
   content?: string;
+  width?: number;
+  height?: number;
+  pixel_ratio?: number;
+  duration_ms?: number;
+  alt_text?: string;
+  url_type?: string;
+  media?: AssetValue;
+  headline?: string;
+  description?: string;
+  cta?: string;
+  landing_page_url?: AssetValue;
   [key: string]: unknown;
 }
 
@@ -28,6 +39,113 @@ export interface RenderDimensions {
   height: number;
 }
 
+export interface ProductFormatDeclaration {
+  format_kind: string;
+  params: Record<string, unknown>;
+  supported_macros?: string[];
+  [key: string]: unknown;
+}
+
+export type ReferenceRendererIssueCode =
+  | 'INVALID_INPUT'
+  | 'INVALID_MANIFEST'
+  | 'INVALID_FORMAT_DECLARATION'
+  | 'FORMAT_MISMATCH'
+  | 'MISSING_ASSET'
+  | 'INVALID_ASSET'
+  | 'CONSTRAINT_VIOLATION'
+  | 'UNSUPPORTED_MACRO'
+  | 'MISSING_MACRO_VALUE';
+
+export interface ReferenceRendererIssue {
+  code: ReferenceRendererIssueCode;
+  path: string;
+  message: string;
+}
+
+export interface ReferenceRendererInput {
+  manifest: CreativeManifest;
+  declaration?: ProductFormatDeclaration;
+  supportedMacros?: readonly string[];
+  supported_macros?: readonly string[];
+  macros?: Readonly<Record<string, string>>;
+}
+
+export interface ReferenceNetworkPlan {
+  eager_assets: readonly string[];
+  user_navigations: readonly string[];
+}
+
+export interface PreparedMedia {
+  type: 'image' | 'video';
+  url: string;
+  source_url: string;
+  width: number;
+  height: number;
+  alt_text?: string;
+}
+
+export interface PreparedImagePresentation {
+  format_kind: 'image';
+  image: PreparedMedia & { type: 'image' };
+  headline?: string;
+  body_text?: string;
+  primary_text?: string;
+  cta?: string;
+  landing_page_url?: string;
+  network: ReferenceNetworkPlan;
+}
+
+export interface PreparedCarouselCard {
+  media: PreparedMedia;
+  headline?: string;
+  description?: string;
+  cta?: string;
+  landing_page_url?: string;
+}
+
+export interface PreparedImageCarouselPresentation {
+  format_kind: 'image_carousel';
+  cards: readonly PreparedCarouselCard[];
+  primary_text?: string;
+  landing_page_url?: string;
+  network: ReferenceNetworkPlan;
+}
+
+export type PrepareReferenceResult<T> =
+  | { ok: true; presentation: T }
+  | { ok: false; issues: readonly ReferenceRendererIssue[] };
+
+export type RenderReferenceResult<T> =
+  | { ok: true; presentation: T; html: string }
+  | { ok: false; issues: readonly ReferenceRendererIssue[] };
+
+export const REFERENCE_PRESENTATION_LABEL: 'Community reference presentation — non-authoritative';
+
 export function renderImage(manifest: CreativeManifest, dimensions?: RenderDimensions): string;
 export function renderNativeInFeed(manifest: CreativeManifest, dimensions?: RenderDimensions): string;
 export function renderVast(manifest: CreativeManifest, dimensions?: RenderDimensions, label?: string): string;
+export function prepareImageReference(input: ReferenceRendererInput): PrepareReferenceResult<PreparedImagePresentation>;
+export function renderImageResult(
+  input: ReferenceRendererInput,
+  dimensions?: RenderDimensions
+): RenderReferenceResult<PreparedImagePresentation>;
+export function prepareImageCarouselReference(
+  input: ReferenceRendererInput
+): PrepareReferenceResult<PreparedImageCarouselPresentation>;
+export function renderImageCarousel(manifest: CreativeManifest, dimensions?: RenderDimensions): string;
+export function renderImageCarouselResult(
+  input: ReferenceRendererInput,
+  dimensions?: RenderDimensions
+): RenderReferenceResult<PreparedImageCarouselPresentation>;
+
+export interface MountedReferencePreview {
+  iframe: HTMLIFrameElement;
+  destroy(): void;
+}
+
+export function mountReferencePreview(
+  container: HTMLElement,
+  html: string,
+  options?: { title?: string; loading?: 'eager' | 'lazy' }
+): MountedReferencePreview;

--- a/packages/reference-renderers/index.js
+++ b/packages/reference-renderers/index.js
@@ -4,7 +4,12 @@
  * resolve VAST wrappers, or execute creative-provided code.
  */
 
+import { prepareImageCarouselReference, prepareImageReference } from './structured.js';
+
+export { prepareImageCarouselReference, prepareImageReference } from './structured.js';
+
 const DEFAULT_DIMENSIONS = Object.freeze({ width: 300, height: 250 });
+export const REFERENCE_PRESENTATION_LABEL = 'Community reference presentation — non-authoritative';
 
 function assetValue(assets, ...keys) {
   for (const key of keys) {
@@ -61,8 +66,12 @@ function page(body, dimensions, title, responsive = false) {
   return `<!DOCTYPE html>
 <html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta name="referrer" content="no-referrer"><meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src https:; media-src https:; style-src 'unsafe-inline'; base-uri 'none'; form-action 'none'">
 <title>${escapeHtml(title)}</title><style>
-*{box-sizing:border-box}html,body{margin:0}body{min-height:100vh;display:flex;align-items:center;justify-content:center;background:#f5f5f5;font-family:system-ui,-apple-system,sans-serif}.adcp-preview{${frameSize};overflow:hidden;position:relative;background:#fff;border:1px solid #ddd}.adcp-preview img,.adcp-preview video{display:block;width:100%;height:100%;object-fit:cover}.adcp-preview video{object-fit:contain;background:#000}.adcp-placeholder{display:flex;flex-direction:column;align-items:center;justify-content:center;width:100%;height:100%;padding:16px;color:#fff;text-align:center;background:linear-gradient(135deg,#0f766e,#115e59)}.adcp-placeholder strong{font-size:14px}.adcp-placeholder span{margin-top:4px;font-size:11px;opacity:.85}.adcp-native{display:flex;flex-direction:column;gap:8px;height:100%;padding:16px}.adcp-native img{height:60%;border-radius:4px}.adcp-native__sponsor{font-size:11px;color:#666;text-transform:uppercase;letter-spacing:.04em}.adcp-native__title{font-size:16px;font-weight:650;color:#171717}.adcp-native__body{font-size:13px;line-height:1.4;color:#525252}.adcp-native__cta{font-size:13px;font-weight:650;color:#0f766e}
+*{box-sizing:border-box}html,body{margin:0}body{min-height:100vh;display:flex;flex-direction:column;align-items:center;justify-content:center;background:#f5f5f5;font-family:system-ui,-apple-system,sans-serif}.adcp-label{width:min(100%,600px);padding:5px 8px;background:#e5e7eb;color:#374151;font-size:10px;font-weight:650;letter-spacing:.02em}.adcp-preview{${frameSize};overflow:hidden;position:relative;background:#fff;border:1px solid #ddd}.adcp-preview img,.adcp-preview video{display:block;width:100%;height:100%;object-fit:cover}.adcp-preview video{object-fit:contain;background:#000}.adcp-placeholder{display:flex;flex-direction:column;align-items:center;justify-content:center;width:100%;height:100%;padding:16px;color:#fff;text-align:center;background:linear-gradient(135deg,#0f766e,#115e59)}.adcp-placeholder strong{font-size:14px}.adcp-placeholder span{margin-top:4px;font-size:11px;opacity:.85}.adcp-native{display:flex;flex-direction:column;gap:8px;height:100%;padding:16px}.adcp-native img{height:60%;border-radius:4px}.adcp-native__sponsor{font-size:11px;color:#666;text-transform:uppercase;letter-spacing:.04em}.adcp-native__title{font-size:16px;font-weight:650;color:#171717}.adcp-native__body{font-size:13px;line-height:1.4;color:#525252}.adcp-native__cta{font-size:13px;font-weight:650;color:#0f766e}.adcp-carousel{display:grid;grid-auto-flow:column;grid-auto-columns:minmax(180px,80%);gap:10px;width:min(100%,600px);padding:10px;overflow-x:auto;background:#fff;border:1px solid #ddd}.adcp-card{overflow:hidden;border:1px solid #ddd;border-radius:6px;background:#fff;scroll-snap-align:start}.adcp-card img,.adcp-card video{display:block;width:100%;aspect-ratio:1/1;object-fit:cover}.adcp-card__copy{display:grid;gap:5px;padding:9px}.adcp-card__headline{font-size:14px;font-weight:650;color:#171717}.adcp-card__description,.adcp-carousel__primary{font-size:12px;line-height:1.4;color:#525252}.adcp-card__cta{font-size:12px;font-weight:650;color:#0f766e}
 </style></head><body>${body}</body></html>`;
+}
+
+function labeled(body) {
+  return `<div class="adcp-label">${escapeHtml(REFERENCE_PRESENTATION_LABEL)}</div>${body}`;
 }
 
 function placeholder(dimensions, label, detail) {
@@ -90,7 +99,104 @@ export function renderImage(manifest, requestedDimensions) {
     body = placeholder(dimensions, 'Image creative');
   }
 
-  return page(body, dimensions, manifest?.name || 'Image preview');
+  return page(labeled(body), dimensions, manifest?.name || 'Image preview');
+}
+
+function imageBody(presentation) {
+  const image = `<img src="${escapeHtml(presentation.image.url)}" alt="${escapeHtml(
+    presentation.image.alt_text ?? ''
+  )}" referrerpolicy="no-referrer">`;
+  const media = presentation.landing_page_url
+    ? `<a href="${escapeHtml(presentation.landing_page_url)}" target="_blank" rel="noopener noreferrer">${image}</a>`
+    : image;
+  const copy = [
+    presentation.headline ? `<div class="adcp-card__headline">${escapeHtml(presentation.headline)}</div>` : '',
+    presentation.primary_text
+      ? `<div class="adcp-card__description">${escapeHtml(presentation.primary_text)}</div>`
+      : '',
+    presentation.body_text ? `<div class="adcp-card__description">${escapeHtml(presentation.body_text)}</div>` : '',
+    presentation.cta ? `<div class="adcp-card__cta">${escapeHtml(presentation.cta)}</div>` : '',
+  ].join('');
+  return `<div class="adcp-preview">${media}${copy ? `<div class="adcp-card__copy">${copy}</div>` : ''}</div>`;
+}
+
+/**
+ * Validate and render an image manifest, returning structured issues instead of
+ * silently inventing a presentation when the canonical contract is not met.
+ */
+export function renderImageResult(input, requestedDimensions) {
+  const prepared = prepareImageReference(input);
+  if (!prepared.ok) return prepared;
+  const dimensions = dimensionsFor(input.manifest, requestedDimensions);
+  return {
+    ...prepared,
+    html: page(labeled(imageBody(prepared.presentation)), dimensions, input.manifest?.name || 'Image preview'),
+  };
+}
+
+function carouselMedia(media) {
+  if (media.type === 'video') {
+    return `<video controls playsinline preload="metadata" controlslist="nodownload noremoteplayback" disablepictureinpicture><source src="${escapeHtml(
+      media.url
+    )}"></video>`;
+  }
+  return `<img src="${escapeHtml(media.url)}" alt="${escapeHtml(media.alt_text ?? '')}" referrerpolicy="no-referrer">`;
+}
+
+function carouselBody(presentation) {
+  const primary = presentation.primary_text
+    ? `<div class="adcp-carousel__primary">${escapeHtml(presentation.primary_text)}</div>`
+    : '';
+  const cards = presentation.cards
+    .map(card => {
+      const media = carouselMedia(card.media);
+      const linkedMedia = card.landing_page_url
+        ? `<a href="${escapeHtml(card.landing_page_url)}" target="_blank" rel="noopener noreferrer">${media}</a>`
+        : media;
+      const copy = [
+        card.headline ? `<div class="adcp-card__headline">${escapeHtml(card.headline)}</div>` : '',
+        card.description ? `<div class="adcp-card__description">${escapeHtml(card.description)}</div>` : '',
+        card.cta ? `<div class="adcp-card__cta">${escapeHtml(card.cta)}</div>` : '',
+      ].join('');
+      return `<article class="adcp-card">${linkedMedia}${
+        copy ? `<div class="adcp-card__copy">${copy}</div>` : ''
+      }</article>`;
+    })
+    .join('');
+  return `${primary}<div class="adcp-carousel">${cards}</div>`;
+}
+
+/** Validate and render a canonical image_carousel manifest. */
+export function renderImageCarouselResult(input, requestedDimensions) {
+  const prepared = prepareImageCarouselReference(input);
+  if (!prepared.ok) return prepared;
+  const dimensions = dimensionsFor(input.manifest, requestedDimensions);
+  return {
+    ...prepared,
+    html: page(
+      labeled(carouselBody(prepared.presentation)),
+      dimensions,
+      input.manifest?.name || 'Image carousel preview',
+      true
+    ),
+  };
+}
+
+/**
+ * Compatibility HTML export matching renderImage. Invalid manifests produce an
+ * inert placeholder; use renderImageCarouselResult when failures must be
+ * surfaced to a caller.
+ */
+export function renderImageCarousel(manifest, requestedDimensions) {
+  const result = renderImageCarouselResult({ manifest }, requestedDimensions);
+  if (result.ok) return result.html;
+  const dimensions = dimensionsFor(manifest, requestedDimensions);
+  return page(
+    labeled(placeholder(dimensions, 'Image carousel creative', 'Manifest cannot be rendered safely')),
+    dimensions,
+    manifest?.name || 'Image carousel preview',
+    true
+  );
 }
 
 function extractInlineVastMediaUrl(xml) {
@@ -132,7 +238,7 @@ export function renderVast(manifest, requestedDimensions, label = 'VAST video ad
             : 'No VAST media asset'
       );
 
-  return page(body, dimensions, manifest?.name || label);
+  return page(labeled(body), dimensions, manifest?.name || label);
 }
 
 /** Render an AdCP `native_in_feed` manifest as a complete inert HTML document. */
@@ -161,5 +267,38 @@ ${
 }
 </article></div>`;
 
-  return page(body, dimensions, manifest?.name || 'Native preview', true);
+  return page(labeled(body), dimensions, manifest?.name || 'Native preview', true);
+}
+
+/**
+ * Mount a complete renderer document into a capability-minimal iframe. The
+ * caller supplies the container; this helper does not consult ambient DOM,
+ * credentials, storage, or network APIs.
+ */
+export function mountReferencePreview(container, html, options = {}) {
+  if (
+    !container ||
+    typeof container.append !== 'function' ||
+    !container.ownerDocument ||
+    typeof container.ownerDocument.createElement !== 'function'
+  ) {
+    throw new TypeError('container must be a DOM element with an ownerDocument');
+  }
+  if (typeof html !== 'string' || !html.startsWith('<!DOCTYPE html>')) {
+    throw new TypeError('html must be a complete reference-renderer document');
+  }
+  const iframe = container.ownerDocument.createElement('iframe');
+  iframe.setAttribute('sandbox', '');
+  iframe.setAttribute('referrerpolicy', 'no-referrer');
+  iframe.setAttribute('title', options.title ?? REFERENCE_PRESENTATION_LABEL);
+  iframe.setAttribute('loading', options.loading ?? 'lazy');
+  iframe.srcdoc = html;
+  if (typeof container.replaceChildren === 'function') container.replaceChildren(iframe);
+  else container.append(iframe);
+  return {
+    iframe,
+    destroy() {
+      iframe.remove();
+    },
+  };
 }

--- a/packages/reference-renderers/index.js
+++ b/packages/reference-renderers/index.js
@@ -66,7 +66,7 @@ function page(body, dimensions, title, responsive = false) {
   return `<!DOCTYPE html>
 <html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta name="referrer" content="no-referrer"><meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src https:; media-src https:; style-src 'unsafe-inline'; base-uri 'none'; form-action 'none'">
 <title>${escapeHtml(title)}</title><style>
-*{box-sizing:border-box}html,body{margin:0}body{min-height:100vh;display:flex;flex-direction:column;align-items:center;justify-content:center;background:#f5f5f5;font-family:system-ui,-apple-system,sans-serif}.adcp-label{width:min(100%,600px);padding:5px 8px;background:#e5e7eb;color:#374151;font-size:10px;font-weight:650;letter-spacing:.02em}.adcp-preview{${frameSize};overflow:hidden;position:relative;background:#fff;border:1px solid #ddd}.adcp-preview img,.adcp-preview video{display:block;width:100%;height:100%;object-fit:cover}.adcp-preview video{object-fit:contain;background:#000}.adcp-placeholder{display:flex;flex-direction:column;align-items:center;justify-content:center;width:100%;height:100%;padding:16px;color:#fff;text-align:center;background:linear-gradient(135deg,#0f766e,#115e59)}.adcp-placeholder strong{font-size:14px}.adcp-placeholder span{margin-top:4px;font-size:11px;opacity:.85}.adcp-native{display:flex;flex-direction:column;gap:8px;height:100%;padding:16px}.adcp-native img{height:60%;border-radius:4px}.adcp-native__sponsor{font-size:11px;color:#666;text-transform:uppercase;letter-spacing:.04em}.adcp-native__title{font-size:16px;font-weight:650;color:#171717}.adcp-native__body{font-size:13px;line-height:1.4;color:#525252}.adcp-native__cta{font-size:13px;font-weight:650;color:#0f766e}.adcp-carousel{display:grid;grid-auto-flow:column;grid-auto-columns:minmax(180px,80%);gap:10px;width:min(100%,600px);padding:10px;overflow-x:auto;background:#fff;border:1px solid #ddd}.adcp-card{overflow:hidden;border:1px solid #ddd;border-radius:6px;background:#fff;scroll-snap-align:start}.adcp-card img,.adcp-card video{display:block;width:100%;aspect-ratio:1/1;object-fit:cover}.adcp-card__copy{display:grid;gap:5px;padding:9px}.adcp-card__headline{font-size:14px;font-weight:650;color:#171717}.adcp-card__description,.adcp-carousel__primary{font-size:12px;line-height:1.4;color:#525252}.adcp-card__cta{font-size:12px;font-weight:650;color:#0f766e}
+*{box-sizing:border-box}html,body{margin:0}body{min-height:100vh;display:flex;flex-direction:column;align-items:center;justify-content:center;background:#f5f5f5;font-family:system-ui,-apple-system,sans-serif}.adcp-label{width:min(100%,600px);padding:5px 8px;background:#e5e7eb;color:#374151;font-size:10px;font-weight:650;letter-spacing:.02em}.adcp-preview{${frameSize};overflow:hidden;position:relative;background:#fff;border:1px solid #ddd}.adcp-preview img,.adcp-preview video{display:block;width:100%;height:100%;object-fit:cover}.adcp-preview video{object-fit:contain;background:#000}.adcp-preview--with-copy{display:grid;grid-template-rows:minmax(0,1fr) auto}.adcp-preview--with-copy>a,.adcp-preview--with-copy>img{min-height:0}.adcp-preview--with-copy>a>img{height:100%}.adcp-placeholder{display:flex;flex-direction:column;align-items:center;justify-content:center;width:100%;height:100%;padding:16px;color:#fff;text-align:center;background:linear-gradient(135deg,#0f766e,#115e59)}.adcp-placeholder strong{font-size:14px}.adcp-placeholder span{margin-top:4px;font-size:11px;opacity:.85}.adcp-native{display:flex;flex-direction:column;gap:8px;height:100%;padding:16px}.adcp-native img{height:60%;border-radius:4px}.adcp-native__sponsor{font-size:11px;color:#666;text-transform:uppercase;letter-spacing:.04em}.adcp-native__title{font-size:16px;font-weight:650;color:#171717}.adcp-native__body{font-size:13px;line-height:1.4;color:#525252}.adcp-native__cta{font-size:13px;font-weight:650;color:#0f766e}.adcp-carousel{display:grid;grid-auto-flow:column;grid-auto-columns:minmax(180px,80%);gap:10px;width:min(100%,600px);padding:10px;overflow-x:auto;background:#fff;border:1px solid #ddd}.adcp-card{overflow:hidden;border:1px solid #ddd;border-radius:6px;background:#fff;scroll-snap-align:start}.adcp-card img,.adcp-card video{display:block;width:100%;height:auto;object-fit:cover}.adcp-card__copy{display:grid;gap:5px;padding:9px}.adcp-card__headline{font-size:14px;font-weight:650;color:#171717}.adcp-card__description,.adcp-carousel__primary{font-size:12px;line-height:1.4;color:#525252}.adcp-card__cta{font-size:12px;font-weight:650;color:#0f766e}
 </style></head><body>${body}</body></html>`;
 }
 
@@ -117,7 +117,9 @@ function imageBody(presentation) {
     presentation.body_text ? `<div class="adcp-card__description">${escapeHtml(presentation.body_text)}</div>` : '',
     presentation.cta ? `<div class="adcp-card__cta">${escapeHtml(presentation.cta)}</div>` : '',
   ].join('');
-  return `<div class="adcp-preview">${media}${copy ? `<div class="adcp-card__copy">${copy}</div>` : ''}</div>`;
+  return `<div class="adcp-preview${copy ? ' adcp-preview--with-copy' : ''}">${media}${
+    copy ? `<div class="adcp-card__copy">${copy}</div>` : ''
+  }</div>`;
 }
 
 /**
@@ -136,11 +138,13 @@ export function renderImageResult(input, requestedDimensions) {
 
 function carouselMedia(media) {
   if (media.type === 'video') {
-    return `<video controls playsinline preload="metadata" controlslist="nodownload noremoteplayback" disablepictureinpicture><source src="${escapeHtml(
+    return `<video width="${media.width}" height="${media.height}" controls playsinline preload="metadata" controlslist="nodownload noremoteplayback" disablepictureinpicture><source src="${escapeHtml(
       media.url
     )}"></video>`;
   }
-  return `<img src="${escapeHtml(media.url)}" alt="${escapeHtml(media.alt_text ?? '')}" referrerpolicy="no-referrer">`;
+  return `<img src="${escapeHtml(media.url)}" width="${media.width}" height="${media.height}" alt="${escapeHtml(
+    media.alt_text ?? ''
+  )}" referrerpolicy="no-referrer">`;
 }
 
 function carouselBody(presentation) {
@@ -150,8 +154,9 @@ function carouselBody(presentation) {
   const cards = presentation.cards
     .map(card => {
       const media = carouselMedia(card.media);
-      const linkedMedia = card.landing_page_url
-        ? `<a href="${escapeHtml(card.landing_page_url)}" target="_blank" rel="noopener noreferrer">${media}</a>`
+      const navigationUrl = card.landing_page_url ?? presentation.landing_page_url;
+      const linkedMedia = navigationUrl
+        ? `<a href="${escapeHtml(navigationUrl)}" target="_blank" rel="noopener noreferrer">${media}</a>`
         : media;
       const copy = [
         card.headline ? `<div class="adcp-card__headline">${escapeHtml(card.headline)}</div>` : '',

--- a/packages/reference-renderers/package.json
+++ b/packages/reference-renderers/package.json
@@ -13,6 +13,7 @@
   "files": [
     "index.js",
     "index.d.ts",
+    "structured.js",
     "README.md"
   ],
   "sideEffects": false,

--- a/packages/reference-renderers/structured.js
+++ b/packages/reference-renderers/structured.js
@@ -349,18 +349,21 @@ function validateImageSizeMode(params, issues) {
   }
 }
 
-function imageDimensions(raw, params, path, issues) {
+function imageDimensions(raw, params, path, issues, options = {}) {
   if (!positiveInteger(raw.width) || !positiveInteger(raw.height)) {
     issues.push(issue('INVALID_ASSET', path, 'image needs positive integer width and height'));
     return;
   }
-  const ratios = acceptedPixelRatios(params, issues);
+  const ratios =
+    options.useAssetPixelRatio === true
+      ? [positiveNumber(raw.pixel_ratio) ? raw.pixel_ratio : 1]
+      : acceptedPixelRatios(params, issues);
   if (raw.pixel_ratio !== undefined && !positiveNumber(raw.pixel_ratio)) {
     issues.push(issue('INVALID_ASSET', `${path}.pixel_ratio`, 'pixel_ratio must be positive'));
     return;
   }
   const candidates = raw.pixel_ratio === undefined ? ratios : [raw.pixel_ratio];
-  if (raw.pixel_ratio !== undefined && !ratios.includes(raw.pixel_ratio)) {
+  if (options.useAssetPixelRatio !== true && raw.pixel_ratio !== undefined && !ratios.includes(raw.pixel_ratio)) {
     issues.push(
       issue(
         'CONSTRAINT_VIOLATION',
@@ -439,12 +442,12 @@ function imageDimensions(raw, params, path, issues) {
   }
 }
 
-function imageMedia(parsed, raw, path, params, issues) {
+function imageMedia(parsed, raw, path, params, issues, options) {
   if (!isRecord(raw) || raw.asset_type !== 'image' || typeof raw.url !== 'string') {
     issues.push(issue('INVALID_ASSET', path, 'media must be an image asset'));
     return undefined;
   }
-  imageDimensions(raw, params, path, issues);
+  imageDimensions(raw, params, path, issues, options);
   const substituted = substituteMacros(raw.url, `${path}.url`, parsed.supportedMacros, parsed.macros, issues);
   const url = safeHttpsUrl(substituted, `${path}.url`, issues);
   if (!url || !positiveInteger(raw.width) || !positiveInteger(raw.height)) return undefined;
@@ -585,7 +588,7 @@ function prepareCard(parsed, raw, index, allowedTypes, aspectRatio, issues) {
   }
   const media =
     raw.media.asset_type === 'image'
-      ? imageMedia(parsed, raw.media, `${path}.media`, {}, issues)
+      ? imageMedia(parsed, raw.media, `${path}.media`, {}, issues, { useAssetPixelRatio: true })
       : videoMedia(parsed, raw.media, `${path}.media`, parsed.params, issues);
   if (media && aspectRatio !== undefined && !ratioMatches(media.width, media.height, aspectRatio)) {
     issues.push(issue('CONSTRAINT_VIOLATION', `${path}.media`, 'card media does not match card_aspect_ratio'));
@@ -678,8 +681,10 @@ export function prepareImageCarouselReference(input) {
       ? undefined
       : navigationAsset(parsed, parsed.manifest.assets.landing_page_url, 'manifest.assets.landing_page_url', issues);
   if (issues.length > 0) return { ok: false, issues };
-  const navigations = preparedCards.flatMap(card => (card.landing_page_url ? [card.landing_page_url] : []));
-  if (landingPageUrl) navigations.push(landingPageUrl);
+  const navigations = preparedCards.flatMap(card => {
+    const navigation = card.landing_page_url ?? landingPageUrl;
+    return navigation ? [navigation] : [];
+  });
   return {
     ok: true,
     presentation: {

--- a/packages/reference-renderers/structured.js
+++ b/packages/reference-renderers/structured.js
@@ -1,0 +1,696 @@
+/**
+ * Dependency-free validation for the canonical image and image_carousel
+ * contracts. The schemas are intentionally represented as small executable
+ * checks so the browser package does not depend on the Node-oriented SDK schema
+ * loader. Conformance fixtures keep these checks aligned with the SDK schemas.
+ */
+
+const MACRO_PATTERN = /\$?\{([A-Z][A-Z0-9_]*)\}/g;
+
+const DEFAULT_SLOTS = Object.freeze({
+  image: Object.freeze([
+    { asset_group_id: 'image_main', asset_type: 'image', required: true },
+    { asset_group_id: 'headline', asset_type: 'text', required: false },
+    { asset_group_id: 'body_text', asset_type: 'text', required: false },
+    { asset_group_id: 'primary_text', asset_type: 'text', required: false },
+    { asset_group_id: 'cta', asset_type: 'text', required: false },
+    { asset_group_id: 'landing_page_url', asset_type: 'url', required: false },
+  ]),
+  image_carousel: Object.freeze([
+    { asset_group_id: 'cards', asset_type: 'card', required: true, min: 2, max: 10 },
+    { asset_group_id: 'primary_text', asset_type: 'text', required: false },
+    { asset_group_id: 'landing_page_url', asset_type: 'url', required: false },
+  ]),
+});
+
+function issue(code, path, message) {
+  return { code, path, message };
+}
+
+function isRecord(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function positiveInteger(value) {
+  return Number.isInteger(value) && value > 0;
+}
+
+function positiveNumber(value) {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0;
+}
+
+function normalizeMacroName(value) {
+  return String(value)
+    .replace(/^\$?\{/, '')
+    .replace(/\}$/, '')
+    .toUpperCase();
+}
+
+function declaredMacros(input, params) {
+  const values =
+    input.supportedMacros ??
+    input.supported_macros ??
+    input.declaration?.supported_macros ??
+    params.supported_macros ??
+    [];
+  return Array.isArray(values)
+    ? new Set(values.filter(value => typeof value === 'string').map(normalizeMacroName))
+    : new Set();
+}
+
+function macroValues(input, supported, issues) {
+  const values = new Map();
+  if (input.macros === undefined) return values;
+  if (!isRecord(input.macros)) {
+    issues.push(issue('INVALID_INPUT', 'macros', 'macros must be an object of string preview values'));
+    return values;
+  }
+  for (const [rawName, value] of Object.entries(input.macros)) {
+    const name = normalizeMacroName(rawName);
+    if (!supported.has(name)) {
+      issues.push(issue('UNSUPPORTED_MACRO', `macros.${rawName}`, `${rawName} is not declared in supported_macros`));
+    } else if (typeof value !== 'string') {
+      issues.push(issue('INVALID_INPUT', `macros.${rawName}`, 'preview macro values must be strings'));
+    } else {
+      values.set(name, value);
+    }
+  }
+  return values;
+}
+
+function substituteMacros(value, path, supported, values, issues) {
+  return value.replace(MACRO_PATTERN, (token, rawName) => {
+    const name = normalizeMacroName(rawName);
+    if (!supported.has(name)) {
+      issues.push(issue('UNSUPPORTED_MACRO', path, `${token} is not declared in supported_macros`));
+      return token;
+    }
+    const replacement = values.get(name);
+    if (replacement === undefined) {
+      issues.push(issue('MISSING_MACRO_VALUE', path, `${token} needs an explicit preview value`));
+      return token;
+    }
+    return replacement;
+  });
+}
+
+function safeHttpsUrl(value, path, issues) {
+  if (typeof value !== 'string' || value.length > 8192) {
+    issues.push(issue('INVALID_ASSET', path, 'URL must be an HTTPS string of at most 8192 characters'));
+    return undefined;
+  }
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol === 'https:' && !parsed.username && !parsed.password) return value;
+  } catch {
+    // Return the common structured issue below.
+  }
+  issues.push(issue('INVALID_ASSET', path, 'URL must use HTTPS without embedded credentials'));
+  return undefined;
+}
+
+function parseSlots(params, formatKind, issues) {
+  const rawSlots = params.slots ?? DEFAULT_SLOTS[formatKind];
+  if (!Array.isArray(rawSlots)) {
+    issues.push(issue('INVALID_FORMAT_DECLARATION', 'declaration.params.slots', 'slots must be an array'));
+    return [];
+  }
+  const slots = [];
+  for (const [index, rawSlot] of rawSlots.entries()) {
+    if (!isRecord(rawSlot) || typeof rawSlot.asset_group_id !== 'string' || typeof rawSlot.asset_type !== 'string') {
+      issues.push(
+        issue(
+          'INVALID_FORMAT_DECLARATION',
+          `declaration.params.slots.${index}`,
+          'each slot needs asset_group_id and asset_type'
+        )
+      );
+      continue;
+    }
+    slots.push(rawSlot);
+  }
+  return slots;
+}
+
+function parseInput(input, expectedFormat) {
+  const issues = [];
+  if (!isRecord(input)) {
+    return { ok: false, issues: [issue('INVALID_INPUT', '(root)', 'input must be an object')] };
+  }
+  const manifest = input.manifest;
+  if (!isRecord(manifest)) {
+    return { ok: false, issues: [issue('INVALID_MANIFEST', 'manifest', 'manifest must be an object')] };
+  }
+  if (manifest.format_kind !== expectedFormat) {
+    return {
+      ok: false,
+      issues: [
+        issue(
+          manifest.format_kind === undefined ? 'INVALID_MANIFEST' : 'FORMAT_MISMATCH',
+          'manifest.format_kind',
+          `expected format_kind ${expectedFormat}`
+        ),
+      ],
+    };
+  }
+  if (!isRecord(manifest.assets)) {
+    return {
+      ok: false,
+      issues: [issue('INVALID_MANIFEST', 'manifest.assets', 'manifest assets must be an object')],
+    };
+  }
+
+  const declaration = input.declaration ?? {
+    format_kind: expectedFormat,
+    params: isRecord(manifest.params) ? manifest.params : {},
+  };
+  if (!isRecord(declaration) || declaration.format_kind !== expectedFormat) {
+    return {
+      ok: false,
+      issues: [issue('FORMAT_MISMATCH', 'declaration.format_kind', `declaration must target ${expectedFormat}`)],
+    };
+  }
+  if (!isRecord(declaration.params)) {
+    return {
+      ok: false,
+      issues: [issue('INVALID_FORMAT_DECLARATION', 'declaration.params', 'declaration params must be an object')],
+    };
+  }
+
+  const params = declaration.params;
+  const slots = parseSlots(params, expectedFormat, issues);
+  const supportedMacros = declaredMacros(input, params);
+  const macros = macroValues(input, supportedMacros, issues);
+  if (issues.length > 0) return { ok: false, issues };
+  return { ok: true, manifest, declaration, params, slots, supportedMacros, macros };
+}
+
+function slotFor(parsed, assetGroupId) {
+  return parsed.slots.find(slot => slot.asset_group_id === assetGroupId);
+}
+
+function requireDeclaredSlot(parsed, assetGroupId, assetType, issues) {
+  const slot = slotFor(parsed, assetGroupId);
+  if (!slot || slot.asset_type !== assetType) {
+    issues.push(
+      issue(
+        'INVALID_FORMAT_DECLARATION',
+        'declaration.params.slots',
+        `${assetGroupId} must be declared as an ${assetType} slot`
+      )
+    );
+    return undefined;
+  }
+  return slot;
+}
+
+function requiredSlots(parsed, issues) {
+  for (const slot of parsed.slots) {
+    if (slot.required === true && parsed.manifest.assets[slot.asset_group_id] === undefined) {
+      issues.push(
+        issue(
+          'MISSING_ASSET',
+          `manifest.assets.${slot.asset_group_id}`,
+          `${slot.asset_group_id} is required by the format declaration`
+        )
+      );
+    }
+  }
+}
+
+function textAsset(parsed, assetGroupId, maxParam, issues) {
+  const raw = parsed.manifest.assets[assetGroupId];
+  if (raw === undefined) return undefined;
+  if (!requireDeclaredSlot(parsed, assetGroupId, 'text', issues)) return undefined;
+  if (!isRecord(raw) || raw.asset_type !== 'text' || typeof raw.content !== 'string') {
+    issues.push(issue('INVALID_ASSET', `manifest.assets.${assetGroupId}`, `${assetGroupId} must be a text asset`));
+    return undefined;
+  }
+  const value = substituteMacros(
+    raw.content,
+    `manifest.assets.${assetGroupId}.content`,
+    parsed.supportedMacros,
+    parsed.macros,
+    issues
+  );
+  const slotMaximum = slotFor(parsed, assetGroupId)?.max_chars;
+  const maximum = parsed.params[maxParam] ?? slotMaximum;
+  if (maximum !== undefined && (!positiveInteger(maximum) || value.length > maximum)) {
+    issues.push(
+      issue(
+        positiveInteger(maximum) ? 'CONSTRAINT_VIOLATION' : 'INVALID_FORMAT_DECLARATION',
+        positiveInteger(maximum) ? `manifest.assets.${assetGroupId}.content` : `declaration.params.${maxParam}`,
+        positiveInteger(maximum)
+          ? `${assetGroupId} exceeds the declared ${maximum}-character limit`
+          : `${maxParam} must be a positive integer`
+      )
+    );
+  }
+  return value;
+}
+
+function navigationAsset(parsed, raw, path, issues) {
+  const assetGroupId = path.split('.').at(-1);
+  if (path.split('.').length === 3 && !requireDeclaredSlot(parsed, assetGroupId, 'url', issues)) {
+    return undefined;
+  }
+  if (!isRecord(raw) || raw.asset_type !== 'url' || typeof raw.url !== 'string') {
+    issues.push(issue('INVALID_ASSET', path, 'landing page must be a URL asset'));
+    return undefined;
+  }
+  if (raw.url_type !== undefined && raw.url_type !== 'clickthrough') {
+    issues.push(issue('INVALID_ASSET', `${path}.url_type`, 'landing page URL must use clickthrough'));
+    return undefined;
+  }
+  const substituted = substituteMacros(raw.url, `${path}.url`, parsed.supportedMacros, parsed.macros, issues);
+  return safeHttpsUrl(substituted, `${path}.url`, issues);
+}
+
+function parseRatio(value, path, issues) {
+  if (value === undefined) return undefined;
+  if (typeof value !== 'string' || !/^[0-9]+(?:\.[0-9]+)?:[0-9]+(?:\.[0-9]+)?$/.test(value)) {
+    issues.push(issue('INVALID_FORMAT_DECLARATION', path, 'aspect ratio must use width:height'));
+    return undefined;
+  }
+  const [width, height] = value.split(':').map(Number);
+  if (!positiveNumber(width) || !positiveNumber(height)) {
+    issues.push(issue('INVALID_FORMAT_DECLARATION', path, 'aspect ratio values must be positive'));
+    return undefined;
+  }
+  return width / height;
+}
+
+function ratioMatches(width, height, expected) {
+  return Math.abs(width / height - expected) < 0.001;
+}
+
+function acceptedPixelRatios(params, issues) {
+  const ratios = params.pixel_ratios ?? [1];
+  if (!Array.isArray(ratios) || ratios.length === 0 || !ratios.every(positiveNumber)) {
+    issues.push(
+      issue(
+        'INVALID_FORMAT_DECLARATION',
+        'declaration.params.pixel_ratios',
+        'pixel_ratios must be a non-empty array of positive numbers'
+      )
+    );
+    return [1];
+  }
+  return ratios;
+}
+
+function validateImageSizeMode(params, issues) {
+  const hasWidth = params.width !== undefined;
+  const hasHeight = params.height !== undefined;
+  const hasFixed = hasWidth || hasHeight;
+  const hasSizes = params.sizes !== undefined;
+  const hasRange = ['min_width', 'max_width', 'min_height', 'max_height'].some(name => params[name] !== undefined);
+  if (hasWidth !== hasHeight) {
+    issues.push(
+      issue(
+        'INVALID_FORMAT_DECLARATION',
+        'declaration.params',
+        'fixed image declarations require both width and height'
+      )
+    );
+  }
+  if ([hasFixed, hasSizes, hasRange].filter(Boolean).length > 1) {
+    issues.push(
+      issue(
+        'INVALID_FORMAT_DECLARATION',
+        'declaration.params',
+        'fixed, multi-size, and responsive image size modes are mutually exclusive'
+      )
+    );
+  }
+  if (hasWidth && (!positiveInteger(params.width) || !positiveInteger(params.height))) {
+    issues.push(
+      issue(
+        'INVALID_FORMAT_DECLARATION',
+        'declaration.params',
+        'fixed image width and height must be positive integers'
+      )
+    );
+  }
+  if (hasSizes && (!Array.isArray(params.sizes) || params.sizes.length === 0)) {
+    issues.push(issue('INVALID_FORMAT_DECLARATION', 'declaration.params.sizes', 'sizes must be a non-empty array'));
+  }
+  for (const [minimumName, maximumName] of [
+    ['min_width', 'max_width'],
+    ['min_height', 'max_height'],
+  ]) {
+    const minimum = params[minimumName];
+    const maximum = params[maximumName];
+    if (minimum !== undefined && maximum !== undefined && minimum > maximum) {
+      issues.push(
+        issue('INVALID_FORMAT_DECLARATION', 'declaration.params', `${minimumName} cannot exceed ${maximumName}`)
+      );
+    }
+  }
+}
+
+function imageDimensions(raw, params, path, issues) {
+  if (!positiveInteger(raw.width) || !positiveInteger(raw.height)) {
+    issues.push(issue('INVALID_ASSET', path, 'image needs positive integer width and height'));
+    return;
+  }
+  const ratios = acceptedPixelRatios(params, issues);
+  if (raw.pixel_ratio !== undefined && !positiveNumber(raw.pixel_ratio)) {
+    issues.push(issue('INVALID_ASSET', `${path}.pixel_ratio`, 'pixel_ratio must be positive'));
+    return;
+  }
+  const candidates = raw.pixel_ratio === undefined ? ratios : [raw.pixel_ratio];
+  if (raw.pixel_ratio !== undefined && !ratios.includes(raw.pixel_ratio)) {
+    issues.push(
+      issue(
+        'CONSTRAINT_VIOLATION',
+        `${path}.pixel_ratio`,
+        `pixel_ratio ${raw.pixel_ratio} is not accepted by the declaration`
+      )
+    );
+  }
+
+  const fixed = positiveInteger(params.width) && positiveInteger(params.height);
+  const sizes = Array.isArray(params.sizes) ? params.sizes : undefined;
+  const matchesSize = (logicalWidth, logicalHeight) =>
+    candidates.some(
+      ratio =>
+        Math.abs(raw.width / ratio - logicalWidth) < 0.001 && Math.abs(raw.height / ratio - logicalHeight) < 0.001
+    );
+
+  if (fixed && !matchesSize(params.width, params.height)) {
+    issues.push(
+      issue(
+        'CONSTRAINT_VIOLATION',
+        path,
+        `image ${raw.width}x${raw.height} does not satisfy logical ${params.width}x${params.height}`
+      )
+    );
+  } else if (sizes) {
+    const validSizes = sizes.filter(
+      size => isRecord(size) && positiveInteger(size.width) && positiveInteger(size.height)
+    );
+    if (validSizes.length !== sizes.length) {
+      issues.push(
+        issue(
+          'INVALID_FORMAT_DECLARATION',
+          'declaration.params.sizes',
+          'sizes must contain positive integer width and height pairs'
+        )
+      );
+    } else if (!validSizes.some(size => matchesSize(size.width, size.height))) {
+      issues.push(
+        issue(
+          'CONSTRAINT_VIOLATION',
+          path,
+          `image ${raw.width}x${raw.height} does not match a declared logical size and pixel ratio`
+        )
+      );
+    }
+  } else {
+    const ratio = raw.pixel_ratio ?? 1;
+    const logicalWidth = raw.width / ratio;
+    const logicalHeight = raw.height / ratio;
+    for (const [name, compare] of [
+      ['min_width', (actual, limit) => actual >= limit],
+      ['max_width', (actual, limit) => actual <= limit],
+      ['min_height', (actual, limit) => actual >= limit],
+      ['max_height', (actual, limit) => actual <= limit],
+    ]) {
+      const limit = params[name];
+      const actual = name.endsWith('width') ? logicalWidth : logicalHeight;
+      if (limit !== undefined && (!positiveInteger(limit) || !compare(actual, limit))) {
+        issues.push(
+          issue(
+            positiveInteger(limit) ? 'CONSTRAINT_VIOLATION' : 'INVALID_FORMAT_DECLARATION',
+            positiveInteger(limit) ? path : `declaration.params.${name}`,
+            positiveInteger(limit)
+              ? `logical image dimensions violate ${name} ${limit}`
+              : `${name} must be a positive integer`
+          )
+        );
+      }
+    }
+  }
+
+  const aspectRatio = parseRatio(params.aspect_ratio, 'declaration.params.aspect_ratio', issues);
+  if (aspectRatio !== undefined && !ratioMatches(raw.width, raw.height, aspectRatio)) {
+    issues.push(issue('CONSTRAINT_VIOLATION', path, 'image does not match the declared aspect ratio'));
+  }
+}
+
+function imageMedia(parsed, raw, path, params, issues) {
+  if (!isRecord(raw) || raw.asset_type !== 'image' || typeof raw.url !== 'string') {
+    issues.push(issue('INVALID_ASSET', path, 'media must be an image asset'));
+    return undefined;
+  }
+  imageDimensions(raw, params, path, issues);
+  const substituted = substituteMacros(raw.url, `${path}.url`, parsed.supportedMacros, parsed.macros, issues);
+  const url = safeHttpsUrl(substituted, `${path}.url`, issues);
+  if (!url || !positiveInteger(raw.width) || !positiveInteger(raw.height)) return undefined;
+  return {
+    type: 'image',
+    url,
+    source_url: raw.url,
+    width: raw.width,
+    height: raw.height,
+    ...(typeof raw.alt_text === 'string' ? { alt_text: raw.alt_text } : {}),
+  };
+}
+
+function videoMedia(parsed, raw, path, params, issues) {
+  if (
+    !isRecord(raw) ||
+    raw.asset_type !== 'video' ||
+    typeof raw.url !== 'string' ||
+    !positiveInteger(raw.width) ||
+    !positiveInteger(raw.height)
+  ) {
+    issues.push(issue('INVALID_ASSET', path, 'media must be a video asset with width and height'));
+    return undefined;
+  }
+  const substituted = substituteMacros(raw.url, `${path}.url`, parsed.supportedMacros, parsed.macros, issues);
+  const url = safeHttpsUrl(substituted, `${path}.url`, issues);
+  const maximumDuration = params.card_video_max_duration_ms;
+  if (
+    maximumDuration !== undefined &&
+    (!positiveInteger(maximumDuration) || !positiveNumber(raw.duration_ms) || raw.duration_ms > maximumDuration)
+  ) {
+    issues.push(
+      issue(
+        positiveInteger(maximumDuration) ? 'CONSTRAINT_VIOLATION' : 'INVALID_FORMAT_DECLARATION',
+        positiveInteger(maximumDuration) ? `${path}.duration_ms` : 'declaration.params.card_video_max_duration_ms',
+        positiveInteger(maximumDuration)
+          ? `video duration must be present and at most ${maximumDuration}ms`
+          : 'card_video_max_duration_ms must be a positive integer'
+      )
+    );
+  }
+  if (!url) return undefined;
+  return {
+    type: 'video',
+    url,
+    source_url: raw.url,
+    width: raw.width,
+    height: raw.height,
+  };
+}
+
+/** Validate and prepare a canonical image manifest without touching the DOM or network. */
+export function prepareImageReference(input) {
+  const parsed = parseInput(input, 'image');
+  if (!parsed.ok) return parsed;
+  const issues = [];
+  requiredSlots(parsed, issues);
+  requireDeclaredSlot(parsed, 'image_main', 'image', issues);
+  validateImageSizeMode(parsed.params, issues);
+  const image = imageMedia(
+    parsed,
+    parsed.manifest.assets.image_main,
+    'manifest.assets.image_main',
+    parsed.params,
+    issues
+  );
+  const headline = textAsset(parsed, 'headline', 'headline_max_chars', issues);
+  const bodyText = textAsset(parsed, 'body_text', 'body_text_max_chars', issues);
+  const primaryText = textAsset(parsed, 'primary_text', 'primary_text_max_chars', issues);
+  const cta = textAsset(parsed, 'cta', 'cta_max_chars', issues);
+  const ctaValues = parsed.params.cta_values;
+  if (ctaValues !== undefined && (!Array.isArray(ctaValues) || !ctaValues.every(v => typeof v === 'string'))) {
+    issues.push(
+      issue('INVALID_FORMAT_DECLARATION', 'declaration.params.cta_values', 'cta_values must be an array of strings')
+    );
+  } else if (cta && ctaValues && !ctaValues.includes(cta)) {
+    issues.push(issue('CONSTRAINT_VIOLATION', 'manifest.assets.cta.content', 'CTA is not allowed by cta_values'));
+  }
+  const landingPageUrl =
+    parsed.manifest.assets.landing_page_url === undefined
+      ? undefined
+      : navigationAsset(parsed, parsed.manifest.assets.landing_page_url, 'manifest.assets.landing_page_url', issues);
+  if (issues.length > 0 || !image) return { ok: false, issues };
+  return {
+    ok: true,
+    presentation: {
+      format_kind: 'image',
+      image,
+      ...(headline ? { headline } : {}),
+      ...(bodyText ? { body_text: bodyText } : {}),
+      ...(primaryText ? { primary_text: primaryText } : {}),
+      ...(cta ? { cta } : {}),
+      ...(landingPageUrl ? { landing_page_url: landingPageUrl } : {}),
+      network: {
+        eager_assets: [image.url],
+        user_navigations: landingPageUrl ? [landingPageUrl] : [],
+      },
+    },
+  };
+}
+
+function cardText(parsed, raw, key, path, maximum, issues) {
+  if (raw[key] === undefined) return undefined;
+  if (typeof raw[key] !== 'string') {
+    issues.push(issue('INVALID_ASSET', `${path}.${key}`, `${key} must be a string`));
+    return undefined;
+  }
+  const value = substituteMacros(raw[key], `${path}.${key}`, parsed.supportedMacros, parsed.macros, issues);
+  if (maximum !== undefined && (!positiveInteger(maximum) || value.length > maximum)) {
+    issues.push(
+      issue(
+        positiveInteger(maximum) ? 'CONSTRAINT_VIOLATION' : 'INVALID_FORMAT_DECLARATION',
+        positiveInteger(maximum) ? `${path}.${key}` : `declaration.params.${key}`,
+        positiveInteger(maximum)
+          ? `${key} exceeds the declared ${maximum}-character limit`
+          : `${key} maximum must be a positive integer`
+      )
+    );
+  }
+  return value;
+}
+
+function prepareCard(parsed, raw, index, allowedTypes, aspectRatio, issues) {
+  const path = `manifest.assets.cards.${index}`;
+  if (!isRecord(raw) || raw.asset_type !== 'card' || !isRecord(raw.media)) {
+    issues.push(issue('INVALID_ASSET', path, 'each carousel item must be a card asset with media'));
+    return undefined;
+  }
+  if (!allowedTypes.includes(raw.media.asset_type)) {
+    issues.push(
+      issue(
+        'CONSTRAINT_VIOLATION',
+        `${path}.media.asset_type`,
+        `${String(raw.media.asset_type)} is not an allowed carousel media type`
+      )
+    );
+    return undefined;
+  }
+  const media =
+    raw.media.asset_type === 'image'
+      ? imageMedia(parsed, raw.media, `${path}.media`, {}, issues)
+      : videoMedia(parsed, raw.media, `${path}.media`, parsed.params, issues);
+  if (media && aspectRatio !== undefined && !ratioMatches(media.width, media.height, aspectRatio)) {
+    issues.push(issue('CONSTRAINT_VIOLATION', `${path}.media`, 'card media does not match card_aspect_ratio'));
+  }
+  const headline = cardText(parsed, raw, 'headline', path, parsed.params.card_headline_max_chars, issues);
+  const description = cardText(parsed, raw, 'description', path, parsed.params.card_description_max_chars, issues);
+  const cta = cardText(parsed, raw, 'cta', path, undefined, issues);
+  const ctaValues = parsed.params.cta_values;
+  if (cta && Array.isArray(ctaValues) && !ctaValues.includes(cta)) {
+    issues.push(issue('CONSTRAINT_VIOLATION', `${path}.cta`, 'CTA is not allowed by cta_values'));
+  }
+  const landingPageUrl =
+    raw.landing_page_url === undefined
+      ? undefined
+      : navigationAsset(parsed, raw.landing_page_url, `${path}.landing_page_url`, issues);
+  if (!media) return undefined;
+  return {
+    media,
+    ...(headline ? { headline } : {}),
+    ...(description ? { description } : {}),
+    ...(cta ? { cta } : {}),
+    ...(landingPageUrl ? { landing_page_url: landingPageUrl } : {}),
+  };
+}
+
+/** Validate and prepare a canonical image_carousel manifest without touching the DOM or network. */
+export function prepareImageCarouselReference(input) {
+  const parsed = parseInput(input, 'image_carousel');
+  if (!parsed.ok) return parsed;
+  const issues = [];
+  requiredSlots(parsed, issues);
+  requireDeclaredSlot(parsed, 'cards', 'card', issues);
+  const cards = parsed.manifest.assets.cards;
+  if (!Array.isArray(cards)) {
+    return {
+      ok: false,
+      issues: [issue('MISSING_ASSET', 'manifest.assets.cards', 'image_carousel requires a cards array')],
+    };
+  }
+  const cardSlot = slotFor(parsed, 'cards');
+  const minimum = parsed.params.min_cards ?? cardSlot?.min ?? 2;
+  const maximum = parsed.params.max_cards ?? cardSlot?.max ?? 10;
+  if (!positiveInteger(minimum) || minimum < 2 || !positiveInteger(maximum) || maximum < minimum) {
+    issues.push(
+      issue(
+        'INVALID_FORMAT_DECLARATION',
+        'declaration.params',
+        'carousel min/max cards must be positive, ordered integers with min_cards at least 2'
+      )
+    );
+  } else if (cards.length < minimum || cards.length > maximum) {
+    issues.push(
+      issue(
+        'CONSTRAINT_VIOLATION',
+        'manifest.assets.cards',
+        `carousel has ${cards.length} cards; declaration allows ${minimum}-${maximum}`
+      )
+    );
+  }
+  const allowedTypes = parsed.params.allowed_card_media_asset_types ??
+    parsed.params.allowed_card_asset_types ?? ['image'];
+  if (
+    !Array.isArray(allowedTypes) ||
+    allowedTypes.length === 0 ||
+    !allowedTypes.every(value => value === 'image' || value === 'video')
+  ) {
+    issues.push(
+      issue(
+        'INVALID_FORMAT_DECLARATION',
+        'declaration.params.allowed_card_media_asset_types',
+        'allowed carousel media types must be a non-empty subset of image and video'
+      )
+    );
+  }
+  const aspectRatio = parseRatio(parsed.params.card_aspect_ratio, 'declaration.params.card_aspect_ratio', issues);
+  const preparedCards = cards.flatMap((card, index) => {
+    const prepared = prepareCard(
+      parsed,
+      card,
+      index,
+      Array.isArray(allowedTypes) ? allowedTypes : [],
+      aspectRatio,
+      issues
+    );
+    return prepared ? [prepared] : [];
+  });
+  const primaryText = textAsset(parsed, 'primary_text', 'primary_text_max_chars', issues);
+  const landingPageUrl =
+    parsed.manifest.assets.landing_page_url === undefined
+      ? undefined
+      : navigationAsset(parsed, parsed.manifest.assets.landing_page_url, 'manifest.assets.landing_page_url', issues);
+  if (issues.length > 0) return { ok: false, issues };
+  const navigations = preparedCards.flatMap(card => (card.landing_page_url ? [card.landing_page_url] : []));
+  if (landingPageUrl) navigations.push(landingPageUrl);
+  return {
+    ok: true,
+    presentation: {
+      format_kind: 'image_carousel',
+      cards: preparedCards,
+      ...(primaryText ? { primary_text: primaryText } : {}),
+      ...(landingPageUrl ? { landing_page_url: landingPageUrl } : {}),
+      network: {
+        eager_assets: preparedCards.map(card => card.media.url),
+        user_navigations: navigations,
+      },
+    },
+  };
+}

--- a/packages/reference-renderers/test/package.test.js
+++ b/packages/reference-renderers/test/package.test.js
@@ -3,7 +3,9 @@ import { readFile } from 'node:fs/promises';
 import test from 'node:test';
 
 const packageMetadata = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8'));
-const source = await readFile(new URL('../index.js', import.meta.url), 'utf8');
+const sources = await Promise.all(
+  ['index.js', 'structured.js'].map(file => readFile(new URL(`../${file}`, import.meta.url), 'utf8'))
+);
 
 test('package is public browser ESM with no runtime dependencies', () => {
   assert.equal(packageMetadata.name, '@adcp/reference-renderers');
@@ -14,7 +16,7 @@ test('package is public browser ESM with no runtime dependencies', () => {
   assert.equal(packageMetadata.dependencies, undefined);
 });
 
-test('renderer source has no ambient or network capabilities', () => {
+test('renderer sources have no ambient or network capabilities', () => {
   for (const forbidden of [
     "from 'node:",
     'require(',
@@ -26,10 +28,12 @@ test('renderer source has no ambient or network capabilities', () => {
     'document.body',
     'localStorage',
   ]) {
-    assert.equal(
-      source.includes(forbidden),
-      false,
-      `browser renderer contains forbidden runtime capability: ${forbidden}`
-    );
+    for (const source of sources) {
+      assert.equal(
+        source.includes(forbidden),
+        false,
+        `browser renderer contains forbidden runtime capability: ${forbidden}`
+      );
+    }
   }
 });

--- a/packages/reference-renderers/test/structured-renderers.test.js
+++ b/packages/reference-renderers/test/structured-renderers.test.js
@@ -105,6 +105,26 @@ test('accepts declared Retina image density without changing logical size', () =
   assert.equal(result.ok, true);
 });
 
+test('accepts self-declared Retina density on carousel card images', () => {
+  const result = prepareImageCarouselReference({
+    manifest: {
+      format_kind: 'image_carousel',
+      assets: {
+        cards: ['one', 'two'].map(id =>
+          card(`https://cdn.example/${id}.png`, {
+            media: {
+              ...imageAsset(`https://cdn.example/${id}.png`, 1200, 1200),
+              pixel_ratio: 2,
+            },
+          })
+        ),
+      },
+    },
+  });
+
+  assert.equal(result.ok, true);
+});
+
 test('prepares and renders canonical image carousel cards', () => {
   const input = {
     manifest: {
@@ -150,6 +170,56 @@ test('prepares and renders canonical image carousel cards', () => {
   assert.match(rendered.html, /Community reference presentation — non-authoritative/);
   assert.match(rendered.html, /https:\/\/cdn\.example\/one\.png/);
   assert.doesNotMatch(rendered.html, /<script/i);
+});
+
+test('preserves non-square carousel media dimensions in rendered HTML', () => {
+  const input = {
+    manifest: {
+      format_kind: 'image_carousel',
+      assets: {
+        cards: ['one', 'two'].map(id =>
+          card(`https://cdn.example/${id}.png`, {
+            media: imageAsset(`https://cdn.example/${id}.png`, 600, 300),
+          })
+        ),
+      },
+    },
+    declaration: {
+      format_kind: 'image_carousel',
+      params: { card_aspect_ratio: '2:1' },
+    },
+  };
+
+  const result = renderImageCarouselResult(input);
+  assert.equal(result.ok, true);
+  assert.match(result.html, /width="600" height="300"/);
+  assert.doesNotMatch(result.html, /aspect-ratio:1\/1/);
+  assert.match(result.html, /\.adcp-card img,.adcp-card video\{[^}]*height:auto/);
+});
+
+test('uses the carousel landing page as the fallback card navigation', () => {
+  const landingPageUrl = 'https://brand.example/all-products';
+  const input = {
+    manifest: {
+      format_kind: 'image_carousel',
+      assets: {
+        cards: [card('https://cdn.example/one.png'), card('https://cdn.example/two.png')],
+        landing_page_url: {
+          asset_type: 'url',
+          url_type: 'clickthrough',
+          url: landingPageUrl,
+        },
+      },
+    },
+  };
+
+  const prepared = prepareImageCarouselReference(input);
+  assert.equal(prepared.ok, true);
+  assert.deepEqual(prepared.presentation.network.user_navigations, [landingPageUrl, landingPageUrl]);
+
+  const rendered = renderImageCarouselResult(input);
+  assert.equal(rendered.ok, true);
+  assert.equal(rendered.html.split(`href="${landingPageUrl}"`).length - 1, 2);
 });
 
 test('rejects carousel count, aspect ratio, and media-type violations', () => {
@@ -208,6 +278,23 @@ test('structured image rendering exposes issues instead of a placeholder', () =>
   });
   assert.equal(result.ok, false);
   assert.ok(result.issues.some(entry => entry.code === 'INVALID_ASSET'));
+});
+
+test('allocates visible layout space for structured image copy', () => {
+  const result = renderImageResult({
+    manifest: {
+      format_kind: 'image',
+      assets: {
+        image_main: imageAsset('https://cdn.example/image.png'),
+        headline: { asset_type: 'text', content: 'Visible headline' },
+      },
+    },
+  });
+
+  assert.equal(result.ok, true);
+  assert.match(result.html, /adcp-preview adcp-preview--with-copy/);
+  assert.match(result.html, /grid-template-rows:minmax\(0,1fr\) auto/);
+  assert.match(result.html, /Visible headline/);
 });
 
 test('mounts complete documents into a capability-minimal iframe', () => {

--- a/packages/reference-renderers/test/structured-renderers.test.js
+++ b/packages/reference-renderers/test/structured-renderers.test.js
@@ -1,0 +1,239 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  mountReferencePreview,
+  prepareImageCarouselReference,
+  prepareImageReference,
+  REFERENCE_PRESENTATION_LABEL,
+  renderImageCarouselResult,
+  renderImageResult,
+} from '../index.js';
+
+function imageAsset(url, width = 300, height = 250) {
+  return { asset_type: 'image', url, width, height };
+}
+
+function card(url, overrides = {}) {
+  return {
+    asset_type: 'card',
+    media: imageAsset(url, 600, 600),
+    ...overrides,
+  };
+}
+
+test('prepares a canonical image with declared preview macros', () => {
+  const result = prepareImageReference({
+    manifest: {
+      format_kind: 'image',
+      assets: {
+        image_main: imageAsset('https://cdn.example/{CREATIVE_ID}.png'),
+        headline: { asset_type: 'text', content: 'Creative {CREATIVE_ID}' },
+        landing_page_url: {
+          asset_type: 'url',
+          url_type: 'clickthrough',
+          url: 'https://brand.example/?id=${CREATIVE_ID}',
+        },
+        impression_tracker: {
+          asset_type: 'url',
+          url_type: 'tracker_pixel',
+          url: 'https://tracking.example/pixel',
+        },
+      },
+    },
+    declaration: {
+      format_kind: 'image',
+      params: {
+        width: 300,
+        height: 250,
+        headline_max_chars: 40,
+        supported_macros: ['CREATIVE_ID'],
+      },
+    },
+    macros: { CREATIVE_ID: 'preview-1' },
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.presentation.image.url, 'https://cdn.example/preview-1.png');
+  assert.deepEqual(result.presentation.network, {
+    eager_assets: ['https://cdn.example/preview-1.png'],
+    user_navigations: ['https://brand.example/?id=preview-1'],
+  });
+  assert.doesNotMatch(JSON.stringify(result), /tracking\.example/);
+});
+
+test('fails closed for undeclared macros and canonical dimension mismatches', () => {
+  const macroResult = prepareImageReference({
+    manifest: {
+      format_kind: 'image',
+      assets: { image_main: imageAsset('https://cdn.example/{ACCOUNT_ID}.png') },
+    },
+  });
+  assert.equal(macroResult.ok, false);
+  assert.equal(macroResult.issues[0].code, 'UNSUPPORTED_MACRO');
+
+  const dimensionsResult = prepareImageReference({
+    manifest: {
+      format_kind: 'image',
+      assets: { image_main: imageAsset('https://cdn.example/image.png', 728, 90) },
+    },
+    declaration: {
+      format_kind: 'image',
+      params: { width: 300, height: 250 },
+    },
+  });
+  assert.equal(dimensionsResult.ok, false);
+  assert.ok(dimensionsResult.issues.some(entry => entry.code === 'CONSTRAINT_VIOLATION'));
+});
+
+test('accepts declared Retina image density without changing logical size', () => {
+  const result = prepareImageReference({
+    manifest: {
+      format_kind: 'image',
+      assets: {
+        image_main: {
+          ...imageAsset('https://cdn.example/retina.png', 600, 500),
+          pixel_ratio: 2,
+        },
+      },
+    },
+    declaration: {
+      format_kind: 'image',
+      params: { width: 300, height: 250, pixel_ratios: [1, 2] },
+    },
+  });
+  assert.equal(result.ok, true);
+});
+
+test('prepares and renders canonical image carousel cards', () => {
+  const input = {
+    manifest: {
+      name: 'Seasonal products',
+      format_kind: 'image_carousel',
+      assets: {
+        cards: [
+          card('https://cdn.example/one.png', {
+            headline: 'One',
+            landing_page_url: {
+              asset_type: 'url',
+              url_type: 'clickthrough',
+              url: 'https://brand.example/one',
+            },
+          }),
+          card('https://cdn.example/two.png', { headline: 'Two' }),
+        ],
+        primary_text: { asset_type: 'text', content: 'Choose a product' },
+      },
+    },
+    declaration: {
+      format_kind: 'image_carousel',
+      params: {
+        min_cards: 2,
+        max_cards: 4,
+        card_aspect_ratio: '1:1',
+        allowed_card_media_asset_types: ['image'],
+        card_headline_max_chars: 20,
+      },
+    },
+  };
+
+  const prepared = prepareImageCarouselReference(input);
+  assert.equal(prepared.ok, true);
+  assert.equal(prepared.presentation.cards.length, 2);
+  assert.deepEqual(prepared.presentation.network.eager_assets, [
+    'https://cdn.example/one.png',
+    'https://cdn.example/two.png',
+  ]);
+
+  const rendered = renderImageCarouselResult(input);
+  assert.equal(rendered.ok, true);
+  assert.match(rendered.html, /Community reference presentation — non-authoritative/);
+  assert.match(rendered.html, /https:\/\/cdn\.example\/one\.png/);
+  assert.doesNotMatch(rendered.html, /<script/i);
+});
+
+test('rejects carousel count, aspect ratio, and media-type violations', () => {
+  const result = prepareImageCarouselReference({
+    manifest: {
+      format_kind: 'image_carousel',
+      assets: {
+        cards: [card('https://cdn.example/wide.png', { media: imageAsset('https://cdn.example/wide.png', 600, 300) })],
+      },
+    },
+    declaration: {
+      format_kind: 'image_carousel',
+      params: {
+        min_cards: 2,
+        max_cards: 3,
+        card_aspect_ratio: '1:1',
+        allowed_card_media_asset_types: ['video'],
+      },
+    },
+  });
+
+  assert.equal(result.ok, false);
+  assert.ok(result.issues.some(entry => entry.path === 'manifest.assets.cards'));
+  assert.ok(result.issues.some(entry => entry.path.endsWith('media.asset_type')));
+
+  const aspectResult = prepareImageCarouselReference({
+    manifest: {
+      format_kind: 'image_carousel',
+      assets: {
+        cards: ['one', 'two'].map(id =>
+          card(`https://cdn.example/${id}.png`, {
+            media: imageAsset(`https://cdn.example/${id}.png`, 600, 300),
+          })
+        ),
+      },
+    },
+    declaration: {
+      format_kind: 'image_carousel',
+      params: {
+        card_aspect_ratio: '1:1',
+        allowed_card_media_asset_types: ['image'],
+      },
+    },
+  });
+
+  assert.equal(aspectResult.ok, false);
+  assert.ok(aspectResult.issues.some(entry => entry.message.includes('card_aspect_ratio')));
+});
+
+test('structured image rendering exposes issues instead of a placeholder', () => {
+  const result = renderImageResult({
+    manifest: {
+      format_kind: 'image',
+      assets: { image_main: imageAsset('javascript:alert(1)') },
+    },
+  });
+  assert.equal(result.ok, false);
+  assert.ok(result.issues.some(entry => entry.code === 'INVALID_ASSET'));
+});
+
+test('mounts complete documents into a capability-minimal iframe', () => {
+  const attributes = new Map();
+  const iframe = {
+    setAttribute(name, value) {
+      attributes.set(name, value);
+    },
+    remove() {
+      this.removed = true;
+    },
+  };
+  const container = {
+    ownerDocument: { createElement: () => iframe },
+    append() {},
+    replaceChildren(child) {
+      this.child = child;
+    },
+  };
+  const mounted = mountReferencePreview(container, '<!DOCTYPE html><html><body>safe</body></html>');
+
+  assert.equal(container.child, iframe);
+  assert.equal(attributes.get('sandbox'), '');
+  assert.equal(attributes.get('referrerpolicy'), 'no-referrer');
+  assert.equal(attributes.get('title'), REFERENCE_PRESENTATION_LABEL);
+  assert.equal(iframe.srcdoc, '<!DOCTYPE html><html><body>safe</body></html>');
+  mounted.destroy();
+  assert.equal(iframe.removed, true);
+});

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1872,7 +1872,16 @@ export {
   getPreviewUrl,
   getPreviewHtml,
 } from './utils/preview-normalizer';
-export type { PreviewRenderV3 } from './utils/preview-normalizer';
+export type { PreviewRendererMetadata, PreviewRenderV3 } from './utils/preview-normalizer';
+export {
+  resolvePreviewAuthority,
+  type PlacementPreviewCandidate,
+  type PreviewAuthorityInput,
+  type PreviewAuthorityResolution,
+  type PreviewFidelity,
+  type SelectedPreviewAuthority,
+  type SellerPreviewCandidate,
+} from './utils/preview-authority';
 
 // ====== TYPE GUARD UTILITIES ======
 // Type guards for automatic TypeScript type narrowing in webhook handlers

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -15,6 +15,15 @@ export {
   type PreviewCacheBackend,
   type PreviewCacheEntry,
 } from './preview-utils';
+export {
+  resolvePreviewAuthority,
+  type PlacementPreviewCandidate,
+  type PreviewAuthorityInput,
+  type PreviewAuthorityResolution,
+  type PreviewFidelity,
+  type SelectedPreviewAuthority,
+  type SellerPreviewCandidate,
+} from './preview-authority';
 
 // Configuration constants
 export const REQUEST_TIMEOUT = parseInt(process.env.REQUEST_TIMEOUT || '30000'); // 30 seconds

--- a/src/lib/utils/preview-authority.ts
+++ b/src/lib/utils/preview-authority.ts
@@ -1,0 +1,154 @@
+/**
+ * Pure preview-authority selection for AdCP consumers.
+ *
+ * This module selects already-discovered candidates. It deliberately does not
+ * fetch presentation metadata, call preview providers, resolve npm packages,
+ * or execute renderer code.
+ */
+
+export type PreviewFidelity = 'authoritative' | 'representative';
+
+export interface SellerPreviewCandidate<T> {
+  fidelity: PreviewFidelity;
+  value: T;
+}
+
+export interface PlacementPreviewCandidate<T> {
+  placementId: string;
+  value: T;
+}
+
+export interface PreviewAuthorityInput<TSeller, TProvider, TPresentation, TReference, TManifest> {
+  /** Seller preview plus fidelity discovered through creative.preview. */
+  sellerPreview?: SellerPreviewCandidate<TSeller>;
+  /** Placement currently being represented. Required to select placement-scoped candidates. */
+  targetPlacementId?: string;
+  /** Preview provider explicitly delegated by the targeted publisher placement. */
+  publisherPreviewProvider?: PlacementPreviewCandidate<TProvider>;
+  /** Immutable presentation metadata declared by the targeted publisher placement. */
+  publisherPresentation?: PlacementPreviewCandidate<TPresentation>;
+  /** Prepared output from the community registry's pinned reference renderer. */
+  communityReference?: TReference;
+  /** Canonical manifest/assets fallback. */
+  manifest: TManifest;
+}
+
+export type SelectedPreviewAuthority<TSeller, TProvider, TPresentation, TReference, TManifest> =
+  | {
+      kind: 'serving_platform';
+      authoritative: true;
+      value: TSeller;
+    }
+  | {
+      kind: 'publisher_preview_provider';
+      authoritative: true;
+      placementId: string;
+      value: TProvider;
+    }
+  | {
+      kind: 'publisher_presentation';
+      authoritative: true;
+      placementId: string;
+      value: TPresentation;
+    }
+  | {
+      kind: 'community_reference';
+      authoritative: false;
+      value: TReference;
+    }
+  | {
+      kind: 'manifest';
+      authoritative: false;
+      value: TManifest;
+    };
+
+export interface PreviewAuthorityResolution<TSeller, TProvider, TPresentation, TReference, TManifest> {
+  selected: SelectedPreviewAuthority<TSeller, TProvider, TPresentation, TReference, TManifest>;
+  /**
+   * Representative seller output remains available for a clearly labeled
+   * secondary view but never displaces publisher-scoped authority.
+   */
+  representativeSellerPreview?: TSeller;
+  /** Placement-scoped inputs ignored because they did not match the target. */
+  ignoredPlacementCandidates: Array<'publisher_preview_provider' | 'publisher_presentation'>;
+}
+
+function matchingPlacement<T>(
+  candidate: PlacementPreviewCandidate<T> | undefined,
+  targetPlacementId: string | undefined
+): PlacementPreviewCandidate<T> | undefined {
+  return candidate !== undefined && targetPlacementId !== undefined && candidate.placementId === targetPlacementId
+    ? candidate
+    : undefined;
+}
+
+/**
+ * Resolve the AdCP preview authority order without executing side effects.
+ *
+ * Placement-scoped candidates fail closed unless their placement ID exactly
+ * matches the target. Representative seller output is returned only as a
+ * secondary view; it is never inserted into the authoritative chain.
+ */
+export function resolvePreviewAuthority<TSeller, TProvider, TPresentation, TReference, TManifest>(
+  input: PreviewAuthorityInput<TSeller, TProvider, TPresentation, TReference, TManifest>
+): PreviewAuthorityResolution<TSeller, TProvider, TPresentation, TReference, TManifest> {
+  const ignoredPlacementCandidates: PreviewAuthorityResolution<
+    TSeller,
+    TProvider,
+    TPresentation,
+    TReference,
+    TManifest
+  >['ignoredPlacementCandidates'] = [];
+  const matchedProvider = matchingPlacement(input.publisherPreviewProvider, input.targetPlacementId);
+  const matchedPresentation = matchingPlacement(input.publisherPresentation, input.targetPlacementId);
+  if (input.publisherPreviewProvider && !matchedProvider) {
+    ignoredPlacementCandidates.push('publisher_preview_provider');
+  }
+  if (input.publisherPresentation && !matchedPresentation) {
+    ignoredPlacementCandidates.push('publisher_presentation');
+  }
+
+  const representativeSellerPreview =
+    input.sellerPreview?.fidelity === 'representative' ? input.sellerPreview.value : undefined;
+  let selected: PreviewAuthorityResolution<TSeller, TProvider, TPresentation, TReference, TManifest>['selected'];
+
+  if (input.sellerPreview?.fidelity === 'authoritative') {
+    selected = {
+      kind: 'serving_platform',
+      authoritative: true,
+      value: input.sellerPreview.value,
+    };
+  } else if (matchedProvider) {
+    selected = {
+      kind: 'publisher_preview_provider',
+      authoritative: true,
+      placementId: matchedProvider.placementId,
+      value: matchedProvider.value,
+    };
+  } else if (matchedPresentation) {
+    selected = {
+      kind: 'publisher_presentation',
+      authoritative: true,
+      placementId: matchedPresentation.placementId,
+      value: matchedPresentation.value,
+    };
+  } else if (input.communityReference !== undefined) {
+    selected = {
+      kind: 'community_reference',
+      authoritative: false,
+      value: input.communityReference,
+    };
+  } else {
+    selected = {
+      kind: 'manifest',
+      authoritative: false,
+      value: input.manifest,
+    };
+  }
+
+  return {
+    selected,
+    ...(representativeSellerPreview === undefined ? {} : { representativeSellerPreview }),
+    ignoredPlacementCandidates,
+  };
+}

--- a/src/lib/utils/preview-normalizer.ts
+++ b/src/lib/utils/preview-normalizer.ts
@@ -8,6 +8,20 @@
 /**
  * v3 preview render
  */
+export interface PreviewRendererMetadata {
+  /** Stable identifier for the renderer implementation. */
+  renderer_id: string;
+  /** Exact semantic version of the renderer implementation. */
+  version: string;
+  /** Named package export or implementation entry point used. */
+  export: string;
+  /** Whether this renderer represents serving-platform output or an approximation. */
+  fidelity: 'authoritative' | 'representative';
+  /** True when delivery and measurement side effects were suppressed. */
+  tracking_suppressed: boolean;
+  [key: string]: unknown;
+}
+
 export interface PreviewRenderV3 {
   render_id: string;
   role: string;
@@ -24,6 +38,8 @@ export interface PreviewRenderV3 {
     supports_fullscreen?: boolean;
     csp_policy?: string;
   };
+  /** Renderer provenance and safety metadata; it does not independently grant authority. */
+  renderer?: PreviewRendererMetadata;
 }
 
 /**
@@ -47,6 +63,7 @@ export interface PreviewRenderV2 {
     supports_fullscreen?: boolean;
     csp_policy?: string;
   };
+  renderer?: PreviewRendererMetadata;
 }
 
 /**
@@ -77,6 +94,7 @@ export function normalizePreviewRender(render: PreviewRenderV2): PreviewRenderV3
     preview_html: render.preview_html,
     dimensions: render.dimensions,
     embedding: render.embedding,
+    renderer: render.renderer,
   };
 }
 

--- a/test/lib/preview-authority.test.js
+++ b/test/lib/preview-authority.test.js
@@ -1,0 +1,89 @@
+const { describe, test } = require('node:test');
+const assert = require('node:assert');
+
+const { resolvePreviewAuthority } = require('../../dist/lib/utils/preview-authority.js');
+
+const manifest = { format_id: 'display/image' };
+
+describe('resolvePreviewAuthority', () => {
+  test('selects authoritative seller truth before every fallback', () => {
+    const result = resolvePreviewAuthority({
+      sellerPreview: { fidelity: 'authoritative', value: 'seller' },
+      targetPlacementId: 'home',
+      publisherPreviewProvider: { placementId: 'home', value: 'provider' },
+      publisherPresentation: { placementId: 'home', value: 'presentation' },
+      communityReference: 'community',
+      manifest,
+    });
+
+    assert.deepStrictEqual(result.selected, {
+      kind: 'serving_platform',
+      authoritative: true,
+      value: 'seller',
+    });
+  });
+
+  test('keeps representative seller output secondary to publisher authority', () => {
+    const result = resolvePreviewAuthority({
+      sellerPreview: { fidelity: 'representative', value: 'seller approximation' },
+      targetPlacementId: 'home',
+      publisherPreviewProvider: { placementId: 'home', value: 'provider' },
+      publisherPresentation: { placementId: 'home', value: 'presentation' },
+      communityReference: 'community',
+      manifest,
+    });
+
+    assert.deepStrictEqual(result.selected, {
+      kind: 'publisher_preview_provider',
+      authoritative: true,
+      placementId: 'home',
+      value: 'provider',
+    });
+    assert.strictEqual(result.representativeSellerPreview, 'seller approximation');
+  });
+
+  test('selects placement presentation after the placement preview provider', () => {
+    const result = resolvePreviewAuthority({
+      targetPlacementId: 'home',
+      publisherPresentation: { placementId: 'home', value: 'presentation' },
+      communityReference: 'community',
+      manifest,
+    });
+
+    assert.deepStrictEqual(result.selected, {
+      kind: 'publisher_presentation',
+      authoritative: true,
+      placementId: 'home',
+      value: 'presentation',
+    });
+  });
+
+  test('fails closed on placement mismatch and records ignored candidates', () => {
+    const result = resolvePreviewAuthority({
+      targetPlacementId: 'article',
+      publisherPreviewProvider: { placementId: 'home', value: 'wrong provider' },
+      publisherPresentation: { placementId: 'home', value: 'wrong presentation' },
+      communityReference: 'community',
+      manifest,
+    });
+
+    assert.deepStrictEqual(result.selected, {
+      kind: 'community_reference',
+      authoritative: false,
+      value: 'community',
+    });
+    assert.deepStrictEqual(result.ignoredPlacementCandidates, ['publisher_preview_provider', 'publisher_presentation']);
+  });
+
+  test('uses the canonical manifest only after the community reference', () => {
+    const community = resolvePreviewAuthority({ communityReference: 'community', manifest });
+    const canonical = resolvePreviewAuthority({ manifest });
+
+    assert.strictEqual(community.selected.kind, 'community_reference');
+    assert.deepStrictEqual(canonical.selected, {
+      kind: 'manifest',
+      authoritative: false,
+      value: manifest,
+    });
+  });
+});

--- a/test/lib/v3-compatibility.test.js
+++ b/test/lib/v3-compatibility.test.js
@@ -1012,6 +1012,26 @@ describe('Preview Response Normalizer', () => {
       assert.strictEqual(result.render_id, 'primary');
       assert.strictEqual(result.role, 'primary');
     });
+
+    test('should preserve renderer provenance and safety metadata', () => {
+      const renderer = {
+        renderer_id: '@adcp/reference-renderers',
+        version: '1.1.0',
+        export: 'renderImageResult',
+        fidelity: 'representative',
+        tracking_suppressed: true,
+      };
+
+      const result = normalizePreviewRender({
+        output_id: 'main',
+        output_role: 'primary',
+        output_format: 'html',
+        preview_html: '<div>Preview</div>',
+        renderer,
+      });
+
+      assert.deepStrictEqual(result.renderer, renderer);
+    });
   });
 
   describe('Detection helpers', () => {

--- a/test/lib/zod-schemas.test.js
+++ b/test/lib/zod-schemas.test.js
@@ -12,6 +12,62 @@ describe('Zod Schema Validation', () => {
     assert.ok(schemas, 'Schemas should be importable');
   });
 
+  test('reference image and carousel fixtures conform to SDK schemas', async () => {
+    if (!schemas) {
+      schemas = await import('../../dist/lib/types/schemas.generated.js');
+    }
+    const { prepareImageCarouselReference, prepareImageReference } =
+      await import('../../packages/reference-renderers/index.js');
+    const imageManifest = {
+      format_kind: 'image',
+      assets: {
+        image_main: {
+          asset_type: 'image',
+          url: 'https://cdn.example/image.png',
+          width: 300,
+          height: 250,
+        },
+      },
+    };
+    const imageDeclaration = {
+      format_kind: 'image',
+      params: { width: 300, height: 250 },
+    };
+    const carouselManifest = {
+      format_kind: 'image_carousel',
+      assets: {
+        cards: ['one', 'two'].map(id => ({
+          asset_type: 'card',
+          media: {
+            asset_type: 'image',
+            url: `https://cdn.example/${id}.png`,
+            width: 600,
+            height: 600,
+          },
+          headline: `Card ${id}`,
+        })),
+      },
+    };
+    const carouselDeclaration = {
+      format_kind: 'image_carousel',
+      params: {
+        min_cards: 2,
+        max_cards: 4,
+        card_aspect_ratio: '1:1',
+        allowed_card_media_asset_types: ['image'],
+      },
+    };
+
+    for (const [manifest, declaration, prepare] of [
+      [imageManifest, imageDeclaration, prepareImageReference],
+      [carouselManifest, carouselDeclaration, prepareImageCarouselReference],
+    ]) {
+      assert.strictEqual(schemas.CreativeManifestSchema.safeParse(manifest).success, true);
+      assert.strictEqual(schemas.ProductFormatDeclarationSchema.safeParse(declaration).success, true);
+      assert.strictEqual(prepare({ manifest, declaration }).ok, true);
+    }
+  });
+
   test('all canonical-format overlays accept the shared array-valued slots contract', async () => {
     if (!schemas) {
       schemas = await import('../../dist/lib/types/schemas.generated.js');


### PR DESCRIPTION
## Summary

- extend the dependency-free, Apache-2.0 `@adcp/reference-renderers` package with strict structured preparation and rendering for canonical `image` and `image_carousel` manifests
- expand only explicitly declared preview macros, expose the exact media/navigation network plan, reject unsafe URLs and contract mismatches, and mount complete inert documents in a capability-minimal iframe
- label every package rendering as a non-authoritative community reference presentation
- preserve renderer provenance through SDK preview normalization and add a pure SDK helper implementing the seller → publisher provider → publisher presentation → community reference → manifest authority order

## Protocol relationship

This complements adcontextprotocol/adcp#6653. The registry remains metadata-only: it points at exact package versions/exports and never serves executable renderer code. This package does not fetch a registry, dynamically load code, or execute creative-provided scripts.

Protocol-generated preview metadata and discovery types should be synced in the normal SDK schema update after #6653 merges and is published; this PR deliberately does not hand-edit generated types.

## Validation

- `npm run build`
- `npm run typecheck`
- SDK authority, compatibility, and complete Zod schema tests: 248 passed
- `npm run check --workspace=@adcp/reference-renderers`: 18 passed; strict publint passed
- focused Prettier check
- `npx changeset status --since=origin/main`
- repository pre-push validation

This opens the contribution for review only. It does not publish a package, merge a release, or make the separate community announcement owed by the release.

