### PR TITLE
fix(async): complete beta.5 webhook convergence

### DIFF
--- a/.changeset/warm-webhooks-converge.md
+++ b/.changeset/warm-webhooks-converge.md
@@ -1,0 +1,9 @@
+---
+'@adcp/sdk': patch
+---
+
+Complete AdCP 3.2.0-beta.5 async adoption: carry buyer operation IDs in
+application-layer webhook registration across MCP and A2A, reject malformed
+beta.5 registrations before seller dispatch, converge terminal re-emissions
+across delivery keys, and preserve failed or rejected task artifacts when
+polling with `include_result`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,13 +103,31 @@ if (!artifact.name) { ... }
 
 Used for receiving task completion/progress notifications. Placement differs by protocol:
 
-- **A2A Protocol**: Goes in `params.configuration.pushNotificationConfig` (camelCase)
+- **AdCP 3.2.0-beta.5 on A2A**: Goes in skill parameters as
+  `push_notification_config` (snake_case), including `operation_id`. The native
+  A2A `params.configuration.pushNotificationConfig` is a distinct transport
+  facility; the SDK may retain it for compatibility, but it does not replace
+  the AdCP application-layer field.
 
   ```typescript
   await a2aClient.sendMessage({
-    message: { /* task content */ },
+    message: {
+      parts: [{
+        kind: 'data',
+        data: {
+          skill: 'create_media_buy',
+          parameters: {
+            push_notification_config: {
+              url: webhookUrl,
+              operation_id: operationId
+            }
+          }
+        }
+      }]
+    },
+    // Optional native A2A configuration remains separate.
     configuration: {
-      pushNotificationConfig: {  // ← For async task status
+      pushNotificationConfig: {
         url: webhookUrl,
         token?: clientToken,
         authentication: { schemes: ['HMAC-SHA256'], credentials: secret }
@@ -118,13 +136,15 @@ Used for receiving task completion/progress notifications. Placement differs by 
   });
   ```
 
-- **MCP Protocol**: Goes in tool arguments as `push_notification_config` (snake_case)
+- **MCP Protocol (remote or in-process)**: Goes in tool arguments as
+  `push_notification_config` (snake_case)
   ```typescript
   await mcpClient.callTool('create_media_buy', {
     buyer_ref: '...',
     packages: [...],
     push_notification_config: {  // ← For async task status
       url: webhookUrl,
+      operation_id: operationId,
       token?: clientToken,
       authentication: { schemes: ['HMAC-SHA256'], credentials: secret }
     }

--- a/docs/guides/PUSH-NOTIFICATION-CONFIG.md
+++ b/docs/guides/PUSH-NOTIFICATION-CONFIG.md
@@ -1,6 +1,6 @@
 # Push Notification Config
 
-Push notification config tells the AdCP agent where to send async task status updates via webhook. It is automatically injected by the client at the transport layer — you do not set it per-request.
+Push notification config tells the AdCP agent where to send async task status updates via webhook. In AdCP 3.2.0-beta.5 it is application-layer request data on MCP, A2A, and REST. The client injects it automatically when `webhookUrlTemplate` is configured.
 
 ## How It Works
 
@@ -21,7 +21,8 @@ The default RFC 9421 registration has no `authentication` block:
 ```json
 {
   "push_notification_config": {
-    "url": "https://your-app.com/adcp/webhook/create_media_buy/agent_123/cd51e063-2b79-4a6d-afac-ed7789c3a443"
+    "url": "https://your-app.com/adcp/webhook/create_media_buy/agent_123/cd51e063-2b79-4a6d-afac-ed7789c3a443",
+    "operation_id": "cd51e063-2b79-4a6d-afac-ed7789c3a443"
   }
 }
 ```
@@ -32,6 +33,7 @@ Setting `webhookSecret` opts into the legacy shape:
 {
   "push_notification_config": {
     "url": "https://your-app.com/adcp/webhook/create_media_buy/agent_123/cd51e063-2b79-4a6d-afac-ed7789c3a443",
+    "operation_id": "cd51e063-2b79-4a6d-afac-ed7789c3a443",
     "authentication": {
       "schemes": ["HMAC-SHA256"],
       "credentials": "your-hmac-secret-min-32-characters-here"
@@ -67,6 +69,7 @@ Setting `webhookSecret` opts into the legacy shape:
     },
     "push_notification_config": {
       "url": "https://your-app.com/adcp/webhook/create_media_buy/agent_123/cd51e063-2b79-4a6d-afac-ed7789c3a443",
+      "operation_id": "cd51e063-2b79-4a6d-afac-ed7789c3a443",
       "authentication": {
         "schemes": ["HMAC-SHA256"],
         "credentials": "your-hmac-secret-min-32-characters-here"
@@ -85,6 +88,7 @@ Setting `webhookSecret` opts into the legacy shape:
     "creatives": [...],
     "push_notification_config": {
       "url": "https://your-app.com/adcp/webhook/sync_creatives/agent_123/f3a9b2c1-1234-5678-abcd-ef0123456789",
+      "operation_id": "f3a9b2c1-1234-5678-abcd-ef0123456789",
       "authentication": {
         "schemes": ["HMAC-SHA256"],
         "credentials": "your-hmac-secret-min-32-characters-here"
@@ -101,7 +105,25 @@ Setting `webhookSecret` opts into the legacy shape:
 | Purpose | Task status updates (submitted, complete, failed) | Ongoing campaign delivery metrics |
 | Operations | All async operations | `create_media_buy` only |
 | Frequency | Per task lifecycle event | Hourly / daily / monthly |
-| Set by | Client auto-injects | Client auto-injects |
+| Set by | Client auto-injects | Caller supplies in task parameters |
+
+On A2A, this AdCP registration stays in the skill parameters as
+`push_notification_config`. It is distinct from A2A's native
+`configuration.pushNotificationConfig`; the SDK retains native A2A
+configuration for transport compatibility without treating it as a substitute
+for the application-layer registration. In-process MCP receives the same AdCP
+argument as remote MCP.
+
+For beta.5, sellers reject a registration whose `operation_id` is missing or
+does not match `^[A-Za-z0-9_.:-]{1,255}$`. The SDK reuses the operation identity
+created by `TaskExecutor`, so the request, registration record, webhook route,
+and returned webhook envelope all correlate on the same value.
+
+As with MCP, a modern governed A2A request cannot disclose an HMAC credential
+to the governance service while also authorizing the exact seller argument
+object. The SDK fails closed for that combination; use RFC 9421 (omit
+`webhookSecret`), set `{ disableWebhook: true }` and poll, or use an application
+flow whose governance boundary can safely authorize the callback configuration.
 
 ## Authentication
 
@@ -162,7 +184,7 @@ The mode recorded at registration is authoritative. The receiver never tries RFC
 
 ## Deduplication
 
-AdCP webhooks use at-least-once delivery — publishers retry until they see a 2xx response, so the same event can arrive more than once. Every MCP webhook payload carries a required `idempotency_key` the publisher keeps stable across retries; receivers dedupe by it.
+AdCP webhooks use at-least-once delivery — publishers retry until they see a 2xx response, so the same event can arrive more than once. Every MCP webhook payload carries a required `idempotency_key` for one delivery identity. Beta.5 can re-emit the same terminal task under another delivery key; the receiver therefore also fences terminal publication by authenticated seller, buyer `operation_id`, and seller `task_id`. Optional `notification_id` is preserved as logical-event evidence and conflicting reuse fails closed.
 
 Wire the client's `webhookDedup` on the `AsyncHandler` to get this for free:
 
@@ -176,7 +198,8 @@ const client = new AdCPClient(agents, {
   handlers: {
     webhookDedup: { backend: memoryBackend(), ttlSeconds: 86_400 }, // 24h
     onCreateMediaBuyStatusChange: async (result, metadata) => {
-      // First delivery for this idempotency_key runs here; retries are dropped.
+      // One terminal publication runs here, even if it is re-emitted under
+      // another delivery idempotency_key.
     },
   },
 });
@@ -204,7 +227,7 @@ The `webhook_duplicate` event intentionally omits `payload` (the original `webho
 
 ### Migrating from ad-hoc dedup
 
-If you previously tracked processed webhooks by `(task_id, status, timestamp)`, replace that with `webhookDedup`. The tuple is fragile — two status transitions sharing a millisecond collide, and governance/artifact webhooks have no `task_id` to key on. `idempotency_key` is the canonical dedup field per AdCP 3.0. Running both layers in parallel is a silent footgun: the ad-hoc tuple can drop events that the key-based layer would have dispatched correctly.
+If you previously tracked processed webhooks by `(task_id, status, timestamp)`, replace that with `webhookDedup`. The SDK keeps delivery-key replay protection separate from beta.5 terminal-task convergence, avoiding timestamp-based collisions while still detecting one delivery key reused with changed content.
 
 ### A2A and missing keys
 

--- a/docs/migration-13-to-14.md
+++ b/docs/migration-13-to-14.md
@@ -14,6 +14,29 @@ continuations. Beta.5 defines stable async identity, cross-channel terminal
 convergence, webhook retry horizons, and crash-safe continuation generation
 replacement.
 
+### Beta.5 task webhook registration and polling
+
+`push_notification_config` is now an AdCP application-layer field across MCP,
+A2A, and REST. On A2A it is carried in skill parameters and remains distinct
+from native `TaskPushNotificationConfig`. Every beta.5 registration must carry
+a buyer `operation_id`; SDK clients generate and reuse one identity across the
+authorized request, registration provenance, route, and webhook envelope.
+Beta.5 sellers return `INVALID_REQUEST` before handler dispatch when the field
+is missing or malformed. Explicitly negotiated older bundles keep their prior
+wire behavior.
+
+Receivers continue to fence exact delivery retries by seller plus
+`idempotency_key`, and additionally fence terminal publication by authenticated
+seller, buyer `operation_id`, and seller `task_id`. This prevents a beta.5
+terminal re-emission under a new delivery key from running handlers twice while
+keeping seller task IDs that are scoped per buyer operation isolated. Configure
+shared durable `webhookDedup` storage for multi-replica receivers.
+
+When polling with `include_result: true`, `get_task_status`/`tasks_get` now
+returns a stored canonical artifact for `completed`, `failed`, and `rejected`
+tasks. A failed response may carry both the top-level summary `error` and a
+canonical `result.errors[]`; they describe the same failure.
+
 ```bash
 npm install @adcp/sdk@beta
 ```
@@ -60,6 +83,8 @@ loading; keep using `requires_capability` for a singular predicate.
 10. Upgrade durable idempotency storage before application traffic: add the nullable PostgreSQL `retain_until` column/index, preserve `IdempotencyCacheEntry.retainUntil`, and add atomic `putIfAbsent()`, `replaceIfPayloadHash()`, `replaceIfPayloadHashAndExpired()`, and `deleteIfPayloadHash()` to every custom backend.
 11. Upgrade custom deferred-task storage with `putForSettlementOperationIfAbsent()`, `getBySettlementOperationId()`, and `replaceForSettlementOperationIfVersion()`. The initial token/index write and nested A→B index move must each be atomic.
 12. Replace webhook emitter `operation_id` arguments with SDK-local `delivery_id` values and upgrade custom stores to `WebhookDeliveryStore`. One delivery ID binds one canonical payload and key; use a fresh delivery ID for each changed status observation while retaining the AdCP `operation_id` inside the payload.
+13. Ensure custom beta.5 buyers include `push_notification_config.operation_id`, and update A2A integrations to keep the AdCP registration in skill parameters even when native A2A push configuration is also present.
+14. Treat failed/rejected task results as canonical terminal artifacts when `include_result` is requested; do not discard them while preserving only the summary error.
 
 ### Webhook delivery identity and retry horizons
 

--- a/src/lib/core/AsyncHandler.ts
+++ b/src/lib/core/AsyncHandler.ts
@@ -102,6 +102,8 @@ export interface WebhookMetadata {
    * canonical dedup key; see `AsyncHandlerConfig.webhookDedup`.
    */
   idempotency_key?: string;
+  /** Seller notification identity, stable when one logical event is re-emitted. */
+  notification_id?: string;
   /**
    * Buyer-side product property policy evaluation for completed get_products
    * webhooks. Present when the client filters, audits, or rejects a webhook
@@ -532,8 +534,8 @@ export class AsyncHandler {
     metadata: WebhookMetadata;
     dispatch: () => Promise<T>;
   }): Promise<{ outcome: 'handled' | 'already_handled' | 'in_progress'; value?: T }> {
-    const dedupClaim = await this.claimWebhook(metadata, result);
-    if (dedupClaim.outcome !== 'claimed') {
+    const deliveryClaim = await this.claimWebhook(metadata, result);
+    if (deliveryClaim.outcome !== 'claimed') {
       await this.emitActivity({
         type: 'webhook_duplicate',
         operation_id: metadata.operation_id,
@@ -545,69 +547,69 @@ export class AsyncHandler {
         idempotency_key: metadata.idempotency_key,
         timestamp: metadata.timestamp,
       });
-      return { outcome: dedupClaim.outcome };
+      return { outcome: deliveryClaim.outcome };
     }
 
-    const stopClaimRenewal = this.startWebhookClaimRenewal(dedupClaim);
+    const claims = [deliveryClaim];
+    if (this.config.webhookDedup && TERMINAL_WEBHOOK_STATUSES.has(metadata.status)) {
+      // Sellers may scope task IDs per buyer operation. Include the trusted
+      // registration's operation ID so two tenants sharing a seller and
+      // backend cannot poison each other's logical terminal fence.
+      const taskIdentity = createHash('sha256')
+        .update(canonicalize({ operationId: metadata.operation_id, taskId: metadata.task_id }))
+        .digest('base64url');
+      let logicalClaim: WebhookDedupClaim;
+      try {
+        logicalClaim = await this.claimWebhook(
+          { ...metadata, idempotency_key: `terminal:${taskIdentity}` },
+          result,
+          'terminal'
+        );
+      } catch (error) {
+        await this.releaseWebhookClaim(deliveryClaim);
+        throw error;
+      }
+      if (logicalClaim.outcome !== 'claimed') {
+        if (logicalClaim.outcome === 'already_handled') {
+          // Bind this fresh delivery key to the already-published terminal
+          // event so an exact transport retry is also acknowledged cheaply.
+          await this.publishWebhookClaim(deliveryClaim);
+        } else {
+          await this.releaseWebhookClaim(deliveryClaim);
+        }
+        await this.emitActivity({
+          type: 'webhook_duplicate',
+          operation_id: metadata.operation_id,
+          agent_id: metadata.agent_id,
+          context_id: metadata.context_id,
+          task_id: metadata.task_id,
+          task_type: metadata.task_type,
+          status: metadata.status,
+          idempotency_key: metadata.idempotency_key,
+          timestamp: metadata.timestamp,
+        });
+        return { outcome: logicalClaim.outcome };
+      }
+      claims.push(logicalClaim);
+    }
+
+    const stopClaimRenewals = claims.map(claim => this.startWebhookClaimRenewal(claim));
     let dispatchCompleted = false;
     let renewalStopped = false;
     try {
       const value = await dispatch();
       dispatchCompleted = true;
-      await stopClaimRenewal();
+      await Promise.all(stopClaimRenewals.map(stop => stop()));
       renewalStopped = true;
-
-      if (dedupClaim.claimKey && dedupClaim.claimToken && this.config.webhookDedup) {
-        const handledMarker: WebhookDedupHandledMarker = {
-          state: WEBHOOK_DEDUP_HANDLED,
-          eventFingerprint: dedupClaim.eventFingerprint ?? '',
-        };
-        const handledExpiresAt = Math.floor(Date.now() / 1000) + dedupClaim.ttlSeconds!;
-        const published = await this.config.webhookDedup.backend.replaceIfPayloadHash(
-          dedupClaim.claimKey,
-          dedupClaim.claimToken,
-          {
-            // A unique publication generation prevents an expired-marker
-            // ABA: a stale taker cannot match a later receiver's handled
-            // marker even when both callbacks have the same fingerprint.
-            payloadHash: `${WEBHOOK_DEDUP_HANDLED}:${randomUUID()}`,
-            response: handledMarker,
-            // Retention starts when processing completes, not when it was
-            // claimed. Long-running handlers therefore receive the full
-            // configured duplicate fence after their side effects finish.
-            expiresAt: handledExpiresAt,
-            retainUntil: handledExpiresAt,
-          }
-        );
-        if (!published) {
-          throw new Error('Webhook processing claim was lost before handler publication completed.');
-        }
-      }
+      // Publish the logical terminal fence before its delivery fence. If the
+      // second publication fails, another delivery still cannot republish the
+      // terminal effect.
+      for (const claim of [...claims].reverse()) await this.publishWebhookClaim(claim);
       return { outcome: 'handled', value };
     } catch (error) {
-      if (
-        !dispatchCompleted &&
-        !(error instanceof WebhookDedupClaimRetentionError) &&
-        dedupClaim.claimKey &&
-        dedupClaim.claimToken &&
-        this.config.webhookDedup
-      ) {
+      if (!dispatchCompleted && !(error instanceof WebhookDedupClaimRetentionError)) {
         try {
-          const nowSeconds = Math.floor(Date.now() / 1000);
-          await this.config.webhookDedup.backend.replaceIfPayloadHash(dedupClaim.claimKey, dedupClaim.claimToken, {
-            // Release processing ownership for an exact retry without
-            // releasing the sender key to a different payload. The expired
-            // logical lease is immediately reclaimable by the same event;
-            // retainUntil keeps its immutable fingerprint through the full
-            // dedup window.
-            payloadHash: dedupClaim.claimToken,
-            response: {
-              claimToken: dedupClaim.claimToken,
-              eventFingerprint: dedupClaim.eventFingerprint,
-            },
-            expiresAt: nowSeconds - 1,
-            retainUntil: nowSeconds + dedupClaim.ttlSeconds!,
-          });
+          await Promise.all(claims.map(claim => this.releaseWebhookClaim(claim)));
         } catch (rollbackError) {
           console.error(
             `Error rolling back webhook dedup claim for task ${metadata.task_type}:`,
@@ -617,8 +619,35 @@ export class AsyncHandler {
       }
       throw error;
     } finally {
-      if (!renewalStopped) await stopClaimRenewal();
+      if (!renewalStopped) await Promise.all(stopClaimRenewals.map(stop => stop()));
     }
+  }
+
+  private async publishWebhookClaim(claim: WebhookDedupClaim): Promise<void> {
+    if (!claim.claimKey || !claim.claimToken || !claim.ttlSeconds || !this.config.webhookDedup) return;
+    const handledMarker: WebhookDedupHandledMarker = {
+      state: WEBHOOK_DEDUP_HANDLED,
+      eventFingerprint: claim.eventFingerprint ?? '',
+    };
+    const handledExpiresAt = Math.floor(Date.now() / 1000) + claim.ttlSeconds;
+    const published = await this.config.webhookDedup.backend.replaceIfPayloadHash(claim.claimKey, claim.claimToken, {
+      payloadHash: `${WEBHOOK_DEDUP_HANDLED}:${randomUUID()}`,
+      response: handledMarker,
+      expiresAt: handledExpiresAt,
+      retainUntil: handledExpiresAt,
+    });
+    if (!published) throw new Error('Webhook processing claim was lost before handler publication completed.');
+  }
+
+  private async releaseWebhookClaim(claim: WebhookDedupClaim): Promise<void> {
+    if (!claim.claimKey || !claim.claimToken || !claim.ttlSeconds || !this.config.webhookDedup) return;
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    await this.config.webhookDedup.backend.replaceIfPayloadHash(claim.claimKey, claim.claimToken, {
+      payloadHash: claim.claimToken,
+      response: { claimToken: claim.claimToken, eventFingerprint: claim.eventFingerprint },
+      expiresAt: nowSeconds - 1,
+      retainUntil: nowSeconds + claim.ttlSeconds,
+    });
   }
 
   /** Dispatch a webhook whose sender dedup claim is already owned. @internal */
@@ -834,7 +863,8 @@ export class AsyncHandler {
    */
   private async claimWebhook(
     metadata: WebhookMetadata,
-    result: AdCPAsyncResponseData | undefined
+    result: AdCPAsyncResponseData | undefined,
+    namespace: 'delivery' | 'terminal' = 'delivery'
   ): Promise<WebhookDedupClaim> {
     const dedup = this.config.webhookDedup;
     if (!dedup) return { outcome: 'claimed' };
@@ -850,13 +880,17 @@ export class AsyncHandler {
     // can never produce a scoped key with this prefix because the
     // principal regex excludes U+001F.
     const agentScope = createHash('sha256').update(metadata.agent_id).digest('base64url');
-    const completedKey = `adcp\u001fwebhook\u001fv2\u001f${agentScope}\u001f${key}`;
+    const completedKey =
+      namespace === 'terminal'
+        ? `adcp\u001fwebhook-terminal\u001fv1\u001f${agentScope}\u001f${key}`
+        : `adcp\u001fwebhook\u001fv2\u001f${agentScope}\u001f${key}`;
     // The previous receiver version stored the authenticated agent ID directly in this
     // v1 scope and published a `{ payloadHash: '', response: null }` fence.
     // Keep v1 exclusively for that read-only migration probe: sharing a
     // namespace with hashed scopes would let an agent ID equal to another
     // agent's digest alias the two authenticated senders. New writes use v2.
-    const legacyCompletedKey = `adcp\u001fwebhook\u001fv1\u001f${metadata.agent_id}\u001f${key}`;
+    const legacyCompletedKey =
+      namespace === 'delivery' ? `adcp\u001fwebhook\u001fv1\u001f${metadata.agent_id}\u001f${key}` : undefined;
     // One record transitions atomically from owner token to handled marker.
     // A separate completion key would create a check-then-put publication
     // race where a stale owner could publish after losing its lease.
@@ -871,6 +905,7 @@ export class AsyncHandler {
           taskId: metadata.task_id,
           taskType: metadata.task_type,
           status: metadata.status,
+          notificationId: metadata.notification_id ?? null,
           contextId: metadata.context_id ?? null,
           message: metadata.message ?? null,
           result: result ?? null,
@@ -909,16 +944,18 @@ export class AsyncHandler {
       }
     }
 
-    const legacyCompleted = await dedup.backend.get(legacyCompletedKey);
-    const legacyState = webhookDedupEntryState(legacyCompleted, nowSeconds);
-    if (legacyState === 'live') {
-      // Only the exact origin-main marker is a completed legacy fence. A live
-      // unknown shape fails closed because it may belong to a partially
-      // upgraded receiver or a damaged record that still protects side effects.
-      return { outcome: legacyWebhookHandledFence(legacyCompleted) ? 'already_handled' : 'in_progress' };
-    }
-    if (legacyState === 'corrupt') {
-      return { outcome: 'in_progress' };
+    if (legacyCompletedKey !== undefined) {
+      const legacyCompleted = await dedup.backend.get(legacyCompletedKey);
+      const legacyState = webhookDedupEntryState(legacyCompleted, nowSeconds);
+      if (legacyState === 'live') {
+        // Only the exact origin-main marker is a completed legacy fence. A live
+        // unknown shape fails closed because it may belong to a partially
+        // upgraded receiver or a damaged record that still protects side effects.
+        return { outcome: legacyWebhookHandledFence(legacyCompleted) ? 'already_handled' : 'in_progress' };
+      }
+      if (legacyState === 'corrupt') {
+        return { outcome: 'in_progress' };
+      }
     }
 
     const claimToken = randomUUID();
@@ -996,6 +1033,7 @@ interface WebhookDedupClaim {
 // pattern is malformed and fails closed before a scoped key or handler
 // dispatch can be formed from arbitrary sender-supplied bytes.
 const IDEMPOTENCY_KEY_PATTERN = /^[A-Za-z0-9_.:-]{16,255}$/;
+const TERMINAL_WEBHOOK_STATUSES = new Set<WebhookMetadata['status']>(['completed', 'failed', 'rejected', 'canceled']);
 const WEBHOOK_DEDUP_HANDLED = 'adcp_webhook_handled_v1';
 
 interface WebhookDedupHandledMarker {

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -960,6 +960,7 @@ type NormalizedWebhookPayload = {
   message?: string;
   timestamp?: string;
   idempotency_key?: string;
+  notification_id?: string;
   protocol?: 'mcp' | 'a2a';
 };
 
@@ -1084,6 +1085,7 @@ export interface WebhookParseSuccess {
     operationId: string;
     contextId?: string;
     idempotencyKey?: string;
+    notificationId?: string;
     status: TaskStatus;
     timestamp?: string;
     message?: string;
@@ -3368,6 +3370,7 @@ export class SingleAgentClient {
         message: normalizedPayload.message,
         timestamp: normalizedPayload.timestamp || new Date().toISOString(),
         idempotency_key: normalizedPayload.idempotency_key,
+        notification_id: normalizedPayload.notification_id,
         protocol: normalizedPayload.protocol ?? 'mcp',
       };
       const canonicalCreativeTask =
@@ -3412,6 +3415,7 @@ export class SingleAgentClient {
           previewHandler,
           timestamp: normalizedPayload.timestamp,
           idempotencyKey: normalizedPayload.idempotency_key,
+          notificationId: normalizedPayload.notification_id,
           requiresDurableSettlement: registration?.requiresDurableSettlement,
         },
       };
@@ -3479,6 +3483,7 @@ export class SingleAgentClient {
       message: parsed.metadata.message,
       timestamp: parsed.metadata.timestamp || new Date().toISOString(),
       idempotency_key: parsed.metadata.idempotencyKey,
+      notification_id: parsed.metadata.notificationId,
       protocol: parsed.protocol,
       rawHTTPPayload: canonicalCreativeTask ? stripLegacyCreativeIdentity(parsed.envelope) : parsed.envelope,
     };
@@ -3920,6 +3925,7 @@ export class SingleAgentClient {
         message: textParts.length > 0 ? textParts.join(' ') : undefined,
         timestamp: a2aPayload.status?.timestamp || new Date().toISOString(),
         ...(typeof adcpData.idempotency_key === 'string' && { idempotency_key: adcpData.idempotency_key }),
+        ...(typeof adcpData.notification_id === 'string' && { notification_id: adcpData.notification_id }),
         protocol: 'a2a',
       };
     }
@@ -3956,6 +3962,7 @@ export class SingleAgentClient {
         message: mcpPayload.message ?? undefined,
         timestamp: mcpPayload.timestamp,
         idempotency_key: mcpPayload.idempotency_key,
+        notification_id: mcpPayload.notification_id ?? undefined,
         protocol: 'mcp',
       };
     }

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -305,16 +305,16 @@ type GovernedCredentialScanResult =
   | { kind: 'limit'; limit: 'nodes' | 'depth' };
 
 function webhookRegistrationFromPreparedCall(
-  agent: AgentConfig,
+  _agent: AgentConfig,
   preparedCall: PreparedProtocolToolCall
 ): { callbackUrl: string; mode: 'rfc9421' | 'hmac-sha256' } | undefined {
   const candidate =
-    agent.protocol === 'a2a'
-      ? preparedCall.pushNotificationConfig
-      : preparedCall.args.push_notification_config &&
-          typeof preparedCall.args.push_notification_config === 'object' &&
-          !Array.isArray(preparedCall.args.push_notification_config)
-        ? (preparedCall.args.push_notification_config as Record<string, unknown>)
+    preparedCall.args.push_notification_config &&
+    typeof preparedCall.args.push_notification_config === 'object' &&
+    !Array.isArray(preparedCall.args.push_notification_config)
+      ? (preparedCall.args.push_notification_config as Record<string, unknown>)
+      : _agent.protocol === 'a2a'
+        ? preparedCall.pushNotificationConfig
         : undefined;
   if (!candidate) return undefined;
   if (typeof candidate.url !== 'string') {
@@ -1335,6 +1335,7 @@ export class TaskExecutor {
               toolName: taskName,
               webhookUrl,
               webhookSecret: this.config.webhookSecret,
+              operationId: taskId,
               serverVersion: effectiveServerVersion,
               adcpVersion: this.config.adcpVersion,
               wireAdcpVersion: this.config.wireAdcpVersion,
@@ -1343,10 +1344,7 @@ export class TaskExecutor {
           : params;
         if (await governanceMiddleware.shouldCheck(taskName, governableParams, targetCapabilities)) {
           const sdkInjectedPushConfig =
-            modernGovernance &&
-            agent.protocol === 'mcp' &&
-            webhookUrl !== undefined &&
-            this.config.webhookSecret !== undefined;
+            modernGovernance && webhookUrl !== undefined && this.config.webhookSecret !== undefined;
           assertGovernedPayloadHasNoCallbackCredentials(taskName, governableParams, { sdkInjectedPushConfig });
           const { result: govResult, params: adjustedParams } = await governanceMiddleware.checkProposed(
             agent,
@@ -1412,6 +1410,7 @@ export class TaskExecutor {
         toolName: taskName,
         webhookUrl,
         webhookSecret: this.config.webhookSecret,
+        operationId: taskId,
         serverVersion: effectiveServerVersion,
         adcpVersion: this.config.adcpVersion,
         wireAdcpVersion: this.config.wireAdcpVersion,
@@ -1513,6 +1512,7 @@ export class TaskExecutor {
         debugLogs,
         webhookUrl,
         webhookSecret: this.config.webhookSecret,
+        operationId: taskId,
         serverVersion: effectiveServerVersion,
         session: { contextId: options.contextId, taskId: options.taskId },
         adcpVersion: this.config.adcpVersion,

--- a/src/lib/protocols/index.ts
+++ b/src/lib/protocols/index.ts
@@ -11,6 +11,7 @@ export {
 import { closeMCPConnections } from './mcp';
 import { closeCurrentMCPConnectionScope, withMCPConnectionScope } from './mcp-scope';
 import { closeA2AConnections } from './a2a';
+import { randomUUID } from 'node:crypto';
 
 /**
  * Close protocol connections for the given protocol.
@@ -340,6 +341,12 @@ export interface CallToolOptions {
   webhookSecret?: string;
   /** Bearer token for push_notification_config validation. */
   webhookToken?: string;
+  /**
+   * Buyer operation identifier echoed by task-status webhooks. TaskExecutor
+   * supplies its stable task ID; direct protocol callers receive a generated
+   * identifier when they omit this value.
+   */
+  operationId?: string;
   /** Pinned protocol generation when the agent advertises both v2 and v3. */
   serverVersion?: 'v2' | 'v3';
   /** A2A session continuity (contextId carries conversation, taskId resumes a task). */
@@ -416,16 +423,18 @@ function applyPublishedSchemaCompatibility(
 export interface PreparedProtocolToolCall {
   /** Exact AdCP tool arguments that the target service will receive. */
   args: Record<string, unknown>;
-  /** A2A carries task-status webhook registration outside tool arguments. */
+  /** Native A2A TaskPushNotificationConfig retained independently of AdCP registration. */
   pushNotificationConfig?: PushNotificationConfig;
+  /** Stable operation ID generated for a beta.5 application webhook registration. */
+  operationId?: string;
 }
 
 /**
  * Materialize protocol-owned request fields before a tool call is authorized.
  *
  * Governance binds the complete downstream AdCP argument object, including
- * version fields and (for MCP) `push_notification_config`. Keeping this pure
- * preparation step shared with {@link ProtocolClient.callTool} prevents the
+ * version fields and `push_notification_config`. Keeping this preparation
+ * step shared with {@link ProtocolClient.callTool} prevents the
  * authorized payload from drifting from the payload that reaches the service.
  */
 export function prepareProtocolToolCall(
@@ -436,6 +445,7 @@ export function prepareProtocolToolCall(
     | 'webhookUrl'
     | 'webhookSecret'
     | 'webhookToken'
+    | 'operationId'
     | 'serverVersion'
     | 'adcpVersion'
     | 'wireAdcpVersion'
@@ -449,15 +459,14 @@ export function prepareProtocolToolCall(
   );
   const argsWithVersion = applyVersionEnvelope(args, envelope);
   applyPublishedSchemaCompatibility(options.toolName, argsWithVersion, args);
-
-  // The in-process MCP client has historically had no protocol webhook
-  // registration path. Preserve that behavior and, crucially, describe the
-  // exact arguments that path will receive.
-  if (agent.protocol === 'mcp' && agent._inProcessMcpClient) {
-    return { args: argsWithVersion };
-  }
+  const effectiveBundle =
+    typeof argsWithVersion.adcp_version === 'string' ? resolveBundleKey(argsWithVersion.adcp_version) : undefined;
+  const usesBeta5ApplicationRegistration =
+    options.serverVersion !== 'v2' && (effectiveBundle === '3.2.0-beta.5' || effectiveBundle === '3.2-beta.5');
 
   let pushNotificationConfig: PushNotificationConfig | undefined;
+  let applicationPushNotificationConfig: PushNotificationConfig | undefined;
+  let operationId: string | undefined;
   if (options.webhookUrl) {
     if (options.webhookSecret) {
       pushNotificationConfig = {
@@ -476,14 +485,29 @@ export function prepareProtocolToolCall(
         ...(options.webhookToken && { token: options.webhookToken }),
       };
     }
+    if (usesBeta5ApplicationRegistration && pushNotificationConfig) {
+      operationId = options.operationId ?? randomUUID();
+      applicationPushNotificationConfig = {
+        ...pushNotificationConfig,
+        url: options.webhookUrl,
+        operation_id: operationId,
+      };
+    } else if (agent.protocol === 'mcp' && !agent._inProcessMcpClient) {
+      // Preserve the pre-beta.5 MCP wire shape for explicitly negotiated
+      // older bundles. A2A used only its native configuration on those lines.
+      applicationPushNotificationConfig = pushNotificationConfig;
+    }
   }
 
   return {
-    args:
-      agent.protocol === 'mcp' && pushNotificationConfig
-        ? { ...argsWithVersion, push_notification_config: pushNotificationConfig }
-        : argsWithVersion,
-    ...(pushNotificationConfig ? { pushNotificationConfig } : {}),
+    // AdCP 3.2 task-webhook registration is application-layer data on every
+    // transport. A2A's native TaskPushNotificationConfig is a distinct
+    // transport feature and must not replace this argument.
+    args: applicationPushNotificationConfig
+      ? { ...argsWithVersion, push_notification_config: applicationPushNotificationConfig }
+      : argsWithVersion,
+    ...(agent.protocol === 'a2a' && pushNotificationConfig ? { pushNotificationConfig } : {}),
+    ...(operationId ? { operationId } : {}),
   };
 }
 
@@ -510,6 +534,7 @@ export class ProtocolClient {
       webhookUrl,
       webhookSecret,
       webhookToken,
+      operationId,
       serverVersion,
       session,
       adcpVersion,
@@ -528,6 +553,7 @@ export class ProtocolClient {
         webhookUrl,
         webhookSecret,
         webhookToken,
+        operationId,
         serverVersion,
         adcpVersion,
         wireAdcpVersion,
@@ -744,7 +770,6 @@ export class ProtocolClient {
                   throw err;
                 }
               } else if (agent.protocol === 'a2a') {
-                // For A2A, pass pushNotificationConfig separately (not in skill parameters)
                 try {
                   return await callA2ATool(
                     agent.agent_uri,

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -4260,6 +4260,33 @@ function compareAdcpRelease(left: ParsedAdcpRelease, right: ParsedAdcpRelease): 
   return 0;
 }
 
+const PUSH_OPERATION_ID_PATTERN = /^[A-Za-z0-9_.:-]{1,255}$/;
+
+function releaseRequiresPushOperationId(release: string): boolean {
+  const bundle = resolveBundleKey(release);
+  return bundle === '3.2.0-beta.5' || bundle === '3.2-beta.5';
+}
+
+function pushOperationIdError(
+  params: Record<string, unknown>,
+  release: ServedAdcpRelease
+): McpToolResponse | undefined {
+  if (!releaseRequiresPushOperationId(release.validationVersion)) return undefined;
+  const config = params.push_notification_config;
+  if (config === undefined) return undefined;
+  if (
+    !isPlainObject(config) ||
+    typeof config.operation_id !== 'string' ||
+    !PUSH_OPERATION_ID_PATTERN.test(config.operation_id)
+  ) {
+    return adcpError('INVALID_REQUEST', {
+      message: `push_notification_config.operation_id must match ${PUSH_OPERATION_ID_PATTERN.source}`,
+      field: 'push_notification_config.operation_id',
+    });
+  }
+  return undefined;
+}
+
 let bundledCompatibleReleases: ParsedAdcpRelease[] | undefined;
 
 function bundledReleasesForMajors(majors: readonly number[], configured: ParsedAdcpRelease): ParsedAdcpRelease[] {
@@ -5536,6 +5563,8 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
             })
           );
         }
+        const operationIdError = pushOperationIdError(params, requestRelease);
+        if (operationIdError) return finalize(operationIdError);
 
         // --- Buyer-agent registry resolution (#1269 / #1292) ---
         // Runs after `authInfo` is populated and before account resolution
@@ -7482,7 +7511,11 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
             })
           );
         }
-        if (params?.include_result === true && response.status === 'completed') {
+        if (
+          params?.include_result === true &&
+          (response.status === 'completed' || response.status === 'failed' || response.status === 'rejected') &&
+          task.result !== undefined
+        ) {
           response.result = task.result as GetTaskStatusResponse['result'];
         }
         if (isPlainObject(params?.context)) response.context = params.context;

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -3252,6 +3252,10 @@ function buildTasksGetTool<P extends DecisioningPlatform<any, any>>(
         'Optional account reference for tenant scoping. Either AccountReference arm is accepted: ' +
           '`{account_id}` for explicit accounts or `{brand, operator, sandbox?}` for implicit accounts.'
       ),
+    include_result: z
+      .boolean()
+      .optional()
+      .describe('Include a canonical terminal artifact for completed, failed, or rejected tasks.'),
   };
   return {
     description:
@@ -3274,7 +3278,7 @@ function buildTasksGetTool<P extends DecisioningPlatform<any, any>>(
     // resolver and reads tenant B's task. Same threading as the regular
     // `resolveAccount` dispatch flow in `create-adcp-server.ts:2380-2398`.
     handler: async (
-      args: { task_id: string; account?: { account_id?: string } },
+      args: { task_id: string; account?: { account_id?: string }; include_result?: boolean },
       extra: { authInfo?: ResolvedAuthInfo }
     ) => {
       const policyError = credentialPolicyError(args as Record<string, unknown>, extra);
@@ -3471,7 +3475,11 @@ function buildTasksGetTool<P extends DecisioningPlatform<any, any>>(
         payload.completed_at = record.updatedAt;
       }
       if (record.statusMessage) payload.message = record.statusMessage;
-      if (record.status === 'completed' && record.result !== undefined) {
+      if (
+        args.include_result === true &&
+        (record.status === 'completed' || record.status === 'failed' || record.status === 'rejected') &&
+        record.result !== undefined
+      ) {
         payload.result = record.result;
       }
       if (record.status === 'failed' && record.error) {
@@ -3985,6 +3993,7 @@ interface DispatchHitlOpts {
   pushNotificationUrl?: string;
   pushNotificationToken?: string;
   pushNotificationOperationId?: string;
+  servedAdcpVersion?: string;
   emitWebhook?: HandlerContext<Account>['emitWebhook'];
   observability?: DecisioningObservabilityHooks;
   logger: AdcpLogger;
@@ -4211,8 +4220,9 @@ async function dispatchHitl<TResult>(
             message: 'Task failed',
           }
     );
+    const failureArtifact = { errors: [structured] };
     try {
-      await taskRegistry.fail(taskId, structured);
+      await taskRegistry.fail(taskId, structured, failureArtifact);
     } catch (registryErr) {
       opts.logger.error(
         `[adcp/decisioning] task ${taskId} (${opts.tool}) failed AND registry fail-write also failed — ` +
@@ -4224,7 +4234,7 @@ async function dispatchHitl<TResult>(
     }
     fireTransition('failed', structured.code);
     await emitTaskWebhook(opts, {
-      task: { task_id: taskId, status: 'failed', error: structured },
+      task: { task_id: taskId, status: 'failed', result: failureArtifact, error: structured },
     });
   })();
   taskRegistry._registerBackground(taskId, completion);
@@ -4280,13 +4290,24 @@ function buildTaskWebhookPayload(
     payload.result = artifact.result;
   }
   if (status === 'failed' && artifact.error !== undefined) {
-    payload.result = { errors: [artifact.error] };
+    payload.result = artifact.result ?? { errors: [artifact.error] };
     payload.message = artifact.error.message;
   }
   return payload;
 }
 
 function resolveWebhookPayloadOperationId(opts: DispatchHitlOpts, taskId: string): string {
+  if (
+    opts.pushNotificationOperationId === undefined &&
+    (opts.servedAdcpVersion === '3.2.0-beta.5' || opts.servedAdcpVersion === '3.2-beta.5')
+  ) {
+    throw new AdcpError('INVALID_REQUEST', {
+      message: 'push_notification_config.operation_id is required for webhook delivery',
+      field: 'push_notification_config.operation_id',
+    });
+  }
+  // Older negotiated bundles predate buyer-supplied operation IDs. Preserve
+  // their stable compatibility value without allowing beta.5 to synthesize.
   return opts.pushNotificationOperationId ?? `${opts.tool}.${taskId}`;
 }
 
@@ -5235,6 +5256,7 @@ function buildProposalNegotiationHandlers<P extends DecisioningPlatform<any, any
               pushNotificationUrl: push.url,
               pushNotificationToken: push.token,
               pushNotificationOperationId: push.operationId,
+              servedAdcpVersion: ctx.servedAdcpVersion,
               emitWebhook: taskWebhookEmit ?? ctx.emitWebhook,
               autoEmitCompletion: pushOpts.autoEmitCompletionWebhooks,
               observability,
@@ -5321,6 +5343,7 @@ function buildMediaBuyHandlers<P extends DecisioningPlatform<any, any>>(
             pushNotificationUrl: push.url,
             pushNotificationToken: push.token,
             pushNotificationOperationId: push.operationId,
+            servedAdcpVersion: ctx.servedAdcpVersion,
             emitWebhook: taskWebhookEmit ?? ctx.emitWebhook,
             autoEmitCompletion: pushOpts.autoEmitCompletionWebhooks,
             observability,
@@ -5437,6 +5460,7 @@ function buildMediaBuyHandlers<P extends DecisioningPlatform<any, any>>(
                 pushNotificationUrl: push.url,
                 pushNotificationToken: push.token,
                 pushNotificationOperationId: push.operationId,
+                servedAdcpVersion: ctx.servedAdcpVersion,
                 emitWebhook: taskWebhookEmit ?? ctx.emitWebhook,
                 autoEmitCompletion: pushOpts.autoEmitCompletionWebhooks,
                 observability,
@@ -5547,6 +5571,7 @@ function buildMediaBuyHandlers<P extends DecisioningPlatform<any, any>>(
                 pushNotificationUrl: push.url,
                 pushNotificationToken: push.token,
                 pushNotificationOperationId: push.operationId,
+                servedAdcpVersion: ctx.servedAdcpVersion,
                 emitWebhook: taskWebhookEmit ?? ctx.emitWebhook,
                 autoEmitCompletion: pushOpts.autoEmitCompletionWebhooks,
                 observability,
@@ -5664,6 +5689,7 @@ function buildMediaBuyHandlers<P extends DecisioningPlatform<any, any>>(
                 pushNotificationUrl: push.url,
                 pushNotificationToken: push.token,
                 pushNotificationOperationId: push.operationId,
+                servedAdcpVersion: ctx.servedAdcpVersion,
                 emitWebhook: taskWebhookEmit ?? ctx.emitWebhook,
                 autoEmitCompletion: pushOpts.autoEmitCompletionWebhooks,
                 observability,
@@ -5751,6 +5777,7 @@ function buildMediaBuyHandlers<P extends DecisioningPlatform<any, any>>(
                 pushNotificationUrl: push.url,
                 pushNotificationToken: push.token,
                 pushNotificationOperationId: push.operationId,
+                servedAdcpVersion: ctx.servedAdcpVersion,
                 emitWebhook: taskWebhookEmit ?? ctx.emitWebhook,
                 autoEmitCompletion: pushOpts.autoEmitCompletionWebhooks,
                 observability,
@@ -5804,6 +5831,7 @@ function buildMediaBuyHandlers<P extends DecisioningPlatform<any, any>>(
                 pushNotificationUrl: push.url,
                 pushNotificationToken: push.token,
                 pushNotificationOperationId: push.operationId,
+                servedAdcpVersion: ctx.servedAdcpVersion,
                 emitWebhook: taskWebhookEmit ?? ctx.emitWebhook,
                 autoEmitCompletion: pushOpts.autoEmitCompletionWebhooks,
                 observability,
@@ -6150,6 +6178,7 @@ function buildCreativeHandlers<P extends DecisioningPlatform<any, any>>(
                 pushNotificationUrl: push.url,
                 pushNotificationToken: push.token,
                 pushNotificationOperationId: push.operationId,
+                servedAdcpVersion: ctx.servedAdcpVersion,
                 emitWebhook: taskWebhookEmit ?? ctx.emitWebhook,
                 autoEmitCompletion: pushOpts.autoEmitCompletionWebhooks,
                 observability,
@@ -6385,6 +6414,7 @@ function buildSignalsHandlers<P extends DecisioningPlatform<any, any>>(
               pushNotificationUrl: push.url,
               pushNotificationToken: push.token,
               pushNotificationOperationId: push.operationId,
+              servedAdcpVersion: ctx.servedAdcpVersion,
               emitWebhook: taskWebhookEmit ?? ctx.emitWebhook,
               autoEmitCompletion: pushOpts.autoEmitCompletionWebhooks,
               observability,

--- a/src/lib/server/decisioning/runtime/postgres-task-registry.ts
+++ b/src/lib/server/decisioning/runtime/postgres-task-registry.ts
@@ -307,19 +307,21 @@ export function createPostgresTaskRegistry(opts: CreatePostgresTaskRegistryOptio
       await pool.query(
         `UPDATE ${table}
          SET status = 'completed', result = $2::jsonb, updated_at = NOW()
-         WHERE task_id = $1 AND status NOT IN ('completed', 'failed')`,
+         WHERE task_id = $1 AND status NOT IN ('completed', 'failed', 'rejected', 'canceled')`,
         [taskId, json]
       );
     },
 
-    async fail(taskId: string, error: AdcpStructuredError): Promise<void> {
-      const json = safeStringify(error, taskId);
-      assertResultSize(json, taskId);
+    async fail(taskId: string, error: AdcpStructuredError, result?: unknown): Promise<void> {
+      const errorJson = safeStringify(error, taskId);
+      const resultJson = result === undefined ? undefined : safeStringify(result, taskId);
+      assertResultSize(errorJson, taskId);
+      if (resultJson !== undefined) assertResultSize(resultJson, taskId);
       await pool.query(
         `UPDATE ${table}
-         SET status = 'failed', error = $2::jsonb, status_message = $3, updated_at = NOW()
-         WHERE task_id = $1 AND status NOT IN ('completed', 'failed')`,
-        [taskId, json, error.message]
+         SET status = 'failed', error = $2::jsonb, result = $3::jsonb, status_message = $4, updated_at = NOW()
+         WHERE task_id = $1 AND status NOT IN ('completed', 'failed', 'rejected', 'canceled')`,
+        [taskId, errorJson, resultJson ?? null, error.message]
       );
     },
 
@@ -330,7 +332,7 @@ export function createPostgresTaskRegistry(opts: CreatePostgresTaskRegistryOptio
          SET progress = $2::jsonb,
              status = CASE WHEN status = 'submitted' THEN 'working' ELSE status END,
              updated_at = NOW()
-         WHERE task_id = $1 AND status NOT IN ('completed', 'failed')`,
+         WHERE task_id = $1 AND status NOT IN ('completed', 'failed', 'rejected', 'canceled')`,
         [taskId, json]
       );
     },

--- a/src/lib/server/decisioning/runtime/task-registry.ts
+++ b/src/lib/server/decisioning/runtime/task-registry.ts
@@ -42,6 +42,12 @@ export type TaskStatus =
   | 'auth-required'
   | 'unknown';
 
+const TERMINAL_TASK_STATUSES: ReadonlySet<TaskStatus> = new Set(['completed', 'failed', 'rejected', 'canceled']);
+
+function isTerminalTaskStatus(status: TaskStatus): boolean {
+  return TERMINAL_TASK_STATUSES.has(status);
+}
+
 export interface TaskRecord<TResult = unknown, TError extends AdcpStructuredError = AdcpStructuredError> {
   taskId: string;
   /** Tool name that started the task (e.g., 'create_media_buy'). */
@@ -54,7 +60,7 @@ export interface TaskRecord<TResult = unknown, TError extends AdcpStructuredErro
   status: TaskStatus;
   /** Status message on the final arm (`error.message` on failed). */
   statusMessage?: string;
-  /** Terminal result on `completed`. */
+  /** Canonical terminal artifact on `completed`, `failed`, or `rejected`. */
   result?: TResult;
   /** Terminal error on `failed`. */
   error?: TError;
@@ -140,10 +146,10 @@ export interface TaskRegistry {
   complete<TResult>(taskId: string, result: TResult): Promise<void>;
 
   /**
-   * Mark a task `failed` with the structured error. No-op if the task is
-   * already terminal (idempotent).
+   * Mark a task `failed` with the structured error and, when available, the
+   * canonical terminal artifact. No-op if the task is already terminal.
    */
-  fail(taskId: string, error: AdcpStructuredError): Promise<void>;
+  fail(taskId: string, error: AdcpStructuredError, result?: unknown): Promise<void>;
 
   /**
    * Record intermediate progress from `TaskHandoffContext.update(...)`.
@@ -228,18 +234,19 @@ export function createInMemoryTaskRegistry(): TaskRegistry {
     async complete<TResult>(taskId: string, result: TResult): Promise<void> {
       const existing = tasks.get(taskId);
       if (!existing) return;
-      if (existing.status === 'completed' || existing.status === 'failed') return;
+      if (isTerminalTaskStatus(existing.status)) return;
       existing.status = 'completed';
       existing.result = result;
       existing.updatedAt = new Date().toISOString();
     },
 
-    async fail(taskId: string, error: AdcpStructuredError): Promise<void> {
+    async fail(taskId: string, error: AdcpStructuredError, result?: unknown): Promise<void> {
       const existing = tasks.get(taskId);
       if (!existing) return;
-      if (existing.status === 'completed' || existing.status === 'failed') return;
+      if (isTerminalTaskStatus(existing.status)) return;
       existing.status = 'failed';
       existing.error = error;
+      if (result !== undefined) existing.result = result;
       existing.statusMessage = error.message;
       existing.updatedAt = new Date().toISOString();
     },
@@ -247,7 +254,7 @@ export function createInMemoryTaskRegistry(): TaskRegistry {
     async updateProgress(taskId: string, progress: TaskHandoffProgress): Promise<void> {
       const existing = tasks.get(taskId);
       if (!existing) return;
-      if (existing.status === 'completed' || existing.status === 'failed') return;
+      if (isTerminalTaskStatus(existing.status)) return;
       if (existing.status === 'submitted') existing.status = 'working';
       existing.progress = progress;
       existing.updatedAt = new Date().toISOString();

--- a/test/fixtures/create_media_buy_async_submitted.yaml
+++ b/test/fixtures/create_media_buy_async_submitted.yaml
@@ -170,6 +170,7 @@ phases:
               pricing_option_id: "cpm_standard"
           push_notification_config:
             url: "https://buyer.example/webhooks/adcp"
+            operation_id: "storyboard_create_media_buy_async_submitted"
           idempotency_key: "$generate:uuid_v4#media_buy_seller_create_submitted_create_media_buy"
           context:
             correlation_id: "create_media_buy_async_submitted--create_media_buy"

--- a/test/lib/async-handler-webhook-dedup.test.js
+++ b/test/lib/async-handler-webhook-dedup.test.js
@@ -13,9 +13,10 @@ function baseMetadata(overrides = {}) {
     task_id: 'task_1',
     agent_id: 'agent_1',
     task_type: 'create_media_buy',
-    status: 'completed',
+    status: 'working',
     timestamp: new Date().toISOString(),
     idempotency_key: 'whk_01HW9D3H8FZP2N6R8T0V4X6Z9B',
+    notification_id: 'notification_01HW9D3H8FZP2N6R8T0V4X6Z9B',
     ...overrides,
   };
 }
@@ -37,6 +38,7 @@ function dedupEventFingerprint(metadata, result) {
         taskId: metadata.task_id,
         taskType: metadata.task_type,
         status: metadata.status,
+        notificationId: metadata.notification_id ?? null,
         contextId: metadata.context_id ?? null,
         message: metadata.message ?? null,
         result: result ?? null,
@@ -228,6 +230,101 @@ test('webhookDedup dispatches distinct idempotency_keys independently', async ()
   });
 
   assert.deepStrictEqual(calls, ['whk_0000000000000001', 'whk_0000000000000002']);
+});
+
+test('webhookDedup publishes one terminal task across distinct delivery keys', async () => {
+  const calls = [];
+  const handler = new AsyncHandler({
+    webhookDedup: { backend: memoryBackend({ sweepIntervalMs: 0 }) },
+    onCreateMediaBuyStatusChange: (_response, metadata) => calls.push(metadata.idempotency_key),
+  });
+  const terminal = {
+    status: 'completed',
+    notification_id: 'notification_terminal_0001',
+  };
+  assert.strictEqual(
+    await handler.handleWebhook({
+      result: { media_buy_id: 'mb_1' },
+      metadata: baseMetadata({ ...terminal, idempotency_key: 'whk_terminal_000000001' }),
+    }),
+    'handled'
+  );
+  assert.strictEqual(
+    await handler.handleWebhook({
+      result: { media_buy_id: 'mb_1' },
+      metadata: baseMetadata({ ...terminal, idempotency_key: 'whk_terminal_000000002' }),
+    }),
+    'already_handled'
+  );
+  assert.deepStrictEqual(calls, ['whk_terminal_000000001']);
+});
+
+test('webhookDedup keeps identical seller task IDs isolated by buyer operation', async () => {
+  const calls = [];
+  const handler = new AsyncHandler({
+    webhookDedup: { backend: memoryBackend({ sweepIntervalMs: 0 }) },
+    onCreateMediaBuyStatusChange: (_response, metadata) => calls.push(metadata.operation_id),
+  });
+  for (const [operation_id, idempotency_key] of [
+    ['op_tenant_a', 'whk_terminal_tenant_0001'],
+    ['op_tenant_b', 'whk_terminal_tenant_0002'],
+  ]) {
+    assert.strictEqual(
+      await handler.handleWebhook({
+        result: { media_buy_id: 'mb_shared_seller_id' },
+        metadata: baseMetadata({
+          operation_id,
+          task_id: 'seller_task_scoped_per_operation',
+          status: 'completed',
+          idempotency_key,
+        }),
+      }),
+      'handled'
+    );
+  }
+  assert.deepStrictEqual(calls, ['op_tenant_a', 'op_tenant_b']);
+});
+
+test('webhookDedup rejects conflicting terminal artifacts across delivery keys', async () => {
+  const handler = new AsyncHandler({ webhookDedup: { backend: memoryBackend({ sweepIntervalMs: 0 }) } });
+  await handler.handleWebhook({
+    result: { media_buy_id: 'mb_1' },
+    metadata: baseMetadata({ status: 'completed', idempotency_key: 'whk_terminal_conflict01' }),
+  });
+  await assert.rejects(
+    handler.handleWebhook({
+      result: { media_buy_id: 'mb_2' },
+      metadata: baseMetadata({ status: 'completed', idempotency_key: 'whk_terminal_conflict02' }),
+    }),
+    /idempotency key was reused/
+  );
+});
+
+test('sender delivery keys cannot poison the internal terminal-task namespace', async () => {
+  const calls = [];
+  const handler = new AsyncHandler({
+    webhookDedup: { backend: memoryBackend({ sweepIntervalMs: 0 }) },
+    onCreateMediaBuyStatusChange: (_result, metadata) => calls.push(metadata.status),
+  });
+  const taskId = 'task_namespace_isolation';
+  const taskHash = createHash('sha256').update(taskId).digest('base64url');
+  await handler.handleWebhook({
+    result: { progress: 50 },
+    metadata: baseMetadata({
+      task_id: taskId,
+      status: 'working',
+      idempotency_key: `terminal:${taskHash}`,
+    }),
+  });
+  await handler.handleWebhook({
+    result: { media_buy_id: 'mb_1' },
+    metadata: baseMetadata({
+      task_id: taskId,
+      status: 'completed',
+      idempotency_key: 'whk_terminal_namespace01',
+    }),
+  });
+  assert.deepStrictEqual(calls, ['working', 'completed']);
 });
 
 test('webhookDedup rejects one sender key reused for a different callback payload', async () => {
@@ -457,6 +554,7 @@ test('idempotency_key propagates from MCP envelope through SingleAgentClient to 
 
   const envelope = {
     idempotency_key: 'whk_01HW9D3H8FZP2N6R8T0V4X6Z9B',
+    notification_id: 'notification_01HW9D3H8FZP2N6R8T0V4X6Z9B',
     operation_id: 'op_1',
     task_id: 'task_1',
     task_type: 'create_media_buy',
@@ -469,6 +567,7 @@ test('idempotency_key propagates from MCP envelope through SingleAgentClient to 
   assert.strictEqual(handled, true);
   assert.ok(seenMetadata, 'handler should be called');
   assert.strictEqual(seenMetadata.idempotency_key, 'whk_01HW9D3H8FZP2N6R8T0V4X6Z9B');
+  assert.strictEqual(seenMetadata.notification_id, 'notification_01HW9D3H8FZP2N6R8T0V4X6Z9B');
 });
 
 test('webhookDedup re-dispatches after backend eviction (TTL expiry path)', async () => {

--- a/test/lib/governance.test.js
+++ b/test/lib/governance.test.js
@@ -1167,38 +1167,19 @@ describe('governance wire binding', () => {
     }
   });
 
-  it('keeps SDK-injected A2A webhook authentication outside the governed arguments', async () => {
+  it('fails closed before disclosing an SDK-injected A2A webhook secret', async () => {
     const originalCallTool = ProtocolClient.callTool;
-    let governedPayload;
-    let sellerPayload;
-    let sellerOptions;
-    ProtocolClient.callTool = async (_agent, tool, params, options) => {
-      if (tool === 'check_governance') {
-        governedPayload = structuredClone(params.payload);
-        return {
-          structuredContent: {
-            check_id: 'a2a-wire-check',
-            check_type: 'intent',
-            verdict: 'approved',
-            explanation: 'Approved',
-            governance_context: 'signed-a2a-context',
-            expires_at: '2026-08-18T12:00:00Z',
-          },
-        };
-      }
-      if (tool === 'report_plan_outcome') {
-        return { structuredContent: { outcome_id: 'a2a-outcome', outcome_state: 'accepted' } };
-      }
-      sellerPayload = structuredClone(params);
-      sellerOptions = structuredClone(options);
-      return { structuredContent: { status: 'completed', media_buy_id: 'a2a-buy' } };
+    let calls = 0;
+    ProtocolClient.callTool = async () => {
+      calls += 1;
+      throw new Error('must not be called');
     };
     try {
       const executor = createGovernedExecutor({
         webhookUrlTemplate: 'https://buyer.example/hooks/{operation_id}',
         webhookSecret: 'a-secure-a2a-webhook-secret-at-least-32-chars',
       });
-      await executor.executeTask(
+      const result = await executor.executeTask(
         { id: 'seller', name: 'Seller', agent_uri: 'https://seller.example/a2a', protocol: 'a2a' },
         'create_media_buy',
         { total_budget: { amount: 10, currency: 'USD' } },
@@ -1207,9 +1188,11 @@ describe('governance wire binding', () => {
         'v3',
         modernCapabilities
       );
-      assert.ok(!('push_notification_config' in governedPayload));
-      assert.equal(computeGovernedPayloadHash(governedPayload), computeGovernedPayloadHash(sellerPayload));
-      assert.equal(sellerOptions.webhookSecret, 'a-secure-a2a-webhook-secret-at-least-32-chars');
+      assert.equal(result.success, false);
+      assert.match(result.error, /push_notification_config\.authentication\.credentials/);
+      assert.match(result.error, /disableWebhook: true/);
+      assert.ok(!result.error.includes('a-secure-a2a-webhook-secret-at-least-32-chars'));
+      assert.equal(calls, 0);
     } finally {
       ProtocolClient.callTool = originalCallTool;
     }

--- a/test/lib/webhook-emitter-server-e2e.test.js
+++ b/test/lib/webhook-emitter-server-e2e.test.js
@@ -111,6 +111,7 @@ describe('createAdcpServer + webhook emitter: full-stack publisher E2E', () => {
       idempotency_key: 'e2e_create_key_0123456',
       push_notification_config: {
         url: `${receiver.base_url}/step/e2e_trigger/e2e_op_01`,
+        operation_id: 'e2e_op_01',
       },
     });
 
@@ -299,7 +300,10 @@ describe('createAdcpServer + webhook emitter: full-stack publisher E2E', () => {
       end_time: '2026-05-31T23:59:59Z',
       packages: [{ product_id: 'p1', budget: 5000, pricing_option_id: 'po-1' }],
       idempotency_key: 'stability_key_abcdefghij',
-      push_notification_config: { url: `${receiver.base_url}/step/stable/op_stable` },
+      push_notification_config: {
+        url: `${receiver.base_url}/step/stable/op_stable`,
+        operation_id: 'op_stable',
+      },
     });
     assert.strictEqual(emittedKeys[0], emittedKeys[1], 'exact retries must reuse the delivery key');
     assert.notStrictEqual(emittedKeys[1], emittedKeys[2], 'changed observations must use a fresh delivery key');

--- a/test/request-signing-agent-a2a.test.js
+++ b/test/request-signing-agent-a2a.test.js
@@ -261,6 +261,9 @@ test('A2A: webhook authentication payload is signed even when the operation is o
       schemes: ['HMAC-SHA256'],
       credentials: 'placeholder_secret_min_32_characters_required',
     });
+    const applicationPush = call.body.params.message.parts[0].data.parameters.push_notification_config;
+    assert.strictEqual(applicationPush.authentication.credentials, 'placeholder_secret_min_32_characters_required');
+    assert.match(applicationPush.operation_id, /^[A-Za-z0-9_.:-]{1,255}$/);
   } finally {
     await cleanup(stub);
   }

--- a/test/server-create-adcp-server.test.js
+++ b/test/server-create-adcp-server.test.js
@@ -2271,6 +2271,26 @@ describe('createAdcpServer', () => {
       assert.deepStrictEqual(status.result, { creatives: [{ creative_id: 'cr_1' }] });
       assert.deepStrictEqual(status.context, { trace_id: 'trace_1' });
 
+      const failed = await taskRegistry.create({
+        tool: 'sync_creatives',
+        accountId: 'acct_1',
+        ownerScope: 'api_key:buyer-1',
+      });
+      const failure = { code: 'SERVICE_UNAVAILABLE', message: 'seller unavailable', recovery: 'transient' };
+      const failureArtifact = { errors: [failure] };
+      await taskRegistry.fail(failed.taskId, failure, failureArtifact);
+      const failedWithoutResult = await callTool(server, 'get_task_status', { task_id: failed.taskId }, buyerOne);
+      assert.strictEqual(failedWithoutResult.status, 'failed');
+      assert.strictEqual(failedWithoutResult.result, undefined);
+      const failedWithResult = await callTool(
+        server,
+        'get_task_status',
+        { task_id: failed.taskId, include_result: true },
+        buyerOne
+      );
+      assert.deepStrictEqual(failedWithResult.result, failureArtifact);
+      assert.strictEqual(failedWithResult.error.code, 'SERVICE_UNAVAILABLE');
+
       const crossTenant = await callToolRaw(server, 'get_task_status', { task_id: owned.taskId }, buyerTwo);
       assert.strictEqual(crossTenant.isError, true);
       assert.strictEqual(crossTenant.structuredContent.adcp_error.code, 'REFERENCE_NOT_FOUND');
@@ -2327,6 +2347,44 @@ describe('createAdcpServer', () => {
       );
       assert.strictEqual(tooManyTaskIds.isError, true);
       assert.strictEqual(tooManyTaskIds.structuredContent.adcp_error.code, 'INVALID_REQUEST');
+    });
+
+    it('returns a produced rejected artifact only when include_result is true', async () => {
+      const now = new Date().toISOString();
+      const record = {
+        taskId: 'task_rejected_artifact',
+        tool: 'sync_creatives',
+        accountId: 'acct_1',
+        ownerScope: 'api_key:buyer-1',
+        status: 'rejected',
+        result: { errors: [{ code: 'POLICY_VIOLATION', message: 'rejected by policy' }] },
+        createdAt: now,
+        updatedAt: now,
+      };
+      const taskRegistry = {
+        create: async () => ({ taskId: record.taskId }),
+        getTask: async taskId => (taskId === record.taskId ? record : null),
+        complete: async () => {},
+        fail: async () => {},
+        updateProgress: async () => {},
+        _registerBackground: () => {},
+      };
+      const server = createAdcpServer({
+        name: 'Test',
+        version: '1.0.0',
+        taskRegistry,
+        resolveAccountFromAuth: async () => ({ id: 'acct_1' }),
+      });
+      const buyer = { authInfo: { credential: { kind: 'api_key', key_id: 'buyer-1' } } };
+      const summary = await callTool(server, 'get_task_status', { task_id: record.taskId }, buyer);
+      assert.strictEqual(summary.result, undefined);
+      const detailed = await callTool(
+        server,
+        'get_task_status',
+        { task_id: record.taskId, include_result: true },
+        buyer
+      );
+      assert.deepStrictEqual(detailed.result, record.result);
     });
 
     it('polls and lists every task type newly admitted by the 3.2 enum', async () => {

--- a/test/server-decisioning-allow-private-webhook-urls.test.js
+++ b/test/server-decisioning-allow-private-webhook-urls.test.js
@@ -62,7 +62,7 @@ async function callCreateMediaBuyWithUrl(server, url) {
         promoted_offering: 'x',
         packages: [],
         idempotency_key: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
-        push_notification_config: { url },
+        push_notification_config: { url, operation_id: 'op_private_webhook_test' },
       },
     },
   });

--- a/test/server-decisioning-auto-emit-completion.test.js
+++ b/test/server-decisioning-auto-emit-completion.test.js
@@ -72,6 +72,11 @@ const ARGS_BASE = {
   idempotency_key: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
 };
 
+const PUSH_CONFIG = {
+  url: 'https://buyer.example.com/webhook',
+  operation_id: 'op_sync_completion_silence',
+};
+
 // Webhook auto-emit is fire-and-forget (security review F12 must-fix —
 // awaiting inline lets a slowloris buyer URL hold the seller's request
 // worker for the full retry budget). Tests asserting on `calls` after
@@ -94,7 +99,7 @@ describe('sync completion webhook silence', () => {
         name: 'create_media_buy',
         arguments: {
           ...ARGS_BASE,
-          push_notification_config: { url: 'https://buyer.example.com/webhook' },
+          push_notification_config: PUSH_CONFIG,
         },
       },
     });
@@ -120,7 +125,7 @@ describe('sync completion webhook silence', () => {
           account: { account_id: 'acc_1' },
           creatives: [{ creative_id: 'cr_1', name: 'Creative 1', format_kind: 'image', assets: {} }],
           idempotency_key: 'dddddddd-dddd-dddd-dddd-dddddddddddd',
-          push_notification_config: { url: 'https://buyer.example.com/webhook' },
+          push_notification_config: PUSH_CONFIG,
         },
       },
     });
@@ -141,7 +146,7 @@ describe('sync completion webhook silence', () => {
           account: { account_id: 'acc_1' },
           discovery_mode: 'brief',
           brief: 'sports fans',
-          push_notification_config: { url: 'https://buyer.example.com/webhook' },
+          push_notification_config: PUSH_CONFIG,
         },
       },
     });
@@ -158,7 +163,7 @@ describe('sync completion webhook silence', () => {
         name: 'create_media_buy',
         arguments: {
           ...ARGS_BASE,
-          push_notification_config: { url: 'https://buyer.example.com/webhook' },
+          push_notification_config: PUSH_CONFIG,
         },
       },
     });
@@ -185,7 +190,7 @@ describe('sync completion webhook silence', () => {
         name: 'create_media_buy',
         arguments: {
           ...ARGS_BASE,
-          push_notification_config: { url: 'https://buyer.example.com/webhook' },
+          push_notification_config: PUSH_CONFIG,
         },
       },
     });
@@ -201,7 +206,7 @@ describe('sync completion webhook silence', () => {
         name: 'create_media_buy',
         arguments: {
           ...ARGS_BASE,
-          push_notification_config: { url: 'https://buyer.example.com/webhook', token: 'shhh' },
+          push_notification_config: { ...PUSH_CONFIG, token: 'shhh' },
         },
       },
     });
@@ -228,7 +233,7 @@ describe('sync completion webhook silence', () => {
         name: 'create_media_buy',
         arguments: {
           ...ARGS_BASE,
-          push_notification_config: { url: 'https://buyer.example.com/webhook' },
+          push_notification_config: PUSH_CONFIG,
         },
       },
     });
@@ -247,7 +252,7 @@ describe('sync completion webhook silence', () => {
           account: { account_id: 'acc_1' },
           creatives: [{ creative_id: 'cr_1', name: 'Creative 1', format_kind: 'image', assets: {} }],
           idempotency_key: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
-          push_notification_config: { url: 'https://buyer.example.com/webhook' },
+          push_notification_config: PUSH_CONFIG,
         },
       },
     });
@@ -265,7 +270,7 @@ describe('sync completion webhook silence', () => {
           account: { account_id: 'acc_1' },
           media_buy_id: 'mb_42',
           idempotency_key: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
-          push_notification_config: { url: 'https://buyer.example.com/webhook' },
+          push_notification_config: PUSH_CONFIG,
         },
       },
     });
@@ -297,7 +302,7 @@ describe('sync completion webhook silence', () => {
         name: 'create_media_buy',
         arguments: {
           ...ARGS_BASE,
-          push_notification_config: { url: 'https://buyer.example.com/webhook' },
+          push_notification_config: PUSH_CONFIG,
         },
       },
     });

--- a/test/server-decisioning-from-platform.test.js
+++ b/test/server-decisioning-from-platform.test.js
@@ -3650,7 +3650,7 @@ describe('HITL dual-method dispatch — *Task variants', () => {
     const productsPush = await dispatchGetProducts(productsServer, {
       buying_mode: 'wholesale',
       brief: undefined,
-      push_notification_config: { url: 'https://buyer.example.com/webhook' },
+      push_notification_config: { url: 'https://buyer.example.com/webhook', operation_id: 'op_products_wholesale' },
     });
     assert.strictEqual(productsPush.isError, true);
     assert.strictEqual(productsPush.structuredContent.adcp_error.code, 'INVALID_REQUEST');
@@ -3692,7 +3692,7 @@ describe('HITL dual-method dispatch — *Task variants', () => {
     const signalsPush = await dispatchGetSignals(signalsServer, {
       discovery_mode: 'wholesale',
       brief: undefined,
-      push_notification_config: { url: 'https://buyer.example.com/webhook' },
+      push_notification_config: { url: 'https://buyer.example.com/webhook', operation_id: 'op_signals_wholesale' },
     });
     assert.strictEqual(signalsPush.isError, true);
     assert.strictEqual(signalsPush.structuredContent.adcp_error.code, 'INVALID_REQUEST');
@@ -5888,7 +5888,7 @@ describe('Observability hooks (DecisioningObservabilityHooks)', () => {
           start_time: '2026-05-01T00:00:00Z',
           end_time: '2026-06-01T00:00:00Z',
           account: { account_id: 'acc_1' },
-          push_notification_config: { url: 'https://buyer.example.com/webhook' },
+          push_notification_config: { url: 'https://buyer.example.com/webhook', operation_id: 'op_registry_failure' },
         },
       },
     });
@@ -5964,7 +5964,7 @@ describe('Observability hooks (DecisioningObservabilityHooks)', () => {
           start_time: '2026-05-01T00:00:00Z',
           end_time: '2026-06-01T00:00:00Z',
           account: { account_id: 'acc_1' },
-          push_notification_config: { url: 'https://buyer.example.com/webhook' },
+          push_notification_config: { url: 'https://buyer.example.com/webhook', operation_id: 'op_observability' },
         },
       },
     });
@@ -6152,7 +6152,7 @@ describe('HITL push notification webhook on terminal state', () => {
     assertMcpWebhookPayloadValid(emit.payload);
   });
 
-  it('treats webhook URL as opaque when push config omits operation_id', async () => {
+  it('rejects beta.5 webhook registration when operation_id is omitted', async () => {
     const emits = [];
     const fakeEmitter = {
       emit: async params => {
@@ -6180,6 +6180,8 @@ describe('HITL push notification webhook on terminal state', () => {
           start_time: '2026-05-01T00:00:00Z',
           end_time: '2026-06-01T00:00:00Z',
           account: { account_id: 'acc_1' },
+          adcp_major_version: 3,
+          adcp_version: '3.2-beta.5',
           push_notification_config: {
             url: 'https://buyer.example.com/step/create_media_buy/op_url_must_not_be_parsed',
             token: 'webhook-token-1234',
@@ -6188,15 +6190,10 @@ describe('HITL push notification webhook on terminal state', () => {
       },
     });
 
-    assert.strictEqual(result.structuredContent.status, 'submitted');
-    await server.awaitTask(result.structuredContent.task_id);
-
-    assert.strictEqual(emits.length, 1, 'one webhook emitted on terminal completion');
-    assert.ok(emits[0].payload.operation_id.startsWith('create_media_buy.'));
-    assert.match(emits[0].delivery_id, /^task-webhook:acc_1:create_media_buy:task_/);
-    assert.notStrictEqual(emits[0].payload.operation_id, 'op_url_must_not_be_parsed');
-    assert.notStrictEqual(emits[0].delivery_id, 'op_url_must_not_be_parsed');
-    assertMcpWebhookPayloadValid(emits[0].payload);
+    assert.strictEqual(result.isError, true);
+    assert.strictEqual(result.structuredContent.adcp_error.code, 'INVALID_REQUEST');
+    assert.strictEqual(result.structuredContent.adcp_error.field, 'push_notification_config.operation_id');
+    assert.strictEqual(emits.length, 0);
   });
 
   it('emits webhook on failed task with structured error', async () => {
@@ -6229,7 +6226,7 @@ describe('HITL push notification webhook on terminal state', () => {
           start_time: '2026-05-01T00:00:00Z',
           end_time: '2026-06-01T00:00:00Z',
           account: { account_id: 'acc_1' },
-          push_notification_config: { url: 'https://buyer.example.com/webhook' },
+          push_notification_config: { url: 'https://buyer.example.com/webhook', operation_id: 'op_failed_task' },
         },
       },
     });
@@ -6328,7 +6325,11 @@ describe('Push notification webhook URL/token validation (B5/B6)', () => {
   }
 
   async function dispatchWithUrl(server, url, token) {
-    return dispatchWithPushConfig(server, { url, ...(token != null && { token }) });
+    return dispatchWithPushConfig(server, {
+      url,
+      operation_id: 'op_url_validation',
+      ...(token != null && { token }),
+    });
   }
 
   function makeServer({ warns, emits } = {}) {
@@ -6451,7 +6452,7 @@ describe('Push notification webhook URL/token validation (B5/B6)', () => {
   });
 
   for (const [label, operationId, reasonFragment] of [
-    ['non-string operation_id', 123, 'must be a string'],
+    ['non-string operation_id', 123, 'must match'],
     ['empty operation_id', '', 'must match'],
     ['operation_id over 255 chars', 'a'.repeat(256), 'must match'],
     ['operation_id with invalid character', 'op/bad', 'must match'],
@@ -6561,7 +6562,10 @@ describe('tasks_get wire tool (B9)', () => {
     const taskId = await createTask(server, 'acc_owner');
     const result = await server.dispatchTestRequest({
       method: 'tools/call',
-      params: { name: 'tasks_get', arguments: { task_id: taskId, account: { account_id: 'acc_owner' } } },
+      params: {
+        name: 'tasks_get',
+        arguments: { task_id: taskId, account: { account_id: 'acc_owner' }, include_result: true },
+      },
     });
     assert.notStrictEqual(result.isError, true, JSON.stringify(result.structuredContent));
     const payload = result.structuredContent;
@@ -6598,7 +6602,10 @@ describe('tasks_get wire tool (B9)', () => {
             start_time: '2026-05-01T00:00:00Z',
             end_time: '2026-06-01T00:00:00Z',
             account: { account_id: 'acc_owner' },
-            push_notification_config: { url: 'https://buyer.example/webhooks/tasks' },
+            push_notification_config: {
+              url: 'https://buyer.example/webhooks/tasks',
+              operation_id: 'op_submitted_task_tools',
+            },
           },
         },
       });

--- a/test/server-decisioning-postgres-task-registry.test.js
+++ b/test/server-decisioning-postgres-task-registry.test.js
@@ -91,6 +91,49 @@ describe('getDecisioningTaskRegistryMigration', () => {
       'missing ownerScope should fail closed before issuing a broad DB query'
     );
   });
+
+  test('in-memory registry preserves rejected and canceled terminal records', async () => {
+    const { createInMemoryTaskRegistry } = require('../dist/lib/server/decisioning/runtime/task-registry');
+    const registry = createInMemoryTaskRegistry();
+
+    for (const status of ['rejected', 'canceled']) {
+      const { taskId } = await registry.create({ tool: 'create_media_buy', accountId: 'acct_1' });
+      const seeded = await registry.getTask(taskId);
+      seeded.status = status;
+      seeded.result = { terminal: status };
+
+      await registry.updateProgress(taskId, { percent: 50, message: 'must not overwrite' });
+      await registry.complete(taskId, { terminal: 'completed' });
+      await registry.fail(taskId, { code: 'INVALID_STATE', message: 'must not overwrite' });
+
+      const record = await registry.getTask(taskId);
+      assert.strictEqual(record.status, status);
+      assert.deepStrictEqual(record.result, { terminal: status });
+      assert.strictEqual(record.progress, undefined);
+      assert.strictEqual(record.error, undefined);
+    }
+  });
+
+  test('Postgres registry fences every terminal status in all update queries', async () => {
+    const { createPostgresTaskRegistry } = require('../dist/lib/server/decisioning');
+    const queries = [];
+    const pool = {
+      async query(text) {
+        queries.push(text);
+        return { rowCount: 0, rows: [] };
+      },
+    };
+    const registry = createPostgresTaskRegistry({ pool });
+
+    await registry.updateProgress('task_terminal', { percent: 50 });
+    await registry.complete('task_terminal', { terminal: 'completed' });
+    await registry.fail('task_terminal', { code: 'INVALID_STATE', message: 'must not overwrite' });
+
+    assert.strictEqual(queries.length, 3);
+    for (const query of queries) {
+      assert.match(query, /status NOT IN \('completed', 'failed', 'rejected', 'canceled'\)/);
+    }
+  });
 });
 
 describe('createPostgresTaskRegistry', { skip: !DATABASE_URL && 'DATABASE_URL not set' }, () => {
@@ -181,17 +224,20 @@ describe('createPostgresTaskRegistry', { skip: !DATABASE_URL && 'DATABASE_URL no
     const registry = createPostgresTaskRegistry({ pool });
     const { taskId } = await registry.create({ tool: 'sync_creatives', accountId: 'acc_1' });
 
-    await registry.fail(taskId, {
+    const error = {
       code: 'GOVERNANCE_DENIED',
       recovery: 'terminal',
       message: 'operator declined the buy',
-    });
+    };
+    const artifact = { errors: [error] };
+    await registry.fail(taskId, error, artifact);
 
     let record = await registry.getTask(taskId);
     assert.strictEqual(record.status, 'failed');
     assert.strictEqual(record.error.code, 'GOVERNANCE_DENIED');
     assert.strictEqual(record.error.recovery, 'terminal');
     assert.strictEqual(record.statusMessage, 'operator declined the buy');
+    assert.deepStrictEqual(record.result, artifact);
 
     // Second fail is a no-op
     await registry.fail(taskId, { code: 'INVALID_STATE', recovery: 'correctable', message: 'should not overwrite' });

--- a/test/server-idempotency.test.js
+++ b/test/server-idempotency.test.js
@@ -484,6 +484,7 @@ describe('createAdcpServer with idempotency', () => {
       governance_context: 'governance-token-v1',
       push_notification_config: {
         url: 'https://buyer.example/callback',
+        operation_id: 'op_finalize_proposal_2',
         token: 'receipt-token',
         authentication: { schemes: ['HMAC-SHA256'], credentials: 'secret-v1' },
       },

--- a/test/webhook-rfc9421-client.test.js
+++ b/test/webhook-rfc9421-client.test.js
@@ -1201,15 +1201,51 @@ describe('webhook registration provenance', () => {
   test('prepares MCP and A2A placement exactly and never treats reporting_webhook as task registration', async () => {
     const reporting = { url: 'https://buyer.example/reporting' };
     const callbackUrl = 'https://buyer.example/webhook/op-placement';
-    const mcp = prepareProtocolToolCall(agent, { reporting_webhook: reporting }, { webhookUrl: callbackUrl });
+    const operationId = 'op-placement';
+    const mcp = prepareProtocolToolCall(
+      agent,
+      { reporting_webhook: reporting },
+      { webhookUrl: callbackUrl, operationId }
+    );
     assert.strictEqual(mcp.args.reporting_webhook, reporting);
-    assert.deepStrictEqual(mcp.args.push_notification_config, { url: callbackUrl });
+    assert.deepStrictEqual(mcp.args.push_notification_config, { url: callbackUrl, operation_id: operationId });
 
     const a2aAgent = { ...agent, protocol: 'a2a' };
-    const a2a = prepareProtocolToolCall(a2aAgent, { reporting_webhook: reporting }, { webhookUrl: callbackUrl });
+    const a2a = prepareProtocolToolCall(
+      a2aAgent,
+      { reporting_webhook: reporting },
+      { webhookUrl: callbackUrl, operationId }
+    );
     assert.strictEqual(a2a.args.reporting_webhook, reporting);
-    assert.strictEqual(a2a.args.push_notification_config, undefined);
+    assert.deepStrictEqual(a2a.args.push_notification_config, { url: callbackUrl, operation_id: operationId });
     assert.deepStrictEqual(a2a.pushNotificationConfig, { url: callbackUrl });
+
+    const inProcess = prepareProtocolToolCall(
+      { ...agent, _inProcessMcpClient: {} },
+      {},
+      { webhookUrl: callbackUrl, operationId }
+    );
+    assert.deepStrictEqual(inProcess.args.push_notification_config, { url: callbackUrl, operation_id: operationId });
+
+    const legacyA2a = prepareProtocolToolCall(a2aAgent, {}, { webhookUrl: callbackUrl, adcpVersion: '3.1.18' });
+    assert.strictEqual(legacyA2a.args.push_notification_config, undefined);
+    assert.deepStrictEqual(legacyA2a.pushNotificationConfig, { url: callbackUrl });
+
+    const callerDowngrade = prepareProtocolToolCall(
+      a2aAgent,
+      { adcp_version: '3.1', adcp_major_version: 3 },
+      { webhookUrl: callbackUrl, operationId }
+    );
+    assert.strictEqual(callerDowngrade.args.push_notification_config, undefined);
+    const callerUpgrade = prepareProtocolToolCall(
+      a2aAgent,
+      { adcp_version: '3.2-beta.5', adcp_major_version: 3 },
+      { webhookUrl: callbackUrl, operationId, adcpVersion: '3.1.18' }
+    );
+    assert.deepStrictEqual(callerUpgrade.args.push_notification_config, {
+      url: callbackUrl,
+      operation_id: operationId,
+    });
 
     const args = { reporting_webhook: reporting };
     const prepared = { args: { ...args, exact_marker: true } };


### PR DESCRIPTION
## Summary

- carry the buyer operation ID in beta.5 application-layer webhook registration across MCP, in-process MCP, and A2A while keeping native A2A push configuration distinct
- reject missing or malformed beta.5 operation IDs before seller dispatch, preserving older wire behavior
- converge terminal webhook re-emissions across delivery keys with seller, buyer-operation, and task scoping
- return canonical completed, failed, and rejected task artifacts when polling with `include_result`
- document the beta.5 migration and add a patch changeset

## Validation

- `npm run typecheck`
- `npm run ci:codegen-strict`
- `npm run format:check`
- `npm run test:protocols`
- 10 changed-area suites, 528 tests passed
- protocol, code, and security expert reviews: SHIP
- `npm run review:codex -- --all --base main`: no blocking findings
