### PR TITLE
feat: add canonical preview creative APIs

### DIFF
--- a/.changeset/calm-pandas-preview.md
+++ b/.changeset/calm-pandas-preview.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': minor
+---
+
+Add canonical `previewCreative` client and decisioning-platform APIs for capability, manifest, and creative-library preview routes while retaining `previewCreativeLegacy` for `format_id` compatibility.

--- a/README.md
+++ b/README.md
@@ -584,6 +584,7 @@ extension tools intentionally use that explicit raw-task route.
 - `syncCreatives()` - Upload/sync creative assets
 - `listCreatives()` - List creative assets
 - `buildCreativeLegacy()` - Build through the legacy named-format protocol (migration tooling only)
+- `previewCreative()` - Preview by advertised capability, inline manifest, or creative-library ID
 - `previewCreativeLegacy()` - Preview through the legacy named-format protocol (migration tooling only)
 - `getMediaBuyDelivery()` - Get delivery performance
 

--- a/docs/migration-12-to-14.md
+++ b/docs/migration-12-to-14.md
@@ -84,7 +84,7 @@ OAuth flow handlers must preserve `state`, verify callback binding, and pass an 
 - Add `zip`, `published_post`, `card`, `pixel_tracker`, `vast_tracker`, and `daast_tracker` to exhaustive `AssetInstance` handling.
 - Read canonical compliance scenarios from `ComplianceResult.tracks`; `tested_tracks` contains compact reference entries.
 - `createAdcpServerFromPlatform()` does not emit a completion webhook for an inline terminal result by default. `autoEmitCompletionWebhooks: true` is a temporary non-conformant bridge.
-- Rename raw platform hooks to explicit forms such as `buildCreativeLegacy`, `previewCreativeLegacy`, `listCreativeFormatsLegacy`, and the corresponding content-standard and brand-rights names.
+- Rename raw platform hooks to explicit forms such as `buildCreativeLegacy`, `previewCreativeLegacy`, `listCreativeFormatsLegacy`, and the corresponding content-standard and brand-rights names. Canonical AdCP 3.2 previews now use `previewCreative` with `target_capability_id`, `creative_id`, or `creative_manifest`; retain `previewCreativeLegacy` only for `format_id` callers. Custom `WebhookRegistrationStore` implementations must round-trip the optional `previewMode` field so callback routing survives restarts.
 - Put incrementally migrated raw handler groups under `legacyHandlers`.
 - Replace removed registry hierarchy calls with `lookupBrand()`/`lookupBrands()` and inspect relationship evidence; use `{ fresh: true }` when a live origin check is required.
 - Use `PayloadDigestOptions` for `computePayloadDigestSha256()` rather than the removed bare `RegExp` or `false` overloads.

--- a/src/lib/core/AgentClient.ts
+++ b/src/lib/core/AgentClient.ts
@@ -141,6 +141,8 @@ import type {
   CanonicalGetProductsResponse,
   CanonicalListCreativesRequest,
   CanonicalListCreativesResponse,
+  CanonicalPreviewCreativeRequest,
+  CanonicalPreviewCreativeResponse,
   CanonicalProduct,
   CanonicalSyncCreativesRequest,
   CanonicalUpdateMediaBuyRequest,
@@ -1210,6 +1212,19 @@ export class AgentClient {
    */
   async requireV3(taskType: string = 'request'): Promise<void> {
     return this.client.requireSupportedMajor(taskType);
+  }
+
+  /** Preview a creative using canonical capability or creative-library identity. */
+  async previewCreative(
+    params: CanonicalPreviewCreativeRequest,
+    inputHandler?: InputHandler,
+    options?: TaskOptions
+  ): Promise<TaskResult<CanonicalPreviewCreativeResponse>> {
+    const result = await this.client.previewCreative(params, inputHandler, {
+      ...this.withSession('preview_creative', options),
+    });
+    this.retainSession(result);
+    return result;
   }
 
   /** @deprecated Migration-only access to legacy `format_id`-based creative preview. */

--- a/src/lib/core/AsyncHandler.ts
+++ b/src/lib/core/AsyncHandler.ts
@@ -246,6 +246,11 @@ export interface AsyncHandlerConfig {
     response: CanonicalListCreativesResponse,
     metadata: WebhookMetadata
   ) => void | Promise<void>;
+  onPreviewCreativeStatusChange?: (
+    response: CanonicalCreativeResponse<PreviewCreativeResponse>,
+    metadata: WebhookMetadata
+  ) => void | Promise<void>;
+  /** @deprecated Use `onPreviewCreativeStatusChange`. */
   onPreviewCreativeLegacyStatusChange?: (
     response: PreviewCreativeResponse,
     metadata: WebhookMetadata
@@ -372,9 +377,12 @@ export class AsyncHandler {
   async handleWebhook({
     result,
     metadata,
+    previewHandler,
   }: {
     result: AdCPAsyncResponseData | undefined;
     metadata: WebhookMetadata;
+    /** @internal Preserves the originating preview API across async completion. */
+    previewHandler?: 'canonical' | 'legacy';
   }): Promise<void> {
     if (await this.isDuplicate(metadata)) {
       await this.emitActivity({
@@ -431,7 +439,7 @@ export class AsyncHandler {
 
     // All status changes go through the specific handler
     // The handler receives metadata with status and can act accordingly
-    await this.handleCompletion(metadata.task_type, result, metadata);
+    await this.handleCompletion(metadata.task_type, result, metadata, previewHandler);
   }
 
   /**
@@ -440,7 +448,8 @@ export class AsyncHandler {
   private async handleCompletion(
     taskType: string,
     result: AdCPAsyncResponseData | undefined,
-    metadata: WebhookMetadata
+    metadata: WebhookMetadata,
+    previewHandler?: 'canonical' | 'legacy'
   ): Promise<void> {
     let handler: ((result: any, metadata: any) => void | Promise<void>) | undefined;
 
@@ -455,7 +464,10 @@ export class AsyncHandler {
         break;
 
       case 'preview_creative':
-        handler = this.config.onPreviewCreativeLegacyStatusChange;
+        handler =
+          previewHandler === 'legacy'
+            ? (this.config.onPreviewCreativeLegacyStatusChange ?? this.config.onPreviewCreativeStatusChange)
+            : (this.config.onPreviewCreativeStatusChange ?? this.config.onPreviewCreativeLegacyStatusChange);
         break;
 
       case 'build_creative':

--- a/src/lib/core/AsyncHandler.ts
+++ b/src/lib/core/AsyncHandler.ts
@@ -381,7 +381,7 @@ export class AsyncHandler {
   }: {
     result: AdCPAsyncResponseData | undefined;
     metadata: WebhookMetadata;
-    /** @internal Preserves the originating preview API across async completion. */
+    /** Preserves the originating preview API across async completion. */
     previewHandler?: 'canonical' | 'legacy';
   }): Promise<void> {
     if (await this.isDuplicate(metadata)) {

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -5,7 +5,12 @@ import * as schemas from '../types/schemas.generated';
 import type { AgentConfig } from '../types';
 import { ADCP_ENVELOPE_FIELDS } from '../types/adcp';
 import { parseAdcpMajorVersion, type AdcpVersion } from '../version';
-import { isAdcpVersionSupported, isPre31AdcpVersion, resolveAdcpVersion } from '../utils/adcp-version-config';
+import {
+  isAdcpVersionSupported,
+  isPre31AdcpVersion,
+  isPre32AdcpVersion,
+  resolveAdcpVersion,
+} from '../utils/adcp-version-config';
 import { getVersionAdapter, resolveAdapterKey } from '../adapters/version';
 import { isExternalSchemaRootActive, schemaAllowsTopLevelField } from '../validation/schema-loader';
 import type {
@@ -204,6 +209,8 @@ import {
   type CanonicalGetProductsResponse,
   type CanonicalListCreativesRequest,
   type CanonicalListCreativesResponse,
+  type CanonicalPreviewCreativeRequest,
+  type CanonicalPreviewCreativeResponse,
   type CanonicalSyncCreativesRequest,
   type CanonicalUpdateMediaBuyRequest,
   type CreativeFormatWireMode,
@@ -279,6 +286,27 @@ function hasMediaBuyCreativeFormatData(request: unknown): boolean {
       })
     );
   });
+}
+
+function legacyCreativeIdentityPath(value: unknown, path = '$', seen = new WeakSet<object>()): string | undefined {
+  if (value === null || typeof value !== 'object') return undefined;
+  if (seen.has(value)) return `${path} (cycle)`;
+  seen.add(value);
+  try {
+    for (const key of Reflect.ownKeys(value)) {
+      if (typeof key !== 'string' || (Array.isArray(value) && key === 'length')) continue;
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      if (!descriptor || !descriptor.enumerable) continue;
+      const childPath = Array.isArray(value) ? `${path}[${key}]` : `${path}.${key}`;
+      if (/(^|_)(?:format_ids?|v1_format_ref)($|_)/.test(key)) return childPath;
+      if (!('value' in descriptor)) return `${childPath} (accessor)`;
+      const nested = legacyCreativeIdentityPath(descriptor.value, childPath, seen);
+      if (nested) return nested;
+    }
+    return undefined;
+  } finally {
+    seen.delete(value);
+  }
 }
 
 const CANONICAL_CREATIVE_ACTIVITY_TASKS = new Set([
@@ -441,9 +469,17 @@ function canonicalCreativeRoutingSnapshot(
 
 const canonicalCreativeExecutionStorage = globalAsyncLocalStorage<{
   taskType: string;
+  canonical: boolean;
   legacyFormatConverter?: LegacyFormatConverter;
   canonicalRequest?: unknown;
 }>('canonicalCreativeExecution');
+
+function isCanonicalCreativeExecution(taskType: string | undefined): boolean {
+  if (!taskType) return false;
+  if (CANONICAL_CREATIVE_ACTIVITY_TASKS.has(taskType)) return true;
+  const active = canonicalCreativeExecutionStorage.getStore();
+  return active?.canonical === true && active.taskType === taskType;
+}
 
 /**
  * Snapshot semantic payloads without executing adopter-controlled behavior.
@@ -624,9 +660,8 @@ function projectCanonicalCreativeAncillaryValue(
 /** Keep legacy creative identity confined to the transport adapter. */
 function canonicalCreativeActivity(activity: Activity): Activity {
   const active = canonicalCreativeExecutionStorage.getStore();
-  const effectiveTaskType =
-    active?.taskType && CANONICAL_CREATIVE_ACTIVITY_TASKS.has(active.taskType) ? active.taskType : activity.task_type;
-  if (!CANONICAL_CREATIVE_ACTIVITY_TASKS.has(effectiveTaskType) || activity.payload === undefined) {
+  const effectiveTaskType = active?.taskType && active.canonical ? active.taskType : activity.task_type;
+  if (!isCanonicalCreativeExecution(effectiveTaskType) || activity.payload === undefined) {
     return activity;
   }
   const converter = active?.taskType === effectiveTaskType ? active.legacyFormatConverter : undefined;
@@ -667,11 +702,8 @@ function canonicalCreativeTransportActivity(
   event: import('../protocols').TransportActivity
 ): import('../protocols').TransportActivity {
   const active = canonicalCreativeExecutionStorage.getStore();
-  const taskType =
-    active?.taskType && CANONICAL_CREATIVE_ACTIVITY_TASKS.has(active.taskType)
-      ? active.taskType
-      : (event.taskType ?? event.tool);
-  if (!taskType || !CANONICAL_CREATIVE_ACTIVITY_TASKS.has(taskType)) return event;
+  const taskType = active?.taskType && active.canonical ? active.taskType : (event.taskType ?? event.tool);
+  if (!taskType || !isCanonicalCreativeExecution(taskType)) return event;
   return {
     ...event,
     ...(event.requestBody !== undefined && {
@@ -969,6 +1001,7 @@ export interface WebhookParseSuccess {
     status: TaskStatus;
     timestamp?: string;
     message?: string;
+    previewHandler?: 'canonical' | 'legacy';
   };
 }
 
@@ -1413,6 +1446,7 @@ export class SingleAgentClient {
   private _syntheticV2WarningFired = false; // Gate: emit the synthetic-v2 warning once per client instance
   private readonly productPolicyRequestParamsByTask = new Map<string, ProductPolicyRequestState>();
   private readonly canonicalCreativeTaskAssociations = new Map<string, CanonicalCreativeTaskAssociation>();
+  private readonly previewCreativeHandlersByTask = new Map<string, 'canonical' | 'legacy'>();
   private readonly canonicalLegacyRoutes = new Map<string, CanonicalLegacyRoute>();
   private readonly resolvedAdcpVersion: string;
   private readonly webhookRegistrationStore: WebhookRegistrationStore;
@@ -1493,6 +1527,25 @@ export class SingleAgentClient {
       ? Math.floor(this.config.webhookVerification.now() * 1000)
       : Date.now();
     const ttlSeconds = this.config.webhookRegistrationTtlSeconds ?? 7 * 24 * 60 * 60;
+    const activeCreativeExecution = canonicalCreativeExecutionStorage.getStore();
+    const previewMode =
+      args.taskType === 'preview_creative' && activeCreativeExecution?.taskType === args.taskType
+        ? activeCreativeExecution.canonical
+          ? 'canonical'
+          : 'legacy'
+        : undefined;
+    // Keep an operation-scoped fallback before awaiting durable persistence.
+    // This preserves preview callback identity for immediate HMAC callbacks and
+    // for the legacy HMAC compatibility path when the registration store is
+    // temporarily unavailable.
+    if (previewMode) {
+      this.rememberPreviewCreativeHandlerKey(args.operationId, previewMode);
+      if (previewMode === 'canonical') {
+        this.rememberCanonicalCreativeTaskAssociation(args.operationId, args.taskType);
+      } else {
+        this.canonicalCreativeTaskAssociations.delete(args.operationId);
+      }
+    }
     try {
       await this.webhookRegistrationStore.putIfAbsent({
         agentId: args.agent.id,
@@ -1503,6 +1556,7 @@ export class SingleAgentClient {
         callbackUrl: args.callbackUrl,
         method: 'POST',
         mode: args.mode,
+        ...(previewMode && { previewMode }),
         createdAt: nowMs,
         expiresAt: nowMs + ttlSeconds * 1000,
       });
@@ -2696,9 +2750,26 @@ export class SingleAgentClient {
     const associatedTaskType = associatedTaskTypes.size === 1 ? [...associatedTaskTypes][0] : undefined;
     const routedTaskType = options.taskType === 'unknown' ? undefined : options.taskType;
     const declaredTaskType = routedTaskType ?? parsedTaskType;
+    const previewOperationId =
+      typeof payloadRecord?.operation_id === 'string' ? payloadRecord.operation_id : options.operationId;
+    const localPreviewHandler =
+      declaredTaskType === 'preview_creative' && previewOperationId
+        ? this.previewCreativeHandlerForWebhook({
+            operation_id: previewOperationId,
+            task_id: '',
+            context_id: '',
+            task_type: 'preview_creative',
+          })
+        : undefined;
+    // Durable registration provenance wins when available. During the legacy
+    // HMAC store-outage fallback, the operation-scoped local marker must win
+    // over a stale canonical association on a reused task or context id.
+    const previewHandler = registration?.previewMode ?? localPreviewHandler;
+    const authoritativePreviewTask = declaredTaskType === 'preview_creative' && previewHandler !== undefined;
     if (
-      associatedTaskTypes.size > 1 ||
-      (associatedTaskType !== undefined && declaredTaskType !== undefined && associatedTaskType !== declaredTaskType)
+      !authoritativePreviewTask &&
+      (associatedTaskTypes.size > 1 ||
+        (associatedTaskType !== undefined && declaredTaskType !== undefined && associatedTaskType !== declaredTaskType))
     ) {
       return {
         ok: false,
@@ -2706,7 +2777,7 @@ export class SingleAgentClient {
         message: 'Webhook task_type does not match the locally tracked task association.',
       };
     }
-    let normalizedTaskType = associatedTaskType ?? declaredTaskType;
+    let normalizedTaskType = authoritativePreviewTask ? declaredTaskType : (associatedTaskType ?? declaredTaskType);
     try {
       const normalizedPayload = this.normalizeWebhookPayload(
         parsedPayload.payload,
@@ -2721,7 +2792,11 @@ export class SingleAgentClient {
           message: 'Authenticated webhook protocol does not match the trusted registration.',
         };
       }
-      if (associatedTaskType !== undefined && normalizedPayload.task_type !== associatedTaskType) {
+      if (
+        !authoritativePreviewTask &&
+        associatedTaskType !== undefined &&
+        normalizedPayload.task_type !== associatedTaskType
+      ) {
         return {
           ok: false,
           code: 'webhook_envelope_invalid',
@@ -2740,8 +2815,15 @@ export class SingleAgentClient {
         idempotency_key: normalizedPayload.idempotency_key,
         protocol: normalizedPayload.protocol ?? 'mcp',
       };
-      const canonicalResult = this.canonicalizeWebhookCreativeResult(metadata, normalizedPayload.result);
-      const canonicalCreativeTask = CANONICAL_CREATIVE_ACTIVITY_TASKS.has(normalizedPayload.task_type);
+      const canonicalCreativeTask =
+        CANONICAL_CREATIVE_ACTIVITY_TASKS.has(normalizedPayload.task_type) ||
+        (normalizedPayload.task_type === 'preview_creative' &&
+          (previewHandler !== undefined ? previewHandler === 'canonical' : associatedTaskType === 'preview_creative'));
+      const canonicalResult = this.canonicalizeWebhookCreativeResult(
+        metadata,
+        normalizedPayload.result,
+        canonicalCreativeTask
+      );
       const legacyFormatConverter = this.legacyFormatConverterForWebhook(metadata);
       const canonicalEnvelope = canonicalCreativeTask
         ? stripLegacyCreativeIdentity(
@@ -2772,13 +2854,19 @@ export class SingleAgentClient {
           taskType: normalizedPayload.task_type,
           status: normalizedPayload.status,
           message: canonicalMessage,
+          previewHandler,
           timestamp: normalizedPayload.timestamp,
           idempotencyKey: normalizedPayload.idempotency_key,
         },
       };
     } catch (error) {
       const canonicalCreativeTask =
-        normalizedTaskType !== undefined && CANONICAL_CREATIVE_ACTIVITY_TASKS.has(normalizedTaskType);
+        normalizedTaskType !== undefined &&
+        (CANONICAL_CREATIVE_ACTIVITY_TASKS.has(normalizedTaskType) ||
+          (normalizedTaskType === 'preview_creative' &&
+            (previewHandler !== undefined
+              ? previewHandler === 'canonical'
+              : associatedTaskType === 'preview_creative')));
       if (error instanceof WebhookDispatchError) {
         if (!canonicalCreativeTask) {
           return { ok: false, code: error.code, message: error.message };
@@ -2805,6 +2893,26 @@ export class SingleAgentClient {
   }
 
   private async dispatchParsedWebhook(parsed: WebhookParseSuccess): Promise<boolean> {
+    if (parsed.metadata.taskType === 'preview_creative' && parsed.metadata.previewHandler) {
+      for (const key of [parsed.metadata.operationId, parsed.metadata.taskId, parsed.metadata.contextId]) {
+        if (!key) continue;
+        this.rememberPreviewCreativeHandlerKey(key, parsed.metadata.previewHandler);
+        if (parsed.metadata.previewHandler === 'canonical') {
+          this.rememberCanonicalCreativeTaskAssociation(key, 'preview_creative');
+        } else {
+          this.canonicalCreativeTaskAssociations.delete(key);
+        }
+      }
+    }
+    const canonicalCreativeTask =
+      parsed.metadata.taskType === 'preview_creative' && parsed.metadata.previewHandler !== undefined
+        ? parsed.metadata.previewHandler === 'canonical'
+        : this.isCanonicalCreativeWebhook({
+            operation_id: parsed.metadata.operationId,
+            context_id: parsed.metadata.contextId,
+            task_id: parsed.metadata.taskId,
+            task_type: parsed.metadata.taskType,
+          });
     let metadata: WebhookMetadata = {
       operation_id: parsed.metadata.operationId,
       context_id: parsed.metadata.contextId,
@@ -2816,13 +2924,11 @@ export class SingleAgentClient {
       timestamp: parsed.metadata.timestamp || new Date().toISOString(),
       idempotency_key: parsed.metadata.idempotencyKey,
       protocol: parsed.protocol,
-      rawHTTPPayload: CANONICAL_CREATIVE_ACTIVITY_TASKS.has(parsed.metadata.taskType)
-        ? stripLegacyCreativeIdentity(parsed.envelope)
-        : parsed.envelope,
+      rawHTTPPayload: canonicalCreativeTask ? stripLegacyCreativeIdentity(parsed.envelope) : parsed.envelope,
     };
     this.rememberCanonicalCreativeWebhookContext(metadata);
     try {
-      const canonicalResult = this.canonicalizeWebhookCreativeResult(metadata, parsed.result);
+      const canonicalResult = this.canonicalizeWebhookCreativeResult(metadata, parsed.result, canonicalCreativeTask);
       const policyDispatch = await this.applyProductPropertyPolicyToWebhookResult(
         canonicalResult as AdCPAsyncResponseData | undefined,
         metadata
@@ -2849,7 +2955,11 @@ export class SingleAgentClient {
 
       // Handle through async handler if configured
       if (this.asyncHandler) {
-        await this.asyncHandler.handleWebhook({ result: webhookResult, metadata });
+        await this.asyncHandler.handleWebhook({
+          result: webhookResult,
+          metadata,
+          previewHandler: parsed.metadata.previewHandler ?? this.previewCreativeHandlerForWebhook(metadata),
+        });
         return true;
       }
 
@@ -2865,7 +2975,7 @@ export class SingleAgentClient {
   }
 
   private rememberCanonicalCreativeWebhookContext(metadata: WebhookMetadata): void {
-    if (!metadata.context_id || !CANONICAL_CREATIVE_ACTIVITY_TASKS.has(metadata.task_type)) return;
+    if (!metadata.context_id || !this.isCanonicalCreativeWebhook(metadata)) return;
     const association =
       this.canonicalCreativeTaskAssociation(metadata.operation_id) ??
       this.canonicalCreativeTaskAssociation(metadata.task_id) ??
@@ -2877,9 +2987,15 @@ export class SingleAgentClient {
       association.legacyFormatConverter,
       association.routingSnapshot
     );
+    const previewHandler = this.previewCreativeHandlerForWebhook(metadata);
+    if (previewHandler) this.rememberPreviewCreativeHandlerKey(metadata.context_id, previewHandler);
   }
 
-  private canonicalizeWebhookCreativeResult(metadata: WebhookMetadata, result: unknown): unknown {
+  private canonicalizeWebhookCreativeResult(
+    metadata: WebhookMetadata,
+    result: unknown,
+    canonicalCreativeTask = this.isCanonicalCreativeWebhook(metadata)
+  ): unknown {
     if (!result || typeof result !== 'object' || Array.isArray(result)) return result;
     const taskType = metadata.task_type;
     const legacyFormatConverter = this.legacyFormatConverterForWebhook(metadata);
@@ -2905,7 +3021,7 @@ export class SingleAgentClient {
         ),
       });
     }
-    const canonical = CANONICAL_CREATIVE_ACTIVITY_TASKS.has(taskType)
+    const canonical = canonicalCreativeTask
       ? stripLegacyCreativeIdentity(projectCanonicalCreativeResponseValue(result, taskType, legacyFormatConverter))
       : result;
     const association =
@@ -3270,12 +3386,14 @@ export class SingleAgentClient {
     canonicalRequest?: unknown
   ): Promise<TaskResult<T>> {
     throwIfAborted(options?.signal);
+    const canonicalCreativeInvocation =
+      CANONICAL_CREATIVE_ACTIVITY_TASKS.has(taskType) || canonicalRequest !== undefined;
     // Normalize params for backwards compatibility before validation
     let normalizedParams = normalizeRequestParams(taskType, params, {
       skipIdempotencyAutoInject: options?.skipIdempotencyAutoInject,
       skipAccountValidation: options?.skipAccountValidation,
     });
-    this.assertRequestSupportedByConfiguredVersion(taskType, normalizedParams, options);
+    this.assertRequestSupportedByConfiguredVersion(taskType, normalizedParams, options, canonicalCreativeInvocation);
 
     // Inject an idempotency_key for mutating tools before schema validation
     // so callers don't have to supply one. TaskExecutor also guards against
@@ -3347,7 +3465,13 @@ export class SingleAgentClient {
     };
     const serverVersion = await this.detectServerVersion(detectionOptions);
     throwIfAborted(options?.signal);
-    this.assertRequestSupportedByTargetVersion(taskType, normalizedParams, capabilityDiscoveryContext.capabilities);
+    this.assertRequestSupportedByTargetVersion(
+      taskType,
+      normalizedParams,
+      capabilityDiscoveryContext.capabilities,
+      canonicalCreativeInvocation,
+      serverVersion
+    );
     const { options: effectiveOptions, driftLog: webhookDriftLog } = this.suppressPre31DiscoveryWebhook(
       taskType,
       options,
@@ -3375,9 +3499,18 @@ export class SingleAgentClient {
       this.executor.validateAdaptedRequestAgainstV2(taskType, adaptedParams, v25DriftLogs);
     }
 
-    const canonicalInputHandler = this.canonicalCreativeInputHandler(taskType, inputHandler);
+    const canonicalInputHandler = this.canonicalCreativeInputHandler(
+      taskType,
+      inputHandler,
+      canonicalCreativeInvocation
+    );
     let result = await canonicalCreativeExecutionStorage.run(
-      { taskType, legacyFormatConverter, canonicalRequest: canonicalRequest ?? normalizedParams },
+      {
+        taskType,
+        canonical: canonicalCreativeInvocation,
+        legacyFormatConverter,
+        canonicalRequest: canonicalRequest ?? normalizedParams,
+      },
       () =>
         this.executor.executeTask<T>(
           agent,
@@ -3415,7 +3548,7 @@ export class SingleAgentClient {
     result = await this.applyProductPropertyPolicy(result, taskType, normalizedParams);
     throwIfAborted(effectiveOptions?.signal);
 
-    if (CANONICAL_CREATIVE_ACTIVITY_TASKS.has(taskType)) {
+    if (canonicalCreativeInvocation) {
       // The full canonical request is needed only while the protocol activity
       // callback runs above. Async/terminal state retains a frozen routing-only
       // projection so creative assets and webhook credentials are not pinned.
@@ -3433,6 +3566,7 @@ export class SingleAgentClient {
       result = { ...result, data: transformCompletedResponse(result.data) };
     }
 
+    this.rememberPreviewCreativeHandler(result, taskType, handlerName, effectiveOptions);
     await this.notifyCompletedStatusHandler(result, taskType, handlerName, effectiveOptions);
 
     return result;
@@ -3462,8 +3596,12 @@ export class SingleAgentClient {
     throwIfAborted(options?.signal);
   }
 
-  private canonicalCreativeInputHandler(taskType: string, inputHandler?: InputHandler): InputHandler | undefined {
-    if (!inputHandler || !CANONICAL_CREATIVE_ACTIVITY_TASKS.has(taskType)) return inputHandler;
+  private canonicalCreativeInputHandler(
+    taskType: string,
+    inputHandler?: InputHandler,
+    canonical = CANONICAL_CREATIVE_ACTIVITY_TASKS.has(taskType)
+  ): InputHandler | undefined {
+    if (!inputHandler || !canonical) return inputHandler;
     return async context => {
       const active = canonicalCreativeExecutionStorage.getStore();
       const converter = this.resolveLegacyFormatConverter(
@@ -3643,7 +3781,7 @@ export class SingleAgentClient {
           ...submitted,
           track: async transport => {
             const canonical = this.canonicalizeCreativeTaskInfo<T>(
-              await canonicalCreativeExecutionStorage.run({ taskType, legacyFormatConverter }, () =>
+              await canonicalCreativeExecutionStorage.run({ taskType, canonical: true, legacyFormatConverter }, () =>
                 submitted.track(transport)
               ),
               taskType,
@@ -3656,8 +3794,9 @@ export class SingleAgentClient {
             return canonical;
           },
           waitForCompletion: async (pollInterval, signal) => {
-            const completed = await canonicalCreativeExecutionStorage.run({ taskType, legacyFormatConverter }, () =>
-              submitted.waitForCompletion(pollInterval, signal)
+            const completed = await canonicalCreativeExecutionStorage.run(
+              { taskType, canonical: true, legacyFormatConverter },
+              () => submitted.waitForCompletion(pollInterval, signal)
             );
             const canonical = this.canonicalizeCreativeTaskResult(
               completed,
@@ -3687,8 +3826,9 @@ export class SingleAgentClient {
         deferred: {
           ...deferred,
           resume: async input => {
-            const resumed = await canonicalCreativeExecutionStorage.run({ taskType, legacyFormatConverter }, () =>
-              deferred.resume(input)
+            const resumed = await canonicalCreativeExecutionStorage.run(
+              { taskType, canonical: true, legacyFormatConverter },
+              () => deferred.resume(input)
             );
             const canonical = this.canonicalizeCreativeTaskResult(resumed, taskType, transform, legacyFormatConverter);
             if (canonical.success && canonical.status === 'completed' && canonical.data !== undefined) {
@@ -3726,6 +3866,66 @@ export class SingleAgentClient {
       if (!key) continue;
       this.rememberCanonicalCreativeTaskAssociation(key, taskType, legacyFormatConverter, routingSnapshot);
     }
+  }
+
+  private rememberPreviewCreativeHandler<T>(
+    result: TaskResult<T>,
+    taskType: string,
+    handlerName: keyof AsyncHandlerConfig,
+    options?: TaskOptions
+  ): void {
+    if (taskType !== 'preview_creative') return;
+    const handler = handlerName === 'onPreviewCreativeLegacyStatusChange' ? 'legacy' : 'canonical';
+    const metadata = result.metadata as typeof result.metadata & { operationId?: string };
+    const keys = [
+      metadata.operationId,
+      metadata.taskId,
+      metadata.contextId,
+      metadata.serverTaskId,
+      result.submitted?.taskId,
+      options?.taskId,
+      options?.contextId,
+    ];
+    for (const key of keys) {
+      if (!key) continue;
+      this.rememberPreviewCreativeHandlerKey(key, handler);
+      if (handler === 'legacy') this.canonicalCreativeTaskAssociations.delete(key);
+    }
+  }
+
+  private rememberPreviewCreativeHandlerKey(key: string, handler: 'canonical' | 'legacy'): void {
+    this.previewCreativeHandlersByTask.delete(key);
+    this.previewCreativeHandlersByTask.set(key, handler);
+    while (this.previewCreativeHandlersByTask.size > TASK_SCOPED_STATE_LIMIT) {
+      const oldest = this.previewCreativeHandlersByTask.keys().next().value;
+      if (oldest === undefined) break;
+      this.previewCreativeHandlersByTask.delete(oldest);
+    }
+  }
+
+  private previewCreativeHandlerForWebhook(
+    metadata: Pick<WebhookMetadata, 'operation_id' | 'task_id' | 'context_id' | 'task_type'>
+  ): 'canonical' | 'legacy' | undefined {
+    if (metadata.task_type !== 'preview_creative') return undefined;
+    for (const key of [metadata.operation_id, metadata.task_id, metadata.context_id]) {
+      if (!key) continue;
+      const handler = this.previewCreativeHandlersByTask.get(key);
+      if (!handler) continue;
+      this.previewCreativeHandlersByTask.delete(key);
+      this.previewCreativeHandlersByTask.set(key, handler);
+      return handler;
+    }
+    return undefined;
+  }
+
+  private isCanonicalCreativeWebhook(
+    metadata: Pick<WebhookMetadata, 'operation_id' | 'task_id' | 'context_id' | 'task_type'>
+  ): boolean {
+    if (CANONICAL_CREATIVE_ACTIVITY_TASKS.has(metadata.task_type)) return true;
+    if (metadata.task_type !== 'preview_creative') return false;
+    return [metadata.operation_id, metadata.task_id, metadata.context_id].some(
+      key => this.canonicalCreativeTaskAssociation(key) !== undefined
+    );
   }
 
   private rememberCanonicalCreativeTaskAssociation(
@@ -5074,14 +5274,39 @@ export class SingleAgentClient {
     return this.executeTaskUnprojected<ListCreativesResponse>('list_creatives', params, inputHandler, options);
   }
 
-  /**
-   * Preview a creative through the legacy named-format protocol.
-   *
-   * @param params - Preview creative parameters
-   * @param inputHandler - Handler for clarification requests
-   * @param options - Task execution options
-   * @deprecated Migration-only access to `format_id`-based creative preview.
-   */
+  /** Preview a creative using canonical capability or creative-library identity. */
+  async previewCreative(
+    params: CanonicalPreviewCreativeRequest,
+    inputHandler?: InputHandler,
+    options?: TaskOptions
+  ): Promise<TaskResult<CanonicalPreviewCreativeResponse>> {
+    const legacyPath = legacyCreativeIdentityPath(params);
+    if (legacyPath) {
+      const suggestion = 'Move this request to previewCreativeLegacy(), or replace format_id with canonical identity.';
+      throw new ProtocolFeatureUnsupportedError(['preview_creative.canonical_identity'], [], this.agent.agent_uri, {
+        message: `previewCreative() does not accept legacy creative identity at ${legacyPath}. ${suggestion}`,
+        field: legacyPath,
+        suggestion,
+        details: {
+          feature: 'preview_creative.canonical_identity',
+          tool: 'preview_creative',
+          field: legacyPath,
+        },
+      });
+    }
+    return this.executeAndHandle<CanonicalPreviewCreativeResponse>(
+      'preview_creative',
+      'onPreviewCreativeStatusChange',
+      params,
+      inputHandler,
+      options,
+      undefined,
+      undefined,
+      params
+    );
+  }
+
+  /** @deprecated Migration-only access to `format_id`-based creative preview. */
   async previewCreativeLegacy(
     params: PreviewCreativeRequest,
     inputHandler?: InputHandler,
@@ -5966,7 +6191,7 @@ export class SingleAgentClient {
     const { taskType: creativeTaskType } = creativeAssociation;
     const legacyFormatConverter = this.resolveLegacyFormatConverter(creativeAssociation.legacyFormatConverter);
     const result = await canonicalCreativeExecutionStorage.run(
-      { taskType: creativeTaskType, legacyFormatConverter },
+      { taskType: creativeTaskType, canonical: true, legacyFormatConverter },
       () =>
         this.executor.executeTask<T>(
           agent,
@@ -7030,7 +7255,19 @@ export class SingleAgentClient {
    * result set. A pre-3.1 client pin should not silently drop those controls
    * or let a generic schema error hide the recovery path.
    */
-  private assertRequestSupportedByConfiguredVersion(taskName: string, params: unknown, _options?: TaskOptions): void {
+  private assertRequestSupportedByConfiguredVersion(
+    taskName: string,
+    params: unknown,
+    _options?: TaskOptions,
+    canonicalCreativeInvocation = false
+  ): void {
+    if (
+      taskName === 'preview_creative' &&
+      canonicalCreativeInvocation &&
+      isPre32AdcpVersion(this.config.wireAdcpVersion ?? this.resolvedAdcpVersion)
+    ) {
+      this.throwCanonicalPreviewUnsupported(this.config.wireAdcpVersion ?? this.resolvedAdcpVersion);
+    }
     if (!isPre31AdcpVersion(this.resolvedAdcpVersion)) return;
     const request =
       params && typeof params === 'object' && !Array.isArray(params) ? (params as Record<string, unknown>) : {};
@@ -7117,8 +7354,29 @@ export class SingleAgentClient {
   private assertRequestSupportedByTargetVersion(
     taskName: string,
     params: unknown,
-    capabilities: AdcpCapabilities | undefined
+    capabilities: AdcpCapabilities | undefined,
+    canonicalCreativeInvocation = false,
+    serverVersion?: 'v2' | 'v3'
   ): void {
+    if (taskName === 'preview_creative' && canonicalCreativeInvocation) {
+      const advertisedVersions = capabilities?.supportedVersions ?? [];
+      const responseVersion =
+        typeof capabilities?._raw?.adcp_version === 'string' ? capabilities._raw.adcp_version : undefined;
+      const supports32 =
+        advertisedVersions.some(version => !isPre32AdcpVersion(version)) ||
+        (advertisedVersions.length === 0 && responseVersion !== undefined && !isPre32AdcpVersion(responseVersion));
+      const hasAuthoritativeLegacyEvidence =
+        serverVersion === 'v2' ||
+        advertisedVersions.length > 0 ||
+        responseVersion !== undefined ||
+        (capabilities?._synthetic === false && capabilities?.version === 'v3');
+      if (!supports32 && hasAuthoritativeLegacyEvidence) {
+        this.throwCanonicalPreviewUnsupported(
+          advertisedVersions.join(', ') || responseVersion || serverVersion || capabilities?.version || 'unknown',
+          'the target seller does not advertise AdCP 3.2 support'
+        );
+      }
+    }
     if (isPre31AdcpVersion(this.resolvedAdcpVersion)) return;
     // supportedVersions is the authoritative negotiation field. Legacy 3.0
     // sellers omit it; buildVersion is advisory and must not select a newer
@@ -7167,6 +7425,26 @@ export class SingleAgentClient {
         current_version: currentVersion,
         tool: taskName,
         field,
+      },
+    });
+  }
+
+  private throwCanonicalPreviewUnsupported(currentVersion: string, incompatibility?: string): never {
+    const suggestion =
+      'Use previewCreativeLegacy() for format_id-based sellers, or negotiate AdCP 3.2 before calling previewCreative().';
+    throw new ProtocolFeatureUnsupportedError(['preview_creative.canonical_identity'], [], this.agent.agent_uri, {
+      message:
+        `preview_creative canonical identity requires AdCP 3.2 or later; ` +
+        `${incompatibility ?? `this client is pinned to ${currentVersion}`}. ${suggestion}`,
+      field: 'target_capability_id',
+      suggestion,
+      details: {
+        feature: 'preview_creative.canonical_identity',
+        required_version: '3.2',
+        capability_path: 'adcp.supported_versions',
+        current_version: currentVersion,
+        tool: 'preview_creative',
+        field: 'target_capability_id',
       },
     });
   }

--- a/src/lib/core/webhook-registration.ts
+++ b/src/lib/core/webhook-registration.ts
@@ -19,6 +19,8 @@ export interface WebhookRegistration {
   callbackUrl: string;
   method: 'POST';
   mode: WebhookAuthenticationMode;
+  /** Originating preview API, persisted so async routing survives races and restarts. */
+  previewMode?: 'canonical' | 'legacy';
   /** Epoch milliseconds. */
   createdAt: number;
   /** Epoch milliseconds. */
@@ -117,6 +119,9 @@ function validateRegistration(registration: WebhookRegistration): void {
   ) {
     throw new TypeError('Webhook registration identifiers cannot contain NUL characters.');
   }
+  if (registration.previewMode !== undefined && !['canonical', 'legacy'].includes(registration.previewMode)) {
+    throw new TypeError('Webhook registration previewMode must be canonical or legacy.');
+  }
   const callback = new URL(registration.callbackUrl);
   if (callback.username || callback.password || callback.hash) {
     throw new TypeError('Webhook callbackUrl cannot contain userinfo or a fragment.');
@@ -138,6 +143,7 @@ function sameRegistration(a: Readonly<WebhookRegistration>, b: WebhookRegistrati
     a.taskType === b.taskType &&
     a.callbackUrl === b.callbackUrl &&
     a.method === b.method &&
-    a.mode === b.mode
+    a.mode === b.mode &&
+    a.previewMode === b.previewMode
   );
 }

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -999,16 +999,10 @@ export type FormatID = never;
 export type BuildCreativeRequest = never;
 /** @deprecated Use `LegacyBuildCreativeResponse`. */
 export type BuildCreativeResponse = never;
-/** @deprecated Use `LegacyPreviewCreativeRequest`. */
-export type PreviewCreativeRequest = never;
-/** @deprecated Use `LegacyPreviewCreativeResponse`. */
-export type PreviewCreativeResponse = never;
 /** @deprecated Use `LegacyBuildCreativePayload`. */
 export type BuildCreativePayload = never;
 /** @deprecated Use `LegacyBuildCreativeMultiPayload`. */
 export type BuildCreativeMultiPayload = never;
-/** @deprecated Use `LegacyPreviewCreativePayload`. */
-export type PreviewCreativePayload = never;
 /** @deprecated Use `LegacyListCreativeFormatsRequest`. */
 export type ListCreativeFormatsRequest = never;
 /** @deprecated Use `LegacyListCreativeFormatsResponse`. */
@@ -1317,6 +1311,8 @@ export type {
   GetMediaBuyDeliveryPayload,
   ListCreativesPayload,
   GetCreativeDeliveryPayload,
+  CanonicalPreviewCreativePayload,
+  PreviewCreativePayload,
   LegacyGetProductsPayload,
   LegacyCreateMediaBuyPayload,
   LegacyUpdateMediaBuyPayload,
@@ -1723,6 +1719,10 @@ export {
   type CanonicalPackage as Package,
   type CanonicalPlacement,
   type CanonicalPlacement as Placement,
+  type CanonicalPreviewCreativeRequest,
+  type CanonicalPreviewCreativeRequest as PreviewCreativeRequest,
+  type CanonicalPreviewCreativeResponse,
+  type CanonicalPreviewCreativeResponse as PreviewCreativeResponse,
   type CanonicalProduct,
   type CanonicalProduct as Product,
   type CanonicalProjectedCreative,

--- a/src/lib/server/decisioning/decisioning.type-checks.ts
+++ b/src/lib/server/decisioning/decisioning.type-checks.ts
@@ -882,6 +882,36 @@ function _preview_creative_requires_account_narrow(): void {
   });
 }
 
+// Canonical preview is the primary platform hook and excludes legacy
+// named-format identity while retaining both protocol 3.2 lookup modes.
+function _preview_creative_accepts_canonical_routes(): void {
+  defineCreativeBuilderPlatform({
+    buildCreativeLegacy: async () => ({}) as never,
+    previewCreative: async req => {
+      const _capability: string | undefined = req.target_capability_id;
+      const _creative: string | undefined = req.creative_id;
+      void _capability;
+      void _creative;
+      return {} as PreviewCreativeResponse;
+    },
+  });
+}
+
+function _ad_server_accepts_canonical_preview(): void {
+  defineCreativeAdServerPlatform<{ workspace_id: string }>({
+    buildCreativeLegacy: async () => ({}) as never,
+    previewCreative: async (_req, ctx) => {
+      if (ctx.account != null) {
+        const _workspace: string = ctx.account.ctx_metadata.workspace_id;
+        void _workspace;
+      }
+      return {} as PreviewCreativeResponse;
+    },
+    listCreatives: async () => ({}) as CanonicalListCreativesResponse,
+    getCreativeDelivery: async () => ({}) as GetCreativeDeliveryResponse,
+  });
+}
+
 // Reading `ctx.account.ctx_metadata` without a narrow MUST fail typecheck
 // — this is the regression alarm guarding the no-account contract.
 function _preview_creative_rejects_unnarrowed_access(): void {

--- a/src/lib/server/decisioning/index.ts
+++ b/src/lib/server/decisioning/index.ts
@@ -177,6 +177,7 @@ export type {
   LegacyBuildCreativeReturn,
   LegacyBuildCreativePayload,
   LegacyBuildCreativeMultiPayload,
+  PreviewCreativePayload,
   LegacyPreviewCreativePayload,
   LegacyListCreativeFormatsPayload,
   // Deprecated aliases — kept for one-release source compat. Both
@@ -192,6 +193,7 @@ export type {
   LegacyBuildCreativeReturn as CreativeAdServerLegacyBuildCreativeReturn,
   LegacyBuildCreativePayload as CreativeAdServerLegacyBuildCreativePayload,
   LegacyBuildCreativeMultiPayload as CreativeAdServerLegacyBuildCreativeMultiPayload,
+  PreviewCreativePayload as CreativeAdServerPreviewCreativePayload,
   LegacyPreviewCreativePayload as CreativeAdServerLegacyPreviewCreativePayload,
   LegacyListCreativeFormatsPayload as CreativeAdServerLegacyListCreativeFormatsPayload,
   ListCreativesPayload as CreativeAdServerListCreativesPayload,

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -85,6 +85,7 @@ import { suggestBilling } from '../buyer-agent';
 import { AdcpError, type AdcpStructuredError } from '../async-outcome';
 import type { CreativeBuilderPlatform } from '../specialisms/creative';
 import type { CreativeAdServerPlatform } from '../specialisms/creative-ad-server';
+import type { CanonicalPreviewCreativeRequest } from '../../../v2/projection/creative-delivery';
 import type { Audience } from '../specialisms/audiences';
 import type { RequestContext } from '../context';
 import {
@@ -6211,19 +6212,37 @@ function buildCreativeHandlers<P extends DecisioningPlatform<any, any>>(
     },
 
     previewCreative: async (params, ctx) => {
-      if (
-        !('previewCreativeLegacy' in creative) ||
-        (creative as CreativeBuilderPlatform).previewCreativeLegacy == null
-      ) {
+      const canonicalHandler =
+        'previewCreative' in creative ? (creative as CreativeBuilderPlatform).previewCreative : undefined;
+      const legacyHandler =
+        'previewCreativeLegacy' in creative ? (creative as CreativeBuilderPlatform).previewCreativeLegacy : undefined;
+      const usesLegacyFormatId =
+        params.format_id != null ||
+        (Array.isArray(params.requests) && params.requests.some(request => request.format_id != null));
+
+      if (usesLegacyFormatId && legacyHandler == null) {
         return adcpError('UNSUPPORTED_FEATURE', {
           message:
-            'preview_creative: this creative platform did not implement previewCreativeLegacy. ' +
-            'Add `previewCreativeLegacy(req, ctx)` to your CreativeBuilderPlatform / CreativeAdServerPlatform literal.',
+            'preview_creative: this creative platform does not support legacy format_id preview requests. ' +
+            'Use target_capability_id, creative_id, or creative_manifest with the canonical previewCreative handler.',
+        });
+      }
+      if (canonicalHandler == null && legacyHandler == null) {
+        return adcpError('UNSUPPORTED_FEATURE', {
+          message:
+            'preview_creative: this creative platform did not implement previewCreative. ' +
+            'Add `previewCreative(req, ctx)` to your CreativeBuilderPlatform / CreativeAdServerPlatform literal.',
         });
       }
       const reqCtx = ctxFor(ctx, params);
+      if (usesLegacyFormatId || canonicalHandler == null) {
+        return projectSync(
+          () => legacyHandler!(params, reqCtx),
+          preview => preview
+        );
+      }
       return projectSync(
-        () => (creative as CreativeBuilderPlatform).previewCreativeLegacy!(params, reqCtx),
+        () => canonicalHandler(params as CanonicalPreviewCreativeRequest, reqCtx),
         preview => preview
       );
     },

--- a/src/lib/server/decisioning/specialisms/creative-ad-server.ts
+++ b/src/lib/server/decisioning/specialisms/creative-ad-server.ts
@@ -31,8 +31,8 @@ import type { ServerPayload } from '../../../types/server-payload';
 import type {
   BuildCreativeRequest,
   CreativeManifest,
-  PreviewCreativeRequest,
-  PreviewCreativeResponse,
+  PreviewCreativeRequest as LegacyPreviewCreativeRequest,
+  PreviewCreativeResponse as LegacyPreviewCreativeResponse,
   ListCreativesRequest,
   ListCreativesResponse,
   ListCreativeFormatsRequest,
@@ -47,13 +47,16 @@ import type {
   CanonicalCreativeResponse,
   CanonicalListCreativesRequest,
   CanonicalListCreativesResponse,
+  CanonicalPreviewCreativeRequest,
+  CanonicalPreviewCreativeResponse,
 } from '../../../v2/projection/creative-delivery';
 import type { SyncCreativesRow } from './sales';
 
 type SyncCreative = CanonicalSyncCreativeAsset;
 type Ctx<TCtxMeta> = RequestContext<Account<TCtxMeta>>;
 
-export type LegacyPreviewCreativePayload = ServerPayload<PreviewCreativeResponse>;
+export type PreviewCreativePayload = ServerPayload<CanonicalPreviewCreativeResponse>;
+export type LegacyPreviewCreativePayload = ServerPayload<LegacyPreviewCreativeResponse>;
 export type LegacyListCreativeFormatsPayload = ServerPayload<ListCreativeFormatsResponse>;
 export type ListCreativesPayload = ServerPayload<CanonicalListCreativesResponse>;
 export type GetCreativeDeliveryPayload = ServerPayload<CanonicalCreativeResponse<GetCreativeDeliveryResponse>>;
@@ -66,7 +69,7 @@ export type LegacyBuildCreativeReturn =
   | LegacyBuildCreativePayload
   | LegacyBuildCreativeMultiPayload;
 
-export interface CreativeAdServerPlatform<TCtxMeta = Record<string, unknown>> {
+interface CreativeAdServerPlatformBase<TCtxMeta> {
   /**
    * Build / retrieve creative tags. Two invocation modes per the spec:
    *
@@ -88,18 +91,6 @@ export interface CreativeAdServerPlatform<TCtxMeta = Record<string, unknown>> {
    * changes flow via `publishStatusChange`.
    */
   buildCreativeLegacy(req: BuildCreativeRequest, ctx: Ctx<TCtxMeta>): Promise<LegacyBuildCreativeReturn>;
-
-  /**
-   * Preview-only variant — sandbox URL or inline HTML, expires. Always sync.
-   *
-   * ⚠️  NO-ACCOUNT TOOL — `ctx: NoAccountCtx<TCtxMeta>`. The wire request
-   * does not carry an `account` field; narrow `ctx.account` before reading
-   * `ctx_metadata` / `id`. See {@link NoAccountCtx}.
-   */
-  previewCreativeLegacy(
-    req: PreviewCreativeRequest,
-    ctx: NoAccountCtx<TCtxMeta>
-  ): Promise<LegacyPreviewCreativePayload>;
 
   /**
    * Format catalog. Optional because adopters who delegate format definitions
@@ -156,3 +147,29 @@ export interface CreativeAdServerPlatform<TCtxMeta = Record<string, unknown>> {
    */
   getCreativeDelivery(filter: GetCreativeDeliveryRequest, ctx: Ctx<TCtxMeta>): Promise<GetCreativeDeliveryPayload>;
 }
+
+type CreativeAdServerPreview<TCtxMeta> =
+  | {
+      /** Canonical preview through an advertised capability or stored creative. */
+      previewCreative(
+        req: CanonicalPreviewCreativeRequest,
+        ctx: NoAccountCtx<TCtxMeta>
+      ): Promise<PreviewCreativePayload>;
+      /** @deprecated Migration-only alias for requests using legacy `format_id`. */
+      previewCreativeLegacy?(
+        req: LegacyPreviewCreativeRequest,
+        ctx: NoAccountCtx<TCtxMeta>
+      ): Promise<LegacyPreviewCreativePayload>;
+    }
+  | {
+      previewCreative?: never;
+      /** @deprecated Implement canonical `previewCreative` for new integrations. */
+      previewCreativeLegacy(
+        req: LegacyPreviewCreativeRequest,
+        ctx: NoAccountCtx<TCtxMeta>
+      ): Promise<LegacyPreviewCreativePayload>;
+    };
+
+/** Stateful creative-ad-server platform with canonical preview and a legacy-compatible alias. */
+export type CreativeAdServerPlatform<TCtxMeta = Record<string, unknown>> = CreativeAdServerPlatformBase<TCtxMeta> &
+  CreativeAdServerPreview<TCtxMeta>;

--- a/src/lib/server/decisioning/specialisms/creative.ts
+++ b/src/lib/server/decisioning/specialisms/creative.ts
@@ -24,12 +24,16 @@ import type {
   BuildCreativeRequest,
   BuildCreativeSuccess,
   BuildCreativeMultiSuccess,
-  PreviewCreativeRequest,
-  PreviewCreativeResponse,
+  PreviewCreativeRequest as LegacyPreviewCreativeRequest,
+  PreviewCreativeResponse as LegacyPreviewCreativeResponse,
   ListCreativeFormatsRequest,
   ListCreativeFormatsResponse,
 } from '../../../types/tools.generated';
-import type { CanonicalSyncCreativeAsset } from '../../../v2/projection/creative-delivery';
+import type {
+  CanonicalPreviewCreativeRequest,
+  CanonicalPreviewCreativeResponse,
+  CanonicalSyncCreativeAsset,
+} from '../../../v2/projection/creative-delivery';
 import type { SyncCreativesRow } from './sales';
 
 type SyncCreative = CanonicalSyncCreativeAsset;
@@ -37,7 +41,8 @@ type Ctx<TCtxMeta> = RequestContext<Account<TCtxMeta>>;
 
 export type LegacyBuildCreativePayload = ServerPayload<BuildCreativeSuccess>;
 export type LegacyBuildCreativeMultiPayload = ServerPayload<BuildCreativeMultiSuccess>;
-export type LegacyPreviewCreativePayload = ServerPayload<PreviewCreativeResponse>;
+export type PreviewCreativePayload = ServerPayload<CanonicalPreviewCreativeResponse>;
+export type LegacyPreviewCreativePayload = ServerPayload<LegacyPreviewCreativeResponse>;
 export type LegacyListCreativeFormatsPayload = ServerPayload<ListCreativeFormatsResponse>;
 
 /**
@@ -138,8 +143,11 @@ export interface CreativeBuilderPlatform<TCtxMeta = Record<string, unknown>> {
    * when `accounts.resolve(undefined)` returned null. Narrow before reading
    * `ctx.account.ctx_metadata`. See {@link NoAccountCtx}.
    */
+  previewCreative?(req: CanonicalPreviewCreativeRequest, ctx: NoAccountCtx<TCtxMeta>): Promise<PreviewCreativePayload>;
+
+  /** @deprecated Migration-only alias for requests using legacy `format_id`. */
   previewCreativeLegacy?(
-    req: PreviewCreativeRequest,
+    req: LegacyPreviewCreativeRequest,
     ctx: NoAccountCtx<TCtxMeta>
   ): Promise<LegacyPreviewCreativePayload>;
 

--- a/src/lib/server/index.ts
+++ b/src/lib/server/index.ts
@@ -86,6 +86,7 @@ export type {
   ListCreativesPayload as LegacyListCreativesPayload,
   ListPropertyListsPayload,
   LogEventPayload,
+  CanonicalPreviewCreativePayload,
   PreviewCreativePayload as LegacyPreviewCreativePayload,
   ProvidePerformanceFeedbackPayload,
   ReportPlanOutcomePayload,

--- a/src/lib/types/server-payload-aliases.ts
+++ b/src/lib/types/server-payload-aliases.ts
@@ -79,6 +79,7 @@ import type {
   UpdateRightsSuccess,
 } from './core.generated';
 import type { RequireCacheScopeWhenProducts, ServerPayload } from './server-payload';
+import type { CanonicalCreativeResponse } from '../v2/projection/creative-delivery';
 
 type ExclusivePayload<TLeft, TRight> =
   | (TLeft & { [K in Exclude<keyof TRight, keyof TLeft>]?: never })
@@ -128,6 +129,8 @@ export type SyncAudiencesPayload = ServerPayload<SyncAudiencesSuccess>;
 
 export type BuildCreativePayload = ServerPayload<BuildCreativeSuccess>;
 export type BuildCreativeMultiPayload = ServerPayload<BuildCreativeMultiSuccess>;
+export type CanonicalPreviewCreativePayload = ServerPayload<CanonicalCreativeResponse<PreviewCreativeResponse>>;
+/** @deprecated Use `CanonicalPreviewCreativePayload` for canonical preview handlers. */
 export type PreviewCreativePayload = ServerPayload<PreviewCreativeResponse>;
 export type GetCreativeDeliveryPayload = ServerPayload<GetCreativeDeliveryResponse>;
 

--- a/src/lib/utils/adcp-version-config.ts
+++ b/src/lib/utils/adcp-version-config.ts
@@ -133,6 +133,25 @@ export function isPre31AdcpVersion(version: string | undefined): boolean {
   return Number.isFinite(minor) && minor < 1;
 }
 
+/** Whether a release pin predates the canonical creative identity surface in AdCP 3.2. */
+export function isPre32AdcpVersion(version: string | undefined): boolean {
+  if (version === undefined) return false;
+  const trimmed = version.trim();
+  if (trimmed.length === 0) return false;
+
+  const withoutLegacyPrefix = trimmed.startsWith('v') ? trimmed.slice(1) : trimmed;
+  const match = /^(\d+)(?:\.(\d+))?/.exec(withoutLegacyPrefix);
+  if (!match?.[1]) return false;
+
+  const major = Number.parseInt(match[1], 10);
+  if (!Number.isFinite(major)) return false;
+  if (major < 3) return true;
+  if (major > 3) return false;
+
+  const minor = match[2] === undefined ? 0 : Number.parseInt(match[2], 10);
+  return Number.isFinite(minor) && minor < 2;
+}
+
 /**
  * Does the seller authoritatively advertise AdCP 3.1+ support?
  *

--- a/src/lib/v2/projection/creative-delivery.ts
+++ b/src/lib/v2/projection/creative-delivery.ts
@@ -15,6 +15,8 @@ import type {
   PackageUpdate,
   Package,
   Placement,
+  PreviewCreativeRequest,
+  PreviewCreativeResponse,
   Product,
   SyncCreativesRequest,
   SyncCreativesResponse,
@@ -142,6 +144,80 @@ export type CanonicalSyncCreativesResponse = CanonicalCreativeResponse<SyncCreat
 export type CanonicalGetMediaBuysResponse = CanonicalCreativeResponse<GetMediaBuysResponse>;
 export type CanonicalGetMediaBuyDeliveryResponse = CanonicalCreativeResponse<GetMediaBuyDeliveryResponse>;
 export type CanonicalGetCreativeDeliveryResponse = CanonicalCreativeResponse<GetCreativeDeliveryResponse>;
+
+type PreviewInput = NonNullable<PreviewCreativeRequest['inputs']>[number];
+type PreviewBatchItem = NonNullable<PreviewCreativeRequest['requests']>[number];
+
+type CanonicalPreviewRenderOptions = {
+  inputs?: CanonicalCreativeResponse<PreviewInput>[];
+  template_id?: PreviewCreativeRequest['template_id'];
+  quality?: PreviewCreativeRequest['quality'];
+  output_format?: PreviewCreativeRequest['output_format'];
+  item_limit?: PreviewCreativeRequest['item_limit'];
+};
+
+type CanonicalPreviewSource =
+  | {
+      creative_manifest: CanonicalCreativeResponse<NonNullable<PreviewCreativeRequest['creative_manifest']>>;
+      creative_id?: never;
+    }
+  | {
+      creative_id: NonNullable<PreviewCreativeRequest['creative_id']>;
+      creative_manifest?: never;
+    };
+
+type CanonicalPreviewBatchSource =
+  | {
+      creative_manifest: CanonicalCreativeResponse<NonNullable<PreviewBatchItem['creative_manifest']>>;
+      creative_id?: never;
+    }
+  | {
+      creative_id: NonNullable<PreviewBatchItem['creative_id']>;
+      creative_manifest?: never;
+    };
+
+type CanonicalPreviewCreativeBatchItem = CanonicalPreviewRenderOptions &
+  CanonicalPreviewBatchSource & {
+    target_capability_id?: PreviewBatchItem['target_capability_id'];
+    format_id?: never;
+  };
+
+type CanonicalPreviewRequestEnvelope = Pick<PreviewCreativeRequest, 'adcp_version' | 'adcp_major_version'> & {
+  allow_async?: PreviewCreativeRequest['allow_async'];
+  push_notification_config?: PreviewCreativeRequest['push_notification_config'];
+  context?: PreviewCreativeRequest['context'];
+  ext?: PreviewCreativeRequest['ext'];
+  format_id?: never;
+};
+
+/** Primary preview request: a strict canonical union with no named-format identity at any depth. */
+export type CanonicalPreviewCreativeRequest = CanonicalPreviewRequestEnvelope &
+  (
+    | (CanonicalPreviewRenderOptions &
+        CanonicalPreviewSource & {
+          request_type: 'single';
+          target_capability_id?: PreviewCreativeRequest['target_capability_id'];
+          requests?: never;
+          variant_id?: never;
+        })
+    | (CanonicalPreviewRenderOptions & {
+        request_type: 'batch';
+        target_capability_id?: PreviewCreativeRequest['target_capability_id'];
+        requests: CanonicalPreviewCreativeBatchItem[];
+        creative_manifest?: never;
+        creative_id?: never;
+        variant_id?: never;
+      })
+    | {
+        request_type: 'variant';
+        variant_id: NonNullable<PreviewCreativeRequest['variant_id']>;
+        creative_id?: PreviewCreativeRequest['creative_id'];
+        creative_manifest?: never;
+        target_capability_id?: never;
+        requests?: never;
+      }
+  );
+export type CanonicalPreviewCreativeResponse = CanonicalCreativeResponse<PreviewCreativeResponse>;
 
 export type CanonicalCreativeFilters = Omit<CanonicalCreativeResponse<CreativeFilters>, 'format_ids'> & {
   format_ids?: never;

--- a/src/lib/v2/projection/index.ts
+++ b/src/lib/v2/projection/index.ts
@@ -182,6 +182,8 @@ export {
   type CanonicalPackageUpdate,
   type CanonicalPackage,
   type CanonicalPlacement,
+  type CanonicalPreviewCreativeRequest,
+  type CanonicalPreviewCreativeResponse,
   type CanonicalProduct,
   type CanonicalProjectedCreative,
   type CanonicalSyncCreativesRequest,

--- a/src/type-tests/canonical-creative-client.type-test.ts
+++ b/src/type-tests/canonical-creative-client.type-test.ts
@@ -19,6 +19,7 @@ import {
   type CanonicalFormatLegacyResolver,
   type CanonicalGetProductsRequest,
   type CanonicalPackageRequest,
+  type CanonicalPreviewCreativeRequest,
   type CanonicalProduct,
   type CanonicalSyncCreativesRequest,
   type CanonicalUpdateMediaBuyRequest,
@@ -32,6 +33,8 @@ import {
   type LegacyIContentStandardsAdapter,
   type FormatAssetsInput,
   type LegacyPreviewCreativeRequest,
+  type PreviewCreativeRequest,
+  type PreviewCreativeResponse,
   type LegacySyncCreativesRequest,
   type LegacyUpdateMediaBuyRequest,
   type CreativeAgentClient,
@@ -65,6 +68,8 @@ declare const legacyUpdate: MutatingRequestInput<LegacyUpdateMediaBuyRequest>;
 declare const canonicalSync: MutatingRequestInput<CanonicalSyncCreativesRequest>;
 declare const legacySync: MutatingRequestInput<LegacySyncCreativesRequest>;
 declare const previewRequest: LegacyPreviewCreativeRequest;
+declare const canonicalPreviewRequest: CanonicalPreviewCreativeRequest;
+declare const primaryPreviewRequest: PreviewCreativeRequest;
 declare const buildRequest: MutatingRequestInput<LegacyBuildCreativeRequest>;
 declare const standardTaskName: AdcpTaskName;
 declare const standardTaskParams: TaskRequestFor<typeof standardTaskName>;
@@ -316,9 +321,29 @@ SingleAgentClient.discoverCreativeFormatsLegacy('https://creative.example/mcp');
 // @ts-expect-error Legacy creative build has no unqualified primary method.
 agent.buildCreative(buildRequest);
 agent.buildCreativeLegacy(buildRequest);
-// @ts-expect-error Legacy creative preview has no unqualified primary method.
-single.previewCreative(previewRequest);
+single.previewCreative(canonicalPreviewRequest);
+agent.previewCreative(primaryPreviewRequest);
+single.previewCreative({ request_type: 'single', creative_id: 'creative_1' });
+single.previewCreative({
+  request_type: 'single',
+  creative_id: 'creative_versioned',
+  adcp_version: previewRequest.adcp_version,
+  adcp_major_version: previewRequest.adcp_major_version,
+});
+single.previewCreative({ request_type: 'batch', requests: [{ creative_id: 'creative_1' }] });
+single.previewCreative({ request_type: 'variant', variant_id: 'variant_1' });
 single.previewCreativeLegacy(previewRequest);
+// @ts-expect-error Canonical preview requires a discriminated request mode and its required source fields.
+single.previewCreative({});
+// @ts-expect-error Canonical preview excludes legacy named-format routing.
+single.previewCreative({ request_type: 'single', format_id: legacyFormatId });
+single.previewCreative({
+  request_type: 'batch',
+  // @ts-expect-error Canonical preview excludes legacy named-format routing inside batch items.
+  requests: [{ creative_id: 'creative_1', format_id: legacyFormatId }],
+});
+declare const previewResponse: PreviewCreativeResponse;
+void previewResponse;
 // @ts-expect-error Raw legacy build is excluded from primary generic execution.
 agent.executeTask('build_creative', buildRequest);
 // @ts-expect-error Raw legacy preview is excluded from primary generic execution.
@@ -448,8 +473,8 @@ new SingleAgentClient(
   { id: 'legacy-handler-name', name: 'Legacy handler name', agent_uri: 'https://example.test/mcp', protocol: 'mcp' },
   {
     handlers: {
-      // @ts-expect-error Legacy callbacks are explicitly named on the modern handler config.
       onPreviewCreativeStatusChange() {},
+      onPreviewCreativeLegacyStatusChange() {},
     },
   }
 );

--- a/test/lib/adcp-client.test.js
+++ b/test/lib/adcp-client.test.js
@@ -122,7 +122,7 @@ describe('AdCPClient', () => {
       assert.ok(typeof agent.getProducts === 'function');
       assert.ok(typeof agent.listCreativeFormatsLegacy === 'function');
       assert.strictEqual(agent.listCreativeFormats, undefined);
-      assert.strictEqual(agent.previewCreative, undefined);
+      assert.ok(typeof agent.previewCreative === 'function');
       assert.strictEqual(agent.buildCreative, undefined);
       assert.strictEqual(agent.listTransformers, undefined);
       assert.ok(typeof agent.previewCreativeLegacy === 'function');

--- a/test/lib/async-handler.test.js
+++ b/test/lib/async-handler.test.js
@@ -192,6 +192,51 @@ test('explicit legacy handlers receive asynchronous creative and content-standar
   assert.strictEqual(fallbackCalled, false, 'Legacy task-specific handlers should win over the fallback');
 });
 
+test('canonical preview handler takes precedence for asynchronous preview completions', async () => {
+  const received = [];
+  const handler = new AsyncHandler({
+    onPreviewCreativeStatusChange: () => received.push('canonical'),
+    onPreviewCreativeLegacyStatusChange: () => received.push('legacy'),
+  });
+
+  await handler.handleWebhook({
+    result: { response_type: 'single', previews: [] },
+    metadata: {
+      operation_id: 'op_preview',
+      task_id: 'task_preview',
+      agent_id: 'agent_preview',
+      task_type: 'preview_creative',
+      status: 'completed',
+      timestamp: '2026-08-20T12:00:00.000Z',
+    },
+  });
+
+  assert.deepStrictEqual(received, ['canonical']);
+});
+
+test('tracked legacy preview completion preserves the legacy callback identity', async () => {
+  const received = [];
+  const handler = new AsyncHandler({
+    onPreviewCreativeStatusChange: () => received.push('canonical'),
+    onPreviewCreativeLegacyStatusChange: () => received.push('legacy'),
+  });
+
+  await handler.handleWebhook({
+    result: { response_type: 'single', previews: [] },
+    metadata: {
+      operation_id: 'op_preview_legacy',
+      task_id: 'task_preview_legacy',
+      agent_id: 'agent_preview',
+      task_type: 'preview_creative',
+      status: 'completed',
+      timestamp: '2026-08-20T12:00:00.000Z',
+    },
+    previewHandler: 'legacy',
+  });
+
+  assert.deepStrictEqual(received, ['legacy']);
+});
+
 test('onTaskStatusChange fallback handler called for unmapped task type', async () => {
   let fallbackCalled = false;
   let receivedTaskType = null;

--- a/test/lib/preview-creative-client.test.js
+++ b/test/lib/preview-creative-client.test.js
@@ -1,0 +1,481 @@
+const { describe, test } = require('node:test');
+const assert = require('node:assert');
+const { createHmac } = require('node:crypto');
+
+const { AgentClient, InMemoryWebhookRegistrationStore, SingleAgentClient } = require('../../dist/lib/index.js');
+
+const TEST_AGENT = {
+  id: 'preview-client-test',
+  name: 'Preview client test',
+  agent_uri: 'https://creative.example/mcp',
+  protocol: 'mcp',
+};
+const WEBHOOK_SECRET = 'preview-test-secret-with-at-least-32-bytes';
+
+function signedWebhook(payload) {
+  const rawBody = JSON.stringify(payload);
+  const timestamp = Math.floor(Date.now() / 1000).toString();
+  const digest = createHmac('sha256', WEBHOOK_SECRET).update(`${timestamp}.${rawBody}`, 'utf8').digest('hex');
+  return { rawBody, timestamp, signature: `sha256=${digest}` };
+}
+
+function completed(taskName = 'preview_creative') {
+  return {
+    success: true,
+    status: 'completed',
+    data: { response_type: 'single', previews: [] },
+    metadata: { taskName },
+    conversation: [],
+    debug_logs: [],
+  };
+}
+
+function runtimeClient(executeTask, config = {}) {
+  const client = new SingleAgentClient(TEST_AGENT, {
+    validateFeatures: false,
+    validation: { requests: 'off', responses: 'off' },
+    ...config,
+  });
+  client.discoveredEndpoint = TEST_AGENT.agent_uri;
+  client.cachedCapabilities = {
+    version: 'v3',
+    majorVersions: [3],
+    supportedVersions: ['3.2.0-beta.3'],
+    protocols: ['creative'],
+    features: {},
+    extensions: [],
+    _synthetic: false,
+  };
+  client.ensureEndpointDiscovered = async () => TEST_AGENT;
+  client.executor.validateRequest = () => {};
+  client.executor.executeTask = executeTask;
+  return client;
+}
+
+describe('canonical previewCreative clients', () => {
+  const requests = [
+    {
+      request_type: 'single',
+      target_capability_id: 'display.responsive',
+      creative_manifest: { manifest_id: 'mf_inline', assets: [] },
+    },
+    { request_type: 'single', creative_id: 'creative_library_1' },
+  ];
+
+  test('SingleAgentClient dispatches canonical preview requests and callback identity', async () => {
+    const client = new SingleAgentClient(TEST_AGENT, { validateFeatures: false });
+    const calls = [];
+    client.executeAndHandle = async (...args) => {
+      calls.push(args);
+      return completed();
+    };
+
+    for (const request of requests) await client.previewCreative(request);
+
+    assert.deepStrictEqual(
+      calls.map(([taskName, handlerName, params]) => ({ taskName, handlerName, params })),
+      requests.map(params => ({
+        taskName: 'preview_creative',
+        handlerName: 'onPreviewCreativeStatusChange',
+        params,
+      }))
+    );
+  });
+
+  test('AgentClient forwards canonical preview requests through its session-aware client', async () => {
+    const client = new AgentClient(TEST_AGENT, { validateFeatures: false });
+    const calls = [];
+    client.client.previewCreative = async (...args) => {
+      calls.push(args);
+      return completed();
+    };
+
+    for (const request of requests) await client.previewCreative(request);
+
+    assert.deepStrictEqual(
+      calls.map(([params]) => params),
+      requests
+    );
+  });
+
+  test('canonical preview projects variant manifests while the legacy alias stays raw', async () => {
+    const formatId = { id: 'legacy', agent_url: 'https://creative.example/mcp' };
+    const rawResult = {
+      success: true,
+      status: 'completed',
+      data: {
+        response_type: 'variant',
+        manifest: { manifest_id: 'mf_variant', format_id: formatId, assets: [] },
+      },
+      metadata: {
+        taskId: 'preview-task',
+        taskName: 'preview_creative',
+        agent: TEST_AGENT,
+        responseTimeMs: 1,
+        timestamp: '2026-08-20T12:00:00.000Z',
+        clarificationRounds: 0,
+        status: 'completed',
+      },
+      conversation: [],
+      debug_logs: [],
+    };
+    const canonicalCallbacks = [];
+    const canonical = runtimeClient(async () => structuredClone(rawResult), {
+      handlers: { onPreviewCreativeStatusChange: response => canonicalCallbacks.push(response) },
+    });
+
+    const projected = await canonical.previewCreative(requests[0]);
+    assert.strictEqual(projected.data.manifest.format_id, undefined);
+    assert.strictEqual(canonicalCallbacks[0].manifest.format_id, undefined);
+
+    const legacy = runtimeClient(async () => structuredClone(rawResult));
+    const unprojected = await legacy.previewCreativeLegacy({
+      request_type: 'single',
+      creative_id: 'creative_legacy',
+      format_id: formatId,
+    });
+    assert.deepStrictEqual(unprojected.data.manifest.format_id, formatId);
+  });
+
+  test('canonical preview rejects a pre-3.2 client pin with legacy recovery guidance', async () => {
+    const client = new SingleAgentClient(TEST_AGENT, {
+      adcpVersion: '3.1',
+      validateFeatures: false,
+      validation: { requests: 'off', responses: 'off' },
+    });
+
+    await assert.rejects(
+      () => client.previewCreative(requests[0]),
+      error =>
+        error.code === 'UNSUPPORTED_FEATURE' &&
+        error.details.required_version === '3.2' &&
+        /previewCreativeLegacy/.test(error.message)
+    );
+  });
+
+  test('canonical preview rejects legacy identity from untyped callers at any depth', async () => {
+    const client = runtimeClient(async () => completed());
+    const formatId = { id: 'legacy', agent_url: 'https://creative.example/mcp' };
+
+    await assert.rejects(
+      () => client.previewCreative({ request_type: 'single', creative_id: 'creative_1', format_id: formatId }),
+      /previewCreative\(\) does not accept legacy creative identity at \$\.format_id/
+    );
+    await assert.rejects(
+      () =>
+        client.previewCreative({
+          request_type: 'batch',
+          requests: [{ creative_id: 'creative_1', format_id: formatId }],
+        }),
+      /requests\[0\]\.format_id/
+    );
+  });
+
+  test('canonical preview refuses a seller that advertises only AdCP 3.1', async () => {
+    let dispatched = false;
+    const client = runtimeClient(async () => {
+      dispatched = true;
+      return completed();
+    });
+    client.cachedCapabilities.supportedVersions = ['3.1'];
+
+    await assert.rejects(
+      () => client.previewCreative(requests[0]),
+      error => error.code === 'UNSUPPORTED_FEATURE' && error.details.current_version === '3.1'
+    );
+    assert.strictEqual(dispatched, false);
+  });
+
+  test('legacy preview keeps its callback identity after webhook completion', async () => {
+    const received = [];
+    const formatId = { id: 'legacy', agent_url: 'https://creative.example/mcp' };
+    const client = runtimeClient(
+      async () => ({
+        ...completed(),
+        data: { response_type: 'variant', manifest: { manifest_id: 'mf_legacy', format_id: formatId, assets: [] } },
+        metadata: { ...completed().metadata, taskId: 'preview-legacy-task' },
+      }),
+      {
+        allowUnauthenticatedWebhooks: true,
+        handlers: {
+          onPreviewCreativeStatusChange: () => received.push('canonical'),
+          onPreviewCreativeLegacyStatusChange: response => received.push(response.manifest.format_id.id),
+        },
+      }
+    );
+    await client.previewCreativeLegacy({
+      request_type: 'single',
+      creative_id: 'creative_legacy',
+      format_id: formatId,
+    });
+    received.length = 0;
+
+    const handled = await client.handleWebhook(
+      {
+        idempotency_key: 'preview-legacy-event',
+        operation_id: 'preview-legacy-operation',
+        task_id: 'preview-legacy-task',
+        task_type: 'preview_creative',
+        status: 'completed',
+        timestamp: '2026-08-20T12:00:00.000Z',
+        result: {
+          response_type: 'variant',
+          manifest: { manifest_id: 'mf_legacy', format_id: formatId, assets: [] },
+        },
+      },
+      'preview_creative',
+      'preview-legacy-operation'
+    );
+
+    assert.strictEqual(handled, true);
+    assert.deepStrictEqual(received, ['legacy']);
+  });
+
+  test('a later legacy preview overrides canonical provenance in a shared session context', async () => {
+    const received = [];
+    const formatId = { id: 'legacy', agent_url: 'https://creative.example/mcp' };
+    let call = 0;
+    const client = runtimeClient(
+      async () => {
+        call += 1;
+        return {
+          ...completed(),
+          data: { response_type: 'variant', manifest: { manifest_id: `mf_${call}`, format_id: formatId, assets: [] } },
+          metadata: {
+            ...completed().metadata,
+            taskId: `preview-shared-${call}`,
+            contextId: 'preview-shared-context',
+          },
+        };
+      },
+      {
+        allowUnauthenticatedWebhooks: true,
+        handlers: {
+          onPreviewCreativeStatusChange: () => {},
+          onPreviewCreativeLegacyStatusChange: response => received.push(response.manifest.format_id?.id),
+        },
+      }
+    );
+    await client.previewCreative({ request_type: 'single', creative_id: 'creative_canonical' }, undefined, {
+      contextId: 'preview-shared-context',
+    });
+    await client.previewCreativeLegacy(
+      { request_type: 'single', creative_id: 'creative_legacy', format_id: formatId },
+      undefined,
+      { contextId: 'preview-shared-context' }
+    );
+    received.length = 0;
+
+    await client.handleWebhook(
+      {
+        idempotency_key: 'preview-shared-event',
+        operation_id: 'preview-shared-operation',
+        context_id: 'preview-shared-context',
+        task_id: 'preview-shared-2',
+        task_type: 'preview_creative',
+        status: 'completed',
+        timestamp: '2026-08-20T12:00:00.000Z',
+        result: {
+          response_type: 'variant',
+          manifest: { manifest_id: 'mf_legacy', format_id: formatId, assets: [] },
+        },
+      },
+      'preview_creative',
+      'preview-shared-operation'
+    );
+
+    assert.deepStrictEqual(received, ['legacy']);
+  });
+
+  test('preview provenance is registered before dispatch and survives a client restart', async () => {
+    const store = new InMemoryWebhookRegistrationStore();
+    const formatId = { id: 'legacy', agent_url: 'https://creative.example/mcp' };
+    const webhookResult = {
+      response_type: 'variant',
+      manifest: { manifest_id: 'mf_webhook', format_id: formatId, assets: [] },
+    };
+
+    const immediateReceived = [];
+    let immediateClient;
+    immediateClient = runtimeClient(
+      async () => {
+        await immediateClient.persistWebhookRegistration({
+          agent: TEST_AGENT,
+          taskType: 'preview_creative',
+          operationId: 'op_immediate_legacy',
+          callbackUrl: 'https://buyer.example/webhook',
+          mode: 'hmac-sha256',
+        });
+        const payload = {
+          idempotency_key: 'event_immediate_legacy',
+          operation_id: 'op_immediate_legacy',
+          task_id: 'task_immediate_legacy',
+          task_type: 'preview_creative',
+          status: 'completed',
+          timestamp: '2026-08-20T12:00:00.000Z',
+          result: webhookResult,
+        };
+        const auth = signedWebhook(payload);
+        await immediateClient.handleWebhook(
+          payload,
+          'preview_creative',
+          'op_immediate_legacy',
+          auth.signature,
+          auth.timestamp,
+          auth.rawBody
+        );
+        return completed();
+      },
+      {
+        webhookSecret: WEBHOOK_SECRET,
+        webhookRegistrationStore: store,
+        handlers: {
+          onPreviewCreativeStatusChange: () => immediateReceived.push('canonical'),
+          onPreviewCreativeLegacyStatusChange: () => immediateReceived.push('legacy'),
+        },
+      }
+    );
+    await immediateClient.previewCreativeLegacy({
+      request_type: 'single',
+      creative_id: 'creative_legacy',
+      format_id: formatId,
+    });
+    assert.deepStrictEqual(immediateReceived, ['legacy', 'legacy']);
+
+    let producer;
+    producer = runtimeClient(
+      async () => {
+        await producer.persistWebhookRegistration({
+          agent: TEST_AGENT,
+          taskType: 'preview_creative',
+          operationId: 'op_restart_canonical',
+          callbackUrl: 'https://buyer.example/webhook',
+          mode: 'hmac-sha256',
+        });
+        return completed();
+      },
+      { webhookSecret: WEBHOOK_SECRET, webhookRegistrationStore: store }
+    );
+    await producer.previewCreative({ request_type: 'single', creative_id: 'creative_canonical' });
+
+    const restartedReceived = [];
+    const restarted = runtimeClient(async () => completed(), {
+      webhookSecret: WEBHOOK_SECRET,
+      webhookRegistrationStore: store,
+      handlers: {
+        onPreviewCreativeStatusChange: response => restartedReceived.push(response),
+        onPreviewCreativeLegacyStatusChange: () => restartedReceived.push('legacy'),
+      },
+    });
+    const payload = {
+      idempotency_key: 'event_restart_canonical',
+      operation_id: 'op_restart_canonical',
+      task_id: 'task_restart_canonical',
+      task_type: 'preview_creative',
+      status: 'completed',
+      timestamp: '2026-08-20T12:00:00.000Z',
+      result: webhookResult,
+    };
+    const auth = signedWebhook(payload);
+    await restarted.handleWebhook(
+      payload,
+      'preview_creative',
+      'op_restart_canonical',
+      auth.signature,
+      auth.timestamp,
+      auth.rawBody
+    );
+
+    assert.strictEqual(restartedReceived.length, 1);
+    assert.strictEqual(restartedReceived[0].manifest.format_id, undefined);
+  });
+
+  test('legacy HMAC preview overrides stale cross-tool context when registration persistence fails', async () => {
+    const formatId = { id: 'legacy', agent_url: 'https://creative.example/mcp' };
+    const received = [];
+    const unavailableStore = {
+      async get() {
+        throw new Error('store unavailable');
+      },
+      async putIfAbsent() {
+        throw new Error('store unavailable');
+      },
+    };
+    let call = 0;
+    let client;
+    client = runtimeClient(
+      async () => {
+        call += 1;
+        if (call === 1) {
+          return {
+            ...completed('get_products'),
+            data: { products: [] },
+            metadata: {
+              ...completed('get_products').metadata,
+              taskId: 'task_store_outage_products',
+              contextId: 'shared-context',
+            },
+          };
+        }
+        await client.persistWebhookRegistration({
+          agent: TEST_AGENT,
+          taskType: 'preview_creative',
+          operationId: 'op_store_outage_legacy',
+          callbackUrl: 'https://buyer.example/webhook',
+          mode: 'hmac-sha256',
+        });
+        const payload = {
+          idempotency_key: 'event_store_outage_legacy',
+          operation_id: 'op_store_outage_legacy',
+          task_id: 'task_store_outage_legacy',
+          context_id: 'shared-context',
+          task_type: 'preview_creative',
+          status: 'completed',
+          timestamp: '2026-08-20T12:00:00.000Z',
+          result: {
+            response_type: 'variant',
+            manifest: { manifest_id: 'mf_legacy', format_id: formatId, assets: [] },
+          },
+        };
+        const auth = signedWebhook(payload);
+        await client.handleWebhook(
+          payload,
+          'preview_creative',
+          'op_store_outage_legacy',
+          auth.signature,
+          auth.timestamp,
+          auth.rawBody
+        );
+        return {
+          ...completed(),
+          data: {
+            response_type: 'variant',
+            manifest: { manifest_id: 'mf_legacy', format_id: formatId, assets: [] },
+          },
+        };
+      },
+      {
+        webhookSecret: WEBHOOK_SECRET,
+        webhookRegistrationStore: unavailableStore,
+        handlers: {
+          onPreviewCreativeStatusChange: () => received.push('canonical'),
+          onPreviewCreativeLegacyStatusChange: response => received.push(response.manifest.format_id.id),
+        },
+      }
+    );
+
+    await client.getProducts({ buying_mode: 'wholesale' }, undefined, { contextId: 'shared-context' });
+    received.length = 0;
+    await client.previewCreativeLegacy(
+      {
+        request_type: 'single',
+        creative_id: 'creative_legacy',
+        format_id: formatId,
+      },
+      undefined,
+      { contextId: 'shared-context' }
+    );
+
+    assert.deepStrictEqual(received, ['legacy', 'legacy']);
+  });
+});

--- a/test/server-decisioning-from-platform.test.js
+++ b/test/server-decisioning-from-platform.test.js
@@ -2697,6 +2697,142 @@ describe('CreativeBuilderPlatform + AudiencePlatform wiring', () => {
     assert.ok(sawReq, 'creative.buildCreative should be invoked');
   });
 
+  it('preview_creative dispatches canonical capability and creative-library routes through previewCreative', async () => {
+    const seen = [];
+    const platform = {
+      ...buildCreativeOnlyPlatform({ specialisms: ['creative-template'] }),
+      creative: {
+        buildCreativeLegacy: async () => ({ manifest_id: 'mf_1', assets: [] }),
+        previewCreative: async req => {
+          seen.push(req);
+          return { response_type: 'single', previews: [] };
+        },
+      },
+    };
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'canonical-preview',
+      version: '1.0.0',
+      validation: { requests: 'off', responses: 'off' },
+    });
+
+    const requests = [
+      {
+        request_type: 'single',
+        target_capability_id: 'display.responsive',
+        creative_manifest: { manifest_id: 'mf_inline', assets: [] },
+      },
+      { request_type: 'single', creative_id: 'creative_library_1' },
+    ];
+    for (const args of requests) {
+      const result = await server.dispatchTestRequest({
+        method: 'tools/call',
+        params: { name: 'preview_creative', arguments: args },
+      });
+      assert.notStrictEqual(result.isError, true, JSON.stringify(result.structuredContent));
+    }
+
+    assert.deepStrictEqual(seen, requests);
+  });
+
+  it('preview_creative keeps format_id requests on previewCreativeLegacy when both aliases exist', async () => {
+    const calls = [];
+    const platform = {
+      ...buildCreativeOnlyPlatform({ specialisms: ['creative-template'] }),
+      creative: {
+        buildCreativeLegacy: async () => ({ manifest_id: 'mf_1', assets: [] }),
+        previewCreative: async () => {
+          calls.push('canonical');
+          return { response_type: 'single', previews: [] };
+        },
+        previewCreativeLegacy: async () => {
+          calls.push('legacy');
+          return { response_type: 'single', previews: [] };
+        },
+      },
+    };
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'legacy-preview-alias',
+      version: '1.0.0',
+      validation: { requests: 'off', responses: 'off' },
+    });
+    const result = await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'preview_creative',
+        arguments: {
+          request_type: 'single',
+          format_id: { id: 'legacy', agent_url: 'https://creative.example/mcp' },
+        },
+      },
+    });
+
+    assert.notStrictEqual(result.isError, true, JSON.stringify(result.structuredContent));
+    assert.deepStrictEqual(calls, ['legacy']);
+  });
+
+  it('preview_creative treats a batch item format_id as legacy identity', async () => {
+    const calls = [];
+    const legacyBatch = {
+      request_type: 'batch',
+      requests: [
+        {
+          creative_id: 'creative_legacy',
+          format_id: { id: 'legacy', agent_url: 'https://creative.example/mcp' },
+        },
+      ],
+    };
+    const platform = {
+      ...buildCreativeOnlyPlatform({ specialisms: ['creative-template'] }),
+      creative: {
+        buildCreativeLegacy: async () => ({ manifest_id: 'mf_1', assets: [] }),
+        previewCreative: async () => {
+          calls.push('canonical');
+          return { response_type: 'batch', previews: [] };
+        },
+        previewCreativeLegacy: async () => {
+          calls.push('legacy');
+          return { response_type: 'batch', previews: [] };
+        },
+      },
+    };
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'legacy-preview-batch-alias',
+      version: '1.0.0',
+      validation: { requests: 'off', responses: 'off' },
+    });
+
+    const result = await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: { name: 'preview_creative', arguments: legacyBatch },
+    });
+
+    assert.notStrictEqual(result.isError, true, JSON.stringify(result.structuredContent));
+    assert.deepStrictEqual(calls, ['legacy']);
+
+    const canonicalOnly = createAdcpServerFromPlatform(
+      {
+        ...platform,
+        creative: {
+          buildCreativeLegacy: platform.creative.buildCreativeLegacy,
+          previewCreative: platform.creative.previewCreative,
+        },
+      },
+      {
+        name: 'canonical-only-preview-batch',
+        version: '1.0.0',
+        validation: { requests: 'off', responses: 'off' },
+      }
+    );
+    const rejected = await canonicalOnly.dispatchTestRequest({
+      method: 'tools/call',
+      params: { name: 'preview_creative', arguments: legacyBatch },
+    });
+
+    assert.strictEqual(rejected.isError, true, JSON.stringify(rejected.structuredContent));
+    assert.match(JSON.stringify(rejected.structuredContent), /UNSUPPORTED_FEATURE/);
+    assert.deepStrictEqual(calls, ['legacy']);
+  });
+
   it('F13: creative-generative specialism accepts the merged CreativeBuilderPlatform shape', async () => {
     // Pre-merge, creative-generative required CreativeGenerativePlatform
     // (which had `refineCreative` required and no previewCreative). After

--- a/test/webhook-rfc9421-client.test.js
+++ b/test/webhook-rfc9421-client.test.js
@@ -304,6 +304,7 @@ describe('webhook registration provenance', () => {
       store.putIfAbsent({ ...registration, callbackUrl: 'https://attacker.example/webhook' }),
       /different trusted provenance/
     );
+    await assert.rejects(store.putIfAbsent({ ...registration, previewMode: 'legacy' }), /different trusted provenance/);
   });
 
   test('TaskExecutor persists the single prepared call before dispatch', async () => {


### PR DESCRIPTION
## Summary

- add canonical `previewCreative` APIs to session-aware clients and decisioning servers
- retain `previewCreativeLegacy` for named-format compatibility
- enforce canonical request identity at the type and runtime boundaries
- preserve canonical versus legacy callback routing across synchronous, webhook, restart, and registration-store outage paths
- document the migration and include a minor changeset

## Root cause

The SDK exposed only the legacy named-format preview surface through session-aware clients and server platform interfaces. Canonical capability, manifest, and creative-library preview requests therefore had no stable first-class path, and asynchronous callback routing lacked durable invocation provenance.

## Validation

- `npm test`
- `npm run typecheck`
- `npm run build:lib`
- focused preview, async-handler, webhook, and server-routing tests: 230/230 passing
- commitlint, formatting, and diff checks
- independent code, protocol, and TypeScript expert reviews with no remaining actionable findings

Closes #2627
