### PR TITLE
fix: restore beta conformance and compatibility regressions

### DIFF
--- a/.changeset/fresh-seals-fix-beta-regressions.md
+++ b/.changeset/fresh-seals-fix-beta-regressions.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Restore beta conformance and compatibility behavior for structured business rejections, storyboard applicability, safe auth-probe selection, natural-key account operators, AdCP 3.0 capability projection, and portfolio-shaped brand JWKS discovery.

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -24,7 +24,7 @@ import {
 } from '../validation/client-hooks';
 import { formatIssues } from '../validation/schema-validator';
 import { ADCP_VERSION } from '../version';
-import { unwrapProtocolResponse, isAdcpError, isTerminalAdcpError } from '../utils/response-unwrapper';
+import { unwrapProtocolResponse, isTerminalAdcpError } from '../utils/response-unwrapper';
 import { extractAdcpErrorInfo, extractCorrelationId } from '../utils/error-extraction';
 import { generateIdempotencyKey, requestUsesIdempotency, redactIdempotencyKeyInArgs } from '../utils/idempotency';
 import { normalizeGetProductsResponse } from '../utils/pricing-adapter';
@@ -1417,9 +1417,18 @@ export class TaskExecutor {
       const ae = data.adcp_error;
       return ae.message ? `${ae.code}: ${ae.message}` : ae.code;
     }
+    const pluralError = Array.isArray(data?.errors)
+      ? data.errors
+          .map((error: any) => error?.message || error?.code)
+          .filter((value: unknown): value is string => typeof value === 'string' && value.length > 0)
+          .join('; ')
+      : undefined;
     return (
       data?.error ||
-      (isAdcpError(data) ? data.errors.map((e: any) => e.message || e.code).join('; ') : null) ||
+      pluralError ||
+      data?.error_detail ||
+      data?.reason ||
+      data?.rejection_reason ||
       data?.message ||
       'Operation failed'
     );

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -1212,11 +1212,20 @@ export class TaskExecutor {
       case ADCP_STATUS.REJECTED:
       case ADCP_STATUS.CANCELED: {
         const failedData = this.extractResponseData(response, debugLogs, taskName);
-        const adcpErrorInfo = extractAdcpErrorInfo(failedData);
+        // Raw/in-process protocol clients may wrap the tool payload under
+        // `data` while carrying the task lifecycle status at the top level.
+        // The generic unwrapper intentionally preserves that wrapper, so
+        // select its nested payload here before extracting business errors.
+        const failedPayload =
+          response?.structuredContent === undefined &&
+          response?.content === undefined &&
+          response?.result === undefined &&
+          response?.data != null &&
+          typeof response.data === 'object'
+            ? response.data
+            : failedData;
+        const adcpErrorInfo = extractAdcpErrorInfo(failedPayload);
         const hasStructuredError = !!adcpErrorInfo;
-        const failedError = hasStructuredError
-          ? this.extractOperationError(failedData)
-          : response.error || response.message || `Task ${status}`;
         // Preserve failedData whenever the server returned a structured
         // payload — not just when extractAdcpErrorInfo recognizes an
         // `adcp_error`/`errors` envelope. Tool-level error shapes like
@@ -1226,17 +1235,22 @@ export class TaskExecutor {
         // Only drop `data` when there's literally no structured payload —
         // i.e. falsy or an empty object.
         const hasStructuredPayload =
-          failedData != null &&
-          typeof failedData === 'object' &&
-          (Array.isArray(failedData) || Object.keys(failedData).length > 0);
+          failedPayload != null &&
+          typeof failedPayload === 'object' &&
+          (Array.isArray(failedPayload) || Object.keys(failedPayload).length > 0);
+        const structuredMessage = hasStructuredPayload ? this.extractOperationError(failedPayload) : undefined;
+        const failedError =
+          structuredMessage && structuredMessage !== 'Operation failed'
+            ? structuredMessage
+            : response.error || response.message || structuredMessage || `Task ${status}`;
         return {
           success: false as const,
           status: 'failed' as const,
-          data: hasStructuredError || hasStructuredPayload ? failedData : undefined,
+          data: hasStructuredError || hasStructuredPayload ? failedPayload : undefined,
           error: typeof failedError === 'string' ? failedError : `Task ${status}`,
           adcpError: adcpErrorInfo,
           errorInstance: this.buildErrorInstance(taskId, adcpErrorInfo),
-          correlationId: extractCorrelationId(failedData),
+          correlationId: extractCorrelationId(failedPayload),
           metadata: this.buildMetadata({
             taskId,
             taskName,

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -7550,7 +7550,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
       if (selected?.major === 3 && selected.minor === 0) {
         data = projectCapabilitiesToVersion(data, release.validationVersion);
       }
-      if (selected?.major === 3 && selected.minor === 1) {
+      if (selected !== undefined && (selected.major < 3 || (selected.major === 3 && selected.minor === 1))) {
         delete (data.adcp as GetAdCPCapabilitiesResponse['adcp'] & { capability_changes?: unknown }).capability_changes;
         const forwardMediaBuy = data.media_buy as
           | (NonNullable<typeof data.media_buy> & {
@@ -7568,6 +7568,14 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
             if (forwardMediaBuy.lifecycle_tools.length === 0) delete forwardMediaBuy.lifecycle_tools;
           }
         }
+      }
+      if (selected !== undefined && selected.major < 3) {
+        delete (data.adcp as GetAdCPCapabilitiesResponse['adcp'] & { supported_versions?: string[] })
+          .supported_versions;
+        if (data.media_buy?.features !== undefined) {
+          delete (data.media_buy.features as { canonical_creatives?: boolean }).canonical_creatives;
+        }
+        delete (data as unknown as Record<string, unknown>).library_version;
       }
       const ctx = requestParams.context;
       if (ctx !== null && typeof ctx === 'object' && !Array.isArray(ctx)) {

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -2957,122 +2957,165 @@ const COMPACT_MEDIA_BUY_LIFECYCLE_TOOLS = [
   'control_media_buy',
 ] as const;
 
-const ADCP_3_0_CAPABILITY_KEYS = {
-  root: [
-    'adcp',
-    'supported_protocols',
-    'account',
-    'media_buy',
-    'signals',
-    'governance',
-    'sponsored_intelligence',
-    'brand',
-    'creative',
-    'request_signing',
-    'webhook_signing',
-    'identity',
-    'compliance_testing',
-    'specialisms',
-    'extensions_supported',
-    'experimental_features',
-    'last_updated',
-    'errors',
-    'context',
-    'ext',
-  ],
-  adcp: ['major_versions', 'idempotency'],
-  account: [
-    'require_operator_auth',
-    'authorization_endpoint',
-    'supported_billing',
-    'required_for_products',
-    'account_financials',
-    'sandbox',
-  ],
-  media_buy: [
-    'supported_pricing_models',
-    'reporting_delivery_methods',
-    'offline_delivery_protocols',
-    'features',
-    'execution',
-    'audience_targeting',
-    'conversion_tracking',
-    'content_standards',
-    'portfolio',
-  ],
-  media_buy_features: ['inline_creative_management', 'property_list_filtering', 'catalog_management'],
-  signals: ['data_provider_domains', 'features'],
-  governance: ['aggregation_window_days', 'property_features', 'creative_features'],
-  creative: ['supports_compliance', 'has_creative_library', 'supports_generation', 'supports_transformation'],
-  request_signing: ['supported', 'covers_content_digest', 'required_for', 'warn_for', 'supported_for'],
-  identity: ['per_principal_key_isolation', 'key_origins', 'compromise_notification'],
-} as const;
+type ProjectionSchema = Record<string, unknown>;
 
-const ADCP_3_0_CAPABILITY_PROTOCOLS: ReadonlySet<string> = new Set([
-  'media_buy',
-  'signals',
-  'governance',
-  'sponsored_intelligence',
-  'creative',
-  'brand',
-]);
+const OMIT_PROJECTED_VALUE = Symbol('omit-projected-value');
 
-const ADCP_3_0_CAPABILITY_SPECIALISMS: ReadonlySet<string> = new Set([
-  'audience-sync',
-  'brand-rights',
-  'collection-lists',
-  'content-standards',
-  'creative-ad-server',
-  'creative-generative',
-  'creative-template',
-  'governance-aware-seller',
-  'governance-delivery-monitor',
-  'governance-spend-authority',
-  'property-lists',
-  'sales-broadcast-tv',
-  'sales-catalog-driven',
-  'sales-guaranteed',
-  'sales-non-guaranteed',
-  'sales-proposal-mode',
-  'sales-social',
-  'signal-marketplace',
-  'signal-owned',
-  'signed-requests',
-]);
-
-const LEGACY_PRICING_MODELS = new Set(['cpm', 'vcpm', 'cpc', 'cpcv', 'cpv', 'cpp', 'cpa', 'flat_rate', 'time']);
-
-function retainCapabilityKeys(target: unknown, allowed: readonly string[]): void {
-  if (!isPlainObject(target)) return;
-  const keep = new Set<string>(allowed);
-  for (const key of Object.keys(target)) {
-    if (!keep.has(key)) delete target[key];
-  }
+function asProjectionSchema(value: unknown): ProjectionSchema | undefined {
+  return isPlainObject(value) ? value : undefined;
 }
 
-function projectAdcp30Capabilities(data: GetAdCPCapabilitiesResponse): void {
-  retainCapabilityKeys(data, ADCP_3_0_CAPABILITY_KEYS.root);
-  retainCapabilityKeys(data.adcp, ADCP_3_0_CAPABILITY_KEYS.adcp);
-  retainCapabilityKeys(data.account, ADCP_3_0_CAPABILITY_KEYS.account);
-  retainCapabilityKeys(data.media_buy, ADCP_3_0_CAPABILITY_KEYS.media_buy);
-  retainCapabilityKeys(data.media_buy?.features, ADCP_3_0_CAPABILITY_KEYS.media_buy_features);
-  retainCapabilityKeys(data.signals, ADCP_3_0_CAPABILITY_KEYS.signals);
-  retainCapabilityKeys(data.governance, ADCP_3_0_CAPABILITY_KEYS.governance);
-  retainCapabilityKeys(data.creative, ADCP_3_0_CAPABILITY_KEYS.creative);
-  retainCapabilityKeys(data.request_signing, ADCP_3_0_CAPABILITY_KEYS.request_signing);
-  retainCapabilityKeys(data.identity, ADCP_3_0_CAPABILITY_KEYS.identity);
+function resolveLocalProjectionRef(root: ProjectionSchema, schema: ProjectionSchema): ProjectionSchema {
+  const ref = schema.$ref;
+  if (typeof ref !== 'string' || !ref.startsWith('#/')) return schema;
+  let current: unknown = root;
+  for (const encodedSegment of ref.slice(2).split('/')) {
+    if (!isPlainObject(current)) return schema;
+    const segment = encodedSegment.replace(/~1/g, '/').replace(/~0/g, '~');
+    current = current[segment];
+  }
+  return asProjectionSchema(current) ?? schema;
+}
 
-  if (Array.isArray(data.supported_protocols)) {
-    data.supported_protocols = data.supported_protocols.filter(protocol => ADCP_3_0_CAPABILITY_PROTOCOLS.has(protocol));
+function projectionDiscriminatorMatch(
+  root: ProjectionSchema,
+  schema: ProjectionSchema,
+  value: unknown
+): boolean | undefined {
+  if (!isPlainObject(value)) return undefined;
+  const resolved = resolveLocalProjectionRef(root, schema);
+  const properties = asProjectionSchema(resolved.properties);
+  if (!properties) return undefined;
+  let found = false;
+  for (const [key, propertySchemaValue] of Object.entries(properties)) {
+    const propertySchema = asProjectionSchema(propertySchemaValue);
+    if (!propertySchema || !Object.hasOwn(propertySchema, 'const')) continue;
+    found = true;
+    if (value[key] !== propertySchema.const) return false;
   }
-  if (Array.isArray(data.specialisms)) {
-    data.specialisms = data.specialisms.filter(specialism => ADCP_3_0_CAPABILITY_SPECIALISMS.has(specialism));
+  return found ? true : undefined;
+}
+
+function collectProjectionSchemas(
+  root: ProjectionSchema,
+  schema: ProjectionSchema,
+  value: unknown,
+  depth = 0
+): ProjectionSchema[] {
+  if (depth > 64) return [];
+  const resolved = resolveLocalProjectionRef(root, schema);
+  const schemas: ProjectionSchema[] = [resolved];
+  for (const keyword of ['allOf'] as const) {
+    const branches = resolved[keyword];
+    if (!Array.isArray(branches)) continue;
+    for (const branch of branches) {
+      const branchSchema = asProjectionSchema(branch);
+      if (branchSchema) schemas.push(...collectProjectionSchemas(root, branchSchema, value, depth + 1));
+    }
   }
-  if (Array.isArray(data.media_buy?.supported_pricing_models)) {
-    data.media_buy.supported_pricing_models = data.media_buy.supported_pricing_models.filter(model =>
-      LEGACY_PRICING_MODELS.has(model)
-    );
+  for (const keyword of ['oneOf', 'anyOf'] as const) {
+    const branches = resolved[keyword];
+    if (!Array.isArray(branches)) continue;
+    const branchSchemas = branches.map(asProjectionSchema).filter((branch): branch is ProjectionSchema => !!branch);
+    const matched = branchSchemas.filter(branch => projectionDiscriminatorMatch(root, branch, value) === true);
+    const selected = matched.length > 0 ? matched : branchSchemas;
+    for (const branch of selected) {
+      schemas.push(...collectProjectionSchemas(root, branch, value, depth + 1));
+    }
   }
+  return schemas;
+}
+
+function projectValueToCapabilitySchema(
+  root: ProjectionSchema,
+  schema: ProjectionSchema,
+  value: unknown,
+  depth = 0
+): unknown | typeof OMIT_PROJECTED_VALUE {
+  if (depth > 64) return OMIT_PROJECTED_VALUE;
+  const schemas = collectProjectionSchemas(root, schema, value, depth);
+
+  const allowedValues = schemas.flatMap(candidate => (Array.isArray(candidate.enum) ? candidate.enum : []));
+  if (allowedValues.length > 0 && !allowedValues.some(allowed => Object.is(allowed, value))) {
+    return OMIT_PROJECTED_VALUE;
+  }
+  const constants = schemas.filter(candidate => Object.hasOwn(candidate, 'const')).map(candidate => candidate.const);
+  if (constants.length > 0 && !constants.some(constant => Object.is(constant, value))) {
+    return OMIT_PROJECTED_VALUE;
+  }
+
+  if (Array.isArray(value)) {
+    const itemSchemas = schemas.map(candidate => asProjectionSchema(candidate.items)).filter(Boolean);
+    if (itemSchemas.length === 0) return value;
+    const itemSchema: ProjectionSchema = { allOf: itemSchemas };
+    return value
+      .map(item => projectValueToCapabilitySchema(root, itemSchema, item, depth + 1))
+      .filter(item => item !== OMIT_PROJECTED_VALUE);
+  }
+
+  if (!isPlainObject(value)) return value;
+
+  const propertySchemas = new Map<string, ProjectionSchema[]>();
+  for (const candidate of schemas) {
+    const properties = asProjectionSchema(candidate.properties);
+    if (!properties) continue;
+    for (const [key, propertySchemaValue] of Object.entries(properties)) {
+      const propertySchema = asProjectionSchema(propertySchemaValue);
+      if (!propertySchema) continue;
+      const existing = propertySchemas.get(key) ?? [];
+      existing.push(propertySchema);
+      propertySchemas.set(key, existing);
+    }
+  }
+
+  if (propertySchemas.size === 0) {
+    const mapValueSchema = schemas
+      .map(candidate => asProjectionSchema(candidate.additionalProperties))
+      .find((candidate): candidate is ProjectionSchema => !!candidate);
+    if (!mapValueSchema) return value;
+    const projectedMap: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value)) {
+      const projected = projectValueToCapabilitySchema(root, mapValueSchema, entry, depth + 1);
+      if (projected !== OMIT_PROJECTED_VALUE) projectedMap[key] = projected;
+    }
+    return projectedMap;
+  }
+
+  const projectedObject: Record<string, unknown> = {};
+  for (const [key, candidateSchemas] of propertySchemas) {
+    if (!Object.hasOwn(value, key)) continue;
+    const projected = projectValueToCapabilitySchema(root, { allOf: candidateSchemas }, value[key], depth + 1);
+    if (projected !== OMIT_PROJECTED_VALUE) projectedObject[key] = projected;
+  }
+  return projectedObject;
+}
+
+function projectCapabilitiesToVersion(data: GetAdCPCapabilitiesResponse, version: string): GetAdCPCapabilitiesResponse {
+  const validator = getValidator('get_adcp_capabilities', 'sync', version);
+  const schema = asProjectionSchema((validator as { schema?: unknown } | undefined)?.schema);
+  if (!schema) return data;
+  const projected = projectValueToCapabilitySchema(schema, schema, data);
+  if (!isPlainObject(projected)) return data;
+  const result = projected as unknown as GetAdCPCapabilitiesResponse;
+
+  // The 3.0 response contract predates account inference: every media-buy
+  // seller must advertise a billing party even when the modern source
+  // capability relied on implicit-account defaults.
+  if (result.supported_protocols?.includes('media_buy')) {
+    if (!result.account) {
+      result.account = { supported_billing: ['agent'] };
+    } else if (!Array.isArray(result.account.supported_billing) || result.account.supported_billing.length === 0) {
+      result.account.supported_billing = ['agent'];
+    }
+  }
+
+  // A modern request-signing block can contain only post-3.0 fields. After
+  // projection, omit that empty optional block rather than emitting an object
+  // that violates 3.0's required `supported` discriminator.
+  if (result.request_signing && Object.keys(result.request_signing).length === 0) {
+    delete result.request_signing;
+  }
+  return result;
 }
 
 /** @internal Shared by the platform adapter's principal resolver and dispatcher gate. */
@@ -7493,7 +7536,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
           );
         }
       }
-      const data = structuredClone(capabilitiesData) as GetAdCPCapabilitiesResponse;
+      let data = structuredClone(capabilitiesData) as GetAdCPCapabilitiesResponse;
       const selected = parseAdcpRelease(release.validationVersion);
       if (
         selected !== undefined &&
@@ -7504,7 +7547,9 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
         // temporarily accepts the legacy serialization during a rolling deploy.
         data.request_signing = { ...data.request_signing, covers_content_digest: 'required' };
       }
-      if (selected?.major === 3 && selected.minor === 0) projectAdcp30Capabilities(data);
+      if (selected?.major === 3 && selected.minor === 0) {
+        data = projectCapabilitiesToVersion(data, release.validationVersion);
+      }
       if (selected?.major === 3 && selected.minor === 1) {
         delete (data.adcp as GetAdCPCapabilitiesResponse['adcp'] & { capability_changes?: unknown }).capability_changes;
         const forwardMediaBuy = data.media_buy as

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -2957,6 +2957,124 @@ const COMPACT_MEDIA_BUY_LIFECYCLE_TOOLS = [
   'control_media_buy',
 ] as const;
 
+const ADCP_3_0_CAPABILITY_KEYS = {
+  root: [
+    'adcp',
+    'supported_protocols',
+    'account',
+    'media_buy',
+    'signals',
+    'governance',
+    'sponsored_intelligence',
+    'brand',
+    'creative',
+    'request_signing',
+    'webhook_signing',
+    'identity',
+    'compliance_testing',
+    'specialisms',
+    'extensions_supported',
+    'experimental_features',
+    'last_updated',
+    'errors',
+    'context',
+    'ext',
+  ],
+  adcp: ['major_versions', 'idempotency'],
+  account: [
+    'require_operator_auth',
+    'authorization_endpoint',
+    'supported_billing',
+    'required_for_products',
+    'account_financials',
+    'sandbox',
+  ],
+  media_buy: [
+    'supported_pricing_models',
+    'reporting_delivery_methods',
+    'offline_delivery_protocols',
+    'features',
+    'execution',
+    'audience_targeting',
+    'conversion_tracking',
+    'content_standards',
+    'portfolio',
+  ],
+  media_buy_features: ['inline_creative_management', 'property_list_filtering', 'catalog_management'],
+  signals: ['data_provider_domains', 'features'],
+  governance: ['aggregation_window_days', 'property_features', 'creative_features'],
+  creative: ['supports_compliance', 'has_creative_library', 'supports_generation', 'supports_transformation'],
+  request_signing: ['supported', 'covers_content_digest', 'required_for', 'warn_for', 'supported_for'],
+  identity: ['per_principal_key_isolation', 'key_origins', 'compromise_notification'],
+} as const;
+
+const ADCP_3_0_CAPABILITY_PROTOCOLS: ReadonlySet<string> = new Set([
+  'media_buy',
+  'signals',
+  'governance',
+  'sponsored_intelligence',
+  'creative',
+  'brand',
+]);
+
+const ADCP_3_0_CAPABILITY_SPECIALISMS: ReadonlySet<string> = new Set([
+  'audience-sync',
+  'brand-rights',
+  'collection-lists',
+  'content-standards',
+  'creative-ad-server',
+  'creative-generative',
+  'creative-template',
+  'governance-aware-seller',
+  'governance-delivery-monitor',
+  'governance-spend-authority',
+  'property-lists',
+  'sales-broadcast-tv',
+  'sales-catalog-driven',
+  'sales-guaranteed',
+  'sales-non-guaranteed',
+  'sales-proposal-mode',
+  'sales-social',
+  'signal-marketplace',
+  'signal-owned',
+  'signed-requests',
+]);
+
+const LEGACY_PRICING_MODELS = new Set(['cpm', 'vcpm', 'cpc', 'cpcv', 'cpv', 'cpp', 'cpa', 'flat_rate', 'time']);
+
+function retainCapabilityKeys(target: unknown, allowed: readonly string[]): void {
+  if (!isPlainObject(target)) return;
+  const keep = new Set<string>(allowed);
+  for (const key of Object.keys(target)) {
+    if (!keep.has(key)) delete target[key];
+  }
+}
+
+function projectAdcp30Capabilities(data: GetAdCPCapabilitiesResponse): void {
+  retainCapabilityKeys(data, ADCP_3_0_CAPABILITY_KEYS.root);
+  retainCapabilityKeys(data.adcp, ADCP_3_0_CAPABILITY_KEYS.adcp);
+  retainCapabilityKeys(data.account, ADCP_3_0_CAPABILITY_KEYS.account);
+  retainCapabilityKeys(data.media_buy, ADCP_3_0_CAPABILITY_KEYS.media_buy);
+  retainCapabilityKeys(data.media_buy?.features, ADCP_3_0_CAPABILITY_KEYS.media_buy_features);
+  retainCapabilityKeys(data.signals, ADCP_3_0_CAPABILITY_KEYS.signals);
+  retainCapabilityKeys(data.governance, ADCP_3_0_CAPABILITY_KEYS.governance);
+  retainCapabilityKeys(data.creative, ADCP_3_0_CAPABILITY_KEYS.creative);
+  retainCapabilityKeys(data.request_signing, ADCP_3_0_CAPABILITY_KEYS.request_signing);
+  retainCapabilityKeys(data.identity, ADCP_3_0_CAPABILITY_KEYS.identity);
+
+  if (Array.isArray(data.supported_protocols)) {
+    data.supported_protocols = data.supported_protocols.filter(protocol => ADCP_3_0_CAPABILITY_PROTOCOLS.has(protocol));
+  }
+  if (Array.isArray(data.specialisms)) {
+    data.specialisms = data.specialisms.filter(specialism => ADCP_3_0_CAPABILITY_SPECIALISMS.has(specialism));
+  }
+  if (Array.isArray(data.media_buy?.supported_pricing_models)) {
+    data.media_buy.supported_pricing_models = data.media_buy.supported_pricing_models.filter(model =>
+      LEGACY_PRICING_MODELS.has(model)
+    );
+  }
+}
+
 /** @internal Shared by the platform adapter's principal resolver and dispatcher gate. */
 export const COMPACT_MEDIA_BUY_MUTATION_TOOLS = new Set<string>([
   'request_proposals',
@@ -7375,16 +7493,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
           );
         }
       }
-      const data = {
-        ...capabilitiesData,
-        adcp: { ...capabilitiesData.adcp },
-        ...(capabilitiesData.media_buy !== undefined && {
-          media_buy: {
-            ...capabilitiesData.media_buy,
-            features: { ...capabilitiesData.media_buy.features },
-          },
-        }),
-      } as GetAdCPCapabilitiesResponse;
+      const data = structuredClone(capabilitiesData) as GetAdCPCapabilitiesResponse;
       const selected = parseAdcpRelease(release.validationVersion);
       if (
         selected !== undefined &&
@@ -7395,7 +7504,8 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
         // temporarily accepts the legacy serialization during a rolling deploy.
         data.request_signing = { ...data.request_signing, covers_content_digest: 'required' };
       }
-      if (selected !== undefined && (selected.major < 3 || (selected.major === 3 && selected.minor < 2))) {
+      if (selected?.major === 3 && selected.minor === 0) projectAdcp30Capabilities(data);
+      if (selected?.major === 3 && selected.minor === 1) {
         delete (data.adcp as GetAdCPCapabilitiesResponse['adcp'] & { capability_changes?: unknown }).capability_changes;
         const forwardMediaBuy = data.media_buy as
           | (NonNullable<typeof data.media_buy> & {
@@ -7413,14 +7523,6 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
             if (forwardMediaBuy.lifecycle_tools.length === 0) delete forwardMediaBuy.lifecycle_tools;
           }
         }
-      }
-      if (selected !== undefined && (selected.major < 3 || (selected.major === 3 && selected.minor < 1))) {
-        delete (data.adcp as GetAdCPCapabilitiesResponse['adcp'] & { supported_versions?: string[] })
-          .supported_versions;
-        if (data.media_buy?.features !== undefined) {
-          delete (data.media_buy.features as { canonical_creatives?: boolean }).canonical_creatives;
-        }
-        delete (data as unknown as Record<string, unknown>).library_version;
       }
       const ctx = requestParams.context;
       if (ctx !== null && typeof ctx === 'object' && !Array.isArray(ctx)) {

--- a/src/lib/testing/compliance/comply.ts
+++ b/src/lib/testing/compliance/comply.ts
@@ -882,13 +882,14 @@ export function partitionStoryboardsByRequiredTools(
   const runnable: Storyboard[] = [];
   const missing: NotApplicableStoryboard[] = [];
   for (const sb of storyboards) {
-    const absent = (sb.required_tools ?? []).filter(tool => !discoveredToolNames.has(tool));
-    if (absent.length > 0) {
+    const required = sb.required_tools ?? [];
+    const hasApplicableTool = required.length === 0 || required.some(tool => discoveredToolNames.has(tool));
+    if (!hasApplicableTool) {
       missing.push({
         storyboard_id: sb.id,
         storyboard_title: sb.title,
         track: sb.track,
-        reason: `missing required_tools: ${absent.join(', ')}`,
+        reason: `missing required_tools: ${required.join(', ')}`,
       });
     } else {
       runnable.push(sb);
@@ -1199,16 +1200,36 @@ async function complyImpl(agentUrl: string, options: ComplyOptions): Promise<Com
     // Discover agent capabilities once and share across all storyboards.
     // External cancellation still aborts discovery; timeout_ms is enforced
     // later as a soft storyboard-start budget.
-    const discoveryOptions =
-      testOptions.versionEnvelope === undefined
-        ? { ...effectiveOptions, versionEnvelope: 'major-only' as const }
-        : effectiveOptions;
-    const discoveryClient = createTestClient(agentUrl, effectiveOptions.protocol ?? 'mcp', discoveryOptions);
-    const { profile, step: profileStep } = await discoverAgentProfile(
+    // Discover with the configured release pin first. A major-only discovery
+    // forces modern same-major sellers to project their capabilities as 3.0,
+    // hiding the very fields needed to select current storyboards. Strict
+    // legacy sellers still get a compatibility retry below.
+    let discoveryOptions = effectiveOptions;
+    let discoveryClient = createTestClient(agentUrl, effectiveOptions.protocol ?? 'mcp', discoveryOptions);
+    let { profile, step: profileStep } = await discoverAgentProfile(
       discoveryClient,
       signal,
       complianceIndex.adcp_version
     );
+    if (
+      testOptions.versionEnvelope === undefined &&
+      profile.tools.includes('get_adcp_capabilities') &&
+      profile.raw_capabilities === undefined
+    ) {
+      const legacyDiscoveryOptions = { ...effectiveOptions, versionEnvelope: 'major-only' as const };
+      const legacyDiscoveryClient = createTestClient(
+        agentUrl,
+        effectiveOptions.protocol ?? 'mcp',
+        legacyDiscoveryOptions
+      );
+      const legacyDiscovery = await discoverAgentProfile(legacyDiscoveryClient, signal, complianceIndex.adcp_version);
+      if (legacyDiscovery.profile.raw_capabilities !== undefined) {
+        discoveryOptions = legacyDiscoveryOptions;
+        discoveryClient = legacyDiscoveryClient;
+        profile = legacyDiscovery.profile;
+        profileStep = legacyDiscovery.step;
+      }
+    }
     effectiveOptions = applyNegotiatedComplianceVersionOptions(profile, effectiveOptions, {
       complianceVersion: complianceIndex.adcp_version,
       ...(hostedStableLineAlias !== undefined && { hostedStableLineAlias }),
@@ -1345,17 +1366,21 @@ async function complyImpl(agentUrl: string, options: ComplyOptions): Promise<Com
     }
     const applicableStoryboards = expandScenarios(initialStoryboards, resolveOptions);
 
-    // Exclude storyboards and injected scenarios whose required_tools are absent
-    // from the agent's discovered toolset. These are
+    // For capability-resolved runs, exclude storyboards and injected scenarios whose
+    // required_tools are absent from the agent's discovered toolset. These are
     // not-applicable — the agent doesn't claim the specialism being tested. Running
     // them produces cascading skips that pull the track to `partial`, which is a false
     // signal for AAO badge grading (adcp-client#1680).
-    // Explicit selection narrows which storyboards are considered; it does not make
-    // an unsupported specialism applicable. Call runStoryboard() directly when a
-    // developer intentionally needs to exercise an unsupported tool surface.
-    const applicability = partitionStoryboardsByRequiredTools(applicableStoryboards, profile.tools);
-    const runnableStoryboards = applicability.runnable;
-    missingToolStoryboards.push(...applicability.missing);
+    // Explicit storyboard IDs remain an operator override. Some targeted conformance
+    // runs intentionally exercise the storyboard's own missing-tool skip semantics.
+    let runnableStoryboards: Storyboard[];
+    if (explicitStoryboards?.length) {
+      runnableStoryboards = applicableStoryboards;
+    } else {
+      const applicability = partitionStoryboardsByRequiredTools(applicableStoryboards, profile.tools);
+      runnableStoryboards = applicability.runnable;
+      missingToolStoryboards.push(...applicability.missing);
+    }
 
     // Run storyboards
     const storyboardResults: StoryboardResult[] = [];

--- a/src/lib/testing/compliance/comply.ts
+++ b/src/lib/testing/compliance/comply.ts
@@ -873,6 +873,30 @@ function expandScenarios(storyboards: Storyboard[], resolveOptions: ResolveOptio
   return expanded;
 }
 
+/** @internal Capability applicability partition used by comply() after selection. */
+export function partitionStoryboardsByRequiredTools(
+  storyboards: Storyboard[],
+  discoveredTools: readonly string[]
+): { runnable: Storyboard[]; missing: NotApplicableStoryboard[] } {
+  const discoveredToolNames = new Set(discoveredTools);
+  const runnable: Storyboard[] = [];
+  const missing: NotApplicableStoryboard[] = [];
+  for (const sb of storyboards) {
+    const absent = (sb.required_tools ?? []).filter(tool => !discoveredToolNames.has(tool));
+    if (absent.length > 0) {
+      missing.push({
+        storyboard_id: sb.id,
+        storyboard_title: sb.title,
+        track: sb.track,
+        reason: `missing required_tools: ${absent.join(', ')}`,
+      });
+    } else {
+      runnable.push(sb);
+    }
+  }
+  return { runnable, missing };
+}
+
 /**
  * Group storyboard results by track.
  *
@@ -1321,34 +1345,17 @@ async function complyImpl(agentUrl: string, options: ComplyOptions): Promise<Com
     }
     const applicableStoryboards = expandScenarios(initialStoryboards, resolveOptions);
 
-    // For capability-resolved runs, exclude storyboards and injected scenarios whose
-    // required_tools are absent from the agent's discovered toolset. These are
+    // Exclude storyboards and injected scenarios whose required_tools are absent
+    // from the agent's discovered toolset. These are
     // not-applicable — the agent doesn't claim the specialism being tested. Running
     // them produces cascading skips that pull the track to `partial`, which is a false
     // signal for AAO badge grading (adcp-client#1680).
-    // Explicit storyboard IDs (options.storyboards) bypass this filter — they are an
-    // operator override and should run regardless of required_tools.
-    let runnableStoryboards: Storyboard[];
-    if (explicitStoryboards?.length) {
-      runnableStoryboards = applicableStoryboards;
-    } else {
-      const discoveredToolNames = new Set(profile.tools);
-      const filtered: Storyboard[] = [];
-      for (const sb of applicableStoryboards) {
-        const missing = (sb.required_tools ?? []).filter(t => !discoveredToolNames.has(t));
-        if (missing.length > 0) {
-          missingToolStoryboards.push({
-            storyboard_id: sb.id,
-            storyboard_title: sb.title,
-            track: sb.track,
-            reason: `missing required_tools: ${missing.join(', ')}`,
-          });
-        } else {
-          filtered.push(sb);
-        }
-      }
-      runnableStoryboards = filtered;
-    }
+    // Explicit selection narrows which storyboards are considered; it does not make
+    // an unsupported specialism applicable. Call runStoryboard() directly when a
+    // developer intentionally needs to exercise an unsupported tool surface.
+    const applicability = partitionStoryboardsByRequiredTools(applicableStoryboards, profile.tools);
+    const runnableStoryboards = applicability.runnable;
+    missingToolStoryboards.push(...applicability.missing);
 
     // Run storyboards
     const storyboardResults: StoryboardResult[] = [];

--- a/src/lib/testing/storyboard/request-builder.ts
+++ b/src/lib/testing/storyboard/request-builder.ts
@@ -146,6 +146,29 @@ function runClockMs(runnerVars: RunnerVariables | undefined): number {
   return runnerVars?.runStartMs ?? Date.now();
 }
 
+function resolveMediaBuyReadAccount(fixtureAccount: unknown, contextAccount: unknown, options: TestOptions): unknown {
+  const resolvedAccount = contextAccount ?? resolveAccount(options);
+  // Preserve a fixture-authored natural-key operator: it identifies the
+  // buyer acting for the brand and is not interchangeable with brand.domain.
+  // A context account remains authoritative, while the harness still owns
+  // sandbox routing for fixture-authored natural keys.
+  if (
+    contextAccount === undefined &&
+    fixtureAccount !== null &&
+    typeof fixtureAccount === 'object' &&
+    !Array.isArray(fixtureAccount) &&
+    typeof (fixtureAccount as Record<string, unknown>).operator === 'string' &&
+    typeof (fixtureAccount as Record<string, unknown>).account_id !== 'string'
+  ) {
+    const sandbox = (resolvedAccount as { sandbox?: boolean }).sandbox;
+    return {
+      ...(fixtureAccount as Record<string, unknown>),
+      ...(sandbox !== undefined && { sandbox }),
+    };
+  }
+  return resolvedAccount;
+}
+
 function generatedIdSuffix(step: StoryboardStep, runnerVars: RunnerVariables | undefined, nowMs?: number): string {
   const timestamp = nowMs ?? runClockMs(runnerVars);
   if (runnerVars?.runStartMs === undefined) return String(timestamp);
@@ -471,28 +494,7 @@ const REQUEST_ENRICHERS: Record<string, RequestEnricher> = {
         )
       : {};
     const result: Record<string, unknown> = { ...fixtureFields };
-    const resolvedAccount = context.account ?? resolveAccount(options);
-    const fixtureAccount = fixtureFields.account;
-    // Preserve the fixture-authored natural-key operator: it identifies the
-    // buyer acting for the brand and is not interchangeable with brand.domain.
-    // The harness still owns sandbox routing, and context.account (when a
-    // preceding step resolved a concrete account) remains authoritative.
-    if (
-      context.account === undefined &&
-      fixtureAccount !== null &&
-      typeof fixtureAccount === 'object' &&
-      !Array.isArray(fixtureAccount) &&
-      typeof (fixtureAccount as Record<string, unknown>).operator === 'string' &&
-      typeof (fixtureAccount as Record<string, unknown>).account_id !== 'string'
-    ) {
-      const sandbox = (resolvedAccount as { sandbox?: boolean }).sandbox;
-      result.account = {
-        ...(fixtureAccount as Record<string, unknown>),
-        ...(sandbox !== undefined && { sandbox }),
-      };
-    } else {
-      result.account = resolvedAccount;
-    }
+    result.account = resolveMediaBuyReadAccount(fixtureFields.account, context.account, options);
     if (context.media_buy_id != null && result.media_buy_ids === undefined) {
       result.media_buy_ids = [context.media_buy_id];
     }
@@ -510,7 +512,7 @@ const REQUEST_ENRICHERS: Record<string, RequestEnricher> = {
         )
       : {};
     const result: Record<string, unknown> = { ...fixtureFields };
-    result.account = context.account ?? resolveAccount(options);
+    result.account = resolveMediaBuyReadAccount(fixtureFields.account, context.account, options);
     if (context.media_buy_id != null && result.media_buy_ids === undefined) {
       result.media_buy_ids = [context.media_buy_id];
     }

--- a/src/lib/testing/storyboard/request-builder.ts
+++ b/src/lib/testing/storyboard/request-builder.ts
@@ -471,7 +471,28 @@ const REQUEST_ENRICHERS: Record<string, RequestEnricher> = {
         )
       : {};
     const result: Record<string, unknown> = { ...fixtureFields };
-    result.account = context.account ?? resolveAccount(options);
+    const resolvedAccount = context.account ?? resolveAccount(options);
+    const fixtureAccount = fixtureFields.account;
+    // Preserve the fixture-authored natural-key operator: it identifies the
+    // buyer acting for the brand and is not interchangeable with brand.domain.
+    // The harness still owns sandbox routing, and context.account (when a
+    // preceding step resolved a concrete account) remains authoritative.
+    if (
+      context.account === undefined &&
+      fixtureAccount !== null &&
+      typeof fixtureAccount === 'object' &&
+      !Array.isArray(fixtureAccount) &&
+      typeof (fixtureAccount as Record<string, unknown>).operator === 'string' &&
+      typeof (fixtureAccount as Record<string, unknown>).account_id !== 'string'
+    ) {
+      const sandbox = (resolvedAccount as { sandbox?: boolean }).sandbox;
+      result.account = {
+        ...(fixtureAccount as Record<string, unknown>),
+        ...(sandbox !== undefined && { sandbox }),
+      };
+    } else {
+      result.account = resolvedAccount;
+    }
     if (context.media_buy_id != null && result.media_buy_ids === undefined) {
       result.media_buy_ids = [context.media_buy_id];
     }

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -81,7 +81,7 @@ import {
   generateRandomInvalidJwt,
 } from './probes';
 import { readBrandJsonUrl } from '../../signing/agent-resolver/capabilities-types';
-import { collectAgentEntries } from '../../signing/agent-resolver/select-agent';
+import { selectAgentByUrl } from '../../signing/agent-resolver/select-agent';
 import { selectProbeTask, validateTestKit } from './test-kit';
 import { validateStoryboardShape } from './loader';
 import { probeRequestSigningVector } from './request-signing/probe-dispatch';
@@ -4290,8 +4290,12 @@ async function runStoryboardStepBody(
   if (!clientResolution.reusedShared) {
     const discovered = await getOrDiscoverProfile(client, options);
     profile = discovered.profile;
-    if (profile && !options._profile) {
-      options = { ...options, _profile: profile };
+    if (profile && (!options._profile || !options.agentTools)) {
+      options = {
+        ...options,
+        ...(!options._profile && { _profile: profile }),
+        ...(!options.agentTools && { agentTools: normalizeAgentToolNames(profile.tools) }),
+      };
     }
   } else {
     profile = options._profile;
@@ -5974,7 +5978,7 @@ async function executeProbeStep(
   } else if (step.task === 'request_signing_probe') {
     httpResult = await probeRequestSigningVector(step.id, runState.agentUrl, options);
   } else if (step.task === 'fetch_brand_jwks') {
-    httpResult = await probeBrandJwks(options._profile?.raw_capabilities, probeOpts);
+    httpResult = await probeBrandJwks(options._profile?.raw_capabilities, runState.agentUrl, probeOpts);
   } else if (step.task === 'assert_jwks_purpose') {
     // Webhook delivery is signed with the agent's request-signing key; the
     // deprecated webhook-signing purpose is still accepted (adcontextprotocol/adcp#5555).
@@ -7008,6 +7012,7 @@ function rateLimitTripObservationToProbeResult(
 
 async function probeBrandJwks(
   rawCapabilities: unknown,
+  agentUrl: string,
   options: { allowPrivateIp?: boolean; fetchFn?: typeof fetch }
 ): Promise<HttpProbeResult> {
   const brandJsonUrl = readBrandJsonUrl(rawCapabilities);
@@ -7029,16 +7034,26 @@ async function probeBrandJwks(
     };
   }
 
-  const jwksUri = collectAgentEntries(brand.body)
-    .map(agent => agent.jwks_uri)
-    .find((uri): uri is string => typeof uri === 'string' && uri.length > 0);
+  let jwksUri: string | undefined;
+  try {
+    const agent = selectAgentByUrl(brand.body, agentUrl);
+    jwksUri = typeof agent.jwks_uri === 'string' && agent.jwks_uri.length > 0 ? agent.jwks_uri : undefined;
+  } catch {
+    return {
+      url: brandJsonUrl,
+      status: 0,
+      headers: {},
+      body: brand.body,
+      error: 'brand.json agent portfolio did not uniquely match the agent under test',
+    };
+  }
   if (!jwksUri) {
     return {
       url: brandJsonUrl,
       status: 0,
       headers: {},
       body: brand.body,
-      error: 'brand.json agent portfolio did not contain a jwks_uri',
+      error: 'brand.json agent entry for the agent under test did not contain a jwks_uri',
     };
   }
 

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -81,7 +81,8 @@ import {
   generateRandomInvalidJwt,
 } from './probes';
 import { readBrandJsonUrl } from '../../signing/agent-resolver/capabilities-types';
-import { validateTestKit } from './test-kit';
+import { collectAgentEntries } from '../../signing/agent-resolver/select-agent';
+import { selectProbeTask, validateTestKit } from './test-kit';
 import { validateStoryboardShape } from './loader';
 import { probeRequestSigningVector } from './request-signing/probe-dispatch';
 import { createWebhookReceiver, type WebhookReceiver, type WebhookWaitResult } from './webhook-receiver';
@@ -4534,6 +4535,26 @@ async function executeStep(
   // When the reference resolves to nothing, fall back to `task_default`.
   const resolvedTask = resolveTaskName(step, options);
   if (!resolvedTask) {
+    if (step.task === '$test_kit.auth.probe_task' && options.agentTools) {
+      const detail =
+        `Agent does not advertise an auth-required, read-only tool that accepts an empty request body; ` +
+        `security auth probes are not applicable to tools [${options.agentTools.join(', ')}].`;
+      return {
+        step_id: step.id,
+        phase_id: phaseId,
+        title: step.title,
+        task: step.task,
+        passed: true,
+        skipped: true,
+        skip_reason: 'not_applicable',
+        skip: buildSkip('not_applicable', detail),
+        duration_ms: 0,
+        validations: [],
+        context,
+        next: getNextStepPreview(step.id, allSteps, context, runState.runnerVars),
+        extraction: { path: 'none' },
+      };
+    }
     return {
       step_id: step.id,
       phase_id: phaseId,
@@ -7008,19 +7029,16 @@ async function probeBrandJwks(
     };
   }
 
-  const agents = brand.body && typeof brand.body === 'object' ? (brand.body as { agents?: unknown }).agents : undefined;
-  const jwksUri = Array.isArray(agents)
-    ? agents
-        .map(agent => (agent && typeof agent === 'object' ? (agent as { jwks_uri?: unknown }).jwks_uri : undefined))
-        .find((uri): uri is string => typeof uri === 'string' && uri.length > 0)
-    : undefined;
+  const jwksUri = collectAgentEntries(brand.body)
+    .map(agent => agent.jwks_uri)
+    .find((uri): uri is string => typeof uri === 'string' && uri.length > 0);
   if (!jwksUri) {
     return {
       url: brandJsonUrl,
       status: 0,
       headers: {},
       body: brand.body,
-      error: 'brand.json agents[] did not contain a jwks_uri',
+      error: 'brand.json agent portfolio did not contain a jwks_uri',
     };
   }
 
@@ -7263,8 +7281,11 @@ function resolveTaskName(step: StoryboardStep, options: StoryboardRunOptions): s
     }
     value = (value as Record<string, unknown>)[segment];
   }
-  if (typeof value === 'string' && value.length > 0) return value;
-  return step.task_default;
+  const configured = typeof value === 'string' && value.length > 0 ? value : step.task_default;
+  if (step.task === '$test_kit.auth.probe_task') {
+    return selectProbeTask(configured, options.agentTools);
+  }
+  return configured;
 }
 
 /**

--- a/src/lib/testing/storyboard/test-kit.ts
+++ b/src/lib/testing/storyboard/test-kit.ts
@@ -37,12 +37,27 @@ export const PROBE_TASK_ALLOWLIST: readonly string[] = Object.freeze([
   'get_media_buy_delivery',
   'list_authorized_properties',
   'get_signals',
-  'list_si_sessions',
   // governance specialism tools — all fields optional, auth-required, read-only
   'list_property_lists',
   'list_collection_lists',
   'list_content_standards',
 ]);
+
+/**
+ * Select an advertised auth probe without dispatching an inapplicable tool.
+ * The configured task is a preference, not permission to call a tool the
+ * agent did not advertise. Returns undefined when the agent has no safe,
+ * empty-body read probe (currently true for SI-only agents).
+ */
+export function selectProbeTask(
+  preferred: string | undefined,
+  advertisedTools: readonly string[] | undefined
+): string | undefined {
+  if (!advertisedTools) return preferred;
+  const advertised = new Set(advertisedTools);
+  if (preferred && PROBE_TASK_ALLOWLIST.includes(preferred) && advertised.has(preferred)) return preferred;
+  return PROBE_TASK_ALLOWLIST.find(task => advertised.has(task));
+}
 
 /**
  * Raised when a test kit violates the schema invariants above. Carries the

--- a/test/lib/compliance-required-tools-applicability.test.js
+++ b/test/lib/compliance-required-tools-applicability.test.js
@@ -25,6 +25,7 @@ describe('compliance storyboard required-tool applicability', () => {
     const result = partitionStoryboardsByRequiredTools(
       [
         storyboard('si_baseline', ['si_initiate_session']),
+        storyboard('si_partial_surface', ['si_initiate_session', 'si_optional_tool']),
         storyboard('media_buy', ['get_products']),
         storyboard('creative_transformers', ['list_transformers']),
       ],
@@ -33,7 +34,7 @@ describe('compliance storyboard required-tool applicability', () => {
 
     assert.deepStrictEqual(
       result.runnable.map(item => item.id),
-      ['si_baseline']
+      ['si_baseline', 'si_partial_surface']
     );
     assert.deepStrictEqual(
       result.missing.map(item => item.storyboard_id),

--- a/test/lib/compliance-required-tools-applicability.test.js
+++ b/test/lib/compliance-required-tools-applicability.test.js
@@ -1,0 +1,43 @@
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { partitionStoryboardsByRequiredTools } = require('../../dist/lib/testing/compliance/comply');
+
+function storyboard(id, requiredTools) {
+  return {
+    id,
+    version: '1.0.0',
+    title: id,
+    category: 'test',
+    track: 'core',
+    summary: '',
+    narrative: '',
+    agent: { interaction_model: '*', capabilities: [] },
+    caller: { role: 'buyer_agent' },
+    required_tools: requiredTools,
+    phases: [],
+  };
+}
+
+describe('compliance storyboard required-tool applicability', () => {
+  test('keeps media-buy and unrelated specialism storyboards out of an SI-only run', () => {
+    const siTools = ['si_get_offering', 'si_initiate_session', 'si_send_message', 'si_terminate_session'];
+    const result = partitionStoryboardsByRequiredTools(
+      [
+        storyboard('si_baseline', ['si_initiate_session']),
+        storyboard('media_buy', ['get_products']),
+        storyboard('creative_transformers', ['list_transformers']),
+      ],
+      siTools
+    );
+
+    assert.deepStrictEqual(
+      result.runnable.map(item => item.id),
+      ['si_baseline']
+    );
+    assert.deepStrictEqual(
+      result.missing.map(item => item.storyboard_id),
+      ['media_buy', 'creative_transformers']
+    );
+  });
+});

--- a/test/lib/request-builder.test.js
+++ b/test/lib/request-builder.test.js
@@ -1177,6 +1177,24 @@ describe('Request Builder', () => {
       assert.deepStrictEqual(result.account, contextAccount);
       assert.deepStrictEqual(result.media_buy_ids, ['buy-7']);
     });
+
+    test('preserves a fixture natural-key operator while enforcing harness sandbox routing', () => {
+      const fixtureAccount = {
+        brand: { domain: 'advertiser.example' },
+        operator: 'buyer-agent.example',
+        sandbox: false,
+      };
+      const result = buildRequest(
+        step('get_media_buys', { sample_request: { account: fixtureAccount } }),
+        {},
+        { ...DEFAULT_OPTIONS, sandbox: true }
+      );
+      assert.deepStrictEqual(result.account, {
+        brand: { domain: 'advertiser.example' },
+        operator: 'buyer-agent.example',
+        sandbox: true,
+      });
+    });
   });
 
   describe('get_media_buy_delivery', () => {

--- a/test/lib/request-builder.test.js
+++ b/test/lib/request-builder.test.js
@@ -1237,6 +1237,26 @@ describe('Request Builder', () => {
       assert.deepStrictEqual(result.account, contextAccount);
       assert.deepStrictEqual(result.media_buy_ids, ['buy-11']);
     });
+
+    test('preserves a fixture natural-key operator and timezone while enforcing harness sandbox routing', () => {
+      const fixtureAccount = {
+        brand: { domain: 'advertiser.example' },
+        operator: 'buyer-agent.example',
+        timezone: 'America/New_York',
+        sandbox: false,
+      };
+      const result = buildRequest(
+        step('get_media_buy_delivery', { sample_request: { account: fixtureAccount } }),
+        {},
+        { ...DEFAULT_OPTIONS, sandbox: true }
+      );
+      assert.deepStrictEqual(result.account, {
+        brand: { domain: 'advertiser.example' },
+        operator: 'buyer-agent.example',
+        timezone: 'America/New_York',
+        sandbox: true,
+      });
+    });
   });
 
   describe('update_media_buy', () => {

--- a/test/lib/storyboard-security.test.js
+++ b/test/lib/storyboard-security.test.js
@@ -26,6 +26,7 @@ const {
   CapabilityResolutionError,
 } = require('../../dist/lib/testing/storyboard/compliance');
 const { ADCPError, isADCPError } = require('../../dist/lib/errors');
+const { BrandJsonSchema } = require('../../dist/lib/types/wellknown-schemas.generated');
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
@@ -1097,6 +1098,104 @@ describe('storyboard runner: auth-override dispatch', () => {
     }
   });
 
+  it('selects an advertised safe auth probe when the configured preference is inapplicable', async () => {
+    let seenTool;
+    const server = http.createServer(async (req, res) => {
+      const chunks = [];
+      for await (const c of req) chunks.push(c);
+      const rpc = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+      if (maybeHandleMcpHandshake(rpc, res)) return;
+      seenTool = rpc.params.name;
+      res.writeHead(401, { 'content-type': 'application/json', 'www-authenticate': 'Bearer realm="x"' });
+      res.end('{}');
+    });
+    await new Promise(r => server.listen(0, r));
+    const agentUrl = `http://127.0.0.1:${server.address().port}/mcp`;
+    try {
+      const storyboard = {
+        id: 'select_safe_probe',
+        version: '1.0.0',
+        title: 'Select safe probe',
+        category: 'security',
+        summary: '',
+        narrative: '',
+        agent: { interaction_model: '*', capabilities: [] },
+        caller: { role: 'buyer_agent' },
+        phases: [
+          {
+            id: 'p',
+            title: 'probe',
+            steps: [
+              {
+                id: 's1',
+                title: 'unauth probe',
+                task: '$test_kit.auth.probe_task',
+                task_default: 'list_creatives',
+                auth: 'none',
+                expect_error: true,
+                validations: [{ check: 'http_status_in', allowed_values: [401, 403], description: 'rejects unauth' }],
+              },
+            ],
+          },
+        ],
+      };
+      const result = await runStoryboard(agentUrl, storyboard, {
+        protocol: 'mcp',
+        allow_http: true,
+        agentTools: ['get_signals'],
+        test_kit: { auth: { api_key: 'sk_test', probe_task: 'list_creatives' } },
+        _profile: { name: 'Test', tools: ['get_signals'] },
+        _client: { getAgentInfo: async () => ({ name: 'Test', tools: [{ name: 'get_signals' }] }) },
+      });
+      assert.strictEqual(seenTool, 'get_signals');
+      assert.strictEqual(result.overall_passed, true);
+    } finally {
+      server.close();
+    }
+  });
+
+  it('grades SI-only auth probes not_applicable instead of calling a nonexistent session-list tool', async () => {
+    const storyboard = {
+      id: 'si_probe_not_applicable',
+      version: '1.0.0',
+      title: 'SI probe selection',
+      category: 'security',
+      summary: '',
+      narrative: '',
+      agent: { interaction_model: '*', capabilities: [] },
+      caller: { role: 'buyer_agent' },
+      phases: [
+        {
+          id: 'p',
+          title: 'probe',
+          steps: [
+            {
+              id: 's1',
+              title: 'unauth probe',
+              task: '$test_kit.auth.probe_task',
+              task_default: 'list_creatives',
+              auth: 'none',
+              expect_error: true,
+              validations: [{ check: 'http_status_in', allowed_values: [401, 403], description: 'rejects unauth' }],
+            },
+          ],
+        },
+      ],
+    };
+    const siTools = ['si_get_offering', 'si_initiate_session', 'si_send_message', 'si_terminate_session'];
+    const result = await runStoryboard('https://si.example/mcp', storyboard, {
+      protocol: 'mcp',
+      agentTools: siTools,
+      test_kit: { auth: { api_key: 'sk_test', probe_task: 'list_creatives' } },
+      _profile: { name: 'SI', tools: siTools },
+      _client: { getAgentInfo: async () => ({ name: 'SI', tools: siTools.map(name => ({ name })) }) },
+    });
+    const step = result.phases[0].steps[0];
+    assert.strictEqual(step.passed, true);
+    assert.strictEqual(step.skipped, true);
+    assert.strictEqual(step.skip.reason, 'not_applicable');
+  });
+
   it('auth: none sends no Authorization header; value_strategy: random_invalid sends a random key', async () => {
     const observed = [];
     const server = http.createServer((req, res) => {
@@ -1367,6 +1466,81 @@ describe('storyboard runner: auth-override dispatch', () => {
     } finally {
       server.close();
     }
+  });
+});
+
+describe('storyboard runner: portfolio brand JWKS discovery', () => {
+  it('finds jwks_uri under a house portfolio brand agents array', async () => {
+    const brandJsonUrl = 'https://portfolio.example/.well-known/brand.json';
+    const jwksUrl = 'https://keys.example/jwks.json';
+    const fetchedUrls = [];
+    const manifest = {
+      house: { domain: 'portfolio.example', name: 'Publisher House', agents: [] },
+      brands: [
+        {
+          id: 'publisher-brand',
+          names: [{ en: 'Publisher Brand' }],
+          agents: [{ type: 'sales', id: 'publisher_sales', url: 'https://seller.example/mcp', jwks_uri: jwksUrl }],
+        },
+      ],
+    };
+    assert.doesNotThrow(() => BrandJsonSchema.parse(manifest));
+    const fetchFn = async input => {
+      const url = String(input);
+      fetchedUrls.push(url);
+      if (url === brandJsonUrl) {
+        return new Response(JSON.stringify(manifest), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url === jwksUrl) {
+        return new Response(JSON.stringify({ keys: [] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      throw new Error(`unexpected URL ${url}`);
+    };
+    const storyboard = {
+      id: 'portfolio_jwks',
+      version: '1.0.0',
+      title: 'Portfolio JWKS',
+      category: 'security',
+      summary: '',
+      narrative: '',
+      agent: { interaction_model: '*', capabilities: [] },
+      caller: { role: 'buyer_agent' },
+      phases: [
+        {
+          id: 'jwks',
+          title: 'JWKS',
+          steps: [
+            {
+              id: 'fetch',
+              title: 'Fetch portfolio JWKS',
+              task: 'fetch_brand_jwks',
+              validations: [{ check: 'http_status', value: 200, description: 'JWKS is reachable' }],
+            },
+          ],
+        },
+      ],
+    };
+    const result = await runStoryboard('https://seller.example/mcp', storyboard, {
+      protocol: 'mcp',
+      agentTools: ['get_adcp_capabilities'],
+      transport: { trustedFetchFn: fetchFn },
+      _profile: {
+        name: 'Portfolio seller',
+        tools: ['get_adcp_capabilities'],
+        raw_capabilities: { identity: { brand_json_url: brandJsonUrl } },
+      },
+      _client: {
+        getAgentInfo: async () => ({ name: 'Portfolio seller', tools: [{ name: 'get_adcp_capabilities' }] }),
+      },
+    });
+    assert.strictEqual(result.overall_passed, true, JSON.stringify(result.phases[0].steps[0]));
+    assert.deepStrictEqual(fetchedUrls, [brandJsonUrl, jwksUrl]);
   });
 });
 
@@ -2137,7 +2311,6 @@ describe('validateTestKit', () => {
         'get_media_buy_delivery',
         'list_authorized_properties',
         'get_signals',
-        'list_si_sessions',
         'list_property_lists',
         'list_collection_lists',
         'list_content_standards',

--- a/test/lib/storyboard-security.test.js
+++ b/test/lib/storyboard-security.test.js
@@ -13,7 +13,7 @@ const {
   rawMcpProbe,
   rawA2aProbe,
 } = require('../../dist/lib/testing/storyboard/probes');
-const { runStoryboard } = require('../../dist/lib/testing/storyboard/runner');
+const { runStoryboard, runStoryboardStep } = require('../../dist/lib/testing/storyboard/runner');
 const { loadStoryboardFile } = require('../../dist/lib/testing/storyboard/loader');
 const { comply, detectAuthRejection } = require('../../dist/lib/testing/compliance/comply');
 const {
@@ -1154,6 +1154,75 @@ describe('storyboard runner: auth-override dispatch', () => {
     }
   });
 
+  it('standalone steps select an advertised auth probe after discovering tools', async () => {
+    let seenTool;
+    const server = http.createServer(async (req, res) => {
+      const chunks = [];
+      for await (const chunk of req) chunks.push(chunk);
+      if (chunks.length === 0) {
+        res.writeHead(204);
+        res.end();
+        return;
+      }
+      const rpc = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+      if (maybeHandleMcpHandshake(rpc, res)) return;
+      if (rpc.method === 'tools/list') {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            id: rpc.id,
+            result: { tools: [{ name: 'get_signals', inputSchema: { type: 'object' } }] },
+          })
+        );
+        return;
+      }
+      seenTool = rpc.params.name;
+      res.writeHead(401, { 'content-type': 'application/json', 'www-authenticate': 'Bearer realm="x"' });
+      res.end(JSON.stringify({ jsonrpc: '2.0', id: rpc.id, error: { code: -32001, message: 'auth required' } }));
+    });
+    await new Promise(resolve => server.listen(0, resolve));
+    const agentUrl = `http://127.0.0.1:${server.address().port}/mcp`;
+    const storyboard = {
+      id: 'standalone_safe_probe',
+      version: '1.0.0',
+      title: 'Standalone safe probe',
+      category: 'security',
+      summary: '',
+      narrative: '',
+      agent: { interaction_model: '*', capabilities: [] },
+      caller: { role: 'buyer_agent' },
+      phases: [
+        {
+          id: 'p',
+          title: 'probe',
+          steps: [
+            {
+              id: 's1',
+              title: 'unauth probe',
+              task: '$test_kit.auth.probe_task',
+              task_default: 'list_creatives',
+              auth: 'none',
+              expect_error: true,
+              validations: [{ check: 'http_status_in', allowed_values: [401, 403], description: 'rejects unauth' }],
+            },
+          ],
+        },
+      ],
+    };
+    try {
+      const result = await runStoryboardStep(agentUrl, storyboard, 's1', {
+        protocol: 'mcp',
+        allow_http: true,
+        test_kit: { auth: { api_key: 'sk_test', probe_task: 'list_creatives' } },
+      });
+      assert.strictEqual(seenTool, 'get_signals');
+      assert.strictEqual(result.passed, true, JSON.stringify(result));
+    } finally {
+      server.close();
+    }
+  });
+
   it('grades SI-only auth probes not_applicable instead of calling a nonexistent session-list tool', async () => {
     const storyboard = {
       id: 'si_probe_not_applicable',
@@ -1475,7 +1544,18 @@ describe('storyboard runner: portfolio brand JWKS discovery', () => {
     const jwksUrl = 'https://keys.example/jwks.json';
     const fetchedUrls = [];
     const manifest = {
-      house: { domain: 'portfolio.example', name: 'Publisher House', agents: [] },
+      house: {
+        domain: 'portfolio.example',
+        name: 'Publisher House',
+        agents: [
+          {
+            type: 'sales',
+            id: 'other_sales',
+            url: 'https://other-seller.example/mcp',
+            jwks_uri: 'https://other-keys.example/jwks.json',
+          },
+        ],
+      },
       brands: [
         {
           id: 'publisher-brand',

--- a/test/lib/task-executor-operation-error.test.js
+++ b/test/lib/task-executor-operation-error.test.js
@@ -1,0 +1,28 @@
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { TaskExecutor } = require('../../dist/lib/core/TaskExecutor');
+
+describe('TaskExecutor business rejection diagnostics', () => {
+  test('surfaces a valid business rejection reason instead of the generic fallback', () => {
+    const executor = new TaskExecutor({ strictSchemaValidation: false });
+    assert.equal(
+      executor.extractOperationError({ success: false, outcome: 'rejected', reason: 'Inventory is unavailable' }),
+      'Inventory is unavailable'
+    );
+  });
+
+  test('surfaces plural structured errors even without a terminal status field', () => {
+    const executor = new TaskExecutor({ strictSchemaValidation: false });
+    assert.equal(
+      executor.extractOperationError({
+        success: false,
+        errors: [
+          { code: 'POLICY_VIOLATION', message: 'Placement policy rejected the request' },
+          { code: 'PRODUCT_UNAVAILABLE' },
+        ],
+      }),
+      'Placement policy rejected the request; PRODUCT_UNAVAILABLE'
+    );
+  });
+});

--- a/test/lib/task-executor-operation-error.test.js
+++ b/test/lib/task-executor-operation-error.test.js
@@ -2,14 +2,27 @@ const { describe, test } = require('node:test');
 const assert = require('node:assert/strict');
 
 const { TaskExecutor } = require('../../dist/lib/core/TaskExecutor');
+const { ProtocolClient } = require('../../dist/lib/protocols');
 
 describe('TaskExecutor business rejection diagnostics', () => {
-  test('surfaces a valid business rejection reason instead of the generic fallback', () => {
+  test('surfaces a valid business rejection reason through executeTask', async () => {
+    const originalCallTool = ProtocolClient.callTool;
+    ProtocolClient.callTool = async () => ({
+      status: 'rejected',
+      data: { success: false, outcome: 'rejected', reason: 'Inventory is unavailable' },
+    });
     const executor = new TaskExecutor({ strictSchemaValidation: false });
-    assert.equal(
-      executor.extractOperationError({ success: false, outcome: 'rejected', reason: 'Inventory is unavailable' }),
-      'Inventory is unavailable'
-    );
+    try {
+      const result = await executor.executeTask(
+        { id: 'seller', name: 'Seller', agent_uri: 'https://seller.example/mcp', protocol: 'mcp' },
+        'get_products',
+        {}
+      );
+      assert.equal(result.success, false);
+      assert.equal(result.error, 'Inventory is unavailable');
+    } finally {
+      ProtocolClient.callTool = originalCallTool;
+    }
   });
 
   test('surfaces plural structured errors even without a terminal status field', () => {

--- a/test/server-decisioning-capability-projections.test.js
+++ b/test/server-decisioning-capability-projections.test.js
@@ -181,6 +181,32 @@ describe('Capability projections — declarative capability blocks on Decisionin
     assert.deepStrictEqual(result.structuredContent?.media_buy?.supported_pricing_models, ['cpm']);
   });
 
+  it('rejects 2.x capability negotiation before response projection', async () => {
+    const server = createAdcpServerFromPlatform(
+      basePlatform({
+        supported_versions: ['2.5', '3.2'],
+        overrides: {
+          adcp: { capability_changes: { supported: true } },
+          media_buy: {
+            lifecycle_tools: ['create_media_buy', 'sync_media_buy'],
+            proposal_refinement: { supported: true },
+            features: { canonical_creatives: true },
+          },
+        },
+      }),
+      {
+        name: 'capability-2x-downshift',
+        version: '4.0.0',
+        validation: { requests: 'off', responses: 'off' },
+      }
+    );
+
+    const result = await dispatchCapabilities(server, { adcp_version: '2.5' });
+    assert.strictEqual(result.isError, true);
+    assert.strictEqual(result.structuredContent?.adcp_error?.code, 'VERSION_UNSUPPORTED');
+    assert.match(result.structuredContent?.adcp_error?.message ?? '', /not defined.*2\.5/i);
+  });
+
   it('canonical creative capability remains authoritative over adopter overrides', async () => {
     const server = createAdcpServerFromPlatform(
       basePlatform({

--- a/test/server-decisioning-capability-projections.test.js
+++ b/test/server-decisioning-capability-projections.test.js
@@ -109,13 +109,27 @@ describe('Capability projections — declarative capability blocks on Decisionin
           oauth: { supported: true },
           measurement: { supported: true },
           wholesale_feed_versioning: { supported: true },
-          adcp: { capability_changes: { supported: true }, governance_enforcement: { mode: 'strict' } },
+          adcp: {
+            capability_changes: { supported: true },
+            governance_enforcement: { mode: 'strict' },
+            idempotency: { supported: true, replay_ttl_seconds: 3600, in_flight_max_seconds: 30 },
+          },
           account: { timezone: { supported: true }, notifications: { supported: true } },
           media_buy: {
             buying_modes: ['brief'],
             budget_capping: { supported: true },
             supported_pricing_models: ['cpm', 'revenue_share'],
             features: { canonical_creatives: true, seller_optimized_budget: true },
+            execution: {
+              targeting: {
+                geo_postal_areas: {
+                  us_zip: true,
+                  us_zip_plus_four: true,
+                  US: ['zip', 'zip_plus_four'],
+                  NL: ['postal_code'],
+                },
+              },
+            },
           },
           signals: { discovery_modes: ['brief'] },
           governance: { runtime_attestations: { supported: true } },
@@ -129,7 +143,7 @@ describe('Capability projections — declarative capability blocks on Decisionin
       {
         name: 'capability-downshift',
         version: '4.0.0',
-        validation: { requests: 'off', responses: 'off' },
+        validation: { requests: 'off', responses: 'strict' },
       }
     );
 
@@ -143,10 +157,19 @@ describe('Capability projections — declarative capability blocks on Decisionin
     assert.strictEqual(result.structuredContent?.measurement, undefined);
     assert.strictEqual(result.structuredContent?.wholesale_feed_versioning, undefined);
     assert.strictEqual(result.structuredContent?.adcp?.capability_changes, undefined);
+    assert.strictEqual(result.structuredContent?.adcp?.idempotency?.in_flight_max_seconds, undefined);
+    assert.strictEqual(result.structuredContent?.adcp?.idempotency?.replay_ttl_seconds, 3600);
     assert.strictEqual(result.structuredContent?.account?.timezone, undefined);
     assert.strictEqual(result.structuredContent?.media_buy?.buying_modes, undefined);
     assert.strictEqual(result.structuredContent?.media_buy?.budget_capping, undefined);
     assert.strictEqual(result.structuredContent?.media_buy?.features?.seller_optimized_budget, undefined);
+    assert.strictEqual(result.structuredContent?.media_buy?.execution?.targeting?.geo_postal_areas?.US, undefined);
+    assert.strictEqual(result.structuredContent?.media_buy?.execution?.targeting?.geo_postal_areas?.NL, undefined);
+    assert.strictEqual(result.structuredContent?.media_buy?.execution?.targeting?.geo_postal_areas?.us_zip, true);
+    assert.strictEqual(
+      result.structuredContent?.media_buy?.execution?.targeting?.geo_postal_areas?.us_zip_plus_four,
+      true
+    );
     assert.strictEqual(result.structuredContent?.signals?.discovery_modes, undefined);
     assert.strictEqual(result.structuredContent?.governance?.runtime_attestations, undefined);
     assert.strictEqual(result.structuredContent?.creative?.supports_transformers, undefined);

--- a/test/server-decisioning-capability-projections.test.js
+++ b/test/server-decisioning-capability-projections.test.js
@@ -102,11 +102,36 @@ describe('Capability projections — declarative capability blocks on Decisionin
   });
 
   it('serves get_adcp_capabilities at the mutually selected 3.0 release', async () => {
-    const server = createAdcpServerFromPlatform(basePlatform({ supported_versions: ['3.0', '3.1'] }), {
-      name: 'capability-downshift',
-      version: '4.0.0',
-      validation: { requests: 'off', responses: 'off' },
-    });
+    const server = createAdcpServerFromPlatform(
+      basePlatform({
+        supported_versions: ['3.0', '3.1'],
+        overrides: {
+          oauth: { supported: true },
+          measurement: { supported: true },
+          wholesale_feed_versioning: { supported: true },
+          adcp: { capability_changes: { supported: true }, governance_enforcement: { mode: 'strict' } },
+          account: { timezone: { supported: true }, notifications: { supported: true } },
+          media_buy: {
+            buying_modes: ['brief'],
+            budget_capping: { supported: true },
+            supported_pricing_models: ['cpm', 'revenue_share'],
+            features: { canonical_creatives: true, seller_optimized_budget: true },
+          },
+          signals: { discovery_modes: ['brief'] },
+          governance: { runtime_attestations: { supported: true } },
+          creative: { supports_transformers: true, preview: { supported: true } },
+          request_signing: { protocol_methods_required_for: ['tools/call'] },
+          identity: { brand_json_url: 'https://seller.example/.well-known/brand.json' },
+          specialisms: ['sales-non-guaranteed', 'creative-transformers', 'sponsored-intelligence'],
+          supported_protocols: ['media_buy', 'measurement'],
+        },
+      }),
+      {
+        name: 'capability-downshift',
+        version: '4.0.0',
+        validation: { requests: 'off', responses: 'off' },
+      }
+    );
 
     const result = await dispatchCapabilities(server, { adcp_version: '3.0' });
     assert.notStrictEqual(result.isError, true, JSON.stringify(result.structuredContent));
@@ -114,6 +139,23 @@ describe('Capability projections — declarative capability blocks on Decisionin
     assert.strictEqual(result.structuredContent?.adcp?.supported_versions, undefined);
     assert.strictEqual(result.structuredContent?.media_buy?.features?.canonical_creatives, undefined);
     assert.strictEqual(result.structuredContent?.library_version, undefined);
+    assert.strictEqual(result.structuredContent?.oauth, undefined);
+    assert.strictEqual(result.structuredContent?.measurement, undefined);
+    assert.strictEqual(result.structuredContent?.wholesale_feed_versioning, undefined);
+    assert.strictEqual(result.structuredContent?.adcp?.capability_changes, undefined);
+    assert.strictEqual(result.structuredContent?.account?.timezone, undefined);
+    assert.strictEqual(result.structuredContent?.media_buy?.buying_modes, undefined);
+    assert.strictEqual(result.structuredContent?.media_buy?.budget_capping, undefined);
+    assert.strictEqual(result.structuredContent?.media_buy?.features?.seller_optimized_budget, undefined);
+    assert.strictEqual(result.structuredContent?.signals?.discovery_modes, undefined);
+    assert.strictEqual(result.structuredContent?.governance?.runtime_attestations, undefined);
+    assert.strictEqual(result.structuredContent?.creative?.supports_transformers, undefined);
+    assert.strictEqual(result.structuredContent?.creative?.preview, undefined);
+    assert.strictEqual(result.structuredContent?.request_signing?.protocol_methods_required_for, undefined);
+    assert.strictEqual(result.structuredContent?.identity?.brand_json_url, undefined);
+    assert.deepStrictEqual(result.structuredContent?.supported_protocols, ['media_buy']);
+    assert.deepStrictEqual(result.structuredContent?.specialisms, ['sales-non-guaranteed']);
+    assert.deepStrictEqual(result.structuredContent?.media_buy?.supported_pricing_models, ['cpm']);
   });
 
   it('canonical creative capability remains authoritative over adopter overrides', async () => {


### PR DESCRIPTION
## Summary

- preserve structured business-rejection diagnostics instead of collapsing valid failures to `Operation failed` (#2179 regression)
- exclude storyboards whose required tools are not advertised, including explicitly selected inapplicable specialisms (#1680 regression)
- select auth security probes only from safe advertised tools and remove the nonexistent `list_si_sessions` probe
- preserve fixture-authored natural-key account operators for `get_media_buys`
- project AdCP 3.0 capabilities against the exact legacy field and enum surface
- discover JWKS URIs from valid house portfolio agent arrays as well as flat `agents[]`

## Root cause and impact

The beta.3 paths had drifted in several independent compatibility boundaries: response diagnostics only recognized a narrower terminal-error shape, explicit storyboard selection bypassed tool applicability, the security probe list included an SI tool that does not exist, request enrichment replaced a meaningful account operator, 3.0 down-projection removed only a few known fields, and the conformance JWKS probe assumed the flat brand manifest shape.

Together these produced misleading failures, inapplicable SI runs, mutated requests, forward-field leakage to 3.0 clients, and false JWKS discovery failures for valid portfolio manifests. The changes restore the earlier behavior while adding focused regression coverage and a patch changeset.

## Validation

- `npm run build`
- focused regression suite: 244 passed, 0 failed
- `npm run test:node:fast`: 15,503 passed, 0 failed, 7 skipped
- pre-push typecheck and build validation
- commitlint and PR-title validation
