### PR TITLE
fix(decisioning): preserve live abort signals

### DIFF
--- a/.changeset/live-signals-cancel.md
+++ b/.changeset/live-signals-cancel.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Preserve live `AbortSignal` identity in native decisioning request authentication context so provider work observes host cancellation after dispatch begins.

--- a/src/lib/server/decisioning/context.ts
+++ b/src/lib/server/decisioning/context.ts
@@ -56,6 +56,10 @@ export interface RequestContext<TAccount = Account> {
    * `ctx_metadata`, account objects, task results, logs, or durable HITL
    * state. Background workers must re-resolve credentials; if durable work
    * only needs identity, snapshot a stable non-secret principal identifier.
+   * A native `AbortSignal` stored as a data property at
+   * `authInfo.extra.signal` retains its identity so later host cancellation
+   * remains observable. Other auth values retain the framework's existing
+   * clone-and-freeze behavior.
    */
   authInfo?: Readonly<ResolvedAuthInfo>;
 

--- a/src/lib/server/decisioning/runtime/to-context.ts
+++ b/src/lib/server/decisioning/runtime/to-context.ts
@@ -40,32 +40,93 @@ import {
 } from '../async-outcome';
 import type { CtxMetadataStore, ResourceKind, CtxMetadataRef } from '../../ctx-metadata';
 
-function cloneAndFreezeAuthValue<T>(value: T, seen = new WeakMap<object, unknown>()): T {
+const abortSignalAbortedGetter =
+  typeof AbortSignal === 'undefined'
+    ? undefined
+    : Object.getOwnPropertyDescriptor(AbortSignal.prototype, 'aborted')?.get;
+
+function isNativeAbortSignal(value: object): value is AbortSignal {
+  if (abortSignalAbortedGetter === undefined) return false;
+  try {
+    abortSignalAbortedGetter.call(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+type AuthValuePosition = 'root' | 'extra' | 'abort-signal' | 'other';
+type SeenAuthValues = WeakMap<object, Map<AuthValuePosition, unknown>>;
+
+function nestedAuthValuePosition(position: AuthValuePosition, key: PropertyKey): AuthValuePosition {
+  if (position === 'root' && key === 'extra') return 'extra';
+  if (position === 'extra' && key === 'signal') return 'abort-signal';
+  return 'other';
+}
+
+function authValueCachePosition(object: object, position: AuthValuePosition, root: object): AuthValuePosition {
+  if (position === 'root' || object === root) return 'root';
+  if (position !== 'extra') return 'other';
+  const signalDescriptor = Object.getOwnPropertyDescriptor(object, 'signal');
+  return signalDescriptor &&
+    'value' in signalDescriptor &&
+    signalDescriptor.value !== null &&
+    (typeof signalDescriptor.value === 'object' || typeof signalDescriptor.value === 'function') &&
+    isNativeAbortSignal(signalDescriptor.value)
+    ? 'extra'
+    : 'other';
+}
+
+function rememberAuthValueClone(
+  seen: SeenAuthValues,
+  object: object,
+  position: AuthValuePosition,
+  clone: unknown
+): void {
+  const clonesByPosition = seen.get(object) ?? new Map<AuthValuePosition, unknown>();
+  clonesByPosition.set(position, clone);
+  seen.set(object, clonesByPosition);
+}
+
+function cloneAndFreezeAuthValue<T>(
+  value: T,
+  seen: SeenAuthValues = new WeakMap(),
+  position: AuthValuePosition = 'root',
+  rootObject?: object
+): T {
   if (value === null || (typeof value !== 'object' && typeof value !== 'function')) return value;
+  // AbortSignal is a live, request-local capability rather than a data
+  // record. Cloning its prototype and own properties creates an object that
+  // fails the native brand check and is disconnected from future aborts.
+  // Preserve the verified host signal by reference so provider work observes
+  // cancellation after dispatch has begun.
   const object = value as unknown as object;
-  const prior = seen.get(object);
-  if (prior !== undefined) return prior as T;
+  const root = rootObject ?? object;
+  if (position === 'abort-signal' && object !== root && isNativeAbortSignal(object)) return value;
+  const cachePosition = authValueCachePosition(object, position, root);
+  const clonesByPosition = seen.get(object);
+  if (clonesByPosition?.has(cachePosition)) return clonesByPosition.get(cachePosition) as T;
   if (value instanceof Date) return Object.freeze(new Date(value.getTime())) as T;
   if (value instanceof Map) {
     const clone = new Map();
-    seen.set(object, clone);
+    rememberAuthValueClone(seen, object, cachePosition, clone);
     for (const [key, entry] of value)
-      clone.set(cloneAndFreezeAuthValue(key, seen), cloneAndFreezeAuthValue(entry, seen));
+      clone.set(cloneAndFreezeAuthValue(key, seen, 'other', root), cloneAndFreezeAuthValue(entry, seen, 'other', root));
     return Object.freeze(clone) as T;
   }
   if (value instanceof Set) {
     const clone = new Set();
-    seen.set(object, clone);
-    for (const entry of value) clone.add(cloneAndFreezeAuthValue(entry, seen));
+    rememberAuthValueClone(seen, object, cachePosition, clone);
+    for (const entry of value) clone.add(cloneAndFreezeAuthValue(entry, seen, 'other', root));
     return Object.freeze(clone) as T;
   }
   const clone = Array.isArray(value) ? [] : Object.create(Object.getPrototypeOf(value));
-  seen.set(object, clone);
+  rememberAuthValueClone(seen, object, cachePosition, clone);
   for (const key of Reflect.ownKeys(object)) {
     const descriptor = Object.getOwnPropertyDescriptor(object, key);
     if (!descriptor) continue;
     if ('value' in descriptor) {
-      descriptor.value = cloneAndFreezeAuthValue(descriptor.value, seen);
+      descriptor.value = cloneAndFreezeAuthValue(descriptor.value, seen, nestedAuthValuePosition(position, key), root);
       descriptor.writable = false;
     }
     descriptor.configurable = false;

--- a/test/server-decisioning-from-platform.test.js
+++ b/test/server-decisioning-from-platform.test.js
@@ -681,6 +681,304 @@ describe('createAdcpServerFromPlatform — v6.0 alpha', () => {
     assert.strictEqual(await server.getTaskState(taskId, { accountId: 'acct-1', ownerScope: 'client:caller-b' }), null);
   });
 
+  it('preserves live AbortSignal cancellation in native authInfo context (#2773)', async () => {
+    const controller = new AbortController();
+    let receivedSignal;
+    let handlerStartedResolve;
+    const handlerStarted = new Promise(resolve => {
+      handlerStartedResolve = resolve;
+    });
+    let continueHandlerResolve;
+    const continueHandler = new Promise(resolve => {
+      continueHandlerResolve = resolve;
+    });
+    const base = buildPlatform();
+    const server = createAdcpServerFromPlatform(
+      buildPlatform({
+        sales: {
+          ...base.sales,
+          getProducts: async (_req, ctx) => {
+            receivedSignal = ctx.authInfo.extra.signal;
+            handlerStartedResolve();
+            await continueHandler;
+            return { products: [], cache_scope: 'account' };
+          },
+        },
+      }),
+      {
+        name: 'native-auth-cancellation',
+        version: '1.0.0',
+        validation: { requests: 'off', responses: 'off' },
+      }
+    );
+
+    const request = server.invoke({
+      toolName: 'get_products',
+      args: { account: { account_id: 'acct-1' }, buying_mode: 'wholesale' },
+      authInfo: {
+        token: 'secret',
+        clientId: 'buyer',
+        scopes: [],
+        extra: { signal: controller.signal },
+      },
+    });
+    await handlerStarted;
+
+    controller.abort(new Error('deadline'));
+    continueHandlerResolve();
+    await request;
+    assert.strictEqual(receivedSignal, controller.signal);
+    assert.strictEqual(receivedSignal.aborted, true);
+  });
+
+  it('does not eagerly invoke accessors while cloning the authInfo signal slot (#2773)', async () => {
+    const controller = new AbortController();
+    let signalReads = 0;
+    const extra = {};
+    Object.defineProperty(extra, 'signal', {
+      configurable: true,
+      enumerable: true,
+      get() {
+        signalReads += 1;
+        return controller.signal;
+      },
+    });
+    let receivedExtra;
+    let receivedSignalDescriptor;
+    const base = buildPlatform();
+    const server = createAdcpServerFromPlatform(
+      buildPlatform({
+        sales: {
+          ...base.sales,
+          getProducts: async (_req, ctx) => {
+            receivedExtra = ctx.authInfo.extra;
+            receivedSignalDescriptor = Object.getOwnPropertyDescriptor(receivedExtra, 'signal');
+            return { products: [], cache_scope: 'account' };
+          },
+        },
+      }),
+      {
+        name: 'native-auth-signal-accessor',
+        version: '1.0.0',
+        validation: { requests: 'off', responses: 'off' },
+      }
+    );
+
+    await server.invoke({
+      toolName: 'get_products',
+      args: { account: { account_id: 'acct-1' }, buying_mode: 'wholesale' },
+      authInfo: { token: 'secret', clientId: 'buyer', scopes: [], extra },
+    });
+
+    assert.strictEqual(signalReads, 0);
+    assert.notStrictEqual(receivedExtra, extra);
+    assert.ok(Object.isFrozen(receivedExtra));
+    assert.strictEqual(receivedSignalDescriptor.get, Object.getOwnPropertyDescriptor(extra, 'signal').get);
+  });
+
+  it('preserves only extra.signal when auth credential and extra records alias in either key order (#2773)', async () => {
+    const controller = new AbortController();
+    const shared = {
+      kind: 'api_key',
+      key_id: 'caller-a',
+      signal: controller.signal,
+    };
+    const principals = [
+      {
+        token: 'secret',
+        clientId: 'caller-a',
+        scopes: [],
+        credential: shared,
+        extra: shared,
+      },
+      {
+        token: 'secret',
+        clientId: 'caller-a',
+        scopes: [],
+        extra: shared,
+        credential: shared,
+      },
+    ];
+    const receivedAuth = [];
+    const base = buildPlatform();
+    const server = createAdcpServerFromPlatform(
+      buildPlatform({
+        sales: {
+          ...base.sales,
+          getProducts: async (_req, ctx) => {
+            receivedAuth.push(ctx.authInfo);
+            return { products: [], cache_scope: 'account' };
+          },
+        },
+      }),
+      {
+        name: 'native-auth-signal-alias',
+        version: '1.0.0',
+        validation: { requests: 'off', responses: 'off' },
+      }
+    );
+
+    for (const principal of principals) {
+      await server.invoke({
+        toolName: 'get_products',
+        args: { account: { account_id: 'acct-1' }, buying_mode: 'wholesale' },
+        authInfo: principal,
+      });
+    }
+    controller.abort(new Error('deadline'));
+
+    for (const authInfo of receivedAuth) {
+      assert.strictEqual(authInfo.extra.signal, controller.signal);
+      assert.strictEqual(authInfo.extra.signal.aborted, true);
+      assert.notStrictEqual(authInfo.credential.signal, controller.signal);
+      assert.notStrictEqual(authInfo.extra, authInfo.credential);
+      assert.ok(Object.isFrozen(authInfo.extra));
+      assert.ok(Object.isFrozen(authInfo.credential));
+    }
+  });
+
+  it('preserves auth record aliases when no live signal requires a path-specific clone (#2773)', async () => {
+    const shared = { kind: 'api_key', key_id: 'caller-a' };
+    let receivedAuthInfo;
+    const base = buildPlatform();
+    const server = createAdcpServerFromPlatform(
+      buildPlatform({
+        sales: {
+          ...base.sales,
+          getProducts: async (_req, ctx) => {
+            receivedAuthInfo = ctx.authInfo;
+            return { products: [], cache_scope: 'account' };
+          },
+        },
+      }),
+      {
+        name: 'native-auth-record-alias',
+        version: '1.0.0',
+        validation: { requests: 'off', responses: 'off' },
+      }
+    );
+
+    await server.invoke({
+      toolName: 'get_products',
+      args: { account: { account_id: 'acct-1' }, buying_mode: 'wholesale' },
+      authInfo: {
+        token: 'secret',
+        clientId: 'caller-a',
+        scopes: [],
+        credential: shared,
+        extra: shared,
+      },
+    });
+
+    assert.strictEqual(receivedAuthInfo.credential, receivedAuthInfo.extra);
+    assert.notStrictEqual(receivedAuthInfo.extra, shared);
+    assert.ok(Object.isFrozen(receivedAuthInfo.extra));
+  });
+
+  it('does not let an AbortSignal prototype spoof bypass authInfo snapshotting (#2773)', async () => {
+    const principal = {
+      token: 'secret',
+      clientId: 'caller-a',
+      scopes: [],
+    };
+    Object.setPrototypeOf(principal, AbortSignal.prototype);
+    let receivedAuthInfo;
+    const base = buildPlatform();
+    const server = createAdcpServerFromPlatform(
+      buildPlatform({
+        sales: {
+          ...base.sales,
+          getProducts: async (_req, ctx) => {
+            receivedAuthInfo = ctx.authInfo;
+            ctx.authInfo.clientId = 'caller-b';
+            return ctx.handoffToTask(async () => ({ products: [], cache_scope: 'account' }));
+          },
+        },
+      }),
+      {
+        name: 'native-auth-signal-spoof',
+        version: '1.0.0',
+        validation: { requests: 'off', responses: 'off' },
+      }
+    );
+
+    const result = await server.dispatchTestRequest(
+      {
+        method: 'tools/call',
+        params: { name: 'get_products', arguments: { account: { account_id: 'acct-1' } } },
+      },
+      { authInfo: principal }
+    );
+    const taskId = result.structuredContent.task_id;
+    await server.awaitTaskUnsafe(taskId);
+
+    assert.notStrictEqual(receivedAuthInfo, principal);
+    assert.ok(Object.isFrozen(receivedAuthInfo));
+    assert.strictEqual(receivedAuthInfo.clientId, 'caller-a');
+    assert.ok(await server.getTaskState(taskId, { accountId: 'acct-1', ownerScope: 'client:caller-a' }));
+    assert.strictEqual(await server.getTaskState(taskId, { accountId: 'acct-1', ownerScope: 'client:caller-b' }), null);
+  });
+
+  it('snapshots root auth principals backed by genuine AbortSignals (#2773)', async () => {
+    const inheritedController = new AbortController();
+    const principals = [
+      Object.assign(new AbortController().signal, {
+        token: 'secret',
+        clientId: 'caller-a',
+        scopes: [],
+      }),
+      Object.setPrototypeOf(
+        {
+          token: 'secret',
+          clientId: 'caller-a',
+          scopes: [],
+        },
+        inheritedController.signal
+      ),
+    ];
+
+    for (const [index, principal] of principals.entries()) {
+      let receivedAuthInfo;
+      const base = buildPlatform();
+      const server = createAdcpServerFromPlatform(
+        buildPlatform({
+          sales: {
+            ...base.sales,
+            getProducts: async (_req, ctx) => {
+              receivedAuthInfo = ctx.authInfo;
+              ctx.authInfo.clientId = 'caller-b';
+              return ctx.handoffToTask(async () => ({ products: [], cache_scope: 'account' }));
+            },
+          },
+        }),
+        {
+          name: `native-auth-signal-root-${index}`,
+          version: '1.0.0',
+          validation: { requests: 'off', responses: 'off' },
+        }
+      );
+
+      const result = await server.dispatchTestRequest(
+        {
+          method: 'tools/call',
+          params: { name: 'get_products', arguments: { account: { account_id: 'acct-1' } } },
+        },
+        { authInfo: principal }
+      );
+      const taskId = result.structuredContent.task_id;
+      await server.awaitTaskUnsafe(taskId);
+
+      assert.notStrictEqual(receivedAuthInfo, principal);
+      assert.ok(Object.isFrozen(receivedAuthInfo));
+      assert.strictEqual(receivedAuthInfo.clientId, 'caller-a');
+      assert.ok(await server.getTaskState(taskId, { accountId: 'acct-1', ownerScope: 'client:caller-a' }));
+      assert.strictEqual(
+        await server.getTaskState(taskId, { accountId: 'acct-1', ownerScope: 'client:caller-b' }),
+        null
+      );
+    }
+  });
+
   it('omits authInfo from unauthenticated native RequestContext calls (#2765)', async () => {
     let handlerCtx;
     const base = buildPlatform();


### PR DESCRIPTION
## Summary

- preserve a genuine native `AbortSignal` at `authInfo.extra.signal` so provider handlers observe cancellation after dispatch begins
- retain clone-and-freeze isolation everywhere else, including spoofed signals, root principals, ordinary aliases, and accessor-backed values
- document the request-context contract and add a patch changeset

## Testing

- `npm run build`
- `npm run test:file -- test/server-decisioning-from-platform.test.js` (219 passed)
- `npm run typecheck`
- `npm run review:codex -- --all --base main`
- pre-push validation

Closes #2773
