### PR TITLE
fix: preserve generated creative types and complete CLI JSON output

### DIFF
--- a/.changeset/clean-types-drain-json.md
+++ b/.changeset/clean-types-drain-json.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Preserve inline `sync_creatives` result fields in the public core generated types and drain large CLI `--json` payloads before exit.

--- a/bin/adcp-grade.js
+++ b/bin/adcp-grade.js
@@ -2,6 +2,7 @@
 
 const { gradeRequestSigning } = require('../dist/lib/testing/storyboard/request-signing/index.js');
 const { gradeSigner } = require('../dist/lib/testing/storyboard/signer-grader/index.js');
+const { writeJsonOutput } = require('./adcp-json-stdout.js');
 
 const USAGE_REQUEST_SIGNING = `Usage: adcp grade request-signing <agent-url> [options]
 
@@ -244,7 +245,7 @@ async function runRequestSigningGrader(args) {
     }
     const report = await gradeRequestSigning(agentUrl, options);
     if (emitJson) {
-      process.stdout.write(JSON.stringify(report, null, 2) + '\n');
+      await writeJsonOutput(report);
     } else {
       printHumanReport(report, options);
     }
@@ -361,7 +362,7 @@ async function runSignerGrader(args) {
   try {
     const report = await gradeSigner(options);
     if (emitJson) {
-      process.stdout.write(JSON.stringify(report, null, 2) + '\n');
+      await writeJsonOutput(report);
     } else {
       printSignerReport(report);
     }

--- a/bin/adcp-json-stdout.js
+++ b/bin/adcp-json-stdout.js
@@ -6,7 +6,9 @@
 // library on the path corrupts the JSON. These helpers give the CLI two
 // disciplines: capture stray logs and forward them to stderr, and write the
 // final payload via `process.stdout.write` so nothing else can interleave
-// with it.
+// with it. The write callback is awaited because a `true` return value only
+// means the stream is below its high-water mark; it does not mean the bytes
+// have reached a downstream pipe before a caller invokes `process.exit()`.
 
 function captureStdoutLogs() {
   const origLog = console.log;
@@ -28,9 +30,12 @@ function captureStdoutLogs() {
 
 async function writeJsonOutput(payload) {
   const str = typeof payload === 'string' ? payload : JSON.stringify(payload, null, 2);
-  if (!process.stdout.write(str + '\n')) {
-    await new Promise(resolve => process.stdout.once('drain', resolve));
-  }
+  await new Promise((resolve, reject) => {
+    process.stdout.write(str + '\n', error => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
 }
 
 module.exports = { captureStdoutLogs, writeJsonOutput };

--- a/bin/adcp-resolve.js
+++ b/bin/adcp-resolve.js
@@ -18,6 +18,7 @@
 
 const { resolveAgent, AgentResolverError } = require('../dist/lib/signing/server');
 const { createMCPClient, createA2AClient } = require('../dist/lib/protocols');
+const { writeJsonOutput } = require('./adcp-json-stdout.js');
 
 function parseArgs(argv) {
   const opts = { json: false, fresh: false, quiet: false, protocol: 'mcp', allowPrivateIp: false };
@@ -95,7 +96,7 @@ async function handleResolveCommand(argv) {
       fetchCapabilities,
     });
     if (opts.json) {
-      process.stdout.write(JSON.stringify(serialize(resolution), null, 2) + '\n');
+      await writeJsonOutput(serialize(resolution));
     } else {
       printText(resolution, { quiet: opts.quiet });
     }
@@ -103,18 +104,12 @@ async function handleResolveCommand(argv) {
   } catch (err) {
     if (err instanceof AgentResolverError) {
       if (opts.json) {
-        process.stdout.write(
-          JSON.stringify(
-            {
-              ok: false,
-              code: err.code,
-              message: err.message,
-              detail: err.detail,
-            },
-            null,
-            2
-          ) + '\n'
-        );
+        await writeJsonOutput({
+          ok: false,
+          code: err.code,
+          message: err.message,
+          detail: err.detail,
+        });
       } else {
         process.stderr.write(`✖ ${err.code}\n  ${err.message}\n`);
         for (const [k, v] of Object.entries(err.detail)) {

--- a/bin/adcp-signing.js
+++ b/bin/adcp-signing.js
@@ -12,6 +12,7 @@ const {
   StaticJwksResolver,
   verifyRequestSignature,
 } = require('../dist/lib/signing/index.js');
+const { writeJsonOutput } = require('./adcp-json-stdout.js');
 
 function generateKey(argv) {
   let alg = 'ed25519';
@@ -164,7 +165,7 @@ async function verifyVector(argv) {
       operation,
       adcpVersion: vector.signing_profile_version ?? '3.1',
     });
-    console.log(JSON.stringify({ outcome: 'accepted', verified_signer: verified, operation }, null, 2));
+    await writeJsonOutput({ outcome: 'accepted', verified_signer: verified, operation });
     return { accepted: true };
   } catch (err) {
     if (err instanceof RequestSignatureError) {
@@ -174,7 +175,7 @@ async function verifyVector(argv) {
         failed_step: err.failedStep,
         message: err.message,
       };
-      console.log(JSON.stringify(payload, null, 2));
+      await writeJsonOutput(payload);
       return { accepted: false, code: err.code };
     }
     throw err;

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -518,7 +518,7 @@ async function displayAgentInfo(agentConfig, jsonOutput) {
       ...info,
       ...(capabilities && { capabilities }),
     };
-    console.log(JSON.stringify(output, null, 2));
+    await writeJsonOutput(output);
   } else {
     console.log(`\n📋 Agent Information\n`);
     console.log(`Name: ${info.name}`);
@@ -732,7 +732,7 @@ async function handleTestCommand(args) {
         if (useOAuth) {
           // Only error on expired tokens if --oauth flag was explicitly passed
           if (jsonOutput) {
-            console.log(
+            await writeJsonOutput(
               JSON.stringify({
                 success: false,
                 error: 'OAuth tokens expired',
@@ -813,7 +813,7 @@ async function handleTestCommand(args) {
     const result = await runAgentTests(agentUrl, scenario, testOptions);
 
     if (jsonOutput) {
-      console.log(formatTestResultsJSON(result));
+      await writeJsonOutput(formatTestResultsJSON(result));
     } else {
       console.log(formatTestResults(result));
     }
@@ -1224,7 +1224,7 @@ async function maybeRunInlineOAuth(agentArg, args, { jsonOutput } = {}) {
     } catch (err) {
       const hint = `Run: adcp --save-auth ${agentArg} ${saved.url} --oauth to re-register`;
       if (jsonOutput) {
-        console.log(
+        await writeJsonOutput(
           JSON.stringify({
             success: false,
             error: 'oauth_flow_failed',
@@ -1249,7 +1249,7 @@ async function maybeRunInlineOAuth(agentArg, args, { jsonOutput } = {}) {
     // non-zero instead of silently running and failing N minutes later on
     // a 401 from the storyboard runner.
     if (jsonOutput) {
-      console.log(
+      await writeJsonOutput(
         JSON.stringify({
           success: false,
           error: 'oauth_requires_alias',
@@ -1627,12 +1627,12 @@ function prepareTestKitComplianceSelection(args, opts) {
   };
 }
 
-function exitTestKitSelectionError(error, jsonOutput) {
+async function exitTestKitSelectionError(error, jsonOutput) {
   const message = error instanceof Error ? error.message : String(error);
   const code = error?.code || 'TEST_KIT_LOAD_FAILED';
   const details = error?.details || {};
   if (jsonOutput) {
-    process.stdout.write(`${JSON.stringify({ success: false, error: { code, message, ...details } })}\n`);
+    await writeJsonOutput(JSON.stringify({ success: false, error: { code, message, ...details } }));
   } else {
     console.error(`ERROR: ${message}`);
   }
@@ -2643,7 +2643,7 @@ async function handleStoryboardRun(args) {
     args = prepared.args;
     opts = prepared.opts;
   } catch (err) {
-    exitTestKitSelectionError(err, jsonOutput);
+    await exitTestKitSelectionError(err, jsonOutput);
   }
 
   ({
@@ -4907,7 +4907,7 @@ EXAMPLES:
     const report = await checker.check();
 
     if (jsonOutput) {
-      console.log(JSON.stringify(report, null, 2));
+      await writeJsonOutput(report);
       process.exit(report.summary.totalIssues > 0 ? 1 : 0);
       return;
     }
@@ -5087,7 +5087,7 @@ EXAMPLES:
   });
 
   if (jsonOutput) {
-    console.log(JSON.stringify(report, null, 2));
+    await writeJsonOutput(report);
     process.exit(hasLikelyHypothesis(report) ? 1 : 0);
   }
 
@@ -5215,7 +5215,8 @@ async function main() {
   // Handle subcommands before global --help so their own --help works
   if (args[0] === 'registry') {
     const code = await handleRegistryCommand(args.slice(1));
-    process.exit(code);
+    process.exitCode = code;
+    return;
   }
 
   if (args[0] === 'test') {
@@ -6364,7 +6365,7 @@ credential material — never sync or commit.
         await mcpClient.close();
 
         if (jsonOutput) {
-          console.log(JSON.stringify({ tools: toolsResult.tools, protocol: 'mcp', oauth: true }, null, 2));
+          await writeJsonOutput({ tools: toolsResult.tools, protocol: 'mcp', oauth: true });
         } else {
           console.log(`\n📋 Agent Information (OAuth)\n`);
           console.log(`Protocol: MCP`);
@@ -6544,20 +6545,14 @@ credential material — never sync or commit.
         }
 
         if (jsonOutput) {
-          console.log(
-            JSON.stringify(
-              {
-                data: resultData,
-                metadata: {
-                  protocol: 'mcp',
-                  responseTimeMs: responseTime,
-                  oauth: true,
-                },
-              },
-              null,
-              2
-            )
-          );
+          await writeJsonOutput({
+            data: resultData,
+            metadata: {
+              protocol: 'mcp',
+              responseTimeMs: responseTime,
+              oauth: true,
+            },
+          });
         } else {
           console.log('\n✅ SUCCESS\n');
           console.log('Response:');
@@ -6612,7 +6607,7 @@ credential material — never sync or commit.
 
           // Output webhook response
           if (jsonOutput) {
-            console.log(JSON.stringify(webhookResponse.result || webhookResponse, null, 2));
+            await writeJsonOutput(webhookResponse.result || webhookResponse);
           } else {
             console.log('\n✅ ASYNC RESPONSE RECEIVED\n');
             console.log('Response:');
@@ -6650,26 +6645,20 @@ credential material — never sync or commit.
     if (result.success) {
       if (jsonOutput) {
         // Raw JSON output - include protocol metadata and warnings
-        console.log(
-          JSON.stringify(
-            {
-              data: result.data,
-              metadata: {
-                taskId: result.metadata.taskId,
-                protocol: result.metadata.agent.protocol,
-                responseTimeMs: result.metadata.responseTimeMs,
-                ...(result.conversation &&
-                  result.conversation.length > 0 && {
-                    protocolMessage: extractProtocolMessage(result.conversation, result.metadata.agent.protocol),
-                    contextId: result.metadata.taskId, // Using taskId as context identifier
-                  }),
-              },
-              ...(deprecationWarnings.length > 0 && { warnings: deprecationWarnings }),
-            },
-            null,
-            2
-          )
-        );
+        await writeJsonOutput({
+          data: result.data,
+          metadata: {
+            taskId: result.metadata.taskId,
+            protocol: result.metadata.agent.protocol,
+            responseTimeMs: result.metadata.responseTimeMs,
+            ...(result.conversation &&
+              result.conversation.length > 0 && {
+                protocolMessage: extractProtocolMessage(result.conversation, result.metadata.agent.protocol),
+                contextId: result.metadata.taskId, // Using taskId as context identifier
+              }),
+          },
+          ...(deprecationWarnings.length > 0 && { warnings: deprecationWarnings }),
+        });
       } else {
         // Pretty output
         console.log('\n✅ SUCCESS\n');
@@ -6760,20 +6749,14 @@ credential material — never sync or commit.
 
       if (!canAutoBrowse) {
         if (jsonOutput) {
-          console.log(
-            JSON.stringify(
-              {
-                error: {
-                  code: error.code,
-                  subCode: error.subCode,
-                  message: error.message,
-                  requirements: error.requirements,
-                },
-              },
-              null,
-              2
-            )
-          );
+          await writeJsonOutput({
+            error: {
+              code: error.code,
+              subCode: error.subCode,
+              message: error.message,
+              requirements: error.requirements,
+            },
+          });
         } else {
           console.error('\n🔐 Agent requires OAuth authorization.');
           console.error(`   Authorization server: ${safe(error.requirements.authorizationServer) ?? '(unknown)'}`);
@@ -6895,16 +6878,10 @@ credential material — never sync or commit.
             }
 
             if (jsonOutput) {
-              console.log(
-                JSON.stringify(
-                  {
-                    data: resultData,
-                    metadata: { protocol: 'mcp', responseTimeMs: responseTime, oauth: true },
-                  },
-                  null,
-                  2
-                )
-              );
+              await writeJsonOutput({
+                data: resultData,
+                metadata: { protocol: 'mcp', responseTimeMs: responseTime, oauth: true },
+              });
             } else {
               console.log('\n✅ SUCCESS\n');
               console.log('Response:');
@@ -6921,7 +6898,7 @@ credential material — never sync or commit.
             await mcpClient.close();
 
             if (jsonOutput) {
-              console.log(JSON.stringify({ tools: toolsResult.tools, protocol: 'mcp', oauth: true }, null, 2));
+              await writeJsonOutput({ tools: toolsResult.tools, protocol: 'mcp', oauth: true });
             } else {
               console.log(`\n📋 Agent Information (OAuth)\n`);
               console.log(`Protocol: MCP`);

--- a/scripts/generate-types.ts
+++ b/scripts/generate-types.ts
@@ -100,6 +100,18 @@ const PRIORITY_CANONICAL_SCHEMAS = [
   'property/validate-property-delivery-response.json',
 ] as const;
 
+// Extract only these declarations from their authoritative schemas before
+// broad aggregate roots compile. Compiling the entire schema early would also
+// claim every referenced type and cause large, unrelated declaration-order
+// churn in core.generated.ts.
+const PRIORITY_EXTRACTED_TYPES = [
+  {
+    ref: 'creative/sync-creatives-response.json',
+    typeName: 'SyncCreativesSuccess',
+    reason: 'the async-response-data webhook union can collapse the conditional creatives[] item to an empty object',
+  },
+] as const;
+
 const PRIORITY_CANONICAL_TYPE_NAMES = new Set([
   'ExtensionObject',
   'CreativeBrief',
@@ -3534,6 +3546,40 @@ async function generateTypes() {
     }
   }
   console.log(`✅ Generated ${PRIORITY_CANONICAL_SCHEMAS.length} priority canonical schemas`);
+
+  for (const { ref, typeName, reason } of PRIORITY_EXTRACTED_TYPES) {
+    try {
+      const schema = loadCachedSchema(ref);
+      if (!schema) throw new Error(`Schema ${ref} not found in cache`);
+      const rootTypeName =
+        typeof schema.title === 'string' ? schema.title.replace(/[^A-Za-z0-9]/g, '') : schemaPathToTypeName(ref);
+      const strictSchema = enforceStrictSchema(removeArrayLengthConstraints(injectJsdocConstraints(schema)));
+      const types = await compile(strictSchema, rootTypeName, {
+        bannerComment: '',
+        style: { semi: true, singleQuote: true },
+        additionalProperties: false,
+        strictIndexSignatures: true,
+        $refOptions: { resolve: { cache: refResolver } },
+      });
+      const emittedNames = collectExportedTypeNames(types);
+      if (!emittedNames.has(typeName)) {
+        throw new Error(`Expected ${typeName} was not emitted from ${ref}`);
+      }
+
+      // Suppress every auxiliary declaration from this compile. Those types
+      // retain their normal first-definition ownership later in generation.
+      const suppressedNames = new Set([...generatedCoreTypes, ...emittedNames].filter(name => name !== typeName));
+      const extractedType = filterDuplicateTypeDefinitions(types, suppressedNames);
+      if (!new RegExp(`^export (?:type|interface) ${typeName}\\b`, 'm').test(extractedType)) {
+        throw new Error(`Unable to isolate ${typeName} from ${ref}`);
+      }
+      generatedCoreTypes.add(typeName);
+      coreTypes += `// ${typeName.toUpperCase()} PRIORITY EXTRACTED TYPE\n${extractedType}\n`;
+    } catch (error) {
+      console.error(`❌ Failed to generate priority extracted type ${typeName} (${reason}):`, error.message);
+    }
+  }
+  console.log(`✅ Generated ${PRIORITY_EXTRACTED_TYPES.length} priority extracted types`);
 
   for (const schemaName of ADCP_CORE_SCHEMAS) {
     try {

--- a/src/lib/types/core.generated.ts
+++ b/src/lib/types/core.generated.ts
@@ -1,5 +1,5 @@
 // Generated AdCP core types from official schemas v3.2.0-beta.2
-// Generated at: 2026-08-19T05:52:36.208Z
+// Generated at: 2026-08-19T10:59:40.427Z
 
 // ACCOUNTCURRENCYMODE CANONICAL ENUM
 /**
@@ -10183,6 +10183,76 @@ export interface AuthorizationResult {
     message: string;
   };
 }
+// SYNCCREATIVESSUCCESS PRIORITY EXTRACTED TYPE
+/**
+ * Success response - sync operation processed creatives (may include per-item failures)
+ */
+export interface SyncCreativesSuccess {
+  /**
+   * Whether this was a dry run (no actual changes made)
+   */
+  dry_run?: boolean;
+  /**
+   * Results for each creative processed. Items with action='failed' indicate per-item validation/processing failures, not operation-level failures.
+   */
+  creatives: {
+    /**
+     * Creative ID from the request
+     */
+    creative_id: string;
+    account?: Account;
+    action: CreativeAction;
+    status?: CreativeStatus;
+    /**
+     * Platform-specific ID assigned to the creative
+     */
+    platform_id?: string;
+    localization?: CreativeLocalizationReadback;
+    /**
+     * Field names that were modified (only present when action='updated')
+     */
+    changes?: string[];
+    /**
+     * Validation or processing errors (only present when action='failed')
+     */
+    errors?: Error[];
+    /**
+     * Non-fatal warnings about this creative
+     */
+    warnings?: string[];
+    /**
+     * Preview URL for generative creatives (only present for generative formats)
+     */
+    preview_url?: string;
+    /**
+     * ISO 8601 timestamp when preview link expires (only present when preview_url exists)
+     * @format date-time
+     */
+    expires_at?: string;
+    /**
+     * Package IDs this creative was successfully assigned to (only present when assignments were requested)
+     */
+    assigned_to?: string[];
+    /**
+     * Assignment errors by package ID (only present when assignment failures occurred)
+     */
+    assignment_errors?: {
+      /**
+       * Error message for this package assignment
+       *
+       * This interface was referenced by `undefined`'s JSON-Schema definition
+       * via the `patternProperty` "^[a-zA-Z0-9_-]+$".
+       */
+      [k: string]: string | undefined;
+    };
+  }[];
+  /**
+   * When true, this response contains simulated data from sandbox mode.
+   */
+  sandbox?: boolean;
+  context?: ContextObject;
+  ext?: ExtensionObject;
+}
 // MEDIA-BUY SCHEMA
 /**
  * Pending or rejected operator-identity transition. While present, the top-level operator and operator_unit remain the current canonical identity. Re-read list_accounts until the request is applied (canonical fields change and this object disappears) or rejected.
@@ -20035,26 +20105,6 @@ export interface BuildCreativeAsyncSubmitted {
    * Optional advisory errors accompanying the submitted envelope. Use only for non-blocking warnings (e.g., throttled_severity advisories, governance observations). Terminal failures belong in the error branch, not here.
    */
   errors?: Error[];
-  context?: ContextObject;
-  ext?: ExtensionObject;
-}
-/**
- * Success response - sync operation processed creatives (may include per-item failures)
- */
-export interface SyncCreativesSuccess {
-  /**
-   * Whether this was a dry run (no actual changes made)
-   */
-  dry_run?: boolean;
-  /**
-   * Results for each creative processed. Items with action='failed' indicate per-item validation/processing failures, not operation-level failures.
-   */
-  creatives: {
-  }[];
-  /**
-   * When true, this response contains simulated data from sandbox mode.
-   */
-  sandbox?: boolean;
   context?: ContextObject;
   ext?: ExtensionObject;
 }

--- a/src/type-tests/generated-required-fields.type-test.ts
+++ b/src/type-tests/generated-required-fields.type-test.ts
@@ -3,6 +3,7 @@ import type {
   GeoDeliveryMetrics,
   KeywordDeliveryMetrics,
   PostalCountrySystem,
+  SyncCreativesSuccess as CoreSyncCreativesSuccess,
   TasksGetResponse,
 } from '../lib/types/core.generated';
 import type {
@@ -18,11 +19,13 @@ import type {
   ProtocolEnvelope as ToolProtocolEnvelope,
   SignalDefinitionEnrichment as ToolSignalDefinitionEnrichment,
   SignalTargetingExpression as ToolSignalTargetingExpression,
+  SyncCreativesSuccess as ToolSyncCreativesSuccess,
 } from '../lib/types/tools.generated';
 
 type Assert<T extends true> = T;
 type IsRequired<T, K extends keyof T> = {} extends Pick<T, K> ? false : true;
 type IsOptional<T, K extends keyof T> = {} extends Pick<T, K> ? true : false;
+type HasKey<T, K extends PropertyKey> = K extends keyof T ? true : false;
 
 // Canonical core types must preserve every required property declared by their
 // source JSON Schema. Compatibility widening belongs on tool-specific response
@@ -35,6 +38,27 @@ type _ContentIdIsRequired = Assert<IsRequired<CatalogItemDeliveryMetrics, 'conte
 type _PostalCountryIsRequired = Assert<IsRequired<PostalCountrySystem, 'country'>>;
 type _PostalSystemIsRequired = Assert<IsRequired<PostalCountrySystem, 'system'>>;
 type _TaskProtocolIsRequired = Assert<IsRequired<TasksGetResponse, 'protocol'>>;
+
+// The core copy is also reached through MCPWebhookPayload's broad async
+// response union. Keep that generation path from erasing the inline
+// sync_creatives result item to `{}` while the tool-local copy stays intact.
+type CoreSyncCreative = CoreSyncCreativesSuccess['creatives'][number];
+type ToolSyncCreative = ToolSyncCreativesSuccess['creatives'][number];
+type _CoreSyncCreativeIdIsRequired = Assert<IsRequired<CoreSyncCreative, 'creative_id'>>;
+type _CoreSyncCreativeActionIsRequired = Assert<IsRequired<CoreSyncCreative, 'action'>>;
+type _CoreSyncCreativeHasAccount = Assert<HasKey<CoreSyncCreative, 'account'>>;
+type _CoreSyncCreativeHasStatus = Assert<HasKey<CoreSyncCreative, 'status'>>;
+type _CoreSyncCreativeHasPlatformId = Assert<HasKey<CoreSyncCreative, 'platform_id'>>;
+type _CoreSyncCreativeHasLocalization = Assert<HasKey<CoreSyncCreative, 'localization'>>;
+type _CoreSyncCreativeHasChanges = Assert<HasKey<CoreSyncCreative, 'changes'>>;
+type _CoreSyncCreativeHasErrors = Assert<HasKey<CoreSyncCreative, 'errors'>>;
+type _CoreSyncCreativeHasWarnings = Assert<HasKey<CoreSyncCreative, 'warnings'>>;
+type _CoreSyncCreativeHasPreviewUrl = Assert<HasKey<CoreSyncCreative, 'preview_url'>>;
+type _CoreSyncCreativeHasExpiresAt = Assert<HasKey<CoreSyncCreative, 'expires_at'>>;
+type _CoreSyncCreativeHasAssignedTo = Assert<HasKey<CoreSyncCreative, 'assigned_to'>>;
+type _CoreSyncCreativeHasAssignmentErrors = Assert<HasKey<CoreSyncCreative, 'assignment_errors'>>;
+type _ToolSyncCreativeIdIsRequired = Assert<IsRequired<ToolSyncCreative, 'creative_id'>>;
+type _ToolSyncCreativeActionIsRequired = Assert<IsRequired<ToolSyncCreative, 'action'>>;
 
 // The published @adcp/sdk/types/tools.generated deep import historically
 // exported these canonical names. Keep them as strict core re-exports.

--- a/test/lib/cli-json-stdout.test.js
+++ b/test/lib/cli-json-stdout.test.js
@@ -1,6 +1,17 @@
 const { test } = require('node:test');
 const assert = require('node:assert');
+const http = require('node:http');
+const { spawn } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { Writable } = require('node:stream');
+const { McpServer } = require('@modelcontextprotocol/sdk/server/mcp.js');
+const { StreamableHTTPServerTransport } = require('@modelcontextprotocol/sdk/server/streamableHttp.js');
+const { z } = require('zod');
 const { captureStdoutLogs, writeJsonOutput } = require('../../bin/adcp-json-stdout.js');
+
+const CLI = path.resolve(__dirname, '../../bin/adcp.js');
 
 function withWritePatch(stream, fn) {
   const original = stream.write;
@@ -15,6 +26,32 @@ function withWritePatch(stream, fn) {
     stream.write = original;
   }
   return captured.join('');
+}
+
+async function collectSlowCliOutput(child) {
+  let stdout = '';
+  let stderr = '';
+  child.stderr.setEncoding('utf8');
+  child.stderr.on('data', chunk => (stderr += chunk));
+  const slowConsumer = new Writable({
+    highWaterMark: 1024,
+    write(chunk, _encoding, callback) {
+      stdout += chunk.toString('utf8');
+      setTimeout(callback, 10);
+    },
+  });
+  child.stdout.pipe(slowConsumer);
+
+  const exitCodePromise = new Promise((resolve, reject) => {
+    child.on('error', reject);
+    child.on('close', resolve);
+  });
+  const outputFinished = new Promise((resolve, reject) => {
+    slowConsumer.on('finish', resolve);
+    slowConsumer.on('error', reject);
+  });
+  const [exitCode] = await Promise.all([exitCodePromise, outputFinished]);
+  return { exitCode, stdout, stderr };
 }
 
 test('captureStdoutLogs forwards console.log to stderr', () => {
@@ -46,8 +83,9 @@ test('writeJsonOutput writes stringified JSON plus newline to stdout', async () 
   const stdoutText = await new Promise(resolve => {
     const chunks = [];
     const original = process.stdout.write;
-    process.stdout.write = chunk => {
+    process.stdout.write = (chunk, callback) => {
       chunks.push(typeof chunk === 'string' ? chunk : chunk.toString('utf8'));
+      callback?.();
       return true;
     };
     writeJsonOutput({ a: 1, b: 'x' }).finally(() => {
@@ -65,8 +103,9 @@ test('writeJsonOutput passes strings through unchanged (already formatted)', asy
   const stdoutText = await new Promise(resolve => {
     const chunks = [];
     const original = process.stdout.write;
-    process.stdout.write = chunk => {
+    process.stdout.write = (chunk, callback) => {
       chunks.push(typeof chunk === 'string' ? chunk : chunk.toString('utf8'));
+      callback?.();
       return true;
     };
     writeJsonOutput(preformatted).finally(() => {
@@ -75,6 +114,107 @@ test('writeJsonOutput passes strings through unchanged (already formatted)', asy
     });
   });
   assert.strictEqual(stdoutText, preformatted + '\n');
+});
+
+test('writeJsonOutput waits for the stream callback when write reports success', async () => {
+  const original = process.stdout.write;
+  let finishWrite;
+  let settled = false;
+
+  process.stdout.write = (_chunk, callback) => {
+    finishWrite = callback;
+    return true;
+  };
+
+  try {
+    const writing = writeJsonOutput({ buffered: true }).then(() => {
+      settled = true;
+    });
+    assert.strictEqual(settled, false, 'a true return value must not be treated as a completed write');
+    finishWrite();
+    await writing;
+    assert.strictEqual(settled, true);
+  } finally {
+    process.stdout.write = original;
+  }
+});
+
+test('CLI tools-list --json drains a large schema document before exiting', { timeout: 60_000 }, async t => {
+  const largeDescription = 'schema-description-'.repeat(24_000);
+  const createMcpServer = () => {
+    const server = new McpServer({ name: 'large-schema-test', version: '1.0.0' });
+    server.registerTool(
+      'large_schema_tool',
+      {
+        description: 'Tool with a generated-size input schema',
+        inputSchema: {
+          payload: z.string().describe(largeDescription),
+        },
+      },
+      async () => ({ content: [{ type: 'text', text: '{}' }] })
+    );
+    server.registerTool(
+      'large_result_tool',
+      {
+        description: 'Tool with a generated-size result',
+        inputSchema: {},
+      },
+      async () => ({
+        content: [{ type: 'text', text: JSON.stringify({ status: 'completed', payload: largeDescription }) }],
+      })
+    );
+    return server;
+  };
+
+  const httpServer = http.createServer(async (req, res) => {
+    const mcp = createMcpServer();
+    const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+    try {
+      await mcp.connect(transport);
+      await transport.handleRequest(req, res);
+    } finally {
+      await mcp.close();
+    }
+  });
+  await new Promise(resolve => httpServer.listen(0, '127.0.0.1', resolve));
+  t.after(async () => {
+    if (typeof httpServer.closeAllConnections === 'function') httpServer.closeAllConnections();
+    await new Promise(resolve => httpServer.close(resolve));
+  });
+
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'adcp-cli-json-'));
+  t.after(() => fs.rmSync(tempHome, { recursive: true, force: true }));
+  const url = `http://127.0.0.1:${httpServer.address().port}/mcp`;
+  const listChild = spawn('node', [CLI, url, '--protocol', 'mcp', '--json', '--allow-http'], {
+    env: { ...process.env, HOME: tempHome, ADCP_SKIP_VERSION_CHECK: '1' },
+  });
+  const listOutput = await collectSlowCliOutput(listChild);
+
+  assert.strictEqual(listOutput.exitCode, 0, `CLI should exit successfully. stderr:\n${listOutput.stderr}`);
+  assert.ok(
+    Buffer.byteLength(listOutput.stdout) > 128 * 1024,
+    'fixture must exceed the historical truncation boundary'
+  );
+  const listed = JSON.parse(listOutput.stdout);
+  assert.strictEqual(listed.tools[0].name, 'large_schema_tool');
+  assert.strictEqual(listed.tools[0].inputSchema.properties.payload.description, largeDescription);
+
+  const resultChild = spawn(
+    'node',
+    [CLI, url, 'large_result_tool', '{}', '--protocol', 'mcp', '--json', '--allow-http'],
+    {
+      env: { ...process.env, HOME: tempHome, ADCP_SKIP_VERSION_CHECK: '1' },
+    }
+  );
+  const resultOutput = await collectSlowCliOutput(resultChild);
+
+  assert.strictEqual(resultOutput.exitCode, 0, `CLI should exit successfully. stderr:\n${resultOutput.stderr}`);
+  assert.ok(
+    Buffer.byteLength(resultOutput.stdout) > 128 * 1024,
+    'result fixture must exceed the historical truncation boundary'
+  );
+  const result = JSON.parse(resultOutput.stdout);
+  assert.strictEqual(result.data.payload, largeDescription);
 });
 
 test('stdout stays clean when libraries log during a captured region', () => {


### PR DESCRIPTION
## Summary

- preserve the authoritative inline `sync_creatives` result item shape in `core.generated`
- await stdout completion before CLI JSON commands force process exit, including delegated registry, grade, resolve, and signing paths
- add generated-type assertions and slow-consumer regressions for tool listings and tool results larger than 128 KiB

## Root cause

The broad async webhook schema claimed `SyncCreativesSuccess` before its authoritative response schema was compiled, collapsing the inline `creatives[]` item to `{}`. Separately, CLI JSON branches treated a successful `stdout.write()` return value or `console.log()` call as proof that downstream pipes had received all bytes before `process.exit()`.

## Validation

- three independent expert reviews: protocol/type generation, code quality, and Node/CLI stream behavior
- `npm run typecheck`
- `npm run ci:codegen-strict`
- focused CLI stdout, OAuth, signing, test-kit, registry, and generated-type tests
- full `npm test` run reached 15,490 passing tests with one unrelated 100 ms timing assertion missing by 2 ms under load; that test passed in 6 ms when rerun alone
- pre-push typecheck and build validation

Fixes #2611
Fixes #2612
