### PR TITLE
feat(codegen): support immutable protocol PR bundles

### DIFF
--- a/.changeset/steady-bundles-generate.md
+++ b/.changeset/steady-bundles-generate.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Support digest-verified, commit-addressed protocol PR bundles in schema sync and generated-code CI.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,12 +47,28 @@ jobs:
         id: schema-sync
         run: npm run sync-schemas:all
 
+      - name: Report immutable protocol bundle provenance
+        if: steps.schema-sync.outputs.primary_schema_source == 'bundle'
+        env:
+          PROTOCOL_COMMIT: ${{ steps.schema-sync.outputs.protocol_commit }}
+          BUNDLE_SHA256: ${{ steps.schema-sync.outputs.bundle_sha256 }}
+          BUNDLE_VERSION: ${{ steps.schema-sync.outputs.bundle_version }}
+        run: |
+          {
+            echo '### Immutable protocol PR bundle'
+            echo
+            echo "- Published version: \`${BUNDLE_VERSION}\`"
+            echo "- Protocol commit: \`${PROTOCOL_COMMIT}\`"
+            echo "- Bundle SHA-256: \`${BUNDLE_SHA256}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Validate generated files are in sync
         env:
           ADCP_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
           ADCP_PRIMARY_SCHEMA_SOURCE: ${{ steps.schema-sync.outputs.primary_schema_source }}
         run: |
           generated_paths=(
+            schemas/codegen-provenance.json
             ':(glob)src/lib/types/*.generated.ts'
             src/lib/types/v2-5/tools.generated.ts
             src/lib/agents/index.generated.ts
@@ -108,12 +124,12 @@ jobs:
           npm run generate-types:v2.5
           npm run generate-registry-types -- --sync
 
-          if ! git diff --exit-code -I '// Generated at:' "${generated_paths[@]}" 2>/dev/null; then
+          if ! git diff --exit-code -I '// Generated at:' -- "${generated_paths[@]}" 2>/dev/null; then
             echo ""
             echo "❌ Generated TypeScript files are out of sync with AdCP schemas or registry OpenAPI!"
             echo ""
             echo "📋 Changes detected in:"
-            git diff --name-only "${generated_paths[@]}" 2>/dev/null || true
+            git diff --name-only -- "${generated_paths[@]}" 2>/dev/null || true
             echo ""
             echo "🔧 To fix, run locally:"
             echo "  npm run sync-schemas:all"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,10 @@ npm test
 npm run build
 ```
 
+If your change depends on schemas from an unreleased protocol pull request,
+follow [the immutable protocol bundle workflow](docs/development/PROTOCOL-PR-BUNDLES.md)
+so local generation and CI use the same commit-addressed artifact.
+
 #### npm-only workspaces
 
 This repo is an npm workspace with two packages — the SDK at the root (`@adcp/sdk`) and the legacy-name compat shim under `packages/client-shim/` (`@adcp/client`). The root `package.json` lists `workspaces: [".", "packages/*"]`, with the leading `"."` so the shim can resolve the root package as a workspace member rather than reaching for the registry.

--- a/docs/development/PROTOCOL-PR-BUNDLES.md
+++ b/docs/development/PROTOCOL-PR-BUNDLES.md
@@ -1,0 +1,85 @@
+# Generate from an unreleased protocol bundle
+
+Use this workflow when an SDK change depends on schemas from an AdCP protocol
+pull request that have not been published yet. The protocol repository builds a
+complete bundle for every schema-changing PR and publishes it at a URL keyed by
+the full protocol commit:
+
+```text
+https://adcontextprotocol.org/protocol/pr/<commit-sha>/latest.tgz
+```
+
+PR bundles are unsigned development artifacts. The SDK requires both the
+expected commit and SHA-256, verifies the complete tarball before extraction,
+and checks the same commit inside the bundle manifest. A mismatch never falls
+back to the published protocol bundle.
+
+## Generate a dependent SDK branch
+
+Copy the protocol commit and bundle SHA-256 from the protocol PR workflow
+summary, then run:
+
+```sh
+npm run sync-schemas -- \
+  --bundle https://adcontextprotocol.org/protocol/pr/<commit-sha>/latest.tgz \
+  --bundle-sha256 <64-character-sha256> \
+  --protocol-commit <40-character-commit-sha>
+
+npm run generate-types
+npm run generate-wellknown-schemas
+```
+
+The sync writes `schemas/codegen-provenance.json`. Commit that file with the
+generated output. It records the exact protocol commit, bundle digest,
+published-version label, and immutable URL. `npm run sync-schemas:all` detects
+the file automatically, so the normal generated-drift CI job consumes the same
+bundle and reports its commit and digest in the workflow summary.
+
+The equivalent environment variables are useful in scripts:
+
+```sh
+export ADCP_BUNDLE_URL=https://adcontextprotocol.org/protocol/pr/<commit-sha>/latest.tgz
+export ADCP_BUNDLE_SHA256=<64-character-sha256>
+export ADCP_PROTOCOL_COMMIT_SHA=<40-character-commit-sha>
+npm run sync-schemas:all
+```
+
+The environment declaration applies to the primary `ADCP_VERSION`; maintained
+side bundles in `sync-schemas:all` continue to use their published artifacts.
+An explicit `--bundle` invocation rejects a positional side-bundle version
+instead of silently ignoring the bundle.
+
+All three inputs are required. Remote inputs must use the official HTTPS,
+commit-addressed URL exactly; query strings, redirects to another hostname, and
+moving URLs are rejected. For an unpublished local build, `--bundle` may be a
+filesystem path, but its generated provenance has no reproducible `bundle_url`
+and therefore cannot drive CI.
+
+`ADCP_BUNDLE` is retained as a shorter alias for `ADCP_BUNDLE_URL`; do not set
+both names to different values.
+
+`ADCP_REQUIRE_SIGNATURE=1` deliberately rejects PR bundles because upstream
+does not sign them. Published release bundles retain their existing Cosign
+verification behavior.
+
+## Refresh after an upstream rebase
+
+Every protocol rebase or force-push produces a new commit and therefore a new
+artifact tuple. Do not edit the provenance JSON by hand:
+
+1. Wait for the protocol PR's bundle workflow to finish on the new head.
+2. Copy the new commit, SHA-256, and commit-addressed URL.
+3. Re-run the sync and generators with all three new values.
+4. Confirm the old commit no longer appears in
+   `schemas/codegen-provenance.json`, generated output, or the SDK PR body.
+5. Commit the regenerated output and updated provenance together.
+
+If the artifact has expired, rerun the protocol validation workflow for that
+commit before refreshing the SDK branch.
+
+## Return to a published bundle
+
+Before merging an SDK change that no longer needs an unreleased protocol input,
+delete `schemas/codegen-provenance.json`, run `npm run sync-schemas:all`, and
+regenerate normally. With no provenance declaration present, schema sync keeps
+its existing published-release and GitHub fallback behavior.

--- a/docs/development/WIRE-VERSION-COMPAT.md
+++ b/docs/development/WIRE-VERSION-COMPAT.md
@@ -42,6 +42,12 @@ npm run sync-schemas:v2.5    # legacy bundle
 npm run sync-schemas:all     # primary pin plus maintained side bundles
 ```
 
+When the primary types must be generated from an unreleased protocol PR, use
+the immutable bundle workflow in
+[Generate from an unreleased protocol bundle](./PROTOCOL-PR-BUNDLES.md). It
+records the upstream commit and tarball digest in checked-in provenance so the
+normal CI drift check uses the identical input.
+
 `sync-v2-5-schemas.ts` pulls from a pinned `2.5-maintenance` SHA with a sha256 verification — published v2.5 tags are stale (see `adcontextprotocol/adcp#3689` upstream).
 
 ### Generated types
@@ -447,10 +453,10 @@ const BETA_VERSION = '3.X.0-beta.N';
 await syncSchemas(BETA_VERSION); // inherits cosign + sha256 + tarball extract
 ```
 
-After the wrapped call, **restore two side-effect classes** that `syncSchemas()` overwrites:
-
-- **The `latest/` symlink** in `schemas/cache/` and `compliance/cache/`. `syncSchemas()` points it at whatever it just synced; for an opt-in side-bundle, repoint it back at the primary GA pin (read from `ADCP_VERSION` file). The SDK's runtime loader doesn't consult `latest/` for opt-in resolution (it uses release-precision fuzzy match against the prerelease directory directly), but downstream tooling does.
-- **Tracked side-effect paths.** `syncSchemas()` also extracts `schemas/registry/registry.yaml` and protocol-managed skills from the synced tarball. These track the SDK's primary pin, not the opt-in beta — restore them from `HEAD` with `git checkout HEAD -- <paths>`. Hardcode the list in a `RESTORE_PATHS` constant so the next contributor sees exactly what the wrapper protects.
+`syncSchemas()` recognizes that this is not the primary `ADCP_VERSION` and updates
+only the versioned schema and compliance caches. It leaves the shared `latest/`
+symlinks, registry schema, and protocol-managed skills at the primary pin; the
+wrapper does not need to restore those paths.
 
 Wire into `package.json#scripts`:
 - `sync-schemas:<version>` — direct invocation

--- a/scripts/generate-types.ts
+++ b/scripts/generate-types.ts
@@ -3819,7 +3819,7 @@ function discoverAllSchemaFiles(dir: string, base: string = dir): string[] {
       const relativeDirectory = path.relative(base, fullPath);
       if (entry === 'tmp' || relativeDirectory === 'mcp' || relativeDirectory === 'bundled') continue;
       results.push(...discoverAllSchemaFiles(fullPath, base));
-    } else if (entry.endsWith('.json') && entry !== 'index.json') {
+    } else if (entry.endsWith('.json') && entry !== 'index.json' && entry !== '_provenance.json') {
       results.push(path.relative(base, fullPath));
     }
   }
@@ -4344,4 +4344,4 @@ if (require.main === module) {
   })();
 }
 
-export { generateTypes };
+export { discoverAllSchemaFiles, generateTypes };

--- a/scripts/schemas-ensure.ts
+++ b/scripts/schemas-ensure.ts
@@ -9,10 +9,10 @@
  * but local dev hits a paper cut.
  *
  * This script runs as a `pretest` hook. It checks whether both caches
- * exist and runs `sync-schemas:all` only when something is missing. The
- * check is ~10ms when caches are present (filesystem stat); the sync
- * fetches a tarball and takes ~5s, but only the first time after a
- * cache wipe.
+ * exist and whether the primary cache matches any tracked PR-bundle
+ * provenance, then syncs only stale or missing caches. The fast path is
+ * filesystem reads; the sync fetches a tarball and takes ~5s, but only after
+ * a cache wipe or provenance change.
  *
  * No CI-time cost: CI's explicit `sync-schemas:all` populates both
  * caches before tests run, so this guard is a no-op there.
@@ -20,6 +20,7 @@
 import { existsSync, lstatSync, readFileSync, rmSync, symlinkSync } from 'fs';
 import path from 'path';
 import { spawnSync } from 'child_process';
+import { cacheMatchesCodegenProvenance } from './sync-schemas';
 
 const REPO_ROOT = path.join(__dirname, '..');
 const CACHE_ROOT = path.join(REPO_ROOT, 'schemas/cache');
@@ -33,7 +34,13 @@ function currentAdcpVersion(): string {
 
 function hasCurrentV3Cache(): boolean {
   const current = currentAdcpVersion();
-  return existsSync(path.join(CACHE_ROOT, current));
+  return (
+    existsSync(path.join(CACHE_ROOT, current)) &&
+    cacheMatchesCodegenProvenance(
+      path.join(REPO_ROOT, 'schemas/codegen-provenance.json'),
+      path.join(CACHE_ROOT, current, '_provenance.json')
+    )
+  );
 }
 
 function hasStableV30Cache(): boolean {
@@ -100,7 +107,7 @@ if (!stableV30Ok || !stableV30ComplianceOk) scripts.push(`sync-schemas -- ${STAB
 if (!stableV31Ok || !stableV31ComplianceOk) scripts.push(`sync-schemas -- ${STABLE_3_1_SCHEMA_VERSION}`);
 if (!v25Ok) scripts.push('sync-schemas:v2.5');
 
-console.log(`[schemas:ensure] Missing schema cache; running: ${scripts.join(', ')}`);
+console.log(`[schemas:ensure] Missing or provenance-stale schema cache; running: ${scripts.join(', ')}`);
 
 for (const script of scripts) {
   const [name, ...args] = script.split(' ');

--- a/scripts/sync-schemas.ts
+++ b/scripts/sync-schemas.ts
@@ -31,6 +31,32 @@ const REPO_ROOT = path.join(__dirname, '..');
 const SCHEMA_CACHE_DIR = path.join(REPO_ROOT, 'schemas/cache');
 const COMPLIANCE_CACHE_DIR = path.join(REPO_ROOT, 'compliance/cache');
 const SKILLS_DIR = path.join(REPO_ROOT, 'skills');
+const CODEGEN_PROVENANCE_PATH = path.join(REPO_ROOT, 'schemas/codegen-provenance.json');
+const PROTOCOL_SOURCE_REPOSITORY = 'adcontextprotocol/adcp';
+const SHA256_PATTERN = /^(?:sha256:)?([0-9a-f]{64})$/;
+const COMMIT_SHA_PATTERN = /^[0-9a-f]{40}$/;
+const PROTOCOL_SKILL_NAME_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9_-]*[A-Za-z0-9])?$/;
+
+interface ProtocolBundleProvenance {
+  schema_version: 1;
+  source_repository: typeof PROTOCOL_SOURCE_REPOSITORY;
+  source_commit: string;
+  published_version: string;
+  bundle_sha256: string;
+  bundle_url?: string;
+}
+
+interface CustomBundleRequest {
+  bundle: string;
+  bundleSha256: string;
+  protocolCommit: string;
+}
+
+interface SyncCommandLine {
+  version?: string;
+  bundle?: CustomBundleRequest;
+  bundleSource?: 'arguments' | 'environment';
+}
 
 /**
  * GitHub mirrors used when adcontextprotocol.org is unavailable.
@@ -83,6 +109,275 @@ function assertBundleVersion(requestedVersion: string, bundledVersion: unknown):
   if (requestedVersion !== 'latest' && bundledVersion !== requestedVersion) {
     throw new Error(`Protocol bundle version mismatch: requested ${requestedVersion}, received ${bundledVersion}.`);
   }
+}
+
+function normalizeBundleSha256(value: string): string {
+  const match = SHA256_PATTERN.exec(value.trim());
+  if (!match) {
+    throw new Error(
+      'Protocol bundle SHA-256 must be 64 lowercase hexadecimal characters (optionally prefixed by "sha256:").'
+    );
+  }
+  return match[1];
+}
+
+function assertProtocolCommit(value: string): void {
+  if (!COMMIT_SHA_PATTERN.test(value)) {
+    throw new Error('Protocol commit must be a lowercase 40-character Git commit SHA.');
+  }
+}
+
+function officialBundleUrlForCommit(source: string, protocolCommit: string): string | undefined {
+  if (!source.includes('://')) return undefined;
+  let url: URL;
+  try {
+    url = new URL(source);
+  } catch {
+    return undefined;
+  }
+  const expectedPath = `/protocol/pr/${protocolCommit}/latest.tgz`;
+  if (
+    url.protocol !== 'https:' ||
+    url.hostname !== 'adcontextprotocol.org' ||
+    url.port ||
+    url.username ||
+    url.password ||
+    url.pathname !== expectedPath ||
+    url.search ||
+    url.hash
+  ) {
+    throw new Error(
+      `Protocol PR bundle URL must be the official immutable URL ` +
+        `https://adcontextprotocol.org${expectedPath}. Use a local file path for unpublished bundles.`
+    );
+  }
+  return url.href;
+}
+
+function validateCustomBundleRequest(request: CustomBundleRequest): CustomBundleRequest {
+  const protocolCommit = request.protocolCommit.trim();
+  assertProtocolCommit(protocolCommit);
+  const bundleSha256 = normalizeBundleSha256(request.bundleSha256);
+  const bundle = request.bundle.trim();
+  if (!bundle) throw new Error('Protocol bundle path or URL must not be empty.');
+  officialBundleUrlForCommit(bundle, protocolCommit);
+  return { bundle, bundleSha256, protocolCommit };
+}
+
+function readCodegenProvenance(filePath = CODEGEN_PROVENANCE_PATH): ProtocolBundleProvenance | undefined {
+  if (!existsSync(filePath)) return undefined;
+  let document: unknown;
+  try {
+    document = JSON.parse(readFileSync(filePath, 'utf8'));
+  } catch (cause) {
+    throw new Error(`Invalid codegen provenance at ${filePath}: ${cause instanceof Error ? cause.message : cause}`, {
+      cause,
+    });
+  }
+  if (!document || typeof document !== 'object') {
+    throw new Error(`Invalid codegen provenance at ${filePath}: expected a JSON object.`);
+  }
+  const candidate = document as Partial<ProtocolBundleProvenance>;
+  if (candidate.schema_version !== 1) {
+    throw new Error(`Invalid codegen provenance at ${filePath}: schema_version must be 1.`);
+  }
+  if (candidate.source_repository !== PROTOCOL_SOURCE_REPOSITORY) {
+    throw new Error(
+      `Invalid codegen provenance at ${filePath}: source_repository must be ${PROTOCOL_SOURCE_REPOSITORY}.`
+    );
+  }
+  if (typeof candidate.source_commit !== 'string') {
+    throw new Error(`Invalid codegen provenance at ${filePath}: source_commit is required.`);
+  }
+  assertProtocolCommit(candidate.source_commit);
+  if (typeof candidate.bundle_sha256 !== 'string') {
+    throw new Error(`Invalid codegen provenance at ${filePath}: bundle_sha256 is required.`);
+  }
+  const bundleSha256 = normalizeBundleSha256(candidate.bundle_sha256);
+  if (typeof candidate.published_version !== 'string') {
+    throw new Error(`Invalid codegen provenance at ${filePath}: published_version is required.`);
+  }
+  assertValidAdcpVersion(candidate.published_version);
+  if (candidate.bundle_url !== undefined) {
+    if (typeof candidate.bundle_url !== 'string') {
+      throw new Error(`Invalid codegen provenance at ${filePath}: bundle_url must be a string.`);
+    }
+    if (!officialBundleUrlForCommit(candidate.bundle_url, candidate.source_commit)) {
+      throw new Error(`Invalid codegen provenance at ${filePath}: bundle_url must be an HTTPS URL.`);
+    }
+  }
+  return {
+    schema_version: 1,
+    source_repository: PROTOCOL_SOURCE_REPOSITORY,
+    source_commit: candidate.source_commit,
+    published_version: candidate.published_version,
+    bundle_sha256: bundleSha256,
+    ...(candidate.bundle_url ? { bundle_url: candidate.bundle_url } : {}),
+  };
+}
+
+function writeCodegenProvenance(provenance: ProtocolBundleProvenance): void {
+  mkdirSync(path.dirname(CODEGEN_PROVENANCE_PATH), { recursive: true });
+  writeFileSync(CODEGEN_PROVENANCE_PATH, `${JSON.stringify(provenance, null, 2)}\n`);
+}
+
+function cacheMatchesCodegenProvenance(
+  declarationPath = CODEGEN_PROVENANCE_PATH,
+  cacheProvenancePath = path.join(SCHEMA_CACHE_DIR, getTargetAdCPVersion(), '_provenance.json')
+): boolean {
+  const declarationExists = existsSync(declarationPath);
+  const cacheProvenanceExists = existsSync(cacheProvenancePath);
+  if (!declarationExists) return !cacheProvenanceExists;
+  if (!cacheProvenanceExists) return false;
+
+  const declaration = readCodegenProvenance(declarationPath)!;
+  const cached = readCodegenProvenance(cacheProvenancePath)!;
+  return (
+    declaration.source_repository === cached.source_repository &&
+    declaration.source_commit === cached.source_commit &&
+    declaration.published_version === cached.published_version &&
+    declaration.bundle_sha256 === cached.bundle_sha256 &&
+    declaration.bundle_url === cached.bundle_url
+  );
+}
+
+function createProtocolBundleProvenance(
+  manifest: {
+    published_version?: unknown;
+    source?: { repository?: unknown; commit_sha?: unknown };
+  },
+  bundledVersion: string,
+  expectedProtocolCommit: string,
+  bundleSha256: string,
+  bundleUrl?: string
+): ProtocolBundleProvenance {
+  if (manifest.source?.repository !== PROTOCOL_SOURCE_REPOSITORY) {
+    throw new Error(
+      `Protocol bundle source repository mismatch: expected ${PROTOCOL_SOURCE_REPOSITORY}, ` +
+        `received ${JSON.stringify(manifest.source?.repository)}.`
+    );
+  }
+  if (manifest.source.commit_sha !== expectedProtocolCommit) {
+    throw new Error(
+      `Protocol bundle commit mismatch: expected ${expectedProtocolCommit}, ` +
+        `received ${JSON.stringify(manifest.source.commit_sha)}.`
+    );
+  }
+  if (manifest.published_version !== bundledVersion) {
+    throw new Error(
+      `Protocol bundle manifest version mismatch: schemas report ${bundledVersion}, ` +
+        `manifest reports ${JSON.stringify(manifest.published_version)}.`
+    );
+  }
+  return {
+    schema_version: 1,
+    source_repository: PROTOCOL_SOURCE_REPOSITORY,
+    source_commit: expectedProtocolCommit,
+    published_version: bundledVersion,
+    bundle_sha256: normalizeBundleSha256(bundleSha256),
+    ...(bundleUrl ? { bundle_url: bundleUrl } : {}),
+  };
+}
+
+function parseSyncCommandLine(args: string[], env: NodeJS.ProcessEnv = process.env): SyncCommandLine {
+  let version: string | undefined;
+  let bundleSource: SyncCommandLine['bundleSource'];
+  if (env.ADCP_BUNDLE && env.ADCP_BUNDLE_URL && env.ADCP_BUNDLE !== env.ADCP_BUNDLE_URL) {
+    throw new Error('ADCP_BUNDLE and ADCP_BUNDLE_URL disagree; set only one bundle source.');
+  }
+  let bundle = env.ADCP_BUNDLE ?? env.ADCP_BUNDLE_URL;
+  let bundleSha256 = env.ADCP_BUNDLE_SHA256;
+  let protocolCommit = env.ADCP_PROTOCOL_COMMIT_SHA;
+
+  const takeValue = (flag: string, index: number): [string, number] => {
+    const argument = args[index];
+    const inlinePrefix = `${flag}=`;
+    if (argument.startsWith(inlinePrefix)) return [argument.slice(inlinePrefix.length), index];
+    const value = args[index + 1];
+    if (!value || value.startsWith('--')) throw new Error(`${flag} requires a value.`);
+    return [value, index + 1];
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === '--bundle' || argument.startsWith('--bundle=')) {
+      [bundle, index] = takeValue('--bundle', index);
+      bundleSource = 'arguments';
+    } else if (argument === '--bundle-sha256' || argument.startsWith('--bundle-sha256=')) {
+      [bundleSha256, index] = takeValue('--bundle-sha256', index);
+      bundleSource = 'arguments';
+    } else if (argument === '--protocol-commit' || argument.startsWith('--protocol-commit=')) {
+      [protocolCommit, index] = takeValue('--protocol-commit', index);
+      bundleSource = 'arguments';
+    } else if (argument.startsWith('--')) {
+      throw new Error(`Unknown schema sync option ${argument}.`);
+    } else if (version === undefined) {
+      version = argument;
+    } else {
+      throw new Error(`Unexpected schema sync argument ${argument}.`);
+    }
+  }
+
+  const suppliedBundleFields = [bundle, bundleSha256, protocolCommit].filter(value => value !== undefined).length;
+  if (suppliedBundleFields !== 0 && suppliedBundleFields !== 3) {
+    throw new Error(
+      'Custom protocol bundles require --bundle, --bundle-sha256, and --protocol-commit ' +
+        '(or ADCP_BUNDLE_URL, ADCP_BUNDLE_SHA256, and ADCP_PROTOCOL_COMMIT_SHA).'
+    );
+  }
+
+  return {
+    ...(version ? { version } : {}),
+    ...(suppliedBundleFields === 3
+      ? {
+          bundle: validateCustomBundleRequest({
+            bundle: bundle!,
+            bundleSha256: bundleSha256!,
+            protocolCommit: protocolCommit!,
+          }),
+        }
+      : {}),
+    ...(suppliedBundleFields === 3 ? { bundleSource: bundleSource ?? 'environment' } : {}),
+  };
+}
+
+function resolveCustomBundleRequest(
+  adcpVersion: string,
+  primaryPin: string,
+  explicitBundle?: CustomBundleRequest,
+  provenancePath = CODEGEN_PROVENANCE_PATH,
+  bundleSource: SyncCommandLine['bundleSource'] = 'arguments'
+): CustomBundleRequest | undefined {
+  if (adcpVersion !== primaryPin) {
+    if (explicitBundle && bundleSource === 'arguments') {
+      throw new Error(
+        `Explicit protocol bundles may only target the primary ADCP_VERSION (${primaryPin}); ` +
+          `received side-bundle version ${adcpVersion}.`
+      );
+    }
+    return undefined;
+  }
+  if (explicitBundle) return validateCustomBundleRequest(explicitBundle);
+
+  const declared = readCodegenProvenance(provenancePath);
+  if (!declared) return undefined;
+  if (declared.published_version !== adcpVersion) {
+    throw new Error(
+      `Codegen provenance version mismatch: ADCP_VERSION is ${adcpVersion}, ` +
+        `${path.relative(REPO_ROOT, provenancePath)} declares ${declared.published_version}.`
+    );
+  }
+  if (!declared.bundle_url) {
+    throw new Error(
+      `${path.relative(REPO_ROOT, provenancePath)} was generated from a local bundle and has no ` +
+        'bundle_url for reproducible CI. Re-run sync with the official commit-addressed PR bundle URL.'
+    );
+  }
+  return {
+    bundle: declared.bundle_url,
+    bundleSha256: declared.bundle_sha256,
+    protocolCommit: declared.source_commit,
+  };
 }
 
 interface DomainEntry {
@@ -244,8 +539,8 @@ function assertNoSymlinks(root: string): void {
   }
 }
 
-async function fetchBinary(url: string): Promise<Buffer> {
-  const res = await fetchAvailable(url);
+async function fetchBinary(url: string, init?: RequestInit): Promise<Buffer> {
+  const res = await fetchAvailable(url, init);
   if (!res.ok) throw fetchStatusError(url, res);
   try {
     return Buffer.from(await res.arrayBuffer());
@@ -404,13 +699,17 @@ function copyTreeFiltered(srcDir: string, destDir: string): void {
  */
 const SDK_LOCAL_SKILLS = new Set(['call-adcp-agent']);
 
+function isSafeProtocolSkillName(value: unknown): value is string {
+  return typeof value === 'string' && PROTOCOL_SKILL_NAME_PATTERN.test(value);
+}
+
 /**
  * Sync protocol-managed skills from the extracted bundle into the SDK's
  * top-level `skills/` tree. Driven by `manifest.contents.skills` (a list of
  * skill directory names) so we only overwrite the entries the spec repo
  * publishes — leaves SDK-local skills (`build-seller-agent/`, etc.) alone.
  */
-function syncSkillsFromBundle(extractRoot: string): void {
+function syncSkillsFromBundle(extractRoot: string, skillsDir = SKILLS_DIR): void {
   const skillsInBundle = path.join(extractRoot, 'skills');
   const manifestPath = path.join(extractRoot, 'manifest.json');
   if (!existsSync(skillsInBundle) || !existsSync(manifestPath)) {
@@ -430,12 +729,10 @@ function syncSkillsFromBundle(extractRoot: string): void {
   }
   let synced = 0;
   for (const name of skillNames) {
-    if (typeof name !== 'string' || name.includes('/') || name.includes('..')) {
-      continue;
-    }
+    if (!isSafeProtocolSkillName(name)) continue;
     if (SDK_LOCAL_SKILLS.has(name)) continue;
     const src = path.join(skillsInBundle, name);
-    const dst = path.join(SKILLS_DIR, name);
+    const dst = path.join(skillsDir, name);
     if (!existsSync(src) || !statSync(src).isDirectory()) continue;
     // Skip nested `schemas/` subdirs — those duplicate `schemas/cache/<version>/`
     // already extracted from the same tarball. Per-protocol skills in the spec
@@ -446,7 +743,137 @@ function syncSkillsFromBundle(extractRoot: string): void {
     synced++;
   }
   if (synced > 0) {
-    console.log(`📁 Skills:     ${SKILLS_DIR} (${synced} protocol-managed)`);
+    console.log(`📁 Skills:     ${skillsDir} (${synced} protocol-managed)`);
+  }
+}
+
+interface InstallProtocolBundleOptions {
+  version: string;
+  tgzBuf: Buffer;
+  expectedSha256: string;
+  source: string;
+  includeSharedSurfaces: boolean;
+  verifySignature?: (tgzPath: string) => Promise<void>;
+  expectedProtocolCommit?: string;
+  bundleUrl?: string;
+  repoRoot?: string;
+  schemaCacheDir?: string;
+  complianceCacheDir?: string;
+  skillsDir?: string;
+}
+
+/** Verify, inspect, and install a complete protocol bundle into the local caches. */
+async function installProtocolBundle(
+  options: InstallProtocolBundleOptions
+): Promise<ProtocolBundleProvenance | undefined> {
+  const { version, tgzBuf, source, includeSharedSurfaces, verifySignature, expectedProtocolCommit, bundleUrl } =
+    options;
+  const repoRoot = options.repoRoot ?? REPO_ROOT;
+  const schemaCacheDir = options.schemaCacheDir ?? SCHEMA_CACHE_DIR;
+  const complianceCacheDir = options.complianceCacheDir ?? COMPLIANCE_CACHE_DIR;
+  const skillsDir = options.skillsDir ?? SKILLS_DIR;
+  const expectedSha256 = normalizeBundleSha256(options.expectedSha256);
+  const actualSha256 = createHash('sha256').update(tgzBuf).digest('hex');
+  if (actualSha256 !== expectedSha256) {
+    throw new Error(
+      `Tarball sha256 mismatch for ${source}\n  expected: ${expectedSha256}\n  actual:   ${actualSha256}`
+    );
+  }
+  console.log(`✅ sha256 verified (${expectedSha256.slice(0, 12)}…)`);
+
+  // Keep the work dir inside the repo so renameSync never crosses filesystems (EXDEV).
+  mkdirSync(repoRoot, { recursive: true });
+  const workDir = mkdtempSync(path.join(repoRoot, '.adcp-sync-'));
+  try {
+    const tgzPath = path.join(workDir, 'bundle.tgz');
+    writeFileSync(tgzPath, tgzBuf);
+
+    if (verifySignature) await verifySignature(tgzPath);
+
+    await tar.x({ file: tgzPath, cwd: workDir, strict: true });
+
+    const extractRoot = path.join(workDir, `adcp-${version}`);
+    if (!existsSync(extractRoot)) {
+      throw new Error(`Tarball root ${extractRoot} not found — upstream wrapping directory may have changed.`);
+    }
+    assertNoSymlinks(extractRoot);
+
+    const bundleIndex = JSON.parse(readFileSync(path.join(extractRoot, 'schemas/index.json'), 'utf8'));
+    const bundledVersion: string | undefined = bundleIndex.adcp_version;
+    assertBundleVersion(version, bundledVersion);
+
+    let provenance: ProtocolBundleProvenance | undefined;
+    if (expectedProtocolCommit) {
+      assertProtocolCommit(expectedProtocolCommit);
+      const manifestPath = path.join(extractRoot, 'manifest.json');
+      if (!existsSync(manifestPath)) {
+        throw new Error('Protocol PR bundle is missing manifest.json provenance.');
+      }
+      const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as {
+        published_version?: unknown;
+        source?: { repository?: unknown; commit_sha?: unknown };
+      };
+      provenance = createProtocolBundleProvenance(
+        manifest,
+        bundledVersion,
+        expectedProtocolCommit,
+        actualSha256,
+        bundleUrl
+      );
+    }
+
+    for (const requiredTree of ['schemas', 'compliance']) {
+      const requiredPath = path.join(extractRoot, requiredTree);
+      if (!existsSync(requiredPath) || !statSync(requiredPath).isDirectory()) {
+        throw new Error(`Protocol bundle is missing required ${requiredTree}/ tree.`);
+      }
+    }
+
+    replaceTree(path.join(extractRoot, 'schemas'), path.join(schemaCacheDir, version));
+    replaceTree(path.join(extractRoot, 'compliance'), path.join(complianceCacheDir, version));
+
+    // Skills sync is manifest-driven and per-name. SDK-local skills like
+    // build-seller-agent/ stay untouched; protocol-canonical ones (the
+    // call-adcp-agent buyer skill plus per-protocol skills) are kept aligned
+    // with the pinned spec version. Older tarballs (no manifest.contents.skills
+    // array) are silently skipped — the SDK-local copies stay as-is. Skipped
+    // entirely for side-bundle syncs so they keep the primary pin's skills.
+    if (includeSharedSurfaces) {
+      syncSkillsFromBundle(extractRoot, skillsDir);
+    }
+
+    // Refs inside the tarball point to /schemas/latest/; rewrite for pinned versions.
+    const schemaDest = path.join(schemaCacheDir, version);
+    const semanticVersion: string = bundledVersion || version;
+    normalizeRefsInTree(schemaDest, semanticVersion);
+    if (provenance) {
+      writeFileSync(path.join(schemaDest, '_provenance.json'), `${JSON.stringify(provenance, null, 2)}\n`);
+    }
+
+    // schemas/registry/registry.yaml is intentionally NOT written here. Although
+    // the protocol tarball ships an openapi/registry.yaml, the registry spec has
+    // its own upstream (agenticadvertising.org) and its own owner,
+    // `generate-registry-types --sync`. That live spec runs ahead of the pinned
+    // protocol bundle, so copying the tarball's copy only downgraded the checked-in
+    // file and left a spurious diff in every working tree after a plain sync.
+
+    // `latest/` is a shared, non-version-scoped pointer that resolves to the
+    // default bundle — so it tracks the primary pin, not whichever side-bundle
+    // is being synced. Repointing it for a legacy/beta sync would silently make
+    // the SDK validate against an older version by default. Gate it like skills.
+    if (includeSharedSurfaces) {
+      updateLatestSymlink(schemaCacheDir, version);
+      updateLatestSymlink(complianceCacheDir, version);
+    }
+
+    console.log(`📁 Schemas:    ${path.join(schemaCacheDir, version)}`);
+    console.log(`📁 Compliance: ${path.join(complianceCacheDir, version)}`);
+    if (existsSync(`${path.join(schemaCacheDir, version)}.previous`)) {
+      console.log(`💡 Wire-level deltas: npm run schema-diff`);
+    }
+    return provenance;
+  } finally {
+    rmSync(workDir, { recursive: true, force: true });
   }
 }
 
@@ -480,80 +907,53 @@ async function syncFromTarball(
 
   console.log(`📥 Fetching protocol bundle: ${tgzUrl}`);
   const [tgzBuf, shaText] = await Promise.all([fetchBinary(tgzUrl), fetchText(shaUrl)]);
+  await installProtocolBundle({
+    version,
+    tgzBuf,
+    expectedSha256: shaText.trim().split(/\s+/)[0],
+    source: tgzUrl,
+    includeSharedSurfaces,
+    verifySignature: tgzPath => verifyCosignSignature(tgzPath, version, baseUrl),
+  });
+  return true;
+}
 
-  const expectedSha = shaText.trim().split(/\s+/)[0];
-  const actualSha = createHash('sha256').update(tgzBuf).digest('hex');
-  if (actualSha !== expectedSha) {
-    throw new Error(`Tarball sha256 mismatch for ${tgzUrl}\n  expected: ${expectedSha}\n  actual:   ${actualSha}`);
+async function readCustomBundle(source: string): Promise<Buffer> {
+  const bundlePath = path.resolve(process.cwd(), source);
+  if (!existsSync(bundlePath) || !statSync(bundlePath).isFile()) {
+    throw new Error(`Protocol bundle file not found: ${bundlePath}`);
   }
-  console.log(`✅ sha256 verified (${expectedSha.slice(0, 12)}…)`);
+  return readFileSync(bundlePath);
+}
 
-  // Keep the work dir inside the repo so renameSync never crosses filesystems (EXDEV).
-  mkdirSync(REPO_ROOT, { recursive: true });
-  const workDir = mkdtempSync(path.join(REPO_ROOT, '.adcp-sync-'));
-  try {
-    const tgzPath = path.join(workDir, 'bundle.tgz');
-    writeFileSync(tgzPath, tgzBuf);
-
-    // Cosign keyless signature verification (adcontextprotocol/adcp#2273).
-    // Best-effort: latest is unsigned, sidecars may be absent on older releases.
-    await verifyCosignSignature(tgzPath, version, baseUrl);
-
-    await tar.x({ file: tgzPath, cwd: workDir, strict: true });
-
-    const extractRoot = path.join(workDir, `adcp-${version}`);
-    if (!existsSync(extractRoot)) {
-      throw new Error(`Tarball root ${extractRoot} not found — upstream wrapping directory may have changed.`);
-    }
-    assertNoSymlinks(extractRoot);
-
-    const bundleIndex = JSON.parse(readFileSync(path.join(extractRoot, 'schemas/index.json'), 'utf8'));
-    const bundledVersion: string | undefined = bundleIndex.adcp_version;
-    assertBundleVersion(version, bundledVersion);
-
-    replaceTree(path.join(extractRoot, 'schemas'), path.join(SCHEMA_CACHE_DIR, version));
-    replaceTree(path.join(extractRoot, 'compliance'), path.join(COMPLIANCE_CACHE_DIR, version));
-
-    // Skills sync is manifest-driven and per-name. SDK-local skills like
-    // build-seller-agent/ stay untouched; protocol-canonical ones (the
-    // call-adcp-agent buyer skill plus per-protocol skills) are kept aligned
-    // with the pinned spec version. Older tarballs (no manifest.contents.skills
-    // array) are silently skipped — the SDK-local copies stay as-is. Skipped
-    // entirely for side-bundle syncs so they keep the primary pin's skills.
-    if (includeSharedSurfaces) {
-      syncSkillsFromBundle(extractRoot);
-    }
-
-    // Refs inside the tarball point to /schemas/latest/; rewrite for pinned versions.
-    const schemaDest = path.join(SCHEMA_CACHE_DIR, version);
-    const semanticVersion: string = bundledVersion || version;
-    normalizeRefsInTree(schemaDest, semanticVersion);
-
-    // schemas/registry/registry.yaml is intentionally NOT written here. Although
-    // the protocol tarball ships an openapi/registry.yaml, the registry spec has
-    // its own upstream (agenticadvertising.org) and its own owner,
-    // `generate-registry-types --sync`. That live spec runs ahead of the pinned
-    // protocol bundle, so copying the tarball's copy only downgraded the checked-in
-    // file and left a spurious diff in every working tree after a plain sync.
-
-    // `latest/` is a shared, non-version-scoped pointer that resolves to the
-    // default bundle — so it tracks the primary pin, not whichever side-bundle
-    // is being synced. Repointing it for a legacy/beta sync would silently make
-    // the SDK validate against an older version by default. Gate it like skills.
-    if (includeSharedSurfaces) {
-      updateLatestSymlink(SCHEMA_CACHE_DIR, version);
-      updateLatestSymlink(COMPLIANCE_CACHE_DIR, version);
-    }
-
-    console.log(`📁 Schemas:    ${path.join(SCHEMA_CACHE_DIR, version)}`);
-    console.log(`📁 Compliance: ${path.join(COMPLIANCE_CACHE_DIR, version)}`);
-    if (existsSync(`${path.join(SCHEMA_CACHE_DIR, version)}.previous`)) {
-      console.log(`💡 Wire-level deltas: npm run schema-diff`);
-    }
-    return true;
-  } finally {
-    rmSync(workDir, { recursive: true, force: true });
+async function syncFromCustomBundle(
+  version: string,
+  request: CustomBundleRequest,
+  includeSharedSurfaces: boolean,
+  requireSignature: boolean
+): Promise<ProtocolBundleProvenance> {
+  const validated = validateCustomBundleRequest(request);
+  if (requireSignature) {
+    throw new Error(
+      'Protocol PR bundles are unsigned development artifacts; refusing --bundle because ADCP_REQUIRE_SIGNATURE=1.'
+    );
   }
+  const bundleUrl = officialBundleUrlForCommit(validated.bundle, validated.protocolCommit);
+  console.log(`📥 Reading immutable protocol PR bundle: ${validated.bundle}`);
+  const tgzBuf = bundleUrl
+    ? await fetchBinary(bundleUrl, { redirect: 'error' })
+    : await readCustomBundle(validated.bundle);
+  const provenance = await installProtocolBundle({
+    version,
+    tgzBuf,
+    expectedSha256: validated.bundleSha256,
+    source: validated.bundle,
+    includeSharedSurfaces,
+    expectedProtocolCommit: validated.protocolCommit,
+    ...(bundleUrl ? { bundleUrl } : {}),
+  });
+  if (!provenance) throw new Error('Protocol PR bundle did not produce codegen provenance.');
+  return provenance;
 }
 
 // Per-file schema fallback. Used only if the tarball endpoint is unavailable.
@@ -697,15 +1097,49 @@ function findMissingRefs(cacheDir: string, alreadyAttempted: Set<string>): Set<s
  * clobbering the checked-in skills or silently repointing `latest/` — callers
  * no longer need to restore them afterward.
  */
-async function sync(version?: string, options: { includeSharedSurfaces?: boolean } = {}): Promise<void> {
+async function sync(
+  version?: string,
+  options: {
+    includeSharedSurfaces?: boolean;
+    bundle?: CustomBundleRequest;
+    bundleSource?: SyncCommandLine['bundleSource'];
+  } = {}
+): Promise<void> {
   const adcpVersion = version || getTargetAdCPVersion();
   assertValidAdcpVersion(adcpVersion);
   const primaryPin = getTargetAdCPVersion();
   const includeSharedSurfaces = options.includeSharedSurfaces ?? adcpVersion === primaryPin;
+  const customBundle = resolveCustomBundleRequest(
+    adcpVersion,
+    primaryPin,
+    options.bundle,
+    CODEGEN_PROVENANCE_PATH,
+    options.bundleSource
+  );
   console.log(
     `🔄 Syncing AdCP @ ${adcpVersion}` +
       (includeSharedSurfaces ? '' : ' (schemas only — skills + latest pointer stay at the primary pin)')
   );
+
+  if (customBundle) {
+    const provenance = await syncFromCustomBundle(
+      adcpVersion,
+      customBundle,
+      includeSharedSurfaces,
+      process.env.ADCP_REQUIRE_SIGNATURE === '1'
+    );
+    writeCodegenProvenance(provenance);
+    console.log(`📌 Protocol commit: ${provenance.source_commit}`);
+    console.log(`📌 Bundle SHA-256: ${provenance.bundle_sha256}`);
+    if (includeSharedSurfaces && process.env.GITHUB_OUTPUT) {
+      appendFileSync(process.env.GITHUB_OUTPUT, `primary_schema_source=bundle\n`);
+      appendFileSync(process.env.GITHUB_OUTPUT, `protocol_commit=${provenance.source_commit}\n`);
+      appendFileSync(process.env.GITHUB_OUTPUT, `bundle_sha256=${provenance.bundle_sha256}\n`);
+      appendFileSync(process.env.GITHUB_OUTPUT, `bundle_version=${provenance.published_version}\n`);
+    }
+    console.log(`✅ Sync complete for AdCP ${adcpVersion} from immutable protocol PR bundle`);
+    return;
+  }
 
   const syncSource = await syncSchemasWithFallbacks(
     {
@@ -804,19 +1238,39 @@ async function syncSchemasWithFallbacks(
 }
 
 if (require.main === module) {
-  const version = process.argv[2];
-  sync(version).catch(error => {
+  try {
+    const commandLine = parseSyncCommandLine(process.argv.slice(2));
+    sync(commandLine.version, {
+      bundle: commandLine.bundle,
+      bundleSource: commandLine.bundleSource,
+    }).catch(error => {
+      console.error('❌ Sync failed:', error);
+      process.exit(1);
+    });
+  } catch (error) {
     console.error('❌ Sync failed:', error);
     process.exit(1);
-  });
+  }
 }
 
 export {
+  CODEGEN_PROVENANCE_PATH,
   assertBundleVersion,
+  assertProtocolCommit,
   assertValidAdcpVersion,
+  cacheMatchesCodegenProvenance,
+  createProtocolBundleProvenance,
   getGithubDistFallbackBaseUrls,
+  installProtocolBundle,
+  isSafeProtocolSkillName,
+  normalizeBundleSha256,
+  officialBundleUrlForCommit,
+  parseSyncCommandLine,
+  readCodegenProvenance,
+  resolveCustomBundleRequest,
   SchemaSyncAvailabilityError,
   sync as syncSchemas,
+  syncFromCustomBundle,
   syncFromTarball,
   syncSchemasPerFile,
   syncSchemasWithFallbacks,

--- a/test/sync-schemas-custom-bundle.test.js
+++ b/test/sync-schemas-custom-bundle.test.js
@@ -1,0 +1,346 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const TAR_MODULE = require.resolve('tar');
+
+function runHarness() {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'adcp-custom-bundle-'));
+  const script = path.join(directory, 'harness.ts');
+  const output = path.join(directory, 'output.json');
+  fs.writeFileSync(
+    script,
+    `
+import { createHash } from 'node:crypto';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import tar = require(${JSON.stringify(TAR_MODULE)});
+import { discoverAllSchemaFiles } from ${JSON.stringify(path.join(REPO_ROOT, 'scripts/generate-types.ts'))};
+import {
+  createProtocolBundleProvenance,
+  cacheMatchesCodegenProvenance,
+  installProtocolBundle,
+  isSafeProtocolSkillName,
+  normalizeBundleSha256,
+  officialBundleUrlForCommit,
+  parseSyncCommandLine,
+  readCodegenProvenance,
+  resolveCustomBundleRequest,
+  syncFromCustomBundle,
+} from ${JSON.stringify(path.join(REPO_ROOT, 'scripts/sync-schemas.ts'))};
+
+async function main() {
+const commit = 'a'.repeat(40);
+const digest = 'b'.repeat(64);
+const url = 'https://adcontextprotocol.org/protocol/pr/' + commit + '/latest.tgz';
+const capture = (fn: () => unknown) => {
+  try {
+    return { value: fn() };
+  } catch (error) {
+    return { error: error instanceof Error ? error.message : String(error) };
+  }
+};
+
+const validDocument = {
+  schema_version: 1,
+  source_repository: 'adcontextprotocol/adcp',
+  source_commit: commit,
+  published_version: '3.2.0-beta.9',
+  bundle_sha256: digest,
+  bundle_url: url,
+};
+const provenancePath = ${JSON.stringify(path.join(directory, 'provenance.json'))};
+writeFileSync(provenancePath, JSON.stringify(validDocument));
+const wrongVersionProvenancePath = ${JSON.stringify(path.join(directory, 'wrong-version-provenance.json'))};
+writeFileSync(wrongVersionProvenancePath, JSON.stringify({ ...validDocument, published_version: '3.2.0-beta.8' }));
+const localProvenancePath = ${JSON.stringify(path.join(directory, 'local-provenance.json'))};
+const { bundle_url: _bundleUrl, ...localProvenance } = validDocument;
+writeFileSync(localProvenancePath, JSON.stringify(localProvenance));
+const noDeclarationPath = ${JSON.stringify(path.join(directory, 'no-declaration.json'))};
+const noCacheProvenancePath = ${JSON.stringify(path.join(directory, 'no-cache-provenance.json'))};
+const mismatchedCacheProvenancePath = ${JSON.stringify(path.join(directory, 'mismatched-cache-provenance.json'))};
+writeFileSync(mismatchedCacheProvenancePath, JSON.stringify({ ...validDocument, bundle_sha256: 'c'.repeat(64) }));
+
+const fixtureRoot = ${JSON.stringify(path.join(directory, 'fixture'))};
+const bundleRootName = 'adcp-3.2.0-beta.9';
+const bundleRoot = path.join(fixtureRoot, bundleRootName);
+mkdirSync(path.join(bundleRoot, 'schemas'), { recursive: true });
+mkdirSync(path.join(bundleRoot, 'compliance'), { recursive: true });
+writeFileSync(path.join(bundleRoot, 'schemas/index.json'), JSON.stringify({ adcp_version: '3.2.0-beta.9', schemas: {} }));
+writeFileSync(path.join(bundleRoot, 'compliance/index.json'), JSON.stringify({ adcp_version: '3.2.0-beta.9' }));
+writeFileSync(path.join(bundleRoot, 'manifest.json'), JSON.stringify({
+  published_version: '3.2.0-beta.9',
+  source: { repository: 'adcontextprotocol/adcp', commit_sha: commit },
+}));
+const bundlePath = ${JSON.stringify(path.join(directory, 'latest.tgz'))};
+tar.c({ cwd: fixtureRoot, file: bundlePath, gzip: true, sync: true }, [bundleRootName]);
+const bundleBytes = readFileSync(bundlePath);
+const fixtureDigest = createHash('sha256').update(bundleBytes).digest('hex');
+const installRoot = ${JSON.stringify(path.join(directory, 'install'))};
+const installedProvenance = await installProtocolBundle({
+  version: '3.2.0-beta.9',
+  tgzBuf: bundleBytes,
+  expectedSha256: fixtureDigest,
+  source: bundlePath,
+  includeSharedSurfaces: false,
+  expectedProtocolCommit: commit,
+  repoRoot: installRoot,
+  schemaCacheDir: path.join(installRoot, 'schemas'),
+  complianceCacheDir: path.join(installRoot, 'compliance'),
+  skillsDir: path.join(installRoot, 'skills'),
+});
+const matchingDeclarationPath = ${JSON.stringify(path.join(directory, 'matching-declaration.json'))};
+writeFileSync(matchingDeclarationPath, JSON.stringify(installedProvenance));
+
+const results = {
+  digest: normalizeBundleSha256('sha256:' + digest),
+  officialUrl: officialBundleUrlForCommit(url, commit),
+  validSkillNames: ['adcp-media-buy', 'skill_2', 'A1'].map(isSafeProtocolSkillName),
+  unsafeSkillNames: [
+    '',
+    '.',
+    '..',
+    '../outside',
+    'nested/skill',
+    'nested' + String.fromCharCode(92) + 'skill',
+    '-leading',
+    'trailing-',
+  ].map(isSafeProtocolSkillName),
+  localPath: officialBundleUrlForCommit('/tmp/latest.tgz', commit),
+  parsedFlags: parseSyncCommandLine([
+    '3.2.0-beta.9',
+    '--bundle', url,
+    '--bundle-sha256=sha256:' + digest,
+    '--protocol-commit', commit,
+  ], {}),
+  parsedEnv: parseSyncCommandLine([], {
+    ADCP_BUNDLE_URL: '/tmp/latest.tgz',
+    ADCP_BUNDLE_SHA256: digest,
+    ADCP_PROTOCOL_COMMIT_SHA: commit,
+  }),
+  rejectedExplicitSideBundle: capture(() => resolveCustomBundleRequest(
+    '3.1.18',
+    '3.2.0-beta.9',
+    { bundle: url, bundleSha256: digest, protocolCommit: commit }
+  )),
+  ignoredEnvironmentSideBundle: resolveCustomBundleRequest(
+    '3.1.18',
+    '3.2.0-beta.9',
+    { bundle: url, bundleSha256: digest, protocolCommit: commit },
+    provenancePath,
+    'environment'
+  ),
+  readProvenance: readCodegenProvenance(provenancePath),
+  resolvedDeclaration: resolveCustomBundleRequest(
+    '3.2.0-beta.9',
+    '3.2.0-beta.9',
+    undefined,
+    provenancePath,
+    'environment'
+  ),
+  ignoredForSideBundle: resolveCustomBundleRequest(
+    '3.1.18',
+    '3.2.0-beta.9',
+    undefined,
+    provenancePath
+  ),
+  wrongDeclaredVersion: capture(() => resolveCustomBundleRequest(
+    '3.2.0-beta.9',
+    '3.2.0-beta.9',
+    undefined,
+    wrongVersionProvenancePath
+  )),
+  localDeclaration: capture(() => resolveCustomBundleRequest(
+    '3.2.0-beta.9',
+    '3.2.0-beta.9',
+    undefined,
+    localProvenancePath
+  )),
+  createdProvenance: createProtocolBundleProvenance(
+    {
+      published_version: '3.2.0-beta.9',
+      source: { repository: 'adcontextprotocol/adcp', commit_sha: commit },
+    },
+    '3.2.0-beta.9',
+    commit,
+    digest,
+    url
+  ),
+  uppercaseDigest: capture(() => normalizeBundleSha256('B'.repeat(64))),
+  partialFlags: capture(() => parseSyncCommandLine(['--bundle', url], {})),
+  conflictingEnv: capture(() => parseSyncCommandLine([], {
+    ADCP_BUNDLE: '/tmp/one.tgz',
+    ADCP_BUNDLE_URL: '/tmp/two.tgz',
+    ADCP_BUNDLE_SHA256: digest,
+    ADCP_PROTOCOL_COMMIT_SHA: commit,
+  })),
+  unknownFlag: capture(() => parseSyncCommandLine(['--wat'], {})),
+  wrongHost: capture(() => officialBundleUrlForCommit(
+    'https://example.com/protocol/pr/' + commit + '/latest.tgz',
+    commit
+  )),
+  wrongUrlCommit: capture(() => officialBundleUrlForCommit(
+    'https://adcontextprotocol.org/protocol/pr/' + 'c'.repeat(40) + '/latest.tgz',
+    commit
+  )),
+  queryString: capture(() => officialBundleUrlForCommit(url + '?download=1', commit)),
+  wrongManifestCommit: capture(() => createProtocolBundleProvenance(
+    {
+      published_version: '3.2.0-beta.9',
+      source: { repository: 'adcontextprotocol/adcp', commit_sha: 'c'.repeat(40) },
+    },
+    '3.2.0-beta.9',
+    commit,
+    digest,
+    url
+  )),
+  wrongManifestVersion: capture(() => createProtocolBundleProvenance(
+    {
+      published_version: '3.2.0-beta.8',
+      source: { repository: 'adcontextprotocol/adcp', commit_sha: commit },
+    },
+    '3.2.0-beta.9',
+    commit,
+    digest,
+    url
+  )),
+  installedProvenance,
+  installedIndex: JSON.parse(readFileSync(path.join(installRoot, 'schemas/3.2.0-beta.9/index.json'), 'utf8')),
+  installedCacheProvenance: JSON.parse(readFileSync(
+    path.join(installRoot, 'schemas/3.2.0-beta.9/_provenance.json'),
+    'utf8'
+  )),
+  matchingCacheProvenance: cacheMatchesCodegenProvenance(
+    matchingDeclarationPath,
+    path.join(installRoot, 'schemas/3.2.0-beta.9/_provenance.json')
+  ),
+  missingDeclaredCacheProvenance: cacheMatchesCodegenProvenance(provenancePath, noCacheProvenancePath),
+  mismatchedCacheProvenance: cacheMatchesCodegenProvenance(provenancePath, mismatchedCacheProvenancePath),
+  staleCustomCacheWithoutDeclaration: cacheMatchesCodegenProvenance(
+    noDeclarationPath,
+    path.join(installRoot, 'schemas/3.2.0-beta.9/_provenance.json')
+  ),
+  publishedCacheWithoutDeclaration: cacheMatchesCodegenProvenance(noDeclarationPath, noCacheProvenancePath),
+  discoveredSchemaFiles: discoverAllSchemaFiles(path.join(installRoot, 'schemas/3.2.0-beta.9')),
+  wrongFixtureDigest: await (async () => {
+    try {
+      await installProtocolBundle({
+        version: '3.2.0-beta.9',
+        tgzBuf: bundleBytes,
+        expectedSha256: 'd'.repeat(64),
+        source: bundlePath,
+        includeSharedSurfaces: false,
+        repoRoot: path.join(installRoot, 'wrong-digest'),
+        schemaCacheDir: path.join(installRoot, 'wrong-digest/schemas'),
+        complianceCacheDir: path.join(installRoot, 'wrong-digest/compliance'),
+      });
+      return {};
+    } catch (error) {
+      return { error: error instanceof Error ? error.message : String(error) };
+    }
+  })(),
+  missingLocalBundle: await (async () => {
+    try {
+      await syncFromCustomBundle('3.2.0-beta.9', {
+        bundle: path.join(installRoot, 'missing.tgz'),
+        bundleSha256: digest,
+        protocolCommit: commit,
+      }, false, false);
+      return {};
+    } catch (error) {
+      return { error: error instanceof Error ? error.message : String(error) };
+    }
+  })(),
+  signatureRequired: await (async () => {
+    try {
+      await syncFromCustomBundle('3.2.0-beta.9', {
+        bundle: bundlePath,
+        bundleSha256: fixtureDigest,
+        protocolCommit: commit,
+      }, false, true);
+      return {};
+    } catch (error) {
+      return { error: error instanceof Error ? error.message : String(error) };
+    }
+  })(),
+};
+
+writeFileSync(${JSON.stringify(output)}, JSON.stringify(results));
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});
+`
+  );
+
+  try {
+    const result = spawnSync(path.join(REPO_ROOT, 'node_modules/.bin/tsx'), [script], {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 0, `harness failed:\n${result.stderr}\n${result.stdout}`);
+    return JSON.parse(fs.readFileSync(output, 'utf8'));
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+test('custom schema bundles are immutable, commit-addressed, and reproducible', () => {
+  const results = runHarness();
+  const commit = 'a'.repeat(40);
+  const digest = 'b'.repeat(64);
+  const url = `https://adcontextprotocol.org/protocol/pr/${commit}/latest.tgz`;
+
+  assert.equal(results.digest, digest);
+  assert.equal(results.officialUrl, url);
+  assert.deepEqual(results.validSkillNames, [true, true, true]);
+  assert.deepEqual(results.unsafeSkillNames, [false, false, false, false, false, false, false, false]);
+  assert.equal(results.localPath, undefined);
+  assert.deepEqual(results.parsedFlags, {
+    version: '3.2.0-beta.9',
+    bundle: { bundle: url, bundleSha256: digest, protocolCommit: commit },
+    bundleSource: 'arguments',
+  });
+  assert.deepEqual(results.parsedEnv, {
+    bundle: { bundle: '/tmp/latest.tgz', bundleSha256: digest, protocolCommit: commit },
+    bundleSource: 'environment',
+  });
+  assert.match(results.rejectedExplicitSideBundle.error, /may only target the primary ADCP_VERSION/);
+  assert.equal(results.ignoredEnvironmentSideBundle, undefined);
+  assert.deepEqual(results.readProvenance, results.createdProvenance);
+  assert.deepEqual(results.resolvedDeclaration, {
+    bundle: url,
+    bundleSha256: digest,
+    protocolCommit: commit,
+  });
+  assert.equal(results.ignoredForSideBundle, undefined);
+  assert.match(results.wrongDeclaredVersion.error, /Codegen provenance version mismatch/);
+  assert.match(results.localDeclaration.error, /no bundle_url for reproducible CI/);
+  assert.match(results.uppercaseDigest.error, /64 lowercase hexadecimal/);
+  assert.match(results.partialFlags.error, /require --bundle, --bundle-sha256, and --protocol-commit/);
+  assert.match(results.conflictingEnv.error, /ADCP_BUNDLE and ADCP_BUNDLE_URL disagree/);
+  assert.match(results.unknownFlag.error, /Unknown schema sync option/);
+  assert.match(results.wrongHost.error, /official immutable URL/);
+  assert.match(results.wrongUrlCommit.error, /official immutable URL/);
+  assert.match(results.queryString.error, /official immutable URL/);
+  assert.match(results.wrongManifestCommit.error, /commit mismatch/);
+  assert.match(results.wrongManifestVersion.error, /manifest version mismatch/);
+  assert.equal(results.installedProvenance.source_commit, commit);
+  assert.equal(results.installedProvenance.bundle_sha256, results.installedCacheProvenance.bundle_sha256);
+  assert.equal(results.installedIndex.adcp_version, '3.2.0-beta.9');
+  assert.equal(results.matchingCacheProvenance, true);
+  assert.equal(results.missingDeclaredCacheProvenance, false);
+  assert.equal(results.mismatchedCacheProvenance, false);
+  assert.equal(results.staleCustomCacheWithoutDeclaration, false);
+  assert.equal(results.publishedCacheWithoutDeclaration, true);
+  assert.ok(!results.discoveredSchemaFiles.includes('_provenance.json'));
+  assert.match(results.wrongFixtureDigest.error, /sha256 mismatch/);
+  assert.match(results.missingLocalBundle.error, /file not found/);
+  assert.match(results.signatureRequired.error, /unsigned development artifacts/);
+});


### PR DESCRIPTION
Closes #2751

## Summary

- accept immutable protocol PR bundles from an exact local path or official commit-addressed URL
- require and verify the bundle SHA-256, upstream commit, manifest provenance, version, archive shape, and required schema trees before installation
- persist the exact provenance tuple so code generation and CI drift checks reproduce the reviewed bundle without falling back to published schemas
- document the dependent-branch refresh workflow and cover success, failure, cache, branch-switch, and code-generation paths with hermetic tests

## Verification

- `npm test`
- `npm run typecheck`
- `npm run build`
- `npm run format:check`
- `npm run lint`
- `npm run lint:workflows`
- focused custom-bundle and fallback tests
- independent code, protocol, and security reviews
- security diff scan: no reportable findings
