### PR TITLE
fix: enforce delegated signing and structured MCP validation

### DIFF
--- a/.changeset/secure-operators-structure-errors.md
+++ b/.changeset/secure-operators-structure-errors.md
@@ -1,5 +1,5 @@
 ---
-'@adcp/sdk': patch
+'@adcp/sdk': minor
 ---
 
 Enforce active, scoped cross-origin operator delegations during signing-key discovery and cap JWKS caches at delegation expiry. Preserve strict official modern MCP discovery schemas while routing AdCP input failures through the structured framework error envelope.

--- a/.changeset/secure-operators-structure-errors.md
+++ b/.changeset/secure-operators-structure-errors.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Enforce active, scoped cross-origin operator delegations during signing-key discovery and cap JWKS caches at delegation expiry. Preserve strict official modern MCP discovery schemas while routing AdCP input failures through the structured framework error envelope.

--- a/docs/guides/PUSH-NOTIFICATION-CONFIG.md
+++ b/docs/guides/PUSH-NOTIFICATION-CONFIG.md
@@ -149,6 +149,17 @@ Custom registration stores used by durability-protected mutation flows must also
 
 For deterministic tests or infrastructure-managed keys, set `webhookVerification.jwks`. Otherwise seller key discovery is automatic and uses an unauthenticated official protocol client for the capabilities step, so credentials configured for one endpoint are never transplanted to the registered callback origin. Sellers whose capability discovery requires authentication should provide an origin-bound `webhookVerification.fetchCapabilities(agentUrl, protocol)` callback or inject `webhookVerification.jwks` directly.
 
+When a cross-origin seller is authorized through a constrained
+`brand.json.authorized_operators[]` entry, also configure the trusted
+`webhookVerification.resolverOptions.requiredOperatorBrand`,
+`requiredOperatorScope`, and/or `requiredOperatorCountry` values that select the
+intended grant. Narrow brand, scope, or country lists fail closed without this
+context. Broad grants use `brands: ['*']`, omitted scopes (or `['all']`), and
+omitted countries. Delegated JWKS caches never outlive `valid_until`.
+Resolver options are trusted client-wide policy; they are not inferred from
+individual tool arguments. Use separate clients/resolvers for operations with
+different constrained brand, scope, or country tuples.
+
 ### Legacy HMAC-SHA256
 
 When `webhookSecret` is configured, the legacy webhook authentication path uses `HMAC-SHA256`. The agent signs `${timestamp}.${raw_body_bytes}` with the shared secret and sends:

--- a/docs/migration-12-to-14.md
+++ b/docs/migration-12-to-14.md
@@ -88,6 +88,15 @@ Body-bearing requests fail closed without `rawBody`. HMAC webhook registrations 
 
 OAuth flow handlers must preserve `state`, verify callback binding, and pass an HTTP(S) URL to `redirectToAuthorization()`. Literal-host SSRF validation now applies in every `NODE_ENV`; private/internal targets require the documented explicit opt-in and metadata addresses remain blocked.
 
+Cross-origin signing-key discovery now requires a schema-shaped, active
+`authorized_operators[]` grant. Broad grants use `brands: ['*']`, omitted
+scopes (or `['all']`), and omitted countries. For narrower grants, configure
+the matching trusted `requiredOperatorBrand`, `requiredOperatorScope`, and/or
+`requiredOperatorCountry` under `webhookVerification.resolverOptions` (or the
+corresponding low-level resolver options); constrained dimensions fail closed
+without context. Cached delegated keys expire no later than `valid_until`. See
+[the 13→14 migration detail](migration-13-to-14.md#cross-origin-signing-key-delegation).
+
 ## SDK 13 payload and API changes included in 14
 
 - Narrow `CreateMediaBuyPayload` with `'errors' in payload` before reading success fields.

--- a/docs/migration-13-to-14.md
+++ b/docs/migration-13-to-14.md
@@ -32,6 +32,55 @@ installed. Existing `createA2AAdapter()` card options remain accepted, but
 `preferredTransport` and `protocolVersion` are deprecated because the adapter
 now advertises JSON-RPC 1.0 plus its 0.3 compatibility interface.
 
+### Cross-origin signing-key delegation
+
+Signing-key discovery now evaluates the complete matching
+`authorized_operators[]` entry. Bare strings, missing/empty `brands`, malformed
+validity timestamps, future grants, and grants at or after `valid_until` no
+longer authorize an operator. Domain comparison remains eTLD+1-based (including
+private suffixes), while brand, activity scope, country, and time must all match
+the same entry.
+
+Broad grants remain configuration-free: use `brands: ['*']`, omit `scopes` for
+all activities (or use `['all']`), and omit `countries` for global scope. If a
+house publishes a constrained grant, bind the trusted verification context:
+
+```ts
+const client = new SingleAgentClient(agent, {
+  webhookVerification: {
+    resolverOptions: {
+      requiredOperatorBrand: 'brand_a',
+      requiredOperatorScope: 'media_buying',
+      requiredOperatorCountry: 'GB',
+    },
+  },
+});
+```
+
+These resolver options are trusted client-wide key-discovery policy, not
+per-operation authorization inferred from tool arguments. Use a separate
+client/resolver for each constrained brand, scope, and country tuple; do not
+reuse the example client for operations outside `brand_a` / `media_buying` /
+`GB`.
+
+The same options are accepted by `resolveAgent()`, `getAgentJwks()`,
+`createAgentJwksSet()`, and `ResolvedAgentJwksResolver`. A constrained list with
+no corresponding trusted option fails closed. Built-in JWKS caches now expire
+at the earlier of their configured TTL and the accepted delegation's
+`valid_until` boundary. Low-level `getAgentJwks()` callers receive that boundary
+as `operatorAuthorizationValidUntil` and must apply it to any custom cache.
+
+### Modern MCP validation errors
+
+Modern MCP `tools/list` continues to advertise the exact official AdCP input
+schema. Call-time domain validation now remains in the AdCP framework pipeline,
+so schema-invalid AdCP objects return the framework's structured `adcp_error`
+and `context` echo instead of a generic MCP input-validation string. Because
+the modern transport advertises that strict schema, it requests strict
+framework request validation even when the server-wide validation mode is
+`warn` or `off`; explicit custom tool schemas remain enforced by the MCP server
+layer.
+
 ### Beta.5 task webhook registration and polling
 
 `push_notification_config` is now an AdCP application-layer field across MCP,

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -1654,7 +1654,20 @@ export class SingleAgentClient {
     // historically returns the input object unchanged for the preferred
     // `trustedFetchFn` spelling, so clone first while retaining function identity.
     const configuredTransport = config.transport === undefined ? undefined : { ...config.transport };
-    this.config = { ...config, transport: normalizeTransportOptions(configuredTransport) };
+    const configuredWebhookVerification =
+      config.webhookVerification === undefined
+        ? undefined
+        : {
+            ...config.webhookVerification,
+            ...(config.webhookVerification.resolverOptions !== undefined && {
+              resolverOptions: { ...config.webhookVerification.resolverOptions },
+            }),
+          };
+    this.config = {
+      ...config,
+      transport: normalizeTransportOptions(configuredTransport),
+      ...(configuredWebhookVerification !== undefined && { webhookVerification: configuredWebhookVerification }),
+    };
     config = this.config;
     // Validate the configured adcpVersion at construction time. Throws
     // ConfigurationError if the pin's major differs from ADCP_MAJOR_VERSION

--- a/src/lib/server/adcp-server.ts
+++ b/src/lib/server/adcp-server.ts
@@ -137,6 +137,13 @@ export interface AdcpInvokeOptions {
   authInfo?: AdcpAuthInfo;
   /** Abort signal for cancellation; defaults to a fresh controller. */
   signal?: AbortSignal;
+  /**
+   * Require the framework to enforce the bundled request schema even when the
+   * server's general validation mode is `warn` or `off`. Transport adapters
+   * that advertise the exact official schema use this strengthening-only flag
+   * so failures retain the structured AdCP error envelope.
+   */
+  enforceRequestSchema?: true;
 }
 
 /**
@@ -695,10 +702,11 @@ export function wrapMcpServer(
     if (!tool) {
       throw new Error(`AdcpServer.invoke: tool "${options.toolName}" is not registered`);
     }
-    const extra: { signal: AbortSignal; authInfo?: AdcpAuthInfo } = {
+    const extra: { signal: AbortSignal; authInfo?: AdcpAuthInfo; enforceRequestSchema?: true } = {
       signal: options.signal ?? new AbortController().signal,
     };
     if (options.authInfo) extra.authInfo = options.authInfo;
+    if (options.enforceRequestSchema === true) extra.enforceRequestSchema = true;
     return (await tool.handler(options.args, extra)) as McpToolResponse;
   };
   const wrapper: AdcpServerInternal = {

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -4637,6 +4637,10 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
   const isProduction = process.env.NODE_ENV === 'production';
   const requestValidationMode = validationConfig?.requests ?? (isProduction ? 'off' : 'strict');
   const responseValidationMode = validationConfig?.responses ?? (isProduction ? 'off' : 'strict');
+  const effectiveRequestValidationMode = (extra: unknown): 'off' | 'warn' | 'strict' =>
+    (extra as { enforceRequestSchema?: unknown } | undefined)?.enforceRequestSchema === true
+      ? 'strict'
+      : requestValidationMode;
 
   // Split the `idempotency` config field into "the active store" and
   // "explicitly opted out" so existing call sites keep working with a
@@ -5106,16 +5110,18 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
 
   const protocolTaskRequestValidationError = (
     toolName: 'get_task_status' | 'list_tasks',
-    params: Record<string, unknown>
+    params: Record<string, unknown>,
+    extra?: unknown
   ): McpToolResponse | undefined => {
+    const validationMode = effectiveRequestValidationMode(extra);
     const accountIssues = protocolTaskAccountExtensionIssues(params);
     const outcome =
-      requestValidationMode === 'off'
+      validationMode === 'off'
         ? ({ valid: true, issues: [], schemaId: undefined } as const)
         : validateRequest(toolName, params, requestServedRelease(params)?.validationVersion ?? adcpVersion);
     const issues = [...(outcome.valid ? [] : outcome.issues), ...accountIssues];
     if (issues.length === 0) return undefined;
-    if (requestValidationMode === 'strict' || accountIssues.length > 0) {
+    if (validationMode === 'strict' || accountIssues.length > 0) {
       return adcpError(
         'VALIDATION_ERROR',
         buildAdcpValidationErrorPayload(toolName, 'request', issues, {
@@ -5458,6 +5464,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
 
       const wrap = meta?.wrap ?? ((data: any, summary?: string) => genericResponse(toolName, data, summary));
       const toolHandler = async (params: any, extra: any) => {
+        const callRequestValidationMode = effectiveRequestValidationMode(extra);
         const releaseSelection = selectServedAdcpRelease(params, capConfig, adcpVersion);
         let releaseError: McpToolResponse | undefined;
         let requestRelease: ServedAdcpRelease;
@@ -5913,7 +5920,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
             }
           }
         }
-        if (requestValidationMode !== 'off') {
+        if (callRequestValidationMode !== 'off') {
           const outcome = validateFrameworkPayload(
             toolName,
             'request',
@@ -5955,7 +5962,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
                 ? outcome.issues.filter(i => !(i.keyword === 'required' && i.pointer === '/idempotency_key'))
                 : outcome.issues;
             if (issues.length > 0) {
-              if (requestValidationMode === 'strict') {
+              if (callRequestValidationMode === 'strict') {
                 // Thread `exposeSchemaPath` the same way response-side does
                 // so request-side schemaPath also ships in dev and stays
                 // gated in production. Prior to this, request-side silently
@@ -7436,7 +7443,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
             echoContext: false,
           });
         }
-        const validationError = protocolTaskRequestValidationError('get_task_status', params ?? {});
+        const validationError = protocolTaskRequestValidationError('get_task_status', params ?? {}, extra);
         if (validationError) return finalizeProtocolTaskToolResponse('get_task_status', params ?? {}, validationError);
         const boundsError = protocolTaskBoundsError('get_task_status', params ?? {});
         if (boundsError) return finalizeProtocolTaskToolResponse('get_task_status', params ?? {}, boundsError);
@@ -7532,7 +7539,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
         if (credentialError) {
           return finalizeProtocolTaskToolResponse('list_tasks', params ?? {}, credentialError, { echoContext: false });
         }
-        const validationError = protocolTaskRequestValidationError('list_tasks', params ?? {});
+        const validationError = protocolTaskRequestValidationError('list_tasks', params ?? {}, extra);
         if (validationError) return finalizeProtocolTaskToolResponse('list_tasks', params ?? {}, validationError);
         const boundsError = protocolTaskBoundsError('list_tasks', params ?? {});
         if (boundsError) return finalizeProtocolTaskToolResponse('list_tasks', params ?? {}, boundsError);
@@ -7922,6 +7929,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
       _meta: frameworkToolMeta,
     },
     (async (params: any, extra: { authInfo?: ResolvedAuthInfo } = {}) => {
+      const callRequestValidationMode = effectiveRequestValidationMode(extra);
       const requestParams = isPlainObject(params) ? params : {};
       const releaseSelection = selectServedAdcpRelease(requestParams, capConfig, adcpVersion);
       const release = isMcpToolResponse(releaseSelection)
@@ -7949,7 +7957,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
         );
       }
 
-      if (requestValidationMode !== 'off') {
+      if (callRequestValidationMode !== 'off') {
         const requestOutcome = validateRequest('get_adcp_capabilities', requestParams, release.validationVersion);
         if (!requestOutcome.valid) {
           logger.warn(
@@ -7959,7 +7967,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
               issues: requestOutcome.issues,
             }
           );
-          if (requestValidationMode === 'strict') {
+          if (callRequestValidationMode === 'strict') {
             return finalizeCapabilityResponse(
               adcpError(
                 'VALIDATION_ERROR',

--- a/src/lib/server/mcp-modern-server.ts
+++ b/src/lib/server/mcp-modern-server.ts
@@ -10,10 +10,8 @@
 import {
   McpServer as ModernMcpServer,
   createMcpHandler,
-  fromJsonSchema,
   isLegacyRequest,
   type AuthInfo as ModernAuthInfo,
-  type JsonSchemaType,
   type ResourceMetadata,
   type RegisteredTool as ModernRegisteredTool,
   type StandardSchemaWithJSON,
@@ -115,20 +113,8 @@ function officialAdcpToolSummary(
   );
 }
 
-function schemaForModernMcp(
-  toolName: string,
-  schema: unknown,
-  adcpVersion: string,
-  profile: 'media-buy' | 'all'
-): StandardSchemaWithJSON {
-  const officialSchema = officialAdcpInputSchema(toolName, adcpVersion, profile);
-  if (officialSchema) {
-    // This official MCP bridge supplies both validation and the JSON
-    // conversion hook that Zod versions before 4.2 do not implement.
-    return fromJsonSchema(officialSchema as JsonSchemaType);
-  }
-
-  if (!hasJsonConversionForSchemaOrRawShape(schema) && !warnedAboutCustomSchemaJsonConversion) {
+function schemaForModernMcp(schema: unknown, hasOfficialSchema: boolean): StandardSchemaWithJSON {
+  if (!hasOfficialSchema && !hasJsonConversionForSchemaOrRawShape(schema) && !warnedAboutCustomSchemaJsonConversion) {
     warnedAboutCustomSchemaJsonConversion = true;
     console.warn(
       '[adcp/serve] A custom MCP tool schema does not expose ~standard.jsonSchema. ' +
@@ -156,17 +142,31 @@ export function createModernMcpServerAdapter(agentServer: AdcpServer): ModernMcp
   const modernToolDefinitions: Array<
     Omit<RegisteredToolDefinition, 'inputSchema' | 'outputSchema'> & {
       inputSchema?: StandardSchemaWithJSON;
+      advertisedInputSchema?: Readonly<Record<string, unknown>>;
       outputSchema?: StandardSchemaWithJSON;
     }
   > = toolDefinitions.map(tool => {
     const { inputSchema, outputSchema, ...definition } = tool;
     const description = tool.description ?? officialAdcpToolSummary(tool.name, adcpVersion, activeMcpToolProfile);
+    // Framework-registered AdCP tools carry the version marker below. A
+    // hand-wrapped adopter tool may reuse an official name while intentionally
+    // defining a different contract; advertising the official schema for that
+    // tool would lie about the schema enforced at call time.
+    const frameworkAdcpTool = tool._meta?.adcp_version === adcpVersion;
+    const advertisedInputSchema = frameworkAdcpTool
+      ? officialAdcpInputSchema(tool.name, adcpVersion, activeMcpToolProfile)
+      : undefined;
     return {
       ...definition,
       ...(description !== undefined && { description }),
       ...(inputSchema !== undefined && {
-        inputSchema: schemaForModernMcp(tool.name, inputSchema, adcpVersion, activeMcpToolProfile),
+        // Keep call-time validation on the adopter/framework schema. The
+        // framework's AdCP validator must see domain-invalid objects so it can
+        // return a structured `adcp_error` + context echo; the official strict
+        // projection remains discovery-only below.
+        inputSchema: schemaForModernMcp(inputSchema, advertisedInputSchema !== undefined),
       }),
+      ...(advertisedInputSchema !== undefined && { advertisedInputSchema }),
       // Output schemas can dwarf the input discovery surface and are not
       // required for clients to form tool calls. Preserve an adopter's
       // explicitly registered schema, but do not replace it with a bundled
@@ -209,6 +209,10 @@ export function createModernMcpServerAdapter(agentServer: AdcpServer): ModernMcp
             args,
             authInfo: toAdcpAuthInfo(ctx.http?.authInfo),
             signal: ctx.mcpReq.signal,
+            // Only strengthen calls for tools whose exact official schema we
+            // advertise. Hidden compatibility tools remain directly callable
+            // and retain the adopter's configured validation mode.
+            ...(tool.advertisedInputSchema !== undefined && { enforceRequestSchema: true }),
           });
 
         if (tool.inputSchema !== undefined) {
@@ -241,10 +245,11 @@ export function createModernMcpServerAdapter(agentServer: AdcpServer): ModernMcp
                 name: tool.name,
                 ...(tool.title !== undefined && { title: tool.title }),
                 ...(tool.description !== undefined && { description: tool.description }),
-                inputSchema: (modern.toolInputSchemaJson(tool.name) ?? {
-                  type: 'object',
-                  properties: {},
-                }) as unknown as ModernTool['inputSchema'],
+                inputSchema: (tool.advertisedInputSchema ??
+                  modern.toolInputSchemaJson(tool.name) ?? {
+                    type: 'object',
+                    properties: {},
+                  }) as unknown as ModernTool['inputSchema'],
                 ...(registered.outputSchemaJson !== undefined && { outputSchema: registered.outputSchemaJson }),
                 ...(tool.annotations !== undefined && { annotations: tool.annotations as ToolAnnotations }),
                 ...(tool._meta !== undefined && { _meta: tool._meta }),

--- a/src/lib/signing/agent-resolver/index.ts
+++ b/src/lib/signing/agent-resolver/index.ts
@@ -21,6 +21,7 @@ export { ResolvedAgentJwksResolver } from './resolved-agent-jwks';
 export type {
   AgentResolution,
   AgentProtocol,
+  AuthorizedOperatorScope,
   FetchCapabilitiesFn,
   ResolveAgentOptions,
   TraceStep,

--- a/src/lib/signing/agent-resolver/jwks-set.ts
+++ b/src/lib/signing/agent-resolver/jwks-set.ts
@@ -23,7 +23,14 @@ import { resolveAgent, type AgentResolution, type ResolveAgentOptions } from './
 
 export type GetAgentJwksOptions = Pick<
   ResolveAgentOptions,
-  'protocol' | 'fetchCapabilities' | 'allowPrivateIp' | 'timeoutMs' | 'now'
+  | 'protocol'
+  | 'fetchCapabilities'
+  | 'allowPrivateIp'
+  | 'timeoutMs'
+  | 'now'
+  | 'requiredOperatorBrand'
+  | 'requiredOperatorScope'
+  | 'requiredOperatorCountry'
 >;
 
 export interface AgentJwksResult {
@@ -32,6 +39,8 @@ export interface AgentJwksResult {
   jwksUri: string;
   jwks: { keys: ReadonlyArray<Record<string, unknown>> };
   cacheControl?: string;
+  /** Cross-origin operator delegation expiry, in epoch seconds. Never cache these keys at or beyond this instant. */
+  operatorAuthorizationValidUntil?: number;
   fetchedAt: number;
 }
 
@@ -49,13 +58,23 @@ export async function getAgentJwks(agentUrl: string, options: GetAgentJwksOption
     jwksUri: resolution.jwksUri,
     jwks: resolution.jwks,
     ...(resolution.jwksCacheControl !== undefined && { cacheControl: resolution.jwksCacheControl }),
+    ...(resolution.operatorAuthorizationValidUntil !== undefined && {
+      operatorAuthorizationValidUntil: resolution.operatorAuthorizationValidUntil,
+    }),
     fetchedAt: resolution.freshness.jwksFetchedAt,
   };
 }
 
 export interface CreateAgentJwksSetOptions extends Pick<
   ResolveAgentOptions,
-  'protocol' | 'fetchCapabilities' | 'allowPrivateIp' | 'timeoutMs' | 'now'
+  | 'protocol'
+  | 'fetchCapabilities'
+  | 'allowPrivateIp'
+  | 'timeoutMs'
+  | 'now'
+  | 'requiredOperatorBrand'
+  | 'requiredOperatorScope'
+  | 'requiredOperatorCountry'
 > {
   /**
    * Algorithm allowlist enforced at JWKS-import time AND surfaced to
@@ -113,7 +132,13 @@ export function createAgentJwksSet(agentUrl: string, options: CreateAgentJwksSet
   const allowedAlgs = new Set(options.allowedAlgs);
   const cacheMaxAge = options.cacheMaxAgeSeconds ?? DEFAULT_CACHE_MAX_AGE_SECONDS;
   const kidCooldown = options.kidMissCooldownSeconds ?? DEFAULT_KID_MISS_COOLDOWN_SECONDS;
-  const now = options.now ?? (() => Math.floor(Date.now() / 1000));
+  if (!Number.isFinite(cacheMaxAge) || cacheMaxAge <= 0) {
+    throw new TypeError('cacheMaxAgeSeconds must be a finite positive number.');
+  }
+  if (!Number.isFinite(kidCooldown) || kidCooldown < 0) {
+    throw new TypeError('kidMissCooldownSeconds must be a finite non-negative number.');
+  }
+  const now = options.now ?? (() => Date.now() / 1000);
 
   let cache: CachedJwks | undefined;
   let lastRefetchAt = 0;
@@ -123,10 +148,22 @@ export function createAgentJwksSet(agentUrl: string, options: CreateAgentJwksSet
     if (inFlight) return inFlight;
     inFlight = (async () => {
       const resolution = await resolveAgent(agentUrl, options);
+      const refreshedAt = now();
+      if (
+        resolution.operatorAuthorizationValidUntil !== undefined &&
+        refreshedAt >= resolution.operatorAuthorizationValidUntil
+      ) {
+        throw new AgentResolverError(
+          'request_signature_brand_origin_mismatch',
+          'The cross-origin operator delegation expired during key discovery.',
+          { agent_url: agentUrl },
+          ['agent_url']
+        );
+      }
       assertAllJwksAllowed(resolution.jwks, allowedAlgs, agentUrl);
       const filtered = filterJwksToAllowedAlgs(resolution.jwks, allowedAlgs);
       const getKey = createLocalJWKSet({ keys: filtered as unknown as JWK[] });
-      cache = { resolution, fetchedAt: now(), getKey };
+      cache = { resolution, fetchedAt: refreshedAt, getKey };
       lastRefetchAt = cache.fetchedAt;
       return cache;
     })().finally(() => {
@@ -136,7 +173,12 @@ export function createAgentJwksSet(agentUrl: string, options: CreateAgentJwksSet
   };
 
   const ensureFresh = async (): Promise<CachedJwks> => {
-    if (!cache || now() - cache.fetchedAt >= cacheMaxAge) {
+    if (
+      !cache ||
+      now() - cache.fetchedAt >= cacheMaxAge ||
+      (cache.resolution.operatorAuthorizationValidUntil !== undefined &&
+        now() >= cache.resolution.operatorAuthorizationValidUntil)
+    ) {
       return refresh();
     }
     return cache;

--- a/src/lib/signing/agent-resolver/resolve-agent.ts
+++ b/src/lib/signing/agent-resolver/resolve-agent.ts
@@ -47,6 +47,14 @@ import { type AgentEntry, selectAgentByUrl, AgentSelectorError } from './select-
 
 export type AgentProtocol = 'mcp' | 'a2a';
 
+export type AuthorizedOperatorScope =
+  | 'media_buying'
+  | 'creative_generation'
+  | 'rights_clearance'
+  | 'governance'
+  | 'measurement'
+  | 'agent_operations';
+
 export interface FetchCapabilitiesFn {
   (agentUrl: string): Promise<unknown>;
 }
@@ -96,6 +104,24 @@ export interface ResolveAgentOptions {
   publisherPinned?: { webhook_signing?: boolean };
   /** Override the current time (epoch seconds) — for deterministic tests. */
   now?: () => number;
+  /**
+   * Brand authorization required from a cross-origin `authorized_operators[]`
+   * entry. Constrained brand lists fail closed when this context is omitted;
+   * `brands: ['*']` remains a context-free broad grant.
+   */
+  requiredOperatorBrand?: string;
+  /**
+   * Activity authorization required from a cross-origin operator entry.
+   * Omitted `scopes` and `scopes: ['all']` are broad grants. A narrower list
+   * fails closed when this context is omitted.
+   */
+  requiredOperatorScope?: AuthorizedOperatorScope;
+  /**
+   * ISO 3166-1 alpha-2 country authorization required from a cross-origin
+   * operator entry. Omitted `countries` is global; a present list fails closed
+   * when this context is omitted.
+   */
+  requiredOperatorCountry?: string;
 }
 
 export interface TraceStep {
@@ -128,6 +154,11 @@ export interface AgentResolution {
   };
   /** `Cache-Control` header from the JWKS fetch, when the response carried one. */
   jwksCacheControl?: string;
+  /**
+   * Epoch seconds when the cross-origin operator delegation stops authorizing
+   * this resolution. Built-in JWKS caches cap their lifetime at this boundary.
+   */
+  operatorAuthorizationValidUntil?: number;
   trace: ReadonlyArray<TraceStep>;
 }
 
@@ -135,7 +166,7 @@ const DEFAULT_TIMEOUT_MS = 10_000;
 
 export async function resolveAgent(agentUrl: string, options: ResolveAgentOptions = {}): Promise<AgentResolution> {
   const trace: TraceStep[] = [];
-  const now = options.now ?? (() => Math.floor(Date.now() / 1000));
+  const now = options.now ?? (() => Date.now() / 1000);
   const allowPrivateIp = checkAllowPrivateIp(options.allowPrivateIp === true);
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const caps = options.bodyCaps ?? {};
@@ -276,9 +307,10 @@ export async function resolveAgent(agentUrl: string, options: ResolveAgentOption
   }
 
   // Now run step 3's authorized_operators delegation check against the body.
+  let operatorAuthorizationValidUntil: number | undefined;
   if (!sameOrigin) {
-    const delegated = isAuthorizedOperator(brandJson, agentEtld1);
-    if (!delegated) {
+    const delegation = findAuthorizedOperator(brandJson, agentEtld1, now(), options);
+    if (!delegation) {
       const detail: AgentResolverErrorDetail = {
         agent_url: agentUrl,
         agent_etld1: agentEtld1,
@@ -292,6 +324,7 @@ export async function resolveAgent(agentUrl: string, options: ResolveAgentOption
         ['agent_url']
       );
     }
+    operatorAuthorizationValidUntil = delegation.validUntil;
     pushTrace(trace, {
       step: 3,
       name: 'etld1_binding',
@@ -417,6 +450,23 @@ export async function resolveAgent(agentUrl: string, options: ResolveAgentOption
     throw new AgentResolverError('request_signature_jwks_unreachable', `JWKS fetch failed`, detail, ['jwks_uri']);
   }
 
+  // A delegation can expire while brand.json/JWKS discovery is in flight.
+  // Re-check at the trust-chain boundary so the first cache use cannot extend
+  // authorization past the normative `valid_until` instant.
+  if (operatorAuthorizationValidUntil !== undefined && now() >= operatorAuthorizationValidUntil) {
+    const detail: AgentResolverErrorDetail = {
+      agent_url: agentUrl,
+      agent_etld1: agentEtld1,
+      brand_json_url_etld1: brandEtld1,
+    };
+    throw new AgentResolverError(
+      'request_signature_brand_origin_mismatch',
+      `Agent delegation expired while resolving signing keys`,
+      detail,
+      ['agent_url']
+    );
+  }
+
   return {
     agentUrl,
     brandJsonUrl,
@@ -427,6 +477,7 @@ export async function resolveAgent(agentUrl: string, options: ResolveAgentOption
     consistency: { ok: true },
     freshness: { capabilitiesFetchedAt, brandJsonFetchedAt, jwksFetchedAt },
     ...(jwksCacheControl !== undefined && { jwksCacheControl }),
+    ...(operatorAuthorizationValidUntil !== undefined && { operatorAuthorizationValidUntil }),
     trace: trace.map(annotateAge(now())),
   };
 }
@@ -457,31 +508,136 @@ function defaultFetchCapabilities(agentUrl: string, protocol: AgentProtocol): Fe
   };
 }
 
-function isAuthorizedOperator(brandJson: unknown, agentEtld1: string): boolean {
-  if (!brandJson || typeof brandJson !== 'object') return false;
+interface ActiveOperatorDelegation {
+  validUntil?: number;
+}
+
+const AUTHORIZED_OPERATOR_SCOPES = new Set<string>([
+  'all',
+  'media_buying',
+  'creative_generation',
+  'rights_clearance',
+  'governance',
+  'measurement',
+  'agent_operations',
+]);
+const AUTHORIZED_OPERATOR_DOMAIN = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/;
+
+/**
+ * Evaluate the complete cross-origin delegation tuple. Domain matching is
+ * deliberately at eTLD+1 (including the private PSL) to match step 3 of the
+ * discovery algorithm; brand, activity, country, and time remain independent
+ * authorization dimensions and must all match the same entry.
+ */
+function findAuthorizedOperator(
+  brandJson: unknown,
+  agentEtld1: string,
+  now: number,
+  options: Pick<ResolveAgentOptions, 'requiredOperatorBrand' | 'requiredOperatorScope' | 'requiredOperatorCountry'>
+): ActiveOperatorDelegation | undefined {
+  if (!brandJson || typeof brandJson !== 'object') return undefined;
   const operators = (brandJson as { authorized_operators?: unknown }).authorized_operators;
-  if (!Array.isArray(operators)) return false;
+  if (!Array.isArray(operators)) return undefined;
+  let latestValidUntil: number | undefined;
+  let matched = false;
   for (const op of operators) {
-    if (op && typeof op === 'object') {
-      const domain = (op as { domain?: unknown }).domain;
-      if (typeof domain === 'string') {
-        try {
-          if (eTldPlusOne(domain) === agentEtld1) return true;
-        } catch {
-          continue;
-        }
-      }
+    if (!op || typeof op !== 'object' || Array.isArray(op)) continue;
+    const candidate = op as Record<string, unknown>;
+    const domain = candidate.domain;
+    const brands = candidate.brands;
+    if (typeof domain !== 'string' || !AUTHORIZED_OPERATOR_DOMAIN.test(domain) || !isValidBrandGrant(brands)) {
+      continue;
     }
-    // Some brand.json shapes carry a bare-string entry rather than `{ domain }`.
-    if (typeof op === 'string') {
-      try {
-        if (eTldPlusOne(op) === agentEtld1) return true;
-      } catch {
-        continue;
-      }
+    try {
+      if (eTldPlusOne(domain) !== agentEtld1) continue;
+    } catch {
+      continue;
     }
+
+    const scopes = candidate.scopes;
+    if (scopes !== undefined && !isValidScopeGrant(scopes)) continue;
+    const countries = candidate.countries;
+    if (countries !== undefined && !isValidCountryGrant(countries)) continue;
+
+    const validFrom = parseOptionalRfc3339(candidate.valid_from);
+    const validUntil = parseOptionalRfc3339(candidate.valid_until);
+    if (validFrom === null || validUntil === null) continue;
+    if (validFrom !== undefined && validUntil !== undefined && validFrom >= validUntil) continue;
+    if (validFrom !== undefined && now < validFrom) continue;
+    if (validUntil !== undefined && now >= validUntil) continue;
+
+    if (!matchesGrant(brands, options.requiredOperatorBrand, '*')) continue;
+    if (scopes !== undefined && !matchesGrant(scopes, options.requiredOperatorScope, 'all')) continue;
+    if (countries !== undefined && !matchesGrant(countries, options.requiredOperatorCountry)) continue;
+
+    matched = true;
+    // Any unbounded active sibling keeps the same authorization tuple active.
+    if (validUntil === undefined) return {};
+    latestValidUntil = Math.max(latestValidUntil ?? Number.NEGATIVE_INFINITY, validUntil);
   }
-  return false;
+  return matched ? { validUntil: latestValidUntil } : undefined;
+}
+
+function isValidBrandGrant(value: unknown): value is string[] {
+  return (
+    Array.isArray(value) &&
+    value.length > 0 &&
+    value.every(item => typeof item === 'string' && (item === '*' || /^[a-z0-9_]+$/.test(item)))
+  );
+}
+
+function isValidScopeGrant(value: unknown): value is string[] {
+  return (
+    Array.isArray(value) &&
+    value.length > 0 &&
+    new Set(value).size === value.length &&
+    value.every(item => typeof item === 'string' && AUTHORIZED_OPERATOR_SCOPES.has(item))
+  );
+}
+
+function isValidCountryGrant(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every(item => typeof item === 'string' && /^[A-Z]{2}$/.test(item));
+}
+
+function matchesGrant(grants: readonly string[], required: string | undefined, wildcard?: string): boolean {
+  if (wildcard !== undefined && grants.includes(wildcard)) return true;
+  return required !== undefined && grants.includes(required);
+}
+
+function parseOptionalRfc3339(value: unknown): number | undefined | null {
+  if (value === undefined) return undefined;
+  if (typeof value !== 'string') return null;
+  const match = /^(\d{4})-(\d{2})-(\d{2})[Tt](\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?([Zz]|([+-])(\d{2}):(\d{2}))$/.exec(
+    value
+  );
+  if (!match) return null;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const hour = Number(match[4]);
+  const minute = Number(match[5]);
+  const second = Number(match[6]);
+  const offsetHour = match[10] === undefined ? 0 : Number(match[10]);
+  const offsetMinute = match[11] === undefined ? 0 : Number(match[11]);
+  if (
+    month < 1 ||
+    month > 12 ||
+    day < 1 ||
+    day > daysInMonth(year, month) ||
+    hour > 23 ||
+    minute > 59 ||
+    second > 59 ||
+    offsetHour > 23 ||
+    offsetMinute > 59
+  ) {
+    return null;
+  }
+  const parsed = Date.parse(value) / 1000;
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function daysInMonth(year: number, month: number): number {
+  return new Date(Date.UTC(year, month, 0)).getUTCDate();
 }
 
 function originOf(url: string): string {

--- a/src/lib/signing/agent-resolver/resolved-agent-jwks.ts
+++ b/src/lib/signing/agent-resolver/resolved-agent-jwks.ts
@@ -1,10 +1,18 @@
 import type { AdcpJsonWebKey } from '../types';
 import type { JwksResolver } from '../jwks';
+import { AgentResolverError } from './errors';
 import { resolveAgent, type AgentProtocol, type AgentResolution, type ResolveAgentOptions } from './resolve-agent';
 
 export interface ResolvedAgentJwksResolverOptions extends Pick<
   ResolveAgentOptions,
-  'fetchCapabilities' | 'allowPrivateIp' | 'bodyCaps' | 'timeoutMs' | 'now'
+  | 'fetchCapabilities'
+  | 'allowPrivateIp'
+  | 'bodyCaps'
+  | 'timeoutMs'
+  | 'now'
+  | 'requiredOperatorBrand'
+  | 'requiredOperatorScope'
+  | 'requiredOperatorCountry'
 > {
   /** Positive cache lifetime in seconds. Defaults to 300. */
   cacheTtlSeconds?: number;
@@ -30,7 +38,7 @@ export class ResolvedAgentJwksResolver implements JwksResolver {
     private readonly protocol: AgentProtocol,
     private readonly options: ResolvedAgentJwksResolverOptions = {}
   ) {
-    this.now = options.now ?? (() => Math.floor(Date.now() / 1000));
+    this.now = options.now ?? (() => Date.now() / 1000);
     this.cacheTtlSeconds = options.cacheTtlSeconds ?? 300;
     this.unknownKidCooldownSeconds = options.unknownKidCooldownSeconds ?? 30;
     if (!Number.isFinite(this.cacheTtlSeconds) || this.cacheTtlSeconds <= 0) {
@@ -75,7 +83,28 @@ export class ResolvedAgentJwksResolver implements JwksResolver {
         ...(this.options.bodyCaps && { bodyCaps: this.options.bodyCaps }),
         ...(this.options.timeoutMs !== undefined && { timeoutMs: this.options.timeoutMs }),
         ...(this.options.now && { now: this.options.now }),
+        ...(this.options.requiredOperatorBrand !== undefined && {
+          requiredOperatorBrand: this.options.requiredOperatorBrand,
+        }),
+        ...(this.options.requiredOperatorScope !== undefined && {
+          requiredOperatorScope: this.options.requiredOperatorScope,
+        }),
+        ...(this.options.requiredOperatorCountry !== undefined && {
+          requiredOperatorCountry: this.options.requiredOperatorCountry,
+        }),
       });
+      const refreshedAt = this.now();
+      if (
+        resolution.operatorAuthorizationValidUntil !== undefined &&
+        refreshedAt >= resolution.operatorAuthorizationValidUntil
+      ) {
+        throw new AgentResolverError(
+          'request_signature_brand_origin_mismatch',
+          'The cross-origin operator delegation expired during key discovery.',
+          { agent_url: this.agentUrl },
+          ['agent_url']
+        );
+      }
       const next = new Map<string, AdcpJsonWebKey>();
       for (const candidate of resolution.jwks.keys) {
         if (candidate && typeof candidate === 'object' && typeof candidate.kid === 'string') {
@@ -83,7 +112,10 @@ export class ResolvedAgentJwksResolver implements JwksResolver {
         }
       }
       this.keys = next;
-      this.expiresAt = this.now() + this.cacheTtlSeconds;
+      this.expiresAt = Math.min(
+        refreshedAt + this.cacheTtlSeconds,
+        resolution.operatorAuthorizationValidUntil ?? Number.POSITIVE_INFINITY
+      );
     })().finally(() => {
       this.inFlight = undefined;
     });

--- a/src/lib/signing/server.ts
+++ b/src/lib/signing/server.ts
@@ -122,6 +122,7 @@ export {
   readIdentityPosture,
   type AgentResolution,
   type AgentProtocol,
+  type AuthorizedOperatorScope,
   type AgentResolverErrorCode,
   type AgentResolverErrorDetail,
   type AgentEntry,

--- a/test/agent-resolver-integration.test.js
+++ b/test/agent-resolver-integration.test.js
@@ -17,6 +17,7 @@ const {
   AgentResolverError,
   getAgentJwks,
   createAgentJwksSet,
+  ResolvedAgentJwksResolver,
   attackerInfluencedFields,
 } = require('../dist/lib/signing/server');
 
@@ -204,22 +205,260 @@ describe('resolveAgent — rejection codes', () => {
     );
   });
 
-  it('request_signature_brand_origin_mismatch passes when authorized_operators delegates', async () => {
+  it('accepts only active, schema-shaped broad operator delegations', async () => {
     const agentUrl = 'https://operator.example/mcp';
+    const now = 1_700_000_000;
+    const validUntil = now + 60;
     routes['/.well-known/brand.json'] = {
       body: {
-        authorized_operators: [{ domain: 'operator.example' }],
+        authorized_operators: [
+          {
+            domain: 'operator.example',
+            brands: ['*'],
+            scopes: ['all'],
+            valid_from: new Date(now * 1000).toISOString(),
+            valid_until: new Date(validUntil * 1000).toISOString(),
+          },
+        ],
         agents: [{ type: 'sales', url: agentUrl, jwks_uri: `${baseUrl}/jwks.json` }],
       },
     };
     routes['/jwks.json'] = { body: { keys: [publicJwk] } };
     const result = await resolveAgent(agentUrl, {
       allowPrivateIp: true,
+      now: () => now,
       fetchCapabilities: fakeCapabilities({
         identity: { brand_json_url: `${baseUrl}/.well-known/brand.json` },
       }),
     });
     assert.equal(result.agentUrl, agentUrl);
+    assert.equal(result.operatorAuthorizationValidUntil, validUntil);
+  });
+
+  it('accepts RFC 3339 lower-case date/time separators', async () => {
+    const agentUrl = 'https://operator.example/mcp';
+    const now = 1_700_000_000;
+    const validUntil = now + 60;
+    routes['/.well-known/brand.json'] = {
+      body: {
+        authorized_operators: [
+          {
+            domain: 'operator.example',
+            brands: ['*'],
+            valid_from: new Date((now - 60) * 1000).toISOString().replace('T', 't').replace('Z', 'z'),
+            valid_until: new Date(validUntil * 1000).toISOString().replace('T', 't').replace('Z', 'z'),
+          },
+        ],
+        agents: [{ type: 'sales', url: agentUrl, jwks_uri: `${baseUrl}/jwks.json` }],
+      },
+    };
+    routes['/jwks.json'] = { body: { keys: [publicJwk] } };
+
+    const result = await resolveAgent(agentUrl, {
+      allowPrivateIp: true,
+      now: () => now,
+      fetchCapabilities: fakeCapabilities({
+        identity: { brand_json_url: `${baseUrl}/.well-known/brand.json` },
+      }),
+    });
+    assert.equal(result.operatorAuthorizationValidUntil, validUntil);
+  });
+
+  it('rejects expired, future, malformed, and schema-invalid operator delegations', async () => {
+    const agentUrl = 'https://operator.example/mcp';
+    const now = 1_700_000_000;
+    const inactiveEntries = [
+      'operator.example',
+      { domain: 'operator.example' },
+      { domain: 'operator.example', brands: [] },
+      { domain: 'evil.invalid@operator.example', brands: ['*'] },
+      { domain: 'operator.example', brands: ['*'], valid_until: new Date(now * 1000).toISOString() },
+      { domain: 'operator.example', brands: ['*'], valid_until: 'tomorrow' },
+      { domain: 'operator.example', brands: ['*'], valid_from: new Date((now + 1) * 1000).toISOString() },
+    ];
+    routes['/jwks.json'] = { body: { keys: [publicJwk] } };
+
+    for (const entry of inactiveEntries) {
+      routes['/.well-known/brand.json'] = {
+        body: {
+          authorized_operators: [entry],
+          agents: [{ type: 'sales', url: agentUrl, jwks_uri: `${baseUrl}/jwks.json` }],
+        },
+      };
+      await assertCode(
+        () =>
+          resolveAgent(agentUrl, {
+            allowPrivateIp: true,
+            now: () => now,
+            fetchCapabilities: fakeCapabilities({
+              identity: { brand_json_url: `${baseUrl}/.well-known/brand.json` },
+            }),
+          }),
+        'request_signature_brand_origin_mismatch'
+      );
+    }
+  });
+
+  it('binds constrained operator delegations to explicit brand, scope, and country context', async () => {
+    const agentUrl = 'https://operator.example/mcp';
+    routes['/.well-known/brand.json'] = {
+      body: {
+        authorized_operators: [
+          {
+            domain: 'operator.example',
+            brands: ['brand_a'],
+            scopes: ['media_buying'],
+            countries: ['GB'],
+          },
+        ],
+        agents: [{ type: 'sales', url: agentUrl, jwks_uri: `${baseUrl}/jwks.json` }],
+      },
+    };
+    routes['/jwks.json'] = { body: { keys: [publicJwk] } };
+    const baseOptions = {
+      allowPrivateIp: true,
+      fetchCapabilities: fakeCapabilities({
+        identity: { brand_json_url: `${baseUrl}/.well-known/brand.json` },
+      }),
+    };
+
+    await assertCode(() => resolveAgent(agentUrl, baseOptions), 'request_signature_brand_origin_mismatch');
+    await assertCode(
+      () =>
+        resolveAgent(agentUrl, {
+          ...baseOptions,
+          requiredOperatorBrand: 'brand_b',
+          requiredOperatorScope: 'media_buying',
+          requiredOperatorCountry: 'GB',
+        }),
+      'request_signature_brand_origin_mismatch'
+    );
+    await assertCode(
+      () =>
+        resolveAgent(agentUrl, {
+          ...baseOptions,
+          requiredOperatorBrand: 'brand_a',
+          requiredOperatorScope: 'creative_generation',
+          requiredOperatorCountry: 'GB',
+        }),
+      'request_signature_brand_origin_mismatch'
+    );
+    await assertCode(
+      () =>
+        resolveAgent(agentUrl, {
+          ...baseOptions,
+          requiredOperatorBrand: 'brand_a',
+          requiredOperatorScope: 'media_buying',
+          requiredOperatorCountry: 'US',
+        }),
+      'request_signature_brand_origin_mismatch'
+    );
+
+    const result = await resolveAgent(agentUrl, {
+      ...baseOptions,
+      requiredOperatorBrand: 'brand_a',
+      requiredOperatorScope: 'media_buying',
+      requiredOperatorCountry: 'GB',
+    });
+    assert.equal(result.agentUrl, agentUrl);
+  });
+
+  it('keeps authorization while an active sibling delegation remains', async () => {
+    const agentUrl = 'https://operator.example/mcp';
+    const now = 1_700_000_000;
+    const earlierValidUntil = now + 30;
+    const validUntil = now + 60;
+    routes['/.well-known/brand.json'] = {
+      body: {
+        authorized_operators: [
+          {
+            domain: 'operator.example',
+            brands: ['*'],
+            valid_until: new Date(earlierValidUntil * 1000).toISOString(),
+          },
+          { domain: 'operator.example', brands: ['*'], valid_until: new Date(validUntil * 1000).toISOString() },
+        ],
+        agents: [{ type: 'sales', url: agentUrl, jwks_uri: `${baseUrl}/jwks.json` }],
+      },
+    };
+    routes['/jwks.json'] = { body: { keys: [publicJwk] } };
+    const result = await resolveAgent(agentUrl, {
+      allowPrivateIp: true,
+      now: () => now,
+      fetchCapabilities: fakeCapabilities({
+        identity: { brand_json_url: `${baseUrl}/.well-known/brand.json` },
+      }),
+    });
+    assert.equal(result.operatorAuthorizationValidUntil, validUntil);
+  });
+
+  it('rejects a delegation that expires while JWKS discovery is in flight', async () => {
+    const agentUrl = 'https://operator.example/mcp';
+    let now = 1_700_000_000;
+    const validUntil = now + 1;
+    routes['/.well-known/brand.json'] = {
+      body: {
+        authorized_operators: [
+          {
+            domain: 'operator.example',
+            brands: ['*'],
+            valid_until: new Date(validUntil * 1000).toISOString(),
+          },
+        ],
+        agents: [{ type: 'sales', url: agentUrl, jwks_uri: `${baseUrl}/jwks.json` }],
+      },
+    };
+    routes['/jwks.json'] = (_req, res) => {
+      now = validUntil;
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ keys: [publicJwk] }));
+    };
+
+    await assertCode(
+      () =>
+        resolveAgent(agentUrl, {
+          allowPrivateIp: true,
+          now: () => now,
+          fetchCapabilities: fakeCapabilities({
+            identity: { brand_json_url: `${baseUrl}/.well-known/brand.json` },
+          }),
+        }),
+      'request_signature_brand_origin_mismatch'
+    );
+  });
+
+  it('treats fractional valid_until as inactive at the exact real-time boundary', async () => {
+    const agentUrl = 'https://operator.example/mcp';
+    const originalDateNow = Date.now;
+    const boundaryMs = 1_700_000_000_500;
+    Date.now = () => boundaryMs + 400;
+    try {
+      routes['/.well-known/brand.json'] = {
+        body: {
+          authorized_operators: [
+            {
+              domain: 'operator.example',
+              brands: ['*'],
+              valid_until: new Date(boundaryMs).toISOString(),
+            },
+          ],
+          agents: [{ type: 'sales', url: agentUrl, jwks_uri: `${baseUrl}/jwks.json` }],
+        },
+      };
+      routes['/jwks.json'] = { body: { keys: [publicJwk] } };
+      await assertCode(
+        () =>
+          resolveAgent(agentUrl, {
+            allowPrivateIp: true,
+            fetchCapabilities: fakeCapabilities({
+              identity: { brand_json_url: `${baseUrl}/.well-known/brand.json` },
+            }),
+          }),
+        'request_signature_brand_origin_mismatch'
+      );
+    } finally {
+      Date.now = originalDateNow;
+    }
   });
 
   it('request_signature_agent_not_in_brand_json on byte-equal miss (trailing slash)', async () => {
@@ -382,6 +621,34 @@ describe('getAgentJwks fast path', () => {
     assert.ok(typeof result.fetchedAt === 'number');
     assert.ok(!('trace' in result));
   });
+
+  it('returns the accepted operator-delegation cache boundary', async () => {
+    const agentUrl = 'https://operator.example/mcp';
+    const now = 1_700_000_000;
+    const validUntil = now + 60;
+    routes['/.well-known/brand.json'] = {
+      body: {
+        authorized_operators: [
+          {
+            domain: 'operator.example',
+            brands: ['*'],
+            valid_until: new Date(validUntil * 1000).toISOString(),
+          },
+        ],
+        agents: [{ type: 'sales', url: agentUrl, jwks_uri: `${baseUrl}/jwks.json` }],
+      },
+    };
+    routes['/jwks.json'] = { body: { keys: [publicJwk] } };
+
+    const result = await getAgentJwks(agentUrl, {
+      allowPrivateIp: true,
+      now: () => now,
+      fetchCapabilities: fakeCapabilities({
+        identity: { brand_json_url: `${baseUrl}/.well-known/brand.json` },
+      }),
+    });
+    assert.equal(result.operatorAuthorizationValidUntil, validUntil);
+  });
 });
 
 describe('createAgentJwksSet — JOSE adapter', () => {
@@ -436,6 +703,102 @@ describe('createAgentJwksSet — JOSE adapter', () => {
     }
     assert.ok(caught instanceof AgentResolverError);
     assert.equal(caught.code, 'request_signature_jwks_alg_disallowed');
+  });
+
+  it('does not cache a delegated JWKS past valid_until', async () => {
+    const agentUrl = 'https://operator.example/mcp';
+    let now = 1_700_000_000;
+    let brandFetches = 0;
+    const validUntil = now + 10;
+    routes['/.well-known/brand.json'] = (_req, res) => {
+      brandFetches += 1;
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          authorized_operators: [
+            {
+              domain: 'operator.example',
+              brands: ['*'],
+              valid_until: new Date(validUntil * 1000).toISOString(),
+            },
+          ],
+          agents: [{ type: 'sales', url: agentUrl, jwks_uri: `${baseUrl}/jwks.json` }],
+        })
+      );
+    };
+    routes['/jwks.json'] = { body: { keys: [publicJwk] } };
+    const getKey = createAgentJwksSet(agentUrl, {
+      allowPrivateIp: true,
+      allowedAlgs: ['EdDSA'],
+      cacheMaxAgeSeconds: 300,
+      now: () => now,
+      fetchCapabilities: fakeCapabilities({
+        identity: { brand_json_url: `${baseUrl}/.well-known/brand.json` },
+      }),
+    });
+    const jwt = await new SignJWT({ scope: 'test' })
+      .setProtectedHeader({ alg: 'EdDSA', kid: 'test-resolver-key' })
+      .setIssuedAt()
+      .setExpirationTime('1h')
+      .sign(privateKey);
+
+    await jwtVerify(jwt, getKey, { algorithms: ['EdDSA'] });
+    now = validUntil;
+    await assert.rejects(
+      () => jwtVerify(jwt, getKey, { algorithms: ['EdDSA'] }),
+      error => error instanceof AgentResolverError && error.code === 'request_signature_brand_origin_mismatch'
+    );
+    assert.equal(brandFetches, 2);
+  });
+});
+
+describe('ResolvedAgentJwksResolver cache', () => {
+  it('does not cache a delegated JWKS past valid_until', async () => {
+    let now = 1_700_000_000;
+    let resolutions = 0;
+    const validUntil = now + 10;
+    const resolver = new ResolvedAgentJwksResolver('https://operator.example/mcp', 'mcp', {
+      now: () => now,
+      cacheTtlSeconds: 300,
+      resolve: async () => {
+        resolutions += 1;
+        if (now >= validUntil) {
+          throw new AgentResolverError('request_signature_brand_origin_mismatch', 'delegation expired', {});
+        }
+        return {
+          jwks: { keys: [{ ...publicJwk, kid: 'known-key' }] },
+          operatorAuthorizationValidUntil: validUntil,
+        };
+      },
+    });
+
+    assert.equal((await resolver.resolve('known-key')).kid, 'known-key');
+    now = validUntil;
+    await assert.rejects(
+      () => resolver.resolve('known-key'),
+      error => error instanceof AgentResolverError && error.code === 'request_signature_brand_origin_mismatch'
+    );
+    assert.equal(resolutions, 2);
+  });
+
+  it('rejects a resolution whose delegation expires before cache installation', async () => {
+    let now = 1_700_000_000;
+    const validUntil = now + 0.5;
+    const resolver = new ResolvedAgentJwksResolver('https://operator.example/mcp', 'mcp', {
+      now: () => now,
+      resolve: async () => {
+        now = validUntil;
+        return {
+          jwks: { keys: [{ ...publicJwk, kid: 'known-key' }] },
+          operatorAuthorizationValidUntil: validUntil,
+        };
+      },
+    });
+
+    await assert.rejects(
+      () => resolver.resolve('known-key'),
+      error => error instanceof AgentResolverError && error.code === 'request_signature_brand_origin_mismatch'
+    );
   });
 });
 

--- a/test/lib/mcp-modern-negotiation.test.js
+++ b/test/lib/mcp-modern-negotiation.test.js
@@ -574,6 +574,90 @@ test('serve exposes AdCP tools to a client pinned to MCP 2026-07-28', async t =>
   await hostileClient.close().catch(() => {});
 });
 
+test('modern serving returns structured AdCP validation errors while advertising the strict official schema', async t => {
+  const { serve, InMemoryStateStore } = require('../../dist/lib/index.js');
+  const { createAdcpServer } = require('../../dist/lib/server/legacy/v5/index.js');
+  const { Client, StreamableHTTPClientTransport } = require('@modelcontextprotocol/client');
+
+  let handlerCalls = 0;
+  const httpServer = serve(
+    () =>
+      createAdcpServer({
+        name: 'modern-validation-test',
+        version: '1.0.0',
+        adcpVersion: '3.2.0-beta.8',
+        mcpToolProfile: 'all',
+        stateStore: new InMemoryStateStore(),
+        validation: { requests: 'off', responses: 'off' },
+        mediaBuy: {
+          createMediaBuy: async () => {
+            handlerCalls += 1;
+            return { media_buy_id: 'mb-modern-validation', packages: [], status: 'pending_creative' };
+          },
+        },
+      }),
+    { port: 0, onListening: () => {} }
+  );
+  await new Promise((resolve, reject) => {
+    httpServer.once('error', reject);
+    if (httpServer.listening) resolve();
+    else httpServer.once('listening', resolve);
+  });
+  const address = httpServer.address();
+  assert.ok(address && typeof address === 'object');
+  const client = new Client(
+    { name: 'modern-validation-client', version: '1.0.0' },
+    { versionNegotiation: { mode: { pin: '2026-07-28' } } }
+  );
+
+  t.after(async () => {
+    await client.close().catch(() => {});
+    await closeServer(httpServer);
+  });
+
+  await client.connect(new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${address.port}/mcp`)));
+  const listed = await client.listTools();
+  const createMediaBuy = listed.tools.find(tool => tool.name === 'create_media_buy');
+  assert.ok(createMediaBuy);
+  assert.match(createMediaBuy.inputSchema.$id, /\/mcp\/2026-07-28\/media-buy\/create-media-buy-request\.json$/);
+  assert.equal(
+    createMediaBuy.inputSchema.$defs['external:media-buy/package-request.json'].properties.budget.minimum,
+    0
+  );
+
+  const context = { correlation_id: 'negative-budget-probe' };
+  const baseArguments = {
+    account: { account_id: 'acct-modern-validation' },
+    brand: { domain: 'example.com' },
+    start_time: '2026-09-01T00:00:00Z',
+    end_time: '2026-09-02T00:00:00Z',
+    packages: [{ product_id: 'product-1', pricing_option_id: 'pricing-1', budget: -1 }],
+    idempotency_key: 'modern-validation-negative',
+    context,
+  };
+  const rejected = await client.callTool({ name: 'create_media_buy', arguments: baseArguments });
+  assert.equal(rejected.isError, true);
+  assert.equal(rejected.structuredContent.adcp_error.code, 'VALIDATION_ERROR');
+  assert.equal(rejected.structuredContent.adcp_error.recovery, 'correctable');
+  assert.deepEqual(rejected.structuredContent.context, context);
+  assert.match(JSON.stringify(rejected.structuredContent.adcp_error), /packages\/0\/budget/);
+  assert.match(JSON.stringify(rejected.structuredContent.adcp_error), /minimum/);
+  assert.doesNotMatch(rejected.content.map(part => part.text ?? '').join('\n'), /Input validation error/);
+  assert.equal(handlerCalls, 0);
+
+  const accepted = await client.callTool({
+    name: 'create_media_buy',
+    arguments: {
+      ...baseArguments,
+      idempotency_key: 'modern-validation-positive',
+      packages: [{ product_id: 'product-1', pricing_option_id: 'pricing-1', budget: 1 }],
+    },
+  });
+  assert.notEqual(accepted.isError, true);
+  assert.deepEqual(accepted.structuredContent.context, context);
+  assert.equal(handlerCalls, 1);
+});
+
 test('modern serving honors the resolved AdCP MCP tool profile', async () => {
   const { serve, InMemoryStateStore } = require('../../dist/lib/index.js');
   const { createAdcpServer, MEDIA_BUY_MCP_TOOL_PROFILE } = require('../../dist/lib/server/create-adcp-server.js');
@@ -589,6 +673,7 @@ test('modern serving honors the resolved AdCP MCP tool profile', async () => {
           adcpVersion: '3.2.0-beta.8',
           ...(mcpToolProfile !== undefined && { mcpToolProfile }),
           stateStore: new InMemoryStateStore(),
+          validation: { requests: 'off', responses: 'off' },
           mediaBuy: {
             listProducts: async () => ({ outcome: 'listed', products: [], feed_version: 'feed-1' }),
             requestProposals: async () => ({ outcome: 'rejected', reason: 'fixture' }),
@@ -621,13 +706,17 @@ test('modern serving honors the resolved AdCP MCP tool profile', async () => {
     try {
       await client.connect(new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${address.port}/mcp`)));
       const listed = await client.listTools();
+      let hiddenCompatibilityResult;
       if (mcpToolProfile === undefined) {
-        await client.callTool({
+        hiddenCompatibilityResult = await client.callTool({
           name: 'get_products',
-          arguments: { buying_mode: 'brief', brief: 'legacy compatibility probe' },
+          // Deliberately violates the hidden tool's official schema. Hidden
+          // compatibility tools retain the adopter's explicit validation-off
+          // policy even though advertised framework tools are strengthened.
+          arguments: { buying_mode: 'not-a-mode', brief: 'legacy compatibility probe' },
         });
       }
-      return { listed, legacyCalls };
+      return { listed, legacyCalls, hiddenCompatibilityResult };
     } finally {
       await client.close().catch(() => {});
       await closeServer(httpServer);
@@ -642,6 +731,11 @@ test('modern serving honors the resolved AdCP MCP tool profile', async () => {
   assert.ok(!compactNames.includes('get_products'));
   assert.ok(!compactNames.includes('build_creative'));
   assert.equal(compactResult.legacyCalls, 1, 'a legacy tool hidden from discovery must remain directly callable');
+  assert.notEqual(
+    compactResult.hiddenCompatibilityResult?.isError,
+    true,
+    'hidden compatibility calls must retain an explicit validation-off policy'
+  );
   assert.ok(
     compactNames.every(name => MEDIA_BUY_MCP_TOOL_PROFILE.includes(name)),
     compactNames.join(', ')
@@ -702,14 +796,18 @@ test('modern serving preserves explicitly registered custom schemas and descript
   const { createModernMcpServerAdapter } = require('../../dist/lib/server/mcp-modern-server.js');
 
   const legacy = new McpServer({ name: 'modern-output-schema-test', version: '1.0.0' });
+  let handlerCalls = 0;
   legacy.registerTool(
     'request_proposals',
     {
       description: 'Adopter-specific proposal bridge.',
-      inputSchema: {},
+      inputSchema: { required_value: z.string() },
       outputSchema: z.object({ placeholder: z.string() }),
     },
-    async () => ({ content: [{ type: 'text', text: 'unused' }] })
+    async () => {
+      handlerCalls += 1;
+      return { content: [{ type: 'text', text: 'unused' }] };
+    }
   );
   const adapter = createModernMcpServerAdapter(wrapMcpServer(legacy, undefined, '3.2.0-beta.8'));
   const httpServer = createServer((req, res) => void adapter.handle(req, res));
@@ -729,8 +827,13 @@ test('modern serving preserves explicitly registered custom schemas and descript
   const listed = await client.listTools();
   const proposals = listed.tools.find(tool => tool.name === 'request_proposals');
   assert.equal(proposals.description, 'Adopter-specific proposal bridge.');
+  assert.ok(proposals.inputSchema.properties?.required_value);
+  assert.equal(proposals.inputSchema.properties?.account, undefined);
   assert.ok(proposals.outputSchema.properties?.placeholder);
   assert.equal(proposals.outputSchema.properties?.outcome, undefined);
+  const rejected = await client.callTool({ name: 'request_proposals', arguments: {} });
+  assert.equal(rejected.isError, true, 'the adopter-provided call-time schema must remain enforced');
+  assert.equal(handlerCalls, 0);
 });
 
 test('modern serving forwards portable MCP App metadata for custom tools', async t => {


### PR DESCRIPTION
## Summary

- enforce schema-shaped, time-bounded, brand/scope/country-aware cross-origin operator delegation during signing-key discovery
- cap built-in and adopter JWKS caches at the accepted delegation expiry
- keep modern MCP discovery on the official schema while returning structured AdCP validation errors from the framework
- preserve adopter schemas and explicit validation policy for custom or hidden compatibility tools

Closes #2697.
Closes #2700.

## Verification

- `npm run build`
- `npm run typecheck`
- focused resolver tests: 29 passed
- focused modern MCP tests: 13 passed
- `npm run test:lib:fast`: 13,725 passed, 7 skipped, 0 failed
- `npm run test:lib:slow`: 165 passed
- `npm run lint`: 0 errors (existing warning baseline only)
- `npm run lint:workflows`
- `npm run check:runtime-compat`
- `npm run check:adopter-types-narrow`
- `npm run check:adopter-types`
- `npm run verify:package`
- protocol, security, code, and second-model review stack completed
