### PR TITLE
feat(schemas): read optional nulls as absent at the call site

### DIFF
--- a/.changeset/optional-null-tolerance-helper.md
+++ b/.changeset/optional-null-tolerance-helper.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': minor
+---
+
+Add `treatOptionalNullsAsAbsent` to `@adcp/sdk/schemas`, which reads an agent's explicit `null` as an omitted field wherever a generated schema declares the field optional and non-nullable, so one unreported hint no longer discards a whole response. Nullable fields keep their `null` as a value, required and `z.never()` fields keep their `null` and still fail validation, undeclared keys pass through, and the input payload is never mutated. The walk recurses through nested objects and arrays and consults both sides of the intersections that JSON Schema `allOf` projects into, so it covers 80 of the 87 generated `*ResponseSchema` roots; union-rooted schemas are left untouched. Removes the never-called `postProcessForNullish` transform from the Zod generator, which read as live behavior to anyone auditing it.

--- a/docs/ZOD-SCHEMAS.md
+++ b/docs/ZOD-SCHEMAS.md
@@ -95,6 +95,61 @@ app.post('/api/products', async (req, res) => {
 });
 ```
 
+## Tolerating `null` on Optional Fields
+
+Optional fields in the generated schemas are `.optional()`, which accepts
+`undefined` and rejects `null`. That keeps the schemas an exact mirror of the
+TypeScript types, but plenty of agents serialize from Pydantic, Jackson, or
+`encoding/json` and emit `null` for a field they have nothing to report for.
+Because Zod validates the whole payload before you read any field, one `null`
+on an optional hint discards everything alongside it — a `null`
+`next_expected_at` (a scheduling hint carrying no figures) takes every
+`media_buy_deliveries` spend and impression count with it.
+
+`treatOptionalNullsAsAbsent` reinterprets those `null`s, and only those:
+
+```typescript
+import {
+  GetMediaBuyDeliveryResponseSchema,
+  treatOptionalNullsAsAbsent,
+} from '@adcp/sdk/schemas';
+
+const tolerated = treatOptionalNullsAsAbsent(GetMediaBuyDeliveryResponseSchema, response);
+const result = GetMediaBuyDeliveryResponseSchema.safeParse(tolerated);
+```
+
+A `null` is dropped only where the schema says it carries no information the
+omission wouldn't — the field may be skipped, and `null` is not among the
+values it accepts. Everything else keeps its `null`, and its verdict:
+
+| Schema declares | Payload sends | Result |
+| --- | --- | --- |
+| `.optional()` | `null` | key dropped; parse succeeds |
+| `.optional().nullable()` | `null` | `null` kept — the spec assigns it a meaning (`completion_rate: null` means "not applicable to these buys") |
+| required | `null` | `null` kept; parse still fails |
+| `z.never().optional()` | `null` | `null` kept; parse still fails (the field must not be provided) |
+| not declared (`passthrough`) | `null` | passed through untouched |
+
+The walk is schema-driven and recurses through nested objects and arrays, so a
+`null` deep inside `media_buy_deliveries[].by_package[]` is resolved against
+that entry's own field declaration. Schemas projected from a JSON Schema
+`allOf` are Zod intersections; both sides are consulted, and a `null` is only
+dropped where every side that declares the field agrees it means absent.
+
+Subtrees reached through a `union`, `pipe`, `lazy`, or `record` are left alone:
+the schema doesn't name a single shape to resolve the field against, and
+guessing one risks dropping a `null` that one arm of the union treats as a
+value.
+
+The input is never mutated. Nodes containing a reinterpreted `null` are
+copied; every other node is shared with the original, so a caller keeping an
+audit trail of what the agent actually sent can hold onto the payload it
+passed in.
+
+This is the Zod-surface counterpart to the null tolerance the SDK's own
+response validator applies to v2.x envelope fields (`errors`, `context`,
+`ext`) before Ajv.
+
 ## Advanced Usage
 
 ### Partial Schemas

--- a/scripts/generate-zod-from-ts.ts
+++ b/scripts/generate-zod-from-ts.ts
@@ -21,22 +21,6 @@ const TOOLS_SOURCE_FILE = path.join(__dirname, '../src/lib/types/tools.generated
 const OUTPUT_FILE = path.join(__dirname, '../src/lib/types/schemas.generated.ts');
 
 /**
- * Post-process generated Zod schemas to convert .optional() to .nullish() globally.
- * This is needed because real-world API responses often send explicit null values for optional
- * fields, but ts-to-zod generates .optional() which only accepts undefined.
- * Using .nullish() accepts both undefined and null.
- *
- * Many JSON serializers (Python, Java, etc.) default to sending null for absent optional fields,
- * so treating "optional" as "can be undefined OR null" is the pragmatic approach.
- */
-function postProcessForNullish(content: string): string {
-  // Replace .optional() with .nullish() globally, except when preceded by .never()
-  // z.never().optional() must stay as-is: it means "this field must not be provided",
-  // and converting to .nullish() would allow null values through, weakening that constraint.
-  return content.replace(/(?<!\.never\(\))\.optional\(\)/g, '.nullish()');
-}
-
-/**
  * Post-process generated Zod schemas to fix imports from "undefined".
  *
  * ts-to-zod generates `import { type X } from "undefined"` for recursive types
@@ -3873,13 +3857,14 @@ async function generateZodSchemas() {
     // Get the generated Zod schemas
     let zodSchemas = result.getZodSchemasFile();
 
-    // Post-process: Convert .optional() to .nullish() for PackageSchema fields
-    // This is needed because real-world API responses (e.g., Yahoo webhook) send explicit
-    // null values for optional fields, but ts-to-zod generates .optional() which only
-    // accepts undefined, not null. Using .nullish() accepts both undefined and null.
-    // Note: we intentionally keep .optional() (NOT .nullish()) so Zod schemas match
-    // TypeScript types. Callers that need to accept null from external APIs should use
-    // .nullish() at the call site, not globally in every schema.
+    // Optional fields stay `.optional()` (NOT `.nullish()`) so the Zod schemas match the
+    // TypeScript types and the inferred types stay exact. Real-world responses do send
+    // explicit null for fields they have nothing to report for (e.g. the Yahoo webhook,
+    // any Pydantic- or Jackson-serialized seller). Callers that need to tolerate those
+    // pass the payload through `treatOptionalNullsAsAbsent` from `@adcp/sdk/schemas`
+    // (src/lib/schemas/optional-nulls.ts), which drops a null only where the schema
+    // declares the field optional and non-nullable — nullable and required fields keep
+    // their null and their verdict.
 
     // Post-process: Fix broken imports from "undefined" (recursive types with z.lazy())
     zodSchemas = postProcessUndefinedImports(zodSchemas);
@@ -4346,7 +4331,6 @@ if (require.main === module) {
 export const __test__ = {
   postProcessTupleRestArrays,
   relaxArrayCardinalityTypes,
-  postProcessForNullish,
   postProcessRecordIntersections,
   postProcessMarkerUnionObjectIntersections,
   postProcessRepeatedProductIntersections,

--- a/src/lib/schemas/index.ts
+++ b/src/lib/schemas/index.ts
@@ -21,6 +21,9 @@
  *   - {@link customToolFor}: sugar for registering a single custom tool
  *     with type-safe `handler` params derived from the schema's shape.
  *   - {@link customToolForSchema}: same sugar for full Zod schemas.
+ *   - {@link treatOptionalNullsAsAbsent}: reads a seller's explicit `null` as
+ *     an omitted field wherever the schema declares it optional and
+ *     non-nullable, so one unreported hint doesn't discard a whole response.
  *
  * ```ts
  * import { createAdcpServer } from '@adcp/sdk/server/legacy/v5';
@@ -54,6 +57,7 @@ import {
 import { resolveAdcpVersion } from '../utils/adcp-version-config';
 
 export * from '../types/schemas.generated';
+export { treatOptionalNullsAsAbsent } from './optional-nulls';
 
 type LooseObjectShapeFor<T extends object> = {
   [K in keyof T]-?: undefined extends T[K]

--- a/src/lib/schemas/optional-nulls.ts
+++ b/src/lib/schemas/optional-nulls.ts
@@ -1,0 +1,188 @@
+/**
+ * Read an explicit `null` as "field absent" wherever a generated schema says
+ * the field may be omitted and may not hold `null`.
+ *
+ * The generated schemas mirror the AdCP TypeScript types exactly: an optional
+ * field is `.optional()`, which accepts `undefined` and rejects `null`. Many
+ * sellers serialize from Pydantic, Jackson, or encoding/json and emit `null`
+ * for a field they have nothing to report for. Zod validates the whole payload
+ * before a caller reads any field, so one such `null` on a scheduling hint
+ * discards the spend and impression figures alongside it.
+ *
+ * A `null` is only reinterpreted where the schema itself says it carries no
+ * information the omission wouldn't: the field may be skipped, and `null` is
+ * not among the values it accepts. Everything else keeps its `null` and its
+ * verdict — a `.nullable()` field whose spec assigns `null` a meaning, a
+ * required field whose `null` must still fail, a `z.never()` field that must
+ * not be provided at all.
+ */
+
+import type { z } from 'zod';
+
+/**
+ * Zod wrappers that only widen what an inner schema accepts. The shape a
+ * payload has to match lives inside them, so a walk has to look through them
+ * to find the object or array underneath. Whether a `null` survives is decided
+ * by parsing against the wrapped field, not by this list — looking through a
+ * wrapper never changes the verdict, only where the walk can reach.
+ *
+ * The generated schemas use `optional`, `nullable`, and `default`; the rest are
+ * here because these schemas are public and adopters compose them (a
+ * `.readonly()` response schema, a `.catch()` fallback, a `.nonoptional()`
+ * narrowing) before handing them back to this helper.
+ */
+const TRANSPARENT_WRAPPERS = new Set([
+  'optional',
+  'nullable',
+  'default',
+  'prefault',
+  'nonoptional',
+  'readonly',
+  'catch',
+]);
+
+/** The subset of a Zod def this walk reads, across the types it recognises. */
+interface WalkableDef {
+  type: string;
+  innerType?: z.ZodType;
+  element?: z.ZodType;
+  shape?: Record<string, z.ZodType>;
+  left?: z.ZodType;
+  right?: z.ZodType;
+}
+
+function defOf(schema: z.ZodType): WalkableDef {
+  return schema.def as unknown as WalkableDef;
+}
+
+function innermostSchema(schema: z.ZodType): z.ZodType {
+  let current = schema;
+  for (;;) {
+    const def = defOf(current);
+    if (!TRANSPARENT_WRAPPERS.has(def.type) || def.innerType === undefined) {
+      return current;
+    }
+    current = def.innerType;
+  }
+}
+
+/**
+ * Every declaration a value at this position has to satisfy, as the object
+ * shapes or array element schemas that carry it.
+ *
+ * An intersection contributes both of its sides — a JSON Schema `allOf` lands
+ * as one, and its object shape is usually on one side with conditional
+ * requirements on the other. Wrappers that aren't listed above and combinators
+ * that aren't intersections (`union`, `pipe`, `lazy`, `record`) contribute
+ * nothing and so end the walk: they name no single shape to resolve a field
+ * against, and leaving that subtree untouched only forgoes tolerance.
+ */
+function collect<K extends 'shape' | 'element'>(schema: z.ZodType, key: K, into: NonNullable<WalkableDef[K]>[]): void {
+  const def = defOf(innermostSchema(schema));
+  if (def.type === 'intersection') {
+    if (def.left) collect(def.left, key, into);
+    if (def.right) collect(def.right, key, into);
+    return;
+  }
+  const found = def[key];
+  if (found !== undefined) into.push(found);
+}
+
+function collectAll<K extends 'shape' | 'element'>(
+  schemas: readonly z.ZodType[],
+  key: K
+): NonNullable<WalkableDef[K]>[] {
+  const into: NonNullable<WalkableDef[K]>[] = [];
+  for (const schema of schemas) collect(schema, key, into);
+  return into;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Whether the schema itself says a `null` here carries no more information
+ * than omitting the field: the value may be skipped, and `null` is not one of
+ * the values the field is allowed to hold.
+ *
+ * `z.never()` is excluded. It accepts nothing, so the probe below would read
+ * its rejection of `null` as "drop the key" — which would turn a field the
+ * schema forbids into a field the payload silently passes.
+ */
+function nullMeansAbsent(field: z.ZodType): boolean {
+  if (defOf(innermostSchema(field)).type === 'never') return false;
+  return field.safeParse(undefined).success === true && field.safeParse(null).success === false;
+}
+
+/**
+ * Reinterpret nulls in `value` against every declaration it has to satisfy.
+ * A `null` is dropped only where all of them agree it means absent, so a field
+ * one side declares nullable keeps its `null` even if another side doesn't
+ * mention it as a value.
+ */
+function walk(schemas: readonly z.ZodType[], value: unknown): unknown {
+  if (Array.isArray(value)) {
+    const elements = collectAll(schemas, 'element');
+    if (elements.length === 0) return value;
+    let changed = false;
+    const mapped = value.map(entry => {
+      const next = walk(elements, entry);
+      if (next !== entry) changed = true;
+      return next;
+    });
+    return changed ? mapped : value;
+  }
+
+  if (isRecord(value)) {
+    const shapes = collectAll(schemas, 'shape');
+    if (shapes.length === 0) return value;
+    // Keys no shape declares are left alone: their value is either rejected or
+    // passed through verbatim, and neither is ours to reinterpret.
+    let result: Record<string, unknown> | null = null;
+    // Cloning by spread *defines* properties rather than assigning them, so a
+    // payload key named `__proto__` stays an ordinary key.
+    const clone = () => (result ??= { ...value });
+    for (const [key, entry] of Object.entries(value)) {
+      const fields = shapes.flatMap(shape => shape[key] ?? []);
+      if (fields.length === 0) continue;
+      if (entry === null) {
+        if (fields.every(nullMeansAbsent)) delete clone()[key];
+        continue;
+      }
+      const next = walk(fields, entry);
+      if (next !== entry) clone()[key] = next;
+    }
+    return result ?? value;
+  }
+
+  return value;
+}
+
+/**
+ * Return `payload` with every `null` dropped that the schema declares optional
+ * and non-nullable, so `schema.safeParse()` accepts it.
+ *
+ * The input is never mutated: objects and arrays containing a reinterpreted
+ * `null` are copied, and every other node is shared with the original. A
+ * caller keeping an audit trail of what the seller actually sent can hold onto
+ * the payload it passed in.
+ *
+ * ```ts
+ * import { GetMediaBuyDeliveryResponseSchema, treatOptionalNullsAsAbsent } from '@adcp/sdk/schemas';
+ *
+ * // Seller sent `next_expected_at: null` — an optional scheduling hint.
+ * const tolerated = treatOptionalNullsAsAbsent(GetMediaBuyDeliveryResponseSchema, response);
+ * const parsed = GetMediaBuyDeliveryResponseSchema.safeParse(tolerated);
+ * // parsed.success === true, and every media_buy_deliveries figure survives.
+ * // A `null` reporting_period still fails: the schema requires it.
+ * ```
+ *
+ * Subtrees reached through a `union`, `pipe`, `lazy`, or `record` are left as
+ * they are — the schema does not name a single shape to resolve the field
+ * against, and guessing one risks dropping a `null` that one arm of the union
+ * treats as a value.
+ */
+export function treatOptionalNullsAsAbsent<T>(schema: z.ZodType, payload: T): T {
+  return walk([schema], payload) as T;
+}

--- a/test/generate-zod-object-intersections.test.js
+++ b/test/generate-zod-object-intersections.test.js
@@ -42,10 +42,6 @@ function postProcessObjectIntersections(input) {
   return runPostProcess('postProcessObjectIntersections', input, '.zod-object-intersections-');
 }
 
-function postProcessForNullish(input) {
-  return runPostProcess('postProcessForNullish', input, '.zod-nullish-');
-}
-
 function postProcessRecordIntersections(input) {
   return runPostProcess('postProcessRecordIntersections', input, '.zod-record-intersections-');
 }
@@ -73,18 +69,6 @@ function postProcessRepeatedProductIntersections(input) {
 function postProcessObjectUnionIntersections(input) {
   return runPostProcess('postProcessObjectUnionIntersections', input, '.zod-object-union-');
 }
-
-test('postProcessForNullish keeps never optional constraints strict', () => {
-  const output = postProcessForNullish(`
-export const ExampleSchema = z.object({
-  forbidden: z.never().optional(),
-  allowed: z.string().optional()
-}).passthrough();
-`);
-
-  assert.match(output, /forbidden: z\.never\(\)\.optional\(\)/);
-  assert.match(output, /allowed: z\.string\(\)\.nullish\(\)/);
-});
 
 test('postProcessMarkerUnionObjectIntersections collapses opaque marker unions', () => {
   const output = postProcessMarkerUnionObjectIntersections(`

--- a/test/lib/optional-null-tolerance.test.js
+++ b/test/lib/optional-null-tolerance.test.js
@@ -1,0 +1,292 @@
+// Tests for treatOptionalNullsAsAbsent: reading an explicit `null` as an
+// omitted field wherever a generated Zod schema declares the field optional
+// and non-nullable.
+//
+// The generated schemas keep `.optional()` so they mirror the TypeScript types
+// exactly, which means they reject `null`. Agents that serialize from Pydantic,
+// Jackson, or encoding/json emit `null` for fields they have nothing to report
+// for, and Zod validates the whole payload before a caller reads any field — so
+// a `null` on an optional scheduling hint discards the spend and impression
+// figures reported alongside it.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const { z } = require('zod');
+const {
+  treatOptionalNullsAsAbsent,
+  GetMediaBuyDeliveryResponseSchema,
+  AcquireRightsResponseSchema,
+} = require('../../dist/lib/schemas/index.js');
+
+function deliveryResponse(overrides = {}) {
+  return {
+    status: 'completed',
+    reporting_period: { start: '2026-08-01T00:00:00Z', end: '2026-08-02T00:00:00Z' },
+    media_buy_deliveries: [
+      {
+        media_buy_id: 'mb_1',
+        status: 'active',
+        totals: { impressions: 1000, spend: 500 },
+        by_package: [{ package_id: 'pkg_1', impressions: 1000, spend: 500 }],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe('treatOptionalNullsAsAbsent — what the schema says about a null', () => {
+  test('drops null on an optional, non-nullable field', () => {
+    const schema = z.object({ hint: z.string().optional() });
+
+    const tolerated = treatOptionalNullsAsAbsent(schema, { hint: null });
+
+    assert.deepEqual(tolerated, {});
+    assert.equal('hint' in tolerated, false);
+    assert.equal(schema.safeParse(tolerated).success, true);
+  });
+
+  test('keeps null on an explicitly nullable field', () => {
+    const schema = z.object({ completion_rate: z.number().optional().nullable() });
+
+    const tolerated = treatOptionalNullsAsAbsent(schema, { completion_rate: null });
+
+    assert.deepEqual(tolerated, { completion_rate: null });
+    assert.equal(schema.safeParse(tolerated).success, true);
+  });
+
+  test('keeps null on a required field so validation still fails', () => {
+    const schema = z.object({ reporting_period: z.string() });
+
+    const tolerated = treatOptionalNullsAsAbsent(schema, { reporting_period: null });
+
+    assert.deepEqual(tolerated, { reporting_period: null });
+    assert.equal(schema.safeParse(tolerated).success, false);
+  });
+
+  test('keeps null on a field the schema forbids outright', () => {
+    // z.never().optional() means "must not be provided". Dropping the key would
+    // turn a payload the schema rejects into one it accepts.
+    const schema = z.object({ forbidden: z.never().optional() });
+
+    const tolerated = treatOptionalNullsAsAbsent(schema, { forbidden: null });
+
+    assert.deepEqual(tolerated, { forbidden: null });
+    assert.equal(schema.safeParse(tolerated).success, false);
+  });
+
+  test('keeps null on an optional field whose type admits null', () => {
+    const schema = z.object({ either: z.union([z.string(), z.null()]).optional() });
+
+    const tolerated = treatOptionalNullsAsAbsent(schema, { either: null });
+
+    assert.deepEqual(tolerated, { either: null });
+  });
+
+  test('passes through a key the schema does not declare', () => {
+    const schema = z.looseObject({ declared: z.string().optional() });
+
+    const tolerated = treatOptionalNullsAsAbsent(schema, { declared: null, undeclared: null });
+
+    assert.deepEqual(tolerated, { undeclared: null });
+  });
+
+  test('leaves a union-typed field alone rather than guessing an arm', () => {
+    const schema = z.object({
+      arm: z.union([z.object({ a: z.string().optional() }), z.object({ b: z.number().optional() })]).optional(),
+    });
+
+    const tolerated = treatOptionalNullsAsAbsent(schema, { arm: { a: null } });
+
+    assert.deepEqual(tolerated, { arm: { a: null } });
+  });
+});
+
+describe('treatOptionalNullsAsAbsent — traversal', () => {
+  test('recurses through nested objects', () => {
+    const schema = z.object({
+      outer: z.object({ inner: z.object({ hint: z.string().optional(), kept: z.number().optional().nullable() }) }),
+    });
+
+    const tolerated = treatOptionalNullsAsAbsent(schema, {
+      outer: { inner: { hint: null, kept: null } },
+    });
+
+    assert.deepEqual(tolerated, { outer: { inner: { kept: null } } });
+    assert.equal(schema.safeParse(tolerated).success, true);
+  });
+
+  test('recurses through array entries', () => {
+    const schema = z.object({ rows: z.array(z.object({ hint: z.string().optional(), id: z.string() })) });
+
+    const tolerated = treatOptionalNullsAsAbsent(schema, {
+      rows: [
+        { id: 'a', hint: null },
+        { id: 'b', hint: 'kept' },
+      ],
+    });
+
+    assert.deepEqual(tolerated, { rows: [{ id: 'a' }, { id: 'b', hint: 'kept' }] });
+    assert.equal(schema.safeParse(tolerated).success, true);
+  });
+
+  test('resolves a merged shape against the merged field set', () => {
+    // by_package entries are DeliveryMetricsSchema.merge(package fields): a
+    // nullable field from the base and an optional field from the overlay have
+    // to resolve differently within the same object.
+    const base = z.object({ completion_rate: z.number().optional().nullable() });
+    const schema = base.merge(z.object({ package_id: z.string(), rate: z.number().optional() }));
+
+    const tolerated = treatOptionalNullsAsAbsent(schema, {
+      package_id: 'pkg_1',
+      completion_rate: null,
+      rate: null,
+    });
+
+    assert.deepEqual(tolerated, { package_id: 'pkg_1', completion_rate: null });
+    assert.equal(schema.safeParse(tolerated).success, true);
+  });
+
+  test('resolves an intersection against both of its sides', () => {
+    // JSON Schema `allOf` lands as a Zod intersection: the object shape on one
+    // side, conditional requirements on the other.
+    const schema = z
+      .object({ hint: z.string().optional(), id: z.string() })
+      .and(z.looseObject({ note: z.string().optional() }));
+
+    const tolerated = treatOptionalNullsAsAbsent(schema, { id: 'a', hint: null, note: null });
+
+    assert.deepEqual(tolerated, { id: 'a' });
+    assert.equal(schema.safeParse(tolerated).success, true);
+  });
+
+  test('keeps a null the sides of an intersection disagree about', () => {
+    const schema = z
+      .object({ rate: z.number().optional() })
+      .and(z.looseObject({ rate: z.number().optional().nullable() }));
+
+    const tolerated = treatOptionalNullsAsAbsent(schema, { rate: null });
+
+    assert.deepEqual(tolerated, { rate: null });
+  });
+
+  test('drops a null on a defaulted field so the default applies', () => {
+    const schema = z.object({ max_results: z.number().default(50) });
+
+    const tolerated = treatOptionalNullsAsAbsent(schema, { max_results: null });
+
+    assert.deepEqual(tolerated, {});
+    assert.equal(schema.parse(tolerated).max_results, 50);
+  });
+
+  test('keeps a null on a field whose catch swallows it', () => {
+    // `.catch()` accepts null and substitutes its fallback, so null is a value
+    // the field holds — not an absence.
+    const schema = z.object({ hint: z.string().catch('fallback') });
+
+    const tolerated = treatOptionalNullsAsAbsent(schema, { hint: null });
+
+    assert.deepEqual(tolerated, { hint: null });
+    assert.equal(schema.parse(tolerated).hint, 'fallback');
+  });
+
+  test('keeps a null on an optional field narrowed back to required', () => {
+    const schema = z.object({ hint: z.string().optional().nonoptional() });
+
+    const tolerated = treatOptionalNullsAsAbsent(schema, { hint: null });
+
+    assert.deepEqual(tolerated, { hint: null });
+    assert.equal(schema.safeParse(tolerated).success, false);
+  });
+
+  test('reaches an object shape through prefault, default and readonly wrappers', () => {
+    const inner = z.object({ hint: z.string().optional(), keep: z.number().optional().nullable() });
+    const wrapped = {
+      prefaulted: inner.prefault({}),
+      defaulted: inner.default({}),
+      frozen: inner.readonly(),
+    };
+
+    for (const [label, field] of Object.entries(wrapped)) {
+      const schema = z.object({ [label]: field });
+
+      const tolerated = treatOptionalNullsAsAbsent(schema, { [label]: { hint: null, keep: null } });
+
+      assert.deepEqual(tolerated, { [label]: { keep: null } }, label);
+    }
+  });
+
+  test('leaves nulls inside a record alone', () => {
+    // A record names no per-key declaration to resolve a null against.
+    const schema = z.object({ ext: z.record(z.string(), z.object({ hint: z.string().optional() })) });
+    const payload = { ext: { vendor: { hint: null } } };
+
+    assert.equal(treatOptionalNullsAsAbsent(schema, payload), payload);
+  });
+
+  test('does not mutate the input payload', () => {
+    const schema = z.object({ rows: z.array(z.object({ hint: z.string().optional(), id: z.string() })) });
+    const payload = { rows: [{ id: 'a', hint: null }] };
+
+    treatOptionalNullsAsAbsent(schema, payload);
+
+    assert.deepEqual(payload, { rows: [{ id: 'a', hint: null }] });
+  });
+
+  test('returns the original nodes when there is nothing to reinterpret', () => {
+    const schema = z.object({ rows: z.array(z.object({ id: z.string() })) });
+    const payload = { rows: [{ id: 'a' }] };
+
+    assert.equal(treatOptionalNullsAsAbsent(schema, payload), payload);
+  });
+});
+
+describe('treatOptionalNullsAsAbsent — get_media_buy_delivery', () => {
+  test('a null next_expected_at no longer discards the reported figures', () => {
+    const response = deliveryResponse({ next_expected_at: null });
+
+    assert.equal(GetMediaBuyDeliveryResponseSchema.safeParse(response).success, false);
+
+    const tolerated = treatOptionalNullsAsAbsent(GetMediaBuyDeliveryResponseSchema, response);
+    const parsed = GetMediaBuyDeliveryResponseSchema.safeParse(tolerated);
+
+    assert.equal(parsed.success, true, JSON.stringify(parsed.error?.issues));
+    assert.equal(parsed.data.media_buy_deliveries.length, 1);
+    assert.equal(parsed.data.media_buy_deliveries[0].totals.spend, 500);
+    assert.equal(parsed.data.media_buy_deliveries[0].totals.impressions, 1000);
+    assert.equal(parsed.data.media_buy_deliveries[0].by_package[0].spend, 500);
+    assert.equal('next_expected_at' in tolerated, false);
+  });
+
+  test('a null completion_rate inside by_package survives as a value', () => {
+    const response = deliveryResponse();
+    response.media_buy_deliveries[0].by_package[0].completion_rate = null;
+
+    const tolerated = treatOptionalNullsAsAbsent(GetMediaBuyDeliveryResponseSchema, response);
+    const parsed = GetMediaBuyDeliveryResponseSchema.safeParse(tolerated);
+
+    assert.equal(parsed.success, true, JSON.stringify(parsed.error?.issues));
+    assert.equal(parsed.data.media_buy_deliveries[0].by_package[0].completion_rate, null);
+  });
+
+  test('a null reporting_period still fails validation', () => {
+    const response = deliveryResponse({ reporting_period: null });
+
+    const tolerated = treatOptionalNullsAsAbsent(GetMediaBuyDeliveryResponseSchema, response);
+
+    assert.equal(tolerated.reporting_period, null);
+    assert.equal(GetMediaBuyDeliveryResponseSchema.safeParse(tolerated).success, false);
+  });
+
+  test('reaches the fields of a generated schema rooted in an intersection', () => {
+    // Response schemas projected from a JSON Schema `allOf` are intersections
+    // at their root; the envelope fields sit on one side of it.
+    assert.equal(AcquireRightsResponseSchema.def.type, 'intersection');
+
+    const tolerated = treatOptionalNullsAsAbsent(AcquireRightsResponseSchema, {
+      context_id: null,
+      status: 'completed',
+    });
+
+    assert.deepEqual(tolerated, { status: 'completed' });
+  });
+});


### PR DESCRIPTION
## Problem

Generated Zod schemas keep `.optional()` so they mirror the AdCP TypeScript types exactly. `.optional()` accepts `undefined` and rejects `null`. Plenty of agents serialize from Pydantic, Jackson, or `encoding/json` and emit `null` for a field they have nothing to report for — and because Zod validates a whole payload before a caller reads any field, one such `null` discards everything reported alongside it.

This is not hypothetical. A seller sent `next_expected_at: null` in a `get_media_buy_delivery` response — a scheduling hint carrying no spend, no impressions, nothing an accounting pipeline consumes. `GetMediaBuyDeliveryResponseSchema` rejected the response and took every `media_buy_deliveries` leg's figures with it. Four distinct reporting days for two customers, never recovered, because retries fail identically.

The generator already records the deliberate decision to keep `.optional()`, and tells callers what to do instead:

> we intentionally keep `.optional()` (NOT `.nullish()`) so Zod schemas match TypeScript types. Callers that need to accept null from external APIs should use `.nullish()` at the call site, not globally in every schema.

That decision is right — but it had no mechanism. A consumer cannot `.nullish()` one field inside a `.pick()` of an 8755-field generated schema graph without patching generated code, which then has to be redone on every SDK bump. So every TypeScript consumer either patches the generated file or writes its own normalizer.

## What this adds

`treatOptionalNullsAsAbsent(schema, payload)`, exported from `@adcp/sdk/schemas`. It drops a `null` only where the schema itself says it carries no more information than omitting the field: the value may be skipped, and `null` is not among the values it accepts.

| Schema declares | Payload sends | Result |
| --- | --- | --- |
| `.optional()` | `null` | key dropped; parse succeeds |
| `.optional().nullable()` | `null` | `null` kept — the spec assigns it meaning (`completion_rate: null` = "not applicable to these buys") |
| required | `null` | `null` kept; parse still fails |
| `z.never().optional()` | `null` | `null` kept; parse still fails (field must not be provided) |
| not declared (`passthrough`) | `null` | passed through untouched |

The type-fidelity decision is preserved: schemas keep `.optional()`, inferred types stay exact, and nothing becomes globally lenient. Tolerance is opt-in per call.

The walk recurses through nested objects and arrays, so a `null` inside `media_buy_deliveries[].by_package[]` resolves against that entry's own declaration. It also consults **both sides of an intersection** — response schemas projected from a JSON Schema `allOf` are intersections at their root, and a `null` is dropped only where every declaring side agrees it means absent. That covers 80 of the 87 generated `*ResponseSchema` roots (48 object-rooted, 32 intersection-rooted); the 7 union-rooted ones are left untouched, since a union names no single shape to resolve a field against.

The input is never mutated. Nodes containing a reinterpreted `null` are copied; every other node is shared with the original, so a caller keeping an audit trail of what the agent actually sent can hold onto the payload it passed in.

This is the Zod-surface counterpart to the null tolerance #1158 added for v2.x envelope fields before Ajv (#1149). Same class of bug, different surface: that one is Ajv, top-level envelope keys only, gated to v2.x.

## Also: removes a dead transform

`postProcessForNullish` was defined, documented with a rationale arguing *for* global `.nullish()`, and unit-tested — but never called in the generation pipeline. Its only other reference was the test-only `__test__` export block. A transform in that state reads as live behavior to anyone auditing the generator; it misled us until we checked the call sites. Deleted, along with its test. The comment recording why optional fields stay `.optional()` now points at `treatOptionalNullsAsAbsent` as the mechanism it tells callers to use.

## Tests

`test/lib/optional-null-tolerance.test.js`, 23 cases:

- `null` on optional-only → dropped; on `.optional().nullable()` → kept; on required → kept and still fails `safeParse`; on `z.never().optional()` → kept and still fails.
- `.default()` → dropped, and the default then applies. `.catch()` → kept (catch accepts `null`, so it is a value, not an absence). `.nonoptional()` → kept.
- Traversal reaches an object shape through `prefault` / `default` / `readonly` wrappers.
- Nested objects and array entries get the same treatment.
- A `.merge()`-built shape resolves against the merged field set, so a `null` `completion_rate` in a `by_package` entry survives.
- Intersections: dropped when both sides agree, kept when they disagree.
- `z.record()` stop-case returns the payload by identity (120 `z.record(` uses in the generated schemas).
- Undeclared keys pass through; a union-typed field is left alone; the input is not mutated; untouched nodes are returned by identity.
- End-to-end on `GetMediaBuyDeliveryResponseSchema`: `next_expected_at: null` parses and retains every leg's figures; `completion_rate: null` inside `by_package` survives as a value; `reporting_period: null` still fails. Plus one case proving the walk reaches the fields of an intersection-rooted generated schema.

Verification run locally:

- `node --test test/lib/optional-null-tolerance.test.js` → 23/23 pass
- `node --test test/lib/zod-schemas.test.js test/lib/v2-5-envelope-null-stripping.test.js` → 83/83 pass
- `node --test test/generate-zod-object-intersections.test.js` → 18/18 pass after the deletion
- `tsc --project tsconfig.lib.json --noEmit` → clean; `prettier --check` → clean

## Not in scope

Making `next_expected_at` nullable in the AdCP spec. The spec already uses `"type": ["number", "null"]` where `null` carries meaning (`completion_rate`), so plain-optional means "omit when not reported". Adding `"null"` there would introduce a second way to say "absent" and would not fix the class — the next agent nulls a different field. That is a separate docs-only conformance note for `adcontextprotocol/adcp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
