### PR TITLE
fix: repair AdCP 3.2 conformance regressions

### DIFF
--- a/.changeset/calm-webhooks-scope-tasks.md
+++ b/.changeset/calm-webhooks-scope-tasks.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': major
+---
+
+Repair AdCP 3.2 compliance execution across webhook proof-of-control, wholesale signal account overlays, account/principal/tenant-scoped task storage, governance delivery requests, transformer JSON values, creative variant responses, and dual creative selector routes. TaskRegistry lifecycle methods and DecisioningAdcpServer task accessors now require an explicit scope.

--- a/docs/guides/POSTGRES.md
+++ b/docs/guides/POSTGRES.md
@@ -12,9 +12,9 @@ When you wire `pool` on `createAdcpServerFromPlatform`, the framework creates an
 | `adcp_ctx_metadata` | Adapter-internal state round-trip cache | Lifetime of referenced resource (often months) | Bounded by your active product / media-buy / creative count |
 | `adcp_decisioning_tasks` | HITL task lifecycle (submitted → working → completed/failed) | Until terminal + manual cleanup | Bounded by HITL request volume |
 
-**Run `getAllAdcpMigrations()` once per database at deploy time.** Idempotent: safe to re-run on every boot.
+**Run `getAllAdcpMigrations({ taskRegistryNamespace })` once per database at deploy time.** The namespace must be stable and unique per hosted tenant. The migration is idempotent and safe to re-run on every boot.
 
-`getAllAdcpMigrations()` installs one default idempotency table. The official
+`getAllAdcpMigrations({ taskRegistryNamespace })` installs one default idempotency table. The official
 `serve()` path automatically includes its canonical, server-controlled host in
 every resolved idempotency principal, so multiple hosted agents remain isolated
 when they share that table. Low-level integrations that do not enter through
@@ -87,13 +87,15 @@ CREATE INDEX idx_adcp_ctx_metadata_expires_at
 
 ### `adcp_decisioning_tasks`
 
-This DDL is returned by `getDecisioningTaskRegistryMigration()` (exported from `@adcp/sdk/server/decisioning`). Call `await pool.query(getDecisioningTaskRegistryMigration())` once at boot — it is idempotent (`CREATE TABLE IF NOT EXISTS`). Pass `{ tableName: 'your_tasks' }` to override the default `adcp_decisioning_tasks` name; constraint and index names derive from the table name automatically. Use `getAllAdcpMigrations()` from `@adcp/sdk/server` when you want one call to install all three SDK tables at once.
+This DDL is returned by `getDecisioningTaskRegistryMigration()` (exported from `@adcp/sdk/server/decisioning`). Call `await pool.query(getDecisioningTaskRegistryMigration({ namespace: taskRegistryNamespace }))` once at boot, using the same stable trusted namespace passed to the registry. Existing rows are backfilled into that namespace, and the migration is idempotent. Pass `{ tableName: 'your_tasks', namespace: taskRegistryNamespace }` to override the default table name. Use `getAllAdcpMigrations({ taskRegistryNamespace })` from `@adcp/sdk/server` when you want one call to install all three SDK tables at once.
 
 ```sql
 CREATE TABLE adcp_decisioning_tasks (
-  task_id        TEXT PRIMARY KEY,
+  registry_namespace TEXT NOT NULL,
+  task_id        TEXT NOT NULL,
   tool           TEXT NOT NULL,
   account_id     TEXT NOT NULL,
+  owner_scope    TEXT NOT NULL,
   status         TEXT NOT NULL DEFAULT 'submitted',
   status_message TEXT,
   result         JSONB,
@@ -104,7 +106,8 @@ CREATE TABLE adcp_decisioning_tasks (
   updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   CONSTRAINT adcp_decisioning_tasks_valid_status CHECK (
     status IN ('submitted', 'working', 'completed', 'failed')
-  )
+  ),
+  PRIMARY KEY (registry_namespace, account_id, owner_scope, task_id)
 );
 CREATE INDEX idx_adcp_decisioning_tasks_account_id ON adcp_decisioning_tasks(account_id);
 CREATE INDEX idx_adcp_decisioning_tasks_status_created ON adcp_decisioning_tasks(status, created_at);
@@ -112,8 +115,8 @@ CREATE INDEX idx_adcp_decisioning_tasks_status_created ON adcp_decisioning_tasks
 
 The four-value status constraint is intentionally narrow. The five additional spec-defined states (`input-required`, `canceled`, `rejected`, `auth-required`, `unknown`) are reserved for adopter-emitted transitions via a forthcoming `taskRegistry.transition()` API; a migration will widen this constraint when that API ships.
 
-- **PK on `task_id`** — primary lookup path.
-- **Index on `account_id`** — tenant-scoped reads (`getTaskState(taskId, expectedAccountId)` and ops queries).
+- **Composite PK on registry namespace, account, owner, and task ID** — prevents task identifiers from crossing hosted-tenant, account, or authenticated-principal boundaries.
+- **Index on `account_id`** — tenant-scoped operational queries.
 - **Index on `(status, created_at)`** — "pending tasks oldest first" queue queries for cron / monitoring.
 - **CHECK constraint on status** — guards against invalid transitions writing bad rows.
 

--- a/docs/migration-5.x-to-6.x.md
+++ b/docs/migration-5.x-to-6.x.md
@@ -269,11 +269,12 @@ In-memory task registry refuses to construct outside `NODE_ENV=test/development`
 ```ts
 import { createPostgresTaskRegistry, getDecisioningTaskRegistryMigration } from '@adcp/sdk/server';
 
-await pool.query(getDecisioningTaskRegistryMigration());
+const taskRegistryNamespace = 'tenant:my-agent';
+await pool.query(getDecisioningTaskRegistryMigration({ namespace: taskRegistryNamespace }));
 
 createAdcpServerFromPlatform(platform, {
   name: '...', version: '...',
-  taskRegistry: createPostgresTaskRegistry({ pool }),
+  taskRegistry: createPostgresTaskRegistry({ pool, namespace: taskRegistryNamespace }),
 });
 ```
 

--- a/docs/migration-task-registry-scoping.md
+++ b/docs/migration-task-registry-scoping.md
@@ -1,0 +1,61 @@
+# Task registry scope migration
+
+Task registry reads, writes, and background waits now require the account and
+authenticated owner scope that created the task. This prevents a known task ID
+from crossing account or principal boundaries.
+
+```ts
+const scope = { accountId: account.id, ownerScope: `api_key:${keyId}` };
+
+await registry.getTask(taskId, scope);
+await registry.updateProgress(taskId, scope, progress);
+await registry.complete(taskId, scope, result);
+await registry.fail(taskId, scope, error, failureArtifact);
+await registry.awaitTask(taskId, scope);
+```
+
+Custom `TaskRegistry` implementations must apply every scope component in the
+storage query. Do not derive `ownerScope` from request parameters; use the
+authenticated server context. Set `scopeVersion: 1` only after migrating those
+method signatures; the platform factory rejects unmarked legacy registries so
+an old `(taskId, result)` write cannot mistake the new scope argument for a
+result.
+
+`DecisioningAdcpServer.getTaskState()` and `.awaitTask()` accept the same scope.
+Administrative and test code that intentionally has no buyer context can use
+the explicitly named `getTaskStateUnsafe()` and `awaitTaskUnsafe()` helpers.
+Unsafe reads return `null` when the same public task ID exists in more than one
+scope.
+
+PostgreSQL registries additionally require a trusted deployment or tenant
+namespace:
+
+```ts
+const taskRegistryNamespace = 'tenant:my-agent';
+createPostgresTaskRegistry({
+  pool,
+  namespace: taskRegistryNamespace,
+});
+```
+
+Run the migration with that same namespace before deploying the new registry:
+
+```ts
+await pool.query(
+  getDecisioningTaskRegistryMigration({ namespace: taskRegistryNamespace })
+);
+```
+
+It backfills legacy rows to the supplied registry namespace and account fallback
+owner scope, then migrates the primary key to
+`(registry_namespace, account_id, owner_scope, task_id)`. The namespace must be
+stable across deploys and unique for every hosted tenant. A single in-memory
+registry instance must likewise not be shared across tenants unless the host
+includes tenant identity in both `accountId` and `ownerScope`.
+
+The legacy table did not store a tenant identifier. If multiple hosted tenants
+previously shared one legacy table, the SDK cannot infer which tenant owns each
+row: the first migration would otherwise assign every legacy row to its supplied
+namespace. Before migrating, drain in-flight tasks or explicitly map legacy rows
+to tenant namespaces in an operator-managed migration. Do not run separate
+tenant migrations over an ambiguous shared legacy table.

--- a/docs/proposals/decisioning-platform-v1.md
+++ b/docs/proposals/decisioning-platform-v1.md
@@ -378,8 +378,8 @@ sales: SalesPlatform = {
 - **`AdcpError`** class — throwable structured error carrying `code`, `recovery`, `field?`, `suggestion?`, `retry_after?`, `details?`. Mirrors `schemas/cache/3.0.0/core/error.json`. Required field: `recovery` (the wire schema makes it optional, but every adopter needs to declare buyer-recovery intent on every rejection).
 - **`ctx.runAsync(opts, fn)`** — in-process async opt-in. Races `fn()` against `submittedAfterMs` (default 30s). Fast path: returns the value normally (sync wire arm). Slow path: throws internal `TaskDeferredError` (the runtime catches and projects to submitted envelope with `task_id` / `message` / `partial_result`); meanwhile `fn()` keeps running and notifies the registry on resolve/throw.
 - **`ctx.startTask(opts?)`** — out-of-process async explicit. Returns a `TaskHandle` whose `taskId` is framework-issued. Adopter persists the taskId; webhook handler later calls `notify` directly (or `server.completeTask` once the wire path lands).
-- **`server.getTaskState(taskId)`** — read the registry record (status, result, error, partialResult, statusMessage, timestamps). The API the forthcoming `tasks/get` wire handler plugs into.
-- **`server.awaitTask(taskId)`** — await any registered background completion. Used by tests + the wire path for deterministic settlement.
+- **`server.getTaskState(taskId, scope)`** — read the registry record (status, result, error, partialResult, statusMessage, timestamps) within an explicit account/principal scope. The API the forthcoming `tasks/get` wire handler plugs into.
+- **`server.awaitTask(taskId, scope)`** — await any registered background completion within that scope. Used by tests + the wire path for deterministic settlement.
 
 ### Production hardening (round-6)
 

--- a/examples/hello_seller_adapter_guaranteed.ts
+++ b/examples/hello_seller_adapter_guaranteed.ts
@@ -1355,7 +1355,7 @@ const mediaBuyStore = createMediaBuyStore({ store: stateStore });
 // instance persists across requests — a fresh registry per request would
 // lose every submitted task between create_media_buy and the buyer's
 // first tasks_get poll. SWAP `createInMemoryTaskRegistry()` for
-// `createPostgresTaskRegistry({ pool })` in production; in-memory
+// `createPostgresTaskRegistry({ pool, namespace: tenantId })` in production; in-memory
 // in-flight tasks are lost on process restart.
 const taskRegistry = createInMemoryTaskRegistry();
 

--- a/scripts/check-adopter-types.ts
+++ b/scripts/check-adopter-types.ts
@@ -52,11 +52,13 @@ import type {
   ActivateSignalPayload,
   LegacyBuildCreativePayload,
   LegacyBuildCreativeMultiPayload,
+  LegacyBuildCreativeVariantPayload,
   CheckGovernancePayload,
   CreativeApprovedPayload,
   CreatePropertyListPayload,
   CreateMediaBuyPayload,
   CreateMediaBuyHandlerResult,
+  DecisioningAdcpServer,
   GetMediaBuyDeliveryPayload,
   GetMediaBuysPayload,
   GetAccountFinancialsHandlerResult,
@@ -82,6 +84,7 @@ import type {
   SyncCreativesHandlerResult,
   SyncEventSourcesPayload,
   SyncGovernanceHandlerResult,
+  TaskRegistry,
   LegacyUpdateRightsPayload,
   UpdateMediaBuyPayload,
 } from '@adcp/sdk/server';
@@ -96,6 +99,7 @@ import { createSingleAgentClient, extractAdcpErrorFromMcp, extractAdcpErrorFromT
 import type {
   CreateMediaBuyPayload as TypesCreateMediaBuyPayload,
   CreateMediaBuySuccess,
+  BuildCreativeVariantSuccess,
   CanonicalFormatAgentPlacementAISurfaceSponsoredPlacement,
   CanonicalFormatBase,
   CanonicalFormatDAASTAudio,
@@ -390,6 +394,32 @@ void extractAdcpErrorFromMcp;
 void extractAdcpErrorFromTransport;
 void createAdcpServerFromPlatform;
 
+// Scoped task-registry migration: the explicitly unsafe admin/test escape
+// hatches must survive stripInternal in the declarations that adopters pack.
+declare const _decisioningServer: DecisioningAdcpServer;
+void _decisioningServer.getTaskStateUnsafe('task_1');
+void _decisioningServer.awaitTaskUnsafe('task_1');
+const _taskRegistry: TaskRegistry = {
+  scopeVersion: 1,
+  async create() {
+    return { taskId: 'task_1' };
+  },
+  async getTask() {
+    return null;
+  },
+  async _getTaskUnsafe() {
+    return null;
+  },
+  async complete() {},
+  async fail() {},
+  async updateProgress() {},
+  _registerBackground() {},
+  async awaitTask() {},
+  async _awaitTaskUnsafe() {},
+};
+void _taskRegistry._getTaskUnsafe('task_1');
+void _taskRegistry._awaitTaskUnsafe('task_1');
+
 const _createMediaBuyPayload: CreateMediaBuyPayload = {
   media_buy_id: 'mb_1',
   confirmed_at: '2026-01-01T00:00:00Z',
@@ -462,6 +492,7 @@ const _payloadResults: [
   Result<GetMediaBuyDeliveryPayload, Error>,
   Result<LegacyBuildCreativePayload, Error>,
   Result<LegacyBuildCreativeMultiPayload, Error>,
+  Result<LegacyBuildCreativeVariantPayload, Error>,
   Result<SyncAudiencesPayload, Error>,
   Result<ActivateSignalPayload, Error>,
   Result<GetBrandIdentityPayload, Error>,
@@ -485,6 +516,7 @@ const _payloadResults: [
   }),
   ok({ creative_manifest: creativeManifest }),
   ok({ creative_manifests: [] }),
+  ok({ creatives: [] } satisfies BuildCreativeVariantSuccess),
   ok({ audiences: [] }),
   ok({ deployments: [] }),
   ok({ brand_id: 'brand_1', house: { domain: 'acme.com', name: 'Acme' }, names: [{ en: 'Acme' }] }),

--- a/scripts/generate-types.ts
+++ b/scripts/generate-types.ts
@@ -69,6 +69,27 @@ export function relaxZodCompatibilityArrayTypes(content: string): string {
     );
 }
 
+/** Preserve arbitrary JSON values when jsts sees them through aggregate roots. */
+export function normalizeTransformerParamJsonValueTypes(content: string): string {
+  const interfaceStart = content.indexOf('export interface TransformerParam {');
+  const typeStart = content.indexOf('export type TransformerParam =');
+  const start =
+    interfaceStart === -1 ? typeStart : typeStart === -1 ? interfaceStart : Math.min(interfaceStart, typeStart);
+  if (start === -1) return content;
+  const end = content.indexOf('\nexport ', start + 1);
+  const blockEnd = end === -1 ? content.length : end;
+  const block = content
+    .slice(start, blockEnd)
+    .replace(/value: \{\s*\};/, 'value: JsonValue;')
+    .replace(/default\?: \{\s*\};/, 'default?: JsonValue;')
+    .replace(/value: unknown;/, 'value: JsonValue;')
+    .replace(/default\?: unknown;/, 'default?: JsonValue;');
+  if (!block.includes('JsonValue')) return content;
+  const alias =
+    'export type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };\n\n';
+  return content.slice(0, start) + alias + block + content.slice(blockEnd);
+}
+
 // Schema cache configuration
 const SCHEMA_CACHE_DIR = path.join(__dirname, '../schemas/cache');
 const LATEST_CACHE_DIR = path.join(SCHEMA_CACHE_DIR, 'latest');
@@ -4146,20 +4167,22 @@ async function generateTypes() {
   // residual jsts under-resolution artifacts (*Asset1, AssetVariant1, CreativeAsset1) —
   // see applyKnownJstsAliases for the rationale. Finally, restore the asset_type
   // discriminator on Individual*Asset slot aliases that jsts collapses (#1498).
-  const processedCoreTypes = relaxZodCompatibilityArrayTypes(
-    hardenTrustedMatchGeneratedTypes(
-      applyIndividualAssetDiscriminators(
-        addBackwardCompatTypeAliases(
-          simplifyForecastRange(
-            simplifyPriceBreakdown(
-              widenMediaBuyFeaturesIndexSignature(
-                widenPostalAreaSupportIndexSignature(
-                  fixTypedIndexSignatures(
-                    removeResidualInlineIndexSignatureArms(
-                      applyKnownJstsAliases(
-                        namePostalAreaCountryBranch(
-                          renameKnownNumberedSemanticTypes(
-                            removeNumberedTypeDuplicates(removeIndexSignatureTypes(coreTypes))
+  const processedCoreTypes = normalizeTransformerParamJsonValueTypes(
+    relaxZodCompatibilityArrayTypes(
+      hardenTrustedMatchGeneratedTypes(
+        applyIndividualAssetDiscriminators(
+          addBackwardCompatTypeAliases(
+            simplifyForecastRange(
+              simplifyPriceBreakdown(
+                widenMediaBuyFeaturesIndexSignature(
+                  widenPostalAreaSupportIndexSignature(
+                    fixTypedIndexSignatures(
+                      removeResidualInlineIndexSignatureArms(
+                        applyKnownJstsAliases(
+                          namePostalAreaCountryBranch(
+                            renameKnownNumberedSemanticTypes(
+                              removeNumberedTypeDuplicates(removeIndexSignatureTypes(coreTypes))
+                            )
                           )
                         )
                       )
@@ -4176,8 +4199,10 @@ async function generateTypes() {
   const coreChanged = writeFileIfChanged(coreTypesPath, processedCoreTypes);
 
   const toolTypesPath = path.join(libOutputDir, 'tools.generated.ts');
-  const processedToolTypes = relaxZodCompatibilityArrayTypes(
-    addCanonicalToolTypeAliases(applyIndividualAssetDiscriminators(addBackwardCompatTypeAliases(toolTypes)), tools)
+  const processedToolTypes = normalizeTransformerParamJsonValueTypes(
+    relaxZodCompatibilityArrayTypes(
+      addCanonicalToolTypeAliases(applyIndividualAssetDiscriminators(addBackwardCompatTypeAliases(toolTypes)), tools)
+    )
   );
   const toolsChanged = writeFileIfChanged(toolTypesPath, processedToolTypes);
 

--- a/scripts/generate-zod-from-ts.ts
+++ b/scripts/generate-zod-from-ts.ts
@@ -361,6 +361,27 @@ function postProcessTuplesToArrays(content: string): string {
 }
 
 /**
+ * ts-to-zod narrows `unknown` properties nested in an open object to another
+ * open object. Transformer parameter defaults and enumerable option values
+ * are explicitly arbitrary JSON, including scalars and null, so restore the
+ * TypeScript contract on this one schema.
+ */
+export function postProcessTransformerParamJsonValues(content: string): string {
+  const start = content.indexOf('export const TransformerParamSchema =');
+  if (start < 0) return content;
+  const end = content.indexOf('\nexport const ', start + 1);
+  const blockEnd = end < 0 ? content.length : end;
+  const block = content
+    .slice(start, blockEnd)
+    .replace(/value:\s*(?:z\.object\(\{\}\)\.passthrough\(\)|JsonValueSchema)/, 'value: z.json()')
+    .replace(
+      /default:\s*(?:z\.object\(\{\}\)\.passthrough\(\)|JsonValueSchema)\.optional\(\),/,
+      'default: z.json().optional(),'
+    );
+  return content.slice(0, start) + block + content.slice(blockEnd);
+}
+
+/**
  * Post-process generated Zod schemas to remove z.undefined() from unions.
  *
  * ts-to-zod generates z.undefined() in unions for TypeScript types like
@@ -3157,6 +3178,10 @@ async function generateZodSchemas() {
     // Agents may return extra/platform-specific fields not in the schema. Without passthrough,
     // Zod strips those fields, causing data loss for consumers who need them.
     zodSchemas = postProcessForPassthrough(zodSchemas);
+
+    // Preserve arbitrary JSON transformer values after ts-to-zod narrows
+    // nested `unknown` properties to open objects.
+    zodSchemas = postProcessTransformerParamJsonValues(zodSchemas);
 
     // String-only JSON Schema constraints on object|string unions must stay
     // attached to the string arm; applying them to z.union() crashes Zod.

--- a/skills/build-decisioning-creative-template/SKILL.md
+++ b/skills/build-decisioning-creative-template/SKILL.md
@@ -405,7 +405,7 @@ serve(() => server, {
 
 - Calls `validatePlatform()` — throws if you advertise a specialism but don't implement it, or define both halves of a method-pair
 - Wraps each method with `AdcpError`-catch + `submitted`-envelope projection for HITL
-- Returns a `DecisioningAdcpServer` (extends `AdcpServer`) with `getTaskState(taskId)` + `awaitTask(taskId)` for HITL inspection
+- Returns a `DecisioningAdcpServer` (extends `AdcpServer`) with scoped `getTaskState(taskId, scope)` + `awaitTask(taskId, scope)` for HITL inspection. Trusted admin/tests may use the explicitly unsafe `getTaskStateUnsafe(taskId)` + `awaitTaskUnsafe(taskId)` helpers.
 
 `serve()` accepts the server and binds HTTP transport for both MCP and A2A.
 
@@ -483,7 +483,7 @@ console.log(result.structuredContent);
 
 `dispatchTestRequest` is the canonical loop for unit-testing platform behavior without HTTP. It's available on `DecisioningAdcpServer` (the type returned by `createAdcpServerFromPlatform`). Set `validation: { requests: 'off' }` while iterating; turn it back to `strict` for end-to-end tests.
 
-For HITL platforms, `server.awaitTask(taskId)` settles the background promise; `server.getTaskState(taskId)` reads terminal status.
+For HITL platforms, `server.awaitTask(taskId, scope)` settles the background promise; `server.getTaskState(taskId, scope)` reads terminal status. Use the `*Unsafe(taskId)` variants only in trusted admin or test code.
 
 ## What NOT to do
 

--- a/skills/build-decisioning-platform/SKILL.md
+++ b/skills/build-decisioning-platform/SKILL.md
@@ -289,13 +289,15 @@ import { Pool } from 'pg';
 import { createAdcpServerFromPlatform, getAllAdcpMigrations, serve } from '@adcp/sdk/server';
 
 const pool = new Pool({ connectionString: process.env.DATABASE_URL });
-await pool.query(getAllAdcpMigrations()); // one DDL call, all 3 tables
+const taskRegistryNamespace = 'tenant:my-agent';
+await pool.query(getAllAdcpMigrations({ taskRegistryNamespace })); // one DDL call, all 3 tables
 
 const platform = new MyPlatform(myAdServer);
 const server = createAdcpServerFromPlatform(platform, {
   name: 'My Sales Agent',
   version: '1.0.0',
   pool, // wires idempotency + ctxMetadata + taskRegistry
+  taskRegistryNamespace,
 });
 
 serve(() => server, { port: process.env.PORT });
@@ -310,7 +312,7 @@ For dev / single-process: omit `pool` entirely. Framework defaults to in-memory 
 Things you set up once at deploy time:
 
 - [ ] `DATABASE_URL` env var pointing at your Postgres instance
-- [ ] Run `getAllAdcpMigrations()` once per database (idempotent — safe to re-run)
+- [ ] Run `getAllAdcpMigrations({ taskRegistryNamespace })` once per database with a stable, trusted namespace (idempotent — safe to re-run)
 - [ ] OAuth provider config — see `advanced/OAUTH.md` if buyers authenticate via OIDC
 - [ ] `ADCP_VERSION` env (default `3.0.0`) if pinning a specific spec version
 

--- a/skills/build-decisioning-platform/advanced/REFERENCE.md
+++ b/skills/build-decisioning-platform/advanced/REFERENCE.md
@@ -267,7 +267,7 @@ sales: SalesPlatform<MyMeta> = {
 **The buyer gets terminal state two ways:**
 
 1. **Webhook push** — buyer included `push_notification_config: { url, token }` in the original request. Framework signs (RFC 9421) + delivers to that URL with the spec's `mcp-webhook-payload.json` envelope on terminal state. URL is validated server-side: rejects RFC 1918, loopback, link-local, CGNAT, IPv6 unique-local, alternate IPv4 forms, and IPv4-mapped IPv6 before delivery (SSRF guard). Bad URLs FAIL FAST with `INVALID_REQUEST` at the request boundary — buyers see their config error immediately, not as silent webhook drops.
-2. **Polling** — framework auto-registers a `tasks_get` custom tool. Buyers call it with `{ task_id, account }` and receive the spec-flat lifecycle shape (`task_id`, `task_type`, `status`, `created_at`, `updated_at`, `completed_at` on terminal, `result` on completed, top-level `error: { code, message, details? }` on failed). Tenant-scoped — passes `account` through `accounts.resolve(ref, ctx)` and refuses cross-tenant probes with `REFERENCE_NOT_FOUND`. You don't write this tool; it's wired in by the framework. Programmatic access for ops / cron code is via `server.getTaskState(taskId, accountId)`.
+2. **Polling** — framework auto-registers a `tasks_get` custom tool. Buyers call it with `{ task_id, account }` and receive the spec-flat lifecycle shape (`task_id`, `task_type`, `status`, `created_at`, `updated_at`, `completed_at` on terminal, `result` on completed, top-level `error: { code, message, details? }` on failed). Tenant-scoped — passes `account` through `accounts.resolve(ref, ctx)` and refuses cross-tenant probes with `REFERENCE_NOT_FOUND`. You don't write this tool; it's wired in by the framework. Scoped application code uses `server.getTaskState(taskId, { accountId, ownerScope })`; explicitly trusted ops and test code can use `server.getTaskStateUnsafe(taskId)`.
 
 **Sync-only tools that need long-running completion** use `publishStatusChange(...)` for lifecycle updates instead of HITL. The per-tool wire response schemas don't include `Submitted` arms for `update_media_buy`, `build_creative`, `sync_catalogs`, or `get_products` (a spec inconsistency tracked as [adcp#3392](https://github.com/adcontextprotocol/adcp/issues/3392) — the Submitted schemas exist but aren't rolled into each tool's response `oneOf`). Until the spec consolidates, long-running work on those tools publishes status changes (`media_buy` → `active` → `completed`) on the event bus and buyers subscribe. When adcp#3392 lands, the SDK will widen the unified shape to `update_media_buy`, `build_creative`, and `sync_catalogs` — but NOT to `get_products` (see "Proposal generation" below).
 
@@ -528,7 +528,7 @@ Same pattern for stdio + http transports — `authenticate` runs at the transpor
 
 The framework's default in-memory `TaskRegistry` is gated by `NODE_ENV` — refuses to construct outside `{test, development}` unless `ADCP_DECISIONING_ALLOW_INMEMORY_TASKS=1` is explicitly set. Every HITL-eligible production deployment needs a durable task registry so task state survives process restarts and load-balancer failover.
 
-Ship `createPostgresTaskRegistry({ pool, tableName? })`:
+Ship `createPostgresTaskRegistry({ pool, namespace, tableName? })`:
 
 ```ts
 import { Pool } from 'pg';
@@ -540,19 +540,20 @@ import {
 
 const pool = new Pool({ connectionString: process.env.DATABASE_URL });
 
-// Once at boot — idempotent CREATE TABLE IF NOT EXISTS, safe to re-run
-await pool.query(getDecisioningTaskRegistryMigration());
+const taskRegistryNamespace = 'tenant:my-agent';
+// Once at boot — idempotent and safe to re-run with the same namespace
+await pool.query(getDecisioningTaskRegistryMigration({ namespace: taskRegistryNamespace }));
 
 const server = createAdcpServerFromPlatform(platform, {
   name: 'My Ad Network',
   version: '1.0.0',
-  taskRegistry: createPostgresTaskRegistry({ pool }),
+  taskRegistry: createPostgresTaskRegistry({ pool, namespace: taskRegistryNamespace }),
 });
 ```
 
 Cross-instance reads work — process A allocates the task, process B reads the lifecycle for `tasks_get`. Terminal-state idempotency is enforced via SQL `WHERE status = 'submitted'` so concurrent webhook deliveries can't race to overwrite each other. Background-completion tracking (`_registerBackground`) is process-local — promises don't serialize, so production HITL flows that span process boundaries drive completion via webhook → an explicit `complete()` / `fail()` from the receiving process.
 
-Custom backend? Implement the `TaskRegistry` interface (8 methods) for Redis / DynamoDB / Spanner / etc. — the framework awaits each call so all 4 mutators (`create`, `complete`, `fail`, `getTask`) can be storage-backed.
+Custom backend? Implement the scoped `TaskRegistry` interface for Redis / DynamoDB / Spanner / etc. The framework awaits every storage method; apply both `accountId` and `ownerScope` on every read and write, then set `scopeVersion: 1`. Keep the explicitly named unsafe methods limited to trusted administrative and test paths.
 
 **Adopter `*Task` return size cap.** Postgres-backed registries cap `result` / `error` JSONB rows at 4MB. Returns over the cap surface via `onTaskTransition` with `errorCode: 'REGISTRY_WRITE_FAILED'` and skip webhook delivery (registry state is inconsistent, so the framework refuses to push). Offload large payloads to blob storage and return references in the result body instead. The cap protects the DB write path only — adopter code that serializes `result` for logs/metrics MUST impose its own bound.
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -972,6 +972,7 @@ export type {
   BuildCreativeResponse as LegacyBuildCreativeResponse,
   BuildCreativeSuccess as LegacyBuildCreativeSuccess,
   BuildCreativeMultiSuccess as LegacyBuildCreativeMultiSuccess,
+  BuildCreativeVariantSuccess as LegacyBuildCreativeVariantSuccess,
   BuildCreativeError as LegacyBuildCreativeError,
   PreviewCreativeRequest as LegacyPreviewCreativeRequest,
   PreviewCreativeResponse as LegacyPreviewCreativeResponse,
@@ -1390,6 +1391,7 @@ export type {
   LegacyListCreativeFormatsServerPayload,
   LegacyBuildCreativePayload,
   LegacyBuildCreativeMultiPayload,
+  LegacyBuildCreativeVariantPayload,
   LegacyPreviewCreativePayload,
   SyncCreativesPayload,
   SyncCreativesSuccessPayload,
@@ -1833,17 +1835,19 @@ export type {
 } from './utils/signal-discovery-helpers';
 
 // ====== BUILD CREATIVE RETURN BUILDERS ======
-// Typed factories for the four return shapes accepted by the framework
+// Typed factories for the five return shapes accepted by the framework
 // from `build_creative` handlers. `.single` / `.multi` emit bare manifests
 // the framework auto-wraps; `.singleEnveloped` / `.multiEnveloped` emit
 // the shaped envelope when the handler needs to attach `sandbox` /
-// `expires_at` / `preview`. SHAPE-GOTCHAS §5.
+// `expires_at` / `preview`; `.variantEnveloped` preserves multiplicity.
+// SHAPE-GOTCHAS §5.
 export {
   buildCreativeReturn,
   singleBuildCreativeReturn,
   multiBuildCreativeReturn,
   singleEnvelopedBuildCreativeReturn,
   multiEnvelopedBuildCreativeReturn,
+  variantEnvelopedBuildCreativeReturn,
 } from './utils/build-creative-return-builders';
 
 // ====== PREVIEW CREATIVE BUILDERS ======

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -332,6 +332,7 @@ import type {
   ProvidePerformanceFeedbackResponse,
   BuildCreativeSuccess,
   BuildCreativeMultiSuccess,
+  BuildCreativeVariantSuccess,
   BuildCreativeResponse,
   GetCreativeDeliveryResponse,
   ListCreativesResponse,
@@ -708,7 +709,10 @@ export interface AdcpToolMap {
   };
   build_creative: {
     params: z.input<typeof BuildCreativeRequestSchema>;
-    result: ServerPayload<BuildCreativeSuccess> | ServerPayload<BuildCreativeMultiSuccess>;
+    result:
+      | ServerPayload<BuildCreativeSuccess>
+      | ServerPayload<BuildCreativeMultiSuccess>
+      | ServerPayload<BuildCreativeVariantSuccess>;
     response: BuildCreativeResponse;
   };
   preview_creative: {
@@ -4433,6 +4437,11 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
     testController: testControllerBridge,
     responseEnhancer,
   } = config;
+  if (taskRegistry !== undefined && taskRegistry.scopeVersion !== 1) {
+    throw new Error(
+      'createAdcpServer: taskRegistry.scopeVersion must be 1. Migrate custom registries to the account/principal-scoped TaskRegistry signatures before use.'
+    );
+  }
   if (!['auto', 'media-buy', 'all'].includes(mcpToolProfile)) {
     throw new Error(
       `createAdcpServer: mcpToolProfile must be "auto", "media-buy", or "all"; got ${JSON.stringify(mcpToolProfile)}`
@@ -7428,7 +7437,10 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
         if (error) return finalizeProtocolTaskToolResponse('get_task_status', params ?? {}, error);
         let task: TaskRecord | null = null;
         try {
-          task = taskId && taskRegistry !== undefined ? await taskRegistry.getTask(taskId) : null;
+          task =
+            taskId && taskRegistry !== undefined && accountId !== undefined && ownerScope !== undefined
+              ? await taskRegistry.getTask(taskId, { accountId, ownerScope })
+              : null;
         } catch (err) {
           const reason = err instanceof Error ? err.message : String(err);
           logger.error('Task registry read failed during task poll', { tool: 'get_task_status', error: reason });

--- a/src/lib/server/decisioning/decisioning.type-checks.ts
+++ b/src/lib/server/decisioning/decisioning.type-checks.ts
@@ -76,6 +76,7 @@ import {
 import type { ComplyControllerConfig } from '../../testing/comply-controller';
 import type { CanonicalListCreativesResponse } from '../../v2/projection/creative-delivery';
 import type { PostalArea } from '../../types/core.generated';
+import type { BuildCreativeVariantSuccess, TransformerParam } from '../../types/tools.generated';
 import { getAccountMode } from '../account-mode';
 
 // ── AdcpError construction ────────────────────────────────────────────
@@ -1085,8 +1086,30 @@ function _build_creative_return_factories_pin_arm(): void {
   const enveloped = buildCreativeReturn.singleEnveloped({ manifest: m, sandbox: true });
   void bare;
   void enveloped;
+  const variants: BuildCreativeVariantSuccess = {} as BuildCreativeVariantSuccess;
+  const variantEnvelope = buildCreativeReturn.variantEnveloped(variants);
+  void variantEnvelope;
   // @ts-expect-error — `creative_manifest` is the wire field, not the helper input.
   singleEnvelopedBuildCreativeReturn({ creative_manifest: m });
+}
+
+function _transformer_param_accepts_json_values(): void {
+  const param: TransformerParam = {
+    field: 'voice',
+    type: 'string',
+    value_source: 'enumerable',
+    default: null,
+    options: [{ value: ['voice-a', { locale: 'en-GB', weight: 1 }, true, null] }],
+  };
+  void param;
+  const invalid: TransformerParam = {
+    field: 'voice',
+    type: 'string',
+    value_source: 'enumerable',
+    // @ts-expect-error — functions are JavaScript values, not JSON values.
+    default: () => true,
+  };
+  void invalid;
 }
 
 function _media_buy_delivery_notification_factories_inject_discriminator(): void {

--- a/src/lib/server/decisioning/index.ts
+++ b/src/lib/server/decisioning/index.ts
@@ -179,6 +179,7 @@ export type {
   LegacyBuildCreativeReturn,
   LegacyBuildCreativePayload,
   LegacyBuildCreativeMultiPayload,
+  BuildCreativeVariantPayload,
   PreviewCreativePayload,
   LegacyPreviewCreativePayload,
   LegacyListCreativeFormatsPayload,
@@ -195,6 +196,7 @@ export type {
   LegacyBuildCreativeReturn as CreativeAdServerLegacyBuildCreativeReturn,
   LegacyBuildCreativePayload as CreativeAdServerLegacyBuildCreativePayload,
   LegacyBuildCreativeMultiPayload as CreativeAdServerLegacyBuildCreativeMultiPayload,
+  BuildCreativeVariantPayload as CreativeAdServerBuildCreativeVariantPayload,
   PreviewCreativePayload as CreativeAdServerPreviewCreativePayload,
   LegacyPreviewCreativePayload as CreativeAdServerLegacyPreviewCreativePayload,
   LegacyListCreativeFormatsPayload as CreativeAdServerLegacyListCreativeFormatsPayload,
@@ -356,6 +358,7 @@ export { PlatformConfigError, validatePlatform } from './runtime/validate-platfo
 export {
   createInMemoryTaskRegistry,
   type TaskRegistry,
+  type TaskRegistryScope,
   type TaskRecord,
   type TaskStatus,
 } from './runtime/task-registry';

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -105,6 +105,7 @@ import type {
   BrandReference,
   BuildCreativeMultiSuccess,
   BuildCreativeSuccess,
+  BuildCreativeVariantSuccess,
   CreativeManifest,
   GetAdCPCapabilitiesResponse,
   PaymentTerms,
@@ -143,7 +144,14 @@ import { _extractResponseSummaryEntry } from '../response-summary';
 import { productsResponse } from '../../responses';
 import { TOOL_ENTITY_FIELDS } from './entity-hydration.generated';
 import { z } from 'zod';
-import { createInMemoryTaskRegistry, type TaskRegistry, type TaskRecord, type TaskStatus } from './task-registry';
+import {
+  createInMemoryTaskRegistry,
+  taskRecordMatchesScope,
+  type TaskRegistry,
+  type TaskRecord,
+  type TaskRegistryScope,
+  type TaskStatus,
+} from './task-registry';
 import { protocolForTool, SPEC_WEBHOOK_TASK_TYPES } from './protocol-for-tool';
 
 /**
@@ -1967,6 +1975,12 @@ export interface CreateAdcpServerFromPlatformOptions extends Omit<
    */
   taskRegistry?: TaskRegistry;
   /**
+   * Trusted tenant/deployment namespace for the `pool` task-registry shortcut.
+   * Required when `pool` supplies the registry. Use the same value with the
+   * migration helper so legacy rows remain reachable after upgrade.
+   */
+  taskRegistryNamespace?: string;
+  /**
    * Override the framework's status-change event bus for this server.
    * Defaults to a fresh per-server `createInMemoryStatusChangeBus()` so
    * tests get isolation without touching the module-level singleton from
@@ -2090,7 +2104,7 @@ export interface CreateAdcpServerFromPlatformOptions extends Omit<
    * explicitly keep override priority — the explicit values win, and the
    * pool fills only the unset ones.
    *
-   * Run `getAllAdcpMigrations()` once per database to create the three
+   * Run `getAllAdcpMigrations({ taskRegistryNamespace })` once per database to create the three
    * required tables (idempotency cache, ctx-metadata cache, task registry).
    *
    * @example
@@ -2102,12 +2116,14 @@ export interface CreateAdcpServerFromPlatformOptions extends Omit<
    * } from '@adcp/sdk/server';
    *
    * const pool = new Pool({ connectionString: process.env.DATABASE_URL });
-   * await pool.query(getAllAdcpMigrations());
+   * const taskRegistryNamespace = 'tenant:my-agent';
+   * await pool.query(getAllAdcpMigrations({ taskRegistryNamespace }));
    *
    * const server = createAdcpServerFromPlatform(myPlatform, {
    *   name: 'my-agent',
    *   version: '1.0.0',
    *   pool,                                // wires all three persistence stores
+   *   taskRegistryNamespace,
    * });
    * ```
    *
@@ -2329,28 +2345,23 @@ export type RequiredOptsFor<P extends DecisioningPlatform<any, any>> = P extends
 export interface DecisioningAdcpServer extends AdcpServer {
   /**
    * Read the current lifecycle state for a HITL task. Returns `null` if the
-   * `taskId` is unknown OR (when `expectedAccountId` is supplied) the
-   * task's owning account doesn't match.
-   *
-   * **Multi-tenant isolation: pass `expectedAccountId` whenever the caller
-   * has a buyer-derived account in scope.** Adopters wrapping this method
-   * in a `tasks/get` wire handler MUST pass `ctx.account.id` to scope reads
-   * — without it, any caller with a known `task_id` reads any tenant's
-   * task lifecycle, including its `result` and `error` payloads. The
-   * unscoped form (single-arg) is for ops / test harnesses that hold no
-   * buyer account in scope.
+   * `taskId` is unknown or the account/principal scope does not match.
    *
    * Async to accommodate storage-backed task registries
    * (`createPostgresTaskRegistry`); the in-memory impl resolves synchronously.
    */
-  getTaskState<TResult = unknown>(taskId: string, expectedAccountId?: string): Promise<TaskRecord<TResult> | null>;
+  getTaskState<TResult = unknown>(taskId: string, scope: TaskRegistryScope): Promise<TaskRecord<TResult> | null>;
+  /** Administrative/test access; null when task_id is ambiguous across scopes. Never expose to buyer traffic. */
+  getTaskStateUnsafe<TResult = unknown>(taskId: string): Promise<TaskRecord<TResult> | null>;
   /**
    * Await any in-flight background completion for `taskId` (HITL handoff
    * function still running). Resolves immediately if the task is terminal
    * or has no registered background. Used by tests + the `tasks/get` wire
    * path for deterministic settlement.
    */
-  awaitTask(taskId: string): Promise<void>;
+  awaitTask(taskId: string, scope: TaskRegistryScope): Promise<void>;
+  /** Administrative/test wait across all scopes with this task_id. Never expose to buyer traffic. */
+  awaitTaskUnsafe(taskId: string): Promise<void>;
   /**
    * Per-server status-change bus. Delegates to the same internal bus the
    * framework uses for MCP Resources subscription projection.
@@ -2516,13 +2527,27 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
     opts.pool && opts.ctxMetadata === undefined
       ? createCtxMetadataStore({ backend: pgCtxMetadataStore(opts.pool) })
       : undefined;
+  if (opts.pool && opts.taskRegistry === undefined && opts.taskRegistryNamespace === undefined) {
+    throw new PlatformConfigError(
+      'taskRegistryNamespace is required when opts.pool supplies the task registry. ' +
+        'Use the same trusted namespace with getAllAdcpMigrations({ taskRegistryNamespace }) or ' +
+        'getDecisioningTaskRegistryMigration({ namespace }).'
+    );
+  }
   const pooledTaskRegistry: TaskRegistry | undefined =
-    opts.pool && opts.taskRegistry === undefined ? createPostgresTaskRegistry({ pool: opts.pool }) : undefined;
+    opts.pool && opts.taskRegistry === undefined
+      ? createPostgresTaskRegistry({ pool: opts.pool, namespace: opts.taskRegistryNamespace! })
+      : undefined;
 
   // Effective resolved values. Explicit > pooled > default.
   const effectiveIdempotency: IdempotencyStore | 'disabled' | undefined = opts.idempotency ?? pooledIdempotency;
   const effectiveCtxMetadata: CtxMetadataStore | undefined = opts.ctxMetadata ?? pooledCtxMetadata;
   const taskRegistry = opts.taskRegistry ?? pooledTaskRegistry ?? buildDefaultTaskRegistry();
+  if (taskRegistry.scopeVersion !== 1) {
+    throw new PlatformConfigError(
+      'taskRegistry.scopeVersion must be 1. Migrate custom registries to the account/principal-scoped TaskRegistry signatures before use.'
+    );
+  }
   const baseBus = opts.statusChangeBus ?? createInMemoryStatusChangeBus();
   const taskWebhookEmit = opts.taskWebhookEmitter?.emit;
 
@@ -3580,20 +3605,15 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
   return Object.assign(server, {
     getTaskState: async <TResult = unknown>(
       taskId: string,
-      expectedAccountId?: string
+      scope: TaskRegistryScope
     ): Promise<TaskRecord<TResult> | null> => {
-      const record = await taskRegistry.getTask<TResult>(taskId);
-      if (record == null) return null;
-      // Tenant boundary: if caller specified the expected account and the
-      // task's owner doesn't match, treat as not-found. Returning null
-      // here mirrors the "not-found / cross-tenant" envelope and avoids
-      // principal-enumeration via task_id probing.
-      if (expectedAccountId !== undefined && record.accountId !== expectedAccountId) {
-        return null;
-      }
-      return record;
+      const record = await taskRegistry.getTask<TResult>(taskId, scope);
+      return record && taskRecordMatchesScope(record, scope) ? record : null;
     },
-    awaitTask: (taskId: string): Promise<void> => taskRegistry.awaitTask(taskId),
+    getTaskStateUnsafe: <TResult = unknown>(taskId: string): Promise<TaskRecord<TResult> | null> =>
+      taskRegistry._getTaskUnsafe<TResult>(taskId),
+    awaitTask: (taskId: string, scope: TaskRegistryScope): Promise<void> => taskRegistry.awaitTask(taskId, scope),
+    awaitTaskUnsafe: (taskId: string): Promise<void> => taskRegistry._awaitTaskUnsafe(taskId),
     statusChange: statusChangeBus,
   });
 }
@@ -3603,7 +3623,7 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
 // ---------------------------------------------------------------------------
 
 /**
- * Custom tool exposing `taskRegistry.getTask(taskId)` over the wire so
+ * Custom tool exposing a scoped `taskRegistry.getTask(taskId, scope)` over the wire so
  * buyer agents can poll HITL task state. Snake-case `tasks_get` (MCP tool
  * names disallow `/`) approximates the spec's `tasks/get` method.
  *
@@ -3613,13 +3633,10 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
  * handles the protocol-level `tasks/get` natively. Until then, this
  * custom tool is the buyer-facing polling surface.
  *
- * **Tenant scoping.** The tool reads from `taskRegistry.getTask`
- * directly. Adopters with multi-tenant deployments MUST pass `account`
- * in the request so the framework's account-resolution flow scopes the
- * read; the handler then verifies `record.accountId` matches the
- * resolved account before returning the task. Single-tenant agents
- * (`resolution: 'derived'`) get scoping for free via the auth-derived
- * resolver.
+ * **Tenant scoping.** The handler resolves both the trusted account and
+ * authenticated owner scope before the registry read. Postgres-backed
+ * deployments additionally isolate each server/tenant through the registry
+ * namespace configured by `taskRegistryNamespace`.
  */
 function buildTasksGetTool<P extends DecisioningPlatform<any, any>>(
   platform: P,
@@ -3855,9 +3872,27 @@ function buildTasksGetTool<P extends DecisioningPlatform<any, any>>(
         }
       }
 
+      if (resolvedAccountId === undefined) {
+        return adcpError('REFERENCE_NOT_FOUND', {
+          message: `Task ${args.task_id} not found`,
+          field: 'task_id',
+        });
+      }
+      const ownerCtx: HandlerContext<Account> = {
+        store: {} as HandlerContext<Account>['store'],
+        ...(extra?.authInfo !== undefined && { authInfo: extra.authInfo }),
+        ...(agent !== undefined && { agent }),
+        ...(sessionKey !== undefined && { sessionKey }),
+        account: resolvedAccount ?? ({ id: resolvedAccountId } as Account),
+      };
+      const expectedOwnerScope = taskOwnerScopeFor(ownerCtx, resolvedAccountId);
+
       let record;
       try {
-        record = await taskRegistry.getTask(args.task_id);
+        record = await taskRegistry.getTask(args.task_id, {
+          accountId: resolvedAccountId,
+          ownerScope: expectedOwnerScope,
+        });
       } catch (err) {
         logger.error?.('Task registry read failed during tasks_get poll', {
           error: err instanceof Error ? err.message : String(err),
@@ -3870,45 +3905,17 @@ function buildTasksGetTool<P extends DecisioningPlatform<any, any>>(
           field: 'task_id',
         });
       }
-      // Tenant boundary. Two checks to close the auth-derived bypass:
-      //   1. If we resolved an account, the task's owning account must match.
-      //   2. If we did NOT resolve an account but the task IS owned by an
-      //      account, refuse to leak. This catches the unauthenticated /
-      //      `'explicit'`-mode-misconfigured caller that hits the auth-derived
-      //      branch and would otherwise read any task by id.
-      if (resolvedAccountId === undefined && record.accountId) {
+      if (
+        !taskRecordMatchesScope(record, {
+          accountId: resolvedAccountId,
+          ownerScope: expectedOwnerScope,
+        })
+      ) {
         return adcpError('REFERENCE_NOT_FOUND', {
           message: `Task ${args.task_id} not found`,
           field: 'task_id',
         });
       }
-      if (resolvedAccountId !== undefined && record.accountId !== resolvedAccountId) {
-        return adcpError('REFERENCE_NOT_FOUND', {
-          message: `Task ${args.task_id} not found`,
-          field: 'task_id',
-        });
-      }
-      if (resolvedAccountId !== undefined) {
-        const ownerCtx: HandlerContext<Account> = {
-          store: {} as HandlerContext<Account>['store'],
-          ...(extra?.authInfo !== undefined && { authInfo: extra.authInfo }),
-          ...(agent !== undefined && { agent }),
-          ...(sessionKey !== undefined && { sessionKey }),
-          account: resolvedAccount ?? ({ id: resolvedAccountId } as Account),
-        };
-        const expectedOwnerScope = taskOwnerScopeFor(ownerCtx, resolvedAccountId);
-        if (
-          record.ownerScope === undefined
-            ? expectedOwnerScope !== `account:${resolvedAccountId}`
-            : record.ownerScope !== expectedOwnerScope
-        ) {
-          return adcpError('REFERENCE_NOT_FOUND', {
-            message: `Task ${args.task_id} not found`,
-            field: 'task_id',
-          });
-        }
-      }
-
       // Spec shape: `tasks-get-response.json` requires task_id, task_type,
       // status, created_at, updated_at, protocol. Optional: completed_at
       // (terminal states), error (failed tasks — top-level, NOT inside
@@ -4215,11 +4222,13 @@ function wrapBusWithObservability(bus: StatusChangeBus, observability: Decisioni
  *
  * ```ts
  * const pool = new Pool({ connectionString: process.env.DATABASE_URL });
- * await pool.query(getAllAdcpMigrations());
+ * const taskRegistryNamespace = 'tenant:my-agent';
+ * await pool.query(getAllAdcpMigrations({ taskRegistryNamespace }));
  *
  * createAdcpServerFromPlatform(myPlatform, {
  *   name: '...', version: '...',
  *   pool,
+ *   taskRegistryNamespace,
  * });
  * ```
  *
@@ -4229,8 +4238,17 @@ function wrapBusWithObservability(bus: StatusChangeBus, observability: Decisioni
  *
  * @public
  */
-export function getAllAdcpMigrations(): string {
-  return [getIdempotencyMigration(), getCtxMetadataMigration(), getDecisioningTaskRegistryMigration()].join('\n\n');
+export function getAllAdcpMigrations(options: { taskRegistryNamespace: string }): string {
+  if (!options) {
+    throw new PlatformConfigError(
+      'getAllAdcpMigrations requires { taskRegistryNamespace }; use a stable, trusted deployment or tenant namespace.'
+    );
+  }
+  return [
+    getIdempotencyMigration(),
+    getCtxMetadataMigration(),
+    getDecisioningTaskRegistryMigration({ namespace: options.taskRegistryNamespace }),
+  ].join('\n\n');
 }
 
 function buildDefaultTaskRegistry(): TaskRegistry {
@@ -4242,9 +4260,9 @@ function buildDefaultTaskRegistry(): TaskRegistry {
       'createAdcpServerFromPlatform: in-memory task registry refused outside ' +
         '{NODE_ENV=test, NODE_ENV=development}. Production deployments need a ' +
         'durable task registry — pick one of:\n' +
-        '  1. (Recommended) Pass `taskRegistry: createPostgresTaskRegistry({ pool })` ' +
+        '  1. (Recommended) Pass `taskRegistry: createPostgresTaskRegistry({ pool, namespace: tenantId })` ' +
         'to keep HITL tasks across restarts. See `@adcp/sdk/server/decisioning` ' +
-        'for `getDecisioningTaskRegistryMigration()` — run it once against your DB.\n' +
+        'for `getDecisioningTaskRegistryMigration({ namespace })` — run it once against your DB.\n' +
         '  2. Pass `taskRegistry: createInMemoryTaskRegistry()` explicitly if you ' +
         'accept that in-flight tasks are lost on process restart. The explicit ' +
         'pass-in is the contract — saying "yes I want in-memory in production" ' +
@@ -4441,7 +4459,7 @@ async function projectSync<TResult, TWire, TCtxMeta = unknown>(
  * wired `webhooks` on `serve()`, the framework emits a signed RFC 9421
  * webhook to that URL on terminal state with the task lifecycle payload.
  * Buyers don't need to poll — they receive completion via push. Polling via
- * `server.getTaskState(taskId)` continues to work for harnesses + the
+ * `server.getTaskState(taskId, scope)` continues to work for harnesses + the
  * forthcoming wire-level `tasks/get`.
  */
 interface DispatchHitlOpts {
@@ -4569,7 +4587,12 @@ async function routeIfHandoff<TInner, TWire>(
       taskRegistry,
       opts,
       async taskId => {
-        const inner = await taskFn(buildHandoffContext(taskRegistry, taskId));
+        const inner = await taskFn(
+          buildHandoffContext(taskRegistry, taskId, {
+            accountId: opts.accountId,
+            ownerScope: opts.ownerScope ?? `account:${opts.accountId}`,
+          })
+        );
         rejectResponseSummary(inner);
         return await project(inner);
       },
@@ -4637,6 +4660,10 @@ async function dispatchHitl<TResult>(
   // Webhook delivery is gated on the registry write succeeding so the
   // buyer's view (via webhook OR getTaskState) is always consistent.
   const completion: Promise<void> = (async () => {
+    const registryScope = {
+      accountId: opts.accountId,
+      ownerScope: opts.ownerScope ?? `account:${opts.accountId}`,
+    };
     let result: TResult | undefined;
     let taskFnError: unknown;
     try {
@@ -4659,12 +4686,12 @@ async function dispatchHitl<TResult>(
         stripImplementationConfig(result as Record<string, unknown>);
       }
       try {
-        await taskRegistry.complete(taskId, result as TResult);
+        await taskRegistry.complete(taskId, registryScope, result as TResult);
       } catch (registryErr) {
         opts.logger.error(
           `[adcp/decisioning] task ${taskId} (${opts.tool}) completed but registry write failed — ` +
             `manual reconciliation required. Webhook not emitted; buyer state will diverge until resolved. ` +
-            `Error: ${registryErr instanceof Error ? registryErr.message : String(registryErr)}`
+            `Error type: ${registryErr instanceof Error ? 'Error' : typeof registryErr}`
         );
         fireTransition('failed', 'REGISTRY_WRITE_FAILED');
         return;
@@ -4688,12 +4715,12 @@ async function dispatchHitl<TResult>(
     );
     const failureArtifact = { errors: [structured] };
     try {
-      await taskRegistry.fail(taskId, structured, failureArtifact);
+      await taskRegistry.fail(taskId, registryScope, structured, failureArtifact);
     } catch (registryErr) {
       opts.logger.error(
         `[adcp/decisioning] task ${taskId} (${opts.tool}) failed AND registry fail-write also failed — ` +
           `manual reconciliation required. Webhook not emitted. ` +
-          `taskFn error: ${structured.message}; registry error: ${registryErr instanceof Error ? registryErr.message : String(registryErr)}`
+          `Task error code: ${structured.code}; registry error type: ${registryErr instanceof Error ? 'Error' : typeof registryErr}`
       );
       fireTransition('failed', 'REGISTRY_WRITE_FAILED');
       return;
@@ -4703,7 +4730,11 @@ async function dispatchHitl<TResult>(
       task: { task_id: taskId, status: 'failed', result: failureArtifact, error: structured },
     });
   })();
-  taskRegistry._registerBackground(taskId, completion);
+  taskRegistry._registerBackground(
+    taskId,
+    { accountId: opts.accountId, ownerScope: opts.ownerScope ?? `account:${opts.accountId}` },
+    completion
+  );
 
   return { status: 'submitted', task_id: taskId };
 }
@@ -6561,12 +6592,14 @@ function buildMediaBuyHandlers<P extends DecisioningPlatform<any, any>>(
 
 /**
  * Project an adopter `buildCreative` return value into the wire response
- * shape. Handles the four legal adopter shapes per `BuildCreativeReturn`:
+ * shape. Handles the five legal adopter shapes per `BuildCreativeReturn`:
  *
  *   - Already-shaped Single envelope (`creative_manifest` field present) →
  *     passthrough. Adopter set `sandbox` / `expires_at` / `preview` themselves.
  *   - Already-shaped Multi envelope (`creative_manifests` field present) →
  *     passthrough. Same metadata-controlled case for multi-format requests.
+ *   - Already-shaped multiplicity envelope (`creatives` field present) →
+ *     passthrough. Used for best-of-N, variant-axis, and catalog fan-out.
  *   - Bare array → wrap as `{ creative_manifests: <array> }` (multi, no metadata).
  *   - Plain `CreativeManifest` → wrap as `{ creative_manifest: <obj> }`
  *     (single, no metadata).
@@ -6577,8 +6610,11 @@ function buildMediaBuyHandlers<P extends DecisioningPlatform<any, any>>(
  * `{ creative_manifest: { creative_manifest, sandbox: true } }`. Same
  * concern applies symmetrically for Multi.
  */
-function projectBuildCreativeReturn(ret: unknown): BuildCreativeSuccess | BuildCreativeMultiSuccess {
+function projectBuildCreativeReturn(
+  ret: unknown
+): BuildCreativeSuccess | BuildCreativeMultiSuccess | BuildCreativeVariantSuccess {
   if (ret != null && typeof ret === 'object' && !Array.isArray(ret)) {
+    if ('creatives' in ret) return ret as BuildCreativeVariantSuccess;
     if ('creative_manifest' in ret) return ret as BuildCreativeSuccess;
     if ('creative_manifests' in ret) return ret as BuildCreativeMultiSuccess;
   }

--- a/src/lib/server/decisioning/runtime/postgres-task-registry.ts
+++ b/src/lib/server/decisioning/runtime/postgres-task-registry.ts
@@ -5,7 +5,7 @@
  * restart and doesn't share state across instances behind a load balancer —
  * fine for tests and local dev, broken for production HITL paths
  * (`createMediaBuyTask`, `syncCreativesTask`, etc.). Wire this in via
- * `createAdcpServerFromPlatform({ taskRegistry: createPostgresTaskRegistry({ pool }) })`
+ * `createAdcpServerFromPlatform({ taskRegistry: createPostgresTaskRegistry({ pool, namespace }) })`
  * to persist task lifecycle across requests, processes, and crashes.
  *
  * @example
@@ -19,13 +19,14 @@
  *
  * const pool = new Pool({ connectionString: process.env.DATABASE_URL });
  *
- * // Run once at boot — idempotent CREATE TABLE IF NOT EXISTS.
- * await pool.query(getDecisioningTaskRegistryMigration());
+ * const taskRegistryNamespace = 'tenant:my-agent';
+ * // Run once at boot, using the same trusted namespace as the registry.
+ * await pool.query(getDecisioningTaskRegistryMigration({ namespace: taskRegistryNamespace }));
  *
  * const server = createAdcpServerFromPlatform(platform, {
  *   name: 'My Ad Network',
  *   version: '1.0.0',
- *   taskRegistry: createPostgresTaskRegistry({ pool }),
+ *   taskRegistry: createPostgresTaskRegistry({ pool, namespace: taskRegistryNamespace }),
  * });
  * ```
  *
@@ -47,7 +48,7 @@
 
 import { randomUUID } from 'node:crypto';
 import type { AdcpStructuredError, TaskHandoffProgress } from '../async-outcome';
-import type { TaskRecord, TaskRegistry, TaskStatus } from './task-registry';
+import type { TaskRecord, TaskRegistry, TaskRegistryScope, TaskStatus } from './task-registry';
 
 /**
  * Minimal subset of the `pg.Pool` interface used by the registry.
@@ -61,6 +62,8 @@ export interface PgQueryable {
 export interface CreatePostgresTaskRegistryOptions {
   /** A `pg.Pool` instance (or any `PgQueryable`). */
   pool: PgQueryable;
+  /** Trusted deployment/tenant namespace. Use a distinct value per hosted tenant. */
+  namespace: string;
   /**
    * Table name. Defaults to `'adcp_decisioning_tasks'` (vendor-prefixed to
    * avoid collisions with the MCP-level `adcp_mcp_tasks` table from
@@ -78,12 +81,21 @@ const DEFAULT_TABLE = 'adcp_decisioning_tasks';
 
 /** Validates a SQL identifier to prevent injection via table names. */
 const VALID_IDENTIFIER = /^[a-z_][a-z0-9_]*$/;
+const VALID_NAMESPACE = /^[A-Za-z0-9_.:-]{1,255}$/;
 
 function assertValidIdentifier(name: string): void {
-  if (!VALID_IDENTIFIER.test(name)) {
+  if (!VALID_IDENTIFIER.test(name) || Buffer.byteLength(name, 'utf8') > 40) {
     throw new Error(
       `Invalid table name "${name}": must be lowercase letters, digits, ` +
-        `or underscores, starting with a letter or underscore.`
+        `or underscores, starting with a letter or underscore, and at most 40 bytes.`
+    );
+  }
+}
+
+function assertValidNamespace(namespace: unknown): asserts namespace is string {
+  if (typeof namespace !== 'string' || !VALID_NAMESPACE.test(namespace)) {
+    throw new Error(
+      'Invalid registry namespace: namespace is required and must be 1-255 ASCII letters, digits, dots, underscores, colons, or hyphens.'
     );
   }
 }
@@ -141,19 +153,22 @@ function safeStringify(value: unknown, taskId: string): string {
  * @example
  * ```typescript
  * import { getDecisioningTaskRegistryMigration } from '@adcp/sdk/server/decisioning';
- * await pool.query(getDecisioningTaskRegistryMigration());
- * await pool.query(getDecisioningTaskRegistryMigration({ tableName: 'my_tasks' }));
+ * await pool.query(getDecisioningTaskRegistryMigration({ namespace: tenantId }));
+ * await pool.query(getDecisioningTaskRegistryMigration({ tableName: 'my_tasks', namespace: tenantId }));
  * ```
  */
-export function getDecisioningTaskRegistryMigration(options?: { tableName?: string }): string {
+export function getDecisioningTaskRegistryMigration(options: { tableName?: string; namespace: string }): string {
+  assertValidNamespace(options?.namespace);
   const table = options?.tableName ?? DEFAULT_TABLE;
   assertValidIdentifier(table);
+  const namespace = options.namespace;
   return `
 CREATE TABLE IF NOT EXISTS ${table} (
-  task_id         TEXT PRIMARY KEY,
+  registry_namespace TEXT NOT NULL DEFAULT '${namespace}',
+  task_id         TEXT NOT NULL,
   tool            TEXT NOT NULL,
   account_id      TEXT NOT NULL,
-  owner_scope     TEXT,
+  owner_scope     TEXT NOT NULL,
   status          TEXT NOT NULL DEFAULT 'submitted',
   status_message  TEXT,
   result          JSONB,
@@ -183,6 +198,45 @@ CREATE INDEX IF NOT EXISTS idx_${table}_status_created
 
 ALTER TABLE ${table}
   ADD COLUMN IF NOT EXISTS owner_scope TEXT;
+
+ALTER TABLE ${table}
+  ADD COLUMN IF NOT EXISTS registry_namespace TEXT NOT NULL DEFAULT '__adcp_legacy_unscoped__';
+
+UPDATE ${table}
+  SET registry_namespace = '${namespace}'
+  WHERE registry_namespace = '__adcp_legacy_unscoped__';
+
+ALTER TABLE ${table}
+  ALTER COLUMN registry_namespace SET DEFAULT '${namespace}';
+
+UPDATE ${table}
+  SET owner_scope = 'account:' || account_id
+  WHERE owner_scope IS NULL;
+
+ALTER TABLE ${table}
+  ALTER COLUMN owner_scope SET NOT NULL;
+
+DO $$
+DECLARE
+  current_primary_key TEXT;
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtext('adcp-task-registry:${table}'));
+  SELECT conname INTO current_primary_key
+    FROM pg_constraint
+    WHERE conrelid = '${table}'::regclass AND contype = 'p';
+  IF current_primary_key IS NOT NULL AND current_primary_key <> '${table}_scope_pkey' THEN
+    EXECUTE format('ALTER TABLE %I DROP CONSTRAINT %I', '${table}', current_primary_key);
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = '${table}_scope_pkey'
+      AND conrelid = '${table}'::regclass
+  ) THEN
+    ALTER TABLE ${table}
+      ADD CONSTRAINT ${table}_scope_pkey
+      PRIMARY KEY (registry_namespace, account_id, owner_scope, task_id);
+  END IF;
+END $$;
 
 CREATE INDEX IF NOT EXISTS idx_${table}_owner_account
   ON ${table}(owner_scope, account_id);
@@ -229,25 +283,17 @@ function rowToRecord<TResult>(row: DbTaskRow): TaskRecord<TResult> {
  * is enforced via SQL `WHERE status = 'submitted'` predicates so concurrent
  * webhook deliveries can't race to overwrite each other.
  *
- * **Multi-tenant deployments — accountId namespacing.** When sharing a
- * single Postgres registry across tenants in a `TenantRegistry`
- * deployment (one table for all tenants), prefix `account_id` per-tenant
- * to prevent cross-tenant collisions. If tenant A and tenant B both
- * resolve a buyer to literal `account_id: 'acme'`, their tasks land in
- * the same row keyspace and `tasks_get` can't distinguish ownership
- * by `account_id` alone (the tenant boundary upstream IS protected by
- * `accounts.resolve(ref, ctx)` returning each tenant's own Account, but
- * the registry sees the same `acme` string in both rows). Recommended
- * pattern: adopters' `accounts.resolve` returns
- * `id: \`tenant_${tenantId}_${accountId}\`` so the table-level keys
- * stay distinct. Alternative: separate `tableName` per tenant, one
- * `createPostgresTaskRegistry({ pool, tableName })` per `TenantRegistry`
- * tenant — heavier ops, stronger isolation.
+ * **Multi-tenant deployments.** `namespace` is a trusted deployment/tenant
+ * partition and participates in every query plus the primary key. Construct
+ * one registry per tenant with a stable unique namespace; never derive it
+ * from buyer request parameters. Tenants may safely share the same table.
  */
 export function createPostgresTaskRegistry(opts: CreatePostgresTaskRegistryOptions): TaskRegistry {
   const table = opts.tableName ?? DEFAULT_TABLE;
   assertValidIdentifier(table);
   const pool = opts.pool;
+  const namespace = opts.namespace;
+  assertValidNamespace(namespace);
 
   // Process-local background tracking — see file header note. Promises
   // can't be persisted; cross-instance HITL completion happens via
@@ -255,6 +301,7 @@ export function createPostgresTaskRegistry(opts: CreatePostgresTaskRegistryOptio
   const backgrounds = new Map<string, Promise<void>>();
 
   return {
+    scopeVersion: 1,
     async create(createOpts: {
       tool: string;
       accountId: string;
@@ -264,13 +311,14 @@ export function createPostgresTaskRegistry(opts: CreatePostgresTaskRegistryOptio
     }): Promise<{ taskId: string }> {
       const taskId = createOpts.overrideTaskId ?? `task_${randomUUID()}`;
       const result = await pool.query(
-        `INSERT INTO ${table} (task_id, tool, account_id, owner_scope, status, has_webhook) VALUES ($1, $2, $3, $4, 'submitted', $5) ON CONFLICT (task_id) DO NOTHING`,
+        `INSERT INTO ${table} (task_id, tool, account_id, owner_scope, status, has_webhook, registry_namespace) VALUES ($1, $2, $3, $4, 'submitted', $5, $6) ON CONFLICT (registry_namespace, account_id, owner_scope, task_id) DO NOTHING`,
         [
           taskId,
           createOpts.tool,
           createOpts.accountId,
           createOpts.ownerScope ?? `account:${createOpts.accountId}`,
           createOpts.hasWebhook === true,
+          namespace,
         ]
       );
       if ((result.rowCount ?? 0) === 0) {
@@ -279,79 +327,99 @@ export function createPostgresTaskRegistry(opts: CreatePostgresTaskRegistryOptio
       return { taskId };
     },
 
-    async getTask<TResult = unknown>(taskId: string): Promise<TaskRecord<TResult> | null> {
+    async getTask<TResult = unknown>(taskId: string, scope: TaskRegistryScope): Promise<TaskRecord<TResult> | null> {
       const { rows } = await pool.query(
         `SELECT task_id, tool, account_id, owner_scope, status, status_message, result, error, progress, has_webhook, created_at, updated_at
-         FROM ${table} WHERE task_id = $1`,
-        [taskId]
+         FROM ${table} WHERE task_id = $1 AND registry_namespace = $2 AND account_id = $3 AND owner_scope = $4`,
+        [taskId, namespace, scope.accountId, scope.ownerScope]
       );
       if (rows.length === 0) return null;
       return rowToRecord<TResult>(rows[0] as unknown as DbTaskRow);
     },
 
-    async list(listOpts: { accountId: string; ownerScope?: string }): Promise<{ tasks: TaskRecord[] }> {
-      if (listOpts.ownerScope === undefined) return { tasks: [] };
+    async _getTaskUnsafe<TResult = unknown>(taskId: string): Promise<TaskRecord<TResult> | null> {
+      const { rows } = await pool.query(
+        `SELECT task_id, tool, account_id, owner_scope, status, status_message, result, error, progress, has_webhook, created_at, updated_at
+         FROM ${table} WHERE task_id = $1 AND registry_namespace = $2 LIMIT 2`,
+        [taskId, namespace]
+      );
+      if (rows.length !== 1) return null;
+      return rowToRecord<TResult>(rows[0] as unknown as DbTaskRow);
+    },
+
+    async list(listOpts: { accountId: string; ownerScope: string }): Promise<{ tasks: TaskRecord[] }> {
       const { rows } = await pool.query(
         `SELECT task_id, tool, account_id, owner_scope, status, status_message, result, error, progress, has_webhook, created_at, updated_at
          FROM ${table}
-         WHERE account_id = $1 AND (owner_scope = $2 OR (owner_scope IS NULL AND $2 = $3))
+         WHERE registry_namespace = $1 AND account_id = $2 AND owner_scope = $3
          ORDER BY created_at DESC, task_id DESC`,
-        [listOpts.accountId, listOpts.ownerScope, `account:${listOpts.accountId}`]
+        [namespace, listOpts.accountId, listOpts.ownerScope]
       );
       return { tasks: rows.map(row => rowToRecord(row as unknown as DbTaskRow)) };
     },
 
-    async complete<TResult>(taskId: string, result: TResult): Promise<void> {
+    async complete<TResult>(taskId: string, scope: TaskRegistryScope, result: TResult): Promise<void> {
       const json = safeStringify(result, taskId);
       assertResultSize(json, taskId);
       await pool.query(
         `UPDATE ${table}
-         SET status = 'completed', result = $2::jsonb, updated_at = NOW()
-         WHERE task_id = $1 AND status NOT IN ('completed', 'failed', 'rejected', 'canceled')`,
-        [taskId, json]
+         SET status = 'completed', result = $5::jsonb, updated_at = NOW()
+         WHERE task_id = $1 AND registry_namespace = $2 AND account_id = $3 AND owner_scope = $4
+           AND status NOT IN ('completed', 'failed', 'rejected', 'canceled')`,
+        [taskId, namespace, scope.accountId, scope.ownerScope, json]
       );
     },
 
-    async fail(taskId: string, error: AdcpStructuredError, result?: unknown): Promise<void> {
+    async fail(taskId: string, scope: TaskRegistryScope, error: AdcpStructuredError, result?: unknown): Promise<void> {
       const errorJson = safeStringify(error, taskId);
       const resultJson = result === undefined ? undefined : safeStringify(result, taskId);
       assertResultSize(errorJson, taskId);
       if (resultJson !== undefined) assertResultSize(resultJson, taskId);
       await pool.query(
         `UPDATE ${table}
-         SET status = 'failed', error = $2::jsonb, result = $3::jsonb, status_message = $4, updated_at = NOW()
-         WHERE task_id = $1 AND status NOT IN ('completed', 'failed', 'rejected', 'canceled')`,
-        [taskId, errorJson, resultJson ?? null, error.message]
+         SET status = 'failed', error = $5::jsonb, result = $6::jsonb, status_message = $7, updated_at = NOW()
+         WHERE task_id = $1 AND registry_namespace = $2 AND account_id = $3 AND owner_scope = $4
+           AND status NOT IN ('completed', 'failed', 'rejected', 'canceled')`,
+        [taskId, namespace, scope.accountId, scope.ownerScope, errorJson, resultJson ?? null, error.message]
       );
     },
 
-    async updateProgress(taskId: string, progress: TaskHandoffProgress): Promise<void> {
+    async updateProgress(taskId: string, scope: TaskRegistryScope, progress: TaskHandoffProgress): Promise<void> {
       const json = safeStringify(progress, taskId);
       await pool.query(
         `UPDATE ${table}
-         SET progress = $2::jsonb,
+         SET progress = $5::jsonb,
              status = CASE WHEN status = 'submitted' THEN 'working' ELSE status END,
              updated_at = NOW()
-         WHERE task_id = $1 AND status NOT IN ('completed', 'failed', 'rejected', 'canceled')`,
-        [taskId, json]
+         WHERE task_id = $1 AND registry_namespace = $2 AND account_id = $3 AND owner_scope = $4
+           AND status NOT IN ('completed', 'failed', 'rejected', 'canceled')`,
+        [taskId, namespace, scope.accountId, scope.ownerScope, json]
       );
     },
 
-    _registerBackground(taskId: string, completion: Promise<void>): void {
+    _registerBackground(taskId: string, scope: TaskRegistryScope, completion: Promise<void>): void {
+      const backgroundKey = JSON.stringify([scope.accountId, scope.ownerScope, taskId]);
       const composed: Promise<void> = completion.then(
         () => {
-          if (backgrounds.get(taskId) === composed) backgrounds.delete(taskId);
+          if (backgrounds.get(backgroundKey) === composed) backgrounds.delete(backgroundKey);
         },
         () => {
-          if (backgrounds.get(taskId) === composed) backgrounds.delete(taskId);
+          if (backgrounds.get(backgroundKey) === composed) backgrounds.delete(backgroundKey);
         }
       );
-      backgrounds.set(taskId, composed);
+      backgrounds.set(backgroundKey, composed);
     },
 
-    async awaitTask(taskId: string): Promise<void> {
-      const pending = backgrounds.get(taskId);
+    async awaitTask(taskId: string, scope: TaskRegistryScope): Promise<void> {
+      const pending = backgrounds.get(JSON.stringify([scope.accountId, scope.ownerScope, taskId]));
       if (pending) await pending;
+    },
+
+    async _awaitTaskUnsafe(taskId: string): Promise<void> {
+      const pending = Array.from(backgrounds.entries())
+        .filter(([key]) => (JSON.parse(key) as [string, string, string])[2] === taskId)
+        .map(([, completion]) => completion);
+      await Promise.all(pending);
     },
   } satisfies TaskRegistry;
 }

--- a/src/lib/server/decisioning/runtime/task-registry.ts
+++ b/src/lib/server/decisioning/runtime/task-registry.ts
@@ -10,7 +10,7 @@
  *      state (`complete` / `fail`) from the method's return/throw.
  *
  * Adopters never call into the registry directly. Wire-level `tasks/get`
- * integration (so buyers can poll the lifecycle) reads via `getTask`;
+ * integration (so buyers can poll the lifecycle) reads via scoped `getTask`;
  * test harnesses use `awaitTask` to flush the background promise
  * deterministically.
  *
@@ -84,14 +84,27 @@ export interface TaskRecord<TResult = unknown, TError extends AdcpStructuredErro
 
 export interface TaskRegistryListOptions {
   accountId: string;
-  /**
-   * Caller ownership scope derived from buyer agent, credential, session,
-   * or the single-principal account fallback. Optional for source
-   * compatibility with older custom registries, but buyer-visible protocol
-   * task tools pass it whenever they can identify a caller and built-in
-   * registries fail closed when it is absent.
-   */
-  ownerScope?: string;
+  /** Caller ownership scope derived from authenticated server context. */
+  ownerScope: string;
+}
+
+/** Account/principal boundary required for buyer-visible task access. */
+export interface TaskRegistryScope {
+  accountId: string;
+  ownerScope: string;
+}
+
+/** Defense-in-depth boundary check for custom registry results. */
+export function taskRecordMatchesScope(record: TaskRecord, scope: TaskRegistryScope): boolean {
+  if (record.accountId !== scope.accountId) return false;
+  return (
+    record.ownerScope === scope.ownerScope ||
+    (record.ownerScope === undefined && scope.ownerScope === `account:${scope.accountId}`)
+  );
+}
+
+function taskStorageKey(taskId: string, scope: TaskRegistryScope): string {
+  return JSON.stringify([scope.accountId, scope.ownerScope, taskId]);
 }
 
 export interface TaskRegistryListResult<TResult = unknown> {
@@ -103,6 +116,9 @@ export interface TaskRegistryListResult<TResult = unknown> {
 // resolves immediately. The framework `await`s every call, so the
 // in-memory case pays one microtask per dispatch — negligible.
 export interface TaskRegistry {
+  /** Confirms that lifecycle methods use the account/principal-scoped v1 signatures. */
+  readonly scopeVersion: 1;
+
   /**
    * Allocate a new task record. Returns the `taskId` the framework hands
    * to `platform.xxxTask(taskId, ...)`. Initial status is `submitted`.
@@ -112,7 +128,8 @@ export interface TaskRegistry {
    *
    * `overrideTaskId` — when set, the registry uses this exact string as the
    * task id instead of minting a fresh one. Throws if the id is already
-   * registered (uniqueness is the caller's responsibility).
+   * registered in the same account/principal scope (uniqueness within that
+   * scope is the caller's responsibility).
    */
   create(opts: {
     tool: string;
@@ -122,8 +139,11 @@ export interface TaskRegistry {
     overrideTaskId?: string;
   }): Promise<{ taskId: string }>;
 
-  /** Read a task by id. Returns `null` if unknown. */
-  getTask<TResult = unknown>(taskId: string): Promise<TaskRecord<TResult> | null>;
+  /** Read a task within its account/principal boundary. */
+  getTask<TResult = unknown>(taskId: string, scope: TaskRegistryScope): Promise<TaskRecord<TResult> | null>;
+
+  /** Administrative/test access; returns null when an id is ambiguous across scopes. Never expose to buyer traffic. */
+  _getTaskUnsafe<TResult = unknown>(taskId: string): Promise<TaskRecord<TResult> | null>;
 
   /**
    * List tasks owned by a resolved account. Buyer-facing AdCP task
@@ -143,13 +163,13 @@ export interface TaskRegistry {
    * Mark a task `completed` with the method's return value. No-op if the
    * task is already terminal (idempotent).
    */
-  complete<TResult>(taskId: string, result: TResult): Promise<void>;
+  complete<TResult>(taskId: string, scope: TaskRegistryScope, result: TResult): Promise<void>;
 
   /**
    * Mark a task `failed` with the structured error and, when available, the
    * canonical terminal artifact. No-op if the task is already terminal.
    */
-  fail(taskId: string, error: AdcpStructuredError, result?: unknown): Promise<void>;
+  fail(taskId: string, scope: TaskRegistryScope, error: AdcpStructuredError, result?: unknown): Promise<void>;
 
   /**
    * Record intermediate progress from `TaskHandoffContext.update(...)`.
@@ -157,23 +177,24 @@ export interface TaskRegistry {
    * call. No-op on already-terminal tasks. The `progress` payload is
    * written to the record and surfaced to buyers polling `tasks_get`.
    */
-  updateProgress(taskId: string, progress: TaskHandoffProgress): Promise<void>;
+  updateProgress(taskId: string, scope: TaskRegistryScope, progress: TaskHandoffProgress): Promise<void>;
 
   /**
    * Register the background completion promise the framework spawned for
    * the `*Task` invocation. Tests await this for deterministic settlement;
    * production callers don't need it.
-   *
-   * @internal
    */
-  _registerBackground(taskId: string, completion: Promise<void>): void;
+  _registerBackground(taskId: string, scope: TaskRegistryScope, completion: Promise<void>): void;
 
   /**
    * Await any registered background completion for a task. Resolves
    * immediately if no background is registered or it has already settled.
    * Used by test harnesses + `tasks/get` integration.
    */
-  awaitTask(taskId: string): Promise<void>;
+  awaitTask(taskId: string, scope: TaskRegistryScope): Promise<void>;
+
+  /** Administrative/test wait across every scope sharing this public task id. Never expose to buyer traffic. */
+  _awaitTaskUnsafe(taskId: string): Promise<void>;
 
   /**
    * Optional test-harness flush. In-memory registries expose this so
@@ -189,6 +210,7 @@ export function createInMemoryTaskRegistry(): TaskRegistry {
   const backgrounds = new Map<string, Promise<void>>();
 
   return {
+    scopeVersion: 1,
     async create(opts: {
       tool: string;
       accountId: string;
@@ -197,11 +219,13 @@ export function createInMemoryTaskRegistry(): TaskRegistry {
       overrideTaskId?: string;
     }): Promise<{ taskId: string }> {
       const taskId = opts.overrideTaskId ?? `task_${randomUUID()}`;
-      if (tasks.has(taskId)) {
+      const scope = { accountId: opts.accountId, ownerScope: opts.ownerScope ?? `account:${opts.accountId}` };
+      const storageKey = taskStorageKey(taskId, scope);
+      if (tasks.has(storageKey)) {
         throw new Error(`task_id already registered: ${taskId}`);
       }
       const now = new Date().toISOString();
-      tasks.set(taskId, {
+      tasks.set(storageKey, {
         taskId,
         tool: opts.tool,
         accountId: opts.accountId,
@@ -214,25 +238,26 @@ export function createInMemoryTaskRegistry(): TaskRegistry {
       return { taskId };
     },
 
-    async getTask<TResult = unknown>(taskId: string): Promise<TaskRecord<TResult> | null> {
-      const record = tasks.get(taskId);
+    async getTask<TResult = unknown>(taskId: string, scope: TaskRegistryScope): Promise<TaskRecord<TResult> | null> {
+      const record = tasks.get(taskStorageKey(taskId, scope));
       return (record as TaskRecord<TResult> | undefined) ?? null;
     },
 
+    async _getTaskUnsafe<TResult = unknown>(taskId: string): Promise<TaskRecord<TResult> | null> {
+      const matches = Array.from(tasks.values()).filter(record => record.taskId === taskId);
+      return matches.length === 1 ? (matches[0] as TaskRecord<TResult>) : null;
+    },
+
     async list(opts: TaskRegistryListOptions): Promise<TaskRegistryListResult> {
-      if (opts.ownerScope === undefined) return { tasks: [] };
       return {
         tasks: Array.from(tasks.values()).filter(
-          record =>
-            record.accountId === opts.accountId &&
-            (record.ownerScope === opts.ownerScope ||
-              (record.ownerScope === undefined && opts.ownerScope === `account:${opts.accountId}`))
+          record => record.accountId === opts.accountId && record.ownerScope === opts.ownerScope
         ),
       };
     },
 
-    async complete<TResult>(taskId: string, result: TResult): Promise<void> {
-      const existing = tasks.get(taskId);
+    async complete<TResult>(taskId: string, scope: TaskRegistryScope, result: TResult): Promise<void> {
+      const existing = tasks.get(taskStorageKey(taskId, scope));
       if (!existing) return;
       if (isTerminalTaskStatus(existing.status)) return;
       existing.status = 'completed';
@@ -240,8 +265,8 @@ export function createInMemoryTaskRegistry(): TaskRegistry {
       existing.updatedAt = new Date().toISOString();
     },
 
-    async fail(taskId: string, error: AdcpStructuredError, result?: unknown): Promise<void> {
-      const existing = tasks.get(taskId);
+    async fail(taskId: string, scope: TaskRegistryScope, error: AdcpStructuredError, result?: unknown): Promise<void> {
+      const existing = tasks.get(taskStorageKey(taskId, scope));
       if (!existing) return;
       if (isTerminalTaskStatus(existing.status)) return;
       existing.status = 'failed';
@@ -251,8 +276,8 @@ export function createInMemoryTaskRegistry(): TaskRegistry {
       existing.updatedAt = new Date().toISOString();
     },
 
-    async updateProgress(taskId: string, progress: TaskHandoffProgress): Promise<void> {
-      const existing = tasks.get(taskId);
+    async updateProgress(taskId: string, scope: TaskRegistryScope, progress: TaskHandoffProgress): Promise<void> {
+      const existing = tasks.get(taskStorageKey(taskId, scope));
       if (!existing) return;
       if (isTerminalTaskStatus(existing.status)) return;
       if (existing.status === 'submitted') existing.status = 'working';
@@ -260,21 +285,29 @@ export function createInMemoryTaskRegistry(): TaskRegistry {
       existing.updatedAt = new Date().toISOString();
     },
 
-    _registerBackground(taskId: string, completion: Promise<void>): void {
+    _registerBackground(taskId: string, scope: TaskRegistryScope, completion: Promise<void>): void {
+      const storageKey = taskStorageKey(taskId, scope);
       const composed: Promise<void> = completion.then(
         () => {
-          if (backgrounds.get(taskId) === composed) backgrounds.delete(taskId);
+          if (backgrounds.get(storageKey) === composed) backgrounds.delete(storageKey);
         },
         () => {
-          if (backgrounds.get(taskId) === composed) backgrounds.delete(taskId);
+          if (backgrounds.get(storageKey) === composed) backgrounds.delete(storageKey);
         }
       );
-      backgrounds.set(taskId, composed);
+      backgrounds.set(storageKey, composed);
     },
 
-    async awaitTask(taskId: string): Promise<void> {
-      const pending = backgrounds.get(taskId);
+    async awaitTask(taskId: string, scope: TaskRegistryScope): Promise<void> {
+      const pending = backgrounds.get(taskStorageKey(taskId, scope));
       if (pending) await pending;
+    },
+
+    async _awaitTaskUnsafe(taskId: string): Promise<void> {
+      const pending = Array.from(backgrounds.entries())
+        .filter(([key]) => (JSON.parse(key) as [string, string, string])[2] === taskId)
+        .map(([, completion]) => completion);
+      await Promise.all(pending);
     },
 
     clear(): void {

--- a/src/lib/server/decisioning/runtime/to-context.ts
+++ b/src/lib/server/decisioning/runtime/to-context.ts
@@ -30,7 +30,7 @@
 import type { HandlerContext } from '../../create-adcp-server';
 import type { Account } from '../account';
 import type { RequestContext, CtxMetadataAccessor } from '../context';
-import type { TaskRegistry } from './task-registry';
+import type { TaskRegistry, TaskRegistryScope } from './task-registry';
 import {
   _createTaskHandoff,
   type TaskHandoffContext,
@@ -184,12 +184,16 @@ export function buildRequestContext<TCtxMeta = Record<string, unknown>>(
  * `heartbeat()` remains a no-op stub (v6.1); it is a liveness / TTL-reset
  * signal for operator infrastructure, not buyer-facing.
  */
-export function buildHandoffContext(taskRegistry: TaskRegistry, taskId: string): TaskHandoffContext {
+export function buildHandoffContext(
+  taskRegistry: TaskRegistry,
+  taskId: string,
+  scope: TaskRegistryScope
+): TaskHandoffContext {
   return {
     id: taskId,
     update: async progress => {
       try {
-        await taskRegistry.updateProgress(taskId, progress);
+        await taskRegistry.updateProgress(taskId, scope, progress);
       } catch {
         // Swallow — a transient registry write failure must not abort the
         // adopter's background handoff function. The buyer-facing impact is

--- a/src/lib/server/decisioning/specialisms/creative-ad-server.ts
+++ b/src/lib/server/decisioning/specialisms/creative-ad-server.ts
@@ -41,6 +41,7 @@ import type {
   GetCreativeDeliveryResponse,
   BuildCreativeSuccess,
   BuildCreativeMultiSuccess,
+  BuildCreativeVariantSuccess,
 } from '../../../types/tools.generated';
 import type {
   CanonicalSyncCreativeAsset,
@@ -63,11 +64,13 @@ export type GetCreativeDeliveryPayload = ServerPayload<CanonicalCreativeResponse
 export type LegacyGetCreativeDeliveryPayload = ServerPayload<GetCreativeDeliveryResponse>;
 export type LegacyBuildCreativePayload = ServerPayload<BuildCreativeSuccess>;
 export type LegacyBuildCreativeMultiPayload = ServerPayload<BuildCreativeMultiSuccess>;
+export type BuildCreativeVariantPayload = ServerPayload<BuildCreativeVariantSuccess>;
 export type LegacyBuildCreativeReturn =
   | CreativeManifest
   | CreativeManifest[]
   | LegacyBuildCreativePayload
-  | LegacyBuildCreativeMultiPayload;
+  | LegacyBuildCreativeMultiPayload
+  | BuildCreativeVariantPayload;
 
 interface CreativeAdServerPlatformBase<TCtxMeta> {
   /**

--- a/src/lib/server/decisioning/specialisms/creative.ts
+++ b/src/lib/server/decisioning/specialisms/creative.ts
@@ -24,6 +24,7 @@ import type {
   BuildCreativeRequest,
   BuildCreativeSuccess,
   BuildCreativeMultiSuccess,
+  BuildCreativeVariantSuccess,
   PreviewCreativeRequest as LegacyPreviewCreativeRequest,
   PreviewCreativeResponse as LegacyPreviewCreativeResponse,
   ListCreativeFormatsRequest,
@@ -41,6 +42,7 @@ type Ctx<TCtxMeta> = RequestContext<Account<TCtxMeta>>;
 
 export type LegacyBuildCreativePayload = ServerPayload<BuildCreativeSuccess>;
 export type LegacyBuildCreativeMultiPayload = ServerPayload<BuildCreativeMultiSuccess>;
+export type BuildCreativeVariantPayload = ServerPayload<BuildCreativeVariantSuccess>;
 export type PreviewCreativePayload = ServerPayload<CanonicalPreviewCreativeResponse>;
 export type LegacyPreviewCreativePayload = ServerPayload<LegacyPreviewCreativeResponse>;
 export type LegacyListCreativeFormatsPayload = ServerPayload<ListCreativeFormatsResponse>;
@@ -58,11 +60,11 @@ export type LegacyListCreativeFormatsPayload = ServerPayload<ListCreativeFormats
  *     `CreativeManifest[]`. Framework wraps as
  *     `{ creative_manifests: [...] }`. Use this for multi-format
  *     requests (`target_format_ids`) when you don't need rich metadata.
- *   - **Fully-shaped envelope**: return a `BuildCreativePayload` (single)
- *     or `BuildCreativeMultiPayload` (multi) with `sandbox` /
- *     `expires_at` / `preview` populated. Framework passes through
- *     unchanged. Detected by the presence of `creative_manifest` (single
- *     envelope) or `creative_manifests` (multi envelope) at the top level.
+ *   - **Fully-shaped envelope**: return a `BuildCreativePayload` (single),
+ *     `BuildCreativeMultiPayload` (multi), or `BuildCreativeVariantPayload`
+ *     (multiplicity) with any response metadata populated. Framework passes
+ *     it through unchanged. Detected by `creative_manifest`,
+ *     `creative_manifests`, or `creatives` at the top level.
  *
  * Adopters route on `req.target_format_ids` (multi) vs `req.target_format_id`
  * (single) and return the matching arm. Returning a `CreativeManifest[]`
@@ -74,7 +76,8 @@ export type LegacyBuildCreativeReturn =
   | CreativeManifest
   | CreativeManifest[]
   | LegacyBuildCreativePayload
-  | LegacyBuildCreativeMultiPayload;
+  | LegacyBuildCreativeMultiPayload
+  | BuildCreativeVariantPayload;
 
 // Re-export SyncCreativesRow so creative-specialism adopters don't need to
 // reach into the sales module to import the shared row type.
@@ -125,9 +128,8 @@ export interface CreativeBuilderPlatform<TCtxMeta = Record<string, unknown>> {
    *
    * Return shape is discriminated; see {@link BuildCreativeReturn}:
    * single `CreativeManifest`, `CreativeManifest[]` for multi-format
-   * requests, OR a fully-shaped `BuildCreativePayload` /
-   * `BuildCreativeMultiPayload` payload when you need to set
-   * `sandbox` / `expires_at` / `preview`.
+   * requests, OR a fully-shaped `BuildCreativePayload`,
+   * `BuildCreativeMultiPayload`, or `BuildCreativeVariantPayload` response.
    */
   buildCreativeLegacy(req: BuildCreativeRequest, ctx: Ctx<TCtxMeta>): Promise<LegacyBuildCreativeReturn>;
 

--- a/src/lib/server/index.ts
+++ b/src/lib/server/index.ts
@@ -48,6 +48,7 @@ export type {
   AcquireRightsRejectedPayload as LegacyAcquireRightsRejectedPayload,
   BuildCreativeMultiPayload as LegacyBuildCreativeMultiPayload,
   BuildCreativePayload as LegacyBuildCreativePayload,
+  BuildCreativeVariantPayload as LegacyBuildCreativeVariantPayload,
   CalibrateContentPayload as LegacyCalibrateContentPayload,
   CheckGovernancePayload,
   CreateCollectionListPayload,

--- a/src/lib/testing/storyboard/index.ts
+++ b/src/lib/testing/storyboard/index.ts
@@ -97,6 +97,7 @@ export type { AssertionSpec, AssertionContext, RegisterAssertionOptions } from '
 export { createWebhookReceiver } from './webhook-receiver';
 export type {
   CapturedWebhook,
+  CapturedWebhookChallenge,
   CreateWebhookReceiverOptions,
   RetryReplayPolicy,
   WebhookFilter,

--- a/src/lib/testing/storyboard/request-builder.ts
+++ b/src/lib/testing/storyboard/request-builder.ts
@@ -75,6 +75,7 @@ const FALLBACK_CALLER_AGENT_URL = 'https://e2e-orchestrator.adcontextprotocol.or
 const FIXTURE_AWARE_ENRICHERS = new Set<string>([
   'create_media_buy', // merges discovery-derived product_id / pricing_option_id INTO fixture packages[0]
   'comply_test_controller', // forces account.sandbox: true regardless of fixture
+  'check_governance', // preserves the authored intent-vs-delivery request shape
   'get_products', // preserves wholesale fixture fields while keeping resolved account scope authoritative
   'update_media_buy', // resolves account via resolveAccount(options) so sandbox routing matches create_media_buy
   'get_media_buys', // resolves account via resolveAccount(options) so sandbox routing matches create_media_buy
@@ -841,13 +842,35 @@ const REQUEST_ENRICHERS: Record<string, RequestEnricher> = {
     };
   },
 
-  check_governance(step, context, options) {
+  check_governance(step, context, options, runnerVars) {
     // `caller` names the CALLER-AGENT's URL, not the brand — governance agents
     // use it for agent identity (rate limits, audit, JWS issuer correlation).
     // The brand belongs inside `payload`, where governance rules about the
     // advertised entity are evaluated. Using the fallback harness-orchestrator
     // URL keeps the semantics honest when no sample_request is authored.
-    return {
+    const fixture =
+      step.sample_request !== undefined
+        ? omitEnvelopeFields(
+            injectContext({ ...(step.sample_request as Record<string, unknown>) }, context, runnerVars) as Record<
+              string,
+              unknown
+            >
+          )
+        : undefined;
+    const isDelivery =
+      fixture?.phase === 'delivery' ||
+      fixture?.planned_delivery !== undefined ||
+      fixture?.delivery_metrics !== undefined ||
+      fixture?.governance_context !== undefined;
+
+    if (fixture && isDelivery) {
+      return {
+        ...fixture,
+        caller: fixture.caller ?? FALLBACK_CALLER_AGENT_URL,
+      };
+    }
+
+    const fallback = {
       plan_id: context.plan_id ?? 'unknown',
       caller: FALLBACK_CALLER_AGENT_URL,
       tool: 'get_products',
@@ -859,6 +882,7 @@ const REQUEST_ENRICHERS: Record<string, RequestEnricher> = {
         total_budget: options.budget ?? 10000,
       },
     };
+    return fixture ? { ...fallback, ...fixture } : fallback;
   },
 
   get_account_financials(_step, context, options) {

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -7686,13 +7686,15 @@ export function applyBrandInvariant(
       const acct = existingAccount as Record<string, unknown>;
       const isNaturalKeyVariant = 'brand' in acct || 'operator' in acct;
       if (isNaturalKeyVariant) {
-        // Wholesale cache-scope storyboards deliberately address a different
+        // Wholesale discovery storyboards deliberately address a different
         // natural-key account to prove public/account token isolation. Keep
-        // that explicitly authored account identity while still enforcing the
-        // run-scoped top-level brand. Other tools and buying modes retain the
-        // cross-step account-brand invariant from #579.
+        // that explicitly authored account identity for product and signal
+        // feeds while still enforcing the run-scoped top-level brand. Other
+        // tools and discovery modes retain the cross-step invariant from #579.
         const preserveWholesaleAccountBrand =
-          taskName === 'get_products' && request.buying_mode === 'wholesale' && acct.brand !== undefined;
+          ((taskName === 'get_products' && request.buying_mode === 'wholesale') ||
+            (taskName === 'get_signals' && request.discovery_mode === 'wholesale')) &&
+          acct.brand !== undefined;
         const merged: Record<string, unknown> = {
           ...acct,
           brand: preserveWholesaleAccountBrand ? acct.brand : brand,

--- a/src/lib/testing/storyboard/task-map.ts
+++ b/src/lib/testing/storyboard/task-map.ts
@@ -332,8 +332,16 @@ export async function executeStoryboardTask(
   // preserves the seller response; wire selection and response projection are
   // independent concerns.
   const forceRawProjection = opts.responseProjection === 'raw';
+  const mediaBuyPackages = [params.packages, params.new_packages].flatMap(value => (Array.isArray(value) ? value : []));
+  const preserveExplicitLegacySelectorRoutes =
+    (taskName === 'create_media_buy' || taskName === 'update_media_buy') &&
+    mediaBuyPackages.some(
+      pkg => pkg != null && typeof pkg === 'object' && Object.hasOwn(pkg as Record<string, unknown>, 'format_ids')
+    );
   const useLegacyCreativeMethod =
-    forceRawProjection || (gradesLegacyCreativeWire(client) && readCreativeWireHint(params) !== 'canonical');
+    forceRawProjection ||
+    preserveExplicitLegacySelectorRoutes ||
+    (gradesLegacyCreativeWire(client) && readCreativeWireHint(params) !== 'canonical');
   const legacyMethodName = useLegacyCreativeMethod ? LEGACY_CREATIVE_TASK_TO_METHOD[taskName] : undefined;
   const methodName =
     legacyMethodName ?? (Object.hasOwn(TASK_TO_METHOD, taskName) ? TASK_TO_METHOD[taskName] : undefined);
@@ -342,7 +350,7 @@ export async function executeStoryboardTask(
   // the raw response shape; it must not force the seller onto a legacy-only
   // response. Other creative lifecycle methods retain explicit legacy routing.
   const callParams =
-    legacyMethodName && taskName !== 'get_products' && !forceRawProjection
+    legacyMethodName && taskName !== 'get_products' && !forceRawProjection && !preserveExplicitLegacySelectorRoutes
       ? withLegacyCreativeWireHint(params)
       : params;
   const compatibilityMethod = opts.mediaBuyLifecycleCompatibility

--- a/src/lib/testing/storyboard/webhook-assertions.ts
+++ b/src/lib/testing/storyboard/webhook-assertions.ts
@@ -93,10 +93,18 @@ export const WEBHOOK_ASSERTION_TASKS: Set<string> = new Set([
 
 const DEFAULT_TIMEOUT_SECONDS = 30;
 const DEFAULT_NO_WEBHOOK_TIMEOUT_SECONDS = 5;
-const DEFAULT_RETRY_REPLAY_TIMEOUT_SECONDS = 90;
+// Leave enough headroom for setup/report serialization inside the documented
+// 120-second isolated-run budget, even when a remote receiver is unreachable.
+const DEFAULT_RETRY_REPLAY_TIMEOUT_SECONDS = 60;
 const DEFAULT_RETRY_COUNT = 3;
 const DEFAULT_RETRY_HTTP_STATUS = 503;
 const DEFAULT_MIN_DELIVERIES = 2;
+
+function webhookTimeoutDetail(receiver: WebhookReceiver, base: string): string {
+  return receiver.mode === 'loopback_mock' && receiver.all().length === 0 && receiver.challenges().length === 0
+    ? `${base} No request reached the loopback receiver; an out-of-process agent must use webhook_receiver.mode="proxy_url".`
+    : base;
+}
 const DEFAULT_WEBHOOK_SIGNING_TAG = 'adcp/webhook-signing/v1';
 
 /**
@@ -142,6 +150,70 @@ interface FlatStep {
   step: StoryboardStep;
   phaseId: string;
   globalIndex: number;
+}
+
+function collectNotificationConfigs(
+  value: unknown,
+  configs: Record<string, unknown>[] = []
+): Record<string, unknown>[] {
+  if (!value || typeof value !== 'object') return configs;
+  if (Array.isArray(value)) {
+    for (const item of value) collectNotificationConfigs(item, configs);
+    return configs;
+  }
+  const record = value as Record<string, unknown>;
+  if (Array.isArray(record.notification_configs)) {
+    for (const config of record.notification_configs) {
+      if (config && typeof config === 'object' && !Array.isArray(config)) {
+        configs.push(config as Record<string, unknown>);
+      }
+    }
+  }
+  for (const nested of Object.values(record)) collectNotificationConfigs(nested, configs);
+  return configs;
+}
+
+function notificationSetupMatchesAssertion(setup: StoryboardStep, assertion: StoryboardStep): boolean {
+  const configs = collectNotificationConfigs(setup.sample_request);
+  if (configs.length === 0) return false;
+  const filter =
+    assertion.filter && typeof assertion.filter === 'object'
+      ? (assertion.filter as Record<string, unknown>)
+      : undefined;
+  const body = filter?.body && typeof filter.body === 'object' ? (filter.body as Record<string, unknown>) : undefined;
+  const subscriberId = filter?.subscriber_id ?? body?.subscriber_id;
+  const eventType = filter?.notification_type ?? body?.notification_type ?? filter?.event ?? body?.event;
+
+  // A setup failure is only an implicit prerequisite when the assertion names
+  // a subscriber or event configured by that setup. Other webhook assertions
+  // retain their own trigger dependency and cannot be masked by an unrelated
+  // failed registration elsewhere in the storyboard.
+  if (typeof subscriberId !== 'string' && typeof eventType !== 'string') return false;
+  return configs.some(config => {
+    const subscriberMatches = typeof subscriberId !== 'string' || config.subscriber_id === subscriberId;
+    const eventMatches =
+      typeof eventType !== 'string' || (Array.isArray(config.event_types) && config.event_types.includes(eventType));
+    return subscriberMatches && eventMatches;
+  });
+}
+
+function failedNotificationSetup(
+  step: StoryboardStep,
+  allSteps: FlatStep[],
+  priorStepResults: Map<string, StoryboardStepResult>
+): StoryboardStepResult | undefined {
+  const currentIndex = allSteps.find(entry => entry.step.id === step.id)?.globalIndex ?? Number.POSITIVE_INFINITY;
+  const setup = [...allSteps]
+    .reverse()
+    .find(
+      entry =>
+        entry.globalIndex < currentIndex &&
+        (entry.step.task === 'sync_accounts' || entry.step.task === 'sync_agent_notification_configs') &&
+        notificationSetupMatchesAssertion(entry.step, step)
+    );
+  if (!setup) return undefined;
+  const result = priorStepResults.get(setup.step.id);
+  return result && (result.skipped || !result.passed) ? result : undefined;
 }
 
 type GetNextPreview = (currentStepId: string) => StoryboardStepPreview | undefined;
@@ -225,6 +297,17 @@ export async function executeWebhookAssertionStep(
       detail:
         `Step "${step.task}" requires an ephemeral webhook receiver. Pass ` +
         '`webhook_receiver` on runStoryboard options to enable.',
+      extraction,
+      request: requestRecord,
+      next,
+    });
+  }
+
+  const failedSetup = failedNotificationSetup(step, allSteps, runState.priorStepResults);
+  if (failedSetup) {
+    return skippedResult(step, phaseId, context, start, {
+      skip_reason: 'prerequisite_failed',
+      detail: `Notification setup step "${failedSetup.step_id}" did not complete successfully.`,
       extraction,
       request: requestRecord,
       next,
@@ -420,7 +503,7 @@ async function runExpectWebhook(
     return singleFailure(
       step,
       'no_webhook_received',
-      `No webhook matching filter arrived within ${timeoutMs}ms.`,
+      webhookTimeoutDetail(receiver, `No webhook matching filter arrived within ${timeoutMs}ms.`),
       'webhook delivery matching filter',
       null
     );
@@ -490,8 +573,11 @@ async function runExpectRetryKeysStable(
     return singleFailure(
       step,
       'insufficient_retries',
-      `Observed ${matches.length} deliveries; expected at least ${minDeliveries}. ` +
-        'The sender may not be retrying on 5xx responses.',
+      webhookTimeoutDetail(
+        receiver,
+        `Observed ${matches.length} deliveries; expected at least ${minDeliveries}. ` +
+          'The sender may not be retrying on 5xx responses.'
+      ),
       `≥ ${minDeliveries} deliveries`,
       matches.length
     );
@@ -575,7 +661,7 @@ async function runExpectSignatureValid(
     return singleFailure(
       step,
       'no_webhook_received',
-      `No webhook matching filter arrived within ${timeoutMs}ms.`,
+      webhookTimeoutDetail(receiver, `No webhook matching filter arrived within ${timeoutMs}ms.`),
       'signed webhook delivery matching filter',
       null
     );

--- a/src/lib/testing/storyboard/webhook-receiver.ts
+++ b/src/lib/testing/storyboard/webhook-receiver.ts
@@ -19,12 +19,14 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
 import { randomUUID } from 'node:crypto';
 import type { AddressInfo } from 'node:net';
+import { getSchemaValidatorByRef } from '../../validation/schema-loader';
 
 /**
  * Size cap on any single webhook body. A non-conformant sender retrying
  * with oversize payloads shouldn't be able to exhaust the runner's memory.
  */
 const MAX_BODY_BYTES = 1_048_576; // 1 MiB
+const MAX_CHALLENGE_BODY_BYTES = 16_384; // 16 KiB; challenge envelopes are tiny
 
 /**
  * Caps on cumulative capture state. `MAX_CAPTURED_TOTAL` bounds the total
@@ -111,6 +113,20 @@ export interface CapturedWebhook {
   response_status: number;
 }
 
+/** Proof-of-control challenge retained separately from event deliveries. */
+export interface CapturedWebhookChallenge {
+  id: string;
+  step_id: string;
+  operation_id: string;
+  received_at: number;
+  method: string;
+  path: string;
+  headers: Record<string, string>;
+  raw_body: string;
+  body: Record<string, unknown>;
+  response_status: 200;
+}
+
 /** Match predicate applied when waiting for a webhook. */
 export interface WebhookFilter {
   /** Restrict matches to this step id's URL. */
@@ -139,6 +155,8 @@ export interface WebhookReceiver {
   readonly mode: 'loopback_mock' | 'proxy_url';
   /** All webhooks captured so far, in arrival order. */
   all(): CapturedWebhook[];
+  /** Schema-valid proof-of-control challenges, kept separate from event deliveries. */
+  challenges(): CapturedWebhookChallenge[];
   /** Webhooks matching a filter, in arrival order. */
   matching(filter: WebhookFilter): CapturedWebhook[];
   /**
@@ -198,6 +216,7 @@ export async function createWebhookReceiver(options: CreateWebhookReceiverOption
   const proxyBase = mode === 'proxy_url' ? validateProxyUrl(options.public_url!) : undefined;
 
   const captured: CapturedWebhook[] = [];
+  const challenges: CapturedWebhookChallenge[] = [];
   const waiters: Array<{
     filter: WebhookFilter;
     resolve: (result: WebhookWaitResult) => void;
@@ -210,10 +229,11 @@ export async function createWebhookReceiver(options: CreateWebhookReceiverOption
   }> = [];
   const retryPolicies = new Map<string, { policy: RetryReplayPolicy; delivered: number }>();
   const deliveryCounts = new Map<string, number>();
+  const challengeCounts = new Map<string, number>();
   let closed = false;
 
   const server = createServer((req, res) =>
-    handleRequest(req, res, { captured, waiters, retryPolicies, deliveryCounts })
+    handleRequest(req, res, { captured, challenges, waiters, retryPolicies, deliveryCounts, challengeCounts })
   );
   // Transport-level hardening — trim Node's generous defaults so a slow /
   // hostile publisher can't wedge the runner.
@@ -239,6 +259,7 @@ export async function createWebhookReceiver(options: CreateWebhookReceiverOption
     base_url,
     mode,
     all: () => captured.slice(),
+    challenges: () => challenges.slice(),
     matching: filter => captured.filter(w => matchesFilter(w, filter)),
     set_retry_replay: (key, policy) => {
       retryPolicies.set(retryKeyString(key), { policy, delivered: 0 });
@@ -265,6 +286,7 @@ export async function createWebhookReceiver(options: CreateWebhookReceiverOption
 
 interface HandlerState {
   captured: CapturedWebhook[];
+  challenges: CapturedWebhookChallenge[];
   waiters: Array<{
     filter: WebhookFilter;
     resolve: (r: WebhookWaitResult) => void;
@@ -272,6 +294,7 @@ interface HandlerState {
   }>;
   retryPolicies: Map<string, { policy: RetryReplayPolicy; delivered: number }>;
   deliveryCounts: Map<string, number>;
+  challengeCounts: Map<string, number>;
 }
 
 function handleRequest(req: IncomingMessage, res: ServerResponse, state: HandlerState): void {
@@ -313,6 +336,54 @@ function handleRequest(req: IncomingMessage, res: ServerResponse, state: Handler
     }
     const raw = Buffer.concat(chunks).toString('utf8');
     const headers = normalizeHeaders(req.headers);
+    const parsedBody = parseBody(raw, headers['content-type']);
+
+    // Notification-config proof is POSTed to the configured webhook URL
+    // itself. Validate the complete protocol envelope, echo only the
+    // challenge field, and retain the request separately so conformance
+    // checks can inspect its RFC 9421 headers without treating it as an
+    // event delivery.
+    if (isWebhookChallenge(parsedBody.body)) {
+      if (Buffer.byteLength(raw, 'utf8') > MAX_CHALLENGE_BODY_BYTES) {
+        res.statusCode = 413;
+        res.end();
+        return;
+      }
+      const challenge = parsedBody.body.challenge;
+      const schemaRef =
+        parsedBody.body.scope === 'agent' ? 'core/agent-webhook-challenge.json' : 'core/webhook-challenge.json';
+      const validate = getSchemaValidatorByRef(schemaRef);
+      if (!validate || !validate(parsedBody.body) || typeof challenge !== 'string') {
+        res.statusCode = 400;
+        res.end();
+        return;
+      }
+      const key = retryKeyString({ step_id, operation_id });
+      const perKey = state.challengeCounts.get(key) ?? 0;
+      if (state.captured.length + state.challenges.length >= MAX_CAPTURED_TOTAL || perKey >= MAX_CAPTURED_PER_KEY) {
+        res.statusCode = 429;
+        res.setHeader('retry-after', '1');
+        res.end();
+        return;
+      }
+      state.challengeCounts.set(key, perKey + 1);
+      state.challenges.push({
+        id: randomUUID(),
+        step_id,
+        operation_id,
+        received_at: Date.now(),
+        method: req.method ?? 'POST',
+        path: req.url ?? '/',
+        headers: redactHeaders(headers),
+        raw_body: raw,
+        body: parsedBody.body as Record<string, unknown>,
+        response_status: 200,
+      });
+      res.statusCode = 200;
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify({ challenge }));
+      return;
+    }
 
     const key = retryKeyString({ step_id, operation_id });
     const deliveryIndex = (state.deliveryCounts.get(key) ?? 0) + 1;
@@ -323,7 +394,7 @@ function handleRequest(req: IncomingMessage, res: ServerResponse, state: Handler
     // here masks the policy's eventual 2xx forever and can amplify a sender's
     // retries after the runner has already reached its memory bound (#2653).
     const perKey = state.deliveryCounts.get(key) ?? 0;
-    if (state.captured.length >= MAX_CAPTURED_TOTAL || perKey >= MAX_CAPTURED_PER_KEY) {
+    if (state.captured.length + state.challenges.length >= MAX_CAPTURED_TOTAL || perKey >= MAX_CAPTURED_PER_KEY) {
       res.statusCode = status;
       if (status === 429 || status >= 500) res.setHeader('retry-after', '1');
       res.end();
@@ -342,7 +413,7 @@ function handleRequest(req: IncomingMessage, res: ServerResponse, state: Handler
       path: req.url ?? '/',
       headers: redactHeaders(headers),
       raw_body: raw,
-      ...parseBody(raw, headers['content-type']),
+      ...parsedBody,
       response_status: status,
     };
     state.captured.push(webhook);
@@ -370,10 +441,24 @@ function handleRequest(req: IncomingMessage, res: ServerResponse, state: Handler
   });
 }
 
-function parseStepPath(reqUrl: string): { step_id: string; operation_id: string } | undefined {
+function isWebhookChallenge(
+  body: unknown
+): body is { type: 'webhook.challenge'; challenge: unknown } & Record<string, unknown> {
+  return (
+    body !== null &&
+    typeof body === 'object' &&
+    !Array.isArray(body) &&
+    (body as Record<string, unknown>).type === 'webhook.challenge'
+  );
+}
+
+function requestPathname(reqUrl: string): string {
   const q = reqUrl.indexOf('?');
-  const pathname = q === -1 ? reqUrl : reqUrl.slice(0, q);
-  const match = STEP_PATH_RE.exec(pathname);
+  return q === -1 ? reqUrl : reqUrl.slice(0, q);
+}
+
+function parseStepPath(reqUrl: string): { step_id: string; operation_id: string } | undefined {
+  const match = STEP_PATH_RE.exec(requestPathname(reqUrl));
   if (!match) return undefined;
   return { step_id: match[1]!, operation_id: match[2]! };
 }

--- a/src/lib/types/core.generated.ts
+++ b/src/lib/types/core.generated.ts
@@ -1,5 +1,5 @@
 // Generated AdCP core types from official schemas v3.2.0-beta.6
-// Generated at: 2026-08-26T10:39:00.240Z
+// Generated at: 2026-08-27T15:41:03.381Z
 
 // ACCOUNTCURRENCYMODE CANONICAL ENUM
 /**
@@ -32000,6 +32000,8 @@ export interface TasksListResponse {
 /**
  * Descriptor for one configuration knob a transformer exposes. Returned inside transformer.json `params[]` from list_transformers. The descriptor declares the knob's shape; the buyer supplies its value in build_creative `config` keyed by `field`. For `value_source: enumerable` params (e.g. account-specific voices), the legal `options[]` are account-scoped and dynamic — they are returned only when the param's `field` is named in the list_transformers `expand_params` request, and may be paginated via `options_cursor`.
  */
+export type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
+
 export interface TransformerParam {
   /**
    * The config key. Buyers set the value under this exact key in build_creative `config`.
@@ -32037,7 +32039,7 @@ export interface TransformerParam {
     /**
      * The value the buyer passes in `config` for this field.
      */
-    value: unknown;
+    value: JsonValue;
     /**
      * Human-readable label for this option.
      */
@@ -32054,7 +32056,7 @@ export interface TransformerParam {
   /**
    * The value applied when the buyer omits this field from `config`. Type matches `type`.
    */
-  default?: unknown;
+  default?: JsonValue;
   /**
    * Whether the buyer MUST supply this field in `config`. When false and no `default` is declared, the agent chooses.
    */

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -201,6 +201,7 @@ export type {
   BuildCreativeSuccess,
   BuildCreativeError,
   BuildCreativeMultiSuccess,
+  BuildCreativeVariantSuccess,
   BuildCreativeAsyncSubmitted,
   CreativeManifest,
   PreviewCreativeRequest,

--- a/src/lib/types/schemas.generated.ts
+++ b/src/lib/types/schemas.generated.ts
@@ -1,5 +1,5 @@
 // Generated Zod v4 schemas from TypeScript types
-// Generated at: 2026-08-27T04:39:30.483Z
+// Generated at: 2026-08-27T16:04:46.208Z
 // Sources:
 //   - core.generated.ts (core types)
 //   - tools.generated.ts (tool types)
@@ -35,6 +35,7 @@ import { fullFormats as adcpJsonSchemaFormats } from "ajv-formats/dist/formats.j
 
 const adcpDateTimeFormat = adcpJsonSchemaFormats["date-time"] as { validate: (value: string) => boolean };
 const adcpJsonSchemaDateTime = (value: string): boolean => adcpDateTimeFormat.validate(value);
+import { type JsonValue } from "./tools.generated";
 
 export const AccountCurrencyModeSchema = z.union([z.literal("fixed"), z.literal("per_media_buy")]);
 
@@ -6643,6 +6644,8 @@ export const TasksListResponseSchema = z.object({
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
+export const JsonValueSchema: z.ZodSchema<JsonValue> = z.lazy(() => z.union([z.string(), z.number(), z.boolean(), z.array(JsonValueSchema), z.record(z.string(), JsonValueSchema)]).nullable());
+
 export const TransformerParamSchema = z.object({}).passthrough().merge(z.object({
     field: z.string(),
     type: z.union([z.literal("string"), z.literal("number"), z.literal("integer"), z.literal("boolean")]),
@@ -6652,12 +6655,12 @@ export const TransformerParamSchema = z.object({}).passthrough().merge(z.object(
     minimum: z.number().optional(),
     maximum: z.number().optional(),
     options: z.array(z.object({
-        value: z.object({}).passthrough(),
+        value: z.json(),
         label: z.string().optional(),
         metadata: z.object({}).passthrough().optional()
     }).passthrough()).optional(),
     options_cursor: z.string().optional(),
-    default: z.object({}).passthrough().optional(),
+    default: z.json().optional(),
     required: z.boolean().optional(),
     description: z.string().optional()
 }).passthrough());

--- a/src/lib/types/server-payload-aliases.ts
+++ b/src/lib/types/server-payload-aliases.ts
@@ -11,6 +11,7 @@ import type {
   ActivateSignalSuccess,
   BuildCreativeMultiSuccess,
   BuildCreativeSuccess,
+  BuildCreativeVariantSuccess,
   CalibrateContentResponse,
   CheckGovernanceResponse,
   CreateCollectionListResponse,
@@ -129,6 +130,7 @@ export type SyncAudiencesPayload = ServerPayload<SyncAudiencesSuccess>;
 
 export type BuildCreativePayload = ServerPayload<BuildCreativeSuccess>;
 export type BuildCreativeMultiPayload = ServerPayload<BuildCreativeMultiSuccess>;
+export type BuildCreativeVariantPayload = ServerPayload<BuildCreativeVariantSuccess>;
 export type CanonicalPreviewCreativePayload = ServerPayload<CanonicalCreativeResponse<PreviewCreativeResponse>>;
 /** @deprecated Use `CanonicalPreviewCreativePayload` for canonical preview handlers. */
 export type PreviewCreativePayload = ServerPayload<PreviewCreativeResponse>;

--- a/src/lib/types/tools.generated.ts
+++ b/src/lib/types/tools.generated.ts
@@ -19438,6 +19438,8 @@ export type Transformer = (CanonicalTransformerOutputs | NamedFormatTransformerO
 /**
  * Descriptor for one configuration knob a transformer exposes. Returned inside transformer.json `params[]` from list_transformers. The descriptor declares the knob's shape; the buyer supplies its value in build_creative `config` keyed by `field`. For `value_source: enumerable` params (e.g. account-specific voices), the legal `options[]` are account-scoped and dynamic — they are returned only when the param's `field` is named in the list_transformers `expand_params` request, and may be paginated via `options_cursor`.
  */
+export type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
+
 export type TransformerParam = {
 } & {
   /**
@@ -19477,8 +19479,7 @@ export type TransformerParam = {
     /**
      * The value the buyer passes in `config` for this field.
      */
-    value: {
-    };
+    value: JsonValue;
     /**
      * Human-readable label for this option.
      */
@@ -19496,8 +19497,7 @@ export type TransformerParam = {
   /**
    * The value applied when the buyer omits this field from `config`. Type matches `type`.
    */
-  default?: {
-  };
+  default?: JsonValue;
   /**
    * Whether the buyer MUST supply this field in `config`. When false and no `default` is declared, the agent chooses.
    */

--- a/src/lib/utils/build-creative-return-builders.ts
+++ b/src/lib/utils/build-creative-return-builders.ts
@@ -1,14 +1,16 @@
-// Typed factory helpers for `build_creative` return values. Four shapes:
+// Typed factory helpers for `build_creative` return values. Five shapes:
 //   1. bare `CreativeManifest`            — auto-wrapped as `{ creative_manifest }`
 //   2. bare `CreativeManifest[]`          — auto-wrapped as `{ creative_manifests }`
 //   3. shaped `BuildCreativeSuccess`      — passthrough
 //   4. shaped `BuildCreativeMultiSuccess` — passthrough multi-format
+//   5. shaped `BuildCreativeVariantSuccess` — passthrough multiplicity
 //
 // Adopters writing the shaped envelope by hand consistently miss the
 // distinction between single (`creative_manifest`) and multi
 // (`creative_manifests`) field names. SHAPE-GOTCHAS §5.
 
 import type { BuildCreativeSuccess, BuildCreativeMultiSuccess, CreativeManifest } from '../types/core.generated';
+import type { BuildCreativeVariantSuccess } from '../types/tools.generated';
 
 type SingleEnvelopeFields = Omit<BuildCreativeSuccess, 'creative_manifest'> & { manifest: CreativeManifest };
 type MultiEnvelopeFields = Omit<BuildCreativeMultiSuccess, 'creative_manifests'> & { manifests: CreativeManifest[] };
@@ -38,10 +40,16 @@ export function multiEnvelopedBuildCreativeReturn(fields: MultiEnvelopeFields): 
   return { ...rest, creative_manifests: manifests as [CreativeManifest, ...CreativeManifest[]] };
 }
 
-/** Grouped accessor for the four `build_creative` return shapes. */
+/** Shaped multiplicity response. Passed through with its top-level `creatives` array intact. */
+export function variantEnvelopedBuildCreativeReturn(fields: BuildCreativeVariantSuccess): BuildCreativeVariantSuccess {
+  return fields;
+}
+
+/** Grouped accessor for the five `build_creative` return shapes. */
 export const buildCreativeReturn = {
   single: singleBuildCreativeReturn,
   multi: multiBuildCreativeReturn,
   singleEnveloped: singleEnvelopedBuildCreativeReturn,
   multiEnveloped: multiEnvelopedBuildCreativeReturn,
+  variantEnveloped: variantEnvelopedBuildCreativeReturn,
 } as const;

--- a/src/lib/utils/response-unwrapper.ts
+++ b/src/lib/utils/response-unwrapper.ts
@@ -117,7 +117,7 @@ const SUCCESS_PAYLOAD_FIELD_GROUPS_BY_TOOL: Readonly<Record<string, readonly (re
   sync_catalogs: [['catalogs']],
   sync_creatives: [['creatives']],
   list_creatives: [['query_summary', 'pagination', 'creatives']],
-  build_creative: [['creative_manifest'], ['creative_manifests']],
+  build_creative: [['creative_manifest'], ['creative_manifests'], ['creatives']],
   preview_creative: [['response_type', 'previews']],
   get_creative_delivery: [['currency', 'reporting_period', 'creatives']],
   validate_input: [['results']],

--- a/src/lib/validation/schema-loader.ts
+++ b/src/lib/validation/schema-loader.ts
@@ -352,6 +352,7 @@ interface LoaderState {
 }
 
 const states: Map<string, LoaderState> = new Map();
+const schemaRefValidators = new Map<string, ValidateFunction>();
 const externalSchemaRoots: Map<string, string> = new Map();
 const scopedExternalSchemaRoots = new AsyncLocalStorage<Map<string, string>>();
 
@@ -362,6 +363,9 @@ function stateCacheKey(bundleKey: string, root: string): string {
 function clearStatesForBundle(bundleKey: string): void {
   for (const [stateKey, state] of states) {
     if (state.version === bundleKey) states.delete(stateKey);
+  }
+  for (const cacheKey of schemaRefValidators.keys()) {
+    if (cacheKey.startsWith(`${bundleKey}\0`)) schemaRefValidators.delete(cacheKey);
   }
 }
 
@@ -895,15 +899,18 @@ export function getSchemaValidatorByRef(
   schemaRef: string,
   version: string = ADCP_VERSION
 ): ValidateFunction | undefined {
-  const s = ensureInit(version);
+  // Keep remote schema-ref validation out of the shared tool-validator AJV,
+  // which intentionally collects all errors for developer diagnostics.
+  const bundleKey = resolveBundleKey(version);
+  const root = resolveSchemaRoot(version);
   const normalized = normalizeSchemaRef(schemaRef);
   if (!normalized) return undefined;
 
-  const cacheKey = `schema-ref::${normalized}`;
-  const cached = s.validators.get(cacheKey);
+  const cacheKey = `${stateCacheKey(bundleKey, root)}\0schema-ref::${normalized}`;
+  const cached = schemaRefValidators.get(cacheKey);
   if (cached) return cached;
 
-  const file = path.join(s.root, normalized);
+  const file = path.join(root, normalized);
   if (!existsSync(file)) return undefined;
 
   // Use an isolated AJV instance for arbitrary schema refs. Tool response
@@ -912,13 +919,16 @@ export function getSchemaValidatorByRef(
   // shared tool-validator registry with unrelaxed response schemas.
   const ajv = new Ajv({
     strict: false,
-    allErrors: true,
+    // Schema-ref validators process remote webhook payloads. Fail on the
+    // first violation so deeply nested hostile input cannot amplify error
+    // collection into CPU or memory exhaustion.
+    allErrors: false,
     allowUnionTypes: true,
   });
   addFormats(ajv);
   const dependencySchemas: LoadedSchema[] = [];
   const registeredIds = new Set<string>();
-  for (const schemaFile of walkJsonFiles(s.root)) {
+  for (const schemaFile of walkJsonFiles(root)) {
     if (schemaFile.includes(`${path.sep}bundled${path.sep}`)) continue;
     if (
       [...TRANSPORT_PROJECTION_DIRECTORIES].some(directory => schemaFile.includes(`${path.sep}${directory}${path.sep}`))
@@ -937,7 +947,7 @@ export function getSchemaValidatorByRef(
   }
   const rawSchema = loadJson(file);
   const compiled = ajv.compile(rawSchema);
-  s.validators.set(cacheKey, compiled);
+  schemaRefValidators.set(cacheKey, compiled);
   return compiled;
 }
 
@@ -1146,6 +1156,7 @@ export function _resetValidationLoader(version?: string): void {
   mcpToolSummaryCache.clear();
   if (version === undefined) {
     states.clear();
+    schemaRefValidators.clear();
   } else {
     clearStatesForBundle(resolveBundleKey(version));
   }

--- a/test/lib/request-builder.test.js
+++ b/test/lib/request-builder.test.js
@@ -1077,6 +1077,31 @@ describe('Request Builder', () => {
     });
   });
 
+  describe('check_governance', () => {
+    test('preserves an authored delivery request without injecting intent-only fields (#2705)', () => {
+      const fixture = {
+        phase: 'delivery',
+        caller: 'https://buyer-agent.example/',
+        governance_context: 'signed-context',
+        planned_delivery: { impressions: 1000 },
+        delivery_metrics: { impressions: 750 },
+      };
+      const result = buildRequest(step('check_governance', { sample_request: fixture }), {}, DEFAULT_OPTIONS);
+
+      assert.deepStrictEqual(result, fixture);
+      assert.strictEqual(result.plan_id, undefined);
+      assert.strictEqual(result.tool, undefined);
+      assert.strictEqual(result.payload, undefined);
+    });
+
+    test('keeps the intent fallback for an un-authored request', () => {
+      const result = buildRequest(step('check_governance'), {}, DEFAULT_OPTIONS);
+      assert.strictEqual(result.plan_id, 'unknown');
+      assert.strictEqual(result.tool, 'get_products');
+      assert.ok(result.payload);
+    });
+  });
+
   describe('sync_governance', () => {
     test('fallback credentials satisfy schema minLength of 32', () => {
       // Regression: the hardcoded 'test-governance-token' is 21 chars,

--- a/test/lib/storyboard-brand-invariant.test.js
+++ b/test/lib/storyboard-brand-invariant.test.js
@@ -252,6 +252,23 @@ describe('applyBrandInvariant', () => {
         brand: BRAND,
       });
     });
+
+    test('preserves authored wholesale signal-feed account overlays (#2702)', () => {
+      const overlayBrand = { domain: 'wholesale-signal-feed.example' };
+      const result = applyBrandInvariant(
+        {
+          discovery_mode: 'wholesale',
+          account: { brand: overlayBrand, operator: 'signal-operator.example' },
+        },
+        { brand: BRAND },
+        'get_signals'
+      );
+
+      assert.deepStrictEqual(result.account, {
+        brand: overlayBrand,
+        operator: 'signal-operator.example',
+      });
+    });
   });
 
   // ── AccountReference oneOf safety ──────────────────────────

--- a/test/lib/storyboard-task-map-error.test.js
+++ b/test/lib/storyboard-task-map-error.test.js
@@ -584,6 +584,67 @@ describe('executeStoryboardTask creative wire selection', () => {
     assert.deepEqual(calls, [{ method: 'raw', request: params }]);
     assert.equal(result.data.wire, 'dual');
   });
+
+  for (const [label, formatIds, formatOptions] of [
+    ['equivalent', [{ id: 'display', agent_url: 'https://seller.example/' }], [{ format_kind: 'display' }]],
+    ['conflicting', [{ id: 'video', agent_url: 'https://seller.example/' }], [{ format_kind: 'audio' }]],
+    ['unprojectable', [{ id: 'custom', agent_url: 'https://other.example/' }], undefined],
+  ]) {
+    test(`preserves ${label} co-present format selector routes at the receiver (#2707)`, async () => {
+      const calls = [];
+      const pkg = { package_id: 'pkg-1', format_ids: formatIds };
+      if (formatOptions) pkg.format_options = formatOptions;
+      const params = { packages: [pkg] };
+
+      await executeStoryboardTask(
+        {
+          getAdcpVersion: () => '3.2.0-beta.6',
+          createMediaBuy: async () => {
+            throw new Error('canonical projection must not drop an authored legacy route');
+          },
+          createMediaBuyLegacy: async request => {
+            calls.push(request);
+            return { data: { media_buy_id: 'mb-1' } };
+          },
+        },
+        'create_media_buy',
+        params
+      );
+
+      assert.deepStrictEqual(calls, [params]);
+      assert.strictEqual(calls[0].ext, undefined, '3.2 requests must not be stamped as legacy wire');
+    });
+  }
+
+  test('preserves format_ids on update_media_buy new_packages (#2707)', async () => {
+    const calls = [];
+    const params = {
+      media_buy_id: 'mb-1',
+      new_packages: [
+        {
+          package_id: 'pkg-new',
+          format_ids: [{ id: 'display', agent_url: 'https://seller.example/' }],
+        },
+      ],
+    };
+
+    await executeStoryboardTask(
+      {
+        getAdcpVersion: () => '3.2.0-beta.6',
+        updateMediaBuy: async () => {
+          throw new Error('canonical projection must not drop new_packages format_ids');
+        },
+        updateMediaBuyLegacy: async request => {
+          calls.push(request);
+          return { data: { media_buy_id: 'mb-1' } };
+        },
+      },
+      'update_media_buy',
+      params
+    );
+
+    assert.deepStrictEqual(calls, [params]);
+  });
 });
 
 describe('executeStoryboardTask creative asset directives', () => {

--- a/test/lib/storyboard-webhook-receiver.test.js
+++ b/test/lib/storyboard-webhook-receiver.test.js
@@ -36,6 +36,86 @@ async function post(url, body, headers) {
 }
 
 describe('createWebhookReceiver', () => {
+  test('echoes proof-of-control challenges on the registered callback URL (#2701)', async () => {
+    const receiver = await createWebhookReceiver();
+    try {
+      const challenge = 'proof-control-token-0000000000000001';
+      const callbackUrl = `${receiver.base_url}/step/register/op-1`;
+      const challengeBody = {
+        type: 'webhook.challenge',
+        challenge,
+        account_id: 'acct_123',
+        subscriber_id: 'buyer-primary',
+        seller_agent_url: 'https://seller.example/adcp',
+        delivery_auth: { mode: 'rfc9421' },
+        event_types: ['creative.status_changed'],
+      };
+      const response = await post(callbackUrl, challengeBody, {
+        signature: 'sig1=:c2lnbmF0dXJl:',
+        'signature-input': 'sig1=("@method" "@target-uri");keyid="seller-key"',
+      });
+      assert.strictEqual(response.status, 200);
+      assert.deepStrictEqual(await response.json(), { challenge });
+      assert.strictEqual(receiver.all().length, 0, 'challenge probes are not webhook deliveries');
+      assert.strictEqual(receiver.challenges().length, 1, 'challenge metadata is retained for grading');
+      assert.deepStrictEqual(receiver.challenges()[0].body, challengeBody);
+      assert.ok(receiver.challenges()[0].headers['signature-input']);
+
+      const malformed = await post(callbackUrl, { ...challengeBody, challenge: 'too-short' });
+      assert.strictEqual(malformed.status, 400);
+      const missingRequired = await post(callbackUrl, { type: 'webhook.challenge', challenge });
+      assert.strictEqual(missingRequired.status, 400);
+      const obsoleteRoute = await post(`${receiver.base_url}/challenge`, challengeBody);
+      assert.strictEqual(obsoleteRoute.status, 404);
+    } finally {
+      await receiver.close();
+    }
+  });
+
+  test('accepts the agent-level proof-of-control challenge arm', async () => {
+    const receiver = await createWebhookReceiver();
+    try {
+      const challenge = 'agent-proof-control-token-000000000001';
+      const body = {
+        type: 'webhook.challenge',
+        scope: 'agent',
+        challenge,
+        subscriber_id: 'registry-cache',
+        seller_agent_url: 'https://seller.example/adcp',
+        delivery_auth: { mode: 'rfc9421' },
+        event_types: ['capabilities.changed'],
+      };
+      const response = await post(`${receiver.base_url}/step/register_agent/op-2`, body);
+
+      assert.strictEqual(response.status, 200);
+      assert.deepStrictEqual(await response.json(), { challenge });
+      assert.deepStrictEqual(receiver.challenges()[0].body, body);
+      assert.strictEqual(receiver.all().length, 0);
+    } finally {
+      await receiver.close();
+    }
+  });
+
+  test('rejects oversized challenge envelopes before retaining them', async () => {
+    const receiver = await createWebhookReceiver();
+    try {
+      const response = await post(`${receiver.base_url}/step/register/op-large`, {
+        type: 'webhook.challenge',
+        challenge: 'proof-control-token-0000000000000001',
+        account_id: 'x'.repeat(17_000),
+        subscriber_id: 'buyer-primary',
+        seller_agent_url: 'https://seller.example/adcp',
+        delivery_auth: { mode: 'rfc9421' },
+        event_types: ['creative.status_changed'],
+      });
+
+      assert.strictEqual(response.status, 413);
+      assert.strictEqual(receiver.challenges().length, 0);
+    } finally {
+      await receiver.close();
+    }
+  });
+
   test('per-step URL routing captures step_id + operation_id from path', async () => {
     const receiver = await createWebhookReceiver();
     try {
@@ -156,6 +236,15 @@ describe('createWebhookReceiver', () => {
     await receiver.close();
     const result = await Promise.race([pending, delay(250).then(() => 'still-pending')]);
     assert.deepStrictEqual(result, []);
+  });
+
+  test('close resolves a pending first-match waiter immediately (#2701)', async () => {
+    const receiver = await createWebhookReceiver();
+    const pending = receiver.wait({ step_id: 'nobody' }, 60_000);
+
+    await receiver.close();
+    const result = await Promise.race([pending, delay(250).then(() => 'still-pending')]);
+    assert.deepStrictEqual(result, { timed_out: true });
   });
 
   test('close preserves matches already captured by a pending wait_all', async () => {
@@ -1129,6 +1218,120 @@ describe('runStoryboard: expect_no_webhook step task', () => {
     const esmAssertions = await import('../../dist/lib/testing/storyboard/webhook-assertions.mjs');
     assert.strictEqual(webhookAssertions.WEBHOOK_ASSERTION_TASKS.has('expect_no_webhook'), true);
     assert.strictEqual(esmAssertions.WEBHOOK_ASSERTION_TASKS.has('expect_no_webhook'), true);
+  });
+});
+
+describe('executeWebhookAssertionStep prerequisites', () => {
+  test('fails immediately when an earlier account notification setup failed (#2701)', async () => {
+    const receiver = await createWebhookReceiver();
+    try {
+      const setup = {
+        id: 'register_notifications',
+        title: 'Register notifications',
+        task: 'sync_accounts',
+        sample_request: {
+          accounts: [
+            {
+              notification_configs: [
+                {
+                  subscriber_id: 'buyer-primary',
+                  url: 'https://receiver.example/',
+                  event_types: ['creative.status_changed'],
+                },
+              ],
+            },
+          ],
+        },
+      };
+      const assertion = {
+        id: 'assert_notification',
+        title: 'Assert notification',
+        task: 'expect_webhook',
+        filter: { subscriber_id: 'buyer-primary' },
+        timeout_seconds: 60,
+      };
+      const runState = {
+        contributions: new Set(),
+        priorStepResults: new Map([
+          ['register_notifications', { step_id: 'register_notifications', passed: false, skipped: false }],
+        ]),
+        priorProbes: new Map(),
+        agentUrl: '',
+        webhookReceiver: { ...receiver, wait: async () => ({ timed_out: true }) },
+        runnerVars: createRunnerVariables({ webhookBase: receiver.base_url }),
+      };
+      const started = Date.now();
+      const result = await executeWebhookAssertionStep(
+        assertion,
+        'assertions',
+        {},
+        [
+          { step: setup, phaseId: 'setup', globalIndex: 0 },
+          { step: assertion, phaseId: 'assertions', globalIndex: 1 },
+        ],
+        {},
+        runState
+      );
+
+      assert.strictEqual(result.skipped, true);
+      assert.strictEqual(result.skip.reason, 'prerequisite_failed');
+      assert.match(result.skip.detail, /register_notifications/);
+      assert.ok(Date.now() - started < 250, 'must not enter the webhook timeout');
+    } finally {
+      await receiver.close();
+    }
+  });
+
+  test('requires every supplied discriminator to match a failed notification setup (#2701)', async () => {
+    const receiver = await createWebhookReceiver();
+    try {
+      const setup = {
+        id: 'register_other_notifications',
+        title: 'Register other notifications',
+        task: 'sync_accounts',
+        sample_request: {
+          accounts: [
+            {
+              notification_configs: [{ subscriber_id: 'other', event_types: ['creative.status_changed'] }],
+            },
+          ],
+        },
+      };
+      const assertion = {
+        id: 'assert_notification',
+        title: 'Assert notification',
+        task: 'expect_no_webhook',
+        triggered_by: 'trigger',
+        filter: { subscriber_id: 'buyer-primary', notification_type: 'creative.status_changed' },
+        timeout_seconds: 0,
+      };
+      const runState = {
+        contributions: new Set(),
+        priorStepResults: new Map([
+          ['register_other_notifications', { step_id: 'register_other_notifications', passed: false, skipped: false }],
+          ['trigger', { step_id: 'trigger', passed: true, skipped: false }],
+        ]),
+        priorProbes: new Map(),
+        agentUrl: '',
+        webhookReceiver: { ...receiver, wait: async () => ({ timed_out: true }) },
+        runnerVars: createRunnerVariables({ webhookBase: receiver.base_url }),
+      };
+      const result = await executeWebhookAssertionStep(
+        assertion,
+        'assertions',
+        {},
+        [
+          { step: setup, phaseId: 'setup', globalIndex: 0 },
+          { step: assertion, phaseId: 'assertions', globalIndex: 1 },
+        ],
+        {},
+        runState
+      );
+
+      assert.notStrictEqual(result.skip?.reason, 'prerequisite_failed');
+    } finally {
+      await receiver.close();
+    }
   });
 });
 

--- a/test/server-create-adcp-server.test.js
+++ b/test/server-create-adcp-server.test.js
@@ -2124,15 +2124,26 @@ describe('createAdcpServer', () => {
       }
     });
 
+    it('rejects unmarked legacy task registries before their shifted write signatures can run', () => {
+      assert.throws(
+        () => createAdcpServer({ name: 'Test', version: '1.0.0', taskRegistry: {} }),
+        /taskRegistry\.scopeVersion must be 1/
+      );
+    });
+
     it('does not require custom AdCP task registries to implement list', async () => {
       const server = createAdcpServer({
         name: 'Test',
         version: '1.0.0',
         taskRegistry: {
+          scopeVersion: 1,
           async create() {
             return { taskId: 'task_1' };
           },
           async getTask() {
+            return null;
+          },
+          async _getTaskUnsafe() {
             return null;
           },
           async complete() {},
@@ -2140,6 +2151,7 @@ describe('createAdcpServer', () => {
           async updateProgress() {},
           _registerBackground() {},
           async awaitTask() {},
+          async _awaitTaskUnsafe() {},
         },
       });
 
@@ -2230,7 +2242,13 @@ describe('createAdcpServer', () => {
         accountId: 'acct_1',
         ownerScope: 'account:acct_1',
       });
-      await taskRegistry.complete(owned.taskId, { creatives: [{ creative_id: 'cr_1' }] });
+      await taskRegistry.complete(
+        owned.taskId,
+        { accountId: 'acct_1', ownerScope: 'account:acct_1' },
+        {
+          creatives: [{ creative_id: 'cr_1' }],
+        }
+      );
       const server = createAdcpServer({
         name: 'Test',
         version: '1.0.0',
@@ -2261,7 +2279,13 @@ describe('createAdcpServer', () => {
         accountId: 'acct_1',
         ownerScope: 'account:acct_1',
       });
-      await taskRegistry.complete(owned.taskId, { creatives: [{ creative_id: 'cr_1' }] });
+      await taskRegistry.complete(
+        owned.taskId,
+        { accountId: 'acct_1', ownerScope: 'account:acct_1' },
+        {
+          creatives: [{ creative_id: 'cr_1' }],
+        }
+      );
       const server = createAdcpServer({
         name: 'Test',
         version: '1.0.0',
@@ -2302,10 +2326,14 @@ describe('createAdcpServer', () => {
         version: '1.0.0',
         validation: { responses: 'strict' },
         taskRegistry: {
+          scopeVersion: 1,
           async create() {
             return { taskId: invalidTask.taskId };
           },
           async getTask(taskId) {
+            return taskId === invalidTask.taskId ? invalidTask : null;
+          },
+          async _getTaskUnsafe(taskId) {
             return taskId === invalidTask.taskId ? invalidTask : null;
           },
           async list() {
@@ -2316,6 +2344,7 @@ describe('createAdcpServer', () => {
           async updateProgress() {},
           _registerBackground() {},
           async awaitTask() {},
+          async _awaitTaskUnsafe() {},
         },
         resolveAccountFromAuth: async () => ({ id: 'acct_1' }),
       });
@@ -2338,7 +2367,13 @@ describe('createAdcpServer', () => {
         ownerScope: 'api_key:buyer-1',
         hasWebhook: true,
       });
-      await taskRegistry.complete(owned.taskId, { creatives: [{ creative_id: 'cr_1' }] });
+      await taskRegistry.complete(
+        owned.taskId,
+        { accountId: 'acct_1', ownerScope: 'api_key:buyer-1' },
+        {
+          creatives: [{ creative_id: 'cr_1' }],
+        }
+      );
       const other = await taskRegistry.create({
         tool: 'activate_signal',
         accountId: 'acct_2',
@@ -2382,7 +2417,12 @@ describe('createAdcpServer', () => {
       });
       const failure = { code: 'SERVICE_UNAVAILABLE', message: 'seller unavailable', recovery: 'transient' };
       const failureArtifact = { errors: [failure] };
-      await taskRegistry.fail(failed.taskId, failure, failureArtifact);
+      await taskRegistry.fail(
+        failed.taskId,
+        { accountId: 'acct_1', ownerScope: 'api_key:buyer-1' },
+        failure,
+        failureArtifact
+      );
       const failedWithoutResult = await callTool(server, 'get_task_status', { task_id: failed.taskId }, buyerOne);
       assert.strictEqual(failedWithoutResult.status, 'failed');
       assert.strictEqual(failedWithoutResult.result, undefined);
@@ -2439,7 +2479,13 @@ describe('createAdcpServer', () => {
         ownerScope: 'api_key:buyer-1',
         overrideTaskId: opaqueTaskId,
       });
-      await taskRegistry.complete(opaque.taskId, { creatives: [{ creative_id: 'cr_opaque' }] });
+      await taskRegistry.complete(
+        opaque.taskId,
+        { accountId: 'acct_1', ownerScope: 'api_key:buyer-1' },
+        {
+          creatives: [{ creative_id: 'cr_opaque' }],
+        }
+      );
       const opaqueStatus = await callTool(server, 'get_task_status', { task_id: opaqueTaskId }, buyerOne);
       assert.strictEqual(opaqueStatus.task_id, opaqueTaskId);
 
@@ -2466,6 +2512,7 @@ describe('createAdcpServer', () => {
         updatedAt: now,
       };
       const taskRegistry = {
+        scopeVersion: 1,
         create: async () => ({ taskId: record.taskId }),
         getTask: async taskId => (taskId === record.taskId ? record : null),
         complete: async () => {},
@@ -2512,7 +2559,13 @@ describe('createAdcpServer', () => {
           accountId: 'acct_1',
           ownerScope: 'api_key:buyer-1',
         });
-        await taskRegistry.complete(task.taskId, { outcome: 'completed' });
+        await taskRegistry.complete(
+          task.taskId,
+          { accountId: 'acct_1', ownerScope: 'api_key:buyer-1' },
+          {
+            outcome: 'completed',
+          }
+        );
         tasks.push(task);
       }
       const server = createAdcpServer({
@@ -2544,7 +2597,13 @@ describe('createAdcpServer', () => {
         accountId: 'acct_1',
         ownerScope: 'api_key:buyer-1',
       });
-      await taskRegistry.complete(owned.taskId, { event_sources: [{ event_source_id: 'evt_1' }] });
+      await taskRegistry.complete(
+        owned.taskId,
+        { accountId: 'acct_1', ownerScope: 'api_key:buyer-1' },
+        {
+          event_sources: [{ event_source_id: 'evt_1' }],
+        }
+      );
       const server = createAdcpServer({
         name: 'Test',
         version: '1.0.0',
@@ -2571,7 +2630,13 @@ describe('createAdcpServer', () => {
         accountId: 'acct_shared',
         ownerScope: 'api_key:buyer-1',
       });
-      await taskRegistry.complete(owned.taskId, { creatives: [{ creative_id: 'cr_1' }] });
+      await taskRegistry.complete(
+        owned.taskId,
+        { accountId: 'acct_shared', ownerScope: 'api_key:buyer-1' },
+        {
+          creatives: [{ creative_id: 'cr_1' }],
+        }
+      );
       const server = createAdcpServer({
         name: 'Test',
         version: '1.0.0',
@@ -2595,13 +2660,25 @@ describe('createAdcpServer', () => {
         accountId: 'acct_shared',
         ownerScope: 'session:channel-a',
       });
-      await taskRegistry.complete(channelA.taskId, { creatives: [{ creative_id: 'cr_a' }] });
+      await taskRegistry.complete(
+        channelA.taskId,
+        { accountId: 'acct_shared', ownerScope: 'session:channel-a' },
+        {
+          creatives: [{ creative_id: 'cr_a' }],
+        }
+      );
       const channelB = await taskRegistry.create({
         tool: 'sync_creatives',
         accountId: 'acct_shared',
         ownerScope: 'session:channel-b',
       });
-      await taskRegistry.complete(channelB.taskId, { creatives: [{ creative_id: 'cr_b' }] });
+      await taskRegistry.complete(
+        channelB.taskId,
+        { accountId: 'acct_shared', ownerScope: 'session:channel-b' },
+        {
+          creatives: [{ creative_id: 'cr_b' }],
+        }
+      );
       const server = createAdcpServer({
         name: 'Test',
         version: '1.0.0',
@@ -2670,10 +2747,14 @@ describe('createAdcpServer', () => {
         name: 'Test',
         version: '1.0.0',
         taskRegistry: {
+          scopeVersion: 1,
           async create() {
             return { taskId: 'unused' };
           },
           async getTask(taskId) {
+            return tasks.find(task => task.taskId === taskId) ?? null;
+          },
+          async _getTaskUnsafe(taskId) {
             return tasks.find(task => task.taskId === taskId) ?? null;
           },
           async list() {
@@ -2684,6 +2765,7 @@ describe('createAdcpServer', () => {
           async updateProgress() {},
           _registerBackground() {},
           async awaitTask() {},
+          async _awaitTaskUnsafe() {},
         },
         resolveAccountFromAuth: async () => ({ id: 'acct_1' }),
       });
@@ -2716,10 +2798,14 @@ describe('createAdcpServer', () => {
         name: 'Test',
         version: '1.0.0',
         taskRegistry: {
+          scopeVersion: 1,
           async create() {
             return { taskId: task.taskId };
           },
           async getTask(taskId) {
+            return taskId === task.taskId ? task : null;
+          },
+          async _getTaskUnsafe(taskId) {
             return taskId === task.taskId ? task : null;
           },
           async list() {
@@ -2730,6 +2816,7 @@ describe('createAdcpServer', () => {
           async updateProgress() {},
           _registerBackground() {},
           async awaitTask() {},
+          async _awaitTaskUnsafe() {},
         },
         resolveAccountFromAuth: async () => ({ id: 'acct_shared' }),
       });
@@ -2746,7 +2833,13 @@ describe('createAdcpServer', () => {
         accountId: 'acct_auth',
         ownerScope: 'api_key:buyer-1',
       });
-      await taskRegistry.complete(owned.taskId, { creatives: [{ creative_id: 'cr_1' }] });
+      await taskRegistry.complete(
+        owned.taskId,
+        { accountId: 'acct_auth', ownerScope: 'api_key:buyer-1' },
+        {
+          creatives: [{ creative_id: 'cr_1' }],
+        }
+      );
       const server = createAdcpServer({
         name: 'Test',
         version: '1.0.0',
@@ -2788,10 +2881,14 @@ describe('createAdcpServer', () => {
         name: 'Test',
         version: '1.0.0',
         taskRegistry: {
+          scopeVersion: 1,
           async create() {
             return { taskId: task.taskId };
           },
           async getTask(taskId) {
+            return taskId === task.taskId ? task : null;
+          },
+          async _getTaskUnsafe(taskId) {
             return taskId === task.taskId ? task : null;
           },
           async list() {
@@ -2802,6 +2899,7 @@ describe('createAdcpServer', () => {
           async updateProgress() {},
           _registerBackground() {},
           async awaitTask() {},
+          async _awaitTaskUnsafe() {},
         },
         resolveAccount: async ref => ({ id: ref.account_id }),
       });
@@ -2840,7 +2938,13 @@ describe('createAdcpServer', () => {
         accountId: 'acct_1',
         ownerScope: 'api_key:buyer-1',
       });
-      await taskRegistry.complete(owned.taskId, { creatives: [{ creative_id: 'cr_1' }] });
+      await taskRegistry.complete(
+        owned.taskId,
+        { accountId: 'acct_1', ownerScope: 'api_key:buyer-1' },
+        {
+          creatives: [{ creative_id: 'cr_1' }],
+        }
+      );
       const server = createAdcpServer({
         name: 'Test',
         version: '1.0.0',
@@ -2880,7 +2984,13 @@ describe('createAdcpServer', () => {
     it('fails closed when task polling has no account scope', async () => {
       const taskRegistry = createInMemoryTaskRegistry();
       const owned = await taskRegistry.create({ tool: 'sync_creatives', accountId: 'acct_1' });
-      await taskRegistry.complete(owned.taskId, { creatives: [{ creative_id: 'cr_1' }] });
+      await taskRegistry.complete(
+        owned.taskId,
+        { accountId: 'acct_1', ownerScope: 'account:acct_1' },
+        {
+          creatives: [{ creative_id: 'cr_1' }],
+        }
+      );
       const other = await taskRegistry.create({ tool: 'activate_signal', accountId: 'acct_2' });
       const server = createAdcpServer({ name: 'Test', version: '1.0.0', taskRegistry });
 

--- a/test/server-decisioning-broadcast-tv.test.js
+++ b/test/server-decisioning-broadcast-tv.test.js
@@ -178,8 +178,8 @@ describe('BroadcastTvSeller — HITL via *Task variants', () => {
     assert.strictEqual(result.structuredContent.status, 'submitted');
     const taskId = result.structuredContent.task_id;
 
-    await server.awaitTask(taskId);
-    const final = await server.getTaskState(taskId);
+    await server.awaitTaskUnsafe(taskId);
+    const final = await server.getTaskStateUnsafe(taskId);
     assert.strictEqual(final.status, 'completed');
     assert.strictEqual(final.result.status, 'pending_start');
     assert.ok(final.result.media_buy_id.startsWith('mb_WCBS_'));
@@ -214,7 +214,7 @@ describe('BroadcastTvSeller — HITL via *Task variants', () => {
       });
 
       const taskId = result.structuredContent.task_id;
-      await server.awaitTask(taskId);
+      await server.awaitTaskUnsafe(taskId);
       await new Promise(r => setTimeout(r, 60));
 
       const activations = received.filter(e => e.resource_type === 'media_buy' && e.payload.status === 'active');
@@ -266,9 +266,9 @@ describe('BroadcastTvSeller — HITL via *Task variants', () => {
     });
 
     const taskId = result.structuredContent.task_id;
-    await server.awaitTask(taskId);
+    await server.awaitTaskUnsafe(taskId);
 
-    const final = await server.getTaskState(taskId);
+    const final = await server.getTaskStateUnsafe(taskId);
     assert.strictEqual(final.status, 'completed');
     // Task result is the wire-shape `{ creatives: [...] }` envelope (framework
     // wraps the per-creative rows when the handoff resolves).

--- a/test/server-decisioning-from-platform.test.js
+++ b/test/server-decisioning-from-platform.test.js
@@ -20,6 +20,7 @@ const { StaticJwksResolver, InMemoryReplayStore, InMemoryRevocationStore } = req
 const { getSchemaValidatorByRef } = require('../dist/lib/validation/schema-loader');
 const { toCanonicalOnlyResponse } = require('../dist/lib/v2/projection');
 const { createIdempotencyStore, memoryBackend } = require('../dist/lib/server/idempotency');
+const { createInMemoryTaskRegistry } = require('../dist/lib/server/decisioning/runtime/task-registry');
 
 const PRODUCTS_ONLY_BRIEF_VECTORS = JSON.parse(
   readFileSync(
@@ -3301,6 +3302,73 @@ describe('CreativeBuilderPlatform + AudiencePlatform wiring', () => {
     assert.ok(sawReq, 'creative.buildCreative should be invoked');
   });
 
+  it('passes the BuildCreativeVariantSuccess arm through without manifest wrapping (#2706)', async () => {
+    const variantResponse = {
+      creatives: [
+        {
+          build_creative_id: 'build-1',
+          variants: [
+            {
+              build_variant_id: 'variant-1',
+              creative_manifest: {
+                format_id: { id: 'standard', agent_url: 'https://creative.example/' },
+                assets: {},
+              },
+              variant_axis_value: 'voice-1',
+              recommended: true,
+              rank: 1,
+            },
+          ],
+        },
+      ],
+      items_total: 1,
+      items_returned: 1,
+      leaves_total: 2,
+      leaves_returned: 1,
+      budget_status: 'capped',
+      errors: [{ code: 'BUDGET_CAP_REACHED', message: 'Spend cap reached', recovery: 'correctable' }],
+    };
+    const platform = {
+      ...buildCreativeOnlyPlatform({ specialisms: ['creative-generative'] }),
+      creative: { buildCreativeLegacy: async () => variantResponse },
+    };
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'variant-builder',
+      version: '1.0.0',
+      validation: { requests: 'off', responses: 'strict' },
+    });
+    const result = await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: { name: 'build_creative', arguments: {} },
+    });
+
+    assert.notStrictEqual(result.isError, true, JSON.stringify(result.structuredContent));
+    assert.deepStrictEqual(result.structuredContent.creatives, variantResponse.creatives);
+    assert.strictEqual(result.structuredContent.status, 'completed');
+    assert.strictEqual(result.structuredContent.budget_status, 'capped');
+    assert.strictEqual(result.structuredContent.errors[0].code, 'BUDGET_CAP_REACHED');
+    assert.strictEqual(result.structuredContent.creative_manifest, undefined);
+  });
+
+  it('keeps malformed creative variant groups rejected by strict response validation (#2706)', async () => {
+    const platform = {
+      ...buildCreativeOnlyPlatform({ specialisms: ['creative-generative'] }),
+      creative: { buildCreativeLegacy: async () => ({ creatives: [{}] }) },
+    };
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'invalid-variant-builder',
+      version: '1.0.0',
+      validation: { requests: 'off', responses: 'strict' },
+    });
+    const result = await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: { name: 'build_creative', arguments: {} },
+    });
+
+    assert.strictEqual(result.isError, true);
+    assert.strictEqual(result.structuredContent.adcp_error.code, 'VALIDATION_ERROR');
+  });
+
   it('preview_creative dispatches canonical capability and creative-library routes through previewCreative', async () => {
     const seen = [];
     const platform = {
@@ -3800,9 +3868,9 @@ describe('HITL dual-method dispatch — *Task variants', () => {
     assert.strictEqual(result.structuredContent.proposals, undefined);
 
     const taskId = result.structuredContent.task_id;
-    await server.awaitTask(taskId);
+    await server.awaitTaskUnsafe(taskId);
 
-    const finalRecord = await server.getTaskState(taskId);
+    const finalRecord = await server.getTaskStateUnsafe(taskId);
     assert.strictEqual(finalRecord.status, 'completed');
     assert.deepStrictEqual(finalRecord.result, {
       products: [
@@ -3850,9 +3918,9 @@ describe('HITL dual-method dispatch — *Task variants', () => {
     assert.strictEqual(result.structuredContent.signals, undefined);
 
     const taskId = result.structuredContent.task_id;
-    await server.awaitTask(taskId);
+    await server.awaitTaskUnsafe(taskId);
 
-    const finalRecord = await server.getTaskState(taskId);
+    const finalRecord = await server.getTaskStateUnsafe(taskId);
     assert.strictEqual(finalRecord.status, 'completed');
     assert.deepStrictEqual(finalRecord.result, {
       signals: [{ signal_agent_segment_id: 'sig_async', name: 'Async signal' }],
@@ -3941,7 +4009,7 @@ describe('HITL dual-method dispatch — *Task variants', () => {
     );
 
     releaseTask();
-    await server.awaitTask(taskId);
+    await server.awaitTaskUnsafe(taskId);
 
     const completed = await server.dispatchTestRequest({
       method: 'tools/call',
@@ -4064,7 +4132,7 @@ describe('HITL dual-method dispatch — *Task variants', () => {
     );
 
     releaseTask();
-    await server.awaitTask(taskId);
+    await server.awaitTaskUnsafe(taskId);
 
     const completed = await server.dispatchTestRequest({
       method: 'tools/call',
@@ -4251,9 +4319,9 @@ describe('HITL dual-method dispatch — *Task variants', () => {
     );
 
     const taskId = result.structuredContent.task_id;
-    await server.awaitTask(taskId);
+    await server.awaitTaskUnsafe(taskId);
 
-    const finalRecord = await server.getTaskState(taskId);
+    const finalRecord = await server.getTaskStateUnsafe(taskId);
     assert.strictEqual(finalRecord.status, 'completed');
     assert.deepStrictEqual(finalRecord.result, { media_buy_id: 'mb_final', status: 'active' });
   });
@@ -4298,8 +4366,8 @@ describe('HITL dual-method dispatch — *Task variants', () => {
 
     const submitted = await dispatchCreate(server);
     assert.strictEqual(submitted.structuredContent.status, 'submitted');
-    await server.awaitTask(submitted.structuredContent.task_id);
-    const finalRecord = await server.getTaskState(submitted.structuredContent.task_id);
+    await server.awaitTaskUnsafe(submitted.structuredContent.task_id);
+    const finalRecord = await server.getTaskStateUnsafe(submitted.structuredContent.task_id);
 
     assert.strictEqual(finalRecord.status, 'completed');
     const creative = finalRecord.result.packages[0].creatives[0];
@@ -4335,7 +4403,7 @@ describe('HITL dual-method dispatch — *Task variants', () => {
     assert.strictEqual(submitted.structuredContent.media_buy_id, undefined);
 
     const taskId = submitted.structuredContent.task_id;
-    await server.awaitTask(taskId);
+    await server.awaitTaskUnsafe(taskId);
 
     const polled = await server.dispatchTestRequest({
       method: 'tools/call',
@@ -4451,8 +4519,8 @@ describe('HITL dual-method dispatch — *Task variants', () => {
     });
     assert.strictEqual(slowResult.structuredContent.status, 'submitted');
     assert.ok(slowResult.structuredContent.task_id);
-    await server.awaitTask(slowResult.structuredContent.task_id);
-    const finalSlow = await server.getTaskState(slowResult.structuredContent.task_id);
+    await server.awaitTaskUnsafe(slowResult.structuredContent.task_id);
+    const finalSlow = await server.getTaskStateUnsafe(slowResult.structuredContent.task_id);
     assert.strictEqual(finalSlow.result.media_buy_id, 'mb_hitl_slow');
   });
 
@@ -4498,9 +4566,9 @@ describe('HITL dual-method dispatch — *Task variants', () => {
     assert.strictEqual(result.structuredContent.status, 'submitted');
     const taskId = result.structuredContent.task_id;
 
-    await server.awaitTask(taskId);
+    await server.awaitTaskUnsafe(taskId);
 
-    const finalRecord = await server.getTaskState(taskId);
+    const finalRecord = await server.getTaskStateUnsafe(taskId);
     assert.strictEqual(finalRecord.status, 'failed');
     assert.strictEqual(finalRecord.error.code, 'GOVERNANCE_DENIED');
     assert.strictEqual(finalRecord.error.recovery, 'terminal');
@@ -4523,9 +4591,9 @@ describe('HITL dual-method dispatch — *Task variants', () => {
     const result = await dispatchCreate(server);
     const taskId = result.structuredContent.task_id;
 
-    await server.awaitTask(taskId);
+    await server.awaitTaskUnsafe(taskId);
 
-    const finalRecord = await server.getTaskState(taskId);
+    const finalRecord = await server.getTaskStateUnsafe(taskId);
     assert.strictEqual(finalRecord.status, 'failed');
     assert.strictEqual(finalRecord.error.code, 'SERVICE_UNAVAILABLE');
     assert.strictEqual(finalRecord.error.recovery, 'transient');
@@ -6336,7 +6404,7 @@ describe('Observability hooks (DecisioningObservabilityHooks)', () => {
         },
       },
     });
-    await server.awaitTask(result.structuredContent.task_id);
+    await server.awaitTaskUnsafe(result.structuredContent.task_id);
 
     const create = events.find(e => e.kind === 'create');
     const transition = events.find(e => e.kind === 'transition');
@@ -6363,14 +6431,11 @@ describe('Observability hooks (DecisioningObservabilityHooks)', () => {
       const inner = require('../dist/lib/server/decisioning/runtime/task-registry').createInMemoryTaskRegistry();
       return {
         ...inner,
-        create: opts => inner.create(opts),
-        getTask: id => inner.getTask(id),
         complete: async () => {
-          throw new Error('connection refused');
+          const error = new Error('secret connection details');
+          error.name = 'secret error classification';
+          throw error;
         },
-        fail: (id, err) => inner.fail(id, err),
-        _registerBackground: (id, p) => inner._registerBackground(id, p),
-        awaitTask: id => inner.awaitTask(id),
       };
     })();
     const server = createAdcpServerFromPlatform(platform, {
@@ -6403,7 +6468,7 @@ describe('Observability hooks (DecisioningObservabilityHooks)', () => {
         },
       },
     });
-    await server.awaitTask(result.structuredContent.task_id);
+    await server.awaitTaskUnsafe(result.structuredContent.task_id);
     assert.strictEqual(transitions.length, 1);
     assert.strictEqual(transitions[0].status, 'failed');
     assert.strictEqual(transitions[0].errorCode, 'REGISTRY_WRITE_FAILED');
@@ -6411,6 +6476,10 @@ describe('Observability hooks (DecisioningObservabilityHooks)', () => {
     assert.ok(
       errors.find(e => e.includes('registry write failed')),
       'error logged'
+    );
+    assert.ok(
+      errors.every(e => !e.includes('secret')),
+      'registry error details are not logged'
     );
   });
 
@@ -6440,7 +6509,7 @@ describe('Observability hooks (DecisioningObservabilityHooks)', () => {
         },
       },
     });
-    await server.awaitTask(result.structuredContent.task_id);
+    await server.awaitTaskUnsafe(result.structuredContent.task_id);
     assert.strictEqual(transitions.length, 1);
     assert.strictEqual(transitions[0].status, 'failed');
     assert.strictEqual(transitions[0].errorCode, 'GOVERNANCE_DENIED');
@@ -6479,7 +6548,7 @@ describe('Observability hooks (DecisioningObservabilityHooks)', () => {
         },
       },
     });
-    await server.awaitTask(result.structuredContent.task_id);
+    await server.awaitTaskUnsafe(result.structuredContent.task_id);
     assert.strictEqual(emits.length, 1);
     assert.strictEqual(emits[0].url, 'https://buyer.example.com/webhook');
     assert.strictEqual(emits[0].status, 'completed');
@@ -6641,7 +6710,7 @@ describe('HITL push notification webhook on terminal state', () => {
 
     assert.strictEqual(result.structuredContent.status, 'submitted');
     const taskId = result.structuredContent.task_id;
-    await server.awaitTask(taskId);
+    await server.awaitTaskUnsafe(taskId);
 
     assert.strictEqual(emits.length, 1, 'one webhook emitted on terminal completion');
     const emit = emits[0];
@@ -6743,7 +6812,7 @@ describe('HITL push notification webhook on terminal state', () => {
         },
       },
     });
-    await server.awaitTask(result.structuredContent.task_id);
+    await server.awaitTaskUnsafe(result.structuredContent.task_id);
 
     assert.strictEqual(emits.length, 1);
     assert.strictEqual(emits[0].payload.status, 'failed');
@@ -6781,7 +6850,7 @@ describe('HITL push notification webhook on terminal state', () => {
         },
       },
     });
-    await server.awaitTask(result.structuredContent.task_id);
+    await server.awaitTaskUnsafe(result.structuredContent.task_id);
 
     assert.strictEqual(emits.length, 0, "no webhook when buyer didn't opt in");
   });
@@ -6918,7 +6987,7 @@ describe('Push notification webhook URL/token validation (B5/B6)', () => {
     const emits = [];
     const server = makeServer({ emits });
     const result = await dispatchWithUrl(server, 'https://buyer.example.com/webhook');
-    await server.awaitTask(result.structuredContent.task_id);
+    await server.awaitTaskUnsafe(result.structuredContent.task_id);
     assert.strictEqual(emits.length, 1);
     assert.strictEqual(emits[0].url, 'https://buyer.example.com/webhook');
   });
@@ -6928,7 +6997,7 @@ describe('Push notification webhook URL/token validation (B5/B6)', () => {
     const emits = [];
     const server = makeServer({ emits });
     const result = await dispatchWithUrl(server, 'http://buyer.example.com/webhook');
-    await server.awaitTask(result.structuredContent.task_id);
+    await server.awaitTaskUnsafe(result.structuredContent.task_id);
     assert.strictEqual(emits.length, 1);
   });
 
@@ -6993,7 +7062,7 @@ describe('Push notification webhook URL/token validation (B5/B6)', () => {
     const emits = [];
     const server = makeServer({ emits });
     const result = await dispatchWithUrl(server, 'https://buyer.example.com/webhook', 'tok_abc-123:xyz.456');
-    await server.awaitTask(result.structuredContent.task_id);
+    await server.awaitTaskUnsafe(result.structuredContent.task_id);
     assert.strictEqual(emits.length, 1);
     assert.strictEqual(emits[0].payload.token, 'tok_abc-123:xyz.456');
   });
@@ -7048,7 +7117,7 @@ describe('tasks_get wire tool (B9)', () => {
         },
       },
     });
-    await server.awaitTask(result.structuredContent.task_id);
+    await server.awaitTaskUnsafe(result.structuredContent.task_id);
     return result.structuredContent.task_id;
   }
 
@@ -7174,7 +7243,7 @@ describe('tasks_get wire tool (B9)', () => {
       assert.strictEqual(crossTenant.structuredContent.adcp_error.code, 'REFERENCE_NOT_FOUND');
 
       releaseTask();
-      await server.awaitTask(taskId);
+      await server.awaitTaskUnsafe(taskId);
 
       const completed = await server.dispatchTestRequest({
         method: 'tools/call',
@@ -7188,7 +7257,7 @@ describe('tasks_get wire tool (B9)', () => {
       assert.deepStrictEqual(completed.structuredContent.result, { media_buy_id: 'mb_42', status: 'active' });
     } finally {
       releaseTask();
-      if (taskId) await server.awaitTask(taskId);
+      if (taskId) await server.awaitTaskUnsafe(taskId);
     }
   });
 
@@ -7235,7 +7304,7 @@ describe('tasks_get wire tool (B9)', () => {
       },
     });
     const taskId = submitted.structuredContent.task_id;
-    await server.awaitTask(taskId);
+    await server.awaitTaskUnsafe(taskId);
 
     const status = await server.dispatchTestRequest({
       method: 'tools/call',
@@ -7434,9 +7503,46 @@ describe('tasks_get wire tool (B9)', () => {
     assert.strictEqual(result.isError, true);
     assert.strictEqual(result.structuredContent.adcp_error.code, 'REFERENCE_NOT_FOUND');
   });
+
+  it('fails closed when a custom registry returns a record outside the requested scope', async () => {
+    const inner = createInMemoryTaskRegistry();
+    const taskRegistry = {
+      ...inner,
+      getTask: async () => ({
+        taskId: 'task_known',
+        tool: 'create_media_buy',
+        accountId: 'acc_owner',
+        ownerScope: 'account:acc_owner',
+        status: 'completed',
+        result: { media_buy_id: 'mb_private' },
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:01:00.000Z',
+      }),
+    };
+    const server = createAdcpServerFromPlatform(
+      buildHitlPlatform(async () => ({ media_buy_id: 'unused' })),
+      {
+        name: 'p',
+        version: '0.0.1',
+        validation: { requests: 'off', responses: 'off' },
+        taskRegistry,
+      }
+    );
+
+    const result = await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'tasks_get',
+        arguments: { task_id: 'task_known', account: { account_id: 'acc_attacker' } },
+      },
+    });
+
+    assert.strictEqual(result.isError, true);
+    assert.strictEqual(result.structuredContent.adcp_error.code, 'REFERENCE_NOT_FOUND');
+  });
 });
 
-describe('getTaskState account-scoping (B7)', () => {
+describe('getTaskState account/principal scoping (B7)', () => {
   // Cross-tenant leak protection. getTaskState must filter by account when
   // an `expectedAccountId` is supplied — adopters wrapping it as `tasks/get`
   // pass `ctx.account.id` to scope reads.
@@ -7484,7 +7590,7 @@ describe('getTaskState account-scoping (B7)', () => {
         },
       },
     });
-    await server.awaitTask(result.structuredContent.task_id);
+    await server.awaitTaskUnsafe(result.structuredContent.task_id);
     return result.structuredContent.task_id;
   }
 
@@ -7495,7 +7601,10 @@ describe('getTaskState account-scoping (B7)', () => {
       validation: { requests: 'off', responses: 'off' },
     });
     const taskId = await createTaskFor(server, 'acc_owner');
-    const record = await server.getTaskState(taskId, 'acc_owner');
+    const record = await server.getTaskState(taskId, {
+      accountId: 'acc_owner',
+      ownerScope: 'account:acc_owner',
+    });
     assert.ok(record);
     assert.strictEqual(record.accountId, 'acc_owner');
   });
@@ -7507,18 +7616,50 @@ describe('getTaskState account-scoping (B7)', () => {
       validation: { requests: 'off', responses: 'off' },
     });
     const taskId = await createTaskFor(server, 'acc_owner');
-    const record = await server.getTaskState(taskId, 'acc_other');
+    const record = await server.getTaskState(taskId, {
+      accountId: 'acc_other',
+      ownerScope: 'account:acc_other',
+    });
     assert.strictEqual(record, null, 'cross-tenant probe must not leak the task');
   });
 
-  it('unscoped read still works (ops/test contexts)', async () => {
+  it('fails closed when a custom registry returns a mismatched record', async () => {
+    const inner = createInMemoryTaskRegistry();
+    const taskRegistry = {
+      ...inner,
+      getTask: async () => ({
+        taskId: 'task_known',
+        tool: 'create_media_buy',
+        accountId: 'acc_owner',
+        ownerScope: 'session:owner',
+        status: 'completed',
+        result: { media_buy_id: 'mb_private' },
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:01:00.000Z',
+      }),
+    };
+    const server = createAdcpServerFromPlatform(buildHitlPlatform(), {
+      name: 't',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+      taskRegistry,
+    });
+
+    const record = await server.getTaskState('task_known', {
+      accountId: 'acc_attacker',
+      ownerScope: 'session:attacker',
+    });
+    assert.strictEqual(record, null);
+  });
+
+  it('explicitly unsafe read remains available to ops/test contexts', async () => {
     const server = createAdcpServerFromPlatform(buildHitlPlatform(), {
       name: 't',
       version: '0.0.1',
       validation: { requests: 'off', responses: 'off' },
     });
     const taskId = await createTaskFor(server, 'acc_owner');
-    const record = await server.getTaskState(taskId);
+    const record = await server.getTaskStateUnsafe(taskId);
     assert.ok(record);
     assert.strictEqual(record.accountId, 'acc_owner');
   });

--- a/test/server-decisioning-handoff-task-id.test.js
+++ b/test/server-decisioning-handoff-task-id.test.js
@@ -11,6 +11,7 @@ const { describe, it } = require('node:test');
 const assert = require('node:assert');
 const { createAdcpServerFromPlatform } = require('../dist/lib/server/decisioning/runtime/from-platform');
 const { createInMemoryTaskRegistry } = require('../dist/lib/server/decisioning/runtime/task-registry');
+const ACC_1_SCOPE = { accountId: 'acc_1', ownerScope: 'account:acc_1' };
 
 function buildPlatform(overrides = {}) {
   return {
@@ -84,8 +85,8 @@ describe('ctx.handoffToTask options.task_id (#1554)', () => {
     assert.strictEqual(result.structuredContent.status, 'submitted');
     assert.strictEqual(result.structuredContent.task_id, FORCED_ID);
 
-    await server.awaitTask(FORCED_ID);
-    const record = await server.getTaskState(FORCED_ID);
+    await server.awaitTask(FORCED_ID, ACC_1_SCOPE);
+    const record = await server.getTaskState(FORCED_ID, ACC_1_SCOPE);
     assert.strictEqual(record.status, 'completed');
     assert.strictEqual(record.result.media_buy_id, 'mb_1');
   });
@@ -162,16 +163,56 @@ describe('createInMemoryTaskRegistry overrideTaskId collision guard (#1554)', ()
     assert.ok(taskId.startsWith('task_'));
   });
 
+  it('scopes reads and lifecycle writes by account plus principal (#2703)', async () => {
+    const registry = createInMemoryTaskRegistry();
+    const { taskId } = await registry.create({
+      tool: 'create_media_buy',
+      accountId: 'acct-owner',
+      ownerScope: 'api_key:buyer-owner',
+    });
+    const owner = { accountId: 'acct-owner', ownerScope: 'api_key:buyer-owner' };
+    const otherAccount = { accountId: 'acct-attacker', ownerScope: 'api_key:buyer-owner' };
+    const otherPrincipal = { accountId: 'acct-owner', ownerScope: 'api_key:buyer-attacker' };
+
+    assert.ok(await registry.getTask(taskId, owner));
+    assert.strictEqual(await registry.getTask(taskId, otherAccount), null);
+    assert.strictEqual(await registry.getTask(taskId, otherPrincipal), null);
+
+    await registry.updateProgress(taskId, otherAccount, { percent: 50 });
+    await registry.complete(taskId, otherPrincipal, { leaked: true });
+    assert.strictEqual((await registry.getTask(taskId, owner)).status, 'submitted');
+
+    await registry.complete(taskId, owner, { media_buy_id: 'mb-owner' });
+    const completed = await registry.getTask(taskId, owner);
+    assert.strictEqual(completed.status, 'completed');
+    assert.deepStrictEqual(completed.result, { media_buy_id: 'mb-owner' });
+  });
+
+  it('permits the same public task_id in separate account/principal partitions (#2703)', async () => {
+    const registry = createInMemoryTaskRegistry();
+    const first = { accountId: 'acct-a', ownerScope: 'api_key:buyer-a' };
+    const second = { accountId: 'acct-b', ownerScope: 'api_key:buyer-b' };
+    await registry.create({ tool: 't', ...first, overrideTaskId: 'task_shared' });
+    await registry.create({ tool: 't', ...second, overrideTaskId: 'task_shared' });
+
+    await registry.complete('task_shared', first, { owner: 'a' });
+    await registry.complete('task_shared', second, { owner: 'b' });
+
+    assert.deepStrictEqual((await registry.getTask('task_shared', first)).result, { owner: 'a' });
+    assert.deepStrictEqual((await registry.getTask('task_shared', second)).result, { owner: 'b' });
+    assert.strictEqual(await registry._getTaskUnsafe('task_shared'), null, 'unsafe reads fail closed when ambiguous');
+  });
+
   it('clear() removes existing tasks and preserves the registry instance', async () => {
     const registry = createInMemoryTaskRegistry();
     const registerBackground = registry._registerBackground;
     await registry.create({ tool: 't', accountId: 'a1', overrideTaskId: 'task_clear' });
-    registry._registerBackground('task_clear', new Promise(() => {}));
+    registry._registerBackground('task_clear', { accountId: 'a1', ownerScope: 'account:a1' }, new Promise(() => {}));
 
     registry.clear();
 
     assert.strictEqual(registry._registerBackground, registerBackground);
-    assert.strictEqual(await registry.getTask('task_clear'), null);
+    assert.strictEqual(await registry.getTask('task_clear', { accountId: 'a1', ownerScope: 'account:a1' }), null);
     await assert.doesNotReject(() => registry.create({ tool: 't', accountId: 'a1', overrideTaskId: 'task_clear' }));
   });
 });
@@ -193,12 +234,12 @@ describe('compliance.reset taskRegistry flush (#2154)', () => {
 
     const first = await dispatchCreate(server);
     assert.strictEqual(first.structuredContent.task_id, FORCED_ID);
-    await server.awaitTask(FORCED_ID);
-    assert.ok(await taskRegistry.getTask(FORCED_ID), 'pre-reset task is present');
+    await server.awaitTask(FORCED_ID, ACC_1_SCOPE);
+    assert.ok(await taskRegistry.getTask(FORCED_ID, ACC_1_SCOPE), 'pre-reset task is present');
 
     await server.compliance.reset();
 
-    assert.strictEqual(await taskRegistry.getTask(FORCED_ID), null, 'reset cleared task registry');
+    assert.strictEqual(await taskRegistry.getTask(FORCED_ID, ACC_1_SCOPE), null, 'reset cleared task registry');
     const second = await dispatchCreate(server);
     assert.strictEqual(second.structuredContent.task_id, FORCED_ID);
     assert.notStrictEqual(second.isError, true, JSON.stringify(second.structuredContent));

--- a/test/server-decisioning-mock-seller.test.js
+++ b/test/server-decisioning-mock-seller.test.js
@@ -219,9 +219,9 @@ describe('MockSeller worked example — unified hybrid shape', () => {
       assert.ok(result.structuredContent.task_id.startsWith('task_'));
       const taskId = result.structuredContent.task_id;
 
-      await server.awaitTask(taskId);
+      await server.awaitTaskUnsafe(taskId);
 
-      const final = await server.getTaskState(taskId);
+      const final = await server.getTaskStateUnsafe(taskId);
       assert.strictEqual(final.status, 'completed');
       assert.strictEqual(final.result.status, 'active');
     });
@@ -238,9 +238,9 @@ describe('MockSeller worked example — unified hybrid shape', () => {
       assert.strictEqual(result.structuredContent.status, 'submitted');
       const taskId = result.structuredContent.task_id;
 
-      await server.awaitTask(taskId);
+      await server.awaitTaskUnsafe(taskId);
 
-      const final = await server.getTaskState(taskId);
+      const final = await server.getTaskStateUnsafe(taskId);
       assert.strictEqual(final.status, 'failed');
       assert.strictEqual(final.error.code, 'INVALID_REQUEST');
       assert.strictEqual(final.error.recovery, 'correctable');

--- a/test/server-decisioning-postgres-task-registry.test.js
+++ b/test/server-decisioning-postgres-task-registry.test.js
@@ -12,20 +12,33 @@ const assert = require('node:assert');
 
 const DATABASE_URL = process.env.DATABASE_URL;
 const TABLE = 'adcp_decisioning_tasks';
+const NAMESPACE = 'test';
+const ACC_1_SCOPE = { accountId: 'acc_1', ownerScope: 'account:acc_1' };
+const ACCT_1_SCOPE = { accountId: 'acct_1', ownerScope: 'account:acct_1' };
 
 describe('getDecisioningTaskRegistryMigration', () => {
-  test('adds owner_scope before creating the owner/account index and keeps legacy rows nullable', () => {
+  test('Postgres registry requires an explicit trusted namespace', () => {
+    const { createPostgresTaskRegistry } = require('../dist/lib/server/decisioning');
+    const pool = {
+      async query() {
+        return { rows: [], rowCount: 0 };
+      },
+    };
+    assert.throws(() => createPostgresTaskRegistry({ pool }), /Invalid registry namespace/);
+  });
+
+  test('backfills owner_scope and migrates to a composite task identity', () => {
     const { getDecisioningTaskRegistryMigration } = require('../dist/lib/server/decisioning');
-    const sql = getDecisioningTaskRegistryMigration();
+    const sql = getDecisioningTaskRegistryMigration({ namespace: NAMESPACE });
     const addColumn = sql.indexOf('ADD COLUMN IF NOT EXISTS owner_scope TEXT');
     const ownerIndex = sql.indexOf('idx_adcp_decisioning_tasks_owner_account');
     assert.ok(addColumn >= 0, 'migration should add owner_scope for existing tables');
     assert.ok(ownerIndex > addColumn, 'owner_scope index must be created after the column exists');
-    assert.ok(!sql.includes('ALTER COLUMN owner_scope SET NOT NULL'), 'legacy rows remain nullable');
-    assert.ok(
-      !sql.includes('SET owner_scope = account_id'),
-      'legacy rows should not be rewritten to a fake owner scope'
-    );
+    assert.ok(sql.includes("SET owner_scope = 'account:' || account_id"), 'legacy rows get account fallback scope');
+    assert.ok(sql.includes("SET registry_namespace = 'test'"), 'legacy rows get the configured registry namespace');
+    assert.ok(sql.includes('ALTER COLUMN owner_scope SET NOT NULL'));
+    assert.ok(sql.includes('PRIMARY KEY (registry_namespace, account_id, owner_scope, task_id)'));
+    assert.ok(sql.includes("pg_advisory_xact_lock(hashtext('adcp-task-registry:"));
   });
 
   test('registry persists owner_scope and lists with account + owner predicates', async () => {
@@ -59,7 +72,7 @@ describe('getDecisioningTaskRegistryMigration', () => {
         throw new Error(`unexpected query: ${text}`);
       },
     };
-    const registry = createPostgresTaskRegistry({ pool });
+    const registry = createPostgresTaskRegistry({ pool, namespace: NAMESPACE });
 
     await registry.create({
       tool: 'create_media_buy',
@@ -68,28 +81,28 @@ describe('getDecisioningTaskRegistryMigration', () => {
       overrideTaskId: 'task_1',
     });
 
-    assert.deepStrictEqual(queries[0].params, ['task_1', 'create_media_buy', 'acct_1', 'api_key:buyer-1', false]);
+    assert.deepStrictEqual(queries[0].params, [
+      'task_1',
+      'create_media_buy',
+      'acct_1',
+      'api_key:buyer-1',
+      false,
+      'test',
+    ]);
 
     const listed = await registry.list({ accountId: 'acct_1', ownerScope: 'api_key:buyer-1' });
     assert.strictEqual(listed.tasks.length, 1);
     assert.strictEqual(listed.tasks[0].ownerScope, 'api_key:buyer-1');
-    assert.match(
-      queries[1].text,
-      /WHERE account_id = \$1 AND \(owner_scope = \$2 OR \(owner_scope IS NULL AND \$2 = \$3\)\)/
-    );
-    assert.deepStrictEqual(queries[1].params, ['acct_1', 'api_key:buyer-1', 'account:acct_1']);
+    assert.match(queries[1].text, /WHERE registry_namespace = \$1 AND account_id = \$2 AND owner_scope = \$3/);
+    assert.deepStrictEqual(queries[1].params, ['test', 'acct_1', 'api_key:buyer-1']);
 
     await registry.list({ accountId: 'acct_1', ownerScope: 'account:acct_1' });
-    assert.match(queries[2].text, /owner_scope IS NULL AND \$2 = \$3/);
-    assert.deepStrictEqual(queries[2].params, ['acct_1', 'account:acct_1', 'account:acct_1']);
+    assert.deepStrictEqual(queries[2].params, ['test', 'acct_1', 'account:acct_1']);
 
-    const beforeMissingScopeQueryCount = queries.length;
-    assert.deepStrictEqual(await registry.list({ accountId: 'acct_1' }), { tasks: [] });
-    assert.strictEqual(
-      queries.length,
-      beforeMissingScopeQueryCount,
-      'missing ownerScope should fail closed before issuing a broad DB query'
-    );
+    await registry.getTask('task_1', { accountId: 'acct_1', ownerScope: 'api_key:buyer-1' });
+    assert.match(queries[3].text, /task_id = \$1 AND registry_namespace = \$2 AND account_id = \$3/);
+    assert.match(queries[3].text, /owner_scope = \$4/);
+    assert.deepStrictEqual(queries[3].params, ['task_1', 'test', 'acct_1', 'api_key:buyer-1']);
   });
 
   test('in-memory registry preserves rejected and canceled terminal records', async () => {
@@ -98,15 +111,15 @@ describe('getDecisioningTaskRegistryMigration', () => {
 
     for (const status of ['rejected', 'canceled']) {
       const { taskId } = await registry.create({ tool: 'create_media_buy', accountId: 'acct_1' });
-      const seeded = await registry.getTask(taskId);
+      const seeded = await registry.getTask(taskId, ACCT_1_SCOPE);
       seeded.status = status;
       seeded.result = { terminal: status };
 
-      await registry.updateProgress(taskId, { percent: 50, message: 'must not overwrite' });
-      await registry.complete(taskId, { terminal: 'completed' });
-      await registry.fail(taskId, { code: 'INVALID_STATE', message: 'must not overwrite' });
+      await registry.updateProgress(taskId, ACCT_1_SCOPE, { percent: 50, message: 'must not overwrite' });
+      await registry.complete(taskId, ACCT_1_SCOPE, { terminal: 'completed' });
+      await registry.fail(taskId, ACCT_1_SCOPE, { code: 'INVALID_STATE', message: 'must not overwrite' });
 
-      const record = await registry.getTask(taskId);
+      const record = await registry.getTask(taskId, ACCT_1_SCOPE);
       assert.strictEqual(record.status, status);
       assert.deepStrictEqual(record.result, { terminal: status });
       assert.strictEqual(record.progress, undefined);
@@ -123,11 +136,11 @@ describe('getDecisioningTaskRegistryMigration', () => {
         return { rowCount: 0, rows: [] };
       },
     };
-    const registry = createPostgresTaskRegistry({ pool });
+    const registry = createPostgresTaskRegistry({ pool, namespace: NAMESPACE });
 
-    await registry.updateProgress('task_terminal', { percent: 50 });
-    await registry.complete('task_terminal', { terminal: 'completed' });
-    await registry.fail('task_terminal', { code: 'INVALID_STATE', message: 'must not overwrite' });
+    await registry.updateProgress('task_terminal', ACC_1_SCOPE, { percent: 50 });
+    await registry.complete('task_terminal', ACC_1_SCOPE, { terminal: 'completed' });
+    await registry.fail('task_terminal', ACC_1_SCOPE, { code: 'INVALID_STATE', message: 'must not overwrite' });
 
     assert.strictEqual(queries.length, 3);
     for (const query of queries) {
@@ -149,7 +162,7 @@ describe('createPostgresTaskRegistry', { skip: !DATABASE_URL && 'DATABASE_URL no
     getDecisioningTaskRegistryMigration = lib.getDecisioningTaskRegistryMigration;
 
     await pool.query(`DROP TABLE IF EXISTS ${TABLE} CASCADE`);
-    await pool.query(getDecisioningTaskRegistryMigration());
+    await pool.query(getDecisioningTaskRegistryMigration({ namespace: NAMESPACE }));
   });
 
   afterEach(async () => {
@@ -161,7 +174,7 @@ describe('createPostgresTaskRegistry', { skip: !DATABASE_URL && 'DATABASE_URL no
   });
 
   test('migration generates the expected table + indexes', () => {
-    const sql = getDecisioningTaskRegistryMigration();
+    const sql = getDecisioningTaskRegistryMigration({ namespace: NAMESPACE });
     assert.ok(sql.includes('CREATE TABLE IF NOT EXISTS adcp_decisioning_tasks'));
     assert.ok(sql.includes('adcp_decisioning_tasks_valid_status'));
     assert.ok(sql.includes('idx_adcp_decisioning_tasks_account_id'));
@@ -169,21 +182,33 @@ describe('createPostgresTaskRegistry', { skip: !DATABASE_URL && 'DATABASE_URL no
   });
 
   test('migration rejects invalid table names', () => {
-    assert.throws(() => getDecisioningTaskRegistryMigration({ tableName: 'DROP TABLE; --' }), /Invalid table name/);
-    assert.throws(() => getDecisioningTaskRegistryMigration({ tableName: '1bad' }), /Invalid table name/);
-    assert.throws(() => getDecisioningTaskRegistryMigration({ tableName: 'MixedCase' }), /Invalid table name/);
+    assert.throws(
+      () => getDecisioningTaskRegistryMigration({ tableName: 'DROP TABLE; --', namespace: NAMESPACE }),
+      /Invalid table name/
+    );
+    assert.throws(
+      () => getDecisioningTaskRegistryMigration({ tableName: '1bad', namespace: NAMESPACE }),
+      /Invalid table name/
+    );
+    assert.throws(
+      () => getDecisioningTaskRegistryMigration({ tableName: 'MixedCase', namespace: NAMESPACE }),
+      /Invalid table name/
+    );
   });
 
   test('factory rejects invalid table names', () => {
-    assert.throws(() => createPostgresTaskRegistry({ pool, tableName: 'Robert; DROP TABLE--' }), /Invalid table name/);
+    assert.throws(
+      () => createPostgresTaskRegistry({ pool, namespace: NAMESPACE, tableName: 'Robert; DROP TABLE--' }),
+      /Invalid table name/
+    );
   });
 
   test('create + getTask roundtrips a submitted task', async () => {
-    const registry = createPostgresTaskRegistry({ pool });
+    const registry = createPostgresTaskRegistry({ pool, namespace: NAMESPACE });
     const { taskId } = await registry.create({ tool: 'create_media_buy', accountId: 'acc_1' });
     assert.ok(taskId.startsWith('task_'));
 
-    const record = await registry.getTask(taskId);
+    const record = await registry.getTask(taskId, ACC_1_SCOPE);
     assert.ok(record);
     assert.strictEqual(record.taskId, taskId);
     assert.strictEqual(record.tool, 'create_media_buy');
@@ -194,25 +219,25 @@ describe('createPostgresTaskRegistry', { skip: !DATABASE_URL && 'DATABASE_URL no
   });
 
   test('getTask returns null for unknown task_id', async () => {
-    const registry = createPostgresTaskRegistry({ pool });
-    const record = await registry.getTask('task_unknown');
+    const registry = createPostgresTaskRegistry({ pool, namespace: NAMESPACE });
+    const record = await registry.getTask('task_unknown', ACC_1_SCOPE);
     assert.strictEqual(record, null);
   });
 
   test('complete updates status + result, then is idempotent', async () => {
-    const registry = createPostgresTaskRegistry({ pool });
+    const registry = createPostgresTaskRegistry({ pool, namespace: NAMESPACE });
     const { taskId } = await registry.create({ tool: 'create_media_buy', accountId: 'acc_1' });
 
-    await registry.complete(taskId, { media_buy_id: 'mb_42', status: 'active' });
+    await registry.complete(taskId, ACC_1_SCOPE, { media_buy_id: 'mb_42', status: 'active' });
 
-    let record = await registry.getTask(taskId);
+    let record = await registry.getTask(taskId, ACC_1_SCOPE);
     assert.strictEqual(record.status, 'completed');
     assert.deepStrictEqual(record.result, { media_buy_id: 'mb_42', status: 'active' });
 
     // Subsequent complete() is a no-op (terminal-state guard via SQL WHERE)
-    await registry.complete(taskId, { media_buy_id: 'mb_99', status: 'paused' });
+    await registry.complete(taskId, ACC_1_SCOPE, { media_buy_id: 'mb_99', status: 'paused' });
 
-    record = await registry.getTask(taskId);
+    record = await registry.getTask(taskId, ACC_1_SCOPE);
     assert.deepStrictEqual(
       record.result,
       { media_buy_id: 'mb_42', status: 'active' },
@@ -221,7 +246,7 @@ describe('createPostgresTaskRegistry', { skip: !DATABASE_URL && 'DATABASE_URL no
   });
 
   test('fail updates status + error + status_message, then is idempotent', async () => {
-    const registry = createPostgresTaskRegistry({ pool });
+    const registry = createPostgresTaskRegistry({ pool, namespace: NAMESPACE });
     const { taskId } = await registry.create({ tool: 'sync_creatives', accountId: 'acc_1' });
 
     const error = {
@@ -230,9 +255,9 @@ describe('createPostgresTaskRegistry', { skip: !DATABASE_URL && 'DATABASE_URL no
       message: 'operator declined the buy',
     };
     const artifact = { errors: [error] };
-    await registry.fail(taskId, error, artifact);
+    await registry.fail(taskId, ACC_1_SCOPE, error, artifact);
 
-    let record = await registry.getTask(taskId);
+    let record = await registry.getTask(taskId, ACC_1_SCOPE);
     assert.strictEqual(record.status, 'failed');
     assert.strictEqual(record.error.code, 'GOVERNANCE_DENIED');
     assert.strictEqual(record.error.recovery, 'terminal');
@@ -240,20 +265,28 @@ describe('createPostgresTaskRegistry', { skip: !DATABASE_URL && 'DATABASE_URL no
     assert.deepStrictEqual(record.result, artifact);
 
     // Second fail is a no-op
-    await registry.fail(taskId, { code: 'INVALID_STATE', recovery: 'correctable', message: 'should not overwrite' });
+    await registry.fail(taskId, ACC_1_SCOPE, {
+      code: 'INVALID_STATE',
+      recovery: 'correctable',
+      message: 'should not overwrite',
+    });
 
-    record = await registry.getTask(taskId);
+    record = await registry.getTask(taskId, ACC_1_SCOPE);
     assert.strictEqual(record.error.code, 'GOVERNANCE_DENIED', 'second fail must be a no-op');
   });
 
   test('complete after fail is a no-op (terminal-state guard)', async () => {
-    const registry = createPostgresTaskRegistry({ pool });
+    const registry = createPostgresTaskRegistry({ pool, namespace: NAMESPACE });
     const { taskId } = await registry.create({ tool: 'create_media_buy', accountId: 'acc_1' });
 
-    await registry.fail(taskId, { code: 'POLICY_VIOLATION', recovery: 'terminal', message: 'denied' });
-    await registry.complete(taskId, { media_buy_id: 'mb_should_not_set' });
+    await registry.fail(taskId, ACC_1_SCOPE, {
+      code: 'POLICY_VIOLATION',
+      recovery: 'terminal',
+      message: 'denied',
+    });
+    await registry.complete(taskId, ACC_1_SCOPE, { media_buy_id: 'mb_should_not_set' });
 
-    const record = await registry.getTask(taskId);
+    const record = await registry.getTask(taskId, ACC_1_SCOPE);
     assert.strictEqual(record.status, 'failed', 'complete() after fail() must not change terminal state');
     assert.strictEqual(record.result, undefined);
   });
@@ -261,18 +294,18 @@ describe('createPostgresTaskRegistry', { skip: !DATABASE_URL && 'DATABASE_URL no
   test('cross-instance read: registry A creates, registry B reads', async () => {
     // Models the load-balanced deployment scenario: process A allocates the
     // task, process B reads the lifecycle for `tasks/get`.
-    const registryA = createPostgresTaskRegistry({ pool });
-    const registryB = createPostgresTaskRegistry({ pool });
+    const registryA = createPostgresTaskRegistry({ pool, namespace: NAMESPACE });
+    const registryB = createPostgresTaskRegistry({ pool, namespace: NAMESPACE });
 
     const { taskId } = await registryA.create({ tool: 'create_media_buy', accountId: 'acc_1' });
 
-    const recordViaB = await registryB.getTask(taskId);
+    const recordViaB = await registryB.getTask(taskId, ACC_1_SCOPE);
     assert.ok(recordViaB, 'registry B sees a task created by registry A');
     assert.strictEqual(recordViaB.status, 'submitted');
 
-    await registryA.complete(taskId, { media_buy_id: 'mb_77' });
+    await registryA.complete(taskId, ACC_1_SCOPE, { media_buy_id: 'mb_77' });
 
-    const finalViaB = await registryB.getTask(taskId);
+    const finalViaB = await registryB.getTask(taskId, ACC_1_SCOPE);
     assert.strictEqual(finalViaB.status, 'completed');
     assert.deepStrictEqual(finalViaB.result, { media_buy_id: 'mb_77' });
   });
@@ -280,12 +313,12 @@ describe('createPostgresTaskRegistry', { skip: !DATABASE_URL && 'DATABASE_URL no
   test('custom tableName works end-to-end', async () => {
     const customTable = 'custom_decisioning_tasks';
     await pool.query(`DROP TABLE IF EXISTS ${customTable} CASCADE`);
-    await pool.query(getDecisioningTaskRegistryMigration({ tableName: customTable }));
+    await pool.query(getDecisioningTaskRegistryMigration({ tableName: customTable, namespace: NAMESPACE }));
 
-    const registry = createPostgresTaskRegistry({ pool, tableName: customTable });
+    const registry = createPostgresTaskRegistry({ pool, namespace: NAMESPACE, tableName: customTable });
     const { taskId } = await registry.create({ tool: 'create_media_buy', accountId: 'acc_1' });
 
-    const record = await registry.getTask(taskId);
+    const record = await registry.getTask(taskId, ACC_1_SCOPE);
     assert.ok(record);
     assert.strictEqual(record.taskId, taskId);
 
@@ -296,7 +329,7 @@ describe('createPostgresTaskRegistry', { skip: !DATABASE_URL && 'DATABASE_URL no
     // hasWebhook is set when buyer wires push_notification_config.url at
     // dispatch time; surfaced via tasks_get's spec-defined `has_webhook`
     // field. Two records: one with, one without.
-    const registry = createPostgresTaskRegistry({ pool });
+    const registry = createPostgresTaskRegistry({ pool, namespace: NAMESPACE });
     const { taskId: tWithHook } = await registry.create({
       tool: 'create_media_buy',
       accountId: 'acc_1',
@@ -307,14 +340,14 @@ describe('createPostgresTaskRegistry', { skip: !DATABASE_URL && 'DATABASE_URL no
       accountId: 'acc_1',
     });
 
-    const r1 = await registry.getTask(tWithHook);
-    const r2 = await registry.getTask(tNoHook);
+    const r1 = await registry.getTask(tWithHook, ACC_1_SCOPE);
+    const r2 = await registry.getTask(tNoHook, ACC_1_SCOPE);
     assert.strictEqual(r1.hasWebhook, true);
     assert.strictEqual(r2.hasWebhook, undefined, 'hasWebhook omitted on read when stored false');
   });
 
-  test('list enforces owner_scope and only exposes legacy null rows to account fallback', async () => {
-    const registry = createPostgresTaskRegistry({ pool });
+  test('list enforces owner_scope and exposes account fallback tasks only to that scope', async () => {
+    const registry = createPostgresTaskRegistry({ pool, namespace: NAMESPACE });
     const { taskId: scoped } = await registry.create({
       tool: 'sync_creatives',
       accountId: 'acc_1',
@@ -325,11 +358,11 @@ describe('createPostgresTaskRegistry', { skip: !DATABASE_URL && 'DATABASE_URL no
       accountId: 'acc_1',
       ownerScope: 'session:publisher-b',
     });
-    await pool.query(
-      `INSERT INTO ${TABLE} (task_id, tool, account_id, owner_scope, status, has_webhook)
-       VALUES ($1, $2, $3, NULL, 'submitted', FALSE)`,
-      ['task_legacy_ownerless', 'sync_creatives', 'acc_1']
-    );
+    const { taskId: accountScoped } = await registry.create({
+      tool: 'sync_creatives',
+      accountId: 'acc_1',
+      overrideTaskId: 'task_account_fallback',
+    });
 
     const publisherA = await registry.list({ accountId: 'acc_1', ownerScope: 'session:publisher-a' });
     assert.deepStrictEqual(
@@ -346,22 +379,80 @@ describe('createPostgresTaskRegistry', { skip: !DATABASE_URL && 'DATABASE_URL no
     const accountFallback = await registry.list({ accountId: 'acc_1', ownerScope: 'account:acc_1' });
     assert.deepStrictEqual(
       accountFallback.tasks.map(task => task.taskId),
-      ['task_legacy_ownerless']
+      [accountScoped]
     );
+  });
+
+  test('migration backfills legacy tasks into the configured namespace', async () => {
+    const legacyTable = 'legacy_decisioning_tasks';
+    await pool.query(`DROP TABLE IF EXISTS ${legacyTable} CASCADE`);
+    try {
+      await pool.query(`
+        CREATE TABLE ${legacyTable} (
+          task_id TEXT PRIMARY KEY,
+          tool TEXT NOT NULL,
+          account_id TEXT NOT NULL,
+          status TEXT NOT NULL DEFAULT 'submitted',
+          status_message TEXT,
+          result JSONB,
+          error JSONB,
+          progress JSONB,
+          has_webhook BOOLEAN NOT NULL DEFAULT FALSE,
+          created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+          updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+          CONSTRAINT ${legacyTable}_valid_status CHECK (
+            status IN ('submitted', 'working', 'completed', 'failed')
+          )
+        )
+      `);
+      await pool.query(`INSERT INTO ${legacyTable} (task_id, tool, account_id) VALUES ($1, $2, $3)`, [
+        'task_legacy',
+        'sync_creatives',
+        'acc_legacy',
+      ]);
+
+      await pool.query(getDecisioningTaskRegistryMigration({ tableName: legacyTable, namespace: 'tenant:migrated' }));
+
+      const migrated = createPostgresTaskRegistry({
+        pool,
+        tableName: legacyTable,
+        namespace: 'tenant:migrated',
+      });
+      const record = await migrated.getTask('task_legacy', {
+        accountId: 'acc_legacy',
+        ownerScope: 'account:acc_legacy',
+      });
+      assert.ok(record);
+
+      const otherNamespace = createPostgresTaskRegistry({
+        pool,
+        tableName: legacyTable,
+        namespace: 'tenant:other',
+      });
+      assert.strictEqual(
+        await otherNamespace.getTask('task_legacy', {
+          accountId: 'acc_legacy',
+          ownerScope: 'account:acc_legacy',
+        }),
+        null
+      );
+    } finally {
+      await pool.query(`DROP TABLE IF EXISTS ${legacyTable} CASCADE`);
+    }
   });
 
   test('complete() rejects oversized result with descriptive error', async () => {
     // 4MB cap on JSONB column. 5MB string trips assertResultSize before
     // the DB write — protects the Node process from OOM on a malicious
     // adopter return.
-    const registry = createPostgresTaskRegistry({ pool });
+    const registry = createPostgresTaskRegistry({ pool, namespace: NAMESPACE });
     const { taskId } = await registry.create({ tool: 'create_media_buy', accountId: 'acc_1' });
 
     const oversized = { huge: 'x'.repeat(5 * 1024 * 1024) };
-    await assert.rejects(registry.complete(taskId, oversized), /exceeds.*bytes/);
+    await assert.rejects(registry.complete(taskId, ACC_1_SCOPE, oversized), /exceeds.*bytes/);
 
     // Task stays submitted — failed write didn't transition.
-    const record = await registry.getTask(taskId);
+    const record = await registry.getTask(taskId, ACC_1_SCOPE);
     assert.strictEqual(record.status, 'submitted');
   });
 
@@ -369,14 +460,14 @@ describe('createPostgresTaskRegistry', { skip: !DATABASE_URL && 'DATABASE_URL no
     // safeStringify wraps JSON.stringify so adopter circular-ref returns
     // surface as a clear "not JSON-serializable" error pointing at the
     // task id, instead of bubbling as a generic registry-write fail.
-    const registry = createPostgresTaskRegistry({ pool });
+    const registry = createPostgresTaskRegistry({ pool, namespace: NAMESPACE });
     const { taskId } = await registry.create({ tool: 'create_media_buy', accountId: 'acc_1' });
 
     const circular = { name: 'mb_42' };
     circular.self = circular;
-    await assert.rejects(registry.complete(taskId, circular), /not JSON-serializable/);
+    await assert.rejects(registry.complete(taskId, ACC_1_SCOPE, circular), /not JSON-serializable/);
 
-    const record = await registry.getTask(taskId);
+    const record = await registry.getTask(taskId, ACC_1_SCOPE);
     assert.strictEqual(record.status, 'submitted');
   });
 });

--- a/test/server-pool-shortcut.test.js
+++ b/test/server-pool-shortcut.test.js
@@ -7,7 +7,7 @@ const { createAdcpServerFromPlatform, getAllAdcpMigrations } = require('../dist/
 
 describe('createAdcpServerFromPlatform — pool shortcut', () => {
   it('getAllAdcpMigrations returns concatenated DDL for all three tables', () => {
-    const ddl = getAllAdcpMigrations();
+    const ddl = getAllAdcpMigrations({ taskRegistryNamespace: 'tenant:pool-shortcut-test' });
     assert.match(ddl, /adcp_idempotency/);
     assert.match(ddl, /adcp_ctx_metadata/);
     assert.match(ddl, /CREATE TABLE/);
@@ -17,6 +17,10 @@ describe('createAdcpServerFromPlatform — pool shortcut', () => {
       tableMatches && tableMatches.length >= 3,
       `expected ≥3 CREATE TABLE statements, got ${tableMatches?.length}`
     );
+  });
+
+  it('getAllAdcpMigrations gives JavaScript callers an actionable missing-namespace error', () => {
+    assert.throws(() => getAllAdcpMigrations(), /requires \{ taskRegistryNamespace \}/);
   });
 
   it('opts.pool wires idempotency + ctxMetadata + taskRegistry without explicit per-store opts', () => {
@@ -60,6 +64,7 @@ describe('createAdcpServerFromPlatform — pool shortcut', () => {
       name: 'pool-shortcut-test',
       version: '1.0.0',
       pool: mockPool,
+      taskRegistryNamespace: 'tenant:pool-shortcut-test',
       validation: { requests: 'off', responses: 'off' },
     });
     assert.ok(server);
@@ -130,6 +135,7 @@ describe('createAdcpServerFromPlatform — pool shortcut', () => {
       name: 'override-test',
       version: '1.0.0',
       pool: mockPool,
+      taskRegistryNamespace: 'tenant:override-test',
       ctxMetadata: explicitCtxMetadata, // explicit wins
       validation: { requests: 'off', responses: 'off' },
     });
@@ -140,5 +146,44 @@ describe('createAdcpServerFromPlatform — pool shortcut', () => {
     });
 
     assert.equal(explicitCtxMetadataAccessed, true, 'explicit ctxMetadata should be used, not pool-derived default');
+  });
+
+  it('requires a trusted task registry namespace for the pool shortcut', () => {
+    const mockPool = {
+      async query() {
+        return { rows: [], rowCount: 0 };
+      },
+    };
+    const platform = {
+      capabilities: {
+        adcp_version: '3.0.0',
+        specialisms: ['sales-non-guaranteed'],
+        pricingModels: ['cpm'],
+        channels: ['display'],
+        formats: [],
+      },
+      accounts: {
+        resolution: 'derived',
+        resolve: async () => ({ id: 'pub_main', operator: 'mypub', ctx_metadata: {} }),
+      },
+      sales: {
+        getProducts: async () => ({ products: [] }),
+        createMediaBuy: async () => ({ media_buy_id: 'mb_1', status: 'active', packages: [] }),
+        updateMediaBuy: async () => ({ media_buy_id: 'mb_1', status: 'active', packages: [] }),
+        getMediaBuyDelivery: async () => ({ deliveries: [] }),
+        getMediaBuys: async () => ({ media_buys: [] }),
+      },
+    };
+
+    assert.throws(
+      () =>
+        createAdcpServerFromPlatform(platform, {
+          name: 'missing-namespace',
+          version: '1.0.0',
+          pool: mockPool,
+          validation: { requests: 'off', responses: 'off' },
+        }),
+      /taskRegistryNamespace is required/
+    );
   });
 });

--- a/test/server-tasks-get-agent-forwarding.test.js
+++ b/test/server-tasks-get-agent-forwarding.test.js
@@ -75,7 +75,7 @@ async function createCompletedTask(server, accountId) {
       },
     },
   });
-  await server.awaitTask(result.structuredContent.task_id);
+  await server.awaitTaskUnsafe(result.structuredContent.task_id);
   return result.structuredContent.task_id;
 }
 

--- a/test/type-generator-required-fields.test.js
+++ b/test/type-generator-required-fields.test.js
@@ -18,6 +18,7 @@ function runGeneratorHarness(source) {
     script,
     source
       .replaceAll('__GENERATOR__', JSON.stringify(path.join(REPO_ROOT, 'scripts/generate-types.ts')))
+      .replaceAll('__ZOD_GENERATOR__', JSON.stringify(path.join(REPO_ROOT, 'scripts/generate-zod-from-ts.ts')))
       .replaceAll('__REPO_ROOT__', JSON.stringify(REPO_ROOT))
       .replaceAll('__OUTPUT__', JSON.stringify(output))
   );
@@ -72,6 +73,74 @@ writeFileSync(__OUTPUT__, JSON.stringify({ output: relaxZodCompatibilityArrayTyp
 
   assert.match(result.output, /NamedFormatProduct \| CanonicalFormatProduct/);
   assert.match(result.output, /named_format_id: string;/);
+});
+
+test('TransformerParam defaults and enumerable option values retain arbitrary JSON types (#2704)', () => {
+  const result = runGeneratorHarness(`
+import { writeFileSync } from 'node:fs';
+import { postProcessTransformerParamJsonValues } from __ZOD_GENERATOR__;
+
+const input = \`export const TransformerParamSchema = z.object({
+    options: z.array(z.object({ value: JsonValueSchema })).optional(),
+    default: JsonValueSchema.optional(),
+});
+export const NextSchema = z.object({ value: z.object({}).passthrough() });\`;
+writeFileSync(__OUTPUT__, JSON.stringify({ output: postProcessTransformerParamJsonValues(input) }));
+`);
+
+  assert.match(result.output, /value: z\.json\(\)/);
+  assert.match(result.output, /default: z\.json\(\)\.optional\(\)/);
+  assert.match(result.output, /NextSchema = z\.object\(\{ value: z\.object/);
+});
+
+test('TransformerParam public types use recursive JSON values in aggregate tool output (#2704)', () => {
+  const result = runGeneratorHarness(`
+import { writeFileSync } from 'node:fs';
+import { normalizeTransformerParamJsonValueTypes } from __GENERATOR__;
+
+const input = \`export type TransformerParam = {} & {
+  options?: { value: {}; label?: string }[];
+  default?: {};
+}
+export interface NextType { value: {}; }\`;
+writeFileSync(__OUTPUT__, JSON.stringify({ output: normalizeTransformerParamJsonValueTypes(input) }));
+`);
+
+  assert.match(result.output, /export type JsonValue = string \| number \| boolean \| null/);
+  assert.match(result.output, /value: JsonValue/);
+  assert.match(result.output, /default\?: JsonValue/);
+  assert.match(result.output, /NextType \{ value: \{\}/);
+});
+
+test('generated TransformerParamSchema accepts scalar, array, object, and null JSON values (#2704)', () => {
+  const { TransformerParamSchema } = require('../dist/lib/types/schemas.generated.js');
+  const values = ['voice-1', 1.25, true, null, ['a', 2], { provider: 'example' }];
+
+  for (const value of values) {
+    assert.strictEqual(
+      TransformerParamSchema.safeParse({
+        field: 'voice',
+        type: 'string',
+        value_source: 'enumerable',
+        default: value,
+        options: [{ value }],
+      }).success,
+      true,
+      `expected ${JSON.stringify(value)} to remain valid JSON`
+    );
+  }
+
+  for (const value of [undefined, () => true, 1n, Symbol('not-json'), Number.NaN, Number.POSITIVE_INFINITY]) {
+    assert.strictEqual(
+      TransformerParamSchema.safeParse({
+        field: 'voice',
+        type: 'string',
+        value_source: 'enumerable',
+        options: [{ value }],
+      }).success,
+      false
+    );
+  }
 });
 
 test('PostalCountrySystem propagates unconditional requirements into every anyOf branch', () => {


### PR DESCRIPTION
## Summary

- fix webhook proof-of-control handling and bounded challenge capture
- enforce account/principal/namespace task isolation with a documented major migration
- repair arbitrary JSON transformer values, governance delivery types, creative variant returns, and legacy selector routing
- add focused regressions and packed-adopter type coverage

## Verification

- expert protocol, security, DX, and code reviews: ship
- npm run build
- npm run typecheck
- npm run check:adopter-types
- focused server, task-registry, webhook, generator, and routing suites
- npm run review:codex -- --all --base main

Closes #2701
Closes #2702
Closes #2703
Closes #2704
Closes #2705
Closes #2706
Closes #2707

Related to #2708. Its protocol-cache update remains dependent on upstream adcontextprotocol/adcp#6883, so this PR intentionally does not close it.