### PR TITLE
fix(testing): align local storyboard schema grading

### DIFF
--- a/.changeset/strict-storyboards-open-scenarios.md
+++ b/.changeset/strict-storyboards-open-scenarios.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Make SDK test clients, including `createTestClient`, and authored storyboard response-schema checks grade strict JSON Schema verdicts by default so local CLI and programmatic preflight results match hosted compliance grading. Add `strictResponseSchemaValidation: false` as a packaged-schema diagnostic migration escape hatch, and preserve implementation-specific strings in `compliance_testing.scenarios`.

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -2012,6 +2012,8 @@ SUBCOMMANDS:
   step <agent> <id> <step_id>  Run a single step (stateless, LLM-friendly)
 
 RUN OPTIONS (full assessment):
+  Response-schema checks are strict and grading by default, matching the
+  hosted compliance grader. JSON output includes strict_validation_summary.
   --tracks TRACKS     Comma-separated tracks to include in the report
   --storyboards IDS   Comma-separated storyboard/bundle IDs to run
   --compliance-version VERSION

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -1049,6 +1049,10 @@ function parseAgentOptions(args) {
   const debug = args.includes('--debug') || process.env.ADCP_DEBUG === 'true';
   const dryRun = args.includes('--dry-run');
   const allowHttp = args.includes('--allow-http');
+  // Migration escape hatch for compatibility harnesses that are testing
+  // transport/version behavior against a known schema-invalid legacy seller.
+  // Normal local compliance runs remain strict by default.
+  const strictResponseSchemaValidation = !args.includes('--no-strict-response-schema-validation');
   // `--no-sandbox` forces `account.sandbox: false` (production) on every
   // request the runner builds. The default behavior leaves the field unset
   // (spec-equivalent to false), but agents that key sandbox routing on
@@ -1233,6 +1237,7 @@ function parseAgentOptions(args) {
     debug,
     dryRun,
     allowHttp,
+    strictResponseSchemaValidation,
     noSandbox,
     assertsSeededState,
     mediaBuyLifecycleCompatibility,
@@ -2014,6 +2019,9 @@ SUBCOMMANDS:
 RUN OPTIONS (full assessment):
   Response-schema checks are strict and grading by default, matching the
   hosted compliance grader. JSON output includes strict_validation_summary.
+  --no-strict-response-schema-validation
+                      Keep packaged-schema strict failures diagnostic-only.
+                      Intended only for temporary legacy migration harnesses.
   --tracks TRACKS     Comma-separated tracks to include in the report
   --storyboards IDS   Comma-separated storyboard/bundle IDs to run
   --compliance-version VERSION
@@ -2890,6 +2898,7 @@ async function handleStoryboardRun(args) {
     ...(webhookReceiverOpts ?? {}),
     ...(fileComplianceVersion && { adcpVersion: fileComplianceVersion }),
     ...(fileSchemaRoot && { schemaRoot: fileSchemaRoot }),
+    ...(!opts.strictResponseSchemaValidation && { strictResponseSchemaValidation: false }),
     ...(opts.noSandbox && { sandbox: false, disable_sandbox: true }),
     ...(opts.assertsSeededState && { assertsSeededState: true }),
     ...(opts.mediaBuyLifecycleCompatibility && {
@@ -3731,6 +3740,7 @@ async function handleLocalAgentStoryboardRun(modulePath, args, opts) {
       compliance: resolveOptions,
       ...(opts.complianceVersion ||
       opts.schemaRoot ||
+      !opts.strictResponseSchemaValidation ||
       opts.noSandbox ||
       opts.assertsSeededState ||
       opts.mediaBuyLifecycleCompatibility ||
@@ -3739,6 +3749,7 @@ async function handleLocalAgentStoryboardRun(modulePath, args, opts) {
             runStoryboardOptions: {
               ...(opts.complianceVersion && !opts.complianceDir && { adcpVersion: opts.complianceVersion }),
               ...(opts.schemaRoot && { schemaRoot: opts.schemaRoot }),
+              ...(!opts.strictResponseSchemaValidation && { strictResponseSchemaValidation: false }),
               ...(opts.noSandbox && { sandbox: false, disable_sandbox: true }),
               ...(opts.assertsSeededState && { assertsSeededState: true }),
               ...(opts.mediaBuyLifecycleCompatibility && {
@@ -4159,6 +4170,7 @@ async function handleMultiInstanceStoryboardRun(args, opts, urls) {
     ...(webhookReceiverOpts ?? {}),
     ...(opts.complianceVersion && !opts.complianceDir && { adcpVersion: opts.complianceVersion }),
     ...(opts.schemaRoot && { schemaRoot: opts.schemaRoot }),
+    ...(!opts.strictResponseSchemaValidation && { strictResponseSchemaValidation: false }),
     ...(opts.noSandbox && { sandbox: false, disable_sandbox: true }),
     ...(opts.assertsSeededState && { assertsSeededState: true }),
     ...(opts.mediaBuyLifecycleCompatibility && {
@@ -4426,6 +4438,7 @@ async function handleAgentsRoutedStoryboardRun(args, opts, routing) {
     ...(webhookReceiverOpts ?? {}),
     ...(opts.complianceVersion && !opts.complianceDir && { adcpVersion: opts.complianceVersion }),
     ...(opts.schemaRoot && { schemaRoot: opts.schemaRoot }),
+    ...(!opts.strictResponseSchemaValidation && { strictResponseSchemaValidation: false }),
     ...(opts.noSandbox && { sandbox: false, disable_sandbox: true }),
     ...(opts.assertsSeededState && { assertsSeededState: true }),
     ...(opts.mediaBuyLifecycleCompatibility && {
@@ -4653,6 +4666,7 @@ async function runFullAssessment(agentArg, rawArgs, parsedOpts) {
     ...(opts.complianceVersion && { version: opts.complianceVersion }),
     ...(opts.complianceDir && { complianceDir: opts.complianceDir }),
     ...(opts.schemaRoot && { schemaRoot: opts.schemaRoot }),
+    ...(!opts.strictResponseSchemaValidation && { strictResponseSchemaValidation: false }),
     ...(opts.hostedStableLineAlias && { hostedStableLineAlias: opts.hostedStableLineAlias }),
   };
 
@@ -4802,6 +4816,7 @@ async function handleStoryboardStepCmd(args) {
     positionalArgs,
     complianceVersion,
     schemaRoot,
+    strictResponseSchemaValidation,
     mediaBuyLifecycleCompatibility,
   } = parseAgentOptions(args);
   const { resolveOptions } = parseComplianceSelection(args);
@@ -4859,6 +4874,7 @@ async function handleStoryboardStepCmd(args) {
     request,
     ...(complianceVersion && { adcpVersion: complianceVersion }),
     ...(schemaRoot && { schemaRoot }),
+    ...(!strictResponseSchemaValidation && { strictResponseSchemaValidation: false }),
     ...(mediaBuyLifecycleCompatibility && {
       mediaBuyLifecycleCompatibility,
     }),

--- a/docs/guides/VALIDATE-YOUR-AGENT.md
+++ b/docs/guides/VALIDATE-YOUR-AGENT.md
@@ -86,6 +86,8 @@ delta for diagnostics. Programmatic migration tooling can temporarily pass
 `strictResponseSchemaValidation: false` to `runStoryboard()` or `comply()` to
 restore the historical informational-only posture when using packaged schemas.
 An explicit external `schemaRoot` always remains authoritative.
+The CLI equivalent is `--no-strict-response-schema-validation`; reserve it for
+temporary legacy compatibility harnesses rather than routine compliance runs.
 
 **Flags you'll actually use:**
 

--- a/docs/guides/VALIDATE-YOUR-AGENT.md
+++ b/docs/guides/VALIDATE-YOUR-AGENT.md
@@ -78,6 +78,15 @@ npx @adcp/sdk@adcp-3.1 storyboard run http://localhost:3001/mcp --file ./my-wip.
 npx @adcp/sdk@adcp-3.1 storyboard run http://localhost:3001/mcp --json > report.json
 ```
 
+Storyboard `response_schema` checks use strict JSON Schema validation for
+grading by default, matching the hosted compliance grader. A strict failure
+therefore fails the owning step even when the generated lenient Zod projection
+would accept the response; `strict_validation_summary` still reports that
+delta for diagnostics. Programmatic migration tooling can temporarily pass
+`strictResponseSchemaValidation: false` to `runStoryboard()` or `comply()` to
+restore the historical informational-only posture when using packaged schemas.
+An explicit external `schemaRoot` always remains authoritative.
+
 **Flags you'll actually use:**
 
 - `--tracks <a,b,c>` — limit to named tracks (e.g., `core,products,security_baseline`)

--- a/scripts/ci/run_storyboard_strict_3_0_reference_seller.sh
+++ b/scripts/ci/run_storyboard_strict_3_0_reference_seller.sh
@@ -348,6 +348,7 @@ RUN_STATUS=0
 ADCP_AUTH_TOKEN="$ADCP_AUTH_TOKEN" "${RUNNER_CMD[@]}" storyboard run "http://127.0.0.1:$ADCP_PORT/mcp" "$ADCP_STORYBOARD_ID" \
   --json \
   --allow-http \
+  --no-strict-response-schema-validation \
   --timeout "$ADCP_RUNNER_TIMEOUT_SECONDS" >"$STORYBOARD_RESULT_PATH" 2>>"$SELLER_LOG_PATH" || RUN_STATUS=$?
 
 log "Probing get_products through candidate SDK with major-only envelope"

--- a/src/lib/server/decisioning/capabilities.ts
+++ b/src/lib/server/decisioning/capabilities.ts
@@ -618,11 +618,11 @@ export type BrandCapabilities = NonNullable<NonNullable<GetAdCPCapabilitiesRespo
  */
 export interface ComplianceTestingCapabilities {
   /**
-   * Scenarios this agent advertises support for. Wire enum is the
-   * canonical scenario enum, excluding `list_scenarios` because that
-   * is a discovery operation rather than a test capability. Framework
-   * defaults this from the adopter-supplied `complyTest` adapter set
-   * when omitted.
+   * Scenarios this agent advertises support for. The wire field is open to
+   * implementation-specific string values; canonical controller scenarios
+   * are recommendations, not an enum constraint. `list_scenarios` remains a
+   * discovery operation rather than a test capability. Framework defaults
+   * this from the adopter-supplied `complyTest` adapter set when omitted.
    */
   scenarios?: ReadonlyArray<_ComplianceTestingScenario>;
 }

--- a/src/lib/server/decisioning/decisioning.type-checks.ts
+++ b/src/lib/server/decisioning/decisioning.type-checks.ts
@@ -804,6 +804,13 @@ function _define_platform_with_compliance_accepts_ct(p: _PlatformWithCT): _Platf
   return definePlatformWithCompliance(p);
 }
 
+// Positive: the capability schema is deliberately open to seller-specific
+// scenario names; canonical controller constants are recommendations only.
+const _custom_compliance_scenario: ComplianceTestingCapabilities = {
+  scenarios: ['seller_custom_fixture_reset'],
+};
+void _custom_compliance_scenario;
+
 // Negative: definePlatformWithCompliance rejects a platform missing compliance_testing
 // (compliance_testing is optional on DecisioningPlatformCapabilities, required by the helper).
 function _define_platform_with_compliance_rejects_missing_ct() {

--- a/src/lib/testing/client.ts
+++ b/src/lib/testing/client.ts
@@ -32,6 +32,7 @@ interface TestClientVersionOptions {
   adcpVersion: string;
   wireAdcpVersion?: string;
   versionEnvelope: VersionEnvelopeMode;
+  strictResponseSchemaValidation: boolean;
   authMode?: string;
   fetchFn?: typeof fetch;
   maxResponseBytes?: number;
@@ -194,7 +195,10 @@ export function createTestClient(agentUrl: string, protocol: 'mcp' | 'a2a' = 'mc
 
   const multiClient = new ADCPMultiAgentClient([agentConfig], {
     headers,
-    validation: { logSchemaViolations: false },
+    validation: {
+      responses: options.strictResponseSchemaValidation === false ? 'warn' : 'strict',
+      logSchemaViolations: false,
+    },
     ...(options.adcpVersion !== undefined && { adcpVersion: options.adcpVersion }),
     ...(options.wireAdcpVersion !== undefined && { wireAdcpVersion: options.wireAdcpVersion }),
     ...(options.versionEnvelope !== undefined && { versionEnvelope: options.versionEnvelope }),
@@ -209,6 +213,7 @@ export function createTestClient(agentUrl: string, protocol: 'mcp' | 'a2a' = 'mc
       adcpVersion: multiClient.getAdcpVersion(),
       ...(options.wireAdcpVersion !== undefined && { wireAdcpVersion: options.wireAdcpVersion }),
       versionEnvelope: options.versionEnvelope ?? 'auto',
+      strictResponseSchemaValidation: options.strictResponseSchemaValidation !== false,
       ...(authMode !== undefined && { authMode }),
       ...(options.transport?.trustedFetchFn && { fetchFn: options.transport.trustedFetchFn }),
       ...(options.transport?.maxResponseBytes !== undefined && {
@@ -273,6 +278,7 @@ function testClientMatchesVersionOptions(client: TestClient, options: TestOption
     meta.adcpVersion === expectedAdcpVersion &&
     meta.wireAdcpVersion === expectedWireAdcpVersion &&
     meta.versionEnvelope === expectedVersionEnvelope &&
+    meta.strictResponseSchemaValidation === (effectiveOptions.strictResponseSchemaValidation !== false) &&
     meta.authMode === expectedAuthMode &&
     meta.fetchFn === effectiveOptions.transport?.trustedFetchFn &&
     meta.maxResponseBytes === effectiveOptions.transport?.maxResponseBytes &&

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -5449,6 +5449,7 @@ async function executeStep(
       taskName: effectiveStep.task,
       ...(options.adcpVersion && { adcpVersion: options.adcpVersion }),
       ...(options._serverAdcpVersion && { responseAdcpVersion: options._serverAdcpVersion }),
+      strictResponseSchemaValidation: options.strictResponseSchemaValidation !== false,
       ...(validationTaskResult && { taskResult: validationTaskResult }),
       ...(httpResult && { httpResult }),
       agentUrl: runState.agentUrl,
@@ -5558,6 +5559,7 @@ async function executeStep(
       taskName: effectiveStep.task,
       ...(options.adcpVersion && { adcpVersion: options.adcpVersion }),
       ...(options._serverAdcpVersion && { responseAdcpVersion: options._serverAdcpVersion }),
+      strictResponseSchemaValidation: options.strictResponseSchemaValidation !== false,
       ...(validationTaskResult && { taskResult: validationTaskResult }),
       agentUrl: runState.agentUrl,
       contributions: runState.contributions,
@@ -6317,6 +6319,7 @@ async function executeProbeStep(
     taskName: step.task === REPLAY_TRUSTED_MATCH_CONTEXT_VECTOR_TASK ? 'context_match' : step.task,
     ...(options.adcpVersion && { adcpVersion: options.adcpVersion }),
     ...(options._serverAdcpVersion && { responseAdcpVersion: options._serverAdcpVersion }),
+    strictResponseSchemaValidation: options.strictResponseSchemaValidation !== false,
     httpResult: redactedHttpResult,
     ...(step.task === REPLAY_TRUSTED_MATCH_CONTEXT_VECTOR_TASK &&
       redactedHttpResult && {

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -2414,33 +2414,29 @@ export interface ValidationResult {
   observations?: unknown[];
   /**
    * Non-fatal human-readable warning attached when a check `passed` but
-   * detected a softer issue the caller should still see — today used only
-   * by `response_schema` to surface the top strict-AJV issue when Zod
-   * accepts and AJV rejects (the "lenient-passes ∧ strict-fails" subset
-   * of issue #820). LLM-driven self-correction and CI graphs that scan
-   * `error`/`warning` fields can act on this without the runner flipping
-   * step pass/fail and breaking existing tests.
+   * detected a softer issue the caller should still see. `response_schema`
+   * uses this for variant-fallback diagnostics and, when strict grading is
+   * explicitly disabled, strict-only AJV findings. LLM-driven self-correction
+   * and CI graphs that scan `error`/`warning` fields can act on the warning.
    */
   warning?: string;
   /**
    * Issue #820 follow-up — strict JSON-schema (AJV) verdict for
-   * `response_schema` checks. `passed` remains the lenient Zod outcome
-   * (runner's historical packaged-cache semantics); `strict` carries the
-   * AJV-with-formats-and-additionalProperties verdict separately so agent
-   * developers can see the strict/lenient delta. When the run supplies an
-   * external `schemaRoot`, its AJV verdict is authoritative and may drive
-   * `passed`. Absent on non-response_schema checks or when no AJV schema is
-   * available.
+   * `response_schema` checks. Packaged-schema storyboard runs grade this
+   * verdict by default; `strictResponseSchemaValidation: false` restores the
+   * historical lenient grade while retaining the verdict as diagnostics.
+   * An external `schemaRoot` is always authoritative. Absent on
+   * non-response_schema checks or when no AJV schema is available.
    */
   strict?: StrictValidationVerdict;
 }
 
 /**
  * Strict (AJV JSON-schema) verdict attached to a response_schema
- * validation result. Informational for packaged-cache runs, where step
- * pass/fail remains driven by the lenient Zod path. Authoritative for runs
- * with an external `schemaRoot`, so current protocol source is not gated by
- * the SDK's generated Zod snapshot.
+ * validation result. Authoritative by default for packaged-cache storyboard
+ * runs and always authoritative for runs with an external `schemaRoot`.
+ * Packaged-cache callers may explicitly make it informational with
+ * `strictResponseSchemaValidation: false` during migrations.
  */
 export interface StrictValidationVerdict {
   valid: boolean;
@@ -3153,8 +3149,10 @@ export interface StrictValidationSummary {
    * Count of validations where lenient Zod accepted AND strict AJV
    * rejected — the "silent failures" the agent ships today that a strict
    * dispatcher would block. Subset of `failed`. This is the actionable
-   * production-readiness signal for agent developers: a green lenient run
-   * with `strict_only_failures > 0` is a migration trap.
+   * production-readiness signal for agent developers. With the default
+   * strict grading these failures make the owning step fail; callers that
+   * explicitly disable strict grading can still use this count as migration
+   * telemetry.
    */
   strict_only_failures: number;
   /**

--- a/src/lib/testing/storyboard/validations.ts
+++ b/src/lib/testing/storyboard/validations.ts
@@ -59,6 +59,8 @@ export interface ValidationContext {
   adcpVersion?: string;
   /** Server-declared AdCP version to use for response-shape compatibility decisions. */
   responseAdcpVersion?: string;
+  /** Make a strict AJV response-schema rejection fail the validation. */
+  strictResponseSchemaValidation?: boolean;
   taskResult?: TaskResult;
   httpResult?: HttpProbeResult;
   agentUrl: string;
@@ -612,9 +614,10 @@ function validateResponseSchema(
   // packaged verdict.
   if (!parseResult) return noResponseSchemaResult(validation, taskName, schema_id, schema_url, strict);
 
-  // Strict (AJV) verdict runs alongside the lenient Zod check so packaged-cache
-  // runs surface strictness deltas without changing their historical pass/fail.
-  // Explicit external bundles take the authoritative branch above instead.
+  // Strict (AJV) verdict runs alongside the lenient Zod check. Storyboard runs
+  // grade that verdict by default; direct validation callers and explicit
+  // migration runs can leave it informational. Explicit external bundles take
+  // the authoritative branch above instead.
 
   // Shape-drift no longer rides on `ValidationResult.warning` — issue #935
   // moved that diagnostic to `StoryboardStepResult.hints[]` as a structured
@@ -630,6 +633,25 @@ function validateResponseSchema(
       schema_id,
       schema_url,
     };
+    if (strict && !strict.valid && ctx.strictResponseSchemaValidation === true) {
+      const issues = strict.issues ?? [];
+      const firstIssue = issues[0];
+      return {
+        ...base,
+        passed: false,
+        error:
+          issues.length > 0
+            ? issues
+                .slice(0, 5)
+                .map(issue => `${issue.instance_path || '/'}: ${issue.message}`)
+                .join('; ')
+            : `Strict JSON Schema rejected the ${taskName} response`,
+        json_pointer: firstIssue?.instance_path || null,
+        expected: schema_id ?? `response schema for ${taskName}`,
+        actual: issues,
+        strict,
+      };
+    }
     // Surface strict-only / variant-fallback signal via `warning` so step-
     // level output (and LLM-driven self-correction that scans `error`/
     // `warning` fields) sees something without flipping `passed`.

--- a/src/lib/testing/types.ts
+++ b/src/lib/testing/types.ts
@@ -116,6 +116,17 @@ export interface TestOptions {
    * authoritative over the SDK's generated Zod snapshot for the run.
    */
   schemaRoot?: string;
+  /**
+   * Whether strict AJV response-schema failures contribute to storyboard
+   * grading. Defaults to `true`, matching the hosted compliance grader.
+   *
+   * Set to `false` only for packaged-schema diagnostic migrations that need
+   * the historical lenient-Zod grade while inspecting
+   * `strict_validation_summary` and the per-validation `strict` verdicts.
+   * Strict validation still runs in that mode; it is informational rather
+   * than grading. An explicit external `schemaRoot` remains authoritative.
+   */
+  strictResponseSchemaValidation?: boolean;
   /** Custom User-Agent string sent with all outbound requests */
   userAgent?: string;
   // Brand reference for product discovery (preferred over brand_manifest)

--- a/test/lib/cli-soft-fail.test.js
+++ b/test/lib/cli-soft-fail.test.js
@@ -65,6 +65,19 @@ test('--soft-fail does not affect a passing storyboard ID parse (positional inta
   assert.match(res.stdout, /Storyboards:\s+capability_discovery/);
 });
 
+test('--no-strict-response-schema-validation remains a boolean flag and preserves positionals', () => {
+  const res = runCli([
+    'storyboard',
+    'run',
+    UNREACHABLE,
+    STORYBOARD,
+    '--no-strict-response-schema-validation',
+    '--soft-fail',
+  ]);
+  assert.strictEqual(res.status, 0, `expected exit 0, got ${res.status}. stderr: ${res.stderr}`);
+  assert.match(res.stdout, /Storyboards:\s+capability_discovery/);
+});
+
 test('--summary-file PATH writes the Markdown summary to PATH', () => {
   const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'adcp-soft-fail-'));
   try {

--- a/test/lib/storyboard-rejection-hints-e2e.test.js
+++ b/test/lib/storyboard-rejection-hints-e2e.test.js
@@ -82,6 +82,7 @@ const storyboard = {
 };
 
 const searchResponse = {
+  cache_scope: 'public',
   signals: [
     {
       // Shape matches get-signals-response.json required fields + their

--- a/test/lib/storyboard-security.test.js
+++ b/test/lib/storyboard-security.test.js
@@ -1756,6 +1756,9 @@ describe('security_baseline: unconditional PRM enforcement (#677)', () => {
     return {
       protocol: 'mcp',
       allow_http: true,
+      // These fixtures intentionally exercise auth-routing behavior with a
+      // minimal list_creatives envelope, not response-schema conformance.
+      strictResponseSchemaValidation: false,
       agentTools: ['list_creatives'],
       _profile: { name: 'T', tools: ['list_creatives'] },
       _client: {

--- a/test/lib/storyboard-strict-validation.test.js
+++ b/test/lib/storyboard-strict-validation.test.js
@@ -1,12 +1,13 @@
 /**
  * Strict/lenient response-schema validation + run-level aggregation (issue
  * #820, fourth proposal). `runValidations` must attach an AJV-based strict
- * verdict to every `response_schema` ValidationResult. Packaged-cache runs
- * stay Zod-driven for backwards compatibility; an explicit external schema
- * root makes AJV authoritative for current-source validation.
+ * verdict to every `response_schema` ValidationResult. Storyboard runs grade
+ * the strict verdict by default; direct validation callers can keep it
+ * informational, while an explicit external schema root is always
+ * authoritative for current-source validation.
  *
- * Tests hit the storyboard validation layer directly — `runValidations`
- * with a synthetic `ValidationContext`. No runner boot or network needed.
+ * Most tests hit the storyboard validation layer directly with a synthetic
+ * `ValidationContext`; one runner-level regression locks the public default.
  */
 
 const { describe, test } = require('node:test');
@@ -15,8 +16,14 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 
+const { ProtocolClient } = require('../../dist/lib/index.js');
+const { createTestClient } = require('../../dist/lib/testing/client.js');
 const { runValidations } = require('../../dist/lib/testing/storyboard/validations.js');
-const { summarizeStrictValidation, listStrictOnlyFailures } = require('../../dist/lib/testing/storyboard/runner.js');
+const {
+  runStoryboardStep,
+  summarizeStrictValidation,
+  listStrictOnlyFailures,
+} = require('../../dist/lib/testing/storyboard/runner.js');
 const { _resetValidationLoader, withExternalSchemaRoot } = require('../../dist/lib/validation/schema-loader.js');
 
 const EXTERNAL_VERSION = '9.9.0-beta.1';
@@ -46,6 +53,40 @@ function ctx(taskName, data, responseSchemaRef) {
 
 function ctxWith(taskName, data, responseSchemaRef, extra) {
   return { ...ctx(taskName, data, responseSchemaRef), ...extra };
+}
+
+function strictDeltaCapabilitiesStoryboard() {
+  return {
+    id: 'strict_response_default',
+    version: '1.0.0',
+    title: 'Strict response default',
+    category: 'test',
+    summary: 'Verifies strict response-schema grading defaults.',
+    narrative: '',
+    agent: { interaction_model: 'sync', capabilities: [] },
+    caller: { role: 'buyer_agent' },
+    phases: [
+      {
+        id: 'capabilities',
+        title: 'Capabilities',
+        steps: [
+          {
+            id: 'discover',
+            title: 'Discover capabilities',
+            task: 'get_adcp_capabilities',
+            response_schema_ref: 'protocol/get-adcp-capabilities-response.json',
+            validations: [{ check: 'response_schema', description: 'response conforms' }],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function withoutAuthoredValidations(storyboard) {
+  const copy = structuredClone(storyboard);
+  delete copy.phases[0].steps[0].validations;
+  return copy;
 }
 
 describe('storyboard validations: strict/lenient response_schema delta', () => {
@@ -170,6 +211,146 @@ describe('storyboard validations: strict/lenient response_schema delta', () => {
     assert.ok(v.strict, 'strict verdict attached');
     assert.strictEqual(v.strict.valid, true, 'AJV path accepts');
     assert.strictEqual(v.strict.issues, undefined, 'no issues on a valid response');
+  });
+
+  test('strict grading fails a packaged-schema violation that lenient Zod accepts', () => {
+    const response = {
+      adcp: { major_versions: [3], idempotency: { supported: false } },
+      supported_protocols: ['media_buy'],
+      // The JSON Schema requires at least one advertised scenario. The
+      // generated Zod projection intentionally remains more permissive.
+      compliance_testing: { scenarios: [] },
+    };
+    const [graded] = runValidations(
+      [{ check: 'response_schema', description: 'response conforms' }],
+      ctxWith('get_adcp_capabilities', response, 'protocol/get-adcp-capabilities-response.json', {
+        adcpVersion: '3.1.18',
+        strictResponseSchemaValidation: true,
+      })
+    );
+
+    assert.strictEqual(graded.strict.lenient_valid, true);
+    assert.strictEqual(graded.strict.valid, false);
+    assert.strictEqual(graded.passed, false);
+    assert.match(graded.error, /compliance_testing\/scenarios/);
+
+    const [diagnostic] = runValidations(
+      [{ check: 'response_schema', description: 'response conforms' }],
+      ctxWith('get_adcp_capabilities', response, 'protocol/get-adcp-capabilities-response.json', {
+        strictResponseSchemaValidation: false,
+      })
+    );
+    assert.strictEqual(diagnostic.passed, true, 'explicit opt-out preserves the diagnostic-only grade');
+    assert.match(diagnostic.warning, /strict JSON-schema rejected/);
+  });
+
+  test('storyboard runner grades strict response schemas by default and honors the opt-out', async () => {
+    const response = {
+      adcp: { major_versions: [3], idempotency: { supported: false } },
+      supported_protocols: ['media_buy'],
+      compliance_testing: { scenarios: [] },
+    };
+    const client = {
+      async getAdcpCapabilities() {
+        return { status: 'completed', data: response };
+      },
+    };
+    const profile = {
+      name: 'Strict response stub',
+      tools: ['get_adcp_capabilities'],
+      raw_capabilities: response,
+    };
+    const options = { protocol: 'mcp', _client: client, _profile: profile };
+
+    const graded = await runStoryboardStep(
+      'https://stub.example/mcp',
+      strictDeltaCapabilitiesStoryboard(),
+      'discover',
+      options
+    );
+    const gradedSchema = graded.validations.find(v => v.check === 'response_schema');
+    assert.strictEqual(gradedSchema.strict.lenient_valid, true);
+    assert.strictEqual(gradedSchema.strict.valid, false);
+    assert.strictEqual(gradedSchema.passed, false);
+    assert.strictEqual(graded.passed, false);
+
+    const diagnostic = await runStoryboardStep(
+      'https://stub.example/mcp',
+      strictDeltaCapabilitiesStoryboard(),
+      'discover',
+      { ...options, strictResponseSchemaValidation: false }
+    );
+    const diagnosticSchema = diagnostic.validations.find(v => v.check === 'response_schema');
+    assert.strictEqual(diagnosticSchema.passed, true);
+    assert.strictEqual(diagnostic.passed, true);
+  });
+
+  test('test client enforces strict responses when a step has no authored response_schema check', async () => {
+    const response = {
+      status: 'completed',
+      // Missing required idempotency proves transport-level strict validation
+      // protects steps that do not author a response_schema validation.
+      adcp: { major_versions: [3] },
+      supported_protocols: ['media_buy'],
+      compliance_testing: { scenarios: ['seller_custom_fixture_reset'] },
+    };
+    const profile = {
+      name: 'Strict response stub',
+      tools: ['get_adcp_capabilities'],
+      raw_capabilities: response,
+    };
+    const storyboard = withoutAuthoredValidations(strictDeltaCapabilitiesStoryboard());
+    const originalCallTool = ProtocolClient.callTool;
+    ProtocolClient.callTool = async () => response;
+
+    try {
+      const strictClient = createTestClient('https://stub.example/mcp');
+      strictClient.client.discoveredEndpoint = 'https://stub.example/mcp';
+      const graded = await runStoryboardStep('https://stub.example/mcp', storyboard, 'discover', {
+        protocol: 'mcp',
+        _client: strictClient,
+        _profile: profile,
+      });
+      assert.strictEqual(graded.passed, false);
+      assert.match(graded.error, /Schema validation failed.*idempotency/);
+
+      const diagnosticClient = createTestClient('https://stub.example/mcp', 'mcp', {
+        strictResponseSchemaValidation: false,
+      });
+      diagnosticClient.client.discoveredEndpoint = 'https://stub.example/mcp';
+      const diagnostic = await runStoryboardStep('https://stub.example/mcp', storyboard, 'discover', {
+        protocol: 'mcp',
+        strictResponseSchemaValidation: false,
+        _client: diagnosticClient,
+        _profile: profile,
+      });
+      assert.strictEqual(diagnostic.passed, true);
+      assert.strictEqual(
+        diagnostic.validations.some(v => v.check === 'response_schema'),
+        false
+      );
+    } finally {
+      ProtocolClient.callTool = originalCallTool;
+    }
+  });
+
+  test('implementation-specific compliance scenario strings pass strict validation', () => {
+    const response = {
+      adcp: { major_versions: [3], idempotency: { supported: false } },
+      supported_protocols: ['media_buy'],
+      compliance_testing: { scenarios: ['seller_custom_fixture_reset'] },
+    };
+    const [result] = runValidations(
+      [{ check: 'response_schema', description: 'response conforms' }],
+      ctxWith('get_adcp_capabilities', response, 'protocol/get-adcp-capabilities-response.json', {
+        adcpVersion: '3.1.18',
+        strictResponseSchemaValidation: true,
+      })
+    );
+
+    assert.strictEqual(result.passed, true, result.error);
+    assert.strictEqual(result.strict.valid, true);
+    assert.strictEqual(result.strict.lenient_valid, true);
   });
 
   test('response missing a required field: Zod and AJV both fail; strict.valid=false', () => {

--- a/test/lib/storyboard-version-negotiation.test.js
+++ b/test/lib/storyboard-version-negotiation.test.js
@@ -268,6 +268,15 @@ describe('storyboard runner AdCP version negotiation', () => {
       }),
       shared
     );
+    assert.notStrictEqual(
+      getOrCreateClient('https://example.com/mcp', {
+        _client: shared,
+        adcpVersion: CURRENT_PRERELEASE_VERSION,
+        versionEnvelope: 'auto',
+        strictResponseSchemaValidation: false,
+      }),
+      shared
+    );
   });
 
   test('discovery-only _client is not reused for executable storyboard calls', () => {

--- a/test/server-decisioning-comply-test.test.js
+++ b/test/server-decisioning-comply-test.test.js
@@ -285,7 +285,7 @@ describe('createAdcpServerFromPlatform — comply_test_controller wiring', () =>
     const platform = basePlatform({ withComplianceTesting: true });
     // Adopter wires three adapters but only wants to advertise two.
     platform.capabilities.compliance_testing = {
-      scenarios: ['force_creative_status', 'simulate_delivery'],
+      scenarios: ['force_creative_status', 'simulate_delivery', 'seller_custom_fixture_reset'],
     };
     const server = createAdcpServerFromPlatform(platform, {
       name: 'comply-host',
@@ -326,7 +326,7 @@ describe('createAdcpServerFromPlatform — comply_test_controller wiring', () =>
       params: { name: 'get_adcp_capabilities', arguments: {} },
     });
     const scenarios = result.structuredContent?.compliance_testing?.scenarios;
-    assert.deepStrictEqual(scenarios, ['force_creative_status', 'simulate_delivery']);
+    assert.deepStrictEqual(scenarios, ['force_creative_status', 'simulate_delivery', 'seller_custom_fixture_reset']);
   });
 
   it('does NOT project compliance_testing block when capability + complyTest are both omitted', async () => {


### PR DESCRIPTION
## Summary

- make SDK storyboard/test clients enforce strict response schemas by default, matching hosted compliance grading
- make authored `response_schema` validations grade strict AJV verdicts by default, with an explicit diagnostic opt-out
- preserve implementation-specific `compliance_testing.scenarios` strings and document the updated behavior
- add regression coverage for un-authored schema checks, opt-out behavior, client reuse, and AdCP 3.1.18 custom scenarios

Closes adcontextprotocol/adcp#6724
Closes adcontextprotocol/adcp#6725

## Validation

- `npm run build:lib`
- `npm run typecheck`
- `npm run format:check`
- focused storyboard, version-negotiation, security, rejection-hint, and decisioning compliance tests
- fast and slow Node shards; parallel-only timeout/port flakes reproduced cleanly in isolated reruns

