### PR TITLE
fix(conformance): grade structured product rejections

### DIFF
--- a/.changeset/tender-foxes-grade-rejections.md
+++ b/.changeset/tender-foxes-grade-rejections.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Treat AdCP 3.2 `get_products` structured rejection responses as successful business outcomes in client and storyboard result classification.

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -1385,9 +1385,7 @@ export class TaskExecutor {
       // Now unwrap the response
       const unwrapped = unwrapProtocolResponse(response, toolName, undefined, {
         filterInvalidProducts: this.config.filterInvalidProducts,
-        ...(this.responseAdcpVersionForValidation() && {
-          responseAdcpVersion: this.responseAdcpVersionForValidation(),
-        }),
+        responseAdcpVersion: this.effectiveResponseAdcpVersion(),
       });
 
       // Log successful extraction with result details
@@ -1428,7 +1426,7 @@ export class TaskExecutor {
    * Handles singular `error`, plural `errors` (AdCP schema), and `success: false`.
    */
   private isOperationSuccess(data: any, taskName?: string): boolean {
-    return isAdcpOperationSuccess(data, taskName);
+    return isAdcpOperationSuccess(data, taskName, this.effectiveResponseAdcpVersion());
   }
 
   /**
@@ -2612,6 +2610,11 @@ export class TaskExecutor {
   private responseAdcpVersionForValidation(): string | undefined {
     if (this.config.versionEnvelope === 'major-only') return '3.0';
     return undefined;
+  }
+
+  private effectiveResponseAdcpVersion(): string {
+    if (this.lastKnownServerVersion === 'v2') return 'v2.5';
+    return this.responseAdcpVersionForValidation() ?? this.config.adcpVersion ?? ADCP_VERSION;
   }
 
   /**

--- a/src/lib/testing/storyboard/task-map.test.ts
+++ b/src/lib/testing/storyboard/task-map.test.ts
@@ -361,6 +361,52 @@ describe('executeStoryboardTask — adcp_error forwarding', () => {
     }
   });
 
+  it('treats a raw get_products structured rejection as a successful business outcome', async () => {
+    const rejection = {
+      status: 'rejected',
+      reason: 'No inventory matches the requested brief',
+      suggestions: ['Try broadening the requested geography'],
+    };
+    const client = {
+      getAdcpVersion: () => '3.2.0-beta.3',
+      getProducts: async () => rejection,
+    };
+
+    const result = await executeStoryboardTask(client, 'get_products', {});
+
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual(rejection);
+    expect(result.data).not.toHaveProperty('products');
+  });
+
+  it('preserves a completed get_products structured rejection for storyboard validations', async () => {
+    const rejection = {
+      status: 'rejected',
+      reason: 'No inventory matches the requested brief',
+      suggestions: ['Try broadening the requested geography'],
+    };
+    const client = {
+      getAdcpVersion: () => '3.2.0-beta.3',
+      getProducts: async () => ({ success: true, status: 'completed', data: rejection }),
+    };
+
+    const result = await executeStoryboardTask(client, 'get_products', {});
+
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual(rejection);
+    expect(result.data).not.toHaveProperty('products');
+  });
+
+  it('keeps a bare get_products rejected status classified as a failure', async () => {
+    const client = {
+      getProducts: async () => ({ status: 'rejected' }),
+    };
+
+    const result = await executeStoryboardTask(client, 'get_products', {});
+
+    expect(result.success).toBe(false);
+  });
+
   it('does not treat advisory errors on a success payload as failure', async () => {
     const client = {
       getProducts: async () => ({

--- a/src/lib/testing/storyboard/task-map.ts
+++ b/src/lib/testing/storyboard/task-map.ts
@@ -212,21 +212,26 @@ export function defaultStoryboardResponseProjection(
 }
 
 function gradesLegacyCreativeWire(client: unknown): boolean {
-  if (client === null || typeof client !== 'object') return false;
-  const getAdcpVersion = (client as { getAdcpVersion?: unknown }).getAdcpVersion;
-  if (typeof getAdcpVersion !== 'function') return false;
-  let version: unknown;
-  try {
-    version = getAdcpVersion.call(client);
-  } catch {
-    return false;
-  }
-  if (typeof version !== 'string') return false;
+  const version = readClientAdcpVersion(client);
+  if (version === undefined) return false;
   const match = /^v?(\d+)(?:\.(\d+))?/.exec(version.trim());
   if (!match) return false;
   const major = Number(match[1]);
   const minor = Number(match[2] ?? 0);
   return major < 3 || (major === 3 && minor < 2);
+}
+
+function readClientAdcpVersion(client: unknown): string | undefined {
+  if (client === null || typeof client !== 'object') return undefined;
+  const getAdcpVersion = (client as { getAdcpVersion?: unknown }).getAdcpVersion;
+  if (typeof getAdcpVersion !== 'function') return undefined;
+  let version: unknown;
+  try {
+    version = getAdcpVersion.call(client);
+  } catch {
+    return undefined;
+  }
+  return typeof version === 'string' ? version : undefined;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -284,13 +289,15 @@ function normalizeStoryboardTaskSuccess(
   result: unknown,
   taskName: string,
   terminalDataError?: boolean,
-  adcpError?: AdcpErrorInfo
+  adcpError?: AdcpErrorInfo,
+  responseAdcpVersion?: string
 ): boolean {
   if (!isRecord(result)) return true;
   if (typeof result.success === 'boolean') return result.success;
-  if (result.status === 'failed' || result.status === 'rejected') return false;
+  if (result.status === 'failed') return false;
+  if (result.status === 'rejected' && isTerminalAdcpError(result, taskName, responseAdcpVersion)) return false;
   if (adcpError || result.adcpError || result.adcp_error) return false;
-  if (terminalDataError ?? isTerminalAdcpError(result.data, taskName)) return false;
+  if (terminalDataError ?? isTerminalAdcpError(result.data, taskName, responseAdcpVersion)) return false;
   return true;
 }
 
@@ -458,14 +465,19 @@ export async function executeStoryboardTask(
       }
     }
 
-    const terminalDataError = isTerminalAdcpError(result.data, taskName);
+    const responseAdcpVersion = readClientAdcpVersion(client);
+    const terminalDataError = isTerminalAdcpError(result.data, taskName, responseAdcpVersion);
     const adcpError =
       result.adcpError ??
       result.adcp_error ??
       readAdcpError(result.data) ??
       (terminalDataError ? readFirstError(result.data) : undefined);
-    const data = result.data ?? (adcpError ? { adcp_error: adcpError } : undefined);
-    const success = normalizeStoryboardTaskSuccess(result, taskName, terminalDataError, adcpError);
+    const isRawStructuredRejection =
+      result.data == null &&
+      result.status === 'rejected' &&
+      !isTerminalAdcpError(result, taskName, responseAdcpVersion);
+    const data = result.data ?? (isRawStructuredRejection ? result : adcpError ? { adcp_error: adcpError } : undefined);
+    const success = normalizeStoryboardTaskSuccess(result, taskName, terminalDataError, adcpError, responseAdcpVersion);
     const error = result.error ?? (!success ? errorMessageFrom(adcpError, undefined) : undefined);
     const extractionPath = readExtractionPath(data);
     const debugLogs = Array.isArray(result.debug_logs) ? result.debug_logs : [];

--- a/src/lib/utils/response-unwrapper.ts
+++ b/src/lib/utils/response-unwrapper.ts
@@ -190,8 +190,63 @@ export function hasAdvisorySuccessPayload(response: unknown, toolName?: string):
   return successFieldGroups.some(group => group.every(field => hasOwnField(obj, field)));
 }
 
-export function isTerminalAdcpError(response: unknown, toolName?: string): boolean {
+/**
+ * AdCP 3.2 models an inventory refusal from `get_products` as a successful,
+ * typed business outcome. Its `status: "rejected"` discriminator must not be
+ * confused with the task-envelope terminal state that uses the same literal.
+ */
+function isStructuredGetProductsRejection(response: unknown, toolName?: string, responseAdcpVersion?: string): boolean {
+  if (toolName !== 'get_products' || response == null || typeof response !== 'object' || Array.isArray(response)) {
+    return false;
+  }
+
+  const obj = response as Record<string, unknown>;
+  const effectiveVersion = typeof obj.adcp_version === 'string' ? obj.adcp_version : responseAdcpVersion;
+  const versionMatch =
+    typeof effectiveVersion === 'string' ? /^v?(\d+)\.(\d+)(?:\.|-|$)/.exec(effectiveVersion.trim()) : null;
+  const major = versionMatch?.[1] === undefined ? undefined : Number.parseInt(versionMatch[1], 10);
+  const minor = versionMatch?.[2] === undefined ? undefined : Number.parseInt(versionMatch[2], 10);
+  const declaresStructuredRejectionVersion =
+    major !== undefined && minor !== undefined && (major > 3 || (major === 3 && minor >= 2));
+  const suggestionsValid =
+    obj.suggestions === undefined ||
+    (Array.isArray(obj.suggestions) &&
+      obj.suggestions.length >= 1 &&
+      obj.suggestions.length <= 20 &&
+      obj.suggestions.every(
+        suggestion => typeof suggestion === 'string' && suggestion.length >= 1 && suggestion.length <= 1000
+      ));
+  const forbiddenFields = [
+    'products',
+    'proposals',
+    'errors',
+    'adcp_error',
+    'incomplete',
+    'cache_scope',
+    'filter_diagnostics',
+    'refinement_applied',
+    'unchanged',
+    'wholesale_feed_version',
+    'pricing_version',
+    'pagination',
+  ];
+  return (
+    declaresStructuredRejectionVersion &&
+    obj.status === 'rejected' &&
+    typeof obj.reason === 'string' &&
+    obj.reason.length >= 1 &&
+    obj.reason.length <= 2000 &&
+    suggestionsValid &&
+    obj.success !== false &&
+    obj.error == null &&
+    typeof obj.error_code !== 'string' &&
+    forbiddenFields.every(field => !hasOwnField(obj, field))
+  );
+}
+
+export function isTerminalAdcpError(response: unknown, toolName?: string, responseAdcpVersion?: string): boolean {
   const obj = response as Record<string, unknown> | null | undefined;
+  if (isStructuredGetProductsRejection(obj, toolName, responseAdcpVersion)) return false;
   if (obj?.status === 'failed' || obj?.status === 'rejected') return true;
   if (obj?.adcp_error && typeof (obj.adcp_error as { code?: unknown }).code === 'string') return true;
   if (typeof obj?.error_code === 'string') {
@@ -208,9 +263,14 @@ export function isTerminalAdcpError(response: unknown, toolName?: string): boole
  * A transport task may be `completed` while its operation payload is terminally
  * unsuccessful, so callers must evaluate both layers.
  */
-export function isAdcpOperationSuccess(response: unknown, toolName?: string): boolean {
+export function isAdcpOperationSuccess(response: unknown, toolName?: string, responseAdcpVersion?: string): boolean {
   const obj = response as Record<string, unknown> | null | undefined;
-  return obj?.success !== false && !obj?.error && !obj?.adcp_error && !isTerminalAdcpError(response, toolName);
+  return (
+    obj?.success !== false &&
+    !obj?.error &&
+    !obj?.adcp_error &&
+    !isTerminalAdcpError(response, toolName, responseAdcpVersion)
+  );
 }
 
 /**
@@ -269,7 +329,10 @@ export function unwrapProtocolResponse(
   // Skip schema validation for error responses — they don't include
   // tool-specific fields like `products`. Handles both AdCP-standard
   // { errors: [...] } and legacy singular { error: "..." } patterns.
-  if (isTerminalAdcpError(unwrapped, toolName) || (unwrapped?.error && typeof unwrapped.error === 'string')) {
+  if (
+    isTerminalAdcpError(unwrapped, toolName, options?.responseAdcpVersion) ||
+    (unwrapped?.error && typeof unwrapped.error === 'string')
+  ) {
     return retag(unwrapped);
   }
 
@@ -737,7 +800,7 @@ export function isAdcpError(response: any): boolean {
  */
 export function isAdcpSuccess(response: any, taskName: string, responseAdcpVersion?: string): boolean {
   // First check if it's an error response
-  if (isTerminalAdcpError(response, taskName)) {
+  if (isTerminalAdcpError(response, taskName, responseAdcpVersion)) {
     return false;
   }
 

--- a/test/lib/response-unwrapper.test.js
+++ b/test/lib/response-unwrapper.test.js
@@ -1342,6 +1342,40 @@ describe('Response Unwrapper', () => {
       assert.strictEqual(isAdcpSuccess(terminalPayload, 'report_usage'), false);
     });
 
+    test('get_products structured rejection is a successful business outcome', () => {
+      const structuredRejection = {
+        status: 'rejected',
+        adcp_version: '3.2-beta.3',
+        reason: 'No inventory matches the requested brief',
+        suggestions: ['Try broadening the requested geography'],
+      };
+
+      assert.strictEqual(isTerminalAdcpError(structuredRejection, 'get_products'), false);
+      assert.strictEqual(isAdcpSuccess(structuredRejection, 'get_products'), true);
+      assert.strictEqual(
+        isTerminalAdcpError({ ...structuredRejection, suggestions: undefined }, 'get_products'),
+        false
+      );
+      assert.strictEqual(isTerminalAdcpError(structuredRejection), true);
+      assert.strictEqual(
+        isTerminalAdcpError({ ...structuredRejection, adcp_error: { code: 'INVALID_REQUEST' } }, 'get_products'),
+        true
+      );
+      assert.strictEqual(
+        isTerminalAdcpError({ ...structuredRejection, adcp_version: '3.1', suggestions: undefined }, 'get_products'),
+        true
+      );
+      const versionlessRejection = { ...structuredRejection };
+      delete versionlessRejection.adcp_version;
+      assert.strictEqual(isTerminalAdcpError(versionlessRejection, 'get_products', '3.2.0-beta.3'), false);
+      assert.strictEqual(isAdcpSuccess(versionlessRejection, 'get_products', '3.2.0-beta.3'), true);
+      assert.strictEqual(isTerminalAdcpError(versionlessRejection, 'get_products', '3.1.15'), true);
+      assert.strictEqual(isTerminalAdcpError({ ...structuredRejection, suggestions: [] }, 'get_products'), true);
+      assert.strictEqual(isTerminalAdcpError({ ...structuredRejection, reason: '' }, 'get_products'), true);
+      assert.strictEqual(isTerminalAdcpError({ ...structuredRejection, products: [] }, 'get_products'), true);
+      assert.strictEqual(isTerminalAdcpError({ status: 'rejected' }, 'get_products'), true);
+    });
+
     test('task-aware terminal detection rejects envelope-only errors[] as failures', () => {
       const envelopeOnly = {
         status: 'completed',

--- a/test/lib/task-executor-operation-error.test.js
+++ b/test/lib/task-executor-operation-error.test.js
@@ -5,6 +5,32 @@ const { TaskExecutor } = require('../../dist/lib/core/TaskExecutor');
 const { ProtocolClient } = require('../../dist/lib/protocols');
 
 describe('TaskExecutor business rejection diagnostics', () => {
+  test('preserves a get_products structured rejection as a successful operation result', async () => {
+    const originalCallTool = ProtocolClient.callTool;
+    ProtocolClient.callTool = async () => ({
+      isError: false,
+      structuredContent: {
+        status: 'rejected',
+        reason: 'No inventory matches the requested brief',
+        suggestions: ['Try broadening the requested geography'],
+      },
+    });
+    const executor = new TaskExecutor({ strictSchemaValidation: false, adcpVersion: '3.2.0-beta.3' });
+    try {
+      const result = await executor.executeTask(
+        { id: 'seller', name: 'Seller', agent_uri: 'https://seller.example/mcp', protocol: 'mcp' },
+        'get_products',
+        {}
+      );
+      assert.equal(result.success, true);
+      assert.equal(result.status, 'completed');
+      assert.equal(result.data.status, 'rejected');
+      assert.equal(result.data.reason, 'No inventory matches the requested brief');
+    } finally {
+      ProtocolClient.callTool = originalCallTool;
+    }
+  });
+
   test('surfaces a valid business rejection reason through executeTask', async () => {
     const originalCallTool = ProtocolClient.callTool;
     ProtocolClient.callTool = async () => ({

--- a/test/lib/v2-getproducts-autowire.test.js
+++ b/test/lib/v2-getproducts-autowire.test.js
@@ -26,8 +26,23 @@ const { AgentClient, packageRefsForFormatOptions } = require('../../dist/lib/ind
  */
 const PRICING_OPTIONS = [{ pricing_option_id: 'po_cpm', pricing_model: 'cpm', currency: 'USD', fixed_price: 5 }];
 
-async function buildMockSeller(getProductsResponse, clientConfig = {}) {
+async function buildMockSeller(getProductsResponse, clientConfig = {}, { advertiseV3 = false } = {}) {
   const server = new McpServer({ name: 'autowire-test', version: '1.0.0' });
+  if (advertiseV3) {
+    server.registerTool('get_adcp_capabilities', { inputSchema: {} }, async () => {
+      const capabilities = {
+        status: 'completed',
+        adcp_version: '3.2.0-beta.3',
+        adcp: { major_versions: [3], supported_versions: ['3.2.0-beta.3'] },
+        supported_protocols: ['media_buy'],
+        specialisms: [],
+      };
+      return {
+        content: [{ type: 'text', text: JSON.stringify(capabilities) }],
+        structuredContent: capabilities,
+      };
+    });
+  }
   server.registerTool(
     'get_products',
     { inputSchema: { brief: z.string().optional(), adcp_major_version: z.number().optional() } },
@@ -54,6 +69,28 @@ async function buildMockSeller(getProductsResponse, clientConfig = {}) {
 }
 
 describe('AgentClient.getProducts — auto-wired v1→v2 projection', () => {
+  test('preserves a structured rejection without injecting product projection fields', async () => {
+    const rejection = {
+      status: 'rejected',
+      reason: 'No inventory matches the requested brief',
+      suggestions: ['Try broadening the requested geography'],
+    };
+    const { agent, close } = await buildMockSeller(rejection, {}, { advertiseV3: true });
+    try {
+      const result = await agent.getProducts({ brief: 'test' });
+
+      assert.strictEqual(result.success, true);
+      assert.strictEqual(result.status, 'completed');
+      assert.strictEqual(result.data.status, 'rejected');
+      assert.strictEqual(result.data.reason, rejection.reason);
+      assert.deepStrictEqual(result.data.suggestions, rejection.suggestions);
+      assert.strictEqual(result.data.products, undefined);
+      assert.strictEqual(result.data.projection, undefined);
+    } finally {
+      await close();
+    }
+  });
+
   test('v1 seller response becomes canonical-only by default', async () => {
     const v1Response = {
       success: true,


### PR DESCRIPTION
## Summary

- classify AdCP 3.2 `get_products` structured rejections as successful business outcomes
- use the explicit or negotiated AdCP version while preserving 3.1 rejection behavior
- preserve raw rejection payloads for storyboard validation and public client callers
- cover valid, malformed, legacy, transport, storyboard, and public-client paths

## Validation

- `npm run build:lib`
- `npm run typecheck`
- `npx vitest run src/lib/testing/storyboard/task-map.test.ts` (22 passed)
- `node --test test/lib/response-unwrapper.test.js test/lib/task-executor-operation-error.test.js test/lib/v2-getproducts-autowire.test.js` (97 passed)
- targeted ESLint (0 errors; existing warnings only)
- protocol, code, and test expert reviews: approved

Fixes #2631
