### PR TITLE
fix(types): preserve pricing schema constraints

### DIFF
--- a/.changeset/bright-prices-hold.md
+++ b/.changeset/bright-prices-hold.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Preserve canonical currency, price, CPV threshold, and DOOH bounds in generated runtime schemas.

--- a/scripts/generate-zod-from-ts.ts
+++ b/scripts/generate-zod-from-ts.ts
@@ -1952,7 +1952,10 @@ function postProcessCanonicalPrimitiveConstraints(content: string): string {
 
   for (const schemaFile of schemaFiles.sort()) {
     const schema = JSON.parse(readFileSync(schemaFile, 'utf8')) as Record<string, unknown>;
-    const schemaName = typeof schema.title === 'string' ? schema.title.replace(/[^A-Za-z0-9]/g, '') : '';
+    const rawSchemaName = typeof schema.title === 'string' ? schema.title.replace(/[^A-Za-z0-9]/g, '') : '';
+    const schemaName = [rawSchemaName, rawSchemaName && rawSchemaName[0].toUpperCase() + rawSchemaName.slice(1)].find(
+      candidate => candidate && content.includes(`export const ${candidate}Schema`)
+    );
     if (!schemaName) continue;
     const exportStart = content.indexOf(`export const ${schemaName}Schema`);
     if (exportStart < 0) continue;
@@ -2002,6 +2005,109 @@ function postProcessCanonicalPrimitiveConstraints(content: string): string {
 
     content = content.slice(0, exportStart) + block + content.slice(exportEnd);
   }
+  return content;
+}
+
+/**
+ * Preserve constraints that live inside pricing union branches or a titled
+ * nested definition. Those locations are not visible to the generic
+ * property reconciliation above, so guard the exact canonical constraints
+ * before applying the corresponding generated Zod refinements.
+ */
+function postProcessPricingOptionConstraints(content: string): string {
+  const readCanonical = (fileName: string): Record<string, unknown> =>
+    JSON.parse(
+      readFileSync(path.join(__dirname, `../schemas/cache/latest/pricing-options/${fileName}`), 'utf8')
+    ) as Record<string, unknown>;
+  const requireRecord = (value: unknown, label: string): Record<string, unknown> => {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      throw new Error(`postProcessPricingOptionConstraints: canonical ${label} is missing.`);
+    }
+    return value as Record<string, unknown>;
+  };
+  const requireConstraint = (
+    schema: Record<string, unknown>,
+    label: string,
+    expected: Record<string, string | number>
+  ): void => {
+    for (const [key, value] of Object.entries(expected)) {
+      if (schema[key] !== value) {
+        throw new Error(
+          `postProcessPricingOptionConstraints: canonical ${label}.${key} changed; expected ${JSON.stringify(value)}.`
+        );
+      }
+    }
+  };
+  const replaceInSchema = (schemaName: string, before: string, after: string): void => {
+    const start = content.indexOf(`export const ${schemaName}Schema = `);
+    if (start < 0) throw new Error(`postProcessPricingOptionConstraints: ${schemaName}Schema not found.`);
+    const endCandidate = content.indexOf('\n\nexport const ', start + 1);
+    const end = endCandidate < 0 ? content.length : endCandidate;
+    const block = content.slice(start, end);
+    const first = block.indexOf(before);
+    if (first < 0 || block.indexOf(before, first + before.length) >= 0) {
+      throw new Error(
+        `postProcessPricingOptionConstraints: expected exactly one ${JSON.stringify(before)} in ${schemaName}Schema.`
+      );
+    }
+    content = content.slice(0, start) + block.replace(before, after) + content.slice(end);
+  };
+
+  const cpv = readCanonical('cpv-option.json');
+  const cpvProperties = requireRecord(cpv.properties, 'CPV properties');
+  const parameters = requireRecord(cpvProperties.parameters, 'CPV parameters');
+  const parameterProperties = requireRecord(parameters.properties, 'CPV parameter properties');
+  const viewThreshold = requireRecord(parameterProperties.view_threshold, 'CPV view_threshold');
+  const thresholdBranches = viewThreshold.oneOf;
+  if (!Array.isArray(thresholdBranches) || thresholdBranches.length !== 2) {
+    throw new Error('postProcessPricingOptionConstraints: canonical CPV view_threshold branches changed.');
+  }
+  const numericThreshold = requireRecord(thresholdBranches[0], 'CPV numeric view_threshold');
+  requireConstraint(numericThreshold, 'CPV numeric view_threshold', { type: 'number', minimum: 0, maximum: 1 });
+  const durationBranch = requireRecord(thresholdBranches[1], 'CPV duration view_threshold');
+  const durationProperties = requireRecord(durationBranch.properties, 'CPV duration properties');
+  const durationSeconds = requireRecord(durationProperties.duration_seconds, 'CPV duration_seconds');
+  requireConstraint(durationSeconds, 'CPV duration_seconds', { type: 'integer', minimum: 1 });
+  replaceInSchema(
+    'CPVPricingOption',
+    'view_threshold: z.union([z.number(),',
+    'view_threshold: z.union([z.number().gte(0).lte(1),'
+  );
+  replaceInSchema('CPVPricingOption', 'duration_seconds: z.number()', 'duration_seconds: z.number().int().gte(1)');
+
+  const flatRate = readCanonical('flat-rate-option.json');
+  let doohParameters: Record<string, unknown> | undefined;
+  const findDoohParameters = (value: unknown): void => {
+    if (doohParameters || !value || typeof value !== 'object') return;
+    if (Array.isArray(value)) {
+      value.forEach(findDoohParameters);
+      return;
+    }
+    const node = value as Record<string, unknown>;
+    if (node.title === 'DoohParameters') {
+      doohParameters = node;
+      return;
+    }
+    Object.values(node).forEach(findDoohParameters);
+  };
+  findDoohParameters(flatRate);
+  const doohProperties = requireRecord(requireRecord(doohParameters, 'DoohParameters').properties, 'DOOH properties');
+  const doohConstraints: Array<[string, Record<string, string | number>, string]> = [
+    ['sov_percentage', { type: 'number', minimum: 0, maximum: 100 }, '.gte(0).lte(100)'],
+    ['loop_duration_seconds', { type: 'integer', minimum: 1 }, '.int().gte(1)'],
+    ['min_plays_per_hour', { type: 'integer', minimum: 1 }, '.int().gte(1)'],
+    ['duration_hours', { type: 'number', minimum: 0 }, '.gte(0)'],
+    ['estimated_impressions', { type: 'integer', minimum: 0 }, '.int().gte(0)'],
+  ];
+  for (const [propertyName, expected, suffix] of doohConstraints) {
+    requireConstraint(
+      requireRecord(doohProperties[propertyName], `DOOH ${propertyName}`),
+      `DOOH ${propertyName}`,
+      expected
+    );
+    replaceInSchema('DoohParameters', `${propertyName}: z.number()`, `${propertyName}: z.number()${suffix}`);
+  }
+
   return content;
 }
 
@@ -4178,6 +4284,7 @@ async function generateZodSchemas() {
     // Reconcile canonical primitive constraints last, after structural and
     // exact-schema rewrites that may replace earlier generated blocks.
     zodSchemas = postProcessCanonicalPrimitiveConstraints(zodSchemas);
+    zodSchemas = postProcessPricingOptionConstraints(zodSchemas);
     zodSchemas = postProcessJsonSchemaUriFormats(zodSchemas);
 
     // Compatibility aliases can make jsts emit repeated format/placement

--- a/src/lib/types/schemas.generated.ts
+++ b/src/lib/types/schemas.generated.ts
@@ -1,5 +1,5 @@
 // Generated Zod v4 schemas from TypeScript types
-// Generated at: 2026-08-30T07:26:00.288Z
+// Generated at: 2026-08-30T17:54:53.168Z
 // Sources:
 //   - core.generated.ts (core types)
 //   - tools.generated.ts (tool types)
@@ -3244,12 +3244,12 @@ export const PriceGuidanceSchema = z.object({
 export const VCPMPricingOptionSchema = z.object({
     pricing_option_id: z.string(),
     pricing_model: z.literal("vcpm"),
-    currency: z.string(),
-    fixed_price: z.number().optional(),
-    floor_price: z.number().optional(),
+    currency: z.string().regex(new RegExp("^[A-Z]{3}$")),
+    fixed_price: z.number().gte(0).optional(),
+    floor_price: z.number().gte(0).optional(),
     max_bid: z.boolean().optional(),
     price_guidance: PriceGuidanceSchema.optional(),
-    min_spend_per_package: z.number().optional(),
+    min_spend_per_package: z.number().gte(0).optional(),
     price_breakdown: PriceBreakdownSchema.optional(),
     eligible_adjustments: z.array(PriceAdjustmentKindSchema).optional()
 }).passthrough();
@@ -3289,8 +3289,8 @@ export const CPVPricingOptionSchema = z.object({
     max_bid: z.boolean().optional(),
     price_guidance: PriceGuidanceSchema.optional(),
     parameters: z.object({
-        view_threshold: z.union([z.number(), z.object({
-                duration_seconds: z.number()
+        view_threshold: z.union([z.number().gte(0).lte(1), z.object({
+                duration_seconds: z.number().int().gte(1)
             }).passthrough()])
     }).passthrough(),
     min_spend_per_package: z.number().gte(0).optional(),
@@ -3317,13 +3317,13 @@ export const CPPPricingOptionSchema = z.object({
 
 export const DoohParametersSchema = z.object({
     type: z.literal("dooh"),
-    sov_percentage: z.number().optional(),
-    loop_duration_seconds: z.number().optional(),
-    min_plays_per_hour: z.number().optional(),
+    sov_percentage: z.number().gte(0).lte(100).optional(),
+    loop_duration_seconds: z.number().int().gte(1).optional(),
+    min_plays_per_hour: z.number().int().gte(1).optional(),
     venue_package: z.string().optional(),
-    duration_hours: z.number().optional(),
+    duration_hours: z.number().gte(0).optional(),
     daypart: z.string().optional(),
-    estimated_impressions: z.number().optional()
+    estimated_impressions: z.number().int().gte(0).optional()
 }).passthrough();
 
 export const TimeBasedPricingOptionSchema = z.object({

--- a/test/jsdoc-constraints-codegen.test.js
+++ b/test/jsdoc-constraints-codegen.test.js
@@ -261,6 +261,9 @@ describe('generated Zod schemas — constraint pinning', () => {
   let PropertyTagSchema;
   let VendorMetricIDSchema;
   let LanguageTagSchema;
+  let VCPMPricingOptionSchema;
+  let CPVPricingOptionSchema;
+  let DoohParametersSchema;
 
   try {
     ({
@@ -282,11 +285,65 @@ describe('generated Zod schemas — constraint pinning', () => {
       PropertyTagSchema,
       VendorMetricIDSchema,
       LanguageTagSchema,
+      VCPMPricingOptionSchema,
+      CPVPricingOptionSchema,
+      DoohParametersSchema,
     } = require('../dist/lib/types/schemas.generated'));
   } catch (e) {
     // Build hasn't run yet — skip the pinning slice rather than fail the unit slice.
     console.warn(`⏭️  Skipping pinning tests — dist not built: ${e.message}`);
   }
+
+  it('preserves canonical vCPM, CPV, and DOOH pricing constraints', { skip: !VCPMPricingOptionSchema }, () => {
+    const vcpm = value =>
+      VCPMPricingOptionSchema.safeParse({
+        pricing_option_id: 'vcpm-1',
+        pricing_model: 'vcpm',
+        currency: 'USD',
+        ...value,
+      }).success;
+    assert.equal(vcpm({ fixed_price: 0, floor_price: 0, min_spend_per_package: 0 }), true);
+    assert.equal(vcpm({ currency: 'usd' }), false);
+    for (const field of ['fixed_price', 'floor_price', 'min_spend_per_package']) {
+      assert.equal(vcpm({ [field]: -0.01 }), false, `${field} must be non-negative`);
+    }
+
+    const cpv = viewThreshold =>
+      CPVPricingOptionSchema.safeParse({
+        pricing_option_id: 'cpv-1',
+        pricing_model: 'cpv',
+        currency: 'USD',
+        parameters: { view_threshold: viewThreshold },
+      }).success;
+    assert.equal(cpv(0), true);
+    assert.equal(cpv(1), true);
+    assert.equal(cpv(-0.01), false);
+    assert.equal(cpv(1.01), false);
+    assert.equal(cpv({ duration_seconds: 1 }), true);
+    assert.equal(cpv({ duration_seconds: 0 }), false);
+    assert.equal(cpv({ duration_seconds: 1.5 }), false);
+
+    const dooh = value => DoohParametersSchema.safeParse({ type: 'dooh', ...value }).success;
+    assert.equal(
+      dooh({
+        sov_percentage: 0,
+        loop_duration_seconds: 1,
+        min_plays_per_hour: 1,
+        duration_hours: 0,
+        estimated_impressions: 0,
+      }),
+      true
+    );
+    assert.equal(dooh({ sov_percentage: -1 }), false);
+    assert.equal(dooh({ sov_percentage: 101 }), false);
+    assert.equal(dooh({ loop_duration_seconds: 0 }), false);
+    assert.equal(dooh({ loop_duration_seconds: 1.5 }), false);
+    assert.equal(dooh({ min_plays_per_hour: 0 }), false);
+    assert.equal(dooh({ min_plays_per_hour: 1.5 }), false);
+    assert.equal(dooh({ duration_hours: -1 }), false);
+    assert.equal(dooh({ estimated_impressions: -1 }), false);
+    assert.equal(dooh({ estimated_impressions: 1.5 }), false);
+  });
 
   it('MediaBuySchema.revision rejects 0 (minimum: 1)', { skip: !MediaBuySchema }, () => {
     const r = MediaBuySchema.shape.revision.safeParse(0);


### PR DESCRIPTION
## Summary

- restore canonical currency and non-negative price constraints on generated vCPM Zod schemas
- restore CPV numeric/time threshold bounds and DOOH allocation bounds
- fail code generation if the canonical pricing shapes change, with runtime regression coverage

## Verification

- `npm run build:lib`
- `node --test test/jsdoc-constraints-codegen.test.js` (24/24)
- pre-push formatting, typecheck, and build gate

This fixes the generated runtime/OpenAPI drift surfaced while integrating SDK 14 downstream.