### PR TITLE
fix(server): harden beta.7 lifecycle cutover

### DIFF
--- a/.changeset/quiet-ledgers-retain.md
+++ b/.changeset/quiet-ledgers-retain.md
@@ -1,0 +1,7 @@
+---
+'@adcp/sdk': major
+---
+
+Define a seven-day minimum retention and pruning contract for established-proposal completion tombstones, and allow production webhook publishers to bind trusted tenant scope after emitter construction.
+
+Production servers that previously relied on the implicit `single-tenant` webhook namespace must now configure `webhooks.tenantScope` or resolve trusted account, session, or authentication scope for each request. Unscoped production emission fails before durable checkpointing or network delivery.

--- a/docs/TYPE-SUMMARY.md
+++ b/docs/TYPE-SUMMARY.md
@@ -1,6 +1,6 @@
 # AdCP Type Summary
 
-> Generated at: 2026-08-22
+> Generated at: 2026-08-23
 > @adcp/sdk v14.0.0-beta.7
 
 Curated reference of the types that matter for using the AdCP client. For full generated types see `src/lib/types/tools.generated.ts` and `src/lib/types/core.generated.ts`.
@@ -98,7 +98,9 @@ interface EstablishedProposalReserveRequest { bindings: readonly EstablishedProp
 type EstablishedProposalPutResult = { outcome: 'stored' | 'unchanged' | 'fenced'; record: EstablishedProposalRecord } | { outcome: 'missing' | 'capacity' };
 type EstablishedProposalReserveResult = { outcome: 'reserved'; records: EstablishedProposalRecord[]; retry: boolean } | { outcome: 'missing' | 'expired' | 'in_flight' | 'ambiguous' | 'terminal' | 'conflict' | 'capacity'; records: EstablishedProposalRecord[] };
 type EstablishedProposalTransitionResult = { outcome: 'updated'; records: EstablishedProposalRecord[] } | { outcome: 'missing' | 'conflict' | 'capacity'; records: EstablishedProposalRecord[] };
-interface EstablishedProposalSubmittedOperation { request: EstablishedProposalReserveRequest; records: EstablishedProposalRecord[]; sellerTaskId: string; settled?: boolean; }
+const ESTABLISHED_PROPOSAL_COMPLETION_TOMBSTONE_RETENTION_MS = 604800000;
+interface EstablishedProposalCompletionWindow { completedAt: string; retainUntil: string; }
+interface EstablishedProposalSubmittedOperation { request: EstablishedProposalReserveRequest; records: EstablishedProposalRecord[]; sellerTaskId: string; settled?: boolean; completion?: EstablishedProposalCompletionWindow; }
 
 interface EstablishedProposalStore {
   putSnapshot(snapshot: ProposalSnapshotEntry, expectedSnapshotFingerprint?: string): Promise<EstablishedProposalPutResult>;
@@ -106,16 +108,51 @@ interface EstablishedProposalStore {
   get(binding: EstablishedProposalBinding): Promise<EstablishedProposalRecord | undefined>;
   find(scope: EstablishedProposalScope, proposalIds: readonly string[]): Promise<EstablishedProposalRecord[]>;
   findSubmittedTask(scope: EstablishedProposalTaskScope, sellerTaskId: string): Promise<EstablishedProposalSubmittedOperation | undefined>;
+  /** Any retained tombstone with this operationKey returns conflict, even if claim or binding evidence differs. */
   reserveMutation(request: EstablishedProposalReserveRequest): Promise<EstablishedProposalReserveResult>;
   completeMutation(request: EstablishedProposalReserveRequest, disposition: 'accepted', terminalResultFingerprint: string): Promise<EstablishedProposalTransitionResult>;
   completeRefinement(request: EstablishedProposalReserveRequest, replacements: readonly ProposalSnapshotEntry[], retainedBindings?: readonly EstablishedProposalMutationBinding[]): Promise<EstablishedProposalTransitionResult>;
   completeDecline(request: EstablishedProposalReserveRequest, retainedBindings?: readonly EstablishedProposalMutationBinding[]): Promise<EstablishedProposalTransitionResult>;
+  pruneCompletionTombstones?(limit?: number): Promise<number>;
   releaseMutation(request: EstablishedProposalReserveRequest): Promise<EstablishedProposalTransitionResult>;
   recordSubmittedTask(request: EstablishedProposalReserveRequest, sellerTaskId: string): Promise<EstablishedProposalTransitionResult>;
   markAmbiguous(request: EstablishedProposalReserveRequest, ambiguity: 'paused' | 'commit-uncertain'): Promise<EstablishedProposalTransitionResult>;
 }
 
 // After restart: lifecycle.reconcileEstablishedProposalTask({ account, sellerTaskId })
+```
+
+## Production Webhook Tenant Binding
+
+An unbound production `WebhookEmitter` is safe to construct with a stable `publisherScope`, durable delivery store, and durable recovery outbox. It refuses direct emission until trusted tenant scope is bound:
+
+```typescript
+interface WebhookEmitter {
+  emit(params: WebhookEmitParams): Promise<WebhookEmitResult>;
+  forTenantScope(tenantScope: string): WebhookEmitter;
+}
+
+// Relevant WebhooksConfig fields (other signing and delivery fields omitted):
+interface WebhooksConfig {
+  publisherScope?: string; // defaults to the trusted server name
+  tenantScope?: string;    // explicit trusted single-tenant fallback only
+}
+
+const publisher = createWebhookEmitter({ publisherScope: 'publisher', deliveryStore, deliveryRecovery, signerKey });
+await publisher.forTenantScope(authenticatedTenant).emit(params);
+
+createAdcpServer({
+  name: 'publisher',
+  version: '1.0.0',
+  // Multi-tenant: omit tenantScope; trusted request context is required.
+  webhooks: { signerKey, deliveryStore, deliveryRecovery },
+});
+createAdcpServer({
+  name: 'publisher',
+  version: '1.0.0',
+  // Genuinely single-tenant: configure the trusted fallback explicitly.
+  webhooks: { signerKey, deliveryStore, deliveryRecovery, tenantScope: 'tenant-a' },
+});
 ```
 
 ## Trusted Match 3.1.10 Types

--- a/docs/guides/MEDIA-BUY-3.2-COMPATIBILITY.md
+++ b/docs/guides/MEDIA-BUY-3.2-COMPATIBILITY.md
@@ -204,11 +204,16 @@ identical row remains terminal so an ambiguity replay cannot resurrect the
 source. Implementations must retain a bounded completion tombstone keyed by
 `operationKey`, including source, successor, and retained fingerprints. An
 exact repeated completion returns `updated`, while conflicting completion
-evidence fails closed. Tombstones count toward the configured record and byte
-limits. `putSnapshot(snapshot, expectedSnapshotFingerprint)` may replace a
-different generation only when that exact generation is still available in
-the same atomic transaction; concurrent, reserved, and terminal generations
-win. `discardSnapshot()` must likewise compare the expected fingerprint in the
+evidence fails closed. Stamp each tombstone with the backing store's
+authoritative completion time and retain it for at least
+`ESTABLISHED_PROPOSAL_COMPLETION_TOMBSTONE_RETENTION_MS` (seven days).
+`findSubmittedTask()` exposes that `completedAt` / `retainUntil` window when a
+tombstone services recovery. Tombstones count toward the configured record and
+byte limits until they expire.
+`putSnapshot(snapshot, expectedSnapshotFingerprint)` may replace a different
+generation only when that exact generation is still available in the same
+atomic transaction; concurrent, reserved, and terminal generations win.
+`discardSnapshot()` must likewise compare the expected fingerprint in the
 delete transaction.
 
 The remaining transitions are equally fail-closed: `recordSubmittedTask()` may
@@ -224,13 +229,20 @@ only accept→accepted and compares a hash of the authoritative reduced terminal
 evidence so conflicting successful observations fail closed; and
 `completeDecline()` atomically terminalizes successful
 rows while restoring seller-confirmed unable bindings. Authoritatively settled
-terminal records and completion tombstones are permanent authorization fences:
-a bounded store
-must return capacity rather than evict them and reauthorize a proposal. An
-exact operation already represented by a completion tombstone must not be
-reserved or dispatched again. The tombstone must also service the scoped
-`findSubmittedTask(..., sellerTaskId)` lookup so reconciliation remains
-idempotent after the caller loses a completion response.
+terminal records are permanent authorization fences. Completion tombstones are
+authorization fences through their protocol-owned retention horizon: a bounded
+store must return capacity rather than evict them early and reauthorize a
+proposal. Any `reserveMutation()` reuse of an `operationKey` represented by a
+retained completion tombstone must return `conflict`, even when the new claim
+or binding evidence differs; only an exact repeated completion may return the
+idempotent `updated` outcome. The tombstone must also service the
+scoped `findSubmittedTask(..., sellerTaskId)` lookup so reconciliation remains
+idempotent after the caller loses a completion response. Durable stores should
+implement `pruneCompletionTombstones()` or an equivalent database-owned sweeper
+that uses the database clock. At or after `retainUntil`, pruning may make
+`findSubmittedTask()` return `undefined`; `reserveMutation()` then derives its
+result solely from the remaining source records and may reserve again when all
+sources were restored as available.
 
 After restart, call
 `lifecycle.reconcileEstablishedProposalTask({ account, sellerTaskId })`. The

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,6 +1,6 @@
 # Ad Context Protocol (AdCP)
 
-> Generated at: 2026-08-22
+> Generated at: 2026-08-23
 > Library: @adcp/sdk v14.0.0-beta.7
 > AdCP major version: 3
 > Canonical URL: https://adcontextprotocol.github.io/adcp-client/llms.txt
@@ -1829,7 +1829,10 @@ See docs/TYPE-SUMMARY.md for field-level detail. Key types at a glance:
 | `Targeting` | Audience criteria (geo, demo, behavioral, contextual, device) |
 | `PricingOption` | Price model (CPM, vCPM, CPC, CPCV, CPV, CPP, CPA, FlatRate, Time) |
 | `GovernanceConfig` | Buyer-side governance middleware config |
-| `EstablishedProposalStore` | Durable 3.0/3.1 proposal snapshots, atomic mutation fences, and submitted-task reconciliation |
+| `EstablishedProposalStore` | Durable 3.0/3.1 proposal snapshots, atomic mutation fences, seven-day completion proofs, pruning, and submitted-task reconciliation |
+| `WebhooksConfig.tenantScope` | Explicit trusted webhook namespace for a genuinely single-tenant server; multi-tenant servers derive scope per request |
+
+Production webhook publishers may construct an unbound emitter and call `forTenantScope(trustedTenant)` before every delivery. Direct unbound `emit()` fails before checkpointing or network access. `createAdcpServer` derives scope from trusted request context; configure `webhooks.tenantScope` only for a genuinely single-tenant factory.
 
 ## Task Statuses
 

--- a/docs/migration-13-to-14.md
+++ b/docs/migration-13-to-14.md
@@ -56,7 +56,7 @@ loading; keep using `requires_capability` for a singular predicate.
 6. Re-run TypeScript against generated schema imports. Prefer per-tool type slices if the complete schema barrel exhausts the default Node heap.
 7. Exercise mixed-version tests before rollout: 14→3.0, 14→3.1, 14→3.2 beta, and older buyer→14 server where applicable.
 8. If a legacy brief may return products without a proposal, configure a durable `LegacyPurchaseContinuationStore`, stable `principalScope`, and application-owned `reconcileLegacyPurchase(record, exactInput)` callback before offering `continueLegacyPurchase()`. Keep reverse compact-seller → older-buyer handlers application-owned.
-9. If established 3.0/3.1 proposal discovery and mutation can land on different processes, configure the same durable `EstablishedProposalStore`, stable `principalScope`, and stable non-secret `legacyPurchaseSellerSessionScope` on every coordinator. Recover submitted work with `reconcileEstablishedProposalTask({ account, sellerTaskId })`; see [Media-buy compatibility: durable established proposal state](./guides/MEDIA-BUY-3.2-COMPATIBILITY.md#durable-established-proposal-state). The bundled in-memory store is a non-durable reference implementation.
+9. If established 3.0/3.1 proposal discovery and mutation can land on different processes, configure the same durable `EstablishedProposalStore`, stable `principalScope`, and stable non-secret `legacyPurchaseSellerSessionScope` on every coordinator. Add store-clock `completedAt` and `retainUntil` fields to refinement/decline completion tombstones, index `retainUntil`, and retain each proof for at least `ESTABLISHED_PROPOSAL_COMPLETION_TOMBSTONE_RETENTION_MS`. Conservatively backfill pre-upgrade tombstones to a future seven-day horizon, then run a database-clock sweeper that atomically prunes only expired rows. Recover submitted work with `reconcileEstablishedProposalTask({ account, sellerTaskId })`; see [Media-buy compatibility: durable established proposal state](./guides/MEDIA-BUY-3.2-COMPATIBILITY.md#durable-established-proposal-state). The bundled in-memory store is a non-durable reference implementation.
 10. Upgrade durable idempotency storage before application traffic: add the nullable PostgreSQL `retain_until` column/index, preserve `IdempotencyCacheEntry.retainUntil`, and add atomic `putIfAbsent()`, `replaceIfPayloadHash()`, `replaceIfPayloadHashAndExpired()`, and `deleteIfPayloadHash()` to every custom backend.
 11. Upgrade custom deferred-task storage with `putForSettlementOperationIfAbsent()`, `getBySettlementOperationId()`, and `replaceForSettlementOperationIfVersion()`. The initial token/index write and nested A→B index move must each be atomic.
 12. Replace webhook emitter `operation_id` arguments with SDK-local `delivery_id` values and upgrade custom stores to `WebhookDeliveryStore`. One delivery ID binds one canonical payload and key; use a fresh delivery ID for each changed status observation while retaining the AdCP `operation_id` inside the payload.
@@ -117,11 +117,17 @@ horizon. Do not mint a new delivery ID merely to extend a failed delivery; a
 fresh ID is only for a protocol-defined re-emission or genuinely distinct
 observation.
 
-Production direct `createWebhookEmitter()` callers must provide stable
-`publisherScope` and `tenantScope` values. `createAdcpServer()` uses its trusted
-server name for the publisher scope and derives the tenant scope only from
-resolved account/session/authentication context; it never trusts request or
-payload fields for this namespace.
+Production direct `createWebhookEmitter()` callers must provide a stable
+`publisherScope`. A production publisher may omit `tenantScope`; the resulting
+unbound emitter refuses direct `emit()` calls, so bind every authenticated
+request or durable job with `forTenantScope(trustedTenant)` first. Callers that
+provide `tenantScope` at construction retain the existing directly usable
+behavior. `createAdcpServer()` uses its trusted server name for the publisher
+scope and derives tenant scope only from resolved account/session/authentication
+context. A genuinely single-tenant server may configure
+`webhooks.tenantScope`; otherwise production emission without trusted scope
+fails before durable checkpointing or delivery. Request and payload fields
+never select this namespace.
 
 ### Legacy continuation store upgrade
 

--- a/scripts/generate-agent-docs.ts
+++ b/scripts/generate-agent-docs.ts
@@ -1109,7 +1109,14 @@ function generateLlmsTxt(
   ln(`| \`PricingOption\` | Price model (CPM, vCPM, CPC, CPCV, CPV, CPP, CPA, FlatRate, Time) |`);
   ln(`| \`GovernanceConfig\` | Buyer-side governance middleware config |`);
   ln(
-    `| \`EstablishedProposalStore\` | Durable 3.0/3.1 proposal snapshots, atomic mutation fences, and submitted-task reconciliation |`
+    `| \`EstablishedProposalStore\` | Durable 3.0/3.1 proposal snapshots, atomic mutation fences, seven-day completion proofs, pruning, and submitted-task reconciliation |`
+  );
+  ln(
+    `| \`WebhooksConfig.tenantScope\` | Explicit trusted webhook namespace for a genuinely single-tenant server; multi-tenant servers derive scope per request |`
+  );
+  ln();
+  ln(
+    `Production webhook publishers may construct an unbound emitter and call \`forTenantScope(trustedTenant)\` before every delivery. Direct unbound \`emit()\` fails before checkpointing or network access. \`createAdcpServer\` derives scope from trusted request context; configure \`webhooks.tenantScope\` only for a genuinely single-tenant factory.`
   );
   ln();
 
@@ -1338,8 +1345,10 @@ function generateTypeSummary(index: SchemaIndex, tools: ToolInfo[]): string {
   ln(
     `type EstablishedProposalTransitionResult = { outcome: 'updated'; records: EstablishedProposalRecord[] } | { outcome: 'missing' | 'conflict' | 'capacity'; records: EstablishedProposalRecord[] };`
   );
+  ln(`const ESTABLISHED_PROPOSAL_COMPLETION_TOMBSTONE_RETENTION_MS = 604800000;`);
+  ln(`interface EstablishedProposalCompletionWindow { completedAt: string; retainUntil: string; }`);
   ln(
-    `interface EstablishedProposalSubmittedOperation { request: EstablishedProposalReserveRequest; records: EstablishedProposalRecord[]; sellerTaskId: string; settled?: boolean; }`
+    `interface EstablishedProposalSubmittedOperation { request: EstablishedProposalReserveRequest; records: EstablishedProposalRecord[]; sellerTaskId: string; settled?: boolean; completion?: EstablishedProposalCompletionWindow; }`
   );
   ln();
   ln(`interface EstablishedProposalStore {`);
@@ -1354,6 +1363,9 @@ function generateTypeSummary(index: SchemaIndex, tools: ToolInfo[]): string {
   ln(
     `  findSubmittedTask(scope: EstablishedProposalTaskScope, sellerTaskId: string): Promise<EstablishedProposalSubmittedOperation | undefined>;`
   );
+  ln(
+    `  /** Any retained tombstone with this operationKey returns conflict, even if claim or binding evidence differs. */`
+  );
   ln(`  reserveMutation(request: EstablishedProposalReserveRequest): Promise<EstablishedProposalReserveResult>;`);
   ln(
     `  completeMutation(request: EstablishedProposalReserveRequest, disposition: 'accepted', terminalResultFingerprint: string): Promise<EstablishedProposalTransitionResult>;`
@@ -1364,6 +1376,7 @@ function generateTypeSummary(index: SchemaIndex, tools: ToolInfo[]): string {
   ln(
     `  completeDecline(request: EstablishedProposalReserveRequest, retainedBindings?: readonly EstablishedProposalMutationBinding[]): Promise<EstablishedProposalTransitionResult>;`
   );
+  ln(`  pruneCompletionTombstones?(limit?: number): Promise<number>;`);
   ln(`  releaseMutation(request: EstablishedProposalReserveRequest): Promise<EstablishedProposalTransitionResult>;`);
   ln(
     `  recordSubmittedTask(request: EstablishedProposalReserveRequest, sellerTaskId: string): Promise<EstablishedProposalTransitionResult>;`
@@ -1374,6 +1387,44 @@ function generateTypeSummary(index: SchemaIndex, tools: ToolInfo[]): string {
   ln(`}`);
   ln();
   ln(`// After restart: lifecycle.reconcileEstablishedProposalTask({ account, sellerTaskId })`);
+  ln('```');
+  ln();
+
+  ln(`## Production Webhook Tenant Binding`);
+  ln();
+  ln(
+    `An unbound production \`WebhookEmitter\` is safe to construct with a stable \`publisherScope\`, durable delivery store, and durable recovery outbox. It refuses direct emission until trusted tenant scope is bound:`
+  );
+  ln();
+  ln('```typescript');
+  ln(`interface WebhookEmitter {`);
+  ln(`  emit(params: WebhookEmitParams): Promise<WebhookEmitResult>;`);
+  ln(`  forTenantScope(tenantScope: string): WebhookEmitter;`);
+  ln(`}`);
+  ln();
+  ln(`// Relevant WebhooksConfig fields (other signing and delivery fields omitted):`);
+  ln(`interface WebhooksConfig {`);
+  ln(`  publisherScope?: string; // defaults to the trusted server name`);
+  ln(`  tenantScope?: string;    // explicit trusted single-tenant fallback only`);
+  ln(`}`);
+  ln();
+  ln(
+    `const publisher = createWebhookEmitter({ publisherScope: 'publisher', deliveryStore, deliveryRecovery, signerKey });`
+  );
+  ln(`await publisher.forTenantScope(authenticatedTenant).emit(params);`);
+  ln();
+  ln(`createAdcpServer({`);
+  ln(`  name: 'publisher',`);
+  ln(`  version: '1.0.0',`);
+  ln(`  // Multi-tenant: omit tenantScope; trusted request context is required.`);
+  ln(`  webhooks: { signerKey, deliveryStore, deliveryRecovery },`);
+  ln(`});`);
+  ln(`createAdcpServer({`);
+  ln(`  name: 'publisher',`);
+  ln(`  version: '1.0.0',`);
+  ln(`  // Genuinely single-tenant: configure the trusted fallback explicitly.`);
+  ln(`  webhooks: { signerKey, deliveryStore, deliveryRecovery, tenantScope: 'tenant-a' },`);
+  ln(`});`);
   ln('```');
   ln();
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -368,7 +368,9 @@ export {
 export {
   InMemoryEstablishedProposalStore,
   createInMemoryEstablishedProposalStore,
+  ESTABLISHED_PROPOSAL_COMPLETION_TOMBSTONE_RETENTION_MS,
   type EstablishedProposalBinding,
+  type EstablishedProposalCompletionWindow,
   type EstablishedProposalMutationClaim,
   type EstablishedProposalMutationBinding,
   type EstablishedProposalMutationIntent,

--- a/src/lib/media-buy/established-proposal-store.ts
+++ b/src/lib/media-buy/established-proposal-store.ts
@@ -2,6 +2,9 @@ export type EstablishedProposalSourceVersion = '3.0' | '3.1';
 export type EstablishedProposalMutationKind = 'accept' | 'refine' | 'decline';
 export type EstablishedProposalMutationDisposition = 'accepted' | 'refined' | 'declined' | 'commit-uncertain';
 
+/** Minimum replay/restart horizon for completed refinement and decline proofs. */
+export const ESTABLISHED_PROPOSAL_COMPLETION_TOMBSTONE_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
+
 export interface EstablishedProposalScope {
   /** Stable, server-controlled authenticated principal identity. Never a credential. */
   principalScope: string;
@@ -95,6 +98,15 @@ export interface EstablishedProposalSubmittedOperation {
   sellerTaskId: string;
   /** True when a bounded completion tombstone is servicing an idempotent reconciliation retry. */
   settled?: boolean;
+  /** Present when recovery was served by a completion tombstone. */
+  completion?: EstablishedProposalCompletionWindow;
+}
+
+export interface EstablishedProposalCompletionWindow {
+  /** Store-authoritative completion time. */
+  completedAt: string;
+  /** Earliest instant at which the completion proof may be pruned. */
+  retainUntil: string;
 }
 
 /**
@@ -139,6 +151,12 @@ export interface EstablishedProposalStore {
     scope: EstablishedProposalTaskScope,
     sellerTaskId: string
   ): Promise<EstablishedProposalSubmittedOperation | undefined>;
+  /**
+   * Atomically reserve the supplied mutation. Any retained completion
+   * tombstone with the same `operationKey` must return `conflict`, even when
+   * claim or binding evidence differs; an operation-identity collision must
+   * never authorize redispatch.
+   */
   reserveMutation(request: EstablishedProposalReserveRequest): Promise<EstablishedProposalReserveResult>;
   completeMutation(
     request: EstablishedProposalReserveRequest,
@@ -156,6 +174,22 @@ export interface EstablishedProposalStore {
     request: EstablishedProposalReserveRequest,
     retainedBindings?: readonly EstablishedProposalMutationBinding[]
   ): Promise<EstablishedProposalTransitionResult>;
+  /**
+   * Delete completion tombstones whose store-authored `retainUntil` is at or
+   * before the store's current time. Implementations must never prune earlier
+   * than `ESTABLISHED_PROPOSAL_COMPLETION_TOMBSTONE_RETENTION_MS` after
+   * completion. After pruning, `findSubmittedTask` may return `undefined` and
+   * `reserveMutation` may return any result justified by the remaining source
+   * records (including a fresh reservation when every source was restored).
+   * `limit` is the maximum number of tombstones deleted in one call; ordering
+   * is unspecified. Return the number of deletions committed. Durable stores
+   * must select eligible rows and delete them atomically using one transaction
+   * and one backing-store clock snapshot.
+   *
+   * Optional for backward compatibility; durable implementations should
+   * implement this or provide an equivalent database-owned sweeper.
+   */
+  pruneCompletionTombstones?(limit?: number): Promise<number>;
   /**
    * Release an exact reserved/retryable claim, or an exact terminal
    * `commit-uncertain` claim after authoritative seller failure evidence.
@@ -176,6 +210,16 @@ export interface InMemoryEstablishedProposalStoreOptions {
   maxRecords?: number;
   maxBytes?: number;
   clock?: () => Date;
+  /** Must be at least the protocol-owned seven-day minimum. */
+  completionTombstoneRetentionMs?: number;
+}
+
+interface InMemoryCompletionTombstone extends EstablishedProposalCompletionWindow {
+  requestSignature: string;
+  replacementSignature: string;
+  request: EstablishedProposalReserveRequest;
+  sellerTaskId?: string;
+  records: EstablishedProposalRecord[];
 }
 
 function clone<T>(value: T): T {
@@ -235,32 +279,46 @@ export class InMemoryEstablishedProposalStore implements EstablishedProposalStor
   private readonly recordBytes = new Map<string, number>();
   private readonly operationIndex = new Map<string, readonly string[]>();
   private readonly proposalMutationIndex = new Map<string, string>();
-  private readonly completedRefinements = new Map<
-    string,
-    {
-      requestSignature: string;
-      replacementSignature: string;
-      request: EstablishedProposalReserveRequest;
-      sellerTaskId?: string;
-      records: EstablishedProposalRecord[];
-    }
-  >();
+  private readonly completedRefinements = new Map<string, InMemoryCompletionTombstone>();
   private completedRefinementBytes = 0;
   private totalBytes = 0;
   private readonly maxRecords: number;
   private readonly maxBytes: number;
   private readonly clock: () => Date;
+  private readonly completionTombstoneRetentionMs: number;
 
   constructor(options: InMemoryEstablishedProposalStoreOptions = {}) {
     this.maxRecords = options.maxRecords ?? 256;
     this.maxBytes = options.maxBytes ?? 4 * 1024 * 1024;
     this.clock = options.clock ?? (() => new Date());
+    this.completionTombstoneRetentionMs =
+      options.completionTombstoneRetentionMs ?? ESTABLISHED_PROPOSAL_COMPLETION_TOMBSTONE_RETENTION_MS;
     if (!Number.isSafeInteger(this.maxRecords) || this.maxRecords <= 0) {
       throw new TypeError('maxRecords must be a positive safe integer.');
     }
     if (!Number.isSafeInteger(this.maxBytes) || this.maxBytes <= 0) {
       throw new TypeError('maxBytes must be a positive safe integer.');
     }
+    if (
+      !Number.isSafeInteger(this.completionTombstoneRetentionMs) ||
+      this.completionTombstoneRetentionMs < ESTABLISHED_PROPOSAL_COMPLETION_TOMBSTONE_RETENTION_MS
+    ) {
+      throw new TypeError(
+        `completionTombstoneRetentionMs must be a safe integer of at least ${ESTABLISHED_PROPOSAL_COMPLETION_TOMBSTONE_RETENTION_MS}.`
+      );
+    }
+  }
+
+  private completionWindow(): EstablishedProposalCompletionWindow {
+    const completedAtMs = this.clock().getTime();
+    const retainUntilMs = completedAtMs + this.completionTombstoneRetentionMs;
+    if (!Number.isFinite(completedAtMs) || retainUntilMs > 8_640_000_000_000_000) {
+      throw new TypeError('clock must return a valid Date within the supported completion retention range.');
+    }
+    return {
+      completedAt: new Date(completedAtMs).toISOString(),
+      retainUntil: new Date(retainUntilMs).toISOString(),
+    };
   }
 
   private sizeOf(record: EstablishedProposalRecord): number {
@@ -375,6 +433,7 @@ export class InMemoryEstablishedProposalStore implements EstablishedProposalStor
         records: completed.records,
         sellerTaskId,
         settled: true,
+        completion: { completedAt: completed.completedAt, retainUntil: completed.retainUntil },
       });
     }
     const matched = [...this.records.values()].find(
@@ -427,12 +486,7 @@ export class InMemoryEstablishedProposalStore implements EstablishedProposalStor
     const bindingKeys = [...new Set(request.bindings.map(key))].sort();
     if (bindingKeys.length === 0) return { outcome: 'missing', records: [] };
     const completed = this.completedRefinements.get(request.claim.operationKey);
-    if (
-      completed &&
-      completed.request.claim.operation === request.claim.operation &&
-      completed.request.claim.requestFingerprint === request.claim.requestFingerprint &&
-      completed.request.claim.idempotencyKey === request.claim.idempotencyKey
-    ) {
+    if (completed) {
       return { outcome: 'conflict', records: completed.records.map(clone) };
     }
     const records = bindingKeys.flatMap(recordKey => {
@@ -739,12 +793,13 @@ export class InMemoryEstablishedProposalStore implements EstablishedProposalStor
         ? []
         : [record.operation.sellerTaskId]
     )[0];
-    const tombstone = {
+    const tombstone: InMemoryCompletionTombstone = {
       requestSignature,
       replacementSignature,
       request: clone(request),
       ...(sellerTaskId && { sellerTaskId }),
       records: updated.map(clone),
+      ...this.completionWindow(),
     };
     const tombstoneBytes = Buffer.byteLength(JSON.stringify(tombstone), 'utf8');
     if (
@@ -842,12 +897,13 @@ export class InMemoryEstablishedProposalStore implements EstablishedProposalStor
         ? []
         : [record.operation.sellerTaskId]
     )[0];
-    const tombstone = {
+    const tombstone: InMemoryCompletionTombstone = {
       requestSignature,
       replacementSignature,
       request: clone(request),
       ...(sellerTaskId && { sellerTaskId }),
       records: updated.map(clone),
+      ...this.completionWindow(),
     };
     const tombstoneBytes = Buffer.byteLength(JSON.stringify(tombstone), 'utf8');
     if (
@@ -869,6 +925,24 @@ export class InMemoryEstablishedProposalStore implements EstablishedProposalStor
       }
     }
     return { outcome: 'updated', records: updated.map(clone) };
+  }
+
+  async pruneCompletionTombstones(limit = 1_000): Promise<number> {
+    if (!Number.isSafeInteger(limit) || limit <= 0) {
+      throw new TypeError('pruneCompletionTombstones limit must be a positive safe integer.');
+    }
+    const now = this.clock().getTime();
+    if (!Number.isFinite(now)) throw new TypeError('clock must return a valid Date.');
+    let pruned = 0;
+    for (const [operationKey, tombstone] of this.completedRefinements) {
+      if (pruned >= limit) break;
+      const retainUntil = Date.parse(tombstone.retainUntil);
+      if (!Number.isFinite(retainUntil) || retainUntil > now) continue;
+      this.completedRefinements.delete(operationKey);
+      this.completedRefinementBytes -= Buffer.byteLength(JSON.stringify(tombstone), 'utf8');
+      pruned += 1;
+    }
+    return pruned;
   }
 
   async releaseMutation(request: EstablishedProposalReserveRequest): Promise<EstablishedProposalTransitionResult> {
@@ -969,6 +1043,6 @@ export class InMemoryEstablishedProposalStore implements EstablishedProposalStor
 
 export function createInMemoryEstablishedProposalStore(
   options: InMemoryEstablishedProposalStoreOptions = {}
-): EstablishedProposalStore {
+): InMemoryEstablishedProposalStore {
   return new InMemoryEstablishedProposalStore(options);
 }

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -1596,6 +1596,8 @@ export type WebhooksConfig = Pick<
 > & {
   /** Stable publisher namespace for shared delivery-store keys. Defaults to the trusted server name. */
   publisherScope?: string;
+  /** Trusted fallback namespace for a genuinely single-tenant server. */
+  tenantScope?: string;
   /** Observability: emitter-wide onAttempt hook. */
   onAttempt?: WebhookEmitterOptions['onAttempt'];
   /** Observability: emitter-wide onAttemptResult hook. */
@@ -2745,7 +2747,7 @@ function taskOwnerScopeForContext(
  * never participate, so one tenant cannot preclaim another tenant's delivery
  * binding in a shared durable store.
  */
-function webhookTenantScopeForContext<TAccount>(ctx: HandlerContext<TAccount>): string {
+function webhookTenantScopeForContext<TAccount>(ctx: HandlerContext<TAccount>): string | undefined {
   if (ctx.callerMutationScope) {
     return JSON.stringify([
       'caller',
@@ -2777,7 +2779,7 @@ function webhookTenantScopeForContext<TAccount>(ctx: HandlerContext<TAccount>): 
     return JSON.stringify(['account', tenantId ?? null, accountId ?? null, principal ?? null]);
   }
   if (principal !== undefined) return JSON.stringify(['principal', principal]);
-  return 'single-tenant';
+  return undefined;
 }
 
 function compareProtocolTaskItems(
@@ -4909,10 +4911,15 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
     ? createWebhookEmitter({
         ...webhooks,
         publisherScope: webhooks.publisherScope ?? name,
-        // Rebound to a trusted request-derived scope before handler dispatch.
-        tenantScope: 'single-tenant',
+        // Intentionally unbound until handler dispatch derives trusted scope.
+        tenantScope: undefined,
       })
     : undefined;
+  const configuredWebhookTenantScope = webhooks?.tenantScope;
+  const configuredWebhookEmitter =
+    webhookEmitter && configuredWebhookTenantScope !== undefined
+      ? webhookEmitter.forTenantScope(configuredWebhookTenantScope)
+      : webhookEmitter;
 
   // Resolve `instructions` — sync function form is evaluated at construction.
   // Under `serve({ reuseAgent: false })` (the default) the factory runs
@@ -6379,7 +6386,9 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
         let mutationHandlerCompleted = false;
         try {
           if (webhookEmitter) {
-            const scopedEmitter = webhookEmitter.forTenantScope(webhookTenantScopeForContext(ctx));
+            const tenantScope = webhookTenantScopeForContext(ctx);
+            const scopedEmitter =
+              tenantScope === undefined ? configuredWebhookEmitter! : webhookEmitter.forTenantScope(tenantScope);
             ctx.emitWebhook = scopedEmitter.emit.bind(scopedEmitter);
           }
           const result = await handler(params, ctx);

--- a/src/lib/server/webhook-emitter.ts
+++ b/src/lib/server/webhook-emitter.ts
@@ -261,9 +261,10 @@ export interface WebhookEmitterOptions {
    */
   publisherScope?: string;
   /**
-   * Stable tenant namespace for direct emitter callers. Production direct
-   * callers MUST set it. `createAdcpServer` derives it from resolved trusted
-   * request context and never from webhook payload fields.
+   * Stable tenant namespace for direct emitter callers. A production emitter
+   * that omits it is intentionally unbound: direct `emit()` calls fail until
+   * `forTenantScope()` supplies trusted scope. `createAdcpServer` derives that
+   * scope from resolved request context and never from webhook payload fields.
    */
   tenantScope?: string;
   /**
@@ -405,23 +406,29 @@ export function createWebhookEmitter(options: WebhookEmitterOptions): WebhookEmi
         'to checkpoint exact retry state before the first attempt'
     );
   }
-  if (production && (!options.publisherScope || !options.tenantScope)) {
-    throw new TypeError(
-      'createWebhookEmitter: production direct emitters require non-empty publisherScope and tenantScope'
-    );
+  if (production && !options.publisherScope) {
+    throw new TypeError('createWebhookEmitter: production webhook emitters require a non-empty publisherScope');
   }
   const publisherScope = requireScope(options.publisherScope ?? 'development-publisher', 'publisherScope');
-  const tenantScope = requireScope(options.tenantScope ?? 'development-tenant', 'tenantScope');
+  const tenantScope =
+    options.tenantScope === undefined && production
+      ? undefined
+      : requireScope(options.tenantScope ?? 'development-tenant', 'tenantScope');
   const generateKey = options.generateIdempotencyKey ?? defaultGenerateIdempotencyKey;
   const fetchImpl = options.fetch ?? createPinAndBindFetch();
   const sleep = options.sleep ?? defaultSleep;
   const now = options.now ?? Date.now;
 
-  const makeEmitter = (boundTenantScope: string): WebhookEmitter => ({
+  const makeEmitter = (boundTenantScope: string | undefined): WebhookEmitter => ({
     forTenantScope(nextTenantScope: string): WebhookEmitter {
       return makeEmitter(requireScope(nextTenantScope, 'tenantScope'));
     },
     async emit(params: WebhookEmitParams): Promise<WebhookEmitResult> {
+      if (boundTenantScope === undefined) {
+        throw new TypeError(
+          'WebhookEmitter.emit: production emitter is not tenant-bound; call forTenantScope(trustedTenant) before emit()'
+        );
+      }
       // Snapshot every caller-owned value before the first await. A slow
       // durable claim must not let post-invocation mutation change identity,
       // destination, authentication, or retry policy.

--- a/test/lib/established-proposal-store.test.js
+++ b/test/lib/established-proposal-store.test.js
@@ -1,7 +1,10 @@
 const { describe, test } = require('node:test');
 const assert = require('node:assert/strict');
 
-const { createInMemoryEstablishedProposalStore } = require('../../dist/lib/index.js');
+const {
+  createInMemoryEstablishedProposalStore,
+  ESTABLISHED_PROPOSAL_COMPLETION_TOMBSTONE_RETENTION_MS,
+} = require('../../dist/lib/index.js');
 
 const scope = {
   principalScope: 'buyer-tenant-1',
@@ -401,6 +404,129 @@ describe('InMemoryEstablishedProposalStore', () => {
         idempotencyKey: `${operation}-unable-key-0002`,
       });
       assert.equal((await store.reserveMutation(next)).outcome, 'reserved');
+    }
+  });
+
+  test('retains completion proofs through the minimum horizon and prunes them at the boundary', async () => {
+    for (const operation of ['refine', 'decline']) {
+      let now = Date.parse('2026-08-22T00:00:00.000Z');
+      const store = createInMemoryEstablishedProposalStore({ clock: () => new Date(now) });
+      const entry = snapshot(`retained-completion-${operation}`);
+      await store.putSnapshot(entry);
+      const mutation = request(entry, {
+        operation,
+        operationKey: `retained-completion-${operation}-operation`,
+        requestFingerprint: `retained-completion-${operation}-request`,
+        idempotencyKey: `retained-completion-${operation}-key`,
+      });
+      await store.reserveMutation(mutation);
+      await store.recordSubmittedTask(mutation, `retained-completion-${operation}-task`);
+      const completion =
+        operation === 'refine'
+          ? await store.completeRefinement(mutation, [], mutation.bindings)
+          : await store.completeDecline(mutation, mutation.bindings);
+      assert.equal(completion.outcome, 'updated');
+
+      now += ESTABLISHED_PROPOSAL_COMPLETION_TOMBSTONE_RETENTION_MS - 1;
+      assert.equal(await store.pruneCompletionTombstones(), 0);
+      assert.equal((await store.reserveMutation(mutation)).outcome, 'conflict');
+      const conflictingReuse = request(entry, {
+        operation,
+        operationKey: mutation.claim.operationKey,
+        requestFingerprint: `retained-completion-${operation}-changed-request`,
+        idempotencyKey: `retained-completion-${operation}-changed-key`,
+      });
+      assert.equal((await store.reserveMutation(conflictingReuse)).outcome, 'conflict');
+      const recovered = await store.findSubmittedTask(
+        { ...scope, accountScope: entry.accountScope },
+        `retained-completion-${operation}-task`
+      );
+      assert.equal(recovered.settled, true);
+      assert.deepEqual(recovered.completion, {
+        completedAt: '2026-08-22T00:00:00.000Z',
+        retainUntil: new Date(
+          Date.parse('2026-08-22T00:00:00.000Z') + ESTABLISHED_PROPOSAL_COMPLETION_TOMBSTONE_RETENTION_MS
+        ).toISOString(),
+      });
+
+      now += 1;
+      assert.equal(await store.pruneCompletionTombstones(), 1);
+      assert.equal(
+        await store.findSubmittedTask(
+          { ...scope, accountScope: entry.accountScope },
+          `retained-completion-${operation}-task`
+        ),
+        undefined
+      );
+      assert.equal((await store.reserveMutation(mutation)).outcome, 'reserved');
+    }
+  });
+
+  test('rejects completion retention below the protocol-owned minimum', () => {
+    assert.throws(
+      () =>
+        createInMemoryEstablishedProposalStore({
+          completionTombstoneRetentionMs: ESTABLISHED_PROPOSAL_COMPLETION_TOMBSTONE_RETENTION_MS - 1,
+        }),
+      /completionTombstoneRetentionMs must be a safe integer of at least/
+    );
+  });
+
+  test('prunes at most the requested limit and rejects invalid limits', async () => {
+    let now = Date.parse('2026-08-22T00:00:00.000Z');
+    const store = createInMemoryEstablishedProposalStore({ clock: () => new Date(now) });
+    for (const suffix of ['a', 'b']) {
+      const entry = snapshot(`limited-prune-${suffix}`);
+      await store.putSnapshot(entry);
+      const mutation = request(entry, {
+        operation: 'decline',
+        operationKey: `limited-prune-${suffix}-operation`,
+        requestFingerprint: `limited-prune-${suffix}-request`,
+        idempotencyKey: `limited-prune-${suffix}-key`,
+      });
+      assert.equal((await store.reserveMutation(mutation)).outcome, 'reserved');
+      assert.equal((await store.completeDecline(mutation, mutation.bindings)).outcome, 'updated');
+    }
+
+    now += ESTABLISHED_PROPOSAL_COMPLETION_TOMBSTONE_RETENTION_MS;
+    assert.equal(await store.pruneCompletionTombstones(1), 1);
+    assert.equal(await store.pruneCompletionTombstones(1), 1);
+    assert.equal(await store.pruneCompletionTombstones(1), 0);
+
+    for (const invalid of [0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1, Number.NaN]) {
+      await assert.rejects(store.pruneCompletionTombstones(invalid), /limit must be a positive safe integer/);
+    }
+  });
+
+  test('pruning task recovery never reauthorizes consumed refinement or decline sources', async () => {
+    for (const operation of ['refine', 'decline']) {
+      let now = Date.parse('2026-08-22T00:00:00.000Z');
+      const store = createInMemoryEstablishedProposalStore({ clock: () => new Date(now) });
+      const entry = snapshot(`consumed-completion-${operation}`);
+      await store.putSnapshot(entry);
+      const mutation = request(entry, {
+        operation,
+        operationKey: `consumed-completion-${operation}-operation`,
+        requestFingerprint: `consumed-completion-${operation}-request`,
+        idempotencyKey: `consumed-completion-${operation}-key`,
+      });
+      await store.reserveMutation(mutation);
+      await store.recordSubmittedTask(mutation, `consumed-completion-${operation}-task`);
+      const completion =
+        operation === 'refine' ? await store.completeRefinement(mutation, []) : await store.completeDecline(mutation);
+      assert.equal(completion.outcome, 'updated');
+
+      now += ESTABLISHED_PROPOSAL_COMPLETION_TOMBSTONE_RETENTION_MS;
+      assert.equal(await store.pruneCompletionTombstones(), 1);
+      assert.equal(
+        await store.findSubmittedTask(
+          { ...scope, accountScope: entry.accountScope },
+          `consumed-completion-${operation}-task`
+        ),
+        undefined
+      );
+      assert.equal((await store.reserveMutation(mutation)).outcome, 'terminal');
+      assert.equal((await store.get(entry)).operation.disposition, operation === 'refine' ? 'refined' : 'declined');
     }
   });
 

--- a/test/lib/media-buy-lifecycle-coordinator.test.js
+++ b/test/lib/media-buy-lifecycle-coordinator.test.js
@@ -12,6 +12,7 @@ const {
   MemoryStorage,
   MediaBuyLifecycleCompatibilityError,
   createInMemoryEstablishedProposalStore,
+  ESTABLISHED_PROPOSAL_COMPLETION_TOMBSTONE_RETENTION_MS,
   ProtocolClient,
   createInMemoryLegacyPurchaseContinuationStore,
   legacyPurchaseSettlementFingerprint,
@@ -4795,7 +4796,8 @@ describe('durable established proposal compatibility', () => {
 
   test('fresh coordinators reconcile submitted refine and unable-decline results', async () => {
     for (const operation of ['refine', 'decline']) {
-      const store = createInMemoryEstablishedProposalStore();
+      let storeNow = Date.parse('2026-08-23T00:00:00.000Z');
+      const store = createInMemoryEstablishedProposalStore({ clock: () => new Date(storeNow) });
       const terms = {
         brand: { domain: 'example.com' },
         start_time: '2027-01-01T00:00:00Z',
@@ -4884,6 +4886,34 @@ describe('durable established proposal compatibility', () => {
         ).status,
         'completed'
       );
+
+      const settledAgent = clientWithCaps(capabilities({ version: '3.1' }));
+      settledAgent.getTaskStatus = async () => assert.fail('retained completion proof must avoid seller polling');
+      const settled = await settledAgent.negotiateMediaBuyLifecycle(options);
+      assert.equal(
+        (
+          await settled.reconcileEstablishedProposalTask({
+            account: { account_id: 'account-1' },
+            sellerTaskId: `seller-${operation}-task`,
+          })
+        ).status,
+        'completed'
+      );
+      settled.dispose();
+
+      storeNow += ESTABLISHED_PROPOSAL_COMPLETION_TOMBSTONE_RETENTION_MS;
+      assert.equal(await store.pruneCompletionTombstones(), 1);
+      const prunedAgent = clientWithCaps(capabilities({ version: '3.1' }));
+      prunedAgent.getTaskStatus = async () => assert.fail('pruned recovery must fail before seller polling');
+      const pruned = await prunedAgent.negotiateMediaBuyLifecycle(options);
+      await assert.rejects(
+        pruned.reconcileEstablishedProposalTask({
+          account: { account_id: 'account-1' },
+          sellerTaskId: `seller-${operation}-task`,
+        }),
+        /No submitted established proposal mutation exists/
+      );
+      pruned.dispose();
 
       const acceptAgent = clientWithCaps(capabilities({ version: '3.1' }));
       acceptAgent.createMediaBuy = async () => durableCreateSuccess(`mb-${operation}`);

--- a/test/lib/webhook-emitter-server-e2e.test.js
+++ b/test/lib/webhook-emitter-server-e2e.test.js
@@ -15,6 +15,7 @@ const { generateKeyPairSync } = require('node:crypto');
 
 const { createAdcpServer } = require('../../dist/lib/server/create-adcp-server.js');
 const { InMemoryStateStore } = require('../../dist/lib/server/state-store.js');
+const { createIdempotencyStore, memoryBackend } = require('../../dist/lib/server/idempotency/index.js');
 const { memoryWebhookDeliveryStore } = require('../../dist/lib/server/webhook-emitter.js');
 const {
   createPinAndBindFetch,
@@ -168,6 +169,182 @@ describe('createAdcpServer + webhook emitter: full-stack publisher E2E', () => {
     assert.strictEqual(seenEmitWebhook, undefined);
   });
 
+  test('production server binds its unbound publisher from an explicit single-tenant fallback', async () => {
+    const { signerKey } = makeSignerKey();
+    const claimedKeys = [];
+    const deliveryStore = {
+      durability: 'durable',
+      claim(key, proposed, retentionMs) {
+        claimedKeys.push({ ...key });
+        const firstAttemptAtMs = Date.now();
+        return {
+          status: 'bound',
+          ...proposed,
+          firstAttemptAtMs,
+          retainUntilMs: firstAttemptAtMs + retentionMs,
+        };
+      },
+    };
+    const deliveryRecovery = {
+      durability: 'durable',
+      checkpoint() {},
+      settle() {},
+    };
+    const previousNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+    let server;
+    try {
+      server = createAdcpServer({
+        name: 'production-publisher',
+        version: '1.0.0',
+        stateStore: new InMemoryStateStore(),
+        idempotency: createIdempotencyStore({ backend: memoryBackend({ sweepIntervalMs: 0 }) }),
+        resolveIdempotencyPrincipal: () => 'trusted-principal',
+        webhooks: {
+          signerKey,
+          deliveryStore,
+          deliveryRecovery,
+          tenantScope: 'single-tenant',
+          fetch: async () => new Response(null, { status: 204 }),
+        },
+        mediaBuy: {
+          createMediaBuy: async (_params, ctx) => {
+            await ctx.emitWebhook({ url: 'https://buyer.example/status', payload: {}, delivery_id: 'delivery-1' });
+            return { media_buy_id: 'mb_production', packages: [] };
+          },
+        },
+      });
+    } finally {
+      if (previousNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = previousNodeEnv;
+    }
+
+    const result = await callTool(server, 'create_media_buy', {
+      account: { brand: { domain: 'acme.example' }, operator: 'op.example' },
+      brand: { domain: 'acme.example' },
+      start_time: '2026-05-01T00:00:00Z',
+      end_time: '2026-05-31T23:59:59Z',
+      packages: [{ product_id: 'p1', budget: 5000, pricing_option_id: 'po-1' }],
+      idempotency_key: 'production_create_key_01',
+      push_notification_config: { url: 'https://buyer.example/status' },
+    });
+
+    assert.strictEqual(result.media_buy_id, 'mb_production');
+    assert.deepStrictEqual(claimedKeys, [
+      { publisherScope: 'production-publisher', tenantScope: 'single-tenant', deliveryId: 'delivery-1' },
+    ]);
+  });
+
+  test('production server refuses webhook emission without trusted tenant scope', async () => {
+    const { signerKey } = makeSignerKey();
+    let claims = 0;
+    let checkpoints = 0;
+    let fetches = 0;
+    let emissionError;
+    const deliveryStore = {
+      durability: 'durable',
+      claim(_key, proposed, retentionMs) {
+        claims += 1;
+        const firstAttemptAtMs = Date.now();
+        return {
+          status: 'bound',
+          ...proposed,
+          firstAttemptAtMs,
+          retainUntilMs: firstAttemptAtMs + retentionMs,
+        };
+      },
+    };
+    const deliveryRecovery = {
+      durability: 'durable',
+      checkpoint() {
+        checkpoints += 1;
+      },
+      settle() {},
+    };
+    const previousNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+    let server;
+    try {
+      server = createAdcpServer({
+        name: 'unscoped-production-publisher',
+        version: '1.0.0',
+        stateStore: new InMemoryStateStore(),
+        idempotency: createIdempotencyStore({ backend: memoryBackend({ sweepIntervalMs: 0 }) }),
+        resolveIdempotencyPrincipal: () => 'trusted-principal',
+        webhooks: {
+          signerKey,
+          deliveryStore,
+          deliveryRecovery,
+          fetch: async () => {
+            fetches += 1;
+            return new Response(null, { status: 204 });
+          },
+        },
+        mediaBuy: {
+          createMediaBuy: async (_params, ctx) => {
+            try {
+              await ctx.emitWebhook({
+                url: 'https://buyer.example/status',
+                payload: {},
+                delivery_id: 'unscoped-delivery',
+              });
+            } catch (error) {
+              emissionError = error;
+              throw error;
+            }
+            return { media_buy_id: 'must-not-complete', packages: [] };
+          },
+        },
+      });
+    } finally {
+      if (previousNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = previousNodeEnv;
+    }
+
+    const result = await callTool(server, 'create_media_buy', {
+      account: { brand: { domain: 'acme.example' }, operator: 'op.example' },
+      brand: { domain: 'acme.example' },
+      start_time: '2026-05-01T00:00:00Z',
+      end_time: '2026-05-31T23:59:59Z',
+      packages: [{ product_id: 'p1', budget: 5000, pricing_option_id: 'po-1' }],
+      idempotency_key: 'unscoped_create_key_01',
+      push_notification_config: { url: 'https://buyer.example/status' },
+    });
+
+    assert.match(emissionError.message, /not tenant-bound; call forTenantScope/);
+    assert.strictEqual(result.status, 'failed');
+    assert.strictEqual(claims, 0);
+    assert.strictEqual(checkpoints, 0);
+    assert.strictEqual(fetches, 0);
+  });
+
+  test('production server validates an explicit tenant scope at startup', () => {
+    const { signerKey } = makeSignerKey();
+    const previousNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+    try {
+      const memory = memoryWebhookDeliveryStore();
+      assert.throws(
+        () =>
+          createAdcpServer({
+            name: 'invalid-tenant-scope',
+            version: '1.0.0',
+            stateStore: new InMemoryStateStore(),
+            webhooks: {
+              signerKey,
+              tenantScope: 'invalid\0tenant',
+              deliveryStore: { ...memory, durability: 'durable' },
+              deliveryRecovery: { durability: 'durable', checkpoint() {}, settle() {} },
+            },
+          }),
+        /tenantScope must be a non-empty string without NUL characters/
+      );
+    } finally {
+      if (previousNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = previousNodeEnv;
+    }
+  });
+
   test('production server refuses an implicit in-memory delivery binding store', () => {
     const { signerKey } = makeSignerKey();
     const previousNodeEnv = process.env.NODE_ENV;
@@ -313,6 +490,15 @@ describe('createAdcpServer + webhook emitter: full-stack publisher E2E', () => {
   test('trusted resolved tenant scopes isolate colliding delivery IDs in one shared store', async () => {
     const { signerKey } = makeSignerKey();
     const delivered = [];
+    const claimedKeys = [];
+    const bindings = memoryWebhookDeliveryStore();
+    const deliveryStore = {
+      durability: bindings.durability,
+      claim(key, proposed, retentionMs) {
+        claimedKeys.push({ ...key });
+        return bindings.claim(key, proposed, retentionMs);
+      },
+    };
     const server = createAdcpServer({
       name: 'tenant-scoped-publisher',
       version: '1.0.0',
@@ -320,6 +506,7 @@ describe('createAdcpServer + webhook emitter: full-stack publisher E2E', () => {
       resolveSessionKey: ({ account }) => account.id,
       webhooks: {
         signerKey,
+        deliveryStore,
         fetch: async (_url, init) => {
           delivered.push(JSON.parse(init.body));
           return { status: 204, headers: new Headers() };
@@ -348,5 +535,13 @@ describe('createAdcpServer + webhook emitter: full-stack publisher E2E', () => {
     await callTool(server, 'create_media_buy', request('tenant-b.example'));
     assert.strictEqual(delivered.length, 2);
     assert.notStrictEqual(delivered[0].idempotency_key, delivered[1].idempotency_key);
+    assert.strictEqual(claimedKeys.length, 2);
+    assert.strictEqual(claimedKeys[0].publisherScope, 'tenant-scoped-publisher');
+    assert.strictEqual(claimedKeys[1].publisherScope, 'tenant-scoped-publisher');
+    assert.strictEqual(claimedKeys[0].deliveryId, 'same-local-delivery-id');
+    assert.strictEqual(claimedKeys[1].deliveryId, 'same-local-delivery-id');
+    assert.match(claimedKeys[0].tenantScope, /tenant-a\.example/);
+    assert.match(claimedKeys[1].tenantScope, /tenant-b\.example/);
+    assert.notStrictEqual(claimedKeys[0].tenantScope, claimedKeys[1].tenantScope);
   });
 });

--- a/test/lib/webhook-emitter.test.js
+++ b/test/lib/webhook-emitter.test.js
@@ -800,6 +800,67 @@ describe('createWebhookEmitter: signerKey and signerProvider produce byte-identi
 // ────────────────────────────────────────────────────────────
 
 describe('createWebhookEmitter: construction validation', () => {
+  test('production permits tenant binding after constructing an unbound publisher', async () => {
+    const { signerKey } = makeSignerKey();
+    const fetch = stubFetch([{ status: 204 }]);
+    const records = new Map();
+    const deliveryStore = {
+      durability: 'durable',
+      claim(key, proposed, retentionMs) {
+        const storageKey = JSON.stringify([key.publisherScope, key.tenantScope, key.deliveryId]);
+        const existing = records.get(storageKey);
+        if (existing) return { ...existing };
+        const record = {
+          status: 'bound',
+          ...proposed,
+          firstAttemptAtMs: 1_000,
+          retainUntilMs: 1_000 + retentionMs,
+        };
+        records.set(storageKey, record);
+        return { ...record };
+      },
+    };
+    const recoveryKeys = [];
+    const deliveryRecovery = {
+      durability: 'durable',
+      checkpoint(key) {
+        recoveryKeys.push({ ...key });
+      },
+      settle() {},
+    };
+    const previousNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+    let publisher;
+    try {
+      publisher = createWebhookEmitter({
+        signerKey,
+        fetch,
+        sleep: noSleep,
+        now: () => 1_000,
+        deliveryStore,
+        deliveryRecovery,
+        publisherScope: 'publisher',
+      });
+    } finally {
+      if (previousNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = previousNodeEnv;
+    }
+
+    await assert.rejects(
+      () => publisher.emit({ url: 'http://x/h', payload: {}, delivery_id: 'unbound-delivery' }),
+      /not tenant-bound; call forTenantScope/
+    );
+    const result = await publisher
+      .forTenantScope('trusted-tenant')
+      .emit({ url: 'http://x/h', payload: {}, delivery_id: 'bound-delivery' });
+
+    assert.equal(result.delivered, true);
+    assert.deepEqual(recoveryKeys, [
+      { publisherScope: 'publisher', tenantScope: 'trusted-tenant', deliveryId: 'bound-delivery' },
+    ]);
+    assert.equal(fetch.calls.length, 1);
+  });
+
   test('production rejects an explicit process-local delivery store', () => {
     const { signerKey } = makeSignerKey();
     const previousNodeEnv = process.env.NODE_ENV;


### PR DESCRIPTION
## Summary

- define a durable seven-day completion-tombstone retention and pruning contract for established proposal continuations
- make production webhook emitters bind trusted request-derived tenant scope, with an explicit single-tenant fallback and fail-closed unscoped behavior
- add restart, pruning-boundary, tenant-isolation, and pre-durable-state regression coverage
- document PostgreSQL backfill, indexing, sweeper, and adopter migration requirements

Closes #2655
Closes #2656

## Verification

- `npm run build`
- `npm run typecheck`
- 343 focused lifecycle/webhook tests
- `npm run generate-agent-docs` (idempotent)
- `git diff --check origin/main --`
- protocol, security, code/DX, and independent Codex review stacks converged with no remaining findings