### PR TITLE
fix(runner): normalize schema-invalid request errors

### DIFF
--- a/.changeset/calm-runners-normalize.md
+++ b/.changeset/calm-runners-normalize.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Normalize SDK-local request-schema rejections for explicitly schema-invalid storyboard steps to synthetic `INVALID_REQUEST` results.

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -5555,10 +5555,28 @@ async function executeStep(
     };
   }
 
-  // For expect_error steps where TaskResult has no data but has an error string,
-  // wrap the error string so validations have something to check against.
-  if (step.expect_error && !taskResult?.data && taskResult?.error) {
-    taskResult = { ...taskResult, data: { error: taskResult.error } };
+  // An intentionally schema-invalid vector can be rejected by the SDK before
+  // transport. That is protocol-equivalent to INVALID_REQUEST, but the local
+  // validation path only carries a string. Normalize that narrow case so the
+  // authored error_code check can grade it while retaining a synthetic marker
+  // that makes clear the seller did not produce this envelope.
+  const unstructuredStepError = taskResult?.error ?? (taskResult === undefined ? stepResult.error : undefined);
+  if (step.expect_error && !taskResult?.data && unstructuredStepError) {
+    const localSchemaRejection =
+      step.negative_path === 'schema_invalid' &&
+      /^(?:Request validation failed for\b|Validation failed for field\b)/.test(unstructuredStepError);
+    if (taskResult || localSchemaRejection) {
+      taskResult = {
+        ...(taskResult ?? { success: false }),
+        error: unstructuredStepError,
+        data: localSchemaRejection
+          ? {
+              errors: [{ code: 'INVALID_REQUEST', message: unstructuredStepError }],
+              synthetic: true,
+            }
+          : { error: unstructuredStepError },
+      };
+    }
   }
 
   const responseDerivedSkip = detectResponseDerivedNotApplicable(

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -728,6 +728,14 @@ export interface StoryboardStep {
   /** When true, the step passes if the task returns an error */
   expect_error?: boolean;
   /**
+   * Classifies an expected rejection as either an intentionally malformed
+   * request (`schema_invalid`) or a schema-valid request rejected by seller
+   * policy/state (`payload_well_formed`). The distinction lets the runner
+   * treat an SDK-local request-schema rejection as `INVALID_REQUEST` without
+   * masking seller-side validation on well-formed negative paths.
+   */
+  negative_path?: 'schema_invalid' | 'payload_well_formed';
+  /**
    * Per-step invariant opt-out. See `StepInvariantsObject`. Use when a
    * specific step deliberately trips a default invariant (e.g. a
    * `check_governance` 200 `status: denied` that is the setup for a

--- a/test/lib/storyboard-schema-invalid-negative-path.test.js
+++ b/test/lib/storyboard-schema-invalid-negative-path.test.js
@@ -1,0 +1,148 @@
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { ProtocolClient } = require('../../dist/lib/index.js');
+const { createTestClient } = require('../../dist/lib/testing/client.js');
+const { runStoryboardStep } = require('../../dist/lib/testing/storyboard/runner.js');
+
+function storyboard(negativePath) {
+  return {
+    id: 'schema_invalid_negative_path',
+    version: '1.0.0',
+    title: 'Schema-invalid negative path',
+    category: 'test',
+    summary: 'Grades SDK-local request validation as INVALID_REQUEST.',
+    narrative: '',
+    agent: { interaction_model: 'sync', capabilities: [] },
+    caller: { role: 'buyer_agent' },
+    phases: [
+      {
+        id: 'negative',
+        title: 'Negative path',
+        steps: [
+          {
+            id: 'reject_invalid_request',
+            title: 'Reject an invalid request',
+            task: 'get_products',
+            expect_error: true,
+            negative_path: negativePath,
+            sample_request: { buying_mode: 'invalid-mode' },
+            validations: [
+              {
+                check: 'error_code',
+                allowed_values: ['INVALID_REQUEST'],
+                description: 'The invalid request is rejected canonically',
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function options(error) {
+  const client = {
+    async getProducts() {
+      return { success: false, error };
+    },
+  };
+  return {
+    protocol: 'mcp',
+    _client: client,
+    _profile: { name: 'Local validation stub', tools: ['get_products'], raw_capabilities: {} },
+  };
+}
+
+describe('storyboard schema-invalid negative paths', () => {
+  test('grades the real SDK pre-dispatch request validator without contacting the seller', async () => {
+    const originalCallTool = ProtocolClient.callTool;
+    let dispatches = 0;
+    ProtocolClient.callTool = async () => {
+      dispatches += 1;
+      throw new Error('seller transport must not be called');
+    };
+
+    try {
+      const result = await runStoryboardStep(
+        'https://stub.example/mcp',
+        storyboard('schema_invalid'),
+        'reject_invalid_request',
+        {
+          protocol: 'mcp',
+          _client: createTestClient('https://stub.example/mcp'),
+          _profile: { name: 'Strict request client', tools: ['get_products'], raw_capabilities: {} },
+        }
+      );
+
+      assert.equal(dispatches, 0, 'request validation must reject before protocol dispatch');
+      assert.equal(result.passed, true, JSON.stringify(result.validations));
+      assert.equal(result.response.synthetic, true);
+      assert.equal(result.response.errors[0].code, 'INVALID_REQUEST');
+      assert.match(result.response.errors[0].message, /Request validation failed for get_products/);
+    } finally {
+      ProtocolClient.callTool = originalCallTool;
+    }
+  });
+
+  test('normalizes a field-level SDK-local request rejection to synthetic INVALID_REQUEST', async () => {
+    const result = await runStoryboardStep(
+      'https://stub.example/mcp',
+      storyboard('schema_invalid'),
+      'reject_invalid_request',
+      options('Validation failed for field buying_mode: must be equal to one of the allowed values')
+    );
+
+    assert.equal(result.passed, true, JSON.stringify(result.validations));
+    assert.deepEqual(result.response, {
+      errors: [
+        {
+          code: 'INVALID_REQUEST',
+          message: 'Validation failed for field buying_mode: must be equal to one of the allowed values',
+        },
+      ],
+      synthetic: true,
+    });
+    assert.equal(result.validations[0].passed, true);
+    assert.equal(result.validations[0].actual, undefined);
+  });
+
+  test('does not normalize a post-transport response-schema rejection', async () => {
+    const result = await runStoryboardStep(
+      'https://stub.example/mcp',
+      storyboard('schema_invalid'),
+      'reject_invalid_request',
+      options('Schema validation failed: seller returned an invalid response')
+    );
+
+    assert.equal(result.passed, false);
+    assert.equal(result.validations[0].passed, false);
+    assert.deepEqual(result.response, { error: 'Schema validation failed: seller returned an invalid response' });
+  });
+
+  test('does not normalize schema-valid seller rejection paths', async () => {
+    const result = await runStoryboardStep(
+      'https://stub.example/mcp',
+      storyboard('payload_well_formed'),
+      'reject_invalid_request',
+      options('Schema validation failed: seller rejected the request')
+    );
+
+    assert.equal(result.passed, false);
+    assert.equal(result.validations[0].passed, false);
+    assert.deepEqual(result.response, { error: 'Schema validation failed: seller rejected the request' });
+  });
+
+  test('does not relabel transport failures as INVALID_REQUEST', async () => {
+    const result = await runStoryboardStep(
+      'https://stub.example/mcp',
+      storyboard('schema_invalid'),
+      'reject_invalid_request',
+      options('ECONNRESET while connecting to seller')
+    );
+
+    assert.equal(result.passed, false);
+    assert.equal(result.validations[0].passed, false);
+    assert.deepEqual(result.response, { error: 'ECONNRESET while connecting to seller' });
+  });
+});


### PR DESCRIPTION
## Summary

- normalize SDK-local request-schema rejection strings to synthetic `INVALID_REQUEST` envelopes for explicitly `schema_invalid` storyboard steps
- keep `payload_well_formed` seller rejections and transport failures unchanged
- type the canonical `negative_path` storyboard field and add focused regression coverage

Closes #2813.

## Validation

- `npm run build:lib`
- `npm run typecheck`
- `npm run format:check`
- `npm run lint` (0 errors; inherited warnings only)
- `node --test test/lib/storyboard-schema-invalid-negative-path.test.js test/lib/storyboard-strict-validation.test.js test/lib/storyboard-schema-validation-attribution.test.js` (43 passed)
- protected pre-push gate
