### PR TITLE
feat(negotiation): verify proposal commercial terms

### DIFF
--- a/.changeset/calm-proposals-verify-terms.md
+++ b/.changeset/calm-proposals-verify-terms.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': minor
+---
+
+Add a schema-bundle-derived buyer verifier for proposal commercial terms. It checks the proposal digest before recursively comparing every binding field, returns typed JSON Pointer mismatches, and fails closed for unavailable or unsupported schema bundles.

--- a/src/lib/negotiation/types.ts
+++ b/src/lib/negotiation/types.ts
@@ -297,3 +297,44 @@ export interface ProposalVerificationResult {
   ok: boolean;
   issues: ProposalVerificationIssue[];
 }
+
+export type ProposalCommercialTermsMismatch =
+  | {
+      kind: 'digest_mismatch';
+      path: '/terms_digest';
+      message: string;
+    }
+  | {
+      kind: 'invalid_terms';
+      subject: 'proposal' | 'expected';
+      path: string;
+      keyword?: string;
+      message: string;
+    }
+  | {
+      kind: 'missing' | 'unexpected' | 'changed';
+      path: string;
+      message: string;
+    }
+  | {
+      kind: 'schema_unavailable' | 'unsupported_schema';
+      path: '/commercial_terms';
+      message: string;
+    };
+
+export interface ProposalCommercialTermsVerificationResult {
+  ok: boolean;
+  /** Exact release declared by the selected bundle, when it could be loaded. */
+  schemaVersion?: string;
+  /** True when diagnostics reached the bounded mismatch-reporting limit. */
+  truncated?: boolean;
+  mismatches: ProposalCommercialTermsMismatch[];
+}
+
+export interface VerifyProposalCommercialTermsOptions {
+  /**
+   * Schema bundle used to define binding commercial-term fields. Defaults to
+   * the SDK pin. Pass the seller-served release when verifying another line.
+   */
+  adcpVersion?: string;
+}

--- a/src/lib/negotiation/verification.ts
+++ b/src/lib/negotiation/verification.ts
@@ -1,8 +1,12 @@
 import { createHash } from 'node:crypto';
+import { MAX_JSON_DEPTH } from '../utils/json-depth';
 import { canonicalize } from '../utils/jcs';
-import { getSchemaValidatorByRef } from '../validation/schema-loader';
+import { getSchemaDocumentByRef, getSchemaValidatorByRef } from '../validation/schema-loader';
+import { ADCP_VERSION } from '../version';
 import type {
   CanonicalProposal,
+  ProposalCommercialTermsMismatch,
+  ProposalCommercialTermsVerificationResult,
   ProposalConstraints,
   ProposalProductChanges,
   ProposalRefinement,
@@ -12,12 +16,17 @@ import type {
   RefineProposalsCompletedResponse,
   RefineProposalsRequest,
   RefineProposalsResponse,
+  VerifyProposalCommercialTermsOptions,
 } from './types';
 
 // Release-precision wire version: `3.2` or a non-empty, dot/hyphen-separated
 // prerelease whose segments are alphanumeric. Reject dangling separators such
 // as `3.2-.` and `3.2-rc.` even though they begin with the right release.
 const ADCP_32_RELEASE = /^3\.2(?:-[A-Za-z0-9]+(?:[.-][A-Za-z0-9]+)*)?$/;
+const MAX_COMMERCIAL_TERMS_BYTES = 256 * 1024;
+const MAX_COMMERCIAL_TERMS_NODES = 50_000;
+const MAX_COMMERCIAL_TERMS_MISMATCHES = 100;
+const MAX_COMMERCIAL_TERMS_DIAGNOSTIC_BYTES = 64 * 1024;
 
 export class ProposalResponseVerificationError extends Error {
   readonly issues: ProposalVerificationIssue[];
@@ -36,6 +45,251 @@ export function proposalTermsDigest(commercialTerms: unknown): string {
 
 export function verifyProposalTermsDigest(proposal: CanonicalProposal): boolean {
   return proposal.terms_digest === proposalTermsDigest(proposal.commercial_terms);
+}
+
+export class ProposalCommercialTermsVerificationError extends Error {
+  readonly mismatches: ProposalCommercialTermsMismatch[];
+  readonly truncated: boolean;
+
+  constructor(mismatches: ProposalCommercialTermsMismatch[], truncated = false) {
+    super(
+      `proposal commercial terms failed verification (${mismatches.length} mismatch${mismatches.length === 1 ? '' : 'es'}${truncated ? ', diagnostics truncated' : ''})`
+    );
+    this.name = 'ProposalCommercialTermsVerificationError';
+    this.mismatches = mismatches;
+    this.truncated = truncated;
+  }
+}
+
+/**
+ * Verify a proposal's binding commercial terms against the complete terms the
+ * buyer reviewed.
+ *
+ * The comparison surface is read at runtime from `media-buy/commercial-terms.json`
+ * in the selected AdCP schema bundle. This coupling is deliberate: callers
+ * should pass the seller-served release through `adcpVersion`, and must ship
+ * that matching bundle. A newly added optional commercial field is therefore
+ * compared automatically when present instead of being omitted by a stale SDK
+ * allowlist.
+ *
+ * The proposal's `terms_digest` is checked before schema validation or field
+ * comparison. A digest failure returns only `digest_mismatch`, preventing a
+ * tampered payload from being interpreted as a trustworthy field-level diff.
+ * Paths are RFC 6901 JSON Pointers rooted at `/commercial_terms`.
+ */
+export function verifyProposalCommercialTerms(
+  proposal: unknown,
+  expectedCommercialTerms: unknown,
+  options: VerifyProposalCommercialTermsOptions = {}
+): ProposalCommercialTermsVerificationResult {
+  const mismatches: ProposalCommercialTermsMismatch[] = [];
+  if (!isRecord(proposal)) {
+    return invalidTermsResult('proposal', '/commercial_terms', 'proposal must be an object');
+  }
+
+  let actualTerms: unknown;
+  let suppliedDigest: unknown;
+  let actualCanonical: string;
+  try {
+    const suppliedTerms = proposal.commercial_terms;
+    suppliedDigest = proposal.terms_digest;
+    const complexityError = commercialTermsComplexityError(suppliedTerms);
+    if (complexityError) return invalidTermsResult('proposal', '/commercial_terms', complexityError);
+    actualTerms = structuredClone(suppliedTerms);
+    actualCanonical = canonicalProposalTerms(actualTerms);
+    if (Buffer.byteLength(actualCanonical, 'utf8') > MAX_COMMERCIAL_TERMS_BYTES) {
+      return invalidTermsResult('proposal', '/commercial_terms', 'proposal commercial terms exceed 256 KiB');
+    }
+  } catch {
+    return invalidTermsResult('proposal', '/commercial_terms', 'proposal commercial terms cannot be canonicalized');
+  }
+
+  const actualDigest = digestCanonicalTerms(actualCanonical);
+  if (suppliedDigest !== actualDigest) {
+    return {
+      ok: false,
+      mismatches: [
+        {
+          kind: 'digest_mismatch',
+          path: '/terms_digest',
+          message: 'proposal terms_digest does not match commercial_terms',
+        },
+      ],
+    };
+  }
+
+  let adcpVersion: string;
+  try {
+    adcpVersion = options.adcpVersion ?? ADCP_VERSION;
+  } catch {
+    return schemaUnavailableResult();
+  }
+  let document: ReturnType<typeof getSchemaDocumentByRef>;
+  let validator: ReturnType<typeof getSchemaValidatorByRef>;
+  try {
+    document = getSchemaDocumentByRef('media-buy/commercial-terms.json', adcpVersion);
+    validator = getSchemaValidatorByRef('media-buy/commercial-terms.json', adcpVersion);
+  } catch {
+    return schemaUnavailableResult();
+  }
+  if (!document || !validator) {
+    return schemaUnavailableResult();
+  }
+
+  const schemaVersion = document.resolvedVersion;
+  const schemaProperties = isRecord(document.schema.properties) ? document.schema.properties : undefined;
+  if (!schemaProperties || document.schema.additionalProperties !== false) {
+    return {
+      ok: false,
+      schemaVersion,
+      mismatches: [
+        {
+          kind: 'unsupported_schema',
+          path: '/commercial_terms',
+          message: 'commercial-terms schema must declare a closed properties object for exhaustive comparison',
+        },
+      ],
+    };
+  }
+  let changeTermSchema: Readonly<Record<string, unknown>> | undefined;
+  if (Object.hasOwn(schemaProperties, 'change_terms')) {
+    try {
+      changeTermSchema = getSchemaDocumentByRef('media-buy/change-term.json', adcpVersion)?.schema;
+    } catch {
+      return schemaUnavailableResult();
+    }
+    if (!changeTermSchema) return schemaUnavailableResult();
+  }
+
+  let expectedCanonical: string;
+  try {
+    const complexityError = commercialTermsComplexityError(expectedCommercialTerms);
+    if (complexityError) return invalidTermsResult('expected', '/commercial_terms', complexityError, schemaVersion);
+    const expectedTerms = structuredClone(expectedCommercialTerms);
+    expectedCanonical = canonicalProposalTerms(expectedTerms);
+    if (Buffer.byteLength(expectedCanonical, 'utf8') > MAX_COMMERCIAL_TERMS_BYTES) {
+      return invalidTermsResult(
+        'expected',
+        '/commercial_terms',
+        'expected commercial terms exceed 256 KiB',
+        schemaVersion
+      );
+    }
+  } catch {
+    return invalidTermsResult(
+      'expected',
+      '/commercial_terms',
+      'expected commercial terms cannot be canonicalized',
+      schemaVersion
+    );
+  }
+
+  const actual = JSON.parse(actualCanonical) as unknown;
+  const expected = JSON.parse(expectedCanonical) as unknown;
+  if (!validator(actual)) {
+    const error = validator.errors?.[0];
+    return invalidTermsResult(
+      'proposal',
+      schemaValidationPointer(error),
+      `proposal commercial terms do not satisfy AdCP ${schemaVersion}${error?.message ? `: ${error.message}` : ''}`,
+      schemaVersion,
+      error?.keyword
+    );
+  }
+  if (!validator(expected)) {
+    const error = validator.errors?.[0];
+    return invalidTermsResult(
+      'expected',
+      schemaValidationPointer(error),
+      `expected commercial terms do not satisfy AdCP ${schemaVersion}${error?.message ? `: ${error.message}` : ''}`,
+      schemaVersion,
+      error?.keyword
+    );
+  }
+
+  if (!isRecord(actual) || !isRecord(expected)) {
+    return invalidTermsResult('proposal', '/commercial_terms', 'commercial terms must be objects', schemaVersion);
+  }
+
+  const semanticSupportError = commercialTermsSemanticSupportError(document.schema, changeTermSchema);
+  if (semanticSupportError) {
+    return {
+      ok: false,
+      schemaVersion,
+      mismatches: [
+        {
+          kind: 'unsupported_schema',
+          path: '/commercial_terms',
+          message: semanticSupportError,
+        },
+      ],
+    };
+  }
+  const actualSemanticIssues = validateCommercialTermsSemantics(actual, document.schema, changeTermSchema);
+  if (actualSemanticIssues.length > 0) {
+    const truncated = actualSemanticIssues.length > MAX_COMMERCIAL_TERMS_MISMATCHES;
+    return {
+      ok: false,
+      schemaVersion,
+      ...(truncated && { truncated: true }),
+      mismatches: actualSemanticIssues.slice(0, MAX_COMMERCIAL_TERMS_MISMATCHES).map(issue => ({
+        kind: 'invalid_terms',
+        subject: 'proposal',
+        keyword: 'x-adcp-validation',
+        ...issue,
+      })),
+    };
+  }
+  const expectedSemanticIssues = validateCommercialTermsSemantics(expected, document.schema, changeTermSchema);
+  if (expectedSemanticIssues.length > 0) {
+    const truncated = expectedSemanticIssues.length > MAX_COMMERCIAL_TERMS_MISMATCHES;
+    return {
+      ok: false,
+      schemaVersion,
+      ...(truncated && { truncated: true }),
+      mismatches: expectedSemanticIssues.slice(0, MAX_COMMERCIAL_TERMS_MISMATCHES).map(issue => ({
+        kind: 'invalid_terms',
+        subject: 'expected',
+        keyword: 'x-adcp-validation',
+        ...issue,
+      })),
+    };
+  }
+
+  // Derive the exhaustive top-level comparison allowlist from the selected
+  // schema. Nested values are recursively compared in full after AJV has
+  // proved that both trees satisfy the same schema bundle.
+  const comparisonFields = new Set([...Object.keys(actual), ...Object.keys(expected)]);
+  const mismatchState = { truncated: false, diagnosticBytes: 0 };
+  for (const field of [...comparisonFields].sort()) {
+    const actualHas = Object.hasOwn(actual, field);
+    const expectedHas = Object.hasOwn(expected, field);
+    diffCommercialTerm(
+      actual[field],
+      expected[field],
+      `/commercial_terms/${escapeJsonPointer(field)}`,
+      mismatches,
+      mismatchState,
+      { actualHas, expectedHas }
+    );
+    if (mismatchState.truncated) break;
+  }
+
+  return {
+    ok: mismatches.length === 0 && !mismatchState.truncated,
+    schemaVersion,
+    ...(mismatchState.truncated && { truncated: true }),
+    mismatches,
+  };
+}
+
+export function assertProposalCommercialTerms(
+  proposal: unknown,
+  expectedCommercialTerms: unknown,
+  options: VerifyProposalCommercialTermsOptions = {}
+): void {
+  const result = verifyProposalCommercialTerms(proposal, expectedCommercialTerms, options);
+  if (!result.ok) throw new ProposalCommercialTermsVerificationError(result.mismatches, result.truncated);
 }
 
 /** Strict RFC 3339 date-time accepted by the AdCP `format: date-time` contract. */
@@ -999,6 +1253,429 @@ function allowedKeys(
     if (!allowed.has(key)) valid = shape(issues, `${path}.${key}`, `${key} is not allowed`);
   }
   return valid;
+}
+
+function invalidTermsResult(
+  subject: 'proposal' | 'expected',
+  path: string,
+  message: string,
+  schemaVersion?: string,
+  keyword?: string
+): ProposalCommercialTermsVerificationResult {
+  if (Buffer.byteLength(path, 'utf8') + Buffer.byteLength(message, 'utf8') > MAX_COMMERCIAL_TERMS_DIAGNOSTIC_BYTES) {
+    return {
+      ok: false,
+      ...(schemaVersion && { schemaVersion }),
+      truncated: true,
+      mismatches: [],
+    };
+  }
+  return {
+    ok: false,
+    ...(schemaVersion && { schemaVersion }),
+    mismatches: [
+      {
+        kind: 'invalid_terms',
+        subject,
+        path,
+        ...(keyword && { keyword }),
+        message,
+      },
+    ],
+  };
+}
+
+function schemaUnavailableResult(): ProposalCommercialTermsVerificationResult {
+  return {
+    ok: false,
+    mismatches: [
+      {
+        kind: 'schema_unavailable',
+        path: '/commercial_terms',
+        message: 'the selected AdCP commercial-terms schema is unavailable',
+      },
+    ],
+  };
+}
+
+function commercialTermsComplexityError(value: unknown): string | undefined {
+  const stack: Array<{ value: unknown; depth: number; leaving?: boolean }> = [{ value, depth: 0 }];
+  const activeAncestors = new WeakSet<object>();
+  let nodes = 0;
+  let arraySlots = 0;
+  let stringBytes = 0;
+
+  while (stack.length > 0) {
+    const current = stack.pop()!;
+    if (current.leaving) {
+      if (current.value !== null && typeof current.value === 'object') activeAncestors.delete(current.value);
+      continue;
+    }
+    nodes++;
+    if (nodes > MAX_COMMERCIAL_TERMS_NODES) return 'commercial terms exceed the 50,000-node complexity limit';
+    if (current.depth > MAX_JSON_DEPTH) {
+      return `commercial terms exceed the maximum JSON depth of ${MAX_JSON_DEPTH}`;
+    }
+    const valueType = typeof current.value;
+    if (
+      valueType === 'undefined' ||
+      valueType === 'function' ||
+      valueType === 'symbol' ||
+      valueType === 'bigint' ||
+      (valueType === 'number' && !Number.isFinite(current.value))
+    ) {
+      return 'commercial terms must contain JSON values only';
+    }
+    if (typeof current.value === 'string') {
+      stringBytes += Buffer.byteLength(current.value, 'utf8');
+      if (stringBytes > MAX_COMMERCIAL_TERMS_BYTES) return 'commercial terms exceed 256 KiB';
+      continue;
+    }
+    if (current.value === null || typeof current.value !== 'object') continue;
+    const prototype = Object.getPrototypeOf(current.value);
+    if (!Array.isArray(current.value) && prototype !== null && prototype !== Object.prototype) {
+      return 'commercial terms must contain JSON values only';
+    }
+    if (activeAncestors.has(current.value)) return 'commercial terms must not contain cyclic references';
+    activeAncestors.add(current.value);
+    stack.push({ value: current.value, depth: current.depth, leaving: true });
+    if (Array.isArray(current.value)) {
+      arraySlots += current.value.length;
+      if (arraySlots > MAX_COMMERCIAL_TERMS_NODES) {
+        return 'commercial terms exceed the 50,000-node complexity limit';
+      }
+    }
+
+    const descriptors = Object.getOwnPropertyDescriptors(current.value);
+    for (const [key, descriptor] of Object.entries(descriptors)) {
+      if (!descriptor.enumerable) continue;
+      if (!('value' in descriptor)) return 'commercial terms must contain data properties only';
+      stringBytes += Buffer.byteLength(key, 'utf8');
+      if (stringBytes > MAX_COMMERCIAL_TERMS_BYTES) return 'commercial terms exceed 256 KiB';
+      stack.push({ value: descriptor.value, depth: current.depth + 1 });
+    }
+  }
+  return undefined;
+}
+
+const PRICING_INTEGRITY_CONSTRAINTS = {
+  pricing_option_ids: 'each_purchase.pricing_option_id_equals_pricing.pricing_option_id',
+  purchase_currencies: 'all_purchase.pricing.currency_equal',
+  total_budget_currency: 'when_total_budget_present_equals_purchase_pricing_currency',
+  monetary_fields: 'purchase_budget_min_spend_and_bidding_use_purchase_pricing_currency',
+  on_violation: 'reject_proposal_or_commitment',
+} as const;
+
+function commercialTermsSemanticSupportError(
+  schema: Readonly<Record<string, unknown>>,
+  changeTermSchema: Readonly<Record<string, unknown>> | undefined
+): string | undefined {
+  const validation = schema['x-adcp-validation'];
+  if (validation !== undefined) {
+    if (!isRecord(validation)) return 'commercial-terms x-adcp-validation metadata must be an object';
+    const constraints = validation.verifier_constraints;
+    if (constraints !== undefined) {
+      if (!isRecord(constraints)) return 'commercial-terms verifier_constraints metadata must be an object';
+      const constraintKeys = Object.keys(constraints);
+      if (constraintKeys.some(key => key !== 'pricing_integrity')) {
+        return 'commercial-terms schema declares verifier constraints this SDK does not understand';
+      }
+      if (constraints.pricing_integrity !== undefined) {
+        if (!isRecord(constraints.pricing_integrity)) {
+          return 'commercial-terms pricing_integrity metadata must be an object';
+        }
+        const actual = constraints.pricing_integrity;
+        const expectedKeys = Object.keys(PRICING_INTEGRITY_CONSTRAINTS);
+        if (
+          Object.keys(actual).length !== expectedKeys.length ||
+          expectedKeys.some(
+            key => actual[key] !== PRICING_INTEGRITY_CONSTRAINTS[key as keyof typeof PRICING_INTEGRITY_CONSTRAINTS]
+          )
+        ) {
+          return 'commercial-terms schema declares unsupported pricing_integrity constraints';
+        }
+      }
+    }
+  }
+
+  const properties = schema.properties;
+  if (!isRecord(properties)) return undefined;
+  const changeTermsProperty = properties.change_terms;
+  if (!isRecord(changeTermsProperty)) return undefined;
+  const changeTermsValidation = changeTermsProperty['x-adcp-validation'];
+  if (changeTermsValidation !== undefined) {
+    if (
+      !isRecord(changeTermsValidation) ||
+      Object.keys(changeTermsValidation).length !== 1 ||
+      changeTermsValidation.unique_by !== 'action'
+    ) {
+      return 'commercial-terms schema declares unsupported change_terms validation metadata';
+    }
+  }
+  if (!changeTermSchema) return 'commercial-terms schema is missing its change-term schema';
+  return changeTermSemanticSupportError(changeTermSchema);
+}
+
+function validateCommercialTermsSemantics(
+  terms: Record<string, unknown>,
+  schema: Readonly<Record<string, unknown>>,
+  changeTermSchema: Readonly<Record<string, unknown>> | undefined
+): Array<{ path: string; message: string }> {
+  const validation = schema['x-adcp-validation'];
+  const pricingIntegrityEnabled =
+    isRecord(validation) &&
+    isRecord(validation.verifier_constraints) &&
+    isRecord(validation.verifier_constraints.pricing_integrity);
+
+  const issues: Array<{ path: string; message: string }> = [];
+  if (!Array.isArray(terms.purchases)) return issues;
+  let purchaseCurrency: string | undefined;
+  for (const [index, purchase] of terms.purchases.entries()) {
+    if (!isRecord(purchase) || !isRecord(purchase.pricing)) continue;
+    const pricing = purchase.pricing;
+    if (pricingIntegrityEnabled && purchase.pricing_option_id !== pricing.pricing_option_id) {
+      issues.push({
+        path: `/commercial_terms/purchases/${index}/pricing/pricing_option_id`,
+        message: 'pricing pricing_option_id must match the purchase pricing_option_id',
+      });
+      if (issues.length > MAX_COMMERCIAL_TERMS_MISMATCHES) return issues;
+    }
+    const currency = pricing.currency as string;
+    purchaseCurrency ??= currency;
+    if (pricingIntegrityEnabled && currency !== purchaseCurrency) {
+      issues.push({
+        path: `/commercial_terms/purchases/${index}/pricing/currency`,
+        message: 'every purchase pricing currency must be identical',
+      });
+      if (issues.length > MAX_COMMERCIAL_TERMS_MISMATCHES) return issues;
+    }
+  }
+  if (
+    pricingIntegrityEnabled &&
+    purchaseCurrency !== undefined &&
+    isRecord(terms.total_budget) &&
+    terms.total_budget.currency !== purchaseCurrency
+  ) {
+    issues.push({
+      path: '/commercial_terms/total_budget/currency',
+      message: 'total budget currency must equal purchase currency',
+    });
+  }
+  if (changeTermSchema && Array.isArray(terms.change_terms)) {
+    validateChangeTermSemantics(terms.change_terms, purchaseCurrency, issues);
+  }
+  return issues;
+}
+
+function changeTermSemanticSupportError(schema: Readonly<Record<string, unknown>>): string | undefined {
+  const validation = schema['x-adcp-validation'];
+  if (!isRecord(validation) || !isRecord(validation.verifier_constraints)) {
+    return 'change-term schema is missing verifier constraint metadata';
+  }
+  const constraints = validation.verifier_constraints;
+  const expectedKeys = new Set([
+    'allowed_statuses',
+    'constraint_action_compatibility',
+    'constraint_currency',
+    'constraint_consistency',
+  ]);
+  if (
+    Object.keys(constraints).length !== expectedKeys.size ||
+    Object.keys(constraints).some(key => !expectedKeys.has(key))
+  ) {
+    return 'change-term schema declares verifier constraints this SDK does not understand';
+  }
+  if (
+    constraints.allowed_statuses !==
+      'Every value is a non-terminal MediaBuy status. The current buy projection omits the action outside these statuses without extinguishing the negotiated right.' ||
+    constraints.constraint_currency !==
+      'Every monetary constraint currency equals the commercial terms purchase currency.' ||
+    constraints.constraint_consistency !==
+      'Minimum result does not exceed maximum result; earliest timestamp does not exceed latest timestamp.'
+  ) {
+    return 'change-term schema declares unsupported verifier constraint semantics';
+  }
+  const compatibility = constraints.constraint_action_compatibility;
+  if (!isRecord(compatibility) || compatibility.on_violation !== 'reject_proposal') {
+    return 'change-term schema declares unsupported action compatibility metadata';
+  }
+  for (const [kind, actions] of Object.entries(CHANGE_TERM_ACTIONS_BY_CONSTRAINT)) {
+    const declared = compatibility[kind];
+    if (
+      !Array.isArray(declared) ||
+      declared.length !== actions.size ||
+      declared.some(action => typeof action !== 'string' || !actions.has(action))
+    ) {
+      return 'change-term schema declares unsupported action compatibility metadata';
+    }
+  }
+  if (Object.keys(compatibility).some(key => key !== 'on_violation' && !(key in CHANGE_TERM_ACTIONS_BY_CONSTRAINT))) {
+    return 'change-term schema declares unsupported action compatibility metadata';
+  }
+  return undefined;
+}
+
+function validateChangeTermSemantics(
+  terms: unknown[],
+  purchaseCurrency: string | undefined,
+  issues: Array<{ path: string; message: string }>
+): void {
+  const actions = new Set<string>();
+  for (const [index, value] of terms.entries()) {
+    if (!isRecord(value)) continue;
+    const path = `/commercial_terms/change_terms/${index}`;
+    const action = value.action;
+    if (typeof action === 'string') {
+      if (actions.has(action)) {
+        issues.push({ path: `${path}/action`, message: 'change term actions must be unique' });
+      }
+      actions.add(action);
+    }
+    if (!isRecord(value.constraints)) continue;
+    const constraints = value.constraints;
+    const kind = constraints.kind as keyof typeof CHANGE_TERM_ACTIONS_BY_CONSTRAINT;
+    if (typeof action === 'string' && !CHANGE_TERM_ACTIONS_BY_CONSTRAINT[kind]?.has(action)) {
+      issues.push({
+        path: `${path}/constraints/kind`,
+        message: `${String(kind)} constraints are not compatible with action ${action}`,
+      });
+    }
+    for (const key of ['max_delta_amount', 'min_result_amount', 'max_result_amount'] as const) {
+      const money = constraints[key];
+      if (purchaseCurrency !== undefined && isRecord(money) && money.currency !== purchaseCurrency) {
+        issues.push({
+          path: `${path}/constraints/${key}/currency`,
+          message: `constraint currency must equal ${purchaseCurrency}`,
+        });
+      }
+    }
+    const minimum = constraints.min_result_amount;
+    const maximum = constraints.max_result_amount;
+    if (isRecord(minimum) && isRecord(maximum) && minimum.amount > maximum.amount) {
+      issues.push({
+        path: `${path}/constraints`,
+        message: 'minimum result amount must not exceed maximum result amount',
+      });
+    }
+    for (const [earliestKey, latestKey] of [
+      ['earliest_result', 'latest_result'],
+      ['earliest_effective_at', 'latest_effective_at'],
+    ] as const) {
+      if (
+        typeof constraints[earliestKey] === 'string' &&
+        typeof constraints[latestKey] === 'string' &&
+        Date.parse(constraints[earliestKey]) > Date.parse(constraints[latestKey])
+      ) {
+        issues.push({
+          path: `${path}/constraints`,
+          message: `${earliestKey} must not be later than ${latestKey}`,
+        });
+      }
+    }
+    if (issues.length > MAX_COMMERCIAL_TERMS_MISMATCHES) return;
+  }
+}
+
+function diffCommercialTerm(
+  actual: unknown,
+  expected: unknown,
+  path: string,
+  mismatches: ProposalCommercialTermsMismatch[],
+  state: { truncated: boolean; diagnosticBytes: number },
+  presence: { actualHas: boolean; expectedHas: boolean } = { actualHas: true, expectedHas: true }
+): void {
+  if (state.truncated) return;
+  if (!presence.actualHas) {
+    pushCommercialTermsMismatch(mismatches, state, {
+      kind: 'missing',
+      path,
+      message: 'proposal is missing a reviewed commercial term',
+    });
+    return;
+  }
+  if (!presence.expectedHas) {
+    pushCommercialTermsMismatch(mismatches, state, {
+      kind: 'unexpected',
+      path,
+      message: 'proposal contains an unreviewed commercial term',
+    });
+    return;
+  }
+  if (Object.is(actual, expected)) return;
+
+  if (Array.isArray(actual) && Array.isArray(expected)) {
+    const length = Math.max(actual.length, expected.length);
+    for (let index = 0; index < length; index++) {
+      diffCommercialTerm(actual[index], expected[index], `${path}/${index}`, mismatches, state, {
+        actualHas: index < actual.length,
+        expectedHas: index < expected.length,
+      });
+    }
+    return;
+  }
+
+  if (isRecord(actual) && isRecord(expected)) {
+    const keys = new Set([...Object.keys(actual), ...Object.keys(expected)]);
+    for (const key of [...keys].sort()) {
+      diffCommercialTerm(actual[key], expected[key], `${path}/${escapeJsonPointer(key)}`, mismatches, state, {
+        actualHas: Object.hasOwn(actual, key),
+        expectedHas: Object.hasOwn(expected, key),
+      });
+    }
+    return;
+  }
+
+  pushCommercialTermsMismatch(mismatches, state, {
+    kind: 'changed',
+    path,
+    message: 'proposal changed a reviewed commercial term',
+  });
+}
+
+function pushCommercialTermsMismatch(
+  mismatches: ProposalCommercialTermsMismatch[],
+  state: { truncated: boolean; diagnosticBytes: number },
+  mismatch: ProposalCommercialTermsMismatch
+): void {
+  const diagnosticBytes = Buffer.byteLength(mismatch.path, 'utf8') + Buffer.byteLength(mismatch.message, 'utf8');
+  if (
+    mismatches.length >= MAX_COMMERCIAL_TERMS_MISMATCHES ||
+    state.diagnosticBytes + diagnosticBytes > MAX_COMMERCIAL_TERMS_DIAGNOSTIC_BYTES
+  ) {
+    state.truncated = true;
+    return;
+  }
+  state.diagnosticBytes += diagnosticBytes;
+  mismatches.push(mismatch);
+}
+
+function schemaValidationPointer(
+  error:
+    | {
+        instancePath?: string;
+        keyword?: string;
+        params?: Record<string, unknown>;
+      }
+    | null
+    | undefined
+): string {
+  let pointer = `/commercial_terms${error?.instancePath ?? ''}`;
+  const field =
+    error?.keyword === 'required'
+      ? error.params?.missingProperty
+      : error?.keyword === 'additionalProperties'
+        ? error.params?.additionalProperty
+        : undefined;
+  if (typeof field === 'string') pointer += `/${escapeJsonPointer(field)}`;
+  return pointer;
+}
+
+function escapeJsonPointer(value: string): string {
+  return value.replaceAll('~', '~0').replaceAll('/', '~1');
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 /** Canonicalize once so validation and hashing observe the exact same bytes, including accessor-backed input. */

--- a/src/lib/negotiation/verification.ts
+++ b/src/lib/negotiation/verification.ts
@@ -1674,10 +1674,6 @@ function escapeJsonPointer(value: string): string {
   return value.replaceAll('~', '~0').replaceAll('/', '~1');
 }
 
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
-
 /** Canonicalize once so validation and hashing observe the exact same bytes, including accessor-backed input. */
 function canonicalProposalTerms(value: unknown): string {
   const canonical = canonicalize(value);

--- a/src/lib/validation/schema-loader.ts
+++ b/src/lib/validation/schema-loader.ts
@@ -863,6 +863,16 @@ export interface ResolvedToolSchemaDocument {
   schema: Readonly<Record<string, unknown>>;
 }
 
+export interface ResolvedSchemaDocument {
+  schemaRef: string;
+  requestedVersion: string;
+  /** Loader key used to select the installed schema bundle. */
+  bundleKey: string;
+  /** Exact protocol release recorded by the resolved bundle, when available. */
+  resolvedVersion: string;
+  schema: Readonly<Record<string, unknown>>;
+}
+
 /**
  * Return an unmodified tool JSON Schema from the same version-aware bundle
  * resolver used by runtime validation. Unlike `getValidator().schema`, response
@@ -893,6 +903,41 @@ export function getToolSchemaDocument(
     bundleKey: state.version,
     resolvedVersion,
     schema,
+  };
+}
+
+/**
+ * Return an unmodified JSON Schema fragment from the selected AdCP bundle.
+ *
+ * This is the document counterpart to {@link getSchemaValidatorByRef}. It is
+ * intended for SDK features whose behavior must be derived from protocol
+ * metadata rather than from a second, hand-maintained field list.
+ */
+export function getSchemaDocumentByRef(
+  schemaRef: string,
+  version: string = ADCP_VERSION
+): ResolvedSchemaDocument | undefined {
+  const state = ensureInit(version);
+  const normalized = normalizeSchemaRef(schemaRef);
+  if (!normalized) return undefined;
+  const file = path.join(state.root, normalized);
+  if (!existsSync(file)) return undefined;
+
+  let resolvedVersion = state.version;
+  try {
+    const index = loadJson(path.join(state.root, 'index.json')) as Record<string, unknown>;
+    if (typeof index.adcp_version === 'string') resolvedVersion = index.adcp_version;
+  } catch {
+    // Legacy/external bundles may omit index.json; the loader key remains an
+    // accurate identifier for the selected schema directory.
+  }
+
+  return {
+    schemaRef: normalized,
+    requestedVersion: version,
+    bundleKey: state.version,
+    resolvedVersion,
+    schema: loadJson(file),
   };
 }
 

--- a/test/lib/proposal-negotiation-validation.test.js
+++ b/test/lib/proposal-negotiation-validation.test.js
@@ -1,17 +1,25 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 const {
   ProposalNegotiator,
+  ProposalCommercialTermsVerificationError,
   ProposalRefinementValidationError,
+  assertProposalCommercialTerms,
   buildRefineProposalsRequest,
   canonicalize,
   extractProposalRefinementSupport,
   proposalTermsDigest,
   validateRefineProposalsRequest,
   validateRefineProposalsResponseShape,
+  verifyProposalCommercialTerms,
   verifyRefineProposalsResponse,
 } = require('../../dist/lib/index.js');
+const { withExternalSchemaRoot } = require('../../dist/lib/validation/schema-loader.js');
+const { ADCP_VERSION } = require('../../dist/lib/version.js');
 
 const KEY = 'refine-validation-0001';
 
@@ -68,6 +76,408 @@ function response(proposals = [proposal()]) {
 function shapeIssues(req, payload) {
   return verifyRefineProposalsResponse(req, payload).issues.filter(issue => issue.code === 'shape');
 }
+
+function clone(value) {
+  return structuredClone(value);
+}
+
+test('commercial-terms verifier accepts a digest-bound exact reviewed snapshot', () => {
+  const terms = commercialTerms({
+    purchase_order_ref: 'PO-2027-001',
+    change_terms: [
+      {
+        term_id: 'term-budget-1',
+        action: 'increase_budget',
+        service_mode: 'self_serve',
+        constraints: { kind: 'budget', max_delta_amount: { amount: 1000, currency: 'USD' } },
+        terms_ref: 'contract-2027-001',
+      },
+    ],
+  });
+  const result = verifyProposalCommercialTerms(
+    proposal('proposal-terms', 'source-1', { commercial_terms: terms }),
+    terms,
+    { adcpVersion: '3.2-beta.9' }
+  );
+
+  assert.equal(result.ok, true);
+  assert.equal(result.schemaVersion, ADCP_VERSION);
+  assert.deepEqual(result.mismatches, []);
+  assert.doesNotThrow(() =>
+    assertProposalCommercialTerms(proposal('proposal-terms', 'source-1', { commercial_terms: terms }), terms)
+  );
+});
+
+test('commercial-terms verifier checks terms_digest before producing field comparisons', () => {
+  const reviewed = commercialTerms();
+  const offered = commercialTerms({ total_budget: { amount: 9000, currency: 'USD' } });
+  const tampered = proposal('proposal-tampered', 'source-1', {
+    commercial_terms: offered,
+    terms_digest: proposalTermsDigest(reviewed),
+  });
+
+  const result = verifyProposalCommercialTerms(tampered, reviewed);
+  assert.equal(result.ok, false);
+  assert.deepEqual(result.mismatches, [
+    {
+      kind: 'digest_mismatch',
+      path: '/terms_digest',
+      message: 'proposal terms_digest does not match commercial_terms',
+    },
+  ]);
+});
+
+test('commercial-terms verifier enforces schema-declared pricing integrity', () => {
+  const pricingIdentity = commercialTerms();
+  pricingIdentity.purchases[0].pricing.pricing_option_id = 'different-price';
+
+  const mixedCurrencies = commercialTerms();
+  mixedCurrencies.purchases.push({
+    ...clone(mixedCurrencies.purchases[0]),
+    product_id: 'product-2',
+    pricing_option_id: 'price-2',
+    pricing: {
+      ...clone(mixedCurrencies.purchases[0].pricing),
+      pricing_option_id: 'price-2',
+      currency: 'EUR',
+    },
+  });
+
+  const budgetCurrency = commercialTerms({ total_budget: { amount: 8000, currency: 'GBP' } });
+  for (const [terms, expectedPath] of [
+    [pricingIdentity, '/commercial_terms/purchases/0/pricing/pricing_option_id'],
+    [mixedCurrencies, '/commercial_terms/purchases/1/pricing/currency'],
+    [budgetCurrency, '/commercial_terms/total_budget/currency'],
+  ]) {
+    const result = verifyProposalCommercialTerms(
+      proposal('proposal-invalid-pricing', 'source-1', { commercial_terms: terms }),
+      terms
+    );
+    assert.equal(result.ok, false);
+    assert.equal(result.mismatches[0].kind, 'invalid_terms');
+    assert.equal(result.mismatches[0].keyword, 'x-adcp-validation');
+    assert.equal(result.mismatches[0].path, expectedPath);
+  }
+});
+
+test('commercial-terms verifier enforces schema-declared change-term invariants', () => {
+  const duplicateActions = commercialTerms({
+    change_terms: [
+      { term_id: 'pause-1', action: 'pause', service_mode: 'self_serve' },
+      { term_id: 'pause-2', action: 'pause', service_mode: 'seller_managed' },
+    ],
+  });
+  const incompatibleKind = commercialTerms({
+    change_terms: [
+      {
+        term_id: 'pause-budget',
+        action: 'pause',
+        service_mode: 'self_serve',
+        constraints: { kind: 'budget', max_delta_amount: { amount: 100, currency: 'USD' } },
+      },
+    ],
+  });
+  const wrongCurrency = commercialTerms({
+    change_terms: [
+      {
+        term_id: 'increase-eur',
+        action: 'increase_budget',
+        service_mode: 'self_serve',
+        constraints: { kind: 'budget', max_delta_amount: { amount: 100, currency: 'EUR' } },
+      },
+    ],
+  });
+  const inconsistentRange = commercialTerms({
+    change_terms: [
+      {
+        term_id: 'increase-range',
+        action: 'increase_budget',
+        service_mode: 'self_serve',
+        constraints: {
+          kind: 'budget',
+          min_result_amount: { amount: 1000, currency: 'USD' },
+          max_result_amount: { amount: 500, currency: 'USD' },
+        },
+      },
+    ],
+  });
+
+  for (const [terms, expectedPath] of [
+    [duplicateActions, '/commercial_terms/change_terms/1/action'],
+    [incompatibleKind, '/commercial_terms/change_terms/0/constraints/kind'],
+    [wrongCurrency, '/commercial_terms/change_terms/0/constraints/max_delta_amount/currency'],
+    [inconsistentRange, '/commercial_terms/change_terms/0/constraints'],
+  ]) {
+    const result = verifyProposalCommercialTerms(
+      proposal('proposal-invalid-change-term', 'source-1', { commercial_terms: terms }),
+      terms
+    );
+    assert.equal(result.ok, false);
+    assert.equal(result.mismatches[0].kind, 'invalid_terms');
+    assert.equal(result.mismatches[0].keyword, 'x-adcp-validation');
+    assert.equal(result.mismatches[0].path, expectedPath);
+  }
+});
+
+test('commercial-terms verifier recursively reports binding changes with JSON Pointer paths', () => {
+  const reviewed = commercialTerms({
+    purchase_order_ref: 'PO-ORIGINAL',
+    change_terms: [
+      {
+        term_id: 'term-flight-1',
+        action: 'extend_flight',
+        service_mode: 'self_serve',
+        allowed_statuses: ['active'],
+        terms_ref: 'contract-original',
+      },
+    ],
+  });
+  const offered = clone(reviewed);
+  offered.purchases[0].pricing.fixed_price = 9;
+  offered.purchases[0].product_id = 'product-2';
+  offered.end_time = '2027-03-01T00:00:00Z';
+  offered.total_budget.amount = 9000;
+  offered.purchase_order_ref = 'PO-CHANGED';
+  offered.change_terms[0].service_mode = 'seller_managed';
+  offered.change_terms[0].terms_ref = 'contract-changed';
+
+  const result = verifyProposalCommercialTerms(
+    proposal('proposal-changed', 'source-1', { commercial_terms: offered }),
+    reviewed
+  );
+  assert.equal(result.ok, false);
+  assert.deepEqual(
+    result.mismatches.map(mismatch => [mismatch.kind, mismatch.path]),
+    [
+      ['changed', '/commercial_terms/change_terms/0/service_mode'],
+      ['changed', '/commercial_terms/change_terms/0/terms_ref'],
+      ['changed', '/commercial_terms/end_time'],
+      ['changed', '/commercial_terms/purchase_order_ref'],
+      ['changed', '/commercial_terms/purchases/0/pricing/fixed_price'],
+      ['changed', '/commercial_terms/purchases/0/product_id'],
+      ['changed', '/commercial_terms/total_budget/amount'],
+    ]
+  );
+  assert.throws(
+    () =>
+      assertProposalCommercialTerms(proposal('proposal-changed', 'source-1', { commercial_terms: offered }), reviewed),
+    ProposalCommercialTermsVerificationError
+  );
+});
+
+test('commercial-terms verifier rejects fields outside the selected schema', () => {
+  const terms = commercialTerms({ unrecognized_binding: 'must-not-pass' });
+  const result = verifyProposalCommercialTerms(
+    proposal('proposal-unknown', 'source-1', { commercial_terms: terms }),
+    terms
+  );
+
+  assert.equal(result.ok, false);
+  assert.deepEqual(
+    result.mismatches.map(({ kind, subject, path, keyword }) => ({ kind, subject, path, keyword })),
+    [
+      {
+        kind: 'invalid_terms',
+        subject: 'proposal',
+        path: '/commercial_terms/unrecognized_binding',
+        keyword: 'additionalProperties',
+      },
+    ]
+  );
+});
+
+test('commercial-terms verifier derives newly added binding fields from the selected bundle', () => {
+  const schemaRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'adcp-commercial-terms-schema-'));
+  try {
+    const mediaBuyDir = path.join(schemaRoot, 'media-buy');
+    fs.mkdirSync(mediaBuyDir, { recursive: true });
+    fs.writeFileSync(path.join(schemaRoot, 'index.json'), JSON.stringify({ adcp_version: ADCP_VERSION }));
+    fs.writeFileSync(
+      path.join(mediaBuyDir, 'commercial-terms.json'),
+      JSON.stringify({
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        $id: `https://adcontextprotocol.org/schemas/${ADCP_VERSION}/media-buy/commercial-terms.json`,
+        type: 'object',
+        properties: {
+          brand: { type: 'object' },
+          purchases: { type: 'array', minItems: 1 },
+          start_time: { type: 'string' },
+          end_time: { type: 'string' },
+          future_binding: { type: 'string' },
+        },
+        patternProperties: { '^x_': { type: 'string' } },
+        required: ['brand', 'purchases', 'start_time', 'end_time'],
+        additionalProperties: false,
+      })
+    );
+    const reviewed = {
+      brand: { domain: 'buyer.example' },
+      purchases: [{}],
+      start_time: 'asap',
+      end_time: '2027-02-01T00:00:00Z',
+    };
+    const offered = {
+      ...reviewed,
+      future_binding: 'new-contract-value',
+      x_dynamic_binding: 'pattern-contract-value',
+    };
+    const result = withExternalSchemaRoot(ADCP_VERSION, schemaRoot, () =>
+      verifyProposalCommercialTerms(
+        { commercial_terms: offered, terms_digest: proposalTermsDigest(offered) },
+        reviewed,
+        { adcpVersion: ADCP_VERSION }
+      )
+    );
+
+    assert.equal(result.ok, false);
+    assert.deepEqual(
+      result.mismatches.map(({ kind, path }) => ({ kind, path })),
+      [
+        { kind: 'unexpected', path: '/commercial_terms/future_binding' },
+        { kind: 'unexpected', path: '/commercial_terms/x_dynamic_binding' },
+      ]
+    );
+  } finally {
+    fs.rmSync(schemaRoot, { recursive: true, force: true });
+  }
+});
+
+test('commercial-terms verifier fails closed when the requested schema bundle is unavailable', () => {
+  const terms = commercialTerms();
+  const result = verifyProposalCommercialTerms(
+    proposal('proposal-version', 'source-1', { commercial_terms: terms }),
+    terms,
+    {
+      adcpVersion: '3.2.0-beta.999',
+    }
+  );
+  assert.equal(result.ok, false);
+  assert.equal(result.mismatches[0].kind, 'schema_unavailable');
+  assert.equal(result.mismatches[0].message, 'the selected AdCP commercial-terms schema is unavailable');
+});
+
+test('commercial-terms verifier caps mismatch diagnostics', () => {
+  const reviewed = commercialTerms();
+  reviewed.purchases[0].ext = { vendor: {} };
+  const offered = clone(reviewed);
+  for (let index = 0; index < 101; index++) {
+    reviewed.purchases[0].ext.vendor[`field_${index}`] = `reviewed_${index}`;
+    offered.purchases[0].ext.vendor[`field_${index}`] = `offered_${index}`;
+  }
+
+  const result = verifyProposalCommercialTerms(
+    proposal('proposal-many-differences', 'source-1', { commercial_terms: offered }),
+    reviewed
+  );
+  assert.equal(result.ok, false);
+  assert.equal(result.truncated, true);
+  assert.equal(result.mismatches.length, 100);
+});
+
+test('commercial-terms verifier rejects oversized and accessor-backed trees before canonicalization', () => {
+  const oversized = commercialTerms();
+  oversized.purchases[0].ext = { vendor: { payload: 'x'.repeat(256 * 1024 + 1) } };
+  const oversizedResult = verifyProposalCommercialTerms(
+    { commercial_terms: oversized, terms_digest: 'sha256:unchecked' },
+    oversized
+  );
+  assert.equal(oversizedResult.ok, false);
+  assert.match(oversizedResult.mismatches[0].message, /exceed 256 KiB/);
+
+  let reads = 0;
+  const accessorTerms = commercialTerms();
+  Object.defineProperty(accessorTerms.purchases[0], 'ext', {
+    enumerable: true,
+    get() {
+      reads++;
+      return { vendor: {} };
+    },
+  });
+  const accessorResult = verifyProposalCommercialTerms(
+    { commercial_terms: accessorTerms, terms_digest: 'sha256:unchecked' },
+    accessorTerms
+  );
+  assert.equal(accessorResult.ok, false);
+  assert.match(accessorResult.mismatches[0].message, /data properties only/);
+  assert.equal(reads, 0);
+});
+
+test('commercial-terms verifier accepts shared references but bounds node count and depth', () => {
+  const shared = { value: 'same' };
+  const aliased = commercialTerms();
+  aliased.purchases[0].ext = { vendor: { first: shared, second: shared } };
+  assert.equal(
+    verifyProposalCommercialTerms(
+      proposal('proposal-shared-reference', 'source-1', { commercial_terms: aliased }),
+      aliased
+    ).ok,
+    true
+  );
+
+  const tooManyNodes = commercialTerms();
+  tooManyNodes.purchases[0].ext = { vendor: { sparse: new Array(50_001) } };
+  const nodeResult = verifyProposalCommercialTerms(
+    { commercial_terms: tooManyNodes, terms_digest: 'sha256:unchecked' },
+    tooManyNodes
+  );
+  assert.equal(nodeResult.ok, false);
+  assert.match(nodeResult.mismatches[0].message, /50,000-node/);
+
+  const tooDeep = commercialTerms();
+  let cursor = {};
+  tooDeep.purchases[0].ext = { vendor: cursor };
+  for (let depth = 0; depth < 257; depth++) {
+    cursor.next = {};
+    cursor = cursor.next;
+  }
+  const depthResult = verifyProposalCommercialTerms(
+    { commercial_terms: tooDeep, terms_digest: 'sha256:unchecked' },
+    tooDeep
+  );
+  assert.equal(depthResult.ok, false);
+  assert.match(depthResult.mismatches[0].message, /maximum JSON depth/);
+});
+
+test('commercial-terms verifier caps diagnostic bytes and keeps attacker keys out of error messages', () => {
+  const longKey = `hostile\n\u001b[31m${'x'.repeat(70_000)}`;
+  const reviewed = commercialTerms();
+  const offered = commercialTerms();
+  reviewed.purchases[0].ext = { vendor: { [longKey]: { value: 'reviewed' } } };
+  offered.purchases[0].ext = { vendor: { [longKey]: { value: 'offered' } } };
+
+  const candidate = proposal('proposal-long-diagnostic', 'source-1', { commercial_terms: offered });
+  const result = verifyProposalCommercialTerms(candidate, reviewed);
+  assert.equal(result.ok, false);
+  assert.equal(result.truncated, true);
+  assert.deepEqual(result.mismatches, []);
+  assert.throws(
+    () => assertProposalCommercialTerms(candidate, reviewed),
+    error =>
+      error instanceof ProposalCommercialTermsVerificationError &&
+      error.message === 'proposal commercial terms failed verification (0 mismatches, diagnostics truncated)' &&
+      !error.message.includes('hostile')
+  );
+
+  const unknownKey = `unknown_${'y'.repeat(70_000)}`;
+  const unknownTerms = commercialTerms({ [unknownKey]: 'value' });
+  const schemaResult = verifyProposalCommercialTerms(
+    proposal('proposal-long-schema-path', 'source-1', { commercial_terms: unknownTerms }),
+    unknownTerms
+  );
+  assert.equal(schemaResult.ok, false);
+  assert.equal(schemaResult.truncated, true);
+  assert.deepEqual(schemaResult.mismatches, []);
+});
+
+test('commercial-terms verifier rejects values that cannot appear on the JSON wire', () => {
+  for (const invalidValue of [undefined, () => 'secret source', Symbol('secret'), 1n, Number.NaN]) {
+    const terms = commercialTerms();
+    terms.purchases[0].ext = { vendor: { invalid: invalidValue } };
+    const result = verifyProposalCommercialTerms({ commercial_terms: terms, terms_digest: 'sha256:unchecked' }, terms);
+    assert.equal(result.ok, false);
+    assert.equal(result.mismatches[0].message, 'commercial terms must contain JSON values only');
+  }
+});
 
 test('buyer validation fails closed on malformed union arms, non-finite values, and non-RFC3339 dates', () => {
   assert.throws(


### PR DESCRIPTION
## Summary

- add a schema-bundle-derived verifier for proposal commercial terms
- check `terms_digest` before validation and exhaustive field comparison
- enforce schema-declared pricing and change-term invariants, failing closed on metadata drift
- bound input complexity and structured diagnostics for safe pre-acceptance use

## Verification

- `npm run typecheck`
- `npm run build:lib`
- `node --test test/lib/proposal-negotiation-validation.test.js` (33/33)
- `npm run ci:schema-check`
- `npm run format:check`
- `npm run lint` (baseline warnings only, no errors)
- protocol, code, and security expert reviews: no remaining blockers
- `npm run review:codex -- --persona code --base main`: no findings

Addresses the Part B request in #2664.
