### PR TITLE
fix(media-buy): harden legacy continuation settlement

### DIFF
--- a/.changeset/fair-dragons-settle.md
+++ b/.changeset/fair-dragons-settle.md
@@ -1,0 +1,11 @@
+---
+'@adcp/sdk': major
+---
+
+Harden legacy media-buy continuation dispatch, durable settlement, task correlation, replay-loss reporting, and projection validation across AdCP 3.0–3.2.
+
+This is a breaking prerelease correction. `RequestProposalsResponse` now exposes the complete `products_available` and `legacy_create` branch types instead of collapsing them to `{}`. Callers using legacy sellers that do not return a stable context ID must now configure `legacyPurchaseSellerSessionScope` from authenticated, restart-stable seller-session identity before issuing continuations.
+
+Custom durable `webhookRegistrationStore` implementations must implement `markRequiresDurableSettlement` so mutation callbacks remain fail-closed across restarts and replicas.
+
+Recordless legacy HMAC webhook fallback is now limited to explicitly read-only tools. Mutations, unknown extensions, and `get_products` callbacks require live registration provenance.

--- a/docs/guides/MEDIA-BUY-3.2-COMPATIBILITY.md
+++ b/docs/guides/MEDIA-BUY-3.2-COMPATIBILITY.md
@@ -167,23 +167,28 @@ accepted before the legacy `create_media_buy` mutation:
 const continuations = createInMemoryLegacyPurchaseContinuationStore();
 const lifecycle = await agent.negotiateMediaBuyLifecycle({
   principalScope: authenticatedPrincipalId,
-  // Required for 2.5 sellers that provide no server context ID. Persist this
-  // non-secret authenticated seller/account session ID across rehydration.
+  // Required for established 2.5, 3.0, and 3.1 sellers that provide no server
+  // context ID. Persist this non-secret authenticated session ID across rehydration.
   legacyPurchaseSellerSessionScope: authenticatedSellerSessionId,
   legacyPurchaseContinuationStore: continuations,
 });
 
 const discovery = await lifecycle.requestProposals({ account, brand, brief });
 if (discovery.status === 'completed' && discovery.data.outcome === 'products_available') {
-  const continuation = discovery.data.purchase_continuation!;
-  await lifecycle.continueLegacyPurchase({
-    idempotency_key: crypto.randomUUID(),
-    continuation_token: continuation.continuation_token,
-    account,
-    selected_product_ids: [continuation.product_ids[0]],
-    accepted_losses: continuation.losses,
-    legacy_create_request: exactLegacyCreateRequest,
-  });
+  const continuation = discovery.data.purchase_continuation;
+  if (continuation.kind === 'legacy_create') {
+    await lifecycle.continueLegacyPurchase({
+      idempotency_key: crypto.randomUUID(),
+      continuation_token: continuation.continuation_token,
+      account,
+      selected_product_ids: [continuation.product_ids[0]],
+      accepted_losses: continuation.losses,
+      legacy_create_request: exactLegacyCreateRequest,
+    });
+  } else {
+    // listed_purchase carries seller-issued feed/pricing fences and proceeds
+    // through the native buy_products flow.
+  }
 }
 ```
 
@@ -199,13 +204,22 @@ token. A claim is consumed at the first mutation; exact retries replay the
 recorded terminal `TaskResult` during the separate 24-hour operation replay
 window (configurable with `legacyPurchaseOperationTtlMs`).
 
-For an AdCP 2.5 seller without a server context ID,
+For any established seller without a server context ID,
 `legacyPurchaseSellerSessionScope` is required before a continuation can be
 issued. It must be a stable, non-secret ID derived by the application from the
 authenticated seller/account session—not a bearer token. Persist and reuse it
 with the continuation store so a restarted coordinator can redeem or replay
 the same operation without making the token portable to another credentialed
-session.
+session. This applies to 2.5, 3.0, and 3.1; endpoint identity is not an
+authenticated session identity. URL userinfo and presigned URLs are rejected
+before the discovered payload can enter durable storage.
+
+Every 2.5 continuation declares `mutation_idempotency_not_guaranteed`.
+3.0/3.1 continuations declare the same loss whenever the seller does not
+advertise a usable replay TTL; accepting an idempotency key alone is not treated
+as evidence that a mutation can be replayed safely. Submitted completions are
+accepted only for the exact seller task ID recorded at dispatch. Unstructured
+or SDK-synthetic terminal errors remain ambiguous and retain the durable fence.
 
 A transport crash becomes `LegacyPurchaseContinuationError` with
 `code: 'ambiguous'`. `reconcileLegacyPurchase(record, exactInput)` receives the
@@ -239,7 +253,7 @@ ambiguous, disposed, and expired refinements leave the source non-executable.
 | `declineProposals` | `decline_proposals` | proposal-scoped legacy omit | Rejected by default because omit is not a terminal decline and cannot carry the required compact reason/detail. Explicit opt-in reports `proposal_decline_not_terminal` and `proposal_decline_reason_not_forwarded`. |
 | `buyProducts` | `buy_products` | `create_media_buy` | Feed/pricing fencing is not atomic. Rejected by default; explicit opt-in names `feed_version_not_atomic` and, when present, `pricing_version_not_atomic`. Shared package fields and nested targeting/reporting enums map against the negotiated schema, including 3.1+ `format_option_refs`; newer targeting, metric, and postal shapes fail closed. v2.5 also rejects non-empty compact targeting and push notification configuration. A direct compact `total_budget` and fields introduced on the 3.2 established surface—including allocation, budget-cap, bidding, governance, opportunity, and newer package controls—map only on a negotiated 3.2 established lane. Compact `catalog_ids` and resolved `pricing` remain typed unsupported. |
 | `acceptProposal` | `accept_proposal` | `create_media_buy(proposal_id=...)` | A compact-shaped proposal retains strict digest, immutable-snapshot, account-scope, kind/status, and expiry checks. Caller values cannot override digest-bound budget, budget-cap, timezone, or purchase-order terms. An honest 3.0/3.1 proposal remains executable with its ordinary `proposal_id` semantics only after explicit opt-in to `proposal_terms_digest_not_enforced`, `proposal_terms_digest_unavailable`, and `proposal_snapshot_not_immutable` (plus `proposal_hold_not_verifiable` when it has no expiry). The caller supplies the original brand/flight as `established_fallback`; the SDK does not claim those values came from the seller or synthesize a digest. |
-| `controlMediaBuy` | `control_media_buy` | `update_media_buy` | Account, media-buy ID, and a positive revision are required. Revision and identically shaped fields present in the negotiated established schema map directly. v2.5 requires explicit `revision_not_atomic` opt-in and rejects cancellation plus v3-only package controls. Pre-3.2 lanes reject the broader compact optimization-goal union and nested targeting/keyword shapes they cannot represent. Compact `catalog_ids` cannot be cast to established `catalogs` objects, so it fails closed in every established lane. |
+| `controlMediaBuy` | `control_media_buy` | `update_media_buy` | Account, media-buy ID, and a positive revision are required. Revision and identically shaped fields present in the negotiated established schema map directly; `name` maps on the 3.2 established surface and fails closed on 3.0/3.1, whose update schemas do not define it. v2.5 requires explicit `revision_not_atomic` opt-in and rejects cancellation plus v3-only package controls. Pre-3.2 lanes reject the broader compact optimization-goal union and nested targeting/keyword shapes they cannot represent. Compact `catalog_ids` cannot be cast to established `catalogs` objects, so it fails closed in every established lane. |
 | Readback | shared tools | `get_media_buys`, `get_media_buy_delivery` | Same public calls and canonical creative projection in every lane. Versioned request additions fail closed: webhook-activity and delivery-window/granularity options require 3.1+, while `indicator_types`, demographic breakdowns, and spot breakdowns require 3.2. Native postal reporting shapes require 3.1+. |
 
 Lossy mutations are fail-closed. An adopter may opt into only the exact named

--- a/docs/guides/PUSH-NOTIFICATION-CONFIG.md
+++ b/docs/guides/PUSH-NOTIFICATION-CONFIG.md
@@ -123,6 +123,8 @@ app.post(
 
 The default registration and replay stores are process-local. Production receivers that can restart or run multiple replicas must inject a shared durable `webhookRegistrationStore` and `webhookVerification.replayStore`; registration writes must be atomic create-or-identical, and replay insertion must be atomic across replicas. Retain registrations for at least the seller retry horizon (seven days by default).
 
+Custom registration stores used by durability-protected mutation flows must also implement `markRequiresDurableSettlement(agentId, operationId)` as an atomic update of the live registration. The SDK calls this after registration but before claiming or dispatching the mutation. If the method is absent or the update fails, dispatch fails closed.
+
 For deterministic tests or infrastructure-managed keys, set `webhookVerification.jwks`. Otherwise seller key discovery is automatic and uses an unauthenticated official protocol client for the capabilities step, so credentials configured for one endpoint are never transplanted to the registered callback origin. Sellers whose capability discovery requires authentication should provide an origin-bound `webhookVerification.fetchCapabilities(agentUrl, protocol)` callback or inject `webhookVerification.jwks` directly.
 
 ### Legacy HMAC-SHA256
@@ -132,7 +134,7 @@ When `webhookSecret` is configured, the legacy webhook authentication path uses 
 - `x-adcp-signature: sha256=<hex digest>`
 - `x-adcp-timestamp: <unix seconds>`
 
-HMAC registration provenance never stores the credential or a secret-derived fingerprint. The configured global `webhookSecret` remains the verification key, preserving the established behavior across process restarts and replicas. If the optional registration store is unavailable, HMAC dispatch and verification continue; RFC 9421 dispatch fails closed because seller-pinned provenance is required for safe verification.
+HMAC registration provenance never stores the credential or a secret-derived fingerprint. The configured global `webhookSecret` remains the verification key. Recordless fallback is limited to an explicit set of read-only tasks; mutations, unknown extensions, and `get_products` (which has a state-changing legacy finalization variant) require a live trusted registration and fail closed when registration state is missing or unavailable. RFC 9421 always fails closed without seller-pinned provenance.
 
 Capture the raw request body before JSON parsing and verify it with the SDK helper:
 

--- a/scripts/generate-types.ts
+++ b/scripts/generate-types.ts
@@ -106,9 +106,17 @@ const PRIORITY_CANONICAL_SCHEMAS = [
 // churn in core.generated.ts.
 const PRIORITY_EXTRACTED_TYPES = [
   {
+    ref: 'media-buy/request-proposals-response.json',
+    typeName: 'RequestProposalsResponse',
+    reason:
+      'the async-response-data webhook union can collapse products_available and legacy_create branches to empty objects',
+    numberedReferenceAliases: ['ProductDiscoveryTargetingResolution'],
+  },
+  {
     ref: 'creative/sync-creatives-response.json',
     typeName: 'SyncCreativesSuccess',
     reason: 'the async-response-data webhook union can collapse the conditional creatives[] item to an empty object',
+    numberedReferenceAliases: [],
   },
 ] as const;
 
@@ -171,6 +179,7 @@ const CORE_AUTHORED_TOOL_SHARED_TYPES = new Set([
   'Provenance',
   'ProtocolEnvelope',
   'PurchaseType',
+  'RequestProposalsResponse',
   'RightsConstraint',
   'SignalDefinitionEnrichment',
   'SignalTargetingExpression',
@@ -1778,7 +1787,11 @@ export function applyCodegenSchemaWorkarounds(schema: any, schemaName: string): 
 
   schema = coalesceDefinitionKeywords(schema);
 
-  if (schemaName === 'DeclineProposalsResponse' || schemaName === 'RefineProposalsResponse') {
+  if (
+    schemaName === 'RequestProposalsResponse' ||
+    schemaName === 'DeclineProposalsResponse' ||
+    schemaName === 'RefineProposalsResponse'
+  ) {
     schema = materializeProposalResponseBranches(schema, schemaName);
   }
 
@@ -1890,7 +1903,7 @@ export function applyCodegenSchemaWorkarounds(schema: any, schemaName: string): 
 }
 
 function materializeProposalResponseBranches(schema: any, schemaName: string): any {
-  if (!schema?.properties || !Array.isArray(schema.anyOf) || schema.anyOf.length !== 2) return schema;
+  if (!schema?.properties || !Array.isArray(schema.anyOf) || schema.anyOf.length < 2) return schema;
 
   const branches: any[] = [];
   for (const member of schema.anyOf) {
@@ -1905,8 +1918,23 @@ function materializeProposalResponseBranches(schema: any, schemaName: string): a
       required: [...new Set([...(schema.required ?? []), ...(overlay.required ?? [])])],
       additionalProperties: schema.additionalProperties ?? false,
     };
+    for (const forbiddenArm of overlay.not?.anyOf ?? []) {
+      for (const forbiddenField of forbiddenArm?.required ?? []) {
+        if (schemaName === 'RequestProposalsResponse') {
+          // Keep forbidden fields as optional `never` properties. This
+          // preserves source-compatible union indexing/property reads while
+          // still making each discriminated arm reject the field.
+          branch.properties[forbiddenField] = false;
+        } else {
+          delete branch.properties[forbiddenField];
+        }
+      }
+    }
     const isCompleted = overlay.properties?.status?.const === 'completed';
-    if (isCompleted) delete branch.properties.task_id;
+    if (isCompleted) {
+      if (schemaName === 'RequestProposalsResponse') branch.properties.task_id = false;
+      else delete branch.properties.task_id;
+    }
 
     if (schemaName === 'RefineProposalsResponse' && branch.properties.results?.items) {
       const item = branch.properties.results?.items;
@@ -3646,7 +3674,10 @@ async function compileGapSchemas(generatedTypes: Set<string>, refResolver: any):
       }
       schema = applyCodegenSchemaWorkarounds(schema, pascalName);
 
-      const strictSchema = enforceStrictSchema(removeArrayLengthConstraints(injectJsdocConstraints(schema)));
+      const annotatedSchema = injectJsdocConstraints(schema);
+      const strictSchema = enforceStrictSchema(
+        typeName === 'RequestProposalsResponse' ? annotatedSchema : removeArrayLengthConstraints(annotatedSchema)
+      );
       const types = await compile(strictSchema, typeName, {
         bannerComment: '',
         style: { semi: true, singleQuote: true },
@@ -3778,13 +3809,16 @@ async function generateTypes() {
   }
   console.log(`✅ Generated ${PRIORITY_CANONICAL_SCHEMAS.length} priority canonical schemas`);
 
-  for (const { ref, typeName, reason } of PRIORITY_EXTRACTED_TYPES) {
+  for (const { ref, typeName, reason, numberedReferenceAliases } of PRIORITY_EXTRACTED_TYPES) {
     try {
       const schema = loadCachedSchema(ref);
       if (!schema) throw new Error(`Schema ${ref} not found in cache`);
       const rootTypeName =
         typeof schema.title === 'string' ? schema.title.replace(/[^A-Za-z0-9]/g, '') : schemaPathToTypeName(ref);
-      const strictSchema = enforceStrictSchema(removeArrayLengthConstraints(injectJsdocConstraints(schema)));
+      const annotatedSchema = injectJsdocConstraints(schema);
+      const strictSchema = enforceStrictSchema(
+        typeName === 'RequestProposalsResponse' ? annotatedSchema : removeArrayLengthConstraints(annotatedSchema)
+      );
       const types = await compile(strictSchema, rootTypeName, {
         bannerComment: '',
         style: { semi: true, singleQuote: true },
@@ -3800,7 +3834,10 @@ async function generateTypes() {
       // Suppress every auxiliary declaration from this compile. Those types
       // retain their normal first-definition ownership later in generation.
       const suppressedNames = new Set([...generatedCoreTypes, ...emittedNames].filter(name => name !== typeName));
-      const extractedType = filterDuplicateTypeDefinitions(types, suppressedNames);
+      let extractedType = filterDuplicateTypeDefinitions(types, suppressedNames);
+      for (const baseName of numberedReferenceAliases) {
+        extractedType = extractedType.replace(new RegExp(`\\b${baseName}\\d+\\b`, 'g'), baseName);
+      }
       if (!new RegExp(`^export (?:type|interface) ${typeName}\\b`, 'm').test(extractedType)) {
         throw new Error(`Unable to isolate ${typeName} from ${ref}`);
       }

--- a/scripts/generate-zod-from-ts.ts
+++ b/scripts/generate-zod-from-ts.ts
@@ -752,18 +752,18 @@ function postProcessCompatibilityPurchaseCoordinatorInput(content: string): stri
 /** Restore beta.4 runtime-only membership constraints on projected legacy continuations. */
 function postProcessLegacyPurchaseContinuationResponse(content: string): string {
   const schemaStart = content.indexOf('export const RequestProposalsResponseSchema = ');
-  const schemaEnd = content.indexOf('\n\nexport const RefineProposalsResponseSchema = ', schemaStart);
+  const schemaEnd = content.indexOf('\n\nexport const ', schemaStart + 1);
   if (schemaStart < 0 || schemaEnd < 0) {
     throw new Error('Could not locate RequestProposalsResponseSchema.');
   }
   const block = content.slice(schemaStart, schemaEnd);
   const armPattern =
-    /z\.object\(\{\n\s+kind: z\.literal\("legacy_create"\),[\s\S]*?requires_explicit_acceptance: z\.literal\(true\)\n\s+\}\)\.passthrough\(\)/;
-  const match = block.match(armPattern);
-  if (!match) {
+    /z\.object\(\{\n\s+kind: z\.literal\("legacy_create"\),[\s\S]*?requires_explicit_acceptance: z\.literal\(true\)\n\s+\}\)\.passthrough\(\)/g;
+  const matches = [...block.matchAll(armPattern)];
+  if (matches.length === 0) {
     throw new Error('Could not locate the legacy_create purchase continuation response arm.');
   }
-  const refinedArm = `${match[0]}.superRefine((value, ctx) => {
+  const refineArm = (arm: string) => `${arm}.superRefine((value, ctx) => {
             if (value.product_ids.length === 0) {
                 ctx.addIssue({ code: "custom", path: ["product_ids"], message: "product_ids must contain at least one entry" });
             }
@@ -788,12 +788,15 @@ function postProcessLegacyPurchaseContinuationResponse(content: string): string 
                 ctx.addIssue({ code: "custom", path: ["losses"], message: "AdCP 2.5 losses must contain mutation_idempotency_not_guaranteed" });
             }
         })`;
-  const corrected = block.replace(armPattern, refinedArm);
-  const suffix = '}).passthrough());';
-  if (!corrected.endsWith(suffix)) {
-    throw new Error('RequestProposalsResponseSchema has an unexpected generated suffix.');
+  const corrected = block.replace(armPattern, refineArm);
+  if (!corrected.endsWith(';')) {
+    throw new Error('RequestProposalsResponseSchema has an unexpected generated terminator.');
   }
-  const rootRefinement = `}).passthrough()).superRefine((value, ctx) => {
+  // Attach the source-schema invariants to whichever top-level expression
+  // ts-to-zod emits. The old lossy type produced union(...).and(object(...));
+  // while the materialized discriminated type correctly produces union(...);
+  // coupling this postprocessor to either suffix makes type generation fragile.
+  const rootRefinement = `.superRefine((value: any, ctx) => {
     const present = (field: string): boolean => Object.prototype.hasOwnProperty.call(value, field);
     const requireNonEmptyArray = (field: "products" | "proposals"): void => {
         if (!Array.isArray(value[field]) || value[field].length === 0) {
@@ -806,7 +809,7 @@ function postProcessLegacyPurchaseContinuationResponse(content: string): string 
         }
     };
     forbid(["refinement_applied", "pagination", "unchanged", "wholesale_feed_version"]);
-    if (value.suggestions !== undefined && (value.suggestions.length === 0 || value.suggestions.some(suggestion => suggestion.length === 0))) {
+    if (value.suggestions !== undefined && (value.suggestions.length === 0 || value.suggestions.some((suggestion: string) => suggestion.length === 0))) {
         ctx.addIssue({ code: "custom", path: ["suggestions"], message: "suggestions must contain non-empty strings" });
     }
     if (value.incomplete !== undefined && value.incomplete.length === 0) {
@@ -824,18 +827,18 @@ function postProcessLegacyPurchaseContinuationResponse(content: string): string 
         forbid(["proposals", "reason", "suggestions", "task_id"]);
         if (value.purchase_continuation?.kind === "listed_purchase") {
             const ids = value.purchase_continuation.product_ids;
-            if (ids.length === 0 || ids.some(productId => productId.length === 0)) {
+            if (ids.length === 0 || ids.some((productId: string) => productId.length === 0)) {
                 ctx.addIssue({ code: "custom", path: ["purchase_continuation", "product_ids"], message: "product_ids must contain non-empty IDs" });
             }
             if (new Set(ids).size !== ids.length) {
                 ctx.addIssue({ code: "custom", path: ["purchase_continuation", "product_ids"], message: "product_ids must be unique" });
             }
-            const returnedIds = (value.products ?? []).map(product => product.product_id);
+            const returnedIds = (value.products ?? []).map((product: any) => product.product_id);
             const returnedIdSet = new Set(returnedIds);
             if (
                 returnedIds.length !== ids.length ||
                 returnedIdSet.size !== returnedIds.length ||
-                ids.some(productId => !returnedIdSet.has(productId))
+                ids.some((productId: string) => !returnedIdSet.has(productId))
             ) {
                 ctx.addIssue({ code: "custom", path: ["purchase_continuation", "product_ids"], message: "listed product_ids must exactly match returned products" });
             }
@@ -855,7 +858,7 @@ function postProcessLegacyPurchaseContinuationResponse(content: string): string 
         forbid(["proposals", "products", "incomplete", "purchase_continuation", "task_id"]);
     }
 });`;
-  const constrained = corrected.slice(0, -suffix.length) + rootRefinement;
+  const constrained = corrected.slice(0, -1) + rootRefinement;
   return content.slice(0, schemaStart) + constrained + content.slice(schemaEnd);
 }
 

--- a/src/lib/core/AgentClient.ts
+++ b/src/lib/core/AgentClient.ts
@@ -29,6 +29,7 @@ import {
 } from './SingleAgentClient';
 import type { InputHandler, TaskOptions, TaskResult, TaskInfo, Message } from './ConversationTypes';
 import type { BeforeProtocolDispatchHook } from './TaskExecutor';
+import { assertNativeRequestProposalsTask, guardNativeRequestProposalsCompletion } from './request-proposals-guard';
 import type { AdcpCapabilities } from '../utils/capabilities';
 import type { WebhookHeaderValue } from '../webhooks';
 import type {
@@ -404,6 +405,15 @@ export class AgentClient {
     return (this.client as any).executor;
   }
 
+  /** Poll one authoritative server task status for compatibility coordinators. @internal */
+  getTaskStatus(
+    taskId: string,
+    transport?: import('../protocols').TransportOptions,
+    signal?: AbortSignal
+  ): Promise<TaskInfo> {
+    return this.executor.getTaskStatus(this.agent, taskId, transport, signal) as Promise<TaskInfo>;
+  }
+
   /**
    * Returns the AdCP protocol version this client speaks. Mirrors
    * `SingleAgentClient.getAdcpVersion()`. See {@link SingleAgentClientConfig.adcpVersion}.
@@ -683,14 +693,7 @@ export class AgentClient {
       inputHandler,
       this.withSession('request_proposals', options)
     );
-    if (
-      result.data &&
-      (result.data.outcome === 'products_available' || result.data.purchase_continuation !== undefined)
-    ) {
-      throw new TypeError(
-        'request_proposals returned the projection-only products_available outcome from a native compact seller.'
-      );
-    }
+    guardNativeRequestProposalsCompletion(result);
     this.retainSession(result);
     return result;
   }
@@ -1737,7 +1740,7 @@ export class AgentClient {
    * Get active tasks for this agent
    */
   getActiveTasks() {
-    return this.client.getActiveTasks();
+    return this.client.getActiveTasks().map(assertNativeRequestProposalsTask);
   }
 
   // ====== GENERIC TASK EXECUTION ======
@@ -1771,6 +1774,12 @@ export class AgentClient {
     switch (taskName) {
       case 'get_products':
         return this.getProducts(params as CanonicalGetProductsRequest, inputHandler, options);
+      case 'request_proposals':
+        return (await this.requestProposals(
+          params as MutatingRequestInput<RequestProposalsRequest>,
+          inputHandler,
+          options
+        )) as TaskResult<unknown>;
       case 'refine_proposals':
         return (await this.refineProposals(
           params as RefineProposalsInput,
@@ -1851,21 +1860,22 @@ export class AgentClient {
    * List all tasks for this agent
    */
   async listTasks(): Promise<TaskInfo[]> {
-    return this.client.listTasks();
+    return (await this.client.listTasks()).map(assertNativeRequestProposalsTask);
   }
 
   /**
    * Get detailed information about a specific task
    */
   async getTaskInfo(taskId: string): Promise<TaskInfo | null> {
-    return this.client.getTaskInfo(taskId);
+    const task = await this.client.getTaskInfo(taskId);
+    return task ? assertNativeRequestProposalsTask(task) : null;
   }
 
   /**
    * Subscribe to task notifications for this agent
    */
   onTaskUpdate(callback: (task: TaskInfo) => void): () => void {
-    return this.client.onTaskUpdate(callback);
+    return this.client.onTaskUpdate(task => callback(assertNativeRequestProposalsTask(task)));
   }
 
   /**
@@ -1877,7 +1887,15 @@ export class AgentClient {
     onTaskCompleted?: (task: TaskInfo) => void;
     onTaskFailed?: (task: TaskInfo, error: string) => void;
   }): () => void {
-    return this.client.onTaskEvents(callbacks);
+    const safe = (task: TaskInfo): TaskInfo => assertNativeRequestProposalsTask(task);
+    return this.client.onTaskEvents({
+      ...(callbacks.onTaskCreated && { onTaskCreated: task => callbacks.onTaskCreated!(safe(task)) }),
+      ...(callbacks.onTaskUpdated && { onTaskUpdated: task => callbacks.onTaskUpdated!(safe(task)) }),
+      ...(callbacks.onTaskCompleted && { onTaskCompleted: task => callbacks.onTaskCompleted!(safe(task)) }),
+      ...(callbacks.onTaskFailed && {
+        onTaskFailed: (task, error) => callbacks.onTaskFailed!(safe(task), error),
+      }),
+    });
   }
 
   /**

--- a/src/lib/core/AsyncHandler.ts
+++ b/src/lib/core/AsyncHandler.ts
@@ -48,7 +48,6 @@ import type {
   SyncCreativesAsyncInputRequired,
   SyncCreativesAsyncSubmitted,
   SyncCreativesAsyncWorking,
-  TaskStatus,
   TaskType,
   UpdateMediaBuyAsyncInputRequired,
   UpdateMediaBuyAsyncSubmitted,
@@ -80,7 +79,7 @@ export interface WebhookMetadata {
   /** Task type/tool name */
   task_type: string;
   /** Task status (completed, failed, needs_input, working, etc) */
-  status: TaskStatus;
+  status: TaskResultMetadata['status'] | 'unknown';
   /** Server's context ID */
   context_id?: string;
   /** Human-readable context about the status change */
@@ -371,6 +370,21 @@ export interface AsyncHandlerConfig {
 export class AsyncHandler {
   constructor(private config: AsyncHandlerConfig) {}
 
+  /** Emit duplicate observability without re-running public result handlers. */
+  async handleDurableSettlementDuplicate(metadata: WebhookMetadata): Promise<void> {
+    await this.emitActivity({
+      type: 'webhook_duplicate',
+      operation_id: metadata.operation_id,
+      agent_id: metadata.agent_id,
+      context_id: metadata.context_id,
+      task_id: metadata.task_id,
+      task_type: metadata.task_type,
+      status: metadata.status,
+      idempotency_key: metadata.idempotency_key,
+      timestamp: metadata.timestamp,
+    });
+  }
+
   /**
    * Handle incoming webhook payload (both task completions and notifications)
    */
@@ -409,7 +423,7 @@ export class AsyncHandler {
       task_id: metadata.task_id,
       task_type: metadata.task_type,
       status: metadata.status,
-      payload: metadata.rawHTTPPayload?.result ?? result,
+      payload: result,
       timestamp: metadata.timestamp,
     });
 

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -343,6 +343,7 @@ const RECORDLESS_HMAC_READ_ONLY_TASKS = new Set([
   'list_creatives',
   'get_media_buys',
   'get_media_buy_delivery',
+  'media_buy_delivery',
   'get_creative_delivery',
   'get_signals',
   'list_accounts',

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -95,8 +95,18 @@ import { A2AClient as A2AClientImpl } from '@a2a-js/sdk/client';
 // the prior CommonJS `require('@a2a-js/sdk/client')` behaviour.
 const A2AClient: any = A2AClientImpl;
 
-import { TaskExecutor, BeforeProtocolDispatchHookError, type BeforeProtocolDispatchHook } from './TaskExecutor';
+import {
+  TaskExecutor,
+  AfterProtocolDispatchHookError,
+  BeforeProtocolDispatchHookError,
+  type BeforeProtocolDispatchHook,
+} from './TaskExecutor';
 import { attachMatch } from './match';
+import {
+  assertNativeRequestProposalsResult,
+  assertNativeRequestProposalsTask,
+  guardNativeRequestProposalsCompletion,
+} from './request-proposals-guard';
 import { withTaskDeadline } from './task-deadline';
 import { createMCPRequestHeaders } from '../auth';
 import { isAbortOrTimeoutError } from '../protocols/abort';
@@ -319,6 +329,28 @@ const CANONICAL_CREATIVE_ACTIVITY_TASKS = new Set([
   'get_media_buys',
   'get_media_buy_delivery',
   'get_creative_delivery',
+]);
+
+// Missing legacy-HMAC registrations are safe only for tools that cannot
+// mutate seller state. `get_products` is intentionally absent because its
+// legacy proposal-finalization variant is state-changing.
+const RECORDLESS_HMAC_READ_ONLY_TASKS = new Set([
+  'get_adcp_capabilities',
+  'list_products',
+  'list_creative_formats',
+  'list_transformers',
+  'list_creatives',
+  'get_media_buys',
+  'get_media_buy_delivery',
+  'get_creative_delivery',
+  'get_signals',
+  'list_accounts',
+  'get_property_list',
+  'list_property_lists',
+  'list_content_standards',
+  'get_content_standards',
+  'si_get_offering',
+  'get_plan_audit_logs',
 ]);
 
 /**
@@ -918,6 +950,7 @@ export type WebhookParseErrorCode =
   | 'webhook_registration_mismatch'
   | 'webhook_verification_context_missing'
   | 'webhook_registration_store_unavailable'
+  | 'webhook_durable_settlement_unavailable'
   | 'webhook_verification_unavailable';
 
 export interface WebhookVerificationConfig {
@@ -996,6 +1029,7 @@ export interface WebhookParseSuccess {
     timestamp?: string;
     message?: string;
     previewHandler?: 'canonical' | 'legacy';
+    requiresDurableSettlement?: boolean;
   };
 }
 
@@ -1486,6 +1520,8 @@ export class SingleAgentClient {
       agentId: agent.id,
       webhookSecret: config.webhookSecret,
       onWebhookRegistration: registration => this.persistWebhookRegistration(registration),
+      onDurableSettlementRequired: operationId => this.markWebhookDurableSettlementRequired(operationId),
+      externalTaskSettlementRetentionMs: registrationTtl * 1000,
       strictSchemaValidation: config.validation?.strictSchemaValidation !== false, // Default: true
       logSchemaViolations: config.validation?.logSchemaViolations !== false, // Default: true
       filterInvalidProducts: config.validation?.filterInvalidProducts === true, // Default: false
@@ -1540,10 +1576,14 @@ export class SingleAgentClient {
         this.canonicalCreativeTaskAssociations.delete(args.operationId);
       }
     }
+    const persistedAgentUrl = new URL(args.agent.agent_uri);
+    persistedAgentUrl.username = '';
+    persistedAgentUrl.password = '';
+    persistedAgentUrl.hash = '';
     try {
       await this.webhookRegistrationStore.putIfAbsent({
         agentId: args.agent.id,
-        agentUrl: args.agent.agent_uri,
+        agentUrl: persistedAgentUrl.toString(),
         protocol: args.agent.protocol,
         operationId: args.operationId,
         taskType: args.taskType,
@@ -1560,6 +1600,16 @@ export class SingleAgentClient {
       // pre-registration behavior across restarts and replicas.
       if (args.mode === 'rfc9421') throw cause;
     }
+  }
+
+  private async markWebhookDurableSettlementRequired(operationId: string): Promise<void> {
+    const mark = this.webhookRegistrationStore.markRequiresDurableSettlement;
+    if (!mark) {
+      throw new ConfigurationError(
+        'A custom webhookRegistrationStore must implement markRequiresDurableSettlement for durable mutation callbacks.'
+      );
+    }
+    await mark.call(this.webhookRegistrationStore, this.agent.id, operationId);
   }
 
   private webhookJwksFor(registration: Readonly<WebhookRegistration>): JwksResolver {
@@ -2511,7 +2561,12 @@ export class SingleAgentClient {
       try {
         registration = await this.webhookRegistrationStore.get(this.agent.id, trustedOperationId);
       } catch (cause) {
-        if (!this.config.webhookSecret) {
+        const routedTaskType = options.taskType && options.taskType !== 'unknown' ? options.taskType : undefined;
+        if (
+          !this.config.webhookSecret ||
+          routedTaskType === undefined ||
+          !RECORDLESS_HMAC_READ_ONLY_TASKS.has(routedTaskType)
+        ) {
           return {
             ok: false,
             code: 'webhook_registration_store_unavailable',
@@ -2539,7 +2594,33 @@ export class SingleAgentClient {
           message: 'Webhook registration state contains invalid timestamps.',
         };
       }
+      try {
+        const registeredAgentUrl = new URL(registration.agentUrl);
+        if (registeredAgentUrl.username || registeredAgentUrl.password) {
+          throw new TypeError('Webhook registration seller URL contains userinfo.');
+        }
+      } catch (cause) {
+        return {
+          ok: false,
+          code: 'webhook_registration_store_unavailable',
+          message: 'Webhook registration state contains an invalid seller URL.',
+          cause,
+        };
+      }
       if (registration.expiresAt <= nowMs) registration = undefined;
+    }
+
+    const trustedRouteTaskType = options.taskType && options.taskType !== 'unknown' ? options.taskType : undefined;
+    if (
+      !registration &&
+      this.config.webhookSecret &&
+      (trustedRouteTaskType === undefined || !RECORDLESS_HMAC_READ_ONLY_TASKS.has(trustedRouteTaskType))
+    ) {
+      return {
+        ok: false,
+        code: 'webhook_registration_store_unavailable',
+        message: 'A trusted webhook registration is required for this task type.',
+      };
     }
 
     if (authHeaders.hasRfc9421 && !trustedOperationId) {
@@ -2851,6 +2932,7 @@ export class SingleAgentClient {
           previewHandler,
           timestamp: normalizedPayload.timestamp,
           idempotencyKey: normalizedPayload.idempotency_key,
+          requiresDurableSettlement: registration?.requiresDurableSettlement,
         },
       };
     } catch (error) {
@@ -2927,8 +3009,58 @@ export class SingleAgentClient {
         canonicalResult as AdCPAsyncResponseData | undefined,
         metadata
       );
-      const webhookResult = policyDispatch.result;
+      let webhookResult = policyDispatch.result;
       metadata = policyDispatch.metadata;
+
+      if (metadata.task_type === 'request_proposals') {
+        assertNativeRequestProposalsResult(webhookResult);
+      }
+
+      if (
+        parsed.metadata.requiresDurableSettlement === true &&
+        !this.executor.hasExternalTaskSettlementRoute(metadata.operation_id)
+      ) {
+        throw new WebhookDispatchError(
+          'webhook_durable_settlement_unavailable',
+          'The callback requires durable mutation settlement, but no recoverable settlement route is available.'
+        );
+      }
+
+      const externalStatus = await this.executor.observeExternalTaskStatus(
+        metadata.operation_id,
+        metadata.status as import('./ConversationTypes').TaskStatus,
+        webhookResult,
+        { serverTaskId: metadata.task_id, taskType: metadata.task_type }
+      );
+      if (externalStatus.duplicate) {
+        metadata = {
+          ...metadata,
+          status: externalStatus.status ?? metadata.status,
+          ...(externalStatus.error !== undefined && { message: externalStatus.error }),
+        };
+        const duplicateActivity: Activity = {
+          type: 'webhook_duplicate',
+          operation_id: metadata.operation_id,
+          agent_id: metadata.agent_id,
+          context_id: metadata.context_id,
+          task_id: metadata.task_id,
+          task_type: metadata.task_type,
+          status: metadata.status,
+          idempotency_key: metadata.idempotency_key,
+          timestamp: metadata.timestamp,
+        };
+        await this.config.onActivity?.(canonicalCreativeActivity(duplicateActivity));
+        await this.asyncHandler?.handleDurableSettlementDuplicate(metadata);
+        return true;
+      }
+      if (externalStatus.settled) {
+        webhookResult = externalStatus.result as AdCPAsyncResponseData | undefined;
+        metadata = {
+          ...metadata,
+          status: externalStatus.status ?? metadata.status,
+          ...(externalStatus.error !== undefined && { message: externalStatus.error }),
+        };
+      }
 
       // Emit activity
       await this.config.onActivity?.(
@@ -2940,7 +3072,7 @@ export class SingleAgentClient {
           task_id: metadata.task_id,
           task_type: metadata.task_type,
           status: metadata.status,
-          payload: canonicalResult,
+          payload: webhookResult,
           timestamp: metadata.timestamp,
         })
       );
@@ -2959,11 +3091,6 @@ export class SingleAgentClient {
 
       return false;
     } finally {
-      this.executor.observeExternalTaskStatus(
-        metadata.operation_id,
-        metadata.status as import('./ConversationTypes').TaskStatus,
-        metadata.rawHTTPPayload
-      );
       this.forgetProductPolicyRequestParams(metadata);
     }
   }
@@ -3281,8 +3408,9 @@ export class SingleAgentClient {
           res.end(JSON.stringify({ status: 'accepted', received: handled }));
         }
       } catch (error: unknown) {
-        // Return error
-        const errorMessage = error instanceof Error ? error.message : String(error);
+        // Stable verification/dispatch errors are safe for callers. Never
+        // reflect arbitrary handler, storage, or infrastructure messages.
+        const errorMessage = error instanceof WebhookDispatchError ? error.message : 'Webhook could not be processed.';
         const statusCode = webhookErrorHttpStatus(error);
 
         if (res.json) {
@@ -5005,9 +5133,13 @@ export class SingleAgentClient {
     inputHandler?: InputHandler,
     options?: CreativeDeliveryTaskOptions
   ): Promise<TaskResult<CreateMediaBuyResponse>> {
+    // Snapshot synchronously at the public boundary. Request validation and
+    // endpoint/capability discovery contain awaits; callers must not be able to
+    // mutate nested commercial terms between validation and durable dispatch.
+    const requestSnapshot = structuredClone(params);
     return this.executeTaskUnprojected<CreateMediaBuyResponse>(
       'create_media_buy',
-      params,
+      requestSnapshot,
       inputHandler,
       options,
       'onCreateMediaBuyStatusChange',
@@ -5946,6 +6078,10 @@ export class SingleAgentClient {
         return this.getMediaBuyDelivery(params as GetMediaBuyDeliveryRequest, inputHandler, options);
       case 'get_creative_delivery':
         return this.getCreativeDelivery(params as GetCreativeDeliveryRequest, inputHandler, options);
+      case 'request_proposals':
+        return guardNativeRequestProposalsCompletion(
+          await this.executeTaskUnprojected(taskName, params, inputHandler, options)
+        );
     }
     return this.executeTaskUnprojected(taskName, params, inputHandler, options);
   }
@@ -6098,7 +6234,9 @@ export class SingleAgentClient {
 
       return result;
     } catch (error) {
-      if (error instanceof BeforeProtocolDispatchHookError) throw error.original;
+      if (error instanceof BeforeProtocolDispatchHookError || error instanceof AfterProtocolDispatchHookError) {
+        throw error.original;
+      }
       // Structured protocol errors carry typed fields (reason, actualVersion,
       // unsupportedFeatures, …) that callers use for recovery decisions. Auth
       // and timeout errors trigger OAuth flows / cancellation. All four are
@@ -6423,6 +6561,7 @@ export class SingleAgentClient {
       .getActiveTasks()
       .filter(task => task.agent.id === this.agent.id)
       .map(task => {
+        assertNativeRequestProposalsTask(task);
         if (!CANONICAL_CREATIVE_ACTIVITY_TASKS.has(task.taskName)) return task;
         const converter = this.resolveLegacyFormatConverter(
           this.canonicalCreativeTaskAssociation(task.taskId)?.legacyFormatConverter
@@ -6459,14 +6598,18 @@ export class SingleAgentClient {
   async listTasks(): Promise<TaskInfo[]> {
     const tasks = await this.executor.getTaskList(this.agent.id);
     return tasks.map(task =>
-      CANONICAL_CREATIVE_ACTIVITY_TASKS.has(task.taskType)
-        ? this.canonicalizeCreativeTaskInfo(
-            task,
-            task.taskType,
-            undefined,
-            this.resolveLegacyFormatConverter(this.canonicalCreativeTaskAssociation(task.taskId)?.legacyFormatConverter)
-          )
-        : task
+      assertNativeRequestProposalsTask(
+        CANONICAL_CREATIVE_ACTIVITY_TASKS.has(task.taskType)
+          ? this.canonicalizeCreativeTaskInfo(
+              task,
+              task.taskType,
+              undefined,
+              this.resolveLegacyFormatConverter(
+                this.canonicalCreativeTaskAssociation(task.taskId)?.legacyFormatConverter
+              )
+            )
+          : task
+      )
     );
   }
 
@@ -6478,14 +6621,17 @@ export class SingleAgentClient {
    */
   async getTaskInfo(taskId: string): Promise<TaskInfo | null> {
     const task = await this.executor.getTaskInfo(taskId);
-    return task && CANONICAL_CREATIVE_ACTIVITY_TASKS.has(task.taskType)
-      ? this.canonicalizeCreativeTaskInfo(
-          task,
-          task.taskType,
-          undefined,
-          this.resolveLegacyFormatConverter(this.canonicalCreativeTaskAssociation(task.taskId)?.legacyFormatConverter)
-        )
-      : task;
+    if (!task) return null;
+    return assertNativeRequestProposalsTask(
+      CANONICAL_CREATIVE_ACTIVITY_TASKS.has(task.taskType)
+        ? this.canonicalizeCreativeTaskInfo(
+            task,
+            task.taskType,
+            undefined,
+            this.resolveLegacyFormatConverter(this.canonicalCreativeTaskAssociation(task.taskId)?.legacyFormatConverter)
+          )
+        : task
+    );
   }
 
   /**
@@ -6510,16 +6656,18 @@ export class SingleAgentClient {
   onTaskUpdate(callback: (task: TaskInfo) => void): () => void {
     return this.executor.onTaskUpdate(this.agent.id, task =>
       callback(
-        CANONICAL_CREATIVE_ACTIVITY_TASKS.has(task.taskType)
-          ? this.canonicalizeCreativeTaskInfo(
-              task,
-              task.taskType,
-              undefined,
-              this.resolveLegacyFormatConverter(
-                this.canonicalCreativeTaskAssociation(task.taskId)?.legacyFormatConverter
+        assertNativeRequestProposalsTask(
+          CANONICAL_CREATIVE_ACTIVITY_TASKS.has(task.taskType)
+            ? this.canonicalizeCreativeTaskInfo(
+                task,
+                task.taskType,
+                undefined,
+                this.resolveLegacyFormatConverter(
+                  this.canonicalCreativeTaskAssociation(task.taskId)?.legacyFormatConverter
+                )
               )
-            )
-          : task
+            : task
+        )
       )
     );
   }
@@ -6537,14 +6685,18 @@ export class SingleAgentClient {
     onTaskFailed?: (task: TaskInfo, error: string) => void;
   }): () => void {
     const safe = (task: TaskInfo): TaskInfo =>
-      CANONICAL_CREATIVE_ACTIVITY_TASKS.has(task.taskType)
-        ? this.canonicalizeCreativeTaskInfo(
-            task,
-            task.taskType,
-            undefined,
-            this.resolveLegacyFormatConverter(this.canonicalCreativeTaskAssociation(task.taskId)?.legacyFormatConverter)
-          )
-        : task;
+      assertNativeRequestProposalsTask(
+        CANONICAL_CREATIVE_ACTIVITY_TASKS.has(task.taskType)
+          ? this.canonicalizeCreativeTaskInfo(
+              task,
+              task.taskType,
+              undefined,
+              this.resolveLegacyFormatConverter(
+                this.canonicalCreativeTaskAssociation(task.taskId)?.legacyFormatConverter
+              )
+            )
+          : task
+      );
     return this.executor.onTaskEvents(this.agent.id, {
       ...(callbacks.onTaskCreated && { onTaskCreated: task => callbacks.onTaskCreated!(safe(task)) }),
       ...(callbacks.onTaskUpdated && { onTaskUpdated: task => callbacks.onTaskUpdated!(safe(task)) }),

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -338,6 +338,7 @@ const RECORDLESS_HMAC_READ_ONLY_TASKS = new Set([
   'get_adcp_capabilities',
   'list_products',
   'list_creative_formats',
+  'preview_creative',
   'list_transformers',
   'list_creatives',
   'get_media_buys',

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -1,7 +1,7 @@
 // Core task execution engine for ADCP conversation flow
 // Implements PR #78 async patterns: working/submitted/input-required/completed
 
-import { randomUUID } from 'crypto';
+import { createHash, randomUUID } from 'crypto';
 import type { AgentConfig } from '../types';
 import {
   ProtocolClient,
@@ -94,13 +94,55 @@ export class InputRequiredError extends Error {
 
 /** Supporting contract for the internal pre-dispatch boundary. */
 export type BeforeProtocolDispatchHookResult<T> =
-  | { action: 'dispatch_committed' }
+  | {
+      action: 'dispatch_committed';
+      /** Persist or otherwise settle the seller result inside the executor-owned dispatch lifetime. */
+      onResult?: (result: TaskResult<T>) => Promise<TaskResult<T>>;
+      /** Fence transport/parser uncertainty inside the executor-owned dispatch lifetime. */
+      onError?: (error: unknown) => Promise<never>;
+    }
   | { action: 'return'; result: TaskResult<T> };
 
 /** Context supplied to the internal pre-dispatch boundary. */
 export interface BeforeProtocolDispatchContext {
   /** True when governance changed the payload rather than approving it unchanged. */
   governanceAdjusted: boolean;
+  /** Publish a terminal continuation result after its durable settlement succeeds. */
+  publishSettledTaskStatus: (status: TaskStatus, data?: unknown, error?: string) => void;
+  /** Register durable settlement for an authoritative terminal push notification. */
+  registerExternalTaskSettlement: (handler: ExternalTaskSettlementHandler) => void;
+}
+
+export interface ExternalTaskSettlementObservation {
+  status: TaskStatus;
+  result?: unknown;
+  serverTaskId?: string;
+  taskType?: string;
+}
+
+export type ExternalTaskSettlementHandler = (
+  observation: ExternalTaskSettlementObservation
+) => Promise<TaskResult<unknown>>;
+
+export interface ExternalTaskStatusResult {
+  settled: boolean;
+  /** Exact retry of a terminal observation that already completed durable settlement. */
+  duplicate?: boolean;
+  result?: unknown;
+  status?: TaskStatus;
+  error?: string;
+}
+
+interface SettledExternalTaskObservation {
+  key: string;
+  status: TaskStatus;
+  error?: string;
+}
+
+interface ExternalTaskSettlementInFlight {
+  observationKey: string;
+  settlement: Promise<ExternalTaskStatusResult>;
+  waiterCount: number;
 }
 
 /** Hook used by higher-level SDK coordinators at the final dispatch boundary. */
@@ -115,6 +157,15 @@ export class BeforeProtocolDispatchHookError extends Error {
   constructor(readonly original: unknown) {
     super('An SDK pre-dispatch hook failed.', { cause: original });
     this.name = 'BeforeProtocolDispatchHookError';
+  }
+}
+
+/** Keeps internal post-dispatch settlement failures out of normal TaskResult error projection. */
+/** @internal */
+export class AfterProtocolDispatchHookError extends Error {
+  constructor(readonly original: unknown) {
+    super('An SDK post-dispatch settlement hook failed.', { cause: original });
+    this.name = 'AfterProtocolDispatchHookError';
   }
 }
 
@@ -467,6 +518,8 @@ interface TaskStatusPollResult {
 }
 
 const COMPACTED_TASK_STATE_LIMIT = 10_000;
+const DEFAULT_EXTERNAL_TASK_SETTLEMENT_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
 const TERMINAL_TASK_STATUSES = new Set<TaskStatus>([
   'completed',
   'failed',
@@ -475,11 +528,28 @@ const TERMINAL_TASK_STATUSES = new Set<TaskStatus>([
   'governance-denied',
   'aborted',
 ]);
+const MAX_PENDING_EXTERNAL_TASK_OBSERVATIONS = 8;
+const MAX_RETAINED_EXTERNAL_TASK_ERROR_CHARS = 1_024;
 
 /**
  * Core task execution engine that handles the conversation loop with agents
  */
 export class TaskExecutor {
+  private readonly deferredTerminalPublicationTaskIds = new Set<string>();
+  private readonly settlementCapacityReservations = new Set<string>();
+  private readonly closedExternalTaskSettlementTaskIds = new Set<string>();
+  private readonly externalTaskSettlementHandlers = new Map<string, ExternalTaskSettlementHandler>();
+  private readonly externalTaskSettlementInFlight = new Map<string, ExternalTaskSettlementInFlight>();
+  private readonly settledExternalTaskObservationKeys = new Map<string, SettledExternalTaskObservation>();
+  private readonly externalTaskSettlementExpiry = new Map<string, number>();
+  private readonly pendingExternalTaskObservations = new Map<
+    string,
+    Array<{
+      observation: ExternalTaskSettlementObservation;
+      resolve: (result: ExternalTaskStatusResult) => void;
+      reject: (error: unknown) => void;
+    }>
+  >();
   private responseParser: ProtocolResponseParser;
   private activeTasks = new Map<string, TaskState>();
   private compactedTaskIds = new Map<string, true>();
@@ -517,6 +587,10 @@ export class TaskExecutor {
         callbackUrl: string;
         mode: 'rfc9421' | 'hmac-sha256';
       }) => void | Promise<void>;
+      /** Persist fail-closed routing provenance before a durable mutation claim can run. */
+      onDurableSettlementRequired?: (operationId: string) => void | Promise<void>;
+      /** Retain durable push-settlement fences for at least the callback registration lifetime. */
+      externalTaskSettlementRetentionMs?: number;
       /** Fail tasks when response schema validation fails (default: true) */
       strictSchemaValidation?: boolean;
       /** Emit schema validation violations to debug logs and the console (default: true) */
@@ -556,6 +630,12 @@ export class TaskExecutor {
       transport?: import('../protocols').TransportOptions;
     } = {}
   ) {
+    if (
+      config.externalTaskSettlementRetentionMs !== undefined &&
+      (!Number.isSafeInteger(config.externalTaskSettlementRetentionMs) || config.externalTaskSettlementRetentionMs < 1)
+    ) {
+      throw new ConfigurationError('externalTaskSettlementRetentionMs must be a positive safe integer.');
+    }
     this.responseParser = new ProtocolResponseParser();
     if (config.enableConversationStorage) {
       this.conversationStorage = new Map();
@@ -604,9 +684,53 @@ export class TaskExecutor {
    *
    * @internal
    */
-  observeExternalTaskStatus(taskId: string, status: TaskStatus, result?: unknown): void {
-    if (!['completed', 'failed', 'rejected', 'canceled'].includes(status)) return;
+  async observeExternalTaskStatus(
+    taskId: string,
+    status: TaskStatus,
+    result?: unknown,
+    identity: { serverTaskId?: string; taskType?: string } = {}
+  ): Promise<ExternalTaskStatusResult> {
+    if (!['completed', 'failed', 'rejected', 'canceled', 'governance-denied', 'aborted'].includes(status)) {
+      return { settled: false, result };
+    }
+    const observation: ExternalTaskSettlementObservation = { status, result, ...identity };
+    const observationKey = this.externalTaskObservationKey(observation);
+    if (this.closedExternalTaskSettlementTaskIds.has(taskId)) {
+      const accepted = this.settledExternalTaskObservationKeys.get(taskId);
+      if (accepted?.key === observationKey) {
+        return {
+          settled: true,
+          duplicate: true,
+          status: accepted.status,
+          ...(accepted.error !== undefined && { error: accepted.error }),
+        };
+      }
+      throw new Error('This task already completed durable settlement; the pushed result was not accepted.');
+    }
+    if (this.deferredTerminalPublicationTaskIds.has(taskId)) {
+      const handler = this.externalTaskSettlementHandlers.get(taskId);
+      if (handler) return this.settleExternalTaskStatus(taskId, handler, observation);
+      return new Promise((resolve, reject) => {
+        const pending = this.pendingExternalTaskObservations.get(taskId) ?? [];
+        if (pending.length >= MAX_PENDING_EXTERNAL_TASK_OBSERVATIONS) {
+          reject(new Error('Too many terminal push notifications are awaiting durable task settlement.'));
+          return;
+        }
+        pending.push({ observation, resolve, reject });
+        this.pendingExternalTaskObservations.set(taskId, pending);
+      });
+    }
     this.updateTaskStatus(taskId, status, result);
+    return { settled: false, result };
+  }
+
+  /** Whether this process can safely settle or reject a durable callback for the operation. */
+  hasExternalTaskSettlementRoute(taskId: string): boolean {
+    return (
+      this.deferredTerminalPublicationTaskIds.has(taskId) ||
+      this.closedExternalTaskSettlementTaskIds.has(taskId) ||
+      this.externalTaskSettlementHandlers.has(taskId)
+    );
   }
 
   /**
@@ -740,6 +864,10 @@ export class TaskExecutor {
     beforeProtocolDispatch?: BeforeProtocolDispatchHook<T>
   ): Promise<TaskResult<T>> {
     if (serverVersion) this.lastKnownServerVersion = serverVersion;
+    // Own the request graph before the first awaited activity/governance
+    // boundary. This executor is internal, but direct callers and higher
+    // layers may still retain the original nested objects.
+    params = structuredClone(params);
     // The client-minted `taskId` is a local correlation id for tracking this
     // call's lifecycle (activeTasks map, metadata, webhook URL macros). It is
     // NOT the same thing as the A2A `taskId` that the server assigns — that
@@ -779,6 +907,12 @@ export class TaskExecutor {
     };
     this.activeTasks.set(taskId, taskState);
 
+    // Once the final compatibility boundary starts, an abort may race a
+    // durable claim that has committed but whose hook has not returned yet.
+    // In that window the boundary, not the caller signal, owns publication of
+    // terminal state. The abort listener still compacts retained request data.
+    let dispatchBoundaryOwnsTerminalState = false;
+
     // Compact task state as soon as cancellation fires, even if a protocol
     // adapter or caller callback never settles after receiving the signal.
     // The outer deadline race guarantees prompt rejection; this listener is
@@ -787,6 +921,10 @@ export class TaskExecutor {
       ? () => {
           const currentStatus = this.activeTasks.get(taskId)?.status;
           if (currentStatus && !TERMINAL_TASK_STATUSES.has(currentStatus)) {
+            if (dispatchBoundaryOwnsTerminalState) {
+              this.compactAbandonedObserverTaskState(taskId);
+              return;
+            }
             const reason = options.signal?.reason;
             this.updateTaskStatus(
               taskId,
@@ -822,6 +960,11 @@ export class TaskExecutor {
     let governanceResult: GovernanceCheckResult | undefined;
     let effectiveParams = params;
     let governanceAdjusted = false;
+    let dispatchCommitted = false;
+    let dispatchSettlement:
+      | Pick<Extract<BeforeProtocolDispatchHookResult<T>, { action: 'dispatch_committed' }>, 'onResult' | 'onError'>
+      | undefined;
+    let dispatchSettlementStarted = false;
 
     try {
       // Emit protocol_request activity. The activity payload is the boundary
@@ -909,11 +1052,17 @@ export class TaskExecutor {
         }
       }
 
-      // Create initial message (uses effectiveParams which may have governance-applied conditions)
+      // Detach the final request graph before the durable claim boundary. The
+      // caller may still hold and mutate nested account/brand/targeting values;
+      // validation, claim verification, the prepared wire call, and dispatch
+      // must all observe one immutable-by-ownership snapshot.
+      const dispatchParams = structuredClone(effectiveParams);
+
+      // Create initial message (uses dispatchParams which may have governance-applied conditions)
       const initialMessage: Message = {
         id: randomUUID(),
         role: 'user',
-        content: { tool: taskName, params: effectiveParams },
+        content: { tool: taskName, params: dispatchParams },
         timestamp: new Date().toISOString(),
         metadata: { toolName: taskName, type: 'request' },
       };
@@ -922,7 +1071,7 @@ export class TaskExecutor {
       // prepared object. A seller can post immediately after receiving the
       // request, so the registration write must complete before the network
       // boundary is crossed.
-      const preparedCall = prepareProtocolToolCall(agent, effectiveParams, {
+      const preparedCall = prepareProtocolToolCall(agent, dispatchParams, {
         toolName: taskName,
         webhookUrl,
         webhookSecret: this.config.webhookSecret,
@@ -931,6 +1080,7 @@ export class TaskExecutor {
         wireAdcpVersion: this.config.wireAdcpVersion,
         versionEnvelope: this.config.versionEnvelope,
       });
+      let webhookRegistrationPersisted = false;
       if (webhookUrl && this.config.onWebhookRegistration) {
         const registration = webhookRegistrationFromPreparedCall(agent, preparedCall);
         if (registration) {
@@ -940,6 +1090,7 @@ export class TaskExecutor {
             operationId: taskId,
             ...registration,
           });
+          webhookRegistrationPersisted = true;
         }
       }
 
@@ -948,13 +1099,35 @@ export class TaskExecutor {
       // call; callers can therefore distinguish deterministic preflight failure
       // from transport uncertainty after the commit point.
       throwIfAborted(options.signal);
-      let dispatchCommitted = false;
       if (beforeProtocolDispatch) {
         let decision: BeforeProtocolDispatchHookResult<T>;
+        dispatchBoundaryOwnsTerminalState = true;
         try {
-          decision = await beforeProtocolDispatch(effectiveParams, { governanceAdjusted });
+          if (
+            this.deferredTerminalPublicationTaskIds.size + this.settlementCapacityReservations.size >=
+            COMPACTED_TASK_STATE_LIMIT
+          ) {
+            throw new Error('The durable task-settlement capacity is exhausted; no mutation claim was attempted.');
+          }
+          this.settlementCapacityReservations.add(taskId);
+          if (webhookRegistrationPersisted) {
+            await this.config.onDurableSettlementRequired?.(taskId);
+            throwIfAborted(options.signal);
+          }
+          decision = await beforeProtocolDispatch(dispatchParams, {
+            governanceAdjusted,
+            publishSettledTaskStatus: (status, data, error) =>
+              this.publishSettledTaskStatus(taskId, status, data, error),
+            registerExternalTaskSettlement: handler => this.registerExternalTaskSettlement(taskId, handler),
+          });
+          if (decision.action === 'dispatch_committed') {
+            this.deferredTerminalPublicationTaskIds.add(taskId);
+            this.retainExternalTaskSettlementState(taskId);
+          }
         } catch (error) {
           throw new BeforeProtocolDispatchHookError(error);
+        } finally {
+          this.settlementCapacityReservations.delete(taskId);
         }
         if (decision.action === 'return') {
           const earlyResult = decision.result;
@@ -966,7 +1139,19 @@ export class TaskExecutor {
           return attachMatch(earlyResult);
         }
         dispatchCommitted = true;
+        dispatchSettlement = decision;
       }
+
+      // A claim that completes after the caller deadline must be fenced, not
+      // turned into a hidden seller mutation after the caller has already
+      // received a timeout and may have replanned. The catch path invokes the
+      // committed hook's onError settlement before any protocol call begins.
+      throwIfAborted(options.signal);
+
+      // Once a durable claim commits, the caller-facing signal may already be
+      // aborted after seller dispatch begins. Never let that abandoned
+      // observer prevent response parsing or durable settlement.
+      const postDispatchOptions = dispatchCommitted ? { ...options, signal: undefined } : options;
 
       // Send initial request and get streaming response with webhook URL.
       // Pass the caller's A2A session ids (contextId for conversation binding,
@@ -982,12 +1167,9 @@ export class TaskExecutor {
         ...(this.config.wireAdcpVersion !== undefined && { wireAdcpVersion: this.config.wireAdcpVersion }),
         ...(this.config.versionEnvelope !== undefined && { versionEnvelope: this.config.versionEnvelope }),
         transport: options.transport ?? this.config.transport,
-        // Once a durable continuation claim commits, the seller call itself
-        // must cross the network boundary even if the caller's deadline fired
-        // while the atomic store operation was pending. The outer deadline
-        // still rejects promptly and post-call handling marks the outcome
-        // ambiguous for reconciliation.
-        signal: dispatchCommitted ? undefined : options.signal,
+        // Once dispatch begins for a live committed claim, post-call handling
+        // owns durable settlement even if the caller's deadline fires later.
+        signal: postDispatchOptions.signal,
         onTransportActivity: this.config.onTransportActivity,
         transportActivityContext: {
           operationId: taskId,
@@ -997,10 +1179,10 @@ export class TaskExecutor {
         },
       };
       const response = await withPreparedProtocolToolCall(
-        { agent, toolName: taskName, args: effectiveParams, preparedCall },
-        () => ProtocolClient.callTool(agent, taskName, effectiveParams, callOptions)
+        { agent, toolName: taskName, args: dispatchParams, preparedCall },
+        () => ProtocolClient.callTool(agent, taskName, dispatchParams, callOptions)
       );
-      throwIfAborted(options.signal);
+      throwIfAborted(postDispatchOptions.signal);
 
       // Emit protocol_response activity
       const respStatus = this.responseParser.getStatus(response) as string | undefined;
@@ -1015,7 +1197,7 @@ export class TaskExecutor {
         payload: response,
         timestamp: new Date().toISOString(),
       });
-      throwIfAborted(options.signal);
+      throwIfAborted(postDispatchOptions.signal);
 
       // Add initial response message
       const responseMessage: Message = {
@@ -1029,26 +1211,44 @@ export class TaskExecutor {
       const messages = [initialMessage, responseMessage];
 
       // Handle response based on status
-      const result = await this.handleAsyncResponse<T>(
+      let result = await this.handleAsyncResponse<T>(
         agent,
         taskId,
         taskName,
-        effectiveParams,
+        dispatchParams,
         response,
         messages,
         inputHandler,
-        options,
+        postDispatchOptions,
         debugLogs,
-        startTime
+        startTime,
+        dispatchCommitted
       );
-      throwIfAborted(options.signal);
+      throwIfAborted(postDispatchOptions.signal);
 
       // Attach governance check result to the task result
       if (governanceResult) {
         result.governance = governanceResult;
       }
 
-      // Report governance outcome if we had a governance check.
+      if (dispatchSettlement?.onResult) {
+        dispatchSettlementStarted = true;
+        try {
+          result = await dispatchSettlement.onResult(attachMatch(result));
+        } catch (error) {
+          // A committed mutation is not terminal from the SDK's perspective
+          // until its durable settlement succeeds. Publish only the failed
+          // local coordinator state here; never leak the seller's earlier
+          // completed response through task events or retained task state.
+          this.closeExternalTaskSettlement(taskId, error);
+          this.updateTaskStatus(taskId, 'failed', undefined, error instanceof Error ? error.message : String(error));
+          throw new AfterProtocolDispatchHookError(error);
+        }
+      }
+
+      // Report governance only after a committed compatibility mutation has
+      // durably settled. A seller terminal response is not authoritative if
+      // the coordinator subsequently fails to persist it.
       // For async tasks (submitted/working), outcome reporting is deferred —
       // the caller reports via client.reportGovernanceOutcome() when the
       // task resolves through polling or webhooks.
@@ -1071,10 +1271,10 @@ export class TaskExecutor {
             undefined,
             debugLogs,
             govCtx,
-            options.signal,
+            postDispatchOptions.signal,
             outcomeIdempotencyKey
           );
-          throwIfAborted(options.signal);
+          throwIfAborted(postDispatchOptions.signal);
           if (!result.governanceOutcome) {
             result.governanceOutcomeError = 'Outcome reporting to governance agent failed';
           }
@@ -1092,16 +1292,23 @@ export class TaskExecutor {
             { message: result.error },
             debugLogs,
             govCtx,
-            options.signal,
+            postDispatchOptions.signal,
             outcomeIdempotencyKey
           );
-          throwIfAborted(options.signal);
+          throwIfAborted(postDispatchOptions.signal);
           if (!result.governanceOutcome) {
             result.governanceOutcomeError = 'Outcome reporting to governance agent failed';
           }
         } else if (result.status === 'submitted' || result.status === 'working') {
           // Attach the check ID so callers can report outcome after async resolution
           result.governance = { ...(result.governance ?? {}), checkId: governanceCheckId } as GovernanceCheckResult;
+        }
+      }
+
+      if (dispatchCommitted) {
+        result = this.attachSettledContinuationTaskStatus(taskId, result);
+        if (TERMINAL_TASK_STATUSES.has(result.status as TaskStatus)) {
+          this.publishSettledTaskStatus(taskId, result.status as TaskStatus, result.data, result.error);
         }
       }
 
@@ -1120,6 +1327,23 @@ export class TaskExecutor {
         // full request payloads and options in activeTasks.
         this.updateTaskStatus(taskId, 'failed', undefined, error.message);
         throw error;
+      }
+      if (error instanceof AfterProtocolDispatchHookError) throw error;
+      if (dispatchCommitted && dispatchSettlement?.onError && !dispatchSettlementStarted) {
+        dispatchSettlementStarted = true;
+        try {
+          await dispatchSettlement.onError(error);
+        } catch (settlementError) {
+          this.closeExternalTaskSettlement(taskId, settlementError);
+          this.updateTaskStatus(
+            taskId,
+            'failed',
+            undefined,
+            settlementError instanceof Error ? settlementError.message : String(settlementError)
+          );
+          throw new AfterProtocolDispatchHookError(settlementError);
+        }
+        this.closeExternalTaskSettlement(taskId, error);
       }
       if (isAbortOrTimeoutError(error)) {
         if (idempotencyKey && error && typeof error === 'object') {
@@ -1192,7 +1416,8 @@ export class TaskExecutor {
     inputHandler?: InputHandler,
     options: TaskOptions = {},
     debugLogs: any[] = [],
-    startTime: number = Date.now()
+    startTime: number = Date.now(),
+    deferTerminalTaskStatus = false
   ): Promise<TaskResult<T>> {
     const status = this.responseParser.getStatus(response) as ADCPStatus;
 
@@ -1200,7 +1425,10 @@ export class TaskExecutor {
       case ADCP_STATUS.COMPLETED:
         // Task completed immediately
         const completedData = this.extractResponseData(response, debugLogs, taskName);
-        this.updateTaskStatus(taskId, 'completed', completedData);
+        // Ordinary calls retain the historical behavior of publishing seller
+        // completion before optional governance postflight work. A committed
+        // compatibility mutation defers this until durable settlement.
+        if (!deferTerminalTaskStatus) this.updateTaskStatus(taskId, 'completed', completedData);
 
         const operationSuccess = this.isOperationSuccess(completedData, taskName);
 
@@ -1270,7 +1498,17 @@ export class TaskExecutor {
 
       case ADCP_STATUS.SUBMITTED:
         // Long-running task - set up webhook
-        return this.setupSubmittedTask<T>(agent, taskId, taskName, response, messages, options, debugLogs, startTime);
+        return this.setupSubmittedTask<T>(
+          agent,
+          taskId,
+          taskName,
+          response,
+          messages,
+          options,
+          debugLogs,
+          startTime,
+          deferTerminalTaskStatus
+        );
 
       case ADCP_STATUS.INPUT_REQUIRED:
         // Server needs input - handler is mandatory
@@ -1284,7 +1522,8 @@ export class TaskExecutor {
           inputHandler,
           options,
           debugLogs,
-          startTime
+          startTime,
+          deferTerminalTaskStatus
         );
 
       case ADCP_STATUS.FAILED:
@@ -1589,7 +1828,8 @@ export class TaskExecutor {
     messages: Message[],
     options: TaskOptions = {},
     debugLogs: any[] = [],
-    startTime: number = Date.now()
+    startTime: number = Date.now(),
+    deferTerminalTaskStatus = false
   ): Promise<TaskResult<T>> {
     // Extract any data that came with the submitted response
     const partialData = this.extractResponseData(response, debugLogs, taskName);
@@ -1647,7 +1887,7 @@ export class TaskExecutor {
       webhookUrl,
       track: async (transport?: import('../protocols').TransportOptions) => {
         const task = await this.getTaskStatus(agent, serverTaskId, transport ?? pollingTransport);
-        if (['completed', 'failed', 'rejected', 'canceled'].includes(task.status)) {
+        if (!deferTerminalTaskStatus && ['completed', 'failed', 'rejected', 'canceled'].includes(task.status)) {
           this.updateTaskStatus(taskId, task.status as TaskStatus, task.result, task.error);
         }
         return task;
@@ -1657,7 +1897,9 @@ export class TaskExecutor {
         // `pollTaskCompletion` also returns paused input-required/auth-required
         // states. Preserve that status so callers can resume the seller task;
         // only genuinely terminal statuses trigger delayed state eviction.
-        this.updateTaskStatus(taskId, completed.status as TaskStatus, completed.data, completed.error);
+        if (!deferTerminalTaskStatus || !TERMINAL_TASK_STATUSES.has(completed.status as TaskStatus)) {
+          this.updateTaskStatus(taskId, completed.status as TaskStatus, completed.data, completed.error);
+        }
         return completed;
       },
     };
@@ -1684,6 +1926,223 @@ export class TaskExecutor {
   }
 
   /**
+   * A committed compatibility hook may replace resumable continuations with
+   * wrappers that validate and durably persist their terminal result. Attach
+   * local task publication only after those final wrappers return.
+   */
+  private attachSettledContinuationTaskStatus<T>(taskId: string, result: TaskResult<T>): TaskResult<T> {
+    const publish = (status: TaskStatus, data?: unknown, error?: string) => {
+      this.publishSettledTaskStatus(taskId, status, data, error);
+    };
+
+    if (result.submitted) {
+      const submitted = result.submitted;
+      result.submitted = {
+        ...submitted,
+        track: async transport => {
+          const task = await submitted.track(transport);
+          publish(task.status as TaskStatus, task.result, task.error);
+          return task;
+        },
+        waitForCompletion: async (pollInterval, signal) => {
+          const completion = this.attachSettledContinuationTaskStatus(
+            taskId,
+            await submitted.waitForCompletion(pollInterval, signal)
+          );
+          publish(completion.status as TaskStatus, completion.data, completion.error);
+          return completion;
+        },
+      };
+    }
+
+    if (result.deferred) {
+      const deferred = result.deferred;
+      result.deferred = {
+        ...deferred,
+        resume: async input => {
+          const completion = this.attachSettledContinuationTaskStatus(taskId, await deferred.resume(input));
+          publish(completion.status as TaskStatus, completion.data, completion.error);
+          return completion;
+        },
+      };
+    }
+
+    return result;
+  }
+
+  private publishSettledTaskStatus(
+    taskId: string,
+    status: TaskStatus,
+    data?: unknown,
+    error?: string,
+    fromExternalObservation = false
+  ): void {
+    if (!TERMINAL_TASK_STATUSES.has(status)) return;
+    const task = this.activeTasks.get(taskId);
+    if (!task) return;
+    if (!fromExternalObservation) {
+      this.closeExternalTaskSettlement(
+        taskId,
+        new Error('The task settled through its direct response; a racing pushed result was not accepted.')
+      );
+    }
+    if (task.status !== status) this.updateTaskStatus(taskId, status, data, error);
+  }
+
+  private rejectPendingExternalTaskObservations(taskId: string, error: unknown): void {
+    const pending = this.pendingExternalTaskObservations.get(taskId);
+    this.pendingExternalTaskObservations.delete(taskId);
+    for (const waiter of pending ?? []) waiter.reject(error);
+  }
+
+  private closeExternalTaskSettlement(taskId: string, error: unknown): void {
+    this.externalTaskSettlementHandlers.delete(taskId);
+    this.externalTaskSettlementInFlight.delete(taskId);
+    this.closedExternalTaskSettlementTaskIds.add(taskId);
+    this.rejectPendingExternalTaskObservations(taskId, error);
+  }
+
+  private clearExternalTaskSettlementState(taskId: string): void {
+    this.deferredTerminalPublicationTaskIds.delete(taskId);
+    this.closedExternalTaskSettlementTaskIds.delete(taskId);
+    this.externalTaskSettlementHandlers.delete(taskId);
+    this.externalTaskSettlementInFlight.delete(taskId);
+    this.settledExternalTaskObservationKeys.delete(taskId);
+    this.externalTaskSettlementExpiry.delete(taskId);
+    this.rejectPendingExternalTaskObservations(
+      taskId,
+      new Error('The durable push-settlement retention window expired before the observation was accepted.')
+    );
+  }
+
+  private retainExternalTaskSettlementState(taskId: string): void {
+    const retentionMs = this.config.externalTaskSettlementRetentionMs ?? DEFAULT_EXTERNAL_TASK_SETTLEMENT_RETENTION_MS;
+    const expiry = Date.now() + retentionMs;
+    if ((this.externalTaskSettlementExpiry.get(taskId) ?? 0) >= expiry) return;
+    this.externalTaskSettlementExpiry.set(taskId, expiry);
+    const expire = () => {
+      if (this.externalTaskSettlementExpiry.get(taskId) !== expiry) return;
+      const remaining = expiry - Date.now();
+      if (remaining > 0) {
+        const timer = setTimeout(expire, Math.min(remaining, MAX_TIMER_DELAY_MS));
+        timer.unref?.();
+        return;
+      }
+      this.clearExternalTaskSettlementState(taskId);
+    };
+    const timer = setTimeout(expire, Math.min(retentionMs, MAX_TIMER_DELAY_MS));
+    timer.unref?.();
+  }
+
+  /** Release short-lived task inspection state without dropping a live durable push fence. */
+  private cleanupTerminalTaskInspectionState(taskId: string): void {
+    this.activeTasks.delete(taskId);
+    this.compactedTaskIds.delete(taskId);
+    if (
+      this.deferredTerminalPublicationTaskIds.has(taskId) ||
+      this.closedExternalTaskSettlementTaskIds.has(taskId) ||
+      this.externalTaskSettlementHandlers.has(taskId)
+    ) {
+      if (this.externalTaskSettlementExpiry.has(taskId)) return;
+    }
+    this.clearExternalTaskSettlementState(taskId);
+  }
+
+  private registerExternalTaskSettlement(taskId: string, handler: ExternalTaskSettlementHandler): void {
+    this.externalTaskSettlementHandlers.set(taskId, handler);
+    const pending = this.pendingExternalTaskObservations.get(taskId);
+    if (!pending) return;
+    this.pendingExternalTaskObservations.delete(taskId);
+    for (const waiter of pending) {
+      void this.settleExternalTaskStatus(taskId, handler, waiter.observation).then(waiter.resolve, waiter.reject);
+    }
+  }
+
+  private externalTaskObservationKey(observation: ExternalTaskSettlementObservation): string {
+    return createHash('sha256')
+      .update(
+        canonicalize({
+          status: observation.status,
+          serverTaskId: observation.serverTaskId ?? null,
+          taskType: observation.taskType ?? null,
+          result: observation.result ?? null,
+        })
+      )
+      .digest('base64url');
+  }
+
+  private async settleExternalTaskStatus(
+    taskId: string,
+    handler: ExternalTaskSettlementHandler,
+    observation: ExternalTaskSettlementObservation
+  ): Promise<ExternalTaskStatusResult> {
+    const observationKey = this.externalTaskObservationKey(observation);
+    const existing = this.externalTaskSettlementInFlight.get(taskId);
+    if (existing) {
+      if (existing.waiterCount >= MAX_PENDING_EXTERNAL_TASK_OBSERVATIONS) {
+        throw new Error('Too many terminal push notifications are undergoing durable task settlement.');
+      }
+      existing.waiterCount += 1;
+      try {
+        const accepted = await existing.settlement;
+        if (existing.observationKey !== observationKey) {
+          throw new Error('This task already completed durable settlement; the pushed result was not accepted.');
+        }
+        return { ...accepted, duplicate: true };
+      } finally {
+        existing.waiterCount -= 1;
+      }
+    }
+    const settlement = (async () => {
+      const settled = await handler(observation);
+      const settledStatus = settled.status as TaskStatus;
+      if (this.closedExternalTaskSettlementTaskIds.has(taskId)) {
+        throw new Error('The task settled through its direct response; the racing pushed result was not accepted.');
+      }
+      if (this.settledExternalTaskObservationKeys.has(taskId)) {
+        throw new Error('This task already completed durable settlement; the pushed result was not accepted.');
+      }
+      this.publishSettledTaskStatus(taskId, settledStatus, settled.data, settled.error, true);
+      this.settledExternalTaskObservationKeys.set(taskId, {
+        key: observationKey,
+        status: settledStatus,
+        ...(settled.error !== undefined && {
+          error: settled.error.slice(0, MAX_RETAINED_EXTERNAL_TASK_ERROR_CHARS),
+        }),
+      });
+      this.closeExternalTaskSettlement(
+        taskId,
+        new Error('The task already completed durable external settlement; a later pushed result was not accepted.')
+      );
+      return {
+        settled: true,
+        result: settled.data,
+        status: settled.status as TaskStatus,
+        ...(settled.error !== undefined && { error: settled.error }),
+      };
+    })();
+    const inFlight = { observationKey, settlement, waiterCount: 1 };
+    this.externalTaskSettlementInFlight.set(taskId, inFlight);
+    try {
+      return await settlement;
+    } finally {
+      if (this.externalTaskSettlementInFlight.get(taskId) === inFlight) {
+        this.externalTaskSettlementInFlight.delete(taskId);
+      }
+    }
+  }
+
+  /** Release abandoned caller data without publishing a premature terminal state. */
+  private compactAbandonedObserverTaskState(taskId: string): void {
+    const task = this.activeTasks.get(taskId);
+    if (!task) return;
+    task.params = undefined;
+    task.messages = [];
+    task.options = {};
+    delete task.pendingInput;
+  }
+
+  /**
    * A working/submitted response carries everything needed to poll externally.
    * Keeping the original request in activeTasks after dispatch would pin
    * inline assets, webhook credentials, conversation payloads, and per-call
@@ -1704,10 +2163,17 @@ export class TaskExecutor {
     this.compactedTaskIds.delete(taskId);
     this.compactedTaskIds.set(taskId, true);
     while (this.compactedTaskIds.size > COMPACTED_TASK_STATE_LIMIT) {
-      const oldest = this.compactedTaskIds.keys().next().value;
+      const oldest = [...this.compactedTaskIds.keys()].find(
+        candidate =>
+          !this.deferredTerminalPublicationTaskIds.has(candidate) &&
+          !this.externalTaskSettlementHandlers.has(candidate) &&
+          !this.externalTaskSettlementInFlight.has(candidate)
+      );
       if (oldest === undefined) break;
       this.compactedTaskIds.delete(oldest);
       this.activeTasks.delete(oldest);
+      this.closeExternalTaskSettlement(oldest, new Error('The compacted task was evicted before push settlement.'));
+      this.closedExternalTaskSettlementTaskIds.delete(oldest);
     }
   }
 
@@ -1729,7 +2195,8 @@ export class TaskExecutor {
     inputHandler?: InputHandler,
     options: TaskOptions = {},
     debugLogs: any[] = [],
-    startTime: number = Date.now()
+    startTime: number = Date.now(),
+    deferTerminalTaskStatus = false
   ): Promise<TaskResult<T>> {
     const inputRequest = this.responseParser.parseInputRequest(response);
 
@@ -1838,7 +2305,7 @@ export class TaskExecutor {
       const deferred: DeferredContinuation<T> = {
         token,
         question: inputRequest.question,
-        resume: input => this.resumeDeferredTask<T>(token, input),
+        resume: input => this.resumeDeferredTask<T>(token, input, !deferTerminalTaskStatus),
       };
 
       return {
@@ -1872,7 +2339,8 @@ export class TaskExecutor {
       inputHandler, // Pass handler for multi-round clarification
       options,
       debugLogs,
-      startTime
+      startTime,
+      deferTerminalTaskStatus
     );
   }
 
@@ -2224,7 +2692,7 @@ export class TaskExecutor {
   /**
    * Resume a deferred task (client deferral)
    */
-  async resumeDeferredTask<T>(token: string, input: any): Promise<TaskResult<T>> {
+  async resumeDeferredTask<T>(token: string, input: any, publishTerminalTaskStatus = true): Promise<TaskResult<T>> {
     if (!this.config.deferredStorage) {
       throw new Error('Deferred storage not configured');
     }
@@ -2244,10 +2712,15 @@ export class TaskExecutor {
         state.contextId,
         input,
         state.messages,
-        undefined // No handler for deferred tasks - input was provided by human
+        undefined, // No handler for deferred tasks - input was provided by human
+        {},
+        [],
+        Date.now(),
+        !publishTerminalTaskStatus
       );
       const remainsPaused = ['input-required', 'auth-required', 'deferred'].includes(resumed.status);
       if (
+        publishTerminalTaskStatus &&
         ['completed', 'failed', 'rejected', 'canceled', 'governance-denied', 'aborted'].includes(resumed.status) &&
         this.activeTasks.get(state.taskId)?.status !== resumed.status
       ) {
@@ -2261,7 +2734,14 @@ export class TaskExecutor {
       // A thrown continuation failure is terminal for this deferred token.
       // Release both persistence and the in-memory request payload before the
       // error escapes to the caller.
-      this.updateTaskStatus(state.taskId, 'failed', undefined, error instanceof Error ? error.message : String(error));
+      if (publishTerminalTaskStatus) {
+        this.updateTaskStatus(
+          state.taskId,
+          'failed',
+          undefined,
+          error instanceof Error ? error.message : String(error)
+        );
+      }
       try {
         await this.config.deferredStorage.delete(token);
       } catch {
@@ -2286,7 +2766,8 @@ export class TaskExecutor {
     inputHandler: InputHandler | undefined,
     options: TaskOptions = {},
     debugLogs: any[] = [],
-    startTime: number = Date.now()
+    startTime: number = Date.now(),
+    deferTerminalTaskStatus = false
   ): Promise<TaskResult<T>> {
     // Add user input message
     const inputMessage: Message = {
@@ -2344,7 +2825,8 @@ export class TaskExecutor {
       inputHandler,
       options,
       debugLogs,
-      startTime
+      startTime,
+      deferTerminalTaskStatus
     );
   }
 
@@ -2738,8 +3220,7 @@ export class TaskExecutor {
         task.options = {};
         delete task.pendingInput;
         setTimeout(() => {
-          this.activeTasks.delete(taskId);
-          this.compactedTaskIds.delete(taskId);
+          this.cleanupTerminalTaskInspectionState(taskId);
         }, 30000).unref(); // Keep for 30 seconds for final status checks
       }
     }

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -1330,7 +1330,6 @@ export class TaskExecutor {
       }
       if (error instanceof AfterProtocolDispatchHookError) throw error;
       if (dispatchCommitted && dispatchSettlement?.onError && !dispatchSettlementStarted) {
-        dispatchSettlementStarted = true;
         try {
           await dispatchSettlement.onError(error);
         } catch (settlementError) {

--- a/src/lib/core/request-proposals-guard.ts
+++ b/src/lib/core/request-proposals-guard.ts
@@ -1,0 +1,50 @@
+import type { TaskResult } from './ConversationTypes';
+
+const PROJECTION_ONLY_REQUEST_PROPOSALS_MESSAGE =
+  'request_proposals returned the projection-only products_available outcome from a native compact seller.';
+
+/** Reject compatibility-only proposal projections at every native 3.2 completion boundary. */
+export function assertNativeRequestProposalsResult(data: unknown): void {
+  if (
+    data !== null &&
+    typeof data === 'object' &&
+    ((data as { outcome?: unknown }).outcome === 'products_available' ||
+      (data as { purchase_continuation?: unknown }).purchase_continuation !== undefined)
+  ) {
+    throw new TypeError(PROJECTION_ONLY_REQUEST_PROPOSALS_MESSAGE);
+  }
+}
+
+/** Apply the native proposal guard to remote TaskInfo and local TaskState records. */
+export function assertNativeRequestProposalsTask<T extends { taskType?: string; taskName?: string; result?: unknown }>(
+  task: T
+): T {
+  if ((task.taskType ?? task.taskName) === 'request_proposals') assertNativeRequestProposalsResult(task.result);
+  return task;
+}
+
+/** Guard immediate and resumable completions returned by the native task API. */
+export function guardNativeRequestProposalsCompletion<T>(completion: TaskResult<T>): TaskResult<T> {
+  assertNativeRequestProposalsResult(completion.data);
+  if (completion.submitted) {
+    const submitted = completion.submitted;
+    completion.submitted = {
+      ...submitted,
+      track: async transport => {
+        const task = await submitted.track(transport);
+        assertNativeRequestProposalsResult(task.result);
+        return task;
+      },
+      waitForCompletion: async (pollInterval, signal) =>
+        guardNativeRequestProposalsCompletion(await submitted.waitForCompletion(pollInterval, signal)),
+    };
+  }
+  if (completion.deferred) {
+    const deferred = completion.deferred;
+    completion.deferred = {
+      ...deferred,
+      resume: async resumeInput => guardNativeRequestProposalsCompletion(await deferred.resume(resumeInput)),
+    };
+  }
+  return completion;
+}

--- a/src/lib/core/webhook-registration.ts
+++ b/src/lib/core/webhook-registration.ts
@@ -21,6 +21,8 @@ export interface WebhookRegistration {
   mode: WebhookAuthenticationMode;
   /** Originating preview API, persisted so async routing survives races and restarts. */
   previewMode?: 'canonical' | 'legacy';
+  /** Callback must fail closed unless a durable mutation-settlement route is recoverable. */
+  requiresDurableSettlement?: boolean;
   /** Epoch milliseconds. */
   createdAt: number;
   /** Epoch milliseconds. */
@@ -35,6 +37,8 @@ export interface WebhookRegistrationStore {
    * conflicting live registration for the same key MUST reject.
    */
   putIfAbsent(registration: WebhookRegistration): Promise<void>;
+  /** Atomically mark a live registration as requiring durable mutation settlement. */
+  markRequiresDurableSettlement?(agentId: string, operationId: string): Promise<void>;
   /** Remove provenance after a definitively synchronous terminal response. */
   delete?(agentId: string, operationId: string): Promise<void>;
 }
@@ -96,6 +100,16 @@ export class InMemoryWebhookRegistrationStore implements WebhookRegistrationStor
     this.entries.delete(registrationKey(agentId, operationId));
   }
 
+  async markRequiresDurableSettlement(agentId: string, operationId: string): Promise<void> {
+    const key = registrationKey(agentId, operationId);
+    const registration = this.entries.get(key);
+    if (!registration || registration.expiresAt <= this.now()) {
+      this.entries.delete(key);
+      throw new Error('Cannot mark a missing or expired webhook registration for durable settlement.');
+    }
+    this.entries.set(key, Object.freeze({ ...registration, requiresDurableSettlement: true }));
+  }
+
   private pruneExpired(): void {
     const now = this.now();
     for (const [key, registration] of this.entries) {
@@ -128,6 +142,10 @@ function validateRegistration(registration: WebhookRegistration): void {
   }
   if (callback.protocol !== 'https:' && !isWebhookLoopbackHost(callback.hostname)) {
     throw new TypeError('Webhook callbackUrl must use HTTPS (except loopback development URLs).');
+  }
+  const agent = new URL(registration.agentUrl);
+  if (agent.username || agent.password) {
+    throw new TypeError('Webhook agentUrl cannot contain userinfo credentials.');
   }
   if (registration.expiresAt <= registration.createdAt) {
     throw new TypeError('Webhook registration expiresAt must be later than createdAt.');

--- a/src/lib/media-buy/compatibility.ts
+++ b/src/lib/media-buy/compatibility.ts
@@ -2,12 +2,14 @@ import { createHash, randomBytes } from 'node:crypto';
 import type { AgentClient, CanonicalProjectionTaskOptions, ProposalRefinementTaskOptions } from '../core/AgentClient';
 import type {
   InputHandler,
+  TaskInfo,
   TaskOptions,
   TaskResult,
   TaskResultCompleted,
   TaskResultFailure,
   TaskResultIntermediate,
 } from '../core/ConversationTypes';
+import type { BeforeProtocolDispatchContext, BeforeProtocolDispatchHookResult } from '../core/TaskExecutor';
 import { attachMatch } from '../core/match';
 import { generateIdempotencyKey, isValidIdempotencyKey, type MutatingRequestInput } from '../utils/idempotency';
 import { canonicalize } from '../utils/jcs';
@@ -198,6 +200,7 @@ const CONTROL_MEDIA_BUY_FIELDS = new Set([
   'governance_context',
   'idempotency_key',
   'media_buy_id',
+  'name',
   'pacing',
   'packages',
   'paused',
@@ -555,16 +558,58 @@ interface CompatibleProposalResponseBase {
   context?: CompatibleContext;
 }
 
-export interface CompatibleRequestProposalsResponse extends CompatibleProposalResponseBase {
+type CompatibleRequestProposalsResponseBase = Omit<CompatibleProposalResponseBase, 'proposals' | 'products'> & {
   operation: 'request';
-  /** `legacy_unavailable` never overstates an empty legacy response as a seller rejection. */
-  outcome: 'proposed' | 'products_available' | 'rejected' | 'legacy_unavailable';
-  reason?: string;
-  suggestions?: string[];
-  incomplete?: RequestProposalsResponse['incomplete'];
-  purchase_continuation?: RequestProposalsResponse['purchase_continuation'];
   raw: RequestProposalsResponse | EstablishedProductsWireResponse;
-}
+};
+
+/** Completed request-proposal projection with branch fields narrowed by `outcome`. */
+export type CompatibleRequestProposalsResponse = CompatibleRequestProposalsResponseBase &
+  (
+    | {
+        outcome: 'proposed';
+        proposals: CompatibleProposal[];
+        products?: CompatibleProduct[];
+        incomplete?: RequestProposalsIncomplete;
+        reason?: never;
+        suggestions?: never;
+        purchase_continuation?: never;
+      }
+    | {
+        outcome: 'products_available';
+        proposals?: never;
+        products: CompatibleProduct[];
+        incomplete?: RequestProposalsIncomplete;
+        reason?: never;
+        suggestions?: never;
+        purchase_continuation: RequestProposalsPurchaseContinuation;
+      }
+    | {
+        outcome: 'rejected';
+        proposals?: never;
+        products?: never;
+        incomplete?: never;
+        reason: string;
+        suggestions?: string[];
+        purchase_continuation?: never;
+      }
+    | {
+        /** Never overstates an empty or unsafe legacy response as a seller rejection. */
+        outcome: 'legacy_unavailable';
+        proposals?: never;
+        products?: CompatibleProduct[];
+        incomplete?: RequestProposalsIncomplete;
+        reason?: never;
+        suggestions?: never;
+        purchase_continuation?: never;
+      }
+  );
+
+type RequestProposalsIncomplete = NonNullable<Extract<RequestProposalsResponse, { outcome: 'proposed' }>['incomplete']>;
+type RequestProposalsPurchaseContinuation = Extract<
+  RequestProposalsResponse,
+  { outcome: 'products_available' }
+>['purchase_continuation'];
 
 export interface CompatibleRefineProposalsResponse extends CompatibleProposalResponseBase {
   operation: 'refine';
@@ -625,7 +670,7 @@ export interface MediaBuyLifecycleCoordinatorOptions {
   /**
    * Stable, non-secret identity for the authenticated seller/account session.
    * Persist and reuse it when a coordinator is rehydrated. It is required for
-   * AdCP 2.5 sellers that do not provide a server context ID.
+   * every established 2.5, 3.0, or 3.1 seller that provides no server context ID.
    */
   legacyPurchaseSellerSessionScope?: string;
   /** Durable storage for products-only legacy purchase continuations. */
@@ -652,7 +697,7 @@ export type LegacyPurchaseContinuationErrorCode =
   | 'ambiguous'
   | 'store_error';
 
-/** Fail-closed local error raised before a legacy create is sent or replayed. */
+/** Fail-closed continuation error; ambiguous/store variants may be raised after seller dispatch. */
 export class LegacyPurchaseContinuationError extends Error {
   readonly name = 'LegacyPurchaseContinuationError';
 
@@ -796,18 +841,19 @@ function containsCredentialShapedKey(value: unknown, seen = new WeakSet<object>(
 function containsPresignedUrl(value: unknown, seen = new WeakSet<object>()): boolean {
   if (typeof value === 'string') {
     try {
-      const url = new URL(value);
-      const sensitiveQueryKeys = new Set([
-        'x-amz-credential',
-        'x-amz-signature',
-        'x-goog-credential',
-        'x-goog-signature',
-        'signature',
-        'sig',
-        'token',
-        'access_token',
-      ]);
-      return [...url.searchParams.keys()].some(key => sensitiveQueryKeys.has(key.toLowerCase()));
+      const url = new URL(value, 'https://adcp-relative.invalid');
+      const signedUrlAliases = new Set(['xamzcredential', 'xamzsignature', 'xgoogcredential', 'xgoogsignature', 'sig']);
+      const isSensitiveUrlKey = (key: string): boolean => {
+        const normalized = key.replace(/[-_]/g, '').toLowerCase();
+        return isCredentialShapedKey(key) || signedUrlAliases.has(normalized);
+      };
+      const fragmentParams = new URLSearchParams(url.hash.startsWith('#') ? url.hash.slice(1) : url.hash);
+      return (
+        url.username.length > 0 ||
+        url.password.length > 0 ||
+        [...url.searchParams.keys()].some(isSensitiveUrlKey) ||
+        [...fragmentParams.keys()].some(isSensitiveUrlKey)
+      );
     } catch {
       return false;
     }
@@ -904,7 +950,6 @@ function negotiatedVersion(capabilities: AdcpCapabilities, clientVersion: string
 
 const MAX_PROPOSAL_TRAVERSAL_NODES = 4096;
 const LEGACY_PROPOSAL_RAW = Symbol('legacyProposalRaw');
-const LEGACY_PURCHASE_CLIENT_SCOPES = new WeakMap<AgentClient, string>();
 const COMPACT_REQUEST_PROPOSALS_RESPONSE_FIELDS = new Set([
   'adcp_version',
   'outcome',
@@ -1075,15 +1120,15 @@ function projectRequestProposals(
     ...(typeof source.reason === 'string' && { reason: source.reason }),
     ...(Array.isArray(source.suggestions) && { suggestions: source.suggestions as string[] }),
     ...(Array.isArray(source.incomplete) && {
-      incomplete: source.incomplete as RequestProposalsResponse['incomplete'],
+      incomplete: source.incomplete as RequestProposalsIncomplete,
     }),
     ...(source.purchase_continuation !== undefined && {
-      purchase_continuation: source.purchase_continuation as RequestProposalsResponse['purchase_continuation'],
+      purchase_continuation: source.purchase_continuation as RequestProposalsPurchaseContinuation,
     }),
     raw: ((source as Record<PropertyKey, unknown>)[LEGACY_PROPOSAL_RAW] ?? source) as
       | RequestProposalsResponse
       | EstablishedProductsWireResponse,
-  };
+  } as CompatibleRequestProposalsResponse;
 }
 
 function projectRefineProposals(
@@ -2372,7 +2417,9 @@ export class MediaBuyLifecycleCoordinator {
     return [
       'feed_version_not_atomic',
       'pricing_version_not_atomic',
-      ...(sourceVersion === '2.5' ? (['mutation_idempotency_not_guaranteed'] as const) : []),
+      ...(sourceVersion === '2.5' || this.idempotencyReplayTtlMs === undefined
+        ? (['mutation_idempotency_not_guaranteed'] as const)
+        : []),
     ];
   }
 
@@ -2381,17 +2428,10 @@ export class MediaBuyLifecycleCoordinator {
     const contextId = this.agent.getContextId();
     if (this.resolvedLegacyPurchaseSellerSessionScope === undefined) {
       let sessionScope = this.configuredLegacyPurchaseSellerSessionScope ?? contextId;
-      if (sessionScope === undefined && this.legacyPurchaseSourceVersion() === '2.5') {
-        throw new ConfigurationError(
-          'Products-only AdCP 2.5 purchase continuations require mediaBuy.legacyPurchaseSellerSessionScope when the seller provides no context ID.'
-        );
-      }
       if (sessionScope === undefined) {
-        sessionScope = LEGACY_PURCHASE_CLIENT_SCOPES.get(this.agent);
-        if (sessionScope === undefined) {
-          sessionScope = randomBytes(32).toString('base64url');
-          LEGACY_PURCHASE_CLIENT_SCOPES.set(this.agent, sessionScope);
-        }
+        throw new ConfigurationError(
+          'Products-only legacy purchase continuations require legacyPurchaseSellerSessionScope in negotiateMediaBuyLifecycle() when the seller provides no context ID.'
+        );
       }
       this.resolvedLegacyPurchaseSellerSessionScope = sessionScope;
     }
@@ -4261,15 +4301,15 @@ export class MediaBuyLifecycleCoordinator {
     }
     const packages = array(legacyRequest.packages);
     const packageProductIds = packages.map(pkg => optionalString(record(pkg).product_id));
+    const distinctPackageProductIds = [...new Set(packageProductIds)];
     if (
       packages.length === 0 ||
       packageProductIds.some(productId => productId === undefined) ||
-      new Set(packageProductIds).size !== packageProductIds.length ||
-      !exactSet(packageProductIds, selectedProductIds)
+      !exactSet(distinctPackageProductIds, selectedProductIds)
     ) {
       throw new LegacyPurchaseContinuationError(
         'selection_mismatch',
-        'The distinct legacy_create_request package product IDs must exactly match selected_product_ids.'
+        'The legacy_create_request package product ID set must exactly match selected_product_ids.'
       );
     }
     const observedPricingOptions = new Map<string, Set<string>>();
@@ -4316,7 +4356,7 @@ export class MediaBuyLifecycleCoordinator {
         `legacy_create_request is invalid for AdCP ${continuation.sourceAdcpVersion}: ${formatIssues(validation.issues)}`
       );
     }
-    const claim: LegacyPurchaseClaim = {
+    let claim: LegacyPurchaseClaim = {
       idempotencyKey,
       inputFingerprint: requestFingerprint(input),
       operationKey: requestFingerprint({
@@ -4337,8 +4377,8 @@ export class MediaBuyLifecycleCoordinator {
     let claimedForDispatch = false;
     const claimBeforeDispatch = async (
       effectiveParams: unknown,
-      context: { governanceAdjusted: boolean }
-    ): Promise<{ action: 'dispatch_committed' } | { action: 'return'; result: TaskResult<CreateMediaBuyResponse> }> => {
+      context: BeforeProtocolDispatchContext
+    ): Promise<BeforeProtocolDispatchHookResult<CreateMediaBuyResponse>> => {
       // Legacy continuation consent binds the complete pre-governance purchase.
       // Unlike native 3.2 proposal execution, it has no mechanism for the
       // caller to approve rewritten commercial terms, so fail closed before
@@ -4352,11 +4392,11 @@ export class MediaBuyLifecycleCoordinator {
       const finalRequest = record(effectiveParams);
       const finalPackages = array(finalRequest.packages);
       const finalProductIds = finalPackages.map(pkg => optionalString(record(pkg).product_id));
+      const distinctFinalProductIds = [...new Set(finalProductIds)];
       if (
         finalPackages.length === 0 ||
         finalProductIds.some(productId => productId === undefined) ||
-        new Set(finalProductIds).size !== finalProductIds.length ||
-        !exactSet(finalProductIds, selectedProductIds)
+        !exactSet(distinctFinalProductIds, selectedProductIds)
       ) {
         throw new LegacyPurchaseContinuationError(
           'selection_mismatch',
@@ -4390,6 +4430,15 @@ export class MediaBuyLifecycleCoordinator {
         );
       }
 
+      // Capture the mutation/replay clock at the durable CAS boundary, after
+      // all awaited preflight and governance work. Earlier timestamps can
+      // make a slow claim look abandoned or shorten its replay window before
+      // the seller has even been dispatched.
+      claim = {
+        ...claim,
+        claimedAt: new Date().toISOString(),
+        replayExpiresAt: new Date(Date.now() + this.legacyPurchaseOperationTtlMs).toISOString(),
+      };
       let claimed;
       try {
         claimed = await this.legacyPurchaseContinuationStore.claim(token, {
@@ -4463,9 +4512,38 @@ export class MediaBuyLifecycleCoordinator {
         );
       }
       claimedForDispatch = true;
-      return { action: 'dispatch_committed' };
+      return {
+        action: 'dispatch_committed',
+        onResult: async result => {
+          const settled = await this.trackLegacyPurchaseResult(
+            token,
+            claim,
+            result,
+            context.publishSettledTaskStatus,
+            context.registerExternalTaskSettlement,
+            options?.transport
+          );
+          settledInsideExecutor = true;
+          return settled;
+        },
+        onError: async error => {
+          settledInsideExecutor = true;
+          if (error instanceof LegacyPurchaseContinuationError) {
+            if (error.code === 'ambiguous') {
+              await this.markLegacyPurchaseAmbiguous(token, claim, 'create_media_buy_result_invalid');
+            }
+            throw error;
+          }
+          await this.markLegacyPurchaseAmbiguous(token, claim, 'create_media_buy_transport_uncertain');
+          throw this.legacyPurchaseAmbiguousError(
+            'The legacy create transport failed after the token was claimed.',
+            error
+          );
+        },
+      };
     };
 
+    let settledInsideExecutor = false;
     try {
       const result = await this.agent.createMediaBuyLegacyWithPreDispatch(
         legacyRequest as unknown as CreateMediaBuyRequest,
@@ -4478,9 +4556,13 @@ export class MediaBuyLifecycleCoordinator {
         }
       );
       if (!claimedForDispatch) return result;
-      return this.trackLegacyPurchaseResult(token, claim, result);
+      if (settledInsideExecutor) return result;
+      // Test doubles and older internal façades may invoke the pre-dispatch
+      // hook without honoring its executor-owned settlement callbacks.
+      return this.trackLegacyPurchaseResult(token, claim, result, undefined, undefined, options?.transport);
     } catch (error) {
       if (!claimedForDispatch) throw error;
+      if (settledInsideExecutor) throw error;
       if (error instanceof LegacyPurchaseContinuationError) {
         if (error.code === 'ambiguous') {
           await this.markLegacyPurchaseAmbiguous(token, claim, 'create_media_buy_result_invalid');
@@ -4598,7 +4680,10 @@ export class MediaBuyLifecycleCoordinator {
   private async trackLegacyPurchaseResult(
     token: string,
     claim: LegacyPurchaseClaim,
-    result: TaskResult<CreateMediaBuyResponse>
+    result: TaskResult<CreateMediaBuyResponse>,
+    publishSettledTaskStatus?: BeforeProtocolDispatchContext['publishSettledTaskStatus'],
+    registerExternalTaskSettlement?: BeforeProtocolDispatchContext['registerExternalTaskSettlement'],
+    settlementTransport?: TaskOptions['transport']
   ): Promise<TaskResult<CreateMediaBuyResponse>> {
     if (result.status === 'completed' || result.status === 'failed' || result.status === 'governance-denied') {
       // TaskExecutor also uses status=failed for local response-schema and
@@ -4606,19 +4691,99 @@ export class MediaBuyLifecycleCoordinator {
       // authoritatively rejected the mutation: it may have succeeded and
       // returned a malformed completion. Persist only structured AdCP
       // failures; otherwise fence the claimed operation as ambiguous.
-      if (result.status === 'failed' && result.adcpError === undefined) {
+      if (result.status === 'failed' && (result.adcpError === undefined || result.adcpError.synthetic === true)) {
         await this.markLegacyPurchaseAmbiguous(token, claim, 'create_media_buy_failure_not_authoritative');
         throw this.legacyPurchaseAmbiguousError(
           'The legacy create failure was not an authoritative structured AdCP error.'
         );
       }
-      const terminal = this.assertLegacyPurchaseTerminalResult(result, this.legacyPurchaseSourceVersion());
+      let terminal: LegacyPurchaseTerminalResult;
+      try {
+        terminal = this.assertLegacyPurchaseTerminalResult(result, this.legacyPurchaseSourceVersion());
+      } catch (error) {
+        if (error instanceof LegacyPurchaseContinuationError && error.code === 'ambiguous') {
+          await this.markLegacyPurchaseAmbiguous(token, claim, 'create_media_buy_result_invalid');
+        }
+        throw error;
+      }
       return attachMatch(await this.completeLegacyPurchase(token, claim, terminal));
     }
-    if (result.submitted) {
-      const submitted = result.submitted;
+
+    const settlementMetadata = {
+      taskId: result.metadata.taskId,
+      taskName: result.metadata.taskName,
+      agent: { ...result.metadata.agent },
+      responseTimeMs: result.metadata.responseTimeMs,
+      timestamp: result.metadata.timestamp,
+      clarificationRounds: result.metadata.clarificationRounds,
+      status: result.metadata.status,
+      ...(result.metadata.contextId !== undefined && { contextId: result.metadata.contextId }),
+      ...((result.submitted?.taskId ?? result.metadata.serverTaskId ?? claim.sellerTaskId) !== undefined && {
+        serverTaskId: result.submitted?.taskId ?? result.metadata.serverTaskId ?? claim.sellerTaskId,
+      }),
+      ...(result.metadata.idempotency_key !== undefined && { idempotency_key: result.metadata.idempotency_key }),
+      ...(result.metadata.replayed !== undefined && { replayed: result.metadata.replayed }),
+      ...(result.metadata.adcpVersion !== undefined && { adcpVersion: result.metadata.adcpVersion }),
+    };
+    const failureFieldsFromTask = (task: TaskInfo) => {
+      const extracted = extractAdcpErrorInfo(task.result);
+      const adcpError = extracted?.synthetic === true ? undefined : extracted;
+      const correlationId = extractCorrelationId(task.result);
+      return {
+        // tasks/get and webhook free text are not durable-safe boundaries.
+        // Preserve a structured AdCP message when present; otherwise replay a
+        // generic error while retaining the seller payload for inspection.
+        error: adcpError?.message ?? 'Legacy create failed.',
+        ...(adcpError !== undefined && { adcpError }),
+        ...(correlationId !== undefined && { correlationId }),
+      };
+    };
+    const resultFromTask = (task: TaskInfo): TaskResult<CreateMediaBuyResponse> | undefined => {
+      const metadata = {
+        ...settlementMetadata,
+        taskName: task.taskType,
+        timestamp: new Date().toISOString(),
+      };
+      if (
+        task.status === 'completed' &&
+        task.result !== undefined &&
+        isAdcpOperationSuccess(task.result, task.taskType)
+      ) {
+        return attachMatch({
+          success: true,
+          status: 'completed',
+          data: task.result as CreateMediaBuyResponse,
+          metadata: { ...metadata, status: 'completed' },
+        });
+      }
+      if (task.status === 'unknown') {
+        throw this.legacyPurchaseAmbiguousError(
+          'tasks/get returned an unrecognizable response for the submitted legacy purchase.'
+        );
+      }
+      if (['completed', 'failed', 'rejected', 'canceled', 'governance-denied'].includes(task.status)) {
+        const status = task.status === 'governance-denied' ? 'governance-denied' : 'failed';
+        return attachMatch({
+          success: false,
+          status,
+          ...failureFieldsFromTask(task),
+          ...(task.result !== undefined && { data: task.result as CreateMediaBuyResponse }),
+          metadata: { ...metadata, status },
+        } as TaskResult<CreateMediaBuyResponse>);
+      }
+      if (task.status === 'input-required' || task.status === 'auth-required') {
+        return attachMatch({
+          success: true,
+          status: task.status,
+          ...(task.result !== undefined && { data: task.result as CreateMediaBuyResponse }),
+          metadata: { ...metadata, status: task.status },
+        } as TaskResult<CreateMediaBuyResponse>);
+      }
+      return undefined;
+    };
+    const bindSellerTask = async (sellerTaskId: string) => {
       try {
-        const recorded = await this.legacyPurchaseContinuationStore.recordSubmittedTask(token, claim, submitted.taskId);
+        const recorded = await this.legacyPurchaseContinuationStore.recordSubmittedTask(token, claim, sellerTaskId);
         if (!recorded) {
           await this.markLegacyPurchaseAmbiguous(token, claim, 'submitted_task_persistence_failed');
           throw this.legacyPurchaseAmbiguousError('Could not durably bind the submitted seller task.');
@@ -4628,18 +4793,116 @@ export class MediaBuyLifecycleCoordinator {
         await this.markLegacyPurchaseAmbiguous(token, claim, 'submitted_task_persistence_failed');
         throw this.legacyPurchaseAmbiguousError('Could not durably bind the submitted seller task.', error);
       }
-      const failureFieldsFromTask = (task: Awaited<ReturnType<typeof submitted.track>>) => {
-        const adcpError = extractAdcpErrorInfo(task.result);
-        const correlationId = extractCorrelationId(task.result);
-        return {
-          // tasks/get free text is not a durable-safe boundary. Preserve a
-          // structured AdCP message when present; otherwise replay a generic
-          // error while retaining the seller payload in data for inspection.
-          error: adcpError?.message ?? 'Legacy create failed.',
-          ...(adcpError !== undefined && { adcpError }),
-          ...(correlationId !== undefined && { correlationId }),
-        };
-      };
+
+      // Register only after the seller task binding is durable. A webhook may
+      // already be queued in TaskExecutor, but it must never complete the
+      // operation before recordSubmittedTask commits the exact task identity.
+      registerExternalTaskSettlement?.(async observation => {
+        try {
+          if (observation.serverTaskId !== sellerTaskId) {
+            throw this.legacyPurchaseAmbiguousError(
+              'The pushed seller task ID does not match the durably recorded submitted task.'
+            );
+          }
+          if (observation.taskType !== 'create_media_buy') {
+            throw this.legacyPurchaseAmbiguousError('The pushed seller task has the wrong task identity.');
+          }
+          const task: TaskInfo = {
+            taskId: sellerTaskId,
+            taskType: observation.taskType,
+            status: observation.status,
+            createdAt: Date.now(),
+            updatedAt: Date.now(),
+            ...(observation.result !== undefined && { result: observation.result }),
+          };
+          const observed = resultFromTask(task);
+          if (!observed || !['completed', 'failed', 'governance-denied'].includes(observed.status)) {
+            throw this.legacyPurchaseAmbiguousError(
+              'The pushed legacy create status was not an authoritative terminal result.'
+            );
+          }
+          return await this.trackLegacyPurchaseResult(
+            token,
+            claim,
+            observed,
+            publishSettledTaskStatus,
+            registerExternalTaskSettlement,
+            settlementTransport
+          );
+        } catch (error) {
+          if (error instanceof LegacyPurchaseContinuationError && error.code === 'ambiguous') {
+            await this.markLegacyPurchaseAmbiguous(token, claim, 'pushed_task_result_invalid');
+          }
+          throw error;
+        }
+      });
+    };
+
+    if (result.status === 'working' || result.status === 'input-required' || result.status === 'auth-required') {
+      const sellerTaskId = result.metadata.serverTaskId;
+      if (!sellerTaskId) {
+        await this.markLegacyPurchaseAmbiguous(token, claim, 'paused_task_identity_missing');
+        throw this.legacyPurchaseAmbiguousError(
+          'The non-terminal legacy create response did not provide a durable seller task identity.'
+        );
+      }
+      await bindSellerTask(sellerTaskId);
+      if (result.status !== 'working') return attachMatch(result);
+      const watchSignal = AbortSignal.timeout(Math.min(this.legacyPurchaseOperationTtlMs, 5 * 60 * 1000));
+      const waitForWorkingPoll = () =>
+        new Promise<void>((resolve, reject) => {
+          if (watchSignal.aborted) {
+            reject(createAbortError(watchSignal.reason));
+            return;
+          }
+          const timer = setTimeout(finish, 60_000);
+          const abort = () => finish(createAbortError(watchSignal.reason));
+          watchSignal.addEventListener('abort', abort, { once: true });
+          function finish(error?: Error) {
+            clearTimeout(timer);
+            watchSignal.removeEventListener('abort', abort);
+            if (error) reject(error);
+            else resolve();
+          }
+        });
+      void new Promise<void>(resolve => setTimeout(resolve, 0))
+        .then(async () => {
+          while (!watchSignal.aborted) {
+            const task = await this.agent.getTaskStatus(sellerTaskId, settlementTransport, watchSignal);
+            if (task.taskId !== sellerTaskId || task.taskType !== 'create_media_buy') {
+              throw this.legacyPurchaseAmbiguousError(
+                'The polled working seller task does not match the durably recorded create_media_buy task.'
+              );
+            }
+            const observed = resultFromTask(task);
+            if (observed) {
+              return this.trackLegacyPurchaseResult(
+                token,
+                claim,
+                observed,
+                publishSettledTaskStatus,
+                registerExternalTaskSettlement,
+                settlementTransport
+              );
+            }
+            await waitForWorkingPoll();
+          }
+          throw createAbortError(watchSignal.reason);
+        })
+        .then(completion => {
+          publishSettledTaskStatus?.(completion.status, completion.data, completion.error);
+        })
+        .catch(async error => {
+          if (watchSignal.aborted || isAbortOrTimeoutError(error)) return;
+          await this.markLegacyPurchaseAmbiguous(token, claim, 'non_terminal_completion_watch_uncertain');
+          void error;
+        });
+      return attachMatch(result);
+    }
+
+    if (result.submitted) {
+      const submitted = result.submitted;
+      await bindSellerTask(submitted.taskId);
       const observeTask = async (
         transport?: import('../protocols').TransportOptions,
         observationSignal?: AbortSignal
@@ -4648,10 +4911,15 @@ export class MediaBuyLifecycleCoordinator {
           const task = observationSignal
             ? await withAbortSignal([observationSignal], undefined, () => submitted.track(transport))
             : await submitted.track(transport);
+          if (task.taskId !== submitted.taskId) {
+            throw this.legacyPurchaseAmbiguousError(
+              'The tracked seller task ID does not match the durably recorded submitted task.'
+            );
+          }
+          if (task.taskType !== 'create_media_buy') {
+            throw this.legacyPurchaseAmbiguousError('The tracked seller task has the wrong task identity.');
+          }
           if (['completed', 'failed', 'rejected', 'canceled', 'governance-denied'].includes(task.status)) {
-            if (task.taskType !== 'create_media_buy') {
-              throw this.legacyPurchaseAmbiguousError('The tracked seller task has the wrong task identity.');
-            }
             if (task.status === 'completed' && task.result === undefined) {
               throw this.legacyPurchaseAmbiguousError(
                 'The tracked seller task reported completion without a create_media_buy result.'
@@ -4662,7 +4930,10 @@ export class MediaBuyLifecycleCoordinator {
             if (
               !completedSuccessfully &&
               task.status !== 'governance-denied' &&
-              extractAdcpErrorInfo(task.result) === undefined
+              (() => {
+                const adcpError = extractAdcpErrorInfo(task.result);
+                return adcpError === undefined || adcpError.synthetic === true;
+              })()
             ) {
               throw this.legacyPurchaseAmbiguousError(
                 'The tracked legacy create failure was not an authoritative structured AdCP error.'
@@ -4683,7 +4954,7 @@ export class MediaBuyLifecycleCoordinator {
                       ...(task.result !== undefined && { data: task.result }),
                     }),
                 metadata: {
-                  ...result.metadata,
+                  ...settlementMetadata,
                   status: completedSuccessfully
                     ? 'completed'
                     : task.status === 'governance-denied'
@@ -4722,51 +4993,6 @@ export class MediaBuyLifecycleCoordinator {
           throw this.legacyPurchaseAmbiguousError('Legacy create task tracking failed after claim.', error);
         }
       };
-      const resultFromTask = (
-        task: Awaited<ReturnType<typeof submitted.track>>
-      ): TaskResult<CreateMediaBuyResponse> | undefined => {
-        const metadata = {
-          ...result.metadata,
-          taskName: task.taskType,
-          timestamp: new Date().toISOString(),
-        };
-        if (
-          task.status === 'completed' &&
-          task.result !== undefined &&
-          isAdcpOperationSuccess(task.result, task.taskType)
-        ) {
-          return attachMatch({
-            success: true,
-            status: 'completed',
-            data: task.result as CreateMediaBuyResponse,
-            metadata: { ...metadata, status: 'completed' },
-          });
-        }
-        if (task.status === 'unknown') {
-          throw this.legacyPurchaseAmbiguousError(
-            'tasks/get returned an unrecognizable response for the submitted legacy purchase.'
-          );
-        }
-        if (['completed', 'failed', 'rejected', 'canceled', 'governance-denied'].includes(task.status)) {
-          const status = task.status === 'governance-denied' ? 'governance-denied' : 'failed';
-          return attachMatch({
-            success: false,
-            status,
-            ...failureFieldsFromTask(task),
-            ...(task.result !== undefined && { data: task.result as CreateMediaBuyResponse }),
-            metadata: { ...metadata, status },
-          } as TaskResult<CreateMediaBuyResponse>);
-        }
-        if (task.status === 'input-required' || task.status === 'auth-required') {
-          return attachMatch({
-            success: true,
-            status: task.status,
-            ...(task.result !== undefined && { data: task.result as CreateMediaBuyResponse }),
-            metadata: { ...metadata, status: task.status },
-          } as TaskResult<CreateMediaBuyResponse>);
-        }
-        return undefined;
-      };
       type SharedCompletion = {
         controller: AbortController;
         pollInterval: number;
@@ -4797,9 +5023,18 @@ export class MediaBuyLifecycleCoordinator {
       const pollTrackedCompletion = async (state: SharedCompletion, signal: AbortSignal) => {
         while (true) {
           if (signal.aborted) throw createAbortError(signal.reason);
-          const task = await observeTask(undefined, signal);
+          const task = await observeTask(settlementTransport, signal);
           const observed = resultFromTask(task);
-          if (observed) return this.trackLegacyPurchaseResult(token, claim, observed);
+          if (observed) {
+            return this.trackLegacyPurchaseResult(
+              token,
+              claim,
+              observed,
+              publishSettledTaskStatus,
+              registerExternalTaskSettlement,
+              settlementTransport
+            );
+          }
           await waitForNextPoll(state, signal);
         }
       };
@@ -4902,6 +5137,9 @@ export class MediaBuyLifecycleCoordinator {
       const watchSignal = AbortSignal.timeout(Math.min(this.legacyPurchaseOperationTtlMs, 5 * 60 * 1000));
       void new Promise<void>(resolve => setTimeout(resolve, 0))
         .then(() => waitForSharedCompletion(undefined, watchSignal))
+        .then(completion => {
+          publishSettledTaskStatus?.(completion.status, completion.data, completion.error);
+        })
         .catch(async error => {
           if (watchSignal.aborted || isAbortOrTimeoutError(error)) return;
           await this.markLegacyPurchaseAmbiguous(token, claim, 'background_completion_watch_uncertain');
@@ -4916,7 +5154,14 @@ export class MediaBuyLifecycleCoordinator {
         ...deferred,
         resume: async (resumeInput: unknown) => {
           try {
-            return await this.trackLegacyPurchaseResult(token, claim, await deferred.resume(resumeInput));
+            return await this.trackLegacyPurchaseResult(
+              token,
+              claim,
+              await deferred.resume(resumeInput),
+              publishSettledTaskStatus,
+              registerExternalTaskSettlement,
+              settlementTransport
+            );
           } catch (error) {
             if (error instanceof LegacyPurchaseContinuationError) {
               if (error.code === 'ambiguous') {
@@ -5979,6 +6224,25 @@ export class MediaBuyLifecycleCoordinator {
     const input = record(params);
     const lifecycle = this.selectLifecycle('control_media_buy');
     this.assertLegacyReferenceShapes('controlMediaBuy', input);
+    const canceledControlConflicts = [
+      'name',
+      'paused',
+      'total_budget',
+      'daily_budget_cap',
+      'budget_cap_timezone',
+      'budget_allocation',
+      'pacing',
+      'bidding',
+      'packages',
+      'reporting_webhook',
+    ];
+    if (Object.hasOwn(input, 'canceled') && canceledControlConflicts.some(field => Object.hasOwn(input, field))) {
+      throw this.unsupported(
+        'controlMediaBuy',
+        'canceled',
+        'Compact media-buy cancellation cannot be combined with other operational controls.'
+      );
+    }
     if (lifecycle === 'compact') {
       this.assertValidCompactRequest('control_media_buy', params, lifecycle, true);
       const result = await this.agent.controlMediaBuy(params, inputHandler, options);
@@ -5997,6 +6261,9 @@ export class MediaBuyLifecycleCoordinator {
       'bidding',
       'governance_context',
     ]);
+    if (!isCompactRelease(this.negotiated_version)) {
+      this.assertCompactWireFieldsAbsent('controlMediaBuy', input, ['name']);
+    }
     if (compareRelease(this.negotiated_version, '3.0') < 0) {
       this.assertCompactWireFieldsAbsent('controlMediaBuy', input, ['reporting_webhook']);
     }
@@ -6203,29 +6470,12 @@ export class MediaBuyLifecycleCoordinator {
         'Compact media-buy cancellation_reason requires canceled=true.'
       );
     }
-    const canceledControlConflicts = [
-      'paused',
-      'total_budget',
-      'daily_budget_cap',
-      'budget_cap_timezone',
-      'budget_allocation',
-      'pacing',
-      'bidding',
-      'packages',
-      'reporting_webhook',
-    ];
-    if (Object.hasOwn(input, 'canceled') && canceledControlConflicts.some(field => Object.hasOwn(input, field))) {
-      throw this.unsupported(
-        'controlMediaBuy',
-        'canceled',
-        'Compact media-buy cancellation cannot be combined with other operational controls.'
-      );
-    }
     const request: MutatingRequestInput<CanonicalUpdateMediaBuyRequest> = {
       account: input.account as CanonicalUpdateMediaBuyRequest['account'],
       media_buy_id: input.media_buy_id as string,
       ...(input.idempotency_key !== undefined && { idempotency_key: input.idempotency_key as string }),
       revision: input.revision as number,
+      ...(input.name !== undefined && { name: input.name as string }),
       ...(input.paused !== undefined && { paused: input.paused as boolean }),
       ...(input.canceled !== undefined && { canceled: input.canceled as true }),
       ...(input.cancellation_reason !== undefined && { cancellation_reason: input.cancellation_reason as string }),

--- a/src/lib/types/core.generated.ts
+++ b/src/lib/types/core.generated.ts
@@ -1,5 +1,5 @@
 // Generated AdCP core types from official schemas v3.2.0-beta.4
-// Generated at: 2026-08-20T19:56:16.188Z
+// Generated at: 2026-08-21T05:16:23.707Z
 
 // ACCOUNTCURRENCYMODE CANONICAL ENUM
 /**
@@ -10233,6 +10233,349 @@ export interface AuthorizationResult {
     message: string;
   };
 }
+// REQUESTPROPOSALSRESPONSE PRIORITY EXTRACTED TYPE
+/**
+ * One or more immutable draft media-plan proposals and compact canonical products referenced by their purchases. Products always carry product_id and name and never carry legacy named-format identifiers. During the AdCP 3.x compatibility window, an SDK projecting a valid products-only get_products brief result may instead return the deprecated products_available outcome with an explicit purchase continuation. Native 3.2 sellers MUST NOT use that compatibility outcome, and adapters MUST NOT fabricate a proposal, terms digest, or feed version.
+ */
+export type RequestProposalsResponse =
+  | {
+      /**
+       * Release-precision AdCP version (VERSION.RELEASE, e.g. "3.0", "3.1", "3.1-beta"). On a request: the buyer's release pin — the seller validates against its supported_versions and returns VERSION_UNSUPPORTED on cross-major mismatch, or downshifts to the highest supported release within the same major. On a response: the release the seller actually served — clients SHOULD validate the response against that release's schema, not against their pin. Patches are not negotiated; surface them as build_version on capabilities for operational visibility. When omitted, falls back to adcp_major_version (deprecated) or server default. Buyers SHOULD emit both adcp_version and adcp_major_version through 3.x to remain compatible with sellers that only read the legacy field. NORMALIZATION: SDKs that read full-semver values from bundle metadata (e.g. ComplianceIndex.published_version = "3.1.0-beta.1") MUST normalize to release-precision ("3.1-beta.1") before emitting on the wire — meta-field values are NOT valid wire values.
+       */
+      adcp_version?: string;
+      outcome: 'proposed';
+      reason?: never;
+      suggestions?: never;
+      /**
+       * @minItems 1
+       */
+      proposals: [
+        CanonicalProposal & {
+          proposal_status: 'draft';
+          /**
+           * @format date-time
+           */
+          expires_at: string;
+        },
+        ...(CanonicalProposal & {
+          proposal_status: 'draft';
+          /**
+           * @format date-time
+           */
+          expires_at: string;
+        })[]
+      ];
+      /**
+       * @minItems 1
+       */
+      products: [CanonicalProduct, ...CanonicalProduct[]];
+      /**
+       * Usable partial discovery result retained from the established get_products response. Absence means the source response did not declare an incomplete scope; it does not authorize an adapter to infer missing proposal terms.
+       *
+       * @minItems 1
+       */
+      incomplete?: [
+        {
+          scope: 'products' | 'pricing' | 'forecast' | 'proposals' | 'wholesale_feed';
+          /**
+           * @minLength 1
+           */
+          description: string;
+          estimated_wait?: Duration;
+        },
+        ...{
+          scope: 'products' | 'pricing' | 'forecast' | 'proposals' | 'wholesale_feed';
+          /**
+           * @minLength 1
+           */
+          description: string;
+          estimated_wait?: Duration;
+        }[]
+      ];
+      purchase_continuation?: never;
+      targeting_resolution?: ProductDiscoveryTargetingResolution;
+      status?: 'completed';
+      task_id?: never;
+      /**
+       * @maxLength 2000
+       */
+      message?: string;
+      errors?: Error[];
+      context?: ContextObject;
+      ext?: ExtensionObject;
+      replayed?: true;
+    }
+  | {
+      /**
+       * Release-precision AdCP version (VERSION.RELEASE, e.g. "3.0", "3.1", "3.1-beta"). On a request: the buyer's release pin — the seller validates against its supported_versions and returns VERSION_UNSUPPORTED on cross-major mismatch, or downshifts to the highest supported release within the same major. On a response: the release the seller actually served — clients SHOULD validate the response against that release's schema, not against their pin. Patches are not negotiated; surface them as build_version on capabilities for operational visibility. When omitted, falls back to adcp_major_version (deprecated) or server default. Buyers SHOULD emit both adcp_version and adcp_major_version through 3.x to remain compatible with sellers that only read the legacy field. NORMALIZATION: SDKs that read full-semver values from bundle metadata (e.g. ComplianceIndex.published_version = "3.1.0-beta.1") MUST normalize to release-precision ("3.1-beta.1") before emitting on the wire — meta-field values are NOT valid wire values.
+       */
+      adcp_version?: string;
+      outcome: 'products_available';
+      reason?: never;
+      suggestions?: never;
+      proposals?: never;
+      /**
+       * @minItems 1
+       */
+      products: [CanonicalProduct, ...CanonicalProduct[]];
+      /**
+       * Usable partial discovery result retained from the established get_products response. Absence means the source response did not declare an incomplete scope; it does not authorize an adapter to infer missing proposal terms.
+       *
+       * @minItems 1
+       */
+      incomplete?: [
+        {
+          scope: 'products' | 'pricing' | 'forecast' | 'proposals' | 'wholesale_feed';
+          /**
+           * @minLength 1
+           */
+          description: string;
+          estimated_wait?: Duration;
+        },
+        ...{
+          scope: 'products' | 'pricing' | 'forecast' | 'proposals' | 'wholesale_feed';
+          /**
+           * @minLength 1
+           */
+          description: string;
+          estimated_wait?: Duration;
+        }[]
+      ];
+      /**
+       * @deprecated
+       * Deprecated AdCP 3.x projection instruction for purchasing products returned without a proposal. This is coordinator state, not a claim that the established seller implements a compact task. A native 3.2 seller MUST NOT emit it.
+       */
+      purchase_continuation:
+        | {
+            kind: 'listed_purchase';
+            /**
+             * Exact products the coordinator promoted and re-read through account-scoped list_products before returning this result. The set MUST match products[].product_id.
+             *
+             * @minItems 1
+             */
+            product_ids: [string, ...string[]];
+            cache_scope: 'account';
+            /**
+             * Real seller-issued account-scoped feed fence obtained by re-reading the promoted products through list_products.
+             * @minLength 1
+             */
+            feed_version: string;
+            /**
+             * Real seller-issued pricing fence from the same account-scoped list_products response, when the seller versions pricing independently.
+             * @minLength 1
+             */
+            pricing_version?: string;
+          }
+        | {
+            kind: 'legacy_create';
+            /**
+             * Opaque, short-lived coordinator token bound to the caller principal, account, and complete observed product/pricing payload. It is not a seller-issued feed fence.
+             * @minLength 16
+             */
+            continuation_token: string;
+            /**
+             * Absolute expiry of the single-use compatibility continuation.
+             * @format date-time
+             */
+            continuation_expires_at: string;
+            /**
+             * Established AdCP version actually negotiated with the peer. This provenance is required; the coordinator MUST NOT infer stronger guarantees from the label.
+             */
+            source_adcp_version: '2.5' | '3.0' | '3.1';
+            /**
+             * Exact products bound to this continuation. A follow-up MUST select a non-empty subset and MUST NOT substitute an ID from another discovery result.
+             *
+             * @minItems 1
+             */
+            product_ids: [string, ...string[]];
+            /**
+             * Guarantees that the established create_media_buy continuation cannot provide. The coordinator MUST fail before mutation unless the caller explicitly accepts every listed loss.
+             *
+             * @minItems 2
+             */
+            losses: [
+              'feed_version_not_atomic' | 'pricing_version_not_atomic' | 'mutation_idempotency_not_guaranteed',
+              'feed_version_not_atomic' | 'pricing_version_not_atomic' | 'mutation_idempotency_not_guaranteed',
+              ...('feed_version_not_atomic' | 'pricing_version_not_atomic' | 'mutation_idempotency_not_guaranteed')[]
+            ];
+            requires_explicit_acceptance: true;
+          };
+      targeting_resolution?: ProductDiscoveryTargetingResolution;
+      status?: 'completed';
+      task_id?: never;
+      /**
+       * @maxLength 2000
+       */
+      message?: string;
+      errors?: Error[];
+      context?: ContextObject;
+      ext?: ExtensionObject;
+      replayed?: true;
+    }
+  | {
+      /**
+       * Release-precision AdCP version (VERSION.RELEASE, e.g. "3.0", "3.1", "3.1-beta"). On a request: the buyer's release pin — the seller validates against its supported_versions and returns VERSION_UNSUPPORTED on cross-major mismatch, or downshifts to the highest supported release within the same major. On a response: the release the seller actually served — clients SHOULD validate the response against that release's schema, not against their pin. Patches are not negotiated; surface them as build_version on capabilities for operational visibility. When omitted, falls back to adcp_major_version (deprecated) or server default. Buyers SHOULD emit both adcp_version and adcp_major_version through 3.x to remain compatible with sellers that only read the legacy field. NORMALIZATION: SDKs that read full-semver values from bundle metadata (e.g. ComplianceIndex.published_version = "3.1.0-beta.1") MUST normalize to release-precision ("3.1-beta.1") before emitting on the wire — meta-field values are NOT valid wire values.
+       */
+      adcp_version?: string;
+      outcome: 'rejected';
+      /**
+       * @minLength 1
+       */
+      reason: string;
+      /**
+       * @minItems 1
+       */
+      suggestions?: [string, ...string[]];
+      proposals?: never;
+      products?: never;
+      incomplete?: never;
+      purchase_continuation?: never;
+      targeting_resolution?: ProductDiscoveryTargetingResolution;
+      status?: 'completed';
+      task_id?: never;
+      /**
+       * @maxLength 2000
+       */
+      message?: string;
+      errors?: Error[];
+      context?: ContextObject;
+      ext?: ExtensionObject;
+      replayed?: true;
+    }
+  | {
+      /**
+       * Release-precision AdCP version (VERSION.RELEASE, e.g. "3.0", "3.1", "3.1-beta"). On a request: the buyer's release pin — the seller validates against its supported_versions and returns VERSION_UNSUPPORTED on cross-major mismatch, or downshifts to the highest supported release within the same major. On a response: the release the seller actually served — clients SHOULD validate the response against that release's schema, not against their pin. Patches are not negotiated; surface them as build_version on capabilities for operational visibility. When omitted, falls back to adcp_major_version (deprecated) or server default. Buyers SHOULD emit both adcp_version and adcp_major_version through 3.x to remain compatible with sellers that only read the legacy field. NORMALIZATION: SDKs that read full-semver values from bundle metadata (e.g. ComplianceIndex.published_version = "3.1.0-beta.1") MUST normalize to release-precision ("3.1-beta.1") before emitting on the wire — meta-field values are NOT valid wire values.
+       */
+      adcp_version?: string;
+      outcome?: 'proposed' | 'products_available' | 'rejected';
+      /**
+       * @minLength 1
+       */
+      reason?: string;
+      /**
+       * @minItems 1
+       */
+      suggestions?: [string, ...string[]];
+      /**
+       * @minItems 1
+       */
+      proposals?: [
+        CanonicalProposal & {
+          proposal_status: 'draft';
+          /**
+           * @format date-time
+           */
+          expires_at: string;
+        },
+        ...(CanonicalProposal & {
+          proposal_status: 'draft';
+          /**
+           * @format date-time
+           */
+          expires_at: string;
+        })[]
+      ];
+      /**
+       * @minItems 1
+       */
+      products?: [CanonicalProduct, ...CanonicalProduct[]];
+      /**
+       * Usable partial discovery result retained from the established get_products response. Absence means the source response did not declare an incomplete scope; it does not authorize an adapter to infer missing proposal terms.
+       *
+       * @minItems 1
+       */
+      incomplete?: [
+        {
+          scope: 'products' | 'pricing' | 'forecast' | 'proposals' | 'wholesale_feed';
+          /**
+           * @minLength 1
+           */
+          description: string;
+          estimated_wait?: Duration;
+        },
+        ...{
+          scope: 'products' | 'pricing' | 'forecast' | 'proposals' | 'wholesale_feed';
+          /**
+           * @minLength 1
+           */
+          description: string;
+          estimated_wait?: Duration;
+        }[]
+      ];
+      /**
+       * @deprecated
+       * Deprecated AdCP 3.x projection instruction for purchasing products returned without a proposal. This is coordinator state, not a claim that the established seller implements a compact task. A native 3.2 seller MUST NOT emit it.
+       */
+      purchase_continuation?:
+        | {
+            kind: 'listed_purchase';
+            /**
+             * Exact products the coordinator promoted and re-read through account-scoped list_products before returning this result. The set MUST match products[].product_id.
+             *
+             * @minItems 1
+             */
+            product_ids: [string, ...string[]];
+            cache_scope: 'account';
+            /**
+             * Real seller-issued account-scoped feed fence obtained by re-reading the promoted products through list_products.
+             * @minLength 1
+             */
+            feed_version: string;
+            /**
+             * Real seller-issued pricing fence from the same account-scoped list_products response, when the seller versions pricing independently.
+             * @minLength 1
+             */
+            pricing_version?: string;
+          }
+        | {
+            kind: 'legacy_create';
+            /**
+             * Opaque, short-lived coordinator token bound to the caller principal, account, and complete observed product/pricing payload. It is not a seller-issued feed fence.
+             * @minLength 16
+             */
+            continuation_token: string;
+            /**
+             * Absolute expiry of the single-use compatibility continuation.
+             * @format date-time
+             */
+            continuation_expires_at: string;
+            /**
+             * Established AdCP version actually negotiated with the peer. This provenance is required; the coordinator MUST NOT infer stronger guarantees from the label.
+             */
+            source_adcp_version: '2.5' | '3.0' | '3.1';
+            /**
+             * Exact products bound to this continuation. A follow-up MUST select a non-empty subset and MUST NOT substitute an ID from another discovery result.
+             *
+             * @minItems 1
+             */
+            product_ids: [string, ...string[]];
+            /**
+             * Guarantees that the established create_media_buy continuation cannot provide. The coordinator MUST fail before mutation unless the caller explicitly accepts every listed loss.
+             *
+             * @minItems 2
+             */
+            losses: [
+              'feed_version_not_atomic' | 'pricing_version_not_atomic' | 'mutation_idempotency_not_guaranteed',
+              'feed_version_not_atomic' | 'pricing_version_not_atomic' | 'mutation_idempotency_not_guaranteed',
+              ...('feed_version_not_atomic' | 'pricing_version_not_atomic' | 'mutation_idempotency_not_guaranteed')[]
+            ];
+            requires_explicit_acceptance: true;
+          };
+      targeting_resolution?: ProductDiscoveryTargetingResolution;
+      status: 'submitted';
+      /**
+       * @minLength 1
+       */
+      task_id: string;
+      /**
+       * @maxLength 2000
+       */
+      message?: string;
+      errors?: Error[];
+      context?: ContextObject;
+      ext?: ExtensionObject;
+      replayed?: true;
+    };
 // SYNCCREATIVESSUCCESS PRIORITY EXTRACTED TYPE
 /**
  * Success response - sync operation processed creatives (may include per-item failures)
@@ -16509,100 +16852,6 @@ export type GetProductsRejected = AdCPVersionEnvelope &
     context?: ContextObject;
     ext?: ExtensionObject;
   };
-/**
- * Terminal response for request_proposals
- */
-export type RequestProposalsResponse = (
-  | {
-      outcome: 'proposed';
-      status?: 'completed';
-    }
-  | {
-    }
-  | {
-      outcome: 'rejected';
-      status?: 'completed';
-    }
-  | CompactTaskSubmitted
-) & {
-  /**
-   * Release-precision AdCP version (VERSION.RELEASE, e.g. "3.0", "3.1", "3.1-beta"). On a request: the buyer's release pin — the seller validates against its supported_versions and returns VERSION_UNSUPPORTED on cross-major mismatch, or downshifts to the highest supported release within the same major. On a response: the release the seller actually served — clients SHOULD validate the response against that release's schema, not against their pin. Patches are not negotiated; surface them as build_version on capabilities for operational visibility. When omitted, falls back to adcp_major_version (deprecated) or server default. Buyers SHOULD emit both adcp_version and adcp_major_version through 3.x to remain compatible with sellers that only read the legacy field. NORMALIZATION: SDKs that read full-semver values from bundle metadata (e.g. ComplianceIndex.published_version = "3.1.0-beta.1") MUST normalize to release-precision ("3.1-beta.1") before emitting on the wire — meta-field values are NOT valid wire values.
-   */
-  adcp_version?: string;
-  outcome?: 'proposed' | 'products_available' | 'rejected';
-  reason?: string;
-  /**
-   * @minItems 1
-   */
-  suggestions?: [string, ...string[]];
-  /**
-   * @minItems 1
-   */
-  proposals?: [
-    CanonicalProposal & {
-      proposal_status: 'draft';
-      expires_at: string;
-    },
-    ...(CanonicalProposal & {
-      proposal_status: 'draft';
-      expires_at: string;
-    })[]
-  ];
-  /**
-   * @minItems 1
-   */
-  products?: [CanonicalProduct, ...CanonicalProduct[]];
-  /**
-   * Usable partial discovery result retained from the established get_products response. Absence means the source response did not declare an incomplete scope; it does not authorize an adapter to infer missing proposal terms.
-   *
-   * @minItems 1
-   */
-  incomplete?: [
-    {
-      scope: 'products' | 'pricing' | 'forecast' | 'proposals' | 'wholesale_feed';
-      description: string;
-      estimated_wait?: Duration;
-    },
-    ...{
-      scope: 'products' | 'pricing' | 'forecast' | 'proposals' | 'wholesale_feed';
-      description: string;
-      estimated_wait?: Duration;
-    }[]
-  ];
-  /**
-   * @deprecated
-   * Deprecated AdCP 3.x projection instruction for purchasing products returned without a proposal. This is coordinator state, not a claim that the established seller implements a compact task. A native 3.2 seller MUST NOT emit it.
-   */
-  purchase_continuation?:
-    | {
-        kind: 'listed_purchase';
-        /**
-         * Exact products the coordinator promoted and re-read through account-scoped list_products before returning this result. The set MUST match products[].product_id.
-         *
-         * @minItems 1
-         */
-        product_ids: [string, ...string[]];
-        cache_scope: 'account';
-        /**
-         * Real seller-issued account-scoped feed fence obtained by re-reading the promoted products through list_products.
-         */
-        feed_version: string;
-        /**
-         * Real seller-issued pricing fence from the same account-scoped list_products response, when the seller versions pricing independently.
-         */
-        pricing_version?: string;
-      }
-    | {
-      };
-  targeting_resolution?: ProductDiscoveryTargetingResolution;
-  status?: 'completed' | 'submitted';
-  task_id?: string;
-  message?: string;
-  errors?: Error[];
-  context?: ContextObject;
-  ext?: ExtensionObject;
-  replayed?: true;
-};
 /**
  * Compact immutable proposal for the AdCP 3.2 lifecycle. commercial_terms is the sole authoritative commercial envelope; narrative fields do not duplicate legacy allocation or creative graphs.
  */

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -133,6 +133,12 @@ export type {
   GetPlanAuditLogsResponse,
 } from './tools.generated';
 
+// Compact proposal authoring. The response is owned by core.generated so
+// every public surface retains its discriminated branches and non-empty
+// tuple guarantees instead of the weaker aggregate-tool projection.
+export type { RequestProposalsRequest } from './tools.generated';
+export type { RequestProposalsResponse } from './core.generated';
+
 // Pricing models (discriminated union across pricing types)
 export type { PricingOption, CPMPricingOption, CPCPricingOption, CPVPricingOption } from './tools.generated';
 

--- a/src/lib/types/schemas.generated.ts
+++ b/src/lib/types/schemas.generated.ts
@@ -1,5 +1,5 @@
 // Generated Zod v4 schemas from TypeScript types
-// Generated at: 2026-08-20T22:13:35.407Z
+// Generated at: 2026-08-21T05:29:30.153Z
 // Sources:
 //   - core.generated.ts (core types)
 //   - tools.generated.ts (tool types)
@@ -2957,8 +2957,6 @@ export const DeclineProposalsResponseSchema = z.union([z.object({
             }).passthrough(), z.object({
                 outcome: z.literal("unable")
             }).passthrough()])),
-        status: z.literal("submitted").optional(),
-        task_id: z.string().min(1).optional(),
         message: z.string().max(2000).optional(),
         errors: z.array(ErrorSchema).optional(),
         context: ContextObjectSchema.optional(),
@@ -11633,6 +11631,11 @@ export const ValidationResultSchema = z.object({
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
+export const ProductDiscoveryTargetingResolutionSchema = z.object({
+    brief_targeting: TargetingOverlaySchema,
+    ext: ExtensionObjectSchema.optional()
+}).passthrough();
+
 export const AudienceEvidenceSchema: z.ZodType = z.object({}).passthrough().merge(z.object({}).passthrough()).merge(z.object({}).passthrough()).merge(z.object({
     evidence_id: z.string(),
     snapshot_id: z.string(),
@@ -13214,11 +13217,6 @@ export const ProductSchema: z.ZodObject<{ product_id: z.ZodType; name: z.ZodType
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
-export const ProductDiscoveryTargetingResolutionSchema = z.object({
-    brief_targeting: TargetingOverlaySchema,
-    ext: ExtensionObjectSchema.optional()
-}).passthrough();
-
 export const ProductAllocationSchema = z.object({
     product_id: z.string(),
     allocation_percentage: z.number().optional(),
@@ -14352,44 +14350,6 @@ export const RequestProposalsRequestSchema = z.object({
     }).passthrough()).optional()
 }).passthrough();
 
-export const CanonicalProductSchema = z.object({
-    product_id: z.string(),
-    name: z.string(),
-    description: z.string().optional(),
-    publisher_properties: z.array(PublisherPropertySelectorSchema.and(z.object({}).passthrough())).optional(),
-    channels: z.array(MediaChannelSchema).optional(),
-    video_placement_types: z.array(VideoPlacementTypeSchema).optional(),
-    audio_distribution_types: z.array(AudioDistributionTypeSchema).optional(),
-    sponsored_placement_types: z.array(SponsoredPlacementTypeSchema).optional(),
-    social_placement_surfaces: z.array(SocialPlacementSurfaceSchema).optional(),
-    format_options: z.array(CanonicalFormatOptionSchema).optional(),
-    placements: z.array(CanonicalProductPlacementSchema).optional(),
-    delivery_type: DeliveryTypeSchema.optional(),
-    exclusivity: ExclusivitySchema.optional(),
-    pricing_options: z.array(CanonicalPricingOptionSchema).optional(),
-    forecast: CanonicalDeliveryForecastSchema.optional(),
-    reporting_capabilities: CanonicalReportingCapabilitiesSchema.optional(),
-    measurement_terms: CanonicalMeasurementTermsSchema.optional(),
-    performance_standards: z.array(CanonicalPerformanceStandardSchema).optional(),
-    catalog_types: z.array(CatalogTypeSchema).optional(),
-    signal_targeting_allowed: z.boolean().optional(),
-    signal_targeting_rules: SignalTargetingRulesSchema.optional(),
-    demographic_targeting: DemographicTargetingCapabilitySchema.optional(),
-    audience_evidence: z.array(CanonicalAudienceEvidenceSchema).optional(),
-    audience_evidence_selections: z.array(CanonicalAudienceEvidenceSelectionSchema).optional(),
-    max_optimization_goals: z.number().optional(),
-    catalog_match: z.object({
-        matched_gtins: z.array(z.string()).optional(),
-        matched_ids: z.array(z.string()).optional(),
-        matched_count: z.number().optional(),
-        submitted_count: z.number()
-    }).passthrough().optional(),
-    brief_relevance: z.string().optional(),
-    expires_at: z.string().optional(),
-    allowed_actions: z.array(CanonicalProductActionSchema).optional(),
-    ext: ExtensionObjectSchema.optional()
-}).passthrough();
-
 export const CommercialTermsSchema = z.object({
     source_feed_version: z.string().optional(),
     source_pricing_version: z.string().optional(),
@@ -15159,6 +15119,44 @@ export const CanonicalProposalSchema: z.ZodObject<{ [K in keyof CanonicalProposa
         extend: objectSchema.extend.bind(objectSchema),
       });
     })();
+
+export const CanonicalProductSchema = z.object({
+    product_id: z.string(),
+    name: z.string(),
+    description: z.string().optional(),
+    publisher_properties: z.array(PublisherPropertySelectorSchema.and(z.object({}).passthrough())).optional(),
+    channels: z.array(MediaChannelSchema).optional(),
+    video_placement_types: z.array(VideoPlacementTypeSchema).optional(),
+    audio_distribution_types: z.array(AudioDistributionTypeSchema).optional(),
+    sponsored_placement_types: z.array(SponsoredPlacementTypeSchema).optional(),
+    social_placement_surfaces: z.array(SocialPlacementSurfaceSchema).optional(),
+    format_options: z.array(CanonicalFormatOptionSchema).optional(),
+    placements: z.array(CanonicalProductPlacementSchema).optional(),
+    delivery_type: DeliveryTypeSchema.optional(),
+    exclusivity: ExclusivitySchema.optional(),
+    pricing_options: z.array(CanonicalPricingOptionSchema).optional(),
+    forecast: CanonicalDeliveryForecastSchema.optional(),
+    reporting_capabilities: CanonicalReportingCapabilitiesSchema.optional(),
+    measurement_terms: CanonicalMeasurementTermsSchema.optional(),
+    performance_standards: z.array(CanonicalPerformanceStandardSchema).optional(),
+    catalog_types: z.array(CatalogTypeSchema).optional(),
+    signal_targeting_allowed: z.boolean().optional(),
+    signal_targeting_rules: SignalTargetingRulesSchema.optional(),
+    demographic_targeting: DemographicTargetingCapabilitySchema.optional(),
+    audience_evidence: z.array(CanonicalAudienceEvidenceSchema).optional(),
+    audience_evidence_selections: z.array(CanonicalAudienceEvidenceSelectionSchema).optional(),
+    max_optimization_goals: z.number().optional(),
+    catalog_match: z.object({
+        matched_gtins: z.array(z.string()).optional(),
+        matched_ids: z.array(z.string()).optional(),
+        matched_count: z.number().optional(),
+        submitted_count: z.number()
+    }).passthrough().optional(),
+    brief_relevance: z.string().optional(),
+    expires_at: z.string().optional(),
+    allowed_actions: z.array(CanonicalProductActionSchema).optional(),
+    ext: ExtensionObjectSchema.optional()
+}).passthrough();
 
 export const BuyProductsRequestSchema = z.object({
     adcp_version: z.string().optional(),
@@ -16745,6 +16743,249 @@ export const ValidatePropertyDeliveryResponseSchema = z.object({
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
+export const RequestProposalsResponseSchema = z.union([z.object({
+        adcp_version: z.string().optional(),
+        outcome: z.literal("proposed"),
+        reason: z.never().optional(),
+        suggestions: z.never().optional(),
+        proposals: z.tuple([CanonicalProposalSchema.and(z.object({
+                proposal_status: z.literal("draft"),
+                expires_at: z.iso.datetime()
+            }).passthrough())]).rest(CanonicalProposalSchema.and(z.object({
+            proposal_status: z.literal("draft"),
+            expires_at: z.iso.datetime()
+        }).passthrough())),
+        products: z.array(CanonicalProductSchema),
+        incomplete: z.tuple([z.object({
+                scope: z.union([z.literal("products"), z.literal("pricing"), z.literal("forecast"), z.literal("proposals"), z.literal("wholesale_feed")]),
+                description: z.string().min(1),
+                estimated_wait: DurationSchema.optional()
+            }).passthrough()]).rest(z.object({
+            scope: z.union([z.literal("products"), z.literal("pricing"), z.literal("forecast"), z.literal("proposals"), z.literal("wholesale_feed")]),
+            description: z.string().min(1),
+            estimated_wait: DurationSchema.optional()
+        }).passthrough()).optional(),
+        purchase_continuation: z.never().optional(),
+        targeting_resolution: ProductDiscoveryTargetingResolutionSchema.optional(),
+        status: z.literal("completed").optional(),
+        task_id: z.never().optional(),
+        message: z.string().max(2000).optional(),
+        errors: z.array(ErrorSchema).optional(),
+        context: ContextObjectSchema.optional(),
+        ext: ExtensionObjectSchema.optional(),
+        replayed: z.literal(true).optional()
+    }).passthrough(), z.object({
+        adcp_version: z.string().optional(),
+        outcome: z.literal("products_available"),
+        reason: z.never().optional(),
+        suggestions: z.never().optional(),
+        proposals: z.never().optional(),
+        products: z.array(CanonicalProductSchema),
+        incomplete: z.tuple([z.object({
+                scope: z.union([z.literal("products"), z.literal("pricing"), z.literal("forecast"), z.literal("proposals"), z.literal("wholesale_feed")]),
+                description: z.string().min(1),
+                estimated_wait: DurationSchema.optional()
+            }).passthrough()]).rest(z.object({
+            scope: z.union([z.literal("products"), z.literal("pricing"), z.literal("forecast"), z.literal("proposals"), z.literal("wholesale_feed")]),
+            description: z.string().min(1),
+            estimated_wait: DurationSchema.optional()
+        }).passthrough()).optional(),
+        purchase_continuation: z.union([z.object({
+                kind: z.literal("listed_purchase"),
+                product_ids: z.array(z.string()),
+                cache_scope: z.literal("account"),
+                feed_version: z.string().min(1),
+                pricing_version: z.string().min(1).optional()
+            }).passthrough(), z.object({
+                kind: z.literal("legacy_create"),
+                continuation_token: z.string().min(16),
+                continuation_expires_at: z.iso.datetime(),
+                source_adcp_version: z.union([z.literal("2.5"), z.literal("3.0"), z.literal("3.1")]),
+                product_ids: z.array(z.string()),
+                losses: z.tuple([z.union([z.literal("feed_version_not_atomic"), z.literal("pricing_version_not_atomic"), z.literal("mutation_idempotency_not_guaranteed")]), z.union([z.literal("feed_version_not_atomic"), z.literal("pricing_version_not_atomic"), z.literal("mutation_idempotency_not_guaranteed")])]).rest(z.union([z.literal("feed_version_not_atomic"), z.literal("pricing_version_not_atomic"), z.literal("mutation_idempotency_not_guaranteed")])),
+                requires_explicit_acceptance: z.literal(true)
+            }).passthrough().superRefine((value, ctx) => {
+            if (value.product_ids.length === 0) {
+                ctx.addIssue({ code: "custom", path: ["product_ids"], message: "product_ids must contain at least one entry" });
+            }
+            if (value.product_ids.some(productId => productId.length === 0)) {
+                ctx.addIssue({ code: "custom", path: ["product_ids"], message: "product_ids must not contain empty IDs" });
+            }
+            if (new Set(value.product_ids).size !== value.product_ids.length) {
+                ctx.addIssue({ code: "custom", path: ["product_ids"], message: "product_ids must be unique" });
+            }
+            if (value.losses.length < 2) {
+                ctx.addIssue({ code: "custom", path: ["losses"], message: "losses must contain at least two entries" });
+            }
+            if (new Set(value.losses).size !== value.losses.length) {
+                ctx.addIssue({ code: "custom", path: ["losses"], message: "losses must be unique" });
+            }
+            for (const required of ["feed_version_not_atomic", "pricing_version_not_atomic"] as const) {
+                if (!value.losses.includes(required)) {
+                    ctx.addIssue({ code: "custom", path: ["losses"], message: `losses must contain ${required}` });
+                }
+            }
+            if (value.source_adcp_version === "2.5" && !value.losses.includes("mutation_idempotency_not_guaranteed")) {
+                ctx.addIssue({ code: "custom", path: ["losses"], message: "AdCP 2.5 losses must contain mutation_idempotency_not_guaranteed" });
+            }
+        })]),
+        targeting_resolution: ProductDiscoveryTargetingResolutionSchema.optional(),
+        status: z.literal("completed").optional(),
+        task_id: z.never().optional(),
+        message: z.string().max(2000).optional(),
+        errors: z.array(ErrorSchema).optional(),
+        context: ContextObjectSchema.optional(),
+        ext: ExtensionObjectSchema.optional(),
+        replayed: z.literal(true).optional()
+    }).passthrough(), z.object({
+        adcp_version: z.string().optional(),
+        outcome: z.literal("rejected"),
+        reason: z.string().min(1),
+        suggestions: z.array(z.string()).optional(),
+        proposals: z.never().optional(),
+        products: z.never().optional(),
+        incomplete: z.never().optional(),
+        purchase_continuation: z.never().optional(),
+        targeting_resolution: ProductDiscoveryTargetingResolutionSchema.optional(),
+        status: z.literal("completed").optional(),
+        task_id: z.never().optional(),
+        message: z.string().max(2000).optional(),
+        errors: z.array(ErrorSchema).optional(),
+        context: ContextObjectSchema.optional(),
+        ext: ExtensionObjectSchema.optional(),
+        replayed: z.literal(true).optional()
+    }).passthrough(), z.object({
+        adcp_version: z.string().optional(),
+        outcome: z.union([z.literal("proposed"), z.literal("products_available"), z.literal("rejected")]).optional(),
+        reason: z.string().min(1).optional(),
+        suggestions: z.array(z.string()).optional(),
+        proposals: z.tuple([CanonicalProposalSchema.and(z.object({
+                proposal_status: z.literal("draft"),
+                expires_at: z.iso.datetime()
+            }).passthrough())]).rest(CanonicalProposalSchema.and(z.object({
+            proposal_status: z.literal("draft"),
+            expires_at: z.iso.datetime()
+        }).passthrough())).optional(),
+        products: z.array(CanonicalProductSchema).optional(),
+        incomplete: z.tuple([z.object({
+                scope: z.union([z.literal("products"), z.literal("pricing"), z.literal("forecast"), z.literal("proposals"), z.literal("wholesale_feed")]),
+                description: z.string().min(1),
+                estimated_wait: DurationSchema.optional()
+            }).passthrough()]).rest(z.object({
+            scope: z.union([z.literal("products"), z.literal("pricing"), z.literal("forecast"), z.literal("proposals"), z.literal("wholesale_feed")]),
+            description: z.string().min(1),
+            estimated_wait: DurationSchema.optional()
+        }).passthrough()).optional(),
+        purchase_continuation: z.union([z.object({
+                kind: z.literal("listed_purchase"),
+                product_ids: z.array(z.string()),
+                cache_scope: z.literal("account"),
+                feed_version: z.string().min(1),
+                pricing_version: z.string().min(1).optional()
+            }).passthrough(), z.object({
+                kind: z.literal("legacy_create"),
+                continuation_token: z.string().min(16),
+                continuation_expires_at: z.iso.datetime(),
+                source_adcp_version: z.union([z.literal("2.5"), z.literal("3.0"), z.literal("3.1")]),
+                product_ids: z.array(z.string()),
+                losses: z.tuple([z.union([z.literal("feed_version_not_atomic"), z.literal("pricing_version_not_atomic"), z.literal("mutation_idempotency_not_guaranteed")]), z.union([z.literal("feed_version_not_atomic"), z.literal("pricing_version_not_atomic"), z.literal("mutation_idempotency_not_guaranteed")])]).rest(z.union([z.literal("feed_version_not_atomic"), z.literal("pricing_version_not_atomic"), z.literal("mutation_idempotency_not_guaranteed")])),
+                requires_explicit_acceptance: z.literal(true)
+            }).passthrough().superRefine((value, ctx) => {
+            if (value.product_ids.length === 0) {
+                ctx.addIssue({ code: "custom", path: ["product_ids"], message: "product_ids must contain at least one entry" });
+            }
+            if (value.product_ids.some(productId => productId.length === 0)) {
+                ctx.addIssue({ code: "custom", path: ["product_ids"], message: "product_ids must not contain empty IDs" });
+            }
+            if (new Set(value.product_ids).size !== value.product_ids.length) {
+                ctx.addIssue({ code: "custom", path: ["product_ids"], message: "product_ids must be unique" });
+            }
+            if (value.losses.length < 2) {
+                ctx.addIssue({ code: "custom", path: ["losses"], message: "losses must contain at least two entries" });
+            }
+            if (new Set(value.losses).size !== value.losses.length) {
+                ctx.addIssue({ code: "custom", path: ["losses"], message: "losses must be unique" });
+            }
+            for (const required of ["feed_version_not_atomic", "pricing_version_not_atomic"] as const) {
+                if (!value.losses.includes(required)) {
+                    ctx.addIssue({ code: "custom", path: ["losses"], message: `losses must contain ${required}` });
+                }
+            }
+            if (value.source_adcp_version === "2.5" && !value.losses.includes("mutation_idempotency_not_guaranteed")) {
+                ctx.addIssue({ code: "custom", path: ["losses"], message: "AdCP 2.5 losses must contain mutation_idempotency_not_guaranteed" });
+            }
+        })]).optional(),
+        targeting_resolution: ProductDiscoveryTargetingResolutionSchema.optional(),
+        status: z.literal("submitted"),
+        task_id: z.string().min(1),
+        message: z.string().max(2000).optional(),
+        errors: z.array(ErrorSchema).optional(),
+        context: ContextObjectSchema.optional(),
+        ext: ExtensionObjectSchema.optional(),
+        replayed: z.literal(true).optional()
+    }).passthrough()]).superRefine((value: any, ctx) => {
+    const present = (field: string): boolean => Object.prototype.hasOwnProperty.call(value, field);
+    const requireNonEmptyArray = (field: "products" | "proposals"): void => {
+        if (!Array.isArray(value[field]) || value[field].length === 0) {
+            ctx.addIssue({ code: "custom", path: [field], message: `${field} must contain at least one entry` });
+        }
+    };
+    const forbid = (fields: readonly string[]): void => {
+        for (const field of fields) {
+            if (present(field)) ctx.addIssue({ code: "custom", path: [field], message: `${field} is forbidden for this outcome` });
+        }
+    };
+    forbid(["refinement_applied", "pagination", "unchanged", "wholesale_feed_version"]);
+    if (value.suggestions !== undefined && (value.suggestions.length === 0 || value.suggestions.some((suggestion: string) => suggestion.length === 0))) {
+        ctx.addIssue({ code: "custom", path: ["suggestions"], message: "suggestions must contain non-empty strings" });
+    }
+    if (value.incomplete !== undefined && value.incomplete.length === 0) {
+        ctx.addIssue({ code: "custom", path: ["incomplete"], message: "incomplete must contain at least one entry" });
+    }
+    if (value.outcome === "proposed") {
+        requireNonEmptyArray("proposals");
+        requireNonEmptyArray("products");
+        forbid(["reason", "suggestions", "purchase_continuation", "task_id"]);
+    } else if (value.outcome === "products_available") {
+        requireNonEmptyArray("products");
+        if (!present("purchase_continuation")) {
+            ctx.addIssue({ code: "custom", path: ["purchase_continuation"], message: "purchase_continuation is required" });
+        }
+        forbid(["proposals", "reason", "suggestions", "task_id"]);
+        if (value.purchase_continuation?.kind === "listed_purchase") {
+            const ids = value.purchase_continuation.product_ids;
+            if (ids.length === 0 || ids.some((productId: string) => productId.length === 0)) {
+                ctx.addIssue({ code: "custom", path: ["purchase_continuation", "product_ids"], message: "product_ids must contain non-empty IDs" });
+            }
+            if (new Set(ids).size !== ids.length) {
+                ctx.addIssue({ code: "custom", path: ["purchase_continuation", "product_ids"], message: "product_ids must be unique" });
+            }
+            const returnedIds = (value.products ?? []).map((product: any) => product.product_id);
+            const returnedIdSet = new Set(returnedIds);
+            if (
+                returnedIds.length !== ids.length ||
+                returnedIdSet.size !== returnedIds.length ||
+                ids.some((productId: string) => !returnedIdSet.has(productId))
+            ) {
+                ctx.addIssue({ code: "custom", path: ["purchase_continuation", "product_ids"], message: "listed product_ids must exactly match returned products" });
+            }
+            for (const [index, product] of (value.products ?? []).entries()) {
+                if (!Array.isArray(product.pricing_options) || product.pricing_options.length === 0) {
+                    ctx.addIssue({ code: "custom", path: ["products", index, "pricing_options"], message: "listed products require pricing_options" });
+                }
+            }
+            for (const [index, incomplete] of (value.incomplete ?? []).entries()) {
+                if (["products", "pricing", "wholesale_feed"].includes(incomplete.scope)) {
+                    ctx.addIssue({ code: "custom", path: ["incomplete", index, "scope"], message: "listed purchase cannot report incomplete product or pricing data" });
+                }
+            }
+        }
+    } else if (value.outcome === "rejected") {
+        if (!present("reason")) ctx.addIssue({ code: "custom", path: ["reason"], message: "reason is required" });
+        forbid(["proposals", "products", "incomplete", "purchase_continuation", "task_id"]);
+    }
+});
+
 export const MediaBuySchema: z.ZodType = z.object({
     media_buy_id: z.string(),
     name: z.string().min(1).max(255).regex(/\S/).optional(),
@@ -16777,140 +17018,6 @@ export const MediaBuySchema: z.ZodType = z.object({
     updated_at: z.iso.datetime().optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
-
-export const RequestProposalsResponseSchema = z.union([z.object({
-        outcome: z.literal("proposed"),
-        status: z.literal("completed").optional()
-    }).passthrough(), z.object({
-        outcome: z.literal("products_available"),
-        status: z.literal("completed").optional()
-    }).passthrough(), z.object({
-        outcome: z.literal("rejected"),
-        status: z.literal("completed").optional()
-    }).passthrough(), CompactTaskSubmittedSchema]).and(z.object({
-    adcp_version: z.string().optional(),
-    outcome: z.union([z.literal("proposed"), z.literal("products_available"), z.literal("rejected")]).optional(),
-    reason: z.string().min(1).optional(),
-    suggestions: z.array(z.string()).optional(),
-    proposals: z.array(CanonicalProposalSchema.and(z.object({
-        proposal_status: z.literal("draft"),
-        expires_at: z.iso.datetime()
-    }).passthrough())).optional(),
-    products: z.array(CanonicalProductSchema).optional(),
-    incomplete: z.array(z.object({
-        scope: z.union([z.literal("products"), z.literal("pricing"), z.literal("forecast"), z.literal("proposals"), z.literal("wholesale_feed")]),
-        description: z.string().min(1),
-        estimated_wait: DurationSchema.optional()
-    }).passthrough()).optional(),
-    purchase_continuation: z.union([z.object({
-            kind: z.literal("listed_purchase"),
-            product_ids: z.array(z.string()),
-            cache_scope: z.literal("account"),
-            feed_version: z.string().min(1),
-            pricing_version: z.string().min(1).optional()
-        }).passthrough(), z.object({
-            kind: z.literal("legacy_create"),
-            continuation_token: z.string().min(16),
-            continuation_expires_at: z.iso.datetime(),
-            source_adcp_version: z.union([z.literal("2.5"), z.literal("3.0"), z.literal("3.1")]),
-            product_ids: z.array(z.string()),
-            losses: z.array(z.union([z.literal("feed_version_not_atomic"), z.literal("pricing_version_not_atomic"), z.literal("mutation_idempotency_not_guaranteed")])),
-            requires_explicit_acceptance: z.literal(true)
-        }).passthrough().superRefine((value, ctx) => {
-            if (value.product_ids.length === 0) {
-                ctx.addIssue({ code: "custom", path: ["product_ids"], message: "product_ids must contain at least one entry" });
-            }
-            if (value.product_ids.some(productId => productId.length === 0)) {
-                ctx.addIssue({ code: "custom", path: ["product_ids"], message: "product_ids must not contain empty IDs" });
-            }
-            if (new Set(value.product_ids).size !== value.product_ids.length) {
-                ctx.addIssue({ code: "custom", path: ["product_ids"], message: "product_ids must be unique" });
-            }
-            if (value.losses.length < 2) {
-                ctx.addIssue({ code: "custom", path: ["losses"], message: "losses must contain at least two entries" });
-            }
-            if (new Set(value.losses).size !== value.losses.length) {
-                ctx.addIssue({ code: "custom", path: ["losses"], message: "losses must be unique" });
-            }
-            for (const required of ["feed_version_not_atomic", "pricing_version_not_atomic"] as const) {
-                if (!value.losses.includes(required)) {
-                    ctx.addIssue({ code: "custom", path: ["losses"], message: `losses must contain ${required}` });
-                }
-            }
-            if (value.source_adcp_version === "2.5" && !value.losses.includes("mutation_idempotency_not_guaranteed")) {
-                ctx.addIssue({ code: "custom", path: ["losses"], message: "AdCP 2.5 losses must contain mutation_idempotency_not_guaranteed" });
-            }
-        })]).optional(),
-    targeting_resolution: ProductDiscoveryTargetingResolutionSchema.optional(),
-    status: z.union([z.literal("completed"), z.literal("submitted")]).optional(),
-    task_id: z.string().min(1).optional(),
-    message: z.string().max(2000).optional(),
-    errors: z.array(ErrorSchema).optional(),
-    context: ContextObjectSchema.optional(),
-    ext: ExtensionObjectSchema.optional(),
-    replayed: z.literal(true).optional()
-}).passthrough()).superRefine((value, ctx) => {
-    const present = (field: string): boolean => Object.prototype.hasOwnProperty.call(value, field);
-    const requireNonEmptyArray = (field: "products" | "proposals"): void => {
-        if (!Array.isArray(value[field]) || value[field].length === 0) {
-            ctx.addIssue({ code: "custom", path: [field], message: `${field} must contain at least one entry` });
-        }
-    };
-    const forbid = (fields: readonly string[]): void => {
-        for (const field of fields) {
-            if (present(field)) ctx.addIssue({ code: "custom", path: [field], message: `${field} is forbidden for this outcome` });
-        }
-    };
-    forbid(["refinement_applied", "pagination", "unchanged", "wholesale_feed_version"]);
-    if (value.suggestions !== undefined && (value.suggestions.length === 0 || value.suggestions.some(suggestion => suggestion.length === 0))) {
-        ctx.addIssue({ code: "custom", path: ["suggestions"], message: "suggestions must contain non-empty strings" });
-    }
-    if (value.incomplete !== undefined && value.incomplete.length === 0) {
-        ctx.addIssue({ code: "custom", path: ["incomplete"], message: "incomplete must contain at least one entry" });
-    }
-    if (value.outcome === "proposed") {
-        requireNonEmptyArray("proposals");
-        requireNonEmptyArray("products");
-        forbid(["reason", "suggestions", "purchase_continuation", "task_id"]);
-    } else if (value.outcome === "products_available") {
-        requireNonEmptyArray("products");
-        if (!present("purchase_continuation")) {
-            ctx.addIssue({ code: "custom", path: ["purchase_continuation"], message: "purchase_continuation is required" });
-        }
-        forbid(["proposals", "reason", "suggestions", "task_id"]);
-        if (value.purchase_continuation?.kind === "listed_purchase") {
-            const ids = value.purchase_continuation.product_ids;
-            if (ids.length === 0 || ids.some(productId => productId.length === 0)) {
-                ctx.addIssue({ code: "custom", path: ["purchase_continuation", "product_ids"], message: "product_ids must contain non-empty IDs" });
-            }
-            if (new Set(ids).size !== ids.length) {
-                ctx.addIssue({ code: "custom", path: ["purchase_continuation", "product_ids"], message: "product_ids must be unique" });
-            }
-            const returnedIds = (value.products ?? []).map(product => product.product_id);
-            const returnedIdSet = new Set(returnedIds);
-            if (
-                returnedIds.length !== ids.length ||
-                returnedIdSet.size !== returnedIds.length ||
-                ids.some(productId => !returnedIdSet.has(productId))
-            ) {
-                ctx.addIssue({ code: "custom", path: ["purchase_continuation", "product_ids"], message: "listed product_ids must exactly match returned products" });
-            }
-            for (const [index, product] of (value.products ?? []).entries()) {
-                if (!Array.isArray(product.pricing_options) || product.pricing_options.length === 0) {
-                    ctx.addIssue({ code: "custom", path: ["products", index, "pricing_options"], message: "listed products require pricing_options" });
-                }
-            }
-            for (const [index, incomplete] of (value.incomplete ?? []).entries()) {
-                if (["products", "pricing", "wholesale_feed"].includes(incomplete.scope)) {
-                    ctx.addIssue({ code: "custom", path: ["incomplete", index, "scope"], message: "listed purchase cannot report incomplete product or pricing data" });
-                }
-            }
-        }
-    } else if (value.outcome === "rejected") {
-        if (!present("reason")) ctx.addIssue({ code: "custom", path: ["reason"], message: "reason is required" });
-        forbid(["proposals", "products", "incomplete", "purchase_continuation", "task_id"]);
-    }
-});
 
 export const RefineProposalsResponseSchema = z.union([z.object({
         adcp_version: z.string().optional(),

--- a/src/lib/types/tools.generated.ts
+++ b/src/lib/types/tools.generated.ts
@@ -190,6 +190,7 @@ import type {
   PurchaseType,
   ReachUnit,
   ReportingFrequency,
+  RequestProposalsResponse,
   Responsive,
   RestrictedAttribute,
   RightType,
@@ -241,7 +242,7 @@ import type {
   WebhookSecurityMethod,
 } from './core.generated';
 
-export type { AccountCurrencyMode, AccountReference, AccountScope, AccountStatus, ActionNotAllowedReason, ActionSource, AdCPProtocol, AdCPSpecialism, AdCPVersionEnvelope, AdvertiserIndustry, AgeDeterminationBasis, AgeVerificationMethod, AssessmentStatus, AssetContentType, AssetVariant, AttestationClaim, AttributionMethodology, AttributionModel, AudienceConstraints, AudienceEvidenceMethodology, AudienceResolutionMethod, AudienceSource, AudienceStatus, AudienceSubjectType, AudioChannelLayout, AudioDistributionType, AuthenticationScheme, AvailabilityStatus, AvailableMetric, BillingParty, BinaryVerdict, BrandAgentType, BrandReference, BrowserFamily, BusinessEntity, C2PAWatermarkAction, CanceledBy, CancellationPolicy, CanonicalFormatAgentPlacementAISurfaceSponsoredPlacement, CanonicalFormatBase, CanonicalFormatDAASTAudio, CanonicalFormatDisplayTag, CanonicalFormatHTML5Banner, CanonicalFormatHostedAudio, CanonicalFormatHostedVideo, CanonicalFormatImage, CanonicalFormatImageCarousel, CanonicalFormatNativeInFeed, CanonicalFormatResponsiveCreative, CanonicalFormatSponsoredPlacementRetailMediaCatalogDriven, CanonicalFormatVASTVideo, CanonicalMediaBuyActionMode, CanonicalMediaBuyActionName, CatalogAction, CatalogItemDeliveryMetrics, CatalogItemStatus, CatalogType, CloudStorageProtocol, CoBrandingRequirement, CollectionCadence, CollectionKind, CollectionRelationship, CollectionStatus, CompletionSource, ConsentBasis, ContentIDType, ContentRatingSystem, CountryFusedPostalCodeSystem, CreativeAction, CreativeAgentCapability, CreativeApprovalStatus, CreativeAsset, CreativeBrief, CreativeEventReasonCode, CreativeIdentifierType, CreativeQuality, CreativeSelectionStrategy, CreativeSortField, CreativeStatus, DAASTTrackingEvent, DAASTVersion, DayOfWeek, DelegationAuthority, DeliveryMetricAggregate, DeliveryMetrics, DeliveryStatus, DeliveryType, DemographicSystem, DerivativeType, DevicePlatform, DeviceType, DigitalSourceType, DimensionUnit, DisclosurePersistence, DisclosurePosition, DistanceUnit, DistributionIdentifierType, EmbeddedProvenanceMethod, ErrorCode, ErrorScope, EscalationSeverity, EventType, Exclusivity, ExtensionObject, FeatureCheckStatus, FeedFormat, FeedbackSource, Fixed, ForecastMethod, ForecastPoint, ForecastRangeUnit, ForecastableMetric, Format, FormatIDParameter, FormatReferenceStructuredObject, FrameRateType, FrequencyCapScope, GOPType, GenreTaxonomy, GeoDeliveryMetrics, GeographicTargetingLevel, GetProductsAsyncSubmitted, GovernanceDecision, GovernanceDomain, GovernanceMode, GovernancePhase, HTTPMethod, HistoryEntryType, ImageAsset, ImpairmentOfflineState, ImpairmentReasonCode, IndicatorType, InstallmentStatus, JavaScriptModuleType, KeywordDeliveryMetrics, LandingPageRequirement, LiftDimension, LogoSlot, MakegoodRemedy, MarkdownFlavor, MatchIDType, MatchType, MeasurementTerms, MediaBuyActionMode, MediaBuyHealth, MediaBuyStatus, MediaBuyValidAction, MediaChannel, MetricScope, MetricType, MetroAreaSystem, MoovAtomPosition, MultiSize, None, NotificationType, OfferingAvailabilityStatus, OutcomeType, Pacing, PackageUpdate, PaymentTerms, PerformanceBaseline, PerformanceStandardMetric, PlatformExtensionReference, PolicyCategory, PolicyEnforcementLevel, PostalCodeSystem, PostalCountrySystem, PreviewOutputFormat, PriceAdjustmentKind, PricingModel, PricingStructure, ProductionQuality, PropertyIdentifierTypes, PropertyType, ProposalDeclineReason, ProposalRefinementReason, ProposalStatus, ProtocolEnvelope, Provenance, PublisherIdentifierTypes, PublisherPropertySelector, PurchaseType, ReachUnit, ReportingFrequency, Responsive, RestrictedAttribute, RightType, RightUse, RightsBillingPeriod, RightsConstraint, SISessionStatus, ScanType, ScopedCreativeApproval, SignalAvailabilityType, SignalDefinitionEnrichment, SignalSource, SignalTargetingExpression, SignalValueType, SizeModeMutex, SnapshotUnavailableReason, SocialPlacementSurface, SortDirection, SortMetric, SpecialCategory, SponsoredPlacementType, TMPResponseType, TalentRole, TargetingOverlayRequirements, TargetingOverlaySupport, TaskStatus, TaskType, TransportMode, TravelTimeUnit, UIDType, URLAssetType, UniversalMacro, UpdateFrequency, VASTTrackingEvent, VASTVersion, ValidationMode, VideoPlacementType, ViewabilityStandard, WCAGLevel, WarningAffectedResource, WarningCode, WatermarkMediaType, WebhookResponseType, WebhookSecurityMethod } from './core.generated';
+export type { AccountCurrencyMode, AccountReference, AccountScope, AccountStatus, ActionNotAllowedReason, ActionSource, AdCPProtocol, AdCPSpecialism, AdCPVersionEnvelope, AdvertiserIndustry, AgeDeterminationBasis, AgeVerificationMethod, AssessmentStatus, AssetContentType, AssetVariant, AttestationClaim, AttributionMethodology, AttributionModel, AudienceConstraints, AudienceEvidenceMethodology, AudienceResolutionMethod, AudienceSource, AudienceStatus, AudienceSubjectType, AudioChannelLayout, AudioDistributionType, AuthenticationScheme, AvailabilityStatus, AvailableMetric, BillingParty, BinaryVerdict, BrandAgentType, BrandReference, BrowserFamily, BusinessEntity, C2PAWatermarkAction, CanceledBy, CancellationPolicy, CanonicalFormatAgentPlacementAISurfaceSponsoredPlacement, CanonicalFormatBase, CanonicalFormatDAASTAudio, CanonicalFormatDisplayTag, CanonicalFormatHTML5Banner, CanonicalFormatHostedAudio, CanonicalFormatHostedVideo, CanonicalFormatImage, CanonicalFormatImageCarousel, CanonicalFormatNativeInFeed, CanonicalFormatResponsiveCreative, CanonicalFormatSponsoredPlacementRetailMediaCatalogDriven, CanonicalFormatVASTVideo, CanonicalMediaBuyActionMode, CanonicalMediaBuyActionName, CatalogAction, CatalogItemDeliveryMetrics, CatalogItemStatus, CatalogType, CloudStorageProtocol, CoBrandingRequirement, CollectionCadence, CollectionKind, CollectionRelationship, CollectionStatus, CompletionSource, ConsentBasis, ContentIDType, ContentRatingSystem, CountryFusedPostalCodeSystem, CreativeAction, CreativeAgentCapability, CreativeApprovalStatus, CreativeAsset, CreativeBrief, CreativeEventReasonCode, CreativeIdentifierType, CreativeQuality, CreativeSelectionStrategy, CreativeSortField, CreativeStatus, DAASTTrackingEvent, DAASTVersion, DayOfWeek, DelegationAuthority, DeliveryMetricAggregate, DeliveryMetrics, DeliveryStatus, DeliveryType, DemographicSystem, DerivativeType, DevicePlatform, DeviceType, DigitalSourceType, DimensionUnit, DisclosurePersistence, DisclosurePosition, DistanceUnit, DistributionIdentifierType, EmbeddedProvenanceMethod, ErrorCode, ErrorScope, EscalationSeverity, EventType, Exclusivity, ExtensionObject, FeatureCheckStatus, FeedFormat, FeedbackSource, Fixed, ForecastMethod, ForecastPoint, ForecastRangeUnit, ForecastableMetric, Format, FormatIDParameter, FormatReferenceStructuredObject, FrameRateType, FrequencyCapScope, GOPType, GenreTaxonomy, GeoDeliveryMetrics, GeographicTargetingLevel, GetProductsAsyncSubmitted, GovernanceDecision, GovernanceDomain, GovernanceMode, GovernancePhase, HTTPMethod, HistoryEntryType, ImageAsset, ImpairmentOfflineState, ImpairmentReasonCode, IndicatorType, InstallmentStatus, JavaScriptModuleType, KeywordDeliveryMetrics, LandingPageRequirement, LiftDimension, LogoSlot, MakegoodRemedy, MarkdownFlavor, MatchIDType, MatchType, MeasurementTerms, MediaBuyActionMode, MediaBuyHealth, MediaBuyStatus, MediaBuyValidAction, MediaChannel, MetricScope, MetricType, MetroAreaSystem, MoovAtomPosition, MultiSize, None, NotificationType, OfferingAvailabilityStatus, OutcomeType, Pacing, PackageUpdate, PaymentTerms, PerformanceBaseline, PerformanceStandardMetric, PlatformExtensionReference, PolicyCategory, PolicyEnforcementLevel, PostalCodeSystem, PostalCountrySystem, PreviewOutputFormat, PriceAdjustmentKind, PricingModel, PricingStructure, ProductionQuality, PropertyIdentifierTypes, PropertyType, ProposalDeclineReason, ProposalRefinementReason, ProposalStatus, ProtocolEnvelope, Provenance, PublisherIdentifierTypes, PublisherPropertySelector, PurchaseType, ReachUnit, ReportingFrequency, RequestProposalsResponse, Responsive, RestrictedAttribute, RightType, RightUse, RightsBillingPeriod, RightsConstraint, SISessionStatus, ScanType, ScopedCreativeApproval, SignalAvailabilityType, SignalDefinitionEnrichment, SignalSource, SignalTargetingExpression, SignalValueType, SizeModeMutex, SnapshotUnavailableReason, SocialPlacementSurface, SortDirection, SortMetric, SpecialCategory, SponsoredPlacementType, TMPResponseType, TalentRole, TargetingOverlayRequirements, TargetingOverlaySupport, TaskStatus, TaskType, TransportMode, TravelTimeUnit, UIDType, URLAssetType, UniversalMacro, UpdateFrequency, VASTTrackingEvent, VASTVersion, ValidationMode, VideoPlacementType, ViewabilityStandard, WCAGLevel, WarningAffectedResource, WarningCode, WatermarkMediaType, WebhookResponseType, WebhookSecurityMethod } from './core.generated';
 
 // Tool Parameter and Response Types
 // Generated from official AdCP schemas
@@ -9101,117 +9102,6 @@ export interface RequestProposalsRequest {
   };
 }
 /**
- * One or more immutable draft media-plan proposals and compact canonical products referenced by their purchases. Products always carry product_id and name and never carry legacy named-format identifiers. During the AdCP 3.x compatibility window, an SDK projecting a valid products-only get_products brief result may instead return the deprecated products_available outcome with an explicit purchase continuation. Native 3.2 sellers MUST NOT use that compatibility outcome, and adapters MUST NOT fabricate a proposal, terms digest, or feed version.
- */
-export type RequestProposalsResponse = (
-  | {
-      outcome: 'proposed';
-      status?: 'completed';
-    }
-  | {
-      outcome: 'products_available';
-      status?: 'completed';
-    }
-  | {
-      outcome: 'rejected';
-      status?: 'completed';
-    }
-  | CompactTaskSubmitted
-) & {
-  /**
-   * Release-precision AdCP version (VERSION.RELEASE, e.g. "3.0", "3.1", "3.1-beta"). On a request: the buyer's release pin — the seller validates against its supported_versions and returns VERSION_UNSUPPORTED on cross-major mismatch, or downshifts to the highest supported release within the same major. On a response: the release the seller actually served — clients SHOULD validate the response against that release's schema, not against their pin. Patches are not negotiated; surface them as build_version on capabilities for operational visibility. When omitted, falls back to adcp_major_version (deprecated) or server default. Buyers SHOULD emit both adcp_version and adcp_major_version through 3.x to remain compatible with sellers that only read the legacy field. NORMALIZATION: SDKs that read full-semver values from bundle metadata (e.g. ComplianceIndex.published_version = "3.1.0-beta.1") MUST normalize to release-precision ("3.1-beta.1") before emitting on the wire — meta-field values are NOT valid wire values.
-   */
-  adcp_version?: string;
-  outcome?: 'proposed' | 'products_available' | 'rejected';
-  /**
-   * @minLength 1
-   */
-  reason?: string;
-  suggestions?: string[];
-  proposals?: (CanonicalProposal & {
-    proposal_status: 'draft';
-    /**
-     * @format date-time
-     */
-    expires_at: string;
-  })[];
-  products?: CanonicalProduct[];
-  /**
-   * Usable partial discovery result retained from the established get_products response. Absence means the source response did not declare an incomplete scope; it does not authorize an adapter to infer missing proposal terms.
-   */
-  incomplete?: {
-    scope: 'products' | 'pricing' | 'forecast' | 'proposals' | 'wholesale_feed';
-    /**
-     * @minLength 1
-     */
-    description: string;
-    estimated_wait?: Duration;
-  }[];
-  /**
-   * @deprecated
-   * Deprecated AdCP 3.x projection instruction for purchasing products returned without a proposal. This is coordinator state, not a claim that the established seller implements a compact task. A native 3.2 seller MUST NOT emit it.
-   */
-  purchase_continuation?:
-    | {
-        kind: 'listed_purchase';
-        /**
-         * Exact products the coordinator promoted and re-read through account-scoped list_products before returning this result. The set MUST match products[].product_id.
-         */
-        product_ids: string[];
-        cache_scope: 'account';
-        /**
-         * Real seller-issued account-scoped feed fence obtained by re-reading the promoted products through list_products.
-         * @minLength 1
-         */
-        feed_version: string;
-        /**
-         * Real seller-issued pricing fence from the same account-scoped list_products response, when the seller versions pricing independently.
-         * @minLength 1
-         */
-        pricing_version?: string;
-      }
-    | {
-        kind: 'legacy_create';
-        /**
-         * Opaque, short-lived coordinator token bound to the caller principal, account, and complete observed product/pricing payload. It is not a seller-issued feed fence.
-         * @minLength 16
-         */
-        continuation_token: string;
-        /**
-         * Absolute expiry of the single-use compatibility continuation.
-         * @format date-time
-         */
-        continuation_expires_at: string;
-        /**
-         * Established AdCP version actually negotiated with the peer. This provenance is required; the coordinator MUST NOT infer stronger guarantees from the label.
-         */
-        source_adcp_version: '2.5' | '3.0' | '3.1';
-        /**
-         * Exact products bound to this continuation. A follow-up MUST select a non-empty subset and MUST NOT substitute an ID from another discovery result.
-         */
-        product_ids: string[];
-        /**
-         * Guarantees that the established create_media_buy continuation cannot provide. The coordinator MUST fail before mutation unless the caller explicitly accepts every listed loss.
-         */
-        losses: ('feed_version_not_atomic' | 'pricing_version_not_atomic' | 'mutation_idempotency_not_guaranteed')[];
-        requires_explicit_acceptance: true;
-      };
-  targeting_resolution?: ProductDiscoveryTargetingResolution;
-  status?: 'completed' | 'submitted';
-  /**
-   * @minLength 1
-   */
-  task_id?: string;
-  /**
-   * @maxLength 2000
-   */
-  message?: string;
-  errors?: Error[];
-  context?: ContextObject;
-  ext?: ExtensionObject;
-  replayed?: true;
-};
-/**
  * Compact immutable proposal for the AdCP 3.2 lifecycle. commercial_terms is the sole authoritative commercial envelope; narrative fields do not duplicate legacy allocation or creative graphs.
  */
 export type CanonicalProposal = {
@@ -9390,17 +9280,6 @@ export type CanonicalReportingCommitment =
       effective_at?: string;
     };
 /**
- * Bounded submitted envelope shared by the compact lifecycle tools.
- */
-export interface CompactTaskSubmitted {
-  status: 'submitted';
-  task_id: string;
-  message?: string;
-  errors?: Error[];
-  context?: ContextObject;
-  ext?: ExtensionObject;
-}
-/**
  * Complete typed commercial envelope for a compact-lifecycle proposal. This is the authoritative audit and refinement snapshot; allocations and narrative fields are explanatory views rather than substitutes for these terms.
  */
 export interface CommercialTerms {
@@ -9563,6 +9442,8 @@ export interface CanonicalMetricQualifier {
   attribution_window?: Duration;
   lift_dimension?: LiftDimension;
 }
+
+// refine_proposals parameters
 /**
  * Fork an immutable proposal or finalize a draft into a held committed snapshot. Revising with structured criteria, typed boundaries, product changes, requested alternatives, and/or a semantic ask creates one or more new drafts; finalizing changes no terms. Refining an accepted proposal creates a draft amendment or cancellation proposal against its MediaBuy; the source remains accepted and unchanged.
  */
@@ -10027,11 +9908,6 @@ export type DeclineProposalsResponse =
             outcome: 'unable';
           }
       )[];
-      status?: 'submitted';
-      /**
-       * @minLength 1
-       */
-      task_id?: string;
       /**
        * @maxLength 2000
        */

--- a/src/type-tests/media-buy-lifecycle-compatibility.type-test.ts
+++ b/src/type-tests/media-buy-lifecycle-compatibility.type-test.ts
@@ -5,7 +5,21 @@ import type {
   CompatibleRequestProposalsResponse,
   EstablishedProductsWireResponse,
   MediaBuyLifecycleCoordinator,
+  RequestProposalsResponse,
 } from '../lib';
+
+type ProductsAvailableResponse = Extract<RequestProposalsResponse, { outcome: 'products_available' }>;
+type RequestContinuation = RequestProposalsResponse['purchase_continuation'];
+type IsNonEmpty<T> = T extends readonly [unknown, ...unknown[]] ? true : false;
+declare const productsAvailableResponse: ProductsAvailableResponse;
+const projectedProductId: string = productsAvailableResponse.products[0]!.product_id;
+const continuationKind: 'listed_purchase' | 'legacy_create' = productsAvailableResponse.purchase_continuation.kind;
+const productsStayNonEmpty: IsNonEmpty<ProductsAvailableResponse['products']> = true;
+declare const requestContinuation: RequestContinuation;
+void projectedProductId;
+void continuationKind;
+void productsStayNonEmpty;
+void requestContinuation;
 
 declare const products: CompatibleProductsResponse;
 const productId: string | undefined = products.products?.[0]?.product_id;
@@ -23,6 +37,12 @@ const requestedProposalId: string | undefined = requested.proposals?.[0]?.propos
 void requestOutcome;
 void requestedProposalId;
 void requested.raw.context;
+if (requested.outcome === 'products_available') {
+  const continuation = requested.purchase_continuation;
+  const firstProjectedProductId: string = requested.products[0]!.product_id;
+  void continuation;
+  void firstProjectedProductId;
+}
 
 declare const refined: CompatibleRefineProposalsResponse;
 for (const result of refined.results ?? []) {

--- a/test/lib/agent-client-request-proposals.test.js
+++ b/test/lib/agent-client-request-proposals.test.js
@@ -1,7 +1,7 @@
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
 
-const { AgentClient } = require('../../dist/lib/index.js');
+const { AgentClient, SingleAgentClient } = require('../../dist/lib/index.js');
 
 test('AgentClient rejects projection-only products_available from native request_proposals', async () => {
   const agent = new AgentClient(
@@ -41,4 +41,193 @@ test('AgentClient rejects projection-only products_available from native request
     }),
     /projection-only products_available/
   );
+  await assert.rejects(
+    agent.executeTask('request_proposals', {
+      idempotency_key: 'native-proposals-generic-guard-0001',
+      account: { account_id: 'account-1' },
+      brand: { domain: 'example.com' },
+      brief: 'Native proposals through generic dispatch',
+    }),
+    /projection-only products_available/
+  );
+});
+
+function projectionOnlyCompletion(status = 'completed') {
+  return {
+    success: true,
+    status,
+    data: {
+      outcome: 'products_available',
+      products: [{ product_id: 'p1' }],
+      purchase_continuation: { kind: 'listed_purchase', product_ids: ['p1'] },
+    },
+    metadata: {
+      taskId: 'proposal-task',
+      taskName: 'request_proposals',
+      agent: { id: 'native-compact-seller', name: 'Native compact seller', protocol: 'mcp' },
+      responseTimeMs: 1,
+      timestamp: new Date().toISOString(),
+      clarificationRounds: 0,
+      status,
+    },
+  };
+}
+
+function nativeAgent() {
+  return new AgentClient(
+    {
+      id: 'native-compact-seller',
+      name: 'Native compact seller',
+      agent_uri: 'https://seller.example/mcp',
+      protocol: 'mcp',
+    },
+    { validateFeatures: false }
+  );
+}
+
+const request = {
+  idempotency_key: 'native-proposals-guard-async-0001',
+  account: { account_id: 'account-1' },
+  brand: { domain: 'example.com' },
+  brief: 'Native proposals only',
+};
+
+test('AgentClient rejects projection-only products_available from submitted request_proposals completions', async () => {
+  const agent = nativeAgent();
+  agent.client.executeTask = async () => ({
+    success: true,
+    status: 'submitted',
+    metadata: { ...projectionOnlyCompletion('submitted').metadata, status: 'submitted' },
+    submitted: {
+      taskId: 'seller-proposal-task',
+      track: async () => ({
+        taskId: 'seller-proposal-task',
+        status: 'completed',
+        taskType: 'request_proposals',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        result: projectionOnlyCompletion().data,
+      }),
+      waitForCompletion: async () => projectionOnlyCompletion(),
+    },
+  });
+
+  const pending = await agent.requestProposals(request);
+  await assert.rejects(pending.submitted.track(), /projection-only products_available/);
+  await assert.rejects(pending.submitted.waitForCompletion(0), /projection-only products_available/);
+});
+
+test('AgentClient rejects projection-only products_available from deferred request_proposals completions', async () => {
+  const agent = nativeAgent();
+  agent.client.executeTask = async () => ({
+    success: true,
+    status: 'deferred',
+    metadata: { ...projectionOnlyCompletion('deferred').metadata, status: 'deferred' },
+    deferred: {
+      token: 'resume-proposal-task',
+      resume: async () => projectionOnlyCompletion(),
+    },
+  });
+
+  const deferred = await agent.requestProposals(request);
+  await assert.rejects(deferred.deferred.resume({ approved: true }), /projection-only products_available/);
+});
+
+function projectionOnlyTask() {
+  return {
+    taskId: 'seller-proposal-task',
+    status: 'completed',
+    taskType: 'request_proposals',
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    result: projectionOnlyCompletion().data,
+  };
+}
+
+test('AgentClient rejects projection-only request_proposals task reads and events', async () => {
+  const agent = nativeAgent();
+  agent.client.listTasks = async () => [projectionOnlyTask()];
+  agent.client.getTaskInfo = async () => projectionOnlyTask();
+
+  await assert.rejects(agent.listTasks(), /projection-only products_available/);
+  await assert.rejects(agent.getTaskInfo('seller-proposal-task'), /projection-only products_available/);
+  agent.client.getActiveTasks = () => [
+    { ...projectionOnlyTask(), taskName: 'request_proposals', agent: { id: agent.agent.id } },
+  ];
+  assert.throws(() => agent.getActiveTasks(), /projection-only products_available/);
+
+  let updateListener;
+  agent.client.onTaskUpdate = listener => {
+    updateListener = listener;
+    return () => {};
+  };
+  agent.onTaskUpdate(() => assert.fail('projection-only update reached caller'));
+  assert.throws(() => updateListener(projectionOnlyTask()), /projection-only products_available/);
+
+  let eventListeners;
+  agent.client.onTaskEvents = listeners => {
+    eventListeners = listeners;
+    return () => {};
+  };
+  agent.onTaskEvents({ onTaskCompleted: () => assert.fail('projection-only event reached caller') });
+  assert.throws(() => eventListeners.onTaskCompleted(projectionOnlyTask()), /projection-only products_available/);
+});
+
+test('AgentClient rejects projection-only request_proposals webhook completions before handlers', async () => {
+  let handlerCalled = false;
+  let externalStatusObserved = false;
+  const agent = new AgentClient(
+    {
+      id: 'native-compact-seller',
+      name: 'Native compact seller',
+      agent_uri: 'https://seller.example/mcp',
+      protocol: 'mcp',
+    },
+    {
+      allowUnauthenticatedWebhooks: true,
+      validateFeatures: false,
+      handlers: { onTaskStatusChange: () => (handlerCalled = true) },
+    }
+  );
+  agent.client.executor.observeExternalTaskStatus = () => {
+    externalStatusObserved = true;
+  };
+  const payload = {
+    idempotency_key: 'proposal-webhook-event-0001',
+    operation_id: 'proposal-operation',
+    task_id: 'seller-proposal-task',
+    task_type: 'request_proposals',
+    status: 'completed',
+    timestamp: '2026-08-21T12:00:00.000Z',
+    result: projectionOnlyCompletion().data,
+  };
+
+  await assert.rejects(
+    agent.handleWebhook(payload, 'request_proposals', 'proposal-operation'),
+    /projection-only products_available/
+  );
+  assert.equal(handlerCalled, false);
+  assert.equal(externalStatusObserved, false);
+});
+
+test('SingleAgentClient generic execution and task lists enforce the native request_proposals guard', async () => {
+  const client = new SingleAgentClient(
+    {
+      id: 'native-compact-seller',
+      name: 'Native compact seller',
+      agent_uri: 'https://seller.example/mcp',
+      protocol: 'mcp',
+    },
+    { validateFeatures: false }
+  );
+  client.executeTaskUnprojected = async () => projectionOnlyCompletion();
+  await assert.rejects(client.executeTask('request_proposals', request), /projection-only products_available/);
+
+  client.executor.getTaskList = async () => [projectionOnlyTask()];
+  await assert.rejects(client.listTasks(), /projection-only products_available/);
+
+  client.executor.getActiveTasks = () => [
+    { ...projectionOnlyTask(), taskName: 'request_proposals', agent: { id: 'native-compact-seller' } },
+  ];
+  assert.throws(() => client.getActiveTasks(), /projection-only products_available/);
 });

--- a/test/lib/codegen-aliases-drift.test.js
+++ b/test/lib/codegen-aliases-drift.test.js
@@ -62,6 +62,6 @@ describe('Codegen drift guard: numbered Foo1 exports must be aliased', () => {
     const src = readFileSync(CORE_GENERATED_PATH, 'utf8');
 
     assert.doesNotMatch(src, /export type TaskStatus2\b/);
-    assert.match(src, /outcome: 'rejected';\n\s+status\?: 'completed';/);
+    assert.match(src, /outcome: 'rejected';[\s\S]{0,1200}?status\?: 'completed';/);
   });
 });

--- a/test/lib/media-buy-lifecycle-coordinator.test.js
+++ b/test/lib/media-buy-lifecycle-coordinator.test.js
@@ -168,9 +168,28 @@ function deferred(taskName, resume) {
 function clientWithCaps(caps, adcpVersion) {
   const agent = new AgentClient(AGENT, { validateFeatures: false, ...(adcpVersion && { adcpVersion }) });
   agent.getCapabilities = async () => caps;
+  const negotiate = agent.negotiateMediaBuyLifecycle.bind(agent);
+  agent.negotiateMediaBuyLifecycle = options =>
+    negotiate({ legacyPurchaseSellerSessionScope: 'test-authenticated-seller-session', ...options });
   agent.createMediaBuyLegacyWithPreDispatch = async (params, beforeDispatch, inputHandler, options) => {
-    const decision = await beforeDispatch(params, { governanceAdjusted: false });
-    return decision.action === 'return' ? decision.result : agent.createMediaBuyLegacy(params, inputHandler, options);
+    const decision = await beforeDispatch(params, {
+      governanceAdjusted: false,
+      publishSettledTaskStatus: (status, data, error) => {
+        agent.lastSettledTaskStatus = { status, data, error };
+      },
+      registerExternalTaskSettlement: handler => {
+        agent.externalTaskSettlementHandler = handler;
+      },
+    });
+    if (decision.action === 'return') return decision.result;
+    let result;
+    try {
+      result = await agent.createMediaBuyLegacy(params, inputHandler, options);
+    } catch (error) {
+      if (decision.onError) return decision.onError(error);
+      throw error;
+    }
+    return decision.onResult ? decision.onResult(result) : result;
   };
   return agent;
 }
@@ -4164,6 +4183,7 @@ describe('legacy products-only purchase continuations', () => {
     otherSeller.createMediaBuyLegacy = async () => assert.fail('seller binding must fail before mutation');
     const otherCoordinator = await otherSeller.negotiateMediaBuyLifecycle({
       principalScope: 'buyer-bound',
+      legacyPurchaseSellerSessionScope: 'test-authenticated-seller-session',
       legacyPurchaseContinuationStore: store,
     });
     const third = await discover('request-proposals-bound-0003');
@@ -4385,6 +4405,111 @@ describe('legacy products-only purchase continuations', () => {
     assert.equal(replay.status, 'completed');
     assert.equal(replay.data.media_buy_id, 'buy-submitted');
   });
+
+  for (const initialStatus of ['submitted', 'working']) {
+    test(`durably settles an authoritative ${initialStatus} legacy purchase ${
+      initialStatus === 'working' ? 'poll' : 'push'
+    }`, async () => {
+      const suffix = `push-${initialStatus}`;
+      const sellerTaskId = `${suffix}-seller-task`;
+      const agent = clientWithCaps(capabilities({ version: '3.0' }), '3.0');
+      agent.getProducts = async () =>
+        completed('get_products', { products: [legacyListedProduct(`p-${suffix}`, `Push ${initialStatus}`)] });
+      agent.createMediaBuyLegacy = async () => {
+        if (initialStatus === 'submitted') {
+          const result = submitted(
+            'create_media_buy',
+            completed('create_media_buy', { media_buy_id: `${suffix}-background`, packages: [] })
+          );
+          result.submitted.taskId = sellerTaskId;
+          result.submitted.track = async () => ({
+            taskId: sellerTaskId,
+            status: 'completed',
+            taskType: 'create_media_buy',
+            createdAt: Date.now(),
+            updatedAt: Date.now(),
+            result: { media_buy_id: `${suffix}-background`, packages: [] },
+          });
+          return result;
+        }
+        return {
+          success: true,
+          status: 'working',
+          metadata: {
+            taskId: `${suffix}-runner-task`,
+            serverTaskId: sellerTaskId,
+            taskName: 'create_media_buy',
+            agent: { id: AGENT.id, name: AGENT.name, protocol: AGENT.protocol },
+            responseTimeMs: 1,
+            timestamp: new Date().toISOString(),
+            clarificationRounds: 0,
+            status: 'working',
+          },
+        };
+      };
+      let polledTransport;
+      agent.getTaskStatus = async (_taskId, transport) => {
+        polledTransport = transport;
+        return {
+          taskId: sellerTaskId,
+          status: 'completed',
+          taskType: 'create_media_buy',
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+          result: { media_buy_id: `${suffix}-settled`, packages: [] },
+        };
+      };
+      const coordinator = await agent.negotiateMediaBuyLifecycle({ principalScope: `buyer-${suffix}` });
+      const discovery = await coordinator.requestProposals({
+        idempotency_key: `request-proposals-${suffix}-0001`,
+        account: { account_id: `account-${suffix}` },
+        brand: { domain: 'example.com' },
+        brief: `Push ${initialStatus} purchase`,
+      });
+      const input = {
+        idempotency_key:
+          initialStatus === 'submitted'
+            ? '933d750a-04e0-4ffd-b7e8-dd31a0a20fb0'
+            : 'b54970d2-fcfd-48b4-9cff-e55821ae6cb7',
+        continuation_token: discovery.data.purchase_continuation.continuation_token,
+        account: { account_id: `account-${suffix}` },
+        selected_product_ids: [`p-${suffix}`],
+        accepted_losses: discovery.data.purchase_continuation.losses,
+        legacy_create_request: {
+          idempotency_key: `legacy-create-${suffix}-0001`,
+          account: { account_id: `account-${suffix}` },
+          brand: { domain: 'example.com' },
+          packages: [{ product_id: `p-${suffix}`, budget: 10, pricing_option_id: 'fixed-cpm' }],
+          start_time: '2099-01-01T00:00:00Z',
+          end_time: '2099-02-01T00:00:00Z',
+        },
+      };
+
+      const settlementTransport = { maxResponseBytes: 12345 };
+      const pending = await coordinator.continueLegacyPurchase(input, undefined, { transport: settlementTransport });
+      assert.equal(pending.status, initialStatus);
+      assert.equal(typeof agent.externalTaskSettlementHandler, 'function');
+      if (initialStatus === 'working') {
+        await new Promise(resolve => setTimeout(resolve, 5));
+        const replay = await coordinator.continueLegacyPurchase(input);
+        assert.equal(replay.status, 'completed');
+        assert.equal(replay.data.media_buy_id, `${suffix}-settled`);
+        assert.equal(polledTransport, settlementTransport);
+        return;
+      }
+      const settled = await agent.externalTaskSettlementHandler({
+        status: 'completed',
+        result: { media_buy_id: `${suffix}-settled`, packages: [] },
+        serverTaskId: sellerTaskId,
+        taskType: 'create_media_buy',
+      });
+      assert.equal(settled.status, 'completed');
+      assert.equal(settled.data.media_buy_id, `${suffix}-settled`);
+      const replay = await coordinator.continueLegacyPurchase(input);
+      assert.equal(replay.status, 'completed');
+      assert.equal(replay.data.media_buy_id, `${suffix}-settled`);
+    });
+  }
 
   test('shares one seller polling loop between the background observer and callers', async () => {
     const agent = clientWithCaps(capabilities({ version: '3.0' }), '3.0');
@@ -5108,6 +5233,240 @@ describe('legacy products-only purchase continuations', () => {
     assert.equal((await store.create(continuation('retry-token', 'retry-issuance'))).outcome, 'created');
     assert.equal((await store.claim('retry-token', { claim, expected: binding })).outcome, 'conflict');
     assert.equal((await store.get('ambiguous-token')).operation.state, 'ambiguous');
+  });
+
+  test('declares missing seller replay guarantees for 3.0 and 3.1 continuations', async () => {
+    for (const version of ['3.0', '3.1']) {
+      const caps = capabilities({ version });
+      delete caps.idempotency;
+      const agent = clientWithCaps(caps, version);
+      agent.getProducts = async () =>
+        completed('get_products', { products: [legacyListedProduct(`p-no-replay-${version}`, 'No replay')] });
+      const coordinator = await agent.negotiateMediaBuyLifecycle({ principalScope: `buyer-no-replay-${version}` });
+      const discovery = await coordinator.requestProposals({
+        idempotency_key: `request-proposals-no-replay-${version}`,
+        account: { account_id: `account-no-replay-${version}` },
+        brand: { domain: 'example.com' },
+        brief: 'No replay guarantee',
+      });
+      assert.ok(discovery.data.purchase_continuation.losses.includes('mutation_idempotency_not_guaranteed'));
+    }
+  });
+
+  test('uses a caller-supplied restart-stable authenticated binding when 3.0 omits context ID', async () => {
+    const store = createInMemoryLegacyPurchaseContinuationStore();
+    const firstAgent = clientWithCaps(capabilities({ version: '3.0' }), '3.0');
+    firstAgent.getProducts = async () =>
+      completed('get_products', { products: [legacyListedProduct('p-restart-stable', 'Restart stable')] });
+    const first = await firstAgent.negotiateMediaBuyLifecycle({
+      principalScope: 'buyer-restart-stable',
+      legacyPurchaseSellerSessionScope: 'authenticated-session-restart-stable',
+      legacyPurchaseContinuationStore: store,
+    });
+    const discovery = await first.requestProposals({
+      idempotency_key: 'request-proposals-restart-stable-0001',
+      account: { account_id: 'account-restart-stable' },
+      brand: { domain: 'example.com' },
+      brief: 'Restart-safe continuation',
+    });
+
+    const rehydratedAgent = clientWithCaps(capabilities({ version: '3.0' }), '3.0');
+    rehydratedAgent.createMediaBuyLegacy = async () =>
+      completed('create_media_buy', { media_buy_id: 'buy-restart-stable', packages: [] });
+    const rehydrated = await rehydratedAgent.negotiateMediaBuyLifecycle({
+      principalScope: 'buyer-restart-stable',
+      legacyPurchaseSellerSessionScope: 'authenticated-session-restart-stable',
+      legacyPurchaseContinuationStore: store,
+    });
+    const continuationInput = {
+      idempotency_key: '6e94a193-0c76-461c-b048-85ca03349008',
+      continuation_token: discovery.data.purchase_continuation.continuation_token,
+      account: { account_id: 'account-restart-stable' },
+      selected_product_ids: ['p-restart-stable'],
+      accepted_losses: discovery.data.purchase_continuation.losses,
+      legacy_create_request: {
+        idempotency_key: 'legacy-restart-stable-create-0001',
+        account: { account_id: 'account-restart-stable' },
+        brand: { domain: 'example.com' },
+        packages: [{ product_id: 'p-restart-stable', budget: 10, pricing_option_id: 'fixed-cpm' }],
+        start_time: '2099-01-01T00:00:00Z',
+        end_time: '2099-02-01T00:00:00Z',
+      },
+    };
+    const wrongSession = await rehydratedAgent.negotiateMediaBuyLifecycle({
+      principalScope: 'buyer-restart-stable',
+      legacyPurchaseSellerSessionScope: 'different-authenticated-session',
+      legacyPurchaseContinuationStore: store,
+    });
+    await assert.rejects(
+      wrongSession.continueLegacyPurchase(continuationInput),
+      error => error.code === 'binding_mismatch'
+    );
+    const result = await rehydrated.continueLegacyPurchase(continuationInput);
+    assert.equal(result.data.media_buy_id, 'buy-restart-stable');
+  });
+
+  test('rejects URL credentials before a legacy products snapshot enters durable storage', async () => {
+    const credentialUrls = [
+      'https://username:password@assets.example/preview',
+      'https://assets.example/preview?api_key=secret',
+      'https://assets.example/preview?authorization=Bearer',
+      'https://assets.example/preview#access_token=secret',
+      '/preview?X-Amz-Signature=secret',
+    ];
+    for (const [index, previewUrl] of credentialUrls.entries()) {
+      const agent = clientWithCaps(capabilities({ version: '3.0' }), '3.0');
+      agent.getProducts = async () =>
+        completed('get_products', {
+          products: [
+            legacyListedProduct(`p-credential-url-${index}`, 'Credential URL', {
+              ext: { preview_url: previewUrl },
+            }),
+          ],
+        });
+      const coordinator = await agent.negotiateMediaBuyLifecycle({ principalScope: `buyer-credential-url-${index}` });
+      await assert.rejects(
+        coordinator.requestProposals({
+          idempotency_key: `request-proposals-credential-url-${index}`,
+          account: { account_id: `account-credential-url-${index}` },
+          brand: { domain: 'example.com' },
+          brief: 'Credential-bearing URL',
+        }),
+        error => error.code === 'request_invalid' && /credential-shaped material/.test(error.message)
+      );
+    }
+  });
+
+  test('allows multiple legacy packages to purchase the same selected product', async () => {
+    const agent = clientWithCaps(capabilities({ version: '3.0' }), '3.0');
+    agent.getProducts = async () =>
+      completed('get_products', { products: [legacyListedProduct('p-multi-package', 'Multi-package')] });
+    let dispatched;
+    agent.createMediaBuyLegacy = async request => {
+      dispatched = request;
+      return completed('create_media_buy', { media_buy_id: 'buy-multi-package', packages: [] });
+    };
+    const coordinator = await agent.negotiateMediaBuyLifecycle({ principalScope: 'buyer-multi-package' });
+    const discovery = await coordinator.requestProposals({
+      idempotency_key: 'request-proposals-multi-package-0001',
+      account: { account_id: 'account-multi-package' },
+      brand: { domain: 'example.com' },
+      brief: 'Two packages for one product',
+    });
+    const result = await coordinator.continueLegacyPurchase({
+      idempotency_key: '315501f1-72e8-4dc4-a436-288a3d64dfe6',
+      continuation_token: discovery.data.purchase_continuation.continuation_token,
+      account: { account_id: 'account-multi-package' },
+      selected_product_ids: ['p-multi-package'],
+      accepted_losses: discovery.data.purchase_continuation.losses,
+      legacy_create_request: {
+        idempotency_key: 'legacy-multi-package-create-0001',
+        account: { account_id: 'account-multi-package' },
+        brand: { domain: 'example.com' },
+        packages: [
+          { product_id: 'p-multi-package', budget: 10, pricing_option_id: 'fixed-cpm' },
+          { product_id: 'p-multi-package', budget: 20, pricing_option_id: 'fixed-cpm' },
+        ],
+        start_time: '2099-01-01T00:00:00Z',
+        end_time: '2099-02-01T00:00:00Z',
+      },
+    });
+    assert.equal(result.data.media_buy_id, 'buy-multi-package');
+    assert.equal(dispatched.packages.length, 2);
+  });
+
+  test('fences a submitted completion whose task ID differs from the recorded seller task', async () => {
+    const store = createInMemoryLegacyPurchaseContinuationStore();
+    const agent = clientWithCaps(capabilities({ version: '3.0' }), '3.0');
+    agent.getProducts = async () =>
+      completed('get_products', { products: [legacyListedProduct('p-task-mismatch', 'Task mismatch')] });
+    agent.createMediaBuyLegacy = async () => {
+      const result = submitted(
+        'create_media_buy',
+        completed('create_media_buy', { media_buy_id: 'wrong-task-buy', packages: [] })
+      );
+      result.submitted.track = async () => ({
+        taskId: 'different-seller-task',
+        status: 'completed',
+        taskType: 'create_media_buy',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        result: { media_buy_id: 'wrong-task-buy', packages: [] },
+      });
+      return result;
+    };
+    const coordinator = await agent.negotiateMediaBuyLifecycle({
+      principalScope: 'buyer-task-mismatch',
+      legacyPurchaseContinuationStore: store,
+    });
+    const discovery = await coordinator.requestProposals({
+      idempotency_key: 'request-proposals-task-mismatch-0001',
+      account: { account_id: 'account-task-mismatch' },
+      brand: { domain: 'example.com' },
+      brief: 'Task mismatch',
+    });
+    const token = discovery.data.purchase_continuation.continuation_token;
+    const pending = await coordinator.continueLegacyPurchase({
+      idempotency_key: '7681b778-c414-44d7-a21a-70108ec0be0c',
+      continuation_token: token,
+      account: { account_id: 'account-task-mismatch' },
+      selected_product_ids: ['p-task-mismatch'],
+      accepted_losses: discovery.data.purchase_continuation.losses,
+      legacy_create_request: {
+        idempotency_key: 'legacy-task-mismatch-create-0001',
+        account: { account_id: 'account-task-mismatch' },
+        brand: { domain: 'example.com' },
+        packages: [{ product_id: 'p-task-mismatch', budget: 10, pricing_option_id: 'fixed-cpm' }],
+        start_time: '2099-01-01T00:00:00Z',
+        end_time: '2099-02-01T00:00:00Z',
+      },
+    });
+    await assert.rejects(pending.submitted.waitForCompletion(0), /task ID does not match/);
+    assert.equal((await store.get(token)).operation.state, 'ambiguous');
+  });
+
+  test('treats an SDK-synthetic AdCP error as ambiguous rather than authoritative', async () => {
+    const store = createInMemoryLegacyPurchaseContinuationStore();
+    const agent = clientWithCaps(capabilities({ version: '3.0' }), '3.0');
+    agent.getProducts = async () =>
+      completed('get_products', { products: [legacyListedProduct('p-synthetic-error', 'Synthetic error')] });
+    agent.createMediaBuyLegacy = async () => ({
+      success: false,
+      status: 'failed',
+      error: 'raw seller text',
+      adcpError: { code: 'mcp_error', message: 'raw seller text', synthetic: true },
+      metadata: { ...completed('create_media_buy', {}).metadata, status: 'failed' },
+    });
+    const coordinator = await agent.negotiateMediaBuyLifecycle({
+      principalScope: 'buyer-synthetic-error',
+      legacyPurchaseContinuationStore: store,
+    });
+    const discovery = await coordinator.requestProposals({
+      idempotency_key: 'request-proposals-synthetic-error-0001',
+      account: { account_id: 'account-synthetic-error' },
+      brand: { domain: 'example.com' },
+      brief: 'Synthetic error',
+    });
+    const token = discovery.data.purchase_continuation.continuation_token;
+    await assert.rejects(
+      coordinator.continueLegacyPurchase({
+        idempotency_key: 'adce5540-b171-4272-b0e9-f2241dde4ea9',
+        continuation_token: token,
+        account: { account_id: 'account-synthetic-error' },
+        selected_product_ids: ['p-synthetic-error'],
+        accepted_losses: discovery.data.purchase_continuation.losses,
+        legacy_create_request: {
+          idempotency_key: 'legacy-synthetic-error-create-0001',
+          account: { account_id: 'account-synthetic-error' },
+          brand: { domain: 'example.com' },
+          packages: [{ product_id: 'p-synthetic-error', budget: 10, pricing_option_id: 'fixed-cpm' }],
+          start_time: '2099-01-01T00:00:00Z',
+          end_time: '2099-02-01T00:00:00Z',
+        },
+      }),
+      error => error.code === 'ambiguous'
+    );
+    assert.equal((await store.get(token)).operation.state, 'ambiguous');
   });
 });
 
@@ -8961,5 +9320,54 @@ describe('MediaBuyLifecycleCoordinator mutation boundaries', () => {
     );
     assert.equal(paused.compatibility.compatibility, 'lossless_projection');
     assert.equal(canceled.compatibility.compatibility, 'lossless_projection');
+  });
+
+  test('rejects media-buy cancellation combined with name on compact and established lifecycles', async () => {
+    for (const { version, tools } of [{ version: '3.0' }, { version: '3.2.0-beta.4', tools: COMPACT_TOOLS }]) {
+      const agent = clientWithCaps(capabilities({ version, tools }));
+      let mutations = 0;
+      agent.updateMediaBuy = async () => {
+        mutations += 1;
+        return completed('update_media_buy', {});
+      };
+      agent.controlMediaBuy = async () => {
+        mutations += 1;
+        return completed('control_media_buy', {});
+      };
+      const coordinator = await agent.negotiateMediaBuyLifecycle();
+
+      await assert.rejects(
+        coordinator.controlMediaBuy({
+          idempotency_key: `control-cancel-name-${version}-0001`,
+          account: { account_id: 'account-1' },
+          media_buy_id: 'mb-1',
+          revision: 1,
+          canceled: true,
+          name: 'must not be applied',
+        }),
+        /cancellation cannot be combined/
+      );
+      assert.equal(mutations, 0);
+    }
+  });
+
+  test('projects compact media-buy name changes through the 3.2 established surface', async () => {
+    const agent = clientWithCaps(capabilities({ tools: [...COMPACT_TOOLS, 'get_products', 'update_media_buy'] }));
+    const mutations = [];
+    agent.updateMediaBuy = async request => {
+      mutations.push(request);
+      return completed('update_media_buy', {});
+    };
+    const coordinator = await agent.negotiateMediaBuyLifecycle({ preferredLifecycle: 'established' });
+
+    await coordinator.controlMediaBuy({
+      idempotency_key: 'control-name-compat-key-0001',
+      account: { account_id: 'account-1' },
+      media_buy_id: 'mb-1',
+      revision: 3,
+      name: 'Renamed buy',
+    });
+    assert.equal(mutations.length, 1);
+    assert.equal(mutations[0].name, 'Renamed buy');
   });
 });

--- a/test/lib/task-executor-pre-dispatch-boundary.test.js
+++ b/test/lib/task-executor-pre-dispatch-boundary.test.js
@@ -427,7 +427,7 @@ describe('TaskExecutor pre-dispatch boundary', () => {
             result.submitted = {
               ...submitted,
               track: async transport => {
-                const task = await submitted.track(transport);
+                await submitted.track(transport);
                 assert.equal(observedStatuses.includes('completed'), false);
                 throw durableError;
               },

--- a/test/lib/task-executor-pre-dispatch-boundary.test.js
+++ b/test/lib/task-executor-pre-dispatch-boundary.test.js
@@ -1,7 +1,7 @@
 const { describe, test, afterEach, mock } = require('node:test');
 const assert = require('node:assert/strict');
 
-const { TaskExecutor, ProtocolClient } = require('../../dist/lib/index.js');
+const { SingleAgentClient, TaskExecutor, ProtocolClient } = require('../../dist/lib/index.js');
 
 const AGENT = {
   id: 'dispatch-boundary-seller',
@@ -92,7 +92,118 @@ describe('TaskExecutor pre-dispatch boundary', () => {
     assert.equal(ProtocolClient.callTool.mock.callCount(), 0);
   });
 
-  test('dispatches without the aborted caller signal when abort races a committed claim', async () => {
+  test('reserves durable settlement capacity before awaiting a concurrent claim hook', async () => {
+    ProtocolClient.callTool = mock.fn(async () => ({ status: 'completed', data: { ok: true } }));
+    const executor = new TaskExecutor({ strictSchemaValidation: false });
+    for (let index = 0; index < 9_999; index += 1) {
+      executor.deferredTerminalPublicationTaskIds.add(`protected-task-${index}`);
+    }
+    let releaseFirstClaim;
+    const firstClaimRelease = new Promise(resolve => {
+      releaseFirstClaim = resolve;
+    });
+    let markFirstClaimStarted;
+    const firstClaimStarted = new Promise(resolve => {
+      markFirstClaimStarted = resolve;
+    });
+    let hookCalls = 0;
+    const hook = async () => {
+      hookCalls += 1;
+      markFirstClaimStarted();
+      await firstClaimRelease;
+      return {
+        action: 'return',
+        result: {
+          success: true,
+          status: 'completed',
+          data: { media_buy_id: 'capacity-replay' },
+          metadata: {
+            taskId: 'capacity-replay-task',
+            taskName: 'create_media_buy',
+            agent: { id: AGENT.id, name: AGENT.name, protocol: AGENT.protocol },
+            responseTimeMs: 1,
+            timestamp: new Date().toISOString(),
+            clarificationRounds: 0,
+            status: 'completed',
+          },
+        },
+      };
+    };
+    const first = executor.executeTask(
+      AGENT,
+      'create_media_buy',
+      { idempotency_key: 'capacity-first' },
+      undefined,
+      {},
+      'v3',
+      undefined,
+      hook
+    );
+    await firstClaimStarted;
+
+    await assert.rejects(
+      executor.executeTask(
+        AGENT,
+        'create_media_buy',
+        { idempotency_key: 'capacity-second' },
+        undefined,
+        {},
+        'v3',
+        undefined,
+        hook
+      ),
+      error =>
+        error?.name === 'BeforeProtocolDispatchHookError' && /capacity is exhausted/i.test(error.original?.message)
+    );
+    assert.equal(hookCalls, 1);
+    releaseFirstClaim();
+    assert.equal((await first).status, 'completed');
+    assert.equal(executor.settlementCapacityReservations.size, 0);
+    assert.equal(ProtocolClient.callTool.mock.callCount(), 0);
+  });
+
+  test('expires unresolved durable settlement handlers from the capacity-accounted claim slot', async () => {
+    for (const invalidRetention of [0, -1, Number.NaN, Number.POSITIVE_INFINITY, 1.5]) {
+      assert.throws(
+        () => new TaskExecutor({ externalTaskSettlementRetentionMs: invalidRetention }),
+        /positive safe integer/
+      );
+    }
+    ProtocolClient.callTool = mock.fn(async () => ({ status: 'submitted', task_id: 'expiring-seller-task' }));
+    const executor = new TaskExecutor({
+      strictSchemaValidation: false,
+      externalTaskSettlementRetentionMs: 10,
+    });
+    const pending = await executor.executeTask(
+      AGENT,
+      'create_media_buy',
+      { idempotency_key: 'expiring-settlement-handler' },
+      undefined,
+      {},
+      'v3',
+      undefined,
+      async (_params, context) => ({
+        action: 'dispatch_committed',
+        onResult: async result => {
+          context.registerExternalTaskSettlement(async () => result);
+          return result;
+        },
+        onError: async error => {
+          throw error;
+        },
+      })
+    );
+
+    assert.equal(pending.status, 'submitted');
+    assert.equal(executor.deferredTerminalPublicationTaskIds.size, 1);
+    assert.equal(executor.externalTaskSettlementHandlers.size, 1);
+    await new Promise(resolve => setTimeout(resolve, 25));
+    assert.equal(executor.deferredTerminalPublicationTaskIds.size, 0);
+    assert.equal(executor.externalTaskSettlementHandlers.size, 0);
+    assert.equal(executor.externalTaskSettlementExpiry.size, 0);
+  });
+
+  test('fences a committed claim without dispatch when the caller deadline fires while claim is pending', async () => {
     let releaseClaim;
     const claimRelease = new Promise(resolve => {
       releaseClaim = resolve;
@@ -101,38 +212,957 @@ describe('TaskExecutor pre-dispatch boundary', () => {
     const claimStarted = new Promise(resolve => {
       markClaimStarted = resolve;
     });
-    let sellerDispatched;
-    const sellerDispatch = new Promise(resolve => {
-      sellerDispatched = resolve;
+    let markFenced;
+    const fenced = new Promise(resolve => {
+      markFenced = resolve;
     });
-    ProtocolClient.callTool = mock.fn(async (_agent, _taskName, _params, options) => {
-      assert.equal(options.signal, undefined);
-      sellerDispatched();
-      return { status: 'completed', data: { media_buy_id: 'buy-committed' } };
-    });
+    ProtocolClient.callTool = mock.fn(async () => ({ status: 'completed', data: {} }));
     const executor = new TaskExecutor({ strictSchemaValidation: false });
-    const controller = new AbortController();
-
+    const observedStatuses = [];
+    executor.onTaskUpdate(AGENT.id, task => observedStatuses.push(task.status));
     const execution = executor.executeTask(
       AGENT,
       'create_media_buy',
       { idempotency_key: 'claim-abort' },
       undefined,
-      { signal: controller.signal },
+      { timeout: 10 },
       'v3',
       undefined,
       async () => {
         markClaimStarted();
         await claimRelease;
+        return {
+          action: 'dispatch_committed',
+          onResult: async result => result,
+          onError: async error => {
+            assert.equal(
+              observedStatuses.some(status =>
+                ['completed', 'failed', 'rejected', 'canceled', 'aborted'].includes(status)
+              ),
+              false
+            );
+            markFenced(error);
+            throw error;
+          },
+        };
+      }
+    );
+    await claimStarted;
+    await assert.rejects(execution, error => error?.name === 'TaskTimeoutError');
+    releaseClaim();
+
+    const fenceError = await fenced;
+    assert.equal(fenceError.name, 'TaskTimeoutError');
+    assert.equal(ProtocolClient.callTool.mock.callCount(), 0);
+    await new Promise(resolve => setImmediate(resolve));
+    assert.equal(observedStatuses.includes('aborted'), false);
+    assert.equal(observedStatuses.at(-1), 'failed');
+  });
+
+  test('dispatches the request snapshot validated before an awaited durable claim', async () => {
+    let releaseClaim;
+    const claimRelease = new Promise(resolve => {
+      releaseClaim = resolve;
+    });
+    let markClaimStarted;
+    const claimStarted = new Promise(resolve => {
+      markClaimStarted = resolve;
+    });
+    let dispatchedParams;
+    ProtocolClient.callTool = mock.fn(async (_agent, _taskName, params) => {
+      dispatchedParams = params;
+      return { status: 'completed', data: { media_buy_id: 'buy-snapshot' } };
+    });
+    const executor = new TaskExecutor({ strictSchemaValidation: false });
+    const request = {
+      account: { account_id: 'account-original' },
+      brand: { domain: 'original.example' },
+      packages: [{ product_id: 'product-original', targeting: { geo_countries: ['US'] } }],
+    };
+
+    const execution = executor.executeTask(
+      AGENT,
+      'create_media_buy',
+      request,
+      undefined,
+      {},
+      'v3',
+      undefined,
+      async params => {
+        assert.equal(params.account.account_id, 'account-original');
+        markClaimStarted();
+        await claimRelease;
+        assert.equal(params.brand.domain, 'original.example');
+        assert.deepEqual(params.packages[0].targeting.geo_countries, ['US']);
         return { action: 'dispatch_committed' };
       }
     );
     await claimStarted;
-    controller.abort(new Error('abort while claim is pending'));
+    request.account.account_id = 'account-mutated';
+    request.brand.domain = 'mutated.example';
+    request.packages[0].targeting.geo_countries[0] = 'GB';
     releaseClaim();
 
-    await assert.rejects(execution, /abort while claim is pending/);
-    await sellerDispatch;
+    const result = await execution;
+    assert.equal(result.status, 'completed');
+    assert.equal(dispatchedParams.account.account_id, 'account-original');
+    assert.equal(dispatchedParams.brand.domain, 'original.example');
+    assert.deepEqual(dispatchedParams.packages[0].targeting.geo_countries, ['US']);
+  });
+
+  test('runs the committed error settlement exactly once when seller dispatch throws', async () => {
+    const transportError = new Error('seller transport failed after dispatch');
+    const durableError = new Error('durable outcome fenced');
+    ProtocolClient.callTool = mock.fn(async () => {
+      throw transportError;
+    });
+    const executor = new TaskExecutor({ strictSchemaValidation: false });
+    let errorSettlements = 0;
+    let resultSettlements = 0;
+
+    await assert.rejects(
+      executor.executeTask(
+        AGENT,
+        'create_media_buy',
+        { idempotency_key: 'post-dispatch-error' },
+        undefined,
+        {},
+        'v3',
+        undefined,
+        async () => ({
+          action: 'dispatch_committed',
+          onResult: async result => {
+            resultSettlements += 1;
+            return result;
+          },
+          onError: async error => {
+            errorSettlements += 1;
+            assert.equal(error, transportError);
+            throw durableError;
+          },
+        })
+      ),
+      error => error?.name === 'AfterProtocolDispatchHookError' && error.original === durableError
+    );
+
     assert.equal(ProtocolClient.callTool.mock.callCount(), 1);
+    assert.equal(errorSettlements, 1);
+    assert.equal(resultSettlements, 0);
+  });
+
+  test('publishes terminal completion only after durable result settlement succeeds', async () => {
+    const durableError = new Error('durable completion persistence failed');
+    ProtocolClient.callTool = mock.fn(async () => ({
+      status: 'completed',
+      data: { media_buy_id: 'seller-created-buy' },
+    }));
+    const executor = new TaskExecutor({ strictSchemaValidation: false });
+    const observedStatuses = [];
+    executor.onTaskUpdate(AGENT.id, task => observedStatuses.push(task.status));
+
+    await assert.rejects(
+      executor.executeTask(
+        AGENT,
+        'create_media_buy',
+        { idempotency_key: 'post-dispatch-settlement-order' },
+        undefined,
+        {},
+        'v3',
+        undefined,
+        async () => ({
+          action: 'dispatch_committed',
+          onResult: async () => {
+            assert.equal(observedStatuses.includes('completed'), false);
+            throw durableError;
+          },
+          onError: async error => {
+            throw error;
+          },
+        })
+      ),
+      error => error?.name === 'AfterProtocolDispatchHookError' && error.original === durableError
+    );
+
+    assert.equal(observedStatuses.includes('completed'), false);
+    assert.equal(observedStatuses.at(-1), 'failed');
+    const retained = executor.getActiveTasks();
+    assert.equal(retained[0].status, 'failed');
+    assert.equal(retained[0].params, undefined);
+  });
+
+  for (const observation of ['track', 'waitForCompletion']) {
+    test(`does not publish submitted ${observation} completion when durable persistence fails`, async () => {
+      const durableError = new Error(`durable ${observation} persistence failed`);
+      ProtocolClient.callTool = mock.fn(async (_agent, taskName) => {
+        if (taskName === 'tasks/get' || taskName === 'tasks_get') {
+          return {
+            task: {
+              taskId: 'seller-created-task',
+              status: 'completed',
+              taskType: 'create_media_buy',
+              createdAt: Date.now(),
+              updatedAt: Date.now(),
+              result: { media_buy_id: 'seller-created-buy' },
+            },
+          };
+        }
+        return { status: 'submitted', task_id: 'seller-created-task' };
+      });
+      const executor = new TaskExecutor({ strictSchemaValidation: false });
+      const observedStatuses = [];
+      executor.onTaskUpdate(AGENT.id, task => observedStatuses.push(task.status));
+
+      const pending = await executor.executeTask(
+        AGENT,
+        'create_media_buy',
+        { idempotency_key: `submitted-${observation}-settlement-order` },
+        undefined,
+        {},
+        'v3',
+        undefined,
+        async () => ({
+          action: 'dispatch_committed',
+          onResult: async result => {
+            const submitted = result.submitted;
+            result.submitted = {
+              ...submitted,
+              track: async transport => {
+                const task = await submitted.track(transport);
+                assert.equal(observedStatuses.includes('completed'), false);
+                throw durableError;
+              },
+              waitForCompletion: async (pollInterval, signal) => {
+                const completion = await submitted.waitForCompletion(pollInterval, signal);
+                assert.equal(completion.status, 'completed');
+                assert.equal(observedStatuses.includes('completed'), false);
+                throw durableError;
+              },
+            };
+            return result;
+          },
+          onError: async error => {
+            throw error;
+          },
+        })
+      );
+
+      await assert.rejects(
+        observation === 'track' ? pending.submitted.track() : pending.submitted.waitForCompletion(0),
+        error => error === durableError
+      );
+      assert.equal(observedStatuses.includes('completed'), false);
+      assert.equal(executor.getActiveTasks()[0].status, 'submitted');
+    });
+  }
+
+  test('closes durable webhook settlement after polling completes first', async () => {
+    ProtocolClient.callTool = mock.fn(async (_agent, taskName) => {
+      if (taskName === 'tasks/get' || taskName === 'tasks_get') {
+        return {
+          task: {
+            taskId: 'poll-first-seller-task',
+            status: 'completed',
+            taskType: 'create_media_buy',
+            createdAt: Date.now(),
+            updatedAt: Date.now(),
+            result: { media_buy_id: 'poll-first-buy' },
+          },
+        };
+      }
+      return { status: 'submitted', task_id: 'poll-first-seller-task' };
+    });
+    const executor = new TaskExecutor({ strictSchemaValidation: false });
+    let webhookSettlements = 0;
+    const pending = await executor.executeTask(
+      AGENT,
+      'create_media_buy',
+      { idempotency_key: 'poll-first-settlement' },
+      undefined,
+      {},
+      'v3',
+      undefined,
+      async (_params, context) => ({
+        action: 'dispatch_committed',
+        onResult: async result => {
+          context.registerExternalTaskSettlement(async () => {
+            webhookSettlements += 1;
+            return result;
+          });
+          return result;
+        },
+        onError: async error => {
+          throw error;
+        },
+      })
+    );
+
+    const completed = await pending.submitted.waitForCompletion(0);
+    assert.equal(completed.status, 'completed');
+    await assert.rejects(
+      executor.observeExternalTaskStatus(
+        pending.metadata.taskId,
+        'completed',
+        { media_buy_id: 'poll-first-buy' },
+        { serverTaskId: 'poll-first-seller-task', taskType: 'create_media_buy' }
+      ),
+      /settled through its direct response|already completed durable settlement/
+    );
+    assert.equal(webhookSettlements, 0);
+  });
+
+  test('rejects an in-flight webhook when polling closes the durable route first', async () => {
+    ProtocolClient.callTool = mock.fn(async () => ({
+      status: 'submitted',
+      task_id: 'poll-race-seller-task',
+    }));
+    let markWebhookSettlementStarted;
+    const webhookSettlementStarted = new Promise(resolve => {
+      markWebhookSettlementStarted = resolve;
+    });
+    let releaseWebhookSettlement;
+    const webhookSettlementRelease = new Promise(resolve => {
+      releaseWebhookSettlement = resolve;
+    });
+    let publishPollCompletion;
+    const executor = new TaskExecutor({ strictSchemaValidation: false });
+    let terminalEvent;
+    executor.onTaskUpdate(AGENT.id, task => {
+      if (task.status === 'completed') terminalEvent = task;
+    });
+    const pending = await executor.executeTask(
+      AGENT,
+      'create_media_buy',
+      { idempotency_key: 'poll-first-racing-webhook' },
+      undefined,
+      {},
+      'v3',
+      undefined,
+      async (_params, context) => {
+        publishPollCompletion = context.publishSettledTaskStatus;
+        return {
+          action: 'dispatch_committed',
+          onResult: async result => {
+            context.registerExternalTaskSettlement(async () => {
+              markWebhookSettlementStarted();
+              await webhookSettlementRelease;
+              return {
+                success: true,
+                status: 'completed',
+                data: { media_buy_id: 'webhook-race-loser' },
+                metadata: { ...result.metadata, status: 'completed' },
+              };
+            });
+            return result;
+          },
+          onError: async error => {
+            throw error;
+          },
+        };
+      }
+    );
+
+    const webhook = executor.observeExternalTaskStatus(
+      pending.metadata.taskId,
+      'completed',
+      { media_buy_id: 'webhook-race-loser' },
+      { serverTaskId: 'poll-race-seller-task', taskType: 'create_media_buy' }
+    );
+    await webhookSettlementStarted;
+    publishPollCompletion('completed', { media_buy_id: 'poll-race-winner' });
+    releaseWebhookSettlement();
+
+    await assert.rejects(webhook, /settled through its direct response/);
+    assert.equal(executor.settledExternalTaskObservationKeys.has(pending.metadata.taskId), false);
+    assert.equal(terminalEvent.result.media_buy_id, 'poll-race-winner');
+  });
+
+  test('does not publish deferred completion when durable persistence fails', async () => {
+    const durableError = new Error('durable deferred persistence failed');
+    const deferredRecords = new Map();
+    ProtocolClient.callTool = mock.fn(async (_agent, taskName) =>
+      taskName === 'continue_task'
+        ? { status: 'completed', data: { media_buy_id: 'seller-created-buy' } }
+        : {
+            status: 'input-required',
+            question: 'Approve the legacy purchase?',
+            field: 'approval',
+            contextId: 'legacy-create-context',
+          }
+    );
+    const executor = new TaskExecutor({
+      strictSchemaValidation: false,
+      deferredStorage: {
+        set: async (token, state) => deferredRecords.set(token, state),
+        get: async token => deferredRecords.get(token),
+        delete: async token => deferredRecords.delete(token),
+      },
+    });
+    const observedStatuses = [];
+    executor.onTaskUpdate(AGENT.id, task => observedStatuses.push(task.status));
+
+    const pending = await executor.executeTask(
+      AGENT,
+      'create_media_buy',
+      { idempotency_key: 'deferred-settlement-order' },
+      async () => ({ defer: true, token: 'legacy-create-deferred-token' }),
+      {},
+      'v3',
+      undefined,
+      async () => ({
+        action: 'dispatch_committed',
+        onResult: async result => {
+          const deferred = result.deferred;
+          result.deferred = {
+            ...deferred,
+            resume: async input => {
+              const completion = await deferred.resume(input);
+              assert.equal(completion.status, 'completed');
+              assert.equal(observedStatuses.includes('completed'), false);
+              throw durableError;
+            },
+          };
+          return result;
+        },
+        onError: async error => {
+          throw error;
+        },
+      })
+    );
+
+    await assert.rejects(pending.deferred.resume({ approved: true }), error => error === durableError);
+    assert.equal(observedStatuses.includes('completed'), false);
+    assert.equal(executor.getActiveTasks()[0].status, 'deferred');
+  });
+
+  test('publishes deferred-to-submitted completion only after recursive durable settlement', async () => {
+    const deferredRecords = new Map();
+    let markPersistenceStarted;
+    const persistenceStarted = new Promise(resolve => {
+      markPersistenceStarted = resolve;
+    });
+    let releasePersistence;
+    const persistenceRelease = new Promise(resolve => {
+      releasePersistence = resolve;
+    });
+    ProtocolClient.callTool = mock.fn(async (_agent, taskName) => {
+      if (taskName === 'continue_task') return { status: 'submitted', task_id: 'resumed-seller-task' };
+      if (taskName === 'tasks/get' || taskName === 'tasks_get') {
+        return {
+          task: {
+            taskId: 'resumed-seller-task',
+            status: 'completed',
+            taskType: 'create_media_buy',
+            createdAt: Date.now(),
+            updatedAt: Date.now(),
+            result: { media_buy_id: 'seller-created-buy' },
+          },
+        };
+      }
+      return {
+        status: 'input-required',
+        question: 'Approve the legacy purchase?',
+        field: 'approval',
+        contextId: 'legacy-create-context',
+      };
+    });
+    const executor = new TaskExecutor({
+      strictSchemaValidation: false,
+      deferredStorage: {
+        set: async (token, state) => deferredRecords.set(token, state),
+        get: async token => deferredRecords.get(token),
+        delete: async token => deferredRecords.delete(token),
+      },
+    });
+    const observedStatuses = [];
+    executor.onTaskUpdate(AGENT.id, task => observedStatuses.push(task.status));
+
+    const settleRecursively = result => {
+      if (result.deferred) {
+        const deferred = result.deferred;
+        result.deferred = {
+          ...deferred,
+          resume: async input => settleRecursively(await deferred.resume(input)),
+        };
+      }
+      if (result.submitted) {
+        const submitted = result.submitted;
+        result.submitted = {
+          ...submitted,
+          waitForCompletion: async (pollInterval, signal) => {
+            const completion = await submitted.waitForCompletion(pollInterval, signal);
+            markPersistenceStarted();
+            await persistenceRelease;
+            return completion;
+          },
+        };
+      }
+      return result;
+    };
+
+    const deferred = await executor.executeTask(
+      AGENT,
+      'create_media_buy',
+      { idempotency_key: 'deferred-submitted-settlement-order' },
+      async () => ({ defer: true, token: 'legacy-create-deferred-submitted-token' }),
+      {},
+      'v3',
+      undefined,
+      async () => ({
+        action: 'dispatch_committed',
+        onResult: async result => settleRecursively(result),
+        onError: async error => {
+          throw error;
+        },
+      })
+    );
+
+    const submitted = await deferred.deferred.resume({ approved: true });
+    assert.equal(submitted.status, 'submitted');
+    const completionPromise = submitted.submitted.waitForCompletion(0);
+    await persistenceStarted;
+    assert.equal(observedStatuses.includes('completed'), false);
+    releasePersistence();
+    const completion = await completionPromise;
+    assert.equal(completion.status, 'completed');
+    assert.equal(observedStatuses.at(-1), 'completed');
+  });
+
+  test('does not publish a submitted webhook completion when durable settlement fails', async () => {
+    const durableError = new Error('webhook completion persistence failed');
+    let markSettlementStarted;
+    const settlementStarted = new Promise(resolve => {
+      markSettlementStarted = resolve;
+    });
+    let releaseSettlement;
+    const settlementRelease = new Promise(resolve => {
+      releaseSettlement = resolve;
+    });
+    ProtocolClient.callTool = mock.fn(async () => ({ status: 'submitted', task_id: 'webhook-seller-task' }));
+    const webhookActivities = [];
+    const handlerResults = [];
+    const client = new SingleAgentClient(AGENT, {
+      allowUnauthenticatedWebhooks: true,
+      strictSchemaValidation: false,
+      validateFeatures: false,
+      onActivity: activity => {
+        if (activity.type === 'webhook_received') webhookActivities.push(activity);
+      },
+      handlers: {
+        onCreateMediaBuyStatusChange: response => handlerResults.push(response),
+      },
+    });
+    const observedStatuses = [];
+    client.onTaskUpdate(task => observedStatuses.push(task.status));
+
+    const pending = await client.executor.executeTask(
+      AGENT,
+      'create_media_buy',
+      { idempotency_key: 'submitted-webhook-settlement-order' },
+      undefined,
+      {},
+      'v3',
+      undefined,
+      async (_params, context) => ({
+        action: 'dispatch_committed',
+        onResult: async result => {
+          context.registerExternalTaskSettlement(async observation => {
+            assert.equal(observation.serverTaskId, 'webhook-seller-task');
+            assert.equal(observation.taskType, 'create_media_buy');
+            markSettlementStarted();
+            await settlementRelease;
+            throw durableError;
+          });
+          return result;
+        },
+        onError: async error => {
+          throw error;
+        },
+      })
+    );
+
+    const webhook = client.handleWebhook(
+      {
+        idempotency_key: 'submitted-webhook-event-0001',
+        operation_id: pending.metadata.taskId,
+        task_id: 'webhook-seller-task',
+        task_type: 'create_media_buy',
+        status: 'completed',
+        timestamp: '2026-08-21T12:00:00.000Z',
+        result: { media_buy_id: 'unsettled-webhook-buy' },
+      },
+      'create_media_buy',
+      pending.metadata.taskId
+    );
+    await settlementStarted;
+    assert.equal(observedStatuses.includes('completed'), false);
+    assert.deepEqual(webhookActivities, []);
+    assert.deepEqual(handlerResults, []);
+
+    releaseSettlement();
+    await assert.rejects(webhook, error => error === durableError);
+    assert.equal(observedStatuses.includes('completed'), false);
+    assert.deepEqual(webhookActivities, []);
+    assert.deepEqual(handlerResults, []);
+    assert.equal(client.getActiveTasks()[0].status, 'submitted');
+  });
+
+  test('bounds followers and retained error metadata while one durable webhook settlement is pending', async () => {
+    let markSettlementStarted;
+    const settlementStarted = new Promise(resolve => {
+      markSettlementStarted = resolve;
+    });
+    let releaseSettlement;
+    const settlementRelease = new Promise(resolve => {
+      releaseSettlement = resolve;
+    });
+    const longError = 'E'.repeat(2_048);
+    ProtocolClient.callTool = mock.fn(async () => ({ status: 'submitted', task_id: 'bounded-seller-task' }));
+    const executor = new TaskExecutor({ strictSchemaValidation: false });
+    const pending = await executor.executeTask(
+      AGENT,
+      'create_media_buy',
+      { idempotency_key: 'bounded-webhook-followers' },
+      undefined,
+      {},
+      'v3',
+      undefined,
+      async (_params, context) => ({
+        action: 'dispatch_committed',
+        onResult: async result => {
+          context.registerExternalTaskSettlement(async () => {
+            markSettlementStarted();
+            await settlementRelease;
+            return {
+              success: false,
+              status: 'failed',
+              error: longError,
+              data: { errors: [{ code: 'INTERNAL_ERROR', message: 'Durable failure' }] },
+              metadata: { ...result.metadata, status: 'failed' },
+            };
+          });
+          return result;
+        },
+        onError: async error => {
+          throw error;
+        },
+      })
+    );
+    const observation = {
+      status: 'completed',
+      result: { media_buy_id: 'must-not-publish' },
+      serverTaskId: 'bounded-seller-task',
+      taskType: 'create_media_buy',
+    };
+    const leader = executor.observeExternalTaskStatus(pending.metadata.taskId, observation.status, observation.result, {
+      serverTaskId: observation.serverTaskId,
+      taskType: observation.taskType,
+    });
+    await settlementStarted;
+    const followers = Array.from({ length: 7 }, () =>
+      executor.observeExternalTaskStatus(pending.metadata.taskId, observation.status, observation.result, {
+        serverTaskId: observation.serverTaskId,
+        taskType: observation.taskType,
+      })
+    );
+    await assert.rejects(
+      executor.observeExternalTaskStatus(pending.metadata.taskId, observation.status, observation.result, {
+        serverTaskId: observation.serverTaskId,
+        taskType: observation.taskType,
+      }),
+      /Too many terminal push notifications/
+    );
+    releaseSettlement();
+    const settled = await leader;
+    assert.equal(settled.status, 'failed');
+    assert.equal(settled.error.length, 2_048);
+    const duplicates = await Promise.all(followers);
+    assert.equal(
+      duplicates.every(result => result.duplicate && result.status === 'failed'),
+      true
+    );
+    assert.equal(
+      duplicates.every(result => result.error.length === 2_048),
+      true
+    );
+    const retained = executor.settledExternalTaskObservationKeys.get(pending.metadata.taskId);
+    assert.equal(retained.error.length, 1_024);
+  });
+
+  test('publishes the durably settled webhook result before invoking public handlers', async () => {
+    let markSettlementStarted;
+    const settlementStarted = new Promise(resolve => {
+      markSettlementStarted = resolve;
+    });
+    let releaseSettlement;
+    const settlementRelease = new Promise(resolve => {
+      releaseSettlement = resolve;
+    });
+    ProtocolClient.callTool = mock.fn(async () => ({ status: 'submitted', task_id: 'webhook-seller-task' }));
+    const webhookActivities = [];
+    const asyncHandlerActivities = [];
+    const handlerResults = [];
+    const client = new SingleAgentClient(AGENT, {
+      allowUnauthenticatedWebhooks: true,
+      strictSchemaValidation: false,
+      validateFeatures: false,
+      onActivity: activity => {
+        if (activity.type === 'webhook_received') webhookActivities.push(activity);
+      },
+      handlers: {
+        onActivity: activity => asyncHandlerActivities.push(activity),
+        onCreateMediaBuyStatusChange: response => handlerResults.push(response),
+      },
+    });
+    const observedStatuses = [];
+    client.onTaskUpdate(task => observedStatuses.push(task.status));
+
+    const pending = await client.executor.executeTask(
+      AGENT,
+      'create_media_buy',
+      { idempotency_key: 'submitted-webhook-success-order' },
+      undefined,
+      {},
+      'v3',
+      undefined,
+      async (_params, context) => ({
+        action: 'dispatch_committed',
+        onResult: async result => {
+          context.registerExternalTaskSettlement(async observation => {
+            if (observation.serverTaskId !== 'webhook-seller-task') throw new Error('pushed task identity mismatch');
+            markSettlementStarted();
+            await settlementRelease;
+            return {
+              success: true,
+              status: 'completed',
+              data: { media_buy_id: 'durably-settled-buy' },
+              metadata: { ...result.metadata, status: 'completed' },
+            };
+          });
+          return result;
+        },
+        onError: async error => {
+          throw error;
+        },
+      })
+    );
+
+    const terminalWebhookPayload = {
+      idempotency_key: 'submitted-webhook-event-0002',
+      operation_id: pending.metadata.taskId,
+      task_id: 'webhook-seller-task',
+      task_type: 'create_media_buy',
+      status: 'completed',
+      timestamp: '2026-08-21T12:00:00.000Z',
+      result: { media_buy_id: 'unsettled-webhook-buy' },
+    };
+    const webhook = client.handleWebhook(terminalWebhookPayload, 'create_media_buy', pending.metadata.taskId);
+    await settlementStarted;
+    assert.equal(observedStatuses.includes('completed'), false);
+    assert.deepEqual(webhookActivities, []);
+    assert.deepEqual(handlerResults, []);
+
+    const concurrentDuplicate = client.handleWebhook(
+      terminalWebhookPayload,
+      'create_media_buy',
+      pending.metadata.taskId
+    );
+    const concurrentConflict = client.handleWebhook(
+      {
+        ...terminalWebhookPayload,
+        idempotency_key: 'submitted-webhook-event-conflict',
+        result: { media_buy_id: 'conflicting-unsettled-buy' },
+      },
+      'create_media_buy',
+      pending.metadata.taskId
+    );
+
+    releaseSettlement();
+    assert.equal(await webhook, true);
+    assert.equal(await concurrentDuplicate, true);
+    await assert.rejects(concurrentConflict, /already completed durable settlement/);
+    assert.equal(observedStatuses.at(-1), 'completed');
+    assert.equal(webhookActivities.length, 1);
+    assert.equal(webhookActivities[0].payload.media_buy_id, 'durably-settled-buy');
+    assert.equal(
+      asyncHandlerActivities.find(activity => activity.type === 'webhook_received').payload.media_buy_id,
+      'durably-settled-buy'
+    );
+    assert.equal(asyncHandlerActivities.length, 2);
+    assert.equal(asyncHandlerActivities.filter(activity => activity.type === 'webhook_duplicate').length, 1);
+    assert.deepEqual(handlerResults, [{ media_buy_id: 'durably-settled-buy' }]);
+    const acceptedObservation = client.executor.settledExternalTaskObservationKeys.get(pending.metadata.taskId);
+    assert.match(acceptedObservation.key, /^[A-Za-z0-9_-]{43}$/);
+    assert.equal(JSON.stringify(acceptedObservation).includes('unsettled-webhook-buy'), false);
+
+    // The short task-inspection window may expire days before the trusted
+    // webhook registration. Its canonical durable replay path must survive.
+    client.executor.cleanupTerminalTaskInspectionState(pending.metadata.taskId);
+    assert.equal(client.executor.deferredTerminalPublicationTaskIds.size, 1);
+    assert.equal(
+      await client.handleWebhook(
+        {
+          idempotency_key: 'submitted-webhook-event-0002',
+          operation_id: pending.metadata.taskId,
+          task_id: 'webhook-seller-task',
+          task_type: 'create_media_buy',
+          status: 'completed',
+          timestamp: '2026-08-21T12:00:00.000Z',
+          result: { media_buy_id: 'unsettled-webhook-buy' },
+        },
+        'create_media_buy',
+        pending.metadata.taskId
+      ),
+      true
+    );
+    assert.equal(webhookActivities.length, 1);
+    assert.equal(asyncHandlerActivities.length, 3);
+    assert.equal(asyncHandlerActivities.at(-1).type, 'webhook_duplicate');
+    assert.deepEqual(handlerResults, [{ media_buy_id: 'durably-settled-buy' }]);
+
+    await assert.rejects(
+      client.handleWebhook(
+        {
+          idempotency_key: 'submitted-webhook-event-0003',
+          operation_id: pending.metadata.taskId,
+          task_id: 'different-seller-task',
+          task_type: 'create_media_buy',
+          status: 'completed',
+          timestamp: '2026-08-21T12:01:00.000Z',
+          result: { media_buy_id: 'conflicting-late-buy' },
+        },
+        'create_media_buy',
+        pending.metadata.taskId
+      ),
+      /already completed durable settlement/
+    );
+    assert.equal(webhookActivities.length, 1);
+    assert.equal(asyncHandlerActivities.length, 3);
+    assert.deepEqual(handlerResults, [{ media_buy_id: 'durably-settled-buy' }]);
+  });
+
+  test('normalizes webhook metadata to the durably settled terminal failure', async () => {
+    ProtocolClient.callTool = mock.fn(async () => ({ status: 'submitted', task_id: 'failed-webhook-task' }));
+    const topLevelActivities = [];
+    const asyncActivities = [];
+    const handlerCalls = [];
+    const client = new SingleAgentClient(AGENT, {
+      allowUnauthenticatedWebhooks: true,
+      strictSchemaValidation: false,
+      validateFeatures: false,
+      onActivity: activity => {
+        if (activity.type === 'webhook_received') topLevelActivities.push(activity);
+      },
+      handlers: {
+        onActivity: activity => asyncActivities.push(activity),
+        onCreateMediaBuyStatusChange: (response, metadata) => handlerCalls.push({ response, metadata }),
+      },
+    });
+    const observedStatuses = [];
+    client.onTaskUpdate(task => observedStatuses.push(task.status));
+    const pending = await client.executor.executeTask(
+      AGENT,
+      'create_media_buy',
+      { idempotency_key: 'submitted-webhook-failed-normalization' },
+      undefined,
+      {},
+      'v3',
+      undefined,
+      async (_params, context) => ({
+        action: 'dispatch_committed',
+        onResult: async result => {
+          context.registerExternalTaskSettlement(async () => ({
+            success: false,
+            status: 'governance-denied',
+            error: 'Canonical durable governance denial',
+            data: { errors: [{ code: 'INVALID_REQUEST', message: 'Rejected durably' }] },
+            metadata: { ...result.metadata, status: 'governance-denied' },
+          }));
+          return result;
+        },
+        onError: async error => {
+          throw error;
+        },
+      })
+    );
+
+    assert.equal(
+      await client.handleWebhook(
+        {
+          idempotency_key: 'submitted-webhook-event-0004',
+          operation_id: pending.metadata.taskId,
+          task_id: 'failed-webhook-task',
+          task_type: 'create_media_buy',
+          status: 'completed',
+          timestamp: '2026-08-21T12:02:00.000Z',
+          result: { media_buy_id: 'must-not-be-published' },
+        },
+        'create_media_buy',
+        pending.metadata.taskId
+      ),
+      true
+    );
+    assert.equal(observedStatuses.at(-1), 'governance-denied');
+    assert.equal(topLevelActivities[0].status, 'governance-denied');
+    assert.deepEqual(topLevelActivities[0].payload, {
+      errors: [{ code: 'INVALID_REQUEST', message: 'Rejected durably' }],
+    });
+    assert.equal(asyncActivities[0].status, 'governance-denied');
+    assert.deepEqual(asyncActivities[0].payload, topLevelActivities[0].payload);
+    assert.equal(handlerCalls[0].metadata.status, 'governance-denied');
+    assert.equal(handlerCalls[0].metadata.message, 'Canonical durable governance denial');
+    assert.deepEqual(handlerCalls[0].response, topLevelActivities[0].payload);
+
+    assert.equal(
+      await client.handleWebhook(
+        {
+          idempotency_key: 'submitted-webhook-event-0004',
+          operation_id: pending.metadata.taskId,
+          task_id: 'failed-webhook-task',
+          task_type: 'create_media_buy',
+          status: 'completed',
+          timestamp: '2026-08-21T12:02:00.000Z',
+          result: { media_buy_id: 'must-not-be-published' },
+        },
+        'create_media_buy',
+        pending.metadata.taskId
+      ),
+      true
+    );
+    assert.equal(asyncActivities.at(-1).type, 'webhook_duplicate');
+    assert.equal(asyncActivities.at(-1).status, 'governance-denied');
+    assert.equal(handlerCalls.length, 1);
+  });
+
+  test('fails closed when a durable webhook registration survives without its process-local settlement route', async () => {
+    const client = new SingleAgentClient(AGENT, {
+      allowUnauthenticatedWebhooks: true,
+      strictSchemaValidation: false,
+      validateFeatures: false,
+    });
+
+    await assert.rejects(
+      client.dispatchParsedWebhook({
+        ok: true,
+        protocol: 'mcp',
+        envelope: {
+          operation_id: 'restarted-durable-operation',
+          task_id: 'restarted-seller-task',
+          task_type: 'create_media_buy',
+          status: 'completed',
+          result: { media_buy_id: 'must-not-publish' },
+        },
+        result: { media_buy_id: 'must-not-publish' },
+        metadata: {
+          operationId: 'restarted-durable-operation',
+          taskId: 'restarted-seller-task',
+          taskType: 'create_media_buy',
+          status: 'completed',
+          requiresDurableSettlement: true,
+        },
+      }),
+      error =>
+        error?.code === 'webhook_durable_settlement_unavailable' &&
+        /no recoverable settlement route/i.test(error.message)
+    );
   });
 });

--- a/test/type-generator-required-fields.test.js
+++ b/test/type-generator-required-fields.test.js
@@ -204,6 +204,49 @@ writeFileSync(__OUTPUT__, JSON.stringify({
   assert.equal(result.finalized.hasExpiry, true);
 });
 
+test('request_proposals outcome branches retain products and legacy continuation fields', () => {
+  const result = runGeneratorHarness(`
+import { readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { applyCodegenSchemaWorkarounds, enforceStrictSchema } from __GENERATOR__;
+
+const source = JSON.parse(
+  readFileSync(path.join(__REPO_ROOT__, 'schemas/cache/latest/media-buy/request-proposals-response.json'), 'utf8')
+);
+const transformed = enforceStrictSchema(applyCodegenSchemaWorkarounds(source, 'RequestProposalsResponse'));
+const proposed = transformed.oneOf.find(
+  (branch: any) => branch.properties?.outcome?.const === 'proposed'
+);
+const productsAvailable = transformed.oneOf.find(
+  (branch: any) => branch.properties?.outcome?.const === 'products_available'
+);
+const legacyCreate = productsAvailable.properties.purchase_continuation.oneOf.find(
+  (branch: any) => branch.properties?.kind?.const === 'legacy_create'
+);
+writeFileSync(__OUTPUT__, JSON.stringify({
+  branchCount: transformed.oneOf.length,
+  productsAvailableRequired: productsAvailable.required,
+  productsAvailableProperties: Object.keys(productsAvailable.properties),
+  productsMinItems: productsAvailable.properties.products.minItems,
+  proposedForbidsContinuation: proposed.properties.purchase_continuation === false,
+  productsAvailableForbidsProposals: productsAvailable.properties.proposals === false,
+  continuationRequired: legacyCreate.required,
+  continuationProperties: Object.keys(legacyCreate.properties),
+}));
+`);
+
+  assert.equal(result.branchCount, 4);
+  assert.ok(result.productsAvailableRequired.includes('products'));
+  assert.ok(result.productsAvailableRequired.includes('purchase_continuation'));
+  assert.ok(result.productsAvailableProperties.includes('purchase_continuation'));
+  assert.equal(result.productsMinItems, 1);
+  assert.equal(result.proposedForbidsContinuation, true);
+  assert.equal(result.productsAvailableForbidsProposals, true);
+  assert.ok(result.continuationRequired.includes('continuation_token'));
+  assert.ok(result.continuationRequired.includes('losses'));
+  assert.ok(result.continuationProperties.includes('product_ids'));
+});
+
 test('GetMediaBuyDeliveryResponse isolates optional breakdown identifiers under unique compat titles', () => {
   const result = runGeneratorHarness(`
 import { readFileSync, writeFileSync } from 'node:fs';

--- a/test/webhook-rfc9421-client.test.js
+++ b/test/webhook-rfc9421-client.test.js
@@ -103,6 +103,25 @@ function makeResponse() {
   };
 }
 
+test('webhook registrations persist durable-settlement routing provenance', async () => {
+  const store = new InMemoryWebhookRegistrationStore();
+  await store.putIfAbsent({
+    agentId: agent.id,
+    agentUrl: agent.agent_uri,
+    protocol: agent.protocol,
+    operationId: 'op-durable-settlement-marker',
+    taskType: 'create_media_buy',
+    callbackUrl: 'https://buyer.example/webhooks/create_media_buy/op-durable-settlement-marker',
+    method: 'POST',
+    mode: 'rfc9421',
+    createdAt: Date.now(),
+    expiresAt: Date.now() + 60_000,
+  });
+
+  await store.markRequiresDurableSettlement(agent.id, 'op-durable-settlement-marker');
+  assert.equal((await store.get(agent.id, 'op-durable-settlement-marker')).requiresDurableSettlement, true);
+});
+
 describe('SingleAgentClient RFC 9421 webhook receiver', () => {
   test('verifies the registered seller, public URL, and exact raw bytes', async () => {
     const { client, callbackUrl, signer } = await registeredRfcClient();
@@ -245,7 +264,7 @@ describe('SingleAgentClient RFC 9421 webhook receiver', () => {
     assert.strictEqual(substituted.code, 'webhook_mode_mismatch');
   });
 
-  test('preserves recordless legacy HMAC compatibility after restart or replica changes', async () => {
+  test('preserves recordless legacy HMAC compatibility only for explicitly read-only tasks', async () => {
     const secret = 'legacy-secret';
     const unavailableStore = {
       async get() {
@@ -259,15 +278,52 @@ describe('SingleAgentClient RFC 9421 webhook receiver', () => {
       webhookSecret: secret,
       webhookRegistrationStore: unavailableStore,
     });
-    const rawBody = JSON.stringify(envelope({ operation_id: 'unregistered-operation' }));
+    const rawBody = JSON.stringify(envelope({ operation_id: 'unregistered-operation', task_type: 'list_products' }));
     const headers = hmacHeaders(rawBody, secret);
     const verified = await client.verifyAndParseWebhook({
       rawBody,
       headers,
-      taskType: 'get_products',
+      taskType: 'list_products',
       operationId: 'unregistered-operation',
     });
     assert.strictEqual(verified.ok, true);
+
+    const mutatingRawBody = JSON.stringify(
+      envelope({
+        operation_id: 'unregistered-mutation',
+        task_type: 'create_media_buy',
+        result: { media_buy_id: 'must-not-dispatch' },
+      })
+    );
+    const mutatingVerified = await client.verifyAndParseWebhook({
+      rawBody: mutatingRawBody,
+      headers: hmacHeaders(mutatingRawBody, secret),
+      taskType: 'create_media_buy',
+      operationId: 'unregistered-mutation',
+    });
+    assert.strictEqual(mutatingVerified.ok, false);
+    assert.strictEqual(mutatingVerified.code, 'webhook_registration_store_unavailable');
+
+    const recoveredStoreClient = new SingleAgentClient(agent, {
+      webhookSecret: secret,
+      webhookRegistrationStore: {
+        async get() {
+          return undefined;
+        },
+        async putIfAbsent() {},
+      },
+    });
+    for (const taskType of ['create_media_buy', 'get_products', 'extension_task']) {
+      const missingRawBody = JSON.stringify(envelope({ operation_id: `missing-${taskType}`, task_type: taskType }));
+      const missing = await recoveredStoreClient.verifyAndParseWebhook({
+        rawBody: missingRawBody,
+        headers: hmacHeaders(missingRawBody, secret),
+        taskType,
+        operationId: `missing-${taskType}`,
+      });
+      assert.strictEqual(missing.ok, false);
+      assert.strictEqual(missing.code, 'webhook_registration_store_unavailable');
+    }
 
     const registrationBase = {
       agent,
@@ -305,6 +361,41 @@ describe('webhook registration provenance', () => {
       /different trusted provenance/
     );
     await assert.rejects(store.putIfAbsent({ ...registration, previewMode: 'legacy' }), /different trusted provenance/);
+    await assert.rejects(
+      store.putIfAbsent({
+        ...registration,
+        operationId: 'op-agent-userinfo',
+        agentUrl: 'https://seller-user:secret@seller.example/mcp',
+      }),
+      /userinfo credentials/
+    );
+  });
+
+  test('strips seller URL userinfo before durable webhook registration', async () => {
+    let persisted;
+    const client = new SingleAgentClient(
+      { ...agent, agent_uri: 'https://seller-user:secret@seller.example/mcp#fragment' },
+      {
+        webhookSecret: 'legacy-secret',
+        webhookRegistrationStore: {
+          async get() {
+            return undefined;
+          },
+          async putIfAbsent(registration) {
+            persisted = registration;
+          },
+        },
+      }
+    );
+    await client.persistWebhookRegistration({
+      agent: { ...agent, agent_uri: 'https://seller-user:secret@seller.example/mcp#fragment' },
+      taskType: 'get_products',
+      operationId: 'op-sanitized-agent-url',
+      callbackUrl: 'https://buyer.example/webhook/op-sanitized-agent-url',
+      mode: 'hmac-sha256',
+    });
+    assert.strictEqual(persisted.agentUrl, 'https://seller.example/mcp');
+    assert.strictEqual(JSON.stringify(persisted).includes('secret'), false);
   });
 
   test('TaskExecutor persists the single prepared call before dispatch', async () => {
@@ -347,6 +438,121 @@ describe('webhook registration provenance', () => {
     } finally {
       ProtocolClient.callTool = original;
     }
+  });
+
+  test('does not claim or dispatch after timing out while the durable marker is pending', async () => {
+    const original = ProtocolClient.callTool;
+    let markStarted;
+    const markerStarted = new Promise(resolve => {
+      markStarted = resolve;
+    });
+    let releaseMarker;
+    const markerRelease = new Promise(resolve => {
+      releaseMarker = resolve;
+    });
+    let claims = 0;
+    let dispatches = 0;
+    ProtocolClient.callTool = async () => {
+      dispatches += 1;
+      return { status: 'completed', result: {} };
+    };
+    try {
+      const executor = new TaskExecutor({
+        webhookUrlTemplate: 'https://buyer.example/webhook/{operation_id}',
+        agentId: agent.id,
+        onWebhookRegistration: async () => {},
+        onDurableSettlementRequired: async () => {
+          markStarted();
+          await markerRelease;
+        },
+        validation: { requests: 'off', responses: 'off' },
+      });
+      const execution = executor.executeTask(
+        agent,
+        'create_media_buy',
+        { idempotency_key: 'marker-timeout-before-claim' },
+        undefined,
+        { timeout: 10 },
+        'v3',
+        undefined,
+        async () => {
+          claims += 1;
+          return { action: 'dispatch_committed' };
+        }
+      );
+      await markerStarted;
+      await assert.rejects(execution, error => error?.name === 'TaskTimeoutError');
+      releaseMarker();
+      await new Promise(resolve => setImmediate(resolve));
+      assert.strictEqual(claims, 0);
+      assert.strictEqual(dispatches, 0);
+    } finally {
+      ProtocolClient.callTool = original;
+    }
+  });
+
+  test('custom durable stores must implement the pre-claim settlement marker', async () => {
+    const original = ProtocolClient.callTool;
+    let claims = 0;
+    let dispatches = 0;
+    ProtocolClient.callTool = async () => {
+      dispatches += 1;
+      return { status: 'completed', result: {} };
+    };
+    try {
+      const client = new SingleAgentClient(agent, {
+        webhookUrlTemplate: 'https://buyer.example/webhook/{operation_id}',
+        webhookSecret: 'legacy-secret',
+        webhookRegistrationStore: {
+          async get() {
+            return undefined;
+          },
+          async putIfAbsent() {},
+        },
+        validation: { requests: 'off', responses: 'off' },
+      });
+      await assert.rejects(
+        client.executor.executeTask(
+          agent,
+          'create_media_buy',
+          { idempotency_key: 'missing-marker-contract' },
+          undefined,
+          {},
+          'v3',
+          undefined,
+          async () => {
+            claims += 1;
+            return { action: 'dispatch_committed' };
+          }
+        ),
+        error => /must implement markRequiresDurableSettlement/.test(error?.cause?.message ?? '')
+      );
+      assert.strictEqual(claims, 0);
+      assert.strictEqual(dispatches, 0);
+    } finally {
+      ProtocolClient.callTool = original;
+    }
+  });
+
+  test('webhook HTTP helpers do not reflect arbitrary infrastructure errors', async () => {
+    const client = new SingleAgentClient(agent, {
+      allowUnauthenticatedWebhooks: true,
+      onActivity: () => {
+        throw new Error('database password appeared in an internal failure');
+      },
+    });
+    const handler = client.createWebhookHandler();
+    const response = makeResponse();
+    await handler(
+      {
+        body: envelope({ operation_id: 'op-generic-http-error' }),
+        params: { task_type: 'get_products', operation_id: 'op-generic-http-error' },
+      },
+      response
+    );
+    assert.strictEqual(response.statusCode, 500);
+    assert.strictEqual(response.body.error, 'Webhook could not be processed.');
+    assert.strictEqual(JSON.stringify(response.body).includes('password'), false);
   });
 
   test('prepares MCP and A2A placement exactly and never treats reporting_webhook as task registration', async () => {

--- a/test/webhook-signature-verification.test.js
+++ b/test/webhook-signature-verification.test.js
@@ -77,10 +77,10 @@ describe('Webhook Signature Verification (PR #86 Spec)', () => {
     const rawBody = JSON.stringify({
       operation_id: 'op_1',
       task_id: 'task_1',
-      task_type: 'create_media_buy',
+      task_type: 'list_products',
       status: 'completed',
       timestamp: new Date().toISOString(),
-      result: { media_buy_id: 'mb_1' },
+      result: { products: [] },
     });
     const timestamp = Math.floor(Date.now() / 1000);
     const hmac = crypto.createHmac('sha256', webhookSecret);
@@ -95,7 +95,7 @@ describe('Webhook Signature Verification (PR #86 Spec)', () => {
           'x-adcp-timestamp': String(timestamp),
         },
         body: rawBody,
-        params: { task_type: 'create_media_buy', operation_id: 'op_1' },
+        params: { task_type: 'list_products', operation_id: 'op_1' },
       },
       res
     );


### PR DESCRIPTION
## Summary

- make legacy 3.0/3.1 purchase continuation dispatch crash-safe, immutable after validation, task-correlated, and explicit about missing mutation replay guarantees
- harden durable webhook settlement across timeout, polling, restart/replica, duplicate/conflicting delivery, bounded retention, credential sanitization, and governance reporting order
- restore complete AdCP 3.2 beta.4 proposal response types and enforce native `request_proposals` outcome rules across synchronous and asynchronous APIs
- allow multiple packages for one selected product and preserve established `control_media_buy.name` projection while rejecting cancel-and-rename requests
- document the custom webhook store marker contract and recordless HMAC read-only restriction

This follows merged #2641 / closed #2640. Upstream protocol tracking already records the required current and 3.0/3.1 backports in adcontextprotocol/adcp#6701 and adcontextprotocol/adcp#6702.

## Breaking prerelease corrections

- `RequestProposalsResponse` now exposes the complete `products_available` and `legacy_create` branches instead of `{}`
- sellers without a stable context require a restart-stable `legacyPurchaseSellerSessionScope`
- custom durable `webhookRegistrationStore` implementations must implement `markRequiresDurableSettlement` for protected mutation callbacks
- recordless legacy HMAC fallback is restricted to explicitly read-only tasks

## Verification

- expert code, protocol, and security reviews: clean
- independent Codex protocol/code/security review completed; all blocker/high findings addressed
- `npm run typecheck`
- `npm run build`
- `npm run lint` (existing warnings only)
- 306 focused compatibility, settlement, webhook, and signature tests pass
- `git diff --check` and commitlint pass

## Release

Includes a major changeset for the next prerelease.