### PR TITLE
fix(testing): honor storyboard runner contracts

### DIFF
--- a/.changeset/calm-runners-honor-contracts.md
+++ b/.changeset/calm-runners-honor-contracts.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Allow `list_accounts` as the lowest-priority security-baseline authentication probe, and skip ordinary storyboard tool calls whose required test-kit contract is not configured.

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -3889,10 +3889,13 @@ async function executeStoryboardPass(
   }
 
   // Overall pass requires (a) no required-phase failures, (b) either an
-  // executed pass or every required phase grading canonically not_applicable,
+  // executed pass, every required phase grading canonically not_applicable,
+  // or every required step being gated by an unavailable test-kit contract,
   // and (c) no assertion failures. Without (b), a storyboard where every phase
   // is optional or every required step is skipped for another reason (for
-  // example, missing_tool) would pass vacuously.
+  // example, missing_tool) would pass vacuously. Contract-gated storyboards
+  // are the deliberate exception: the runner has positively established that
+  // their opt-in adapter is out of scope, so the result is non-failing.
   // (c) makes assertions gating — a run with all validations green but a
   // cross-step invariant broken is not conformant.
   // When no phases had executable steps the storyboard result is a skip, not a
@@ -3918,6 +3921,17 @@ async function executeStoryboardPass(
         phaseResult.steps.every(step => step.skipped && step.skip?.reason === 'not_applicable')
       );
     });
+  const requiredPhasesContractGated =
+    requiredPhaseDefs.length > 0 &&
+    requiredPhaseDefs.every(phaseDef => {
+      const phaseResult = phaseResults.find(p => p.phase_id === phaseDef.id);
+      return (
+        !!phaseResult &&
+        phaseResult.passed &&
+        phaseResult.steps.length > 0 &&
+        phaseResult.steps.every(step => step.skipped && step.skip_reason === 'missing_test_kit_contract')
+      );
+    });
   const requiredPhasesCoveredByCapabilityGates =
     phaseCapabilitySkippedIds.size > 0 &&
     requiredPhaseDefs.length > 0 &&
@@ -3930,6 +3944,7 @@ async function executeStoryboardPass(
     !hasExecutableSteps ||
     requiredPhaseHasExecutedPass ||
     requiredPhasesNotApplicable ||
+    requiredPhasesContractGated ||
     (failedCount === 0 && requiredPhasesCoveredByCapabilityGates);
   const storyboardWideFixtureUnavailable =
     (seedingUnsupported || fixtureUnsatisfied || creativeAssetFixtureGap !== undefined) && failedCount === 0;
@@ -4646,6 +4661,30 @@ async function executeStep(
   // a seller tool call.
   if (step.task === REPLAY_WEBHOOK_VECTOR_TASK) {
     return executeReplayWebhookVectorStep(step, phaseId, context, allSteps, options, runState);
+  }
+
+  // Ordinary MCP/A2A steps honor the same opt-in contract boundary as the
+  // runner-native probe and replay paths above. Gate before resolving a
+  // dynamic task name, inspecting tool availability, building a request, or
+  // dispatching so an out-of-scope adapter is never invoked accidentally.
+  if (step.requires_contract && !new Set(options.contracts ?? []).has(step.requires_contract)) {
+    const detail = `Test-kit contract "${step.requires_contract}" is not configured on this runner.`;
+    const reason: RunnerDetailedSkipReason = 'missing_test_kit_contract';
+    return {
+      step_id: step.id,
+      phase_id: phaseId,
+      title: step.title,
+      task: step.task,
+      passed: true,
+      skipped: true,
+      skip_reason: reason,
+      skip: buildSkip(DETAILED_SKIP_TO_CANONICAL[reason], detail),
+      duration_ms: 0,
+      validations: [],
+      context,
+      next: getNextStepPreview(step.id, allSteps, context, runState.runnerVars),
+      extraction: { path: 'none', note: 'test-kit contract not configured' },
+    };
   }
 
   // Resolve $test_kit.* task references before any downstream dispatch / skip checks.

--- a/src/lib/testing/storyboard/test-kit.ts
+++ b/src/lib/testing/storyboard/test-kit.ts
@@ -44,6 +44,7 @@ export const PROBE_TASK_ALLOWLIST: readonly string[] = Object.freeze([
   'list_property_lists',
   'list_collection_lists',
   'list_content_standards',
+  'list_accounts',
 ]);
 
 /**

--- a/test/lib/storyboard-requires-gate.test.js
+++ b/test/lib/storyboard-requires-gate.test.js
@@ -1119,3 +1119,81 @@ describe('Storyboard.required_any_of_tools gate (#1642)', () => {
     );
   });
 });
+
+describe('StoryboardStep.requires_contract ordinary-task gate (#2755)', () => {
+  const contract = 'signed_responses_runner';
+  const tools = ['get_adcp_capabilities', 'comply_test_controller'];
+  const storyboard = buildStoryboard({
+    phases: [
+      {
+        id: 'contract_vectors',
+        title: 'Contract vectors',
+        steps: [
+          {
+            id: 'vector_one',
+            title: 'First controller vector',
+            task: 'comply_test_controller',
+            stateful: true,
+            requires_contract: contract,
+            sample_request: { scenario: 'signed_response_vector_one' },
+            validations: [],
+          },
+          {
+            id: 'vector_two',
+            title: 'Dependent controller vector',
+            task: 'comply_test_controller',
+            stateful: true,
+            requires_contract: contract,
+            sample_request: { scenario: 'signed_response_vector_two' },
+            validations: [],
+          },
+        ],
+      },
+    ],
+  });
+
+  function options(calls, contracts) {
+    return {
+      _profile: { name: 'contract-gate-stub', tools, raw_capabilities: {} },
+      agentTools: tools,
+      contracts,
+      _client: {
+        executeTask: async (task, params) => {
+          calls.push({ task, params });
+          return { success: true, data: { status: 'completed', success: true } };
+        },
+      },
+    };
+  }
+
+  test('skips every gated ordinary task without dispatch when the contract is absent', async () => {
+    const calls = [];
+    const result = await runStoryboard('https://contract-gate.example/mcp', storyboard, options(calls, []));
+
+    assert.deepStrictEqual(calls, [], 'no ordinary tool may dispatch outside its declared contract');
+    assert.equal(result.overall_passed, true);
+    assert.equal(result.failed_count, 0);
+    assert.equal(result.skipped_count, 2);
+    for (const step of result.phases[0].steps) {
+      assert.equal(step.passed, true);
+      assert.equal(step.skipped, true);
+      assert.equal(step.skip_reason, 'missing_test_kit_contract');
+      assert.equal(step.skip.reason, 'unsatisfied_contract');
+      assert.notEqual(step.skip_reason, 'prerequisite_failed');
+    }
+  });
+
+  test('dispatches gated ordinary tasks when the contract is present', async () => {
+    const calls = [];
+    const result = await runStoryboard('https://contract-gate.example/mcp', storyboard, options(calls, [contract]));
+
+    assert.deepStrictEqual(
+      calls.map(call => call.task),
+      ['comply_test_controller', 'comply_test_controller']
+    );
+    assert.equal(result.overall_passed, true, JSON.stringify(result));
+    assert.equal(result.failed_count, 0);
+    assert.equal(result.skipped_count, 0);
+    assert.equal(result.passed_count, 2);
+  });
+});

--- a/test/lib/storyboard-security.test.js
+++ b/test/lib/storyboard-security.test.js
@@ -20,6 +20,7 @@ const {
   validateTestKit,
   TestKitValidationError,
   PROBE_TASK_ALLOWLIST,
+  selectProbeTask,
 } = require('../../dist/lib/testing/storyboard/test-kit');
 const {
   resolveStoryboardsForCapabilities,
@@ -2407,19 +2408,26 @@ describe('validateTestKit', () => {
   });
 
   it('allowlist includes read-only auth-required tasks only', () => {
-    // Guard against accidental inclusion of write tasks — retesting the list
-    // here catches an allowlist edit that would make probes destructive.
-    assert.deepStrictEqual(
-      new Set(PROBE_TASK_ALLOWLIST),
-      new Set([
-        'list_creatives',
-        'get_media_buy_delivery',
-        'list_authorized_properties',
-        'get_signals',
-        'list_property_lists',
-        'list_collection_lists',
-        'list_content_standards',
-      ])
+    // Order is probe priority. Keep list_accounts last so existing domain-
+    // specific fallback selection remains unchanged when several are present.
+    assert.deepStrictEqual(PROBE_TASK_ALLOWLIST, [
+      'list_creatives',
+      'get_media_buy_delivery',
+      'list_authorized_properties',
+      'get_signals',
+      'list_property_lists',
+      'list_collection_lists',
+      'list_content_standards',
+      'list_accounts',
+    ]);
+  });
+
+  it('selects list_accounts only after every existing safe fallback', () => {
+    assert.strictEqual(selectProbeTask('list_creatives', ['list_accounts']), 'list_accounts');
+    assert.strictEqual(
+      selectProbeTask('list_creatives', ['list_accounts', 'get_signals']),
+      'get_signals',
+      'adding list_accounts must not change existing fallback priority'
     );
   });
 });


### PR DESCRIPTION
Closes #2752.
Closes #2755.

## Summary

- enforce `requires_contract` before ordinary MCP/A2A storyboard task resolution or dispatch
- preserve the existing detailed `missing_test_kit_contract` and canonical `unsatisfied_contract` skip semantics
- keep all-contract-gated required phases non-failing without weakening other vacuous-skip safeguards
- add `list_accounts` as the lowest-priority safe authentication probe fallback

## Verification

- focused storyboard and security tests: 168/168
- `npm run build:lib`
- `npm run typecheck`
- Prettier and `git diff --check`
- focused expert protocol/code review: all clear