### PR TITLE
fix(types): preserve signal targeting union constraints

### DIFF
--- a/.changeset/clean-signals-codegen.md
+++ b/.changeset/clean-signals-codegen.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Fix generated `SignalTargetingExpression` types and validators so categorical values remain non-empty, numeric bounds remain required and ordered, and unrelated objects cannot satisfy the union.

--- a/scripts/generate-types.ts
+++ b/scripts/generate-types.ts
@@ -126,6 +126,11 @@ const PRIORITY_CANONICAL_SCHEMAS = [
   'core/business-entity.json',
   'core/property-id.json',
   'core/signal-ref.json',
+  // The numeric branch carries an `anyOf` minimum/maximum constraint. When
+  // first reached through the aggregate targeting schema, jsts can claim the
+  // union as two open empty objects and make every object validate. Compile
+  // the authoritative discriminator before aggregate roots.
+  'core/signal-targeting-expression.json',
   'core/pagination-request.json',
   'core/forecast-point.json',
   'core/delivery-forecast.json',
@@ -1051,6 +1056,7 @@ export function enforceStrictSchema(schema: any): any {
     return schema;
   }
 
+  schema = normalizeSignalTargetingForCodegen(schema);
   schema = normalizePostalAreaForCodegen(schema);
   schema = nameVendorMetricValueQualifierForCodegen(schema);
   schema = normalizeCanonicalFormatOptionKindsForCodegen(schema);
@@ -1419,6 +1425,49 @@ export function enforceStrictSchema(schema: any): any {
   }
 
   return flattenMutualExclusiveOneOf(strictSchema);
+}
+
+/**
+ * Preserve signal-expression cardinality that the general compatibility pass
+ * intentionally relaxes for less strict schema families.
+ *
+ * The categorical branch cannot be meaningful with zero values. In the
+ * numeric branch, jsts treats the branch-local required-only `anyOf` as the
+ * whole object and emits two open `{}` arms. Give that branch an exact
+ * TypeScript union so TypeScript and Zod retain the presence guard.
+ */
+function normalizeSignalTargetingForCodegen(schema: any): any {
+  if (schema?.title !== 'Signal Targeting Expression' || !Array.isArray(schema.oneOf)) {
+    return schema;
+  }
+
+  return {
+    ...schema,
+    oneOf: schema.oneOf.map((branch: any) => {
+      const valueType = branch?.properties?.value_type;
+      if (valueType?.const === 'categorical' && branch.properties?.values) {
+        return {
+          ...branch,
+          properties: {
+            ...branch.properties,
+            values: {
+              ...branch.properties.values,
+              tsType: '[string, ...string[]]',
+            },
+          },
+        };
+      }
+      if (valueType?.const !== 'numeric' || !Array.isArray(branch.anyOf)) return branch;
+
+      if (!branch.anyOf.every(isRequirednessOnlySchema)) return branch;
+      return {
+        description: branch.description,
+        tsType:
+          "{ signal_ref: SignalRef; value_type: 'numeric'; min_value: number; max_value?: number } | " +
+          "{ signal_ref: SignalRef; value_type: 'numeric'; min_value?: number; max_value: number }",
+      };
+    }),
+  };
 }
 
 function canonicalCodegenJson(value: unknown, keyHint?: string): string {

--- a/scripts/generate-zod-from-ts.ts
+++ b/scripts/generate-zod-from-ts.ts
@@ -1249,6 +1249,37 @@ function postProcessExactSchema(content: string, schemaName: string, exactSchema
   return content.slice(0, target.expressionStart) + exactSchemaExpression + content.slice(target.expressionEnd);
 }
 
+/** Restore canonical cardinality constraints for signal expressions. */
+function postProcessSignalTargetingExpressionConstraints(content: string): string {
+  const target = findSchemaExportExpressions(content).find(entry => entry.name === 'SignalTargetingExpressionSchema');
+  if (!target) {
+    throw new Error('postProcessSignalTargetingExpressionConstraints: unable to locate schema.');
+  }
+  const expression = content.slice(target.expressionStart, target.expressionEnd);
+  const refined = `${expression}.superRefine((value, ctx) => {
+    if (value.value_type === "categorical" && value.values.length === 0) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["values"],
+        message: "categorical signal values must contain at least one entry",
+      });
+    }
+    if (
+      value.value_type === "numeric" &&
+      value.min_value !== undefined &&
+      value.max_value !== undefined &&
+      value.min_value > value.max_value
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["min_value"],
+        message: "min_value must be less than or equal to max_value",
+      });
+    }
+  })`;
+  return content.slice(0, target.expressionStart) + refined + content.slice(target.expressionEnd);
+}
+
 /** Add a refinement to one property schema inside a generated z.object expression. */
 function refineGeneratedObjectProperty(expression: string, propertyName: string, refinement: string): string {
   const marker = `"${propertyName}": `;
@@ -3785,6 +3816,7 @@ async function generateZodSchemas() {
     zodSchemas = postProcessPriceBreakdownConstraints(zodSchemas);
     zodSchemas = postProcessBeta4OfferAndOutcomeConstraints(zodSchemas);
     zodSchemas = postProcessCanonicalSharedConstraints(zodSchemas);
+    zodSchemas = postProcessSignalTargetingExpressionConstraints(zodSchemas);
     zodSchemas = postProcessPreviewCreativeRequestConstraints(zodSchemas);
 
     // Placement presentation is a closed, non-executable document boundary.

--- a/src/lib/types/core.generated.ts
+++ b/src/lib/types/core.generated.ts
@@ -1,5 +1,5 @@
 // Generated AdCP core types from official schemas v3.2.0-beta.9
-// Generated at: 2026-08-29T04:43:08.184Z
+// Generated at: 2026-08-30T07:23:28.359Z
 
 // ACCOUNTCURRENCYMODE CANONICAL ENUM
 /**
@@ -2959,7 +2959,35 @@ export type SignalRef =
       signal_id: string;
     };
 
-// PAGINATIONREQUEST PRIORITY CANONICAL SCHEMA
+// SIGNALTARGETINGEXPRESSION PRIORITY CANONICAL SCHEMA
+/**
+ * Predicate over a named signal definition. Signals are typed dimensions, similar to feature values: binary signals match true, categorical signals match one of a set of values, and numeric signals match a range. In package signal targeting groups, include/exclude semantics are controlled by the parent group operator, not by negating the expression.
+ */
+export type SignalTargetingExpression =
+  | {
+      signal_ref: SignalRef;
+      /**
+       * Discriminator for binary signals.
+       */
+      value_type: 'binary';
+      /**
+       * Binary package signal entries match users for whom the signal is true. Use the parent group operator for include/exclude.
+       */
+      value: true;
+    }
+  | {
+      signal_ref: SignalRef;
+      /**
+       * Discriminator for categorical signals.
+       */
+      value_type: 'categorical';
+      /**
+       * Values to target. Users with any of these values match the expression.
+       */
+      values: [string, ...string[]];
+    }
+  | {signal_ref: SignalRef; value_type: 'numeric'; min_value: number; max_value?: number}
+  | {signal_ref: SignalRef; value_type: 'numeric'; min_value?: number; max_value: number};
 /**
  * Standard cursor-based pagination parameters for list operations
  */
@@ -5653,40 +5681,6 @@ export type PackageSignalTargeting = SignalTargetingExpression & {
   signal_agent_segment_id?: string;
   activation_key?: ActivationKey;
 };
-/**
- * Predicate over a named signal definition. Signals are typed dimensions, similar to feature values: binary signals match true, categorical signals match one of a set of values, and numeric signals match a range. In package signal targeting groups, include/exclude semantics are controlled by the parent group operator, not by negating the expression.
- */
-export type SignalTargetingExpression =
-  | {
-      signal_ref: SignalRef;
-      /**
-       * Discriminator for binary signals.
-       */
-      value_type: 'binary';
-      /**
-       * Binary package signal entries match users for whom the signal is true. Use the parent group operator for include/exclude.
-       */
-      value: true;
-    }
-  | {
-      signal_ref: SignalRef;
-      /**
-       * Discriminator for categorical signals.
-       */
-      value_type: 'categorical';
-      /**
-       * Values to target. Users with any of these values match the expression.
-       *
-       * @minItems 1
-       */
-      values: [string, ...string[]];
-    }
-  | (
-      | {
-        }
-      | {
-        }
-    );
 /**
  * Destination-specific activation key returned by get_signals or activate_signal. Usually omitted for seller-offered signals selected directly through the same seller; include only when the selected signal was separately activated and the seller requires the activation key to correlate the package selection.
  */

--- a/src/lib/types/schemas.generated.ts
+++ b/src/lib/types/schemas.generated.ts
@@ -1,5 +1,5 @@
 // Generated Zod v4 schemas from TypeScript types
-// Generated at: 2026-08-29T20:19:54.191Z
+// Generated at: 2026-08-30T07:26:00.288Z
 // Sources:
 //   - core.generated.ts (core types)
 //   - tools.generated.ts (tool types)
@@ -537,6 +537,46 @@ export const SignalRefSchema = z.union([z.object({
         signal_id: z.string().regex(/^[a-zA-Z0-9_-]+$/)
     }).passthrough()]);
 
+export const SignalTargetingExpressionSchema = z.union([z.object({
+        signal_ref: SignalRefSchema,
+        value_type: z.literal("binary"),
+        value: z.literal(true)
+    }).passthrough(), z.object({
+        signal_ref: SignalRefSchema,
+        value_type: z.literal("categorical"),
+        values: z.array(z.string())
+    }).passthrough(), z.object({
+        signal_ref: SignalRefSchema,
+        value_type: z.literal("numeric"),
+        min_value: z.number(),
+        max_value: z.number().optional()
+    }).passthrough(), z.object({
+        signal_ref: SignalRefSchema,
+        value_type: z.literal("numeric"),
+        min_value: z.number().optional(),
+        max_value: z.number()
+    }).passthrough()]).superRefine((value, ctx) => {
+    if (value.value_type === "categorical" && value.values.length === 0) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["values"],
+        message: "categorical signal values must contain at least one entry",
+      });
+    }
+    if (
+      value.value_type === "numeric" &&
+      value.min_value !== undefined &&
+      value.max_value !== undefined &&
+      value.min_value > value.max_value
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["min_value"],
+        message: "min_value must be less than or equal to max_value",
+      });
+    }
+  });
+
 export const PaginationRequestSchema = z.object({
     max_results: z.number().int().min(1).max(100).optional(),
     cursor: z.string().optional()
@@ -961,16 +1001,6 @@ export const PostalCountryAreaSchema = PostalCountrySystemSchema.and(z.object({
 }).passthrough());
 
 export const GeographicPlaceIdentifierSystemSchema = z.union([z.union([z.literal("geonames"), z.literal("google_ads"), z.literal("microsoft_ads")]), z.string()]);
-
-export const SignalTargetingExpressionSchema = z.union([z.object({
-        signal_ref: SignalRefSchema,
-        value_type: z.literal("binary"),
-        value: z.literal(true)
-    }).passthrough(), z.object({
-        signal_ref: SignalRefSchema,
-        value_type: z.literal("categorical"),
-        values: z.array(z.string())
-    }).passthrough(), z.union([z.object({}).passthrough(), z.object({}).passthrough()])]);
 
 export const ActivationKeySchema = z.union([z.object({
         type: z.literal("segment_id"),

--- a/src/type-tests/generated-required-fields.type-test.ts
+++ b/src/type-tests/generated-required-fields.type-test.ts
@@ -4,6 +4,7 @@ import type {
   GeoDeliveryMetrics,
   KeywordDeliveryMetrics,
   PostalCountrySystem,
+  SignalTargetingExpression,
   SyncCreativesSuccess as CoreSyncCreativesSuccess,
   TasksGetResponse,
 } from '../lib/types/core.generated';
@@ -77,6 +78,26 @@ type _ToolAdCPVersionEnvelopeExport = ToolAdCPVersionEnvelope;
 type _ToolCanonicalFormatBaseExport = ToolCanonicalFormatBase;
 type _ToolSignalDefinitionEnrichmentExport = ToolSignalDefinitionEnrichment;
 type _ToolSignalTargetingExpressionExport = ToolSignalTargetingExpression;
+
+const validLowerBoundedSignal: SignalTargetingExpression = {
+  signal_ref: { scope: 'product', signal_id: 'age' },
+  value_type: 'numeric',
+  min_value: 25,
+};
+const invalidEmptyCategoricalSignal: SignalTargetingExpression = {
+  signal_ref: { scope: 'product', signal_id: 'segment' },
+  value_type: 'categorical',
+  // @ts-expect-error categorical targeting expressions require at least one value.
+  values: [],
+};
+// @ts-expect-error numeric targeting expressions require at least one bound.
+const invalidUnboundedSignal: SignalTargetingExpression = {
+  signal_ref: { scope: 'product', signal_id: 'age' },
+  value_type: 'numeric',
+};
+void validLowerBoundedSignal;
+void invalidEmptyCategoricalSignal;
+void invalidUnboundedSignal;
 
 // Refine result branches narrow CanonicalProposal; they do not replace it.
 // Keep every canonical continuation field plus branch-specific lineage/status

--- a/test/lib/zod-schemas.test.js
+++ b/test/lib/zod-schemas.test.js
@@ -2085,6 +2085,90 @@ describe('Zod Schema Validation', () => {
     assert.ok(result.success, `Categorical signal selector should validate: ${JSON.stringify(result.error?.issues)}`);
   });
 
+  test('SignalTargetingExpressionSchema preserves every discriminated branch', async () => {
+    if (!schemas) {
+      schemas = await import('../../dist/lib/types/schemas.generated.js');
+    }
+
+    assert.equal(
+      schemas.SignalTargetingExpressionSchema.safeParse({
+        signal_ref: { scope: 'product', signal_id: 'intent' },
+        value_type: 'binary',
+        value: true,
+      }).success,
+      true,
+      'binary true must satisfy the binary branch'
+    );
+    assert.equal(
+      schemas.SignalTargetingExpressionSchema.safeParse({
+        signal_ref: { scope: 'product', signal_id: 'intent' },
+        value_type: 'binary',
+        value: false,
+      }).success,
+      false,
+      'binary false must not fall through an open-object codegen branch'
+    );
+    assert.equal(
+      schemas.SignalTargetingExpressionSchema.safeParse({
+        signal_ref: { scope: 'product', signal_id: 'segment' },
+        value_type: 'categorical',
+        values: ['sports'],
+      }).success,
+      true,
+      'a non-empty categorical selector must satisfy the categorical branch'
+    );
+    assert.equal(
+      schemas.SignalTargetingExpressionSchema.safeParse({
+        signal_ref: { scope: 'product', signal_id: 'segment' },
+        value_type: 'categorical',
+        values: [],
+      }).success,
+      false,
+      'categorical selectors require at least one value'
+    );
+    assert.equal(
+      schemas.SignalTargetingExpressionSchema.safeParse({
+        signal_ref: { scope: 'product', signal_id: 'age' },
+        value_type: 'numeric',
+        min_value: 25,
+      }).success,
+      true,
+      'a lower-bounded numeric branch must remain available after code generation'
+    );
+    assert.equal(
+      schemas.SignalTargetingExpressionSchema.safeParse({
+        signal_ref: { scope: 'product', signal_id: 'age' },
+        value_type: 'numeric',
+        max_value: 54,
+      }).success,
+      true,
+      'an upper-bounded numeric branch must remain available after code generation'
+    );
+    assert.equal(
+      schemas.SignalTargetingExpressionSchema.safeParse({
+        signal_ref: { scope: 'product', signal_id: 'age' },
+        value_type: 'numeric',
+      }).success,
+      false,
+      'a numeric expression must declare at least one bound'
+    );
+    assert.equal(
+      schemas.SignalTargetingExpressionSchema.safeParse({
+        signal_ref: { scope: 'product', signal_id: 'age' },
+        value_type: 'numeric',
+        min_value: 55,
+        max_value: 54,
+      }).success,
+      false,
+      'numeric bounds must be ordered'
+    );
+    assert.equal(
+      schemas.SignalTargetingExpressionSchema.safeParse({ arbitrary: true }).success,
+      false,
+      'unrelated objects must not satisfy the targeting expression union'
+    );
+  });
+
   test('AudienceConstraintsSchema validates include/exclude arrays', async () => {
     if (!schemas) {
       schemas = await import('../../dist/lib/types/schemas.generated.js');


### PR DESCRIPTION
## Summary

- compile the canonical signal targeting expression before aggregate schemas can claim its union
- preserve non-empty categorical values and numeric at-least-one-bound contracts in generated TypeScript
- enforce categorical cardinality and ordered numeric bounds in the generated Zod validator
- add runtime and type-level regressions for false binary values, empty categorical values, unbounded/reversed numeric ranges, and open-object fallthrough

## Verification

- `npm run build:lib`
- `node --test --test-name-pattern="SignalTargetingExpressionSchema preserves" test/lib/zod-schemas.test.js`
- `npm run typecheck`
- pre-push validation (format, typecheck, build)