### PR TITLE
fix(sdk): resolve compatibility projection blockers

### DIFF
--- a/.changeset/curly-tools-resolve.md
+++ b/.changeset/curly-tools-resolve.md
@@ -1,0 +1,7 @@
+---
+'@adcp/sdk': minor
+---
+
+Add seller-version result provenance, version-aware tool JSON Schema lookup,
+legacy forecast timestamp normalization, and asynchronous server-side custom
+format resolution.

--- a/.changeset/tidy-protocols-derive.md
+++ b/.changeset/tidy-protocols-derive.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Derive server `supported_protocols` from registered domain handler groups so overlapping creative/media-buy tool names and utility handlers cannot advertise unsupported domains.

--- a/docs/TYPE-SUMMARY.md
+++ b/docs/TYPE-SUMMARY.md
@@ -39,6 +39,8 @@ interface TaskResult<T = any> {
     timestamp: string;
     clarificationRounds: number;
     adcpVersion?: string;        // Seller-served release-precision response adcp_version
+    serverVersion?: 'v2' | 'v3'; // Seller wire generation selected by capability discovery
+    serverVersionSynthetic?: boolean; // True when generation came from the SDK fallback
   };
   conversation?: Message[];
 }

--- a/docs/TYPE-SUMMARY.md
+++ b/docs/TYPE-SUMMARY.md
@@ -1,6 +1,6 @@
 # AdCP Type Summary
 
-> Generated at: 2026-08-24
+> Generated at: 2026-08-25
 > @adcp/sdk v14.0.0-beta.8
 
 Curated reference of the types that matter for using the AdCP client. For full generated types see `src/lib/types/tools.generated.ts` and `src/lib/types/core.generated.ts`.

--- a/docs/guides/CREATIVE-DELIVERY.md
+++ b/docs/guides/CREATIVE-DELIVERY.md
@@ -244,8 +244,10 @@ asynchronous `legacyCreativeFormatResolver` instead:
 createAdcpServerFromPlatform(platform, {
   name: 'Seller',
   version: '1.0.0',
-  legacyCreativeFormatResolver: async ({ formatId, accountId, servedAdcpVersion }) =>
-    catalog.resolveCanonicalDeclaration(formatId, { accountId, servedAdcpVersion }),
+  legacyCreativeFormatResolver: async ({ formatId, accountId, servedAdcpVersion, signal }) =>
+    catalog.resolveCanonicalDeclaration(formatId, { accountId, servedAdcpVersion, signal }),
+  legacyCreativeFormatResolverTimeoutMs: 10_000,
+  legacyCreativeFormatResolverConcurrency: 8,
 });
 ```
 
@@ -253,6 +255,9 @@ The resolver runs only after bundled/standard projection fails, receives the
 exact owner-qualified format tuple plus non-secret request context, and may
 resolve independent formats concurrently. Returning no declaration, throwing,
 or returning a malformed declaration fails closed with `INVALID_REQUEST`.
+The SDK runs at most eight lookups concurrently and aborts the shared resolver
+phase after ten seconds by default. Resolvers should honor the supplied
+`signal`; tune the timeout and 1–64 concurrency options for the backing catalog.
 
 When a `SalesPlatform.getProducts` implementation already has owner-scoped
 catalog snapshots, attach them directly to each returned product instead of

--- a/docs/guides/CREATIVE-DELIVERY.md
+++ b/docs/guides/CREATIVE-DELIVERY.md
@@ -237,6 +237,49 @@ delivery task options. The configured converter applies consistently to
 discovery, `createMediaBuyLegacy()`, `updateMediaBuyLegacy()`,
 `syncCreativesLegacy()`, async continuations, and webhooks. Server adopters use
 the `legacyCreativeFormatConverter` option on `createAdcpServerFromPlatform()`.
+When product-format lookup requires a database or seller catalog call, use the
+asynchronous `legacyCreativeFormatResolver` instead:
+
+```ts
+createAdcpServerFromPlatform(platform, {
+  name: 'Seller',
+  version: '1.0.0',
+  legacyCreativeFormatResolver: async ({ formatId, accountId, servedAdcpVersion }) =>
+    catalog.resolveCanonicalDeclaration(formatId, { accountId, servedAdcpVersion }),
+});
+```
+
+The resolver runs only after bundled/standard projection fails, receives the
+exact owner-qualified format tuple plus non-secret request context, and may
+resolve independent formats concurrently. Returning no declaration, throwing,
+or returning a malformed declaration fails closed with `INVALID_REQUEST`.
+
+When a `SalesPlatform.getProducts` implementation already has owner-scoped
+catalog snapshots, attach them directly to each returned product instead of
+performing another lookup:
+
+```ts
+import { getHydratedLegacyFormatIds } from '@adcp/sdk/server';
+
+const sales = {
+  getProducts: async () => ({
+    cache_scope: 'account',
+    products: [{ ...legacyProduct, projectionCatalogs: [publisherSnapshot] }],
+  }),
+  createMediaBuy: async request => {
+    const exactSellerRoutes = getHydratedLegacyFormatIds(request.packages[0].product);
+    return proxyCreateToLegacySeller(request, exactSellerRoutes);
+  },
+};
+```
+
+`projectionCatalogs` is framework-only metadata: the SDK consumes it before
+projection and never emits it on the buyer wire. With `ctxMetadata` storage
+configured, the SDK persists the resolved owner-qualified routes privately and
+restores them for hydrated create packages and update `packages`/
+`new_packages`. Read them with `getHydratedLegacyFormatIds`; they remain absent
+from serialized canonical products and buyer responses.
+
 Modern server platform handlers always receive canonical creatives. An invalid
 explicit conversion is rejected with `INVALID_REQUEST`; an unmapped legacy ref
 without a converter is never guessed as one of the 12 standard canonical

--- a/docs/migration-13-to-14.md
+++ b/docs/migration-13-to-14.md
@@ -689,6 +689,42 @@ The outer `status` remains the asynchronous task state (`completed`, `working`, 
 
 Regenerated 3.2 types include new tools, error codes, canonical formats, measurement surfaces, and more exact intersections/tuples. If application code imported broad generated types or runtime schemas, expect TypeScript to reveal newly exhaustive unions.
 
+Tool JSON Schema discovery is now version-aware. Use the schema subpath when
+an agent or gateway must publish the exact bundled contract for a negotiated
+release:
+
+```ts
+import { getToolInputSchema, getToolResponseSchema } from '@adcp/sdk/schemas';
+
+const request = getToolInputSchema('create_media_buy', { adcpVersion: '3.0' });
+const response = getToolResponseSchema('create_media_buy', {
+  adcpVersion: '3.2.0-beta.6',
+  variant: 'sync',
+});
+
+if (!request || !response) throw new Error('Tool schema is not present in the selected bundle');
+console.log(request.resolvedVersion, request.schema);
+```
+
+The returned record reports the requested version, selected bundle key, and
+exact release recorded by that bundle. A missing bundle throws an actionable
+configuration error; a tool or response variant absent from an installed
+bundle returns `undefined`. Neither case silently falls back to the current
+schema.
+
+Every `TaskResult.metadata` now exposes the selected seller wire generation as
+`serverVersion: 'v2' | 'v3'`. `serverVersionSynthetic` distinguishes an
+authoritative capability declaration (`false`) from the SDK's compatibility
+fallback (`true`). Both fields survive submitted/deferred continuations and
+durable restart recovery. `adcpVersion` remains the distinct, release-precision
+value echoed by a seller response.
+
+The v2.5 `get_products` response adapter also accepts explicitly zoned legacy
+forecast timestamps, including offset variants and single `$date`/`value`
+wrappers. It converts them to UTC RFC 3339 without losing fractional precision;
+ambiguous or unzoned values remain untouched, and the preserved seller wire
+object is not mutated.
+
 SDK 14 also adds semantic refinements to public object schemas. Behavior when
 composing a refined schema varies across supported Zod 4 releases: `.extend()`
 may throw during module initialization or may succeed with version-specific

--- a/scripts/generate-agent-docs.ts
+++ b/scripts/generate-agent-docs.ts
@@ -1268,6 +1268,8 @@ function generateTypeSummary(index: SchemaIndex, tools: ToolInfo[]): string {
   ln(`    timestamp: string;`);
   ln(`    clarificationRounds: number;`);
   ln(`    adcpVersion?: string;        // Seller-served release-precision response adcp_version`);
+  ln(`    serverVersion?: 'v2' | 'v3'; // Seller wire generation selected by capability discovery`);
+  ln(`    serverVersionSynthetic?: boolean; // True when generation came from the SDK fallback`);
   ln(`  };`);
   ln(`  conversation?: Message[];`);
   ln(`}`);

--- a/src/lib/core/ConversationTypes.ts
+++ b/src/lib/core/ConversationTypes.ts
@@ -252,6 +252,10 @@ export interface TaskState {
     name: string;
     protocol: 'mcp' | 'a2a';
   };
+  /** Seller wire generation selected for this task. */
+  serverVersion?: 'v2' | 'v3';
+  /** True when seller-version detection used the SDK's compatibility heuristic. */
+  serverVersionSynthetic?: boolean;
   /**
    * Idempotency key for this task, when the tool is mutating. Tracked on
    * state so internal retries reuse the same key (the whole point of the
@@ -462,6 +466,10 @@ export interface TaskResultMetadata {
    * configuration pin, when detecting same-major downshift.
    */
   adcpVersion?: string;
+  /** Seller wire generation used for this request after capability discovery. */
+  serverVersion?: 'v2' | 'v3';
+  /** True when {@link serverVersion} came from the SDK's synthetic fallback. */
+  serverVersionSynthetic?: boolean;
   /**
    * Buyer-side product property policy enforcement summary for `get_products`.
    * Present when the client evaluates a configured product property policy or

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -434,6 +434,8 @@ interface DeferredClientFinalizationContext {
   readonly taskType: string;
   readonly handlerName?: keyof AsyncHandlerConfig;
   readonly canonical: boolean;
+  readonly serverVersion?: 'v2' | 'v3';
+  readonly serverVersionSynthetic?: boolean;
   readonly productPolicyRequest: Readonly<Record<string, unknown>>;
   readonly projectionCatalogs?: readonly ProjectionCatalogSnapshot[];
   readonly routingSnapshot?: CanonicalCreativeRoutingSnapshot;
@@ -451,6 +453,8 @@ function isDeferredClientFinalizationContext(value: unknown): value is DeferredC
     !!context.productPolicyRequest &&
     typeof context.productPolicyRequest === 'object' &&
     !Array.isArray(context.productPolicyRequest) &&
+    (context.serverVersion === undefined || context.serverVersion === 'v2' || context.serverVersion === 'v3') &&
+    (context.serverVersionSynthetic === undefined || typeof context.serverVersionSynthetic === 'boolean') &&
     (context.projectionCatalogs === undefined || Array.isArray(context.projectionCatalogs)) &&
     (context.handlerName === undefined || typeof context.handlerName === 'string')
   );
@@ -4331,6 +4335,10 @@ export class SingleAgentClient {
       taskType,
       handlerName,
       canonical: canonicalCreativeInvocation,
+      serverVersion,
+      ...(capabilityDiscoveryContext.capabilities?._synthetic !== undefined && {
+        serverVersionSynthetic: capabilityDiscoveryContext.capabilities._synthetic,
+      }),
       productPolicyRequest: productPolicyRequestSnapshot(normalizedParams),
       ...(projectionCatalogs !== undefined && { projectionCatalogs }),
       ...(routingSnapshot !== undefined && { routingSnapshot }),
@@ -4407,6 +4415,15 @@ export class SingleAgentClient {
     transformCompletedResponse?: (data: T) => T,
     legacyFormatConverter?: LegacyFormatConverter
   ): Promise<TaskResult<T>> {
+    if (context.serverVersion !== undefined) {
+      result.metadata = {
+        ...result.metadata,
+        serverVersion: context.serverVersion,
+        ...(context.serverVersionSynthetic !== undefined && {
+          serverVersionSynthetic: context.serverVersionSynthetic,
+        }),
+      };
+    }
     const completionHandlerAlreadyPublished = hasCompletionHandlerAlreadyPublished(result);
     const settlementAcknowledger = (
       result as TaskResult<T> & {
@@ -5705,6 +5722,8 @@ export class SingleAgentClient {
         timestamp: new Date().toISOString(),
         clarificationRounds: 0,
         status: 'completed',
+        serverVersion: capabilities.version,
+        serverVersionSynthetic: capabilities._synthetic,
       },
     };
   }
@@ -7057,6 +7076,8 @@ export class SingleAgentClient {
   ): Promise<TaskResult<T>> {
     throwIfAborted(options?.signal);
     const startTime = Date.now();
+    let detectedServerVersion: 'v2' | 'v3' | undefined;
+    let detectedServerVersionSynthetic: boolean | undefined;
     try {
       const normalizedParams = normalizeRequestParams(taskName, params, {
         skipIdempotencyAutoInject: options?.skipIdempotencyAutoInject,
@@ -7087,6 +7108,8 @@ export class SingleAgentClient {
         [CAPABILITY_DISCOVERY_CONTEXT]: capabilityDiscoveryContext,
       };
       const serverVersion = await this.detectServerVersion(detectionOptions);
+      detectedServerVersion = serverVersion;
+      detectedServerVersionSynthetic = capabilityDiscoveryContext.capabilities?._synthetic;
       this.assertRequestSupportedByTargetVersion(
         taskName,
         normalizedParams,
@@ -7123,6 +7146,10 @@ export class SingleAgentClient {
         taskType: taskName,
         ...(handlerName !== undefined && { handlerName }),
         canonical: false,
+        serverVersion,
+        ...(capabilityDiscoveryContext.capabilities?._synthetic !== undefined && {
+          serverVersionSynthetic: capabilityDiscoveryContext.capabilities._synthetic,
+        }),
         productPolicyRequest: productPolicyRequestSnapshot(normalizedParams),
         ...(effectiveOptions?.taskId !== undefined && { optionTaskId: effectiveOptions.taskId }),
         ...(effectiveOptions?.contextId !== undefined && { optionContextId: effectiveOptions.contextId }),
@@ -7184,6 +7211,10 @@ export class SingleAgentClient {
           timestamp: new Date().toISOString(),
           clarificationRounds: 0,
           status: 'failed',
+          ...(detectedServerVersion !== undefined && { serverVersion: detectedServerVersion }),
+          ...(detectedServerVersionSynthetic !== undefined && {
+            serverVersionSynthetic: detectedServerVersionSynthetic,
+          }),
         },
         conversation: [],
         debug_logs: [],

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -790,6 +790,17 @@ function trustedDeferredServerTaskId(state: DeferredTaskState): string | undefin
   );
 }
 
+function attachDeferredServerVersion<T>(result: TaskResult<T>, state: DeferredTaskState): TaskResult<T> {
+  result.metadata = {
+    ...result.metadata,
+    serverVersion: state.serverVersion,
+    ...(state.serverVersionSynthetic !== undefined && {
+      serverVersionSynthetic: state.serverVersionSynthetic,
+    }),
+  };
+  return attachMatch(result);
+}
+
 interface DeferredFinalizationLease {
   finalize<T>(result: TaskResult<T>): Promise<void>;
   release(completionHandlerPublished?: boolean): Promise<void>;
@@ -1108,6 +1119,11 @@ export class TaskExecutor {
       clarificationRounds: args.clarificationRounds ?? 0,
       status: args.status,
     };
+    const taskState = this.activeTasks.get(args.taskId);
+    if (taskState?.serverVersion !== undefined) meta.serverVersion = taskState.serverVersion;
+    if (taskState?.serverVersionSynthetic !== undefined) {
+      meta.serverVersionSynthetic = taskState.serverVersionSynthetic;
+    }
     if (args.inputRequest) meta.inputRequest = args.inputRequest;
     const key = this.activeTasks.get(args.taskId)?.idempotencyKey;
     if (key) meta.idempotency_key = key;
@@ -1237,6 +1253,8 @@ export class TaskExecutor {
       maxAttempts: options.maxClarifications || this.config.defaultMaxClarifications || 3,
       options,
       agent: { id: agent.id, name: agent.name, protocol: agent.protocol },
+      serverVersion: effectiveServerVersion,
+      serverVersionSynthetic: targetCapabilities?._synthetic ?? serverVersion === undefined,
       idempotencyKey,
     };
     this.activeTasks.set(taskId, taskState);
@@ -2766,6 +2784,7 @@ export class TaskExecutor {
           ...(serverContextId !== undefined && { contextId: serverContextId }),
           a2aTaskId,
           serverVersion,
+          serverVersionSynthetic: this.activeTasks.get(taskId)?.serverVersionSynthetic,
           agentId: agent.id,
           taskName,
           params: durableDeferredSnapshot(params),
@@ -2907,6 +2926,7 @@ export class TaskExecutor {
           ...(serverContextId !== undefined && { contextId: serverContextId }),
           a2aTaskId,
           serverVersion,
+          serverVersionSynthetic: this.activeTasks.get(taskId)?.serverVersionSynthetic,
           agentId: agent.id,
           taskName,
           params: durableDeferredSnapshot(params),
@@ -3613,6 +3633,10 @@ export class TaskExecutor {
         clarificationRounds: 0,
         status,
         a2aTaskId: state.a2aTaskId,
+        serverVersion: state.serverVersion,
+        ...(state.serverVersionSynthetic !== undefined && {
+          serverVersionSynthetic: state.serverVersionSynthetic,
+        }),
         ...(state.contextId !== undefined && { contextId: state.contextId }),
         ...(state.settlementServerTaskId !== undefined && { serverTaskId: state.settlementServerTaskId }),
       },
@@ -3825,7 +3849,7 @@ export class TaskExecutor {
       if (normalizedFinalized.serverTaskId === undefined) {
         throw new Error('The finalized deferred settlement does not contain its trusted seller task identity.');
       }
-      const finalized = attachMatch(normalizedFinalized.result);
+      const finalized = attachDeferredServerVersion(normalizedFinalized.result, state);
       if (state.settlementCompletionHandlerPublished === true) {
         markCompletionHandlerAlreadyPublished(finalized);
       }
@@ -3900,7 +3924,7 @@ export class TaskExecutor {
           );
         }
         return {
-          result: recovered.result,
+          result: attachDeferredServerVersion(recovered.result, currentRoute.state),
           ...(currentRoute.state.clientContext !== undefined && {
             clientContext: structuredClone(currentRoute.state.clientContext),
           }),
@@ -3957,7 +3981,7 @@ export class TaskExecutor {
         true
       );
       return {
-        result: attachMatch(recoveredPending),
+        result: attachDeferredServerVersion(recoveredPending, state),
         ...(state.clientContext !== undefined && { clientContext: structuredClone(state.clientContext) }),
         settlementOperationId: committedOperationId,
         settlementServerTaskId: state.settlementPendingTaskId,
@@ -3996,7 +4020,7 @@ export class TaskExecutor {
           markCompletionHandlerAlreadyPublished(recovered);
         }
         return {
-          result: attachMatch(recovered),
+          result: attachDeferredServerVersion(recovered, state),
           ...(state.clientContext !== undefined && { clientContext: structuredClone(state.clientContext) }),
           settlementOperationId: committedOperationId,
           ...(state.settlementServerTaskId !== undefined && {
@@ -4198,6 +4222,7 @@ export class TaskExecutor {
         state.clientContext,
         state.settlementResumeAuthorizationRequired === true
       );
+      resumed = attachDeferredServerVersion(resumed, state);
       const observedResumedServerTaskId = resumed.metadata.serverTaskId;
       if (requiresSettlement && !TERMINAL_TASK_STATUSES.has(resumed.status as TaskStatus)) {
         resumed = attachMatch(
@@ -4231,6 +4256,9 @@ export class TaskExecutor {
               : {}),
           a2aTaskId: nextA2ATaskId,
           serverVersion: state.serverVersion,
+          ...(state.serverVersionSynthetic !== undefined && {
+            serverVersionSynthetic: state.serverVersionSynthetic,
+          }),
           agentId: state.agentId,
           taskName: state.taskName,
           params: durableDeferredSnapshot(state.params),
@@ -4514,7 +4542,7 @@ export class TaskExecutor {
         }
       }
       return {
-        result: attachMatch(settledResult),
+        result: attachDeferredServerVersion(settledResult, state),
         ...(state.clientContext !== undefined && { clientContext: structuredClone(state.clientContext) }),
         ...(state.settlementOperationId !== undefined && {
           settlementOperationId: state.settlementOperationId,

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1735,6 +1735,8 @@ export {
   CreativeFormatProjectionError,
   type LegacyFormatConversionContext,
   type LegacyFormatConverter,
+  type LegacyFormatResolutionContext,
+  type LegacyFormatResolver,
   legacyFormatConverterFromCatalogSnapshots,
   canonicalFormatLegacyResolverFromCatalogSnapshots,
   canonicalFormatLegacyResolverFromRoutes,
@@ -2025,7 +2027,7 @@ export {
   VERSION_INFO,
 } from './version';
 export type { AdcpVersion } from './version';
-export { resolveAdcpVersion } from './utils/adcp-version-config';
+export { listBundledAdcpVersions, resolveAdcpVersion } from './utils/adcp-version-config';
 
 // ====== OBSERVABILITY ======
 // OpenTelemetry tracing utilities (no-op if @opentelemetry/api not installed)

--- a/src/lib/schemas/index.ts
+++ b/src/lib/schemas/index.ts
@@ -44,6 +44,12 @@ import type { z } from 'zod';
 import * as schemas from '../types/schemas.generated';
 import { TOOL_REQUEST_SCHEMAS } from '../utils/tool-request-schemas';
 import type { KnownToolRequestSchemas } from '../utils/tool-request-schemas';
+import {
+  getToolSchemaDocument,
+  type ResolvedToolSchemaDocument,
+  type ResponseVariant,
+} from '../validation/schema-loader';
+import { resolveAdcpVersion } from '../utils/adcp-version-config';
 
 export * from '../types/schemas.generated';
 export { BiddingPolicySchema } from '../validation/bidding-policy';
@@ -57,6 +63,34 @@ export {
   SyncCreativesActionSchema,
 } from '../validation/sync-creatives';
 export type { SyncCreativesItem, SyncCreativesSuccessStrict } from '../validation/sync-creatives';
+
+export interface ToolSchemaLookupOptions {
+  /** AdCP release/minor/legacy alias resolved through the bundled schema loader. */
+  adcpVersion?: string;
+}
+
+export interface ToolResponseSchemaLookupOptions extends ToolSchemaLookupOptions {
+  /** Response arm to retrieve. Defaults to the synchronous response schema. */
+  variant?: ResponseVariant;
+}
+
+export type VersionedToolSchema = ResolvedToolSchemaDocument;
+
+/** Retrieve the protocol-authored request JSON Schema for a specific AdCP release. */
+export function getToolInputSchema(
+  toolName: string,
+  options: ToolSchemaLookupOptions = {}
+): VersionedToolSchema | undefined {
+  return getToolSchemaDocument(toolName, 'request', resolveAdcpVersion(options.adcpVersion));
+}
+
+/** Retrieve a protocol-authored response JSON Schema for a specific AdCP release. */
+export function getToolResponseSchema(
+  toolName: string,
+  options: ToolResponseSchemaLookupOptions = {}
+): VersionedToolSchema | undefined {
+  return getToolSchemaDocument(toolName, options.variant ?? 'sync', resolveAdcpVersion(options.adcpVersion));
+}
 
 type InputShape = Record<string, z.ZodType>;
 type InputSchema = z.ZodType;

--- a/src/lib/server/adcp-server.ts
+++ b/src/lib/server/adcp-server.ts
@@ -113,6 +113,7 @@ export interface AdcpAuthInfo {
 export interface AdcpTestRequestExtras {
   authInfo?: AdcpAuthInfo;
   sessionId?: string;
+  signal?: AbortSignal;
 }
 
 /**
@@ -666,7 +667,7 @@ export function wrapMcpServer(
   };
   const dispatch = async (request: AdcpTestRequest, extras?: AdcpTestRequestExtras): Promise<AdcpTestResponse> => {
     const extra: { signal: AbortSignal; authInfo?: AdcpTestRequestExtras['authInfo']; sessionId?: string } = {
-      signal: new AbortController().signal,
+      signal: extras?.signal ?? new AbortController().signal,
     };
     if (extras?.authInfo) extra.authInfo = extras.authInfo;
     if (extras?.sessionId) extra.sessionId = extras.sessionId;

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -474,6 +474,8 @@ export interface CallerMutationScope {
  */
 export interface HandlerContext<TAccount = unknown> {
   account?: TAccount;
+  /** Transport cancellation signal for the current request. */
+  signal?: AbortSignal;
   /**
    * AdCP release selected for this request after applying the buyer pin to
    * `capabilities.adcp.supported_versions`. This may be older than the
@@ -5525,6 +5527,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
         const ctx: HandlerContext<TAccount> = {
           store: stateStore,
           servedAdcpVersion: requestRelease.validationVersion,
+          ...(extra?.signal !== undefined && { signal: extra.signal }),
         };
         if (extra?.authInfo) {
           ctx.authInfo = extra.authInfo;

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -3354,9 +3354,12 @@ function hasDomainHandler(entries: readonly HandlerEntry[], handlers: object | u
  */
 function detectProtocolsFromHandlers<TAccount>(config: AdcpServerConfig<TAccount>): AdcpProtocol[] {
   const protocols: AdcpProtocol[] = [];
+  const declaresSalesSpecialism = config.capabilities?.specialisms?.some(specialism => specialism.startsWith('sales-'));
+  const hasAnyMediaBuyHandler = hasDomainHandler(MEDIA_BUY_ENTRIES, config.mediaBuy);
   if (
     hasDomainHandler(MEDIA_BUY_PROTOCOL_ENTRIES, config.mediaBuy) ||
-    hasDomainHandler(PROPOSAL_NEGOTIATION_ENTRIES, config.proposalNegotiation)
+    hasDomainHandler(PROPOSAL_NEGOTIATION_ENTRIES, config.proposalNegotiation) ||
+    (declaresSalesSpecialism && hasAnyMediaBuyHandler)
   ) {
     protocols.push('media_buy');
   }

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -402,14 +402,6 @@ import {
   isStandardErrorCode,
   type ErrorRecovery,
 } from '../types/error-codes';
-import {
-  MEDIA_BUY_TOOLS,
-  SIGNALS_TOOLS,
-  GOVERNANCE_TOOLS,
-  CREATIVE_TOOLS,
-  SPONSORED_INTELLIGENCE_TOOLS,
-  BRAND_RIGHTS_TOOLS,
-} from '../utils/capabilities';
 
 // ---------------------------------------------------------------------------
 // Logger
@@ -3259,6 +3251,10 @@ const MEDIA_BUY_ENTRIES: HandlerEntry[] = [
   { handlerKey: 'listCreatives', toolName: 'list_creatives' },
 ];
 
+const MEDIA_BUY_PROTOCOL_ENTRIES = MEDIA_BUY_ENTRIES.filter(
+  ({ handlerKey }) => !['listCreativeFormats', 'syncCreatives', 'listCreatives'].includes(handlerKey)
+);
+
 const PROPOSAL_NEGOTIATION_ENTRIES: HandlerEntry[] = [{ handlerKey: 'refineProposals', toolName: 'refine_proposals' }];
 
 const EVENT_TRACKING_ENTRIES: HandlerEntry[] = [
@@ -3339,23 +3335,34 @@ const BRAND_RIGHTS_ENTRIES: HandlerEntry[] = [
 // Protocol detection
 // ---------------------------------------------------------------------------
 
-const TOOL_PROTOCOL_MAP: [readonly string[], AdcpProtocol][] = [
-  [MEDIA_BUY_TOOLS, 'media_buy'],
-  [SIGNALS_TOOLS, 'signals'],
-  [GOVERNANCE_TOOLS, 'governance'],
-  [CREATIVE_TOOLS, 'creative'],
-  [SPONSORED_INTELLIGENCE_TOOLS, 'sponsored_intelligence'],
-  [BRAND_RIGHTS_TOOLS, 'brand'],
-];
+function hasDomainHandler(entries: readonly HandlerEntry[], handlers: object | undefined): boolean {
+  if (handlers === undefined) return false;
+  const candidate = handlers as Record<string, unknown>;
+  return entries.some(({ handlerKey }) => typeof candidate[handlerKey] === 'function');
+}
 
-function detectProtocols(toolNames: string[]): AdcpProtocol[] {
-  const nameSet = new Set(toolNames);
+/**
+ * Derive buyer-visible protocol domains from the handler group that owns each
+ * operation, not from the flattened tools/list catalog. Several compatibility
+ * tools intentionally appear in more than one protocol's discovery list
+ * (`list_creative_formats`, `list_creatives`, and `sync_creatives`), so tool
+ * names alone cannot distinguish a creative agent from a media-buy seller.
+ * Utility groups (accounts, tasks, event tracking, protocol helpers, custom
+ * tools) do not independently activate a protocol domain.
+ */
+function detectProtocolsFromHandlers<TAccount>(config: AdcpServerConfig<TAccount>): AdcpProtocol[] {
   const protocols: AdcpProtocol[] = [];
-  for (const [tools, protocol] of TOOL_PROTOCOL_MAP) {
-    if (tools.some(t => nameSet.has(t))) {
-      protocols.push(protocol);
-    }
+  if (
+    hasDomainHandler(MEDIA_BUY_PROTOCOL_ENTRIES, config.mediaBuy) ||
+    hasDomainHandler(PROPOSAL_NEGOTIATION_ENTRIES, config.proposalNegotiation)
+  ) {
+    protocols.push('media_buy');
   }
+  if (hasDomainHandler(SIGNALS_ENTRIES, config.signals)) protocols.push('signals');
+  if (hasDomainHandler(GOVERNANCE_ENTRIES, config.governance)) protocols.push('governance');
+  if (hasDomainHandler(CREATIVE_ENTRIES, config.creative)) protocols.push('creative');
+  if (hasDomainHandler(SI_ENTRIES, config.sponsoredIntelligence)) protocols.push('sponsored_intelligence');
+  if (hasDomainHandler(BRAND_RIGHTS_ENTRIES, config.brandRights)) protocols.push('brand');
   return protocols;
 }
 
@@ -7755,7 +7762,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
   }
 
   // --- Auto-register get_adcp_capabilities ---
-  const protocols = detectProtocols([...registeredToolNames]);
+  const protocols = detectProtocolsFromHandlers(config);
 
   // Idempotency capability declaration. Spec defines a discriminated
   // union (`get-adcp-capabilities-response.json` `adcp.idempotency.oneOf`):

--- a/src/lib/server/decisioning/index.ts
+++ b/src/lib/server/decisioning/index.ts
@@ -245,6 +245,7 @@ export type {
   MediaBuyLifecycleCorePlatform,
   MediaBuyLifecycleProposalPlatform,
   GetProductsPayload,
+  GetProductsProjectionInput,
   LegacyGetProductsPayload,
   GetProductsHandlerResult,
   CreateMediaBuyPayload,
@@ -341,6 +342,7 @@ export type {
 // new shape. Subject to change before 6.0 GA.
 export {
   createAdcpServerFromPlatform,
+  getHydratedLegacyFormatIds,
   getAllAdcpMigrations,
   type CreateAdcpServerFromPlatformOptions,
   type LegacyDecisioningHandlerGroups,

--- a/src/lib/server/decisioning/proposal/types.ts
+++ b/src/lib/server/decisioning/proposal/types.ts
@@ -33,16 +33,15 @@ import type { MaybePromise } from '../../create-adcp-server';
 import type { Account } from '../account';
 import type { RequestContext } from '../context';
 import type { GetProductsResponse } from '../../../types/tools.generated';
-import type {
-  CanonicalCreativeResponse,
-  CanonicalGetProductsRequest,
-  CanonicalProduct,
-} from '../../../v2/projection/creative-delivery';
+import type { CanonicalCreativeResponse, CanonicalGetProductsRequest } from '../../../v2/projection/creative-delivery';
 import type { RequireCacheScopeWhenProducts, ServerPayload } from '../../../types/server-payload';
 import type { TaskHandoff } from '../async-outcome';
+import type { GetProductsProjectionInput } from '../specialisms/sales';
 
 export type ProposalGetProductsPayload = RequireCacheScopeWhenProducts<
-  Omit<ServerPayload<CanonicalCreativeResponse<GetProductsResponse>>, 'products'> & { products?: CanonicalProduct[] }
+  Omit<ServerPayload<CanonicalCreativeResponse<GetProductsResponse>>, 'products'> & {
+    products?: GetProductsProjectionInput[];
+  }
 >;
 export type LegacyProposalGetProductsPayload = RequireCacheScopeWhenProducts<ServerPayload<GetProductsResponse>>;
 

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -180,7 +180,16 @@ import {
   projectMediaBuyCreativesForDelivery,
   stripLegacyCreativeIdentity,
 } from '../../../v2/projection/creative-delivery';
-import { projectV1ProductToV2, type LegacyFormatConverter } from '../../../v2/projection/v1-to-v2';
+import {
+  projectV1ProductToV2,
+  type LegacyFormatConversionContext,
+  type LegacyFormatConverter,
+  type LegacyFormatResolver,
+} from '../../../v2/projection/v1-to-v2';
+import {
+  legacyFormatConverterFromCatalogSnapshots,
+  type ProjectionCatalogSnapshot,
+} from '../../../v2/projection/catalog-snapshot';
 import type {
   CanonicalSyncCreativeAsset,
   CanonicalCreateMediaBuyRequest,
@@ -814,10 +823,7 @@ function asCanonicalListCreativesRequest(
   return { ...withLegacyFilter, fields } as CanonicalListCreativesRequest;
 }
 
-function asCanonicalProductResponse<T extends { products?: unknown[] }>(
-  response: T,
-  legacyFormatConverter: LegacyFormatConverter | undefined
-): T {
+function assertSafeGetProductsResponse(response: unknown): void {
   try {
     assertSafeSemanticPayload(response, 'get_products');
   } catch (error) {
@@ -828,6 +834,13 @@ function asCanonicalProductResponse<T extends { products?: unknown[] }>(
       suggestion: 'Return an acyclic data-only product response without enumerable accessors.',
     });
   }
+}
+
+function asCanonicalProductResponse<T extends { products?: unknown[] }>(
+  response: T,
+  legacyFormatConverter: LegacyFormatConverter | undefined
+): T {
+  assertSafeGetProductsResponse(response);
   validateDualProductFormatDeclarations(response, legacyFormatConverter);
   const projected = toCanonicalOnlyResponse(response as T & { products?: V1Product[] }, {
     legacyFormatConverter,
@@ -854,7 +867,316 @@ function asCanonicalProductResponse<T extends { products?: unknown[] }>(
   return canonicalResponse;
 }
 
+function legacyFormatResolutionKey(context: LegacyFormatConversionContext): string {
+  const formatId = context.formatId;
+  return JSON.stringify([
+    context.productId,
+    context.field,
+    formatId.agent_url,
+    formatId.id,
+    formatId.width ?? null,
+    formatId.height ?? null,
+    formatId.duration_ms ?? null,
+  ]);
+}
+
+function preparePerProductProjectionCatalogs<T extends { products?: unknown[] }>(
+  response: T,
+  fallback: LegacyFormatConverter | undefined
+): { response: T; converter: LegacyFormatConverter | undefined } {
+  assertSafeGetProductsResponse(response);
+  if (!Array.isArray(response.products)) return { response, converter: fallback };
+  assertNoReservedLegacyRouteMetadata(response.products, 'products');
+
+  const converters = new Map<string, LegacyFormatConverter>();
+  const productIdCounts = new Map<string, number>();
+  for (const product of response.products) {
+    if (!product || typeof product !== 'object' || Array.isArray(product)) continue;
+    const productId = (product as Record<string, unknown>).product_id;
+    if (typeof productId === 'string') productIdCounts.set(productId, (productIdCounts.get(productId) ?? 0) + 1);
+  }
+  let strippedCatalogMetadata = false;
+  const products = response.products.map(product => {
+    if (!product || typeof product !== 'object' || Array.isArray(product)) return product;
+    const record = product as Record<string, unknown>;
+    if (!Object.prototype.hasOwnProperty.call(record, 'projectionCatalogs')) return product;
+    strippedCatalogMetadata = true;
+    const { projectionCatalogs, ...wireProduct } = record;
+    if (!Array.isArray(projectionCatalogs)) {
+      throw new AdcpError('INVALID_REQUEST', {
+        message: 'get_products projectionCatalogs must be an array of immutable catalog snapshots.',
+        field: `products[${String(record.product_id ?? '?')}].projectionCatalogs`,
+      });
+    }
+    if (typeof record.product_id === 'string' && (productIdCounts.get(record.product_id) ?? 0) > 1) {
+      throw new AdcpError('INVALID_REQUEST', {
+        message: 'get_products projection catalogs require unique product identifiers.',
+        field: `products[${record.product_id}].projectionCatalogs`,
+      });
+    }
+    if (projectionCatalogs.length > 0 && typeof record.product_id === 'string') {
+      if (converters.has(record.product_id)) {
+        throw new AdcpError('INVALID_REQUEST', {
+          message: 'get_products cannot attach different projection catalogs to duplicate product identifiers.',
+          field: `products[${record.product_id}].projectionCatalogs`,
+        });
+      }
+      const converter = legacyFormatConverterFromCatalogSnapshots(
+        projectionCatalogs as readonly ProjectionCatalogSnapshot[]
+      );
+      if (converter) {
+        converters.set(record.product_id, converter);
+        const placements = wireProduct.placements;
+        if (Array.isArray(placements)) {
+          for (let placementIndex = 0; placementIndex < placements.length; placementIndex++) {
+            const placement = placements[placementIndex];
+            if (!placement || typeof placement !== 'object' || Array.isArray(placement)) continue;
+            const placementRecord = placement as Record<string, unknown>;
+            const placementId =
+              typeof placementRecord.placement_id === 'string' ? placementRecord.placement_id : String(placementIndex);
+            const projectionProductId = `${record.product_id}:placement:${placementId}`;
+            if (converters.has(projectionProductId)) {
+              throw new AdcpError('INVALID_REQUEST', {
+                message: 'get_products projection catalog scopes resolve to a duplicate product identifier.',
+                field: `products[${record.product_id}].placements[${placementIndex}]`,
+              });
+            }
+            converters.set(projectionProductId, converter);
+          }
+        }
+      }
+    }
+    return wireProduct;
+  });
+
+  const converter: LegacyFormatConverter | undefined =
+    converters.size === 0
+      ? fallback
+      : context => {
+          const productConverter = converters.get(context.productId);
+          const resolved = productConverter?.(context);
+          return resolved === undefined ? fallback?.(context) : resolved;
+        };
+  return {
+    response: (strippedCatalogMetadata ? { ...response, products } : response) as T,
+    converter,
+  };
+}
+
+async function resolveLegacyProductFormats<T extends { products?: unknown[] }>(
+  response: T,
+  converter: LegacyFormatConverter | undefined,
+  resolver: LegacyFormatResolver | undefined,
+  requestContext: { servedAdcpVersion?: string; accountId?: string }
+): Promise<LegacyFormatConverter | undefined> {
+  if (!resolver) return converter;
+  assertSafeGetProductsResponse(response);
+  if (!Array.isArray(response.products)) return converter;
+
+  const resolutions = new Map<
+    string,
+    Awaited<ReturnType<LegacyFormatResolver>> | { readonly resolutionError: unknown }
+  >();
+  const pending: Promise<void>[] = [];
+  const scanScope = (projectionProduct: V1Product, resolverProductId: string, resolverFieldPrefix: string): void => {
+    if (Array.isArray((projectionProduct as unknown as V2Product).format_options)) return;
+    for (let index = 0; index < projectionProduct.format_ids.length; index++) {
+      const formatId = projectionProduct.format_ids[index];
+      if (!formatId || typeof formatId !== 'object' || Array.isArray(formatId)) continue;
+      const projectionField = `products[${projectionProduct.product_id}].format_ids[${index}]`;
+      const resolverField = `${resolverFieldPrefix}.format_ids[${index}]`;
+      const projectionContext: LegacyFormatConversionContext = {
+        formatId: formatId as V1FormatId,
+        productId: projectionProduct.product_id,
+        field: projectionField,
+      };
+      const contextAwareConverter: LegacyFormatConverter | undefined = converter
+        ? context => converter({ ...context, field: projectionField })
+        : undefined;
+      const alreadyProjected = projectV1ProductToV2(
+        { ...projectionProduct, format_ids: [formatId] },
+        { legacyFormatConverter: contextAwareConverter }
+      );
+      if (alreadyProjected.diagnostics.length === 0) continue;
+
+      let resolverEligible = false;
+      projectV1ProductToV2(
+        { ...projectionProduct, format_ids: [formatId] },
+        {
+          legacyFormatConverter: () => {
+            resolverEligible = true;
+            return {
+              format_option_id: '__legacy_resolver_probe__',
+              format_kind: 'custom',
+              format_shape: '__legacy_resolver_probe__',
+              format_schema: {
+                uri: 'https://adcontextprotocol.org/schemas/legacy-resolver-probe.json',
+                digest: `sha256:${'0'.repeat(64)}`,
+              },
+              params: {},
+            };
+          },
+        }
+      );
+      if (!resolverEligible) continue;
+
+      const key = legacyFormatResolutionKey(projectionContext);
+      const frozenFormatId = Object.freeze({ ...(formatId as V1FormatId) });
+      pending.push(
+        Promise.resolve()
+          .then(() =>
+            resolver({
+              formatId: frozenFormatId,
+              productId: resolverProductId,
+              field: resolverField,
+              operation: 'get_products',
+              ...requestContext,
+            })
+          )
+          .then(
+            value => {
+              resolutions.set(key, value);
+            },
+            error => {
+              resolutions.set(key, { resolutionError: error });
+            }
+          )
+      );
+    }
+  };
+
+  for (const product of response.products) {
+    if (!isProjectionProductInput(product)) continue;
+    if (Array.isArray(product.format_ids)) {
+      scanScope(product as V1Product, product.product_id, `products[${product.product_id}]`);
+    }
+    const placements = (product as unknown as Record<string, unknown>).placements;
+    if (!Array.isArray(placements)) continue;
+    for (let placementIndex = 0; placementIndex < placements.length; placementIndex++) {
+      const placement = placements[placementIndex];
+      if (!placement || typeof placement !== 'object' || Array.isArray(placement)) continue;
+      const placementRecord = placement as Record<string, unknown>;
+      if (Array.isArray(placementRecord.format_options) || !Array.isArray(placementRecord.format_ids)) continue;
+      const placementId =
+        typeof placementRecord.placement_id === 'string' ? placementRecord.placement_id : String(placementIndex);
+      scanScope(
+        {
+          product_id: `${product.product_id}:placement:${placementId}`,
+          name: typeof placementRecord.name === 'string' ? placementRecord.name : placementId,
+          description: `Nested placement ${placementId}`,
+          format_ids: placementRecord.format_ids as V1FormatId[],
+        },
+        product.product_id,
+        `products[${product.product_id}].placements[${placementIndex}]`
+      );
+    }
+  }
+  await Promise.all(pending);
+  if (resolutions.size === 0) return converter;
+
+  return context => {
+    const resolved = resolutions.get(legacyFormatResolutionKey(context));
+    if (resolved !== undefined) {
+      if (typeof resolved === 'object' && resolved !== null && 'resolutionError' in resolved) {
+        throw resolved.resolutionError;
+      }
+      return resolved;
+    }
+    return converter?.(context);
+  };
+}
+
 const authoredFormatIdsByOwner = new WeakMap<object, readonly V1FormatId[]>();
+const STORED_LEGACY_FORMAT_ROUTES = '__adcp_private_legacy_format_routes';
+
+function assertNoReservedLegacyRouteMetadata(value: unknown, path: string): void {
+  const visited = new WeakSet<object>();
+  const visit = (current: unknown, currentPath: string): void => {
+    if (current === null || typeof current !== 'object' || visited.has(current)) return;
+    visited.add(current);
+    for (const [key, descriptor] of Object.entries(Object.getOwnPropertyDescriptors(current))) {
+      if (!descriptor.enumerable || !('value' in descriptor)) continue;
+      const childPath = Array.isArray(current) ? `${currentPath}[${key}]` : `${currentPath}.${key}`;
+      if (key === STORED_LEGACY_FORMAT_ROUTES) {
+        throw new AdcpError('INVALID_REQUEST', {
+          message: 'get_products returned a field reserved for SDK-private route persistence.',
+          field: childPath,
+        });
+      }
+      visit(descriptor.value, childPath);
+    }
+  };
+  visit(value, path);
+}
+
+interface StoredLegacyFormatRoutes {
+  formatIds?: readonly V1FormatId[];
+  placements?: readonly (StoredLegacyFormatRoutes | null)[];
+}
+
+function captureStoredLegacyFormatRoutes(value: unknown): StoredLegacyFormatRoutes | undefined {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  const record = value as Record<string, unknown>;
+  const formatIds = authoredFormatIdsByOwner.get(record);
+  const placements = Array.isArray(record.placements)
+    ? record.placements.map(placement => captureStoredLegacyFormatRoutes(placement) ?? null)
+    : undefined;
+  if (!formatIds && !placements?.some(Boolean)) return undefined;
+  return {
+    ...(formatIds && { formatIds: formatIds.map(ref => cloneWireData(ref)) }),
+    ...(placements?.some(Boolean) && { placements }),
+  };
+}
+
+function restoreStoredLegacyFormatRoutes(value: unknown, routes: unknown): void {
+  if (
+    value === null ||
+    typeof value !== 'object' ||
+    Array.isArray(value) ||
+    routes === null ||
+    typeof routes !== 'object' ||
+    Array.isArray(routes)
+  ) {
+    return;
+  }
+  const record = value as Record<string, unknown>;
+  const routeRecord = routes as Record<string, unknown>;
+  if (
+    Array.isArray(routeRecord.formatIds) &&
+    routeRecord.formatIds.length > 0 &&
+    routeRecord.formatIds.every(ref => isValidStoredLegacyFormatRef(ref))
+  ) {
+    authoredFormatIdsByOwner.set(
+      record,
+      routeRecord.formatIds.map(ref => cloneWireData(ref as V1FormatId))
+    );
+  }
+  if (Array.isArray(record.placements) && Array.isArray(routeRecord.placements)) {
+    const count = Math.min(record.placements.length, routeRecord.placements.length);
+    for (let index = 0; index < count; index++) {
+      restoreStoredLegacyFormatRoutes(record.placements[index], routeRecord.placements[index]);
+    }
+  }
+}
+
+function isValidStoredLegacyFormatRef(value: unknown): value is V1FormatId {
+  if (legacyFormatRefKey(value) === undefined) return false;
+  const ref = value as Record<string, unknown>;
+  if (ref.agent_url === '' || ref.id === '') return false;
+  for (const field of ['width', 'height', 'duration_ms'] as const) {
+    const fieldValue = ref[field];
+    if (fieldValue !== undefined && (!Number.isInteger(fieldValue) || (fieldValue as number) <= 0)) return false;
+  }
+  return true;
+}
+
+/** Read exact SDK-private legacy routes restored on an auto-hydrated product or placement. */
+export function getHydratedLegacyFormatIds(value: unknown): readonly V1FormatId[] | undefined {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  const refs = authoredFormatIdsByOwner.get(value);
+  return refs?.map(ref => cloneWireData(ref));
+}
+
 type LegacyDropDiagnostic = Extract<ProjectionDiagnostic, { code: 'LEGACY_FORMAT_ID_DROPPED_UNMAPPED' }>;
 const resolvedLegacyDropDiagnosticsByResponse = new WeakMap<object, readonly LegacyDropDiagnostic[]>();
 
@@ -1535,6 +1857,12 @@ export interface CreateAdcpServerFromPlatformOptions extends Omit<
    * declaration (normally `format_kind: 'custom'` + shape/schema).
    */
   legacyCreativeFormatConverter?: LegacyFormatConverter;
+  /**
+   * Resolve seller-specific legacy product formats asynchronously before the
+   * canonical `get_products` projection. The resolver receives only the exact
+   * format tuple plus non-secret request routing context and fails closed.
+   */
+  legacyCreativeFormatResolver?: LegacyFormatResolver;
   /** Resolve persisted canonical custom formats when this server emits a legacy wire response. */
   canonicalFormatLegacyResolver?: CanonicalFormatLegacyResolver;
   /**
@@ -1961,7 +2289,6 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
     RequiredCapabilitiesFor<P['capabilities']['specialisms'][number]>,
   opts: RequiredOptsFor<P>
 ): DecisioningAdcpServer {
-  validatePlatform(platform);
   // Runtime-only compatibility for pre-13 JavaScript/config objects. The
   // public type exposes these raw handler groups only under legacyHandlers;
   // retaining the hidden fallback avoids turning a type migration into an
@@ -1973,6 +2300,11 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
     governance: opts.legacyHandlers?.governance ?? runtimeLegacyOptions.governance,
     brandRights: opts.legacyHandlers?.brandRights ?? runtimeLegacyOptions.brandRights,
   };
+  validatePlatform(platform, {
+    creative: legacyHandlers.creative,
+    campaignGovernance: legacyHandlers.governance,
+    brandRights: legacyHandlers.brandRights,
+  });
 
   // Specialism→required-tools coverage check (adcp-client#1299).
   //
@@ -1992,7 +2324,14 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
   // flagged.
   {
     const specialisms = (platform.capabilities as { specialisms?: readonly string[] }).specialisms;
-    const issues = validateSpecialismRequiredTools(platform, specialisms);
+    const effectiveSpecialismSurface = {
+      ...platform,
+      mediaBuy: legacyHandlers.mediaBuy,
+      creative: platform.creative ?? legacyHandlers.creative,
+      governance: legacyHandlers.governance,
+      brandRights: platform.brandRights ?? legacyHandlers.brandRights,
+    };
+    const issues = validateSpecialismRequiredTools(effectiveSpecialismSurface, specialisms);
     if (issues.length > 0) {
       const messages = issues.map(formatSpecialismIssue);
       if (opts.strictSpecialismValidation === true) {
@@ -2605,6 +2944,7 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
         opts.mediaBuyStore,
         opts.proposalStore,
         opts.legacyCreativeFormatConverter,
+        opts.legacyCreativeFormatResolver,
         opts.canonicalFormatLegacyResolver,
         defaultCreativeWireMode
       ),
@@ -4510,8 +4850,15 @@ async function autoStoreResources(
     const ctxMeta = obj['ctx_metadata'];
     // Strip ctx_metadata from the resource before storing — round-trip
     // restores it on hydration. Keeping a pristine wire copy in `resource`.
-    const { ctx_metadata: _stripped, ...wireResource } = obj as Record<string, unknown>;
+    const {
+      ctx_metadata: _stripped,
+      [STORED_LEGACY_FORMAT_ROUTES]: _reservedRouteMetadata,
+      ...wireResource
+    } = obj as Record<string, unknown>;
     void _stripped;
+    void _reservedRouteMetadata;
+    const legacyFormatRoutes = kind === 'product' ? captureStoredLegacyFormatRoutes(obj) : undefined;
+    if (legacyFormatRoutes) wireResource[STORED_LEGACY_FORMAT_ROUTES] = legacyFormatRoutes;
     try {
       // Use `setResource` (not `setEntry`) so a publisher's prior
       // `ctx.ctxMetadata.set(kind, id, blob)` is preserved when the
@@ -4656,10 +5003,13 @@ async function hydratePackagesWithProducts(
     if (!entry?.resource || typeof entry.resource !== 'object') continue;
     let hydrated: Record<string, unknown>;
     try {
-      hydrated = asCanonicalSemanticServerRequest(entry.resource, 'hydrate_product', legacyFormatConverter) as Record<
+      const storedResource = entry.resource as Record<string, unknown>;
+      const { [STORED_LEGACY_FORMAT_ROUTES]: storedLegacyFormatRoutes, ...resource } = storedResource;
+      hydrated = asCanonicalSemanticServerRequest(resource, 'hydrate_product', legacyFormatConverter) as Record<
         string,
         unknown
       >;
+      restoreStoredLegacyFormatRoutes(hydrated, storedLegacyFormatRoutes);
     } catch {
       logger.warn(
         `[adcp/decisioning] auto-hydrate product:${productId} skipped: stored creative format has no canonical representation`
@@ -5288,6 +5638,7 @@ function buildMediaBuyHandlers<P extends DecisioningPlatform<any, any>>(
   mediaBuyStore: MediaBuyStore | undefined,
   proposalStore: import('../proposal').ProposalStore | undefined,
   legacyFormatConverter: LegacyFormatConverter | undefined,
+  legacyFormatResolver: LegacyFormatResolver | undefined,
   canonicalFormatLegacyResolver: CanonicalFormatLegacyResolver | undefined,
   creativeWireMode: 'canonical' | 'legacy'
 ): MediaBuyHandlers<Account> | undefined {
@@ -5511,7 +5862,20 @@ function buildMediaBuyHandlers<P extends DecisioningPlatform<any, any>>(
                 | TaskHandoff<GetProductsPayload>;
             }
             const projectProducts = async (terminalResult: GetProductsPayload) => {
-              const canonicalResult = asCanonicalProductResponse(terminalResult, legacyFormatConverter);
+              const preparedProjection = preparePerProductProjectionCatalogs(terminalResult, legacyFormatConverter);
+              const requestLegacyFormatConverter = await resolveLegacyProductFormats(
+                preparedProjection.response,
+                preparedProjection.converter,
+                legacyFormatResolver,
+                {
+                  ...(ctx.servedAdcpVersion !== undefined && { servedAdcpVersion: ctx.servedAdcpVersion }),
+                  ...(reqCtx.account?.id !== undefined && { accountId: reqCtx.account.id }),
+                }
+              );
+              const canonicalResult = asCanonicalProductResponse(
+                preparedProjection.response,
+                requestLegacyFormatConverter
+              );
               // Auto-store products: persist each Product's wire shape +
               // ctx_metadata so subsequent createMediaBuy / updateMediaBuy
               // calls referencing product_id can hydrate the full Product
@@ -5533,7 +5897,7 @@ function buildMediaBuyHandlers<P extends DecisioningPlatform<any, any>>(
               // cross the buyer-facing response boundary.
               if (proposalStore) {
                 await maybePersistDraftAfterGetProducts({
-                  response: terminalResult,
+                  response: terminalResult as unknown as import('../proposal').ProposalGetProductsPayload,
                   store: proposalStore,
                   ctx: reqCtx as unknown as { account: { id: string } },
                 });
@@ -5744,6 +6108,20 @@ function buildMediaBuyHandlers<P extends DecisioningPlatform<any, any>>(
           reqCtx.account?.id,
           'update_media_buy',
           params,
+          logger,
+          legacyFormatConverter
+        );
+        await hydratePackagesWithProducts(
+          ctxMetadataStore,
+          reqCtx.account?.id,
+          (params as { packages?: unknown[] }).packages,
+          logger,
+          legacyFormatConverter
+        );
+        await hydratePackagesWithProducts(
+          ctxMetadataStore,
+          reqCtx.account?.id,
+          (params as { new_packages?: unknown[] }).new_packages,
           logger,
           legacyFormatConverter
         );

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -184,6 +184,7 @@ import {
   projectV1ProductToV2,
   type LegacyFormatConversionContext,
   type LegacyFormatConverter,
+  type LegacyFormatResolutionContext,
   type LegacyFormatResolver,
 } from '../../../v2/projection/v1-to-v2';
 import {
@@ -963,11 +964,83 @@ function preparePerProductProjectionCatalogs<T extends { products?: unknown[] }>
   };
 }
 
+const DEFAULT_LEGACY_FORMAT_RESOLVER_TIMEOUT_MS = 10_000;
+const DEFAULT_LEGACY_FORMAT_RESOLVER_CONCURRENCY = 8;
+const MAX_LEGACY_FORMAT_RESOLVER_TIMEOUT_MS = 2_147_483_647;
+const MAX_LEGACY_FORMAT_RESOLVER_CONCURRENCY = 64;
+
+function legacyFormatResolverLimit(
+  value: number | undefined,
+  fallback: number,
+  field: string,
+  maximum?: number
+): number {
+  if (value === undefined) return fallback;
+  if (!Number.isSafeInteger(value) || value <= 0 || (maximum !== undefined && value > maximum)) {
+    const range = maximum === undefined ? 'a positive safe integer' : `an integer between 1 and ${maximum}`;
+    throw new PlatformConfigError(`${field} must be ${range}.`);
+  }
+  return value;
+}
+
+function legacyFormatResolverAbortError(signal: AbortSignal): Error {
+  return signal.reason instanceof Error
+    ? signal.reason
+    : new Error('legacyCreativeFormatResolver was aborted before projection completed.');
+}
+
+function createLegacyFormatResolverSignal(
+  requestSignal: AbortSignal | undefined,
+  timeoutMs: number
+): { signal: AbortSignal; dispose(): void } {
+  const controller = new AbortController();
+  const abortFromRequest = () => controller.abort(requestSignal?.reason);
+  if (requestSignal?.aborted) abortFromRequest();
+  else requestSignal?.addEventListener('abort', abortFromRequest, { once: true });
+  const timeout = controller.signal.aborted
+    ? undefined
+    : setTimeout(
+        () => controller.abort(new Error(`legacyCreativeFormatResolver exceeded its ${timeoutMs}ms deadline.`)),
+        timeoutMs
+      );
+  return {
+    signal: controller.signal,
+    dispose() {
+      if (timeout !== undefined) clearTimeout(timeout);
+      requestSignal?.removeEventListener('abort', abortFromRequest);
+    },
+  };
+}
+
+async function invokeLegacyFormatResolver(
+  resolver: LegacyFormatResolver,
+  context: Omit<LegacyFormatResolutionContext, 'signal'>,
+  signal: AbortSignal
+): Promise<Awaited<ReturnType<LegacyFormatResolver>>> {
+  if (signal.aborted) throw legacyFormatResolverAbortError(signal);
+  let abortListener: (() => void) | undefined;
+  const aborted = new Promise<never>((_resolve, reject) => {
+    abortListener = () => reject(legacyFormatResolverAbortError(signal));
+    signal.addEventListener('abort', abortListener, { once: true });
+  });
+  try {
+    return await Promise.race([Promise.resolve().then(() => resolver({ ...context, signal })), aborted]);
+  } finally {
+    if (abortListener) signal.removeEventListener('abort', abortListener);
+  }
+}
+
 async function resolveLegacyProductFormats<T extends { products?: unknown[] }>(
   response: T,
   converter: LegacyFormatConverter | undefined,
   resolver: LegacyFormatResolver | undefined,
-  requestContext: { servedAdcpVersion?: string; accountId?: string }
+  requestContext: {
+    servedAdcpVersion?: string;
+    accountId?: string;
+    signal?: AbortSignal;
+    timeoutMs: number;
+    concurrency: number;
+  }
 ): Promise<LegacyFormatConverter | undefined> {
   if (!resolver) return converter;
   assertSafeGetProductsResponse(response);
@@ -977,7 +1050,7 @@ async function resolveLegacyProductFormats<T extends { products?: unknown[] }>(
     string,
     Awaited<ReturnType<LegacyFormatResolver>> | { readonly resolutionError: unknown }
   >();
-  const pending: Promise<void>[] = [];
+  const pending: Array<(signal: AbortSignal) => Promise<void>> = [];
   const scanScope = (projectionProduct: V1Product, resolverProductId: string, resolverFieldPrefix: string): void => {
     if (Array.isArray((projectionProduct as unknown as V2Product).format_options)) return;
     for (let index = 0; index < projectionProduct.format_ids.length; index++) {
@@ -1022,26 +1095,27 @@ async function resolveLegacyProductFormats<T extends { products?: unknown[] }>(
 
       const key = legacyFormatResolutionKey(projectionContext);
       const frozenFormatId = Object.freeze({ ...(formatId as V1FormatId) });
-      pending.push(
-        Promise.resolve()
-          .then(() =>
-            resolver({
+      pending.push(async signal => {
+        try {
+          const value = await invokeLegacyFormatResolver(
+            resolver,
+            {
               formatId: frozenFormatId,
               productId: resolverProductId,
               field: resolverField,
               operation: 'get_products',
-              ...requestContext,
-            })
-          )
-          .then(
-            value => {
-              resolutions.set(key, value);
+              ...(requestContext.servedAdcpVersion !== undefined && {
+                servedAdcpVersion: requestContext.servedAdcpVersion,
+              }),
+              ...(requestContext.accountId !== undefined && { accountId: requestContext.accountId }),
             },
-            error => {
-              resolutions.set(key, { resolutionError: error });
-            }
-          )
-      );
+            signal
+          );
+          resolutions.set(key, value);
+        } catch (error) {
+          resolutions.set(key, { resolutionError: error });
+        }
+      });
     }
   };
 
@@ -1071,7 +1145,21 @@ async function resolveLegacyProductFormats<T extends { products?: unknown[] }>(
       );
     }
   }
-  await Promise.all(pending);
+  const resolverSignal = createLegacyFormatResolverSignal(requestContext.signal, requestContext.timeoutMs);
+  try {
+    let nextJob = 0;
+    const workerCount = Math.min(requestContext.concurrency, pending.length);
+    await Promise.all(
+      Array.from({ length: workerCount }, async () => {
+        while (nextJob < pending.length) {
+          const job = pending[nextJob++];
+          if (job) await job(resolverSignal.signal);
+        }
+      })
+    );
+  } finally {
+    resolverSignal.dispose();
+  }
   if (resolutions.size === 0) return converter;
 
   return context => {
@@ -1863,6 +1951,10 @@ export interface CreateAdcpServerFromPlatformOptions extends Omit<
    * format tuple plus non-secret request routing context and fails closed.
    */
   legacyCreativeFormatResolver?: LegacyFormatResolver;
+  /** Shared resolver-phase deadline in milliseconds. Defaults to 10 seconds. */
+  legacyCreativeFormatResolverTimeoutMs?: number;
+  /** Maximum concurrent resolver calls within one get_products response (1–64). Defaults to 8. */
+  legacyCreativeFormatResolverConcurrency?: number;
   /** Resolve persisted canonical custom formats when this server emits a legacy wire response. */
   canonicalFormatLegacyResolver?: CanonicalFormatLegacyResolver;
   /**
@@ -2945,6 +3037,20 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
         opts.proposalStore,
         opts.legacyCreativeFormatConverter,
         opts.legacyCreativeFormatResolver,
+        {
+          timeoutMs: legacyFormatResolverLimit(
+            opts.legacyCreativeFormatResolverTimeoutMs,
+            DEFAULT_LEGACY_FORMAT_RESOLVER_TIMEOUT_MS,
+            'legacyCreativeFormatResolverTimeoutMs',
+            MAX_LEGACY_FORMAT_RESOLVER_TIMEOUT_MS
+          ),
+          concurrency: legacyFormatResolverLimit(
+            opts.legacyCreativeFormatResolverConcurrency,
+            DEFAULT_LEGACY_FORMAT_RESOLVER_CONCURRENCY,
+            'legacyCreativeFormatResolverConcurrency',
+            MAX_LEGACY_FORMAT_RESOLVER_CONCURRENCY
+          ),
+        },
         opts.canonicalFormatLegacyResolver,
         defaultCreativeWireMode
       ),
@@ -5639,6 +5745,7 @@ function buildMediaBuyHandlers<P extends DecisioningPlatform<any, any>>(
   proposalStore: import('../proposal').ProposalStore | undefined,
   legacyFormatConverter: LegacyFormatConverter | undefined,
   legacyFormatResolver: LegacyFormatResolver | undefined,
+  legacyFormatResolverOptions: { timeoutMs: number; concurrency: number },
   canonicalFormatLegacyResolver: CanonicalFormatLegacyResolver | undefined,
   creativeWireMode: 'canonical' | 'legacy'
 ): MediaBuyHandlers<Account> | undefined {
@@ -5870,6 +5977,8 @@ function buildMediaBuyHandlers<P extends DecisioningPlatform<any, any>>(
                 {
                   ...(ctx.servedAdcpVersion !== undefined && { servedAdcpVersion: ctx.servedAdcpVersion }),
                   ...(reqCtx.account?.id !== undefined && { accountId: reqCtx.account.id }),
+                  ...(ctx.signal !== undefined && { signal: ctx.signal }),
+                  ...legacyFormatResolverOptions,
                 }
               );
               const canonicalResult = asCanonicalProductResponse(

--- a/src/lib/server/decisioning/runtime/validate-platform.ts
+++ b/src/lib/server/decisioning/runtime/validate-platform.ts
@@ -111,7 +111,10 @@ export class PlatformConfigError extends Error {
 // arm). When adcontextprotocol/adcp#3392 lands, the same shape extends
 // to `update_media_buy`, `build_creative`, `sync_catalogs`, `get_products`.
 
-export function validatePlatform(platform: DecisioningPlatform): void {
+export function validatePlatform(
+  platform: DecisioningPlatform,
+  effectiveFields: Partial<Record<keyof DecisioningPlatform, unknown>> = {}
+): void {
   const claimed = platform.capabilities?.specialisms ?? [];
   const errors: string[] = [];
 
@@ -139,7 +142,7 @@ export function validatePlatform(platform: DecisioningPlatform): void {
     const required = SPECIALISM_REQUIREMENTS[specialism];
     if (!required) continue; // forward-compat for unknown specialisms
     for (const field of required) {
-      if (platform[field] == null) {
+      if (platform[field] == null && effectiveFields[field] == null) {
         errors.push(`capabilities.specialisms claims '${specialism}'; platform.${String(field)} is missing`);
       }
     }

--- a/src/lib/server/decisioning/specialisms/sales.ts
+++ b/src/lib/server/decisioning/specialisms/sales.ts
@@ -102,6 +102,8 @@ import type {
   CanonicalProduct,
   CanonicalUpdateMediaBuyRequest,
 } from '../../../v2/projection/creative-delivery';
+import type { ProjectionCatalogSnapshot } from '../../../v2/projection/catalog-snapshot';
+import type { V1ProductInput } from '../../../v2/projection/types';
 
 type SyncCreative = CanonicalSyncCreativeAsset;
 type Ctx<TCtxMeta> = RequestContext<Account<TCtxMeta>>;
@@ -110,8 +112,12 @@ type ExclusivePayload<TLeft, TRight> =
   | (TRight & { [K in Exclude<keyof TLeft, keyof TRight>]?: never });
 type LegacyMediaBuyStatusInput<T> = T & { status?: MediaBuyStatus };
 
+export type GetProductsProjectionInput = (CanonicalProduct | V1ProductInput) & {
+  /** Exact owner-scoped aliases used only while projecting this product; never emitted on the wire. */
+  projectionCatalogs?: readonly ProjectionCatalogSnapshot[];
+};
 type CanonicalGetProductsPayload = Omit<ServerPayload<CanonicalCreativeResponse<GetProductsResponse>>, 'products'> & {
-  products?: CanonicalProduct[];
+  products?: GetProductsProjectionInput[];
 };
 export type GetProductsPayload = RequireCacheScopeWhenProducts<CanonicalGetProductsPayload>;
 type CreateMediaBuySuccessPayload = LegacyMediaBuyStatusInput<

--- a/src/lib/storage/interfaces.ts
+++ b/src/lib/storage/interfaces.ts
@@ -147,6 +147,8 @@ export interface DeferredTaskState {
   a2aTaskId: string;
   /** Seller wire generation used for the original task and every continuation. */
   serverVersion: 'v2' | 'v3';
+  /** True when the original seller-version decision used the SDK's synthetic fallback. */
+  serverVersionSynthetic?: boolean;
   /** Trusted agent identifier resolved through current client configuration. */
   agentId: string;
   /** Task/tool name. */

--- a/src/lib/utils/adcp-version-config.ts
+++ b/src/lib/utils/adcp-version-config.ts
@@ -62,7 +62,7 @@ export function resolveAdcpVersion(adcpVersion: string | undefined): string {
     throw new ConfigurationError(
       `adcpVersion ${JSON.stringify(adcpVersion)} is not a valid AdCP version. ` +
         `Expected a semver string (e.g. '3.0.1', '3.1.0-beta.1') or a legacy alias. ` +
-        `Currently bundled: ${listBundledVersions().join(', ')}.`,
+        `Currently bundled: ${listBundledAdcpVersions().join(', ')}.`,
       'adcpVersion'
     );
   }
@@ -80,7 +80,7 @@ export function resolveAdcpVersion(adcpVersion: string | undefined): string {
     throw new ConfigurationError(
       `adcpVersion ${JSON.stringify(adcpVersion)} resolves to bundle key "${resolvedKey}", ` +
         `but no schema bundle for that key ships with this SDK build. ` +
-        `Currently bundled: ${listBundledVersions().join(', ')}. ` +
+        `Currently bundled: ${listBundledAdcpVersions().join(', ')}. ` +
         `If you're testing against a beta that the spec repo has tagged but the SDK hasn't synced yet, ` +
         `run \`npm run sync-schemas\` and \`npm run build:lib\` to populate the cache, ` +
         `then re-construct.`,
@@ -232,7 +232,7 @@ function prereleaseFamilyAlias(version: string): string | undefined {
  * Always includes `ADCP_VERSION` even when its bundle hasn't been built yet
  * (dev-tree case) so the error remains actionable on first build.
  */
-function listBundledVersions(): string[] {
+export function listBundledAdcpVersions(): string[] {
   const bundled = COMPATIBLE_ADCP_VERSIONS.filter(v => hasSchemaBundle(v));
   if (!bundled.includes(ADCP_VERSION as (typeof COMPATIBLE_ADCP_VERSIONS)[number])) {
     return [ADCP_VERSION, ...bundled];

--- a/src/lib/utils/pricing-adapter.ts
+++ b/src/lib/utils/pricing-adapter.ts
@@ -342,6 +342,94 @@ export function normalizeProductChannels(product: any): any {
   return { ...product, channels: [...new Set(normalized)] };
 }
 
+const LEGACY_ZONED_TIMESTAMP =
+  /^(\d{4})-(\d{2})-(\d{2})[Tt ](\d{2}):(\d{2}):(\d{2})(\.\d+)?(?:[Zz]|\s*UTC|([+-])(\d{2})(?::?(\d{2}))?)$/i;
+
+function normalizeLegacyZonedTimestamp(value: unknown): unknown {
+  let candidate = value;
+  if (candidate && typeof candidate === 'object' && !Array.isArray(candidate)) {
+    const entries = Object.entries(candidate as Record<string, unknown>);
+    if (entries.length === 0) return undefined;
+    if (entries.length !== 1 || (entries[0]![0] !== '$date' && entries[0]![0] !== 'value')) return value;
+    candidate = entries[0]![1];
+  }
+  if (candidate === null) return undefined;
+  if (candidate && typeof candidate === 'object' && !Array.isArray(candidate)) {
+    return Object.keys(candidate as Record<string, unknown>).length === 0 ? undefined : value;
+  }
+  if (typeof candidate !== 'string') return value;
+
+  const match = LEGACY_ZONED_TIMESTAMP.exec(candidate.trim());
+  if (!match) return value;
+  const [
+    ,
+    yearText,
+    monthText,
+    dayText,
+    hourText,
+    minuteText,
+    secondText,
+    fraction = '',
+    sign,
+    offsetHourText,
+    offsetMinuteText,
+  ] = match;
+  const year = Number(yearText);
+  const month = Number(monthText);
+  const day = Number(dayText);
+  const hour = Number(hourText);
+  const minute = Number(minuteText);
+  const second = Number(secondText);
+  const offsetHours = offsetHourText === undefined ? 0 : Number(offsetHourText);
+  const offsetMinutes = offsetMinuteText === undefined ? 0 : Number(offsetMinuteText);
+  if (sign === '-' && offsetHours === 0 && offsetMinutes === 0) return value;
+  if (
+    month < 1 ||
+    month > 12 ||
+    day < 1 ||
+    day > 31 ||
+    hour > 23 ||
+    minute > 59 ||
+    second > 59 ||
+    offsetHours > 23 ||
+    offsetMinutes > 59
+  ) {
+    return value;
+  }
+
+  const local = new Date(0);
+  local.setUTCFullYear(year, month - 1, day);
+  local.setUTCHours(hour, minute, second, 0);
+  if (
+    local.getUTCFullYear() !== year ||
+    local.getUTCMonth() !== month - 1 ||
+    local.getUTCDate() !== day ||
+    local.getUTCHours() !== hour ||
+    local.getUTCMinutes() !== minute ||
+    local.getUTCSeconds() !== second
+  ) {
+    return value;
+  }
+
+  const offset = (offsetHours * 60 + offsetMinutes) * 60_000 * (sign === '-' ? -1 : 1);
+  const utc = new Date(local.getTime() - offset);
+  if (utc.getUTCFullYear() < 0 || utc.getUTCFullYear() > 9999) return value;
+  return `${utc.toISOString().slice(0, 19)}${fraction}Z`;
+}
+
+/** Normalize optional forecast timestamps at the v2.5 compatibility boundary. */
+export function normalizeLegacyProductForecast(product: any): any {
+  if (!product?.forecast || typeof product.forecast !== 'object' || Array.isArray(product.forecast)) return product;
+  const forecast = { ...product.forecast };
+  for (const field of ['generated_at', 'valid_until'] as const) {
+    if (!(field in forecast)) continue;
+    const normalized = normalizeLegacyZonedTimestamp(forecast[field]);
+    if (normalized === undefined) delete forecast[field];
+    else forecast[field] = normalized;
+  }
+  return { ...product, forecast };
+}
+
 /**
  * Normalize all products in a get_products response to v3
  */
@@ -365,7 +453,9 @@ export function normalizeGetProductsResponse(response: any): any {
 
   return {
     ...response,
-    products: response.products.map((p: any) => normalizeProductChannels(normalizeProductPricing(p))),
+    products: response.products.map((p: any) =>
+      normalizeLegacyProductForecast(normalizeProductChannels(normalizeProductPricing(p)))
+    ),
   };
 }
 

--- a/src/lib/v2/projection/index.ts
+++ b/src/lib/v2/projection/index.ts
@@ -47,6 +47,8 @@ export type {
   BareFormatIdResolveOptions,
   LegacyFormatConversionContext,
   LegacyFormatConverter,
+  LegacyFormatResolutionContext,
+  LegacyFormatResolver,
 } from './v1-to-v2';
 
 export { projectV2ProductToV1 } from './v2-to-v1';

--- a/src/lib/v2/projection/v1-to-v2.ts
+++ b/src/lib/v2/projection/v1-to-v2.ts
@@ -32,9 +32,9 @@
  * deterministic for that single format_id.
  *
  * **Scope (prototype)**:
- *   - AAO catalog only — seller-specific catalogs (publisher's own
- *     `list_creative_formats`) require an AgentClient hook the auto-
- *     negotiation surface will provide in the full 8.0 enablement.
+ *   - AAO catalog plus explicit adopter resolvers for seller-specific
+ *     formats. Network-backed resolution remains outside this pure module;
+ *     server integrations can use `LegacyFormatResolver` before projection.
  *   - Param extraction is dimensions-only (`width`, `height`,
  *     `duration_ms`). Full canonical-specific params (slots, codecs,
  *     char limits, platform_extensions) are not constructed. A v2
@@ -126,6 +126,22 @@ export interface LegacyFormatConversionContext {
 export type LegacyFormatConverter = (
   context: LegacyFormatConversionContext
 ) => V2ProductFormatDeclaration | null | undefined;
+
+/** Safe request context supplied to an asynchronous seller-specific resolver. */
+export interface LegacyFormatResolutionContext extends LegacyFormatConversionContext {
+  operation: 'get_products';
+  servedAdcpVersion?: string;
+  accountId?: string;
+}
+
+/**
+ * Asynchronous counterpart to {@link LegacyFormatConverter}. Intended for
+ * catalog/database lookups that must complete before a server projects a
+ * legacy `get_products` result onto its canonical wire boundary.
+ */
+export type LegacyFormatResolver = (
+  context: LegacyFormatResolutionContext
+) => PromiseLike<V2ProductFormatDeclaration | null | undefined> | V2ProductFormatDeclaration | null | undefined;
 
 export interface V1ToV2ProjectionOptions {
   legacyFormatConverter?: LegacyFormatConverter;

--- a/src/lib/v2/projection/v1-to-v2.ts
+++ b/src/lib/v2/projection/v1-to-v2.ts
@@ -132,6 +132,8 @@ export interface LegacyFormatResolutionContext extends LegacyFormatConversionCon
   operation: 'get_products';
   servedAdcpVersion?: string;
   accountId?: string;
+  /** Aborts when the request is cancelled or the SDK resolver deadline expires. */
+  signal?: AbortSignal;
 }
 
 /**

--- a/src/lib/validation/schema-loader.ts
+++ b/src/lib/validation/schema-loader.ts
@@ -842,6 +842,50 @@ export function getValidator(
   return compiled;
 }
 
+export interface ResolvedToolSchemaDocument {
+  toolName: string;
+  direction: Direction;
+  requestedVersion: string;
+  /** Loader key used to select the installed schema bundle. */
+  bundleKey: string;
+  /** Exact protocol release recorded by the resolved bundle, when available. */
+  resolvedVersion: string;
+  schema: Readonly<Record<string, unknown>>;
+}
+
+/**
+ * Return an unmodified tool JSON Schema from the same version-aware bundle
+ * resolver used by runtime validation. Unlike `getValidator().schema`, response
+ * documents are not relaxed for extensible envelopes, so callers can publish
+ * the protocol-authored schema verbatim from an on-demand discovery tool.
+ */
+export function getToolSchemaDocument(
+  toolName: string,
+  direction: Direction,
+  version: string = ADCP_VERSION
+): ResolvedToolSchemaDocument | undefined {
+  const state = ensureInit(version);
+  const file = state.fileIndex.get(`${toolName}::${direction}`);
+  if (!file) return undefined;
+  const schema = loadJson(file) as Record<string, unknown>;
+  let resolvedVersion = state.version;
+  try {
+    const index = loadJson(path.join(state.root, 'index.json')) as Record<string, unknown>;
+    if (typeof index.adcp_version === 'string') resolvedVersion = index.adcp_version;
+  } catch {
+    // Legacy/external bundles may omit index.json; the resolved key remains an
+    // accurate identifier for the schema directory selected by the loader.
+  }
+  return {
+    toolName,
+    direction,
+    requestedVersion: version,
+    bundleKey: state.version,
+    resolvedVersion,
+    schema,
+  };
+}
+
 /**
  * Compile an arbitrary schema from the cached bundle by path, e.g.
  * `core/mcp-webhook-payload.json`. Used by storyboard webhook assertions
@@ -1020,6 +1064,7 @@ export function getMcpToolSchema(
       profile === 'all'
         ? path.resolve(mcpRoot, protocolVersion)
         : path.resolve(mcpRoot, protocolVersion, 'profiles', profile);
+    if (!manifestRoot.startsWith(`${mcpRoot}${path.sep}`)) continue;
     const manifestFile = path.join(manifestRoot, 'manifest.json');
     if (!existsSync(manifestFile)) continue;
     const manifest = loadJson(manifestFile) as {
@@ -1066,6 +1111,7 @@ export function getMcpToolSummary(
       profile === 'all'
         ? path.resolve(mcpRoot, protocolVersion)
         : path.resolve(mcpRoot, protocolVersion, 'profiles', profile);
+    if (!manifestRoot.startsWith(`${mcpRoot}${path.sep}`)) continue;
     const manifestFile = path.join(manifestRoot, 'manifest.json');
     if (!existsSync(manifestFile)) continue;
     const manifest = loadJson(manifestFile) as {

--- a/src/type-tests/server-payload-aliases.type-test.ts
+++ b/src/type-tests/server-payload-aliases.type-test.ts
@@ -95,11 +95,22 @@ void unchangedServerGetProductsPayload;
 
 declare const publicTypesGetProductsPayload: TypesGetProductsPayload;
 declare const decisioningGetProductsPayload: DecisioningGetProductsPayload;
-// @ts-expect-error DecisioningPlatform is canonical-only; the raw wire alias may contain legacy-only products.
 const decisioningPayloadFromPublicAlias: DecisioningGetProductsPayload = publicTypesGetProductsPayload;
+const legacyDecisioningPayload: DecisioningGetProductsPayload = {
+  cache_scope: 'account',
+  products: [
+    {
+      product_id: 'legacy-product',
+      name: 'Legacy product',
+      format_ids: [{ agent_url: 'https://formats.example/catalog', id: 'custom' }],
+      projectionCatalogs: [],
+    },
+  ],
+};
 // @ts-expect-error Generated Product's empty oneOf marker interfaces prevent structural recovery of the canonical arm.
 const publicAliasFromDecisioningPayload: TypesGetProductsPayload = decisioningGetProductsPayload;
 void decisioningPayloadFromPublicAlias;
+void legacyDecisioningPayload;
 void publicAliasFromDecisioningPayload;
 
 // @ts-expect-error get_products payloads with products must declare cache_scope.

--- a/test/lib/pricing-adapter.test.js
+++ b/test/lib/pricing-adapter.test.js
@@ -441,5 +441,49 @@ describe('pricing adapter utilities', () => {
       assert.ok(Array.isArray(normalized.products), 'Should still be an array');
       assert.strictEqual(normalized.products.length, 0);
     });
+
+    test('normalizes explicitly zoned legacy forecast timestamps without losing fractional precision (#2677)', () => {
+      const vectors = [
+        ['2026-08-23T22:00:00+02:00', '2026-08-23T20:00:00Z'],
+        ['2026-08-24t02:30:00.123456+02:30', '2026-08-24T00:00:00.123456Z'],
+        [' 2026-08-23 22:00:00.123456+0200 ', '2026-08-23T20:00:00.123456Z'],
+        ['2026-08-23t20:00:00z', '2026-08-23T20:00:00Z'],
+        ['2026-08-23T20:00:00 UTC', '2026-08-23T20:00:00Z'],
+        ['2026-08-23T22:00:00+02', '2026-08-23T20:00:00Z'],
+        [{ $date: '2026-08-23T20:00:00Z' }, '2026-08-23T20:00:00Z'],
+        [{ value: '2026-08-24T02:30:00+02:30' }, '2026-08-24T00:00:00Z'],
+      ];
+
+      for (const [input, expected] of vectors) {
+        const response = {
+          products: [{ product_id: 'legacy', forecast: { generated_at: input, valid_until: input } }],
+        };
+        const auditCopy = structuredClone(response);
+        const normalized = normalizeGetProductsResponse(response);
+
+        assert.strictEqual(normalized.products[0].forecast.generated_at, expected);
+        assert.strictEqual(normalized.products[0].forecast.valid_until, expected);
+        assert.deepStrictEqual(response, auditCopy, 'normalization must not mutate the preserved seller wire object');
+      }
+    });
+
+    test('omits null and empty forecast timestamps but leaves ambiguous values untouched (#2677)', () => {
+      const ambiguous = { $date: '2026-08-23T20:00:00Z', value: '2026-08-24T00:00:00Z' };
+      const unknownOffset = '2026-08-23T20:00:00-00:00';
+      const expandedUtcYear = '9999-12-31T23:59:59-23:59';
+      const normalized = normalizeGetProductsResponse({
+        products: [
+          { product_id: 'empty', forecast: { generated_at: null, valid_until: { value: {} } } },
+          { product_id: 'ambiguous', forecast: { generated_at: ambiguous, valid_until: '2026-08-23T20:00:00' } },
+          { product_id: 'unknown-offset', forecast: { generated_at: unknownOffset, valid_until: expandedUtcYear } },
+        ],
+      });
+
+      assert.deepStrictEqual(normalized.products[0].forecast, {});
+      assert.deepStrictEqual(normalized.products[1].forecast.generated_at, ambiguous);
+      assert.strictEqual(normalized.products[1].forecast.valid_until, '2026-08-23T20:00:00');
+      assert.strictEqual(normalized.products[2].forecast.generated_at, unknownOffset);
+      assert.strictEqual(normalized.products[2].forecast.valid_until, expandedUtcYear);
+    });
   });
 });

--- a/test/lib/server-version-provenance.test.js
+++ b/test/lib/server-version-provenance.test.js
@@ -1,0 +1,191 @@
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { SingleAgentClient } = require('../../dist/lib/core/SingleAgentClient.js');
+const { TaskExecutor } = require('../../dist/lib/core/TaskExecutor.js');
+const { ProtocolClient } = require('../../dist/lib/protocols/index.js');
+
+const agent = {
+  id: 'versioned-seller',
+  name: 'Versioned seller',
+  agent_uri: 'https://seller.example/mcp',
+  protocol: 'mcp',
+};
+
+function metadata(status) {
+  return {
+    taskId: 'client-task',
+    taskName: 'list_authorized_properties',
+    agent: { id: agent.id, name: agent.name, protocol: agent.protocol },
+    responseTimeMs: 1,
+    timestamp: '2026-08-25T00:00:00.000Z',
+    clarificationRounds: 0,
+    status,
+  };
+}
+
+function capabilities(version, synthetic) {
+  return {
+    version,
+    majorVersions: [version === 'v2' ? 2 : 3],
+    protocols: ['media_buy'],
+    features: {},
+    extensions: [],
+    _synthetic: synthetic,
+  };
+}
+
+function makeClient(caps, executeTask) {
+  const client = new SingleAgentClient(agent, {
+    validateFeatures: false,
+    validation: { requests: 'off', responses: 'off' },
+  });
+  client.discoveredEndpoint = agent.agent_uri;
+  client.cachedCapabilities = caps;
+  client.ensureEndpointDiscovered = async () => agent;
+  client.validateRequest = () => {};
+  client.executor.validateRequest = () => {};
+  client.executor.executeTask = executeTask;
+  return client;
+}
+
+function assertProvenance(result, version, synthetic) {
+  assert.equal(result.metadata.serverVersion, version);
+  assert.equal(result.metadata.serverVersionSynthetic, synthetic);
+}
+
+describe('seller-version result provenance', () => {
+  test('keeps concurrent TaskExecutor provenance task-local', async () => {
+    const originalCallTool = ProtocolClient.callTool;
+    ProtocolClient.callTool = async currentAgent => {
+      await new Promise(resolve => setImmediate(resolve));
+      return { status: 'completed', result: { agent_id: currentAgent.id } };
+    };
+    try {
+      const executor = new TaskExecutor({ strictSchemaValidation: false });
+      const v2Agent = { ...agent, id: 'seller-v2', name: 'Seller v2' };
+      const v3Agent = { ...agent, id: 'seller-v3', name: 'Seller v3' };
+      const [v2, v3] = await Promise.all([
+        executor.executeTask(v2Agent, 'list_authorized_properties', {}, undefined, {}, 'v2', capabilities('v2', false)),
+        executor.executeTask(v3Agent, 'list_authorized_properties', {}, undefined, {}, 'v3', capabilities('v3', true)),
+      ]);
+
+      assertProvenance(v2, 'v2', false);
+      assertProvenance(v3, 'v3', true);
+    } finally {
+      ProtocolClient.callTool = originalCallTool;
+    }
+  });
+
+  test('surfaces declared and synthetic seller generations on terminal results', async () => {
+    for (const [version, synthetic, rawResult] of [
+      [
+        'v2',
+        false,
+        {
+          success: true,
+          status: 'completed',
+          data: { properties: [] },
+          metadata: metadata('completed'),
+        },
+      ],
+      [
+        'v3',
+        true,
+        {
+          success: false,
+          status: 'failed',
+          error: 'seller failed',
+          metadata: metadata('failed'),
+        },
+      ],
+    ]) {
+      const client = makeClient(capabilities(version, synthetic), async () => structuredClone(rawResult));
+      const result = await client.executeTask('list_authorized_properties', {});
+      assertProvenance(result, version, synthetic);
+    }
+  });
+
+  test('retains discovered provenance when execution fails unexpectedly', async () => {
+    const client = makeClient(capabilities('v3', false), async () => {
+      throw new Error('unexpected transport parser failure');
+    });
+    const failed = await client.executeTask('list_authorized_properties', {});
+    assert.equal(failed.status, 'failed');
+    assertProvenance(failed, 'v3', false);
+  });
+
+  test('includes provenance on v2 unsupported-feature early results', async () => {
+    const client = makeClient(capabilities('v2', false), async () => {
+      throw new Error('the unsupported-feature result must not dispatch');
+    });
+
+    const result = await client.executeTask('get_products', {
+      filters: { required_features: ['content_standards'] },
+    });
+
+    assert.equal(result.status, 'completed');
+    assert.deepStrictEqual(result.data.products, []);
+    assertProvenance(result, 'v2', false);
+  });
+
+  test('preserves provenance through submitted and deferred continuations', async () => {
+    const completed = () => ({
+      success: true,
+      status: 'completed',
+      data: { properties: [] },
+      metadata: metadata('completed'),
+    });
+    const client = makeClient(capabilities('v2', true), async () => ({
+      success: true,
+      status: 'submitted',
+      metadata: metadata('submitted'),
+      submitted: {
+        taskId: 'seller-task',
+        track: async () => ({ taskId: 'seller-task', taskType: 'list_authorized_properties', status: 'working' }),
+        waitForCompletion: async () => ({
+          success: true,
+          status: 'deferred',
+          metadata: metadata('deferred'),
+          deferred: {
+            token: 'resume-token',
+            question: 'Continue?',
+            resume: async () => completed(),
+          },
+        }),
+      },
+    }));
+
+    const submitted = await client.executeTask('list_authorized_properties', {});
+    assertProvenance(submitted, 'v2', true);
+    const deferred = await submitted.submitted.waitForCompletion(1);
+    assertProvenance(deferred, 'v2', true);
+    const resumed = await deferred.deferred.resume({ approved: true });
+    assertProvenance(resumed, 'v2', true);
+  });
+
+  test('restores provenance from durable client finalization context after restart', async () => {
+    const client = makeClient(capabilities('v3', false), async () => {
+      throw new Error('not used');
+    });
+    client.executor.resumeDeferredTaskWithContext = async () => ({
+      result: {
+        success: true,
+        status: 'completed',
+        data: { properties: [] },
+        metadata: metadata('completed'),
+      },
+      clientContext: {
+        kind: 'single-agent',
+        taskType: 'list_authorized_properties',
+        canonical: false,
+        serverVersion: 'v2',
+        serverVersionSynthetic: true,
+        productPolicyRequest: {},
+      },
+    });
+
+    const resumed = await client.resumeDeferredTask('durable-token', { approved: true });
+    assertProvenance(resumed, 'v2', true);
+  });
+});

--- a/test/lib/versioned-tool-schemas.test.js
+++ b/test/lib/versioned-tool-schemas.test.js
@@ -1,0 +1,56 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+
+const { getToolInputSchema, getToolResponseSchema } = require('../../dist/lib/schemas/index.js');
+
+describe('version-aware tool JSON Schemas (#2678)', () => {
+  it('selects distinct 3.0, 3.1, and 3.2 request schemas and reports the resolved release', () => {
+    const v30 = getToolInputSchema('create_media_buy', { adcpVersion: '3.0' });
+    const v31 = getToolInputSchema('create_media_buy', { adcpVersion: '3.1' });
+    const v32 = getToolInputSchema('create_media_buy', { adcpVersion: '3.2.0-beta.6' });
+
+    assert.strictEqual(v30.bundleKey, '3.0');
+    assert.strictEqual(v30.resolvedVersion, '3.0.25');
+    assert.ok(v30.schema.properties.adcp_major_version);
+    assert.strictEqual(v30.schema.properties.paused, undefined);
+
+    assert.strictEqual(v31.bundleKey, '3.1');
+    assert.strictEqual(v31.resolvedVersion, '3.1.18');
+    assert.strictEqual(v31.schema.properties.adcp_major_version, undefined);
+    assert.ok(v31.schema.properties.paused);
+
+    assert.strictEqual(v32.bundleKey, '3.2.0-beta.6');
+    assert.strictEqual(v32.resolvedVersion, '3.2.0-beta.6');
+    assert.strictEqual(v32.schema.deprecated, true);
+    assert.deepStrictEqual(v32.schema['x-superseded-by'], ['buy_products', 'accept_proposal']);
+  });
+
+  it('returns protocol-authored response documents and independent caller-owned objects', () => {
+    const first = getToolResponseSchema('create_media_buy', { adcpVersion: '3.0' });
+    first.schema.title = 'caller mutation';
+    const second = getToolResponseSchema('create_media_buy', { adcpVersion: '3.0' });
+
+    assert.strictEqual(second.direction, 'sync');
+    assert.notStrictEqual(second.schema.title, 'caller mutation');
+
+    const submitted = getToolResponseSchema('get_products', { adcpVersion: '3.1', variant: 'submitted' });
+    assert.strictEqual(submitted.direction, 'submitted');
+    assert.strictEqual(submitted.resolvedVersion, '3.1.18');
+  });
+
+  it('fails clearly for unavailable bundles, tools, and response variants', () => {
+    assert.throws(
+      () => getToolInputSchema('create_media_buy', { adcpVersion: '99.0' }),
+      /schema data for version|schema bundle/i
+    );
+    assert.strictEqual(getToolInputSchema('not_a_tool', { adcpVersion: '3.1' }), undefined);
+    assert.strictEqual(
+      getToolResponseSchema('get_adcp_capabilities', { adcpVersion: '3.1', variant: 'submitted' }),
+      undefined
+    );
+    assert.throws(
+      () => getToolInputSchema('create_media_buy', { adcpVersion: '3.2-beta' }),
+      /moving prerelease-family alias/i
+    );
+  });
+});

--- a/test/server-auto-hydration.test.js
+++ b/test/server-auto-hydration.test.js
@@ -6,10 +6,11 @@ const assert = require('node:assert/strict');
 const {
   createAdcpServerFromPlatform,
   createCtxMetadataStore,
+  getHydratedLegacyFormatIds,
   memoryCtxMetadataStore,
 } = require('../dist/lib/server/legacy/v5');
 
-function makePlatform({ getProductsImpl, createMediaBuyImpl, getMediaBuysImpl }) {
+function makePlatform({ getProductsImpl, createMediaBuyImpl, updateMediaBuyImpl, getMediaBuysImpl }) {
   return {
     capabilities: {
       adcp_version: '3.0.0',
@@ -28,7 +29,7 @@ function makePlatform({ getProductsImpl, createMediaBuyImpl, getMediaBuysImpl })
     sales: {
       getProducts: getProductsImpl,
       createMediaBuy: createMediaBuyImpl,
-      updateMediaBuy: async () => ({ media_buy_id: 'mb_1', status: 'active', packages: [] }),
+      updateMediaBuy: updateMediaBuyImpl ?? (async () => ({ media_buy_id: 'mb_1', status: 'active', packages: [] })),
       getMediaBuyDelivery: async () => ({ deliveries: [] }),
       getMediaBuys: getMediaBuysImpl ?? (async () => ({ media_buys: [] })),
     },
@@ -36,6 +37,138 @@ function makePlatform({ getProductsImpl, createMediaBuyImpl, getMediaBuysImpl })
 }
 
 describe('createAdcpServerFromPlatform — auto-hydration of products', () => {
+  it('preserves the exact owner-qualified legacy route across discovery storage and create', async () => {
+    const refs = {
+      a: { agent_url: 'https://formats-a.example/catalog', id: 'shared_takeover' },
+      b: { agent_url: 'https://formats-b.example/catalog', id: 'shared_takeover' },
+    };
+    let selectedRoutes;
+    let updatedRoutes;
+    const platform = makePlatform({
+      getProductsImpl: async () => ({
+        cache_scope: 'account',
+        products: Object.entries(refs).map(([owner, ref]) => ({
+          product_id: `product-${owner}`,
+          name: `Product ${owner}`,
+          format_ids: [ref],
+        })),
+      }),
+      createMediaBuyImpl: async req => {
+        selectedRoutes = getHydratedLegacyFormatIds(req.packages[0].product);
+        return { media_buy_id: 'mb-owner-route', status: 'pending_creatives', packages: [] };
+      },
+      updateMediaBuyImpl: async (_mediaBuyId, req) => {
+        updatedRoutes = getHydratedLegacyFormatIds(req.new_packages[0].product);
+        return { media_buy_id: 'mb-owner-route', status: 'active', packages: [] };
+      },
+    });
+    const ctxMetadata = createCtxMetadataStore({
+      backend: memoryCtxMetadataStore({ sweepIntervalMs: 0 }),
+    });
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'Legacy route hydration',
+      version: '1.0.0',
+      ctxMetadata,
+      validation: { requests: 'off', responses: 'off' },
+      legacyCreativeFormatResolver: async ({ formatId }) => ({
+        format_option_id: `takeover-${new URL(formatId.agent_url).hostname[8]}`,
+        format_kind: 'custom',
+        format_shape: 'takeover',
+        format_schema: {
+          uri: 'https://schemas.example/takeover.json',
+          digest: `sha256:${'a'.repeat(64)}`,
+        },
+        params: {},
+      }),
+    });
+
+    const discovered = await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: { name: 'get_products', arguments: { brief: 'owner-specific takeover' } },
+    });
+    assert.notStrictEqual(discovered.isError, true, JSON.stringify(discovered.structuredContent));
+    assert.strictEqual(discovered.structuredContent.products[1].format_ids, undefined);
+
+    const created = await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'create_media_buy',
+        arguments: {
+          buyer_ref: 'br_owner_route',
+          packages: [{ buyer_ref: 'pkg_owner_route', product_id: 'product-b' }],
+          idempotency_key: 'idem_owner_route',
+        },
+      },
+    });
+    assert.notStrictEqual(created.isError, true, JSON.stringify(created.structuredContent));
+    assert.deepStrictEqual(selectedRoutes, [refs.b]);
+
+    const updated = await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'update_media_buy',
+        arguments: {
+          media_buy_id: 'mb-owner-route',
+          idempotency_key: 'idem_owner_route_update',
+          new_packages: [{ buyer_ref: 'pkg_owner_route_update', product_id: 'product-a' }],
+        },
+      },
+    });
+    assert.notStrictEqual(updated.isError, true, JSON.stringify(updated.structuredContent));
+    assert.deepStrictEqual(updatedRoutes, [refs.a]);
+  });
+
+  it('rejects adopter injection of the SDK-private legacy route sidecar at product and placement scope', async () => {
+    let createCalls = 0;
+    const forgedRoutes = {
+      formatIds: [{ agent_url: 'http://127.0.0.1/internal', id: 'forged' }],
+    };
+    for (const injectedProduct of [
+      {
+        product_id: 'injected-product-route',
+        name: 'Injected product route',
+        format_options: [{ format_kind: 'image', params: { width: 300, height: 250 } }],
+        __adcp_private_legacy_format_routes: forgedRoutes,
+      },
+      {
+        product_id: 'injected-placement-route',
+        name: 'Injected placement route',
+        format_options: [{ format_kind: 'image', params: { width: 300, height: 250 } }],
+        placements: [
+          {
+            placement_id: 'sidebar',
+            format_options: [{ format_kind: 'image', params: { width: 300, height: 250 } }],
+            __adcp_private_legacy_format_routes: {
+              ...forgedRoutes,
+            },
+          },
+        ],
+      },
+    ]) {
+      const platform = makePlatform({
+        getProductsImpl: async () => ({ products: [injectedProduct] }),
+        createMediaBuyImpl: async () => {
+          createCalls += 1;
+          return { media_buy_id: 'must-not-run', status: 'active', packages: [] };
+        },
+      });
+      const server = createAdcpServerFromPlatform(platform, {
+        name: 'Reserved route injection',
+        version: '1.0.0',
+        ctxMetadata: createCtxMetadataStore({ backend: memoryCtxMetadataStore({ sweepIntervalMs: 0 }) }),
+        validation: { requests: 'off', responses: 'off' },
+      });
+
+      const result = await server.dispatchTestRequest({
+        method: 'tools/call',
+        params: { name: 'get_products', arguments: { brief: 'injected' } },
+      });
+      assert.strictEqual(result.isError, true);
+      assert.strictEqual(result.structuredContent.adcp_error.code, 'INVALID_REQUEST');
+    }
+    assert.strictEqual(createCalls, 0);
+  });
+
   it('createMediaBuy receives req.packages[i].product hydrated from prior getProducts', async () => {
     let observedPackages;
     let getProductsAccountId;

--- a/test/server-create-adcp-server.test.js
+++ b/test/server-create-adcp-server.test.js
@@ -891,6 +891,23 @@ describe('createAdcpServer', () => {
           tools: ['get_adcp_capabilities', 'list_creative_formats'],
           protocols: [],
         },
+        {
+          name: 'sales-social-ingestion',
+          config: {
+            capabilities: { specialisms: ['sales-social'] },
+            mediaBuy: { syncCreatives: async () => ({ creatives: [] }) },
+          },
+          tools: ['get_adcp_capabilities', 'sync_creatives'],
+          protocols: ['media_buy'],
+        },
+        {
+          name: 'bare-sales-specialism',
+          config: {
+            capabilities: { specialisms: ['sales-guaranteed'] },
+          },
+          tools: ['get_adcp_capabilities'],
+          protocols: [],
+        },
       ];
 
       for (const fixture of cases) {

--- a/test/server-create-adcp-server.test.js
+++ b/test/server-create-adcp-server.test.js
@@ -821,6 +821,93 @@ describe('createAdcpServer', () => {
       assert.ok(caps.supported_protocols.includes('sponsored_intelligence'));
     });
 
+    it('derives supported_protocols from domain handler groups, not overlapping or utility tool names (#2680)', async () => {
+      const cases = [
+        {
+          name: 'sales-only',
+          config: {
+            mediaBuy: {
+              getProducts: async () => ({ products: [] }),
+              syncCreatives: async () => ({ creatives: [] }),
+            },
+          },
+          tools: ['get_adcp_capabilities', 'get_products', 'sync_creatives'],
+          protocols: ['media_buy'],
+        },
+        {
+          name: 'creative-only',
+          config: {
+            creative: {
+              buildCreative: async () => ({}),
+              listCreativeFormats: async () => ({ formats: [] }),
+            },
+          },
+          tools: ['build_creative', 'get_adcp_capabilities', 'list_creative_formats'],
+          protocols: ['creative'],
+        },
+        {
+          name: 'signals-only',
+          config: { signals: { getSignals: async () => ({ signals: [] }) } },
+          tools: ['get_adcp_capabilities', 'get_signals'],
+          protocols: ['signals'],
+        },
+        {
+          name: 'mixed',
+          config: {
+            mediaBuy: {
+              getProducts: async () => ({ products: [] }),
+              syncCreatives: async () => ({ creatives: [] }),
+            },
+            creative: {
+              buildCreative: async () => ({}),
+              listCreativeFormats: async () => ({ formats: [] }),
+            },
+            signals: { getSignals: async () => ({ signals: [] }) },
+          },
+          tools: [
+            'build_creative',
+            'get_adcp_capabilities',
+            'get_products',
+            'get_signals',
+            'list_creative_formats',
+            'sync_creatives',
+          ],
+          protocols: ['media_buy', 'signals', 'creative'],
+        },
+        {
+          name: 'utility-only',
+          config: {
+            accounts: { listAccounts: async () => ({ accounts: [] }) },
+            eventTracking: { logEvent: async () => ({}) },
+          },
+          tools: ['get_adcp_capabilities', 'list_accounts', 'log_event'],
+          protocols: [],
+        },
+        {
+          name: 'overlap-only-media-buy-group',
+          config: {
+            mediaBuy: { listCreativeFormats: async () => ({ formats: [] }) },
+          },
+          tools: ['get_adcp_capabilities', 'list_creative_formats'],
+          protocols: [],
+        },
+      ];
+
+      for (const fixture of cases) {
+        const server = createAdcpServer({
+          name: fixture.name,
+          version: '1.0.0',
+          mcpToolProfile: 'all',
+          ...fixture.config,
+        });
+        const listed = await server.dispatchTestRequest({ method: 'tools/list' });
+        const caps = await callTool(server, 'get_adcp_capabilities', {});
+
+        assert.deepStrictEqual(listed.tools.map(tool => tool.name).sort(), fixture.tools, `${fixture.name} tools/list`);
+        assert.deepStrictEqual(caps.supported_protocols, fixture.protocols, `${fixture.name} supported_protocols`);
+      }
+    });
+
     it('promotes explicitly declared measurement capabilities into supported_protocols', async () => {
       const server = createAdcpServer({
         name: 'Test',
@@ -2870,7 +2957,7 @@ describe('createAdcpServer', () => {
   });
 
   describe('eventTracking domain', () => {
-    it('registers event tracking tools in their own domain without advertising experimental measurement', async () => {
+    it('registers event tracking utilities without advertising an unrelated protocol domain', async () => {
       const server = createAdcpServer({
         name: 'Test',
         version: '1.0.0',
@@ -2888,8 +2975,7 @@ describe('createAdcpServer', () => {
       assert.ok(tools.includes('sync_catalogs'));
 
       const caps = await callTool(server, 'get_adcp_capabilities', {});
-      assert.ok(caps.supported_protocols.includes('media_buy'));
-      assert.ok(!caps.supported_protocols.includes('measurement'));
+      assert.deepStrictEqual(caps.supported_protocols, []);
     });
   });
 

--- a/test/server-decisioning-capability-projections.test.js
+++ b/test/server-decisioning-capability-projections.test.js
@@ -173,7 +173,7 @@ describe('Capability projections — declarative capability blocks on Decisionin
     assert.strictEqual(result.structuredContent?.creative?.preview, undefined);
     assert.strictEqual(result.structuredContent?.request_signing?.protocol_methods_required_for, undefined);
     assert.strictEqual(result.structuredContent?.identity?.brand_json_url, undefined);
-    assert.deepStrictEqual(result.structuredContent?.supported_protocols, ['media_buy', 'creative']);
+    assert.deepStrictEqual(result.structuredContent?.supported_protocols, ['media_buy']);
     assert.deepStrictEqual(result.structuredContent?.specialisms, ['sales-non-guaranteed']);
     assert.deepStrictEqual(result.structuredContent?.media_buy?.supported_pricing_models, ['cpm']);
   });

--- a/test/server-decisioning-from-platform.test.js
+++ b/test/server-decisioning-from-platform.test.js
@@ -1277,6 +1277,326 @@ describe('createAdcpServerFromPlatform — v6.0 alpha', () => {
     ]);
   });
 
+  it('resolves seller-owned legacy product formats asynchronously with exact owner routing', async () => {
+    const base = buildPlatform();
+    const calls = [];
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const product = (product_id, agent_url, id) => ({
+      product_id,
+      name: product_id,
+      description: 'Legacy custom format',
+      format_ids: [{ agent_url, id }],
+      delivery_type: 'non_guaranteed',
+      publisher_properties: [{ publisher_domain: 'seller.example', selection_type: 'all' }],
+      reporting_capabilities: {
+        available_reporting_frequencies: ['daily'],
+        expected_delay_minutes: 60,
+        timezone: 'UTC',
+        supports_webhooks: false,
+        available_metrics: ['impressions'],
+        date_range_support: 'date_range',
+      },
+      pricing_options: [
+        { pricing_option_id: `${product_id}-cpm`, pricing_model: 'cpm', fixed_price: 5, currency: 'USD' },
+      ],
+    });
+    const ownerA = product('owner-a', 'https://formats-a.example/catalog', 'shared_takeover');
+    ownerA.placements = [
+      {
+        placement_id: 'companion',
+        name: 'Companion placement',
+        format_ids: [{ agent_url: 'https://formats-c.example/catalog', id: 'shared_takeover' }],
+      },
+    ];
+    const dualDeclared = product('dual-declared', 'https://formats-d.example/catalog', 'shared_takeover');
+    dualDeclared.format_options = [
+      {
+        format_option_id: 'takeover-d',
+        format_kind: 'custom',
+        format_shape: 'takeover_d',
+        format_schema: {
+          uri: 'https://schemas.example/takeover-d.json',
+          digest: `sha256:${'d'.repeat(64)}`,
+        },
+        params: {},
+        v1_format_ref: dualDeclared.format_ids,
+      },
+    ];
+    const server = createAdcpServerFromPlatform(
+      buildPlatform({
+        sales: {
+          ...base.sales,
+          getProducts: async () => ({
+            cache_scope: 'account',
+            products: [
+              ownerA,
+              product('owner-b', 'https://formats-b.example/catalog', 'shared_takeover'),
+              product('known-aao', 'https://creative.adcontextprotocol.org/', 'display_300x250_image'),
+              dualDeclared,
+            ],
+          }),
+        },
+      }),
+      {
+        name: 'async-legacy-format-resolution',
+        version: '1.0.0',
+        adcpVersion: '3.1.18',
+        capabilities: { supported_versions: ['3.0.25', '3.1.18'] },
+        validation: { requests: 'off', responses: 'off' },
+        legacyCreativeFormatResolver: async context => {
+          calls.push(context);
+          assert.strictEqual(Object.isFrozen(context.formatId), true);
+          inFlight += 1;
+          maxInFlight = Math.max(maxInFlight, inFlight);
+          await new Promise(resolve => setImmediate(resolve));
+          inFlight -= 1;
+          const owner = new URL(context.formatId.agent_url).hostname.split('-')[1].split('.')[0];
+          return {
+            format_option_id: `takeover-${owner}`,
+            format_kind: 'custom',
+            format_shape: `takeover_${owner}`,
+            format_schema: {
+              uri: `https://schemas.example/takeover-${owner}.json`,
+              digest: `sha256:${(owner === 'a' ? 'a' : 'b').repeat(64)}`,
+            },
+            params: {},
+          };
+        },
+      }
+    );
+
+    const result = await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'get_products',
+        arguments: {
+          adcp_version: '3.1.18',
+          account: { account_id: 'acc_async_formats' },
+          brief: 'custom takeovers',
+        },
+      },
+    });
+
+    assert.notStrictEqual(result.isError, true, JSON.stringify(result.structuredContent));
+    assert.strictEqual(calls.length, 3, 'known AAO and dual-declared formats must not invoke the adopter resolver');
+    assert.ok(maxInFlight >= 2, 'independent format resolutions should run concurrently');
+    assert.deepStrictEqual(
+      calls.map(({ operation, servedAdcpVersion, accountId, formatId }) => ({
+        operation,
+        servedAdcpVersion,
+        accountId,
+        owner: formatId.agent_url,
+      })),
+      [
+        {
+          operation: 'get_products',
+          servedAdcpVersion: '3.1',
+          accountId: 'acc_async_formats',
+          owner: 'https://formats-a.example/catalog',
+        },
+        {
+          operation: 'get_products',
+          servedAdcpVersion: '3.1',
+          accountId: 'acc_async_formats',
+          owner: 'https://formats-c.example/catalog',
+        },
+        {
+          operation: 'get_products',
+          servedAdcpVersion: '3.1',
+          accountId: 'acc_async_formats',
+          owner: 'https://formats-b.example/catalog',
+        },
+      ]
+    );
+    const products = result.structuredContent.products;
+    assert.strictEqual(products[0].format_options[0].format_option_id, 'takeover-a');
+    assert.strictEqual(products[0].placements[0].format_options[0].format_option_id, 'takeover-c');
+    assert.deepStrictEqual(products[0].placements[0].format_options[0].v1_format_ref, [
+      { agent_url: 'https://formats-c.example/catalog', id: 'shared_takeover' },
+    ]);
+    assert.strictEqual(products[1].format_options[0].format_option_id, 'takeover-b');
+    assert.deepStrictEqual(products[0].format_options[0].v1_format_ref, [
+      { agent_url: 'https://formats-a.example/catalog', id: 'shared_takeover' },
+    ]);
+    assert.deepStrictEqual(products[1].format_options[0].v1_format_ref, [
+      { agent_url: 'https://formats-b.example/catalog', id: 'shared_takeover' },
+    ]);
+    assert.strictEqual(products[3].format_options[0].format_option_id, 'takeover-d');
+
+    calls.length = 0;
+    const v30Result = await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'get_products',
+        arguments: {
+          adcp_version: '3.0.25',
+          account: { account_id: 'acc_async_formats' },
+          brief: 'custom takeovers on 3.0',
+        },
+      },
+    });
+    assert.notStrictEqual(v30Result.isError, true, JSON.stringify(v30Result.structuredContent));
+    assert.strictEqual(calls.length, 3);
+    assert.ok(calls.every(call => call.servedAdcpVersion === '3.0'));
+    assert.deepStrictEqual(v30Result.structuredContent.products[0].format_ids[0], {
+      agent_url: 'https://formats-a.example/catalog',
+      id: 'shared_takeover',
+    });
+  });
+
+  it('consumes per-product catalog snapshots for top-level and placement formats without emitting metadata', async () => {
+    const base = buildPlatform();
+    const topRef = { agent_url: 'https://catalog-owner.example/formats', id: 'homepage' };
+    const placementRef = { agent_url: 'https://catalog-owner.example/formats', id: 'companion' };
+    const snapshot = {
+      source: 'publisher',
+      publisher_domain: 'catalog-owner.example',
+      formats: [
+        {
+          format_option_id: 'homepage-canonical',
+          format_kind: 'custom',
+          format_shape: 'homepage',
+          format_schema: {
+            uri: 'https://catalog-owner.example/schemas/homepage.json',
+            digest: `sha256:${'e'.repeat(64)}`,
+          },
+          params: {},
+          v1_format_ref: [topRef],
+        },
+        {
+          format_option_id: 'companion-canonical',
+          format_kind: 'custom',
+          format_shape: 'companion',
+          format_schema: {
+            uri: 'https://catalog-owner.example/schemas/companion.json',
+            digest: `sha256:${'f'.repeat(64)}`,
+          },
+          params: {},
+          v1_format_ref: [placementRef],
+        },
+      ],
+    };
+    let resolverCalls = 0;
+    const server = createAdcpServerFromPlatform(
+      buildPlatform({
+        sales: {
+          ...base.sales,
+          getProducts: async () => ({
+            cache_scope: 'account',
+            products: [
+              {
+                product_id: 'snapshot-product',
+                name: 'Snapshot product',
+                format_ids: [topRef],
+                placements: [{ placement_id: 'companion', format_ids: [placementRef] }],
+                projectionCatalogs: [snapshot],
+              },
+            ],
+          }),
+        },
+      }),
+      {
+        name: 'per-product-projection-snapshot',
+        version: '1.0.0',
+        validation: { requests: 'off', responses: 'off' },
+        legacyCreativeFormatResolver: async () => {
+          resolverCalls += 1;
+          throw new Error('snapshot-backed formats must not invoke the resolver');
+        },
+      }
+    );
+
+    const result = await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'get_products',
+        arguments: { account: { account_id: 'acc_test' }, brief: 'snapshot formats' },
+      },
+    });
+
+    assert.notStrictEqual(result.isError, true, JSON.stringify(result.structuredContent));
+    assert.strictEqual(resolverCalls, 0);
+    const projected = result.structuredContent.products[0];
+    assert.strictEqual(projected.projectionCatalogs, undefined);
+    assert.strictEqual(projected.format_options[0].format_option_id, 'homepage-canonical');
+    assert.strictEqual(projected.placements[0].format_options[0].format_option_id, 'companion-canonical');
+  });
+
+  it('rejects duplicate product ids when only one row carries projection catalogs', async () => {
+    const base = buildPlatform();
+    const server = createAdcpServerFromPlatform(
+      buildPlatform({
+        sales: {
+          ...base.sales,
+          getProducts: async () => ({
+            cache_scope: 'account',
+            products: [
+              { product_id: 'duplicate', name: 'Catalog row', format_options: [], projectionCatalogs: [{}] },
+              { product_id: 'duplicate', name: 'Plain row', format_options: [] },
+            ],
+          }),
+        },
+      }),
+      { name: 'duplicate-projection-scope', version: '1.0.0', validation: { requests: 'off', responses: 'off' } }
+    );
+
+    const result = await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: { name: 'get_products', arguments: { account: { account_id: 'acc_test' }, brief: 'duplicates' } },
+    });
+    assert.strictEqual(result.isError, true);
+    assert.strictEqual(result.structuredContent.adcp_error.code, 'INVALID_REQUEST');
+  });
+
+  it('fails closed when asynchronous legacy product format resolution is unavailable or invalid', async () => {
+    const base = buildPlatform();
+    for (const resolver of [
+      async () => null,
+      async () => ({ format_kind: 'custom', params: {} }),
+      () => {
+        throw new Error('catalog unavailable synchronously');
+      },
+      async () => {
+        throw new Error('catalog unavailable');
+      },
+    ]) {
+      const server = createAdcpServerFromPlatform(
+        buildPlatform({
+          sales: {
+            ...base.sales,
+            getProducts: async () => ({
+              cache_scope: 'account',
+              products: [
+                {
+                  product_id: 'unresolved-custom',
+                  name: 'Unresolved custom',
+                  description: 'Must not cross the canonical boundary',
+                  format_ids: [{ agent_url: 'https://formats.example/catalog', id: 'unknown_custom' }],
+                },
+              ],
+            }),
+          },
+        }),
+        {
+          name: 'failed-async-legacy-format-resolution',
+          version: '1.0.0',
+          validation: { requests: 'off', responses: 'off' },
+          legacyCreativeFormatResolver: resolver,
+        }
+      );
+      const result = await server.dispatchTestRequest({
+        method: 'tools/call',
+        params: {
+          name: 'get_products',
+          arguments: { account: { account_id: 'acc_test' }, brief: 'unresolved custom format' },
+        },
+      });
+      assert.strictEqual(result.isError, true);
+      assert.strictEqual(result.structuredContent.adcp_error.code, 'INVALID_REQUEST');
+    }
+  });
+
   it('rejects format-agnostic modern products while preserving nested 3.0 response projection', async () => {
     const base = buildPlatform();
     let modernProduct = {
@@ -2724,6 +3044,7 @@ describe('CreativeBuilderPlatform + AudiencePlatform wiring', () => {
       legacyHandlers: {
         creative: {
           buildCreative: async () => ({ creative_manifest: { manifest_id: 'mf_1', assets: [] } }),
+          listCreativeFormats: async () => ({ formats: [] }),
         },
       },
     });
@@ -2735,11 +3056,18 @@ describe('CreativeBuilderPlatform + AudiencePlatform wiring', () => {
     return result.structuredContent;
   }
 
-  it('omits media_buy capabilities for a creative-only platform (#2438)', async () => {
+  it('omits media_buy capabilities when creative-only handlers use overlapping tool names (#2438, #2680)', async () => {
     const caps = await getCapabilities(buildCreativeOnlyPlatform());
 
     assert.deepStrictEqual(caps.supported_protocols, ['creative']);
     assert.strictEqual(caps.media_buy, undefined);
+  });
+
+  it('accepts creative specialisms implemented through the merged legacy handler seam (#2680)', async () => {
+    const caps = await getCapabilities(buildCreativeOnlyPlatform({ specialisms: ['creative-generative'] }));
+
+    assert.deepStrictEqual(caps.supported_protocols, ['creative']);
+    assert.ok(caps.specialisms.includes('creative-generative'));
   });
 
   it('preserves a media_buy null override for a creative-only platform (#2438)', async () => {

--- a/test/server-decisioning-from-platform.test.js
+++ b/test/server-decisioning-from-platform.test.js
@@ -1344,9 +1344,11 @@ describe('createAdcpServerFromPlatform — v6.0 alpha', () => {
         adcpVersion: '3.1.18',
         capabilities: { supported_versions: ['3.0.25', '3.1.18'] },
         validation: { requests: 'off', responses: 'off' },
+        legacyCreativeFormatResolverConcurrency: 2,
         legacyCreativeFormatResolver: async context => {
           calls.push(context);
           assert.strictEqual(Object.isFrozen(context.formatId), true);
+          assert.strictEqual(context.signal.aborted, false);
           inFlight += 1;
           maxInFlight = Math.max(maxInFlight, inFlight);
           await new Promise(resolve => setImmediate(resolve));
@@ -1380,7 +1382,7 @@ describe('createAdcpServerFromPlatform — v6.0 alpha', () => {
 
     assert.notStrictEqual(result.isError, true, JSON.stringify(result.structuredContent));
     assert.strictEqual(calls.length, 3, 'known AAO and dual-declared formats must not invoke the adopter resolver');
-    assert.ok(maxInFlight >= 2, 'independent format resolutions should run concurrently');
+    assert.strictEqual(maxInFlight, 2, 'format resolution must honor the configured concurrency bound');
     assert.deepStrictEqual(
       calls.map(({ operation, servedAdcpVersion, accountId, formatId }) => ({
         operation,
@@ -1595,6 +1597,134 @@ describe('createAdcpServerFromPlatform — v6.0 alpha', () => {
       assert.strictEqual(result.isError, true);
       assert.strictEqual(result.structuredContent.adcp_error.code, 'INVALID_REQUEST');
     }
+  });
+
+  it('bounds asynchronous legacy format resolution with a shared aborting deadline', async () => {
+    const base = buildPlatform();
+    assert.throws(
+      () =>
+        createAdcpServerFromPlatform(buildPlatform(), {
+          name: 'invalid-legacy-format-resolution-limit',
+          version: '1.0.0',
+          legacyCreativeFormatResolverConcurrency: 0,
+          legacyCreativeFormatResolver: async () => null,
+        }),
+      /legacyCreativeFormatResolverConcurrency must be an integer between 1 and 64/
+    );
+    assert.throws(
+      () =>
+        createAdcpServerFromPlatform(buildPlatform(), {
+          name: 'invalid-legacy-format-resolution-timeout',
+          version: '1.0.0',
+          legacyCreativeFormatResolverTimeoutMs: 2_147_483_648,
+          legacyCreativeFormatResolver: async () => null,
+        }),
+      /legacyCreativeFormatResolverTimeoutMs must be an integer between 1 and 2147483647/
+    );
+    let resolverSignal;
+    const server = createAdcpServerFromPlatform(
+      buildPlatform({
+        sales: {
+          ...base.sales,
+          getProducts: async () => ({
+            cache_scope: 'account',
+            products: [
+              {
+                product_id: 'deadline-custom',
+                name: 'Deadline custom',
+                format_ids: [{ agent_url: 'https://formats.example/catalog', id: 'hung_custom' }],
+              },
+            ],
+          }),
+        },
+      }),
+      {
+        name: 'bounded-async-legacy-format-resolution',
+        version: '1.0.0',
+        validation: { requests: 'off', responses: 'off' },
+        legacyCreativeFormatResolverTimeoutMs: 20,
+        legacyCreativeFormatResolverConcurrency: 1,
+        legacyCreativeFormatResolver: ({ signal }) => {
+          resolverSignal = signal;
+          return new Promise(() => {});
+        },
+      }
+    );
+
+    const startedAt = Date.now();
+    const result = await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'get_products',
+        arguments: { account: { account_id: 'acc_test' }, brief: 'deadline custom format' },
+      },
+    });
+    assert.strictEqual(result.isError, true);
+    assert.strictEqual(result.structuredContent.adcp_error.code, 'INVALID_REQUEST');
+    assert.strictEqual(resolverSignal?.aborted, true);
+    assert.ok(Date.now() - startedAt < 1_000, 'hung resolver must not stall the get_products response');
+  });
+
+  it('cancels legacy format resolution with the request and does not start queued lookups', async () => {
+    const base = buildPlatform();
+    let resolverCalls = 0;
+    let resolverStartedResolve;
+    const resolverStarted = new Promise(resolve => {
+      resolverStartedResolve = resolve;
+    });
+    const server = createAdcpServerFromPlatform(
+      buildPlatform({
+        sales: {
+          ...base.sales,
+          getProducts: async () => ({
+            cache_scope: 'account',
+            products: [
+              {
+                product_id: 'cancelled-custom',
+                name: 'Cancelled custom',
+                format_ids: [
+                  { agent_url: 'https://formats.example/catalog', id: 'first' },
+                  { agent_url: 'https://formats.example/catalog', id: 'second' },
+                  { agent_url: 'https://formats.example/catalog', id: 'third' },
+                ],
+              },
+            ],
+          }),
+        },
+      }),
+      {
+        name: 'request-cancelled-legacy-format-resolution',
+        version: '1.0.0',
+        validation: { requests: 'off', responses: 'off' },
+        legacyCreativeFormatResolverTimeoutMs: 10_000,
+        legacyCreativeFormatResolverConcurrency: 1,
+        legacyCreativeFormatResolver: () => {
+          resolverCalls += 1;
+          resolverStartedResolve();
+          return new Promise(() => {});
+        },
+      }
+    );
+    const controller = new AbortController();
+    const resultPromise = server.dispatchTestRequest(
+      {
+        method: 'tools/call',
+        params: {
+          name: 'get_products',
+          arguments: { account: { account_id: 'acc_test' }, brief: 'cancelled custom format' },
+        },
+      },
+      { signal: controller.signal }
+    );
+    await resolverStarted;
+    const startedAt = Date.now();
+    controller.abort(new Error('buyer cancelled'));
+    const result = await resultPromise;
+
+    assert.strictEqual(result.isError, true);
+    assert.strictEqual(result.structuredContent.adcp_error.code, 'INVALID_REQUEST');
+    assert.strictEqual(resolverCalls, 1, 'queued lookups must not invoke the resolver after cancellation');
+    assert.ok(Date.now() - startedAt < 1_000, 'request cancellation must promptly settle the response');
   });
 
   it('rejects format-agnostic modern products while preserving nested 3.0 response projection', async () => {


### PR DESCRIPTION
## Summary

- project standard and extension capabilities from the registered handler surface without false protocol claims
- preserve negotiated seller-version provenance across synchronous, deferred, recovered, and early-return task results
- normalize legacy forecast timestamps and expose version-aware request/response schema lookup
- resolve seller-specific legacy product formats, including nested placements, catalog snapshots, and exact create/update route hydration
- harden schema and private-route boundaries against traversal, accessors, and reserved-field injection

## Validation

- `npm run format:check`
- `npm run typecheck`
- `npm run build:lib`
- `npm test`
- `npm run check:adopter-types`
- `npx changeset status`
- independent code, protocol, and test expert reviews: no remaining blockers

Closes #2671
Closes #2675
Closes #2677
Closes #2678
Closes #2679
Closes #2680