### PR TITLE
feat(substitution): adopt universal macro translation policies

### DIFF
--- a/.changeset/calm-macros-translate.md
+++ b/.changeset/calm-macros-translate.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': minor
+---
+
+Adopt the canonical universal-macro translation fixture. `translateUniversalMacros` now reports literal consent mappings in `frozen_consent_macros` and throws the exported `UnsafeNativeMappingError` when any native mapping contains an ASCII C0 control character or DEL, including unused mapping entries.

--- a/docs/guides/VALIDATE-YOUR-AGENT.md
+++ b/docs/guides/VALIDATE-YOUR-AGENT.md
@@ -517,6 +517,31 @@ for (const m of matches) {
 
 Unencoded substitution is a common XSS / scheme-injection vector. `CATALOG_MACRO_VECTORS` exports the seven canonical test bindings (`url-scheme-injection-neutralized`, `reserved-character-breakout`, `nested-expansion-preserved-as-literal`, etc.). For preview-URL fetches, `observer.fetch_and_parse(url)` enforces an SSRF policy — DNS revalidation, bare-IP rejection, cloud-metadata deny — before the HTTP connect.
 
+For pixel URLs that mix AdCP universal macros with a platform's native macro syntax, use `translateUniversalMacros`. Native mappings are inserted verbatim; literal values are RFC 3986 encoded. A native mapping containing U+0000–U+001F or U+007F throws `UnsafeNativeMappingError` before any URL is emitted, even when that mapping is unused. Consent macros frozen through literal `value` mappings remain encoded and are reported in `frozen_consent_macros` for advisory handling:
+
+```typescript
+import { translateUniversalMacros, UnsafeNativeMappingError } from '@adcp/sdk';
+
+try {
+  const translated = translateUniversalMacros(pixelUrl, {
+    '{CACHEBUSTER}': { native: '%%CACHEBUSTER%%' },
+    '{GPP_STRING}': { value: consentSnapshot },
+  });
+  if ((translated.frozen_consent_macros?.length ?? 0) > 0) {
+    auditConsentSnapshot(translated.frozen_consent_macros ?? []);
+  }
+  emitPixel(translated.url);
+} catch (error) {
+  if (error instanceof UnsafeNativeMappingError) {
+    // `message` includes the exact mapping key in a log-safe escaped form.
+    rejectMapping(error.code, error.message);
+  }
+  throw error;
+}
+```
+
+These policies follow the language-neutral fixture ratified in [AdCP #6674](https://github.com/adcontextprotocol/adcp/issues/6674).
+
 ---
 
 ## The fork-matrix: canonical adapter → compliance

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -2063,6 +2063,7 @@ export {
   isUnreservedOnly,
   divergenceOffset,
   translateUniversalMacros,
+  UnsafeNativeMappingError,
 } from './substitution';
 export type {
   ObserverFetchOptions,

--- a/src/lib/substitution/fixtures/universal-macro-translation.json
+++ b/src/lib/substitution/fixtures/universal-macro-translation.json
@@ -1,0 +1,308 @@
+{
+  "$schema": "./universal-macro-translation.schema.json",
+  "$schema_version": "1.0",
+  "version": "3.2",
+  "name": "Universal macro translation — cross-SDK conformance fixtures",
+  "spec_reference": "docs/creative/universal-macros.mdx#implementing-translation-with-the-sdk",
+  "description": "Language-neutral golden vectors for ratified producer-side universal-macro translation behavior, including typed rejection cases and the complete successful result shape.",
+  "ordering": {
+    "dropped_params": "Query-parameter occurrence order; repeated keys remain repeated.",
+    "unmapped_macros": "First occurrence in query order, deduplicated.",
+    "dropped_consent_macros": "First occurrence in query order, deduplicated subset of unmapped_macros.",
+    "frozen_consent_macros": "Mapping property order, deduplicated consent macros supplied through value entries.",
+    "suspect_native_values": "Mapping property order, deduplicated. JSON fixture consumers MUST preserve the mapping order shown here."
+  },
+  "vectors": [
+    {
+      "name": "value-reserved-characters",
+      "input_pixel_url": "https://pixel.example/i?v={VALUE}",
+      "mapping": { "{VALUE}": { "value": "/?&=% {}#" } },
+      "expected": {
+        "url": "https://pixel.example/i?v=%2F%3F%26%3D%25%20%7B%7D%23",
+        "dropped_params": [],
+        "unmapped_macros": [],
+        "dropped_consent_macros": [],
+        "frozen_consent_macros": [],
+        "suspect_native_values": []
+      }
+    },
+    {
+      "name": "value-unreserved-characters",
+      "input_pixel_url": "https://pixel.example/i?v={VALUE}",
+      "mapping": { "{VALUE}": { "value": "AZaz09-._~" } },
+      "expected": {
+        "url": "https://pixel.example/i?v=AZaz09-._~",
+        "dropped_params": [],
+        "unmapped_macros": [],
+        "dropped_consent_macros": [],
+        "frozen_consent_macros": [],
+        "suspect_native_values": []
+      }
+    },
+    {
+      "name": "value-non-ascii-utf8",
+      "input_pixel_url": "https://pixel.example/i?store={STORE_ID}",
+      "mapping": { "{STORE_ID}": { "value": "café" } },
+      "expected": {
+        "url": "https://pixel.example/i?store=caf%C3%A9",
+        "dropped_params": [],
+        "unmapped_macros": [],
+        "dropped_consent_macros": [],
+        "frozen_consent_macros": [],
+        "suspect_native_values": []
+      }
+    },
+    {
+      "name": "native-token-forms-inserted-verbatim",
+      "input_pixel_url": "https://pixel.example/i?a={A}&b={B}&c={C}&d={D}",
+      "mapping": {
+        "{A}": { "native": "%%TOKEN%%" },
+        "{B}": { "native": "{{token}}" },
+        "{C}": { "native": "${token}" },
+        "{D}": { "native": "[TOKEN]" }
+      },
+      "expected": {
+        "url": "https://pixel.example/i?a=%%TOKEN%%&b={{token}}&c=${token}&d=[TOKEN]",
+        "dropped_params": [],
+        "unmapped_macros": [],
+        "dropped_consent_macros": [],
+        "frozen_consent_macros": [],
+        "suspect_native_values": []
+      }
+    },
+    {
+      "name": "multiple-mapped-macros-in-one-parameter",
+      "input_pixel_url": "https://pixel.example/i?ids=pre-{A}-{B}-{A}",
+      "mapping": {
+        "{A}": { "value": "a/b" },
+        "{B}": { "native": "%%B%%" }
+      },
+      "expected": {
+        "url": "https://pixel.example/i?ids=pre-a%2Fb-%%B%%-a%2Fb",
+        "dropped_params": [],
+        "unmapped_macros": [],
+        "dropped_consent_macros": [],
+        "frozen_consent_macros": [],
+        "suspect_native_values": []
+      }
+    },
+    {
+      "name": "mapped-plus-unmapped-drops-whole-parameter",
+      "input_pixel_url": "https://pixel.example/i?ids={MEDIA_BUY_ID}-{UNKNOWN}&literal=keep",
+      "mapping": { "{MEDIA_BUY_ID}": { "value": "mb_1" } },
+      "expected": {
+        "url": "https://pixel.example/i?literal=keep",
+        "dropped_params": ["ids"],
+        "unmapped_macros": ["{UNKNOWN}"],
+        "dropped_consent_macros": [],
+        "frozen_consent_macros": [],
+        "suspect_native_values": []
+      }
+    },
+    {
+      "name": "repeated-keys-and-first-seen-report-order",
+      "input_pixel_url": "https://pixel.example/i?first={Z}&same={A}&same={Z}&mix={B}{A}&ok=1",
+      "mapping": {},
+      "expected": {
+        "url": "https://pixel.example/i?ok=1",
+        "dropped_params": ["first", "same", "same", "mix"],
+        "unmapped_macros": ["{Z}", "{A}", "{B}"],
+        "dropped_consent_macros": [],
+        "frozen_consent_macros": [],
+        "suspect_native_values": []
+      }
+    },
+    {
+      "name": "privacy-drops-and-deduplicated-order",
+      "input_pixel_url": "https://pixel.example/i?g={GPP_STRING}&u={US_PRIVACY}&g2={GPP_STRING}&c={GDPR_CONSENT}",
+      "mapping": {},
+      "expected": {
+        "url": "https://pixel.example/i",
+        "dropped_params": ["g", "u", "g2", "c"],
+        "unmapped_macros": ["{GPP_STRING}", "{US_PRIVACY}", "{GDPR_CONSENT}"],
+        "dropped_consent_macros": ["{GPP_STRING}", "{US_PRIVACY}", "{GDPR_CONSENT}"],
+        "frozen_consent_macros": [],
+        "suspect_native_values": []
+      }
+    },
+    {
+      "name": "privacy-native-mappings-allowed",
+      "input_pixel_url": "https://pixel.example/i?g={GPP_STRING}&u={US_PRIVACY}&c={GDPR_CONSENT}",
+      "mapping": {
+        "{GPP_STRING}": { "native": "%%GPP_STRING%%" },
+        "{US_PRIVACY}": { "native": "%%US_PRIVACY%%" },
+        "{GDPR_CONSENT}": { "native": "%%GDPR_CONSENT%%" }
+      },
+      "expected": {
+        "url": "https://pixel.example/i?g=%%GPP_STRING%%&u=%%US_PRIVACY%%&c=%%GDPR_CONSENT%%",
+        "dropped_params": [],
+        "unmapped_macros": [],
+        "dropped_consent_macros": [],
+        "frozen_consent_macros": [],
+        "suspect_native_values": []
+      }
+    },
+    {
+      "name": "literal-parameters-pass-through-byte-for-byte",
+      "input_pixel_url": "https://pixel.example/i?encoded=%2f+%7e&flag&empty=&equals=a=b",
+      "mapping": {},
+      "expected": {
+        "url": "https://pixel.example/i?encoded=%2f+%7e&flag&empty=&equals=a=b",
+        "dropped_params": [],
+        "unmapped_macros": [],
+        "dropped_consent_macros": [],
+        "frozen_consent_macros": [],
+        "suspect_native_values": []
+      }
+    },
+    {
+      "name": "path-and-no-query-left-untouched",
+      "input_pixel_url": "https://pixel.example/{MEDIA_BUY_ID}",
+      "mapping": { "{MEDIA_BUY_ID}": { "value": "mb_1" } },
+      "expected": {
+        "url": "https://pixel.example/{MEDIA_BUY_ID}",
+        "dropped_params": [],
+        "unmapped_macros": [],
+        "dropped_consent_macros": [],
+        "frozen_consent_macros": [],
+        "suspect_native_values": []
+      }
+    },
+    {
+      "name": "fragment-left-untouched",
+      "input_pixel_url": "https://pixel.example/i?buy={MEDIA_BUY_ID}#frag={CREATIVE_ID}",
+      "mapping": {
+        "{MEDIA_BUY_ID}": { "value": "mb_1" },
+        "{CREATIVE_ID}": { "value": "cr_1" }
+      },
+      "expected": {
+        "url": "https://pixel.example/i?buy=mb_1#frag={CREATIVE_ID}",
+        "dropped_params": [],
+        "unmapped_macros": [],
+        "dropped_consent_macros": [],
+        "frozen_consent_macros": [],
+        "suspect_native_values": []
+      }
+    },
+    {
+      "name": "macro-in-key-left-untouched",
+      "input_pixel_url": "https://pixel.example/i?{MEDIA_BUY_ID}=literal",
+      "mapping": { "{MEDIA_BUY_ID}": { "value": "mb_1" } },
+      "expected": {
+        "url": "https://pixel.example/i?{MEDIA_BUY_ID}=literal",
+        "dropped_params": [],
+        "unmapped_macros": [],
+        "dropped_consent_macros": [],
+        "frozen_consent_macros": [],
+        "suspect_native_values": []
+      }
+    },
+    {
+      "name": "substitution-is-single-pass",
+      "input_pixel_url": "https://pixel.example/i?buy={MEDIA_BUY_ID}",
+      "mapping": {
+        "{MEDIA_BUY_ID}": { "value": "{PACKAGE_ID}" },
+        "{PACKAGE_ID}": { "value": "pkg_1" }
+      },
+      "expected": {
+        "url": "https://pixel.example/i?buy=%7BPACKAGE_ID%7D",
+        "dropped_params": [],
+        "unmapped_macros": [],
+        "dropped_consent_macros": [],
+        "frozen_consent_macros": [],
+        "suspect_native_values": []
+      }
+    },
+    {
+      "name": "suspect-native-values-are-mapping-scoped-and-ordered",
+      "input_pixel_url": "https://pixel.example/i?ok={NORMAL}",
+      "mapping": {
+        "{PERCENT}": { "value": "%%TOKEN%%" },
+        "{DOUBLE_BRACE}": { "value": "{{token}}" },
+        "{DOLLAR_BRACE}": { "value": "${token}" },
+        "{BRACKET}": { "value": "[TOKEN]" },
+        "{NORMAL}": { "value": "ok" }
+      },
+      "expected": {
+        "url": "https://pixel.example/i?ok=ok",
+        "dropped_params": [],
+        "unmapped_macros": [],
+        "dropped_consent_macros": [],
+        "frozen_consent_macros": [],
+        "suspect_native_values": ["{PERCENT}", "{DOUBLE_BRACE}", "{DOLLAR_BRACE}", "{BRACKET}"]
+      }
+    },
+    {
+      "name": "ordinary-bracketed-values-not-suspect",
+      "input_pixel_url": "https://pixel.example/i?a={A}&b={B}",
+      "mapping": {
+        "{A}": { "value": "[1,2,3]" },
+        "{B}": { "value": "[redacted]" }
+      },
+      "expected": {
+        "url": "https://pixel.example/i?a=%5B1%2C2%2C3%5D&b=%5Bredacted%5D",
+        "dropped_params": [],
+        "unmapped_macros": [],
+        "dropped_consent_macros": [],
+        "frozen_consent_macros": [],
+        "suspect_native_values": []
+      }
+    },
+    {
+      "name": "privacy-value-mappings-are-encoded-and-reported",
+      "input_pixel_url": "https://pixel.example/i?g={GPP_STRING}&u={US_PRIVACY}",
+      "mapping": {
+        "{GPP_STRING}": { "value": "DBABMA~CPXxRfA/PXxRfA" },
+        "{US_PRIVACY}": { "value": "1YNN" }
+      },
+      "expected": {
+        "url": "https://pixel.example/i?g=DBABMA~CPXxRfA%2FPXxRfA&u=1YNN",
+        "dropped_params": [],
+        "unmapped_macros": [],
+        "dropped_consent_macros": [],
+        "frozen_consent_macros": ["{GPP_STRING}", "{US_PRIVACY}"],
+        "suspect_native_values": []
+      }
+    },
+    {
+      "name": "bare-query-normalized-away",
+      "input_pixel_url": "https://pixel.example/i?",
+      "mapping": {},
+      "expected": {
+        "url": "https://pixel.example/i",
+        "dropped_params": [],
+        "unmapped_macros": [],
+        "dropped_consent_macros": [],
+        "frozen_consent_macros": [],
+        "suspect_native_values": []
+      }
+    },
+    {
+      "name": "native-c0-null-rejected",
+      "input_pixel_url": "https://pixel.example/i?cb={CACHEBUSTER}",
+      "mapping": { "{CACHEBUSTER}": { "native": "%%CACHE\u0000BUSTER%%" } },
+      "expected_error": {
+        "code": "unsafe_native_mapping",
+        "macro": "{CACHEBUSTER}"
+      }
+    },
+    {
+      "name": "native-c0-unit-separator-rejected",
+      "input_pixel_url": "https://pixel.example/i?cb={CACHEBUSTER}",
+      "mapping": { "{CACHEBUSTER}": { "native": "%%CACHE\u001fBUSTER%%" } },
+      "expected_error": {
+        "code": "unsafe_native_mapping",
+        "macro": "{CACHEBUSTER}"
+      }
+    },
+    {
+      "name": "native-del-rejected",
+      "input_pixel_url": "https://pixel.example/i?cb={CACHEBUSTER}",
+      "mapping": { "{CACHEBUSTER}": { "native": "%%CACHE\u007fBUSTER%%" } },
+      "expected_error": {
+        "code": "unsafe_native_mapping",
+        "macro": "{CACHEBUSTER}"
+      }
+    }
+  ]
+}

--- a/src/lib/substitution/fixtures/universal-macro-translation.schema.json
+++ b/src/lib/substitution/fixtures/universal-macro-translation.schema.json
@@ -1,0 +1,119 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "universal-macro-translation.schema.json",
+  "title": "Universal macro translation fixture",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["$schema", "$schema_version", "version", "name", "spec_reference", "description", "ordering", "vectors"],
+  "properties": {
+    "$schema": { "type": "string" },
+    "$schema_version": { "const": "1.0" },
+    "version": { "const": "3.2" },
+    "name": { "type": "string", "minLength": 1 },
+    "spec_reference": { "type": "string", "minLength": 1 },
+    "description": { "type": "string", "minLength": 1 },
+    "ordering": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "dropped_params",
+        "unmapped_macros",
+        "dropped_consent_macros",
+        "frozen_consent_macros",
+        "suspect_native_values"
+      ],
+      "properties": {
+        "dropped_params": { "type": "string", "minLength": 1 },
+        "unmapped_macros": { "type": "string", "minLength": 1 },
+        "dropped_consent_macros": { "type": "string", "minLength": 1 },
+        "frozen_consent_macros": { "type": "string", "minLength": 1 },
+        "suspect_native_values": { "type": "string", "minLength": 1 }
+      }
+    },
+    "vectors": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/definitions/vector" }
+    }
+  },
+  "definitions": {
+    "macro": {
+      "type": "string",
+      "pattern": "^\\{[A-Z][A-Z0-9_]*\\}$"
+    },
+    "mappingEntry": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["native"],
+          "properties": { "native": { "type": "string" } }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["value"],
+          "properties": { "value": { "type": "string" } }
+        }
+      ]
+    },
+    "mapping": {
+      "type": "object",
+      "propertyNames": { "$ref": "#/definitions/macro" },
+      "additionalProperties": { "$ref": "#/definitions/mappingEntry" }
+    },
+    "macroArray": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": { "$ref": "#/definitions/macro" }
+    },
+    "expected": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url",
+        "dropped_params",
+        "unmapped_macros",
+        "dropped_consent_macros",
+        "frozen_consent_macros",
+        "suspect_native_values"
+      ],
+      "properties": {
+        "url": { "type": "string" },
+        "dropped_params": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "unmapped_macros": { "$ref": "#/definitions/macroArray" },
+        "dropped_consent_macros": { "$ref": "#/definitions/macroArray" },
+        "frozen_consent_macros": { "$ref": "#/definitions/macroArray" },
+        "suspect_native_values": { "$ref": "#/definitions/macroArray" }
+      }
+    },
+    "expectedError": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["code", "macro"],
+      "properties": {
+        "code": { "const": "unsafe_native_mapping" },
+        "macro": { "$ref": "#/definitions/macro" }
+      }
+    },
+    "vector": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "input_pixel_url", "mapping"],
+      "oneOf": [{ "required": ["expected"] }, { "required": ["expected_error"] }],
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+        },
+        "input_pixel_url": { "type": "string", "minLength": 1 },
+        "mapping": { "$ref": "#/definitions/mapping" },
+        "expected": { "$ref": "#/definitions/expected" },
+        "expected_error": { "$ref": "#/definitions/expectedError" }
+      }
+    }
+  }
+}

--- a/src/lib/substitution/index.ts
+++ b/src/lib/substitution/index.ts
@@ -60,5 +60,5 @@ export type {
   TrackerUrlRecord,
 } from './types';
 
-export { translateUniversalMacros } from './translate';
+export { translateUniversalMacros, UnsafeNativeMappingError } from './translate';
 export type { MacroMapping, TranslateResult } from './translate';

--- a/src/lib/substitution/translate.ts
+++ b/src/lib/substitution/translate.ts
@@ -28,6 +28,12 @@
  * inspect it (and `unmapped_macros`) so a missing consent signal is caught
  * rather than shipped as a degraded pixel.
  *
+ * A `native` mapping is trusted syntax and is therefore validated before any
+ * URL is emitted. If any native entry contains an ASCII C0 control character
+ * (U+0000-U+001F) or DEL (U+007F), this function throws
+ * {@link UnsafeNativeMappingError}. Validation is mapping-scoped: an unsafe
+ * entry is rejected even when its macro does not occur in `input_pixel_url`.
+ *
  * URLSearchParams is intentionally avoided — it force-encodes values and would
  * corrupt native ad-server tokens (e.g. `%%GDPR%%`).  Query manipulation is
  * done textually so native tokens remain raw and value-encoding is controlled.
@@ -62,6 +68,9 @@ const CONSENT_MACROS = new Set<string>([
   '{LIMIT_AD_TRACKING}',
 ]);
 
+/** ASCII control characters forbidden in native mapping entries. */
+const UNSAFE_NATIVE_CHARACTER = /[\u0000-\u001F\u007F]/;
+
 /**
  * A mapping from universal macro token (e.g. `'{GDPR}'`) to either:
  *   - `{ native: string }` — inserted verbatim (not percent-encoded), for
@@ -70,6 +79,29 @@ const CONSENT_MACROS = new Set<string>([
  *     percent-encoding, for seller-supplied data values.
  */
 export type MacroMapping = Record<string, { native: string } | { value: string }>;
+
+/**
+ * Thrown when a native mapping contains an ASCII control character.
+ *
+ * The error intentionally identifies the mapping key but does not retain the
+ * unsafe value, so callers can report the failure without propagating control
+ * characters into logs or error envelopes. `message` escapes control
+ * characters in the key for log safety; `macro` preserves the exact offending
+ * key for programmatic handling and must be escaped before logging.
+ */
+export class UnsafeNativeMappingError extends Error {
+  readonly code = 'unsafe_native_mapping' as const;
+  readonly macro: string;
+
+  constructor(macro: string) {
+    const escapedMacro = JSON.stringify(macro).replace(/[\u007F-\u009F\u2028\u2029]/g, character => {
+      return `\\u${character.charCodeAt(0).toString(16).padStart(4, '0')}`;
+    });
+    super(`Native mapping for ${escapedMacro} contains a forbidden ASCII control character`);
+    this.name = 'UnsafeNativeMappingError';
+    this.macro = macro;
+  }
+}
 
 /** Result of {@link translateUniversalMacros}. */
 export interface TranslateResult {
@@ -95,6 +127,13 @@ export interface TranslateResult {
    */
   dropped_consent_macros: string[];
   /**
+   * Consent/privacy macros supplied through a `value` entry. These values are
+   * still RFC 3986 encoded and translated, but are reported because freezing a
+   * consent signal at translation time can make it stale. Mapping-scoped,
+   * mapping-property ordered, and deduplicated.
+   */
+  frozen_consent_macros?: string[];
+  /**
    * Macro tokens whose `value` entry looks like a native ad-server token
    * (`%%…%%`, `{{…}}`, `${…}`, `[UPPER_SNAKE]`). Such a value will be
    * percent-encoded and break at impression time — almost always it should
@@ -112,12 +151,29 @@ export interface TranslateResult {
  * Translate universal macro tokens in the query-parameter values of
  * `input_pixel_url` using `mapping`. See module-level documentation for the
  * substitution rules and the privacy note on dropped parameters.
+ *
+ * @throws {UnsafeNativeMappingError} If any native mapping entry contains
+ * U+0000-U+001F or U+007F. The whole mapping is checked before translation,
+ * including entries not referenced by `input_pixel_url`.
  */
 export function translateUniversalMacros(input_pixel_url: string, mapping: MacroMapping): TranslateResult {
   const suspect_native_values: string[] = [];
   const suspectSeen = new Set<string>();
+  const frozen_consent_macros: string[] = [];
+  const frozenConsentSeen = new Set<string>();
   for (const [macro, entry] of Object.entries(mapping)) {
-    if ('value' in entry && NATIVE_TOKEN_SHAPE.test(entry.value) && !suspectSeen.has(macro)) {
+    if ('native' in entry) {
+      if (UNSAFE_NATIVE_CHARACTER.test(entry.native)) {
+        throw new UnsafeNativeMappingError(macro);
+      }
+      continue;
+    }
+
+    if (CONSENT_MACROS.has(macro) && !frozenConsentSeen.has(macro)) {
+      frozenConsentSeen.add(macro);
+      frozen_consent_macros.push(macro);
+    }
+    if (NATIVE_TOKEN_SHAPE.test(entry.value) && !suspectSeen.has(macro)) {
       suspectSeen.add(macro);
       suspect_native_values.push(macro);
     }
@@ -136,6 +192,7 @@ export function translateUniversalMacros(input_pixel_url: string, mapping: Macro
       dropped_params: [],
       unmapped_macros: [],
       dropped_consent_macros: [],
+      frozen_consent_macros,
       suspect_native_values,
     };
   }
@@ -200,5 +257,12 @@ export function translateUniversalMacros(input_pixel_url: string, mapping: Macro
   const newQuery = outputParts.join('&');
   const url = newQuery ? `${base}?${newQuery}${fragment}` : `${base}${fragment}`;
 
-  return { url, dropped_params, unmapped_macros, dropped_consent_macros, suspect_native_values };
+  return {
+    url,
+    dropped_params,
+    unmapped_macros,
+    dropped_consent_macros,
+    frozen_consent_macros,
+    suspect_native_values,
+  };
 }

--- a/test/lib/substitution-translate.test.js
+++ b/test/lib/substitution-translate.test.js
@@ -1,212 +1,122 @@
+const { readFileSync } = require('node:fs');
+const path = require('node:path');
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
+const Ajv = require('ajv');
 
-const { translateUniversalMacros } = require('../../dist/lib/index.js');
+const { translateUniversalMacros, UnsafeNativeMappingError } = require('../../dist/lib/index.js');
 
-describe('translateUniversalMacros — query-string macro substitution', () => {
-  // ─── native insertion ────────────────────────────────────────────────────
+// Vendored language-neutral inputs from adcontextprotocol/adcp@acc022a53fad8ecab877d374df1760fef756325f.
+const FIXTURE_PATH = path.resolve(__dirname, '../../src/lib/substitution/fixtures/universal-macro-translation.json');
+const FIXTURE_SCHEMA_PATH = path.resolve(
+  __dirname,
+  '../../src/lib/substitution/fixtures/universal-macro-translation.schema.json'
+);
+const fixture = JSON.parse(readFileSync(FIXTURE_PATH, 'utf8'));
+const fixtureSchema = JSON.parse(readFileSync(FIXTURE_SCHEMA_PATH, 'utf8'));
 
-  it('inserts a native macro raw (not percent-encoded)', () => {
-    const result = translateUniversalMacros('https://px.example/i?gdpr={GDPR}', {
-      '{GDPR}': { native: '%%GDPR%%' },
+describe('translateUniversalMacros — canonical AdCP fixture', () => {
+  it('matches the pinned language-neutral fixture schema', () => {
+    const validate = new Ajv({ allErrors: true, strict: false }).compile(fixtureSchema);
+    assert.equal(validate(fixture), true, JSON.stringify(validate.errors));
+  });
+
+  for (const vector of fixture.vectors) {
+    it(vector.name, () => {
+      if (vector.expected_error) {
+        assert.throws(
+          () => translateUniversalMacros(vector.input_pixel_url, vector.mapping),
+          error => {
+            assert.ok(error instanceof UnsafeNativeMappingError);
+            assert.equal(error.code, vector.expected_error.code);
+            assert.equal(error.macro, vector.expected_error.macro);
+            return true;
+          }
+        );
+        return;
+      }
+
+      assert.deepEqual(translateUniversalMacros(vector.input_pixel_url, vector.mapping), vector.expected);
     });
-    assert.equal(result.url, 'https://px.example/i?gdpr=%%GDPR%%');
-    assert.deepEqual(result.dropped_params, []);
-    assert.deepEqual(result.unmapped_macros, []);
+  }
+});
+
+describe('translateUniversalMacros — JavaScript integration mechanics', () => {
+  it('rejects every C0 control character and DEL in native mappings', () => {
+    const forbiddenCodePoints = [...Array.from({ length: 0x20 }, (_, codePoint) => codePoint), 0x7f];
+
+    for (const codePoint of forbiddenCodePoints) {
+      assert.throws(
+        () =>
+          translateUniversalMacros('https://pixel.example/i?v={VALUE}', {
+            '{VALUE}': { native: `before${String.fromCharCode(codePoint)}after` },
+          }),
+        error =>
+          error instanceof UnsafeNativeMappingError &&
+          error.code === 'unsafe_native_mapping' &&
+          error.macro === '{VALUE}',
+        `expected U+${codePoint.toString(16).toUpperCase().padStart(4, '0')} to be rejected`
+      );
+    }
   });
 
-  // ─── value insertion ─────────────────────────────────────────────────────
+  it('rejects an unsafe native mapping that the input URL does not reference', () => {
+    assert.throws(
+      () =>
+        translateUniversalMacros('https://pixel.example/i?ok={OK}', {
+          '{OK}': { value: 'safe' },
+          '{UNUSED}': { native: 'unsafe\nvalue' },
+        }),
+      error => {
+        assert.ok(error instanceof UnsafeNativeMappingError);
+        assert.equal(error.name, 'UnsafeNativeMappingError');
+        assert.equal(error.code, 'unsafe_native_mapping');
+        assert.equal(error.macro, '{UNUSED}');
+        return true;
+      }
+    );
+  });
 
-  it('percent-encodes a value macro per RFC 3986 unreserved whitelist', () => {
-    const result = translateUniversalMacros('https://px.example/i?mb={MEDIA_BUY_ID}', {
-      '{MEDIA_BUY_ID}': { value: 'a&b=c' },
+  it('rejects the first unsafe native entry in mapping-property order', () => {
+    assert.throws(
+      () =>
+        translateUniversalMacros('https://pixel.example/i', {
+          '{FIRST}': { native: 'bad\u007f' },
+          '{SECOND}': { native: 'bad\u0000' },
+        }),
+      error => error instanceof UnsafeNativeMappingError && error.macro === '{FIRST}'
+    );
+  });
+
+  it('escapes unsafe log characters in an untyped mapping key while preserving error.macro', () => {
+    const unsafeLogCharacters = [
+      ['newline', '\n', '\\n'],
+      ['DEL', '\u007f', '\\u007f'],
+      ['C1', '\u0080', '\\u0080'],
+      ['line separator', '\u2028', '\\u2028'],
+      ['paragraph separator', '\u2029', '\\u2029'],
+    ];
+
+    for (const [name, character, escaped] of unsafeLogCharacters) {
+      const macro = `bad${character}macro`;
+      assert.throws(
+        () => translateUniversalMacros('https://pixel.example/i', { [macro]: { native: 'bad\u0000value' } }),
+        error => {
+          assert.ok(error instanceof UnsafeNativeMappingError);
+          assert.equal(error.macro, macro);
+          assert.equal(error.message.includes(character), false, `${name} must not remain literal in message`);
+          assert.ok(error.message.includes(`bad${escaped}macro`), `${name} must be escaped in message`);
+          return true;
+        }
+      );
+    }
+  });
+
+  it('does not broaden native rejection beyond C0 and DEL', () => {
+    const result = translateUniversalMacros('https://pixel.example/i?v={VALUE}', {
+      '{VALUE}': { native: 'allowed\u0080\u2028\u2029?&' },
     });
-    assert.equal(result.url, 'https://px.example/i?mb=a%26b%3Dc');
-    assert.deepEqual(result.dropped_params, []);
-    assert.deepEqual(result.unmapped_macros, []);
-  });
 
-  // ─── literal param untouched ─────────────────────────────────────────────
-
-  it('leaves an already-minted literal param unchanged and substitutes the other', () => {
-    const result = translateUniversalMacros('https://px.example/i?pkg_id=123456&mb={MEDIA_BUY_ID}', {
-      '{MEDIA_BUY_ID}': { value: 'buy-42' },
-    });
-    assert.equal(result.url, 'https://px.example/i?pkg_id=123456&mb=buy-42');
-    assert.deepEqual(result.dropped_params, []);
-    assert.deepEqual(result.unmapped_macros, []);
-  });
-
-  // ─── unmapped macro drops the whole param ────────────────────────────────
-
-  it('drops a param whose macro is not in the mapping', () => {
-    const result = translateUniversalMacros('https://px.example/i?mb={MEDIA_BUY_ID}&foo={UNSUPPORTED}', {
-      '{MEDIA_BUY_ID}': { value: 'buy-42' },
-    });
-    assert.equal(result.url, 'https://px.example/i?mb=buy-42');
-    assert.deepEqual(result.dropped_params, ['foo']);
-    assert.deepEqual(result.unmapped_macros, ['{UNSUPPORTED}']);
-  });
-
-  // ─── mixed param with one unmapped macro dropped whole ───────────────────
-
-  it('drops a param that contains even one unmapped macro', () => {
-    const result = translateUniversalMacros('https://px.example/i?ids={MEDIA_BUY_ID}-{UNSUPPORTED}', {
-      '{MEDIA_BUY_ID}': { value: 'buy-42' },
-    });
-    assert.equal(result.url, 'https://px.example/i');
-    assert.deepEqual(result.dropped_params, ['ids']);
-    assert.deepEqual(result.unmapped_macros, ['{UNSUPPORTED}']);
-  });
-
-  // ─── no nested re-expansion ──────────────────────────────────────────────
-
-  it('does not re-expand macros that appear inside a substituted value', () => {
-    // {MEDIA_BUY_ID} maps to a value containing {GDPR} — that inner token must
-    // be encoded as data, not treated as a macro.
-    const result = translateUniversalMacros('https://px.example/i?mb={MEDIA_BUY_ID}', {
-      '{MEDIA_BUY_ID}': { value: 'has-{GDPR}-inside' },
-      '{GDPR}': { native: '%%GDPR%%' },
-    });
-    // {GDPR} inside the value is encoded; the braces → %7B / %7D
-    assert.equal(result.url, 'https://px.example/i?mb=has-%7BGDPR%7D-inside');
-    assert.deepEqual(result.dropped_params, []);
-    assert.deepEqual(result.unmapped_macros, []);
-  });
-
-  // ─── no query string ─────────────────────────────────────────────────────
-
-  it('returns the URL unchanged when there is no query string', () => {
-    const url = 'https://px.example/i';
-    const result = translateUniversalMacros(url, { '{GDPR}': { native: '%%GDPR%%' } });
-    assert.equal(result.url, url);
-    assert.deepEqual(result.dropped_params, []);
-    assert.deepEqual(result.unmapped_macros, []);
-  });
-
-  // ─── multiple macros in one param ────────────────────────────────────────
-
-  it('translates multiple mapped macros within a single param in one pass', () => {
-    const result = translateUniversalMacros('https://px.example/i?ids={MEDIA_BUY_ID}_{GDPR}', {
-      '{MEDIA_BUY_ID}': { value: 'buy-42' },
-      '{GDPR}': { native: '%%GDPR%%' },
-    });
-    assert.equal(result.url, 'https://px.example/i?ids=buy-42_%%GDPR%%');
-    assert.deepEqual(result.dropped_params, []);
-    assert.deepEqual(result.unmapped_macros, []);
-  });
-
-  // ─── base / path / fragment pass through ────────────────────────────────
-
-  it('preserves scheme, host, path, and fragment verbatim', () => {
-    const result = translateUniversalMacros('https://px.example/path/segment?q={GDPR}#anchor', {
-      '{GDPR}': { native: '%%GDPR%%' },
-    });
-    assert.equal(result.url, 'https://px.example/path/segment?q=%%GDPR%%#anchor');
-  });
-
-  // ─── non-universal tokens not matched ────────────────────────────────────
-
-  it('does not treat native ad-server tokens (%%X%%) as universal macros', () => {
-    const result = translateUniversalMacros('https://px.example/i?gdpr=%%GDPR%%', {
-      '{GDPR}': { native: '%%GDPR%%' },
-    });
-    // no universal macro present → param is literal, left untouched
-    assert.equal(result.url, 'https://px.example/i?gdpr=%%GDPR%%');
-    assert.deepEqual(result.dropped_params, []);
-    assert.deepEqual(result.unmapped_macros, []);
-  });
-
-  it('does not treat double-brace tokens ({{x}}) as universal macros', () => {
-    const result = translateUniversalMacros('https://px.example/i?t={{timestamp}}', {});
-    assert.equal(result.url, 'https://px.example/i?t={{timestamp}}');
-    assert.deepEqual(result.dropped_params, []);
-    assert.deepEqual(result.unmapped_macros, []);
-  });
-
-  // ─── empty query-param value ─────────────────────────────────────────────
-
-  it('leaves a param with an empty value untouched', () => {
-    const result = translateUniversalMacros('https://px.example/i?k=', {});
-    assert.equal(result.url, 'https://px.example/i?k=');
-    assert.deepEqual(result.dropped_params, []);
-    assert.deepEqual(result.unmapped_macros, []);
-  });
-
-  // ─── macro token in KEY position is ignored ──────────────────────────────
-
-  it('does not substitute, drop, or flag a macro token appearing in a key position', () => {
-    // Matching runs on values only; a {MACRO} in the key must pass through raw.
-    const result = translateUniversalMacros('https://px.example/i?{MEDIA_BUY_ID}=v', {
-      '{MEDIA_BUY_ID}': { value: 'buy-42' },
-    });
-    assert.equal(result.url, 'https://px.example/i?{MEDIA_BUY_ID}=v');
-    assert.deepEqual(result.dropped_params, []);
-    assert.deepEqual(result.unmapped_macros, []);
-  });
-
-  // ─── non-ASCII value is UTF-8 percent-encoded ────────────────────────────
-
-  it('percent-encodes non-ASCII characters in a substituted value (UTF-8)', () => {
-    const result = translateUniversalMacros('https://px.example/i?s={STORE_ID}', {
-      '{STORE_ID}': { value: 'café' },
-    });
-    assert.equal(result.url, 'https://px.example/i?s=caf%C3%A9');
-    assert.deepEqual(result.dropped_params, []);
-    assert.deepEqual(result.unmapped_macros, []);
-  });
-
-  // ─── native-token shape mistakenly mapped as a value is flagged ──────────
-
-  it('flags a value entry that looks like a native ad-server token', () => {
-    const result = translateUniversalMacros('https://px.example/i?cb={CACHEBUSTER}&dom={DOMAIN}&ts={TS}', {
-      '{CACHEBUSTER}': { value: '%%CACHEBUSTER%%' }, // wrong arm — should be native
-      '{DOMAIN}': { value: '${SITE}' }, // wrong arm — should be native
-      '{TS}': { value: '1700000000' }, // legitimate value
-    });
-    assert.deepEqual(result.suspect_native_values.sort(), ['{CACHEBUSTER}', '{DOMAIN}']);
-    // The suspect values are still encoded (the helper does not silently fix them).
-    assert.equal(result.url, 'https://px.example/i?cb=%25%25CACHEBUSTER%25%25&dom=%24%7BSITE%7D&ts=1700000000');
-  });
-
-  it('does not flag native entries or ordinary values', () => {
-    const result = translateUniversalMacros('https://px.example/i?cb={CACHEBUSTER}&mb={MEDIA_BUY_ID}', {
-      '{CACHEBUSTER}': { native: '%%CACHEBUSTER%%' },
-      '{MEDIA_BUY_ID}': { value: 'mb_123' },
-    });
-    assert.deepEqual(result.suspect_native_values, []);
-  });
-
-  it('does not flag ordinary bracketed values as native tokens', () => {
-    const result = translateUniversalMacros('https://px.example/i?a={A}&b={B}', {
-      '{A}': { value: '[1,2,3]' },
-      '{B}': { value: '[redacted]' },
-    });
-    assert.deepEqual(result.suspect_native_values, []);
-  });
-
-  it('flags an upper-snake bracketed token (VAST-style) as native', () => {
-    const result = translateUniversalMacros('https://px.example/i?cb={CB}', {
-      '{CB}': { value: '[CACHEBUSTING]' },
-    });
-    assert.deepEqual(result.suspect_native_values, ['{CB}']);
-  });
-
-  // ─── dropped consent/privacy macros are surfaced separately ──────────────
-
-  it('reports a dropped consent macro in dropped_consent_macros', () => {
-    const result = translateUniversalMacros('https://px.example/i?mb={MEDIA_BUY_ID}&c={GDPR_CONSENT}&x={FOO}', {
-      '{MEDIA_BUY_ID}': { value: 'mb_123' },
-    });
-    assert.equal(result.url, 'https://px.example/i?mb=mb_123');
-    assert.deepEqual(result.dropped_params.sort(), ['c', 'x']);
-    assert.deepEqual(result.unmapped_macros.sort(), ['{FOO}', '{GDPR_CONSENT}']);
-    // Only the consent macro is highlighted; the benign {FOO} drop is not.
-    assert.deepEqual(result.dropped_consent_macros, ['{GDPR_CONSENT}']);
-  });
-
-  it('leaves dropped_consent_macros empty when no consent macro is dropped', () => {
-    const result = translateUniversalMacros('https://px.example/i?x={FOO}', {});
-    assert.deepEqual(result.dropped_consent_macros, []);
+    assert.equal(result.url, 'https://pixel.example/i?v=allowed\u0080\u2028\u2029?&');
   });
 });


### PR DESCRIPTION
## Summary

- adopt the canonical universal-macro translation fixture and schema
- reject unsafe native mapping controls with a typed, log-safe error
- report consent macros frozen through literal mappings while preserving source compatibility
- document the seller-side translation workflow and add exhaustive regression coverage

Closes #2620.

Implements the policies ratified in https://github.com/adcontextprotocol/adcp/issues/6674.

## Validation

- `npm run build`
- `npm run typecheck`
- `node --test test/lib/substitution-translate.test.js` (27 passed)
- `npm run test:node:fast` (15,463 passed, 7 skipped)
- protocol, code-quality, and Node.js testing expert reviews converged with no actionable findings
