### PR TITLE
fix: reduce published SDK package below 20 MB

### DIFF
--- a/.changeset/compact-offline-schemas.md
+++ b/.changeset/compact-offline-schemas.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Reduce install size by publishing compact offline schema bundles and omitting source maps.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,7 +225,7 @@ jobs:
           if [ -z "$base" ] || ! git cat-file -e "${base}^{commit}" 2>/dev/null; then
             # No usable base (first push, force-push, scheduled run) — run to be safe.
             echo "changed=true" >> "$GITHUB_OUTPUT"
-          elif git diff --name-only "$base" HEAD | grep -qE '^(package\.json|package-lock\.json|tsup\.config\.ts|tsconfig\.json|tsconfig\.lib\.json|tsconfig\.build\.json|scripts/(generate-dmts-declarations|generate-per-tool-types|copy-schemas-to-dist|copy-v2-projection-catalog|generate-wire-spec-fields)\.ts|scripts/(verify-package|check-package-size)\.mjs|\.github/workflows/ci\.yml)$'; then
+          elif git diff --name-only "$base" HEAD | grep -qE '^(ADCP_VERSION|package\.json|package-lock\.json|tsup\.config\.ts|tsconfig\.json|tsconfig\.lib\.json|tsconfig\.build\.json|scripts/(generate-dmts-declarations|generate-per-tool-types|copy-schemas-to-dist|copy-v2-projection-catalog|generate-wire-spec-fields|compact-schema-bundle)\.ts|scripts/(verify-package|check-package-size)\.mjs|src/lib/(validation/(bundled-schema-store|schema-loader)|conformance/schemaLoader|server/error-arm-tools)\.ts|\.github/workflows/ci\.yml)$'; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"

--- a/docs/development/PACKAGE-VERIFICATION.md
+++ b/docs/development/PACKAGE-VERIFICATION.md
@@ -44,11 +44,31 @@ Requires a prior `npm run build:lib` (it inspects `dist/`).
 
 `scripts/check-package-size.mjs` asks npm for the exact dry-run pack manifest
 and fails closed if its size metadata is missing. It enforces budgets for
-compressed bytes, installed bytes, and entry count, plus separate limits for
-the canonical generated schema declaration and its ESM façade. Because it runs
+compressed bytes, installed bytes, file count, total compact bundled-schema
+bytes, and the canonical generated schema declaration plus its ESM façade. It
+also rejects source maps in the publish artifact. Because it runs
 unconditionally after `build:lib`, growth from any packaged source, generated
 schema, or copied cache is covered even when the live package smoke is skipped.
 The full `verify:package` smoke imports and runs the same checker.
+
+### Compact offline schema bundles
+
+The protocol cache contains both canonical schemas with `$ref` links and a
+mostly dereferenced `bundled/` copy of every tool schema. Publishing those
+upstream bundles verbatim duplicates shared definitions hundreds of times.
+`scripts/copy-schemas-to-dist.ts` instead compacts each protocol-authored
+bundled document, storing repeated schema fragments once under private local
+`$defs`. Local builds retain those compact JSON files for direct inspection.
+The published package stores them together in one Brotli archive per wire
+version; the schema loader expands the private refs before returning a schema,
+so IDs, retained refs, AJV diagnostics, and logical
+`bundled/<domain>/<tool>.json` paths remain unchanged for runtime validation
+and conformance consumers. There is no network fetch and no supported-version
+reduction.
+
+Runtime JavaScript and declaration source maps are intentionally not shipped.
+The public repository and declarations remain the debugging source, while the
+maps added thousands of files and several compressed MiB to every install.
 
 ### Why the build emits `.d.mts`
 
@@ -99,10 +119,11 @@ the tarball plus its **required** peers pinned to their **range floors** and
 (outside the workspace, so npm resolution is honest and not monorepo-deduped),
 then loads the main, enums, server, testing, and schemas entry points through
 both a real ESM `import` and a real CJS `require`, asserting each loads and
-exposes a known runtime symbol. It also type-checks the exact generated schema
-surface from `.mts` and `.cts` consumers. `server` is included so the
-`@a2a-js/sdk` peer gets real ESM/CJS load coverage through a dedicated
-entrypoint. Optional peers
+exposes a known runtime symbol. It also exercises runtime validation,
+conformance loading, and server error-arm discovery from the installed Brotli
+archives, then type-checks the exact generated schema surface from `.mts` and
+`.cts` consumers. `server` is included so the `@a2a-js/sdk` peer gets real
+ESM/CJS load coverage through a dedicated entrypoint. Optional peers
 (`peerDependenciesMeta`) are **not** installed — no tested subpath loads them,
 so pinning them would add only install weight and registry-flake surface. The
 floor/load smoke uses `npm install` (never workspace pnpm/catalog), and both

--- a/package.json
+++ b/package.json
@@ -454,6 +454,8 @@
   },
   "files": [
     "dist/lib/**/*",
+    "!dist/**/*.map",
+    "!dist/lib/schemas-data/*/bundled/**/*",
     "bin/**/*.js",
     "skills/**/*",
     ".claude-plugin/**/*",

--- a/scripts/check-package-size.mjs
+++ b/scripts/check-package-size.mjs
@@ -11,14 +11,15 @@ import { readFileSync } from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-// The signed 3.2.0-beta.6 bundle adds two substantial canonical format
-// schemas and expands the reporting/tool projections. Keep the budgets tight
-// to the resulting artifact (about 48 MiB packed, 337 MiB unpacked, 7,811
-// files) while allowing normal compressor variance across supported Node/npm
-// versions.
-const MAX_PACKED_TARBALL_BYTES = 50 * 1024 * 1024;
-const MAX_UNPACKED_PACKAGE_BYTES = 340 * 1024 * 1024;
-const MAX_PACKED_FILE_COUNT = 7_900;
+// Compact local-ref schema bundles and omission of source maps bring the
+// package below pnpm's default fetch-timeout boundary on moderate links. Keep
+// enough compressor variance for supported Node/npm versions without allowing
+// the old 48 MB artifact shape to return. The packed limit is decimal because
+// npm reports published package size in MB and issue #2579 set a 20 MB target.
+const MAX_PACKED_TARBALL_BYTES = 20_000_000;
+const MAX_UNPACKED_PACKAGE_BYTES = 120 * 1024 * 1024;
+const MAX_PACKED_FILE_COUNT = 5_800;
+const MAX_BUNDLED_SCHEMA_BYTES = 1280 * 1024;
 const MAX_CJS_SCHEMA_DECLARATION_BYTES = 45 * 1024 * 1024;
 const MAX_ESM_SCHEMA_FACADE_BYTES = 1024;
 const EXPECTED_ESM_SCHEMA_FACADE = "export * from './schemas.generated.js';\n";
@@ -81,6 +82,33 @@ export function checkPackageSize(repoRoot) {
   }
   assertAtMost('packed file count', packageInfo.entryCount, MAX_PACKED_FILE_COUNT, 'files');
 
+  const sourceMaps = packageInfo.files.filter(file => file.path.endsWith('.map'));
+  if (sourceMaps.length > 0) {
+    throw new Error(`packed package contains ${sourceMaps.length} source map files`);
+  }
+  const rawBundledSchemas = packageInfo.files.filter(
+    file => file.path.includes('/schemas-data/') && file.path.includes('/bundled/') && file.path.endsWith('.json')
+  );
+  if (rawBundledSchemas.length > 0) {
+    throw new Error(`packed package contains ${rawBundledSchemas.length} expanded bundled schema files`);
+  }
+  const bundledSchemaBytes = packageInfo.files
+    .filter(file => file.path.endsWith('/bundled.schemas.br'))
+    .reduce((sum, file) => sum + file.size, 0);
+  assertAtMost('bundled schema data', bundledSchemaBytes, MAX_BUNDLED_SCHEMA_BYTES);
+  const currentProtocolVersion = readFileSync(path.join(repoRoot, 'ADCP_VERSION'), 'utf8').trim();
+  const currentBundleKey = currentProtocolVersion.includes('-')
+    ? currentProtocolVersion
+    : currentProtocolVersion.split('.').slice(0, 2).join('.');
+  const expectedBundleKeys = new Set(['3.0', '3.1', currentBundleKey]);
+  const packedPaths = new Set(packageInfo.files.map(file => file.path));
+  for (const bundleKey of expectedBundleKeys) {
+    const expectedArchivePath = `dist/lib/schemas-data/${bundleKey}/bundled.schemas.br`;
+    if (!packedPaths.has(expectedArchivePath)) {
+      throw new Error(`packed package is missing a required bundled schema archive: ${expectedArchivePath}`);
+    }
+  }
+
   const cjsSchema = packageInfo.files.find(file => file.path === 'dist/lib/types/schemas.generated.d.ts');
   const esmSchema = packageInfo.files.find(file => file.path === 'dist/lib/types/schemas.generated.d.mts');
   if (!cjsSchema) throw new Error('packed package is missing schemas.generated.d.ts');
@@ -103,7 +131,8 @@ export function checkPackageSize(repoRoot) {
 
   console.log(
     `✅ Package size: ${mib(packageInfo.size)} MiB packed, ${mib(packageInfo.unpackedSize)} MiB unpacked, ` +
-      `${packageInfo.entryCount} files; schema declarations ${mib(cjsSchema.size)} MiB CJS + ${esmSchema.size} B ESM`
+      `${packageInfo.entryCount} files; bundled schemas ${mib(bundledSchemaBytes)} MiB; ` +
+      `schema declarations ${mib(cjsSchema.size)} MiB CJS + ${esmSchema.size} B ESM`
   );
   return packageInfo;
 }

--- a/scripts/compact-schema-bundle.ts
+++ b/scripts/compact-schema-bundle.ts
@@ -1,0 +1,241 @@
+/**
+ * Convert a mostly dereferenced bundled JSON Schema into a serializable schema
+ * that stores repeated schema nodes once under `$defs`.
+ *
+ * The upstream `bundled/` tree expands shared definitions at every use site,
+ * growing to hundreds of megabytes. This serializer replaces repeated schema
+ * nodes with private local refs while leaving annotation/default/example data
+ * alone. The runtime store expands the private refs before returning a schema.
+ */
+
+import { createHash } from 'node:crypto';
+
+type JsonObject = Record<string, unknown>;
+
+export const COMPACT_DEFINITIONS_KEY = 'x-adcp-compact-definitions';
+
+const SCHEMA_MAP_KEYWORDS = new Set(['properties', 'patternProperties', '$defs', 'definitions', 'dependentSchemas']);
+const SCHEMA_ARRAY_KEYWORDS = new Set(['allOf', 'anyOf', 'oneOf', 'prefixItems']);
+const SCHEMA_VALUE_KEYWORDS = new Set([
+  'additionalProperties',
+  'additionalItems',
+  'contains',
+  'if',
+  'then',
+  'else',
+  'not',
+  'propertyNames',
+  'contentSchema',
+  'unevaluatedProperties',
+  'unevaluatedItems',
+]);
+
+function isObject(value: unknown): value is JsonObject {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function forEachChildSchema(schema: JsonObject, visit: (schema: unknown) => void): void {
+  for (const [keyword, value] of Object.entries(schema)) {
+    if (SCHEMA_MAP_KEYWORDS.has(keyword) && isObject(value)) {
+      for (const child of Object.values(value)) visit(child);
+    } else if (SCHEMA_ARRAY_KEYWORDS.has(keyword) && Array.isArray(value)) {
+      for (const child of value) visit(child);
+    } else if (SCHEMA_VALUE_KEYWORDS.has(keyword)) {
+      visit(value);
+    } else if (keyword === 'items') {
+      if (Array.isArray(value)) {
+        for (const child of value) visit(child);
+      } else {
+        visit(value);
+      }
+    } else if (keyword === 'dependencies' && isObject(value)) {
+      for (const child of Object.values(value)) {
+        if (!Array.isArray(child)) visit(child);
+      }
+    }
+  }
+}
+
+function cloneData(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(cloneData);
+  if (!isObject(value)) return value;
+  return Object.fromEntries(Object.entries(value).map(([key, child]) => [key, cloneData(child)]));
+}
+
+/**
+ * Compact an acyclic schema object graph. Repeated schemas become private local
+ * `$defs` refs. The archive reader expands those private refs before exposing
+ * a schema, preserving the original document and AJV diagnostic paths.
+ */
+export function compactBundledSchema(root: JsonObject): JsonObject {
+  const referenceCounts = new Map<JsonObject, number>();
+  const visited = new Set<JsonObject>();
+
+  const countSchema = (value: unknown): void => {
+    if (!isObject(value)) return;
+    referenceCounts.set(value, (referenceCounts.get(value) ?? 0) + 1);
+    if (visited.has(value)) return;
+    visited.add(value);
+    forEachChildSchema(value, countSchema);
+  };
+  countSchema(root);
+
+  const signatureCache = new Map<JsonObject, string>();
+  const weightCache = new Map<JsonObject, number>();
+  const schemaSignature = (schema: JsonObject): string => {
+    const cached = signatureCache.get(schema);
+    if (cached) return cached;
+    const hash = createHash('sha256');
+    const updateHash = (value: string): void => {
+      hash.update(`${Buffer.byteLength(value)}:`);
+      hash.update(value);
+    };
+    let weight = 2;
+    for (const [keyword, value] of Object.entries(schema)) {
+      updateHash(keyword);
+      if (SCHEMA_MAP_KEYWORDS.has(keyword) && isObject(value)) {
+        for (const [key, child] of Object.entries(value)) {
+          updateHash(key);
+          if (isObject(child)) {
+            updateHash(schemaSignature(child));
+            weight += weightCache.get(child) ?? 0;
+          } else {
+            const serialized = JSON.stringify(child);
+            updateHash(serialized);
+            weight += Buffer.byteLength(serialized);
+          }
+        }
+      } else if (SCHEMA_ARRAY_KEYWORDS.has(keyword) && Array.isArray(value)) {
+        for (const child of value) {
+          if (isObject(child)) {
+            updateHash(schemaSignature(child));
+            weight += weightCache.get(child) ?? 0;
+          } else {
+            const serialized = JSON.stringify(child);
+            updateHash(serialized);
+            weight += Buffer.byteLength(serialized);
+          }
+        }
+      } else if (SCHEMA_VALUE_KEYWORDS.has(keyword) && isObject(value)) {
+        updateHash(schemaSignature(value));
+        weight += weightCache.get(value) ?? 0;
+      } else if (keyword === 'items') {
+        // Draft-07 assigns different semantics to `items: schema` and the
+        // one-element tuple form `items: [schema]`; keep their signatures
+        // distinct even though both contain the same child sequence.
+        updateHash(Array.isArray(value) ? 'tuple' : 'single');
+        const children = Array.isArray(value) ? value : [value];
+        for (const child of children) {
+          if (isObject(child)) {
+            updateHash(schemaSignature(child));
+            weight += weightCache.get(child) ?? 0;
+          } else {
+            const serialized = JSON.stringify(child);
+            updateHash(serialized);
+            weight += Buffer.byteLength(serialized);
+          }
+        }
+      } else if (keyword === 'dependencies' && isObject(value)) {
+        for (const [key, child] of Object.entries(value)) {
+          updateHash(key);
+          if (isObject(child)) {
+            updateHash(schemaSignature(child));
+            weight += weightCache.get(child) ?? 0;
+          } else {
+            const serialized = JSON.stringify(child);
+            updateHash(serialized);
+            weight += Buffer.byteLength(serialized);
+          }
+        }
+      } else {
+        const serialized = JSON.stringify(value);
+        updateHash(serialized);
+        weight += Buffer.byteLength(serialized);
+      }
+    }
+    const signature = hash.digest('hex');
+    signatureCache.set(schema, signature);
+    weightCache.set(schema, weight);
+    return signature;
+  };
+
+  const signatureGroups = new Map<string, JsonObject[]>();
+  for (const schema of visited) {
+    if (schema === root) continue;
+    const signature = schemaSignature(schema);
+    const group = signatureGroups.get(signature) ?? [];
+    group.push(schema);
+    signatureGroups.set(signature, group);
+  }
+
+  const sharedNames = new Map<JsonObject, string>();
+  const sharedDefinitions = new Map<string, JsonObject>();
+  const reservedNames = new Set(isObject(root.$defs) ? Object.keys(root.$defs) : []);
+  let sharedIndex = 0;
+  for (const group of signatureGroups.values()) {
+    const useCount = group.reduce((sum, schema) => sum + (referenceCounts.get(schema) ?? 0), 0);
+    const weight = weightCache.get(group[0]!) ?? 0;
+    // Tiny repeated schemas compress better as literals than as a definition
+    // plus multiple pointer strings. Identity-shared nodes are retained even
+    // when small because they came from an authored `$ref` boundary.
+    const identityShared = group.some(schema => (referenceCounts.get(schema) ?? 0) > 1);
+    if (useCount < 2 || (!identityShared && weight < 256)) continue;
+    let name: string;
+    do name = `__adcp_shared_${sharedIndex++}`;
+    while (reservedNames.has(name));
+    reservedNames.add(name);
+    for (const schema of group) sharedNames.set(schema, name);
+    sharedDefinitions.set(name, group[0]!);
+  }
+
+  const encodeSchema = (schema: unknown, expanding?: JsonObject, ancestors = new Set<JsonObject>()): unknown => {
+    if (!isObject(schema)) return schema;
+
+    const sharedName = sharedNames.get(schema);
+    if (sharedName && schema !== expanding) return { $ref: `#/$defs/${sharedName}` };
+    if (ancestors.has(schema)) {
+      if (!sharedName) throw new Error('Dereferenced schema contains an unaddressable cycle');
+      return { $ref: `#/$defs/${sharedName}` };
+    }
+
+    const nextAncestors = new Set(ancestors);
+    nextAncestors.add(schema);
+    const encoded: JsonObject = {};
+
+    for (const [keyword, value] of Object.entries(schema)) {
+      if (SCHEMA_MAP_KEYWORDS.has(keyword) && isObject(value)) {
+        encoded[keyword] = Object.fromEntries(
+          Object.entries(value).map(([key, child]) => [key, encodeSchema(child, undefined, nextAncestors)])
+        );
+      } else if (SCHEMA_ARRAY_KEYWORDS.has(keyword) && Array.isArray(value)) {
+        encoded[keyword] = value.map(child => encodeSchema(child, undefined, nextAncestors));
+      } else if (SCHEMA_VALUE_KEYWORDS.has(keyword)) {
+        encoded[keyword] = encodeSchema(value, undefined, nextAncestors);
+      } else if (keyword === 'items') {
+        encoded[keyword] = Array.isArray(value)
+          ? value.map(child => encodeSchema(child, undefined, nextAncestors))
+          : encodeSchema(value, undefined, nextAncestors);
+      } else if (keyword === 'dependencies' && isObject(value)) {
+        encoded[keyword] = Object.fromEntries(
+          Object.entries(value).map(([key, child]) => [
+            key,
+            Array.isArray(child) ? cloneData(child) : encodeSchema(child, undefined, nextAncestors),
+          ])
+        );
+      } else {
+        encoded[keyword] = cloneData(value);
+      }
+    }
+    return encoded;
+  };
+
+  const compacted = encodeSchema(root, root) as JsonObject;
+  if (compacted[COMPACT_DEFINITIONS_KEY] !== undefined) {
+    throw new Error(`Schema already contains reserved property ${COMPACT_DEFINITIONS_KEY}`);
+  }
+  const defs = isObject(compacted.$defs) ? { ...compacted.$defs } : {};
+  for (const [name, schema] of sharedDefinitions) defs[name] = encodeSchema(schema, schema);
+  if (Object.keys(defs).length > 0) compacted.$defs = defs;
+  if (sharedDefinitions.size > 0) compacted[COMPACT_DEFINITIONS_KEY] = [...sharedDefinitions.keys()];
+  return compacted;
+}

--- a/scripts/copy-schemas-to-dist.ts
+++ b/scripts/copy-schemas-to-dist.ts
@@ -31,6 +31,8 @@
 
 import { cpSync, existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import path from 'path';
+import { brotliCompressSync, constants as zlibConstants } from 'node:zlib';
+import { compactBundledSchema } from './compact-schema-bundle';
 
 interface ParsedVersion {
   version: string;
@@ -167,7 +169,7 @@ function patchPrereleaseGetProductsTaskType(schemaRoot: string): void {
 }
 
 function patchInlineTaskTypeEnums(root: string): void {
-  for (const entry of readdirSync(root, { withFileTypes: true })) {
+  for (const entry of readdirSync(root, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
     const abs = path.join(root, entry.name);
     if (entry.isDirectory()) {
       patchInlineTaskTypeEnums(abs);
@@ -262,6 +264,59 @@ function stripMcpOutputSchemaReferences(schemaRoot: string): void {
   visit(mcpRoot);
 }
 
+function walkJsonFiles(root: string): string[] {
+  if (!existsSync(root)) return [];
+  const files: string[] = [];
+  for (const entry of readdirSync(root, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+    const full = path.join(root, entry.name);
+    if (entry.isDirectory()) files.push(...walkJsonFiles(full));
+    else if (entry.isFile() && entry.name.endsWith('.json')) files.push(full);
+  }
+  return files;
+}
+
+/**
+ * Rebuild the upstream `bundled/` tree as compact local-ref documents. The
+ * protocol-authored bundled file itself is the input so expanding the private
+ * refs at runtime restores its exact IDs, retained refs, and diagnostic paths.
+ */
+function writeCompactBundles(sourceRoot: string, destRoot: string): void {
+  const sourceBundledRoot = path.join(sourceRoot, 'bundled');
+  if (!existsSync(sourceBundledRoot)) return;
+
+  const destBundledRoot = path.join(destRoot, 'bundled');
+  mkdirSync(destBundledRoot, { recursive: true });
+
+  let count = 0;
+  let totalBytes = 0;
+  const archive: Record<string, Record<string, unknown>> = {};
+  for (const sourceBundledFile of walkJsonFiles(sourceBundledRoot)) {
+    const relativePath = path.relative(sourceBundledRoot, sourceBundledFile);
+    const canonicalFile = path.join(destRoot, relativePath);
+    if (!existsSync(canonicalFile)) {
+      throw new Error(`Bundled schema has no canonical counterpart: ${relativePath}`);
+    }
+
+    const bundledSchema = JSON.parse(readFileSync(sourceBundledFile, 'utf8')) as Record<string, unknown>;
+    const compacted = compactBundledSchema(bundledSchema);
+    const serialized = `${JSON.stringify(compacted)}\n`;
+    const destination = path.join(destBundledRoot, relativePath);
+    mkdirSync(path.dirname(destination), { recursive: true });
+    writeFileSync(destination, serialized);
+    totalBytes += Buffer.byteLength(serialized);
+    archive[relativePath.split(path.sep).join('/')] = compacted;
+    count++;
+  }
+  const archiveContents = brotliCompressSync(Buffer.from(JSON.stringify(archive)), {
+    params: { [zlibConstants.BROTLI_PARAM_QUALITY]: 9 },
+  });
+  writeFileSync(path.join(destRoot, 'bundled.schemas.br'), archiveContents);
+  console.log(
+    `[copy-schemas-to-dist] compacted ${count} bundled schemas (${(totalBytes / 1024 / 1024).toFixed(1)} MiB raw, ` +
+      `${(archiveContents.length / 1024 / 1024).toFixed(1)} MiB archive)`
+  );
+}
+
 function main(): void {
   const repoRoot = path.resolve(__dirname, '..');
   const cacheRoot = path.join(repoRoot, 'schemas', 'cache');
@@ -338,7 +393,7 @@ function main(): void {
         if (!rel) return true;
         const parts = rel.split(path.sep);
         const top = parts[0];
-        if (top === 'tmp' || top === 'compliance') return false;
+        if (top === 'tmp' || top === 'compliance' || top === 'bundled') return false;
         if (top === 'mcp') {
           return [...allowedMcpFiles].some(allowed => allowed === rel || allowed.startsWith(`${rel}${path.sep}`));
         }
@@ -348,6 +403,7 @@ function main(): void {
     stripMcpOutputSchemaReferences(destRoot);
     relaxAdagentsAuthorizedAgentsMinItems(destRoot);
     patchPrereleaseGetProductsTaskType(destRoot);
+    writeCompactBundles(srcRoot, destRoot);
     const note = key === source.version ? '' : ` (key collapsed from ${source.version})`;
     console.log(`[copy-schemas-to-dist] copied ${srcRoot} → ${destRoot}${note}`);
   }
@@ -368,4 +424,9 @@ function main(): void {
   }
 }
 
-main();
+try {
+  main();
+} catch (error) {
+  console.error(`[copy-schemas-to-dist] failed: ${error instanceof Error ? error.message : String(error)}`);
+  process.exitCode = 1;
+}

--- a/scripts/verify-package.mjs
+++ b/scripts/verify-package.mjs
@@ -203,6 +203,34 @@ try {
   console.log('🔍 CJS require:');
   run('node', ['smoke.cjs'], { cwd: tmpDir, stdio: 'inherit' });
 
+  // The publish artifact omits expanded bundled JSON files and restores them
+  // from one Brotli archive per wire version. Exercise all archive-backed
+  // consumers from the installed tarball, where source-tree fallback is
+  // impossible, and assert the protocol-authored bundled ID survives.
+  writeFileSync(
+    path.join(tmpDir, 'smoke-schema-archive.cjs'),
+    [
+      "const { validateRequest } = require('./node_modules/@adcp/sdk/dist/lib/validation/index.js');",
+      "const { loadRequestSchema } = require('./node_modules/@adcp/sdk/dist/lib/conformance/schemaLoader.js');",
+      "const { getToolsWithErrorArm } = require('./node_modules/@adcp/sdk/dist/lib/server/error-arm-tools.js');",
+      "const invalid = validateRequest('get_products', {}, '3.2.0-beta.6');",
+      "if (invalid.valid || !invalid.issues.some(issue => issue.pointer === '/buying_mode')) {",
+      "  throw new Error('runtime validator did not load the archived get_products schema');",
+      '}',
+      "const schema = loadRequestSchema('get_products', { version: '3.2.0-beta.6' });",
+      "if (!schema.$id?.includes('/bundled/media-buy/get-products-request.json')) {",
+      '  throw new Error(`conformance loader returned the wrong archived schema ID: ${schema.$id}`);',
+      '}',
+      "const errorArmTools = getToolsWithErrorArm('3.2.0-beta.6');",
+      "if (!errorArmTools.has('create_media_buy')) {",
+      "  throw new Error('server error-arm discovery did not load the archived response schemas');",
+      '}',
+    ].join('\n')
+  );
+  console.log('🗜️  Archived offline schemas:');
+  run('node', ['smoke-schema-archive.cjs'], { cwd: tmpDir, stdio: 'inherit' });
+  console.log('  validation, conformance, and server discovery load schemas from the packed archives');
+
   const schemaTypeSmoke = [
     "import { CreativeAssetSchema } from '@adcp/sdk/schemas';",
     "import type { z } from 'zod';",

--- a/src/lib/conformance/schemaLoader.ts
+++ b/src/lib/conformance/schemaLoader.ts
@@ -1,8 +1,8 @@
-import * as fs from 'fs';
 import * as path from 'path';
 import type { ConformanceToolName } from './types';
 import { ADCP_VERSION } from '../version';
 import { resolveBundleKey } from '../validation/schema-loader';
+import { hasBundledSchemaStore, loadBundledSchemaFile } from '../validation/bundled-schema-store';
 
 type JsonSchema = Record<string, unknown>;
 
@@ -70,18 +70,20 @@ const TOOL_SCHEMA_LOCATIONS: Record<ConformanceToolName, ToolSchemaLocation> = {
 function findBundledDir(options: ConformanceSchemaOptions = {}): string {
   if (options.schemaRoot) {
     const bundled = path.join(options.schemaRoot, 'bundled');
-    if (fs.existsSync(bundled)) return bundled;
-    if (path.basename(options.schemaRoot) === 'bundled' && fs.existsSync(options.schemaRoot)) return options.schemaRoot;
+    if (hasBundledSchemaStore(bundled)) return bundled;
+    if (path.basename(options.schemaRoot) === 'bundled' && hasBundledSchemaStore(options.schemaRoot)) {
+      return options.schemaRoot;
+    }
     throw new Error(`Conformance schema bundle not found at ${options.schemaRoot}. Expected a root with bundled/.`);
   }
 
   const version = options.version ?? ADCP_VERSION;
   const bundleKey = resolveBundleKey(version);
   const distCandidate = path.resolve(__dirname, '..', 'schemas-data', bundleKey, 'bundled');
-  if (fs.existsSync(distCandidate)) return distCandidate;
+  if (hasBundledSchemaStore(distCandidate)) return distCandidate;
 
   const srcCandidate = path.resolve(__dirname, '..', '..', '..', 'schemas', 'cache', version, 'bundled');
-  if (fs.existsSync(srcCandidate)) return srcCandidate;
+  if (hasBundledSchemaStore(srcCandidate)) return srcCandidate;
 
   throw new Error(
     `Conformance schema bundle not found. Looked in ${distCandidate} and ${srcCandidate}. ` +
@@ -97,7 +99,8 @@ function loadSchema(relativePath: string, options: ConformanceSchemaOptions = {}
   const cached = schemaCache.get(cacheKey);
   if (cached) return cached;
   const full = path.join(bundledDir, relativePath);
-  const parsed = JSON.parse(fs.readFileSync(full, 'utf8')) as JsonSchema;
+  const parsed = loadBundledSchemaFile(full);
+  if (!parsed) throw new Error(`Conformance schema not found: ${full}`);
   schemaCache.set(cacheKey, parsed);
   return parsed;
 }

--- a/src/lib/server/error-arm-tools.ts
+++ b/src/lib/server/error-arm-tools.ts
@@ -26,6 +26,11 @@ import { readdirSync, readFileSync, existsSync } from 'fs';
 import path from 'path';
 import { ADCP_VERSION } from '../version';
 import { resolveBundleKey, toReleasePrecisionWire } from '../validation/schema-loader';
+import {
+  hasBundledSchemaStore,
+  listBundledSchemaFiles,
+  loadBundledSchemaFile,
+} from '../validation/bundled-schema-store';
 
 function findPrereleaseBundle(root: string, key: string): string | undefined {
   if (!existsSync(root)) return undefined;
@@ -65,7 +70,7 @@ function resolveBundledRoot(version: string): string | undefined {
   const distRoot = path.join(__dirname, '..', 'schemas-data');
   // Built layout (dist): dist/lib/schemas-data/<bundle-key>/bundled
   const distCandidate = path.join(distRoot, key, 'bundled');
-  if (existsSync(distCandidate)) return distCandidate;
+  if (hasBundledSchemaStore(distCandidate)) return distCandidate;
 
   // Wire envelopes carry release-precision prerelease values such as
   // `3.2-beta.0`, while published bundles retain the exact full-semver
@@ -80,7 +85,7 @@ function resolveBundledRoot(version: string): string | undefined {
   // Source-tree layout (dev): schemas/cache/<exact-version>/bundled
   const cacheRoot = path.join(__dirname, '..', '..', '..', 'schemas', 'cache');
   const exactCandidate = path.join(cacheRoot, version, 'bundled');
-  if (existsSync(exactCandidate)) return exactCandidate;
+  if (hasBundledSchemaStore(exactCandidate)) return exactCandidate;
 
   // Latest-patch fallback for stable minor pins (matches schema-loader).
   const minorMatch = key.match(/^(\d+)\.(\d+)$/);
@@ -202,24 +207,14 @@ function scanForErrorArmTools(bundledRoot: string): Map<string, ErrorArmDescript
     // fallback for those versions; current bundles always take the stricter
     // manifest path below.
   }
-  const files: string[] = [];
-  function walk(dir: string): void {
-    if (!existsSync(dir)) return;
-    for (const entry of readdirSync(dir, { withFileTypes: true })) {
-      const full = path.join(dir, entry.name);
-      if (entry.isDirectory()) {
-        walk(full);
-      } else if (entry.isFile() && entry.name.endsWith('-response.json')) {
-        files.push(full);
-      }
-    }
-  }
-  walk(bundledRoot);
+  const files = listBundledSchemaFiles(bundledRoot).filter(file => file.endsWith('-response.json'));
 
   for (const file of files) {
     let schema: Record<string, unknown>;
     try {
-      schema = JSON.parse(readFileSync(file, 'utf-8')) as Record<string, unknown>;
+      const loaded = loadBundledSchemaFile(file);
+      if (!loaded) continue;
+      schema = loaded;
     } catch {
       continue;
     }

--- a/src/lib/validation/bundled-schema-store.ts
+++ b/src/lib/validation/bundled-schema-store.ts
@@ -1,0 +1,141 @@
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { brotliDecompressSync } from 'node:zlib';
+
+const ARCHIVE_FILE = 'bundled.schemas.br';
+const MAX_ARCHIVE_BYTES = 16 * 1024 * 1024;
+const MAX_UNCOMPRESSED_BYTES = 64 * 1024 * 1024;
+const COMPACT_DEFINITIONS_KEY = 'x-adcp-compact-definitions';
+type JsonSchema = Record<string, unknown>;
+
+const archiveCache = new Map<string, ReadonlyMap<string, JsonSchema>>();
+
+function walkRawSchemas(root: string): string[] {
+  if (!existsSync(root)) return [];
+  const files: string[] = [];
+  for (const entry of readdirSync(root, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+    const full = path.join(root, entry.name);
+    if (entry.isDirectory()) files.push(...walkRawSchemas(full));
+    else if (entry.isFile() && entry.name.endsWith('.json')) files.push(full);
+  }
+  return files;
+}
+
+function archivePath(bundledRoot: string): string {
+  return path.join(path.dirname(bundledRoot), ARCHIVE_FILE);
+}
+
+/** Restore a compact archive entry to the protocol-authored inline shape. */
+function expandCompactSchema(root: JsonSchema): JsonSchema {
+  const compactNames = root[COMPACT_DEFINITIONS_KEY];
+  const definitions = root.$defs;
+  if (
+    !Array.isArray(compactNames) ||
+    !compactNames.every(name => typeof name === 'string') ||
+    !definitions ||
+    typeof definitions !== 'object' ||
+    Array.isArray(definitions)
+  ) {
+    return root;
+  }
+
+  const compactNameSet = new Set(compactNames as string[]);
+  const definitionMap = definitions as Record<string, unknown>;
+  const expand = (value: unknown, resolving = new Set<string>()): unknown => {
+    if (Array.isArray(value)) return value.map(child => expand(child, resolving));
+    if (!value || typeof value !== 'object') return value;
+
+    const object = value as Record<string, unknown>;
+    if (typeof object.$ref === 'string' && Object.keys(object).length === 1) {
+      const match = object.$ref.match(/^#\/\$defs\/([^/]+)$/);
+      const name = match?.[1];
+      if (name && compactNameSet.has(name)) {
+        if (resolving.has(name)) throw new Error(`Bundled schema compact definition is cyclic: ${name}`);
+        const target = definitionMap[name];
+        if (!target || typeof target !== 'object' || Array.isArray(target)) {
+          throw new Error(`Bundled schema compact definition is missing: ${name}`);
+        }
+        const nextResolving = new Set(resolving);
+        nextResolving.add(name);
+        return expand(target, nextResolving);
+      }
+    }
+
+    const expanded: JsonSchema = {};
+    for (const [key, child] of Object.entries(object)) {
+      if (key === COMPACT_DEFINITIONS_KEY) continue;
+      if (key === '$defs' && object === root) {
+        const authoredDefinitions = Object.fromEntries(
+          Object.entries(definitionMap)
+            .filter(([name]) => !compactNameSet.has(name))
+            .map(([name, definition]) => [name, expand(definition, resolving)])
+        );
+        if (Object.keys(authoredDefinitions).length > 0) expanded.$defs = authoredDefinitions;
+        continue;
+      }
+      expanded[key] = expand(child, resolving);
+    }
+    return expanded;
+  };
+
+  return expand(root) as JsonSchema;
+}
+
+function loadArchive(bundledRoot: string): ReadonlyMap<string, JsonSchema> | undefined {
+  const file = archivePath(bundledRoot);
+  const cached = archiveCache.get(file);
+  if (cached) return cached;
+  if (!existsSync(file)) return undefined;
+  if (statSync(file).size > MAX_ARCHIVE_BYTES) throw new Error(`Bundled schema archive exceeds 16 MiB: ${file}`);
+
+  const decoded = brotliDecompressSync(readFileSync(file), { maxOutputLength: MAX_UNCOMPRESSED_BYTES });
+  const parsed = JSON.parse(decoded.toString('utf8')) as unknown;
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`Bundled schema archive is not an object: ${file}`);
+  }
+
+  const schemas = new Map<string, JsonSchema>();
+  for (const [relativePath, schema] of Object.entries(parsed)) {
+    const normalized = relativePath.replace(/\\/g, '/');
+    const parts = normalized.split('/');
+    if (
+      normalized.startsWith('/') ||
+      /^[A-Za-z]:/.test(normalized) ||
+      parts.some(part => part === '' || part === '.' || part === '..') ||
+      !normalized.endsWith('.json') ||
+      !schema ||
+      typeof schema !== 'object' ||
+      Array.isArray(schema)
+    ) {
+      throw new Error(`Bundled schema archive contains an invalid entry: ${relativePath}`);
+    }
+    schemas.set(normalized, schema as JsonSchema);
+  }
+  archiveCache.set(file, schemas);
+  return schemas;
+}
+
+export function hasBundledSchemaStore(bundledRoot: string): boolean {
+  return walkRawSchemas(bundledRoot).length > 0 || existsSync(archivePath(bundledRoot));
+}
+
+export function listBundledSchemaFiles(bundledRoot: string): string[] {
+  const raw = walkRawSchemas(bundledRoot);
+  if (raw.length > 0) return raw;
+  const archive = loadArchive(bundledRoot);
+  return archive ? [...archive.keys()].map(relativePath => path.join(bundledRoot, relativePath)) : [];
+}
+
+export function loadBundledSchemaFile(file: string): JsonSchema | undefined {
+  if (existsSync(file)) return expandCompactSchema(JSON.parse(readFileSync(file, 'utf8')) as JsonSchema);
+  const marker = `${path.sep}bundled${path.sep}`;
+  const markerIndex = file.lastIndexOf(marker);
+  if (markerIndex < 0) return undefined;
+  const bundledRoot = file.slice(0, markerIndex + `${path.sep}bundled`.length);
+  const relativePath = file
+    .slice(markerIndex + marker.length)
+    .split(path.sep)
+    .join('/');
+  const schema = loadArchive(bundledRoot)?.get(relativePath);
+  return schema ? expandCompactSchema(schema) : undefined;
+}

--- a/src/lib/validation/schema-loader.ts
+++ b/src/lib/validation/schema-loader.ts
@@ -20,6 +20,7 @@ import { readdirSync, readFileSync, existsSync } from 'fs';
 import path from 'path';
 import { ADCP_VERSION } from '../version';
 import { ConfigurationError } from '../errors';
+import { hasBundledSchemaStore, listBundledSchemaFiles, loadBundledSchemaFile } from './bundled-schema-store';
 
 export type ResponseVariant = 'sync' | 'submitted' | 'working' | 'input-required';
 export type Direction = 'request' | ResponseVariant;
@@ -372,7 +373,7 @@ function clearStatesForBundle(bundleKey: string): void {
 function hasSchemaRootShape(root: string): boolean {
   if (!existsSync(root)) return false;
   const bundledRoot = path.join(root, 'bundled');
-  const files = existsSync(bundledRoot) ? walkJsonFiles(bundledRoot) : walkJsonFiles(root);
+  const files = hasBundledSchemaStore(bundledRoot) ? walkJsonFiles(bundledRoot) : walkJsonFiles(root);
   return files.some(file => {
     try {
       const schema = loadJson(file);
@@ -575,6 +576,7 @@ export function isExternalSchemaRootActive(version: string): boolean {
 }
 
 function walkJsonFiles(dir: string): string[] {
+  if (path.basename(dir) === 'bundled') return listBundledSchemaFiles(dir);
   if (!existsSync(dir)) return [];
   const out: string[] = [];
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
@@ -586,6 +588,10 @@ function walkJsonFiles(dir: string): string[] {
 }
 
 function loadJson(file: string): LoadedSchema {
+  if (file.includes(`${path.sep}bundled${path.sep}`)) {
+    const bundled = loadBundledSchemaFile(file);
+    if (bundled) return bundled;
+  }
   return JSON.parse(readFileSync(file, 'utf-8')) as LoadedSchema;
 }
 

--- a/test/bundled-schema-store.test.js
+++ b/test/bundled-schema-store.test.js
@@ -1,0 +1,74 @@
+const assert = require('node:assert/strict');
+const { mkdtempSync, rmSync, writeFileSync } = require('node:fs');
+const { tmpdir } = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const { test } = require('node:test');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+
+test('reads logical bundled schema paths from the published archive shape', () => {
+  const tempDir = mkdtempSync(path.join(tmpdir(), 'bundled-schema-store-'));
+  const harness = path.join(tempDir, 'harness.ts');
+  writeFileSync(
+    harness,
+    `
+import assert from 'node:assert/strict';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { brotliCompressSync } from 'node:zlib';
+import {
+  hasBundledSchemaStore,
+  listBundledSchemaFiles,
+  loadBundledSchemaFile,
+} from ${JSON.stringify(path.join(REPO_ROOT, 'src', 'lib', 'validation', 'bundled-schema-store.ts'))};
+
+// A parent directory also named "bundled" verifies path lookup selects the
+// schema-store segment nearest the logical file.
+const versionRoot = ${JSON.stringify(path.join(tempDir, 'bundled', 'consumer', '3.2'))};
+const bundledRoot = path.join(versionRoot, 'bundled');
+mkdirSync(versionRoot, { recursive: true });
+const expandedSchema = {
+  $id: '/schemas/3.2/media-buy/get-products-request.json',
+  type: 'object',
+  properties: { account: { $id: '/schemas/3.2/core/account.json', type: 'string' } },
+};
+const schema = {
+  $id: expandedSchema.$id,
+  type: 'object',
+  properties: { account: { $ref: '#/$defs/__adcp_shared_0' } },
+  $defs: { __adcp_shared_0: expandedSchema.properties.account },
+  'x-adcp-compact-definitions': ['__adcp_shared_0'],
+};
+writeFileSync(
+  path.join(versionRoot, 'bundled.schemas.br'),
+  brotliCompressSync(Buffer.from(JSON.stringify({ 'media-buy/get-products-request.json': schema })))
+);
+
+assert.equal(hasBundledSchemaStore(bundledRoot), true);
+assert.deepEqual(listBundledSchemaFiles(bundledRoot), [
+  path.join(bundledRoot, 'media-buy/get-products-request.json'),
+]);
+assert.deepEqual(loadBundledSchemaFile(path.join(bundledRoot, 'media-buy/get-products-request.json')), expandedSchema);
+
+const unsafeVersionRoot = ${JSON.stringify(path.join(tempDir, 'unsafe'))};
+const unsafeBundledRoot = path.join(unsafeVersionRoot, 'bundled');
+mkdirSync(unsafeVersionRoot, { recursive: true });
+writeFileSync(
+  path.join(unsafeVersionRoot, 'bundled.schemas.br'),
+  brotliCompressSync(Buffer.from(JSON.stringify({ '../escape.json': schema })))
+);
+assert.throws(() => listBundledSchemaFiles(unsafeBundledRoot), /invalid entry/);
+`
+  );
+
+  try {
+    const result = spawnSync(path.join(REPO_ROOT, 'node_modules', '.bin', 'tsx'), [harness], {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/test/compact-schema-bundle.test.js
+++ b/test/compact-schema-bundle.test.js
@@ -1,0 +1,71 @@
+const assert = require('node:assert/strict');
+const { mkdtempSync, rmSync, writeFileSync } = require('node:fs');
+const { tmpdir } = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const { test } = require('node:test');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+
+test('compacts shared schema nodes without turning annotation data into refs', () => {
+  const tempDir = mkdtempSync(path.join(tmpdir(), 'compact-schema-bundle-'));
+  const harness = path.join(tempDir, 'harness.ts');
+  writeFileSync(
+    harness,
+    `
+import assert from 'node:assert/strict';
+import Ajv from ${JSON.stringify(path.join(REPO_ROOT, 'node_modules', 'ajv', 'dist', 'ajv.js'))};
+import { compactBundledSchema } from ${JSON.stringify(path.join(REPO_ROOT, 'scripts', 'compact-schema-bundle.ts'))};
+
+const first = {
+  $id: '/nested/shared.json',
+  type: 'string',
+  enum: ['active', 'paused'],
+  description: 'x'.repeat(300),
+};
+const second = { ...first };
+const annotation = { source: 'fixture' };
+const root = {
+  $id: '/root.json',
+  type: 'object',
+  properties: { first, second },
+  required: ['first', 'second'],
+  examples: [annotation, annotation],
+};
+
+const compacted = compactBundledSchema(root);
+assert.equal(compacted.$id, '/root.json');
+assert.equal(JSON.stringify(compacted).includes('/nested/shared.json'), true);
+assert.deepEqual(compacted.examples, [{ source: 'fixture' }, { source: 'fixture' }]);
+assert.deepEqual(compacted.properties.first, { $ref: '#/$defs/__adcp_shared_0' });
+assert.deepEqual(compacted.properties.second, { $ref: '#/$defs/__adcp_shared_0' });
+assert.deepEqual(compacted['x-adcp-compact-definitions'], ['__adcp_shared_0']);
+
+const validate = new Ajv({ strict: false }).compile(compacted);
+assert.equal(validate({ first: 'active', second: 'paused' }), true);
+assert.equal(validate({ first: 'invalid', second: 'active' }), false);
+
+const itemSchema = { type: 'string', description: 'y'.repeat(300) };
+const itemForms = compactBundledSchema({
+  type: 'object',
+  properties: {
+    all: { type: 'array', items: { ...itemSchema } },
+    tuple: { type: 'array', items: [{ ...itemSchema }] },
+  },
+  required: ['all', 'tuple'],
+});
+const validateItemForms = new Ajv({ strict: false }).compile(itemForms);
+assert.equal(validateItemForms({ all: ['ok'], tuple: ['ok', 42] }), true);
+`
+  );
+
+  try {
+    const result = spawnSync(path.join(REPO_ROOT, 'node_modules', '.bin', 'tsx'), [harness], {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -4,8 +4,8 @@
     "outDir": "./dist/lib",
     "rootDir": "./src/lib",
     "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
+    "declarationMap": false,
+    "sourceMap": false,
     "stripInternal": true
   },
   "include": ["src/lib/**/*"],

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -110,7 +110,10 @@ export default defineConfig({
   bundle: false,
   // A paths-free tsconfig so the import-fixer's alias resolution is a no-op.
   tsconfig: 'tsconfig.build.json',
-  sourcemap: true,
+  // Published source maps account for thousands of files and several MiB of
+  // the compressed artifact. The source is public and declaration files remain
+  // the debugging contract, so the install-DX cost is not justified.
+  sourcemap: false,
   clean: true,
   dts: false,
   // Not tsup's `shims: true`: with many entries it emits `__dirname` once in a


### PR DESCRIPTION
## Summary

- compact protocol-authored bundled schemas and publish one Brotli archive per supported wire version
- transparently restore archived schemas for validation, conformance, and server error-arm discovery
- omit runtime/declaration source maps from the package and enforce a 20 MB packed-size budget
- extend clean-room package smoke coverage and CI path detection for the new archive pipeline

The resulting package is 15.9 MiB packed, 105.9 MiB unpacked, and 5,554 files, down from the 47.9 MB / 351 MB / 7,698-file artifact reported in #2579. All 276 bundled schemas round-trip to their protocol-cache originals exactly.

## Verification

- `npm run typecheck`
- `npm run build:lib`
- `npm run check:package`
- `npm run verify:package`
- focused compaction, archive-store, validation, conformance, error-arm, CLI, and compact-lifecycle tests
- independent code, protocol, and Node.js test Expert reviews

Addresses #2579.
