### PR TITLE
fix(decisioning): bind comply authority and shorten settlement locks

### DIFF
--- a/.changeset/quiet-controllers-bind.md
+++ b/.changeset/quiet-controllers-bind.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': minor
+---
+
+Expose framework-resolved account, agent, authentication, and task scope to comply-controller adapters, and keep webhook secret protection outside PostgreSQL settlement transactions.

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -174,7 +174,11 @@ const DEFAULT_FRAMEWORK_LOGGER: AdcpLogger = {
   error: console.error.bind(console),
 };
 import { createInMemoryStatusChangeBus, type StatusChangeBus, type PublishStatusChangeOpts } from '../status-changes';
-import { createComplyController, type ComplyControllerConfig } from '../../../testing/comply-controller';
+import {
+  _handleComplyControllerWithResolvedAuthority,
+  createComplyController,
+  type ComplyControllerConfig,
+} from '../../../testing/comply-controller';
 import type { TestControllerBridge } from '../../test-controller-bridge';
 import { mergeSeedProduct } from '../../../testing/seed-merge';
 import {
@@ -3223,11 +3227,11 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
     }
   };
 
-  const resolveComplyControllerVisible = async (
+  const resolveComplyPrincipalAuthority = async (
     extra: McpExtra,
     toolName?: string,
     input?: Readonly<Record<string, unknown>>
-  ): Promise<boolean> => {
+  ): Promise<{ agent?: BuyerAgent; principalAccount: Account | null }> => {
     const agent = await resolveComplyBuyerAgent(extra, input);
     let principalAccount: Account | null = null;
     try {
@@ -3245,7 +3249,10 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
     } catch {
       principalAccount = null;
     }
+    return { ...(agent !== undefined && { agent }), principalAccount };
+  };
 
+  const isComplyControllerVisible = (principalAccount: Account | null): boolean => {
     recordResolvedAccountMode(principalAccount);
 
     if (isSandboxOrMockAccount(principalAccount)) return true;
@@ -3263,6 +3270,15 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
     }
 
     return false;
+  };
+
+  const resolveComplyControllerVisible = async (
+    extra: McpExtra,
+    toolName?: string,
+    input?: Readonly<Record<string, unknown>>
+  ): Promise<boolean> => {
+    const { principalAccount } = await resolveComplyPrincipalAuthority(extra, toolName, input);
+    return isComplyControllerVisible(principalAccount);
   };
 
   if (hasComplianceTestingProjection) {
@@ -3319,30 +3335,16 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
       // when the adopter didn't wire explicit ones. Explicit adapters win — the
       // spread only fills the undefined slots.
       //
-      // **Namespace key: raw `account.account_id`.** The adapter does NOT call
-      // `platform.accounts.resolve` even though that would seem symmetric with
-      // the bridge's `ctx.account?.id` read — calling resolve here without
-      // `authInfo` (which `ComplyControllerContext` doesn't expose) lets a
-      // caller spoof `account.account_id: 'victim'` and have a non-validating
-      // resolver write seeds into the victim's resolved namespace. Raw id is
-      // the safe choice: a caller can only write to their own claimed id, and
-      // the sandboxGate already filters non-sandbox traffic.
-      //
-      // **Trade-off.** Adopters whose resolver maps `account_id` to a distinct
-      // internal id (e.g., `acc_1` → `tenant_a:acc_1`) will see seeded fixtures
-      // disappear — the adapter writes to `acc_1`, the bridge reads
-      // `tenant_a:acc_1`, no match. That's a documented limitation, not a
-      // security issue: silent test loss, not cross-tenant pollution. The
-      // architectural fix (widen `ComplyControllerContext` to expose the
-      // framework-resolved account so writes match reads even under mapping
-      // resolvers) is tracked at #2723. Mapping-resolver adopters wire
-      // explicit seed adapters today.
+      // Namespace writes with the same trusted account id the framework used
+      // for the sandbox gate. The raw account reference remains only as a
+      // compatibility fallback for custom transports that do not provide
+      // resolved authority to the controller.
       const explicitSeed = opts.complyTest.seed ?? {};
       const autoSeed = { ...explicitSeed };
 
       if (!explicitSeed.product) {
         autoSeed.product = async (params, ctx) => {
-          const accountId = readAutoSeedAccountId(ctx.input);
+          const accountId = ctx.account?.id ?? readAutoSeedAccountId(ctx.input);
           if (accountId == null) {
             fwLogger.warn(
               '[adcp/auto-seed] seed_product fired without `account.account_id`; dropping write. ' +
@@ -3360,7 +3362,7 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
 
       if (!explicitSeed.pricing_option) {
         autoSeed.pricing_option = async (params, ctx) => {
-          const accountId = readAutoSeedAccountId(ctx.input);
+          const accountId = ctx.account?.id ?? readAutoSeedAccountId(ctx.input);
           if (accountId == null) {
             fwLogger.warn(
               '[adcp/auto-seed] seed_pricing_option fired without `account.account_id`; dropping write. ' +
@@ -3464,7 +3466,8 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
           inputSchema: gatedInputSchema,
         },
         (async (input: Record<string, unknown>, extra: { authInfo?: ResolvedAuthInfo } | undefined) => {
-          if (!(await resolveComplyControllerVisible(extra, 'comply_test_controller', input))) {
+          const principalAuthority = await resolveComplyPrincipalAuthority(extra, 'comply_test_controller', input);
+          if (!isComplyControllerVisible(principalAuthority.principalAccount)) {
             throw new McpError(ErrorCode.MethodNotFound, 'Method not found');
           }
 
@@ -3480,8 +3483,8 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
           const accountRef = refFromTop ?? refFromContext;
 
           let resolvedAccount: Account | null = null;
+          const agent = principalAuthority.agent;
           try {
-            const agent = await resolveComplyBuyerAgent(extra, input);
             resolvedAccount = await platform.accounts.resolve(
               accountRef,
               toResolveCtx(
@@ -3575,7 +3578,62 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
             return response;
           }
 
-          return controller.handle(input);
+          const controllerParams =
+            input.params !== null && typeof input.params === 'object'
+              ? (input.params as { task_id?: unknown })
+              : undefined;
+          const controllerTaskId = controllerParams?.task_id;
+          const taskLookupParams =
+            input.scenario === 'force_task_completion' &&
+            typeof controllerTaskId === 'string' &&
+            controllerTaskId.length > 0 &&
+            controllerTaskId.length <= 255
+              ? { task_id: controllerTaskId }
+              : undefined;
+          let sessionKey: string | undefined;
+          if (opts.resolveSessionKey !== undefined && resolvedAccount !== null && taskLookupParams !== undefined) {
+            try {
+              sessionKey = await opts.resolveSessionKey({
+                // Resolve exactly the scope the framework's tasks/get path
+                // would authorize for this task-oriented controller action.
+                toolName: 'tasks_get' as AdcpServerToolName,
+                params: taskLookupParams,
+                account: resolvedAccount,
+                ...(agent !== undefined && { agent }),
+              });
+            } catch (err) {
+              fwLogger.warn?.('Session key resolution failed during comply controller dispatch', {
+                error: redactCredentialPatterns(err instanceof Error ? err.message : String(err)),
+              });
+              return adcpError('SERVICE_UNAVAILABLE', {
+                message: 'Session key resolution failed',
+                recovery: 'transient',
+              });
+            }
+          }
+
+          let taskScope: Readonly<TaskRegistryScope> | undefined;
+          if (resolvedAccount !== null) {
+            const ownerCtx: HandlerContext<Account> = {
+              store: {} as HandlerContext<Account>['store'],
+              account: resolvedAccount,
+              ...(extra?.authInfo !== undefined && { authInfo: extra.authInfo }),
+              ...(agent !== undefined && { agent }),
+              ...(sessionKey !== undefined && { sessionKey }),
+            };
+            taskScope = Object.freeze({
+              accountId: resolvedAccount.id,
+              ownerScope: taskOwnerScopeFor(ownerCtx, resolvedAccount.id),
+              ...(taskRegistry.registryId !== undefined && { registryId: taskRegistry.registryId }),
+            });
+          }
+
+          return _handleComplyControllerWithResolvedAuthority(controller, input, {
+            ...(resolvedAccount !== null && { account: resolvedAccount }),
+            ...(agent !== undefined && { agent }),
+            ...(extra?.authInfo !== undefined && { authInfo: extra.authInfo }),
+            ...(taskScope !== undefined && { taskScope }),
+          });
         }) as Parameters<typeof mcp.registerTool>[2]
       );
 
@@ -7845,13 +7903,9 @@ function buildAccountHandlers<P extends DecisioningPlatform<any, any>>(
 // when `ctx.account?.id` is absent — i.e., the framework didn't
 // pre-resolve the account on a custom dispatcher path).
 //
-// Write-side rationale: the adapter cannot reach the framework-resolved
-// `ctx.account.id` (the comply-controller's `ComplyControllerContext`
-// only exposes `{ input }`), and calling `platform.accounts.resolve`
-// here without `authInfo` would let a caller spoof `account.account_id`
-// and write into another tenant's resolved namespace. The architectural
-// fix (widen `ComplyControllerContext` to surface the resolved authority)
-// is tracked at #2723 — until then, raw id is the secure choice.
+// Framework-managed writes and reads prefer `ctx.account.id`. This extractor
+// remains only for custom controller paths that cannot supply resolved
+// authority and therefore must stay in the caller-provided namespace.
 function readAutoSeedAccountId(input: Record<string, unknown>): string | undefined {
   const account = input.account;
   if (account == null || typeof account !== 'object') return undefined;

--- a/src/lib/server/decisioning/runtime/postgres-task-settlement.ts
+++ b/src/lib/server/decisioning/runtime/postgres-task-settlement.ts
@@ -27,6 +27,7 @@ import { pgWebhookDeliveryRecoveryBackend, type PgWebhookDeliveryRecoveryOptions
 import { protocolForTool, SPEC_WEBHOOK_TASK_TYPES } from './protocol-for-tool';
 import {
   _postgresTaskRegistryBinding,
+  type PgQueryable,
   type PgTransactionClient,
   type PgTransactionalPool,
 } from './postgres-task-registry';
@@ -151,48 +152,134 @@ export function createPostgresTaskSettlementCoordinator(
       if (ref.registryId !== options.registry.registryId) {
         return { outcome: 'not_found_in_scope', delivery: 'not_applicable' };
       }
+      const deliveryKey = {
+        ...claimScope,
+        deliveryId: stableScope('task-webhook', ref),
+      };
+      const transactionalPool = pool as PgTransactionalPool;
+
+      // Read the immutable inputs needed by protection without retaining a
+      // transaction client. KMS/secret-manager adapters may be slow or hung;
+      // they must never run while a task/outbox row lock or pooled connection
+      // is held. The transaction below re-reads and validates every relevant
+      // task/outbox field before committing.
+      let observed: LockedTaskRow | undefined;
+      try {
+        observed = await readTaskRow(transactionalPool, binding.tableName, binding.namespace, ref, false);
+      } catch (cause) {
+        throwSettlementFailure(cause);
+      }
+      if (!observed) return { outcome: 'not_found_in_scope', delivery: 'not_applicable' };
+
+      validatePush(push);
+      if (observed.has_webhook !== true) {
+        throw new TaskPushSettlementConfigurationError(
+          'Crash-safe push settlement requires a task created with hasWebhook: true'
+        );
+      }
+
+      let result: unknown;
+      let error: AdcpStructuredError | undefined;
+      try {
+        result =
+          terminal.status === 'completed'
+            ? sanitizeTaskResultForWire(structuredClone(terminal.result), ref)
+            : terminal.result === undefined
+              ? { errors: [sanitizeStructuredAdcpError(terminal.error)] }
+              : sanitizeTaskResultForWire(structuredClone(terminal.result), ref);
+        error = terminal.status === 'failed' ? sanitizeStructuredAdcpError(terminal.error) : undefined;
+        // Validate the exact canonical domain used later for immutable
+        // terminal and outbox fingerprints. JSON.stringify alone would
+        // silently coerce NaN/Infinity and exotic objects.
+        canonicalJsonSha256({ result, error });
+        assertPayloadSize(result, error);
+      } catch (cause) {
+        if (cause instanceof TaskPushSettlementConfigurationError) throw cause;
+        throw new TaskPushSettlementConfigurationError('Task terminal result/error must be serializable JSON', {
+          cause,
+        });
+      }
+
+      if (TERMINAL.has(observed.status) && !terminalMatches(observed, terminal.status, result, error)) {
+        return {
+          outcome: 'already_terminal',
+          status: observed.status,
+          compatibility: 'conflicting',
+          delivery: 'not_applicable',
+        };
+      }
+      if (!SPEC_WEBHOOK_TASK_TYPES.has(observed.tool)) {
+        throw new TaskPushSettlementConfigurationError(
+          `Task type ${observed.tool} cannot be emitted by the closed AdCP task-webhook schema`
+        );
+      }
+
+      let observedOutbox: OutboxRow | undefined;
+      try {
+        observedOutbox = await readOutbox(transactionalPool, outboxTable, deliveryKey, false);
+      } catch (cause) {
+        throwSettlementFailure(cause);
+      }
+      if (TERMINAL.has(observed.status) && !observedOutbox) {
+        throw new TaskPushSettlementConfigurationError(
+          'Terminal task has no atomic webhook delivery checkpoint; refusing to create a duplicate notification'
+        );
+      }
+      const existingTimestamp =
+        observedOutbox?.state === 'pending' ? observedOutbox.snapshot.payload.timestamp : undefined;
+      const payload: Record<string, unknown> = {
+        idempotency_key: `pending.${deliveryKey.deliveryId.slice(-48)}`,
+        operation_id: resolveOperationId(push, observed.tool, ref.taskId),
+        task_id: ref.taskId,
+        task_type: observed.tool,
+        status: terminal.status,
+        timestamp: typeof existingTimestamp === 'string' ? existingTimestamp : new Date().toISOString(),
+        protocol: protocolForTool(observed.tool),
+        result,
+        ...(push.token !== undefined && { token: push.token }),
+        ...(terminal.status === 'failed' && { message: error!.message }),
+      };
+      let prepared: PreparedWebhookDeliverySnapshot;
+      try {
+        prepared = await recovery.prepare(
+          deliveryKey,
+          {
+            url: push.url,
+            payload,
+            authentication: push.authentication ?? null,
+            retries,
+          },
+          { protectPayloadToken: push.token !== undefined }
+        );
+      } catch (cause) {
+        if (cause instanceof WebhookAuthenticationProtectionError) throwSettlementFailure(cause);
+        throw new TaskPushSettlementConfigurationError('Terminal webhook delivery configuration is invalid', {
+          cause,
+        });
+      }
+      const intentFingerprint = taskPushIntentFingerprint(prepared.snapshot);
+
       let client: PgTransactionClient | undefined;
       try {
-        client = await (pool as PgTransactionalPool).connect();
+        client = await transactionalPool.connect();
         await client.query('BEGIN');
-        const locked = await client.query(
-          `SELECT tool, status, result, error, has_webhook
-             FROM ${binding.tableName}
-            WHERE task_id = $1 AND registry_namespace = $2 AND account_id = $3 AND owner_scope = $4
-            FOR UPDATE`,
-          [ref.taskId, binding.namespace, ref.accountId, ref.ownerScope]
-        );
-        if (locked.rows.length === 0) {
+        const row = await readTaskRow(client, binding.tableName, binding.namespace, ref, true);
+        if (!row) {
           await client.query('ROLLBACK');
           return { outcome: 'not_found_in_scope', delivery: 'not_applicable' };
         }
-        const row = locked.rows[0] as unknown as LockedTaskRow;
-        validatePush(push);
         if (row.has_webhook !== true) {
           throw new TaskPushSettlementConfigurationError(
             'Crash-safe push settlement requires a task created with hasWebhook: true'
           );
         }
-        let result: unknown;
-        let error: AdcpStructuredError | undefined;
-        try {
-          result =
-            terminal.status === 'completed'
-              ? sanitizeTaskResultForWire(structuredClone(terminal.result), ref)
-              : terminal.result === undefined
-                ? { errors: [sanitizeStructuredAdcpError(terminal.error)] }
-                : sanitizeTaskResultForWire(structuredClone(terminal.result), ref);
-          error = terminal.status === 'failed' ? sanitizeStructuredAdcpError(terminal.error) : undefined;
-          // Validate the exact canonical domain used later for immutable
-          // terminal and outbox fingerprints. JSON.stringify alone would
-          // silently coerce NaN/Infinity and exotic objects.
-          canonicalJsonSha256({ result, error });
-          assertPayloadSize(result, error);
-        } catch (cause) {
-          if (cause instanceof TaskPushSettlementConfigurationError) throw cause;
-          throw new TaskPushSettlementConfigurationError('Task terminal result/error must be serializable JSON', {
-            cause,
-          });
+        if (row.tool !== observed.tool) {
+          throw new TaskPushSettlementConfigurationError('Task type changed during settlement protection');
+        }
+        if (!SPEC_WEBHOOK_TASK_TYPES.has(row.tool)) {
+          throw new TaskPushSettlementConfigurationError(
+            `Task type ${row.tool} cannot be emitted by the closed AdCP task-webhook schema`
+          );
         }
         const compatible = terminalMatches(row, terminal.status, result, error);
         if (TERMINAL.has(row.status) && !compatible) {
@@ -205,11 +292,7 @@ export function createPostgresTaskSettlementCoordinator(
           };
         }
 
-        const deliveryKey = {
-          ...claimScope,
-          deliveryId: stableScope('task-webhook', ref),
-        };
-        const existing = await readOutbox(client, outboxTable, deliveryKey);
+        const existing = await readOutbox(client, outboxTable, deliveryKey, true);
         if (TERMINAL.has(row.status) && !existing) {
           throw new TaskPushSettlementConfigurationError(
             'Terminal task has no atomic webhook delivery checkpoint; refusing to create a duplicate notification'
@@ -217,44 +300,6 @@ export function createPostgresTaskSettlementCoordinator(
         }
         let inserted = false;
         let delivery = existing ? deliveryState(existing) : undefined;
-
-        if (!SPEC_WEBHOOK_TASK_TYPES.has(row.tool)) {
-          throw new TaskPushSettlementConfigurationError(
-            `Task type ${row.tool} cannot be emitted by the closed AdCP task-webhook schema`
-          );
-        }
-        const existingTimestamp = existing?.state === 'pending' ? existing.snapshot.payload.timestamp : undefined;
-        const payload: Record<string, unknown> = {
-          idempotency_key: `pending.${deliveryKey.deliveryId.slice(-48)}`,
-          operation_id: resolveOperationId(push, row.tool, ref.taskId),
-          task_id: ref.taskId,
-          task_type: row.tool,
-          status: terminal.status,
-          timestamp: typeof existingTimestamp === 'string' ? existingTimestamp : new Date().toISOString(),
-          protocol: protocolForTool(row.tool),
-          result,
-          ...(push.token !== undefined && { token: push.token }),
-          ...(terminal.status === 'failed' && { message: error!.message }),
-        };
-        let prepared: PreparedWebhookDeliverySnapshot;
-        try {
-          prepared = await recovery.prepare(
-            deliveryKey,
-            {
-              url: push.url,
-              payload,
-              authentication: push.authentication ?? null,
-              retries,
-            },
-            { protectPayloadToken: push.token !== undefined }
-          );
-        } catch (cause) {
-          if (cause instanceof WebhookAuthenticationProtectionError) throw cause;
-          throw new TaskPushSettlementConfigurationError('Terminal webhook delivery configuration is invalid', {
-            cause,
-          });
-        }
-        const intentFingerprint = taskPushIntentFingerprint(prepared.snapshot);
 
         // Settled records redact their snapshots but retain a non-secret
         // fingerprint of every immutable route/payload field except the
@@ -278,7 +323,7 @@ export function createPostgresTaskSettlementCoordinator(
           };
         }
 
-        if (existing && existing.snapshot_fingerprint !== prepared.snapshotFingerprint) {
+        if (existing && !outboxMatchesPrepared(existing, prepared, intentFingerprint)) {
           throw new TaskPushSettlementConfigurationError(
             'Terminal webhook delivery identity is already bound to a conflicting route or payload'
           );
@@ -302,8 +347,8 @@ export function createPostgresTaskSettlementCoordinator(
             ]
           );
           if ((write.rowCount ?? 0) !== 1) {
-            const raced = await readOutbox(client, outboxTable, deliveryKey);
-            if (!raced || raced.snapshot_fingerprint !== prepared.snapshotFingerprint) {
+            const raced = await readOutbox(client, outboxTable, deliveryKey, true);
+            if (!raced || !outboxMatchesPrepared(raced, prepared, intentFingerprint)) {
               throw new TaskPushSettlementConfigurationError(
                 'Terminal webhook delivery identity is already bound to a conflicting route or payload'
               );
@@ -354,8 +399,7 @@ export function createPostgresTaskSettlementCoordinator(
         };
       } catch (cause) {
         if (client) await rollbackQuietly(client);
-        if (cause instanceof TaskPushSettlementConfigurationError) throw cause;
-        throw new Error('PostgresTaskSettlementCoordinator.settle: transaction failed', { cause });
+        throwSettlementFailure(cause);
       } finally {
         client?.release();
       }
@@ -532,19 +576,50 @@ interface OutboxRow {
   disposition: string | null;
 }
 
-async function readOutbox(
-  client: PgTransactionClient,
+async function readTaskRow(
+  db: PgQueryable,
   table: string,
-  key: { publisherScope: string; tenantScope: string; deliveryId: string }
+  namespace: string,
+  ref: ScopedTaskRef,
+  lock: boolean
+): Promise<LockedTaskRow | undefined> {
+  const found = await db.query(
+    `SELECT tool, status, result, error, has_webhook
+       FROM ${table}
+      WHERE task_id = $1 AND registry_namespace = $2 AND account_id = $3 AND owner_scope = $4${lock ? '\n      FOR UPDATE' : ''}`,
+    [ref.taskId, namespace, ref.accountId, ref.ownerScope]
+  );
+  return found.rows[0] as unknown as LockedTaskRow | undefined;
+}
+
+async function readOutbox(
+  db: PgQueryable,
+  table: string,
+  key: { publisherScope: string; tenantScope: string; deliveryId: string },
+  lock: boolean
 ): Promise<OutboxRow | undefined> {
-  const found = await client.query(
+  const found = await db.query(
     `SELECT snapshot, snapshot_fingerprint, intent_fingerprint, state, disposition
        FROM ${table}
-      WHERE publisher_scope = $1 AND tenant_scope = $2 AND delivery_id = $3
-      FOR UPDATE`,
+      WHERE publisher_scope = $1 AND tenant_scope = $2 AND delivery_id = $3${lock ? '\n      FOR UPDATE' : ''}`,
     [key.publisherScope, key.tenantScope, key.deliveryId]
   );
   return found.rows[0] as unknown as OutboxRow | undefined;
+}
+
+function outboxMatchesPrepared(
+  existing: OutboxRow,
+  prepared: PreparedWebhookDeliverySnapshot,
+  intentFingerprint: string
+): boolean {
+  return existing.intent_fingerprint !== null
+    ? existing.intent_fingerprint === intentFingerprint
+    : existing.snapshot_fingerprint === prepared.snapshotFingerprint;
+}
+
+function throwSettlementFailure(cause: unknown): never {
+  if (cause instanceof TaskPushSettlementConfigurationError) throw cause;
+  throw new Error('PostgresTaskSettlementCoordinator.settle: transaction failed', { cause });
 }
 
 function deliveryState(row: OutboxRow): TaskPushDeliveryState {

--- a/src/lib/server/test-controller.ts
+++ b/src/lib/server/test-controller.ts
@@ -1094,7 +1094,7 @@ async function dispatchSeed(
 async function handleTestControllerRequestImpl(
   storeOrFactory: TestControllerStoreOrFactory,
   input: Record<string, unknown>,
-  options?: { seedCache?: SeedFixtureCache }
+  options?: { seedCache?: SeedFixtureCache; seedScopePrefix?: string }
 ): Promise<ComplyTestControllerResponse> {
   const scenario = input.scenario as string | undefined;
   if (!scenario) {
@@ -1387,11 +1387,17 @@ async function handleTestControllerRequestImpl(
         // sessions, or storyboard correlation buckets on one server can each
         // seed the same fixture id with divergent fixtures; without a scope
         // prefix the cache treats divergent replays as INVALID_PARAMS even when
-        // each scoped fixture is internally self-consistent. No resolver call here — test-controller is a
-        // generic helper that doesn't know about platform.accounts.resolve,
-        // and read-time misalignment is fine because the cache only governs
-        // idempotency, not user-visible state.
-        const scope = makeSeedCacheScope(input);
+        // each scoped fixture is internally self-consistent. This generic
+        // helper never resolves caller-provided account references itself; a
+        // framework wrapper can supply a trusted seedScopePrefix after its
+        // normal account/tenant authorization path.
+        const inputScope = makeSeedCacheScope(input);
+        const scope =
+          options?.seedScopePrefix === undefined
+            ? inputScope
+            : inputScope === undefined
+              ? options.seedScopePrefix
+              : `${options.seedScopePrefix}\u0000${inputScope}`;
         return await dispatchSeed(store, scenario as SeedScenario, params, options?.seedCache, scope);
       }
 
@@ -1516,7 +1522,7 @@ async function handleTestControllerRequestImpl(
 export async function handleTestControllerRequest(
   storeOrFactory: TestControllerStoreOrFactory,
   input: Record<string, unknown>,
-  options?: { seedCache?: SeedFixtureCache }
+  options?: { seedCache?: SeedFixtureCache; seedScopePrefix?: string }
 ): Promise<ComplyTestControllerResponse> {
   const ctx = input.context;
   const result = await handleTestControllerRequestImpl(storeOrFactory, input, options);
@@ -1632,7 +1638,7 @@ export const TOOL_INPUT_SHAPE = {
 export function registerTestController(
   server: AdcpServer | McpServer,
   storeOrFactory: TestControllerStoreOrFactory,
-  options?: { seedCache?: SeedFixtureCache }
+  options?: { seedCache?: SeedFixtureCache; seedScopePrefix?: string }
 ): void {
   const mcp = getSdkServer(server as AdcpServer) ?? (server as McpServer);
   // Per-registration cache so seed idempotency holds across all requests on
@@ -1670,6 +1676,7 @@ export function registerTestController(
     (async (input: Record<string, unknown>) => {
       const response = await handleTestControllerRequest(storeOrFactory, input, {
         seedCache,
+        ...(options?.seedScopePrefix !== undefined && { seedScopePrefix: options.seedScopePrefix }),
       });
       return toMcpResponse(response);
     }) as Parameters<typeof mcp.registerTool>[2]

--- a/src/lib/testing/comply-controller.ts
+++ b/src/lib/testing/comply-controller.ts
@@ -75,7 +75,9 @@ import type {
   CreativeStatus,
   MediaBuyStatus,
 } from '../types/core.generated';
+import type { Account, ResolvedAuthInfo } from '../server/decisioning/account';
 import type { BuyerAgent, BuyerAgentBillingMode, BuyerAgentStatus } from '../server/decisioning/buyer-agent';
+import type { TaskRegistryScope } from '../server/decisioning/runtime/task-registry';
 import type { McpToolResponse } from '../server/responses';
 
 // ────────────────────────────────────────────────────────────
@@ -87,6 +89,28 @@ import type { McpToolResponse } from '../server/responses';
 export interface ComplyControllerContext {
   /** The tool input as received over the wire, pre-validation. */
   input: Record<string, unknown>;
+  /**
+   * Framework-resolved target account. Never derived from `input.account`.
+   * This is a trusted server-side reference; adapters must not mutate it.
+   */
+  readonly account?: Readonly<Account>;
+  /** Authenticated buyer agent used while resolving the target account. */
+  readonly agent?: Readonly<BuyerAgent>;
+  /**
+   * Trusted transport authentication context supplied by the server framework.
+   * It may contain credentials or claims; do not mutate, log, or persist it wholesale.
+   */
+  readonly authInfo?: Readonly<ResolvedAuthInfo>;
+  /** Trusted account/principal scope for task-oriented controller adapters. */
+  readonly taskScope?: Readonly<TaskRegistryScope>;
+}
+
+/** @internal Trusted authority supplied only by the decisioning framework. */
+export interface ResolvedComplyControllerAuthority {
+  readonly account?: Readonly<Account>;
+  readonly agent?: Readonly<BuyerAgent>;
+  readonly authInfo?: Readonly<ResolvedAuthInfo>;
+  readonly taskScope?: Readonly<TaskRegistryScope>;
 }
 
 /** Params for `seed_product`. `fixture` mirrors the persisted product shape
@@ -694,6 +718,28 @@ function advertisedScenarios(config: ComplyControllerConfig): ControllerScenario
   return out;
 }
 
+type ResolvedContextHandler = (
+  input: Record<string, unknown>,
+  authority: ResolvedComplyControllerAuthority
+) => Promise<ComplyTestControllerResponse>;
+
+// Keep the authority-bearing entry point off the public ComplyController
+// object. Custom transports retain the existing raw-input-only API, while the
+// decisioning framework can thread the authority it already resolved without
+// making a second lookup or accepting authority from request extension fields.
+const resolvedContextHandlers = new WeakMap<ComplyController, ResolvedContextHandler>();
+
+/** @internal Decisioning-framework bridge; not exported from the package barrel. */
+export async function _handleComplyControllerWithResolvedAuthority(
+  controller: ComplyController,
+  input: Record<string, unknown>,
+  authority: ResolvedComplyControllerAuthority
+): Promise<McpToolResponse & { isError?: true }> {
+  const handler = resolvedContextHandlers.get(controller);
+  if (!handler) throw new TypeError('ComplyController was not created by createComplyController');
+  return toMcpResponse(await handler(input, authority));
+}
+
 /** Create a comply_test_controller scaffold from domain-grouped adapters. */
 export function createComplyController(config: ComplyControllerConfig): ComplyController {
   const seedCache = config.seedCache ?? createSeedFixtureCache();
@@ -702,7 +748,10 @@ export function createComplyController(config: ComplyControllerConfig): ComplyCo
   // createStore — handleTestControllerRequest inspects the `scenarios` field.
   const factoryScenarios = Object.freeze([...scenarios]) as readonly ControllerScenario[];
 
-  async function handleRaw(input: Record<string, unknown>): Promise<ComplyTestControllerResponse> {
+  async function handleRawWithResolvedAuthority(
+    input: Record<string, unknown>,
+    authority: ResolvedComplyControllerAuthority
+  ): Promise<ComplyTestControllerResponse> {
     const inputCtx = input.context;
     // Echoes input.context on FORBIDDEN early-returns (sandboxGate denial/throw)
     // that bypass handleTestControllerRequest. The delegated call at the end of
@@ -741,10 +790,33 @@ export function createComplyController(config: ComplyControllerConfig): ComplyCo
       }
     }
 
+    // Keep the pre-existing mutable `input` slot for source/runtime
+    // compatibility while making trusted authority slots non-overridable even
+    // for JavaScript adapters. The authority objects themselves are the exact
+    // framework-resolved references and must be treated as readonly.
     const ctx: ComplyControllerContext = { input };
+    for (const [key, value] of Object.entries(authority)) {
+      if (value === undefined) continue;
+      Object.defineProperty(ctx, key, {
+        value,
+        enumerable: true,
+        writable: false,
+        configurable: false,
+      });
+    }
     const store = buildStore(config, ctx);
 
-    return handleTestControllerRequest({ scenarios: factoryScenarios, createStore: () => store }, input, { seedCache });
+    const resolvedAccountId = authority.account?.id;
+    return handleTestControllerRequest({ scenarios: factoryScenarios, createStore: () => store }, input, {
+      seedCache,
+      ...(resolvedAccountId !== undefined && {
+        seedScopePrefix: `resolved_account:${resolvedAccountId.length}:${resolvedAccountId}`,
+      }),
+    });
+  }
+
+  async function handleRaw(input: Record<string, unknown>): Promise<ComplyTestControllerResponse> {
+    return handleRawWithResolvedAuthority(input, {});
   }
 
   async function handle(input: Record<string, unknown>) {
@@ -789,5 +861,7 @@ export function createComplyController(config: ComplyControllerConfig): ComplyCo
     );
   }
 
-  return { toolDefinition, handleRaw, handle, register };
+  const controller = { toolDefinition, handleRaw, handle, register };
+  resolvedContextHandlers.set(controller, handleRawWithResolvedAuthority);
+  return controller;
 }

--- a/test/server-decisioning-comply-auto-seed.test.js
+++ b/test/server-decisioning-comply-auto-seed.test.js
@@ -68,18 +68,24 @@ const BASE_OPTS = {
   validation: { requests: 'off', responses: 'off' },
 };
 
-async function callComply(server, args) {
-  return server.dispatchTestRequest({
-    method: 'tools/call',
-    params: { name: 'comply_test_controller', arguments: args },
-  });
+async function callComply(server, args, extras) {
+  return server.dispatchTestRequest(
+    {
+      method: 'tools/call',
+      params: { name: 'comply_test_controller', arguments: args },
+    },
+    extras
+  );
 }
 
-async function callGetProducts(server, args) {
-  return server.dispatchTestRequest({
-    method: 'tools/call',
-    params: { name: 'get_products', arguments: args },
-  });
+async function callGetProducts(server, args, extras) {
+  return server.dispatchTestRequest(
+    {
+      method: 'tools/call',
+      params: { name: 'get_products', arguments: args },
+    },
+    extras
+  );
 }
 
 describe('createAdcpServerFromPlatform — catalog-backed auto-seed (issue #1091)', () => {
@@ -333,37 +339,23 @@ describe('createAdcpServerFromPlatform — catalog-backed auto-seed (issue #1091
     );
   });
 
-  it('security: caller spoofing account.account_id only writes to its own claimed namespace (no resolver call)', async () => {
-    // Pin: the auto-seed adapter MUST NOT call platform.accounts.resolve
-    // with attacker-supplied account_id and no authInfo. If it did, a
-    // caller could spoof account.account_id: 'victim' and a non-validating
-    // resolver would map it to the victim's resolved namespace.
-    //
-    // This test pins the contract: even when the resolver maps
-    // 'attacker' → 'tenant_victim' (simulating a misconfigured resolver
-    // that returns based on raw id alone), the adapter writes ONLY under
-    // the raw 'attacker' namespace. The victim's bridge (reading
-    // ctx.account.id = 'tenant_victim_real') never sees the attacker's
-    // fixtures.
+  it('security: resolved account namespace does not leak fixtures to a different resolved tenant', async () => {
+    // The framework resolves the target with the authenticated request
+    // context before the adapter runs. The adapter and catalog bridge both
+    // use that resolved internal id; a different resolved tenant must not see
+    // the fixture even when the public references look related.
     const platform = basePlatform();
-    platform.accounts.resolve = async ref => {
-      // Deliberately bad resolver: maps any account_id to a "victim"
-      // namespace (simulating a resolver that doesn't validate authInfo).
-      if (ref?.account_id === 'tenant_victim') {
-        return {
-          id: 'tenant_victim_real',
-          operator: 'test.example.com',
-          ctx_metadata: {},
-          authInfo: { kind: 'api_key' },
-          ...(ref?.sandbox === true && { sandbox: true }),
-        };
-      }
+    platform.accounts.resolve = async (ref, ctx) => {
+      const principal = ctx.authInfo?.clientId;
+      if (principal !== 'attacker' && principal !== 'victim') return null;
       return {
-        id: ref?.account_id ?? 'unknown',
+        // The same public alias is authorization-aware and resolves into a
+        // different internal tenant namespace for each authenticated caller.
+        id: `${principal}:${ref?.account_id ?? 'principal'}`,
         operator: 'test.example.com',
         ctx_metadata: {},
         authInfo: { kind: 'api_key' },
-        ...(ref?.sandbox === true && { sandbox: true }),
+        sandbox: true,
       };
     };
 
@@ -372,42 +364,61 @@ describe('createAdcpServerFromPlatform — catalog-backed auto-seed (issue #1091
       complyTest: { sandboxGate: SANDBOX_GATE },
     });
 
-    // Attacker spoofs account_id: 'tenant_victim' on a seed.
-    await callComply(server, {
-      scenario: 'seed_product',
-      account: { account_id: 'tenant_victim', sandbox: true },
-      params: {
-        product_id: 'attacker_product',
-        fixture: { delivery_type: 'guaranteed' },
+    // Both principals use the same caller-visible alias. Authority-aware
+    // resolution must keep their auto-seed namespaces distinct.
+    await callComply(
+      server,
+      {
+        scenario: 'seed_product',
+        account: { account_id: 'shared-alias', sandbox: true },
+        params: {
+          product_id: 'shared_product',
+          fixture: { delivery_type: 'guaranteed' },
+        },
       },
-    });
-
-    // Victim's get_products (resolves to tenant_victim_real) must NOT see
-    // the attacker's fixture.
-    const victimResult = await callGetProducts(server, {
-      account: { account_id: 'tenant_victim_alias', sandbox: true },
-    });
-    const victimProducts = victimResult.structuredContent.products ?? [];
-    assert.ok(
-      !victimProducts.some(p => p.product_id === 'attacker_product'),
-      "victim's get_products MUST NOT see attacker's spoofed fixture (cross-tenant write vector)"
+      { authInfo: { clientId: 'attacker' } }
     );
+
+    const victimSeed = await callComply(
+      server,
+      {
+        scenario: 'seed_product',
+        account: { account_id: 'shared-alias', sandbox: true },
+        params: {
+          product_id: 'shared_product',
+          fixture: { delivery_type: 'non_guaranteed' },
+        },
+      },
+      { authInfo: { clientId: 'victim' } }
+    );
+    assert.notStrictEqual(victimSeed.isError, true, JSON.stringify(victimSeed.structuredContent));
+
+    // The victim resolves the same alias under different trusted authority.
+    const victimResult = await callGetProducts(
+      server,
+      {
+        account: { account_id: 'shared-alias', sandbox: true },
+      },
+      { authInfo: { clientId: 'victim' } }
+    );
+    const victimProducts = victimResult.structuredContent.products ?? [];
+    const victimProduct = victimProducts.find(p => p.product_id === 'shared_product');
+    assert.strictEqual(victimProduct?.delivery_type, 'non_guaranteed');
+
+    const attackerResult = await callGetProducts(
+      server,
+      {
+        account: { account_id: 'shared-alias', sandbox: true },
+      },
+      { authInfo: { clientId: 'attacker' } }
+    );
+    const attackerProduct = (attackerResult.structuredContent.products ?? []).find(
+      p => p.product_id === 'shared_product'
+    );
+    assert.strictEqual(attackerProduct?.delivery_type, 'guaranteed');
   });
 
-  it('mapping resolver: adapter writes under raw account_id (security-correct asymmetry, issue #1216)', async () => {
-    // Adopters whose resolver maps `account_id` to a distinct internal `id`
-    // (e.g., `acc_42` → `mapped:acc_42`) hit a documented limitation: the
-    // adapter writes under the RAW account_id, but the bridge reads under
-    // the framework-resolved id. Asymmetric — fixtures don't appear in
-    // get_products. That's the security-correct trade-off:
-    //
-    // The alternative — having the adapter call platform.accounts.resolve
-    // — would let a caller spoof account.account_id and have a non-validating
-    // resolver write seeds into another tenant's namespace (the adapter has
-    // no authInfo to pass to resolve). Architectural fix tracked at #1216:
-    // widen ComplyControllerContext so the adapter sees the framework-resolved
-    // account. Until then, mapping-resolver adopters wire explicit seed
-    // adapters or use identity resolvers.
+  it('mapping resolver: adapter and bridge use the same resolved account namespace (issue #2723)', async () => {
     const platform = basePlatform();
     platform.accounts.resolve = async ref => ({
       id: ref?.account_id ? `mapped:${ref.account_id}` : 'mapped:unknown',
@@ -435,11 +446,10 @@ describe('createAdcpServerFromPlatform — catalog-backed auto-seed (issue #1091
       account: { account_id: 'acc_42', sandbox: true },
     });
 
-    // Adapter wrote to namespace 'acc_42'; bridge reads from resolved id
-    // 'mapped:acc_42' — no match. Documented limitation.
     const products = result.structuredContent.products ?? [];
     const seeded = products.find(p => p.product_id === 'mapped_product');
-    assert.equal(seeded, undefined, 'mapping-resolver fixtures do NOT appear in get_products (documented limitation)');
+    assert.ok(seeded, 'mapping-resolver fixtures should appear in the resolved account namespace');
+    assert.equal(seeded.product_id, 'mapped_product');
   });
 
   it('warn-on-drop: seed_product with no account.account_id logs and drops, no fixture leaks (issue #1216)', async () => {
@@ -450,6 +460,8 @@ describe('createAdcpServerFromPlatform — catalog-backed auto-seed (issue #1091
     // emit a warn-level log so the misconfiguration is diagnosable.
     const warnings = [];
     const platform = basePlatform();
+    const normalResolve = platform.accounts.resolve;
+    platform.accounts.resolve = async () => null;
     const server = createAdcpServerFromPlatform(platform, {
       ...BASE_OPTS,
       logger: {
@@ -484,6 +496,7 @@ describe('createAdcpServerFromPlatform — catalog-backed auto-seed (issue #1091
 
     // Confirm no fixture leaked into a shared namespace: a sandbox account's
     // get_products must NOT see the orphan.
+    platform.accounts.resolve = normalResolve;
     const gpResult = await callGetProducts(server, {
       account: { account_id: 'any_acc', sandbox: true },
     });

--- a/test/server-decisioning-comply-gate.test.js
+++ b/test/server-decisioning-comply-gate.test.js
@@ -52,7 +52,8 @@ function buildServer(resolveAccount, overrides = {}) {
     name: 'gate-host',
     version: '0.0.1',
     validation: { requests: 'off', responses: 'off' },
-    complyTest: {
+    ...(overrides.resolveSessionKey !== undefined && { resolveSessionKey: overrides.resolveSessionKey }),
+    complyTest: overrides.complyTest ?? {
       force: {
         creative_status: async params => ({
           success: true,
@@ -125,6 +126,18 @@ function assertPermissionDenied(result) {
 }
 
 async function callMcpToolsCallHandler(server, args = {}, extra = {}) {
+  return callMcpControllerHandler(
+    server,
+    {
+      scenario: 'force_creative_status',
+      params: { creative_id: 'cr_1', status: 'approved' },
+      ...args,
+    },
+    extra
+  );
+}
+
+async function callMcpControllerHandler(server, input, extra = {}) {
   const sdk = getSdkServer(server);
   const handler = sdk?.server?._requestHandlers?.get('tools/call');
   if (!handler) throw new Error('tools/call request handler not found');
@@ -133,11 +146,7 @@ async function callMcpToolsCallHandler(server, args = {}, extra = {}) {
       method: 'tools/call',
       params: {
         name: 'comply_test_controller',
-        arguments: {
-          scenario: 'force_creative_status',
-          params: { creative_id: 'cr_1', status: 'approved' },
-          ...args,
-        },
+        arguments: input,
       },
     },
     { signal: new AbortController().signal, ...extra }
@@ -403,6 +412,210 @@ describe('createAdcpServerFromPlatform — sandbox-authority gate (resolver path
     assert.ok(seenCredentials.every(call => call.credential?.key_id === 'sandbox-key'));
     assert.ok(seenCredentials.every(call => call.extra?.tenant === 'tenant_1'));
     assert.ok(seenCredentials.some(call => call.input?.scenario === 'force_creative_status'));
+  });
+
+  it('passes the exact resolved target account and transport authority to adapters', async () => {
+    const authInfo = {
+      clientId: 'buyer-client',
+      credential: { kind: 'api_key', key_id: 'sandbox-key' },
+      extra: { tenant: 'tenant-a' },
+    };
+    const targetAccount = {
+      id: 'internal:tenant-a:account-1',
+      mode: 'sandbox',
+      ctx_metadata: { upstream_account: 'account-1' },
+    };
+    let captured;
+    const server = buildServer(
+      async ref =>
+        ref?.account_id === 'public-account-1'
+          ? targetAccount
+          : { id: 'principal-account', mode: 'sandbox', ctx_metadata: {} },
+      {
+        complyTest: {
+          force: {
+            creative_status: async (params, ctx) => {
+              captured = ctx;
+              return {
+                success: true,
+                transition: 'forced',
+                resource_type: 'creative',
+                resource_id: params.creative_id,
+                previous_state: 'pending_review',
+                current_state: params.status,
+              };
+            },
+          },
+        },
+      }
+    );
+
+    const result = await callMcpToolsCallHandler(
+      server,
+      {
+        account: { account_id: 'public-account-1' },
+        ext: { account: { id: 'attacker-controlled' }, authInfo: { clientId: 'attacker' } },
+      },
+      { authInfo }
+    );
+
+    assert.notStrictEqual(result.isError, true);
+    assert.strictEqual(captured.account, targetAccount);
+    assert.strictEqual(captured.authInfo, authInfo);
+    assert.strictEqual(captured.agent, undefined);
+    assert.strictEqual(captured.taskScope.accountId, targetAccount.id);
+    assert.strictEqual(captured.taskScope.ownerScope, 'api_key:sandbox-key');
+    assert.strictEqual(Object.getOwnPropertyDescriptor(captured, 'account').writable, false);
+    assert.strictEqual(Object.getOwnPropertyDescriptor(captured, 'authInfo').writable, false);
+    captured.input = { retained: 'legacy mutable context behavior' };
+    assert.deepStrictEqual(captured.input, { retained: 'legacy mutable context behavior' });
+  });
+
+  it('uses an auth-derived account when the request omits an explicit account', async () => {
+    const authDerived = { id: 'auth-derived-account', mode: 'sandbox', ctx_metadata: {} };
+    let captured;
+    const server = buildServer(async () => authDerived, {
+      complyTest: {
+        force: {
+          creative_status: async (params, ctx) => {
+            captured = ctx;
+            return {
+              success: true,
+              transition: 'forced',
+              resource_type: 'creative',
+              resource_id: params.creative_id,
+              previous_state: 'pending_review',
+              current_state: params.status,
+            };
+          },
+        },
+      },
+    });
+
+    const result = await callMcpToolsCallHandler(server);
+
+    assert.notStrictEqual(result.isError, true);
+    assert.strictEqual(captured.account, authDerived);
+    assert.strictEqual(captured.taskScope.accountId, authDerived.id);
+    assert.strictEqual(captured.taskScope.ownerScope, `account:${authDerived.id}`);
+  });
+
+  it('issues agent-scoped task authority for task-oriented adapters', async () => {
+    const registryAgent = {
+      agent_url: 'https://buyer.example/agent',
+      display_name: 'Buyer',
+      status: 'active',
+      billing_capabilities: new Set(['operator']),
+    };
+    let captured;
+    const server = buildServer(
+      async ref => ({ id: ref?.account_id ?? 'principal-account', mode: 'sandbox', ctx_metadata: {} }),
+      {
+        agentRegistry: { resolve: async () => registryAgent },
+        complyTest: {
+          force: {
+            task_completion: async (params, ctx) => {
+              captured = ctx;
+              return {
+                success: true,
+                transition: 'forced',
+                resource_type: 'task',
+                resource_id: params.task_id,
+                previous_state: 'working',
+                current_state: 'completed',
+              };
+            },
+          },
+        },
+      }
+    );
+
+    const result = await callMcpControllerHandler(server, {
+      scenario: 'force_task_completion',
+      account: { account_id: 'account-1' },
+      params: { task_id: 'task-42', result: { ok: true } },
+    });
+
+    assert.notStrictEqual(result.isError, true, JSON.stringify(result.structuredContent));
+    assert.strictEqual(captured.agent, registryAgent);
+    assert.deepStrictEqual(captured.taskScope, {
+      accountId: 'account-1',
+      ownerScope: `agent:${registryAgent.agent_url}`,
+      ...(captured.taskScope.registryId !== undefined && { registryId: captured.taskScope.registryId }),
+    });
+    assert.ok(Object.isFrozen(captured.taskScope));
+  });
+
+  it('prefers trusted session scope for task-oriented adapters', async () => {
+    let captured;
+    const server = buildServer(
+      async ref => ({ id: ref?.account_id ?? 'principal-account', mode: 'sandbox', ctx_metadata: {} }),
+      {
+        resolveSessionKey: async ({ toolName, params, account }) => {
+          assert.strictEqual(toolName, 'tasks_get');
+          assert.deepStrictEqual(params, { task_id: 'task-session' });
+          return `approval:${account.id}`;
+        },
+        complyTest: {
+          force: {
+            task_completion: async (params, ctx) => {
+              captured = ctx;
+              return {
+                success: true,
+                transition: 'forced',
+                resource_type: 'task',
+                resource_id: params.task_id,
+                previous_state: 'working',
+                current_state: 'completed',
+              };
+            },
+          },
+        },
+      }
+    );
+
+    const result = await callMcpControllerHandler(
+      server,
+      {
+        scenario: 'force_task_completion',
+        account: { account_id: 'account-1' },
+        params: { task_id: 'task-session', result: { ok: true } },
+      },
+      { authInfo: { credential: { kind: 'api_key', key_id: 'key-that-must-not-win' } } }
+    );
+
+    assert.notStrictEqual(result.isError, true);
+    assert.strictEqual(captured.taskScope.ownerScope, 'session:approval:account-1');
+  });
+
+  it('leaves account and task authority absent when the sandbox deployment has no resolved account', async () => {
+    process.env.ADCP_SANDBOX = '1';
+    let captured;
+    const authInfo = { clientId: 'sandbox-client' };
+    const server = buildServer(async () => null, {
+      complyTest: {
+        force: {
+          creative_status: async (params, ctx) => {
+            captured = ctx;
+            return {
+              success: true,
+              transition: 'forced',
+              resource_type: 'creative',
+              resource_id: params.creative_id,
+              previous_state: 'pending_review',
+              current_state: params.status,
+            };
+          },
+        },
+      },
+    });
+
+    const result = await callMcpToolsCallHandler(server, {}, { authInfo });
+
+    assert.notStrictEqual(result.isError, true);
+    assert.strictEqual(captured.account, undefined);
+    assert.strictEqual(captured.taskScope, undefined);
+    assert.strictEqual(captured.authInfo, authInfo);
   });
 });
 

--- a/test/server-decisioning-postgres-task-registry.test.js
+++ b/test/server-decisioning-postgres-task-registry.test.js
@@ -99,7 +99,13 @@ describe('decisioning task registry schema management', () => {
     } = require('../dist/lib/server/decisioning');
     const databaseError = new Error('private database host unavailable');
     const pool = {
-      async query() {
+      async query(sql) {
+        if (sql.includes('SELECT tool, status, result, error, has_webhook')) {
+          return {
+            rows: [{ tool: 'create_media_buy', status: 'submitted', result: null, error: null, has_webhook: true }],
+            rowCount: 1,
+          };
+        }
         return { rows: [], rowCount: 0 };
       },
       async connect() {
@@ -127,6 +133,203 @@ describe('decisioning task registry schema management', () => {
         error.message === 'PostgresTaskSettlementCoordinator.settle: transaction failed' &&
         error.cause === databaseError
     );
+  });
+
+  test('push settlement finishes secret protection before acquiring a transaction client', async () => {
+    const {
+      createPostgresTaskRegistry,
+      createPostgresTaskSettlementCoordinator,
+    } = require('../dist/lib/server/decisioning');
+    const databaseError = new Error('stop after the protection-order assertion');
+    let connectCalls = 0;
+    let releaseProtection;
+    const protectionReleased = new Promise(resolve => {
+      releaseProtection = resolve;
+    });
+    let markProtectionStarted;
+    const protectionStarted = new Promise(resolve => {
+      markProtectionStarted = resolve;
+    });
+    const pool = {
+      async query(sql) {
+        if (sql.includes('SELECT tool, status, result, error, has_webhook')) {
+          return {
+            rows: [{ tool: 'create_media_buy', status: 'submitted', result: null, error: null, has_webhook: true }],
+            rowCount: 1,
+          };
+        }
+        return { rows: [], rowCount: 0 };
+      },
+      async connect() {
+        connectCalls++;
+        throw databaseError;
+      },
+    };
+    const registry = createPostgresTaskRegistry({ namespace: NAMESPACE, storageId: 'protect-before-connect', pool });
+    const coordinator = createPostgresTaskSettlementCoordinator({
+      registry,
+      publisherScope: 'test-seller',
+      outbox: { tableName: SETTLEMENT_OUTBOX },
+      authenticationAdapter: {
+        async protect(authentication) {
+          markProtectionStarted();
+          await protectionReleased;
+          return {
+            protectedValue: { ciphertext: 'opaque-test-value' },
+            fingerprint: require('node:crypto').createHash('sha256').update(authentication.token).digest('hex'),
+          };
+        },
+        resolve() {
+          return { type: 'bearer', token: 'buyer-validation-secret' };
+        },
+      },
+    });
+    const settlement = coordinator.settle(
+      {
+        taskId: 'task_protection_order',
+        accountId: 'acc_1',
+        ownerScope: 'account:acc_1',
+        registryId: registry.registryId,
+      },
+      { status: 'completed', result: { ok: true } },
+      {
+        url: 'https://buyer.example/webhooks/task',
+        operationId: 'protection-order-operation',
+        token: 'buyer-validation-secret',
+      }
+    );
+
+    await protectionStarted;
+    assert.strictEqual(connectCalls, 0, 'KMS work must finish before the transaction client is acquired');
+    releaseProtection();
+    await assert.rejects(
+      settlement,
+      error =>
+        error.message === 'PostgresTaskSettlementCoordinator.settle: transaction failed' &&
+        error.cause === databaseError
+    );
+    assert.strictEqual(connectCalls, 1);
+  });
+
+  test('out-of-scope settlement refs return not_found before validation or secret protection', async () => {
+    const {
+      createPostgresTaskRegistry,
+      createPostgresTaskSettlementCoordinator,
+    } = require('../dist/lib/server/decisioning');
+    let protectionCalls = 0;
+    let connectCalls = 0;
+    const pool = {
+      async query() {
+        return { rows: [], rowCount: 0 };
+      },
+      async connect() {
+        connectCalls++;
+        throw new Error('must not acquire a transaction for a scoped miss');
+      },
+    };
+    const registry = createPostgresTaskRegistry({ namespace: NAMESPACE, storageId: 'scoped-miss', pool });
+    const coordinator = createPostgresTaskSettlementCoordinator({
+      registry,
+      publisherScope: 'test-seller',
+      outbox: { tableName: SETTLEMENT_OUTBOX },
+      authenticationAdapter: {
+        protect() {
+          protectionCalls++;
+          throw new Error('must not protect a scoped miss');
+        },
+        resolve() {
+          return { type: 'bearer', token: 'unused-validation-secret' };
+        },
+      },
+    });
+
+    assert.deepStrictEqual(
+      await coordinator.settle(
+        {
+          taskId: 'missing_task',
+          accountId: 'wrong_account',
+          ownerScope: 'account:wrong_account',
+          registryId: registry.registryId,
+        },
+        { status: 'completed', result: { not_json: Number.POSITIVE_INFINITY } },
+        { url: 'not-a-url', token: 'short' }
+      ),
+      { outcome: 'not_found_in_scope', delivery: 'not_applicable' }
+    );
+    assert.strictEqual(protectionCalls, 0);
+    assert.strictEqual(connectCalls, 0);
+  });
+
+  test('an observed conflicting terminal task returns before secret protection', async () => {
+    const {
+      createPostgresTaskRegistry,
+      createPostgresTaskSettlementCoordinator,
+    } = require('../dist/lib/server/decisioning');
+    let protectionCalls = 0;
+    let connectCalls = 0;
+    const pool = {
+      async query(sql) {
+        if (sql.includes('SELECT tool, status, result, error, has_webhook')) {
+          return {
+            rows: [
+              {
+                tool: 'create_media_buy',
+                status: 'completed',
+                result: { media_buy_id: 'winner' },
+                error: null,
+                has_webhook: true,
+              },
+            ],
+            rowCount: 1,
+          };
+        }
+        throw new Error(`unexpected query: ${sql}`);
+      },
+      async connect() {
+        connectCalls++;
+        throw new Error('must not acquire a transaction for a known conflict');
+      },
+    };
+    const registry = createPostgresTaskRegistry({ namespace: NAMESPACE, storageId: 'known-terminal-conflict', pool });
+    const coordinator = createPostgresTaskSettlementCoordinator({
+      registry,
+      publisherScope: 'test-seller',
+      outbox: { tableName: SETTLEMENT_OUTBOX },
+      authenticationAdapter: {
+        protect() {
+          protectionCalls++;
+          throw new Error('must not protect a known conflict');
+        },
+        resolve() {
+          return { type: 'bearer', token: 'buyer-validation-secret' };
+        },
+      },
+    });
+
+    assert.deepStrictEqual(
+      await coordinator.settle(
+        {
+          taskId: 'terminal_task',
+          accountId: 'acc_1',
+          ownerScope: 'account:acc_1',
+          registryId: registry.registryId,
+        },
+        { status: 'completed', result: { media_buy_id: 'loser' } },
+        {
+          url: 'https://buyer.example/webhooks/task',
+          operationId: 'known-terminal-conflict',
+          token: 'buyer-validation-secret',
+        }
+      ),
+      {
+        outcome: 'already_terminal',
+        status: 'completed',
+        compatibility: 'conflicting',
+        delivery: 'not_applicable',
+      }
+    );
+    assert.strictEqual(protectionCalls, 0);
+    assert.strictEqual(connectCalls, 0);
   });
 
   test('bootstrap DDL creates the scoped schema without legacy upgrade writes', () => {
@@ -991,6 +1194,246 @@ describe('createPostgresTaskRegistry', { skip: !DATABASE_URL && 'DATABASE_URL no
     const outbox = await pool.query(`SELECT snapshot FROM ${SETTLEMENT_OUTBOX}`);
     assert.strictEqual(outbox.rowCount, 1);
     assert.deepStrictEqual(outbox.rows[0].snapshot.payload.result, task.result);
+  });
+
+  test('paused authentication protection holds neither a transaction connection nor the task row lock', async () => {
+    const {
+      completeScopedPushTask,
+      createPostgresTaskSettlementCoordinator,
+    } = require('../dist/lib/server/decisioning');
+    let connectCalls = 0;
+    let activeConnections = 0;
+    const trackingPool = {
+      query: (sql, values) => pool.query(sql, values),
+      async connect() {
+        connectCalls++;
+        activeConnections++;
+        const client = await pool.connect();
+        return {
+          query: (sql, values) => client.query(sql, values),
+          release() {
+            activeConnections--;
+            client.release();
+          },
+        };
+      },
+    };
+    const registry = createPostgresTaskRegistry({
+      pool: trackingPool,
+      namespace: NAMESPACE,
+      storageId: 'store:paused-protection',
+    });
+    let releaseProtection;
+    const protectionReleased = new Promise(resolve => {
+      releaseProtection = resolve;
+    });
+    let markProtectionStarted;
+    const protectionStarted = new Promise(resolve => {
+      markProtectionStarted = resolve;
+    });
+    const coordinator = createPostgresTaskSettlementCoordinator({
+      registry,
+      publisherScope: 'test-seller',
+      outbox: { tableName: SETTLEMENT_OUTBOX },
+      authenticationAdapter: {
+        async protect(authentication) {
+          markProtectionStarted();
+          await protectionReleased;
+          return {
+            protectedValue: { ciphertext: 'opaque-paused-protection' },
+            fingerprint: require('node:crypto').createHash('sha256').update(authentication.token).digest('hex'),
+          };
+        },
+        resolve() {
+          return { type: 'bearer', token: 'buyer-validation-secret' };
+        },
+      },
+    });
+    const ref = await registry.create({ tool: 'create_media_buy', accountId: 'acc_1', hasWebhook: true });
+    const settlement = completeScopedPushTask(
+      coordinator,
+      ref,
+      {
+        url: 'https://buyer.example/webhooks/task',
+        operationId: 'paused-protection-operation',
+        token: 'buyer-validation-secret',
+      },
+      { media_buy_id: 'paused-protection-buy' }
+    );
+
+    await protectionStarted;
+    assert.strictEqual(connectCalls, 0, 'settlement must not acquire a transaction client before protection finishes');
+    assert.strictEqual(activeConnections, 0);
+
+    const probe = await pool.connect();
+    try {
+      await probe.query('BEGIN');
+      await probe.query(
+        `SELECT task_id FROM ${TABLE}
+          WHERE task_id = $1 AND registry_namespace = $2 AND account_id = $3 AND owner_scope = $4
+          FOR UPDATE NOWAIT`,
+        [ref.taskId, NAMESPACE, ref.accountId, ref.ownerScope]
+      );
+      await probe.query('ROLLBACK');
+    } finally {
+      probe.release();
+    }
+
+    releaseProtection();
+    assert.deepStrictEqual(await settlement, { outcome: 'applied', delivery: 'durably_bound' });
+    assert.strictEqual(connectCalls, 1);
+    assert.strictEqual(activeConnections, 0);
+  });
+
+  test('task transitions that race paused protection are revalidated under the settlement lock', async () => {
+    const {
+      completeScopedPushTask,
+      createPostgresTaskSettlementCoordinator,
+    } = require('../dist/lib/server/decisioning');
+    const registry = createPostgresTaskRegistry({
+      pool,
+      namespace: NAMESPACE,
+      storageId: 'store:task-transition-during-protection',
+    });
+    let releaseProtection;
+    const protectionReleased = new Promise(resolve => {
+      releaseProtection = resolve;
+    });
+    let markProtectionStarted;
+    const protectionStarted = new Promise(resolve => {
+      markProtectionStarted = resolve;
+    });
+    const pausedCoordinator = createPostgresTaskSettlementCoordinator({
+      registry,
+      publisherScope: 'test-seller',
+      outbox: { tableName: SETTLEMENT_OUTBOX },
+      authenticationAdapter: {
+        async protect(authentication) {
+          markProtectionStarted();
+          await protectionReleased;
+          return {
+            protectedValue: { ciphertext: 'opaque-task-race-secret' },
+            fingerprint: require('node:crypto').createHash('sha256').update(authentication.token).digest('hex'),
+          };
+        },
+        resolve() {
+          return { type: 'bearer', token: 'buyer-validation-secret' };
+        },
+      },
+    });
+    const winnerCoordinator = createPostgresTaskSettlementCoordinator({
+      registry,
+      publisherScope: 'test-seller',
+      outbox: { tableName: SETTLEMENT_OUTBOX },
+    });
+    const ref = await registry.create({ tool: 'create_media_buy', accountId: 'acc_1', hasWebhook: true });
+    const paused = completeScopedPushTask(
+      pausedCoordinator,
+      ref,
+      {
+        url: 'https://buyer.example/webhooks/task',
+        operationId: 'task-transition-race',
+        token: 'buyer-validation-secret',
+      },
+      { media_buy_id: 'paused-candidate' }
+    );
+
+    await protectionStarted;
+    assert.deepStrictEqual(
+      await completeScopedPushTask(
+        winnerCoordinator,
+        ref,
+        {
+          url: 'https://buyer.example/webhooks/task',
+          operationId: 'task-transition-race',
+        },
+        { media_buy_id: 'winning-candidate' }
+      ),
+      { outcome: 'applied', delivery: 'durably_bound' }
+    );
+    releaseProtection();
+
+    assert.deepStrictEqual(await paused, {
+      outcome: 'already_terminal',
+      status: 'completed',
+      compatibility: 'conflicting',
+      delivery: 'not_applicable',
+    });
+    assert.deepStrictEqual((await registry.getTask(ref.taskId, ref)).result, {
+      media_buy_id: 'winning-candidate',
+    });
+    assert.strictEqual((await pool.query(`SELECT count(*)::int AS count FROM ${SETTLEMENT_OUTBOX}`)).rows[0].count, 1);
+  });
+
+  test('an outbox race during protection accepts one intent and rejects the conflicting route', async () => {
+    const {
+      completeScopedPushTask,
+      createPostgresTaskSettlementCoordinator,
+      TaskPushSettlementConfigurationError,
+    } = require('../dist/lib/server/decisioning');
+    const registry = createPostgresTaskRegistry({
+      pool,
+      namespace: NAMESPACE,
+      storageId: 'store:protection-race',
+    });
+    let releaseProtection;
+    const protectionReleased = new Promise(resolve => {
+      releaseProtection = resolve;
+    });
+    let protectionCalls = 0;
+    let markBothStarted;
+    const bothStarted = new Promise(resolve => {
+      markBothStarted = resolve;
+    });
+    const coordinator = createPostgresTaskSettlementCoordinator({
+      registry,
+      publisherScope: 'test-seller',
+      outbox: { tableName: SETTLEMENT_OUTBOX },
+      authenticationAdapter: {
+        async protect(authentication) {
+          protectionCalls++;
+          if (protectionCalls === 2) markBothStarted();
+          await protectionReleased;
+          return {
+            protectedValue: { ciphertext: `opaque-protection-race-${protectionCalls}` },
+            fingerprint: require('node:crypto').createHash('sha256').update(authentication.token).digest('hex'),
+          };
+        },
+        resolve() {
+          return { type: 'bearer', token: 'buyer-validation-secret' };
+        },
+      },
+    });
+    const ref = await registry.create({ tool: 'create_media_buy', accountId: 'acc_1', hasWebhook: true });
+    const basePush = {
+      operationId: 'protection-race-operation',
+      token: 'buyer-validation-secret',
+    };
+    const first = completeScopedPushTask(
+      coordinator,
+      ref,
+      { ...basePush, url: 'https://buyer.example/webhooks/first' },
+      { media_buy_id: 'protection-race-buy' }
+    );
+    const second = completeScopedPushTask(
+      coordinator,
+      ref,
+      { ...basePush, url: 'https://buyer.example/webhooks/second' },
+      { media_buy_id: 'protection-race-buy' }
+    );
+
+    await bothStarted;
+    releaseProtection();
+    const outcomes = await Promise.allSettled([first, second]);
+    assert.strictEqual(
+      outcomes.filter(outcome => outcome.status === 'fulfilled' && outcome.value.outcome === 'applied').length,
+      1
+    );
+    const rejected = outcomes.find(outcome => outcome.status === 'rejected');
+    assert.ok(rejected);
+    assert.ok(rejected.reason instanceof TaskPushSettlementConfigurationError);
+    assert.match(rejected.reason.message, /already bound to a conflicting route or payload/);
+    assert.strictEqual((await pool.query(`SELECT count(*)::int AS count FROM ${SETTLEMENT_OUTBOX}`)).rows[0].count, 1);
   });
 
   test('a transient authentication-protection outage leaves settlement retryable', async () => {


### PR DESCRIPTION
## Summary

- expose framework-resolved account, agent, authentication, and task scope to comply-controller adapters without making adapter input immutable
- isolate compliance auto-seed caching by trusted resolved account authority
- perform webhook secret protection before opening PostgreSQL settlement transactions, then revalidate task and outbox state under locks
- preserve scoped not-found and known terminal-conflict behavior before validation or secret-protection work

Fixes #2723.
Fixes #2737.

## Validation

- npm run typecheck
- npm run build:lib
- 110 focused compliance/settlement tests pass; PostgreSQL-only integration cases skip when DATABASE_URL is unavailable
- 46 version-negotiation tests covering the client side of adcontextprotocol/adcp#2629 pass
- npm run review:codex -- --all --base main plus code, protocol, and security review found no remaining blockers

The full local npm test run was also attempted. Its hyperparallel execution exhausted local resources and raced concurrent dist generation/cleanup, producing unrelated timeouts and missing generated-artifact failures. The affected suites above pass in isolation, and CI is expected to provide the authoritative full run.

## Scope

- draft PR #2726 is intentionally untouched
- the external test agent for adcontextprotocol/adcp#2629 is still deployed on 3.2.0-beta.6 and must be upgraded outside this repository