### PR TITLE
fix(server): project capability extension fields

### DIFF
--- a/.changeset/tidy-extensions-project.md
+++ b/.changeset/tidy-extensions-project.md
@@ -1,5 +1,5 @@
 ---
-'@adcp/sdk': patch
+'@adcp/sdk': minor
 ---
 
 Project standard `extensions_supported` and top-level capability `ext` fields through both server construction APIs, and document Zod `safeExtend` migration for refined public schemas.

--- a/.changeset/tidy-extensions-project.md
+++ b/.changeset/tidy-extensions-project.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Project standard `extensions_supported` and top-level capability `ext` fields through both server construction APIs, and document Zod `safeExtend` migration for refined public schemas.

--- a/docs/migration-13-to-14.md
+++ b/docs/migration-13-to-14.md
@@ -689,6 +689,29 @@ The outer `status` remains the asynchronous task state (`completed`, `working`, 
 
 Regenerated 3.2 types include new tools, error codes, canonical formats, measurement surfaces, and more exact intersections/tuples. If application code imported broad generated types or runtime schemas, expect TypeScript to reveal newly exhaustive unions.
 
+SDK 14 also adds semantic refinements to public object schemas. Behavior when
+composing a refined schema varies across supported Zod 4 releases: `.extend()`
+may throw during module initialization or may succeed with version-specific
+semantics. When adding application-owned fields to an SDK schema, use
+`.safeExtend()` consistently:
+
+```ts
+import { z } from 'zod';
+import { BiddingPolicySchema } from '@adcp/sdk/schemas';
+
+const ApplicationBiddingPolicySchema = BiddingPolicySchema.safeExtend({
+  application_policy_id: z.string(),
+});
+```
+
+Keep the SDK refinements in place: they enforce protocol rules that structural
+object validation alone cannot express. `.partial()` is also version-dependent:
+it may reject a refined object or return a structural partial without the
+original checks. Define application patch schemas separately, merge the patch
+with a complete object, and parse that result through the full SDK schema before
+using it. Do not rebuild from `.shape`, because doing so silently discards the
+protocol checks.
+
 The media-buy compatibility coordinator does not expose `unknown[]` rows or a
 `Record<string, unknown>` escape hatch. Product and proposal collections use
 `CompatibleProduct` / `CompatibleProposal`, proposal methods return separate

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -1157,7 +1157,13 @@ export interface AdcpCapabilitiesConfig {
   features?: Partial<MediaBuyFeatures>;
   account?: Partial<AccountCapabilities>;
   creative?: Partial<CreativeCapabilities>;
-  extensions_supported?: string[];
+  extensions_supported?: readonly string[];
+  /**
+   * Vendor-namespaced extension capability data emitted at the top-level
+   * `get_adcp_capabilities.ext` field. Each populated namespace should also
+   * be listed in {@link extensions_supported}.
+   */
+  ext?: NonNullable<GetAdCPCapabilitiesResponse['ext']>;
   /**
    * RFC 9421 request-signing verifier capability. See
    * docs/building/implementation/security.mdx#signed-requests-transport-layer.
@@ -1204,7 +1210,7 @@ export interface AdcpCapabilitiesConfig {
    * - primitive overrides replace the auto-derived value.
    *
    * Top-level fields the framework owns (`adcp`, `supported_protocols`,
-   * `specialisms`, `extensions_supported`) are not accepted here — configure
+   * `specialisms`, `extensions_supported`, `ext`) are not accepted here — configure
    * them via their dedicated fields on {@link AdcpCapabilitiesConfig}.
    */
   overrides?: AdcpCapabilitiesOverrides;
@@ -7818,8 +7824,12 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
     };
   }
 
-  if (capConfig?.extensions_supported?.length) {
-    capabilitiesData.extensions_supported = capConfig.extensions_supported;
+  if (capConfig?.extensions_supported !== undefined) {
+    capabilitiesData.extensions_supported = [...capConfig.extensions_supported];
+  }
+
+  if (capConfig?.ext !== undefined) {
+    capabilitiesData.ext = structuredClone(capConfig.ext);
   }
 
   if (capConfig?.request_signing) {

--- a/src/lib/server/decisioning/capabilities.ts
+++ b/src/lib/server/decisioning/capabilities.ts
@@ -296,6 +296,20 @@ export interface DecisioningCapabilities<TConfig = unknown> {
   account?: Partial<AccountCapabilities>;
 
   /**
+   * Registered extension namespaces supported by this platform. Projected
+   * verbatim onto `get_adcp_capabilities.extensions_supported`; use the
+   * matching namespace keys in {@link ext} for capability data.
+   */
+  extensions_supported?: readonly string[];
+
+  /**
+   * Vendor-namespaced extension capability data projected onto the top-level
+   * `get_adcp_capabilities.ext` field. Each populated namespace should also
+   * be declared in {@link extensions_supported}.
+   */
+  ext?: NonNullable<GetAdCPCapabilitiesResponse['ext']>;
+
+  /**
    * Deep-merge overrides applied to the wire `get_adcp_capabilities`
    * response. Use this for fields that the top-level `DecisioningCapabilities`
    * shape doesn't model — `media_buy.propagation_surfaces`,
@@ -303,7 +317,9 @@ export interface DecisioningCapabilities<TConfig = unknown> {
    * framework's per-domain projections (auto-derived `media_buy`, `brand`,
    * `account`, `compliance_testing` blocks) are merged AFTER adopter
    * overrides, so framework-derived values remain authoritative on the keys
-   * the projection engine handles.
+   * the projection engine handles. Framework-owned top-level fields such as
+   * `supported_protocols`, `extensions_supported`, and `ext` stay outside
+   * this override bag and use dedicated projection slots.
    *
    * Mirrors `AdcpCapabilitiesConfig.overrides` on the lower-level
    * `createAdcpServer` API. Resolves the `definePlatform` passthrough gap

--- a/src/lib/server/decisioning/decisioning.type-checks.ts
+++ b/src/lib/server/decisioning/decisioning.type-checks.ts
@@ -267,6 +267,13 @@ function _signals_only_capabilities_compiles(): DecisioningCapabilities {
   };
 }
 
+function _standard_extension_capabilities_compile(): Pick<DecisioningCapabilities, 'extensions_supported' | 'ext'> {
+  return {
+    extensions_supported: ['example'] as const,
+    ext: { example: { feature: true } },
+  };
+}
+
 // Negative: channels rejects values outside the MediaChannel union.
 function _channels_rejects_unknown_channel(): Pick<DecisioningCapabilities, 'channels'> {
   // @ts-expect-error — 'billboard' is not a known MediaChannel value.

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -2360,6 +2360,8 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
   };
   const adopterCreative = platform.capabilities.creative;
   const adopterAccount = platform.capabilities.account;
+  const adopterExtensionsSupported = platform.capabilities.extensions_supported;
+  const adopterCapabilityExt = platform.capabilities.ext;
   const adopterOverrides = platform.capabilities.overrides;
   const adopterSupportedVersions = platform.capabilities.supported_versions;
   const hasOverridesObject = hasOverridesProjection || adopterOverrides !== undefined;
@@ -2374,6 +2376,10 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
     }),
     ...(adopterCreative !== undefined && { creative: adopterCreative }),
     ...(adopterAccount !== undefined && { account: adopterAccount }),
+    ...(adopterExtensionsSupported !== undefined && {
+      extensions_supported: [...adopterExtensionsSupported],
+    }),
+    ...(adopterCapabilityExt !== undefined && { ext: adopterCapabilityExt }),
     ...(adopterSupportedVersions !== undefined && {
       supported_versions: [...adopterSupportedVersions],
     }),

--- a/test/capabilities-overrides.test.js
+++ b/test/capabilities-overrides.test.js
@@ -11,6 +11,64 @@ async function callCapabilities(server) {
 }
 
 describe('capabilities.overrides — per-domain merge (#654)', () => {
+  it('projects standard extension declarations through their dedicated fields', async () => {
+    const extensionsSupported = ['example'];
+    const ext = { example: { feature: true } };
+    const server = createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      mediaBuy: { getProducts: async () => ({ products: [] }) },
+      capabilities: {
+        extensions_supported: extensionsSupported,
+        ext,
+      },
+    });
+
+    extensionsSupported.push('caller-mutation');
+    ext.example.feature = false;
+    const caps = await callCapabilities(server);
+    assert.deepStrictEqual(caps.extensions_supported, ['example']);
+    assert.deepStrictEqual(caps.ext, { example: { feature: true } });
+    assert.deepStrictEqual(caps.supported_protocols, ['media_buy']);
+
+    caps.extensions_supported.push('response-mutation');
+    caps.ext.example.feature = false;
+    const secondCaps = await callCapabilities(server);
+    assert.deepStrictEqual(secondCaps.extensions_supported, ['example']);
+    assert.deepStrictEqual(secondCaps.ext, { example: { feature: true } });
+  });
+
+  it('preserves an explicitly empty extension declaration', async () => {
+    const server = createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      mediaBuy: { getProducts: async () => ({ products: [] }) },
+      capabilities: { extensions_supported: [], ext: {} },
+    });
+    const caps = await callCapabilities(server);
+    assert.deepStrictEqual(caps.extensions_supported, []);
+    assert.deepStrictEqual(caps.ext, {});
+  });
+
+  it('keeps standard top-level fields outside the override bag', () => {
+    for (const [key, value] of [
+      ['supported_protocols', ['creative']],
+      ['extensions_supported', ['example']],
+      ['ext', { example: { feature: true } }],
+    ]) {
+      assert.throws(
+        () =>
+          createAdcpServer({
+            name: 'Test',
+            version: '1.0.0',
+            mediaBuy: { getProducts: async () => ({ products: [] }) },
+            capabilities: { overrides: { [key]: value } },
+          }),
+        new RegExp(`capabilities\\.overrides\\.${key} is not allowed`)
+      );
+    }
+  });
+
   it('adds fields that the framework does not auto-derive', async () => {
     const server = createAdcpServer({
       name: 'Test',

--- a/test/server-decisioning-from-platform.test.js
+++ b/test/server-decisioning-from-platform.test.js
@@ -92,6 +92,62 @@ describe('createAdcpServerFromPlatform — v6.0 alpha', () => {
     assert.strictEqual(typeof server.dispatchTestRequest, 'function');
   });
 
+  it('projects standard extension capabilities without overriding derived protocols (#2671)', async () => {
+    const platform = buildPlatform();
+    const extensionsSupported = ['example'];
+    const ext = { example: { feature: true } };
+    platform.capabilities.extensions_supported = extensionsSupported;
+    platform.capabilities.ext = ext;
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'extension-capabilities',
+      version: '1.0.0',
+      validation: { requests: 'off', responses: 'strict' },
+    });
+
+    extensionsSupported.push('caller_mutation');
+    ext.example.feature = false;
+    const result = await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: { name: 'get_adcp_capabilities', arguments: {} },
+    });
+    assert.notStrictEqual(result.isError, true, JSON.stringify(result.structuredContent));
+    assert.deepStrictEqual(result.structuredContent.extensions_supported, ['example']);
+    assert.deepStrictEqual(result.structuredContent.ext, { example: { feature: true } });
+    assert.ok(result.structuredContent.supported_protocols.includes('media_buy'));
+
+    result.structuredContent.extensions_supported.push('response_mutation');
+    result.structuredContent.ext.example.feature = false;
+    const secondResult = await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: { name: 'get_adcp_capabilities', arguments: {} },
+    });
+    assert.notStrictEqual(secondResult.isError, true, JSON.stringify(secondResult.structuredContent));
+    assert.deepStrictEqual(secondResult.structuredContent.extensions_supported, ['example']);
+    assert.deepStrictEqual(secondResult.structuredContent.ext, { example: { feature: true } });
+  });
+
+  it('strictly validates extension capability declarations (#2671)', async () => {
+    for (const invalidCapabilities of [
+      { extensions_supported: ['Invalid-Namespace'] },
+      { extensions_supported: ['example', 'example'] },
+      { ext: [] },
+    ]) {
+      const platform = buildPlatform();
+      Object.assign(platform.capabilities, invalidCapabilities);
+      const server = createAdcpServerFromPlatform(platform, {
+        name: 'invalid-extension-capabilities',
+        version: '1.0.0',
+        validation: { requests: 'off', responses: 'strict' },
+      });
+      const result = await server.dispatchTestRequest({
+        method: 'tools/call',
+        params: { name: 'get_adcp_capabilities', arguments: {} },
+      });
+      assert.strictEqual(result.isError, true, JSON.stringify(result.structuredContent));
+      assert.strictEqual(result.structuredContent.adcp_error.code, 'VALIDATION_ERROR');
+    }
+  });
+
   it('makes the compact 3.2 lifecycle primary while preserving legacy seller routes', async () => {
     const calls = [];
     const base = buildPlatform();


### PR DESCRIPTION
## Summary

- expose standard `extensions_supported` and top-level capability `ext` on both server construction APIs
- preserve framework-derived `supported_protocols`, explicit empty declarations, readonly inputs, and mutation isolation
- document Zod 4 migration behavior for refined public schemas
- add strict projection, validation, override, and immutability coverage

## Verification

- `npm run typecheck`
- `npm run build:lib`
- `npm run format:check`
- `npm run ci:schema-check`
- `node --test test/capabilities-overrides.test.js test/server-decisioning-from-platform.test.js`
- protocol, code, and testing/docs expert reviews converged clean

Closes #2671
Follow-up to #2575