### PR TITLE
feat(testing): sign functional storyboard requests

### DIFF
--- a/.changeset/functional-storyboard-signing.md
+++ b/.changeset/functional-storyboard-signing.md
@@ -1,0 +1,9 @@
+---
+'@adcp/sdk': minor
+---
+
+Sign ordinary sandbox storyboard requests with the existing compliance test
+key when the bundled `signed-requests-runner` contract enables functional
+dispatch. Capability-driven signing covers required and supported operations,
+preserves existing transport authentication, and leaves older bundles on the
+explicit `not_applicable` compatibility path.

--- a/bin/adcp-storyboard-sandbox.js
+++ b/bin/adcp-storyboard-sandbox.js
@@ -1,0 +1,16 @@
+'use strict';
+
+/**
+ * Translate storyboard CLI routing flags into runner options.
+ * Omitted flags intentionally preserve the historical undefined sandbox mode.
+ */
+function sandboxRunOptions(options = {}) {
+  if (options.sandbox && options.noSandbox) {
+    throw new Error('--sandbox and --no-sandbox are mutually exclusive');
+  }
+  if (options.sandbox) return { sandbox: true };
+  if (options.noSandbox) return { sandbox: false, disable_sandbox: true };
+  return {};
+}
+
+module.exports = { sandboxRunOptions };

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -53,6 +53,7 @@ const { scheduleVersionCheck } = require('./adcp-version-check.js');
 const { formatStoryboardResultsAsJUnit } = require('../dist/lib/testing/storyboard/junit.js');
 const { LIBRARY_VERSION } = require('../dist/lib/version.js');
 const { appendBuiltInVersionUnsupportedHint } = require('./adcp-version-unsupported-hint.js');
+const { sandboxRunOptions } = require('./adcp-storyboard-sandbox.js');
 const {
   createCLIOAuthProvider,
   hasValidOAuthTokens,
@@ -1053,12 +1054,14 @@ function parseAgentOptions(args) {
   // transport/version behavior against a known schema-invalid legacy seller.
   // Normal local compliance runs remain strict by default.
   const strictResponseSchemaValidation = !args.includes('--no-strict-response-schema-validation');
-  // `--no-sandbox` forces `account.sandbox: false` (production) on every
-  // request the runner builds. The default behavior leaves the field unset
-  // (spec-equivalent to false), but agents that key sandbox routing on
-  // field PRESENCE rather than VALUE behave differently. Setting the flag
-  // makes the production intent explicit on the wire.
+  // Direct storyboard runs can explicitly choose sandbox or production
+  // routing. Leaving both flags absent preserves the historical wire shape.
+  const sandbox = args.includes('--sandbox');
   const noSandbox = args.includes('--no-sandbox');
+  if (sandbox && noSandbox) {
+    console.error('Error: --sandbox and --no-sandbox are mutually exclusive.');
+    process.exit(2);
+  }
 
   // `--asserts-seeded-state` declares that the operator has provisioned
   // initial test state out-of-band (HTTP admin endpoint, pre-test script,
@@ -1238,6 +1241,7 @@ function parseAgentOptions(args) {
     dryRun,
     allowHttp,
     strictResponseSchemaValidation,
+    sandbox,
     noSandbox,
     assertsSeededState,
     mediaBuyLifecycleCompatibility,
@@ -2049,6 +2053,9 @@ RUN OPTIONS (full assessment):
                       after this budget, without aborting an active storyboard
                       (default: max(120, 10 × selected storyboard count))
   --brief TEXT        Custom brief for product discovery
+  --sandbox           Explicitly run against sandbox accounts. Sets
+                      account.sandbox=true and enables sandbox-only runner
+                      facilities such as functional request signing.
   --no-sandbox        Force production-path responses (#841). Sets
                       account.sandbox=false on every request AND stamps
                       ext.adcp.disable_sandbox=true to signal adopters
@@ -2916,7 +2923,7 @@ async function handleStoryboardRun(args) {
     ...(fileComplianceOptions.adcpVersion && { adcpVersion: fileComplianceOptions.adcpVersion }),
     ...(fileComplianceOptions.schemaRoot && { schemaRoot: fileComplianceOptions.schemaRoot }),
     ...(!opts.strictResponseSchemaValidation && { strictResponseSchemaValidation: false }),
-    ...(opts.noSandbox && { sandbox: false, disable_sandbox: true }),
+    ...sandboxRunOptions(opts),
     ...(opts.assertsSeededState && { assertsSeededState: true }),
     ...(opts.mediaBuyLifecycleCompatibility && {
       mediaBuyLifecycleCompatibility: opts.mediaBuyLifecycleCompatibility,
@@ -3755,27 +3762,17 @@ async function handleLocalAgentStoryboardRun(modulePath, args, opts) {
       createAgent,
       storyboards: storyboardsSpec,
       compliance: resolveOptions,
-      ...(opts.complianceVersion ||
-      opts.schemaRoot ||
-      !opts.strictResponseSchemaValidation ||
-      opts.noSandbox ||
-      opts.assertsSeededState ||
-      opts.mediaBuyLifecycleCompatibility ||
-      opts.loadedTestKit !== undefined
-        ? {
-            runStoryboardOptions: {
-              ...(opts.complianceVersion && !opts.complianceDir && { adcpVersion: opts.complianceVersion }),
-              ...(opts.schemaRoot && { schemaRoot: opts.schemaRoot }),
-              ...(!opts.strictResponseSchemaValidation && { strictResponseSchemaValidation: false }),
-              ...(opts.noSandbox && { sandbox: false, disable_sandbox: true }),
-              ...(opts.assertsSeededState && { assertsSeededState: true }),
-              ...(opts.mediaBuyLifecycleCompatibility && {
-                mediaBuyLifecycleCompatibility: opts.mediaBuyLifecycleCompatibility,
-              }),
-              ...(opts.loadedTestKit !== undefined && { test_kit: opts.loadedTestKit }),
-            },
-          }
-        : {}),
+      runStoryboardOptions: {
+        ...sandboxRunOptions(opts),
+        ...(opts.complianceVersion && !opts.complianceDir && { adcpVersion: opts.complianceVersion }),
+        ...(opts.schemaRoot && { schemaRoot: opts.schemaRoot }),
+        ...(!opts.strictResponseSchemaValidation && { strictResponseSchemaValidation: false }),
+        ...(opts.assertsSeededState && { assertsSeededState: true }),
+        ...(opts.mediaBuyLifecycleCompatibility && {
+          mediaBuyLifecycleCompatibility: opts.mediaBuyLifecycleCompatibility,
+        }),
+        ...(opts.loadedTestKit !== undefined && { test_kit: opts.loadedTestKit }),
+      },
       onStoryboardComplete:
         jsonOutput || format === 'junit'
           ? undefined
@@ -4204,7 +4201,7 @@ async function handleMultiInstanceStoryboardRun(args, opts, urls) {
     ...(runAdcpVersion && { adcpVersion: runAdcpVersion }),
     ...(runSchemaRoot && { schemaRoot: runSchemaRoot }),
     ...(!opts.strictResponseSchemaValidation && { strictResponseSchemaValidation: false }),
-    ...(opts.noSandbox && { sandbox: false, disable_sandbox: true }),
+    ...sandboxRunOptions(opts),
     ...(opts.assertsSeededState && { assertsSeededState: true }),
     ...(opts.mediaBuyLifecycleCompatibility && {
       mediaBuyLifecycleCompatibility: opts.mediaBuyLifecycleCompatibility,
@@ -4488,7 +4485,7 @@ async function handleAgentsRoutedStoryboardRun(args, opts, routing) {
     ...(runAdcpVersion && { adcpVersion: runAdcpVersion }),
     ...(runSchemaRoot && { schemaRoot: runSchemaRoot }),
     ...(!opts.strictResponseSchemaValidation && { strictResponseSchemaValidation: false }),
-    ...(opts.noSandbox && { sandbox: false, disable_sandbox: true }),
+    ...sandboxRunOptions(opts),
     ...(opts.assertsSeededState && { assertsSeededState: true }),
     ...(opts.mediaBuyLifecycleCompatibility && {
       mediaBuyLifecycleCompatibility: opts.mediaBuyLifecycleCompatibility,
@@ -4703,7 +4700,7 @@ async function runFullAssessment(agentArg, rawArgs, parsedOpts) {
     ...(authOption && { auth: authOption }),
     ...(opts.allowHttp && { allow_http: true }),
     ...(webhookReceiverOpts ?? {}),
-    ...(opts.noSandbox && { sandbox: false, disable_sandbox: true }),
+    ...sandboxRunOptions(opts),
     ...(opts.assertsSeededState && { assertsSeededState: true }),
     ...(opts.mediaBuyLifecycleCompatibility && {
       mediaBuyLifecycleCompatibility: opts.mediaBuyLifecycleCompatibility,
@@ -4941,6 +4938,7 @@ async function handleStoryboardStepCmd(args) {
     context,
     ...(contributions && { contributions }),
     request,
+    ...sandboxRunOptions(opts),
     ...(complianceVersion && { adcpVersion: complianceVersion }),
     ...(opts.complianceDir && { complianceDir: opts.complianceDir }),
     ...(schemaRoot && { schemaRoot }),

--- a/src/lib/signing/agent-context.ts
+++ b/src/lib/signing/agent-context.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'node:crypto';
+import { createHash, hkdfSync, randomBytes } from 'node:crypto';
 import { globalAsyncLocalStorage } from '../utils/global-async-local-storage';
 import type { AgentConfig, AgentRequestSigningConfig } from '../types/adcp';
 import {
@@ -11,6 +11,8 @@ import type { SigningProvider } from './provider';
 import type { AdcpSignAlg } from './types';
 import { ADCP_VERSION } from '../version';
 
+const CAPABILITY_SCOPE_SALT = randomBytes(32);
+
 /**
  * Snapshot of the signing identity captured at context-build time. The
  * transport layer reads from this snapshot rather than from `provider.*`
@@ -22,6 +24,7 @@ import { ADCP_VERSION } from '../version';
 export interface AgentSigningIdentitySnapshot {
   keyid: string;
   algorithm: AdcpSignAlg;
+  adcpUse?: string;
   /** Defensively hashed disambiguator — see {@link buildAgentSigningContext}. */
   fingerprint: string;
 }
@@ -91,7 +94,12 @@ export function buildAgentSigningContext(
   const identity = snapshotIdentity(signing);
   const cacheFingerprint = deriveCacheFingerprint(identity);
   const adcpVersion = options.adcpVersion ?? ADCP_VERSION;
-  const capabilityCacheKey = buildCapabilityCacheKey(agent.agent_uri, agent.auth_token, cacheFingerprint, adcpVersion);
+  const capabilityCacheKey = buildCapabilityCacheKey(
+    agent.agent_uri,
+    capabilityPrincipalScope(agent),
+    cacheFingerprint,
+    adcpVersion
+  );
   // Transport-connection cache-key suffix binds to the defensively hashed
   // identity, not just the advertised `kid`. Two tenants that misconfigure
   // the same `kid` string but hold distinct keys must not collide on a
@@ -116,6 +124,47 @@ export function buildAgentSigningContext(
 }
 
 /**
+ * Bind capability advertisements to the effective authenticated/routed
+ * principal. Basic and routing credentials live in headers, while OAuth
+ * credentials live outside `auth_token`; hashing the complete scope prevents
+ * one principal from reusing another principal's signing policy.
+ */
+function capabilityPrincipalScope(agent: AgentConfig): string | undefined {
+  const credentials = agent.oauth_client_credentials;
+  const headers = agent.headers
+    ? Object.fromEntries(
+        Object.entries(agent.headers)
+          .map(([name, value]) => [name.toLowerCase(), value] as const)
+          .sort(([a], [b]) => a.localeCompare(b))
+      )
+    : undefined;
+  const scope = {
+    protocol: agent.protocol,
+    authToken: agent.auth_token,
+    oauthAccessToken: agent.oauth_tokens?.access_token,
+    oauthClientId: agent.oauth_client?.client_id,
+    oauthResource: agent.oauth_resource,
+    oauthClientCredentials: credentials
+      ? {
+          tokenEndpoint: credentials.token_endpoint,
+          clientId: credentials.client_id,
+          scope: credentials.scope,
+          resource: credentials.resource,
+          audience: credentials.audience,
+        }
+      : undefined,
+    headers,
+  };
+  return capabilityScopeDisambiguator(JSON.stringify(scope));
+}
+
+function capabilityScopeDisambiguator(value: string): string {
+  return Buffer.from(hkdfSync('sha256', value, CAPABILITY_SCOPE_SALT, 'adcp-signing-capability-cache', 32)).toString(
+    'hex'
+  );
+}
+
+/**
  * Snapshot the signing identity at context-build time. For provider configs,
  * reads `keyid` / `algorithm` / `fingerprint` once and freezes them. For
  * inline configs, derives a fingerprint from the private scalar — same
@@ -127,12 +176,14 @@ function snapshotIdentity(signing: AgentRequestSigningConfig): AgentSigningIdent
     return {
       keyid: provider.keyid,
       algorithm: provider.algorithm,
+      ...(provider.adcpUse !== undefined && { adcpUse: provider.adcpUse }),
       fingerprint: provider.fingerprint,
     };
   }
   return {
     keyid: signing.kid,
     algorithm: signing.alg,
+    ...(typeof signing.private_key.adcp_use === 'string' && { adcpUse: signing.private_key.adcp_use }),
     fingerprint: inlineFingerprint(signing.kid, signing.private_key.d),
   };
 }
@@ -155,6 +206,8 @@ function deriveCacheFingerprint(identity: AgentSigningIdentitySnapshot): string 
     .update(identity.algorithm)
     .update('\0')
     .update(identity.keyid)
+    .update('\0')
+    .update(identity.adcpUse ?? '')
     .update('\0')
     .update(identity.fingerprint)
     .digest('hex')

--- a/src/lib/signing/agent-fetch.ts
+++ b/src/lib/signing/agent-fetch.ts
@@ -146,8 +146,7 @@ function carriesWebhookAuthentication(body: unknown): boolean {
  *      `sign_supported: true` (defaults off).
  *
  * Returns false when the capability is unknown (cold cache) except for ops
- * in `always_sign`, so the priming `get_adcp_capabilities` call itself is
- * never signed.
+ * in `always_sign`.
  */
 export function shouldSignOperation(
   operation: string | undefined,
@@ -268,10 +267,12 @@ export function buildAgentSigningFetch(options: BuildAgentSigningFetchOptions): 
 function freezeProviderIdentity(provider: AgentRequestSigningConfigProvider['provider']) {
   const keyid = provider.keyid;
   const algorithm = provider.algorithm;
+  const adcpUse = provider.adcpUse;
   const fingerprint = provider.fingerprint;
   return {
     keyid,
     algorithm,
+    adcpUse,
     fingerprint,
     sign: (payload: Uint8Array) => provider.sign(payload),
   };

--- a/src/lib/testing/client.ts
+++ b/src/lib/testing/client.ts
@@ -23,18 +23,28 @@ import { classifyProbeUrl } from '../utils/probe-policy';
 import { SsrfRefusedError } from '../net/ssrf-fetch';
 import { ADCP_VERSION } from '../version';
 import type { VersionEnvelopeMode } from '../protocols';
+import type { AgentRequestSigningConfig } from '../types/adcp';
+import { createHmac, hkdfSync, randomBytes } from 'node:crypto';
 import { validateIncomingResponse } from '../validation/client-hooks';
 import { extractVersionUnsupportedDetails } from '../utils/error-extraction';
+import { buildAgentSigningContext } from '../signing/client';
+import type { VerifierCapability } from '../signing/types';
 
 const TEST_CLIENT_VERSION_OPTIONS = Symbol('adcp.testClientVersionOptions');
+const TEST_CLIENT_SCOPE_SALT = randomBytes(32);
 
 interface TestClientVersionOptions {
+  agentUrl: string;
+  protocol: 'mcp' | 'a2a';
   adcpVersion: string;
   wireAdcpVersion?: string;
   versionEnvelope: VersionEnvelopeMode;
   strictResponseSchemaValidation: boolean;
   authMode?: string;
+  requestScopeMode?: string;
+  requestSigningMode?: string;
   fetchFn?: typeof fetch;
+  allowPrivateIp?: boolean;
   maxResponseBytes?: number;
   requestTimeoutMs?: number;
 }
@@ -155,6 +165,7 @@ export function createTestClient(agentUrl: string, protocol: 'mcp' | 'a2a' = 'mc
     oauth_tokens?: import('../types/adcp').AgentOAuthTokens;
     oauth_client?: import('../types/adcp').AgentOAuthClient;
     oauth_client_credentials?: import('../types/adcp').AgentOAuthClientCredentials;
+    request_signing?: AgentRequestSigningConfig;
     headers?: Record<string, string>;
   } = {
     id: 'test',
@@ -193,6 +204,10 @@ export function createTestClient(agentUrl: string, protocol: 'mcp' | 'a2a' = 'mc
     }
   }
 
+  if (options.functional_request_signing) {
+    agentConfig.request_signing = options.functional_request_signing;
+  }
+
   const multiClient = new ADCPMultiAgentClient([agentConfig], {
     headers,
     validation: {
@@ -208,14 +223,21 @@ export function createTestClient(agentUrl: string, protocol: 'mcp' | 'a2a' = 'mc
 
   const client = multiClient.agent('test');
   const authMode = authReuseMode(options);
+  const requestScopeMode = requestScopeReuseMode(options);
+  const requestSigningMode = requestSigningReuseMode(options.functional_request_signing);
   Object.defineProperty(client, TEST_CLIENT_VERSION_OPTIONS, {
     value: {
+      agentUrl,
+      protocol,
       adcpVersion: multiClient.getAdcpVersion(),
       ...(options.wireAdcpVersion !== undefined && { wireAdcpVersion: options.wireAdcpVersion }),
       versionEnvelope: options.versionEnvelope ?? 'auto',
       strictResponseSchemaValidation: options.strictResponseSchemaValidation !== false,
       ...(authMode !== undefined && { authMode }),
+      ...(requestScopeMode !== undefined && { requestScopeMode }),
+      ...(requestSigningMode !== undefined && { requestSigningMode }),
       ...(options.transport?.trustedFetchFn && { fetchFn: options.transport.trustedFetchFn }),
+      ...(options.transport?.allowPrivateIp !== undefined && { allowPrivateIp: options.transport.allowPrivateIp }),
       ...(options.transport?.maxResponseBytes !== undefined && {
         maxResponseBytes: options.transport.maxResponseBytes,
       }),
@@ -245,7 +267,7 @@ export function getOrCreateClient(agentUrl: string, options: TestOptions): TestC
 
 export function getOrCreateClientResolution(agentUrl: string, options: TestOptions): TestClientResolution {
   const shared = options._client as TestClient | undefined;
-  if (shared && isExecutableTestClient(shared) && testClientMatchesVersionOptions(shared, options)) {
+  if (shared && isExecutableTestClient(shared) && testClientMatchesVersionOptions(shared, agentUrl, options)) {
     return { client: shared, reusedShared: true };
   }
   return { client: createTestClient(agentUrl, options.protocol || 'mcp', options), reusedShared: false };
@@ -258,14 +280,17 @@ function isExecutableTestClient(client: unknown): client is TestClient {
   return Object.entries(candidate).some(([key, value]) => key !== 'getAgentInfo' && typeof value === 'function');
 }
 
-function testClientMatchesVersionOptions(client: TestClient, options: TestOptions): boolean {
+function testClientMatchesVersionOptions(client: TestClient, agentUrl: string, options: TestOptions): boolean {
   const effectiveOptions = withTestKitAuthDefaults(options);
   const meta = (client as unknown as { [TEST_CLIENT_VERSION_OPTIONS]?: TestClientVersionOptions })[
     TEST_CLIENT_VERSION_OPTIONS
   ];
   const expectedAuthMode = authReuseMode(effectiveOptions);
+  const expectedRequestScopeMode = requestScopeReuseMode(effectiveOptions);
+  const expectedRequestSigningMode = requestSigningReuseMode(effectiveOptions.functional_request_signing);
   if (!meta) {
     return (
+      expectedRequestSigningMode === undefined &&
       effectiveOptions.adcpVersion === undefined &&
       effectiveOptions.versionEnvelope === undefined &&
       effectiveOptions.transport === undefined
@@ -275,12 +300,17 @@ function testClientMatchesVersionOptions(client: TestClient, options: TestOption
   const expectedWireAdcpVersion = effectiveOptions.wireAdcpVersion;
   const expectedVersionEnvelope = effectiveOptions.versionEnvelope ?? 'auto';
   return (
+    meta.agentUrl === agentUrl &&
+    meta.protocol === (effectiveOptions.protocol ?? 'mcp') &&
     meta.adcpVersion === expectedAdcpVersion &&
     meta.wireAdcpVersion === expectedWireAdcpVersion &&
     meta.versionEnvelope === expectedVersionEnvelope &&
     meta.strictResponseSchemaValidation === (effectiveOptions.strictResponseSchemaValidation !== false) &&
     meta.authMode === expectedAuthMode &&
+    meta.requestScopeMode === expectedRequestScopeMode &&
+    meta.requestSigningMode === expectedRequestSigningMode &&
     meta.fetchFn === effectiveOptions.transport?.trustedFetchFn &&
+    meta.allowPrivateIp === effectiveOptions.transport?.allowPrivateIp &&
     meta.maxResponseBytes === effectiveOptions.transport?.maxResponseBytes &&
     meta.requestTimeoutMs === effectiveOptions.transport?.requestTimeoutMs
   );
@@ -323,6 +353,56 @@ function authReuseMode(options: TestOptions): string | undefined {
   return options.auth?.type;
 }
 
+function requestScopeReuseMode(options: TestOptions): string | undefined {
+  const headers = options.headers
+    ? Object.fromEntries(
+        Object.entries(options.headers)
+          .map(([name, value]) => [name.toLowerCase(), value] as const)
+          .sort(([a], [b]) => a.localeCompare(b))
+      )
+    : undefined;
+  if (!options.auth && !headers && !options.test_session_id && !options.userAgent) return undefined;
+  return testClientScopeDisambiguator(
+    JSON.stringify({
+      auth: options.auth,
+      headers,
+      testSessionId: options.test_session_id,
+      userAgent: options.userAgent,
+    })
+  );
+}
+
+function testClientScopeDisambiguator(value: string): string {
+  return Buffer.from(hkdfSync('sha256', value, TEST_CLIENT_SCOPE_SALT, 'adcp-test-client-cache', 8)).toString('hex');
+}
+
+function requestSigningReuseMode(config: AgentRequestSigningConfig | undefined): string | undefined {
+  if (!config) return undefined;
+  const kind = config.kind === 'provider' ? 'provider' : 'inline';
+  const identity =
+    config.kind === 'provider'
+      ? {
+          algorithm: config.provider.algorithm,
+          keyid: config.provider.keyid,
+          adcpUse: config.provider.adcpUse,
+          fingerprint: config.provider.fingerprint,
+        }
+      : { algorithm: config.alg, keyid: config.kid, privateKey: config.private_key };
+  const fingerprint = createHmac('sha256', '')
+    .update(
+      JSON.stringify({
+        identity,
+        agentUrl: config.agent_url,
+        jwksUri: config.jwks_uri,
+        signSupported: config.sign_supported === true,
+        alwaysSign: config.always_sign ?? [],
+      })
+    )
+    .digest('hex')
+    .slice(0, 16);
+  return `${kind}:${fingerprint}`;
+}
+
 /**
  * Return a pre-discovered profile from options (set by comply()) or discover fresh.
  */
@@ -331,12 +411,44 @@ export async function getOrDiscoverProfile(
   options: TestOptions
 ): Promise<{ profile: AgentProfile; step: TestStepResult }> {
   if (options._profile) {
+    seedTestClientSigningCapability(client, options._profile, options.adcpVersion);
     return {
       profile: options._profile,
       step: { step: 'Discover agent capabilities', passed: true, duration_ms: 0 },
     };
   }
   return discoverAgentProfile(client, options.signal, options.adcpVersion);
+}
+
+/**
+ * Reuse the already-observed capability advertisement for signing decisions.
+ * This avoids a second discovery call whose failure could otherwise downgrade
+ * a functional compliance dispatch to unsigned.
+ */
+export function seedTestClientSigningCapability(client: TestClient, profile: AgentProfile, adcpVersion?: string): void {
+  const raw = profile.raw_capabilities;
+  if (!raw || typeof raw !== 'object') return;
+  const clientAccess = client as unknown as {
+    getAgent?: TestClient['getAgent'];
+    getAdcpVersion?: TestClient['getAdcpVersion'];
+  };
+  if (typeof clientAccess.getAgent !== 'function') return;
+  const agent = clientAccess.getAgent.call(client);
+  const meta = (client as unknown as { [TEST_CLIENT_VERSION_OPTIONS]?: TestClientVersionOptions })[
+    TEST_CLIENT_VERSION_OPTIONS
+  ];
+  const effectiveVersion =
+    meta?.wireAdcpVersion ??
+    meta?.adcpVersion ??
+    (typeof clientAccess.getAdcpVersion === 'function' ? clientAccess.getAdcpVersion.call(client) : undefined) ??
+    adcpVersion;
+  const signingContext = buildAgentSigningContext(agent, { adcpVersion: effectiveVersion });
+  if (!signingContext) return;
+  signingContext.cache.set(signingContext.capabilityCacheKey, {
+    requestSigning: (raw as { request_signing?: VerifierCapability }).request_signing,
+    adcpVersion: profile.adcp_major_versions?.[0],
+    fetchedAt: Math.floor(Date.now() / 1000),
+  });
 }
 
 /**
@@ -561,6 +673,7 @@ export async function discoverAgentProfile(
     }
   }
 
+  seedTestClientSigningCapability(client, profile, schemaAdcpVersion);
   return { profile, step };
 }
 

--- a/src/lib/testing/compliance/comply.ts
+++ b/src/lib/testing/compliance/comply.ts
@@ -8,7 +8,7 @@
  * Resolution priority: explicit storyboards > capability-driven.
  */
 
-import { createTestClient, discoverAgentProfile } from '../client';
+import { createTestClient, discoverAgentProfile, seedTestClientSigningCapability } from '../client';
 import type { TestOptions, TestResult, AgentProfile, TestStepResult } from '../types';
 import { collectDetachedAssertionFailures, mapStoryboardResultsToTrackResult, TRACK_LABELS } from './storyboard-tracks';
 import { applyAdcpVersionRunOptions, runStoryboard } from '../storyboard/runner';
@@ -64,6 +64,7 @@ import { redactOAuthUrlForOutput, redactOAuthUrlsInText } from '../storyboard/oa
 import { LIBRARY_VERSION } from '../../version';
 import { validationFailsStep } from '../storyboard/validations';
 import { isLikelyPrivateUrl } from '../../net/address-guards';
+import { applyFunctionalRequestSigning } from '../storyboard/request-signing/functional-dispatch';
 
 /**
  * All compliance tracks in display order.
@@ -1218,6 +1219,10 @@ async function complyImpl(agentUrl: string, options: ComplyOptions): Promise<Com
       sandbox: testOptions.sandbox !== false,
       test_session_id: testOptions.test_session_id || `comply-${Date.now()}`,
     });
+    effectiveOptions = applyFunctionalRequestSigning(effectiveOptions, {
+      ...(complianceDir !== undefined && { complianceDir }),
+      version: complianceIndex.adcp_version,
+    });
 
     // Check for abort before starting
     signal?.throwIfAborted();
@@ -1269,6 +1274,11 @@ async function complyImpl(agentUrl: string, options: ComplyOptions): Promise<Com
       discoveryOptions === effectiveOptions
         ? discoveryClient
         : createTestClient(agentUrl, effectiveOptions.protocol ?? 'mcp', effectiveOptions);
+    // Negotiation may replace the discovery client with one configured for a
+    // different wire version. Seed that selected client from the capability
+    // response we already trust so its first functional dispatch cannot be
+    // downgraded by a redundant, transiently failing discovery probe.
+    seedTestClientSigningCapability(client, profile, complianceIndex.adcp_version);
     effectiveOptions._client = client;
     effectiveOptions._profile = profile;
 

--- a/src/lib/testing/storyboard/request-signing/functional-dispatch.ts
+++ b/src/lib/testing/storyboard/request-signing/functional-dispatch.ts
@@ -1,0 +1,107 @@
+import type { AgentRequestSigningConfig, AdcpPrivateJsonWebKey } from '../../../types/adcp';
+import type { TestOptions } from '../../types';
+import { loadRequestSigningKeys, findKey } from './vector-loader';
+import { loadSignedRequestsRunnerContract } from './test-kit';
+
+export interface FunctionalDispatchLoadOptions {
+  complianceDir?: string;
+  version?: string;
+}
+
+/**
+ * Attach the shared compliance signer for ordinary functional dispatch.
+ *
+ * The bundled private scalar is deliberately public test material, so it is
+ * auto-loaded only for an explicit sandbox run. `disable_sandbox` always wins.
+ * A caller-provided signer is already operator-authorized. Its identity and
+ * provider are preserved; in an in-scope sandbox run, the contract's
+ * supported-operation policy is applied without loading the bundled key.
+ */
+export function applyFunctionalRequestSigning<T extends TestOptions>(
+  options: T,
+  loadOptions: FunctionalDispatchLoadOptions = {}
+): T {
+  if (options.sandbox !== true || options.disable_sandbox === true) return options;
+
+  const contract = loadSignedRequestsRunnerContract(loadOptions);
+  const dispatch = contract?.functional_dispatch;
+  // Older compliance bundles predate functional signing. Keep beta.8's
+  // post-dispatch not_applicable compatibility behavior for those bundles.
+  if (!dispatch) return options;
+  if (contract.endpoint_scope !== 'sandbox') {
+    throw new Error(
+      `functional request signing refused: signed-requests runner endpoint_scope must be "sandbox", got "${contract.endpoint_scope}"`
+    );
+  }
+  if (!dispatch.operation_selection.sign_required_for) {
+    throw new Error('functional request signing contract must enable sign_required_for');
+  }
+  if (!dispatch.operation_selection.sign_supported_for) {
+    throw new Error('functional request signing contract must enable sign_supported_for');
+  }
+  if (
+    dispatch.bootstrap_operations_unsigned.length !== 1 ||
+    dispatch.bootstrap_operations_unsigned[0] !== 'get_adcp_capabilities'
+  ) {
+    throw new Error('functional request signing supports only unsigned bootstrap discovery via get_adcp_capabilities');
+  }
+  if (!dispatch.preserve_transport_auth || !dispatch.fresh_signature_per_dispatch) {
+    throw new Error(
+      'functional request signing contract must preserve transport auth and mint a fresh signature per dispatch'
+    );
+  }
+
+  const suppliedSigning = options.functional_request_signing;
+  if (suppliedSigning) {
+    if (suppliedSigning.always_sign?.includes('get_adcp_capabilities')) {
+      throw new Error('functional request signing requires unsigned bootstrap discovery via get_adcp_capabilities');
+    }
+    if (suppliedSigning.sign_supported === true) return options;
+    return {
+      ...options,
+      functional_request_signing: { ...suppliedSigning, sign_supported: true },
+    };
+  }
+
+  const declaredKey = contract.runner_signing_keys.find(entry => entry.keyid === dispatch.signing_keyid);
+  if (!declaredKey) {
+    throw new Error(
+      `functional request signing key "${dispatch.signing_keyid}" is not declared in runner_signing_keys`
+    );
+  }
+  const key = findKey(loadRequestSigningKeys(loadOptions), dispatch.signing_keyid);
+  const alg = key.crv === 'Ed25519' ? 'ed25519' : key.crv === 'P-256' ? 'ecdsa-p256-sha256' : undefined;
+  if (!alg || alg !== declaredKey.alg) {
+    throw new Error(
+      `functional request signing key "${key.kid}" does not match declared algorithm "${declaredKey.alg}"`
+    );
+  }
+  if (key.adcp_use !== 'request-signing') {
+    throw new Error(`functional request signing key "${key.kid}" must have adcp_use="request-signing"`);
+  }
+  if (contract.stateful_vector_contract.revocation.pre_revoked_keyid === key.kid) {
+    throw new Error(`functional request signing key "${key.kid}" is the contract's pre-revoked key`);
+  }
+
+  const privateKey: AdcpPrivateJsonWebKey = {
+    kid: key.kid,
+    kty: key.kty,
+    ...(key.crv && { crv: key.crv }),
+    ...(key.alg && { alg: key.alg }),
+    ...(key.use && { use: key.use }),
+    key_ops: ['sign'],
+    ...(key.adcp_use && { adcp_use: key.adcp_use }),
+    ...(key.x && { x: key.x }),
+    ...(key.y && { y: key.y }),
+    d: key.private_d,
+  };
+  const signing: AgentRequestSigningConfig = {
+    kind: 'inline',
+    kid: key.kid,
+    alg,
+    private_key: privateKey,
+    agent_url: dispatch.signer_agent_url,
+    sign_supported: dispatch.operation_selection.sign_supported_for,
+  };
+  return { ...options, functional_request_signing: signing };
+}

--- a/src/lib/testing/storyboard/request-signing/test-kit.ts
+++ b/src/lib/testing/storyboard/request-signing/test-kit.ts
@@ -27,11 +27,27 @@ export interface RateAbuseContract {
   window_seconds: number;
 }
 
+export interface FunctionalDispatchContract {
+  signing_keyid: string;
+  signer_agent_url: string;
+  operation_selection: {
+    capability_path: 'request_signing';
+    sign_required_for: boolean;
+    sign_supported_for: boolean;
+  };
+  content_digest_policy_source: 'request_signing.covers_content_digest';
+  preserve_transport_auth: boolean;
+  fresh_signature_per_dispatch: boolean;
+  bootstrap_operations_unsigned: string[];
+  unavailable_behavior: 'not_applicable';
+}
+
 export interface SignedRequestsRunnerContract {
   id: string;
   endpoint_scope: 'sandbox' | string;
   harness_mode: 'black_box' | 'white_box';
   runner_signing_keys: RunnerSigningKey[];
+  functional_dispatch?: FunctionalDispatchContract;
   stateful_vector_contract: {
     replay_window: ReplayWindowContract;
     revocation: RevocationContract;
@@ -56,12 +72,61 @@ export function loadSignedRequestsRunnerContract(
   const path = join(cacheDir, 'test-kits', 'signed-requests-runner.yaml');
   if (!existsSync(path)) return undefined;
   const raw = parse(readFileSync(path, 'utf-8')) as Record<string, unknown>;
+  const functionalDispatch = parseFunctionalDispatch(raw.functional_dispatch);
   return {
     id: assertString(raw.id, 'id'),
     endpoint_scope: assertString(raw.endpoint_scope, 'endpoint_scope'),
     harness_mode: parseHarnessMode(raw.harness_mode),
     runner_signing_keys: parseSigningKeys(raw.runner_signing_keys),
+    ...(functionalDispatch && { functional_dispatch: functionalDispatch }),
     stateful_vector_contract: parseStatefulContracts(raw.stateful_vector_contract),
+  };
+}
+
+function parseFunctionalDispatch(raw: unknown): FunctionalDispatchContract | undefined {
+  if (raw === undefined) return undefined;
+  const r = asObject(raw, 'functional_dispatch');
+  const selection = asObject(r.operation_selection, 'functional_dispatch.operation_selection');
+  const capabilityPath = assertString(
+    selection.capability_path,
+    'functional_dispatch.operation_selection.capability_path'
+  );
+  if (capabilityPath !== 'request_signing') {
+    throw new Error('functional_dispatch.operation_selection.capability_path must be "request_signing"');
+  }
+  const digestSource = assertString(r.content_digest_policy_source, 'functional_dispatch.content_digest_policy_source');
+  if (digestSource !== 'request_signing.covers_content_digest') {
+    throw new Error('functional_dispatch.content_digest_policy_source must be "request_signing.covers_content_digest"');
+  }
+  const unavailable = assertString(r.unavailable_behavior, 'functional_dispatch.unavailable_behavior');
+  if (unavailable !== 'not_applicable') {
+    throw new Error('functional_dispatch.unavailable_behavior must be "not_applicable"');
+  }
+  return {
+    signing_keyid: assertString(r.signing_keyid, 'functional_dispatch.signing_keyid'),
+    signer_agent_url: assertString(r.signer_agent_url, 'functional_dispatch.signer_agent_url'),
+    operation_selection: {
+      capability_path: 'request_signing',
+      sign_required_for: assertBoolean(
+        selection.sign_required_for,
+        'functional_dispatch.operation_selection.sign_required_for'
+      ),
+      sign_supported_for: assertBoolean(
+        selection.sign_supported_for,
+        'functional_dispatch.operation_selection.sign_supported_for'
+      ),
+    },
+    content_digest_policy_source: 'request_signing.covers_content_digest',
+    preserve_transport_auth: assertBoolean(r.preserve_transport_auth, 'functional_dispatch.preserve_transport_auth'),
+    fresh_signature_per_dispatch: assertBoolean(
+      r.fresh_signature_per_dispatch,
+      'functional_dispatch.fresh_signature_per_dispatch'
+    ),
+    bootstrap_operations_unsigned: assertStringArray(
+      r.bootstrap_operations_unsigned,
+      'functional_dispatch.bootstrap_operations_unsigned'
+    ),
+    unavailable_behavior: 'not_applicable',
   };
 }
 
@@ -147,5 +212,17 @@ function assertString(v: unknown, where: string): string {
 
 function assertNumber(v: unknown, where: string): number {
   if (typeof v !== 'number') throw new Error(`${where} must be number`);
+  return v;
+}
+
+function assertBoolean(v: unknown, where: string): boolean {
+  if (typeof v !== 'boolean') throw new Error(`${where} must be boolean`);
+  return v;
+}
+
+function assertStringArray(v: unknown, where: string): string[] {
+  if (!Array.isArray(v) || v.some(item => typeof item !== 'string')) {
+    throw new Error(`${where} must be string[]`);
+  }
   return v;
 }

--- a/src/lib/testing/storyboard/request-signing/vector-loader.ts
+++ b/src/lib/testing/storyboard/request-signing/vector-loader.ts
@@ -71,11 +71,17 @@ export function loadRequestSigningVectors(options: LoadVectorsOptions = {}): Loa
           },
         }
       : {},
-    keys: loadKeys(join(sourceDir, 'keys.json')),
+    keys: loadRequestSigningKeys(options),
     sourceDir,
   };
   VECTOR_CACHE.set(sourceDir, loaded);
   return loaded;
+}
+
+/** Load only the shared signing keyset, without requiring the grader vectors. */
+export function loadRequestSigningKeys(options: LoadVectorsOptions = {}): TestKeyset {
+  const cacheDir = getComplianceCacheDir(options);
+  return loadKeys(join(cacheDir, 'test-vectors', 'request-signing', 'keys.json'));
 }
 
 /** Test-only: clear the memoization cache so a fresh cache path is reread. */

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -18,6 +18,7 @@ import {
 } from '../../protocols';
 import { getCapturesFromError, withRawResponseCapture, type RawHttpCapture } from '../../protocols/rawResponseCapture';
 import { defaultStoryboardResponseProjection, executeStoryboardTask } from './task-map';
+import { applyFunctionalRequestSigning } from './request-signing/functional-dispatch';
 import {
   extractContextWithProvenance,
   injectContext,
@@ -1271,6 +1272,10 @@ export async function runStoryboard(
   return withMCPConnectionScope(
     async () => {
       options = applyStoryboardVersionOptions(storyboard, options);
+      options = applyFunctionalRequestSigning(options, {
+        ...(options.complianceDir && { complianceDir: options.complianceDir }),
+        ...(options.adcpVersion && { version: options.adcpVersion }),
+      });
       // adcp#6735 — a declared prerequisites.test_kit is a loading directive,
       // not decoration: resolve it into options.test_kit (caller-supplied
       // kits win) so from_test_kit / $test_kit.* references get the
@@ -4322,6 +4327,10 @@ export async function runStoryboardStep(
     async () => {
       validateStoryboardShape(storyboard);
       options = applyStoryboardVersionOptions(storyboard, options);
+      options = applyFunctionalRequestSigning(options, {
+        ...(options.complianceDir && { complianceDir: options.complianceDir }),
+        ...(options.adcpVersion && { version: options.adcpVersion }),
+      });
       // adcp#6735 — same declared-kit resolution as runStoryboard, so the
       // printed fix_command path exercises the step with its real credential.
       options = resolveDeclaredTestKit(storyboard, options);
@@ -5256,6 +5265,7 @@ async function executeStep(
     taskResult?.adcp_error?.code === 'request_signature_required' &&
     Array.isArray(requiredForSigning) &&
     requiredForSigning.includes(effectiveStep.task) &&
+    options.functional_request_signing === undefined &&
     runState.storyboardRequiresRequestSigner !== true
   ) {
     const next = getNextStepPreview(step.id, allSteps, context, runState.runnerVars);

--- a/src/lib/testing/types.ts
+++ b/src/lib/testing/types.ts
@@ -7,6 +7,7 @@ import type { ControllerDetection } from './test-controller';
 import type { WebhookReceiver } from './storyboard/webhook-receiver';
 import type { AdcpVersion } from '../version';
 import type { TransportOptions, VersionEnvelopeMode } from '../protocols';
+import type { AgentRequestSigningConfig } from '../types/adcp';
 
 // Test scenarios that can be run
 export type TestScenario =
@@ -83,6 +84,15 @@ export interface TestOptions {
    * enforce a request-scoped network policy without replacing global fetch.
    */
   transport?: TransportOptions;
+  /**
+   * RFC 9421 identity used for ordinary functional test/storyboard calls.
+   * Distinct from `StoryboardRunOptions.request_signing`, which configures
+   * the dedicated verifier-vector grader. Compliance runners populate this
+   * automatically from `signed-requests-runner.yaml > functional_dispatch`
+   * only for sandbox runs; callers may provide their own key/provider for a
+   * different trusted environment.
+   */
+  functional_request_signing?: AgentRequestSigningConfig;
   /**
    * AdCP protocol version the test client should speak. Storyboard runners
    * set this from the compliance cache version instead of relying on the

--- a/test/lib/cli-no-sandbox.test.js
+++ b/test/lib/cli-no-sandbox.test.js
@@ -2,7 +2,8 @@
  * CLI plumbing for `adcp storyboard run --no-sandbox`.
  *
  * Asserts the flag is parsed without value, surfaces in the dry-run header,
- * threads through to options.sandbox = false, and is a no-op when omitted.
+ * threads through to options.sandbox = false, while an explicit --sandbox
+ * selects sandbox routing without changing the historical omitted default.
  * Uses --dry-run + --url so we never make network calls.
  */
 
@@ -10,6 +11,7 @@ const { test } = require('node:test');
 const assert = require('node:assert');
 const { spawnSync } = require('node:child_process');
 const path = require('node:path');
+const { sandboxRunOptions } = require('../../bin/adcp-storyboard-sandbox.js');
 
 const CLI = path.resolve(__dirname, '../../bin/adcp.js');
 
@@ -73,7 +75,31 @@ test('storyboard run --help mentions --no-sandbox', () => {
   assert.strictEqual(result.status, 0, `expected exit 0, got ${result.status}. stderr: ${result.stderr}`);
   const help = `${result.stdout}\n${result.stderr}`;
   assert.match(help, /--no-sandbox/, 'help text should advertise --no-sandbox');
+  assert.match(help, /--sandbox/, 'help text should advertise explicit sandbox mode');
   assert.match(help, /account\.sandbox=false/, 'help should name the wire field affected');
+});
+
+test('--sandbox and --no-sandbox are mutually exclusive', () => {
+  const result = runCli(['storyboard', 'run', 'test-mcp', '--sandbox', '--no-sandbox', '--dry-run']);
+  assert.strictEqual(result.status, 2);
+  assert.match(result.stderr, /mutually exclusive/);
+});
+
+test('shared runner routing maps explicit sandbox flags without changing the omitted default', () => {
+  assert.deepStrictEqual(sandboxRunOptions({}), {});
+  assert.deepStrictEqual(sandboxRunOptions({ sandbox: true }), { sandbox: true });
+  assert.deepStrictEqual(sandboxRunOptions({ noSandbox: true }), {
+    sandbox: false,
+    disable_sandbox: true,
+  });
+  assert.throws(() => sandboxRunOptions({ sandbox: true, noSandbox: true }), /mutually exclusive/);
+
+  const source = require('node:fs').readFileSync(CLI, 'utf8');
+  assert.strictEqual(
+    source.match(/\.\.\.sandboxRunOptions\(opts\)/g)?.length,
+    6,
+    'every storyboard run and step option builder must use the shared sandbox routing helper'
+  );
 });
 
 test('resolveAccount honors options.sandbox=false (final wire-shape contract)', async () => {

--- a/test/lib/functional-request-signing.test.js
+++ b/test/lib/functional-request-signing.test.js
@@ -1,0 +1,597 @@
+const { afterEach, describe, test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { generateKeyPairSync } = require('node:crypto');
+const http = require('node:http');
+const { McpServer } = require('@modelcontextprotocol/sdk/server/mcp.js');
+const { StreamableHTTPServerTransport } = require('@modelcontextprotocol/sdk/server/streamableHttp.js');
+
+const {
+  createTestClient,
+  getOrCreateClientResolution,
+  getOrDiscoverProfile,
+  seedTestClientSigningCapability,
+} = require('../../dist/lib/testing/client.js');
+const {
+  applyFunctionalRequestSigning,
+} = require('../../dist/lib/testing/storyboard/request-signing/functional-dispatch.js');
+const { buildAgentSigningContext } = require('../../dist/lib/signing/client.js');
+const { ProtocolClient } = require('../../dist/lib/protocols/index.js');
+const { closeMCPConnections } = require('../../dist/lib/protocols/mcp.js');
+const { defaultCapabilityCache } = require('../../dist/lib/signing/client.js');
+const {
+  verifyRequestSignature,
+  StaticJwksResolver,
+  InMemoryReplayStore,
+  InMemoryRevocationStore,
+} = require('../../dist/lib/signing/server.js');
+
+const generatedKeyPair = generateKeyPairSync('ed25519');
+const generatedPublicJwk = generatedKeyPair.publicKey.export({ format: 'jwk' });
+const generatedPrivateJwk = generatedKeyPair.privateKey.export({ format: 'jwk' });
+
+const tempDirs = new Set();
+
+afterEach(() => {
+  for (const dir of tempDirs) fs.rmSync(dir, { recursive: true, force: true });
+  tempDirs.clear();
+});
+
+function writeComplianceBundle({
+  functionalDispatch = true,
+  endpointScope = 'sandbox',
+  bootstrapOperations = '[get_adcp_capabilities]',
+  signSupportedFor = true,
+} = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'adcp-functional-signing-'));
+  tempDirs.add(dir);
+  fs.mkdirSync(path.join(dir, 'test-kits'), { recursive: true });
+  fs.mkdirSync(path.join(dir, 'test-vectors', 'request-signing'), { recursive: true });
+  const dispatch = functionalDispatch
+    ? `
+functional_dispatch:
+  signing_keyid: test-ed25519-2026
+  signer_agent_url: https://compliance-runner.example
+  operation_selection:
+    capability_path: request_signing
+    sign_required_for: true
+    sign_supported_for: ${signSupportedFor}
+  content_digest_policy_source: request_signing.covers_content_digest
+  preserve_transport_auth: true
+  fresh_signature_per_dispatch: true
+  bootstrap_operations_unsigned: ${bootstrapOperations}
+  unavailable_behavior: not_applicable
+`
+    : '';
+  fs.writeFileSync(
+    path.join(dir, 'test-kits', 'signed-requests-runner.yaml'),
+    `id: signed_requests_runner
+endpoint_scope: ${endpointScope}
+harness_mode: black_box
+runner_signing_keys:
+  - keyid: test-ed25519-2026
+    alg: ed25519
+${dispatch}
+stateful_vector_contract:
+  replay_window:
+    vector_id: replay
+    black_box_behavior: repeat_request
+    max_interval_seconds: 5
+    min_replay_ttl_seconds: 10
+  revocation:
+    vector_id: revoked
+    pre_revoked_keyid: test-revoked-2026
+  rate_abuse:
+    vector_id: abuse
+    grading_target_per_keyid_cap_requests: 100
+    production_min_per_keyid_cap_requests: 1000000
+    window_seconds: 60
+`
+  );
+  fs.writeFileSync(
+    path.join(dir, 'test-vectors', 'request-signing', 'keys.json'),
+    JSON.stringify({
+      keys: [
+        {
+          kid: 'test-ed25519-2026',
+          kty: 'OKP',
+          crv: 'Ed25519',
+          alg: 'EdDSA',
+          use: 'sig',
+          key_ops: ['verify'],
+          adcp_use: 'request-signing',
+          x: generatedPublicJwk.x,
+          _private_d_for_test_only: generatedPrivateJwk.d,
+        },
+      ],
+    })
+  );
+  return dir;
+}
+
+function mcpResult(payload) {
+  return { content: [{ type: 'text', text: JSON.stringify(payload) }], structuredContent: payload };
+}
+
+async function startSigningCaptureSeller() {
+  const toolRequests = [];
+  const server = http.createServer(async (req, res) => {
+    const requestBodyChunks = [];
+    for await (const chunk of req) requestBodyChunks.push(chunk);
+    const requestBody = Buffer.concat(requestBodyChunks).toString('utf8');
+    const parsedBody = requestBody ? JSON.parse(requestBody) : undefined;
+    const requestHeaders = { ...req.headers };
+    const capturedRequest = tool => ({
+      tool,
+      method: req.method,
+      url: `http://${req.headers.host}${req.url}`,
+      headers: requestHeaders,
+      body: requestBody,
+    });
+    const mcp = new McpServer({ name: 'functional-signing-capture', version: '1.0.0' });
+    mcp.registerTool('get_adcp_capabilities', { inputSchema: {} }, async () => {
+      toolRequests.push(capturedRequest('get_adcp_capabilities'));
+      return mcpResult({
+        adcp: {
+          major_versions: [3],
+          supported_versions: ['3.2.0-beta.6'],
+          idempotency: { supported: true, replay_ttl_seconds: 86400 },
+        },
+        supported_protocols: ['media_buy'],
+        specialisms: ['sales-non-guaranteed'],
+        request_signing: {
+          supported: true,
+          required_for: [],
+          supported_for: ['get_products'],
+          covers_content_digest: 'required',
+        },
+      });
+    });
+    mcp.registerTool('get_products', { inputSchema: {} }, async () => {
+      toolRequests.push(capturedRequest('get_products'));
+      return mcpResult({ products: [] });
+    });
+    const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+    try {
+      await mcp.connect(transport);
+      await transport.handleRequest(req, res, parsedBody);
+    } finally {
+      await mcp.close();
+    }
+  });
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  return {
+    toolRequests,
+    url: `http://127.0.0.1:${server.address().port}/mcp`,
+    close: async () => {
+      server.closeAllConnections();
+      await new Promise(resolve => server.close(resolve));
+    },
+  };
+}
+
+describe('functional request signing', () => {
+  test('loads the public compliance signer only for sandbox functional dispatch', () => {
+    const complianceDir = writeComplianceBundle();
+    const options = applyFunctionalRequestSigning(
+      { sandbox: true, auth: { type: 'bearer', token: 'preserved-token' } },
+      { complianceDir }
+    );
+
+    assert.deepStrictEqual(options.auth, { type: 'bearer', token: 'preserved-token' });
+    assert.strictEqual(options.functional_request_signing.kind, 'inline');
+    assert.strictEqual(options.functional_request_signing.kid, 'test-ed25519-2026');
+    assert.strictEqual(options.functional_request_signing.alg, 'ed25519');
+    assert.strictEqual(options.functional_request_signing.agent_url, 'https://compliance-runner.example');
+    assert.strictEqual(options.functional_request_signing.sign_supported, true);
+    assert.strictEqual(options.functional_request_signing.private_key.d, generatedPrivateJwk.d);
+
+    const client = createTestClient('https://seller.example/mcp', 'mcp', options);
+    assert.strictEqual(client.getAgent().request_signing, options.functional_request_signing);
+  });
+
+  test('signs ordinary MCP dispatches with fresh signatures while preserving transport auth', async t => {
+    const complianceDir = writeComplianceBundle();
+    const seller = await startSigningCaptureSeller();
+    t.after(async () => {
+      await closeMCPConnections();
+      defaultCapabilityCache.clear();
+      await seller.close();
+    });
+    const options = applyFunctionalRequestSigning(
+      {
+        sandbox: true,
+        auth: { type: 'bearer', token: 'preserved-transport-token' },
+        headers: { 'x-adcp-tenant': 'tenant-a' },
+      },
+      { complianceDir }
+    );
+    const client = createTestClient(seller.url, 'mcp', options);
+    const agent = client.getAgent();
+
+    await ProtocolClient.callTool(agent, 'get_products', { brief: 'first', buying_mode: 'brief' });
+    await ProtocolClient.callTool(agent, 'get_products', { brief: 'second', buying_mode: 'brief' });
+
+    const bootstrap = seller.toolRequests.filter(entry => entry.tool === 'get_adcp_capabilities');
+    const functional = seller.toolRequests.filter(entry => entry.tool === 'get_products');
+    assert.ok(bootstrap.length >= 1, 'capability bootstrap should be observed');
+    assert.ok(bootstrap.every(entry => entry.headers['signature-input'] === undefined));
+    assert.strictEqual(functional.length, 2);
+    for (const entry of functional) {
+      assert.ok(entry.headers['signature-input'], 'functional request must include Signature-Input');
+      assert.ok(entry.headers.signature, 'functional request must include Signature');
+      assert.strictEqual(entry.headers.authorization, 'Bearer preserved-transport-token');
+      assert.strictEqual(entry.headers['x-adcp-auth'], 'preserved-transport-token');
+      assert.strictEqual(entry.headers['x-adcp-tenant'], 'tenant-a');
+    }
+    const nonces = functional.map(entry => entry.headers['signature-input'].match(/;nonce="([^"]+)"/)?.[1]);
+    assert.ok(nonces.every(Boolean), 'each signature must carry a nonce');
+    assert.notStrictEqual(nonces[0], nonces[1], 'each dispatch must mint a fresh signature nonce');
+
+    const replayStore = new InMemoryReplayStore();
+    const jwks = new StaticJwksResolver([
+      {
+        kid: options.functional_request_signing.kid,
+        kty: 'OKP',
+        crv: 'Ed25519',
+        alg: 'EdDSA',
+        use: 'sig',
+        key_ops: ['verify'],
+        adcp_use: 'request-signing',
+        x: generatedPublicJwk.x,
+      },
+    ]);
+    for (const entry of functional) {
+      const verified = await verifyRequestSignature(entry, {
+        capability: {
+          supported: true,
+          required_for: [],
+          supported_for: ['get_products'],
+          covers_content_digest: 'required',
+        },
+        jwks,
+        replayStore,
+        revocationStore: new InMemoryRevocationStore(),
+        operation: 'get_products',
+        adcpVersion: '3.2.0-beta.6',
+      });
+      assert.strictEqual(verified.status, 'verified');
+      assert.strictEqual(verified.keyid, options.functional_request_signing.kid);
+    }
+  });
+
+  test('never auto-loads the public test key outside the sandbox boundary', () => {
+    const complianceDir = writeComplianceBundle();
+    const production = { sandbox: false };
+    const disabled = { sandbox: true, disable_sandbox: true };
+
+    assert.strictEqual(applyFunctionalRequestSigning(production, { complianceDir }), production);
+    assert.strictEqual(applyFunctionalRequestSigning(disabled, { complianceDir }), disabled);
+  });
+
+  test('preserves an operator-supplied signer without reading the compliance key', () => {
+    const supplied = {
+      kind: 'provider',
+      provider: {
+        keyid: 'operator-key',
+        algorithm: 'ed25519',
+        fingerprint: 'operator-controlled',
+        sign: async () => new Uint8Array(),
+      },
+    };
+    const options = { sandbox: false, functional_request_signing: supplied };
+    assert.strictEqual(applyFunctionalRequestSigning(options), options);
+    assert.strictEqual(options.functional_request_signing, supplied);
+  });
+
+  test('applies functional supported-operation policy to an operator-supplied sandbox signer', () => {
+    const complianceDir = writeComplianceBundle();
+    const supplied = {
+      kind: 'provider',
+      provider: {
+        keyid: 'operator-key',
+        algorithm: 'ed25519',
+        fingerprint: 'operator-controlled',
+        sign: async () => new Uint8Array(),
+      },
+      agent_url: 'https://operator.example',
+    };
+    const options = applyFunctionalRequestSigning(
+      { sandbox: true, functional_request_signing: supplied },
+      { complianceDir }
+    );
+
+    assert.strictEqual(options.functional_request_signing.provider, supplied.provider);
+    assert.strictEqual(options.functional_request_signing.sign_supported, true);
+  });
+
+  test('rejects an operator signer that would sign unsigned bootstrap discovery', () => {
+    const complianceDir = writeComplianceBundle();
+    assert.throws(
+      () =>
+        applyFunctionalRequestSigning(
+          {
+            sandbox: true,
+            functional_request_signing: {
+              kind: 'provider',
+              provider: {
+                keyid: 'operator-key',
+                algorithm: 'ed25519',
+                fingerprint: 'operator-controlled',
+                sign: async () => new Uint8Array(),
+              },
+              agent_url: 'https://operator.example',
+              always_sign: ['get_adcp_capabilities'],
+            },
+          },
+          { complianceDir }
+        ),
+      /requires unsigned bootstrap discovery/
+    );
+  });
+
+  test('keeps the beta.8 not-applicable compatibility path for an older bundle', () => {
+    const complianceDir = writeComplianceBundle({ functionalDispatch: false });
+    const options = { sandbox: true };
+    assert.strictEqual(applyFunctionalRequestSigning(options, { complianceDir }), options);
+  });
+
+  test('fails closed when a functional signer contract is not sandbox-scoped', () => {
+    const complianceDir = writeComplianceBundle({ endpointScope: 'production' });
+    assert.throws(
+      () => applyFunctionalRequestSigning({ sandbox: true }, { complianceDir }),
+      /endpoint_scope must be "sandbox"/
+    );
+  });
+
+  test('fails closed when the contract asks the runner to leave functional operations unsigned', () => {
+    const complianceDir = writeComplianceBundle({
+      bootstrapOperations: '[get_adcp_capabilities, create_media_buy]',
+    });
+    assert.throws(
+      () => applyFunctionalRequestSigning({ sandbox: true }, { complianceDir }),
+      /supports only unsigned bootstrap discovery/
+    );
+  });
+
+  test('fails closed when the contract disables signing supported operations', () => {
+    const complianceDir = writeComplianceBundle({ signSupportedFor: false });
+    assert.throws(
+      () => applyFunctionalRequestSigning({ sandbox: true }, { complianceDir }),
+      /must enable sign_supported_for/
+    );
+  });
+
+  test('does not reuse a shared client configured with a different signer', () => {
+    const complianceDir = writeComplianceBundle();
+    const signedOptions = applyFunctionalRequestSigning({ sandbox: true }, { complianceDir });
+    const shared = createTestClient('https://seller.example/mcp', 'mcp', signedOptions);
+
+    assert.strictEqual(
+      getOrCreateClientResolution('https://seller.example/mcp', { ...signedOptions, _client: shared }).reusedShared,
+      true
+    );
+    assert.strictEqual(
+      getOrCreateClientResolution('https://seller.example/mcp', {
+        ...signedOptions,
+        functional_request_signing: {
+          ...signedOptions.functional_request_signing,
+          private_key: { ...signedOptions.functional_request_signing.private_key, d: 'different-private-scalar' },
+        },
+        _client: shared,
+      }).reusedShared,
+      false
+    );
+    assert.strictEqual(
+      getOrCreateClientResolution('https://seller.example/mcp', {
+        ...signedOptions,
+        functional_request_signing: {
+          ...signedOptions.functional_request_signing,
+          sign_supported: false,
+        },
+        _client: shared,
+      }).reusedShared,
+      false,
+      'operation-selection overrides participate in shared-client identity'
+    );
+  });
+
+  test('does not reuse a metadata-less client when functional signing is required', () => {
+    const complianceDir = writeComplianceBundle();
+    const signedOptions = applyFunctionalRequestSigning({ sandbox: true }, { complianceDir });
+    const metadataLessClient = { executeTask: async () => ({ success: true }) };
+
+    assert.strictEqual(
+      getOrCreateClientResolution('https://seller.example/mcp', {
+        ...signedOptions,
+        _client: metadataLessClient,
+      }).reusedShared,
+      false
+    );
+  });
+
+  test('cached profiles remain usable with lightweight metadata-less client stubs', async () => {
+    const profile = {
+      name: 'Stubbed seller',
+      tools: ['get_products'],
+      raw_capabilities: { request_signing: { supported: true, required_for: ['get_products'] } },
+    };
+    const clientStub = { executeTask: async () => ({ success: true }) };
+
+    const discovered = await getOrDiscoverProfile(clientStub, { _profile: profile });
+
+    assert.strictEqual(discovered.profile, profile);
+    assert.strictEqual(discovered.step.passed, true);
+  });
+
+  test('isolates shared clients by endpoint, protocol, credentials, and routing headers', () => {
+    const complianceDir = writeComplianceBundle();
+    const signedOptions = applyFunctionalRequestSigning(
+      {
+        sandbox: true,
+        auth: { type: 'bearer', token: 'tenant-a-token' },
+        headers: { 'x-adcp-tenant': 'tenant-a' },
+      },
+      { complianceDir }
+    );
+    const shared = createTestClient('https://seller-a.example/mcp', 'mcp', signedOptions);
+    const reuse = overrides =>
+      getOrCreateClientResolution(overrides.agentUrl ?? 'https://seller-a.example/mcp', {
+        ...signedOptions,
+        ...overrides.options,
+        _client: shared,
+      }).reusedShared;
+
+    assert.strictEqual(reuse({}), true);
+    assert.strictEqual(reuse({ agentUrl: 'https://seller-b.example/mcp' }), false);
+    assert.strictEqual(reuse({ options: { protocol: 'a2a' } }), false);
+    assert.strictEqual(reuse({ options: { auth: { type: 'bearer', token: 'tenant-b-token' } } }), false);
+    assert.strictEqual(reuse({ options: { headers: { 'x-adcp-tenant': 'tenant-b' } } }), false);
+  });
+
+  test('isolates signing capability cache entries by effective principal and routing headers', () => {
+    const complianceDir = writeComplianceBundle();
+    const signing = applyFunctionalRequestSigning({ sandbox: true }, { complianceDir }).functional_request_signing;
+    const contextFor = agent =>
+      buildAgentSigningContext({
+        id: 'test',
+        name: 'Test',
+        agent_uri: 'https://seller.example/mcp',
+        protocol: 'mcp',
+        request_signing: signing,
+        ...agent,
+      });
+
+    const anonymous = contextFor({});
+    const bearerA = contextFor({ auth_token: 'bearer-a' });
+    const bearerB = contextFor({ auth_token: 'bearer-b' });
+    const basicA = contextFor({
+      headers: { Authorization: `Basic ${Buffer.from('tenant-a:pass').toString('base64')}` },
+    });
+    const basicB = contextFor({
+      headers: { Authorization: `Basic ${Buffer.from('tenant-b:pass').toString('base64')}` },
+    });
+    const oauthA = contextFor({ oauth_tokens: { access_token: 'oauth-a', token_type: 'Bearer' } });
+    const oauthB = contextFor({ oauth_tokens: { access_token: 'oauth-b', token_type: 'Bearer' } });
+    const oauthClientA = contextFor({
+      oauth_client: { client_id: 'oauth-client-a', client_secret: 'oauth-client-secret-a' },
+    });
+    const oauthClientB = contextFor({
+      oauth_client: { client_id: 'oauth-client-b', client_secret: 'oauth-client-secret-b' },
+    });
+    const oauthClientSecretRotation = contextFor({
+      oauth_client: { client_id: 'oauth-client-a', client_secret: 'oauth-client-secret-rotated' },
+    });
+    const oauthResourceA = contextFor({
+      oauth_client: { client_id: 'oauth-client-a' },
+      oauth_resource: 'https://seller.example/tenant-a',
+    });
+    const oauthResourceB = contextFor({
+      oauth_client: { client_id: 'oauth-client-a' },
+      oauth_resource: 'https://seller.example/tenant-b',
+    });
+    const clientCredentialsFor = overrides =>
+      contextFor({
+        oauth_client_credentials: {
+          token_endpoint: 'https://auth.example/token',
+          client_id: 'machine-client-a',
+          client_secret: 'machine-client-secret-a',
+          scope: 'adcp',
+          resource: 'https://seller.example/mcp',
+          audience: 'seller-a',
+          ...overrides,
+        },
+      });
+    const clientCredentialsA = clientCredentialsFor({});
+    const clientCredentialsB = clientCredentialsFor({ client_id: 'machine-client-b' });
+    const clientCredentialsEndpointB = clientCredentialsFor({ token_endpoint: 'https://auth-b.example/token' });
+    const clientCredentialsScopeB = clientCredentialsFor({ scope: 'adcp:write' });
+    const clientCredentialsResourceB = clientCredentialsFor({ resource: 'https://seller.example/tenant-b' });
+    const clientCredentialsAudienceB = clientCredentialsFor({ audience: 'seller-b' });
+    const clientCredentialsSecretRotation = clientCredentialsFor({
+      client_secret: 'machine-client-secret-rotated',
+    });
+    const clientCredentialsAuthMethod = clientCredentialsFor({ auth_method: 'body' });
+    const routedA = contextFor({ headers: { 'x-adcp-tenant': 'tenant-a' } });
+    const routedB = contextFor({ headers: { 'x-adcp-tenant': 'tenant-b' } });
+
+    assert.notStrictEqual(anonymous.capabilityCacheKey, bearerA.capabilityCacheKey);
+    assert.notStrictEqual(bearerA.capabilityCacheKey, bearerB.capabilityCacheKey);
+    assert.notStrictEqual(anonymous.capabilityCacheKey, basicA.capabilityCacheKey);
+    assert.notStrictEqual(basicA.capabilityCacheKey, basicB.capabilityCacheKey);
+    assert.notStrictEqual(oauthA.capabilityCacheKey, oauthB.capabilityCacheKey);
+    assert.notStrictEqual(oauthClientA.capabilityCacheKey, oauthClientB.capabilityCacheKey);
+    assert.strictEqual(oauthClientA.capabilityCacheKey, oauthClientSecretRotation.capabilityCacheKey);
+    assert.notStrictEqual(oauthResourceA.capabilityCacheKey, oauthResourceB.capabilityCacheKey);
+    assert.notStrictEqual(clientCredentialsA.capabilityCacheKey, clientCredentialsB.capabilityCacheKey);
+    assert.notStrictEqual(clientCredentialsA.capabilityCacheKey, clientCredentialsEndpointB.capabilityCacheKey);
+    assert.notStrictEqual(clientCredentialsA.capabilityCacheKey, clientCredentialsScopeB.capabilityCacheKey);
+    assert.notStrictEqual(clientCredentialsA.capabilityCacheKey, clientCredentialsResourceB.capabilityCacheKey);
+    assert.notStrictEqual(clientCredentialsA.capabilityCacheKey, clientCredentialsAudienceB.capabilityCacheKey);
+    assert.strictEqual(clientCredentialsA.capabilityCacheKey, clientCredentialsSecretRotation.capabilityCacheKey);
+    assert.strictEqual(clientCredentialsA.capabilityCacheKey, clientCredentialsAuthMethod.capabilityCacheKey);
+    assert.doesNotMatch(clientCredentialsA.capabilityCacheKey, /machine-client-secret-a/);
+    assert.notStrictEqual(routedA.capabilityCacheKey, routedB.capabilityCacheKey);
+  });
+
+  test('seeds discovered signing capabilities under the effective wire version', async () => {
+    const complianceDir = writeComplianceBundle();
+    const options = applyFunctionalRequestSigning(
+      {
+        sandbox: true,
+        adcpVersion: '3.2.0-beta.6',
+        wireAdcpVersion: '3.1.0',
+        _profile: {
+          name: 'Versioned seller',
+          tools: ['get_adcp_capabilities', 'get_products'],
+          raw_capabilities: {
+            request_signing: {
+              supported: true,
+              required_for: ['get_products'],
+              supported_for: [],
+            },
+          },
+        },
+      },
+      { complianceDir }
+    );
+    const client = createTestClient('https://seller.example/mcp', 'mcp', options);
+
+    await getOrDiscoverProfile(client, options);
+
+    const wireContext = buildAgentSigningContext(client.getAgent(), { adcpVersion: '3.1.0' });
+    const schemaContext = buildAgentSigningContext(client.getAgent(), { adcpVersion: '3.2.0-beta.6' });
+    assert.deepStrictEqual(wireContext.cache.get(wireContext.capabilityCacheKey)?.requestSigning, {
+      supported: true,
+      required_for: ['get_products'],
+      supported_for: [],
+    });
+    assert.strictEqual(schemaContext.cache.get(schemaContext.capabilityCacheKey), undefined);
+  });
+
+  test('selected client version wins over a discovery-schema fallback when seeding', () => {
+    const complianceDir = writeComplianceBundle();
+    const options = applyFunctionalRequestSigning({ sandbox: true, adcpVersion: '3.1.0' }, { complianceDir });
+    const client = createTestClient('https://pinned-seller.example/mcp', 'mcp', options);
+    const profile = {
+      name: 'Pinned seller',
+      tools: ['get_adcp_capabilities', 'get_products'],
+      raw_capabilities: {
+        request_signing: { supported: true, required_for: ['get_products'], supported_for: [] },
+      },
+    };
+
+    seedTestClientSigningCapability(client, profile, '3.2.0-beta.6');
+
+    const pinnedContext = buildAgentSigningContext(client.getAgent(), { adcpVersion: '3.1.0' });
+    const fallbackContext = buildAgentSigningContext(client.getAgent(), { adcpVersion: '3.2.0-beta.6' });
+    assert.deepStrictEqual(pinnedContext.cache.get(pinnedContext.capabilityCacheKey)?.requestSigning, {
+      supported: true,
+      required_for: ['get_products'],
+      supported_for: [],
+    });
+    assert.strictEqual(fallbackContext.cache.get(fallbackContext.capabilityCacheKey), undefined);
+  });
+});

--- a/test/lib/signing-defaults-and-preset.test.js
+++ b/test/lib/signing-defaults-and-preset.test.js
@@ -577,6 +577,48 @@ describe('createAgentSignedFetch preset', () => {
     assert.ok(headers.get('signature'), 'Signature header should be present');
   });
 
+  it('preserves provider purpose binding through the agent signing wrapper', async () => {
+    let signCalls = 0;
+    const { upstream } = makeCapturingUpstream();
+    const signedFetch = buildAgentSigningFetch({
+      signing: {
+        kind: 'provider',
+        provider: {
+          keyid: 'wrong-purpose-provider',
+          algorithm: 'ed25519',
+          adcpUse: 'governance-signing',
+          fingerprint: 'wrong-purpose-provider',
+          sign: async () => {
+            signCalls += 1;
+            return new Uint8Array(64);
+          },
+        },
+        agent_url: 'https://buyer.example.com',
+      },
+      getCapability: () => ({
+        requestSigning: { supported: true, required_for: ['create_media_buy'] },
+        fetchedAt: Math.floor(Date.now() / 1000),
+      }),
+      upstream,
+    });
+
+    await assert.rejects(
+      () =>
+        signedFetch('https://seller.example.com/mcp', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            jsonrpc: '2.0',
+            id: 1,
+            method: 'tools/call',
+            params: { name: 'create_media_buy', arguments: {} },
+          }),
+        }),
+      /requires 'request-signing'/
+    );
+    assert.strictEqual(signCalls, 0, 'purpose mismatch must fail before invoking the provider');
+  });
+
   it('signs when the capability cache lists the operation as required_for', async () => {
     const cache = new CapabilityCache();
     const { buildCapabilityCacheKey } = require('../../dist/lib/signing/index.js');

--- a/test/lib/storyboard-request-signature-required.test.js
+++ b/test/lib/storyboard-request-signature-required.test.js
@@ -3,6 +3,7 @@ const assert = require('node:assert/strict');
 const http = require('node:http');
 
 const { runStoryboard } = require('../../dist/lib/testing/storyboard/runner');
+const { createTestClient } = require('../../dist/lib/testing/client');
 const { closeMCPConnections } = require('../../dist/lib/protocols/mcp');
 
 function buildClient(errorCode = 'request_signature_required') {
@@ -244,6 +245,35 @@ describe('unsigned functional request-signing guard (adcp-client#2373)', () => {
 
     assert.notEqual(result.skipped, true);
     assert.equal(result.passed, false);
+  });
+
+  test('does not skip a rejection after a functional signer was configured', async () => {
+    const signing = {
+      kind: 'provider',
+      provider: {
+        keyid: 'configured-test-signer',
+        algorithm: 'ed25519',
+        fingerprint: 'configured-test-signer',
+        sign: async () => new Uint8Array(64),
+      },
+      agent_url: 'https://compliance-runner.example',
+    };
+    const client = createTestClient('https://stub.example/mcp', 'mcp', {
+      functional_request_signing: signing,
+    });
+    client.executeTask = buildClient().executeTask;
+    const result = await runStoryboard('https://stub.example/mcp', buildStoryboard(), {
+      protocol: 'mcp',
+      allow_http: true,
+      agentTools: ['create_media_buy'],
+      functional_request_signing: signing,
+      _client: client,
+      _profile: buildProfile(),
+    });
+    const step = result.phases[0].steps[0];
+
+    assert.notEqual(step.skipped, true);
+    assert.equal(step.passed, false);
   });
 
   test('uses the routed agent profile when only the secondary requires the task signature', async () => {


### PR DESCRIPTION
## Summary

- load the published compliance signing key for explicit sandbox functional storyboard runs
- route it through the capability-driven RFC 9421 signer for MCP and A2A requests
- preserve bearer, basic, OAuth, and tenant-routing authentication alongside signature headers
- retain the older-bundle not_applicable compatibility path only when no functional signer is configured
- isolate shared clients and capability caches by endpoint, protocol, signer, effective credentials, and routing headers
- seed signing capabilities from trusted discovery under the selected wire version
- expose explicit storyboard --sandbox routing while preserving the historical omitted default

## Security

- auto-loading requires sandbox mode, rejects disable_sandbox, and requires a sandbox-scoped runner contract
- validates required and supported operation policy, bootstrap behavior, key algorithm, request-signing purpose, and revocation status
- preserves provider purpose binding through the signing wrapper
- generates the test Ed25519 keypair at runtime; no private scalar is committed
- verifies captured functional signatures cryptographically with fresh nonces while confirming transport auth survives

## Validation

- npm run build:lib
- npm run typecheck
- npm run lint -- --quiet
- 72 focused and adjacent MCP/A2A request-signing tests
- protocol, code, and security expert reviews plus the required second-model review

## Coordination

This client support is conditional on the bundled compliance contract exposing functional_dispatch. The currently pinned AdCP 3.2.0-beta.6 bundle does not contain that field, so the companion protocol contract must be published in a new immutable bundle and the client pin synced before bundled runs activate this feature. Older bundles remain compatible.

Refs adcontextprotocol/adcp#5701
Follow-up to #2393