### PR TITLE
fix(storyboard): drain webhook receiver waits

### DIFF
--- a/.changeset/quiet-hooks-release.md
+++ b/.changeset/quiet-hooks-release.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Drain pending webhook storyboard waits during shutdown and stop capture limits from trapping retry senders in a 5xx loop.

--- a/src/lib/testing/storyboard/webhook-receiver.ts
+++ b/src/lib/testing/storyboard/webhook-receiver.ts
@@ -202,6 +202,10 @@ export async function createWebhookReceiver(options: CreateWebhookReceiverOption
     resolve: (result: WebhookWaitResult) => void;
     timer: NodeJS.Timeout;
   }> = [];
+  const waitAllTimers: Array<{
+    resolve: (result: CapturedWebhook[]) => void;
+    timer: NodeJS.Timeout;
+  }> = [];
   const retryPolicies = new Map<string, { policy: RetryReplayPolicy; delivered: number }>();
   const deliveryCounts = new Map<string, number>();
 
@@ -237,8 +241,8 @@ export async function createWebhookReceiver(options: CreateWebhookReceiverOption
       retryPolicies.set(retryKeyString(key), { policy, delivered: 0 });
     },
     wait: (filter, timeout_ms) => wait(filter, timeout_ms, captured, waiters),
-    wait_all: (filter, timeout_ms) => waitAll(filter, timeout_ms, captured),
-    close: () => closeServer(server, waiters),
+    wait_all: (filter, timeout_ms) => waitAll(filter, timeout_ms, captured, waitAllTimers),
+    close: () => closeServer(server, waiters, waitAllTimers),
   };
 }
 
@@ -299,21 +303,21 @@ function handleRequest(req: IncomingMessage, res: ServerResponse, state: Handler
 
     const key = retryKeyString({ step_id, operation_id });
     const deliveryIndex = (state.deliveryCounts.get(key) ?? 0) + 1;
+    const status = nextResponseStatus(state.retryPolicies, key);
 
-    // Back-pressure on capture exhaustion — signal 503 so a conformant
-    // sender retries later, drop the capture so the runner's memory
-    // footprint stays bounded. Drops a delivery quietly is worse than
-    // surfacing a clearly observable refusal.
-    const perKey = countPerKey(state.captured, step_id, operation_id);
+    // Stop retaining bodies once a capture cap is exhausted, but preserve the
+    // configured retry-replay status sequence. Unconditionally returning 503
+    // here masks the policy's eventual 2xx forever and can amplify a sender's
+    // retries after the runner has already reached its memory bound (#2653).
+    const perKey = state.deliveryCounts.get(key) ?? 0;
     if (state.captured.length >= MAX_CAPTURED_TOTAL || perKey >= MAX_CAPTURED_PER_KEY) {
-      res.statusCode = 503;
-      res.setHeader('retry-after', '1');
+      res.statusCode = status;
+      if (status === 429 || status >= 500) res.setHeader('retry-after', '1');
       res.end();
       return;
     }
 
     state.deliveryCounts.set(key, deliveryIndex);
-    const status = nextResponseStatus(state.retryPolicies, key);
 
     const webhook: CapturedWebhook = {
       id: randomUUID(),
@@ -376,12 +380,6 @@ function redactHeaders(headers: Record<string, string>): Record<string, string> 
     out[k] = SECRET_HEADER_PATTERN.test(k) ? '[redacted]' : v;
   }
   return out;
-}
-
-function countPerKey(captured: ReadonlyArray<CapturedWebhook>, step_id: string, operation_id: string): number {
-  let n = 0;
-  for (const w of captured) if (w.step_id === step_id && w.operation_id === operation_id) n++;
-  return n;
 }
 
 function parseBody(raw: string, contentType: string | undefined): Pick<CapturedWebhook, 'body' | 'parse_error'> {
@@ -502,15 +500,23 @@ function wait(
  * Waits a minimum of `timeout_ms` even if matches arrive earlier — callers
  * that need "resolve on first match" should use `wait` instead.
  */
-function waitAll(filter: WebhookFilter, timeout_ms: number, captured: CapturedWebhook[]): Promise<CapturedWebhook[]> {
+function waitAll(
+  filter: WebhookFilter,
+  timeout_ms: number,
+  captured: CapturedWebhook[],
+  waitAllTimers: Array<{ resolve: (result: CapturedWebhook[]) => void; timer: NodeJS.Timeout }>
+): Promise<CapturedWebhook[]> {
   return new Promise<CapturedWebhook[]>(resolve => {
     const timer = setTimeout(
       () => {
+        const idx = waitAllTimers.findIndex(entry => entry.timer === timer);
+        if (idx >= 0) waitAllTimers.splice(idx, 1);
         resolve(captured.filter(w => matchesFilter(w, filter)));
       },
       Math.max(0, timeout_ms)
     );
     timer.unref?.();
+    waitAllTimers.push({ resolve, timer });
   });
 }
 
@@ -520,12 +526,18 @@ function waitAll(filter: WebhookFilter, timeout_ms: number, captured: CapturedWe
 
 function closeServer(
   server: Server,
-  waiters: Array<{ filter: WebhookFilter; resolve: (r: WebhookWaitResult) => void; timer: NodeJS.Timeout }>
+  waiters: Array<{ filter: WebhookFilter; resolve: (r: WebhookWaitResult) => void; timer: NodeJS.Timeout }>,
+  waitAllTimers: Array<{ resolve: (result: CapturedWebhook[]) => void; timer: NodeJS.Timeout }>
 ): Promise<void> {
   while (waiters.length > 0) {
     const w = waiters.pop()!;
     clearTimeout(w.timer);
     w.resolve({ timed_out: true });
+  }
+  while (waitAllTimers.length > 0) {
+    const pending = waitAllTimers.pop()!;
+    clearTimeout(pending.timer);
+    pending.resolve([]);
   }
   // Force-close keep-alive sockets so shutdown doesn't hang up to
   // keepAliveTimeout waiting for idle connections to drain.

--- a/src/lib/testing/storyboard/webhook-receiver.ts
+++ b/src/lib/testing/storyboard/webhook-receiver.ts
@@ -243,10 +243,15 @@ export async function createWebhookReceiver(options: CreateWebhookReceiverOption
     set_retry_replay: (key, policy) => {
       retryPolicies.set(retryKeyString(key), { policy, delivered: 0 });
     },
-    wait: (filter, timeout_ms) =>
-      closed ? Promise.resolve({ timed_out: true }) : wait(filter, timeout_ms, captured, waiters),
+    wait: (filter, timeout_ms) => {
+      if (!closed) return wait(filter, timeout_ms, captured, waiters);
+      const already = captured.find(w => matchesFilter(w, filter));
+      return Promise.resolve(already ? { webhook: already } : { timed_out: true });
+    },
     wait_all: (filter, timeout_ms) =>
-      closed ? Promise.resolve([]) : waitAll(filter, timeout_ms, captured, waitAllTimers),
+      closed
+        ? Promise.resolve(captured.filter(w => matchesFilter(w, filter)))
+        : waitAll(filter, timeout_ms, captured, waitAllTimers),
     close: () => {
       closed = true;
       return closeServer(server, captured, waiters, waitAllTimers);

--- a/src/lib/testing/storyboard/webhook-receiver.ts
+++ b/src/lib/testing/storyboard/webhook-receiver.ts
@@ -30,8 +30,9 @@ const MAX_BODY_BYTES = 1_048_576; // 1 MiB
  * Caps on cumulative capture state. `MAX_CAPTURED_TOTAL` bounds the total
  * number of webhooks retained for the run; `MAX_CAPTURED_PER_KEY` bounds
  * per-(step_id, operation_id) deliveries — a publisher stuck in a retry
- * loop can't exhaust memory. Once a cap is hit the receiver returns 503
- * (signalling back-pressure to the sender) and drops the capture.
+ * loop can't exhaust memory. Once a cap is hit the receiver stops retaining
+ * bodies but continues the configured retry-status sequence (or returns 204
+ * when no rejection remains), so the cap cannot trap a sender in a retry loop.
  */
 const MAX_CAPTURED_TOTAL = 1000;
 const MAX_CAPTURED_PER_KEY = 100;
@@ -203,11 +204,13 @@ export async function createWebhookReceiver(options: CreateWebhookReceiverOption
     timer: NodeJS.Timeout;
   }> = [];
   const waitAllTimers: Array<{
+    filter: WebhookFilter;
     resolve: (result: CapturedWebhook[]) => void;
     timer: NodeJS.Timeout;
   }> = [];
   const retryPolicies = new Map<string, { policy: RetryReplayPolicy; delivered: number }>();
   const deliveryCounts = new Map<string, number>();
+  let closed = false;
 
   const server = createServer((req, res) =>
     handleRequest(req, res, { captured, waiters, retryPolicies, deliveryCounts })
@@ -240,9 +243,14 @@ export async function createWebhookReceiver(options: CreateWebhookReceiverOption
     set_retry_replay: (key, policy) => {
       retryPolicies.set(retryKeyString(key), { policy, delivered: 0 });
     },
-    wait: (filter, timeout_ms) => wait(filter, timeout_ms, captured, waiters),
-    wait_all: (filter, timeout_ms) => waitAll(filter, timeout_ms, captured, waitAllTimers),
-    close: () => closeServer(server, waiters, waitAllTimers),
+    wait: (filter, timeout_ms) =>
+      closed ? Promise.resolve({ timed_out: true }) : wait(filter, timeout_ms, captured, waiters),
+    wait_all: (filter, timeout_ms) =>
+      closed ? Promise.resolve([]) : waitAll(filter, timeout_ms, captured, waitAllTimers),
+    close: () => {
+      closed = true;
+      return closeServer(server, captured, waiters, waitAllTimers);
+    },
   };
 }
 
@@ -504,7 +512,11 @@ function waitAll(
   filter: WebhookFilter,
   timeout_ms: number,
   captured: CapturedWebhook[],
-  waitAllTimers: Array<{ resolve: (result: CapturedWebhook[]) => void; timer: NodeJS.Timeout }>
+  waitAllTimers: Array<{
+    filter: WebhookFilter;
+    resolve: (result: CapturedWebhook[]) => void;
+    timer: NodeJS.Timeout;
+  }>
 ): Promise<CapturedWebhook[]> {
   return new Promise<CapturedWebhook[]>(resolve => {
     const timer = setTimeout(
@@ -516,7 +528,7 @@ function waitAll(
       Math.max(0, timeout_ms)
     );
     timer.unref?.();
-    waitAllTimers.push({ resolve, timer });
+    waitAllTimers.push({ filter, resolve, timer });
   });
 }
 
@@ -526,27 +538,32 @@ function waitAll(
 
 function closeServer(
   server: Server,
+  captured: CapturedWebhook[],
   waiters: Array<{ filter: WebhookFilter; resolve: (r: WebhookWaitResult) => void; timer: NodeJS.Timeout }>,
-  waitAllTimers: Array<{ resolve: (result: CapturedWebhook[]) => void; timer: NodeJS.Timeout }>
+  waitAllTimers: Array<{
+    filter: WebhookFilter;
+    resolve: (result: CapturedWebhook[]) => void;
+    timer: NodeJS.Timeout;
+  }>
 ): Promise<void> {
-  while (waiters.length > 0) {
-    const w = waiters.pop()!;
-    clearTimeout(w.timer);
-    w.resolve({ timed_out: true });
-  }
-  while (waitAllTimers.length > 0) {
-    const pending = waitAllTimers.pop()!;
-    clearTimeout(pending.timer);
-    pending.resolve([]);
-  }
-  // Force-close keep-alive sockets so shutdown doesn't hang up to
-  // keepAliveTimeout waiting for idle connections to drain.
-  server.closeAllConnections?.();
   return new Promise<void>((resolve, reject) => {
     server.close(err => {
       if (err && (err as NodeJS.ErrnoException).code !== 'ERR_SERVER_NOT_RUNNING') reject(err);
       else resolve();
     });
+    // Stop accepting new sockets before force-closing existing keep-alive
+    // connections; the opposite order leaves a small acceptance race.
+    server.closeAllConnections?.();
+    while (waiters.length > 0) {
+      const w = waiters.pop()!;
+      clearTimeout(w.timer);
+      w.resolve({ timed_out: true });
+    }
+    while (waitAllTimers.length > 0) {
+      const pending = waitAllTimers.pop()!;
+      clearTimeout(pending.timer);
+      pending.resolve(captured.filter(w => matchesFilter(w, pending.filter)));
+    }
   });
 }
 

--- a/test/lib/storyboard-webhook-receiver.test.js
+++ b/test/lib/storyboard-webhook-receiver.test.js
@@ -93,6 +93,33 @@ describe('createWebhookReceiver', () => {
     }
   });
 
+  test('global capture cap does not mask retry-replay acceptance after prior steps (#2653)', async () => {
+    const receiver = await createWebhookReceiver();
+    try {
+      for (let step = 0; step < 10; step++) {
+        for (let batch = 0; batch < 4; batch++) {
+          const responses = await Promise.all(
+            Array.from({ length: 25 }, () =>
+              post(`${receiver.base_url}/step/prior_${step}/op-${step}`, {
+                idempotency_key: `evt_prior${step}abcdef012345`,
+              })
+            )
+          );
+          assert.ok(responses.every(res => res.status === 204));
+        }
+      }
+      assert.strictEqual(receiver.all().length, 1000);
+
+      receiver.set_retry_replay({ step_id: 'trigger', operation_id: 'op-global-cap' }, { count: 1, http_status: 503 });
+      const url = `${receiver.base_url}/step/trigger/op-global-cap`;
+      assert.strictEqual((await post(url, { idempotency_key: 'evt_stable0123456789' })).status, 503);
+      assert.strictEqual((await post(url, { idempotency_key: 'evt_stable0123456789' })).status, 204);
+      assert.strictEqual(receiver.all().length, 1000, 'overflow deliveries are not retained');
+    } finally {
+      await receiver.close();
+    }
+  });
+
   test('wait resolves on first match; wait_all returns every match after delay', async () => {
     const receiver = await createWebhookReceiver();
     try {
@@ -129,6 +156,27 @@ describe('createWebhookReceiver', () => {
     await receiver.close();
     const result = await Promise.race([pending, delay(250).then(() => 'still-pending')]);
     assert.deepStrictEqual(result, []);
+  });
+
+  test('close preserves matches already captured by a pending wait_all', async () => {
+    const receiver = await createWebhookReceiver();
+    const pending = receiver.wait_all({ step_id: 'captured_before_close' }, 60_000);
+    await post(`${receiver.base_url}/step/captured_before_close/op-close`, {
+      idempotency_key: 'evt_close0123456789ab',
+    });
+
+    await receiver.close();
+    const result = await pending;
+    assert.strictEqual(result.length, 1);
+    assert.strictEqual(result[0].step_id, 'captured_before_close');
+  });
+
+  test('waits registered after close resolve immediately', async () => {
+    const receiver = await createWebhookReceiver();
+    await receiver.close();
+
+    assert.deepStrictEqual(await receiver.wait({ step_id: 'late' }, 60_000), { timed_out: true });
+    assert.deepStrictEqual(await receiver.wait_all({ step_id: 'late' }, 60_000), []);
   });
 
   test('filter scopes by step_id, operation_id, and body path', async () => {

--- a/test/lib/storyboard-webhook-receiver.test.js
+++ b/test/lib/storyboard-webhook-receiver.test.js
@@ -75,6 +75,24 @@ describe('createWebhookReceiver', () => {
     }
   });
 
+  test('capture cap does not mask retry-replay acceptance (#2653)', async () => {
+    const receiver = await createWebhookReceiver();
+    try {
+      receiver.set_retry_replay({ step_id: 'trigger', operation_id: 'op-cap' }, { count: 100, http_status: 503 });
+      const url = `${receiver.base_url}/step/trigger/op-cap`;
+      for (let i = 0; i < 100; i++) {
+        const res = await post(url, { idempotency_key: 'evt_stable0123456789' });
+        assert.strictEqual(res.status, 503);
+      }
+
+      const accepted = await post(url, { idempotency_key: 'evt_stable0123456789' });
+      assert.strictEqual(accepted.status, 204);
+      assert.strictEqual(receiver.all().length, 100, 'the accepted overflow delivery is not retained');
+    } finally {
+      await receiver.close();
+    }
+  });
+
   test('wait resolves on first match; wait_all returns every match after delay', async () => {
     const receiver = await createWebhookReceiver();
     try {
@@ -102,6 +120,15 @@ describe('createWebhookReceiver', () => {
     } finally {
       await receiver.close();
     }
+  });
+
+  test('close drains pending wait_all timers immediately (#2653)', async () => {
+    const receiver = await createWebhookReceiver();
+    const pending = receiver.wait_all({ step_id: 'nobody' }, 60_000);
+
+    await receiver.close();
+    const result = await Promise.race([pending, delay(250).then(() => 'still-pending')]);
+    assert.deepStrictEqual(result, []);
   });
 
   test('filter scopes by step_id, operation_id, and body path', async () => {

--- a/test/lib/storyboard-webhook-receiver.test.js
+++ b/test/lib/storyboard-webhook-receiver.test.js
@@ -171,10 +171,16 @@ describe('createWebhookReceiver', () => {
     assert.strictEqual(result[0].step_id, 'captured_before_close');
   });
 
-  test('waits registered after close resolve immediately', async () => {
+  test('waits registered after close resolve immediately and preserve retained matches', async () => {
     const receiver = await createWebhookReceiver();
+    await post(`${receiver.base_url}/step/retained/op-late`, {
+      idempotency_key: 'evt_retained12345678',
+    });
     await receiver.close();
 
+    const retained = await receiver.wait({ step_id: 'retained' }, 60_000);
+    assert.strictEqual(retained.webhook.step_id, 'retained');
+    assert.strictEqual((await receiver.wait_all({ step_id: 'retained' }, 60_000)).length, 1);
     assert.deepStrictEqual(await receiver.wait({ step_id: 'late' }, 60_000), { timed_out: true });
     assert.deepStrictEqual(await receiver.wait_all({ step_id: 'late' }, 60_000), []);
   });


### PR DESCRIPTION
## Summary

- track pending `wait_all` timers and resolve them when the receiver closes
- preserve retry-replay status progression after capture limits are reached, preventing a permanent 503 retry loop
- use the per-key delivery counter for constant-time capture-limit checks
- add shutdown and cap-boundary regressions plus a patch changeset

## Testing

- `npm run format:check`
- `npm run typecheck`
- `npm run build:lib`
- focused webhook receiver suite: 44 tests passed
- full `npm test`: 16,585 passed; one unrelated multihost test raced to 404 and passed 43/43 on isolated rerun
- pre-push validation passed

Fixes #2653