### PR TITLE
feat(testing): report authoritative compliance bundles

### DIFF
--- a/.changeset/brave-bundles-report.md
+++ b/.changeset/brave-bundles-report.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': minor
+---
+
+Return authoritative compliance bundle verdicts and expose structured versions on unsupported compliance-cache errors.

--- a/src/lib/testing/compliance/comply.ts
+++ b/src/lib/testing/compliance/comply.ts
@@ -13,7 +13,7 @@ import type { TestOptions, TestResult, AgentProfile, TestStepResult } from '../t
 import { collectDetachedAssertionFailures, mapStoryboardResultsToTrackResult, TRACK_LABELS } from './storyboard-tracks';
 import { applyAdcpVersionRunOptions, runStoryboard } from '../storyboard/runner';
 import { validateTestKit } from '../storyboard/test-kit';
-import { checkAccountDiscoveryGate } from './spec-conformance';
+import { checkAccountDiscoveryGate, isAccountBearingSpecialism } from './spec-conformance';
 
 // Side-effect import: registers default assertion stubs for invariant ids that
 // upstream storyboards (e.g., `universal/idempotency.yaml` after adcp#2639)
@@ -30,8 +30,9 @@ import {
   loadComplianceIndex,
   isComplianceVersionSupported,
   getExternalSchemaRootForCompliance,
+  getStoryboardVersionGateReason,
 } from '../storyboard/compliance';
-import type { NotApplicableStoryboard, ResolveOptions } from '../storyboard/compliance';
+import type { NotApplicableStoryboard, ResolveOptions, ResolvedBundle } from '../storyboard/compliance';
 import type {
   RunnerSelectionReason,
   RunnerSkipReason,
@@ -44,6 +45,7 @@ import type {
 } from '../storyboard/types';
 import type {
   ComplianceNotSelectedRecord,
+  ComplianceBundleResult,
   ComplianceTrack,
   ComplianceFailure,
   TrackResult,
@@ -721,10 +723,15 @@ function resolveFromCapabilities(
   profile: AgentProfile,
   resolveOptions: ResolveOptions = {}
 ): {
+  bundles: ResolvedBundle[];
   storyboards: Storyboard[];
   not_applicable: NotApplicableStoryboard[];
 } {
-  const { storyboards, not_applicable } = resolveStoryboardsForCapabilities(
+  const {
+    bundles,
+    storyboards: selectedStoryboards,
+    not_applicable: selectedNotApplicable,
+  } = resolveStoryboardsForCapabilities(
     {
       supported_protocols: profile.supported_protocols,
       specialisms: profile.specialisms,
@@ -733,7 +740,125 @@ function resolveFromCapabilities(
     },
     resolveOptions
   );
-  return { storyboards, not_applicable };
+  const notApplicable = [...selectedNotApplicable];
+  const notApplicableIds = new Set(notApplicable.map(storyboard => storyboard.storyboard_id));
+  const storyboards = expandScenarios(selectedStoryboards, resolveOptions).filter(storyboard => {
+    const gate = getStoryboardVersionGateReason(storyboard, profile.adcp_major_versions);
+    if (!gate) return true;
+    if (!notApplicableIds.has(storyboard.id)) {
+      notApplicableIds.add(storyboard.id);
+      notApplicable.push({
+        storyboard_id: storyboard.id,
+        storyboard_title: storyboard.title,
+        track: storyboard.track,
+        reason: gate,
+        selection_result: { reason: 'version_excluded', detail: gate },
+      });
+    }
+    return false;
+  });
+  return {
+    bundles: bundles.map(bundle => ({
+      ...bundle,
+      storyboards: expandScenarios(bundle.storyboards, resolveOptions, notApplicableIds),
+    })),
+    storyboards,
+    not_applicable: notApplicable,
+  };
+}
+
+export interface ComplianceBundleAssessmentOptions {
+  /** Storyboards excluded because the seller's declared version predates them. */
+  notApplicable?: readonly NotApplicableStoryboard[];
+  /** Storyboards selected for the bundle but unavailable from tool discovery. */
+  missingTools?: readonly NotApplicableStoryboard[];
+  /** Bundle ids failed by cross-storyboard synthetic conformance gates. */
+  failingBundleIds?: readonly string[];
+}
+
+const NEUTRAL_BUNDLE_SKIP_REASONS = new Set<string>(['peer_branch_taken', 'peer_substituted']);
+
+/**
+ * Aggregate the exact cache bundles selected for a capability-driven run.
+ * A bundle passes only when every storyboard satisfies its required
+ * conformance checks. Required failures take precedence, while every form of
+ * missing coverage remains visible as partial, untested, or not_applicable.
+ */
+export function buildComplianceBundleResults(
+  bundles: readonly ResolvedBundle[],
+  storyboardResults: readonly StoryboardResult[],
+  options: ComplianceBundleAssessmentOptions = {}
+): ComplianceBundleResult[] {
+  const resultByStoryboard = new Map(storyboardResults.map(result => [result.storyboard_id, result]));
+  const notApplicableIds = new Set((options.notApplicable ?? []).map(storyboard => storyboard.storyboard_id));
+  const missingToolIds = new Set((options.missingTools ?? []).map(storyboard => storyboard.storyboard_id));
+  const failingBundleIds = new Set(options.failingBundleIds ?? []);
+
+  return bundles.map(bundle => {
+    const storyboardIds = bundle.storyboards.map(storyboard => storyboard.id);
+    const statuses = bundle.storyboards.map(storyboard => {
+      const storyboardId = storyboard.id;
+      if (notApplicableIds.has(storyboardId)) return 'not_applicable' as const;
+      if (missingToolIds.has(storyboardId)) return 'partial' as const;
+      if (storyboard.phases.length === 0) return 'untested' as const;
+      const result = resultByStoryboard.get(storyboardId);
+      if (!result) return 'untested' as const;
+      if (!result.overall_passed && (result.failed_count > 0 || collectDetachedAssertionFailures(result).length > 0)) {
+        return 'failing' as const;
+      }
+      const branchSetPhaseIds = new Set(
+        storyboard.phases.filter(phase => phase.branch_set !== undefined).map(phase => phase.id)
+      );
+      const hasCoverageGapSkip = (result.passes?.flatMap(pass => pass.phases) ?? result.phases).some(phase =>
+        phase.steps.some(step => {
+          if (!step.skipped && step.skip === undefined && step.skip_reason === undefined) return false;
+          const reason = step.skip?.reason ?? step.skip_reason;
+          if (reason !== undefined && NEUTRAL_BUNDLE_SKIP_REASONS.has(reason)) return false;
+          // A successful authored any-of branch makes its unselected peers
+          // legitimately not applicable; generic not_applicable skips remain
+          // coverage gaps everywhere else.
+          if (reason === 'not_applicable' && result.overall_passed && branchSetPhaseIds.has(phase.phase_id)) {
+            return false;
+          }
+          return true;
+        })
+      );
+      const observationAssertions = (result.assertions ?? []).filter(
+        assertion => typeof assertion.observation_count === 'number'
+      );
+      const hasNoObservedEvidence =
+        observationAssertions.length > 0 && observationAssertions.every(assertion => assertion.observation_count === 0);
+      if (
+        !result.overall_passed ||
+        result.passed_count === 0 ||
+        (result.validations_not_applicable ?? 0) > 0 ||
+        (result.coverage_gaps?.length ?? 0) > 0 ||
+        hasCoverageGapSkip ||
+        hasNoObservedEvidence
+      ) {
+        return 'partial' as const;
+      }
+      return 'passing' as const;
+    });
+
+    let status: ComplianceBundleResult['status'];
+    if (failingBundleIds.has(bundle.ref.id) || statuses.includes('failing')) status = 'failing';
+    else if (statuses.length > 0 && statuses.every(candidate => candidate === 'passing')) status = 'passing';
+    else if (statuses.length > 0 && statuses.every(candidate => candidate === 'not_applicable')) {
+      status = 'not_applicable';
+    } else if (statuses.length === 0 || statuses.every(candidate => candidate === 'untested')) {
+      status = 'untested';
+    } else {
+      status = 'partial';
+    }
+
+    return {
+      kind: bundle.ref.kind,
+      id: bundle.ref.id,
+      storyboard_ids: storyboardIds,
+      status,
+    };
+  });
 }
 
 export function applyNegotiatedComplianceVersionOptions(
@@ -856,7 +981,11 @@ function compareAdcpVersionStrings(a: string, b: string): number {
  * bundle (e.g., `sales-guaranteed` → `media_buy_seller/governance_approved`),
  * so the lookup spans every cached storyboard — not just the declared set.
  */
-function expandScenarios(storyboards: Storyboard[], resolveOptions: ResolveOptions = {}): Storyboard[] {
+function expandScenarios(
+  storyboards: Storyboard[],
+  resolveOptions: ResolveOptions = {},
+  skipDependencyExpansionFor: ReadonlySet<string> = new Set()
+): Storyboard[] {
   const seen = new Set(storyboards.map(s => s.id));
   const expanded: Storyboard[] = [];
   let allStoryboardsCache: Storyboard[] | null = null;
@@ -866,7 +995,7 @@ function expandScenarios(storyboards: Storyboard[], resolveOptions: ResolveOptio
   };
 
   for (const sb of storyboards) {
-    if (sb.requires_scenarios?.length) {
+    if (!skipDependencyExpansionFor.has(sb.id) && sb.requires_scenarios?.length) {
       for (const scenarioId of sb.requires_scenarios) {
         if (seen.has(scenarioId)) continue;
         const scenario = lookupById(scenarioId);
@@ -1406,15 +1535,19 @@ async function complyImpl(agentUrl: string, options: ComplyOptions): Promise<Com
     // Resolve storyboards: explicit IDs override capability-driven selection.
     let initialStoryboards: Storyboard[];
     let notApplicable: NotApplicableStoryboard[] = [];
+    let resolvedBundles: ResolvedBundle[] | undefined;
     const missingToolStoryboards: NotApplicableStoryboard[] = [];
     if (explicitStoryboards?.length) {
       initialStoryboards = resolveExplicitStoryboards(explicitStoryboards, resolveOptions);
     } else {
       const resolved = resolveFromCapabilities(profile, resolveOptions);
+      resolvedBundles = resolved.bundles;
       initialStoryboards = resolved.storyboards;
       notApplicable = resolved.not_applicable;
     }
-    const applicableStoryboards = expandScenarios(initialStoryboards, resolveOptions);
+    const applicableStoryboards = explicitStoryboards?.length
+      ? expandScenarios(initialStoryboards, resolveOptions)
+      : initialStoryboards;
 
     // For capability-resolved runs, exclude storyboards and injected scenarios whose
     // required_tools are absent from the agent's discovered toolset. These are
@@ -1617,6 +1750,15 @@ async function complyImpl(agentUrl: string, options: ComplyOptions): Promise<Com
       observations: allObservations,
       failures: failures.length > 0 ? failures : undefined,
       storyboards_executed: executedStoryboards.map(sb => sb.id),
+      ...(resolvedBundles !== undefined && {
+        bundle_results: buildComplianceBundleResults(resolvedBundles, storyboardResults, {
+          notApplicable,
+          missingTools: missingToolStoryboards,
+          failingBundleIds: accountDiscoveryFailure
+            ? (profile.specialisms ?? []).filter(isAccountBearingSpecialism)
+            : [],
+        }),
+      }),
       ...(notApplicable.length > 0 && { storyboards_not_applicable: notApplicable.map(na => na.storyboard_id) }),
       ...(missingToolStoryboards.length > 0 && {
         storyboards_missing_tools: missingToolStoryboards.map(na => na.storyboard_id),

--- a/src/lib/testing/compliance/index.ts
+++ b/src/lib/testing/compliance/index.ts
@@ -7,12 +7,13 @@
 export {
   comply,
   collectObservations,
+  buildComplianceBundleResults,
   computeOverallStatus,
   formatComplianceResults,
   formatComplianceResultsJSON,
   rotateStoryboardsForOffset,
 } from './comply';
-export type { ComplyOptions } from './comply';
+export type { ComplyOptions, ComplianceBundleAssessmentOptions } from './comply';
 
 export {
   buildComplianceSummary,
@@ -37,6 +38,8 @@ export type {
   TrackStatus,
   OverallStatus,
   ComplianceFailure,
+  ComplianceBundleResult,
+  ComplianceBundleStatus,
   ComplianceResult,
   ComplianceSummary,
   AdvisoryObservation,

--- a/src/lib/testing/compliance/spec-conformance.ts
+++ b/src/lib/testing/compliance/spec-conformance.ts
@@ -57,7 +57,8 @@ export const ACCOUNT_DISCOVERY_GATE_STORYBOARD_ID = '__spec_conformance__/accoun
  * account discovery. Same for `signal-*`, `brand-rights`,
  * `signed-requests`.
  */
-function isAccountBearingSpecialism(specialism: string): boolean {
+/** @internal Used by bundle verdict aggregation to assign this synthetic gate. */
+export function isAccountBearingSpecialism(specialism: string): boolean {
   if (specialism.startsWith('sales-')) return true;
   if (specialism === 'audience-sync') return true;
   if (specialism.startsWith('governance-')) return true;

--- a/src/lib/testing/compliance/types.ts
+++ b/src/lib/testing/compliance/types.ts
@@ -4,6 +4,7 @@
 
 import type { AgentProfile, TestResult, TestScenario } from '../types';
 import type { AdcpErrorInfo } from '../../core/ConversationTypes';
+import type { BundleKind } from '../storyboard/compliance';
 import type { RunnerNotice, RunnerSelectionReason, RunnerSkipReason } from '../storyboard/types';
 
 // ============================================================
@@ -157,6 +158,12 @@ export interface ComplianceResult {
   failures?: ComplianceFailure[];
   /** Storyboard IDs that were resolved and executed */
   storyboards_executed?: string[];
+  /**
+   * Authoritative verdicts for the exact universal, protocol, and specialism
+   * bundles selected from the compliance cache. Omitted for explicit targeted
+   * storyboard runs, which do not establish complete bundle coverage.
+   */
+  bundle_results?: ComplianceBundleResult[];
   /** Storyboard IDs graded not-applicable because the agent's declared major version predates the storyboard */
   storyboards_not_applicable?: string[];
   /**
@@ -189,6 +196,16 @@ export interface ComplianceResult {
    * Spec: adcp-client#1704.
    */
   notices: RunnerNotice[];
+}
+
+export type ComplianceBundleStatus = 'passing' | 'failing' | 'partial' | 'untested' | 'not_applicable';
+
+export interface ComplianceBundleResult {
+  kind: BundleKind;
+  id: string;
+  /** Storyboards assessed for this bundle, including injected required scenarios, in assessment order. */
+  storyboard_ids: string[];
+  status: ComplianceBundleStatus;
 }
 
 export interface ComplianceSummary {

--- a/src/lib/testing/index.ts
+++ b/src/lib/testing/index.ts
@@ -99,6 +99,7 @@ export {
 // Compliance assessment
 export {
   comply,
+  buildComplianceBundleResults,
   formatComplianceResults,
   formatComplianceResultsJSON,
   buildComplianceSummary,
@@ -108,10 +109,13 @@ export {
   getBriefsByVertical,
   // Types
   type ComplyOptions,
+  type ComplianceBundleAssessmentOptions,
   type ComplianceTrack,
   type TrackResult,
   type TestedTrackEntry,
   type TrackStatus,
+  type ComplianceBundleResult,
+  type ComplianceBundleStatus,
   type ComplianceResult,
   type ComplianceSummary,
   type ComplianceSummaryArtifact,

--- a/src/lib/testing/storyboard/compliance.ts
+++ b/src/lib/testing/storyboard/compliance.ts
@@ -41,6 +41,8 @@ export class CapabilityResolutionError extends ADCPError {
   readonly specialism?: string;
   readonly parentProtocol?: string;
   readonly protocol?: string;
+  readonly complianceVersion?: string;
+  readonly supportedVersions?: readonly string[];
 
   constructor(params: {
     code: CapabilityResolutionCode;
@@ -48,12 +50,18 @@ export class CapabilityResolutionError extends ADCPError {
     specialism?: string;
     parentProtocol?: string;
     protocol?: string;
+    complianceVersion?: string;
+    supportedVersions?: readonly string[];
   }) {
     super(params.message);
     this.code = params.code;
     if (params.specialism !== undefined) this.specialism = params.specialism;
     if (params.parentProtocol !== undefined) this.parentProtocol = params.parentProtocol;
     if (params.protocol !== undefined) this.protocol = params.protocol;
+    if (params.complianceVersion !== undefined) this.complianceVersion = params.complianceVersion;
+    if (params.supportedVersions !== undefined) {
+      this.supportedVersions = Object.freeze([...params.supportedVersions]);
+    }
   }
 }
 
@@ -813,7 +821,7 @@ export function resolveStoryboardsForCapabilities(
     for (const sb of sbs) {
       if (seenStoryboards.has(sb.id)) continue;
       seenStoryboards.add(sb.id);
-      const gate = checkVersionGate(sb, caps.major_versions);
+      const gate = getStoryboardVersionGateReason(sb, caps.major_versions);
       if (gate) {
         notApplicable.push({
           storyboard_id: sb.id,
@@ -936,6 +944,8 @@ function assertSupportedComplianceVersion(
   if (isComplianceVersionSupported(cacheVersion, supportedVersions, options)) return;
   throw new CapabilityResolutionError({
     code: 'unsupported_adcp_version',
+    complianceVersion: cacheVersion,
+    supportedVersions,
     message:
       `Compliance cache version ${cacheVersion} is not supported by this seller. ` +
       `Seller advertises adcp.supported_versions [${supportedVersions.join(', ')}]. ` +
@@ -979,7 +989,8 @@ function isPrereleaseVersion(version: string): boolean {
  * `major_versions` (v2 synthetic profiles, discovery failures) run every
  * storyboard, and storyboards without `introduced_in` always apply.
  */
-function checkVersionGate(sb: Storyboard, agentMajors: number[] | undefined): string | undefined {
+/** @internal Shared with capability-driven dependency expansion. */
+export function getStoryboardVersionGateReason(sb: Storyboard, agentMajors: number[] | undefined): string | undefined {
   if (!sb.introduced_in || !agentMajors || agentMajors.length === 0) return undefined;
   const parsed = parseIntroducedIn(sb.introduced_in);
   if (parsed === undefined) return undefined; // unparseable → don't block

--- a/test/lib/compliance-bundle-results.test.js
+++ b/test/lib/compliance-bundle-results.test.js
@@ -1,0 +1,168 @@
+const { describe, test } = require('node:test');
+const assert = require('node:assert');
+
+const { buildComplianceBundleResults } = require('../../dist/lib/testing/compliance/comply.js');
+
+function bundle(...storyboardIds) {
+  return {
+    ref: { kind: 'specialism', id: 'sales-test', path: '/unused' },
+    storyboards: storyboardIds.map(id => ({ id, phases: [{ id: 'test' }] })),
+  };
+}
+
+function result(storyboardId, overrides = {}) {
+  return {
+    storyboard_id: storyboardId,
+    overall_passed: true,
+    passed_count: 1,
+    failed_count: 0,
+    skipped_count: 0,
+    phases: [],
+    ...overrides,
+  };
+}
+
+describe('buildComplianceBundleResults', () => {
+  test('fails a multi-storyboard specialism when any storyboard fails', () => {
+    const [assessment] = buildComplianceBundleResults(
+      [bundle('root', 'secondary')],
+      [result('root'), result('secondary', { overall_passed: false, passed_count: 0, failed_count: 1 })]
+    );
+
+    assert.deepStrictEqual(assessment, {
+      kind: 'specialism',
+      id: 'sales-test',
+      storyboard_ids: ['root', 'secondary'],
+      status: 'failing',
+    });
+  });
+
+  test('reports partial when selected coverage is unstarted or inapplicable', () => {
+    assert.strictEqual(
+      buildComplianceBundleResults([bundle('root', 'secondary')], [result('root')])[0].status,
+      'partial'
+    );
+    assert.strictEqual(
+      buildComplianceBundleResults([bundle('root', 'secondary')], [result('root')], {
+        missingTools: [{ storyboard_id: 'secondary' }],
+      })[0].status,
+      'partial'
+    );
+  });
+
+  test('distinguishes wholly untested and wholly not-applicable bundles', () => {
+    assert.strictEqual(buildComplianceBundleResults([bundle('root', 'secondary')], [])[0].status, 'untested');
+    assert.strictEqual(
+      buildComplianceBundleResults([bundle('root', 'secondary')], [], {
+        notApplicable: [{ storyboard_id: 'root' }, { storyboard_id: 'secondary' }],
+      })[0].status,
+      'not_applicable'
+    );
+  });
+
+  test('reports empty preview placeholder storyboards as untested', () => {
+    const previewBundle = bundle('preview-root');
+    previewBundle.storyboards[0].phases = [];
+
+    assert.strictEqual(
+      buildComplianceBundleResults(
+        [previewBundle],
+        [result('preview-root', { overall_passed: false, passed_count: 0, skipped_count: 1 })]
+      )[0].status,
+      'untested'
+    );
+  });
+
+  test('requires every storyboard to run cleanly before passing', () => {
+    assert.strictEqual(
+      buildComplianceBundleResults([bundle('root', 'secondary')], [result('root'), result('secondary')])[0].status,
+      'passing'
+    );
+    assert.strictEqual(
+      buildComplianceBundleResults([bundle('root')], [result('root', { validations_not_applicable: 1 })])[0].status,
+      'partial'
+    );
+  });
+
+  test('keeps neutral alternative-path skips passing', () => {
+    for (const reason of ['peer_branch_taken', 'peer_substituted']) {
+      const passingWithPeerSkip = result('root', {
+        skipped_count: 1,
+        phases: [
+          {
+            steps: [{ skip: { reason } }],
+          },
+        ],
+      });
+
+      assert.strictEqual(buildComplianceBundleResults([bundle('root')], [passingWithPeerSkip])[0].status, 'passing');
+    }
+  });
+
+  test('only treats not-applicable skips as neutral inside a successful authored branch set', () => {
+    const branchBundle = bundle('root');
+    branchBundle.storyboards[0].phases = [{ id: 'auth-choice', branch_set: { id: 'auth', semantics: 'any_of' } }];
+    const notApplicableResult = result('root', {
+      skipped_count: 1,
+      phases: [
+        {
+          phase_id: 'auth-choice',
+          steps: [{ skip: { reason: 'not_applicable' } }],
+        },
+      ],
+    });
+
+    assert.strictEqual(buildComplianceBundleResults([branchBundle], [notApplicableResult])[0].status, 'passing');
+    assert.strictEqual(buildComplianceBundleResults([bundle('root')], [notApplicableResult])[0].status, 'partial');
+  });
+
+  test('honors an overall pass when an optional phase contains a failed step', () => {
+    assert.strictEqual(
+      buildComplianceBundleResults(
+        [bundle('root')],
+        [result('root', { overall_passed: true, passed_count: 1, failed_count: 1 })]
+      )[0].status,
+      'passing'
+    );
+  });
+
+  test('reports incomplete coverage without failure evidence as partial', () => {
+    assert.strictEqual(
+      buildComplianceBundleResults(
+        [bundle('root')],
+        [result('root', { overall_passed: false, failed_count: 0, skipped_count: 1 })]
+      )[0].status,
+      'partial'
+    );
+  });
+
+  test('reports mixed passed and missing-tool coverage as partial', () => {
+    const partialResult = result('root', {
+      skipped_count: 1,
+      phases: [
+        {
+          steps: [{ skip: { reason: 'missing_tool' } }],
+        },
+      ],
+    });
+
+    assert.strictEqual(buildComplianceBundleResults([bundle('root')], [partialResult])[0].status, 'partial');
+  });
+
+  test('reports observation-based checks with no evidence as partial', () => {
+    const silentResult = result('root', {
+      assertions: [{ passed: true, observation_count: 0 }],
+    });
+
+    assert.strictEqual(buildComplianceBundleResults([bundle('root')], [silentResult])[0].status, 'partial');
+  });
+
+  test('assigns synthetic conformance failures to their affected bundle', () => {
+    assert.strictEqual(
+      buildComplianceBundleResults([bundle('root')], [result('root')], {
+        failingBundleIds: ['sales-test'],
+      })[0].status,
+      'failing'
+    );
+  });
+});

--- a/test/lib/comply-abort.test.js
+++ b/test/lib/comply-abort.test.js
@@ -103,9 +103,64 @@ phases:
   return dir;
 }
 
+function writeSpecialismDependencyComplianceCache(options = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'adcp-comply-bundle-'));
+  fs.mkdirSync(path.join(dir, 'universal'), { recursive: true });
+  fs.mkdirSync(path.join(dir, 'protocols', 'media-buy', 'scenarios'), { recursive: true });
+  fs.mkdirSync(path.join(dir, 'specialisms', 'sales-guaranteed'), { recursive: true });
+  if (options.dependencyInUnselectedSpecialism) {
+    fs.mkdirSync(path.join(dir, 'specialisms', 'governance-aware-seller'), { recursive: true });
+  }
+  fs.writeFileSync(
+    path.join(dir, 'index.json'),
+    JSON.stringify({
+      adcp_version: ADCP_VERSION,
+      generated_at: new Date().toISOString(),
+      universal: [],
+      protocols: [{ id: 'media-buy', title: 'Media buy', has_baseline: true, path: 'protocols/media-buy' }],
+      specialisms: [
+        {
+          id: 'sales-guaranteed',
+          protocol: 'media-buy',
+          title: 'Guaranteed sales',
+          status: 'stable',
+          path: 'specialisms/sales-guaranteed',
+        },
+        ...(options.dependencyInUnselectedSpecialism
+          ? [
+              {
+                id: 'governance-aware-seller',
+                protocol: 'media-buy',
+                title: 'Governance-aware seller',
+                status: 'stable',
+                path: 'specialisms/governance-aware-seller',
+              },
+            ]
+          : []),
+      ],
+    })
+  );
+  const dependencyYaml = `${timeoutStoryboardYaml('shared_dependency', 0)}${
+    options.dependencyIntroducedIn ? `introduced_in: ${options.dependencyIntroducedIn}\n` : ''
+  }`;
+  fs.writeFileSync(
+    options.dependencyInUnselectedSpecialism
+      ? path.join(dir, 'specialisms', 'governance-aware-seller', 'index.yaml')
+      : path.join(dir, 'protocols', 'media-buy', 'scenarios', 'shared.yaml'),
+    dependencyYaml
+  );
+  fs.writeFileSync(
+    path.join(dir, 'specialisms', 'sales-guaranteed', 'index.yaml'),
+    `${timeoutStoryboardYaml('guaranteed_root', 0)}${
+      options.rootIntroducedIn ? `introduced_in: ${options.rootIntroducedIn}\n` : ''
+    }requires_scenarios:\n  - shared_dependency\n`
+  );
+  return dir;
+}
+
 async function startTimeoutAgent(options = {}) {
   const requests = [];
-  const tools = ['__test_probe', 'get_adcp_capabilities'];
+  const tools = options.tools ?? ['__test_probe', 'get_adcp_capabilities'];
   const server = http.createServer(async (req, res) => {
     const chunks = [];
     for await (const chunk of req) chunks.push(chunk);
@@ -328,6 +383,7 @@ describe('comply() storyboard assertion aggregation', () => {
       assert.strictEqual(json.summary.steps_passed, 1);
       assert.strictEqual(json.summary.steps_failed, 0);
       assert.strictEqual(json.failures, undefined);
+      assert.strictEqual(json.bundle_results, undefined, 'targeted storyboard runs must not imply bundle coverage');
       for (const observation of [trackObservation, rootObservation, testedTrackObservation]) {
         assert.ok(observation, 'expected assertion failure observation at every aggregate projection');
         assert.strictEqual(observation.severity, 'error');
@@ -342,6 +398,177 @@ describe('comply() storyboard assertion aggregation', () => {
 });
 
 describe('comply() timeout_ms option', () => {
+  test('returns authoritative bundle verdicts for capability-driven runs', async () => {
+    const complianceDir = writeTimeoutComplianceCache();
+    const agent = await startTimeoutAgent({
+      capabilitiesResponse: {
+        adcp: {
+          major_versions: [3],
+          supported_versions: [ADCP_VERSION],
+          build_version: ADCP_VERSION,
+          idempotency: { supported: false },
+        },
+        supported_protocols: [],
+        specialisms: [],
+      },
+    });
+    try {
+      const result = await comply(agent.url, { allow_http: true, complianceDir });
+
+      assert.deepStrictEqual(result.storyboards_executed, ['slow_timeout_one', 'slow_timeout_two']);
+      assert.deepStrictEqual(result.bundle_results, [
+        {
+          kind: 'universal',
+          id: 'slow-timeout-one',
+          storyboard_ids: ['slow_timeout_one'],
+          status: 'partial',
+        },
+        {
+          kind: 'universal',
+          id: 'slow-timeout-two',
+          storyboard_ids: ['slow_timeout_two'],
+          status: 'partial',
+        },
+      ]);
+    } finally {
+      await closeServer(agent.server);
+      fs.rmSync(complianceDir, { recursive: true, force: true });
+    }
+  });
+
+  test('assigns injected dependencies and synthetic gates to their specialism bundle', async () => {
+    const complianceDir = writeSpecialismDependencyComplianceCache();
+    const agent = await startTimeoutAgent({
+      capabilitiesResponse: {
+        adcp: {
+          major_versions: [3],
+          supported_versions: [ADCP_VERSION],
+          build_version: ADCP_VERSION,
+          idempotency: { supported: false },
+        },
+        supported_protocols: ['media_buy'],
+        specialisms: ['sales-guaranteed'],
+      },
+    });
+    try {
+      const result = await comply(agent.url, { allow_http: true, complianceDir });
+      const specialism = result.bundle_results.find(bundleResult => bundleResult.kind === 'specialism');
+
+      assert.deepStrictEqual(specialism, {
+        kind: 'specialism',
+        id: 'sales-guaranteed',
+        storyboard_ids: ['shared_dependency', 'guaranteed_root'],
+        status: 'failing',
+      });
+      assert.ok(
+        result.failures.some(failure => failure.storyboard_id === '__spec_conformance__/account_discovery'),
+        'the account-discovery gate should own the specialism failure'
+      );
+    } finally {
+      await closeServer(agent.server);
+      fs.rmSync(complianceDir, { recursive: true, force: true });
+    }
+  });
+
+  test('does not inject dependencies from version-inapplicable bundle roots', async () => {
+    const complianceDir = writeSpecialismDependencyComplianceCache({ rootIntroducedIn: '4.0' });
+    const agent = await startTimeoutAgent({
+      tools: ['__test_probe', 'get_adcp_capabilities', 'list_accounts'],
+      capabilitiesResponse: {
+        adcp: {
+          major_versions: [3],
+          supported_versions: [ADCP_VERSION],
+          build_version: ADCP_VERSION,
+          idempotency: { supported: false },
+        },
+        supported_protocols: ['media_buy'],
+        specialisms: ['sales-guaranteed'],
+      },
+    });
+    try {
+      const result = await comply(agent.url, { allow_http: true, complianceDir });
+      const specialism = result.bundle_results.find(bundleResult => bundleResult.kind === 'specialism');
+
+      assert.deepStrictEqual(specialism, {
+        kind: 'specialism',
+        id: 'sales-guaranteed',
+        storyboard_ids: ['guaranteed_root'],
+        status: 'not_applicable',
+      });
+    } finally {
+      await closeServer(agent.server);
+      fs.rmSync(complianceDir, { recursive: true, force: true });
+    }
+  });
+
+  test('does not execute version-inapplicable dependencies of applicable roots', async () => {
+    const complianceDir = writeSpecialismDependencyComplianceCache({ dependencyIntroducedIn: '4.0' });
+    const agent = await startTimeoutAgent({
+      tools: ['__test_probe', 'get_adcp_capabilities', 'list_accounts'],
+      capabilitiesResponse: {
+        adcp: {
+          major_versions: [3],
+          supported_versions: [ADCP_VERSION],
+          build_version: ADCP_VERSION,
+          idempotency: { supported: false },
+        },
+        supported_protocols: ['media_buy'],
+        specialisms: ['sales-guaranteed'],
+      },
+    });
+    try {
+      const result = await comply(agent.url, { allow_http: true, complianceDir });
+      const specialism = result.bundle_results.find(bundleResult => bundleResult.kind === 'specialism');
+
+      assert.deepStrictEqual(result.storyboards_executed, ['guaranteed_root']);
+      assert.deepStrictEqual(specialism, {
+        kind: 'specialism',
+        id: 'sales-guaranteed',
+        storyboard_ids: ['shared_dependency', 'guaranteed_root'],
+        status: 'partial',
+      });
+    } finally {
+      await closeServer(agent.server);
+      fs.rmSync(complianceDir, { recursive: true, force: true });
+    }
+  });
+
+  test('version-gates injected dependencies from unselected bundles', async () => {
+    const complianceDir = writeSpecialismDependencyComplianceCache({
+      dependencyIntroducedIn: '4.0',
+      dependencyInUnselectedSpecialism: true,
+    });
+    const agent = await startTimeoutAgent({
+      tools: ['__test_probe', 'get_adcp_capabilities', 'list_accounts'],
+      capabilitiesResponse: {
+        adcp: {
+          major_versions: [3],
+          supported_versions: [ADCP_VERSION],
+          build_version: ADCP_VERSION,
+          idempotency: { supported: false },
+        },
+        supported_protocols: ['media_buy'],
+        specialisms: ['sales-guaranteed'],
+      },
+    });
+    try {
+      const result = await comply(agent.url, { allow_http: true, complianceDir });
+      const specialism = result.bundle_results.find(bundleResult => bundleResult.id === 'sales-guaranteed');
+
+      assert.deepStrictEqual(result.storyboards_executed, ['guaranteed_root']);
+      assert.deepStrictEqual(specialism, {
+        kind: 'specialism',
+        id: 'sales-guaranteed',
+        storyboard_ids: ['shared_dependency', 'guaranteed_root'],
+        status: 'partial',
+      });
+      assert.ok(result.storyboards_not_applicable.includes('shared_dependency'));
+    } finally {
+      await closeServer(agent.server);
+      fs.rmSync(complianceDir, { recursive: true, force: true });
+    }
+  });
+
   test('timeout_ms stops new storyboards without aborting the active storyboard', async () => {
     const complianceDir = writeTimeoutComplianceCache();
     const realDateNow = Date.now;
@@ -424,6 +651,23 @@ describe('comply() timeout_ms option', () => {
       assert.ok(result.tracks.some(t => t.track === 'core' && t.status === 'skip'));
       assert.ok(result.skipped_tracks.some(t => t.track === 'core'));
       assert.ok(result.observations.some(o => o.source?.code === 'timeout-budget-exceeded'));
+    } finally {
+      await closeServer(agent.server);
+      fs.rmSync(complianceDir, { recursive: true, force: true });
+    }
+  });
+
+  test('degraded auth discovery omits non-authoritative bundle results', async () => {
+    const complianceDir = writeTimeoutComplianceCache();
+    const agent = await startUnauthorizedAgent();
+    try {
+      const result = await comply(agent.url, {
+        allow_http: true,
+        complianceDir,
+        timeout_ms: 30000,
+      });
+
+      assert.strictEqual(result.bundle_results, undefined);
     } finally {
       await closeServer(agent.server);
       fs.rmSync(complianceDir, { recursive: true, force: true });

--- a/test/lib/storyboard-security.test.js
+++ b/test/lib/storyboard-security.test.js
@@ -1651,7 +1651,7 @@ describe('security_baseline: unconditional PRM enforcement (#677)', () => {
   //     can bake the live port into the PRM `resource` field
   //   - a plain object — served as HTTP 200 with JSON body
   //   - a `{ status, body }` tuple — explicit status with JSON body
-  function createAuthTestAgent({ prm, authServer, validApiKey = 'sk_test' } = {}) {
+  function createAuthTestAgent({ prm, authServer, validApiKey = 'sk_test', advertisedTool = 'list_creatives' } = {}) {
     let agentUrl = null;
     const resolveConfig = conf => (typeof conf === 'function' ? conf(agentUrl) : conf);
     const writeMetadata = (res, cfg) => {
@@ -1715,7 +1715,7 @@ describe('security_baseline: unconditional PRM enforcement (#677)', () => {
               result: {
                 tools: [
                   {
-                    name: 'list_creatives',
+                    name: advertisedTool,
                     inputSchema: {
                       type: 'object',
                       additionalProperties: true,
@@ -1728,7 +1728,10 @@ describe('security_baseline: unconditional PRM enforcement (#677)', () => {
           return reply(200, {
             jsonrpc: '2.0',
             id: body.id,
-            result: { structuredContent: { creatives: [], context } },
+            result: {
+              structuredContent:
+                advertisedTool === 'list_accounts' ? { accounts: [], context } : { creatives: [], context },
+            },
           });
         }
         return reply(
@@ -1754,17 +1757,17 @@ describe('security_baseline: unconditional PRM enforcement (#677)', () => {
     };
   }
 
-  function runOpts(testKit) {
+  function runOpts(testKit, advertisedTool = 'list_creatives') {
     return {
       protocol: 'mcp',
       allow_http: true,
       // These fixtures intentionally exercise auth-routing behavior with a
       // minimal list_creatives envelope, not response-schema conformance.
       strictResponseSchemaValidation: false,
-      agentTools: ['list_creatives'],
-      _profile: { name: 'T', tools: ['list_creatives'] },
+      agentTools: [advertisedTool],
+      _profile: { name: 'T', tools: [advertisedTool] },
       _client: {
-        getAgentInfo: async () => ({ name: 'T', tools: [{ name: 'list_creatives' }] }),
+        getAgentInfo: async () => ({ name: 'T', tools: [{ name: advertisedTool }] }),
       },
       test_kit: testKit,
     };
@@ -1801,6 +1804,29 @@ describe('security_baseline: unconditional PRM enforcement (#677)', () => {
         assert.strictEqual(s.skip_reason, 'oauth_not_advertised');
         assert.strictEqual(s.skip.reason, 'not_applicable');
       }
+    } finally {
+      await agent.close();
+    }
+  });
+
+  it('runs valid and invalid credential probes through list_accounts when it is the available safe read', async () => {
+    const agent = createAuthTestAgent({ prm: 404, advertisedTool: 'list_accounts' });
+    const agentUrl = await agent.listen();
+    try {
+      const result = await runStoryboard(agentUrl, loadSecurityBaseline(), runOpts(API_KEY_KIT, 'list_accounts'));
+      const authProbeSteps = result.phases
+        .flatMap(phase => phase.steps)
+        .filter(step => ['probe_unauth', 'probe_api_key', 'probe_invalid_api_key'].includes(step.step_id));
+
+      assert.strictEqual(result.overall_passed, true);
+      assert.deepStrictEqual(
+        authProbeSteps.map(step => step.request.operation),
+        ['list_accounts', 'list_accounts', 'list_accounts']
+      );
+      assert.ok(
+        authProbeSteps.every(step => step.passed),
+        JSON.stringify(authProbeSteps, null, 2)
+      );
     } finally {
       await agent.close();
     }

--- a/test/lib/storyboard-version-negotiation.test.js
+++ b/test/lib/storyboard-version-negotiation.test.js
@@ -516,17 +516,24 @@ describe('storyboard runner AdCP version negotiation', () => {
       resolveStoryboardsForCapabilities,
     } = require('../../dist/lib/testing/storyboard/index.js');
 
+    const sellerSupportedVersions = ['3.0'];
     assert.throws(
       () =>
         resolveStoryboardsForCapabilities({
           supported_protocols: [],
-          supported_versions: ['3.0'],
+          supported_versions: sellerSupportedVersions,
         }),
-      err =>
-        err instanceof CapabilityResolutionError &&
-        err.code === 'unsupported_adcp_version' &&
-        /Compliance cache version/.test(err.message) &&
-        /supported_versions \[3\.0\]/.test(err.message)
+      err => {
+        assert.ok(err instanceof CapabilityResolutionError);
+        assert.strictEqual(err.code, 'unsupported_adcp_version');
+        assert.strictEqual(err.complianceVersion, ADCP_VERSION);
+        assert.deepStrictEqual(err.supportedVersions, ['3.0']);
+        assert.ok(Object.isFrozen(err.supportedVersions));
+        sellerSupportedVersions.push('9.9');
+        assert.deepStrictEqual(err.supportedVersions, ['3.0']);
+        assert.throws(() => err.supportedVersions.push('9.9'), TypeError);
+        return true;
+      }
     );
   });
 


### PR DESCRIPTION
## Summary

- return authoritative universal, protocol, and specialism bundle verdicts from capability-driven compliance runs
- preserve partial, untested, version-inapplicable, cross-bundle dependency, synthetic-gate, and preview semantics without false-green badges
- expose structured compliance and supported version fields on unsupported-version errors
- retain an end-to-end `list_accounts` authentication-probe regression following the independently merged #2752 fix

## Verification

- expert DX, protocol, code, and security reviews
- `npm run review:codex -- --all --base main` (workspace-isolated output)
- `npm run build`
- `npm run lint` (0 errors; existing warnings only)
- 200 focused compliance, security, version-negotiation, and account-discovery tests
- pre-push typecheck and build gate

Closes #2753
Closes #2754

Upstream narrative coordination remains tracked in adcontextprotocol/adcp#6907.