### PR TITLE
fix(auth): preserve static credential rejection semantics

### DIFF
--- a/.changeset/calm-bearers-stay-static.md
+++ b/.changeset/calm-bearers-stay-static.md
@@ -1,5 +1,5 @@
 ---
-'@adcp/sdk': patch
+'@adcp/sdk': minor
 ---
 
 Preserve static bearer and header credential rejections instead of misclassifying them as interactive OAuth, and require validated MCP protected-resource metadata before raising `NeedsAuthorizationError`.

--- a/.changeset/calm-bearers-stay-static.md
+++ b/.changeset/calm-bearers-stay-static.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Preserve static bearer and header credential rejections instead of misclassifying them as interactive OAuth, and require validated MCP protected-resource metadata before raising `NeedsAuthorizationError`.

--- a/src/lib/auth/oauth/authorization-required.ts
+++ b/src/lib/auth/oauth/authorization-required.ts
@@ -14,6 +14,7 @@ import { ssrfSafeFetch, decodeBodyAsJsonOrText } from '../../net';
 import { AuthenticationRequiredError, type OAuthMetadataInfo } from '../../errors';
 import { throwIfAborted } from '../../protocols/abort';
 import { parseWWWAuthenticate, type WWWAuthenticateChallenge } from './diagnostics';
+import { buildProtectedResourceMetadataUrl, normalizeOAuthResourceForComparison } from './resource-url';
 
 /**
  * Maximum length of an individual server-supplied string we copy into the
@@ -76,9 +77,10 @@ function sanitizeChallenge(c: WWWAuthenticateChallenge): WWWAuthenticateChalleng
 }
 
 /**
- * Structured description of what an agent's authorization server requires
- * before it will accept a `tools/call`. Produced by
- * {@link discoverAuthorizationRequirements}.
+ * Structured result from a Bearer challenge and its available discovery
+ * metadata. Records may be partial; use
+ * {@link hasValidatedMcpAuthorizationRequirements} before treating one as
+ * proof that an MCP endpoint requires OAuth.
  */
 export interface AuthorizationRequirements {
   /** The agent URL we probed. */
@@ -138,12 +140,12 @@ export interface AuthorizationRequirements {
  *   `instanceof NeedsAuthorizationError` for type-narrowing and use `subCode`
  *   only for structured-log keying.
  *
- * Note on `hasOAuth`:
+ * Note on validation and `hasOAuth`:
  *   The inherited getter returns `true` only when both `authorization_endpoint`
  *   and `token_endpoint` were walked successfully. A partially-walked
- *   requirements record (PRM reachable but AS metadata missing) still yields
- *   `hasOAuth === false` even though `requirements.authorizationServer` is set.
- *   Treat it as "we have enough to start a flow," not "server wants OAuth."
+ *   requirements record still yields `hasOAuth === false`. Callers should
+ *   construct this error only after
+ *   {@link hasValidatedMcpAuthorizationRequirements} succeeds.
  */
 export class NeedsAuthorizationError extends AuthenticationRequiredError {
   /** Narrow discriminator for consumers that already know about this class. */
@@ -211,14 +213,17 @@ export interface DiscoverAuthorizationOptions {
 }
 
 /**
- * Walk the OAuth discovery chain starting from an agent URL. Returns
- * `AuthorizationRequirements` when the agent demands OAuth, or `null` when a
- * `tools/list` call succeeds without credentials.
+ * Walk the OAuth discovery chain starting from an agent URL. Returns an
+ * `AuthorizationRequirements` diagnostic record for a Bearer challenge (even
+ * when later metadata is absent), or `null` when the probe is not a Bearer
+ * 401. Use {@link hasValidatedMcpAuthorizationRequirements} before promoting
+ * the record to an interactive OAuth requirement.
  *
  * Strategy:
  *   1. POST `tools/list` to the agent with no `Authorization` header.
  *   2. If 401 + `WWW-Authenticate: Bearer`: parse the challenge.
- *   3. If the challenge carries `resource_metadata=…`: GET it and read
+ *   3. Resolve `resource_metadata=…`, or the RFC 9728 well-known fallback,
+ *      then GET it and read
  *      `resource` + `authorization_servers`.
  *   4. For the first `authorization_servers[0]`: GET `/.well-known/oauth-authorization-server`
  *      and read `authorization_endpoint`, `token_endpoint`, `registration_endpoint`,
@@ -266,17 +271,26 @@ export async function discoverAuthorizationRequirements(
 
   const requirements: AuthorizationRequirements = {
     agentUrl,
-    resourceMetadataUrl: challenge.resource_metadata ? sanitizeDisplay(challenge.resource_metadata) : undefined,
     challengeScope: challenge.scope ? sanitizeDisplay(challenge.scope) : undefined,
     challenge: sanitizeChallenge(challenge),
   };
 
+  let resourceMetadataUrl = challenge.resource_metadata;
+  if (!resourceMetadataUrl) {
+    try {
+      resourceMetadataUrl = buildProtectedResourceMetadataUrl(agentUrl);
+    } catch {
+      resourceMetadataUrl = undefined;
+    }
+  }
+  if (resourceMetadataUrl) requirements.resourceMetadataUrl = sanitizeDisplay(resourceMetadataUrl);
+
   // Walk protected-resource metadata (RFC 9728 §3). Private-IP targets are
   // only allowed when the hop's origin matches the agent's.
-  if (challenge.resource_metadata && isSafeHttpUrl(challenge.resource_metadata)) {
+  if (resourceMetadataUrl && isSafeHttpUrl(resourceMetadataUrl)) {
     const prm = await fetchJson(
-      challenge.resource_metadata,
-      allowPrivateIpForHop(challenge.resource_metadata),
+      resourceMetadataUrl,
+      allowPrivateIpForHop(resourceMetadataUrl),
       options.timeoutMs,
       options.fetchFn,
       options.signal
@@ -363,6 +377,27 @@ export async function discoverAuthorizationRequirements(
   }
 
   return requirements;
+}
+
+/**
+ * Whether a discovery record proves the MCP endpoint is OAuth protected.
+ *
+ * `discoverAuthorizationRequirements` intentionally returns partial records
+ * for diagnostics. Those records are not sufficient evidence for an
+ * interactive OAuth prompt: the MCP authorization profile requires protected
+ * resource metadata whose `resource` exactly identifies the endpoint and
+ * which names at least one authorization server.
+ */
+export function hasValidatedMcpAuthorizationRequirements(
+  requirements: AuthorizationRequirements,
+  agentUrl: string
+): boolean {
+  return (
+    normalizeOAuthResourceForComparison(requirements.resource ?? '') ===
+      normalizeOAuthResourceForComparison(agentUrl) &&
+    Array.isArray(requirements.authorizationServers) &&
+    requirements.authorizationServers.length > 0
+  );
 }
 
 /**

--- a/src/lib/auth/oauth/index.ts
+++ b/src/lib/auth/oauth/index.ts
@@ -321,6 +321,7 @@ export {
 export {
   NeedsAuthorizationError,
   discoverAuthorizationRequirements,
+  hasValidatedMcpAuthorizationRequirements,
   probeAuthChallenge,
   type AuthorizationRequirements,
   type DiscoverAuthorizationOptions,

--- a/src/lib/auth/oauth/resource-url.ts
+++ b/src/lib/auth/oauth/resource-url.ts
@@ -2,6 +2,52 @@ import { OAuthError } from './types';
 
 const MAX_RESOURCE_URL_LENGTH = 2048;
 
+/**
+ * RFC 9728 resource comparison semantics used by OAuth discovery and
+ * compliance grading. Scheme and host are case-insensitive and default ports
+ * are equivalent; the remainder stays byte-for-byte significant.
+ */
+export function normalizeOAuthResourceForComparison(value: string): string {
+  const match = /^([A-Za-z][A-Za-z\d+.-]*):\/\/([^/?#]*)([\s\S]*)$/.exec(value);
+  if (!match) return value;
+  const scheme = match[1]!.toLowerCase();
+  const authority = match[2]!;
+  const remainder = match[3]!;
+  const at = authority.lastIndexOf('@');
+  const userinfo = at >= 0 ? authority.slice(0, at + 1) : '';
+  const hostAndPort = at >= 0 ? authority.slice(at + 1) : authority;
+  let host: string;
+  let port = '';
+  if (hostAndPort.startsWith('[')) {
+    const bracket = hostAndPort.indexOf(']');
+    if (bracket < 0) return value;
+    host = hostAndPort.slice(0, bracket + 1).toLowerCase();
+    const suffix = hostAndPort.slice(bracket + 1);
+    if (suffix && !/^:\d+$/.test(suffix)) return value;
+    port = suffix.slice(1);
+  } else {
+    const colon = hostAndPort.lastIndexOf(':');
+    if (colon >= 0) {
+      const suffix = hostAndPort.slice(colon + 1);
+      if (!/^\d+$/.test(suffix)) return value;
+      host = hostAndPort.slice(0, colon).toLowerCase();
+      port = suffix;
+    } else {
+      host = hostAndPort.toLowerCase();
+    }
+  }
+  if (!host) return value;
+  const defaultPort = scheme === 'https' ? '443' : scheme === 'http' ? '80' : undefined;
+  const renderedPort = port && port !== defaultPort ? `:${port}` : '';
+  return `${scheme}://${userinfo}${host}${renderedPort}${remainder}`;
+}
+
+/** Build the RFC 9728 well-known metadata URL for a protected resource. */
+export function buildProtectedResourceMetadataUrl(agentUrl: string): string {
+  const url = new URL(agentUrl);
+  return `${url.origin}/.well-known/oauth-protected-resource${url.pathname}`;
+}
+
 /** Validate and canonicalize an operator-configured RFC 8707 resource URI. */
 export function validateOAuthResourceUrl(value: string, options: { allowHttp?: boolean } = {}): URL {
   if (value.length === 0 || value.length > MAX_RESOURCE_URL_LENGTH) {

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -120,6 +120,7 @@ import { createMCPRequestHeaders } from '../auth';
 import { isAbortOrTimeoutError } from '../protocols/abort';
 import { ProtocolClient, normalizeTransportOptions } from '../protocols';
 import {
+  AuthenticationCredentialsRejectedError,
   AuthenticationRequiredError,
   ConfigurationError,
   FeatureUnsupportedError,
@@ -131,6 +132,7 @@ import {
 import { createAgentTransportFetch, isLikelyPrivateUrl } from '../net';
 import {
   discoverAuthorizationRequirements,
+  hasValidatedMcpAuthorizationRequirements,
   NeedsAuthorizationError,
   probeAuthChallenge,
 } from '../auth/oauth/authorization-required';
@@ -192,6 +194,19 @@ import {
   throwIfAborted,
   withAbortSignal,
 } from '../protocols/abort';
+
+function presentedStaticTransportCredential(
+  authToken: string | undefined,
+  headers: Record<string, string> | undefined,
+  authProvider?: object
+): boolean {
+  if (authProvider) return false;
+  if (authToken) return true;
+  return Object.keys(headers ?? {}).some(key => {
+    const normalized = key.toLowerCase();
+    return normalized === 'authorization' || normalized === 'x-adcp-auth';
+  });
+}
 
 // v3.0 compatibility utilities
 import type { AdcpCapabilities, AdcpMajorVersion, ToolInfo, FeatureName } from '../utils/capabilities';
@@ -2788,8 +2803,8 @@ export class SingleAgentClient {
    *
    * Special handling for authentication errors (401):
    * - If any endpoint returns 401, we know the server exists but requires auth
-   * - We fetch OAuth metadata and throw AuthenticationRequiredError
-   * - This gives consumers clear guidance on how to authenticate
+   * - A validated MCP protected-resource metadata chain yields NeedsAuthorizationError
+   * - Otherwise AuthenticationRequiredError carries the advertised challenge
    *
    * Note: This is async and called lazily on first agent interaction
    */
@@ -2900,6 +2915,7 @@ export class SingleAgentClient {
 
     // Track results and whether we got any 401s
     let got401 = false;
+    let first401Error: unknown;
     let firstWorkingUrl: string | undefined;
 
     // Test each URL
@@ -2913,6 +2929,7 @@ export class SingleAgentClient {
 
       if (result.status === 401) {
         got401 = true;
+        first401Error ??= result.error;
       }
     }
 
@@ -2923,15 +2940,18 @@ export class SingleAgentClient {
     // If we got 401 from any endpoint, throw an authentication-required error.
     // Prefer the richer NeedsAuthorizationError when we can walk the full
     // RFC 9728 chain (PRM → AS metadata → endpoints + scopes + DCR hint).
-    // Fall back to the simpler AuthenticationRequiredError with one-hop AS
-    // metadata when the walk doesn't yield enough.
+    // Fall back to AuthenticationRequiredError with the advertised challenge
+    // when the walk does not prove this MCP resource is OAuth protected.
     if (got401) {
+      if (presentedStaticTransportCredential(authToken, agentHeaders, authProvider)) {
+        throw new AuthenticationCredentialsRejectedError(providedUri, first401Error);
+      }
       const requirements = await discoverAuthorizationRequirements(providedUri, {
         allowPrivateIp: transport?.allowPrivateIp ?? isLikelyPrivateUrl(providedUri),
         fetchFn: transport?.trustedFetchFn,
         signal: options?.signal,
       });
-      if (requirements) {
+      if (requirements && hasValidatedMcpAuthorizationRequirements(requirements, providedUri)) {
         throw new NeedsAuthorizationError(requirements);
       }
       // Non-Bearer 401 (or Bearer-without-PRM). Re-probe to surface the
@@ -2943,12 +2963,7 @@ export class SingleAgentClient {
         fetchFn: transport?.trustedFetchFn,
         signal: options?.signal,
       });
-      const oauthMetadata = await discoverOAuthMetadata(providedUri, {
-        trustedFetchFn: transport?.trustedFetchFn,
-        allowPrivateIp: transport?.allowPrivateIp ?? isLikelyPrivateUrl(providedUri),
-        signal: options?.signal,
-      });
-      throw new AuthenticationRequiredError(providedUri, oauthMetadata || undefined, undefined, challenge ?? undefined);
+      throw new AuthenticationRequiredError(providedUri, undefined, undefined, challenge ?? undefined);
     }
 
     // None worked and no 401 - generic discovery failure.

--- a/src/lib/errors/index.ts
+++ b/src/lib/errors/index.ts
@@ -308,6 +308,45 @@ export class AuthenticationRequiredError extends ADCPError {
 }
 
 /**
+ * A configured non-interactive credential reached the agent and was rejected.
+ * The transport error is retained as a non-enumerable cause so reflected
+ * credential material from an untrusted 401 body cannot enter JSON reports.
+ */
+export class AuthenticationCredentialsRejectedError extends AuthenticationRequiredError {
+  readonly subCode = 'credentials_rejected' as const;
+
+  constructor(agentUrl: string, cause?: unknown) {
+    const safeAgentUrl = sanitizeAgentUrlForError(agentUrl);
+    super(
+      safeAgentUrl,
+      undefined,
+      'The agent rejected the configured credential with HTTP 401. Verify or replace the saved credential and retry.'
+    );
+    this.name = 'AuthenticationCredentialsRejectedError';
+    if (cause !== undefined) {
+      Object.defineProperty(this, 'cause', {
+        value: cause,
+        enumerable: false,
+        configurable: true,
+      });
+    }
+  }
+}
+
+function sanitizeAgentUrlForError(value: string): string {
+  try {
+    const url = new URL(value);
+    url.username = '';
+    url.password = '';
+    url.search = '';
+    url.hash = '';
+    return url.toString();
+  } catch {
+    return 'invalid_url';
+  }
+}
+
+/**
  * Build the default error message. Branches on what the 401 disclosed:
  * - non-Bearer challenge (Basic, Digest, …) → scheme-specific remediation
  * - OAuth metadata → point at the authorization endpoint

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -650,6 +650,7 @@ export {
   MissingInputHandlerError,
   InvalidContextError,
   ConfigurationError,
+  AuthenticationCredentialsRejectedError,
   AuthenticationRequiredError,
   FeatureUnsupportedError,
   ProtocolFeatureUnsupportedError,
@@ -1497,6 +1498,7 @@ export {
 export {
   NeedsAuthorizationError,
   discoverAuthorizationRequirements,
+  hasValidatedMcpAuthorizationRequirements,
   createFileOAuthStorage,
   bindAgentStorage,
   getAgentStorage,

--- a/src/lib/protocols/index.ts
+++ b/src/lib/protocols/index.ts
@@ -60,8 +60,9 @@ import {
   getAgentStorage,
   ensureClientCredentialsTokens,
 } from '../auth/oauth';
+import { hasValidatedMcpAuthorizationRequirements } from '../auth/oauth/authorization-required';
 import { getNonInteractiveOAuthProvider } from '../auth/oauth/provider-cache';
-import { is401Error } from '../errors';
+import { AuthenticationCredentialsRejectedError, is401Error } from '../errors';
 import { isLikelyPrivateUrl } from '../net';
 import { validateAgentUrl } from '../validation';
 import { withSpan } from '../observability/tracing';
@@ -86,6 +87,16 @@ export {
 export type { TransportActivity, TransportActivityContext, TransportActivityHandler } from './transportDiagnostics';
 
 export type VersionEnvelopeMode = 'auto' | 'none' | 'major-only';
+
+type AuthorizationRecoveryMode = 'discover' | 'oauth' | 'static' | 'legacy-a2a';
+
+function hasStaticAgentCredentials(agent: AgentConfig, authToken: string | undefined): boolean {
+  if (authToken) return true;
+  return Object.keys(agent.headers ?? {}).some(key => {
+    const normalized = key.toLowerCase();
+    return normalized === 'authorization' || normalized === 'x-adcp-auth';
+  });
+}
 
 /**
  * Derive the wire-level `adcp_major_version` integer from a caller-supplied
@@ -688,7 +699,8 @@ export class ProtocolClient {
                       agent.agent_uri,
                       transport?.trustedFetchFn,
                       signal,
-                      transport?.allowPrivateIp
+                      transport?.allowPrivateIp,
+                      'oauth'
                     );
                     throw err;
                   }
@@ -756,7 +768,8 @@ export class ProtocolClient {
                         agent.agent_uri,
                         transport?.trustedFetchFn,
                         signal,
-                        transport?.allowPrivateIp
+                        transport?.allowPrivateIp,
+                        'static'
                       );
                       throw retryErr;
                     }
@@ -766,7 +779,8 @@ export class ProtocolClient {
                     agent.agent_uri,
                     transport?.trustedFetchFn,
                     signal,
-                    transport?.allowPrivateIp
+                    transport?.allowPrivateIp,
+                    hasStaticAgentCredentials(agent, authToken) ? 'static' : 'discover'
                   );
                   throw err;
                 }
@@ -825,7 +839,8 @@ export class ProtocolClient {
                         agent.agent_uri,
                         transport?.trustedFetchFn,
                         signal,
-                        transport?.allowPrivateIp
+                        transport?.allowPrivateIp,
+                        'legacy-a2a'
                       );
                       throw retryErr;
                     }
@@ -835,7 +850,8 @@ export class ProtocolClient {
                     agent.agent_uri,
                     transport?.trustedFetchFn,
                     signal,
-                    transport?.allowPrivateIp
+                    transport?.allowPrivateIp,
+                    'legacy-a2a'
                   );
                   throw err;
                 }
@@ -863,10 +879,14 @@ async function rethrowAsNeedsAuthorization(
   agentUrl: string,
   fetchFn?: typeof fetch,
   signal?: AbortSignal,
-  configuredAllowPrivateIp?: boolean
+  configuredAllowPrivateIp?: boolean,
+  recoveryMode: AuthorizationRecoveryMode = 'discover'
 ): Promise<void> {
   if (err instanceof NeedsAuthorizationError) throw err;
   if (!is401Error(err)) return;
+  if (recoveryMode === 'static') {
+    throw new AuthenticationCredentialsRejectedError(agentUrl, err);
+  }
 
   // If the caller has already connected to the agent URL, they've implicitly
   // trusted it — inherit that trust for the discovery probe so loopback /
@@ -877,7 +897,10 @@ async function rethrowAsNeedsAuthorization(
   // returns null rather than throwing — anything that escapes is a genuine
   // bug we want to surface rather than mask the 401 with.
   const requirements = await discoverAuthorizationRequirements(agentUrl, { allowPrivateIp, fetchFn, signal });
-  if (requirements) {
+  if (
+    requirements &&
+    (recoveryMode === 'legacy-a2a' || hasValidatedMcpAuthorizationRequirements(requirements, agentUrl))
+  ) {
     throw new NeedsAuthorizationError(requirements);
   }
   // No requirements walked; let the caller re-throw the original error.

--- a/src/lib/protocols/mcp.ts
+++ b/src/lib/protocols/mcp.ts
@@ -17,7 +17,7 @@ import { buildAgentSigningFetch, signingContextStorage, type AgentSigningContext
 import { redactArgsForLog } from '../utils/redact-args';
 import { wrapFetchWithCapture } from './rawResponseCapture';
 import { wrapFetchWithSizeLimit } from './responseSizeLimit';
-import { wrapFetchWithTransportDiagnostics } from './transportDiagnostics';
+import { sanitizeTransportUrl, wrapFetchWithTransportDiagnostics } from './transportDiagnostics';
 import {
   isAbortOrTimeoutError,
   resolveClientRequestTimeoutMs,
@@ -1255,9 +1255,11 @@ export async function connectMCP(options: {
     });
     return { client: mcpClient, transport };
   } catch (error) {
-    // If it's an UnauthorizedError, the OAuth flow has started
-    // Rethrow so the caller can handle the callback
-    if (error instanceof UnauthorizedError) {
+    // UnauthorizedError is also used by the MCP transport when no OAuth
+    // provider exists. Only interpret it as an initiated OAuth flow when this
+    // connection actually supplied a provider; static and unauthenticated
+    // 401s belong in the structured rejection path below.
+    if (authProvider && error instanceof UnauthorizedError) {
       debugLogs.push({
         type: 'info',
         message: 'MCP: OAuth authorization required, flow initiated',
@@ -1285,13 +1287,15 @@ export async function connectMCP(options: {
             : scheme === 'bearer'
               ? "Verify the bearer token matches the agent's expected credential."
               : 'OAuth provider returned tokens that the agent rejected — check the provider configuration and token scopes.';
-      const detail = `MCP connect rejected with HTTP 401 from ${agentUrl}. SDK sent auth scheme: ${scheme}. ${hint}`;
+      const safeAgentUrl = sanitizeTransportUrl(agentUrl);
+      const detail = `MCP connect rejected with HTTP 401 from ${safeAgentUrl}. SDK sent auth scheme: ${scheme}. ${hint}`;
       const wrapped = Object.assign(new Error(detail), {
-        cause: error,
         code: 'MCP_AUTH_REJECTED',
         scheme,
-        agentUrl,
-        originalError: error,
+      });
+      Object.defineProperties(wrapped, {
+        agentUrl: { value: safeAgentUrl, enumerable: false, configurable: true },
+        cause: { value: error, enumerable: false, configurable: true },
       });
       throw wrapped;
     }

--- a/src/lib/testing/client.ts
+++ b/src/lib/testing/client.ts
@@ -594,8 +594,12 @@ export async function discoverAgentProfile(
   signal?: AbortSignal,
   /** Compliance/schema line selected by the caller. Defaults to the client pin. */
   schemaAdcpVersion?: string
-): Promise<{ profile: AgentProfile; step: TestStepResult }> {
-  const { result: agentInfo, step } = await runStep('Discover agent capabilities', 'getAgentInfo', () =>
+): Promise<{ profile: AgentProfile; step: TestStepResult; caughtError?: unknown }> {
+  const {
+    result: agentInfo,
+    step,
+    caughtError,
+  } = await runStep('Discover agent capabilities', 'getAgentInfo', () =>
     raceWithSignal(client.getAgentInfo({ signal }), signal)
   );
 
@@ -674,7 +678,7 @@ export async function discoverAgentProfile(
   }
 
   seedTestClientSigningCapability(client, profile, schemaAdcpVersion);
-  return { profile, step };
+  return { profile, step, ...(caughtError !== undefined && { caughtError }) };
 }
 
 /**

--- a/src/lib/testing/compliance/comply.ts
+++ b/src/lib/testing/compliance/comply.ts
@@ -63,7 +63,11 @@ import { withExternalSchemaRoot } from '../../validation/schema-loader';
 import { redactOAuthUrlForOutput, redactOAuthUrlsInText } from '../storyboard/oauth-metadata-graph';
 import { LIBRARY_VERSION } from '../../version';
 import { validationFailsStep } from '../storyboard/validations';
-import { isLikelyPrivateUrl } from '../../net/address-guards';
+import { createAgentTransportFetch } from '../../net/agent-transport-fetch';
+import {
+  hasValidatedMcpAuthorizationRequirements,
+  NeedsAuthorizationError,
+} from '../../auth/oauth/authorization-required';
 import { applyFunctionalRequestSigning } from '../storyboard/request-signing/functional-dispatch';
 
 /**
@@ -1239,11 +1243,11 @@ async function complyImpl(agentUrl: string, options: ComplyOptions): Promise<Com
     // legacy sellers still get a compatibility retry below.
     let discoveryOptions = effectiveOptions;
     let discoveryClient = createTestClient(agentUrl, effectiveOptions.protocol ?? 'mcp', discoveryOptions);
-    let { profile, step: profileStep } = await discoverAgentProfile(
-      discoveryClient,
-      signal,
-      complianceIndex.adcp_version
-    );
+    let {
+      profile,
+      step: profileStep,
+      caughtError: profileCaughtError,
+    } = await discoverAgentProfile(discoveryClient, signal, complianceIndex.adcp_version);
     if (
       testOptions.versionEnvelope === undefined &&
       profile.tools.includes('get_adcp_capabilities') &&
@@ -1262,6 +1266,7 @@ async function complyImpl(agentUrl: string, options: ComplyOptions): Promise<Com
         discoveryClient = legacyDiscoveryClient;
         profile = legacyDiscovery.profile;
         profileStep = legacyDiscovery.step;
+        profileCaughtError = legacyDiscovery.caughtError;
       }
     }
     effectiveOptions = applyNegotiatedComplianceVersionOptions(profile, effectiveOptions, {
@@ -1353,7 +1358,14 @@ async function complyImpl(agentUrl: string, options: ComplyOptions): Promise<Com
       const isVersionUnsupported = profileStep.error?.startsWith('VERSION_UNSUPPORTED:') === true;
       const authCheck = isVersionUnsupported
         ? { isAuth: false, observations: [] }
-        : await detectAuthRejection(agentUrl, profileStep.error, signal, effectiveOptions.transport?.trustedFetchFn);
+        : await detectAuthRejection(
+            agentUrl,
+            profileStep.error,
+            signal,
+            effectiveOptions.transport?.trustedFetchFn,
+            profileCaughtError,
+            effectiveOptions.transport?.allowPrivateIp
+          );
       if (authCheck.isAuth) {
         const degraded: AgentProfile = { name: profile.name || 'Unknown (auth required)', tools: [] };
         const candidate = explicitStoryboards?.length
@@ -1386,6 +1398,7 @@ async function complyImpl(agentUrl: string, options: ComplyOptions): Promise<Com
         start,
         effectiveOptions,
         complianceIndex.adcp_version,
+        profileCaughtError,
         signal
       );
     }
@@ -1664,14 +1677,16 @@ function buildComplyTimeoutBudgetObservation(
  * Centralized so the "run security.yaml against 401-happy agents" path and
  * the fallback "unreachable result" path share the same truth.
  *
- * Exported for direct unit tests of the keyword classifier — callers inside
+ * Exported for direct unit tests of the auth classifier — callers inside
  * the library should go through `comply()`, not this helper.
  */
 export async function detectAuthRejection(
   agentUrl: string,
   errorMsg: string | undefined,
   signal?: AbortSignal,
-  fetchFn?: typeof fetch
+  fetchFn?: typeof fetch,
+  caughtError?: unknown,
+  allowPrivateIp?: boolean
 ): Promise<{ isAuth: boolean; observations: AdvisoryObservation[] }> {
   const err = errorMsg || 'Unknown error';
   const observations: AdvisoryObservation[] = [];
@@ -1687,7 +1702,7 @@ export async function detectAuthRejection(
   // then suppress the real "Agent unreachable" classification and tell the
   // operator to re-authenticate a healthy-but-offline agent.
   const lower = err.toLowerCase();
-  const hasOAuthSignal =
+  const hasLegacyAuthSignal =
     lower.includes('oauth authorization') ||
     lower.includes('requires oauth') ||
     lower.includes('requires authorization') ||
@@ -1696,11 +1711,15 @@ export async function detectAuthRejection(
     lower.includes('needsauthorizationerror') ||
     lower.includes('www-authenticate') ||
     lower.includes('bearer realm');
+  const hasValidatedOAuthSignal =
+    caughtError instanceof NeedsAuthorizationError &&
+    hasValidatedMcpAuthorizationRequirements(caughtError.requirements, agentUrl);
   const isExplicitAuthError =
     lower.includes('401') ||
     lower.includes('unauthorized') ||
     lower.includes('authentication') ||
-    hasOAuthSignal ||
+    hasLegacyAuthSignal ||
+    hasValidatedOAuthSignal ||
     lower.includes('jws') ||
     lower.includes('jwt') ||
     lower.includes('signature verification');
@@ -1713,7 +1732,11 @@ export async function detectAuthRejection(
   if (!isAuth) {
     try {
       const probeSignal = signal ? AbortSignal.any([signal, AbortSignal.timeout(5000)]) : AbortSignal.timeout(5000);
-      const probe = await (fetchFn ?? fetch)(agentUrl, {
+      const transportFetch = createAgentTransportFetch(agentUrl, {
+        trustedFetchFn: fetchFn,
+        allowPrivateIp: allowPrivateIp ?? false,
+      });
+      const probe = await transportFetch(agentUrl, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         redirect: 'manual',
@@ -1726,19 +1749,17 @@ export async function detectAuthRejection(
   }
 
   if (isAuth) {
-    const { discoverOAuthMetadata } = await import('../../auth/oauth/discovery');
-    const oauthMeta = await discoverOAuthMetadata(agentUrl, {
-      trustedFetchFn: fetchFn,
-      allowPrivateIp: isLikelyPrivateUrl(agentUrl),
-    });
-    // Classify OAuth vs bearer based on (a) explicit OAuth phrasing in the
-    // error text, or (b) a resolvable OAuth metadata document. Either is
-    // enough; a plain 401 on a static-token endpoint matches neither.
-    const looksOAuth = oauthMeta !== null || hasOAuthSignal;
+    // Only a typed error produced from a validated MCP challenge → PRM chain
+    // is OAuth evidence. Human-readable error text and unbound authorization
+    // server metadata are agent-controlled and must not trigger an OAuth flow.
+    const oauthRequirements = hasValidatedOAuthSignal ? caughtError.requirements : undefined;
+    const looksOAuth = oauthRequirements !== undefined;
     if (looksOAuth) {
       // `oauthMeta.issuer` comes from the agent's well-known document — agent-
       // controlled, same fencing as capabilities_probe_error.
-      const issuer = oauthMeta?.issuer ? fenceAgentText(redactOAuthUrlForOutput(oauthMeta.issuer), 200) : '(unknown)';
+      const issuer = oauthRequirements?.authorizationServer
+        ? fenceAgentText(redactOAuthUrlForOutput(oauthRequirements.authorizationServer), 200)
+        : '(unknown)';
       const safeAgentUrl = redactOAuthUrlForOutput(agentUrl);
       observations.push({
         category: 'auth',
@@ -1747,7 +1768,9 @@ export async function detectAuthRejection(
           `Agent requires OAuth (issuer: ${issuer}). ` +
           `Inline: adcp storyboard run ${safeAgentUrl} --oauth (requires a saved alias). ` +
           `Save once: adcp --save-auth <alias> ${safeAgentUrl} --oauth.`,
-        ...(oauthMeta?.issuer && { evidence: { oauth_issuer: redactOAuthUrlForOutput(oauthMeta.issuer) } }),
+        ...(oauthRequirements?.authorizationServer && {
+          evidence: { oauth_issuer: redactOAuthUrlForOutput(oauthRequirements.authorizationServer) },
+        }),
         source: { kind: 'probe', code: 'auth-oauth-required' },
       });
     } else {
@@ -1919,12 +1942,20 @@ async function buildUnreachableResult(
   start: number,
   effectiveOptions: TestOptions,
   adcpVersion: string,
+  caughtError?: unknown,
   signal?: AbortSignal
 ): Promise<ComplianceResult> {
   const isVersionUnsupported = errorMsg?.startsWith('VERSION_UNSUPPORTED:') === true;
   const { isAuth, observations } = isVersionUnsupported
     ? { isAuth: false, observations: [] }
-    : await detectAuthRejection(agentUrl, errorMsg, signal, effectiveOptions.transport?.trustedFetchFn);
+    : await detectAuthRejection(
+        agentUrl,
+        errorMsg,
+        signal,
+        effectiveOptions.transport?.trustedFetchFn,
+        caughtError,
+        effectiveOptions.transport?.allowPrivateIp
+      );
   const err = redactOAuthUrlsInText(errorMsg || 'Unknown error');
   const headline = isAuth ? `Authentication required` : `Agent unreachable — ${err}`;
   return {

--- a/src/lib/testing/storyboard/oauth-metadata-graph/grader.ts
+++ b/src/lib/testing/storyboard/oauth-metadata-graph/grader.ts
@@ -1,6 +1,14 @@
 import { isAlwaysBlocked, isPrivateIp } from '../../../net/address-guards';
 import { ssrfSafeFetch, SsrfRefusedError } from '../../../net/ssrf-fetch';
 import type { HttpProbeResult } from '../types';
+export {
+  buildProtectedResourceMetadataUrl,
+  normalizeOAuthResourceForComparison,
+} from '../../../auth/oauth/resource-url';
+import {
+  buildProtectedResourceMetadataUrl,
+  normalizeOAuthResourceForComparison,
+} from '../../../auth/oauth/resource-url';
 import type {
   OAuthMetadataFetchResponse,
   OAuthMetadataFetchTransport,
@@ -72,49 +80,6 @@ interface FetchDocumentOptions {
   authorizationServerIndex?: number;
 }
 
-/**
- * Shared RFC 9728 comparison semantics used by security.yaml and oauth_setup.
- * Only scheme and host are case-folded and default ports are elided. The
- * path, query, fragment, userinfo, and trailing slash remain significant.
- */
-export function normalizeOAuthResourceForComparison(value: string): string {
-  // Do not rebuild through URL: WHATWG parsing removes dot segments and turns
-  // an empty path into `/`, but the shared storyboard rule says the remainder
-  // of the URL is byte-for-byte significant after scheme/host/default-port.
-  const match = /^([A-Za-z][A-Za-z\d+.-]*):\/\/([^/?#]*)([\s\S]*)$/.exec(value);
-  if (!match) return value;
-  const scheme = match[1]!.toLowerCase();
-  const authority = match[2]!;
-  const remainder = match[3]!;
-  const at = authority.lastIndexOf('@');
-  const userinfo = at >= 0 ? authority.slice(0, at + 1) : '';
-  const hostAndPort = at >= 0 ? authority.slice(at + 1) : authority;
-  let host: string;
-  let port = '';
-  if (hostAndPort.startsWith('[')) {
-    const bracket = hostAndPort.indexOf(']');
-    if (bracket < 0) return value;
-    host = hostAndPort.slice(0, bracket + 1).toLowerCase();
-    const suffix = hostAndPort.slice(bracket + 1);
-    if (suffix && !/^:\d+$/.test(suffix)) return value;
-    port = suffix.slice(1);
-  } else {
-    const colon = hostAndPort.lastIndexOf(':');
-    if (colon >= 0) {
-      const suffix = hostAndPort.slice(colon + 1);
-      if (!/^\d+$/.test(suffix)) return value;
-      host = hostAndPort.slice(0, colon).toLowerCase();
-      port = suffix;
-    } else {
-      host = hostAndPort.toLowerCase();
-    }
-  }
-  if (!host) return value;
-  const defaultPort = scheme === 'https' ? '443' : scheme === 'http' ? '80' : undefined;
-  const renderedPort = port && port !== defaultPort ? `:${port}` : '';
-  return `${scheme}://${userinfo}${host}${renderedPort}${remainder}`;
-}
-
 /** Redact sensitive URL components before including a URL in a report. */
 export function redactOAuthUrlForOutput(value: string): string {
   try {
@@ -134,11 +99,6 @@ export function redactOAuthUrlForOutput(value: string): string {
 /** Redact absolute URLs embedded in diagnostic text before report serialization. */
 export function redactOAuthUrlsInText(value: string): string {
   return value.replace(/https?:\/\/[^\s"'<>]+/gi, url => redactOAuthUrlForOutput(url));
-}
-
-export function buildProtectedResourceMetadataUrl(agentUrl: string): string {
-  const u = new URL(agentUrl);
-  return `${u.origin}/.well-known/oauth-protected-resource${u.pathname}`;
 }
 
 export function buildAuthorizationServerMetadataUrl(issuer: string): string {

--- a/test/lib/connect-mcp-401-context.test.js
+++ b/test/lib/connect-mcp-401-context.test.js
@@ -114,7 +114,25 @@ describe('connectMCP — 401 errors carry auth-scheme context', () => {
     await assert.rejects(
       () => connectMCP({ agentUrl: baseUrl, authToken: 'wrong' }),
       err => {
-        assert.strictEqual(err.agentUrl, baseUrl);
+        assert.strictEqual(err.agentUrl, new URL(baseUrl).toString());
+        return true;
+      }
+    );
+  });
+
+  it('keeps raw transport details out of serialized errors', async () => {
+    const sensitiveQuery = 'query-secret-do-not-leak';
+    await assert.rejects(
+      () => connectMCP({ agentUrl: `${baseUrl}/mcp?access_token=${sensitiveQuery}`, authToken: 'wrong' }),
+      err => {
+        const serialized = JSON.stringify(err);
+        assert.ok(!serialized.includes(sensitiveQuery), `URL credential leaked into serialized error: ${serialized}`);
+        assert.ok(!serialized.includes('unauthorized'), `raw 401 body leaked into serialized error: ${serialized}`);
+        assert.strictEqual(err.agentUrl, `${baseUrl}/mcp`);
+        assert.ok(err.cause, 'the original transport error remains available for in-process diagnostics');
+        assert.ok(!Object.keys(err).includes('cause'));
+        assert.ok(!Object.keys(err).includes('agentUrl'));
+        assert.ok(!Object.keys(err).includes('originalError'));
         return true;
       }
     );

--- a/test/lib/mcp-negotiation-401-legacy-fallback.test.js
+++ b/test/lib/mcp-negotiation-401-legacy-fallback.test.js
@@ -54,6 +54,7 @@ const { ADCPMultiAgentClient } = require('../../dist/lib/core/ADCPMultiAgentClie
 const { closeMCPConnections } = require('../../dist/lib/protocols/mcp.js');
 const { defaultCapabilityCache } = require('../../dist/lib/signing/client.js');
 const { InMemorySigningProvider, mintEphemeralEd25519Key } = require('../../dist/lib/signing/testing.js');
+const { comply } = require('../../dist/lib/testing/compliance/comply.js');
 
 const API_KEY = 'plain-api-key-for-v3-seller-0123456789';
 const AGENT_ID = '15';
@@ -181,6 +182,15 @@ async function startV3Seller({
       source: req.headers[SOURCE_HEADER],
     };
     requests.push(entry);
+
+    // Reproduce adcp#6903: an unmatched RFC 9728 route is swallowed by an
+    // authenticated catch-all and returns a generic Bearer 401, not metadata.
+    if (req.url === '/.well-known/oauth-protected-resource/v3/mcp') {
+      res
+        .writeHead(401, { 'Content-Type': 'application/json', 'WWW-Authenticate': 'Bearer error="invalid_token"' })
+        .end(JSON.stringify({ error: 'invalid_token', error_description: 'Authentication required' }));
+      return;
+    }
 
     // The reported seller 401s this sibling path regardless of credential.
     // `discoverMCPEndpoint` needs a 401 from somewhere to raise
@@ -348,6 +358,35 @@ for (const era of ['modern', 'legacy']) {
     assert.equal(result.success, true, String(result.error ?? 'delivery read should succeed'));
   });
 }
+
+test('comply keeps a valid saved bearer when an unmatched PRM route returns a catch-all 401 (adcp#6903)', async t => {
+  withCleanup(t);
+  const seller = await startV3Seller();
+  t.after(() => seller.stop());
+
+  const result = await comply(seller.url, {
+    allow_http: true,
+    auth: { type: 'bearer', token: API_KEY },
+    storyboards: ['security_baseline'],
+    timeout_ms: 30_000,
+  });
+
+  assert.notEqual(result.overall_status, 'auth_required');
+  assert.equal(
+    result.observations.some(observation => observation.source?.code === 'auth-oauth-required'),
+    false,
+    JSON.stringify(result.observations)
+  );
+  assert.ok(
+    seller.requests.some(request => request.path === SELLER_PATH && request.authorization === `Bearer ${API_KEY}`),
+    'capability discovery should use the saved bearer'
+  );
+  assert.equal(
+    seller.requests.some(request => request.path === '/.well-known/oauth-protected-resource/v3/mcp'),
+    false,
+    'bearer-only capabilities should not trigger an unrelated OAuth metadata probe'
+  );
+});
 
 test('v3 MCP seller: per-request header churn does not drop the credential across calls', async t => {
   withCleanup(t);

--- a/test/lib/oauth-authorization-required.test.js
+++ b/test/lib/oauth-authorization-required.test.js
@@ -11,6 +11,7 @@ const assert = require('node:assert');
 const http = require('node:http');
 
 const { NeedsAuthorizationError, discoverAuthorizationRequirements } = require('../../dist/lib/auth/oauth');
+const { hasValidatedMcpAuthorizationRequirements } = require('../../dist/lib/auth/oauth/authorization-required');
 
 const state = { handlers: {}, server: null, port: 0 };
 
@@ -147,6 +148,41 @@ describe('discoverAuthorizationRequirements', () => {
     assert.deepStrictEqual(result.scopesSupported, ['mcp.read', 'mcp.write']);
     assert.strictEqual(result.challengeScope, 'mcp.read mcp.write');
     assert.strictEqual(result.challenge.error, 'invalid_token');
+  });
+
+  test('uses the RFC 9728 well-known fallback when the challenge omits resource_metadata', async () => {
+    state.handlers = {
+      '/mcp': (req, res) => {
+        res.statusCode = 401;
+        res.setHeader('www-authenticate', 'Bearer realm="api"');
+        res.end();
+      },
+      '/.well-known/oauth-protected-resource/mcp': (req, res) =>
+        jsonRes(res, 200, { resource: agentUrl(), authorization_servers: [issuer()] }),
+      '/.well-known/oauth-authorization-server': (req, res) =>
+        jsonRes(res, 200, { authorization_endpoint: `${issuer()}/authorize`, token_endpoint: `${issuer()}/token` }),
+    };
+    const result = await discoverAuthorizationRequirements(agentUrl(), { allowPrivateIp: true });
+    assert.ok(result);
+    assert.strictEqual(result.resourceMetadataUrl, `${issuer()}/.well-known/oauth-protected-resource/mcp`);
+    assert.strictEqual(hasValidatedMcpAuthorizationRequirements(result, agentUrl()), true);
+  });
+
+  test('validates resource identity with scheme/host case and default-port normalization', () => {
+    const requirements = {
+      agentUrl: 'https://example.test/mcp',
+      resource: 'HTTPS://EXAMPLE.TEST:443/mcp',
+      authorizationServers: ['https://auth.example.test'],
+      challenge: { scheme: 'bearer', params: {} },
+    };
+    assert.strictEqual(hasValidatedMcpAuthorizationRequirements(requirements, 'https://example.test/mcp'), true);
+    assert.strictEqual(
+      hasValidatedMcpAuthorizationRequirements(
+        { ...requirements, resource: 'https://example.test/mcp/' },
+        'https://example.test/mcp'
+      ),
+      false
+    );
   });
 
   test('returns partial record when PRM is 404 (still captures challenge)', async () => {

--- a/test/lib/protocol-client-needs-auth.test.js
+++ b/test/lib/protocol-client-needs-auth.test.js
@@ -12,9 +12,23 @@ const assert = require('node:assert');
 const http = require('node:http');
 
 const { ProtocolClient } = require('../../dist/lib/protocols');
+const { AuthenticationCredentialsRejectedError, hasValidatedMcpAuthorizationRequirements } = require('../../dist/lib');
 const { NeedsAuthorizationError, bindAgentStorage, getAgentStorage } = require('../../dist/lib/auth/oauth');
 
 const state = { handlers: {}, server: null, port: 0 };
+
+test('AuthenticationCredentialsRejectedError keeps URL credentials out of JSON', () => {
+  const sensitive = 'query-secret-do-not-leak';
+  const err = new AuthenticationCredentialsRejectedError(
+    `https://user:password@example.test/mcp?access_token=${sensitive}#fragment`,
+    new Error(`reflected ${sensitive}`)
+  );
+  const serialized = JSON.stringify(err);
+  assert.doesNotMatch(serialized, /user|password|query-secret-do-not-leak|access_token|fragment/);
+  assert.strictEqual(err.agentUrl, 'https://example.test/mcp');
+  assert.ok(err.cause);
+  assert.ok(!Object.keys(err).includes('cause'));
+});
 
 before(async () => {
   state.server = http.createServer((req, res) => {
@@ -95,6 +109,81 @@ describe('ProtocolClient.callTool: auto-auth discovery', () => {
         assert.strictEqual(err.requirements.authorizationServer, issuer());
         assert.strictEqual(err.requirements.registrationEndpoint, `${issuer()}/oauth/register`);
         assert.strictEqual(err.requirements.challenge.error, 'invalid_token');
+        assert.strictEqual(hasValidatedMcpAuthorizationRequirements(err.requirements, agentUrl()), true);
+        return true;
+      }
+    );
+
+    const basicAgent = {
+      ...agent,
+      id: 'basic-agent',
+      auth_token: undefined,
+      headers: { Authorization: `Basic ${Buffer.from('user:wrong').toString('base64')}` },
+    };
+    await assert.rejects(
+      () => ProtocolClient.callTool(basicAgent, 'get_products', { brief: 'test' }),
+      err => {
+        assert.ok(!(err instanceof NeedsAuthorizationError));
+        assert.ok(err instanceof AuthenticationCredentialsRejectedError);
+        assert.match(err.message, /rejected the configured credential/i);
+        assert.doesNotMatch(err.message, /requires OAuth authorization/i);
+        return true;
+      }
+    );
+  });
+
+  test('preserves a rejected static bearer credential instead of prompting for OAuth', async () => {
+    state.handlers = {
+      '/mcp': (req, res) => {
+        res.statusCode = 401;
+        res.setHeader(
+          'www-authenticate',
+          `Bearer error="invalid_token", resource_metadata="${issuer()}/.well-known/oauth-protected-resource/mcp"`
+        );
+        res.end('rejected credential: saved-static-token');
+      },
+      '/.well-known/oauth-protected-resource/mcp': (req, res) =>
+        jsonRes(res, 200, { resource: agentUrl(), authorization_servers: [issuer()] }),
+      '/.well-known/oauth-authorization-server': (req, res) =>
+        jsonRes(res, 200, { authorization_endpoint: `${issuer()}/oauth/authorize` }),
+    };
+
+    const agent = {
+      id: 'test-agent',
+      name: 'test',
+      agent_uri: agentUrl(),
+      protocol: 'mcp',
+      auth_token: 'saved-static-token',
+    };
+
+    await assert.rejects(
+      () => ProtocolClient.callTool(agent, 'get_products', { brief: 'test' }),
+      err => {
+        assert.ok(!(err instanceof NeedsAuthorizationError));
+        assert.match(err.message, /401|authentication/i);
+        assert.doesNotMatch(err.message, /oauth/i);
+        assert.doesNotMatch(err.message, /saved-static-token/);
+        assert.doesNotMatch(JSON.stringify(err), /saved-static-token/);
+        return true;
+      }
+    );
+  });
+
+  test('does not infer OAuth from a bare Bearer challenge without valid PRM', async () => {
+    state.handlers = {
+      '/mcp': (req, res) => {
+        res.statusCode = 401;
+        res.setHeader('www-authenticate', 'Bearer error="invalid_token"');
+        res.end();
+      },
+    };
+
+    const agent = { id: 'test-agent', name: 'test', agent_uri: agentUrl(), protocol: 'mcp' };
+    await assert.rejects(
+      () => ProtocolClient.callTool(agent, 'get_products', {}),
+      err => {
+        assert.ok(!(err instanceof NeedsAuthorizationError));
+        assert.match(err.message, /401|authentication/i);
         return true;
       }
     );

--- a/test/lib/single-agent-client-needs-auth.test.js
+++ b/test/lib/single-agent-client-needs-auth.test.js
@@ -138,4 +138,64 @@ describe('SingleAgentClient pre-flight discovery: 401 → NeedsAuthorizationErro
       }
     );
   });
+
+  test('does not upgrade a rejected saved bearer token to OAuth', async () => {
+    state.handlers = {
+      '/mcp': (req, res) => {
+        res.statusCode = 401;
+        res.setHeader(
+          'www-authenticate',
+          `Bearer error="invalid_token", resource_metadata="${issuer()}/.well-known/oauth-protected-resource/mcp"`
+        );
+        res.end();
+      },
+      '/.well-known/oauth-protected-resource/mcp': (req, res) =>
+        jsonRes(res, 200, { resource: agentUrl(), authorization_servers: [issuer()] }),
+    };
+    const client = new AdCPClient([
+      {
+        id: 'test-agent',
+        name: 'test',
+        agent_uri: agentUrl(),
+        protocol: 'mcp',
+        auth_token: 'saved-static-token',
+      },
+    ]);
+
+    await assert.rejects(
+      () => client.agent('test-agent').executeTask('get_products', { brief: 'test' }),
+      err => {
+        assert.ok(!(err instanceof NeedsAuthorizationError));
+        assert.doesNotMatch(err.message, /requires OAuth authorization/i);
+        assert.doesNotMatch(err.message, /saved-static-token/);
+        return true;
+      }
+    );
+  });
+
+  test('does not upgrade mismatched protected-resource metadata to OAuth', async () => {
+    state.handlers = {
+      '/mcp': (req, res) => {
+        res.statusCode = 401;
+        res.setHeader(
+          'www-authenticate',
+          `Bearer resource_metadata="${issuer()}/.well-known/oauth-protected-resource/mcp"`
+        );
+        res.end();
+      },
+      '/.well-known/oauth-protected-resource/mcp': (req, res) =>
+        jsonRes(res, 200, { resource: `${issuer()}/different`, authorization_servers: [issuer()] }),
+    };
+    const client = new AdCPClient([{ id: 'test-agent', name: 'test', agent_uri: agentUrl(), protocol: 'mcp' }]);
+
+    await assert.rejects(
+      () => client.agent('test-agent').executeTask('get_products', { brief: 'test' }),
+      err => {
+        assert.ok(err instanceof AuthenticationRequiredError);
+        assert.ok(!(err instanceof NeedsAuthorizationError));
+        assert.doesNotMatch(err.message, /requires OAuth authorization/i);
+        return true;
+      }
+    );
+  });
 });

--- a/test/lib/storyboard-security.test.js
+++ b/test/lib/storyboard-security.test.js
@@ -26,6 +26,7 @@ const {
   CapabilityResolutionError,
 } = require('../../dist/lib/testing/storyboard/compliance');
 const { ADCPError, isADCPError } = require('../../dist/lib/errors');
+const { NeedsAuthorizationError } = require('../../dist/lib/auth/oauth');
 const { BrandJsonSchema } = require('../../dist/lib/types/wellknown-schemas.generated');
 const fs = require('fs');
 const path = require('path');
@@ -2084,7 +2085,7 @@ describe('comply() degraded-profile path (security_baseline against 401-on-disco
     }
   });
 
-  it('detectAuthRejection classifies NeedsAuthorizationError-style messages as auth', async () => {
+  it('detectAuthRejection classifies validated NeedsAuthorizationError instances as OAuth', async () => {
     // Regression: `NeedsAuthorizationError.defaultMessage()` phrases the
     // error as "Agent <url> requires OAuth authorization. ... Provide an
     // OAuthFlowHandler or run an interactive flow to complete authorization."
@@ -2100,24 +2101,45 @@ describe('comply() degraded-profile path (security_baseline against 401-on-disco
       'Agent https://example.test/mcp requires OAuth authorization. ' +
       'Authorization server: https://example.test/mcp. ' +
       'Provide an OAuthFlowHandler or run an interactive flow to complete authorization.';
-    const result = await detectAuthRejection('https://127.0.0.1:1/mcp', errMsg);
-    assert.strictEqual(result.isAuth, true, 'keyword match on "authorization"/"oauth" should classify as auth');
+    const caughtError = new NeedsAuthorizationError({
+      agentUrl: 'https://example.test/mcp',
+      resource: 'https://example.test/mcp',
+      authorizationServers: ['https://auth.example.test'],
+      authorizationServer: 'https://auth.example.test',
+      challenge: { scheme: 'bearer', params: {} },
+    });
+    const result = await detectAuthRejection('https://example.test/mcp', errMsg, undefined, undefined, caughtError);
+    assert.strictEqual(result.isAuth, true, 'typed, validated requirements should classify as auth');
     const hint = result.observations.find(o => o.category === 'auth' && /--save-auth/.test(o.message));
     assert.ok(hint, `expected a --save-auth remediation hint, got ${JSON.stringify(result.observations)}`);
     assert.match(hint.message, /--oauth/);
   });
 
-  it('detectAuthRejection emits the OAuth hint even when OAuth metadata is not discoverable', async () => {
-    // Regression for the "hint only fires when discoverOAuthMetadata returns
-    // non-null" branch. An agent that 401s before its /.well-known/* chain
-    // resolves should still get an actionable hint — the wording in the
-    // error is sufficient signal that it's an OAuth agent.
+  it('detectAuthRejection does not promote a typed but partial requirements record to OAuth', async () => {
+    const caughtError = new NeedsAuthorizationError({
+      agentUrl: 'https://example.test/mcp',
+      challenge: { scheme: 'bearer', params: {} },
+    });
+    const result = await detectAuthRejection(
+      'https://example.test/mcp',
+      caughtError.message,
+      undefined,
+      undefined,
+      caughtError
+    );
+    assert.strictEqual(result.isAuth, true);
+    assert.strictEqual(result.observations[0].source.code, 'auth-401');
+    assert.doesNotMatch(result.observations[0].message, /--oauth/);
+  });
+
+  it('detectAuthRejection does not trust OAuth wording without validated metadata', async () => {
     const errMsg = 'Unauthorized — MCP server requires OAuth2 authorization';
     const result = await detectAuthRejection('https://127.0.0.1:1/mcp', errMsg);
     assert.strictEqual(result.isAuth, true);
-    const hint = result.observations.find(o => o.category === 'auth' && /--save-auth/.test(o.message));
-    assert.ok(hint, 'hint must fire on OAuth wording even without discovery');
-    assert.match(hint.message, /issuer: \(unknown\)/i);
+    const observation = result.observations.find(o => o.category === 'auth');
+    assert.ok(observation);
+    assert.strictEqual(observation.source.code, 'auth-401');
+    assert.doesNotMatch(observation.message, /--oauth/);
   });
 
   it('detectAuthRejection does not mis-classify benign "authorization header" upstream errors as OAuth', async () => {


### PR DESCRIPTION
## Summary

- preserve rejected static bearer and header credentials as credential-rejection errors instead of promoting them to interactive OAuth
- require resource-bound RFC 9728 metadata with at least one authorization server before classifying an MCP endpoint as OAuth-required
- carry typed auth provenance into compliance reporting and keep legacy A2A behavior unchanged
- sanitize URLs and retain hostile/raw 401 causes non-enumerably so credentials and reflected response data do not enter serialized errors

## Security

This closes a phishing/integrity risk where mutable error text or an unbound Bearer challenge could trigger misleading OAuth remediation. Metadata discovery uses the hardened transport, resource identity is normalized and validated, and static credential failures do not cause additional metadata egress.

The exact production diff received protocol, code, DX, and security expert review plus a full-file Codex Security diff scan. No reportable security findings remain.

## Tests

- `npm run typecheck`
- `npm run build`
- `npm run lint`
- `npm run format:check`
- focused auth/security matrix: 161 passing
- `git diff --check`

## Scope

This hardens the SDK behavior uncovered while investigating [adcontextprotocol/adcp#6903](https://github.com/adcontextprotocol/adcp/issues/6903). The accepted saved-bearer control already succeeds on `main`; this PR therefore does not claim to explain or fix the issue's reported valid-token connection failure. That remaining failure needs an Addie-side trace/defensive handling rather than a protocol change.

No AdCP specification change is required.
