### PR TITLE
fix(storyboard): preserve wholesale account scope

### DIFF
--- a/.changeset/calm-feeds-keep-scope.md
+++ b/.changeset/calm-feeds-keep-scope.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Preserve account scope and conditional-feed context across packaged wholesale product storyboards.

--- a/src/lib/testing/storyboard/context.ts
+++ b/src/lib/testing/storyboard/context.ts
@@ -123,14 +123,21 @@ export const CONTEXT_EXTRACTORS: Record<string, ContextExtractor> = {
   },
 
   get_products(data) {
-    const d = data as Record<string, unknown> | undefined;
+    const d = asRecord(data);
     const products = d?.products as Array<Record<string, unknown>> | undefined;
-    if (!products?.[0]) return {};
-    const extracted: Record<string, unknown> = { products };
-    if (products[0].product_id) extracted.product_id = products[0].product_id;
+    const extracted: Record<string, unknown> = {};
+    if (products?.[0]) {
+      extracted.products = products;
+      if (products[0].product_id) extracted.product_id = products[0].product_id;
+    }
     // Extract proposal_id if proposals are returned
     const proposals = d?.proposals as Array<Record<string, unknown>> | undefined;
     if (proposals?.[0]?.proposal_id) extracted.proposal_id = proposals[0].proposal_id;
+    // Wholesale conditional-fetch steps need the response's scope and version
+    // metadata even when `unchanged: true` legitimately omits product rows.
+    if (d?.wholesale_feed_version !== undefined) extracted.wholesale_feed_version = d.wholesale_feed_version;
+    if (d?.pricing_version !== undefined) extracted.pricing_version = d.pricing_version;
+    if (d?.cache_scope !== undefined) extracted.cache_scope = d.cache_scope;
     return extracted;
   },
 

--- a/src/lib/testing/storyboard/request-builder.ts
+++ b/src/lib/testing/storyboard/request-builder.ts
@@ -75,10 +75,20 @@ const FALLBACK_CALLER_AGENT_URL = 'https://e2e-orchestrator.adcontextprotocol.or
 const FIXTURE_AWARE_ENRICHERS = new Set<string>([
   'create_media_buy', // merges discovery-derived product_id / pricing_option_id INTO fixture packages[0]
   'comply_test_controller', // forces account.sandbox: true regardless of fixture
+  'get_products', // preserves wholesale fixture fields while keeping resolved account scope authoritative
   'update_media_buy', // resolves account via resolveAccount(options) so sandbox routing matches create_media_buy
   'get_media_buys', // resolves account via resolveAccount(options) so sandbox routing matches create_media_buy
   'get_media_buy_delivery', // resolves account via resolveAccount(options) so sandbox routing matches create_media_buy
 ]);
+
+function hasUnresolvedContextReference(value: unknown): boolean {
+  if (typeof value === 'string') return /^\$context\.\w+$/.test(value);
+  if (Array.isArray(value)) return value.some(hasUnresolvedContextReference);
+  if (value && typeof value === 'object') {
+    return Object.values(value as Record<string, unknown>).some(hasUnresolvedContextReference);
+  }
+  return false;
+}
 
 /**
  * Placeholder identifiers that the upstream universal compliance
@@ -272,18 +282,43 @@ const REQUEST_ENRICHERS: Record<string, RequestEnricher> = {
   // ── Product Discovery ──────────────────────────────────
 
   get_products(step, context, options) {
+    // Fixture-aware: wholesale storyboards author cache validators, filters,
+    // and account identities that must survive enrichment together. Resolve
+    // placeholders before selecting the account. A fully resolved fixture
+    // account remains authoritative (scope-isolation storyboards deliberately
+    // switch accounts between steps); only an unresolved fixture reference
+    // falls back to the context/run account (#2654).
+    const fixtureFields = step.sample_request
+      ? omitEnvelopeFields(
+          injectContext({ ...(step.sample_request as Record<string, unknown>) }, context) as Record<string, unknown>
+        )
+      : {};
+    const fixtureAccount = fixtureFields.account;
+    const resolvedAccount =
+      fixtureAccount !== undefined && !hasUnresolvedContextReference(fixtureAccount)
+        ? fixtureAccount
+        : (context.account ?? resolveAccount(options));
+
+    if (fixtureFields.buying_mode === 'wholesale') {
+      return {
+        ...fixtureFields,
+        account: resolvedAccount,
+      };
+    }
+
     // If the step is a "refine" step, build a refine request
     if (step.sample_request?.buying_mode === 'refine' && context.products) {
       return {
+        ...fixtureFields,
         buying_mode: 'refine',
-        refine: [
+        refine: fixtureFields.refine ?? [
           {
             scope: 'request',
             ask: 'Only guaranteed packages with premium placement.',
           },
         ],
-        brand: resolveBrand(options),
-        account: context.account ?? resolveAccount(options),
+        brand: fixtureFields.brand ?? resolveBrand(options),
+        account: resolvedAccount,
       };
     }
 
@@ -291,6 +326,8 @@ const REQUEST_ENRICHERS: Record<string, RequestEnricher> = {
       buying_mode: 'brief',
       brief: options.brief || 'Show me all available advertising products across all channels',
       brand: resolveBrand(options),
+      ...fixtureFields,
+      account: resolvedAccount,
     };
   },
 

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -7671,15 +7671,26 @@ export function applyBrandInvariant(
       const acct = existingAccount as Record<string, unknown>;
       const isNaturalKeyVariant = 'brand' in acct || 'operator' in acct;
       if (isNaturalKeyVariant) {
-        const merged: Record<string, unknown> = { ...acct, brand };
+        // Wholesale cache-scope storyboards deliberately address a different
+        // natural-key account to prove public/account token isolation. Keep
+        // that explicitly authored account identity while still enforcing the
+        // run-scoped top-level brand. Other tools and buying modes retain the
+        // cross-step account-brand invariant from #579.
+        const preserveWholesaleAccountBrand =
+          taskName === 'get_products' && request.buying_mode === 'wholesale' && acct.brand !== undefined;
+        const merged: Record<string, unknown> = {
+          ...acct,
+          brand: preserveWholesaleAccountBrand ? acct.brand : brand,
+        };
         // The natural-key arm of AccountReference requires `operator` (per
         // schemas/cache/{version}/core/account-ref.json). A fixture or earlier
         // context-extraction step that produced `{brand, sandbox}` without
         // operator would otherwise be passed through and rejected by a
         // strict-validating seller. Default operator to brand.domain — same
         // convention `resolveAccount` uses for synthetic refs.
-        if (typeof merged.operator !== 'string' && typeof brand.domain === 'string') {
-          merged.operator = brand.domain;
+        const accountBrand = merged.brand as { domain?: unknown } | undefined;
+        if (typeof merged.operator !== 'string' && typeof accountBrand?.domain === 'string') {
+          merged.operator = accountBrand.domain;
         }
         result.account = merged;
       }

--- a/test/lib/context-extractors.test.js
+++ b/test/lib/context-extractors.test.js
@@ -5,6 +5,41 @@ const { extractContext, extractContextWithProvenance } = require('../../dist/lib
 const { proposalTermsDigest } = require('../../dist/lib/negotiation/verification.js');
 
 describe('context extractors', () => {
+  describe('get_products', () => {
+    it('extracts wholesale scope and version metadata with product rows (#2654)', () => {
+      const products = [{ product_id: 'prod_overlay' }];
+      const result = extractContext('get_products', {
+        products,
+        wholesale_feed_version: 'feed-account-v2',
+        pricing_version: 'pricing-account-v4',
+        cache_scope: 'account',
+      });
+
+      assert.deepStrictEqual(result, {
+        products,
+        product_id: 'prod_overlay',
+        wholesale_feed_version: 'feed-account-v2',
+        pricing_version: 'pricing-account-v4',
+        cache_scope: 'account',
+      });
+    });
+
+    it('extracts wholesale metadata from unchanged responses without product rows (#2654)', () => {
+      const result = extractContext('get_products', {
+        unchanged: true,
+        wholesale_feed_version: 'feed-public-v1',
+        pricing_version: 'pricing-public-v1',
+        cache_scope: 'public',
+      });
+
+      assert.deepStrictEqual(result, {
+        wholesale_feed_version: 'feed-public-v1',
+        pricing_version: 'pricing-public-v1',
+        cache_scope: 'public',
+      });
+    });
+  });
+
   describe('build_creative', () => {
     it('preserves single creative_manifest extraction', () => {
       const data = {

--- a/test/lib/request-builder.test.js
+++ b/test/lib/request-builder.test.js
@@ -38,6 +38,53 @@ function withDateNow(iso, fn) {
 }
 
 describe('Request Builder', () => {
+  describe('get_products', () => {
+    test('keeps the resolved context account authoritative for wholesale probes (#2654)', () => {
+      const contextAccount = { account_id: 'account-overlay-resolved' };
+      const result = buildRequest(
+        step('get_products', {
+          sample_request: {
+            buying_mode: 'wholesale',
+            account: { account_id: '$context.account_id' },
+            if_wholesale_feed_version: '$context.wholesale_feed_version',
+            context: { correlation_id: 'scope-probe' },
+          },
+        }),
+        {
+          account: contextAccount,
+          wholesale_feed_version: 'public-v1',
+        },
+        DEFAULT_OPTIONS
+      );
+
+      assert.deepStrictEqual(result.account, contextAccount);
+      assert.strictEqual(result.buying_mode, 'wholesale');
+      assert.strictEqual(result.if_wholesale_feed_version, 'public-v1');
+      assert.deepStrictEqual(result.context, { correlation_id: 'scope-probe' });
+    });
+
+    test('preserves an authored wholesale account over a different context account (#2654)', () => {
+      const overlayAccount = {
+        brand: { domain: 'account-overlay.example' },
+        operator: 'pinnacle-agency.example',
+      };
+      const result = buildRequest(
+        step('get_products', {
+          sample_request: {
+            buying_mode: 'wholesale',
+            account: overlayAccount,
+            filters: { pricing_currencies: ['USD'] },
+          },
+        }),
+        { account: { account_id: 'stale-context-account' } },
+        DEFAULT_OPTIONS
+      );
+
+      assert.deepStrictEqual(result.account, overlayAccount);
+      assert.deepStrictEqual(result.filters, { pricing_currencies: ['USD'] });
+    });
+  });
+
   describe('build_creative', () => {
     test('does not mix a legacy target_format_id into a canonical single target', () => {
       const result = buildRequest(

--- a/test/lib/storyboard-brand-invariant.test.js
+++ b/test/lib/storyboard-brand-invariant.test.js
@@ -76,6 +76,24 @@ describe('applyBrandInvariant', () => {
     assert.deepStrictEqual(result.account.brand, BRAND);
   });
 
+  test('preserves an authored wholesale get_products account scope (#2654)', () => {
+    const overlayBrand = { domain: 'account-overlay.example' };
+    const result = applyBrandInvariant(
+      {
+        buying_mode: 'wholesale',
+        account: { brand: overlayBrand, operator: 'pinnacle-agency.example' },
+      },
+      { brand: BRAND },
+      'get_products'
+    );
+
+    assert.deepStrictEqual(result.brand, BRAND, 'the run-scoped top-level brand remains invariant');
+    assert.deepStrictEqual(result.account, {
+      brand: overlayBrand,
+      operator: 'pinnacle-agency.example',
+    });
+  });
+
   test('passes through when no brand is configured (e.g. security probes)', () => {
     const input = { list_id: 'pl-1' };
     const result = applyBrandInvariant(input, {});


### PR DESCRIPTION
## Summary

- preserve fixture-authored wholesale account identities while resolving missing context references
- carry wholesale feed versions, pricing versions, and cache scope across storyboard steps
- keep the run-scoped top-level brand without rewriting deliberate wholesale account overlays
- add regression coverage and a patch changeset

## Testing

- `npm run format:check`
- `npm run typecheck`
- `npm run build:lib`
- focused regression suite: 166 tests passed
- full `npm test`: 16,638 passed; one transport test hit a transient `ECONNRESET` and passed on isolated rerun
- pre-push validation passed

Fixes #2654