### PR TITLE
fix: wire beta 10 server handlers

### DIFF
--- a/.changeset/fresh-beta-ten.md
+++ b/.changeset/fresh-beta-ten.md
@@ -2,4 +2,4 @@
 '@adcp/sdk': patch
 ---
 
-Adopt the signed AdCP 3.2.0-beta.10 bundle, including principal discovery, reporting-delivery contracts, and DOOH schema updates.
+Adopt the signed AdCP 3.2.0-beta.10 bundle, including principal discovery, reporting-delivery contracts and server handler wiring, and DOOH schema updates.

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -252,10 +252,14 @@ import type {
   UpdateMediaBuyRequestSchema,
   GetMediaBuysRequestSchema,
   GetMediaBuyDeliveryRequestSchema,
+  GetReportingStatusRequestSchema,
+  SyncReportingReceiptsRequestSchema,
   ProvidePerformanceFeedbackRequestSchema,
   GetTaskStatusRequestSchema,
   ListTasksRequestSchema,
   SyncAgentNotificationConfigsRequestSchema,
+  GetPrincipalRequestSchema,
+  SyncPrincipalRequestSchema,
   ListCreativeFormatsRequestSchema,
   ListTransformersRequestSchema,
   BuildCreativeRequestSchema,
@@ -331,9 +335,13 @@ import type {
   UpdateMediaBuyResponse,
   GetMediaBuysResponse,
   GetMediaBuyDeliveryResponse,
+  GetReportingStatusResponse,
+  SyncReportingReceiptsResponse,
   GetTaskStatusResponse,
   ListTasksResponse,
   SyncAgentNotificationConfigsResponse,
+  GetPrincipalResponse,
+  SyncPrincipalResponse,
   ListAccountsResponse,
   ListCreativeFormatsResponse,
   ListTransformersResponse,
@@ -687,6 +695,16 @@ export interface AdcpToolMap {
     result: ServerPayload<GetMediaBuyDeliveryResponse>;
     response: GetMediaBuyDeliveryResponse;
   };
+  get_reporting_status: {
+    params: z.input<typeof GetReportingStatusRequestSchema>;
+    result: ServerPayload<GetReportingStatusResponse>;
+    response: GetReportingStatusResponse;
+  };
+  sync_reporting_receipts: {
+    params: z.input<typeof SyncReportingReceiptsRequestSchema>;
+    result: ServerPayload<SyncReportingReceiptsResponse>;
+    response: SyncReportingReceiptsResponse;
+  };
   provide_performance_feedback: {
     params: z.input<typeof ProvidePerformanceFeedbackRequestSchema>;
     result: ServerPayload<ProvidePerformanceFeedbackSuccess>;
@@ -706,6 +724,16 @@ export interface AdcpToolMap {
     params: z.input<typeof SyncAgentNotificationConfigsRequestSchema>;
     result: ServerPayload<SyncAgentNotificationConfigsResponse>;
     response: SyncAgentNotificationConfigsResponse;
+  };
+  get_principal: {
+    params: z.input<typeof GetPrincipalRequestSchema>;
+    result: ServerPayload<GetPrincipalResponse>;
+    response: GetPrincipalResponse;
+  };
+  sync_principal: {
+    params: z.input<typeof SyncPrincipalRequestSchema>;
+    result: ServerPayload<SyncPrincipalResponse>;
+    response: SyncPrincipalResponse;
   };
   list_creative_formats: {
     params: z.input<typeof ListCreativeFormatsRequestSchema>;
@@ -1034,6 +1062,8 @@ export interface MediaBuyHandlers<TAccount = unknown> {
   updateMediaBuy?: DomainHandler<'update_media_buy', TAccount>;
   getMediaBuys?: DomainHandler<'get_media_buys', TAccount>;
   getMediaBuyDelivery?: DomainHandler<'get_media_buy_delivery', TAccount>;
+  getReportingStatus?: DomainHandler<'get_reporting_status', TAccount>;
+  syncReportingReceipts?: DomainHandler<'sync_reporting_receipts', TAccount>;
   providePerformanceFeedback?: DomainHandler<'provide_performance_feedback', TAccount>;
   listCreativeFormats?: DomainHandler<'list_creative_formats', TAccount>;
   syncCreatives?: DomainHandler<'sync_creatives', TAccount>;
@@ -1109,6 +1139,8 @@ export interface ProtocolHandlers<TAccount = unknown> {
     params: AdcpToolMap['sync_agent_notification_configs']['params']
   ) => CallerMutationScope | Promise<CallerMutationScope>;
   syncAgentNotificationConfigs?: DomainHandler<'sync_agent_notification_configs', TAccount>;
+  getPrincipal?: DomainHandler<'get_principal', TAccount>;
+  syncPrincipal?: DomainHandler<'sync_principal', TAccount>;
 }
 
 export interface AccountHandlers<TAccount = unknown> {
@@ -2998,12 +3030,16 @@ const TOOL_META: Record<string, ToolMeta> = {
   update_media_buy: { wrap: updateMediaBuyResponse, annotations: MUT },
   get_media_buys: { wrap: getMediaBuysResponse, annotations: RO },
   get_media_buy_delivery: { wrap: deliveryResponse, annotations: RO },
+  get_reporting_status: { wrap: null, annotations: RO },
+  sync_reporting_receipts: { wrap: null, annotations: IDEMP },
   provide_performance_feedback: { wrap: performanceFeedbackResponse, annotations: MUT },
 
   // Protocol
   get_task_status: { wrap: null, annotations: RO },
   list_tasks: { wrap: null, annotations: RO },
   sync_agent_notification_configs: { wrap: null, annotations: IDEMP },
+  get_principal: { wrap: null, annotations: RO },
+  sync_principal: { wrap: null, annotations: IDEMP },
 
   // Creative
   list_creative_formats: { wrap: listCreativeFormatsResponse, annotations: RO },
@@ -3279,6 +3315,8 @@ const MEDIA_BUY_ENTRIES: HandlerEntry[] = [
   { handlerKey: 'updateMediaBuy', toolName: 'update_media_buy' },
   { handlerKey: 'getMediaBuys', toolName: 'get_media_buys' },
   { handlerKey: 'getMediaBuyDelivery', toolName: 'get_media_buy_delivery' },
+  { handlerKey: 'getReportingStatus', toolName: 'get_reporting_status' },
+  { handlerKey: 'syncReportingReceipts', toolName: 'sync_reporting_receipts' },
   { handlerKey: 'providePerformanceFeedback', toolName: 'provide_performance_feedback' },
   { handlerKey: 'listCreativeFormats', toolName: 'list_creative_formats' },
   { handlerKey: 'syncCreatives', toolName: 'sync_creatives' },
@@ -3341,6 +3379,8 @@ const GOVERNANCE_ENTRIES: HandlerEntry[] = [
 
 const PROTOCOL_ENTRIES: HandlerEntry[] = [
   { handlerKey: 'syncAgentNotificationConfigs', toolName: 'sync_agent_notification_configs' },
+  { handlerKey: 'getPrincipal', toolName: 'get_principal' },
+  { handlerKey: 'syncPrincipal', toolName: 'sync_principal' },
 ];
 
 const ACCOUNT_ENTRIES: HandlerEntry[] = [

--- a/src/lib/utils/tool-request-schemas.ts
+++ b/src/lib/utils/tool-request-schemas.ts
@@ -126,6 +126,8 @@ export type KnownToolRequestSchemas = {
   update_media_buy: typeof UpdateMediaBuyToolRequestSchema;
   get_media_buys: typeof schemas.GetMediaBuysRequestSchema;
   get_media_buy_delivery: typeof schemas.GetMediaBuyDeliveryRequestSchema;
+  get_reporting_status: typeof schemas.GetReportingStatusRequestSchema;
+  sync_reporting_receipts: typeof schemas.SyncReportingReceiptsRequestSchema;
   provide_performance_feedback: typeof schemas.ProvidePerformanceFeedbackRequestSchema;
   list_creative_formats: typeof schemas.ListCreativeFormatsRequestSchema;
   list_transformers: typeof schemas.ListTransformersRequestSchema;
@@ -178,6 +180,8 @@ export type KnownToolRequestSchemas = {
   si_terminate_session: typeof schemas.SITerminateSessionRequestSchema;
   get_adcp_capabilities: typeof schemas.GetAdCPCapabilitiesRequestSchema;
   sync_agent_notification_configs: typeof schemas.SyncAgentNotificationConfigsRequestSchema;
+  get_principal: typeof schemas.GetPrincipalRequestSchema;
+  sync_principal: typeof schemas.SyncPrincipalRequestSchema;
   comply_test_controller: typeof schemas.ComplyTestControllerRequestSchema;
   validate_input: typeof schemas.ValidateInputRequestSchema;
   get_brand_identity: typeof schemas.GetBrandIdentityRequestSchema;
@@ -207,6 +211,8 @@ export const TOOL_REQUEST_SCHEMAS: ToolRequestSchemas = {
   update_media_buy: UpdateMediaBuyToolRequestSchema,
   get_media_buys: schemas.GetMediaBuysRequestSchema,
   get_media_buy_delivery: schemas.GetMediaBuyDeliveryRequestSchema,
+  get_reporting_status: schemas.GetReportingStatusRequestSchema,
+  sync_reporting_receipts: schemas.SyncReportingReceiptsRequestSchema,
   provide_performance_feedback: schemas.ProvidePerformanceFeedbackRequestSchema,
 
   // Creative
@@ -279,6 +285,8 @@ export const TOOL_REQUEST_SCHEMAS: ToolRequestSchemas = {
   get_task_status: schemas.GetTaskStatusRequestSchema,
   list_tasks: schemas.ListTasksRequestSchema,
   sync_agent_notification_configs: schemas.SyncAgentNotificationConfigsRequestSchema,
+  get_principal: schemas.GetPrincipalRequestSchema,
+  sync_principal: schemas.SyncPrincipalRequestSchema,
 
   // Creative preflight
   validate_input: schemas.ValidateInputRequestSchema,

--- a/test/lib/mcp-modern-negotiation.test.js
+++ b/test/lib/mcp-modern-negotiation.test.js
@@ -686,6 +686,7 @@ test('modern serving honors the resolved AdCP MCP tool profile', async () => {
           name: 'modern-profile-test',
           version: '1.0.0',
           adcpVersion: '3.2.0-beta.10',
+          idempotency: 'disabled',
           ...(mcpToolProfile !== undefined && { mcpToolProfile }),
           stateStore: new InMemoryStateStore(),
           validation: { requests: 'off', responses: 'off' },
@@ -696,6 +697,8 @@ test('modern serving honors the resolved AdCP MCP tool profile', async () => {
             buyProducts: async () => ({ media_buy_id: 'mb-buy' }),
             acceptProposal: async () => ({ media_buy_id: 'mb-accept' }),
             controlMediaBuy: async () => ({ media_buy_id: 'mb-control', revision: 2 }),
+            getReportingStatus: async () => ({}),
+            syncReportingReceipts: async () => ({}),
             getProducts: async () => {
               legacyCalls++;
               return { products: [], cache_scope: 'public' };
@@ -703,6 +706,10 @@ test('modern serving honors the resolved AdCP MCP tool profile', async () => {
           },
           creative: {
             buildCreative: async () => ({ creative_manifest: { manifest_id: 'mf-1', assets: [] } }),
+          },
+          protocol: {
+            getPrincipal: async () => ({}),
+            syncPrincipal: async () => ({}),
           },
         }),
       { port: 0, onListening: () => {} }
@@ -743,6 +750,9 @@ test('modern serving honors the resolved AdCP MCP tool profile', async () => {
   const compactNames = compact.tools.map(tool => tool.name);
   assert.ok(compactNames.includes('list_products'));
   assert.ok(compactNames.includes('buy_products'));
+  assert.ok(compactNames.includes('sync_principal'));
+  assert.ok(compactNames.includes('get_reporting_status'));
+  assert.ok(compactNames.includes('sync_reporting_receipts'));
   assert.ok(!compactNames.includes('get_products'));
   assert.ok(!compactNames.includes('build_creative'));
   assert.equal(compactResult.legacyCalls, 1, 'a legacy tool hidden from discovery must remain directly callable');
@@ -794,6 +804,7 @@ test('modern serving honors the resolved AdCP MCP tool profile', async () => {
   assert.ok(allNames.includes('list_products'));
   assert.ok(allNames.includes('get_products'));
   assert.ok(allNames.includes('build_creative'));
+  assert.ok(allNames.includes('get_principal'));
   assert.equal(
     all.tools.find(tool => tool.name === 'request_proposals').inputSchema.$schema,
     'https://json-schema.org/draft/2020-12/schema'

--- a/test/lib/storyboard-completeness.test.js
+++ b/test/lib/storyboard-completeness.test.js
@@ -15,6 +15,7 @@ const assert = require('node:assert/strict');
 const { listAllComplianceStoryboards } = require('../../dist/lib/testing/storyboard/index.js');
 const { hasRequestBuilder } = require('../../dist/lib/testing/storyboard/request-builder.js');
 const { TASK_TO_METHOD } = require('../../dist/lib/testing/storyboard/task-map.js');
+const { TOOL_REQUEST_SCHEMAS } = require('../../dist/lib/utils/tool-request-schemas.js');
 const { TOOL_RESPONSE_SCHEMAS } = require('../../dist/lib/utils/response-schemas.js');
 
 const allStoryboards = listAllComplianceStoryboards();
@@ -173,6 +174,14 @@ describe('response schema coverage', () => {
         TOOL_RESPONSE_SCHEMAS[task],
         `Task "${task}" is used in storyboards but has no response schema in TOOL_RESPONSE_SCHEMAS`
       );
+    });
+  }
+});
+
+describe('AdCP 3.2 beta.10 request schema coverage', () => {
+  for (const task of ['get_principal', 'sync_principal', 'get_reporting_status', 'sync_reporting_receipts']) {
+    it(`${task} has a registered request schema`, () => {
+      assert.ok(TOOL_REQUEST_SCHEMAS[task], `Task "${task}" has no request schema in TOOL_REQUEST_SCHEMAS`);
     });
   }
 });


### PR DESCRIPTION
## Summary
- register beta.10 request schemas for principal and reporting-delivery tools
- expose typed server handler seams and runtime registration for all four tools
- add discovery and schema-coverage regression tests

Follow-up to #2805, which exposed generated client types but left these tools unavailable to SDK server adopters.

## Testing
- `npm run build:lib`
- `npm run typecheck`
- focused modern MCP discovery test
- response-schema, storyboard-completeness, and storyboard-drift suites
- pre-push formatting, typecheck, and build validation