### PR TITLE
fix: resolve open 3.0 and 3.1 compatibility bugs

### DIFF
--- a/.changeset/bright-maps-fix-open-bugs.md
+++ b/.changeset/bright-maps-fix-open-bugs.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': minor
+---
+
+Make compliance timeout truncation structurally visible and scale the CLI's default budget, forward exact wire pins through `ADCPMultiAgentClient.simple()`, bridge auto-wired RFC 9421 signer identity into handler auth and buyer-agent resolution, and complete seller-aware AdCP 3.1-to-3.0 discovery request adaptation across MCP and A2A.

--- a/bin/adcp-storyboard-summary.js
+++ b/bin/adcp-storyboard-summary.js
@@ -40,6 +40,14 @@ function buildComplianceSummaryMarkdown(result, agentUrl) {
       `${s.steps_passed ?? 0} passed / ${s.steps_failed ?? 0} failed / ${s.steps_skipped ?? 0} skipped / ` +
       `${s.steps_not_selected ?? 0} not selected`
   );
+  if (result.completeness === 'timed_out') {
+    const timeoutObservation = result.observations?.find(
+      observation => observation.source?.code === 'timeout-budget-exceeded'
+    );
+    lines.push(
+      `**Incomplete:** ${timeoutObservation?.message || 'The compliance timeout budget was reached before every selected storyboard ran.'}`
+    );
+  }
   const notSelectedReasons = formatReasonCounts(s.not_selected_by_reason);
   if (notSelectedReasons) lines.push(`**Not selected:** ${notSelectedReasons}`);
   const skippedReasons = formatReasonCounts(s.skipped_by_reason);
@@ -67,6 +75,16 @@ function buildComplianceSummaryMarkdown(result, agentUrl) {
     lines.push('');
   }
   return lines.join('\n');
+}
+
+/**
+ * Scale the implicit compliance budget with the selected storyboard set.
+ * Keep the historical 120-second floor for small/unknown selections and
+ * reserve ten seconds per selected storyboard for larger release lines.
+ */
+function defaultComplianceTimeoutSeconds(selectedStoryboardCount) {
+  if (!Number.isSafeInteger(selectedStoryboardCount) || selectedStoryboardCount <= 0) return 120;
+  return Math.max(120, selectedStoryboardCount * 10);
 }
 
 function formatReasonCounts(counts) {
@@ -164,4 +182,5 @@ module.exports = {
   buildStoryboardSummaryMarkdown,
   writeSummaryFile,
   printSoftFailBlock,
+  defaultComplianceTimeoutSeconds,
 };

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -47,6 +47,7 @@ const {
   buildStoryboardSummaryMarkdown,
   writeSummaryFile,
   printSoftFailBlock,
+  defaultComplianceTimeoutSeconds,
 } = require('./adcp-storyboard-summary.js');
 const { scheduleVersionCheck } = require('./adcp-version-check.js');
 const { formatStoryboardResultsAsJUnit } = require('../dist/lib/testing/storyboard/junit.js');
@@ -1984,7 +1985,7 @@ RUN OPTIONS (full assessment):
                       line is required for storyboard resolution.
   --timeout SECONDS   Soft budget in seconds: stop starting new storyboards
                       after this budget, without aborting an active storyboard
-                      (default: 120)
+                      (default: max(120, 10 × selected storyboard count))
   --brief TEXT        Custom brief for product discovery
   --no-sandbox        Force production-path responses (#841). Sets
                       account.sandbox=false on every request AND stamps
@@ -4504,8 +4505,10 @@ async function runFullAssessment(agentArg, rawArgs, parsedOpts) {
     storyboards = rawArgs[storyboardsIndex + 1].split(',');
   }
   const complianceResolveOptions = parseComplianceSelection(rawArgs).resolveOptions;
+  const { listAllComplianceStoryboards, listBundles, resolveBundleOrStoryboard } =
+    await import('../dist/lib/testing/storyboard/index.js');
+  let selectedStoryboardCount = listAllComplianceStoryboards(complianceResolveOptions).length;
   if (storyboards?.length) {
-    const { listAllComplianceStoryboards, listBundles } = await import('../dist/lib/testing/storyboard/index.js');
     try {
       const knownStoryboardIds = new Set(listAllComplianceStoryboards(complianceResolveOptions).map(s => s.id));
       const knownBundleIds = new Set(listBundles(complianceResolveOptions).map(b => b.id));
@@ -4515,15 +4518,21 @@ async function runFullAssessment(agentArg, rawArgs, parsedOpts) {
         console.error(`Run 'adcp storyboard list' to see all options.\n`);
         process.exit(2);
       }
+      selectedStoryboardCount = new Set(
+        storyboards.flatMap(id =>
+          resolveBundleOrStoryboard(id, complianceResolveOptions).map(storyboard => storyboard.id)
+        )
+      ).size;
     } catch (err) {
       console.error(`ERROR: ${err.message}`);
       process.exit(1);
     }
   }
 
-  // Parse --timeout (seconds, default 120)
+  // Parse --timeout (seconds). The implicit budget scales with the selected
+  // set so spec releases that add storyboards do not silently truncate runs.
   const timeoutFlagIndex = rawArgs.indexOf('--timeout');
-  const DEFAULT_TIMEOUT_S = 120;
+  const DEFAULT_TIMEOUT_S = defaultComplianceTimeoutSeconds(selectedStoryboardCount);
   let timeoutMs = DEFAULT_TIMEOUT_S * 1000;
   if (timeoutFlagIndex !== -1) {
     if (timeoutFlagIndex + 1 >= rawArgs.length || rawArgs[timeoutFlagIndex + 1].startsWith('--')) {

--- a/docs/migration-buyer-agent-registry.md
+++ b/docs/migration-buyer-agent-registry.md
@@ -26,7 +26,7 @@ The framework picks up the registry, runs `resolve()` once per request, threads 
 | `BuyerAgentRegistry` Protocol + 3 factories | Map credentials to durable buyer-agent records | Opt in via `platform.agentRegistry` |
 | `BuyerAgent.status` enforcement | Reject `suspended`/`blocked` agents at 403 | Active when registry returns a record |
 | `ResolvedAuthInfo.credential` (kind-discriminated) | Stable identity surface across api-key / OAuth / signed-request auth | Opt in by reading `ctx.authInfo.credential.kind` |
-| Verifier-attested `http_sig.agent_url` | Cryptographic proof of buyer-agent identity (per adcp#3831) | Active when `verifySignatureAsAuthenticator` is wired |
+| Verifier-attested `http_sig.agent_url` | Cryptographic proof of buyer-agent identity (per adcp#3831) | Active with `verifySignatureAsAuthenticator` or auto-wired `signedRequests.agentUrlForKeyid` |
 | `BuyerAgentRegistry.cached` decorator | TTL + LRU + concurrent-resolve coalescing + `invalidate()` / `clear()` API | Decorator pattern — wrap your registry |
 | `BuyerAgent.sandbox_only` (Phase 1.5) | Defense-in-depth for test agents | Set on the agent record; framework gates after `accounts.resolve` |
 | `sync_accounts` billing gate | Reject billing values outside the resolved agent's commercial relationship | Active when `platform.agentRegistry` returns a record |
@@ -322,6 +322,35 @@ const auth = verifySignatureAsAuthenticator({
 ```
 
 Per adcp#3831, the `agent_url` derivation rule is "the `agents[]` entry whose `jwks_uri` resolved the keyid." Your `agentUrlForKeyid` MUST follow this — don't return arbitrary URLs.
+
+### Auto-wired `signedRequests`
+
+Servers using `createAdcpServer({ signedRequests })` can expose the same
+verified identity without separately wiring `verifySignatureAsAuthenticator`:
+
+```ts
+createAdcpServer({
+  // ...platform configuration...
+  signedRequests: {
+    jwks,
+    replayStore,
+    revocationStore,
+    agentUrlForKeyid: (keyid) => keyidToAgentUrlMap.get(keyid),
+    // Optional: map the signer to your stable internal principal.
+    makePrincipal: (signer) => {
+      const principal = keyidToPrincipal.get(signer.keyid);
+      if (!principal) throw new Error('Unknown signer key');
+      return { principal };
+    },
+  },
+});
+```
+
+`makePrincipal` must return a non-empty principal; an unmapped key is rejected.
+If `serve({ authenticate })` is also configured, the signer and authenticate
+hook must resolve to the same principal or the request is rejected with 401.
+This prevents bearer scopes/task ownership from being combined with a
+different signed buyer-agent identity.
 
 ## Common pitfalls
 

--- a/src/lib/adapters/version/3.0/get-products.ts
+++ b/src/lib/adapters/version/3.0/get-products.ts
@@ -17,6 +17,14 @@ const PRICING_FILTERS_DRIFT: VersionDrift = {
   strippedFields: ['filters.pricing_currencies'],
 };
 
+const PUSH_NOTIFICATION_DRIFT: VersionDrift = {
+  type: 'pre31_discovery_webhook_stripped',
+  message:
+    'push_notification_config stripped from get_products: discovery-task webhooks require AdCP 3.1, ' +
+    'but the target seller does not advertise 3.1 support. Poll for the result instead.',
+  strippedFields: ['push_notification_config'],
+};
+
 export const getProductsAdapter: VersionAdapter = {
   toolName: 'get_products',
   adaptRequest(params) {
@@ -45,7 +53,24 @@ export const getProductsAdapter: VersionAdapter = {
       }
     }
 
+    if ('push_notification_config' in adapted) {
+      const { push_notification_config: _, ...rest } = adapted;
+      adapted = rest;
+      drifts.push(PUSH_NOTIFICATION_DRIFT);
+    }
+
     if (adapted === req) return { params };
-    return { params: adapted, drift: drifts[0] };
+    if (drifts.length === 1) return { params: adapted, drift: drifts[0] };
+    return {
+      params: adapted,
+      drift: {
+        // Preserve the established first-drift type for monitoring clients;
+        // constituentTypes makes every aggregated change machine-readable.
+        type: drifts[0]!.type,
+        message: drifts.map(drift => drift.message).join(' '),
+        strippedFields: drifts.flatMap(drift => drift.strippedFields ?? []),
+        constituentTypes: drifts.map(drift => drift.type),
+      },
+    };
   },
 };

--- a/src/lib/adapters/version/3.0/get-signals.ts
+++ b/src/lib/adapters/version/3.0/get-signals.ts
@@ -1,0 +1,20 @@
+import type { VersionAdapter, VersionDrift } from '../types';
+
+const PUSH_NOTIFICATION_DRIFT: VersionDrift = {
+  type: 'pre31_discovery_webhook_stripped',
+  message:
+    'push_notification_config stripped from get_signals: discovery-task webhooks require AdCP 3.1, ' +
+    'but the target seller does not advertise 3.1 support. Poll for the result instead.',
+  strippedFields: ['push_notification_config'],
+};
+
+export const getSignalsAdapter: VersionAdapter = {
+  toolName: 'get_signals',
+  adaptRequest(params) {
+    if (!params || typeof params !== 'object' || Array.isArray(params)) return { params };
+    const request = params as Record<string, unknown>;
+    if (!('push_notification_config' in request)) return { params };
+    const { push_notification_config: _, ...adapted } = request;
+    return { params: adapted, drift: PUSH_NOTIFICATION_DRIFT };
+  },
+};

--- a/src/lib/adapters/version/3.0/index.ts
+++ b/src/lib/adapters/version/3.0/index.ts
@@ -1,10 +1,12 @@
 import { createMediaBuyAdapter } from './brand-fields';
 import { getProductsAdapter } from './get-products';
+import { getSignalsAdapter } from './get-signals';
 import { syncAccountsAdapter } from './sync-accounts';
 import type { VersionAdapter } from '../types';
 
 export const v30Adapters: ReadonlyArray<VersionAdapter> = [
   createMediaBuyAdapter,
   getProductsAdapter,
+  getSignalsAdapter,
   syncAccountsAdapter,
 ];

--- a/src/lib/adapters/version/index.ts
+++ b/src/lib/adapters/version/index.ts
@@ -44,7 +44,7 @@ export function getVersionAdapter(adapterKey: string, toolName: string): Version
  */
 export function resolveAdapterKey(
   clientVersion: string | undefined,
-  caps: { supportedVersions?: string[]; buildVersion?: string } | undefined
+  caps: { supportedVersions?: string[]; buildVersion?: string; _raw?: Record<string, unknown> } | undefined
 ): string | undefined {
   if (shouldOmit31Fields(clientVersion, caps)) return '3.0';
   return undefined;

--- a/src/lib/adapters/version/types.ts
+++ b/src/lib/adapters/version/types.ts
@@ -18,6 +18,8 @@ export interface VersionDrift {
   message: string;
   /** Names of the fields removed from the request. */
   strippedFields?: string[];
+  /** Individual drift types when one adaptation aggregates multiple changes. */
+  constituentTypes?: string[];
 }
 
 export interface VersionAdapter {

--- a/src/lib/core/ADCPMultiAgentClient.ts
+++ b/src/lib/core/ADCPMultiAgentClient.ts
@@ -17,7 +17,7 @@ import type {
   WebhookHandlerRequest,
   WebhookParseResult,
 } from './SingleAgentClient';
-import { ADCP_VERSION } from '../version';
+import { ADCP_VERSION, type AdcpVersion } from '../version';
 import { resolveAdcpVersion } from '../utils/adcp-version-config';
 import { ConfigurationManager } from './ConfigurationManager';
 import { CreativeAgentClient, STANDARD_CREATIVE_AGENTS } from './CreativeAgentClient';
@@ -561,6 +561,10 @@ export class ADCPMultiAgentClient {
       authToken?: string;
       debug?: boolean;
       timeout?: number;
+      /** Public schema/version pin used by the client validators and adapters. */
+      adcpVersion?: AdcpVersion | (string & {});
+      /** Exact release-line pin emitted on the wire (including prereleases). */
+      wireAdcpVersion?: AdcpVersion | (string & {});
     } = {}
   ): ADCPMultiAgentClient {
     const {
@@ -570,6 +574,8 @@ export class ADCPMultiAgentClient {
       authToken,
       debug = false,
       timeout,
+      adcpVersion,
+      wireAdcpVersion,
     } = options;
 
     const agent: AgentConfig = {
@@ -585,6 +591,8 @@ export class ADCPMultiAgentClient {
     return new ADCPMultiAgentClient([agent], {
       debug,
       workingTimeout: timeout,
+      ...(adcpVersion !== undefined && { adcpVersion }),
+      ...(wireAdcpVersion !== undefined && { wireAdcpVersion }),
     });
   }
 

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -7138,8 +7138,7 @@ export class SingleAgentClient {
         capabilityPath: 'signals.discovery_modes',
         currentVersion: advertisedVersions.join(', ') || responseVersion || '3.0 (not advertised)',
         incompatibility: 'the target seller does not advertise AdCP 3.1 support',
-        suffix:
-          'Retry with a meaningful signal_spec, or probe signals.discovery_modes before issuing wholesale calls.',
+        suffix: 'Retry with a meaningful signal_spec, or probe signals.discovery_modes before issuing wholesale calls.',
       });
     }
   }

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -3276,14 +3276,6 @@ export class SingleAgentClient {
     });
     this.assertRequestSupportedByConfiguredVersion(taskType, normalizedParams, options);
 
-    // Degrade an auto-injected discovery webhook to polling for pre-3.1 pins
-    // (get_products / get_signals). `effectiveOptions` carries disableWebhook
-    // so no push_notification_config reaches a seller that can't accept it.
-    const { options: effectiveOptions, driftLog: webhookDriftLog } = this.suppressPre31DiscoveryWebhook(
-      taskType,
-      options
-    );
-
     // Inject an idempotency_key for mutating tools before schema validation
     // so callers don't have to supply one. TaskExecutor also guards against
     // missing keys, but validation happens here first — do the injection up
@@ -3354,6 +3346,12 @@ export class SingleAgentClient {
     };
     const serverVersion = await this.detectServerVersion(detectionOptions);
     throwIfAborted(options?.signal);
+    this.assertRequestSupportedByTargetVersion(taskType, normalizedParams, capabilityDiscoveryContext.capabilities);
+    const { options: effectiveOptions, driftLog: webhookDriftLog } = this.suppressPre31DiscoveryWebhook(
+      taskType,
+      options,
+      capabilityDiscoveryContext.capabilities
+    );
     const inputSchemaStripLogs: any[] = [];
     const { params: adaptedParams, driftLogs: adaptDriftLogs } = this.adaptRequest(
       taskType,
@@ -5784,14 +5782,6 @@ export class SingleAgentClient {
       });
       this.assertRequestSupportedByConfiguredVersion(taskName, normalizedParams, options);
 
-      // Degrade an auto-injected discovery webhook to polling for pre-3.1 pins
-      // (get_products / get_signals). `effectiveOptions` carries disableWebhook
-      // so no push_notification_config reaches a seller that can't accept it.
-      const { options: effectiveOptions, driftLog: webhookDriftLog } = this.suppressPre31DiscoveryWebhook(
-        taskName,
-        options
-      );
-
       await this.validateTaskFeatures(taskName, options);
       if (this.config.requireV3ForMutations && requestUsesIdempotency(taskName, normalizedParams)) {
         await this.requireSupportedMajor(taskName, options);
@@ -5814,6 +5804,12 @@ export class SingleAgentClient {
         [CAPABILITY_DISCOVERY_CONTEXT]: capabilityDiscoveryContext,
       };
       const serverVersion = await this.detectServerVersion(detectionOptions);
+      this.assertRequestSupportedByTargetVersion(taskName, normalizedParams, capabilityDiscoveryContext.capabilities);
+      const { options: effectiveOptions, driftLog: webhookDriftLog } = this.suppressPre31DiscoveryWebhook(
+        taskName,
+        options,
+        capabilityDiscoveryContext.capabilities
+      );
       const inputSchemaStripLogs: any[] = [];
       const { params: adaptedParams, driftLogs: adaptDriftLogs } = this.adaptRequest(
         taskName,
@@ -7076,45 +7072,95 @@ export class SingleAgentClient {
    */
   private suppressPre31DiscoveryWebhook(
     taskName: string,
-    options?: TaskOptions
+    options?: TaskOptions,
+    capabilities?: AdcpCapabilities
   ): { options: TaskOptions | undefined; driftLog?: Record<string, unknown> } {
-    if (!isPre31AdcpVersion(this.resolvedAdcpVersion)) return { options };
+    if (resolveAdapterKey(this.resolvedAdcpVersion, capabilities) !== '3.0') return { options };
     if (taskName !== 'get_products' && taskName !== 'get_signals') return { options };
     if (options?.disableWebhook) return { options };
     if (selectWebhookTemplate(this.config.webhookUrlTemplate, taskName) === undefined) return { options };
 
+    const clientPinnedPre31 = isPre31AdcpVersion(this.resolvedAdcpVersion);
+    const targetVersions = capabilities?.supportedVersions ?? [];
+    const reason = clientPinnedPre31
+      ? `this client is pinned to ${this.resolvedAdcpVersion}`
+      : targetVersions.length > 0
+        ? `the target seller advertises only ${targetVersions.join(', ')}`
+        : 'the target seller does not advertise AdCP 3.1 support';
     return {
       options: { ...options, disableWebhook: true },
       driftLog: {
         type: 'pre31_webhook_degraded',
         message:
           `${taskName} discovery webhook degraded to polling: discovery-task push_notification_config ` +
-          `requires AdCP 3.1, but this client is pinned to ${this.resolvedAdcpVersion}. ` +
+          `requires AdCP 3.1, but ${reason}. ` +
           'The seller will not receive a push webhook; poll for the result instead.',
         timestamp: new Date().toISOString(),
         taskName,
         clientVersion: this.resolvedAdcpVersion,
+        ...(targetVersions.length > 0 ? { targetVersions } : {}),
       },
     };
+  }
+
+  /**
+   * Reject shape-changing 3.1 requests after seller capability discovery.
+   * This second gate covers a modern client talking to a 3.0 seller on the
+   * first (cold-cache) call; the configured-version gate above still catches
+   * an explicitly pre-3.1 client before validation or network I/O.
+   */
+  private assertRequestSupportedByTargetVersion(
+    taskName: string,
+    params: unknown,
+    capabilities: AdcpCapabilities | undefined
+  ): void {
+    if (isPre31AdcpVersion(this.resolvedAdcpVersion)) return;
+    // supportedVersions is the authoritative negotiation field. Legacy 3.0
+    // sellers omit it; buildVersion is advisory and must not select a newer
+    // wire shape. Shape-breaking wholesale discovery therefore requires
+    // positive 3.1+ support from a declared v3 seller. The response envelope's
+    // adcp_version is also direct evidence of the wire release the seller just
+    // served (distinct from advisory adcp.build_version). Synthetic discovery
+    // alone is not enough evidence to classify the seller as 3.0.
+    const advertisedVersions = capabilities?.supportedVersions ?? [];
+    if (advertisedVersions.some(version => !isPre31AdcpVersion(version))) return;
+    const responseVersion =
+      typeof capabilities?._raw?.adcp_version === 'string' ? capabilities._raw.adcp_version : undefined;
+    if (advertisedVersions.length === 0 && responseVersion !== undefined && !isPre31AdcpVersion(responseVersion)) {
+      return;
+    }
+    const declaredLegacyV3 = capabilities?.version === 'v3' && capabilities._synthetic === false;
+    if (advertisedVersions.length === 0 && !declaredLegacyV3) return;
+    const request =
+      params && typeof params === 'object' && !Array.isArray(params) ? (params as Record<string, unknown>) : {};
+    if (taskName === 'get_signals' && request.discovery_mode === 'wholesale') {
+      this.throwPre31UnsupportedFeature(taskName, 'discovery_mode', 'get_signals.discovery_mode=wholesale', {
+        capabilityPath: 'signals.discovery_modes',
+        currentVersion: advertisedVersions.join(', ') || responseVersion || '3.0 (not advertised)',
+        incompatibility: 'the target seller does not advertise AdCP 3.1 support',
+        suffix:
+          'Retry with a meaningful signal_spec, or probe signals.discovery_modes before issuing wholesale calls.',
+      });
+    }
   }
 
   private throwPre31UnsupportedFeature(
     taskName: string,
     field: string,
     feature: string,
-    opts: { capabilityPath: string; suffix: string }
+    opts: { capabilityPath: string; suffix: string; currentVersion?: string; incompatibility?: string }
   ): never {
+    const currentVersion = opts.currentVersion ?? this.resolvedAdcpVersion;
+    const incompatibility = opts.incompatibility ?? `this client is pinned to ${this.resolvedAdcpVersion}`;
     throw new ProtocolFeatureUnsupportedError([feature], [], this.agent.agent_uri, {
-      message:
-        `${taskName} ${field} requires AdCP 3.1 or later; ` +
-        `this client is pinned to ${this.resolvedAdcpVersion}. ${opts.suffix}`,
+      message: `${taskName} ${field} requires AdCP 3.1 or later; ` + `${incompatibility}. ${opts.suffix}`,
       field,
       suggestion: opts.suffix,
       details: {
         feature,
         required_version: '3.1',
         capability_path: opts.capabilityPath,
-        current_version: this.resolvedAdcpVersion,
+        current_version: currentVersion,
         tool: taskName,
         field,
       },

--- a/src/lib/server/auth-signature.ts
+++ b/src/lib/server/auth-signature.ts
@@ -177,57 +177,12 @@ export function verifySignatureAsAuthenticator(options: VerifySignatureAsAuthent
       });
     }
 
-    // keyid is buyer-controlled (JWK spec places no charset restriction on
-    // `kid`). Bound it to a URL-safe shape — explicitly excluding `:` — before
-    // interpolating into the principal string, so downstream tenant-isolation
-    // checks that split `signing:<keyid>` on the first `:` can't be confused
-    // by a colon embedded in the signer's key id.
-    if (!SAFE_KEYID.test(result.keyid)) {
-      throw new AuthError('Signature key id contains unsupported characters.', {
-        cause: new Error(`keyid=${JSON.stringify(result.keyid)} fails /^[A-Za-z0-9._-]{1,256}$/`),
-      });
-    }
-
     const signer: VerifiedSigner = {
       keyid: result.keyid,
       verified_at: result.verified_at,
       ...(result.agent_url !== undefined ? { agent_url: result.agent_url } : {}),
     };
-
-    // Stamp the kind-discriminated `credential` variant for the framework's
-    // dispatcher and `BuyerAgentRegistry` resolution (Phase 1 Stage 3 of
-    // #1269). Per adcontextprotocol/adcp#3831, `agent_url` here is the
-    // verifier's `agentUrlForKeyid` lookup result — derived from the
-    // `agents[]` entry whose `jwks_uri` resolved the keyid.
-    //
-    // When `agent_url` is unset (verifier wired without a keyid→agent URL
-    // resolver), we OMIT the `credential` rather than synthesize an
-    // `http_sig` variant that would otherwise carry an empty agent_url —
-    // Stage 1's runtime guard rejects malformed http_sig credentials, so
-    // emitting one would just trip the guard and confuse the audit trail.
-    const credential =
-      signer.agent_url !== undefined
-        ? markVerifiedHttpSig({
-            kind: 'http_sig',
-            keyid: signer.keyid,
-            agent_url: signer.agent_url,
-            verified_at: signer.verified_at,
-          })
-        : undefined;
-
-    const principal = options.makePrincipal
-      ? options.makePrincipal(signer)
-      : {
-          principal: `signing:${signer.keyid}`,
-          claims: {
-            signature: {
-              keyid: signer.keyid,
-              verified_at: signer.verified_at,
-              ...(signer.agent_url !== undefined ? { agent_url: signer.agent_url } : {}),
-            },
-          },
-          ...(credential !== undefined && { credential }),
-        };
+    const principal = principalForVerifiedSigner(signer, options.makePrincipal);
 
     // Write the side-channel state only after the principal is fully built so
     // a throw from `makePrincipal` leaves `req.verifiedSigner` unset — the
@@ -238,6 +193,62 @@ export function verifySignatureAsAuthenticator(options: VerifySignatureAsAuthent
   };
 
   return tagAuthenticatorNeedsRawBody(authenticator);
+}
+
+/**
+ * Build the authenticated principal shared by the authenticate-hook and the
+ * auto-wired `signedRequests` verifier. A custom principal keeps its identity
+ * fields, while the framework still attaches the branded HTTP-signature
+ * credential unless the callback explicitly supplied a credential of its own.
+ *
+ * @internal
+ */
+export function principalForVerifiedSigner(
+  signer: VerifiedSigner,
+  makePrincipal?: (signer: VerifiedSigner) => AuthPrincipal
+): AuthPrincipal {
+  // keyid is buyer-controlled (JWK spec places no charset restriction on
+  // `kid`). Bound it to a URL-safe shape — explicitly excluding `:` — before
+  // interpolating into the principal string, so downstream tenant-isolation
+  // checks that split `signing:<keyid>` on the first `:` cannot be confused.
+  if (!SAFE_KEYID.test(signer.keyid)) {
+    throw new AuthError('Signature key id contains unsupported characters.', {
+      cause: new Error(`keyid=${JSON.stringify(signer.keyid)} fails /^[A-Za-z0-9._-]{1,256}$/`),
+    });
+  }
+
+  const credential =
+    signer.agent_url !== undefined
+      ? markVerifiedHttpSig({
+          kind: 'http_sig',
+          keyid: signer.keyid,
+          agent_url: signer.agent_url,
+          verified_at: signer.verified_at,
+        })
+      : undefined;
+  if (makePrincipal !== undefined) {
+    const custom = makePrincipal(signer);
+    if (
+      !custom ||
+      typeof custom !== 'object' ||
+      typeof (custom as AuthPrincipal).principal !== 'string' ||
+      (custom as AuthPrincipal).principal.length === 0
+    ) {
+      throw new AuthError('Signature key is not mapped to an authenticated principal.');
+    }
+    return credential !== undefined && custom.credential === undefined ? { ...custom, credential } : custom;
+  }
+  return {
+    principal: `signing:${signer.keyid}`,
+    claims: {
+      signature: {
+        keyid: signer.keyid,
+        verified_at: signer.verified_at,
+        ...(signer.agent_url !== undefined ? { agent_url: signer.agent_url } : {}),
+      },
+    },
+    ...(credential !== undefined && { credential }),
+  };
 }
 
 /**

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -52,6 +52,7 @@ import { getToolsWithErrorArm, type ErrorArmDescriptor } from './error-arm-tools
 import type { ToolCallback } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { ZodRawShapeCompat, AnySchema } from '@modelcontextprotocol/sdk/server/zod-compat.js';
 import type { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
 import {
   ADCP_CAPABILITIES,
   ADCP_STATE_STORE,
@@ -88,7 +89,8 @@ import {
 import { ADCP_ERROR_FIELD_ALLOWLIST } from './envelope-allowlist';
 import { InMemoryStateStore } from './state-store';
 import type { AdcpStateStore } from './state-store';
-import { getServeRequestContext } from './auth';
+import { AuthError, getServeRequestContext, type AuthPrincipal } from './auth';
+import { principalForVerifiedSigner } from './auth-signature';
 import {
   capabilitiesResponse,
   productsResponse,
@@ -1279,6 +1281,14 @@ export interface SignedRequestsConfig {
    * signing key is scoped to a brand identifier rather than the root.
    */
   agentUrlForKeyid?: (keyid: string) => string | undefined;
+  /**
+   * Shape the signer identity exposed to handlers. The framework attaches a
+   * branded `http_sig` credential when `agentUrlForKeyid` resolves, unless
+   * this callback explicitly supplies another credential. When `serve()` also
+   * authenticates the request, this callback must resolve the signer to that
+   * same authenticated principal or the request is rejected.
+   */
+  makePrincipal?: (signer: import('../signing/types').VerifiedSigner) => AuthPrincipal;
 }
 
 /**
@@ -3983,12 +3993,65 @@ function buildSignedRequestsPreTransport(
           }
           handled = true;
         }
+        const verifiedSigner = reqShim.verifiedSigner as import('../signing/types').VerifiedSigner | undefined;
+        if (!err && verifiedSigner) {
+          try {
+            const principal = principalForVerifiedSigner(verifiedSigner, signedRequests.makePrincipal);
+            attachVerifiedSignerAuth(req, principal, verifiedSigner);
+          } catch (identityError) {
+            const errName = (identityError as Error).name || 'Error';
+            console.error(`[adcp/signed-requests] signer identity rejected: ${errName}`);
+            if (!res.writableEnded) {
+              res.statusCode = 401;
+              res.setHeader('WWW-Authenticate', 'Signature error="request_signature_invalid"');
+              res.setHeader('Content-Type', 'application/json');
+              res.end(
+                JSON.stringify({
+                  error: 'request_signature_invalid',
+                  message: 'Request signature verification failed',
+                })
+              );
+            }
+            handled = true;
+          }
+        }
         if (res.writableEnded) handled = true;
         done();
       });
     });
     return handled;
   };
+}
+
+function attachVerifiedSignerAuth(
+  req: import('http').IncomingMessage,
+  principal: AuthPrincipal,
+  signer: import('../signing/types').VerifiedSigner
+): void {
+  const request = req as import('http').IncomingMessage & { auth?: AuthInfo; verifiedSigner?: typeof signer };
+  const existing = request.auth;
+  if (existing && existing.clientId !== principal.principal) {
+    throw new AuthError('Request signature identity does not match the authenticated principal.');
+  }
+  const claims = principal.claims !== undefined ? { ...principal.claims } : {};
+  const adopterExtra =
+    principal.extra && typeof principal.extra === 'object' ? (principal.extra as Record<string, unknown>) : {};
+  const extra = {
+    ...(existing?.extra ?? {}),
+    ...claims,
+    ...adopterExtra,
+    ...(principal.credential !== undefined ? { credential: principal.credential } : {}),
+  };
+  request.auth = existing
+    ? { ...existing, extra }
+    : {
+        token: principal.token ?? '',
+        clientId: principal.principal,
+        scopes: principal.scopes ?? [],
+        ...(principal.expiresAt !== undefined ? { expiresAt: principal.expiresAt } : {}),
+        extra,
+      };
+  request.verifiedSigner = signer;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/testing/compliance/comply.ts
+++ b/src/lib/testing/compliance/comply.ts
@@ -1542,6 +1542,7 @@ async function complyImpl(agentUrl: string, options: ComplyOptions): Promise<Com
     return {
       agent_url: safeAgentUrl,
       adcp_version: complianceIndex.adcp_version,
+      completeness: stoppedForTimeoutBudget ? 'timed_out' : 'complete',
       agent_profile: profile,
       overall_status: overallStatus,
       tracks: trackResults,
@@ -1815,6 +1816,7 @@ async function runWithDegradedProfile(
   return {
     agent_url: safeAgentUrl,
     adcp_version: adcpVersion,
+    completeness: stoppedForTimeoutBudget ? 'timed_out' : 'complete',
     agent_profile: profile,
     overall_status: overallStatus,
     tracks: trackResults,
@@ -1860,6 +1862,7 @@ async function buildUnreachableResult(
   return {
     agent_url: redactOAuthUrlForOutput(agentUrl),
     adcp_version: adcpVersion,
+    completeness: 'complete',
     agent_profile: profile,
     overall_status: (isAuth ? 'auth_required' : 'unreachable') as OverallStatus,
     tracks: [],
@@ -2079,6 +2082,12 @@ export function formatComplianceResults(result: ComplianceResult): string {
 
   // Summary line
   output += `${result.summary.headline}\n\n`;
+  if (result.completeness === 'timed_out') {
+    const timeoutObservation = result.observations.find(
+      observation => observation.source?.code === 'timeout-budget-exceeded'
+    );
+    output += `⚠️  INCOMPLETE RUN: ${timeoutObservation?.message ?? 'The compliance timeout budget was reached before every selected storyboard ran.'}\n\n`;
+  }
   if (
     result.summary.steps_passed !== undefined ||
     result.summary.steps_failed !== undefined ||

--- a/src/lib/testing/compliance/summary.ts
+++ b/src/lib/testing/compliance/summary.ts
@@ -420,15 +420,16 @@ export function formatComplianceSummaryText(s: ComplianceSummaryArtifact): strin
  */
 export function formatComplianceSummaryMarkdown(s: ComplianceSummaryArtifact): string {
   const lines: string[] = [];
-  const heading = s.completeness === 'timed_out'
-    ? `⏱️ Storyboard run timed out (status: ${s.overall_status})`
-    : !isHardFail(s)
-    ? s.overall_status === 'passing'
-      ? '✅ Storyboard run passed'
-      : `⚠️ Storyboard run ended ${s.overall_status} (wired but partly unexercised)`
-    : s.failures.length === 0
-      ? `❌ Storyboard run: ended ${s.overall_status} with no graded steps`
-      : `❌ Storyboard run: ${s.failures.length} failure(s)`;
+  const heading =
+    s.completeness === 'timed_out'
+      ? `⏱️ Storyboard run timed out (status: ${s.overall_status})`
+      : !isHardFail(s)
+        ? s.overall_status === 'passing'
+          ? '✅ Storyboard run passed'
+          : `⚠️ Storyboard run ended ${s.overall_status} (wired but partly unexercised)`
+        : s.failures.length === 0
+          ? `❌ Storyboard run: ended ${s.overall_status} with no graded steps`
+          : `❌ Storyboard run: ${s.failures.length} failure(s)`;
   lines.push(`## ${heading}`);
   lines.push('');
   lines.push(`- **Agent:** \`${s.agent_url}\``);

--- a/src/lib/testing/compliance/summary.ts
+++ b/src/lib/testing/compliance/summary.ts
@@ -52,6 +52,8 @@ export interface ComplianceSummaryArtifact {
   sdk_version: string;
   adcp_version: string;
   overall_status: OverallStatus;
+  /** Whether the global timeout budget truncated the selected storyboard set. */
+  completeness?: 'complete' | 'timed_out';
   passed: number;
   failed: number;
   /** Failed advisory validations; does not affect the failed-step count. */
@@ -105,6 +107,7 @@ export function buildComplianceSummary(result: ComplianceResult, opts: BuildSumm
     sdk_version: opts.sdkVersion,
     adcp_version: opts.adcpVersion,
     overall_status: result.overall_status,
+    ...(result.completeness !== undefined ? { completeness: result.completeness } : {}),
     passed: result.summary.steps_passed ?? 0,
     failed: result.summary.steps_failed ?? 0,
     ...(result.summary.validations_advisory_failed
@@ -352,6 +355,9 @@ export function formatComplianceSummaryText(s: ComplianceSummaryArtifact): strin
   lines.push(`Agent:     ${s.agent_url}`);
   lines.push(`SDK:       @adcp/sdk ${s.sdk_version} (AdCP ${s.adcp_version})`);
   lines.push(`Status:    ${s.overall_status}`);
+  if (s.completeness === 'timed_out') {
+    lines.push('Incomplete: global timeout budget expired before every selected storyboard could run');
+  }
   lines.push(
     `Steps:     ${s.passed} passed, ${s.failed} failed, ${s.validations_advisory_failed ?? 0} advisory validation(s) failed, ${s.skipped} skipped, ${s.not_selected_count} not selected`
   );
@@ -383,7 +389,9 @@ export function formatComplianceSummaryText(s: ComplianceSummaryArtifact): strin
   lines.push('');
 
   if (!isHardFail(s)) {
-    if (s.overall_status === 'passing') {
+    if (s.completeness === 'timed_out') {
+      lines.push(`STORYBOARD-INCOMPLETE ${s.passed} steps passed before the timeout budget expired`);
+    } else if (s.overall_status === 'passing') {
       lines.push(`STORYBOARD-OK ${s.passed}/${s.passed + s.failed + s.skipped} selected steps passed`);
     } else {
       // `partial` and `silent` — some tracks were wired but not exercised.
@@ -412,7 +420,9 @@ export function formatComplianceSummaryText(s: ComplianceSummaryArtifact): strin
  */
 export function formatComplianceSummaryMarkdown(s: ComplianceSummaryArtifact): string {
   const lines: string[] = [];
-  const heading = !isHardFail(s)
+  const heading = s.completeness === 'timed_out'
+    ? `⏱️ Storyboard run timed out (status: ${s.overall_status})`
+    : !isHardFail(s)
     ? s.overall_status === 'passing'
       ? '✅ Storyboard run passed'
       : `⚠️ Storyboard run ended ${s.overall_status} (wired but partly unexercised)`
@@ -424,6 +434,9 @@ export function formatComplianceSummaryMarkdown(s: ComplianceSummaryArtifact): s
   lines.push(`- **Agent:** \`${s.agent_url}\``);
   lines.push(`- **SDK:** \`@adcp/sdk ${s.sdk_version}\` (AdCP \`${s.adcp_version}\`)`);
   lines.push(`- **Status:** \`${s.overall_status}\``);
+  if (s.completeness === 'timed_out') {
+    lines.push('- **Incomplete:** Global timeout budget expired before every selected storyboard could run.');
+  }
   lines.push(
     `- **Steps:** ${s.passed} passed, ${s.failed} failed, ${s.validations_advisory_failed ?? 0} advisory validation(s) failed, ${s.skipped} skipped, ${s.not_selected_count} not selected`
   );
@@ -500,6 +513,7 @@ export function buildCrashSummary(opts: BuildCrashSummaryOptions): ComplianceSum
     sdk_version: opts.sdkVersion,
     adcp_version: opts.adcpVersion,
     overall_status: 'unreachable',
+    completeness: 'complete',
     passed: 0,
     failed: 1,
     skipped: 0,

--- a/src/lib/testing/compliance/types.ts
+++ b/src/lib/testing/compliance/types.ts
@@ -133,6 +133,13 @@ export interface ComplianceResult {
   agent_url: string;
   /** AdCP compliance cache version used for this assessment. */
   adcp_version?: string;
+  /**
+   * Whether the run was truncated by its global timeout budget. Additive so
+   * older serialized results remain readable; newly produced results always
+   * populate it. `complete` means the runner reached a terminal outcome
+   * without that timeout, including `unreachable` and `auth_required` outcomes.
+   */
+  completeness?: 'complete' | 'timed_out';
   agent_profile: AgentProfile;
   /** Machine-readable overall status */
   overall_status: OverallStatus;

--- a/src/lib/utils/adcp-version-config.ts
+++ b/src/lib/utils/adcp-version-config.ts
@@ -133,11 +133,24 @@ export function isPre31AdcpVersion(version: string | undefined): boolean {
   return Number.isFinite(minor) && minor < 1;
 }
 
-/** Does the seller advertise AdCP 3.1+ support (via get_adcp_capabilities)? */
-export function sellerAdvertises31(caps: { supportedVersions?: string[]; buildVersion?: string } | undefined): boolean {
+/**
+ * Does the seller authoritatively advertise AdCP 3.1+ support?
+ *
+ * `supportedVersions` is the negotiation field; the response envelope's
+ * `adcp_version` is direct evidence of the wire release the seller just
+ * served. `buildVersion` is advisory and MUST NOT select a wire shape.
+ */
+export function sellerAdvertises31(
+  caps: { supportedVersions?: string[]; buildVersion?: string; _raw?: Record<string, unknown> } | undefined
+): boolean {
   if (!caps) return false;
-  if (caps.buildVersion && !isPre31AdcpVersion(caps.buildVersion)) return true;
-  return (caps.supportedVersions ?? []).some(v => !isPre31AdcpVersion(v));
+  const supportedVersions = caps.supportedVersions ?? [];
+  if (supportedVersions.length > 0) {
+    return supportedVersions.some(v => !isPre31AdcpVersion(v));
+  }
+  const responseVersion = typeof caps._raw?.adcp_version === 'string' ? caps._raw.adcp_version : undefined;
+  if (responseVersion !== undefined && !isPre31AdcpVersion(responseVersion)) return true;
+  return false;
 }
 
 /**
@@ -148,7 +161,7 @@ export function sellerAdvertises31(caps: { supportedVersions?: string[]; buildVe
  */
 export function shouldOmit31Fields(
   resolvedClientVersion: string | undefined,
-  caps: { supportedVersions?: string[]; buildVersion?: string } | undefined
+  caps: { supportedVersions?: string[]; buildVersion?: string; _raw?: Record<string, unknown> } | undefined
 ): boolean {
   if (isPre31AdcpVersion(resolvedClientVersion)) return true;
   return !sellerAdvertises31(caps);

--- a/test/auth-signature-compose.test.js
+++ b/test/auth-signature-compose.test.js
@@ -230,6 +230,25 @@ describe('verifySignatureAsAuthenticator', () => {
     assert.strictEqual(req.verifiedSigner, undefined);
   });
 
+  it('fails closed when makePrincipal does not map the verified signer', async () => {
+    const now = 1_776_520_800;
+    const body = '{}';
+    const url = 'https://seller.example.com/mcp';
+    const req = signedReq({ now, url, body, nonce: 'makeprincipal-unmapped-01' });
+    const auth = verifySignatureAsAuthenticator(
+      baseOptions({
+        now: () => now,
+        agentUrlForKeyid: () => 'https://buyer.example.com',
+        makePrincipal: () => null,
+      })
+    );
+    await assert.rejects(
+      () => auth(req),
+      err => err instanceof AuthError && /not mapped/.test(err.message)
+    );
+    assert.strictEqual(req.verifiedSigner, undefined);
+  });
+
   it('uses makePrincipal override when provided', async () => {
     const now = 1_776_520_800;
     const body = '{}';
@@ -238,6 +257,7 @@ describe('verifySignatureAsAuthenticator', () => {
     const auth = verifySignatureAsAuthenticator(
       baseOptions({
         now: () => now,
+        agentUrlForKeyid: () => 'https://buyer.example.com',
         makePrincipal: signer => ({
           principal: `custom:${signer.keyid}`,
           scopes: ['signing'],
@@ -247,6 +267,8 @@ describe('verifySignatureAsAuthenticator', () => {
     const result = await auth(req);
     assert.strictEqual(result.principal, 'custom:test-ed25519-2026');
     assert.deepStrictEqual(result.scopes, ['signing']);
+    assert.strictEqual(result.credential.kind, 'http_sig');
+    assert.strictEqual(result.credential.agent_url, 'https://buyer.example.com');
   });
 });
 

--- a/test/lib/adcp-version-projection.test.js
+++ b/test/lib/adcp-version-projection.test.js
@@ -6,12 +6,17 @@ const {
   omit31BrandFields,
 } = require('../../dist/lib/utils/adcp-version-config.js');
 
-test('sellerAdvertises31: true when buildVersion >= 3.1', () => {
-  assert.equal(sellerAdvertises31({ buildVersion: '3.1.0' }), true);
-  assert.equal(sellerAdvertises31({ buildVersion: '3.2.1' }), true);
+test('sellerAdvertises31: buildVersion is advisory and never used for negotiation', () => {
+  assert.equal(sellerAdvertises31({ buildVersion: '3.1.0' }), false);
+  assert.equal(sellerAdvertises31({ buildVersion: '3.2.1', supportedVersions: ['3.0'] }), false);
 });
 test('sellerAdvertises31: true when supportedVersions contains a >=3.1 release', () => {
   assert.equal(sellerAdvertises31({ supportedVersions: ['3.0', '3.1'] }), true);
+  assert.equal(sellerAdvertises31({ _raw: { adcp_version: '3.2-beta.2' } }), true);
+  assert.equal(
+    sellerAdvertises31({ supportedVersions: ['3.0'], _raw: { adcp_version: '3.2-beta.2' } }),
+    false
+  );
 });
 test('sellerAdvertises31: false for legacy 3.0-only sellers / missing fields', () => {
   assert.equal(sellerAdvertises31(undefined), false);
@@ -23,7 +28,8 @@ test('shouldOmit31Fields: client pinned <3.1 always omits', () => {
 });
 test('shouldOmit31Fields: 3.1 client omits for legacy sellers, sends to 3.1 sellers', () => {
   assert.equal(shouldOmit31Fields('3.1', { supportedVersions: ['3.0'] }), true);
-  assert.equal(shouldOmit31Fields('3.1', { buildVersion: '3.1.0' }), false);
+  assert.equal(shouldOmit31Fields('3.1', { supportedVersions: ['3.1'], buildVersion: '3.0.99' }), false);
+  assert.equal(shouldOmit31Fields('3.1', { buildVersion: '3.1.0' }), true);
   assert.equal(shouldOmit31Fields('3.1', undefined), true);
 });
 test('omit31BrandFields strips brand_kit_override only, preserves AdCP 3.0 fields', () => {

--- a/test/lib/adcp-version-projection.test.js
+++ b/test/lib/adcp-version-projection.test.js
@@ -13,10 +13,7 @@ test('sellerAdvertises31: buildVersion is advisory and never used for negotiatio
 test('sellerAdvertises31: true when supportedVersions contains a >=3.1 release', () => {
   assert.equal(sellerAdvertises31({ supportedVersions: ['3.0', '3.1'] }), true);
   assert.equal(sellerAdvertises31({ _raw: { adcp_version: '3.2-beta.2' } }), true);
-  assert.equal(
-    sellerAdvertises31({ supportedVersions: ['3.0'], _raw: { adcp_version: '3.2-beta.2' } }),
-    false
-  );
+  assert.equal(sellerAdvertises31({ supportedVersions: ['3.0'], _raw: { adcp_version: '3.2-beta.2' } }), false);
 });
 test('sellerAdvertises31: false for legacy 3.0-only sellers / missing fields', () => {
   assert.equal(sellerAdvertises31(undefined), false);

--- a/test/lib/cli-summary-markdown.test.js
+++ b/test/lib/cli-summary-markdown.test.js
@@ -18,6 +18,7 @@ const {
   buildComplianceSummaryMarkdown,
   buildStoryboardSummaryMarkdown,
   escapeMarkdownCell,
+  defaultComplianceTimeoutSeconds,
 } = require('../../bin/adcp-storyboard-summary.js');
 
 // ----------------------------------------------------------------------------
@@ -121,6 +122,32 @@ test('compliance summary: surfaces specialisms when present on the agent profile
   );
 
   assert.match(md, /\*\*Specialisms:\*\* sales-non-guaranteed, creative-template/);
+});
+
+test('compliance summary: timeout truncation is structurally visible', () => {
+  const md = buildComplianceSummaryMarkdown(
+    {
+      overall_status: 'partial',
+      completeness: 'timed_out',
+      summary: { steps_passed: 8, steps_failed: 0, steps_skipped: 1 },
+      observations: [
+        {
+          message: 'Stopped after 8/12 selected storyboard(s).',
+          source: { code: 'timeout-budget-exceeded' },
+        },
+      ],
+    },
+    'https://agent.example.com'
+  );
+  assert.match(md, /\*\*Incomplete:\*\* Stopped after 8\/12 selected storyboard\(s\)\./);
+});
+
+test('default compliance timeout scales with selected storyboards', () => {
+  assert.strictEqual(defaultComplianceTimeoutSeconds(undefined), 120);
+  assert.strictEqual(defaultComplianceTimeoutSeconds(5), 120);
+  assert.strictEqual(defaultComplianceTimeoutSeconds(12), 120);
+  assert.strictEqual(defaultComplianceTimeoutSeconds(13), 130);
+  assert.strictEqual(defaultComplianceTimeoutSeconds(61), 610);
 });
 
 // ----------------------------------------------------------------------------

--- a/test/lib/compliance-summary.test.js
+++ b/test/lib/compliance-summary.test.js
@@ -94,6 +94,24 @@ describe('buildComplianceSummary', () => {
     assert.deepStrictEqual(s.skipped_by_reason, {});
   });
 
+  test('propagates timeout completeness to JSON, text, and Markdown summaries', () => {
+    const result = passingResult();
+    result.overall_status = 'partial';
+    result.completeness = 'timed_out';
+    const s = buildComplianceSummary(result, { sdkVersion: '14.0.0', adcpVersion: '3.2.0-beta.2' });
+    assert.strictEqual(s.completeness, 'timed_out');
+
+    const text = formatComplianceSummaryText(s);
+    assert.ok(text.indexOf('Incomplete:') < text.indexOf('Steps:'));
+    assert.match(text, /STORYBOARD-INCOMPLETE/);
+    assert.doesNotMatch(text, /wired but unexercised/);
+
+    const markdown = formatComplianceSummaryMarkdown(s);
+    assert.match(markdown, /Storyboard run timed out/);
+    assert.ok(markdown.indexOf('**Incomplete:**') < markdown.indexOf('**Steps:**'));
+    assert.doesNotMatch(markdown, /wired but partly unexercised/);
+  });
+
   test('surfaces validation-level not_applicable counts for gating consumers', () => {
     const result = passingResult();
     result.summary.validations_not_applicable = 2;

--- a/test/lib/compliance.test.js
+++ b/test/lib/compliance.test.js
@@ -200,6 +200,33 @@ describe('formatComplianceResults', () => {
     const output = formatComplianceResults(mockResult);
     assert.ok(output.includes('1 passing, 1 failing'), 'Should show headline');
   });
+
+  test('puts a visible incomplete-run warning immediately before step totals', () => {
+    const timedOut = {
+      ...mockResult,
+      completeness: 'timed_out',
+      summary: {
+        ...mockResult.summary,
+        steps_passed: 12,
+        steps_failed: 0,
+        steps_skipped: 2,
+        steps_not_selected: 0,
+      },
+      observations: [
+        {
+          category: 'performance',
+          severity: 'warning',
+          message: 'Stopped starting new storyboards after 3/5 selected storyboard(s).',
+          source: { kind: 'profile', code: 'timeout-budget-exceeded' },
+        },
+      ],
+    };
+    const output = formatComplianceResults(timedOut);
+    assert.match(
+      output,
+      /INCOMPLETE RUN: Stopped starting new storyboards after 3\/5 selected storyboard\(s\)\.\n\nSteps: 12 passed, 0 failed/
+    );
+  });
 });
 
 // ============================================================

--- a/test/lib/comply-abort.test.js
+++ b/test/lib/comply-abort.test.js
@@ -317,6 +317,7 @@ describe('comply() timeout_ms option', () => {
 
       assert.notStrictEqual(result.overall_status, 'unreachable');
       assert.strictEqual(result.overall_status, 'partial');
+      assert.strictEqual(result.completeness, 'timed_out');
       assert.deepStrictEqual(result.storyboards_executed, ['slow_timeout_one']);
       assert.strictEqual(agent.requests.filter(r => r.tool === '__test_probe').length, 1);
       assert.ok(result.tested_tracks.length > 0, 'expected the completed storyboard to produce a tested track');
@@ -350,6 +351,7 @@ describe('comply() timeout_ms option', () => {
       });
 
       assert.strictEqual(result.overall_status, 'partial');
+      assert.strictEqual(result.completeness, 'timed_out');
       assert.deepStrictEqual(result.storyboards_executed, []);
       assert.strictEqual(agent.requests.filter(r => r.tool === '__test_probe').length, 0);
       assert.ok(result.observations.some(o => o.source?.code === 'timeout-budget-exceeded'));
@@ -371,6 +373,7 @@ describe('comply() timeout_ms option', () => {
       });
 
       assert.strictEqual(result.overall_status, 'partial');
+      assert.strictEqual(result.completeness, 'timed_out');
       assert.deepStrictEqual(result.storyboards_executed, []);
       assert.ok(result.tracks.some(t => t.track === 'core' && t.status === 'skip'));
       assert.ok(result.skipped_tracks.some(t => t.track === 'core'));

--- a/test/lib/get-products-webhook-degrade.test.js
+++ b/test/lib/get-products-webhook-degrade.test.js
@@ -28,10 +28,14 @@ function makeClient(adcpVersion) {
     validation: { requests: 'off', responses: 'off' },
   });
   client.ensureEndpointDiscovered = async () => agent;
-  client.detectServerVersion = async () => 'v3';
   // Inject caps so getCapabilities() short-circuits (no live fetch) and the
   // get_products early-feature check treats the seller as v3.
-  client.cachedCapabilities = { version: 'v3', majorVersions: [3], supportedVersions: ['3.0'], _synthetic: false };
+  client.cachedCapabilities = {
+    version: 'v3',
+    majorVersions: [3],
+    supportedVersions: [adcpVersion],
+    _synthetic: false,
+  };
   return client;
 }
 

--- a/test/lib/get-signals-pre31-wholesale.test.js
+++ b/test/lib/get-signals-pre31-wholesale.test.js
@@ -273,8 +273,7 @@ describe('modern client cold-call downgrade to a 3.0 seller', () => {
       const client = makeModernClientTargeting30(protocol, {}, { supportedVersions: undefined });
       await assert.rejects(
         () => client.getSignals({ discovery_mode: 'wholesale' }),
-        err =>
-          err instanceof ProtocolFeatureUnsupportedError && err.details.current_version === '3.0 (not advertised)'
+        err => err instanceof ProtocolFeatureUnsupportedError && err.details.current_version === '3.0 (not advertised)'
       );
     });
 

--- a/test/lib/get-signals-pre31-wholesale.test.js
+++ b/test/lib/get-signals-pre31-wholesale.test.js
@@ -54,6 +54,36 @@ function makePre31Client(config = {}) {
   );
 }
 
+function makeModernClientTargeting30(protocol = 'mcp', config = {}, capabilityOverrides = {}) {
+  const client = new SingleAgentClient(
+    {
+      id: `seller-${protocol}`,
+      name: `Seller ${protocol}`,
+      agent_uri: protocol === 'mcp' ? 'https://seller.example.com/mcp' : 'https://seller.example.com',
+      protocol,
+    },
+    {
+      adcpVersion: '3.2.0-beta.2',
+      validateFeatures: false,
+      validation: { requests: 'off', responses: 'off' },
+      ...config,
+    }
+  );
+  const capabilities = {
+    version: 'v3',
+    majorVersions: [3],
+    supportedVersions: [ADCP_30_PIN],
+    protocols: ['signals', 'media_buy'],
+    features: {},
+    extensions: [],
+    _synthetic: false,
+    ...capabilityOverrides,
+  };
+  client.getCapabilities = async () => capabilities;
+  client.ensureEndpointDiscovered = async () => client.agent;
+  return client;
+}
+
 function assertPre31Unsupported(err, expected) {
   assert.ok(err instanceof FeatureUnsupportedError, `expected FeatureUnsupportedError, got ${err?.constructor?.name}`);
   assert.ok(
@@ -220,4 +250,136 @@ describe('get_signals wholesale against pre-3.1 client pin', () => {
       }
     );
   });
+});
+
+describe('modern client cold-call downgrade to a 3.0 seller', () => {
+  for (const protocol of ['mcp', 'a2a']) {
+    test(`${protocol.toUpperCase()} wholesale getSignals fails with a typed recovery path`, async () => {
+      const client = makeModernClientTargeting30(protocol);
+      await assert.rejects(
+        () => client.getSignals({ discovery_mode: 'wholesale' }),
+        err => {
+          assert.ok(err instanceof ProtocolFeatureUnsupportedError);
+          assert.match(err.message, /target seller does not advertise AdCP 3\.1 support/);
+          assert.strictEqual(err.details.current_version, ADCP_30_PIN);
+          assert.strictEqual(err.details.field, 'discovery_mode');
+          assert.match(err.adcpError.suggestion, /meaningful signal_spec/);
+          return true;
+        }
+      );
+    });
+
+    test(`${protocol.toUpperCase()} rejects wholesale when a legacy seller omits release metadata`, async () => {
+      const client = makeModernClientTargeting30(protocol, {}, { supportedVersions: undefined });
+      await assert.rejects(
+        () => client.getSignals({ discovery_mode: 'wholesale' }),
+        err =>
+          err instanceof ProtocolFeatureUnsupportedError && err.details.current_version === '3.0 (not advertised)'
+      );
+    });
+
+    test(`${protocol.toUpperCase()} ignores advisory buildVersion when supportedVersions is 3.0`, async () => {
+      const client = makeModernClientTargeting30(
+        protocol,
+        {},
+        {
+          buildVersion: '3.2.0',
+          supportedVersions: ['3.0'],
+          _raw: { adcp_version: '3.2-beta.2' },
+        }
+      );
+      await assert.rejects(
+        () => client.getSignals({ discovery_mode: 'wholesale' }),
+        err => err instanceof ProtocolFeatureUnsupportedError && err.details.current_version === '3.0'
+      );
+    });
+
+    test(`${protocol.toUpperCase()} accepts wholesale when the response envelope proves a 3.1+ wire release`, async () => {
+      const client = makeModernClientTargeting30(
+        protocol,
+        {},
+        { supportedVersions: undefined, _raw: { adcp_version: '3.2-beta.2' } }
+      );
+      const originalCallTool = ProtocolClient.callTool;
+      const calls = [];
+      ProtocolClient.callTool = async (_agent, taskName, params) => {
+        calls.push({ taskName, params });
+        return { status: 'completed', signals: [] };
+      };
+      try {
+        await client.getSignals({ discovery_mode: 'wholesale' });
+        assert.strictEqual(calls.length, 1);
+        assert.strictEqual(calls[0].params.discovery_mode, 'wholesale');
+      } finally {
+        ProtocolClient.callTool = originalCallTool;
+      }
+    });
+
+    test(`${protocol.toUpperCase()} strips explicit discovery webhook config for a 3.0 seller`, async () => {
+      const client = makeModernClientTargeting30(protocol);
+      const calls = [];
+      const originalCallTool = ProtocolClient.callTool;
+      ProtocolClient.callTool = async (_agent, taskName, params, options) => {
+        calls.push({ taskName, params, options });
+        return { status: 'completed', products: [] };
+      };
+      try {
+        const result = await client.getProducts({
+          buying_mode: 'brief',
+          brief: 'sports fans',
+          push_notification_config: { url: 'https://buyer.example.com/adcp-webhook' },
+        });
+        assert.strictEqual(calls.length, 1);
+        assert.strictEqual(calls[0].params.push_notification_config, undefined);
+        assert.ok(result.debug_logs.some(log => log.type === 'pre31_discovery_webhook_stripped'));
+      } finally {
+        ProtocolClient.callTool = originalCallTool;
+      }
+    });
+
+    test(`${protocol.toUpperCase()} strips explicit get_signals webhook config for a 3.0 seller`, async () => {
+      const client = makeModernClientTargeting30(protocol);
+      const calls = [];
+      const originalCallTool = ProtocolClient.callTool;
+      ProtocolClient.callTool = async (_agent, taskName, params, options) => {
+        calls.push({ taskName, params, options });
+        return { status: 'completed', signals: [] };
+      };
+      try {
+        const result = await client.getSignals({
+          signal_spec: 'sports fans',
+          push_notification_config: { url: 'https://buyer.example.com/adcp-webhook' },
+        });
+        assert.strictEqual(calls.length, 1);
+        assert.strictEqual(calls[0].params.push_notification_config, undefined);
+        assert.ok(result.debug_logs.some(log => log.type === 'pre31_discovery_webhook_stripped'));
+      } finally {
+        ProtocolClient.callTool = originalCallTool;
+      }
+    });
+
+    test(`${protocol.toUpperCase()} suppresses auto-injected discovery webhooks on the first 3.0 call`, async () => {
+      const client = makeModernClientTargeting30(protocol, {
+        webhookUrlTemplate: 'https://buyer.example.com/adcp-webhook/{task_type}/{agent_id}/{operation_id}',
+      });
+      const calls = [];
+      const originalCallTool = ProtocolClient.callTool;
+      ProtocolClient.callTool = async (_agent, taskName, params, options) => {
+        calls.push({ taskName, params, options });
+        return { status: 'completed', signals: [] };
+      };
+      try {
+        const result = await client.getSignals({ signal_spec: 'sports fans' });
+        assert.strictEqual(calls.length, 1);
+        assert.strictEqual(calls[0].params.push_notification_config, undefined);
+        assert.strictEqual(calls[0].options.webhookUrl, undefined);
+        const drift = result.debug_logs.find(log => log.type === 'pre31_webhook_degraded');
+        assert.ok(drift);
+        assert.match(drift.message, /target seller advertises only 3\.0\.12/);
+        assert.doesNotMatch(drift.message, /client is pinned to 3\.2/);
+      } finally {
+        ProtocolClient.callTool = originalCallTool;
+      }
+    });
+  }
 });

--- a/test/lib/per-seller-brand-projection.test.js
+++ b/test/lib/per-seller-brand-projection.test.js
@@ -25,7 +25,7 @@ const brand = {
 };
 
 const caps30 = { version: 'v3', majorVersions: [3], supportedVersions: ['3.0'], _synthetic: false };
-const caps31 = { version: 'v3', majorVersions: [3], buildVersion: '3.1.0', _synthetic: false };
+const caps31 = { version: 'v3', majorVersions: [3], supportedVersions: ['3.1'], _synthetic: false };
 
 test('resolveAdapterKey: returns 3.0 for pre-3.1 client', () => {
   assert.equal(resolveAdapterKey('3.0', caps31), '3.0');
@@ -99,7 +99,6 @@ test('sync_accounts: no strip when no account has brand_kit_override', () => {
 
 test('adapters return undefined for unregistered tools at 3.0', () => {
   assert.equal(getVersionAdapter('3.0', 'list_creative_formats'), undefined);
-  assert.equal(getVersionAdapter('3.0', 'get_signals'), undefined);
 });
 
 // pricing_currencies is an AdCP 3.1-only filter. 3.0 sellers return
@@ -131,11 +130,12 @@ test('get_products: no strip when filters absent entirely', () => {
   assert.equal(drift, undefined);
 });
 
-test('get_products: strips both brand_kit_override and pricing_currencies, emits first drift', () => {
+test('get_products: aggregates every stripped field into one observable drift', () => {
   const adapter = getVersionAdapter('3.0', 'get_products');
   const { params, drift } = adapter.adaptRequest({
     brand: { ...brand },
     filters: { pricing_currencies: ['USD'] },
+    push_notification_config: { url: 'https://buyer.example/webhook' },
     brief: 'Premium placements',
   });
   assert.deepEqual(params.brand, {
@@ -145,5 +145,17 @@ test('get_products: strips both brand_kit_override and pricing_currencies, emits
     data_subject_contestation: { email: 'p@goldpeaktea.com' },
   });
   assert.deepEqual(params.filters, {});
-  assert.ok(drift);
+  assert.equal(params.push_notification_config, undefined);
+  assert.equal(drift?.type, 'pre31_brand_fields_stripped');
+  assert.deepEqual(drift?.constituentTypes, [
+    'pre31_brand_fields_stripped',
+    'pre31_pricing_currencies_stripped',
+    'pre31_discovery_webhook_stripped',
+  ]);
+  assert.deepEqual(drift?.strippedFields, [
+    'brand_kit_override',
+    'filters.pricing_currencies',
+    'push_notification_config',
+  ]);
+  assert.match(drift?.message, /Poll for the result instead/);
 });

--- a/test/lib/proposal-negotiation.test.js
+++ b/test/lib/proposal-negotiation.test.js
@@ -56,7 +56,7 @@ function revise(overrides = {}) {
 }
 
 function request(refinements = [revise()]) {
-  return { adcp_version: '3.2', adcp_major_version: 3, idempotency_key: KEY, refinements };
+  return { adcp_version: '3.2-beta.2', adcp_major_version: 3, idempotency_key: KEY, refinements };
 }
 
 function completed(data) {
@@ -352,6 +352,38 @@ test('AgentClient.refineProposals dispatches through the official MCP client wit
 
   await mcpClient.close();
   await server.close();
+});
+
+test('ADCPMultiAgentClient.simple forwards an exact prerelease wire pin to proposal requests', async () => {
+  const { ADCPMultiAgentClient } = require('../../dist/lib/index.js');
+  const client = ADCPMultiAgentClient.simple('https://seller.example.com/mcp', {
+    adcpVersion: '3.2.0-beta.2',
+    wireAdcpVersion: '3.2.0-beta.1',
+  });
+  const agent = client.agent('default-agent');
+  let captured;
+  agent.client.executeTask = async (_taskName, request) => {
+    captured = request;
+    return {
+      success: false,
+      status: 'failed',
+      error: 'test transport stopped after request capture',
+      metadata: {
+        taskId: 'capture-1',
+        taskName: 'refine_proposals',
+        agent: { id: 'default-agent', name: 'Default Agent', protocol: 'mcp' },
+        responseTimeMs: 0,
+        timestamp: new Date().toISOString(),
+        clarificationRounds: 0,
+        status: 'failed',
+      },
+    };
+  };
+
+  await agent.refineProposals({ refinements: [revise()] });
+  assert.equal(client.getAdcpVersion(), '3.2.0-beta.2');
+  assert.equal(captured.adcp_version, '3.2-beta.1');
+  assert.equal(captured.adcp_major_version, 3);
 });
 
 test('seller handler commits a complete finalize batch atomically', async () => {

--- a/test/server-auto-signed-requests.test.js
+++ b/test/server-auto-signed-requests.test.js
@@ -9,6 +9,7 @@ const {
   InMemoryStateStore,
   ADCP_PRE_TRANSPORT,
   ADCP_SIGNED_REQUESTS_STATE,
+  BuyerAgentRegistry,
 } = require('../dist/lib/server/legacy/v5/index.js');
 const { StaticJwksResolver, InMemoryReplayStore, InMemoryRevocationStore } = require('../dist/lib/signing/server.js');
 const { signRequest } = require('../dist/lib/signing/signer.js');
@@ -138,7 +139,7 @@ function mcpGetProductsBody() {
     method: 'tools/call',
     params: {
       name: 'get_products',
-      arguments: { brief: 'test' },
+      arguments: { buying_mode: 'brief', brief: 'test' },
     },
   });
 }
@@ -935,6 +936,123 @@ describe('createAdcpServer: signedRequests auto-wiring', () => {
         'agentUrlForKeyid return value MUST surface on VerifyResult.agent_url'
       );
       assert.deepStrictEqual(resolverCalls, ['test-ed25519-2026']);
+    });
+
+    it('bridges the verified signer into handler auth and BuyerAgentRegistry resolution', async () => {
+      const buyerAgent = {
+        agent_url: 'https://buyer.example.com',
+        display_name: 'Buyer',
+        status: 'active',
+        billing_capabilities: new Set(['operator']),
+      };
+      let registryUrl;
+      let capturedContext;
+      const config = sellerConfig({ withSignedRequests: true, withSpecialism: true });
+      config.signedRequests.agentUrlForKeyid = () => buyerAgent.agent_url;
+      config.agentRegistry = BuyerAgentRegistry.signingOnly({
+        resolveByAgentUrl: async agentUrl => {
+          registryUrl = agentUrl;
+          return buyerAgent;
+        },
+      });
+      config.mediaBuy.getProducts = async (_params, ctx) => {
+        capturedContext = ctx;
+        return { products: [] };
+      };
+
+      const started = await startServer(() => createAdcpServer(config));
+      try {
+        const body = mcpGetProductsBody();
+        const res = await postSigned({ url: started.url, body, sign: true, nonce: 'auto-identity-bridge-01' });
+        assert.strictEqual(res.status, 200);
+        assert.strictEqual(registryUrl, buyerAgent.agent_url);
+        assert.strictEqual(capturedContext.authInfo.credential.kind, 'http_sig');
+        assert.strictEqual(capturedContext.authInfo.credential.keyid, 'test-ed25519-2026');
+        assert.strictEqual(capturedContext.authInfo.credential.agent_url, buyerAgent.agent_url);
+        assert.strictEqual(capturedContext.agent.agent_url, buyerAgent.agent_url);
+      } finally {
+        await new Promise(resolve => started.server.close(resolve));
+      }
+    });
+
+    it('combines matching authenticate-hook and signer identities', async () => {
+      let capturedContext;
+      const config = sellerConfig({ withSignedRequests: true, withSpecialism: true });
+      config.signedRequests.agentUrlForKeyid = () => 'https://buyer.example.com';
+      config.signedRequests.makePrincipal = () => ({ principal: 'internal-user-42' });
+      config.mediaBuy.getProducts = async (_params, ctx) => {
+        capturedContext = ctx;
+        return { products: [] };
+      };
+
+      const started = await startServer(() => createAdcpServer(config), {
+        authenticate: async () => ({
+          principal: 'internal-user-42',
+          token: 'request-local-token',
+          credential: { kind: 'api_key', key_id: 'api-key-42' },
+        }),
+      });
+      try {
+        const body = mcpGetProductsBody();
+        const res = await postSigned({ url: started.url, body, sign: true, nonce: 'auto-identity-merge-01' });
+        assert.strictEqual(res.status, 200);
+        assert.strictEqual(capturedContext.authInfo.clientId, 'internal-user-42');
+        assert.strictEqual(capturedContext.authInfo.token, 'request-local-token');
+        assert.strictEqual(capturedContext.authInfo.credential.kind, 'http_sig');
+      } finally {
+        await new Promise(resolve => started.server.close(resolve));
+      }
+    });
+
+    it('rejects mismatched authenticate-hook and signer identities before handler dispatch', async () => {
+      let handlerCalled = false;
+      const config = sellerConfig({ withSignedRequests: true, withSpecialism: true });
+      config.signedRequests.agentUrlForKeyid = () => 'https://buyer.example.com';
+      config.mediaBuy.getProducts = async () => {
+        handlerCalled = true;
+        return { products: [] };
+      };
+
+      const started = await startServer(() => createAdcpServer(config), {
+        authenticate: async () => ({
+          principal: 'internal-user-42',
+          token: 'request-local-token',
+          credential: { kind: 'api_key', key_id: 'api-key-42' },
+        }),
+      });
+      try {
+        const body = mcpGetProductsBody();
+        const res = await postSigned({ url: started.url, body, sign: true, nonce: 'auto-identity-mismatch-01' });
+        assert.strictEqual(res.status, 401);
+        assert.match(res.headers.get('www-authenticate'), /error="request_signature_invalid"/);
+        assert.strictEqual((await res.json()).error, 'request_signature_invalid');
+        assert.strictEqual(handlerCalled, false);
+      } finally {
+        await new Promise(resolve => started.server.close(resolve));
+      }
+    });
+
+    it('fails closed when signedRequests.makePrincipal does not map the signer', async () => {
+      let handlerCalled = false;
+      const config = sellerConfig({ withSignedRequests: true, withSpecialism: true });
+      config.signedRequests.agentUrlForKeyid = () => 'https://buyer.example.com';
+      config.signedRequests.makePrincipal = () => null;
+      config.mediaBuy.getProducts = async () => {
+        handlerCalled = true;
+        return { products: [] };
+      };
+
+      const started = await startServer(() => createAdcpServer(config));
+      try {
+        const body = mcpGetProductsBody();
+        const res = await postSigned({ url: started.url, body, sign: true, nonce: 'auto-identity-unmapped-01' });
+        assert.strictEqual(res.status, 401);
+        assert.match(res.headers.get('www-authenticate'), /error="request_signature_invalid"/);
+        assert.strictEqual((await res.json()).error, 'request_signature_invalid');
+        assert.strictEqual(handlerCalled, false);
+      } finally {
+        await new Promise(resolve => started.server.close(resolve));
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

- make compliance timeout truncation explicit in JSON, terminal, Markdown, and CLI output while scaling the default budget with selected storyboard count
- preserve exact prerelease pins through `ADCPMultiAgentClient.simple()` and lock proposal negotiation to the configured wire release
- bridge auto-wired RFC 9421 signer identity into handler auth and `BuyerAgentRegistry`, with fail-closed principal matching
- adapt 3.1 discovery requests safely for declared 3.0 sellers across MCP and A2A without using advisory `build_version` for negotiation
- add regression coverage for existing adagents discovery parity behavior

## Compatibility

The seller-aware adapter keeps `supported_versions` authoritative, uses response `adcp_version` only when that list is absent, and preserves existing machine-readable drift types. Explicit 3.0 pins remain supported; 3.1+ response evidence avoids false downgrades.

## Validation

- expert protocol, security, code-quality, and adopter-DX reviews converged
- `npm run review:codex -- --all --base main`
- `npm run build:lib`
- `npm run lint` (0 errors; existing warnings)
- `npm run test:node:fast` (15,490 passed, 7 skipped, 0 failed)
- focused compatibility, signing, summary, and conformance tests (85 passed, 0 failed)

## Follow-up

Issues #2401 and #2432 require source changes in `adcontextprotocol/adcp`; upstream issues will call out 3.0/3.1 compliance-pack backports explicitly.

Closes #2262
Closes #2301
Closes #2363
Closes #2609
Closes #2616
