### PR TITLE
feat(webhooks): add durable registration stores

### DIFF
--- a/.changeset/durable-webhook-registrations.md
+++ b/.changeset/durable-webhook-registrations.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': minor
+---
+
+Add first-party Redis and PostgreSQL webhook registration stores for restart-safe, multi-replica callback verification, with atomic provenance binding, backend-clock expiry, durable settlement markers, migration/probe helpers, cleanup, deployment-isolation safeguards, and method/URL binding for registered legacy HMAC callbacks.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -453,6 +453,13 @@ jobs:
           REDIS_URL: redis://127.0.0.1:6379
         run: node --test test/lib/webhook-delivery-durability.test.js
 
+      - name: Run durable webhook registration backend contract
+        env:
+          NODE_ENV: test
+          DATABASE_URL: postgresql://postgres@127.0.0.1:5432/postgres
+          REDIS_URL: redis://127.0.0.1:6379
+        run: node --test --test-timeout=120000 test/lib/webhook-registration-durability.test.js
+
       - name: Run PostgreSQL decisioning task-registry contract
         env:
           NODE_ENV: test

--- a/docs/guides/PUSH-NOTIFICATION-CONFIG.md
+++ b/docs/guides/PUSH-NOTIFICATION-CONFIG.md
@@ -145,6 +145,51 @@ app.post(
 
 The default registration and replay stores are process-local. Production receivers that can restart or run multiple replicas must inject a shared durable `webhookRegistrationStore` and `webhookVerification.replayStore`; registration writes must be atomic create-or-identical, and replay insertion must be atomic across replicas. Retain registrations for at least the seller retry horizon (seven days by default).
 
+The SDK includes Redis and PostgreSQL registration stores. Configure the same
+backend and stable `agent.id` in every process that can dispatch a task or
+receive its callback:
+
+```ts
+import {
+  SingleAgentClient,
+  getWebhookRegistrationMigration,
+  pgWebhookRegistrationStore,
+  redisWebhookRegistrationStore,
+} from '@adcp/sdk';
+import { PostgresReplayStore, getReplayStoreMigration } from '@adcp/sdk/signing/server';
+
+// PostgreSQL: run the idempotent migration during deployment, not per request.
+await pool.query(getWebhookRegistrationMigration({ tableName: 'buyer_eu_webhook_registrations' }));
+const pgRegistrations = pgWebhookRegistrationStore(pool, {
+  tableName: 'buyer_eu_webhook_registrations',
+});
+await pgRegistrations.probe();
+await pool.query(getReplayStoreMigration('buyer_eu_webhook_replays'));
+const sharedReplayStore = new PostgresReplayStore(pool, {
+  tableName: 'buyer_eu_webhook_replays',
+});
+
+// Redis alternative: use a deployment-unique prefix and primary-consistent client.
+const redisRegistrations = redisWebhookRegistrationStore(redis, {
+  keyPrefix: 'buyer-eu:webhook-registration:v1:',
+});
+await redisRegistrations.probe();
+
+const client = new SingleAgentClient(agent, {
+  webhookRegistrationStore: pgRegistrations, // or redisRegistrations
+  webhookVerification: { replayStore: sharedReplayStore },
+});
+```
+
+PostgreSQL and Redis use their backend clocks for inclusive expiry
+(`expiresAt <= now` is unavailable). PostgreSQL needs scheduled
+`cleanupExpiredWebhookRegistrations()` maintenance; Redis expires keys itself.
+Registration correctness never depends on cleanup. Redis must provide
+read-your-writes on the primary and support Lua, `TIME`, `PXAT`, and `KEEPTTL`.
+Use TLS, authentication, capacity monitoring, and a non-evicting policy for
+security state. Early eviction fails callbacks closed but causes availability
+loss. For RFC 9421, the replay store must also be shared and atomic.
+
 Custom registration stores used by durability-protected mutation flows must also implement `markRequiresDurableSettlement(agentId, operationId)` as an atomic update of the live registration. The SDK calls this after registration but before claiming or dispatching the mutation. If the method is absent or the update fails, dispatch fails closed.
 
 For deterministic tests or infrastructure-managed keys, set `webhookVerification.jwks`. Otherwise seller key discovery is automatic and uses an unauthenticated official protocol client for the capabilities step, so credentials configured for one endpoint are never transplanted to the registered callback origin. Sellers whose capability discovery requires authentication should provide an origin-bound `webhookVerification.fetchCapabilities(agentUrl, protocol)` callback or inject `webhookVerification.jwks` directly.
@@ -203,7 +248,7 @@ When `webhookSecret` is configured, the legacy webhook authentication path uses 
 - `x-adcp-signature: sha256=<hex digest>`
 - `x-adcp-timestamp: <unix seconds>`
 
-HMAC registration provenance never stores the credential or a secret-derived fingerprint. The configured global `webhookSecret` remains the verification key. Recordless fallback is limited to an explicit set of read-only tasks; mutations, unknown extensions, and `get_products` (which has a state-changing legacy finalization variant) require a live trusted registration and fail closed when registration state is missing or unavailable. RFC 9421 always fails closed without seller-pinned provenance.
+HMAC registration provenance never stores the credential or a secret-derived fingerprint. The configured global `webhookSecret` remains the verification key. For a registered HMAC callback, the receiver must supply the trusted HTTP method and externally visible absolute request URL; the SDK requires POST and compares that URL with the persisted callback URL before accepting the body-only HMAC. Recordless fallback is limited to an explicit set of read-only tasks; mutations, unknown extensions, and `get_products` (which has a state-changing legacy finalization variant) require a live trusted registration and fail closed when registration state is missing or unavailable. RFC 9421 always fails closed without seller-pinned provenance.
 
 Capture the raw request body before JSON parsing and use the SDK's HTTP handler,
 which verifies the signature and preserves typed failure status codes:

--- a/docs/migration-13-to-14.md
+++ b/docs/migration-13-to-14.md
@@ -93,6 +93,66 @@ operation to create a versioned registration. A caller-supplied
 `webhookVerification.jwks` may support legacy rows only when it independently
 preserves their original trust boundary.
 
+### Durable webhook registration across replicas
+
+The process-local registration store cannot survive a restart or route a
+callback to another replica. SDK 14 includes first-party PostgreSQL and Redis
+stores with the same atomic create-or-identical contract:
+
+```ts
+import {
+  SingleAgentClient,
+  cleanupExpiredWebhookRegistrations,
+  getWebhookRegistrationMigration,
+  pgWebhookRegistrationStore,
+  redisWebhookRegistrationStore,
+} from '@adcp/sdk';
+import { PostgresReplayStore, getReplayStoreMigration } from '@adcp/sdk/signing/server';
+
+// PostgreSQL deployment bootstrap:
+await pool.query(getWebhookRegistrationMigration({
+  tableName: 'buyer_eu_webhook_registrations',
+}));
+const registrations = pgWebhookRegistrationStore(pool, {
+  tableName: 'buyer_eu_webhook_registrations',
+});
+await registrations.probe();
+await pool.query(getReplayStoreMigration('buyer_eu_webhook_replays'));
+const sharedReplayStore = new PostgresReplayStore(pool, {
+  tableName: 'buyer_eu_webhook_replays',
+});
+
+// Or Redis, using the same deployment-unique prefix on every replica:
+const redisRegistrations = redisWebhookRegistrationStore(redis, {
+  keyPrefix: 'buyer-eu:webhook-registration:v1:',
+});
+await redisRegistrations.probe();
+
+// Construct this identically in outbound workers and inbound HTTP replicas.
+const client = new SingleAgentClient(agentWithStableId, {
+  webhookRegistrationStore: registrations, // or redisRegistrations
+  webhookVerification: { replayStore: sharedReplayStore },
+});
+
+// Schedule for PostgreSQL; expiry checks do not depend on this cleanup.
+await cleanupExpiredWebhookRegistrations(pool, {
+  tableName: 'buyer_eu_webhook_registrations',
+  batchSize: 1_000,
+});
+```
+
+Run migrations and `probe()` before serving traffic. All replicas must use the
+same stable agent id and the same isolated table or key prefix. Redis reads
+must be primary-consistent and the deployment must support Lua. Retain records
+for at least the seller retry horizon; monitor Redis capacity because eviction
+causes fail-closed callback unavailability. RFC 9421 additionally requires a
+shared durable replay store so two replicas cannot accept the same signature.
+
+Existing custom-store rows are not imported automatically. They must preserve
+the complete `authorizationContextVersion` and
+`delegatedOperatorAuthorization` tuple. Drain or re-dispatch legacy/lossy rows
+rather than deriving their original authority from current configuration.
+
 The same options are accepted by `resolveAgent()`, `getAgentJwks()`,
 `createAgentJwksSet()`, and `ResolvedAgentJwksResolver`. A constrained list with
 no corresponding trusted option fails closed. Built-in JWKS caches now expire

--- a/src/lib/core/ADCPMultiAgentClient.ts
+++ b/src/lib/core/ADCPMultiAgentClient.ts
@@ -16,6 +16,7 @@ import type {
   WebhookHandlerAdapter,
   WebhookHandlerRequest,
   WebhookParseResult,
+  WebhookRequestContext,
 } from './SingleAgentClient';
 import { ADCP_VERSION, type AdcpVersion } from '../version';
 import { resolveAdcpVersion } from '../utils/adcp-version-config';
@@ -1032,6 +1033,8 @@ export class ADCPMultiAgentClient {
    * @param operationId - Operation id (e.g used for client app to track the operation) from the param or url part of the webhook delivery
    * @param signature - Optional signature for verification (X-ADCP-Signature)
    * @param timestamp - Optional timestamp for verification (X-ADCP-Timestamp)
+   * @param rawBody - Raw request body bytes used for HMAC verification
+   * @param requestContext - Trusted method and public URL. Required for registered callbacks.
    * @returns Whether webhook was handled successfully
    *
    * @example
@@ -1055,7 +1058,8 @@ export class ADCPMultiAgentClient {
     operationId: string,
     signature?: WebhookHeaderValue,
     timestamp?: WebhookHeaderValue,
-    rawBody?: string | Buffer | Uint8Array
+    rawBody?: string | Buffer | Uint8Array,
+    requestContext?: WebhookRequestContext
   ): Promise<boolean> {
     // Extract agent ID from payload
     // Webhook payloads include agent_id or we can infer from operation_id pattern
@@ -1066,7 +1070,7 @@ export class ADCPMultiAgentClient {
     }
 
     const agent = this.getAgent(agentId);
-    return agent.handleWebhook(payload, taskType, operationId, signature, timestamp, rawBody);
+    return agent.handleWebhook(payload, taskType, operationId, signature, timestamp, rawBody, requestContext);
   }
 
   /**

--- a/src/lib/core/AgentClient.ts
+++ b/src/lib/core/AgentClient.ts
@@ -26,6 +26,7 @@ import {
   type VerifyAndParseWebhookOptions,
   type WebhookHandlerAdapter,
   type WebhookParseResult,
+  type WebhookRequestContext,
 } from './SingleAgentClient';
 import type { InputHandler, TaskOptions, TaskResult, TaskInfo, Message } from './ConversationTypes';
 import type {
@@ -701,7 +702,8 @@ export class AgentClient {
    * @param operationId - Operation id (e.g used for client app to track the operation) from the param or url part of the webhook delivery
    * @param signature - Optional signature for verification (X-ADCP-Signature)
    * @param timestamp - Optional timestamp for verification (X-ADCP-Timestamp)
-   * @param taskType - Task type from URL path (e.g., 'create_media_buy')
+   * @param rawBody - Raw request body bytes used for HMAC verification
+   * @param requestContext - Trusted method and public URL. Required for registered callbacks.
    * @returns Whether webhook was handled successfully
    */
   async handleWebhook(
@@ -710,9 +712,10 @@ export class AgentClient {
     operationId: string,
     signature?: WebhookHeaderValue,
     timestamp?: WebhookHeaderValue,
-    rawBody?: string | Buffer | Uint8Array
+    rawBody?: string | Buffer | Uint8Array,
+    requestContext?: WebhookRequestContext
   ): Promise<boolean> {
-    return this.client.handleWebhook(payload, taskType, operationId, signature, timestamp, rawBody);
+    return this.client.handleWebhook(payload, taskType, operationId, signature, timestamp, rawBody, requestContext);
   }
 
   /**

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -162,6 +162,9 @@ import { verifyWebhookRequest, type WebhookHeaderValue, type WebhookHeadersLike 
 import {
   canonicalDelegatedOperatorAuthorization,
   InMemoryWebhookRegistrationStore,
+  parseWebhookRegistration,
+  sameWebhookRegistration,
+  WebhookRegistrationIntegrityError,
   type WebhookRegistration,
   type WebhookRegistrationStore,
   validateWebhookRegistrationAuthorization,
@@ -1143,14 +1146,22 @@ export interface VerifyAndParseWebhookOptions {
   taskType?: string;
   /** Operation id from trusted routing context. Used as an A2A fallback. */
   operationId?: string;
-  /** Actual HTTP method from trusted server context. Required for RFC 9421. */
+  /** Actual HTTP method from trusted server context. Required for every registered callback. */
   requestMethod?: string;
-  /** Externally visible absolute request URL from trusted server/proxy configuration. Required for RFC 9421. */
+  /** Externally visible absolute request URL from trusted server/proxy configuration. Required for every registered callback. */
   requestUrl?: string;
   /** Explicit legacy HMAC signature header value. */
   signature?: WebhookHeaderValue;
   /** Explicit legacy HMAC timestamp header value. */
   timestamp?: WebhookHeaderValue;
+}
+
+/** Trusted HTTP request context for direct registered-webhook dispatch. */
+export interface WebhookRequestContext {
+  /** Actual HTTP method from trusted server context. */
+  requestMethod: string;
+  /** Externally visible absolute request URL from trusted server/proxy configuration. */
+  requestUrl: string;
 }
 
 export interface WebhookHandlerRequest {
@@ -1855,9 +1866,11 @@ export class SingleAgentClient {
       const persisted = await this.webhookRegistrationStore.get(args.agent.id, args.operationId);
       if (
         !persisted ||
-        persisted.authorizationContextVersion !== 1 ||
-        canonicalDelegatedOperatorAuthorization(persisted.delegatedOperatorAuthorization) !==
-          canonicalDelegatedOperatorAuthorization(delegatedOperatorAuthorization)
+        !sameWebhookRegistration(
+          parseWebhookRegistration(persisted, { agentId: args.agent.id, operationId: args.operationId }),
+          registration
+        ) ||
+        persisted.authorizationContextVersion !== 1
       ) {
         throw new Error(
           'Webhook registration store did not preserve the versioned delegated-operator authorization context.'
@@ -1918,6 +1931,21 @@ export class SingleAgentClient {
       );
     }
     await mark.call(this.webhookRegistrationStore, this.agent.id, operationId);
+    try {
+      const persisted = await this.webhookRegistrationStore.get(this.agent.id, operationId);
+      if (
+        !persisted ||
+        parseWebhookRegistration(persisted, { agentId: this.agent.id, operationId }).requiresDurableSettlement !== true
+      ) {
+        throw new Error('Webhook registration durable-settlement marker is missing.');
+      }
+    } catch (cause) {
+      const error = new ConfigurationError(
+        'The webhook registration store did not preserve the durable-settlement requirement.'
+      );
+      Object.defineProperty(error, 'cause', { value: cause, configurable: true });
+      throw error;
+    }
   }
 
   private webhookJwksFor(registration: Readonly<WebhookRegistration>): JwksResolver {
@@ -3144,12 +3172,15 @@ export class SingleAgentClient {
    *
    * The method normalizes both formats so handlers receive the unwrapped
    * AdCP response data (AdCPAsyncResponseData), not the raw protocol structure.
+   * Registered callbacks require trusted HTTP method and public-URL context;
+   * use `createWebhookHandler()` or `verifyAndParseWebhook()` for those flows.
    *
    * @param payload - Protocol-specific webhook payload (MCPWebhookPayload | Task | TaskStatusUpdateEvent)
    * @param taskType - Task type (e.g create_media_buy) from url param or url part of the webhook delivery
    * @param operationId - Operation id (e.g used for client app to track the operation) from the param or url part of the webhook delivery
    * @param signature - X-ADCP-Signature header (format: "sha256=...")
    * @param timestamp - X-ADCP-Timestamp header (Unix timestamp)
+   * @param requestContext - Trusted method and public URL. Required for registered callbacks.
    * @returns Whether webhook was handled successfully
    *
    * @example
@@ -3174,7 +3205,8 @@ export class SingleAgentClient {
     operationId: string,
     signature?: WebhookHeaderValue,
     timestamp?: WebhookHeaderValue,
-    rawBody?: string | Buffer | Uint8Array
+    rawBody?: string | Buffer | Uint8Array,
+    requestContext?: WebhookRequestContext
   ): Promise<boolean> {
     const parsed = await this.verifyAndParseWebhook({
       payload,
@@ -3183,6 +3215,8 @@ export class SingleAgentClient {
       signature,
       timestamp,
       rawBody,
+      requestMethod: requestContext?.requestMethod,
+      requestUrl: requestContext?.requestUrl,
     });
     if (!parsed.ok) {
       throw new WebhookDispatchError(parsed.code, parsed.message, parsed.cause);
@@ -3201,6 +3235,8 @@ export class SingleAgentClient {
    * validates the transport envelope shape, and returns the canonicalized
    * AdCP result plus routing metadata. Legacy wire inspection is intentionally
    * confined to the transport adapter and is not returned by this primary API.
+   * Every registered callback must include its trusted HTTP method and externally
+   * visible absolute request URL so the persisted callback target is enforced.
    */
   async verifyAndParseWebhook(options: VerifyAndParseWebhookOptions): Promise<WebhookParseResult> {
     const rawBody = options.rawBody ?? rawBodyFromUnknown(options.body);
@@ -3209,9 +3245,18 @@ export class SingleAgentClient {
       options.operationId && options.operationId !== 'unknown' ? options.operationId : undefined;
     let registration: Readonly<WebhookRegistration> | undefined;
     if (trustedOperationId) {
+      let stored: Readonly<WebhookRegistration> | undefined;
       try {
-        registration = await this.webhookRegistrationStore.get(this.agent.id, trustedOperationId);
+        stored = await this.webhookRegistrationStore.get(this.agent.id, trustedOperationId);
       } catch (cause) {
+        if (cause instanceof WebhookRegistrationIntegrityError) {
+          return {
+            ok: false,
+            code: 'webhook_registration_store_unavailable',
+            message: 'Webhook registration state is invalid.',
+            cause,
+          };
+        }
         const routedTaskType = options.taskType && options.taskType !== 'unknown' ? options.taskType : undefined;
         if (
           !this.config.webhookSecret ||
@@ -3226,48 +3271,28 @@ export class SingleAgentClient {
           };
         }
       }
-    }
-    if (registration && (registration.agentId !== this.agent.id || registration.operationId !== trustedOperationId)) {
-      return {
-        ok: false,
-        code: 'webhook_registration_store_unavailable',
-        message: 'Webhook registration state is inconsistent with the trusted route.',
-      };
+      if (stored) {
+        try {
+          registration = parseWebhookRegistration(stored, {
+            agentId: this.agent.id,
+            operationId: trustedOperationId,
+          });
+        } catch (cause) {
+          // Corrupt or mismatched state is an authorization failure, not a
+          // transient read outage eligible for recordless HMAC fallback.
+          return {
+            ok: false,
+            code: 'webhook_registration_store_unavailable',
+            message: 'Webhook registration state is invalid.',
+            cause,
+          };
+        }
+      }
     }
     if (registration) {
       const nowMs = this.config.webhookVerification?.now
         ? Math.floor(this.config.webhookVerification.now() * 1000)
         : Date.now();
-      if (!Number.isFinite(registration.createdAt) || !Number.isFinite(registration.expiresAt)) {
-        return {
-          ok: false,
-          code: 'webhook_registration_store_unavailable',
-          message: 'Webhook registration state contains invalid timestamps.',
-        };
-      }
-      try {
-        validateWebhookRegistrationAuthorization(registration);
-      } catch (cause) {
-        return {
-          ok: false,
-          code: 'webhook_registration_store_unavailable',
-          message: 'Webhook registration state contains invalid authorization context.',
-          cause,
-        };
-      }
-      try {
-        const registeredAgentUrl = new URL(registration.agentUrl);
-        if (registeredAgentUrl.username || registeredAgentUrl.password) {
-          throw new TypeError('Webhook registration seller URL contains userinfo.');
-        }
-      } catch (cause) {
-        return {
-          ok: false,
-          code: 'webhook_registration_store_unavailable',
-          message: 'Webhook registration state contains an invalid seller URL.',
-          cause,
-        };
-      }
       if (registration.expiresAt <= nowMs) registration = undefined;
     }
 
@@ -3320,26 +3345,20 @@ export class SingleAgentClient {
       );
       return { ok: false, code: cause.code, message: cause.message, cause };
     }
-    if (registration?.mode === 'rfc9421') {
-      if (
-        rawBody === undefined ||
-        !options.headers ||
-        !trustedOperationId ||
-        !options.requestMethod ||
-        !options.requestUrl
-      ) {
+    if (registration) {
+      if (!options.requestMethod || !options.requestUrl) {
         return {
           ok: false,
           code: 'webhook_verification_context_missing',
           message:
-            'RFC 9421 verification requires raw body bytes, all headers, POST method, an absolute trusted public URL, and a trusted route operation id.',
+            'Registered webhook verification requires the POST method and externally visible absolute request URL from trusted server context.',
         };
       }
-      if (options.requestMethod.toUpperCase() !== 'POST') {
+      if (options.requestMethod.toUpperCase() !== registration.method) {
         return {
           ok: false,
           code: 'webhook_verification_context_missing',
-          message: 'Webhook request method must be POST.',
+          message: 'Webhook request method does not match the registered callback method.',
         };
       }
       try {
@@ -3359,14 +3378,26 @@ export class SingleAgentClient {
           cause,
         };
       }
+    }
+    if (registration?.mode === 'rfc9421') {
+      const requestMethod = options.requestMethod;
+      const requestUrl = options.requestUrl;
+      if (rawBody === undefined || !options.headers || !trustedOperationId || !requestMethod || !requestUrl) {
+        return {
+          ok: false,
+          code: 'webhook_verification_context_missing',
+          message:
+            'RFC 9421 verification requires raw body bytes, all headers, POST method, an absolute trusted public URL, and a trusted route operation id.',
+        };
+      }
       const normalizedHeaders = normalizeRfc9421WebhookHeaders(options.headers);
       if (!normalizedHeaders.ok) return normalizedHeaders.failure;
       try {
         const delegatedOperatorAuthorization = this.delegatedOperatorAuthorizationForRegistration(registration);
         await verifyRfc9421WebhookSignature(
           {
-            method: options.requestMethod,
-            url: options.requestUrl,
+            method: requestMethod,
+            url: requestUrl,
             headers: normalizedHeaders.headers,
             body: rawBody,
           },

--- a/src/lib/core/postgres-webhook-registration-store.ts
+++ b/src/lib/core/postgres-webhook-registration-store.ts
@@ -1,0 +1,441 @@
+/**
+ * PostgreSQL-backed webhook registration provenance for multi-replica clients.
+ *
+ * The store deliberately accepts the structural `PgQueryable` interface rather
+ * than depending on `pg`, so pools, clients, and transaction wrappers can all
+ * be supplied by adopters without adding a runtime dependency to the SDK.
+ */
+
+import { ConfigurationError } from '../errors';
+import type { PgQueryable } from '../server/postgres-task-store';
+import {
+  parseWebhookRegistration,
+  sameWebhookRegistration,
+  validateWebhookRegistrationKey,
+  webhookRegistrationFingerprint,
+  WebhookRegistrationIntegrityError,
+  type WebhookRegistration,
+  type WebhookRegistrationStore,
+} from './webhook-registration';
+
+const DEFAULT_TABLE = 'adcp_webhook_registrations';
+const VALID_IDENTIFIER = /^[a-z_][a-z0-9_]*$/;
+// Keeps every table-derived PostgreSQL constraint/index identifier below the
+// server's 63-byte identifier limit.
+const MAX_TABLE_NAME_LENGTH = 40;
+
+export interface PgWebhookRegistrationStoreOptions {
+  /** Defaults to `adcp_webhook_registrations`. */
+  tableName?: string;
+  /** Assert that the database/schema is dedicated to this deployment. */
+  acknowledgeIsolatedDatabase?: boolean;
+}
+
+export interface CleanupExpiredWebhookRegistrationsOptions extends PgWebhookRegistrationStoreOptions {
+  /** Limit work per call. When omitted, all expired registrations are deleted. */
+  batchSize?: number;
+}
+
+function quoteTableName(tableName: string): string {
+  if (!VALID_IDENTIFIER.test(tableName) || tableName.length > MAX_TABLE_NAME_LENGTH) {
+    throw new Error(
+      `Invalid webhook registration table name: must match ${VALID_IDENTIFIER} and be at most ${MAX_TABLE_NAME_LENGTH} characters.`
+    );
+  }
+  return `"${tableName}"`;
+}
+
+function assertDeploymentNamespace(
+  api: string,
+  tableName: string,
+  options: Pick<PgWebhookRegistrationStoreOptions, 'acknowledgeIsolatedDatabase'>
+): void {
+  const development = process.env.NODE_ENV === 'test' || process.env.NODE_ENV === 'development';
+  if (!development && tableName === DEFAULT_TABLE && !options.acknowledgeIsolatedDatabase) {
+    throw new Error(`${api}: production requires a deployment-unique tableName or acknowledgeIsolatedDatabase: true`);
+  }
+}
+
+function databaseOperationError(operation: string, cause: unknown): Error {
+  return new Error(`pgWebhookRegistrationStore.${operation}: database operation failed`, { cause });
+}
+
+/**
+ * Render the idempotent migration for a durable webhook-registration table.
+ * Run this before constructing the store, and rerun it on every deployment so
+ * a future additive migration can upgrade existing installations.
+ */
+export function getWebhookRegistrationMigration(options: PgWebhookRegistrationStoreOptions = {}): string {
+  const tableName = options.tableName ?? DEFAULT_TABLE;
+  const table = quoteTableName(tableName);
+  return `
+CREATE TABLE IF NOT EXISTS ${table} (
+  agent_id                         TEXT NOT NULL,
+  operation_id                     TEXT NOT NULL,
+  agent_url                        TEXT NOT NULL,
+  protocol                         TEXT NOT NULL,
+  task_type                        TEXT NOT NULL,
+  callback_url                     TEXT NOT NULL,
+  method                           TEXT NOT NULL,
+  mode                             TEXT NOT NULL,
+  authorization_context_version    SMALLINT,
+  delegated_operator_authorization JSONB,
+  preview_mode                     TEXT,
+  requires_durable_settlement      BOOLEAN,
+  created_at                       TIMESTAMPTZ NOT NULL,
+  expires_at                       TIMESTAMPTZ NOT NULL,
+  PRIMARY KEY (agent_id, operation_id),
+  CONSTRAINT ${tableName}_valid_protocol CHECK (protocol IN ('mcp', 'a2a')),
+  CONSTRAINT ${tableName}_valid_method CHECK (method = 'POST'),
+  CONSTRAINT ${tableName}_valid_mode CHECK (mode IN ('hmac-sha256', 'rfc9421')),
+  CONSTRAINT ${tableName}_valid_preview CHECK (preview_mode IS NULL OR preview_mode IN ('canonical', 'legacy')),
+  CONSTRAINT ${tableName}_valid_auth_version CHECK (
+    authorization_context_version IS NULL OR authorization_context_version = 1
+  ),
+  CONSTRAINT ${tableName}_valid_auth_context CHECK (
+    delegated_operator_authorization IS NULL OR
+    ((authorization_context_version = 1) IS TRUE AND jsonb_typeof(delegated_operator_authorization) = 'object')
+  ),
+  CONSTRAINT ${tableName}_valid_expiry CHECK (expires_at > created_at)
+);
+
+CREATE INDEX IF NOT EXISTS idx_${tableName}_expires_at
+  ON ${table}(expires_at);
+`.trim();
+}
+
+/** Pre-rendered migration for the default table name. */
+export const WEBHOOK_REGISTRATION_MIGRATION = getWebhookRegistrationMigration();
+
+const RETURNING_REGISTRATION = `
+  agent_id,
+  operation_id,
+  agent_url,
+  protocol,
+  task_type,
+  callback_url,
+  method,
+  mode,
+  authorization_context_version,
+  delegated_operator_authorization,
+  preview_mode,
+  requires_durable_settlement,
+  FLOOR(EXTRACT(EPOCH FROM created_at) * 1000)::bigint AS created_at_ms,
+  FLOOR(EXTRACT(EPOCH FROM expires_at) * 1000)::bigint AS expires_at_ms
+`;
+
+function requiredString(row: Record<string, unknown>, key: string): string {
+  const value = row[key];
+  if (typeof value !== 'string') throw new TypeError('PostgreSQL returned an invalid webhook registration row.');
+  return value;
+}
+
+function optionalString(row: Record<string, unknown>, key: string): string | undefined {
+  const value = row[key];
+  if (value === null) return undefined;
+  if (typeof value !== 'string') throw new TypeError('PostgreSQL returned an invalid webhook registration row.');
+  return value;
+}
+
+function epochMillis(row: Record<string, unknown>, key: string): number {
+  const value = row[key];
+  if (typeof value !== 'string' && typeof value !== 'number') {
+    throw new TypeError('PostgreSQL returned an invalid webhook registration row.');
+  }
+  const parsed = typeof value === 'number' ? value : Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 0) {
+    throw new TypeError('PostgreSQL returned an invalid webhook registration row.');
+  }
+  return parsed;
+}
+
+function registrationFromRow(
+  row: Record<string, unknown>,
+  expectedKey: Readonly<{ agentId: string; operationId: string }>
+): Readonly<WebhookRegistration> {
+  try {
+    const authorizationContextVersion = row.authorization_context_version;
+    if (authorizationContextVersion !== null && authorizationContextVersion !== 1) {
+      throw new TypeError('PostgreSQL returned an invalid webhook registration row.');
+    }
+    const delegatedOperatorAuthorization = row.delegated_operator_authorization;
+    if (
+      delegatedOperatorAuthorization !== null &&
+      (typeof delegatedOperatorAuthorization !== 'object' || Array.isArray(delegatedOperatorAuthorization))
+    ) {
+      throw new TypeError('PostgreSQL returned an invalid webhook registration row.');
+    }
+    const requiresDurableSettlement = row.requires_durable_settlement;
+    if (requiresDurableSettlement !== null && typeof requiresDurableSettlement !== 'boolean') {
+      throw new TypeError('PostgreSQL returned an invalid webhook registration row.');
+    }
+    const previewMode = optionalString(row, 'preview_mode');
+
+    return parseWebhookRegistration(
+      {
+        agentId: requiredString(row, 'agent_id'),
+        operationId: requiredString(row, 'operation_id'),
+        agentUrl: requiredString(row, 'agent_url'),
+        protocol: requiredString(row, 'protocol'),
+        taskType: requiredString(row, 'task_type'),
+        callbackUrl: requiredString(row, 'callback_url'),
+        method: requiredString(row, 'method'),
+        mode: requiredString(row, 'mode'),
+        ...(authorizationContextVersion === 1 && { authorizationContextVersion }),
+        ...(delegatedOperatorAuthorization !== null && { delegatedOperatorAuthorization }),
+        ...(previewMode !== undefined && { previewMode }),
+        ...(requiresDurableSettlement !== null && { requiresDurableSettlement }),
+        createdAt: epochMillis(row, 'created_at_ms'),
+        expiresAt: epochMillis(row, 'expires_at_ms'),
+      },
+      expectedKey
+    );
+  } catch (cause) {
+    // Never attach or interpolate the corrupt persisted row: it contains seller
+    // and callback URLs that must not escape through public diagnostics. Parser
+    // causes contain field labels only, so operators retain safe diagnostics.
+    throw new WebhookRegistrationIntegrityError(
+      'pgWebhookRegistrationStore: database returned invalid webhook registration state',
+      { cause }
+    );
+  }
+}
+
+/** PostgreSQL implementation of trusted outbound webhook provenance. */
+export function pgWebhookRegistrationStore(
+  db: PgQueryable,
+  options: PgWebhookRegistrationStoreOptions = {}
+): WebhookRegistrationStore & { probe(): Promise<void> } {
+  const tableName = options.tableName ?? DEFAULT_TABLE;
+  const table = quoteTableName(tableName);
+  assertDeploymentNamespace('pgWebhookRegistrationStore', tableName, options);
+
+  async function query(operation: string, text: string, values?: unknown[]) {
+    try {
+      return await db.query(text, values);
+    } catch (cause) {
+      throw databaseOperationError(operation, cause);
+    }
+  }
+
+  return {
+    async probe(): Promise<void> {
+      try {
+        await db.query(`SELECT ${RETURNING_REGISTRATION} FROM ${table} LIMIT 0`);
+      } catch (cause) {
+        throw new Error(
+          `webhook registration store probe failed: cannot use the "${tableName}" table. Run getWebhookRegistrationMigration() before serving.`,
+          { cause }
+        );
+      }
+    },
+
+    async putIfAbsent(registration: WebhookRegistration): Promise<void> {
+      // Parsing clones and freezes the caller-owned object before the first
+      // await, preventing later mutation from changing the claimed provenance.
+      const proposed = parseWebhookRegistration(registration);
+      const proposedFingerprint = webhookRegistrationFingerprint(proposed);
+      const delegatedAuthorization = proposed.delegatedOperatorAuthorization;
+
+      // One backend clock and one upsert form the transaction boundary. The
+      // conflict update locks the existing row. Expired rows are replaced in
+      // full; live rows take a no-op update and are returned for exact comparison.
+      const result = await query(
+        'putIfAbsent',
+        `WITH key_lock AS MATERIALIZED (
+           SELECT pg_advisory_xact_lock(
+             hashtextextended(json_build_array($1::text, $2::text)::text, 0)
+           )
+         ), backend_clock AS MATERIALIZED (
+           SELECT clock_timestamp() AS now
+           FROM key_lock
+         )
+         INSERT INTO ${table} AS existing (
+           agent_id, operation_id, agent_url, protocol, task_type, callback_url,
+           method, mode, authorization_context_version, delegated_operator_authorization,
+           preview_mode, requires_durable_settlement, created_at, expires_at
+         )
+         SELECT
+           $1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb, $11, $12,
+           to_timestamp($13::double precision / 1000.0),
+           to_timestamp($14::double precision / 1000.0)
+         FROM backend_clock
+         WHERE to_timestamp($14::double precision / 1000.0) > backend_clock.now
+         ON CONFLICT (agent_id, operation_id) DO UPDATE SET (
+           agent_url, protocol, task_type, callback_url, method, mode,
+           authorization_context_version, delegated_operator_authorization,
+           preview_mode, requires_durable_settlement, created_at, expires_at
+         ) = (
+           SELECT
+             CASE WHEN existing.expires_at <= backend_clock.now THEN EXCLUDED.agent_url
+               ELSE existing.agent_url END,
+             CASE WHEN existing.expires_at <= backend_clock.now THEN EXCLUDED.protocol
+               ELSE existing.protocol END,
+             CASE WHEN existing.expires_at <= backend_clock.now THEN EXCLUDED.task_type
+               ELSE existing.task_type END,
+             CASE WHEN existing.expires_at <= backend_clock.now THEN EXCLUDED.callback_url
+               ELSE existing.callback_url END,
+             CASE WHEN existing.expires_at <= backend_clock.now THEN EXCLUDED.method
+               ELSE existing.method END,
+             CASE WHEN existing.expires_at <= backend_clock.now THEN EXCLUDED.mode
+               ELSE existing.mode END,
+             CASE WHEN existing.expires_at <= backend_clock.now THEN EXCLUDED.authorization_context_version
+               ELSE existing.authorization_context_version END,
+             CASE WHEN existing.expires_at <= backend_clock.now THEN EXCLUDED.delegated_operator_authorization
+               ELSE existing.delegated_operator_authorization END,
+             CASE WHEN existing.expires_at <= backend_clock.now THEN EXCLUDED.preview_mode
+               ELSE existing.preview_mode END,
+             CASE WHEN existing.expires_at <= backend_clock.now THEN EXCLUDED.requires_durable_settlement
+               ELSE existing.requires_durable_settlement END,
+             CASE WHEN existing.expires_at <= backend_clock.now THEN EXCLUDED.created_at
+               ELSE existing.created_at END,
+             CASE WHEN existing.expires_at <= backend_clock.now THEN EXCLUDED.expires_at
+               ELSE existing.expires_at END
+           FROM backend_clock
+         )
+         RETURNING ${RETURNING_REGISTRATION},
+                   (expires_at > (SELECT now FROM backend_clock)) AS registration_live`,
+        [
+          proposed.agentId,
+          proposed.operationId,
+          proposed.agentUrl,
+          proposed.protocol,
+          proposed.taskType,
+          proposed.callbackUrl,
+          proposed.method,
+          proposed.mode,
+          proposed.authorizationContextVersion ?? null,
+          delegatedAuthorization === undefined ? null : JSON.stringify(delegatedAuthorization),
+          proposed.previewMode ?? null,
+          proposed.requiresDurableSettlement ?? null,
+          proposed.createdAt,
+          proposed.expiresAt,
+        ]
+      );
+      const row = result.rows[0];
+      // The INSERT source is empty for an already-expired proposal, so no row
+      // is created and the operation fails atomically.
+      if (!row) throw new ConfigurationError('Cannot persist an expired webhook registration.', 'expiresAt');
+      if (row.registration_live !== true) {
+        if (row.registration_live !== false) {
+          throw new WebhookRegistrationIntegrityError(
+            'pgWebhookRegistrationStore: database returned invalid webhook registration state'
+          );
+        }
+        throw new ConfigurationError('Cannot persist an expired webhook registration.', 'expiresAt');
+      }
+      const persisted = registrationFromRow(row, proposed);
+      if (
+        webhookRegistrationFingerprint(persisted) !== proposedFingerprint ||
+        !sameWebhookRegistration(persisted, proposed)
+      ) {
+        throw new ConfigurationError(
+          'Webhook operation is already registered with different trusted provenance.',
+          'operationId'
+        );
+      }
+    },
+
+    async get(agentId: string, operationId: string): Promise<Readonly<WebhookRegistration> | undefined> {
+      validateWebhookRegistrationKey(agentId, operationId);
+      const result = await query(
+        'get',
+        `SELECT ${RETURNING_REGISTRATION}
+         FROM ${table}
+         WHERE agent_id = $1 AND operation_id = $2
+           AND expires_at > clock_timestamp()
+         LIMIT 1`,
+        [agentId, operationId]
+      );
+      const row = result.rows[0];
+      return row ? registrationFromRow(row, { agentId, operationId }) : undefined;
+    },
+
+    async markRequiresDurableSettlement(agentId: string, operationId: string): Promise<void> {
+      validateWebhookRegistrationKey(agentId, operationId);
+      const result = await query(
+        'markRequiresDurableSettlement',
+        `WITH key_lock AS MATERIALIZED (
+           SELECT pg_advisory_xact_lock(
+             hashtextextended(json_build_array($1::text, $2::text)::text, 0)
+           )
+         ), backend_clock AS MATERIALIZED (
+           SELECT clock_timestamp() AS now
+           FROM key_lock
+         )
+         UPDATE ${table}
+         SET requires_durable_settlement = TRUE
+         FROM backend_clock
+         WHERE agent_id = $1 AND operation_id = $2
+           AND expires_at > backend_clock.now`,
+        [agentId, operationId]
+      );
+      if ((result.rowCount ?? 0) === 0) {
+        throw new Error('Cannot mark a missing or expired webhook registration for durable settlement.');
+      }
+    },
+
+    async delete(agentId: string, operationId: string): Promise<void> {
+      validateWebhookRegistrationKey(agentId, operationId);
+      await query(
+        'delete',
+        `WITH key_lock AS MATERIALIZED (
+           SELECT pg_advisory_xact_lock(
+             hashtextextended(json_build_array($1::text, $2::text)::text, 0)
+           )
+         )
+         DELETE FROM ${table}
+         USING key_lock
+         WHERE agent_id = $1 AND operation_id = $2`,
+        [agentId, operationId]
+      );
+    },
+  };
+}
+
+/**
+ * Delete expired registration rows. Expiry correctness does not depend on this
+ * helper: all store operations independently use the PostgreSQL clock.
+ */
+export async function cleanupExpiredWebhookRegistrations(
+  db: PgQueryable,
+  options: CleanupExpiredWebhookRegistrationsOptions = {}
+): Promise<{ deleted: number }> {
+  const tableName = options.tableName ?? DEFAULT_TABLE;
+  const table = quoteTableName(tableName);
+  assertDeploymentNamespace('cleanupExpiredWebhookRegistrations', tableName, options);
+  const { batchSize } = options;
+  if (batchSize !== undefined && (!Number.isSafeInteger(batchSize) || batchSize <= 0)) {
+    throw new TypeError('cleanupExpiredWebhookRegistrations batchSize must be a positive safe integer.');
+  }
+
+  try {
+    if (batchSize === undefined) {
+      const result = await db.query(`DELETE FROM ${table} WHERE expires_at <= clock_timestamp()`);
+      return { deleted: result.rowCount ?? 0 };
+    }
+
+    const result = await db.query(
+      `WITH backend_clock AS MATERIALIZED (
+         SELECT clock_timestamp() AS now
+       ), expired AS MATERIALIZED (
+         SELECT registrations.agent_id, registrations.operation_id
+         FROM ${table} AS registrations
+         CROSS JOIN backend_clock
+         WHERE registrations.expires_at <= backend_clock.now
+         ORDER BY registrations.expires_at, registrations.agent_id, registrations.operation_id
+         FOR UPDATE OF registrations SKIP LOCKED
+         LIMIT $1
+       )
+       DELETE FROM ${table} AS registrations
+       USING expired, backend_clock
+       WHERE registrations.agent_id = expired.agent_id
+         AND registrations.operation_id = expired.operation_id
+         AND registrations.expires_at <= backend_clock.now`,
+      [batchSize]
+    );
+    return { deleted: result.rowCount ?? 0 };
+  } catch (cause) {
+    throw databaseOperationError('cleanupExpiredWebhookRegistrations', cause);
+  }
+}

--- a/src/lib/core/redis-webhook-registration-store.ts
+++ b/src/lib/core/redis-webhook-registration-store.ts
@@ -1,0 +1,418 @@
+import { randomBytes } from 'node:crypto';
+import { ConfigurationError } from '../errors';
+import type { RedisBackendClient, RedisLikeClient } from '../server/idempotency';
+import { maybeWarnOnSharedRedisPrefix } from '../utils/redis-default-prefix-warn';
+import {
+  parseWebhookRegistration,
+  sameWebhookRegistration,
+  webhookRegistrationFingerprint,
+  webhookRegistrationStorageDigest,
+  validateWebhookRegistrationKey,
+  WebhookRegistrationIntegrityError,
+  type WebhookRegistration,
+  type WebhookRegistrationStore,
+} from './webhook-registration';
+
+const DEFAULT_KEY_PREFIX = 'adcp:webhook-registration:v1:';
+const MAX_MARK_OR_DELETE_ATTEMPTS = 4;
+
+export interface RedisWebhookRegistrationStoreOptions {
+  /** Deployment-unique prefix. Defaults to `adcp:webhook-registration:v1:`. */
+  keyPrefix?: string;
+  /** Suppress the development warning for the default prefix on Redis db 0. */
+  suppressDefaultPrefixWarning?: boolean;
+  /** Explicit acknowledgement when the Redis database is deployment-isolated. */
+  acknowledgeIsolatedDatabase?: boolean;
+}
+
+interface SerializedRegistrationEnvelope {
+  version: 1;
+  agentId: string;
+  operationId: string;
+  fingerprint: string;
+  /** Exact JSON bytes; Lua must never decode/re-encode epoch-millisecond integers. */
+  registration: string;
+  expiresAt: string;
+  requiresDurableSettlement: 'unset' | 'false' | 'true';
+}
+
+interface ScriptOutcome {
+  status: string;
+  record?: string;
+}
+
+const GET_SCRIPT = `
+local raw = redis.call('GET', KEYS[1])
+if not raw then return cjson.encode({status = 'missing'}) end
+
+local decoded_ok, stored = pcall(cjson.decode, raw)
+if not decoded_ok or type(stored) ~= 'table' or type(stored.registration) ~= 'string' then
+  return cjson.encode({status = 'corrupt'})
+end
+if stored.version ~= 1 or stored.agentId ~= ARGV[1] or stored.operationId ~= ARGV[2]
+   or type(stored.expiresAt) ~= 'string'
+   or (stored.requiresDurableSettlement ~= 'unset' and stored.requiresDurableSettlement ~= 'false'
+       and stored.requiresDurableSettlement ~= 'true') then
+  return cjson.encode({status = 'collision'})
+end
+
+local expires_at = tonumber(stored.expiresAt)
+if not expires_at then return cjson.encode({status = 'corrupt'}) end
+local redis_time = redis.call('TIME')
+local now_ms = (tonumber(redis_time[1]) * 1000) + math.floor(tonumber(redis_time[2]) / 1000)
+if expires_at <= now_ms then
+  redis.call('DEL', KEYS[1])
+  return cjson.encode({status = 'missing'})
+end
+if redis.call('PTTL', KEYS[1]) < 0 then return cjson.encode({status = 'corrupt'}) end
+return cjson.encode({status = 'found', record = raw})
+`;
+
+const PUT_IF_ABSENT_SCRIPT = `
+local proposed_expires_at = tonumber(ARGV[4])
+if not proposed_expires_at then return cjson.encode({status = 'invalid_expiry'}) end
+local redis_time = redis.call('TIME')
+local now_ms = (tonumber(redis_time[1]) * 1000) + math.floor(tonumber(redis_time[2]) / 1000)
+if proposed_expires_at <= now_ms then return cjson.encode({status = 'expired'}) end
+
+local raw = redis.call('GET', KEYS[1])
+if raw then
+  local decoded_ok, stored = pcall(cjson.decode, raw)
+  if not decoded_ok or type(stored) ~= 'table' or type(stored.registration) ~= 'string' then
+    return cjson.encode({status = 'corrupt'})
+  end
+  if stored.version ~= 1 or stored.agentId ~= ARGV[1] or stored.operationId ~= ARGV[2]
+     or type(stored.expiresAt) ~= 'string'
+     or (stored.requiresDurableSettlement ~= 'unset' and stored.requiresDurableSettlement ~= 'false'
+         and stored.requiresDurableSettlement ~= 'true') then
+    return cjson.encode({status = 'collision'})
+  end
+  local current_expires_at = tonumber(stored.expiresAt)
+  if not current_expires_at then return cjson.encode({status = 'corrupt'}) end
+  if current_expires_at > now_ms then
+    if redis.call('PTTL', KEYS[1]) < 0 then return cjson.encode({status = 'corrupt'}) end
+    if stored.fingerprint == ARGV[3] then
+      return cjson.encode({status = 'existing', record = raw})
+    end
+    return cjson.encode({status = 'conflict'})
+  end
+end
+
+redis.call('SET', KEYS[1], ARGV[5], 'PXAT', ARGV[4])
+return cjson.encode({status = 'inserted', record = ARGV[5]})
+`;
+
+const MARK_SCRIPT = `
+local raw = redis.call('GET', KEYS[1])
+if not raw then return cjson.encode({status = 'missing'}) end
+if raw ~= ARGV[3] then return cjson.encode({status = 'retry'}) end
+
+local decoded_ok, stored = pcall(cjson.decode, raw)
+if not decoded_ok or type(stored) ~= 'table' or type(stored.registration) ~= 'string' then
+  return cjson.encode({status = 'corrupt'})
+end
+if stored.version ~= 1 or stored.agentId ~= ARGV[1] or stored.operationId ~= ARGV[2]
+   or type(stored.expiresAt) ~= 'string'
+   or (stored.requiresDurableSettlement ~= 'unset' and stored.requiresDurableSettlement ~= 'false'
+       and stored.requiresDurableSettlement ~= 'true') then
+  return cjson.encode({status = 'collision'})
+end
+
+local expires_at = tonumber(stored.expiresAt)
+if not expires_at then return cjson.encode({status = 'corrupt'}) end
+local redis_time = redis.call('TIME')
+local now_ms = (tonumber(redis_time[1]) * 1000) + math.floor(tonumber(redis_time[2]) / 1000)
+if expires_at <= now_ms then
+  redis.call('DEL', KEYS[1])
+  return cjson.encode({status = 'missing'})
+end
+if redis.call('PTTL', KEYS[1]) < 0 then return cjson.encode({status = 'corrupt'}) end
+if stored.requiresDurableSettlement == 'true' then
+  return cjson.encode({status = 'marked', record = raw})
+end
+
+stored.requiresDurableSettlement = 'true'
+local updated = cjson.encode(stored)
+redis.call('SET', KEYS[1], updated, 'KEEPTTL')
+return cjson.encode({status = 'marked', record = updated})
+`;
+
+const DELETE_SCRIPT = `
+local raw = redis.call('GET', KEYS[1])
+if not raw then return cjson.encode({status = 'missing'}) end
+if raw ~= ARGV[3] then return cjson.encode({status = 'retry'}) end
+
+local decoded_ok, stored = pcall(cjson.decode, raw)
+if not decoded_ok or type(stored) ~= 'table' or type(stored.registration) ~= 'string' then
+  return cjson.encode({status = 'corrupt'})
+end
+if stored.version ~= 1 or stored.agentId ~= ARGV[1] or stored.operationId ~= ARGV[2]
+   or type(stored.expiresAt) ~= 'string'
+   or (stored.requiresDurableSettlement ~= 'unset' and stored.requiresDurableSettlement ~= 'false'
+       and stored.requiresDurableSettlement ~= 'true') then
+  return cjson.encode({status = 'collision'})
+end
+redis.call('DEL', KEYS[1])
+return cjson.encode({status = 'deleted'})
+`;
+
+const PROBE_SCRIPT = `
+local redis_time = redis.call('TIME')
+local expires_at = (tonumber(redis_time[1]) * 1000) + math.floor(tonumber(redis_time[2]) / 1000) + 5000
+redis.call('SET', KEYS[1], 'probe-before-marker', 'PXAT', expires_at)
+redis.call('SET', KEYS[1], 'probe-after-marker', 'KEEPTTL')
+local ttl = redis.call('PTTL', KEYS[1])
+redis.call('DEL', KEYS[1])
+if ttl <= 0 then return 0 end
+return 1
+`;
+
+/** Redis-backed trusted webhook registration provenance for multi-replica clients. */
+export function redisWebhookRegistrationStore(
+  client: RedisBackendClient,
+  options: RedisWebhookRegistrationStoreOptions = {}
+): WebhookRegistrationStore & { probe(): Promise<void> } {
+  const c = client as RedisLikeClient;
+  for (const method of ['eval', 'ping'] as const) {
+    if (typeof c?.[method] !== 'function') {
+      throw new TypeError(`redisWebhookRegistrationStore: client must implement ${method}()`);
+    }
+  }
+  if (options.keyPrefix !== undefined && typeof options.keyPrefix !== 'string') {
+    throw new TypeError('redisWebhookRegistrationStore: keyPrefix must be a string');
+  }
+
+  const keyPrefix = options.keyPrefix ?? DEFAULT_KEY_PREFIX;
+  const unsafePrefix = keyPrefix.trim().length === 0 || keyPrefix === DEFAULT_KEY_PREFIX;
+  const development = process.env.NODE_ENV === 'test' || process.env.NODE_ENV === 'development';
+  if (!development && unsafePrefix && !options.acknowledgeIsolatedDatabase) {
+    throw new Error(
+      'redisWebhookRegistrationStore: production requires a deployment-unique keyPrefix or acknowledgeIsolatedDatabase: true'
+    );
+  }
+  maybeWarnOnSharedRedisPrefix({
+    client,
+    callerKeyPrefix: options.keyPrefix,
+    defaultKeyPrefix: DEFAULT_KEY_PREFIX,
+    suppress: options.suppressDefaultPrefixWarning || options.acknowledgeIsolatedDatabase,
+    backendName: 'redisWebhookRegistrationStore',
+  });
+
+  const redisKey = (agentId: string, operationId: string): string => {
+    validateWebhookRegistrationKey(agentId, operationId);
+    return `${keyPrefix}${webhookRegistrationStorageDigest(agentId, operationId)}`;
+  };
+
+  const runtimeCall = async (
+    operation: string,
+    script: string,
+    keys: string[],
+    args: string[]
+  ): Promise<ScriptOutcome> => {
+    let raw: unknown;
+    try {
+      raw = await c.eval(script, { keys, arguments: args });
+    } catch (cause) {
+      throw new Error(`redisWebhookRegistrationStore.${operation}: database operation failed`, { cause });
+    }
+    if (typeof raw !== 'string') throw corruptStoreError(operation);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      throw corruptStoreError(operation);
+    }
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) throw corruptStoreError(operation);
+    const outcome = parsed as Record<string, unknown>;
+    if (typeof outcome.status !== 'string') throw corruptStoreError(operation);
+    if (outcome.record !== undefined && typeof outcome.record !== 'string') throw corruptStoreError(operation);
+    return outcome as unknown as ScriptOutcome;
+  };
+
+  const parseStoredEnvelope = (
+    serialized: string,
+    expectedKey: Readonly<{ agentId: string; operationId: string }>,
+    operation: string
+  ): Readonly<WebhookRegistration> => {
+    let value: unknown;
+    try {
+      value = JSON.parse(serialized);
+    } catch {
+      throw corruptStoreError(operation);
+    }
+    if (!value || typeof value !== 'object' || Array.isArray(value)) throw corruptStoreError(operation);
+    const envelope = value as Partial<SerializedRegistrationEnvelope>;
+    if (
+      envelope.version !== 1 ||
+      envelope.agentId !== expectedKey.agentId ||
+      envelope.operationId !== expectedKey.operationId
+    ) {
+      throw collisionError(operation);
+    }
+    if (
+      typeof envelope.fingerprint !== 'string' ||
+      typeof envelope.registration !== 'string' ||
+      typeof envelope.expiresAt !== 'string' ||
+      (envelope.requiresDurableSettlement !== 'unset' &&
+        envelope.requiresDurableSettlement !== 'false' &&
+        envelope.requiresDurableSettlement !== 'true')
+    ) {
+      throw corruptStoreError(operation);
+    }
+    let storedRegistration: unknown;
+    try {
+      storedRegistration = JSON.parse(envelope.registration);
+    } catch {
+      throw corruptStoreError(operation);
+    }
+    let registration: Readonly<WebhookRegistration>;
+    try {
+      const parsed = parseWebhookRegistration(storedRegistration, expectedKey);
+      if (envelope.expiresAt !== String(parsed.expiresAt) || parsed.requiresDurableSettlement !== undefined) {
+        throw new TypeError('Stored registration envelope metadata does not match its record.');
+      }
+      registration = parseWebhookRegistration({
+        ...parsed,
+        ...(envelope.requiresDurableSettlement !== 'unset' && {
+          requiresDurableSettlement: envelope.requiresDurableSettlement === 'true',
+        }),
+      });
+    } catch {
+      throw corruptStoreError(operation);
+    }
+    if (webhookRegistrationFingerprint(registration) !== envelope.fingerprint) throw corruptStoreError(operation);
+    return registration;
+  };
+
+  const readRecord = async (
+    agentId: string,
+    operationId: string,
+    operation: string
+  ): Promise<{ registration: Readonly<WebhookRegistration>; serialized: string } | undefined> => {
+    const key = redisKey(agentId, operationId);
+    const outcome = await runtimeCall(operation, GET_SCRIPT, [key], [agentId, operationId]);
+    if (outcome.status === 'missing') return undefined;
+    if (outcome.status === 'collision') throw collisionError(operation);
+    if (outcome.status !== 'found' || outcome.record === undefined) throw corruptStoreError(operation);
+    return {
+      registration: parseStoredEnvelope(outcome.record, { agentId, operationId }, operation),
+      serialized: outcome.record,
+    };
+  };
+
+  return {
+    async probe(): Promise<void> {
+      try {
+        await c.ping();
+        const probeKey = `${keyPrefix}probe:${randomBytes(12).toString('hex')}`;
+        const result = await c.eval(PROBE_SCRIPT, { keys: [probeKey], arguments: [] });
+        if (Number(result) !== 1) throw new Error('Redis returned an unexpected Lua probe result.');
+      } catch (cause) {
+        throw new Error('webhook registration store probe failed: Redis is unreachable or lacks required Lua access', {
+          cause,
+        });
+      }
+    },
+
+    async get(agentId: string, operationId: string): Promise<Readonly<WebhookRegistration> | undefined> {
+      return (await readRecord(agentId, operationId, 'get'))?.registration;
+    },
+
+    async putIfAbsent(registration: WebhookRegistration): Promise<void> {
+      const proposed = parseWebhookRegistration(registration);
+      const expectedKey = { agentId: proposed.agentId, operationId: proposed.operationId } as const;
+      const key = redisKey(expectedKey.agentId, expectedKey.operationId);
+      const fingerprint = webhookRegistrationFingerprint(proposed);
+      const { requiresDurableSettlement, ...registrationWithoutMarker } = proposed;
+      const registrationJson = JSON.stringify(registrationWithoutMarker);
+      const serialized = JSON.stringify({
+        version: 1,
+        agentId: expectedKey.agentId,
+        operationId: expectedKey.operationId,
+        fingerprint,
+        registration: registrationJson,
+        expiresAt: String(proposed.expiresAt),
+        requiresDurableSettlement:
+          requiresDurableSettlement === undefined ? 'unset' : requiresDurableSettlement ? 'true' : 'false',
+      } satisfies SerializedRegistrationEnvelope);
+      const outcome = await runtimeCall(
+        'putIfAbsent',
+        PUT_IF_ABSENT_SCRIPT,
+        [key],
+        [expectedKey.agentId, expectedKey.operationId, fingerprint, String(proposed.expiresAt), serialized]
+      );
+      if (outcome.status === 'conflict') {
+        throw new ConfigurationError(
+          'Webhook operation is already registered with different trusted provenance.',
+          'operationId'
+        );
+      }
+      if (outcome.status === 'expired') {
+        throw new ConfigurationError('Cannot persist an expired webhook registration.', 'expiresAt');
+      }
+      if (outcome.status === 'collision') throw collisionError('putIfAbsent');
+      if ((outcome.status !== 'inserted' && outcome.status !== 'existing') || outcome.record === undefined) {
+        throw corruptStoreError('putIfAbsent');
+      }
+      const persisted = parseStoredEnvelope(outcome.record, expectedKey, 'putIfAbsent');
+      if (!sameWebhookRegistration(persisted, proposed)) throw collisionError('putIfAbsent');
+    },
+
+    async markRequiresDurableSettlement(agentId: string, operationId: string): Promise<void> {
+      const key = redisKey(agentId, operationId);
+      for (let attempt = 0; attempt < MAX_MARK_OR_DELETE_ATTEMPTS; attempt++) {
+        const current = await readRecord(agentId, operationId, 'markRequiresDurableSettlement');
+        if (!current) {
+          throw new Error('Cannot mark a missing or expired webhook registration for durable settlement.');
+        }
+        if (current.registration.requiresDurableSettlement === true) return;
+        const outcome = await runtimeCall(
+          'markRequiresDurableSettlement',
+          MARK_SCRIPT,
+          [key],
+          [agentId, operationId, current.serialized]
+        );
+        if (outcome.status === 'retry') continue;
+        if (outcome.status === 'missing') {
+          throw new Error('Cannot mark a missing or expired webhook registration for durable settlement.');
+        }
+        if (outcome.status === 'collision') throw collisionError('markRequiresDurableSettlement');
+        if (outcome.status !== 'marked' || outcome.record === undefined) {
+          throw corruptStoreError('markRequiresDurableSettlement');
+        }
+        const marked = parseStoredEnvelope(outcome.record, { agentId, operationId }, 'markRequiresDurableSettlement');
+        if (marked.requiresDurableSettlement !== true || !sameWebhookRegistration(marked, current.registration)) {
+          throw corruptStoreError('markRequiresDurableSettlement');
+        }
+        return;
+      }
+      throw new Error('Webhook registration changed repeatedly during durable-settlement marking.');
+    },
+
+    async delete(agentId: string, operationId: string): Promise<void> {
+      const key = redisKey(agentId, operationId);
+      for (let attempt = 0; attempt < MAX_MARK_OR_DELETE_ATTEMPTS; attempt++) {
+        const current = await readRecord(agentId, operationId, 'delete');
+        if (!current) return;
+        const outcome = await runtimeCall('delete', DELETE_SCRIPT, [key], [agentId, operationId, current.serialized]);
+        if (outcome.status === 'retry') continue;
+        if (outcome.status === 'missing' || outcome.status === 'deleted') return;
+        if (outcome.status === 'collision') throw collisionError('delete');
+        throw corruptStoreError('delete');
+      }
+      throw new Error('Webhook registration changed repeatedly during deletion.');
+    },
+  };
+}
+
+function corruptStoreError(operation: string): Error {
+  return new WebhookRegistrationIntegrityError(
+    `redisWebhookRegistrationStore.${operation}: corrupt registration state`
+  );
+}
+
+function collisionError(operation: string): Error {
+  return new WebhookRegistrationIntegrityError(
+    `redisWebhookRegistrationStore.${operation}: registration identity collision`
+  );
+}

--- a/src/lib/core/webhook-registration.ts
+++ b/src/lib/core/webhook-registration.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { ConfigurationError } from '../errors';
 import type {
   AuthorizedOperatorScope,
@@ -47,7 +48,10 @@ export interface WebhookRegistrationStore {
    * so the SDK can verify trusted authorization provenance before dispatch.
    */
   putIfAbsent(registration: WebhookRegistration): Promise<void>;
-  /** Atomically mark a live registration as requiring durable mutation settlement. */
+  /**
+   * Atomically mark a live registration as requiring durable mutation
+   * settlement. The update MUST be immediately visible through `get()`.
+   */
   markRequiresDurableSettlement?(agentId: string, operationId: string): Promise<void>;
   /** Remove provenance after a definitively synchronous terminal response. */
   delete?(agentId: string, operationId: string): Promise<void>;
@@ -58,6 +62,11 @@ export interface InMemoryWebhookRegistrationStoreOptions {
   maxEntries?: number;
   /** Current time in epoch milliseconds, for deterministic tests. */
   now?: () => number;
+}
+
+/** @internal Durable state exists but cannot be trusted as a registration. */
+export class WebhookRegistrationIntegrityError extends Error {
+  override readonly name = 'WebhookRegistrationIntegrityError';
 }
 
 /**
@@ -78,6 +87,7 @@ export class InMemoryWebhookRegistrationStore implements WebhookRegistrationStor
   }
 
   async get(agentId: string, operationId: string): Promise<Readonly<WebhookRegistration> | undefined> {
+    validateWebhookRegistrationKey(agentId, operationId);
     const key = registrationKey(agentId, operationId);
     const registration = this.entries.get(key);
     if (!registration) return undefined;
@@ -89,35 +99,40 @@ export class InMemoryWebhookRegistrationStore implements WebhookRegistrationStor
   }
 
   async putIfAbsent(registration: WebhookRegistration): Promise<void> {
-    validateRegistration(registration);
+    const parsed = parseWebhookRegistration(registration);
     this.pruneExpired();
-    const key = registrationKey(registration.agentId, registration.operationId);
+    if (parsed.expiresAt <= this.now()) {
+      throw new TypeError('Webhook registration must not already be expired.');
+    }
+    const key = registrationKey(parsed.agentId, parsed.operationId);
     const existing = this.entries.get(key);
     if (existing) {
-      if (sameRegistration(existing, registration)) return;
+      if (sameWebhookRegistration(existing, parsed)) return;
       throw new ConfigurationError(
-        `Webhook operation id '${registration.operationId}' is already registered with different trusted provenance.`,
+        'Webhook operation id is already registered with different trusted provenance.',
         'operationId'
       );
     }
     if (this.entries.size >= this.maxEntries) {
       throw new Error('Webhook registration store capacity reached; refusing to dispatch an untracked callback.');
     }
-    this.entries.set(key, freezeRegistration(registration));
+    this.entries.set(key, parsed);
   }
 
   async delete(agentId: string, operationId: string): Promise<void> {
+    validateWebhookRegistrationKey(agentId, operationId);
     this.entries.delete(registrationKey(agentId, operationId));
   }
 
   async markRequiresDurableSettlement(agentId: string, operationId: string): Promise<void> {
+    validateWebhookRegistrationKey(agentId, operationId);
     const key = registrationKey(agentId, operationId);
     const registration = this.entries.get(key);
     if (!registration || registration.expiresAt <= this.now()) {
       this.entries.delete(key);
       throw new Error('Cannot mark a missing or expired webhook registration for durable settlement.');
     }
-    this.entries.set(key, freezeRegistration({ ...registration, requiresDurableSettlement: true }));
+    this.entries.set(key, freezeWebhookRegistration({ ...registration, requiresDurableSettlement: true }));
   }
 
   private pruneExpired(): void {
@@ -132,35 +147,144 @@ function registrationKey(agentId: string, operationId: string): string {
   return `${agentId}\x00${operationId}`;
 }
 
-function validateRegistration(registration: WebhookRegistration): void {
-  if (!registration.agentId || !registration.operationId || !registration.taskType) {
-    throw new TypeError('Webhook registration requires agentId, operationId, and taskType.');
+const MAX_IDENTIFIER_BYTES = 512;
+const MAX_URL_BYTES = 8 * 1024;
+const MAX_RECORD_BYTES = 64 * 1024;
+const MAX_EPOCH_MS = 253_402_300_799_999;
+
+function hasUnpairedSurrogate(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) return true;
+      index += 1;
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      return true;
+    }
   }
-  if (
-    registration.agentId.includes('\0') ||
-    registration.operationId.includes('\0') ||
-    registration.taskType.includes('\0')
-  ) {
-    throw new TypeError('Webhook registration identifiers cannot contain NUL characters.');
+  return false;
+}
+
+function requireBoundedString(label: string, value: unknown, maxBytes: number): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new TypeError(`Webhook registration ${label} must be a non-empty string.`);
   }
-  if (registration.previewMode !== undefined && !['canonical', 'legacy'].includes(registration.previewMode)) {
+  if (value.includes('\0')) throw new TypeError(`Webhook registration ${label} cannot contain NUL characters.`);
+  if (hasUnpairedSurrogate(value)) {
+    throw new TypeError(`Webhook registration ${label} cannot contain unpaired surrogates.`);
+  }
+  if (Buffer.byteLength(value, 'utf8') > maxBytes) {
+    throw new TypeError(`Webhook registration ${label} must be at most ${maxBytes} UTF-8 bytes.`);
+  }
+  return value;
+}
+
+function requireEpochMs(label: string, value: unknown): number {
+  if (!Number.isSafeInteger(value) || (value as number) < 0 || (value as number) > MAX_EPOCH_MS) {
+    throw new TypeError(`Webhook registration ${label} must be a safe epoch-millisecond integer.`);
+  }
+  return value as number;
+}
+
+/** @internal Validate the exact logical key used by every registration backend. */
+export function validateWebhookRegistrationKey(agentId: string, operationId: string): void {
+  requireBoundedString('agentId', agentId, MAX_IDENTIFIER_BYTES);
+  requireBoundedString('operationId', operationId, MAX_IDENTIFIER_BYTES);
+}
+
+/** @internal Parse untrusted durable state into a detached, deeply frozen registration. */
+export function parseWebhookRegistration(
+  value: unknown,
+  expectedKey?: Readonly<{ agentId: string; operationId: string }>
+): Readonly<WebhookRegistration> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError('Webhook registration record must be an object.');
+  }
+  const input = value as Record<string, unknown>;
+  const agentId = requireBoundedString('agentId', input.agentId, MAX_IDENTIFIER_BYTES);
+  const operationId = requireBoundedString('operationId', input.operationId, MAX_IDENTIFIER_BYTES);
+  validateWebhookRegistrationKey(agentId, operationId);
+  if (expectedKey && (agentId !== expectedKey.agentId || operationId !== expectedKey.operationId)) {
+    throw new TypeError('Webhook registration record does not match the requested key.');
+  }
+  const taskType = requireBoundedString('taskType', input.taskType, MAX_IDENTIFIER_BYTES);
+  const agentUrl = requireBoundedString('agentUrl', input.agentUrl, MAX_URL_BYTES);
+  const callbackUrl = requireBoundedString('callbackUrl', input.callbackUrl, MAX_URL_BYTES);
+  if (input.protocol !== 'mcp' && input.protocol !== 'a2a') {
+    throw new TypeError('Webhook registration protocol must be mcp or a2a.');
+  }
+  if (input.method !== 'POST') throw new TypeError('Webhook registration method must be POST.');
+  if (input.mode !== 'hmac-sha256' && input.mode !== 'rfc9421') {
+    throw new TypeError('Webhook registration mode is invalid.');
+  }
+  if (input.previewMode !== undefined && input.previewMode !== 'canonical' && input.previewMode !== 'legacy') {
     throw new TypeError('Webhook registration previewMode must be canonical or legacy.');
   }
-  validateWebhookRegistrationAuthorization(registration);
-  const callback = new URL(registration.callbackUrl);
+  if (input.requiresDurableSettlement !== undefined && typeof input.requiresDurableSettlement !== 'boolean') {
+    throw new TypeError('Webhook registration requiresDurableSettlement must be boolean.');
+  }
+  const createdAt = requireEpochMs('createdAt', input.createdAt);
+  const expiresAt = requireEpochMs('expiresAt', input.expiresAt);
+  if (expiresAt <= createdAt) {
+    throw new TypeError('Webhook registration expiresAt must be later than createdAt.');
+  }
+
+  const authorization = {
+    authorizationContextVersion: input.authorizationContextVersion,
+    delegatedOperatorAuthorization: input.delegatedOperatorAuthorization,
+  } as Pick<WebhookRegistration, 'authorizationContextVersion' | 'delegatedOperatorAuthorization'>;
+  validateWebhookRegistrationAuthorization(authorization);
+  const delegatedOperatorAuthorization = authorization.delegatedOperatorAuthorization;
+
+  let callback: URL;
+  let agent: URL;
+  try {
+    callback = new URL(callbackUrl);
+    agent = new URL(agentUrl);
+  } catch {
+    throw new TypeError('Webhook registration contains an invalid URL.');
+  }
   if (callback.username || callback.password || callback.hash) {
     throw new TypeError('Webhook callbackUrl cannot contain userinfo or a fragment.');
   }
   if (callback.protocol !== 'https:' && !isWebhookLoopbackHost(callback.hostname)) {
     throw new TypeError('Webhook callbackUrl must use HTTPS (except loopback development URLs).');
   }
-  const agent = new URL(registration.agentUrl);
-  if (agent.username || agent.password) {
-    throw new TypeError('Webhook agentUrl cannot contain userinfo credentials.');
+  if (agent.username || agent.password || agent.hash) {
+    throw new TypeError('Webhook agentUrl cannot contain userinfo credentials or a fragment.');
   }
-  if (registration.expiresAt <= registration.createdAt) {
-    throw new TypeError('Webhook registration expiresAt must be later than createdAt.');
+
+  const parsed: WebhookRegistration = {
+    agentId,
+    agentUrl,
+    protocol: input.protocol,
+    operationId,
+    taskType,
+    callbackUrl,
+    method: 'POST',
+    mode: input.mode,
+    ...(input.authorizationContextVersion === 1 && { authorizationContextVersion: 1 }),
+    ...(delegatedOperatorAuthorization !== undefined && {
+      delegatedOperatorAuthorization: { ...delegatedOperatorAuthorization },
+    }),
+    ...(input.previewMode !== undefined && { previewMode: input.previewMode }),
+    ...(input.requiresDurableSettlement !== undefined && {
+      requiresDurableSettlement: input.requiresDurableSettlement,
+    }),
+    createdAt,
+    expiresAt,
+  };
+  const serialized = JSON.stringify(parsed);
+  if (Buffer.byteLength(serialized, 'utf8') > MAX_RECORD_BYTES) {
+    throw new TypeError(`Webhook registration record must be at most ${MAX_RECORD_BYTES} UTF-8 bytes.`);
   }
+  return Object.freeze({
+    ...parsed,
+    ...(parsed.delegatedOperatorAuthorization !== undefined && {
+      delegatedOperatorAuthorization: Object.freeze({ ...parsed.delegatedOperatorAuthorization }),
+    }),
+  });
 }
 
 const AUTHORIZED_OPERATOR_SCOPES = new Set<AuthorizedOperatorScope>([
@@ -184,7 +308,12 @@ export function validateDelegatedOperatorAuthorizationContext(
   if (unknown.length > 0) {
     throw new TypeError('delegatedOperatorAuthorization contains unsupported fields.');
   }
-  if (value.brand !== undefined && (typeof value.brand !== 'string' || !/^[a-z0-9_]+$/.test(value.brand))) {
+  if (
+    value.brand !== undefined &&
+    (typeof value.brand !== 'string' ||
+      !/^[a-z0-9_]+$/.test(value.brand) ||
+      Buffer.byteLength(value.brand, 'utf8') > 4096)
+  ) {
     throw new TypeError('delegatedOperatorAuthorization.brand must be a protocol brand id.');
   }
   if (value.scope !== undefined && (typeof value.scope !== 'string' || !AUTHORIZED_OPERATOR_SCOPES.has(value.scope))) {
@@ -220,29 +349,38 @@ export function canonicalDelegatedOperatorAuthorization(
   return JSON.stringify([value.brand ?? null, value.scope ?? null, value.country ?? null]);
 }
 
-function freezeRegistration(registration: WebhookRegistration): Readonly<WebhookRegistration> {
-  const delegatedOperatorAuthorization = registration.delegatedOperatorAuthorization;
-  return Object.freeze({
-    ...registration,
-    ...(delegatedOperatorAuthorization !== undefined && {
-      delegatedOperatorAuthorization: Object.freeze({ ...delegatedOperatorAuthorization }),
-    }),
-  });
+/** @internal Detach, validate, and deeply freeze a registration before storage. */
+export function freezeWebhookRegistration(registration: WebhookRegistration): Readonly<WebhookRegistration> {
+  return parseWebhookRegistration(registration);
 }
 
-function sameRegistration(a: Readonly<WebhookRegistration>, b: WebhookRegistration): boolean {
-  return (
-    a.agentId === b.agentId &&
-    a.agentUrl === b.agentUrl &&
-    a.protocol === b.protocol &&
-    a.operationId === b.operationId &&
-    a.taskType === b.taskType &&
-    a.callbackUrl === b.callbackUrl &&
-    a.method === b.method &&
-    a.mode === b.mode &&
-    a.previewMode === b.previewMode &&
-    a.authorizationContextVersion === b.authorizationContextVersion &&
-    canonicalDelegatedOperatorAuthorization(a.delegatedOperatorAuthorization) ===
-      canonicalDelegatedOperatorAuthorization(b.delegatedOperatorAuthorization)
-  );
+/** @internal Canonical immutable provenance used for create-or-identical storage. */
+export function webhookRegistrationFingerprint(registration: Readonly<WebhookRegistration>): string {
+  const parsed = parseWebhookRegistration(registration);
+  return JSON.stringify([
+    parsed.agentId,
+    parsed.agentUrl,
+    parsed.protocol,
+    parsed.operationId,
+    parsed.taskType,
+    parsed.callbackUrl,
+    parsed.method,
+    parsed.mode,
+    parsed.previewMode ?? null,
+    parsed.authorizationContextVersion ?? null,
+    canonicalDelegatedOperatorAuthorization(parsed.delegatedOperatorAuthorization),
+  ]);
+}
+
+/** @internal Compare only immutable trusted provenance, not timestamps or settlement state. */
+export function sameWebhookRegistration(a: Readonly<WebhookRegistration>, b: Readonly<WebhookRegistration>): boolean {
+  return webhookRegistrationFingerprint(a) === webhookRegistrationFingerprint(b);
+}
+
+/** @internal Fixed-length Redis storage digest for the exact logical key. */
+export function webhookRegistrationStorageDigest(agentId: string, operationId: string): string {
+  validateWebhookRegistrationKey(agentId, operationId);
+  return createHash('sha256')
+    .update(JSON.stringify([agentId, operationId]))
+    .digest('hex');
 }

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -284,6 +284,7 @@ export type {
   VerifyAndParseWebhookOptions,
   WebhookHandlerAdapter,
   WebhookHandlerRequest,
+  WebhookRequestContext,
   WebhookParseErrorCode,
   WebhookParseFailure,
   WebhookParseResult,
@@ -297,6 +298,18 @@ export {
   type WebhookRegistration,
   type WebhookRegistrationStore,
 } from './core/webhook-registration';
+export {
+  pgWebhookRegistrationStore,
+  getWebhookRegistrationMigration,
+  WEBHOOK_REGISTRATION_MIGRATION,
+  cleanupExpiredWebhookRegistrations,
+  type PgWebhookRegistrationStoreOptions,
+  type CleanupExpiredWebhookRegistrationsOptions,
+} from './core/postgres-webhook-registration-store';
+export {
+  redisWebhookRegistrationStore,
+  type RedisWebhookRegistrationStoreOptions,
+} from './core/redis-webhook-registration-store';
 export type { DelegatedOperatorAuthorizationContext } from './signing/agent-resolver';
 export {
   AgentClient,

--- a/test/helpers/webhook-registration-store-contract.js
+++ b/test/helpers/webhook-registration-store-contract.js
@@ -1,0 +1,241 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+let sequence = 0;
+
+function nextOperationId(label) {
+  sequence += 1;
+  return `webhook-registration-contract-${label}-${sequence}`;
+}
+
+function registration(label, overrides = {}) {
+  const createdAt = Date.now();
+  const operationId = nextOperationId(label);
+  return {
+    agentId: 'seller-contract',
+    agentUrl: 'https://seller.example/mcp',
+    protocol: 'mcp',
+    operationId,
+    taskType: 'create_media_buy',
+    callbackUrl: `https://buyer.example/webhooks/create_media_buy/${operationId}`,
+    method: 'POST',
+    mode: 'rfc9421',
+    authorizationContextVersion: 1,
+    delegatedOperatorAuthorization: {
+      brand: 'brand_a',
+      scope: 'media_buying',
+      country: 'GB',
+    },
+    previewMode: 'canonical',
+    requiresDurableSettlement: true,
+    createdAt,
+    expiresAt: createdAt + 60_000,
+    ...overrides,
+  };
+}
+
+async function createHarness(factory) {
+  const value = await factory();
+  const harness = value && value.store ? value : { store: value };
+  assert.ok(harness.store, 'store factory must return a store or { store, expire } harness');
+  for (const method of ['get', 'putIfAbsent', 'markRequiresDurableSettlement', 'delete']) {
+    assert.equal(typeof harness.store[method], 'function', `contract store must implement ${method}()`);
+  }
+  return harness;
+}
+
+/**
+ * Register the shared WebhookRegistrationStore behavioral contract.
+ *
+ * `factory` may return a store directly or `{ store, expire }`. An expiry hook
+ * may alternatively be supplied as `options.expire`. Hooks receive
+ * `{ store, registration }` and must make that exact row expired according to
+ * the backend before returning. Backend-specific TTL and corruption behavior
+ * belongs in each adapter's own tests.
+ */
+function runWebhookRegistrationStoreContract(name, factory, options = {}) {
+  test(`${name}: full round-trip is immutable and store-owned`, async () => {
+    const { store } = await createHarness(factory);
+    const input = registration('roundtrip');
+    const expected = structuredClone(input);
+
+    await store.putIfAbsent(input);
+    input.callbackUrl = 'https://mutated.example/webhook';
+    input.delegatedOperatorAuthorization.brand = 'mutated_brand';
+
+    const first = await store.get(expected.agentId, expected.operationId);
+    assert.deepEqual(first, expected);
+    assert.equal(Object.isFrozen(first), true, 'returned registration must be frozen');
+    assert.equal(
+      Object.isFrozen(first.delegatedOperatorAuthorization),
+      true,
+      'returned delegated authorization must be frozen'
+    );
+
+    const second = await store.get(expected.agentId, expected.operationId);
+    assert.deepEqual(second, expected, 'reads must not reflect caller-owned input mutations');
+  });
+
+  test(`${name}: agent and operation identifiers form an exact composite identity`, async () => {
+    const { store } = await createHarness(factory);
+    const first = registration('identity-first', {
+      agentId: 'seller',
+      operationId: 'region:operation',
+      callbackUrl: 'https://buyer.example/webhooks/identity-first',
+    });
+    const second = registration('identity-second', {
+      agentId: 'seller:region',
+      operationId: 'operation',
+      callbackUrl: 'https://buyer.example/webhooks/identity-second',
+    });
+    const third = registration('identity-third', {
+      agentId: first.agentId,
+      operationId: 'region:operation:sibling',
+      callbackUrl: 'https://buyer.example/webhooks/identity-third',
+    });
+
+    await Promise.all([store.putIfAbsent(first), store.putIfAbsent(second), store.putIfAbsent(third)]);
+    assert.deepEqual(await store.get(first.agentId, first.operationId), first);
+    assert.deepEqual(await store.get(second.agentId, second.operationId), second);
+    assert.deepEqual(await store.get(third.agentId, third.operationId), third);
+    assert.equal(await store.get(second.agentId, first.operationId), undefined);
+    assert.equal(await store.get(first.agentId, second.operationId), undefined);
+  });
+
+  test(`${name}: identical provenance is idempotent without replacing timestamps or settlement state`, async () => {
+    const { store } = await createHarness(factory);
+    const first = registration('idempotent');
+    await store.putIfAbsent(first);
+
+    await store.putIfAbsent({
+      ...first,
+      requiresDurableSettlement: false,
+      createdAt: first.createdAt + 1_000,
+      expiresAt: first.expiresAt + 10_000,
+    });
+
+    assert.deepEqual(
+      await store.get(first.agentId, first.operationId),
+      first,
+      'an identical retry must preserve the winning row, including timestamps and a true settlement marker'
+    );
+  });
+
+  test(`${name}: every immutable provenance dimension conflicts without overwriting the winner`, async () => {
+    const { store } = await createHarness(factory);
+    const first = registration('conflicts');
+    await store.putIfAbsent(first);
+
+    const conflicts = [
+      { agentUrl: 'https://other-seller.example/mcp' },
+      { protocol: 'a2a' },
+      { taskType: 'sync_creatives' },
+      { callbackUrl: 'https://buyer.example/webhooks/substituted' },
+      { method: 'GET' },
+      { mode: 'hmac-sha256' },
+      { previewMode: 'legacy' },
+      { authorizationContextVersion: undefined, delegatedOperatorAuthorization: undefined },
+      { delegatedOperatorAuthorization: { ...first.delegatedOperatorAuthorization, brand: 'brand_b' } },
+    ];
+
+    for (const conflict of conflicts) {
+      await assert.rejects(() => store.putIfAbsent({ ...first, ...conflict }));
+      assert.deepEqual(await store.get(first.agentId, first.operationId), first);
+    }
+  });
+
+  test(`${name}: durable-settlement marking is monotonic, exact-keyed, and rejects missing rows`, async () => {
+    const { store } = await createHarness(factory);
+    const first = registration('mark');
+    delete first.requiresDurableSettlement;
+    const sibling = registration('mark-sibling', { requiresDurableSettlement: false });
+    await Promise.all([store.putIfAbsent(first), store.putIfAbsent(sibling)]);
+
+    await store.markRequiresDurableSettlement(first.agentId, first.operationId);
+    await store.markRequiresDurableSettlement(first.agentId, first.operationId);
+    await store.putIfAbsent(first);
+
+    const marked = await store.get(first.agentId, first.operationId);
+    assert.deepEqual(marked, { ...first, requiresDurableSettlement: true });
+    assert.deepEqual(await store.get(sibling.agentId, sibling.operationId), sibling);
+    await assert.rejects(() => store.markRequiresDurableSettlement(first.agentId, nextOperationId('missing-mark')));
+  });
+
+  test(`${name}: delete removes only the exact composite key`, async () => {
+    const { store } = await createHarness(factory);
+    const first = registration('delete-first', { agentId: 'seller-delete' });
+    const sameOperationOtherAgent = registration('delete-other-agent', {
+      agentId: 'seller-delete-other',
+      operationId: first.operationId,
+    });
+    const sameAgentOtherOperation = registration('delete-other-operation', { agentId: first.agentId });
+    await Promise.all([first, sameOperationOtherAgent, sameAgentOtherOperation].map(value => store.putIfAbsent(value)));
+
+    await store.delete(first.agentId, first.operationId);
+    assert.equal(await store.get(first.agentId, first.operationId), undefined);
+    assert.deepEqual(
+      await store.get(sameOperationOtherAgent.agentId, sameOperationOtherAgent.operationId),
+      sameOperationOtherAgent
+    );
+    assert.deepEqual(
+      await store.get(sameAgentOtherOperation.agentId, sameAgentOtherOperation.operationId),
+      sameAgentOtherOperation
+    );
+    await store.delete(first.agentId, first.operationId);
+  });
+
+  test(`${name}: an expired key can be atomically replaced`, async context => {
+    const harness = await createHarness(factory);
+    const expire = options.expire ?? harness.expire;
+    if (expire === undefined) {
+      context.skip('expiry contract requires an expire hook');
+      return;
+    }
+    assert.equal(typeof expire, 'function', 'expiry hook must be a function');
+    const first = registration('expiry');
+    await harness.store.putIfAbsent(first);
+    await expire({ store: harness.store, registration: first });
+    assert.equal(await harness.store.get(first.agentId, first.operationId), undefined);
+
+    // A deterministic in-memory clock may have advanced to the first row's
+    // expiry, so keep the replacement's own interval valid in either clock.
+    const replacementCreatedAt = Math.max(Date.now(), first.expiresAt + 1);
+    const replacement = {
+      ...first,
+      callbackUrl: 'https://buyer.example/webhooks/replacement',
+      createdAt: replacementCreatedAt,
+      expiresAt: replacementCreatedAt + 60_000,
+    };
+    await harness.store.putIfAbsent(replacement);
+    assert.deepEqual(await harness.store.get(replacement.agentId, replacement.operationId), replacement);
+  });
+
+  test(`${name}: concurrent identical and conflicting creates have one immutable winner`, async () => {
+    const identicalHarness = await createHarness(factory);
+    const identical = registration('concurrent-identical');
+    const identicalResults = await Promise.allSettled(
+      Array.from({ length: 12 }, () => identicalHarness.store.putIfAbsent(structuredClone(identical)))
+    );
+    assert.ok(identicalResults.every(result => result.status === 'fulfilled'));
+    assert.deepEqual(await identicalHarness.store.get(identical.agentId, identical.operationId), identical);
+
+    const conflictHarness = await createHarness(factory);
+    const base = registration('concurrent-conflict');
+    const candidates = Array.from({ length: 12 }, (_, index) => ({
+      ...base,
+      callbackUrl: `https://buyer.example/webhooks/concurrent-winner-${index}`,
+    }));
+    const conflictResults = await Promise.allSettled(
+      candidates.map(candidate => conflictHarness.store.putIfAbsent(candidate))
+    );
+    const winners = conflictResults.flatMap((result, index) => (result.status === 'fulfilled' ? [index] : []));
+    assert.equal(winners.length, 1, 'exactly one conflicting concurrent create must win');
+    assert.deepEqual(
+      await conflictHarness.store.get(base.agentId, base.operationId),
+      candidates[winners[0]],
+      'the stored row must be the complete winning candidate'
+    );
+  });
+}
+
+module.exports = { runWebhookRegistrationStoreContract };

--- a/test/lib/media-buy-lifecycle-coordinator.test.js
+++ b/test/lib/media-buy-lifecycle-coordinator.test.js
@@ -7018,8 +7018,20 @@ describe('legacy products-only purchase continuations', () => {
       .createHmac('sha256', webhookSecret)
       .update(`${timestamp}.${rawBody}`)
       .digest('hex')}`;
+    const requestContext = {
+      requestMethod: 'POST',
+      requestUrl: `https://buyer.example/webhooks/create_media_buy/${operationId}`,
+    };
     const dispatch = () =>
-      agent.handleWebhook(payload, 'create_media_buy', operationId, signature, String(timestamp), rawBody);
+      agent.handleWebhook(
+        payload,
+        'create_media_buy',
+        operationId,
+        signature,
+        String(timestamp),
+        rawBody,
+        requestContext
+      );
 
     const firstDispatch = dispatch();
     await firstHandlerEntered;
@@ -7070,7 +7082,8 @@ describe('legacy products-only purchase continuations', () => {
         operationId,
         rotatedSignature,
         String(timestamp),
-        rotatedRawBody
+        rotatedRawBody,
+        requestContext
       ),
       true
     );
@@ -8099,7 +8112,18 @@ describe('legacy products-only purchase continuations', () => {
       .update(`${timestamp}.${rawBody}`)
       .digest('hex')}`;
     assert.equal(
-      await replicaAgent.handleWebhook(payload, 'create_media_buy', operationId, signature, String(timestamp), rawBody),
+      await replicaAgent.handleWebhook(
+        payload,
+        'create_media_buy',
+        operationId,
+        signature,
+        String(timestamp),
+        rawBody,
+        {
+          requestMethod: 'POST',
+          requestUrl: `https://buyer.example/webhooks/create_media_buy/${operationId}`,
+        }
+      ),
       true
     );
     const queued = await store.get(token);
@@ -8125,7 +8149,11 @@ describe('legacy products-only purchase continuations', () => {
         operationId,
         laterSignature,
         String(laterTimestamp),
-        laterRawBody
+        laterRawBody,
+        {
+          requestMethod: 'POST',
+          requestUrl: `https://buyer.example/webhooks/create_media_buy/${operationId}`,
+        }
       ),
       error => error.code === 'ambiguous' && /callback event identity does not match/.test(error.message)
     );

--- a/test/lib/preview-creative-client.test.js
+++ b/test/lib/preview-creative-client.test.js
@@ -322,7 +322,11 @@ describe('canonical previewCreative clients', () => {
           'op_immediate_legacy',
           auth.signature,
           auth.timestamp,
-          auth.rawBody
+          auth.rawBody,
+          {
+            requestMethod: 'POST',
+            requestUrl: 'https://buyer.example/webhook',
+          }
         );
         return completed();
       },
@@ -383,7 +387,11 @@ describe('canonical previewCreative clients', () => {
       'op_restart_canonical',
       auth.signature,
       auth.timestamp,
-      auth.rawBody
+      auth.rawBody,
+      {
+        requestMethod: 'POST',
+        requestUrl: 'https://buyer.example/webhook',
+      }
     );
 
     assert.strictEqual(restartedReceived.length, 1);

--- a/test/lib/webhook-registration-durability.test.js
+++ b/test/lib/webhook-registration-durability.test.js
@@ -1,0 +1,427 @@
+const { after, test } = require('node:test');
+const assert = require('node:assert/strict');
+const { createHash, createHmac, randomBytes } = require('node:crypto');
+const { spawnSync } = require('node:child_process');
+const {
+  InMemoryWebhookRegistrationStore,
+  SingleAgentClient,
+  cleanupExpiredWebhookRegistrations,
+  getWebhookRegistrationMigration,
+  pgWebhookRegistrationStore,
+  redisWebhookRegistrationStore,
+} = require('../../dist/lib/index.js');
+const { runWebhookRegistrationStoreContract } = require('../helpers/webhook-registration-store-contract.js');
+
+const agent = {
+  id: 'durable-registration-seller',
+  name: 'Durable registration seller',
+  agent_uri: 'https://seller.example/mcp',
+  protocol: 'mcp',
+};
+
+function registration(operationId, overrides = {}) {
+  const createdAt = Date.now();
+  return {
+    agentId: agent.id,
+    agentUrl: agent.agent_uri,
+    protocol: agent.protocol,
+    operationId,
+    taskType: 'create_media_buy',
+    callbackUrl: `https://buyer.example/webhooks/create_media_buy/${operationId}`,
+    method: 'POST',
+    mode: 'hmac-sha256',
+    authorizationContextVersion: 1,
+    delegatedOperatorAuthorization: { brand: 'brand_a', scope: 'media_buying', country: 'GB' },
+    createdAt,
+    expiresAt: createdAt + 60_000,
+    ...overrides,
+  };
+}
+
+function redisStorageKey(prefix, agentId, operationId) {
+  const digest = createHash('sha256')
+    .update(JSON.stringify([agentId, operationId]))
+    .digest('hex');
+  return `${prefix}${digest}`;
+}
+
+function hmacHeaders(rawBody, secret) {
+  const timestamp = Math.floor(Date.now() / 1000);
+  const digest = createHmac('sha256', secret).update(`${timestamp}.${rawBody}`).digest('hex');
+  return {
+    'x-adcp-signature': `sha256=${digest}`,
+    'x-adcp-timestamp': String(timestamp),
+  };
+}
+
+runWebhookRegistrationStoreContract('InMemoryWebhookRegistrationStore', async () => {
+  let now = Date.now();
+  return {
+    store: new InMemoryWebhookRegistrationStore({ now: () => now }),
+    expire: async ({ registration: value }) => {
+      now = value.expiresAt;
+    },
+  };
+});
+
+test('client rejects a registration store that acknowledges but drops the durable marker', async () => {
+  let persisted;
+  const lossyStore = {
+    async putIfAbsent(value) {
+      persisted = structuredClone(value);
+    },
+    async get() {
+      return persisted;
+    },
+    async markRequiresDurableSettlement() {},
+  };
+  const client = new SingleAgentClient(agent, {
+    webhookSecret: 'marker-readback-secret',
+    webhookRegistrationStore: lossyStore,
+  });
+  await client.persistWebhookRegistration({
+    agent,
+    taskType: 'create_media_buy',
+    operationId: 'lossy-marker-operation',
+    callbackUrl: 'https://buyer.example/webhooks/create_media_buy/lossy-marker-operation',
+    mode: 'hmac-sha256',
+  });
+  await assert.rejects(
+    () => client.markWebhookDurableSettlementRequired('lossy-marker-operation'),
+    /did not preserve the durable-settlement requirement/
+  );
+});
+
+test('corrupt durable state never falls back to recordless read-only HMAC verification', async () => {
+  const secret = 'corrupt-registration-secret';
+  const operationId = 'corrupt-read-only-registration';
+  const client = new SingleAgentClient(agent, {
+    webhookSecret: secret,
+    webhookRegistrationStore: {
+      async putIfAbsent() {},
+      async get() {
+        return registration(operationId, {
+          agentId: 'substituted-seller',
+          taskType: 'list_products',
+          mode: 'hmac-sha256',
+        });
+      },
+    },
+  });
+  const rawBody = JSON.stringify({
+    idempotency_key: 'corrupt-registration-delivery',
+    operation_id: operationId,
+    task_id: 'corrupt-registration-task',
+    task_type: 'list_products',
+    status: 'completed',
+    timestamp: new Date().toISOString(),
+    result: { products: [] },
+  });
+  const parsed = await client.verifyAndParseWebhook({
+    rawBody,
+    headers: hmacHeaders(rawBody, secret),
+    taskType: 'list_products',
+    operationId,
+  });
+  assert.equal(parsed.ok, false);
+  assert.equal(parsed.code, 'webhook_registration_store_unavailable');
+});
+
+test('durable registration backends require deployment isolation in production', () => {
+  const script = `
+    const {
+      pgWebhookRegistrationStore,
+      redisWebhookRegistrationStore,
+    } = require(${JSON.stringify(require.resolve('../../dist/lib/index.js'))});
+    const client = { eval: async () => null, ping: async () => 'PONG' };
+    const db = { query: async () => ({ rows: [], rowCount: 0 }) };
+    try { pgWebhookRegistrationStore(db); process.exit(8); }
+    catch (error) { if (!/deployment-unique tableName/.test(error.message)) throw error; }
+    try { redisWebhookRegistrationStore(client); process.exit(9); }
+    catch (error) { if (!/deployment-unique keyPrefix/.test(error.message)) throw error; }
+    pgWebhookRegistrationStore(db, { tableName: 'prod_eu_webhook_registrations' });
+    redisWebhookRegistrationStore(client, { keyPrefix: 'prod-eu:webhook-registration:v1:' });
+  `;
+  const result = spawnSync(process.execPath, ['-e', script], {
+    env: { ...process.env, NODE_ENV: 'production' },
+    encoding: 'utf8',
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+});
+
+async function proveFreshReceiverAcceptsMutation(storeA, storeB, label) {
+  const secret = `shared-hmac-${label}`;
+  const operationId = `durable-registration-restart-${label}`;
+  const callbackUrl = `https://buyer.example/webhooks/create_media_buy/${operationId}`;
+  const producer = new SingleAgentClient(agent, {
+    webhookSecret: secret,
+    webhookRegistrationStore: storeA,
+    strictSchemaValidation: false,
+    validateFeatures: false,
+  });
+  await producer.persistWebhookRegistration({
+    agent,
+    taskType: 'create_media_buy',
+    operationId,
+    callbackUrl,
+    mode: 'hmac-sha256',
+    delegatedOperatorAuthorization: { brand: 'brand_a', scope: 'media_buying', country: 'GB' },
+  });
+  await producer.markWebhookDurableSettlementRequired(operationId);
+
+  const handlerCalls = [];
+  const recoveries = [];
+  const receiver = new SingleAgentClient(agent, {
+    webhookSecret: secret,
+    webhookRegistrationStore: storeB,
+    strictSchemaValidation: false,
+    validateFeatures: false,
+    handlers: {
+      onCreateMediaBuyStatusChange: (result, metadata) => handlerCalls.push({ result, metadata }),
+    },
+  });
+  receiver.registerDurableSettlementRecovery(async (recoveredOperationId, observation) => {
+    recoveries.push({ operationId: recoveredOperationId, observation });
+    return { settled: true, status: observation.status, result: observation.result };
+  });
+
+  const payload = {
+    idempotency_key: `delivery-${label}`,
+    operation_id: operationId,
+    task_id: `task-${label}`,
+    task_type: 'create_media_buy',
+    status: 'completed',
+    timestamp: new Date().toISOString(),
+    result: { media_buy_id: `buy-${label}`, packages: [] },
+  };
+  const rawBody = JSON.stringify(payload);
+  const parsed = await receiver.verifyAndParseWebhook({
+    rawBody,
+    headers: hmacHeaders(rawBody, secret),
+    taskType: 'create_media_buy',
+    operationId,
+    requestMethod: 'POST',
+    requestUrl: callbackUrl,
+  });
+  assert.equal(parsed.ok, true);
+  assert.equal(await receiver.dispatchParsedWebhook(parsed), true);
+  assert.equal(recoveries.length, 1);
+  assert.equal(recoveries[0].operationId, operationId);
+  assert.equal(handlerCalls.length, 1);
+}
+
+if (process.env.DATABASE_URL) {
+  const { Pool } = require('pg');
+  const tableName = `adcp_wh_registration_${randomBytes(4).toString('hex')}`;
+  const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+  const ready = pool.query(getWebhookRegistrationMigration({ tableName }));
+
+  after(async () => {
+    await ready;
+    await pool.query(`DROP TABLE IF EXISTS "${tableName}"`);
+    await pool.end();
+  });
+
+  runWebhookRegistrationStoreContract('pgWebhookRegistrationStore (live)', async () => {
+    await ready;
+    const store = pgWebhookRegistrationStore(pool, { tableName });
+    return {
+      store,
+      expire: async ({ registration: value }) => {
+        await pool.query(
+          `UPDATE "${tableName}" SET expires_at = clock_timestamp() - interval '1 millisecond', created_at = clock_timestamp() - interval '2 milliseconds' WHERE agent_id = $1 AND operation_id = $2`,
+          [value.agentId, value.operationId]
+        );
+      },
+    };
+  });
+
+  test('PostgreSQL registration store probes, rejects stale creates, cleans up, and survives reconstruction', async () => {
+    await ready;
+    const first = pgWebhookRegistrationStore(pool, { tableName });
+    await first.probe();
+    const expired = registration('pg-already-expired', {
+      createdAt: Date.now() - 2_000,
+      expiresAt: Date.now() - 1_000,
+    });
+    await assert.rejects(() => first.putIfAbsent(expired), /expired webhook registration/i);
+    assert.equal(await first.get(expired.agentId, expired.operationId), undefined);
+
+    const cleanupTarget = registration('pg-cleanup-target');
+    await first.putIfAbsent(cleanupTarget);
+    await pool.query(
+      `UPDATE "${tableName}" SET expires_at = clock_timestamp() - interval '1 millisecond', created_at = clock_timestamp() - interval '2 milliseconds' WHERE agent_id = $1 AND operation_id = $2`,
+      [cleanupTarget.agentId, cleanupTarget.operationId]
+    );
+    assert.deepEqual(await cleanupExpiredWebhookRegistrations(pool, { tableName, batchSize: 1 }), { deleted: 1 });
+    assert.equal(await first.get(cleanupTarget.agentId, cleanupTarget.operationId), undefined);
+
+    const corruptOperationId = 'pg-corrupt-read-only-registration';
+    const corruptValue = registration(corruptOperationId, { taskType: 'list_products' });
+    await first.putIfAbsent(corruptValue);
+    await pool.query(`UPDATE "${tableName}" SET agent_url = 'not a URL' WHERE agent_id = $1 AND operation_id = $2`, [
+      corruptValue.agentId,
+      corruptValue.operationId,
+    ]);
+    const corruptReceiver = new SingleAgentClient(agent, {
+      webhookSecret: 'pg-corrupt-secret',
+      webhookRegistrationStore: first,
+    });
+    const corruptBody = JSON.stringify({
+      idempotency_key: 'pg-corrupt-delivery',
+      operation_id: corruptOperationId,
+      task_id: 'pg-corrupt-task',
+      task_type: 'list_products',
+      status: 'completed',
+      timestamp: new Date().toISOString(),
+      result: { products: [] },
+    });
+    const corruptParsed = await corruptReceiver.verifyAndParseWebhook({
+      rawBody: corruptBody,
+      headers: hmacHeaders(corruptBody, 'pg-corrupt-secret'),
+      taskType: 'list_products',
+      operationId: corruptOperationId,
+    });
+    assert.equal(corruptParsed.ok, false);
+    assert.equal(corruptParsed.code, 'webhook_registration_store_unavailable');
+
+    await proveFreshReceiverAcceptsMutation(
+      pgWebhookRegistrationStore(pool, { tableName }),
+      pgWebhookRegistrationStore(pool, { tableName }),
+      'postgres'
+    );
+  });
+
+  test('PostgreSQL samples expiry only after a conflicting registration lock is acquired', async () => {
+    await ready;
+    const operationId = 'pg-conflict-crosses-expiry';
+    const holder = await pool.connect();
+    try {
+      await holder.query('BEGIN');
+      const first = registration(operationId, {
+        createdAt: Date.now(),
+        expiresAt: Date.now() + 300,
+      });
+      await pgWebhookRegistrationStore(holder, { tableName }).putIfAbsent(first);
+
+      const replacement = registration(operationId, {
+        callbackUrl: `https://buyer.example/webhooks/create_media_buy/${operationId}/replacement`,
+        createdAt: Date.now(),
+        expiresAt: Date.now() + 60_000,
+      });
+      const waitingPut = pgWebhookRegistrationStore(pool, { tableName }).putIfAbsent(replacement);
+      await new Promise(resolve => setTimeout(resolve, 450));
+      await holder.query('COMMIT');
+      await waitingPut;
+
+      assert.deepEqual(await pgWebhookRegistrationStore(pool, { tableName }).get(agent.id, operationId), replacement);
+    } finally {
+      try {
+        await holder.query('ROLLBACK');
+      } catch {}
+      holder.release();
+    }
+  });
+}
+
+if (process.env.REDIS_URL) {
+  const { createClient } = require('redis');
+  const client = createClient({ url: process.env.REDIS_URL });
+  client.on('error', () => {});
+  const ready = client.connect();
+  const prefix = `adcp:test:webhook-registration:${randomBytes(6).toString('hex')}:`;
+
+  after(async () => {
+    await ready;
+    const keys = await client.keys(`${prefix}*`);
+    if (keys.length > 0) await client.del(keys);
+    await client.quit();
+  });
+
+  runWebhookRegistrationStoreContract('redisWebhookRegistrationStore (live)', async () => {
+    await ready;
+    const store = redisWebhookRegistrationStore(client, { keyPrefix: prefix });
+    return {
+      store,
+      expire: async ({ registration: value }) => {
+        const expired = await client.pExpireAt(
+          redisStorageKey(prefix, value.agentId, value.operationId),
+          Date.now() - 1
+        );
+        assert.ok(
+          expired === true || expired === 1,
+          'the exact Redis registration key must exist before forced expiry'
+        );
+      },
+    };
+  });
+
+  test('Redis registration store preserves TTL, hides keys, rejects corruption, and survives reconstruction', async () => {
+    await ready;
+    const first = redisWebhookRegistrationStore(client, { keyPrefix: prefix });
+    await first.probe();
+    const value = registration('redis-ttl');
+    await first.putIfAbsent(value);
+    const key = redisStorageKey(prefix, value.agentId, value.operationId);
+    assert.doesNotMatch(key, /durable-registration-seller|redis-ttl|buyer|seller\.example/);
+    const expiryBefore = await client.pExpireTime(key);
+    await first.putIfAbsent({ ...value, expiresAt: value.expiresAt + 10_000 });
+    await first.markRequiresDurableSettlement(value.agentId, value.operationId);
+    assert.equal(
+      await client.pExpireTime(key),
+      expiryBefore,
+      'idempotent writes and marking must preserve absolute expiry'
+    );
+
+    const corruptOperationId = 'redis-corrupt-canary-operation';
+    const corruptKey = redisStorageKey(prefix, agent.id, corruptOperationId);
+    await client.set(corruptKey, '{"sellerSecret":"do-not-expose"', { PX: 60_000 });
+    await assert.rejects(
+      () => first.get(agent.id, corruptOperationId),
+      error => {
+        assert.match(error.message, /corrupt registration state/);
+        assert.doesNotMatch(String(error), /do-not-expose|redis-corrupt-canary-operation/);
+        return true;
+      }
+    );
+    const corruptReceiver = new SingleAgentClient(agent, {
+      webhookSecret: 'redis-corrupt-secret',
+      webhookRegistrationStore: first,
+    });
+    const corruptBody = JSON.stringify({
+      idempotency_key: 'redis-corrupt-delivery',
+      operation_id: corruptOperationId,
+      task_id: 'redis-corrupt-task',
+      task_type: 'list_products',
+      status: 'completed',
+      timestamp: new Date().toISOString(),
+      result: { products: [] },
+    });
+    const corruptParsed = await corruptReceiver.verifyAndParseWebhook({
+      rawBody: corruptBody,
+      headers: hmacHeaders(corruptBody, 'redis-corrupt-secret'),
+      taskType: 'list_products',
+      operationId: corruptOperationId,
+    });
+    assert.equal(corruptParsed.ok, false);
+    assert.equal(corruptParsed.code, 'webhook_registration_store_unavailable');
+
+    const upperRange = registration('redis-upper-range-timestamp', {
+      createdAt: 253_402_300_798_999,
+      expiresAt: 253_402_300_799_999,
+      requiresDurableSettlement: undefined,
+    });
+    await first.putIfAbsent(upperRange);
+    await first.markRequiresDurableSettlement(upperRange.agentId, upperRange.operationId);
+    assert.deepEqual(await first.get(upperRange.agentId, upperRange.operationId), {
+      ...upperRange,
+      requiresDurableSettlement: true,
+    });
+
+    await proveFreshReceiverAcceptsMutation(
+      redisWebhookRegistrationStore(client, { keyPrefix: prefix }),
+      redisWebhookRegistrationStore(client, { keyPrefix: prefix }),
+      'redis'
+    );
+  });
+}

--- a/test/webhook-rfc9421-client.test.js
+++ b/test/webhook-rfc9421-client.test.js
@@ -4,6 +4,7 @@ const crypto = require('node:crypto');
 
 const {
   ADCPMultiAgentClient,
+  AgentClient,
   InMemoryWebhookRegistrationStore,
   SingleAgentClient,
   TaskExecutor,
@@ -319,7 +320,7 @@ describe('SingleAgentClient RFC 9421 webhook receiver', () => {
     assert.strictEqual(result.code, 'webhook_envelope_invalid');
   });
 
-  test('uses configured HMAC without persisting secret-derived material and rejects selector substitution', async () => {
+  test('binds registered HMAC callbacks to their trusted method and URL without persisting secret-derived material', async () => {
     const secret = 'legacy-secret';
     const store = new InMemoryWebhookRegistrationStore();
     const registration = {
@@ -343,22 +344,132 @@ describe('SingleAgentClient RFC 9421 webhook receiver', () => {
     });
     const rawBody = JSON.stringify(envelope());
     const headers = hmacHeaders(rawBody, secret);
+    const registeredContext = {
+      taskType: 'get_products',
+      operationId: 'op-rfc-1',
+      requestMethod: 'POST',
+      requestUrl: registration.callbackUrl,
+    };
     const verified = await client.verifyAndParseWebhook({
       rawBody,
       headers,
-      taskType: 'get_products',
-      operationId: 'op-rfc-1',
+      ...registeredContext,
     });
     assert.strictEqual(verified.ok, true);
+
+    const canonicalEquivalent = await client.verifyAndParseWebhook({
+      rawBody,
+      headers,
+      ...registeredContext,
+      requestUrl: 'https://BUYER.EXAMPLE:443/webhooks/get_products/op-rfc-1',
+    });
+    assert.strictEqual(canonicalEquivalent.ok, true);
+
+    for (const requestContext of [
+      { requestMethod: 'POST', requestUrl: 'https://other.example/webhooks/get_products/op-rfc-1' },
+      { requestMethod: 'POST', requestUrl: 'https://buyer.example/webhooks/get_products/other' },
+      { requestMethod: 'POST', requestUrl: 'https://buyer.example/webhooks/get_products/op-rfc-1?copy=1' },
+    ]) {
+      const wrongTarget = await client.verifyAndParseWebhook({
+        rawBody,
+        headers,
+        ...registeredContext,
+        ...requestContext,
+      });
+      assert.strictEqual(wrongTarget.ok, false);
+      assert.strictEqual(wrongTarget.code, 'webhook_signature_invalid');
+    }
+
+    for (const requestContext of [
+      { requestMethod: undefined, requestUrl: registration.callbackUrl },
+      { requestMethod: 'POST', requestUrl: undefined },
+      { requestMethod: 'GET', requestUrl: registration.callbackUrl },
+      { requestMethod: 'POST', requestUrl: '/webhooks/get_products/op-rfc-1' },
+    ]) {
+      const missingOrInvalidContext = await client.verifyAndParseWebhook({
+        rawBody,
+        headers,
+        ...registeredContext,
+        ...requestContext,
+      });
+      assert.strictEqual(missingOrInvalidContext.ok, false);
+      assert.strictEqual(missingOrInvalidContext.code, 'webhook_verification_context_missing');
+    }
 
     const substituted = await client.verifyAndParseWebhook({
       rawBody,
       headers: { ...headers, signature: 'sig1=:AAAA:' },
-      taskType: 'get_products',
-      operationId: 'op-rfc-1',
+      ...registeredContext,
     });
     assert.strictEqual(substituted.ok, false);
     assert.strictEqual(substituted.code, 'webhook_mode_mismatch');
+  });
+
+  test('forwards trusted registered-HMAC request context through public client wrappers', async () => {
+    const secret = 'wrapper-hmac-secret';
+    const store = new InMemoryWebhookRegistrationStore();
+    const operationId = 'op-wrapper-hmac';
+    const callbackUrl = `https://buyer.example/webhooks/get_products/${operationId}`;
+    await store.putIfAbsent({
+      agentId: agent.id,
+      agentUrl: agent.agent_uri,
+      protocol: agent.protocol,
+      operationId,
+      taskType: 'get_products',
+      callbackUrl,
+      method: 'POST',
+      mode: 'hmac-sha256',
+      createdAt: Date.now(),
+      expiresAt: Date.now() + 60_000,
+    });
+    let handlerCalls = 0;
+    const config = {
+      webhookSecret: secret,
+      webhookRegistrationStore: store,
+      strictSchemaValidation: false,
+      validateFeatures: false,
+      handlers: {
+        onGetProductsStatusChange: () => {
+          handlerCalls += 1;
+        },
+      },
+    };
+    const requestContext = { requestMethod: 'POST', requestUrl: callbackUrl };
+
+    const directPayload = envelope({ operation_id: operationId });
+    const directRawBody = JSON.stringify(directPayload);
+    const directHeaders = hmacHeaders(directRawBody, secret);
+    const wrappedAgent = new AgentClient(agent, config);
+    assert.strictEqual(
+      await wrappedAgent.handleWebhook(
+        directPayload,
+        'get_products',
+        operationId,
+        directHeaders['x-adcp-signature'],
+        directHeaders['x-adcp-timestamp'],
+        directRawBody,
+        requestContext
+      ),
+      true
+    );
+
+    const multiPayload = envelope({ operation_id: operationId, agent_id: agent.id });
+    const multiRawBody = JSON.stringify(multiPayload);
+    const multiHeaders = hmacHeaders(multiRawBody, secret);
+    const multi = new ADCPMultiAgentClient([agent], config);
+    assert.strictEqual(
+      await multi.handleWebhook(
+        multiPayload,
+        'get_products',
+        operationId,
+        multiHeaders['x-adcp-signature'],
+        multiHeaders['x-adcp-timestamp'],
+        multiRawBody,
+        requestContext
+      ),
+      true
+    );
+    assert.strictEqual(handlerCalls, 2);
   });
 
   test('preserves recordless legacy HMAC compatibility only for explicitly read-only tasks', async () => {
@@ -697,6 +808,8 @@ describe('SingleAgentClient RFC 9421 webhook receiver', () => {
       headers,
       taskType: 'create_media_buy',
       operationId: 'op-a2a-hmac-a',
+      requestMethod: 'POST',
+      requestUrl: 'https://buyer.example/webhooks/create_media_buy/op-a2a-hmac-a',
     });
     assert.strictEqual(accepted.ok, true);
 
@@ -734,6 +847,8 @@ describe('SingleAgentClient RFC 9421 webhook receiver', () => {
       headers: statusHeaders,
       taskType: 'create_media_buy',
       operationId: 'op-a2a-hmac-a',
+      requestMethod: 'POST',
+      requestUrl: 'https://buyer.example/webhooks/create_media_buy/op-a2a-hmac-a',
     });
     assert.strictEqual(acceptedStatus.ok, true);
     assert.strictEqual(acceptedStatus.metadata.taskId, 'adcp-hmac-status-work-task');
@@ -743,6 +858,8 @@ describe('SingleAgentClient RFC 9421 webhook receiver', () => {
       headers,
       taskType: 'create_media_buy',
       operationId: 'op-a2a-hmac-b',
+      requestMethod: 'POST',
+      requestUrl: 'https://buyer.example/webhooks/create_media_buy/op-a2a-hmac-b',
     });
     assert.strictEqual(rejected.ok, false);
     assert.strictEqual(rejected.code, 'webhook_registration_mismatch');
@@ -752,6 +869,8 @@ describe('SingleAgentClient RFC 9421 webhook receiver', () => {
       headers: statusHeaders,
       taskType: 'create_media_buy',
       operationId: 'op-a2a-hmac-b',
+      requestMethod: 'POST',
+      requestUrl: 'https://buyer.example/webhooks/create_media_buy/op-a2a-hmac-b',
     });
     assert.strictEqual(rejectedStatus.ok, false);
     assert.strictEqual(rejectedStatus.code, 'webhook_registration_mismatch');


### PR DESCRIPTION
Closes #2740.

## Summary

- add first-party PostgreSQL and Redis webhook registration stores with migration, probe, cleanup, deployment-isolation, and backend-clock expiry support
- centralize registration validation, immutable provenance binding, corruption handling, and exact create-or-identical semantics across memory and durable backends
- preserve durable settlement markers and authorization context across replicas/restarts
- bind every registered HMAC/RFC callback to the trusted HTTP method and persisted callback URL, including all public client wrappers
- document multi-replica setup and run the shared store contract against PostgreSQL 16 and Redis 7 in CI

## Verification

- live PostgreSQL 16 + Redis 7 durability suite: 30/30
- webhook signing/registration suite: 48/48
- durable lifecycle callback/restart regressions: 2/2
- slow Node suite: 390/390
- `npm run typecheck`
- `npm run build:lib`
- `npm run check:adopter-types`
- `npm run format:check`
- `npm run ci:docs-check`
- `npm run lint:workflows`
- protocol, DX, code, and security expert reviews converged; final second-model protocol/security review says ship

One full fast-suite run had a single unrelated concurrent auth-signature test return a transient 404; its isolated file rerun passed 38/38. GitHub CI will run the clean full matrix.