### PR TITLE
fix(validation): suppress provisional schema advisories

### DIFF
--- a/.changeset/quiet-versioned-schema-advisories.md
+++ b/.changeset/quiet-versioned-schema-advisories.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Honor `validation.logSchemaViolations: false` for console output and identify the AdCP schema version in enabled validation diagnostics.

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -1190,7 +1190,8 @@ export interface SingleAgentClientConfig extends ConversationConfig {
      */
     strictSchemaValidation?: boolean;
     /**
-     * Log all schema validation violations to debug logs (default: true)
+     * Emit schema validation violations to debug logs and the console (default: true).
+     * Set false when violations are surfaced through another structured channel.
      *
      * @default true
      */

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -23,6 +23,7 @@ import {
   type ValidationMode,
 } from '../validation/client-hooks';
 import { formatIssues } from '../validation/schema-validator';
+import { ADCP_VERSION } from '../version';
 import { unwrapProtocolResponse, isAdcpError, isTerminalAdcpError } from '../utils/response-unwrapper';
 import { extractAdcpErrorInfo, extractCorrelationId } from '../utils/error-extraction';
 import { generateIdempotencyKey, requestUsesIdempotency, redactIdempotencyKeyInArgs } from '../utils/idempotency';
@@ -484,7 +485,7 @@ export class TaskExecutor {
       }) => void | Promise<void>;
       /** Fail tasks when response schema validation fails (default: true) */
       strictSchemaValidation?: boolean;
-      /** Log all schema validation violations to debug logs (default: true) */
+      /** Emit schema validation violations to debug logs and the console (default: true) */
       logSchemaViolations?: boolean;
       /**
        * Schema-driven validation using the bundled AdCP JSON schemas.
@@ -2523,8 +2524,10 @@ export class TaskExecutor {
       const validationVersion =
         this.lastKnownServerVersion === 'v2'
           ? 'v2.5'
-          : (this.responseAdcpVersionForValidation() ?? this.config.adcpVersion);
-      const outcome = validateIncomingResponse(taskName, normalizedResponse, mode, debugLogs, validationVersion);
+          : (this.responseAdcpVersionForValidation() ?? this.config.adcpVersion ?? ADCP_VERSION);
+      // TaskExecutor owns the user-facing log entry below. Passing debugLogs
+      // into the lower-level hook would emit a second, unversioned duplicate.
+      const outcome = validateIncomingResponse(taskName, normalizedResponse, mode, undefined, validationVersion);
       if (outcome.valid) return { valid: true, errors: [] };
 
       const errorStrings = outcome.issues.map(i => `${i.pointer}: ${i.message}`);
@@ -2537,17 +2540,26 @@ export class TaskExecutor {
             outcome.issues
           )}`,
           errors: errorStrings,
+          issues: outcome.issues,
           schemaVariant: outcome.variant,
+          schemaVersion: validationVersion,
           mode,
         });
       }
 
       if (mode === 'warn') {
-        console.warn(`Schema validation failed for ${taskName} (non-blocking):`, errorStrings);
+        if (logViolations) {
+          console.warn(
+            `Schema validation failed for ${taskName} against AdCP ${validationVersion} (non-blocking):`,
+            errorStrings
+          );
+        }
         return { valid: true, errors: [] };
       }
 
-      console.error(`Schema validation failed for ${taskName}:`, errorStrings);
+      if (logViolations) {
+        console.error(`Schema validation failed for ${taskName} against AdCP ${validationVersion}:`, errorStrings);
+      }
       return { valid: false, errors: errorStrings };
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'unknown error';

--- a/test/lib/schema-validation-logging.test.js
+++ b/test/lib/schema-validation-logging.test.js
@@ -1,0 +1,167 @@
+const { describe, test } = require('node:test');
+const assert = require('node:assert');
+
+const { TaskExecutor } = require('../../dist/lib/core/TaskExecutor.js');
+const { validateResponse } = require('../../dist/lib/validation/schema-validator.js');
+const { ADCP_VERSION } = require('../../dist/lib/version.js');
+const { ProtocolClient } = require('../../dist/lib/index.js');
+const { createTestClient, discoverAgentProfile } = require('../../dist/lib/testing/client.js');
+
+const CAPABILITIES_RESPONSE = {
+  adcp: {
+    major_versions: [3],
+    idempotency: { supported: false },
+  },
+  supported_protocols: ['media_buy'],
+  account: { supported_billing: ['operator'] },
+  compliance_testing: {
+    // AdCP 3.1 opened this list to implementation-specific scenarios. The
+    // provisional 3.0 compatibility check still carries the old closed enum.
+    scenarios: ['implementation_specific_scenario'],
+  },
+};
+
+function makeExecutor(responses, logSchemaViolations) {
+  return new TaskExecutor({
+    validation: { responses },
+    logSchemaViolations,
+    versionEnvelope: 'major-only',
+    adcpVersion: '3.1.15',
+  });
+}
+
+function captureConsole(method, callback) {
+  const original = console[method];
+  const calls = [];
+  console[method] = (...args) => calls.push(args);
+  try {
+    return { result: callback(), calls };
+  } finally {
+    console[method] = original;
+  }
+}
+
+async function discoverWithCapabilities(response) {
+  const client = createTestClient('https://example.com/mcp', 'mcp', {
+    adcpVersion: '3.1.15',
+    versionEnvelope: 'major-only',
+  });
+  client.getAgentInfo = async () => ({
+    name: '3.1-only seller',
+    tools: [{ name: 'get_adcp_capabilities' }],
+  });
+  client.client.discoveredEndpoint = 'https://example.com/mcp';
+
+  const originalCallTool = ProtocolClient.callTool;
+  const originalWarn = console.warn;
+  const warnings = [];
+  ProtocolClient.callTool = async () => response;
+  console.warn = (...args) => warnings.push(args);
+  try {
+    const discovery = await discoverAgentProfile(client, undefined, '3.1.15');
+    return { discovery, warnings };
+  } finally {
+    ProtocolClient.callTool = originalCallTool;
+    console.warn = originalWarn;
+  }
+}
+
+describe('TaskExecutor schema violation logging', () => {
+  test('fixture is valid for 3.1 but not the provisional 3.0 compatibility schema', () => {
+    assert.strictEqual(validateResponse('get_adcp_capabilities', CAPABILITIES_RESPONSE, '3.1.15').valid, true);
+    assert.strictEqual(validateResponse('get_adcp_capabilities', CAPABILITIES_RESPONSE, '3.0.24').valid, false);
+  });
+
+  test('logSchemaViolations=false suppresses warn-mode console and debug output', () => {
+    const executor = makeExecutor('warn', false);
+    const debugLogs = [];
+    const { result, calls } = captureConsole('warn', () =>
+      executor.validateResponseSchema(CAPABILITIES_RESPONSE, 'get_adcp_capabilities', debugLogs)
+    );
+
+    assert.deepStrictEqual(result, { valid: true, errors: [] });
+    assert.deepStrictEqual(calls, []);
+    assert.deepStrictEqual(debugLogs, []);
+  });
+
+  test('logSchemaViolations=false suppresses strict-mode console output without changing the verdict', () => {
+    const executor = makeExecutor('strict', false);
+    const debugLogs = [];
+    const { result, calls } = captureConsole('error', () =>
+      executor.validateResponseSchema(CAPABILITIES_RESPONSE, 'get_adcp_capabilities', debugLogs)
+    );
+
+    assert.strictEqual(result.valid, false);
+    assert.ok(result.errors.some(error => error.includes('/compliance_testing/scenarios/0')));
+    assert.deepStrictEqual(calls, []);
+    assert.deepStrictEqual(debugLogs, []);
+  });
+
+  test('enabled warn-mode output identifies the schema version', () => {
+    const executor = makeExecutor('warn', true);
+    const debugLogs = [];
+    const { result, calls } = captureConsole('warn', () =>
+      executor.validateResponseSchema(CAPABILITIES_RESPONSE, 'get_adcp_capabilities', debugLogs)
+    );
+
+    assert.strictEqual(result.valid, true);
+    assert.strictEqual(calls.length, 1);
+    assert.match(calls[0][0], /against AdCP 3\.0 \(non-blocking\)/);
+    assert.strictEqual(debugLogs.length, 1);
+    assert.strictEqual(debugLogs[0].schemaVersion, '3.0');
+    assert.ok(debugLogs[0].issues.some(issue => issue.pointer === '/compliance_testing/scenarios/0'));
+  });
+
+  test('default executor diagnostics identify the SDK-pinned schema version', () => {
+    const executor = new TaskExecutor({
+      validation: { responses: 'warn' },
+      logSchemaViolations: true,
+    });
+    const debugLogs = [];
+    const { calls } = captureConsole('warn', () =>
+      executor.validateResponseSchema({}, 'get_adcp_capabilities', debugLogs)
+    );
+
+    assert.strictEqual(calls.length, 1);
+    assert.match(calls[0][0], new RegExp(`against AdCP ${ADCP_VERSION.replaceAll('.', '\\.')}`));
+    assert.strictEqual(debugLogs.length, 1);
+    assert.strictEqual(debugLogs[0].schemaVersion, ADCP_VERSION);
+  });
+
+  test('3.1-only capability discovery suppresses the provisional 3.0 advisory', async () => {
+    const response = {
+      ...CAPABILITIES_RESPONSE,
+      status: 'completed',
+      adcp_version: '3.1',
+      adcp: {
+        ...CAPABILITIES_RESPONSE.adcp,
+        supported_versions: ['3.1'],
+      },
+    };
+    const { discovery, warnings } = await discoverWithCapabilities(response);
+
+    assert.deepStrictEqual(warnings, []);
+    assert.strictEqual(discovery.profile.capabilities_schema_issues, undefined);
+    assert.deepStrictEqual(discovery.profile.adcp_supported_versions, ['3.1']);
+  });
+
+  test('primary capability violations remain available as structured issues', async () => {
+    const response = {
+      ...CAPABILITIES_RESPONSE,
+      status: 'completed',
+      adcp_version: '3.1',
+      adcp: {
+        major_versions: [3],
+        supported_versions: ['3.1'],
+        // Missing required idempotency declaration.
+      },
+    };
+    const { discovery, warnings } = await discoverWithCapabilities(response);
+
+    assert.deepStrictEqual(warnings, []);
+    assert.ok(
+      discovery.profile.capabilities_schema_issues.some(issue => issue.pointer === '/adcp/idempotency'),
+      JSON.stringify(discovery.profile.capabilities_schema_issues)
+    );
+  });
+});


### PR DESCRIPTION
Closes #2599.

## What changed

- honor `validation.logSchemaViolations: false` for console output as well as debug logs;
- keep warn/strict validation verdicts unchanged when logging is suppressed;
- label enabled diagnostics with the AdCP schema version used for validation;
- consolidate enabled debug output into one versioned entry while preserving structured issues;
- fall back to the SDK-pinned `ADCP_VERSION` for direct/default `TaskExecutor` use.

The compliance runner's initial `major-only` capability probe must provisionally use the 3.0 schema before it knows the seller's declared versions. Test clients already disable schema-violation logging for this bootstrap call. After discovery, `discoverAgentProfile` independently validates the response against the selected compliance version and exposes genuine failures through structured `capabilities_schema_issues`, so this removes the misleading compatibility advisory without hiding primary-schema failures.

## Verification

- `npm run ci:quick` — green (15,124 core tests, zero failures; workspace suites green)
- focused validation/version-negotiation tests — 81/81 green
- `npm run build:lib`
- `npm run typecheck`
- `npm run format:check`
- commitlint and pre-push validation

Code and DX expert reviews found no remaining blockers.
