### PR TITLE
fix: restore schema composition and mature dependency floor

### DIFF
--- a/.changeset/calm-ravens-fix-schema-floors.md
+++ b/.changeset/calm-ravens-fix-schema-floors.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Restore composable product discovery schema declarations and relax the compatible `tldts` dependency floor for release-age-gated consumers.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,7 +243,9 @@ jobs:
         if: steps.detect.outputs.changed == 'true'
         uses: pnpm/action-setup@v4
         with:
-          version: 11.1.2
+          # Exact-version minimumReleaseAge exclusions landed in pnpm 10.19;
+          # stay on v10 so this smoke still exercises the SDK's Node 20 floor.
+          version: 10.19.0
 
       - name: Install dependencies
         if: steps.detect.outputs.changed == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,6 +239,12 @@ jobs:
           node-version: '20.x'
           cache: 'npm'
 
+      - name: Setup pnpm release-age resolver
+        if: steps.detect.outputs.changed == 'true'
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.1.2
+
       - name: Install dependencies
         if: steps.detect.outputs.changed == 'true'
         run: npm ci

--- a/docs/development/PACKAGE-VERIFICATION.md
+++ b/docs/development/PACKAGE-VERIFICATION.md
@@ -92,8 +92,10 @@ façade contract becomes unsafe.
 
 ## `npm run verify:package` — clean-room dual-format smoke
 
-`scripts/verify-package.mjs` packs a tarball, installs it plus its **required**
-peers pinned to their **range floors** into a throwaway dir under `os.tmpdir()`
+`scripts/verify-package.mjs` packs a tarball and first installs it with pnpm's
+seven-day `minimumReleaseAge` policy in a throwaway project. It then installs
+the tarball plus its **required** peers pinned to their **range floors** and
+`tldts@7.0.0` into another throwaway dir under `os.tmpdir()`
 (outside the workspace, so npm resolution is honest and not monorepo-deduped),
 then loads the main, enums, server, testing, and schemas entry points through
 both a real ESM `import` and a real CJS `require`, asserting each loads and
@@ -102,9 +104,10 @@ surface from `.mts` and `.cts` consumers. `server` is included so the
 `@a2a-js/sdk` peer gets real ESM/CJS load coverage through a dedicated
 entrypoint. Optional peers
 (`peerDependenciesMeta`) are **not** installed — no tested subpath loads them,
-so pinning them would add only install weight and registry-flake surface. It
-uses `npm install` in the temp dir (never workspace pnpm/catalog) and cleans up
-on exit. Requires a prior `npm run build:lib`.
+so pinning them would add only install weight and registry-flake surface. The
+floor/load smoke uses `npm install` (never workspace pnpm/catalog), and both
+temporary projects are cleaned up on exit. Requires pnpm 11, plus a prior
+`npm run build:lib`.
 
 This is what catches a peer floor that is declared lower than the code needs:
 CJS named-import interop can mask a too-low pin, but a real ESM import surfaces

--- a/docs/development/PACKAGE-VERIFICATION.md
+++ b/docs/development/PACKAGE-VERIFICATION.md
@@ -106,8 +106,8 @@ entrypoint. Optional peers
 (`peerDependenciesMeta`) are **not** installed — no tested subpath loads them,
 so pinning them would add only install weight and registry-flake surface. The
 floor/load smoke uses `npm install` (never workspace pnpm/catalog), and both
-temporary projects are cleaned up on exit. Requires pnpm 11, plus a prior
-`npm run build:lib`.
+temporary projects are cleaned up on exit. Requires pnpm 10.19 or newer, plus a
+prior `npm run build:lib`.
 
 This is what catches a peer floor that is declared lower than the code needs:
 CJS named-import interop can mask a too-low pin, but a real ESM import surfaces

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "secure-json-parse": "^4.1.0",
         "semver": "^7.8.5",
         "structured-headers": "2.0.3",
-        "tldts": "^7.4.11",
+        "tldts": "^7.0.0",
         "undici": "^6.28.0",
         "ws": "^8.21.3",
         "yaml": "^2.9.0"

--- a/package.json
+++ b/package.json
@@ -600,7 +600,7 @@
     "secure-json-parse": "^4.1.0",
     "semver": "^7.8.5",
     "structured-headers": "2.0.3",
-    "tldts": "^7.4.11",
+    "tldts": "^7.0.0",
     "undici": "^6.28.0",
     "ws": "^8.21.3",
     "yaml": "^2.9.0"

--- a/scripts/check-adopter-types.ts
+++ b/scripts/check-adopter-types.ts
@@ -127,6 +127,7 @@ import type {
   Package,
   ProductCardFields,
   ProductCardDetailedFields,
+  GetProductsRequest,
   SLAWindow,
   SlaWindow,
   UpdateMediaBuyPayload as RootUpdateMediaBuyPayload,
@@ -191,6 +192,9 @@ const _productOutputExtensionsSchema = z.object({
   publisher_properties: z.array(publicSchemas.PublisherPropertySelectorSchema),
 });
 const _compatibleProductSchema = publicSchemas.ProductSchema.safeExtend(_productOutputExtensionsSchema.shape);
+const _consumerProductSchema = publicSchemas.ProductSchema.safeExtend({
+  publisher_properties: z.array(z.object({ property_id: z.string() })).optional(),
+});
 const _composedProductsResponseSchema = publicSchemas.GetProductsResponseSchema.extend({
   status: z.literal('completed'),
   products: z.array(_compatibleProductSchema),
@@ -213,6 +217,12 @@ type _PickedPublisherProperties = z.output<
 type _PickedPublisherPropertiesIsTyped = _Assert<_IsAny<_PickedPublisherProperties> extends false ? true : false>;
 void (null as unknown as _ComposedProductIsTyped);
 void (null as unknown as _PickedPublisherPropertiesIsTyped);
+declare const _consumerProduct: z.output<typeof _consumerProductSchema>;
+const _consumerProductId: string = _consumerProduct.product_id;
+void _consumerProductId;
+const _productChannelsSchema = publicSchemas.ProductSchema.pick({ channels: true });
+const _productChannelsInput: z.input<typeof _productChannelsSchema> = {};
+void _productChannelsInput;
 type _InferredPackage = z.infer<typeof publicSchemas.PackageSchema>;
 declare const _inferredPackage: _InferredPackage;
 const _inferredPackageAsPublic: Package = _inferredPackage;
@@ -220,13 +230,19 @@ declare const _publicPackage: Package;
 const _publicPackageAsInferred: _InferredPackage = _publicPackage;
 void _inferredPackageAsPublic;
 void _publicPackageAsInferred;
-const _packedGetProductsRequest: LegacyGetProductsRequest =
+const _packedGetProductsRequest: GetProductsRequest =
   publicSchemas.GetProductsRequestSchema.parse(_unknownPackedInput);
 void _packedGetProductsRequest;
 const _minimalPackedGetProductsRequestInput: z.input<typeof publicSchemas.GetProductsRequestSchema> = {
   buying_mode: 'brief',
 };
 void _minimalPackedGetProductsRequestInput;
+const _extendedPackedGetProductsRequest = publicSchemas.GetProductsRequestSchema.extend({
+  local_extension: z.string().optional(),
+}).parse({ buying_mode: 'wholesale' }) satisfies GetProductsRequest & {
+  local_extension?: string;
+};
+void _extendedPackedGetProductsRequest;
 const _summarizedProducts: GetProductsHandlerResult = withResponseSummary(
   { products: [], cache_scope: 'public' },
   'Synthetic sample data for demonstration only.'
@@ -252,7 +268,7 @@ void _normalizedRecoveredProducts;
 void _invalidForecastNormalizationAsTyped;
 void (null as unknown as _NormalizedRecoveredProductsIsTyped);
 
-const _wireFields = publicSchemas.GetProductsRequestSchema.parse({
+const _wireFields = publicSchemas.LegacyGetProductsRequestSchema.parse({
   buying_mode: 'wholesale',
   fields: ['format_ids'],
   brand: {
@@ -283,10 +299,20 @@ type _WireFieldSupportsLegacy = _Assert<
   'format_ids' extends NonNullable<LegacyGetProductsRequest['fields']>[number] ? true : false
 >;
 const _wireField: NonNullable<LegacyGetProductsRequest['fields']>[number] | undefined = _wireFields.fields?.[0];
+const _canonicalGetProductsFields: z.input<typeof publicSchemas.GetProductsRequestSchema> = {
+  buying_mode: 'wholesale',
+  fields: ['format_options'],
+};
+const _legacyGetProductsFields: z.input<typeof publicSchemas.LegacyGetProductsRequestSchema> = {
+  buying_mode: 'wholesale',
+  fields: ['format_ids'],
+};
 const _disclosurePosition: DisclosurePosition | undefined =
   _wireFields.brand?.brand_kit_override?.logo?.provenance?.disclosure?.jurisdictions?.[0]?.render_guidance
     ?.positions?.[0];
 void _wireField;
+void _canonicalGetProductsFields;
+void _legacyGetProductsFields;
 void _disclosurePosition;
 void (null as unknown as _WireFieldSupportsLegacy);
 

--- a/scripts/generate-types.ts
+++ b/scripts/generate-types.ts
@@ -43,7 +43,25 @@ export function relaxZodCompatibilityArrayTypes(content: string): string {
   // get_products composition replaces this complete selector array in one
   // safeExtend call. Its runtime schema is intentionally an ordinary ZodArray,
   // so the public Product field must not retain jsts' non-empty tuple wrapper.
-  return content
+  const productMarkersAreEmpty =
+    /export interface NamedFormatProduct\s*\{\s*\}/.test(content) &&
+    /export interface CanonicalFormatProduct\s*\{\s*\}/.test(content);
+  const productMarkersNormalized = productMarkersAreEmpty
+    ? content
+        // These marker interfaces are currently empty, so retaining their union
+        // in the Product intersection makes indexed access such as Product[K]
+        // collapse to never. Inspect the declarations before removing the exact
+        // marker-only codegen forms so future marker fields remain in Product.
+        .replace(
+          /export type Product = \{\s*\} & \(NamedFormatProduct \| CanonicalFormatProduct\) & \{/g,
+          'export type Product = {'
+        )
+        .replace(
+          /export type Product = \(NamedFormatProduct \| CanonicalFormatProduct\) & \{/g,
+          'export type Product = {'
+        )
+    : content;
+  return productMarkersNormalized
     .replace(/positions\?: \[DisclosurePosition, \.\.\.DisclosurePosition\[\]\];/g, 'positions?: DisclosurePosition[];')
     .replace(
       /publisher_properties: \[\s*PublisherPropertySelector & \{\s*\},\s*\.\.\.\(PublisherPropertySelector & \{\s*\}\)\[\]\s*\];/g,

--- a/scripts/generate-zod-from-ts.ts
+++ b/scripts/generate-zod-from-ts.ts
@@ -84,7 +84,7 @@ const TS7056_SCHEMAS: Array<{
   name: string;
   tsType?: string;
   objectShape?: boolean;
-  typeSource?: 'tools' | 'core';
+  typeSource?: 'tools' | 'core' | 'v2-projection';
 }> = [
   { name: 'AdCPAsyncResponseDataSchema' },
   { name: 'MCPWebhookPayloadSchema' },
@@ -99,7 +99,11 @@ const TS7056_SCHEMAS: Array<{
   { name: 'AudienceEvidenceSchema' },
   { name: 'AudienceEvidenceSelectionSchema' },
   { name: 'ProductSchema', tsType: 'Product', objectShape: true },
-  { name: 'GetProductsRequestSchema', tsType: 'GetProductsRequest', objectShape: true },
+  {
+    name: 'GetProductsRequestSchema',
+    tsType: 'GetProductsRequest',
+    objectShape: true,
+  },
   { name: 'GetProductsAsyncInputRequiredSchema' },
   { name: 'WholesaleFeedEventSchema' },
   { name: 'PackageRequestSchema', tsType: 'PackageRequest', objectShape: true },
@@ -158,6 +162,7 @@ function postProcessTS7056Annotations(content: string): string {
   const typesToImport = {
     tools: new Set<string>(),
     core: new Set<string>(),
+    v2Projection: new Set<string>(),
   };
   for (const { name, tsType, objectShape, typeSource = 'tools' } of TS7056_SCHEMAS) {
     const pattern = new RegExp(`export const ${name} = `);
@@ -190,9 +195,12 @@ function postProcessTS7056Annotations(content: string): string {
         const objectShapeType =
           name === 'PreviewCreativeRequestSchema'
             ? `{ request_type: z.ZodType<PreviewCreativeRequest['request_type'], PreviewCreativeRequest['request_type']> } & Record<string, z.ZodType>`
-            : typedObjectShape;
+            : name === 'ProductSchema'
+              ? `{ [K in keyof Product]-?: K extends 'publisher_properties' ? z.ZodType : undefined extends Product[K] ? z.ZodOptional<z.ZodType<Exclude<Product[K], undefined>, Exclude<Product[K], undefined>>> : z.ZodType<Product[K], Product[K]> }`
+              : typedObjectShape;
         annotation = `z.ZodObject<${objectShapeType}, z.core.$loose> & z.ZodType<${widened}, ${widened}>`;
-        typesToImport[typeSource].add(tsType);
+        const importBucket = typeSource === 'v2-projection' ? typesToImport.v2Projection : typesToImport[typeSource];
+        importBucket.add(tsType);
       } else {
         annotation =
           name === 'ProductSchema'
@@ -202,7 +210,8 @@ function postProcessTS7056Annotations(content: string): string {
     } else if (tsType) {
       const widened = `${tsType} & Record<string, unknown>`;
       annotation = `z.ZodType<${widened}, ${widened}>`;
-      typesToImport[typeSource].add(tsType);
+      const importBucket = typeSource === 'v2-projection' ? typesToImport.v2Projection : typesToImport[typeSource];
+      importBucket.add(tsType);
     } else {
       annotation = 'z.ZodType';
     }
@@ -213,13 +222,16 @@ function postProcessTS7056Annotations(content: string): string {
   }
   // Inject `import type { ... } from './tools.generated'` for the typed-zod
   // entries. The compound schemas reference response types defined there.
-  if (typesToImport.tools.size > 0 || typesToImport.core.size > 0) {
+  if (typesToImport.tools.size > 0 || typesToImport.core.size > 0 || typesToImport.v2Projection.size > 0) {
     const importStatements = [
       typesToImport.tools.size > 0
         ? `import type { ${[...typesToImport.tools].join(', ')} } from './tools.generated';`
         : undefined,
       typesToImport.core.size > 0
         ? `import type { ${[...typesToImport.core].join(', ')} } from './core.generated';`
+        : undefined,
+      typesToImport.v2Projection.size > 0
+        ? `import type { ${[...typesToImport.v2Projection].join(', ')} } from '../v2/projection/creative-delivery';`
         : undefined,
     ]
       .filter(Boolean)

--- a/scripts/verify-package.mjs
+++ b/scripts/verify-package.mjs
@@ -10,6 +10,9 @@
  * `require`, asserting each exposes a known runtime symbol. It also compiles
  * the exact schema surface through both declaration formats and runs a modern
  * MCP negotiation under Bun, whose ESM/CJS interoperability differs from Node's.
+ * A pnpm resolver pass enforces the same seven-day minimum release age used by
+ * security-conscious adopters, and the npm runtime pass pins selected direct
+ * dependencies to their declared compatibility floors.
  *
  * Why a temp dir outside the repo: installing inside the workspace would let
  * the monorepo dedupe peers against the repo's own node_modules, so a missing
@@ -22,7 +25,7 @@
  * Exits non-zero on any failure.
  */
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -87,6 +90,37 @@ try {
   console.log(`   → ${tgz}`);
   console.log(`   ${(tarballBytes / 1024 / 1024).toFixed(1)} MiB`);
 
+  // Reproduce pnpm consumers that quarantine newly-published dependency
+  // versions. The SDK prerelease itself and the security-motivated jose floor
+  // are explicit exceptions; every other direct/transitive resolution must
+  // have aged for seven days. This catches fresh transitive floors that a
+  // manifest-only timestamp check cannot see.
+  const releaseAgeDir = path.join(tmpDir, 'release-age-consumer');
+  mkdirSync(releaseAgeDir);
+  writeFileSync(
+    path.join(releaseAgeDir, 'package.json'),
+    JSON.stringify(
+      {
+        name: 'adcp-release-age-consumer',
+        version: '1.0.0',
+        private: true,
+        dependencies: { '@adcp/sdk': `file:${tarballPath}` },
+      },
+      null,
+      2
+    )
+  );
+  writeFileSync(
+    path.join(releaseAgeDir, 'pnpm-workspace.yaml'),
+    ['minimumReleaseAge: 10080', 'minimumReleaseAgeExclude:', "  - '@adcp/sdk'", "  - 'jose@6.2.10'", ''].join('\n')
+  );
+  console.log('🕰️  pnpm seven-day minimum-release-age resolution:');
+  run('pnpm', ['install', '--lockfile-only', '--frozen-lockfile=false'], {
+    cwd: releaseAgeDir,
+    stdio: 'inherit',
+  });
+  console.log('  packed artifact resolves without admitting unapproved fresh dependencies');
+
   const packedPaths = new Set(run('tar', ['-tf', tarballPath]).trim().split('\n'));
   const requiredGuides = [
     'package/docs/migration-12-to-14.md',
@@ -106,11 +140,19 @@ try {
   }
   console.log('   migration guides referenced by README are present');
 
-  console.log(`📥 Installing tarball + peer floors:\n   ${peerFloors.join('\n   ')}`);
-  run('npm', ['install', '--no-audit', '--no-fund', '--loglevel=error', tarballPath, ...peerFloors], {
+  const runtimeFloors = ['tldts@7.0.0'];
+  console.log(`📥 Installing tarball + runtime/peer floors:\n   ${[...runtimeFloors, ...peerFloors].join('\n   ')}`);
+  run('npm', ['install', '--no-audit', '--no-fund', '--loglevel=error', tarballPath, ...runtimeFloors, ...peerFloors], {
     cwd: tmpDir,
     stdio: 'inherit',
   });
+  const installedTldtsVersion = JSON.parse(
+    readFileSync(path.join(tmpDir, 'node_modules', 'tldts', 'package.json'), 'utf8')
+  ).version;
+  if (installedTldtsVersion !== '7.0.0') {
+    throw new Error(`expected tldts compatibility floor 7.0.0, got ${installedTldtsVersion}`);
+  }
+  console.log('  tldts compatibility floor 7.0.0 installed');
 
   // Cover the barrel, a zod-free enum entry, and the server subpath — the last
   // adds real ESM/CJS load coverage of the @a2a-js/sdk peer through a dedicated
@@ -119,6 +161,7 @@ try {
     { specifier: '@adcp/sdk', symbol: 'EventTypeValues' },
     { specifier: '@adcp/sdk/enums', symbol: 'EventTypeValues' },
     { specifier: '@adcp/sdk/server', symbol: 'A2AInvocationError' },
+    { specifier: '@adcp/sdk/signing/server', symbol: 'resolveAgent' },
     { specifier: '@adcp/sdk/testing', symbol: 'mergeSeedProductLegacy' },
     { specifier: '@adcp/sdk/schemas', symbol: 'CreativeAssetSchema' },
   ];

--- a/src/lib/schemas/index.ts
+++ b/src/lib/schemas/index.ts
@@ -40,8 +40,10 @@
  * ```
  */
 
-import type { z } from 'zod';
+import { z } from 'zod';
 import * as schemas from '../types/schemas.generated';
+import { GetProductsRequest_FieldsValues } from '../types/inline-enums.generated';
+import type { CanonicalGetProductsRequest } from '../v2/projection/creative-delivery';
 import { TOOL_REQUEST_SCHEMAS } from '../utils/tool-request-schemas';
 import type { KnownToolRequestSchemas } from '../utils/tool-request-schemas';
 import {
@@ -52,6 +54,30 @@ import {
 import { resolveAdcpVersion } from '../utils/adcp-version-config';
 
 export * from '../types/schemas.generated';
+
+type LooseObjectSchemaFor<T extends object> = z.ZodObject<
+  {
+    [K in keyof T]-?: undefined extends T[K]
+      ? z.ZodOptional<z.ZodType<Exclude<T[K], undefined>, Exclude<T[K], undefined>>>
+      : z.ZodType<T[K], T[K]>;
+  },
+  z.core.$loose
+> &
+  z.ZodType<T & Record<string, unknown>, T & Record<string, unknown>>;
+
+/** Wire-compatible request schema, including the legacy `format_ids` selector. */
+export const LegacyGetProductsRequestSchema = schemas.GetProductsRequestSchema;
+
+type CanonicalGetProductsField = NonNullable<CanonicalGetProductsRequest['fields']>[number];
+const canonicalGetProductsFields = GetProductsRequest_FieldsValues.filter(
+  (field): field is CanonicalGetProductsField => field !== 'format_ids'
+) as [CanonicalGetProductsField, ...CanonicalGetProductsField[]];
+
+/** Primary request schema; legacy `format_ids` selection is rejected. */
+export const GetProductsRequestSchema = schemas.GetProductsRequestSchema.safeExtend({
+  fields: z.array(z.enum(canonicalGetProductsFields)).optional(),
+}) as unknown as LooseObjectSchemaFor<CanonicalGetProductsRequest>;
+
 export { BiddingPolicySchema } from '../validation/bidding-policy';
 export { CanonicalBudgetAllocationSchema } from '../validation/budget-allocation';
 export { TOOL_REQUEST_SCHEMAS } from '../utils/tool-request-schemas';

--- a/src/lib/signing/agent-resolver/etld.ts
+++ b/src/lib/signing/agent-resolver/etld.ts
@@ -1,10 +1,10 @@
 /**
  * eTLD+1 computation against a pinned, dated PSL snapshot. Backed by
  * `tldts`, which ships its PSL bundled into the published package — pinning
- * the dependency in `package.json` pins the snapshot. Runtime PSL fetches are
- * never performed: a runtime fetch creates both a denial-of-service oracle
- * (PSL host outage stalls verification) and a non-deterministic eTLD+1
- * across deployments running on different snapshot ages
+ * the resolved version in `package-lock.json` pins this repository's snapshot.
+ * Runtime PSL fetches are never performed: a runtime fetch creates both a
+ * denial-of-service oracle (PSL host outage stalls verification) and a
+ * non-deterministic eTLD+1 across deployments running on different snapshot ages
  * (security.mdx §"Quickstart: implement a `brand_json_url`-based verifier"
  * step 3).
  *

--- a/src/lib/types/core.generated.ts
+++ b/src/lib/types/core.generated.ts
@@ -1,5 +1,5 @@
 // Generated AdCP core types from official schemas v3.2.0-beta.6
-// Generated at: 2026-08-25T15:01:23.730Z
+// Generated at: 2026-08-26T10:39:00.240Z
 
 // ACCOUNTCURRENCYMODE CANONICAL ENUM
 /**
@@ -15358,7 +15358,7 @@ export type BusinessEntity1 = BusinessEntity;
 /**
  * Represents available advertising inventory
  */
-export type Product = (NamedFormatProduct | CanonicalFormatProduct) & {
+export type Product = {
   /**
    * Opaque identifier for this buyable product. For a non-custom wholesale product, sellers MUST reuse the ID for the same logical catalog offer within the seller and declared cache_scope across reads and wholesale-feed webhooks; feed and pricing versions communicate temporal catalog mutation, while retirement or replacement may end the identity. Concurrent or request-bound configurations whose effective targeting, disclosed targeting modifications, forecast assumptions, terms, or overlay support differ MUST use distinguishable configured product IDs. For is_custom: true, the ID identifies only the request-specific discovery/refinement lineage and is not stable across independent contexts. Sellers MUST keep every issued configured ID resolvable for its promised lifetime. Pricing variants within one logical product are distinguished by pricing_option_id: a seller MUST mint a new pricing_option_id whenever a binding fixed price, floor, currency, model, or priced applicability changes, and MUST NOT reinterpret an issued option ID at a new price. Selecting product_id plus pricing_option_id in create_media_buy accepts that returned configuration and commercial option.
    */

--- a/src/lib/types/schemas.generated.ts
+++ b/src/lib/types/schemas.generated.ts
@@ -1,5 +1,5 @@
 // Generated Zod v4 schemas from TypeScript types
-// Generated at: 2026-08-25T20:09:37.947Z
+// Generated at: 2026-08-26T10:45:39.051Z
 // Sources:
 //   - core.generated.ts (core types)
 //   - tools.generated.ts (tool types)
@@ -2752,10 +2752,6 @@ export const CanonicalFormatCoordinatedPlacementsSchema: z.ZodObject<{ [K in key
             });
           }), "shared_slots": z.array(z.object({ "asset_group_id": z.string().regex(new RegExp("^[a-z0-9_]+$")), "asset_type": z.enum(["image","video","audio","text","markdown","url","html","css","javascript","vast","daast","webhook","brief","catalog","published_post","zip","card","object","pixel_tracker","vast_tracker","daast_tracker"]), "required": z.boolean().optional(), "min": z.number().int().gte(0).optional(), "max": z.number().int().gte(1).optional(), "consumed_by": z.array(z.string()).min(1).refine((arr) => arr.every((item, i) => arr.indexOf(item) == i), "All items must be unique!").describe("Component IDs that consume this shared asset. Every value MUST resolve to `components[].component_id`.") }).catchall(z.any())).describe("Manifest slots supplied once and consumed by one or more coordinated components.").optional() }).catchall(z.any()).describe("One creative manifest atomically supplies assets for multiple declared product placements. Each component binds to a public `Product.placements[]` entry and either declares an inline non-custom canonical format or references a sibling format option on the same product. Components cannot nest coordinated placements. The manifest supplies component slots under `component_assets.<component_id>`; `shared_slots` assets are supplied once at top level. Inventory exclusivity remains `Product.exclusivity`, not a creative-format parameter. Ordinary products whose placements accept independently assigned creatives do not need this canonical.");
 
-export const NamedFormatProductSchema = z.object({}).passthrough();
-
-export const CanonicalFormatProductSchema = z.object({}).passthrough();
-
 export const PublisherPropertySelectorSchema = z.union([z.object({
         publisher_domain: z.string().regex(/^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/).optional(),
         publisher_domains: z.array(z.string()).optional(),
@@ -2968,6 +2964,10 @@ export const ReplaceTargetingValueSchema = z.object({
 }).passthrough();
 
 export const RemoveTargetingSetValuesSchema = z.object({}).passthrough();
+
+export const NamedFormatProductSchema = z.object({}).passthrough();
+
+export const CanonicalFormatProductSchema = z.object({}).passthrough();
 
 export const PriceGuidanceSchema = z.object({
     p25: z.number().optional(),
@@ -13337,7 +13337,7 @@ export const SyncCatalogsResponseSchema = z.object({
 }).passthrough().and(z.union([SyncCatalogsSuccessSchema, SyncCatalogsErrorSchema, SyncCatalogsSubmittedSchema]));
 
 // @ts-ignore -- preserve the public schema type across lossy TS-to-Zod projection details.
-export const ProductSchema: z.ZodObject<{ [K in keyof Product]-?: undefined extends Product[K] ? z.ZodOptional<z.ZodType<Exclude<Product[K], undefined>, Exclude<Product[K], undefined>>> : z.ZodType<Product[K], Product[K]> }, z.core.$loose> & z.ZodType<Product & Record<string, unknown>, Product & Record<string, unknown>> = z.object({
+export const ProductSchema: z.ZodObject<{ [K in keyof Product]-?: K extends 'publisher_properties' ? z.ZodType : undefined extends Product[K] ? z.ZodOptional<z.ZodType<Exclude<Product[K], undefined>, Exclude<Product[K], undefined>>> : z.ZodType<Product[K], Product[K]> }, z.core.$loose> & z.ZodType<Product & Record<string, unknown>, Product & Record<string, unknown>> = z.object({
     product_id: z.string(),
     name: z.string(),
     description: z.string(),

--- a/src/lib/types/tools.generated.ts
+++ b/src/lib/types/tools.generated.ts
@@ -2139,7 +2139,6 @@ export interface ContextObject {
  * Represents available advertising inventory
  */
 export type Product = {
-} & (NamedFormatProduct | CanonicalFormatProduct) & {
     /**
      * Opaque identifier for this buyable product. For a non-custom wholesale product, sellers MUST reuse the ID for the same logical catalog offer within the seller and declared cache_scope across reads and wholesale-feed webhooks; feed and pricing versions communicate temporal catalog mutation, while retirement or replacement may end the identity. Concurrent or request-bound configurations whose effective targeting, disclosed targeting modifications, forecast assumptions, terms, or overlay support differ MUST use distinguishable configured product IDs. For is_custom: true, the ID identifies only the request-specific discovery/refinement lineage and is not stable across independent contexts. Sellers MUST keep every issued configured ID resolvable for its promised lifetime. Pricing variants within one logical product are distinguished by pricing_option_id: a seller MUST mint a new pricing_option_id whenever a binding fixed price, floor, currency, model, or priced applicability changes, and MUST NOT reinterpret an issued option ID at a new price. Selecting product_id plus pricing_option_id in create_media_buy accepts that returned configuration and commercial option.
      */

--- a/src/type-tests/zod-schema-ergonomics.type-test.ts
+++ b/src/type-tests/zod-schema-ergonomics.type-test.ts
@@ -14,7 +14,7 @@ import {
   PackageSchema,
   PackageRequestSchema,
   PackageUpdateSchema,
-  GetProductsRequestSchema,
+  GetProductsRequestSchema as LegacyGetProductsRequestSchema,
   GetProductsResponseSchema,
   PublisherPropertySelectorSchema,
   ProductFormatDeclarationSchema,
@@ -28,7 +28,9 @@ import {
   GetAdCPCapabilitiesResponseSchema,
   ListTransformersResponseSchema,
 } from '../lib/types/schemas.generated';
+import { GetProductsRequestSchema } from '../lib/schemas';
 import type { Format, AvailablePackage, PackageUpdate } from '../lib/types/core.generated';
+import type { CanonicalGetProductsRequest } from '../lib/v2/projection/creative-delivery';
 import type {
   GetProductsResponse,
   GetProductsRequest,
@@ -74,6 +76,15 @@ const ProductOutputExtensionsSchema = z.object({
   publisher_properties: z.array(PublisherPropertySelectorSchema),
 });
 ProductSchema.safeExtend(ProductOutputExtensionsSchema.shape);
+const ConsumerProductSchema = ProductSchema.safeExtend({
+  publisher_properties: z.array(z.object({ property_id: z.string() })).optional(),
+});
+declare const consumerProduct: z.output<typeof ConsumerProductSchema>;
+const consumerProductId: string = consumerProduct.product_id;
+void consumerProductId;
+const ProductChannelsSchema = ProductSchema.pick({ channels: true });
+const productChannelsInput: z.input<typeof ProductChannelsSchema> = {};
+void productChannelsInput;
 const ExtendedGetProductsResponseSchema = GetProductsResponseSchema.extend({
   products: z.array(ProductSchema),
 }).partial();
@@ -131,9 +142,14 @@ const mediaPackage: Package = PackageSchema.parse(unknownInput);
 const packageRequest: PackageRequest = PackageRequestSchema.parse(unknownInput);
 const packageUpdate: PackageUpdate = PackageUpdateSchema.parse(unknownInput);
 const productsResponse: GetProductsResponse = GetProductsResponseSchema.parse(unknownInput);
-const getProductsRequest: GetProductsRequest = GetProductsRequestSchema.parse(unknownInput);
+const getProductsRequest: GetProductsRequest = LegacyGetProductsRequestSchema.parse(unknownInput);
 const minimalGetProductsRequestInput: z.input<typeof GetProductsRequestSchema> = {
   buying_mode: 'brief',
+};
+const extendedGetProductsRequest = GetProductsRequestSchema.extend({
+  local_extension: z.string().optional(),
+}).parse({ buying_mode: 'wholesale' }) satisfies CanonicalGetProductsRequest & {
+  local_extension?: string;
 };
 const productFormat: ProductFormatDeclaration = ProductFormatDeclarationSchema.parse(unknownInput);
 const placement: Placement = PlacementSchema.parse(unknownInput);
@@ -154,6 +170,7 @@ void [
   productsResponse,
   getProductsRequest,
   minimalGetProductsRequestInput,
+  extendedGetProductsRequest,
   productFormat,
   placement,
   format,

--- a/test/lib/zod-schemas.test.js
+++ b/test/lib/zod-schemas.test.js
@@ -17,9 +17,9 @@ describe('Zod Schema Validation', () => {
     assert.equal(typeof sdk.ADCP_VERSION, 'string', 'package root should expose its version');
   });
 
-  test('get_products wire schema preserves legacy fields and relaxed disclosure positions', async () => {
-    if (!schemas) schemas = await import('../../dist/lib/types/schemas.generated.js');
-    const parsed = schemas.GetProductsRequestSchema.parse({
+  test('get_products schemas split canonical and legacy field selection', async () => {
+    const publicSchemas = await import('../../dist/lib/schemas/index.js');
+    const request = {
       buying_mode: 'wholesale',
       fields: ['format_ids'],
       brand: {
@@ -45,9 +45,15 @@ describe('Zod Schema Validation', () => {
           },
         },
       },
-    });
+    };
+    const parsed = publicSchemas.LegacyGetProductsRequestSchema.parse(request);
 
     assert.deepEqual(parsed.fields, ['format_ids']);
+    assert.equal(publicSchemas.GetProductsRequestSchema.safeParse(request).success, false);
+    const canonicalJsonSchema = z.toJSONSchema(publicSchemas.GetProductsRequestSchema);
+    const canonicalFieldsJson = JSON.stringify(canonicalJsonSchema.properties.fields);
+    assert.doesNotMatch(canonicalFieldsJson, /format_ids/);
+    assert.match(canonicalFieldsJson, /format_options/);
     assert.deepEqual(
       parsed.brand.brand_kit_override.logo.provenance.disclosure.jurisdictions[0].render_guidance.positions,
       []

--- a/test/type-generator-required-fields.test.js
+++ b/test/type-generator-required-fields.test.js
@@ -36,12 +36,15 @@ import { writeFileSync } from 'node:fs';
 import { relaxZodCompatibilityArrayTypes } from __GENERATOR__;
 
 const input = \`export type Product = {
+} & (NamedFormatProduct | CanonicalFormatProduct) & {
   publisher_properties: [
     PublisherPropertySelector & {},
     ...(PublisherPropertySelector & {})[]
   ];
   placements?: [Placement, ...Placement[]];
 };
+export interface NamedFormatProduct {}
+export interface CanonicalFormatProduct {}
 positions?: [DisclosurePosition, ...DisclosurePosition[]];\`;
 writeFileSync(__OUTPUT__, JSON.stringify({ output: relaxZodCompatibilityArrayTypes(input) }));
 `);
@@ -49,6 +52,26 @@ writeFileSync(__OUTPUT__, JSON.stringify({ output: relaxZodCompatibilityArrayTyp
   assert.match(result.output, /publisher_properties: \(PublisherPropertySelector & \{\}\)\[\];/);
   assert.match(result.output, /positions\?: DisclosurePosition\[\];/);
   assert.match(result.output, /placements\?: \[Placement, \.\.\.Placement\[\]\];/);
+  assert.doesNotMatch(result.output, /NamedFormatProduct \| CanonicalFormatProduct/);
+});
+
+test('issue #2674 preserves Product marker fields when either marker becomes non-empty', () => {
+  const result = runGeneratorHarness(`
+import { writeFileSync } from 'node:fs';
+import { relaxZodCompatibilityArrayTypes } from __GENERATOR__;
+
+const input = \`export type Product = {} & (NamedFormatProduct | CanonicalFormatProduct) & {
+  product_id: string;
+};
+export interface NamedFormatProduct {
+  named_format_id: string;
+}
+export interface CanonicalFormatProduct {}\`;
+writeFileSync(__OUTPUT__, JSON.stringify({ output: relaxZodCompatibilityArrayTypes(input) }));
+`);
+
+  assert.match(result.output, /NamedFormatProduct \| CanonicalFormatProduct/);
+  assert.match(result.output, /named_format_id: string;/);
 });
 
 test('PostalCountrySystem propagates unconditional requirements into every anyOf branch', () => {


### PR DESCRIPTION
## Summary

- preserve concrete Product schema field types through safeExtend/pick/omit and guard marker normalization against future non-empty protocol branches
- split canonical and legacy get-products request schemas so runtime validation, TypeScript output, and emitted JSON Schema agree
- restore the tldts 7.0 compatibility floor and verify packed installs under pnpm minimumReleaseAge plus the exact runtime floor

## Verification

- npm run typecheck
- npm run build:lib
- npm run check:adopter-types
- npm run check:package
- npm run test:node:slow (166/166)
- npm run verify:package
- expert code, protocol, and test review

Closes #2674
Closes #2693