### PR TITLE
fix(testing): honor external storyboard schemas

### DIFF
--- a/.changeset/curvy-hounds-validate.md
+++ b/.changeset/curvy-hounds-validate.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Make external schema roots authoritative for storyboard request and response validation, including `latest` schema IDs pinned by a matching schema index, so pre-publish protocol builds are not rejected by the SDK's generated validator snapshot.

--- a/docs/guides/VALIDATE-YOUR-AGENT.md
+++ b/docs/guides/VALIDATE-YOUR-AGENT.md
@@ -84,6 +84,7 @@ npx @adcp/sdk@adcp-3.1 storyboard run http://localhost:3001/mcp --json > report.
 - `--storyboards <id1,id2>` — limit to specific storyboard IDs
 - `--compliance-version <version>` — select the compliance cache/spec line used for resolution and request version intent; pass the same flag to `storyboard list`, `show`, and `step` when reproducing a pinned run
 - `--compliance-dir <path>` — use a specific compliance cache directory for local protocol/cache development
+- `--schema-root <path>` — use a matching external schema bundle for request/response validation; pair it with `--compliance-dir` when the two directories are not co-located
 - `--webhook-receiver [loopback|proxy]` — host a webhook sink so async steps grade instead of skip
 - `--webhook-receiver-auto-tunnel` — autodetect `ngrok`/`cloudflared` on `PATH`, spawn and plug into proxy mode
 - `--invariants <mod1,mod2>` — load custom cross-step assertion modules
@@ -117,9 +118,25 @@ All `expect_webhook*` steps require `webhook_receiver` runner support. If the
 `triggered_by` step is missing, skipped, or failed, the assertion skips with
 `prerequisite_failed` instead of treating the absence as a passing result.
 
-**Hosted compliance bundles.** Programmatic runners that mount compliance
-assets outside the installed SDK can pair the storyboard cache and schema cache
-explicitly:
+### Running against pre-publish artifacts
+
+Use a matching compliance bundle and schema root to validate a protocol build
+before its matching SDK package is published:
+
+```bash
+adcp storyboard run https://agent.example.com/mcp \
+  --compliance-dir /app/dist/compliance/latest \
+  --schema-root /app/dist/schemas/latest
+```
+
+The supplied JSON Schema bundle is authoritative for storyboard request and
+response validation. Same-change tools, fields, and controller scenarios do
+not need to exist in the SDK's generated validator snapshot, and the workflow
+does not write into `node_modules/@adcp/sdk`. A `schemas/latest` bundle may
+retain `/schemas/latest/...` IDs when its root `index.json` declares the real
+`adcp_version`; the index preserves cross-version validation fencing.
+
+Programmatic runners can pair the two directories explicitly as well:
 
 ```ts
 import { comply } from '@adcp/sdk/testing';

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -7,7 +7,7 @@ import { ADCP_ENVELOPE_FIELDS } from '../types/adcp';
 import { parseAdcpMajorVersion, type AdcpVersion } from '../version';
 import { isAdcpVersionSupported, isPre31AdcpVersion, resolveAdcpVersion } from '../utils/adcp-version-config';
 import { getVersionAdapter, resolveAdapterKey } from '../adapters/version';
-import { schemaAllowsTopLevelField } from '../validation/schema-loader';
+import { isExternalSchemaRootActive, schemaAllowsTopLevelField } from '../validation/schema-loader';
 import type {
   GetProductsRequest,
   GetProductsResponse,
@@ -3301,8 +3301,14 @@ export class SingleAgentClient {
     // absent and Zod would fail on it too. This matches the pre-existing
     // `skipIdempotencyAutoInject` behavior and is acceptable because both
     // flags are @internal and only set by the storyboard runner for
-    // schema_validation steps.
-    if (!options?.skipIdempotencyAutoInject && !options?.skipAccountValidation) {
+    // schema_validation steps. An explicit external schema root also skips
+    // this generated snapshot; TaskExecutor's AJV pass below validates the
+    // same request against the caller-supplied current-source bundle.
+    if (
+      !options?.skipIdempotencyAutoInject &&
+      !options?.skipAccountValidation &&
+      !isExternalSchemaRootActive(this.resolvedAdcpVersion)
+    ) {
       this.validateRequest(taskType, normalizedParams);
     }
 
@@ -5003,7 +5009,9 @@ export class SingleAgentClient {
     ) {
       normalizedParams = { ...normalizedParams, idempotency_key: generateIdempotencyKey() };
     }
-    this.validateRequest(taskType, normalizedParams);
+    if (!isExternalSchemaRootActive(this.resolvedAdcpVersion)) {
+      this.validateRequest(taskType, normalizedParams);
+    }
   }
 
   /**

--- a/src/lib/testing/storyboard/compliance.ts
+++ b/src/lib/testing/storyboard/compliance.ts
@@ -174,7 +174,10 @@ export interface ResolveOptions {
   /**
    * Explicit schema bundle root to use with the selected compliance cache.
    * The path must point at the schema-data directory for the cache version,
-   * for example `.../dist/lib/schemas-data/3.0`.
+   * for example `.../dist/lib/schemas-data/3.0`. During storyboard runs this
+   * external JSON Schema bundle is authoritative for request/response
+   * validation, including tools or fields newer than the SDK's generated Zod
+   * snapshot.
    */
   schemaRoot?: string;
   /**

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -33,6 +33,7 @@ import { detectStrictValidationHints } from './strict-validation-hints';
 import {
   runValidations,
   decorateValidationResult,
+  isExternalResponseSchemaAuthoritative,
   validationFailsStep,
   RUNNER_CAPABILITY_VERSION,
   type ValidationContext,
@@ -4143,6 +4144,7 @@ function collectSchemasUsed(phases: StoryboardPhaseResult[]): Array<{ schema_id:
  * production-readiness gap.
  * `lenient_also_failed` = #(lenient-fail ∧ strict-fail) — step already
  * broken, strict-rejection isn't new signal.
+ * `lenient_unobserved` = #(no packaged Zod comparator ∧ strict-fail).
  *
  * Exported so callers post-processing a `StoryboardResult` (dashboards,
  * CI formatters) can compute the same summary over a subset of phases
@@ -4180,7 +4182,8 @@ export function listStrictOnlyFailures(
         if (v.check !== 'response_schema') continue;
         if (v.strict === undefined) continue;
         if (v.strict.valid) continue;
-        if (!v.passed) continue; // already counted by lenient path
+        const lenientAccepted = v.strict.lenient_valid === true || (v.strict.lenient_valid === undefined && v.passed);
+        if (!lenientAccepted) continue;
         rows.push({
           phase_id: phase.phase_id,
           step_id: step.step_id,
@@ -4198,6 +4201,8 @@ export function summarizeStrictValidation(phases: StoryboardPhaseResult[]): Stri
   let checked = 0;
   let passed = 0;
   let strictOnlyFailures = 0;
+  let lenientAlsoFailed = 0;
+  let lenientUnobserved = 0;
   for (const phase of phases) {
     for (const step of phase.steps) {
       for (const v of step.validations) {
@@ -4205,10 +4210,17 @@ export function summarizeStrictValidation(phases: StoryboardPhaseResult[]): Stri
         checked++;
         if (v.strict.valid) {
           passed++;
-        } else if (v.passed) {
-          // Lenient Zod accepted this response; strict AJV rejected it.
-          // That's the agent's strictness gap — the signal #820 wants.
-          strictOnlyFailures++;
+        } else {
+          const lenientValid = v.strict.lenient_valid;
+          if (lenientValid === true || (lenientValid === undefined && v.passed)) {
+            // Lenient Zod accepted this response; strict AJV rejected it.
+            // That's the agent's strictness gap — the signal #820 wants.
+            strictOnlyFailures++;
+          } else if (lenientValid === false || lenientValid === undefined) {
+            lenientAlsoFailed++;
+          } else {
+            lenientUnobserved++;
+          }
         }
       }
     }
@@ -4220,7 +4232,8 @@ export function summarizeStrictValidation(phases: StoryboardPhaseResult[]): Stri
     passed,
     failed,
     strict_only_failures: strictOnlyFailures,
-    lenient_also_failed: failed - strictOnlyFailures,
+    lenient_also_failed: lenientAlsoFailed,
+    ...(lenientUnobserved > 0 && { lenient_unobserved: lenientUnobserved }),
   };
 }
 
@@ -5463,21 +5476,58 @@ async function executeStep(
       ...(validationTaskResult && { taskResult: validationTaskResult }),
       agentUrl: runState.agentUrl,
       contributions: runState.contributions,
+      ...(effectiveStep.response_schema_ref && { responseSchemaRef: effectiveStep.response_schema_ref }),
       request: requestRecord,
       ...(responseRecord && { response: responseRecord }),
     };
-    const decoratedCandidates = authoredSchemaValidations.map(validation =>
-      decorateValidationResult(baseSchemaResult, schemaValidationContext, validation)
-    );
-    const schemaResults = decoratedCandidates.length
-      ? decoratedCandidates
-      : [{ ...baseSchemaResult, severity: 'required' } satisfies ValidationResult];
-    schemaRejectionIsAdvisory = schemaResults.every(result => !validationFailsStep(result));
-    if (schemaRejectionIsAdvisory && !step.expect_error) passed = true;
-    // Prepend so extractFailures picks it up before any inline validation
-    // entry that may also be failing (e.g. `field_present` checks that
-    // legitimately can't observe their target against an unparsed payload).
-    validations = [...schemaResults, ...validations.filter(result => result.check !== 'response_schema')];
+    if (isExternalResponseSchemaAuthoritative(schemaValidationContext)) {
+      // The installed SDK's generated Zod snapshot can reject a response that
+      // the caller's current-source schemaRoot accepts. Re-grade the raw
+      // payload preserved on ResponseSchemaValidationError through that
+      // authoritative bundle instead of replacing its verdict with the stale
+      // packaged rejection.
+      const authoredExternalResults = validations.filter(result => result.check === 'response_schema');
+      const externalSchemaResults =
+        authoredExternalResults.length > 0
+          ? authoredExternalResults
+          : runValidations(
+              [
+                {
+                  check: 'response_schema',
+                  description: `Response schema validation for ${schemaValidationError.toolName}`,
+                },
+              ],
+              schemaValidationContext
+            );
+      const externalPayloadAccepted =
+        externalSchemaResults.length > 0 && externalSchemaResults.every(result => result.passed);
+      schemaRejectionIsAdvisory = externalSchemaResults.every(result => !validationFailsStep(result));
+      if (externalPayloadAccepted && validationTaskResult) {
+        taskResult = validationTaskResult;
+        passed = !step.expect_error;
+        responseRecord ??= {
+          transport: options.protocol === 'a2a' ? 'a2a' : 'mcp',
+          payload: redactSecrets(validationTaskResult.data),
+          duration_ms: stepResult.duration_ms,
+        };
+      } else if (schemaRejectionIsAdvisory && !step.expect_error) {
+        passed = true;
+      }
+      validations = [...externalSchemaResults, ...validations.filter(result => result.check !== 'response_schema')];
+    } else {
+      const decoratedCandidates = authoredSchemaValidations.map(validation =>
+        decorateValidationResult(baseSchemaResult, schemaValidationContext, validation)
+      );
+      const schemaResults = decoratedCandidates.length
+        ? decoratedCandidates
+        : [{ ...baseSchemaResult, severity: 'required' } satisfies ValidationResult];
+      schemaRejectionIsAdvisory = schemaResults.every(result => !validationFailsStep(result));
+      if (schemaRejectionIsAdvisory && !step.expect_error) passed = true;
+      // Prepend so extractFailures picks it up before any inline validation
+      // entry that may also be failing (e.g. `field_present` checks that
+      // legitimately can't observe their target against an unparsed payload).
+      validations = [...schemaResults, ...validations.filter(result => result.check !== 'response_schema')];
+    }
   }
 
   // Persist the captured A2A envelope keyed by step id so cross-step

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -2403,25 +2403,31 @@ export interface ValidationResult {
   /**
    * Issue #820 follow-up — strict JSON-schema (AJV) verdict for
    * `response_schema` checks. `passed` remains the lenient Zod outcome
-   * (runner's historical pass/fail semantics); `strict` carries the
-   * AJV-with-formats-and-additionalProperties verdict separately so
-   * agent developers can see the strict/lenient delta without the
-   * runner failing a step that the Zod path accepts. Absent on non-
-   * response_schema checks or when no AJV schema is available.
+   * (runner's historical packaged-cache semantics); `strict` carries the
+   * AJV-with-formats-and-additionalProperties verdict separately so agent
+   * developers can see the strict/lenient delta. When the run supplies an
+   * external `schemaRoot`, its AJV verdict is authoritative and may drive
+   * `passed`. Absent on non-response_schema checks or when no AJV schema is
+   * available.
    */
   strict?: StrictValidationVerdict;
 }
 
 /**
  * Strict (AJV JSON-schema) verdict attached to a response_schema
- * validation result. Informational — the step's pass/fail is driven by
- * the lenient Zod path. `valid: false` with `valid_lenient: true`
- * indicates the strict/lenient delta: the agent's response passes the
- * generated Zod shape but fails strict JSON-schema (typically a
- * `format` violation or an `additionalProperties: false` breach).
+ * validation result. Informational for packaged-cache runs, where step
+ * pass/fail remains driven by the lenient Zod path. Authoritative for runs
+ * with an external `schemaRoot`, so current protocol source is not gated by
+ * the SDK's generated Zod snapshot.
  */
 export interface StrictValidationVerdict {
   valid: boolean;
+  /**
+   * Outcome from the SDK's packaged Zod snapshot, captured only as a
+   * comparison signal. `null` means that snapshot has no schema for the tool.
+   * External-schema runs never use this field to decide pass/fail.
+   */
+  lenient_valid?: boolean | null;
   /** Response variant AJV ultimately validated against. After fallback: `"sync"`. */
   variant: string;
   /** Concrete AJV issues (RFC 6901 pointers) when `valid: false`. Absent when valid. */
@@ -3132,11 +3138,17 @@ export interface StrictValidationSummary {
   /**
    * Count of validations where BOTH lenient Zod AND strict AJV rejected —
    * the step already failed under today's semantics, so strict rejection
-   * isn't new signal. Equals `failed - strict_only_failures`. Useful for
-   * dashboards that want to distinguish "already-failing" from
-   * "silently-failing" in the same run.
+   * isn't new signal. Useful for dashboards that want to distinguish
+   * "already-failing" from "silently-failing" in the same run. Strict
+   * failures without a packaged Zod comparator are reported separately as
+   * `lenient_unobserved`.
    */
   lenient_also_failed: number;
+  /**
+   * Strict AJV failures for tools with no packaged Zod schema to compare.
+   * Present only when non-zero so older serialized summaries remain stable.
+   */
+  lenient_unobserved?: number;
 }
 
 /**

--- a/src/lib/testing/storyboard/validations.ts
+++ b/src/lib/testing/storyboard/validations.ts
@@ -12,7 +12,7 @@ import { prepareResponseForSchemaValidation, TOOL_RESPONSE_SCHEMAS } from '../..
 import { injectLegacyEnvelopeStatus } from '../../utils/envelope-status-compat';
 import { TRANSPORT_SUFFIX_REGEX } from '../../utils/a2a-discovery';
 import { validateResponse, type ValidationIssue } from '../../validation/schema-validator';
-import { hasSchemaBundle } from '../../validation/schema-loader';
+import { hasSchemaBundle, isExternalSchemaRootActive } from '../../validation/schema-loader';
 import { ADCP_VERSION, LIBRARY_VERSION } from '../../version';
 import { isPre31AdcpVersion } from '../../utils/adcp-version-config';
 import { gte as semverGte, valid as validSemver } from 'semver';
@@ -441,10 +441,13 @@ const SCHEMA_URL_BASE = 'https://adcontextprotocol.org';
  * convention used by `$id` in cached JSON schemas; the url dereferences
  * against the public docs origin so implementors can fetch it.
  */
-function resolveSchemaIdentity(schemaRef: string | undefined): { schema_id: string | null; schema_url: string | null } {
+function resolveSchemaIdentity(
+  schemaRef: string | undefined,
+  adcpVersion: string = ADCP_VERSION
+): { schema_id: string | null; schema_url: string | null } {
   if (!schemaRef) return { schema_id: null, schema_url: null };
   const trimmed = schemaRef.replace(/^\/+/, '');
-  const schemaId = `/schemas/${ADCP_VERSION}/${trimmed}`;
+  const schemaId = `/schemas/${adcpVersion}/${trimmed}`;
   const schemaUrl = `${SCHEMA_URL_BASE}${schemaId}`;
   return { schema_id: schemaId, schema_url: schemaUrl };
 }
@@ -520,7 +523,7 @@ function mapZodIssueToSchemaKeyword(issue: { code: string; message: string }): s
 }
 
 // ────────────────────────────────────────────────────────────
-// response_schema: validate against Zod
+// response_schema: validate against the active schema authority
 // ────────────────────────────────────────────────────────────
 
 function validateResponseSchema(
@@ -529,52 +532,89 @@ function validateResponseSchema(
   taskResult: TaskResult
 ): ValidationResult {
   const taskName = ctx.taskName;
-  const { schema_id, schema_url } = resolveSchemaIdentity(ctx.responseSchemaRef);
-  const schema = TOOL_RESPONSE_SCHEMAS[taskName];
-  if (!schema) {
-    return {
-      check: 'response_schema',
-      passed: false,
-      description: validation.description,
-      error: `No schema registered for task "${taskName}"`,
-      json_pointer: null,
-      expected: schema_id ?? `response schema for ${taskName}`,
-      // The runner failed before observing the agent — distinguish that from
-      // "agent returned null" so implementors don't chase a phantom agent bug.
-      actual: { reason: 'no_schema_registered', task: taskName },
-      schema_id,
-      schema_url,
-    };
-  }
+  const schemaIdentityVersion = ctx.adcpVersion ?? ctx.responseAdcpVersion ?? ADCP_VERSION;
+  const { schema_id, schema_url } = resolveSchemaIdentity(ctx.responseSchemaRef, schemaIdentityVersion);
 
   // Keep the raw payload separately from the object-form one below so the
   // shape-drift detector can recognize bare-array responses (a common drift
   // pattern for list tools). Strip _message when it's a top-level property —
   // bare arrays don't carry that field.
-  const rawData = taskResult.data ?? {};
+  const rawData: unknown = taskResult.data ?? {};
   const dataWithoutMessage = Array.isArray(rawData)
     ? rawData
     : (() => {
         const { _message, ...rest } = rawData as Record<string, unknown>;
         return rest;
       })();
-  // 3.0.x back-compat: synthesize envelope `status` for legacy peers
-  // before validating against the 3.1 envelope schema. See
-  // `utils/envelope-status-compat.ts`.
+  const schema = TOOL_RESPONSE_SCHEMAS[taskName];
+  // Evaluate the packaged validator for diagnostics even when an external
+  // bundle is authoritative. Its result must never gate that run, but it lets
+  // strict-summary consumers distinguish an actual strict/lenient delta from
+  // a response that both schema sources reject.
   const dataForValidation = Array.isArray(dataWithoutMessage)
     ? dataWithoutMessage
     : injectLegacyEnvelopeStatus(dataWithoutMessage as Record<string, unknown>, { toolName: taskName });
   const responseAdcpVersion = ctx.responseAdcpVersion ?? ctx.adcpVersion;
-  const parseResult = schema.safeParse(
+  const parseResult = schema?.safeParse(
     prepareResponseForSchemaValidation(taskName, dataForValidation, responseAdcpVersion)
   );
+  const computedStrict = computeStrictVerdict(taskName, dataWithoutMessage, ctx.adcpVersion, ctx.responseAdcpVersion);
+  const strict = computedStrict ? { ...computedStrict, lenient_valid: parseResult?.success ?? null } : undefined;
+  const externalSchemaIsAuthoritative = isExternalResponseSchemaAuthoritative(ctx);
 
-  // Strict (AJV) verdict runs alongside the lenient Zod check so the run
-  // report surfaces strictness deltas (issue #820 follow-up). The AJV path
-  // enforces `format` keywords and `additionalProperties: false` that Zod's
-  // `passthrough()` omits — a response can pass Zod and fail AJV. The step's
-  // overall pass/fail stays Zod-driven to preserve backwards compatibility.
-  const strict = computeStrictVerdict(taskName, dataWithoutMessage, ctx.adcpVersion, ctx.responseAdcpVersion);
+  // An explicit schemaRoot represents current source that may be newer than
+  // this SDK package's generated Zod snapshot. In that mode the external JSON
+  // Schema bundle is the source of truth for both known tools and tools added
+  // by the external build.
+  if (externalSchemaIsAuthoritative) {
+    if (!strict) {
+      return noResponseSchemaResult(validation, taskName, schema_id, schema_url);
+    }
+    if (strict.valid) {
+      const base: ValidationResult = {
+        check: 'response_schema',
+        passed: true,
+        description: validation.description,
+        schema_id,
+        schema_url,
+        strict,
+      };
+      const warning = buildStrictWarning(strict);
+      return warning ? { ...base, warning } : base;
+    }
+
+    const issues = strict.issues ?? [];
+    const firstIssue = issues[0];
+    return {
+      check: 'response_schema',
+      passed: false,
+      description: validation.description,
+      error:
+        issues.length > 0
+          ? issues
+              .slice(0, 5)
+              .map(issue => `${issue.instance_path || '/'}: ${issue.message}`)
+              .join('; ')
+          : `External JSON Schema rejected the ${taskName} response`,
+      json_pointer: firstIssue?.instance_path || null,
+      expected: schema_id ?? `response schema for ${taskName}`,
+      actual: issues,
+      schema_id,
+      schema_url,
+      strict,
+    };
+  }
+
+  if (!schema) {
+    return noResponseSchemaResult(validation, taskName, schema_id, schema_url, strict);
+  }
+  // `schema` is present, so optional chaining above necessarily produced a
+  // packaged verdict.
+  if (!parseResult) return noResponseSchemaResult(validation, taskName, schema_id, schema_url, strict);
+
+  // Strict (AJV) verdict runs alongside the lenient Zod check so packaged-cache
+  // runs surface strictness deltas without changing their historical pass/fail.
+  // Explicit external bundles take the authoritative branch above instead.
 
   // Shape-drift no longer rides on `ValidationResult.warning` — issue #935
   // moved that diagnostic to `StoryboardStepResult.hints[]` as a structured
@@ -621,6 +661,48 @@ function validateResponseSchema(
   return strict ? { ...failed, strict } : failed;
 }
 
+/** @internal Shared with the storyboard runner's Zod-rejection recovery path. */
+export function isExternalResponseSchemaAuthoritative(
+  ctx: Pick<ValidationContext, 'adcpVersion' | 'responseAdcpVersion'>
+): boolean {
+  const validationVersion = responseSchemaValidationVersion(ctx.adcpVersion, ctx.responseAdcpVersion);
+  return validationVersion !== undefined && isExternalSchemaRootActive(validationVersion);
+}
+
+function responseSchemaValidationVersion(
+  adcpVersion: string | undefined,
+  responseAdcpVersion: string | undefined
+): string | undefined {
+  // An explicit external root belongs to the caller-selected protocol source
+  // and must win over a packaged stable wire alias advertised by the server.
+  // The server version still feeds compatibility preparation separately.
+  if (adcpVersion && isExternalSchemaRootActive(adcpVersion)) return adcpVersion;
+  return responseAdcpVersion && hasSchemaBundle(responseAdcpVersion) ? responseAdcpVersion : adcpVersion;
+}
+
+function noResponseSchemaResult(
+  validation: StoryboardValidation,
+  taskName: string,
+  schema_id: string | null,
+  schema_url: string | null,
+  strict?: StrictValidationVerdict
+): ValidationResult {
+  const result: ValidationResult = {
+    check: 'response_schema',
+    passed: false,
+    description: validation.description,
+    error: `No schema registered for task "${taskName}"`,
+    json_pointer: null,
+    expected: schema_id ?? `response schema for ${taskName}`,
+    // The runner failed before observing the agent — distinguish that from
+    // "agent returned null" so implementors don't chase a phantom agent bug.
+    actual: { reason: 'no_schema_registered', task: taskName },
+    schema_id,
+    schema_url,
+  };
+  return strict ? { ...result, strict } : result;
+}
+
 /**
  * Run the strict AJV validator for `taskName` against the response payload.
  * Returns undefined when no AJV schema is available (the client can't
@@ -634,9 +716,14 @@ function computeStrictVerdict(
   adcpVersion?: string,
   responseAdcpVersion?: string
 ): StrictValidationVerdict | undefined {
-  const validationVersion =
-    responseAdcpVersion && hasSchemaBundle(responseAdcpVersion) ? responseAdcpVersion : adcpVersion;
-  if (responseAdcpVersion && isPre31AdcpVersion(responseAdcpVersion) && !hasSchemaBundle(responseAdcpVersion)) {
+  const externalVersionSelected = adcpVersion !== undefined && isExternalSchemaRootActive(adcpVersion);
+  const validationVersion = responseSchemaValidationVersion(adcpVersion, responseAdcpVersion);
+  if (
+    !externalVersionSelected &&
+    responseAdcpVersion &&
+    isPre31AdcpVersion(responseAdcpVersion) &&
+    !hasSchemaBundle(responseAdcpVersion)
+  ) {
     return undefined;
   }
   const payloadForValidation = prepareResponseForSchemaValidation(taskName, payload, responseAdcpVersion);

--- a/src/lib/testing/types.ts
+++ b/src/lib/testing/types.ts
@@ -105,7 +105,8 @@ export interface TestOptions {
   /**
    * External schema bundle root used for request/response validation during
    * storyboard and compliance runs. The root is registered against
-   * `adcpVersion` (or the storyboard/compliance version when omitted).
+   * `adcpVersion` (or the storyboard/compliance version when omitted) and is
+   * authoritative over the SDK's generated Zod snapshot for the run.
    */
   schemaRoot?: string;
   /** Custom User-Agent string sent with all outbound requests */

--- a/src/lib/validation/schema-loader.ts
+++ b/src/lib/validation/schema-loader.ts
@@ -439,13 +439,37 @@ function collectSchemaRootVersionAliasGroups(root: string): Array<{ hint: string
   return groups;
 }
 
+function readSchemaRootDeclaredVersion(root: string): string | undefined {
+  const candidates = [path.join(root, 'index.json')];
+  if (path.basename(root) === 'bundled') candidates.push(path.join(path.dirname(root), 'index.json'));
+  for (const candidate of candidates) {
+    if (!existsSync(candidate)) continue;
+    try {
+      const index = loadJson(candidate);
+      if (typeof index.adcp_version === 'string' && index.adcp_version !== 'latest') {
+        return index.adcp_version;
+      }
+    } catch {
+      // The normal mismatch error below carries the actionable root/version context.
+    }
+  }
+  return undefined;
+}
+
 function assertSchemaRootMatchesVersion(version: string, root: string): Set<string> {
   const expectedAliases = schemaRootVersionAliases(version);
   const rootGroups = collectSchemaRootVersionAliasGroups(root);
   const rootAliases = collectSchemaRootVersionAliases(root);
+  const declaredVersion = readSchemaRootDeclaredVersion(root);
+  const declaredAliases = declaredVersion ? schemaRootVersionAliases(declaredVersion) : new Set<string>();
+  const latestIsPinnedByIndex = [...declaredAliases].some(alias => expectedAliases.has(alias));
   if (
     rootGroups.length > 0 &&
-    rootGroups.every(group => [...group.aliases].some(alias => expectedAliases.has(alias)))
+    rootGroups.every(
+      group =>
+        [...group.aliases].some(alias => expectedAliases.has(alias)) ||
+        (group.hint === 'latest' && latestIsPinnedByIndex)
+    )
   ) {
     return new Set([...expectedAliases, ...rootAliases]);
   }
@@ -458,7 +482,8 @@ function assertSchemaRootMatchesVersion(version: string, root: string): Set<stri
           .join(', ');
   throw new Error(
     `External AdCP schema root for version "${version}" at ${root} does not match the requested version and ` +
-      `must contain only schema ids matching ${Array.from(expectedAliases).sort().join(', ')}; found ${found}.`
+      `must contain only schema ids matching ${Array.from(expectedAliases).sort().join(', ')}, or "latest" ids ` +
+      `pinned by a matching root index.json adcp_version; found ${found}.`
   );
 }
 
@@ -524,6 +549,25 @@ export function withExternalSchemaRoot<T>(version: string, root: string | undefi
     clearStatesForBundle(alias);
   }
   return scopedExternalSchemaRoots.run(next, fn);
+}
+
+/**
+ * Return whether validation for `version` currently resolves through a
+ * caller-supplied schema bundle rather than the SDK's packaged snapshot.
+ *
+ * Storyboard validation uses this to make an explicit external JSON Schema
+ * bundle authoritative. Without that distinction, the runner can validate a
+ * response successfully with the supplied bundle and then fail the same
+ * response against the older generated Zod schemas compiled into the SDK.
+ *
+ * @internal — not part of the public API surface; may change without a major bump.
+ */
+export function isExternalSchemaRootActive(version: string): boolean {
+  const key = resolveBundleKey(version);
+  const scopedRoot = scopedExternalSchemaRoots.getStore()?.get(key);
+  if (scopedRoot && existsSync(scopedRoot)) return true;
+  const registeredRoot = externalSchemaRoots.get(key);
+  return registeredRoot !== undefined && existsSync(registeredRoot);
 }
 
 function walkJsonFiles(dir: string): string[] {

--- a/test/lib/storyboard-schema-validation-attribution.test.js
+++ b/test/lib/storyboard-schema-validation-attribution.test.js
@@ -20,9 +20,14 @@
 
 const { describe, test } = require('node:test');
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 const { runStoryboard, runStoryboardStep } = require('../../dist/lib/testing/storyboard/index.js');
+const { createTestClient } = require('../../dist/lib/testing/client.js');
 const { ResponseSchemaValidationError } = require('../../dist/lib/utils/response-unwrapper.js');
+const { ADCP_VERSION } = require('../../dist/lib/version.js');
 
 /**
  * Build a minimal stub client that throws `ResponseSchemaValidationError`
@@ -105,6 +110,76 @@ function buildStoryboard(overrides = {}) {
 }
 
 describe('adcp-client#1709 — Zod-reject error attribution', () => {
+  test('external schemaRoot overrides a stale packaged-Zod rejection end to end', async () => {
+    const externalVersion = ADCP_VERSION;
+    const schemaRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'adcp-runner-external-authority-'));
+    const bundled = path.join(schemaRoot, 'bundled');
+    fs.mkdirSync(bundled, { recursive: true });
+    fs.writeFileSync(
+      path.join(bundled, 'get-products-response.json'),
+      JSON.stringify({
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        $id: `/schemas/${externalVersion}/media-buy/get-products-response.json`,
+        type: 'object',
+        required: ['current_source_marker'],
+        properties: { current_source_marker: { const: true } },
+        additionalProperties: false,
+      })
+    );
+
+    const client = createTestClient('https://stub.example/mcp', 'mcp', {
+      adcpVersion: externalVersion,
+      versionEnvelope: 'auto',
+    });
+    Object.assign(client, buildSchemaRejectingClient('get_products', { current_source_marker: true }));
+    const storyboard = buildStoryboard({ adcp_version: externalVersion });
+    storyboard.phases[0].steps[0].response_schema_ref = 'media-buy/get-products-response.json';
+    storyboard.phases[0].steps[0].validations = [
+      { check: 'response_schema', description: 'Current-source response is valid' },
+    ];
+    storyboard.phases[0].steps[0].context_outputs = [{ key: 'current_source_marker', path: 'current_source_marker' }];
+
+    try {
+      const result = await runStoryboardStep('https://stub.example/mcp', storyboard, 'fetch_products', {
+        protocol: 'mcp',
+        schemaRoot,
+        _serverAdcpVersion: '3.1',
+        _client: client,
+        _profile: stubProfile,
+      });
+
+      const schemaValidation = result.validations.find(v => v.check === 'response_schema');
+      assert.equal(schemaValidation?.passed, true, schemaValidation?.error ?? JSON.stringify(result));
+      assert.equal(schemaValidation?.strict?.valid, true);
+      assert.equal(result.passed, true);
+      assert.equal(result.error, undefined);
+      assert.deepEqual(result.response, { current_source_marker: true });
+      assert.equal(result.context.current_source_marker, true, 'accepted payload remains available for extraction');
+
+      const expectErrorStoryboard = structuredClone(storyboard);
+      expectErrorStoryboard.phases[0].steps[0].expect_error = true;
+      const expectErrorResult = await runStoryboardStep(
+        'https://stub.example/mcp',
+        expectErrorStoryboard,
+        'fetch_products',
+        {
+          protocol: 'mcp',
+          schemaRoot,
+          _serverAdcpVersion: '3.1',
+          _client: client,
+          _profile: stubProfile,
+        }
+      );
+      assert.equal(
+        expectErrorResult.passed,
+        false,
+        'an externally valid success must not satisfy an expect_error step'
+      );
+    } finally {
+      fs.rmSync(schemaRoot, { recursive: true, force: true });
+    }
+  });
+
   test('synthesizes response_schema ValidationResult on the step when unwrapper rejects', async () => {
     const client = buildSchemaRejectingClient('get_products');
     const result = await runStoryboardStep('https://stub.example/mcp', buildStoryboard(), 'fetch_products', {

--- a/test/lib/storyboard-strict-validation.test.js
+++ b/test/lib/storyboard-strict-validation.test.js
@@ -1,8 +1,9 @@
 /**
  * Strict/lenient response-schema validation + run-level aggregation (issue
  * #820, fourth proposal). `runValidations` must attach an AJV-based strict
- * verdict to every `response_schema` ValidationResult without flipping the
- * step's pass/fail (which stays Zod-driven for backwards compatibility).
+ * verdict to every `response_schema` ValidationResult. Packaged-cache runs
+ * stay Zod-driven for backwards compatibility; an explicit external schema
+ * root makes AJV authoritative for current-source validation.
  *
  * Tests hit the storyboard validation layer directly — `runValidations`
  * with a synthetic `ValidationContext`. No runner boot or network needed.
@@ -10,9 +11,28 @@
 
 const { describe, test } = require('node:test');
 const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 const { runValidations } = require('../../dist/lib/testing/storyboard/validations.js');
 const { summarizeStrictValidation, listStrictOnlyFailures } = require('../../dist/lib/testing/storyboard/runner.js');
+const { _resetValidationLoader, withExternalSchemaRoot } = require('../../dist/lib/validation/schema-loader.js');
+
+const EXTERNAL_VERSION = '9.9.0-beta.1';
+
+function writeExternalResponseSchema(root, toolName, schema) {
+  const bundled = path.join(root, 'bundled');
+  fs.mkdirSync(bundled, { recursive: true });
+  fs.writeFileSync(
+    path.join(bundled, `${toolName.replaceAll('_', '-')}-response.json`),
+    JSON.stringify({
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      $id: `/schemas/${EXTERNAL_VERSION}/test/${toolName.replaceAll('_', '-')}-response.json`,
+      ...schema,
+    })
+  );
+}
 
 function ctx(taskName, data, responseSchemaRef) {
   return {
@@ -29,6 +49,113 @@ function ctxWith(taskName, data, responseSchemaRef, extra) {
 }
 
 describe('storyboard validations: strict/lenient response_schema delta', () => {
+  test('external schemaRoot accepts current-source responses rejected by packaged Zod', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'adcp-external-authority-'));
+    try {
+      writeExternalResponseSchema(root, 'list_creative_formats', {
+        type: 'object',
+        required: ['current_source_marker'],
+        properties: { current_source_marker: { const: true } },
+        additionalProperties: false,
+      });
+
+      const [result] = withExternalSchemaRoot(EXTERNAL_VERSION, root, () =>
+        runValidations(
+          [{ check: 'response_schema', description: 'response conforms to current source' }],
+          ctxWith('list_creative_formats', { current_source_marker: true }, 'test/list-response.json', {
+            adcpVersion: EXTERNAL_VERSION,
+          })
+        )
+      );
+
+      assert.strictEqual(result.passed, true, result.error);
+      assert.strictEqual(result.strict.valid, true);
+      assert.strictEqual(result.strict.lenient_valid, false);
+      assert.match(result.schema_id, new RegExp(`/schemas/${EXTERNAL_VERSION.replaceAll('.', '\\.')}/`));
+    } finally {
+      _resetValidationLoader(EXTERNAL_VERSION);
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('external schemaRoot rejects packaged-Zod responses that current source disallows', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'adcp-external-authority-'));
+    try {
+      writeExternalResponseSchema(root, 'list_creative_formats', {
+        type: 'object',
+        required: ['current_source_marker'],
+        properties: { current_source_marker: { const: true } },
+        additionalProperties: false,
+      });
+
+      const [result] = withExternalSchemaRoot(EXTERNAL_VERSION, root, () =>
+        runValidations(
+          [{ check: 'response_schema', description: 'response conforms to current source' }],
+          ctxWith('list_creative_formats', { formats: [] }, 'test/list-response.json', {
+            adcpVersion: EXTERNAL_VERSION,
+          })
+        )
+      );
+
+      assert.strictEqual(result.passed, false);
+      assert.strictEqual(result.strict.valid, false);
+      assert.strictEqual(result.strict.lenient_valid, true);
+      assert.ok(result.actual.some(issue => issue.keyword === 'required'));
+
+      const summary = summarizeStrictValidation([
+        { phase_id: 'external', steps: [{ step_id: 'reject', task: 'list_creative_formats', validations: [result] }] },
+      ]);
+      assert.strictEqual(summary.strict_only_failures, 1);
+      assert.strictEqual(summary.lenient_also_failed, 0);
+    } finally {
+      _resetValidationLoader(EXTERNAL_VERSION);
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('external schemaRoot validates tools absent from the packaged Zod map', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'adcp-external-authority-'));
+    try {
+      writeExternalResponseSchema(root, 'future_protocol_tool', {
+        type: 'object',
+        required: ['future_value'],
+        properties: { future_value: { type: 'string' } },
+        additionalProperties: false,
+      });
+
+      const [result] = withExternalSchemaRoot(EXTERNAL_VERSION, root, () =>
+        runValidations(
+          [{ check: 'response_schema', description: 'future tool response conforms' }],
+          ctxWith('future_protocol_tool', { future_value: 'same-change' }, 'test/future-tool-response.json', {
+            adcpVersion: EXTERNAL_VERSION,
+          })
+        )
+      );
+
+      assert.strictEqual(result.passed, true, result.error);
+      assert.strictEqual(result.strict.valid, true);
+      assert.strictEqual(result.strict.lenient_valid, null);
+
+      const [rejected] = withExternalSchemaRoot(EXTERNAL_VERSION, root, () =>
+        runValidations(
+          [{ check: 'response_schema', description: 'future tool response conforms' }],
+          ctxWith('future_protocol_tool', { future_value: 42 }, 'test/future-tool-response.json', {
+            adcpVersion: EXTERNAL_VERSION,
+          })
+        )
+      );
+      const summary = summarizeStrictValidation([
+        { phase_id: 'external', steps: [{ step_id: 'future', task: 'future_protocol_tool', validations: [rejected] }] },
+      ]);
+      assert.strictEqual(summary.strict_only_failures, 0);
+      assert.strictEqual(summary.lenient_also_failed, 0);
+      assert.strictEqual(summary.lenient_unobserved, 1);
+    } finally {
+      _resetValidationLoader(EXTERNAL_VERSION);
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   test('clean response: strict.valid=true, passed=true, no issues emitted', () => {
     // Minimal valid list_creative_formats response — `formats` is the only
     // required field at the root; an empty array satisfies both Zod and AJV.

--- a/test/lib/storyboard-version-negotiation.test.js
+++ b/test/lib/storyboard-version-negotiation.test.js
@@ -53,6 +53,23 @@ function writeGetProductsRequestSchema(schemaRoot, idVersion, sentinel = 'extern
   );
 }
 
+function writeListCreativesRequestSchema(schemaRoot, idVersion) {
+  fs.mkdirSync(path.join(schemaRoot, 'bundled', 'creative'), { recursive: true });
+  fs.writeFileSync(
+    path.join(schemaRoot, 'bundled', 'creative', 'list-creatives-request.json'),
+    JSON.stringify({
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      $id: `/schemas/${idVersion}/bundled/creative/list-creatives-request.json`,
+      type: 'object',
+      properties: {
+        fields: { type: 'array', items: { enum: ['assets'] } },
+      },
+      required: ['fields'],
+      additionalProperties: true,
+    })
+  );
+}
+
 function writeComplyControllerAsyncRefSchemas(schemaRoot, idVersion) {
   fs.mkdirSync(path.join(schemaRoot, 'compliance'), { recursive: true });
   fs.mkdirSync(path.join(schemaRoot, 'core'), { recursive: true });
@@ -749,6 +766,86 @@ describe('storyboard runner AdCP version negotiation', () => {
     }
   });
 
+  test('latest schema ids and same-change request fields work through the public storyboard runner', async () => {
+    const { createTestClient } = require('../../dist/lib/testing/client.js');
+    const { runStoryboardStep } = require('../../dist/lib/testing/storyboard/runner.js');
+
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'adcp-latest-current-source-request-'));
+    const schemaRoot = path.join(tempRoot, 'dist', 'schemas', 'latest');
+    writeSchemaIndex(schemaRoot, CURRENT_PRERELEASE_VERSION);
+    writeListCreativesRequestSchema(schemaRoot, 'latest');
+
+    const agent = {
+      id: 'current-source-request-agent',
+      name: 'Current source request agent',
+      agent_uri: 'https://stub.example/mcp',
+      protocol: 'mcp',
+    };
+    const client = createTestClient(agent.agent_uri, 'mcp', {
+      adcpVersion: CURRENT_PRERELEASE_VERSION,
+      versionEnvelope: 'auto',
+    });
+    const innerClient = client.client;
+    let capturedRequest;
+    innerClient.ensureEndpointDiscovered = async () => agent;
+    innerClient.detectServerVersion = async () => 'v3';
+    innerClient.validateTaskFeatures = async () => {};
+    innerClient.executor.executeTask = async (_agent, taskName, params) => {
+      capturedRequest = params;
+      return {
+        success: true,
+        status: 'completed',
+        data: {
+          status: 'completed',
+          creatives: [],
+          query_summary: {},
+          pagination: { total: 0, offset: 0, limit: 50, has_more: false },
+        },
+        metadata: {},
+      };
+    };
+
+    const storyboard = {
+      id: 'current_source_request',
+      version: '1.0.0',
+      adcp_version: CURRENT_PRERELEASE_VERSION,
+      title: 'Current-source request',
+      category: 'test',
+      summary: '',
+      narrative: '',
+      agent: { interaction_model: 'sync', capabilities: [] },
+      caller: { role: 'buyer_agent' },
+      phases: [
+        {
+          id: 'creative',
+          title: 'Creative',
+          steps: [
+            {
+              id: 'list',
+              title: 'List creatives with a same-change field value',
+              task: 'list_creatives',
+              sample_request: { fields: ['assets'] },
+            },
+          ],
+        },
+      ],
+    };
+
+    try {
+      const result = await runStoryboardStep('https://stub.example/mcp', storyboard, 'list', {
+        protocol: 'mcp',
+        schemaRoot,
+        _client: client,
+        _profile: { name: agent.name, tools: ['list_creatives'], raw_capabilities: {} },
+      });
+
+      assert.strictEqual(result.passed, true, result.error);
+      assert.deepStrictEqual(capturedRequest.fields, ['assets']);
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   test('latest compliance metadata can be repaired from published_version', () => {
     const { loadComplianceIndex } = require('../../dist/lib/testing/storyboard/index.js');
 
@@ -969,6 +1066,14 @@ describe('storyboard runner AdCP version negotiation', () => {
       assert.throws(
         () => withExternalSchemaRoot('3.0.12', wrongSchemaRoot, () => {}),
         new RegExp(`does not match the requested version.*${CURRENT_PRERELEASE_VERSION.replaceAll('.', '\\.')}`)
+      );
+
+      const mismatchedLatestRoot = path.join(tempRoot, 'schema-bundles', 'latest');
+      writeSchemaIndex(mismatchedLatestRoot, CURRENT_PRERELEASE_VERSION);
+      writeGetProductsRequestSchema(mismatchedLatestRoot, 'latest');
+      assert.throws(
+        () => withExternalSchemaRoot('3.0.12', mismatchedLatestRoot, () => {}),
+        /does not match the requested version.*"latest" ids pinned by a matching root index/
       );
     } finally {
       _resetValidationLoader('3.0.12');


### PR DESCRIPTION
## Summary

- make an explicit external schema root authoritative for storyboard request and response validation
- accept `/schemas/latest/...` IDs only when the schema root index pins a matching real AdCP version
- recover responses rejected only by the packaged Zod snapshot while preserving `expect_error`, version-alias, and context-extraction semantics
- document the pre-publish compliance workflow and add a patch changeset

## Root cause

Pre-publish storyboard runs could load current JSON Schemas, but generated Zod validators compiled into the installed SDK still gated requests and responses. Current-source tools and fields were therefore rejected before or after AJV validation, forcing downstream builds to patch installed package files.

## Validation

- three parallel expert reviews (code, protocol, and Node.js testing), followed by re-review
- `npm run typecheck`
- `npm run build:lib`
- `npm run lint`
- `npm run test:node:fast`
- 69 focused storyboard schema/version tests
- Prettier and commitlint checks

Fixes #2105
