### PR TITLE
fix: preserve generated schema fields and version errors

### DIFF
--- a/.changeset/tidy-geckos-restore-codegen.md
+++ b/.changeset/tidy-geckos-restore-codegen.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Preserve base fields and required values in generated creative-approval and postal-area types and schemas, and surface exact-version capability failures instead of silently downgrading storyboard discovery.

--- a/bin/adcp-version-unsupported-hint.js
+++ b/bin/adcp-version-unsupported-hint.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const BUILT_IN_VERSION_HINT =
+  'The built-in test agent does not support the requested ADCP version; wait for a compatible server update or pass a compatible agent URL instead.';
+
+function appendBuiltInVersionUnsupportedHint(result, agentArg, builtInAgents) {
+  const headline = result?.summary?.headline;
+  if (!builtInAgents?.[agentArg] || typeof headline !== 'string' || !headline.includes('VERSION_UNSUPPORTED')) {
+    return result;
+  }
+  if (headline.includes(BUILT_IN_VERSION_HINT)) return result;
+  return {
+    ...result,
+    summary: {
+      ...result.summary,
+      headline: `${headline}. ${BUILT_IN_VERSION_HINT}`,
+    },
+  };
+}
+
+module.exports = { BUILT_IN_VERSION_HINT, appendBuiltInVersionUnsupportedHint };

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -52,6 +52,7 @@ const {
 const { scheduleVersionCheck } = require('./adcp-version-check.js');
 const { formatStoryboardResultsAsJUnit } = require('../dist/lib/testing/storyboard/junit.js');
 const { LIBRARY_VERSION } = require('../dist/lib/version.js');
+const { appendBuiltInVersionUnsupportedHint } = require('./adcp-version-unsupported-hint.js');
 const {
   createCLIOAuthProvider,
   hasValidOAuthTokens,
@@ -4727,7 +4728,8 @@ async function runFullAssessment(agentArg, rawArgs, parsedOpts) {
       setAgentTesterLogger({ info: () => {}, error: () => {}, warn: () => {}, debug: () => {} });
     }
 
-    const result = await comply(agentUrl, testOptions);
+    let result = await comply(agentUrl, testOptions);
+    result = appendBuiltInVersionUnsupportedHint(result, agentArg, BUILT_IN_AGENTS);
 
     if (opts.summaryFile) {
       writeSummaryFile(opts.summaryFile, buildComplianceSummaryMarkdown(result, agentUrl));

--- a/scripts/check-adopter-types.ts
+++ b/scripts/check-adopter-types.ts
@@ -155,6 +155,8 @@ import type {
   None1,
   None2,
   PlatformExtensionReference1,
+  PostalArea,
+  PostalArea1,
   Product1,
   Property1,
 } from '@adcp/sdk/types/core.generated';
@@ -280,6 +282,28 @@ const _payloadResults: [
   ok([]),
 ];
 void _payloadResults;
+
+const _nativePostalArea: PostalArea = { country: 'US', system: 'zip', values: ['10001'] };
+const _legacyNamedNativePostalArea: PostalArea1 = _nativePostalArea;
+// @ts-expect-error Native postal targeting requires at least one value.
+const _emptyNativePostalArea: PostalArea = { country: 'US', system: 'zip', values: [] };
+void _legacyNamedNativePostalArea;
+void _emptyNativePostalArea;
+
+type PackedCreativeApproval = NonNullable<
+  GetMediaBuysPayload['media_buys'][number]['packages'][number]['creative_approvals']
+>[number];
+const _packedCreativeApproval: PackedCreativeApproval = {
+  creative_id: 'creative-1',
+  approval_status: 'approved',
+  rejection_reason: 'not used for approved creatives',
+  approval_scopes: [],
+  indicator_types_evaluated: ['creative_fatigue'],
+  indicators: [],
+  indicators_as_of: '2026-08-20T00:00:00Z',
+  indicators_evaluated_scope: [],
+};
+void _packedCreativeApproval;
 
 const _accountHandlerResults: [
   ListAccountsHandlerResult,

--- a/scripts/generate-types.ts
+++ b/scripts/generate-types.ts
@@ -378,6 +378,19 @@ function intersectCodegenPropertySchemas(parent: any, branch: any): any {
   return merged;
 }
 
+function mergeCodegenPropertyMaps(
+  base: Record<string, any> | undefined,
+  overlay: Record<string, any> | undefined
+): Record<string, any> {
+  const merged: Record<string, any> = { ...(base ?? {}) };
+  for (const [name, overlayProperty] of Object.entries(overlay ?? {})) {
+    merged[name] = Object.hasOwn(merged, name)
+      ? intersectCodegenPropertySchemas(merged[name], overlayProperty)
+      : overlayProperty;
+  }
+  return merged;
+}
+
 /**
  * Rewrite a discriminated `oneOf` whose branches are mutual-exclusion clauses
  * into explicit closed shapes. Without this, json-schema-to-typescript sees a
@@ -833,11 +846,52 @@ function shouldPreserveOpenIndexSignature(schema: any): boolean {
   );
 }
 
+function normalizePostalAreaForCodegen(schema: any): any {
+  if (!schema || typeof schema !== 'object' || !Array.isArray(schema.anyOf)) return schema;
+  const nativeBranchIndex = schema.anyOf.findIndex(
+    (branch: any) =>
+      branch?.title === 'PostalArea' &&
+      branch?.type === 'object' &&
+      Array.isArray(branch.allOf) &&
+      branch.properties?.values
+  );
+  if (nativeBranchIndex === -1) return schema;
+
+  const nativeBranch = schema.anyOf[nativeBranchIndex];
+  const nativeValues = nativeBranch.properties.values;
+  const normalizedNativeBranch = {
+    ...nativeBranch,
+    title: 'Postal Country Area',
+    properties: {
+      ...nativeBranch.properties,
+      values: {
+        ...nativeValues,
+        // The general generator relaxes array cardinality for legacy
+        // interoperability. PostalArea is a wire discriminator: an empty
+        // values list is never meaningful, so retain the source minItems: 1
+        // constraint in the public TypeScript surface.
+        tsType: '[string, ...string[]]',
+      },
+    },
+  };
+  // The branch repeats country/system alongside PostalCountrySystem. Keep
+  // the complete local shape and remove the allOf ref so jsts cannot
+  // collapse the branch to the referenced base and lose values.
+  delete normalizedNativeBranch.allOf;
+  return {
+    ...schema,
+    anyOf: schema.anyOf.map((branch: any, index: number) =>
+      index === nativeBranchIndex ? normalizedNativeBranch : branch
+    ),
+  };
+}
+
 export function enforceStrictSchema(schema: any): any {
   if (!schema || typeof schema !== 'object') {
     return schema;
   }
 
+  schema = normalizePostalAreaForCodegen(schema);
   schema = expandConditionalRequiredDiscriminator(schema);
   schema = preservePostalCountrySystemRequiredness(schema);
   schema = dropValidationOnlyAnyOf(schema);
@@ -1716,6 +1770,10 @@ export function applyCodegenSchemaWorkarounds(schema: any, schemaName: string): 
     return isolateGetMediaBuyDeliveryCompatBreakdowns(schema);
   }
 
+  if (schemaName === 'PostalArea' && Array.isArray(schema.anyOf)) {
+    return normalizePostalAreaForCodegen(schema);
+  }
+
   if (schemaName === 'GetMediaBuysResponse') {
     const item = schema.properties?.media_buys?.items;
     if (item && typeof item === 'object' && !Array.isArray(item)) {
@@ -1734,13 +1792,14 @@ export function applyCodegenSchemaWorkarounds(schema: any, schemaName: string): 
         // that root, then remove allOf so nested conditionals inside the
         // duplicated MediaBuy member cannot make jsts discard the base type.
         const structuralProperties = cleanedItem.allOf.reduce(
-          (properties: Record<string, unknown>, member: any) => ({
-            ...properties,
-            ...(member && typeof member === 'object' && !Array.isArray(member) ? member.properties : undefined),
-          }),
+          (properties: Record<string, any>, member: any) =>
+            mergeCodegenPropertyMaps(
+              properties,
+              member && typeof member === 'object' && !Array.isArray(member) ? member.properties : undefined
+            ),
           {}
         );
-        cleanedItem.properties = { ...cleanedItem.properties, ...structuralProperties };
+        cleanedItem.properties = mergeCodegenPropertyMaps(cleanedItem.properties, structuralProperties);
         delete cleanedItem.allOf;
       }
       const packageItems = cleanedItem.properties?.packages?.items;
@@ -1749,16 +1808,47 @@ export function applyCodegenSchemaWorkarounds(schema: any, schemaName: string): 
         // root. Its allOf/dependencies members are runtime-only validation
         // overlays; leaving them in lets jsts emit only the indicator fields.
         const packageStructuralProperties = (packageItems.allOf ?? []).reduce(
-          (properties: Record<string, unknown>, member: any) => ({
-            ...properties,
-            ...(member && typeof member === 'object' && !Array.isArray(member) ? member.properties : undefined),
-          }),
+          (properties: Record<string, any>, member: any) =>
+            mergeCodegenPropertyMaps(
+              properties,
+              member && typeof member === 'object' && !Array.isArray(member) ? member.properties : undefined
+            ),
           {}
         );
         const cleanedPackageItems = {
           ...packageItems,
-          properties: { ...packageItems.properties, ...packageStructuralProperties },
+          properties: mergeCodegenPropertyMaps(packageItems.properties, packageStructuralProperties),
         };
+
+        const approvalItems = cleanedPackageItems.properties?.creative_approvals?.items;
+        if (approvalItems && typeof approvalItems === 'object' && !Array.isArray(approvalItems)) {
+          const approvalStructuralProperties = (approvalItems.allOf ?? []).reduce(
+            (properties: Record<string, any>, member: any) =>
+              mergeCodegenPropertyMaps(
+                properties,
+                member && typeof member === 'object' && !Array.isArray(member) ? member.properties : undefined
+              ),
+            {}
+          );
+          const cleanedApprovalItems = {
+            ...approvalItems,
+            properties: mergeCodegenPropertyMaps(approvalItems.properties, approvalStructuralProperties),
+          };
+          // The root owns the complete approval surface; the allOf members
+          // only narrow indicators or enforce runtime conditionals. Folding
+          // the structural overlay retains those enum refinements while the
+          // untouched signed schema remains authoritative for conditionals.
+          for (const keyword of ['allOf', 'dependencies', 'not', 'if', 'then', 'else']) {
+            delete cleanedApprovalItems[keyword];
+          }
+          cleanedPackageItems.properties = {
+            ...cleanedPackageItems.properties,
+            creative_approvals: {
+              ...cleanedPackageItems.properties.creative_approvals,
+              items: cleanedApprovalItems,
+            },
+          };
+        }
         for (const keyword of ['allOf', 'dependencies', 'not', 'if', 'then', 'else']) {
           delete cleanedPackageItems[keyword];
         }
@@ -2532,7 +2622,24 @@ export interface PriceBreakdown {
 }
 
 function namePostalAreaCountryBranch(typeDefinitions: string): string {
-  return typeDefinitions.replace(
+  const collapsedAlias = 'export type PostalArea1 = PostalCountrySystem;';
+  if (typeDefinitions.includes(collapsedAlias)) {
+    return typeDefinitions.replace(
+      collapsedAlias,
+      [
+        'export type PostalCountryArea = PostalCountrySystem & {',
+        '  values: [string, ...string[]];',
+        '};',
+        '/**',
+        ' * Re-export of `PostalCountryArea` under the legacy codegen artifact name.',
+        ' *',
+        ' * @deprecated Use `PostalCountryArea` from `@adcp/sdk/types`. Slated for removal in the next major.',
+        ' */',
+        'export type PostalArea1 = PostalCountryArea;',
+      ].join('\n')
+    );
+  }
+  const namedDefinitions = typeDefinitions.replace(
     /(export interface )PostalArea1(\s*\{[\s\S]*?\n\})/,
     [
       '$1PostalCountryArea$2',
@@ -2544,6 +2651,13 @@ function namePostalAreaCountryBranch(typeDefinitions: string): string {
       'export type PostalArea1 = PostalCountryArea;',
     ].join('\n')
   );
+  if (
+    !namedDefinitions.includes('export type PostalArea1 = PostalCountryArea;') &&
+    /export (?:interface|type) PostalCountryArea\b/.test(namedDefinitions)
+  ) {
+    return `${namedDefinitions}\n\n/**\n * Re-export of \`PostalCountryArea\` under the legacy codegen artifact name.\n *\n * @deprecated Use \`PostalCountryArea\` from \`@adcp/sdk/types\`. Slated for removal in the next major.\n */\nexport type PostalArea1 = PostalCountryArea;`;
+  }
+  return namedDefinitions;
 }
 
 /**

--- a/scripts/generate-zod-from-ts.ts
+++ b/scripts/generate-zod-from-ts.ts
@@ -588,6 +588,37 @@ function postProcessCreativeBriefRequiredDisclosures(content: string): string {
   return content.slice(0, schemaStart) + correctedBlock + content.slice(schemaEnd);
 }
 
+/** Restore native PostalArea.values minItems: 1 after tuple relaxation. */
+function postProcessPostalAreaValues(content: string): string {
+  const schemaStart = content.indexOf('export const PostalAreaSchema = ');
+  const schemaEnd = content.indexOf('\n\nexport const ', schemaStart + 1);
+  if (schemaStart === -1 || schemaEnd === -1) {
+    throw new Error('postProcessPostalAreaValues: unable to locate PostalAreaSchema.');
+  }
+
+  const block = content.slice(schemaStart, schemaEnd);
+  if (block.includes('native postal values must contain at least one entry')) {
+    return content;
+  }
+  const correctedBlock = block.replace(
+    /;\s*$/,
+    `.superRefine((value, ctx) => {
+  const postal = value as { country?: unknown; values?: unknown };
+  if (typeof postal.country === "string" && (!Array.isArray(postal.values) || postal.values.length === 0)) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["values"],
+      message: "native postal values must contain at least one entry",
+    });
+  }
+});`
+  );
+  if (correctedBlock === block) {
+    throw new Error('postProcessPostalAreaValues: unable to append native values refinement.');
+  }
+  return content.slice(0, schemaStart) + correctedBlock + content.slice(schemaEnd);
+}
+
 /** Replace the lossy TS round-trip with Zod generated from the dereferenced canonical wire schema. */
 function postProcessCanonicalProposalRuntimeConstraints(content: string, exactSchemaExpression: string): string {
   const schemaStart = content.indexOf('export const CanonicalProposalSchema = ');
@@ -2629,6 +2660,7 @@ async function generateZodSchemas() {
     zodSchemas = postProcessCanonicalFormatMarkerIntersections(zodSchemas);
     zodSchemas = postProcessCanonicalFormatSlots(zodSchemas);
     zodSchemas = postProcessCreativeBriefRequiredDisclosures(zodSchemas);
+    zodSchemas = postProcessPostalAreaValues(zodSchemas);
     const refineResponseSource = JSON.parse(
       readFileSync(
         path.join(__dirname, '../schemas/cache/latest/bundled/media-buy/refine-proposals-response.json'),

--- a/src/lib/server/decisioning/decisioning.type-checks.ts
+++ b/src/lib/server/decisioning/decisioning.type-checks.ts
@@ -74,6 +74,7 @@ import {
 } from './index';
 import type { ComplyControllerConfig } from '../../testing/comply-controller';
 import type { CanonicalListCreativesResponse } from '../../v2/projection/creative-delivery';
+import type { PostalArea } from '../../types/core.generated';
 import { getAccountMode } from '../account-mode';
 
 // ── AdcpError construction ────────────────────────────────────────────
@@ -314,6 +315,32 @@ function _postal_area_support_accepts_native_and_deprecated_forms(): TargetingPo
     GB: ['outward'] as const,
     NL: ['postal_code'] as const,
     us_zip: true,
+  };
+}
+
+const _native_postal_area_with_values: PostalArea = {
+  country: 'US',
+  system: 'zip',
+  values: ['10001'],
+};
+
+// @ts-expect-error — native postal values are minItems: 1 on the wire.
+const _native_postal_area_rejects_empty_values: PostalArea = { country: 'US', system: 'zip', values: [] };
+
+type CreativeApprovalReadback = NonNullable<
+  GetMediaBuysPayload['media_buys'][number]['packages'][number]['creative_approvals']
+>[number];
+type CreativeApprovalRequiresCreativeId = {} extends Pick<CreativeApprovalReadback, 'creative_id'> ? false : true;
+const _creative_approval_requires_creative_id: CreativeApprovalRequiresCreativeId = true;
+
+function _creative_approval_readback_exposes_base_and_indicator_fields(): CreativeApprovalReadback {
+  return {
+    creative_id: 'creative-1',
+    approval_status: 'approved',
+    rejection_reason: 'not used for approved creatives',
+    indicator_types_evaluated: ['creative_fatigue'],
+    indicators: [],
+    indicators_as_of: '2026-08-20T00:00:00Z',
   };
 }
 

--- a/src/lib/testing/client.ts
+++ b/src/lib/testing/client.ts
@@ -24,6 +24,7 @@ import { SsrfRefusedError } from '../net/ssrf-fetch';
 import { ADCP_VERSION } from '../version';
 import type { VersionEnvelopeMode } from '../protocols';
 import { validateIncomingResponse } from '../validation/client-hooks';
+import { extractVersionUnsupportedDetails } from '../utils/error-extraction';
 
 const TEST_CLIENT_VERSION_OPTIONS = Symbol('adcp.testClientVersionOptions');
 
@@ -435,6 +436,30 @@ export async function runStep<T>(
   }
 }
 
+function describeVersionUnsupported(result: unknown, requestedVersion: string | undefined): string | undefined {
+  if (!result || typeof result !== 'object') return undefined;
+  const record = result as Record<string, unknown>;
+  const dataRecord =
+    record.data && typeof record.data === 'object' && !Array.isArray(record.data)
+      ? (record.data as Record<string, unknown>)
+      : undefined;
+  const dataError =
+    dataRecord?.adcp_error && typeof dataRecord.adcp_error === 'object' ? dataRecord.adcp_error : undefined;
+  const adcpError = record.adcpError ?? record.adcp_error ?? dataError;
+  if (!adcpError || typeof adcpError !== 'object') return undefined;
+  const adcpErrorRecord = adcpError as Record<string, unknown>;
+  if (adcpErrorRecord.code !== 'VERSION_UNSUPPORTED') return undefined;
+
+  const details = extractVersionUnsupportedDetails(adcpErrorRecord) ?? extractVersionUnsupportedDetails(record.data);
+  const requested = details?.requested_version ?? requestedVersion;
+  const supported = details?.supported_versions;
+  const requestedText = requested ? `requested ${JSON.stringify(requested)}` : 'requested version is unsupported';
+  const supportedText = supported?.length
+    ? `; seller supports ${supported.map(version => JSON.stringify(version)).join(', ')}`
+    : '; seller did not report supported_versions';
+  return `VERSION_UNSUPPORTED: ${requestedText}${supportedText}`;
+}
+
 /**
  * Discover agent profile - what capabilities does this agent have?
  *
@@ -476,7 +501,16 @@ export async function discoverAgentProfile(
   if (profile.tools.includes('get_adcp_capabilities')) {
     try {
       const caps = (await raceWithSignal(client.getAdcpCapabilities({}, undefined, { signal }), signal)) as TaskResult;
-      if (caps?.data) {
+      const versionUnsupported = describeVersionUnsupported(caps, schemaAdcpVersion ?? client.getAdcpVersion?.());
+      if (versionUnsupported) {
+        // Some transports return AdCP error envelopes as successful tool data.
+        // Detect the protocol error before validating/parsing it as a
+        // capabilities success response, or best-effort parsing will produce
+        // a synthetic v2 profile from the error object.
+        profile.capabilities_probe_error = versionUnsupported;
+        step.passed = false;
+        step.error = versionUnsupported;
+      } else if (caps?.data) {
         profile.raw_capabilities = caps.data;
         const validation = validateIncomingResponse(
           'get_adcp_capabilities',
@@ -511,7 +545,7 @@ export async function discoverAgentProfile(
         const libVersion = (caps.data as Record<string, unknown>).library_version;
         if (typeof libVersion === 'string') profile.library_version = libVersion;
       }
-      if ((!caps?.success || !caps?.data) && !profile.capabilities_schema_issues?.length) {
+      if (!versionUnsupported && (!caps?.success || !caps?.data) && !profile.capabilities_schema_issues?.length) {
         profile.capabilities_probe_error = caps?.error || 'get_adcp_capabilities returned no data';
       }
     } catch (err) {

--- a/src/lib/testing/compliance/comply.ts
+++ b/src/lib/testing/compliance/comply.ts
@@ -1214,7 +1214,8 @@ async function complyImpl(agentUrl: string, options: ComplyOptions): Promise<Com
     if (
       testOptions.versionEnvelope === undefined &&
       profile.tools.includes('get_adcp_capabilities') &&
-      profile.raw_capabilities === undefined
+      profile.raw_capabilities === undefined &&
+      !profileStep.error?.startsWith('VERSION_UNSUPPORTED:')
     ) {
       const legacyDiscoveryOptions = { ...effectiveOptions, versionEnvelope: 'major-only' as const };
       const legacyDiscoveryClient = createTestClient(
@@ -1311,12 +1312,10 @@ async function complyImpl(agentUrl: string, options: ComplyOptions): Promise<Com
       // universal/security_baseline, which is designed precisely to diagnose
       // agents that mishandle auth. Fall back to the unreachable result only
       // when no such storyboards are available.
-      const authCheck = await detectAuthRejection(
-        agentUrl,
-        profileStep.error,
-        signal,
-        effectiveOptions.transport?.trustedFetchFn
-      );
+      const isVersionUnsupported = profileStep.error?.startsWith('VERSION_UNSUPPORTED:') === true;
+      const authCheck = isVersionUnsupported
+        ? { isAuth: false, observations: [] }
+        : await detectAuthRejection(agentUrl, profileStep.error, signal, effectiveOptions.transport?.trustedFetchFn);
       if (authCheck.isAuth) {
         const degraded: AgentProfile = { name: profile.name || 'Unknown (auth required)', tools: [] };
         const candidate = explicitStoryboards?.length
@@ -1851,12 +1850,10 @@ async function buildUnreachableResult(
   adcpVersion: string,
   signal?: AbortSignal
 ): Promise<ComplianceResult> {
-  const { isAuth, observations } = await detectAuthRejection(
-    agentUrl,
-    errorMsg,
-    signal,
-    effectiveOptions.transport?.trustedFetchFn
-  );
+  const isVersionUnsupported = errorMsg?.startsWith('VERSION_UNSUPPORTED:') === true;
+  const { isAuth, observations } = isVersionUnsupported
+    ? { isAuth: false, observations: [] }
+    : await detectAuthRejection(agentUrl, errorMsg, signal, effectiveOptions.transport?.trustedFetchFn);
   const err = redactOAuthUrlsInText(errorMsg || 'Unknown error');
   const headline = isAuth ? `Authentication required` : `Agent unreachable — ${err}`;
   return {

--- a/src/lib/types/core.generated.ts
+++ b/src/lib/types/core.generated.ts
@@ -1,5 +1,5 @@
 // Generated AdCP core types from official schemas v3.2.0-beta.3
-// Generated at: 2026-08-20T05:25:37.341Z
+// Generated at: 2026-08-20T08:36:34.306Z
 
 // ACCOUNTCURRENCYMODE CANONICAL ENUM
 /**
@@ -4792,7 +4792,15 @@ export type TargetingOverlay = {
  * Postal area values. Prefer the native country + postal system form. Deprecated legacy country-fused postal-system tokens remain accepted for compatibility.
  */
 export type PostalArea = PostalArea1 | PostalAreaWithFusedSystem;
-export type PostalArea1 = PostalCountrySystem;
+export type PostalCountryArea = PostalCountrySystem & {
+  values: [string, ...string[]];
+};
+/**
+ * Re-export of `PostalCountryArea` under the legacy codegen artifact name.
+ *
+ * @deprecated Use `PostalCountryArea` from `@adcp/sdk/types`. Slated for removal in the next major.
+ */
+export type PostalArea1 = PostalCountryArea;
 /**
  * Valid country-local postal system pairing. Registered countries only accept their registered local systems; countries without a registered local system use postal_code or custom.
  */

--- a/src/lib/types/schemas.generated.ts
+++ b/src/lib/types/schemas.generated.ts
@@ -1,5 +1,5 @@
 // Generated Zod v4 schemas from TypeScript types
-// Generated at: 2026-08-19T23:09:10.265Z
+// Generated at: 2026-08-20T08:38:07.822Z
 // Sources:
 //   - core.generated.ts (core types)
 //   - tools.generated.ts (tool types)
@@ -838,6 +838,10 @@ export const PostalCountrySystemSchema = z.union([z.object({
     }).passthrough()]).and(z.object({
     country: z.string(),
     system: PostalCodeSystemSchema
+}).passthrough());
+
+export const PostalCountryAreaSchema = PostalCountrySystemSchema.and(z.object({
+    values: z.array(z.string())
 }).passthrough());
 
 export const GeographicPlaceIdentifierSystemSchema = z.union([z.union([z.literal("geonames"), z.literal("google_ads"), z.literal("microsoft_ads")]), z.string()]);
@@ -7429,7 +7433,7 @@ export const PolicyProfileSchema = z.object({}).passthrough().merge(z.object({
     supported_combinations: z.tuple([z.union([MaxBidWithCostPerSchema, MaxBidWithRoasSchema])]).rest(z.union([MaxBidWithCostPerSchema, MaxBidWithRoasSchema])).optional()
 }).passthrough());
 
-export const PostalArea1Schema = PostalCountrySystemSchema;
+export const PostalArea1Schema = PostalCountryAreaSchema;
 
 export const AttestationBrandIssuerSchema = z.object({
     type: z.literal("brand"),
@@ -7437,7 +7441,16 @@ export const AttestationBrandIssuerSchema = z.object({
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
-export const PostalAreaSchema = z.union([PostalArea1Schema, PostalAreaWithFusedSystemSchema]);
+export const PostalAreaSchema = z.union([PostalArea1Schema, PostalAreaWithFusedSystemSchema]).superRefine((value, ctx) => {
+  const postal = value as { country?: unknown; values?: unknown };
+  if (typeof postal.country === "string" && (!Array.isArray(postal.values) || postal.values.length === 0)) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["values"],
+      message: "native postal values must contain at least one entry",
+    });
+  }
+});
 
 export const GeographicPlaceAreaSchema = z.object({}).passthrough().merge(z.object({
     country: z.string(),
@@ -7984,6 +7997,12 @@ export const AccountSchema = z.object({
     notification_configs: z.union([z.tuple([]), z.tuple([NotificationConfigSchema]), z.tuple([NotificationConfigSchema, NotificationConfigSchema]), z.tuple([NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema]), z.tuple([NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema]), z.tuple([NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema]), z.tuple([NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema]), z.tuple([NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema]), z.tuple([NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema]), z.tuple([NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema]), z.tuple([NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema]), z.tuple([NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema]), z.tuple([NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema]), z.tuple([NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema]), z.tuple([NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema]), z.tuple([NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema]), z.tuple([NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema, NotificationConfigSchema])]).optional(),
     webhook_activity: z.array(WebhookActivityRecordSchema).optional(),
     ext: ExtensionObjectSchema.optional()
+}).passthrough();
+
+export const ScopedCreativeApprovalSchema = z.object({
+    scope: IndicatorScopeSchema,
+    approval_status: CreativeApprovalStatusSchema.and(z.union([z.literal("pending_review"), z.literal("approved"), z.literal("rejected")])),
+    rejection_reason: z.string().optional()
 }).passthrough();
 
 export const GetMediaBuyDeliveryRequestSchema = z.object({
@@ -11498,12 +11517,6 @@ export const TargetingOverlaySchema = z.object({}).passthrough().merge(z.object(
         match_type: MatchTypeSchema
     }).passthrough()).optional()
 }).passthrough());
-
-export const ScopedCreativeApprovalSchema = z.object({
-    scope: IndicatorScopeSchema,
-    approval_status: CreativeApprovalStatusSchema.and(z.union([z.literal("pending_review"), z.literal("approved"), z.literal("rejected")])),
-    rejection_reason: z.string().optional()
-}).passthrough();
 
 export const DeliveryRecordSchema = z.object({
     identifier: IdentifierSchema,
@@ -15359,10 +15372,16 @@ export const PackageStatusSchema = z.object({
     creative_deadline: z.iso.datetime().optional(),
     context: ContextObjectSchema.optional(),
     creative_approvals: z.array(z.object({
-        indicator_types_evaluated: z.array(z.union([z.literal("creative_fatigue"), z.literal("creative_quality_opportunity")])).optional(),
-        indicators: z.array(z.object({
+        creative_id: z.string(),
+        approval_status: CreativeApprovalStatusSchema.optional(),
+        rejection_reason: z.string().optional(),
+        approval_scopes: z.array(ScopedCreativeApprovalSchema).optional(),
+        indicators: z.array(IndicatorSchema.and(z.object({
             type: z.union([z.literal("creative_fatigue"), z.literal("creative_quality_opportunity")]).optional()
-        }).passthrough()).optional()
+        }).passthrough())).optional(),
+        indicator_types_evaluated: z.array(IndicatorTypeSchema.and(z.union([z.literal("creative_fatigue"), z.literal("creative_quality_opportunity")]))).optional(),
+        indicators_as_of: z.iso.datetime().optional(),
+        indicators_evaluated_scope: z.array(IndicatorScopeSchema).optional()
     }).passthrough()).optional(),
     formats_to_provide: z.array(ProductFormatDeclarationSchema).optional(),
     formats_pending: z.array(ProductFormatDeclarationSchema).optional(),

--- a/src/lib/types/tools.generated.ts
+++ b/src/lib/types/tools.generated.ts
@@ -430,7 +430,15 @@ export type SignalTargeting =
  * Postal area values. Prefer the native country + postal system form. Deprecated legacy country-fused postal-system tokens remain accepted for compatibility.
  */
 export type PostalArea = PostalArea1 | PostalAreaWithFusedSystem;
-export type PostalArea1 = PostalCountrySystem;
+export type PostalCountryArea = PostalCountrySystem & {
+  values: [string, ...string[]];
+};
+/**
+ * Re-export of `PostalCountryArea` under the legacy codegen artifact name.
+ *
+ * @deprecated Use `PostalCountryArea` from `@adcp/sdk/types`. Slated for removal in the next major.
+ */
+export type PostalArea1 = PostalCountryArea;
 /**
  * Buyer policy for evaluating Product.audience_evidence. In required mode, sellers MUST apply the evidence_presence and admissibility semantics and exclude non-matching products; they MUST NOT ignore an unsupported hard requirement. In preferred mode, sellers use matches for ranking and explain the evidence selected. Buyers SHOULD inspect media_buy.audience_evidence capabilities before sending this object.
  */
@@ -15041,10 +15049,38 @@ export interface PackageStatus {
    * Approval status for each creative assigned to this package. Absent when no creatives have been assigned.
    */
   creative_approvals?: {
-    indicator_types_evaluated?: ('creative_fatigue' | 'creative_quality_opportunity')[];
-    indicators?: {
+    /**
+     * Creative identifier
+     */
+    creative_id: string;
+    approval_status?: CreativeApprovalStatus;
+    /**
+     * Human-readable explanation of why the creative was rejected. Present only when approval_status is 'rejected'.
+     */
+    rejection_reason?: string;
+    /**
+     * Complete, disjoint publisher/placement approval partition when approval_status is partially_approved. A normalized scope appears once. For one publisher, use either one publisher-wide row or placement-specific rows, never both. Omit when one approval_status applies uniformly to the whole assignment. The same scoped outcomes are mirrored on list_creatives.
+     */
+    approval_scopes?: ScopedCreativeApproval[];
+    /**
+     * Current seller indicators that are true for this creative in this package. The enclosing media buy, package, and creative approval supply the default delivery scope; an indicator may narrow further with scope. Omitted means unknown or not evaluated. A present empty array means the seller completed the evaluation identified by indicators_evaluated_scope at indicators_as_of and asserts no current indicator in that evaluated scope.
+     */
+    indicators?: (Indicator & {
       type?: 'creative_fatigue' | 'creative_quality_opportunity';
-    }[];
+    })[];
+    /**
+     * Indicator types covered by this assignment snapshot. Required whenever indicators is present; omitted types remain unknown.
+     */
+    indicator_types_evaluated?: (IndicatorType & ('creative_fatigue' | 'creative_quality_opportunity'))[];
+    /**
+     * When the seller last completed the evaluation represented by indicators for this relationship. Required whenever indicators is present, including an empty array.
+     * @format date-time
+     */
+    indicators_as_of?: string;
+    /**
+     * Optional publisher or placement scopes covered by this evaluation. Omit when indicators covers the whole package–creative assignment. When present, scopes not listed remain unknown; every returned indicator.scope entry MUST be contained by this set.
+     */
+    indicators_evaluated_scope?: IndicatorScope[];
   }[];
   /**
    * The immutable canonical creative contracts established for this package at booking time. Each entry is the selected Product.format_options declaration, or the equivalent declaration normalized from a direct format_kind + params selector. Compare this full checklist with formats_pending to determine current creative readiness.
@@ -15123,6 +15159,36 @@ export interface PackageStatus {
       | 'pacing_risk'
       | 'budget_constrained';
   }[];
+}
+/**
+ * Publisher or placement to which this approval outcome applies.
+ */
+export interface IndicatorScope {
+  /**
+   * Domain where the publisher's adagents.json is hosted.
+   */
+  publisher_domain: string;
+  /**
+   * Optional placement ID within publisher_domain. Omit to scope the assertion or evaluation to all delivery for the publisher in the enclosing object.
+   */
+  placement_id?: string;
+}
+/**
+ * A compact current seller assertion identifying a material risk or optimization opportunity that warrants buyer attention on the containing media buy, package, or package–creative relationship. An indicator is read-side state, not an error, warning, durable event record, authorization, executable action, or independently addressable resource. The responding seller is the source. Different sellers may use different methodologies for the same standard type; native scores, evaluation windows, suggested actions, deep links, and upstream attribution belong in ext.
+ */
+export interface Indicator {
+  type: IndicatorType;
+  /**
+   * When the seller first detected the current uninterrupted occurrence of this indicator. Keep this value stable while the condition remains present. If the condition clears and is later detected again, use the new detection time. Optional because some upstream platforms expose current assessments without an original detection timestamp.
+   */
+  detected_at?: string;
+  /**
+   * Optional narrower publisher or placement scope within the enclosing media buy, package, or package–creative assignment. Omit only when the seller evaluated and asserts the indicator across the whole enclosing resource/relationship. When partial indicators_evaluated_scope is declared, every returned indicator MUST include scope and every entry MUST fall within that coverage. This is scope, not source: the responding seller remains the source.
+   *
+   * @minItems 1
+   */
+  scope?: [IndicatorScope, ...IndicatorScope[]];
+  ext?: ExtensionObject;
 }
 /**
  * Request parameters for retrieving comprehensive delivery metrics

--- a/src/lib/utils/error-extraction.ts
+++ b/src/lib/utils/error-extraction.ts
@@ -350,6 +350,10 @@ export function extractVersionUnsupportedDetails(input: unknown): VersionUnsuppo
   }
   if (typeof candidate.requested_version === 'string') {
     out.requested_version = candidate.requested_version;
+  } else if (typeof candidate.adcp_version === 'string') {
+    // The canonical VERSION_UNSUPPORTED schema names the echoed wire field
+    // `adcp_version`; normalize it to the helper's established public shape.
+    out.requested_version = candidate.adcp_version;
   }
   if (typeof candidate.build_version === 'string') {
     out.build_version = candidate.build_version;

--- a/test/lib/adcp-version-string-emit.test.js
+++ b/test/lib/adcp-version-string-emit.test.js
@@ -87,6 +87,16 @@ describe('extractVersionUnsupportedDetails', () => {
     assert.deepStrictEqual(out, { supported_versions: ['3.1'] });
   });
 
+  test('normalizes canonical adcp_version to requested_version', () => {
+    const out = extractVersionUnsupportedDetails({
+      details: { adcp_version: '3.2-beta.3', supported_versions: ['3.2-beta.2'] },
+    });
+    assert.deepStrictEqual(out, {
+      supported_versions: ['3.2-beta.2'],
+      requested_version: '3.2-beta.3',
+    });
+  });
+
   test('parses adcp_error.data nesting', () => {
     const out = extractVersionUnsupportedDetails({
       adcp_error: {

--- a/test/lib/cli-version-unsupported-hint.test.js
+++ b/test/lib/cli-version-unsupported-hint.test.js
@@ -1,0 +1,34 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  BUILT_IN_VERSION_HINT,
+  appendBuiltInVersionUnsupportedHint,
+} = require('../../bin/adcp-version-unsupported-hint.js');
+
+const builtIns = { 'test-mcp': { url: 'https://test.example/mcp/' } };
+
+test('built-in agent VERSION_UNSUPPORTED results include an actionable deployment hint', () => {
+  const result = {
+    overall_status: 'unreachable',
+    summary: { headline: 'Agent unreachable — VERSION_UNSUPPORTED: requested "3.2-beta.3"' },
+  };
+
+  const hinted = appendBuiltInVersionUnsupportedHint(result, 'test-mcp', builtIns);
+  assert.match(hinted.summary.headline, /VERSION_UNSUPPORTED/);
+  assert.match(hinted.summary.headline, new RegExp(BUILT_IN_VERSION_HINT.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  assert.notStrictEqual(hinted, result);
+});
+
+test('version hints are limited to built-in aliases and version failures', () => {
+  const versionFailure = {
+    summary: { headline: 'Agent unreachable — VERSION_UNSUPPORTED: requested "3.2-beta.3"' },
+  };
+  const networkFailure = { summary: { headline: 'Agent unreachable — connection refused' } };
+
+  assert.strictEqual(
+    appendBuiltInVersionUnsupportedHint(versionFailure, 'https://local.example/mcp', builtIns),
+    versionFailure
+  );
+  assert.strictEqual(appendBuiltInVersionUnsupportedHint(networkFailure, 'test-mcp', builtIns), networkFailure);
+});

--- a/test/lib/comply-abort.test.js
+++ b/test/lib/comply-abort.test.js
@@ -156,16 +156,20 @@ async function startTimeoutAgent(options = {}) {
       return okTool(res, rpc.id, { probed: true });
     }
     if (toolName === 'get_adcp_capabilities') {
-      return okTool(res, rpc.id, {
-        adcp: {
-          major_versions: [3],
-          supported_versions: ['3.1-rc.10'],
-          build_version: ADCP_VERSION,
-          idempotency: { supported: false },
-        },
-        supported_protocols: ['brand'],
-        specialisms: [],
-      });
+      return okTool(
+        res,
+        rpc.id,
+        options.capabilitiesResponse ?? {
+          adcp: {
+            major_versions: [3],
+            supported_versions: ['3.1-rc.10'],
+            build_version: ADCP_VERSION,
+            idempotency: { supported: false },
+          },
+          supported_protocols: ['brand'],
+          specialisms: [],
+        }
+      );
     }
 
     res.writeHead(200, { 'content-type': 'application/json' });
@@ -239,6 +243,48 @@ describe('comply() signal option', () => {
         return true;
       }
     );
+  });
+});
+
+describe('comply() exact-version capability refusal', () => {
+  test('does not retry major-only or misclassify VERSION_UNSUPPORTED as auth', async () => {
+    const complianceDir = writeTimeoutComplianceCache();
+    const agent = await startTimeoutAgent({
+      capabilitiesResponse: {
+        adcp_error: {
+          code: 'VERSION_UNSUPPORTED',
+          message: 'AdCP version 3.2-beta.3 is not supported',
+          details: {
+            adcp_version: '3.2-beta.3',
+            supported_versions: ['3.2-beta.2'],
+          },
+        },
+      },
+    });
+
+    try {
+      const result = await comply(agent.url, {
+        allow_http: true,
+        complianceDir,
+        storyboards: ['slow_timeout_one'],
+      });
+
+      assert.strictEqual(result.overall_status, 'unreachable');
+      assert.match(result.summary.headline, /VERSION_UNSUPPORTED/);
+      assert.match(result.summary.headline, /requested "3\.2-beta\.3"/);
+      assert.match(result.summary.headline, /seller supports "3\.2-beta\.2"/);
+      assert.deepStrictEqual(result.storyboards_executed, []);
+      assert.deepStrictEqual(result.tracks, []);
+      assert.strictEqual(result.agent_profile.raw_capabilities, undefined);
+      assert.strictEqual(
+        agent.requests.filter(request => request.tool === 'get_adcp_capabilities').length,
+        1,
+        'must not retry with a major-only version envelope'
+      );
+    } finally {
+      await closeServer(agent.server);
+      fs.rmSync(complianceDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/test/lib/discover-agent-profile-signal.test.js
+++ b/test/lib/discover-agent-profile-signal.test.js
@@ -130,6 +130,68 @@ describe('discoverAgentProfile: AbortSignal honored (#1612)', () => {
     assert.strictEqual(profile.capabilities_probe_error, 'get_adcp_capabilities returned no data');
   });
 
+  test('marks VERSION_UNSUPPORTED capability discovery as a hard failure with the version delta', async () => {
+    const client = {
+      getAgentInfo: async () => ({
+        name: 'Older prerelease seller',
+        tools: [{ name: 'get_adcp_capabilities' }, { name: 'get_products' }],
+      }),
+      getAdcpVersion: () => '3.2-beta.3',
+      getAdcpCapabilities: async () => ({
+        success: false,
+        error: 'AdCP version 3.2-beta.3 is not supported',
+        adcpError: {
+          code: 'VERSION_UNSUPPORTED',
+          message: 'AdCP version 3.2-beta.3 is not supported',
+          details: {
+            adcp_version: '3.2-beta.3',
+            supported_versions: ['3.1-rc.15', '3.2-beta.2'],
+          },
+        },
+      }),
+    };
+
+    const { profile, step } = await discoverAgentProfile(client);
+    assert.strictEqual(step.passed, false);
+    assert.match(step.error, /^VERSION_UNSUPPORTED:/);
+    assert.match(step.error, /3\.2-beta\.3/);
+    assert.match(step.error, /3\.2-beta\.2/);
+    assert.strictEqual(profile.capabilities_probe_error, step.error);
+    assert.strictEqual(profile.adcp_version, undefined, 'must not synthesize a v2 capability profile');
+  });
+
+  test('detects VERSION_UNSUPPORTED returned as successful tool data', async () => {
+    const client = {
+      getAgentInfo: async () => ({
+        name: 'Public test seller',
+        tools: [{ name: 'get_adcp_capabilities' }, { name: 'list_products' }],
+      }),
+      getAdcpVersion: () => '3.2-beta.3',
+      getAdcpCapabilities: async () => ({
+        success: true,
+        data: {
+          adcp_error: {
+            code: 'VERSION_UNSUPPORTED',
+            message: 'AdCP version 3.2-beta.3 is not supported',
+            details: {
+              adcp_version: '3.2-beta.3',
+              supported_versions: ['3.2-beta.2'],
+            },
+          },
+        },
+      }),
+    };
+
+    const { profile, step } = await discoverAgentProfile(client);
+    assert.strictEqual(step.passed, false);
+    assert.match(step.error, /^VERSION_UNSUPPORTED:/);
+    assert.match(step.error, /3\.2-beta\.2/);
+    assert.strictEqual(profile.capabilities_probe_error, step.error);
+    assert.strictEqual(profile.adcp_version, undefined, 'must not parse an error envelope as v2 capabilities');
+    assert.strictEqual(profile.raw_capabilities, undefined, 'must not publish an error envelope as capabilities');
+    assert.strictEqual(profile.capabilities_schema_issues, undefined, 'must not validate an error as success data');
+  });
+
   // code-reviewer follow-up on #1612: the wrapper covers the second
   // `getAdcpCapabilities()` call, not just the first `getAgentInfo()`.
   // Cover that path explicitly so a future refactor that bypasses

--- a/test/lib/zod-schemas.test.js
+++ b/test/lib/zod-schemas.test.js
@@ -821,6 +821,44 @@ describe('Zod Schema Validation', () => {
     );
   });
 
+  test('GetMediaBuysResponseSchema rejects creative approvals missing creative_id', async () => {
+    if (!schemas) {
+      schemas = await import('../../dist/lib/types/schemas.generated.js');
+    }
+
+    const responseWithApproval = approval => ({
+      status: 'completed',
+      media_buys: [
+        {
+          media_buy_id: 'mb_123',
+          status: 'active',
+          currency: 'USD',
+          total_budget: 50000,
+          confirmed_at: '2026-01-15T10:00:00Z',
+          revision: 1,
+          packages: [{ package_id: 'pkg_1', creative_approvals: [approval] }],
+        },
+      ],
+    });
+
+    assert.equal(
+      schemas.GetMediaBuysResponseSchema.safeParse(responseWithApproval({ approval_status: 'approved' })).success,
+      false
+    );
+    assert.equal(
+      schemas.GetMediaBuysResponseSchema.safeParse(
+        responseWithApproval({ indicator_types_evaluated: ['creative_fatigue'] })
+      ).success,
+      false
+    );
+    assert.equal(
+      schemas.GetMediaBuysResponseSchema.safeParse(
+        responseWithApproval({ creative_id: 'creative-1', approval_status: 'approved' })
+      ).success,
+      true
+    );
+  });
+
   test('GetMediaBuysResponseSchema validates response with snapshot', async () => {
     if (!schemas) {
       schemas = await import('../../dist/lib/types/schemas.generated.js');
@@ -1607,6 +1645,16 @@ describe('Zod Schema Validation', () => {
       !schemas.PostalAreaSupportSchema.safeParse({ NL: ['outward'] }).success,
       'postal support should keep future country keys restricted to postal_code/custom'
     );
+  });
+
+  test('PostalAreaSchema requires a non-empty native values list', async () => {
+    if (!schemas) {
+      schemas = await import('../../dist/lib/types/schemas.generated.js');
+    }
+
+    assert.equal(schemas.PostalAreaSchema.safeParse({ country: 'US', system: 'zip' }).success, false);
+    assert.equal(schemas.PostalAreaSchema.safeParse({ country: 'US', system: 'zip', values: [] }).success, false);
+    assert.equal(schemas.PostalAreaSchema.safeParse({ country: 'US', system: 'zip', values: ['10001'] }).success, true);
   });
 
   test('per-asset-type requirements schemas are typed (not z.any)', async () => {

--- a/test/type-generator-required-fields.test.js
+++ b/test/type-generator-required-fields.test.js
@@ -59,6 +59,83 @@ writeFileSync(__OUTPUT__, JSON.stringify({
   assert.equal(result.originalBranchesRemainUntouched, true);
 });
 
+test('PostalArea preserves the native branch fields and non-empty values type', () => {
+  const result = runGeneratorHarness(`
+import { readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { applyCodegenSchemaWorkarounds, enforceStrictSchema } from __GENERATOR__;
+
+const source = JSON.parse(
+  readFileSync(path.join(__REPO_ROOT__, 'schemas/cache/latest/core/postal-area.json'), 'utf8')
+);
+const transformed = applyCodegenSchemaWorkarounds(source, 'PostalArea');
+const native = transformed.anyOf.find((branch: any) => branch.title === 'Postal Country Area');
+const nested = enforceStrictSchema({ type: 'object', properties: { postal: source } })
+  .properties.postal.anyOf.find((branch: any) => branch.title === 'Postal Country Area');
+writeFileSync(__OUTPUT__, JSON.stringify({
+  hasAllOf: Array.isArray(native.allOf),
+  required: native.required,
+  properties: Object.keys(native.properties),
+  valuesMinItems: native.properties.values.minItems,
+  valuesTsType: native.properties.values.tsType,
+  nestedHasAllOf: Array.isArray(nested.allOf),
+  nestedProperties: Object.keys(nested.properties),
+}));
+`);
+
+  assert.equal(result.hasAllOf, false);
+  assert.deepEqual(result.required, ['country', 'system', 'values']);
+  assert.deepEqual(result.properties, ['country', 'system', 'values']);
+  assert.equal(result.valuesMinItems, 1);
+  assert.equal(result.valuesTsType, '[string, ...string[]]');
+  assert.equal(result.nestedHasAllOf, false);
+  assert.deepEqual(result.nestedProperties, ['country', 'system', 'values']);
+});
+
+test('GetMediaBuysResponse folds creative approval refinements without dropping base fields', () => {
+  const result = runGeneratorHarness(`
+import { readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { applyCodegenSchemaWorkarounds } from __GENERATOR__;
+
+const source = JSON.parse(
+  readFileSync(path.join(__REPO_ROOT__, 'schemas/cache/latest/media-buy/get-media-buys-response.json'), 'utf8')
+);
+const transformed = applyCodegenSchemaWorkarounds(source, 'GetMediaBuysResponse');
+const approval = transformed.properties.media_buys.items.properties.packages.items
+  .properties.creative_approvals.items;
+const indicatorTypeOverlay = (approval.properties.indicators.items.allOf ?? [])
+  .find((member: any) => member.properties?.type);
+const evaluatedTypeOverlay = (approval.properties.indicator_types_evaluated.items.allOf ?? [])
+  .find((member: any) => member.enum);
+writeFileSync(__OUTPUT__, JSON.stringify({
+  hasAllOf: Array.isArray(approval.allOf),
+  required: approval.required,
+  properties: Object.keys(approval.properties),
+  indicatorTypes: evaluatedTypeOverlay.enum,
+  indicatorKinds: indicatorTypeOverlay.properties.type.enum,
+}));
+`);
+
+  assert.equal(result.hasAllOf, false);
+  assert.ok(result.required.includes('creative_id'));
+  assert.ok(result.required.includes('approval_status'));
+  for (const field of [
+    'creative_id',
+    'approval_status',
+    'rejection_reason',
+    'approval_scopes',
+    'indicators',
+    'indicator_types_evaluated',
+    'indicators_as_of',
+    'indicators_evaluated_scope',
+  ]) {
+    assert.ok(result.properties.includes(field), `${field} should remain in the approval shape`);
+  }
+  assert.deepEqual(result.indicatorTypes, ['creative_fatigue', 'creative_quality_opportunity']);
+  assert.deepEqual(result.indicatorKinds, ['creative_fatigue', 'creative_quality_opportunity']);
+});
+
 test('refine_proposals result overlays preserve the canonical proposal base', () => {
   const result = runGeneratorHarness(`
 import { readFileSync, writeFileSync } from 'node:fs';


### PR DESCRIPTION
## Summary

- preserve inherited fields when generated schemas compose object branches with `allOf`
- restore the complete `PostalArea` runtime/type contract and its compatibility alias
- treat exact AdCP version incompatibility as an unreachable server result instead of retrying through auth or legacy fallbacks
- add an actionable CLI version-mismatch hint plus generator, runtime, compliance, and packed-adopter regressions

## Validation

- `npm run typecheck`
- `npm run build:lib`
- focused regression suite (116 tests)
- `npm run check:adopter-types`
- `npm run format:check`
- commitlint
- live `test-mcp` lifecycle command (now fails quickly and accurately on its beta.2/beta.3 mismatch)

Fixes #2628
Addresses #2629
