### PR TITLE
feat(comply): storyboard_start_offset — distribute coverage across budget-limited runs

### DIFF
--- a/.changeset/comply-storyboard-start-offset.md
+++ b/.changeset/comply-storyboard-start-offset.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': minor
+---
+
+comply: add `storyboard_start_offset` to distribute coverage across budget-limited runs (adcontextprotocol/adcp#6632). When `timeout_ms` truncates a run, execution previously always started from the same list head, so consecutive truncated runs re-graded the same prefix while tail storyboards were never exercised. The new option rotates the runnable storyboard list (modulo length, relative order preserved) so callers can vary the starting point between runs. The timeout-budget observation now also lists `storyboards_not_started` ids so per-run coverage gaps are inspectable, not just countable.

--- a/src/lib/testing/compliance/comply.ts
+++ b/src/lib/testing/compliance/comply.ts
@@ -545,6 +545,17 @@ export interface ComplyOptions extends TestOptions {
   tracks?: ComplianceTrack[];
   /** Timeout in milliseconds — stops new storyboards from starting when exceeded. */
   timeout_ms?: number;
+  /**
+   * Rotate the runnable storyboard list to start at this offset (modulo the
+   * list length) before sequential execution. Ordering is otherwise
+   * unchanged: the list wraps, so every storyboard still runs when the
+   * budget allows. Intended for budget-limited runs (`timeout_ms`): without
+   * rotation, consecutive truncated runs re-grade the same prefix and the
+   * tail storyboards are never exercised (adcontextprotocol/adcp#6632).
+   * Callers distribute coverage by varying the offset between runs (e.g.,
+   * a persisted per-agent run counter). Non-negative integer; default 0.
+   */
+  storyboard_start_offset?: number;
   /** AbortSignal for external cancellation (e.g., graceful shutdown). */
   signal?: AbortSignal;
   /** Original agent alias or identifier (used in fix_command instead of resolved URL). */
@@ -1147,6 +1158,7 @@ async function complyImpl(agentUrl: string, options: ComplyOptions): Promise<Com
     storyboards: explicitStoryboards,
     tracks: trackFilter,
     timeout_ms,
+    storyboard_start_offset,
     signal: externalSignal,
     webhook_receiver,
     webhook_replay_receiver,
@@ -1173,6 +1185,17 @@ async function complyImpl(agentUrl: string, options: ComplyOptions): Promise<Com
   if (timeout_ms !== undefined) {
     if (typeof timeout_ms !== 'number' || !Number.isFinite(timeout_ms) || timeout_ms <= 0) {
       throw new TypeError(`timeout_ms must be a positive finite number, got: ${timeout_ms}`);
+    }
+  }
+
+  // Validate storyboard_start_offset
+  if (storyboard_start_offset !== undefined) {
+    if (
+      typeof storyboard_start_offset !== 'number' ||
+      !Number.isInteger(storyboard_start_offset) ||
+      storyboard_start_offset < 0
+    ) {
+      throw new TypeError(`storyboard_start_offset must be a non-negative integer, got: ${storyboard_start_offset}`);
     }
   }
 
@@ -1381,6 +1404,15 @@ async function complyImpl(agentUrl: string, options: ComplyOptions): Promise<Com
       missingToolStoryboards.push(...applicability.missing);
     }
 
+    // Distribute coverage across budget-limited runs: rotate the execution
+    // starting point so consecutive `timeout_ms`-truncated runs don't
+    // re-grade the same prefix while the tail is never exercised
+    // (adcontextprotocol/adcp#6632). Rotation preserves relative order and
+    // is a no-op at offset 0 / when unset.
+    if (storyboard_start_offset !== undefined && storyboard_start_offset > 0) {
+      runnableStoryboards = rotateStoryboardsForOffset(runnableStoryboards, storyboard_start_offset);
+    }
+
     // Run storyboards
     const storyboardResults: StoryboardResult[] = [];
     const executedStoryboards: Storyboard[] = [];
@@ -1415,7 +1447,12 @@ async function complyImpl(agentUrl: string, options: ComplyOptions): Promise<Com
     }
     if (stoppedForTimeoutBudget) {
       allObservations.push(
-        buildComplyTimeoutBudgetObservation(timeout_ms!, storyboardResults.length, runnableStoryboards.length)
+        buildComplyTimeoutBudgetObservation(
+          timeout_ms!,
+          storyboardResults.length,
+          runnableStoryboards.length,
+          runnableStoryboards.slice(storyboardResults.length).map(sb => sb.id)
+        )
       );
     }
 
@@ -1568,10 +1605,24 @@ function hasComplyTimeoutBudgetExpired(start: number, timeout_ms: number | undef
   return timeout_ms !== undefined && now - start >= timeout_ms;
 }
 
+/**
+ * Rotate a storyboard list to start at `offset % length`, preserving relative
+ * order (the head wraps to the tail). Pure and deterministic: offset 0, an
+ * offset that is a multiple of the length, or an empty list all return the
+ * input order. See `ComplyOptions.storyboard_start_offset`.
+ */
+export function rotateStoryboardsForOffset<T>(items: readonly T[], offset: number): T[] {
+  if (items.length === 0) return [...items];
+  const shift = offset % items.length;
+  if (shift === 0) return [...items];
+  return [...items.slice(shift), ...items.slice(0, shift)];
+}
+
 function buildComplyTimeoutBudgetObservation(
   timeout_ms: number,
   storyboardsExecuted: number,
-  storyboardsSelected: number
+  storyboardsSelected: number,
+  storyboardsNotStarted: readonly string[] = []
 ): AdvisoryObservation {
   return {
     category: 'performance',
@@ -1584,6 +1635,9 @@ function buildComplyTimeoutBudgetObservation(
       storyboards_executed: storyboardsExecuted,
       storyboards_selected: storyboardsSelected,
       storyboards_remaining: Math.max(0, storyboardsSelected - storyboardsExecuted),
+      // Which storyboards never started — so budget-limited coverage gaps
+      // are inspectable per-run instead of only countable (adcp#6632).
+      storyboards_not_started: [...storyboardsNotStarted],
     },
     source: { kind: 'profile', code: 'timeout-budget-exceeded' },
   };

--- a/src/lib/testing/compliance/index.ts
+++ b/src/lib/testing/compliance/index.ts
@@ -10,6 +10,7 @@ export {
   computeOverallStatus,
   formatComplianceResults,
   formatComplianceResultsJSON,
+  rotateStoryboardsForOffset,
 } from './comply';
 export type { ComplyOptions } from './comply';
 

--- a/test/lib/comply-storyboard-offset.test.js
+++ b/test/lib/comply-storyboard-offset.test.js
@@ -1,0 +1,52 @@
+// storyboard_start_offset — distribute coverage across budget-limited comply()
+// runs (adcontextprotocol/adcp#6632). The rotation itself is a pure exported
+// helper so it is testable without a live agent; option validation is
+// asserted through comply(), which validates synchronously before any
+// network activity.
+const { describe, test } = require('node:test');
+const assert = require('node:assert');
+
+const { comply, rotateStoryboardsForOffset } = require('../../dist/lib/testing/compliance/index.js');
+
+describe('rotateStoryboardsForOffset', () => {
+  const items = ['a', 'b', 'c', 'd', 'e'];
+
+  test('offset 0 returns the input order', () => {
+    assert.deepStrictEqual(rotateStoryboardsForOffset(items, 0), items);
+  });
+
+  test('rotates to the offset, preserving relative order with wrap', () => {
+    assert.deepStrictEqual(rotateStoryboardsForOffset(items, 2), ['c', 'd', 'e', 'a', 'b']);
+  });
+
+  test('offset wraps modulo the list length', () => {
+    assert.deepStrictEqual(rotateStoryboardsForOffset(items, 5), items);
+    assert.deepStrictEqual(rotateStoryboardsForOffset(items, 7), ['c', 'd', 'e', 'a', 'b']);
+  });
+
+  test('empty list stays empty', () => {
+    assert.deepStrictEqual(rotateStoryboardsForOffset([], 3), []);
+  });
+
+  test('does not mutate the input', () => {
+    const input = ['a', 'b', 'c'];
+    rotateStoryboardsForOffset(input, 1);
+    assert.deepStrictEqual(input, ['a', 'b', 'c']);
+  });
+
+  test('rotation loses no items (set-equal at every offset)', () => {
+    for (let off = 0; off < 12; off++) {
+      const rotated = rotateStoryboardsForOffset(items, off);
+      assert.strictEqual(rotated.length, items.length);
+      assert.deepStrictEqual([...rotated].sort(), [...items].sort());
+    }
+  });
+});
+
+describe('comply() storyboard_start_offset validation', () => {
+  for (const bad of [-1, 1.5, NaN, Infinity, 'two']) {
+    test(`rejects ${String(bad)}`, async () => {
+      await assert.rejects(comply('https://agent.example/mcp', { storyboard_start_offset: bad }), TypeError);
+    });
+  }
+});


### PR DESCRIPTION
## Problem

Addresses the coverage-gap half of adcontextprotocol/adcp#6632 (P0).

When `timeout_ms` truncates a `comply()` run, execution always starts from the same head of the runnable list, so consecutive truncated runs re-grade the identical prefix while tail storyboards are never exercised. Observed against a production seller: two consecutive graded runs completed 19/67 then 9/67 storyboards — same prefix both times (reproduced locally: two `--timeout 45` runs against the same agent executed the identical 14/67 prefix). The newest graded surface (canonical-formats, package-selector storyboards) sits in the tail and has therefore never been exercised against a seller that implements it.

## Change

- `ComplyOptions.storyboard_start_offset?: number` — rotates the runnable storyboard list to start at `offset % length` before sequential execution. Relative order is preserved and the list wraps, so nothing is dropped; offset `0`/unset is a no-op (default behavior unchanged). Callers distribute coverage by varying the offset between runs (e.g., a persisted per-agent run counter in the hosted engine — happy to follow up with that consumption change in the adcp repo if this lands).
- Rotation is a pure exported helper (`rotateStoryboardsForOffset`) so it is unit-testable without a live agent.
- The timeout-budget observation now lists `storyboards_not_started` ids (additive `evidence` key; message unchanged), so a truncated run's coverage gap is inspectable per-run rather than only countable.
- Validation mirrors `timeout_ms` style: non-negative integer, `TypeError` otherwise, thrown synchronously before any network activity.

## Testing

- New `test/lib/comply-storyboard-offset.test.js` (11 tests): identity at offset 0, rotation with wrap, modulo behavior, empty list, input immutability, set-equality at every offset 0–11, and validation rejections (−1, 1.5, NaN, Infinity, non-number) via `comply()`.
- `test/lib/compliance.test.js` unchanged and passing (25/25) — the observation message is untouched so the `INCOMPLETE RUN` formatter contract still holds.
- `npm run build:lib` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)