### PR TITLE
feat(decisioning): prove terminal webhook checkpoints

### DIFF
--- a/.changeset/quiet-tasks-prove.md
+++ b/.changeset/quiet-tasks-prove.md
@@ -1,0 +1,6 @@
+---
+'@adcp/sdk': minor
+---
+
+Expose a scoped proof that a terminal push task has its deterministic durable
+webhook checkpoint, allowing adopters to recover safely after deleting secrets.

--- a/docs/TYPE-SUMMARY.md
+++ b/docs/TYPE-SUMMARY.md
@@ -255,9 +255,14 @@ const settlements = createPostgresTaskSettlementCoordinator({
 });
 await completeScopedPushTask(settlements, scopedTaskRef, push, result);
 await failScopedPushTask(settlements, scopedTaskRef, push, structuredError);
+// Recovery after task + outbox commit and intentional push-config deletion:
+// First compare the stored terminal result/error with the intended artifact.
+if (await settlements.hasTerminalCheckpoint(scopedTaskRef)) {
+  // The scoped terminal task still has its durable checkpoint.
+}
 ```
 
-The registry and outbox must share one PostgreSQL pool. Run the task-registry and webhook-recovery migrations, return `ctx.handoffToTask(producer, { settlement: 'external' })`, and persist the complete `ScopedTaskRef` plus encrypted push route before the producer returns. The framework waits for that durable producer commit before returning `submitted`; rejection fails the initial invocation. Poll `settlements.recovery` from a worker. See `docs/migration-task-registry-scoping.md`.
+The registry and outbox must share one PostgreSQL pool. Run the task-registry and webhook-recovery migrations, return `ctx.handoffToTask(producer, { settlement: 'external' })`, and persist the complete `ScopedTaskRef` plus encrypted push route before the producer returns. The framework waits for that durable producer commit before returning `submitted`; rejection fails the initial invocation. Poll `settlements.recovery` from a worker. After intentionally deleting a settled task's push config, first compare the stored terminal result/error with the intended artifact; then `hasTerminalCheckpoint()` proves that the scoped task still has its deterministic durable webhook checkpoint without reconstructing the secret route. It does not prove artifact compatibility or delivery. Reconstructed coordinators must retain the same publisher scope, registry storage ID/namespace, and outbox table, and checkpoint tombstones must remain through the intent replay horizon. See `docs/migration-task-registry-scoping.md`.
 
 ## Production Webhook Tenant Binding
 

--- a/scripts/generate-agent-docs.ts
+++ b/scripts/generate-agent-docs.ts
@@ -1595,10 +1595,15 @@ function generateTypeSummary(index: SchemaIndex, tools: ToolInfo[]): string {
   ln(`});`);
   ln(`await completeScopedPushTask(settlements, scopedTaskRef, push, result);`);
   ln(`await failScopedPushTask(settlements, scopedTaskRef, push, structuredError);`);
+  ln(`// Recovery after task + outbox commit and intentional push-config deletion:`);
+  ln(`// First compare the stored terminal result/error with the intended artifact.`);
+  ln(`if (await settlements.hasTerminalCheckpoint(scopedTaskRef)) {`);
+  ln(`  // The scoped terminal task still has its durable checkpoint.`);
+  ln(`}`);
   ln('```');
   ln();
   ln(
-    `The registry and outbox must share one PostgreSQL pool. Run the task-registry and webhook-recovery migrations, return \`ctx.handoffToTask(producer, { settlement: 'external' })\`, and persist the complete \`ScopedTaskRef\` plus encrypted push route before the producer returns. The framework waits for that durable producer commit before returning \`submitted\`; rejection fails the initial invocation. Poll \`settlements.recovery\` from a worker. See \`docs/migration-task-registry-scoping.md\`.`
+    `The registry and outbox must share one PostgreSQL pool. Run the task-registry and webhook-recovery migrations, return \`ctx.handoffToTask(producer, { settlement: 'external' })\`, and persist the complete \`ScopedTaskRef\` plus encrypted push route before the producer returns. The framework waits for that durable producer commit before returning \`submitted\`; rejection fails the initial invocation. Poll \`settlements.recovery\` from a worker. After intentionally deleting a settled task's push config, first compare the stored terminal result/error with the intended artifact; then \`hasTerminalCheckpoint()\` proves that the scoped task still has its deterministic durable webhook checkpoint without reconstructing the secret route. It does not prove artifact compatibility or delivery. Reconstructed coordinators must retain the same publisher scope, registry storage ID/namespace, and outbox table, and checkpoint tombstones must remain through the intent replay horizon. See \`docs/migration-task-registry-scoping.md\`.`
   );
   ln();
 

--- a/src/lib/server/decisioning/runtime/postgres-task-settlement.ts
+++ b/src/lib/server/decisioning/runtime/postgres-task-settlement.ts
@@ -88,6 +88,16 @@ export interface PostgresTaskSettlementCoordinator {
   readonly durability: 'durable';
   /** Wire this into the normal webhook recovery poller/emitter. */
   readonly recovery: DurableWebhookDeliveryRecovery;
+  /**
+   * Prove that a scoped terminal task has its deterministic durable webhook
+   * checkpoint. This does not compare the task's result/error with a caller's
+   * intended artifact and does not prove delivery; verify terminal artifact
+   * compatibility separately before acknowledging an intent. Reconstructed
+   * coordinators must use the same registry, publisher scope, and outbox, and
+   * the checkpoint must be retained for the full intent replay horizon. The
+   * proof does not require the now-redacted push config.
+   */
+  hasTerminalCheckpoint(ref: ScopedTaskRef): Promise<boolean>;
   settle(
     ref: ScopedTaskRef,
     terminal: TerminalSettlement,
@@ -152,6 +162,27 @@ export function createPostgresTaskSettlementCoordinator(
   return {
     durability: 'durable',
     recovery,
+    async hasTerminalCheckpoint(ref): Promise<boolean> {
+      const settlementRef = snapshotSettlementRef(ref);
+      if (settlementRef.registryId !== registryId) return false;
+      const deliveryKey = {
+        ...claimScope,
+        deliveryId: stableScope('task-webhook', settlementRef),
+      };
+      try {
+        const task = await readTaskRow(
+          pool as PgTransactionalPool,
+          binding.tableName,
+          binding.namespace,
+          settlementRef,
+          false
+        );
+        if (!task || !TERMINAL.has(task.status) || task.has_webhook !== true) return false;
+        return Boolean(await readOutbox(pool as PgTransactionalPool, outboxTable, deliveryKey, false));
+      } catch (cause) {
+        throw new Error('PostgresTaskSettlementCoordinator.hasTerminalCheckpoint: query failed', { cause });
+      }
+    },
     async settle(ref, terminal, push): Promise<TaskPushSettlementOutcome> {
       const settlementRef = snapshotSettlementRef(ref);
       if (settlementRef.registryId !== registryId) {

--- a/test/server-decisioning-postgres-task-registry.test.js
+++ b/test/server-decisioning-postgres-task-registry.test.js
@@ -135,6 +135,39 @@ describe('decisioning task registry schema management', () => {
     );
   });
 
+  test('terminal checkpoint proof attributes database failures to its read-only operation', async () => {
+    const {
+      createPostgresTaskRegistry,
+      createPostgresTaskSettlementCoordinator,
+    } = require('../dist/lib/server/decisioning');
+    const databaseError = new Error('private database host unavailable');
+    const pool = {
+      async query() {
+        throw databaseError;
+      },
+      async connect() {
+        throw new Error('checkpoint proof must not acquire a transaction client');
+      },
+    };
+    const registry = createPostgresTaskRegistry({ namespace: NAMESPACE, storageId: 'proof-error', pool });
+    const coordinator = createPostgresTaskSettlementCoordinator({
+      registry,
+      publisherScope: 'test-seller',
+      outbox: { tableName: SETTLEMENT_OUTBOX },
+    });
+    await assert.rejects(
+      coordinator.hasTerminalCheckpoint({
+        taskId: 'task_proof_error',
+        accountId: 'acc_1',
+        ownerScope: 'account:acc_1',
+        registryId: registry.registryId,
+      }),
+      error =>
+        error.message === 'PostgresTaskSettlementCoordinator.hasTerminalCheckpoint: query failed' &&
+        error.cause === databaseError
+    );
+  });
+
   test('push settlement finishes secret protection before acquiring a transaction client', async () => {
     const {
       createPostgresTaskRegistry,
@@ -1186,6 +1219,7 @@ describe('createPostgresTaskRegistry', { skip: !DATABASE_URL && 'DATABASE_URL no
     });
     const ref = await registry.create({ tool: 'create_media_buy', accountId: 'acc_1', hasWebhook: true });
     const result = { media_buy_id: 'mb_preterminal' };
+    assert.strictEqual(await coordinator.hasTerminalCheckpoint(ref), false);
     assert.deepStrictEqual(await registry.complete(ref.taskId, ref, result), { outcome: 'applied' });
 
     await assert.rejects(
@@ -1200,6 +1234,37 @@ describe('createPostgresTaskRegistry', { skip: !DATABASE_URL && 'DATABASE_URL no
         /no atomic webhook delivery checkpoint/.test(error.message)
     );
     assert.strictEqual((await pool.query(`SELECT count(*)::int AS count FROM ${SETTLEMENT_OUTBOX}`)).rows[0].count, 0);
+    assert.strictEqual(await coordinator.hasTerminalCheckpoint(ref), false);
+  });
+
+  test('push settlement proves a terminal checkpoint without retaining push configuration', async () => {
+    const {
+      completeScopedPushTask,
+      createPostgresTaskSettlementCoordinator,
+    } = require('../dist/lib/server/decisioning');
+    const registry = createPostgresTaskRegistry({
+      pool,
+      namespace: NAMESPACE,
+      storageId: 'store:terminal-checkpoint-proof',
+    });
+    const coordinator = createPostgresTaskSettlementCoordinator({
+      registry,
+      publisherScope: 'test-seller-terminal-checkpoint-proof',
+      outbox: { tableName: SETTLEMENT_OUTBOX },
+    });
+    const ref = await registry.create({ tool: 'create_media_buy', accountId: 'acc_1', hasWebhook: true });
+    assert.strictEqual(await coordinator.hasTerminalCheckpoint(ref), false);
+    assert.deepStrictEqual(
+      await completeScopedPushTask(
+        coordinator,
+        ref,
+        { url: 'https://buyer.example/terminal-checkpoint-proof', operationId: 'checkpoint-proof-operation' },
+        { media_buy_id: 'mb_checkpoint_proof' }
+      ),
+      { outcome: 'applied', delivery: 'durably_bound' }
+    );
+    assert.strictEqual(await coordinator.hasTerminalCheckpoint(ref), true);
+    assert.strictEqual(await coordinator.hasTerminalCheckpoint({ ...ref, ownerScope: 'account:wrong-owner' }), false);
   });
 
   test('a separate Node process reconstructs the registry and atomically settles a push task', async () => {
@@ -1857,6 +1922,7 @@ describe('createPostgresTaskRegistry', { skip: !DATABASE_URL && 'DATABASE_URL no
         WHERE publisher_scope = $1`,
       ['test-seller-upgrade']
     );
+    assert.strictEqual(await coordinator.hasTerminalCheckpoint(ref), true);
     assert.deepStrictEqual(await failScopedPushTask(coordinator, ref, push, legacyError), {
       outcome: 'already_terminal',
       status: 'failed',


### PR DESCRIPTION
## Summary

- expose a scoped, read-only proof that a terminal push task still has its deterministic PostgreSQL webhook checkpoint after secret push configuration is deleted
- keep wrong-scope reads non-enumerating and surface database failures as retryable operation failures rather than false absence
- document that callers must prove terminal artifact compatibility separately and retain checkpoint tombstones through their intent replay horizon

## Why

During a rolling upgrade, an adopter may recover a durable settlement intent after task/outbox commit and push-config cleanup. Reconstructing the secret route is neither possible nor necessary: the deterministic scoped outbox key is sufficient to prove the atomic checkpoint already exists. The API does not adopt legacy terminal rows or create new notifications.

## Verification

- `npm run build:lib`
- `DATABASE_URL=postgresql:///brianokelley node --test test/server-decisioning-postgres-task-registry.test.js` (56/56)
- `npm run generate-agent-docs`
- Prettier checks on all modified files
- `git diff --check`
- dual review: protocol/code/security expert review plus `npm run review:codex -- --all --base main`
