### PR TITLE
fix(server): configure structured-content text fallback

### DIFF
--- a/.changeset/fair-hosts-listen.md
+++ b/.changeset/fair-hosts-listen.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Make the structured-content text fallback a marked, per-client transport-edge decoration while keeping canonical cached responses and A2A artifacts clean.

--- a/.changeset/fair-hosts-listen.md
+++ b/.changeset/fair-hosts-listen.md
@@ -1,5 +1,5 @@
 ---
-'@adcp/sdk': patch
+'@adcp/sdk': minor
 ---
 
 Make the structured-content text fallback a marked, per-client transport-edge decoration while keeping canonical cached responses and A2A artifacts clean.

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1293,6 +1293,7 @@ export {
   createA2AAdapter,
   A2AInvocationError,
   MCP_APP_RESOURCE_MIME_TYPE,
+  ADCP_MIRRORED_STRUCTURED_CONTENT_META_KEY,
 } from './server';
 export type {
   AdcpErrorOptions,
@@ -1352,6 +1353,10 @@ export type {
   AdcpTestRequest,
   AdcpTestToolsCallRequest,
   AdcpTestResponse,
+  AdcpInvokeOptions,
+  StructuredContentFallbackTransport,
+  StructuredContentTextFallback,
+  StructuredContentTextFallbackContext,
   CheckGovernanceOptions,
   GovernanceCallResult,
   GovernanceApproved,

--- a/src/lib/server/a2a-adapter.ts
+++ b/src/lib/server/a2a-adapter.ts
@@ -510,6 +510,7 @@ class AdcpA2AAgentExecutor implements AgentExecutor {
               toolName,
               args: invocation.input,
               ...(authInfo && { authInfo }),
+              responseContext: { transport: 'a2a' },
             });
             break;
           } catch (err) {

--- a/src/lib/server/adcp-server.ts
+++ b/src/lib/server/adcp-server.ts
@@ -32,6 +32,11 @@ import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import type { McpToolResponse } from './responses';
 import type { AdcpMcpResourceDefinition } from './mcp-app';
 import { ADCP_VERSION } from '../version';
+import {
+  applyStructuredContentTextFallback,
+  type StructuredContentTextFallback,
+  type StructuredContentTextFallbackContext,
+} from './structured-content-fallback';
 
 /**
  * Structural shape of an MCP transport the server can connect to.
@@ -114,6 +119,8 @@ export interface AdcpTestRequestExtras {
   authInfo?: AdcpAuthInfo;
   sessionId?: string;
   signal?: AbortSignal;
+  /** Override client/transport facts used by response-decoration tests. */
+  responseContext?: StructuredContentTextFallbackContext;
 }
 
 /**
@@ -144,6 +151,12 @@ export interface AdcpInvokeOptions {
    * so failures retain the structured AdCP error envelope.
    */
   enforceRequestSchema?: true;
+  /**
+   * Transport/session facts used only after the canonical response has been
+   * finalized and cached. Omit for direct embedding; the fail-safe direct path
+   * mirrors structured content for compatibility.
+   */
+  responseContext?: StructuredContentTextFallbackContext;
 }
 
 /**
@@ -709,10 +722,12 @@ export function wrapSdkRequestHandler(
 export function wrapMcpServer(
   inner: McpServer | AdcpServerInternal,
   compliance?: AdcpServerComplianceApi,
-  adcpVersion: string = ADCP_VERSION
+  adcpVersion: string = ADCP_VERSION,
+  options: { structuredContentTextFallback?: StructuredContentTextFallback } = {}
 ): AdcpServerInternal {
   if (isAdcpServer(inner)) return inner;
   const mcp = inner as McpServer;
+  const structuredContentTextFallback = options.structuredContentTextFallback ?? 'always';
   const resolvedCompliance: AdcpServerComplianceApi = compliance ?? {
     async reset() {
       throw new Error(
@@ -737,7 +752,12 @@ export function wrapMcpServer(
       if (!tool) {
         throw new Error(`dispatchTestRequest: tool "${params.name}" is not registered`);
       }
-      return tool.handler(params.arguments ?? {}, extra);
+      const result = await tool.handler(params.arguments ?? {}, extra);
+      return applyStructuredContentTextFallback(
+        result,
+        structuredContentTextFallback,
+        extras?.responseContext ?? { transport: 'mcp' }
+      );
     }
 
     const handler = getRequestHandler(mcp, request.method);
@@ -756,7 +776,12 @@ export function wrapMcpServer(
     };
     if (options.authInfo) extra.authInfo = options.authInfo;
     if (options.enforceRequestSchema === true) extra.enforceRequestSchema = true;
-    return (await tool.handler(options.args, extra)) as McpToolResponse;
+    const response = (await tool.handler(options.args, extra)) as McpToolResponse;
+    return applyStructuredContentTextFallback(
+      response,
+      structuredContentTextFallback,
+      options.responseContext ?? { transport: 'direct' }
+    );
   };
   const wrapper: AdcpServerInternal = {
     [ADCP_SDK_SERVER]: mcp,

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -67,6 +67,7 @@ import type { ToolCallback } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { ZodRawShapeCompat, AnySchema } from '@modelcontextprotocol/sdk/server/zod-compat.js';
 import type { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
+import { applyStructuredContentTextFallback, type StructuredContentTextFallback } from './structured-content-fallback';
 import {
   ADCP_CAPABILITIES,
   ADCP_STATE_STORE,
@@ -1954,6 +1955,22 @@ export interface AdcpServerConfig<TAccount = unknown> {
    * responses registered by `createAdcpServer`.
    */
   responseEnhancer?: (response: McpToolResponse) => void;
+  /**
+   * Mirror final MCP `structuredContent` into a marked compact-JSON text block
+   * for hosts that do not expose the structured channel to the model.
+   *
+   * Defaults to `always`, matching MCP's backwards-compatibility guidance.
+   * `never` is a deployment-owned opt-out. `auto` currently behaves like
+   * `always` until MCP defines a client capability for structured-result
+   * consumption. A predicate receives one extensible bag with the negotiated
+   * client facts and transport; missing client facts are legitimate and the
+   * named/default modes fail safe to mirroring. A2A named/default modes do not
+   * mirror because its Task artifact already carries the typed DataPart.
+   *
+   * Decoration happens after response finalization and idempotency caching, so
+   * a replay can be shaped independently for each client session.
+   */
+  structuredContentTextFallback?: StructuredContentTextFallback;
   /**
    * Auto-wire the RFC 9421 request-signature verifier onto the HTTP transport.
    * When set together with `capabilities.specialisms` containing
@@ -4609,6 +4626,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
     credentialPolicy,
     testController: testControllerBridge,
     responseEnhancer,
+    structuredContentTextFallback = 'always',
   } = config;
   if (taskRegistry !== undefined && taskRegistry.scopeVersion !== 1) {
     throw new Error(
@@ -4618,6 +4636,14 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
   if (!['auto', 'media-buy', 'all'].includes(mcpToolProfile)) {
     throw new Error(
       `createAdcpServer: mcpToolProfile must be "auto", "media-buy", or "all"; got ${JSON.stringify(mcpToolProfile)}`
+    );
+  }
+  if (
+    typeof structuredContentTextFallback !== 'function' &&
+    !['always', 'never', 'auto'].includes(structuredContentTextFallback)
+  ) {
+    throw new Error(
+      'createAdcpServer: structuredContentTextFallback must be "always", "never", "auto", or a predicate'
     );
   }
   const notificationHandlerConfigured = typeof config.protocol?.syncAgentNotificationConfigs === 'function';
@@ -5201,18 +5227,6 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
 
   const applyResponseEnhancer = (response: McpToolResponse): McpToolResponse => {
     responseEnhancer?.(response);
-    const structuredContent = response.structuredContent;
-    if (structuredContent !== undefined) {
-      const serialized = JSON.stringify(structuredContent);
-      const hasSerializedFallback = response.content.some(block => block.type === 'text' && block.text === serialized);
-      if (!hasSerializedFallback) {
-        // MCP recommends mirroring structuredContent into a TextContent block
-        // for clients that do not expose the structured channel to the model.
-        // Preserve any adopter-authored summary as the first block and append
-        // the exact final wire object after every framework/enhancer rewrite.
-        response.content.push({ type: 'text', text: serialized });
-      }
-    }
     return response;
   };
 
@@ -8405,6 +8419,33 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
     );
   }
 
+  // Keep the canonical handler result (and idempotency cache entry) free of
+  // client-specific compatibility decoration. The low-level tools/call seam is
+  // after the registered handler has finalized/cached its response and is the
+  // first point where the legacy MCP SDK exposes negotiated clientInfo.
+  const wrappedToolsCallForStructuredFallback = wrapSdkRequestHandler(
+    server,
+    'tools/call',
+    async (original, request, extra) => {
+      const response = await original(request, extra);
+      const clientInfo = server.server.getClientVersion();
+      const clientCapabilities = server.server.getClientCapabilities();
+      return applyStructuredContentTextFallback(response, structuredContentTextFallback, {
+        transport: 'mcp',
+        ...(clientInfo !== undefined && { clientInfo }),
+        ...(clientCapabilities !== undefined && {
+          clientCapabilities: clientCapabilities as Readonly<Record<string, unknown>>,
+        }),
+      });
+    }
+  );
+  if (!wrappedToolsCallForStructuredFallback) {
+    throw new Error(
+      'createAdcpServer: failed to install MCP structured-content fallback decoration; ' +
+        'the MCP SDK request-handler internals may have changed'
+    );
+  }
+
   // Validate `credentialPolicy.tools` keys against the FULL registered
   // tool set, including `get_adcp_capabilities` (registered just above).
   // Earlier placement (before this tool was added) made
@@ -8469,7 +8510,9 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
       if (taskRegistry?.clear) await taskRegistry.clear();
     },
   };
-  const wrapped: AdcpServerInternal = wrapMcpServer(server, compliance, adcpVersion);
+  const wrapped: AdcpServerInternal = wrapMcpServer(server, compliance, adcpVersion, {
+    structuredContentTextFallback,
+  });
   setToolVersionAvailabilityResolver(wrapped, toolAvailableForRelease);
   setDiscoveryVersionResolver(wrapped, requestedVersion => {
     if (requestedVersion === undefined) return adcpVersion;

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -1966,6 +1966,10 @@ export interface AdcpServerConfig<TAccount = unknown> {
    * client facts and transport; missing client facts are legitimate and the
    * named/default modes fail safe to mirroring. A2A named/default modes do not
    * mirror because its Task artifact already carries the typed DataPart.
+   * The default legacy `serve()` route is stateless across HTTP requests, so
+   * it cannot safely correlate `initialize` client facts with a later
+   * `tools/call`; predicates therefore take the unknown-client fail-safe path
+   * there. Modern MCP requests and stateful transports expose client facts.
    *
    * Decoration happens after response finalization and idempotency caching, so
    * a replay can be shaped independently for each client session.

--- a/src/lib/server/index.ts
+++ b/src/lib/server/index.ts
@@ -162,6 +162,13 @@ export {
 } from './responses';
 export type { McpToolResponse } from './responses';
 
+export { ADCP_MIRRORED_STRUCTURED_CONTENT_META_KEY } from './structured-content-fallback';
+export type {
+  StructuredContentFallbackTransport,
+  StructuredContentTextFallback,
+  StructuredContentTextFallbackContext,
+} from './structured-content-fallback';
+
 export { validActionsForStatus } from './media-buy-helpers';
 export type { ValidAction, CancelMediaBuyInput } from './media-buy-helpers';
 export { assertUpdateMediaBuyAllowed } from './media-buy-actions';
@@ -357,6 +364,7 @@ export type {
   AdcpTestRequest,
   AdcpTestToolsCallRequest,
   AdcpTestResponse,
+  AdcpInvokeOptions,
 } from './adcp-server';
 // Handler-bag types describe the raw v5 server surface. Primary-barrel names
 // are explicit Legacy aliases; the legacy/v5 subpath retains the originals.

--- a/src/lib/server/mcp-modern-server.ts
+++ b/src/lib/server/mcp-modern-server.ts
@@ -18,6 +18,8 @@ import {
   type ServerContext,
   type Tool as ModernTool,
   type ToolAnnotations,
+  CLIENT_CAPABILITIES_META_KEY,
+  CLIENT_INFO_META_KEY,
 } from '@modelcontextprotocol/server';
 import { toNodeHandler, toWebRequest, type NodeMcpRequestHandler } from '@modelcontextprotocol/node';
 import type { IncomingMessage } from 'http';
@@ -39,6 +41,7 @@ import { ADCP_INSTRUCTIONS_RESOLVER, MEDIA_BUY_MCP_TOOL_PROFILE } from './create
 import { mcpAppResourceMetadata, readMcpAppResource } from './mcp-app';
 import { getMcpToolSchema, getMcpToolSummary, getToolSchemaDocument } from '../validation/schema-loader';
 import { isAdcpVersionAtLeast } from '../utils/adcp-version-config';
+import type { StructuredContentTextFallbackContext } from './structured-content-fallback';
 
 export interface ModernMcpServerAdapter {
   handle: NodeMcpRequestHandler;
@@ -54,6 +57,26 @@ function toAdcpAuthInfo(authInfo: ModernAuthInfo | undefined): AdcpAuthInfo | un
     scopes: authInfo.scopes,
     ...(authInfo.expiresAt !== undefined && { expiresAt: authInfo.expiresAt }),
     ...(authInfo.extra !== undefined && { extra: authInfo.extra }),
+  };
+}
+
+function structuredContentFallbackContext(ctx: ServerContext): StructuredContentTextFallbackContext {
+  const envelope = ctx.mcpReq.envelope as unknown as Record<string, unknown> | undefined;
+  const clientInfo = envelope?.[CLIENT_INFO_META_KEY];
+  const clientCapabilities = envelope?.[CLIENT_CAPABILITIES_META_KEY];
+  return {
+    transport: 'mcp',
+    ...(clientInfo != null &&
+      typeof clientInfo === 'object' &&
+      typeof (clientInfo as { name?: unknown }).name === 'string' &&
+      typeof (clientInfo as { version?: unknown }).version === 'string' && {
+        clientInfo: clientInfo as StructuredContentTextFallbackContext['clientInfo'],
+      }),
+    ...(clientCapabilities != null &&
+      typeof clientCapabilities === 'object' &&
+      !Array.isArray(clientCapabilities) && {
+        clientCapabilities: clientCapabilities as Record<string, unknown>,
+      }),
   };
 }
 
@@ -217,6 +240,7 @@ export function createModernMcpServerAdapter(agentServer: AdcpServer): ModernMcp
             args,
             authInfo: toAdcpAuthInfo(ctx.http?.authInfo),
             signal: ctx.mcpReq.signal,
+            responseContext: structuredContentFallbackContext(ctx),
             // Only strengthen calls for tools whose exact official schema we
             // advertise. Hidden compatibility tools remain directly callable
             // and retain the adopter's configured validation mode.

--- a/src/lib/server/responses.ts
+++ b/src/lib/server/responses.ts
@@ -99,7 +99,12 @@ import type {
  */
 export interface McpToolResponse {
   [key: string]: unknown;
-  content: Array<{ type: 'text'; text: string }>;
+  content: Array<{
+    type: 'text';
+    text: string;
+    /** Optional MCP content-block metadata. */
+    _meta?: Record<string, unknown>;
+  }>;
   structuredContent?: Record<string, unknown>;
 }
 

--- a/src/lib/server/structured-content-fallback.ts
+++ b/src/lib/server/structured-content-fallback.ts
@@ -1,0 +1,99 @@
+import type { McpToolResponse } from './responses';
+
+/** Marker placed on SDK-generated structured-content compatibility blocks. */
+export const ADCP_MIRRORED_STRUCTURED_CONTENT_META_KEY = 'adcp/mirrored-structured-content';
+
+/** Transport applying the final response decoration. */
+export type StructuredContentFallbackTransport = 'mcp' | 'a2a' | 'direct';
+
+/**
+ * Client/session information available when deciding whether to mirror an MCP
+ * structured result into text.
+ *
+ * The objects deliberately remain structurally loose. MCP can add capability
+ * and implementation fields without requiring an AdCP SDK release first.
+ */
+export interface StructuredContentTextFallbackContext {
+  transport: StructuredContentFallbackTransport;
+  clientInfo?: Readonly<{ name: string; version: string; [key: string]: unknown }>;
+  clientCapabilities?: Readonly<Record<string, unknown>>;
+}
+
+/**
+ * Controls the MCP structured-content text fallback.
+ *
+ * `auto` currently degrades to `always`: MCP has no standardized client
+ * capability declaring that structured tool results reach the model. It is a
+ * named migration point for capability negotiation once MCP adds one. A
+ * predicate is consulted only when client identity is known (or for A2A,
+ * where transport alone is meaningful); unknown MCP/direct clients mirror as
+ * a fail-safe.
+ */
+export type StructuredContentTextFallback =
+  | 'always'
+  | 'never'
+  | 'auto'
+  | ((context: StructuredContentTextFallbackContext) => boolean);
+
+function shouldMirrorStructuredContent(
+  policy: StructuredContentTextFallback,
+  context: StructuredContentTextFallbackContext
+): boolean {
+  if (typeof policy === 'function') {
+    // A missing MCP/direct client identity is a legitimate embedding path, not
+    // evidence that the caller consumes structured results. Keep it legible.
+    // A2A is the exception: transport is sufficient context for a predicate to
+    // suppress its redundant internal mirror.
+    if (context.transport !== 'a2a' && context.clientInfo === undefined) return true;
+    try {
+      const decision = policy(context);
+      return typeof decision === 'boolean' ? decision : context.transport !== 'a2a';
+    } catch {
+      // A compatibility hint must not make the canonical result illegible.
+      return context.transport !== 'a2a';
+    }
+  }
+  if (policy === 'never') return false;
+  // A2A artifacts carry the typed result in a DataPart. The MCP text fallback
+  // has no wire role there, so named/default policies keep A2A responses clean.
+  if (context.transport === 'a2a') return false;
+  // `auto` intentionally shares today's fail-safe `always` behavior until a
+  // standardized structured-content consumption capability exists.
+  return true;
+}
+
+/**
+ * Decorate a canonical tool response at the transport edge.
+ *
+ * Returns a shallow copy when it appends the fallback so framework/idempotency
+ * cache objects are never mutated. Existing exact compact-JSON text blocks are
+ * retained as-is; structural/pretty-print deduplication would require parsing
+ * adopter-authored prose and is intentionally out of scope.
+ */
+export function applyStructuredContentTextFallback<T>(
+  value: T,
+  policy: StructuredContentTextFallback,
+  context: StructuredContentTextFallbackContext
+): T {
+  if (!shouldMirrorStructuredContent(policy, context)) return value;
+  if (value == null || typeof value !== 'object') return value;
+
+  const response = value as Partial<McpToolResponse>;
+  if (response.structuredContent === undefined || !Array.isArray(response.content)) return value;
+
+  const serialized = JSON.stringify(response.structuredContent);
+  if (serialized === undefined) return value;
+  if (response.content.some(block => block.type === 'text' && block.text === serialized)) return value;
+
+  return {
+    ...(value as object),
+    content: [
+      ...response.content,
+      {
+        type: 'text',
+        text: serialized,
+        _meta: { [ADCP_MIRRORED_STRUCTURED_CONTENT_META_KEY]: true },
+      },
+    ],
+  } as T;
+}

--- a/src/lib/server/structured-content-fallback.ts
+++ b/src/lib/server/structured-content-fallback.ts
@@ -15,6 +15,10 @@ export type StructuredContentFallbackTransport = 'mcp' | 'a2a' | 'direct';
  */
 export interface StructuredContentTextFallbackContext {
   transport: StructuredContentFallbackTransport;
+  /**
+   * Negotiated implementation identity when the transport safely retains it.
+   * Absent for direct embedding and stateless legacy HTTP serving.
+   */
   clientInfo?: Readonly<{ name: string; version: string; [key: string]: unknown }>;
   clientCapabilities?: Readonly<Record<string, unknown>>;
 }

--- a/test/lib/mcp-modern-negotiation.test.js
+++ b/test/lib/mcp-modern-negotiation.test.js
@@ -483,14 +483,20 @@ test('serve exposes AdCP tools to a client pinned to MCP 2026-07-28', async t =>
   const { serve, InMemoryStateStore } = require('../../dist/lib/index.js');
   const { createAdcpServer } = require('../../dist/lib/server/legacy/v5/index.js');
   const { Client, StreamableHTTPClientTransport } = require('@modelcontextprotocol/client');
+  const fallbackContexts = [];
 
   const httpServer = serve(
     () =>
       createAdcpServer({
         name: 'modern-adcp-test',
         version: '1.0.0',
+        adcpVersion: '3.1.18',
         stateStore: new InMemoryStateStore(),
         instructions: async () => 'Use AdCP tools with explicit account context.',
+        structuredContentTextFallback: context => {
+          fallbackContexts.push(context);
+          return context.clientInfo?.name !== 'pinned-modern-test';
+        },
       }),
     { port: 0, onListening: () => {} }
   );
@@ -529,6 +535,15 @@ test('serve exposes AdCP tools to a client pinned to MCP 2026-07-28', async t =>
   const result = await client.callTool({ name: 'get_adcp_capabilities', arguments: {} });
   assert.equal(result.isError, undefined);
   assert.ok(result.structuredContent, 'AdCP response should retain structured content on the modern route');
+  assert.equal(
+    result.content.some(block => block._meta?.['adcp/mirrored-structured-content'] === true),
+    false,
+    'modern client predicate should suppress the compatibility text block'
+  );
+  assert.equal(fallbackContexts.at(-1).transport, 'mcp');
+  assert.equal(fallbackContexts.at(-1).clientInfo.name, 'pinned-modern-test');
+  assert.equal(fallbackContexts.at(-1).clientInfo.version, '1.0.0');
+  assert.ok(fallbackContexts.at(-1).clientCapabilities);
 
   const endpoint = `http://127.0.0.1:${address.port}/mcp`;
   const malformed = await fetch(endpoint, {

--- a/test/server-create-adcp-server.test.js
+++ b/test/server-create-adcp-server.test.js
@@ -11,6 +11,9 @@ const { InMemoryTaskStore } = require('../dist/lib/server/tasks');
 const { createInMemoryTaskRegistry } = require('../dist/lib/server/decisioning/runtime/task-registry');
 const { adcpError } = require('../dist/lib/server/errors');
 const { createIdempotencyStore, memoryBackend } = require('../dist/lib/server/idempotency');
+const { ADCP_MIRRORED_STRUCTURED_CONTENT_META_KEY } = require('../dist/lib/server/structured-content-fallback');
+const { Client } = require('@modelcontextprotocol/sdk/client/index.js');
+const { InMemoryTransport } = require('@modelcontextprotocol/sdk/inMemory.js');
 
 // These tests exercise envelope wrapping, state-store propagation, and
 // idempotency middleware using deliberately sparse handler fixtures
@@ -63,6 +66,12 @@ function registeredTool(server, toolName) {
   const sdk = getSdkServer(server);
   if (!sdk) throw new Error('registeredTool: value is not an AdcpServer');
   return sdk._registeredTools[toolName];
+}
+
+function mirroredBlocks(result) {
+  return result.content.filter(
+    block => block.type === 'text' && block._meta?.[ADCP_MIRRORED_STRUCTURED_CONTENT_META_KEY] === true
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -197,6 +206,18 @@ describe('createAdcpServer', () => {
           mediaBuy: { getProducts: async () => ({ products: [] }) },
         }),
       /get_products range.*does not overlap.*3\.1\.18/
+    );
+  });
+
+  it('rejects an invalid structured-content fallback policy at construction', () => {
+    assert.throws(
+      () =>
+        createAdcpServer({
+          name: 'Bad fallback',
+          version: '1.0.0',
+          structuredContentTextFallback: 'sometimes',
+        }),
+      /structuredContentTextFallback must be/
     );
   });
 
@@ -397,10 +418,9 @@ describe('createAdcpServer', () => {
     assert.deepStrictEqual(sawParams, { brief: 'premium' });
     assert.ok(result.content, 'CallToolResult should carry content');
     assert.ok(result.structuredContent, 'CallToolResult should carry structuredContent');
-    assert.ok(
-      result.content.some(block => block.type === 'text' && block.text === JSON.stringify(result.structuredContent)),
-      'CallToolResult should serialize structuredContent for text-only MCP clients'
-    );
+    assert.strictEqual(result.content[0].text, 'Found 0 products');
+    assert.strictEqual(mirroredBlocks(result).length, 1);
+    assert.strictEqual(mirroredBlocks(result)[0].text, JSON.stringify(result.structuredContent));
   });
 
   it('preserves the human summary and appends one final structured-content fallback', async () => {
@@ -429,8 +449,128 @@ describe('createAdcpServer', () => {
 
     assert.strictEqual(result.content[0].text, 'Found 1 products');
     assert.strictEqual(result.content.filter(block => block.text === serialized).length, 1);
+    assert.strictEqual(mirroredBlocks(result).length, 1);
     assert.strictEqual(JSON.parse(result.content.at(-1).text).products[0].name, 'CTV package');
     assert.strictEqual(JSON.parse(result.content.at(-1).text).enhanced, true);
+  });
+
+  it('supports deployment and per-client opt-out without changing the canonical summary', async () => {
+    const contexts = [];
+    const server = createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      adcpVersion: '3.1.18',
+      structuredContentTextFallback: context => {
+        contexts.push(context);
+        return context.clientInfo?.name !== 'capable-host';
+      },
+      mediaBuy: { getProducts: async () => ({ products: [], cache_scope: 'public' }) },
+    });
+
+    const capable = await callToolRaw(
+      server,
+      'get_products',
+      {},
+      {
+        responseContext: {
+          transport: 'mcp',
+          clientInfo: { name: 'capable-host', version: '1.0.0' },
+          clientCapabilities: { experimental: { structuredResults: true } },
+        },
+      }
+    );
+    const unknown = await callToolRaw(server, 'get_products', {});
+    const direct = await server.invoke({ toolName: 'get_products', args: {} });
+
+    assert.strictEqual(capable.content[0].text, 'Found 0 products');
+    assert.strictEqual(mirroredBlocks(capable).length, 0);
+    assert.strictEqual(mirroredBlocks(unknown).length, 1, 'unknown client should follow the fail-safe predicate path');
+    assert.strictEqual(mirroredBlocks(direct).length, 1, 'direct embedding without client facts should fail safe');
+    assert.deepStrictEqual(contexts[0], {
+      transport: 'mcp',
+      clientInfo: { name: 'capable-host', version: '1.0.0' },
+      clientCapabilities: { experimental: { structuredResults: true } },
+    });
+    assert.strictEqual(contexts.length, 1, 'unknown clients should mirror without invoking the deployment predicate');
+
+    const never = createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      adcpVersion: '3.1.18',
+      structuredContentTextFallback: 'never',
+      mediaBuy: { getProducts: async () => ({ products: [], cache_scope: 'public' }) },
+    });
+    assert.strictEqual(mirroredBlocks(await callToolRaw(never, 'get_products', {})).length, 0);
+  });
+
+  it('deduplicates an adopter-authored exact JSON fallback and fails safe when a predicate throws', async () => {
+    const exact = createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      adcpVersion: '3.1.18',
+      responseEnhancer: response => {
+        response.content.push({ type: 'text', text: JSON.stringify(response.structuredContent) });
+      },
+      mediaBuy: { getProducts: async () => ({ products: [], cache_scope: 'public' }) },
+    });
+    const exactResult = await callToolRaw(exact, 'get_products', {});
+    const serialized = JSON.stringify(exactResult.structuredContent);
+    assert.strictEqual(exactResult.content.filter(block => block.text === serialized).length, 1);
+    assert.strictEqual(mirroredBlocks(exactResult).length, 0, 'adopter-authored blocks must not be relabeled');
+
+    const throwing = createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      adcpVersion: '3.1.18',
+      structuredContentTextFallback: () => {
+        throw new Error('bad deployment predicate');
+      },
+      mediaBuy: { getProducts: async () => ({ products: [], cache_scope: 'public' }) },
+    });
+    const throwingResult = await callToolRaw(
+      throwing,
+      'get_products',
+      {},
+      {
+        responseContext: {
+          transport: 'mcp',
+          clientInfo: { name: 'known-host', version: '1.0.0' },
+        },
+      }
+    );
+    assert.strictEqual(mirroredBlocks(throwingResult).length, 1);
+  });
+
+  it('passes negotiated legacy MCP client facts to the transport-edge predicate', async () => {
+    const contexts = [];
+    const server = createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      adcpVersion: '3.1.18',
+      structuredContentTextFallback: context => {
+        contexts.push(context);
+        return false;
+      },
+      mediaBuy: { getProducts: async () => ({ products: [], cache_scope: 'public' }) },
+    });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    const client = new Client(
+      { name: 'legacy-capable-host', version: '2.3.4' },
+      { capabilities: { experimental: { structuredResults: {} } } }
+    );
+    await client.connect(clientTransport);
+    try {
+      const result = await client.callTool({ name: 'get_products', arguments: {} });
+      assert.strictEqual(mirroredBlocks(result).length, 0);
+      assert.strictEqual(contexts.at(-1).transport, 'mcp');
+      assert.strictEqual(contexts.at(-1).clientInfo.name, 'legacy-capable-host');
+      assert.strictEqual(contexts.at(-1).clientInfo.version, '2.3.4');
+      assert.deepStrictEqual(contexts.at(-1).clientCapabilities.experimental, { structuredResults: {} });
+    } finally {
+      await client.close();
+      await server.close();
+    }
   });
 
   it('dispatchTestRequest throws for unknown tools and methods', async () => {

--- a/test/server-idempotency-disabled-e2e.test.js
+++ b/test/server-idempotency-disabled-e2e.test.js
@@ -217,7 +217,26 @@ describe('idempotency: disabled — A2A wire roundtrip', () => {
 
   it('A2A: create_media_buy succeeds without idempotency_key under strict validation', async () => {
     const calls = [];
-    const adcp = makeFactory({ calls })();
+    const fallbackContexts = [];
+    const adcp = _createAdcpServer({
+      name: 'Disabled E2E',
+      version: '1.0.0',
+      adcpVersion: '3.1.18',
+      idempotency: 'disabled',
+      stateStore: new InMemoryStateStore(),
+      resolveSessionKey: () => 'tenant_e2e',
+      validation: { requests: 'strict', responses: 'off' },
+      structuredContentTextFallback: context => {
+        fallbackContexts.push(context);
+        return true;
+      },
+      mediaBuy: {
+        createMediaBuy: async params => {
+          calls.push(params);
+          return { media_buy_id: `mb_${calls.length}`, packages: [] };
+        },
+      },
+    });
     const a2a = createA2AAdapter({
       server: adcp,
       agentCard: {
@@ -249,5 +268,7 @@ describe('idempotency: disabled — A2A wire roundtrip', () => {
       `A2A roundtrip should accept missing idempotency_key in disabled mode, got: ${JSON.stringify(payload.adcp_error)}`
     );
     assert.equal(calls.length, 1);
+    assert.equal(fallbackContexts.at(-1).transport, 'a2a');
+    assert.equal(payload.content, undefined, 'A2A artifact must contain only the typed DataPart payload');
   });
 });

--- a/test/server-idempotency-disabled-e2e.test.js
+++ b/test/server-idempotency-disabled-e2e.test.js
@@ -28,7 +28,7 @@ after(() => {
 });
 
 const lib = require('../dist/lib/index.js');
-const { serve } = lib;
+const { ADCP_MIRRORED_STRUCTURED_CONTENT_META_KEY, serve } = lib;
 const { createAdcpServer: _createAdcpServer } = require('../dist/lib/server/legacy/v5/index.js');
 const { createA2AAdapter } = require('../dist/lib/server/a2a-adapter');
 const { InMemoryStateStore } = require('../dist/lib/server/state-store');
@@ -70,6 +70,46 @@ const basePayload = {
 };
 
 describe('idempotency: disabled — MCP wire roundtrip', () => {
+  it('fails safe on stateless legacy HTTP where initialize client facts cannot be correlated', async () => {
+    const fallbackContexts = [];
+    const httpServer = serve(
+      () =>
+        _createAdcpServer({
+          name: 'Stateless fallback E2E',
+          version: '1.0.0',
+          adcpVersion: '3.1.18',
+          idempotency: 'disabled',
+          validation: { requests: 'off', responses: 'off' },
+          structuredContentTextFallback: context => {
+            fallbackContexts.push(context);
+            return false;
+          },
+          mediaBuy: {
+            getProducts: async () => ({ products: [], cache_scope: 'public' }),
+          },
+        }),
+      { port: 0, onListening: () => {} }
+    );
+    await waitForListening(httpServer);
+    const port = httpServer.address().port;
+    try {
+      const transport = new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${port}/mcp`));
+      const client = new Client({ name: 'Legacy stateless host', version: '1.0.0' });
+      await client.connect(transport);
+
+      const result = await client.callTool({ name: 'get_products', arguments: {} });
+      assert.equal(fallbackContexts.length, 0, 'unknown clients must not reach the deployment predicate');
+      assert.equal(
+        result.content.some(block => block._meta?.[ADCP_MIRRORED_STRUCTURED_CONTENT_META_KEY] === true),
+        true,
+        'unknown legacy HTTP clients must retain the compatibility mirror'
+      );
+      await client.close();
+    } finally {
+      httpServer.close();
+    }
+  });
+
   it('get_adcp_capabilities advertises {supported: false, no replay_ttl_seconds} over real HTTP', async () => {
     const httpServer = serve(makeFactory(), { port: 0, onListening: () => {} });
     await waitForListening(httpServer);

--- a/test/server-idempotency.test.js
+++ b/test/server-idempotency.test.js
@@ -4,6 +4,7 @@ const assert = require('node:assert/strict');
 const { createAdcpServer: _createAdcpServer } = require('../dist/lib/server/create-adcp-server');
 const { createIdempotencyStore, memoryBackend } = require('../dist/lib/server/idempotency');
 const { adcpError } = require('../dist/lib/server/errors');
+const { ADCP_MIRRORED_STRUCTURED_CONTENT_META_KEY } = require('../dist/lib/server/structured-content-fallback');
 
 // Idempotency tests use sparse handler fixtures; opt out of the strict
 // response-validation default so we stay focused on replay/claim behavior.
@@ -790,6 +791,51 @@ describe('createAdcpServer with idempotency', () => {
     assert.equal(replay.replayed, true);
     assert.equal(enhancements, 1, 'response enhancer must only run for the original execution');
     assert.equal(calls, 1);
+  });
+
+  it('caches the canonical response before applying a per-client text fallback', async () => {
+    let calls = 0;
+    const server = createAdcpServer({
+      name: 'T',
+      version: '1.0.0',
+      adcpVersion: '3.1.18',
+      idempotency: createIdempotencyStore({ backend: memoryBackend({ sweepIntervalMs: 0 }) }),
+      resolveSessionKey: () => 'tenant',
+      structuredContentTextFallback: ({ clientInfo }) => clientInfo?.name !== 'capable-host',
+      mediaBuy: {
+        createMediaBuy: async () => {
+          calls += 1;
+          return { media_buy_id: 'mb_canonical_cache', packages: [] };
+        },
+      },
+    });
+    const args = { ...basePayload, idempotency_key: 'fallback_cache_abcdefgh' };
+
+    const first = await server.invoke({
+      toolName: 'create_media_buy',
+      args,
+      responseContext: {
+        transport: 'mcp',
+        clientInfo: { name: 'text-only-host', version: '1.0.0' },
+      },
+    });
+    const replay = await server.invoke({
+      toolName: 'create_media_buy',
+      args,
+      responseContext: {
+        transport: 'mcp',
+        clientInfo: { name: 'capable-host', version: '1.0.0' },
+      },
+    });
+
+    assert.equal(calls, 1, 'second client should replay rather than re-execute');
+    assert.equal(first.content.at(-1)._meta?.[ADCP_MIRRORED_STRUCTURED_CONTENT_META_KEY], true);
+    assert.equal(
+      replay.content.some(block => block._meta?.[ADCP_MIRRORED_STRUCTURED_CONTENT_META_KEY] === true),
+      false,
+      'the first client decoration must not be stored in the canonical replay entry'
+    );
+    assert.equal(replay.structuredContent.replayed, true);
   });
 
   it('fails closed when the idempotency backend cannot publish a completed response', async () => {

--- a/test/server-structured-content-fallback.test.js
+++ b/test/server-structured-content-fallback.test.js
@@ -1,0 +1,93 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  ADCP_MIRRORED_STRUCTURED_CONTENT_META_KEY,
+  applyStructuredContentTextFallback,
+} = require('../dist/lib/server/structured-content-fallback');
+
+function canonicalResponse() {
+  return {
+    content: [{ type: 'text', text: 'Human summary' }],
+    structuredContent: { products: [{ product_id: 'p1' }] },
+  };
+}
+
+function mirroredBlocks(response) {
+  return response.content.filter(block => block._meta?.[ADCP_MIRRORED_STRUCTURED_CONTENT_META_KEY] === true);
+}
+
+test('named fallback policies mark a cloned MCP response and keep A2A clean', () => {
+  const canonical = canonicalResponse();
+  const always = applyStructuredContentTextFallback(canonical, 'always', { transport: 'mcp' });
+  const auto = applyStructuredContentTextFallback(canonical, 'auto', { transport: 'mcp' });
+
+  assert.notStrictEqual(always, canonical);
+  assert.deepStrictEqual(canonical.content, [{ type: 'text', text: 'Human summary' }]);
+  assert.strictEqual(mirroredBlocks(always).length, 1);
+  assert.strictEqual(mirroredBlocks(auto).length, 1);
+  assert.strictEqual(applyStructuredContentTextFallback(canonical, 'never', { transport: 'mcp' }), canonical);
+  assert.strictEqual(applyStructuredContentTextFallback(canonical, 'always', { transport: 'a2a' }), canonical);
+});
+
+test('unknown clients fail safe without consulting a deployment predicate', () => {
+  const canonical = canonicalResponse();
+  let calls = 0;
+  const result = applyStructuredContentTextFallback(
+    canonical,
+    () => {
+      calls += 1;
+      return false;
+    },
+    { transport: 'direct' }
+  );
+
+  assert.strictEqual(calls, 0);
+  assert.strictEqual(mirroredBlocks(result).length, 1);
+});
+
+test('known clients and A2A expose the extensible predicate context', () => {
+  const canonical = canonicalResponse();
+  const contexts = [];
+  const predicate = context => {
+    contexts.push(context);
+    return false;
+  };
+  const clientInfo = { name: 'capable-host', version: '1.0.0' };
+
+  assert.strictEqual(
+    applyStructuredContentTextFallback(canonical, predicate, {
+      transport: 'mcp',
+      clientInfo,
+      clientCapabilities: { experimental: {} },
+    }),
+    canonical
+  );
+  assert.strictEqual(applyStructuredContentTextFallback(canonical, predicate, { transport: 'a2a' }), canonical);
+  assert.deepStrictEqual(
+    contexts.map(context => context.transport),
+    ['mcp', 'a2a']
+  );
+});
+
+test('exact-string dedup and predicate failures preserve a single legible result', () => {
+  const canonical = canonicalResponse();
+  const serialized = JSON.stringify(canonical.structuredContent);
+  const adopterMirrored = {
+    ...canonical,
+    content: [...canonical.content, { type: 'text', text: serialized }],
+  };
+  const client = {
+    transport: 'mcp',
+    clientInfo: { name: 'known-host', version: '1.0.0' },
+  };
+
+  assert.strictEqual(applyStructuredContentTextFallback(adopterMirrored, 'always', client), adopterMirrored);
+  const failedPredicate = applyStructuredContentTextFallback(
+    canonical,
+    () => {
+      throw new Error('deployment predicate failed');
+    },
+    client
+  );
+  assert.strictEqual(mirroredBlocks(failedPredicate).length, 1);
+});


### PR DESCRIPTION
## Summary

- make the MCP structured-content text mirror configurable globally or per negotiated client
- apply the marked fallback at the transport edge so idempotency caches retain canonical responses
- keep A2A artifacts clean and fail safe to mirroring when MCP/direct client identity is unavailable
- preserve exact-string deduplication and tag SDK-generated blocks with `_meta["adcp/mirrored-structured-content"]`

Follow-up to #2794. The registry contract sync merged there is intentionally untouched here.

## Verification

- `npm run typecheck`
- `npm run build:lib`
- 11 focused policy, legacy MCP, modern MCP, direct replay, and A2A tests
- targeted ESLint and Prettier checks

## Known baseline issue

A broader local server-test run currently encounters upstream AdCP `3.2.0-beta.9` manifest drift: core tools are marked as added in stable `3.2.0`, producing existing `VERSION_UNSUPPORTED` failures under the beta pin. The feature tests use the stable bundled `3.1.18` release to isolate this change.