### PR TITLE
fix(codegen): deduplicate Product OpenAPI schemas

### DIFF
--- a/.changeset/compact-adopter-product-openapi.md
+++ b/.changeset/compact-adopter-product-openapi.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Deduplicate repeated Product format and placement validators so adopter OpenAPI documents stay compact when extending `ProductSchema`.

--- a/scripts/generate-zod-from-ts.ts
+++ b/scripts/generate-zod-from-ts.ts
@@ -3121,6 +3121,92 @@ function postProcessMarkerUnionObjectIntersections(content: string): string {
   return result;
 }
 
+function topLevelAndOperands(expression: string): string[] | undefined {
+  let depth = 0;
+  let firstAnd = -1;
+  for (let i = 0; i < expression.length; i++) {
+    const literalEnd = skipQuotedOrRegexLiteral(expression, i);
+    if (literalEnd !== undefined) {
+      i = literalEnd - 1;
+      continue;
+    }
+    const ch = expression[i];
+    if (ch === '(' || ch === '{' || ch === '[') depth++;
+    else if (ch === ')' || ch === '}' || ch === ']') depth--;
+    else if (depth === 0 && expression.startsWith('.and(', i)) {
+      firstAnd = i;
+      break;
+    }
+  }
+  if (firstAnd < 0) return [expression.trim()];
+
+  const operands = [expression.slice(0, firstAnd).trim()];
+  let cursor = firstAnd;
+  while (cursor < expression.length) {
+    cursor = skipWhitespace(expression, cursor);
+    if (!expression.startsWith('.and(', cursor)) return undefined;
+    const argument = scanBalanced(expression, cursor + '.and'.length);
+    if (!argument) return undefined;
+    operands.push(argument.body.trim());
+    cursor = argument.end;
+  }
+  return operands;
+}
+
+/**
+ * Collapse repeated Product format/placement intersection operands introduced
+ * when json-schema-to-typescript follows the same dereferenced allOf layers
+ * through compatibility aliases. Re-validating an identical pure object or
+ * union adds no semantics, but zod-openapi expands every copy recursively.
+ */
+function postProcessRepeatedProductIntersections(content: string): string {
+  let result = content;
+
+  for (const schemaName of ['ProductFormatDeclarationSchema', 'PlacementSchema']) {
+    const target = findSchemaExportExpressions(result).find(entry => entry.name === schemaName);
+    if (!target) throw new Error(`postProcessRepeatedProductIntersections: ${schemaName} export not found.`);
+    const operands = topLevelAndOperands(target.expression);
+    if (!operands) throw new Error(`postProcessRepeatedProductIntersections: could not parse ${schemaName}.`);
+
+    const seen = new Set<string>();
+    const unique = operands.filter(operand => {
+      const exact = operand.trim();
+      if (seen.has(exact)) return false;
+      seen.add(exact);
+      return true;
+    });
+
+    if (schemaName === 'ProductFormatDeclarationSchema' && unique.length === 3 && unique.length < operands.length) {
+      const exactOperands = operands.map(operand => operand.trim());
+      const [commonA, formatUnion, commonB] = unique;
+      const expected = [commonA, formatUnion, commonB, formatUnion, commonB, formatUnion, commonB, formatUnion];
+      if (
+        exactOperands.length !== expected.length ||
+        exactOperands.some((operand, index) => operand !== expected[index]) ||
+        !commonA?.endsWith(`.merge(${commonB})`)
+      ) {
+        const classes: string[] = [];
+        const classByOperand = new Map<string, string>();
+        for (const operand of exactOperands) {
+          const label = classByOperand.get(operand) ?? String.fromCharCode(65 + classByOperand.size);
+          classByOperand.set(operand, label);
+          classes.push(label);
+        }
+        throw new Error(
+          `postProcessRepeatedProductIntersections: ProductFormatDeclaration no longer matches the verified repeated allOf projection (${classes.join('')}).`
+        );
+      }
+      unique.pop();
+    }
+
+    if (unique.length === operands.length) continue;
+    const rewritten = unique.slice(1).reduce((chain, operand) => `${chain}.and(${operand})`, unique[0]!);
+    result = result.slice(0, target.expressionStart) + rewritten + result.slice(target.expressionEnd);
+  }
+
+  return result;
+}
+
 function postProcessObjectIntersections(content: string): string {
   const schemaExpressions = extractSchemaExports(content);
   const shapeCache = new Map<string, ObjectShape | undefined>();
@@ -4062,6 +4148,11 @@ async function generateZodSchemas() {
     zodSchemas = postProcessCanonicalPrimitiveConstraints(zodSchemas);
     zodSchemas = postProcessJsonSchemaUriFormats(zodSchemas);
 
+    // Compatibility aliases can make jsts emit repeated format/placement
+    // intersections. Collapse them before annotation so adopter OpenAPI
+    // generators see each validation block once.
+    zodSchemas = postProcessRepeatedProductIntersections(zodSchemas);
+
     // Post-process: Add explicit z.ZodType annotations to schemas that trip TS7056.
     zodSchemas = postProcessTS7056Annotations(zodSchemas);
 
@@ -4119,6 +4210,7 @@ export const __test__ = {
   postProcessForNullish,
   postProcessRecordIntersections,
   postProcessMarkerUnionObjectIntersections,
+  postProcessRepeatedProductIntersections,
   postProcessCanonicalFormatSlots,
   postProcessCreativeBriefRequiredDisclosures,
   postProcessObjectUnionIntersections,

--- a/src/lib/types/schemas.generated.ts
+++ b/src/lib/types/schemas.generated.ts
@@ -1,5 +1,5 @@
 // Generated Zod v4 schemas from TypeScript types
-// Generated at: 2026-08-29T14:02:43.834Z
+// Generated at: 2026-08-29T20:19:54.191Z
 // Sources:
 //   - core.generated.ts (core types)
 //   - tools.generated.ts (tool types)
@@ -11530,54 +11530,6 @@ export const ProductFormatDeclarationSchema: z.ZodObject<{ [K in keyof ProductFo
     format_shape: z.string().optional(),
     v1_format_ref: z.array(FormatReferenceStructuredObjectSchema).optional(),
     format_schema: PlatformExtensionReferenceSchema.optional()
-}).passthrough()).and(z.union([ImageFormatDeclarationSchema, HTML5FormatDeclarationSchema, DisplayTagFormatDeclarationSchema, ImageCarouselFormatDeclarationSchema, HostedVideoFormatDeclarationSchema, VASTVideoFormatDeclarationSchema, HostedAudioFormatDeclarationSchema, DAASTAudioFormatDeclarationSchema, SponsoredPlacementFormatDeclarationSchema, NativeInFeedFormatDeclarationSchema, ResponsiveCreativeFormatDeclarationSchema, AgentPlacementFormatDeclarationSchema, SellerRenderedStatefulDisplayFormatDeclarationSchema, CoordinatedPlacementsFormatDeclarationSchema, CustomFormatDeclarationSchema])).and(z.object({
-    format_option_id: z.string().optional(),
-    publisher_domain: z.string().regex(new RegExp("^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$")).optional(),
-    tracker_execution_contract: TrackerExecutionContractSchema.optional(),
-    macro_resolution_capabilities: z.array(MacroProcessingCapabilitySchema).optional(),
-    technical_requirements_complete: z.boolean().optional(),
-    display_name: z.string().optional(),
-    sample_render_url: z.string().regex(new RegExp("^https://")).refine(adcpJsonSchemaUri, "Invalid URI").optional(),
-    applies_to_channels: z.array(MediaChannelSchema).optional(),
-    seller_preference: z.union([z.literal("preferred"), z.literal("accepted"), z.literal("discouraged")]).optional(),
-    locale_policy: CreativeLocalePolicySchema.optional(),
-    canonical_formats_only: z.boolean().optional(),
-    experimental: z.boolean().optional(),
-    format_shape: z.string().optional(),
-    v1_format_ref: z.array(FormatReferenceStructuredObjectSchema).optional(),
-    format_schema: PlatformExtensionReferenceSchema.optional()
-}).passthrough()).and(z.union([ImageFormatDeclarationSchema, HTML5FormatDeclarationSchema, DisplayTagFormatDeclarationSchema, ImageCarouselFormatDeclarationSchema, HostedVideoFormatDeclarationSchema, VASTVideoFormatDeclarationSchema, HostedAudioFormatDeclarationSchema, DAASTAudioFormatDeclarationSchema, SponsoredPlacementFormatDeclarationSchema, NativeInFeedFormatDeclarationSchema, ResponsiveCreativeFormatDeclarationSchema, AgentPlacementFormatDeclarationSchema, SellerRenderedStatefulDisplayFormatDeclarationSchema, CoordinatedPlacementsFormatDeclarationSchema, CustomFormatDeclarationSchema])).and(z.object({
-    format_option_id: z.string().optional(),
-    publisher_domain: z.string().regex(new RegExp("^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$")).optional(),
-    tracker_execution_contract: TrackerExecutionContractSchema.optional(),
-    macro_resolution_capabilities: z.array(MacroProcessingCapabilitySchema).optional(),
-    technical_requirements_complete: z.boolean().optional(),
-    display_name: z.string().optional(),
-    sample_render_url: z.string().regex(new RegExp("^https://")).refine(adcpJsonSchemaUri, "Invalid URI").optional(),
-    applies_to_channels: z.array(MediaChannelSchema).optional(),
-    seller_preference: z.union([z.literal("preferred"), z.literal("accepted"), z.literal("discouraged")]).optional(),
-    locale_policy: CreativeLocalePolicySchema.optional(),
-    canonical_formats_only: z.boolean().optional(),
-    experimental: z.boolean().optional(),
-    format_shape: z.string().optional(),
-    v1_format_ref: z.array(FormatReferenceStructuredObjectSchema).optional(),
-    format_schema: PlatformExtensionReferenceSchema.optional()
-}).passthrough()).and(z.union([ImageFormatDeclarationSchema, HTML5FormatDeclarationSchema, DisplayTagFormatDeclarationSchema, ImageCarouselFormatDeclarationSchema, HostedVideoFormatDeclarationSchema, VASTVideoFormatDeclarationSchema, HostedAudioFormatDeclarationSchema, DAASTAudioFormatDeclarationSchema, SponsoredPlacementFormatDeclarationSchema, NativeInFeedFormatDeclarationSchema, ResponsiveCreativeFormatDeclarationSchema, AgentPlacementFormatDeclarationSchema, SellerRenderedStatefulDisplayFormatDeclarationSchema, CoordinatedPlacementsFormatDeclarationSchema, CustomFormatDeclarationSchema])).and(z.object({
-    format_option_id: z.string().optional(),
-    publisher_domain: z.string().regex(new RegExp("^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$")).optional(),
-    tracker_execution_contract: TrackerExecutionContractSchema.optional(),
-    macro_resolution_capabilities: z.array(MacroProcessingCapabilitySchema).optional(),
-    technical_requirements_complete: z.boolean().optional(),
-    display_name: z.string().optional(),
-    sample_render_url: z.string().regex(new RegExp("^https://")).refine(adcpJsonSchemaUri, "Invalid URI").optional(),
-    applies_to_channels: z.array(MediaChannelSchema).optional(),
-    seller_preference: z.union([z.literal("preferred"), z.literal("accepted"), z.literal("discouraged")]).optional(),
-    locale_policy: CreativeLocalePolicySchema.optional(),
-    canonical_formats_only: z.boolean().optional(),
-    experimental: z.boolean().optional(),
-    format_shape: z.string().optional(),
-    v1_format_ref: z.array(FormatReferenceStructuredObjectSchema).optional(),
-    format_schema: PlatformExtensionReferenceSchema.optional()
 }).passthrough()).and(z.union([ImageFormatDeclarationSchema, HTML5FormatDeclarationSchema, DisplayTagFormatDeclarationSchema, ImageCarouselFormatDeclarationSchema, HostedVideoFormatDeclarationSchema, VASTVideoFormatDeclarationSchema, HostedAudioFormatDeclarationSchema, DAASTAudioFormatDeclarationSchema, SponsoredPlacementFormatDeclarationSchema, NativeInFeedFormatDeclarationSchema, ResponsiveCreativeFormatDeclarationSchema, AgentPlacementFormatDeclarationSchema, SellerRenderedStatefulDisplayFormatDeclarationSchema, CoordinatedPlacementsFormatDeclarationSchema, CustomFormatDeclarationSchema]));
 
 export const AudienceEvidenceSelectionSchema: z.ZodType = z.object({
@@ -11602,21 +11554,6 @@ export const AudienceEvidenceSelectionSchema: z.ZodType = z.object({
 
 // @ts-ignore -- preserve the public schema type across lossy TS-to-Zod projection details.
 export const PlacementSchema: z.ZodType<Placement & Record<string, unknown>, Placement & Record<string, unknown>> = z.object({}).passthrough().merge(z.object({}).passthrough()).merge(z.object({}).passthrough()).and(z.union([z.object({}).passthrough(), z.object({}).passthrough()])).and(z.object({
-    kind: z.union([z.literal("publisher_ref"), z.literal("seller_inline")]),
-    placement_id: z.string(),
-    publisher_domain: z.string().regex(new RegExp("^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$")).optional(),
-    seller_agent: SellerAgentReferenceSchema.optional(),
-    name: z.string().optional(),
-    description: z.string().optional(),
-    mode: z.union([z.literal("targetable"), z.literal("included")]),
-    tags: z.array(z.string()).optional(),
-    format_ids: z.array(FormatReferenceStructuredObjectSchema).optional(),
-    format_options: z.array(ProductFormatDeclarationSchema).optional(),
-    video_placement_types: z.array(VideoPlacementTypeSchema).optional(),
-    audio_distribution_types: z.array(AudioDistributionTypeSchema).optional(),
-    sponsored_placement_types: z.array(SponsoredPlacementTypeSchema).optional(),
-    social_placement_surfaces: z.array(SocialPlacementSurfaceSchema).optional()
-}).passthrough()).and(z.union([z.object({}).passthrough(), z.object({}).passthrough()])).and(z.object({
     kind: z.union([z.literal("publisher_ref"), z.literal("seller_inline")]),
     placement_id: z.string(),
     publisher_domain: z.string().regex(new RegExp("^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$")).optional(),

--- a/test/generate-zod-object-intersections.test.js
+++ b/test/generate-zod-object-intersections.test.js
@@ -66,6 +66,10 @@ function postProcessMarkerUnionObjectIntersections(input) {
   return runPostProcess('postProcessMarkerUnionObjectIntersections', input, '.zod-marker-union-');
 }
 
+function postProcessRepeatedProductIntersections(input) {
+  return runPostProcess('postProcessRepeatedProductIntersections', input, '.zod-product-intersections-');
+}
+
 function postProcessObjectUnionIntersections(input) {
   return runPostProcess('postProcessObjectUnionIntersections', input, '.zod-object-union-');
 }
@@ -241,6 +245,64 @@ export const FutureProductSchema = z.union([V1MarkerSchema, V2MarkerSchema]).and
 
   assert.match(output, /export const FutureProductSchema = z\.union\(\[V1MarkerSchema, V2MarkerSchema\]\)\.and/);
   assert.doesNotMatch(output, /FutureProductSchema = z\.object\(/);
+});
+
+test('postProcessRepeatedProductIntersections collapses repeated format and placement validators', () => {
+  const output = postProcessRepeatedProductIntersections(`
+export const CommonBFormatSchema = z.object({ value: z.string() }).passthrough();
+export const FormatKindsSchema = z.union([z.object({ format_kind: z.literal("image") })]);
+export const ProductFormatDeclarationSchema = z.object({ id: z.string() }).merge(CommonBFormatSchema)
+  .and(FormatKindsSchema)
+  .and(CommonBFormatSchema)
+  .and(FormatKindsSchema)
+  .and(CommonBFormatSchema)
+  .and(FormatKindsSchema)
+  .and(CommonBFormatSchema)
+  .and(FormatKindsSchema);
+export const PlacementBaseSchema = z.object({ placement_id: z.string() });
+export const PlacementChoiceSchema = z.union([z.object({ required: z.boolean() })]);
+export const PlacementSchema = PlacementBaseSchema
+  .and(PlacementChoiceSchema)
+  .and(CommonBFormatSchema)
+  .and(PlacementChoiceSchema)
+  .and(CommonBFormatSchema);
+`);
+
+  assert.match(
+    output,
+    /ProductFormatDeclarationSchema = z\.object\(\{ id: z\.string\(\) \}\)\.merge\(CommonBFormatSchema\)\.and\(FormatKindsSchema\);/
+  );
+  assert.match(
+    output,
+    /PlacementSchema = PlacementBaseSchema\.and\(PlacementChoiceSchema\)\.and\(CommonBFormatSchema\);/
+  );
+});
+
+test('postProcessRepeatedProductIntersections fails closed when the common Product validator is not contained', () => {
+  assert.throws(
+    () =>
+      postProcessRepeatedProductIntersections(`
+export const ProductFormatDeclarationSchema = z.object({ id: z.string() })
+  .and(z.literal("format"))
+  .and(z.object({ constraint: z.string() }))
+  .and(z.literal("format"))
+  .and(z.object({ constraint: z.string() }))
+  .and(z.literal("format"))
+  .and(z.object({ constraint: z.string() }))
+  .and(z.literal("format"));
+export const PlacementSchema = z.object({ placement_id: z.string() });
+`),
+    /no longer matches the verified repeated allOf projection/
+  );
+});
+
+test('postProcessRepeatedProductIntersections preserves literal whitespace semantics', () => {
+  const output = postProcessRepeatedProductIntersections(`
+export const ProductFormatDeclarationSchema = z.object({ product_id: z.string() });
+export const PlacementSchema = z.literal("a b").and(z.literal("a  b")).and(z.literal("a b"));
+`);
+
+  assert.match(output, /PlacementSchema = z\.literal\("a b"\)\.and\(z\.literal\("a  b"\)\);/);
 });
 
 test('postProcessObjectUnionIntersections distributes object envelope over union arms', () => {

--- a/test/lib/zod-openapi-portability.test.js
+++ b/test/lib/zod-openapi-portability.test.js
@@ -13,6 +13,35 @@ function findSinglePrefixMinItemsTwo(value, path = '$', matches = []) {
 }
 
 describe('public Zod schema portability', () => {
+  test('an adopter extension does not repeat Product format intersection blocks', async () => {
+    const [{ ProductSchema }, { createDocument }, { z }] = await Promise.all([
+      import('../../dist/lib/schemas/index.js'),
+      import('zod-openapi'),
+      import('zod'),
+    ]);
+    const adopterProduct = ProductSchema.extend({
+      product_id: z.string().min(1),
+      ext: z.object({ local: z.string().optional() }),
+    });
+    const document = createDocument({
+      openapi: '3.1.0',
+      info: { title: 'adopter-schema-portability', version: '1.0.0' },
+      components: { schemas: { InterchangeProduct: adopterProduct } },
+      paths: {},
+    });
+    const component = document.components.schemas.InterchangeProduct;
+    const formatItems = component.properties.format_options.items;
+    const serializedMembers = formatItems.allOf.map(member => JSON.stringify(member));
+    const renderedBytes = Buffer.byteLength(JSON.stringify(document), 'utf8');
+
+    assert.equal(formatItems.allOf.length, 2);
+    assert.equal(new Set(serializedMembers).size, serializedMembers.length);
+    assert.ok(
+      renderedBytes < 1024 * 1024,
+      `extended ProductSchema OpenAPI document must stay below 1 MiB; rendered ${(renderedBytes / 1024 / 1024).toFixed(2)} MiB`
+    );
+  });
+
   test('ProductSchema renders as OpenAPI 3.1 with every canonical format branch', async () => {
     const [{ PostalAreaSupportSchema, ProductSchema, ProvenanceSchema }, { createDocument }] = await Promise.all([
       import('../../dist/lib/schemas/index.js'),


### PR DESCRIPTION
## Summary

- collapse repeated Product format and Placement intersection operands emitted by Zod codegen
- preserve every distinct validator with exact matching and a fail-closed Product containment check
- reduce an adopter-style extended Product OpenAPI document from 2,251,388 to 684,618 bytes while retaining all canonical format branches
- add generator and adopter portability regressions plus a patch changeset

## Testing

- `npm run ci:quick`
- `npm run ci:schema-check`
- `npm run build`
- `npm run test:zod-openapi-portability`
- `npm run typecheck`
- expert code, protocol, adopter-DX, and security reviews

Closes #2774
