### PR TITLE
fix(server): preserve reporting delivery account projections

### DIFF
--- a/.changeset/busy-planets-doubt.md
+++ b/.changeset/busy-planets-doubt.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Preserve resolved reporting delivery configuration state in server account projections.

--- a/src/lib/server/decisioning/account.ts
+++ b/src/lib/server/decisioning/account.ts
@@ -30,6 +30,7 @@ import type {
   ListAccountChangesResponse,
   ListAccountsRequest,
   PaymentTerms,
+  ReportingDeliveryConfigurationState,
   ListAccountsResponse,
   ReportUsageRequest,
   ReportUsageResponse,
@@ -44,6 +45,7 @@ import type {
 } from '../../types/tools.generated';
 import type { ServerPayload } from '../../types/server-payload';
 import type { NotificationConfig } from '../../types/v3-1-beta';
+import { projectReportingDeliveryConfigStates } from '../reporting-delivery-config';
 import type { CursorPage } from './pagination';
 import type { AccountMode } from '../account-mode';
 import type { AdcpStructuredError } from './async-outcome';
@@ -202,6 +204,14 @@ export interface Account<TCtxMeta = Record<string, unknown>> {
    * schema description for security constraints.
    */
   reporting_bucket?: WireAccount['reporting_bucket'];
+
+  /**
+   * Resolved, caller-owned durable reporting delivery configurations. These
+   * are the secret-free state records returned after the seller validates a
+   * `sync_accounts` reporting delivery declaration; they are not a reporting
+   * ledger and do not grant access to a destination.
+   */
+  reporting_delivery_configs?: ReportingDeliveryConfigurationState[];
 
   /**
    * Account-level webhook subscriptions registered through `sync_accounts`.
@@ -835,6 +845,12 @@ export interface SyncAccountsResultRow {
   /** Applied account-level webhook subscriptions; credentials are stripped on emit. */
   notification_configs?: NotificationConfig[];
   /**
+   * Resolved, secret-free durable reporting delivery configuration states.
+   * The seller returns these after validating the declaration, including for
+   * dry-run previews. This is state projection only, not ledger behavior.
+   */
+  reporting_delivery_configs?: ReportingDeliveryConfigurationState[];
+  /**
    * Caller-specific authorization metadata for this synced account, including
    * downstream grants such as advertiser-account access plus publisher
    * identity/post authorization.
@@ -903,6 +919,11 @@ export function toWireAccount<TCtxMeta>(account: Account<TCtxMeta>): WireAccount
     wire.governance_agents = [projectGovernanceAgent(account.governance_agents[0]!)];
   }
   if (account.reporting_bucket !== undefined) wire.reporting_bucket = account.reporting_bucket;
+  if (account.reporting_delivery_configs !== undefined) {
+    (
+      wire as unknown as { reporting_delivery_configs?: ReportingDeliveryConfigurationState[] }
+    ).reporting_delivery_configs = projectReportingDeliveryConfigStates(account.reporting_delivery_configs);
+  }
   if (account.notification_configs !== undefined) {
     (wire as unknown as { notification_configs?: WireNotificationConfig[] }).notification_configs =
       account.notification_configs.map(projectNotificationConfig);
@@ -968,6 +989,11 @@ export function toWireSyncAccountRow(row: SyncAccountsResultRow): WireSyncAccoun
   if (row.notification_configs !== undefined) {
     (wire as unknown as { notification_configs?: WireNotificationConfig[] }).notification_configs =
       row.notification_configs.map(projectNotificationConfig);
+  }
+  if (row.reporting_delivery_configs !== undefined) {
+    (
+      wire as unknown as { reporting_delivery_configs?: ReportingDeliveryConfigurationState[] }
+    ).reporting_delivery_configs = projectReportingDeliveryConfigStates(row.reporting_delivery_configs);
   }
   if (row.authorization !== undefined) {
     (wire as WireSyncAccountRow & { authorization?: AccountAuthorization }).authorization = projectAccountAuthorization(

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -7837,7 +7837,10 @@ function buildAccountHandlers<P extends DecisioningPlatform<any, any>>(
             );
           }
           if (policy.failedRows.size === 0) {
-            return { accounts: rows.map(toWireSyncAccountRow) };
+            return {
+              ...(params.dry_run === true && { dry_run: true }),
+              accounts: rows.map(toWireSyncAccountRow),
+            };
           }
           const combined: SyncAccountsResultRow[] = [];
           let acceptedIndex = 0;
@@ -7851,7 +7854,10 @@ function buildAccountHandlers<P extends DecisioningPlatform<any, any>>(
               acceptedIndex += 1;
             }
           }
-          return { accounts: combined.map(toWireSyncAccountRow) };
+          return {
+            ...(params.dry_run === true && { dry_run: true }),
+            accounts: combined.map(toWireSyncAccountRow),
+          };
         }
       );
     };

--- a/src/lib/server/reporting-delivery-config.ts
+++ b/src/lib/server/reporting-delivery-config.ts
@@ -1,0 +1,75 @@
+/**
+ * Response-boundary projection for resolved reporting delivery configuration
+ * states. The protocol deliberately makes these records secret-free: they
+ * describe a seller's resolved delivery state, not the credentials used to
+ * reach the delivery destination.
+ */
+import type { ReportingDeliveryConfigurationState } from '../types/tools.generated';
+import { getSchemaValidatorByRef } from '../validation/schema-loader';
+
+const MAX_REPORTING_DELIVERY_CONFIGS = 16;
+const CREDENTIAL_LIKE_URL_COMPONENT =
+  /\b(?:access[_-]?token|api[_-]?key|assertion|authorization|bearer|code|credential|password|passwd|secret|session|signature|token|x-amz-credential|x-amz-security-token|x-amz-signature)\b/i;
+
+function isCredentialLikeUrlComponent(value: string): boolean {
+  try {
+    return CREDENTIAL_LIKE_URL_COMPONENT.test(decodeURIComponent(value));
+  } catch {
+    return CREDENTIAL_LIKE_URL_COMPONENT.test(value);
+  }
+}
+
+function assertSafeSetupUrl(value: unknown): void {
+  if (typeof value !== 'string') return;
+
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    // The raw schema supplies the normal malformed-URL diagnostic. This guard
+    // only adds the protocol's credential-bearing URL constraint.
+    return;
+  }
+
+  if (url.protocol !== 'https:' || url.username || url.password) {
+    throw new Error('reporting_delivery_configs setup.url must not contain credentials');
+  }
+  for (const [key, queryValue] of url.searchParams) {
+    if (isCredentialLikeUrlComponent(key) || isCredentialLikeUrlComponent(queryValue)) {
+      throw new Error('reporting_delivery_configs setup.url must not contain credential-like query parameters');
+    }
+  }
+  if (url.hash && isCredentialLikeUrlComponent(url.hash.slice(1))) {
+    throw new Error('reporting_delivery_configs setup.url must not contain credential-like fragments');
+  }
+}
+
+/**
+ * Validate resolved reporting delivery states before placing them in a wire
+ * response. This remains necessary when an adopter disables whole-response
+ * validation in production. The raw protocol schema rejects unknown fields,
+ * including credentials accidentally retained by a handler or persistence
+ * model, so failing closed prevents those values from reaching a buyer or an
+ * idempotency/replay cache.
+ */
+export function projectReportingDeliveryConfigStates(
+  states: readonly ReportingDeliveryConfigurationState[]
+): ReportingDeliveryConfigurationState[] {
+  if (!Array.isArray(states) || states.length > MAX_REPORTING_DELIVERY_CONFIGS) {
+    throw new Error(`reporting_delivery_configs must contain at most ${MAX_REPORTING_DELIVERY_CONFIGS} state records`);
+  }
+
+  const validateState = getSchemaValidatorByRef('core/reporting-delivery-config-state.json');
+  if (!validateState) {
+    throw new Error('Bundled schema core/reporting-delivery-config-state.json is unavailable');
+  }
+
+  for (const state of states) {
+    if (!validateState(state)) {
+      throw new Error('reporting_delivery_configs contains a state that is not a valid secret-free protocol record');
+    }
+    assertSafeSetupUrl((state as { setup?: { url?: unknown } }).setup?.url);
+  }
+
+  return [...states];
+}

--- a/src/lib/server/responses.ts
+++ b/src/lib/server/responses.ts
@@ -44,6 +44,7 @@ import type { GetMediaBuyDeliveryResponse } from '../types/tools.generated';
 import type { RequireCacheScopeWhenProducts, ServerPayload } from '../types/server-payload';
 import { validActionsForStatus } from './media-buy-helpers';
 import type { CancelMediaBuyInput } from './media-buy-helpers';
+import { projectReportingDeliveryConfigStates } from './reporting-delivery-config';
 import type {
   ListCreativeFormatsResponse,
   GetProductsResponse,
@@ -194,7 +195,15 @@ function stripBusinessEntityBank<T extends object>(row: T, key: 'billing_entity'
 }
 
 function stripAccountWriteOnlyFields<T extends object>(account: T): T {
-  return stripBusinessEntityBank(stripNotificationConfigSecrets(account), 'billing_entity');
+  const stripped = stripBusinessEntityBank(stripNotificationConfigSecrets(account), 'billing_entity');
+  const reportingDeliveryConfigs = (stripped as { reporting_delivery_configs?: unknown }).reporting_delivery_configs;
+  if (reportingDeliveryConfigs === undefined) return stripped;
+  return {
+    ...stripped,
+    reporting_delivery_configs: projectReportingDeliveryConfigStates(
+      reportingDeliveryConfigs as Parameters<typeof projectReportingDeliveryConfigStates>[0]
+    ),
+  } as T;
 }
 
 function stripAccountsWriteOnlyFields<T extends { accounts?: unknown }>(data: T): T {

--- a/test/lib/account-notification-config-projection.test.js
+++ b/test/lib/account-notification-config-projection.test.js
@@ -4,7 +4,73 @@ const assert = require('node:assert');
 const { toWireAccount, toWireSyncAccountRow } = require('../../dist/lib/server/decisioning/account.js');
 const { listAccountsResponse, syncAccountsResponse } = require('../../dist/lib/server/responses.js');
 
+const reportingDeliveryState = {
+  configuration: {
+    delivery_config_id: 'daily-delivery',
+    delivery_config_version: 1,
+    offering_id: 'delivery-v1',
+    active: true,
+    feed_purpose: 'analytics',
+    report_definition_id: 'media-buy-delivery-v1',
+    reporting_profile: 'media_buy_delivery_v1',
+    scope: { all_media_buys: true },
+    coverage_requirement: 'full',
+    required_finality: 'snapshot',
+    reconciliation_mode: 'delivery_only',
+    schedule: { period_duration: 'P1D', alignment: 'utc', delivery_sla: 'PT1H' },
+  },
+  state: 'ready',
+  validated_at: '2026-09-03T00:00:00Z',
+  activated_at: '2026-09-03T00:00:00Z',
+  current_coverage: {
+    status: 'full',
+    evaluated_at: '2026-09-03T00:00:00Z',
+    media_buy_ids: [],
+    fully_covered_media_buy_ids: [],
+    partially_covered_media_buy_ids: [],
+    unsupported_media_buy_ids: [],
+    unknown_media_buy_ids: [],
+    package_ids: [],
+    covered_package_ids: [],
+    unsupported_package_ids: [],
+    unknown_package_ids: [],
+    limitations: [],
+  },
+};
+
 describe('account notification_configs projection', () => {
+  test('list_accounts projection preserves resolved reporting delivery state', () => {
+    const wire = toWireAccount({
+      id: 'acc_acme',
+      name: 'Acme',
+      status: 'active',
+      ctx_metadata: {},
+      reporting_delivery_configs: [reportingDeliveryState],
+    });
+
+    assert.deepStrictEqual(wire.reporting_delivery_configs, [reportingDeliveryState]);
+    assert.ok(!JSON.stringify(wire).includes('credentials'));
+  });
+
+  test('list_accounts projection rejects reporting delivery state with retained credentials', () => {
+    assert.throws(
+      () =>
+        toWireAccount({
+          id: 'acc_acme',
+          name: 'Acme',
+          status: 'active',
+          ctx_metadata: {},
+          reporting_delivery_configs: [
+            {
+              ...reportingDeliveryState,
+              configuration: { ...reportingDeliveryState.configuration, credentials: 'must-not-echo' },
+            },
+          ],
+        }),
+      /reporting_delivery_configs/
+    );
+  });
+
   test('list_accounts projection preserves account-level webhook subscribers and strips credentials', () => {
     const wire = toWireAccount({
       id: 'acc_acme',
@@ -70,6 +136,106 @@ describe('account notification_configs projection', () => {
     ]);
   });
 
+  test('sync_accounts result projection preserves resolved reporting delivery state', () => {
+    const wire = toWireSyncAccountRow({
+      brand: { domain: 'acme.example' },
+      operator: 'acme-direct',
+      account_id: 'acc_acme',
+      action: 'unchanged',
+      status: 'active',
+      reporting_delivery_configs: [reportingDeliveryState],
+    });
+
+    assert.deepStrictEqual(wire.reporting_delivery_configs, [reportingDeliveryState]);
+    assert.ok(!JSON.stringify(wire).includes('credentials'));
+  });
+
+  test('sync_accounts projection rejects reporting delivery state with retained credentials', () => {
+    assert.throws(
+      () =>
+        toWireSyncAccountRow({
+          brand: { domain: 'acme.example' },
+          operator: 'acme-direct',
+          action: 'updated',
+          status: 'active',
+          reporting_delivery_configs: [
+            {
+              ...reportingDeliveryState,
+              configuration: { ...reportingDeliveryState.configuration, credentials: 'must-not-echo' },
+            },
+          ],
+        }),
+      /reporting_delivery_configs/
+    );
+  });
+
+  test('account projectors reject credential-bearing reporting setup URLs', () => {
+    const stateWithBearerUrl = {
+      ...reportingDeliveryState,
+      state: 'pending_setup',
+      setup: {
+        action: 'authorize_provider',
+        message: 'Authorize the reporting provider.',
+        url: 'https://seller.example/reporting/setup?token=must-not-echo',
+      },
+    };
+    assert.throws(
+      () =>
+        toWireAccount({
+          id: 'acc_acme',
+          name: 'Acme',
+          status: 'active',
+          ctx_metadata: {},
+          reporting_delivery_configs: [stateWithBearerUrl],
+        }),
+      /setup\.url/
+    );
+    assert.throws(
+      () =>
+        toWireSyncAccountRow({
+          brand: { domain: 'acme.example' },
+          operator: 'acme-direct',
+          action: 'updated',
+          status: 'active',
+          reporting_delivery_configs: [stateWithBearerUrl],
+        }),
+      /setup\.url/
+    );
+    assert.throws(
+      () =>
+        toWireAccount({
+          id: 'acc_acme',
+          name: 'Acme',
+          status: 'active',
+          ctx_metadata: {},
+          reporting_delivery_configs: [
+            {
+              ...stateWithBearerUrl,
+              setup: {
+                ...stateWithBearerUrl.setup,
+                url: 'https://seller.example/reporting/setup#access_token=must-not-echo',
+              },
+            },
+          ],
+        }),
+      /setup\.url/
+    );
+
+    const wire = toWireAccount({
+      id: 'acc_acme',
+      name: 'Acme',
+      status: 'active',
+      ctx_metadata: {},
+      reporting_delivery_configs: [
+        {
+          ...stateWithBearerUrl,
+          setup: { ...stateWithBearerUrl.setup, url: 'https://seller.example/reporting/setup#continue' },
+        },
+      ],
+    });
+    assert.strictEqual(wire.reporting_delivery_configs[0].setup.url, 'https://seller.example/reporting/setup#continue');
+  });
+
   test('raw list_accounts response builder strips notification credentials and bank details', () => {
     const response = listAccountsResponse({
       accounts: [
@@ -100,6 +266,27 @@ describe('account notification_configs projection', () => {
       schemes: ['Bearer'],
     });
     assert.equal('bank' in response.structuredContent.accounts[0].billing_entity, false);
+  });
+
+  test('raw account response builders reject reporting delivery states with retained credentials', () => {
+    const account = {
+      brand: { domain: 'acme.example' },
+      operator: 'acme.example',
+      action: 'updated',
+      status: 'active',
+      reporting_delivery_configs: [
+        {
+          ...reportingDeliveryState,
+          configuration: { ...reportingDeliveryState.configuration, credentials: 'must-not-echo' },
+        },
+      ],
+    };
+
+    assert.throws(
+      () => listAccountsResponse({ accounts: [{ ...account, account_id: 'acc_acme', name: 'Acme' }] }),
+      /reporting_delivery_configs/
+    );
+    assert.throws(() => syncAccountsResponse({ accounts: [account] }), /reporting_delivery_configs/);
   });
 
   test('raw sync_accounts response builder strips notification credentials and bank details before replay caching', () => {

--- a/test/server-decisioning-from-platform.test.js
+++ b/test/server-decisioning-from-platform.test.js
@@ -6426,6 +6426,121 @@ describe('Custom-handler merge seam (incremental migration)', () => {
     assert.strictEqual(result.structuredContent.accounts[0].brand.domain, 'acme.com');
   });
 
+  it('preserves resolved reporting delivery states for existing and new-account dry runs', async () => {
+    // The reporting delivery schema deliberately contains only secret-free
+    // desired state plus seller-resolved lifecycle fields. This adapter does
+    // not implement its ledger; it only returns the validated state that an
+    // adopter's account handler produced.
+    const reportingDeliveryState = {
+      configuration: {
+        delivery_config_id: 'daily-delivery',
+        delivery_config_version: 1,
+        offering_id: 'delivery-v1',
+        active: true,
+        feed_purpose: 'analytics',
+        report_definition_id: 'media-buy-delivery-v1',
+        reporting_profile: 'media_buy_delivery_v1',
+        scope: { all_media_buys: true },
+        coverage_requirement: 'full',
+        required_finality: 'snapshot',
+        reconciliation_mode: 'delivery_only',
+        schedule: { period_duration: 'P1D', alignment: 'utc', delivery_sla: 'PT1H' },
+      },
+      state: 'ready',
+      validated_at: '2026-09-03T00:00:00Z',
+      activated_at: '2026-09-03T00:00:00Z',
+      current_coverage: {
+        status: 'full',
+        evaluated_at: '2026-09-03T00:00:00Z',
+        media_buy_ids: [],
+        fully_covered_media_buy_ids: [],
+        partially_covered_media_buy_ids: [],
+        unsupported_media_buy_ids: [],
+        unknown_media_buy_ids: [],
+        package_ids: [],
+        covered_package_ids: [],
+        unsupported_package_ids: [],
+        unknown_package_ids: [],
+        limitations: [],
+      },
+    };
+    const platform = buildPlatform({
+      accounts: {
+        resolve: async ref => ({ id: ref?.account_id ?? 'acc_1', metadata: {}, authInfo: { kind: 'api_key' } }),
+        upsert: async (entries, ctx) => {
+          assert.strictEqual(ctx.input.dry_run, true);
+          return entries.map(entry => ({
+            brand: entry.brand ?? { domain: 'acme.example' },
+            operator: entry.operator ?? 'acme-direct',
+            account_id: entry.account?.account_id ?? 'acc_new',
+            action: entry.account ? 'unchanged' : 'created',
+            status: 'active',
+            reporting_delivery_configs: [reportingDeliveryState],
+          }));
+        },
+        list: async () => ({
+          items: [
+            {
+              id: 'acc_existing',
+              name: 'Acme',
+              status: 'active',
+              metadata: {},
+              authInfo: { kind: 'api_key' },
+              reporting_delivery_configs: [reportingDeliveryState],
+            },
+          ],
+          nextCursor: null,
+        }),
+      },
+    });
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'reporting-delivery-dry-run',
+      version: '1.0.0',
+      validation: { requests: 'strict', responses: 'strict' },
+    });
+    const cases = [
+      {
+        name: 'existing account',
+        entry: { account: { account_id: 'acc_existing' } },
+        action: 'unchanged',
+      },
+      {
+        name: 'new account',
+        entry: { brand: { domain: 'acme.example' }, operator: 'acme-direct', billing: 'agent' },
+        action: 'created',
+      },
+    ];
+    for (const [index, scenario] of cases.entries()) {
+      const result = await server.dispatchTestRequest({
+        method: 'tools/call',
+        params: {
+          name: 'sync_accounts',
+          arguments: {
+            idempotency_key: `00000000-0000-4000-8000-00000000000${index + 1}`,
+            dry_run: true,
+            accounts: [scenario.entry],
+          },
+        },
+      });
+      assert.notStrictEqual(result.isError, true, `${scenario.name}: ${JSON.stringify(result.structuredContent)}`);
+      assert.strictEqual(result.structuredContent.dry_run, true);
+      assert.strictEqual(result.structuredContent.accounts[0].action, scenario.action);
+      assert.deepStrictEqual(result.structuredContent.accounts[0].reporting_delivery_configs, [reportingDeliveryState]);
+      assert.ok(!JSON.stringify(result.structuredContent).includes('credentials'));
+    }
+
+    const listed = await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: { name: 'list_accounts', arguments: {} },
+    });
+    assert.notStrictEqual(listed.isError, true, `list_accounts: ${JSON.stringify(listed.structuredContent)}`);
+    assert.ok(
+      listed.structuredContent.accounts.length > 0,
+      `list_accounts: ${JSON.stringify(listed.structuredContent)}`
+    );
+    assert.deepStrictEqual(listed.structuredContent.accounts[0].reporting_delivery_configs, [reportingDeliveryState]);
+  });
+
   it('list_accounts projects CursorPage into 3.1 pagination block (not top-level next_cursor)', async () => {
     // Regression: adcontextprotocol/adcp#5723 — the pre-fix projector emitted a
     // top-level `next_cursor` field. Both 3.0 and 3.1 `list-accounts-response`


### PR DESCRIPTION
## Summary\n- project validated, secret-free reporting_delivery_configs through server account and sync-account responses\n- preserve state for existing and new account dry runs, including list_accounts\n- fail closed for credential-bearing configuration fields and setup URLs; no reporting ledger behavior added\n\n## Validation\n- npm run ci:schema-check\n- npm run build:lib\n- npm run typecheck\n- focused projection and strict server dry-run/list tests\n- independent review (clean after fixes)\n\nNote: full npm test has existing unrelated CLI scaffolding and PostgreSQL dependency failures (16 failures, 185 cancellations); focused change coverage and all build/schema gates pass.