### PR TITLE
fix(net): block non-routable IPv6 SSRF targets

### DIFF
--- a/.changeset/calm-yaks-block-ipv6.md
+++ b/.changeset/calm-yaks-block-ipv6.md
@@ -2,4 +2,4 @@
 '@adcp/sdk': patch
 ---
 
-Harden SSRF address classification by refusing additional non-routable and special-purpose IPv6 ranges. Globally reachable IETF protocol assignments remain allowed, while unsafe translation and tunnel prefixes that cannot exclude metadata targets remain blocked even with private-network opt-in.
+Harden SSRF address classification by refusing additional non-routable and special-purpose IPv6 ranges. Globally reachable IETF protocol assignments remain allowed, while IPv6 metadata endpoints and unsafe translation or tunnel prefixes that cannot exclude metadata targets remain blocked even with private-network opt-in.

--- a/.changeset/calm-yaks-block-ipv6.md
+++ b/.changeset/calm-yaks-block-ipv6.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Harden SSRF address classification by refusing additional non-routable and special-purpose IPv6 ranges, including deprecated transition formats, local translation prefixes, benchmarking, documentation, and segment-routing address space.

--- a/.changeset/calm-yaks-block-ipv6.md
+++ b/.changeset/calm-yaks-block-ipv6.md
@@ -2,4 +2,4 @@
 '@adcp/sdk': patch
 ---
 
-Harden SSRF address classification by refusing additional non-routable and special-purpose IPv6 ranges, including deprecated transition formats, local translation prefixes, benchmarking, documentation, and segment-routing address space.
+Harden SSRF address classification by refusing additional non-routable and special-purpose IPv6 ranges. Globally reachable IETF protocol assignments remain allowed, while unsafe translation and tunnel prefixes that cannot exclude metadata targets remain blocked even with private-network opt-in.

--- a/src/lib/net/address-guards.ts
+++ b/src/lib/net/address-guards.ts
@@ -5,11 +5,11 @@
  *   - {@link isAlwaysBlocked}: link-local + cloud metadata endpoints (IMDS).
  *     Refused even when the caller opts into private networks (dev loops).
  *   - {@link isPrivateIp}: RFC 1918, loopback, CGNAT, IPv6 ULA/link-local,
- *     multicast, broadcast, unspecified, plus defense-in-depth on IPv6
- *     wrappers (NAT64 well-known prefix, 6to4) so a v4-in-v6 address can't
- *     sneak a private target past the classifier. Refused by default; allowed
- *     when the caller passes `allowPrivateIp: true` (storyboard runner's
- *     `--allow-http`).
+ *     multicast, broadcast, unspecified, non-routable special-purpose ranges,
+ *     plus defense-in-depth on IPv6 wrappers (NAT64, IPv4-translated, 6to4)
+ *     so a v4-in-v6 address can't sneak a private target past the classifier.
+ *     Refused by default; allowed when the caller passes `allowPrivateIp: true`
+ *     (storyboard runner's `--allow-http`).
  *
  * Classifiers normalize before matching:
  *   - Zone IDs (`%eth0`) are stripped — they're a host-local concept, not part
@@ -72,15 +72,24 @@ privateIp.addAddress('255.255.255.255', 'ipv4'); // limited broadcast
 // v6
 privateIp.addAddress('::', 'ipv6'); // unspecified
 privateIp.addAddress('::1', 'ipv6'); // loopback
+privateIp.addSubnet('::', 96, 'ipv6'); // deprecated IPv4-compatible addresses (RFC 4291)
 privateIp.addSubnet('fe80::', 10, 'ipv6'); // link-local
+privateIp.addSubnet('fec0::', 10, 'ipv6'); // deprecated site-local addresses (RFC 3879)
 privateIp.addSubnet('fc00::', 7, 'ipv6'); // ULA
 privateIp.addSubnet('ff00::', 8, 'ipv6'); // multicast
 privateIp.addSubnet('100::', 64, 'ipv6'); // discard-only (RFC 6666)
+privateIp.addSubnet('100:0:0:1::', 64, 'ipv6'); // dummy prefix (RFC 9780)
+privateIp.addSubnet('2001:2::', 48, 'ipv6'); // benchmarking (RFC 5180)
+privateIp.addSubnet('2001:10::', 28, 'ipv6'); // deprecated ORCHID (RFC 4843)
 privateIp.addSubnet('2001:db8::', 32, 'ipv6'); // documentation
-// Wrapper prefixes — refuse unconditionally. Tunnels at the caller's edge can
-// translate these into private targets we can't see; safer to refuse than to
-// hope the gateway is configured the way we expect.
+privateIp.addSubnet('3fff::', 20, 'ipv6'); // documentation (RFC 9637)
+privateIp.addSubnet('5f00::', 16, 'ipv6'); // segment-routing SIDs, not globally reachable (RFC 9602)
+// Wrapper prefixes — refuse the entire prefix by default. Tunnels at the
+// caller's edge can translate these into private targets we can't see; safer
+// to refuse than to hope the gateway is configured the way we expect.
+privateIp.addSubnet('::ffff:0:0:0', 96, 'ipv6'); // deprecated IPv4-translated (RFC 2765)
 privateIp.addSubnet('64:ff9b::', 96, 'ipv6'); // NAT64 well-known
+privateIp.addSubnet('64:ff9b:1::', 48, 'ipv6'); // local-use IPv4/IPv6 translation (RFC 8215)
 privateIp.addSubnet('2002::', 16, 'ipv6'); // 6to4
 
 /**
@@ -100,9 +109,10 @@ export function isAlwaysBlocked(address: string): boolean {
 
 /**
  * Reject loopback, link-local, RFC 1918 private ranges, CGNAT (RFC 6598),
- * broadcast, multicast, the unspecified address, NAT64/6to4 wrapper prefixes,
- * and IPv6 equivalents. BlockList handles IPv4-mapped IPv6 canonicalization
- * natively so `::ffff:10.0.0.1` is matched against the v4 rule set.
+ * broadcast, multicast, the unspecified address, non-routable special-purpose
+ * ranges, NAT64/6to4 wrapper prefixes, and IPv6 equivalents. BlockList handles
+ * IPv4-mapped IPv6 canonicalization natively so `::ffff:10.0.0.1` is matched
+ * against the v4 rule set.
  *
  * Returns `false` for non-IP inputs (hostnames).
  */

--- a/src/lib/net/address-guards.ts
+++ b/src/lib/net/address-guards.ts
@@ -48,6 +48,9 @@ alwaysBlocked.addSubnet('fe80::', 10, 'ipv6');
 // IETF-protocol assignments) rather than the 169.254.0.0/16 everyone else
 // uses, so it needs its own entry to be refused even under the private opt-in.
 alwaysBlocked.addAddress('192.0.0.192', 'ipv4');
+// AWS exposes IMDS over this ULA address on Nitro instances. It is a direct
+// credential endpoint, so private-network opt-in must never make it reachable.
+alwaysBlocked.addAddress('fd00:ec2::254', 'ipv6');
 // Deterministic IPv4-in-IPv6 wrappers: block only encodings of the IPv4
 // always-blocked ranges so `allowPrivateIp` can still reach explicitly trusted
 // public translation targets. `a9fe` is 169.254 and `c000:c0` is 192.0.0.192.
@@ -85,6 +88,10 @@ globallyReachableIetfAssignments.addSubnet('2001:30::', 28, 'ipv6'); // DETs
 // wrapped-v4 address can't bypass the classifier by choosing a representation
 // BlockList doesn't natively canonicalize.
 const privateIp = new BlockList();
+const nativeIpv4Loopback = new BlockList();
+nativeIpv4Loopback.addSubnet('127.0.0.0', 8, 'ipv4');
+const nativeIpv6Loopback = new BlockList();
+nativeIpv6Loopback.addAddress('::1', 'ipv6');
 // v4 — BlockList handles IPv4-mapped IPv6 (`::ffff:a.b.c.d`) against these
 // subnets automatically per Node's check semantics.
 privateIp.addSubnet('0.0.0.0', 8, 'ipv4');
@@ -169,6 +176,16 @@ export function isPrivateIp(address: string): boolean {
   const n = normalize(address);
   if (!n) return false;
   return isAlwaysBlockedNormalized(n) || isNonGlobalIetfAssignment(n) || privateIp.check(n.addr, n.family);
+}
+
+/** Return true only for native IPv4/IPv6 loopback, not wrapped forms. */
+export function isLoopbackIp(address: string): boolean {
+  const n = normalize(address);
+  if (!n) return false;
+  // Keep the families in separate lists. A mixed BlockList canonicalizes an
+  // IPv4-mapped IPv6 value against its IPv4 entries, but the loopback policy
+  // intentionally permits only native representations.
+  return n.family === 'ipv4' ? nativeIpv4Loopback.check(n.addr, 'ipv4') : nativeIpv6Loopback.check(n.addr, 'ipv6');
 }
 
 /**

--- a/src/lib/net/address-guards.ts
+++ b/src/lib/net/address-guards.ts
@@ -2,7 +2,8 @@
  * IP address classification for SSRF defense.
  *
  * Two tiers of blocking:
- *   - {@link isAlwaysBlocked}: link-local + cloud metadata endpoints (IMDS).
+ *   - {@link isAlwaysBlocked}: link-local, cloud metadata endpoints (IMDS),
+ *     and opaque translation/tunnel prefixes that cannot safely exclude IMDS.
  *     Refused even when the caller opts into private networks (dev loops).
  *   - {@link isPrivateIp}: RFC 1918, loopback, CGNAT, IPv6 ULA/link-local,
  *     multicast, broadcast, unspecified, non-routable special-purpose ranges,
@@ -22,7 +23,9 @@
  */
 import { BlockList, isIP } from 'net';
 
-function normalize(address: string): { addr: string; family: 'ipv4' | 'ipv6' } | null {
+type NormalizedAddress = { addr: string; family: 'ipv4' | 'ipv6' };
+
+function normalize(address: string): NormalizedAddress | null {
   // Strip surrounding brackets (URL-hostname form) and zone ID.
   let bare = address;
   if (bare.startsWith('[') && bare.endsWith(']')) bare = bare.slice(1, -1);
@@ -45,6 +48,37 @@ alwaysBlocked.addSubnet('fe80::', 10, 'ipv6');
 // IETF-protocol assignments) rather than the 169.254.0.0/16 everyone else
 // uses, so it needs its own entry to be refused even under the private opt-in.
 alwaysBlocked.addAddress('192.0.0.192', 'ipv4');
+// Deterministic IPv4-in-IPv6 wrappers: block only encodings of the IPv4
+// always-blocked ranges so `allowPrivateIp` can still reach explicitly trusted
+// public translation targets. `a9fe` is 169.254 and `c000:c0` is 192.0.0.192.
+alwaysBlocked.addSubnet('::a9fe:0', 112, 'ipv6'); // IPv4-compatible IMDS/link-local
+alwaysBlocked.addAddress('::c000:c0', 'ipv6'); // IPv4-compatible Oracle IMDS
+alwaysBlocked.addSubnet('::ffff:0:a9fe:0', 112, 'ipv6'); // IPv4-translated IMDS/link-local
+alwaysBlocked.addAddress('::ffff:0:c000:c0', 'ipv6'); // IPv4-translated Oracle IMDS
+alwaysBlocked.addSubnet('64:ff9b::a9fe:0', 112, 'ipv6'); // NAT64 WKP IMDS/link-local
+alwaysBlocked.addAddress('64:ff9b::c000:c0', 'ipv6'); // NAT64 WKP Oracle IMDS
+alwaysBlocked.addSubnet('2002:a9fe::', 32, 'ipv6'); // 6to4 IMDS/link-local
+alwaysBlocked.addSubnet('2002:c000:c0::', 48, 'ipv6'); // 6to4 Oracle IMDS
+// RFC 8215 deliberately defines no fixed embedded-IPv4 layout, so the local
+// translation prefix cannot be inspected safely for an IMDS destination.
+alwaysBlocked.addSubnet('64:ff9b:1::', 48, 'ipv6');
+// Teredo also carries obfuscated endpoint information whose ultimate reach is
+// relay-dependent. Refuse it even under the private-network opt-in.
+alwaysBlocked.addSubnet('2001::', 32, 'ipv6');
+
+// IANA marks 2001::/23 non-global unless a more-specific allocation says
+// otherwise. Keep the parent fail-closed and enumerate every currently
+// globally reachable child so new gaps do not silently become SSRF targets.
+const ietfProtocolAssignments = new BlockList();
+ietfProtocolAssignments.addSubnet('2001::', 23, 'ipv6');
+const globallyReachableIetfAssignments = new BlockList();
+globallyReachableIetfAssignments.addAddress('2001:1::1', 'ipv6'); // PCP anycast
+globallyReachableIetfAssignments.addAddress('2001:1::2', 'ipv6'); // TURN anycast
+globallyReachableIetfAssignments.addAddress('2001:1::3', 'ipv6'); // DNS-SD anycast
+globallyReachableIetfAssignments.addSubnet('2001:3::', 32, 'ipv6'); // AMT
+globallyReachableIetfAssignments.addSubnet('2001:4:112::', 48, 'ipv6'); // AS112-v6
+globallyReachableIetfAssignments.addSubnet('2001:20::', 28, 'ipv6'); // ORCHIDv2
+globallyReachableIetfAssignments.addSubnet('2001:30::', 28, 'ipv6'); // DETs
 
 // Private, loopback, multicast, and reserved ranges. Defense-in-depth adds the
 // NAT64 well-known prefix (`64:ff9b::/96`) and 6to4 (`2002::/16`) so a
@@ -79,11 +113,12 @@ privateIp.addSubnet('fc00::', 7, 'ipv6'); // ULA
 privateIp.addSubnet('ff00::', 8, 'ipv6'); // multicast
 privateIp.addSubnet('100::', 64, 'ipv6'); // discard-only (RFC 6666)
 privateIp.addSubnet('100:0:0:1::', 64, 'ipv6'); // dummy prefix (RFC 9780)
-privateIp.addSubnet('2001:2::', 48, 'ipv6'); // benchmarking (RFC 5180)
-privateIp.addSubnet('2001:10::', 28, 'ipv6'); // deprecated ORCHID (RFC 4843)
 privateIp.addSubnet('2001:db8::', 32, 'ipv6'); // documentation
+privateIp.addSubnet('3ffe::', 16, 'ipv6'); // returned 6bone space (RFC 5156)
 privateIp.addSubnet('3fff::', 20, 'ipv6'); // documentation (RFC 9637)
-privateIp.addSubnet('5f00::', 16, 'ipv6'); // segment-routing SIDs, not globally reachable (RFC 9602)
+// The former 6bone /8 remains unallocated except for 5f00::/16, which was
+// reassigned to non-global SRv6 SIDs. Neither portion is publicly reachable.
+privateIp.addSubnet('5f00::', 8, 'ipv6'); // RFC 5156 and RFC 9602
 // Wrapper prefixes — refuse the entire prefix by default. Tunnels at the
 // caller's edge can translate these into private targets we can't see; safer
 // to refuse than to hope the gateway is configured the way we expect.
@@ -97,14 +132,28 @@ privateIp.addSubnet('2002::', 16, 'ipv6'); // 6to4
  * (AWS/GCP/Azure IMDS) live at 169.254.169.254 and would exfiltrate
  * credentials if a CI runner or long-lived server followed an attacker URL to
  * them. IPv6 link-local (`fe80::/10`) is the v6 equivalent reach into the
- * host's local segment.
+ * host's local segment. Deterministic IPv4 wrappers block their encoded IMDS
+ * ranges; opaque local-translation and Teredo prefixes fail closed because
+ * their ultimate destination cannot be classified safely here.
  *
  * Returns `false` for non-IP inputs (hostnames).
  */
 export function isAlwaysBlocked(address: string): boolean {
   const n = normalize(address);
   if (!n) return false;
+  return isAlwaysBlockedNormalized(n);
+}
+
+function isAlwaysBlockedNormalized(n: NormalizedAddress): boolean {
   return alwaysBlocked.check(n.addr, n.family);
+}
+
+function isNonGlobalIetfAssignment(n: NormalizedAddress): boolean {
+  return (
+    n.family === 'ipv6' &&
+    ietfProtocolAssignments.check(n.addr, 'ipv6') &&
+    !globallyReachableIetfAssignments.check(n.addr, 'ipv6')
+  );
 }
 
 /**
@@ -119,7 +168,7 @@ export function isAlwaysBlocked(address: string): boolean {
 export function isPrivateIp(address: string): boolean {
   const n = normalize(address);
   if (!n) return false;
-  return privateIp.check(n.addr, n.family);
+  return isAlwaysBlockedNormalized(n) || isNonGlobalIetfAssignment(n) || privateIp.check(n.addr, n.family);
 }
 
 /**

--- a/src/lib/net/agent-transport-fetch.ts
+++ b/src/lib/net/agent-transport-fetch.ts
@@ -39,12 +39,13 @@ export function createAgentTransportFetch(agentUrl: string, options: AgentTransp
     process.env.ADCP_ALLOW_PRIVATE_AGENT_URL === '1';
   const allowPrivateInitialOrigin = isLikelyPrivateUrl(initialUrl.toString());
   const dispatchers = new Map<string, Promise<Agent>>();
+  const privateIpAllowedFor = (url: URL): boolean =>
+    allowPrivateEverywhere || (allowPrivateInitialOrigin && url.origin === initialUrl.origin);
 
   const dispatcherFor = (url: URL): Promise<Agent> => {
     const cached = dispatchers.get(url.origin);
     if (cached) return cached;
-    const allowPrivateIp = allowPrivateEverywhere || (allowPrivateInitialOrigin && url.origin === initialUrl.origin);
-    const pending = resolveAndCreateDispatcher(url, lookup, allowPrivateIp);
+    const pending = resolveAndCreateDispatcher(url, lookup, privateIpAllowedFor(url));
     dispatchers.set(url.origin, pending);
     pending.catch(() => dispatchers.delete(url.origin));
     return pending;
@@ -65,6 +66,8 @@ export function createAgentTransportFetch(agentUrl: string, options: AgentTransp
 
     for (let redirects = 0; ; redirects++) {
       assertTransportScheme(url);
+      const hostname = url.hostname.replace(/^\[|\]$/g, '');
+      if (isIP(hostname) !== 0) assertAgentAddressAllowed(hostname, hostname, privateIpAllowedFor(url), false);
       const headerRecord: Record<string, string> = {};
       headers.forEach((value, key) => {
         headerRecord[key] = value;
@@ -124,15 +127,7 @@ async function resolveAndCreateDispatcher(
   const addresses = await lookup(hostname);
   if (addresses.length === 0) throw new Error(`DNS returned no addresses for agent host ${hostname}`);
   for (const entry of addresses) {
-    if (isAlwaysBlocked(entry.address)) {
-      throw new Error(`Agent host ${hostname} resolves to an always-blocked address`);
-    }
-    if (!allowPrivateIp && isPrivateIp(entry.address)) {
-      throw new Error(
-        `Agent host ${hostname} resolves to a private or loopback address; ` +
-          'set transport.allowPrivateIp=true for an explicitly trusted private agent, or provide a trustedFetchFn that enforces its own address policy'
-      );
-    }
+    assertAgentAddressAllowed(entry.address, hostname, allowPrivateIp, true);
   }
 
   const pinned = addresses[0]!;
@@ -147,6 +142,24 @@ async function resolveAndCreateDispatcher(
       },
     },
   });
+}
+
+function assertAgentAddressAllowed(
+  address: string,
+  hostname: string,
+  allowPrivateIp: boolean,
+  resolved: boolean
+): void {
+  const relationship = resolved ? 'resolves to' : 'is';
+  if (isAlwaysBlocked(address)) {
+    throw new Error(`Agent host ${hostname} ${relationship} an always-blocked address`);
+  }
+  if (!allowPrivateIp && isPrivateIp(address)) {
+    const guidance = resolved
+      ? 'set transport.allowPrivateIp=true for an explicitly trusted private agent, or provide a trustedFetchFn that enforces its own hostname address policy'
+      : 'set transport.allowPrivateIp=true for an explicitly trusted private agent';
+    throw new Error(`Agent host ${hostname} ${relationship} a private or loopback address; ` + guidance);
+  }
 }
 
 function assertTransportScheme(url: URL): void {

--- a/src/lib/net/ssrf-fetch.ts
+++ b/src/lib/net/ssrf-fetch.ts
@@ -211,7 +211,7 @@ export async function ssrfSafeFetch(url: string, options: SsrfFetchOptions = {})
     if (isAlwaysBlocked(hostname)) {
       throw new SsrfRefusedError(
         'always_blocked_address',
-        'Refusing to fetch an always-blocked address (link-local or cloud metadata)',
+        'Refusing to fetch an always-blocked address (local, metadata, or unsafe translation)',
         { url, hostname, address: hostname }
       );
     }
@@ -267,7 +267,7 @@ export async function ssrfSafeFetch(url: string, options: SsrfFetchOptions = {})
         if (isAlwaysBlocked(a.address)) {
           throw new SsrfRefusedError(
             'always_blocked_address',
-            `Refusing to fetch: ${hostname} resolves to an always-blocked address (link-local or cloud metadata)`,
+            `Refusing to fetch: ${hostname} resolves to an always-blocked address (local, metadata, or unsafe translation)`,
             { url, hostname, address: a.address }
           );
         }

--- a/src/lib/net/ssrf-fetch.ts
+++ b/src/lib/net/ssrf-fetch.ts
@@ -180,6 +180,11 @@ export async function ssrfSafeFetch(url: string, options: SsrfFetchOptions = {})
   } catch {
     throw new SsrfRefusedError('invalid_url', `Invalid URL: ${url}`, { url });
   }
+  const checkedUrl = parsed.href;
+  // From this point onward use the immutable serialization that was checked.
+  // This also prevents stateful string coercion in untyped JavaScript callers
+  // from presenting a different target to diagnostics or result metadata.
+  url = checkedUrl;
 
   // `URL.hostname` wraps IPv6 literals in brackets (`https://[::1]/` →
   // `[::1]`). `dns.lookup` and the address classifier both want the bare
@@ -313,14 +318,14 @@ export async function ssrfSafeFetch(url: string, options: SsrfFetchOptions = {})
     }
 
     const res = options.trustedFetchFn
-      ? await options.trustedFetchFn(url, {
+      ? await options.trustedFetchFn(checkedUrl, {
           method: options.method ?? 'GET',
           redirect: 'manual',
           signal: ac.signal,
           headers: options.headers,
           ...(options.body !== undefined && { body: options.body as BodyInit }),
         })
-      : await undiciFetch(url, {
+      : await undiciFetch(checkedUrl, {
           method: options.method ?? 'GET',
           redirect: 'manual',
           signal: ac.signal,

--- a/src/lib/protocols/index.ts
+++ b/src/lib/protocols/index.ts
@@ -278,10 +278,11 @@ export interface TransportOptions {
    * the SDK uses the global `fetch` implementation.
    *
    * Supplying this function makes it the trusted network boundary: the SDK
-   * still validates URL schemes, redirect behavior, timeouts, and body limits,
-   * but delegates DNS resolution and address policy to the implementation.
-   * It must prevent DNS rebinding and unsafe private-address access itself (for
-   * example with an egress proxy or its own DNS pinning).
+   * still validates URL schemes, redirect behavior, timeouts, body limits, and
+   * literal IP addresses, but delegates hostname DNS resolution and resolved
+   * address policy to the implementation. It must prevent DNS rebinding and
+   * unsafe private-address access itself (for example with an egress proxy or
+   * its own DNS pinning).
    */
   trustedFetchFn?: typeof fetch;
   /**

--- a/src/lib/server/pin-and-bind-fetch.ts
+++ b/src/lib/server/pin-and-bind-fetch.ts
@@ -29,20 +29,22 @@
  * resolves to *any* denied IP is treated as suspect and rejected wholesale.
  */
 
-import { Agent, fetch as undiciFetch, type Dispatcher } from 'undici';
+import { Agent, fetch as undiciFetch, Request as UndiciRequest, type Dispatcher } from 'undici';
 import { lookup as nativeDnsLookup, type LookupAddress } from 'node:dns';
 import { isIPv6 } from 'node:net';
 
+import { isAlwaysBlocked, isLoopbackIp, isPrivateIp } from '../net/address-guards';
 import { enforceSsrfPolicy, enforceSsrfPolicyResolved } from '../substitution/observer/ssrf';
 import type { SsrfPolicy } from '../substitution/types';
 
 /**
- * Default SSRF policy for outbound webhook delivery. Stricter than
+ * Default SSRF policy for outbound webhook delivery. Differs from
  * `DEFAULT_SSRF_POLICY` (substitution observer) only in that it allows
  * `host_literal_policy: 'allow'` — webhook URLs MAY use IP literals
- * (e.g. `https://203.0.113.10/cb`) as long as the IP is not in a denied
- * CIDR range. Schemes restricted to https; signed webhooks SHOULD be
- * delivered over TLS.
+ * (e.g. `https://203.0.113.10/cb`) as long as the IP is allowed by both
+ * the contract CIDRs and the SDK's shared private-address classifier.
+ * Schemes are restricted to https; signed webhooks SHOULD be delivered
+ * over TLS.
  *
  * For storyboard / in-process tests where the receiver runs on
  * `http://127.0.0.1:port`, use {@link LOOPBACK_OK_WEBHOOK_SSRF_POLICY}
@@ -81,6 +83,7 @@ export const WEBHOOK_SSRF_POLICY: SsrfPolicy = Object.freeze({
     'fd00:ec2::254',
   ]),
   host_literal_policy: 'allow',
+  shared_private_address_policy: 'deny',
 }) as SsrfPolicy;
 
 /**
@@ -88,9 +91,10 @@ export const WEBHOOK_SSRF_POLICY: SsrfPolicy = Object.freeze({
  * adopters can enable pin-and-bind for production webhook delivery while
  * keeping storyboard / in-process tests working — `createWebhookReceiver`
  * listens on `http://127.0.0.1:port`. Every other private CIDR, metadata
- * host, and link-local range is still denied, so loopback is the only
- * relaxation. Pass to `createPinAndBindFetch({ policy })` from your test
- * fixture or storyboard runner harness; do NOT use in production.
+ * host, and shared private range is still denied, so native IPv4/IPv6
+ * loopback is the only address relaxation. Pass to
+ * `createPinAndBindFetch({ policy })` from your test fixture or storyboard
+ * runner harness; do NOT use in production.
  */
 export const LOOPBACK_OK_WEBHOOK_SSRF_POLICY: SsrfPolicy = Object.freeze({
   schemes_allowed: Object.freeze(['http', 'https']),
@@ -122,6 +126,7 @@ export const LOOPBACK_OK_WEBHOOK_SSRF_POLICY: SsrfPolicy = Object.freeze({
     'fd00:ec2::254',
   ]),
   host_literal_policy: 'allow',
+  shared_private_address_policy: 'allow_loopback',
 }) as SsrfPolicy;
 
 /**
@@ -139,7 +144,11 @@ export interface PinAndBindFetchOptions {
   /**
    * SSRF policy to enforce against resolved IPs. Defaults to
    * {@link WEBHOOK_SSRF_POLICY} (https-only, all private/loopback/metadata
-   * ranges denied, IP literals allowed).
+   * ranges denied, IP literals allowed). The built-in strict and loopback
+   * presets inherit the SDK's full shared private-address classification;
+   * custom policies own their private ranges. Cloud metadata, link-local, and
+   * opaque translation/tunnel targets in the shared always-blocked tier can
+   * never be enabled by a policy override.
    */
   policy?: SsrfPolicy;
   /**
@@ -216,9 +225,22 @@ export function createPinAndBindFetch(options: PinAndBindFetchOptions = {}): typ
       // rebinding defense.
       const url = new URL(`https://${bracketIfV6(hostname)}`);
       const ips = addresses.map(a => a.address);
+      if (ips.some(isAlwaysBlocked)) {
+        callback(makeSsrfError(`Host ${hostname} resolves to an always-blocked address`, 'always_blocked_address'));
+        return;
+      }
       const result = enforceSsrfPolicyResolved(url, ips, policy);
       if (!result.allowed) {
-        callback(makeSsrfError(result.message ?? 'SSRF policy denied resolved address', result.rule ?? 'ssrf'));
+        callback(makeSsrfError(`Host ${hostname} resolves to an address denied by SSRF policy`, result.rule ?? 'ssrf'));
+        return;
+      }
+      if (ips.some(ip => isSharedPrivateAddressDenied(ip, policy))) {
+        callback(
+          makeSsrfError(
+            `Host ${hostname} resolves to a private, non-routable, or reserved address`,
+            'shared_private_address'
+          )
+        );
         return;
       }
 
@@ -253,11 +275,19 @@ export function createPinAndBindFetch(options: PinAndBindFetchOptions = {}): typ
     // This pre-check enforces the same SSRF policy on URLs like
     // `https://127.0.0.1/cb` or `https://[::1]/cb`.
     const url = resolveRequestUrl(input);
-    if (url) {
-      const sync = enforceSsrfPolicy(url, policy);
-      if (!sync.allowed) {
-        throw makeSsrfError(sync.message ?? 'SSRF policy denied URL', sync.rule ?? 'ssrf');
-      }
+    if (!url) {
+      throw makeSsrfError('Unsupported or invalid URL input', 'invalid_url');
+    }
+    const hostname = url.hostname.replace(/^\[|\]$/g, '');
+    if (isAlwaysBlocked(hostname)) {
+      throw makeSsrfError(`Host ${hostname} is an always-blocked address`, 'always_blocked_address');
+    }
+    const sync = enforceSsrfPolicy(url, policy);
+    if (!sync.allowed) {
+      throw makeSsrfError(sync.message ?? 'SSRF policy denied URL', sync.rule ?? 'ssrf');
+    }
+    if (isSharedPrivateAddressDenied(hostname, policy)) {
+      throw makeSsrfError(`Host ${hostname} is a private, non-routable, or reserved address`, 'shared_private_address');
     }
     // Redirects are never followed, and this is not caller-overridable.
     //
@@ -276,7 +306,12 @@ export function createPinAndBindFetch(options: PinAndBindFetchOptions = {}): typ
     // need to follow a hop should re-enter this fetch with the new URL, which
     // re-runs the full policy on it.
     const redirect = (init as { redirect?: string } | undefined)?.redirect === 'error' ? 'error' : 'manual';
-    return undiciFetch(input as Parameters<typeof undiciFetch>[0], {
+    const runtimeInput: unknown = input;
+    const checkedInput =
+      runtimeInput instanceof globalThis.Request || runtimeInput instanceof UndiciRequest
+        ? new UndiciRequest(url.href, runtimeInput as unknown as ConstructorParameters<typeof UndiciRequest>[1])
+        : url.href;
+    return undiciFetch(checkedInput as Parameters<typeof undiciFetch>[0], {
       ...(init as Parameters<typeof undiciFetch>[1]),
       redirect,
       dispatcher: dispatcher as unknown as Dispatcher,
@@ -286,20 +321,20 @@ export function createPinAndBindFetch(options: PinAndBindFetchOptions = {}): typ
   return wrapped as typeof fetch;
 }
 
-function resolveRequestUrl(input: Parameters<typeof fetch>[0]): URL | null {
+function isSharedPrivateAddressDenied(address: string, policy: SsrfPolicy): boolean {
+  if (!isPrivateIp(address)) return false;
+  if (policy.shared_private_address_policy === 'deny') return true;
+  if (policy.shared_private_address_policy === 'allow_loopback') return !isLoopbackIp(address);
+  return false;
+}
+
+function resolveRequestUrl(input: unknown): URL | null {
   try {
     if (typeof input === 'string') return new URL(input);
-    if (input instanceof URL) return input;
-    if (
-      typeof input === 'object' &&
-      input !== null &&
-      'url' in input &&
-      typeof (input as { url: unknown }).url === 'string'
-    ) {
-      return new URL((input as { url: string }).url);
-    }
+    if (input instanceof URL) return new URL(input.href);
+    if (input instanceof globalThis.Request || input instanceof UndiciRequest) return new URL(input.url);
   } catch {
-    // Let undici surface the parse error in its own shape.
+    // The wrapper converts parse failures into a fail-closed SSRF refusal.
     return null;
   }
   return null;

--- a/src/lib/substitution/observer/ssrf.ts
+++ b/src/lib/substitution/observer/ssrf.ts
@@ -5,6 +5,7 @@
  */
 
 import { BlockList, isIP, isIPv4, isIPv6 } from 'node:net';
+import { isAlwaysBlocked, isLoopbackIp, isPrivateIp } from '../../net/address-guards';
 import type { PolicyResult, SsrfPolicy } from '../types';
 
 /**
@@ -12,7 +13,11 @@ import type { PolicyResult, SsrfPolicy } from '../types';
  * `compliance/cache/latest/test-kits/substitution-observer-runner.yaml`.
  * Callers SHOULD use this constant — overriding the policy is
  * intended for local-dev workflows (`host_literal_policy: 'allow'`),
- * not for loosening deny lists.
+ * not for loosening deny lists. Runtime enforcement supplements these
+ * contract CIDRs with the SDK's shared address classifier so newly reserved
+ * ranges cannot drift between outbound-fetch implementations. The SDK-only
+ * policy marker is deliberately enumerable so spread-based overrides retain
+ * that behavior.
  */
 export const DEFAULT_SSRF_POLICY: SsrfPolicy = Object.freeze({
   schemes_allowed: Object.freeze(['https']),
@@ -45,6 +50,7 @@ export const DEFAULT_SSRF_POLICY: SsrfPolicy = Object.freeze({
     'fd00:ec2::254',
   ]),
   host_literal_policy: 'reject',
+  shared_private_address_policy: 'deny',
 }) as SsrfPolicy;
 
 interface CompiledPolicy {
@@ -75,7 +81,7 @@ function compile(policy: SsrfPolicy): CompiledPolicy {
     policy,
     ipv4,
     ipv6,
-    metadataHostnames: new Set(policy.hosts_denied_metadata.map(h => h.toLowerCase())),
+    metadataHostnames: new Set(policy.hosts_denied_metadata.map(normalizeHostname)),
     schemesAllowed: new Set(policy.schemes_allowed.map(s => s.toLowerCase())),
     schemesDenied: new Set(policy.schemes_denied.map(s => s.toLowerCase())),
   };
@@ -109,7 +115,7 @@ export function enforceSsrfPolicy(url: URL, policy: SsrfPolicy = DEFAULT_SSRF_PO
     };
   }
 
-  const hostname = stripBrackets(url.hostname).toLowerCase();
+  const hostname = normalizeHostname(url.hostname);
 
   if (compiled.metadataHostnames.has(hostname)) {
     return {
@@ -169,7 +175,7 @@ function checkIp(ip: string, compiled: CompiledPolicy): PolicyResult {
         message: `Resolved address ${ip} is in a denied IPv4 range.`,
       };
     }
-    return { allowed: true };
+    return checkSharedAddressPolicy(ip, compiled);
   }
   if (isIPv6(ip)) {
     const normalized = normalizeIpv6(ip);
@@ -189,13 +195,42 @@ function checkIp(ip: string, compiled: CompiledPolicy): PolicyResult {
         message: `Resolved address ${ip} is in a denied IPv6 range.`,
       };
     }
-    return { allowed: true };
+    return checkSharedAddressPolicy(ip, compiled);
   }
   return {
     allowed: false,
     rule: 'invalid_ip',
     message: `Address ${ip} is not a valid IPv4 or IPv6 literal.`,
   };
+}
+
+function checkSharedAddressPolicy(ip: string, compiled: CompiledPolicy): PolicyResult {
+  if (isAlwaysBlocked(ip)) {
+    return {
+      allowed: false,
+      rule: 'always_blocked_address',
+      message: 'Address is always blocked (local, metadata, or unsafe translation).',
+    };
+  }
+  if (compiled.policy.shared_private_address_policy === 'deny' && isPrivateIp(ip)) {
+    return {
+      allowed: false,
+      rule: 'shared_private_address',
+      message: 'Address is private, non-routable, or reserved.',
+    };
+  }
+  if (compiled.policy.shared_private_address_policy === 'allow_loopback' && isPrivateIp(ip) && !isLoopbackIp(ip)) {
+    return {
+      allowed: false,
+      rule: 'shared_private_address',
+      message: 'Address is private, non-routable, or reserved.',
+    };
+  }
+  return { allowed: true };
+}
+
+function normalizeHostname(host: string): string {
+  return stripBrackets(host).replace(/\.$/, '').toLowerCase();
 }
 
 function stripBrackets(host: string): string {

--- a/src/lib/substitution/types.ts
+++ b/src/lib/substitution/types.ts
@@ -121,9 +121,19 @@ export interface SsrfPolicy {
   /**
    * - `reject`: bare IP literal (v4 or v6) in the URL is rejected regardless of range.
    *   Forces resolution through a public DNS name (AdCP Verified behavior).
-   * - `allow`: IP literal is permitted subject only to the CIDR deny lists. Local-dev default.
+   * - `allow`: IP literal is permitted subject to the CIDR deny lists and the
+   *   SDK shared-address setting below. Local-dev default.
    */
   host_literal_policy: 'reject' | 'allow';
+  /**
+   * SDK extension controlling the shared private/non-routable classifier in
+   * addition to the explicit contract CIDRs. Built-in policies set this so
+   * spread-based policy overrides retain their security posture.
+   *
+   * When omitted, custom policies own their private CIDR rules. The shared
+   * always-blocked tier is enforced regardless of this setting.
+   */
+  shared_private_address_policy?: 'deny' | 'allow' | 'allow_loopback';
 }
 
 export interface PolicyResult {

--- a/src/lib/utils/probe-policy.ts
+++ b/src/lib/utils/probe-policy.ts
@@ -143,14 +143,14 @@ export function classifyProbeUrl(url: string): ProbePolicyResult {
     };
   }
 
-  // IMDS / IPv6 link-local: ALWAYS refused. Cloud metadata reach is never
-  // a legitimate buyer-side use case — refuse even when the operator has
-  // explicitly opted into private probes.
+  // IMDS / IPv6 link-local / unsafe translation: ALWAYS refused. Cloud
+  // metadata reach is never a legitimate buyer-side use case — refuse even
+  // when the operator has explicitly opted into private probes.
   if (isAlwaysBlocked(host)) {
     return {
       allowed: false,
       code: 'always_blocked',
-      reason: `Refusing to probe '${host}': cloud-metadata or link-local address.`,
+      reason: `Refusing to probe '${host}': always-blocked local, metadata, or translation address.`,
     };
   }
 

--- a/test/lib/agent-transport-fetch.test.js
+++ b/test/lib/agent-transport-fetch.test.js
@@ -104,3 +104,60 @@ test('agent transport supports an explicit per-client private DNS opt-in', async
   await guarded('https://agent.corp/mcp');
   assert.equal(called, true);
 });
+
+test('agent transport never allows AWS IPv6 IMDS through the private DNS opt-in', async () => {
+  let calls = 0;
+  const guarded = createAgentTransportFetch('https://agent.corp/mcp', {
+    allowPrivateIp: true,
+    lookup: async () => [{ address: 'fd00:ec2::254', family: 6 }],
+    networkFetch: async () => {
+      calls += 1;
+      return new Response('{}');
+    },
+  });
+
+  await assert.rejects(() => guarded('https://agent.corp/mcp'), /always-blocked address/);
+  assert.equal(calls, 0, 'the network fetch must not run for IPv6 IMDS');
+});
+
+test('agent transport never passes a literal AWS IPv6 IMDS URL to a trusted fetch', async () => {
+  let calls = 0;
+  const guarded = createAgentTransportFetch('http://[fd00:ec2::254]/mcp', {
+    allowPrivateIp: true,
+    trustedFetchFn: async () => {
+      calls += 1;
+      return new Response('{}');
+    },
+  });
+
+  await assert.rejects(() => guarded('http://[fd00:ec2::254]/mcp'), /always-blocked address/);
+  assert.equal(calls, 0, 'the trusted fetch must not run for a literal IPv6 IMDS URL');
+});
+
+test('agent transport still permits an ordinary private literal through an explicit trusted-fetch opt-in', async () => {
+  let calls = 0;
+  const guarded = createAgentTransportFetch('http://[fd00::1]/mcp', {
+    allowPrivateIp: true,
+    trustedFetchFn: async () => {
+      calls += 1;
+      return new Response('{}');
+    },
+  });
+
+  await guarded('http://[fd00::1]/mcp');
+  assert.equal(calls, 1);
+});
+
+test('agent transport revalidates a literal AWS IPv6 IMDS trusted-fetch redirect', async () => {
+  const calls = [];
+  const guarded = createAgentTransportFetch('https://agent.example.com/mcp', {
+    allowPrivateIp: true,
+    trustedFetchFn: async url => {
+      calls.push(url.toString());
+      return new Response('', { status: 302, headers: { location: 'http://[fd00:ec2::254]/latest' } });
+    },
+  });
+
+  await assert.rejects(() => guarded('https://agent.example.com/mcp'), /always-blocked address/);
+  assert.deepEqual(calls, ['https://agent.example.com/mcp']);
+});

--- a/test/lib/net-ssrf-fetch.test.js
+++ b/test/lib/net-ssrf-fetch.test.js
@@ -255,10 +255,146 @@ describe('address-guards — bypass resistance', () => {
     assert.strictEqual(isAlwaysBlocked('0:0:0:0:0:ffff:169.254.169.254'), true);
   });
 
+  it('uses exact wrapped link-local prefix boundaries', () => {
+    const boundaries = [
+      {
+        before: '::a9fd:ffff',
+        first: '::a9fe:0',
+        last: '::a9fe:ffff',
+        after: '::a9ff:0',
+      },
+      {
+        before: '::ffff:0:a9fd:ffff',
+        first: '::ffff:0:a9fe:0',
+        last: '::ffff:0:a9fe:ffff',
+        after: '::ffff:0:a9ff:0',
+      },
+      {
+        before: '64:ff9b::a9fd:ffff',
+        first: '64:ff9b::a9fe:0',
+        last: '64:ff9b::a9fe:ffff',
+        after: '64:ff9b::a9ff:0',
+      },
+      {
+        before: '2002:a9fd:ffff:ffff:ffff:ffff:ffff:ffff',
+        first: '2002:a9fe::',
+        last: '2002:a9fe:ffff:ffff:ffff:ffff:ffff:ffff',
+        after: '2002:a9ff::',
+      },
+    ];
+
+    for (const { before, first, last, after } of boundaries) {
+      assert.strictEqual(isAlwaysBlocked(before), false, `${before} should precede the blocked prefix`);
+      assert.strictEqual(isAlwaysBlocked(first), true, `${first} should start the blocked prefix`);
+      assert.strictEqual(isAlwaysBlocked(last), true, `${last} should end the blocked prefix`);
+      assert.strictEqual(isAlwaysBlocked(after), false, `${after} should follow the blocked prefix`);
+    }
+  });
+
+  it('always blocks wrapped metadata even when private-network access is enabled', async () => {
+    const wrappedMetadataAddresses = [
+      '::a9fe:a9fe', // IPv4-compatible 169.254.169.254
+      '::c000:c0', // IPv4-compatible Oracle IMDS
+      '::ffff:0:a9fe:a9fe', // IPv4-translated 169.254.169.254
+      '::ffff:0:c000:c0', // IPv4-translated Oracle IMDS
+      '64:ff9b::a9fe:a9fe', // NAT64 WKP 169.254.169.254
+      '64:ff9b::c000:c0', // NAT64 WKP Oracle IMDS
+      '2002:a9fe:a9fe::', // 6to4 169.254.169.254
+      '2002:c000:c0::', // 6to4 Oracle IMDS
+      '64:ff9b:1::808:808', // opaque local-use translation prefix
+      '2001::1', // Teredo has relay-dependent, obfuscated endpoint data
+    ];
+    let fetchCalls = 0;
+    const trustedFetchFn = async () => {
+      fetchCalls += 1;
+      return new Response(null, { status: 204 });
+    };
+
+    for (const address of wrappedMetadataAddresses) {
+      assert.strictEqual(isAlwaysBlocked(address), true, `${address} should be always blocked`);
+      assert.strictEqual(isPrivateIp(address), true, `${address} should also be private-classified`);
+      await assert.rejects(
+        () =>
+          ssrfSafeFetch(`http://[${address}]/`, {
+            allowPrivateIp: true,
+            trustedFetchFn,
+          }),
+        err => err instanceof SsrfRefusedError && err.code === 'always_blocked_address',
+        `${address} should remain refused under allowPrivateIp`
+      );
+    }
+    assert.strictEqual(fetchCalls, 0, 'always-blocked literals must be rejected before fetch');
+  });
+
+  it('keeps deterministic public wrappers overrideable through allowPrivateIp', async () => {
+    const publicWrapperAddresses = ['::8.8.8.8', '::ffff:0:8.8.8.8', '64:ff9b::8.8.8.8', '2002:0808:0808::'];
+    let fetchCalls = 0;
+    const trustedFetchFn = async () => {
+      fetchCalls += 1;
+      return new Response(null, { status: 204 });
+    };
+
+    for (const address of publicWrapperAddresses) {
+      assert.strictEqual(isAlwaysBlocked(address), false, `${address} should not be always blocked`);
+      assert.strictEqual(isPrivateIp(address), true, `${address} should be refused by default`);
+      await assert.rejects(
+        () => ssrfSafeFetch(`https://[${address}]/`, { trustedFetchFn }),
+        err => err instanceof SsrfRefusedError && err.code === 'private_address'
+      );
+      const response = await ssrfSafeFetch(`https://[${address}]/`, {
+        allowPrivateIp: true,
+        trustedFetchFn,
+      });
+      assert.strictEqual(response.status, 204);
+    }
+    assert.strictEqual(fetchCalls, publicWrapperAddresses.length);
+  });
+
+  it('uses exact opaque-wrapper always-blocked boundaries', () => {
+    const boundaries = [
+      {
+        before: '64:ff9b:0:ffff:ffff:ffff:ffff:ffff',
+        first: '64:ff9b:1::',
+        last: '64:ff9b:1:ffff:ffff:ffff:ffff:ffff',
+        after: '64:ff9b:2::',
+      },
+      {
+        before: '2000:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
+        first: '2001::',
+        last: '2001:0:ffff:ffff:ffff:ffff:ffff:ffff',
+        after: '2001:1::',
+      },
+    ];
+
+    for (const { before, first, last, after } of boundaries) {
+      assert.strictEqual(isAlwaysBlocked(before), false, `${before} should precede the blocked prefix`);
+      assert.strictEqual(isAlwaysBlocked(first), true, `${first} should start the blocked prefix`);
+      assert.strictEqual(isAlwaysBlocked(last), true, `${last} should end the blocked prefix`);
+      assert.strictEqual(isAlwaysBlocked(after), false, `${after} should follow the blocked prefix`);
+    }
+  });
+
+  it('checks every DNS answer for opaque wrappers even under allowPrivateIp', async t => {
+    let blockedAddress = '64:ff9b:1::1';
+    t.mock.method(dnsPromises, 'lookup', async () => [
+      { address: '2606:4700::1111', family: 6 },
+      { address: blockedAddress, family: 6 },
+    ]);
+
+    for (const address of ['64:ff9b:1::1', '2001::1', '64:ff9b::a9fe:a9fe']) {
+      blockedAddress = address;
+      await assert.rejects(
+        () => ssrfSafeFetch('https://wrapped-dns.example/', { allowPrivateIp: true, timeoutMs: 100 }),
+        err =>
+          err instanceof SsrfRefusedError && err.code === 'always_blocked_address' && err.address === blockedAddress
+      );
+    }
+  });
+
   it('blocks NAT64 well-known prefix (64:ff9b::/96) regardless of embedded v4', () => {
     // NAT64 gateway at the caller's edge could translate into a private v4;
-    // refuse the prefix unconditionally rather than hope the gateway is
-    // configured the way we expect.
+    // refuse the prefix by default rather than hope the gateway is configured
+    // the way we expect.
     assert.strictEqual(isPrivateIp('64:ff9b::a9fe:a9fe'), true); // IMDS hex
     assert.strictEqual(isPrivateIp('64:ff9b::8.8.8.8'), true); // public v4 wrapped — still refused
   });
@@ -280,6 +416,10 @@ describe('address-guards — bypass resistance', () => {
       '3fff:fff::1', // documentation
       '5f00::1', // segment-routing SID
       '64:ff9b:1::8.8.8.8', // local-use IPv4/IPv6 translation
+      '2001:2:1::1', // non-global gap in IETF protocol assignments
+      '3ffe::1', // returned 6bone space
+      '5f01::1', // unallocated remainder of returned 6bone /8
+      '5fff:ffff:ffff:ffff:ffff:ffff:ffff:ffff', // end of returned 6bone /8
     ];
 
     for (const address of specialPurposeAddresses) {
@@ -287,14 +427,52 @@ describe('address-guards — bypass resistance', () => {
     }
   });
 
+  it('blocks the non-global 2001::/23 parent except current reachable allocations', () => {
+    const nonGlobalIetfAddresses = [
+      '2001::1', // Teredo
+      '2001:1::', // gap before the point anycast assignments
+      '2001:1::4', // first address after the point anycast assignments
+      '2001:2:1::', // immediately after benchmarking /48, still inside the parent
+      '2001:2:ffff:ffff:ffff:ffff:ffff:ffff', // immediately before AMT
+      '2001:4::1', // gap before AS112-v6
+      '2001:4:113::1', // immediately after AS112-v6
+      '2001:10::1', // deprecated ORCHID
+      '2001:1f:ffff:ffff:ffff:ffff:ffff:ffff', // immediately before ORCHIDv2
+      '2001:40::1', // immediately after the DET allocation
+      '2001:1ff:ffff:ffff:ffff:ffff:ffff:ffff', // end of parent /23
+    ];
+
+    for (const address of nonGlobalIetfAddresses) {
+      assert.strictEqual(isPrivateIp(address), true, `${address} should be refused`);
+    }
+  });
+
+  it('allows every current globally reachable allocation inside 2001::/23', () => {
+    const reachableIetfAddresses = [
+      '2001:1::1', // PCP anycast
+      '2001:1::2', // TURN anycast
+      '2001:1::3', // DNS-SD anycast
+      '2001:3::', // AMT lower bound
+      '2001:3:ffff:ffff:ffff:ffff:ffff:ffff', // AMT upper bound
+      '2001:4:112::', // AS112-v6 lower bound
+      '2001:4:112:ffff:ffff:ffff:ffff:ffff', // AS112-v6 upper bound
+      '2001:20::', // ORCHIDv2 lower bound
+      '2001:2f:ffff:ffff:ffff:ffff:ffff:ffff', // ORCHIDv2 upper bound
+      '2001:30::', // DET lower bound
+      '2001:3f:ffff:ffff:ffff:ffff:ffff:ffff', // DET upper bound
+    ];
+
+    for (const address of reachableIetfAddresses) {
+      assert.strictEqual(isPrivateIp(address), false, `${address} should remain reachable`);
+    }
+  });
+
   it('does not overblock addresses immediately outside the denied prefixes', () => {
-    assert.strictEqual(isPrivateIp('::1:0:0:0'), false); // outside deprecated ::/96
+    assert.strictEqual(isPrivateIp('::1:0:0'), false); // immediately after deprecated ::/96
     assert.strictEqual(isPrivateIp('::ffff:1:0:0'), false); // outside deprecated ::ffff:0:0:0/96
     assert.strictEqual(isPrivateIp('100:0:0:2::1'), false); // after dummy-prefix /64
-    assert.strictEqual(isPrivateIp('2001:3::1'), false); // AMT, after benchmarking /48
-    assert.strictEqual(isPrivateIp('2001:20::1'), false); // ORCHIDv2, outside deprecated 2001:10::/28
+    assert.strictEqual(isPrivateIp('2001:200::1'), false); // immediately after IETF assignments /23
     assert.strictEqual(isPrivateIp('3fff:1000::1'), false); // immediately after 3fff::/20
-    assert.strictEqual(isPrivateIp('5f01::1'), false); // immediately after SRv6 SID /16
     assert.strictEqual(isPrivateIp('64:ff9b:2::1'), false); // outside local-use 64:ff9b:1::/48
   });
 

--- a/test/lib/net-ssrf-fetch.test.js
+++ b/test/lib/net-ssrf-fetch.test.js
@@ -268,6 +268,36 @@ describe('address-guards — bypass resistance', () => {
     assert.strictEqual(isPrivateIp('2002:0808:0808::'), true);
   });
 
+  it('blocks non-routable IPv6 special-purpose ranges', () => {
+    const specialPurposeAddresses = [
+      '::192.0.2.1', // deprecated IPv4-compatible
+      '::ffff:0:192.0.2.1', // deprecated IPv4-translated
+      'fec0::1', // deprecated site-local
+      'feff:ffff:ffff:ffff:ffff:ffff:ffff:ffff', // end of deprecated site-local /10
+      '100:0:0:1::1', // dummy prefix
+      '2001:2::1', // benchmarking
+      '2001:10::1', // deprecated ORCHID
+      '3fff:fff::1', // documentation
+      '5f00::1', // segment-routing SID
+      '64:ff9b:1::8.8.8.8', // local-use IPv4/IPv6 translation
+    ];
+
+    for (const address of specialPurposeAddresses) {
+      assert.strictEqual(isPrivateIp(address), true, `${address} should be refused`);
+    }
+  });
+
+  it('does not overblock addresses immediately outside the denied prefixes', () => {
+    assert.strictEqual(isPrivateIp('::1:0:0:0'), false); // outside deprecated ::/96
+    assert.strictEqual(isPrivateIp('::ffff:1:0:0'), false); // outside deprecated ::ffff:0:0:0/96
+    assert.strictEqual(isPrivateIp('100:0:0:2::1'), false); // after dummy-prefix /64
+    assert.strictEqual(isPrivateIp('2001:3::1'), false); // AMT, after benchmarking /48
+    assert.strictEqual(isPrivateIp('2001:20::1'), false); // ORCHIDv2, outside deprecated 2001:10::/28
+    assert.strictEqual(isPrivateIp('3fff:1000::1'), false); // immediately after 3fff::/20
+    assert.strictEqual(isPrivateIp('5f01::1'), false); // immediately after SRv6 SID /16
+    assert.strictEqual(isPrivateIp('64:ff9b:2::1'), false); // outside local-use 64:ff9b:1::/48
+  });
+
   it('allows real public addresses', () => {
     assert.strictEqual(isPrivateIp('8.8.8.8'), false);
     assert.strictEqual(isPrivateIp('1.1.1.1'), false);

--- a/test/lib/net-ssrf-fetch.test.js
+++ b/test/lib/net-ssrf-fetch.test.js
@@ -12,6 +12,27 @@ const {
 } = require('../../dist/lib/net');
 
 describe('ssrfSafeFetch — scheme guard', () => {
+  it('fetches the exact normalized URL that was checked', async () => {
+    let coercions = 0;
+    const input = {
+      toString() {
+        coercions += 1;
+        return coercions === 1 ? 'https://public.example/' : 'http://127.0.0.1/';
+      },
+    };
+    let fetchedUrl;
+    const result = await ssrfSafeFetch(input, {
+      trustedFetchFn: async url => {
+        fetchedUrl = url;
+        return new Response(null, { status: 204 });
+      },
+    });
+
+    assert.equal(result.status, 204);
+    assert.equal(coercions, 1);
+    assert.equal(fetchedUrl, 'https://public.example/');
+  });
+
   it('refuses file: / data: / ftp: even under allowPrivateIp', async () => {
     for (const url of ['file:///etc/passwd', 'data:text/plain,hi', 'ftp://example.com/']) {
       await assert.rejects(
@@ -324,6 +345,26 @@ describe('address-guards — bypass resistance', () => {
       );
     }
     assert.strictEqual(fetchCalls, 0, 'always-blocked literals must be rejected before fetch');
+  });
+
+  it('always blocks AWS IPv6 IMDS even when private-network access is enabled', async () => {
+    let fetchCalls = 0;
+    const address = 'fd00:ec2::254';
+
+    assert.strictEqual(isAlwaysBlocked(address), true);
+    assert.strictEqual(isPrivateIp(address), true);
+    await assert.rejects(
+      () =>
+        ssrfSafeFetch(`http://[${address}]/latest/meta-data/`, {
+          allowPrivateIp: true,
+          trustedFetchFn: async () => {
+            fetchCalls += 1;
+            return new Response(null, { status: 204 });
+          },
+        }),
+      err => err instanceof SsrfRefusedError && err.code === 'always_blocked_address'
+    );
+    assert.strictEqual(fetchCalls, 0, 'IPv6 IMDS must be rejected before fetch');
   });
 
   it('keeps deterministic public wrappers overrideable through allowPrivateIp', async () => {

--- a/test/lib/pin-and-bind-fetch.test.js
+++ b/test/lib/pin-and-bind-fetch.test.js
@@ -13,6 +13,7 @@
 const { describe, test } = require('node:test');
 const assert = require('node:assert');
 const { createServer } = require('node:http');
+const { Request: UndiciRequest } = require('undici');
 
 const {
   createPinAndBindFetch,
@@ -44,6 +45,16 @@ function ssrfErrorThrown(err) {
     cur = cur.cause;
   }
   return false;
+}
+
+function errorChainText(err) {
+  const messages = [];
+  let cur = err;
+  while (cur) {
+    if (cur.message) messages.push(cur.message);
+    cur = cur.cause;
+  }
+  return messages.join(' — ');
 }
 
 async function expectSsrfBlocked(promise) {
@@ -79,6 +90,21 @@ describe('createPinAndBindFetch: DNS rebinding defense', () => {
       lookup: stubLookup([{ address: '10.0.0.5', family: 4 }]),
     });
     await expectSsrfBlocked(fetch('https://rebind.attacker.test/leak'));
+  });
+
+  test('does not expose a DNS-resolved private address in the rejection chain', async () => {
+    const privateAddress = '10.23.45.67';
+    const fetch = createPinAndBindFetch({
+      lookup: stubLookup([{ address: privateAddress, family: 4 }]),
+    });
+
+    try {
+      await fetch('https://rebind.attacker.test/leak');
+      assert.fail('expected fetch to reject with SSRF error');
+    } catch (err) {
+      assert.ok(ssrfErrorThrown(err));
+      assert.doesNotMatch(errorChainText(err), new RegExp(privateAddress.replaceAll('.', '\\.')));
+    }
   });
 
   test('blocks RFC 1918 private (192.168.1.1)', async () => {
@@ -121,6 +147,24 @@ describe('createPinAndBindFetch: DNS rebinding defense', () => {
       lookup: stubLookup([{ address: '::ffff:10.0.0.1', family: 6 }]),
     });
     await expectSsrfBlocked(fetch('https://rebind.attacker.test/leak'));
+  });
+
+  test('always blocks unsafe IPv6 translation and tunnel targets returned by DNS', async () => {
+    for (const address of ['64:ff9b:1::1', '2001::1', '2002:a9fe:a9fe::']) {
+      const fetch = createPinAndBindFetch({
+        lookup: stubLookup([{ address, family: 6 }]),
+      });
+      await expectSsrfBlocked(fetch('https://rebind.attacker.test/leak'));
+    }
+  });
+
+  test('default webhook policy inherits every shared non-routable IPv6 classification', async () => {
+    for (const address of ['::2', 'fec0::1', '100:0:0:1::1', '2001:2::1', '3ffe::1', '3fff::1', '5f00::1']) {
+      const fetch = createPinAndBindFetch({
+        lookup: stubLookup([{ address, family: 6 }]),
+      });
+      await expectSsrfBlocked(fetch('https://rebind.attacker.test/leak'));
+    }
   });
 
   test('blocks split-resolution: ANY private IP rejects whole hostname (mixed A records)', async () => {
@@ -172,6 +216,7 @@ describe('createPinAndBindFetch: policy override', () => {
     const relaxed = {
       ...WEBHOOK_SSRF_POLICY,
       hosts_denied_ipv4_cidrs: WEBHOOK_SSRF_POLICY.hosts_denied_ipv4_cidrs.filter(c => c !== '127.0.0.0/8'),
+      shared_private_address_policy: 'allow_loopback',
     };
     const fetch = createPinAndBindFetch({
       policy: relaxed,
@@ -207,6 +252,103 @@ describe('createPinAndBindFetch: policy override', () => {
     }
   });
 
+  test('LOOPBACK_OK_WEBHOOK_SSRF_POLICY relaxes only loopback from the shared private tier', async () => {
+    for (const address of ['::2', 'fec0::1', '100:0:0:1::1', '2001:2::1', '3ffe::1', '3fff::1', '5f00::1']) {
+      const fetch = createPinAndBindFetch({
+        policy: LOOPBACK_OK_WEBHOOK_SSRF_POLICY,
+        lookup: stubLookup([{ address, family: 6 }]),
+      });
+      await expectSsrfBlocked(fetch('https://rebind.attacker.test/leak'));
+    }
+  });
+
+  test('built-in webhook presets apply the shared classifier to literal hosts', async () => {
+    for (const policy of [WEBHOOK_SSRF_POLICY, LOOPBACK_OK_WEBHOOK_SSRF_POLICY]) {
+      const fetch = createPinAndBindFetch({ policy });
+      await expectSsrfBlocked(fetch('https://[3ffe::1]/leak'));
+    }
+  });
+
+  test('spread-based built-in policy overrides retain shared private blocking', async () => {
+    for (const policy of [{ ...WEBHOOK_SSRF_POLICY }, { ...WEBHOOK_SSRF_POLICY, schemes_allowed: ['http', 'https'] }]) {
+      const fetch = createPinAndBindFetch({ policy });
+      await expectSsrfBlocked(fetch('https://[3ffe::1]/leak'));
+    }
+  });
+
+  test('rejects nonstandard coercible inputs before validation and fetch can diverge', async () => {
+    let coercions = 0;
+    const input = {
+      toString() {
+        coercions += 1;
+        return coercions === 1 ? 'https://public.example/' : 'http://127.0.0.1/';
+      },
+    };
+    const fetch = createPinAndBindFetch();
+    await expectSsrfBlocked(fetch(input));
+    assert.equal(coercions, 0);
+  });
+
+  test('normalizes global and undici Request inputs without losing fetch semantics', async () => {
+    const observations = [];
+    const server = createServer((req, res) => {
+      const chunks = [];
+      req.on('data', chunk => chunks.push(chunk));
+      req.on('end', () => {
+        observations.push({
+          method: req.method,
+          requestHeader: req.headers['x-request'],
+          initHeader: req.headers['x-init'],
+          body: Buffer.concat(chunks).toString('utf8'),
+        });
+        res.writeHead(204);
+        res.end();
+      });
+    });
+    await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+    const port = server.address().port;
+
+    try {
+      for (const RequestCtor of [Request, UndiciRequest]) {
+        const request = new RequestCtor(`http://127.0.0.1:${port}/request`, {
+          method: 'POST',
+          headers: { 'x-request': 'request' },
+          body: 'payload',
+          duplex: 'half',
+        });
+        const fetch = createPinAndBindFetch({ policy: LOOPBACK_OK_WEBHOOK_SSRF_POLICY });
+        const response = await fetch(request, { headers: { 'x-init': 'override' } });
+        assert.equal(response.status, 204);
+
+        const controller = new AbortController();
+        const abortedRequest = new RequestCtor(`http://127.0.0.1:${port}/aborted`, {
+          signal: controller.signal,
+        });
+        controller.abort();
+        await assert.rejects(
+          () => fetch(abortedRequest),
+          err => err?.name === 'AbortError'
+        );
+      }
+    } finally {
+      await new Promise(resolve => server.close(resolve));
+    }
+
+    assert.deepEqual(observations, [
+      { method: 'POST', requestHeader: undefined, initHeader: 'override', body: 'payload' },
+      { method: 'POST', requestHeader: undefined, initHeader: 'override', body: 'payload' },
+    ]);
+  });
+
+  test('LOOPBACK_OK_WEBHOOK_SSRF_POLICY allows native loopback literals', async () => {
+    const fetch = createPinAndBindFetch({ policy: LOOPBACK_OK_WEBHOOK_SSRF_POLICY });
+    try {
+      await fetch('http://[::1]:9/path');
+    } catch (err) {
+      assert.ok(!ssrfErrorThrown(err), `loopback-OK preset must not raise SSRF; got ${err?.code}: ${err?.message}`);
+    }
+  });
+
   test('LOOPBACK_OK_WEBHOOK_SSRF_POLICY still blocks cloud metadata (regression guard)', async () => {
     // The preset relaxes ONLY loopback. Every other deny range — link-local,
     // RFC 1918, CGNAT, IPv6 ULA, metadata hosts — must still fire. A copy
@@ -215,6 +357,26 @@ describe('createPinAndBindFetch: policy override', () => {
     const fetch = createPinAndBindFetch({
       policy: LOOPBACK_OK_WEBHOOK_SSRF_POLICY,
       lookup: stubLookup([{ address: '169.254.169.254', family: 4 }]),
+    });
+    await expectSsrfBlocked(fetch('https://rebind.attacker.test/leak'));
+  });
+
+  test('policy overrides cannot enable shared always-blocked addresses', async () => {
+    const permissive = {
+      ...LOOPBACK_OK_WEBHOOK_SSRF_POLICY,
+      hosts_denied_ipv4_cidrs: [],
+      hosts_denied_ipv6_cidrs: [],
+      hosts_denied_metadata: [],
+    };
+
+    for (const url of ['https://[fd00:ec2::254]/leak', 'https://[64:ff9b:1::1]/leak', 'https://[2001::1]/leak']) {
+      const fetch = createPinAndBindFetch({ policy: permissive });
+      await expectSsrfBlocked(fetch(url));
+    }
+
+    const fetch = createPinAndBindFetch({
+      policy: permissive,
+      lookup: stubLookup([{ address: '64:ff9b:1::1', family: 6 }]),
     });
     await expectSsrfBlocked(fetch('https://rebind.attacker.test/leak'));
   });

--- a/test/lib/probe-policy.test.js
+++ b/test/lib/probe-policy.test.js
@@ -152,8 +152,8 @@ describe('classifyProbeUrl: ADCP_ALLOW_INTERNAL_PROBES=1 opt-in', () => {
     assert.strictEqual(r.code, 'always_blocked');
   });
 
-  test('ADCP_ALLOW_INTERNAL_PROBES=1 STILL refuses opaque IPv6 translation and tunnel prefixes', () => {
-    for (const url of ['http://[64:ff9b:1::1]/', 'http://[2001::1]/']) {
+  test('ADCP_ALLOW_INTERNAL_PROBES=1 STILL refuses IPv6 metadata, translation, and tunnel targets', () => {
+    for (const url of ['http://[fd00:ec2::254]/', 'http://[64:ff9b:1::1]/', 'http://[2001::1]/']) {
       const r = spawnAssertAllowed(url);
       assert.strictEqual(r.allowed, false, `${url} must remain refused under the env opt-in`);
       assert.strictEqual(r.code, 'always_blocked');

--- a/test/lib/probe-policy.test.js
+++ b/test/lib/probe-policy.test.js
@@ -152,6 +152,14 @@ describe('classifyProbeUrl: ADCP_ALLOW_INTERNAL_PROBES=1 opt-in', () => {
     assert.strictEqual(r.code, 'always_blocked');
   });
 
+  test('ADCP_ALLOW_INTERNAL_PROBES=1 STILL refuses opaque IPv6 translation and tunnel prefixes', () => {
+    for (const url of ['http://[64:ff9b:1::1]/', 'http://[2001::1]/']) {
+      const r = spawnAssertAllowed(url);
+      assert.strictEqual(r.allowed, false, `${url} must remain refused under the env opt-in`);
+      assert.strictEqual(r.code, 'always_blocked');
+    }
+  });
+
   test('ADCP_ALLOW_INTERNAL_PROBES=0 (or unset) keeps default-strict', () => {
     // The other tests in this file run with the default env, so this test
     // is implicit — the previous describe() block confirms strict default.

--- a/test/lib/substitution-ssrf.test.js
+++ b/test/lib/substitution-ssrf.test.js
@@ -91,9 +91,49 @@ describe('enforceSsrfPolicy — IPv6 CIDR deny', () => {
   }
 
   it('allows a public IPv6 outside every deny CIDR', () => {
-    const r = enforceSsrfPolicyResolved(new URL('https://example.test/p'), ['2001:db8::1']);
-    // 2001:db8::/32 is documentation range — not in any deny list.
+    const r = enforceSsrfPolicyResolved(new URL('https://example.test/p'), ['2606:4700:4700::1111']);
     assert.equal(r.allowed, true);
+  });
+
+  it('applies the shared non-routable and always-blocked IPv6 tiers', () => {
+    for (const ip of ['64:ff9b:1::1', '2001::1', '2001:2::1', '2002:a9fe:a9fe::', '3ffe::1', '3fff::1', '5f00::1']) {
+      const r = enforceSsrfPolicyResolved(new URL('https://example.test/p'), [ip]);
+      assert.equal(r.allowed, false, `${ip} must be refused`);
+    }
+  });
+
+  it('lets custom policies own private ranges but never bypass the always-blocked tier', () => {
+    const custom = {
+      ...DEFAULT_SSRF_POLICY,
+      hosts_denied_ipv4_cidrs: [],
+      hosts_denied_ipv6_cidrs: [],
+      shared_private_address_policy: 'allow',
+    };
+
+    assert.equal(enforceSsrfPolicyResolved(new URL('https://example.test/p'), ['3ffe::1'], custom).allowed, true);
+    assert.equal(enforceSsrfPolicyResolved(new URL('https://example.test/p'), ['64:ff9b:1::1'], custom).allowed, false);
+  });
+
+  it('preserves shared private blocking across spread-based default-policy overrides', () => {
+    for (const policy of [{ ...DEFAULT_SSRF_POLICY }, { ...DEFAULT_SSRF_POLICY, host_literal_policy: 'allow' }]) {
+      assert.equal(enforceSsrfPolicyResolved(new URL('https://example.test/p'), ['3ffe::1'], policy).allowed, false);
+    }
+  });
+
+  it('allows only native loopback representations under allow_loopback', () => {
+    const policy = {
+      ...DEFAULT_SSRF_POLICY,
+      hosts_denied_ipv4_cidrs: [],
+      hosts_denied_ipv6_cidrs: [],
+      shared_private_address_policy: 'allow_loopback',
+    };
+
+    for (const ip of ['127.0.0.1', '::1']) {
+      assert.equal(enforceSsrfPolicyResolved(new URL('https://example.test/p'), [ip], policy).allowed, true);
+    }
+    for (const ip of ['::ffff:127.0.0.1', '0:0:0:0:0:ffff:7f00:1']) {
+      assert.equal(enforceSsrfPolicyResolved(new URL('https://example.test/p'), [ip], policy).allowed, false);
+    }
   });
 
   it('rejects a bare IPv6 literal in Verified mode before CIDR check', () => {
@@ -112,14 +152,21 @@ describe('enforceSsrfPolicy — cloud metadata hostnames', () => {
       assert.equal(r.rule, `hosts_denied_metadata:${host}`);
     });
   }
+
+  it('normalizes a trailing DNS root dot before metadata matching', () => {
+    const r = enforceSsrfPolicy(new URL('https://metadata.google.internal./computeMetadata/v1/'));
+    assert.equal(r.allowed, false);
+    assert.equal(r.rule, 'hosts_denied_metadata:metadata.google.internal');
+  });
 });
 
-describe('DEFAULT_SSRF_POLICY mirrors the contract', () => {
+describe('DEFAULT_SSRF_POLICY mirrors and hardens the contract', () => {
   it('exposes readonly schemes_allowed / schemes_denied / deny lists', () => {
     assert.deepEqual([...DEFAULT_SSRF_POLICY.schemes_allowed], ['https']);
     assert.ok(DEFAULT_SSRF_POLICY.schemes_denied.includes('javascript'));
     assert.ok(DEFAULT_SSRF_POLICY.hosts_denied_ipv4_cidrs.includes('169.254.0.0/16'));
     assert.ok(DEFAULT_SSRF_POLICY.hosts_denied_ipv6_cidrs.includes('::1/128'));
     assert.equal(DEFAULT_SSRF_POLICY.host_literal_policy, 'reject');
+    assert.equal(DEFAULT_SSRF_POLICY.shared_private_address_policy, 'deny');
   });
 });


### PR DESCRIPTION
## Summary

- refuse additional non-routable and special-purpose IPv6 ranges in the shared SSRF guard, including AWS IPv6 IMDS and unsafe translation/tunnel prefixes
- preserve current globally reachable IETF allocations inside the otherwise non-global `2001::/23` parent
- apply the shared policy consistently across MCP/A2A transport, substitution observation, and webhook pin-and-bind delivery
- classify literal IPs on every agent-transport hop, preserve the policy through spread-based overrides, normalize metadata FQDNs, and fetch exactly the URL that was checked
- keep global and Undici `Request` inputs compatible while preserving method, body, headers, init overrides, and abort signals
- sanitize resolved-address rejection messages and add boundary, DNS, redirect, policy, coercion, and compatibility regressions plus a patch changeset

The trusted-fetch boundary is explicit: the SDK still classifies literal IPs, while a caller-provided fetch remains responsible for hostname DNS resolution, rebinding defense, and resolved-address policy.

## Buyer-side adoption

A temporary buyer-side IPv6/metadata guard can be removed once a published `@adcp/sdk` version containing this change is installed and the buyer uses the SDK's standard DNS-validated, connection-pinned MCP/A2A transport. The same shared policy now covers the standard substitution-observer and webhook pin-and-bind paths.

Keep equivalent protection around raw fetches, externally followed redirects, custom `trustedFetchFn` hostname resolution, or an explicitly supplied unguarded webhook fetch.

## Validation

- `npm run build:lib`
- `npm run format:check`
- `npm run typecheck`
- focused SSRF/probe/transport/webhook suite: 146 passed, 0 failed
- targeted regressions passed on Node 20 and Node 26
- parallel security, protocol, and test-design expert reviews: SHIP
- repository protocol/code/security review harness: no blocking findings
