### PR TITLE
fix(storyboard): backport declared test-kit auth to SDK 13

### DIFF
--- a/.changeset/declared-test-kit-resolution.md
+++ b/.changeset/declared-test-kit-resolution.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+storyboard runner: resolve a storyboard's declared `prerequisites.test_kit` from a caller-selected or trusted-loader compliance cache into `options.test_kit` (caller-supplied kits win), and hard-fail steps whose `auth.from_test_kit` resolves no credential instead of silently sending an unauthenticated probe (adcontextprotocol/adcp#6735). Previously the declaration was decorative: runs without an explicit kit degraded credential-keyed steps (comply_controller_mode_gate) to no-auth probes, grading conformant sellers FAIL. Ad-hoc `--file` runs authorize cache-relative kits only with an explicit `--compliance-dir`; `--compliance-version` selects protocol/schema data without granting credential-read authority, and callers can instead pass `--test-kit`. Targeted `storyboard step --test-kit` reruns now preserve the same explicit override. Declared kit paths are containment-checked against the cache root; a declared kit missing from the cache is tolerated at load time (only steps that actually need the credential fail, with an explicit configuration error).

--- a/.changeset/fair-runners-grade.md
+++ b/.changeset/fair-runners-grade.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Grade explicit payload-level failures as expected errors in compliance storyboards, including live-account controller denials returned through successful MCP calls.

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -2,7 +2,7 @@ name: changeset-check
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, 13.x]
 
 permissions:
   contents: read
@@ -14,20 +14,22 @@ jobs:
 
     steps:
       - name: Skip for release PRs
-        if: github.head_ref == 'changeset-release/main'
+        if: startsWith(github.head_ref, 'changeset-release/')
         run: echo "Release PR — changeset not required"
 
       - name: Checkout code
-        if: github.head_ref != 'changeset-release/main'
+        if: ${{ !startsWith(github.head_ref, 'changeset-release/') }}
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Detect release metadata-only change
-        if: github.head_ref != 'changeset-release/main'
+        if: ${{ !startsWith(github.head_ref, 'changeset-release/') }}
         id: release-metadata
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          changed_files="$(git diff --name-only origin/main...HEAD)"
+          changed_files="$(git diff --name-only "origin/${BASE_REF}...HEAD")"
           package_changes="$(
             printf '%s\n' "$changed_files" |
               grep -Ev '^(\.changeset/pre\.json|CHANGELOG\.md|package(-lock)?\.json|packages/[^/]+/(CHANGELOG\.md|package\.json)|src/lib/version\.ts|docs/(llms\.txt|TYPE-SUMMARY\.md)|\.github/workflows/(changeset-check|release)\.yml)$' ||
@@ -60,16 +62,18 @@ jobs:
           fi
 
       - name: Setup Node.js
-        if: github.head_ref != 'changeset-release/main' && steps.release-metadata.outputs.skip != 'true'
+        if: ${{ !startsWith(github.head_ref, 'changeset-release/') && steps.release-metadata.outputs.skip != 'true' }}
         uses: actions/setup-node@v5
         with:
           node-version: '20.x'
           cache: 'npm'
 
       - name: Install dependencies
-        if: github.head_ref != 'changeset-release/main' && steps.release-metadata.outputs.skip != 'true'
+        if: ${{ !startsWith(github.head_ref, 'changeset-release/') && steps.release-metadata.outputs.skip != 'true' }}
         run: npm ci
 
       - name: Check for changeset
-        if: github.head_ref != 'changeset-release/main' && steps.release-metadata.outputs.skip != 'true'
-        run: npx changeset status --since=origin/main
+        if: ${{ !startsWith(github.head_ref, 'changeset-release/') && steps.release-metadata.outputs.skip != 'true' }}
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: npx changeset status --since="origin/${BASE_REF}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - 13.x
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -1440,13 +1440,13 @@ function loadTestKitFile(testKitPath) {
   try {
     raw = fs.readFileSync(resolved, 'utf8');
   } catch (err) {
-    throw new Error(`failed to read test-kit at ${resolved}: ${err.message}`);
+    throw new Error(`failed to read test-kit at ${resolved} (${err?.code || 'filesystem error'}).`);
   }
   try {
     const { parse } = require('yaml');
     return parse(raw);
-  } catch (err) {
-    throw new Error(`failed to parse ${resolved} as YAML: ${err.message}`);
+  } catch {
+    throw new Error(`failed to parse test-kit at ${resolved} as YAML.`);
   }
 }
 
@@ -1972,14 +1972,18 @@ RUN OPTIONS (full assessment):
                       --test-kit points into a compliance cache, its version is
                       selected automatically; an explicit mismatch is rejected.
   --compliance-dir PATH
-                      Use a specific compliance cache directory
+                      Use a specific compliance cache directory. For --file
+                      storyboards, this explicitly authorizes a cache-relative
+                      prerequisites.test_kit. --compliance-version alone does
+                      not authorize credential loading; pass --test-kit instead.
   --schema-root PATH  Use a specific schema bundle/root for validation.
                       --validator-source is accepted as an alias.
   --hosted-stable-line-alias VERSION
                       Hosted badge mode: allow a stable line (e.g. 3.1)
                       to resolve against a prerelease compliance cache.
   --file PATH         Run an ad-hoc storyboard YAML (spec evolution)
-  --test-kit PATH     Load test-kit YAML. If an ancestor index.json declares
+  --test-kit PATH     Load test-kit YAML for either run or step, overriding any
+                      cache-declared kit. If an ancestor index.json declares
                       adcp_version or published_version, the same compliance
                       line is required for storyboard resolution.
   --timeout SECONDS   Soft budget in seconds: stop starting new storyboards
@@ -2622,6 +2626,27 @@ function enforceStrictFlags(args, removedFound) {
   }
 }
 
+async function resolveFileComplianceRunOptions(args, opts) {
+  let adcpVersion = opts.complianceVersion;
+  let complianceDir = opts.complianceDir;
+  let schemaRoot = opts.schemaRoot;
+  if (opts.complianceDir || opts.complianceVersion || opts.schemaRoot) {
+    const { loadComplianceIndex, getExternalSchemaRootForCompliance } =
+      await import('../dist/lib/testing/storyboard/index.js');
+    const resolveOptions = parseComplianceSelection(args).resolveOptions;
+    const index = loadComplianceIndex(resolveOptions);
+    if (opts.complianceVersion && index.adcp_version !== opts.complianceVersion) {
+      throw new Error(
+        `--compliance-version ${opts.complianceVersion} selected a compliance cache that declares ` +
+          `AdCP ${index.adcp_version}. Check --compliance-dir or ADCP_COMPLIANCE_DIR and select a matching cache.`
+      );
+    }
+    adcpVersion = adcpVersion || index.adcp_version;
+    schemaRoot = schemaRoot || getExternalSchemaRootForCompliance(resolveOptions, index.adcp_version);
+  }
+  return { adcpVersion, complianceDir, schemaRoot };
+}
+
 async function handleStoryboardRun(args) {
   let opts = parseAgentOptions(args);
   let {
@@ -2726,8 +2751,7 @@ async function handleStoryboardRun(args) {
     return;
   }
 
-  const { loadStoryboardFile, runStoryboard, loadComplianceIndex, getExternalSchemaRootForCompliance } =
-    await import('../dist/lib/testing/storyboard/index.js');
+  const { loadStoryboardFile, runStoryboard } = await import('../dist/lib/testing/storyboard/index.js');
   let storyboard;
   try {
     storyboard = loadStoryboardFile(filePath);
@@ -2735,18 +2759,12 @@ async function handleStoryboardRun(args) {
     console.error(`Failed to load storyboard from ${filePath}: ${err.message}`);
     process.exit(2);
   }
-  let fileComplianceVersion = opts.complianceVersion;
-  let fileSchemaRoot = opts.schemaRoot;
-  if (opts.complianceDir || opts.complianceVersion || opts.schemaRoot) {
-    try {
-      const resolveOptions = parseComplianceSelection(args).resolveOptions;
-      const index = loadComplianceIndex(resolveOptions);
-      fileComplianceVersion = fileComplianceVersion || index.adcp_version;
-      fileSchemaRoot = fileSchemaRoot || getExternalSchemaRootForCompliance(resolveOptions, index.adcp_version);
-    } catch (err) {
-      console.error(`ERROR: ${err.message}`);
-      process.exit(2);
-    }
+  let fileComplianceOptions;
+  try {
+    fileComplianceOptions = await resolveFileComplianceRunOptions(args, opts);
+  } catch (err) {
+    console.error(`ERROR: ${err.message}`);
+    process.exit(2);
   }
 
   const {
@@ -2820,8 +2838,6 @@ async function handleStoryboardRun(args) {
     ? await resolveWebhookReceiverOptions(args, { jsonOutput })
     : webhookReceiverBase;
 
-  const loadedTestKit = opts.loadedTestKit ?? null;
-
   const options = {
     protocol,
     ...buildResolvedAuthOption({
@@ -2832,12 +2848,13 @@ async function handleStoryboardRun(args) {
       resolvedOauthClientCredentials,
     }),
     ...(webhookReceiverOpts ?? {}),
-    ...(fileComplianceVersion && { adcpVersion: fileComplianceVersion }),
-    ...(fileSchemaRoot && { schemaRoot: fileSchemaRoot }),
+    ...(fileComplianceOptions.complianceDir && { complianceDir: fileComplianceOptions.complianceDir }),
+    ...(fileComplianceOptions.adcpVersion && { adcpVersion: fileComplianceOptions.adcpVersion }),
+    ...(fileComplianceOptions.schemaRoot && { schemaRoot: fileComplianceOptions.schemaRoot }),
     ...(opts.noSandbox && { sandbox: false, disable_sandbox: true }),
     ...(opts.assertsSeededState && { assertsSeededState: true }),
     ...(mergedRunHeaders && { headers: mergedRunHeaders }),
-    ...(loadedTestKit && { test_kit: loadedTestKit }),
+    ...(opts.loadedTestKit !== undefined && { test_kit: opts.loadedTestKit }),
   };
 
   const restoreLogs = jsonOutput ? captureStdoutLogs() : null;
@@ -3670,14 +3687,18 @@ async function handleLocalAgentStoryboardRun(modulePath, args, opts) {
       createAgent,
       storyboards: storyboardsSpec,
       compliance: resolveOptions,
-      ...(opts.complianceVersion || opts.schemaRoot || opts.noSandbox || opts.assertsSeededState || opts.loadedTestKit
+      ...(opts.complianceVersion ||
+      opts.schemaRoot ||
+      opts.noSandbox ||
+      opts.assertsSeededState ||
+      opts.loadedTestKit !== undefined
         ? {
             runStoryboardOptions: {
               ...(opts.complianceVersion && !opts.complianceDir && { adcpVersion: opts.complianceVersion }),
               ...(opts.schemaRoot && { schemaRoot: opts.schemaRoot }),
               ...(opts.noSandbox && { sandbox: false, disable_sandbox: true }),
               ...(opts.assertsSeededState && { assertsSeededState: true }),
-              ...(opts.loadedTestKit && { test_kit: opts.loadedTestKit }),
+              ...(opts.loadedTestKit !== undefined && { test_kit: opts.loadedTestKit }),
             },
           }
         : {}),
@@ -3962,6 +3983,21 @@ async function handleMultiInstanceStoryboardRun(args, opts, urls) {
     }
   }
 
+  let runAdcpVersion = opts.complianceVersion && !opts.complianceDir ? opts.complianceVersion : undefined;
+  let runComplianceDir = opts.complianceDir;
+  let runSchemaRoot = opts.schemaRoot;
+  if (filePath) {
+    try {
+      const selected = await resolveFileComplianceRunOptions(args, opts);
+      runAdcpVersion = selected.adcpVersion;
+      runComplianceDir = selected.complianceDir;
+      runSchemaRoot = selected.schemaRoot;
+    } catch (err) {
+      console.error(`ERROR: ${err.message}`);
+      process.exit(2);
+    }
+  }
+
   // Auto-detect protocol from the first URL. Multi-instance deployments
   // share a codebase across replicas, so one probe is representative.
   let protocol = protocolFlag;
@@ -4090,11 +4126,12 @@ async function handleMultiInstanceStoryboardRun(args, opts, urls) {
     ...(opts.allowHttp && { allow_http: true }),
     multi_instance_strategy: strategy,
     ...(webhookReceiverOpts ?? {}),
-    ...(opts.complianceVersion && !opts.complianceDir && { adcpVersion: opts.complianceVersion }),
-    ...(opts.schemaRoot && { schemaRoot: opts.schemaRoot }),
+    ...(runComplianceDir && { complianceDir: runComplianceDir }),
+    ...(runAdcpVersion && { adcpVersion: runAdcpVersion }),
+    ...(runSchemaRoot && { schemaRoot: runSchemaRoot }),
     ...(opts.noSandbox && { sandbox: false, disable_sandbox: true }),
     ...(opts.assertsSeededState && { assertsSeededState: true }),
-    ...(opts.loadedTestKit && { test_kit: opts.loadedTestKit }),
+    ...(opts.loadedTestKit !== undefined && { test_kit: opts.loadedTestKit }),
   };
 
   const restoreLogs = jsonOutput ? captureStdoutLogs() : null;
@@ -4269,6 +4306,21 @@ async function handleAgentsRoutedStoryboardRun(args, opts, routing) {
     }
   }
 
+  let runAdcpVersion = opts.complianceVersion && !opts.complianceDir ? opts.complianceVersion : undefined;
+  let runComplianceDir = opts.complianceDir;
+  let runSchemaRoot = opts.schemaRoot;
+  if (filePath) {
+    try {
+      const selected = await resolveFileComplianceRunOptions(args, opts);
+      runAdcpVersion = selected.adcpVersion;
+      runComplianceDir = selected.complianceDir;
+      runSchemaRoot = selected.schemaRoot;
+    } catch (err) {
+      console.error(`ERROR: ${err.message}`);
+      process.exit(2);
+    }
+  }
+
   // Detect protocol from the first agent. Multi-agent topologies typically
   // share the same transport (the prod test-agent uses MCP across all 6
   // tenants), so one probe is representative. Per-agent transport overrides
@@ -4354,11 +4406,12 @@ async function handleAgentsRoutedStoryboardRun(args, opts, routing) {
     agents: routing.agents,
     ...(routing.default_agent ? { default_agent: routing.default_agent } : {}),
     ...(webhookReceiverOpts ?? {}),
-    ...(opts.complianceVersion && !opts.complianceDir && { adcpVersion: opts.complianceVersion }),
-    ...(opts.schemaRoot && { schemaRoot: opts.schemaRoot }),
+    ...(runComplianceDir && { complianceDir: runComplianceDir }),
+    ...(runAdcpVersion && { adcpVersion: runAdcpVersion }),
+    ...(runSchemaRoot && { schemaRoot: runSchemaRoot }),
     ...(opts.noSandbox && { sandbox: false, disable_sandbox: true }),
     ...(opts.assertsSeededState && { assertsSeededState: true }),
-    ...(opts.loadedTestKit && { test_kit: opts.loadedTestKit }),
+    ...(opts.loadedTestKit !== undefined && { test_kit: opts.loadedTestKit }),
   };
 
   const restoreLogs = jsonOutput ? captureStdoutLogs() : null;
@@ -4550,8 +4603,6 @@ async function runFullAssessment(agentArg, rawArgs, parsedOpts) {
 
   await loadInvariantModules(rawArgs);
 
-  const loadedTestKit = opts.loadedTestKit ?? null;
-
   const testOptions = {
     protocol,
     brief: opts.brief,
@@ -4565,7 +4616,8 @@ async function runFullAssessment(agentArg, rawArgs, parsedOpts) {
     ...(opts.noSandbox && { sandbox: false, disable_sandbox: true }),
     ...(opts.assertsSeededState && { assertsSeededState: true }),
     ...(mergedAssessmentHeaders && { headers: mergedAssessmentHeaders }),
-    ...(loadedTestKit && { test_kit: loadedTestKit }),
+    ...(opts.loadedTestKit !== undefined && { test_kit: opts.loadedTestKit }),
+    ...(opts.testKitPath && { testKitPath: path.resolve(opts.testKitPath) }),
     ...(opts.complianceVersion && { version: opts.complianceVersion }),
     ...(opts.complianceDir && { complianceDir: opts.complianceDir }),
     ...(opts.schemaRoot && { schemaRoot: opts.schemaRoot }),
@@ -4709,11 +4761,37 @@ async function runFullAssessment(agentArg, rawArgs, parsedOpts) {
 
 async function handleStoryboardStepCmd(args) {
   const { getComplianceStoryboardById, runStoryboardStep } = await import('../dist/lib/testing/storyboard/index.js');
-  const { authToken, authScheme, protocolFlag, jsonOutput, positionalArgs, complianceVersion, schemaRoot } =
-    parseAgentOptions(args);
-  const { resolveOptions } = parseComplianceSelection(args);
+  let opts = parseAgentOptions(args);
+  let {
+    authToken,
+    authScheme,
+    protocolFlag,
+    jsonOutput,
+    positionalArgs,
+    complianceVersion,
+    schemaRoot,
+  } = opts;
 
   enforceStrictFlags(args, warnRemovedFlags(args));
+
+  try {
+    const prepared = prepareTestKitComplianceSelection(args, opts);
+    args = prepared.args;
+    opts = prepared.opts;
+  } catch (err) {
+    exitTestKitSelectionError(err, jsonOutput);
+  }
+
+  ({
+    authToken,
+    authScheme,
+    protocolFlag,
+    jsonOutput,
+    positionalArgs,
+    complianceVersion,
+    schemaRoot,
+  } = opts);
+  const { resolveOptions } = parseComplianceSelection(args);
 
   const agentArg = positionalArgs[0];
   const storyboardId = positionalArgs[1];
@@ -4765,7 +4843,9 @@ async function handleStoryboardStepCmd(args) {
     ...(contributions && { contributions }),
     request,
     ...(complianceVersion && { adcpVersion: complianceVersion }),
+    ...(opts.complianceDir && { complianceDir: opts.complianceDir }),
     ...(schemaRoot && { schemaRoot }),
+    ...(opts.loadedTestKit !== undefined && { test_kit: opts.loadedTestKit }),
     ...buildResolvedAuthOption({
       resolvedAuth,
       resolvedAuthScheme,

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -4762,15 +4762,7 @@ async function runFullAssessment(agentArg, rawArgs, parsedOpts) {
 async function handleStoryboardStepCmd(args) {
   const { getComplianceStoryboardById, runStoryboardStep } = await import('../dist/lib/testing/storyboard/index.js');
   let opts = parseAgentOptions(args);
-  let {
-    authToken,
-    authScheme,
-    protocolFlag,
-    jsonOutput,
-    positionalArgs,
-    complianceVersion,
-    schemaRoot,
-  } = opts;
+  let { authToken, authScheme, protocolFlag, jsonOutput, positionalArgs, complianceVersion, schemaRoot } = opts;
 
   enforceStrictFlags(args, warnRemovedFlags(args));
 
@@ -4782,15 +4774,7 @@ async function handleStoryboardStepCmd(args) {
     exitTestKitSelectionError(err, jsonOutput);
   }
 
-  ({
-    authToken,
-    authScheme,
-    protocolFlag,
-    jsonOutput,
-    positionalArgs,
-    complianceVersion,
-    schemaRoot,
-  } = opts);
+  ({ authToken, authScheme, protocolFlag, jsonOutput, positionalArgs, complianceVersion, schemaRoot } = opts);
   const { resolveOptions } = parseComplianceSelection(args);
 
   const agentArg = positionalArgs[0];

--- a/src/lib/testing/compliance/comply.ts
+++ b/src/lib/testing/compliance/comply.ts
@@ -587,6 +587,8 @@ export interface ComplyOptions extends TestOptions {
   complianceDir?: string;
   /** Explicit schema bundle root to pair with the selected compliance cache. */
   schemaRoot?: string;
+  /** CLI source path for an explicit test kit, preserved in generated fix commands. */
+  testKitPath?: string;
   /** Scoped hosted stable-line alias for prerelease-backed compliance caches. */
   hostedStableLineAlias?: string;
 }
@@ -1004,6 +1006,7 @@ export function extractFailures(
     complianceDir?: string;
     schemaRoot?: string;
     hostedStableLineAlias?: string;
+    testKitPath?: string;
   } = {}
 ): ComplianceFailure[] {
   const failures: ComplianceFailure[] = [];
@@ -1098,6 +1101,7 @@ function buildFixCommand(
     complianceDir?: string;
     schemaRoot?: string;
     hostedStableLineAlias?: string;
+    testKitPath?: string;
   }
 ): string {
   const parts = ['adcp', 'storyboard', 'step', agentRef, storyboardId, stepId, '--json'];
@@ -1105,6 +1109,7 @@ function buildFixCommand(
   if (options.complianceDir) parts.push('--compliance-dir', options.complianceDir);
   if (options.schemaRoot) parts.push('--schema-root', options.schemaRoot);
   if (options.hostedStableLineAlias) parts.push('--hosted-stable-line-alias', options.hostedStableLineAlias);
+  if (options.testKitPath) parts.push('--test-kit', options.testKitPath);
   return parts.map(shellArg).join(' ');
 }
 
@@ -1479,6 +1484,7 @@ async function complyImpl(agentUrl: string, options: ComplyOptions): Promise<Com
       ...(complianceDir !== undefined && { complianceDir }),
       ...(schemaRoot !== undefined && { schemaRoot }),
       ...(hostedStableLineAlias !== undefined && { hostedStableLineAlias }),
+      ...(options.testKitPath !== undefined && { testKitPath: options.testKitPath }),
     });
 
     // Aggregate notices from all storyboard runs. Dedup is by `code`, or by
@@ -1760,6 +1766,7 @@ async function runWithDegradedProfile(
     ...(options.complianceDir !== undefined && { complianceDir: options.complianceDir }),
     ...(options.schemaRoot !== undefined && { schemaRoot: options.schemaRoot }),
     ...(options.hostedStableLineAlias !== undefined && { hostedStableLineAlias: options.hostedStableLineAlias }),
+    ...(options.testKitPath !== undefined && { testKitPath: options.testKitPath }),
   });
 
   // Scenario detail is canonical under `tracks`; `tested_tracks` is a

--- a/src/lib/testing/storyboard/compliance.ts
+++ b/src/lib/testing/storyboard/compliance.ts
@@ -16,6 +16,7 @@ import { ADCPError } from '../../errors';
 import { isAdcpVersionSupported } from '../../utils/adcp-version-config';
 import { hasSchemaBundle, resolveBundleKey } from '../../validation/schema-loader';
 import { synthesizeRequestSigningSteps } from './request-signing/synthesize';
+import { markStoryboardComplianceRoot } from './provenance';
 import type { RunnerSelectionResult, Storyboard } from './types';
 
 /**
@@ -533,11 +534,23 @@ function loadStoryboardsFromDir(dir: string): Storyboard[] {
 /** Load storyboards for a single bundle (universal YAML file, domain dir, or specialism dir). */
 export function loadBundleStoryboards(ref: BundleRef): Storyboard[] {
   const raw = ref.kind === 'universal' ? safeLoadUniversal(ref.path) : loadStoryboardsFromDir(ref.path);
-  return raw.map(sb => annotateStoryboardVersion(postProcessStoryboard(sb), ref.adcp_version));
+  const complianceDir = dirname(dirname(ref.path));
+  return raw.map(sb => annotateStoryboardVersion(postProcessStoryboard(sb), ref.adcp_version, complianceDir));
 }
 
-function annotateStoryboardVersion(storyboard: Storyboard, adcpVersion: string | undefined): Storyboard {
-  return adcpVersion === undefined ? storyboard : { ...storyboard, adcp_version: adcpVersion };
+function annotateStoryboardVersion(
+  storyboard: Storyboard,
+  adcpVersion: string | undefined,
+  complianceDir: string
+): Storyboard {
+  return markStoryboardComplianceRoot(
+    {
+      ...storyboard,
+      ...(adcpVersion !== undefined && { adcp_version: adcpVersion }),
+      compliance_dir: complianceDir,
+    },
+    complianceDir
+  );
 }
 
 function safeLoadUniversal(path: string): Storyboard[] {

--- a/src/lib/testing/storyboard/loader.ts
+++ b/src/lib/testing/storyboard/loader.ts
@@ -29,6 +29,11 @@ export function parseStoryboard(yamlContent: string): Storyboard {
   if (!parsed?.id || !parsed?.phases) {
     throw new Error('Invalid storyboard YAML: missing required fields (id, phases)');
   }
+  if (Object.prototype.hasOwnProperty.call(parsed, 'compliance_dir')) {
+    throw new Error(
+      'Invalid storyboard YAML: compliance_dir is loader-owned runtime provenance; select an external cache with runner options instead.'
+    );
+  }
   for (const phase of parsed.phases) {
     // Specialism YAMLs may declare a phase with no `steps:` — the steps are
     // synthesized at runtime from fixtures (see request-signing/synthesize.ts).

--- a/src/lib/testing/storyboard/provenance.ts
+++ b/src/lib/testing/storyboard/provenance.ts
@@ -1,0 +1,20 @@
+import type { Storyboard } from './types';
+
+/**
+ * Loader-owned compliance provenance.
+ *
+ * Storyboard YAML is data, not authority to select arbitrary local filesystem
+ * roots. Keep the trusted cache root out-of-band so an ad-hoc `--file`
+ * storyboard cannot forge the public `compliance_dir` diagnostic field and
+ * cause bundle-relative fixtures or credentials to be read from elsewhere.
+ */
+const complianceRoots = new WeakMap<object, string>();
+
+export function markStoryboardComplianceRoot<T extends Storyboard>(storyboard: T, complianceDir: string): T {
+  complianceRoots.set(storyboard, complianceDir);
+  return storyboard;
+}
+
+export function trustedStoryboardComplianceRoot(storyboard: object): string | undefined {
+  return complianceRoots.get(storyboard);
+}

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -5291,8 +5291,13 @@ async function executeStep(
   // Determine pass/fail — inverted when expect_error is set
   let passed: boolean;
   if (step.expect_error) {
-    // Step passes when the task fails (returns an error)
-    passed = !taskResult?.success || !!stepResult.error;
+    // Raw protocol probes can succeed at the transport layer while carrying
+    // a controller-level rejection in their structured payload. Treat the
+    // payload's explicit failure signal as the expected error; authored
+    // validations below still verify that it is the *right* rejection.
+    const responsePayload = taskResult?.data as { success?: unknown } | undefined;
+    const payloadReportsFailure = responsePayload?.success === false;
+    passed = !taskResult?.success || !!stepResult.error || payloadReportsFailure;
   } else if (crossResponses) {
     // Parallel-dispatch step: pass/fail is driven by the cross-response
     // set, not the representative arm. The representative is pinned to

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -80,8 +80,9 @@ import {
   generateRandomInvalidJwt,
 } from './probes';
 import { readBrandJsonUrl } from '../../signing/agent-resolver/capabilities-types';
-import { validateTestKit } from './test-kit';
+import { resolveDeclaredTestKit, validateTestKit } from './test-kit';
 import { validateStoryboardShape } from './loader';
+import { trustedStoryboardComplianceRoot } from './provenance';
 import { probeRequestSigningVector } from './request-signing/probe-dispatch';
 import { createWebhookReceiver, type WebhookReceiver, type WebhookWaitResult } from './webhook-receiver';
 import { WEBHOOK_ASSERTION_TASKS, armWebhookAssertions, executeWebhookAssertionStep } from './webhook-assertions';
@@ -220,7 +221,11 @@ export function applyStoryboardVersionOptions(
   storyboard: Storyboard,
   options: StoryboardRunOptions
 ): StoryboardRunOptions {
-  return applyAdcpVersionRunOptions(storyboard.adcp_version, options);
+  const versioned = applyAdcpVersionRunOptions(storyboard.adcp_version, options);
+  const mayInheritStoryboardDir = options.adcpVersion === undefined || options.adcpVersion === storyboard.adcp_version;
+  const complianceDir =
+    versioned.complianceDir ?? (mayInheritStoryboardDir ? trustedStoryboardComplianceRoot(storyboard) : undefined);
+  return complianceDir && versioned.complianceDir !== complianceDir ? { ...versioned, complianceDir } : versioned;
 }
 
 export function applyAdcpVersionRunOptions(
@@ -1191,6 +1196,11 @@ export async function runStoryboard(
   return withMCPConnectionScope(
     async () => {
       options = applyStoryboardVersionOptions(storyboard, options);
+      // adcp#6735 — a declared prerequisites.test_kit is a loading directive,
+      // not decoration: resolve it into options.test_kit (caller-supplied
+      // kits win) so from_test_kit / $test_kit.* references get the
+      // credential the storyboard was authored against.
+      options = resolveDeclaredTestKit(storyboard, options);
       options = { ...options, transport: normalizeTransportOptions(options.transport) };
       const schemaRoot = getRunSchemaRoot(options);
       if (schemaRoot) {
@@ -4228,6 +4238,9 @@ export async function runStoryboardStep(
     async () => {
       validateStoryboardShape(storyboard);
       options = applyStoryboardVersionOptions(storyboard, options);
+      // adcp#6735 — same declared-kit resolution as runStoryboard, so the
+      // printed fix_command path exercises the step with its real credential.
+      options = resolveDeclaredTestKit(storyboard, options);
       const schemaRoot = getRunSchemaRoot(options);
       if (schemaRoot) {
         return await withExternalSchemaRoot(schemaRoot.adcpVersion, schemaRoot.schemaRoot, () =>
@@ -4834,8 +4847,26 @@ async function executeStep(
   // Missing-field vectors stay on the SDK transport with the skip flags below
   // so Streamable HTTP session setup completes before the malformed tool call
   // reaches the seller handler.
-  const rawProbeHeaders: Record<string, string> | undefined =
-    step.auth !== undefined ? authHeadersForStep(step.auth, options) : undefined;
+  let rawProbeHeaders: Record<string, string> | undefined;
+  try {
+    rawProbeHeaders = step.auth !== undefined ? authHeadersForStep(step.auth, options) : undefined;
+  } catch (err) {
+    // adcp#6735 — an unresolvable from_test_kit credential is a step-level
+    // configuration failure with an explicit message, never a silent
+    // unauthenticated probe (and never a whole-run crash).
+    return {
+      step_id: step.id,
+      phase_id: phaseId,
+      title: step.title,
+      task: step.task,
+      passed: false,
+      duration_ms: 0,
+      validations: [],
+      context,
+      error: `Step auth configuration error: ${err instanceof Error ? err.message : String(err)}`,
+      extraction: { path: 'none' },
+    };
+  }
   const useRawProbe = rawProbeHeaders !== undefined;
 
   let taskResult: TaskResult | undefined;
@@ -7234,6 +7265,18 @@ function authHeadersForStep(directive: StepAuthDirective, options: StoryboardRun
     value = directive.value;
   } else if ('from_test_kit' in directive && directive.from_test_kit) {
     value = options.test_kit?.auth?.api_key;
+    if (!value) {
+      // adcp#6735 — hard-fail instead of silently degrading to an
+      // unauthenticated probe: a probe with no credential cannot test a
+      // credential-keyed contract, and the resulting 401 grades a
+      // conformant agent FAIL.
+      throw new Error(
+        'step declares auth.from_test_kit but no test kit with auth.api_key is configured — ' +
+          'declare prerequisites.test_kit and authorize its cache with options.complianceDir ' +
+          '(CLI: --compliance-dir), ' +
+          'or pass options.test_kit (CLI: --test-kit).'
+      );
+    }
   } else if ('value_strategy' in directive && directive.value_strategy) {
     if (directive.value_strategy === 'random_invalid') value = generateRandomInvalidApiKey();
     else if (directive.value_strategy === 'random_invalid_jwt') value = generateRandomInvalidJwt();
@@ -7266,13 +7309,27 @@ function basicAuthHeadersForStep(
     };
   }
 
-  const source =
-    directive.from_test_kit !== undefined
-      ? resolveStepBasicFromTestKit(directive.from_test_kit, options)
-      : directive.basic !== undefined
-        ? directive.basic
-        : directive;
-  if (source === undefined) return {};
+  const usesTestKit =
+    directive.from_test_kit === true ||
+    (typeof directive.from_test_kit === 'string' && directive.from_test_kit.length > 0);
+  const source = usesTestKit
+    ? resolveStepBasicFromTestKit(directive.from_test_kit!, options)
+    : directive.basic !== undefined
+      ? directive.basic
+      : directive;
+  if (source === undefined) {
+    if (usesTestKit) {
+      // adcp#6735 — same hard-fail as the api_key arm: never send an
+      // unauthenticated probe in place of a declared kit credential.
+      throw new Error(
+        'step declares auth.from_test_kit (basic) but no test kit with matching credentials is configured — ' +
+          'declare prerequisites.test_kit and authorize its cache with options.complianceDir ' +
+          '(CLI: --compliance-dir), ' +
+          'or pass options.test_kit (CLI: --test-kit).'
+      );
+    }
+    return {};
+  }
   return { authorization: encodeBasicAuthHeader(source, 'step.auth.basic') };
 }
 

--- a/src/lib/testing/storyboard/test-kit.ts
+++ b/src/lib/testing/storyboard/test-kit.ts
@@ -18,6 +18,9 @@
  */
 
 import type { TestOptions } from '../types';
+import { readFileSync, realpathSync, statSync } from 'node:fs';
+import { join, resolve, sep } from 'node:path';
+import { parse } from 'yaml';
 
 /**
  * AdCP tasks safe to call with unauth / invalid-key credentials during the
@@ -68,9 +71,27 @@ export class TestKitValidationError extends Error {
  * import this directly to reject malformed kits at file-load time.
  */
 export function validateTestKit(testKit: TestOptions['test_kit']): void {
-  if (!testKit) return;
-  const auth = testKit.auth;
-  if (!auth || typeof auth !== 'object') return;
+  const value: unknown = testKit;
+  if (value === undefined) return;
+  if (!isPlainMapping(value)) {
+    throw new TestKitValidationError('test_kit', 'test_kit must be a YAML mapping.');
+  }
+  const auth = value.auth;
+  if (auth === undefined) return;
+  if (!isPlainMapping(auth)) {
+    throw new TestKitValidationError('test_kit.auth', 'test_kit.auth must be a YAML mapping.');
+  }
+
+  const apiKey = auth.api_key;
+  if (
+    apiKey !== undefined &&
+    (typeof apiKey !== 'string' || apiKey.trim().length === 0 || /[^\x20-\x7E]/u.test(apiKey))
+  ) {
+    throw new TestKitValidationError(
+      'test_kit.auth.api_key',
+      'test_kit.auth.api_key must be a non-empty string containing only printable ASCII characters.'
+    );
+  }
 
   const probeTask = auth.probe_task;
   if (probeTask === undefined) {
@@ -84,22 +105,142 @@ export function validateTestKit(testKit: TestOptions['test_kit']): void {
   if (typeof probeTask !== 'string' || probeTask.length === 0) {
     throw new TestKitValidationError(
       'test_kit.auth.probe_task',
-      `test_kit.auth.probe_task must be a non-empty string; got ${JSON.stringify(probeTask)}.`
+      'test_kit.auth.probe_task must be a non-empty string selected from the allowlist.'
     );
   }
   if (!PROBE_TASK_ALLOWLIST.includes(probeTask)) {
-    // Truncate + JSON-escape the echoed value so a hostile kit can't poison
-    // the rendered compliance report with control chars, ANSI escapes, or
-    // megabyte strings. Kits are operator-supplied, so this is defensive,
-    // not adversarial — but the error message ends up in shareable reports.
-    const safe = JSON.stringify(probeTask.slice(0, 120));
     throw new TestKitValidationError(
       'test_kit.auth.probe_task',
-      `test_kit.auth.probe_task ${safe} is not in the allowlist. ` +
+      `test_kit.auth.probe_task is not in the allowlist. ` +
         `Allowed tasks (auth-required, read-only, accept empty body): ` +
         `${PROBE_TASK_ALLOWLIST.join(', ')}. ` +
         `Tasks outside this list can 400 on schema validation before auth is evaluated, ` +
         `which would misreport as an agent auth failure.`
     );
   }
+}
+
+function isPlainMapping(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function filesystemErrorCode(err: unknown): string | undefined {
+  return isPlainMapping(err) && typeof err.code === 'string' ? err.code : undefined;
+}
+
+function safeLabel(value: unknown): string {
+  return JSON.stringify(String(value ?? '<unknown>').slice(0, 120));
+}
+
+/**
+ * Resolve a storyboard's declared `prerequisites.test_kit` into
+ * `options.test_kit` (adcontextprotocol/adcp#6735).
+ *
+ * Historically the declaration was decorative: `from_test_kit` / `$test_kit.*`
+ * references read only the caller-supplied `options.test_kit`, so a run
+ * without an explicit kit silently degraded credentialed steps to
+ * unauthenticated probes — grading conformant sellers FAIL on
+ * credential-keyed storyboards (`comply_controller_mode_gate`). This loader
+ * makes the declaration real:
+ *
+ *   - No-op when the storyboard declares no kit, or when the caller already
+ *     supplied `options.test_kit` (caller/hosted-engine configuration wins;
+ *     the hosted engine pre-populates the declared kit itself — see the
+ *     server-side half of adcp#6735).
+ *   - Otherwise loads `<compliance cache>/<declared path>`, validates it
+ *     with the same invariants as a caller-supplied kit, and returns amended
+ *     options. Loading requires an explicit caller-selected complianceDir or
+ *     loader-attached trusted provenance (which the runner promotes to that
+ *     option); a storyboard-authored version alone grants no filesystem
+ *     authority.
+ *   - A genuinely absent kit is tolerated because external bundles may omit
+ *     kits that none of their steps use. Other filesystem faults, invalid
+ *     YAML, and invalid kit shapes throw instead of degrading silently.
+ */
+export function resolveDeclaredTestKit<
+  O extends { test_kit?: TestOptions['test_kit']; adcpVersion?: string; complianceDir?: string },
+>(storyboard: { id?: string; prerequisites?: { test_kit?: string } }, options: O): O {
+  const declared = storyboard.prerequisites?.test_kit;
+  if (declared === undefined || options.test_kit !== undefined) return options;
+  if (typeof declared !== 'string' || declared.trim().length === 0) {
+    throw new Error(
+      `storyboard ${safeLabel(storyboard.id)} declares an invalid prerequisites.test_kit path; expected a non-empty string.`
+    );
+  }
+  // Storyboard YAML is data, not authority to read credentials from the SDK's
+  // packaged cache (or ADCP_COMPLIANCE_DIR). Only the caller or the trusted
+  // compliance loader may select a filesystem root.
+  if (options.complianceDir === undefined) return options;
+  if (typeof options.complianceDir !== 'string' || options.complianceDir.trim().length === 0) {
+    throw new Error(
+      `storyboard ${safeLabel(storyboard.id)} received an invalid complianceDir for its declared test kit; expected a non-empty string.`
+    );
+  }
+
+  const sbId = safeLabel(storyboard.id);
+  const declaredLabel = safeLabel(declared);
+  const cacheDir = resolve(options.complianceDir);
+  const kitPath = resolve(join(cacheDir, declared));
+  // Containment: the declared path comes from cache-shipped YAML; never let
+  // it escape the cache root.
+  if (kitPath !== cacheDir && !kitPath.startsWith(cacheDir + sep)) {
+    throw new Error(
+      `storyboard ${sbId} declares prerequisites.test_kit ${declaredLabel} ` +
+        `which resolves outside the compliance cache root — refusing to load it.`
+    );
+  }
+
+  let physicalCacheDir: string;
+  try {
+    physicalCacheDir = realpathSync(cacheDir);
+  } catch (err) {
+    if (filesystemErrorCode(err) === 'ENOENT') return options;
+    throw new Error(
+      `storyboard ${sbId} could not resolve the compliance cache for declared test kit ${declaredLabel} ` +
+        `(${filesystemErrorCode(err) ?? 'filesystem error'}).`
+    );
+  }
+
+  let physicalKitPath: string;
+  try {
+    physicalKitPath = realpathSync(kitPath);
+  } catch (err) {
+    // A declared kit that genuinely isn't present is tolerated at load time:
+    // storyboards may declare a kit whose auth no step uses. Steps that do
+    // require it hard-fail individually before any request reaches the agent.
+    if (filesystemErrorCode(err) === 'ENOENT') return options;
+    throw new Error(
+      `storyboard ${sbId} could not resolve declared test kit ${declaredLabel} ` +
+        `(${filesystemErrorCode(err) ?? 'filesystem error'}).`
+    );
+  }
+  if (physicalKitPath !== physicalCacheDir && !physicalKitPath.startsWith(physicalCacheDir + sep)) {
+    throw new Error(
+      `storyboard ${sbId} declares prerequisites.test_kit ${declaredLabel} ` +
+        `which resolves outside the physical compliance cache root — refusing to load it.`
+    );
+  }
+
+  let raw: string;
+  try {
+    if (!statSync(physicalKitPath).isFile()) {
+      throw new Error('not a regular file');
+    }
+    raw = readFileSync(physicalKitPath, 'utf8');
+  } catch (err) {
+    throw new Error(
+      `storyboard ${sbId} could not read declared test kit ${declaredLabel} ` +
+        `(${filesystemErrorCode(err) ?? 'not a regular file'}).`
+    );
+  }
+  let kit: TestOptions['test_kit'];
+  try {
+    kit = parse(raw) as TestOptions['test_kit'];
+  } catch {
+    throw new Error(
+      `storyboard ${sbId} declares prerequisites.test_kit ${declaredLabel}, but the file is not valid YAML.`
+    );
+  }
+  validateTestKit(kit);
+  return { ...options, test_kit: kit };
 }

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -1600,6 +1600,8 @@ export interface TrustedMatchPublisherAuthRunner {
 }
 
 export interface StoryboardRunOptions extends TestOptions {
+  /** Caller-selected compliance cache root for bundle-scoped test kits. */
+  complianceDir?: string;
   /** Initial context (e.g., from a previous step invocation) */
   context?: StoryboardContext;
   /**

--- a/test/lib/cli-storyboard-file-flag.test.js
+++ b/test/lib/cli-storyboard-file-flag.test.js
@@ -1,9 +1,12 @@
 const { test, before, after } = require('node:test');
 const assert = require('node:assert');
-const { spawnSync } = require('node:child_process');
+const { spawn, spawnSync } = require('node:child_process');
+const http = require('node:http');
 const { writeFileSync, unlinkSync, mkdtempSync, mkdirSync, rmSync } = require('node:fs');
 const path = require('node:path');
 const os = require('node:os');
+const { McpServer } = require('@modelcontextprotocol/sdk/server/mcp.js');
+const { StreamableHTTPServerTransport } = require('@modelcontextprotocol/sdk/server/streamableHttp.js');
 
 const CLI = path.resolve(__dirname, '../../bin/adcp.js');
 
@@ -42,6 +45,20 @@ after(() => {
 
 function runCli(args) {
   return spawnSync('node', [CLI, ...args], { encoding: 'utf8' });
+}
+
+function runCliAsync(args, env) {
+  return new Promise((resolve, reject) => {
+    const child = spawn('node', [CLI, ...args], { env: { ...process.env, ...env } });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', chunk => (stdout += chunk));
+    child.stderr.on('data', chunk => (stderr += chunk));
+    child.on('error', reject);
+    child.on('close', status => resolve({ status, stdout, stderr }));
+  });
 }
 
 function writeComplianceIndex(complianceDir, version) {
@@ -109,4 +126,178 @@ test('--compliance-version fails before dry-run when matching schemas are unavai
     else process.env.ADCP_SCHEMA_ROOT = oldSchemaRoot;
     rmSync(tempRoot, { recursive: true, force: true });
   }
+});
+
+test('--compliance-version rejects an environment cache from a different protocol line', () => {
+  const tempRoot = mkdtempSync(path.join(os.tmpdir(), 'adcp-cli-compliance-version-mismatch-'));
+  const complianceDir = path.join(tempRoot, 'compliance-cache', '3.1.13');
+  const oldComplianceDir = process.env.ADCP_COMPLIANCE_DIR;
+  try {
+    process.env.ADCP_COMPLIANCE_DIR = complianceDir;
+    writeComplianceIndex(complianceDir, '3.1.13');
+
+    const result = runCli([
+      'storyboard',
+      'run',
+      'test-mcp',
+      '--file',
+      scenarioPath,
+      '--dry-run',
+      '--compliance-version',
+      '3.2.0-beta.5',
+    ]);
+
+    assert.strictEqual(result.status, 2);
+    assert.match(result.stderr, /--compliance-version 3\.2\.0-beta\.5/);
+    assert.match(result.stderr, /cache that declares AdCP 3\.1\.13/);
+  } finally {
+    if (oldComplianceDir === undefined) delete process.env.ADCP_COMPLIANCE_DIR;
+    else process.env.ADCP_COMPLIANCE_DIR = oldComplianceDir;
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('multi-target --file modes infer version and schemas from --compliance-dir before dry-run', () => {
+  const tempRoot = mkdtempSync(path.join(os.tmpdir(), 'adcp-cli-multi-file-schema-'));
+  const complianceDir = path.join(tempRoot, 'compliance-cache', '9.9.0-beta.1');
+  try {
+    writeComplianceIndex(complianceDir, '9.9.0-beta.1');
+    const common = [
+      '--protocol',
+      'mcp',
+      '--allow-http',
+      '--file',
+      scenarioPath,
+      '--compliance-dir',
+      complianceDir,
+      '--dry-run',
+    ];
+    const multiInstance = runCli([
+      'storyboard',
+      'run',
+      '--url',
+      'http://127.0.0.1:1/mcp',
+      '--url',
+      'http://127.0.0.1:2/mcp',
+      ...common,
+    ]);
+    assert.strictEqual(multiInstance.status, 2);
+    assert.match(multiInstance.stderr, /matching schemas|--schema-root|installed default schemas/);
+
+    const routed = runCli([
+      'storyboard',
+      'run',
+      '--agent',
+      'default=http://127.0.0.1:1/mcp',
+      '--default-agent',
+      'default',
+      ...common,
+    ]);
+    assert.strictEqual(routed.status, 2);
+    assert.match(routed.stderr, /matching schemas|--schema-root|installed default schemas/);
+  } finally {
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('--file forwards explicit cache authority for a declared test kit', { timeout: 60_000 }, async t => {
+  const fixtureRoot = mkdtempSync(path.join(os.tmpdir(), 'adcp-cli-declared-kit-'));
+  const complianceDir = path.join(fixtureRoot, 'compliance');
+  const kitDir = path.join(complianceDir, 'test-kits');
+  const storyboardPath = path.join(fixtureRoot, 'storyboard.yaml');
+  const cliHome = path.join(fixtureRoot, 'home');
+  mkdirSync(kitDir, { recursive: true });
+  mkdirSync(cliHome, { recursive: true });
+  writeComplianceIndex(complianceDir, '3.2.0-beta.5');
+  writeFileSync(
+    path.join(kitDir, 'live.yaml'),
+    ['auth:', '  api_key: "cli-declared-kit-key"', '  probe_task: list_creatives', ''].join('\n')
+  );
+  writeFileSync(
+    storyboardPath,
+    [
+      'id: cli-declared-kit',
+      'title: CLI declared-kit forwarding',
+      'protocol: media-buy',
+      'prerequisites:',
+      '  test_kit: test-kits/live.yaml',
+      'phases:',
+      '  - id: phase-1',
+      '    title: Authenticated capabilities',
+      '    steps:',
+      '      - id: step-1',
+      '        title: Authenticated capabilities',
+      '        task: get_adcp_capabilities',
+      '        auth:',
+      '          type: api_key',
+      '          from_test_kit: true',
+      '        request: {}',
+      '',
+    ].join('\n')
+  );
+
+  const authorizations = [];
+  const server = http.createServer(async (req, res) => {
+    authorizations.push(req.headers.authorization);
+    const mcp = new McpServer({ name: 'cli-declared-kit-capture', version: '1.0.0' });
+    mcp.registerTool('get_adcp_capabilities', { inputSchema: {} }, async () => ({
+      content: [{ type: 'text', text: '{}' }],
+      structuredContent: {
+        success: true,
+        adcp: { major_versions: [3], idempotency: { supported: true, replay_ttl_seconds: 86400 } },
+        supported_protocols: ['media_buy'],
+        specialisms: [],
+      },
+    }));
+    const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+    try {
+      await mcp.connect(transport);
+      await transport.handleRequest(req, res);
+    } finally {
+      await mcp.close();
+    }
+  });
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  t.after(async () => {
+    if (typeof server.closeAllConnections === 'function') server.closeAllConnections();
+    await new Promise(resolve => server.close(resolve));
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  });
+
+  const run = async (selectionArgs, env = {}) => {
+    authorizations.length = 0;
+    return runCliAsync(
+      [
+        'storyboard',
+        'run',
+        `http://127.0.0.1:${server.address().port}/mcp`,
+        '--protocol',
+        'mcp',
+        '--allow-http',
+        '--file',
+        storyboardPath,
+        ...selectionArgs,
+        '--soft-fail',
+      ],
+      { HOME: cliHome, ADCP_SKIP_VERSION_CHECK: '1', ...env }
+    );
+  };
+
+  const explicitDir = await run(['--compliance-dir', complianceDir], { ADCP_COMPLIANCE_DIR: '' });
+  assert.strictEqual(explicitDir.status, 0, explicitDir.stderr);
+  assert.ok(authorizations.includes('Bearer cli-declared-kit-key'));
+
+  const versionOnly = await run(['--compliance-version', '3.2.0-beta.5'], {
+    ADCP_COMPLIANCE_DIR: complianceDir,
+  });
+  assert.strictEqual(versionOnly.status, 0, versionOnly.stderr);
+  assert.equal(
+    authorizations.includes('Bearer cli-declared-kit-key'),
+    false,
+    '--compliance-version must not authorize an ad-hoc storyboard to transmit cache credentials'
+  );
+  assert.match(
+    `${versionOnly.stdout}\n${versionOnly.stderr}`,
+    /no test kit with auth\.api_key is configured|no credential was resolved/
+  );
 });

--- a/test/lib/cli-storyboard-file-flag.test.js
+++ b/test/lib/cli-storyboard-file-flag.test.js
@@ -208,7 +208,7 @@ test('--file forwards explicit cache authority for a declared test kit', { timeo
   const cliHome = path.join(fixtureRoot, 'home');
   mkdirSync(kitDir, { recursive: true });
   mkdirSync(cliHome, { recursive: true });
-  writeComplianceIndex(complianceDir, '3.2.0-beta.5');
+  writeComplianceIndex(complianceDir, '3.1.15');
   writeFileSync(
     path.join(kitDir, 'live.yaml'),
     ['auth:', '  api_key: "cli-declared-kit-key"', '  probe_task: list_creatives', ''].join('\n')
@@ -287,7 +287,7 @@ test('--file forwards explicit cache authority for a declared test kit', { timeo
   assert.strictEqual(explicitDir.status, 0, explicitDir.stderr);
   assert.ok(authorizations.includes('Bearer cli-declared-kit-key'));
 
-  const versionOnly = await run(['--compliance-version', '3.2.0-beta.5'], {
+  const versionOnly = await run(['--compliance-version', '3.1.15'], {
     ADCP_COMPLIANCE_DIR: complianceDir,
   });
   assert.strictEqual(versionOnly.status, 0, versionOnly.stderr);

--- a/test/lib/cli-test-kit-compliance-version.test.js
+++ b/test/lib/cli-test-kit-compliance-version.test.js
@@ -326,6 +326,78 @@ describe('storyboard run --test-kit compliance-line selection', () => {
     }
   });
 
+  test('malformed test-kit YAML never echoes source credentials', () => {
+    const fixture = createTestKitCache('3.2.0-beta.5');
+    const secret = 'sk-cli-secret-that-must-not-reach-stderr';
+    writeFileSync(fixture.testKitPath, `auth: [${secret}`);
+    try {
+      const result = runCli([
+        'storyboard',
+        'run',
+        'https://127.0.0.1:1/mcp',
+        '--protocol',
+        'mcp',
+        '--test-kit',
+        fixture.testKitPath,
+      ]);
+
+      assert.strictEqual(result.status, 2);
+      assert.match(result.stderr, /failed to parse test-kit.*as YAML/);
+      assert.equal(result.stderr.includes(secret), false);
+    } finally {
+      rmSync(fixture.tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('a falsy parsed --test-kit is forwarded and rejected instead of falling back to disk', () => {
+    const fixture = createTestKitCache('3.2.0-beta.5');
+    writeFileSync(fixture.testKitPath, 'null\n');
+    try {
+      const result = runCli([
+        'storyboard',
+        'run',
+        'https://127.0.0.1:1/mcp',
+        '--protocol',
+        'mcp',
+        '--test-kit',
+        fixture.testKitPath,
+        '--file',
+        fixture.storyboardPath,
+      ]);
+
+      assert.strictEqual(result.status, 1);
+      assert.match(result.stderr, /test_kit must be a YAML mapping/);
+      assert.doesNotMatch(result.stderr, /ECONNREFUSED|Failed to detect protocol/);
+    } finally {
+      rmSync(fixture.tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('storyboard step forwards an explicit test-kit override instead of silently ignoring it', () => {
+    const tempRoot = mkdtempSync(path.join(os.tmpdir(), 'adcp-step-test-kit-'));
+    const testKitPath = path.join(tempRoot, 'override.yaml');
+    writeFileSync(testKitPath, 'null\n');
+    try {
+      const result = runCli([
+        'storyboard',
+        'step',
+        'https://127.0.0.1:1/mcp',
+        'comply_controller_mode_gate',
+        'deny_live_caller',
+        '--protocol',
+        'mcp',
+        '--test-kit',
+        testKitPath,
+      ]);
+
+      assert.strictEqual(result.status, 1);
+      assert.match(result.stderr, /test_kit must be a YAML mapping/);
+      assert.doesNotMatch(result.stderr, /ECONNREFUSED|Failed to detect protocol/);
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   test('help documents --test-kit and its relationship to --compliance-version', () => {
     const result = runCli(['storyboard', 'run', '--help']);
     assert.strictEqual(result.status, 0, result.stderr);

--- a/test/lib/cli-test-kit-compliance-version.test.js
+++ b/test/lib/cli-test-kit-compliance-version.test.js
@@ -327,7 +327,7 @@ describe('storyboard run --test-kit compliance-line selection', () => {
   });
 
   test('malformed test-kit YAML never echoes source credentials', () => {
-    const fixture = createTestKitCache('3.2.0-beta.5');
+    const fixture = createTestKitCache('3.1.15');
     const secret = 'sk-cli-secret-that-must-not-reach-stderr';
     writeFileSync(fixture.testKitPath, `auth: [${secret}`);
     try {
@@ -350,7 +350,7 @@ describe('storyboard run --test-kit compliance-line selection', () => {
   });
 
   test('a falsy parsed --test-kit is forwarded and rejected instead of falling back to disk', () => {
-    const fixture = createTestKitCache('3.2.0-beta.5');
+    const fixture = createTestKitCache('3.1.15');
     writeFileSync(fixture.testKitPath, 'null\n');
     try {
       const result = runCli([

--- a/test/lib/storyboard-controller-mode-gate.test.js
+++ b/test/lib/storyboard-controller-mode-gate.test.js
@@ -1,0 +1,130 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('node:http');
+
+const { runStoryboard } = require('../../dist/lib/testing/storyboard/runner');
+
+const LIVE_KEY = 'demo-live-account-key';
+
+function modeGateStoryboard() {
+  return {
+    id: 'comply_controller_mode_gate',
+    version: '1.0.0',
+    title: 'Controller mode gate',
+    category: 'security',
+    summary: '',
+    narrative: '',
+    agent: { interaction_model: '*', capabilities: [] },
+    caller: { role: 'buyer_agent' },
+    phases: [
+      {
+        id: 'live_mode_denial',
+        title: 'Live-mode denial',
+        steps: [
+          {
+            id: 'deny_live_caller',
+            title: 'Controller rejects a live-mode account',
+            task: 'comply_test_controller',
+            auth: { type: 'api_key', from_test_kit: true },
+            expect_error: true,
+            sample_request: {
+              scenario: 'force_creative_status',
+              params: { creative_id: 'comply-live-mode-probe-000', status: 'approved' },
+              // The controller request schema requires sandbox:true. The
+              // seller determines live mode from this authenticated principal.
+              account: { sandbox: true },
+              context: { correlation_id: 'comply_controller_mode_gate--deny_live_caller' },
+            },
+            validations: [
+              { check: 'field_value', path: 'success', allowed_values: [false], description: 'request rejected' },
+              { check: 'field_value', path: 'error', allowed_values: ['FORBIDDEN'], description: 'live mode denied' },
+              { check: 'field_present', path: 'context', description: 'context echoed' },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+test('mode-gate payload rejection passes expect_error after a successful MCP call', async () => {
+  const calls = [];
+  const server = http.createServer(async (req, res) => {
+    const chunks = [];
+    for await (const chunk of req) chunks.push(chunk);
+    const rpc = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+
+    if (rpc.method === 'initialize') {
+      res.writeHead(200, { 'content-type': 'application/json', 'mcp-session-id': 'mode-gate-test' });
+      res.end(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: rpc.id,
+          result: {
+            protocolVersion: '2025-06-18',
+            capabilities: {},
+            serverInfo: { name: 'mode-gate-capture', version: '1.0.0' },
+          },
+        })
+      );
+      return;
+    }
+    if (rpc.method === 'notifications/initialized') {
+      res.writeHead(202);
+      res.end();
+      return;
+    }
+
+    calls.push({
+      authorization: req.headers.authorization,
+      name: rpc.params?.name,
+      args: rpc.params?.arguments,
+    });
+    const payload = { success: false, error: 'FORBIDDEN', context: rpc.params?.arguments?.context };
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: rpc.id,
+        result: {
+          structuredContent: payload,
+          content: [{ type: 'text', text: JSON.stringify(payload) }],
+        },
+      })
+    );
+  });
+
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  try {
+    const address = server.address();
+    const result = await runStoryboard(`http://127.0.0.1:${address.port}/mcp`, modeGateStoryboard(), {
+      protocol: 'mcp',
+      allow_http: true,
+      agentTools: ['comply_test_controller'],
+      _profile: { name: 'mode-gate-capture', tools: [{ name: 'comply_test_controller' }] },
+      _client: {
+        getAgentInfo: async () => ({ name: 'mode-gate-capture', tools: [{ name: 'comply_test_controller' }] }),
+      },
+      test_kit: {
+        sandbox: false,
+        auth: { api_key: LIVE_KEY, probe_task: 'list_creatives' },
+      },
+    });
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].authorization, `Bearer ${LIVE_KEY}`);
+    assert.equal(calls[0].name, 'comply_test_controller');
+    assert.equal(calls[0].args.account.sandbox, true);
+    assert.equal(calls[0].args.scenario, 'force_creative_status');
+
+    const step = result.phases[0].steps[0];
+    assert.equal(step.passed, true, JSON.stringify(step));
+    assert.equal(
+      step.validations.every(validation => validation.passed),
+      true
+    );
+    assert.equal(result.overall_passed, true);
+  } finally {
+    await new Promise(resolve => server.close(resolve));
+  }
+});

--- a/test/lib/storyboard-declared-test-kit.test.js
+++ b/test/lib/storyboard-declared-test-kit.test.js
@@ -1,0 +1,468 @@
+// adcp#6735 — a storyboard's declared `prerequisites.test_kit` is a runner
+// loading directive, not decoration. These tests cover the resolution matrix:
+// declared kit auto-loads from the compliance cache; caller-supplied
+// options.test_kit wins; an unresolvable from_test_kit credential fails the
+// step with an explicit configuration error instead of silently sending an
+// unauthenticated probe; and declared paths cannot escape the cache root.
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const { mkdtempSync, mkdirSync, writeFileSync, rmSync, symlinkSync } = require('node:fs');
+const { join } = require('node:path');
+const os = require('node:os');
+
+const {
+  runStoryboard,
+  runStoryboardStep,
+  applyStoryboardVersionOptions,
+} = require('../../dist/lib/testing/storyboard/runner');
+const { resolveDeclaredTestKit, validateTestKit } = require('../../dist/lib/testing/storyboard/test-kit');
+const { loadBundleStoryboards } = require('../../dist/lib/testing/storyboard/compliance');
+const { parseStoryboard } = require('../../dist/lib/testing/storyboard/loader');
+
+const KIT_KEY = 'demo-declared-kit-key';
+
+function storyboardWithKit(prerequisites) {
+  return {
+    id: 'declared_kit_probe',
+    version: '1.0.0',
+    title: 'Declared-kit credential delivery',
+    category: 'security',
+    summary: '',
+    narrative: '',
+    agent: { interaction_model: '*', capabilities: [] },
+    caller: { role: 'buyer_agent' },
+    ...(prerequisites ? { prerequisites } : {}),
+    phases: [
+      {
+        id: 'probe',
+        title: 'Credentialed probe',
+        steps: [
+          {
+            id: 'kit_auth_step',
+            title: 'Step authenticates with the kit credential',
+            task: 'comply_test_controller',
+            auth: { type: 'api_key', from_test_kit: true },
+            expect_error: true,
+            sample_request: {
+              scenario: 'force_creative_status',
+              params: { creative_id: 'probe-000', status: 'approved' },
+              account: { sandbox: true },
+              context: { correlation_id: 'declared_kit_probe--kit_auth_step' },
+            },
+            validations: [
+              { check: 'field_value', path: 'success', allowed_values: [false], description: 'request rejected' },
+              { check: 'field_value', path: 'error', allowed_values: ['FORBIDDEN'], description: 'denied' },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function makeCacheDirWithKit() {
+  const dir = mkdtempSync(join(os.tmpdir(), 'adcp-declared-kit-'));
+  mkdirSync(join(dir, 'test-kits'), { recursive: true });
+  writeFileSync(
+    join(dir, 'test-kits', 'live.yaml'),
+    ['auth:', `  api_key: "${KIT_KEY}"`, '  probe_task: list_creatives', ''].join('\n')
+  );
+  return dir;
+}
+
+function captureAgent(calls) {
+  return http.createServer(async (req, res) => {
+    const chunks = [];
+    for await (const chunk of req) chunks.push(chunk);
+    const rpc = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+    if (rpc.method === 'initialize') {
+      res.writeHead(200, { 'content-type': 'application/json', 'mcp-session-id': 'declared-kit-test' });
+      res.end(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: rpc.id,
+          result: {
+            protocolVersion: '2025-06-18',
+            capabilities: {},
+            serverInfo: { name: 'declared-kit-capture', version: '1.0.0' },
+          },
+        })
+      );
+      return;
+    }
+    if (rpc.method === 'notifications/initialized') {
+      res.writeHead(202);
+      res.end();
+      return;
+    }
+    calls.push({ authorization: req.headers.authorization, name: rpc.params?.name });
+    const payload = { success: false, error: 'FORBIDDEN', context: rpc.params?.arguments?.context };
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: rpc.id,
+        result: { structuredContent: payload, content: [{ type: 'text', text: JSON.stringify(payload) }] },
+      })
+    );
+  });
+}
+
+const RUN_OPTIONS = {
+  protocol: 'mcp',
+  allow_http: true,
+  agentTools: ['comply_test_controller'],
+  _profile: { name: 'declared-kit-capture', tools: [{ name: 'comply_test_controller' }] },
+  _client: {
+    getAgentInfo: async () => ({ name: 'declared-kit-capture', tools: [{ name: 'comply_test_controller' }] }),
+  },
+};
+
+test('declared prerequisites.test_kit auto-loads and its credential reaches the step', async () => {
+  const cacheDir = makeCacheDirWithKit();
+  const calls = [];
+  const server = captureAgent(calls);
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  try {
+    const result = await runStoryboard(
+      `http://127.0.0.1:${server.address().port}/mcp`,
+      storyboardWithKit({ test_kit: 'test-kits/live.yaml' }),
+      { ...RUN_OPTIONS, complianceDir: cacheDir }
+    );
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].authorization, `Bearer ${KIT_KEY}`);
+    assert.equal(result.phases[0].steps[0].passed, true, JSON.stringify(result.phases[0].steps[0]));
+  } finally {
+    await new Promise(resolve => server.close(resolve));
+    rmSync(cacheDir, { recursive: true, force: true });
+  }
+});
+
+test('runStoryboardStep resolves the declared kit used by printed fix commands', async () => {
+  const cacheDir = makeCacheDirWithKit();
+  const calls = [];
+  const server = captureAgent(calls);
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  try {
+    const result = await runStoryboardStep(
+      `http://127.0.0.1:${server.address().port}/mcp`,
+      storyboardWithKit({ test_kit: 'test-kits/live.yaml' }),
+      'kit_auth_step',
+      { ...RUN_OPTIONS, complianceDir: cacheDir }
+    );
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].authorization, `Bearer ${KIT_KEY}`);
+    assert.equal(result.passed, true, JSON.stringify(result));
+  } finally {
+    await new Promise(resolve => server.close(resolve));
+    rmSync(cacheDir, { recursive: true, force: true });
+  }
+});
+
+test('caller-supplied options.test_kit wins over the declared kit', async () => {
+  const cacheDir = makeCacheDirWithKit();
+  const calls = [];
+  const server = captureAgent(calls);
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  try {
+    await runStoryboard(
+      `http://127.0.0.1:${server.address().port}/mcp`,
+      storyboardWithKit({ test_kit: 'test-kits/live.yaml' }),
+      {
+        ...RUN_OPTIONS,
+        complianceDir: cacheDir,
+        test_kit: { auth: { api_key: 'caller-override-key', probe_task: 'list_creatives' } },
+      }
+    );
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].authorization, 'Bearer caller-override-key');
+  } finally {
+    await new Promise(resolve => server.close(resolve));
+    rmSync(cacheDir, { recursive: true, force: true });
+  }
+});
+
+test('from_test_kit with no kit anywhere fails the step, never sends an unauthenticated probe', async () => {
+  const calls = [];
+  const server = captureAgent(calls);
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  try {
+    const result = await runStoryboard(
+      `http://127.0.0.1:${server.address().port}/mcp`,
+      storyboardWithKit(undefined),
+      RUN_OPTIONS
+    );
+    const step = result.phases[0].steps[0];
+    assert.equal(step.passed, false);
+    assert.match(step.error ?? '', /auth configuration error/i);
+    assert.equal(calls.length, 0, 'no tools/call must reach the agent without a credential');
+  } finally {
+    await new Promise(resolve => server.close(resolve));
+  }
+});
+
+test('basic-auth from_test_kit with no kit anywhere fails the step, never sends an unauthenticated probe', async () => {
+  const calls = [];
+  const server = captureAgent(calls);
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  try {
+    const storyboard = storyboardWithKit(undefined);
+    storyboard.phases[0].steps[0].auth = { type: 'basic', from_test_kit: true };
+    const result = await runStoryboard(`http://127.0.0.1:${server.address().port}/mcp`, storyboard, RUN_OPTIONS);
+    const step = result.phases[0].steps[0];
+    assert.equal(step.passed, false);
+    assert.match(step.error ?? '', /auth configuration error/i);
+    assert.match(step.error ?? '', /basic/i);
+    assert.equal(calls.length, 0, 'no tools/call must reach the agent without a credential');
+  } finally {
+    await new Promise(resolve => server.close(resolve));
+  }
+});
+
+test('basic-auth from_test_kit false preserves explicit credentials', async () => {
+  const calls = [];
+  const server = captureAgent(calls);
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  try {
+    const storyboard = storyboardWithKit(undefined);
+    storyboard.phases[0].steps[0].auth = {
+      type: 'basic',
+      from_test_kit: false,
+      username: 'explicit-user',
+      password: 'explicit-password',
+    };
+    const result = await runStoryboard(`http://127.0.0.1:${server.address().port}/mcp`, storyboard, RUN_OPTIONS);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].authorization, `Basic ${Buffer.from('explicit-user:explicit-password').toString('base64')}`);
+    assert.equal(result.phases[0].steps[0].passed, true, JSON.stringify(result.phases[0].steps[0]));
+  } finally {
+    await new Promise(resolve => server.close(resolve));
+  }
+});
+
+test('declared kit paths cannot escape the compliance cache root', () => {
+  const cacheDir = makeCacheDirWithKit();
+  try {
+    assert.throws(
+      () =>
+        resolveDeclaredTestKit(
+          { id: 'escape_probe', prerequisites: { test_kit: '../outside.yaml' } },
+          { complianceDir: cacheDir }
+        ),
+      /outside the compliance cache root/
+    );
+  } finally {
+    rmSync(cacheDir, { recursive: true, force: true });
+  }
+});
+
+test('declared kit symlinks cannot escape the physical compliance cache root', () => {
+  const cacheDir = mkdtempSync(join(os.tmpdir(), 'adcp-declared-kit-symlink-cache-'));
+  const outsideDir = makeCacheDirWithKit();
+  try {
+    mkdirSync(join(cacheDir, 'test-kits'), { recursive: true });
+    symlinkSync(join(outsideDir, 'test-kits', 'live.yaml'), join(cacheDir, 'test-kits', 'live.yaml'));
+    assert.throws(
+      () =>
+        resolveDeclaredTestKit(
+          { id: 'symlink_escape_probe', prerequisites: { test_kit: 'test-kits/live.yaml' } },
+          { complianceDir: cacheDir }
+        ),
+      /outside the physical compliance cache root/
+    );
+  } finally {
+    rmSync(cacheDir, { recursive: true, force: true });
+    rmSync(outsideDir, { recursive: true, force: true });
+  }
+});
+
+test('a declared kit path that is not a regular file fails explicitly', () => {
+  const cacheDir = mkdtempSync(join(os.tmpdir(), 'adcp-declared-kit-directory-'));
+  try {
+    mkdirSync(join(cacheDir, 'test-kits', 'directory.yaml'), { recursive: true });
+    assert.throws(
+      () =>
+        resolveDeclaredTestKit(
+          { id: 'directory_probe', prerequisites: { test_kit: 'test-kits/directory.yaml' } },
+          { complianceDir: cacheDir }
+        ),
+      /not a regular file/
+    );
+  } finally {
+    rmSync(cacheDir, { recursive: true, force: true });
+  }
+});
+
+test('a declared kit missing from the cache is tolerated at load time (step-level hard-fail covers users)', () => {
+  const cacheDir = mkdtempSync(join(os.tmpdir(), 'adcp-declared-kit-missing-'));
+  try {
+    const options = { complianceDir: cacheDir };
+    const resolved = resolveDeclaredTestKit(
+      { id: 'missing_kit_probe', prerequisites: { test_kit: 'test-kits/nope.yaml' } },
+      options
+    );
+    assert.equal(resolved.test_kit, undefined);
+  } finally {
+    rmSync(cacheDir, { recursive: true, force: true });
+  }
+});
+
+test('a declared kit that exists but is invalid YAML throws without leaking source or local paths', () => {
+  const cacheDir = mkdtempSync(join(os.tmpdir(), 'adcp-declared-kit-corrupt-'));
+  const secret = 'sk-secret-that-must-not-reach-logs';
+  try {
+    mkdirSync(join(cacheDir, 'test-kits'), { recursive: true });
+    writeFileSync(join(cacheDir, 'test-kits', 'bad.yaml'), `auth: [${secret}`);
+    let error;
+    try {
+      resolveDeclaredTestKit(
+        { id: 'corrupt_kit_probe', prerequisites: { test_kit: 'test-kits/bad.yaml' } },
+        { complianceDir: cacheDir }
+      );
+    } catch (err) {
+      error = err;
+    }
+    assert.ok(error instanceof Error);
+    assert.match(error.message, /not valid YAML/);
+    assert.equal(error.message.includes(secret), false);
+    assert.equal(error.message.includes(cacheDir), false);
+  } finally {
+    rmSync(cacheDir, { recursive: true, force: true });
+  }
+});
+
+test('valid YAML with invalid test-kit shapes fails at the file boundary', () => {
+  const cacheDir = mkdtempSync(join(os.tmpdir(), 'adcp-declared-kit-shape-'));
+  try {
+    mkdirSync(join(cacheDir, 'test-kits'), { recursive: true });
+    writeFileSync(join(cacheDir, 'test-kits', 'scalar.yaml'), 'not-a-mapping\n');
+    assert.throws(
+      () =>
+        resolveDeclaredTestKit(
+          { id: 'scalar_kit_probe', prerequisites: { test_kit: 'test-kits/scalar.yaml' } },
+          { complianceDir: cacheDir }
+        ),
+      /test_kit must be a YAML mapping/
+    );
+    writeFileSync(join(cacheDir, 'test-kits', 'auth-scalar.yaml'), 'auth: not-a-mapping\n');
+    assert.throws(
+      () =>
+        resolveDeclaredTestKit(
+          { id: 'scalar_auth_probe', prerequisites: { test_kit: 'test-kits/auth-scalar.yaml' } },
+          { complianceDir: cacheDir }
+        ),
+      /test_kit.auth must be a YAML mapping/
+    );
+  } finally {
+    rmSync(cacheDir, { recursive: true, force: true });
+  }
+});
+
+test('declared test-kit paths must be non-empty strings', () => {
+  assert.throws(
+    () =>
+      resolveDeclaredTestKit(
+        { id: 'invalid_declaration_probe', prerequisites: { test_kit: 42 } },
+        { complianceDir: os.tmpdir() }
+      ),
+    /expected a non-empty string/
+  );
+});
+
+test('a storyboard-authored version alone cannot authorize packaged-cache credential loading', () => {
+  const options = { adcpVersion: '3.2.0-beta.5' };
+  const resolved = resolveDeclaredTestKit(
+    {
+      id: 'untrusted_version_probe',
+      adcp_version: '3.2.0-beta.5',
+      prerequisites: { test_kit: 'test-kits/acme-outdoor-live.yaml' },
+    },
+    options
+  );
+  assert.equal(resolved, options);
+  assert.equal(resolved.test_kit, undefined);
+});
+
+test('empty or malformed compliance roots cannot grant filesystem authority', () => {
+  const storyboard = {
+    id: 'invalid_root_probe',
+    prerequisites: { test_kit: 'compliance/cache/3.2.0-beta.5/test-kits/acme-outdoor-live.yaml' },
+  };
+  for (const complianceDir of ['', '   ', null]) {
+    assert.throws(
+      () => resolveDeclaredTestKit(storyboard, { complianceDir }),
+      /invalid complianceDir.*expected a non-empty string/
+    );
+  }
+});
+
+test('a malformed explicit test-kit override fails closed instead of falling back to disk', () => {
+  const cacheDir = makeCacheDirWithKit();
+  try {
+    const options = { complianceDir: cacheDir, test_kit: null };
+    const resolved = resolveDeclaredTestKit(
+      { id: 'malformed_override_probe', prerequisites: { test_kit: 'test-kits/live.yaml' } },
+      options
+    );
+    assert.equal(resolved, options);
+    assert.throws(() => validateTestKit(resolved.test_kit), /test_kit must be a YAML mapping/);
+  } finally {
+    rmSync(cacheDir, { recursive: true, force: true });
+  }
+});
+
+test('test-kit validation never echoes invalid probe_task values', () => {
+  const misplacedSecret = 'sk-misplaced-secret-that-must-not-reach-reports';
+  let error;
+  try {
+    validateTestKit({ auth: { probe_task: misplacedSecret } });
+  } catch (err) {
+    error = err;
+  }
+  assert.ok(error instanceof Error);
+  assert.match(error.message, /not in the allowlist/);
+  assert.equal(error.message.includes(misplacedSecret), false);
+});
+
+test('test-kit validation rejects malformed API keys without echoing them', () => {
+  for (const api_key of [123, '', 'line-break\nsecret']) {
+    let error;
+    try {
+      validateTestKit({ auth: { api_key, probe_task: 'list_creatives' } });
+    } catch (err) {
+      error = err;
+    }
+    assert.ok(error instanceof Error);
+    assert.match(error.message, /api_key must be a non-empty string containing only printable ASCII/);
+    if (String(api_key).length > 0) assert.equal(error.message.includes(String(api_key)), false);
+  }
+});
+
+test('storyboard YAML cannot author compliance cache provenance', () => {
+  assert.throws(
+    () => parseStoryboard(JSON.stringify({ ...storyboardWithKit(undefined), compliance_dir: os.tmpdir() })),
+    /compliance_dir is loader-owned runtime provenance/
+  );
+  const forged = { ...storyboardWithKit(undefined), compliance_dir: os.tmpdir() };
+  assert.equal(applyStoryboardVersionOptions(forged, {}).complianceDir, undefined);
+});
+
+test('the compliance loader attaches trusted cache provenance out of band', () => {
+  const cacheDir = mkdtempSync(join(os.tmpdir(), 'adcp-declared-kit-provenance-'));
+  const storyboardPath = join(cacheDir, 'universal', 'declared-kit.yaml');
+  try {
+    mkdirSync(join(cacheDir, 'universal'), { recursive: true });
+    writeFileSync(storyboardPath, JSON.stringify(storyboardWithKit(undefined)));
+    const [loaded] = loadBundleStoryboards({
+      kind: 'universal',
+      id: 'declared-kit',
+      path: storyboardPath,
+      adcp_version: '3.2.0-beta.5',
+    });
+    assert.ok(loaded);
+    assert.equal(applyStoryboardVersionOptions(loaded, {}).complianceDir, cacheDir);
+  } finally {
+    rmSync(cacheDir, { recursive: true, force: true });
+  }
+});

--- a/test/lib/storyboard-expect-error-failed-payload.test.js
+++ b/test/lib/storyboard-expect-error-failed-payload.test.js
@@ -212,4 +212,28 @@ describe('storyboard expect_error failed payload normalization (#2179)', () => {
     assert.equal(gateStep.passed, true);
     assert.equal(result.overall_passed, true);
   });
+
+  test('successful payloads do not pass expect_error merely because they contain an error field', async () => {
+    const client = {
+      getAgentInfo: async () => ({ name: 'stub', tools: [{ name: 'get_products' }] }),
+      getProducts: async () => ({
+        success: true,
+        data: {
+          success: true,
+          error_code: 'INVALID_REQUEST',
+          message: 'Advisory only',
+        },
+      }),
+    };
+
+    const result = await runStoryboard('https://stub.example/mcp', buildStoryboard(), {
+      protocol: 'mcp',
+      _client: client,
+      _profile: { name: 'stub', tools: [{ name: 'get_products' }] },
+    });
+
+    const rejectStep = result.phases[0].steps[0];
+    assert.equal(rejectStep.passed, false);
+    assert.equal(result.overall_passed, false);
+  });
 });

--- a/test/lib/storyboard-version-negotiation.test.js
+++ b/test/lib/storyboard-version-negotiation.test.js
@@ -982,10 +982,12 @@ describe('storyboard runner AdCP version negotiation', () => {
         complianceDir: '/tmp/compliance cache',
         schemaRoot: '/tmp/schema root',
         hostedStableLineAlias: '3.1',
+        testKitPath: '/tmp/test kit.yaml',
       }
     );
 
     assert.match(failures[0].fix_command, /--schema-root '\/tmp\/schema root'/);
     assert.match(failures[0].fix_command, /--hosted-stable-line-alias 3\.1/);
+    assert.match(failures[0].fix_command, /--test-kit '\/tmp\/test kit\.yaml'/);
   });
 });


### PR DESCRIPTION
## Summary

- backport the declared prerequisites.test_kit loading and fail-closed auth behavior from #2643
- backport structured controller-denial grading from #2586
- adapt the compliance cache integration to the SDK 13 / AdCP 3.1 line
- enable changeset release automation and validation on the 13.x maintenance branch

This addresses the SDK half of adcontextprotocol/adcp#7151. The included patch changesets produce @adcp/sdk 13.0.1 after this PR merges and the generated release PR is merged.

## Validation

- npm ci
- npm run build:lib
- npm run format:check
- node --test --test-timeout=60000 test/lib/storyboard-controller-mode-gate.test.js test/lib/storyboard-declared-test-kit.test.js test/lib/cli-storyboard-file-flag.test.js test/lib/cli-test-kit-compliance-version.test.js test/lib/storyboard-version-negotiation.test.js (77 passed)
- npx changeset status --since=@adcp/sdk@13.0.0 (patch release)