### PR TITLE
feat: address community networking and signing gaps

### DIFF
--- a/.changeset/fresh-rivers-help.md
+++ b/.changeset/fresh-rivers-help.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': minor
+---
+
+Support private development-network server URLs, container-reachable storyboard webhook receivers with optional direct TLS, and a public bounded brand.json fetch helper with typed HTTP status errors. Plain-HTTP proxy receiver URLs now require the explicit `allowHttp` or `--allow-http` local-development opt-in.

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -23,7 +23,7 @@ if (process.argv.includes('--allow-http')) {
 }
 
 const { AdCPClient, detectProtocol, usesDeprecatedAssetsField } = require('../dist/lib/index.js');
-const { readFileSync, statSync } = require('fs');
+const { readFileSync, statSync, openSync, fstatSync, readSync, closeSync, constants: fsConstants } = require('fs');
 const path = require('path');
 const { pathToFileURL } = require('url');
 const net = require('net');
@@ -1130,12 +1130,33 @@ function parseAgentOptions(args) {
     !args[webhookReceiverPortIdx + 1].startsWith('--')
       ? args[webhookReceiverPortIdx + 1]
       : null;
+  const webhookReceiverHostIdx = args.indexOf('--webhook-receiver-host');
+  const webhookReceiverHostValue =
+    webhookReceiverHostIdx !== -1 &&
+    webhookReceiverHostIdx + 1 < args.length &&
+    !args[webhookReceiverHostIdx + 1].startsWith('--')
+      ? args[webhookReceiverHostIdx + 1]
+      : null;
   const webhookReceiverPublicUrlIdx = args.indexOf('--webhook-receiver-public-url');
   const webhookReceiverPublicUrlValue =
     webhookReceiverPublicUrlIdx !== -1 &&
     webhookReceiverPublicUrlIdx + 1 < args.length &&
     !args[webhookReceiverPublicUrlIdx + 1].startsWith('--')
       ? args[webhookReceiverPublicUrlIdx + 1]
+      : null;
+  const webhookReceiverTlsCertIdx = args.indexOf('--webhook-receiver-tls-cert');
+  const webhookReceiverTlsCertValue =
+    webhookReceiverTlsCertIdx !== -1 &&
+    webhookReceiverTlsCertIdx + 1 < args.length &&
+    !args[webhookReceiverTlsCertIdx + 1].startsWith('--')
+      ? args[webhookReceiverTlsCertIdx + 1]
+      : null;
+  const webhookReceiverTlsKeyIdx = args.indexOf('--webhook-receiver-tls-key');
+  const webhookReceiverTlsKeyValue =
+    webhookReceiverTlsKeyIdx !== -1 &&
+    webhookReceiverTlsKeyIdx + 1 < args.length &&
+    !args[webhookReceiverTlsKeyIdx + 1].startsWith('--')
+      ? args[webhookReceiverTlsKeyIdx + 1]
       : null;
 
   const invariantsIdx = args.indexOf('--invariants');
@@ -1212,7 +1233,10 @@ function parseAgentOptions(args) {
     multiInstanceStrategyValue,
     webhookReceiverModeValue,
     webhookReceiverPortValue,
+    webhookReceiverHostValue,
     webhookReceiverPublicUrlValue,
+    webhookReceiverTlsCertValue,
+    webhookReceiverTlsKeyValue,
     invariantsValue,
     localAgentValue,
     formatValue,
@@ -2111,11 +2135,19 @@ WEBHOOK OPTIONS:
                                   the webhook-emission and idempotency bundles
                                   to produce grades instead of skips.
   --webhook-receiver-port PORT    Force a bind port (default: auto-assign).
+  --webhook-receiver-host HOST    Bind address for the local listener (default:
+                                  127.0.0.1). Use 0.0.0.0 or :: with proxy mode
+                                  for container-to-container callbacks.
   --webhook-receiver-public-url URL
-                                  Public HTTPS base URL for proxy mode. Implies
+                                  Public HTTPS base URL for proxy mode. HTTP is
+                                  accepted only with --allow-http. Implies
                                   --webhook-receiver proxy when used alone.
                                   Incompatible with --multi-instance-strategy
                                   multi-pass (receiver URL is per-pass).
+  --webhook-receiver-tls-cert FILE
+  --webhook-receiver-tls-key FILE Serve HTTPS directly with this certificate
+                                  and private key. Both flags are required.
+                                  Omit when a tunnel or ingress terminates TLS.
   --webhook-receiver-auto-tunnel  Autodetect a tunnel binary on PATH (ngrok or
                                   cloudflared; override with $ADCP_WEBHOOK_TUNNEL),
                                   spawn it against the receiver, and plug its
@@ -2923,6 +2955,7 @@ async function handleStoryboardRun(args) {
     ...(fileComplianceOptions.adcpVersion && { adcpVersion: fileComplianceOptions.adcpVersion }),
     ...(fileComplianceOptions.schemaRoot && { schemaRoot: fileComplianceOptions.schemaRoot }),
     ...(!opts.strictResponseSchemaValidation && { strictResponseSchemaValidation: false }),
+    ...(opts.allowHttp && { allow_http: true }),
     ...sandboxRunOptions(opts),
     ...(opts.assertsSeededState && { assertsSeededState: true }),
     ...(opts.mediaBuyLifecycleCompatibility && {
@@ -3031,8 +3064,8 @@ async function handleStoryboardRun(args) {
  * transport and land in attribution output.
  */
 /**
- * Parse `--webhook-receiver [mode]`, `--webhook-receiver-port <port>`, and
- * `--webhook-receiver-public-url <url>`. Returns a `{ webhook_receiver, contracts }`
+ * Parse `--webhook-receiver [mode]` and its host, port, public-URL, and TLS
+ * flags. Returns a `{ webhook_receiver, contracts }`
  * pair suitable for spreading into `runStoryboard` / `comply` options, or
  * `null` if no webhook-receiver flag is set.
  *
@@ -3046,8 +3079,13 @@ function extractWebhookReceiverOptions(args) {
   const idx = args.indexOf('--webhook-receiver');
   const publicUrlIdx = args.indexOf('--webhook-receiver-public-url');
   const portIdx = args.indexOf('--webhook-receiver-port');
+  const hostIdx = args.indexOf('--webhook-receiver-host');
+  const tlsCertIdx = args.indexOf('--webhook-receiver-tls-cert');
+  const tlsKeyIdx = args.indexOf('--webhook-receiver-tls-key');
 
-  if (idx === -1 && publicUrlIdx === -1 && portIdx === -1) return null;
+  if (idx === -1 && publicUrlIdx === -1 && portIdx === -1 && hostIdx === -1 && tlsCertIdx === -1 && tlsKeyIdx === -1) {
+    return null;
+  }
 
   let mode = 'loopback_mock';
   if (idx !== -1) {
@@ -3071,6 +3109,29 @@ function extractWebhookReceiverOptions(args) {
       process.exit(2);
     }
     publicUrl = val;
+    let parsedPublicUrl;
+    try {
+      parsedPublicUrl = new URL(publicUrl);
+    } catch {
+      console.error(`ERROR: --webhook-receiver-public-url is not a valid URL: "${publicUrl}"`);
+      process.exit(2);
+    }
+    if (parsedPublicUrl.protocol !== 'http:' && parsedPublicUrl.protocol !== 'https:') {
+      console.error(`ERROR: --webhook-receiver-public-url must use http or https, got ${parsedPublicUrl.protocol}`);
+      process.exit(2);
+    }
+    if (parsedPublicUrl.username || parsedPublicUrl.password) {
+      console.error('ERROR: --webhook-receiver-public-url must not include userinfo');
+      process.exit(2);
+    }
+    if (parsedPublicUrl.search || parsedPublicUrl.hash) {
+      console.error('ERROR: --webhook-receiver-public-url must not include a query string or fragment');
+      process.exit(2);
+    }
+    if (parsedPublicUrl.protocol === 'http:' && !args.includes('--allow-http')) {
+      console.error('ERROR: an http:// webhook receiver public URL requires --allow-http (local development only)');
+      process.exit(2);
+    }
     // --webhook-receiver-public-url without --webhook-receiver implies proxy mode.
     // With explicit `--webhook-receiver loopback`, the combination is a user
     // error — loopback mode ignores public_url.
@@ -3105,14 +3166,91 @@ function extractWebhookReceiverOptions(args) {
     port = parsed;
   }
 
+  let host;
+  if (hostIdx !== -1) {
+    host = args[hostIdx + 1];
+    if (host === undefined || host.startsWith('--')) {
+      console.error('ERROR: --webhook-receiver-host requires a hostname or bind address');
+      process.exit(2);
+    }
+    if (host.length === 0 || /[\s/\\\r\n\x00]/.test(host)) {
+      console.error(`ERROR: --webhook-receiver-host is not a valid bind address: "${host}"`);
+      process.exit(2);
+    }
+  }
+
+  const tlsCertPath = tlsCertIdx === -1 ? undefined : args[tlsCertIdx + 1];
+  const tlsKeyPath = tlsKeyIdx === -1 ? undefined : args[tlsKeyIdx + 1];
+  if (tlsCertPath === undefined && tlsCertIdx !== -1) {
+    console.error('ERROR: --webhook-receiver-tls-cert requires a file path');
+    process.exit(2);
+  }
+  if (tlsKeyPath === undefined && tlsKeyIdx !== -1) {
+    console.error('ERROR: --webhook-receiver-tls-key requires a file path');
+    process.exit(2);
+  }
+  if (tlsCertPath?.startsWith('--')) {
+    console.error('ERROR: --webhook-receiver-tls-cert requires a file path');
+    process.exit(2);
+  }
+  if (tlsKeyPath?.startsWith('--')) {
+    console.error('ERROR: --webhook-receiver-tls-key requires a file path');
+    process.exit(2);
+  }
+  if ((tlsCertPath === undefined) !== (tlsKeyPath === undefined)) {
+    console.error('ERROR: --webhook-receiver-tls-cert and --webhook-receiver-tls-key must be provided together');
+    process.exit(2);
+  }
+  let tls;
+  if (tlsCertPath !== undefined && tlsKeyPath !== undefined) {
+    try {
+      tls = {
+        cert: readBoundedRegularFile(path.resolve(tlsCertPath), 'TLS certificate'),
+        key: readBoundedRegularFile(path.resolve(tlsKeyPath), 'TLS private key'),
+      };
+    } catch (err) {
+      console.error(`ERROR: unable to read webhook receiver TLS files: ${err.message}`);
+      process.exit(2);
+    }
+  }
+  if (tls && publicUrl && new URL(publicUrl).protocol !== 'https:') {
+    console.error('ERROR: direct webhook receiver TLS requires an https:// public URL');
+    process.exit(2);
+  }
+
   return {
     webhook_receiver: {
       mode,
+      ...(host !== undefined && { host }),
       ...(port !== undefined && { port }),
       ...(publicUrl !== undefined && { public_url: publicUrl }),
+      ...(tls !== undefined && { tls }),
     },
     contracts: ['webhook_receiver_runner'],
   };
+}
+
+const MAX_WEBHOOK_TLS_FILE_BYTES = 1_048_576;
+
+function readBoundedRegularFile(filePath, label) {
+  const fd = openSync(filePath, fsConstants.O_RDONLY | fsConstants.O_NONBLOCK);
+  try {
+    const stat = fstatSync(fd);
+    if (!stat.isFile()) throw new Error(`${label} must be a regular file`);
+    if (stat.size > MAX_WEBHOOK_TLS_FILE_BYTES) {
+      throw new Error(`${label} exceeds the 1 MiB size limit`);
+    }
+    const buffer = Buffer.alloc(stat.size);
+    let offset = 0;
+    while (offset < buffer.length) {
+      const count = readSync(fd, buffer, offset, buffer.length - offset, null);
+      if (count === 0) break;
+      offset += count;
+    }
+    return offset === buffer.length ? buffer : buffer.subarray(0, offset);
+  } finally {
+    closeSync(fd);
+  }
 }
 
 /**
@@ -3466,6 +3604,11 @@ function validateAutoTunnelArgs(args, base) {
     console.error('       Pick one — auto-tunnel mints a URL for you, public-url supplies your own.');
     process.exit(2);
   }
+  if (base?.webhook_receiver.tls) {
+    console.error('ERROR: --webhook-receiver-auto-tunnel cannot be combined with direct TLS certificate flags.');
+    console.error('       The tunnel terminates HTTPS and forwards plain HTTP to the local receiver.');
+    process.exit(2);
+  }
   // Auto-tunnel implies proxy mode and mints the URL itself. A coexisting
   // `--webhook-receiver [mode]` flag is always wrong: `loopback` contradicts
   // the minted URL, `proxy` without public-url is caught earlier in
@@ -3488,7 +3631,12 @@ async function resolveWebhookReceiverOptions(args, { jsonOutput } = {}) {
   const { publicUrl } = await spawnAutoTunnel({ port, timeoutMs, jsonOutput });
 
   return {
-    webhook_receiver: { mode: 'proxy_url', port, public_url: publicUrl },
+    webhook_receiver: {
+      mode: 'proxy_url',
+      ...(base?.webhook_receiver.host !== undefined && { host: base.webhook_receiver.host }),
+      port,
+      public_url: publicUrl,
+    },
     contracts: ['webhook_receiver_runner'],
   };
 }

--- a/src/lib/server/serve.ts
+++ b/src/lib/server/serve.ts
@@ -218,8 +218,20 @@ export interface ServeOptions {
    * deriving a URL and throw {@link UnknownHostError} for unknown hosts.
    * Evicted hosts are resolved again on their next request.
    * Setting {@link trustForwardedHost} is recommended when behind a proxy.
+   *
+   * @see {@link allowHttpHosts} for explicitly allowlisted development-only
+   * plain-HTTP hostnames.
    */
   publicUrl?: string | ((host: string) => string);
+
+  /**
+   * Exact hostnames permitted to use plain HTTP in {@link publicUrl}, in
+   * addition to the built-in loopback allowance. This development-only
+   * escape hatch supports private container-network names such as
+   * docker-compose service aliases. Entries are case-insensitive and must
+   * not contain ports or wildcards. HTTPS remains required by default.
+   */
+  allowHttpHosts?: string[];
 
   /**
    * Authentication middleware applied to every request. When configured,
@@ -455,6 +467,7 @@ export function serve(createAgent: (ctx: ServeContext) => AdcpServer | McpServer
   }
 
   const publicUrlOption = options?.publicUrl;
+  const allowHttpHosts = normalizeAllowHttpHosts(options?.allowHttpHosts);
   const protectedResourceOption = options?.protectedResource;
   const publicUrlIsFn = typeof publicUrlOption === 'function';
   const prmIsFn = typeof protectedResourceOption === 'function';
@@ -464,7 +477,7 @@ export function serve(createAgent: (ctx: ServeContext) => AdcpServer | McpServer
   // lazily per host so a stale factory for one host can't prevent boot.
   let staticPublicOrigin: string | undefined;
   if (typeof publicUrlOption === 'string') {
-    staticPublicOrigin = validatePublicUrl(publicUrlOption, mountPath);
+    staticPublicOrigin = validatePublicUrl(publicUrlOption, mountPath, allowHttpHosts);
   }
 
   // Function-form options are pure host → value lookups. Keep their values
@@ -506,7 +519,7 @@ export function serve(createAgent: (ctx: ServeContext) => AdcpServer | McpServer
     const cached = getHostMetadata(host);
     if (cached?.publicUrl !== undefined) return cached.publicUrl;
     const publicUrl = (publicUrlOption as (h: string) => string)(canonicalHostnameForScope(host));
-    const publicOrigin = validatePublicUrl(publicUrl, mountPath);
+    const publicOrigin = validatePublicUrl(publicUrl, mountPath, allowHttpHosts);
     updateHostMetadata(host, { publicUrl, publicOrigin });
     return publicUrl;
   };
@@ -534,6 +547,12 @@ export function serve(createAgent: (ctx: ServeContext) => AdcpServer | McpServer
     console.warn(
       '[adcp/serve] No `authenticate` configured — this agent will accept unauthenticated requests. ' +
         'AdCP security_baseline requires authentication in production.'
+    );
+  }
+  if (allowHttpHosts.size > 0 && process.env.NODE_ENV === 'production') {
+    console.warn(
+      '[adcp/serve] `allowHttpHosts` enables plaintext HTTP for explicitly named hosts. ' +
+        'Remove this development-only option from production deployments.'
     );
   }
 
@@ -1087,7 +1106,7 @@ function trimTrailingSlashes(s: string): string {
  * call site and surfaced as a 500 so the operator sees the misconfigured
  * host instead of a silent audience-mismatch on minted tokens.
  */
-function validatePublicUrl(publicUrl: string, mountPath: string): string {
+function validatePublicUrl(publicUrl: string, mountPath: string, allowHttpHosts: ReadonlySet<string>): string {
   let parsed: URL;
   try {
     parsed = new URL(publicUrl);
@@ -1099,8 +1118,11 @@ function validatePublicUrl(publicUrl: string, mountPath: string): string {
   }
   const loopbackHost =
     parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1' || parsed.hostname === '[::1]';
-  if (parsed.protocol !== 'https:' && !(parsed.protocol === 'http:' && loopbackHost)) {
-    throw new Error('serve(): `publicUrl` must use https (http is allowed only for loopback development URLs)');
+  const explicitlyAllowedHttpHost = allowHttpHosts.has(parsed.hostname.toLowerCase());
+  if (parsed.protocol !== 'https:' && !(parsed.protocol === 'http:' && (loopbackHost || explicitlyAllowedHttpHost))) {
+    throw new Error(
+      'serve(): `publicUrl` must use https (http is allowed only for loopback or hosts named in `allowHttpHosts`)'
+    );
   }
   if (trimTrailingSlashes(parsed.pathname) !== trimTrailingSlashes(mountPath)) {
     throw new Error(
@@ -1112,6 +1134,42 @@ function validatePublicUrl(publicUrl: string, mountPath: string): string {
     throw new Error('serve(): `publicUrl` must not include query parameters or a fragment');
   }
   return parsed.origin;
+}
+
+function normalizeAllowHttpHosts(entries: string[] | undefined): ReadonlySet<string> {
+  const hosts = new Set<string>();
+  for (const entry of entries ?? []) {
+    if (
+      entry.length === 0 ||
+      entry.trim() !== entry ||
+      entry.includes('*') ||
+      entry.includes('?') ||
+      entry.includes(':')
+    ) {
+      throw new Error(
+        `serve(): invalid allowHttpHosts entry "${entry}"; use an exact hostname without whitespace, wildcards, or a port`
+      );
+    }
+    let parsed: URL;
+    try {
+      parsed = new URL(`https://${entry}/`);
+    } catch {
+      throw new Error(`serve(): invalid allowHttpHosts entry "${entry}"; expected a hostname`);
+    }
+    if (
+      parsed.hostname.length === 0 ||
+      parsed.username.length > 0 ||
+      parsed.password.length > 0 ||
+      parsed.port.length > 0 ||
+      parsed.pathname !== '/' ||
+      parsed.search.length > 0 ||
+      parsed.hash.length > 0
+    ) {
+      throw new Error(`serve(): invalid allowHttpHosts entry "${entry}"; expected a hostname without a port`);
+    }
+    hosts.add(parsed.hostname.toLowerCase());
+  }
+  return hosts;
 }
 
 /**

--- a/src/lib/signing/brand-jwks.ts
+++ b/src/lib/signing/brand-jwks.ts
@@ -57,10 +57,19 @@ export type BrandJsonResolverErrorCode =
  */
 export class BrandJsonResolverError extends Error {
   readonly code: BrandJsonResolverErrorCode;
-  constructor(code: BrandJsonResolverErrorCode, message: string) {
+  override readonly cause?: unknown;
+  /** HTTP status for `fetch_failed` responses, when a response was received. */
+  readonly httpStatus?: number;
+  constructor(
+    code: BrandJsonResolverErrorCode,
+    message: string,
+    details: { httpStatus?: number; cause?: unknown } = {}
+  ) {
     super(message);
     this.name = 'BrandJsonResolverError';
     this.code = code;
+    this.httpStatus = details.httpStatus;
+    this.cause = details.cause;
   }
 }
 
@@ -270,13 +279,32 @@ export class BrandJsonJwksResolver implements JwksResolver {
   }
 }
 
-interface FetchedBrandJson {
+export interface FetchedBrandJson {
   status: 'ok' | 'not_modified';
   finalUrl: string;
   data: unknown;
   etag?: string;
   cacheControl?: string;
 }
+
+export interface FetchBrandJsonOptions {
+  /** Entry-point URL. HTTPS and public addresses are required by default. */
+  startUrl: string;
+  /** ETag sent only to the entry URL for cache revalidation. */
+  currentEtag?: string;
+  /** Maximum JSON-level `authoritative_location` / `house` hops. Default 3, hard maximum 10. */
+  maxRedirects?: number;
+  /** Permit HTTP and private addresses for controlled development environments. */
+  allowPrivateIp?: boolean;
+  /** Whole-request deadline per hop. Default and hard maximum 10 seconds. */
+  timeoutMs?: number;
+  /** Response-body cap per hop. Default and hard maximum 256 KiB. */
+  maxBodyBytes?: number;
+}
+
+const MAX_BRAND_JSON_TIMEOUT_MS = 10_000;
+const MAX_BRAND_JSON_BODY_BYTES = 262_144;
+const MAX_BRAND_JSON_REDIRECTS = 10;
 
 /**
  * Fetch brand.json from `startUrl`, following `authoritative_location` and
@@ -287,17 +315,30 @@ interface FetchedBrandJson {
  * `{"house": "evil.com\\@victim.com"}` or `{"authoritative_location":
  * "http://169.254.169.254/..."}` is rejected at parse time rather than
  * relying on `ssrfSafeFetch` to catch every pathological shape.
+ *
+ * This low-level function is intentionally stateless. Callers MUST add
+ * response caching and a minimum refresh cooldown rather than invoking it on
+ * every authorization request. Prefer `BrandJsonJwksResolver` when resolving
+ * signing keys; it provides both safeguards.
  */
-async function fetchBrandJson(args: {
-  startUrl: string;
-  currentEtag?: string;
-  maxRedirects: number;
-  allowPrivateIp: boolean;
-}): Promise<FetchedBrandJson> {
+export async function fetchBrandJson(args: FetchBrandJsonOptions): Promise<FetchedBrandJson> {
+  const maxRedirects = boundedIntegerOption('maxRedirects', args.maxRedirects ?? DEFAULT_MAX_REDIRECTS, {
+    min: 0,
+    max: MAX_BRAND_JSON_REDIRECTS,
+  });
+  const timeoutMs = boundedIntegerOption('timeoutMs', args.timeoutMs ?? MAX_BRAND_JSON_TIMEOUT_MS, {
+    min: 1,
+    max: MAX_BRAND_JSON_TIMEOUT_MS,
+  });
+  const maxBodyBytes = boundedIntegerOption('maxBodyBytes', args.maxBodyBytes ?? MAX_BRAND_JSON_BODY_BYTES, {
+    min: 1,
+    max: MAX_BRAND_JSON_BODY_BYTES,
+  });
+  const allowPrivateIp = args.allowPrivateIp === true;
   const seen = new Set<string>();
-  let url = canonicalizeUrl(args.startUrl, args.allowPrivateIp);
+  let url = canonicalizeUrl(args.startUrl, allowPrivateIp);
 
-  for (let hop = 0; hop <= args.maxRedirects; hop++) {
+  for (let hop = 0; hop <= maxRedirects; hop++) {
     if (seen.has(url)) {
       throw new BrandJsonResolverError('redirect_loop', `brand.json redirect loop detected`);
     }
@@ -311,11 +352,18 @@ async function fetchBrandJson(args: {
     // a lie about the redirect target.
     if (hop === 0 && args.currentEtag) headers['if-none-match'] = args.currentEtag;
 
-    const res = await ssrfSafeFetch(url, {
-      method: 'GET',
-      headers,
-      allowPrivateIp: args.allowPrivateIp,
-    });
+    let res: Awaited<ReturnType<typeof ssrfSafeFetch>>;
+    try {
+      res = await ssrfSafeFetch(url, {
+        method: 'GET',
+        headers,
+        allowPrivateIp,
+        timeoutMs,
+        maxBodyBytes,
+      });
+    } catch (cause) {
+      throw new BrandJsonResolverError('fetch_failed', 'Unable to fetch brand.json', { cause });
+    }
 
     if (hop === 0 && res.status === 304) {
       return {
@@ -327,7 +375,9 @@ async function fetchBrandJson(args: {
       };
     }
     if (res.status !== 200) {
-      throw new BrandJsonResolverError('fetch_failed', `brand.json fetch returned HTTP ${res.status}`);
+      throw new BrandJsonResolverError('fetch_failed', `brand.json fetch returned HTTP ${res.status}`, {
+        httpStatus: res.status,
+      });
     }
 
     const text = Buffer.from(res.body).toString('utf8');
@@ -346,10 +396,10 @@ async function fetchBrandJson(args: {
     const house = typeof obj.house === 'string' ? obj.house : undefined;
 
     if (authoritative !== undefined) {
-      if (hop === args.maxRedirects) {
+      if (hop === maxRedirects) {
         throw new BrandJsonResolverError('redirect_depth_exceeded', `brand.json redirect depth exceeded`);
       }
-      url = canonicalizeUrl(authoritative, args.allowPrivateIp);
+      url = canonicalizeUrl(authoritative, allowPrivateIp);
       continue;
     }
     if (house !== undefined) {
@@ -360,10 +410,10 @@ async function fetchBrandJson(args: {
       if (!BARE_HOSTNAME.test(house)) {
         throw new BrandJsonResolverError('invalid_house', `brand.json "house" is not a bare hostname`);
       }
-      if (hop === args.maxRedirects) {
+      if (hop === maxRedirects) {
         throw new BrandJsonResolverError('redirect_depth_exceeded', `brand.json redirect depth exceeded`);
       }
-      url = canonicalizeUrl(`https://${house}/.well-known/brand.json`, args.allowPrivateIp);
+      url = canonicalizeUrl(`https://${house}/.well-known/brand.json`, allowPrivateIp);
       continue;
     }
 
@@ -385,6 +435,13 @@ async function fetchBrandJson(args: {
   }
 
   throw new BrandJsonResolverError('redirect_depth_exceeded', `brand.json redirect depth exceeded`);
+}
+
+function boundedIntegerOption(name: string, value: number, bounds: { min: number; max: number }): number {
+  if (!Number.isInteger(value) || value < bounds.min || value > bounds.max) {
+    throw new TypeError(`fetchBrandJson: ${name} must be an integer between ${bounds.min} and ${bounds.max}`);
+  }
+  return value;
 }
 
 /**

--- a/src/lib/signing/server.ts
+++ b/src/lib/signing/server.ts
@@ -46,7 +46,10 @@ export { HttpsJwksResolver, type HttpsJwksResolverOptions } from './jwks-https';
 export {
   BrandJsonJwksResolver,
   BrandJsonResolverError,
+  fetchBrandJson,
   type BrandAgentType,
+  type FetchedBrandJson,
+  type FetchBrandJsonOptions,
   type BrandJsonJwksResolverOptions,
   type BrandJsonResolverErrorCode,
 } from './brand-jwks';

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -2750,6 +2750,8 @@ async function executeStoryboardPass(
         ...(options.webhook_receiver.host !== undefined && { host: options.webhook_receiver.host }),
         ...(options.webhook_receiver.port !== undefined && { port: options.webhook_receiver.port }),
         ...(options.webhook_receiver.public_url !== undefined && { public_url: options.webhook_receiver.public_url }),
+        allowHttp: options.allow_http === true,
+        ...(options.webhook_receiver.tls !== undefined && { tls: options.webhook_receiver.tls }),
       })
     : undefined;
   const runnerVars = createRunnerVariables({
@@ -4492,6 +4494,8 @@ async function runStoryboardStepBody(
           ...(options.webhook_receiver.public_url !== undefined && {
             public_url: options.webhook_receiver.public_url,
           }),
+          allowHttp: options.allow_http === true,
+          ...(options.webhook_receiver.tls !== undefined && { tls: options.webhook_receiver.tls }),
         })
       : undefined);
   const ownsWebhookReceiver = !injectedReceiver && !!webhookReceiver;

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -1873,6 +1873,12 @@ export interface StoryboardRunOptions extends TestOptions {
      * validate reachability.
      */
     public_url?: string;
+    /** TLS material for direct HTTPS serving; omit behind a TLS-terminating proxy. */
+    tls?: {
+      cert: string | Buffer;
+      key: string | Buffer;
+      passphrase?: string;
+    };
   };
   /**
    * Target receiver for `replay_webhook_vector` storyboards. This is separate

--- a/src/lib/testing/storyboard/webhook-assertions.ts
+++ b/src/lib/testing/storyboard/webhook-assertions.ts
@@ -101,9 +101,12 @@ const DEFAULT_RETRY_HTTP_STATUS = 503;
 const DEFAULT_MIN_DELIVERIES = 2;
 
 function webhookTimeoutDetail(receiver: WebhookReceiver, base: string): string {
-  return receiver.mode === 'loopback_mock' && receiver.all().length === 0 && receiver.challenges().length === 0
-    ? `${base} No request reached the loopback receiver; an out-of-process agent must use webhook_receiver.mode="proxy_url".`
-    : base;
+  if (receiver.all().length > 0 || receiver.challenges().length > 0) return base;
+  const bindHost = receiver.bind_host ?? 'the configured local address';
+  if (receiver.mode === 'loopback_mock') {
+    return `${base} No request reached the receiver bound to ${bindHost}; an out-of-process agent must use webhook_receiver.mode="proxy_url".`;
+  }
+  return `${base} No request reached the receiver bound to ${bindHost}; verify that the advertised callback URL routes to this container and bind address.`;
 }
 const DEFAULT_WEBHOOK_SIGNING_TAG = 'adcp/webhook-signing/v1';
 

--- a/src/lib/testing/storyboard/webhook-receiver.ts
+++ b/src/lib/testing/storyboard/webhook-receiver.ts
@@ -16,9 +16,10 @@
  *     proxy-URL mode swaps in an operator-supplied public base.
  */
 
-import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import { createServer, type IncomingMessage, type Server as HttpServer, type ServerResponse } from 'node:http';
+import { createServer as createHttpsServer, type Server as HttpsServer } from 'node:https';
 import { randomUUID } from 'node:crypto';
-import type { AddressInfo } from 'node:net';
+import { isIP, type AddressInfo } from 'node:net';
 import { getSchemaValidatorByRef } from '../../validation/schema-loader';
 
 /**
@@ -68,7 +69,7 @@ const SECRET_HEADER_PATTERN =
  * advertise an `http://169.254.169.254`, `file://…`, or header-splitting
  * URL that would then be embedded in outbound `push_notification_config.url`.
  */
-function validateProxyUrl(raw: string): string {
+function validateProxyUrl(raw: string, allowHttp: boolean): string {
   if (/[\r\n\x00]/.test(raw)) {
     throw new Error('webhook_receiver.public_url must not contain CR/LF/NUL');
   }
@@ -81,10 +82,16 @@ function validateProxyUrl(raw: string): string {
   if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
     throw new Error(`webhook_receiver.public_url must be http(s); got ${parsed.protocol}`);
   }
+  if (parsed.protocol === 'http:' && !allowHttp) {
+    throw new Error('webhook_receiver.public_url must use https (set allowHttp only for controlled local development)');
+  }
   if (parsed.username || parsed.password) {
     throw new Error('webhook_receiver.public_url must not include userinfo');
   }
-  return raw.replace(/\/$/, '');
+  if (parsed.search || parsed.hash) {
+    throw new Error('webhook_receiver.public_url must not include a query string or fragment');
+  }
+  return raw.replace(/\/+$/, '');
 }
 
 export interface CapturedWebhook {
@@ -153,6 +160,8 @@ export interface WebhookReceiver {
   readonly base_url: string;
   /** Whether the receiver is in loopback-mock or proxy-url mode. */
   readonly mode: 'loopback_mock' | 'proxy_url';
+  /** Local address the listener is bound to. */
+  readonly bind_host?: string;
   /** All webhooks captured so far, in arrival order. */
   all(): CapturedWebhook[];
   /** Schema-valid proof-of-control challenges, kept separate from event deliveries. */
@@ -185,6 +194,19 @@ export interface CreateWebhookReceiverOptions {
   port?: number;
   /** Public URL to advertise when `mode: 'proxy_url'`. */
   public_url?: string;
+  /**
+   * Permit an HTTP public URL for controlled local-development topologies.
+   */
+  allowHttp?: boolean;
+  /**
+   * TLS material for serving HTTPS directly. Omit when HTTPS terminates at a
+   * tunnel or reverse proxy in front of this listener.
+   */
+  tls?: {
+    cert: string | Buffer;
+    key: string | Buffer;
+    passphrase?: string;
+  };
 }
 
 interface RetryKey {
@@ -203,17 +225,23 @@ export async function createWebhookReceiver(options: CreateWebhookReceiverOption
   }
 
   const host = options.host ?? '127.0.0.1';
-  // A loopback_mock receiver bound on 0.0.0.0 is publicly reachable from any
-  // interface — which would turn a CI runner into an open POST endpoint.
-  // Operators who genuinely want public exposure use mode=proxy_url.
-  if (mode === 'loopback_mock' && (host === '0.0.0.0' || host === '::')) {
+  // Keep loopback_mock literal: aliases for wildcard addresses (including
+  // expanded IPv6 forms) must not turn a CI runner into an open POST endpoint.
+  // Operators who genuinely want non-loopback exposure use mode=proxy_url.
+  if (mode === 'loopback_mock' && !isLoopbackHost(host)) {
     throw new Error(
       `webhook_receiver host ${host} is not permitted in loopback_mock mode. ` +
         'Use mode=proxy_url with an explicit public_url for publicly-reachable runs.'
     );
   }
   const port = options.port ?? 0;
-  const proxyBase = mode === 'proxy_url' ? validateProxyUrl(options.public_url!) : undefined;
+  const proxyBase =
+    mode === 'proxy_url' ? validateProxyUrl(options.public_url!, options.allowHttp === true) : undefined;
+  if (options.tls && proxyBase && new URL(proxyBase).protocol !== 'https:') {
+    throw new Error('webhook_receiver.public_url must use https when local TLS is configured');
+  }
+  const publicRouteSuffix = mode === 'proxy_url' ? `/_adcp_receiver/${randomUUID()}` : '';
+  const routePrefix = proxyBase ? `${new URL(proxyBase).pathname.replace(/\/+$/, '')}${publicRouteSuffix}` : '';
 
   const captured: CapturedWebhook[] = [];
   const challenges: CapturedWebhookChallenge[] = [];
@@ -232,9 +260,26 @@ export async function createWebhookReceiver(options: CreateWebhookReceiverOption
   const challengeCounts = new Map<string, number>();
   let closed = false;
 
-  const server = createServer((req, res) =>
-    handleRequest(req, res, { captured, challenges, waiters, retryPolicies, deliveryCounts, challengeCounts })
-  );
+  const requestListener = (req: IncomingMessage, res: ServerResponse) =>
+    handleRequest(req, res, {
+      captured,
+      challenges,
+      waiters,
+      retryPolicies,
+      deliveryCounts,
+      challengeCounts,
+      routePrefix,
+    });
+  const server = options.tls
+    ? createHttpsServer(
+        {
+          cert: options.tls.cert,
+          key: options.tls.key,
+          ...(options.tls.passphrase !== undefined && { passphrase: options.tls.passphrase }),
+        },
+        requestListener
+      )
+    : createServer(requestListener);
   // Transport-level hardening — trim Node's generous defaults so a slow /
   // hostile publisher can't wedge the runner.
   server.headersTimeout = HEADERS_TIMEOUT_MS;
@@ -253,11 +298,14 @@ export async function createWebhookReceiver(options: CreateWebhookReceiverOption
   });
 
   const bound = server.address() as AddressInfo;
-  const base_url = proxyBase ?? `http://${formatHost(bound.address)}:${bound.port}`;
+  const base_url = proxyBase
+    ? `${proxyBase}${publicRouteSuffix}`
+    : `${options.tls ? 'https' : 'http'}://${formatHost(bound.address)}:${bound.port}`;
 
   return {
     base_url,
     mode,
+    bind_host: host,
     all: () => captured.slice(),
     challenges: () => challenges.slice(),
     matching: filter => captured.filter(w => matchesFilter(w, filter)),
@@ -280,6 +328,14 @@ export async function createWebhookReceiver(options: CreateWebhookReceiverOption
   };
 }
 
+function isLoopbackHost(host: string): boolean {
+  const normalized = host.toLowerCase();
+  if (normalized === 'localhost') return true;
+  if (isIP(host) === 4) return /^127(?:\.\d{1,3}){3}$/.test(host);
+  if (isIP(host) === 6) return normalized === '::1' || /^(?:0:){7}1$/.test(normalized);
+  return false;
+}
+
 // ────────────────────────────────────────────────────────────
 // Request handling
 // ────────────────────────────────────────────────────────────
@@ -295,6 +351,7 @@ interface HandlerState {
   retryPolicies: Map<string, { policy: RetryReplayPolicy; delivered: number }>;
   deliveryCounts: Map<string, number>;
   challengeCounts: Map<string, number>;
+  routePrefix: string;
 }
 
 function handleRequest(req: IncomingMessage, res: ServerResponse, state: HandlerState): void {
@@ -304,13 +361,13 @@ function handleRequest(req: IncomingMessage, res: ServerResponse, state: Handler
     return;
   }
 
-  const pathParts = parseStepPath(req.url ?? '');
+  const pathParts = parseStepPath(req.url ?? '', state.routePrefix);
   if (!pathParts) {
     res.statusCode = 404;
     res.end();
     return;
   }
-  const { step_id, operation_id } = pathParts;
+  const { step_id, operation_id, logical_path } = pathParts;
 
   let size = 0;
   const chunks: Buffer[] = [];
@@ -373,7 +430,7 @@ function handleRequest(req: IncomingMessage, res: ServerResponse, state: Handler
         operation_id,
         received_at: Date.now(),
         method: req.method ?? 'POST',
-        path: req.url ?? '/',
+        path: logical_path,
         headers: redactHeaders(headers),
         raw_body: raw,
         body: parsedBody.body as Record<string, unknown>,
@@ -410,7 +467,7 @@ function handleRequest(req: IncomingMessage, res: ServerResponse, state: Handler
       delivery_index: deliveryIndex,
       received_at: Date.now(),
       method: req.method ?? 'POST',
-      path: req.url ?? '/',
+      path: logical_path,
       headers: redactHeaders(headers),
       raw_body: raw,
       ...parsedBody,
@@ -457,10 +514,18 @@ function requestPathname(reqUrl: string): string {
   return q === -1 ? reqUrl : reqUrl.slice(0, q);
 }
 
-function parseStepPath(reqUrl: string): { step_id: string; operation_id: string } | undefined {
-  const match = STEP_PATH_RE.exec(requestPathname(reqUrl));
+function parseStepPath(
+  reqUrl: string,
+  routePrefix: string
+): { step_id: string; operation_id: string; logical_path: string } | undefined {
+  const pathname = requestPathname(reqUrl);
+  if (routePrefix && !pathname.startsWith(`${routePrefix}/`)) return undefined;
+  const logicalPath = routePrefix ? pathname.slice(routePrefix.length) : pathname;
+  const match = STEP_PATH_RE.exec(logicalPath);
   if (!match) return undefined;
-  return { step_id: match[1]!, operation_id: match[2]! };
+  const queryIndex = reqUrl.indexOf('?');
+  const query = queryIndex === -1 ? '' : reqUrl.slice(queryIndex);
+  return { step_id: match[1]!, operation_id: match[2]!, logical_path: `${logicalPath}${query}` };
 }
 
 function normalizeHeaders(raw: IncomingMessage['headers']): Record<string, string> {
@@ -627,7 +692,7 @@ function waitAll(
 // ────────────────────────────────────────────────────────────
 
 function closeServer(
-  server: Server,
+  server: HttpServer | HttpsServer,
   captured: CapturedWebhook[],
   waiters: Array<{ filter: WebhookFilter; resolve: (r: WebhookWaitResult) => void; timer: NodeJS.Timeout }>,
   waitAllTimers: Array<{

--- a/test/brand-jwks-resolver.test.js
+++ b/test/brand-jwks-resolver.test.js
@@ -23,6 +23,7 @@ const path = require('node:path');
 const {
   BrandJsonJwksResolver,
   BrandJsonResolverError,
+  fetchBrandJson,
   verifyWebhookSignature,
   InMemoryReplayStore,
   InMemoryRevocationStore,
@@ -647,5 +648,93 @@ describe('BrandJsonJwksResolver', () => {
     } finally {
       await server.stop();
     }
+  });
+
+  it('exports the bounded brand.json fetcher with the protocol body allowance', async () => {
+    const payload = JSON.stringify({ agents: [], padding: 'x'.repeat(70 * 1024) });
+    const server = await startServer({
+      '/.well-known/brand.json': { body: payload },
+    });
+    try {
+      const fetched = await fetchBrandJson({
+        startUrl: `${server.origin}/.well-known/brand.json`,
+        allowPrivateIp: true,
+      });
+      assert.strictEqual(fetched.status, 'ok');
+      assert.strictEqual(fetched.finalUrl, `${server.origin}/.well-known/brand.json`);
+      assert.strictEqual(fetched.data.padding.length, 70 * 1024);
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it('surfaces HTTP status without message parsing', async () => {
+    const server = await startServer({
+      '/.well-known/brand.json': { status: 404, body: { error: 'missing' } },
+    });
+    try {
+      await assert.rejects(
+        () =>
+          fetchBrandJson({
+            startUrl: `${server.origin}/.well-known/brand.json`,
+            allowPrivateIp: true,
+          }),
+        err => {
+          assert.ok(err instanceof BrandJsonResolverError);
+          assert.strictEqual(err.code, 'fetch_failed');
+          assert.strictEqual(err.httpStatus, 404);
+          return true;
+        }
+      );
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it('refuses transport redirects instead of following them', async () => {
+    const server = await startServer({
+      '/.well-known/brand.json': { status: 302, headers: { location: '/redirected.json' }, body: '' },
+      '/redirected.json': { body: { agents: [] } },
+    });
+    try {
+      await assert.rejects(
+        () =>
+          fetchBrandJson({
+            startUrl: `${server.origin}/.well-known/brand.json`,
+            allowPrivateIp: true,
+          }),
+        err => err instanceof BrandJsonResolverError && err.httpStatus === 302
+      );
+      assert.strictEqual(server.state.hits['/redirected.json'], 0);
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it('normalizes transport failures to the typed public error', async () => {
+    const server = await startServer({ '/.well-known/brand.json': { body: { agents: [] } } });
+    const url = `${server.origin}/.well-known/brand.json`;
+    await server.stop();
+    await assert.rejects(
+      () => fetchBrandJson({ startUrl: url, allowPrivateIp: true }),
+      err => {
+        assert.ok(err instanceof BrandJsonResolverError);
+        assert.strictEqual(err.code, 'fetch_failed');
+        assert.strictEqual(err.message, 'Unable to fetch brand.json');
+        assert.ok(err.cause instanceof Error);
+        return true;
+      }
+    );
+  });
+
+  it('enforces hard ceilings on public fetch overrides', async () => {
+    await assert.rejects(
+      () => fetchBrandJson({ startUrl: 'https://example.com/brand.json', timeoutMs: 10_001 }),
+      /timeoutMs must be an integer between 1 and 10000/
+    );
+    await assert.rejects(
+      () => fetchBrandJson({ startUrl: 'https://example.com/brand.json', maxBodyBytes: 262_145 }),
+      /maxBodyBytes must be an integer between 1 and 262144/
+    );
   });
 });

--- a/test/lib/cli-webhook-receiver-flag.test.js
+++ b/test/lib/cli-webhook-receiver-flag.test.js
@@ -233,6 +233,139 @@ describe('storyboard run --webhook-receiver', () => {
     assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
   });
 
+  test('--webhook-receiver-host survives positional parsing', () => {
+    const result = runCli([
+      'storyboard',
+      'run',
+      'test-mcp',
+      '--file',
+      scenarioPath,
+      '--webhook-receiver',
+      'proxy',
+      '--webhook-receiver-host',
+      '0.0.0.0',
+      '--webhook-receiver-public-url',
+      'http://tests:9999',
+      '--allow-http',
+      '--dry-run',
+    ]);
+    assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+  });
+
+  test('HTTP proxy public URL requires --allow-http', () => {
+    const result = runCli([
+      'storyboard',
+      'run',
+      'test-mcp',
+      '--file',
+      scenarioPath,
+      '--webhook-receiver',
+      'proxy',
+      '--webhook-receiver-public-url',
+      'http://tests:9999',
+      '--dry-run',
+    ]);
+    assert.strictEqual(result.status, 2);
+    assert.match(result.stderr, /requires --allow-http/);
+  });
+
+  test('invalid proxy public URL forms fail during dry-run validation', () => {
+    for (const [url, pattern] of [
+      ['file:///etc/passwd', /must use http or https/],
+      ['https://user:password@example.com', /must not include userinfo/],
+      ['https://example.com/hooks?tenant=1', /query string or fragment/],
+    ]) {
+      const result = runCli([
+        'storyboard',
+        'run',
+        'test-mcp',
+        '--file',
+        scenarioPath,
+        '--webhook-receiver',
+        'proxy',
+        '--webhook-receiver-public-url',
+        url,
+        '--dry-run',
+      ]);
+      assert.strictEqual(result.status, 2, `${url}: ${result.stderr}`);
+      assert.match(result.stderr, pattern);
+    }
+  });
+
+  test('TLS certificate and key flags must be paired', () => {
+    const result = runCli([
+      'storyboard',
+      'run',
+      'test-mcp',
+      '--file',
+      scenarioPath,
+      '--webhook-receiver',
+      '--webhook-receiver-tls-cert',
+      scenarioPath,
+      '--dry-run',
+    ]);
+    assert.strictEqual(result.status, 2);
+    assert.match(result.stderr, /tls-cert and --webhook-receiver-tls-key must be provided together/);
+  });
+
+  test('direct TLS rejects an HTTP public URL during dry-run', () => {
+    const result = runCli([
+      'storyboard',
+      'run',
+      'test-mcp',
+      '--file',
+      scenarioPath,
+      '--webhook-receiver',
+      'proxy',
+      '--webhook-receiver-public-url',
+      'http://tests:9999',
+      '--allow-http',
+      '--webhook-receiver-tls-cert',
+      scenarioPath,
+      '--webhook-receiver-tls-key',
+      scenarioPath,
+      '--dry-run',
+    ]);
+    assert.strictEqual(result.status, 2);
+    assert.match(result.stderr, /direct webhook receiver TLS requires an https:\/\//);
+  });
+
+  test('TLS material must come from regular files', () => {
+    const result = runCli([
+      'storyboard',
+      'run',
+      'test-mcp',
+      '--file',
+      scenarioPath,
+      '--webhook-receiver',
+      '--webhook-receiver-tls-cert',
+      tmpDir,
+      '--webhook-receiver-tls-key',
+      tmpDir,
+      '--dry-run',
+    ]);
+    assert.strictEqual(result.status, 2);
+    assert.match(result.stderr, /must be a regular file/);
+  });
+
+  test('TLS files are read eagerly with an actionable error', () => {
+    const result = runCli([
+      'storyboard',
+      'run',
+      'test-mcp',
+      '--file',
+      scenarioPath,
+      '--webhook-receiver',
+      '--webhook-receiver-tls-cert',
+      path.join(tmpDir, 'missing-cert.pem'),
+      '--webhook-receiver-tls-key',
+      path.join(tmpDir, 'missing-key.pem'),
+      '--dry-run',
+    ]);
+    assert.strictEqual(result.status, 2);
+    assert.match(result.stderr, /unable to read webhook receiver TLS files/);
+  });
+
   test('--webhook-receiver followed by a storyboard ID does not consume the ID as mode', () => {
     // Footgun check: `--webhook-receiver` takes an OPTIONAL value. An operator
     // writing `... --webhook-receiver webhook-emission` (expecting webhook-emission

--- a/test/lib/serve-multihost.test.js
+++ b/test/lib/serve-multihost.test.js
@@ -172,6 +172,72 @@ describe('serve() multi-host', () => {
     loopback.close();
   });
 
+  test('allows exact development HTTP hosts with allowHttpHosts', () => {
+    const factory = () => new McpServer({ name: 'Test', version: '1.0.0' });
+    const server = serve(factory, {
+      port: 0,
+      publicUrl: 'http://Seller:3007/mcp',
+      allowHttpHosts: ['seller'],
+      onListening: () => {},
+    });
+    server.close();
+
+    assert.throws(
+      () => serve(factory, { publicUrl: 'http://other:3007/mcp', allowHttpHosts: ['seller'] }),
+      /must use https/
+    );
+  });
+
+  test('rejects malformed allowHttpHosts entries at construction', () => {
+    const factory = () => new McpServer({ name: 'Test', version: '1.0.0' });
+    for (const entry of ['*', 'sell?er', 'seller:3007', ' seller', 'seller/path']) {
+      assert.throws(
+        () => serve(factory, { publicUrl: 'https://seller/mcp', allowHttpHosts: [entry] }),
+        /invalid allowHttpHosts entry/
+      );
+    }
+  });
+
+  test('applies allowHttpHosts to function-form publicUrl resolution', async () => {
+    const server = serve(() => new McpServer({ name: 'Test', version: '1.0.0' }), {
+      port: 0,
+      allowedHosts: ['seller'],
+      publicUrl: host => `http://${host}/mcp`,
+      allowHttpHosts: ['SELLER'],
+      onListening: () => {},
+    });
+    await waitForListening(server);
+    try {
+      const response = await request(server.address().port, { host: 'seller' });
+      assert.notStrictEqual(response.status, 500);
+    } finally {
+      server.close();
+    }
+  });
+
+  test('warns when allowHttpHosts is enabled in production', () => {
+    const previousNodeEnv = process.env.NODE_ENV;
+    const previousWarn = console.warn;
+    const warnings = [];
+    process.env.NODE_ENV = 'production';
+    console.warn = message => warnings.push(String(message));
+    let server;
+    try {
+      server = serve(() => new McpServer({ name: 'Test', version: '1.0.0' }), {
+        port: 0,
+        publicUrl: 'http://seller/mcp',
+        allowHttpHosts: ['seller'],
+        onListening: () => {},
+      });
+      assert.ok(warnings.some(message => message.includes('allowHttpHosts')));
+    } finally {
+      server?.close();
+      console.warn = previousWarn;
+      if (previousNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = previousNodeEnv;
+    }
+  });
+
   test('stamps a canonical idempotency scope despite Host port variants', async () => {
     const scopes = [];
     const server = serve(

--- a/test/lib/storyboard-webhook-receiver.test.js
+++ b/test/lib/storyboard-webhook-receiver.test.js
@@ -14,6 +14,12 @@
 const { describe, test, afterEach } = require('node:test');
 const assert = require('node:assert');
 const http = require('http');
+const https = require('node:https');
+const net = require('node:net');
+const { mkdtempSync, readFileSync, rmSync } = require('node:fs');
+const { tmpdir } = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
 const { setTimeout: delay } = require('node:timers/promises');
 
 const { createWebhookReceiver } = require('../../dist/lib/testing/storyboard/webhook-receiver.js');
@@ -33,6 +39,37 @@ async function post(url, body, headers) {
     headers: { 'content-type': 'application/json', ...(headers ?? {}) },
     body: typeof body === 'string' ? body : JSON.stringify(body),
   });
+}
+
+function postWithTestTls(url, body) {
+  const payload = JSON.stringify(body);
+  return new Promise((resolve, reject) => {
+    const req = https.request(
+      url,
+      {
+        method: 'POST',
+        rejectUnauthorized: false,
+        headers: { 'content-type': 'application/json', 'content-length': Buffer.byteLength(payload) },
+      },
+      res => {
+        res.resume();
+        res.once('end', () => resolve(res));
+      }
+    );
+    req.once('error', reject);
+    req.end(payload);
+  });
+}
+
+async function getFreePort() {
+  const server = net.createServer();
+  await new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const port = server.address().port;
+  await new Promise(resolve => server.close(resolve));
+  return port;
 }
 
 describe('createWebhookReceiver', () => {
@@ -309,7 +346,7 @@ describe('createWebhookReceiver', () => {
     const rec = await createWebhookReceiver({ mode: 'proxy_url', public_url: 'https://tunnel.example' });
     try {
       assert.strictEqual(rec.mode, 'proxy_url');
-      assert.strictEqual(rec.base_url, 'https://tunnel.example');
+      assert.match(rec.base_url, /^https:\/\/tunnel\.example\/_adcp_receiver\/[0-9a-f-]+$/);
     } finally {
       await rec.close();
     }
@@ -325,11 +362,117 @@ describe('createWebhookReceiver', () => {
       () => createWebhookReceiver({ mode: 'proxy_url', public_url: 'https://example.com\r\nX-Evil: 1' }),
       /CR\/LF/
     );
+    await assert.rejects(
+      () => createWebhookReceiver({ mode: 'proxy_url', public_url: 'https://example.com?redirect=1' }),
+      /query string or fragment/
+    );
+  });
+
+  test('requires an explicit local-development opt-in for an HTTP proxy URL', async () => {
+    await assert.rejects(
+      () => createWebhookReceiver({ mode: 'proxy_url', public_url: 'http://tests:9999' }),
+      /must use https/
+    );
+    const receiver = await createWebhookReceiver({
+      mode: 'proxy_url',
+      public_url: 'http://tests:9999',
+      allowHttp: true,
+    });
+    await receiver.close();
   });
 
   test('rejects 0.0.0.0 in loopback_mock mode', async () => {
     await assert.rejects(() => createWebhookReceiver({ host: '0.0.0.0' }), /not permitted/);
+    await assert.rejects(() => createWebhookReceiver({ host: '0:0:0:0:0:0:0:0' }), /not permitted/);
   });
+
+  test('binds on all interfaces in proxy mode and protects the route with an unguessable prefix', async () => {
+    const port = await getFreePort();
+    const receiver = await createWebhookReceiver({
+      mode: 'proxy_url',
+      host: '0.0.0.0',
+      port,
+      public_url: `http://tests:${port}/hooks`,
+      allowHttp: true,
+    });
+    try {
+      const routePrefix = new URL(receiver.base_url).pathname;
+      const accepted = await post(`http://127.0.0.1:${port}${routePrefix}/step/container/op-1`, {
+        idempotency_key: 'evt_x1234567890abcdef',
+      });
+      assert.strictEqual(accepted.status, 204);
+      assert.strictEqual(receiver.all().length, 1);
+      assert.strictEqual(receiver.all()[0].path, '/step/container/op-1');
+
+      const unscoped = await post(`http://127.0.0.1:${port}/step/container/op-2`, {
+        idempotency_key: 'evt_x1234567890abcdef',
+      });
+      assert.strictEqual(unscoped.status, 404);
+      assert.strictEqual(receiver.all().length, 1);
+    } finally {
+      await receiver.close();
+    }
+  });
+
+  test('requires an HTTPS public URL when direct TLS is configured', async () => {
+    await assert.rejects(
+      () =>
+        createWebhookReceiver({
+          mode: 'proxy_url',
+          public_url: 'http://tests:9999',
+          allowHttp: true,
+          tls: { cert: 'invalid', key: 'invalid' },
+        }),
+      /must use https when local TLS is configured/
+    );
+  });
+
+  test(
+    'serves and captures webhooks over direct TLS',
+    { skip: spawnSync('openssl', ['version'], { stdio: 'ignore' }).status !== 0 },
+    async () => {
+      const certDir = mkdtempSync(path.join(tmpdir(), 'adcp-webhook-tls-'));
+      const certPath = path.join(certDir, 'cert.pem');
+      const keyPath = path.join(certDir, 'key.pem');
+      let receiver;
+      try {
+        const generated = spawnSync(
+          'openssl',
+          [
+            'req',
+            '-x509',
+            '-newkey',
+            'rsa:2048',
+            '-nodes',
+            '-keyout',
+            keyPath,
+            '-out',
+            certPath,
+            '-days',
+            '1',
+            '-subj',
+            '/CN=127.0.0.1',
+            '-addext',
+            'subjectAltName=IP:127.0.0.1',
+          ],
+          { stdio: 'ignore' }
+        );
+        assert.strictEqual(generated.status, 0, 'failed to generate test TLS certificate');
+        receiver = await createWebhookReceiver({
+          tls: { cert: readFileSync(certPath), key: readFileSync(keyPath) },
+        });
+        assert.match(receiver.base_url, /^https:\/\//);
+        const response = await postWithTestTls(`${receiver.base_url}/step/tls/op-1`, {
+          idempotency_key: 'evt_x1234567890abcdef',
+        });
+        assert.strictEqual(response.statusCode, 204);
+        assert.strictEqual(receiver.all().length, 1);
+      } finally {
+        if (receiver) await receiver.close();
+        rmSync(certDir, { recursive: true, force: true });
+      }
+    }
+  );
 
   test('redacts sensitive headers in captured webhooks', async () => {
     const receiver = await createWebhookReceiver();


### PR DESCRIPTION
## Summary

- allow exact, explicitly configured HTTP development hosts in `serve()` for container-network aliases
- export the bounded SSRF-safe `fetchBrandJson()` helper with typed HTTP/transport failures and hard override ceilings
- make storyboard webhook receivers container-reachable, add direct TLS, protect wildcard listeners with a run-scoped path, and require an explicit local HTTP opt-in

The redirect-policy unification portion of #2696 is intentionally not implemented: applying receiver-side JSON indirection to bootstrap agent resolution would create a cross-origin trust pivot. The safe export and typed-error request is implemented here.

Closes #2645
Closes #2696
Closes #2448

## Validation

- `npm run typecheck`
- `npm run build:lib`
- focused brand resolver tests: 23 passed
- focused CLI receiver tests: all 27 passed
- focused multi-host server tests: 47 passed on isolated run
- receiver implementation tests, including valid-cert HTTPS round trip and non-root proxy paths, passed in the combined run
- code, protocol, security, and second-model review stack completed; all actionable findings addressed

The combined 154-test changed-area run had two existing nondeterministic failures under parallel execution (one reused-agent idempotency assertion and one schema-detail assertion); both are outside the changed behavior, and the multi-host suite passed in isolation.
