### PR TITLE
fix(types): preserve nested structural compatibility

### DIFF
--- a/.changeset/brave-lions-preserve-types.md
+++ b/.changeset/brave-lions-preserve-types.md
@@ -2,4 +2,4 @@
 '@adcp/sdk': patch
 ---
 
-Restore `Pick`, `Omit`, and structural-assignment compatibility for generated named and nested open-object types while preserving explicit extension-map index signatures.
+Restore `Pick`, `Omit`, and structural-assignment compatibility for generated named open-object types while preserving explicit extension-map index signatures.

--- a/.changeset/brave-lions-preserve-types.md
+++ b/.changeset/brave-lions-preserve-types.md
@@ -2,4 +2,4 @@
 '@adcp/sdk': patch
 ---
 
-Restore `Pick`, `Omit`, and structural-assignment compatibility for generated named open-object types while preserving explicit extension-map index signatures.
+Restore `Pick`, `Omit`, and structural-assignment compatibility for generated named and nested open-object types while preserving explicit extension-map index signatures.

--- a/.changeset/gentle-storefront-types.md
+++ b/.changeset/gentle-storefront-types.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Restore structural compatibility for generated nested open-object types while preserving historical generated-module exports.

--- a/.changeset/gentle-storefront-types.md
+++ b/.changeset/gentle-storefront-types.md
@@ -1,5 +1,5 @@
 ---
-'@adcp/sdk': patch
+'@adcp/sdk': minor
 ---
 
 Restore structural compatibility for generated nested open-object types while preserving historical generated-module exports.

--- a/examples/hello_seller_adapter_guaranteed.ts
+++ b/examples/hello_seller_adapter_guaranteed.ts
@@ -491,6 +491,10 @@ function canonicalFormatOptions(p: UpstreamProduct): CanonicalProduct['format_op
 
 function projectProduct(p: UpstreamProduct, publisherDomain: string): CanonicalProduct {
   const recipe = buildGAMLikeRecipe(p);
+  const forecast: CanonicalProduct['forecast'] =
+    p.forecast && p.forecast.points.length > 0
+      ? { ...p.forecast, points: [p.forecast.points[0]!, ...p.forecast.points.slice(1)] }
+      : undefined;
   const product: CanonicalProduct = {
     product_id: p.product_id,
     name: p.name,
@@ -534,7 +538,7 @@ function projectProduct(p: UpstreamProduct, publisherDomain: string): CanonicalP
     // GAM responses need adapter-side translation; the mock skips that step
     // intentionally so adopters can see what AdCP-shape forecast looks like
     // without writing the projection first.
-    ...(p.forecast && { forecast: p.forecast }),
+    ...(forecast && { forecast }),
   };
   // Attach the v1.5 recipe via cast — wire `Product` doesn't enumerate
   // `implementation_config` (it rides as an opaque-to-buyer extension);

--- a/examples/hello_seller_adapter_non_guaranteed.ts
+++ b/examples/hello_seller_adapter_non_guaranteed.ts
@@ -420,6 +420,10 @@ function projectProduct(
   publisherDomain: string,
   pricingMode: 'fixed' | 'auction' = 'fixed'
 ): CanonicalProduct {
+  const forecast: CanonicalProduct['forecast'] =
+    p.forecast && p.forecast.points.length > 0
+      ? { ...p.forecast, points: [p.forecast.points[0]!, ...p.forecast.points.slice(1)] }
+      : undefined;
   const auctionMidpoint = p.pricing.target_cpm ?? round2(p.pricing.min_cpm * 1.3);
   const pricingOption =
     pricingMode === 'auction'
@@ -471,7 +475,7 @@ function projectProduct(
     // already (`points`, `metrics.{impressions,clicks,spend}.{low,mid,high}`,
     // `forecast_range_unit: 'spend'`, `method: 'modeled'`). Real auction-
     // backed sellers (FreeWheel, Magnite SSP) need adapter-side translation.
-    ...(p.forecast && { forecast: p.forecast }),
+    ...(forecast && { forecast }),
   };
 }
 

--- a/scripts/check-adopter-types.ts
+++ b/scripts/check-adopter-types.ts
@@ -114,13 +114,53 @@ import type {
   FormatSchemaReferenceResult,
   CreateMediaBuyPayload as RootCreateMediaBuyPayload,
   GetProductsPayload as RootGetProductsPayload,
+  LegacyProduct,
+  LegacyGetProductsResponse,
   MediaBuyAvailableAction,
+  ProductCardFields,
+  ProductCardDetailedFields,
   SLAWindow,
   SlaWindow,
   UpdateMediaBuyPayload as RootUpdateMediaBuyPayload,
 } from '@adcp/sdk';
+import type {
+  AdCPVersionEnvelope,
+  AudienceCharacteristic,
+  CanonicalFormatBase as ToolCanonicalFormatBase,
+  CommercialTerms,
+  ExplicitPackagesWithFixedAllocation,
+  Placement,
+  PostalCountrySystem,
+  ProductFormatDeclaration,
+  ProtocolEnvelope,
+  SelectedPlacements,
+  SignalDefinitionEnrichment,
+  SignalTargetingExpression,
+} from '@adcp/sdk/types/tools.generated';
+import type {
+  BrandReference1,
+  BrandReference2,
+  BrandReference3,
+  BrandReference4,
+  BrandReference5,
+  BrandReference6,
+  BrandReference7,
+  BrandReference8,
+  BrandReference9,
+  BrandReference10,
+  BrandReference11,
+  BrandReference12,
+  BusinessEntity1,
+  MeasurementTerms1,
+  None1,
+  None2,
+  PlatformExtensionReference1,
+  Product1,
+  Property1,
+} from '@adcp/sdk/types/core.generated';
 import { createCanonicalReferenceResolver as createSubpathCanonicalReferenceResolver } from '@adcp/sdk/canonical-references';
 import { customToolFor, customToolForSchema, TOOL_INPUT_SCHEMAS, TOOL_INPUT_SHAPES, TOOL_REQUEST_SCHEMAS } from '@adcp/sdk/schemas';
+import * as publicSchemas from '@adcp/sdk/schemas';
 
 declare const _server: AdcpServer;
 void _server;
@@ -364,12 +404,72 @@ interface _AdopterCreativeBrief {
 declare const _adopterCreativeBrief: _AdopterCreativeBrief;
 const _structurallyAssignedBrief: CreativeBrief = _adopterCreativeBrief;
 
+// Nested inline shapes must be just as source-compatible as named top-level
+// interfaces. Both sides of this assignment are exported by the SDK: the
+// projection helper produces ProductCardFields, while LegacyProduct embeds
+// the corresponding wire shape inline.
+declare const _helperProductCard: ProductCardFields;
+const _generatedProductCard: NonNullable<LegacyProduct['product_card']> = _helperProductCard;
+const _helperProductCardReverse: ProductCardFields = _generatedProductCard;
+type _ProductCardWithoutDescription = Omit<NonNullable<LegacyProduct['product_card']>, 'description'>;
+const _productCardWithoutDescription: _ProductCardWithoutDescription = _helperProductCard;
+declare const _helperProductCardDetailed: ProductCardDetailedFields;
+const _generatedProductCardDetailed: NonNullable<LegacyProduct['product_card_detailed']> = _helperProductCardDetailed;
+const _helperProductCardDetailedReverse: ProductCardDetailedFields = _generatedProductCardDetailed;
+type _LegacyResponseProduct = NonNullable<LegacyGetProductsResponse['products']>[number];
+const _legacyResponseProductCard: NonNullable<_LegacyResponseProduct['product_card']> = _helperProductCard;
+
 const _extensionMap: ExtensionObject = { vendor: { feature: true } };
 const _extensionValue: unknown = _extensionMap.vendor;
 void _omittedBriefHeadline;
 void _pickedBriefHeadline;
 void _structurallyAssignedBrief;
+void _generatedProductCard;
+void _helperProductCardReverse;
+void _productCardWithoutDescription;
+void _generatedProductCardDetailed;
+void _helperProductCardDetailedReverse;
+void _legacyResponseProductCard;
 void _extensionValue;
+
+type _HasNoStringIndex<T> = string extends keyof T ? false : true;
+const _exactPackageFlowTypes: [
+  _HasNoStringIndex<SelectedPlacements>,
+  _HasNoStringIndex<ExplicitPackagesWithFixedAllocation>,
+  _HasNoStringIndex<CommercialTerms>,
+  _HasNoStringIndex<ProductFormatDeclaration>,
+  _HasNoStringIndex<Placement>,
+  _HasNoStringIndex<AudienceCharacteristic>,
+] = [true, true, true, true, true, true];
+void _exactPackageFlowTypes;
+
+type _LegacyGeneratedAliases =
+  | BrandReference1 | BrandReference2 | BrandReference3 | BrandReference4 | BrandReference5 | BrandReference6
+  | BrandReference7 | BrandReference8 | BrandReference9 | BrandReference10 | BrandReference11 | BrandReference12
+  | BusinessEntity1 | MeasurementTerms1 | None1 | None2 | PlatformExtensionReference1 | Product1 | Property1;
+declare const _legacyGeneratedAlias: _LegacyGeneratedAliases;
+void _legacyGeneratedAlias;
+
+declare const _historicalToolExports: [
+  AdCPVersionEnvelope,
+  ToolCanonicalFormatBase,
+  PostalCountrySystem,
+  ProtocolEnvelope,
+  SignalDefinitionEnrichment,
+  SignalTargetingExpression,
+];
+void _historicalToolExports;
+
+const _legacyGeneratedSchemaAliases = [
+  publicSchemas.BrandReference1Schema, publicSchemas.BrandReference2Schema, publicSchemas.BrandReference3Schema,
+  publicSchemas.BrandReference4Schema, publicSchemas.BrandReference5Schema, publicSchemas.BrandReference6Schema,
+  publicSchemas.BrandReference7Schema, publicSchemas.BrandReference8Schema, publicSchemas.BrandReference9Schema,
+  publicSchemas.BrandReference10Schema, publicSchemas.BrandReference11Schema, publicSchemas.BrandReference12Schema,
+  publicSchemas.BusinessEntity1Schema, publicSchemas.MeasurementTerms1Schema, publicSchemas.None1Schema,
+  publicSchemas.None2Schema, publicSchemas.PlatformExtensionReference1Schema, publicSchemas.Product1Schema,
+  publicSchemas.Property1Schema,
+];
+void _legacyGeneratedSchemaAliases;
 
 // Canonical format overlays refine the base declaration with defaults and
 // format-specific fields. Their slots property must remain assignable from

--- a/scripts/generate-types.ts
+++ b/scripts/generate-types.ts
@@ -149,6 +149,7 @@ const CORE_AUTHORED_TOOL_SHARED_TYPES = new Set([
   'CatalogItemDeliveryMetrics',
   'CreativeAsset',
   'ExtensionObject',
+  'Format',
   'FormatReferenceStructuredObject',
   'GeoDeliveryMetrics',
   'GetProductsAsyncSubmitted',

--- a/scripts/generate-types.ts
+++ b/scripts/generate-types.ts
@@ -169,6 +169,26 @@ const BACKWARD_COMPAT_TYPE_ALIASES: Array<{
   newName: string;
   reason: string;
 }> = [
+  ...Array.from({ length: 12 }, (_, index) => ({
+    oldName: `BrandReference${index + 1}`,
+    newName: 'BrandReference',
+    reason: 'SDK 14 beta exported this numbered codegen compatibility alias.',
+  })),
+  ...(
+    [
+      ['BusinessEntity1', 'BusinessEntity'],
+      ['MeasurementTerms1', 'MeasurementTerms'],
+      ['None1', 'None'],
+      ['None2', 'None'],
+      ['PlatformExtensionReference1', 'PlatformExtensionReference'],
+      ['Product1', 'Product'],
+      ['Property1', 'Property'],
+    ] as const
+  ).map(([oldName, newName]) => ({
+    oldName,
+    newName,
+    reason: 'SDK 14 beta exported this numbered codegen compatibility alias.',
+  })),
   {
     oldName: 'SignalCatalogType',
     newName: 'SignalAvailabilityType',
@@ -734,7 +754,6 @@ export function enforceStrictSchema(schema: any): any {
   schema = expandConditionalRequiredDiscriminator(schema);
   schema = preservePostalCountrySystemRequiredness(schema);
   schema = dropValidationOnlyAnyOf(schema);
-
   // Rewrite mutual-exclusion `oneOf` patterns (e.g. Format.renders[]) into
   // explicit closed-shape branches before any further processing — see
   // {@link tightenMutualExclusionOneOf}. Idempotent on already-rewritten
@@ -2057,15 +2076,10 @@ function addBackwardCompatTypeAliases(typeDefinitions: string): string {
   let output = typeDefinitions;
   for (const { oldName, newName, reason } of BACKWARD_COMPAT_TYPE_ALIASES) {
     if (new RegExp(`^export (?:type|interface) ${oldName}\\b`, 'm').test(output)) continue;
-    const declaration = new RegExp(`(export type ${newName} =[\\s\\S]*?;\\n)`, 'm');
+    const canonicalDeclaration = new RegExp(`^export (?:type|interface) ${newName}\\b`, 'm');
+    if (!canonicalDeclaration.test(output)) continue;
     const alias = `/** @deprecated ${reason} */\nexport type ${oldName} = ${newName};\n`;
-    if (declaration.test(output)) {
-      output = output.replace(declaration, `$1${alias}`);
-      continue;
-    }
-    if (new RegExp(`^export interface ${newName}\\b`, 'm').test(output)) {
-      output += `\n${alias}`;
-    }
+    output += `\n${alias}`;
   }
   return output;
 }
@@ -2244,59 +2258,61 @@ async function generateToolTypes(tools: ToolDefinition[], preGeneratedTypes: Set
  * 4. Cleans up inline index signature objects in intersection types
  */
 function removeIndexSignatureTypes(typeDefinitions: string): string {
-  // Find all types that are pure index signatures
-  // Pattern: export type TypeName = { [k: string]: unknown };
-  // or: export type TypeName = {\n  [k: string]: unknown;\n};
-  const indexSigTypePattern = /export type (\w+) = \{\s*\[k: string\]: unknown;?\s*\};?/g;
-  const indexSigTypes = new Set<string>();
-
-  let match;
-  while ((match = indexSigTypePattern.exec(typeDefinitions)) !== null) {
-    indexSigTypes.add(match[1]);
-  }
+  const unknownIndexValue = String.raw`unknown(?: \| undefined)?`;
+  const markerPattern = new RegExp(
+    String.raw`export type (\w+) = \{\s*\[k: string\]: ${unknownIndexValue};?\s*\};`,
+    'g'
+  );
+  const markerTypes = new Set<string>();
+  let match: RegExpExecArray | null;
+  while ((match = markerPattern.exec(typeDefinitions)) !== null) markerTypes.add(match[1]);
 
   let result = typeDefinitions;
+  for (const typeName of markerTypes) {
+    result = result.replace(new RegExp(` & \\b${typeName}\\b`, 'g'), '');
+    result = result.replace(new RegExp(`\\b${typeName}\\b & `, 'g'), '');
+  }
+  return result;
+}
 
-  if (indexSigTypes.size > 0) {
-    console.log(`🧹 Removing ${indexSigTypes.size} index signature types: ${Array.from(indexSigTypes).join(', ')}`);
+/**
+ * Remove residual open-object markers only after numbered-type deduplication.
+ * Running these rewrites earlier changes the bodies used to identify jsts's
+ * canonical/numbered duplicates and can preserve hundreds of weaker siblings.
+ */
+function removeResidualInlineIndexSignatureArms(typeDefinitions: string): string {
+  let result = typeDefinitions;
 
-    // Remove the index signature type definitions
-    for (const typeName of indexSigTypes) {
-      // Remove single-line pattern
-      result = result.replace(
-        new RegExp(`export type ${typeName} = \\{\\s*\\[k: string\\]: unknown;?\\s*\\};?\\n?`, 'g'),
-        ''
+  for (const typeName of ['CreativeAsset', 'CreativeManifest']) {
+    const start = result.indexOf(`export type ${typeName} = `);
+    const end = start === -1 ? -1 : result.indexOf('\nexport ', start + 1);
+    if (start === -1 || end === -1) continue;
+    const block = result
+      .slice(start, end)
+      .replace(
+        /(  assets: \{\n)\s*\[k: string\]: unknown(?: \| undefined)?;/,
+        '$1    [k: string]: AssetVariant | AssetVariant[];'
       );
-      // Remove multi-line pattern
-      result = result.replace(
-        new RegExp(`export type ${typeName} = \\{\\n\\s*\\[k: string\\]: unknown;\\n\\};?\\n?`, 'g'),
-        ''
-      );
-    }
-
-    // Remove references to these types from intersection types
-    // Pattern: Type1 & IndexSigType becomes Type1
-    // Pattern: IndexSigType & Type1 becomes Type1
-    for (const typeName of indexSigTypes) {
-      // Remove " & TypeName" (when it comes after)
-      result = result.replace(new RegExp(` & ${typeName}(?=[;\\s])`, 'g'), '');
-      // Remove "TypeName & " (when it comes before)
-      result = result.replace(new RegExp(`${typeName} & `, 'g'), '');
-    }
+    result = result.slice(0, start) + block + result.slice(end);
   }
 
-  // Also remove inline index signature objects from intersections
-  // Pattern: & {\n  [k: string]: unknown;\n}
-  result = result.replace(/\s*&\s*\{\s*\[k:\s*string\]:\s*unknown;?\s*\}/gm, '');
+  const extensionStart = result.indexOf('export interface ExtensionObject {');
+  const extensionEnd =
+    extensionStart === -1 ? -1 : result.indexOf('\nexport ', extensionStart + 'export interface '.length);
+  const extensionBlock =
+    extensionStart === -1 ? '' : result.slice(extensionStart, extensionEnd === -1 ? result.length : extensionEnd);
+  const placeholder = '__ADCP_EXTENSION_OBJECT_INDEX_SIGNATURE__';
 
-  // Clean up malformed type aliases that end with semicolon followed by & (from incomplete removal)
-  // Pattern: export type Foo = Bar;\n & {...} -> export type Foo = Bar;
-  result = result.replace(/;\s*\n\s*&\s*\{[^}]*\}/gm, ';');
+  if (extensionBlock) {
+    result = result.replace(
+      extensionBlock,
+      extensionBlock.replace(/\[k: string\]: unknown(?: \| undefined)?;/, placeholder)
+    );
+  }
 
-  // Clean up any remaining orphaned & at the start of lines
-  result = result.replace(/;\s*\n\s*&/gm, ';');
-
-  return result;
+  result = result.replace(/^\s*\[k: string\]: unknown(?: \| undefined)?;\n/gm, '');
+  result = result.replace(/(\s*\/\*\*\n\s*\* @maximum 1\n\s*\*\/\n\s*(?:low|mid|high)\?:) \{\n\s*\};/g, '$1 number;');
+  return result.replace(placeholder, '[k: string]: unknown | undefined;');
 }
 
 /**
@@ -2376,7 +2392,27 @@ function simplifyForecastRange(typeDefinitions: string): string {
   mid?: number;
   /** Optimistic (high-end) forecast value. */
   high?: number;
-  [k: string]: unknown | undefined;
+}`;
+  return typeDefinitions.slice(0, start) + replacement + typeDefinitions.slice(end);
+}
+
+/** Replace jsts's bounded-array cartesian expansion with its structural item shape. */
+function simplifyPriceBreakdown(typeDefinitions: string): string {
+  const start = typeDefinitions.indexOf('export interface PriceBreakdown {');
+  if (start === -1) return typeDefinitions;
+  const end = typeDefinitions.indexOf('\nexport ', start + 1);
+  if (end === -1) throw new Error('simplifyPriceBreakdown: unable to locate next type boundary');
+  const replacement = `export interface PriceAdjustment {
+  kind: PriceAdjustmentKind;
+  name: string;
+  rate?: number;
+  amount?: number;
+  description?: string;
+  beneficiary?: string;
+}
+export interface PriceBreakdown {
+  list_price: number;
+  adjustments: PriceAdjustment[];
 }`;
   return typeDefinitions.slice(0, start) + replacement + typeDefinitions.slice(end);
 }
@@ -2727,6 +2763,31 @@ const JSTS_REPEATED_UNDER_RESOLUTION_BASES = [
   'DeliveryMetrics',
   'MeasurementTerms',
 ] as const;
+
+/**
+ * jsts also numbers genuinely distinct inline refinements when their inferred
+ * title collides with a canonical type. These must not be widened to the
+ * canonical type merely to remove the numeric suffix. Give the refinement a
+ * stable semantic name instead.
+ */
+const JSTS_NUMBERED_SEMANTIC_RENAMES: Array<{ numbered: string; semantic: string }> = [
+  { numbered: 'TaskStatus2', semantic: 'GetProductsRejectedStatus' },
+];
+
+export function renameKnownNumberedSemanticTypes(typeDefinitions: string): string {
+  const exportedTypes = collectExportedTypeNames(typeDefinitions);
+  let result = typeDefinitions;
+
+  for (const { numbered, semantic } of JSTS_NUMBERED_SEMANTIC_RENAMES) {
+    if (!exportedTypes.has(numbered)) continue;
+    if (exportedTypes.has(semantic)) {
+      throw new Error(`Cannot rename ${numbered} to existing generated type ${semantic}`);
+    }
+    result = result.replace(new RegExp(`\\b${numbered}\\b`, 'g'), semantic);
+  }
+
+  return result;
+}
 
 function buildKnownJstsAliases(typeDefinitions: string): Array<{ numbered: string; base: string }> {
   const exportedTypes = collectExportedTypeNames(typeDefinitions);
@@ -3575,12 +3636,14 @@ async function generateTypes() {
   // occurrences of the same schema within a single compilation unit
   toolTypes = removeNumberedTypeDuplicates(toolTypes);
   toolTypes = removeNumberedCoreTypeDuplicates(toolTypes, CORE_AUTHORED_TOOL_SHARED_TYPES);
+  toolTypes = removeResidualInlineIndexSignatureArms(toolTypes);
   toolTypes = namePostalAreaCountryBranch(toolTypes);
   toolTypes = applyKnownJstsAliases(toolTypes);
   toolTypes = fixTypedIndexSignatures(toolTypes);
   toolTypes = widenPostalAreaSupportIndexSignature(toolTypes);
   toolTypes = widenMediaBuyFeaturesIndexSignature(toolTypes);
   toolTypes = simplifyForecastRange(toolTypes);
+  toolTypes = simplifyPriceBreakdown(toolTypes);
   // This set is deliberately limited to canonical enums plus the handful of
   // shared core contracts above. Import all of them: numbered-type cleanup can
   // introduce a canonical reference after lexical reference scanning, and
@@ -3612,11 +3675,19 @@ async function generateTypes() {
     applyIndividualAssetDiscriminators(
       addBackwardCompatTypeAliases(
         simplifyForecastRange(
-          widenMediaBuyFeaturesIndexSignature(
-            widenPostalAreaSupportIndexSignature(
-              fixTypedIndexSignatures(
-                applyKnownJstsAliases(
-                  namePostalAreaCountryBranch(removeNumberedTypeDuplicates(removeIndexSignatureTypes(coreTypes)))
+          simplifyPriceBreakdown(
+            widenMediaBuyFeaturesIndexSignature(
+              widenPostalAreaSupportIndexSignature(
+                fixTypedIndexSignatures(
+                  removeResidualInlineIndexSignatureArms(
+                    applyKnownJstsAliases(
+                      namePostalAreaCountryBranch(
+                        renameKnownNumberedSemanticTypes(
+                          removeNumberedTypeDuplicates(removeIndexSignatureTypes(coreTypes))
+                        )
+                      )
+                    )
+                  )
                 )
               )
             )

--- a/scripts/generate-zod-from-ts.ts
+++ b/scripts/generate-zod-from-ts.ts
@@ -422,6 +422,40 @@ function postProcessForecastRangeConstraint(content: string): string {
   return content.slice(0, start) + constrained + content.slice(end);
 }
 
+/** Restore the price-adjustment XOR and signed 1..20 array bounds. */
+function postProcessPriceBreakdownConstraints(content: string): string {
+  const adjustmentStart = content.indexOf('export const PriceAdjustmentSchema = ');
+  const adjustmentEnd = content.indexOf('\n\nexport const ', adjustmentStart + 1);
+  if (adjustmentStart === -1 || adjustmentEnd === -1) {
+    throw new Error('Unable to locate PriceAdjustmentSchema boundary');
+  }
+  const adjustment = content.slice(adjustmentStart, adjustmentEnd).replace(
+    /;\s*$/,
+    `.superRefine((value, ctx) => {
+    if ((value.rate !== undefined) === (value.amount !== undefined)) {
+        ctx.addIssue({ code: "custom", path: [], message: "price adjustment requires exactly one of rate or amount" });
+    }
+});`
+  );
+  content = content.slice(0, adjustmentStart) + adjustment + content.slice(adjustmentEnd);
+
+  const breakdownStart = content.indexOf('export const PriceBreakdownSchema = ');
+  const breakdownEnd = content.indexOf('\n\nexport const ', breakdownStart + 1);
+  if (breakdownStart === -1 || breakdownEnd === -1) {
+    throw new Error('Unable to locate PriceBreakdownSchema boundary');
+  }
+  const breakdown = content
+    .slice(breakdownStart, breakdownEnd)
+    .replace(
+      'adjustments: z.array(PriceAdjustmentSchema)',
+      'adjustments: z.array(PriceAdjustmentSchema).min(1).max(20)'
+    );
+  if (!breakdown.includes('adjustments: z.array(PriceAdjustmentSchema).min(1).max(20)')) {
+    throw new Error('Unable to preserve PriceBreakdownSchema adjustment bounds');
+  }
+  return content.slice(0, breakdownStart) + breakdown + content.slice(breakdownEnd);
+}
+
 /**
  * Post-process generated Zod schemas to strip .and(z.record(...)) intersections
  * and equivalent record-only union intersections from object schemas that
@@ -680,7 +714,10 @@ function postProcessCreativeRuntimeConstraints(content: string): string {
       // slot keys while continuing to allow forward-compatible extension keys.
       // AssetVariantSchema is declared later in the generated module, so defer
       // resolving it until parse time to avoid a top-level TDZ reference.
-      .replace('assets: z.record(z.string(), z.unknown())', 'assets: CreativeAssetsSchema');
+      .replace(
+        /assets: z\.record\(z\.string\(\), (?:z\.unknown\(\)|z\.union\(\[AssetVariantSchema, z\.array\(AssetVariantSchema\)\]\))\)/,
+        'assets: CreativeAssetsSchema'
+      );
     if (constrainedAssets === schema.block) {
       throw new Error(`Unable to preserve creative asset constraints on ${schemaName}.`);
     }
@@ -695,9 +732,9 @@ function postProcessCreativeRuntimeConstraints(content: string): string {
         /\.and\(z\.union\(\[(?:V1CreativeNamedFormatReferenceSchema, V2CreativeCanonicalFormatKindSchema|NamedFormatManifestSchema, CanonicalFormatManifestSchema)\]\)\)/,
         ''
       );
-    if (withoutLossyIdentityIntersection === constrainedAssets) {
-      throw new Error(`Unable to remove lossy creative identity intersection from ${schemaName}.`);
-    }
+    // Fully normalized named types already project as a single object and do
+    // not carry this lossy intersection. Older generated inputs still do, so
+    // retain the removal for compatibility without requiring it to exist.
 
     const strictSchema = withoutLossyIdentityIntersection.replace(/;\s*$/, `${identityRefinement};`);
     if (strictSchema === withoutLossyIdentityIntersection) {
@@ -1759,7 +1796,7 @@ function isOpaqueRecordMarkerExpression(
   visiting = new Set<string>()
 ): boolean {
   const trimmed = normalizeSchemaExpression(expression);
-  if (trimmed === 'z.record(z.string(), z.unknown())') return true;
+  if (trimmed === 'z.record(z.string(), z.unknown())' || trimmed === 'z.object({}).passthrough()') return true;
 
   const arms = unionArmsForExpression(trimmed);
   if (arms) {
@@ -1832,6 +1869,20 @@ function rewriteLeadingMarkerUnionObjectAnd(
       const base = expression.slice(0, i);
       const arg = scanBalanced(expression, i + '.and'.length);
       if (!arg) return expression;
+
+      if (
+        isOpaqueRecordMarkerExpression(base, schemaExpressions, markerCache) &&
+        isOpaqueMarkerUnion(arg.body, schemaExpressions, markerCache)
+      ) {
+        const remainder = expression.slice(arg.end);
+        if (remainder.startsWith('.and(')) {
+          const objectArg = scanBalanced(remainder, '.and'.length);
+          const objectShape = objectArg
+            ? schemaShapeForExpression(objectArg.body, schemaExpressions, shapeCache)
+            : undefined;
+          if (objectArg && objectShape) return objectArg.body + remainder.slice(objectArg.end);
+        }
+      }
 
       if (isOpaqueMarkerUnion(base, schemaExpressions, markerCache)) {
         const argShape = schemaShapeForExpression(arg.body, schemaExpressions, shapeCache);
@@ -2068,6 +2119,26 @@ const BACKWARD_COMPAT_SCHEMA_ALIASES: Array<{
   newName: string;
   reason: string;
 }> = [
+  ...Array.from({ length: 12 }, (_, index) => ({
+    oldName: `BrandReference${index + 1}`,
+    newName: 'BrandReference',
+    reason: 'SDK 14 beta exported this numbered codegen compatibility alias.',
+  })),
+  ...(
+    [
+      ['BusinessEntity1', 'BusinessEntity'],
+      ['MeasurementTerms1', 'MeasurementTerms'],
+      ['None1', 'None'],
+      ['None2', 'None'],
+      ['PlatformExtensionReference1', 'PlatformExtensionReference'],
+      ['Product1', 'Product'],
+      ['Property1', 'Property'],
+    ] as const
+  ).map(([oldName, newName]) => ({
+    oldName,
+    newName,
+    reason: 'SDK 14 beta exported this numbered codegen compatibility alias.',
+  })),
   {
     oldName: 'SignalCatalogType',
     newName: 'SignalAvailabilityType',
@@ -2253,6 +2324,7 @@ async function generateZodSchemas() {
     // Run after passthrough normalization so the object arm has its final form.
     zodSchemas = postProcessUnionStringLengthConstraints(zodSchemas);
     zodSchemas = postProcessForecastRangeConstraint(zodSchemas);
+    zodSchemas = postProcessPriceBreakdownConstraints(zodSchemas);
 
     // TypeScript cannot retain JSON Schema `format: uri` or root oneOf
     // exclusivity. Restore both for legacy/canonical creative identity.

--- a/src/lib/media-buy/property-policy.ts
+++ b/src/lib/media-buy/property-policy.ts
@@ -55,7 +55,6 @@ export interface ProductPolicyProductLike {
   id?: unknown;
   publisher_properties?: unknown;
   property_targeting_allowed?: unknown;
-  [key: string]: unknown;
 }
 
 export interface ProductPropertyPolicyIdentifier {

--- a/src/lib/testing/scenarios/media-buy.ts
+++ b/src/lib/testing/scenarios/media-buy.ts
@@ -80,8 +80,8 @@ export function buildCreateMediaBuyRequest(
     accountRef?: AccountReference;
   } = {}
 ): Record<string, unknown> {
-  const minSpendPerPackage = 'min_spend_per_package' in pricingOption ? pricingOption.min_spend_per_package : undefined;
-  const minSpend = typeof minSpendPerPackage === 'number' ? minSpendPerPackage : 0;
+  const configuredMinSpend = 'min_spend_per_package' in pricingOption ? pricingOption.min_spend_per_package : undefined;
+  const minSpend = typeof configuredMinSpend === 'number' ? configuredMinSpend : 0;
   const budget = options.budget || Math.max(1000, minSpend);
   const now = new Date();
   const startTime = new Date(now.getTime() + 24 * 60 * 60 * 1000); // Tomorrow

--- a/src/lib/types/core.generated.ts
+++ b/src/lib/types/core.generated.ts
@@ -1,5 +1,5 @@
 // Generated AdCP core types from official schemas v3.2.0-beta.0
-// Generated at: 2026-08-18T17:22:43.578Z
+// Generated at: 2026-08-18T18:23:32.275Z
 
 // ACCOUNTCURRENCYMODE CANONICAL ENUM
 /**
@@ -1671,8 +1671,6 @@ export type SISessionStatus = 'active' | 'pending_handoff' | 'complete' | 'termi
  * Commercial/provenance types for signals available for audience targeting
  */
 export type SignalAvailabilityType = 'marketplace' | 'custom' | 'owned';
-/** @deprecated AdCP 3.1 renamed SignalCatalogType to SignalAvailabilityType. */
-export type SignalCatalogType = SignalAvailabilityType;
 
 // SIGNALSOURCE CANONICAL ENUM
 /**
@@ -2189,7 +2187,6 @@ export interface ReferenceAsset {
    * Human-readable description of the asset and how it should inform creative generation
    */
   description?: string;
-  [k: string]: unknown | undefined;
 }
 
 // BRANDREFERENCE PRIORITY CANONICAL SCHEMA
@@ -2296,7 +2293,6 @@ export interface ImageAsset {
    */
   alt_text?: string;
   provenance?: Provenance;
-  [k: string]: unknown | undefined;
 }
 /**
  * Provenance metadata for this asset, overrides manifest-level provenance
@@ -3140,7 +3136,6 @@ export interface VendorMetricValue {
    * Optional structured payload for vendor metrics that don't fit a single scalar — panel demographic breakouts, co-view audience composition, incremental reach + frequency + lift decompositions. Free-form; the keys and value semantics are defined by the vendor (see the vendor's `brand.json` measurement-agent docs). Buyers MUST treat this object as opaque without consulting the vendor's documentation. Vendors place any fields beyond the standard envelope (e.g., confidence intervals, panel sizes) inside this object rather than at the top level.
    */
   breakdown?: {
-    [k: string]: unknown | undefined;
   };
 }
 /**
@@ -3282,13 +3277,9 @@ export type ForecastPointDimensions = [
  * A geographic dimension for a ForecastPoint row. Variant of ForecastPoint dimensions; see forecast-point-dimensions.json for dispatch rules.
  */
 export type GeoForecastDimension = {
-  [k: string]: unknown | undefined;
 } & {
-  [k: string]: unknown | undefined;
 } & {
-  [k: string]: unknown | undefined;
 } & {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Dimension family discriminator.
@@ -3316,15 +3307,11 @@ export type GeoForecastDimension = {
  * A signal value or signal-presence dimension for a ForecastPoint row. Variant of ForecastPoint dimensions; see forecast-point-dimensions.json for dispatch rules.
  */
 export type SignalForecastDimension = {
-  [k: string]: unknown | undefined;
 } & {
-  [k: string]: unknown | undefined;
 } & (
     | {
-        [k: string]: unknown | undefined;
       }
     | {
-        [k: string]: unknown | undefined;
       }
   ) & {
     /**
@@ -3366,7 +3353,6 @@ export type SignalRef =
        * Product-local signal identifier. For local signals exposed on both get_signals and get_products, this MUST match get_signals.signals[].signal_ref.signal_id for the same signal.
        */
       signal_id: string;
-      [k: string]: unknown | undefined;
     }
   | {
       /**
@@ -3381,7 +3367,6 @@ export type SignalRef =
        * Signal identifier within the data provider's published adagents.json signals[].
        */
       signal_id: string;
-      [k: string]: unknown | undefined;
     }
   | {
       /**
@@ -3396,7 +3381,6 @@ export type SignalRef =
        * Signal identifier within the issuing signal source's signal set.
        */
       signal_id: string;
-      [k: string]: unknown | undefined;
     };
 /**
  * A forecast value with optional confidence bounds. Either mid (point estimate) or both low and high (range) must be provided. mid represents the most likely outcome. low and high represent conservative and optimistic estimates. All three can be provided together.
@@ -3408,7 +3392,6 @@ export interface ForecastRange {
   mid?: number;
   /** Optimistic (high-end) forecast value. */
   high?: number;
-  [k: string]: unknown | undefined;
 }
 export interface ForecastPoint {
   /**
@@ -3453,21 +3436,15 @@ export interface ForecastPoint {
       /**
        * @maximum 1
        */
-      low?: {
-        [k: string]: unknown | undefined;
-      };
+      low?: number;
       /**
        * @maximum 1
        */
-      mid?: {
-        [k: string]: unknown | undefined;
-      };
+      mid?: number;
       /**
        * @maximum 1
        */
-      high?: {
-        [k: string]: unknown | undefined;
-      };
+      high?: number;
     };
     [k: string]: ForecastRange | undefined;
   };
@@ -3485,21 +3462,15 @@ export interface ForecastPoint {
       /**
        * @maximum 1
        */
-      low?: {
-        [k: string]: unknown | undefined;
-      };
+      low?: number;
       /**
        * @maximum 1
        */
-      mid?: {
-        [k: string]: unknown | undefined;
-      };
+      mid?: number;
       /**
        * @maximum 1
        */
-      high?: {
-        [k: string]: unknown | undefined;
-      };
+      high?: number;
     };
     viewed_seconds?: ForecastRange;
     standard?: ViewabilityStandard;
@@ -3535,7 +3506,6 @@ export interface PlacementReference {
    * Placement ID from the publisher's adagents.json placement catalog, or an inline seller-defined placement ID interpreted within the same publisher namespace.
    */
   placement_id: string;
-  [k: string]: unknown | undefined;
 }
 /**
  * A device form-factor dimension for a ForecastPoint row. Variant of ForecastPoint dimensions; see forecast-point-dimensions.json for dispatch rules.
@@ -3591,7 +3561,6 @@ export interface ForecastVendorMetricValue {
    * Optional structured payload for vendor metrics that do not fit a single scalar. Forecast rows SHOULD use ForecastRange values inside breakdown when sub-values are numeric forecasts. Buyers MUST treat this object as opaque without consulting the vendor's documentation.
    */
   breakdown?: {
-    [k: string]: unknown | undefined;
   };
 }
 // TARGETINGOVERLAYSUPPORT PRIORITY CANONICAL SCHEMA
@@ -4195,7 +4164,6 @@ export interface CancellationPolicy {
  * Buyer-authored execution policy for automatic delivery, auction bidding, average outcome cost, or return on ad spend. The containing object determines authored scope: media-buy `bidding` is a complete inherited default and package `bidding` is a complete package override. Sellers MUST preserve authored scope on readback and MUST NOT copy an inherited media-buy policy into package `bidding`. Every monetary field in this block is denominated in the media-buy currency; the selected pricing option supplies the auction unit, never another denomination. Auction-unit identity is the pricing_model plus every canonical billing-event qualifier after defaults are applied: for example CPV view threshold, CPP demographic system/demographic, CPA event tuple, time time_unit, and flat-rate/DOOH parameters. An extension qualifier participates only when its registered extension specification explicitly defines how it contributes to auction-unit identity. A media-buy bid_amount or max_bid is valid only when every inheriting package resolves the same auction-unit identity. Every affected pricing option MUST use the media-buy currency; split currency-mismatched packages into separate buys. Seller-optimized media-buy cost_per/roas bind to the primary budget_allocation.optimization_goals goal. Package-authored cost_per/roas bind to the package primary optimization goal. The primary goal is the earliest array entry among goals with the lowest explicit numeric priority; unprioritized goals follow explicitly prioritized goals; when all priorities are absent, the first entry is primary. In fixed allocation, an inherited media-buy cost_per is valid only when all inheriting packages have compatible primary-goal result units; inherited roas requires value-bearing primary goals on every inheriting package. Canonical ROAS requires each value-bearing event source to declare the media-buy currency in value_currencies; each buy consumes only exact-currency records and sellers MUST NOT convert them. Absence invokes inheritance or provider automatic delivery; `{automatic:true}` is an explicit authored policy that overrides inheritance. Sellers MUST reject unsupported modes, combinations, units, currency, goal bindings, or native placements before any provider mutation and MUST NOT silently translate semantics.
  */
 export type BiddingPolicy = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Explicitly use seller/provider automatic bidding at this authored scope. At package scope this is a complete override of a media-buy policy, not inheritance. It MUST be the only field in the block and MUST be preserved on readback.
@@ -4240,9 +4208,7 @@ export type BiddingPolicy = {
  * Declares how a field in an external feed maps to the AdCP catalog item schema. Used in sync_catalogs feed_field_mappings to normalize non-AdCP feeds (Google Merchant Center, LinkedIn Jobs XML, hotel XML, etc.) to the standard catalog item schema without requiring the buyer to preprocess every feed. Multiple mappings can assemble a nested object via dot notation (e.g., separate mappings for price.amount and price.currency).
  */
 export type CatalogFieldMapping = {
-  [k: string]: unknown | undefined;
 } & {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Field name in the external feed record. Omit when injecting a static literal value (use the value property instead).
@@ -4260,7 +4226,6 @@ export type CatalogFieldMapping = {
    * Static literal value to inject into catalog_field for every item, regardless of what the feed contains. Mutually exclusive with feed_field. Useful for fields the feed omits (e.g., currency when price is always USD, or a constant category value).
    */
   value?: {
-    [k: string]: unknown | undefined;
   };
   /**
    * Named transform to apply to the feed field value before writing to the catalog schema. See transform-specific parameters (format, timezone, by, separator).
@@ -4286,10 +4251,8 @@ export type CatalogFieldMapping = {
    * Fallback value to use when feed_field is absent, null, or empty. Applied after any transform would have been applied. Allows optional feed fields to have a guaranteed baseline value.
    */
   default?: {
-    [k: string]: unknown | undefined;
   };
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Field name in the external feed record. Omit when injecting a static literal value (use the value property instead).
@@ -4307,7 +4270,6 @@ export type CatalogFieldMapping = {
    * Static literal value to inject into catalog_field for every item, regardless of what the feed contains. Mutually exclusive with feed_field. Useful for fields the feed omits (e.g., currency when price is always USD, or a constant category value).
    */
   value?: {
-    [k: string]: unknown | undefined;
   };
   /**
    * Named transform to apply to the feed field value before writing to the catalog schema. See transform-specific parameters (format, timezone, by, separator).
@@ -4333,10 +4295,8 @@ export type CatalogFieldMapping = {
    * Fallback value to use when feed_field is absent, null, or empty. Applied after any transform would have been applied. Allows optional feed fields to have a guaranteed baseline value.
    */
   default?: {
-    [k: string]: unknown | undefined;
   };
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 };
 /**
  * A single objective function: what to maximize or optimize, in what units, and in what priority order. Used on packages to optimize delivery within one package and on seller-optimized budget allocations to allocate spend across packages. Currency-bearing execution policy belongs in BiddingPolicy in 3.2. Legacy target.cost_per and target.per_ad_spend remain accepted only on package goals for migration and are deprecated. The primary goal is the earliest array entry among goals with the lowest explicit numeric priority; goals without priority follow all explicitly prioritized goals; when all priorities are omitted, the first entry is primary. This array-order tie-break makes duplicate priorities deterministic.
@@ -4367,7 +4327,6 @@ export type OptimizationGoal =
        * Target frequency band for reach optimization. Only applicable when metric is 'reach'. Frames frequency as an optimization signal: the seller should treat impressions toward entities already within the [min, max] band as lower-value, and impressions toward unreached entities as higher-value. This shifts budget toward fresh reach rather than re-reaching known users. When omitted, the seller maximizes unique reach without a frequency constraint. A hard cap can still be layered via targeting_overlay.frequency_cap if a ceiling is needed.
        */
       target_frequency?: {
-        [k: string]: unknown | undefined;
       };
       /**
        * Minimum video view duration in seconds that qualifies as a completed_view for this goal. Only applicable when metric is 'completed_views'. When omitted, the seller uses their platform default (typically 2–15 seconds). Common values: 2 (Snap/LinkedIn default), 6 (TikTok), 15 (Snap 15-second views, Meta ThruPlay). Sellers declare which durations they support in metric_optimization.supported_view_durations. Sellers must reject goals with unsupported values — silent rounding would create measurement discrepancies.
@@ -4383,7 +4342,6 @@ export type OptimizationGoal =
              * Target cost per metric unit in the buy currency
              */
             value: number;
-            [k: string]: unknown | undefined;
           }
         | {
             kind: 'threshold_rate';
@@ -4391,13 +4349,11 @@ export type OptimizationGoal =
              * Minimum per-impression value. Units depend on the metric: proportion (clicks, views, completed_views), seconds (viewed_seconds, attention_seconds), or score (attention_score).
              */
             value: number;
-            [k: string]: unknown | undefined;
           };
       /**
        * Relative priority among sibling goals. Lower numbers rank first. Goals without priority follow explicitly prioritized goals. Ties use array order, so the earliest goal at the lowest explicit priority is primary; when all priorities are omitted, the first goal is primary.
        */
       priority?: number;
-      [k: string]: unknown | undefined;
     }
   | {
       kind: 'event';
@@ -4425,7 +4381,6 @@ export type OptimizationGoal =
            * Unit-scaling multiplier the seller must apply to value_field before aggregation. Use -1 for refund events (negate the value), 0.01 for values in cents, -0.01 for refunds in cents. It MUST NOT be used for currency conversion. A value of 0 zeroes out this source's value contribution (the source still counts for event dedup). Defaults to 1. This is not passed as a parameter to underlying platform APIs — the seller applies it when computing aggregated value metrics.
            */
           value_factor?: number;
-          [k: string]: unknown | undefined;
         },
         ...{
           /**
@@ -4445,7 +4400,6 @@ export type OptimizationGoal =
            * Unit-scaling multiplier the seller must apply to value_field before aggregation. Use -1 for refund events (negate the value), 0.01 for values in cents, -0.01 for refunds in cents. It MUST NOT be used for currency conversion. A value of 0 zeroes out this source's value contribution (the source still counts for event dedup). Defaults to 1. This is not passed as a parameter to underlying platform APIs — the seller applies it when computing aggregated value metrics.
            */
           value_factor?: number;
-          [k: string]: unknown | undefined;
         }[]
       ];
       /**
@@ -4458,7 +4412,6 @@ export type OptimizationGoal =
              * Target cost per event in the buy currency
              */
             value: number;
-            [k: string]: unknown | undefined;
           }
         | {
             kind: 'per_ad_spend';
@@ -4466,11 +4419,9 @@ export type OptimizationGoal =
              * Target return ratio (e.g., 4.0 means $4 of value per $1 spent)
              */
             value: number;
-            [k: string]: unknown | undefined;
           }
         | {
             kind: 'maximize_value';
-            [k: string]: unknown | undefined;
           };
       /**
        * Attribution window for this optimization goal — references the canonical `attribution-window` shape (post_click, post_view, model). Values must match an option declared in the seller's `conversion_tracking.attribution_windows` capability. Sellers MUST reject windows not in their declared capabilities. When the entire field is omitted, the seller uses their default window.
@@ -4480,7 +4431,6 @@ export type OptimizationGoal =
        * Relative priority among sibling goals. Lower numbers rank first. Goals without priority follow explicitly prioritized goals. Ties use array order, so the earliest goal at the lowest explicit priority is primary; when all priorities are omitted, the first goal is primary.
        */
       priority?: number;
-      [k: string]: unknown | undefined;
     }
   | {
       kind: 'vendor_metric';
@@ -4496,7 +4446,6 @@ export type OptimizationGoal =
              * Target cost per metric unit in the buy currency. Units of the metric are vendor-defined.
              */
             value: number;
-            [k: string]: unknown | undefined;
           }
         | {
             kind: 'threshold_rate';
@@ -4504,19 +4453,16 @@ export type OptimizationGoal =
              * Minimum per-impression value. Units of the metric are vendor-defined.
              */
             value: number;
-            [k: string]: unknown | undefined;
           };
       /**
        * Relative priority among sibling goals. Lower numbers rank first. Goals without priority follow explicitly prioritized goals. Ties use array order, so the earliest goal at the lowest explicit priority is primary; when all priorities are omitted, the first goal is primary.
        */
       priority?: number;
-      [k: string]: unknown | undefined;
     };
 /**
  * Complete effective targeting overlay to apply to this package. On update, this replaces the package's current effective targeting, including values originally accepted through configured-product selection; omit the field to leave targeting unchanged. Every replacement must remain executable by the product. Sellers reject unsupported or partially applicable changes and use REQUOTE_REQUIRED when a change, including a broader inventory set, falls outside the priced envelope. placement_selection is purchased-inventory targeting; mode default restores the product default, and successful readback echoes the committed selected set when enumerable. If the replacement removes a placement referenced by an existing creative assignment, the seller MUST reject the update unless the same atomic package mutation supplies a compatible complete creative_assignments replacement. Sellers MUST NOT silently delete assignments or retain orphan placement refs.
  */
 export type TargetingOverlay = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Restrict delivery to specific countries. ISO 3166-1 alpha-2 codes (e.g., 'US', 'GB', 'DE').
@@ -4737,7 +4683,6 @@ export type TargetingOverlay = {
        * @minItems 1
        */
       catchment_ids?: [string, ...string[]];
-      [k: string]: unknown | undefined;
     },
     ...{
       /**
@@ -4756,7 +4701,6 @@ export type TargetingOverlay = {
        * @minItems 1
        */
       catchment_ids?: [string, ...string[]];
-      [k: string]: unknown | undefined;
     }[]
   ];
   /**
@@ -4767,24 +4711,18 @@ export type TargetingOverlay = {
   geo_proximity?: [
     (
       | {
-          [k: string]: unknown | undefined;
         }
       | {
-          [k: string]: unknown | undefined;
         }
       | {
-          [k: string]: unknown | undefined;
         }
     ),
     ...(
       | {
-          [k: string]: unknown | undefined;
         }
       | {
-          [k: string]: unknown | undefined;
         }
       | {
-          [k: string]: unknown | undefined;
         }
     )[]
   ];
@@ -4844,7 +4782,6 @@ export type TargetingOverlay = {
       match_type: MatchType;
     }[]
   ];
-  [k: string]: unknown | undefined;
 };
 /**
  * Postal area values. Prefer the native country + postal system form. Deprecated legacy country-fused postal-system tokens remain accepted for compatibility.
@@ -4893,7 +4830,6 @@ export type PostalCountrySystem = (
     }
   | {
       country?: {
-        [k: string]: unknown | undefined;
       };
       system?: 'postal_code' | 'custom';
     }
@@ -4908,7 +4844,6 @@ export type PostalCountrySystem = (
  * A catalog-backed named place target. Values are stable identifiers in the declared system. Entries within geo_places form a union; different geographic inclusion dimensions intersect. value_labels are diagnostic only and MUST NOT be used to resolve targeting.
  */
 export type GeographicPlaceArea = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * ISO 3166-1 alpha-2 country code containing the place.
@@ -4975,7 +4910,6 @@ export type PackageSignalTargeting = SignalTargetingExpression & {
    */
   signal_agent_segment_id?: string;
   activation_key?: ActivationKey;
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Pricing option selected for this signal. Use the pricing_option_id from the product's signal_targeting_options entry when product-scoped pricing is present; otherwise use the seller get_signals pricing only when the product option does not override it. Required when the selected signal has pricing_options; omit only when the signal is bundled into the product price or has no incremental cost.
@@ -4986,7 +4920,6 @@ export type PackageSignalTargeting = SignalTargetingExpression & {
    */
   signal_agent_segment_id?: string;
   activation_key?: ActivationKey;
-  [k: string]: unknown | undefined;
 };
 /**
  * Predicate over a named signal definition. Signals are typed dimensions, similar to feature values: binary signals match true, categorical signals match one of a set of values, and numeric signals match a range. In package signal targeting groups, include/exclude semantics are controlled by the parent group operator, not by negating the expression.
@@ -5002,7 +4935,6 @@ export type SignalTargetingExpression =
        * Binary package signal entries match users for whom the signal is true. Use the parent group operator for include/exclude.
        */
       value: true;
-      [k: string]: unknown | undefined;
     }
   | {
       signal_ref: SignalRef;
@@ -5016,14 +4948,11 @@ export type SignalTargetingExpression =
        * @minItems 1
        */
       values: [string, ...string[]];
-      [k: string]: unknown | undefined;
     }
   | (
       | {
-          [k: string]: unknown | undefined;
         }
       | {
-          [k: string]: unknown | undefined;
         }
     );
 /**
@@ -5039,7 +4968,6 @@ export type ActivationKey =
        * The platform-specific segment identifier to use in campaign targeting
        */
       segment_id: string;
-      [k: string]: unknown | undefined;
     }
   | {
       /**
@@ -5054,7 +4982,6 @@ export type ActivationKey =
        * The targeting parameter value
        */
       value: string;
-      [k: string]: unknown | undefined;
     };
 /**
  * Targeting constraint for a specific signal. Uses value_type as discriminator to determine the targeting expression format.
@@ -5062,33 +4989,26 @@ export type ActivationKey =
 export type SignalTargeting =
   | (
       | {
-          [k: string]: unknown | undefined;
         }
       | {
-          [k: string]: unknown | undefined;
         }
     )
   | (
       | {
-          [k: string]: unknown | undefined;
         }
       | {
-          [k: string]: unknown | undefined;
         }
     )
   | (
       | {
-          [k: string]: unknown | undefined;
         }
       | {
-          [k: string]: unknown | undefined;
         }
     );
 /**
  * A canonical audience-age predicate in completed integer years. min and max are inclusive; omitting one bound means no restriction in that direction. At least one bound is required. include_unknown is always explicit because people whose age is unavailable are not members of any numeric interval. Implementations MUST reject min greater than max; JSON Schema draft-07 cannot compare sibling numeric values.
  */
 export type DemographicAgeRange = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Inclusive minimum age in completed years. Omit for an open lower bound.
@@ -5102,13 +5022,11 @@ export type DemographicAgeRange = {
    * Whether delivery to people whose age is unavailable is part of this predicate. This field has no default and MUST be supplied.
    */
   include_unknown: boolean;
-  [k: string]: unknown | undefined;
 };
 /**
  * Frequency capping settings for package-level application. Two types of frequency control can be used independently or together: suppress enforces a cooldown between consecutive exposures; max_impressions + per + window caps total exposures per entity in a time window. When both suppress and max_impressions are set, an impression is delivered only if both constraints permit it (AND semantics). At least one of suppress, suppress_minutes, or max_impressions must be set.
  */
 export type FrequencyCap = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Cooldown period between consecutive exposures to the same entity. Prevents back-to-back ad delivery (e.g. {"interval": 60, "unit": "minutes"} for a 1-hour cooldown). Preferred over suppress_minutes.
@@ -5131,7 +5049,6 @@ export type FrequencyCap = {
    * Time window for the max_impressions cap (e.g. {"interval": 7, "unit": "days"} or {"interval": 1, "unit": "campaign"} for the full flight). Required when max_impressions is set.
    */
   window?: Duration;
-  [k: string]: unknown | undefined;
 };
 /**
  * Purchased placement selection within the product. This constrains package inventory; it is distinct from creative_assignments[].placement_refs, which only route individual creatives within the purchased set. On create, mode selected supplies the complete selected set and mode default uses the product default. On update, the surrounding targeting_overlay replacement semantics apply.
@@ -5145,7 +5062,6 @@ export type LanguageTag = string;
  * Assignment of a creative asset to a package with optional rotation and placement routing. Used in create_media_buy and update_media_buy requests. Buyers identify the stored creative with `creative_id` only. A generic `id` alias, if present due to adapter-internal payload reuse, is not an AdCP identifier and sellers MUST ignore it on input. Note: sync_creatives does not support package rotation, placement_refs, or placement_ids - use create/update_media_buy for package-level trafficking controls.
  */
 export type CreativeAssignment = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Unique identifier for the creative
@@ -5180,7 +5096,6 @@ export type CreativeAssignment = {
    * @minItems 1
    */
   placement_ids?: [string, ...string[]];
-  [k: string]: unknown | undefined;
 };
 /**
  * Creative asset for upload to library — supports static assets, generative formats, and third-party snippets. Identifies which format this creative conforms to via EITHER a legacy `format_id` (structured `{agent_url, id}`) OR a 3.1+ `format_kind` (canonical format name), with optional `format_option_ref` when the target product needs disambiguation. Mutually exclusive — see the `oneOf` at the schema root.
@@ -5201,7 +5116,7 @@ export type CreativeAsset = {
    * Assets required by the format, keyed by asset_id or canonical asset_group_id. Each slot value is either a single asset object or an array of asset objects (for slots with `min`/`max > 1` like carousel `cards` or responsive_creative `headlines`). Each asset value carries an `asset_type` discriminator that selects the matching asset schema, including reference assets such as `published_post` when a product accepts already-published post references.
    */
   assets: {
-    [k: string]: unknown | undefined;
+    [k: string]: AssetVariant | AssetVariant[];
   };
   /**
    * Preview contexts for generative formats - defines what scenarios to generate previews for
@@ -5221,7 +5136,6 @@ export type CreativeAsset = {
      * Natural language description of the context for AI-generated content
      */
     context_description?: string;
-    [k: string]: unknown | undefined;
   }[];
   /**
    * User-defined tags for organization and searchability
@@ -5256,7 +5170,6 @@ export type CreativeAsset = {
    * @minItems 1
    */
   rights?: [RightsConstraint, ...RightsConstraint[]];
-  [k: string]: unknown | undefined;
 } & (V1CreativeNamedFormatReference | V2CreativeCanonicalFormatKind);
 /**
  * Canonical format name this creative targets (e.g., `image`, `video_hosted`). Mutually exclusive with deprecated `format_id`.
@@ -5333,7 +5246,6 @@ export type VASTAsset = {
    */
   audio_description_url?: string;
   provenance?: Provenance;
-  [k: string]: unknown | undefined;
 } & (
   | {
       /**
@@ -5382,7 +5294,6 @@ export type DAASTAsset = {
    */
   transcript_url?: string;
   provenance?: Provenance;
-  [k: string]: unknown | undefined;
 } & (
   | {
       /**
@@ -5427,7 +5338,6 @@ export type CatalogAsset = Catalog & {
  * Reference to an already-published post on a publisher, creator, or social platform. The buyer supplies a reference to the existing post; the seller resolves, authorizes, reviews, and serves the referenced post according to the target product's format declaration. This asset is for post references, not uploaded bytes and not catalog rows.
  */
 export type PublishedPostAsset = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Discriminator identifying this as a published-post reference asset. See /schemas/creative/asset-types for the registry.
@@ -5461,7 +5371,6 @@ export type PublishedPostAsset = {
      * Opaque platform-native identity identifier.
      */
     platform_identity_id?: string;
-    [k: string]: unknown | undefined;
   };
   /**
    * When the referenced post was originally published, if known.
@@ -5491,10 +5400,8 @@ export type PublishedPostAsset = {
      * Human-readable instructions for completing or restoring authorization.
      */
     authorization_instructions?: string;
-    [k: string]: unknown | undefined;
   };
   provenance?: Provenance;
-  [k: string]: unknown | undefined;
 };
 /**
  * A single renderer-fired HTTP tracker URL — image pixel or JavaScript include — bound to a measurement event (impression, viewability, click, custom). Generic web-pixel tracker primitive applicable to any web-rendered canonical format (image, html5, image_carousel, responsive_creative, sponsored_placement, native_*, plus the non-VAST/DAAST events of video_hosted and audio_hosted). The buyer's measurement vendor declares the tracker URL; the seller's renderer fires it at serve time without buyer-side involvement.
@@ -5541,7 +5448,6 @@ export type PublishedPostAsset = {
  * All v1→v2 upgrades surface `PIXEL_TRACKER_UPGRADE_INFERRED` so consumers can see that event/method were inferred rather than explicitly declared.
  */
 export type PixelTrackerAsset = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Discriminator identifying this as a renderer-fired pixel tracker asset. See /schemas/creative/asset-types for the registry.
@@ -5582,13 +5488,11 @@ export type PixelTrackerAsset = {
    */
   custom_event_name?: string;
   provenance?: Provenance;
-  [k: string]: unknown | undefined;
 };
 /**
  * A single tracker URL bound to a VAST `TrackingEvents` event. Emitted by the creative agent as a decomposed VAST-event URL; the sales agent assembles these into the VAST `TrackingEvents` block at serve time. IMPORTANT: this asset type is for `TrackingEvents` URLs only (start, quartiles, complete, pause, mute, etc.). The `Impression` URL MUST be modeled as a `url` asset with `url_type: "tracker_pixel"`, not as a vast_tracker with `vast_event: "impression"`. Decomposed trackers let format requirements bind specific measurement events (e.g., MRC viewable) without forcing the buyer to construct a full VAST tag.
  */
 export type VASTTrackerAsset = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Discriminator identifying this as a VAST tracker asset. See /schemas/creative/asset-types for the registry.
@@ -5598,7 +5502,6 @@ export type VASTTrackerAsset = {
    * The VAST tracking event this URL fires on. Maps 1:1 to the VAST `Tracking event="..."` attribute inside `TrackingEvents`. MUST NOT be `impression` (belongs in the VAST `Impression` element — model as a `url` asset with `url_type: "tracker_pixel"`), `clickTracking` / `customClick` (belong in `VideoClicks`), `error` (VAST `Error` element), or any of `viewable` / `notViewable` / `viewUndetermined` / `measurableImpression` / `viewableImpression` (children of the VAST `ViewableImpression` element, not `TrackingEvents`).
    */
   vast_event: VASTTrackingEvent & {
-    [k: string]: unknown | undefined;
   };
   /**
    * Tracker URL that fires when `vast_event` occurs. May carry AdCP universal macros (e.g., `{SKU}`, `{MEDIA_BUY_ID}`); the sales agent or ad server URL-encodes substituted values at serve time. See docs/creative/universal-macros.mdx.
@@ -5613,13 +5516,11 @@ export type VASTTrackerAsset = {
    */
   target?: 'linear' | 'non_linear' | 'companion';
   provenance?: Provenance;
-  [k: string]: unknown | undefined;
 };
 /**
  * A single tracker URL bound to a DAAST `TrackingEvents` event. Audio-side analogue of vast-tracker-asset. The `Impression` URL MUST be modeled as a `url` asset with `url_type: "tracker_pixel"`, not as a daast_tracker with `daast_event: "impression"`.
  */
 export type DAASTTrackerAsset = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Discriminator identifying this as a DAAST tracker asset. See /schemas/creative/asset-types for the registry.
@@ -5629,7 +5530,6 @@ export type DAASTTrackerAsset = {
    * The DAAST tracking event this URL fires on. MUST NOT be `impression` (model as `url` asset with `url_type: "tracker_pixel"`), `clickTracking` / `customClick` (click-tracking trackers go on their own URL asset), `error`, or any of the `ViewableImpression`-element children (`viewable`, `notViewable`, `viewUndetermined`, `measurableImpression`, `viewableImpression`).
    */
   daast_event: DAASTTrackingEvent & {
-    [k: string]: unknown | undefined;
   };
   /**
    * Tracker URL that fires when `daast_event` occurs. May carry AdCP universal macros; the sales agent or ad server URL-encodes substituted values at serve time. See docs/creative/universal-macros.mdx.
@@ -5644,13 +5544,11 @@ export type DAASTTrackerAsset = {
    */
   target?: 'linear' | 'companion';
   provenance?: Provenance;
-  [k: string]: unknown | undefined;
 };
 /**
  * Rights metadata attached to a creative. Each entry represents constraints from a single rights holder. Buyer-carried fields are a presentation, not authorization. In AdCP 3.2, a serving party treats a constraint as machine-verified only after one attestation_refs entry evaluates to verified under its own adcp.attestations policy and matches the complete digest-pinned grant.
  */
 export type RightsConstraint = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Rights grant identifier from the acquire_rights response
@@ -5715,7 +5613,6 @@ export type RightsConstraint = {
    * Disclosure obligation issued with the grant and bound by content_digest.
    */
   disclosure?: {
-    [k: string]: unknown | undefined;
   };
   /**
    * Whether each creative produced under this grant requires holder approval before distribution. This enforceable term is bound by content_digest.
@@ -5856,7 +5753,6 @@ export type RightsConstraint = {
         }
       ];
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Rights grant identifier from the acquire_rights response
@@ -5921,7 +5817,6 @@ export type RightsConstraint = {
    * Disclosure obligation issued with the grant and bound by content_digest.
    */
   disclosure?: {
-    [k: string]: unknown | undefined;
   };
   /**
    * Whether each creative produced under this grant requires holder approval before distribution. This enforceable term is bound by content_digest.
@@ -6062,19 +5957,15 @@ export type RightsConstraint = {
         }
       ];
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 };
 /**
  * Portable, reference-first presentation of an independently issued claim. It identifies the claimed issuer, claim vocabulary, subject, and either a stable credential locator or an embedded credential. A presentation is a locator and claim hint, not proof or a trust decision. The evaluator remains verifier-of-record and MUST resolve or inspect the credential only under its published attestation capabilities and local trust policy.
  */
 export type AttestationReference = {
-  [k: string]: unknown | undefined;
 } & (
   | {
-      [k: string]: unknown | undefined;
     }
   | {
-      [k: string]: unknown | undefined;
     }
 ) & {
     issuer: AttestationIssuer;
@@ -6328,7 +6219,6 @@ export interface Catalog {
    * @minItems 1
    */
   feed_field_mappings?: [CatalogFieldMapping, ...CatalogFieldMapping[]];
-  [k: string]: unknown | undefined;
 }
 /**
  * Describes the attribution methodology and lookback windows used for conversion measurement. Enables cross-platform comparison by making attribution methodology transparent. Used as a `$ref` from `optimization-goal.json` (buyer's optimization-time attribution choice), `get-media-buy-delivery-response.json` (seller-declared attribution methodology in delivery reports), and similar surfaces. All fields are optional individually but at least one of `post_click`, `post_view`, or `model` SHOULD be populated; absence of `model` means the seller's default attribution model applies (typically `last_touch` per industry convention) — sellers SHOULD populate `model` explicitly when committing to a specific methodology.
@@ -6343,7 +6233,6 @@ export interface AttributionWindow {
    */
   post_view?: Duration;
   model?: AttributionModel;
-  [k: string]: unknown | undefined;
 }
 /**
  * @deprecated
@@ -6394,7 +6283,6 @@ export interface PackageSignalTargetingGroups {
    * @minItems 1
    */
   groups: [PackageSignalTargetingGroup, ...PackageSignalTargetingGroup[]];
-  [k: string]: unknown | undefined;
 }
 /**
  * A basic Boolean group of package-level signal targeting entries. 'any' means the user must match at least one signal in the group. 'none' means the user must match none of the signals in the group. Use groups for portable include/exclude composition such as (A OR B) AND NOT (C OR D).
@@ -6410,16 +6298,13 @@ export interface PackageSignalTargetingGroup {
    * @minItems 1
    */
   signals: [PackageSignalTargeting, ...PackageSignalTargeting[]];
-  [k: string]: unknown | undefined;
 }
 /**
  * Canonical demographic audience targeting intent with optional constraints on how age may be determined. This is distinct from age_restriction: demographics selects an audience, while age_restriction expresses a legal eligibility or verification floor. Fresh create/update targeting MUST compile exactly or be rejected. During get_products, a seller may offer a different configured predicate only through sparse targeting_resolution modifications on a distinguishable product_id; selecting that product accepts the alternative. Sellers never silently broaden, narrow, default, drop, or substitute the basis.
  */
 export interface DemographicTargetingIntent {
   age: DemographicAgeRange & {
-    [k: string]: unknown | undefined;
   };
-  [k: string]: unknown | undefined;
 }
 /**
  * Reference to a property list for targeting specific properties within this product. The package runs on the intersection of the product's publisher_properties and this list. Sellers SHOULD return a validation error if the product has property_targeting_allowed: false.
@@ -6464,10 +6349,8 @@ export interface SelectedPlacements {
    */
   placement_refs: [
     PlacementReference & {
-      [k: string]: unknown | undefined;
     },
     ...(PlacementReference & {
-      [k: string]: unknown | undefined;
     })[]
   ];
   ext?: ExtensionObject;
@@ -6505,7 +6388,6 @@ export interface FormatReferenceStructuredObject {
    * Required intrinsic-pixel density for a parameterized visual format, expressed as intrinsic pixels per logical pixel. Requires `width` and `height`. Example: `{id: "display_image", width: 300, height: 250, pixel_ratio: 2}` identifies a 300×250 logical render supplied by a 600×500 image. Omit for the backward-compatible 1x variant.
    */
   pixel_ratio?: number;
-  [k: string]: unknown | undefined;
 }
 /**
  * Selects a publisher-catalog-backed product format option by publisher domain and format option ID.
@@ -6523,7 +6405,6 @@ export interface PublisherCatalogFormatOptionReference {
    * Stable format option ID from the publisher's adagents.json top-level `formats[]`, matching a publisher-catalog-backed entry in the target product's `format_options[]`.
    */
   format_option_id: string;
-  [k: string]: unknown | undefined;
 }
 /**
  * Selects a product-local format option by ID within the enclosing package/product context. This branch deliberately forbids `publisher_domain` (`publisher_domain: false` in the schema) because product-local references are namespaced by the enclosing product only; include `scope: "publisher"` when the selector must cross into a publisher catalog.
@@ -6538,7 +6419,6 @@ export interface ProductLocalFormatOptionReference {
    */
   format_option_id: string;
   publisher_domain?: never;
-  [k: string]: unknown | undefined;
 }
 /**
  * A hosted video file delivered directly (e.g., an MP4 you host), with URL and technical specifications including audio track properties. `width` and `height` are required because a hosted video file has intrinsic, native pixel dimensions that are known when the file is created. Tag-delivered video uses the separate `vast` asset, which carries no `width`/`height`: a VAST response resolves geometry per-`MediaFile` at serve time, so there is no single width/height for the ad. Aspect-ratio and size *constraints* (what a placement accepts) belong on the format/requirements layer, not on the asset.
@@ -6650,7 +6530,6 @@ export interface VideoAsset {
    */
   audio_description_url?: string;
   provenance?: Provenance;
-  [k: string]: unknown | undefined;
 }
 /**
  * Audio asset with URL and technical specifications
@@ -6706,7 +6585,6 @@ export interface AudioAsset {
    */
   transcript_url?: string;
   provenance?: Provenance;
-  [k: string]: unknown | undefined;
 }
 /**
  * Text content asset
@@ -6725,7 +6603,6 @@ export interface TextAsset {
    */
   language?: string;
   provenance?: Provenance;
-  [k: string]: unknown | undefined;
 }
 /**
  * URL reference asset. `url_type` declares the mechanism a receiver uses to invoke the URL (clickthrough vs. tracker_pixel vs. tracker_script) and is distinct from the URL's purpose, which the format declares in `url-asset-requirements.role` (clickthrough, landing_page, impression_tracker, click_tracker, viewability_tracker, third_party_tracker). Senders SHOULD include `url_type` on every URL asset. When `url_type` is absent, receivers SHOULD fall back to the format's `url-asset-requirements.role` per this mapping: clickthrough/landing_page → `clickthrough`; impression_tracker/click_tracker → `tracker_pixel`; viewability_tracker → `tracker_script` (OMID and equivalent verification SDKs require a <script> tag — firing them as a pixel produces no measurement); third_party_tracker → no safe fallback (mechanism is integration-specific — DV/IAS ship both pixel and script forms — receivers MAY reject or warn). When neither `url_type` nor a format-side `role` is available, receivers MUST NOT silently pick a mechanism; they SHOULD reject the manifest. Note: VAST/DAAST tag URLs are not URL assets — use `asset_type: "vast"` (or the dedicated tracker types pending RFC #2915), not `asset_type: "url"` with a tracker_pixel mechanism.
@@ -6745,7 +6622,6 @@ export interface URLAsset {
    */
   description?: string;
   provenance?: Provenance;
-  [k: string]: unknown | undefined;
 }
 /**
  * Inline HTML content asset. For URL-delivered HTML5 banner bundles, use the zip asset type instead. For single-URL iframe-rendered tag references, use the url asset type with an appropriate url_type.
@@ -6785,7 +6661,6 @@ export interface HTMLAsset {
     screen_reader_tested?: boolean;
   };
   provenance?: Provenance;
-  [k: string]: unknown | undefined;
 }
 /**
  * Inline JavaScript content asset. For URL-delivered third-party tag scripts, use the url asset type with url_type 'tracker_script'. For HTML5 banner bundles that include JavaScript, use the zip asset type.
@@ -6822,7 +6697,6 @@ export interface JavaScriptAsset {
     screen_reader_tested?: boolean;
   };
   provenance?: Provenance;
-  [k: string]: unknown | undefined;
 }
 /**
  * Bundled creative asset delivered as a zip archive — typically an HTML5 banner with index.html plus supporting CSS, JS, images, and fonts. Receivers unpack the zip, validate internal structure, and serve contents from CDN. Distinct from inline HTML (html asset) and from third-party tag URLs (url asset with url_type tracker_script).
@@ -6878,7 +6752,6 @@ export interface ZipAsset {
     screen_reader_tested?: boolean;
   };
   provenance?: Provenance;
-  [k: string]: unknown | undefined;
 }
 /**
  * Webhook for server-side dynamic content rendering (DCO)
@@ -6921,7 +6794,6 @@ export interface WebhookAsset {
     api_key_header?: string;
   };
   provenance?: Provenance;
-  [k: string]: unknown | undefined;
 }
 /**
  * CSS stylesheet asset
@@ -6940,7 +6812,6 @@ export interface CSSAsset {
    */
   media?: string;
   provenance?: Provenance;
-  [k: string]: unknown | undefined;
 }
 /**
  * Markdown-formatted text content following CommonMark specification
@@ -6963,7 +6834,6 @@ export interface MarkdownAsset {
    * Whether raw HTML blocks are allowed in the markdown. False recommended for security.
    */
   allow_raw_html?: boolean;
-  [k: string]: unknown | undefined;
 }
 /**
  * A single card in a multi-card creative (image_carousel, future composed carousels). Carries: `media` (an image OR video asset), optional `headline` (short text), optional `description` (longer text), optional `cta` (call-to-action label), optional `landing_page_url` (url asset with `url_type: "clickthrough"`).
@@ -6999,7 +6869,6 @@ export interface CardAsset {
    */
   platform_extensions?: PlatformExtensionReference[];
   provenance?: Provenance;
-  [k: string]: unknown | undefined;
 }
 /**
  * An industry-standard or market-specific identifier for an advertising creative (e.g., Ad-ID, ISCI, Clearcast clock number, IDcrea). These identifiers are managed by external registries or clearance bodies and used across the supply chain to track and reference specific creative assets. Add a PR to extend creative-identifier-type when another shared identifier scheme needs first-class support.
@@ -7010,7 +6879,6 @@ export interface IndustryIdentifier {
    * The identifier value (e.g., 'ABCD1234000H' for Ad-ID). Preserve the value exactly as the traffic or clearance system expects it.
    */
   value: string;
-  [k: string]: unknown | undefined;
 }
 export interface AttestationBrandIssuer {
   /**
@@ -7112,19 +6980,16 @@ export interface AttestationIssuerCredentialIdLocator {
  * Deprecated 3.x compatibility branch using a structured named-format reference.
  */
 export interface V1CreativeNamedFormatReference {
-  [k: string]: unknown | undefined;
 }
 /**
  * Creative declares the portable canonical contract it targets via `format_kind` and optional `format_option_ref`.
  */
 export interface V2CreativeCanonicalFormatKind {
-  [k: string]: unknown | undefined;
 }
 /**
  * Opaque correlation data that is echoed unchanged in responses. Used for internal tracking, UI session IDs, trace IDs, and other caller-specific identifiers that don't affect protocol behavior. Context data is never parsed by AdCP agents - it's simply preserved and returned.
  */
 export interface ContextObject {
-  [k: string]: unknown | undefined;
 }
 
 // SCOPEDCREATIVEAPPROVAL PRIORITY CANONICAL SCHEMA
@@ -7151,7 +7016,6 @@ export interface IndicatorScope {
    * Optional placement ID within publisher_domain. Omit to scope the assertion or evaluation to all delivery for the publisher in the enclosing object.
    */
   placement_id?: string;
-  [k: string]: unknown | undefined;
 }
 
 // WARNINGAFFECTEDRESOURCE PRIORITY CANONICAL SCHEMA
@@ -7427,7 +7291,6 @@ export type SizeModeMutex = Fixed | MultiSize | Responsive | None;
  * A seller/platform-side connection or grant required by a product, format, or request. This is not the AdCP caller credential: the AdCP request is still authenticated once, and the seller uses these stored downstream connections to call a platform or service on the buyer's behalf. Use this shape for platforms that require more than one downstream grant, such as an advertiser account connection plus a publisher identity or post authorization for published-post references.
  */
 export type DownstreamConnectionRequirement = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Stable provider or platform namespace, preferably lowercase. Examples: `social.example`, `shortvideo.example`, or a seller-defined namespace. Omit only when the requirement is provider-agnostic, or when an `authorization_url` fully routes the human to the correct provider-specific connection flow.
@@ -7481,7 +7344,6 @@ export type DownstreamConnectionRequirement = {
      * Public URL for the referenced post, when available.
      */
     post_url?: string;
-    [k: string]: unknown | undefined;
   };
   /**
    * Seller-hosted or provider-hosted URL where a human can complete or restore this downstream connection.
@@ -7495,7 +7357,6 @@ export type DownstreamConnectionRequirement = {
    * Expiration time for the downstream grant, when known.
    */
   expires_at?: string;
-  [k: string]: unknown | undefined;
 };
 
 export interface Fixed {
@@ -10148,7 +10009,6 @@ export interface Error {
        */
       value: string | number | boolean | null;
     }[];
-    [k: string]: unknown | undefined;
   }[];
   /**
    * Additional task-specific error details. Sellers MAY mirror `issues[]` here as `details.issues` for backward compatibility with pre-3.1 consumers reading from `details`; new consumers SHOULD prefer the top-level `issues` field.
@@ -10173,7 +10033,6 @@ export interface Error {
    * This is **SHOULD-level guidance**, not MUST: `details` remains `additionalProperties: true` and pre-3.1 sellers using `available` / `allowed` / `accepted_values` at the error root remain conformant. The canonical shape lets buyer-side diagnostic tooling (SDK runner hints, dashboards, error classifiers) reliably surface the accepted-set without per-seller pattern matching. SDKs SHOULD accept any of the legacy variants and normalize on read; the canonical shape is what new sellers and 3.1+ adopters should emit going forward.
    */
   details?: {
-    [k: string]: unknown | undefined;
   };
   /**
    * Agent recovery classification. transient: retry after delay (rate limit, service unavailable, timeout). correctable: fix the request and resend (invalid field, budget too low, creative rejected). terminal: requires human action (account suspended, payment required, account not found). Senders SHOULD populate `recovery` on every error from 3.1 onward — it is the normative carrier of recovery semantics across version skew. A receiver that does not recognize `error.code` (a newer code, or a platform-specific code) MUST still be able to classify the error from `recovery`. The `enumMetadata.recovery` block in `enums/error-code.json` is the documentary mirror for known codes; `error.recovery` on the wire is authoritative.
@@ -10191,7 +10050,6 @@ export interface Error {
    * Optional identifier for the SDK that augmented this error entry. Format: `<sdk_package_name>@<version>` (e.g., `@adcontextprotocol/adcp@7.3.0`, `adcontextprotocol-adcp-python@1.2.0`). MUST be set when `source: "sdk"`; MUST be absent when `source: "producer"` or absent. Lets downstream consumers identify which intermediate processor inserted the entry, useful for debugging cross-SDK divergence (e.g., one SDK detects a projection failure that another SDK's registry version doesn't).
    */
   sdk_id?: string;
-  [k: string]: unknown | undefined;
 }
 /**
  * Push notification configuration for async task updates (A2A and REST protocols). Echoed from the request to confirm webhook settings. Specifies URL, authentication scheme (Bearer or HMAC-SHA256), and credentials. MCP uses progress notifications instead of webhooks.
@@ -10325,7 +10183,6 @@ export type AccountIdentityChange = AccountIdentityChangePending | AccountIdenti
  * Account-level webhook subscription for notifications whose lifecycle outlives any single media buy — creative state changes, library purges, account status changes, wholesale feed change webhooks, and future account-anchored resource events after those event types are added to this schema. This is distinct from `push-notification-config.json`, which anchors at a per-resource operation (a single task or media buy). The one-shot `sync_accounts.push_notification_config` channel may report the first async result of a provisioning request, while durable account lifecycle events such as later `payment_required` or `suspended` transitions use `account.status_changed` here. An account MAY register multiple notification configs to fan a single seller's events out to multiple buyer-side endpoints; each entry filters by `event_types`. As with push-notification-config, the default signing scheme is the AdCP RFC 9421 webhook profile against the seller's brand.json `agents[]` JWKS; the optional `authentication` block opts into the deprecated Bearer / HMAC-SHA256 fallback for compatibility. Credentials and shared secrets in `authentication.credentials` are write-only — sellers MUST NOT echo them back in `list_accounts` responses. Sellers MUST verify endpoint control before activating a new or changed active account-level notification config; delivery-time SSRF validation still applies to every fire.
  */
 export type NotificationConfig = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Buyer-supplied identifier for this subscription endpoint. This is the stable logical key within one account's notification_configs[] set: re-sending the same subscriber_id for the same account replaces that subscriber's URL, event_types, authentication selector, and active flag rather than creating a duplicate. Echoed on every webhook payload and on every `webhook_activity[]` record fired against this config so the buyer can attribute fires across multiple endpoints. MUST be unique within the account's `notification_configs[]`. Sending two entries with the same `subscriber_id` in a single `sync_accounts` request array is rejected as a per-account validation failure with `INVALID_REQUEST` or `VALIDATION_ERROR`, and `error.field` MUST point at the duplicate entry. `subscriber_id` is the stable match key for the per-account declarative-replace diff. Always required (even with a single subscriber) so the SDK contract is uniform — no conditional required-when-multiple rules to trip up implementations. Format is opaque — recommended values are short kebab-case slugs (`buyer-primary`, `audit-bus`, `dx-team`).
@@ -11501,10 +11358,8 @@ export type BudgetAllocation =
        */
       optimization_goals: [
         OptimizationGoal & {
-          [k: string]: unknown | undefined;
         },
         ...(OptimizationGoal & {
-          [k: string]: unknown | undefined;
         })[]
       ];
     };
@@ -11512,7 +11367,6 @@ export type BudgetAllocation =
  * A specific product within a media buy (line item)
  */
 export type Package = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Seller's unique identifier for the package
@@ -11579,7 +11433,6 @@ export type Package = {
    * Parameters for the direct canonical selector in `format_kind`, echoed from the create_media_buy request whenever the request included it. Requires `format_kind`; omitted only when the request did not carry direct canonical params or when the seller cannot reconstruct legacy requests created before this field was persisted.
    */
   params?: {
-    [k: string]: unknown | undefined;
   };
   targeting_overlay?: TargetingOverlay;
   targeting_resolution?: PackageTargetingResolution;
@@ -11670,17 +11523,13 @@ export type Package = {
   creative_deadline?: string;
   context?: ContextObject;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 };
 /**
  * Optional inline immutable snapshot. Its identity, version, and digest MUST equal the surrounding fields.
  */
 export type AudienceEvidence = {
-  [k: string]: unknown | undefined;
 } & {
-  [k: string]: unknown | undefined;
 } & {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Stable provider-scoped identifier for the logical evidence series across versions.
@@ -12163,13 +12012,10 @@ export type AudienceEvidence = {
  * A machine-comparable audience dimension and value or numeric range used in population-level audience evidence. The built-in `age` dimension uses completed years: scalar and set values and range bounds MUST be non-negative integers, and a range's min MUST be less than or equal to its max. Provider-defined dimensions SHOULD use an HTTPS URI and SHOULD identify their taxonomy so two similarly named dimensions are not assumed equivalent.
  */
 export type AudienceCharacteristic = {
-  [k: string]: unknown | undefined;
 } & (
   | {
-      [k: string]: unknown | undefined;
     }
   | {
-      [k: string]: unknown | undefined;
     }
 ) & {
     /**
@@ -12178,7 +12024,6 @@ export type AudienceCharacteristic = {
     dimension: (
       | 'age'
       | {
-          [k: string]: unknown | undefined;
         }
     ) &
       string;
@@ -12210,9 +12055,7 @@ export type AudienceCharacteristic = {
  * Evaluator-of-record result for one portable attestation presentation. The result binds to the exact presentation through reference_digest and may also pin the credential bytes. It records evaluation, not issuer evidence: domain consumers attach this object to the governance context, evidence snapshot, rights decision, or other action that relied on it.
  */
 export type AttestationEvaluation = {
-  [k: string]: unknown | undefined;
 } & {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * SHA-256 of the RFC 8785 JSON Canonicalization Scheme encoding of the complete AttestationReference, including embedded_credential when present. This prevents a result for one presentation from being replayed for another.
@@ -12274,10 +12117,8 @@ export type AttestationEvaluation = {
    */
   action_binding?:
     | {
-        [k: string]: unknown | undefined;
       }
     | {
-        [k: string]: unknown | undefined;
       };
   ext?: ExtensionObject;
 };
@@ -12285,7 +12126,6 @@ export type AttestationEvaluation = {
  * Canonical demographic predicate and exact seller execution details. Include whenever demographic targeting was requested or applied.
  */
 export type DemographicTargetingResolution = {
-  [k: string]: unknown | undefined;
 } & {
   requested: DemographicTargetingIntent;
   applied: DemographicPredicate;
@@ -12297,7 +12137,6 @@ export type DemographicTargetingResolution = {
     | {
         type: 'continuous_bounds';
         ext?: ExtensionObject;
-        [k: string]: unknown | undefined;
       }
     | {
         type: 'enumerated_intervals';
@@ -12308,7 +12147,6 @@ export type DemographicTargetingResolution = {
          */
         interval_ids: [string, ...string[]];
         ext?: ExtensionObject;
-        [k: string]: unknown | undefined;
       }
     | {
         type: 'signals';
@@ -12319,7 +12157,6 @@ export type DemographicTargetingResolution = {
          */
         signal_refs: [SignalRef, ...SignalRef[]];
         ext?: ExtensionObject;
-        [k: string]: unknown | undefined;
       };
   /**
    * Effective user-level determination bases configured for this package after intersecting buyer accepted_bases, product supported_bases, and age_restriction. This is an auditable configuration readback, not proof that every impression used every listed basis.
@@ -12334,7 +12171,6 @@ export type DemographicTargetingResolution = {
    */
   applied_verification_methods?: [AgeVerificationMethod, ...AgeVerificationMethod[]];
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 };
 /**
  * One metric in a package's binding reporting contract. Each entry uses `scope` as the discriminator and identifies a standard or vendor-defined metric that the seller has committed to populate in delivery reports.
@@ -12383,7 +12219,6 @@ export type CommittedMetric =
  * **Custom format_kind** (`format_kind: "custom"`): for adopter-defined shapes that don't fit the 12 canonicals (multi-placement takeover, roadblock, branded content, cross-screen sponsorship, sponsorship lockup, newsletter sponsorship, AR lens, playable, live event sponsorship). When `format_kind` is `custom`, the declaration MUST carry `format_shape` (recognized global pattern from the [format-shape vocabulary registry](/schemas/core/format-shape-vocabulary.json)) AND `format_schema` (URI+digest reference to a fetchable schema describing the actual `params` and `slots`). Buyer agents fetch the schema, validate manifests structurally, and reason about manifests without per-seller integration code. See [adcp#3666](https://github.com/adcontextprotocol/adcp/issues/3666) for the canonical promotion queue.
  */
 export type ProductFormatDeclaration = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Stable identifier for this declaration within its namespace. REQUIRED when a product contains multiple declarations with the same format_kind and SHOULD be set on every entry. Publisher-backed options pair it with publisher_domain; product-local options omit publisher_domain. When a single declaration has a unique format_kind and no ID, buyers author canonically with format_kind plus params; they MUST NOT fall back to deprecated format_ids merely because this optional ID is absent. Examples: 'display_image_300x250', 'responsive_search', 'daily_pulse_homepage_image'.
@@ -12675,7 +12510,6 @@ export interface Account {
    * Request-only staging field. It MUST NOT appear in account read models.
    */
   destination_billing_entity?: {
-    [k: string]: unknown | undefined;
   };
   /**
    * Identifier for the rate card applied to this account
@@ -12705,7 +12539,6 @@ export interface Account {
      * When this setup link expires.
      */
     expires_at?: string;
-    [k: string]: unknown | undefined;
   };
   account_scope?: AccountScope;
   /**
@@ -12922,7 +12755,6 @@ export interface Account {
    */
   webhook_activity?: WebhookActivityRecord[];
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 export interface AccountIdentityChangePending {
   /**
@@ -13064,7 +12896,6 @@ export interface Impairment {
    * Action the buyer can take to clear the impairment, if any. Free text. Absent when no buyer-side remediation is possible (e.g., seller-initiated withdrawal pending re-publication).
    */
   remediation?: string;
-  [k: string]: unknown | undefined;
 }
 /**
  * Decision readback for the exact immutable audience-evidence snapshot used in product recommendation, required eligibility, or package construction. Sellers MUST return this readback when evidence requirements affect inclusion or ranking even if get_products.fields omitted audience_evidence_selections. A constructed package MUST return a matching selection for every buyer audience_evidence_pin and for every evidence item used to satisfy package audience_evidence_requirements. Sellers MUST retain the full snapshot and evaluations for at least as long as the package remains available through media-buy read surfaces. AdCP 3.2 introduces no buyer-controlled snapshot URL: buyers cache product evidence, sellers retain the source record, and this digest-pinned readback detects catalog mutation. Full evidence may be embedded but is not required on every product or package.
@@ -13670,7 +13501,6 @@ export interface DateRange {
    * End date (inclusive), ISO 8601
    */
   end: string;
-  [k: string]: unknown | undefined;
 }
 /**
  * Re-export of `BrandReference` under the legacy codegen artifact name.
@@ -13687,1741 +13517,18 @@ export type BrandReference3 = BrandReference;
 /**
  * Breakdown of the effective price for this package. On fixed-price packages, echoes the pricing option's breakdown. On auction packages, shows the clearing price breakdown including any commission or settlement terms.
  */
-export interface PriceBreakdown {
-  /**
-   * Rate card or base price before any adjustments. The starting point from which fixed_price is derived by applying fee and discount adjustments sequentially.
-   */
-  list_price: number;
-  /**
-   * Ordered list of price adjustments. Fee and discount adjustments walk list_price to fixed_price — fees increase the running price, discounts reduce it. Commission and settlement adjustments are disclosed for transparency but do not affect the buyer's committed price.
-   *
-   * @minItems 1
-   * @maxItems 20
-   */
-  adjustments:
-    | [
-        | {
-            [k: string]: unknown | undefined;
-          }
-        | {
-            [k: string]: unknown | undefined;
-          }
-      ]
-    | [
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        )
-      ]
-    | [
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        )
-      ]
-    | [
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        )
-      ]
-    | [
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        )
-      ]
-    | [
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        )
-      ]
-    | [
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        )
-      ]
-    | [
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        )
-      ]
-    | [
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        )
-      ]
-    | [
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        )
-      ]
-    | [
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        )
-      ]
-    | [
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        )
-      ]
-    | [
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        )
-      ]
-    | [
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        )
-      ]
-    | [
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        )
-      ]
-    | [
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        )
-      ]
-    | [
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        )
-      ]
-    | [
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        )
-      ]
-    | [
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        )
-      ]
-    | [
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        )
-      ];
-  [k: string]: unknown | undefined;
+export interface PriceAdjustment {
+  kind: PriceAdjustmentKind;
+  name: string;
+  rate?: number;
+  amount?: number;
+  description?: string;
+  beneficiary?: string;
 }
-/**
- * Execution details for the package's accepted targeting. Sellers MUST include targeting_resolution.demographics whenever demographic targeting was requested or applied.
- */
+export interface PriceBreakdown {
+  list_price: number;
+  adjustments: PriceAdjustment[];
+}
 export interface PackageTargetingResolution {
   demographics: DemographicTargetingResolution;
   ext?: ExtensionObject;
@@ -15431,7 +13538,6 @@ export interface PackageTargetingResolution {
  */
 export interface DemographicPredicate {
   age: DemographicAgeRange;
-  [k: string]: unknown | undefined;
 }
 /**
  * Re-export of `BrandReference` under the legacy codegen artifact name.
@@ -15456,7 +13562,6 @@ export interface PerformanceStandard {
   threshold: number;
   standard?: ViewabilityStandard;
   vendor: BrandReference5;
-  [k: string]: unknown | undefined;
 }
 /**
  * Re-export of `BrandReference` under the legacy codegen artifact name.
@@ -15493,7 +13598,6 @@ export interface CreativeLocalePolicy {
    * @maxItems 50
    */
   accepted_language_ranges: [LanguageTag, ...LanguageTag[]];
-  [k: string]: unknown | undefined;
 }
 export interface ImageFormatDeclaration {
   format_kind: 'image';
@@ -15549,7 +13653,6 @@ export interface CanonicalFormatBase {
    * Programmatic declaration of which canonical asset_group_id slots a manifest targeting this format must (or may) populate. Lets SDK codegen and validators enumerate expected slots without parsing the format's prose description. Each entry references an asset_group_id from the canonical vocabulary registry, paired with an `asset_type` so the validator knows which asset schema to apply. Format-level narrowing parameters that apply across all slots (e.g., flat `headline_max_chars` on responsive_creative) may also live on the format declaration; per-slot constraints (a specific slot's `max_chars` or `max_size_kb`) live on the slot entry.
    */
   slots?: {
-    [k: string]: unknown | undefined;
   }[];
   /**
    * Downstream platform connections or grants required to use this format declaration. These are in addition to the single AdCP caller credential. Use this when a platform product requires multiple downstream grants, such as an advertiser account connection plus a publisher identity or post authorization for published-post references.
@@ -15563,7 +13666,6 @@ export interface CanonicalFormatBase {
    * Typical production turnaround in business days when the format requires seller-side production (e.g., host-recording from a buyer-supplied script). 0 for synchronous (e.g., generative AI); >0 for human-produced (e.g., podcast host-read). Absent when no production is required (buyer uploads complete creative).
    */
   production_window_business_days?: number;
-  [k: string]: unknown | undefined;
 }
 /**
  * Re-export of `PlatformExtensionReference` under the legacy codegen artifact name.
@@ -15702,7 +13804,6 @@ export interface CustomFormatDeclaration {
    * Custom shape's params. Validated against the schema fetched from `format_schema.uri` at the cached `format_schema.digest`.
    */
   params: {
-    [k: string]: unknown | undefined;
   };
 }
 /**
@@ -16104,7 +14205,6 @@ export type Product = (NamedFormatProduct | CanonicalFormatProduct) & {
  * Represents a specific public ad placement within a product's inventory. Placement IDs are scoped by publisher domain, matching placement definitions in that publisher's adagents.json. `kind` is the structural discriminator: `publisher_ref` means this product placement is a reference to `{publisher_domain, placement_id}`; `seller_inline` means the seller is defining public buyer-facing placement metadata inline. The schema accepts either `name` or `publisher_domain` because publisher-referenced placements can omit `name` only when the publisher declaration supplies it; seller-inline placements carry `name` directly. Whether a reference was resolved from publisher-hosted adagents.json or a community-maintained fallback is resolver metadata, not placement structure. Placement selection purchases inventory; creative assignments may then route creatives only within the purchased set. Reusing a registered placement preserves the registry's semantic identity; product-level placement objects may narrow format_ids/format_options or add operational detail, but SHOULD NOT redefine the placement's meaning incompatibly.
  */
 export type Placement = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Placement structure discriminator. `publisher_ref` identifies a placement by `{publisher_domain, placement_id}` and resolves public metadata from the named publisher's adagents.json placement declarations; `seller_inline` identifies buyer-facing placement metadata defined inline by the sales agent (still in the named publisher namespace when `publisher_domain` is present, or the seller's own namespace in legacy single-publisher contexts).
@@ -16171,7 +14271,6 @@ export type Placement = {
    * @minItems 1
    */
   social_placement_surfaces?: [SocialPlacementSurface, ...SocialPlacementSurface[]];
-  [k: string]: unknown | undefined;
 };
 /**
  * A seller's commercial pricing offer, discriminated by pricing_model. pricing_option_id is the immutable identity of its binding commercial terms: changing fixed price, floor, currency, model, or priced applicability requires a new ID rather than reinterpreting the old one. fixed_price is an agreed seller price; floor_price is the seller minimum for an auction-priced option; price_guidance is non-binding discovery guidance. Buyer execution instructions belong in BiddingPolicy. revenue_share is contingent pricing: its payable spend is calculated from settled commissionable_value and does not use fixed_price or auction bidding fields. The legacy max_bid boolean and package bid_price are deprecated in 3.2 and removed in the next major.
@@ -16191,7 +14290,6 @@ export type PricingOption =
  * Revenue-share pricing. The advertiser pays a fixed decimal commission rate applied to settled commissionable_value attributed to the declared conversion event and event source. Spend is rounded once to the ISO 4217 minor-unit precision of currency after multiplication: spend = round_currency(commissionable_value × commission_rate). This is contingent pricing, not fixed-unit pricing or an auction.
  */
 export type RevenueSharePricingOption = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Unique identifier for this pricing option within the product
@@ -16225,19 +14323,16 @@ export type RevenueSharePricingOption = {
    * Human-readable definition of inclusions, exclusions, and return or cancellation treatment used by the billing authority to calculate commissionable_value.
    */
   commission_basis_description: string;
-  [k: string]: unknown | undefined;
 };
 /**
  * Product-scoped demographic breakdown support for by_demographic reporting. Declares reportable age ranges and measurement systems independently from demographic targeting execution.
  */
 export type DemographicReportingCapability = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Machine-comparable age ranges this product can report.
    */
   age?: {
-    [k: string]: unknown | undefined;
   };
   /**
    * Measurement-system notations this product may return. A code remains opaque unless its capability interval and response row also carry a canonical age predicate.
@@ -16263,7 +14358,6 @@ export type DataProviderSignalSelector =
        * Discriminator indicating all signals from this data provider are included
        */
       selection_type: 'all';
-      [k: string]: unknown | undefined;
     }
   | {
       /**
@@ -16280,7 +14374,6 @@ export type DataProviderSignalSelector =
        * @minItems 1
        */
       signal_ids: [string, ...string[]];
-      [k: string]: unknown | undefined;
     }
   | {
       /**
@@ -16297,13 +14390,11 @@ export type DataProviderSignalSelector =
        * @minItems 1
        */
       signal_tags: [string, ...string[]];
-      [k: string]: unknown | undefined;
     };
 /**
  * Shared signal identity and definition metadata used when a signal is listed outside its authoritative definition. New listings carry signal_ref; legacy listings may carry deprecated signal_id during the SignalRef migration window. Product-local signals use the listing as the definition boundary and MUST include name and value_type. Data-provider and signal-source refs MAY omit definition metadata when the buyer can resolve it from the referenced provider-published definition or source; any supplied name, description, value_type, categories, range, methodology_url, or last_updated is product/account/source context and does not replace the authoritative definition.
  */
 export type SignalListing = {
-  [k: string]: unknown | undefined;
 } & {
   signal_ref?: SignalRef;
   signal_id?: SignalID;
@@ -16350,7 +14441,6 @@ export type SignalListing = {
    */
   restricted_attributes?: [RestrictedAttribute, ...RestrictedAttribute[]];
   demographic_predicate?: DemographicPredicate;
-  [k: string]: unknown | undefined;
 };
 /**
  * DEPRECATED. Use signal_ref instead. Legacy SignalId retained for compatibility with older Signals Protocol clients.
@@ -16369,7 +14459,6 @@ export type SignalID =
        * Signal identifier within the data provider's catalog (e.g., 'likely_ev_buyers', 'income_100k_plus')
        */
       id: string;
-      [k: string]: unknown | undefined;
     }
   | {
       /**
@@ -16384,13 +14473,11 @@ export type SignalID =
        * Signal identifier within the agent's signal set (e.g., 'custom_auto_intenders')
        */
       id: string;
-      [k: string]: unknown | undefined;
     };
 /**
  * A signal the seller makes available inline for package-level signal composition on this product. Product.signal_targeting_options is used when the product needs product-scoped pricing, activation handles, defaults, grouping hints, a brief/refine-selected subset, or a curated inline menu. Wholesale products can instead omit inline options when the selectable menu is the broader get_signals feed. Product-local signals define their name and value_type inline through the shared signal-listing fields; data-provider and signal-source refs may omit those definition fields when the referenced definition or source is authoritative.
  */
 export type ProductSignalTargetingOption = SignalListing & {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Optional opaque resolved-segment or seller execution handle for this signal. Omit when signal_ref plus the value expression is sufficient for the seller to resolve the signal. Include when the seller exposes a distinct runtime or activation handle that buyers must echo in packages[].targeting_overlay.signal_targeting_groups.groups[].signals[].signal_agent_segment_id. Buyers SHOULD echo this handle verbatim rather than reconstructing identity from categorical values; providers MAY namespace handles so cross-provider identity stays legible without a shared taxonomy registry.
@@ -16420,7 +14507,6 @@ export type ProductSignalTargetingOption = SignalListing & {
    * @minItems 1
    */
   pricing_options?: [VendorPricingOption, ...VendorPricingOption[]];
-  [k: string]: unknown | undefined;
 };
 /**
  * A pricing option offered by a vendor agent (signals, creative, governance). Combines pricing_option_id with the pricing model fields. Pass pricing_option_id in report_usage for billing verification. All vendor discovery responses return pricing_options as an array — vendors may offer multiple options (volume tiers, context-specific rates, different models per product line).
@@ -16453,13 +14539,11 @@ export type VendorPricing = CpmPricing | PercentOfMediaPricing | FlatFeePricing 
  */
 export type TargetingModification = ReplaceTargetingValue | RemoveTargetingSetValues;
 export type RemoveTargetingSetValues = {
-  [k: string]: unknown | undefined;
 };
 /**
  * Typed seller collateral for buyer-facing product cards. Each entry carries a semantic role (coverage_map, sample_render, etc.) and a canonical asset payload. Distinct from hero_image/carousel_images (display-oriented) and from core/reference-asset.json (creative-generation oriented).
  */
 export type ProductCardReferenceAsset = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Semantic role of this asset. coverage_map: geographic or audience reach visualization; sample_render: mockup of ad placement in context; environment_photo: photo of the physical or digital environment; media_kit: downloadable media kit or spec sheet; logo: seller or property logo; other: seller-defined role (provide role_label).
@@ -16477,20 +14561,17 @@ export type ProductCardReferenceAsset = {
    * Optional human-readable context about this asset.
    */
   description?: string;
-  [k: string]: unknown | undefined;
 };
 /**
  * @deprecated
  * Deprecated 3.x compatibility branch. Product references one or more named formats by structured format_id ({ agent_url, id }). New 3.2 products use format_options.
  */
 export interface NamedFormatProduct {
-  [k: string]: unknown | undefined;
 }
 /**
  * Product carries one or more inline ProductFormatDeclarations, each narrowing a canonical format. This is the 3.1+ format-option path introduced by RFC #3305. A single-element `format_options` array is the 90% case; multi-element arrays declare that the product accepts any of the listed format options.
  */
 export interface CanonicalFormatProduct {
-  [k: string]: unknown | undefined;
 }
 /**
  * Cost Per Mille (cost per 1,000 impressions) pricing. If fixed_price is present, it's fixed pricing. If absent, it's auction-based.
@@ -16531,7 +14612,6 @@ export interface CPMPricingOption {
    * Adjustment kinds applicable to this pricing option. Tells buyer agents which adjustments are available before negotiation. When absent, no adjustments are pre-declared — the buyer should check price_breakdown if present.
    */
   eligible_adjustments?: PriceAdjustmentKind[];
-  [k: string]: unknown | undefined;
 }
 /**
  * Optional pricing guidance for auction-based bidding
@@ -16553,7 +14633,6 @@ export interface PriceGuidance {
    * 90th percentile of recent winning bids
    */
   p90?: number;
-  [k: string]: unknown | undefined;
 }
 /**
  * Viewable Cost Per Mille (cost per 1,000 viewable impressions) pricing - MRC viewability standard. If fixed_price is present, it's fixed pricing. If absent, it's auction-based.
@@ -16594,7 +14673,6 @@ export interface VCPMPricingOption {
    * Adjustment kinds applicable to this pricing option. Tells buyer agents which adjustments are available before negotiation. When absent, no adjustments are pre-declared — the buyer should check price_breakdown if present.
    */
   eligible_adjustments?: PriceAdjustmentKind[];
-  [k: string]: unknown | undefined;
 }
 /**
  * Cost Per Click pricing. If fixed_price is present, it's fixed pricing. If absent, it's auction-based.
@@ -16635,7 +14713,6 @@ export interface CPCPricingOption {
    * Adjustment kinds applicable to this pricing option. Tells buyer agents which adjustments are available before negotiation. When absent, no adjustments are pre-declared — the buyer should check price_breakdown if present.
    */
   eligible_adjustments?: PriceAdjustmentKind[];
-  [k: string]: unknown | undefined;
 }
 /**
  * Cost Per Completed View (100% video/audio completion) pricing. If fixed_price is present, it's fixed pricing. If absent, it's auction-based.
@@ -16676,7 +14753,6 @@ export interface CPCVPricingOption {
    * Adjustment kinds applicable to this pricing option. Tells buyer agents which adjustments are available before negotiation. When absent, no adjustments are pre-declared — the buyer should check price_breakdown if present.
    */
   eligible_adjustments?: PriceAdjustmentKind[];
-  [k: string]: unknown | undefined;
 }
 /**
  * Cost Per View (at publisher-defined threshold) pricing for video/audio. If fixed_price is present, it's fixed pricing. If absent, it's auction-based.
@@ -16719,9 +14795,7 @@ export interface CPVPricingOption {
            * Seconds of viewing required
            */
           duration_seconds: number;
-          [k: string]: unknown | undefined;
         };
-    [k: string]: unknown | undefined;
   };
   /**
    * Minimum spend requirement per package using this pricing option, in the specified currency
@@ -16732,7 +14806,6 @@ export interface CPVPricingOption {
    * Adjustment kinds applicable to this pricing option. Tells buyer agents which adjustments are available before negotiation. When absent, no adjustments are pre-declared — the buyer should check price_breakdown if present.
    */
   eligible_adjustments?: PriceAdjustmentKind[];
-  [k: string]: unknown | undefined;
 }
 /**
  * Cost Per Point (Gross Rating Point) pricing for TV and audio campaigns. If fixed_price is present, it's fixed pricing. If absent, it's auction-based.
@@ -16772,7 +14845,6 @@ export interface CPPPricingOption {
      * Minimum GRPs/TRPs required
      */
     min_points?: number;
-    [k: string]: unknown | undefined;
   };
   /**
    * Minimum spend requirement per package using this pricing option, in the specified currency
@@ -16783,7 +14855,6 @@ export interface CPPPricingOption {
    * Adjustment kinds applicable to this pricing option. Tells buyer agents which adjustments are available before negotiation. When absent, no adjustments are pre-declared — the buyer should check price_breakdown if present.
    */
   eligible_adjustments?: PriceAdjustmentKind[];
-  [k: string]: unknown | undefined;
 }
 /**
  * Cost Per Acquisition pricing. Advertiser pays a fixed price when a specified conversion event occurs. The event_type field declares which event triggers billing (e.g., purchase, lead, app_install).
@@ -16826,7 +14897,6 @@ export interface CPAPricingOption {
    * Adjustment kinds applicable to this pricing option. Tells buyer agents which adjustments are available before negotiation. When absent, no adjustments are pre-declared — the buyer should check price_breakdown if present.
    */
   eligible_adjustments?: PriceAdjustmentKind[];
-  [k: string]: unknown | undefined;
 }
 /**
  * Flat rate pricing for sponsorships, takeovers, and DOOH exclusive placements. A fixed total cost regardless of delivery volume. For duration-scaled pricing (rate × time units), use the `time` model instead. If fixed_price is present, it's fixed pricing. If absent, it's auction-based.
@@ -16863,7 +14933,6 @@ export interface FlatRatePricingOption {
    * Adjustment kinds applicable to this pricing option. Tells buyer agents which adjustments are available before negotiation. When absent, no adjustments are pre-declared — the buyer should check price_breakdown if present.
    */
   eligible_adjustments?: PriceAdjustmentKind[];
-  [k: string]: unknown | undefined;
 }
 /**
  * DOOH inventory allocation parameters. Sponsorship and takeover flat_rate options omit this field entirely — only include for digital out-of-home inventory.
@@ -16901,7 +14970,6 @@ export interface DoohParameters {
    * Estimated audience impressions for this slot (informational, not a delivery guarantee)
    */
   estimated_impressions?: number;
-  [k: string]: unknown | undefined;
 }
 /**
  * Cost per time unit (hour, day, week, or month) - rate scales with campaign duration. If fixed_price is present, it's fixed pricing. If absent, it's auction-based.
@@ -16944,7 +15012,6 @@ export interface TimeBasedPricingOption {
      * Maximum booking duration in time_units. Must be >= min_duration when both are present.
      */
     max_duration?: number;
-    [k: string]: unknown | undefined;
   };
   /**
    * Minimum spend requirement per package using this pricing option, in the specified currency
@@ -16955,7 +15022,6 @@ export interface TimeBasedPricingOption {
    * Adjustment kinds applicable to this pricing option. Tells buyer agents which adjustments are available before negotiation. When absent, no adjustments are pre-declared — the buyer should check price_breakdown if present.
    */
   eligible_adjustments?: PriceAdjustmentKind[];
-  [k: string]: unknown | undefined;
 }
 /**
  * Forecasted delivery metrics for this product. Concrete discovery targeting scopes the forecast to those effective values. When discovery requested only required_overlay_support for a dimension, the forecast describes the product's discovery/default scope and is not a value-specific forecast for every later selection; buyers rediscover with concrete targeting_overlay values when they need that forecast.
@@ -16992,7 +15058,6 @@ export interface DeliveryForecast {
    */
   valid_until?: string;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * @deprecated
@@ -17015,7 +15080,6 @@ export interface OutcomeMeasurement {
    * Reporting frequency and format
    */
   reporting: string;
-  [k: string]: unknown | undefined;
 }
 /**
  * An action a seller declares as allowed on buys created against this product, scoped to the buy statuses where the action is permitted and the modes available. Advisory template only — the authoritative per-buy resolution lives in `available_actions[]` on the buy response (which may diverge from the product template based on negotiated terms, account tier, or buy-level overrides). The containing `allowed_actions[]` array is uniquely keyed by `action`; sellers MUST NOT emit two entries with the same `action` value. JSON Schema `uniqueItems` only catches structurally identical objects, so validators MUST enforce action-uniqueness separately.
@@ -17127,7 +15191,6 @@ export interface ReportingCapabilities {
    * @minItems 1
    */
   measurement_windows?: [MeasurementWindow, ...MeasurementWindow[]];
-  [k: string]: unknown | undefined;
 }
 /**
  * Geographic breakdown support for this product. Declares which geo levels and systems are available for by_geo reporting within by_package.
@@ -17182,7 +15245,6 @@ export interface MeasurementWindow {
    * Whether this window is the basis for delivery guarantees, reconciliation, and invoicing. A product typically has one guarantee basis window (e.g., C7 for most US broadcast, post-IVT final for DOOH). Buyers reconcile against the guarantee basis window's final numbers.
    */
   is_guarantee_basis?: boolean;
-  [k: string]: unknown | undefined;
 }
 /**
  * Creative requirements and restrictions for a product
@@ -17218,7 +15280,6 @@ export interface CreativePolicy {
      * When true, the seller requires creatives to include at least one `embedded_provenance` entry. For pipelines where sidecar metadata is stripped by intermediaries, this ensures provenance data persists through delivery. Submissions that omit `embedded_provenance` are rejected with `PROVENANCE_EMBEDDED_MISSING`.
      */
     require_embedded_provenance?: boolean;
-    [k: string]: unknown | undefined;
   };
   /**
    * Governance agents the seller operates, has allowlisted, or otherwise trusts to verify provenance claims via `get_creative_features`. Buyers attaching a `verify_agent` pointer on `embedded_provenance[]` or `watermarks[]` MUST select an `agent_url` that appears in this list (canonicalized per /docs/reference/url-canonicalization: lowercase scheme and host, strip default port, normalize path dot-segments) - the buyer is *representing* that they used a verifier the seller will recognize, not asserting unilateral routing. Sellers MUST reject `sync_creatives` submissions whose `verify_agent.agent_url` does not match any entry here with `PROVENANCE_VERIFIER_NOT_ACCEPTED`. The seller is the verifier-of-record: it is the seller, not the buyer, that decides which agent it will call. Publishing the list lets buyers pre-flight their creative shape against `get_products` and lets multiple buyers converge on the same verifier without coordinating with each other.
@@ -17259,7 +15320,6 @@ export interface CreativePolicy {
       providers?: [string, ...string[]];
     }[]
   ];
-  [k: string]: unknown | undefined;
 }
 /**
  * Fixed cost per thousand impressions
@@ -17275,7 +15335,6 @@ export interface CpmPricing {
    */
   currency: string;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Percentage of media spend charged for this signal. When max_cpm is set, the effective rate is capped at that CPM — useful for platforms like The Trade Desk that use percent-of-media pricing with a CPM ceiling.
@@ -17295,7 +15354,6 @@ export interface PercentOfMediaPricing {
    */
   currency: string;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Fixed charge per billing period, regardless of impressions or spend. Used for licensed data bundles and audience subscriptions.
@@ -17315,7 +15373,6 @@ export interface FlatFeePricing {
    */
   currency: string;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Fixed price per unit of work. Used for creative transformation (per format), AI generation (per image, per token), and rendering (per variant). The unit field describes what is counted; unit_price is the cost per one unit.
@@ -17335,7 +15392,6 @@ export interface PerUnitPricing {
    */
   currency: string;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Escape hatch for pricing constructs that do not fit cpm, percent_of_media, flat_fee, or per_unit. Use when a vendor prices via performance kickers, tiered volume, hybrid formulas, outcome-sharing, or any other model the standard forms cannot express. Requires a human-readable description and a structured metadata object that captures the parameters a buyer needs to reason about the charge. Buyers SHOULD route custom pricing through operator review before commitment — automatic selection is not recommended.
@@ -17354,14 +15410,12 @@ export interface CustomPricing {
      * One or two sentences describing the pricing construct in plain language, displayed to the buyer's operator when requesting approval. Should not repeat the top-level `description` verbatim — summarize the charge mechanic instead (e.g., 'Base $12 CPM plus $0.50 per qualifying post-view conversion, capped at $45 CPM').
      */
     summary_for_operator?: string;
-    [k: string]: unknown | undefined;
   };
   /**
    * ISO 4217 currency code. Present when the pricing resolves to a monetary charge in a specific currency.
    */
   currency?: string;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Composition rules for selecting signals on this product. The selectable signal menu may come from inline signal_targeting_options or from get_signals when a wholesale product omits inline options. This is product-scoped because products may be backed by different ad servers with different Boolean targeting support and group limits.
@@ -17401,7 +15455,6 @@ export interface SignalTargetingRules {
    * @minItems 1
    */
   selection_group_rules?: [SignalSelectionGroupRule, ...SignalSelectionGroupRule[]];
-  [k: string]: unknown | undefined;
 }
 /**
  * Product-scoped override for one ProductSignalTargetingOption.selection_group value. Use this when a product has mixed signal-selection behavior, such as fixed suppressions plus a required pick-one include tier.
@@ -17427,7 +15480,6 @@ export interface SignalSelectionGroupRule {
    * Maximum selected options from this selection_group.
    */
   max_selected_signals?: number;
-  [k: string]: unknown | undefined;
 }
 /**
  * Exact demographic execution available for this product. Buyers MUST use this product-scoped declaration, not the seller-wide get_adcp_capabilities rollup, to preflight a demographic predicate.
@@ -17437,9 +15489,7 @@ export interface DemographicTargetingCapability {
    * Age-targeting execution available for this product.
    */
   age: {
-    [k: string]: unknown | undefined;
   };
-  [k: string]: unknown | undefined;
 }
 /**
  * Discovery-time targeting resolution bound to this configured product. modifications sparsely disclose product-specific differences from get_products.targeting_overlay. Request-level brief interpretation is returned once on GetProductsResponse.targeting_resolution. Exact structured overlay values are not repeated. Selecting product_id accepts the disclosed modifications; product forecast and pricing MUST reflect them.
@@ -17467,7 +15517,6 @@ export interface ReplaceTargetingValue {
    * Complete replacement value. It MUST validate against targeting.json at path; the seller then validates the complete effective overlay. This operation may narrow or broaden only as an explicit buyer-visible proposal.
    */
   applied: {
-    [k: string]: unknown | undefined;
   };
   reason: string;
   ext?: ExtensionObject;
@@ -17480,7 +15529,6 @@ export interface VendorMetricOptimization {
    * Vendor-defined metrics this product can steer delivery toward. Each entry pairs a vendor identity (BrandRef anchored on the vendor's `brand.json` `agents[type='measurement']`) with a `metric_id` from that vendor's published `measurement.metrics[]` catalog, plus the target kinds the seller supports for the pair. Semantic uniqueness key is `(vendor.domain, vendor.brand_id, metric_id)`; sellers MUST de-duplicate before publication. JSON Schema `uniqueItems` blocks exact-object duplicates; semantic deduplication on the BrandRef-domain key is a seller obligation.
    */
   supported_metrics: VendorMetricOptimizationSupportedMetric[];
-  [k: string]: unknown | undefined;
 }
 /**
  * One vendor-defined metric that a product can optimize toward. Identified by the tuple `(vendor, metric_id)` plus the supported target kinds for optimization goals.
@@ -17516,7 +15564,6 @@ export interface MeasurementReadiness {
    * Seller explanation of the readiness assessment, recommendations for improvement, or context about what the buyer needs to change.
    */
   notes?: string;
-  [k: string]: unknown | undefined;
 }
 /**
  * An actionable issue detected during a health or readiness assessment. Used by event source health and measurement readiness to surface problems and recommendations.
@@ -17530,7 +15577,6 @@ export interface DiagnosticIssue {
    * Human/agent-readable description of the issue and how to resolve it.
    */
   message: string;
-  [k: string]: unknown | undefined;
 }
 /**
  * References collections declared in an adagents.json. Buyers resolve full collection objects by fetching the adagents.json at the given domain and matching collection_ids against its collections array.
@@ -17546,7 +15592,6 @@ export interface CollectionSelector {
    * @minItems 1
    */
   collection_ids: [string, ...string[]];
-  [k: string]: unknown | undefined;
 }
 /**
  * A single bookable unit within a collection — one episode, issue, event, or rotation period. The parent collection's kind indicates how to interpret each installment: TV/podcast episodes, print issues, live event airings, newsletter editions, or DOOH rotation periods. Installments inherit collection-level fields they don't override: content_rating defaults to the collection's baseline, guest_talent is additive to the collection's recurring talent, and topics add context beyond the collection's genre.
@@ -17612,7 +15657,6 @@ export interface Installment {
     type: DerivativeType;
   };
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Installment-specific content rating. Overrides the collection's baseline content_rating when present.
@@ -17623,7 +15667,6 @@ export interface ContentRating {
    * Rating value within the system (e.g., 'TV-PG', 'R', 'explicit')
    */
   rating: string;
-  [k: string]: unknown | undefined;
 }
 /**
  * Installment-specific event context. When present, this installment is anchored to a real-world event. Overrides the collection-level special when present.
@@ -17642,7 +15685,6 @@ export interface Special {
    * When the event ends (ISO 8601). Omit for single-day events.
    */
   ends?: string;
-  [k: string]: unknown | undefined;
 }
 /**
  * A person associated with a collection or installment, with an optional link to their brand.json identity
@@ -17657,7 +15699,6 @@ export interface Talent {
    * URL to this person's brand.json entry. Enables buyer agents to evaluate the talent's brand identity and associations.
    */
   brand_url?: string;
-  [k: string]: unknown | undefined;
 }
 /**
  * Break-based ad inventory for this installment. For non-break formats (host reads, integrations), use product placements.
@@ -17683,7 +15724,6 @@ export interface AdInventoryConfiguration {
    * Ad format types supported in breaks (e.g., 'video', 'audio', 'display')
    */
   supported_formats?: string[];
-  [k: string]: unknown | undefined;
 }
 /**
  * Booking, cancellation, and material submission deadlines for this installment. Present when the installment has time-sensitive inventory that requires advance commitment or material delivery.
@@ -17703,7 +15743,6 @@ export interface InstallmentDeadlines {
    * @minItems 1
    */
   material_deadlines?: [MaterialDeadline, ...MaterialDeadline[]];
-  [k: string]: unknown | undefined;
 }
 /**
  * A deadline for creative material submission. Sellers declare stages to distinguish draft materials (e.g., talking points, raw artwork) from production-ready assets (e.g., approved scripts, press-ready PDFs).
@@ -17721,7 +15760,6 @@ export interface MaterialDeadline {
    * What the seller needs at this stage (e.g., 'Talking points and brand guidelines', 'Press-ready PDF with bleed')
    */
   label?: string;
-  [k: string]: unknown | undefined;
 }
 
 // TARGETING SCHEMA
@@ -17809,7 +15847,6 @@ export type AdCPAsyncResponseData =
  */
 export type GetProductsResponse = AdCPVersionEnvelope &
   ProtocolEnvelope & {
-    [k: string]: unknown | undefined;
   } & {
     /**
      * Array of matching products
@@ -17820,7 +15857,6 @@ export type GetProductsResponse = AdCPVersionEnvelope &
      * Bundled platform-extension definitions referenced by any product in `products`. Keyed by `<extension_uri>@<digest>` (e.g., `https://creative.adcontextprotocol.org/translated/meta/extensions/meta_pixel@sha256:abc...`). When present, lets buyers resolve `platform_extensions` references on product format declarations without a separate fetch. Buyer SDKs cache by URI@digest; subsequent get_products responses MAY omit definitions the buyer already has cached and rely on the digest match. Each value is an extension definition with `extends` (the canonical concept it extends, e.g., `tracking`), `fields` (the schema for additional fields the extension contributes), `version`, and optional `description`.
      */
     extensions?: {
-      [k: string]: unknown | undefined;
     };
     /**
      * Optional array of proposed media plans with budget allocations across products. Publishers include proposals when they can provide strategic guidance based on the brief. Proposals are actionable - buyers can refine them via follow-up get_products calls within the same session, or execute them directly via create_media_buy.
@@ -18103,7 +16139,6 @@ export type GetProductsResponse = AdCPVersionEnvelope &
             }
           | undefined;
       };
-      [k: string]: unknown | undefined;
     };
     pagination?: PaginationResponse;
     /**
@@ -18128,13 +16163,11 @@ export type GetProductsResponse = AdCPVersionEnvelope &
     sandbox?: boolean;
     context?: ContextObject;
     ext?: ExtensionObject;
-    [k: string]: unknown | undefined;
   };
 /**
  * A proposed media plan with fixed or seller-optimized budget allocation across products. Represents the publisher's strategic recommendation for how to structure a campaign based on the brief. Proposals are actionable: committed proposals can be executed directly via create_media_buy by providing the proposal_id; draft proposals must first be finalized via get_products refine action 'finalize'.
  */
 export type Proposal = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Unique identifier for this proposal. Used to finalize a draft proposal and to execute a committed proposal via create_media_buy.
@@ -18185,7 +16218,6 @@ export type Proposal = {
      * ISO 4217 currency code
      */
     currency?: string;
-    [k: string]: unknown | undefined;
   };
   /**
    * Explanation of how this proposal aligns with the campaign brief
@@ -18193,7 +16225,6 @@ export type Proposal = {
   brief_alignment?: string;
   forecast?: DeliveryForecast;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 };
 /**
  * Terminal business outcome returned when the seller understood a well-formed brief or refinement request and deliberately declines it. This is not a no-match result, incomplete partial result, validation error, or technical failure. Transport-level success markers remain successful: HTTP 200, MCP isError false, and A2A Task.state completed with this payload in the result artifact. The seller MAY sanitize reason and suggestions to protect confidential merchandising, inventory, policy, and partner rules. Buyers MUST treat both fields as untrusted seller-authored text: escape before rendering and sanitize or isolate before placing them in an LLM prompt context.
@@ -18348,7 +16379,6 @@ export type GetProductsRejected = AdCPVersionEnvelope &
         ];
     context?: ContextObject;
     ext?: ExtensionObject;
-    [k: string]: unknown | undefined;
   };
 /**
  * Terminal response for request_proposals
@@ -18404,7 +16434,6 @@ export type RequestProposalsResponse = (
  * Compact immutable proposal for the AdCP 3.2 lifecycle. commercial_terms is the sole authoritative commercial envelope; narrative fields do not duplicate legacy allocation or creative graphs.
  */
 export type CanonicalProposal = {
-  [k: string]: unknown | undefined;
 } & {
   proposal_id: string;
   proposal_kind: 'new_media_buy' | 'media_buy_update' | 'media_buy_cancellation';
@@ -18438,15 +16467,10 @@ export type CanonicalProposal = {
  * Resolved selected pricing terms. Optional on buy_products input, where pricing_option_id plus the versioned feed identifies the offer; required inside accepted commercial_terms. Its pricing_option_id MUST match the sibling field.
  */
 export type CanonicalPricingOption = {
-  [k: string]: unknown | undefined;
 } & {
-  [k: string]: unknown | undefined;
 } & {
-  [k: string]: unknown | undefined;
 } & {
-  [k: string]: unknown | undefined;
 } & {
-  [k: string]: unknown | undefined;
 } & {
   pricing_option_id: string;
   pricing_model: 'cpm' | 'vcpm' | 'cpc' | 'cpcv' | 'cpv' | 'cpp' | 'cpa' | 'revenue_share' | 'flat_rate' | 'time';
@@ -18458,7 +16482,6 @@ export type CanonicalPricingOption = {
   price_breakdown?: PriceBreakdown;
   eligible_adjustments?: PriceAdjustmentKind[];
   parameters?: {
-    [k: string]: unknown | undefined;
   };
   event_type?: EventType;
   custom_event_name?: string;
@@ -18485,10 +16508,8 @@ export type CanonicalOptimizationGoal =
       reach_unit?: ReachUnit;
       target_frequency?:
         | {
-            [k: string]: unknown | undefined;
           }
         | {
-            [k: string]: unknown | undefined;
           };
       view_duration_seconds?: number;
       target?: {
@@ -18538,7 +16559,6 @@ export type CanonicalOptimizationGoal =
  * Buyer evidence-admissibility policy carried into the accepted purchase snapshot.
  */
 export type ProductAudienceEvidenceRequirements = {
-  [k: string]: unknown | undefined;
 } & {
   requirement_mode: 'required' | 'preferred';
   evidence_presence: 'required' | 'when_available';
@@ -18663,7 +16683,6 @@ export type CanonicalReportingCommitment =
  * Compact canonical creative-format declaration. Legacy named-format links are intentionally absent; params are validated against the canonical schema selected by format_kind without inlining every format union into product discovery.
  */
 export type CanonicalFormatOption = {
-  [k: string]: unknown | undefined;
 } & {
   format_option_id?: string;
   publisher_domain?: string;
@@ -18692,7 +16711,6 @@ export type CanonicalFormatOption = {
     | 'agent_placement'
     | 'custom';
   params: {
-    [k: string]: unknown | undefined;
   };
   format_shape?: string;
   format_schema?: PlatformExtensionReference1;
@@ -18724,7 +16742,6 @@ export type CanonicalFormatOption = {
     | 'agent_placement'
     | 'custom';
   params: {
-    [k: string]: unknown | undefined;
   };
   format_shape?: string;
   format_schema?: PlatformExtensionReference1;
@@ -18756,7 +16773,6 @@ export type CanonicalFormatOption = {
     | 'agent_placement'
     | 'custom';
   params: {
-    [k: string]: unknown | undefined;
   };
   format_shape?: string;
   format_schema?: PlatformExtensionReference1;
@@ -18788,7 +16804,6 @@ export type CanonicalFormatOption = {
     | 'agent_placement'
     | 'custom';
   params: {
-    [k: string]: unknown | undefined;
   };
   format_shape?: string;
   format_schema?: PlatformExtensionReference1;
@@ -18797,7 +16812,6 @@ export type CanonicalFormatOption = {
  * Compact product placement with canonical format narrowing only.
  */
 export type CanonicalProductPlacement = {
-  [k: string]: unknown | undefined;
 } & {
   kind: 'publisher_ref' | 'seller_inline';
   placement_id: string;
@@ -18831,11 +16845,8 @@ export type CanonicalProductPlacement = {
  * Compact immutable audience-evidence snapshot for product discovery. Provider identity is a BrandKey; credential and brand-asset graphs are resolved separately.
  */
 export type CanonicalAudienceEvidence = {
-  [k: string]: unknown | undefined;
 } & {
-  [k: string]: unknown | undefined;
 } & {
-  [k: string]: unknown | undefined;
 } & {
   evidence_id: string;
   snapshot_id: string;
@@ -18956,10 +16967,8 @@ export type RefineProposalsResponse = (
    * @minItems 1
    */
   results?: {
-    [k: string]: unknown | undefined;
   } & [
     {
-      [k: string]: unknown | undefined;
     } & (
       | {
           outcome: 'revised';
@@ -19009,7 +17018,6 @@ export type RefineProposalsResponse = (
           }
       ),
     ...({
-      [k: string]: unknown | undefined;
     } & (
       | {
           outcome: 'revised';
@@ -19077,7 +17085,6 @@ export type RefineProposalsAsyncSubmitted = CompactTaskSubmitted;
  */
 export type DeclineProposalsResponse = (
   | {
-      [k: string]: unknown | undefined;
     }
   | CompactTaskSubmitted
 ) & {
@@ -19175,7 +17182,6 @@ export type CanonicalMediaBuyAction =
  * A non-blocking observation returned with a successful operation. The operation succeeded exactly as its success arm states. Warnings are immediate receipts, not durable lifecycle state; a continuing condition MUST also appear on its authoritative read surface as an indicator, defect, delivery issue, approval state, or other applicable resource state.
  */
 export type Warning = {
-  [k: string]: unknown | undefined;
 } & {
   code: WarningCode;
   /**
@@ -19187,10 +17193,8 @@ export type Warning = {
    * Optional seller-specific structured diagnostics. AdCP 3.2 defines interoperability through code and affected_resource only; buyers MUST NOT require portable keys inside details. Seller extensions that are not direct diagnostics belong in ext.
    */
   details?: {
-    [k: string]: unknown | undefined;
   };
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 };
 /**
  * Terminal response for control_media_buy
@@ -19206,7 +17210,6 @@ export type GetSignalsResponse = AdCPVersionEnvelope &
      */
     signals?: (SignalListing &
       SignalDefinitionEnrichment & {
-        [k: string]: unknown | undefined;
       })[];
     /**
      * Task-specific errors and warnings (e.g., signal discovery or pricing issues)
@@ -19270,13 +17273,11 @@ export type GetSignalsResponse = AdCPVersionEnvelope &
     sandbox?: boolean;
     context?: ContextObject;
     ext?: ExtensionObject;
-    [k: string]: unknown | undefined;
   };
 /**
  * Optional signal-definition enrichment fields that may be projected inline on signal listings when requested through get_signals.fields. This schema intentionally excludes signal identity and required definition fields so source-native, private, or compact listings can include typed partial disclosure without becoming a full adagents.json signal definition.
  */
 export type SignalDefinitionEnrichment = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Restricted attribute categories this signal touches.
@@ -19463,18 +17464,14 @@ export type SignalDefinitionEnrichment = {
     channels: [
       (
         | {
-            [k: string]: unknown | undefined;
           }
         | {
-            [k: string]: unknown | undefined;
           }
       ),
       ...(
         | {
-            [k: string]: unknown | undefined;
           }
         | {
-            [k: string]: unknown | undefined;
           }
       )[]
     ];
@@ -19486,13 +17483,11 @@ export type SignalDefinitionEnrichment = {
    */
   last_updated?: string;
   dts_compliant_version?: string;
-  [k: string]: unknown | undefined;
 };
 /**
  * Disclosure requirements and jurisdictional notes for modeled data signals. This schema is intentionally separate from core/provenance.json because creative provenance is about generated content, render guidance, and asset-level chain of custody, while signal modeling disclosure is about data-segment methodology and data-use transparency.
  */
 export type SignalModelingDisclosure = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * The provider's claim that a modeling or AI-use disclosure is required for this signal in at least one applicable jurisdiction. This is a declared compliance signal, not a protocol-level legal determination.
@@ -19571,7 +17566,6 @@ export type CreateMediaBuyResponse = AdCPVersionEnvelope &
  * Success response - media buy created successfully
  */
 export type CreateMediaBuySuccess = {
-  [k: string]: unknown | undefined;
 };
 /**
  * Response for completed or failed update_media_buy
@@ -19603,7 +17597,7 @@ export type CreativeManifest = {
    * Each slot value is **either** a single asset object (most slots — image, video, published_post, vast_tag, landing_page_url, etc.) **or** an array of asset objects (slots with `min`/`max` counts on the format declaration — `cards` on `image_carousel`, `headlines` / `descriptions` / `images_landscape` on `responsive_creative`, etc.). Single-vs-array shape is governed by the format's `slots[].min` and `slots[].max` parameters: when `max > 1` (or when the slot is conceptually a pool), the value MUST be an array; when the slot is single-valued, the value MUST be a single object. Each asset value (single or array element) carries an `asset_type` discriminator (image, video, audio, vast, daast, text, markdown, url, html, css, webhook, javascript, brief, catalog, published_post, zip, card) that selects the matching asset schema. Validators with OpenAPI-style discriminator support use `asset_type` to report errors against only the selected branch instead of all branches.
    */
   assets: {
-    [k: string]: unknown | undefined;
+    [k: string]: AssetVariant | AssetVariant[];
   };
   brand?: BrandReference11;
   /**
@@ -19616,7 +17610,6 @@ export type CreativeManifest = {
   industry_identifiers?: IndustryIdentifier[];
   provenance?: Provenance;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 } & (NamedFormatManifest | CanonicalFormatManifest);
 /**
  * A single rendered piece of a creative preview with discriminated output format
@@ -19667,7 +17660,6 @@ export type PreviewRender =
          */
         csp_policy?: string;
       };
-      [k: string]: unknown | undefined;
     }
   | {
       /**
@@ -19714,7 +17706,6 @@ export type PreviewRender =
          */
         csp_policy?: string;
       };
-      [k: string]: unknown | undefined;
     }
   | {
       /**
@@ -19765,7 +17756,6 @@ export type PreviewRender =
          */
         csp_policy?: string;
       };
-      [k: string]: unknown | undefined;
     };
 /**
  * Terminal response for completed preview_creative
@@ -19791,17 +17781,11 @@ export type SyncCatalogsResponse = AdCPVersionEnvelope &
  * Seller acknowledgement for one buyer-authored catalog item availability update.
  */
 export type CatalogItemAvailabilityUpdateResult = {
-  [k: string]: unknown | undefined;
 } & {
-  [k: string]: unknown | undefined;
 } & {
-  [k: string]: unknown | undefined;
 } & {
-  [k: string]: unknown | undefined;
 } & {
-  [k: string]: unknown | undefined;
 } & {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Zero-based index of the corresponding item_availability_updates entry.
@@ -19850,7 +17834,6 @@ export type CatalogItemAvailabilityUpdateResult = {
    */
   errors?: [CatalogItemAvailabilityError, ...CatalogItemAvailabilityError[]];
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Zero-based index of the corresponding item_availability_updates entry.
@@ -19899,23 +17882,18 @@ export type CatalogItemAvailabilityUpdateResult = {
    */
   errors?: [CatalogItemAvailabilityError, ...CatalogItemAvailabilityError[]];
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 };
 /**
  * Error returned by a catalog item availability operation. REFERENCE_NOT_FOUND has a deliberately closed, invariant shape so callers cannot distinguish unknown, inaccessible, unauthorized, or stale-generation references.
  */
 export type CatalogItemAvailabilityError = Error & {
-  [k: string]: unknown | undefined;
 };
 /**
  * Current buyer-authored availability overlay state for one requested catalog item. Results are returned in request order and identify their request position explicitly.
  */
 export type CatalogItemAvailabilityState = {
-  [k: string]: unknown | undefined;
 } & {
-  [k: string]: unknown | undefined;
 } & {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Zero-based index of the corresponding item_availability_queries entry.
@@ -19949,7 +17927,6 @@ export type CatalogItemAvailabilityState = {
    */
   errors?: [CatalogItemAvailabilityError, ...CatalogItemAvailabilityError[]];
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Zero-based index of the corresponding item_availability_queries entry.
@@ -19983,13 +17960,11 @@ export type CatalogItemAvailabilityState = {
    */
   errors?: [CatalogItemAvailabilityError, ...CatalogItemAvailabilityError[]];
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 };
 /**
  * Error response - operation failed completely, no catalogs were processed
  */
 export type SyncCatalogsError = {
-  [k: string]: unknown | undefined;
 };
 
 /**
@@ -20096,9 +18071,7 @@ export interface ProtocolEnvelope {
    * Conceptual grouping for the task-specific response data defined by individual task response schemas (e.g., get-products-response.json, create-media-buy-response.json). `payload` is a documentary construct — it is NOT a required wire field, and its on-the-wire shape depends on transport (see Transport serialization below). Task response schemas declare body fields without wrapping them in a `payload` object; the wire representation places those body fields per transport convention. On MCP the body fields appear as siblings of envelope fields at the root of the tool response; on A2A they appear inside `task.artifacts[0].parts[].DataPart`; on REST they appear at the root of the JSON body.
    */
   payload?: {
-    [k: string]: unknown | undefined;
   };
-  [k: string]: unknown | undefined;
 }
 /**
  * Request-level confirmation of structured hard targeting inferred from the brief. Sellers MUST include this when their structured interpretation of hard prose materially affects product eligibility, pricing, or forecasting; otherwise inclusion is a best practice. Omitted when no hard targeting was inferred from the brief.
@@ -20160,7 +18133,6 @@ export interface ProductAllocation {
   daypart_targets?: [DaypartTarget, ...DaypartTarget[]];
   forecast?: DeliveryForecast;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Re-export of `BrandReference` under the legacy codegen artifact name.
@@ -20216,7 +18188,6 @@ export interface InsertionOrder {
      * Payment terms
      */
     payment_terms?: 'net_30' | 'net_60' | 'net_90' | 'prepaid' | 'due_on_receipt';
-    [k: string]: unknown | undefined;
   };
   /**
    * URL to a human-readable document containing the full insertion order terms
@@ -20230,7 +18201,6 @@ export interface InsertionOrder {
    * Whether the buyer must accept this IO before creating a media buy. When true, create_media_buy requires an io_acceptance referencing this io_id.
    */
   requires_signature: boolean;
-  [k: string]: unknown | undefined;
 }
 /**
  * Cursor metadata for paginated get_products responses. In brief/refine mode, continuation pages bound returned products[] for the seller's curated or refined answer; proposals may accompany a page as plan metadata but are not independently counted by this pagination envelope, and pagination does not convert the response into an exhaustive feed contract. In wholesale mode, continuation pages walk the wholesale product feed.
@@ -20271,7 +18241,6 @@ export interface GetProductsAsyncWorking {
   step_number?: number;
   context?: ContextObject;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Input requirements for get_products needing clarification
@@ -20291,7 +18260,6 @@ export interface GetProductsAsyncInputRequired {
   suggestions?: string[];
   context?: ContextObject;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Acknowledgment for submitted get_products (custom curation)
@@ -20319,7 +18287,6 @@ export interface GetProductsAsyncSubmitted {
   errors?: Error[];
   context?: ContextObject;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Bounded submitted envelope shared by the compact lifecycle tools.
@@ -20331,7 +18298,6 @@ export interface CompactTaskSubmitted {
   errors?: Error[];
   context?: ContextObject;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Complete typed commercial envelope for a compact-lifecycle proposal. This is the authoritative audit and refinement snapshot; allocations and narrative fields are explanatory views rather than substitutes for these terms.
@@ -20354,10 +18320,8 @@ export interface CommercialTerms {
    */
   purchases: [
     ProductPurchase & {
-      [k: string]: unknown | undefined;
     },
     ...(ProductPurchase & {
-      [k: string]: unknown | undefined;
     })[]
   ];
   start_time: StartTiming;
@@ -20552,10 +18516,8 @@ export interface CanonicalProduct {
    */
   publisher_properties?: [
     PublisherPropertySelector & {
-      [k: string]: unknown | undefined;
     },
     ...(PublisherPropertySelector & {
-      [k: string]: unknown | undefined;
     })[]
   ];
   channels?: MediaChannel[];
@@ -20674,7 +18636,6 @@ export interface CanonicalForecastVendorMetricValue {
   unit?: string;
   measurable_impressions?: ForecastRange;
   breakdown?: {
-    [k: string]: unknown | undefined;
   };
 }
 /**
@@ -20862,7 +18823,6 @@ export interface CompactTaskWorking {
   step_number?: number;
   context?: ContextObject;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Input-required payload for any compact lifecycle task.
@@ -20873,7 +18833,6 @@ export interface CompactTaskInputRequired {
   errors?: Error[];
   context?: ContextObject;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Progress data for working get_signals
@@ -20897,7 +18856,6 @@ export interface GetSignalsAsyncWorking {
   step_number?: number;
   context?: ContextObject;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Acknowledgment for submitted get_signals (semantic discovery)
@@ -20925,7 +18883,6 @@ export interface GetSignalsAsyncSubmitted {
   errors?: Error[];
   context?: ContextObject;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Error response - operation failed, no media buy created
@@ -20939,7 +18896,6 @@ export interface CreateMediaBuyError {
   errors: [Error, ...Error[]];
   context?: ContextObject;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Async task envelope returned when the media buy cannot be confirmed before the response is emitted — for example, when a guaranteed buy requires IO signing, when governance review is outstanding, or when the seller has queued the request for batch processing. The buyer invokes get_task_status with task_id or receives a webhook when the task completes; the media_buy_id and packages land in the terminal result, not this envelope. Do not use a 'pending_approval' MediaBuy.status for this case — that value is not in MediaBuyStatus; IO review and similar pre-issuance workflows are modeled at the task layer only.
@@ -20963,7 +18919,6 @@ export interface CreateMediaBuySubmitted {
   errors?: Error[];
   context?: ContextObject;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Progress data for working create_media_buy
@@ -20987,7 +18942,6 @@ export interface CreateMediaBuyAsyncWorking {
   step_number?: number;
   context?: ContextObject;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Input requirements for create_media_buy needing user input
@@ -21003,7 +18957,6 @@ export interface CreateMediaBuyAsyncInputRequired {
   errors?: Error[];
   context?: ContextObject;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Acknowledgment for submitted create_media_buy
@@ -21027,7 +18980,6 @@ export interface CreateMediaBuyAsyncSubmitted {
   errors?: Error[];
   context?: ContextObject;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Success response - media buy updated successfully
@@ -21099,7 +19051,6 @@ export interface UpdateMediaBuySuccess {
   sandbox?: boolean;
   context?: ContextObject;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Re-export of `MeasurementTerms` under the legacy codegen artifact name.
@@ -21153,7 +19104,6 @@ export interface UpdateMediaBuyError {
   errors: [Error, ...Error[]];
   context?: ContextObject;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Async task envelope returned when update_media_buy cannot be confirmed before the response — for example, when operator re-approval is required for mid-flight changes. The buyer invokes get_task_status with task_id or receives a webhook when the task completes; the updated media buy state lands in the terminal result, not this envelope.
@@ -21177,7 +19127,6 @@ export interface UpdateMediaBuySubmitted {
   errors?: Error[];
   context?: ContextObject;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Progress data for working update_media_buy
@@ -21201,7 +19150,6 @@ export interface UpdateMediaBuyAsyncWorking {
   step_number?: number;
   context?: ContextObject;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Input requirements for update_media_buy needing user input
@@ -21213,7 +19161,6 @@ export interface UpdateMediaBuyAsyncInputRequired {
   reason?: 'APPROVAL_REQUIRED' | 'CHANGE_CONFIRMATION';
   context?: ContextObject;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Acknowledgment for submitted update_media_buy
@@ -21237,7 +19184,6 @@ export interface UpdateMediaBuyAsyncSubmitted {
   errors?: Error[];
   context?: ContextObject;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Delivery-report payload for media_buy_delivery webhook notifications. This is the inner result object carried by mcp-webhook-payload.json, not the full top-level get_media_buy_delivery task response envelope.
@@ -21269,7 +19215,6 @@ export interface MediaBuyDeliveryWebhookResult {
   reporting_period: {
     start: string;
     end: string;
-    [k: string]: unknown | undefined;
   };
   /**
    * ISO 4217 currency code.
@@ -21321,7 +19266,6 @@ export interface MediaBuyDeliveryWebhookResult {
     pacing_index?: number;
     totals: DeliveryMetrics & {
       effective_rate?: number;
-      [k: string]: unknown | undefined;
     };
     /**
      * Metrics broken down by package.
@@ -21341,9 +19285,7 @@ export interface MediaBuyDeliveryWebhookResult {
       finalized_at?: string;
       measurement_window?: string;
       supersedes_window?: string;
-      [k: string]: unknown | undefined;
     })[];
-    [k: string]: unknown | undefined;
   }[];
   /**
    * Task-specific delivery errors or warnings.
@@ -21352,7 +19294,6 @@ export interface MediaBuyDeliveryWebhookResult {
   sandbox?: boolean;
   context?: ContextObject;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Re-export of `BrandReference` under the legacy codegen artifact name.
@@ -21438,7 +19379,6 @@ export interface BuildCreativeSuccess {
            * Context description applied to this variant
            */
           context_description?: string;
-          [k: string]: unknown | undefined;
         };
       },
       ...{
@@ -21470,7 +19410,6 @@ export interface BuildCreativeSuccess {
            * Context description applied to this variant
            */
           context_description?: string;
-          [k: string]: unknown | undefined;
         };
       }[]
     ];
@@ -21499,7 +19438,6 @@ export interface BuildCreativeSuccess {
   consumption?: CreativeConsumption;
   context?: ContextObject;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Re-export of `BrandReference` under the legacy codegen artifact name.
@@ -21530,13 +19468,11 @@ export type BrandReference12 = BrandReference;
  * Deprecated 3.x compatibility branch. Manifest references a named format via the structured format_id object. New 3.2 manifests use format_kind.
  */
 export interface NamedFormatManifest {
-  [k: string]: unknown | undefined;
 }
 /**
  * Manifest declares which canonical format it targets via `format_kind` (e.g., `image`). This 3.1+ canonical-format path was introduced by RFC #3305.
  */
 export interface CanonicalFormatManifest {
-  [k: string]: unknown | undefined;
 }
 /**
  * Structured consumption details for this build. Informational — lets the buyer verify that vendor_cost is consistent with the rate card. vendor_cost is the billing source of truth.
@@ -21558,7 +19494,6 @@ export interface CreativeConsumption {
    * Processing time billed, in seconds. For compute-time pricing models.
    */
   duration_seconds?: number;
-  [k: string]: unknown | undefined;
 }
 /**
  * Multi-capability success response. Returned when the request used target_capability_ids (or deprecated target_format_ids). Contains one manifest per requested capability. Multi-output requests are atomic and preserve request order.
@@ -21590,18 +19525,14 @@ export interface BuildCreativeMultiSuccess {
     previews: [
       (
         | {
-            [k: string]: unknown | undefined;
           }
         | {
-            [k: string]: unknown | undefined;
           }
       ),
       ...(
         | {
-            [k: string]: unknown | undefined;
           }
         | {
-            [k: string]: unknown | undefined;
           }
       )[]
     ];
@@ -21630,7 +19561,6 @@ export interface BuildCreativeMultiSuccess {
   consumption?: CreativeConsumption;
   context?: ContextObject;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Multiplicity success response. Returned WHENEVER the request used max_creatives, max_variants > 1, variant_axis, or refine_from_build_variant_id — with or without a transformer_id. **There is no fallback to the single/multi-format shapes: a client that sends any of those inputs MUST handle this `creatives[]` shape; it will not receive `creative_manifest`/`creative_manifests`.** Carries creatives[] — one entry per produced creative group (per catalog item when fanning out) — each holding variants[] alternatives. The envelope semantics are fixed: creatives[] is the set of creative groups the call produced; variants[] is the choose-among set within each group. Every produced variant is a real, independently-billed build (you pay for all produced); the buyer keeps one or many by trafficking the chosen build_variant_id(s). Mutually exclusive with the other success/error/submitted shapes. Per-FORMAT remains atomic within a (creative) group; per-ITEM (catalog fan-out) is non-atomic — a failed item is reported via that creative's errors[] and does not fail the batch.
@@ -21644,18 +19574,14 @@ export interface BuildCreativeVariantSuccess {
   creatives: [
     (
       | {
-          [k: string]: unknown | undefined;
         }
       | {
-          [k: string]: unknown | undefined;
         }
     ),
     ...(
       | {
-          [k: string]: unknown | undefined;
         }
       | {
-          [k: string]: unknown | undefined;
         }
     )[]
   ];
@@ -21706,7 +19632,6 @@ export interface BuildCreativeVariantSuccess {
   expires_at?: string;
   context?: ContextObject;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Dry-run estimate. Returned when the request set mode:"estimate". The agent produced NOTHING and billed NOTHING; it returns a projected cost band computed against this request's actual inputs (script length, brief, catalog size, max_creatives × max_variants) — the band the buyer cannot derive itself because per_unit gives the rate but not the unit count. Advisory and non-binding in this revision. Mutually exclusive with the success/error/submitted shapes (discriminated by mode:"estimate" + the estimate object).
@@ -21765,16 +19690,13 @@ export interface BuildCreativeEstimate {
      */
     per_leaf?: {
       catalog_item_ref?: {
-        [k: string]: unknown | undefined;
       };
       variant_axis_value?: unknown;
       pricing_option_id?: string;
       cost_low?: number;
       cost_high?: number;
       consumption_estimate?: CreativeConsumption;
-      [k: string]: unknown | undefined;
     }[];
-    [k: string]: unknown | undefined;
   };
   /**
    * ISO 8601 timestamp after which this estimate's inputs/prices may no longer hold.
@@ -21782,7 +19704,6 @@ export interface BuildCreativeEstimate {
   expires_at?: string;
   context?: ContextObject;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Error response — creative generation failed. Multi-capability requests (`target_capability_ids[]`) are atomic: a single output failing means the entire batch returns an error response. Deprecated target_format_ids requests retain equivalent compatibility behavior.
@@ -21796,7 +19717,6 @@ export interface BuildCreativeError {
   errors: [Error, ...Error[]];
   context?: ContextObject;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Async task envelope returned when build_creative cannot be confirmed before the response — for example, when a slow generative pipeline or multi-minute LLM workflow is queued. The buyer invokes get_task_status with task_id or receives a webhook when the task completes; the creative_manifest(s) land in the terminal result, not this envelope.
@@ -21820,7 +19740,6 @@ export interface BuildCreativeSubmitted {
   errors?: Error[];
   context?: ContextObject;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Single preview response - each preview URL returns an HTML page that can be embedded in an iframe
@@ -21910,7 +19829,6 @@ export interface PreviewCreativeSingleResponse {
   expires_at?: string;
   context?: ContextObject;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Batch preview response - contains results for multiple creative requests
@@ -21931,7 +19849,6 @@ export interface PreviewCreativeBatchResponse {
   ];
   context?: ContextObject;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 export interface PreviewBatchResultSuccess {
   /**
@@ -21999,7 +19916,6 @@ export interface PreviewCreativeVariantResponse {
   expires_at?: string;
   context?: ContextObject;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Async task envelope returned only when the preview_creative request set allow_async to true and rendering cannot complete inline. The buyer polls get_task_status with task_id; the completed preview response is the task result.
@@ -22023,7 +19939,6 @@ export interface PreviewCreativeSubmitted {
   message?: string;
   context?: ContextObject;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Progress data for working build_creative
@@ -22047,7 +19962,6 @@ export interface BuildCreativeAsyncWorking {
   step_number?: number;
   context?: ContextObject;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Input requirements for build_creative needing user input
@@ -22063,7 +19977,6 @@ export interface BuildCreativeAsyncInputRequired {
   errors?: Error[];
   context?: ContextObject;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Acknowledgment for submitted build_creative
@@ -22087,7 +20000,6 @@ export interface BuildCreativeAsyncSubmitted {
   errors?: Error[];
   context?: ContextObject;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Success response - sync operation processed creatives (may include per-item failures)
@@ -22101,7 +20013,6 @@ export interface SyncCreativesSuccess {
    * Results for each creative processed. Items with action='failed' indicate per-item validation/processing failures, not operation-level failures.
    */
   creatives: {
-    [k: string]: unknown | undefined;
   }[];
   /**
    * When true, this response contains simulated data from sandbox mode.
@@ -22109,7 +20020,6 @@ export interface SyncCreativesSuccess {
   sandbox?: boolean;
   context?: ContextObject;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Error response - operation failed completely, no creatives were processed
@@ -22123,7 +20033,6 @@ export interface SyncCreativesError {
   errors: [Error, ...Error[]];
   context?: ContextObject;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Async task envelope returned when the whole sync operation cannot be confirmed before the response is emitted — for example, when the seller batches ingestion, when async review must settle before per-item results can be issued, or when governance review gates the sync. The buyer invokes get_task_status with task_id or receives a webhook when the task completes; the creatives array with per-item action/status lands in the terminal result, not this envelope. Per-item async review (an item in pending_review while the rest of the sync resolves synchronously) belongs on the SyncCreativesSuccess branch with status: pending_review, not here.
@@ -22147,7 +20056,6 @@ export interface SyncCreativesSubmitted {
   errors?: Error[];
   context?: ContextObject;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Progress data for working sync_creatives
@@ -22179,7 +20087,6 @@ export interface SyncCreativesAsyncWorking {
   creatives_total?: number;
   context?: ContextObject;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Input requirements for sync_creatives needing user input
@@ -22191,7 +20098,6 @@ export interface SyncCreativesAsyncInputRequired {
   reason?: 'APPROVAL_REQUIRED' | 'ASSET_CONFIRMATION' | 'FORMAT_CLARIFICATION';
   context?: ContextObject;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Acknowledgment for submitted sync_creatives
@@ -22215,7 +20121,6 @@ export interface SyncCreativesAsyncSubmitted {
   errors?: Error[];
   context?: ContextObject;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Success response - sync operation processed catalogs (may include per-catalog failures)
@@ -22233,7 +20138,6 @@ export interface SyncCatalogsSuccess {
    * Results for each catalog processed. Items with action='failed' indicate per-catalog validation/processing failures, not operation-level failures.
    */
   catalogs: {
-    [k: string]: unknown | undefined;
   }[];
   /**
    * Acknowledgements for item_availability_updates. The array length MUST equal the request array length; entry N MUST have request_index N, occupy position N, and exactly echo catalog_id, catalog_generation, item_id, and action from request entry N. Buyers MUST reject the response as non-conformant if count, ordering, request_index, or echoed identity differs. Lenient-mode failures stay in their request positions. In strict mode, any per-entry failure instead produces the operation-level error branch before mutation and this array is absent.
@@ -22255,7 +20159,6 @@ export interface SyncCatalogsSuccess {
   sandbox?: boolean;
   context?: ContextObject;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Async task envelope returned when a catalog-only sync cannot be confirmed before the response — for example, when catalog ingestion and deduplication are queued for batch processing. A request containing item_availability_updates or item_availability_queries MUST NOT return this branch because availability operations are synchronous; mixed requests whose catalog work cannot finish synchronously and atomically fail before mutation and are retried as separate calls. For catalog-only requests, the buyer invokes get_task_status with task_id or receives a webhook when the task completes; the per-catalog results land in the terminal result, not this envelope.
@@ -22279,7 +20182,6 @@ export interface SyncCatalogsSubmitted {
   errors?: Error[];
   context?: ContextObject;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Progress data for working sync_catalogs
@@ -22319,7 +20221,6 @@ export interface SyncCatalogsAsyncWorking {
   items_total?: number;
   context?: ContextObject;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Input requirements for sync_catalogs needing buyer input
@@ -22331,7 +20232,6 @@ export interface SyncCatalogsAsyncInputRequired {
   reason?: 'APPROVAL_REQUIRED' | 'FEED_VALIDATION' | 'ITEM_REVIEW' | 'FEED_ACCESS';
   context?: ContextObject;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Acknowledgment for submitted sync_catalogs
@@ -22355,7 +20255,6 @@ export interface SyncCatalogsAsyncSubmitted {
   errors?: Error[];
   context?: ContextObject;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 
 
@@ -22759,7 +20658,6 @@ export interface AcquireRightsAcquired {
    * Pre-built rights constraint for embedding in creative manifests. Populated from the agreed terms — the buyer does not need to construct it manually.
    */
   rights_constraint: RightsConstraint & {
-    [k: string]: unknown | undefined;
   };
   context?: ContextObject;
   ext?: ExtensionObject;
@@ -22783,9 +20681,7 @@ export interface RightsTerms {
   exclusivity?: {
     scope?: string;
     countries?: string[];
-    [k: string]: unknown | undefined;
   };
-  [k: string]: unknown | undefined;
 }
 /**
  * A scoped credential issued by an LLM provider for generating rights-cleared content. The rights agent coordinates with the provider to issue the credential; the provider enforces usage constraints at generation time. Any creative agent can use the credential.
@@ -22814,7 +20710,6 @@ export interface GenerationCredential {
    */
   endpoint?: string;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 export interface AcquireRightsPendingApproval {
   rights_id: string;
@@ -23699,7 +21594,6 @@ export interface RightsPricingOption {
    */
   description?: string;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 export interface GetRightsError {
   errors: Error[];
@@ -24003,7 +21897,6 @@ export interface UpdateRightsSuccess {
    * Updated rights constraint for re-embedding in creative manifests
    */
   rights_constraint: RightsConstraint & {
-    [k: string]: unknown | undefined;
   };
   /**
    * Whether the grant is currently paused. Included when the update changes pause state.
@@ -24265,9 +22158,7 @@ export interface ResponsePayload {
    * Canonical task-body success response payload being attested. Any unsigned task-body fields on the outer response, excluding signed_response and protocol/version envelope fields, MUST match this object.
    */
   response: {
-    [k: string]: unknown | undefined;
   };
-  [k: string]: unknown | undefined;
 }
 /**
  * Canonical task-body success payload signed inside signed_response.payload.response. Excludes protocol/version envelope fields and signed_response itself.
@@ -24639,7 +22530,6 @@ export type ComplianceTaskCompletionData = GetProductsCompletion | GetSignalsCom
  */
 export type GetProductsCompletion = AdCPVersionEnvelope &
   ProtocolEnvelope & {
-    [k: string]: unknown | undefined;
   } & {
     /**
      * Array of matching products
@@ -24650,7 +22540,6 @@ export type GetProductsCompletion = AdCPVersionEnvelope &
      * Bundled platform-extension definitions referenced by any product in `products`. Keyed by `<extension_uri>@<digest>` (e.g., `https://creative.adcontextprotocol.org/translated/meta/extensions/meta_pixel@sha256:abc...`). When present, lets buyers resolve `platform_extensions` references on product format declarations without a separate fetch. Buyer SDKs cache by URI@digest; subsequent get_products responses MAY omit definitions the buyer already has cached and rely on the digest match. Each value is an extension definition with `extends` (the canonical concept it extends, e.g., `tracking`), `fields` (the schema for additional fields the extension contributes), `version`, and optional `description`.
      */
     extensions?: {
-      [k: string]: unknown | undefined;
     };
     /**
      * Optional array of proposed media plans with budget allocations across products. Publishers include proposals when they can provide strategic guidance based on the brief. Proposals are actionable - buyers can refine them via follow-up get_products calls within the same session, or execute them directly via create_media_buy.
@@ -24933,7 +22822,6 @@ export type GetProductsCompletion = AdCPVersionEnvelope &
             }
           | undefined;
       };
-      [k: string]: unknown | undefined;
     };
     pagination?: PaginationResponse;
     /**
@@ -24958,7 +22846,6 @@ export type GetProductsCompletion = AdCPVersionEnvelope &
     sandbox?: boolean;
     context?: ContextObject;
     ext?: ExtensionObject;
-    [k: string]: unknown | undefined;
   };
 /**
  * Response payload for get_signals task
@@ -24970,7 +22857,6 @@ export type GetSignalsCompletion = AdCPVersionEnvelope &
      */
     signals?: (SignalListing &
       SignalDefinitionEnrichment & {
-        [k: string]: unknown | undefined;
       })[];
     /**
      * Task-specific errors and warnings (e.g., signal discovery or pricing issues)
@@ -25034,13 +22920,11 @@ export type GetSignalsCompletion = AdCPVersionEnvelope &
     sandbox?: boolean;
     context?: ContextObject;
     ext?: ExtensionObject;
-    [k: string]: unknown | undefined;
   };
 /**
  * Success response - media buy created successfully
  */
 export type CreateMediaBuyCompletion = {
-  [k: string]: unknown | undefined;
 };
 
 
@@ -25067,7 +22951,6 @@ export type AssetAccess =
        * Deprecated in AdCP 3.2 and eligible for removal in 4.0 or later only after the deprecation-policy notice and release-cycle gates are satisfied. Presence denotes the legacy inline-credential form, not workload-identity authorization. New producers MUST omit this field. Consumers MUST NOT activate received credentials automatically; they may process them only for an explicitly allowlisted legacy peer and otherwise MUST reject or quarantine them. Consumers MUST redact the complete value from logs, traces, errors, metrics, analytics, model context, and durable storage. Use the consumer's pre-authorized workload identity or `signed_url` instead.
        */
       credentials?: {
-        [k: string]: unknown | undefined;
       };
     }
   | {
@@ -25295,19 +23178,16 @@ export interface Artifact {
      * Open Graph protocol metadata
      */
     open_graph?: {
-      [k: string]: unknown | undefined;
     };
     /**
      * Twitter Card metadata
      */
     twitter_card?: {
-      [k: string]: unknown | undefined;
     };
     /**
      * JSON-LD structured data (schema.org)
      */
     json_ld?: {}[];
-    [k: string]: unknown | undefined;
   };
   provenance?: Provenance;
   /**
@@ -25334,9 +23214,7 @@ export interface Artifact {
      * RSS feed URL
      */
     rss_url?: string;
-    [k: string]: unknown | undefined;
   };
-  [k: string]: unknown | undefined;
 }
 
 // content-standards/content-standards.json
@@ -26006,7 +23884,6 @@ export interface OfferingAssetGroup {
     )[]
   ];
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 
 // core/asset-group-vocabulary.json
@@ -26018,7 +23895,6 @@ export interface OfferingAssetGroup {
  * **Two-tier boundary (normative).** This registry is the *canonical, portable* tier — IAB-aligned, platform-agnostic slot roles every adopter shares (`headline`, `body_text`, `main_image`, `cta`, `landing_page_url`, etc.). Platform-specific asset identifiers (e.g., YouTube video IDs, Pinterest pin IDs, TikTok video IDs, Snap attachment IDs, Meta Advantage+ creative IDs) MUST NOT be added here — they live on the canonical's `platform_extensions[]` (URI+digest reference to the platform's extension schema) so the canonical registry stays portable. Earlier drafts carried `youtube_video_id` and `pin_id` here; they were dropped in 3.1 GA precisely because adding them set precedent for every platform's identifier vocabulary to leak into the canonical tier, defeating the registry's portability purpose. Adopters needing to reference an existing platform-hosted asset attach a `platform_extensions[]` entry on the format declaration whose extension schema defines the platform-specific ID slot.
  */
 export interface AdCPAssetGroupVocabularyRegistry {
-  [k: string]: unknown | undefined;
 }
 
 
@@ -26528,7 +24404,6 @@ export interface CanonicalProjectionSlotOverride {
    * When false, slot is for moderation/review only and is NOT consumed by the seller's renderer (e.g., a brand-safety brief that informs review but doesn't appear in the rendered ad).
    */
   consumed_for_production?: boolean;
-  [k: string]: unknown | undefined;
 }
 
 
@@ -26971,7 +24846,6 @@ export interface LimitedSeries {
    * When the series ends (ISO 8601)
    */
   ends?: string;
-  [k: string]: unknown | undefined;
 }
 /**
  * Default deadline rules for installments of this collection. Agents compute absolute deadlines from each installment's scheduled_at and these lead times. Installments with explicit deadlines override this policy.
@@ -27004,7 +24878,6 @@ export interface DeadlinePolicy {
        * What the seller needs at this stage
        */
       label?: string;
-      [k: string]: unknown | undefined;
     },
     ...{
       /**
@@ -27019,14 +24892,12 @@ export interface DeadlinePolicy {
        * What the seller needs at this stage
        */
       label?: string;
-      [k: string]: unknown | undefined;
     }[]
   ];
   /**
    * When true, lead_days counts business days (Mon-Fri) rather than calendar days. Defaults to false.
    */
   business_days_only?: boolean;
-  [k: string]: unknown | undefined;
 }
 
 // core/creative-delivery-metrics.json
@@ -27187,7 +25058,6 @@ export type CreativeItem =
  * An asset inside a materialized creative locale variant. Text and markdown assets may omit language when they make no language claim. When language is present, it MUST use the shared AdCP BCP 47 wire profile; conformance additionally requires exact equality with the enclosing variant locale.
  */
 export type LocalizedCreativeAsset = AssetVariant & {
-  [k: string]: unknown | undefined;
 };
 /**
  * Exact materialized locale state for one creative, including source-only monolingual topology. Review and serving eligibility remain creative-wide on the enclosing creative; locale variants do not have independent lifecycle states. Presence means every source/target variant was read back completely. Sellers MUST return localization_unavailable on list_creatives rather than a partial or lossy localization object.
@@ -27956,7 +25826,6 @@ export interface EventSurface {
  * User identifiers for attribution matching
  */
 export type UserMatch = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Universal ID values for user matching
@@ -27970,7 +25839,6 @@ export type UserMatch = {
        * Universal ID value
        */
       value: string;
-      [k: string]: unknown | undefined;
     },
     ...{
       type: UIDType;
@@ -27978,7 +25846,6 @@ export type UserMatch = {
        * Universal ID value
        */
       value: string;
-      [k: string]: unknown | undefined;
     }[]
   ];
   /**
@@ -28006,7 +25873,6 @@ export type UserMatch = {
    */
   client_user_agent?: string;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 };
 /**
  * A marketing event (conversion, engagement, or custom) for attribution and optimization
@@ -28134,7 +26000,6 @@ export interface FlightItem {
  * Without this contract, every promotion event silently breaks adopter code branching on `format_kind == "custom"`. With it, the breakage surfaces as a structured warning during the transition window and adopters can update their branching ahead of the cutover.
  */
 export interface AdCPFormatShapeVocabularyRegistry {
-  [k: string]: unknown | undefined;
 }
 
 
@@ -28996,7 +26861,6 @@ export interface Indicator {
    */
   scope?: [IndicatorScope, ...IndicatorScope[]];
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 
 // core/indicators-changed-webhook.json
@@ -29667,7 +27531,6 @@ export interface PerformanceFeedback {
  * Canonical placement definition published in a publisher's adagents.json. Defines stable placement IDs that products can reuse and that authorization rules can reference. When a product reuses a registered placement_id, it is referring to this same semantic placement, not inventing a new one with the same ID.
  */
 export type PlacementDefinition = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Stable placement identifier unique within this adagents.json file.
@@ -29733,7 +27596,6 @@ export type PlacementDefinition = {
  * Inline 3.1+ canonical format-option declaration. Use when the placement narrows a format in a way that's not worth a top-level catalog entry.
  */
 export type InlineDeclaration = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Stable identifier for this declaration within its namespace. REQUIRED when a product contains multiple declarations with the same format_kind and SHOULD be set on every entry. Publisher-backed options pair it with publisher_domain; product-local options omit publisher_domain. When a single declaration has a unique format_kind and no ID, buyers author canonically with format_kind plus params; they MUST NOT fall back to deprecated format_ids merely because this optional ID is absent. Examples: 'display_image_300x250', 'responsive_search', 'daily_pulse_homepage_image'.
@@ -31070,7 +28932,6 @@ export interface ImageAssetRequirements {
    * Maximum weight in grams for the finished physical piece (print inserts, flyers). Affects postage calculations and production constraints. Only applicable to print channels.
    */
   max_weight_grams?: number;
-  [k: string]: unknown | undefined;
 }
 /**
  * Requirements for video creative assets. These define the technical constraints for video files.
@@ -31168,7 +29029,6 @@ export interface VideoAssetRequirements {
    * Maximum true peak level in dBFS (e.g., -2 for broadcast)
    */
   true_peak_dbfs?: number;
-  [k: string]: unknown | undefined;
 }
 /**
  * Requirements for audio creative assets.
@@ -31218,7 +29078,6 @@ export interface AudioAssetRequirements {
    * Maximum true-peak level in dBFS.
    */
   true_peak_dbfs?: number;
-  [k: string]: unknown | undefined;
 }
 /**
  * Requirements for text creative assets such as headlines, body copy, and CTAs.
@@ -31254,7 +29113,6 @@ export interface TextAssetRequirements {
    * @minItems 1
    */
   allowed_values?: [string, ...string[]];
-  [k: string]: unknown | undefined;
 }
 /**
  * Requirements for markdown creative assets.
@@ -31264,7 +29122,6 @@ export interface MarkdownAssetRequirements {
    * Maximum character length
    */
   max_length?: number;
-  [k: string]: unknown | undefined;
 }
 /**
  * Requirements for HTML creative assets. These define the execution environment constraints that the HTML must be compatible with.
@@ -31286,7 +29143,6 @@ export interface HTMLAssetRequirements {
    * List of domains the HTML creative may reference for external resources. Only applicable when external_resources_allowed is true.
    */
   allowed_external_domains?: string[];
-  [k: string]: unknown | undefined;
 }
 /**
  * Requirements for CSS creative assets.
@@ -31296,7 +29152,6 @@ export interface CSSAssetRequirements {
    * Maximum file size in kilobytes
    */
   max_file_size_kb?: number;
-  [k: string]: unknown | undefined;
 }
 /**
  * Requirements for JavaScript creative assets. These define the execution environment constraints that the JavaScript must be compatible with.
@@ -31322,14 +29177,12 @@ export interface JavaScriptAssetRequirements {
    * List of domains the JavaScript may reference for external resources. Only applicable when external_resources_allowed is true.
    */
   allowed_external_domains?: string[];
-  [k: string]: unknown | undefined;
 }
 /**
  * Requirements for VAST (Video Ad Serving Template) creative assets.
  */
 export interface VASTAssetRequirements {
   vast_version?: VASTVersion;
-  [k: string]: unknown | undefined;
 }
 /**
  * Requirements for DAAST (Digital Audio Ad Serving Template) creative assets.
@@ -31339,7 +29192,6 @@ export interface DAASTAssetRequirements {
    * Required DAAST version. DAAST 1.0 is the current IAB standard.
    */
   daast_version?: '1.0';
-  [k: string]: unknown | undefined;
 }
 /**
  * Requirements for URL assets such as click-through URLs, tracking pixels, and landing pages.
@@ -31371,7 +29223,6 @@ export interface URLAssetRequirements {
    * Whether the URL supports macro substitution (e.g., ${CACHEBUSTER})
    */
   macro_support?: boolean;
-  [k: string]: unknown | undefined;
 }
 /**
  * Requirements for webhook creative assets.
@@ -31381,7 +29232,6 @@ export interface WebhookAssetRequirements {
    * Allowed HTTP methods
    */
   methods?: ('GET' | 'POST')[];
-  [k: string]: unknown | undefined;
 }
 
 
@@ -31501,7 +29351,6 @@ export interface OfferingAssetConstraint {
   max_count?: number;
   asset_requirements?: AssetRequirements;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 
 // core/response.json
@@ -31586,10 +29435,8 @@ export interface SignalCoverageForecast {
    */
   points: (ForecastPoint & {
     dimensions: {
-      [k: string]: unknown | undefined;
     };
     metrics?: {
-      [k: string]: unknown | undefined;
     };
   })[];
   /**
@@ -32680,13 +30527,11 @@ export type Transformer = (CanonicalTransformerOutputs | NamedFormatTransformerO
   };
 };
 export interface CanonicalTransformerOutputs {
-  [k: string]: unknown | undefined;
 }
 /**
  * @deprecated
  */
 export interface NamedFormatTransformerOutputs {
-  [k: string]: unknown | undefined;
 }
 
 // core/truncation-sentinel.json
@@ -34316,7 +32161,6 @@ export interface PolicyReference {
 
 // manifest.json
 export interface Manifest {
-  [k: string]: unknown | undefined;
 }
 
 
@@ -34787,7 +32631,6 @@ export type ProposalRefinement = {
     }
   | (
       | {
-          [k: string]: unknown | undefined;
         }
       | {
           change_kind: 'cancellation';
@@ -34992,7 +32835,6 @@ export interface PropertyFeatureValue {
    * Additional vendor-specific details about this measurement
    */
   details?: {
-    [k: string]: unknown | undefined;
   };
   ext?: ExtensionObject;
 }
@@ -35522,7 +33364,6 @@ export interface SISponsoredContext {
      * Human-readable label for disclosure rendering. The canonical identity remains the brand/account reference.
      */
     display_name?: string;
-    [k: string]: unknown | undefined;
   };
   context_use: SIContextUse;
   /**
@@ -35564,7 +33405,6 @@ export interface SISponsoredContext {
          * Regulation or policy identifier.
          */
         regulation: string;
-        [k: string]: unknown | undefined;
       },
       ...{
         /**
@@ -35579,10 +33419,8 @@ export interface SISponsoredContext {
          * Regulation or policy identifier.
          */
         regulation: string;
-        [k: string]: unknown | undefined;
       }[]
     ];
-    [k: string]: unknown | undefined;
   };
   /**
    * When this sponsored-context declaration was made.
@@ -35600,10 +33438,8 @@ export interface SISponsoredContext {
      * Role of the declaring party.
      */
     role: 'brand_agent' | 'seller' | 'network' | 'platform';
-    [k: string]: unknown | undefined;
   };
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 
 // sponsored-intelligence/si-ui-element.json
@@ -35923,7 +33759,6 @@ export interface Offer {
   creative_data?: {
     [k: string]: string | undefined;
   };
-  [k: string]: unknown | undefined;
 }
 /**
  * Price for this offer. Only present when the product supports variable pricing. For fixed-price packages, price is already set on the media buy.
@@ -36475,6 +34310,9 @@ export interface PublisherTMPXMacroMapping {
   };
 }
 
+
+/** @deprecated AdCP 3.1 renamed SignalCatalogType to SignalAvailabilityType. */
+export type SignalCatalogType = SignalAvailabilityType;
 
 /** @deprecated AdCP 3.1.10 renamed the publisher-facing response to distinguish it from the provider hop. */
 export type IdentityMatchResponse = IdentityMatchResponseRouterPublisher;

--- a/src/lib/types/inline-enums.generated.ts
+++ b/src/lib/types/inline-enums.generated.ts
@@ -224,12 +224,36 @@ export const CanonicalReportingCapabilities_DateRangeSupportValues = ["date_rang
 /** single | CapabilitiesChangedWebhook.reason */
 export const CapabilitiesChangedWebhook_ReasonValues = ["configuration_changed", "deployment_changed", "capability_enabled", "capability_disabled", "protocol_versions_changed", "manual_refresh", "other"] as const;
 
+// ====== CatalogFieldMapping ======
+
+/** single | CatalogFieldMapping.transform */
+export const CatalogFieldMapping_TransformValues = ["date", "divide", "boolean", "split"] as const;
+
 // ====== CatalogItemAvailabilityError ======
 
 /** single | CatalogItemAvailabilityError.recovery */
 export const CatalogItemAvailabilityError_RecoveryValues = ["transient", "correctable", "terminal"] as const;
 /** single | CatalogItemAvailabilityError.source */
 export const CatalogItemAvailabilityError_SourceValues = ["producer", "sdk"] as const;
+
+// ====== CatalogItemAvailabilityState ======
+
+/** single | CatalogItemAvailabilityState.availability */
+export const CatalogItemAvailabilityState_AvailabilityValues = ["active", "suppressed"] as const;
+/** single | CatalogItemAvailabilityState.status */
+export const CatalogItemAvailabilityState_StatusValues = ["found", "failed"] as const;
+
+// ====== CatalogItemAvailabilityUpdate ======
+
+/** single | CatalogItemAvailabilityUpdate.action */
+export const CatalogItemAvailabilityUpdate_ActionValues = ["suppress", "restore"] as const;
+/** single | CatalogItemAvailabilityUpdate.reason */
+export const CatalogItemAvailabilityUpdate_ReasonValues = ["out_of_stock", "back_in_stock", "content_unavailable", "content_available", "promotion_start", "promotion_end", "time_window_started", "time_window_expired", "buyer_request", "other"] as const;
+
+// ====== CatalogItemAvailabilityUpdateResult ======
+
+/** single | CatalogItemAvailabilityUpdateResult.status */
+export const CatalogItemAvailabilityUpdateResult_StatusValues = ["applied", "unchanged", "failed"] as const;
 
 // ====== CheckGovernanceResponse ======
 
@@ -250,6 +274,11 @@ export const ControllerError_ErrorValues = ["INVALID_TRANSITION", "INVALID_STATE
 
 /** single | CreateMediaBuyAsyncInputRequired.reason */
 export const CreateMediaBuyAsyncInputRequired_ReasonValues = ["APPROVAL_REQUIRED", "BUDGET_EXCEEDS_LIMIT"] as const;
+
+// ====== CreativeAssignment ======
+
+/** single | CreativeAssignment.rotation_mode */
+export const CreativeAssignment_RotationModeValues = ["weighted", "even", "sequential", "random"] as const;
 
 // ====== CreativeAssignmentChangedWebhook ======
 
@@ -273,6 +302,11 @@ export const CreativePurgedWebhook_PurgeKindValues = ["soft", "hard"] as const;
 /** single | CreativeVariable.variable_type */
 export const CreativeVariable_VariableTypeValues = ["text", "image", "video", "audio", "url", "number", "boolean", "color", "date"] as const;
 
+// ====== DAASTTrackerAsset ======
+
+/** single | DAASTTrackerAsset.target */
+export const DAASTTrackerAsset_TargetValues = ["linear", "companion"] as const;
+
 // ====== DestinationItem ======
 
 /** single | DestinationItem.destination_type */
@@ -289,6 +323,15 @@ export const DiagnosticIssue_SeverityValues = ["error", "warning", "info"] as co
 export const DigestAttestation_MethodValues = ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"] as const;
 /** single | DigestAttestation.purpose */
 export const DigestAttestation_PurposeValues = ["platform_primary", "measurement", "attribution", "creative_serving", "identity", "other"] as const;
+
+// ====== DownstreamConnectionRequirement ======
+
+/** single | DownstreamConnectionRequirement.connection_type */
+export const DownstreamConnectionRequirement_ConnectionTypeValues = ["advertiser_account", "publisher_identity", "post_authorization"] as const;
+/** single | DownstreamConnectionRequirement.scope */
+export const DownstreamConnectionRequirement_ScopeValues = ["account", "identity", "post", "unknown"] as const;
+/** single | DownstreamConnectionRequirement.status */
+export const DownstreamConnectionRequirement_StatusValues = ["connected", "missing", "pending", "expired", "revoked", "not_required", "unknown"] as const;
 
 // ====== Duration ======
 
@@ -470,6 +513,13 @@ export const PackageStatus_IndicatorTypesEvaluatedValues = ["creative_diversity_
 /** single | PerformanceFeedback.status */
 export const PerformanceFeedback_StatusValues = ["accepted", "queued", "applied", "rejected"] as const;
 
+// ====== PixelTrackerAsset ======
+
+/** single | PixelTrackerAsset.event */
+export const PixelTrackerAsset_EventValues = ["impression", "viewable_mrc_50", "viewable_mrc_100", "viewable_video_50", "audible_video_complete", "click", "custom"] as const;
+/** single | PixelTrackerAsset.method */
+export const PixelTrackerAsset_MethodValues = ["img", "js"] as const;
+
 // ====== PolicyEntry ======
 
 /** single | PolicyEntry.source */
@@ -484,6 +534,11 @@ export const PreviewCreativeRequest_RequestTypeValues = ["single", "batch", "var
 
 /** single | Price.period */
 export const Price_PeriodValues = ["night", "month", "year", "one_time"] as const;
+
+// ====== ProductCardReferenceAsset ======
+
+/** single | ProductCardReferenceAsset.role */
+export const ProductCardReferenceAsset_RoleValues = ["coverage_map", "sample_render", "environment_photo", "media_kit", "logo", "other"] as const;
 
 // ====== PropertyError ======
 
@@ -570,6 +625,13 @@ export const ReportPlanOutcomeResponse_OutcomeStateValues = ["accepted", "findin
 /** single | ResponsePayload.task */
 export const ResponsePayload_TaskValues = ["verify_brand_claim", "verify_brand_claims"] as const;
 
+// ====== RightsConstraint ======
+
+/** single | RightsConstraint.approval_status */
+export const RightsConstraint_ApprovalStatusValues = ["pending", "approved", "rejected"] as const;
+/** single | RightsConstraint.grant_status */
+export const RightsConstraint_GrantStatusValues = ["active", "paused", "revoked"] as const;
+
 // ====== SearchBrandResult ======
 
 /** single | SearchBrandResult.relationship_trust */
@@ -602,11 +664,6 @@ export const SignalDefinition_LookbackWindowValues = ["intra_day", "daily", "wee
 /** single | SignalDefinition.methodology */
 export const SignalDefinition_MethodologyValues = ["observed", "declared", "derived", "inferred", "modeled"] as const;
 
-// ====== SignalForecastDimension ======
-
-/** single | SignalForecastDimension.presence */
-export const SignalForecastDimension_PresenceValues = ["present", "absent"] as const;
-
 // ====== SignalSelectionGroupRule ======
 
 /** single | SignalSelectionGroupRule.selection_mode */
@@ -631,6 +688,11 @@ export const SIIdentity_ConsentScopeValues = ["name", "email", "shipping_address
 
 /** single | SITerminateSessionRequest.reason */
 export const SITerminateSessionRequest_ReasonValues = ["handoff_transaction", "handoff_complete", "user_exit", "session_timeout", "host_terminated"] as const;
+
+// ====== SIUIElement ======
+
+/** single | SIUIElement.type */
+export const SIUIElement_TypeValues = ["text", "link", "image", "product_card", "carousel", "action_button", "app_handoff", "integration_actions"] as const;
 
 // ====== SyncAgentNotificationConfigsResponse ======
 
@@ -657,6 +719,13 @@ export const TMPError_CodeValues = ["invalid_request", "unknown_package", "selle
 /** single | TMPProviderRegistration.status */
 export const TMPProviderRegistration_StatusValues = ["active", "inactive", "draining"] as const;
 
+// ====== TransformerParam ======
+
+/** single | TransformerParam.type */
+export const TransformerParam_TypeValues = ["string", "number", "integer", "boolean"] as const;
+/** single | TransformerParam.value_source */
+export const TransformerParam_ValueSourceValues = ["inline", "range", "enumerable", "free_text"] as const;
+
 // ====== UpdateMediaBuyAsyncInputRequired ======
 
 /** single | UpdateMediaBuyAsyncInputRequired.reason */
@@ -669,10 +738,20 @@ export const URLAssetRequirements_ProtocolsValues = ["https", "http"] as const;
 /** single | URLAssetRequirements.role */
 export const URLAssetRequirements_RoleValues = ["clickthrough", "landing_page", "impression_tracker", "click_tracker", "viewability_tracker", "third_party_tracker"] as const;
 
+// ====== ValidateInputResult ======
+
+/** single | ValidateInputResult.result_kind */
+export const ValidateInputResult_ResultKindValues = ["validated_pass", "validated_fail", "unvalidatable_nondeterministic"] as const;
+
 // ====== ValidationResult ======
 
 /** single | ValidationResult.status */
 export const ValidationResult_StatusValues = ["compliant", "non_compliant", "not_covered", "unidentified"] as const;
+
+// ====== VASTTrackerAsset ======
+
+/** single | VASTTrackerAsset.target */
+export const VASTTrackerAsset_TargetValues = ["linear", "non_linear", "companion"] as const;
 
 // ====== VehicleItem ======
 
@@ -814,6 +893,11 @@ export const CanonicalFormatVASTVideo_ReferenceMutabilityValues = CanonicalForma
 // --- CanonicalProjectionReference ---
 /** @deprecated use `CanonicalFormatHostedAudio_AssetSourceValues` — same literal set, CanonicalProjectionReference.asset_source duplicates the canonical export. */
 export const CanonicalProjectionReference_AssetSourceValues = CanonicalFormatHostedAudio_AssetSourceValues;
+// --- CatalogItemAvailabilityUpdateResult ---
+/** @deprecated use `CatalogItemAvailabilityUpdate_ActionValues` — same literal set, CatalogItemAvailabilityUpdateResult.action duplicates the canonical export. */
+export const CatalogItemAvailabilityUpdateResult_ActionValues = CatalogItemAvailabilityUpdate_ActionValues;
+/** @deprecated use `CatalogItemAvailabilityState_AvailabilityValues` — same literal set, CatalogItemAvailabilityUpdateResult.availability duplicates the canonical export. */
+export const CatalogItemAvailabilityUpdateResult_AvailabilityValues = CatalogItemAvailabilityState_AvailabilityValues;
 // --- CreativeBrief ---
 /** @deprecated use `BriefAsset_ObjectiveValues` — same literal set, CreativeBrief.objective duplicates the canonical export. */
 export const CreativeBrief_ObjectiveValues = BriefAsset_ObjectiveValues;
@@ -865,6 +949,15 @@ export const SearchBrandResult_KellerTypeValues = GetBrandIdentitySuccess_Keller
 // --- SignalDefinition ---
 /** @deprecated use `SignalDefinition_LookbackWindowValues` — same literal set, SignalDefinition.refresh_cadence duplicates the canonical export. */
 export const SignalDefinition_RefreshCadenceValues = SignalDefinition_LookbackWindowValues;
+// --- SignalDefinitionEnrichment ---
+/** @deprecated use `SignalDefinition_Art9BasisValues` — same literal set, SignalDefinitionEnrichment.art9_basis duplicates the canonical export. */
+export const SignalDefinitionEnrichment_Art9BasisValues = SignalDefinition_Art9BasisValues;
+/** @deprecated use `SignalDefinition_LookbackWindowValues` — same literal set, SignalDefinitionEnrichment.lookback_window duplicates the canonical export. */
+export const SignalDefinitionEnrichment_LookbackWindowValues = SignalDefinition_LookbackWindowValues;
+/** @deprecated use `SignalDefinition_MethodologyValues` — same literal set, SignalDefinitionEnrichment.methodology duplicates the canonical export. */
+export const SignalDefinitionEnrichment_MethodologyValues = SignalDefinition_MethodologyValues;
+/** @deprecated use `SignalDefinition_LookbackWindowValues` — same literal set, SignalDefinitionEnrichment.refresh_cadence duplicates the canonical export. */
+export const SignalDefinitionEnrichment_RefreshCadenceValues = SignalDefinition_LookbackWindowValues;
 // --- SignalSelectionGroupRule ---
 /** @deprecated use `FeatureRequirement_IfNotCoveredValues` — same literal set, SignalSelectionGroupRule.targeting_mode duplicates the canonical export. */
 export const SignalSelectionGroupRule_TargetingModeValues = FeatureRequirement_IfNotCoveredValues;

--- a/src/lib/types/schemas.generated.ts
+++ b/src/lib/types/schemas.generated.ts
@@ -1,5 +1,5 @@
 // Generated Zod v4 schemas from TypeScript types
-// Generated at: 2026-08-18T18:27:18.293Z
+// Generated at: 2026-08-18T18:52:10.343Z
 // Sources:
 //   - core.generated.ts (core types)
 //   - tools.generated.ts (tool types)
@@ -13432,15 +13432,30 @@ export const SourceLocalizationReadbackSchema = z.object({
     assets: ResolvedAssetsSchema
 }).passthrough();
 
-export const FormatSchema = z.object({}).passthrough().merge(z.object({
+export const FormatSchema = z.object({
     format_id: FormatReferenceStructuredObjectSchema,
     name: z.string(),
     description: z.string().optional(),
     example_url: z.string().optional(),
     accepts_parameters: z.array(FormatIDParameterSchema).optional(),
-    renders: z.tuple([z.union([z.object({}).passthrough(), z.object({
-                parameters_from_format_id: z.literal(true)
-            }).passthrough()])]).rest(z.union([z.object({}).passthrough(), z.object({
+    renders: z.array(z.union([z.object({
+            role: z.string(),
+            dimensions: z.object({
+                width: z.number().optional(),
+                height: z.number().optional(),
+                min_width: z.number().optional(),
+                min_height: z.number().optional(),
+                max_width: z.number().optional(),
+                max_height: z.number().optional(),
+                unit: DimensionUnitSchema.optional(),
+                responsive: z.object({
+                    width: z.boolean(),
+                    height: z.boolean()
+                }).passthrough().optional(),
+                aspect_ratio: z.string().regex(/^\d+(\.\d+)?:\d+(\.\d+)?$/).optional()
+            }).passthrough()
+        }).passthrough(), z.object({
+            role: z.string(),
             parameters_from_format_id: z.literal(true)
         }).passthrough()])).optional(),
     assets: z.array(z.union([z.union([IndividualImageAssetSchema, IndividualVideoAssetSchema, IndividualAudioAssetSchema, IndividualTextAssetSchema, IndividualMarkdownAssetSchema, IndividualHtmlAssetSchema, IndividualCssAssetSchema, IndividualJavaScriptAssetSchema, IndividualZipAssetSchema, IndividualVastAssetSchema, IndividualDaastAssetSchema, IndividualUrlAssetSchema, IndividualWebhookAssetSchema, IndividualBriefAssetSchema, IndividualCatalogAssetSchema]), RepeatableGroupAssetSchema])).optional(),
@@ -13457,10 +13472,7 @@ export const FormatSchema = z.object({}).passthrough().merge(z.object({
         requires_accessible_assets: z.boolean().optional()
     }).passthrough().optional(),
     supported_disclosure_positions: z.array(DisclosurePositionSchema).optional(),
-    disclosure_capabilities: z.tuple([z.object({
-            position: DisclosurePositionSchema,
-            persistence: z.array(DisclosurePersistenceSchema)
-        }).passthrough()]).rest(z.object({
+    disclosure_capabilities: z.array(z.object({
         position: DisclosurePositionSchema,
         persistence: z.array(DisclosurePersistenceSchema)
     }).passthrough()).optional(),
@@ -13472,7 +13484,7 @@ export const FormatSchema = z.object({}).passthrough().merge(z.object({
     pricing_options: z.array(VendorPricingOptionSchema).optional(),
     canonical: CanonicalProjectionReferenceSchema.optional(),
     canonical_parameters: ProductFormatDeclarationSchema.optional()
-}).passthrough());
+}).passthrough();
 
 export const GeoDeliveryMetricsSchema = DeliveryMetricsSchema.merge(z.object({
     geo_level: GeographicTargetingLevelSchema,

--- a/src/lib/types/schemas.generated.ts
+++ b/src/lib/types/schemas.generated.ts
@@ -1,5 +1,5 @@
 // Generated Zod v4 schemas from TypeScript types
-// Generated at: 2026-08-18T17:26:19.019Z
+// Generated at: 2026-08-18T18:27:18.293Z
 // Sources:
 //   - core.generated.ts (core types)
 //   - tools.generated.ts (tool types)
@@ -305,8 +305,6 @@ export const SISessionStatusSchema = z.union([z.literal("active"), z.literal("pe
 
 export const SignalAvailabilityTypeSchema = z.union([z.literal("marketplace"), z.literal("custom"), z.literal("owned")]);
 
-export const SignalCatalogTypeSchema = SignalAvailabilityTypeSchema;
-
 export const SignalSourceSchema = z.union([z.literal("catalog"), z.literal("agent")]);
 
 export const SignalValueTypeSchema = z.union([z.literal("binary"), z.literal("categorical"), z.literal("numeric")]);
@@ -515,14 +513,14 @@ export const PropertyIDSchema = z.string();
 
 export const PropertyTagSchema = z.string();
 
-export const GeoForecastDimensionSchema = z.object({
+export const GeoForecastDimensionSchema = z.object({}).passthrough().merge(z.object({}).passthrough()).merge(z.object({}).passthrough()).merge(z.object({}).passthrough()).merge(z.object({
     kind: z.literal("geo"),
     geo_level: GeographicTargetingLevelSchema,
     system: z.string().optional(),
     country: z.string().optional(),
     geo_code: z.string(),
     geo_name: z.string().optional()
-}).passthrough();
+}).passthrough());
 
 export const DeviceTypeForecastDimensionSchema = z.object({
     kind: z.literal("device_type"),
@@ -721,7 +719,7 @@ export const CancellationPolicySchema = z.object({
         }).passthrough()])
 }).passthrough();
 
-export const BiddingPolicySchema = z.object({
+export const BiddingPolicySchema = z.object({}).passthrough().merge(z.object({
     automatic: z.literal(true).optional(),
     bid_amount: z.number().optional(),
     max_bid: z.number().optional(),
@@ -733,31 +731,31 @@ export const BiddingPolicySchema = z.object({
         value: z.number(),
         strength: z.union([z.literal("floor"), z.literal("target")])
     }).passthrough().optional()
-}).passthrough();
+}).passthrough());
 
-export const CatalogFieldMappingSchema = z.record(z.string(), z.unknown()).and(z.object({
+export const CatalogFieldMappingSchema = z.object({}).passthrough().merge(z.object({}).passthrough()).merge(z.object({
     feed_field: z.string().optional(),
     catalog_field: z.string().optional(),
     asset_group_id: z.string().optional(),
-    value: z.record(z.string(), z.unknown()).optional(),
+    value: z.object({}).passthrough().optional(),
     transform: z.union([z.literal("date"), z.literal("divide"), z.literal("boolean"), z.literal("split")]).optional(),
     format: z.string().optional(),
     timezone: z.string().optional(),
     by: z.number().optional(),
     separator: z.string().optional(),
-    default: z.record(z.string(), z.unknown()).optional(),
+    default: z.object({}).passthrough().optional(),
     ext: ExtensionObjectSchema.optional()
-}).passthrough()).and(z.object({
+}).passthrough()).merge(z.object({
     feed_field: z.string().optional(),
     catalog_field: z.string().optional(),
     asset_group_id: z.string().optional(),
-    value: z.record(z.string(), z.unknown()).optional(),
+    value: z.object({}).passthrough().optional(),
     transform: z.union([z.literal("date"), z.literal("divide"), z.literal("boolean"), z.literal("split")]).optional(),
     format: z.string().optional(),
     timezone: z.string().optional(),
     by: z.number().optional(),
     separator: z.string().optional(),
-    default: z.record(z.string(), z.unknown()).optional(),
+    default: z.object({}).passthrough().optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough());
 
@@ -774,9 +772,9 @@ export const DaypartTargetSchema = z.object({
     label: z.string().optional()
 }).passthrough();
 
-export const SignalTargetingSchema = z.union([z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())])]);
+export const SignalTargetingSchema = z.union([z.union([z.object({}).passthrough(), z.object({}).passthrough()]), z.union([z.object({}).passthrough(), z.object({}).passthrough()]), z.union([z.object({}).passthrough(), z.object({}).passthrough()])]);
 
-export const FrequencyCapSchema = z.record(z.string(), z.unknown()).and(z.object({
+export const FrequencyCapSchema = z.object({}).passthrough().merge(z.object({
     suppress: DurationSchema.optional(),
     suppress_minutes: z.number().optional(),
     max_impressions: z.number().optional(),
@@ -831,7 +829,7 @@ export const PostalCountrySystemSchema = z.union([z.object({
         country: z.literal("ZA").optional(),
         system: z.literal("postal_code").optional()
     }).passthrough(), z.object({
-        country: z.record(z.string(), z.unknown()).optional(),
+        country: z.object({}).passthrough().optional(),
         system: z.union([z.literal("postal_code"), z.literal("custom")]).optional()
     }).passthrough()]).and(z.object({
     country: z.string(),
@@ -848,7 +846,7 @@ export const SignalTargetingExpressionSchema = z.union([z.object({
         signal_ref: SignalRefSchema,
         value_type: z.literal("categorical"),
         values: z.array(z.string())
-    }).passthrough(), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())])]);
+    }).passthrough(), z.union([z.object({}).passthrough(), z.object({}).passthrough()])]);
 
 export const ActivationKeySchema = z.union([z.object({
         type: z.literal("segment_id"),
@@ -859,7 +857,7 @@ export const ActivationKeySchema = z.union([z.object({
         value: z.string()
     }).passthrough()]);
 
-export const DemographicAgeRangeSchema = z.record(z.string(), z.unknown()).and(z.object({
+export const DemographicAgeRangeSchema = z.object({}).passthrough().merge(z.object({
     min: z.number().optional(),
     max: z.number().optional(),
     include_unknown: z.boolean()
@@ -867,7 +865,7 @@ export const DemographicAgeRangeSchema = z.record(z.string(), z.unknown()).and(z
 
 export const SelectedPlacementsSchema = z.object({
     mode: z.literal("selected"),
-    placement_refs: z.tuple([PlacementReferenceSchema]).rest(PlacementReferenceSchema),
+    placement_refs: z.array(PlacementReferenceSchema.merge(z.object({}).passthrough())),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
@@ -876,7 +874,7 @@ export const ProductDefaultPlacementsSchema = z.object({
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
-export const CreativeAssignmentSchema = z.record(z.string(), z.unknown()).and(z.object({
+export const CreativeAssignmentSchema = z.object({}).passthrough().merge(z.object({}).passthrough()).merge(z.object({}).passthrough()).merge(z.object({
     creative_id: z.string(),
     weight: z.number().optional(),
     rotation_mode: z.union([z.literal("weighted"), z.literal("even"), z.literal("sequential"), z.literal("random")]).optional(),
@@ -884,7 +882,7 @@ export const CreativeAssignmentSchema = z.record(z.string(), z.unknown()).and(z.
     sequence_position: z.number().optional(),
     placement_refs: z.array(PlacementReferenceSchema).optional(),
     placement_ids: z.array(z.string()).optional()
-}).passthrough()).and(z.object({
+}).passthrough()).merge(z.object({
     creative_id: z.string(),
     weight: z.number().optional(),
     rotation_mode: z.union([z.literal("weighted"), z.literal("even"), z.literal("sequential"), z.literal("random")]).optional(),
@@ -910,9 +908,9 @@ export const IndustryIdentifierSchema = z.object({
     value: z.string()
 }).passthrough();
 
-export const V1CreativeNamedFormatReferenceSchema = z.record(z.string(), z.unknown());
+export const V1CreativeNamedFormatReferenceSchema = z.object({}).passthrough();
 
-export const V2CreativeCanonicalFormatKindSchema = z.record(z.string(), z.unknown());
+export const V2CreativeCanonicalFormatKindSchema = z.object({}).passthrough();
 
 export const PublisherCatalogFormatOptionReferenceSchema = z.object({
     scope: z.literal("publisher"),
@@ -1115,19 +1113,19 @@ export const PublishedPostAssetSchema = z.object({
     post_url: z.string().optional(),
     platform: z.string().optional(),
     platform_post_id: z.string().optional(),
-    identity_ref: z.record(z.string(), z.unknown()).and(z.object({
+    identity_ref: z.object({
         handle: z.string().optional(),
         profile_url: z.string().optional(),
         platform_identity_id: z.string().optional()
-    }).passthrough()).optional(),
+    }).passthrough().optional(),
     published_at: z.string().optional(),
-    reference_authorization: z.record(z.string(), z.unknown()).and(z.object({
+    reference_authorization: z.object({
         status: z.union([z.literal("authorized"), z.literal("pending"), z.literal("expired"), z.literal("revoked"), z.literal("not_required"), z.literal("unknown")]),
         checked_at: z.string().optional(),
         expires_at: z.string().optional(),
         authorization_url: z.string().optional(),
         authorization_instructions: z.string().optional()
-    }).passthrough()).optional(),
+    }).passthrough().optional(),
     provenance: ProvenanceSchema.optional()
 }).passthrough();
 
@@ -1142,7 +1140,7 @@ export const CardAssetSchema = z.object({
     provenance: ProvenanceSchema.optional()
 }).passthrough();
 
-export const PixelTrackerAssetSchema = z.record(z.string(), z.unknown()).and(z.object({
+export const PixelTrackerAssetSchema = z.object({}).passthrough().merge(z.object({
     asset_type: z.literal("pixel_tracker"),
     event: z.union([z.literal("impression"), z.literal("viewable_mrc_50"), z.literal("viewable_mrc_100"), z.literal("viewable_video_50"), z.literal("audible_video_complete"), z.literal("click"), z.literal("custom")]),
     method: z.union([z.literal("img"), z.literal("js")]).optional(),
@@ -1151,18 +1149,18 @@ export const PixelTrackerAssetSchema = z.record(z.string(), z.unknown()).and(z.o
     provenance: ProvenanceSchema.optional()
 }).passthrough());
 
-export const VASTTrackerAssetSchema = z.record(z.string(), z.unknown()).and(z.object({
+export const VASTTrackerAssetSchema = z.object({}).passthrough().merge(z.object({
     asset_type: z.literal("vast_tracker"),
-    vast_event: VASTTrackingEventSchema,
+    vast_event: VASTTrackingEventSchema.and(z.object({}).passthrough()),
     url: z.string(),
     offset: z.string().optional(),
     target: z.union([z.literal("linear"), z.literal("non_linear"), z.literal("companion")]).optional(),
     provenance: ProvenanceSchema.optional()
 }).passthrough());
 
-export const DAASTTrackerAssetSchema = z.record(z.string(), z.unknown()).and(z.object({
+export const DAASTTrackerAssetSchema = z.object({}).passthrough().merge(z.object({
     asset_type: z.literal("daast_tracker"),
-    daast_event: DAASTTrackingEventSchema,
+    daast_event: DAASTTrackingEventSchema.and(z.object({}).passthrough()),
     url: z.string(),
     offset: z.string().optional(),
     target: z.union([z.literal("linear"), z.literal("companion")]).optional(),
@@ -1254,7 +1252,7 @@ export const AttestationResourceSubjectSchema = z.object({
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
-export const ContextObjectSchema = z.record(z.string(), z.unknown());
+export const ContextObjectSchema = z.object({}).passthrough();
 
 export const PackageSignalTargetingSchema = SignalTargetingExpressionSchema.and(z.object({
     pricing_option_id: z.string().optional(),
@@ -1267,7 +1265,7 @@ export const PackageSignalTargetingSchema = SignalTargetingExpressionSchema.and(
 }).passthrough());
 
 export const DemographicTargetingIntentSchema = z.object({
-    age: DemographicAgeRangeSchema
+    age: DemographicAgeRangeSchema.and(z.object({}).passthrough())
 }).passthrough();
 
 export const BrandReferenceSchema = z.object({
@@ -1327,21 +1325,21 @@ export const WarningAffectedResourceSchema = z.union([z.object({
         creative_id: z.string()
     }).passthrough()]);
 
-export const DownstreamConnectionRequirementSchema = z.record(z.string(), z.unknown()).and(z.object({
+export const DownstreamConnectionRequirementSchema = z.object({}).passthrough().merge(z.object({
     provider: z.string().optional(),
     connection_type: z.union([z.literal("advertiser_account"), z.literal("publisher_identity"), z.literal("post_authorization")]),
     required_for: z.array(z.string()).optional(),
     scope: z.union([z.literal("account"), z.literal("identity"), z.literal("post"), z.literal("unknown")]).optional(),
     status: z.union([z.literal("connected"), z.literal("missing"), z.literal("pending"), z.literal("expired"), z.literal("revoked"), z.literal("not_required"), z.literal("unknown")]).optional(),
     connection_id: z.string().optional(),
-    resource_ref: z.record(z.string(), z.unknown()).and(z.object({
+    resource_ref: z.object({
         platform_account_id: z.string().optional(),
         identity_id: z.string().optional(),
         handle: z.string().optional(),
         profile_url: z.string().optional(),
         post_id: z.string().optional(),
         post_url: z.string().optional()
-    }).passthrough()).optional(),
+    }).passthrough().optional(),
     authorization_url: z.string().optional(),
     authorization_instructions: z.string().optional(),
     expires_at: z.string().optional()
@@ -1848,7 +1846,7 @@ export const ErrorSchema = z.object({
     field: z.string().optional(),
     suggestion: z.string().optional(),
     retry_after: z.number().optional(),
-    issues: z.array(z.record(z.string(), z.unknown()).and(z.object({
+    issues: z.array(z.object({
         pointer: z.string(),
         message: z.string(),
         keyword: z.string(),
@@ -1858,8 +1856,8 @@ export const ErrorSchema = z.object({
             property_name: z.string(),
             value: z.union([z.string(), z.number(), z.boolean()]).nullable()
         }).passthrough()).optional()
-    }).passthrough())).optional(),
-    details: z.record(z.string(), z.unknown()).optional(),
+    }).passthrough()).optional(),
+    details: z.object({}).passthrough().optional(),
     recovery: z.union([z.literal("transient"), z.literal("correctable"), z.literal("terminal")]).optional(),
     source: z.union([z.literal("producer"), z.literal("sdk")]).optional(),
     sdk_id: z.string().optional()
@@ -1885,7 +1883,7 @@ export const AuthorizationResultSchema = z.object({
     }).passthrough().optional()
 }).passthrough();
 
-export const NotificationConfigSchema = z.object({
+export const NotificationConfigSchema = z.object({}).passthrough().merge(z.object({
     subscriber_id: z.string(),
     url: z.string(),
     event_types: z.tuple([z.union([z.literal("creative.status_changed"), z.literal("creative.assignment_changed"), z.literal("indicators.changed"), z.literal("creative.purged"), z.literal("account.status_changed"), z.literal("product.created"), z.literal("product.updated"), z.literal("product.priced"), z.literal("product.removed"), z.literal("signal.created"), z.literal("signal.updated"), z.literal("signal.priced"), z.literal("signal.removed"), z.literal("wholesale_feed.bulk_change")])]).rest(z.union([z.literal("creative.status_changed"), z.literal("creative.assignment_changed"), z.literal("indicators.changed"), z.literal("creative.purged"), z.literal("account.status_changed"), z.literal("product.created"), z.literal("product.updated"), z.literal("product.priced"), z.literal("product.removed"), z.literal("signal.created"), z.literal("signal.updated"), z.literal("signal.priced"), z.literal("signal.removed"), z.literal("wholesale_feed.bulk_change")])),
@@ -1896,7 +1894,7 @@ export const NotificationConfigSchema = z.object({
     }).passthrough().optional(),
     active: z.boolean().optional(),
     ext: ExtensionObjectSchema.optional()
-}).passthrough().merge(z.object({
+}).passthrough()).merge(z.object({
     subscriber_id: z.string(),
     url: z.string(),
     event_types: z.tuple([z.union([z.literal("creative.status_changed"), z.literal("creative.assignment_changed"), z.literal("indicators.changed"), z.literal("creative.purged"), z.literal("account.status_changed"), z.literal("product.created"), z.literal("product.updated"), z.literal("product.priced"), z.literal("product.removed"), z.literal("signal.created"), z.literal("signal.updated"), z.literal("signal.priced"), z.literal("signal.removed"), z.literal("wholesale_feed.bulk_change")])]).rest(z.union([z.literal("creative.status_changed"), z.literal("creative.assignment_changed"), z.literal("indicators.changed"), z.literal("creative.purged"), z.literal("account.status_changed"), z.literal("product.created"), z.literal("product.updated"), z.literal("product.priced"), z.literal("product.removed"), z.literal("signal.created"), z.literal("signal.updated"), z.literal("signal.priced"), z.literal("signal.removed"), z.literal("wholesale_feed.bulk_change")])),
@@ -2067,60 +2065,55 @@ export const OptimizationGoalSchema = z.union([z.object({
         kind: z.literal("metric"),
         metric: z.union([z.literal("clicks"), z.literal("views"), z.literal("completed_views"), z.literal("viewed_seconds"), z.literal("attention_seconds"), z.literal("attention_score"), z.literal("engagements"), z.literal("follows"), z.literal("saves"), z.literal("profile_visits"), z.literal("reach")]),
         reach_unit: ReachUnitSchema.optional(),
-        target_frequency: z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]).optional(),
+        target_frequency: z.union([z.object({}).passthrough(), z.object({}).passthrough()]).optional(),
         view_duration_seconds: z.number().optional(),
-        target: z.union([z.record(z.string(), z.unknown()).and(z.object({
+        target: z.union([z.object({
                 kind: z.literal("cost_per"),
                 value: z.number()
-            }).passthrough()), z.record(z.string(), z.unknown()).and(z.object({
+            }).passthrough(), z.object({
                 kind: z.literal("threshold_rate"),
                 value: z.number()
-            }).passthrough())]).optional(),
+            }).passthrough()]).optional(),
         priority: z.number().optional()
     }).passthrough(), z.object({
         kind: z.literal("event"),
-        event_sources: z.tuple([z.record(z.string(), z.unknown()).and(z.object({
+        event_sources: z.tuple([z.object({
                 event_source_id: z.string(),
                 event_type: EventTypeSchema,
                 custom_event_name: z.string().optional(),
                 value_field: z.string().optional(),
                 value_factor: z.number().optional()
-            }).passthrough())]).rest(z.record(z.string(), z.unknown()).and(z.object({
+            }).passthrough()]).rest(z.object({
             event_source_id: z.string(),
             event_type: EventTypeSchema,
             custom_event_name: z.string().optional(),
             value_field: z.string().optional(),
             value_factor: z.number().optional()
-        }).passthrough())),
-        target: z.union([z.record(z.string(), z.unknown()).and(z.object({
+        }).passthrough()),
+        target: z.union([z.object({
                 kind: z.literal("cost_per"),
                 value: z.number()
-            }).passthrough()), z.record(z.string(), z.unknown()).and(z.object({
+            }).passthrough(), z.object({
                 kind: z.literal("per_ad_spend"),
                 value: z.number()
-            }).passthrough()), z.record(z.string(), z.unknown()).and(z.object({
+            }).passthrough(), z.object({
                 kind: z.literal("maximize_value")
-            }).passthrough())]).optional(),
+            }).passthrough()]).optional(),
         attribution_window: AttributionWindowSchema.optional(),
         priority: z.number().optional()
     }).passthrough(), z.object({
         kind: z.literal("vendor_metric"),
         vendor: BrandReferenceSchema,
         metric_id: VendorMetricIDSchema,
-        target: z.union([z.record(z.string(), z.unknown()).and(z.object({
+        target: z.union([z.object({
                 kind: z.literal("cost_per"),
                 value: z.number()
-            }).passthrough()), z.record(z.string(), z.unknown()).and(z.object({
+            }).passthrough(), z.object({
                 kind: z.literal("threshold_rate"),
                 value: z.number()
-            }).passthrough())]).optional(),
+            }).passthrough()]).optional(),
         priority: z.number().optional()
     }).passthrough()]);
-
-export const PriceBreakdownSchema = z.object({
-    list_price: z.number(),
-    adjustments: z.union([z.tuple([z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())])]), z.tuple([z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())])]), z.tuple([z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())])]), z.tuple([z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())])]), z.tuple([z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())])]), z.tuple([z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())])]), z.tuple([z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())])]), z.tuple([z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())])]), z.tuple([z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())])]), z.tuple([z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())])]), z.tuple([z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())])]), z.tuple([z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())])]), z.tuple([z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())])]), z.tuple([z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())])]), z.tuple([z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())])]), z.tuple([z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())])]), z.tuple([z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())])]), z.tuple([z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())])]), z.tuple([z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())])]), z.tuple([z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())])])])
-}).passthrough();
 
 export const FormatOptionReferenceSchema = z.union([PublisherCatalogFormatOptionReferenceSchema, ProductLocalFormatOptionReferenceSchema]);
 
@@ -2162,7 +2155,7 @@ export const CommittedMetricSchema = z.union([z.object({
     }).passthrough()]);
 
 export const AudienceCharacteristicSchema = z.object({
-    dimension: z.union([z.literal("age"), z.record(z.string(), z.unknown())]).and(z.string()),
+    dimension: z.union([z.literal("age"), z.object({}).passthrough()]).and(z.string()),
     value: z.union([z.string(), z.number(), z.boolean(), z.tuple([z.union([z.string(), z.number(), z.boolean()])]).rest(z.union([z.string(), z.number(), z.boolean()]))]).optional(),
     range: z.object({
         min: z.number().optional(),
@@ -2174,8 +2167,8 @@ export const AudienceCharacteristicSchema = z.object({
         value_id: z.string().optional()
     }).passthrough().optional(),
     label: z.string().optional()
-}).passthrough().and(z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())])).and(z.object({
-    dimension: z.union([z.literal("age"), z.record(z.string(), z.unknown())]).and(z.string()),
+}).passthrough().and(z.union([z.object({}).passthrough(), z.object({}).passthrough()])).and(z.object({
+    dimension: z.union([z.literal("age"), z.object({}).passthrough()]).and(z.string()),
     value: z.union([z.string(), z.number(), z.boolean(), z.tuple([z.union([z.string(), z.number(), z.boolean()])]).rest(z.union([z.string(), z.number(), z.boolean()]))]).optional(),
     range: z.object({
         min: z.number().optional(),
@@ -2196,7 +2189,7 @@ export const DateRangeSchema = z.object({
 
 export const AttestationSubjectSchema = z.union([AttestationBrandSubjectSchema, AttestationAgentSubjectSchema, AttestationResourceSubjectSchema]);
 
-export const AttestationEvaluationSchema = z.object({
+export const AttestationEvaluationSchema = z.object({}).passthrough().merge(z.object({}).passthrough()).merge(z.object({
     reference_digest: z.string(),
     credential_digest: z.string().optional(),
     proof_format: z.string().optional(),
@@ -2208,9 +2201,9 @@ export const AttestationEvaluationSchema = z.object({
     confidence: z.number().optional(),
     revocation_checked_at: z.string().optional(),
     valid_until: z.string().optional(),
-    action_binding: z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]).optional(),
+    action_binding: z.union([z.object({}).passthrough(), z.object({}).passthrough()]).optional(),
     ext: ExtensionObjectSchema.optional()
-}).passthrough();
+}).passthrough());
 
 export const DemographicPredicateSchema = z.object({
     age: DemographicAgeRangeSchema
@@ -2274,7 +2267,7 @@ export const AgentPlacementFormatDeclarationSchema = z.object({
 
 export const CustomFormatDeclarationSchema = z.object({
     format_kind: z.literal("custom"),
-    params: z.record(z.string(), z.unknown())
+    params: z.object({}).passthrough()
 }).passthrough();
 
 export const SizeModeMutex1Schema = SizeModeMutexSchema;
@@ -2304,7 +2297,7 @@ export const BudgetAllocationSchema = z.union([z.object({
         mode: z.literal("fixed")
     }).passthrough(), z.object({
         mode: z.literal("seller_optimized"),
-        optimization_goals: z.tuple([OptimizationGoalSchema]).rest(OptimizationGoalSchema)
+        optimization_goals: z.array(OptimizationGoalSchema.and(z.object({}).passthrough()))
     }).passthrough()]);
 
 export const BusinessEntity1Schema = BusinessEntitySchema;
@@ -2341,22 +2334,40 @@ export const AccountIdentityChangeRejectedSchema = z.object({
 
 export const BrandReference3Schema = BrandReferenceSchema;
 
-export const DemographicTargetingResolutionSchema = z.record(z.string(), z.unknown()).and(z.object({
+export const PriceAdjustmentSchema = z.object({
+    kind: PriceAdjustmentKindSchema,
+    name: z.string(),
+    rate: z.number().optional(),
+    amount: z.number().optional(),
+    description: z.string().optional(),
+    beneficiary: z.string().optional()
+}).passthrough().superRefine((value, ctx) => {
+    if ((value.rate !== undefined) === (value.amount !== undefined)) {
+        ctx.addIssue({ code: "custom", path: [], message: "price adjustment requires exactly one of rate or amount" });
+    }
+});
+
+export const PriceBreakdownSchema = z.object({
+    list_price: z.number(),
+    adjustments: z.array(PriceAdjustmentSchema).min(1).max(20)
+}).passthrough();
+
+export const DemographicTargetingResolutionSchema = z.object({}).passthrough().merge(z.object({
     requested: DemographicTargetingIntentSchema,
     applied: DemographicPredicateSchema,
     equivalent: z.literal(true),
-    execution: z.union([z.record(z.string(), z.unknown()).and(z.object({
+    execution: z.union([z.object({
             type: z.literal("continuous_bounds"),
             ext: ExtensionObjectSchema.optional()
-        }).passthrough()), z.record(z.string(), z.unknown()).and(z.object({
+        }).passthrough(), z.object({
             type: z.literal("enumerated_intervals"),
             interval_ids: z.array(z.string()),
             ext: ExtensionObjectSchema.optional()
-        }).passthrough()), z.record(z.string(), z.unknown()).and(z.object({
+        }).passthrough(), z.object({
             type: z.literal("signals"),
             signal_refs: z.array(SignalRefSchema),
             ext: ExtensionObjectSchema.optional()
-        }).passthrough())]),
+        }).passthrough()]),
     applied_bases: z.array(AgeDeterminationBasisSchema).optional(),
     applied_verification_methods: z.array(AgeVerificationMethodSchema).optional(),
     ext: ExtensionObjectSchema.optional()
@@ -2482,9 +2493,9 @@ export const MultiSize2Schema = MultiSizeSchema;
 
 export const None2Schema = NoneSchema;
 
-export const NamedFormatProductSchema = z.record(z.string(), z.unknown());
+export const NamedFormatProductSchema = z.object({}).passthrough();
 
-export const CanonicalFormatProductSchema = z.record(z.string(), z.unknown());
+export const CanonicalFormatProductSchema = z.object({}).passthrough();
 
 export const PublisherPropertySelectorSchema = z.union([z.object({
         publisher_domain: z.string().regex(/^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/).optional(),
@@ -2515,12 +2526,12 @@ export const CreativePolicySchema = z.object({
     landing_page: LandingPageRequirementSchema,
     templates_available: z.boolean(),
     provenance_required: z.boolean().optional(),
-    provenance_requirements: z.record(z.string(), z.unknown()).and(z.object({
+    provenance_requirements: z.object({
         require_digital_source_type: z.boolean().optional(),
         require_synthetic_depiction: z.boolean().optional(),
         require_disclosure_metadata: z.boolean().optional(),
         require_embedded_provenance: z.boolean().optional()
-    }).passthrough()).optional(),
+    }).passthrough().optional(),
     accepted_verifiers: z.tuple([z.object({
             agent_url: z.string(),
             feature_id: z.string().optional(),
@@ -2546,10 +2557,10 @@ export const DataProviderSignalSelectorSchema = z.union([z.object({
     }).passthrough()]);
 
 export const DemographicTargetingCapabilitySchema = z.object({
-    age: z.record(z.string(), z.unknown())
+    age: z.object({}).passthrough()
 }).passthrough();
 
-export const ProductCardReferenceAssetSchema = z.record(z.string(), z.unknown()).and(z.object({
+export const ProductCardReferenceAssetSchema = z.object({}).passthrough().merge(z.object({
     role: z.union([z.literal("coverage_map"), z.literal("sample_render"), z.literal("environment_photo"), z.literal("media_kit"), z.literal("logo"), z.literal("other")]),
     role_label: z.string().optional(),
     asset: z.union([ImageAssetSchema, VideoAssetSchema, MarkdownAssetSchema, URLAssetSchema]),
@@ -2574,7 +2585,7 @@ export const CPAPricingOptionSchema = z.object({
     eligible_adjustments: z.array(PriceAdjustmentKindSchema).optional()
 }).passthrough();
 
-export const RevenueSharePricingOptionSchema = z.record(z.string(), z.unknown()).and(z.object({
+export const RevenueSharePricingOptionSchema = z.object({}).passthrough().merge(z.object({}).passthrough()).merge(z.object({
     pricing_option_id: z.string(),
     pricing_model: z.literal("revenue_share"),
     event_type: EventTypeSchema,
@@ -2585,11 +2596,11 @@ export const RevenueSharePricingOptionSchema = z.record(z.string(), z.unknown())
     commission_basis_description: z.string()
 }).passthrough());
 
-export const DemographicReportingCapabilitySchema = z.object({
-    age: z.record(z.string(), z.unknown()).optional(),
+export const DemographicReportingCapabilitySchema = z.object({}).passthrough().merge(z.object({
+    age: z.object({}).passthrough().optional(),
     demographic_systems: z.array(DemographicSystemSchema).optional(),
     may_suppress_small_cells: z.boolean()
-}).passthrough();
+}).passthrough());
 
 export const SignalIDSchema = z.union([z.object({
         source: z.literal("catalog"),
@@ -2601,7 +2612,7 @@ export const SignalIDSchema = z.union([z.object({
         id: z.string()
     }).passthrough()]);
 
-export const SignalListingSchema = z.object({
+export const SignalListingSchema = z.object({}).passthrough().merge(z.object({}).passthrough()).and(z.union([z.object({}).passthrough(), z.object({}).passthrough()])).and(z.object({
     signal_ref: SignalRefSchema.optional(),
     signal_id: SignalIDSchema.optional(),
     name: z.string().optional(),
@@ -2616,7 +2627,7 @@ export const SignalListingSchema = z.object({
     }).passthrough().optional(),
     restricted_attributes: z.array(RestrictedAttributeSchema).optional(),
     demographic_predicate: DemographicPredicateSchema.optional()
-}).passthrough().and(z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())])).and(z.object({
+}).passthrough()).and(z.union([z.object({}).passthrough(), z.object({}).passthrough()])).and(z.object({
     signal_ref: SignalRefSchema.optional(),
     signal_id: SignalIDSchema.optional(),
     name: z.string().optional(),
@@ -2631,7 +2642,7 @@ export const SignalListingSchema = z.object({
     }).passthrough().optional(),
     restricted_attributes: z.array(RestrictedAttributeSchema).optional(),
     demographic_predicate: DemographicPredicateSchema.optional()
-}).passthrough()).and(z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())])).and(z.object({
+}).passthrough()).and(z.union([z.object({}).passthrough(), z.object({}).passthrough()])).and(z.object({
     signal_ref: SignalRefSchema.optional(),
     signal_id: SignalIDSchema.optional(),
     name: z.string().optional(),
@@ -2682,9 +2693,9 @@ export const PerUnitPricingSchema = z.object({
 export const CustomPricingSchema = z.object({
     model: z.literal("custom"),
     description: z.string(),
-    metadata: z.record(z.string(), z.unknown()).and(z.object({
+    metadata: z.object({
         summary_for_operator: z.string().optional()
-    }).passthrough()),
+    }).passthrough(),
     currency: z.string().optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -2692,12 +2703,12 @@ export const CustomPricingSchema = z.object({
 export const ReplaceTargetingValueSchema = z.object({
     operation: z.literal("replace"),
     path: z.string(),
-    applied: z.record(z.string(), z.unknown()),
+    applied: z.object({}).passthrough(),
     reason: z.string(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
-export const RemoveTargetingSetValuesSchema = z.record(z.string(), z.unknown());
+export const RemoveTargetingSetValuesSchema = z.object({}).passthrough();
 
 export const PriceGuidanceSchema = z.object({
     p25: z.number().optional(),
@@ -2753,11 +2764,11 @@ export const CPVPricingOptionSchema = z.object({
     floor_price: z.number().optional(),
     max_bid: z.boolean().optional(),
     price_guidance: PriceGuidanceSchema.optional(),
-    parameters: z.record(z.string(), z.unknown()).and(z.object({
-        view_threshold: z.union([z.number(), z.record(z.string(), z.unknown()).and(z.object({
+    parameters: z.object({
+        view_threshold: z.union([z.number(), z.object({
                 duration_seconds: z.number()
-            }).passthrough())])
-    }).passthrough()),
+            }).passthrough()])
+    }).passthrough(),
     min_spend_per_package: z.number().optional(),
     price_breakdown: PriceBreakdownSchema.optional(),
     eligible_adjustments: z.array(PriceAdjustmentKindSchema).optional()
@@ -2770,11 +2781,11 @@ export const CPPPricingOptionSchema = z.object({
     fixed_price: z.number().optional(),
     floor_price: z.number().optional(),
     price_guidance: PriceGuidanceSchema.optional(),
-    parameters: z.record(z.string(), z.unknown()).and(z.object({
+    parameters: z.object({
         demographic_system: DemographicSystemSchema.optional(),
         demographic: z.string(),
         min_points: z.number().optional()
-    }).passthrough()),
+    }).passthrough(),
     min_spend_per_package: z.number().optional(),
     price_breakdown: PriceBreakdownSchema.optional(),
     eligible_adjustments: z.array(PriceAdjustmentKindSchema).optional()
@@ -2798,11 +2809,11 @@ export const TimeBasedPricingOptionSchema = z.object({
     fixed_price: z.number().optional(),
     floor_price: z.number().optional(),
     price_guidance: PriceGuidanceSchema.optional(),
-    parameters: z.record(z.string(), z.unknown()).and(z.object({
+    parameters: z.object({
         time_unit: z.union([z.literal("hour"), z.literal("day"), z.literal("week"), z.literal("month")]),
         min_duration: z.number().optional(),
         max_duration: z.number().optional()
-    }).passthrough()),
+    }).passthrough(),
     min_spend_per_package: z.number().optional(),
     price_breakdown: PriceBreakdownSchema.optional(),
     eligible_adjustments: z.array(PriceAdjustmentKindSchema).optional()
@@ -3089,7 +3100,7 @@ export const ProtocolEnvelopeSchema = z.object({
     adcp_error: ErrorSchema.optional(),
     push_notification_config: PushNotificationConfigSchema.optional(),
     governance_context: z.string().optional(),
-    payload: z.record(z.string(), z.unknown()).optional()
+    payload: z.object({}).passthrough().optional()
 }).passthrough();
 
 export const PaginationResponseSchema = z.object({
@@ -3100,7 +3111,7 @@ export const PaginationResponseSchema = z.object({
 
 export const InsertionOrderSchema = z.object({
     io_id: z.string(),
-    terms: z.record(z.string(), z.unknown()).and(z.object({
+    terms: z.object({
         advertiser: z.string().optional(),
         publisher: z.string().optional(),
         total_budget: z.object({
@@ -3110,7 +3121,7 @@ export const InsertionOrderSchema = z.object({
         flight_start: z.string().optional(),
         flight_end: z.string().optional(),
         payment_terms: z.union([z.literal("net_30"), z.literal("net_60"), z.literal("net_90"), z.literal("prepaid"), z.literal("due_on_receipt")]).optional()
-    }).passthrough()).optional(),
+    }).passthrough().optional(),
     terms_url: z.string().optional(),
     signing_url: z.string().optional(),
     requires_signature: z.boolean()
@@ -3124,7 +3135,7 @@ export const GetProductsRejectedSchema = AdCPVersionEnvelopeSchema.merge(Protoco
     ext: ExtensionObjectSchema.optional()
 }).passthrough());
 
-export const CanonicalPricingOptionSchema = z.object({
+export const CanonicalPricingOptionSchema = z.object({}).passthrough().merge(z.object({}).passthrough()).merge(z.object({}).passthrough()).merge(z.object({}).passthrough()).merge(z.object({}).passthrough()).merge(z.object({
     pricing_option_id: z.string(),
     pricing_model: z.union([z.literal("cpm"), z.literal("vcpm"), z.literal("cpc"), z.literal("cpcv"), z.literal("cpv"), z.literal("cpp"), z.literal("cpa"), z.literal("revenue_share"), z.literal("flat_rate"), z.literal("time")]),
     currency: z.string(),
@@ -3134,13 +3145,13 @@ export const CanonicalPricingOptionSchema = z.object({
     min_spend_per_package: z.number().optional(),
     price_breakdown: PriceBreakdownSchema.optional(),
     eligible_adjustments: z.array(PriceAdjustmentKindSchema).optional(),
-    parameters: z.record(z.string(), z.unknown()).optional(),
+    parameters: z.object({}).passthrough().optional(),
     event_type: EventTypeSchema.optional(),
     custom_event_name: z.string().optional(),
     event_source_id: z.string().optional(),
     commission_rate: z.number().optional(),
     commission_basis_description: z.string().optional()
-}).passthrough().merge(z.object({
+}).passthrough()).merge(z.object({
     pricing_option_id: z.string(),
     pricing_model: z.union([z.literal("cpm"), z.literal("vcpm"), z.literal("cpc"), z.literal("cpcv"), z.literal("cpv"), z.literal("cpp"), z.literal("cpa"), z.literal("revenue_share"), z.literal("flat_rate"), z.literal("time")]),
     currency: z.string(),
@@ -3150,7 +3161,7 @@ export const CanonicalPricingOptionSchema = z.object({
     min_spend_per_package: z.number().optional(),
     price_breakdown: PriceBreakdownSchema.optional(),
     eligible_adjustments: z.array(PriceAdjustmentKindSchema).optional(),
-    parameters: z.record(z.string(), z.unknown()).optional(),
+    parameters: z.object({}).passthrough().optional(),
     event_type: EventTypeSchema.optional(),
     custom_event_name: z.string().optional(),
     event_source_id: z.string().optional(),
@@ -3164,7 +3175,7 @@ export const BrandKeySchema = z.object({
     countries: z.array(z.string()).optional()
 }).passthrough();
 
-export const ProductAudienceEvidenceRequirementsSchema = z.object({
+export const ProductAudienceEvidenceRequirementsSchema = z.object({}).passthrough().merge(z.object({
     requirement_mode: z.union([z.literal("required"), z.literal("preferred")]),
     evidence_presence: z.union([z.literal("required"), z.literal("when_available")]),
     accepted_methodologies: z.array(AudienceEvidenceMethodologySchema).optional(),
@@ -3207,7 +3218,7 @@ export const ProductAudienceEvidenceRequirementsSchema = z.object({
         }).passthrough()])).optional(),
     accepted_attestation_claim_types: z.array(z.string()).optional(),
     ext: ExtensionObjectSchema.optional()
-}).passthrough();
+}).passthrough());
 
 export const StartTimingSchema = z.union([z.literal("asap"), z.string()]);
 
@@ -3215,7 +3226,7 @@ export const CanonicalOptimizationGoalSchema = z.union([z.object({
         kind: z.literal("metric"),
         metric: z.union([z.literal("clicks"), z.literal("views"), z.literal("completed_views"), z.literal("viewed_seconds"), z.literal("engagements"), z.literal("follows"), z.literal("saves"), z.literal("profile_visits"), z.literal("reach")]),
         reach_unit: ReachUnitSchema.optional(),
-        target_frequency: z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]).optional(),
+        target_frequency: z.union([z.object({}).passthrough(), z.object({}).passthrough()]).optional(),
         view_duration_seconds: z.number().optional(),
         target: z.object({
             kind: z.literal("threshold_rate"),
@@ -3261,7 +3272,7 @@ export const CanonicalMetricQualifierSchema = z.object({
     lift_dimension: LiftDimensionSchema.optional()
 }).passthrough();
 
-export const CanonicalFormatOptionSchema = z.object({
+export const CanonicalFormatOptionSchema = z.object({}).passthrough().merge(z.object({
     format_option_id: z.string().optional(),
     publisher_domain: z.string().optional(),
     display_name: z.string().optional(),
@@ -3272,21 +3283,7 @@ export const CanonicalFormatOptionSchema = z.object({
     canonical_formats_only: z.boolean().optional(),
     experimental: z.boolean().optional(),
     format_kind: z.union([z.literal("image"), z.literal("html5"), z.literal("display_tag"), z.literal("image_carousel"), z.literal("video_hosted"), z.literal("video_vast"), z.literal("audio_hosted"), z.literal("audio_daast"), z.literal("sponsored_placement"), z.literal("native_in_feed"), z.literal("responsive_creative"), z.literal("agent_placement"), z.literal("custom")]),
-    params: z.record(z.string(), z.unknown()),
-    format_shape: z.string().optional(),
-    format_schema: PlatformExtensionReferenceSchema.optional()
-}).passthrough().merge(z.object({
-    format_option_id: z.string().optional(),
-    publisher_domain: z.string().optional(),
-    display_name: z.string().optional(),
-    sample_render_url: z.string().optional(),
-    applies_to_channels: z.array(MediaChannelSchema).optional(),
-    seller_preference: z.union([z.literal("preferred"), z.literal("accepted"), z.literal("discouraged")]).optional(),
-    locale_policy: CreativeLocalePolicySchema.optional(),
-    canonical_formats_only: z.boolean().optional(),
-    experimental: z.boolean().optional(),
-    format_kind: z.union([z.literal("image"), z.literal("html5"), z.literal("display_tag"), z.literal("image_carousel"), z.literal("video_hosted"), z.literal("video_vast"), z.literal("audio_hosted"), z.literal("audio_daast"), z.literal("sponsored_placement"), z.literal("native_in_feed"), z.literal("responsive_creative"), z.literal("agent_placement"), z.literal("custom")]),
-    params: z.record(z.string(), z.unknown()),
+    params: z.object({}).passthrough(),
     format_shape: z.string().optional(),
     format_schema: PlatformExtensionReferenceSchema.optional()
 }).passthrough()).merge(z.object({
@@ -3300,7 +3297,7 @@ export const CanonicalFormatOptionSchema = z.object({
     canonical_formats_only: z.boolean().optional(),
     experimental: z.boolean().optional(),
     format_kind: z.union([z.literal("image"), z.literal("html5"), z.literal("display_tag"), z.literal("image_carousel"), z.literal("video_hosted"), z.literal("video_vast"), z.literal("audio_hosted"), z.literal("audio_daast"), z.literal("sponsored_placement"), z.literal("native_in_feed"), z.literal("responsive_creative"), z.literal("agent_placement"), z.literal("custom")]),
-    params: z.record(z.string(), z.unknown()),
+    params: z.object({}).passthrough(),
     format_shape: z.string().optional(),
     format_schema: PlatformExtensionReferenceSchema.optional()
 }).passthrough()).merge(z.object({
@@ -3314,12 +3311,26 @@ export const CanonicalFormatOptionSchema = z.object({
     canonical_formats_only: z.boolean().optional(),
     experimental: z.boolean().optional(),
     format_kind: z.union([z.literal("image"), z.literal("html5"), z.literal("display_tag"), z.literal("image_carousel"), z.literal("video_hosted"), z.literal("video_vast"), z.literal("audio_hosted"), z.literal("audio_daast"), z.literal("sponsored_placement"), z.literal("native_in_feed"), z.literal("responsive_creative"), z.literal("agent_placement"), z.literal("custom")]),
-    params: z.record(z.string(), z.unknown()),
+    params: z.object({}).passthrough(),
+    format_shape: z.string().optional(),
+    format_schema: PlatformExtensionReferenceSchema.optional()
+}).passthrough()).merge(z.object({
+    format_option_id: z.string().optional(),
+    publisher_domain: z.string().optional(),
+    display_name: z.string().optional(),
+    sample_render_url: z.string().optional(),
+    applies_to_channels: z.array(MediaChannelSchema).optional(),
+    seller_preference: z.union([z.literal("preferred"), z.literal("accepted"), z.literal("discouraged")]).optional(),
+    locale_policy: CreativeLocalePolicySchema.optional(),
+    canonical_formats_only: z.boolean().optional(),
+    experimental: z.boolean().optional(),
+    format_kind: z.union([z.literal("image"), z.literal("html5"), z.literal("display_tag"), z.literal("image_carousel"), z.literal("video_hosted"), z.literal("video_vast"), z.literal("audio_hosted"), z.literal("audio_daast"), z.literal("sponsored_placement"), z.literal("native_in_feed"), z.literal("responsive_creative"), z.literal("agent_placement"), z.literal("custom")]),
+    params: z.object({}).passthrough(),
     format_shape: z.string().optional(),
     format_schema: PlatformExtensionReferenceSchema.optional()
 }).passthrough());
 
-export const CanonicalProductPlacementSchema = z.object({
+export const CanonicalProductPlacementSchema = z.object({}).passthrough().merge(z.object({
     kind: z.union([z.literal("publisher_ref"), z.literal("seller_inline")]),
     placement_id: z.string(),
     publisher_domain: z.string().optional(),
@@ -3332,9 +3343,9 @@ export const CanonicalProductPlacementSchema = z.object({
     audio_distribution_types: z.array(AudioDistributionTypeSchema).optional(),
     sponsored_placement_types: z.array(SponsoredPlacementTypeSchema).optional(),
     social_placement_surfaces: z.array(SocialPlacementSurfaceSchema).optional()
-}).passthrough();
+}).passthrough());
 
-export const CanonicalAudienceEvidenceSchema = z.object({
+export const CanonicalAudienceEvidenceSchema = z.object({}).passthrough().merge(z.object({}).passthrough()).merge(z.object({}).passthrough()).merge(z.object({
     evidence_id: z.string(),
     snapshot_id: z.string(),
     version: z.string(),
@@ -3361,7 +3372,7 @@ export const CanonicalAudienceEvidenceSchema = z.object({
     methodology_url: z.string().optional(),
     attestation_digests: z.array(z.string()).optional(),
     ext: ExtensionObjectSchema.optional()
-}).passthrough().merge(z.object({
+}).passthrough()).merge(z.object({
     evidence_id: z.string(),
     snapshot_id: z.string(),
     version: z.string(),
@@ -3459,11 +3470,11 @@ export const CanonicalMediaBuyActionSchema = z.union([z.object({
         terms_ref: z.string().optional()
     }).passthrough()]);
 
-export const WarningSchema = z.record(z.string(), z.unknown()).and(z.object({
+export const WarningSchema = z.object({}).passthrough().merge(z.object({}).passthrough()).merge(z.object({
     code: WarningCodeSchema,
     message: z.string(),
     affected_resource: WarningAffectedResourceSchema,
-    details: z.record(z.string(), z.unknown()).optional(),
+    details: z.object({}).passthrough().optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough());
 
@@ -3501,7 +3512,7 @@ export const ControlSubmittedSchema = z.object({
     replayed: z.literal(true).optional()
 }).passthrough();
 
-export const SignalModelingDisclosureSchema = z.object({
+export const SignalModelingDisclosureSchema = z.object({}).passthrough().merge(z.object({
     required: z.boolean(),
     jurisdictions: z.tuple([z.object({
             country: z.string(),
@@ -3519,7 +3530,7 @@ export const SignalModelingDisclosureSchema = z.object({
         audience: z.union([z.literal("buyer"), z.literal("data_subject"), z.literal("regulator"), z.literal("public")]).optional()
     }).passthrough()).optional(),
     notes: z.string().optional()
-}).passthrough();
+}).passthrough());
 
 export const CreateMediaBuyErrorSchema = z.object({
     errors: z.array(ErrorSchema),
@@ -3568,9 +3579,9 @@ export const BuildCreativeSubmittedSchema = z.object({
 
 export const BrandReference11Schema = BrandReferenceSchema;
 
-export const NamedFormatManifestSchema = z.record(z.string(), z.unknown());
+export const NamedFormatManifestSchema = z.object({}).passthrough();
 
-export const CanonicalFormatManifestSchema = z.record(z.string(), z.unknown());
+export const CanonicalFormatManifestSchema = z.object({}).passthrough();
 
 export const PreviewRenderSchema = z.union([z.object({
         render_id: z.string(),
@@ -3677,9 +3688,9 @@ export const SyncCatalogsSubmittedSchema = z.object({
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
-export const CatalogItemAvailabilityErrorSchema = ErrorSchema;
+export const CatalogItemAvailabilityErrorSchema = ErrorSchema.merge(z.object({}).passthrough());
 
-export const CatalogItemAvailabilityStateSchema = z.record(z.string(), z.unknown()).and(z.object({
+export const CatalogItemAvailabilityStateSchema = z.object({}).passthrough().merge(z.object({
     request_index: z.number(),
     catalog_id: z.string(),
     catalog_generation: z.string(),
@@ -3802,7 +3813,7 @@ export const CanonicalForecastVendorMetricValueSchema = z.object({
     value: ForecastRangeSchema,
     unit: z.string().optional(),
     measurable_impressions: ForecastRangeSchema.optional(),
-    breakdown: z.record(z.string(), z.unknown()).optional()
+    breakdown: z.object({}).passthrough().optional()
 }).passthrough();
 
 export const CreateMediaBuyAsyncSubmittedSchema = CreateMediaBuySubmittedSchema;
@@ -3873,7 +3884,7 @@ export const BuildCreativeAsyncSubmittedSchema = BuildCreativeSubmittedSchema;
 
 export const SyncCreativesAsyncSubmittedSchema = SyncCreativesSubmittedSchema;
 
-export const CatalogItemAvailabilityUpdateResultSchema = z.record(z.string(), z.unknown()).and(z.object({
+export const CatalogItemAvailabilityUpdateResultSchema = z.object({}).passthrough().merge(z.object({
     request_index: z.number(),
     catalog_id: z.string(),
     catalog_generation: z.string(),
@@ -3919,7 +3930,7 @@ export const A2UISurfaceSchema = z.object({
     catalogId: z.string().optional(),
     components: z.array(A2UIComponentSchema),
     rootId: z.string().optional(),
-    dataModel: z.record(z.string(), z.unknown()).optional()
+    dataModel: z.object({}).passthrough().optional()
 }).passthrough();
 
 export const A2UIUserActionSchema = z.object({
@@ -4006,10 +4017,10 @@ export const RightsTermsSchema = z.object({
     overage_cpm: z.number().optional(),
     start_date: z.string().optional(),
     end_date: z.string().optional(),
-    exclusivity: z.record(z.string(), z.unknown()).and(z.object({
+    exclusivity: z.object({
         scope: z.string().optional(),
         countries: z.array(z.string()).optional()
-    }).passthrough()).optional()
+    }).passthrough().optional()
 }).passthrough();
 
 export const GenerationCredentialSchema = z.object({
@@ -4357,7 +4368,7 @@ export const ResponsePayloadSchema = z.object({
     request_hash: z.string(),
     iat: z.number(),
     exp: z.number(),
-    response: z.record(z.string(), z.unknown())
+    response: z.object({}).passthrough()
 }).passthrough();
 
 export const ClaimEntrySchema = z.union([VerifySubsidiaryClaimSchema, VerifyParentClaimSchema, VerifyPropertyClaimSchema, VerifyTrademarkClaimSchema]);
@@ -4452,9 +4463,9 @@ export const CollectionListFiltersSchema = z.object({
 
 export const BaseCollectionSourceSchema = z.union([DistributionIDsSourceSchema, PublisherCollectionsSourceSchema, PublisherGenresSourceSchema]);
 
-export const CreateMediaBuyCompletionSchema = z.record(z.string(), z.unknown());
+export const CreateMediaBuyCompletionSchema = z.object({}).passthrough();
 
-export const SignalDefinitionEnrichmentSchema = z.record(z.string(), z.unknown()).and(z.object({
+export const SignalDefinitionEnrichmentSchema = z.object({}).passthrough().merge(z.object({
     restricted_attributes: z.array(RestrictedAttributeSchema).optional(),
     demographic_predicate: DemographicPredicateSchema.optional(),
     policy_categories: z.array(z.string()).optional(),
@@ -4514,7 +4525,7 @@ export const SignalDefinitionEnrichmentSchema = z.record(z.string(), z.unknown()
     }).passthrough().optional(),
     data_subject_rights: z.object({
         upstream_source_domain: z.string().optional(),
-        channels: z.tuple([z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())])]).rest(z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())])),
+        channels: z.tuple([z.union([z.object({}).passthrough(), z.object({}).passthrough()])]).rest(z.union([z.object({}).passthrough(), z.object({}).passthrough()])),
         response_sla_days: z.number().optional(),
         ccpa_opt_out_url: z.string().optional()
     }).passthrough().optional(),
@@ -4528,7 +4539,7 @@ export const AssetAccessSchema = z.union([z.object({
     }).passthrough(), z.object({
         method: z.literal("service_account"),
         provider: z.union([z.literal("gcp"), z.literal("aws")]),
-        credentials: z.record(z.string(), z.unknown()).optional()
+        credentials: z.object({}).passthrough().optional()
     }).passthrough(), z.object({
         method: z.literal("signed_url")
     }).passthrough()]);
@@ -4579,22 +4590,22 @@ export const ArtifactSchema = z.object({
             transcript_source: z.union([z.literal("original_script"), z.literal("closed_captions"), z.literal("generated")]).optional(),
             provenance: ProvenanceSchema.optional()
         }).passthrough()])),
-    metadata: z.record(z.string(), z.unknown()).and(z.object({
+    metadata: z.object({
         canonical: z.string().optional(),
         author: z.string().optional(),
         keywords: z.string().optional(),
-        open_graph: z.record(z.string(), z.unknown()).optional(),
-        twitter_card: z.record(z.string(), z.unknown()).optional(),
+        open_graph: z.object({}).passthrough().optional(),
+        twitter_card: z.object({}).passthrough().optional(),
         json_ld: z.array(z.object({}).passthrough()).optional()
-    }).passthrough()).optional(),
+    }).passthrough().optional(),
     provenance: ProvenanceSchema.optional(),
-    identifiers: z.record(z.string(), z.unknown()).and(z.object({
+    identifiers: z.object({
         apple_podcast_id: z.string().optional(),
         spotify_collection_id: z.string().optional(),
         podcast_guid: z.string().optional(),
         youtube_video_id: z.string().optional(),
         rss_url: z.string().optional()
-    }).passthrough()).optional()
+    }).passthrough().optional()
 }).passthrough();
 
 export const ExemplarSchema = z.object({
@@ -4927,12 +4938,12 @@ export const AccountStatusChangedWebhookSchema = z.object({
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
-export const AccountTimezoneCapabilitySchema = z.object({
+export const AccountTimezoneCapabilitySchema = z.object({}).passthrough().merge(z.object({
     mode: z.union([z.literal("seller_fixed"), z.literal("account_fixed")]),
     fixed_timezone: z.string().optional(),
     account_selection: z.union([z.literal("seller_assigned"), z.literal("buyer_selected")]).optional(),
     supported_timezones: z.array(z.string()).optional()
-}).passthrough();
+}).passthrough());
 
 export const AgentEncryptionKeySchema = z.object({
     kid: z.string().max(8),
@@ -4993,23 +5004,23 @@ export const OfferingAssetGroupSchema = z.object({
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
-export const AdCPAssetGroupVocabularyRegistrySchema = z.record(z.string(), z.unknown());
+export const AdCPAssetGroupVocabularyRegistrySchema = z.object({}).passthrough();
 
-export const AudienceMemberSchema = z.record(z.string(), z.unknown()).and(z.object({
+export const AudienceMemberSchema = z.object({}).passthrough().merge(z.object({
     external_id: z.string(),
     hashed_email: z.string().optional(),
     hashed_phone: z.string().optional(),
-    uids: z.tuple([z.record(z.string(), z.unknown()).and(z.object({
+    uids: z.tuple([z.object({
             type: UIDTypeSchema,
             value: z.string()
-        }).passthrough())]).rest(z.record(z.string(), z.unknown()).and(z.object({
+        }).passthrough()]).rest(z.object({
         type: UIDTypeSchema,
         value: z.string()
-    }).passthrough())).optional(),
+    }).passthrough()).optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough());
 
-export const AudienceSelectorSchema = z.union([z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())]), z.object({
+export const AudienceSelectorSchema = z.union([z.union([z.object({}).passthrough(), z.object({}).passthrough()]), z.union([z.object({}).passthrough(), z.object({}).passthrough()]), z.union([z.object({}).passthrough(), z.object({}).passthrough()]), z.object({
         type: z.literal("description"),
         description: z.string(),
         category: z.string().optional()
@@ -5044,7 +5055,7 @@ export const BrandResponseAuthorizationResultSchema = z.object({
         trust: z.literal("untrusted")
     }).passthrough()]));
 
-export const BudgetRangeSchema = z.record(z.string(), z.unknown()).and(z.object({
+export const BudgetRangeSchema = z.object({}).passthrough().merge(z.object({
     min: z.number().optional(),
     max: z.number().optional(),
     currency: z.string()
@@ -5089,7 +5100,7 @@ export const CatalogItemAvailabilityReferenceSchema = z.object({
     item_id: z.string()
 }).passthrough();
 
-export const CatalogItemAvailabilityUpdateSchema = z.record(z.string(), z.unknown()).and(z.object({
+export const CatalogItemAvailabilityUpdateSchema = z.object({}).passthrough().merge(z.object({
     catalog_id: z.string(),
     catalog_generation: z.string(),
     item_id: z.string(),
@@ -5186,15 +5197,15 @@ export const LimitedSeriesSchema = z.object({
 export const DeadlinePolicySchema = z.object({
     booking_lead_days: z.number().optional(),
     cancellation_lead_days: z.number().optional(),
-    material_stages: z.tuple([z.record(z.string(), z.unknown()).and(z.object({
+    material_stages: z.tuple([z.object({
             stage: z.string(),
             lead_days: z.number(),
             label: z.string().optional()
-        }).passthrough())]).rest(z.record(z.string(), z.unknown()).and(z.object({
+        }).passthrough()]).rest(z.object({
         stage: z.string(),
         lead_days: z.number(),
         label: z.string().optional()
-    }).passthrough())).optional(),
+    }).passthrough()).optional(),
     business_days_only: z.boolean().optional()
 }).passthrough();
 
@@ -5338,22 +5349,22 @@ export const EventCustomDataSchema = z.object({
     search_string: z.string().optional(),
     progress_percent: z.number().optional(),
     progress_seconds: z.number().optional(),
-    contents: z.array(z.record(z.string(), z.unknown()).and(z.object({
+    contents: z.array(z.object({
         id: z.string(),
         quantity: z.number().optional(),
         price: z.number().optional(),
         brand: z.string().optional()
-    }).passthrough())).optional(),
+    }).passthrough()).optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
 export const EventSourceHealthSchema = z.object({
     status: AssessmentStatusSchema,
-    detail: z.record(z.string(), z.unknown()).and(z.object({
+    detail: z.object({
         score: z.number(),
         max_score: z.number(),
         label: z.string().optional()
-    }).passthrough()).optional(),
+    }).passthrough().optional(),
     match_rate: z.number().optional(),
     last_event_at: z.string().optional(),
     evaluated_at: z.string().optional(),
@@ -5369,14 +5380,14 @@ export const EventSurfaceSchema = z.object({
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
-export const UserMatchSchema = z.record(z.string(), z.unknown()).and(z.object({
-    uids: z.tuple([z.record(z.string(), z.unknown()).and(z.object({
+export const UserMatchSchema = z.object({}).passthrough().merge(z.object({
+    uids: z.tuple([z.object({
             type: UIDTypeSchema,
             value: z.string()
-        }).passthrough())]).rest(z.record(z.string(), z.unknown()).and(z.object({
+        }).passthrough()]).rest(z.object({
         type: UIDTypeSchema,
         value: z.string()
-    }).passthrough())).optional(),
+    }).passthrough()).optional(),
     hashed_email: z.string().optional(),
     hashed_phone: z.string().optional(),
     click_id: z.string().optional(),
@@ -5386,7 +5397,7 @@ export const UserMatchSchema = z.record(z.string(), z.unknown()).and(z.object({
     ext: ExtensionObjectSchema.optional()
 }).passthrough());
 
-export const EventSchema = z.record(z.string(), z.unknown()).and(z.object({
+export const EventSchema = z.object({}).passthrough().merge(z.object({
     event_id: z.string(),
     event_type: EventTypeSchema,
     event_time: z.string(),
@@ -5421,7 +5432,7 @@ export const FlightItemSchema = z.object({
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
-export const AdCPFormatShapeVocabularyRegistrySchema = z.record(z.string(), z.unknown());
+export const AdCPFormatShapeVocabularyRegistrySchema = z.object({}).passthrough();
 
 export const ImageAssetRequirementsSchema = z.object({
     min_width: z.number().optional(),
@@ -5754,7 +5765,7 @@ export const MissingMetricSchema = z.union([z.object({
         metric_id: VendorMetricIDSchema
     }).passthrough()]);
 
-export const OpportunityContextSchema = z.object({
+export const OpportunityContextSchema = z.object({}).passthrough().merge(z.object({
     opportunity_id: z.string(),
     phase: z.union([z.literal("exploratory"), z.literal("planning"), z.literal("active_sourcing")]).optional(),
     intent: z.union([z.literal("test"), z.literal("speculative"), z.literal("planning"), z.literal("live_rfp")]).optional(),
@@ -5763,7 +5774,7 @@ export const OpportunityContextSchema = z.object({
     status: z.union([z.literal("open"), z.literal("closed")]).optional(),
     close_reason: z.union([z.literal("accepted_with_seller"), z.literal("purchased_elsewhere"), z.literal("selected_alternative"), z.literal("not_pursued"), z.literal("budget_changed"), z.literal("timing_changed"), z.literal("other")]).optional(),
     close_detail: z.string().optional()
-}).passthrough();
+}).passthrough());
 
 export const PerformanceFeedbackMetricSchema = z.union([z.object({
         scope: z.literal("standard"),
@@ -5853,14 +5864,14 @@ export const HTML5FormatDeclarationSchema = z.object({
     params: CanonicalFormatHTML5BannerSchema
 }).passthrough();
 
-export const PlannedDeliverySchema = z.record(z.string(), z.unknown()).and(z.object({
+export const PlannedDeliverySchema = z.object({}).passthrough().merge(z.object({
     media_buy_id: z.string().optional(),
     proposal_id: z.string().optional(),
     proposal_terms_digest: z.string().optional(),
-    geo: z.record(z.string(), z.unknown()).and(z.object({
+    geo: z.object({
         countries: z.array(z.string()).optional(),
         regions: z.array(z.string()).optional()
-    }).passthrough()).optional(),
+    }).passthrough().optional(),
     channels: z.array(MediaChannelSchema).optional(),
     start_time: z.string().optional(),
     end_time: z.string().optional(),
@@ -6322,7 +6333,7 @@ export const TasksListResponseSchema = z.object({
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
-export const TransformerParamSchema = z.record(z.string(), z.unknown()).and(z.object({
+export const TransformerParamSchema = z.object({}).passthrough().merge(z.object({
     field: z.string(),
     type: z.union([z.literal("string"), z.literal("number"), z.literal("integer"), z.literal("boolean")]),
     value_source: z.union([z.literal("inline"), z.literal("range"), z.literal("enumerable"), z.literal("free_text")]),
@@ -6330,22 +6341,22 @@ export const TransformerParamSchema = z.record(z.string(), z.unknown()).and(z.ob
     allowed_values: z.array(z.unknown()).optional(),
     minimum: z.number().optional(),
     maximum: z.number().optional(),
-    options: z.array(z.record(z.string(), z.unknown()).and(z.object({
-        value: z.record(z.string(), z.unknown()),
+    options: z.array(z.object({
+        value: z.object({}).passthrough(),
         label: z.string().optional(),
-        metadata: z.record(z.string(), z.unknown()).optional()
-    }).passthrough())).optional(),
+        metadata: z.object({}).passthrough().optional()
+    }).passthrough()).optional(),
     options_cursor: z.string().optional(),
-    default: z.record(z.string(), z.unknown()).optional(),
+    default: z.object({}).passthrough().optional(),
     required: z.boolean().optional(),
     description: z.string().optional()
 }).passthrough());
 
-export const CanonicalTransformerOutputsSchema = z.record(z.string(), z.unknown());
+export const CanonicalTransformerOutputsSchema = z.object({}).passthrough();
 
-export const NamedFormatTransformerOutputsSchema = z.record(z.string(), z.unknown());
+export const NamedFormatTransformerOutputsSchema = z.object({}).passthrough();
 
-export const ProductFormatDeclarationSchema = z.object({
+export const ProductFormatDeclarationSchema = z.object({}).passthrough().merge(z.object({}).passthrough()).merge(z.object({}).passthrough()).merge(z.object({}).passthrough()).merge(z.object({}).passthrough()).merge(z.object({
     format_option_id: z.string().optional(),
     publisher_domain: z.string().optional(),
     display_name: z.string().optional(),
@@ -6358,7 +6369,7 @@ export const ProductFormatDeclarationSchema = z.object({
     format_shape: z.string().optional(),
     v1_format_ref: z.array(FormatReferenceStructuredObjectSchema).optional(),
     format_schema: PlatformExtensionReferenceSchema.optional()
-}).passthrough().and(z.union([ImageFormatDeclarationSchema, HTML5FormatDeclarationSchema, DisplayTagFormatDeclarationSchema, ImageCarouselFormatDeclarationSchema, HostedVideoFormatDeclarationSchema, VASTVideoFormatDeclarationSchema, HostedAudioFormatDeclarationSchema, DAASTAudioFormatDeclarationSchema, SponsoredPlacementFormatDeclarationSchema, NativeInFeedFormatDeclarationSchema, ResponsiveCreativeFormatDeclarationSchema, AgentPlacementFormatDeclarationSchema, CustomFormatDeclarationSchema])).and(z.object({
+}).passthrough()).and(z.union([ImageFormatDeclarationSchema, HTML5FormatDeclarationSchema, DisplayTagFormatDeclarationSchema, ImageCarouselFormatDeclarationSchema, HostedVideoFormatDeclarationSchema, VASTVideoFormatDeclarationSchema, HostedAudioFormatDeclarationSchema, DAASTAudioFormatDeclarationSchema, SponsoredPlacementFormatDeclarationSchema, NativeInFeedFormatDeclarationSchema, ResponsiveCreativeFormatDeclarationSchema, AgentPlacementFormatDeclarationSchema, CustomFormatDeclarationSchema])).and(z.object({
     format_option_id: z.string().optional(),
     publisher_domain: z.string().optional(),
     display_name: z.string().optional(),
@@ -6515,7 +6526,7 @@ export const CreativeFeatureResultSchema = z.object({
     measured_at: z.string().optional(),
     expires_at: z.string().optional(),
     methodology_version: z.string().optional(),
-    details: z.record(z.string(), z.unknown()).optional(),
+    details: z.object({}).passthrough().optional(),
     policy_id: z.string().optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -6555,16 +6566,16 @@ export const CreativeStatusChangedWebhookSchema = z.object({
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
-export const ValidateInputResultSchema = z.record(z.string(), z.unknown()).and(z.object({
-    target: z.record(z.string(), z.unknown()),
+export const ValidateInputResultSchema = z.object({}).passthrough().merge(z.object({
+    target: z.object({}).passthrough(),
     result_kind: z.union([z.literal("validated_pass"), z.literal("validated_fail"), z.literal("unvalidatable_nondeterministic")]),
-    violations: z.array(z.record(z.string(), z.unknown()).and(z.object({
+    violations: z.array(z.object({
         rule: z.string(),
-        expected: z.record(z.string(), z.unknown()).optional(),
-        predicted: z.record(z.string(), z.unknown()).optional(),
+        expected: z.object({}).passthrough().optional(),
+        predicted: z.object({}).passthrough().optional(),
         field: z.string(),
-        retry_with: z.record(z.string(), z.unknown()).optional()
-    }).passthrough())).optional()
+        retry_with: z.object({}).passthrough().optional()
+    }).passthrough()).optional()
 }).passthrough());
 
 export const VideoBriefSchema = z.object({
@@ -6758,7 +6769,7 @@ export const PolicyReferenceSchema = z.object({
     config: z.object({}).passthrough().optional()
 }).passthrough();
 
-export const ManifestSchema = z.record(z.string(), z.unknown());
+export const ManifestSchema = z.object({}).passthrough();
 
 export const SchemaPathSchema = z.string().regex(/^[A-Za-z0-9_-]+(?:\/[A-Za-z0-9_-]+)*\.json$/);
 
@@ -6829,17 +6840,17 @@ export const ProductRefinementRequestsSchema = z.array(z.union([z.object({
         ask: z.string().min(1).optional()
     }).passthrough()]));
 
-export const ProposalBudgetConstraintSchema = z.object({
+export const ProposalBudgetConstraintSchema = z.object({}).passthrough().merge(z.object({
     min: z.number().optional(),
     max: z.number().optional(),
     currency: z.string()
-}).passthrough();
+}).passthrough());
 
-export const ProposalDeclineSchema = z.object({
+export const ProposalDeclineSchema = z.object({}).passthrough().merge(z.object({
     proposal_id: z.string(),
     reason: ProposalDeclineReasonSchema,
     detail: z.string().optional()
-}).passthrough();
+}).passthrough());
 
 export const PublisherTagsSourceSchema = z.object({
     selection_type: z.literal("publisher_tags"),
@@ -6890,7 +6901,7 @@ export const PropertyFeatureValueSchema = z.object({
     measured_at: z.string().optional(),
     expires_at: z.string().optional(),
     methodology_version: z.string().optional(),
-    details: z.record(z.string(), z.unknown()).optional(),
+    details: z.object({}).passthrough().optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
@@ -6958,32 +6969,32 @@ export const V1V2CanonicalFormatMappingRegistrySchema = z.object({
 }).passthrough();
 
 export const SICapabilitiesSchema = z.object({
-    modalities: z.record(z.string(), z.unknown()).and(z.object({
+    modalities: z.object({
         conversational: z.boolean().optional(),
-        voice: z.union([z.boolean(), z.record(z.string(), z.unknown()).and(z.object({
+        voice: z.union([z.boolean(), z.object({
                 provider: z.string().optional(),
                 voice_id: z.string().optional()
-            }).passthrough())]).optional(),
-        video: z.union([z.boolean(), z.record(z.string(), z.unknown()).and(z.object({
+            }).passthrough()]).optional(),
+        video: z.union([z.boolean(), z.object({
                 formats: z.array(z.string()).optional(),
                 max_duration_seconds: z.number().optional()
-            }).passthrough())]).optional(),
-        avatar: z.union([z.boolean(), z.record(z.string(), z.unknown()).and(z.object({
+            }).passthrough()]).optional(),
+        avatar: z.union([z.boolean(), z.object({
                 provider: z.string().optional(),
                 avatar_id: z.string().optional()
-            }).passthrough())]).optional()
-    }).passthrough()).optional(),
-    components: z.record(z.string(), z.unknown()).and(z.object({
+            }).passthrough()]).optional()
+    }).passthrough().optional(),
+    components: z.object({
         standard: z.array(z.union([z.literal("text"), z.literal("link"), z.literal("image"), z.literal("product_card"), z.literal("carousel"), z.literal("action_button")])).optional(),
-        extensions: z.record(z.string(), z.unknown()).optional()
-    }).passthrough()).optional(),
-    commerce: z.record(z.string(), z.unknown()).and(z.object({
+        extensions: z.object({}).passthrough().optional()
+    }).passthrough().optional(),
+    commerce: z.object({
         acp_checkout: z.boolean().optional()
-    }).passthrough()).optional(),
-    a2ui: z.record(z.string(), z.unknown()).and(z.object({
+    }).passthrough().optional(),
+    a2ui: z.object({
         supported: z.boolean().optional(),
         catalogs: z.array(z.string()).optional()
-    }).passthrough()).optional(),
+    }).passthrough().optional(),
     mcp_apps: z.boolean().optional()
 }).passthrough();
 
@@ -6993,62 +7004,62 @@ export const SIIdentitySchema = z.object({
     consent_granted: z.boolean(),
     consent_timestamp: z.string().optional(),
     consent_scope: z.array(z.union([z.literal("name"), z.literal("email"), z.literal("shipping_address"), z.literal("phone"), z.literal("locale")])).optional(),
-    privacy_policy_acknowledged: z.record(z.string(), z.unknown()).and(z.object({
+    privacy_policy_acknowledged: z.object({
         brand_policy_url: z.string().optional(),
         brand_policy_version: z.string().optional()
-    }).passthrough()).optional(),
-    user: z.record(z.string(), z.unknown()).and(z.object({
+    }).passthrough().optional(),
+    user: z.object({
         email: z.string().optional(),
         name: z.string().optional(),
         locale: z.string().optional(),
         phone: z.string().optional(),
-        shipping_address: z.record(z.string(), z.unknown()).and(z.object({
+        shipping_address: z.object({
             street: z.string().optional(),
             city: z.string().optional(),
             state: z.string().optional(),
             postal_code: z.string().optional(),
             country: z.string().optional()
-        }).passthrough()).optional()
-    }).passthrough()).optional(),
+        }).passthrough().optional()
+    }).passthrough().optional(),
     anonymous_session_id: z.string().optional()
 }).passthrough();
 
 export const SISponsoredContextSchema = z.object({
-    paying_principal: z.record(z.string(), z.unknown()).and(z.object({
+    paying_principal: z.object({
         brand: BrandReferenceSchema,
         account: z.object({
             account_id: z.string()
         }).passthrough().optional(),
         operator: z.string().optional(),
         display_name: z.string().optional()
-    }).passthrough()),
+    }).passthrough(),
     context_use: SIContextUseSchema,
-    disclosure_obligation: z.record(z.string(), z.unknown()).and(z.object({
+    disclosure_obligation: z.object({
         required: z.boolean(),
         label_text: z.string().optional(),
         timing: z.union([z.literal("before_use"), z.literal("at_first_influenced_output"), z.literal("near_each_influenced_output")]).optional(),
         proximity: z.union([z.literal("session_level"), z.literal("near_rendered_unit"), z.literal("near_influenced_output")]).optional(),
-        jurisdictions: z.tuple([z.record(z.string(), z.unknown()).and(z.object({
+        jurisdictions: z.tuple([z.object({
                 country: z.string(),
                 region: z.string().optional(),
                 regulation: z.string()
-            }).passthrough())]).rest(z.record(z.string(), z.unknown()).and(z.object({
+            }).passthrough()]).rest(z.object({
             country: z.string(),
             region: z.string().optional(),
             regulation: z.string()
-        }).passthrough())).optional()
-    }).passthrough()),
+        }).passthrough()).optional()
+    }).passthrough(),
     declared_at: z.string().optional(),
-    declared_by: z.record(z.string(), z.unknown()).and(z.object({
+    declared_by: z.object({
         agent_url: z.string().optional(),
         role: z.union([z.literal("brand_agent"), z.literal("seller"), z.literal("network"), z.literal("platform")])
-    }).passthrough()).optional(),
+    }).passthrough().optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
-export const SIUIElementSchema = z.record(z.string(), z.unknown()).and(z.object({
+export const SIUIElementSchema = z.object({}).passthrough().merge(z.object({
     type: z.union([z.literal("text"), z.literal("link"), z.literal("image"), z.literal("product_card"), z.literal("carousel"), z.literal("action_button"), z.literal("app_handoff"), z.literal("integration_actions")]),
-    data: z.record(z.string(), z.unknown()).optional()
+    data: z.object({}).passthrough().optional()
 }).passthrough());
 
 export const AvailablePackageSchema = z.object({
@@ -7227,6 +7238,8 @@ export const PublisherTMPXMacroMappingSchema = z.object({
     )
 }).strict();
 
+export const SignalCatalogTypeSchema = SignalAvailabilityTypeSchema;
+
 export const IdentityMatchResponseRouterPublisherSchema = z.object({
     context_id: z.string().optional(),
     task_id: z.string().optional(),
@@ -7327,12 +7340,12 @@ export const TmpxMacroSchema = z.object({
     value: z.string().min(1).max(1024)
 }).passthrough();
 
-export const PolicyProfileSchema = z.object({
+export const PolicyProfileSchema = z.object({}).passthrough().merge(z.object({
     modes: z.tuple([z.union([z.literal("automatic"), z.literal("bid_amount"), z.literal("max_bid"), z.literal("cost_per"), z.literal("roas")])]).rest(z.union([z.literal("automatic"), z.literal("bid_amount"), z.literal("max_bid"), z.literal("cost_per"), z.literal("roas")])).optional(),
     cost_per_strengths: z.tuple([z.union([z.literal("cap"), z.literal("target")])]).rest(z.union([z.literal("cap"), z.literal("target")])).optional(),
     roas_strengths: z.tuple([z.union([z.literal("floor"), z.literal("target")])]).rest(z.union([z.literal("floor"), z.literal("target")])).optional(),
     supported_combinations: z.tuple([z.union([MaxBidWithCostPerSchema, MaxBidWithRoasSchema])]).rest(z.union([MaxBidWithCostPerSchema, MaxBidWithRoasSchema])).optional()
-}).passthrough();
+}).passthrough());
 
 export const PostalArea1Schema = PostalCountrySystemSchema;
 
@@ -7344,7 +7357,7 @@ export const AttestationBrandIssuerSchema = z.object({
 
 export const PostalAreaSchema = z.union([PostalArea1Schema, PostalAreaWithFusedSystemSchema]);
 
-export const GeographicPlaceAreaSchema = z.object({
+export const GeographicPlaceAreaSchema = z.object({}).passthrough().merge(z.object({
     country: z.string(),
     system: GeographicPlaceIdentifierSystemSchema,
     system_version: z.string().optional(),
@@ -7352,7 +7365,7 @@ export const GeographicPlaceAreaSchema = z.object({
     values: z.array(z.string()),
     value_labels: z.record(z.string(), z.string()).optional(),
     ext: ExtensionObjectSchema.optional()
-}).passthrough().merge(z.object({
+}).passthrough()).merge(z.object({
     country: z.string(),
     system: GeographicPlaceIdentifierSystemSchema,
     system_version: z.string().optional(),
@@ -7378,7 +7391,7 @@ export const GeographicPlaceRequirementSchema = z.object({
     systems: z.record(z.string(), CatalogRequirementSchema)
 }).passthrough();
 
-export const PlacementSchema = z.object({
+export const PlacementSchema = z.object({}).passthrough().merge(z.object({}).passthrough()).merge(z.object({}).passthrough()).and(z.union([z.object({}).passthrough(), z.object({}).passthrough()])).and(z.object({
     kind: z.union([z.literal("publisher_ref"), z.literal("seller_inline")]),
     placement_id: z.string(),
     publisher_domain: z.string().optional(),
@@ -7392,7 +7405,7 @@ export const PlacementSchema = z.object({
     audio_distribution_types: z.array(AudioDistributionTypeSchema).optional(),
     sponsored_placement_types: z.array(SponsoredPlacementTypeSchema).optional(),
     social_placement_surfaces: z.array(SocialPlacementSurfaceSchema).optional()
-}).passthrough().and(z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())])).and(z.object({
+}).passthrough()).and(z.union([z.object({}).passthrough(), z.object({}).passthrough()])).and(z.object({
     kind: z.union([z.literal("publisher_ref"), z.literal("seller_inline")]),
     placement_id: z.string(),
     publisher_domain: z.string().optional(),
@@ -7440,7 +7453,7 @@ export const ReportingCapabilitiesSchema = z.object({
     measurement_windows: z.array(MeasurementWindowSchema).optional()
 }).passthrough();
 
-export const ProductSignalTargetingOptionSchema = SignalListingSchema.and(z.object({
+export const ProductSignalTargetingOptionSchema = SignalListingSchema.and(z.object({}).passthrough()).and(z.object({
     signal_agent_segment_id: z.string().optional(),
     activation_status: z.union([z.literal("ready"), z.literal("requires_activation")]).optional(),
     allowed_targeting_modes: z.tuple([z.union([z.literal("include"), z.literal("exclude")])]).rest(z.union([z.literal("include"), z.literal("exclude")])).optional(),
@@ -7506,7 +7519,7 @@ export const PlacementForecastDimensionSchema = z.object({
     placement_name: z.string().optional()
 }).passthrough();
 
-export const SignalForecastDimensionSchema = z.object({
+export const SignalForecastDimensionSchema = z.object({}).passthrough().merge(z.object({}).passthrough()).and(z.union([z.object({}).passthrough(), z.object({}).passthrough()])).and(z.object({
     kind: z.literal("signal"),
     signal_ref: SignalRefSchema.optional(),
     signal_id: z.string().optional(),
@@ -7514,7 +7527,7 @@ export const SignalForecastDimensionSchema = z.object({
     presence: z.union([z.literal("present"), z.literal("absent")]),
     signal_name: z.string().optional(),
     signal_value_name: z.string().optional()
-}).passthrough();
+}).passthrough());
 
 export const AttestationIssuerSchema = z.union([AttestationBrandIssuerSchema, AttestationAgentIssuerSchema, AttestationOriginIssuerSchema]);
 
@@ -7524,7 +7537,7 @@ export const ForecastVendorMetricValueSchema = z.object({
     value: ForecastRangeSchema,
     unit: z.string().optional(),
     measurable_impressions: ForecastRangeSchema.optional(),
-    breakdown: z.record(z.string(), z.unknown()).optional()
+    breakdown: z.object({}).passthrough().optional()
 }).passthrough();
 
 export const PlaceSupportSchema = z.object({
@@ -7554,7 +7567,7 @@ export const AttestationReferenceSchema = z.object({
         agent_url: z.string()
     }).passthrough().optional(),
     ext: ExtensionObjectSchema.optional()
-}).passthrough().and(z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())])).and(z.object({
+}).passthrough().and(z.union([z.object({}).passthrough(), z.object({}).passthrough()])).and(z.object({
     issuer: AttestationIssuerSchema,
     claim_type: z.string(),
     subject: AttestationSubjectSchema,
@@ -7783,9 +7796,9 @@ export const ExplicitPackagesWithSellerOptimizedAllocationSchema = z.object({
     }).passthrough()
 }).passthrough();
 
-export const CommittedProposalExecutionSchema = z.record(z.string(), z.unknown());
+export const CommittedProposalExecutionSchema = z.object({}).passthrough();
 
-export const AudienceEvidenceRequirementsSchema = z.object({
+export const AudienceEvidenceRequirementsSchema = z.object({}).passthrough().merge(z.object({
     requirement_mode: z.union([z.literal("required"), z.literal("preferred")]),
     evidence_presence: z.union([z.literal("required"), z.literal("when_available")]),
     accepted_methodologies: z.array(AudienceEvidenceMethodologySchema).optional(),
@@ -7804,7 +7817,7 @@ export const AudienceEvidenceRequirementsSchema = z.object({
     accepted_attestation_issuers: z.array(AttestationIssuerSchema).optional(),
     accepted_attestation_claim_types: z.array(z.string()).optional(),
     ext: ExtensionObjectSchema.optional()
-}).passthrough();
+}).passthrough());
 
 export const BriefAssetSchema = CreativeBriefSchema.merge(z.object({
     asset_type: z.literal("brief")
@@ -7858,18 +7871,18 @@ export const AccountSchema = z.object({
     timezone: z.string().optional(),
     billing: BillingPartySchema.optional(),
     billing_entity: BusinessEntitySchema.optional(),
-    destination_billing_entity: z.record(z.string(), z.unknown()).optional(),
+    destination_billing_entity: z.object({}).passthrough().optional(),
     rate_card: z.string().optional(),
     payment_terms: PaymentTermsSchema.optional(),
     credit_limit: z.object({
         amount: z.number(),
         currency: z.string()
     }).passthrough().optional(),
-    setup: z.record(z.string(), z.unknown()).and(z.object({
+    setup: z.object({
         url: z.string().optional(),
         message: z.string(),
         expires_at: z.string().optional()
-    }).passthrough()).optional(),
+    }).passthrough().optional(),
     account_scope: AccountScopeSchema.optional(),
     governance_agents: z.tuple([z.object({
             url: z.string()
@@ -7977,7 +7990,7 @@ export const VendorMetricValueSchema = z.object({
     value: z.number(),
     unit: z.string().optional(),
     measurable_impressions: z.number().optional(),
-    breakdown: z.record(z.string(), z.unknown()).optional()
+    breakdown: z.object({}).passthrough().optional()
 }).passthrough();
 
 export const ProvidePerformanceFeedbackRequestSchema = z.object({
@@ -8176,7 +8189,7 @@ export const SyncAudiencesSubmittedSchema = z.object({
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
-export const SyncCatalogsRequestSchema = z.object({
+export const SyncCatalogsRequestSchema = z.object({}).passthrough().merge(z.object({
     adcp_version: z.string().optional(),
     adcp_major_version: z.number().optional(),
     idempotency_key: z.string().min(16).max(255).regex(/^[A-Za-z0-9_.:-]{16,255}$/),
@@ -8191,7 +8204,7 @@ export const SyncCatalogsRequestSchema = z.object({
     push_notification_config: PushNotificationConfigSchema.optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
-}).passthrough();
+}).passthrough());
 
 export const SyncCatalogsSuccessSchema = z.object({
     status: z.literal("completed").optional(),
@@ -8223,15 +8236,15 @@ export const SyncCatalogsSuccessSchema = z.object({
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
-export const RefinementWithInheritedTargetCapabilitySchema = z.record(z.string(), z.unknown());
+export const RefinementWithInheritedTargetCapabilitySchema = z.object({}).passthrough();
 
-export const CanonicalSingleOutputBuildTargetSchema = z.record(z.string(), z.unknown());
+export const CanonicalSingleOutputBuildTargetSchema = z.object({}).passthrough();
 
-export const CanonicalMultiOutputBuildTargetSchema = z.record(z.string(), z.unknown());
+export const CanonicalMultiOutputBuildTargetSchema = z.object({}).passthrough();
 
-export const SingleOutputNamedFormatTargetSchema = z.record(z.string(), z.unknown());
+export const SingleOutputNamedFormatTargetSchema = z.object({}).passthrough();
 
-export const MultiOutputNamedFormatTargetSchema = z.record(z.string(), z.unknown());
+export const MultiOutputNamedFormatTargetSchema = z.object({}).passthrough();
 
 export const EvaluatorSpecSchema = z.object({
     feature_requirement: z.array(FeatureRequirementSchema).optional(),
@@ -8246,10 +8259,10 @@ export const EvaluatorSpecSchema = z.object({
         agent_url: z.string(),
         feature_id: z.string().optional()
     }).passthrough().optional(),
-    eval_budget: z.record(z.string(), z.unknown()).and(z.object({
+    eval_budget: z.object({
         max_calls: z.number().optional(),
         max_seconds: z.number().optional()
-    }).passthrough()).optional(),
+    }).passthrough().optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough().and(z.union([z.object({
         exemplars: z.object({
@@ -8262,7 +8275,9 @@ export const EvaluatorSpecSchema = z.object({
         agent_url: z.string()
     }).passthrough()]));
 
-export const RightsConstraintSchema = z.record(z.string(), z.unknown()).and(z.object({
+export const AssetVariantSchema = z.union([ImageAssetSchema, VideoAssetSchema, AudioAssetSchema, VASTAssetSchema, TextAssetSchema, URLAssetSchema, HTMLAssetSchema, JavaScriptAssetSchema, ZipAssetSchema, WebhookAssetSchema, CSSAssetSchema, DAASTAssetSchema, MarkdownAssetSchema, BriefAssetSchema, CatalogAssetSchema, PublishedPostAssetSchema, CardAssetSchema, PixelTrackerAssetSchema, VASTTrackerAssetSchema, DAASTTrackerAssetSchema]);
+
+export const RightsConstraintSchema = z.object({}).passthrough().merge(z.object({
     rights_id: z.string(),
     rights_agent: z.object({
         url: z.string(),
@@ -8279,7 +8294,7 @@ export const RightsConstraintSchema = z.record(z.string(), z.unknown()).and(z.ob
     approval_status: z.union([z.literal("pending"), z.literal("approved"), z.literal("rejected")]).optional(),
     grant_status: z.union([z.literal("active"), z.literal("paused"), z.literal("revoked")]).optional(),
     restrictions: z.array(z.string()).optional(),
-    disclosure: z.record(z.string(), z.unknown()).optional(),
+    disclosure: z.object({}).passthrough().optional(),
     creative_approval_required: z.boolean().optional(),
     verification_url: z.string().optional(),
     content_digest: z.string().optional(),
@@ -8385,7 +8400,7 @@ export const RightsConstraintSchema = z.record(z.string(), z.unknown()).and(z.ob
                 }).passthrough().optional()
             }).passthrough())])]).optional(),
     ext: ExtensionObjectSchema.optional()
-}).passthrough()).and(z.object({
+}).passthrough()).merge(z.object({
     rights_id: z.string(),
     rights_agent: z.object({
         url: z.string(),
@@ -8402,7 +8417,7 @@ export const RightsConstraintSchema = z.record(z.string(), z.unknown()).and(z.ob
     approval_status: z.union([z.literal("pending"), z.literal("approved"), z.literal("rejected")]).optional(),
     grant_status: z.union([z.literal("active"), z.literal("paused"), z.literal("revoked")]).optional(),
     restrictions: z.array(z.string()).optional(),
-    disclosure: z.record(z.string(), z.unknown()).optional(),
+    disclosure: z.object({}).passthrough().optional(),
     creative_approval_required: z.boolean().optional(),
     verification_url: z.string().optional(),
     content_digest: z.string().optional(),
@@ -8636,7 +8651,7 @@ export const BuildCreativeVariantSuccessSchema = z.object({
 }).passthrough();
 
 // @ts-ignore -- preserve the public schema type across lossy TS-to-Zod projection details.
-export const PreviewCreativeRequestSchema: z.ZodObject<{ request_type: z.ZodType<PreviewCreativeRequest['request_type'], PreviewCreativeRequest['request_type']> } & Record<string, z.ZodType>, any> & z.ZodType<PreviewCreativeRequest & Record<string, unknown>, PreviewCreativeRequest & Record<string, unknown>> = z.object({
+export const PreviewCreativeRequestSchema: z.ZodObject<{ request_type: z.ZodType<PreviewCreativeRequest['request_type'], PreviewCreativeRequest['request_type']> } & Record<string, z.ZodType>, any> & z.ZodType<PreviewCreativeRequest & Record<string, unknown>, PreviewCreativeRequest & Record<string, unknown>> = z.object({}).passthrough().merge(z.object({
     adcp_version: z.string().optional(),
     adcp_major_version: z.number().optional(),
     request_type: z.union([z.literal("single"), z.literal("batch"), z.literal("variant")]),
@@ -8673,7 +8688,7 @@ export const PreviewCreativeRequestSchema: z.ZodObject<{ request_type: z.ZodType
     push_notification_config: PushNotificationConfigSchema.optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
-}).passthrough();
+}).passthrough());
 
 export const PreviewCreativeBatchResponseSchema = z.object({
     response_type: z.literal("batch"),
@@ -8723,35 +8738,35 @@ export const TransformerSchema = z.object({
     transformer_id: z.string(),
     name: z.string(),
     description: z.string().optional(),
-    metadata: z.record(z.string(), z.unknown()).optional(),
-    voice_synthesis_ref: z.tuple([z.record(z.string(), z.unknown()).and(z.object({
-            brand_agent: z.record(z.string(), z.unknown()).and(z.object({
+    metadata: z.object({}).passthrough().optional(),
+    voice_synthesis_ref: z.tuple([z.object({
+            brand_agent: z.object({
                 url: z.string(),
                 id: z.string()
-            }).passthrough()),
+            }).passthrough(),
             voice_id: z.string(),
             rights_id: z.string().optional()
-        }).passthrough())]).rest(z.record(z.string(), z.unknown()).and(z.object({
-        brand_agent: z.record(z.string(), z.unknown()).and(z.object({
+        }).passthrough()]).rest(z.object({
+        brand_agent: z.object({
             url: z.string(),
             id: z.string()
-        }).passthrough()),
+        }).passthrough(),
         voice_id: z.string(),
         rights_id: z.string().optional()
-    }).passthrough())).optional(),
+    }).passthrough()).optional(),
     input_format_ids: z.array(FormatReferenceStructuredObjectSchema).optional(),
     output_format_ids: z.array(FormatReferenceStructuredObjectSchema).optional(),
     input_formats: z.array(ProductFormatDeclarationSchema).optional(),
     output_capability_ids: z.array(z.string()).optional(),
     params: z.array(TransformerParamSchema).optional(),
     pricing_options: z.array(VendorPricingOptionSchema).optional(),
-    multiplicity: z.record(z.string(), z.unknown()).and(z.object({
+    multiplicity: z.object({
         supports_catalog_fanout: z.boolean().optional(),
         max_creatives_limit: z.number().optional(),
         supports_variants: z.boolean().optional(),
         max_variants_limit: z.number().optional(),
         variant_dimensions: z.array(z.union([z.literal("voice"), z.literal("theme"), z.literal("best_of_n"), z.literal("transformer_config"), z.literal("custom")])).optional()
-    }).passthrough()).optional()
+    }).passthrough().optional()
 }).passthrough();
 
 export const ListTransformersResponseCreativeAgentSchema = z.object({
@@ -8911,7 +8926,7 @@ export const ListCreativesRequestSchema = z.object({
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
-export const AssetVariantSchema = z.union([ImageAssetSchema, VideoAssetSchema, AudioAssetSchema, VASTAssetSchema, TextAssetSchema, URLAssetSchema, HTMLAssetSchema, JavaScriptAssetSchema, ZipAssetSchema, WebhookAssetSchema, CSSAssetSchema, DAASTAssetSchema, MarkdownAssetSchema, BriefAssetSchema, CatalogAssetSchema, PublishedPostAssetSchema, CardAssetSchema, PixelTrackerAssetSchema, VASTTrackerAssetSchema, DAASTTrackerAssetSchema]);
+export const LocalizedCreativeAssetSchema = AssetVariantSchema.and(z.object({}).passthrough());
 
 export const RightsAttestationEvaluationSchema = z.object({
     rights_id: z.string(),
@@ -8931,13 +8946,18 @@ export const RightsAttestationEvaluationSchema = z.object({
         action_binding: z.object({
             action_type: z.literal("https://adcontextprotocol.org/actions/rights-grant-evaluation")
         }).passthrough()
-    }).passthrough()),
+    }).passthrough()).and(z.object({}).passthrough()),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
-export const LocalizedCreativeAssetSchema = AssetVariantSchema;
-
 export const ResolvedAssetsSchema = z.record(z.string(), z.union([LocalizedCreativeAssetSchema, z.array(LocalizedCreativeAssetSchema)]));
+
+export const TargetLocalizationReadbackSchema = z.object({
+    locale_variant_id: z.string(),
+    locale: LanguageTagSchema,
+    role: z.literal("target"),
+    assets: ResolvedAssetsSchema
+}).passthrough();
 
 export const CreativeAssetSchema = z.object({
     creative_id: z.string(),
@@ -8946,11 +8966,11 @@ export const CreativeAssetSchema = z.object({
     format_kind: CanonicalFormatKindSchema.optional(),
     format_option_ref: FormatOptionReferenceSchema.optional(),
     assets: CreativeAssetsSchema,
-    inputs: z.array(z.record(z.string(), z.unknown()).and(z.object({
+    inputs: z.array(z.object({
         name: z.string(),
         macros: z.record(z.string(), z.string()).optional(),
         context_description: z.string().optional()
-    }).passthrough())).optional(),
+    }).passthrough()).optional(),
     tags: z.array(z.string()).optional(),
     status: CreativeStatusSchema.optional(),
     weight: z.number().optional(),
@@ -8979,22 +8999,22 @@ export const CreativeAssetSchema = z.object({
 });
 
 export const CreativeLocalizationSchema = z.object({
-    source: z.record(z.string(), z.unknown()).and(z.object({
+    source: z.object({
         locale_variant_id: z.string(),
         locale: LanguageTagSchema
-    }).passthrough()),
-    target_variants: z.array(z.record(z.string(), z.unknown()).and(z.object({
+    }).passthrough(),
+    target_variants: z.array(z.object({
         locale_variant_id: z.string(),
         locale: LanguageTagSchema,
         assets: z.record(z.string(), z.union([LocalizedCreativeAssetSchema, z.array(LocalizedCreativeAssetSchema)]))
-    }).passthrough())),
-    locale_fallbacks: z.tuple([z.record(z.string(), z.unknown()).and(z.object({
+    }).passthrough()),
+    locale_fallbacks: z.tuple([z.object({
             language_range: LanguageTagSchema,
             locale_variant_id: z.string()
-        }).passthrough())]).rest(z.record(z.string(), z.unknown()).and(z.object({
+        }).passthrough()]).rest(z.object({
         language_range: LanguageTagSchema,
         locale_variant_id: z.string()
-    }).passthrough())).optional(),
+    }).passthrough()).optional(),
     default_locale_variant_id: z.string(),
     unmatched_locale_action: z.union([z.literal("serve_default"), z.literal("do_not_serve")])
 }).passthrough();
@@ -9103,9 +9123,9 @@ export const ForecastPointSchema = z.object({
         downloads: ForecastRangeSchema.optional(),
         plays: ForecastRangeSchema.optional(),
         coverage_rate: ForecastRangeSchema.and(z.object({
-            low: z.record(z.string(), z.unknown()).optional(),
-            mid: z.record(z.string(), z.unknown()).optional(),
-            high: z.record(z.string(), z.unknown()).optional()
+            low: z.number().max(1).optional(),
+            mid: z.number().max(1).optional(),
+            high: z.number().max(1).optional()
         }).passthrough()).optional()
     }).passthrough().catchall(ForecastRangeSchema),
     viewability: z.object({
@@ -9113,9 +9133,9 @@ export const ForecastPointSchema = z.object({
         measurable_impressions: ForecastRangeSchema.optional(),
         viewable_impressions: ForecastRangeSchema.optional(),
         viewable_rate: ForecastRangeSchema.and(z.object({
-            low: z.record(z.string(), z.unknown()).optional(),
-            mid: z.record(z.string(), z.unknown()).optional(),
-            high: z.record(z.string(), z.unknown()).optional()
+            low: z.number().max(1).optional(),
+            mid: z.number().max(1).optional(),
+            high: z.number().max(1).optional()
         }).passthrough()).optional(),
         viewed_seconds: ForecastRangeSchema.optional(),
         standard: ViewabilityStandardSchema.optional()
@@ -9123,30 +9143,30 @@ export const ForecastPointSchema = z.object({
     vendor_metric_values: z.array(ForecastVendorMetricValueSchema).optional()
 }).passthrough();
 
-export const SignalCoverageForecastSchema = z.object({
+export const SignalCoverageForecastSchema = z.object({}).passthrough().merge(z.object({
     points: z.tuple([ForecastPointSchema.and(z.object({
-            dimensions: z.record(z.string(), z.unknown()),
-            metrics: z.record(z.string(), z.unknown()).optional()
+            dimensions: z.object({}).passthrough(),
+            metrics: z.object({}).passthrough().optional()
         }).passthrough())]).rest(ForecastPointSchema.and(z.object({
-        dimensions: z.record(z.string(), z.unknown()),
-        metrics: z.record(z.string(), z.unknown()).optional()
+        dimensions: z.object({}).passthrough(),
+        metrics: z.object({}).passthrough().optional()
     }).passthrough())),
     forecast_range_unit: z.literal("availability"),
     method: ForecastMethodSchema,
-    scope: z.record(z.string(), z.unknown()).and(z.object({
+    scope: z.object({
         kind: z.union([z.literal("inventory"), z.literal("product"), z.literal("account"), z.literal("custom")]),
         label: z.string(),
         product_id: z.string().optional(),
         countries: z.array(z.string()).optional(),
         line_item_types: z.array(z.string()).optional(),
         date_range: DateRangeSchema.optional()
-    }).passthrough()),
+    }).passthrough(),
     bucket_semantics: z.union([z.literal("exclusive"), z.literal("overlapping")]),
     bucket_completeness: z.union([z.literal("complete"), z.literal("partial")]),
     generated_at: z.string().optional(),
     valid_until: z.string().optional(),
     ext: ExtensionObjectSchema.optional()
-}).passthrough();
+}).passthrough());
 
 export const ActivateSignalRequestSchema = z.object({
     adcp_version: z.string().optional(),
@@ -9632,22 +9652,22 @@ export const Artifact1Schema = z.object({
             transcript_source: z.union([z.literal("original_script"), z.literal("closed_captions"), z.literal("generated")]).optional(),
             provenance: ProvenanceSchema.optional()
         }).passthrough()])),
-    metadata: z.record(z.string(), z.unknown()).and(z.object({
+    metadata: z.object({
         canonical: z.string().optional(),
         author: z.string().optional(),
         keywords: z.string().optional(),
-        open_graph: z.record(z.string(), z.unknown()).optional(),
-        twitter_card: z.record(z.string(), z.unknown()).optional(),
+        open_graph: z.object({}).passthrough().optional(),
+        twitter_card: z.object({}).passthrough().optional(),
         json_ld: z.array(z.object({}).passthrough()).optional()
-    }).passthrough()).optional(),
+    }).passthrough().optional(),
     provenance: ProvenanceSchema.optional(),
-    identifiers: z.record(z.string(), z.unknown()).and(z.object({
+    identifiers: z.object({
         apple_podcast_id: z.string().optional(),
         spotify_collection_id: z.string().optional(),
         podcast_guid: z.string().optional(),
         youtube_video_id: z.string().optional(),
         rss_url: z.string().optional()
-    }).passthrough()).optional()
+    }).passthrough().optional()
 }).passthrough();
 
 export const CreateContentStandardsResponseSchema = z.object({
@@ -10483,9 +10503,9 @@ export const SIGetOfferingResponseSchema = z.object({
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
-export const SISponsoredContextReceiptSchema = z.record(z.string(), z.unknown()).and(z.object({
+export const SISponsoredContextReceiptSchema = z.object({}).passthrough().merge(z.object({
     sponsored_context: SISponsoredContextSchema,
-    host_receipt: z.record(z.string(), z.unknown()),
+    host_receipt: z.object({}).passthrough(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough());
 
@@ -10645,7 +10665,7 @@ export const GetAdCPCapabilitiesRequestSchema = z.object({
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
-export const AttestationCapabilitiesSchema = z.object({
+export const AttestationCapabilitiesSchema = z.object({}).passthrough().merge(z.object({
     accepted_claim_types: z.array(z.string()),
     accepted_proof_formats: z.array(z.string()),
     supported_delivery_methods: z.tuple([z.union([z.literal("credential_uri"), z.literal("issuer_credential_id"), z.literal("embedded")])]).rest(z.union([z.literal("credential_uri"), z.literal("issuer_credential_id"), z.literal("embedded")])),
@@ -10693,7 +10713,7 @@ export const AttestationCapabilitiesSchema = z.object({
     }).passthrough()).optional(),
     max_embedded_credential_bytes: z.number().optional(),
     ext: ExtensionObjectSchema.optional()
-}).passthrough();
+}).passthrough());
 
 export const IdempotencySupportedSchema = z.object({
     supported: z.literal(true),
@@ -11126,7 +11146,7 @@ export const GetAccountFinancialsErrorSchema = z.object({
 }).passthrough();
 
 export const GetSignalsCompletionSchema = AdCPVersionEnvelopeSchema.merge(ProtocolEnvelopeSchema).merge(z.object({
-    signals: z.array(SignalListingSchema.and(SignalDefinitionEnrichmentSchema)).optional(),
+    signals: z.array(SignalListingSchema.and(SignalDefinitionEnrichmentSchema).and(z.object({}).passthrough())).optional(),
     errors: z.array(ErrorSchema).optional(),
     incomplete: z.tuple([z.object({
             scope: z.union([z.literal("signals"), z.literal("pricing"), z.literal("wholesale_feed")]),
@@ -11218,7 +11238,7 @@ export const RawAttestationSchema = z.object({
     content_type: z.string(),
     attestation_mode: z.literal("raw"),
     purpose: z.union([z.literal("platform_primary"), z.literal("measurement"), z.literal("attribution"), z.literal("creative_serving"), z.literal("identity"), z.literal("other")]).optional(),
-    payload: z.record(z.string(), z.unknown()),
+    payload: z.object({}).passthrough(),
     payload_length: z.number().min(0),
     timestamp: z.iso.datetime(),
     status_code: z.number().min(100).max(599).optional()
@@ -11319,7 +11339,7 @@ export const PackageSignalTargetingGroupsSchema = z.object({
     groups: z.array(PackageSignalTargetingGroupSchema)
 }).passthrough();
 
-export const TargetingOverlaySchema = z.record(z.string(), z.unknown()).and(z.object({
+export const TargetingOverlaySchema = z.object({}).passthrough().merge(z.object({
     geo_countries: z.array(z.string()).optional(),
     geo_countries_exclude: z.array(z.string()).optional(),
     geo_regions: z.array(z.string()).optional(),
@@ -11367,16 +11387,16 @@ export const TargetingOverlaySchema = z.record(z.string(), z.unknown()).and(z.ob
     device_type_exclude: z.array(DeviceTypeSchema).optional(),
     browser: z.array(BrowserFamilySchema).optional(),
     browser_exclude: z.array(BrowserFamilySchema).optional(),
-    store_catchments: z.tuple([z.record(z.string(), z.unknown()).and(z.object({
+    store_catchments: z.tuple([z.object({
             catalog_id: z.string(),
             store_ids: z.array(z.string()).optional(),
             catchment_ids: z.array(z.string()).optional()
-        }).passthrough())]).rest(z.record(z.string(), z.unknown()).and(z.object({
+        }).passthrough()]).rest(z.object({
         catalog_id: z.string(),
         store_ids: z.array(z.string()).optional(),
         catchment_ids: z.array(z.string()).optional()
-    }).passthrough())).optional(),
-    geo_proximity: z.tuple([z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())])]).rest(z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())])).optional(),
+    }).passthrough()).optional(),
+    geo_proximity: z.tuple([z.union([z.object({}).passthrough(), z.object({}).passthrough(), z.object({}).passthrough()])]).rest(z.union([z.object({}).passthrough(), z.object({}).passthrough(), z.object({}).passthrough()])).optional(),
     language: z.array(LanguageTagSchema).optional(),
     keyword_targets: z.tuple([z.object({
             keyword: z.string(),
@@ -11431,7 +11451,7 @@ export const ValidationResultSchema = z.object({
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
-export const AudienceEvidenceSchema: z.ZodType = z.object({
+export const AudienceEvidenceSchema: z.ZodType = z.object({}).passthrough().merge(z.object({}).passthrough()).merge(z.object({}).passthrough()).merge(z.object({
     evidence_id: z.string(),
     snapshot_id: z.string(),
     version: z.string(),
@@ -11788,7 +11808,7 @@ export const AudienceEvidenceSchema: z.ZodType = z.object({
                 }).passthrough())
             }).passthrough())])]).optional(),
     ext: ExtensionObjectSchema.optional()
-}).passthrough().merge(z.object({
+}).passthrough()).merge(z.object({
     evidence_id: z.string(),
     snapshot_id: z.string(),
     version: z.string(),
@@ -12663,7 +12683,7 @@ export const CanonicalFormatBaseSchema = z.object({
     provenance_required: z.boolean().optional(),
     platform_extensions: z.array(PlatformExtensionReference1Schema).optional(),
     synthesis_nondeterministic: z.boolean().optional(),
-    slots: z.array(z.record(z.string(), z.unknown())).optional(),
+    slots: z.array(z.object({}).passthrough()).optional(),
     required_connections: z.array(DownstreamConnectionRequirementSchema).optional(),
     reference_mutability: z.union([z.literal("immutable_snapshot"), z.literal("mutable_requires_reapproval"), z.literal("mutable_auto_recheck")]).optional(),
     production_window_business_days: z.number().optional()
@@ -12826,13 +12846,13 @@ export const MediaBuyDeliveryWebhookResultSchema = z.object({
     unavailable_count: z.number().optional(),
     sequence_number: z.number().optional(),
     next_expected_at: z.string().optional(),
-    reporting_period: z.record(z.string(), z.unknown()).and(z.object({
+    reporting_period: z.object({
         start: z.string(),
         end: z.string()
-    }).passthrough()),
+    }).passthrough(),
     currency: z.string(),
     attribution_window: AttributionWindowSchema.optional(),
-    media_buy_deliveries: z.array(z.record(z.string(), z.unknown()).and(z.object({
+    media_buy_deliveries: z.array(z.object({
         media_buy_id: z.string(),
         status: z.union([z.literal("pending_creatives"), z.literal("pending_start"), z.literal("pending"), z.literal("active"), z.literal("paused"), z.literal("completed"), z.literal("rejected"), z.literal("canceled"), z.literal("failed"), z.literal("reporting_delayed")]),
         expected_availability: z.string().optional(),
@@ -12841,10 +12861,10 @@ export const MediaBuyDeliveryWebhookResultSchema = z.object({
         finalized_at: z.string().optional(),
         pricing_model: PricingModelSchema.optional(),
         pacing_index: z.number().optional(),
-        totals: DeliveryMetricsSchema.and(z.record(z.string(), z.unknown()).and(z.object({
+        totals: DeliveryMetricsSchema.merge(z.object({
             effective_rate: z.number().optional()
-        }).passthrough())),
-        by_package: z.array(DeliveryMetricsSchema.and(z.record(z.string(), z.unknown()).and(z.object({
+        }).passthrough()),
+        by_package: z.array(DeliveryMetricsSchema.merge(z.object({
             package_id: z.string().optional(),
             pacing_index: z.number().optional(),
             pricing_model: PricingModelSchema.optional(),
@@ -12856,8 +12876,8 @@ export const MediaBuyDeliveryWebhookResultSchema = z.object({
             finalized_at: z.string().optional(),
             measurement_window: z.string().optional(),
             supersedes_window: z.string().optional()
-        }).passthrough())))
-    }).passthrough())),
+        }).passthrough()))
+    }).passthrough()),
     errors: z.array(ErrorSchema).optional(),
     sandbox: z.boolean().optional(),
     context: ContextObjectSchema.optional(),
@@ -12900,7 +12920,7 @@ export const ProductSchema: z.ZodObject<{ product_id: z.ZodType; name: z.ZodType
     product_id: z.string(),
     name: z.string(),
     description: z.string(),
-    publisher_properties: z.tuple([PublisherPropertySelectorSchema]).rest(PublisherPropertySelectorSchema),
+    publisher_properties: z.array(PublisherPropertySelectorSchema.and(z.object({}).passthrough())),
     channels: z.array(MediaChannelSchema).optional(),
     format_ids: z.array(FormatReferenceStructuredObjectSchema).optional(),
     format_options: z.array(ProductFormatDeclarationSchema).optional(),
@@ -12938,20 +12958,20 @@ export const ProductSchema: z.ZodObject<{ product_id: z.ZodType; name: z.ZodType
     audience_evidence: z.array(AudienceEvidenceSchema).optional(),
     audience_evidence_selections: z.array(AudienceEvidenceSelectionSchema).optional(),
     catalog_types: z.array(CatalogTypeSchema).optional(),
-    metric_optimization: z.record(z.string(), z.unknown()).and(z.object({
+    metric_optimization: z.object({
         supported_metrics: z.tuple([z.union([z.literal("clicks"), z.literal("views"), z.literal("completed_views"), z.literal("viewed_seconds"), z.literal("attention_seconds"), z.literal("attention_score"), z.literal("engagements"), z.literal("follows"), z.literal("saves"), z.literal("profile_visits"), z.literal("reach")])]).rest(z.union([z.literal("clicks"), z.literal("views"), z.literal("completed_views"), z.literal("viewed_seconds"), z.literal("attention_seconds"), z.literal("attention_score"), z.literal("engagements"), z.literal("follows"), z.literal("saves"), z.literal("profile_visits"), z.literal("reach")])),
         supported_reach_units: z.array(ReachUnitSchema).optional(),
         supported_view_durations: z.array(z.number()).optional(),
         supported_targets: z.array(z.union([z.literal("cost_per"), z.literal("threshold_rate")])).optional()
-    }).passthrough()).optional(),
+    }).passthrough().optional(),
     vendor_metric_optimization: VendorMetricOptimizationSchema.optional(),
     max_optimization_goals: z.number().optional(),
     measurement_readiness: MeasurementReadinessSchema.optional(),
-    conversion_tracking: z.record(z.string(), z.unknown()).and(z.object({
+    conversion_tracking: z.object({
         action_sources: z.array(ActionSourceSchema).optional(),
         supported_targets: z.tuple([z.union([z.literal("cost_per"), z.literal("per_ad_spend"), z.literal("maximize_value")])]).rest(z.union([z.literal("cost_per"), z.literal("per_ad_spend"), z.literal("maximize_value")])).optional(),
         platform_managed: z.boolean().optional()
-    }).passthrough()).optional(),
+    }).passthrough().optional(),
     catalog_match: z.object({
         matched_gtins: z.array(z.string()).optional(),
         matched_ids: z.array(z.string()).optional(),
@@ -12960,55 +12980,55 @@ export const ProductSchema: z.ZodObject<{ product_id: z.ZodType; name: z.ZodType
     }).passthrough().optional(),
     brief_relevance: z.string().optional(),
     expires_at: z.string().optional(),
-    product_card: z.record(z.string(), z.unknown()).and(z.object({
+    product_card: z.object({
         image: ImageAssetSchema.optional(),
         title: z.string().optional(),
         description: z.string().optional(),
         price_label: z.string().optional(),
         cta_label: z.string().optional()
-    }).passthrough()).optional(),
-    product_card_detailed: z.record(z.string(), z.unknown()).and(z.object({
+    }).passthrough().optional(),
+    product_card_detailed: z.object({
         hero_image: ImageAssetSchema.optional(),
         carousel_images: z.array(ImageAssetSchema).optional(),
         title: z.string().optional(),
         description: z.string().optional(),
-        specifications: z.array(z.record(z.string(), z.unknown()).and(z.object({
+        specifications: z.array(z.object({
             label: z.string(),
             value: z.string()
-        }).passthrough())).optional(),
+        }).passthrough()).optional(),
         price_label: z.string().optional(),
         cta_label: z.string().optional(),
         reference_assets: z.array(ProductCardReferenceAssetSchema).optional()
-    }).passthrough()).optional(),
+    }).passthrough().optional(),
     collections: z.array(CollectionSelectorSchema).optional(),
     collection_targeting_allowed: z.boolean().optional(),
     installments: z.array(InstallmentSchema).optional(),
     enforced_policies: z.array(z.string()).optional(),
-    trusted_match: z.record(z.string(), z.unknown()).and(z.object({
+    trusted_match: z.object({
         context_match: z.boolean(),
         identity_match: z.boolean().optional(),
         response_types: z.array(TMPResponseTypeSchema).optional(),
         dynamic_brands: z.boolean().optional(),
-        providers: z.tuple([z.record(z.string(), z.unknown()).and(z.object({
+        providers: z.tuple([z.object({
                 agent_url: z.string(),
                 context_match: z.boolean().optional(),
                 identity_match: z.boolean().optional(),
                 countries: z.array(z.string()).optional(),
                 uid_types: z.array(UIDTypeSchema).optional()
-            }).passthrough())]).rest(z.record(z.string(), z.unknown()).and(z.object({
+            }).passthrough()]).rest(z.object({
             agent_url: z.string(),
             context_match: z.boolean().optional(),
             identity_match: z.boolean().optional(),
             countries: z.array(z.string()).optional(),
             uid_types: z.array(UIDTypeSchema).optional()
-        }).passthrough())).optional()
-    }).passthrough()).optional(),
-    material_submission: z.record(z.string(), z.unknown()).and(z.object({
+        }).passthrough()).optional()
+    }).passthrough().optional(),
+    material_submission: z.object({
         url: z.string().optional(),
         email: z.string().optional(),
         instructions: z.string().optional(),
         ext: ExtensionObjectSchema.optional()
-    }).passthrough()).optional(),
+    }).passthrough().optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
@@ -13112,7 +13132,7 @@ export const CanonicalForecastPointSchema = z.object({
     vendor_metric_values: z.array(CanonicalForecastVendorMetricValueSchema).optional()
 }).passthrough();
 
-export const PackageSchema: z.ZodType = z.record(z.string(), z.unknown()).and(z.object({
+export const PackageSchema: z.ZodType = z.object({}).passthrough().merge(z.object({
     package_id: z.string(),
     product_id: z.string().optional(),
     audience_evidence_selections: z.array(AudienceEvidenceSelectionSchema).optional(),
@@ -13129,7 +13149,7 @@ export const PackageSchema: z.ZodType = z.record(z.string(), z.unknown()).and(z.
     format_ids: z.array(FormatReferenceStructuredObjectSchema).optional(),
     format_option_refs: z.array(FormatOptionReferenceSchema).optional(),
     format_kind: CanonicalFormatKindSchema.optional(),
-    params: z.record(z.string(), z.unknown()).optional(),
+    params: z.object({}).passthrough().optional(),
     targeting_overlay: TargetingOverlaySchema.optional(),
     targeting_resolution: PackageTargetingResolutionSchema.optional(),
     measurement_terms: MeasurementTermsSchema.optional(),
@@ -13177,7 +13197,7 @@ export const AcquireRightsAcquiredSchema = z.object({
     }).passthrough().optional(),
     approval_webhook: PushNotificationConfigSchema.optional(),
     usage_reporting_url: z.string().optional(),
-    rights_constraint: RightsConstraintSchema,
+    rights_constraint: RightsConstraintSchema.and(z.object({}).passthrough()),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -13273,7 +13293,7 @@ export const UpdateRightsSuccessSchema = z.object({
     rights_id: z.string(),
     terms: RightsTermsSchema,
     generation_credentials: z.array(GenerationCredentialSchema),
-    rights_constraint: RightsConstraintSchema,
+    rights_constraint: RightsConstraintSchema.and(z.object({}).passthrough()),
     paused: z.boolean().optional(),
     implementation_date: z.iso.datetime().optional().nullable(),
     context: ContextObjectSchema.optional(),
@@ -13309,7 +13329,7 @@ export const VerifyBrandClaimsSuccessSchema = z.object({
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
-export const ProposalSchema = z.record(z.string(), z.unknown()).and(z.object({
+export const ProposalSchema = z.object({}).passthrough().merge(z.object({
     proposal_id: z.string(),
     name: z.string(),
     description: z.string().optional(),
@@ -13319,12 +13339,12 @@ export const ProposalSchema = z.record(z.string(), z.unknown()).and(z.object({
     proposal_status: ProposalStatusSchema.optional(),
     expires_at: z.string().optional(),
     insertion_order: InsertionOrderSchema.optional(),
-    total_budget_guidance: z.record(z.string(), z.unknown()).and(z.object({
+    total_budget_guidance: z.object({
         min: z.number().optional(),
         recommended: z.number().optional(),
         max: z.number().optional(),
         currency: z.string().optional()
-    }).passthrough()).optional(),
+    }).passthrough().optional(),
     brief_alignment: z.string().optional(),
     forecast: DeliveryForecastSchema.optional(),
     ext: ExtensionObjectSchema.optional()
@@ -13412,49 +13432,42 @@ export const SourceLocalizationReadbackSchema = z.object({
     assets: ResolvedAssetsSchema
 }).passthrough();
 
-export const TargetLocalizationReadbackSchema = z.object({
-    locale_variant_id: z.string(),
-    locale: LanguageTagSchema,
-    role: z.literal("target"),
-    assets: ResolvedAssetsSchema
-}).passthrough();
-
-export const FormatSchema = z.record(z.string(), z.unknown()).and(z.object({
+export const FormatSchema = z.object({}).passthrough().merge(z.object({
     format_id: FormatReferenceStructuredObjectSchema,
     name: z.string(),
     description: z.string().optional(),
     example_url: z.string().optional(),
     accepts_parameters: z.array(FormatIDParameterSchema).optional(),
-    renders: z.tuple([z.union([z.record(z.string(), z.unknown()), z.object({
+    renders: z.tuple([z.union([z.object({}).passthrough(), z.object({
                 parameters_from_format_id: z.literal(true)
-            }).passthrough()])]).rest(z.union([z.record(z.string(), z.unknown()), z.object({
+            }).passthrough()])]).rest(z.union([z.object({}).passthrough(), z.object({
             parameters_from_format_id: z.literal(true)
         }).passthrough()])).optional(),
     assets: z.array(z.union([z.union([IndividualImageAssetSchema, IndividualVideoAssetSchema, IndividualAudioAssetSchema, IndividualTextAssetSchema, IndividualMarkdownAssetSchema, IndividualHtmlAssetSchema, IndividualCssAssetSchema, IndividualJavaScriptAssetSchema, IndividualZipAssetSchema, IndividualVastAssetSchema, IndividualDaastAssetSchema, IndividualUrlAssetSchema, IndividualWebhookAssetSchema, IndividualBriefAssetSchema, IndividualCatalogAssetSchema]), RepeatableGroupAssetSchema])).optional(),
-    delivery: z.record(z.string(), z.unknown()).optional(),
+    delivery: z.object({}).passthrough().optional(),
     supported_macros: z.array(z.union([UniversalMacroSchema, z.string()])).optional(),
     input_format_ids: z.array(FormatReferenceStructuredObjectSchema).optional(),
     output_format_ids: z.array(FormatReferenceStructuredObjectSchema).optional(),
-    format_card: z.record(z.string(), z.unknown()).and(z.object({
+    format_card: z.object({
         format_id: FormatReferenceStructuredObjectSchema,
-        manifest: z.record(z.string(), z.unknown())
-    }).passthrough()).optional(),
+        manifest: z.object({}).passthrough()
+    }).passthrough().optional(),
     accessibility: z.object({
         wcag_level: WCAGLevelSchema,
         requires_accessible_assets: z.boolean().optional()
     }).passthrough().optional(),
     supported_disclosure_positions: z.array(DisclosurePositionSchema).optional(),
-    disclosure_capabilities: z.tuple([z.record(z.string(), z.unknown()).and(z.object({
+    disclosure_capabilities: z.tuple([z.object({
             position: DisclosurePositionSchema,
             persistence: z.array(DisclosurePersistenceSchema)
-        }).passthrough())]).rest(z.record(z.string(), z.unknown()).and(z.object({
+        }).passthrough()]).rest(z.object({
         position: DisclosurePositionSchema,
         persistence: z.array(DisclosurePersistenceSchema)
-    }).passthrough())).optional(),
-    format_card_detailed: z.record(z.string(), z.unknown()).and(z.object({
-        format_id: FormatReferenceStructuredObjectSchema,
-        manifest: z.record(z.string(), z.unknown())
     }).passthrough()).optional(),
+    format_card_detailed: z.object({
+        format_id: FormatReferenceStructuredObjectSchema,
+        manifest: z.object({}).passthrough()
+    }).passthrough().optional(),
     reported_metrics: z.array(AvailableMetricSchema).optional(),
     pricing_options: z.array(VendorPricingOptionSchema).optional(),
     canonical: CanonicalProjectionReferenceSchema.optional(),
@@ -13505,7 +13518,7 @@ export const OfferingSchema = z.object({
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
-export const InlineDeclarationSchema = z.object({
+export const InlineDeclarationSchema = z.object({}).passthrough().merge(z.object({
     format_option_id: z.string().optional(),
     publisher_domain: z.string().optional(),
     display_name: z.string().optional(),
@@ -13518,7 +13531,7 @@ export const InlineDeclarationSchema = z.object({
     format_shape: z.string().optional(),
     v1_format_ref: z.array(FormatReferenceStructuredObjectSchema).optional(),
     format_schema: PlatformExtensionReferenceSchema.optional()
-}).passthrough().and(z.union([ImageFormatDeclarationSchema, HTML5FormatDeclarationSchema, DisplayTagFormatDeclarationSchema, ImageCarouselFormatDeclarationSchema, HostedVideoFormatDeclarationSchema, VASTVideoFormatDeclarationSchema, HostedAudioFormatDeclarationSchema, DAASTAudioFormatDeclarationSchema, SponsoredPlacementFormatDeclarationSchema, NativeInFeedFormatDeclarationSchema, ResponsiveCreativeFormatDeclarationSchema, AgentPlacementFormatDeclarationSchema, CustomFormatDeclarationSchema]));
+}).passthrough()).and(z.union([ImageFormatDeclarationSchema, HTML5FormatDeclarationSchema, DisplayTagFormatDeclarationSchema, ImageCarouselFormatDeclarationSchema, HostedVideoFormatDeclarationSchema, VASTVideoFormatDeclarationSchema, HostedAudioFormatDeclarationSchema, DAASTAudioFormatDeclarationSchema, SponsoredPlacementFormatDeclarationSchema, NativeInFeedFormatDeclarationSchema, ResponsiveCreativeFormatDeclarationSchema, AgentPlacementFormatDeclarationSchema, CustomFormatDeclarationSchema]));
 
 export const ProductFiltersSchema = z.object({
     delivery_type: DeliveryTypeSchema.optional(),
@@ -13533,7 +13546,7 @@ export const ProductFiltersSchema = z.object({
     min_exposures: z.number().optional(),
     start_date: z.string().optional(),
     end_date: z.string().optional(),
-    budget_range: z.record(z.string(), z.unknown()).optional(),
+    budget_range: z.object({}).passthrough().optional(),
     countries: z.array(z.string()).optional(),
     regions: z.array(z.string()).optional(),
     metros: z.tuple([z.object({
@@ -13550,25 +13563,25 @@ export const ProductFiltersSchema = z.object({
     social_placement_surfaces: z.array(SocialPlacementSurfaceSchema).optional(),
     required_axe_integrations: z.array(z.string()).optional(),
     trusted_match: z.object({
-        providers: z.tuple([z.record(z.string(), z.unknown()).and(z.object({
+        providers: z.tuple([z.object({
                 agent_url: z.string(),
                 context_match: z.boolean().optional(),
                 identity_match: z.boolean().optional()
-            }).passthrough())]).rest(z.record(z.string(), z.unknown()).and(z.object({
+            }).passthrough()]).rest(z.object({
             agent_url: z.string(),
             context_match: z.boolean().optional(),
             identity_match: z.boolean().optional()
-        }).passthrough())).optional(),
+        }).passthrough()).optional(),
         response_types: z.array(TMPResponseTypeSchema).optional()
     }).passthrough().optional(),
     required_features: MediaBuyFeaturesSchema.optional(),
-    required_geo_targeting: z.tuple([z.record(z.string(), z.unknown())]).rest(z.record(z.string(), z.unknown())).optional(),
+    required_geo_targeting: z.array(z.object({}).passthrough().and(z.object({}).passthrough()).and(z.object({}).passthrough())).optional(),
     signal_targeting: z.array(SignalTargetingSchema).optional(),
     postal_areas: z.array(PostalAreaSchema).optional(),
-    geo_proximity: z.tuple([z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())])]).rest(z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())])).optional(),
+    geo_proximity: z.tuple([z.union([z.object({}).passthrough(), z.object({}).passthrough(), z.object({}).passthrough()])]).rest(z.union([z.object({}).passthrough(), z.object({}).passthrough(), z.object({}).passthrough()])).optional(),
     required_performance_standards: z.array(PerformanceStandardSchema).optional(),
     required_metrics: z.array(AvailableMetricSchema).optional(),
-    required_vendor_metrics: z.tuple([z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())])]).rest(z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())])).optional(),
+    required_vendor_metrics: z.tuple([z.union([z.object({}).passthrough(), z.object({}).passthrough()])]).rest(z.union([z.object({}).passthrough(), z.object({}).passthrough()])).optional(),
     keywords: z.tuple([z.object({
             keyword: z.string(),
             match_type: MatchTypeSchema.optional()
@@ -13625,7 +13638,7 @@ export const ProductOfferFiltersSchema = z.object({
         vendor: BrandKeySchema
     }).passthrough()).optional(),
     required_metrics: z.array(AvailableMetricSchema).optional(),
-    required_vendor_metrics: z.tuple([z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())])]).rest(z.union([z.record(z.string(), z.unknown()), z.record(z.string(), z.unknown())])).optional(),
+    required_vendor_metrics: z.tuple([z.union([z.object({}).passthrough(), z.object({}).passthrough()])]).rest(z.union([z.object({}).passthrough(), z.object({}).passthrough()])).optional(),
     audience_evidence_requirements: ProductAudienceEvidenceRequirementsSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -13845,7 +13858,7 @@ export const WholesaleSignalObjectSchema = z.object({
     pricing_options: z.array(VendorPricingOptionSchema).optional()
 }).passthrough();
 
-export const PackageControlSchema = z.object({
+export const PackageControlSchema = z.object({}).passthrough().merge(z.object({
     package_id: z.string(),
     budget: z.number().optional().nullable(),
     daily_budget_cap: z.number().optional().nullable(),
@@ -13863,7 +13876,7 @@ export const PackageControlSchema = z.object({
     negative_keywords_add: z.array(KeywordTargetSchema).optional(),
     negative_keywords_remove: z.array(KeywordTargetSchema).optional(),
     optimization_goals: z.array(CanonicalOptimizationGoalSchema).optional()
-}).passthrough();
+}).passthrough());
 
 export const ProductDiscoveryCriteriaSchema = z.object({
     product_ids: z.array(z.string()).optional(),
@@ -13872,7 +13885,7 @@ export const ProductDiscoveryCriteriaSchema = z.object({
     required_overlay_support: TargetingOverlayRequirementsSchema.optional(),
     catalog: CatalogSelectionSchema.optional(),
     policy_ids: z.array(z.string()).optional(),
-    ext: z.record(z.string(), z.unknown()).optional()
+    ext: z.object({}).passthrough().optional()
 }).passthrough();
 
 export const ProposalRefinementSchema = z.object({
@@ -13888,7 +13901,7 @@ export const ProposalRefinementSchema = z.object({
         impressions: z.object({
             min: z.number()
         }).passthrough().optional(),
-        flight: z.record(z.string(), z.unknown()).optional()
+        flight: z.object({}).passthrough().optional()
     }).passthrough().optional(),
     product_changes: ProductChangeMapSchema.optional(),
     alternatives: z.object({
@@ -13898,7 +13911,7 @@ export const ProposalRefinementSchema = z.object({
     criteria: ProductDiscoveryCriteriaSchema.optional()
 }).passthrough().and(z.union([z.object({
         action: z.literal("finalize")
-    }).passthrough(), z.union([z.record(z.string(), z.unknown()), z.object({
+    }).passthrough(), z.union([z.object({}).passthrough(), z.object({
             change_kind: z.literal("cancellation")
         }).passthrough()])]));
 
@@ -14132,7 +14145,7 @@ export const CanonicalProductSchema = z.object({
     product_id: z.string(),
     name: z.string(),
     description: z.string().optional(),
-    publisher_properties: z.tuple([PublisherPropertySelectorSchema]).rest(PublisherPropertySelectorSchema).optional(),
+    publisher_properties: z.array(PublisherPropertySelectorSchema.and(z.object({}).passthrough())).optional(),
     channels: z.array(MediaChannelSchema).optional(),
     video_placement_types: z.array(VideoPlacementTypeSchema).optional(),
     audio_distribution_types: z.array(AudioDistributionTypeSchema).optional(),
@@ -14171,7 +14184,7 @@ export const CommercialTermsSchema = z.object({
     source_pricing_version: z.string().optional(),
     brand: BrandKeySchema,
     advertiser_industry: AdvertiserIndustrySchema.optional(),
-    purchases: z.tuple([ProductPurchaseSchema]).rest(ProductPurchaseSchema),
+    purchases: z.array(ProductPurchaseSchema.merge(z.object({}).passthrough())),
     start_time: StartTimingSchema,
     end_time: z.string(),
     total_budget: z.object({
@@ -14301,7 +14314,7 @@ export const BuyProductsRequestSchema = z.object({
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
-export const CanonicalProposalSchema = z.object({
+export const CanonicalProposalSchema = z.object({}).passthrough().merge(z.object({
     proposal_id: z.string(),
     proposal_kind: z.union([z.literal("new_media_buy"), z.literal("media_buy_update"), z.literal("media_buy_cancellation")]),
     parent_proposal_id: z.string().optional(),
@@ -14317,7 +14330,7 @@ export const CanonicalProposalSchema = z.object({
     commercial_terms: CommercialTermsSchema,
     terms_digest: z.string(),
     insertion_order: InsertionOrderSchema.optional()
-}).passthrough();
+}).passthrough());
 
 export const ControlMediaBuyRequestSchema = z.object({
     adcp_version: z.string().optional(),
@@ -14372,12 +14385,12 @@ export const ListCreativeFormatsResponseSchema = z.object({
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
-export const PackageRequestSchema: z.ZodType = AdCPVersionEnvelopeSchema.merge(z.object({
+export const PackageRequestSchema: z.ZodType = AdCPVersionEnvelopeSchema.merge(z.object({}).passthrough()).merge(z.object({
     product_id: z.string(),
     format_ids: z.array(FormatReferenceStructuredObjectSchema).optional(),
     format_option_refs: z.array(FormatOptionReferenceSchema).optional(),
     format_kind: CanonicalFormatKindSchema.optional(),
-    params: z.record(z.string(), z.unknown()).optional(),
+    params: z.object({}).passthrough().optional(),
     budget: z.number().optional(),
     min_spend_target: z.number().optional(),
     pacing: PacingSchema.optional(),
@@ -14426,7 +14439,7 @@ export const PackageRequestSchema: z.ZodType = AdCPVersionEnvelopeSchema.merge(z
             metric_id: VendorMetricIDSchema
         }).passthrough()])).optional(),
     creative_assignments: z.array(CreativeAssignmentSchema).optional(),
-    creatives: z.tuple([CreativeAssetSchema]).rest(CreativeAssetSchema).optional(),
+    creatives: z.array(CreativeAssetSchema.and(z.object({}).passthrough())).optional(),
     agency_estimate_number: z.string().optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
@@ -14436,7 +14449,7 @@ export const ExplicitPackagesWithFixedAllocationSchema: z.ZodType = z.object({
     budget_allocation: z.object({
         mode: z.literal("fixed")
     }).passthrough().optional(),
-    packages: z.array(PackageRequestSchema)
+    packages: z.array(PackageRequestSchema.and(z.object({}).passthrough()))
 }).passthrough();
 
 export const CreateMediaBuySuccessSchema: z.ZodType = z.object({
@@ -14847,9 +14860,9 @@ export const BuildCreativeRequestSchema = z.object({
         currency: z.string().regex(/^[A-Z]{3}$/)
     }).passthrough().optional(),
     max_creatives: z.number().min(1).optional(),
-    signal_conditions: z.array(z.object({
+    signal_conditions: z.array(SignalTargetingSchema.and(z.object({
         signal_agent_segment_id: z.string().optional()
-    }).passthrough()).optional(),
+    }).passthrough())).optional(),
     max_variants: z.number().min(1).optional(),
     variant_axis: z.object({
         dimension: z.union([z.literal("voice"), z.literal("theme"), z.literal("best_of_n"), z.literal("transformer_config"), z.literal("custom")]),
@@ -14943,13 +14956,13 @@ export const CreativeLocalizationReadbackSchema: z.ZodType = z.object({
     default_locale_variant_id: z.string(),
     unmatched_locale_action: z.union([z.literal("serve_default"), z.literal("do_not_serve")]),
     locale_matching: z.literal("rfc4647_lookup"),
-    locale_fallbacks: z.tuple([z.record(z.string(), z.unknown()).and(z.object({
+    locale_fallbacks: z.tuple([z.object({
             language_range: LanguageTagSchema,
             locale_variant_id: z.string()
-        }).passthrough())]).rest(z.record(z.string(), z.unknown()).and(z.object({
+        }).passthrough()]).rest(z.object({
         language_range: LanguageTagSchema,
         locale_variant_id: z.string()
-    }).passthrough())).optional(),
+    }).passthrough()).optional(),
     variants: z.tuple([z.union([SourceLocalizationReadbackSchema, TargetLocalizationReadbackSchema])]).rest(z.union([SourceLocalizationReadbackSchema, TargetLocalizationReadbackSchema]))
 }).passthrough();
 
@@ -15179,7 +15192,7 @@ export const UpdateContentStandardsResponseSchema = z.object({
     adcp_major_version: z.number().optional()
 }).passthrough().and(z.union([UpdateContentStandardsSuccessSchema, UpdateContentStandardsErrorSchema]));
 
-export const CheckGovernanceRequestSchema = z.object({
+export const CheckGovernanceRequestSchema = z.object({}).passthrough().merge(z.object({
     adcp_version: z.string().optional(),
     adcp_major_version: z.number().optional(),
     plan_id: z.string().optional(),
@@ -15235,7 +15248,7 @@ export const CheckGovernanceRequestSchema = z.object({
     invoice_recipient: BusinessEntitySchema.optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
-}).passthrough();
+}).passthrough());
 
 export const GetAdCPCapabilitiesResponseSchema = z.object({
     context_id: z.string().optional(),
@@ -15640,7 +15653,7 @@ export const SyncAccountsSuccessSchema = z.object({
         status: z.union([z.literal("active"), z.literal("pending_approval"), z.literal("rejected"), z.literal("payment_required"), z.literal("suspended"), z.literal("closed")]),
         billing: BillingPartySchema.optional(),
         billing_entity: BusinessEntitySchema.optional(),
-        destination_billing_entity: z.record(z.string(), z.unknown()).optional(),
+        destination_billing_entity: z.object({}).passthrough().optional(),
         account_scope: AccountScopeSchema.optional(),
         setup: z.object({
             url: z.string().optional(),
@@ -15695,10 +15708,10 @@ export const GetAccountFinancialsResponseSchema = z.object({
     adcp_major_version: z.number().optional()
 }).passthrough().and(z.union([GetAccountFinancialsSuccessSchema, GetAccountFinancialsErrorSchema]));
 
-export const GetProductsCompletionSchema: z.ZodType = AdCPVersionEnvelopeSchema.merge(ProtocolEnvelopeSchema).merge(z.object({
+export const GetProductsCompletionSchema: z.ZodType = AdCPVersionEnvelopeSchema.merge(ProtocolEnvelopeSchema).merge(z.object({}).passthrough()).merge(z.object({
     products: z.array(ProductSchema).optional(),
     targeting_resolution: ProductDiscoveryTargetingResolutionSchema.optional(),
-    extensions: z.record(z.string(), z.unknown()).optional(),
+    extensions: z.object({}).passthrough().optional(),
     proposals: z.array(ProposalSchema).optional(),
     errors: z.array(ErrorSchema).optional(),
     reason: z.string().optional(),
@@ -15729,7 +15742,7 @@ export const GetProductsCompletionSchema: z.ZodType = AdCPVersionEnvelopeSchema.
         description: z.string(),
         estimated_wait: DurationSchema.optional()
     }).passthrough()).optional(),
-    filter_diagnostics: z.record(z.string(), z.unknown()).and(z.object({
+    filter_diagnostics: z.object({
         semantics: z.union([z.literal("only"), z.literal("any"), z.literal("approximate")]).optional(),
         total_candidates: z.number().optional(),
         excluded_by: z.record(z.string(), z.object({
@@ -15737,7 +15750,7 @@ export const GetProductsCompletionSchema: z.ZodType = AdCPVersionEnvelopeSchema.
                 values: z.array(z.union([z.string(), z.object({}).passthrough()])).optional(),
                 notes: z.string().optional()
             }).passthrough()).optional()
-    }).passthrough()).optional(),
+    }).passthrough().optional(),
     pagination: PaginationResponseSchema.optional(),
     wholesale_feed_version: z.string().optional(),
     pricing_version: z.string().optional(),
@@ -16041,7 +16054,7 @@ export const VerifyBrandClaimsResponseBulkSchema = z.object({
     adcp_major_version: z.number().optional()
 }).passthrough().and(z.union([VerifyBrandClaimsSuccessSchema, VerifyBrandClaimsErrorSchema]));
 
-export const PlacementDefinitionSchema = z.object({
+export const PlacementDefinitionSchema = z.object({}).passthrough().merge(z.object({
     placement_id: z.string(),
     name: z.string(),
     description: z.string().optional(),
@@ -16056,7 +16069,7 @@ export const PlacementDefinitionSchema = z.object({
     sponsored_placement_types: z.array(SponsoredPlacementTypeSchema).optional(),
     social_placement_surfaces: z.array(SocialPlacementSurfaceSchema).optional(),
     ext: ExtensionObjectSchema.optional()
-}).passthrough();
+}).passthrough());
 
 export const RegistryFeedResponseSchema = z.object({
     events: z.array(RegistryEventSchema),

--- a/src/lib/types/tools.generated.ts
+++ b/src/lib/types/tools.generated.ts
@@ -253,9 +253,7 @@ export type BrandID = string;
  * Declares how a field in an external feed maps to the AdCP catalog item schema. Used in sync_catalogs feed_field_mappings to normalize non-AdCP feeds (Google Merchant Center, LinkedIn Jobs XML, hotel XML, etc.) to the standard catalog item schema without requiring the buyer to preprocess every feed. Multiple mappings can assemble a nested object via dot notation (e.g., separate mappings for price.amount and price.currency).
  */
 export type CatalogFieldMapping = {
-  [k: string]: unknown | undefined;
 } & {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Field name in the external feed record. Omit when injecting a static literal value (use the value property instead).
@@ -273,7 +271,6 @@ export type CatalogFieldMapping = {
    * Static literal value to inject into catalog_field for every item, regardless of what the feed contains. Mutually exclusive with feed_field. Useful for fields the feed omits (e.g., currency when price is always USD, or a constant category value).
    */
   value?: {
-    [k: string]: unknown | undefined;
   };
   /**
    * Named transform to apply to the feed field value before writing to the catalog schema. See transform-specific parameters (format, timezone, by, separator).
@@ -299,10 +296,8 @@ export type CatalogFieldMapping = {
    * Fallback value to use when feed_field is absent, null, or empty. Applied after any transform would have been applied. Allows optional feed fields to have a guaranteed baseline value.
    */
   default?: {
-    [k: string]: unknown | undefined;
   };
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Field name in the external feed record. Omit when injecting a static literal value (use the value property instead).
@@ -320,7 +315,6 @@ export type CatalogFieldMapping = {
    * Static literal value to inject into catalog_field for every item, regardless of what the feed contains. Mutually exclusive with feed_field. Useful for fields the feed omits (e.g., currency when price is always USD, or a constant category value).
    */
   value?: {
-    [k: string]: unknown | undefined;
   };
   /**
    * Named transform to apply to the feed field value before writing to the catalog schema. See transform-specific parameters (format, timezone, by, separator).
@@ -346,10 +340,8 @@ export type CatalogFieldMapping = {
    * Fallback value to use when feed_field is absent, null, or empty. Applied after any transform would have been applied. Allows optional feed fields to have a guaranteed baseline value.
    */
   default?: {
-    [k: string]: unknown | undefined;
   };
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 };
 /**
  * Discriminator value naming one of the 12 canonical creative formats — plus `custom` for adopter-defined shapes that don't fit the canonicals (multi-placement takeover, roadblock, branded content, cross-screen sponsorship, AR lens, etc.). Used by `product-format-declaration.json` (the product's inline format declaration), `creative-manifest.json` (the buyer's v2 manifest path), and any other surface that needs to identify which canonical a payload targets.
@@ -382,7 +374,6 @@ export type FormatOptionReference = PublisherCatalogFormatOptionReference | Prod
  * Policies supported when budget allocation is fixed or omitted.
  */
 export type PolicyProfile = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Standalone policy modes accepted in this exact scope and allocation context. Combination-only components belong only in supported_combinations and need not appear here. `automatic` means the seller accepts and preserves an explicit `{automatic:true}` authored block; omission only invokes inheritance/default behavior.
@@ -418,26 +409,20 @@ export type PolicyProfile = {
 export type SignalTargeting =
   | (
       | {
-          [k: string]: unknown | undefined;
         }
       | {
-          [k: string]: unknown | undefined;
         }
     )
   | (
       | {
-          [k: string]: unknown | undefined;
         }
       | {
-          [k: string]: unknown | undefined;
         }
     )
   | (
       | {
-          [k: string]: unknown | undefined;
         }
       | {
-          [k: string]: unknown | undefined;
         }
     );
 /**
@@ -449,7 +434,6 @@ export type PostalArea1 = PostalCountrySystem;
  * Buyer policy for evaluating Product.audience_evidence. In required mode, sellers MUST apply the evidence_presence and admissibility semantics and exclude non-matching products; they MUST NOT ignore an unsupported hard requirement. In preferred mode, sellers use matches for ranking and explain the evidence selected. Buyers SHOULD inspect media_buy.audience_evidence capabilities before sending this object.
  */
 export type AudienceEvidenceRequirements = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * required excludes products whose published evidence violates the constraints; preferred only affects ranking and explanation. When this policy affects inclusion or ranking, the seller MUST return the exact matching audience_evidence_selections even if get_products.fields omitted that field.
@@ -535,7 +519,6 @@ export type AttestationIssuer = AttestationBrandIssuer | AttestationAgentIssuer 
  * Concrete delivery constraints the buyer expects to carry into create_media_buy. Buyers SHOULD use this field instead of putting equivalent exact targeting only in brief prose. Sellers evaluate these constraints during discovery and scope returned pricing and forecasts to the effective targeting. If a product cannot honor the request exactly, the seller may omit it or return a request-scoped configured product with Product targeting_resolution modifications. Absence of Product targeting_resolution means exact acceptance of this structured overlay; it does not confirm how targeting in the brief was interpreted. On refine, presence is complete replacement state for returned configurations; when omitted, each referenced product's bound targeting remains in force.
  */
 export type TargetingOverlay = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Restrict delivery to specific countries. ISO 3166-1 alpha-2 codes (e.g., 'US', 'GB', 'DE').
@@ -756,7 +739,6 @@ export type TargetingOverlay = {
        * @minItems 1
        */
       catchment_ids?: [string, ...string[]];
-      [k: string]: unknown | undefined;
     },
     ...{
       /**
@@ -775,7 +757,6 @@ export type TargetingOverlay = {
        * @minItems 1
        */
       catchment_ids?: [string, ...string[]];
-      [k: string]: unknown | undefined;
     }[]
   ];
   /**
@@ -786,24 +767,18 @@ export type TargetingOverlay = {
   geo_proximity?: [
     (
       | {
-          [k: string]: unknown | undefined;
         }
       | {
-          [k: string]: unknown | undefined;
         }
       | {
-          [k: string]: unknown | undefined;
         }
     ),
     ...(
       | {
-          [k: string]: unknown | undefined;
         }
       | {
-          [k: string]: unknown | undefined;
         }
       | {
-          [k: string]: unknown | undefined;
         }
     )[]
   ];
@@ -863,13 +838,11 @@ export type TargetingOverlay = {
       match_type: MatchType;
     }[]
   ];
-  [k: string]: unknown | undefined;
 };
 /**
  * A catalog-backed named place target. Values are stable identifiers in the declared system. Entries within geo_places form a union; different geographic inclusion dimensions intersect. value_labels are diagnostic only and MUST NOT be used to resolve targeting.
  */
 export type GeographicPlaceArea = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * ISO 3166-1 alpha-2 country code containing the place.
@@ -959,7 +932,6 @@ export type PackageSignalTargeting = SignalTargetingExpression & {
    */
   signal_agent_segment_id?: string;
   activation_key?: ActivationKey;
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Pricing option selected for this signal. Use the pricing_option_id from the product's signal_targeting_options entry when product-scoped pricing is present; otherwise use the seller get_signals pricing only when the product option does not override it. Required when the selected signal has pricing_options; omit only when the signal is bundled into the product price or has no incremental cost.
@@ -970,7 +942,6 @@ export type PackageSignalTargeting = SignalTargetingExpression & {
    */
   signal_agent_segment_id?: string;
   activation_key?: ActivationKey;
-  [k: string]: unknown | undefined;
 };
 /**
  * Named signal being targeted.
@@ -985,7 +956,6 @@ export type SignalRef =
        * Product-local signal identifier. For local signals exposed on both get_signals and get_products, this MUST match get_signals.signals[].signal_ref.signal_id for the same signal.
        */
       signal_id: string;
-      [k: string]: unknown | undefined;
     }
   | {
       /**
@@ -1000,7 +970,6 @@ export type SignalRef =
        * Signal identifier within the data provider's published adagents.json signals[].
        */
       signal_id: string;
-      [k: string]: unknown | undefined;
     }
   | {
       /**
@@ -1015,7 +984,6 @@ export type SignalRef =
        * Signal identifier within the issuing signal source's signal set.
        */
       signal_id: string;
-      [k: string]: unknown | undefined;
     };
 /**
  * Destination-specific activation key returned by get_signals or activate_signal. Usually omitted for seller-offered signals selected directly through the same seller; include only when the selected signal was separately activated and the seller requires the activation key to correlate the package selection.
@@ -1030,7 +998,6 @@ export type ActivationKey =
        * The platform-specific segment identifier to use in campaign targeting
        */
       segment_id: string;
-      [k: string]: unknown | undefined;
     }
   | {
       /**
@@ -1045,13 +1012,11 @@ export type ActivationKey =
        * The targeting parameter value
        */
       value: string;
-      [k: string]: unknown | undefined;
     };
 /**
  * A canonical audience-age predicate in completed integer years. min and max are inclusive; omitting one bound means no restriction in that direction. At least one bound is required. include_unknown is always explicit because people whose age is unavailable are not members of any numeric interval. Implementations MUST reject min greater than max; JSON Schema draft-07 cannot compare sibling numeric values.
  */
 export type DemographicAgeRange = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Inclusive minimum age in completed years. Omit for an open lower bound.
@@ -1065,13 +1030,11 @@ export type DemographicAgeRange = {
    * Whether delivery to people whose age is unavailable is part of this predicate. This field has no default and MUST be supplied.
    */
   include_unknown: boolean;
-  [k: string]: unknown | undefined;
 };
 /**
  * Frequency capping settings for package-level application. Two types of frequency control can be used independently or together: suppress enforces a cooldown between consecutive exposures; max_impressions + per + window caps total exposures per entity in a time window. When both suppress and max_impressions are set, an impression is delivered only if both constraints permit it (AND semantics). At least one of suppress, suppress_minutes, or max_impressions must be set.
  */
 export type FrequencyCap = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Cooldown period between consecutive exposures to the same entity. Prevents back-to-back ad delivery (e.g. {"interval": 60, "unit": "minutes"} for a 1-hour cooldown). Preferred over suppress_minutes.
@@ -1094,7 +1057,6 @@ export type FrequencyCap = {
    * Time window for the max_impressions cap (e.g. {"interval": 7, "unit": "days"} or {"interval": 1, "unit": "campaign"} for the full flight). Required when max_impressions is set.
    */
   window?: Duration;
-  [k: string]: unknown | undefined;
 };
 /**
  * Purchased placement selection within the product. This constrains package inventory; it is distinct from creative_assignments[].placement_refs, which only route individual creatives within the purchased set. On create, mode selected supplies the complete selected set and mode default uses the product default. On update, the surrounding targeting_overlay replacement semantics apply.
@@ -1356,7 +1318,6 @@ export interface Catalog {
    * @minItems 1
    */
   feed_field_mappings?: [CatalogFieldMapping, ...CatalogFieldMapping[]];
-  [k: string]: unknown | undefined;
 }
 /**
  * Optional operator-owned business unit, agency seat, or platform account. Only id participates in the natural account key; name is mutable display metadata.
@@ -1432,7 +1393,6 @@ export interface ProductFilters {
    * Budget range to filter appropriate products
    */
   budget_range?: {
-    [k: string]: unknown | undefined;
   };
   /**
    * @deprecated
@@ -1530,7 +1490,6 @@ export interface ProductFilters {
          * When true, require this provider to support identity match.
          */
         identity_match?: boolean;
-        [k: string]: unknown | undefined;
       },
       ...{
         /**
@@ -1545,7 +1504,6 @@ export interface ProductFilters {
          * When true, require this provider to support identity match.
          */
         identity_match?: boolean;
-        [k: string]: unknown | undefined;
       }[]
     ];
     /**
@@ -1564,18 +1522,12 @@ export interface ProductFilters {
    */
   required_geo_targeting?: [
     {
-      [k: string]: unknown | undefined;
     } & {
-      [k: string]: unknown | undefined;
     } & {
-      [k: string]: unknown | undefined;
     },
     ...({
-      [k: string]: unknown | undefined;
     } & {
-      [k: string]: unknown | undefined;
     } & {
-      [k: string]: unknown | undefined;
     })[]
   ];
   /**
@@ -1601,24 +1553,18 @@ export interface ProductFilters {
   geo_proximity?: [
     (
       | {
-          [k: string]: unknown | undefined;
         }
       | {
-          [k: string]: unknown | undefined;
         }
       | {
-          [k: string]: unknown | undefined;
         }
     ),
     ...(
       | {
-          [k: string]: unknown | undefined;
         }
       | {
-          [k: string]: unknown | undefined;
         }
       | {
-          [k: string]: unknown | undefined;
         }
     )[]
   ];
@@ -1642,18 +1588,14 @@ export interface ProductFilters {
   required_vendor_metrics?: [
     (
       | {
-          [k: string]: unknown | undefined;
         }
       | {
-          [k: string]: unknown | undefined;
         }
     ),
     ...(
       | {
-          [k: string]: unknown | undefined;
         }
       | {
-          [k: string]: unknown | undefined;
         }
     )[]
   ];
@@ -1681,7 +1623,6 @@ export interface ProductFilters {
   ];
   audience_evidence_requirements?: AudienceEvidenceRequirements;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Selects a publisher-catalog-backed product format option by publisher domain and format option ID.
@@ -1699,7 +1640,6 @@ export interface PublisherCatalogFormatOptionReference {
    * Stable format option ID from the publisher's adagents.json top-level `formats[]`, matching a publisher-catalog-backed entry in the target product's `format_options[]`.
    */
   format_option_id: string;
-  [k: string]: unknown | undefined;
 }
 /**
  * Selects a product-local format option by ID within the enclosing package/product context. This branch deliberately forbids `publisher_domain` (`publisher_domain: false` in the schema) because product-local references are namespaced by the enclosing product only; include `scope: "publisher"` when the selector must cross into a publisher catalog.
@@ -1714,7 +1654,6 @@ export interface ProductLocalFormatOptionReference {
    */
   format_option_id: string;
   publisher_domain?: never;
-  [k: string]: unknown | undefined;
 }
 /**
  * Filter to products from sellers supporting specific protocol features. Only features set to true are used for filtering.
@@ -1806,7 +1745,6 @@ export interface PerformanceStandard {
   threshold: number;
   standard?: ViewabilityStandard;
   vendor: BrandReference;
-  [k: string]: unknown | undefined;
 }
 /**
  * A time duration expressed as an interval and unit. Used for frequency cap windows, attribution windows, reach optimization windows, time budgets, and other time-based settings. When unit is 'campaign', interval must be 1 — the window spans the full campaign flight.
@@ -1888,7 +1826,6 @@ export interface PackageSignalTargetingGroups {
    * @minItems 1
    */
   groups: [PackageSignalTargetingGroup, ...PackageSignalTargetingGroup[]];
-  [k: string]: unknown | undefined;
 }
 /**
  * A basic Boolean group of package-level signal targeting entries. 'any' means the user must match at least one signal in the group. 'none' means the user must match none of the signals in the group. Use groups for portable include/exclude composition such as (A OR B) AND NOT (C OR D).
@@ -1904,16 +1841,13 @@ export interface PackageSignalTargetingGroup {
    * @minItems 1
    */
   signals: [PackageSignalTargeting, ...PackageSignalTargeting[]];
-  [k: string]: unknown | undefined;
 }
 /**
  * Canonical demographic audience targeting intent with optional constraints on how age may be determined. This is distinct from age_restriction: demographics selects an audience, while age_restriction expresses a legal eligibility or verification floor. Fresh create/update targeting MUST compile exactly or be rejected. During get_products, a seller may offer a different configured predicate only through sparse targeting_resolution modifications on a distinguishable product_id; selecting that product accepts the alternative. Sellers never silently broaden, narrow, default, drop, or substitute the basis.
  */
 export interface DemographicTargetingIntent {
   age: DemographicAgeRange & {
-    [k: string]: unknown | undefined;
   };
-  [k: string]: unknown | undefined;
 }
 /**
  * Reference to a property list for targeting specific properties within this product. The package runs on the intersection of the product's publisher_properties and this list. Sellers SHOULD return a validation error if the product has property_targeting_allowed: false.
@@ -1958,10 +1892,8 @@ export interface SelectedPlacements {
    */
   placement_refs: [
     PlacementReference & {
-      [k: string]: unknown | undefined;
     },
     ...(PlacementReference & {
-      [k: string]: unknown | undefined;
     })[]
   ];
   ext?: ExtensionObject;
@@ -1978,7 +1910,6 @@ export interface PlacementReference {
    * Placement ID from the publisher's adagents.json placement catalog, or an inline seller-defined placement ID interpreted within the same publisher namespace.
    */
   placement_id: string;
-  [k: string]: unknown | undefined;
 }
 export interface ProductDefaultPlacements {
   mode: 'default';
@@ -2185,7 +2116,6 @@ export interface PaginationRequest {
  * Opaque correlation data that is echoed unchanged in responses. Used for internal tracking, UI session IDs, trace IDs, and other caller-specific identifiers that don't affect protocol behavior. Context data is never parsed by AdCP agents - it's simply preserved and returned.
  */
 export interface ContextObject {
-  [k: string]: unknown | undefined;
 }
 
 
@@ -2194,7 +2124,6 @@ export interface ContextObject {
  * Represents available advertising inventory
  */
 export type Product = {
-  [k: string]: unknown | undefined;
 } & (NamedFormatProduct | CanonicalFormatProduct) & {
     /**
      * Opaque identifier for this buyable product. For a non-custom wholesale product, sellers MUST reuse the ID for the same logical catalog offer within the seller and declared cache_scope across reads and wholesale-feed webhooks; feed and pricing versions communicate temporal catalog mutation, while retirement or replacement may end the identity. Concurrent or request-bound configurations whose effective targeting, disclosed targeting modifications, forecast assumptions, terms, or overlay support differ MUST use distinguishable configured product IDs. For is_custom: true, the ID identifies only the request-specific discovery/refinement lineage and is not stable across independent contexts. Sellers MUST keep every issued configured ID resolvable for its promised lifetime. Pricing variants within one logical product are distinguished by pricing_option_id: a seller MUST mint a new pricing_option_id whenever a binding fixed price, floor, currency, model, or priced applicability changes, and MUST NOT reinterpret an issued option ID at a new price. Selecting product_id plus pricing_option_id in create_media_buy accepts that returned configuration and commercial option.
@@ -2215,10 +2144,8 @@ export type Product = {
      */
     publisher_properties: [
       PublisherPropertySelector & {
-        [k: string]: unknown | undefined;
       },
       ...(PublisherPropertySelector & {
-        [k: string]: unknown | undefined;
       })[]
     ];
     /**
@@ -2420,7 +2347,6 @@ export type Product = {
        * Target kinds available for metric goals on this product. Values match target.kind on the optimization goal. Only these target kinds are accepted — goals with unlisted target kinds will be rejected. When omitted, buyers can set target-less metric goals (maximize volume within budget) but cannot set specific targets.
        */
       supported_targets?: ('cost_per' | 'threshold_rate')[];
-      [k: string]: unknown | undefined;
     };
     vendor_metric_optimization?: VendorMetricOptimization;
     /**
@@ -2451,7 +2377,6 @@ export type Product = {
        * Whether the seller provides its own always-on measurement (e.g. Amazon sales attribution for Amazon advertisers). When true, sync_event_sources response will include seller-managed event sources with managed_by='seller'.
        */
       platform_managed?: boolean;
-      [k: string]: unknown | undefined;
     };
     /**
      * When the buyer provides a catalog on get_products, indicates which catalog items are eligible for this product. Only present for products where catalog matching is relevant (e.g., sponsored product listings, job boards, hotel ads).
@@ -2503,7 +2428,6 @@ export type Product = {
        * Call-to-action button label (e.g., 'View details', 'Get proposal').
        */
       cta_label?: string;
-      [k: string]: unknown | undefined;
     };
     /**
      * Optional detailed card with hero + carousel + structured specifications, for rich product presentation (media-kit-style pages, full product detail views). Distinct from `format` — describes the UI rendering of the product itself, not the ad creative the product accepts. Typed inline; no format_id indirection.
@@ -2528,7 +2452,6 @@ export type Product = {
       specifications?: {
         label: string;
         value: string;
-        [k: string]: unknown | undefined;
       }[];
       /**
        * Formatted price or pricing summary.
@@ -2542,7 +2465,6 @@ export type Product = {
        * Typed seller collateral for buyer planning — coverage maps, sample renders, environment photos, media kits. Distinct from hero_image/carousel_images, which are display-oriented.
        */
       reference_assets?: ProductCardReferenceAsset[];
-      [k: string]: unknown | undefined;
     };
     /**
      * Collections available in this product. Each entry references collections declared in an adagents.json by domain and collection ID. Buyers resolve full collection objects from the referenced adagents.json.
@@ -2615,7 +2537,6 @@ export type Product = {
            * @minItems 1
            */
           uid_types?: [UIDType, ...UIDType[]];
-          [k: string]: unknown | undefined;
         },
         ...{
           /**
@@ -2642,10 +2563,8 @@ export type Product = {
            * @minItems 1
            */
           uid_types?: [UIDType, ...UIDType[]];
-          [k: string]: unknown | undefined;
         }[]
       ];
-      [k: string]: unknown | undefined;
     };
     /**
      * Instructions for submitting physical creative materials (print, static OOH, cinema). Present only for products requiring physical delivery outside the digital creative assignment flow. Buyer agents MUST validate url and email domains against the seller's known domains (from adagents.json) before submitting materials. Never auto-submit without human confirmation.
@@ -2664,10 +2583,8 @@ export type Product = {
        */
       instructions?: string;
       ext?: ExtensionObject;
-      [k: string]: unknown | undefined;
     };
     ext?: ExtensionObject;
-    [k: string]: unknown | undefined;
   };
 /**
  * Identifier for a publisher property. Must be lowercase alphanumeric with underscores only.
@@ -2683,15 +2600,10 @@ export type PropertyID = string;
  * **Custom format_kind** (`format_kind: "custom"`): for adopter-defined shapes that don't fit the 12 canonicals (multi-placement takeover, roadblock, branded content, cross-screen sponsorship, sponsorship lockup, newsletter sponsorship, AR lens, playable, live event sponsorship). When `format_kind` is `custom`, the declaration MUST carry `format_shape` (recognized global pattern from the [format-shape vocabulary registry](/schemas/core/format-shape-vocabulary.json)) AND `format_schema` (URI+digest reference to a fetchable schema describing the actual `params` and `slots`). Buyer agents fetch the schema, validate manifests structurally, and reason about manifests without per-seller integration code. See [adcp#3666](https://github.com/adcontextprotocol/adcp/issues/3666) for the canonical promotion queue.
  */
 export type ProductFormatDeclaration = {
-  [k: string]: unknown | undefined;
 } & {
-  [k: string]: unknown | undefined;
 } & {
-  [k: string]: unknown | undefined;
 } & {
-  [k: string]: unknown | undefined;
 } & {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Stable identifier for this declaration within its namespace. REQUIRED when a product contains multiple declarations with the same format_kind and SHOULD be set on every entry. Publisher-backed options pair it with publisher_domain; product-local options omit publisher_domain. When a single declaration has a unique format_kind and no ID, buyers author canonically with format_kind plus params; they MUST NOT fall back to deprecated format_ids merely because this optional ID is absent. Examples: 'display_image_300x250', 'responsive_search', 'daily_pulse_homepage_image'.
@@ -3013,7 +2925,6 @@ export type ProductFormatDeclaration = {
  * A seller/platform-side connection or grant required by a product, format, or request. This is not the AdCP caller credential: the AdCP request is still authenticated once, and the seller uses these stored downstream connections to call a platform or service on the buyer's behalf. Use this shape for platforms that require more than one downstream grant, such as an advertiser account connection plus a publisher identity or post authorization for published-post references.
  */
 export type DownstreamConnectionRequirement = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Stable provider or platform namespace, preferably lowercase. Examples: `social.example`, `shortvideo.example`, or a seller-defined namespace. Omit only when the requirement is provider-agnostic, or when an `authorization_url` fully routes the human to the correct provider-specific connection flow.
@@ -3067,7 +2978,6 @@ export type DownstreamConnectionRequirement = {
      * Public URL for the referenced post, when available.
      */
     post_url?: string;
-    [k: string]: unknown | undefined;
   };
   /**
    * Seller-hosted or provider-hosted URL where a human can complete or restore this downstream connection.
@@ -3081,23 +2991,17 @@ export type DownstreamConnectionRequirement = {
    * Expiration time for the downstream grant, when known.
    */
   expires_at?: string;
-  [k: string]: unknown | undefined;
 };
 /**
  * Represents a specific public ad placement within a product's inventory. Placement IDs are scoped by publisher domain, matching placement definitions in that publisher's adagents.json. `kind` is the structural discriminator: `publisher_ref` means this product placement is a reference to `{publisher_domain, placement_id}`; `seller_inline` means the seller is defining public buyer-facing placement metadata inline. The schema accepts either `name` or `publisher_domain` because publisher-referenced placements can omit `name` only when the publisher declaration supplies it; seller-inline placements carry `name` directly. Whether a reference was resolved from publisher-hosted adagents.json or a community-maintained fallback is resolver metadata, not placement structure. Placement selection purchases inventory; creative assignments may then route creatives only within the purchased set. Reusing a registered placement preserves the registry's semantic identity; product-level placement objects may narrow format_ids/format_options or add operational detail, but SHOULD NOT redefine the placement's meaning incompatibly.
  */
 export type Placement = {
-  [k: string]: unknown | undefined;
 } & {
-  [k: string]: unknown | undefined;
 } & {
-  [k: string]: unknown | undefined;
 } & (
     | {
-        [k: string]: unknown | undefined;
       }
     | {
-        [k: string]: unknown | undefined;
       }
   ) & {
     /**
@@ -3165,13 +3069,10 @@ export type Placement = {
      * @minItems 1
      */
     social_placement_surfaces?: [SocialPlacementSurface, ...SocialPlacementSurface[]];
-    [k: string]: unknown | undefined;
   } & (
     | {
-        [k: string]: unknown | undefined;
       }
     | {
-        [k: string]: unknown | undefined;
       }
   ) & {
     /**
@@ -3239,7 +3140,6 @@ export type Placement = {
      * @minItems 1
      */
     social_placement_surfaces?: [SocialPlacementSurface, ...SocialPlacementSurface[]];
-    [k: string]: unknown | undefined;
   };
 /**
  * A seller's commercial pricing offer, discriminated by pricing_model. pricing_option_id is the immutable identity of its binding commercial terms: changing fixed price, floor, currency, model, or priced applicability requires a new ID rather than reinterpreting the old one. fixed_price is an agreed seller price; floor_price is the seller minimum for an auction-priced option; price_guidance is non-binding discovery guidance. Buyer execution instructions belong in BiddingPolicy. revenue_share is contingent pricing: its payable spend is calculated from settled commissionable_value and does not use fixed_price or auction bidding fields. The legacy max_bid boolean and package bid_price are deprecated in 3.2 and removed in the next major.
@@ -3259,9 +3159,7 @@ export type PricingOption =
  * Revenue-share pricing. The advertiser pays a fixed decimal commission rate applied to settled commissionable_value attributed to the declared conversion event and event source. Spend is rounded once to the ISO 4217 minor-unit precision of currency after multiplication: spend = round_currency(commissionable_value × commission_rate). This is contingent pricing, not fixed-unit pricing or an auction.
  */
 export type RevenueSharePricingOption = {
-  [k: string]: unknown | undefined;
 } & {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Unique identifier for this pricing option within the product
@@ -3295,7 +3193,6 @@ export type RevenueSharePricingOption = {
    * Human-readable definition of inclusions, exclusions, and return or cancellation treatment used by the billing authority to calculate commissionable_value.
    */
   commission_basis_description: string;
-  [k: string]: unknown | undefined;
 };
 /**
  * Dimension constraints represented by this forecast point, such as country, region, placement, device type, platform, audience, signal value, or intersections such as placement x country or product x signal. Each item declares one dimension family; when multiple items are present, the point represents their intersection. Sellers MUST NOT emit more than one item for each `kind` on a point; consumers MUST NOT treat repeated kinds as OR semantics. Use multiple points with dimensions to expose country/placement/signal availability within one product, proposal, or signal coverage forecast without creating separate products solely for each dimension. Dimensions describe the forecast row and are independent of pricing_options.
@@ -3324,13 +3221,9 @@ export type ForecastPointDimensions = [
  * A geographic dimension for a ForecastPoint row. Variant of ForecastPoint dimensions; see forecast-point-dimensions.json for dispatch rules.
  */
 export type GeoForecastDimension = {
-  [k: string]: unknown | undefined;
 } & {
-  [k: string]: unknown | undefined;
 } & {
-  [k: string]: unknown | undefined;
 } & {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Dimension family discriminator.
@@ -3358,15 +3251,11 @@ export type GeoForecastDimension = {
  * A signal value or signal-presence dimension for a ForecastPoint row. Variant of ForecastPoint dimensions; see forecast-point-dimensions.json for dispatch rules.
  */
 export type SignalForecastDimension = {
-  [k: string]: unknown | undefined;
 } & {
-  [k: string]: unknown | undefined;
 } & (
     | {
-        [k: string]: unknown | undefined;
       }
     | {
-        [k: string]: unknown | undefined;
       }
   ) & {
     /**
@@ -3405,20 +3294,17 @@ export interface ForecastRange {
   mid?: number;
   /** Optimistic (high-end) forecast value. */
   high?: number;
-  [k: string]: unknown | undefined;
 }
 export type VendorMetricID = string;
 /**
  * Product-scoped demographic breakdown support for by_demographic reporting. Declares reportable age ranges and measurement systems independently from demographic targeting execution.
  */
 export type DemographicReportingCapability = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Machine-comparable age ranges this product can report.
    */
   age?: {
-    [k: string]: unknown | undefined;
   };
   /**
    * Measurement-system notations this product may return. A code remains opaque unless its capability interval and response row also carry a canonical age predicate.
@@ -3444,7 +3330,6 @@ export type DataProviderSignalSelector =
        * Discriminator indicating all signals from this data provider are included
        */
       selection_type: 'all';
-      [k: string]: unknown | undefined;
     }
   | {
       /**
@@ -3461,7 +3346,6 @@ export type DataProviderSignalSelector =
        * @minItems 1
        */
       signal_ids: [string, ...string[]];
-      [k: string]: unknown | undefined;
     }
   | {
       /**
@@ -3478,21 +3362,16 @@ export type DataProviderSignalSelector =
        * @minItems 1
        */
       signal_tags: [string, ...string[]];
-      [k: string]: unknown | undefined;
     };
 /**
  * Shared signal identity and definition metadata used when a signal is listed outside its authoritative definition. New listings carry signal_ref; legacy listings may carry deprecated signal_id during the SignalRef migration window. Product-local signals use the listing as the definition boundary and MUST include name and value_type. Data-provider and signal-source refs MAY omit definition metadata when the buyer can resolve it from the referenced provider-published definition or source; any supplied name, description, value_type, categories, range, methodology_url, or last_updated is product/account/source context and does not replace the authoritative definition.
  */
 export type SignalListing = {
-  [k: string]: unknown | undefined;
 } & {
-  [k: string]: unknown | undefined;
 } & (
     | {
-        [k: string]: unknown | undefined;
       }
     | {
-        [k: string]: unknown | undefined;
       }
   ) & {
     signal_ref?: SignalRef;
@@ -3540,13 +3419,10 @@ export type SignalListing = {
      */
     restricted_attributes?: [RestrictedAttribute, ...RestrictedAttribute[]];
     demographic_predicate?: DemographicPredicate;
-    [k: string]: unknown | undefined;
   } & (
     | {
-        [k: string]: unknown | undefined;
       }
     | {
-        [k: string]: unknown | undefined;
       }
   ) & {
     signal_ref?: SignalRef;
@@ -3594,13 +3470,10 @@ export type SignalListing = {
      */
     restricted_attributes?: [RestrictedAttribute, ...RestrictedAttribute[]];
     demographic_predicate?: DemographicPredicate;
-    [k: string]: unknown | undefined;
   } & (
     | {
-        [k: string]: unknown | undefined;
       }
     | {
-        [k: string]: unknown | undefined;
       }
   ) & {
     signal_ref?: SignalRef;
@@ -3648,7 +3521,6 @@ export type SignalListing = {
      */
     restricted_attributes?: [RestrictedAttribute, ...RestrictedAttribute[]];
     demographic_predicate?: DemographicPredicate;
-    [k: string]: unknown | undefined;
   };
 /**
  * DEPRECATED. Use signal_ref instead. Legacy SignalId retained for compatibility with older Signals Protocol clients.
@@ -3667,7 +3539,6 @@ export type SignalID =
        * Signal identifier within the data provider's catalog (e.g., 'likely_ev_buyers', 'income_100k_plus')
        */
       id: string;
-      [k: string]: unknown | undefined;
     }
   | {
       /**
@@ -3682,13 +3553,11 @@ export type SignalID =
        * Signal identifier within the agent's signal set (e.g., 'custom_auto_intenders')
        */
       id: string;
-      [k: string]: unknown | undefined;
     };
 /**
  * A signal the seller makes available inline for package-level signal composition on this product. Product.signal_targeting_options is used when the product needs product-scoped pricing, activation handles, defaults, grouping hints, a brief/refine-selected subset, or a curated inline menu. Wholesale products can instead omit inline options when the selectable menu is the broader get_signals feed. Product-local signals define their name and value_type inline through the shared signal-listing fields; data-provider and signal-source refs may omit those definition fields when the referenced definition or source is authoritative.
  */
 export type ProductSignalTargetingOption = SignalListing & {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Optional opaque resolved-segment or seller execution handle for this signal. Omit when signal_ref plus the value expression is sufficient for the seller to resolve the signal. Include when the seller exposes a distinct runtime or activation handle that buyers must echo in packages[].targeting_overlay.signal_targeting_groups.groups[].signals[].signal_agent_segment_id. Buyers SHOULD echo this handle verbatim rather than reconstructing identity from categorical values; providers MAY namespace handles so cross-provider identity stays legible without a shared taxonomy registry.
@@ -3718,7 +3587,6 @@ export type ProductSignalTargetingOption = SignalListing & {
    * @minItems 1
    */
   pricing_options?: [VendorPricingOption, ...VendorPricingOption[]];
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Optional opaque resolved-segment or seller execution handle for this signal. Omit when signal_ref plus the value expression is sufficient for the seller to resolve the signal. Include when the seller exposes a distinct runtime or activation handle that buyers must echo in packages[].targeting_overlay.signal_targeting_groups.groups[].signals[].signal_agent_segment_id. Buyers SHOULD echo this handle verbatim rather than reconstructing identity from categorical values; providers MAY namespace handles so cross-provider identity stays legible without a shared taxonomy registry.
@@ -3748,7 +3616,6 @@ export type ProductSignalTargetingOption = SignalListing & {
    * @minItems 1
    */
   pricing_options?: [VendorPricingOption, ...VendorPricingOption[]];
-  [k: string]: unknown | undefined;
 };
 /**
  * A pricing option offered by a vendor agent (signals, creative, governance). Combines pricing_option_id with the pricing model fields. Pass pricing_option_id in report_usage for billing verification. All vendor discovery responses return pricing_options as an array — vendors may offer multiple options (volume tiers, context-specific rates, different models per product line).
@@ -3781,17 +3648,13 @@ export type VendorPricing = CpmPricing | PercentOfMediaPricing | FlatFeePricing 
  */
 export type TargetingModification = ReplaceTargetingValue | RemoveTargetingSetValues;
 export type RemoveTargetingSetValues = {
-  [k: string]: unknown | undefined;
 };
 /**
  * An immutable, population-level claim about an inventory audience's composition, affinity, or estimated reach. This object is discovery and planning evidence only: it MUST NOT be interpreted as an exact targeting predicate, proof that any particular impression belongs to the audience, or legal-age verification.
  */
 export type AudienceEvidence = {
-  [k: string]: unknown | undefined;
 } & {
-  [k: string]: unknown | undefined;
 } & {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Stable provider-scoped identifier for the logical evidence series across versions.
@@ -4751,13 +4614,10 @@ export type AudienceEvidence = {
  * A machine-comparable audience dimension and value or numeric range used in population-level audience evidence. The built-in `age` dimension uses completed years: scalar and set values and range bounds MUST be non-negative integers, and a range's min MUST be less than or equal to its max. Provider-defined dimensions SHOULD use an HTTPS URI and SHOULD identify their taxonomy so two similarly named dimensions are not assumed equivalent.
  */
 export type AudienceCharacteristic = {
-  [k: string]: unknown | undefined;
 } & (
   | {
-      [k: string]: unknown | undefined;
     }
   | {
-      [k: string]: unknown | undefined;
     }
 ) & {
     /**
@@ -4766,7 +4626,6 @@ export type AudienceCharacteristic = {
     dimension: (
       | 'age'
       | {
-          [k: string]: unknown | undefined;
         }
     ) &
       string;
@@ -4795,10 +4654,8 @@ export type AudienceCharacteristic = {
     label?: string;
   } & (
     | {
-        [k: string]: unknown | undefined;
       }
     | {
-        [k: string]: unknown | undefined;
       }
   ) & {
     /**
@@ -4807,7 +4664,6 @@ export type AudienceCharacteristic = {
     dimension: (
       | 'age'
       | {
-          [k: string]: unknown | undefined;
         }
     ) &
       string;
@@ -4839,13 +4695,10 @@ export type AudienceCharacteristic = {
  * Portable, reference-first presentation of an independently issued claim. It identifies the claimed issuer, claim vocabulary, subject, and either a stable credential locator or an embedded credential. A presentation is a locator and claim hint, not proof or a trust decision. The evaluator remains verifier-of-record and MUST resolve or inspect the credential only under its published attestation capabilities and local trust policy.
  */
 export type AttestationReference = {
-  [k: string]: unknown | undefined;
 } & (
   | {
-      [k: string]: unknown | undefined;
     }
   | {
-      [k: string]: unknown | undefined;
     }
 ) & {
     issuer: AttestationIssuer;
@@ -4896,10 +4749,8 @@ export type AttestationReference = {
     ext?: ExtensionObject;
   } & (
     | {
-        [k: string]: unknown | undefined;
       }
     | {
-        [k: string]: unknown | undefined;
       }
   ) & {
     issuer: AttestationIssuer;
@@ -4957,9 +4808,7 @@ export type AttestationSubject = AttestationBrandSubject | AttestationAgentSubje
  * Evaluator-of-record result for one portable attestation presentation. The result binds to the exact presentation through reference_digest and may also pin the credential bytes. It records evaluation, not issuer evidence: domain consumers attach this object to the governance context, evidence snapshot, rights decision, or other action that relied on it.
  */
 export type AttestationEvaluation = {
-  [k: string]: unknown | undefined;
 } & {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * SHA-256 of the RFC 8785 JSON Canonicalization Scheme encoding of the complete AttestationReference, including embedded_credential when present. This prevents a result for one presentation from being replayed for another.
@@ -5021,10 +4870,8 @@ export type AttestationEvaluation = {
    */
   action_binding?:
     | {
-        [k: string]: unknown | undefined;
       }
     | {
-        [k: string]: unknown | undefined;
       };
   ext?: ExtensionObject;
 };
@@ -5032,7 +4879,6 @@ export type AttestationEvaluation = {
  * Typed seller collateral for buyer-facing product cards. Each entry carries a semantic role (coverage_map, sample_render, etc.) and a canonical asset payload. Distinct from hero_image/carousel_images (display-oriented) and from core/reference-asset.json (creative-generation oriented).
  */
 export type ProductCardReferenceAsset = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Semantic role of this asset. coverage_map: geographic or audience reach visualization; sample_render: mockup of ad placement in context; environment_photo: photo of the physical or digital environment; media_kit: downloadable media kit or spec sheet; logo: seller or property logo; other: seller-defined role (provide role_label).
@@ -5050,13 +4896,11 @@ export type ProductCardReferenceAsset = {
    * Optional human-readable context about this asset.
    */
   description?: string;
-  [k: string]: unknown | undefined;
 };
 /**
  * A proposed media plan with fixed or seller-optimized budget allocation across products. Represents the publisher's strategic recommendation for how to structure a campaign based on the brief. Proposals are actionable: committed proposals can be executed directly via create_media_buy by providing the proposal_id; draft proposals must first be finalized via get_products refine action 'finalize'.
  */
 export type Proposal = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Unique identifier for this proposal. Used to finalize a draft proposal and to execute a committed proposal via create_media_buy.
@@ -5107,7 +4951,6 @@ export type Proposal = {
      * ISO 4217 currency code
      */
     currency?: string;
-    [k: string]: unknown | undefined;
   };
   /**
    * Explanation of how this proposal aligns with the campaign brief
@@ -5115,7 +4958,6 @@ export type Proposal = {
   brief_alignment?: string;
   forecast?: DeliveryForecast;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 };
 /**
  * How a media buy's total budget is allocated across its packages. Fixed allocation preserves independent package budgets. Seller-optimized allocation delegates continuous cross-package allocation to the seller within the media-buy total, package caps, minimum-spend targets, flight windows, and pacing controls. When a seller-optimized media-buy BiddingPolicy carries cost_per or roas, that control binds to this allocation block's primary optimization goal rather than independently to each package goal.
@@ -5139,10 +4981,8 @@ export type BudgetAllocation =
        */
       optimization_goals: [
         OptimizationGoal & {
-          [k: string]: unknown | undefined;
         },
         ...(OptimizationGoal & {
-          [k: string]: unknown | undefined;
         })[]
       ];
     };
@@ -5176,10 +5016,8 @@ export type OptimizationGoal =
        */
       target_frequency?:
         | {
-            [k: string]: unknown | undefined;
           }
         | {
-            [k: string]: unknown | undefined;
           };
       /**
        * Minimum video view duration in seconds that qualifies as a completed_view for this goal. Only applicable when metric is 'completed_views'. When omitted, the seller uses their platform default (typically 2–15 seconds). Common values: 2 (Snap/LinkedIn default), 6 (TikTok), 15 (Snap 15-second views, Meta ThruPlay). Sellers declare which durations they support in metric_optimization.supported_view_durations. Sellers must reject goals with unsupported values — silent rounding would create measurement discrepancies.
@@ -5195,7 +5033,6 @@ export type OptimizationGoal =
              * Target cost per metric unit in the buy currency
              */
             value: number;
-            [k: string]: unknown | undefined;
           }
         | {
             kind: 'threshold_rate';
@@ -5203,13 +5040,11 @@ export type OptimizationGoal =
              * Minimum per-impression value. Units depend on the metric: proportion (clicks, views, completed_views), seconds (viewed_seconds, attention_seconds), or score (attention_score).
              */
             value: number;
-            [k: string]: unknown | undefined;
           };
       /**
        * Relative priority among sibling goals. Lower numbers rank first. Goals without priority follow explicitly prioritized goals. Ties use array order, so the earliest goal at the lowest explicit priority is primary; when all priorities are omitted, the first goal is primary.
        */
       priority?: number;
-      [k: string]: unknown | undefined;
     }
   | {
       kind: 'event';
@@ -5237,7 +5072,6 @@ export type OptimizationGoal =
            * Unit-scaling multiplier the seller must apply to value_field before aggregation. Use -1 for refund events (negate the value), 0.01 for values in cents, -0.01 for refunds in cents. It MUST NOT be used for currency conversion. A value of 0 zeroes out this source's value contribution (the source still counts for event dedup). Defaults to 1. This is not passed as a parameter to underlying platform APIs — the seller applies it when computing aggregated value metrics.
            */
           value_factor?: number;
-          [k: string]: unknown | undefined;
         },
         ...{
           /**
@@ -5257,7 +5091,6 @@ export type OptimizationGoal =
            * Unit-scaling multiplier the seller must apply to value_field before aggregation. Use -1 for refund events (negate the value), 0.01 for values in cents, -0.01 for refunds in cents. It MUST NOT be used for currency conversion. A value of 0 zeroes out this source's value contribution (the source still counts for event dedup). Defaults to 1. This is not passed as a parameter to underlying platform APIs — the seller applies it when computing aggregated value metrics.
            */
           value_factor?: number;
-          [k: string]: unknown | undefined;
         }[]
       ];
       /**
@@ -5270,7 +5103,6 @@ export type OptimizationGoal =
              * Target cost per event in the buy currency
              */
             value: number;
-            [k: string]: unknown | undefined;
           }
         | {
             kind: 'per_ad_spend';
@@ -5278,11 +5110,9 @@ export type OptimizationGoal =
              * Target return ratio (e.g., 4.0 means $4 of value per $1 spent)
              */
             value: number;
-            [k: string]: unknown | undefined;
           }
         | {
             kind: 'maximize_value';
-            [k: string]: unknown | undefined;
           };
       /**
        * Attribution window for this optimization goal — references the canonical `attribution-window` shape (post_click, post_view, model). Values must match an option declared in the seller's `conversion_tracking.attribution_windows` capability. Sellers MUST reject windows not in their declared capabilities. When the entire field is omitted, the seller uses their default window.
@@ -5292,7 +5122,6 @@ export type OptimizationGoal =
        * Relative priority among sibling goals. Lower numbers rank first. Goals without priority follow explicitly prioritized goals. Ties use array order, so the earliest goal at the lowest explicit priority is primary; when all priorities are omitted, the first goal is primary.
        */
       priority?: number;
-      [k: string]: unknown | undefined;
     }
   | {
       kind: 'vendor_metric';
@@ -5308,7 +5137,6 @@ export type OptimizationGoal =
              * Target cost per metric unit in the buy currency. Units of the metric are vendor-defined.
              */
             value: number;
-            [k: string]: unknown | undefined;
           }
         | {
             kind: 'threshold_rate';
@@ -5316,13 +5144,11 @@ export type OptimizationGoal =
              * Minimum per-impression value. Units of the metric are vendor-defined.
              */
             value: number;
-            [k: string]: unknown | undefined;
           };
       /**
        * Relative priority among sibling goals. Lower numbers rank first. Goals without priority follow explicitly prioritized goals. Ties use array order, so the earliest goal at the lowest explicit priority is primary; when all priorities are omitted, the first goal is primary.
        */
       priority?: number;
-      [k: string]: unknown | undefined;
     };
 /**
  * Canonical response contract for get_products, including completed results, terminal failures, wholesale unchanged responses, and the structured GetProductsRejected business outcome.
@@ -5620,7 +5446,6 @@ export interface Error {
        */
       value: string | number | boolean | null;
     }[];
-    [k: string]: unknown | undefined;
   }[];
   /**
    * Additional task-specific error details. Sellers MAY mirror `issues[]` here as `details.issues` for backward compatibility with pre-3.1 consumers reading from `details`; new consumers SHOULD prefer the top-level `issues` field.
@@ -5645,7 +5470,6 @@ export interface Error {
    * This is **SHOULD-level guidance**, not MUST: `details` remains `additionalProperties: true` and pre-3.1 sellers using `available` / `allowed` / `accepted_values` at the error root remain conformant. The canonical shape lets buyer-side diagnostic tooling (SDK runner hints, dashboards, error classifiers) reliably surface the accepted-set without per-seller pattern matching. SDKs SHOULD accept any of the legacy variants and normalize on read; the canonical shape is what new sellers and 3.1+ adopters should emit going forward.
    */
   details?: {
-    [k: string]: unknown | undefined;
   };
   /**
    * Agent recovery classification. transient: retry after delay (rate limit, service unavailable, timeout). correctable: fix the request and resend (invalid field, budget too low, creative rejected). terminal: requires human action (account suspended, payment required, account not found). Senders SHOULD populate `recovery` on every error from 3.1 onward — it is the normative carrier of recovery semantics across version skew. A receiver that does not recognize `error.code` (a newer code, or a platform-specific code) MUST still be able to classify the error from `recovery`. The `enumMetadata.recovery` block in `enums/error-code.json` is the documentary mirror for known codes; `error.recovery` on the wire is authoritative.
@@ -5663,20 +5487,17 @@ export interface Error {
    * Optional identifier for the SDK that augmented this error entry. Format: `<sdk_package_name>@<version>` (e.g., `@adcontextprotocol/adcp@7.3.0`, `adcontextprotocol-adcp-python@1.2.0`). MUST be set when `source: "sdk"`; MUST be absent when `source: "producer"` or absent. Lets downstream consumers identify which intermediate processor inserted the entry, useful for debugging cross-SDK divergence (e.g., one SDK detects a projection failure that another SDK's registry version doesn't).
    */
   sdk_id?: string;
-  [k: string]: unknown | undefined;
 }
 /**
  * @deprecated
  * Deprecated 3.x compatibility branch. Product references one or more named formats by structured format_id ({ agent_url, id }). New 3.2 products use format_options.
  */
 export interface NamedFormatProduct {
-  [k: string]: unknown | undefined;
 }
 /**
  * Product carries one or more inline ProductFormatDeclarations, each narrowing a canonical format. This is the 3.1+ format-option path introduced by RFC #3305. A single-element `format_options` array is the 90% case; multi-element arrays declare that the product accepts any of the listed format options.
  */
 export interface CanonicalFormatProduct {
-  [k: string]: unknown | undefined;
 }
 /**
  * Optional seller-enforced creative-locale constraint for this format option. This is product/placement eligibility, not a new format kind or synthetic locale-specific format ID. Because legacy format_ids cannot preserve this constraint, declarations carrying locale_policy MUST set canonical_formats_only to true and MUST NOT carry v1_format_ref.
@@ -5689,7 +5510,6 @@ export interface CreativeLocalePolicy {
    * @maxItems 50
    */
   accepted_language_ranges: [LanguageTag, ...LanguageTag[]];
-  [k: string]: unknown | undefined;
 }
 export interface ImageFormatDeclaration {
   format_kind: 'image';
@@ -5748,7 +5568,6 @@ export interface CustomFormatDeclaration {
    * Custom shape's params. Validated against the schema fetched from `format_schema.uri` at the cached `format_schema.digest`.
    */
   params: {
-    [k: string]: unknown | undefined;
   };
 }
 /**
@@ -5790,7 +5609,6 @@ export interface CPMPricingOption {
    * Adjustment kinds applicable to this pricing option. Tells buyer agents which adjustments are available before negotiation. When absent, no adjustments are pre-declared — the buyer should check price_breakdown if present.
    */
   eligible_adjustments?: PriceAdjustmentKind[];
-  [k: string]: unknown | undefined;
 }
 /**
  * Optional pricing guidance for auction-based bidding
@@ -5812,1746 +5630,22 @@ export interface PriceGuidance {
    * 90th percentile of recent winning bids
    */
   p90?: number;
-  [k: string]: unknown | undefined;
 }
 /**
  * Breakdown of how fixed_price was derived from the list (rate card) price. Only meaningful when fixed_price is present.
  */
-export interface PriceBreakdown {
-  /**
-   * Rate card or base price before any adjustments. The starting point from which fixed_price is derived by applying fee and discount adjustments sequentially.
-   */
-  list_price: number;
-  /**
-   * Ordered list of price adjustments. Fee and discount adjustments walk list_price to fixed_price — fees increase the running price, discounts reduce it. Commission and settlement adjustments are disclosed for transparency but do not affect the buyer's committed price.
-   *
-   * @minItems 1
-   * @maxItems 20
-   */
-  adjustments:
-    | [
-        | {
-            [k: string]: unknown | undefined;
-          }
-        | {
-            [k: string]: unknown | undefined;
-          }
-      ]
-    | [
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        )
-      ]
-    | [
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        )
-      ]
-    | [
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        )
-      ]
-    | [
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        )
-      ]
-    | [
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        )
-      ]
-    | [
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        )
-      ]
-    | [
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        )
-      ]
-    | [
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        )
-      ]
-    | [
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        )
-      ]
-    | [
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        )
-      ]
-    | [
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        )
-      ]
-    | [
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        )
-      ]
-    | [
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        )
-      ]
-    | [
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        )
-      ]
-    | [
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        )
-      ]
-    | [
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        )
-      ]
-    | [
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        )
-      ]
-    | [
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        )
-      ]
-    | [
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        ),
-        (
-          | {
-              [k: string]: unknown | undefined;
-            }
-          | {
-              [k: string]: unknown | undefined;
-            }
-        )
-      ];
-  [k: string]: unknown | undefined;
+export interface PriceAdjustment {
+  kind: PriceAdjustmentKind;
+  name: string;
+  rate?: number;
+  amount?: number;
+  description?: string;
+  beneficiary?: string;
 }
-/**
- * Viewable Cost Per Mille (cost per 1,000 viewable impressions) pricing - MRC viewability standard. If fixed_price is present, it's fixed pricing. If absent, it's auction-based.
- */
+export interface PriceBreakdown {
+  list_price: number;
+  adjustments: PriceAdjustment[];
+}
 export interface VCPMPricingOption {
   /**
    * Unique identifier for this pricing option within the product
@@ -7588,7 +5682,6 @@ export interface VCPMPricingOption {
    * Adjustment kinds applicable to this pricing option. Tells buyer agents which adjustments are available before negotiation. When absent, no adjustments are pre-declared — the buyer should check price_breakdown if present.
    */
   eligible_adjustments?: PriceAdjustmentKind[];
-  [k: string]: unknown | undefined;
 }
 /**
  * Cost Per Click pricing. If fixed_price is present, it's fixed pricing. If absent, it's auction-based.
@@ -7629,7 +5722,6 @@ export interface CPCPricingOption {
    * Adjustment kinds applicable to this pricing option. Tells buyer agents which adjustments are available before negotiation. When absent, no adjustments are pre-declared — the buyer should check price_breakdown if present.
    */
   eligible_adjustments?: PriceAdjustmentKind[];
-  [k: string]: unknown | undefined;
 }
 /**
  * Cost Per Completed View (100% video/audio completion) pricing. If fixed_price is present, it's fixed pricing. If absent, it's auction-based.
@@ -7670,7 +5762,6 @@ export interface CPCVPricingOption {
    * Adjustment kinds applicable to this pricing option. Tells buyer agents which adjustments are available before negotiation. When absent, no adjustments are pre-declared — the buyer should check price_breakdown if present.
    */
   eligible_adjustments?: PriceAdjustmentKind[];
-  [k: string]: unknown | undefined;
 }
 /**
  * Cost Per View (at publisher-defined threshold) pricing for video/audio. If fixed_price is present, it's fixed pricing. If absent, it's auction-based.
@@ -7713,9 +5804,7 @@ export interface CPVPricingOption {
            * Seconds of viewing required
            */
           duration_seconds: number;
-          [k: string]: unknown | undefined;
         };
-    [k: string]: unknown | undefined;
   };
   /**
    * Minimum spend requirement per package using this pricing option, in the specified currency
@@ -7726,7 +5815,6 @@ export interface CPVPricingOption {
    * Adjustment kinds applicable to this pricing option. Tells buyer agents which adjustments are available before negotiation. When absent, no adjustments are pre-declared — the buyer should check price_breakdown if present.
    */
   eligible_adjustments?: PriceAdjustmentKind[];
-  [k: string]: unknown | undefined;
 }
 /**
  * Cost Per Point (Gross Rating Point) pricing for TV and audio campaigns. If fixed_price is present, it's fixed pricing. If absent, it's auction-based.
@@ -7766,7 +5854,6 @@ export interface CPPPricingOption {
      * Minimum GRPs/TRPs required
      */
     min_points?: number;
-    [k: string]: unknown | undefined;
   };
   /**
    * Minimum spend requirement per package using this pricing option, in the specified currency
@@ -7777,7 +5864,6 @@ export interface CPPPricingOption {
    * Adjustment kinds applicable to this pricing option. Tells buyer agents which adjustments are available before negotiation. When absent, no adjustments are pre-declared — the buyer should check price_breakdown if present.
    */
   eligible_adjustments?: PriceAdjustmentKind[];
-  [k: string]: unknown | undefined;
 }
 /**
  * Cost Per Acquisition pricing. Advertiser pays a fixed price when a specified conversion event occurs. The event_type field declares which event triggers billing (e.g., purchase, lead, app_install).
@@ -7820,7 +5906,6 @@ export interface CPAPricingOption {
    * Adjustment kinds applicable to this pricing option. Tells buyer agents which adjustments are available before negotiation. When absent, no adjustments are pre-declared — the buyer should check price_breakdown if present.
    */
   eligible_adjustments?: PriceAdjustmentKind[];
-  [k: string]: unknown | undefined;
 }
 /**
  * Flat rate pricing for sponsorships, takeovers, and DOOH exclusive placements. A fixed total cost regardless of delivery volume. For duration-scaled pricing (rate × time units), use the `time` model instead. If fixed_price is present, it's fixed pricing. If absent, it's auction-based.
@@ -7857,7 +5942,6 @@ export interface FlatRatePricingOption {
    * Adjustment kinds applicable to this pricing option. Tells buyer agents which adjustments are available before negotiation. When absent, no adjustments are pre-declared — the buyer should check price_breakdown if present.
    */
   eligible_adjustments?: PriceAdjustmentKind[];
-  [k: string]: unknown | undefined;
 }
 /**
  * DOOH inventory allocation parameters. Sponsorship and takeover flat_rate options omit this field entirely — only include for digital out-of-home inventory.
@@ -7895,7 +5979,6 @@ export interface DoohParameters {
    * Estimated audience impressions for this slot (informational, not a delivery guarantee)
    */
   estimated_impressions?: number;
-  [k: string]: unknown | undefined;
 }
 /**
  * Cost per time unit (hour, day, week, or month) - rate scales with campaign duration. If fixed_price is present, it's fixed pricing. If absent, it's auction-based.
@@ -7938,7 +6021,6 @@ export interface TimeBasedPricingOption {
      * Maximum booking duration in time_units. Must be >= min_duration when both are present.
      */
     max_duration?: number;
-    [k: string]: unknown | undefined;
   };
   /**
    * Minimum spend requirement per package using this pricing option, in the specified currency
@@ -7949,7 +6031,6 @@ export interface TimeBasedPricingOption {
    * Adjustment kinds applicable to this pricing option. Tells buyer agents which adjustments are available before negotiation. When absent, no adjustments are pre-declared — the buyer should check price_breakdown if present.
    */
   eligible_adjustments?: PriceAdjustmentKind[];
-  [k: string]: unknown | undefined;
 }
 /**
  * Forecasted delivery metrics for this product. Concrete discovery targeting scopes the forecast to those effective values. When discovery requested only required_overlay_support for a dimension, the forecast describes the product's discovery/default scope and is not a value-specific forecast for every later selection; buyers rediscover with concrete targeting_overlay values when they need that forecast.
@@ -7986,7 +6067,6 @@ export interface DeliveryForecast {
    */
   valid_until?: string;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * A placement dimension for a ForecastPoint row. Variant of ForecastPoint dimensions; see forecast-point-dimensions.json for dispatch rules.
@@ -8056,7 +6136,6 @@ export interface ForecastVendorMetricValue {
    * Optional structured payload for vendor metrics that do not fit a single scalar. Forecast rows SHOULD use ForecastRange values inside breakdown when sub-values are numeric forecasts. Buyers MUST treat this object as opaque without consulting the vendor's documentation.
    */
   breakdown?: {
-    [k: string]: unknown | undefined;
   };
 }
 /**
@@ -8080,7 +6159,6 @@ export interface OutcomeMeasurement {
    * Reporting frequency and format
    */
   reporting: string;
-  [k: string]: unknown | undefined;
 }
 /**
  * An action a seller declares as allowed on buys created against this product, scoped to the buy statuses where the action is permitted and the modes available. Advisory template only — the authoritative per-buy resolution lives in `available_actions[]` on the buy response (which may diverge from the product template based on negotiated terms, account tier, or buy-level overrides). The containing `allowed_actions[]` array is uniquely keyed by `action`; sellers MUST NOT emit two entries with the same `action` value. JSON Schema `uniqueItems` only catches structurally identical objects, so validators MUST enforce action-uniqueness separately.
@@ -8192,7 +6270,6 @@ export interface ReportingCapabilities {
    * @minItems 1
    */
   measurement_windows?: [MeasurementWindow, ...MeasurementWindow[]];
-  [k: string]: unknown | undefined;
 }
 /**
  * Geographic breakdown support for this product. Declares which geo levels and systems are available for by_geo reporting within by_package.
@@ -8247,7 +6324,6 @@ export interface MeasurementWindow {
    * Whether this window is the basis for delivery guarantees, reconciliation, and invoicing. A product typically has one guarantee basis window (e.g., C7 for most US broadcast, post-IVT final for DOOH). Buyers reconcile against the guarantee basis window's final numbers.
    */
   is_guarantee_basis?: boolean;
-  [k: string]: unknown | undefined;
 }
 /**
  * Creative requirements and restrictions for a product
@@ -8283,7 +6359,6 @@ export interface CreativePolicy {
      * When true, the seller requires creatives to include at least one `embedded_provenance` entry. For pipelines where sidecar metadata is stripped by intermediaries, this ensures provenance data persists through delivery. Submissions that omit `embedded_provenance` are rejected with `PROVENANCE_EMBEDDED_MISSING`.
      */
     require_embedded_provenance?: boolean;
-    [k: string]: unknown | undefined;
   };
   /**
    * Governance agents the seller operates, has allowlisted, or otherwise trusts to verify provenance claims via `get_creative_features`. Buyers attaching a `verify_agent` pointer on `embedded_provenance[]` or `watermarks[]` MUST select an `agent_url` that appears in this list (canonicalized per /docs/reference/url-canonicalization: lowercase scheme and host, strip default port, normalize path dot-segments) - the buyer is *representing* that they used a verifier the seller will recognize, not asserting unilateral routing. Sellers MUST reject `sync_creatives` submissions whose `verify_agent.agent_url` does not match any entry here with `PROVENANCE_VERIFIER_NOT_ACCEPTED`. The seller is the verifier-of-record: it is the seller, not the buyer, that decides which agent it will call. Publishing the list lets buyers pre-flight their creative shape against `get_products` and lets multiple buyers converge on the same verifier without coordinating with each other.
@@ -8324,14 +6399,12 @@ export interface CreativePolicy {
       providers?: [string, ...string[]];
     }[]
   ];
-  [k: string]: unknown | undefined;
 }
 /**
  * Machine-readable demographic meaning. For product-local signals this listing is authoritative; for data-provider and signal-source refs, any projected value MUST match the referenced authoritative definition. Signal names alone never establish demographic semantics.
  */
 export interface DemographicPredicate {
   age: DemographicAgeRange;
-  [k: string]: unknown | undefined;
 }
 /**
  * Fixed cost per thousand impressions
@@ -8347,7 +6420,6 @@ export interface CpmPricing {
    */
   currency: string;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Percentage of media spend charged for this signal. When max_cpm is set, the effective rate is capped at that CPM — useful for platforms like The Trade Desk that use percent-of-media pricing with a CPM ceiling.
@@ -8367,7 +6439,6 @@ export interface PercentOfMediaPricing {
    */
   currency: string;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Fixed charge per billing period, regardless of impressions or spend. Used for licensed data bundles and audience subscriptions.
@@ -8387,7 +6458,6 @@ export interface FlatFeePricing {
    */
   currency: string;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Fixed price per unit of work. Used for creative transformation (per format), AI generation (per image, per token), and rendering (per variant). The unit field describes what is counted; unit_price is the cost per one unit.
@@ -8407,7 +6477,6 @@ export interface PerUnitPricing {
    */
   currency: string;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Escape hatch for pricing constructs that do not fit cpm, percent_of_media, flat_fee, or per_unit. Use when a vendor prices via performance kickers, tiered volume, hybrid formulas, outcome-sharing, or any other model the standard forms cannot express. Requires a human-readable description and a structured metadata object that captures the parameters a buyer needs to reason about the charge. Buyers SHOULD route custom pricing through operator review before commitment — automatic selection is not recommended.
@@ -8426,14 +6495,12 @@ export interface CustomPricing {
      * One or two sentences describing the pricing construct in plain language, displayed to the buyer's operator when requesting approval. Should not repeat the top-level `description` verbatim — summarize the charge mechanic instead (e.g., 'Base $12 CPM plus $0.50 per qualifying post-view conversion, capped at $45 CPM').
      */
     summary_for_operator?: string;
-    [k: string]: unknown | undefined;
   };
   /**
    * ISO 4217 currency code. Present when the pricing resolves to a monetary charge in a specific currency.
    */
   currency?: string;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Composition rules for selecting signals on this product. The selectable signal menu may come from inline signal_targeting_options or from get_signals when a wholesale product omits inline options. This is product-scoped because products may be backed by different ad servers with different Boolean targeting support and group limits.
@@ -8473,7 +6540,6 @@ export interface SignalTargetingRules {
    * @minItems 1
    */
   selection_group_rules?: [SignalSelectionGroupRule, ...SignalSelectionGroupRule[]];
-  [k: string]: unknown | undefined;
 }
 /**
  * Product-scoped override for one ProductSignalTargetingOption.selection_group value. Use this when a product has mixed signal-selection behavior, such as fixed suppressions plus a required pick-one include tier.
@@ -8499,7 +6565,6 @@ export interface SignalSelectionGroupRule {
    * Maximum selected options from this selection_group.
    */
   max_selected_signals?: number;
-  [k: string]: unknown | undefined;
 }
 /**
  * Exact demographic execution available for this product. Buyers MUST use this product-scoped declaration, not the seller-wide get_adcp_capabilities rollup, to preflight a demographic predicate.
@@ -8509,9 +6574,7 @@ export interface DemographicTargetingCapability {
    * Age-targeting execution available for this product.
    */
   age: {
-    [k: string]: unknown | undefined;
   };
-  [k: string]: unknown | undefined;
 }
 /**
  * Country- and value-aware support for selecting canonical ISO 3166-2 subdivisions. all_values is exhaustive for the values active in the seller's support snapshot when the declaration is issued; it does not automatically include values introduced by a later catalog revision. values is an exact finite subset. In seller-wide capabilities, each declared value is individually supported within the response scope, but the declaration does not promise that values are jointly composable or available through the same execution route or account. In Product.overlay_support, the declared values form the binding set of executable targeting permissions for that Product, subject to its declared limits; support does not itself guarantee inventory for every selection.
@@ -8620,7 +6683,6 @@ export interface ReplaceTargetingValue {
    * Complete replacement value. It MUST validate against targeting.json at path; the seller then validates the complete effective overlay. This operation may narrow or broaden only as an explicit buyer-visible proposal.
    */
   applied: {
-    [k: string]: unknown | undefined;
   };
   reason: string;
   ext?: ExtensionObject;
@@ -8637,7 +6699,6 @@ export interface DateRange {
    * End date (inclusive), ISO 8601
    */
   end: string;
-  [k: string]: unknown | undefined;
 }
 export interface AttestationBrandSubject {
   type: 'brand';
@@ -9292,7 +7353,6 @@ export interface VendorMetricOptimization {
    * Vendor-defined metrics this product can steer delivery toward. Each entry pairs a vendor identity (BrandRef anchored on the vendor's `brand.json` `agents[type='measurement']`) with a `metric_id` from that vendor's published `measurement.metrics[]` catalog, plus the target kinds the seller supports for the pair. Semantic uniqueness key is `(vendor.domain, vendor.brand_id, metric_id)`; sellers MUST de-duplicate before publication. JSON Schema `uniqueItems` blocks exact-object duplicates; semantic deduplication on the BrandRef-domain key is a seller obligation.
    */
   supported_metrics: VendorMetricOptimizationSupportedMetric[];
-  [k: string]: unknown | undefined;
 }
 /**
  * One vendor-defined metric that a product can optimize toward. Identified by the tuple `(vendor, metric_id)` plus the supported target kinds for optimization goals.
@@ -9328,7 +7388,6 @@ export interface MeasurementReadiness {
    * Seller explanation of the readiness assessment, recommendations for improvement, or context about what the buyer needs to change.
    */
   notes?: string;
-  [k: string]: unknown | undefined;
 }
 /**
  * An actionable issue detected during a health or readiness assessment. Used by event source health and measurement readiness to surface problems and recommendations.
@@ -9342,7 +7401,6 @@ export interface DiagnosticIssue {
    * Human/agent-readable description of the issue and how to resolve it.
    */
   message: string;
-  [k: string]: unknown | undefined;
 }
 /**
  * A hosted video file delivered directly (e.g., an MP4 you host), with URL and technical specifications including audio track properties. `width` and `height` are required because a hosted video file has intrinsic, native pixel dimensions that are known when the file is created. Tag-delivered video uses the separate `vast` asset, which carries no `width`/`height`: a VAST response resolves geometry per-`MediaFile` at serve time, so there is no single width/height for the ad. Aspect-ratio and size *constraints* (what a placement accepts) belong on the format/requirements layer, not on the asset.
@@ -9454,7 +7512,6 @@ export interface VideoAsset {
    */
   audio_description_url?: string;
   provenance?: Provenance;
-  [k: string]: unknown | undefined;
 }
 /**
  * Markdown-formatted text content following CommonMark specification
@@ -9477,7 +7534,6 @@ export interface MarkdownAsset {
    * Whether raw HTML blocks are allowed in the markdown. False recommended for security.
    */
   allow_raw_html?: boolean;
-  [k: string]: unknown | undefined;
 }
 /**
  * URL reference asset. `url_type` declares the mechanism a receiver uses to invoke the URL (clickthrough vs. tracker_pixel vs. tracker_script) and is distinct from the URL's purpose, which the format declares in `url-asset-requirements.role` (clickthrough, landing_page, impression_tracker, click_tracker, viewability_tracker, third_party_tracker). Senders SHOULD include `url_type` on every URL asset. When `url_type` is absent, receivers SHOULD fall back to the format's `url-asset-requirements.role` per this mapping: clickthrough/landing_page → `clickthrough`; impression_tracker/click_tracker → `tracker_pixel`; viewability_tracker → `tracker_script` (OMID and equivalent verification SDKs require a <script> tag — firing them as a pixel produces no measurement); third_party_tracker → no safe fallback (mechanism is integration-specific — DV/IAS ship both pixel and script forms — receivers MAY reject or warn). When neither `url_type` nor a format-side `role` is available, receivers MUST NOT silently pick a mechanism; they SHOULD reject the manifest. Note: VAST/DAAST tag URLs are not URL assets — use `asset_type: "vast"` (or the dedicated tracker types pending RFC #2915), not `asset_type: "url"` with a tracker_pixel mechanism.
@@ -9497,7 +7553,6 @@ export interface URLAsset {
    */
   description?: string;
   provenance?: Provenance;
-  [k: string]: unknown | undefined;
 }
 /**
  * References collections declared in an adagents.json. Buyers resolve full collection objects by fetching the adagents.json at the given domain and matching collection_ids against its collections array.
@@ -9513,7 +7568,6 @@ export interface CollectionSelector {
    * @minItems 1
    */
   collection_ids: [string, ...string[]];
-  [k: string]: unknown | undefined;
 }
 /**
  * A single bookable unit within a collection — one episode, issue, event, or rotation period. The parent collection's kind indicates how to interpret each installment: TV/podcast episodes, print issues, live event airings, newsletter editions, or DOOH rotation periods. Installments inherit collection-level fields they don't override: content_rating defaults to the collection's baseline, guest_talent is additive to the collection's recurring talent, and topics add context beyond the collection's genre.
@@ -9579,7 +7633,6 @@ export interface Installment {
     type: DerivativeType;
   };
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Installment-specific content rating. Overrides the collection's baseline content_rating when present.
@@ -9590,7 +7643,6 @@ export interface ContentRating {
    * Rating value within the system (e.g., 'TV-PG', 'R', 'explicit')
    */
   rating: string;
-  [k: string]: unknown | undefined;
 }
 /**
  * Installment-specific event context. When present, this installment is anchored to a real-world event. Overrides the collection-level special when present.
@@ -9609,7 +7661,6 @@ export interface Special {
    * When the event ends (ISO 8601). Omit for single-day events.
    */
   ends?: string;
-  [k: string]: unknown | undefined;
 }
 /**
  * A person associated with a collection or installment, with an optional link to their brand.json identity
@@ -9624,7 +7675,6 @@ export interface Talent {
    * URL to this person's brand.json entry. Enables buyer agents to evaluate the talent's brand identity and associations.
    */
   brand_url?: string;
-  [k: string]: unknown | undefined;
 }
 /**
  * Break-based ad inventory for this installment. For non-break formats (host reads, integrations), use product placements.
@@ -9650,7 +7700,6 @@ export interface AdInventoryConfiguration {
    * Ad format types supported in breaks (e.g., 'video', 'audio', 'display')
    */
   supported_formats?: string[];
-  [k: string]: unknown | undefined;
 }
 /**
  * Booking, cancellation, and material submission deadlines for this installment. Present when the installment has time-sensitive inventory that requires advance commitment or material delivery.
@@ -9670,7 +7719,6 @@ export interface InstallmentDeadlines {
    * @minItems 1
    */
   material_deadlines?: [MaterialDeadline, ...MaterialDeadline[]];
-  [k: string]: unknown | undefined;
 }
 /**
  * A deadline for creative material submission. Sellers declare stages to distinguish draft materials (e.g., talking points, raw artwork) from production-ready assets (e.g., approved scripts, press-ready PDFs).
@@ -9688,7 +7736,6 @@ export interface MaterialDeadline {
    * What the seller needs at this stage (e.g., 'Talking points and brand guidelines', 'Press-ready PDF with bleed')
    */
   label?: string;
-  [k: string]: unknown | undefined;
 }
 /**
  * Request-level confirmation of structured hard targeting inferred from the brief. Sellers MUST include this when their structured interpretation of hard prose materially affects product eligibility, pricing, or forecasting; otherwise inclusion is a best practice. Omitted when no hard targeting was inferred from the brief.
@@ -9750,7 +7797,6 @@ export interface ProductAllocation {
   daypart_targets?: [DaypartTarget, ...DaypartTarget[]];
   forecast?: DeliveryForecast;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Describes the attribution methodology and lookback windows used for conversion measurement. Enables cross-platform comparison by making attribution methodology transparent. Used as a `$ref` from `optimization-goal.json` (buyer's optimization-time attribution choice), `get-media-buy-delivery-response.json` (seller-declared attribution methodology in delivery reports), and similar surfaces. All fields are optional individually but at least one of `post_click`, `post_view`, or `model` SHOULD be populated; absence of `model` means the seller's default attribution model applies (typically `last_touch` per industry convention) — sellers SHOULD populate `model` explicitly when committing to a specific methodology.
@@ -9765,7 +7811,6 @@ export interface AttributionWindow {
    */
   post_view?: Duration;
   model?: AttributionModel;
-  [k: string]: unknown | undefined;
 }
 /**
  * Formal insertion order attached to a committed proposal. Present when the seller requires a signed agreement before the media buy can proceed. The buyer references the io_id in io_acceptance on create_media_buy.
@@ -9809,7 +7854,6 @@ export interface InsertionOrder {
      * Payment terms
      */
     payment_terms?: 'net_30' | 'net_60' | 'net_90' | 'prepaid' | 'due_on_receipt';
-    [k: string]: unknown | undefined;
   };
   /**
    * URL to a human-readable document containing the full insertion order terms
@@ -9823,7 +7867,6 @@ export interface InsertionOrder {
    * Whether the buyer must accept this IO before creating a media buy. When true, create_media_buy requires an io_acceptance referencing this io_id.
    */
   requires_signature: boolean;
-  [k: string]: unknown | undefined;
 }
 /**
  * Cursor metadata for paginated get_products responses. In brief/refine mode, continuation pages bound returned products[] for the seller's curated or refined answer; proposals may accompany a page as plan metadata but are not independently counted by this pagination envelope, and pagination does not convert the response into an exhaustive feed contract. In wholesale mode, continuation pages walk the wholesale product feed.
@@ -9870,18 +7913,15 @@ export type CanonicalAccountReference =
  * Extension-tolerant inclusive currency bounds used by legacy discovery filters. At least one bound is required; min MUST be less than or equal to max. The strict negotiation peer that rejects unknown members is media-buy/proposal-budget-constraint.json.
  */
 export type BudgetRange = {
-  [k: string]: unknown | undefined;
 } & {
   min?: number;
   max?: number;
   currency: string;
-  [k: string]: unknown | undefined;
 };
 /**
  * Buyer-authored evidence policy for compact product discovery. Organization selectors are stable keys and never carry brand assets or content provenance.
  */
 export type ProductAudienceEvidenceRequirements = {
-  [k: string]: unknown | undefined;
 } & {
   requirement_mode: 'required' | 'preferred';
   evidence_presence: 'required' | 'when_available';
@@ -10149,7 +8189,6 @@ export interface ProductDiscoveryCriteria {
    */
   policy_ids?: [string, ...string[]];
   ext?: {
-    [k: string]: unknown | undefined;
   };
 }
 /**
@@ -10219,13 +8258,11 @@ export interface ProductOfferFilters {
         agent_url: string;
         context_match?: boolean;
         identity_match?: boolean;
-        [k: string]: unknown | undefined;
       },
       ...{
         agent_url: string;
         context_match?: boolean;
         identity_match?: boolean;
-        [k: string]: unknown | undefined;
       }[]
     ];
     /**
@@ -10246,14 +8283,12 @@ export interface ProductOfferFilters {
       threshold: number;
       standard?: ViewabilityStandard;
       vendor: BrandKey;
-      [k: string]: unknown | undefined;
     },
     ...{
       metric: PerformanceStandardMetric;
       threshold: number;
       standard?: ViewabilityStandard;
       vendor: BrandKey;
-      [k: string]: unknown | undefined;
     }[]
   ];
   /**
@@ -10266,18 +8301,14 @@ export interface ProductOfferFilters {
   required_vendor_metrics?: [
     (
       | {
-          [k: string]: unknown | undefined;
         }
       | {
-          [k: string]: unknown | undefined;
         }
     ),
     ...(
       | {
-          [k: string]: unknown | undefined;
         }
       | {
-          [k: string]: unknown | undefined;
         }
     )[]
   ];
@@ -10368,7 +8399,6 @@ export type ListProductsResponse = {
  * Compact canonical creative-format declaration. Legacy named-format links are intentionally absent; params are validated against the canonical schema selected by format_kind without inlining every format union into product discovery.
  */
 export type CanonicalFormatOption = {
-  [k: string]: unknown | undefined;
 } & {
   format_option_id?: string;
   publisher_domain?: string;
@@ -10397,7 +8427,6 @@ export type CanonicalFormatOption = {
     | 'agent_placement'
     | 'custom';
   params: {
-    [k: string]: unknown | undefined;
   };
   format_shape?: string;
   format_schema?: PlatformExtensionReference;
@@ -10429,7 +8458,6 @@ export type CanonicalFormatOption = {
     | 'agent_placement'
     | 'custom';
   params: {
-    [k: string]: unknown | undefined;
   };
   format_shape?: string;
   format_schema?: PlatformExtensionReference;
@@ -10461,7 +8489,6 @@ export type CanonicalFormatOption = {
     | 'agent_placement'
     | 'custom';
   params: {
-    [k: string]: unknown | undefined;
   };
   format_shape?: string;
   format_schema?: PlatformExtensionReference;
@@ -10493,7 +8520,6 @@ export type CanonicalFormatOption = {
     | 'agent_placement'
     | 'custom';
   params: {
-    [k: string]: unknown | undefined;
   };
   format_shape?: string;
   format_schema?: PlatformExtensionReference;
@@ -10502,7 +8528,6 @@ export type CanonicalFormatOption = {
  * Compact product placement with canonical format narrowing only.
  */
 export type CanonicalProductPlacement = {
-  [k: string]: unknown | undefined;
 } & {
   kind: 'publisher_ref' | 'seller_inline';
   placement_id: string;
@@ -10536,15 +8561,10 @@ export type CanonicalProductPlacement = {
  * Self-contained selected pricing terms for compact product offers and accepted commercial snapshots. Deprecated execution hints such as max_bid are absent; bidding intent lives in BiddingPolicy.
  */
 export type CanonicalPricingOption = {
-  [k: string]: unknown | undefined;
 } & {
-  [k: string]: unknown | undefined;
 } & {
-  [k: string]: unknown | undefined;
 } & {
-  [k: string]: unknown | undefined;
 } & {
-  [k: string]: unknown | undefined;
 } & {
   pricing_option_id: string;
   pricing_model: 'cpm' | 'vcpm' | 'cpc' | 'cpcv' | 'cpv' | 'cpp' | 'cpa' | 'revenue_share' | 'flat_rate' | 'time';
@@ -10556,7 +8576,6 @@ export type CanonicalPricingOption = {
   price_breakdown?: PriceBreakdown;
   eligible_adjustments?: PriceAdjustmentKind[];
   parameters?: {
-    [k: string]: unknown | undefined;
   };
   event_type?: EventType;
   custom_event_name?: string;
@@ -10574,7 +8593,6 @@ export type CanonicalPricingOption = {
   price_breakdown?: PriceBreakdown;
   eligible_adjustments?: PriceAdjustmentKind[];
   parameters?: {
-    [k: string]: unknown | undefined;
   };
   event_type?: EventType;
   custom_event_name?: string;
@@ -10586,11 +8604,8 @@ export type CanonicalPricingOption = {
  * Compact immutable audience-evidence snapshot for product discovery. Provider identity is a BrandKey; credential and brand-asset graphs are resolved separately.
  */
 export type CanonicalAudienceEvidence = {
-  [k: string]: unknown | undefined;
 } & {
-  [k: string]: unknown | undefined;
 } & {
-  [k: string]: unknown | undefined;
 } & {
   evidence_id: string;
   snapshot_id: string;
@@ -10700,10 +8715,8 @@ export interface CanonicalProduct {
    */
   publisher_properties?: [
     PublisherPropertySelector & {
-      [k: string]: unknown | undefined;
     },
     ...(PublisherPropertySelector & {
-      [k: string]: unknown | undefined;
     })[]
   ];
   channels?: MediaChannel[];
@@ -10822,7 +8835,6 @@ export interface CanonicalForecastVendorMetricValue {
   unit?: string;
   measurable_impressions?: ForecastRange | undefined;
   breakdown?: {
-    [k: string]: unknown | undefined;
   };
 }
 /**
@@ -10924,7 +8936,6 @@ export interface CanonicalProductAction {
  * Buyer-supplied context for one planning cycle across proposal request, decline, and media-buy creation. The opaque opportunity_id is stable within the seller and account scope; sellers associate it with proposals without treating it as proposal identity.
  */
 export type OpportunityContext = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Opaque buyer-assigned identifier for this planning cycle, scoped to the seller and account.
@@ -11066,7 +9077,6 @@ export type RequestProposalsResponse = (
  * Compact immutable proposal for the AdCP 3.2 lifecycle. commercial_terms is the sole authoritative commercial envelope; narrative fields do not duplicate legacy allocation or creative graphs.
  */
 export type CanonicalProposal = {
-  [k: string]: unknown | undefined;
 } & {
   proposal_id: string;
   proposal_kind: 'new_media_buy' | 'media_buy_update' | 'media_buy_cancellation';
@@ -11100,7 +9110,6 @@ export type CanonicalProposal = {
  * Buyer-authored execution policy for automatic delivery, auction bidding, average outcome cost, or return on ad spend. The containing object determines authored scope: media-buy `bidding` is a complete inherited default and package `bidding` is a complete package override. Sellers MUST preserve authored scope on readback and MUST NOT copy an inherited media-buy policy into package `bidding`. Every monetary field in this block is denominated in the media-buy currency; the selected pricing option supplies the auction unit, never another denomination. Auction-unit identity is the pricing_model plus every canonical billing-event qualifier after defaults are applied: for example CPV view threshold, CPP demographic system/demographic, CPA event tuple, time time_unit, and flat-rate/DOOH parameters. An extension qualifier participates only when its registered extension specification explicitly defines how it contributes to auction-unit identity. A media-buy bid_amount or max_bid is valid only when every inheriting package resolves the same auction-unit identity. Every affected pricing option MUST use the media-buy currency; split currency-mismatched packages into separate buys. Seller-optimized media-buy cost_per/roas bind to the primary budget_allocation.optimization_goals goal. Package-authored cost_per/roas bind to the package primary optimization goal. The primary goal is the earliest array entry among goals with the lowest explicit numeric priority; unprioritized goals follow explicitly prioritized goals; when all priorities are absent, the first entry is primary. In fixed allocation, an inherited media-buy cost_per is valid only when all inheriting packages have compatible primary-goal result units; inherited roas requires value-bearing primary goals on every inheriting package. Canonical ROAS requires each value-bearing event source to declare the media-buy currency in value_currencies; each buy consumes only exact-currency records and sellers MUST NOT convert them. Absence invokes inheritance or provider automatic delivery; `{automatic:true}` is an explicit authored policy that overrides inheritance. Sellers MUST reject unsupported modes, combinations, units, currency, goal bindings, or native placements before any provider mutation and MUST NOT silently translate semantics.
  */
 export type BiddingPolicy = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Explicitly use seller/provider automatic bidding at this authored scope. At package scope this is a complete override of a media-buy policy, not inheritance. It MUST be the only field in the block and MUST be preserved on readback.
@@ -11160,10 +9169,8 @@ export type CanonicalOptimizationGoal =
       reach_unit?: ReachUnit;
       target_frequency?:
         | {
-            [k: string]: unknown | undefined;
           }
         | {
-            [k: string]: unknown | undefined;
           };
       view_duration_seconds?: number;
       target?: {
@@ -11254,7 +9261,6 @@ export interface CompactTaskSubmitted {
   errors?: Error[];
   context?: ContextObject;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 /**
  * Complete typed commercial envelope for a compact-lifecycle proposal. This is the authoritative audit and refinement snapshot; allocations and narrative fields are explanatory views rather than substitutes for these terms.
@@ -11277,10 +9283,8 @@ export interface CommercialTerms {
    */
   purchases: [
     ProductPurchase & {
-      [k: string]: unknown | undefined;
     },
     ...(ProductPurchase & {
-      [k: string]: unknown | undefined;
     })[]
   ];
   start_time: StartTiming;
@@ -11456,7 +9460,6 @@ export type ProposalRefinement = {
      * Hard flight-window bounds checked against commercial_terms.start_time and end_time. start_no_later_than is satisfied only by a concrete start_time at or before the bound; an asap start is unverifiable and therefore unsatisfied. end_no_earlier_than is satisfied only by an end_time at or after the bound.
      */
     flight?: {
-      [k: string]: unknown | undefined;
     };
   };
   product_changes?: ProductChangeMap;
@@ -11480,7 +9483,6 @@ export type ProposalRefinement = {
     }
   | (
       | {
-          [k: string]: unknown | undefined;
         }
       | {
           change_kind: 'cancellation';
@@ -11491,7 +9493,6 @@ export type ProposalRefinement = {
  * Inclusive bounds checked against commercial_terms.total_budget. Satisfied only when commercial_terms.total_budget is present, its currency matches, and its amount falls within every supplied bound.
  */
 export type ProposalBudgetConstraint = {
-  [k: string]: unknown | undefined;
 } & {
   min?: number;
   max?: number;
@@ -11653,7 +9654,6 @@ export type RefineProposalsResponse = (
  * Terminal buyer feedback for one immutable proposal snapshot.
  */
 export type ProposalDecline = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Immutable proposal ID returned by request_proposals or refine_proposals.
@@ -11880,7 +9880,6 @@ export interface ReportingWebhook {
    * Optional list of metrics to include in webhook notifications. If omitted, all available metrics are included. Must be subset of product's available_metrics.
    */
   requested_metrics?: AvailableMetric[];
-  [k: string]: unknown | undefined;
 }
 
 // buy_products response
@@ -11953,9 +9952,7 @@ export type CanonicalMediaBuyAction =
  * A non-blocking observation returned with a successful operation. The operation succeeded exactly as its success arm states. Warnings are immediate receipts, not durable lifecycle state; a continuing condition MUST also appear on its authoritative read surface as an indicator, defect, delivery issue, approval state, or other applicable resource state.
  */
 export type Warning = {
-  [k: string]: unknown | undefined;
 } & {
-  [k: string]: unknown | undefined;
 } & {
   code: WarningCode;
   /**
@@ -11967,10 +9964,8 @@ export type Warning = {
    * Optional seller-specific structured diagnostics. AdCP 3.2 defines interoperability through code and affected_resource only; buyers MUST NOT require portable keys inside details. Seller extensions that are not direct diagnostics belong in ext.
    */
   details?: {
-    [k: string]: unknown | undefined;
   };
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 };
 export interface CommittedMediaBuy {
   status: 'completed';
@@ -12138,7 +10133,6 @@ export type AcceptProposalResponse = MediaBuyCommitmentResponse;
  * Operational controls for an existing package that remain inside its accepted commercial envelope. targeting_overlay is a complete replacement; keyword add/remove arrays are incremental, and the same keyword MUST NOT appear in both directions. Creative mutation, flight changes, new products, pricing changes, and billing-term changes require their dedicated lifecycle or a refined proposal.
  */
 export type PackageControl = {
-  [k: string]: unknown | undefined;
 } & {
   package_id: string;
   budget?: number | null;
@@ -12402,7 +10396,6 @@ export interface ListCreativeFormatsRequest {
  * **DEPRECATED in 3.2.** Legacy named-format definition retained for older 3.x peers and list_creative_formats compatibility projections. New products and creative agents author ProductFormatDeclaration canonical contracts instead.
  */
 export type Format = {
-  [k: string]: unknown | undefined;
 } & {
   format_id: FormatReferenceStructuredObject;
   /**
@@ -12429,7 +10422,6 @@ export type Format = {
   renders?: [
     (
       | {
-          [k: string]: unknown | undefined;
         }
       | {
           parameters_from_format_id: true;
@@ -12437,7 +10429,6 @@ export type Format = {
     ),
     ...(
       | {
-          [k: string]: unknown | undefined;
         }
       | {
           parameters_from_format_id: true;
@@ -12471,7 +10462,6 @@ export type Format = {
    * Delivery method specifications (e.g., hosted, VAST, third-party tags)
    */
   delivery?: {
-    [k: string]: unknown | undefined;
   };
   /**
    * List of universal macros supported by this format (e.g., MEDIA_BUY_ID, CACHEBUSTER, DEVICE_ID). Used for validation and developer tooling. See docs/creative/universal-macros.mdx for full documentation.
@@ -12504,9 +10494,7 @@ export type Format = {
      * Asset manifest for rendering the card, structure defined by the format
      */
     manifest: {
-      [k: string]: unknown | undefined;
     };
-    [k: string]: unknown | undefined;
   };
   /**
    * Accessibility posture of this format. Declares the WCAG conformance level that creatives produced by this format will meet.
@@ -12538,7 +10526,6 @@ export type Format = {
        * @minItems 1
        */
       persistence: [DisclosurePersistence, ...DisclosurePersistence[]];
-      [k: string]: unknown | undefined;
     },
     ...{
       position: DisclosurePosition;
@@ -12548,7 +10535,6 @@ export type Format = {
        * @minItems 1
        */
       persistence: [DisclosurePersistence, ...DisclosurePersistence[]];
-      [k: string]: unknown | undefined;
     }[]
   ];
   /**
@@ -12560,9 +10546,7 @@ export type Format = {
      * Asset manifest for rendering the detailed card, structure defined by the format
      */
     manifest: {
-      [k: string]: unknown | undefined;
     };
-    [k: string]: unknown | undefined;
   };
   /**
    * Metrics this format can produce in delivery reporting. Buyers receive the intersection of format reported_metrics and product available_metrics. If omitted, the format defers entirely to product-level metric declarations.
@@ -12583,7 +10567,6 @@ export type Format = {
   pricing_options?: [VendorPricingOption, ...VendorPricingOption[]];
   canonical?: CanonicalProjectionReference;
   canonical_parameters?: ProductFormatDeclaration;
-  [k: string]: unknown | undefined;
 };
 /**
  * Image asset
@@ -13031,7 +11014,6 @@ export interface CanonicalProjectionReference {
    * @minItems 1
    */
   slots_override?: [CanonicalProjectionSlotOverride, ...CanonicalProjectionSlotOverride[]];
-  [k: string]: unknown | undefined;
 }
 /**
  * A single slot override used when projecting a legacy named format to a v2 canonical ProductFormatDeclaration. The override replaces the canonical format's default slot with an asset-group-vocabulary entry.
@@ -13057,7 +11039,6 @@ export interface CanonicalProjectionSlotOverride {
    * When false, slot is for moderation/review only and is NOT consumed by the seller's renderer (e.g., a brand-safety brief that informs review but doesn't appear in the rendered ad).
    */
   consumed_for_production?: boolean;
-  [k: string]: unknown | undefined;
 }
 
 // create_media_buy parameters
@@ -13251,7 +11232,6 @@ export type CreateMediaBuyRequest = (
  * Package configuration for media buy creation
  */
 export type PackageRequest = AdCPVersionEnvelope & {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Opaque configured product ID returned by get_products. Selecting it accepts the product's disclosed targeting_resolution, pricing, forecast assumptions, and terms. Sellers MUST echo this value on every response package object that represents this requested package.
@@ -13275,7 +11255,6 @@ export type PackageRequest = AdCPVersionEnvelope & {
    * Parameters for the direct canonical selector in `format_kind`. Shape follows the selected canonical's parameter vocabulary: dimensions (`width`, `height`, `sizes`), duration (`duration_ms_exact`, `duration_ms_range`), codecs, asset-source and slot narrowing, or other canonical-specific constraints. Omit when selecting by `format_option_refs` or `format_ids`; those selectors resolve their parameters from the product declaration or legacy catalog projection.
    */
   params?: {
-    [k: string]: unknown | undefined;
   };
   /**
    * Hard lifetime spend cap for this package in the media buy's currency. Required in fixed allocation mode. Optional in seller-optimized mode; when omitted, the package is bounded by the shared total_budget and any other package constraints. In seller-optimized mode this is a ceiling, not a reserved or current allocation.
@@ -13419,10 +11398,8 @@ export type PackageRequest = AdCPVersionEnvelope & {
    */
   creatives?: [
     CreativeAsset & {
-      [k: string]: unknown | undefined;
     },
     ...(CreativeAsset & {
-      [k: string]: unknown | undefined;
     })[]
   ];
   /**
@@ -13431,17 +11408,13 @@ export type PackageRequest = AdCPVersionEnvelope & {
   agency_estimate_number?: string;
   context?: ContextObject;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 };
 /**
  * Assignment of a creative asset to a package with optional rotation and placement routing. Used in create_media_buy and update_media_buy requests. Buyers identify the stored creative with `creative_id` only. A generic `id` alias, if present due to adapter-internal payload reuse, is not an AdCP identifier and sellers MUST ignore it on input. Note: sync_creatives does not support package rotation, placement_refs, or placement_ids - use create/update_media_buy for package-level trafficking controls.
  */
 export type CreativeAssignment = {
-  [k: string]: unknown | undefined;
 } & {
-  [k: string]: unknown | undefined;
 } & {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Unique identifier for the creative
@@ -13476,7 +11449,6 @@ export type CreativeAssignment = {
    * @minItems 1
    */
   placement_ids?: [string, ...string[]];
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Unique identifier for the creative
@@ -13511,7 +11483,6 @@ export type CreativeAssignment = {
    * @minItems 1
    */
   placement_ids?: [string, ...string[]];
-  [k: string]: unknown | undefined;
 };
 /**
  * VAST (Video Ad Serving Template) tag for third-party video ad serving. Unlike the hosted `video` asset, a VAST tag carries no `width`/`height`: a VAST response can return multiple renditions of differing dimensions, and the player selects one per device at serve time, so there is no single width/height for the ad. Dimensional, duration, and codec *constraints* for a placement live on the format/requirements layer, not on this asset.
@@ -13543,7 +11514,6 @@ export type VASTAsset = {
    */
   audio_description_url?: string;
   provenance?: Provenance;
-  [k: string]: unknown | undefined;
 } & (
   | {
       /**
@@ -13592,7 +11562,6 @@ export type DAASTAsset = {
    */
   transcript_url?: string;
   provenance?: Provenance;
-  [k: string]: unknown | undefined;
 } & (
   | {
       /**
@@ -13638,10 +11607,8 @@ export type CatalogAsset = Catalog & {
  */
 export type PublishedPostAsset = (
   | {
-      [k: string]: unknown | undefined;
     }
   | {
-      [k: string]: unknown | undefined;
     }
 ) & {
   /**
@@ -13676,7 +11643,6 @@ export type PublishedPostAsset = (
      * Opaque platform-native identity identifier.
      */
     platform_identity_id?: string;
-    [k: string]: unknown | undefined;
   };
   /**
    * When the referenced post was originally published, if known.
@@ -13706,10 +11672,8 @@ export type PublishedPostAsset = (
      * Human-readable instructions for completing or restoring authorization.
      */
     authorization_instructions?: string;
-    [k: string]: unknown | undefined;
   };
   provenance?: Provenance;
-  [k: string]: unknown | undefined;
 };
 /**
  * A single renderer-fired HTTP tracker URL — image pixel or JavaScript include — bound to a measurement event (impression, viewability, click, custom). Generic web-pixel tracker primitive applicable to any web-rendered canonical format (image, html5, image_carousel, responsive_creative, sponsored_placement, native_*, plus the non-VAST/DAAST events of video_hosted and audio_hosted). The buyer's measurement vendor declares the tracker URL; the seller's renderer fires it at serve time without buyer-side involvement.
@@ -13756,7 +11720,6 @@ export type PublishedPostAsset = (
  * All v1→v2 upgrades surface `PIXEL_TRACKER_UPGRADE_INFERRED` so consumers can see that event/method were inferred rather than explicitly declared.
  */
 export type PixelTrackerAsset = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Discriminator identifying this as a renderer-fired pixel tracker asset. See /schemas/creative/asset-types for the registry.
@@ -13797,13 +11760,11 @@ export type PixelTrackerAsset = {
    */
   custom_event_name?: string;
   provenance?: Provenance;
-  [k: string]: unknown | undefined;
 };
 /**
  * A single tracker URL bound to a VAST `TrackingEvents` event. Emitted by the creative agent as a decomposed VAST-event URL; the sales agent assembles these into the VAST `TrackingEvents` block at serve time. IMPORTANT: this asset type is for `TrackingEvents` URLs only (start, quartiles, complete, pause, mute, etc.). The `Impression` URL MUST be modeled as a `url` asset with `url_type: "tracker_pixel"`, not as a vast_tracker with `vast_event: "impression"`. Decomposed trackers let format requirements bind specific measurement events (e.g., MRC viewable) without forcing the buyer to construct a full VAST tag.
  */
 export type VASTTrackerAsset = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Discriminator identifying this as a VAST tracker asset. See /schemas/creative/asset-types for the registry.
@@ -13813,7 +11774,6 @@ export type VASTTrackerAsset = {
    * The VAST tracking event this URL fires on. Maps 1:1 to the VAST `Tracking event="..."` attribute inside `TrackingEvents`. MUST NOT be `impression` (belongs in the VAST `Impression` element — model as a `url` asset with `url_type: "tracker_pixel"`), `clickTracking` / `customClick` (belong in `VideoClicks`), `error` (VAST `Error` element), or any of `viewable` / `notViewable` / `viewUndetermined` / `measurableImpression` / `viewableImpression` (children of the VAST `ViewableImpression` element, not `TrackingEvents`).
    */
   vast_event: VASTTrackingEvent & {
-    [k: string]: unknown | undefined;
   };
   /**
    * Tracker URL that fires when `vast_event` occurs. May carry AdCP universal macros (e.g., `{SKU}`, `{MEDIA_BUY_ID}`); the sales agent or ad server URL-encodes substituted values at serve time. See docs/creative/universal-macros.mdx.
@@ -13828,13 +11788,11 @@ export type VASTTrackerAsset = {
    */
   target?: 'linear' | 'non_linear' | 'companion';
   provenance?: Provenance;
-  [k: string]: unknown | undefined;
 };
 /**
  * A single tracker URL bound to a DAAST `TrackingEvents` event. Audio-side analogue of vast-tracker-asset. The `Impression` URL MUST be modeled as a `url` asset with `url_type: "tracker_pixel"`, not as a daast_tracker with `daast_event: "impression"`.
  */
 export type DAASTTrackerAsset = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Discriminator identifying this as a DAAST tracker asset. See /schemas/creative/asset-types for the registry.
@@ -13844,7 +11802,6 @@ export type DAASTTrackerAsset = {
    * The DAAST tracking event this URL fires on. MUST NOT be `impression` (model as `url` asset with `url_type: "tracker_pixel"`), `clickTracking` / `customClick` (click-tracking trackers go on their own URL asset), `error`, or any of the `ViewableImpression`-element children (`viewable`, `notViewable`, `viewUndetermined`, `measurableImpression`, `viewableImpression`).
    */
   daast_event: DAASTTrackingEvent & {
-    [k: string]: unknown | undefined;
   };
   /**
    * Tracker URL that fires when `daast_event` occurs. May carry AdCP universal macros; the sales agent or ad server URL-encodes substituted values at serve time. See docs/creative/universal-macros.mdx.
@@ -13859,14 +11816,12 @@ export type DAASTTrackerAsset = {
    */
   target?: 'linear' | 'companion';
   provenance?: Provenance;
-  [k: string]: unknown | undefined;
 };
 export interface ExplicitPackagesWithFixedAllocation {
   budget_allocation?: {
     mode: 'fixed';
   };
   packages: (PackageRequest & {
-    [k: string]: unknown | undefined;
   })[];
 }
 /**
@@ -13923,7 +11878,6 @@ export interface AudioAsset {
    */
   transcript_url?: string;
   provenance?: Provenance;
-  [k: string]: unknown | undefined;
 }
 /**
  * Text content asset
@@ -13942,7 +11896,6 @@ export interface TextAsset {
    */
   language?: string;
   provenance?: Provenance;
-  [k: string]: unknown | undefined;
 }
 /**
  * Inline HTML content asset. For URL-delivered HTML5 banner bundles, use the zip asset type instead. For single-URL iframe-rendered tag references, use the url asset type with an appropriate url_type.
@@ -13982,7 +11935,6 @@ export interface HTMLAsset {
     screen_reader_tested?: boolean;
   };
   provenance?: Provenance;
-  [k: string]: unknown | undefined;
 }
 /**
  * Inline JavaScript content asset. For URL-delivered third-party tag scripts, use the url asset type with url_type 'tracker_script'. For HTML5 banner bundles that include JavaScript, use the zip asset type.
@@ -14019,7 +11971,6 @@ export interface JavaScriptAsset {
     screen_reader_tested?: boolean;
   };
   provenance?: Provenance;
-  [k: string]: unknown | undefined;
 }
 /**
  * Bundled creative asset delivered as a zip archive — typically an HTML5 banner with index.html plus supporting CSS, JS, images, and fonts. Receivers unpack the zip, validate internal structure, and serve contents from CDN. Distinct from inline HTML (html asset) and from third-party tag URLs (url asset with url_type tracker_script).
@@ -14075,7 +12026,6 @@ export interface ZipAsset {
     screen_reader_tested?: boolean;
   };
   provenance?: Provenance;
-  [k: string]: unknown | undefined;
 }
 /**
  * Webhook for server-side dynamic content rendering (DCO)
@@ -14118,7 +12068,6 @@ export interface WebhookAsset {
     api_key_header?: string;
   };
   provenance?: Provenance;
-  [k: string]: unknown | undefined;
 }
 /**
  * CSS stylesheet asset
@@ -14137,7 +12086,6 @@ export interface CSSAsset {
    */
   media?: string;
   provenance?: Provenance;
-  [k: string]: unknown | undefined;
 }
 /**
  * A reference asset that provides creative context. Carries visual materials (mood boards, product shots, example creatives) with semantic roles that tell creative agents how to use them.
@@ -14155,7 +12103,6 @@ export interface ReferenceAsset {
    * Human-readable description of the asset and how it should inform creative generation
    */
   description?: string;
-  [k: string]: unknown | undefined;
 }
 /**
  * A single card in a multi-card creative (image_carousel, future composed carousels). Carries: `media` (an image OR video asset), optional `headline` (short text), optional `description` (longer text), optional `cta` (call-to-action label), optional `landing_page_url` (url asset with `url_type: "clickthrough"`).
@@ -14191,7 +12138,6 @@ export interface CardAsset {
    */
   platform_extensions?: PlatformExtensionReference[];
   provenance?: Provenance;
-  [k: string]: unknown | undefined;
 }
 /**
  * An industry-standard or market-specific identifier for an advertising creative (e.g., Ad-ID, ISCI, Clearcast clock number, IDcrea). These identifiers are managed by external registries or clearance bodies and used across the supply chain to track and reference specific creative assets. Add a PR to extend creative-identifier-type when another shared identifier scheme needs first-class support.
@@ -14202,20 +12148,17 @@ export interface IndustryIdentifier {
    * The identifier value (e.g., 'ABCD1234000H' for Ad-ID). Preserve the value exactly as the traffic or clearance system expects it.
    */
   value: string;
-  [k: string]: unknown | undefined;
 }
 /**
  * @deprecated
  * Deprecated 3.x compatibility branch using a structured named-format reference.
  */
 export interface V1CreativeNamedFormatReference {
-  [k: string]: unknown | undefined;
 }
 /**
  * Creative declares the portable canonical contract it targets via `format_kind` and optional `format_option_ref`.
  */
 export interface V2CreativeCanonicalFormatKind {
-  [k: string]: unknown | undefined;
 }
 export interface ExplicitPackagesWithSellerOptimizedAllocation {
   budget_allocation: {
@@ -14223,7 +12166,6 @@ export interface ExplicitPackagesWithSellerOptimizedAllocation {
   };
 }
 export interface CommittedProposalExecution {
-  [k: string]: unknown | undefined;
 }
 
 // create_media_buy response
@@ -14285,7 +12227,6 @@ export type AccountIdentityChange = AccountIdentityChangePending | AccountIdenti
  * Account-level webhook subscription for notifications whose lifecycle outlives any single media buy — creative state changes, library purges, account status changes, wholesale feed change webhooks, and future account-anchored resource events after those event types are added to this schema. This is distinct from `push-notification-config.json`, which anchors at a per-resource operation (a single task or media buy). The one-shot `sync_accounts.push_notification_config` channel may report the first async result of a provisioning request, while durable account lifecycle events such as later `payment_required` or `suspended` transitions use `account.status_changed` here. An account MAY register multiple notification configs to fan a single seller's events out to multiple buyer-side endpoints; each entry filters by `event_types`. As with push-notification-config, the default signing scheme is the AdCP RFC 9421 webhook profile against the seller's brand.json `agents[]` JWKS; the optional `authentication` block opts into the deprecated Bearer / HMAC-SHA256 fallback for compatibility. Credentials and shared secrets in `authentication.credentials` are write-only — sellers MUST NOT echo them back in `list_accounts` responses. Sellers MUST verify endpoint control before activating a new or changed active account-level notification config; delivery-time SSRF validation still applies to every fire.
  */
 export type NotificationConfig = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Buyer-supplied identifier for this subscription endpoint. This is the stable logical key within one account's notification_configs[] set: re-sending the same subscriber_id for the same account replaces that subscriber's URL, event_types, authentication selector, and active flag rather than creating a duplicate. Echoed on every webhook payload and on every `webhook_activity[]` record fired against this config so the buyer can attribute fires across multiple endpoints. MUST be unique within the account's `notification_configs[]`. Sending two entries with the same `subscriber_id` in a single `sync_accounts` request array is rejected as a per-account validation failure with `INVALID_REQUEST` or `VALIDATION_ERROR`, and `error.field` MUST point at the duplicate entry. `subscriber_id` is the stable match key for the per-account declarative-replace diff. Always required (even with a single subscriber) so the SDK contract is uniform — no conditional required-when-multiple rules to trip up implementations. Format is opaque — recommended values are short kebab-case slugs (`buyer-primary`, `audit-bus`, `dx-team`).
@@ -15443,7 +13384,6 @@ export type NotificationConfig = {
  * A specific product within a media buy (line item)
  */
 export type Package = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Seller's unique identifier for the package
@@ -15510,7 +13450,6 @@ export type Package = {
    * Parameters for the direct canonical selector in `format_kind`, echoed from the create_media_buy request whenever the request included it. Requires `format_kind`; omitted only when the request did not carry direct canonical params or when the seller cannot reconstruct legacy requests created before this field was persisted.
    */
   params?: {
-    [k: string]: unknown | undefined;
   };
   targeting_overlay?: TargetingOverlay;
   targeting_resolution?: PackageTargetingResolution;
@@ -15601,13 +13540,11 @@ export type Package = {
   creative_deadline?: string;
   context?: ContextObject;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 };
 /**
  * Canonical demographic predicate and exact seller execution details. Include whenever demographic targeting was requested or applied.
  */
 export type DemographicTargetingResolution = {
-  [k: string]: unknown | undefined;
 } & {
   requested: DemographicTargetingIntent;
   applied: DemographicPredicate;
@@ -15619,7 +13556,6 @@ export type DemographicTargetingResolution = {
     | {
         type: 'continuous_bounds';
         ext?: ExtensionObject;
-        [k: string]: unknown | undefined;
       }
     | {
         type: 'enumerated_intervals';
@@ -15630,7 +13566,6 @@ export type DemographicTargetingResolution = {
          */
         interval_ids: [string, ...string[]];
         ext?: ExtensionObject;
-        [k: string]: unknown | undefined;
       }
     | {
         type: 'signals';
@@ -15641,7 +13576,6 @@ export type DemographicTargetingResolution = {
          */
         signal_refs: [SignalRef, ...SignalRef[]];
         ext?: ExtensionObject;
-        [k: string]: unknown | undefined;
       };
   /**
    * Effective user-level determination bases configured for this package after intersecting buyer accepted_bases, product supported_bases, and age_restriction. This is an auditable configuration readback, not proof that every impression used every listed basis.
@@ -15656,7 +13590,6 @@ export type DemographicTargetingResolution = {
    */
   applied_verification_methods?: [AgeVerificationMethod, ...AgeVerificationMethod[]];
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 };
 /**
  * One metric in a package's binding reporting contract. Each entry uses `scope` as the discriminator and identifies a standard or vendor-defined metric that the seller has committed to populate in delivery reports.
@@ -15699,7 +13632,6 @@ export type CommittedMetric =
  * The seller's interpreted delivery parameters. Describes what the seller will actually run -- geo, channels, flight dates, frequency caps, and budget. Present when the account has governance_agents or when the seller chooses to provide delivery transparency.
  */
 export type PlannedDelivery = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Seller-assigned media buy identifier. Optional on a purchase-phase prepare/check because the service may not assign the identifier until commit; required on modification and delivery lifecycle checks.
@@ -15725,7 +13657,6 @@ export type PlannedDelivery = {
      * ISO 3166-2 subdivision codes where ads will deliver.
      */
     regions?: string[];
-    [k: string]: unknown | undefined;
   };
   /**
    * Channels the seller will deliver on.
@@ -15780,7 +13711,6 @@ export type PlannedDelivery = {
    */
   enforced_policies?: string[];
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 };
 /**
  * Selects an audience by signal reference or natural language description. Uses 'type' as the primary discriminator (signal vs description). Signal selectors additionally use 'value_type' to determine the targeting expression format (matching signal-targeting.json variants).
@@ -15788,26 +13718,20 @@ export type PlannedDelivery = {
 export type AudienceSelector =
   | (
       | {
-          [k: string]: unknown | undefined;
         }
       | {
-          [k: string]: unknown | undefined;
         }
     )
   | (
       | {
-          [k: string]: unknown | undefined;
         }
       | {
-          [k: string]: unknown | undefined;
         }
     )
   | (
       | {
-          [k: string]: unknown | undefined;
         }
       | {
-          [k: string]: unknown | undefined;
         }
     )
   | {
@@ -15823,7 +13747,6 @@ export type AudienceSelector =
        * Optional grouping hint for the governance agent (e.g., 'demographic', 'behavioral', 'contextual', 'financial')
        */
       category?: string;
-      [k: string]: unknown | undefined;
     };
 /**
  * Success response - media buy created successfully
@@ -15962,7 +13885,6 @@ export interface Account {
    * Request-only staging field. It MUST NOT appear in account read models.
    */
   destination_billing_entity?: {
-    [k: string]: unknown | undefined;
   };
   /**
    * Identifier for the rate card applied to this account
@@ -15992,7 +13914,6 @@ export interface Account {
      * When this setup link expires.
      */
     expires_at?: string;
-    [k: string]: unknown | undefined;
   };
   account_scope?: AccountScope;
   /**
@@ -16209,7 +14130,6 @@ export interface Account {
    */
   webhook_activity?: WebhookActivityRecord[];
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 export interface AccountIdentityChangePending {
   /**
@@ -16994,7 +14914,6 @@ export interface Impairment {
    * Action the buyer can take to clear the impairment, if any. Free text. Absent when no buyer-side remediation is possible (e.g., seller-initiated withdrawal pending re-publication).
    */
   remediation?: string;
-  [k: string]: unknown | undefined;
 }
 /**
  * Current status of a package within a media buy — includes creative approval state and optional delivery snapshot. For the creation input shape, see PackageRequest. For the creation output shape, see Package.
@@ -18016,7 +15935,6 @@ export interface VendorMetricValue {
    * Optional structured payload for vendor metrics that don't fit a single scalar — panel demographic breakouts, co-view audience composition, incremental reach + frequency + lift decompositions. Free-form; the keys and value semantics are defined by the vendor (see the vendor's `brand.json` measurement-agent docs). Buyers MUST treat this object as opaque without consulting the vendor's documentation. Vendors place any fields beyond the standard envelope (e.g., confidence intervals, panel sizes) inside this object rather than at the top level.
    */
   breakdown?: {
-    [k: string]: unknown | undefined;
   };
 }
 
@@ -18144,7 +16062,6 @@ export interface DatetimeRange {
    * End timestamp (inclusive), ISO 8601
    */
   end: string;
-  [k: string]: unknown | undefined;
 }
 
 // provide_performance_feedback response
@@ -18336,7 +16253,6 @@ export interface EventSurface {
    */
   property_id?: string;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 
 // sync_event_sources response
@@ -18480,7 +16396,6 @@ export interface EventSourceHealth {
      * Seller's name for this score (e.g., 'Event Quality Score', 'Event Match Quality').
      */
     label?: string;
-    [k: string]: unknown | undefined;
   };
   /**
    * Fraction of events from this source that the seller successfully matched to ad interactions (0.0-1.0). Low match rates indicate weak user_match identifiers. Absent when the seller does not compute match rates.
@@ -18502,7 +16417,6 @@ export interface EventSourceHealth {
    * Actionable issues detected with this event source. Sellers should limit to the top 3-5 most actionable items. Buyer agents should sort by severity rather than relying on array position.
    */
   issues?: DiagnosticIssue[];
-  [k: string]: unknown | undefined;
 }
 /**
  * Error response - operation failed completely
@@ -18522,7 +16436,6 @@ export interface SyncEventSourcesError {
  * A marketing event (conversion, engagement, or custom) for attribution and optimization
  */
 export type Event = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Unique identifier for deduplication (scoped to event_type + event_source_id)
@@ -18546,13 +16459,11 @@ export type Event = {
    */
   custom_event_name?: string;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 };
 /**
  * User identifiers for attribution matching
  */
 export type UserMatch = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Universal ID values for user matching
@@ -18566,7 +16477,6 @@ export type UserMatch = {
        * Universal ID value
        */
       value: string;
-      [k: string]: unknown | undefined;
     },
     ...{
       type: UIDType;
@@ -18574,7 +16484,6 @@ export type UserMatch = {
        * Universal ID value
        */
       value: string;
-      [k: string]: unknown | undefined;
     }[]
   ];
   /**
@@ -18602,7 +16511,6 @@ export type UserMatch = {
    */
   client_user_agent?: string;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 };
 /**
  * Request parameters for logging marketing events
@@ -18707,10 +16615,8 @@ export interface EventCustomData {
      * Brand name of this item
      */
     brand?: string;
-    [k: string]: unknown | undefined;
   }[];
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 
 // log_event response
@@ -18829,7 +16735,6 @@ export interface LogEventError {
  * A CRM audience member identified by a buyer-assigned external_id and at least one matchable identifier. All identifiers must be normalized before hashing: emails to lowercase+trim, phone numbers to E.164 format (e.g. +12065551234). Providing multiple identifiers for the same person improves match rates. Composite identifiers (e.g. hashed first name + last name + zip for Google Customer Match) are not yet standardized — use the ext field for platform-specific extensions.
  */
 export type AudienceMember = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Buyer-assigned stable identifier for this audience member (e.g. CRM record ID, loyalty ID). Used for deduplication, removal, and cross-referencing with buyer systems. Adapters for CDPs that don't natively assign IDs can derive one (e.g. hash of the member's identifiers).
@@ -18855,7 +16760,6 @@ export type AudienceMember = {
        * Universal ID value
        */
       value: string;
-      [k: string]: unknown | undefined;
     },
     ...{
       type: UIDType;
@@ -18863,11 +16767,9 @@ export type AudienceMember = {
        * Universal ID value
        */
       value: string;
-      [k: string]: unknown | undefined;
     }[]
   ];
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 };
 /**
  * Request parameters for managing CRM-based audiences on an account with upsert semantics. Existing audiences matched by audience_id are updated, new ones are created. Members are specified as delta operations: add appends new members, remove drops existing ones. Recommend no more than 100,000 members per call; for larger lists, chunk and call incrementally using add/remove deltas. When delete_missing is true, buyer-managed audiences on the account not in this request are removed — do not combine with omitted audiences or all buyer-managed audiences will be deleted. When audiences is omitted, the call is discovery-only: it returns all audiences on the account without modification.
@@ -19119,7 +17021,6 @@ export interface SyncAudiencesSubmitted {
  * Request parameters for syncing buyer-managed catalog feeds, pushing immediate item availability overrides, and reading current availability state. Supports bulk operations across multiple catalog types. Existing catalogs matched by catalog_id are updated, new ones are created. When catalogs, item_availability_updates, and item_availability_queries are all omitted, the call is discovery-only.
  */
 export type SyncCatalogsRequest = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Release-precision AdCP version (VERSION.RELEASE, e.g. "3.0", "3.1", "3.1-beta"). On a request: the buyer's release pin — the seller validates against its supported_versions and returns VERSION_UNSUPPORTED on cross-major mismatch, or downshifts to the highest supported release within the same major. On a response: the release the seller actually served — clients SHOULD validate the response against that release's schema, not against their pin. Patches are not negotiated; surface them as build_version on capabilities for operational visibility. When omitted, falls back to adcp_major_version (deprecated) or server default. Buyers SHOULD emit both adcp_version and adcp_major_version through 3.x to remain compatible with sellers that only read the legacy field. NORMALIZATION: SDKs that read full-semver values from bundle metadata (e.g. ComplianceIndex.published_version = "3.1.0-beta.1") MUST normalize to release-precision ("3.1-beta.1") before emitting on the wire — meta-field values are NOT valid wire values.
@@ -19171,7 +17072,6 @@ export type SyncCatalogsRequest = {
  * An immediate buyer-authored availability override for an item in one immutable incarnation of a buyer-managed catalog. This overlay is distinct from seller review status: suppress makes an otherwise approved item ineligible, while restore removes only the buyer suppression and cannot override seller rejection, withdrawal, policy, rights, or inventory decisions. A suppress overlay persists across scheduled feed fetches and catalog upserts until an explicit restore, expires_at, or deletion of the containing catalog.
  */
 export type CatalogItemAvailabilityUpdate = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Buyer-assigned ID of the buyer-managed catalog containing the item.
@@ -19216,7 +17116,6 @@ export type CatalogItemAvailabilityUpdate = {
    */
   expires_at?: string;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 };
 /**
  * Unambiguous reference to an item availability overlay in one immutable incarnation of a buyer-managed catalog.
@@ -19234,7 +17133,6 @@ export interface CatalogItemAvailabilityReference {
    * Exact canonical item key used by Catalog.ids. For typed catalogs this is the type-specific identifier field; for product, inventory, and promotion catalogs it is the stable normalized source identifier retained during ingestion.
    */
   item_id: string;
-  [k: string]: unknown | undefined;
 }
 
 // sync_catalogs response
@@ -19292,7 +17190,6 @@ export type SyncCatalogsResponse = {
  * Seller acknowledgement for one buyer-authored catalog item availability update.
  */
 export type CatalogItemAvailabilityUpdateResult = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Zero-based index of the corresponding item_availability_updates entry.
@@ -19341,19 +17238,16 @@ export type CatalogItemAvailabilityUpdateResult = {
    */
   errors?: [CatalogItemAvailabilityError, ...CatalogItemAvailabilityError[]];
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 };
 /**
  * Error returned by a catalog item availability operation. REFERENCE_NOT_FOUND has a deliberately closed, invariant shape so callers cannot distinguish unknown, inaccessible, unauthorized, or stale-generation references.
  */
 export type CatalogItemAvailabilityError = Error & {
-  [k: string]: unknown | undefined;
 };
 /**
  * Current buyer-authored availability overlay state for one requested catalog item. Results are returned in request order and identify their request position explicitly.
  */
 export type CatalogItemAvailabilityState = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Zero-based index of the corresponding item_availability_queries entry.
@@ -19387,7 +17281,6 @@ export type CatalogItemAvailabilityState = {
    */
   errors?: [CatalogItemAvailabilityError, ...CatalogItemAvailabilityError[]];
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 };
 
 /**
@@ -19535,7 +17428,6 @@ export interface SyncCatalogsSubmitted {
  * Request to transform, generate, refine, or retrieve a creative manifest. Supports four modes: (1) generation from a brief or seed assets, (2) transformation of an existing manifest, (3) refinement of a prior produced variant via refine_from_build_variant_id (re-build with a natural-language message + config delta), (4) retrieval from a creative library by creative_id. Produces target manifest(s) through canonical capabilities advertised in `get_adcp_capabilities.creative.supported_formats[]`. In 3.2, provide `target_capability_id` for one output or `target_capability_ids` for multiple outputs. Legacy `target_format_id` / `target_format_ids` remain accepted during the 3.x compatibility window but are deprecated.
  */
 export type BuildCreativeRequest = {
-  [k: string]: unknown | undefined;
 } & (
   | RefinementWithInheritedTargetCapability
   | CanonicalSingleOutputBuildTarget
@@ -19735,7 +17627,7 @@ export type CreativeManifest = {
    * Each slot value is **either** a single asset object (most slots — image, video, published_post, vast_tag, landing_page_url, etc.) **or** an array of asset objects (slots with `min`/`max` counts on the format declaration — `cards` on `image_carousel`, `headlines` / `descriptions` / `images_landscape` on `responsive_creative`, etc.). Single-vs-array shape is governed by the format's `slots[].min` and `slots[].max` parameters: when `max > 1` (or when the slot is conceptually a pool), the value MUST be an array; when the slot is single-valued, the value MUST be a single object. Each asset value (single or array element) carries an `asset_type` discriminator (image, video, audio, vast, daast, text, markdown, url, html, css, webhook, javascript, brief, catalog, published_post, zip, card) that selects the matching asset schema. Validators with OpenAPI-style discriminator support use `asset_type` to report errors against only the selected branch instead of all branches.
    */
   assets: {
-    [k: string]: unknown | undefined;
+    [k: string]: AssetVariant | AssetVariant[];
   };
   brand?: BrandReference;
   /**
@@ -19748,7 +17640,6 @@ export type CreativeManifest = {
   industry_identifiers?: IndustryIdentifier[];
   provenance?: Provenance;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 } & (NamedFormatManifest | CanonicalFormatManifest);
 /**
  * Optional advisory evaluator (buyer-attached pointer, #5280) declaring how produced variants should be evaluated and ranked — the rank-side of the get_creative_features feature oracle. Experimental (x-status: experimental): the whole evaluator surface is new and unfrozen, and requires creative.supports_evaluator, which sellers MUST pair with `creative.evaluator` in experimental_features. Drives the producing agent's gate-then-rank pipeline over its best_of_n exploration: per leaf, evaluate (the chosen form) → optionally GATE (`evaluator.feature_requirement[]`, drop fails — internal pruning of which leaves the agent recommends, never an AdCP-layer block of an already-produced billable leaf) → RANK survivors (`evaluator.rank_by`, an explicit {feature_id, direction} ordering). Feature discovery uses get_adcp_capabilities governance.creative_features for rank_by, feature_requirement, and eval.features[]; evaluator_id is a pre-provisioned/account-arranged preset, not an ID discovered from that catalog. Populates a per-leaf `eval` block of creative-feature values (creative-feature-result[]) when supports_evaluator. When the evaluator names an external agent (`evaluator.feature_agent.agent_url` or the agent-form `agent_url`), that agent MUST appear in the seller's `creative_policy.accepted_verifiers[]` (the same allowlist #5280 established for provenance verify_agent); an off-list agent is rejected with `EVALUATOR_AGENT_NOT_ACCEPTED`. The outbound evaluator call authenticates on the transport (request signing/JWKS, mTLS, or a pre-provisioned static credential); credentials and caller-supplied trust material MUST NOT appear in evaluator, context, ext, or creative payload fields, and credential- or trust-material keys should be rejected with `CREDENTIAL_IN_ARGS`. With no `feature_requirement`, evaluation is advisory only and does not change what is produced or billed; an unreachable/unknown on-list agent degrades to seller-default ranking (advisory errors[] note), not a failure. Requires creative.supports_evaluator; otherwise ignored.
@@ -19812,10 +17703,8 @@ export type EvaluatorSpec = {
      * Soft cap on wall-clock seconds the evaluation should consume.
      */
     max_seconds?: number;
-    [k: string]: unknown | undefined;
   };
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 } & (
   | {
       /**
@@ -19831,21 +17720,18 @@ export type EvaluatorSpec = {
          */
         fail?: Artifact[];
       };
-      [k: string]: unknown | undefined;
     }
   | {
       /**
        * Account-scoped house evaluator preset selected by the buyer. This id is pre-provisioned/account-arranged, not discovered from get_adcp_capabilities governance.creative_features. That catalog only discovers the feature vocabulary the preset emits. An unknown id degrades to seller-default ranking (advisory errors[] note), not a failure.
        */
       evaluator_id: string;
-      [k: string]: unknown | undefined;
     }
   | {
       /**
        * URL of an external get_creative_features-capable judge agent the seller calls to score the produced leaves. MUST match an entry in the seller's `creative_policy.accepted_verifiers[].agent_url` (off-list → `EVALUATOR_AGENT_NOT_ACCEPTED`); an on-list agent that is unreachable or rejects the producing agent's transport authentication degrades to seller-default ranking (advisory errors[] note), not a failure. Authentication and trust material for this call belongs on the transport or in account provisioning, not in the evaluator payload.
        */
       agent_url: string;
-      [k: string]: unknown | undefined;
     }
 );
 /**
@@ -19870,45 +17756,37 @@ export type AssetAccess =
        * Deprecated in AdCP 3.2 and eligible for removal in 4.0 or later only after the deprecation-policy notice and release-cycle gates are satisfied. Presence denotes the legacy inline-credential form, not workload-identity authorization. New producers MUST omit this field. Consumers MUST NOT activate received credentials automatically; they may process them only for an explicitly allowlisted legacy peer and otherwise MUST reject or quarantine them. Consumers MUST redact the complete value from logs, traces, errors, metrics, analytics, model context, and durable storage. Use the consumer's pre-authorized workload identity or `signed_url` instead.
        */
       credentials?: {
-        [k: string]: unknown | undefined;
       };
     }
   | {
       method: 'signed_url';
     };
 export interface RefinementWithInheritedTargetCapability {
-  [k: string]: unknown | undefined;
 }
 export interface CanonicalSingleOutputBuildTarget {
-  [k: string]: unknown | undefined;
 }
 export interface CanonicalMultiOutputBuildTarget {
-  [k: string]: unknown | undefined;
 }
 /**
  * @deprecated
  */
 export interface SingleOutputNamedFormatTarget {
-  [k: string]: unknown | undefined;
 }
 /**
  * @deprecated
  */
 export interface MultiOutputNamedFormatTarget {
-  [k: string]: unknown | undefined;
 }
 /**
  * @deprecated
  * Deprecated 3.x compatibility branch. Manifest references a named format via the structured format_id object. New 3.2 manifests use format_kind.
  */
 export interface NamedFormatManifest {
-  [k: string]: unknown | undefined;
 }
 /**
  * Manifest declares which canonical format it targets via `format_kind` (e.g., `image`). This 3.1+ canonical-format path was introduced by RFC #3305.
  */
 export interface CanonicalFormatManifest {
-  [k: string]: unknown | undefined;
 }
 /**
  * A feature-based requirement — a reusable predicate over a feature value. Used by property list filters today; designed for reuse in other surfaces (audience filters, creative gates) in future versions. Use min_value/max_value for quantitative features, allowed_values for binary/categorical features.
@@ -20101,19 +17979,16 @@ export interface Artifact {
      * Open Graph protocol metadata
      */
     open_graph?: {
-      [k: string]: unknown | undefined;
     };
     /**
      * Twitter Card metadata
      */
     twitter_card?: {
-      [k: string]: unknown | undefined;
     };
     /**
      * JSON-LD structured data (schema.org)
      */
     json_ld?: {}[];
-    [k: string]: unknown | undefined;
   };
   provenance?: Provenance;
   /**
@@ -20140,9 +18015,7 @@ export interface Artifact {
      * RSS feed URL
      */
     rss_url?: string;
-    [k: string]: unknown | undefined;
   };
-  [k: string]: unknown | undefined;
 }
 /**
  * Response payload for build_creative. Exactly one of six shapes: (1) synchronous single-capability success — creative_manifest issued in-line; (2) synchronous multi-capability success — creative_manifests issued in request order; (3) multiplicity success — creatives[] each carrying variants[]; (4) dry-run estimate; (5) terminal failure; (6) submitted task envelope. Canonical 3.2 requests use target_capability_id(s); deprecated target_format_id(s) retain the same response branches during the 3.x compatibility window.
@@ -20250,7 +18123,6 @@ export type PreviewRender =
          */
         csp_policy?: string;
       };
-      [k: string]: unknown | undefined;
     }
   | {
       /**
@@ -20297,7 +18169,6 @@ export type PreviewRender =
          */
         csp_policy?: string;
       };
-      [k: string]: unknown | undefined;
     }
   | {
       /**
@@ -20348,7 +18219,6 @@ export type PreviewRender =
          */
         csp_policy?: string;
       };
-      [k: string]: unknown | undefined;
     };
 /**
  * Single-capability success response. Returned when the request used target_capability_id (or deprecated target_format_id) without fan-out. The returned creative_manifest uses canonical format_kind on the 3.2 path.
@@ -20457,7 +18327,6 @@ export interface CreativeConsumption {
    * Processing time billed, in seconds. For compute-time pricing models.
    */
   duration_seconds?: number;
-  [k: string]: unknown | undefined;
 }
 /**
  * Multi-capability success response. Returned when the request used target_capability_ids (or deprecated target_format_ids). Contains one manifest per requested capability. Multi-output requests are atomic and preserve request order.
@@ -20740,7 +18609,6 @@ export interface CreativeFeatureResult {
    * Additional vendor-specific details about this evaluation
    */
   details?: {
-    [k: string]: unknown | undefined;
   };
   /**
    * Optional attribution — when this feature was evaluated for the purpose of a specific policy, policy_id references the authorizing PolicyEntry. Creative agents and sellers populate when the measurement was motivated by a specific policy; do NOT populate when the feature is a generic measurement (carbon score, brand consistency) unrelated to any policy. See /docs/governance/policy-attribution.
@@ -20877,7 +18745,6 @@ export interface BuildCreativeSubmitted {
  * Request to generate previews of creative manifests. Uses request_type to select single, batch, or variant mode.
  */
 export type PreviewCreativeRequest = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Release-precision AdCP version (VERSION.RELEASE, e.g. "3.0", "3.1", "3.1-beta"). On a request: the buyer's release pin — the seller validates against its supported_versions and returns VERSION_UNSUPPORTED on cross-major mismatch, or downshifts to the highest supported release within the same major. On a response: the release the seller actually served — clients SHOULD validate the response against that release's schema, not against their pin. Patches are not negotiated; surface them as build_version on capabilities for operational visibility. When omitted, falls back to adcp_major_version (deprecated) or server default. Buyers SHOULD emit both adcp_version and adcp_major_version through 3.x to remain compatible with sellers that only read the legacy field. NORMALIZATION: SDKs that read full-semver values from bundle metadata (e.g. ComplianceIndex.published_version = "3.1.0-beta.1") MUST normalize to release-precision ("3.1-beta.1") before emitting on the wire — meta-field values are NOT valid wire values.
@@ -21286,7 +19153,6 @@ export type Transformer = (CanonicalTransformerOutputs | NamedFormatTransformerO
    * Transformer-specific attributes a buyer can filter or display (e.g. provider, modality, language).
    */
   metadata?: {
-    [k: string]: unknown | undefined;
   };
   /**
    * Optional discovery/audit anchors for voice transformers provisioned from brand-agent voice_synthesis entries. Informational only: these references help buyers match a discovered transformer to brand/rights-agent provenance, but they do not assert build-time authorization or require the creative agent to perform rights-token validation.
@@ -21307,7 +19173,6 @@ export type Transformer = (CanonicalTransformerOutputs | NamedFormatTransformerO
          * Agent identifier.
          */
         id: string;
-        [k: string]: unknown | undefined;
       };
       /**
        * voice_synthesis.voice_id from the brand agent.
@@ -21317,7 +19182,6 @@ export type Transformer = (CanonicalTransformerOutputs | NamedFormatTransformerO
        * Optional rights offering or buyer-specific grant identifier associated with this provisioned voice. Brand-side voice_synthesis uses rights_offering_id for the configuration-time offering anchor. This transformer field may carry that offering ID or a grant ID after provisioning; it remains provenance metadata only, not a build_creative rights token.
        */
       rights_id?: string;
-      [k: string]: unknown | undefined;
     },
     ...{
       /**
@@ -21332,7 +19196,6 @@ export type Transformer = (CanonicalTransformerOutputs | NamedFormatTransformerO
          * Agent identifier.
          */
         id: string;
-        [k: string]: unknown | undefined;
       };
       /**
        * voice_synthesis.voice_id from the brand agent.
@@ -21342,7 +19205,6 @@ export type Transformer = (CanonicalTransformerOutputs | NamedFormatTransformerO
        * Optional rights offering or buyer-specific grant identifier associated with this provisioned voice. Brand-side voice_synthesis uses rights_offering_id for the configuration-time offering anchor. This transformer field may carry that offering ID or a grant ID after provisioning; it remains provenance metadata only, not a build_creative rights token.
        */
       rights_id?: string;
-      [k: string]: unknown | undefined;
     }[]
   ];
   /**
@@ -21403,15 +19265,12 @@ export type Transformer = (CanonicalTransformerOutputs | NamedFormatTransformerO
      * Variant axis dimensions this transformer supports (⊆ the agent's).
      */
     variant_dimensions?: ('voice' | 'theme' | 'best_of_n' | 'transformer_config' | 'custom')[];
-    [k: string]: unknown | undefined;
   };
-  [k: string]: unknown | undefined;
 };
 /**
  * Descriptor for one configuration knob a transformer exposes. Returned inside transformer.json `params[]` from list_transformers. The descriptor declares the knob's shape; the buyer supplies its value in build_creative `config` keyed by `field`. For `value_source: enumerable` params (e.g. account-specific voices), the legal `options[]` are account-scoped and dynamic — they are returned only when the param's `field` is named in the list_transformers `expand_params` request, and may be paginated via `options_cursor`.
  */
 export type TransformerParam = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * The config key. Buyers set the value under this exact key in build_creative `config`.
@@ -21451,7 +19310,6 @@ export type TransformerParam = {
      * The value the buyer passes in `config` for this field.
      */
     value: {
-      [k: string]: unknown | undefined;
     };
     /**
      * Human-readable label for this option.
@@ -21461,9 +19319,7 @@ export type TransformerParam = {
      * Option-specific attributes the buyer can filter or display (e.g. for a voice: language, gender, provider, custom).
      */
     metadata?: {
-      [k: string]: unknown | undefined;
     };
-    [k: string]: unknown | undefined;
   }[];
   /**
    * Opaque pagination cursor for this param's `options[]`. Present when more option values are available than were returned. Pass back to list_transformers (scoped to this transformer + field) to fetch the next page.
@@ -21473,7 +19329,6 @@ export type TransformerParam = {
    * The value applied when the buyer omits this field from `config`. Type matches `type`.
    */
   default?: {
-    [k: string]: unknown | undefined;
   };
   /**
    * Whether the buyer MUST supply this field in `config`. When false and no `default` is declared, the agent chooses.
@@ -21483,7 +19338,6 @@ export type TransformerParam = {
    * Human-readable explanation of what this knob does.
    */
   description?: string;
-  [k: string]: unknown | undefined;
 };
 /**
  * Response payload for list_transformers — account-scoped transformer descriptors matching the query, with optional per-param enumerated option values (when expanded) and per-account pricing (when requested).
@@ -21546,13 +19400,11 @@ export interface ListTransformersResponseCreativeAgent {
   ext?: ExtensionObject;
 }
 export interface CanonicalTransformerOutputs {
-  [k: string]: unknown | undefined;
 }
 /**
  * @deprecated
  */
 export interface NamedFormatTransformerOutputs {
-  [k: string]: unknown | undefined;
 }
 
 // get_creative_delivery parameters
@@ -21631,7 +19483,6 @@ export type CreativeVariant = DeliveryMetrics & {
       artifact_id: string;
     };
     ext?: ExtensionObject;
-    [k: string]: unknown | undefined;
   };
 };
 /**
@@ -21995,7 +19846,6 @@ export interface CreativeFilters {
    */
   has_variables?: boolean;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 
 // list_creatives response
@@ -22003,7 +19853,6 @@ export interface CreativeFilters {
  * An asset inside a materialized creative locale variant. Text and markdown assets may omit language when they make no language claim. When language is present, it MUST use the shared AdCP BCP 47 wire profile; conformance additionally requires exact equality with the enclosing variant locale.
  */
 export type LocalizedCreativeAsset = AssetVariant & {
-  [k: string]: unknown | undefined;
 };
 /**
  * Item within a multi-asset creative format. Used for carousel products, native ad components, and other formats composed of multiple distinct elements.
@@ -22026,7 +19875,6 @@ export type CreativeItem =
        * URL for media assets (images, videos, etc.)
        */
       content_uri: string;
-      [k: string]: unknown | undefined;
     }
   | {
       /**
@@ -22045,7 +19893,6 @@ export type CreativeItem =
        * Text content for text-based assets like headlines, body text, CTA text, etc.
        */
       content: string | string[];
-      [k: string]: unknown | undefined;
     };
 /**
  * Response from creative library query with filtered results, metadata, and optional enriched data
@@ -22362,12 +20209,10 @@ export interface CreativeLocalizationReadback {
     {
       language_range: LanguageTag;
       locale_variant_id: string;
-      [k: string]: unknown | undefined;
     },
     ...{
       language_range: LanguageTag;
       locale_variant_id: string;
-      [k: string]: unknown | undefined;
     }[]
   ];
   /**
@@ -22380,7 +20225,6 @@ export interface CreativeLocalizationReadback {
     SourceLocalizationReadback | TargetLocalizationReadback,
     ...(SourceLocalizationReadback | TargetLocalizationReadback)[]
   ];
-  [k: string]: unknown | undefined;
 }
 export interface SourceLocalizationReadback {
   /**
@@ -22390,7 +20234,6 @@ export interface SourceLocalizationReadback {
   locale: LanguageTag;
   role: 'source';
   assets: ResolvedAssets;
-  [k: string]: unknown | undefined;
 }
 /**
  * Complete resolved assets for this locale, keyed by creative slot.
@@ -22410,7 +20253,6 @@ export interface TargetLocalizationReadback {
   locale: LanguageTag;
   role: 'target';
   assets: ResolvedAssets;
-  [k: string]: unknown | undefined;
 }
 /**
  * Seller-produced readback for one rights-grant presentation and its verifier-of-record evaluation. Buyers carry AttestationReference values in rights constraints but MUST NOT author this object or assert outcome verified. A seller trusts verified readback only when it retrieves the byte-identical result from its own local evaluation store; evaluated_by is descriptive and is not proof of provenance.
@@ -22440,7 +20282,6 @@ export interface RightsAttestationEvaluation {
       action_type: 'https://adcontextprotocol.org/actions/rights-grant-evaluation';
     };
   } & {
-    [k: string]: unknown | undefined;
   };
   ext?: ExtensionObject;
 }
@@ -22468,7 +20309,6 @@ export interface CreativeVariable {
    * Whether this variable must have a value for the creative to serve
    */
   required?: boolean;
-  [k: string]: unknown | undefined;
 }
 export interface ListedCreativeCanonicalFormatKind {
   /**
@@ -22716,7 +20556,6 @@ export interface CreativeLocalization {
      */
     locale_variant_id: string;
     locale: LanguageTag;
-    [k: string]: unknown | undefined;
   };
   /**
    * Complete desired target-locale set for this creative. May be empty for a monolingual source-only creative. Every target contains materialized locale-specific asset overrides. Missing slots inherit source assets; after inheritance every resolved variant MUST satisfy the selected creative format.
@@ -22740,7 +20579,6 @@ export interface CreativeLocalization {
        */
       [k: string]: LocalizedCreativeAsset | [LocalizedCreativeAsset, ...LocalizedCreativeAsset[]];
     };
-    [k: string]: unknown | undefined;
   }[];
   /**
    * Optional explicit language-family substitutions evaluated only when strict RFC 4647 Lookup finds no equal available tag for the current requested preference. For each preference in order, the seller checks progressively truncated ranges from most to least specific and applies the first rule whose language_range equals that candidate. A rule may map a regional request to a different materialized regional variant, but no substitution is inferred when a rule is absent.
@@ -22755,7 +20593,6 @@ export interface CreativeLocalization {
        * Source or target locale variant to serve when this explicit fallback rule matches.
        */
       locale_variant_id: string;
-      [k: string]: unknown | undefined;
     },
     ...{
       language_range: LanguageTag;
@@ -22763,7 +20600,6 @@ export interface CreativeLocalization {
        * Source or target locale variant to serve when this explicit fallback rule matches.
        */
       locale_variant_id: string;
-      [k: string]: unknown | undefined;
     }[]
   ];
   /**
@@ -22774,7 +20610,6 @@ export interface CreativeLocalization {
    * Required seller behavior when neither strict RFC 4647 Lookup nor an explicit locale_fallbacks rule matches. serve_default serves default_locale_variant_id; do_not_serve makes this creative ineligible for that opportunity.
    */
   unmatched_locale_action: 'serve_default' | 'do_not_serve';
-  [k: string]: unknown | undefined;
 }
 export interface AssignOrUpdate {
   operation: 'assign';
@@ -23044,10 +20879,8 @@ export interface CreativeCapabilityTarget {
  * **Scope of validation (normative).** `validate_input` validates **manifest structure** against the canonical / product / third-party format target — slot counts, asset types, parameter ranges, format-shape constraints. It does NOT predict the surface's per-impression rendering choice. This distinction matters for `composition_model: algorithmic` formats (`responsive_creative`, `agent_placement`) where the surface picks combinations or phrasing at delivery time: the buyer's asset pool can still be structurally validated (does it meet the count/size/length requirements?) → `validated_pass` or `validated_fail` with violations. What's unpredictable is the rendered output composition, and that's NOT what `validate_input` claims to predict. `unvalidatable_nondeterministic` is reserved for `synthesis_nondeterministic: true` cases where the production pipeline itself can't be evaluated upfront — distinct from algorithmic composition where the inputs ARE evaluable but the output rendering isn't. Buyers calling `validate_input` on an algorithmic-composition target SHOULD expect a structural verdict (pass/fail), not a rendering preview.
  */
 export type ValidateInputResult = {
-  [k: string]: unknown | undefined;
 } & {
   target: {
-    [k: string]: unknown | undefined;
   };
   /**
    * Discriminator for the validation outcome. See schema description for the three states. Replaces the earlier boolean `ok` to distinguish 'failed validation' from 'platform is nondeterministic, can't pre-validate'.
@@ -23065,13 +20898,11 @@ export type ValidateInputResult = {
      * Expected value or range (e.g., '28000-32000', '9:16', 200).
      */
     expected?: {
-      [k: string]: unknown | undefined;
     };
     /**
      * Platform's pre-flight estimate for this field (NOT the actual output — there is no protocol state for orphaned out-of-spec artifacts). For TTS, this might be the predicted audio duration from text-length analysis. Helps the buyer fix the input before committing to a build.
      */
     predicted?: {
-      [k: string]: unknown | undefined;
     };
     /**
      * Path to the violating field (e.g., 'assets.video_main.duration_ms').
@@ -23081,11 +20912,8 @@ export type ValidateInputResult = {
      * Optional advisory adjustment hint. Platforms MAY suggest a corrected input shape; buyers MUST treat this as advisory, not authoritative.
      */
     retry_with?: {
-      [k: string]: unknown | undefined;
     };
-    [k: string]: unknown | undefined;
   }[];
-  [k: string]: unknown | undefined;
 };
 
 /**
@@ -23163,7 +20991,6 @@ export type Destination =
        * Optional account identifier on the platform
        */
       account?: string;
-      [k: string]: unknown | undefined;
     }
   | {
       /**
@@ -23178,7 +21005,6 @@ export type Destination =
        * Optional account identifier on the agent
        */
       account?: string;
-      [k: string]: unknown | undefined;
     };
 /**
  * Request parameters for discovering and refining signals. Use signal_spec for natural language discovery, signal_refs for exact lookups, both together to refine previous results, or discovery_mode: 'wholesale' to enumerate the agent's full priced signals feed (symmetric with get_products buying_mode: 'wholesale'). The legacy signal_ids field is deprecated.
@@ -23305,7 +21131,6 @@ export interface SignalFilters {
    */
   min_coverage_percentage?: number;
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 
 // get_signals response
@@ -23313,7 +21138,6 @@ export interface SignalFilters {
  * Disclosure requirements and jurisdictional notes for modeled data signals. This schema is intentionally separate from core/provenance.json because creative provenance is about generated content, render guidance, and asset-level chain of custody, while signal modeling disclosure is about data-segment methodology and data-use transparency.
  */
 export type SignalModelingDisclosure = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * The provider's claim that a modeling or AI-use disclosure is required for this signal in at least one applicable jurisdiction. This is a declared compliance signal, not a protocol-level legal determination.
@@ -23387,7 +21211,6 @@ export type SignalModelingDisclosure = {
  * Optional forecast-shaped signal availability guidance. When present, this is authoritative for signal-level discovery coverage. Use this to disclose the denominator, bucket semantics, not-present bucket, aggregate present bucket, and per-value coverage distribution for the signal.
  */
 export type SignalCoverageForecast = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Coverage or availability points. Each point reuses the standard ForecastPoint shape, MUST include a signal dimension, and MUST include metrics.coverage_rate. Use metrics.impressions for count denominators and metrics.coverage_rate for the fraction of the declared scope represented by the point.
@@ -23397,18 +21220,14 @@ export type SignalCoverageForecast = {
   points: [
     ForecastPoint & {
       dimensions: {
-        [k: string]: unknown | undefined;
       };
       metrics?: {
-        [k: string]: unknown | undefined;
       };
     },
     ...(ForecastPoint & {
       dimensions: {
-        [k: string]: unknown | undefined;
       };
       metrics?: {
-        [k: string]: unknown | undefined;
       };
     })[]
   ];
@@ -23446,7 +21265,6 @@ export type SignalCoverageForecast = {
      */
     line_item_types?: [string, ...string[]];
     date_range?: DateRange;
-    [k: string]: unknown | undefined;
   };
   /**
    * 'exclusive' means the returned signal-value buckets do not overlap with each other. 'overlapping' means one impression or user can appear in multiple returned buckets, so coverage_rate values may sum above 1.0. This field describes overlap among returned buckets; bucket_completeness declares whether the returned buckets cover the full denominator.
@@ -23496,7 +21314,6 @@ export type Deployment =
        * Timestamp when activation completed (if is_live=true)
        */
       deployed_at?: string;
-      [k: string]: unknown | undefined;
     }
   | {
       /**
@@ -23524,7 +21341,6 @@ export type Deployment =
        * Timestamp when activation completed (if is_live=true)
        */
       deployed_at?: string;
-      [k: string]: unknown | undefined;
     };
 /**
  * Response payload for get_signals task
@@ -25917,19 +23733,16 @@ export interface Artifact1 {
      * Open Graph protocol metadata
      */
     open_graph?: {
-      [k: string]: unknown | undefined;
     };
     /**
      * Twitter Card metadata
      */
     twitter_card?: {
-      [k: string]: unknown | undefined;
     };
     /**
      * JSON-LD structured data (schema.org)
      */
     json_ld?: {}[];
-    [k: string]: unknown | undefined;
   };
   provenance?: Provenance;
   /**
@@ -25956,9 +23769,7 @@ export interface Artifact1 {
      * RSS feed URL
      */
     rss_url?: string;
-    [k: string]: unknown | undefined;
   };
-  [k: string]: unknown | undefined;
 }
 
 // create_content_standards response
@@ -28377,7 +26188,6 @@ export interface GetPlanAuditLogsResponse {
  * Universal governance check for campaign actions. The governance agent infers the check type from the fields present: tool+payload = intent check (proposed, orchestrator-side); planned_delivery or delivery_metrics with governance_context = execution or lifecycle check (committed, service-side). Proposal acceptance supplies the immutable proposal separately so governance can inspect its typed commercial terms while payload remains the exact downstream arguments. MediaBuy controls use buyer-proposed and seller-computed positive-delta ceilings. The first check is addressed by plan_id. Subsequent service-side checks use the opaque governance_context as the authoritative plan binding.
  */
 export type CheckGovernanceRequest = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Release-precision AdCP version (VERSION.RELEASE, e.g. "3.0", "3.1", "3.1-beta"). On a request: the buyer's release pin — the seller validates against its supported_versions and returns VERSION_UNSUPPORTED on cross-major mismatch, or downshifts to the highest supported release within the same major. On a response: the release the seller actually served — clients SHOULD validate the response against that release's schema, not against their pin. Patches are not negotiated; surface them as build_version on capabilities for operational visibility. When omitted, falls back to adcp_major_version (deprecated) or server default. Buyers SHOULD emit both adcp_version and adcp_major_version through 3.x to remain compatible with sellers that only read the legacy field. NORMALIZATION: SDKs that read full-semver values from bundle metadata (e.g. ComplianceIndex.published_version = "3.1.0-beta.1") MUST normalize to release-precision ("3.1-beta.1") before emitting on the wire — meta-field values are NOT valid wire values.
@@ -29003,7 +26813,6 @@ export interface SISponsoredContext {
      * Human-readable label for disclosure rendering. The canonical identity remains the brand/account reference.
      */
     display_name?: string;
-    [k: string]: unknown | undefined;
   };
   context_use: SIContextUse;
   /**
@@ -29045,7 +26854,6 @@ export interface SISponsoredContext {
          * Regulation or policy identifier.
          */
         regulation: string;
-        [k: string]: unknown | undefined;
       },
       ...{
         /**
@@ -29060,10 +26868,8 @@ export interface SISponsoredContext {
          * Regulation or policy identifier.
          */
         regulation: string;
-        [k: string]: unknown | undefined;
       }[]
     ];
-    [k: string]: unknown | undefined;
   };
   /**
    * When this sponsored-context declaration was made.
@@ -29081,10 +26887,8 @@ export interface SISponsoredContext {
      * Role of the declaring party.
      */
     role: 'brand_agent' | 'seller' | 'network' | 'platform';
-    [k: string]: unknown | undefined;
   };
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 }
 
 // si_initiate_session parameters
@@ -29092,17 +26896,14 @@ export interface SISponsoredContext {
  * Host receipt for sponsored context accepted from a prior si_get_offering response or other pre-session context package. This records the accepted context_use, disclosure commitment, paying_principal, and host receipt for audit.
  */
 export type SISponsoredContextReceipt = {
-  [k: string]: unknown | undefined;
 } & {
   sponsored_context: SISponsoredContext;
   /**
    * Receiving-surface accountability fact: the use mode the host accepted and committed to honor for this sponsored context.
    */
   host_receipt: {
-    [k: string]: unknown | undefined;
   };
   ext?: ExtensionObject;
-  [k: string]: unknown | undefined;
 };
 /**
  * Host initiates a session with a brand agent
@@ -29178,7 +26979,6 @@ export interface SIIdentity {
      * Version of policy acknowledged
      */
     brand_policy_version?: string;
-    [k: string]: unknown | undefined;
   };
   /**
    * User data (only present if consent_granted is true)
@@ -29209,15 +27009,12 @@ export interface SIIdentity {
       state?: string;
       postal_code?: string;
       country?: string;
-      [k: string]: unknown | undefined;
     };
-    [k: string]: unknown | undefined;
   };
   /**
    * Session ID for anonymous users (when consent_granted is false)
    */
   anonymous_session_id?: string;
-  [k: string]: unknown | undefined;
 }
 /**
  * What capabilities the host supports
@@ -29245,7 +27042,6 @@ export interface SICapabilities {
            * Brand voice identifier
            */
           voice_id?: string;
-          [k: string]: unknown | undefined;
         };
     /**
      * Brand video content playback
@@ -29261,7 +27057,6 @@ export interface SICapabilities {
            * Maximum video duration
            */
           max_duration_seconds?: number;
-          [k: string]: unknown | undefined;
         };
     /**
      * Animated video presence with brand avatar
@@ -29277,9 +27072,7 @@ export interface SICapabilities {
            * Brand avatar identifier
            */
           avatar_id?: string;
-          [k: string]: unknown | undefined;
         };
-    [k: string]: unknown | undefined;
   };
   /**
    * Visual components supported
@@ -29293,9 +27086,7 @@ export interface SICapabilities {
      * Platform-specific extensions (chatgpt_apps_sdk, maps, forms, etc.)
      */
     extensions?: {
-      [k: string]: unknown | undefined;
     };
-    [k: string]: unknown | undefined;
   };
   /**
    * Commerce capabilities
@@ -29305,7 +27096,6 @@ export interface SICapabilities {
      * Supports ACP (Agentic Commerce Protocol) checkout handoff
      */
     acp_checkout?: boolean;
-    [k: string]: unknown | undefined;
   };
   /**
    * A2UI (Agent-to-UI) capabilities
@@ -29319,13 +27109,11 @@ export interface SICapabilities {
      * Supported A2UI component catalogs (e.g., 'si-standard', 'standard')
      */
     catalogs?: string[];
-    [k: string]: unknown | undefined;
   };
   /**
    * Supports MCP Apps for rendering A2UI surfaces in iframes
    */
   mcp_apps?: boolean;
-  [k: string]: unknown | undefined;
 }
 
 // si_initiate_session response
@@ -29333,7 +27121,6 @@ export interface SICapabilities {
  * Standard visual component that brand returns and host renders
  */
 export type SIUIElement = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Component type
@@ -29351,9 +27138,7 @@ export type SIUIElement = {
    * Component-specific data
    */
   data?: {
-    [k: string]: unknown | undefined;
   };
-  [k: string]: unknown | undefined;
 };
 /**
  * Brand agent's response to session initiation
@@ -29627,9 +27412,7 @@ export interface A2UISurface {
    * Application data that components can bind to
    */
   dataModel?: {
-    [k: string]: unknown | undefined;
   };
-  [k: string]: unknown | undefined;
 }
 /**
  * A component in an A2UI surface
@@ -29652,7 +27435,6 @@ export interface A2UIComponent {
      */
     [k: string]: {} | undefined;
   };
-  [k: string]: unknown | undefined;
 }
 
 // si_terminate_session parameters
@@ -29826,7 +27608,6 @@ export interface GetAdCPCapabilitiesRequest {
  * Portable-attestation trust and delivery capabilities for this evaluator. Present only when the agent accepts AttestationReference inputs on one or more domain task surfaces. This block is an allowlist: presenters cannot expand accepted issuers, resolver endpoints, verifier agents, claim types, or proof formats by supplying values in a request.
  */
 export type AttestationCapabilities = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * Open claim identifiers the evaluator is prepared to evaluate. Each value is an absolute URI. Absence means the evaluator has not advertised portable-attestation support; an empty list is not permitted.
@@ -29999,7 +27780,6 @@ export type AttestationCapabilities = {
  * Required for sellers implementing AdCP 3.2 advertiser-account provisioning, but optional in the shared 3.x response schema for compatibility. Declares whether the account timezone is seller-wide or fixed per account and whether a buyer must select it during sync_accounts provisioning. Account timezone is the default for account-scoped calendar semantics; feature-specific capability fields explicitly declare exceptions.
  */
 export type AccountTimezoneCapability = {
-  [k: string]: unknown | undefined;
 } & {
   /**
    * seller_fixed means every account uses fixed_timezone. account_fixed means each account has an immutable timezone returned on Account and selected or assigned during account establishment.
@@ -32139,7 +29919,6 @@ export interface AccountAuthorization {
    * Convenience flag. When true, the caller is permitted only non-mutating tasks. Sellers MUST reject any mutation from a read-only caller with READ_ONLY_SCOPE. For the AdCP 3.2 product split, read-only permits list_products but rejects request_proposals, refine_proposals, and decline_proposals; a legacy get_products call is permitted only when the seller can guarantee the selected arm is a synchronous side-effect-free read. Sellers MAY omit this field; omission is equivalent to `false`. Callers MUST NOT infer read-only from `allowed_tasks` alone — the seller MUST set this explicitly when it applies.
    */
   read_only?: boolean;
-  [k: string]: unknown | undefined;
 }
 
 // sync_accounts parameters
@@ -32868,7 +30647,6 @@ export interface SyncAccountsSuccess {
      * Request-only staging field. It MUST NOT appear in sync_accounts responses.
      */
     destination_billing_entity?: {
-      [k: string]: unknown | undefined;
     };
     account_scope?: AccountScope;
     /**
@@ -33494,7 +31272,6 @@ export type ComplianceTaskCompletionData = GetProductsCompletion | GetSignalsCom
  */
 export type GetProductsCompletion = AdCPVersionEnvelope &
   ProtocolEnvelope & {
-    [k: string]: unknown | undefined;
   } & {
     /**
      * Array of matching products
@@ -33505,7 +31282,6 @@ export type GetProductsCompletion = AdCPVersionEnvelope &
      * Bundled platform-extension definitions referenced by any product in `products`. Keyed by `<extension_uri>@<digest>` (e.g., `https://creative.adcontextprotocol.org/translated/meta/extensions/meta_pixel@sha256:abc...`). When present, lets buyers resolve `platform_extensions` references on product format declarations without a separate fetch. Buyer SDKs cache by URI@digest; subsequent get_products responses MAY omit definitions the buyer already has cached and rely on the digest match. Each value is an extension definition with `extends` (the canonical concept it extends, e.g., `tracking`), `fields` (the schema for additional fields the extension contributes), `version`, and optional `description`.
      */
     extensions?: {
-      [k: string]: unknown | undefined;
     };
     /**
      * Optional array of proposed media plans with budget allocations across products. Publishers include proposals when they can provide strategic guidance based on the brief. Proposals are actionable - buyers can refine them via follow-up get_products calls within the same session, or execute them directly via create_media_buy.
@@ -33788,7 +31564,6 @@ export type GetProductsCompletion = AdCPVersionEnvelope &
             }
           | undefined;
       };
-      [k: string]: unknown | undefined;
     };
     pagination?: PaginationResponse;
     /**
@@ -33813,7 +31588,6 @@ export type GetProductsCompletion = AdCPVersionEnvelope &
     sandbox?: boolean;
     context?: ContextObject;
     ext?: ExtensionObject;
-    [k: string]: unknown | undefined;
   };
 /**
  * Response payload for get_signals task
@@ -33825,7 +31599,6 @@ export type GetSignalsCompletion = AdCPVersionEnvelope &
      */
     signals?: (SignalListing &
       SignalDefinitionEnrichment & {
-        [k: string]: unknown | undefined;
       })[];
     /**
      * Task-specific errors and warnings (e.g., signal discovery or pricing issues)
@@ -33889,13 +31662,11 @@ export type GetSignalsCompletion = AdCPVersionEnvelope &
     sandbox?: boolean;
     context?: ContextObject;
     ext?: ExtensionObject;
-    [k: string]: unknown | undefined;
   };
 /**
  * Success response - media buy created successfully
  */
 export type CreateMediaBuyCompletion = {
-  [k: string]: unknown | undefined;
 };
 
 /**
@@ -34446,7 +32217,6 @@ export interface RawAttestation {
    * Request body the agent sent. Required when `attestation_mode` is `raw` (or omitted); MUST be absent when `attestation_mode` is `digest`. Object when content_type is JSON-shaped and the controller decoded it; string otherwise. The `x-adcp-open-payload: true` annotation applies to the decoded JSON/object arm of this mixed field; non-JSON string payloads remain scalar values governed by the surrounding schema. Adopters MUST apply the recursive secret-key redaction described in this branch's top-level description before emission — secrets at any depth (Authorization values inlined into JSON bodies, embedded JWTs, presigned-URL tokens, OAuth refresh tokens) MUST be replaced with the literal string `[redacted]`. Storyboards that assert `payload_must_contain` or `identifier_paths` are matching against THIS field — secrets MUST be redacted but storyboard-supplied identifiers (hashed PII, request correlation values) MUST NOT be redacted. Adopters SHOULD cap individual payload size at 64 KiB; payloads exceeding that SHOULD be truncated with a trailing `[…truncated]` marker — large payloads bloat compliance reports and the LLM-rendered context windows that consume them.
    */
   payload: {
-    [k: string]: unknown | undefined;
   };
   /**
    * Byte length of the post-redaction body bytes represented by this recorded_call. Required in both `raw` and `digest` modes — symmetric across modes so runners can detect adopter-side truncation regardless of attestation choice. In `raw` mode this MUST equal the UTF-8 byte length of the emitted `payload` value after the same recursive secret-key redaction the controller applied before returning it. In `digest` mode this MUST equal the exact number of bytes fed into SHA-256 for `payload_digest_sha256`: RFC 8785 (JCS) canonical bytes for JSON-shaped content after redaction, or the post-redaction raw body bytes for non-JSON content. Digest-mode `payload_length` is therefore NOT the original outbound body length before JSON parsing, redaction, or canonicalization. Mismatch between observed payload length and reported `payload_length` is a controller-side bug worth surfacing in the report.
@@ -34563,6 +32333,9 @@ export interface ControllerError {
   ext?: ExtensionObject;
 }
 
+
+/** @deprecated SDK 14 beta exported this numbered codegen compatibility alias. */
+export type Product1 = Product;
 
 /** @deprecated SDK 13 exported the 3.1 compatibility name. */
 export type OutcomeMeasurementDeprecated = OutcomeMeasurement;

--- a/src/lib/types/tools.generated.ts
+++ b/src/lib/types/tools.generated.ts
@@ -113,6 +113,7 @@ import type {
   ForecastPoint,
   ForecastRangeUnit,
   ForecastableMetric,
+  Format,
   FormatIDParameter,
   FormatReferenceStructuredObject,
   FrameRateType,
@@ -239,7 +240,7 @@ import type {
   WebhookSecurityMethod,
 } from './core.generated';
 
-export type { AccountCurrencyMode, AccountReference, AccountScope, AccountStatus, ActionNotAllowedReason, ActionSource, AdCPProtocol, AdCPSpecialism, AdCPVersionEnvelope, AdvertiserIndustry, AgeDeterminationBasis, AgeVerificationMethod, AssessmentStatus, AssetContentType, AssetVariant, AttestationClaim, AttributionMethodology, AttributionModel, AudienceConstraints, AudienceEvidenceMethodology, AudienceResolutionMethod, AudienceSource, AudienceStatus, AudienceSubjectType, AudioChannelLayout, AudioDistributionType, AuthenticationScheme, AvailableMetric, BillingParty, BinaryVerdict, BrandAgentType, BrandReference, BrowserFamily, BusinessEntity, C2PAWatermarkAction, CanceledBy, CancellationPolicy, CanonicalFormatAgentPlacementAISurfaceSponsoredPlacement, CanonicalFormatBase, CanonicalFormatDAASTAudio, CanonicalFormatDisplayTag, CanonicalFormatHTML5Banner, CanonicalFormatHostedAudio, CanonicalFormatHostedVideo, CanonicalFormatImage, CanonicalFormatImageCarousel, CanonicalFormatNativeInFeed, CanonicalFormatResponsiveCreative, CanonicalFormatSponsoredPlacementRetailMediaCatalogDriven, CanonicalFormatVASTVideo, CanonicalMediaBuyActionMode, CanonicalMediaBuyActionName, CatalogAction, CatalogItemDeliveryMetrics, CatalogItemStatus, CatalogType, CloudStorageProtocol, CoBrandingRequirement, CollectionCadence, CollectionKind, CollectionRelationship, CollectionStatus, CompletionSource, ConsentBasis, ContentIDType, ContentRatingSystem, CountryFusedPostalCodeSystem, CreativeAction, CreativeAgentCapability, CreativeApprovalStatus, CreativeAsset, CreativeBrief, CreativeEventReasonCode, CreativeIdentifierType, CreativeQuality, CreativeSelectionStrategy, CreativeSortField, CreativeStatus, DAASTTrackingEvent, DAASTVersion, DayOfWeek, DelegationAuthority, DeliveryMetricAggregate, DeliveryMetrics, DeliveryStatus, DeliveryType, DemographicSystem, DerivativeType, DevicePlatform, DeviceType, DigitalSourceType, DimensionUnit, DisclosurePersistence, DisclosurePosition, DistanceUnit, DistributionIdentifierType, EmbeddedProvenanceMethod, ErrorCode, ErrorScope, EscalationSeverity, EventType, Exclusivity, ExtensionObject, FeatureCheckStatus, FeedFormat, FeedbackSource, Fixed, ForecastMethod, ForecastPoint, ForecastRangeUnit, ForecastableMetric, FormatIDParameter, FormatReferenceStructuredObject, FrameRateType, FrequencyCapScope, GOPType, GenreTaxonomy, GeoDeliveryMetrics, GeographicTargetingLevel, GetProductsAsyncSubmitted, GovernanceDecision, GovernanceDomain, GovernanceMode, GovernancePhase, HTTPMethod, HistoryEntryType, ImageAsset, ImpairmentOfflineState, ImpairmentReasonCode, IndicatorType, InstallmentStatus, JavaScriptModuleType, KeywordDeliveryMetrics, LandingPageRequirement, LiftDimension, LogoSlot, MakegoodRemedy, MarkdownFlavor, MatchIDType, MatchType, MeasurementTerms, MediaBuyActionMode, MediaBuyHealth, MediaBuyStatus, MediaBuyValidAction, MediaChannel, MetricScope, MetricType, MetroAreaSystem, MoovAtomPosition, MultiSize, None, NotificationType, OfferingAvailabilityStatus, OutcomeType, Pacing, PackageUpdate, PaymentTerms, PerformanceBaseline, PerformanceStandardMetric, PlatformExtensionReference, PolicyCategory, PolicyEnforcementLevel, PostalCodeSystem, PostalCountrySystem, PreviewOutputFormat, PriceAdjustmentKind, PricingModel, PricingStructure, ProductionQuality, PropertyIdentifierTypes, PropertyType, ProposalDeclineReason, ProposalRefinementReason, ProposalStatus, ProtocolEnvelope, Provenance, PublisherIdentifierTypes, PublisherPropertySelector, PurchaseType, ReachUnit, ReportingFrequency, Responsive, RestrictedAttribute, RightType, RightUse, RightsBillingPeriod, RightsConstraint, SISessionStatus, ScanType, ScopedCreativeApproval, SignalAvailabilityType, SignalDefinitionEnrichment, SignalSource, SignalTargetingExpression, SignalValueType, SizeModeMutex, SnapshotUnavailableReason, SocialPlacementSurface, SortDirection, SortMetric, SpecialCategory, SponsoredPlacementType, TMPResponseType, TalentRole, TargetingOverlayRequirements, TargetingOverlaySupport, TaskStatus, TaskType, TransportMode, TravelTimeUnit, UIDType, URLAssetType, UniversalMacro, UpdateFrequency, VASTTrackingEvent, VASTVersion, ValidationMode, VideoPlacementType, ViewabilityStandard, WCAGLevel, WarningAffectedResource, WarningCode, WatermarkMediaType, WebhookResponseType, WebhookSecurityMethod } from './core.generated';
+export type { AccountCurrencyMode, AccountReference, AccountScope, AccountStatus, ActionNotAllowedReason, ActionSource, AdCPProtocol, AdCPSpecialism, AdCPVersionEnvelope, AdvertiserIndustry, AgeDeterminationBasis, AgeVerificationMethod, AssessmentStatus, AssetContentType, AssetVariant, AttestationClaim, AttributionMethodology, AttributionModel, AudienceConstraints, AudienceEvidenceMethodology, AudienceResolutionMethod, AudienceSource, AudienceStatus, AudienceSubjectType, AudioChannelLayout, AudioDistributionType, AuthenticationScheme, AvailableMetric, BillingParty, BinaryVerdict, BrandAgentType, BrandReference, BrowserFamily, BusinessEntity, C2PAWatermarkAction, CanceledBy, CancellationPolicy, CanonicalFormatAgentPlacementAISurfaceSponsoredPlacement, CanonicalFormatBase, CanonicalFormatDAASTAudio, CanonicalFormatDisplayTag, CanonicalFormatHTML5Banner, CanonicalFormatHostedAudio, CanonicalFormatHostedVideo, CanonicalFormatImage, CanonicalFormatImageCarousel, CanonicalFormatNativeInFeed, CanonicalFormatResponsiveCreative, CanonicalFormatSponsoredPlacementRetailMediaCatalogDriven, CanonicalFormatVASTVideo, CanonicalMediaBuyActionMode, CanonicalMediaBuyActionName, CatalogAction, CatalogItemDeliveryMetrics, CatalogItemStatus, CatalogType, CloudStorageProtocol, CoBrandingRequirement, CollectionCadence, CollectionKind, CollectionRelationship, CollectionStatus, CompletionSource, ConsentBasis, ContentIDType, ContentRatingSystem, CountryFusedPostalCodeSystem, CreativeAction, CreativeAgentCapability, CreativeApprovalStatus, CreativeAsset, CreativeBrief, CreativeEventReasonCode, CreativeIdentifierType, CreativeQuality, CreativeSelectionStrategy, CreativeSortField, CreativeStatus, DAASTTrackingEvent, DAASTVersion, DayOfWeek, DelegationAuthority, DeliveryMetricAggregate, DeliveryMetrics, DeliveryStatus, DeliveryType, DemographicSystem, DerivativeType, DevicePlatform, DeviceType, DigitalSourceType, DimensionUnit, DisclosurePersistence, DisclosurePosition, DistanceUnit, DistributionIdentifierType, EmbeddedProvenanceMethod, ErrorCode, ErrorScope, EscalationSeverity, EventType, Exclusivity, ExtensionObject, FeatureCheckStatus, FeedFormat, FeedbackSource, Fixed, ForecastMethod, ForecastPoint, ForecastRangeUnit, ForecastableMetric, Format, FormatIDParameter, FormatReferenceStructuredObject, FrameRateType, FrequencyCapScope, GOPType, GenreTaxonomy, GeoDeliveryMetrics, GeographicTargetingLevel, GetProductsAsyncSubmitted, GovernanceDecision, GovernanceDomain, GovernanceMode, GovernancePhase, HTTPMethod, HistoryEntryType, ImageAsset, ImpairmentOfflineState, ImpairmentReasonCode, IndicatorType, InstallmentStatus, JavaScriptModuleType, KeywordDeliveryMetrics, LandingPageRequirement, LiftDimension, LogoSlot, MakegoodRemedy, MarkdownFlavor, MatchIDType, MatchType, MeasurementTerms, MediaBuyActionMode, MediaBuyHealth, MediaBuyStatus, MediaBuyValidAction, MediaChannel, MetricScope, MetricType, MetroAreaSystem, MoovAtomPosition, MultiSize, None, NotificationType, OfferingAvailabilityStatus, OutcomeType, Pacing, PackageUpdate, PaymentTerms, PerformanceBaseline, PerformanceStandardMetric, PlatformExtensionReference, PolicyCategory, PolicyEnforcementLevel, PostalCodeSystem, PostalCountrySystem, PreviewOutputFormat, PriceAdjustmentKind, PricingModel, PricingStructure, ProductionQuality, PropertyIdentifierTypes, PropertyType, ProposalDeclineReason, ProposalRefinementReason, ProposalStatus, ProtocolEnvelope, Provenance, PublisherIdentifierTypes, PublisherPropertySelector, PurchaseType, ReachUnit, ReportingFrequency, Responsive, RestrictedAttribute, RightType, RightUse, RightsBillingPeriod, RightsConstraint, SISessionStatus, ScanType, ScopedCreativeApproval, SignalAvailabilityType, SignalDefinitionEnrichment, SignalSource, SignalTargetingExpression, SignalValueType, SizeModeMutex, SnapshotUnavailableReason, SocialPlacementSurface, SortDirection, SortMetric, SpecialCategory, SponsoredPlacementType, TMPResponseType, TalentRole, TargetingOverlayRequirements, TargetingOverlaySupport, TaskStatus, TaskType, TransportMode, TravelTimeUnit, UIDType, URLAssetType, UniversalMacro, UpdateFrequency, VASTTrackingEvent, VASTVersion, ValidationMode, VideoPlacementType, ViewabilityStandard, WCAGLevel, WarningAffectedResource, WarningCode, WatermarkMediaType, WebhookResponseType, WebhookSecurityMethod } from './core.generated';
 
 // Tool Parameter and Response Types
 // Generated from official AdCP schemas
@@ -10392,182 +10393,6 @@ export interface ListCreativeFormatsRequest {
 }
 
 // list_creative_formats response
-/**
- * **DEPRECATED in 3.2.** Legacy named-format definition retained for older 3.x peers and list_creative_formats compatibility projections. New products and creative agents author ProductFormatDeclaration canonical contracts instead.
- */
-export type Format = {
-} & {
-  format_id: FormatReferenceStructuredObject;
-  /**
-   * Human-readable format name
-   */
-  name: string;
-  /**
-   * Plain text explanation of what this format does and what assets it requires
-   */
-  description?: string;
-  /**
-   * Optional URL to showcase page with examples and interactive demos of this format
-   */
-  example_url?: string;
-  /**
-   * List of parameters this format accepts in format_id. Template formats define which parameters (dimensions, duration, etc.) can be specified when instantiating the format. Empty or omitted means this is a concrete format with fixed parameters.
-   */
-  accepts_parameters?: FormatIDParameter[];
-  /**
-   * Specification of rendered pieces for this format. Most formats produce a single render. Companion ad formats (video + banner), adaptive formats, and multi-placement formats produce multiple renders. Each render specifies its role and dimensions.
-   *
-   * @minItems 1
-   */
-  renders?: [
-    (
-      | {
-        }
-      | {
-          parameters_from_format_id: true;
-        }
-    ),
-    ...(
-      | {
-        }
-      | {
-          parameters_from_format_id: true;
-        }
-    )[]
-  ];
-  /**
-   * Array of all assets supported for this format. Each asset is identified by its asset_id, which must be used as the key in creative manifests. Use the 'required' boolean on each asset to indicate whether it's mandatory.
-   */
-  assets?: (
-    | (
-        | IndividualImageAsset
-        | IndividualVideoAsset
-        | IndividualAudioAsset
-        | IndividualTextAsset
-        | IndividualMarkdownAsset
-        | IndividualHtmlAsset
-        | IndividualCssAsset
-        | IndividualJavaScriptAsset
-        | IndividualZipAsset
-        | IndividualVastAsset
-        | IndividualDaastAsset
-        | IndividualUrlAsset
-        | IndividualWebhookAsset
-        | IndividualBriefAsset
-        | IndividualCatalogAsset
-      )
-    | RepeatableGroupAsset
-  )[];
-  /**
-   * Delivery method specifications (e.g., hosted, VAST, third-party tags)
-   */
-  delivery?: {
-  };
-  /**
-   * List of universal macros supported by this format (e.g., MEDIA_BUY_ID, CACHEBUSTER, DEVICE_ID). Used for validation and developer tooling. See docs/creative/universal-macros.mdx for full documentation.
-   */
-  supported_macros?: (UniversalMacro | string)[];
-  /**
-   * @deprecated
-   * **DEPRECATED in 3.1. Removed at 4.0.** Use `list_transformers` instead — a transformer declares its own `input_format_ids`/`output_format_ids`, so build capability is a property of the transformer (the unit you select and that carries pricing), not a relationship hung on a format. Discover build capability via `list_transformers` (optionally filtered by `input_format_ids`/`output_format_ids`).
-   *
-   * Migration: sellers that expressed transform capability by hanging `input_format_ids` on a format SHOULD declare a transformer via `list_transformers` instead. Buyers SHOULD discover build capability via `list_transformers` rather than filtering formats.
-   *
-   * *Legacy behavior, retained for 3.1–3.x backward compatibility:* array of format IDs this format accepts as input creative manifests; when present, indicates this format can take existing creatives in these formats as input. SDKs reading 3.1 catalogs MUST continue to honor this field when present; 4.0+ SDKs MAY reject it. New code SHOULD NOT emit this field.
-   */
-  input_format_ids?: FormatReferenceStructuredObject[];
-  /**
-   * @deprecated
-   * **DEPRECATED in 3.1. Removed at 4.0.** Use `list_transformers` instead — a transformer declares its own `output_format_ids`, so what a builder can produce is a property of the transformer, not a relationship hung on a format. Discover via `list_transformers`.
-   *
-   * Migration: sellers that expressed multi-output build capability (e.g. a multi-publisher template) by hanging `output_format_ids` on a format SHOULD declare a transformer via `list_transformers` instead.
-   *
-   * *Legacy behavior, retained for 3.1–3.x backward compatibility:* array of format IDs this format can produce as output; when present, indicates this format can build creatives in these output formats. SDKs reading 3.1 catalogs MUST continue to honor this field when present; 4.0+ SDKs MAY reject it. New code SHOULD NOT emit this field.
-   */
-  output_format_ids?: FormatReferenceStructuredObject[];
-  /**
-   * Optional standard visual card (300x400px) for displaying this format in user interfaces. Can be rendered via preview_creative or pre-generated.
-   */
-  format_card?: {
-    format_id: FormatReferenceStructuredObject;
-    /**
-     * Asset manifest for rendering the card, structure defined by the format
-     */
-    manifest: {
-    };
-  };
-  /**
-   * Accessibility posture of this format. Declares the WCAG conformance level that creatives produced by this format will meet.
-   */
-  accessibility?: {
-    wcag_level: WCAGLevel;
-    /**
-     * When true, all assets with x-accessibility fields must include those fields. For inspectable assets (image, video, audio), this means providing accessibility metadata like alt_text or captions. For opaque assets (HTML, JavaScript), this means providing self-declared accessibility properties.
-     */
-    requires_accessible_assets?: boolean;
-  };
-  /**
-   * Disclosure positions this format can render. Buyers use this to determine whether a format can satisfy their compliance requirements before submitting a creative. When omitted, the format makes no disclosure rendering guarantees — creative agents SHOULD treat this as incompatible with briefs that require specific disclosure positions. Values correspond to positions on creative-brief.json required_disclosures.
-   *
-   * @minItems 1
-   */
-  supported_disclosure_positions?: [DisclosurePosition, ...DisclosurePosition[]];
-  /**
-   * Structured disclosure capabilities per position with persistence modes. Declares which persistence behaviors each disclosure position supports, enabling persistence-aware matching against provenance render guidance and brief requirements. When present, supersedes supported_disclosure_positions for persistence-aware queries. The flat supported_disclosure_positions field is retained for backward compatibility. Each position MUST appear at most once; validators and agents SHOULD reject duplicates.
-   *
-   * @minItems 1
-   */
-  disclosure_capabilities?: [
-    {
-      position: DisclosurePosition;
-      /**
-       * Persistence modes this position supports
-       *
-       * @minItems 1
-       */
-      persistence: [DisclosurePersistence, ...DisclosurePersistence[]];
-    },
-    ...{
-      position: DisclosurePosition;
-      /**
-       * Persistence modes this position supports
-       *
-       * @minItems 1
-       */
-      persistence: [DisclosurePersistence, ...DisclosurePersistence[]];
-    }[]
-  ];
-  /**
-   * Optional detailed card with carousel and full specifications. Provides rich format documentation similar to ad spec pages.
-   */
-  format_card_detailed?: {
-    format_id: FormatReferenceStructuredObject;
-    /**
-     * Asset manifest for rendering the detailed card, structure defined by the format
-     */
-    manifest: {
-    };
-  };
-  /**
-   * Metrics this format can produce in delivery reporting. Buyers receive the intersection of format reported_metrics and product available_metrics. If omitted, the format defers entirely to product-level metric declarations.
-   *
-   * @minItems 1
-   */
-  reported_metrics?: [AvailableMetric, ...AvailableMetric[]];
-  /**
-   * @deprecated
-   * **DEPRECATED in 3.1. Removed at 4.0.** Use `transformer.pricing_options` (via `list_transformers`) instead — pricing belongs on the transformer (the unit selected and billed), exactly as it belongs on a media-buy product. Once formats only describe output shape, format-level pricing is vestigial.
-   *
-   * Migration: transformation/generation agents that charged via `format.pricing_options` SHOULD move the same `vendor-pricing-option` entries onto the corresponding transformer. The applied option is echoed per-leaf on the build_creative response and reconciled via report_usage, unchanged.
-   *
-   * *Legacy behavior, retained for 3.1–3.x backward compatibility:* pricing options for this format, used by transformation/generation agents that charge per format adapted, per image generated, or per unit of work; present when the request included include_pricing=true and account. SDKs reading 3.1 catalogs MUST continue to honor this field when present; 4.0+ SDKs MAY reject it. New code SHOULD NOT emit this field.
-   *
-   * @minItems 1
-   */
-  pricing_options?: [VendorPricingOption, ...VendorPricingOption[]];
-  canonical?: CanonicalProjectionReference;
-  canonical_parameters?: ProductFormatDeclaration;
-};
 /**
  * Image asset
  */

--- a/src/lib/v2/projection/write-side.ts
+++ b/src/lib/v2/projection/write-side.ts
@@ -38,7 +38,7 @@ export interface PackageFormatRefs {
    * format_option_id }`; publisher-catalog-backed options use
    * `{ scope: 'publisher', publisher_domain, format_option_id }`.
    */
-  format_option_refs: FormatOptionRef[];
+  format_option_refs: [FormatOptionRef, ...FormatOptionRef[]];
   /** Legacy identifiers are deliberately unavailable on the canonical SDK surface. */
   format_ids?: never;
 }
@@ -582,7 +582,7 @@ export function packageRefsForFormatOptions(
     format_option_refs,
     selected.map(declaration => concealLegacyFormatRefs(declaration))
   );
-  return { format_option_refs };
+  return { format_option_refs: format_option_refs as [FormatOptionRef, ...FormatOptionRef[]] };
 }
 
 /**

--- a/src/type-tests/format-asset-slots.type-test.ts
+++ b/src/type-tests/format-asset-slots.type-test.ts
@@ -17,7 +17,7 @@ import type {
   RepeatableGroupSlot,
 } from '../lib/types/format-asset-slots';
 
-// --- Image: `formats` is canonical; extension requirement fields stay forward-compatible ---
+// --- Image: `formats` is canonical; runtime validation stays forward-compatible ---
 const goodImage: IndividualImageAssetSlot = {
   item_type: 'individual',
   asset_type: 'image',
@@ -27,18 +27,20 @@ const goodImage: IndividualImageAssetSlot = {
 };
 void goodImage;
 
-const extendedImage: IndividualImageAssetSlot = {
+const badImage: IndividualImageAssetSlot = {
   item_type: 'individual',
   asset_type: 'image',
   asset_id: 'hero',
   required: true,
   requirements: {
+    // @ts-expect-error non-canonical fields remain wire-valid at runtime but
+    // do not widen the named TypeScript interface with an index signature.
     file_types: ['jpg'],
   },
 };
-void extendedImage;
+void badImage;
 
-// --- Video: milliseconds are canonical ---
+// --- Video: milliseconds are canonical; legacy seconds fields stay rejected ---
 const goodVideo: IndividualVideoAssetSlot = {
   item_type: 'individual',
   asset_type: 'video',
@@ -48,26 +50,38 @@ const goodVideo: IndividualVideoAssetSlot = {
 };
 void goodVideo;
 
-const extendedVideoDurations: IndividualVideoAssetSlot = {
+const badVideoMinSeconds: IndividualVideoAssetSlot = {
   item_type: 'individual',
   asset_type: 'video',
   asset_id: 'ad',
   required: true,
-  requirements: { min_duration_seconds: 6, max_duration_seconds: 30 },
+  // @ts-expect-error use min_duration_ms on the typed surface.
+  requirements: { min_duration_seconds: 6 },
 };
-void extendedVideoDurations;
+void badVideoMinSeconds;
 
-// --- Video: `containers` is canonical; extension requirement fields remain accepted ---
-const extendedVideo: IndividualVideoAssetSlot = {
+const badVideoMaxSeconds: IndividualVideoAssetSlot = {
+  item_type: 'individual',
+  asset_type: 'video',
+  asset_id: 'ad',
+  required: true,
+  // @ts-expect-error use max_duration_ms on the typed surface.
+  requirements: { max_duration_seconds: 30 },
+};
+void badVideoMaxSeconds;
+
+// --- Video: `containers` is canonical; arbitrary siblings do not widen the type ---
+const badVideoFileTypes: IndividualVideoAssetSlot = {
   item_type: 'individual',
   asset_type: 'video',
   asset_id: 'ad',
   required: true,
   requirements: {
+    // @ts-expect-error use containers on the typed surface.
     file_types: ['mp4'],
   },
 };
-void extendedVideo;
+void badVideoFileTypes;
 
 // --- Video: container enum is closed ---
 const badVideoContainer: IndividualVideoAssetSlot = {

--- a/test-agents/seller-agent.ts
+++ b/test-agents/seller-agent.ts
@@ -196,7 +196,7 @@ function createAgent({ taskStore }: ServeContext) {
             product_id: pkg.product_id,
             pricing_option_id: pkg.pricing_option_id,
             budget: pkg.budget,
-            buyer_ref: pkg.buyer_ref,
+            context: pkg.context,
           })),
           context: params.context,
         };

--- a/test/generate-per-tool-collision.test.js
+++ b/test/generate-per-tool-collision.test.js
@@ -74,6 +74,7 @@ const generatedSurface = {
   reExportsCoreSharedTypes: [
     'AudienceConstraints',
     'CatalogItemDeliveryMetrics',
+    'Format',
     'GeoDeliveryMetrics',
     'KeywordDeliveryMetrics',
     'PurchaseType',
@@ -82,6 +83,7 @@ const generatedSurface = {
   ),
   declaresAudienceConstraints: /export interface AudienceConstraints\\b/.test(toolsGenerated),
   declaresCatalogItemDeliveryMetrics: /export type CatalogItemDeliveryMetrics\\b/.test(toolsGenerated),
+  declaresFormat: /export (?:interface|type) Format\\b/.test(toolsGenerated),
   declaresGeoDeliveryMetrics: /export type GeoDeliveryMetrics\\b/.test(toolsGenerated),
   declaresKeywordDeliveryMetrics: /export type KeywordDeliveryMetrics\\b/.test(toolsGenerated),
   declaresPurchaseType: /export type PurchaseType\\b/.test(toolsGenerated),
@@ -179,6 +181,7 @@ test('tools.generated: core-authored shared types are imported and re-exported w
   assert.strictEqual(RESULTS.generatedSurface.reExportsCoreSharedTypes, true);
   assert.strictEqual(RESULTS.generatedSurface.declaresAudienceConstraints, false);
   assert.strictEqual(RESULTS.generatedSurface.declaresCatalogItemDeliveryMetrics, false);
+  assert.strictEqual(RESULTS.generatedSurface.declaresFormat, false);
   assert.strictEqual(RESULTS.generatedSurface.declaresGeoDeliveryMetrics, false);
   assert.strictEqual(RESULTS.generatedSurface.declaresKeywordDeliveryMetrics, false);
   assert.strictEqual(RESULTS.generatedSurface.declaresPurchaseType, false);

--- a/test/lib/codegen-aliases-drift.test.js
+++ b/test/lib/codegen-aliases-drift.test.js
@@ -57,4 +57,11 @@ describe('Codegen drift guard: numbered Foo1 exports must be aliased', () => {
         offenders.map(o => `  ${CORE_GENERATED_PATH}:${o.line}  ${o.snippet}`).join('\n')
     );
   });
+
+  it('gives distinct numbered refinements semantic names without widening them', () => {
+    const src = readFileSync(CORE_GENERATED_PATH, 'utf8');
+
+    assert.doesNotMatch(src, /export type TaskStatus2\b/);
+    assert.match(src, /outcome: 'rejected';\n\s+status\?: 'completed';/);
+  });
 });

--- a/test/lib/zod-schemas.test.js
+++ b/test/lib/zod-schemas.test.js
@@ -121,6 +121,26 @@ describe('Zod Schema Validation', () => {
     assert.ok(schemas.CanonicalFormatImageSchema.shape.image_formats, 'canonical formats should expose object shape');
   });
 
+  test('PriceBreakdownSchema preserves adjustment XOR and 1..20 bounds', async () => {
+    if (!schemas) {
+      schemas = await import('../../dist/lib/types/schemas.generated.js');
+    }
+    const adjustment = { kind: 'fee', name: 'ad_serving', rate: 0.1 };
+    assert.equal(schemas.PriceBreakdownSchema.safeParse({ list_price: 10, adjustments: [adjustment] }).success, true);
+    assert.equal(schemas.PriceBreakdownSchema.safeParse({ list_price: 10, adjustments: [] }).success, false);
+    assert.equal(
+      schemas.PriceBreakdownSchema.safeParse({ list_price: 10, adjustments: Array(21).fill(adjustment) }).success,
+      false
+    );
+    assert.equal(
+      schemas.PriceBreakdownSchema.safeParse({
+        list_price: 10,
+        adjustments: [{ ...adjustment, amount: 1 }],
+      }).success,
+      false
+    );
+  });
+
   test('ProductSchema exposes ZodObject composition helpers', async () => {
     if (!schemas) {
       schemas = await import('../../dist/lib/types/schemas.generated.js');

--- a/test/type-generator-strictness.test.js
+++ b/test/type-generator-strictness.test.js
@@ -78,23 +78,12 @@ test('generated types maintain strict schema enforcement', () => {
   // - CatalogFieldMapping and CatalogFieldBinding are now clean interfaces/unions, not intersections
   // - Remaining ~42 signatures are protocol-mandated context fields + asset metadata
   //
-  // Updated from 50 to 450 for AdCP lifecycle state machine schemas (#1684, #1691):
-  // - Upstream schema sync pulled in additionalProperties: true on many schemas
-  //   due to protocol extensibility requirements (context, ext fields on every request/response)
-  // - New compliance domain (comply_test_controller) adds oneOf variants with extensible params
-  // - Account, SI session, creative, media buy lifecycle schemas added extensible fields
-  //
-  // Updated from 450 to 1050 for AdCP 3.2.0-beta.0:
-  // - The signed bundle expands all canonical-format, proposal, measurement,
-  //   brand, and publisher/property contracts into the public SDK surface.
-  // - Those contracts deliberately preserve vendor-namespaced `ext`, opaque
-  //   context/evidence, and forward-compatible asset metadata at many nested
-  //   positions; the same shared schemas are repeated in multiple tool slices.
-  // - `check-no-loose-oneof.test.js` independently rejects index signatures
-  //   that appear as accidental union arms, so this ceiling covers intentional
-  //   extensibility rather than allowing the known jsts failure mode.
-  //
-  const MAX_ALLOWED = 1050;
+  // Reduced from 1050 to 30 after fully regenerating AdCP 3.2 types through
+  // enforceStrictSchema. Named open objects remain forward-compatible at
+  // runtime without acquiring source-incompatible TypeScript index
+  // signatures. The remaining signatures are explicit opaque maps such as
+  // ExtensionObject and protocol-mandated echo/context values.
+  const MAX_ALLOWED = 0;
 
   console.log(`📊 Type strictness metrics:`);
   console.log(`   Index signatures found: ${count}`);
@@ -159,10 +148,10 @@ test('core types maintain strict schema enforcement', () => {
   // - New enum schemas (account-status, si-session-status) with descriptions
   // - Business entity, price breakdown, adjustment types added
   //
-  // Updated from 450 to 950 for AdCP 3.2.0-beta.0 canonical-format,
-  // proposal, measurement, and registry expansion. As above, the separate
-  // loose-oneOf scanner continues to fail on accidental permissive arms.
-  const MAX_CORE_ALLOWED = 950;
+  // Reduced from 950 to 32 after the same recursive regeneration. Leave two
+  // slots of headroom for intentional opaque maps while making a stale or
+  // partially normalized generated surface fail loudly.
+  const MAX_CORE_ALLOWED = 1;
 
   console.log(`📊 Core types strictness:`);
   console.log(`   Index signatures found: ${count}`);

--- a/test/type-generator-strictness.test.js
+++ b/test/type-generator-strictness.test.js
@@ -78,11 +78,10 @@ test('generated types maintain strict schema enforcement', () => {
   // - CatalogFieldMapping and CatalogFieldBinding are now clean interfaces/unions, not intersections
   // - Remaining ~42 signatures are protocol-mandated context fields + asset metadata
   //
-  // Reduced from 1050 to 30 after fully regenerating AdCP 3.2 types through
-  // enforceStrictSchema. Named open objects remain forward-compatible at
-  // runtime without acquiring source-incompatible TypeScript index
-  // signatures. The remaining signatures are explicit opaque maps such as
-  // ExtensionObject and protocol-mandated echo/context values.
+  // Reduced from 1050 to 0 after fully regenerating AdCP 3.2 tool types
+  // through enforceStrictSchema. Named open objects remain forward-compatible
+  // at runtime without acquiring source-incompatible TypeScript index
+  // signatures; intentional opaque maps are canonicalized outside this file.
   const MAX_ALLOWED = 0;
 
   console.log(`📊 Type strictness metrics:`);


### PR DESCRIPTION
## Summary

- remove accidental TypeScript index signatures from generated named and nested open-object types while retaining the explicit `ExtensionObject` map
- preserve historical numbered aliases and direct generated-module exports across regeneration
- simplify pathological generated forecast and price-breakdown shapes without weakening runtime validation
- add packed-adopter, structural-assignment, codegen-drift, and runtime-schema regression coverage

Closes #2573.

## Expert review

Protocol, code, and test reviews completed. Follow-ups incorporated for historical exports, reverse structural assignments, nested package-flow exactness, and the signed 1–20 price-adjustment bounds.

## Validation

- `npm run ci:quick`
- `npm run check:adopter-types`
- `npm run ci:codegen-strict`
