### PR TITLE
feat(testing): expose storyboard profile reuse

### DIFF
--- a/.changeset/swift-matrices-reuse.md
+++ b/.changeset/swift-matrices-reuse.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': minor
+---
+
+Expose typed storyboard agent-profile reuse so repeated matrix runs can skip redundant capability discovery while preserving tool gates.

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -226,6 +226,18 @@ export function applyStoryboardVersionOptions(
   return complianceDir && versioned.complianceDir !== complianceDir ? { ...versioned, complianceDir } : versioned;
 }
 
+function applyReusableProfileOptions(options: StoryboardRunOptions): StoryboardRunOptions {
+  const profile = options.profile ?? options._profile;
+  if (!profile) return options;
+  const profileTools = options.agents === undefined ? (normalizeAgentToolNames(profile.tools) ?? []) : undefined;
+
+  return {
+    ...options,
+    _profile: profile,
+    ...(options.agentTools === undefined && profileTools !== undefined ? { agentTools: profileTools } : {}),
+  };
+}
+
 export function applyAdcpVersionRunOptions(
   defaultAdcpVersion: string | undefined,
   options: StoryboardRunOptions
@@ -1191,6 +1203,7 @@ export async function runStoryboard(
   storyboard: Storyboard,
   options: StoryboardRunOptions = {}
 ): Promise<StoryboardResult> {
+  options = applyReusableProfileOptions(options);
   return withMCPConnectionScope(
     async () => {
       options = applyStoryboardVersionOptions(storyboard, options);
@@ -4227,6 +4240,7 @@ export async function runStoryboardStep(
   stepId: string,
   options: StoryboardRunOptions = {}
 ): Promise<StoryboardStepResult> {
+  options = applyReusableProfileOptions(options);
   return withMCPConnectionScope(
     async () => {
       validateStoryboardShape(storyboard);

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -6,7 +6,7 @@
  * SingleAgentClient method and includes validations.
  */
 
-import type { TestOptions } from '../types';
+import type { AgentProfile, TestOptions } from '../types';
 import type { BuyerAgent, BuyerAgentBillingMode, BuyerAgentStatus } from '../../server/decisioning/buyer-agent';
 import type { WebhookConformanceSigningOptions } from '../../conformance/types';
 
@@ -65,7 +65,7 @@ export interface Storyboard {
    * the whole storyboard with `requirement_unmet` and a
    * `missing_required_tool_family:` detail prefix. The standard `comply()`
    * path populates `agentTools` before this gate runs; direct callers that
-   * reuse a client should provide `agentTools` or `_profile.tools` so the
+   * reuse a profile should provide `agentTools` or `profile.tools` so the
    * runner can enforce it without discovery ambiguity.
    */
   required_any_of_tools?: RequiredToolFamily[];
@@ -78,7 +78,7 @@ export interface Storyboard {
    *
    * Recognised names:
    *   - `controller` — the agent must advertise `comply_test_controller`.
-   *     Detected from `options.agentTools`, `_profile.tools`, or discovery
+   *     Detected from `options.agentTools`, `profile.tools`, or discovery
    *     on reused clients. Direct callers that deliberately provide none of
    *     those surfaces bypass this check; their storyboard runs into the
    *     per-step `missing_test_controller` cascade instead.
@@ -1608,6 +1608,22 @@ export interface TrustedMatchPublisherAuthRunner {
 export interface StoryboardRunOptions extends TestOptions {
   /** Compliance cache root for bundle-scoped fixtures and test vectors. */
   complianceDir?: string;
+  /**
+   * Pre-discovered agent profile to reuse instead of repeating capability
+   * discovery. When `agentTools` is omitted, the runner derives it from
+   * `profile.tools` so storyboard-level `required_tools` and step-level
+   * `requires_tool` gates remain enforced.
+   *
+   * Reuse a profile only for the same agent URL, authentication, AdCP version,
+   * and route that produced it. Route-specific profiles are not interchangeable.
+   * In an `agents` run this value supplies only the run-level/default-agent
+   * gating context; each routed agent is still discovered independently.
+   * Profile reuse does not retain or reuse a client or transport connection.
+   *
+   * `AgentProfile` does not carry the server's exact wire version. Pass
+   * `adcpVersion` separately when version-skew validation depends on it.
+   */
+  profile?: AgentProfile;
   /** Initial context (e.g., from a previous step invocation) */
   context?: StoryboardContext;
   /**

--- a/src/lib/testing/types.ts
+++ b/src/lib/testing/types.ts
@@ -265,7 +265,10 @@ export interface TestOptions {
   };
   /** @internal Pre-created client from comply() — avoids per-scenario MCP reconnection */
   _client?: unknown;
-  /** @internal Pre-discovered profile from comply() — skips per-scenario discovery */
+  /**
+   * @internal Pre-discovered profile from comply() — skips per-scenario discovery.
+   * @deprecated Use `StoryboardRunOptions.profile` for storyboard profile reuse.
+   */
   _profile?: AgentProfile;
   /**
    * @internal Server-declared AdCP version learned during capability discovery.

--- a/test/lib/storyboard-profile-reuse.test.js
+++ b/test/lib/storyboard-profile-reuse.test.js
@@ -1,0 +1,251 @@
+/**
+ * Public storyboard profile reuse (adcp-client#2600).
+ *
+ * These tests use a deliberately unreachable URL. Reaching the expected tool
+ * gates proves the supplied profile bypassed wire discovery, and omitting
+ * agentTools proves the runner derived the gates from profile.tools.
+ */
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('node:http');
+
+const { runStoryboard, runStoryboardStep } = require('../../dist/lib/testing/storyboard/index.js');
+const { closeMCPConnections } = require('../../dist/lib/protocols/mcp.js');
+
+function buildStoryboard(overrides = {}) {
+  return {
+    id: 'profile_reuse_test',
+    version: '1.0.0',
+    title: 'profile reuse test',
+    category: 'test',
+    summary: 'Exercises public storyboard profile reuse.',
+    narrative: '',
+    agent: { interaction_model: 'sync', capabilities: [] },
+    caller: { role: 'buyer_agent' },
+    phases: [
+      {
+        id: 'p1',
+        title: 'Phase 1',
+        steps: [
+          {
+            id: 'step1',
+            title: 'A gated read',
+            task: 'get_products',
+          },
+        ],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+const profile = {
+  name: 'Reusable profile',
+  tools: ['get_products'],
+  raw_capabilities: {},
+};
+
+function handleMcpHandshake(rpc, res, tools) {
+  if (rpc.method === 'initialize') {
+    res.writeHead(200, { 'content-type': 'application/json', 'mcp-session-id': 'profile-reuse-session' });
+    res.end(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: rpc.id,
+        result: { protocolVersion: '2025-11-25', capabilities: {}, serverInfo: { name: 'test', version: '1.0.0' } },
+      })
+    );
+    return true;
+  }
+  if (rpc.method === 'notifications/initialized') {
+    res.writeHead(202);
+    res.end();
+    return true;
+  }
+  if (rpc.method === 'tools/list') {
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: rpc.id,
+        result: { tools: tools.map(name => ({ name, inputSchema: { type: 'object' } })) },
+      })
+    );
+    return true;
+  }
+  return false;
+}
+
+async function startRoutedAgent(tool, supportedProtocol) {
+  const tools = ['get_adcp_capabilities', tool];
+  const requests = [];
+  const server = http.createServer(async (req, res) => {
+    const chunks = [];
+    for await (const chunk of req) chunks.push(chunk);
+    const body = Buffer.concat(chunks).toString('utf8');
+    if (!body) {
+      res.writeHead(200);
+      res.end();
+      return;
+    }
+    const rpc = JSON.parse(body);
+    if (handleMcpHandshake(rpc, res, tools)) return;
+
+    const toolName = rpc.params?.name;
+    requests.push(toolName);
+    const structuredContent =
+      toolName === 'get_adcp_capabilities'
+        ? {
+            adcp: { major_versions: [3], supported_versions: ['3.2'] },
+            supported_protocols: [supportedProtocol],
+          }
+        : { ok: true };
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ jsonrpc: '2.0', id: rpc.id, result: { structuredContent } }));
+  });
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  return {
+    requests,
+    server,
+    url: `http://127.0.0.1:${server.address().port}/mcp`,
+  };
+}
+
+describe('StoryboardRunOptions.profile', () => {
+  test('runStoryboard reuses profile and derives required_tools gating', async () => {
+    const storyboard = buildStoryboard({ required_tools: ['sync_accounts'] });
+
+    const result = await runStoryboard('http://fake-local-2600', storyboard, { profile });
+
+    assert.equal(result.overall_passed, true);
+    assert.equal(result.skipped_count, 1);
+    assert.equal(result.failed_count, 0);
+    assert.equal(result.phases[0].steps[0].skip_reason, 'missing_tool');
+    assert.match(result.phases[0].steps[0].skip.detail, /sync_accounts/);
+  });
+
+  test('runStoryboardStep reuses profile and derives requires_tool gating', async () => {
+    const storyboard = buildStoryboard();
+    storyboard.phases[0].steps[0].requires_tool = 'sync_accounts';
+
+    const result = await runStoryboardStep('http://fake-local-2600', storyboard, 'step1', { profile });
+
+    assert.equal(result.passed, true);
+    assert.equal(result.skipped, true);
+    assert.equal(result.skip_reason, 'missing_tool');
+    assert.match(result.skip.detail, /sync_accounts/);
+  });
+
+  test('empty profiles remain authoritative for both runner entry points', async () => {
+    const emptyProfile = { name: 'Empty profile', tools: [] };
+    const storyboard = buildStoryboard();
+
+    const fullResult = await runStoryboard('http://fake-local-2600', storyboard, { profile: emptyProfile });
+    const stepResult = await runStoryboardStep('http://fake-local-2600', storyboard, 'step1', {
+      profile: emptyProfile,
+    });
+
+    assert.equal(fullResult.phases[0].steps[0].skip_reason, 'missing_tool');
+    assert.equal(stepResult.skip_reason, 'missing_tool');
+  });
+
+  test('explicit agentTools takes precedence over profile-derived tools', async () => {
+    let calls = 0;
+    const client = {
+      getProducts: async () => {
+        calls += 1;
+        return { success: true, data: { products: [] } };
+      },
+    };
+    const storyboard = buildStoryboard();
+    storyboard.phases[0].steps[0].sample_request = { buying_mode: 'brief', brief: 'test' };
+
+    const result = await runStoryboard('https://stub.example/mcp', storyboard, {
+      _client: client,
+      profile: { name: 'Empty profile', tools: [] },
+      agentTools: ['get_products'],
+    });
+
+    assert.equal(calls, 1);
+    assert.equal(result.phases[0].steps[0].skipped, undefined);
+  });
+
+  test('public profile takes precedence over the deprecated internal profile', async () => {
+    const storyboard = buildStoryboard({ required_tools: ['sync_accounts'] });
+
+    const result = await runStoryboard('http://fake-local-2600', storyboard, {
+      profile,
+      _profile: { name: 'Legacy profile', tools: ['sync_accounts'] },
+    });
+
+    assert.equal(result.skipped_count, 1);
+    assert.equal(result.phases[0].steps[0].skip_reason, 'missing_tool');
+  });
+
+  test('legacy internal profiles still normalize object-shaped tool entries', async () => {
+    let calls = 0;
+    const client = {
+      getProducts: async () => {
+        calls += 1;
+        return { success: true, data: { products: [] } };
+      },
+    };
+    const storyboard = buildStoryboard();
+    storyboard.phases[0].steps[0].sample_request = { buying_mode: 'brief', brief: 'test' };
+
+    const result = await runStoryboard('https://stub.example/mcp', storyboard, {
+      _client: client,
+      _profile: { name: 'Legacy profile', tools: [{ name: 'get_products' }] },
+    });
+
+    assert.equal(calls, 1);
+    assert.equal(result.phases[0].steps[0].skipped, undefined);
+  });
+
+  test('routed discovery replaces default-profile tools with the routed union', async () => {
+    const sales = await startRoutedAgent('__test_sales_profile_reuse', 'media_buy');
+    const signals = await startRoutedAgent('__test_signals_profile_reuse', 'signals');
+    const storyboard = buildStoryboard({
+      phases: [
+        {
+          id: 'p1',
+          title: 'Phase 1',
+          steps: [
+            {
+              id: 'step1',
+              title: 'A routed signals call',
+              task: '__test_signals_profile_reuse',
+              agent: 'signals',
+              auth: 'none',
+              sample_request: {},
+            },
+          ],
+        },
+      ],
+    });
+
+    try {
+      const result = await runStoryboard('', storyboard, {
+        allow_http: true,
+        profile: { ...profile, supported_protocols: ['media_buy'] },
+        agents: {
+          sales: { url: sales.url },
+          signals: { url: signals.url },
+        },
+        default_agent: 'sales',
+      });
+
+      const step = result.phases[0].steps[0];
+      assert.equal(step.skipped, undefined);
+      assert.equal(step.passed, true);
+      assert.ok(signals.requests.includes('__test_signals_profile_reuse'));
+    } finally {
+      await closeMCPConnections();
+      await Promise.all([
+        new Promise(resolve => sales.server.close(resolve)),
+        new Promise(resolve => signals.server.close(resolve)),
+      ]);
+    }
+  });
+});


### PR DESCRIPTION
Closes #2600.

## What changed

- Add typed `profile?: AgentProfile` support to storyboard run options.
- Normalize reusable profiles before capability and tool gates run.
- Derive `agentTools` from reused profiles while preserving explicit options and routed-agent discovery.
- Deprecate the internal `_profile` option and document safe profile reuse boundaries.
- Add regression coverage and a minor changeset.

## Why

Matrix-style storyboard runs can now reuse an already-discovered agent profile instead of repeating capability discovery for every run, without weakening required-tool enforcement.

## Validation

- `npm run typecheck`
- `npm run build:lib`
- 77 focused storyboard, routing, and gating tests
- PR/commit title validation and commitlint
- Expert code, protocol, and test reviews converged with no remaining findings
